### PR TITLE
refactor(resolver): remove unnecessary `Arc`

### DIFF
--- a/crates/rolldown/src/bundler/stages/scan_stage.rs
+++ b/crates/rolldown/src/bundler/stages/scan_stage.rs
@@ -86,7 +86,7 @@ impl<'me, T: FileSystem + Default> ScanStage<'me, T> {
 
   pub async fn scan<Fs: FileSystem + Default + 'static>(
     &self,
-    fs: Arc<Fs>,
+    fs: Fs,
   ) -> BatchedResult<ScanStageOutput> {
     assert!(!self.input_options.input.is_empty(), "You must supply options.input to rolldown");
 

--- a/crates/rolldown_fs/src/file_system.rs
+++ b/crates/rolldown_fs/src/file_system.rs
@@ -1,9 +1,18 @@
-use std::{io, path::Path, sync::Arc};
+use std::{io, path::Path};
 
 use oxc_resolver::FileSystem as OxcResolverFileSystem;
 
 /// File System abstraction used for `ResolverGeneric`.
 pub trait FileSystem: Send + Sync + OxcResolverFileSystem {
+  /// Rolldown will access the file system from multiple places, so it's important to make sure
+  /// that the file system is unique. So we use `share` to create a new reference to the same
+  /// file system and this also why we don't use `Clone`. `Clone` generally means creating a new
+  /// instance, but we want to share the same instance.
+  #[must_use]
+  fn share(&self) -> Self
+  where
+    Self: Sized;
+
   /// # Errors
   ///
   /// * See [std::fs::remove_dir_all]
@@ -23,25 +32,4 @@ pub trait FileSystem: Send + Sync + OxcResolverFileSystem {
   ///
   /// * See [std::fs::write]
   fn exists(&self, path: &Path) -> bool;
-}
-
-impl<T> FileSystem for Arc<T>
-where
-  T: FileSystem + OxcResolverFileSystem,
-{
-  fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
-    self.as_ref().remove_dir_all(path)
-  }
-
-  fn create_dir_all(&self, path: &Path) -> io::Result<()> {
-    self.as_ref().create_dir_all(path)
-  }
-
-  fn write(&self, path: &Path, content: &[u8]) -> io::Result<()> {
-    self.as_ref().write(path, content)
-  }
-
-  fn exists(&self, path: &Path) -> bool {
-    self.as_ref().exists(path)
-  }
 }

--- a/crates/rolldown_fs/src/os.rs
+++ b/crates/rolldown_fs/src/os.rs
@@ -12,6 +12,10 @@ use crate::file_system::FileSystem;
 pub struct OsFileSystem;
 
 impl FileSystem for OsFileSystem {
+  fn share(&self) -> Self {
+    Self
+  }
+
   fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
     std::fs::remove_dir_all(path)
   }

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -1,7 +1,7 @@
 use rolldown_common::{ModuleType, RawPath, ResourceId};
 use rolldown_error::BuildError;
 use rolldown_fs::FileSystem;
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 use sugar_path::{AsPath, SugarPathBuf};
 
 use oxc_resolver::{Resolution, ResolveOptions, ResolverGeneric};
@@ -9,11 +9,11 @@ use oxc_resolver::{Resolution, ResolveOptions, ResolverGeneric};
 #[derive(Debug)]
 pub struct Resolver<T: FileSystem + Default> {
   cwd: PathBuf,
-  inner: ResolverGeneric<Arc<T>>,
+  inner: ResolverGeneric<T>,
 }
 
 impl<F: FileSystem + Default> Resolver<F> {
-  pub fn with_cwd_and_fs(cwd: PathBuf, preserve_symlinks: bool, fs: Arc<F>) -> Self {
+  pub fn with_cwd_and_fs(cwd: PathBuf, preserve_symlinks: bool, fs: F) -> Self {
     let resolve_options = ResolveOptions {
       symlinks: !preserve_symlinks,
       extensions: vec![


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`OsFileSystem`(the most commonly used) doesn't require `Arc`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
