### PR TITLE
feat: render chunk hook binding

### DIFF
--- a/crates/rolldown/src/bundler/bundle/output.rs
+++ b/crates/rolldown/src/bundler/bundle/output.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RenderedModule {
   // The code of the module is omit at now.
   pub original_length: u32,

--- a/crates/rolldown/src/bundler/bundler.rs
+++ b/crates/rolldown/src/bundler/bundler.rs
@@ -176,8 +176,9 @@ impl<T: FileSystem + Default + 'static> Bundler<T> {
     tracing::trace!("InputOptions {:#?}", self.input_options);
     tracing::trace!("OutputOptions: {output_options:#?}",);
     let graph = self.build_result.as_mut().expect("Build should success");
-    let mut bundle_stage = BundleStage::new(graph, &self.input_options, &output_options);
-    let assets = bundle_stage.bundle();
+    let mut bundle_stage =
+      BundleStage::new(graph, &self.input_options, &output_options, &self.plugin_driver);
+    let assets = bundle_stage.bundle().await?;
 
     Ok(RolldownOutput { warnings: std::mem::take(&mut graph.warnings), assets })
   }

--- a/crates/rolldown/src/bundler/chunk/mod.rs
+++ b/crates/rolldown/src/bundler/chunk/mod.rs
@@ -1,9 +1,9 @@
 #[allow(clippy::module_inception)]
 pub mod chunk;
 mod de_conflict;
+pub mod render_chunk;
 mod render_chunk_exports;
 mod render_chunk_imports;
-
 use index_vec::IndexVec;
 
 use self::chunk::Chunk;

--- a/crates/rolldown/src/bundler/chunk/render_chunk.rs
+++ b/crates/rolldown/src/bundler/chunk/render_chunk.rs
@@ -1,0 +1,70 @@
+use rolldown_common::EntryPointKind;
+use rustc_hash::FxHashMap;
+
+use crate::{bundler::stages::link_stage::LinkStageOutput, OutputOptions, RenderedModule};
+
+use super::chunk::Chunk;
+
+#[derive(Debug, Clone)]
+pub struct PreRenderedChunk {
+  // pub name: String,
+  pub is_entry: bool,
+  pub is_dynamic_entry: bool,
+  pub facade_module_id: Option<String>,
+  pub module_ids: Vec<String>,
+  pub exports: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RenderedChunk {
+  // PreRenderedChunk
+  pub is_entry: bool,
+  pub is_dynamic_entry: bool,
+  pub facade_module_id: Option<String>,
+  pub module_ids: Vec<String>,
+  pub exports: Vec<String>,
+  // RenderedChunk
+  pub file_name: String,
+  pub modules: FxHashMap<String, RenderedModule>,
+}
+
+impl Chunk {
+  pub fn get_pre_rendered_chunk_info(
+    &self,
+    graph: &LinkStageOutput,
+    output_options: &OutputOptions,
+  ) -> PreRenderedChunk {
+    PreRenderedChunk {
+      is_entry: matches!(&self.entry_point, Some(e) if e.kind == EntryPointKind::UserDefined),
+      is_dynamic_entry: matches!(&self.entry_point, Some(e) if e.kind == EntryPointKind::DynamicImport),
+      facade_module_id: self
+        .entry_point
+        .as_ref()
+        .map(|entry_point| graph.modules[entry_point.id].expect_normal().pretty_path.to_string()),
+      module_ids: self
+        .modules
+        .iter()
+        .map(|id| graph.modules[*id].expect_normal().pretty_path.to_string())
+        .collect(),
+      exports: self.get_export_names(graph, output_options),
+    }
+  }
+
+  pub fn get_rendered_chunk_info(
+    &self,
+    graph: &LinkStageOutput,
+    output_options: &OutputOptions,
+    render_modules: FxHashMap<String, RenderedModule>,
+  ) -> RenderedChunk {
+    let pre_rendered_chunk = self.get_pre_rendered_chunk_info(graph, output_options);
+    RenderedChunk {
+      is_entry: pre_rendered_chunk.is_entry,
+      is_dynamic_entry: pre_rendered_chunk.is_dynamic_entry,
+      facade_module_id: pre_rendered_chunk.facade_module_id,
+      module_ids: pre_rendered_chunk.module_ids,
+      exports: pre_rendered_chunk.exports,
+      file_name: self.file_name.clone().expect("should have file name"),
+      modules: render_modules,
+    }
+  }
+}

--- a/crates/rolldown/src/bundler/chunk/render_chunk.rs
+++ b/crates/rolldown/src/bundler/chunk/render_chunk.rs
@@ -40,11 +40,11 @@ impl Chunk {
       facade_module_id: self
         .entry_point
         .as_ref()
-        .map(|entry_point| graph.modules[entry_point.id].expect_normal().pretty_path.to_string()),
+        .map(|entry_point| graph.modules[entry_point.id].resource_id().expect_file().to_string()),
       module_ids: self
         .modules
         .iter()
-        .map(|id| graph.modules[*id].expect_normal().pretty_path.to_string())
+        .map(|id| graph.modules[*id].resource_id().expect_file().to_string())
         .collect(),
       exports: self.get_export_names(graph, output_options),
     }

--- a/crates/rolldown/src/bundler/mod.rs
+++ b/crates/rolldown/src/bundler/mod.rs
@@ -2,7 +2,7 @@ mod ast_scanner;
 pub mod bundle;
 #[allow(clippy::module_inception)]
 pub mod bundler;
-mod chunk;
+pub mod chunk;
 mod chunk_graph;
 mod linker;
 mod module;

--- a/crates/rolldown/src/bundler/module/mod.rs
+++ b/crates/rolldown/src/bundler/module/mod.rs
@@ -44,7 +44,7 @@ impl Module {
     }
   }
 
-  pub fn expect_normal(&self) -> &NormalModule {
+  pub fn _expect_normal(&self) -> &NormalModule {
     match self {
       Self::Normal(m) => m,
       Self::External(_) => unreachable!(),

--- a/crates/rolldown/src/bundler/plugin_driver/mod.rs
+++ b/crates/rolldown/src/bundler/plugin_driver/mod.rs
@@ -1,14 +1,12 @@
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 use rolldown_error::BuildError;
-use rolldown_fs::FileSystem;
 
 use rolldown_error::BuildError;
 
 use crate::{
   plugin::{
     args::{HookBuildEndArgs, RenderChunkArgs},
-    context::TransformPluginContext,
     plugin::{BoxPlugin, HookNoopReturn},
   },
   HookLoadArgs, HookLoadReturn, HookResolveIdArgs, HookResolveIdReturn, HookTransformArgs,
@@ -67,9 +65,10 @@ impl PluginDriver {
     Ok(())
   }
 
+  #[allow(dead_code)]
   pub async fn render_chunk(&self, mut args: RenderChunkArgs) -> Result<String, BuildError> {
-    for (plugin, ctx) in &self.plugins {
-      if let Some(r) = plugin.render_chunk(ctx, &args).await? {
+    for plugin in &self.plugins {
+      if let Some(r) = plugin.render_chunk(&PluginContext::new(), &args).await? {
         args.code = r.code;
       }
     }

--- a/crates/rolldown/src/bundler/plugin_driver/mod.rs
+++ b/crates/rolldown/src/bundler/plugin_driver/mod.rs
@@ -65,8 +65,7 @@ impl PluginDriver {
     Ok(())
   }
 
-  #[allow(dead_code)]
-  pub async fn render_chunk(&self, mut args: RenderChunkArgs) -> Result<String, BuildError> {
+  pub async fn render_chunk(&self, mut args: RenderChunkArgs<'_>) -> Result<String, BuildError> {
     for plugin in &self.plugins {
       if let Some(r) = plugin.render_chunk(&PluginContext::new(), &args).await? {
         args.code = r.code;

--- a/crates/rolldown/src/bundler/plugin_driver/mod.rs
+++ b/crates/rolldown/src/bundler/plugin_driver/mod.rs
@@ -1,10 +1,14 @@
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
+
+use rolldown_error::BuildError;
+use rolldown_fs::FileSystem;
 
 use rolldown_error::BuildError;
 
 use crate::{
   plugin::{
     args::{HookBuildEndArgs, RenderChunkArgs},
+    context::TransformPluginContext,
     plugin::{BoxPlugin, HookNoopReturn},
   },
   HookLoadArgs, HookLoadReturn, HookResolveIdArgs, HookResolveIdReturn, HookTransformArgs,
@@ -63,10 +67,9 @@ impl PluginDriver {
     Ok(())
   }
 
-  #[allow(dead_code)]
   pub async fn render_chunk(&self, mut args: RenderChunkArgs) -> Result<String, BuildError> {
-    for plugin in &self.plugins {
-      if let Some(r) = plugin.render_chunk(&PluginContext::new(), &args).await? {
+    for (plugin, ctx) in &self.plugins {
+      if let Some(r) = plugin.render_chunk(ctx, &args).await? {
         args.code = r.code;
       }
     }

--- a/crates/rolldown/src/bundler/plugin_driver/mod.rs
+++ b/crates/rolldown/src/bundler/plugin_driver/mod.rs
@@ -2,8 +2,6 @@ use std::sync::Arc;
 
 use rolldown_error::BuildError;
 
-use rolldown_error::BuildError;
-
 use crate::{
   plugin::{
     args::{HookBuildEndArgs, RenderChunkArgs},

--- a/crates/rolldown/src/bundler/stages/bundle_stage.rs
+++ b/crates/rolldown/src/bundler/stages/bundle_stage.rs
@@ -19,22 +19,21 @@ use crate::{
 };
 use index_vec::{index_vec, IndexVec};
 use rolldown_common::{EntryPointKind, ExportsKind, ImportKind, ModuleId, NamedImport, SymbolRef};
-use rolldown_fs::FileSystem;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-pub struct BundleStage<'a, T: FileSystem + Default> {
+pub struct BundleStage<'a> {
   link_output: &'a mut LinkStageOutput,
   output_options: &'a OutputOptions,
   input_options: &'a InputOptions,
-  plugin_driver: &'a SharedPluginDriver<T>,
+  plugin_driver: &'a SharedPluginDriver,
 }
 
-impl<'a, T: FileSystem + Default + 'static> BundleStage<'a, T> {
+impl<'a> BundleStage<'a> {
   pub fn new(
     link_output: &'a mut LinkStageOutput,
     input_options: &'a InputOptions,
     output_options: &'a OutputOptions,
-    plugin_driver: &'a SharedPluginDriver<T>,
+    plugin_driver: &'a SharedPluginDriver,
   ) -> Self {
     Self { link_output, output_options, input_options, plugin_driver }
   }

--- a/crates/rolldown/src/bundler/stages/scan_stage.rs
+++ b/crates/rolldown/src/bundler/stages/scan_stage.rs
@@ -17,7 +17,7 @@ use crate::{
       symbols::Symbols,
     },
   },
-  error::{collect_result_and_errors, BatchedResult},
+  error::{into_batched_result, BatchedResult},
   HookResolveIdArgsOptions, SharedResolver,
 };
 
@@ -101,6 +101,6 @@ impl<Fs: FileSystem + Default + 'static> ScanStage<Fs> {
         }
       }));
 
-    collect_result_and_errors(resolved_ids)
+    into_batched_result(resolved_ids)
   }
 }

--- a/crates/rolldown/src/bundler/stages/scan_stage.rs
+++ b/crates/rolldown/src/bundler/stages/scan_stage.rs
@@ -17,7 +17,7 @@ use crate::{
       symbols::Symbols,
     },
   },
-  error::{collect_errors, BatchedResult},
+  error::{collect_result_and_errors, BatchedResult},
   HookResolveIdArgsOptions, SharedResolver,
 };
 
@@ -101,6 +101,6 @@ impl<Fs: FileSystem + Default + 'static> ScanStage<Fs> {
         }
       }));
 
-    collect_errors(resolved_ids)
+    collect_result_and_errors(resolved_ids)
   }
 }

--- a/crates/rolldown/src/bundler/utils/render_chunks.rs
+++ b/crates/rolldown/src/bundler/utils/render_chunks.rs
@@ -1,19 +1,25 @@
 use rolldown_utils::block_on_spawn_all;
 
 use crate::{
-  bundler::{chunk::ChunkId, plugin_driver::PluginDriver},
+  bundler::{chunk::render_chunk::RenderedChunk, plugin_driver::SharedPluginDriver},
   error::{collect_errors, BatchedErrors},
   plugin::args::RenderChunkArgs,
 };
 
-#[allow(clippy::unused_async)]
-pub async fn _render_chunks<'a>(
-  plugin_driver: &PluginDriver,
-  chunks: Vec<(ChunkId, String)>,
-) -> Result<Vec<(ChunkId, String)>, BatchedErrors> {
-  let result = block_on_spawn_all(chunks.iter().map(|(chunk, content)| async move {
-    match plugin_driver.render_chunk(RenderChunkArgs { code: content.to_string() }).await {
-      Ok(value) => Ok((*chunk, value)),
+#[allow(clippy::future_not_send)]
+pub async fn render_chunks<'a, T: FileSystem + Default + 'static>(
+  plugin_driver: &SharedPluginDriver<T>,
+  chunks: impl Iterator<Item = (String, RenderedChunk)>,
+) -> Result<Vec<(String, RenderedChunk)>, BatchedErrors> {
+  let result = block_on_spawn_all(chunks.map(|(content, rendered_chunk)| async move {
+    match plugin_driver
+      .render_chunk(RenderChunkArgs {
+        code: content,
+        chunk: unsafe { std::mem::transmute(&rendered_chunk) },
+      })
+      .await
+    {
+      Ok(value) => Ok((value, rendered_chunk)),
       Err(e) => Err(e),
     }
   }));

--- a/crates/rolldown/src/bundler/utils/render_chunks.rs
+++ b/crates/rolldown/src/bundler/utils/render_chunks.rs
@@ -2,7 +2,7 @@ use rolldown_utils::block_on_spawn_all;
 
 use crate::{
   bundler::{chunk::render_chunk::RenderedChunk, plugin_driver::SharedPluginDriver},
-  error::{collect_result_and_errors, BatchedErrors},
+  error::{into_batched_result, BatchedErrors},
   plugin::args::RenderChunkArgs,
 };
 
@@ -24,5 +24,5 @@ pub async fn render_chunks<'a, T: FileSystem + Default + 'static>(
     }
   }));
 
-  collect_result_and_errors(result)
+  into_batched_result(result)
 }

--- a/crates/rolldown/src/bundler/utils/render_chunks.rs
+++ b/crates/rolldown/src/bundler/utils/render_chunks.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 
 #[allow(clippy::future_not_send)]
-pub async fn render_chunks<'a, T: FileSystem + Default + 'static>(
-  plugin_driver: &SharedPluginDriver<T>,
+pub async fn render_chunks<'a>(
+  plugin_driver: &SharedPluginDriver,
   chunks: impl Iterator<Item = (String, RenderedChunk)>,
 ) -> Result<Vec<(String, RenderedChunk)>, BatchedErrors> {
   let result = block_on_spawn_all(chunks.map(|(content, rendered_chunk)| async move {

--- a/crates/rolldown/src/bundler/utils/render_chunks.rs
+++ b/crates/rolldown/src/bundler/utils/render_chunks.rs
@@ -1,4 +1,3 @@
-use rolldown_fs::FileSystem;
 use rolldown_utils::block_on_spawn_all;
 
 use crate::{
@@ -8,8 +7,8 @@ use crate::{
 };
 
 #[allow(clippy::unused_async)]
-pub async fn _render_chunks<'a, T: FileSystem + Default + 'static>(
-  plugin_driver: &PluginDriver<T>,
+pub async fn _render_chunks<'a>(
+  plugin_driver: &PluginDriver,
   chunks: Vec<(ChunkId, String)>,
 ) -> Result<Vec<(ChunkId, String)>, BatchedErrors> {
   let result = block_on_spawn_all(chunks.iter().map(|(chunk, content)| async move {

--- a/crates/rolldown/src/bundler/utils/render_chunks.rs
+++ b/crates/rolldown/src/bundler/utils/render_chunks.rs
@@ -2,7 +2,7 @@ use rolldown_utils::block_on_spawn_all;
 
 use crate::{
   bundler::{chunk::render_chunk::RenderedChunk, plugin_driver::SharedPluginDriver},
-  error::{collect_errors, BatchedErrors},
+  error::{collect_result_and_errors, BatchedErrors},
   plugin::args::RenderChunkArgs,
 };
 
@@ -24,5 +24,5 @@ pub async fn render_chunks<'a, T: FileSystem + Default + 'static>(
     }
   }));
 
-  collect_errors(result)
+  collect_result_and_errors(result)
 }

--- a/crates/rolldown/src/bundler/utils/render_chunks.rs
+++ b/crates/rolldown/src/bundler/utils/render_chunks.rs
@@ -1,3 +1,4 @@
+use rolldown_fs::FileSystem;
 use rolldown_utils::block_on_spawn_all;
 
 use crate::{
@@ -7,8 +8,8 @@ use crate::{
 };
 
 #[allow(clippy::unused_async)]
-pub async fn _render_chunks<'a>(
-  plugin_driver: &PluginDriver,
+pub async fn _render_chunks<'a, T: FileSystem + Default + 'static>(
+  plugin_driver: &PluginDriver<T>,
   chunks: Vec<(ChunkId, String)>,
 ) -> Result<Vec<(ChunkId, String)>, BatchedErrors> {
   let result = block_on_spawn_all(chunks.iter().map(|(chunk, content)| async move {

--- a/crates/rolldown/src/error.rs
+++ b/crates/rolldown/src/error.rs
@@ -38,7 +38,7 @@ impl BatchedErrors {
   }
 }
 
-pub fn collect_result_and_errors<T>(value: Vec<Result<T, BuildError>>) -> BatchedResult<Vec<T>> {
+pub fn into_batched_result<T>(value: Vec<Result<T, BuildError>>) -> BatchedResult<Vec<T>> {
   let mut errors = BatchedErrors::default();
 
   let collected = value.into_iter().filter_map(|item| errors.take_err_from(item)).collect();

--- a/crates/rolldown/src/error.rs
+++ b/crates/rolldown/src/error.rs
@@ -38,7 +38,7 @@ impl BatchedErrors {
   }
 }
 
-pub fn collect_errors<T>(value: Vec<Result<T, BuildError>>) -> BatchedResult<Vec<T>> {
+pub fn collect_result_and_errors<T>(value: Vec<Result<T, BuildError>>) -> BatchedResult<Vec<T>> {
   let mut errors = BatchedErrors::default();
 
   let collected = value.into_iter().filter_map(|item| errors.take_err_from(item)).collect();

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::{
       HookBuildEndArgs, HookLoadArgs, HookResolveIdArgs, HookResolveIdArgsOptions,
       HookTransformArgs,
     },
-    context::PluginContext,
+    context::{PluginContext, ResolveId, TransformPluginContext},
     output::{HookLoadOutput, HookRenderChunkOutput, HookResolveIdOutput},
     plugin::{
       BoxPlugin, HookLoadReturn, HookNoopReturn, HookRenderChunkReturn, HookResolveIdReturn,

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -12,6 +12,7 @@ pub use crate::{
   bundler::{
     bundle::output::{Output, OutputAsset, OutputChunk, RenderedModule},
     bundler::{Bundler, RolldownOutput},
+    chunk::render_chunk::{PreRenderedChunk, RenderedChunk},
     options::{
       file_name_template::FileNameTemplate,
       input_options::{External, InputItem, InputOptions},
@@ -21,7 +22,7 @@ pub use crate::{
   plugin::{
     args::{
       HookBuildEndArgs, HookLoadArgs, HookResolveIdArgs, HookResolveIdArgsOptions,
-      HookTransformArgs,
+      HookTransformArgs, RenderChunkArgs,
     },
     context::PluginContext,
     output::{HookLoadOutput, HookRenderChunkOutput, HookResolveIdOutput},

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::{
       HookBuildEndArgs, HookLoadArgs, HookResolveIdArgs, HookResolveIdArgsOptions,
       HookTransformArgs,
     },
-    context::{PluginContext, ResolveId, TransformPluginContext},
+    context::PluginContext,
     output::{HookLoadOutput, HookRenderChunkOutput, HookResolveIdOutput},
     plugin::{
       BoxPlugin, HookLoadReturn, HookNoopReturn, HookRenderChunkReturn, HookResolveIdReturn,

--- a/crates/rolldown/src/plugin/args.rs
+++ b/crates/rolldown/src/plugin/args.rs
@@ -1,3 +1,4 @@
+use crate::bundler::chunk::render_chunk::RenderedChunk;
 use rolldown_common::ImportKind;
 
 #[derive(Debug)]
@@ -31,6 +32,7 @@ pub struct HookBuildEndArgs {
 }
 
 #[derive(Debug)]
-pub struct RenderChunkArgs {
+pub struct RenderChunkArgs<'a> {
   pub code: String,
+  pub chunk: &'a RenderedChunk,
 }

--- a/crates/rolldown/src/plugin/plugin.rs
+++ b/crates/rolldown/src/plugin/plugin.rs
@@ -4,7 +4,7 @@ use rolldown_error::BuildError;
 
 use super::{
   args::{HookBuildEndArgs, HookLoadArgs, HookResolveIdArgs, HookTransformArgs, RenderChunkArgs},
-  context::{PluginContext, TransformPluginContext},
+  context::PluginContext,
   output::{HookLoadOutput, HookRenderChunkOutput, HookResolveIdOutput},
 };
 
@@ -54,7 +54,7 @@ pub trait Plugin: Debug + Send + Sync {
 
   async fn render_chunk(
     &self,
-    _ctx: &PluginContext<T>,
+    _ctx: &PluginContext,
     _args: &RenderChunkArgs,
   ) -> HookRenderChunkReturn {
     Ok(None)

--- a/crates/rolldown/src/plugin/plugin.rs
+++ b/crates/rolldown/src/plugin/plugin.rs
@@ -4,7 +4,7 @@ use rolldown_error::BuildError;
 
 use super::{
   args::{HookBuildEndArgs, HookLoadArgs, HookResolveIdArgs, HookTransformArgs, RenderChunkArgs},
-  context::PluginContext,
+  context::{PluginContext, TransformPluginContext},
   output::{HookLoadOutput, HookRenderChunkOutput, HookResolveIdOutput},
 };
 
@@ -54,7 +54,7 @@ pub trait Plugin: Debug + Send + Sync {
 
   async fn render_chunk(
     &self,
-    _ctx: &PluginContext,
+    _ctx: &PluginContext<T>,
     _args: &RenderChunkArgs,
   ) -> HookRenderChunkReturn {
     Ok(None)

--- a/crates/rolldown/tests/common/case.rs
+++ b/crates/rolldown/tests/common/case.rs
@@ -95,7 +95,10 @@ impl Case {
             chunk.file_name,
             chunk.is_entry,
             chunk.is_dynamic_entry,
-            chunk.facade_module_id,
+            chunk
+              .facade_module_id
+              .clone()
+              .map(|v| v.replace(self.fixture.dir_path().to_str().unwrap(), "$DIR$")),
             chunk.exports
           ))]
         }

--- a/crates/rolldown/tests/fixtures/code_splitting/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/code_splitting/artifacts.snap
@@ -34,7 +34,7 @@ console.log('shared');
 ## Output Stats
 
 - _rolldown_runtime.mjs, is_entry false, is_dynamic_entry false, facade_module_id None, exports []
-- dynamic_js.mjs, is_entry false, is_dynamic_entry true, facade_module_id Some("dynamic.js"), exports []
-- main1.mjs, is_entry true, is_dynamic_entry false, facade_module_id Some("main1.js"), exports []
-- main2.mjs, is_entry true, is_dynamic_entry false, facade_module_id Some("main2.js"), exports []
+- dynamic_js.mjs, is_entry false, is_dynamic_entry true, facade_module_id Some("$DIR$/dynamic.js"), exports []
+- main1.mjs, is_entry true, is_dynamic_entry false, facade_module_id Some("$DIR$/main1.js"), exports []
+- main2.mjs, is_entry true, is_dynamic_entry false, facade_module_id Some("$DIR$/main2.js"), exports []
 - share_js.mjs, is_entry false, is_dynamic_entry false, facade_module_id None, exports []

--- a/crates/rolldown_binding/index.d.ts
+++ b/crates/rolldown_binding/index.d.ts
@@ -11,24 +11,13 @@ export interface PluginOptions {
     importer?: string,
     options?: HookResolveIdArgsOptions,
   ) => Promise<undefined | ResolveIdResult>
-<<<<<<< HEAD
   load?: (id: string) => Promise<undefined | SourceResult>
   transform?: (id: string, code: string) => Promise<undefined | SourceResult>
   buildEnd?: (error: string) => Promise<void>
-=======
-  load?: (ctx: PluginContext, id: string) => Promise<undefined | SourceResult>
-  transform?: (
-    ctx: TransformPluginContext,
-    id: string,
-    code: string,
-  ) => Promise<undefined | SourceResult>
-  buildEnd?: (ctx: PluginContext, error: string) => Promise<void>
   renderChunk?: (
-    ctx: PluginContext,
     code: string,
     chunk: RenderedChunk,
   ) => Promise<undefined | HookRenderChunkOutput>
->>>>>>> c751110 (feat: render chunk hook binding)
 }
 export interface HookResolveIdArgsOptions {
   isEntry: boolean
@@ -41,8 +30,6 @@ export interface ResolveIdResult {
 export interface SourceResult {
   code: string
 }
-<<<<<<< HEAD
-=======
 export interface HookRenderChunkOutput {
   code: string
 }
@@ -62,11 +49,6 @@ export interface RenderedChunk {
   fileName: string
   modules: Record<string, RenderedModule>
 }
-export interface ResolveId {
-  external: boolean
-  id: string
-}
->>>>>>> c751110 (feat: render chunk hook binding)
 export interface InputItem {
   name?: string
   import: string

--- a/crates/rolldown_binding/index.d.ts
+++ b/crates/rolldown_binding/index.d.ts
@@ -11,9 +11,24 @@ export interface PluginOptions {
     importer?: string,
     options?: HookResolveIdArgsOptions,
   ) => Promise<undefined | ResolveIdResult>
+<<<<<<< HEAD
   load?: (id: string) => Promise<undefined | SourceResult>
   transform?: (id: string, code: string) => Promise<undefined | SourceResult>
   buildEnd?: (error: string) => Promise<void>
+=======
+  load?: (ctx: PluginContext, id: string) => Promise<undefined | SourceResult>
+  transform?: (
+    ctx: TransformPluginContext,
+    id: string,
+    code: string,
+  ) => Promise<undefined | SourceResult>
+  buildEnd?: (ctx: PluginContext, error: string) => Promise<void>
+  renderChunk?: (
+    ctx: PluginContext,
+    code: string,
+    chunk: RenderedChunk,
+  ) => Promise<undefined | HookRenderChunkOutput>
+>>>>>>> c751110 (feat: render chunk hook binding)
 }
 export interface HookResolveIdArgsOptions {
   isEntry: boolean
@@ -26,6 +41,32 @@ export interface ResolveIdResult {
 export interface SourceResult {
   code: string
 }
+<<<<<<< HEAD
+=======
+export interface HookRenderChunkOutput {
+  code: string
+}
+export interface PreRenderedChunk {
+  isEntry: boolean
+  isDynamicEntry: boolean
+  facadeModuleId?: string
+  moduleIds: Array<string>
+  exports: Array<string>
+}
+export interface RenderedChunk {
+  isEntry: boolean
+  isDynamicEntry: boolean
+  facadeModuleId?: string
+  moduleIds: Array<string>
+  exports: Array<string>
+  fileName: string
+  modules: Record<string, RenderedModule>
+}
+export interface ResolveId {
+  external: boolean
+  id: string
+}
+>>>>>>> c751110 (feat: render chunk hook binding)
 export interface InputItem {
   name?: string
   import: string

--- a/crates/rolldown_binding/src/options/input_options/plugin.rs
+++ b/crates/rolldown_binding/src/options/input_options/plugin.rs
@@ -41,7 +41,7 @@ pub struct PluginOptions {
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
   #[napi(
-    ts_type = "(ctx: PluginContext, code: string, chunk: RenderedChunk) => Promise<undefined | HookRenderChunkOutput>"
+    ts_type = "(code: string, chunk: RenderedChunk) => Promise<undefined | HookRenderChunkOutput>"
   )]
   pub render_chunk: Option<JsFunction>,
 }

--- a/crates/rolldown_binding/src/options/input_options/plugin.rs
+++ b/crates/rolldown_binding/src/options/input_options/plugin.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use derivative::Derivative;
 use napi::JsFunction;
 use serde::Deserialize;
@@ -35,6 +37,13 @@ pub struct PluginOptions {
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(error: string) => Promise<void>")]
   pub build_end: Option<JsFunction>,
+
+  #[derivative(Debug = "ignore")]
+  #[serde(skip_deserializing)]
+  #[napi(
+    ts_type = "(ctx: PluginContext, code: string, chunk: RenderedChunk) => Promise<undefined | HookRenderChunkOutput>"
+  )]
+  pub render_chunk: Option<JsFunction>,
 }
 
 #[napi_derive::napi(object)]
@@ -78,5 +87,74 @@ pub struct SourceResult {
 impl From<SourceResult> for rolldown::HookLoadOutput {
   fn from(value: SourceResult) -> Self {
     Self { code: value.code }
+  }
+}
+
+#[napi_derive::napi(object)]
+#[derive(Deserialize, Default, Derivative)]
+#[serde(rename_all = "camelCase")]
+#[derivative(Debug)]
+pub struct HookRenderChunkOutput {
+  pub code: String,
+}
+
+impl From<HookRenderChunkOutput> for rolldown::HookRenderChunkOutput {
+  fn from(value: HookRenderChunkOutput) -> Self {
+    Self { code: value.code }
+  }
+}
+
+#[napi_derive::napi(object)]
+#[derive(Deserialize, Default, Derivative)]
+#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
+pub struct PreRenderedChunk {
+  // pub name: String,
+  pub is_entry: bool,
+  pub is_dynamic_entry: bool,
+  pub facade_module_id: Option<String>,
+  pub module_ids: Vec<String>,
+  pub exports: Vec<String>,
+}
+
+impl From<rolldown::PreRenderedChunk> for PreRenderedChunk {
+  fn from(value: rolldown::PreRenderedChunk) -> Self {
+    Self {
+      is_entry: value.is_entry,
+      is_dynamic_entry: value.is_dynamic_entry,
+      facade_module_id: value.facade_module_id,
+      module_ids: value.module_ids,
+      exports: value.exports,
+    }
+  }
+}
+
+#[napi_derive::napi(object)]
+#[derive(Deserialize, Default, Derivative)]
+#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
+pub struct RenderedChunk {
+  // PreRenderedChunk
+  pub is_entry: bool,
+  pub is_dynamic_entry: bool,
+  pub facade_module_id: Option<String>,
+  pub module_ids: Vec<String>,
+  pub exports: Vec<String>,
+  // RenderedChunk
+  pub file_name: String,
+  pub modules: HashMap<String, crate::output::RenderedModule>,
+}
+
+impl From<rolldown::RenderedChunk> for RenderedChunk {
+  fn from(value: rolldown::RenderedChunk) -> Self {
+    Self {
+      is_entry: value.is_entry,
+      is_dynamic_entry: value.is_dynamic_entry,
+      facade_module_id: value.facade_module_id,
+      module_ids: value.module_ids,
+      exports: value.exports,
+      file_name: value.file_name,
+      modules: value.modules.into_iter().map(|(key, value)| (key, value.into())).collect(),
+    }
   }
 }

--- a/crates/rolldown_binding/src/options/input_options/plugin_adapter.rs
+++ b/crates/rolldown_binding/src/options/input_options/plugin_adapter.rs
@@ -5,25 +5,18 @@ use crate::utils::JsCallback;
 use derivative::Derivative;
 use rolldown::Plugin;
 
-use super::{
-  plugin::{
-    HookRenderChunkOutput, HookResolveIdArgsOptions, PluginOptions, RenderedChunk, ResolveIdResult,
-    SourceResult,
-  },
-  plugin_context::{PluginContext, TransformPluginContext},
+use super::plugin::{
+  HookRenderChunkOutput, HookResolveIdArgsOptions, PluginOptions, RenderedChunk, ResolveIdResult,
+  SourceResult,
 };
 
-pub type BuildStartCallback = JsCallback<(PluginContext,), ()>;
-pub type ResolveIdCallback = JsCallback<
-  (PluginContext, String, Option<String>, HookResolveIdArgsOptions),
-  Option<ResolveIdResult>,
->;
-pub type LoadCallback = JsCallback<(PluginContext, String), Option<SourceResult>>;
-pub type TransformCallback =
-  JsCallback<(TransformPluginContext, String, String), Option<SourceResult>>;
-pub type BuildEndCallback = JsCallback<(PluginContext, Option<String>), ()>;
-pub type RenderChunkCallback =
-  JsCallback<(PluginContext, String, RenderedChunk), Option<HookRenderChunkOutput>>;
+pub type BuildStartCallback = JsCallback<(), ()>;
+pub type ResolveIdCallback =
+  JsCallback<(String, Option<String>, HookResolveIdArgsOptions), Option<ResolveIdResult>>;
+pub type LoadCallback = JsCallback<(String,), Option<SourceResult>>;
+pub type TransformCallback = JsCallback<(String, String), Option<SourceResult>>;
+pub type BuildEndCallback = JsCallback<(Option<String>,), ()>;
+pub type RenderChunkCallback = JsCallback<(String, RenderedChunk), Option<HookRenderChunkOutput>>;
 
 #[derive(Derivative)]
 #[derivative(Debug)]
@@ -151,12 +144,12 @@ impl Plugin for JsAdapterPlugin {
   #[allow(clippy::redundant_closure_for_method_calls)]
   async fn render_chunk(
     &self,
-    ctx: &rolldown::PluginContext<OsFileSystem>,
+    _ctx: &rolldown::PluginContext,
     args: &rolldown::RenderChunkArgs,
   ) -> rolldown::HookRenderChunkReturn {
     if let Some(cb) = &self.render_chunk_fn {
       let res = cb
-        .call_async((ctx.into(), args.code.to_string(), args.chunk.clone().into()))
+        .call_async((args.code.to_string(), args.chunk.clone().into()))
         .await
         .map_err(|e| e.into_bundle_error())?;
       return Ok(res.map(Into::into));

--- a/packages/node/src/options/create-build-plugin-adapter.ts
+++ b/packages/node/src/options/create-build-plugin-adapter.ts
@@ -6,6 +6,7 @@ import type {
   PluginContext as RolldownPluginContext,
   TransformPluginContext as RolldownTransformPluginContext,
   RenderedChunk,
+  HookRenderChunkOutput,
 } from '@rolldown/node-binding'
 import { unimplemented } from '../utils'
 
@@ -34,48 +35,55 @@ function renderChunk(hook: Plugin['renderChunk']) {
       ctx: RolldownPluginContext,
       code: string,
       chunk: RenderedChunk,
-    ): Promise<undefined | SourceResult> => {
+    ): Promise<undefined | HookRenderChunkOutput> => {
       try {
-        let renderedChunk = Object.assign(chunk, {
-          get name() {
-            return unimplemented()
+        let renderedChunk = Object.assign(
+          {
+            get name() {
+              return unimplemented()
+            },
+            get dynamicImports() {
+              return unimplemented()
+            },
+            get imports() {
+              return unimplemented()
+            },
+            get implicitlyLoadedBefore() {
+              return unimplemented()
+            },
+            get importedBindings() {
+              return unimplemented()
+            },
+            get isImplicitEntry() {
+              return unimplemented()
+            },
+            get referencedFiles() {
+              return unimplemented()
+            },
+            type: 'chunk' as const,
           },
-          get dynamicImports() {
-            return unimplemented()
+          chunk,
+          {
+            get modules() {
+              return Object.fromEntries(
+                Object.entries(chunk.modules).map(([key, value]) => [
+                  key,
+                  Object.assign(
+                    {
+                      get code() {
+                        return unimplemented()
+                      },
+                    },
+                    value,
+                  ),
+                ]),
+              )
+            },
+            get facadeModuleId() {
+              return chunk.facadeModuleId || null
+            },
           },
-          get imports() {
-            return unimplemented()
-          },
-          get implicitlyLoadedBefore() {
-            return unimplemented()
-          },
-          get importedBindings() {
-            return unimplemented()
-          },
-          get isImplicitEntry() {
-            return unimplemented()
-          },
-          get referencedFiles() {
-            return unimplemented()
-          },
-          type: 'chunk' as const,
-          get modules() {
-            return Object.fromEntries(
-              Object.entries(chunk.modules).map(([key, value]) => [
-                key,
-                {
-                  ...value,
-                  get code() {
-                    return unimplemented()
-                  },
-                },
-              ]),
-            )
-          },
-          get facadeModuleId() {
-            return chunk.facadeModuleId || null
-          },
-        })
+        )
         // TODO options and meta
         const value = await hook.call(
           normalizePluginContext(ctx),

--- a/packages/node/src/options/create-build-plugin-adapter.ts
+++ b/packages/node/src/options/create-build-plugin-adapter.ts
@@ -3,8 +3,6 @@ import type {
   PluginOptions,
   SourceResult,
   ResolveIdResult,
-  PluginContext as RolldownPluginContext,
-  TransformPluginContext as RolldownTransformPluginContext,
   RenderedChunk,
   HookRenderChunkOutput,
 } from '@rolldown/node-binding'
@@ -32,7 +30,6 @@ function renderChunk(hook: Plugin['renderChunk']) {
       return unimplemented()
     }
     return async (
-      ctx: RolldownPluginContext,
       code: string,
       chunk: RenderedChunk,
     ): Promise<undefined | HookRenderChunkOutput> => {
@@ -86,7 +83,7 @@ function renderChunk(hook: Plugin['renderChunk']) {
         )
         // TODO options and meta
         const value = await hook.call(
-          normalizePluginContext(ctx),
+          {} as any,
           code,
           renderedChunk,
           {} as any,

--- a/packages/node/test/cases/plugin/render-chunk/config.ts
+++ b/packages/node/test/cases/plugin/render-chunk/config.ts
@@ -1,0 +1,37 @@
+import type { RollupOptions, RollupOutput } from '@rolldown/node'
+import { expect, vi } from 'vitest'
+import path from 'path'
+
+const entry = path.join(__dirname, './main.js')
+
+const renderChunkFn = vi.fn()
+
+const config: RollupOptions = {
+  input: entry,
+  plugins: [
+    {
+      name: 'test-plugin',
+      renderChunk: (code, chunk) => {
+        renderChunkFn()
+        expect(code.indexOf('console.log') > -1).toBe(true)
+        expect(chunk.type).toBe('chunk')
+        expect(chunk.fileName).toBe('main.js')
+        expect(chunk.isEntry).toBe(true)
+        expect(chunk.isDynamicEntry).toBe(false)
+        expect(chunk.facadeModuleId).toBe(entry)
+        expect(chunk.exports.length).toBe(0)
+        expect(chunk.moduleIds).toStrictEqual([entry])
+        expect(Object.keys(chunk.modules).length).toBe(1)
+        return 'render-chunk-code'
+      },
+    },
+  ],
+}
+
+export default {
+  config,
+  afterTest: (output: RollupOutput) => {
+    expect(renderChunkFn).toHaveBeenCalledTimes(1)
+    expect(output.output[0].code).toBe('render-chunk-code')
+  },
+}

--- a/packages/node/test/cases/plugin/render-chunk/main.js
+++ b/packages/node/test/cases/plugin/render-chunk/main.js
@@ -1,0 +1,1 @@
+console.log()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add `renderChunk` hook binding. 

Here also add `RenderedChunk` and `PreRenderedChunk` binding, them has some same fields, here list all fields to make rust side API same as js side.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Added.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
