### PR TITLE
refactor: no need to create local facade symbols

### DIFF
--- a/crates/rolldown/src/bundler/bundle/bundle.rs
+++ b/crates/rolldown/src/bundler/bundle/bundle.rs
@@ -264,11 +264,11 @@ impl<'a> Bundle<'a> {
       .par_bridge()
       .for_each(|chunk| chunk.render_file_name(self.output_options));
 
+    self.compute_cross_chunk_links(&mut chunk_graph);
+
     chunk_graph.chunks.iter_mut().par_bridge().for_each(|chunk| {
       chunk.de_conflict(self.graph);
     });
-
-    self.compute_cross_chunk_links(&mut chunk_graph);
 
     let assets = chunk_graph
       .chunks

--- a/crates/rolldown/src/bundler/chunk/de_conflict.rs
+++ b/crates/rolldown/src/bundler/chunk/de_conflict.rs
@@ -48,6 +48,10 @@ impl Chunk {
         Module::External(_) => {}
       });
 
+    self.imports_from_other_chunks.iter().flat_map(|(_, items)| items.iter()).for_each(|item| {
+      renamer.add_top_level_symbol(item.import_ref);
+    });
+
     self.canonical_names = renamer.into_canonical_names();
   }
 }

--- a/crates/rolldown/src/bundler/graph/symbols.rs
+++ b/crates/rolldown/src/bundler/graph/symbols.rs
@@ -76,19 +76,6 @@ impl Symbols {
     Self { inner, references_table: reference_table }
   }
 
-  pub fn create_facade_symbol(&mut self, owner: ModuleId) -> SymbolRef {
-    let symbol_id = self.inner[owner].push(Symbol {
-      // name is meaningless for facade symbols
-      name: Atom::new_inline("#FACADE#"),
-      link: None,
-      chunk_id: None,
-      namespace_alias: None,
-    });
-    let symbol_ref = SymbolRef { owner, symbol: symbol_id };
-    self.references_table[owner].push(Some(symbol_id));
-    symbol_ref
-  }
-
   pub fn create_symbol(&mut self, owner: ModuleId, name: Atom) -> SymbolRef {
     let symbol_id =
       self.inner[owner].push(Symbol { name, link: None, chunk_id: None, namespace_alias: None });

--- a/crates/rolldown/src/bundler/module/normal_module.rs
+++ b/crates/rolldown/src/bundler/module/normal_module.rs
@@ -329,44 +329,21 @@ impl NormalModule {
     }
   }
 
-  pub fn generate_symbol_import_and_use(
+  pub fn reference_symbol_in_facade_stmt_infos(
     &self,
     other_module_symbol_ref: SymbolRef,
     self_linking_info: &mut LinkingInfo,
-    symbols: &mut Symbols,
+    _symbols: &mut Symbols,
   ) {
     debug_assert!(other_module_symbol_ref.owner != self.id);
-    // Create a facade symbol belongs to the self module.
-    let facade_ref = symbols.create_facade_symbol(self.id);
-    // The facade symbol is used to reference the symbol from the other module.
-    symbols.union(facade_ref, other_module_symbol_ref);
 
     self_linking_info.facade_stmt_infos.push(StmtInfo {
-      // Since the facade symbol is created, it should be declared. This will be used to
-      // 1. de-conflict the symbol in the de-conflict pass
-      declared_symbols: vec![facade_ref],
+      declared_symbols: vec![],
       // Since the facade symbol is used, it should be referenced. This will be used to
       // create correct cross-chunk links
-      referenced_symbols: vec![facade_ref],
+      referenced_symbols: vec![other_module_symbol_ref],
       ..Default::default()
     });
-  }
-
-  pub fn generate_local_symbol(
-    &self,
-    name: Atom,
-    self_linking_info: &mut LinkingInfo,
-    symbols: &mut Symbols,
-  ) -> SymbolRef {
-    let local_symbol_ref = symbols.create_symbol(self.id, name);
-    self_linking_info.facade_stmt_infos.push(StmtInfo {
-      // FIXME: should store the symbol in `used_symbols` instead of `declared_symbols`.
-      // The deconflict for runtime symbols would be handled in the deconflict on cross-chunk-imported
-      // symbols
-      declared_symbols: vec![local_symbol_ref],
-      ..Default::default()
-    });
-    local_symbol_ref
   }
 
   pub fn get_star_exports_modules(&self) -> impl Iterator<Item = ModuleId> + '_ {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Referenced cross-chunk symbols would be also be processed by deconflicting, so there are no need to create facade local symbol to reference symbols from other modules.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
