### PR TITLE
chore: remove unnecessary casting

### DIFF
--- a/crates/rolldown/src/bundler/linker/linker.rs
+++ b/crates/rolldown/src/bundler/linker/linker.rs
@@ -100,12 +100,12 @@ impl<'graph> Linker<'graph> {
           WrapKind::None => {}
           WrapKind::Cjs => {
             module.create_wrap_symbol(linking_info, symbols);
-            let runtime_symbol = self.graph.runtime.resolve_symbol(&"__commonJS".into());
+            let runtime_symbol = self.graph.runtime.resolve_symbol("__commonJS");
             linking_info.reference_symbol_in_facade_stmt_infos(runtime_symbol);
           }
           WrapKind::Esm => {
             module.create_wrap_symbol(linking_info, symbols);
-            let runtime_symbol = self.graph.runtime.resolve_symbol(&"__esm".into());
+            let runtime_symbol = self.graph.runtime.resolve_symbol("__esm");
             linking_info.reference_symbol_in_facade_stmt_infos(runtime_symbol);
           }
         },
@@ -139,14 +139,14 @@ impl<'graph> Linker<'graph> {
                     symbols,
                   );
                   importer_linking_info.reference_symbol_in_facade_stmt_infos(
-                    self.graph.runtime.resolve_symbol(&"__toESM".into()),
+                    self.graph.runtime.resolve_symbol("__toESM"),
                   );
                 }
                 (_, ExportsKind::Esm) => {
                   importer_linking_info
                     .reference_symbol_in_facade_stmt_infos(importee.namespace_symbol);
                   importer_linking_info.reference_symbol_in_facade_stmt_infos(
-                    self.graph.runtime.resolve_symbol(&"__toCommonJS".into()),
+                    self.graph.runtime.resolve_symbol("__toCommonJS"),
                   );
                 }
                 _ => {}
@@ -158,7 +158,7 @@ impl<'graph> Linker<'graph> {
               if importee.exports_kind == ExportsKind::CommonJs {
                 let importee_linking_info = &mut linking_infos[importer.id];
                 importee_linking_info.reference_symbol_in_facade_stmt_infos(
-                  self.graph.runtime.resolve_symbol(&"__reExport".into()),
+                  self.graph.runtime.resolve_symbol("__reExport"),
                 );
               }
             }

--- a/crates/rolldown/src/bundler/renderer/utils.rs
+++ b/crates/rolldown/src/bundler/renderer/utils.rs
@@ -21,7 +21,7 @@ impl<'r> AstRenderContext<'r> {
   }
 
   pub fn canonical_name_for_runtime(&self, name: &str) -> &Atom {
-    let symbol = self.graph.runtime.resolve_symbol(&Atom::new_inline(name));
+    let symbol = self.graph.runtime.resolve_symbol(name);
     self.canonical_name_for(symbol)
   }
 

--- a/crates/rolldown/src/bundler/runtime/mod.rs
+++ b/crates/rolldown/src/bundler/runtime/mod.rs
@@ -22,7 +22,7 @@ impl RuntimeModuleBrief {
     self.id
   }
 
-  pub fn resolve_symbol(&self, name: &Atom) -> SymbolRef {
+  pub fn resolve_symbol(&self, name: &str) -> SymbolRef {
     let symbol_id =
       self.name_to_symbol.get(name).unwrap_or_else(|| panic!("Failed to resolve symbol: {name}"));
     (self.id, *symbol_id).into()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`&str` could be treated as `&Atom` without casting. This is cool.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
