### PR TITLE
refactor(ts): clean up methods of `RolldownBuild`

### DIFF
--- a/packages/node/src/rolldown-build.ts
+++ b/packages/node/src/rolldown-build.ts
@@ -1,40 +1,12 @@
 import { Bundler } from '@rolldown/node-binding'
-import { InputOptions, normalizeInputOptions } from './options/input-options'
 import { normalizeOutputOptions, OutputOptions } from './options/output-options'
 import type { RollupBuild, SerializedTimings } from './rollup-types'
 import { transformToRollupOutput, RolldownOutput, unimplemented } from './utils'
-import { createInputOptionsAdapter } from './options/input-options-adapter'
 
 export class RolldownBuild implements RollupBuild {
   #bundler: Bundler
-  private constructor(bundler: Bundler) {
+  constructor(bundler: Bundler) {
     this.#bundler = bundler
-  }
-
-  static async createBundler(inputOptions: InputOptions): Promise<Bundler> {
-    // Convert `InputOptions` to `NormalizedInputOptions`.
-    const normalizedInputOptions = await normalizeInputOptions(inputOptions)
-    // Convert `NormalizedInputOptions` to `BindingInputOptions`
-    const bindingInputOptions = createInputOptionsAdapter(
-      normalizedInputOptions,
-      inputOptions,
-    )
-    return new Bundler(bindingInputOptions)
-  }
-
-  static async fromInputOptionsForScanStage(
-    inputOptions: InputOptions,
-  ): Promise<void> {
-    const bundler = await RolldownBuild.createBundler(inputOptions)
-    await bundler.scan()
-  }
-
-  static async fromInputOptions(
-    inputOptions: InputOptions,
-  ): Promise<RolldownBuild> {
-    const bundler = await RolldownBuild.createBundler(inputOptions)
-    await bundler.build()
-    return new RolldownBuild(bundler)
   }
 
   closed = false

--- a/packages/node/src/rolldown.ts
+++ b/packages/node/src/rolldown.ts
@@ -1,9 +1,12 @@
 import { InputOptions } from './options/input-options'
 import { RolldownBuild } from './rolldown-build'
+import { createBundler } from './utils'
 
 // Compat to `rollup.rollup`, it is include scan module graph and linker.
-export const rolldown = (input: InputOptions): Promise<RolldownBuild> => {
-  return RolldownBuild.fromInputOptions(input)
+export const rolldown = async (input: InputOptions): Promise<RolldownBuild> => {
+  const bundler = await createBundler(input)
+  await bundler.build()
+  return new RolldownBuild(bundler)
 }
 
 /**
@@ -11,6 +14,7 @@ export const rolldown = (input: InputOptions): Promise<RolldownBuild> => {
  * This is a experimental API. It's behavior may change in the future.
  * Calling this API will only execute the scan stage of rolldown.
  */
-export const experimental_scan = (input: InputOptions): Promise<void> => {
-  return RolldownBuild.fromInputOptionsForScanStage(input)
+export const experimental_scan = async (input: InputOptions): Promise<void> => {
+  const bundler = await createBundler(input)
+  await bundler.scan()
 }

--- a/packages/node/src/utils/create-bundler.ts
+++ b/packages/node/src/utils/create-bundler.ts
@@ -1,0 +1,19 @@
+import { Bundler } from '@rolldown/node-binding'
+import {
+  normalizeInputOptions,
+  type InputOptions,
+} from '../options/input-options'
+import { createInputOptionsAdapter } from '../options/input-options-adapter'
+
+export async function createBundler(
+  inputOptions: InputOptions,
+): Promise<Bundler> {
+  // Convert `InputOptions` to `NormalizedInputOptions`.
+  const normalizedInputOptions = await normalizeInputOptions(inputOptions)
+  // Convert `NormalizedInputOptions` to `BindingInputOptions`
+  const bindingInputOptions = createInputOptionsAdapter(
+    normalizedInputOptions,
+    inputOptions,
+  )
+  return new Bundler(bindingInputOptions)
+}

--- a/packages/node/src/utils/index.ts
+++ b/packages/node/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from './async-flatten'
 export * from './transform-to-rollup-output'
 export * from './normalize-plugin-option'
 export * from './ensure-array'
+export * from './create-bundler'
 
 export function arraify<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Should not expose those methods to userland. This rule also includes the constuctor method. So `RolldownBuild` will be an `interface` rather than a `class` in the future.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
