### PR TITLE
refactor: linking imports and exports

### DIFF
--- a/crates/rolldown/src/bundler/bundle/bundle.rs
+++ b/crates/rolldown/src/bundler/bundle/bundle.rs
@@ -98,7 +98,7 @@ impl<'a> Bundle<'a> {
         let entry_module = &self.graph.modules[entry_module];
         let entry_linking_info = &self.graph.linking_infos[entry_module.id()];
         for export_ref in entry_linking_info.resolved_exports.values() {
-          let mut canonical_ref = self.graph.symbols.canonical_ref_for(*export_ref);
+          let mut canonical_ref = self.graph.symbols.canonical_ref_for(export_ref.symbol_ref);
           let symbol = self.graph.symbols.get(canonical_ref);
           if let Some(ns_alias) = &symbol.namespace_alias {
             canonical_ref = ns_alias.namespace_ref;

--- a/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
@@ -19,7 +19,7 @@ impl Chunk {
         linking_info
           .exclude_ambiguous_resolved_exports
           .iter()
-          .map(|name| (name, linking_info.resolved_exports.get(name).unwrap().symbol_ref))
+          .map(|name| (name, linking_info.resolved_exports[name].symbol_ref))
           .collect::<Vec<_>>()
       },
     );

--- a/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
@@ -1,13 +1,12 @@
-use oxc::span::Atom;
 use string_wizard::MagicString;
 
-use crate::bundler::graph::{graph::Graph, linker::is_ambiguous_export};
+use crate::bundler::graph::graph::Graph;
 
 use super::chunk::Chunk;
 
 impl Chunk {
   pub fn render_exports_for_esm(&self, graph: &Graph) -> Option<MagicString<'static>> {
-    let mut export_items = self.entry_module.map_or_else(
+    let export_items = self.entry_module.map_or_else(
       || {
         self
           .exports_to_other_chunks

--- a/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
@@ -16,11 +16,7 @@ impl Chunk {
       },
       |entry_module_id| {
         let linking_info = &graph.linking_infos[entry_module_id];
-        linking_info
-          .exclude_ambiguous_resolved_exports
-          .iter()
-          .map(|name| (name, linking_info.resolved_exports[name].symbol_ref))
-          .collect::<Vec<_>>()
+        linking_info.exports().map(|(name, export)| (name, export.symbol_ref)).collect::<Vec<_>>()
       },
     );
 

--- a/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
@@ -16,7 +16,10 @@ impl Chunk {
       },
       |entry_module_id| {
         let linking_info = &graph.linking_infos[entry_module_id];
-        linking_info.exports().map(|(name, export)| (name, export.symbol_ref)).collect::<Vec<_>>()
+        linking_info
+          .sorted_exports()
+          .map(|(name, export)| (name, export.symbol_ref))
+          .collect::<Vec<_>>()
       },
     );
 

--- a/crates/rolldown/src/bundler/graph/graph.rs
+++ b/crates/rolldown/src/bundler/graph/graph.rs
@@ -1,7 +1,4 @@
-use super::{
-  linker::{Linker, LinkingInfoVec},
-  symbols::Symbols,
-};
+use super::{linker::Linker, linker_info::LinkingInfoVec, symbols::Symbols};
 use crate::bundler::{
   module::ModuleVec, module_loader::ModuleLoader,
   options::normalized_input_options::NormalizedInputOptions, runtime::Runtime,

--- a/crates/rolldown/src/bundler/graph/linker.rs
+++ b/crates/rolldown/src/bundler/graph/linker.rs
@@ -396,61 +396,14 @@ impl<'graph> Linker<'graph> {
                     symbol_ref,
                     mut potentially_ambiguous_symbol_refs,
                   ) => {
-                    let mut results = vec![];
-                    // Iterate all potentially ambiguous symbol refs, If all results not be same, it's a ambiguous export
                     potentially_ambiguous_symbol_refs.push(symbol_ref);
-
-                    for symbol_ref in potentially_ambiguous_symbol_refs {
-                      match &modules[symbol_ref.owner] {
-                        Module::Normal(module) => {
-                          let module_linking_info = &linking_infos[module.id];
-                          if let Some(info) = module.named_imports.get(&symbol_ref.symbol) {
-                            let importee_id = module.import_records[info.record_id].resolved_module;
-                            match &modules[importee_id] {
-                              Module::Normal(importee) => {
-                                results.push(Self::match_import_with_export(
-                                  modules,
-                                  importee,
-                                  &linking_infos[importee_id],
-                                  info,
-                                ));
-                              }
-                              Module::External(_) => {}
-                            }
-                          } else if let Some(info) =
-                            module_linking_info.export_from_map.get(&symbol_ref.symbol)
-                          {
-                            let importee_id = module.import_records[info.record_id].resolved_module;
-                            match &modules[importee_id] {
-                              Module::Normal(importee) => {
-                                results.push(Self::match_import_with_export(
-                                  modules,
-                                  importee,
-                                  &linking_infos[importee_id],
-                                  info,
-                                ));
-                              }
-                              Module::External(_) => {}
-                            }
-                          } else {
-                            results.push(MatchImportKind::Found(symbol_ref));
-                          }
-                        }
-                        Module::External(_) => continue,
-                      }
+                    if self
+                      .determine_ambiguous_export(potentially_ambiguous_symbol_refs, linking_infos)
+                    {
+                      // ambiguous export
+                      panic!("");
                     }
-                    let current_result = results.remove(results.len() - 1);
-                    if let MatchImportKind::Found(symbol_ref) = current_result {
-                      for result in results {
-                        if let MatchImportKind::Found(result_symbol_ref) = result {
-                          if result_symbol_ref != symbol_ref {
-                            // ambiguous export
-                            panic!("");
-                          }
-                        }
-                      }
-                      symbols.union(info.imported_as, symbol_ref);
-                    }
+                    symbols.union(info.imported_as, symbol_ref);
                   }
                   MatchImportKind::Found(symbol_ref) => {
                     symbols.union(info.imported_as, symbol_ref);
@@ -483,6 +436,66 @@ impl<'graph> Linker<'graph> {
         // It's meaningless to be a importer for a external module.
       }
     }
+  }
+
+  // Iterate all potentially ambiguous symbol refs, If all results not be same, it's a ambiguous export
+  pub fn determine_ambiguous_export(
+    &self,
+    potentially_ambiguous_symbol_refs: Vec<SymbolRef>,
+    linking_infos: &LinkingInfoVec,
+  ) -> bool {
+    let modules = &self.graph.modules;
+    let mut results = vec![];
+
+    for symbol_ref in potentially_ambiguous_symbol_refs {
+      match &modules[symbol_ref.owner] {
+        Module::Normal(module) => {
+          let module_linking_info = &linking_infos[module.id];
+          if let Some(info) = module.named_imports.get(&symbol_ref.symbol) {
+            let importee_id = module.import_records[info.record_id].resolved_module;
+            match &modules[importee_id] {
+              Module::Normal(importee) => {
+                results.push(Self::match_import_with_export(
+                  modules,
+                  importee,
+                  &linking_infos[importee_id],
+                  info,
+                ));
+              }
+              Module::External(_) => {}
+            }
+          } else if let Some(info) = module_linking_info.export_from_map.get(&symbol_ref.symbol) {
+            let importee_id = module.import_records[info.record_id].resolved_module;
+            match &modules[importee_id] {
+              Module::Normal(importee) => {
+                results.push(Self::match_import_with_export(
+                  modules,
+                  importee,
+                  &linking_infos[importee_id],
+                  info,
+                ));
+              }
+              Module::External(_) => {}
+            }
+          } else {
+            results.push(MatchImportKind::Found(symbol_ref));
+          }
+        }
+        Module::External(_) => {}
+      }
+    }
+    let current_result = results.remove(results.len() - 1);
+    if let MatchImportKind::Found(symbol_ref) = current_result {
+      for result in results {
+        if let MatchImportKind::Found(result_symbol_ref) = result {
+          if result_symbol_ref != symbol_ref {
+            // ambiguous export
+            return true;
+          }
+        }
+      }
+    }
+    false
   }
 
   pub fn match_import_with_export(

--- a/crates/rolldown/src/bundler/graph/linker_info.rs
+++ b/crates/rolldown/src/bundler/graph/linker_info.rs
@@ -13,7 +13,10 @@ pub struct LinkingInfo {
   // Convert `export { v } from "./a"` to `import { v } from "./a"; export { v }`.
   // It is used to prepare resolved exports generation.
   pub export_from_map: FxHashMap<Atom, NamedImport>,
+  // Store the export info for each module, including export named declaration and export star declaration.
   pub resolved_exports: FxHashMap<Atom, ResolvedExport>,
+  // Store the names of exclude ambiguous resolved exports.
+  // It will be used to generate chunk exports and module namespace binding.
   pub exclude_ambiguous_resolved_exports: Vec<Atom>,
   pub resolved_star_exports: Vec<ModuleId>,
 }

--- a/crates/rolldown/src/bundler/graph/linker_info.rs
+++ b/crates/rolldown/src/bundler/graph/linker_info.rs
@@ -1,0 +1,27 @@
+use index_vec::IndexVec;
+use oxc::span::Atom;
+use rolldown_common::{ModuleId, NamedImport, ResolvedExport, StmtInfo, SymbolRef, WrapKind};
+use rustc_hash::FxHashMap;
+
+/// Store the linking info for module
+#[derive(Debug, Default)]
+pub struct LinkingInfo {
+  // The symbol for wrapped module
+  pub wrap_symbol: Option<SymbolRef>,
+  pub wrap_kind: WrapKind,
+  pub facade_stmt_infos: Vec<StmtInfo>,
+  // Convert `export { v } from "./a"` to `import { v } from "./a"; export { v }`.
+  // It is used to prepare resolved exports generation.
+  pub export_from_map: FxHashMap<Atom, NamedImport>,
+  pub resolved_exports: FxHashMap<Atom, ResolvedExport>,
+  pub exclude_ambiguous_resolved_exports: Vec<Atom>,
+  pub resolved_star_exports: Vec<ModuleId>,
+}
+
+impl LinkingInfo {
+  pub fn exports(&self) -> impl Iterator<Item = (&Atom, &ResolvedExport)> {
+    self.exclude_ambiguous_resolved_exports.iter().map(|name| (name, &self.resolved_exports[name]))
+  }
+}
+
+pub type LinkingInfoVec = IndexVec<ModuleId, LinkingInfo>;

--- a/crates/rolldown/src/bundler/graph/linker_info.rs
+++ b/crates/rolldown/src/bundler/graph/linker_info.rs
@@ -1,5 +1,5 @@
 use index_vec::IndexVec;
-use oxc::span::Atom;
+use oxc::{semantic::SymbolId, span::Atom};
 use rolldown_common::{ModuleId, NamedImport, ResolvedExport, StmtInfo, SymbolRef, WrapKind};
 use rustc_hash::FxHashMap;
 
@@ -14,7 +14,7 @@ pub struct LinkingInfo {
   pub facade_stmt_infos: Vec<StmtInfo>,
   // Convert `export { v } from "./a"` to `import { v } from "./a"; export { v }`.
   // It is used to prepare resolved exports generation.
-  pub export_from_map: FxHashMap<Atom, NamedImport>,
+  pub export_from_map: FxHashMap<SymbolId, NamedImport>,
   // Store the export info for each module, including export named declaration and export star declaration.
   pub resolved_exports: FxHashMap<Atom, ResolvedExport>,
   // Store the names of exclude ambiguous resolved exports.

--- a/crates/rolldown/src/bundler/graph/linker_info.rs
+++ b/crates/rolldown/src/bundler/graph/linker_info.rs
@@ -28,7 +28,7 @@ pub struct LinkingInfo {
 }
 
 impl LinkingInfo {
-  pub fn exports(&self) -> impl Iterator<Item = (&Atom, &ResolvedExport)> {
+  pub fn sorted_exports(&self) -> impl Iterator<Item = (&Atom, &ResolvedExport)> {
     self
       .exclude_ambiguous_sorted_resolved_exports
       .iter()

--- a/crates/rolldown/src/bundler/graph/linker_info.rs
+++ b/crates/rolldown/src/bundler/graph/linker_info.rs
@@ -19,7 +19,7 @@ pub struct LinkingInfo {
   pub resolved_exports: FxHashMap<Atom, ResolvedExport>,
   // Store the names of exclude ambiguous resolved exports.
   // It will be used to generate chunk exports and module namespace binding.
-  pub exclude_ambiguous_resolved_exports: Vec<Atom>,
+  pub exclude_ambiguous_sorted_resolved_exports: Vec<Atom>,
   pub resolved_star_exports: Vec<ModuleId>,
   // If a esm module has export star from commonjs, it will be marked as ESMWithDynamicFallback at linker.
   // The unknown export name will be resolved at runtime.
@@ -29,7 +29,10 @@ pub struct LinkingInfo {
 
 impl LinkingInfo {
   pub fn exports(&self) -> impl Iterator<Item = (&Atom, &ResolvedExport)> {
-    self.exclude_ambiguous_resolved_exports.iter().map(|name| (name, &self.resolved_exports[name]))
+    self
+      .exclude_ambiguous_sorted_resolved_exports
+      .iter()
+      .map(|name| (name, &self.resolved_exports[name]))
   }
 
   pub fn create_exclude_ambiguous_resolved_exports(&mut self, symbols: &Symbols) {
@@ -46,7 +49,7 @@ impl LinkingInfo {
       })
       .collect::<Vec<_>>();
     export_names.sort_unstable_by(|a, b| a.cmp(b));
-    self.exclude_ambiguous_resolved_exports = export_names;
+    self.exclude_ambiguous_sorted_resolved_exports = export_names;
   }
 }
 

--- a/crates/rolldown/src/bundler/graph/linker_info.rs
+++ b/crates/rolldown/src/bundler/graph/linker_info.rs
@@ -3,6 +3,8 @@ use oxc::span::Atom;
 use rolldown_common::{ModuleId, NamedImport, ResolvedExport, StmtInfo, SymbolRef, WrapKind};
 use rustc_hash::FxHashMap;
 
+use super::symbols::Symbols;
+
 /// Store the linking info for module
 #[derive(Debug, Default)]
 pub struct LinkingInfo {
@@ -19,12 +21,46 @@ pub struct LinkingInfo {
   // It will be used to generate chunk exports and module namespace binding.
   pub exclude_ambiguous_resolved_exports: Vec<Atom>,
   pub resolved_star_exports: Vec<ModuleId>,
+  // If a esm module has export star from commonjs, it will be marked as ESMWithDynamicFallback at linker.
+  // The unknown export name will be resolved at runtime.
+  // esbuild add it to `ExportKind`, but the linker shouldn't mutate the module.
+  pub has_dynamic_exports: bool,
 }
 
 impl LinkingInfo {
   pub fn exports(&self) -> impl Iterator<Item = (&Atom, &ResolvedExport)> {
     self.exclude_ambiguous_resolved_exports.iter().map(|name| (name, &self.resolved_exports[name]))
   }
+
+  pub fn create_exclude_ambiguous_resolved_exports(&mut self, symbols: &Symbols) {
+    let mut export_names = self
+      .resolved_exports
+      .iter()
+      .filter_map(|(name, resolved_export)| {
+        if let Some(v) = &resolved_export.potentially_ambiguous_symbol_refs {
+          if is_ambiguous_export(resolved_export.symbol_ref, v, symbols) {
+            return None;
+          }
+        }
+        Some(name.clone())
+      })
+      .collect::<Vec<_>>();
+    export_names.sort_unstable_by(|a, b| a.cmp(b));
+    self.exclude_ambiguous_resolved_exports = export_names;
+  }
+}
+
+pub fn is_ambiguous_export(
+  symbol_ref: SymbolRef,
+  potentially_ambiguous_export: &Vec<SymbolRef>,
+  symbols: &Symbols,
+) -> bool {
+  for export in potentially_ambiguous_export {
+    if symbol_ref != symbols.par_canonical_ref_for(*export) {
+      return true;
+    }
+  }
+  false
 }
 
 pub type LinkingInfoVec = IndexVec<ModuleId, LinkingInfo>;

--- a/crates/rolldown/src/bundler/graph/mod.rs
+++ b/crates/rolldown/src/bundler/graph/mod.rs
@@ -1,4 +1,5 @@
 #[allow(clippy::module_inception)]
 pub mod graph;
 pub mod linker;
+pub mod linker_info;
 pub mod symbols;

--- a/crates/rolldown/src/bundler/module/normal_module.rs
+++ b/crates/rolldown/src/bundler/module/normal_module.rs
@@ -99,7 +99,7 @@ impl NormalModule {
         LocalOrReExport::Re(re) => {
           let symbol_ref = self.create_local_symbol(name.clone(), self_linking_info, symbols);
           self_linking_info.export_from_map.insert(
-            name.clone(),
+            symbol_ref.symbol,
             NamedImport {
               imported: re.imported.clone(),
               is_imported_star: re.is_imported_star,

--- a/crates/rolldown/src/bundler/visitors/renderer_base.rs
+++ b/crates/rolldown/src/bundler/visitors/renderer_base.rs
@@ -90,7 +90,7 @@ impl<'ast> RendererBase<'ast> {
       let namespace_name = self.canonical_name_for(self.module.namespace_symbol);
       let exports: String = self
         .linking_info
-        .exports()
+        .sorted_exports()
         .map(|(exported_name, resolved_export)| {
           let canonical_ref = self.graph.symbols.par_canonical_ref_for(resolved_export.symbol_ref);
           let symbol = self.graph.symbols.get(canonical_ref);

--- a/crates/rolldown/src/bundler/visitors/renderer_base.rs
+++ b/crates/rolldown/src/bundler/visitors/renderer_base.rs
@@ -90,8 +90,8 @@ impl<'ast> RendererBase<'ast> {
         .linking_info
         .resolved_exports
         .iter()
-        .map(|(exported_name, symbol_ref)| {
-          let canonical_ref = self.graph.symbols.par_canonical_ref_for(*symbol_ref);
+        .map(|(exported_name, resolved_export)| {
+          let canonical_ref = self.graph.symbols.par_canonical_ref_for(resolved_export.symbol_ref);
           let symbol = self.graph.symbols.get(canonical_ref);
           let return_expr = if let Some(ns_alias) = &symbol.namespace_alias {
             let canonical_ns_name = &self.canonical_names[&ns_alias.namespace_ref];

--- a/crates/rolldown/src/bundler/visitors/renderer_base.rs
+++ b/crates/rolldown/src/bundler/visitors/renderer_base.rs
@@ -4,9 +4,11 @@ use rolldown_oxc::BindingIdentifierExt;
 use rustc_hash::FxHashMap;
 use string_wizard::{MagicString, UpdateOptions};
 
+use crate::bundler::graph::linker_info::LinkingInfo;
+
 use super::super::{
   chunk_graph::ChunkGraph,
-  graph::{graph::Graph, linker::LinkingInfo},
+  graph::graph::Graph,
   module::{Module, NormalModule},
 };
 
@@ -88,8 +90,7 @@ impl<'ast> RendererBase<'ast> {
       let namespace_name = self.canonical_name_for(self.module.namespace_symbol);
       let exports: String = self
         .linking_info
-        .resolved_exports
-        .iter()
+        .exports()
         .map(|(exported_name, resolved_export)| {
           let canonical_ref = self.graph.symbols.par_canonical_ref_for(resolved_export.symbol_ref);
           let symbol = self.graph.symbols.get(canonical_ref);

--- a/crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_es6/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_e
 ```js
 // entry.js
 var entry_ns = {
-  get foo() { return foo },
-  get ns() { return entry_ns }
+  get ns() { return entry_ns },
+  get foo() { return foo }
 };
 const foo = 123
 

--- a/crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_es6/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_e
 ```js
 // entry.js
 var entry_ns = {
-  get ns() { return entry_ns },
-  get foo() { return foo }
+  get foo() { return foo },
+  get ns() { return entry_ns }
 };
 const foo = 123
 

--- a/crates/rolldown/tests/esbuild/import_star/import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_export_self_as_namespace_es6/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_export_self_as_name
 ```js
 // entry.js
 var entry_ns = {
-  get ns() { return entry_ns },
-  get foo() { return foo }
+  get foo() { return foo },
+  get ns() { return entry_ns }
 };
 const foo = 123
 

--- a/crates/rolldown/tests/esbuild/import_star/import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_export_self_as_namespace_es6/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_export_self_as_name
 ```js
 // entry.js
 var entry_ns = {
-  get foo() { return foo },
-  get ns() { return entry_ns }
+  get ns() { return entry_ns },
+  get foo() { return foo }
 };
 const foo = 123
 

--- a/crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguous_warning/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguous_warning/artifacts.snap
@@ -15,8 +15,7 @@ const y = 2
 // common.js
 var common_ns = {
   get x() { return x },
-  get z() { return z },
-  get y() { return y }
+  get z() { return z }
 };
 
 

--- a/crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguous_warning/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguous_warning/artifacts.snap
@@ -14,8 +14,8 @@ const x = 1
 const y = 2
 // common.js
 var common_ns = {
-  get z() { return z },
-  get x() { return x }
+  get x() { return x },
+  get z() { return z }
 };
 
 

--- a/crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguous_warning/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguous_warning/artifacts.snap
@@ -15,7 +15,8 @@ const y = 2
 // common.js
 var common_ns = {
   get x() { return x },
-  get z() { return z }
+  get z() { return z },
+  get y() { return y }
 };
 
 

--- a/crates/rolldown/tests/esbuild/import_star/import_star_export_star_omit_ambiguous/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_export_star_omit_ambiguous/artifacts.snap
@@ -15,8 +15,7 @@ const y = 2
 // common.js
 var common_ns = {
   get x() { return x },
-  get z() { return z },
-  get y() { return y }
+  get z() { return z }
 };
 
 

--- a/crates/rolldown/tests/esbuild/import_star/import_star_export_star_omit_ambiguous/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_export_star_omit_ambiguous/artifacts.snap
@@ -14,8 +14,8 @@ const x = 1
 const y = 2
 // common.js
 var common_ns = {
-  get z() { return z },
-  get x() { return x }
+  get x() { return x },
+  get z() { return z }
 };
 
 

--- a/crates/rolldown/tests/esbuild/import_star/import_star_export_star_omit_ambiguous/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_export_star_omit_ambiguous/artifacts.snap
@@ -15,7 +15,8 @@ const y = 2
 // common.js
 var common_ns = {
   get x() { return x },
-  get z() { return z }
+  get z() { return z },
+  get y() { return y }
 };
 
 

--- a/crates/rolldown/tests/esbuild/import_star/import_star_of_export_star_as/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_of_export_star_as/artifacts.snap
@@ -7,6 +7,9 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_star_of_export_star
 
 ```js
 // bar.js
+var bar_ns = {
+  get bar() { return bar }
+};
 const bar = 123
 // foo.js
 var foo_ns = {

--- a/crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_
 ```js
 // foo.js
 var foo_ns = {
-  get ns() { return foo_ns },
-  get foo() { return foo }
+  get foo() { return foo },
+  get ns() { return foo_ns }
 };
 const foo = 123
 

--- a/crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6/artifacts.snap
@@ -7,6 +7,10 @@ input_file: crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_
 
 ```js
 // foo.js
+var foo_ns = {
+  get ns() { return foo_ns },
+  get foo() { return foo }
+};
 const foo = 123
 
 // entry.js

--- a/crates/rolldown/tests/esbuild/import_star/other_file_import_export_self_as_namespace_unused_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/other_file_import_export_self_as_namespace_unused_es6/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/esbuild/import_star/other_file_import_export_s
 ```js
 // foo.js
 var foo_ns = {
-  get ns() { return foo_ns },
-  get foo() { return foo }
+  get foo() { return foo },
+  get ns() { return foo_ns }
 };
 const foo = 123
 

--- a/crates/rolldown/tests/esbuild/import_star/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/esbuild/import_star/re_export_other_file_expor
 ```js
 // foo.js
 var foo_ns = {
-  get ns() { return foo_ns },
-  get foo() { return foo }
+  get foo() { return foo },
+  get ns() { return foo_ns }
 };
 const foo = 123
 

--- a/crates/rolldown/tests/esbuild/import_star/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/esbuild/import_star/re_export_other_file_impor
 ```js
 // foo.js
 var foo_ns = {
-  get ns() { return foo_ns },
-  get foo() { return foo }
+  get foo() { return foo },
+  get ns() { return foo_ns }
 };
 const foo = 123
 

--- a/crates/rolldown/tests/esbuild/splitting/shared-commonjs-into-es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/shared-commonjs-into-es6/artifacts.snap
@@ -17,7 +17,7 @@ var require_shared = __commonJS({
 exports.foo = 123
 }
 });
-export { require_shared, shared_ns };
+export { shared_ns, require_shared };
 ```
 # a.mjs
 

--- a/crates/rolldown/tests/fixtures/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/basic_commonjs/artifacts.snap
@@ -13,10 +13,10 @@ function esm_default_fn() {}function esm_named_fn() {}
 
 var esm_named_var,esm_named_class;
 var esm_ns = {
-  get esm_named_var() { return esm_named_var },
   get default() { return esm_default_fn },
+  get esm_named_class() { return esm_named_class },
   get esm_named_fn() { return esm_named_fn },
-  get esm_named_class() { return esm_named_class }
+  get esm_named_var() { return esm_named_var }
 };
 var init_esm = __esm({
 'esm.js'() {

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -6,6 +6,7 @@ mod module_type;
 mod named_export;
 mod named_import;
 mod raw_path;
+mod resolved_export;
 mod stmt_info;
 mod symbol_ref;
 mod wrap_kind;
@@ -18,6 +19,7 @@ pub use crate::{
   named_export::{LocalExport, LocalOrReExport, ReExport},
   named_import::NamedImport,
   raw_path::RawPath,
+  resolved_export::ResolvedExport,
   stmt_info::{StmtInfo, StmtInfoId, StmtInfos},
   symbol_ref::SymbolRef,
   wrap_kind::WrapKind,

--- a/crates/rolldown_common/src/resolved_export.rs
+++ b/crates/rolldown_common/src/resolved_export.rs
@@ -1,7 +1,8 @@
 use crate::{ModuleId, SymbolRef};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ResolvedExport {
+  pub potentially_ambiguous_symbol_refs: Option<Vec<SymbolRef>>,
   pub symbol_ref: SymbolRef,
   pub export_from: Option<ModuleId>,
 }

--- a/crates/rolldown_common/src/resolved_export.rs
+++ b/crates/rolldown_common/src/resolved_export.rs
@@ -1,0 +1,7 @@
+use crate::{ModuleId, SymbolRef};
+
+#[derive(Debug, Clone, Copy)]
+pub struct ResolvedExport {
+  pub symbol_ref: SymbolRef,
+  pub export_from: Option<ModuleId>,
+}

--- a/crates/rolldown_common/src/resolved_export.rs
+++ b/crates/rolldown_common/src/resolved_export.rs
@@ -2,6 +2,26 @@ use crate::{ModuleId, SymbolRef};
 
 #[derive(Debug, Clone)]
 pub struct ResolvedExport {
+  // Because create export star exports happens before linking imports, The symbols can't  determine if duplicate names from export star resolution are
+  // ambiguous (point to different symbols) or not (point to the same symbol).
+  // Here is a example:
+  //
+  //   // entry.js
+  //   export * from './a'
+  //   export * from './b'
+  //
+  //   // a.js
+  //   export * from './c'
+  //
+  //   // b.js
+  //   export {x} from './c'
+  //
+  //   // c.js
+  //   export let x = 1, y = 2
+  //
+  // In this case "entry.js" should have two exports "x" and "y", neither of
+  // which are ambiguous. To handle this case, ambiguity resolution will be
+  // deferred to linking imports.
   pub potentially_ambiguous_symbol_refs: Option<Vec<SymbolRef>>,
   pub symbol_ref: SymbolRef,
   pub export_from: Option<ModuleId>,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Refactor linking imports and exports.

The new implement for linking imports and exports is following esbuild, it has some following steps.
1. Add the export named declaration to `ResolvedExports`, If there is a reexport named declaration `export { a} from 'a'`, it will be converted to `import { a } from 'a'; export { a }`.
2. Mark module has dynamic export, it due to export star from commonjs need to generate resolve symbol at runtime.
3. Add the export star declaration to `ResolvedExports`. Here should process symbol shadowing and potentially ambiguous export.
4. Linking imports to `ResolvedExports`.
5. Collect `exclude_ambiguous_sorted_resolved_exports`. It is excluding the ambiguous export  from`ResolvedExports`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Not need.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
