### PR TITLE
feat: introduce `trait BuildErrorLike`

### DIFF
--- a/crates/rolldown/tests/common/case.rs
+++ b/crates/rolldown/tests/common/case.rs
@@ -1,7 +1,6 @@
 use std::{borrow::Cow, path::Path};
 
 use super::fixture::Fixture;
-use miette::{Diagnostic, GraphicalReportHandler, GraphicalTheme};
 use rolldown::Output;
 use rolldown_error::BuildError;
 use string_wizard::MagicString;
@@ -62,21 +61,17 @@ impl Case {
 
   fn render_errors_to_snapshot(&mut self, mut errors: Vec<BuildError>) {
     self.snapshot.append("# Errors\n\n");
-    errors.sort_by_key(|e| e.code().unwrap().to_string());
+    errors.sort_by_key(|e| e.code());
 
     // Render with miette's diagnostic theme (without colors)
-    let reporter = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
 
     let rendered = errors
       .iter()
       .flat_map(|error| {
-        let mut out = String::new();
-        reporter.render_report(&mut out, error).unwrap();
-
         [
-          Cow::Owned(format!("## {}\n", error.code().unwrap().to_string())),
+          Cow::Owned(format!("## {}\n", error.code())),
           "```text".into(),
-          Cow::Owned(out),
+          Cow::Owned(error.to_string()),
           "```".into(),
         ]
       })

--- a/crates/rolldown/tests/fixtures/errors/unresolved_entry/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/errors/unresolved_entry/artifacts.snap
@@ -8,8 +8,5 @@ input_file: crates/rolldown/tests/fixtures/errors/unresolved_entry
 ## UNRESOLVED_ENTRY
 
 ```text
-UNRESOLVED_ENTRY
-
-  × Cannot resolve entry module ./main.js.
-
+Cannot resolve entry module ./main.js.
 ```

--- a/crates/rolldown_error/src/error_kind/external_entry.rs
+++ b/crates/rolldown_error/src/error_kind/external_entry.rs
@@ -3,9 +3,21 @@ use miette::Diagnostic;
 use std::path::PathBuf;
 use thiserror::Error;
 
+use super::BuildErrorLike;
+
 #[derive(Error, Debug, Diagnostic)]
 #[diagnostic(code = "UNRESOLVED_ENTRY")]
 #[error("Entry module {} cannot be external.", id.relative_display())]
 pub struct ExternalEntry {
   pub(crate) id: PathBuf,
+}
+
+impl BuildErrorLike for ExternalEntry {
+  fn code(&self) -> &'static str {
+    "UNRESOLVED_ENTRY"
+  }
+
+  fn message(&self) -> String {
+    format!("Entry module {} cannot be external.", self.id.relative_display())
+  }
 }

--- a/crates/rolldown_error/src/error_kind/mod.rs
+++ b/crates/rolldown_error/src/error_kind/mod.rs
@@ -1,40 +1,48 @@
-use std::borrow::Cow;
+use std::fmt::Debug;
 
 pub mod external_entry;
-// pub mod impl_to_diagnostic;
 pub mod unresolved_entry;
 pub mod unresolved_import;
 
-use miette::Diagnostic;
-use thiserror::Error;
+// TODO(hyf0): Not a good name, probably should rename to `BuildError`
+pub trait BuildErrorLike: Debug + Sync + Send {
+  fn code(&self) -> &'static str;
 
-use self::{
-  external_entry::ExternalEntry, unresolved_entry::UnresolvedEntry,
-  unresolved_import::UnresolvedImport,
-};
-
-type StaticStr = Cow<'static, str>;
-
-#[derive(Error, Debug, Diagnostic)]
-pub enum ErrorKind {
-  #[diagnostic(transparent)]
-  #[error(transparent)]
-  UnresolvedEntry(Box<UnresolvedEntry>),
-
-  #[diagnostic(transparent)]
-  #[error(transparent)]
-  ExternalEntry(Box<ExternalEntry>),
-
-  #[diagnostic(transparent)]
-  #[error(transparent)]
-  UnresolvedImport(Box<UnresolvedImport>),
-
-  #[diagnostic(code = "IO_ERROR")]
-  #[error(transparent)]
-  Io(Box<std::io::Error>),
-
-  // TODO: probably should remove this error
-  #[diagnostic(code = "NAPI_ERROR")]
-  #[error("Napi error: {status}: {reason}")]
-  Napi { status: String, reason: String },
+  fn message(&self) -> String;
 }
+
+impl<T: BuildErrorLike + 'static> From<T> for Box<dyn BuildErrorLike> {
+  fn from(e: T) -> Self {
+    Box::new(e)
+  }
+}
+
+// --- TODO(hyf0): These errors are only for compatibility with legacy code. They should be replaced with more specific errors.
+
+#[derive(Debug)]
+pub struct NapiError {
+  pub status: String,
+  pub reason: String,
+}
+
+impl BuildErrorLike for NapiError {
+  fn code(&self) -> &'static str {
+    "NAPI_ERROR"
+  }
+
+  fn message(&self) -> String {
+    format!("Napi error: {status}: {reason}", status = self.status, reason = self.reason)
+  }
+}
+
+impl BuildErrorLike for std::io::Error {
+  fn code(&self) -> &'static str {
+    "IO_ERROR"
+  }
+
+  fn message(&self) -> String {
+    format!("IO error: {self}")
+  }
+}
+
+// --- end

--- a/crates/rolldown_error/src/error_kind/unresolved_entry.rs
+++ b/crates/rolldown_error/src/error_kind/unresolved_entry.rs
@@ -3,9 +3,21 @@ use miette::Diagnostic;
 use std::path::PathBuf;
 use thiserror::Error;
 
+use super::BuildErrorLike;
+
 #[derive(Error, Debug, Diagnostic)]
 #[diagnostic(code = "UNRESOLVED_ENTRY")]
 #[error("Cannot resolve entry module {}.", unresolved_id.relative_display())]
 pub struct UnresolvedEntry {
   pub(crate) unresolved_id: PathBuf,
+}
+
+impl BuildErrorLike for UnresolvedEntry {
+  fn code(&self) -> &'static str {
+    "UNRESOLVED_ENTRY"
+  }
+
+  fn message(&self) -> String {
+    format!("Cannot resolve entry module {}.", self.unresolved_id.relative_display())
+  }
 }

--- a/crates/rolldown_error/src/error_kind/unresolved_import.rs
+++ b/crates/rolldown_error/src/error_kind/unresolved_import.rs
@@ -1,5 +1,5 @@
-use super::StaticStr;
-use crate::PathExt;
+use super::BuildErrorLike;
+use crate::{PathExt, StaticStr};
 use miette::Diagnostic;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -10,4 +10,14 @@ use thiserror::Error;
 pub struct UnresolvedImport {
   pub(crate) specifier: StaticStr,
   pub(crate) importer: PathBuf,
+}
+
+impl BuildErrorLike for UnresolvedImport {
+  fn code(&self) -> &'static str {
+    "UNRESOLVED_IMPORT"
+  }
+
+  fn message(&self) -> String {
+    format!("Could not resolve {} from {}.", self.specifier, self.importer.relative_display())
+  }
 }

--- a/crates/rolldown_error/src/lib.rs
+++ b/crates/rolldown_error/src/lib.rs
@@ -2,9 +2,11 @@ mod error;
 mod error_kind;
 mod utils;
 
-use std::path::Path;
+use std::{borrow::Cow, path::Path};
 
 use sugar_path::SugarPath;
+
+pub(crate) type StaticStr = Cow<'static, str>;
 
 // pub use crate::{diagnostic::Diagnostic, error::BuildError};
 pub use crate::error::BuildError;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Each error should defined as self contained. It includes it's error code and message.
- I used `enum` for exposing error kind to rust users of rolldown, and now I think it seems meaningless to care what the errors are.
  - However, I haven't think it through. Let's see when this need is really requires.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
