### PR TITLE
refactor: add virtual stmt info to avoid mutate original stmt info

### DIFF
--- a/crates/rolldown/src/bundler/chunk/de_conflict.rs
+++ b/crates/rolldown/src/bundler/chunk/de_conflict.rs
@@ -33,8 +33,17 @@ impl Chunk {
       .map(|id| &graph.modules[id])
       .for_each(|module| match module {
         Module::Normal(module) => {
-          module.stmt_infos.iter().flat_map(|part| part.declared_symbols.iter().copied()).for_each(
-            |symbol_id| {
+          module
+            .stmt_infos
+            .iter()
+            .flat_map(|part| part.declared_symbols.iter().copied())
+            .chain(
+              module
+                .virtual_stmt_infos
+                .iter()
+                .flat_map(|part| part.declared_symbols.iter().copied()),
+            )
+            .for_each(|symbol_id| {
               let canonical_ref =
                 graph.symbols.par_get_canonical_ref((module.id, symbol_id).into());
 
@@ -52,8 +61,7 @@ impl Chunk {
                   *count += 1;
                 }
               }
-            },
-          );
+            });
         }
         Module::External(_) => {}
       });

--- a/crates/rolldown/src/bundler/module/module_builder.rs
+++ b/crates/rolldown/src/bundler/module/module_builder.rs
@@ -65,6 +65,7 @@ impl NormalModuleBuilder {
       module_type: self.module_type,
       unresolved_symbols: FxHashMap::default(),
       is_entry: self.is_entry,
+      virtual_stmt_infos: Vec::default(),
     }
   }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -19,6 +19,6 @@ pub use crate::{
   named_import::NamedImport,
   raw_path::RawPath,
   resolved_export::{ResolvedExport, ResolvedExportRuntime},
-  stmt_info::{StmtInfo, StmtInfoId},
+  stmt_info::{StmtInfo, StmtInfoId, VirtualStmtInfo},
   symbol_ref::SymbolRef,
 };

--- a/crates/rolldown_common/src/stmt_info.rs
+++ b/crates/rolldown_common/src/stmt_info.rs
@@ -16,3 +16,10 @@ pub struct StmtInfo {
   /// Top level symbols referenced by this statement.
   pub referenced_symbols: Vec<SymbolRef>,
 }
+
+// Because we want declare symbols at linker, it shouldn't mutate the original `StmtInfo`.
+#[derive(Default, Debug)]
+pub struct VirtualStmtInfo {
+  pub declared_symbols: Vec<SymbolId>,
+  pub referenced_symbols: Vec<SymbolRef>,
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Because we should avoid mutating original stmt info to keep the module un-mutable at the linker.

<!-- Please insert your description here and provide especially
 info about the "what" this PR is solving -->

### Test Plan

No need.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
