### PR TITLE
fix: correct id in transform hook

### DIFF
--- a/crates/rolldown/src/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/normal_module_task.rs
@@ -63,7 +63,9 @@ impl<'task, T: FileSystem + Default + 'static> NormalModuleTask<'task, T> {
 
     // Run plugin transform.
     let source: Arc<str> =
-      transform_source(&self.ctx.plugin_driver, source, &mut sourcemap_chain).await?.into();
+      transform_source(&self.ctx.plugin_driver, &self.resolved_path, source, &mut sourcemap_chain)
+        .await?
+        .into();
 
     let (ast, scope, scan_result, ast_symbol, namespace_symbol) = self.scan(&source);
     tracing::trace!("scan {:?}", self.resolved_path);

--- a/crates/rolldown/src/utils/transform_source.rs
+++ b/crates/rolldown/src/utils/transform_source.rs
@@ -1,3 +1,4 @@
+use rolldown_common::ResolvedPath;
 use rolldown_plugin::HookTransformArgs;
 use rolldown_sourcemap::SourceMap;
 
@@ -5,11 +6,12 @@ use crate::{error::BatchedErrors, plugin_driver::PluginDriver};
 
 pub async fn transform_source(
   plugin_driver: &PluginDriver,
+  resolved_path: &ResolvedPath,
   source: String,
   sourcemap_chain: &mut Vec<SourceMap>,
 ) -> Result<String, BatchedErrors> {
   let (code, map_chain) =
-    plugin_driver.transform(&HookTransformArgs { id: source.as_ref(), code: &source }).await?;
+    plugin_driver.transform(&HookTransformArgs { id: &resolved_path.path, code: &source }).await?;
 
   sourcemap_chain.extend(map_chain);
 

--- a/packages/node/test/cases/plugin/transform/config.ts
+++ b/packages/node/test/cases/plugin/transform/config.ts
@@ -7,13 +7,13 @@ const config: RollupOptions = {
   plugins: [
     {
       name: 'test-plugin',
-      transform: function (id, code) {
+      transform: function (code, id) {
         transformFn()
         if (id.endsWith('foo.js')) {
           expect(code).toStrictEqual('')
           return {
-            code: `console.log('foo')`,
-            map: { mappings: "" }
+            code: `console.log('transformed')`,
+            map: { mappings: '' },
           }
         }
       },
@@ -24,6 +24,8 @@ const config: RollupOptions = {
 export default {
   config,
   afterTest: (output: RollupOutput) => {
+    expect.assertions(3)
     expect(transformFn).toHaveBeenCalledTimes(2)
+    expect(output.output[0].code).contains('transformed')
   },
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Correct the `id` passed in the `transform` hook; it should be the resolved path, not `source`.

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

The unit test has been refined for greater precision to ensure that the transform result is included in the final bundle.


P.S This is my first PR in Rust language :P