### PR TITLE
feat: compat node module commonjs interop

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "[rust]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": false
   },
   "[toml]": {
     "editor.formatOnSave": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "[rust]": {
-    "editor.formatOnSave": false
+    "editor.formatOnSave": true
   },
   "[toml]": {
     "editor.formatOnSave": true

--- a/crates/rolldown/src/bundler/graph/linker.rs
+++ b/crates/rolldown/src/bundler/graph/linker.rs
@@ -1,6 +1,6 @@
 use index_vec::IndexVec;
 use oxc::{semantic::ReferenceId, span::Atom};
-use rolldown_common::{LocalOrReExport, ModuleId, ModuleResolution, ResolvedExport, SymbolRef};
+use rolldown_common::{ExportsKind, LocalOrReExport, ModuleId, ResolvedExport, SymbolRef};
 use rustc_hash::FxHashMap;
 
 use super::graph::Graph;
@@ -46,6 +46,9 @@ impl<'graph> Linker<'graph> {
   }
 
   fn wrap_modules_if_needed(&mut self) {
+    // Detect module need wrapped, here has two cases:
+    // - Commonjs module, because cjs symbols can't static binding, it need to be wrapped and lazy evaluated.
+    // - Import esm module at commonjs module.
     let mut module_to_wrapped = index_vec::index_vec![
       false;
       self.graph.modules.len()
@@ -54,7 +57,7 @@ impl<'graph> Linker<'graph> {
     for module in &self.graph.modules {
       match module {
         Module::Normal(module) => {
-          if module.module_resolution == ModuleResolution::CommonJs {
+          if module.exports_kind == ExportsKind::CommonJs {
             wrap_module(self.graph, module.id, &mut module_to_wrapped);
           }
         }
@@ -62,12 +65,15 @@ impl<'graph> Linker<'graph> {
       }
     }
 
+    // Generate symbol for wrap module declaration
+    // Case commonjs, eg var require_a = __commonJS()
+    // Case esm, eg var init_a = __esm()
     for (module_id, wrapped) in module_to_wrapped.into_iter_enumerated() {
       if wrapped {
         match &mut self.graph.modules[module_id] {
           Module::Normal(module) => {
             module.create_wrap_symbol(&mut self.graph.symbols);
-            let name = if module.module_resolution == ModuleResolution::CommonJs {
+            let name = if module.exports_kind == ExportsKind::CommonJs {
               "__commonJS".into()
             } else {
               "__esm".into()
@@ -80,6 +86,9 @@ impl<'graph> Linker<'graph> {
       }
     }
 
+    // Generate symbol for import warp module
+    // Case esm import commonjs, eg var commonjs_ns = __toESM(require_a())
+    // Case commonjs require esm, eg (init_esm(), __toCommonJS(esm_ns))
     let mut imported_symbols = vec![];
 
     for module in &self.graph.modules {
@@ -93,16 +102,22 @@ impl<'graph> Linker<'graph> {
 
             if let Some(importee_warp_symbol) = importee.wrap_symbol {
               imported_symbols.push((importer.id, importee_warp_symbol));
+              imported_symbols.push((importer.id, importee.namespace_symbol.0));
             }
 
-            match (importer.module_resolution, importee.module_resolution) {
-              (ModuleResolution::Esm, ModuleResolution::CommonJs) => {
-                imported_symbols
-                  .push((importer.id, self.graph.runtime.resolve_symbol(&"__toESM".into())));
+            match (importer.exports_kind, importee.exports_kind) {
+              (ExportsKind::Esm, ExportsKind::CommonJs) => {
+                imported_symbols.push((
+                  importer.id,
+                  self.graph.runtime.resolve_symbol(&"__toESM".into()),
+                ));
+                imported_symbols.push((importer.id, importee.namespace_symbol.0));
               }
-              (ModuleResolution::CommonJs, ModuleResolution::Esm) => {
-                imported_symbols
-                  .push((importer.id, self.graph.runtime.resolve_symbol(&"__toCommonJS".into())));
+              (ExportsKind::CommonJs, ExportsKind::Esm) => {
+                imported_symbols.push((
+                  importer.id,
+                  self.graph.runtime.resolve_symbol(&"__toCommonJS".into()),
+                ));
               }
               _ => {}
             }
@@ -166,7 +181,7 @@ impl<'graph> Linker<'graph> {
             let importee = &graph.modules[import_record.resolved_module];
             match importee {
               Module::Normal(importee) => {
-                if importee.module_resolution == ModuleResolution::CommonJs {
+                if importee.exports_kind == ExportsKind::CommonJs {
                   extra_symbols.push((
                     import_record.resolved_module,
                     info.imported.clone(),
@@ -200,12 +215,18 @@ impl<'graph> Linker<'graph> {
         }
         Module::External(_) => {}
       }
-      extra_symbols.into_iter().for_each(|(importee, imported, is_imported_star)| {
-        let importee = &mut graph.modules[importee];
-        match importee {
-          Module::Normal(importee) => {
-            if importee.module_resolution == ModuleResolution::CommonJs {
-              importee.add_cjs_symbol(&mut graph.symbols, imported, is_imported_star);
+      extra_symbols
+        .into_iter()
+        .for_each(|(importee, imported, is_imported_star)| {
+          let importee = &mut graph.modules[importee];
+          match importee {
+            Module::Normal(importee) => {
+              if importee.exports_kind == ExportsKind::CommonJs {
+                importee.add_cjs_symbol(&mut graph.symbols, imported, is_imported_star)
+              }
+            }
+            Module::External(importee) => {
+              importee.add_export_symbol(&mut graph.symbols, imported, is_imported_star);
             }
           }
           Module::External(importee) => {
@@ -312,7 +333,7 @@ impl<'graph> Linker<'graph> {
           let importee = &self.graph.modules[import_record.resolved_module];
           match importee {
             Module::Normal(importee) => {
-              let resolved_ref = if importee.module_resolution == ModuleResolution::CommonJs {
+              let resolved_ref = if importee.exports_kind == ExportsKind::CommonJs {
                 importee.resolve_cjs_symbol(&info.imported, info.is_imported_star)
               } else if info.is_imported_star {
                 importee.namespace_symbol.0

--- a/crates/rolldown/src/bundler/graph/linker.rs
+++ b/crates/rolldown/src/bundler/graph/linker.rs
@@ -107,17 +107,13 @@ impl<'graph> Linker<'graph> {
 
             match (importer.exports_kind, importee.exports_kind) {
               (ExportsKind::Esm, ExportsKind::CommonJs) => {
-                imported_symbols.push((
-                  importer.id,
-                  self.graph.runtime.resolve_symbol(&"__toESM".into()),
-                ));
+                imported_symbols
+                  .push((importer.id, self.graph.runtime.resolve_symbol(&"__toESM".into())));
                 imported_symbols.push((importer.id, importee.namespace_symbol.0));
               }
               (ExportsKind::CommonJs, ExportsKind::Esm) => {
-                imported_symbols.push((
-                  importer.id,
-                  self.graph.runtime.resolve_symbol(&"__toCommonJS".into()),
-                ));
+                imported_symbols
+                  .push((importer.id, self.graph.runtime.resolve_symbol(&"__toCommonJS".into())));
               }
               _ => {}
             }
@@ -215,18 +211,12 @@ impl<'graph> Linker<'graph> {
         }
         Module::External(_) => {}
       }
-      extra_symbols
-        .into_iter()
-        .for_each(|(importee, imported, is_imported_star)| {
-          let importee = &mut graph.modules[importee];
-          match importee {
-            Module::Normal(importee) => {
-              if importee.exports_kind == ExportsKind::CommonJs {
-                importee.add_cjs_symbol(&mut graph.symbols, imported, is_imported_star)
-              }
-            }
-            Module::External(importee) => {
-              importee.add_export_symbol(&mut graph.symbols, imported, is_imported_star);
+      extra_symbols.into_iter().for_each(|(importee, imported, is_imported_star)| {
+        let importee = &mut graph.modules[importee];
+        match importee {
+          Module::Normal(importee) => {
+            if importee.exports_kind == ExportsKind::CommonJs {
+              importee.add_cjs_symbol(&mut graph.symbols, imported, is_imported_star);
             }
           }
           Module::External(importee) => {

--- a/crates/rolldown/src/bundler/module/module_builder.rs
+++ b/crates/rolldown/src/bundler/module/module_builder.rs
@@ -58,9 +58,9 @@ impl NormalModuleBuilder {
       default_export_symbol: self.default_export_symbol,
       namespace_symbol: self.namespace_symbol.unwrap(),
       is_symbol_for_namespace_referenced: false,
-      source_mutations: Default::default(),
+      source_mutations: Vec::default(),
       exports_kind: self.exports_kind.unwrap_or(ExportsKind::Esm),
-      cjs_symbols: Default::default(),
+      cjs_symbols: FxHashMap::default(),
       wrap_symbol: None,
       module_type: self.module_type,
     }

--- a/crates/rolldown/src/bundler/module/module_builder.rs
+++ b/crates/rolldown/src/bundler/module/module_builder.rs
@@ -4,7 +4,7 @@ use oxc::{
   span::{Atom, Span},
 };
 use rolldown_common::{
-  ImportRecord, ImportRecordId, LocalOrReExport, ModuleId, ModuleResolution, NamedImport,
+  ExportsKind, ImportRecord, ImportRecordId, LocalOrReExport, ModuleId, ModuleType, NamedImport,
   ResourceId, StmtInfo, StmtInfoId, SymbolRef,
 };
 use rolldown_oxc::OxcProgram;
@@ -28,8 +28,8 @@ pub struct NormalModuleBuilder {
   pub scope: Option<ScopeTree>,
   pub default_export_symbol: Option<SymbolId>,
   pub namespace_symbol: Option<(SymbolRef, ReferenceId)>,
-  pub module_resolution: Option<ModuleResolution>,
-  pub type_module: bool,
+  pub exports_kind: Option<ExportsKind>,
+  pub module_type: ModuleType,
 }
 
 impl NormalModuleBuilder {
@@ -58,11 +58,11 @@ impl NormalModuleBuilder {
       default_export_symbol: self.default_export_symbol,
       namespace_symbol: self.namespace_symbol.unwrap(),
       is_symbol_for_namespace_referenced: false,
-      source_mutations: Vec::default(),
-      module_resolution: self.module_resolution.unwrap_or(ModuleResolution::Esm),
-      cjs_symbols: FxHashMap::default(),
+      source_mutations: Default::default(),
+      exports_kind: self.exports_kind.unwrap_or(ExportsKind::Esm),
+      cjs_symbols: Default::default(),
       wrap_symbol: None,
-      type_module: self.type_module,
+      module_type: self.module_type,
     }
   }
 }

--- a/crates/rolldown/src/bundler/module/module_builder.rs
+++ b/crates/rolldown/src/bundler/module/module_builder.rs
@@ -29,6 +29,7 @@ pub struct NormalModuleBuilder {
   pub default_export_symbol: Option<SymbolId>,
   pub namespace_symbol: Option<(SymbolRef, ReferenceId)>,
   pub module_resolution: Option<ModuleResolution>,
+  pub type_module: bool,
 }
 
 impl NormalModuleBuilder {
@@ -61,6 +62,7 @@ impl NormalModuleBuilder {
       module_resolution: self.module_resolution.unwrap_or(ModuleResolution::Esm),
       cjs_symbols: FxHashMap::default(),
       wrap_symbol: None,
+      type_module: self.type_module,
     }
   }
 }

--- a/crates/rolldown/src/bundler/module/normal_module.rs
+++ b/crates/rolldown/src/bundler/module/normal_module.rs
@@ -29,6 +29,8 @@ pub struct NormalModule {
   pub exec_order: u32,
   pub id: ModuleId,
   pub resource_id: ResourceId,
+  // The flag for ".mjs" or "type: module" in package.json
+  pub type_module: bool,
   pub ast: OxcProgram,
   pub source_mutations: Vec<BoxedSourceMutation>,
   pub named_imports: FxHashMap<SymbolId, NamedImport>,
@@ -60,7 +62,11 @@ impl NormalModule {
   #[allow(clippy::needless_pass_by_value)]
   pub fn render(&self, ctx: ModuleRenderContext<'_>) -> Option<MagicString<'static>> {
     // FIXME: should not clone
-    let mut source = MagicString::new(self.ast.source().to_string());
+    let source = self.ast.source();
+    if source.is_empty() {
+      return None;
+    }
+    let mut source = MagicString::new(source.to_string());
 
     let ctx = RendererContext::new(
       ctx.symbols,

--- a/crates/rolldown/src/bundler/module_loader/module_loader.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_loader.rs
@@ -181,7 +181,7 @@ impl<'a> ModuleLoader<'a> {
 
           let task = NormalModuleTask::new(
             id,
-            self.resolver.clone(),
+            Arc::<rolldown_resolver::Resolver>::clone(&self.resolver),
             module_path,
             info.module_type,
             self.tx.clone(),

--- a/crates/rolldown/src/bundler/module_loader/module_loader.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_loader.rs
@@ -183,7 +183,7 @@ impl<'a> ModuleLoader<'a> {
             id,
             self.resolver.clone(),
             module_path,
-            info.type_module,
+            info.module_type,
             self.tx.clone(),
           );
           tokio::spawn(async move { task.run().await });

--- a/crates/rolldown/src/bundler/module_loader/module_loader.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_loader.rs
@@ -179,8 +179,13 @@ impl<'a> ModuleLoader<'a> {
 
           let module_path = ResourceId::new(info.path.clone(), &self.input_options.cwd);
 
-          let task =
-            NormalModuleTask::new(id, Arc::clone(&self.resolver), module_path, self.tx.clone());
+          let task = NormalModuleTask::new(
+            id,
+            self.resolver.clone(),
+            module_path,
+            info.type_module,
+            self.tx.clone(),
+          );
           tokio::spawn(async move { task.run().await });
         }
         id

--- a/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
@@ -26,6 +26,7 @@ use crate::{
 pub struct NormalModuleTask {
   module_id: ModuleId,
   path: ResourceId,
+  type_module: bool,
   tx: tokio::sync::mpsc::UnboundedSender<Msg>,
   errors: Vec<BuildError>,
   warnings: Vec<BuildError>,
@@ -37,9 +38,18 @@ impl NormalModuleTask {
     id: ModuleId,
     resolver: SharedResolver,
     path: ResourceId,
+    type_module: bool,
     tx: tokio::sync::mpsc::UnboundedSender<Msg>,
   ) -> Self {
-    Self { module_id: id, resolver, path, tx, errors: Vec::default(), warnings: Vec::default() }
+    Self {
+      module_id: id,
+      resolver,
+      path,
+      type_module,
+      tx,
+      errors: Default::default(),
+      warnings: Default::default(),
+    }
   }
 
   pub async fn run(mut self) -> anyhow::Result<()> {
@@ -83,6 +93,7 @@ impl NormalModuleTask {
     builder.scope = Some(scope);
     builder.module_resolution = module_resolution;
     builder.initialize_namespace_binding(&mut symbol_map);
+    builder.type_module = self.type_module;
 
     self
       .tx

--- a/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
@@ -47,8 +47,8 @@ impl NormalModuleTask {
       path,
       module_type,
       tx,
-      errors: Default::default(),
-      warnings: Default::default(),
+      errors: Vec::default(),
+      warnings: Vec::default(),
     }
   }
 

--- a/crates/rolldown/src/bundler/module_loader/runtime_normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/runtime_normal_module_task.rs
@@ -51,7 +51,7 @@ impl RuntimeNormalModuleTask {
       star_exports,
       export_default_symbol_id,
       imports,
-      module_resolution,
+      exports_kind,
     } = scan_result;
 
     builder.id = Some(self.module_id);
@@ -65,7 +65,7 @@ impl RuntimeNormalModuleTask {
     builder.star_exports = Some(star_exports);
     builder.default_export_symbol = export_default_symbol_id;
     builder.scope = Some(scope);
-    builder.module_resolution = module_resolution;
+    builder.exports_kind = exports_kind;
     builder.initialize_namespace_binding(&mut symbol_map);
 
     self

--- a/crates/rolldown/src/bundler/resolve_id.rs
+++ b/crates/rolldown/src/bundler/resolve_id.rs
@@ -1,11 +1,11 @@
-use rolldown_common::{RawPath, ResourceId};
+use rolldown_common::{ModuleType, RawPath, ResourceId};
 use rolldown_resolver::Resolver;
 
 use crate::BuildResult;
 
 pub struct ResolvedRequestInfo {
   pub path: RawPath,
-  pub type_module: bool,
+  pub module_type: ModuleType,
   pub is_external: bool,
 }
 
@@ -26,7 +26,7 @@ pub async fn resolve_id(
     let resolved = resolver.resolve(importer, request)?;
     Ok(Some(ResolvedRequestInfo {
       path: resolved.resolved,
-      type_module: resolved.type_module,
+      module_type: resolved.module_type,
       is_external: false,
     }))
   }

--- a/crates/rolldown/src/bundler/resolve_id.rs
+++ b/crates/rolldown/src/bundler/resolve_id.rs
@@ -5,6 +5,7 @@ use crate::BuildResult;
 
 pub struct ResolvedRequestInfo {
   pub path: RawPath,
+  pub type_module: bool,
   pub is_external: bool,
 }
 
@@ -23,6 +24,10 @@ pub async fn resolve_id(
     Ok(None)
   } else {
     let resolved = resolver.resolve(importer, request)?;
-    Ok(Some(ResolvedRequestInfo { path: resolved.resolved, is_external: false }))
+    Ok(Some(ResolvedRequestInfo {
+      path: resolved.resolved,
+      type_module: resolved.type_module,
+      is_external: false,
+    }))
   }
 }

--- a/crates/rolldown/src/bundler/visitors/commonjs_source_render.rs
+++ b/crates/rolldown/src/bundler/visitors/commonjs_source_render.rs
@@ -1,5 +1,5 @@
 use oxc::ast::Visit;
-use rolldown_common::ModuleResolution;
+use rolldown_common::ExportsKind;
 
 use crate::bundler::module::module::Module;
 
@@ -37,7 +37,7 @@ impl<'ast> Visit<'ast> for CommonJsSourceRender<'ast> {
         if let Module::Normal(importee) = importee {
           let wrap_symbol_name =
             self.ctx.get_symbol_final_name(importee.wrap_symbol.unwrap()).unwrap();
-          if importee.module_resolution == ModuleResolution::CommonJs {
+          if importee.exports_kind == ExportsKind::CommonJs {
             self.ctx.source.update(expr.span.start, expr.span.end, format!("{wrap_symbol_name}()"));
           } else {
             let namespace_name = self

--- a/crates/rolldown/src/bundler/visitors/mod.rs
+++ b/crates/rolldown/src/bundler/visitors/mod.rs
@@ -165,31 +165,27 @@ impl<'ast> RendererContext<'ast> {
           decl.span.start,
           format!(
             "var {namespace_name} = {to_esm_runtime_symbol_name}({wrap_symbol_name}(){});\n",
-            if self.module.module_type.is_esm() {
-              ", 1"
-            } else {
-              ""
-            }
+            if self.module.module_type.is_esm() { ", 1" } else { "" }
           ),
         );
         decl.specifiers.iter().for_each(|s| match s {
           oxc::ast::ast::ImportDeclarationSpecifier::ImportSpecifier(spec) => {
             if let Some(name) = self.get_symbol_final_name(
-              (importee.id, importee.cjs_symbols.get(spec.imported.name()).unwrap().symbol).into(),
+              (importee.id, importee.cjs_symbols[spec.imported.name()].symbol).into(),
             ) {
               self
                 .source
-                .prepend_left(decl.span.start, format!("var {name} = {namespace_name}.{name};\n"));
+                .prepend_right(decl.span.start, format!("var {name} = {namespace_name}.{name};\n"));
             }
           }
           oxc::ast::ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(_) => {
             if let Some(name) = self.get_symbol_final_name(
-              (importee.id, importee.cjs_symbols.get(&Atom::new_inline("default")).unwrap().symbol)
-                .into(),
+              (importee.id, importee.cjs_symbols[&Atom::new_inline("default")].symbol).into(),
             ) {
-              self
-                .source
-                .prepend_left(decl.span.start, format!("var {name} = {namespace_name}.default;\n"));
+              self.source.prepend_right(
+                decl.span.start,
+                format!("var {name} = {namespace_name}.default;\n"),
+              );
             }
           }
           oxc::ast::ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(_) => {}

--- a/crates/rolldown/tests/fixtures/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/basic_commonjs/artifacts.snap
@@ -35,8 +35,13 @@ module.exports = value;
 }
 });
 // main.js
+<<<<<<< HEAD
 var _default = commonjs_ns.default;
 var commonjs_ns = __toESM(require_commonjs$1());
+=======
+var commonjs_ns = __toESM(require_commonjs());
+var _default = commonjs_ns.default;
+>>>>>>> wip: chore
 
 init_esm();
 

--- a/crates/rolldown/tests/fixtures/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/basic_commonjs/artifacts.snap
@@ -35,13 +35,8 @@ module.exports = value;
 }
 });
 // main.js
-<<<<<<< HEAD
-var _default = commonjs_ns.default;
 var commonjs_ns = __toESM(require_commonjs$1());
-=======
-var commonjs_ns = __toESM(require_commonjs());
 var _default = commonjs_ns.default;
->>>>>>> wip: chore
 
 init_esm();
 

--- a/crates/rolldown/tests/fixtures/node_module_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/node_module_commonjs/artifacts.snap
@@ -3,7 +3,7 @@ source: crates/rolldown/tests/common/case.rs
 expression: content
 input_file: crates/rolldown/tests/fixtures/node_module_commonjs
 ---
-# entry.js
+# 2.js
 
 ```js
 // commonjs.js
@@ -12,9 +12,22 @@ var require_commonjs = __commonJS({
 module.exports = 1;
 }
 });
+```
+# entry.js
+
+```js
 // entry.js
-var _default = commonjs_ns.default;
 var commonjs_ns = __toESM(require_commonjs(), 1);
+var _default = commonjs_ns.default;
+
+console.log(_default)
+```
+# main.js
+
+```js
+// main.mjs
+var commonjs_ns = __toESM(require_commonjs(), 1);
+var _default = commonjs_ns.default;
 
 console.log(_default)
 ```

--- a/crates/rolldown/tests/fixtures/node_module_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/node_module_commonjs/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown/tests/common/case.rs
-assertion_line: 54
 expression: content
 input_file: crates/rolldown/tests/fixtures/node_module_commonjs
 ---

--- a/crates/rolldown/tests/fixtures/node_module_commonjs/artifacts.snap.new
+++ b/crates/rolldown/tests/fixtures/node_module_commonjs/artifacts.snap.new
@@ -1,0 +1,21 @@
+---
+source: crates/rolldown/tests/common/case.rs
+assertion_line: 54
+expression: content
+input_file: crates/rolldown/tests/fixtures/node_module_commonjs
+---
+# entry.js
+
+```js
+// commonjs.js
+var require_commonjs = __commonJS({
+'commonjs.js'(exports, module) {
+module.exports = 1;
+}
+});
+// entry.js
+var _default = commonjs_ns.default;
+var commonjs_ns = __toESM(require_commonjs(), 1);
+
+console.log(_default)
+```

--- a/crates/rolldown/tests/fixtures/node_module_commonjs/commonjs.js
+++ b/crates/rolldown/tests/fixtures/node_module_commonjs/commonjs.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/crates/rolldown/tests/fixtures/node_module_commonjs/entry.js
+++ b/crates/rolldown/tests/fixtures/node_module_commonjs/entry.js
@@ -1,0 +1,2 @@
+import foo from './commonjs.js'
+console.log(foo)

--- a/crates/rolldown/tests/fixtures/node_module_commonjs/main.mjs
+++ b/crates/rolldown/tests/fixtures/node_module_commonjs/main.mjs
@@ -1,0 +1,2 @@
+import foo from './commonjs.js'
+console.log(foo)

--- a/crates/rolldown/tests/fixtures/node_module_commonjs/package.json
+++ b/crates/rolldown/tests/fixtures/node_module_commonjs/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/crates/rolldown/tests/fixtures/node_module_commonjs/test.config.json
+++ b/crates/rolldown/tests/fixtures/node_module_commonjs/test.config.json
@@ -1,0 +1,14 @@
+{
+    "input": {
+        "input": [
+            {
+                "name": "main",
+                "import": "main.mjs"
+            },
+            {
+                "name": "entry",
+                "import": "entry.js"
+            }
+        ]
+    }
+}

--- a/crates/rolldown_common/src/exports_kind.rs
+++ b/crates/rolldown_common/src/exports_kind.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum ModuleResolution {
+pub enum ExportsKind {
   Esm,
   CommonJs,
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -1,7 +1,8 @@
+mod exports_kind;
 mod import_record;
 mod module_id;
 mod module_path;
-mod module_resolution;
+mod module_type;
 mod named_export;
 mod named_import;
 mod raw_path;
@@ -9,10 +10,11 @@ mod resolved_export;
 mod stmt_info;
 mod symbol_ref;
 pub use crate::{
+  exports_kind::ExportsKind,
   import_record::{ImportKind, ImportRecord, ImportRecordId},
   module_id::ModuleId,
   module_path::ResourceId,
-  module_resolution::ModuleResolution,
+  module_type::ModuleType,
   named_export::{LocalExport, LocalOrReExport, ReExport},
   named_import::NamedImport,
   raw_path::RawPath,

--- a/crates/rolldown_common/src/module_type.rs
+++ b/crates/rolldown_common/src/module_type.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, Default, Clone, Copy)]
+pub enum ModuleType {
+  #[default]
+  Unknown,
+  // "c.js"
+  CJS,
+  // ".mjs"
+  EsmMjs,
+  // "type: module" in package.json
+  EsmPackageJson,
+}
+
+impl ModuleType {
+  pub fn is_esm(&self) -> bool {
+    matches!(self, ModuleType::EsmMjs | ModuleType::EsmPackageJson)
+  }
+}

--- a/crates/rolldown_common/src/module_type.rs
+++ b/crates/rolldown_common/src/module_type.rs
@@ -12,6 +12,6 @@ pub enum ModuleType {
 
 impl ModuleType {
   pub fn is_esm(&self) -> bool {
-    matches!(self, ModuleType::EsmMjs | ModuleType::EsmPackageJson)
+    matches!(self, Self::EsmMjs | Self::EsmPackageJson)
   }
 }

--- a/crates/rolldown_resolver/src/lib.rs
+++ b/crates/rolldown_resolver/src/lib.rs
@@ -102,5 +102,5 @@ fn calc_module_type(info: &Resolution) -> ModuleType {
       return ModuleType::EsmPackageJson;
     }
   }
-   ModuleType::Unknown
+  ModuleType::Unknown
 }

--- a/crates/rolldown_resolver/src/lib.rs
+++ b/crates/rolldown_resolver/src/lib.rs
@@ -98,6 +98,5 @@ fn is_type_module(info: &Resolution) -> bool {
   if let Some(package_json) = info.package_json() {
     return package_json.raw_json().get("type").and_then(|v| v.as_str()) == Some("module");
   }
-
-  return false;
+  return false
 }

--- a/crates/rolldown_resolver/src/lib.rs
+++ b/crates/rolldown_resolver/src/lib.rs
@@ -98,5 +98,6 @@ fn is_type_module(info: &Resolution) -> bool {
   if let Some(package_json) = info.package_json() {
     return package_json.raw_json().get("type").and_then(|v| v.as_str()) == Some("module");
   }
+
   return false;
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

close https://github.com/rolldown-rs/rolldown/issues/55

Why need this, please refer to https://github.com/rolldown-rs/rolldown/issues/55. Because we follow esbuild implemention, the pr implement has two parts.
- detect `ModuleType` at resolver
- If importer module is ".mjs" or "type:module" at package.json,  codegen result will render to  `__toEsm(xx, 1/*node mode*/)` 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Added.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
