### PR TITLE
fix: enforce non-empty chunks array and add type assertion

### DIFF
--- a/packages/node/src/utils/transform-to-rollup-output.ts
+++ b/packages/node/src/utils/transform-to-rollup-output.ts
@@ -69,12 +69,15 @@ function transformToRollupOutputAsset(asset: OutputAsset): RollupOutputAsset {
 export function transformToRollupOutput(output: Outputs): RollupOutput {
   const { chunks, assets } = output
 
+  if (chunks.length === 0) {
+    throw new Error("No output chunks found. At least one OutputChunk is required.");
+  }
+  
   return {
-    // @ts-expect-error here chunks.length > 0
     output: [
       ...chunks.map(transformToRollupOutputChunk),
       ...assets.map(transformToRollupOutputAsset),
-    ],
+    ] as [OutputChunk, ...(OutputChunk | OutputAsset)[]],
   }
 }
 


### PR DESCRIPTION
## Overview

This PR addresses a TypeScript compile-time error related to the `transformToRollupOutput` function's return type. The TypeScript compiler could not infer that the returned `output` array always meets the expected type `[OutputChunk, ...(OutputChunk | OutputAsset)[]]`, due to its dynamic construction.

## Problem

The TypeScript error was twofold:
1. There was a potential for the `chunks` array to be empty, which would violate the expected type by not providing at least one `OutputChunk`.
2. TypeScript could not statically verify that the constructed array met the specific tuple type expected.

## Solution

To resolve these issues, the following changes were made:
1. **Runtime Check**: Introduced a runtime check that throws an error if the `chunks` array is found to be empty. This ensures that the scenario of violating the expected type by having no `OutputChunk` is avoided.
   
   ```typescript
   if (chunks.length === 0) {
     throw new Error("No output chunks found. At least one OutputChunk is required.");
   }
