### PR TITLE
fix: external module import order

### DIFF
--- a/crates/rolldown/src/bundler/bundle/bundle.rs
+++ b/crates/rolldown/src/bundler/bundle/bundle.rs
@@ -53,6 +53,7 @@ impl<'a> Bundle<'a> {
       if chunk.is_entry {
         chunk.initialize_exports(&mut self.graph.modules, &self.graph.symbols);
       }
+      chunk.collect_parts(self.graph);
     });
 
     self

--- a/crates/rolldown/src/bundler/chunk/chunk.rs
+++ b/crates/rolldown/src/bundler/chunk/chunk.rs
@@ -94,7 +94,7 @@ impl Chunk {
       if visited.contains(module_id) {
         return;
       }
-
+      visited.insert(*module_id);
       if let Module::Normal(module) = &graph.modules[*module_id] {
         let is_module_in_chunk = chunk_modules.contains(module_id);
         for part in module.parts.iter() {
@@ -123,8 +123,6 @@ impl Chunk {
           }
         }
       }
-
-      visited.insert(*module_id);
     }
 
     for module_id in self.modules.iter() {

--- a/crates/rolldown/src/bundler/chunk/chunk.rs
+++ b/crates/rolldown/src/bundler/chunk/chunk.rs
@@ -163,23 +163,6 @@ impl Chunk {
       .for_each(|item| {
         joiner.append(item);
       });
-    // self
-    //   .modules
-    //   .par_iter()
-    //   .copied()
-    //   .map(|id| &graph.modules[id])
-    //   .filter_map(|m| {
-    //     m.render(RenderModuleContext {
-    //       symbols: &graph.symbols,
-    //       final_names: &self.canonical_names,
-    //       input_options,
-    //     })
-    //   })
-    //   .collect::<Vec<_>>()
-    //   .into_iter()
-    //   .for_each(|item| {
-    //     joiner.append(item);
-    //   });
     if let Some(exports) = self.exports_str.clone() {
       joiner.append_raw(exports);
     }

--- a/crates/rolldown/src/bundler/chunk/chunk.rs
+++ b/crates/rolldown/src/bundler/chunk/chunk.rs
@@ -109,6 +109,7 @@ impl Chunk {
             );
           }
           if is_module_in_chunk {
+            // merge same module parts to one part, it will generate continuously module code
             if let Some(last_part) = parts.pop() {
               if part.module_id == last_part.module_id {
                 parts.push(Part::new(part.module_id, last_part.start, part.end, None));

--- a/crates/rolldown/src/bundler/graph/graph.rs
+++ b/crates/rolldown/src/bundler/graph/graph.rs
@@ -57,6 +57,8 @@ impl Graph {
       match action {
         Action::Enter => {
           if !entered_ids.contains(&id) {
+            *module.exec_order_mut() = next_exec_order;
+            next_exec_order += 1;
             entered_ids.insert(id);
             stack.push((Action::Exit, id));
             stack.extend(
@@ -74,8 +76,6 @@ impl Graph {
           }
         }
         Action::Exit => {
-          *module.exec_order_mut() = next_exec_order;
-          next_exec_order += 1;
           sorted_modules.push(id);
         }
       }

--- a/crates/rolldown/src/bundler/module/module_builder.rs
+++ b/crates/rolldown/src/bundler/module/module_builder.rs
@@ -4,8 +4,8 @@ use oxc::{
   span::Atom,
 };
 use rolldown_common::{
-  ImportRecord, ImportRecordId, LocalOrReExport, ModuleId, NamedImport, ResourceId, StmtInfo,
-  StmtInfoId, SymbolRef,
+  ImportRecord, ImportRecordId, LocalOrReExport, ModuleId, NamedImport, Part, PartId, ResourceId,
+  StmtInfo, StmtInfoId, SymbolRef,
 };
 use rolldown_oxc::OxcProgram;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -19,6 +19,7 @@ pub struct ModuleBuilder {
   pub id: Option<ModuleId>,
   pub path: Option<ResourceId>,
   pub ast: Option<OxcProgram>,
+  pub parts: Option<IndexVec<PartId, Part>>,
   pub named_imports: Option<FxHashMap<SymbolId, NamedImport>>,
   pub named_exports: Option<FxHashMap<Atom, LocalOrReExport>>,
   pub stmt_infos: Option<IndexVec<StmtInfoId, StmtInfo>>,
@@ -56,6 +57,7 @@ impl ModuleBuilder {
       namespace_symbol: self.namespace_symbol.unwrap(),
       is_symbol_for_namespace_referenced: false,
       external_requests: self.external_requests,
+      parts: self.parts.unwrap(),
     }
   }
 }

--- a/crates/rolldown/src/bundler/module/normal_module.rs
+++ b/crates/rolldown/src/bundler/module/normal_module.rs
@@ -7,8 +7,8 @@ use oxc::{
   span::Atom,
 };
 use rolldown_common::{
-  ImportRecord, ImportRecordId, LocalOrReExport, ModuleId, NamedImport, ResolvedExport, ResourceId,
-  StmtInfo, StmtInfoId, SymbolRef,
+  ImportRecord, ImportRecordId, LocalOrReExport, ModuleId, NamedImport, Part, PartId,
+  ResolvedExport, ResourceId, StmtInfo, StmtInfoId, SymbolRef,
 };
 use rolldown_oxc::{DummyIn, IntoIn, OxcProgram};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -26,6 +26,7 @@ pub struct NormalModule {
   pub id: ModuleId,
   pub resource_id: ResourceId,
   pub ast: OxcProgram,
+  pub parts: IndexVec<PartId, Part>,
   pub named_imports: FxHashMap<SymbolId, NamedImport>,
   pub named_exports: FxHashMap<Atom, LocalOrReExport>,
   pub stmt_infos: IndexVec<StmtInfoId, StmtInfo>,
@@ -169,6 +170,7 @@ impl NormalModule {
     ));
     let idx = program.body.len();
     program.body.push(stmt);
+    self.parts.push(Part::new(self.id, idx, idx + 1, None));
     self.stmt_infos.push(StmtInfo {
       stmt_idx: idx,
       declared_symbols: vec![self.namespace_symbol.0.symbol],

--- a/crates/rolldown/src/bundler/module/render.rs
+++ b/crates/rolldown/src/bundler/module/render.rs
@@ -19,9 +19,10 @@ pub struct RenderModuleContext<'a> {
 impl NormalModule {
   pub fn render(&self, ctx: RenderModuleContext<'_>) -> Option<MagicString<'static>> {
     let mut formatter = oxc::formatter::Formatter::new(0, Default::default());
+    let program = self.ast.program();
     let mut i = ctx.part.start;
     while i < ctx.part.end {
-      let stmt = &self.ast.program.body[i];
+      let stmt = &program.body[i];
       if !matches!(stmt, oxc::ast::ast::Statement::EmptyStatement(_)) {
         stmt.gen(&mut formatter);
       }

--- a/crates/rolldown/src/bundler/module_loader/module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_task.rs
@@ -68,6 +68,7 @@ impl ModuleTask {
       import_records,
       star_exports,
       export_default_symbol_id,
+      parts,
     } = scan_result;
 
     builder.id = Some(self.module_id);
@@ -75,6 +76,7 @@ impl ModuleTask {
     builder.path = Some(self.path);
     builder.named_imports = Some(named_imports);
     builder.named_exports = Some(named_exports);
+    builder.parts = Some(parts);
     builder.stmt_infos = Some(stmt_infos);
     builder.import_records = Some(import_records);
     builder.star_exports = Some(star_exports);

--- a/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
@@ -6,17 +6,6 @@ input_file: crates/rolldown/tests/esbuild/default/export_forms_es6
 # main.js
 
 ```js
-// b.js
-const xyz = null;
-var b_ns = {
-    get xyz() {
-        return xyz;
-    }
-};
-
-// a.js
-const abc = undefined;
-
 // main.js
 var main_default = 123;
 var v = 234;
@@ -26,6 +15,17 @@ function Fn () {
 }
 class Class {
 }
+
+// a.js
+const abc = undefined;
+
+// b.js
+const xyz = null;
+var b_ns = {
+    get xyz() {
+        return xyz;
+    }
+};
 
 export { Class, Fn, abc, b_ns as b, c, main_default as default, l, v };
 ```

--- a/crates/rolldown/tests/esbuild/import_star/export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_import_star_capture/artifacts.snap
@@ -7,14 +7,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_import_star_capture
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 var foo_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(foo_ns, foo_ns.foo, foo);
+let foo$1 = 234;
+console.log(foo_ns, foo_ns.foo, foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/export_import_star_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_import_star_no_capture/artifacts.snap
@@ -7,14 +7,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_import_star_no_capt
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 var foo_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(foo_ns.foo, foo_ns.foo, foo);
+let foo$1 = 234;
+console.log(foo_ns.foo, foo_ns.foo, foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_star_as_capture/artifacts.snap
@@ -7,14 +7,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_star_as_capture
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 var foo_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(foo_ns, foo_ns.foo, foo);
+let foo$1 = 234;
+console.log(foo_ns, foo_ns.foo, foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/export_star_as_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_star_as_no_capture/artifacts.snap
@@ -7,14 +7,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_star_as_no_capture
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 var foo_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(foo_ns.foo, foo_ns.foo, foo);
+let foo$1 = 234;
+console.log(foo_ns.foo, foo_ns.foo, foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/export_star_as_unused/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_star_as_unused/artifacts.snap
@@ -7,14 +7,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_star_as_unused
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 var foo_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(foo);
+let foo$1 = 234;
+console.log(foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_star_capture/artifacts.snap
@@ -7,16 +7,16 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_star_capture
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 
 // bar.js
 var bar_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(bar_ns, bar_ns.foo, foo);
+let foo$1 = 234;
+console.log(bar_ns, bar_ns.foo, foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/export_star_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_star_no_capture/artifacts.snap
@@ -7,16 +7,16 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_star_no_capture
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 
 // bar.js
 var bar_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(bar_ns.foo, bar_ns.foo, foo);
+let foo$1 = 234;
+console.log(bar_ns.foo, bar_ns.foo, foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/export_star_unused/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_star_unused/artifacts.snap
@@ -7,16 +7,16 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_star_unused
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 
 // bar.js
 var bar_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(foo);
+let foo$1 = 234;
+console.log(foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/import_default_namespace_combo_issue446/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_default_namespace_combo_issue446/artifacts.snap
@@ -7,14 +7,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_default_namespace_c
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 var foo_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(foo);
+let foo$1 = 234;
+console.log(foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguous_warning/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguous_warning/artifacts.snap
@@ -6,13 +6,13 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguo
 # main.js
 
 ```js
-// bar.js
-const y$1 = 3;
-const z = 4;
-
 // foo.js
 const x = 1;
 const y = 2;
+
+// bar.js
+const y$1 = 3;
+const z = 4;
 
 // common.js
 var common_ns = {

--- a/crates/rolldown/tests/esbuild/import_star/import_of_export_star_of_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_of_export_star_of_import/artifacts.snap
@@ -6,14 +6,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_of_export_star_of_i
 # main.js
 
 ```js
-// baz.js
-const value = 123;
-
 // foo.js
 statement();
 statement();
 statement();
 statement();
+
+// baz.js
+const value = 123;
 
 // main.js
 console.log(value);

--- a/crates/rolldown/tests/esbuild/import_star/import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_capture/artifacts.snap
@@ -7,14 +7,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_star_capture
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 var foo_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(foo_ns, foo_ns.foo, foo);
+let foo$1 = 234;
+console.log(foo_ns, foo_ns.foo, foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/import_star_export_star_omit_ambiguous/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_export_star_omit_ambiguous/artifacts.snap
@@ -6,13 +6,13 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_star_export_star_om
 # main.js
 
 ```js
-// bar.js
-const y$1 = 3;
-const z = 4;
-
 // foo.js
 const x = 1;
 const y = 2;
+
+// bar.js
+const y$1 = 3;
+const z = 4;
 
 // common.js
 var common_ns = {

--- a/crates/rolldown/tests/esbuild/import_star/import_star_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_no_capture/artifacts.snap
@@ -7,14 +7,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_star_no_capture
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 var foo_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(foo_ns.foo, foo_ns.foo, foo);
+let foo$1 = 234;
+console.log(foo_ns.foo, foo_ns.foo, foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/import_star_of_export_star_as/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_of_export_star_as/artifacts.snap
@@ -7,11 +7,11 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_star_of_export_star
 
 ```js
 // c.js
-let x$1 = 2;
+let x = 2;
 
 // b.js
-let x = 1;
+let x$1 = 1;
 
 // main.js
-console.log(x);
+console.log(x$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/import_star_unused/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_unused/artifacts.snap
@@ -7,14 +7,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_star_unused
 
 ```js
 // foo.js
-const foo$1 = 123;
+const foo = 123;
 var foo_ns = {
     get foo() {
-        return foo$1;
+        return foo;
     }
 };
 
 // main.js
-let foo = 234;
-console.log(foo);
+let foo$1 = 234;
+console.log(foo$1);
 ```

--- a/crates/rolldown/tests/esbuild/import_star/re_export_star_name_shadowing_not_ambiguous/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/re_export_star_name_shadowing_not_ambiguous/artifacts.snap
@@ -7,11 +7,11 @@ input_file: crates/rolldown/tests/esbuild/import_star/re_export_star_name_shadow
 
 ```js
 // b.js
-let x$1 = 2;
+let x = 2;
 
 // a.js
-let x = 1;
+let x$1 = 1;
 
 // main.js
-console.log(x);
+console.log(x$1);
 ```

--- a/crates/rolldown/tests/fixtures/export_external/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/export_external/artifacts.snap
@@ -6,6 +6,10 @@ input_file: crates/rolldown/tests/fixtures/export_external
 # main.js
 
 ```js
+// main.js
+import * as external_ns from 'external';
+import { a, b } from 'external';
+
 // foo.js
 import { a as a$1, b as b$1 } from 'external';
 import * as external_ns$1 from 'external';
@@ -13,7 +17,5 @@ const a1 = 1;
 console.log(a1);
 
 // main.js
-import * as external_ns from 'external';
-import { a, b } from 'external';
 console.log(external_ns, a$1, b$1, external_ns$1, a, b);
 ```

--- a/crates/rolldown/tests/fixtures/external/keep_import_external_order/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/external/keep_import_external_order/artifacts.snap
@@ -6,11 +6,13 @@ input_file: crates/rolldown/tests/fixtures/external/keep_import_external_order
 # main.js
 
 ```js
+// main.js
+import 'ext1';
+
 // foo.js
 const a = 'foo';
 
 // main.js
-import 'ext1';
 import 'ext2';
 console.log(a);
 ```

--- a/crates/rolldown/tests/fixtures/import_external/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/import_external/artifacts.snap
@@ -6,13 +6,15 @@ input_file: crates/rolldown/tests/fixtures/import_external
 # main.js
 
 ```js
-// foo.js
+// main.js
 import * as external_ns$1 from 'external';
 import { a as a$1, b as b$1 } from 'external';
-console.log(external_ns$1, a$1, b$1);
 
-// main.js
+// foo.js
 import * as external_ns from 'external';
 import { a, b } from 'external';
 console.log(external_ns, a, b);
+
+// main.js
+console.log(external_ns$1, a$1, b$1);
 ```

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -3,17 +3,18 @@ mod module_id;
 mod module_path;
 mod named_export;
 mod named_import;
+mod part;
 mod raw_path;
 mod resolved_export;
 mod stmt_info;
 mod symbol_ref;
-
 pub use crate::{
   import_record::{ImportRecord, ImportRecordId},
   module_id::ModuleId,
   module_path::ResourceId,
   named_export::{LocalExport, LocalOrReExport, ReExport},
   named_import::NamedImport,
+  part::{Part, PartId},
   raw_path::RawPath,
   resolved_export::ResolvedExport,
   stmt_info::{StmtInfo, StmtInfoId},

--- a/crates/rolldown_common/src/part.rs
+++ b/crates/rolldown_common/src/part.rs
@@ -1,0 +1,29 @@
+use crate::{ImportRecordId, ModuleId};
+
+index_vec::define_index_type! {
+    pub struct PartId = u32;
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Part {
+  pub module_id: ModuleId,
+  pub start: usize,
+  pub end: usize,
+  pub import_record_id: Option<ImportRecordId>,
+}
+
+impl Part {
+  pub fn new(
+    module_id: ModuleId,
+    start: usize,
+    end: usize,
+    import_record_id: Option<ImportRecordId>,
+  ) -> Self {
+    Self {
+      module_id,
+      start,
+      end,
+      import_record_id,
+    }
+  }
+}

--- a/crates/rolldown_oxc/src/compiler.rs
+++ b/crates/rolldown_oxc/src/compiler.rs
@@ -11,10 +11,10 @@ pub struct OxcCompiler;
 
 #[allow(clippy::box_collection)]
 pub struct OxcProgram {
-  pub program: ast::Program<'static>,
+  program: ast::Program<'static>,
   source: Pin<Box<String>>,
   // Order matters here, we need drop the program first, then drop the allocator. Otherwise, there will be a segmentation fault.
-  pub allocator: Pin<Box<Allocator>>,
+  allocator: Pin<Box<Allocator>>,
 }
 
 impl Debug for OxcProgram {

--- a/crates/rolldown_oxc/src/compiler.rs
+++ b/crates/rolldown_oxc/src/compiler.rs
@@ -11,10 +11,10 @@ pub struct OxcCompiler;
 
 #[allow(clippy::box_collection)]
 pub struct OxcProgram {
-  program: ast::Program<'static>,
+  pub program: ast::Program<'static>,
   source: Pin<Box<String>>,
   // Order matters here, we need drop the program first, then drop the allocator. Otherwise, there will be a segmentation fault.
-  allocator: Pin<Box<Allocator>>,
+  pub allocator: Pin<Box<Allocator>>,
 }
 
 impl Debug for OxcProgram {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The pr fix external module import order(`import_external` test).

#### Module Ast Part
The pr implement `Ast Part`, a part is composed of some ast stmts. 

``` .ts
// main.js
import 'external'  // execute first
import 'a.js'
```
See the above module the external module should execute first, but before implement will render to the following code.

``` .ts
// a.js
xxx
// main.js
import 'external'
```

The part is used to generate correct code execute order, see the following.

``` .ts
// main.js
import 'external'
// a.js
xxx
```

The `main.js` has `external` part and `a.js` part, it will scanned ast first scan ast.

#### Chunk Part Codegen

Before chunk codegen is implemented by module ast codegen, the pr will collect chunk parts by visite chunk module part. The chunk render is also used ast part to gen some ast stmts. 


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Update snapshot.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
