### PR TITLE
feat: print fancy messages for errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "ariadne"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72fe02fc62033df9ba41cba57ee19acf5e742511a140c7dbc3a873e19a19a1bd"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "async-scoped"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1585,7 @@ dependencies = [
 name = "rolldown_error"
 version = "0.0.1"
 dependencies = [
+ "ariadne",
  "miette",
  "sugar_path",
  "thiserror",
@@ -2426,3 +2437,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,4 @@ regex          = "1.10.2"
 once_cell      = "1.18.0"
 dashmap        = "5.5.3"
 miette         = { version = "5.10.0", features = ["fancy-no-backtrace"] }
+ariadne        = "0.3.0"

--- a/crates/rolldown/tests/common/case.rs
+++ b/crates/rolldown/tests/common/case.rs
@@ -62,16 +62,16 @@ impl Case {
   fn render_errors_to_snapshot(&mut self, mut errors: Vec<BuildError>) {
     self.snapshot.append("# Errors\n\n");
     errors.sort_by_key(|e| e.code());
+    let diagnostics = errors.into_iter().map(|e| (e.code(), e.into_diagnostic()));
 
     // Render with miette's diagnostic theme (without colors)
 
-    let rendered = errors
-      .iter()
-      .flat_map(|error| {
+    let rendered = diagnostics
+      .flat_map(|(code, diagnostic)| {
         [
-          Cow::Owned(format!("## {}\n", error.code())),
+          Cow::Owned(format!("## {}\n", code)),
           "```text".into(),
-          Cow::Owned(error.to_string()),
+          Cow::Owned(diagnostic.to_string()),
           "```".into(),
         ]
       })

--- a/crates/rolldown/tests/fixtures/errors/unresolved_entry/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/errors/unresolved_entry/artifacts.snap
@@ -8,5 +8,12 @@ input_file: crates/rolldown/tests/fixtures/errors/unresolved_entry
 ## UNRESOLVED_ENTRY
 
 ```text
-Cannot resolve entry module ./main.js.
+[UNRESOLVED_ENTRY] Error: Unresolved entry module
+   ╭─[Output:1:1]
+   │
+ 1 │ ./main.js
+   │ ────┬────  
+   │     ╰────── Module Specifier
+───╯
+
 ```

--- a/crates/rolldown_error/Cargo.toml
+++ b/crates/rolldown_error/Cargo.toml
@@ -17,3 +17,4 @@ workspace = true
 sugar_path = { workspace = true }
 thiserror  = { workspace = true }
 miette     = { workspace = true }
+ariadne    = { workspace = true }

--- a/crates/rolldown_error/src/diagnostic.rs
+++ b/crates/rolldown_error/src/diagnostic.rs
@@ -1,0 +1,68 @@
+use std::{fmt::Display, ops::Range};
+
+use ariadne::{sources, Config, Label, Report, ReportBuilder, ReportKind};
+
+use crate::error::Severity;
+
+#[allow(clippy::type_complexity)]
+#[derive(Debug, Default)]
+pub struct DiagnosticBuilder {
+  pub code: Option<&'static str>,
+  pub summary: Option<String>,
+  pub files: Option<Vec<(String, String)>>,
+  pub labels: Option<Vec<Label<(String, Range<usize>)>>>,
+  pub severity: Option<Severity>,
+}
+
+impl DiagnosticBuilder {
+  pub fn build(self) -> Diagnostic {
+    Diagnostic {
+      code: self.code.expect("Field `code` should be sett"),
+      summary: self.summary.expect("Field `summary` should be set"),
+      severity: self.severity.expect("Field `severity` should be set"),
+      labels: self.labels.unwrap_or_default(),
+      files: self.files.unwrap_or_default(),
+    }
+  }
+}
+
+#[allow(unused)]
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+  pub(crate) code: &'static str,
+  pub(crate) summary: String,
+  pub(crate) files: Vec<(String, String)>,
+  pub(crate) labels: Vec<Label<(String, Range<usize>)>>,
+  pub(crate) severity: Severity,
+}
+
+impl Diagnostic {
+  fn init_report_builder(&mut self) -> ReportBuilder<'static, (String, Range<usize>)> {
+    let mut builder = Report::<(String, Range<usize>)>::build(ReportKind::Error, "", 0)
+      .with_code(self.code)
+      .with_message(self.summary.clone());
+
+    for label in self.labels.clone() {
+      builder = builder.with_label(label);
+    }
+
+    builder
+  }
+
+  pub fn as_string(&self) -> String {
+    let builder = self.clone().init_report_builder();
+    let mut output = Vec::new();
+    builder
+      .with_config(Config::default().with_color(false))
+      .finish()
+      .write_for_stdout(sources(self.files.clone()), &mut output)
+      .unwrap();
+    String::from_utf8(output).expect("Diagnostic should be valid utf8")
+  }
+}
+
+impl Display for Diagnostic {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    self.as_string().fmt(f)
+  }
+}

--- a/crates/rolldown_error/src/error_kind/external_entry.rs
+++ b/crates/rolldown_error/src/error_kind/external_entry.rs
@@ -1,13 +1,9 @@
 use crate::PathExt;
-use miette::Diagnostic;
 use std::path::PathBuf;
-use thiserror::Error;
 
 use super::BuildErrorLike;
 
-#[derive(Error, Debug, Diagnostic)]
-#[diagnostic(code = "UNRESOLVED_ENTRY")]
-#[error("Entry module {} cannot be external.", id.relative_display())]
+#[derive(Debug)]
 pub struct ExternalEntry {
   pub(crate) id: PathBuf,
 }

--- a/crates/rolldown_error/src/error_kind/mod.rs
+++ b/crates/rolldown_error/src/error_kind/mod.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
 
+use crate::diagnostic::DiagnosticBuilder;
+
 pub mod external_entry;
 pub mod unresolved_entry;
 pub mod unresolved_import;
@@ -9,9 +11,20 @@ pub trait BuildErrorLike: Debug + Sync + Send {
   fn code(&self) -> &'static str;
 
   fn message(&self) -> String;
+
+  fn diagnostic_builder(&self) -> DiagnosticBuilder {
+    DiagnosticBuilder {
+      code: Some(self.code()),
+      summary: Some(self.message()),
+      ..Default::default()
+    }
+  }
 }
 
-impl<T: BuildErrorLike + 'static> From<T> for Box<dyn BuildErrorLike> {
+impl<T: BuildErrorLike + 'static> From<T> for Box<dyn BuildErrorLike>
+where
+  Self: Sized,
+{
   fn from(e: T) -> Self {
     Box::new(e)
   }

--- a/crates/rolldown_error/src/error_kind/unresolved_entry.rs
+++ b/crates/rolldown_error/src/error_kind/unresolved_entry.rs
@@ -1,13 +1,11 @@
-use crate::PathExt;
-use miette::Diagnostic;
+use ariadne::Label;
+
+use crate::{diagnostic::DiagnosticBuilder, PathExt};
 use std::path::PathBuf;
-use thiserror::Error;
 
 use super::BuildErrorLike;
 
-#[derive(Error, Debug, Diagnostic)]
-#[diagnostic(code = "UNRESOLVED_ENTRY")]
-#[error("Cannot resolve entry module {}.", unresolved_id.relative_display())]
+#[derive(Debug)]
 pub struct UnresolvedEntry {
   pub(crate) unresolved_id: PathBuf,
 }
@@ -19,5 +17,18 @@ impl BuildErrorLike for UnresolvedEntry {
 
   fn message(&self) -> String {
     format!("Cannot resolve entry module {}.", self.unresolved_id.relative_display())
+  }
+
+  fn diagnostic_builder(&self) -> crate::diagnostic::DiagnosticBuilder {
+    let module_specifier = self.unresolved_id.clone().display().to_string();
+    let module_specifier_len = module_specifier.len();
+    DiagnosticBuilder {
+      code: Some(self.code()),
+      summary: Some("Unresolved entry module".to_string()),
+      files: Some(vec![("Output".to_string(), module_specifier)]),
+      labels: Some(vec![Label::new(("Output".to_string(), 0..module_specifier_len))
+        .with_message("Module Specifier")]),
+      ..Default::default()
+    }
   }
 }

--- a/crates/rolldown_error/src/error_kind/unresolved_import.rs
+++ b/crates/rolldown_error/src/error_kind/unresolved_import.rs
@@ -1,12 +1,8 @@
 use super::BuildErrorLike;
 use crate::{PathExt, StaticStr};
-use miette::Diagnostic;
 use std::path::PathBuf;
-use thiserror::Error;
 
-#[derive(Error, Debug, Diagnostic)]
-#[diagnostic(code = "UNRESOLVED_IMPORT")]
-#[error("Could not resolve {} from {}.", specifier, importer.relative_display())]
+#[derive(Debug)]
 pub struct UnresolvedImport {
   pub(crate) specifier: StaticStr,
   pub(crate) importer: PathBuf,

--- a/crates/rolldown_error/src/lib.rs
+++ b/crates/rolldown_error/src/lib.rs
@@ -1,3 +1,4 @@
+mod diagnostic;
 mod error;
 mod error_kind;
 mod utils;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Just found that we need `ariadne` for better flexbility to control how we display the messages, which is useful when we support warnings.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
