### PR TITLE
feat(ci): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,7 +275,7 @@ jobs:
           find ./packages/ -type d -maxdepth 1 -exec cp LICENSE {} \;
           find ./packages/ -type d -maxdepth 1 -exec cp THIRD-PARTY-LICENSE {} \;
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-          yarn lerna publish from-package --no-verify-access --yes
+          yarn lerna publish from-package --no-private --no-verify-access --yes
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,8 +274,8 @@ jobs:
         run: |
           find ./packages/ -type d -maxdepth 1 -exec cp LICENSE {} \;
           find ./packages/ -type d -maxdepth 1 -exec cp THIRD-PARTY-LICENSE {} \;
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$ROLLDOWN_NPM_TOKEN" >> ~/.npmrc
           yarn lerna publish from-package --no-private --no-verify-access --yes
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          ROLLDOWN_NPM_TOKEN: ${{ secrets.ROLLDOWN_NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,281 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-binding:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            build: |
+              yarn build:binding:release
+              strip -x crates/rolldown_binding/*.node
+
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            build: |
+              sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*;
+              export CC=$(xcrun -f clang);
+              export CXX=$(xcrun -f clang++);
+              SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
+              export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
+              export CARGO_BUILD_TARGET=aarch64-apple-darwin
+              yarn build:binding:release
+              strip -x crates/rolldown_binding/*.node
+
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            build: yarn build:binding:release
+
+          - os: windows-latest
+            target: i686-pc-windows-msvc
+            build: |
+              export CARGO_BUILD_TARGET=i686-pc-windows-msvc
+              yarn build:binding:release
+
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            build: |
+              export CARGO_BUILD_TARGET=aarch64-pc-windows-msvc
+              yarn build:binding:release
+
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            build: |-
+              set -e &&
+              export CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu &&
+              yarn build:binding:release &&
+              strip crates/rolldown_binding/*.node
+
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            build: set -e && yarn build:binding:release && strip crates/rolldown_binding/*.node
+
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
+            build: |-
+              set -e &&
+              export CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu &&
+              rustup target add aarch64-unknown-linux-gnu &&
+              yarn build:binding:release &&
+              aarch64-unknown-linux-gnu-strip crates/rolldown_binding/*.node
+
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            build: |
+              sudo apt-get update
+              sudo apt-get install gcc-arm-linux-gnueabihf -y
+              export CARGO_BUILD_TARGET=armv7-unknown-linux-gnueabihf
+              yarn build:binding:release
+              arm-linux-gnueabihf-strip crates/rolldown_binding/*.node
+
+          - os: ubuntu-latest
+            target: aarch64-linux-android
+            build: |
+              export CARGO_BUILD_TARGET=aarch64-linux-android
+              yarn build:binding:release
+              ${ANDROID_NDK_LATEST_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip crates/rolldown_binding/*.node
+
+          - os: ubuntu-latest
+            target: armv7-linux-androideabi
+            build: |
+              export CARGO_BUILD_TARGET=armv7-linux-androideabi
+              yarn build:binding:release
+              ${ANDROID_NDK_LATEST_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip crates/rolldown_binding/*.node
+
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            build: |-
+              set -e &&
+              rustup target add aarch64-unknown-linux-musl &&
+              export CARGO_BUILD_TARGET=aarch64-unknown-linux-musl &&
+              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc &&
+              yarn build:binding:release &&
+              /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip crates/rolldown_binding/*.node
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: moonrepo/setup-rust@v1
+        with:
+          cache-base: main
+
+      - name: Add Rust Target
+        run: rustup target add ${{ matrix.target }}
+
+      - uses: goto-bus-stop/setup-zig@v2
+        if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
+        with:
+          version: 0.10.1
+
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.18.0
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build Binding in docker
+        uses: addnab/docker-run-action@v3
+        if: ${{ matrix.docker }}
+        with:
+          image: ${{ matrix.docker }}
+          run: ${{ matrix.build }}
+          options: '--user 0:0 -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index -v ${{ github.workspace }}:/build -w /build'
+          shell: bash
+
+      - name: Build Binding
+        run: ${{ matrix.build }}
+        if: ${{ !matrix.docker }}
+        shell: bash
+
+      - name: Upload Binding Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: bindings-${{ matrix.target }}
+          path: crates/rolldown_binding/*.node
+
+  build-node-packages:
+    strategy:
+      fail-fast: false
+    name: Build Node Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.18.0
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build Node Packages
+        run: yarn build:node:ci
+
+      - name: Upload Node Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: node-artifact
+          path: packages/node/dist/**
+
+  test:
+    needs:
+      - build-binding
+      - build-node-packages
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+    name: Test ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true # Pull submodules for additional files
+
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.18.0
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Download Binding Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: crates/rolldown_binding/artifacts
+
+      - name: Move Binding Artifacts
+        run: yarn workspace @rolldown/node-binding artifacts
+
+      - name: List packages
+        run: ls -R ./crates/rolldown_binding
+        shell: bash
+
+      - name: Download Node Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: packages/node/dist
+          name: node-artifact
+
+      - name: Node Test
+        run: yarn test
+
+  publish:
+    name: Publish Npm Packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for softprops/action-gh-release@v1
+      id-token: write # for `npm publish --provenance`
+    needs:
+      - test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.18.0
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Download Binding Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: crates/rolldown_binding/artifacts
+
+      - name: Move Binding Artifacts
+        run: yarn workspace @rolldown/node-binding artifacts
+
+      - name: List packages
+        run: ls -R ./crates/rolldown_binding
+        shell: bash
+
+      - name: Download Node Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: packages/node/dist
+          name: node-artifact
+
+      - name: Publish
+        run: |
+          find ./packages/ -type d -maxdepth 1 -exec cp LICENSE {} \;
+          find ./packages/ -type d -maxdepth 1 -exec cp THIRD-PARTY-LICENSE {} \;
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+          yarn lerna publish from-package --no-verify-access --yes
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/crates/rolldown_binding/npm/android-arm-eabi/package.json
+++ b/crates/rolldown_binding/npm/android-arm-eabi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-android-arm-eabi",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "android"
   ],

--- a/crates/rolldown_binding/npm/android-arm64/package.json
+++ b/crates/rolldown_binding/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-android-arm64",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "android"
   ],

--- a/crates/rolldown_binding/npm/darwin-arm64/package.json
+++ b/crates/rolldown_binding/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-darwin-arm64",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "darwin"
   ],

--- a/crates/rolldown_binding/npm/darwin-x64/package.json
+++ b/crates/rolldown_binding/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-darwin-x64",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "darwin"
   ],

--- a/crates/rolldown_binding/npm/freebsd-x64/package.json
+++ b/crates/rolldown_binding/npm/freebsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-freebsd-x64",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "freebsd"
   ],

--- a/crates/rolldown_binding/npm/linux-arm-gnueabihf/package.json
+++ b/crates/rolldown_binding/npm/linux-arm-gnueabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-linux-arm-gnueabihf",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "linux"
   ],

--- a/crates/rolldown_binding/npm/linux-arm64-gnu/package.json
+++ b/crates/rolldown_binding/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-linux-arm64-gnu",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "linux"
   ],

--- a/crates/rolldown_binding/npm/linux-arm64-musl/package.json
+++ b/crates/rolldown_binding/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-linux-arm64-musl",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "linux"
   ],

--- a/crates/rolldown_binding/npm/linux-x64-gnu/package.json
+++ b/crates/rolldown_binding/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-linux-x64-gnu",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "linux"
   ],

--- a/crates/rolldown_binding/npm/linux-x64-musl/package.json
+++ b/crates/rolldown_binding/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-linux-x64-musl",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "linux"
   ],

--- a/crates/rolldown_binding/npm/win32-arm64-msvc/package.json
+++ b/crates/rolldown_binding/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-win32-arm64-msvc",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "win32"
   ],

--- a/crates/rolldown_binding/npm/win32-ia32-msvc/package.json
+++ b/crates/rolldown_binding/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-win32-ia32-msvc",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "win32"
   ],

--- a/crates/rolldown_binding/npm/win32-x64-msvc/package.json
+++ b/crates/rolldown_binding/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding-win32-x64-msvc",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "os": [
     "win32"
   ],

--- a/crates/rolldown_binding/package.json
+++ b/crates/rolldown_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node-binding",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API.",
   "main": "index.js",
   "repository": "git@github.com:rolldown-rs/rolldown.git",

--- a/crates/rolldown_binding_wasm/package.json
+++ b/crates/rolldown_binding_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/wasm-binding",
-  "version": "0.1.0",
+  "version": "0.0.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/crates/rolldown_binding_wasm/package.json
+++ b/crates/rolldown_binding_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/wasm-binding",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,11 @@
+{
+  "packages": ["crates/rolldown_binding", "packages/*"],
+  "version": "independent",
+  "useWorkspaces": true,
+  "npmClient": "yarn",
+  "command": {
+    "version": {
+      "message": "chore(release): publish"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     "prettier:ci": "prettier . '!**/*.{js,ts,json,md,yml,yaml}' -c",
     "typecheck": "yarn workspace @rolldown/node run typecheck",
     "bench": "yarn workspace bench run bench",
-    "TODO(hyf0): #need to investigate following commands": "_",
-    "build:ci:release": "run-s build:packages:ci build:ts build:binding:release",
     "build:ts": "tsc -b tsconfig.project.json",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "TODO(hyf0): #need to investigate following commands": "_",
+    "build:ci:release": "run-s build:node:ci build:binding:release",
+    "build:node:ci": "yarn workspace @rolldown/node run build",
+    "version": "yarn lerna version --no-private"
   },
   "license": "MIT",
   "devDependencies": {
@@ -46,7 +48,7 @@
     "execa": "^8.0.1",
     "fs-extra": "^11.1.1",
     "husky": "^8.0.3",
-    "lerna": "^6.5.1",
+    "lerna": "^6.6.2",
     "lint-staged": "^13.1.2",
     "lodash-es": "^4.17.21",
     "npm-run-all": "^4.1.5",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "rolldown core binding",
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolldown/node",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "rolldown core binding",
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7579,7 +7579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lerna@npm:^6.5.1":
+"lerna@npm:^6.6.2":
   version: 6.6.2
   resolution: "lerna@npm:6.6.2"
   dependencies:
@@ -8597,7 +8597,7 @@ __metadata:
     execa: "npm:^8.0.1"
     fs-extra: "npm:^11.1.1"
     husky: "npm:^8.0.3"
-    lerna: "npm:^6.5.1"
+    lerna: "npm:^6.6.2"
     lint-staged: "npm:^13.1.2"
     lodash-es: "npm:^4.17.21"
     npm-run-all: "npm:^4.1.5"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Here port release workflow from https://github.com/rolldown-rs/rolldown_legacy/pull/116. Here remove some platform test, only keep x86_64-apple-darwin/x86_64-pc-windows-msvc/x86_64-unknown-linux-gnu test.

The workflow is some steps at now: 
1. Run `yarn verison` at local,it will create new version for packages,  and push it to one pr
2. Run `Release` workflow action at github `Action` tab, choose your branch. It will trigger release build and test and publish it.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Here has a windows test crash, i will fix it at next days.


<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
