### PR TITLE
fix: add stmt info declare symbol for resolution found symbol

### DIFF
--- a/crates/rolldown/tests/fixtures/reexport_star/a.js
+++ b/crates/rolldown/tests/fixtures/reexport_star/a.js
@@ -1,0 +1,1 @@
+export const abc = undefined

--- a/crates/rolldown/tests/fixtures/reexport_star/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/reexport_star/artifacts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/rolldown/tests/common/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/reexport_star
+---
+# 2.js
+
+```js
+// a.js
+var a_ns = {
+  get abc() { return abc }
+};
+const abc = undefined
+```
+# entry.js
+
+```js
+// entry.js
+
+
+export { a_ns as a };
+```
+# main.js
+
+```js
+// main.js
+
+
+export { a_ns as a };
+```

--- a/crates/rolldown/tests/fixtures/reexport_star/entry.js
+++ b/crates/rolldown/tests/fixtures/reexport_star/entry.js
@@ -1,0 +1,1 @@
+export * as a from './a'

--- a/crates/rolldown/tests/fixtures/reexport_star/main.js
+++ b/crates/rolldown/tests/fixtures/reexport_star/main.js
@@ -1,0 +1,1 @@
+export * as a from './a'

--- a/crates/rolldown/tests/fixtures/reexport_star/test.config.json
+++ b/crates/rolldown/tests/fixtures/reexport_star/test.config.json
@@ -1,0 +1,14 @@
+{
+    "input": {
+        "input": [
+            {
+                "name": "main",
+                "import": "main.js"
+            },
+            {
+                "name": "entry",
+                "import": "entry.js"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Before creating local symbol not add the declare symbol to stmt info, it will be caused panic at search final name for the symbol, the previous test can worked because export symbol module and use symbol module at same chunk.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan
Added.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
