### PR TITLE
feat: plugin context binding

### DIFF
--- a/crates/rolldown/src/bundler/plugin_driver/mod.rs
+++ b/crates/rolldown/src/bundler/plugin_driver/mod.rs
@@ -12,24 +12,26 @@ use crate::{
 pub type SharedPluginDriver = Arc<PluginDriver>;
 
 pub struct PluginDriver {
-  plugins: Vec<BoxPlugin>,
+  plugins: Vec<(BoxPlugin, PluginContext)>,
 }
 
 impl PluginDriver {
   pub fn new(plugins: Vec<BoxPlugin>) -> Self {
-    Self { plugins }
+    Self {
+      plugins: plugins.into_iter().map(|plugin| (plugin, PluginContext::new())).collect::<Vec<_>>(),
+    }
   }
 
   pub async fn build_start(&self) -> HookNoopReturn {
-    for plugin in &self.plugins {
-      plugin.build_start(&mut PluginContext::new()).await?;
+    for (plugin, ctx) in &self.plugins {
+      plugin.build_start(ctx).await?;
     }
     Ok(())
   }
 
   pub async fn resolve_id(&self, args: &HookResolveIdArgs<'_>) -> HookResolveIdReturn {
-    for plugin in &self.plugins {
-      if let Some(r) = plugin.resolve_id(&mut PluginContext::new(), args).await? {
+    for (plugin, ctx) in &self.plugins {
+      if let Some(r) = plugin.resolve_id(ctx, args).await? {
         return Ok(Some(r));
       }
     }
@@ -37,8 +39,8 @@ impl PluginDriver {
   }
 
   pub async fn load(&self, args: &HookLoadArgs<'_>) -> HookLoadReturn {
-    for plugin in &self.plugins {
-      if let Some(r) = plugin.load(&mut PluginContext::new(), args).await? {
+    for (plugin, ctx) in &self.plugins {
+      if let Some(r) = plugin.load(ctx, args).await? {
         return Ok(Some(r));
       }
     }
@@ -46,8 +48,8 @@ impl PluginDriver {
   }
 
   pub async fn transform(&self, args: &HookTransformArgs<'_>) -> HookTransformReturn {
-    for plugin in &self.plugins {
-      if let Some(r) = plugin.transform(&mut PluginContext::new(), args).await? {
+    for (plugin, ctx) in &self.plugins {
+      if let Some(r) = plugin.transform(ctx, args).await? {
         return Ok(Some(r));
       }
     }
@@ -55,8 +57,8 @@ impl PluginDriver {
   }
 
   pub async fn build_end(&self, args: Option<&HookBuildEndArgs>) -> HookNoopReturn {
-    for plugin in &self.plugins {
-      plugin.build_end(&mut PluginContext::new(), args).await?;
+    for (plugin, ctx) in &self.plugins {
+      plugin.build_end(ctx, args).await?;
     }
     Ok(())
   }

--- a/crates/rolldown/src/bundler/plugin_driver/mod.rs
+++ b/crates/rolldown/src/bundler/plugin_driver/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::{
   plugin::{
     args::HookBuildEndArgs,
+    context::TransformPluginContext,
     plugin::{BoxPlugin, HookNoopReturn},
   },
   HookLoadArgs, HookLoadReturn, HookResolveIdArgs, HookResolveIdReturn, HookTransformArgs,
@@ -49,7 +50,8 @@ impl PluginDriver {
 
   pub async fn transform(&self, args: &HookTransformArgs<'_>) -> HookTransformReturn {
     for (plugin, ctx) in &self.plugins {
-      if let Some(r) = plugin.transform(ctx, args).await? {
+      let context = TransformPluginContext::new(ctx);
+      if let Some(r) = plugin.transform(&context, args).await? {
         return Ok(Some(r));
       }
     }

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::{
       HookBuildEndArgs, HookLoadArgs, HookResolveIdArgs, HookResolveIdArgsOptions,
       HookTransformArgs,
     },
-    context::PluginContext,
+    context::{PluginContext, TransformPluginContext},
     output::{HookLoadOutput, HookResolveIdOutput},
     plugin::{
       BoxPlugin, HookLoadReturn, HookNoopReturn, HookResolveIdReturn, HookTransformReturn, Plugin,

--- a/crates/rolldown/src/plugin/context.rs
+++ b/crates/rolldown/src/plugin/context.rs
@@ -1,19 +1,10 @@
-/// [`PluginContext`] itself will carry some general data for all hooks and a `context` field for
-/// specific data for different hooks.
 #[derive(Debug, Default)]
-pub struct PluginContext<Ctx = ()> {
-  /// The field is used to pass specific context for different hooks.
-  pub context: Ctx,
-}
+pub struct PluginContext {}
 
 impl PluginContext {
   pub fn new() -> Self {
-    Self::with_context(())
+    Self {}
   }
-}
 
-impl<T> PluginContext<T> {
-  pub fn with_context(context: T) -> Self {
-    Self { context }
-  }
+  pub fn load(&self) {}
 }

--- a/crates/rolldown/src/plugin/context.rs
+++ b/crates/rolldown/src/plugin/context.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PluginContext {}
 
 impl PluginContext {
@@ -7,4 +7,15 @@ impl PluginContext {
   }
 
   pub fn load(&self) {}
+}
+
+#[derive(Debug)]
+pub struct TransformPluginContext<'a> {
+  pub inner: &'a PluginContext,
+}
+
+impl<'a> TransformPluginContext<'a> {
+  pub fn new(inner: &'a PluginContext) -> Self {
+    Self { inner }
+  }
 }

--- a/crates/rolldown/src/plugin/plugin.rs
+++ b/crates/rolldown/src/plugin/plugin.rs
@@ -19,25 +19,25 @@ pub trait Plugin: Debug + Send + Sync {
 
   // The `option` hook consider call at node side.
 
-  async fn build_start(&self, _ctx: &mut PluginContext) -> HookNoopReturn {
+  async fn build_start(&self, _ctx: &PluginContext) -> HookNoopReturn {
     Ok(())
   }
 
   async fn resolve_id(
     &self,
-    _ctx: &mut PluginContext,
+    _ctx: &PluginContext,
     _args: &HookResolveIdArgs,
   ) -> HookResolveIdReturn {
     Ok(None)
   }
 
-  async fn load(&self, _ctx: &mut PluginContext, _args: &HookLoadArgs) -> HookLoadReturn {
+  async fn load(&self, _ctx: &PluginContext, _args: &HookLoadArgs) -> HookLoadReturn {
     Ok(None)
   }
 
   async fn transform(
     &self,
-    _ctx: &mut PluginContext,
+    _ctx: &PluginContext,
     _args: &HookTransformArgs,
   ) -> HookTransformReturn {
     Ok(None)
@@ -45,7 +45,7 @@ pub trait Plugin: Debug + Send + Sync {
 
   async fn build_end(
     &self,
-    _ctx: &mut PluginContext,
+    _ctx: &PluginContext,
     _args: Option<&HookBuildEndArgs>,
   ) -> HookNoopReturn {
     Ok(())

--- a/crates/rolldown/src/plugin/plugin.rs
+++ b/crates/rolldown/src/plugin/plugin.rs
@@ -4,7 +4,7 @@ use rolldown_error::BuildError;
 
 use super::{
   args::{HookBuildEndArgs, HookLoadArgs, HookResolveIdArgs, HookTransformArgs},
-  context::PluginContext,
+  context::{PluginContext, TransformPluginContext},
   output::{HookLoadOutput, HookResolveIdOutput},
 };
 
@@ -37,7 +37,7 @@ pub trait Plugin: Debug + Send + Sync {
 
   async fn transform(
     &self,
-    _ctx: &PluginContext,
+    _ctx: &TransformPluginContext<'_>,
     _args: &HookTransformArgs,
   ) -> HookTransformReturn {
     Ok(None)

--- a/crates/rolldown_binding/index.d.ts
+++ b/crates/rolldown_binding/index.d.ts
@@ -14,7 +14,7 @@ export interface PluginOptions {
   ) => Promise<undefined | ResolveIdResult>
   load?: (ctx: PluginContext, id: string) => Promise<undefined | SourceResult>
   transform?: (
-    ctx: PluginContext,
+    ctx: TransformPluginContext,
     id: string,
     code: string,
   ) => Promise<undefined | SourceResult>
@@ -93,4 +93,7 @@ export class Bundler {
 }
 export class PluginContext {
   load(): Promise<void>
+}
+export class TransformPluginContext {
+  getCtx(): PluginContext
 }

--- a/crates/rolldown_binding/index.d.ts
+++ b/crates/rolldown_binding/index.d.ts
@@ -5,15 +5,20 @@
 
 export interface PluginOptions {
   name: string
-  buildStart?: () => Promise<void>
+  buildStart?: (ctx: PluginContext) => Promise<void>
   resolveId?: (
+    ctx: PluginContext,
     specifier: string,
     importer?: string,
     options?: HookResolveIdArgsOptions,
   ) => Promise<undefined | ResolveIdResult>
-  load?: (id: string) => Promise<undefined | SourceResult>
-  transform?: (id: string, code: string) => Promise<undefined | SourceResult>
-  buildEnd?: (error: string) => Promise<void>
+  load?: (ctx: PluginContext, id: string) => Promise<undefined | SourceResult>
+  transform?: (
+    ctx: PluginContext,
+    id: string,
+    code: string,
+  ) => Promise<undefined | SourceResult>
+  buildEnd?: (ctx: PluginContext, error: string) => Promise<void>
 }
 export interface HookResolveIdArgsOptions {
   isEntry: boolean
@@ -85,4 +90,7 @@ export class Bundler {
   generate(opts: OutputOptions): Promise<Outputs>
   build(): Promise<void>
   scan(): Promise<void>
+}
+export class PluginContext {
+  load(): Promise<void>
 }

--- a/crates/rolldown_binding/index.d.ts
+++ b/crates/rolldown_binding/index.d.ts
@@ -92,7 +92,7 @@ export class Bundler {
   scan(): Promise<void>
 }
 export class PluginContext {
-  load(): Promise<void>
+  load(): void
 }
 export class TransformPluginContext {
   getCtx(): PluginContext

--- a/crates/rolldown_binding/index.js
+++ b/crates/rolldown_binding/index.js
@@ -263,6 +263,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Bundler } = nativeBinding
+const { Bundler, PluginContext } = nativeBinding
 
 module.exports.Bundler = Bundler
+module.exports.PluginContext = PluginContext

--- a/crates/rolldown_binding/index.js
+++ b/crates/rolldown_binding/index.js
@@ -263,7 +263,8 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Bundler, PluginContext } = nativeBinding
+const { Bundler, PluginContext, TransformPluginContext } = nativeBinding
 
 module.exports.Bundler = Bundler
 module.exports.PluginContext = PluginContext
+module.exports.TransformPluginContext = TransformPluginContext

--- a/crates/rolldown_binding/src/options/input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/input_options/mod.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, fmt::Debug, path::PathBuf};
 mod plugin;
 mod plugin_adapter;
+mod plugin_context;
 use crate::utils::{napi_error_ext::NapiErrorExt, JsCallback};
 use derivative::Derivative;
 use napi::JsFunction;

--- a/crates/rolldown_binding/src/options/input_options/plugin.rs
+++ b/crates/rolldown_binding/src/options/input_options/plugin.rs
@@ -11,29 +11,31 @@ pub struct PluginOptions {
 
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "() => Promise<void>")]
+  #[napi(ts_type = "(ctx: PluginContext) => Promise<void>")]
   pub build_start: Option<JsFunction>,
 
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
   #[napi(
-    ts_type = "(specifier: string, importer?: string, options?: HookResolveIdArgsOptions) => Promise<undefined | ResolveIdResult>"
+    ts_type = "(ctx: PluginContext, specifier: string, importer?: string, options?: HookResolveIdArgsOptions) => Promise<undefined | ResolveIdResult>"
   )]
   pub resolve_id: Option<JsFunction>,
 
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(id: string) => Promise<undefined | SourceResult>")]
+  #[napi(ts_type = "(ctx: PluginContext, id: string) => Promise<undefined | SourceResult>")]
   pub load: Option<JsFunction>,
 
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(id: string, code: string) => Promise<undefined | SourceResult>")]
+  #[napi(
+    ts_type = "(ctx: PluginContext, id: string, code: string) => Promise<undefined | SourceResult>"
+  )]
   pub transform: Option<JsFunction>,
 
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(error: string) => Promise<void>")]
+  #[napi(ts_type = "(ctx: PluginContext, error: string) => Promise<void>")]
   pub build_end: Option<JsFunction>,
 }
 

--- a/crates/rolldown_binding/src/options/input_options/plugin.rs
+++ b/crates/rolldown_binding/src/options/input_options/plugin.rs
@@ -29,7 +29,7 @@ pub struct PluginOptions {
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
   #[napi(
-    ts_type = "(ctx: PluginContext, id: string, code: string) => Promise<undefined | SourceResult>"
+    ts_type = "(ctx: TransformPluginContext, id: string, code: string) => Promise<undefined | SourceResult>"
   )]
   pub transform: Option<JsFunction>,
 

--- a/crates/rolldown_binding/src/options/input_options/plugin_adapter.rs
+++ b/crates/rolldown_binding/src/options/input_options/plugin_adapter.rs
@@ -7,7 +7,7 @@ use rolldown::Plugin;
 
 use super::{
   plugin::{HookResolveIdArgsOptions, PluginOptions, ResolveIdResult, SourceResult},
-  plugin_context::PluginContext,
+  plugin_context::{PluginContext, TransformPluginContext},
 };
 
 pub type BuildStartCallback = JsCallback<(PluginContext,), ()>;
@@ -16,7 +16,8 @@ pub type ResolveIdCallback = JsCallback<
   Option<ResolveIdResult>,
 >;
 pub type LoadCallback = JsCallback<(PluginContext, String), Option<SourceResult>>;
-pub type TransformCallback = JsCallback<(PluginContext, String, String), Option<SourceResult>>;
+pub type TransformCallback =
+  JsCallback<(TransformPluginContext, String, String), Option<SourceResult>>;
 pub type BuildEndCallback = JsCallback<(PluginContext, Option<String>), ()>;
 
 #[derive(Derivative)]
@@ -114,7 +115,7 @@ impl Plugin for JsAdapterPlugin {
   #[allow(clippy::redundant_closure_for_method_calls)]
   async fn transform(
     &self,
-    ctx: &rolldown::PluginContext,
+    ctx: &rolldown::TransformPluginContext<'_>,
     args: &rolldown::HookTransformArgs,
   ) -> rolldown::HookTransformReturn {
     if let Some(cb) = &self.transform_fn {

--- a/crates/rolldown_binding/src/options/input_options/plugin_context.rs
+++ b/crates/rolldown_binding/src/options/input_options/plugin_context.rs
@@ -9,14 +9,33 @@ pub struct PluginContext {
 #[napi]
 impl PluginContext {
   #[napi]
-  pub async fn load(&self) -> napi::Result<()> {
+  pub fn load(&self) {
     self.inner.load();
-    Ok(())
   }
 }
 
 impl<'a> From<&'a rolldown::PluginContext> for PluginContext {
   fn from(inner: &'a rolldown::PluginContext) -> Self {
+    unsafe { Self { inner: std::mem::transmute(inner) } }
+  }
+}
+
+#[derive(Debug)]
+#[napi]
+pub struct TransformPluginContext {
+  inner: &'static rolldown::TransformPluginContext<'static>,
+}
+
+#[napi]
+impl TransformPluginContext {
+  #[napi]
+  pub fn get_ctx(&self) -> PluginContext {
+    self.inner.inner.into()
+  }
+}
+
+impl<'a> From<&'a rolldown::TransformPluginContext<'_>> for TransformPluginContext {
+  fn from(inner: &'a rolldown::TransformPluginContext) -> Self {
     unsafe { Self { inner: std::mem::transmute(inner) } }
   }
 }

--- a/crates/rolldown_binding/src/options/input_options/plugin_context.rs
+++ b/crates/rolldown_binding/src/options/input_options/plugin_context.rs
@@ -1,0 +1,22 @@
+use napi_derive::napi;
+
+#[derive(Debug)]
+#[napi]
+pub struct PluginContext {
+  inner: &'static rolldown::PluginContext,
+}
+
+#[napi]
+impl PluginContext {
+  #[napi]
+  pub async fn load(&self) -> napi::Result<()> {
+    self.inner.load();
+    Ok(())
+  }
+}
+
+impl<'a> From<&'a rolldown::PluginContext> for PluginContext {
+  fn from(inner: &'a rolldown::PluginContext) -> Self {
+    unsafe { Self { inner: std::mem::transmute(inner) } }
+  }
+}

--- a/crates/rolldown_plugin_hello/src/lib.rs
+++ b/crates/rolldown_plugin_hello/src/lib.rs
@@ -12,7 +12,7 @@ impl Plugin for HelloPlugin {
   }
 
   #[allow(clippy::print_stdout)]
-  async fn build_start(&self, _ctx: &mut PluginContext) -> HookNoopReturn {
+  async fn build_start(&self, _ctx: &PluginContext) -> HookNoopReturn {
     println!("hello");
     Ok(())
   }

--- a/crates/rolldown_plugin_vite_scanner/src/lib.rs
+++ b/crates/rolldown_plugin_vite_scanner/src/lib.rs
@@ -55,7 +55,7 @@ impl<T: FileSystem + 'static + Default> Plugin for ViteScannerPlugin<T> {
 
   async fn resolve_id(
     &self,
-    _ctx: &mut PluginContext,
+    _ctx: &PluginContext,
     args: &HookResolveIdArgs,
   ) -> HookResolveIdReturn {
     let HookResolveIdArgs { source, .. } = args;
@@ -94,7 +94,7 @@ impl<T: FileSystem + 'static + Default> Plugin for ViteScannerPlugin<T> {
     Ok(None)
   }
 
-  async fn load(&self, _ctx: &mut PluginContext, args: &HookLoadArgs) -> HookLoadReturn {
+  async fn load(&self, _ctx: &PluginContext, args: &HookLoadArgs) -> HookLoadReturn {
     let HookLoadArgs { id } = args;
 
     // extract scripts inside HTML-like files and treat it as a js module

--- a/packages/node/src/options/create-build-plugin-adapter.ts
+++ b/packages/node/src/options/create-build-plugin-adapter.ts
@@ -252,10 +252,10 @@ function normalizePluginContext(ctx: RolldownPluginContext): PluginContext {
 function normalizeTransformPluginContext(
   ctx: RolldownTransformPluginContext,
 ): TransformPluginContext {
-  return {
-    ...normalizePluginContext(ctx.getCtx()),
+  const inner = normalizePluginContext(ctx.getCtx())
+  return Object.assign(inner, {
     getCombinedSourcemap: () => {
       unimplemented()
     },
-  }
+  })
 }

--- a/packages/node/src/options/create-build-plugin-adapter.ts
+++ b/packages/node/src/options/create-build-plugin-adapter.ts
@@ -1,9 +1,19 @@
-import { Plugin, NormalizedInputOptions, PluginContext, RollupError, CustomPluginOptions, PartialNull, ModuleOptions, TransformPluginContext } from '../rollup-types'
+import {
+  Plugin,
+  NormalizedInputOptions,
+  PluginContext,
+  RollupError,
+  CustomPluginOptions,
+  PartialNull,
+  ModuleOptions,
+  TransformPluginContext,
+} from '../rollup-types'
 import type {
   PluginOptions,
   SourceResult,
   ResolveIdResult,
   PluginContext as RolldownPluginContext,
+  TransformPluginContext as RolldownTransformPluginContext,
 } from '@rolldown/node-binding'
 import { unimplemented } from '../utils'
 
@@ -49,7 +59,10 @@ function buildEnd(hook: Plugin['buildEnd']) {
     }
     return async (ctx: RolldownPluginContext, e: string) => {
       try {
-        await hook.call(normalizePluginContext(ctx), e ? new Error(e) : undefined)
+        await hook.call(
+          normalizePluginContext(ctx),
+          e ? new Error(e) : undefined,
+        )
       } catch (error) {
         console.error(error)
         throw error
@@ -64,13 +77,17 @@ function transform(hook: Plugin['transform']) {
       return unimplemented()
     }
     return async (
-      ctx: RolldownPluginContext,
+      ctx: RolldownTransformPluginContext,
       code: string,
       id: string,
     ): Promise<undefined | SourceResult> => {
       try {
         // TODO: Need to investigate how to pass context to plugin.
-        const value = await hook.call(normalizeTransformPluginContext(ctx), code, id)
+        const value = await hook.call(
+          normalizeTransformPluginContext(ctx),
+          code,
+          id,
+        )
         if (value === undefined || value === null) {
           return
         }
@@ -137,7 +154,10 @@ function load(hook: Plugin['load']) {
     if (typeof hook !== 'function') {
       return unimplemented()
     }
-    return async (ctx: RolldownPluginContext, id: string): Promise<undefined | SourceResult> => {
+    return async (
+      ctx: RolldownPluginContext,
+      id: string,
+    ): Promise<undefined | SourceResult> => {
       try {
         const value = await hook.call({} as any, id)
         if (value === undefined || value === null) {
@@ -159,7 +179,7 @@ function load(hook: Plugin['load']) {
   }
 }
 
-function normalizePluginContext(ctx: RolldownPluginContext): PluginContext  {
+function normalizePluginContext(ctx: RolldownPluginContext): PluginContext {
   return {
     get meta() {
       return unimplemented()
@@ -195,7 +215,9 @@ function normalizePluginContext(ctx: RolldownPluginContext): PluginContext  {
       unimplemented()
     },
     load: (
-      options: { id: string; resolveDependencies?: boolean } & Partial<PartialNull<ModuleOptions>>
+      options: { id: string; resolveDependencies?: boolean } & Partial<
+        PartialNull<ModuleOptions>
+      >,
     ) => {
       unimplemented()
     },
@@ -210,11 +232,11 @@ function normalizePluginContext(ctx: RolldownPluginContext): PluginContext  {
       source: string,
       importer?: string,
       options?: {
-        assertions?: Record<string, string>;
-        custom?: CustomPluginOptions;
-        isEntry?: boolean;
-        skipSelf?: boolean;
-      }
+        assertions?: Record<string, string>
+        custom?: CustomPluginOptions
+        isEntry?: boolean
+        skipSelf?: boolean
+      },
     ) => {
       unimplemented()
     },
@@ -227,11 +249,13 @@ function normalizePluginContext(ctx: RolldownPluginContext): PluginContext  {
   }
 }
 
-function normalizeTransformPluginContext(ctx: RolldownPluginContext): TransformPluginContext {
+function normalizeTransformPluginContext(
+  ctx: RolldownTransformPluginContext,
+): TransformPluginContext {
   return {
-    ...normalizePluginContext(ctx),
+    ...normalizePluginContext(ctx.getCtx()),
     getCombinedSourcemap: () => {
       unimplemented()
-    }
+    },
   }
 }

--- a/packages/node/src/rollup-types.ts
+++ b/packages/node/src/rollup-types.ts
@@ -9,4 +9,9 @@ export type {
   OutputChunk,
   NormalizedInputOptions,
   OutputAsset,
+  PluginContext,
+  RollupError,
+  CustomPluginOptions,
+  PartialNull, ModuleOptions,
+  TransformPluginContext
 } from 'rollup'

--- a/packages/node/src/rollup-types.ts
+++ b/packages/node/src/rollup-types.ts
@@ -12,6 +12,7 @@ export type {
   PluginContext,
   RollupError,
   CustomPluginOptions,
-  PartialNull, ModuleOptions,
-  TransformPluginContext
+  PartialNull,
+  ModuleOptions,
+  TransformPluginContext,
 } from 'rollup'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The rollup has tree kind of plugin context, here has some description.

- `PluginContext`, used at `buildStart/load/resolveId...` hooks
- `TransformPluginContext`, used at `transform` hook
- `MminimalPluginContext`, used at `options` hook

The derived relationship is `MminimalPluginContext` -> `PluginContext` -> `TransformPluginContext`, the `MminimalPluginContext` does not need implemented at the rust side because `options` hook is at js side. So the rust side only implement `PluginContext`/`TransformPluginContext` and binding.

The `PluginContext` is created for use in one the plugin's different hooks, because it's `cache` filed is isolate, ref https://github.com/rollup/rollup/blob/master/src/utils/PluginDriver.ts#L108.

The `TransformPluginContext` is derived from  `PluginContext`, it extends some methods and also overwrite some methods, you can see https://github.com/rollup/rollup/blob/master/src/utils/transform.ts#L108.

### Implement

The rust side is also implements `PluginContext`  and `TransformPluginContext`, using `PluginContext` to create `TransformPluginContext` and custom some methods. 

Here move `PluginContext` to immutable because its `cache` need to make sure it thread-safe.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Not need at now.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
