### PR TITLE
feat: only split runtime module into runtime chunk in rust test

### DIFF
--- a/crates/rolldown/examples/basic.rs
+++ b/crates/rolldown/examples/basic.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use rolldown::{Bundler, InputOptions};
+use rolldown::{Bundler, InputItem, InputOptions};
 use sugar_path::SugarPathBuf;
 
 #[tokio::main]
@@ -8,9 +8,13 @@ async fn main() {
   let root = PathBuf::from(&std::env::var("CARGO_MANIFEST_DIR").unwrap());
   let cwd = root.join("./examples").into_normalize();
   let mut bundler = Bundler::new(InputOptions {
-    input: Some(vec!["./index.js".to_string().into()]),
+    input: Some(vec![InputItem {
+      name: Some("basic".to_string()),
+      import: "./index.js".to_string(),
+    }]),
     cwd: Some(cwd),
   });
 
-  bundler.generate(Default::default()).await.unwrap();
+  let outputs = bundler.write(Default::default()).await.unwrap();
+  println!("{outputs:#?}");
 }

--- a/crates/rolldown/tests/common/case.rs
+++ b/crates/rolldown/tests/common/case.rs
@@ -14,6 +14,7 @@ impl Case {
   }
 
   pub fn exec(self) {
+    std::env::set_var("ROLLDOWN_TEST", "1");
     tokio::runtime::Runtime::new().unwrap().block_on(self.exec_inner())
   }
 

--- a/crates/rolldown_common/src/module_path.rs
+++ b/crates/rolldown_common/src/module_path.rs
@@ -42,6 +42,8 @@ impl ResourceId {
     } else {
       path.to_string()
     };
+    // remove \0
+    let pretty = pretty.replace('\0', "");
 
     Self(Inner { path, pretty }.into())
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

After this PR, runtime module will participate in code splitting as the other normal module. Only in `ROLLDOWN_TEST=1`, we will split into `_rolldown_runtime.js` chunk make the snapshot cleaner.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
