### PR TITLE
refactor: render imports from external modules without facade symbols

### DIFF
--- a/crates/rolldown/src/bundler/chunk/chunk.rs
+++ b/crates/rolldown/src/bundler/chunk/chunk.rs
@@ -1,5 +1,5 @@
 use oxc::span::Atom;
-use rolldown_common::{ModuleId, Specifier, SymbolRef};
+use rolldown_common::{ModuleId, NamedImport, Specifier, SymbolRef};
 use rustc_hash::FxHashMap;
 use string_wizard::{Joiner, JoinerOptions};
 
@@ -39,6 +39,7 @@ pub struct Chunk {
   pub canonical_names: FxHashMap<SymbolRef, Atom>,
   pub bits: BitSet,
   pub imports_from_other_chunks: FxHashMap<ChunkSymbolExporter, Vec<CrossChunkImportItem>>,
+  pub imports_from_external_modules: FxHashMap<ModuleId, Vec<NamedImport>>,
   // meaningless if the chunk is an entrypoint
   pub exports_to_other_chunks: FxHashMap<SymbolRef, Atom>,
 }

--- a/crates/rolldown/src/bundler/chunk/render_chunk_imports.rs
+++ b/crates/rolldown/src/bundler/chunk/render_chunk_imports.rs
@@ -6,12 +6,58 @@ use crate::bundler::{chunk_graph::ChunkGraph, stages::link_stage::LinkStageOutpu
 use super::chunk::Chunk;
 
 impl Chunk {
+  // clippy::too_many_lines: TODO(hyf0): refactor this function
+  #[allow(clippy::too_many_lines)]
   pub fn render_imports_for_esm(
     &self,
     graph: &LinkStageOutput,
     chunk_graph: &ChunkGraph,
   ) -> MagicString<'static> {
     let mut s = MagicString::new("");
+    // render imports from external modules
+    let mut imports_from_external_modules =
+      self.imports_from_external_modules.iter().collect::<Vec<_>>();
+    imports_from_external_modules
+      .sort_unstable_by_key(|(module_id, _)| graph.modules[**module_id].exec_order());
+    imports_from_external_modules.into_iter().for_each(|(importee_id, named_imports)| {
+      let importee = graph.modules[*importee_id].expect_external();
+      let mut is_importee_imported = false;
+      let mut import_items = named_imports
+        .iter()
+        .filter_map(|item| {
+          let alias = graph.symbols.get_original_name(item.imported_as);
+          match &item.imported {
+            Specifier::Star => {
+              is_importee_imported = true;
+              s.append(format!(
+                "import * as {alias} from \"{module}\";\n",
+                module = importee.resource_id.expect_file().as_str()
+              ));
+              None
+            }
+            Specifier::Literal(imported) => Some(if imported == alias {
+              format!("{imported}")
+            } else {
+              format!("{imported} as {alias}")
+            }),
+          }
+        })
+        .collect::<Vec<_>>();
+      import_items.sort();
+      if !import_items.is_empty() {
+        s.append(format!(
+          "import {{ {} }} from \"{}\";\n",
+          import_items.join(", "),
+          importee.resource_id.expect_file().as_str()
+        ));
+      } else if !is_importee_imported {
+        // Ensure the side effect
+        s.append(format!("import \"{}\";\n", importee.resource_id.expect_file().as_str()));
+      }
+    });
+
+    // render imports from other chunks
+
     self.imports_from_other_chunks.iter().for_each(|(exporter_id, items)| match exporter_id {
       super::chunk::ChunkSymbolExporter::Chunk(exporter_id) => {
         let importee_chunk = &chunk_graph.chunks[*exporter_id];

--- a/crates/rolldown/src/bundler/module/external_module.rs
+++ b/crates/rolldown/src/bundler/module/external_module.rs
@@ -1,9 +1,5 @@
 use index_vec::IndexVec;
-use oxc::span::Atom;
-use rolldown_common::{ImportRecord, ImportRecordId, ModuleId, ResourceId, Specifier, SymbolRef};
-use rustc_hash::FxHashMap;
-
-use crate::bundler::utils::symbols::Symbols;
+use rolldown_common::{ImportRecord, ImportRecordId, ModuleId, ResourceId};
 
 #[derive(Debug)]
 pub struct ExternalModule {
@@ -11,56 +7,10 @@ pub struct ExternalModule {
   pub exec_order: u32,
   pub resource_id: ResourceId,
   pub import_records: IndexVec<ImportRecordId, ImportRecord>,
-  pub exported_name_to_binding_ref: FxHashMap<Atom, SymbolRef>,
-  // FIXME: make this non-optional
-  pub namespace_ref: Option<SymbolRef>,
 }
 
 impl ExternalModule {
   pub fn new(id: ModuleId, resource_id: ResourceId) -> Self {
-    Self {
-      id,
-      exec_order: u32::MAX,
-      resource_id,
-      import_records: IndexVec::default(),
-      exported_name_to_binding_ref: FxHashMap::default(),
-      namespace_ref: None,
-    }
-  }
-
-  #[allow(clippy::needless_pass_by_value)]
-  pub fn add_export_symbol(&mut self, symbols: &mut Symbols, exported: Specifier) {
-    // Don't worry about the user happen to use the same name as the name we generated for `default export` or `namespace export`.
-    // Since they have different `SymbolId`, so in de-conflict phase, they will be renamed to different names.
-    let symbol_ref = match &exported {
-      Specifier::Star => {
-        self.namespace_ref = Some(symbols.create_symbol(
-          self.id,
-          Atom::from(format!("{}_ns", self.resource_id.expect_file().representative_name())),
-        ));
-        self.namespace_ref.unwrap()
-      }
-      Specifier::Literal(exported) => {
-        *self.exported_name_to_binding_ref.entry(exported.clone()).or_insert_with_key(|exported| {
-          let declared_name = if exported.as_ref() == "default" {
-            Atom::from(format!("{}_default", self.resource_id.expect_file().representative_name()))
-          } else {
-            exported.clone()
-          };
-          symbols.create_symbol(self.id, declared_name)
-        })
-      }
-    };
-    let symbol = symbols.get_mut(symbol_ref);
-    symbol.exported_as = Some(exported);
-  }
-
-  pub fn resolve_export(&self, exported: &Specifier) -> SymbolRef {
-    match exported {
-      Specifier::Star => self.namespace_ref.expect("should have namespace ref"),
-      Specifier::Literal(exported) => {
-        *self.exported_name_to_binding_ref.get(exported).expect("should have export symbol")
-      }
-    }
+    Self { id, exec_order: u32::MAX, resource_id, import_records: IndexVec::default() }
   }
 }

--- a/crates/rolldown/tests/esbuild/default/auto_external/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/auto_external/artifacts.snap
@@ -8,6 +8,11 @@ input_file: crates/rolldown/tests/esbuild/default/auto_external
 ## entry_js.mjs
 
 ```js
+import "http://example.com/code.js";
+import "https://example.com/code.js";
+import "//example.com/code.js";
+import "data:application/javascript;base64,ZXhwb3J0IGRlZmF1bHQgMTIz";
+
 // entry.js
 // These URLs should be external automatically
 ```

--- a/crates/rolldown/tests/esbuild/default/auto_external/test.config.json
+++ b/crates/rolldown/tests/esbuild/default/auto_external/test.config.json
@@ -6,5 +6,7 @@
         "import": "entry.js"
       }
     ]
-  }
+  },
+  "_comment": "The original input import external modules which is not exist in test environment",
+  "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/default/quoted_property/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/quoted_property/artifacts.snap
@@ -8,9 +8,9 @@ input_file: crates/rolldown/tests/esbuild/default/quoted_property
 ## entry_js.mjs
 
 ```js
-import * as ext_ns from "ext";
+import * as ns from "ext";
 
 // entry.js
 
-console.log(ext_ns.mustBeUnquoted, ext_ns['mustBeQuoted'])
+console.log(ns.mustBeUnquoted, ns['mustBeQuoted'])
 ```

--- a/crates/rolldown/tests/esbuild/import_star/re_export_star_external_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/re_export_star_external_es6/artifacts.snap
@@ -8,5 +8,7 @@ input_file: crates/rolldown/tests/esbuild/import_star/re_export_star_external_es
 ## entry_js.mjs
 
 ```js
+import "foo";
+
 // entry.js
 ```

--- a/crates/rolldown/tests/esbuild/import_star/re_export_star_external_es6/test.config.json
+++ b/crates/rolldown/tests/esbuild/import_star/re_export_star_external_es6/test.config.json
@@ -9,5 +9,7 @@
     "external": [
       "foo"
     ]
-  }
+  },
+  "_comment": "Module specifier `foo` is marked as external, so the build output will be executed failed expectedly.",
+  "expectExecuted": false
 }

--- a/crates/rolldown/tests/fixtures/deconflict/basic/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/deconflict/basic/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/fixtures/deconflict/basic
 ## main.mjs
 
 ```js
-import { default as assert_default } from "assert";
+import { default as assert } from "assert";
 
 // a.js
 const a = 'a.js'
@@ -19,6 +19,6 @@ const a = 'a.js'
 
 
 const a$1 = 'main.js'
-assert_default.equal(a$1, 'main.js')
-assert_default.equal(a, 'a.js')
+assert.equal(a$1, 'main.js')
+assert.equal(a, 'a.js')
 ```

--- a/crates/rolldown/tests/fixtures/deconflict/basic_scoped/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/deconflict/basic_scoped/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/fixtures/deconflict/basic_scoped
 ## main.mjs
 
 ```js
-import { default as assert_default } from "assert";
+import { default as assert } from "assert";
 
 // a.js
 const a = 'a.js'
@@ -25,5 +25,5 @@ function foo(a$1$1) {
   return [a$1$1, a$1, a]
 }
 
-assert_default.deepEqual(foo('foo'), ['foo', 'main.js', 'a.js'])
+assert.deepEqual(foo('foo'), ['foo', 'main.js', 'a.js'])
 ```

--- a/crates/rolldown/tests/fixtures/deconflict/complex_params_patterns/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/deconflict/complex_params_patterns/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/fixtures/deconflict/complex_params_patterns
 ## main.mjs
 
 ```js
-import { default as assert_default } from "assert";
+import { default as assert } from "assert";
 
 // names.js
 const [a, b, c, d, e] = ['a2', 'b2', 'c2', 'd2', 'e2']
@@ -28,8 +28,8 @@ function foo(a$1$1, { b$1: b$1$1 }, { c$1: c$1$1 = 'c$1' }, { d$1: d$1$1 } = { d
 }
 
 const ret = foo('a$1', { b$1: 'b$1' }, {}, undefined, undefined)
-assert_default.deepStrictEqual(ret.main, ['a', 'b', 'c', 'd', 'e'])
-assert_default.deepStrictEqual(ret.names, ['a2', 'b2', 'c2', 'd2', 'e2'])
-assert_default.deepStrictEqual(ret.params, ['a$1', 'b$1', 'c$1', 'd$1', 'e$1'])
+assert.deepStrictEqual(ret.main, ['a', 'b', 'c', 'd', 'e'])
+assert.deepStrictEqual(ret.names, ['a2', 'b2', 'c2', 'd2', 'e2'])
+assert.deepStrictEqual(ret.params, ['a$1', 'b$1', 'c$1', 'd$1', 'e$1'])
 export { a$1 as a, b$1 as b, c$1 as c, d$1 as d, e$1 as e };
 ```

--- a/crates/rolldown/tests/fixtures/deconflict/decl_complex_patterns/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/deconflict/decl_complex_patterns/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/fixtures/deconflict/decl_complex_patterns
 ## main.mjs
 
 ```js
-import { default as assert_default } from "assert";
+import { default as assert } from "assert";
 
 // names.js
 const [a] = ['a2']
@@ -28,16 +28,16 @@ const { d: d$1 = '' } = { d: 'd1' }
 const { d: e$1 = '' } = { d: 'e1' }
 
 
-assert_default.equal(a$1, 'a1')
-assert_default.equal(a, 'a2')
-assert_default.equal(b$1, 'b1')
-assert_default.equal(b, 'b2')
-assert_default.equal(c$1, 'c1')
-assert_default.equal(c, 'c2')
-assert_default.equal(d$1, 'd1')
-assert_default.equal(d, 'd2')
-assert_default.equal(e$1, 'e1')
-assert_default.equal(e, 'e2')
+assert.equal(a$1, 'a1')
+assert.equal(a, 'a2')
+assert.equal(b$1, 'b1')
+assert.equal(b, 'b2')
+assert.equal(c$1, 'c1')
+assert.equal(c, 'c2')
+assert.equal(d$1, 'd1')
+assert.equal(d, 'd2')
+assert.equal(e$1, 'e1')
+assert.equal(e, 'e2')
 
 
 export { a$1 as a, a as a2, b$1 as b, b as b2, c$1 as c, c as c2, d$1 as d, d as d2, e$1 as e, e as e2 };

--- a/crates/rolldown/tests/fixtures/deconflict/decl_nested_assign_pattern/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/deconflict/decl_nested_assign_pattern/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/fixtures/deconflict/decl_nested_assign_pattern
 ## main.mjs
 
 ```js
-import { default as assert_default } from "assert";
+import { default as assert } from "assert";
 
 // names.js
 const { foo: { bar: { baz = '' } = {} } = {} } = { foo: { bar: { baz: 'baz2' } } }
@@ -18,8 +18,8 @@ const { foo: { bar: { baz = '' } = {} } = {} } = { foo: { bar: { baz: 'baz2' } }
 
 
 const { foo: { bar: { baz: baz$1 = '' } = {} } = {} } = { foo: { bar: { baz: 'baz' } } }
-assert_default.strictEqual(baz$1, 'baz')
-assert_default.strictEqual(baz, 'baz2')
+assert.strictEqual(baz$1, 'baz')
+assert.strictEqual(baz, 'baz2')
 
 
 

--- a/crates/rolldown/tests/fixtures/external/implicit_import_external/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/external/implicit_import_external/artifacts.snap
@@ -8,14 +8,14 @@ input_file: crates/rolldown/tests/fixtures/external/implicit_import_external
 ## main.mjs
 
 ```js
-import * as node_assert_ns from "node:assert";
-import { default as node_assert_default, equal } from "node:assert";
+import * as assert_star from "node:assert";
+import { default as assert, equal } from "node:assert";
 
 // main.js
 
 
 
-node_assert_default.equal(1, 1)
-node_assert_ns.equal(1, 1)
+assert.equal(1, 1)
+assert_star.equal(1, 1)
 equal(1, 1)
 ```

--- a/crates/rolldown/tests/fixtures/external/keep_import_external_order/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/external/keep_import_external_order/artifacts.snap
@@ -8,6 +8,9 @@ input_file: crates/rolldown/tests/fixtures/external/keep_import_external_order
 ## main.mjs
 
 ```js
+import "ext1";
+import "ext2";
+
 // foo.js
 const a = 'foo'
 

--- a/crates/rolldown/tests/fixtures/external/keep_import_external_order/test.config.json
+++ b/crates/rolldown/tests/fixtures/external/keep_import_external_order/test.config.json
@@ -1,8 +1,10 @@
 {
-    "input": {
-        "external": [
-            "ext1",
-            "ext2"
-        ]
-    }
+  "input": {
+    "external": [
+      "ext1",
+      "ext2"
+    ]
+  },
+  "_comment": "The original input import external modules which is not exist in test environment",
+  "expectExecuted": false
 }

--- a/crates/rolldown/tests/fixtures/external/spliting_with_external_module/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/external/spliting_with_external_module/artifacts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rolldown/tests/common/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/external/spliting_with_external_module
+---
+# Assets
+
+## 2.mjs
+
+```js
+// share.js
+const value = 1
+
+export { value };
+```
+## entry.mjs
+
+```js
+import { value } from "./2.mjs";
+
+// entry.js
+
+
+
+console.log(value)
+```
+## main.mjs
+
+```js
+import { default as assert } from "assert";
+import { value } from "./2.mjs";
+
+// main.js
+
+
+
+
+assert(value === 1)
+```

--- a/crates/rolldown/tests/fixtures/external/spliting_with_external_module/entry.js
+++ b/crates/rolldown/tests/fixtures/external/spliting_with_external_module/entry.js
@@ -1,0 +1,4 @@
+
+import { value } from "./share"
+
+console.log(value)

--- a/crates/rolldown/tests/fixtures/external/spliting_with_external_module/main.js
+++ b/crates/rolldown/tests/fixtures/external/spliting_with_external_module/main.js
@@ -1,0 +1,5 @@
+
+import assert from "assert"
+import { value } from "./share"
+
+assert(value === 1)

--- a/crates/rolldown/tests/fixtures/external/spliting_with_external_module/share.js
+++ b/crates/rolldown/tests/fixtures/external/spliting_with_external_module/share.js
@@ -1,0 +1,1 @@
+export const value = 1

--- a/crates/rolldown/tests/fixtures/external/spliting_with_external_module/test.config.json
+++ b/crates/rolldown/tests/fixtures/external/spliting_with_external_module/test.config.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Test case comes from https://github.com/rolldown-rs/rolldown/pull/350",
+  "input": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.js"
+      },
+      {
+        "name": "entry",
+        "import": "entry.js"
+      }
+    ],
+    "external": [
+      "assert"
+    ]
+  }
+}

--- a/crates/rolldown_common/src/named_import.rs
+++ b/crates/rolldown_common/src/named_import.rs
@@ -7,7 +7,7 @@ use crate::symbol_ref::SymbolRef;
 /// - Case A: `import { foo } from 'foo'`
 /// - Case B: `import * as fooNs from 'foo'`
 /// - Case C: `import { foo as foo2 } from 'foo'`
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NamedImport {
   /// For case A, the `imported` is `foo`.
   /// For case B, the `imported` is meaningless.

--- a/packages/rollup-tests/src/failed-tests.json
+++ b/packages/rollup-tests/src/failed-tests.json
@@ -365,6 +365,7 @@
   "rollup@function@import-default-class: imports a default class",
   "rollup@function@import-default-from-external: imports default from external module",
   "rollup@function@import-default-function: imports a default function",
+  "rollup@function@import-empty-from-external: imports external module for side effects",
   "rollup@function@import-meta-url-b: Access document.currentScript at the top level",
   "rollup@function@import-meta-url: resolves import.meta.url",
   "rollup@function@import-named-from-external: imports names from an external module",

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,8 +1,8 @@
 {
   "total": 901,
   "failed": 0,
-  "skipFailed": 656,
+  "skipFailed": 657,
   "ignored": 7,
   "skipped": 0,
-  "passed": 238
+  "passed": 237
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -2,7 +2,7 @@
 |----| ---- |
 | total | 901|
 | failed | 0|
-| skipFailed | 656|
+| skipFailed | 657|
 | ignored | 7|
 | skipped | 0|
-| passed | 238|
+| passed | 237|


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Rendering imports from external modules has same problem in #323, but the problem is hidden by the old merging behavior.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
