### PR TITLE
refactor: use `ModuleTaskContext` to shared common data between all tasks

### DIFF
--- a/crates/rolldown/src/bundler/module_loader/mod.rs
+++ b/crates/rolldown/src/bundler/module_loader/mod.rs
@@ -1,5 +1,6 @@
 #[allow(clippy::module_inception)]
 mod module_loader;
+mod module_task_context;
 mod normal_module_task;
 mod runtime_normal_module_task;
 mod task_result;

--- a/crates/rolldown/src/bundler/module_loader/module_task_context.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_task_context.rs
@@ -1,0 +1,19 @@
+use rolldown_fs::FileSystemExt;
+
+use crate::{bundler::options::normalized_input_options::NormalizedInputOptions, SharedResolver};
+
+use super::Msg;
+
+/// Used to store common data shared between all tasks.
+pub struct ModuleTaskContext<'task> {
+  pub input_options: &'task NormalizedInputOptions,
+  pub tx: &'task tokio::sync::mpsc::UnboundedSender<Msg>,
+  pub resolver: &'task SharedResolver,
+  pub fs: &'task dyn FileSystemExt,
+}
+
+impl<'task> ModuleTaskContext<'task> {
+  pub unsafe fn assume_static(&self) -> &'static ModuleTaskContext<'static> {
+    std::mem::transmute(self)
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This pr also reduces a lot of `Arc::clone`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
