### PR TITLE
refactor(rust): remove `impl Default` for `ModuleId`

### DIFF
--- a/crates/rolldown/src/bundler/module_loader/runtime_normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/runtime_normal_module_task.rs
@@ -43,7 +43,7 @@ impl<'task, T: FileSystem + Default + 'static> RuntimeNormalModuleTask<'task, T>
       named_imports,
       named_exports,
       stmt_infos,
-      import_records,
+      import_records: _,
       star_exports,
       export_default_symbol_id,
       imports,
@@ -59,10 +59,10 @@ impl<'task, T: FileSystem + Default + 'static> RuntimeNormalModuleTask<'task, T>
     builder.named_imports = Some(named_imports);
     builder.named_exports = Some(named_exports);
     builder.stmt_infos = Some(stmt_infos);
-    builder.import_records = Some(import_records);
     builder.imports = Some(imports);
     builder.star_exports = Some(star_exports);
     builder.default_export_symbol = export_default_symbol_id;
+    builder.import_records = Some(IndexVec::default());
     builder.scope = Some(scope);
     builder.exports_kind = exports_kind;
     builder.namespace_symbol = Some(namespace_symbol);
@@ -77,6 +77,7 @@ impl<'task, T: FileSystem + Default + 'static> RuntimeNormalModuleTask<'task, T>
         warnings: self.warnings,
         ast_symbol: symbol,
         builder,
+        raw_import_records: IndexVec::default(),
       }))
       .unwrap();
   }

--- a/crates/rolldown/src/bundler/module_loader/task_result.rs
+++ b/crates/rolldown/src/bundler/module_loader/task_result.rs
@@ -1,5 +1,5 @@
 use index_vec::IndexVec;
-use rolldown_common::{ImportRecordId, ModuleId};
+use rolldown_common::{ImportRecordId, ModuleId, RawImportRecord};
 use rolldown_error::BuildError;
 
 use crate::bundler::module::normal_module_builder::NormalModuleBuilder;
@@ -10,6 +10,7 @@ pub struct NormalModuleTaskResult {
   pub module_id: ModuleId,
   pub ast_symbol: AstSymbol,
   pub resolved_deps: IndexVec<ImportRecordId, ResolvedRequestInfo>,
+  pub raw_import_records: IndexVec<ImportRecordId, RawImportRecord>,
   pub errors: Vec<BuildError>,
   pub warnings: Vec<BuildError>,
   pub builder: NormalModuleBuilder,

--- a/crates/rolldown/src/bundler/stages/link_stage.rs
+++ b/crates/rolldown/src/bundler/stages/link_stage.rs
@@ -76,7 +76,7 @@ impl LinkStage {
                 .import_records()
                 .iter()
                 .filter(|rec| rec.kind.is_static())
-                .filter_map(|rec| rec.resolved_module.is_valid().then_some(rec.resolved_module))
+                .map(|rec| rec.resolved_module)
                 .rev()
                 .map(Action::Enter),
             );

--- a/crates/rolldown/src/bundler/utils/symbols.rs
+++ b/crates/rolldown/src/bundler/utils/symbols.rs
@@ -35,7 +35,6 @@ pub struct Symbols {
 
 impl Symbols {
   pub fn add_ast_symbol(&mut self, module_id: ModuleId, ast_symbol: AstSymbol) {
-    debug_assert!(module_id.is_valid());
     let module_count = module_id.raw() as usize;
     if self.inner.len() <= module_count {
       self.inner.resize_with(module_count + 1, IndexVec::default);

--- a/crates/rolldown/src/bundler/visitors/scanner.rs
+++ b/crates/rolldown/src/bundler/visitors/scanner.rs
@@ -11,8 +11,8 @@ use oxc::{
   span::{Atom, Span},
 };
 use rolldown_common::{
-  ExportsKind, ImportKind, ImportRecord, ImportRecordId, LocalExport, LocalOrReExport, ModuleId,
-  ModuleType, NamedImport, ReExport, Specifier, StmtInfo, StmtInfos, SymbolRef,
+  ExportsKind, ImportKind, ImportRecordId, LocalExport, LocalOrReExport, ModuleId, ModuleType,
+  NamedImport, RawImportRecord, ReExport, Specifier, StmtInfo, StmtInfos, SymbolRef,
 };
 use rolldown_oxc::{BindingIdentifierExt, BindingPatternExt};
 use rustc_hash::FxHashMap;
@@ -25,7 +25,7 @@ pub struct ScanResult {
   pub named_imports: FxHashMap<SymbolId, NamedImport>,
   pub named_exports: FxHashMap<Atom, LocalOrReExport>,
   pub stmt_infos: StmtInfos,
-  pub import_records: IndexVec<ImportRecordId, ImportRecord>,
+  pub import_records: IndexVec<ImportRecordId, RawImportRecord>,
   pub star_exports: Vec<ImportRecordId>,
   pub export_default_symbol_id: Option<SymbolId>,
   pub imports: FxHashMap<Span, ImportRecordId>,
@@ -113,7 +113,7 @@ impl<'a> Scanner<'a> {
   }
 
   fn add_import_record(&mut self, module_request: &Atom, kind: ImportKind) -> ImportRecordId {
-    let rec = ImportRecord::new(module_request.clone(), kind);
+    let rec = RawImportRecord::new(module_request.clone(), kind);
     self.result.import_records.push(rec)
   }
 

--- a/crates/rolldown_common/src/import_record.rs
+++ b/crates/rolldown_common/src/import_record.rs
@@ -32,6 +32,31 @@ impl Display for ImportKind {
 }
 
 #[derive(Debug)]
+pub struct RawImportRecord {
+  // Module Request
+  pub module_request: Atom,
+  // export * as ns from '...'
+  // import * as ns from '...'
+  pub is_import_namespace: bool,
+  pub kind: ImportKind,
+}
+
+impl RawImportRecord {
+  pub fn new(specifier: Atom, kind: ImportKind) -> Self {
+    Self { module_request: specifier, is_import_namespace: false, kind }
+  }
+
+  pub fn into_import_record(self, resolved_module: ModuleId) -> ImportRecord {
+    ImportRecord {
+      module_request: self.module_request,
+      resolved_module,
+      is_import_namespace: self.is_import_namespace,
+      kind: self.kind,
+    }
+  }
+}
+
+#[derive(Debug)]
 pub struct ImportRecord {
   // Module Request
   pub module_request: Atom,
@@ -40,15 +65,4 @@ pub struct ImportRecord {
   // import * as ns from '...'
   pub is_import_namespace: bool,
   pub kind: ImportKind,
-}
-
-impl ImportRecord {
-  pub fn new(specifier: Atom, kind: ImportKind) -> Self {
-    Self {
-      module_request: specifier,
-      resolved_module: ModuleId::default(),
-      is_import_namespace: false,
-      kind,
-    }
-  }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -12,7 +12,7 @@ mod symbol_ref;
 mod wrap_kind;
 pub use crate::{
   exports_kind::ExportsKind,
-  import_record::{ImportKind, ImportRecord, ImportRecordId},
+  import_record::{ImportKind, ImportRecord, ImportRecordId, RawImportRecord},
   module_id::ModuleId,
   module_path::ResourceId,
   module_type::ModuleType,

--- a/crates/rolldown_common/src/module_id.rs
+++ b/crates/rolldown_common/src/module_id.rs
@@ -1,15 +1,3 @@
 index_vec::define_index_type! {
     pub struct ModuleId = u32;
 }
-
-impl Default for ModuleId {
-  fn default() -> Self {
-    Self::from_raw(u32::MAX)
-  }
-}
-
-impl ModuleId {
-  pub fn is_valid(&self) -> bool {
-    self.raw() < u32::MAX
-  }
-}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I have seen some out of index panics for accessing `modules`. This PR should be able to avoid them or raise errors as early as possible.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
