### PR TITLE
chore: rename `FileSystemExt` to `FileSystem`

### DIFF
--- a/crates/rolldown/src/bundler/bundler.rs
+++ b/crates/rolldown/src/bundler/bundler.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rolldown_error::BuildError;
-use rolldown_fs::FileSystemExt;
+use rolldown_fs::FileSystem;
 use rolldown_resolver::Resolver;
 use sugar_path::AsPath;
 
@@ -18,13 +18,13 @@ use crate::{
 
 type BuildResult<T> = Result<T, Vec<BuildError>>;
 
-pub struct Bundler<T: FileSystemExt> {
+pub struct Bundler<T: FileSystem> {
   input_options: InputOptions,
   plugin_driver: SharedPluginDriver,
   fs: Arc<T>,
 }
 
-impl<T: FileSystemExt + Default + 'static> Bundler<T> {
+impl<T: FileSystem + Default + 'static> Bundler<T> {
   pub fn new(input_options: InputOptions, fs: T) -> Self {
     // rolldown_tracing::enable_tracing_on_demand();
     Self::with_plugins(input_options, vec![], fs)

--- a/crates/rolldown/src/bundler/module_loader/module_loader.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_loader.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use index_vec::IndexVec;
 use rolldown_common::{ImportKind, ModuleId, RawPath, ResourceId};
-use rolldown_fs::FileSystemExt;
+use rolldown_fs::FileSystem;
 use rolldown_resolver::Resolver;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -22,7 +22,7 @@ use crate::bundler::utils::resolve_id::ResolvedRequestInfo;
 use crate::error::BatchedResult;
 use crate::SharedResolver;
 
-pub struct ModuleLoader<'a, T: FileSystemExt + Default> {
+pub struct ModuleLoader<'a, T: FileSystem + Default> {
   ctx: ModuleLoaderContext,
   input_options: &'a InputOptions,
   resolver: SharedResolver<T>,
@@ -42,7 +42,7 @@ pub struct ModuleLoaderContext {
 }
 
 impl ModuleLoaderContext {
-  fn try_spawn_runtime_normal_module_task<T: FileSystemExt + Default + 'static>(
+  fn try_spawn_runtime_normal_module_task<T: FileSystem + Default + 'static>(
     &mut self,
     task_context: &ModuleTaskContext<T>,
   ) -> ModuleId {
@@ -63,7 +63,7 @@ impl ModuleLoaderContext {
     }
   }
 
-  fn try_spawn_new_task<T: FileSystemExt + Default + 'static>(
+  fn try_spawn_new_task<T: FileSystem + Default + 'static>(
     &mut self,
     module_task_context: &ModuleTaskContext<T>,
     info: &ResolvedRequestInfo,
@@ -104,7 +104,7 @@ impl ModuleLoaderContext {
   }
 }
 
-impl<'a, T: FileSystemExt + 'static + Default> ModuleLoader<'a, T> {
+impl<'a, T: FileSystem + 'static + Default> ModuleLoader<'a, T> {
   pub fn new(
     input_options: &'a InputOptions,
     plugin_driver: SharedPluginDriver,

--- a/crates/rolldown/src/bundler/module_loader/module_task_context.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_task_context.rs
@@ -1,4 +1,4 @@
-use rolldown_fs::FileSystemExt;
+use rolldown_fs::FileSystem;
 
 use crate::{
   bundler::{options::input_options::InputOptions, plugin_driver::SharedPluginDriver},
@@ -8,15 +8,15 @@ use crate::{
 use super::Msg;
 
 /// Used to store common data shared between all tasks.
-pub struct ModuleTaskContext<'task, T: FileSystemExt + Default> {
+pub struct ModuleTaskContext<'task, T: FileSystem + Default> {
   pub input_options: &'task InputOptions,
   pub tx: &'task tokio::sync::mpsc::UnboundedSender<Msg>,
   pub resolver: &'task SharedResolver<T>,
-  pub fs: &'task dyn FileSystemExt,
+  pub fs: &'task dyn FileSystem,
   pub plugin_driver: &'task SharedPluginDriver,
 }
 
-impl<'task, T: FileSystemExt + Default> ModuleTaskContext<'task, T> {
+impl<'task, T: FileSystem + Default> ModuleTaskContext<'task, T> {
   pub unsafe fn assume_static(&self) -> &'static ModuleTaskContext<'static, T> {
     std::mem::transmute(self)
   }

--- a/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
@@ -5,7 +5,7 @@ use index_vec::IndexVec;
 use oxc::{ast::Visit, span::SourceType};
 use rolldown_common::{ImportRecord, ImportRecordId, ModuleId, ModuleType, ResourceId, SymbolRef};
 use rolldown_error::BuildError;
-use rolldown_fs::FileSystemExt;
+use rolldown_fs::FileSystem;
 use rolldown_oxc::{OxcCompiler, OxcProgram};
 use rolldown_resolver::Resolver;
 use sugar_path::AsPath;
@@ -26,7 +26,7 @@ use crate::{
   error::BatchedResult,
   HookLoadArgs, HookResolveIdArgsOptions, HookTransformArgs,
 };
-pub struct NormalModuleTask<'task, T: FileSystemExt + Default> {
+pub struct NormalModuleTask<'task, T: FileSystem + Default> {
   ctx: &'task ModuleTaskContext<'task, T>,
   module_id: ModuleId,
   path: ResourceId,
@@ -36,7 +36,7 @@ pub struct NormalModuleTask<'task, T: FileSystemExt + Default> {
   is_entry: bool,
 }
 
-impl<'task, T: FileSystemExt + Default + 'static> NormalModuleTask<'task, T> {
+impl<'task, T: FileSystem + Default + 'static> NormalModuleTask<'task, T> {
   pub fn new(
     ctx: &'task ModuleTaskContext<'task, T>,
     id: ModuleId,
@@ -170,7 +170,7 @@ impl<'task, T: FileSystemExt + Default + 'static> NormalModuleTask<'task, T> {
   }
 
   #[allow(clippy::option_if_let_else)]
-  pub(crate) async fn resolve_id<F: FileSystemExt + Default>(
+  pub(crate) async fn resolve_id<F: FileSystem + Default>(
     resolver: &Resolver<F>,
     plugin_driver: &SharedPluginDriver,
     importer: &ResourceId,

--- a/crates/rolldown/src/bundler/module_loader/runtime_normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/runtime_normal_module_task.rs
@@ -1,7 +1,7 @@
 use oxc::{ast::Visit, span::SourceType};
 use rolldown_common::{ModuleId, ModuleType, ResourceId, SymbolRef};
 use rolldown_error::BuildError;
-use rolldown_fs::FileSystemExt;
+use rolldown_fs::FileSystem;
 use rolldown_oxc::{OxcCompiler, OxcProgram};
 
 use super::{module_task_context::ModuleTaskContext, Msg};
@@ -12,7 +12,7 @@ use crate::bundler::{
   utils::{ast_scope::AstScope, ast_symbol::AstSymbol},
   visitors::scanner::{self, ScanResult},
 };
-pub struct RuntimeNormalModuleTask<'task, T: FileSystemExt + Default> {
+pub struct RuntimeNormalModuleTask<'task, T: FileSystem + Default> {
   ctx: &'task ModuleTaskContext<'task, T>,
   module_id: ModuleId,
   module_type: ModuleType,
@@ -20,7 +20,7 @@ pub struct RuntimeNormalModuleTask<'task, T: FileSystemExt + Default> {
   warnings: Vec<BuildError>,
 }
 
-impl<'task, T: FileSystemExt + Default> RuntimeNormalModuleTask<'task, T> {
+impl<'task, T: FileSystem + Default> RuntimeNormalModuleTask<'task, T> {
   pub fn new(ctx: &'task ModuleTaskContext<'task, T>, id: ModuleId) -> Self {
     Self {
       ctx,

--- a/crates/rolldown/src/bundler/utils/resolve_id.rs
+++ b/crates/rolldown/src/bundler/utils/resolve_id.rs
@@ -1,6 +1,6 @@
 use rolldown_common::{ModuleType, RawPath, ResourceId};
 use rolldown_error::BuildError;
-use rolldown_fs::FileSystemExt;
+use rolldown_fs::FileSystem;
 use rolldown_resolver::Resolver;
 
 use crate::{
@@ -15,7 +15,7 @@ pub struct ResolvedRequestInfo {
 }
 
 #[allow(clippy::unused_async)]
-pub async fn resolve_id<T: FileSystemExt + Default>(
+pub async fn resolve_id<T: FileSystem + Default>(
   resolver: &Resolver<T>,
   plugin_driver: &SharedPluginDriver,
   request: &str,

--- a/crates/rolldown_fs/src/lib.rs
+++ b/crates/rolldown_fs/src/lib.rs
@@ -1,14 +1,14 @@
 mod os;
 mod vfs;
 pub use os::*;
-use oxc_resolver::FileSystem;
+use oxc_resolver::FileSystem as OxcResolverFileSystem;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::{io, path::Path};
 pub use vfs::*;
 
 /// File System abstraction used for `ResolverGeneric`.
-pub trait FileSystemExt: Send + Sync + FileSystem {
+pub trait FileSystem: Send + Sync + OxcResolverFileSystem {
   /// # Errors
   ///
   /// * See [std::fs::remove_dir_all]
@@ -30,9 +30,9 @@ pub trait FileSystemExt: Send + Sync + FileSystem {
   fn exists(&self, path: &Path) -> bool;
 }
 
-impl<T> FileSystemExt for Arc<T>
+impl<T> FileSystem for Arc<T>
 where
-  T: FileSystemExt + FileSystem,
+  T: FileSystem + OxcResolverFileSystem,
 {
   fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
     self.deref().remove_dir_all(path)

--- a/crates/rolldown_fs/src/os.rs
+++ b/crates/rolldown_fs/src/os.rs
@@ -1,6 +1,6 @@
-use oxc_resolver::{FileMetadata, FileSystem};
+use oxc_resolver::{FileMetadata, FileSystem as OxcResolverFileSystem};
 
-use crate::FileSystemExt;
+use crate::FileSystem;
 use std::{
   io,
   path::{Path, PathBuf},
@@ -10,7 +10,7 @@ use std::{
 #[derive(Default)]
 pub struct FileSystemOs;
 
-impl FileSystemExt for FileSystemOs {
+impl FileSystem for FileSystemOs {
   fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
     std::fs::remove_dir_all(path)
   }
@@ -28,7 +28,7 @@ impl FileSystemExt for FileSystemOs {
   }
 }
 
-impl FileSystem for FileSystemOs {
+impl OxcResolverFileSystem for FileSystemOs {
   fn read_to_string(&self, path: &Path) -> io::Result<String> {
     std::fs::read_to_string(path)
   }

--- a/crates/rolldown_fs/src/vfs.rs
+++ b/crates/rolldown_fs/src/vfs.rs
@@ -3,10 +3,10 @@ use std::{
   path::{Path, PathBuf},
 };
 
-use oxc_resolver::{FileMetadata, FileSystem};
+use oxc_resolver::{FileMetadata, FileSystem as OxcResolverFileSystem};
 use vfs::{FileSystem as _, MemoryFS};
 
-use crate::FileSystemExt;
+use crate::FileSystem;
 
 pub struct FileSystemVfs {
   // root path
@@ -48,7 +48,7 @@ impl FileSystemVfs {
   }
 }
 
-impl FileSystemExt for FileSystemVfs {
+impl FileSystem for FileSystemVfs {
   fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
     self
       .fs
@@ -80,7 +80,7 @@ impl FileSystemExt for FileSystemVfs {
   }
 }
 
-impl FileSystem for FileSystemVfs {
+impl OxcResolverFileSystem for FileSystemVfs {
   fn read_to_string(&self, path: &Path) -> io::Result<String> {
     let mut buf = String::new();
     self

--- a/crates/rolldown_resolver/src/lib.rs
+++ b/crates/rolldown_resolver/src/lib.rs
@@ -1,18 +1,18 @@
 use rolldown_common::{ModuleType, RawPath, ResourceId};
 use rolldown_error::BuildError;
-use rolldown_fs::FileSystemExt;
+use rolldown_fs::FileSystem;
 use std::{path::PathBuf, sync::Arc};
 use sugar_path::{AsPath, SugarPathBuf};
 
 use oxc_resolver::{Resolution, ResolveOptions, ResolverGeneric};
 
 #[derive(Debug)]
-pub struct Resolver<T: FileSystemExt + Default> {
+pub struct Resolver<T: FileSystem + Default> {
   cwd: PathBuf,
   inner: ResolverGeneric<Arc<T>>,
 }
 
-impl<F: FileSystemExt + Default> Resolver<F> {
+impl<F: FileSystem + Default> Resolver<F> {
   pub fn with_cwd_and_fs(cwd: PathBuf, preserve_symlinks: bool, fs: Arc<F>) -> Self {
     let resolve_options = ResolveOptions {
       symlinks: !preserve_symlinks,
@@ -41,7 +41,7 @@ pub struct ResolveRet {
   pub module_type: ModuleType,
 }
 
-impl<F: FileSystemExt + Default> Resolver<F> {
+impl<F: FileSystem + Default> Resolver<F> {
   // clippy::option_if_let_else: I think the current code is more readable.
   #[allow(clippy::missing_errors_doc, clippy::option_if_let_else)]
   pub fn resolve(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://rust-lang.github.io/rfcs/0445-extension-trait-conventions.html

`FileSystem` is a more suitable name thant `FileSystemExt`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
