### PR TITLE
chore(wasm): add missing wasm-pack dep

### DIFF
--- a/crates/rolldown_binding_wasm/package.json
+++ b/crates/rolldown_binding_wasm/package.json
@@ -26,6 +26,7 @@
     "./snippets/*"
   ],
   "devDependencies": {
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "wasm-pack": "^0.12.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1501,6 +1501,7 @@ __metadata:
   resolution: "@rolldown/wasm-binding@workspace:crates/rolldown_binding_wasm"
   dependencies:
     npm-run-all: "npm:^4.1.5"
+    wasm-pack: "npm:^0.12.1"
   languageName: unknown
   linkType: soft
 
@@ -2967,6 +2968,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^0.26.1":
+  version: 0.26.1
+  resolution: "axios@npm:0.26.1"
+  dependencies:
+    follow-redirects: "npm:^1.14.8"
+  checksum: 02863f4a4fd4e43ad6e0c8bc9d1359a0863c43cc57bda42ea21dfce34681e3211df193b2bf2e8ee10b2c3870ab8d6bed38a3cf80cd6e8ee17749b7d73ccd4752
+  languageName: node
+  linkType: hard
+
 "axios@npm:^1.0.0":
   version: 1.6.2
   resolution: "axios@npm:1.6.2"
@@ -3054,6 +3064,17 @@ __metadata:
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
   checksum: ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
+  languageName: node
+  linkType: hard
+
+"binary-install@npm:^1.0.1":
+  version: 1.1.0
+  resolution: "binary-install@npm:1.1.0"
+  dependencies:
+    axios: "npm:^0.26.1"
+    rimraf: "npm:^3.0.2"
+    tar: "npm:^6.1.11"
+  checksum: 78121e9c32981c101cc090f1564fbd0453d976a1b40c599a5ca623184d739b0a7c49f5ba5f91c05142eb6ff9b2816959bb9e09a3aecd12e4e3e82398bed9b8f0
   languageName: node
   linkType: hard
 
@@ -5221,7 +5242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.0":
+"follow-redirects@npm:^1.14.8, follow-redirects@npm:^1.15.0":
   version: 1.15.3
   resolution: "follow-redirects@npm:1.15.3"
   peerDependenciesMeta:
@@ -11748,6 +11769,17 @@ __metadata:
   version: 1.0.0
   resolution: "walk-up-path@npm:1.0.0"
   checksum: b8019ac4fb9ba1576839ec66d2217f62ab773c1cc4c704bfd1c79b1359fef5366f1382d3ab230a66a14c3adb1bf0fe102d1fdaa3437881e69154dfd1432abd32
+  languageName: node
+  linkType: hard
+
+"wasm-pack@npm:^0.12.1":
+  version: 0.12.1
+  resolution: "wasm-pack@npm:0.12.1"
+  dependencies:
+    binary-install: "npm:^1.0.1"
+  bin:
+    wasm-pack: run.js
+  checksum: c16b9cf690a2414aa94b72fdc142a72813fccf1c4259499ad6a50a4560f943719234f8336e4e02d5c8cb6fb1b5128dd2870671c19dd01df3f6c9157600dd30d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Add the missing `wasm-pack` dependency in `@rolldown/wasm-binding` package. If I didn't install `wasm_pack` as global dep, the execution fails.

```sh
❯ nr build:wasm
command not found: wasm-pack
ERROR: "build:wasm" exited with 127.
```

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
