### PR TITLE
chore: new with `FileSystemOs` by default

### DIFF
--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -1,16 +1,12 @@
 use std::path::PathBuf;
 
 use rolldown::{Bundler, InputItem, InputOptions, OutputOptions};
-use rolldown_fs::FileSystemOs;
 
 pub async fn run_fixture(fixture_path: PathBuf) {
-  let mut bundler = Bundler::new(
-    InputOptions {
-      input: vec![InputItem { name: Some("main".to_string()), import: "./main.js".to_string() }],
-      cwd: fixture_path.clone(),
-    },
-    FileSystemOs,
-  );
+  let mut bundler = Bundler::new(InputOptions {
+    input: vec![InputItem { name: Some("main".to_string()), import: "./main.js".to_string() }],
+    cwd: fixture_path.clone(),
+  });
 
   if fixture_path.join("dist").is_dir() {
     std::fs::remove_dir_all(fixture_path.join("dist")).unwrap();

--- a/crates/rolldown/examples/basic.rs
+++ b/crates/rolldown/examples/basic.rs
@@ -1,20 +1,16 @@
 use std::path::PathBuf;
 
 use rolldown::{Bundler, InputItem, InputOptions};
-use rolldown_fs::FileSystemOs;
 use sugar_path::SugarPathBuf;
 
 #[tokio::main]
 async fn main() {
   let root = PathBuf::from(&std::env::var("CARGO_MANIFEST_DIR").unwrap());
   let cwd = root.join("./examples").into_normalize();
-  let mut bundler = Bundler::new(
-    InputOptions {
-      input: vec![InputItem { name: Some("basic".to_string()), import: "./index.js".to_string() }],
-      cwd,
-    },
-    FileSystemOs,
-  );
+  let mut bundler = Bundler::new(InputOptions {
+    input: vec![InputItem { name: Some("basic".to_string()), import: "./index.js".to_string() }],
+    cwd,
+  });
 
   let outputs = bundler.write(Default::default()).await.unwrap();
   println!("{outputs:#?}");

--- a/crates/rolldown/src/bundler/bundler.rs
+++ b/crates/rolldown/src/bundler/bundler.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rolldown_error::BuildError;
-use rolldown_fs::FileSystem;
+use rolldown_fs::{FileSystem, FileSystemOs};
 use rolldown_resolver::Resolver;
 use sugar_path::AsPath;
 
@@ -24,13 +24,18 @@ pub struct Bundler<T: FileSystem> {
   fs: Arc<T>,
 }
 
-impl<T: FileSystem + Default + 'static> Bundler<T> {
-  pub fn new(input_options: InputOptions, fs: T) -> Self {
-    // rolldown_tracing::enable_tracing_on_demand();
-    Self::with_plugins(input_options, vec![], fs)
+impl Bundler<FileSystemOs> {
+  pub fn new(input_options: InputOptions) -> Self {
+    Self::with_plugins(input_options, vec![])
   }
 
-  pub fn with_plugins(input_options: InputOptions, plugins: Vec<BoxPlugin>, fs: T) -> Self {
+  pub fn with_plugins(input_options: InputOptions, plugins: Vec<BoxPlugin>) -> Self {
+    Self::with_plugins_and_fs(input_options, plugins, FileSystemOs)
+  }
+}
+
+impl<T: FileSystem + Default + 'static> Bundler<T> {
+  pub fn with_plugins_and_fs(input_options: InputOptions, plugins: Vec<BoxPlugin>, fs: T) -> Self {
     // rolldown_tracing::enable_tracing_on_demand();
     let fs = Arc::new(fs);
     Self { input_options, plugin_driver: Arc::new(PluginDriver::new(plugins)), fs }

--- a/crates/rolldown/tests/common/fixture.rs
+++ b/crates/rolldown/tests/common/fixture.rs
@@ -6,7 +6,6 @@ use std::{
 
 use rolldown::{Bundler, FileNameTemplate, InputOptions, Output, OutputOptions};
 use rolldown_error::BuildError;
-use rolldown_fs::FileSystemOs;
 use rolldown_testing::TestConfig;
 
 fn default_test_input_item() -> rolldown_testing::InputItem {
@@ -90,22 +89,19 @@ impl Fixture {
       test_config.input.input = Some(vec![default_test_input_item()]);
     }
 
-    let mut bundler = Bundler::new(
-      InputOptions {
-        input: test_config
-          .input
-          .input
-          .map(|items| {
-            items
-              .into_iter()
-              .map(|item| rolldown::InputItem { name: Some(item.name), import: item.import })
-              .collect()
-          })
-          .unwrap(),
-        cwd: fixture_path.to_path_buf(),
-      },
-      FileSystemOs,
-    );
+    let mut bundler = Bundler::new(InputOptions {
+      input: test_config
+        .input
+        .input
+        .map(|items| {
+          items
+            .into_iter()
+            .map(|item| rolldown::InputItem { name: Some(item.name), import: item.import })
+            .collect()
+        })
+        .unwrap(),
+      cwd: fixture_path.to_path_buf(),
+    });
 
     if fixture_path.join("dist").is_dir() {
       std::fs::remove_dir_all(fixture_path.join("dist")).unwrap();

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -38,13 +38,7 @@ impl Bundler {
     NAPI_ENV.set(&env, || {
       let (opts, plugins) = input_opts.into();
 
-      Ok(Self {
-        inner: Mutex::new(NativeBundler::<FileSystemOs>::with_plugins(
-          opts,
-          plugins?,
-          FileSystemOs,
-        )),
-      })
+      Ok(Self { inner: Mutex::new(NativeBundler::<FileSystemOs>::with_plugins(opts, plugins?)) })
     })
   }
 

--- a/crates/rolldown_binding_wasm/src/lib.rs
+++ b/crates/rolldown_binding_wasm/src/lib.rs
@@ -46,7 +46,7 @@ pub fn bundle(file_list: Vec<FileItem>) -> Vec<AssetItem> {
       let memory_fs = FileSystemVfs::new(
         &file_list.iter().map(|item| (&item.path, &item.content)).collect::<Vec<_>>(),
       );
-      let mut bundler = Bundler::new(
+      let mut bundler = Bundler::with_plugins_and_fs(
         InputOptions {
           input: vec![InputItem {
             name: Some("basic".to_string()),
@@ -54,6 +54,7 @@ pub fn bundle(file_list: Vec<FileItem>) -> Vec<AssetItem> {
           }],
           cwd: "/".into(),
         },
+        vec![],
         memory_fs,
       );
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Using `FileSystemOs` is more common, which should more common name for constuctor methods

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
