### PR TITLE
chore(rolldown_core): rename `BuildStage` to `ScanStage`

### DIFF
--- a/crates/rolldown/src/bundler/graph/graph.rs
+++ b/crates/rolldown/src/bundler/graph/graph.rs
@@ -1,6 +1,6 @@
 use super::{linker::Linker, linker_info::LinkingInfoVec, symbols::Symbols};
 use crate::{
-  bundler::{module::ModuleVec, runtime::Runtime, stages::build_stage::BuildInfo},
+  bundler::{module::ModuleVec, runtime::Runtime, stages::scan_stage::ScanStageOutput},
   error::BatchedResult,
 };
 use rolldown_common::ModuleId;
@@ -18,8 +18,8 @@ pub struct Graph {
 }
 
 impl Graph {
-  pub fn new(build_info: BuildInfo) -> Self {
-    let BuildInfo { modules, entries, symbols, runtime } = build_info;
+  pub fn new(build_info: ScanStageOutput) -> Self {
+    let ScanStageOutput { modules, entries, symbols, runtime } = build_info;
     Self { modules, entries, symbols, runtime, ..Default::default() }
   }
 

--- a/crates/rolldown/src/bundler/stages/mod.rs
+++ b/crates/rolldown/src/bundler/stages/mod.rs
@@ -1,1 +1,1 @@
-pub mod build_stage;
+pub mod scan_stage;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

The word `build` is already used in rollup. If we reuse this word, this might cause conflict meanings. So we will have stages: scan -> link -> generate/bundle

Now: `build` in rolldown means: scan + link

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
