### PR TITLE
feat: add `RuntimeNormalModuleTask`

### DIFF
--- a/crates/rolldown/src/bundler/module/module_builder.rs
+++ b/crates/rolldown/src/bundler/module/module_builder.rs
@@ -15,7 +15,7 @@ use crate::bundler::graph::symbols::SymbolMap;
 use super::NormalModule;
 
 #[derive(Debug, Default)]
-pub struct ModuleBuilder {
+pub struct NormalModuleBuilder {
   pub id: Option<ModuleId>,
   pub path: Option<ResourceId>,
   pub ast: Option<OxcProgram>,
@@ -31,7 +31,7 @@ pub struct ModuleBuilder {
   pub module_resolution: Option<ModuleResolution>,
 }
 
-impl ModuleBuilder {
+impl NormalModuleBuilder {
   pub fn initialize_namespace_binding(&mut self, symbol_table: &mut SymbolMap) {
     let name = format!("{}_ns", self.path.as_ref().unwrap().generate_unique_name());
     let symbol_ref: SymbolRef = (self.id.unwrap(), symbol_table.create_symbol(name.into())).into();

--- a/crates/rolldown/src/bundler/module_loader/mod.rs
+++ b/crates/rolldown/src/bundler/module_loader/mod.rs
@@ -1,11 +1,11 @@
 #[allow(clippy::module_inception)]
 mod module_loader;
-mod module_task;
+mod normal_module_task;
 mod task_result;
 
 pub use module_loader::ModuleLoader;
 
-use self::task_result::TaskResult;
+use self::task_result::NormalModuleTaskResult;
 pub enum Msg {
-  Done(TaskResult),
+  NormalModuleDone(NormalModuleTaskResult),
 }

--- a/crates/rolldown/src/bundler/module_loader/mod.rs
+++ b/crates/rolldown/src/bundler/module_loader/mod.rs
@@ -1,6 +1,7 @@
 #[allow(clippy::module_inception)]
 mod module_loader;
 mod normal_module_task;
+mod runtime_normal_module_task;
 mod task_result;
 
 pub use module_loader::ModuleLoader;
@@ -8,4 +9,5 @@ pub use module_loader::ModuleLoader;
 use self::task_result::NormalModuleTaskResult;
 pub enum Msg {
   NormalModuleDone(NormalModuleTaskResult),
+  RuntimeNormalModuleDone(NormalModuleTaskResult),
 }

--- a/crates/rolldown/src/bundler/module_loader/module_loader.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_loader.rs
@@ -4,8 +4,8 @@ use rolldown_resolver::Resolver;
 use rolldown_utils::block_on_spawn_all;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use super::module_task::ModuleTask;
-use super::task_result::TaskResult;
+use super::normal_module_task::ModuleTask;
+use super::task_result::NormalModuleTaskResult;
 use super::Msg;
 use crate::bundler::graph::graph::Graph;
 use crate::bundler::graph::symbols::{SymbolMap, Symbols};
@@ -76,8 +76,8 @@ impl<'a> ModuleLoader<'a> {
     while self.remaining > 0 {
       let Some(msg) = self.rx.recv().await else { break };
       match msg {
-        Msg::Done(task_result) => {
-          let TaskResult {
+        Msg::NormalModuleDone(task_result) => {
+          let NormalModuleTaskResult {
             module_id,
             symbol_map: symbol_table,
             resolved_deps,

--- a/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
@@ -13,7 +13,7 @@ use super::Msg;
 use crate::{
   bundler::{
     graph::symbols::SymbolMap,
-    module::module_builder::ModuleBuilder,
+    module::module_builder::NormalModuleBuilder,
     module_loader::NormalModuleTaskResult,
     resolve_id::{resolve_id, ResolvedRequestInfo},
     runtime::RUNTIME_PATH,
@@ -21,7 +21,7 @@ use crate::{
   },
   BuildError, BuildResult, SharedResolver,
 };
-pub struct ModuleTask {
+pub struct NormalModuleTask {
   module_id: ModuleId,
   path: ResourceId,
   tx: tokio::sync::mpsc::UnboundedSender<Msg>,
@@ -30,7 +30,7 @@ pub struct ModuleTask {
   resolver: SharedResolver,
 }
 
-impl ModuleTask {
+impl NormalModuleTask {
   pub fn new(
     id: ModuleId,
     resolver: SharedResolver,
@@ -48,7 +48,7 @@ impl ModuleTask {
   }
 
   pub async fn run(mut self) -> anyhow::Result<()> {
-    let mut builder = ModuleBuilder::default();
+    let mut builder = NormalModuleBuilder::default();
     tracing::trace!("process {:?}", self.path);
     // load
     let source = if RUNTIME_PATH == self.path.as_ref() {

--- a/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
@@ -14,7 +14,7 @@ use crate::{
   bundler::{
     graph::symbols::SymbolMap,
     module::module_builder::ModuleBuilder,
-    module_loader::TaskResult,
+    module_loader::NormalModuleTaskResult,
     resolve_id::{resolve_id, ResolvedRequestInfo},
     runtime::RUNTIME_PATH,
     visitors::scanner::{self, ScanResult},
@@ -93,7 +93,7 @@ impl ModuleTask {
 
     self
       .tx
-      .send(Msg::Done(TaskResult {
+      .send(Msg::NormalModuleDone(NormalModuleTaskResult {
         resolved_deps: res,
         module_id: self.module_id,
         errors: self.errors,

--- a/crates/rolldown/src/bundler/module_loader/runtime_normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/runtime_normal_module_task.rs
@@ -1,0 +1,111 @@
+use oxc::{
+  ast::VisitMut,
+  semantic::{ScopeTree, SymbolTable},
+  span::SourceType,
+};
+use rolldown_common::{ModuleId, ResourceId};
+use rolldown_oxc::{OxcCompiler, OxcProgram};
+
+use super::Msg;
+use crate::{
+  bundler::{
+    graph::symbols::SymbolMap,
+    module::module_builder::NormalModuleBuilder,
+    module_loader::NormalModuleTaskResult,
+    runtime::RUNTIME_PATH,
+    visitors::scanner::{self, ScanResult},
+  },
+  BuildError, SharedResolver,
+};
+pub struct RuntimeNormalModuleTask {
+  module_id: ModuleId,
+  tx: tokio::sync::mpsc::UnboundedSender<Msg>,
+  errors: Vec<BuildError>,
+  warnings: Vec<BuildError>,
+  resolver: SharedResolver,
+}
+
+impl RuntimeNormalModuleTask {
+  pub fn new(
+    id: ModuleId,
+    resolver: SharedResolver,
+    tx: tokio::sync::mpsc::UnboundedSender<Msg>,
+  ) -> Self {
+    Self {
+      module_id: id,
+      resolver,
+      tx,
+      errors: Default::default(),
+      warnings: Default::default(),
+    }
+  }
+
+  pub async fn run(self) -> anyhow::Result<()> {
+    let mut builder = NormalModuleBuilder::default();
+    // load
+    let source = include_str!("../runtime/index.js").to_string();
+
+    let (ast, scope, scan_result, symbol) = self.make_ast(source);
+
+    let mut symbol_map = SymbolMap::from_symbol_table(symbol);
+
+    let ScanResult {
+      named_imports,
+      named_exports,
+      stmt_infos,
+      import_records,
+      star_exports,
+      export_default_symbol_id,
+      imports,
+      module_resolution,
+    } = scan_result;
+
+    builder.id = Some(self.module_id);
+    builder.ast = Some(ast);
+    builder.path = Some(ResourceId::new(
+      RUNTIME_PATH.to_string().into(),
+      self.resolver.cwd(),
+    ));
+    builder.named_imports = Some(named_imports);
+    builder.named_exports = Some(named_exports);
+    builder.stmt_infos = Some(stmt_infos);
+    builder.import_records = Some(import_records);
+    builder.imports = Some(imports);
+    builder.star_exports = Some(star_exports);
+    builder.default_export_symbol = export_default_symbol_id;
+    builder.scope = Some(scope);
+    builder.module_resolution = module_resolution;
+    builder.initialize_namespace_binding(&mut symbol_map);
+
+    self
+      .tx
+      .send(Msg::RuntimeNormalModuleDone(NormalModuleTaskResult {
+        resolved_deps: Default::default(),
+        module_id: self.module_id,
+        errors: self.errors,
+        warnings: self.warnings,
+        symbol_map,
+        builder,
+      }))
+      .unwrap();
+    Ok(())
+  }
+
+  fn make_ast(&self, source: String) -> (OxcProgram, ScopeTree, ScanResult, SymbolTable) {
+    let source_type = SourceType::default();
+    let mut program = OxcCompiler::parse(source, source_type);
+
+    let semantic = program.make_semantic(source_type);
+    let (mut symbol_table, mut scope) = semantic.into_symbol_table_and_scope_tree();
+    let mut scanner = scanner::Scanner::new(
+      self.module_id,
+      &mut scope,
+      &mut symbol_table,
+      "should be unreachable for runtime module",
+    );
+    scanner.visit_program(program.program_mut());
+    let scan_result = scanner.result;
+
+    (program, scope, scan_result, symbol_table)
+  }
+}

--- a/crates/rolldown/src/bundler/module_loader/task_result.rs
+++ b/crates/rolldown/src/bundler/module_loader/task_result.rs
@@ -5,7 +5,7 @@ use crate::bundler::module::module_builder::ModuleBuilder;
 use crate::bundler::resolve_id::ResolvedRequestInfo;
 use crate::BuildError;
 
-pub struct TaskResult {
+pub struct NormalModuleTaskResult {
   pub module_id: ModuleId,
   pub symbol_map: SymbolMap,
   pub resolved_deps: Vec<(ImportRecordId, ResolvedRequestInfo)>,

--- a/crates/rolldown/src/bundler/module_loader/task_result.rs
+++ b/crates/rolldown/src/bundler/module_loader/task_result.rs
@@ -1,7 +1,7 @@
 use rolldown_common::{ImportRecordId, ModuleId};
 
 use crate::bundler::graph::symbols::SymbolMap;
-use crate::bundler::module::module_builder::ModuleBuilder;
+use crate::bundler::module::module_builder::NormalModuleBuilder;
 use crate::bundler::resolve_id::ResolvedRequestInfo;
 use crate::BuildError;
 
@@ -11,5 +11,5 @@ pub struct NormalModuleTaskResult {
   pub resolved_deps: Vec<(ImportRecordId, ResolvedRequestInfo)>,
   pub errors: Vec<BuildError>,
   pub warnings: Vec<BuildError>,
-  pub builder: ModuleBuilder,
+  pub builder: NormalModuleBuilder,
 }

--- a/crates/rolldown/src/bundler/runtime/mod.rs
+++ b/crates/rolldown/src/bundler/runtime/mod.rs
@@ -2,7 +2,7 @@ use oxc::{semantic::SymbolId, span::Atom};
 use rolldown_common::{ModuleId, SymbolRef};
 use rustc_hash::FxHashMap;
 
-use super::graph::symbols::SymbolMap;
+use super::module::NormalModule;
 
 pub static RUNTIME_PATH: &str = "\0rolldown-runtime.js";
 
@@ -13,19 +13,20 @@ pub struct Runtime {
 }
 
 impl Runtime {
-  pub fn init_symbols(&mut self, runtime_symbol_map: &SymbolMap) {
-    // TODO: we should only storing top level symbols here.
-    // But currently, I'm not sure how to get the scope info for the runtime module
-    self.name_to_symbol = runtime_symbol_map
-      .names
-      .iter()
-      .enumerate()
-      .map(|(id, name)| (name.clone(), id.into()))
-      .collect()
+  pub fn init_symbols(&mut self, runtime_module: &NormalModule) {
+    self.name_to_symbol = runtime_module
+      .scope
+      .get_bindings(runtime_module.scope.root_scope_id())
+      .clone()
+      .into_iter()
+      .collect();
   }
 
   pub fn resolve_symbol(&self, name: &Atom) -> SymbolRef {
-    let symbol_id = self.name_to_symbol[name];
-    (self.id, symbol_id).into()
+    let symbol_id = self
+      .name_to_symbol
+      .get(name)
+      .unwrap_or_else(|| panic!("Failed to resolve symbol: {}", name));
+    (self.id, *symbol_id).into()
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

              I'm intending to not include `runtime` module as the part of making module graph. In this way, we don't need to write such code.

Another way is to have a special `ModuleTaskForRuntime` to deal with the special logic of runtime module.

I haven't think through which way is better. Let's change it later.

_Originally posted by @hyf0 in https://github.com/rolldown-rs/rolldown/pull/37#discussion_r1352930778_

---

We should have should have different kind of module task to deal with different module. This prevent mixing up code for different module. 

For example, runtime module would never call `load` or `resolve` hooks.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
