### PR TITLE
chore: polish contributing guide & fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+# Contributing to Rolldown
+
+Want to contribute to Rolldown? Awesome! We have a guide to help you get started.
+
 - For contribution guide, please refer to the deployed version at: https://rolldown.rs/contrib-guide/
 
 - The source is also in this repo: https://github.com/rolldown-rs/rolldown/blob/main/web/docs/contrib-guide/

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@
 
 Rolldown is a JavaScript bundler written in Rust intended to serve as the future bundler used in Vite. It provides Rollup-compatible APIs and plugin interface, but will be more similar to esbuild in scope.
 
-For more information, check out [rolldown.rs](https://rolldown.rs/about).
+For more information, please check out the documentation at [rolldown.rs](https://rolldown.rs/about).
 
 # Contributing
 
-We would love to have more contributors involved! To get started, check out the [Contributing Guide](https://rolldown.rs/contrib-guide/).
+We would love to have more contributors involved! 
+
+To get started, please read our [Contributing Guide](https://rolldown.rs/contrib-guide/).
 
 # Credits
 

--- a/web/docs/about.md
+++ b/web/docs/about.md
@@ -43,7 +43,7 @@ const members = [
 Rolldown is a JavaScript bundler written in Rust intended to serve as the future bundler used in Vite. It provides Rollup-compatible APIs and plugin interface, but will be more similar to esbuild in scope.
 
 :::warning 🚧 Work in Progress
-Rolldown is currently in active development and not usable for production yet. but we are open sourcing it now so we can start collaborating with community contributors.
+Rolldown is currently in active development and not usable for production yet. but we are open sourcing it now, so we can start collaborating with community contributors.
 :::
 
 ## Why we are building Rolldown
@@ -62,7 +62,7 @@ Vite **has to** use two different bundlers because while both are amazing, they 
 
 - Rollup is mature and battle tested for bundling applications, but is significantly slower than bundlers written in compile-to-native languages.
 
-Having to use two different bundlers is sub-optimal in several ways:
+Having to use two different bundlers is suboptimal in several ways:
 
 - Subtle differences between the output can cause behavior differences between development and production builds.
 
@@ -92,7 +92,7 @@ Check out the [Roadmap](https://github.com/rolldown-rs/rolldown/discussions/153)
 
 ## Join Us!
 
-Rolldown is still in early stage. We have a lot of ground to cover and we won't be able to do this without the help from community contributors. We are also actively looking for more team members with long term commitment in improving JavaScript tooling with Rust.
+Rolldown is still in early stage. We have a lot of ground to cover, and we won't be able to do this without the help from community contributors. We are also actively looking for more team members with long term commitment in improving JavaScript tooling with Rust.
 
 ### Useful Links
 

--- a/web/docs/contrib-guide/benchmark.md
+++ b/web/docs/contrib-guide/benchmark.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Before running the benchmarks, setup the necessary fixtures with:
+Before running the benchmarks, set up the necessary fixtures with:
 
 ```shell
 # in project root

--- a/web/docs/contrib-guide/build.md
+++ b/web/docs/contrib-guide/build.md
@@ -1,6 +1,6 @@
 # Building Bindings
 
-For the NAPI-RS based Node packages to work, and for their tests and benchmarks to run, they must be built first. This is done by running `yarn build` in the root directory. This will spin up a process that builds the Node/WASM binding crates (with Cargo), and then builds the rolldown npm package. The `yarn build` script is also smart enough to only re-build if it detects changes since the last time it was ran.
+For the NAPI-RS based Node packages to work, and for their tests and benchmarks to run, they must be built first. This is done by running `yarn build` in the root directory. This will spin up a process that builds the Node/WASM binding crates (with Cargo), and then builds the rolldown npm package. The `yarn build` script is also smart enough to only re-build if it detects changes since the last time it was run.
 
 `yarn build` accepts two flags:
 

--- a/web/docs/contrib-guide/setup.md
+++ b/web/docs/contrib-guide/setup.md
@@ -35,7 +35,7 @@ just init-rust
 
 ### Node.js
 
-Rolldown is an npm package built with [NAPI-RS](https://napi.rs/) and is published to the npm registry, and as such requires Node.js and Yarn (for dependency management).
+Rolldown is a npm package built with [NAPI-RS](https://napi.rs/) and is published to the npm registry, and as such requires Node.js and Yarn (for dependency management).
 
 We recommend installing Node.js with a version manager, like [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm). Make sure to install and use Node.js version 18+, which is the minimum requirement for this project. You can skip this step if you are already using a Node.js version manager of your choice and on a Node.js version that meets the requirement.
 
@@ -56,7 +56,7 @@ just init-node
 The following commands are available and should be used in your standard development workflow.
 
 - `just init` - Install required tools and dependencies.
-- `just check` - Runs the typechecker.
+- `just check` - Runs the type checker.
 - `just lint` - Lints code.
 - `just fmt` - Formats code.
 - `just test` - Runs tests. Also see [Testing](./test.md).

--- a/web/docs/contrib-guide/test.md
+++ b/web/docs/contrib-guide/test.md
@@ -39,7 +39,7 @@ It is our goal to align Rolldown's Node.js API with that of Rollup's as much as 
 In `/packages/node`:
 
 - `yarn test` will run rollup tests.
-- `yarn test:update` will run and update the tests status.
+- `yarn test:update` will run and update the tests' status.
 
 ### Rollup behavior alignment tests
 
@@ -52,4 +52,4 @@ The git submodule should have been initialized after running `just init` when se
 In `/packages/rollup-tests`:
 
 - `yarn test` will run rollup tests.
-- `yarn test:update` will run and update the tests status.
+- `yarn test:update` will run and update the tests' status.


### PR DESCRIPTION
I think a contributing guide under the project's root path would be more visible and work better for now.