### PR TITLE
chore: Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 
 # Enable highlight in GitHub for `.snap` files
-*.snap linguist-language=markdown
+# *.snap linguist-language=markdown
 
 # Ignore fxtures
 crates/rolldown/tests/**/*.{js,jsx,ts,tsx}  linguist-detectable=false


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
It seems that `.snap` linguist rewrite doesn't work, the display looks even worse than the previous default one.
**default**
![image](https://github.com/rolldown-rs/rolldown/assets/17974631/cadb2994-381d-4ef7-90d9-a26e35873e39)
**override gitattr**
![image](https://github.com/rolldown-rs/rolldown/assets/17974631/2ad3e8c2-8b2f-4110-b027-f8cce93cb745)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
