### PR TITLE
chore: fix windows ci

### DIFF
--- a/packages/rollup-tests/src/ignored-tests.js
+++ b/packages/rollup-tests/src/ignored-tests.js
@@ -23,6 +23,9 @@ const ignoreTests = [
   'rollup@function@preserve-modules-default-mode-namespace: import namespace from chunks with default export mode when preserving modules',
   // The test case import test.js from rollup package, it's dependencies can't be resolved.
   "rollup@function@relative-outside-external: correctly resolves relative external imports from outside directories",
+  // Ignore skipIfWindows test avoid test status error
+  'rollup@function@preserve-symlink: follows symlinks',
+  'rollup@function@symlink: follows symlinks',
 ]
 
 module.exports = {

--- a/packages/rollup-tests/src/intercept/check.js
+++ b/packages/rollup-tests/src/intercept/check.js
@@ -8,7 +8,7 @@ const status = {
   // total: 0,
   failed: 0,
   skipFailed: 0,
-  ignored: 0,
+  // ignored: 0,
   skipped: 0,
   passed: 0,
 }
@@ -26,7 +26,7 @@ beforeEach(function skipAlreadyFiledTests() {
   const id = calcTestId(this.currentTest)
 
   if (ignoreTests.has(id)) {
-    status.ignored += 1
+    // status.ignored += 1
     this.currentTest?.skip()
   }
 
@@ -66,7 +66,7 @@ after(function printStatus() {
     // enforce exit process to avoid rust process is not exit.
     process.exit(1)
   } else {
-    if (expectedStatus.ignored != status.ignored || expectedStatus.skipFailed !== status.skipFailed || expectedStatus.passed !== status.passed) {
+    if (expectedStatus.skipFailed !== status.skipFailed || expectedStatus.passed !== status.passed) {
       console.log('expected', expectedStatus)
       console.log('actual', status)
       throw new Error('The rollup test status file is not updated. Please run `yarn test:update` to update it.')

--- a/packages/rollup-tests/src/intercept/check.js
+++ b/packages/rollup-tests/src/intercept/check.js
@@ -5,7 +5,7 @@ const alreadyFailedTests = new Set(loadFailedTests())
 const ignoreTests = loadIgnoredTests()
 
 const status = {
-  total: 0,
+  // total: 0,
   failed: 0,
   skipFailed: 0,
   ignored: 0,
@@ -22,16 +22,17 @@ beforeEach(function skipAlreadyFiledTests() {
   if (!this.currentTest) {
     throw new Error('No current test')
   }
-  status.total += 1
+  // status.total += 1
   const id = calcTestId(this.currentTest)
-  if (alreadyFailedTests.has(id)) {
-    status.skipFailed += 1
-    this.currentTest.skip()
-  }
 
   if (ignoreTests.has(id)) {
     status.ignored += 1
     this.currentTest?.skip()
+  }
+
+  if (alreadyFailedTests.has(id)) {
+    status.skipFailed += 1
+    this.currentTest.skip()
   }
 
   // capture the current test reference
@@ -65,7 +66,7 @@ after(function printStatus() {
     // enforce exit process to avoid rust process is not exit.
     process.exit(1)
   } else {
-    if (expectedStatus.total !== status.total || expectedStatus.ignored != status.ignored || expectedStatus.skipFailed !== status.skipFailed || expectedStatus.passed !== status.passed) {
+    if (expectedStatus.ignored != status.ignored || expectedStatus.skipFailed !== status.skipFailed || expectedStatus.passed !== status.passed) {
       console.log('expected', expectedStatus)
       console.log('actual', status)
       throw new Error('The rollup test status file is not updated. Please run `yarn test:update` to update it.')

--- a/packages/rollup-tests/src/intercept/update-test-status.js
+++ b/packages/rollup-tests/src/intercept/update-test-status.js
@@ -16,7 +16,7 @@ const status = {
   // total: 0,
   failed: 0,
   skipFailed: 0,
-  ignored: 0,
+  // ignored: 0,
   skipped: 0,
   passed: 0,
 }
@@ -33,7 +33,7 @@ beforeEach(function skipAlreadyFiledTests() {
   // }
 
   if (ignoredTests.has(id)) {
-    status.ignored += 1
+    // status.ignored += 1
     this.currentTest?.skip()
   }
 

--- a/packages/rollup-tests/src/intercept/update-test-status.js
+++ b/packages/rollup-tests/src/intercept/update-test-status.js
@@ -13,7 +13,7 @@ const onlyTests = loadOnlyTests()
 const ignoredTests = loadIgnoredTests()
 
 const status = {
-  total: 0,
+  // total: 0,
   failed: 0,
   skipFailed: 0,
   ignored: 0,
@@ -26,20 +26,20 @@ beforeEach(function skipAlreadyFiledTests() {
     throw new Error('No current test')
   }
   const id = calcTestId(this.currentTest)
-  status.total += 1
+  // status.total += 1
 
   // if (!onlyTests.has(id)) {
   //   this.currentTest?.skip()
   // }
 
-  if (alreadyFailedTests.has(id)) {
-    status.skipFailed += 1
-    this.currentTest.skip()
-  }
-
   if (ignoredTests.has(id)) {
     status.ignored += 1
     this.currentTest?.skip()
+  }
+
+  if (alreadyFailedTests.has(id)) {
+    status.skipFailed += 1
+    this.currentTest.skip()
   }
 
   // Easy way to find the test id in the logs

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,7 +1,6 @@
 {
   "failed": 0,
   "skipFailed": 655,
-  "ignored": 9,
   "skipped": 0,
   "passed": 237
 }

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,8 +1,7 @@
 {
-  "total": 901,
   "failed": 0,
-  "skipFailed": 657,
-  "ignored": 7,
+  "skipFailed": 655,
+  "ignored": 9,
   "skipped": 0,
   "passed": 237
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -2,6 +2,5 @@
 |----| ---- |
 | failed | 0|
 | skipFailed | 655|
-| ignored | 9|
 | skipped | 0|
 | passed | 237|

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -1,8 +1,7 @@
 |  | number |
 |----| ---- |
-| total | 901|
 | failed | 0|
-| skipFailed | 657|
-| ignored | 7|
+| skipFailed | 655|
+| ignored | 9|
 | skipped | 0|
 | passed | 237|


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The rollup test has some test run different platform, you can see at https://github.com/rolldown-rs/rolldown/blob/main/packages/rollup-tests/test/utils.js#L277.

Here add the platform test to the ignored test and avoid snapshot test status `total` and `ignored`, it will avoid different platform test status having different. 

Other, we need to use other ideas to check test snapshot.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Not need.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
