### PR TITLE
chore: ignore custom justfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ lib
 *.go
 
 pkg/
+
+# justfile
+justfilee*

--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,4 @@ lib
 pkg/
 
 # justfile
-justfilee*
+justfile*

--- a/justfile
+++ b/justfile
@@ -36,4 +36,3 @@ setup-bench:
 bench:
     cargo bench -p bench
 
-# build wasm of rolldown and move the output `pkg/` under `web` directory


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Allow users to use custom just file extension,  this can avoid violating project scripts convention.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
