### PR TITLE
fix: support browser filed false value

### DIFF
--- a/crates/rolldown/src/bundler/module_loader/module_loader.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_loader.rs
@@ -84,13 +84,13 @@ impl<T: FileSystem + 'static + Default> ModuleLoader<T> {
   }
 
   fn try_spawn_new_task(&mut self, info: ResolvedRequestInfo) -> ModuleId {
-    match self.visited.entry(info.path.clone()) {
+    match self.visited.entry(info.path.path.clone()) {
       std::collections::hash_map::Entry::Occupied(visited) => *visited.get(),
       std::collections::hash_map::Entry::Vacant(not_visited) => {
         let id = Self::alloc_module_id(&mut self.intermediate_modules, &mut self.symbols);
         not_visited.insert(id);
         if info.is_external {
-          let ext = ExternalModule::new(id, ResourceId::new(info.path));
+          let ext = ExternalModule::new(id, ResourceId::new(info.path.path));
           self.intermediate_modules[id] = Some(Module::External(ext));
         } else {
           self.remaining += 1;

--- a/crates/rolldown/src/bundler/stages/scan_stage.rs
+++ b/crates/rolldown/src/bundler/stages/scan_stage.rs
@@ -93,7 +93,7 @@ impl<Fs: FileSystem + Default + 'static> ScanStage<Fs> {
         {
           Ok(info) => {
             if info.is_external {
-              return Err(BuildError::entry_cannot_be_external(info.path.as_str()));
+              return Err(BuildError::entry_cannot_be_external(info.path.path.as_str()));
             }
             Ok((input_item.name.clone(), info))
           }

--- a/crates/rolldown/src/bundler/utils/load_source.rs
+++ b/crates/rolldown/src/bundler/utils/load_source.rs
@@ -1,19 +1,20 @@
-use rolldown_common::FilePath;
+use rolldown_common::ResolvedPath;
 use sugar_path::AsPath;
 
 use crate::{bundler::plugin_driver::PluginDriver, error::BatchedErrors, HookLoadArgs};
 
 pub async fn load_source(
   plugin_driver: &PluginDriver,
-  path: &FilePath,
+  resolved_path: &ResolvedPath,
   fs: &dyn rolldown_fs::FileSystem,
 ) -> Result<String, BatchedErrors> {
-  let source = if let Some(r) = plugin_driver.load(&HookLoadArgs { id: path.as_ref() }).await? {
-    r.code
-  } else if path.is_ignored() {
-    String::new()
-  } else {
-    fs.read_to_string(path.as_path())?
-  };
+  let source =
+    if let Some(r) = plugin_driver.load(&HookLoadArgs { id: &resolved_path.path }).await? {
+      r.code
+    } else if resolved_path.ignored {
+      String::new()
+    } else {
+      fs.read_to_string(resolved_path.path.as_path())?
+    };
   Ok(source)
 }

--- a/crates/rolldown/src/bundler/utils/load_source.rs
+++ b/crates/rolldown/src/bundler/utils/load_source.rs
@@ -10,6 +10,8 @@ pub async fn load_source(
 ) -> Result<String, BatchedErrors> {
   let source = if let Some(r) = plugin_driver.load(&HookLoadArgs { id: path.as_ref() }).await? {
     r.code
+  } else if path.is_ignored() {
+    String::new()
   } else {
     fs.read_to_string(path.as_path())?
   };

--- a/crates/rolldown/src/bundler/utils/resolve_id.rs
+++ b/crates/rolldown/src/bundler/utils/resolve_id.rs
@@ -1,6 +1,6 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
-use rolldown_common::{FilePath, ModuleType};
+use rolldown_common::{FilePath, ModuleType, ResolvedPath};
 use rolldown_error::BuildError;
 use rolldown_fs::FileSystem;
 use rolldown_resolver::Resolver;
@@ -16,7 +16,7 @@ static DATA_URL_REGEX: Lazy<Regex> =
 
 #[derive(Debug)]
 pub struct ResolvedRequestInfo {
-  pub path: FilePath,
+  pub path: ResolvedPath,
   pub module_type: ModuleType,
   pub is_external: bool,
 }

--- a/crates/rolldown/tests/common/fixture.rs
+++ b/crates/rolldown/tests/common/fixture.rs
@@ -106,7 +106,19 @@ impl Fixture {
       cwd: fixture_path.to_path_buf(),
       external: test_config.input.external.map(External::ArrayString).unwrap_or_default(),
       treeshake: test_config.input.treeshake.unwrap_or(true),
-      resolve: None,
+      resolve: test_config.input.resolve.map(|value| rolldown_resolver::ResolverOptions {
+        alias: value
+          .alias
+          .map(|alias| alias.into_iter().map(|(key, value)| (key, value)).collect::<Vec<_>>()),
+        alias_fields: value.alias_fields,
+        condition_names: value.condition_names,
+        exports_fields: value.exports_fields,
+        extensions: value.extensions,
+        main_fields: value.main_fields,
+        main_files: value.main_files,
+        modules: value.modules,
+        symlinks: value.symlinks,
+      }),
     });
 
     if fixture_path.join("dist").is_dir() {

--- a/crates/rolldown/tests/common/fixture.rs
+++ b/crates/rolldown/tests/common/fixture.rs
@@ -107,9 +107,7 @@ impl Fixture {
       external: test_config.input.external.map(External::ArrayString).unwrap_or_default(),
       treeshake: test_config.input.treeshake.unwrap_or(true),
       resolve: test_config.input.resolve.map(|value| rolldown_resolver::ResolverOptions {
-        alias: value
-          .alias
-          .map(|alias| alias.into_iter().map(|(key, value)| (key, value)).collect::<Vec<_>>()),
+        alias: value.alias.map(|alias| alias.into_iter().collect::<Vec<_>>()),
         alias_fields: value.alias_fields,
         condition_names: value.condition_names,
         exports_fields: value.exports_fields,

--- a/crates/rolldown/tests/fixtures/resolve/browser-filed-false/.gitignore
+++ b/crates/rolldown/tests/fixtures/resolve/browser-filed-false/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/crates/rolldown/tests/fixtures/resolve/browser-filed-false/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/resolve/browser-filed-false/artifacts.snap
@@ -8,44 +8,11 @@ input_file: crates/rolldown/tests/fixtures/resolve/browser-filed-false
 ## package.mjs
 
 ```js
-// <runtime>
-
-var __create = Object.create
-var __defProp = Object.defineProperty
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor
-var __getOwnPropNames = Object.getOwnPropertyNames
-var __getProtoOf = Object.getPrototypeOf
-var __hasOwnProp = Object.prototype.hasOwnProperty
-var __commonJS = (cb, mod) => function () {
-  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports
-}
-var __copyProps = (to, from, except, desc) => {
-  if (from && typeof from === 'object' || typeof from === 'function')
-    for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
-      key = keys[i]
-      if (!__hasOwnProp.call(to, key) && key !== except)
-        __defProp(to, key, { get: (k => from[k]).bind(null, key), enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable })
-    }
-  return to
-}
-var __toESM = (mod, isNodeMode, target) => (
-  target = mod != null ? __create(__getProtoOf(mod)) : {},
-  __copyProps(
-    isNodeMode || !mod || !mod.__esModule
-      ? __defProp(target, 'default', { value: mod, enumerable: true })
-      : target,
-    mod)
-)
+import { __commonJS, __toESM } from "./_rolldown_runtime.mjs";
 
 // (ignored) node_modules/package/util.js
-var require_util = __commonJS({
-	'(ignored) node_modules/package/util.js'(exports, module) {
 
-	}
-});
 // node_modules/package/index.js
-var import_util = __toESM(require_util(), 1);
-
-
-console.log(import_util.default)
+import value from './util.js';
+console.log(import_util.default);
 ```

--- a/crates/rolldown/tests/fixtures/resolve/browser-filed-false/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/resolve/browser-filed-false/artifacts.snap
@@ -1,0 +1,51 @@
+---
+source: crates/rolldown/tests/common/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/resolve/browser-filed-false
+---
+# Assets
+
+## package.mjs
+
+```js
+// <runtime>
+
+var __create = Object.create
+var __defProp = Object.defineProperty
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor
+var __getOwnPropNames = Object.getOwnPropertyNames
+var __getProtoOf = Object.getPrototypeOf
+var __hasOwnProp = Object.prototype.hasOwnProperty
+var __commonJS = (cb, mod) => function () {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports
+}
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === 'object' || typeof from === 'function')
+    for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
+      key = keys[i]
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: (k => from[k]).bind(null, key), enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable })
+    }
+  return to
+}
+var __toESM = (mod, isNodeMode, target) => (
+  target = mod != null ? __create(__getProtoOf(mod)) : {},
+  __copyProps(
+    isNodeMode || !mod || !mod.__esModule
+      ? __defProp(target, 'default', { value: mod, enumerable: true })
+      : target,
+    mod)
+)
+
+// (ignored) node_modules/package/util.js
+var require_util = __commonJS({
+	'(ignored) node_modules/package/util.js'(exports, module) {
+
+	}
+});
+// node_modules/package/index.js
+var import_util = __toESM(require_util(), 1);
+
+
+console.log(import_util.default)
+```

--- a/crates/rolldown/tests/fixtures/resolve/browser-filed-false/node_modules/package/index.js
+++ b/crates/rolldown/tests/fixtures/resolve/browser-filed-false/node_modules/package/index.js
@@ -1,0 +1,3 @@
+import value from './util.js'
+
+console.log(value)

--- a/crates/rolldown/tests/fixtures/resolve/browser-filed-false/node_modules/package/package.json
+++ b/crates/rolldown/tests/fixtures/resolve/browser-filed-false/node_modules/package/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "package",
+    "type": "module",
+    "main": "index.js",
+    "browser": {
+        "./util.js": false
+    }
+}

--- a/crates/rolldown/tests/fixtures/resolve/browser-filed-false/test.config.json
+++ b/crates/rolldown/tests/fixtures/resolve/browser-filed-false/test.config.json
@@ -1,0 +1,17 @@
+{
+    "input": {
+        "input": [
+            {
+                "name": "package",
+                "import": "package"
+            }
+        ],
+        "resolve": {
+            "aliasFields": [
+                [
+                    "browser"
+                ]
+            ]
+        }
+    }
+}

--- a/crates/rolldown_common/src/file_path.rs
+++ b/crates/rolldown_common/src/file_path.rs
@@ -9,29 +9,21 @@ use regex::Regex;
 use sugar_path::{AsPath, SugarPath};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
-pub struct FilePath((Arc<str>, bool /* ignored (used to browser filed "false" value) */));
+pub struct FilePath(Arc<str>);
 
 impl FilePath {
   pub fn new(value: impl Into<String>) -> Self {
-    Self((value.into().into(), false))
-  }
-
-  pub fn with_ignored(value: impl Into<String>) -> Self {
-    Self((value.into().into(), true))
+    Self(value.into().into())
   }
 
   pub fn as_str(&self) -> &str {
-    &self.0 .0
-  }
-
-  pub fn is_ignored(&self) -> bool {
-    self.0 .1
+    &self.0
   }
 }
 
 impl AsRef<str> for FilePath {
   fn as_ref(&self) -> &str {
-    &self.0 .0
+    &self.0
   }
 }
 
@@ -39,7 +31,7 @@ impl std::ops::Deref for FilePath {
   type Target = str;
 
   fn deref(&self) -> &Self::Target {
-    &self.0 .0
+    &self.0
   }
 }
 
@@ -51,7 +43,7 @@ impl From<String> for FilePath {
 
 impl FilePath {
   pub fn unique(&self, root: impl AsRef<Path>) -> String {
-    let path = self.0 .0.as_path();
+    let path = self.0.as_path();
     let mut relative = path.relative(root);
     let ext = relative.extension().and_then(OsStr::to_str).unwrap_or("").to_string();
     relative.set_extension("");
@@ -71,28 +63,8 @@ impl FilePath {
     name
   }
 
-  pub fn prettify(&self, cwd: impl AsRef<Path>) -> String {
-    let pretty = if Path::new(self.0 .0.as_ref()).is_absolute() {
-      Path::new(self.0 .0.as_ref())
-        .relative(cwd.as_ref())
-        .into_os_string()
-        .into_string()
-        .expect("should be valid utf8")
-    } else {
-      self.0 .0.to_string()
-    };
-    // remove \0
-    let pretty = pretty.replace('\0', "");
-
-    if self.0 .1 {
-      format!("(ignored) {pretty}")
-    } else {
-      pretty
-    }
-  }
-
   pub fn representative_name(&self) -> Cow<str> {
-    representative_name(&self.0 .0)
+    representative_name(&self.0)
   }
 }
 

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -8,6 +8,7 @@ mod module_type;
 mod named_export;
 mod named_import;
 mod resolved_export;
+mod resolved_path;
 mod stmt_info;
 mod symbol_ref;
 mod wrap_kind;
@@ -22,6 +23,7 @@ pub use crate::{
   named_export::LocalExport,
   named_import::{NamedImport, Specifier},
   resolved_export::ResolvedExport,
+  resolved_path::ResolvedPath,
   stmt_info::{StmtInfo, StmtInfoId, StmtInfos},
   symbol_ref::SymbolRef,
   wrap_kind::WrapKind,

--- a/crates/rolldown_common/src/resolved_path.rs
+++ b/crates/rolldown_common/src/resolved_path.rs
@@ -1,0 +1,38 @@
+use std::path::Path;
+
+use crate::FilePath;
+use sugar_path::SugarPath;
+
+#[derive(Debug, Clone)]
+pub struct ResolvedPath {
+  pub path: FilePath,
+  pub ignored: bool,
+}
+
+impl From<String> for ResolvedPath {
+  fn from(value: String) -> Self {
+    Self { path: value.into(), ignored: false }
+  }
+}
+
+impl ResolvedPath {
+  pub fn prettify(&self, cwd: impl AsRef<Path>) -> String {
+    let pretty = if Path::new(self.path.as_ref()).is_absolute() {
+      Path::new(self.path.as_ref())
+        .relative(cwd.as_ref())
+        .into_os_string()
+        .into_string()
+        .expect("should be valid utf8")
+    } else {
+      self.path.to_string()
+    };
+    // remove \0
+    let pretty = pretty.replace('\0', "");
+
+    if self.ignored {
+      format!("(ignored) {pretty}")
+    } else {
+      pretty
+    }
+  }
+}

--- a/crates/rolldown_common/src/resolved_path.rs
+++ b/crates/rolldown_common/src/resolved_path.rs
@@ -16,6 +16,9 @@ impl From<String> for ResolvedPath {
 }
 
 impl ResolvedPath {
+  /// Created a pretty string representation of the path. The path
+  /// 1. doesn't guarantee to be unique
+  /// 2. relative to the cwd, so it could show stable path across different machines
   pub fn prettify(&self, cwd: impl AsRef<Path>) -> String {
     let pretty = if Path::new(self.path.as_ref()).is_absolute() {
       Path::new(self.path.as_ref())

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -1,4 +1,4 @@
-use rolldown_common::{FilePath, ModuleType};
+use rolldown_common::{FilePath, ModuleType, ResolvedPath};
 use rolldown_error::BuildError;
 use rolldown_fs::FileSystem;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ impl<F: FileSystem + Default> Resolver<F> {
 
 #[derive(Debug)]
 pub struct ResolveRet {
-  pub resolved: FilePath,
+  pub resolved: ResolvedPath,
   pub module_type: ModuleType,
 }
 
@@ -66,13 +66,19 @@ impl<F: FileSystem + Default> Resolver<F> {
 
     match resolved {
       Ok(info) => Ok(ResolveRet {
-        resolved: info.path().to_string_lossy().to_string().into(),
+        resolved: ResolvedPath {
+          path: info.path().to_string_lossy().to_string().into(),
+          ignored: false,
+        },
         module_type: calc_module_type(&info),
       }),
       Err(err) => {
         if let ResolveError::Ignored(path) = err {
           Ok(ResolveRet {
-            resolved: FilePath::with_ignored(path.to_string_lossy().to_string()),
+            resolved: ResolvedPath {
+              path: path.to_string_lossy().to_string().into(),
+              ignored: true,
+            },
             module_type: ModuleType::CJS,
           })
         } else if let Some(importer) = importer {

--- a/crates/rolldown_testing/src/test_config/input_options.rs
+++ b/crates/rolldown_testing/src/test_config/input_options.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
+use std::collections::HashMap;
 
 #[derive(Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -7,6 +8,7 @@ pub struct InputOptions {
   pub input: Option<Vec<InputItem>>,
   pub external: Option<Vec<String>>,
   pub treeshake: Option<bool>,
+  pub resolve: Option<ResolveOptions>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -21,4 +23,18 @@ pub struct InputItem {
 pub struct TsConfig {
   #[serde(default)]
   pub use_define_for_class_fields: bool,
+}
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResolveOptions {
+  pub alias: Option<HashMap<String, Vec<String>>>,
+  pub alias_fields: Option<Vec<Vec<String>>>,
+  pub condition_names: Option<Vec<String>>,
+  pub exports_fields: Option<Vec<Vec<String>>>,
+  pub extensions: Option<Vec<String>>,
+  pub main_fields: Option<Vec<String>>,
+  pub main_files: Option<Vec<String>>,
+  pub modules: Option<Vec<String>>,
+  pub symlinks: Option<bool>,
 }

--- a/crates/rolldown_testing/test.config.scheme.json
+++ b/crates/rolldown_testing/test.config.scheme.json
@@ -69,6 +69,16 @@
             "$ref": "#/definitions/InputItem"
           }
         },
+        "resolve": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResolveOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "treeshake": {
           "type": [
             "boolean",
@@ -88,6 +98,99 @@
         "format": {
           "default": "esm",
           "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ResolveOptions": {
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "aliasFields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "conditionNames": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "exportsFields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "extensions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "mainFields": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "mainFiles": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "modules": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "symlinks": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

You can simply prevent a module or file from being loaded into a bundle by specifying a value of ```false``` for any of the keys. This is useful if you know certain codepaths will not be executed client side but find it awkward to split up or change the code structure.

```javascript
"browser": {
    "module-a": false,
    "./server/only.js": "./shims/server-only.js"
}
```

The above will cause the following to return an empty object into `a`.
```javascript
var a = require('module-a');
```

ref https://github.com/defunctzombie/package-browser-field-spec?tab=readme-ov-file#ignore-a-module
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Added.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
