### PR TITLE
test: fix test input by removing go string template syntax

### DIFF
--- a/crates/rolldown/tests/esbuild/default/.preserve_key_comment/entry.js
+++ b/crates/rolldown/tests/esbuild/default/.preserve_key_comment/entry.js
@@ -1,3 +1,3 @@
-x(/* __KEY__ */ 'notKey', /* __KEY__ */ ` + "`" + `notKey` + "`" + `)
-x(/* @__KEY__ */ 'key', /* @__KEY__ */ ` + "`" + `key` + "`" + `)
-x(/* #__KEY__ */ 'alsoKey', /* #__KEY__ */ ` + "`" + `alsoKey` + "`" + `)
+x(/* __KEY__ */ 'notKey', /* __KEY__ */ `notKey`)
+x(/* @__KEY__ */ 'key', /* @__KEY__ */ `key`)
+x(/* #__KEY__ */ 'alsoKey', /* #__KEY__ */ `alsoKey`)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix snapshot for the test. Snapshot had syntax errors as it was copied with parts of Go string literal syntax.  

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
