### PR TITLE
chore: remove `cargo-nextest`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,0 @@
-[profile.default]
-# https://nexte.st/book/leaky-tests.html
-leak-timeout = "1s"
-# https://nexte.st/book/slow-tests.html
-slow-timeout = { period = "5s", terminate-after = 1 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,8 +66,8 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all -- --deny warnings
 
-  cargo-nextest:
-    name: Cargo Nextest
+  cargo-test:
+    name: Cargo Test
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -75,11 +75,11 @@ jobs:
       - name: Install Rust
         uses: ./.github/actions/rustup
 
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@cargo-nextest
+      - name: Build
+        run: cargo test --no-run
 
       - name: Run Test
-        run: cargo nextest run
+        run: cargo test
 
   node-validation-test:
     name: Node Validation/Test

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -9,7 +9,9 @@ edition.workspace    = true
 repository.workspace = true
 
 [lib]
-bench = false
+bench   = false
+test    = false
+doctest = false
 
 [dependencies]
 criterion   = "0.4.0"

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ _default:
     just --list -u
 
 init:
-    cargo binstall rusty-hook taplo-cli cargo-insta cargo-nextest -y
+    cargo binstall rusty-hook taplo-cli cargo-insta -y
     yarn install
     git submodule update
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`cargo test` is faster than `cargo nextest`. So "Entities should not be multiplied unnecessarily"

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
