### PR TITLE
feat: add sourcemap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64-simd"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
+dependencies = [
+ "simd-abstraction",
+]
+
+[[package]]
 name = "bench"
 version = "0.1.0"
 dependencies = [
@@ -154,10 +174,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytes"
@@ -500,6 +554,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30bfce702bcfa94e906ef82421f2c0e61c076ad76030c16ee5d2e9a32fe193"
+dependencies = [
+ "matches",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +638,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -666,6 +735,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +768,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -881,6 +964,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -1107,6 +1196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
+name = "outref"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,6 +1374,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "parcel_sourcemap"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485b74d7218068b2b7c0e3ff12fbc61ae11d57cb5d8224f525bd304c6be05bbb"
+dependencies = [
+ "base64-simd",
+ "data-url",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "vlq",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,6 +1543,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1570,12 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1539,6 +1674,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
+name = "rend"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527a97cdfef66f65998b5f3b637c26f5a5ec09cc52a3f9932313ac645f4190f5"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c462a1328c8e67e4d6dbad1eb0355dd43e8ab432c6e227a43657f16ade5033"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rolldown"
 version = "0.1.0"
 dependencies = [
@@ -1586,6 +1759,7 @@ dependencies = [
  "rolldown_error",
  "rolldown_fs",
  "rolldown_resolver",
+ "rolldown_sourcemap",
  "rolldown_tracing",
  "rustc-hash",
  "scoped-tls",
@@ -1663,6 +1837,15 @@ dependencies = [
  "rolldown_error",
  "rolldown_fs",
  "sugar_path",
+]
+
+[[package]]
+name = "rolldown_sourcemap"
+version = "0.1.0"
+dependencies = [
+ "parcel_sourcemap",
+ "rolldown_error",
+ "serde_json",
 ]
 
 [[package]]
@@ -1787,6 +1970,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "semver"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,6 +2041,21 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-abstraction"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
+dependencies = [
+ "outref",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "similar"
@@ -1973,6 +2177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2265,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2189,16 +2414,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "uuid"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "vfs"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e4fe92cfc1bad19c19925d5eee4b30584dbbdee4ff10183b261acccbef74e2d"
+
+[[package]]
+name = "vlq"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 
 [[package]]
 name = "walkdir"
@@ -2517,6 +2760,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -14,20 +14,21 @@ workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-async-trait       = { workspace = true }
-derivative        = { workspace = true }
-futures           = { workspace = true }
-napi              = { version = "2.11.1", features = ["full"] }
-napi-derive       = { version = "2.11.0" }
-rolldown          = { path = "../rolldown" }
-rolldown_error    = { path = "../rolldown_error" }
-rolldown_tracing  = { path = "../rolldown_tracing" }
-rolldown_fs       = { path = "../rolldown_fs" }
-rolldown_resolver = { path = "../rolldown_resolver" }
-rustc-hash        = { workspace = true }
-scoped-tls        = { workspace = true }
-serde             = { workspace = true }
-tracing           = { workspace = true }
+async-trait        = { workspace = true }
+derivative         = { workspace = true }
+futures            = { workspace = true }
+napi               = { version = "2.11.1", features = ["full"] }
+napi-derive        = { version = "2.11.0" }
+rolldown           = { path = "../rolldown" }
+rolldown_error     = { path = "../rolldown_error" }
+rolldown_tracing   = { path = "../rolldown_tracing" }
+rolldown_fs        = { path = "../rolldown_fs" }
+rolldown_resolver  = { path = "../rolldown_resolver" }
+rolldown_sourcemap = { path = "../rolldown_sourcemap" }
+rustc-hash         = { workspace = true }
+scoped-tls         = { workspace = true }
+serde              = { workspace = true }
+tracing            = { workspace = true }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 mimalloc-rust = "0.2"

--- a/crates/rolldown_binding/src/options/mod.rs
+++ b/crates/rolldown_binding/src/options/mod.rs
@@ -3,3 +3,4 @@ pub use input_options::*;
 mod output_options;
 pub use output_options::*;
 mod plugin;
+mod sourcemap;

--- a/crates/rolldown_binding/src/options/sourcemap.rs
+++ b/crates/rolldown_binding/src/options/sourcemap.rs
@@ -1,0 +1,35 @@
+use derivative::Derivative;
+use serde::Deserialize;
+
+#[napi_derive::napi(object)]
+#[derive(Deserialize, Default, Derivative)]
+#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
+pub struct SourceMap {
+  // pub file: Option<String>,
+  pub mappings: String,
+  pub names: Vec<String>,
+  pub source_root: Option<String>,
+  pub sources: Vec<String>,
+  pub sources_content: Vec<String>,
+  // pub version: u32,
+  // #[serde(rename = "x_google_ignoreList")]
+  // pub x_google_ignore_list: Option<Vec<u32>>,
+}
+
+impl From<SourceMap> for napi::Result<rolldown_sourcemap::SourceMap> {
+  fn from(value: SourceMap) -> Self {
+    let mut map = rolldown_sourcemap::SourceMap::new(value.source_root.as_deref().unwrap_or(""));
+    if let Err(e) = map.add_vlq_map(
+      value.mappings.as_bytes(),
+      value.sources,
+      value.sources_content,
+      value.names,
+      0,
+      0,
+    ) {
+      return Err(napi::Error::from_reason(format!("{e}")));
+    }
+    Ok(map)
+  }
+}

--- a/crates/rolldown_binding/src/options/sourcemap.rs
+++ b/crates/rolldown_binding/src/options/sourcemap.rs
@@ -17,19 +17,8 @@ pub struct SourceMap {
   // pub x_google_ignore_list: Option<Vec<u32>>,
 }
 
-impl From<SourceMap> for napi::Result<rolldown_sourcemap::SourceMap> {
+impl From<SourceMap> for rolldown_sourcemap::SourceMap {
   fn from(value: SourceMap) -> Self {
-    let mut map = rolldown_sourcemap::SourceMap::new(value.source_root.as_deref().unwrap_or(""));
-    if let Err(e) = map.add_vlq_map(
-      value.mappings.as_bytes(),
-      value.sources,
-      value.sources_content,
-      value.names,
-      0,
-      0,
-    ) {
-      return Err(napi::Error::from_reason(format!("{e}")));
-    }
-    Ok(map)
+    Self::new(value.mappings, value.names, value.source_root, value.sources, value.sources_content)
   }
 }

--- a/crates/rolldown_sourcemap/Cargo.toml
+++ b/crates/rolldown_sourcemap/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name    = "rolldown_sourcemap"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+homepage.workspace   = true
+license.workspace    = true
+edition.workspace    = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+bench   = false
+test    = false
+doctest = false
+
+[dependencies]
+parcel_sourcemap = { version = "2.1.1", features = ["json"] }
+rolldown_error   = { path = "../rolldown_error" }
+
+[dev_dependencies]
+serde_json = { workspace = true }

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -1,0 +1,91 @@
+pub use parcel_sourcemap::SourceMap;
+
+pub fn collapse_sourcemaps(mut sourcemaps: Vec<SourceMap>) -> Result<SourceMap, String> {
+  sourcemaps.reverse();
+
+  let Some(mut result) = sourcemaps.pop() else { return Ok(SourceMap::new("")) };
+
+  for mut sourcemap in sourcemaps.into_iter().rev() {
+    if let Err(e) = sourcemap.extends(&mut result) {
+      return Err(format!("{e}"));
+    };
+    result = sourcemap;
+  }
+
+  Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::SourceMap;
+  use serde_json;
+  #[test]
+  fn it_works() {
+    let sourcemaps = vec![
+      SourceMap::from_json(
+        "/",
+        r#"{
+      "version": 3,
+      "file": "index.js",
+      "sourceRoot": "",
+      "sources": [
+        "index.ts"
+      ],
+      "names": [],
+      "mappings": "AAAA,SAAS,QAAQ,CAAC,IAAY;IAC5B,OAAO,CAAC,GAAG,CAAC,iBAAU,IAAI,CAAE,CAAC,CAAC;AAChC,CAAC",
+      "sourcesContent": [
+        "function sayHello(name: string) {\n  console.log(`Hello, ${name}`);\n}\n"
+      ]
+  }"#,
+      ).unwrap(),
+      SourceMap::from_json(
+        "/",
+        r#"{
+          "version": 3,
+          "file": "minify.js",
+          "sourceRoot": "",
+          "sources": [
+            "index.ts"
+          ],
+          "names": [
+            "sayHello",
+            "name",
+            "console",
+            "log",
+            "concat"
+          ],
+          "mappings": "AAAA,SAASA,SAASC,CAAI,EAClBC,QAAQC,GAAG,CAAC,UAAUC,MAAM,CAACH,GACjC",
+          "sourcesContent": [
+            "function sayHello(name) {\n    console.log(\"Hello, \".concat(name));\n}\n"
+          ]
+      }"#,
+      ).unwrap(),
+    ];
+
+    let result =
+      super::collapse_sourcemaps(sourcemaps).expect("should not fail").to_json(None).unwrap();
+
+    let expected = r#"{
+      "version": 3,
+      "sources": [
+      "index.ts"
+    ],
+    "sourceRoot": null,
+    "sourcesContent": [
+      "function sayHello(name: string) {\n  console.log(`Hello, ${name}`);\n}\n"
+    ],
+    "names": [
+      "sayHello",
+      "name",
+      "console",
+      "log",
+      "concat"
+    ],
+    "mappings": "AAAA,SAAS,SAAS,CAAY,EAC5B,QAAQ,GAAG,CAAC,UAAA,MAAA,CAAU,GACxB"
+  }"#;
+    assert_eq!(
+      result.as_str().parse::<serde_json::Value>().unwrap(),
+      expected.parse::<serde_json::Value>().unwrap()
+    );
+  }
+}

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -1,18 +1,71 @@
-pub use parcel_sourcemap::SourceMap;
+use parcel_sourcemap::SourceMap as ParcelSourcemap;
 
-pub fn collapse_sourcemaps(mut sourcemaps: Vec<SourceMap>) -> Result<SourceMap, String> {
-  sourcemaps.reverse();
+#[derive(Debug, Default, Clone)]
+pub struct SourceMap {
+  pub mappings: String,
+  pub names: Vec<String>,
+  pub source_root: Option<String>,
+  pub sources: Vec<String>,
+  pub sources_content: Vec<String>,
+  inner: Option<ParcelSourcemap>,
+}
 
-  let Some(mut result) = sourcemaps.pop() else { return Ok(SourceMap::new("")) };
+impl SourceMap {
+  pub fn new(
+    mappings: String,
+    names: Vec<String>,
+    source_root: Option<String>,
+    sources: Vec<String>,
+    sources_content: Vec<String>,
+  ) -> Self {
+    Self { mappings, names, source_root, sources, sources_content, inner: None }
+  }
 
-  for mut sourcemap in sourcemaps.into_iter().rev() {
+  pub fn to_json(&mut self) -> String {
+    self.inner.as_mut().expect("should have inner").to_json(None).expect("should success")
+  }
+
+  pub fn to_data_url(&mut self) -> String {
+    self.inner.as_mut().expect("should have inner").to_data_url(None).expect("should success")
+  }
+}
+
+impl From<ParcelSourcemap> for SourceMap {
+  fn from(value: ParcelSourcemap) -> Self {
+    Self { inner: Some(value), ..Default::default() }
+  }
+}
+
+pub fn collapse_sourcemaps(sourcemap_chain: Vec<SourceMap>) -> Result<Option<SourceMap>, String> {
+  let mut parcel_sourcemap_chain = sourcemap_chain
+    .into_iter()
+    .map(|sourcemap| {
+      let mut map = ParcelSourcemap::new(sourcemap.source_root.as_deref().unwrap_or(""));
+      if let Err(e) = map.add_vlq_map(
+        sourcemap.mappings.as_bytes(),
+        sourcemap.sources,
+        sourcemap.sources_content,
+        sourcemap.names,
+        0,
+        0,
+      ) {
+        return Err(format!("{e}"));
+      }
+      Ok(map)
+    })
+    .rev()
+    .collect::<Result<Vec<_>, String>>()?;
+
+  let Some(mut result) = parcel_sourcemap_chain.pop() else { return Ok(None) };
+
+  for mut sourcemap in parcel_sourcemap_chain.into_iter().rev() {
     if let Err(e) = sourcemap.extends(&mut result) {
       return Err(format!("{e}"));
     };
     result = sourcemap;
   }
 
-  Ok(result)
+  Ok(Some(result.into()))
 }
 
 #[cfg(test)]
@@ -22,48 +75,33 @@ mod tests {
   #[test]
   fn it_works() {
     let sourcemaps = vec![
-      SourceMap::from_json(
-        "/",
-        r#"{
-      "version": 3,
-      "file": "index.js",
-      "sourceRoot": "",
-      "sources": [
-        "index.ts"
-      ],
-      "names": [],
-      "mappings": "AAAA,SAAS,QAAQ,CAAC,IAAY;IAC5B,OAAO,CAAC,GAAG,CAAC,iBAAU,IAAI,CAAE,CAAC,CAAC;AAChC,CAAC",
-      "sourcesContent": [
-        "function sayHello(name: string) {\n  console.log(`Hello, ${name}`);\n}\n"
-      ]
-  }"#,
-      ).unwrap(),
-      SourceMap::from_json(
-        "/",
-        r#"{
-          "version": 3,
-          "file": "minify.js",
-          "sourceRoot": "",
-          "sources": [
-            "index.ts"
-          ],
-          "names": [
-            "sayHello",
-            "name",
-            "console",
-            "log",
-            "concat"
-          ],
-          "mappings": "AAAA,SAASA,SAASC,CAAI,EAClBC,QAAQC,GAAG,CAAC,UAAUC,MAAM,CAACH,GACjC",
-          "sourcesContent": [
-            "function sayHello(name) {\n    console.log(\"Hello, \".concat(name));\n}\n"
-          ]
-      }"#,
-      ).unwrap(),
+      SourceMap::new(
+        "AAAA,SAAS,QAAQ,CAAC,IAAY;IAC5B,OAAO,CAAC,GAAG,CAAC,iBAAU,IAAI,CAAE,CAAC,CAAC;AAChC,CAAC"
+          .to_string(),
+        vec![],
+        None,
+        vec!["index.ts".to_string()],
+        vec!["function sayHello(name: string) {\n  console.log(`Hello, ${name}`);\n}\n".to_string()],
+      ),
+      SourceMap::new(
+        "AAAA,SAASA,SAASC,CAAI,EAClBC,QAAQC,GAAG,CAAC,UAAUC,MAAM,CAACH,GACjC".to_string(),
+        vec![
+          "sayHello".to_string(),
+          "name".to_string(),
+          "console".to_string(),
+          "log".to_string(),
+          "concat".to_string(),
+        ],
+        None,
+        vec!["index.ts".to_string()],
+        vec![
+          "function sayHello(name) {\n    console.log(\"Hello, \".concat(name));\n}\n".to_string()
+        ],
+      ),
     ];
 
     let result =
-      super::collapse_sourcemaps(sourcemaps).expect("should not fail").to_json(None).unwrap();
+      super::collapse_sourcemaps(sourcemaps).expect("should not fail").unwrap().to_json();
 
     let expected = r#"{
       "version": 3,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Here using `parcel_sourcemap` to as rolldown sourcemap, it will be used as remaaping sourcemap chain from `load/transfrom/render_chunk` hook returned map.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan
Add remapping simple test.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
