### PR TITLE
feat: support windows for the justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,4 @@
+set windows-shell := ["powershell"]
 set shell := ["bash", "-cu"]
 
 _default:


### PR DESCRIPTION
### Description

Added a line that sets the `windows-shell` for the Justfile to Powershell. This doesn't change any non-windows platforms. 

Benchmarking does not work because the setup-bench recipe uses `sh` specific syntax. Maybe this could be rewritten? This could be in either a shell agnostic way or have multiple recipes, one for Windows and one for UNIX, alternatively, it's not the end of the world if benchmarking only works on unix. 

A rough powershell equivalent would be 
```powershell
foreach ($i in 0..10) { cp -r ./temp/three/src ./temp/three10x/copy$i/ }
echo "" > temp/three10x/entry.js
foreach ($i in 0..10) { echo "import * as three$i from './copy$i/Three.js'; export { three$i }" >> temp/three10x/entry.js }
```

### Test Plan

While it works on my device, somebody else testing it on Windows might be helpful. I'm not certain of how Windows handles some environment specific things for ex: what happens if Just or Rust is installed through Windows Subsystem for Linux.