### PR TITLE
feat: suppport transform hook return map

### DIFF
--- a/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
@@ -65,11 +65,8 @@ impl<'task, T: FileSystem + Default + 'static> NormalModuleTask<'task, T> {
         .await?;
 
     // Run plugin transform.
-    let source: Arc<str> = transform_source(&self.ctx.plugin_driver, source).await?.into();
     let source: Arc<str> =
-      transform_source(&self.ctx.plugin_driver, load_result.code, &mut sourcemap_chain)
-        .await?
-        .into();
+      transform_source(&self.ctx.plugin_driver, source, &mut sourcemap_chain).await?.into();
 
     let (ast, scope, scan_result, ast_symbol, namespace_symbol) = self.scan(&source);
     tracing::trace!("scan {:?}", self.resolved_path);

--- a/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/bundler/module_loader/normal_module_task.rs
@@ -66,6 +66,10 @@ impl<'task, T: FileSystem + Default + 'static> NormalModuleTask<'task, T> {
 
     // Run plugin transform.
     let source: Arc<str> = transform_source(&self.ctx.plugin_driver, source).await?.into();
+    let source: Arc<str> =
+      transform_source(&self.ctx.plugin_driver, load_result.code, &mut sourcemap_chain)
+        .await?
+        .into();
 
     let (ast, scope, scan_result, ast_symbol, namespace_symbol) = self.scan(&source);
     tracing::trace!("scan {:?}", self.resolved_path);

--- a/crates/rolldown/src/bundler/utils/transform_source.rs
+++ b/crates/rolldown/src/bundler/utils/transform_source.rs
@@ -1,14 +1,16 @@
+use rolldown_sourcemap::SourceMap;
+
 use crate::{bundler::plugin_driver::PluginDriver, error::BatchedErrors, HookTransformArgs};
 
 pub async fn transform_source(
   plugin_driver: &PluginDriver,
-  mut source: String,
+  source: String,
+  sourcemap_chain: &mut Vec<SourceMap>,
 ) -> Result<String, BatchedErrors> {
-  if let Some(r) =
-    plugin_driver.transform(&HookTransformArgs { id: source.as_ref(), code: &source }).await?
-  {
-    source = r.code;
-  };
+  let (code, map_chain) =
+    plugin_driver.transform(&HookTransformArgs { id: source.as_ref(), code: &source }).await?;
 
-  Ok(source)
+  sourcemap_chain.extend(map_chain);
+
+  Ok(code)
 }

--- a/packages/node/src/options/create-build-plugin-adapter.ts
+++ b/packages/node/src/options/create-build-plugin-adapter.ts
@@ -207,7 +207,7 @@ function transform(hook: Plugin['transform']) {
           return
         }
         // TODO other filed
-        return { code: value.code }
+        return { code: value.code, map: transformSourcemap(value.map) }
       } catch (error) {
         console.error(error)
         throw error

--- a/packages/node/test/cases/plugin/transform/config.ts
+++ b/packages/node/test/cases/plugin/transform/config.ts
@@ -13,6 +13,7 @@ const config: RollupOptions = {
           expect(code).toStrictEqual('')
           return {
             code: `console.log('foo')`,
+            map: { mappings: "" }
           }
         }
       },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The pr fixed `transform` hook behavior, the returned `code` should be as next parameter. Here also support `transform` hook return `map`, it also will be push into `Module#sourcemap_chain`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Update simple test.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
