### PR TITLE
feat: determine circular dependency

### DIFF
--- a/crates/rolldown/src/bundler/stages/link_stage.rs
+++ b/crates/rolldown/src/bundler/stages/link_stage.rs
@@ -147,8 +147,7 @@ impl LinkStage {
       modules[module]
         .import_records()
         .iter()
-        .filter(|rec| rec.kind.is_static())
-        .map(|rec| rec.resolved_module)
+        .filter_map(|rec| rec.kind.is_static().then_some(rec.resolved_module))
         .for_each(|dependency| {
           if parents.contains_key(&dependency) {
             if !visited_modules.contains(&dependency) {

--- a/crates/rolldown/src/bundler/stages/link_stage.rs
+++ b/crates/rolldown/src/bundler/stages/link_stage.rs
@@ -200,6 +200,7 @@ impl LinkStage {
             .map(|id| self.modules[*id].expect_normal().pretty_path.to_string())
             .collect::<Vec<_>>(),
         )
+        .with_severity_warning()
       }));
     }
   }

--- a/crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_es6/artifacts.snap
@@ -3,6 +3,14 @@ source: crates/rolldown/tests/common/case.rs
 expression: content
 input_file: crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_es6
 ---
+# warnings
+
+## CIRCULAR_DEPENDENCY
+
+```text
+[CIRCULAR_DEPENDENCY] Error: Circular dependency: entry.js -> entry.js.
+
+```
 # Assets
 
 ## entry_js.mjs

--- a/crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_self_as_namespace_e
 ## CIRCULAR_DEPENDENCY
 
 ```text
-[CIRCULAR_DEPENDENCY] Error: Circular dependency: entry.js -> entry.js.
+[CIRCULAR_DEPENDENCY] Warning: Circular dependency: entry.js -> entry.js.
 
 ```
 # Assets

--- a/crates/rolldown/tests/esbuild/import_star/export_self_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_self_es6/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/esbuild/import_star/export_self_es6
 ## CIRCULAR_DEPENDENCY
 
 ```text
-[CIRCULAR_DEPENDENCY] Error: Circular dependency: entry.js -> entry.js.
+[CIRCULAR_DEPENDENCY] Warning: Circular dependency: entry.js -> entry.js.
 
 ```
 # Assets

--- a/crates/rolldown/tests/esbuild/import_star/export_self_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/export_self_es6/artifacts.snap
@@ -3,6 +3,14 @@ source: crates/rolldown/tests/common/case.rs
 expression: content
 input_file: crates/rolldown/tests/esbuild/import_star/export_self_es6
 ---
+# warnings
+
+## CIRCULAR_DEPENDENCY
+
+```text
+[CIRCULAR_DEPENDENCY] Error: Circular dependency: entry.js -> entry.js.
+
+```
 # Assets
 
 ## entry_js.mjs

--- a/crates/rolldown/tests/esbuild/import_star/import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/esbuild/import_star/import_export_self_as_name
 ## CIRCULAR_DEPENDENCY
 
 ```text
-[CIRCULAR_DEPENDENCY] Error: Circular dependency: entry.js -> entry.js.
+[CIRCULAR_DEPENDENCY] Warning: Circular dependency: entry.js -> entry.js.
 
 ```
 # Assets

--- a/crates/rolldown/tests/esbuild/import_star/import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_export_self_as_namespace_es6/artifacts.snap
@@ -3,6 +3,14 @@ source: crates/rolldown/tests/common/case.rs
 expression: content
 input_file: crates/rolldown/tests/esbuild/import_star/import_export_self_as_namespace_es6
 ---
+# warnings
+
+## CIRCULAR_DEPENDENCY
+
+```text
+[CIRCULAR_DEPENDENCY] Error: Circular dependency: entry.js -> entry.js.
+
+```
 # Assets
 
 ## entry_js.mjs

--- a/crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_
 ## CIRCULAR_DEPENDENCY
 
 ```text
-[CIRCULAR_DEPENDENCY] Error: Circular dependency: foo.js -> foo.js.
+[CIRCULAR_DEPENDENCY] Warning: Circular dependency: foo.js -> foo.js.
 
 ```
 # Assets

--- a/crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6/artifacts.snap
@@ -3,6 +3,14 @@ source: crates/rolldown/tests/common/case.rs
 expression: content
 input_file: crates/rolldown/tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6
 ---
+# warnings
+
+## CIRCULAR_DEPENDENCY
+
+```text
+[CIRCULAR_DEPENDENCY] Error: Circular dependency: foo.js -> foo.js.
+
+```
 # Assets
 
 ## entry_js.mjs

--- a/crates/rolldown/tests/esbuild/import_star/other_file_import_export_self_as_namespace_unused_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/other_file_import_export_self_as_namespace_unused_es6/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/esbuild/import_star/other_file_import_export_s
 ## CIRCULAR_DEPENDENCY
 
 ```text
-[CIRCULAR_DEPENDENCY] Error: Circular dependency: foo.js -> foo.js.
+[CIRCULAR_DEPENDENCY] Warning: Circular dependency: foo.js -> foo.js.
 
 ```
 # Assets

--- a/crates/rolldown/tests/esbuild/import_star/other_file_import_export_self_as_namespace_unused_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/other_file_import_export_self_as_namespace_unused_es6/artifacts.snap
@@ -3,6 +3,14 @@ source: crates/rolldown/tests/common/case.rs
 expression: content
 input_file: crates/rolldown/tests/esbuild/import_star/other_file_import_export_self_as_namespace_unused_es6
 ---
+# warnings
+
+## CIRCULAR_DEPENDENCY
+
+```text
+[CIRCULAR_DEPENDENCY] Error: Circular dependency: foo.js -> foo.js.
+
+```
 # Assets
 
 ## entry_js.mjs

--- a/crates/rolldown/tests/esbuild/import_star/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/esbuild/import_star/re_export_other_file_expor
 ## CIRCULAR_DEPENDENCY
 
 ```text
-[CIRCULAR_DEPENDENCY] Error: Circular dependency: foo.js -> foo.js.
+[CIRCULAR_DEPENDENCY] Warning: Circular dependency: foo.js -> foo.js.
 
 ```
 # Assets

--- a/crates/rolldown/tests/esbuild/import_star/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
@@ -3,6 +3,14 @@ source: crates/rolldown/tests/common/case.rs
 expression: content
 input_file: crates/rolldown/tests/esbuild/import_star/re_export_other_file_export_self_as_namespace_es6
 ---
+# warnings
+
+## CIRCULAR_DEPENDENCY
+
+```text
+[CIRCULAR_DEPENDENCY] Error: Circular dependency: foo.js -> foo.js.
+
+```
 # Assets
 
 ## entry_js.mjs

--- a/crates/rolldown/tests/esbuild/import_star/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/esbuild/import_star/re_export_other_file_impor
 ## CIRCULAR_DEPENDENCY
 
 ```text
-[CIRCULAR_DEPENDENCY] Error: Circular dependency: foo.js -> foo.js.
+[CIRCULAR_DEPENDENCY] Warning: Circular dependency: foo.js -> foo.js.
 
 ```
 # Assets

--- a/crates/rolldown/tests/esbuild/import_star/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
@@ -3,6 +3,14 @@ source: crates/rolldown/tests/common/case.rs
 expression: content
 input_file: crates/rolldown/tests/esbuild/import_star/re_export_other_file_import_export_self_as_namespace_es6
 ---
+# warnings
+
+## CIRCULAR_DEPENDENCY
+
+```text
+[CIRCULAR_DEPENDENCY] Error: Circular dependency: foo.js -> foo.js.
+
+```
 # Assets
 
 ## entry_js.mjs

--- a/crates/rolldown/tests/fixtures/warnings/circular_dependency/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/warnings/circular_dependency/artifacts.snap
@@ -8,13 +8,13 @@ input_file: crates/rolldown/tests/fixtures/warnings/circular_dependency
 ## CIRCULAR_DEPENDENCY
 
 ```text
-[CIRCULAR_DEPENDENCY] Error: Circular dependency: foo.js -> main.js -> foo.js.
+[CIRCULAR_DEPENDENCY] Warning: Circular dependency: foo.js -> main.js -> foo.js.
 
 ```
 ## CIRCULAR_DEPENDENCY
 
 ```text
-[CIRCULAR_DEPENDENCY] Error: Circular dependency: entry.js -> foo.js -> entry.js.
+[CIRCULAR_DEPENDENCY] Warning: Circular dependency: entry.js -> foo.js -> entry.js.
 
 ```
 # Assets

--- a/crates/rolldown/tests/fixtures/warnings/circular_dependency/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/warnings/circular_dependency/artifacts.snap
@@ -1,0 +1,41 @@
+---
+source: crates/rolldown/tests/common/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/warnings/circular_dependency
+---
+# warnings
+
+## CIRCULAR_DEPENDENCY
+
+```text
+[CIRCULAR_DEPENDENCY] Error: Circular dependency: foo.js -> main.js -> foo.js.
+
+```
+## CIRCULAR_DEPENDENCY
+
+```text
+[CIRCULAR_DEPENDENCY] Error: Circular dependency: entry.js -> foo.js -> entry.js.
+
+```
+# Assets
+
+## entry.mjs
+
+```js
+
+```
+## main.mjs
+
+```js
+
+```
+## main_js.mjs
+
+```js
+// main.js
+
+// foo.js
+
+
+// entry.js
+```

--- a/crates/rolldown/tests/fixtures/warnings/circular_dependency/entry.js
+++ b/crates/rolldown/tests/fixtures/warnings/circular_dependency/entry.js
@@ -1,0 +1,1 @@
+import './foo'

--- a/crates/rolldown/tests/fixtures/warnings/circular_dependency/foo.js
+++ b/crates/rolldown/tests/fixtures/warnings/circular_dependency/foo.js
@@ -1,0 +1,2 @@
+import "./main";
+import "./entry";

--- a/crates/rolldown/tests/fixtures/warnings/circular_dependency/main.js
+++ b/crates/rolldown/tests/fixtures/warnings/circular_dependency/main.js
@@ -1,0 +1,1 @@
+import './foo'

--- a/crates/rolldown/tests/fixtures/warnings/circular_dependency/test.config.json
+++ b/crates/rolldown/tests/fixtures/warnings/circular_dependency/test.config.json
@@ -1,0 +1,15 @@
+{
+    "input": {
+        "input": [
+            {
+                "name": "entry",
+                "import": "entry.js"
+            },
+            {
+                "name": "main",
+                "import": "main.js"
+            }
+        ]
+    },
+    "expectExecuted": false
+}

--- a/crates/rolldown_error/src/error.rs
+++ b/crates/rolldown_error/src/error.rs
@@ -10,10 +10,10 @@ use oxc::span::Span;
 use crate::{
   diagnostic::Diagnostic,
   error_kind::{
-    external_entry::ExternalEntry, missing_export::MissingExport,
-    namespace_conflict::NamespaceConflict, unresolved_entry::UnresolvedEntry,
-    unresolved_import::UnresolvedImport, unsupported_eval::UnsupportedEval, BuildErrorLike,
-    NapiError,
+    circular_dependency::CircularDependency, external_entry::ExternalEntry,
+    missing_export::MissingExport, namespace_conflict::NamespaceConflict,
+    unresolved_entry::UnresolvedEntry, unresolved_import::UnresolvedImport,
+    unsupported_eval::UnsupportedEval, BuildErrorLike, NapiError,
   },
 };
 
@@ -132,6 +132,10 @@ impl BuildError {
       symbol,
       symbol_span,
     })
+  }
+
+  pub fn circular_dependency(paths: Vec<String>) -> Self {
+    Self::new_inner(CircularDependency { paths })
   }
 }
 

--- a/crates/rolldown_error/src/error_kind/circular_dependency.rs
+++ b/crates/rolldown_error/src/error_kind/circular_dependency.rs
@@ -1,0 +1,16 @@
+use super::BuildErrorLike;
+
+#[derive(Debug)]
+pub struct CircularDependency {
+  pub paths: Vec<String>,
+}
+
+impl BuildErrorLike for CircularDependency {
+  fn code(&self) -> &'static str {
+    "CIRCULAR_DEPENDENCY"
+  }
+
+  fn message(&self) -> String {
+    format!("Circular dependency: {}.", self.paths.join(" -> "))
+  }
+}

--- a/crates/rolldown_error/src/error_kind/mod.rs
+++ b/crates/rolldown_error/src/error_kind/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use crate::diagnostic::DiagnosticBuilder;
 
+pub mod circular_dependency;
 pub mod external_entry;
 pub mod missing_export;
 pub mod namespace_conflict;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Support warning for circular dependency, here is an example, esbuild is not doing it, it is done by rollup. The warning is important to let the user improve the code quality.

```text
[CIRCULAR_DEPENDENCY] Warning: Circular dependency: main.js -> foo.js -> main.js.
```
The implement is port from https://github.com/rollup/rollup/blob/master/src/utils/executionOrder.ts#L31, it is easy to compat rollup code(the rollup implement look like is wired, it may have special behavior, so here using it), but the current `sort_modules` function can't add the logic, so I add single check function.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Added.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
