### PR TITLE
fix: generate local symbol for esm import cjs instead of reference cjs namespace symbol

### DIFF
--- a/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
@@ -34,10 +34,9 @@ impl Chunk {
         let symbol = graph.symbols.get(canonical_ref);
         let canonical_name = &self.canonical_names[&canonical_ref];
         if let Some(ns_alias) = &symbol.namespace_alias {
-          if let Some(property_name) = &ns_alias.property_name {
-            let canonical_ns_name = &self.canonical_names[&ns_alias.namespace_ref];
-            s.append(format!("var {canonical_name} = {canonical_ns_name}.{property_name};\n"));
-          }
+          let canonical_ns_name = &self.canonical_names[&ns_alias.namespace_ref];
+          let property_name = &ns_alias.property_name;
+          s.append(format!("var {canonical_name} = {canonical_ns_name}.{property_name};\n"));
         }
         if canonical_name == exported_name {
           format!("{canonical_name}")

--- a/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/bundler/chunk/render_chunk_exports.rs
@@ -34,11 +34,10 @@ impl Chunk {
         let symbol = graph.symbols.get(canonical_ref);
         let canonical_name = &self.canonical_names[&canonical_ref];
         if let Some(ns_alias) = &symbol.namespace_alias {
-          let canonical_ns_name = &self.canonical_names[&ns_alias.namespace_ref];
-          s.append(format!(
-            "var {canonical_name} = {canonical_ns_name}.{};\n",
-            ns_alias.property_name
-          ));
+          if let Some(property_name) = &ns_alias.property_name {
+            let canonical_ns_name = &self.canonical_names[&ns_alias.namespace_ref];
+            s.append(format!("var {canonical_name} = {canonical_ns_name}.{property_name};\n"));
+          }
         }
         if canonical_name == exported_name {
           format!("{canonical_name}")

--- a/crates/rolldown/src/bundler/graph/linker.rs
+++ b/crates/rolldown/src/bundler/graph/linker.rs
@@ -496,6 +496,7 @@ impl<'graph> Linker<'graph> {
     info: &NamedImport,
   ) -> MatchImportKind {
     // If importee module is commonjs module, it will generate property access to namespace symbol
+    // The namespace symbols should be importer created local symbol.
     if importee.exports_kind == ExportsKind::CommonJs {
       return MatchImportKind::NameSpace(
         importer_linking_info.local_symbol_for_import_cjs[&importee.id],
@@ -531,6 +532,7 @@ impl<'graph> Linker<'graph> {
     }
 
     // If the module has dynamic exports, the unknown export name will be resolved at runtime.
+    // The namespace symbol should be importee namespace symbol.
     if importee_linking_info.has_dynamic_exports {
       return MatchImportKind::NameSpace(importee.namespace_symbol);
     }

--- a/crates/rolldown/src/bundler/graph/linker.rs
+++ b/crates/rolldown/src/bundler/graph/linker.rs
@@ -402,14 +402,14 @@ impl<'graph> Linker<'graph> {
                     symbols.union(info.imported_as, symbol_ref);
                   }
                   MatchImportKind::NameSpace(symbol_ref) => {
-                    symbols.get_mut(info.imported_as).namespace_alias = Some(NamespaceAlias {
-                      property_name: if info.is_imported_star {
-                        None
-                      } else {
-                        Some(info.imported.clone())
-                      },
-                      namespace_ref: symbol_ref,
-                    });
+                    if info.is_imported_star {
+                      symbols.union(info.imported_as, symbol_ref);
+                    } else {
+                      symbols.get_mut(info.imported_as).namespace_alias = Some(NamespaceAlias {
+                        property_name: info.imported.clone(),
+                        namespace_ref: symbol_ref,
+                      });
+                    }
                   }
                 }
               }

--- a/crates/rolldown/src/bundler/graph/linker.rs
+++ b/crates/rolldown/src/bundler/graph/linker.rs
@@ -169,7 +169,7 @@ impl<'graph> Linker<'graph> {
 
     // Linking the module imports to resolved exports
     self.graph.sorted_modules.clone().into_iter().for_each(|id| {
-      self.match_imports_with_exports(id, &mut symbols, &mut linking_infos, &self.graph.modules);
+      self.match_imports_with_exports(id, &mut symbols, &linking_infos, &self.graph.modules);
     });
 
     // Exclude ambiguous from resolved exports
@@ -233,29 +233,23 @@ impl<'graph> Linker<'graph> {
             };
             if let Some(importee_warp_symbol) = importee_linking_info.wrap_symbol {
               let importer_linking_info = &mut linking_infos[importer.id];
-              importer.reference_symbol_in_facade_stmt_infos(
-                importee_warp_symbol,
-                importer_linking_info,
-                symbols,
-              );
-              importer.reference_symbol_in_facade_stmt_infos(
-                importee.namespace_symbol,
-                importer_linking_info,
-                symbols,
-              );
+              importer_linking_info.reference_symbol_in_facade_stmt_infos(importee_warp_symbol);
               match (importer.exports_kind, importee.exports_kind) {
                 (ExportsKind::Esm, ExportsKind::CommonJs) => {
-                  importer.reference_symbol_in_facade_stmt_infos(
-                    self.graph.runtime.resolve_symbol(&"__toESM".into()),
+                  importer.create_local_symbol_for_import_cjs(
+                    importee,
                     importer_linking_info,
                     symbols,
                   );
+                  importer_linking_info.reference_symbol_in_facade_stmt_infos(
+                    self.graph.runtime.resolve_symbol(&"__toESM".into()),
+                  );
                 }
                 (_, ExportsKind::Esm) => {
-                  importer.reference_symbol_in_facade_stmt_infos(
+                  importer_linking_info
+                    .reference_symbol_in_facade_stmt_infos(importee.namespace_symbol);
+                  importer_linking_info.reference_symbol_in_facade_stmt_infos(
                     self.graph.runtime.resolve_symbol(&"__toCommonJS".into()),
-                    importer_linking_info,
-                    symbols,
                   );
                 }
                 _ => {}
@@ -265,10 +259,9 @@ impl<'graph> Linker<'graph> {
           importer.star_export_modules().for_each(|id| match &self.graph.modules[id] {
             Module::Normal(importee) => {
               if importee.exports_kind == ExportsKind::CommonJs {
-                importer.reference_symbol_in_facade_stmt_infos(
+                let importee_linking_info = &mut linking_infos[importer.id];
+                importee_linking_info.reference_symbol_in_facade_stmt_infos(
                   self.graph.runtime.resolve_symbol(&"__reExport".into()),
-                  &mut linking_infos[importer.id],
-                  symbols,
                 );
               }
             }
@@ -306,7 +299,7 @@ impl<'graph> Linker<'graph> {
           "__esm".into()
         };
         let runtime_symbol = self.graph.runtime.resolve_symbol(&name);
-        module.reference_symbol_in_facade_stmt_infos(runtime_symbol, linking_info, symbols);
+        linking_info.reference_symbol_in_facade_stmt_infos(runtime_symbol);
         module.import_records.iter().for_each(|record| {
           self.wrap_module(record.resolved_module, symbols, linking_infos);
         });
@@ -369,13 +362,12 @@ impl<'graph> Linker<'graph> {
     &self,
     id: ModuleId,
     symbols: &mut Symbols,
-    linking_infos: &mut LinkingInfoVec,
+    linking_infos: &LinkingInfoVec,
     modules: &ModuleVec,
   ) {
     let importer = &self.graph.modules[id];
     match importer {
       Module::Normal(importer) => {
-        let mut local_symbols = vec![];
         importer
           .named_imports
           .values()
@@ -389,6 +381,7 @@ impl<'graph> Linker<'graph> {
                   modules,
                   importee,
                   &linking_infos[importee.id],
+                  &linking_infos[importer.id],
                   info,
                 ) {
                   MatchImportKind::NotFound => panic!(""),
@@ -408,12 +401,15 @@ impl<'graph> Linker<'graph> {
                   MatchImportKind::Found(symbol_ref) => {
                     symbols.union(info.imported_as, symbol_ref);
                   }
-                  MatchImportKind::NameSpace => {
+                  MatchImportKind::NameSpace(symbol_ref) => {
                     symbols.get_mut(info.imported_as).namespace_alias = Some(NamespaceAlias {
-                      property_name: info.imported.clone(),
-                      namespace_ref: importee.namespace_symbol,
+                      property_name: if info.is_imported_star {
+                        None
+                      } else {
+                        Some(info.imported.clone())
+                      },
+                      namespace_ref: symbol_ref,
                     });
-                    local_symbols.push(importee.namespace_symbol);
                   }
                 }
               }
@@ -423,14 +419,6 @@ impl<'graph> Linker<'graph> {
               }
             }
           });
-
-        local_symbols.into_iter().for_each(|symbol_ref| {
-          importer.reference_symbol_in_facade_stmt_infos(
-            symbol_ref,
-            &mut linking_infos[importer.id],
-            symbols,
-          );
-        });
       }
       Module::External(_) => {
         // It's meaningless to be a importer for a external module.
@@ -459,6 +447,7 @@ impl<'graph> Linker<'graph> {
                   modules,
                   importee,
                   &linking_infos[importee_id],
+                  module_linking_info,
                   info,
                 ));
               }
@@ -472,6 +461,7 @@ impl<'graph> Linker<'graph> {
                   modules,
                   importee,
                   &linking_infos[importee_id],
+                  module_linking_info,
                   info,
                 ));
               }
@@ -502,15 +492,18 @@ impl<'graph> Linker<'graph> {
     modules: &ModuleVec,
     importee: &NormalModule,
     importee_linking_info: &LinkingInfo,
+    importer_linking_info: &LinkingInfo,
     info: &NamedImport,
   ) -> MatchImportKind {
-    if info.is_imported_star {
-      return MatchImportKind::Found(importee.namespace_symbol);
-    }
-
     // If importee module is commonjs module, it will generate property access to namespace symbol
     if importee.exports_kind == ExportsKind::CommonJs {
-      return MatchImportKind::NameSpace;
+      return MatchImportKind::NameSpace(
+        importer_linking_info.local_symbol_for_import_cjs[&importee.id],
+      );
+    }
+
+    if info.is_imported_star {
+      return MatchImportKind::Found(importee.namespace_symbol);
     }
 
     if let Some(resolved_export) = importee_linking_info.resolved_exports.get(&info.imported) {
@@ -526,7 +519,9 @@ impl<'graph> Linker<'graph> {
         match module {
           Module::Normal(module) => {
             if module.exports_kind == ExportsKind::CommonJs {
-              return MatchImportKind::NameSpace;
+              return MatchImportKind::NameSpace(
+                importer_linking_info.local_symbol_for_import_cjs[&module.id],
+              );
             }
           }
           Module::External(_) => {}
@@ -537,7 +532,7 @@ impl<'graph> Linker<'graph> {
 
     // If the module has dynamic exports, the unknown export name will be resolved at runtime.
     if importee_linking_info.has_dynamic_exports {
-      return MatchImportKind::NameSpace;
+      return MatchImportKind::NameSpace(importee.namespace_symbol);
     }
 
     MatchImportKind::NotFound
@@ -563,7 +558,10 @@ impl<'graph> Linker<'graph> {
         }
         for id in module.star_export_modules() {
           if self.mark_dynamic_exports_due_to_export_star(id, linking_infos, visited_modules) {
-            linking_infos[target].has_dynamic_exports = true;
+            let module_linking_info = &mut linking_infos[target];
+            module_linking_info.has_dynamic_exports = true;
+            // Dynamic exports will generate `__reExport(ns, xx)`, here should reference self namespace symbol
+            module_linking_info.reference_symbol_in_facade_stmt_infos(module.namespace_symbol);
             return true;
           }
         }
@@ -578,7 +576,7 @@ impl<'graph> Linker<'graph> {
 pub enum MatchImportKind {
   NotFound,
   // The import symbol will generate property access to namespace symbol
-  NameSpace,
+  NameSpace(SymbolRef),
   // External,
   PotentiallyAmbiguous(SymbolRef, Vec<SymbolRef>),
   Found(SymbolRef),

--- a/crates/rolldown/src/bundler/graph/linker_info.rs
+++ b/crates/rolldown/src/bundler/graph/linker_info.rs
@@ -25,6 +25,7 @@ pub struct LinkingInfo {
   // The unknown export name will be resolved at runtime.
   // esbuild add it to `ExportKind`, but the linker shouldn't mutate the module.
   pub has_dynamic_exports: bool,
+  pub local_symbol_for_import_cjs: FxHashMap<ModuleId, SymbolRef>,
 }
 
 impl LinkingInfo {
@@ -55,6 +56,16 @@ impl LinkingInfo {
       .collect::<Vec<_>>();
     export_names.sort_unstable_by(|a, b| a.cmp(b));
     self.exclude_ambiguous_sorted_resolved_exports = export_names;
+  }
+
+  pub fn reference_symbol_in_facade_stmt_infos(&mut self, symbol_ref: SymbolRef) {
+    self.facade_stmt_infos.push(StmtInfo {
+      declared_symbols: vec![],
+      // Since the facade symbol is used, it should be referenced. This will be used to
+      // create correct cross-chunk links
+      referenced_symbols: vec![symbol_ref],
+      ..Default::default()
+    });
   }
 }
 

--- a/crates/rolldown/src/bundler/graph/linker_info.rs
+++ b/crates/rolldown/src/bundler/graph/linker_info.rs
@@ -25,6 +25,7 @@ pub struct LinkingInfo {
   // The unknown export name will be resolved at runtime.
   // esbuild add it to `ExportKind`, but the linker shouldn't mutate the module.
   pub has_dynamic_exports: bool,
+  // Store the local symbol for esm import cjs. eg. `var import_ns = __toESM(require_cjs())`
   pub local_symbol_for_import_cjs: FxHashMap<ModuleId, SymbolRef>,
 }
 

--- a/crates/rolldown/src/bundler/graph/symbols.rs
+++ b/crates/rolldown/src/bundler/graph/symbols.rs
@@ -11,7 +11,7 @@ use crate::bundler::chunk::ChunkId;
 
 #[derive(Debug)]
 pub struct NamespaceAlias {
-  pub property_name: Option<Atom>,
+  pub property_name: Atom,
   pub namespace_ref: SymbolRef,
 }
 

--- a/crates/rolldown/src/bundler/graph/symbols.rs
+++ b/crates/rolldown/src/bundler/graph/symbols.rs
@@ -11,7 +11,7 @@ use crate::bundler::chunk::ChunkId;
 
 #[derive(Debug)]
 pub struct NamespaceAlias {
-  pub property_name: Atom,
+  pub property_name: Option<Atom>,
   pub namespace_ref: SymbolRef,
 }
 

--- a/crates/rolldown/src/bundler/module/normal_module_builder.rs
+++ b/crates/rolldown/src/bundler/module/normal_module_builder.rs
@@ -15,6 +15,7 @@ use super::NormalModule;
 #[derive(Debug, Default)]
 pub struct NormalModuleBuilder {
   pub id: Option<ModuleId>,
+  pub unique_name: Option<String>,
   pub path: Option<ResourceId>,
   pub ast: Option<OxcProgram>,
   pub named_imports: Option<FxHashMap<SymbolId, NamedImport>>,
@@ -36,6 +37,7 @@ impl NormalModuleBuilder {
     NormalModule {
       exec_order: u32::MAX,
       id: self.id.unwrap(),
+      unique_name: self.unique_name.unwrap(),
       resource_id: self.path.unwrap(),
       ast: self.ast.unwrap(),
       named_imports: self.named_imports.unwrap(),

--- a/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
@@ -76,10 +76,12 @@ impl NormalModuleTask {
       export_default_symbol_id,
       imports,
       exports_kind,
+      unique_name,
     } = scan_result;
 
     builder.id = Some(self.module_id);
     builder.ast = Some(ast);
+    builder.unique_name = Some(unique_name);
     builder.path = Some(self.path);
     builder.named_imports = Some(named_imports);
     builder.named_exports = Some(named_exports);
@@ -121,7 +123,7 @@ impl NormalModuleTask {
       self.module_id,
       &mut scope,
       &mut symbol_table,
-      &unique_name,
+      unique_name,
       self.module_type,
     );
     scanner.visit_program(program.program_mut());

--- a/crates/rolldown/src/bundler/module_loader/runtime_normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/runtime_normal_module_task.rs
@@ -60,10 +60,12 @@ impl RuntimeNormalModuleTask {
       export_default_symbol_id,
       imports,
       exports_kind,
+      unique_name,
     } = scan_result;
 
     builder.id = Some(self.module_id);
     builder.ast = Some(ast);
+    builder.unique_name = Some(unique_name);
     builder.path = Some(ResourceId::new(RUNTIME_PATH.to_string().into(), self.resolver.cwd()));
     builder.named_imports = Some(named_imports);
     builder.named_exports = Some(named_exports);
@@ -102,7 +104,7 @@ impl RuntimeNormalModuleTask {
       self.module_id,
       &mut scope,
       &mut symbol_table,
-      "should be unreachable for runtime module",
+      RUNTIME_PATH.to_string(),
       self.module_type,
     );
     let namespace_symbol = scanner.namespace_symbol;

--- a/crates/rolldown/src/bundler/visitors/cjs_renderer.rs
+++ b/crates/rolldown/src/bundler/visitors/cjs_renderer.rs
@@ -21,7 +21,7 @@ impl<'ast> CjsRenderer<'ast> {
       "var {wrap_symbol_name} = {commonjs_runtime_symbol_name}({{\n'{module_path}'(exports, module) {{\n",
     ));
     self.base.source.append("\n}\n});");
-    assert!(!self.base.module.is_namespace_referenced())
+    assert!(!self.base.module.is_namespace_referenced());
   }
 }
 

--- a/crates/rolldown/src/bundler/visitors/cjs_renderer.rs
+++ b/crates/rolldown/src/bundler/visitors/cjs_renderer.rs
@@ -21,9 +21,7 @@ impl<'ast> CjsRenderer<'ast> {
       "var {wrap_symbol_name} = {commonjs_runtime_symbol_name}({{\n'{module_path}'(exports, module) {{\n",
     ));
     self.base.source.append("\n}\n});");
-    if let Some(s) = self.base.generate_namespace_variable_declaration() {
-      self.base.source.prepend(s);
-    }
+    assert!(!self.base.module.is_namespace_referenced())
   }
 }
 

--- a/crates/rolldown/src/bundler/visitors/esm_renderer.rs
+++ b/crates/rolldown/src/bundler/visitors/esm_renderer.rs
@@ -50,16 +50,14 @@ impl<'ast> Visit<'ast> for EsmRenderer<'ast> {
       match self.base.get_importee_by_span(named_decl.span) {
         Module::Normal(importee) => {
           if importee.exports_kind == ExportsKind::CommonJs {
-            self.base.overwrite(
+            self.base.hoisted_module_declaration(
               named_decl.span.start,
-              named_decl.span.end,
               self.base.generate_import_commonjs_module(
                 importee,
                 &self.base.graph.linking_infos[importee.id],
                 true,
               ),
             );
-            return;
           }
         }
         Module::External(_) => {} // TODO

--- a/crates/rolldown/src/bundler/visitors/renderer_base.rs
+++ b/crates/rolldown/src/bundler/visitors/renderer_base.rs
@@ -170,10 +170,7 @@ impl<'ast> RendererBase<'ast> {
       // Here need write it to property access. eg `import { a } from 'cjs'; console.log(a)` => `console.log(import_a.a)`
       // Note: we should rewrite call expression to indirect call, eg `import { a } from 'cjs'; console.log(a())` => `console.log((0, import_a.a)())`
       let canonical_ns_name = self.canonical_name_for(ns_alias.namespace_ref);
-      let content = ns_alias.property_name.as_ref().map_or_else(
-        || format!("{canonical_ns_name}",),
-        |property_name| format!("{canonical_ns_name}.{property_name}",),
-      );
+      let content = format!("{canonical_ns_name}.{}", ns_alias.property_name);
       self.source.update(
         ident.span.start,
         ident.span.end,

--- a/crates/rolldown/src/bundler/visitors/renderer_base.rs
+++ b/crates/rolldown/src/bundler/visitors/renderer_base.rs
@@ -22,7 +22,7 @@ pub struct RendererBase<'ast> {
   pub chunk_graph: &'ast ChunkGraph,
   pub wrap_symbol_name: Option<&'ast Atom>,
   pub default_symbol_name: Option<&'ast Atom>,
-  // Used to hoisted import declaration before the first statement
+  // Used to hoisted declaration for import module, including import declaration and export declaration which has source imported
   pub first_stmt_start: Option<u32>,
 }
 
@@ -115,7 +115,7 @@ impl<'ast> RendererBase<'ast> {
     &self,
     importee: &NormalModule,
     importee_linking_info: &LinkingInfo,
-    with_namespace_init: bool,
+    with_declaration: bool,
   ) -> String {
     let wrap_symbol_name = self.canonical_name_for(importee_linking_info.wrap_symbol.unwrap());
     let to_esm_runtime_symbol_name = self.canonical_name_for_runtime(&"__toESM".into());
@@ -123,9 +123,10 @@ impl<'ast> RendererBase<'ast> {
       "{to_esm_runtime_symbol_name}({wrap_symbol_name}(){})",
       if self.module.module_type.is_esm() { ", 1" } else { "" }
     );
-    if with_namespace_init {
-      let namespace_name = self.canonical_name_for(importee.namespace_symbol);
-      format!("var {namespace_name} = {code};\n")
+    if with_declaration {
+      let symbol_ref = self.linking_info.local_symbol_for_import_cjs[&importee.id];
+      let final_name = self.canonical_name_for(symbol_ref);
+      format!("var {final_name} = {code};\n")
     } else {
       code
     }
@@ -133,6 +134,11 @@ impl<'ast> RendererBase<'ast> {
 
   pub fn get_importee_by_span(&self, span: Span) -> &Module {
     &self.graph.modules[self.module.get_import_module_by_span(span)]
+  }
+
+  pub fn hoisted_module_declaration(&mut self, decl_start: u32, content: String) {
+    let start = self.first_stmt_start.unwrap_or(decl_start);
+    self.source.append_left(start, content);
   }
 
   pub fn visit_binding_identifier(&mut self, ident: &'ast oxc::ast::ast::BindingIdentifier) {
@@ -161,18 +167,17 @@ impl<'ast> RendererBase<'ast> {
     let symbol = self.graph.symbols.get(symbol_ref);
     if let Some(ns_alias) = &symbol.namespace_alias {
       // If import symbol from commonjs, the reference of the symbol is not resolved,
-      // Here need write it to property access. eg `import { a } from 'cjs'; console.log(a)` => `console.log(cjs_ns.a)`
-      // Note: we should rewrite call expression to indirect call, eg `import { a } from 'cjs'; console.log(a())` => `console.log((0, cjs_ns.a)())`
+      // Here need write it to property access. eg `import { a } from 'cjs'; console.log(a)` => `console.log(import_a.a)`
+      // Note: we should rewrite call expression to indirect call, eg `import { a } from 'cjs'; console.log(a())` => `console.log((0, import_a.a)())`
       let canonical_ns_name = self.canonical_name_for(ns_alias.namespace_ref);
-      let property_name = &ns_alias.property_name;
+      let content = ns_alias.property_name.as_ref().map_or_else(
+        || format!("{canonical_ns_name}",),
+        |property_name| format!("{canonical_ns_name}.{property_name}",),
+      );
       self.source.update(
         ident.span.start,
         ident.span.end,
-        if is_call {
-          format!("(0, {canonical_ns_name}.{property_name})",)
-        } else {
-          format!("{canonical_ns_name}.{property_name}",)
-        },
+        if is_call { format!("(0, {content})",) } else { content },
       );
     } else if let Some(name) = self.need_to_rename(symbol_ref) {
       if ident.name != name {
@@ -188,11 +193,10 @@ impl<'ast> RendererBase<'ast> {
     if let Module::Normal(importee) = self.get_importee_by_span(decl.span) {
       if importee.exports_kind == ExportsKind::CommonJs {
         // __reExport(a_exports, __toESM(require_c()));
-        let namespace_name = &self.canonical_names[&importee.namespace_symbol];
+        let namespace_name = &self.canonical_names[&self.module.namespace_symbol];
         let re_export_runtime_symbol_name = self.canonical_name_for_runtime(&"__reExport".into());
-        self.source.update(
+        self.hoisted_module_declaration(
           decl.span.start,
-          decl.span.end,
           format!(
             "{re_export_runtime_symbol_name}({namespace_name}, {});",
             self.generate_import_commonjs_module(
@@ -202,7 +206,6 @@ impl<'ast> RendererBase<'ast> {
             )
           ),
         );
-        return;
       }
     }
     self.remove_node(decl.span);
@@ -231,11 +234,10 @@ impl<'ast> RendererBase<'ast> {
     let module_id = self.module.get_import_module_by_span(decl.span);
     let importee = &self.graph.modules[module_id];
     let importee_linking_info = &self.graph.linking_infos[module_id];
-    let start = self.first_stmt_start.unwrap_or(decl.span.start);
     if let Module::Normal(importee) = importee {
       if importee.exports_kind == ExportsKind::CommonJs {
-        self.source.append_right(
-          start,
+        self.hoisted_module_declaration(
+          decl.span.start,
           self.generate_import_commonjs_module(
             importee,
             &self.graph.linking_infos[importee.id],
@@ -245,7 +247,7 @@ impl<'ast> RendererBase<'ast> {
       } else if let Some(wrap_symbol) = importee_linking_info.wrap_symbol {
         let wrap_symbol_name = self.canonical_name_for(wrap_symbol);
         // init wrapped esm module
-        self.source.append_right(start, format!("{wrap_symbol_name}();\n"));
+        self.hoisted_module_declaration(decl.span.start, format!("{wrap_symbol_name}();\n"));
       }
     }
   }
@@ -277,9 +279,20 @@ impl<'ast> RendererBase<'ast> {
   }
 
   pub fn visit_statement(&mut self, stmt: &'ast oxc::ast::ast::Statement<'ast>) {
-    if !matches!(stmt, oxc::ast::ast::Statement::Declaration(_)) && self.first_stmt_start.is_none()
-    {
-      self.first_stmt_start = Some(stmt.span().start);
+    if self.first_stmt_start.is_none() {
+      let hoisted_decl = if let oxc::ast::ast::Statement::ModuleDeclaration(decl) = stmt {
+        match &decl.0 {
+          oxc::ast::ast::ModuleDeclaration::ImportDeclaration(_)
+          | oxc::ast::ast::ModuleDeclaration::ExportAllDeclaration(_) => true,
+          oxc::ast::ast::ModuleDeclaration::ExportNamedDeclaration(decl) => decl.source.is_some(),
+          _ => false,
+        }
+      } else {
+        false
+      };
+      if !hoisted_decl {
+        self.first_stmt_start = Some(stmt.span().start);
+      }
     }
   }
 }

--- a/crates/rolldown/src/bundler/visitors/wrapped_esm_renderer.rs
+++ b/crates/rolldown/src/bundler/visitors/wrapped_esm_renderer.rs
@@ -113,16 +113,14 @@ impl<'ast> Visit<'ast> for WrappedEsmRenderer<'ast> {
       match self.base.get_importee_by_span(named_decl.span) {
         Module::Normal(importee) => {
           if importee.exports_kind == ExportsKind::CommonJs {
-            self.base.overwrite(
+            self.base.hoisted_module_declaration(
               named_decl.span.start,
-              named_decl.span.end,
               self.base.generate_import_commonjs_module(
                 importee,
                 &self.base.graph.linking_infos[importee.id],
                 true,
               ),
             );
-            return;
           }
         }
         Module::External(_) => {} // TODO

--- a/crates/rolldown/tests/esbuild/default/es6_from_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/es6_from_common_js/artifacts.snap
@@ -9,9 +9,6 @@ input_file: crates/rolldown/tests/esbuild/default/es6_from_common_js
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // bar.js
-var bar_ns = {
-
-};
 var require_bar = __commonJS({
 'bar.js'(exports, module) {
 exports.bar = function() {
@@ -20,9 +17,6 @@ exports.bar = function() {
 }
 });
 // foo.js
-var foo_ns = {
-
-};
 var require_foo = __commonJS({
 'foo.js'(exports, module) {
 exports.foo = function() {
@@ -31,9 +25,9 @@ exports.foo = function() {
 }
 });
 // entry.js
-var foo_ns = __toESM(require_foo());
-var bar_ns = __toESM(require_bar());
+var import_foo = __toESM(require_foo());
 
-console.log((0, foo_ns.foo)(), (0, bar_ns.bar)())
+var import_bar = __toESM(require_bar());
+console.log((0, import_foo.foo)(), (0, import_bar.bar)())
  // This should be hoisted
 ```

--- a/crates/rolldown/tests/esbuild/default/nested_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/nested_common_js/artifacts.snap
@@ -9,9 +9,6 @@ input_file: crates/rolldown/tests/esbuild/default/nested_common_js
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // foo.js
-var foo_ns = {
-
-};
 var require_foo = __commonJS({
 'foo.js'(exports, module) {
 module.exports = function() {

--- a/crates/rolldown/tests/esbuild/default/nested_es6_from_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/nested_es6_from_common_js/artifacts.snap
@@ -9,9 +9,6 @@ input_file: crates/rolldown/tests/esbuild/default/nested_es6_from_common_js
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // foo.js
-var foo_ns = {
-
-};
 var require_foo = __commonJS({
 'foo.js'(exports, module) {
 exports.fn = function() {
@@ -20,9 +17,9 @@ exports.fn = function() {
 }
 });
 // entry.js
-var foo_ns = __toESM(require_foo());
+var import_foo = __toESM(require_foo());
 
 (() => {
-	console.log((0, foo_ns.fn)())
+	console.log((0, import_foo.fn)())
 })()
 ```

--- a/crates/rolldown/tests/esbuild/default/new_expression_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/new_expression_common_js/artifacts.snap
@@ -9,9 +9,6 @@ input_file: crates/rolldown/tests/esbuild/default/new_expression_common_js
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // foo.js
-var foo_ns = {
-
-};
 var require_foo = __commonJS({
 'foo.js'(exports, module) {
 class Foo {}

--- a/crates/rolldown/tests/esbuild/default/re_export_common_js_as_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/re_export_common_js_as_es6/artifacts.snap
@@ -9,17 +9,14 @@ input_file: crates/rolldown/tests/esbuild/default/re_export_common_js_as_es6
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // foo.js
-var foo_ns = {
-
-};
 var require_foo = __commonJS({
 'foo.js'(exports, module) {
 exports.bar = 123
 }
 });
 // entry.js
-var foo_ns = __toESM(require_foo());
+var import_foo = __toESM(require_foo());
 
-var bar = foo_ns.bar;
+var bar = import_foo.bar;
 export { bar };
 ```

--- a/crates/rolldown/tests/esbuild/default/require_child_dir_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_child_dir_common_js/artifacts.snap
@@ -9,9 +9,6 @@ input_file: crates/rolldown/tests/esbuild/default/require_child_dir_common_js
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // dir/index.js
-var dir_index_ns = {
-
-};
 var require_dir_index = __commonJS({
 'dir/index.js'(exports, module) {
 module.exports = 123

--- a/crates/rolldown/tests/esbuild/default/require_main_cache_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_main_cache_common_js/artifacts.snap
@@ -9,9 +9,6 @@ input_file: crates/rolldown/tests/esbuild/default/require_main_cache_common_js
 import { __commonJS } from "./_rolldown_runtime.mjs";
 
 // is-main.js
-var is_main_ns = {
-
-};
 var require_is_main = __commonJS({
 'is-main.js'(exports, module) {
 module.exports = require.main === module

--- a/crates/rolldown/tests/esbuild/default/require_parent_dir_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_parent_dir_common_js/artifacts.snap
@@ -9,9 +9,6 @@ input_file: crates/rolldown/tests/esbuild/default/require_parent_dir_common_js
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // index.js
-var require_parent_dir_common_js_index_ns = {
-
-};
 var require_require_parent_dir_common_js_index = __commonJS({
 'index.js'(exports, module) {
 module.exports = 123

--- a/crates/rolldown/tests/esbuild/default/simple_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/simple_common_js/artifacts.snap
@@ -9,9 +9,6 @@ input_file: crates/rolldown/tests/esbuild/default/simple_common_js
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // foo.js
-var foo_ns = {
-
-};
 var require_foo = __commonJS({
 'foo.js'(exports, module) {
 module.exports = function() {

--- a/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_issue1837/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_issue1837/artifacts.snap
@@ -9,9 +9,6 @@ input_file: crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_is
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // cjs.js
-var cjs_ns = {
-
-};
 var require_cjs = __commonJS({
 'cjs.js'(exports, module) {
 'use strict'

--- a/crates/rolldown/tests/esbuild/import_star/import_star_common_js_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_common_js_capture/artifacts.snap
@@ -9,17 +9,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_star_common_js_capt
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // foo.js
-var foo_ns = {
-
-};
 var require_foo = __commonJS({
 'foo.js'(exports, module) {
 exports.foo = 123
 }
 });
 // entry.js
-var foo_ns = __toESM(require_foo());
+var import_foo = __toESM(require_foo());
 
 let foo = 234
-console.log(foo_ns, foo_ns.foo, foo)
+console.log(import_foo, import_foo.foo, foo)
 ```

--- a/crates/rolldown/tests/esbuild/import_star/import_star_common_js_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_common_js_no_capture/artifacts.snap
@@ -9,17 +9,14 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_star_common_js_no_c
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // foo.js
-var foo_ns = {
-
-};
 var require_foo = __commonJS({
 'foo.js'(exports, module) {
 exports.foo = 123
 }
 });
 // entry.js
-var foo_ns = __toESM(require_foo());
+var import_foo = __toESM(require_foo());
 
 let foo = 234
-console.log(foo_ns.foo, foo_ns.foo, foo)
+console.log(import_foo.foo, import_foo.foo, foo)
 ```

--- a/crates/rolldown/tests/esbuild/import_star/import_star_common_js_unused/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_star_common_js_unused/artifacts.snap
@@ -9,16 +9,13 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_star_common_js_unus
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // foo.js
-var foo_ns = {
-
-};
 var require_foo = __commonJS({
 'foo.js'(exports, module) {
 exports.foo = 123
 }
 });
 // entry.js
-var foo_ns = __toESM(require_foo());
+var import_foo = __toESM(require_foo());
 
 let foo = 234
 console.log(foo)

--- a/crates/rolldown/tests/esbuild/import_star/namespace_import_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/namespace_import_missing_common_js/artifacts.snap
@@ -9,16 +9,13 @@ input_file: crates/rolldown/tests/esbuild/import_star/namespace_import_missing_c
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // foo.js
-var foo_ns = {
-
-};
 var require_foo = __commonJS({
 'foo.js'(exports, module) {
 exports.x = 123
 }
 });
 // entry.js
-var foo_ns = __toESM(require_foo());
+var import_foo = __toESM(require_foo());
 
-console.log(foo_ns, foo_ns.foo)
+console.log(import_foo, import_foo.foo)
 ```

--- a/crates/rolldown/tests/esbuild/import_star/namespace_import_unused_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/namespace_import_unused_missing_common_js/artifacts.snap
@@ -9,16 +9,13 @@ input_file: crates/rolldown/tests/esbuild/import_star/namespace_import_unused_mi
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // foo.js
-var foo_ns = {
-
-};
 var require_foo = __commonJS({
 'foo.js'(exports, module) {
 exports.x = 123
 }
 });
 // entry.js
-var foo_ns = __toESM(require_foo());
+var import_foo = __toESM(require_foo());
 
-console.log(foo_ns.foo)
+console.log(import_foo.foo)
 ```

--- a/crates/rolldown/tests/esbuild/splitting/shared-commonjs-into-es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/shared-commonjs-into-es6/artifacts.snap
@@ -9,21 +9,18 @@ input_file: crates/rolldown/tests/esbuild/splitting/shared-commonjs-into-es6
 import { __commonJS } from "./_rolldown_runtime.mjs";
 
 // shared.js
-var shared_ns = {
-
-};
 var require_shared = __commonJS({
 'shared.js'(exports, module) {
 exports.foo = 123
 }
 });
-export { shared_ns, require_shared };
+export { require_shared };
 ```
 # a.mjs
 
 ```js
 import { __toESM } from "./_rolldown_runtime.mjs";
-import { require_shared, shared_ns } from "./2.mjs";
+import { require_shared } from "./2.mjs";
 
 // a.js
 const {foo} = require_shared()
@@ -33,7 +30,7 @@ console.log(foo)
 
 ```js
 import { __toESM } from "./_rolldown_runtime.mjs";
-import { require_shared, shared_ns } from "./2.mjs";
+import { require_shared } from "./2.mjs";
 
 // b.js
 const {foo} = require_shared()

--- a/crates/rolldown/tests/fixtures/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/basic_commonjs/artifacts.snap
@@ -28,9 +28,6 @@ esm_named_class = class esm_named_class {}
 }
 });
 // commonjs.js
-var commonjs_ns = {
-
-};
 var require_commonjs$1 = __commonJS({
 'commonjs.js'(exports, module) {
 var value = (init_esm(), __toCommonJS(esm_ns));
@@ -38,11 +35,11 @@ module.exports = value;
 }
 });
 // main.js
-var commonjs_ns = __toESM(require_commonjs$1());
+var import_commonjs = __toESM(require_commonjs$1());
+
 init_esm();
 
-
-console.log(commonjs_ns.default, esm_default_fn, esm_named_var, esm_named_fn, esm_named_class)
+console.log(import_commonjs.default, esm_default_fn, esm_named_var, esm_named_fn, esm_named_class)
 // test commonjs warp symbol deconflict
 const require_commonjs = () => {}
 // test esm export function symbol deconflict

--- a/crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/artifacts.snap
@@ -9,16 +9,13 @@ input_file: crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/e
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // commonjs.js
-var commonjs_ns = {
-
-};
 var require_commonjs = __commonJS({
 'commonjs.js'(exports, module) {
 exports.a = 1
 }
 });
 // main.js
-var commonjs_ns = __toESM(require_commonjs());
+var import_commonjs = __toESM(require_commonjs());
 
-console.log(commonjs_ns)
+console.log(import_commonjs)
 ```

--- a/crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import/artifacts.snap
@@ -9,16 +9,13 @@ input_file: crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/e
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // commonjs.js
-var commonjs_ns = {
-
-};
 var require_commonjs = __commonJS({
 'commonjs.js'(exports, module) {
 exports.a = 1
 }
 });
 // main.js
-var commonjs_ns = __toESM(require_commonjs());
+var import_commonjs = __toESM(require_commonjs());
 
-console.log(commonjs_ns.a, 1)
+console.log(import_commonjs.a, 1)
 ```

--- a/crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import/artifacts.snap
@@ -9,9 +9,6 @@ input_file: crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/e
 import { __commonJS, __reExport, __toESM } from "./_rolldown_runtime.mjs";
 
 // commonjs.js
-var commonjs_ns = {
-
-};
 var require_commonjs = __commonJS({
 'commonjs.js'(exports, module) {
 exports.a = 1
@@ -21,7 +18,7 @@ exports.a = 1
 var proxy_ns = {
 
 };
-__reExport(commonjs_ns, __toESM(require_commonjs()));
+__reExport(proxy_ns, __toESM(require_commonjs()));
 // main.js
 
 console.log(proxy_ns.a, 1)

--- a/crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import/artifacts.snap
@@ -9,18 +9,12 @@ input_file: crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/e
 import { __commonJS, __reExport, __toESM } from "./_rolldown_runtime.mjs";
 
 // commonjs2.js
-var commonjs2_ns = {
-
-};
 var require_commonjs2 = __commonJS({
 'commonjs2.js'(exports, module) {
 exports.a = 2
 }
 });
 // commonjs.js
-var commonjs_ns = {
-
-};
 var require_commonjs = __commonJS({
 'commonjs.js'(exports, module) {
 exports.a = 1
@@ -30,8 +24,8 @@ exports.a = 1
 var proxy_ns = {
 
 };
-__reExport(commonjs_ns, __toESM(require_commonjs()));
-__reExport(commonjs2_ns, __toESM(require_commonjs2()));
+__reExport(proxy_ns, __toESM(require_commonjs()));
+__reExport(proxy_ns, __toESM(require_commonjs2()));
 // main.js
 
 console.log(proxy_ns.a, 1)

--- a/crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport/artifacts.snap
@@ -9,17 +9,14 @@ input_file: crates/rolldown/tests/fixtures/import_reexport_between_esm_and_cjs/e
 import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // commonjs.js
-var commonjs_ns = {
-
-};
 var require_commonjs = __commonJS({
 'commonjs.js'(exports, module) {
 exports.a = 1
 }
 });
 // main.js
-var commonjs_ns = __toESM(require_commonjs());
+var import_commonjs = __toESM(require_commonjs());
 
-var a = commonjs_ns.a;
+var a = import_commonjs.a;
 export { a };
 ```

--- a/crates/rolldown/tests/fixtures/mix-cjs-esm/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/mix-cjs-esm/artifacts.snap
@@ -18,23 +18,17 @@ var init_foo = __esm({
 }
 });
 // cjs.js
-var cjs_ns = {
-
-};
 var require_cjs = __commonJS({
 'cjs.js'(exports, module) {
 module.exports = 1;
 }
 });
 // esm_import_cjs_require.js
-var cjs_ns = __toESM(require_cjs());
+var import_cjs = __toESM(require_cjs());
 
 (init_foo(), __toCommonJS(foo_ns))
-console.log(cjs_ns.a)
+console.log(import_cjs.a)
 // esm_import_cjs_export.js
-var esm_import_cjs_export_ns = {
-
-};
 var require_esm_import_cjs_export = __commonJS({
 'esm_import_cjs_export.js'(exports, module) {
 init_foo();
@@ -49,5 +43,7 @@ const value$1 = 1;
 module.exports = 1;
 const value = 1;
 // main.js
-var esm_import_cjs_export_ns = __toESM(require_esm_import_cjs_export());
+
+
+var import_esm_import_cjs_export = __toESM(require_esm_import_cjs_export());
 ```

--- a/crates/rolldown/tests/fixtures/reexport_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/reexport_commonjs/artifacts.snap
@@ -9,9 +9,6 @@ input_file: crates/rolldown/tests/fixtures/reexport_commonjs
 import { __commonJS, __reExport, __toESM } from "./_rolldown_runtime.mjs";
 
 // commonjs.js
-var commonjs_ns = {
-
-};
 var require_commonjs = __commonJS({
 'commonjs.js'(exports, module) {
 module.exports = { bar: 1 };
@@ -21,19 +18,19 @@ module.exports = { bar: 1 };
 const value = 1
 // foo.js
 var foo_ns = {
-  get bar() { return commonjs_ns.bar },
+  get bar() { return import_commonjs$1.bar },
   get value() { return value }
 };
-__reExport(commonjs_ns, __toESM(require_commonjs()));
-var commonjs_ns = __toESM(require_commonjs());
+__reExport(foo_ns, __toESM(require_commonjs()));
+var import_commonjs$1 = __toESM(require_commonjs());
 
 
 // main.js
 
 
-console.log(foo_ns, foo_ns.bar, value, foo_ns.foo)
-var commonjs_ns = __toESM(require_commonjs());
+var import_commonjs = __toESM(require_commonjs());
+console.log(foo_ns, import_commonjs.bar, value, foo_ns.foo)
 
-var bar$1 = commonjs_ns.bar;
+var bar$1 = import_commonjs.bar;
 export { bar$1 as bar };
 ```


### PR DESCRIPTION
… namespace symbol

<!-- Thank you for contributing! -->

### Description
close https://github.com/rolldown-rs/rolldown/issues/127.
The pr fixed some bugs.
- fix: generate local symbol for esm import cjs instead of reference cjs namespace symbol
- fix: reExport stmt should reference self namespace symbol
- fix: hoisted module declaration for export all declaration and export name declaration which has source imported
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan
Updated.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
