### PR TITLE
revert: "perf: reduce Module size"

### DIFF
--- a/crates/rolldown/src/bundler/module/module.rs
+++ b/crates/rolldown/src/bundler/module/module.rs
@@ -10,8 +10,8 @@ use super::{external_module::ExternalModule, render::RenderModuleContext, Normal
 
 #[derive(Debug)]
 pub enum Module {
-  Normal(Box<NormalModule>),
-  External(Box<ExternalModule>),
+  Normal(NormalModule),
+  External(ExternalModule),
 }
 
 impl Module {

--- a/crates/rolldown/src/bundler/module_loader/module_loader.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_loader.rs
@@ -86,7 +86,7 @@ impl<'a> ModuleLoader<'a> {
           while tables.len() <= task_result.module_id.raw() as usize {
             tables.push(Default::default());
           }
-          intermediate_modules[module_id] = Some(Module::Normal(Box::new(builder.build())));
+          intermediate_modules[module_id] = Some(Module::Normal(builder.build()));
 
           tables[task_result.module_id] = symbol_table
         }
@@ -151,7 +151,7 @@ impl<'a> ModuleLoader<'a> {
             id,
             ResourceId::new(info.path.clone(), &self.input_options.cwd),
           );
-          intermediate_modules[id] = Some(Module::External(Box::new(ext)));
+          intermediate_modules[id] = Some(Module::External(ext));
         } else {
           not_visited.insert(id);
 


### PR DESCRIPTION
Reverts rolldown-rs/rolldown#6

`Module` would be stored in `Vec`, which is already in the heap. Wrapping with `Box` will cause extra dereferencing on every visiting, which `Module` would be visited frequently a lot.

`ExternalModule` are few, you don't need to worry about the memory usages now.