### PR TITLE
feat: implement plugin context resolve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "rolldown",
+ "rolldown_fs",
 ]
 
 [[package]]

--- a/crates/rolldown/src/bundler/module_loader/module_loader.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_loader.rs
@@ -48,7 +48,7 @@ pub struct ModuleLoaderOutput {
 impl<T: FileSystem + 'static + Default> ModuleLoader<T> {
   pub fn new(
     input_options: SharedInputOptions,
-    plugin_driver: SharedPluginDriver,
+    plugin_driver: SharedPluginDriver<T>,
     fs: T,
     resolver: SharedResolver<T>,
   ) -> Self {

--- a/crates/rolldown/src/bundler/module_loader/module_task_context.rs
+++ b/crates/rolldown/src/bundler/module_loader/module_task_context.rs
@@ -13,7 +13,7 @@ pub struct ModuleTaskCommonData<T: FileSystem + Default> {
   pub tx: tokio::sync::mpsc::UnboundedSender<Msg>,
   pub resolver: SharedResolver<T>,
   pub fs: T,
-  pub plugin_driver: SharedPluginDriver,
+  pub plugin_driver: SharedPluginDriver<T>,
 }
 
 impl<T: FileSystem + Default> ModuleTaskCommonData<T> {

--- a/crates/rolldown/src/bundler/stages/scan_stage.rs
+++ b/crates/rolldown/src/bundler/stages/scan_stage.rs
@@ -23,7 +23,7 @@ use crate::{
 
 pub struct ScanStage<Fs: FileSystem + Default> {
   input_options: SharedInputOptions,
-  plugin_driver: SharedPluginDriver,
+  plugin_driver: SharedPluginDriver<Fs>,
   fs: Fs,
   resolver: SharedResolver<Fs>,
 }
@@ -40,7 +40,7 @@ pub struct ScanStageOutput {
 impl<Fs: FileSystem + Default + 'static> ScanStage<Fs> {
   pub fn new(
     input_options: SharedInputOptions,
-    plugin_driver: SharedPluginDriver,
+    plugin_driver: SharedPluginDriver<Fs>,
     fs: Fs,
     resolver: SharedResolver<Fs>,
   ) -> Self {

--- a/crates/rolldown/src/bundler/utils/load_source.rs
+++ b/crates/rolldown/src/bundler/utils/load_source.rs
@@ -1,12 +1,13 @@
 use rolldown_common::FilePath;
+use rolldown_fs::FileSystem;
 use sugar_path::AsPath;
 
 use crate::{bundler::plugin_driver::PluginDriver, error::BatchedErrors, HookLoadArgs};
 
-pub async fn load_source(
-  plugin_driver: &PluginDriver,
+pub async fn load_source<T: FileSystem + Default + 'static>(
+  plugin_driver: &PluginDriver<T>,
   path: &FilePath,
-  fs: &dyn rolldown_fs::FileSystem,
+  fs: &T,
 ) -> Result<String, BatchedErrors> {
   let source = if let Some(r) = plugin_driver.load(&HookLoadArgs { id: path.as_ref() }).await? {
     r.code

--- a/crates/rolldown/src/bundler/utils/transform_source.rs
+++ b/crates/rolldown/src/bundler/utils/transform_source.rs
@@ -1,7 +1,9 @@
+use rolldown_fs::FileSystem;
+
 use crate::{bundler::plugin_driver::PluginDriver, error::BatchedErrors, HookTransformArgs};
 
-pub async fn transform_source(
-  plugin_driver: &PluginDriver,
+pub async fn transform_source<T: FileSystem + Default + 'static>(
+  plugin_driver: &PluginDriver<T>,
   mut source: String,
 ) -> Result<String, BatchedErrors> {
   if let Some(r) =

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::{
       HookBuildEndArgs, HookLoadArgs, HookResolveIdArgs, HookResolveIdArgsOptions,
       HookTransformArgs,
     },
-    context::{PluginContext, TransformPluginContext},
+    context::{PluginContext, ResolveId, TransformPluginContext},
     output::{HookLoadOutput, HookResolveIdOutput},
     plugin::{
       BoxPlugin, HookLoadReturn, HookNoopReturn, HookResolveIdReturn, HookTransformReturn, Plugin,

--- a/crates/rolldown/src/plugin/context.rs
+++ b/crates/rolldown/src/plugin/context.rs
@@ -1,21 +1,66 @@
-#[derive(Debug)]
-pub struct PluginContext {}
+use std::sync::Weak;
 
-impl PluginContext {
-  pub fn new() -> Self {
-    Self {}
+use rolldown_common::ImportKind;
+use rolldown_fs::FileSystem;
+
+use crate::{
+  bundler::{
+    options::input_options::SharedInputOptions, plugin_driver::PluginDriver,
+    utils::resolve_id::resolve_id_without_defaults,
+  },
+  error::BatchedResult,
+  HookResolveIdArgsOptions, SharedResolver,
+};
+
+#[derive(Debug)]
+pub struct PluginContext<T: FileSystem + Default> {
+  pub plugin_driver: Weak<PluginDriver<T>>,
+  pub input_options: SharedInputOptions,
+  pub resolver: SharedResolver<T>,
+}
+
+impl<T: FileSystem + Default + 'static> PluginContext<T> {
+  pub fn new(
+    plugin_driver: Weak<PluginDriver<T>>,
+    input_options: SharedInputOptions,
+    resolver: SharedResolver<T>,
+  ) -> Self {
+    Self { plugin_driver, input_options, resolver }
   }
 
   pub fn load(&self) {}
+
+  pub async fn resolve(
+    &self,
+    source: String,
+    importer: Option<String>,
+  ) -> BatchedResult<ResolveId> {
+    let plugin_driver = self.plugin_driver.upgrade().expect("should have plugin_driver");
+    let result = resolve_id_without_defaults(
+      &self.input_options,
+      &self.resolver,
+      &plugin_driver,
+      importer.map(std::convert::Into::into),
+      &source,
+      HookResolveIdArgsOptions { is_entry: false, kind: ImportKind::Import },
+    )
+    .await?;
+    Ok(ResolveId { external: result.is_external, id: result.path.to_string() })
+  }
+}
+
+pub struct ResolveId {
+  pub external: bool,
+  pub id: String,
 }
 
 #[derive(Debug)]
-pub struct TransformPluginContext<'a> {
-  pub inner: &'a PluginContext,
+pub struct TransformPluginContext<'a, T: FileSystem + Default> {
+  pub inner: &'a PluginContext<T>,
 }
 
-impl<'a> TransformPluginContext<'a> {
-  pub fn new(inner: &'a PluginContext) -> Self {
+impl<'a, T: FileSystem + Default + 'static> TransformPluginContext<'a, T> {
+  pub fn new(inner: &'a PluginContext<T>) -> Self {
     Self { inner }
   }
 }

--- a/crates/rolldown/src/plugin/plugin.rs
+++ b/crates/rolldown/src/plugin/plugin.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, fmt::Debug};
 
 use rolldown_error::BuildError;
+use rolldown_fs::FileSystem;
 
 use super::{
   args::{HookBuildEndArgs, HookLoadArgs, HookResolveIdArgs, HookTransformArgs},
@@ -14,30 +15,30 @@ pub type HookLoadReturn = Result<Option<HookLoadOutput>, BuildError>;
 pub type HookNoopReturn = Result<(), BuildError>;
 
 #[async_trait::async_trait]
-pub trait Plugin: Debug + Send + Sync {
+pub trait Plugin<T: FileSystem + Default>: Debug + Send + Sync {
   fn name(&self) -> Cow<'static, str>;
 
   // The `option` hook consider call at node side.
 
-  async fn build_start(&self, _ctx: &PluginContext) -> HookNoopReturn {
+  async fn build_start(&self, _ctx: &PluginContext<T>) -> HookNoopReturn {
     Ok(())
   }
 
   async fn resolve_id(
     &self,
-    _ctx: &PluginContext,
+    _ctx: &PluginContext<T>,
     _args: &HookResolveIdArgs,
   ) -> HookResolveIdReturn {
     Ok(None)
   }
 
-  async fn load(&self, _ctx: &PluginContext, _args: &HookLoadArgs) -> HookLoadReturn {
+  async fn load(&self, _ctx: &PluginContext<T>, _args: &HookLoadArgs) -> HookLoadReturn {
     Ok(None)
   }
 
   async fn transform(
     &self,
-    _ctx: &TransformPluginContext<'_>,
+    _ctx: &TransformPluginContext<T, '_>,
     _args: &HookTransformArgs,
   ) -> HookTransformReturn {
     Ok(None)
@@ -45,11 +46,11 @@ pub trait Plugin: Debug + Send + Sync {
 
   async fn build_end(
     &self,
-    _ctx: &PluginContext,
+    _ctx: &PluginContext<T>,
     _args: Option<&HookBuildEndArgs>,
   ) -> HookNoopReturn {
     Ok(())
   }
 }
 
-pub type BoxPlugin = Box<dyn Plugin>;
+pub type BoxPlugin<T> = Box<dyn Plugin<T>>;

--- a/crates/rolldown_binding/index.d.ts
+++ b/crates/rolldown_binding/index.d.ts
@@ -31,6 +31,10 @@ export interface ResolveIdResult {
 export interface SourceResult {
   code: string
 }
+export interface ResolveId {
+  external: boolean
+  id: string
+}
 export interface InputItem {
   name?: string
   import: string
@@ -93,6 +97,10 @@ export class Bundler {
 }
 export class PluginContext {
   load(): void
+  resolve(
+    source: string,
+    importer?: string | undefined | null,
+  ): Promise<ResolveId>
 }
 export class TransformPluginContext {
   getCtx(): PluginContext

--- a/crates/rolldown_binding/src/options/input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/input_options/mod.rs
@@ -7,6 +7,7 @@ use derivative::Derivative;
 use napi::JsFunction;
 use napi_derive::napi;
 
+use rolldown_fs::OsFileSystem;
 use serde::Deserialize;
 
 use crate::options::input_options::plugin_adapter::JsAdapterPlugin;
@@ -106,7 +107,7 @@ pub struct InputOptions {
 
 #[allow(clippy::redundant_closure_for_method_calls)]
 impl From<InputOptions>
-  for (napi::Result<rolldown::InputOptions>, napi::Result<Vec<rolldown::BoxPlugin>>)
+  for (napi::Result<rolldown::InputOptions>, napi::Result<Vec<rolldown::BoxPlugin<OsFileSystem>>>)
 {
   fn from(value: InputOptions) -> Self {
     let cwd = PathBuf::from(value.cwd.clone());

--- a/crates/rolldown_binding/src/options/input_options/plugin_context.rs
+++ b/crates/rolldown_binding/src/options/input_options/plugin_context.rs
@@ -1,9 +1,12 @@
+use derivative::Derivative;
 use napi_derive::napi;
+use rolldown_fs::OsFileSystem;
+use serde::Deserialize;
 
 #[derive(Debug)]
 #[napi]
 pub struct PluginContext {
-  inner: &'static rolldown::PluginContext,
+  inner: &'static rolldown::PluginContext<OsFileSystem>,
 }
 
 #[napi]
@@ -12,18 +15,47 @@ impl PluginContext {
   pub fn load(&self) {
     self.inner.load();
   }
+
+  #[napi]
+  pub async fn resolve(&self, source: String, importer: Option<String>) -> napi::Result<ResolveId> {
+    let result = self.inner.resolve(source, importer).await;
+
+    match result {
+      Ok(value) => Ok(value.into()),
+      Err(err) => {
+        // TODO: better handing errors
+        eprintln!("{err:?}");
+        Err(napi::Error::from_reason("Build failed"))
+      }
+    }
+  }
 }
 
-impl<'a> From<&'a rolldown::PluginContext> for PluginContext {
-  fn from(inner: &'a rolldown::PluginContext) -> Self {
+impl<'a> From<&'a rolldown::PluginContext<OsFileSystem>> for PluginContext {
+  fn from(inner: &'a rolldown::PluginContext<OsFileSystem>) -> Self {
     unsafe { Self { inner: std::mem::transmute(inner) } }
+  }
+}
+
+#[napi_derive::napi(object)]
+#[derive(Deserialize, Default, Derivative)]
+#[serde(rename_all = "camelCase")]
+#[derivative(Debug)]
+pub struct ResolveId {
+  pub external: bool,
+  pub id: String,
+}
+
+impl From<rolldown::ResolveId> for ResolveId {
+  fn from(value: rolldown::ResolveId) -> Self {
+    Self { external: value.external, id: value.id }
   }
 }
 
 #[derive(Debug)]
 #[napi]
 pub struct TransformPluginContext {
-  inner: &'static rolldown::TransformPluginContext<'static>,
+  inner: &'static rolldown::TransformPluginContext<OsFileSystem, 'static>,
 }
 
 #[napi]
@@ -34,8 +66,8 @@ impl TransformPluginContext {
   }
 }
 
-impl<'a> From<&'a rolldown::TransformPluginContext<'_>> for TransformPluginContext {
-  fn from(inner: &'a rolldown::TransformPluginContext) -> Self {
+impl<'a> From<&'a rolldown::TransformPluginContext<'_, OsFileSystem>> for TransformPluginContext {
+  fn from(inner: &'a rolldown::TransformPluginContext<OsFileSystem>) -> Self {
     unsafe { Self { inner: std::mem::transmute(inner) } }
   }
 }

--- a/crates/rolldown_fs/src/os.rs
+++ b/crates/rolldown_fs/src/os.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::file_system::FileSystem;
 
 /// Operating System
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct OsFileSystem;
 
 impl FileSystem for OsFileSystem {

--- a/crates/rolldown_plugin_hello/Cargo.toml
+++ b/crates/rolldown_plugin_hello/Cargo.toml
@@ -13,4 +13,5 @@ workspace = true
 
 [dependencies]
 rolldown    = { path = "../rolldown" }
+rolldown_fs = { path = "../rolldown_fs" }
 async-trait = { workspace = true }

--- a/crates/rolldown_plugin_hello/src/lib.rs
+++ b/crates/rolldown_plugin_hello/src/lib.rs
@@ -1,18 +1,18 @@
-use std::borrow::Cow;
-
 use rolldown::{HookNoopReturn, Plugin, PluginContext};
+use rolldown_fs::FileSystem;
+use std::borrow::Cow;
 
 #[derive(Debug)]
 pub struct HelloPlugin;
 
 #[async_trait::async_trait]
-impl Plugin for HelloPlugin {
+impl<T: FileSystem + 'static + Default> Plugin<T> for HelloPlugin {
   fn name(&self) -> Cow<'static, str> {
     "hello".into()
   }
 
   #[allow(clippy::print_stdout)]
-  async fn build_start(&self, _ctx: &PluginContext) -> HookNoopReturn {
+  async fn build_start(&self, _ctx: &PluginContext<T>) -> HookNoopReturn {
     println!("hello");
     Ok(())
   }

--- a/crates/rolldown_plugin_vite_scanner/src/lib.rs
+++ b/crates/rolldown_plugin_vite_scanner/src/lib.rs
@@ -48,14 +48,14 @@ impl<T: FileSystem + 'static + Default> Debug for ViteScannerPlugin<T> {
 }
 
 #[async_trait::async_trait]
-impl<T: FileSystem + 'static + Default> Plugin for ViteScannerPlugin<T> {
+impl<T: FileSystem + 'static + Default> Plugin<T> for ViteScannerPlugin<T> {
   fn name(&self) -> Cow<'static, str> {
     "rolldown_plugin_vite_scanner".into()
   }
 
   async fn resolve_id(
     &self,
-    _ctx: &PluginContext,
+    _ctx: &PluginContext<T>,
     args: &HookResolveIdArgs,
   ) -> HookResolveIdReturn {
     let HookResolveIdArgs { source, .. } = args;
@@ -94,7 +94,7 @@ impl<T: FileSystem + 'static + Default> Plugin for ViteScannerPlugin<T> {
     Ok(None)
   }
 
-  async fn load(&self, _ctx: &PluginContext, args: &HookLoadArgs) -> HookLoadReturn {
+  async fn load(&self, _ctx: &PluginContext<T>, args: &HookLoadArgs) -> HookLoadReturn {
     let HookLoadArgs { id } = args;
 
     // extract scripts inside HTML-like files and treat it as a js module

--- a/packages/node/src/options/create-build-plugin-adapter.ts
+++ b/packages/node/src/options/create-build-plugin-adapter.ts
@@ -228,7 +228,7 @@ function normalizePluginContext(ctx: RolldownPluginContext): PluginContext {
     parse: (input: string, options?: any) => {
       unimplemented()
     },
-    resolve: (
+    resolve: async (
       source: string,
       importer?: string,
       options?: {
@@ -238,7 +238,29 @@ function normalizePluginContext(ctx: RolldownPluginContext): PluginContext {
         skipSelf?: boolean
       },
     ) => {
-      unimplemented()
+      if (options) {
+        unimplemented()
+      }
+      let result = await ctx.resolve(source, importer)
+      return {
+        external: result.external,
+        id: result.id,
+        get resolvedBy() {
+          return unimplemented()
+        },
+        get assertions() {
+          return unimplemented()
+        },
+        get meta() {
+          return unimplemented()
+        },
+        get moduleSideEffects() {
+          return unimplemented()
+        },
+        get syntheticNamedExports() {
+          return unimplemented()
+        },
+      }
     },
     setAssetSource: (assetReferenceId: string, source: string | Uint8Array) => {
       unimplemented()

--- a/packages/node/test/cases/plugin-context/resolve/config.ts
+++ b/packages/node/test/cases/plugin-context/resolve/config.ts
@@ -1,0 +1,23 @@
+import type { RollupOptions } from '@rolldown/node'
+import { PluginContext } from 'rollup'
+import { expect } from 'vitest'
+import path from 'path'
+
+const config: RollupOptions = {
+  plugins: [
+    {
+      name: 'test-plugin-context',
+      buildStart: async function (this: PluginContext) {
+        const value = await this.resolve(
+          './main.js',
+          path.join(__dirname, './main.js'),
+        )
+        expect(value!.id).toBe(path.join(__dirname, './main.js'))
+      },
+    },
+  ],
+}
+
+export default {
+  config,
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `PluginContext` provide a `resolve` method to resolve some path including the plugin resolve hook and default resolver. Here is a struct cycle at  `PluginContext`  and `PluginDriver` because the `resolve` will run plugin resolve hooks.

We can implement it has some choice.

1. The binding exposes the `resolve` method but it implemented other ways to avoid the struct cycle at  `PluginContext`  and `PluginDriver`. 
But it caused some differences between the `PluginContext` struct and the `BindingPluginContext` struct. It will increase the cost of understanding code and difficult to maintain it. 

2. Using `Arc:: new_cyclic ` to implement this, but it will make the `Plugin/PluginDriver` struct need to care about the `FileSystem` generic type.


The pr is to implement the `2`, because it is more clear for struct and feature.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Added.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
