### PR TITLE
feat: refactor `Symbols` and remove a lot of `ReferenceId`

### DIFF
--- a/crates/rolldown/src/bundler/graph/linker.rs
+++ b/crates/rolldown/src/bundler/graph/linker.rs
@@ -123,7 +123,7 @@ impl<'graph> Linker<'graph> {
                 symbols,
               );
               importer.generate_symbol_import_and_use(
-                importee.namespace_symbol.0,
+                importee.namespace_symbol,
                 importer_linker_module,
                 symbols,
               );
@@ -369,7 +369,7 @@ impl<'graph> Linker<'graph> {
           match importee {
             Module::Normal(importee) => {
               let resolved_ref = if info.is_imported_star {
-                importee.namespace_symbol.0
+                importee.namespace_symbol
               } else {
                 match importee.resolve_export_for_esm_and_cjs(
                   &info.imported,
@@ -385,12 +385,12 @@ impl<'graph> Linker<'graph> {
                     linker_module.unresolved_symbols.insert(
                       info.imported_as,
                       UnresolvedSymbol {
-                        importee_namespace: importee.namespace_symbol.0,
+                        importee_namespace: importee.namespace_symbol,
                         reference_name,
                       },
                     );
                     importer.generate_symbol_import_and_use(
-                      importee.namespace_symbol.0,
+                      importee.namespace_symbol,
                       linker_module,
                       symbols,
                     );

--- a/crates/rolldown/src/bundler/module/external_module.rs
+++ b/crates/rolldown/src/bundler/module/external_module.rs
@@ -34,7 +34,7 @@ impl ExternalModule {
     self
       .symbols_imported_by_others
       .entry(symbol.clone())
-      .or_insert_with(|| (self.id, symbols.tables[self.id].create_symbol(symbol.clone())).into());
+      .or_insert_with(|| symbols.create_symbol(self.id, symbol.clone()));
   }
 
   pub fn resolve_export(&self, exported: &Atom, is_star: bool) -> SymbolRef {

--- a/crates/rolldown/src/bundler/module/module_builder.rs
+++ b/crates/rolldown/src/bundler/module/module_builder.rs
@@ -1,6 +1,6 @@
 use index_vec::IndexVec;
 use oxc::{
-  semantic::{ReferenceId, ScopeTree, SymbolId},
+  semantic::{ScopeTree, SymbolId},
   span::{Atom, Span},
 };
 use rolldown_common::{
@@ -27,7 +27,7 @@ pub struct NormalModuleBuilder {
   pub star_exports: Option<Vec<ImportRecordId>>,
   pub scope: Option<ScopeTree>,
   pub default_export_symbol: Option<SymbolId>,
-  pub namespace_symbol: Option<(SymbolRef, ReferenceId)>,
+  pub namespace_symbol: Option<SymbolRef>,
   pub exports_kind: Option<ExportsKind>,
   pub module_type: ModuleType,
   pub is_entry: bool,
@@ -37,8 +37,7 @@ impl NormalModuleBuilder {
   pub fn initialize_namespace_binding(&mut self, symbol_table: &mut SymbolMap) {
     let name = format!("{}_ns", self.path.as_ref().unwrap().generate_unique_name());
     let symbol_ref: SymbolRef = (self.id.unwrap(), symbol_table.create_symbol(name.into())).into();
-    let refer = symbol_table.create_reference(Some(symbol_ref.symbol));
-    self.namespace_symbol = Some((symbol_ref, refer));
+    self.namespace_symbol = Some(symbol_ref);
   }
 
   pub fn build(self) -> NormalModule {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Many logic require this refactoring`Symbols` and the most important one is code splitting.

`ReferenceId` is an oxc-related concept. since we had dropped rendering module using oxc ast, most of special logic to deal with `ReferenceId` could be removed.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
