### PR TITLE
feat: restrict typings and refactor `RenderedModule`

### DIFF
--- a/crates/rolldown/src/chunk/mod.rs
+++ b/crates/rolldown/src/chunk/mod.rs
@@ -2,6 +2,7 @@ mod de_conflict;
 pub mod render_chunk;
 mod render_chunk_exports;
 mod render_chunk_imports;
+
 use index_vec::IndexVec;
 use rolldown_common::ChunkId;
 
@@ -106,13 +107,7 @@ impl Chunk {
         );
         Some((
           m.resource_id.expect_file().to_string(),
-          RenderedModule {
-            original_length: m.source.len().try_into().unwrap(),
-            rendered_length: rendered_content
-              .as_ref()
-              .map(|c| c.code.len() as u32)
-              .unwrap_or_default(),
-          },
+          RenderedModule { code: None },
           rendered_content,
           if output_options.sourcemap.is_hidden() {
             None

--- a/crates/rolldown_binding/index.d.ts
+++ b/crates/rolldown_binding/index.d.ts
@@ -86,7 +86,7 @@ export interface RenderedChunk {
   moduleIds: Array<string>
   exports: Array<string>
   fileName: string
-  modules: Record<string, RenderedModule>
+  modules: Record<string, BindingRenderedModule>
 }
 export interface SourceMap {
   mappings: string
@@ -95,12 +95,8 @@ export interface SourceMap {
   sources: Array<string>
   sourcesContent: Array<string>
 }
-export interface RenderedModule {
+export interface BindingRenderedModule {
   code?: string
-  removedExports: Array<string>
-  renderedExports: Array<string>
-  originalLength: number
-  renderedLength: number
 }
 export interface OutputChunk {
   isEntry: boolean
@@ -109,7 +105,7 @@ export interface OutputChunk {
   moduleIds: Array<string>
   exports: Array<string>
   fileName: string
-  modules: Record<string, RenderedModule>
+  modules: Record<string, BindingRenderedModule>
   code: string
 }
 export interface OutputAsset {

--- a/crates/rolldown_binding/src/options/plugin/plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/plugin.rs
@@ -155,7 +155,8 @@ pub struct RenderedChunk {
   pub exports: Vec<String>,
   // RenderedChunk
   pub file_name: String,
-  pub modules: HashMap<String, crate::output::RenderedModule>,
+  #[serde(skip)]
+  pub modules: HashMap<String, crate::output::BindingRenderedModule>,
 }
 
 impl From<rolldown_common::RenderedChunk> for RenderedChunk {

--- a/crates/rolldown_binding/src/output.rs
+++ b/crates/rolldown_binding/src/output.rs
@@ -1,29 +1,23 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 
 use derivative::Derivative;
+use napi_derive::napi;
 use serde::Deserialize;
 
-#[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Derivative)]
-#[serde(rename_all = "camelCase")]
-#[derivative(Debug)]
-pub struct RenderedModule {
+#[napi(object)]
+pub struct BindingRenderedModule {
   pub code: Option<String>,
-  pub removed_exports: Vec<String>,
-  pub rendered_exports: Vec<String>,
-  pub original_length: u32,
-  pub rendered_length: u32,
 }
 
-impl From<rolldown_common::RenderedModule> for RenderedModule {
+impl Debug for BindingRenderedModule {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("BindingRenderedModule").field("code", &"...").finish()
+  }
+}
+
+impl From<rolldown_common::RenderedModule> for BindingRenderedModule {
   fn from(value: rolldown_common::RenderedModule) -> Self {
-    Self {
-      code: None,
-      original_length: value.original_length,
-      rendered_length: value.rendered_length,
-      removed_exports: vec![],
-      rendered_exports: vec![],
-    }
+    Self { code: value.code }
   }
 }
 
@@ -40,7 +34,8 @@ pub struct OutputChunk {
   pub exports: Vec<String>,
   // RenderedChunk
   pub file_name: String,
-  pub modules: HashMap<String, RenderedModule>,
+  #[serde(skip_deserializing)]
+  pub modules: HashMap<String, BindingRenderedModule>,
   // OutputChunk
   pub code: String,
 }

--- a/crates/rolldown_common/src/types/output_chunk.rs
+++ b/crates/rolldown_common/src/types/output_chunk.rs
@@ -2,6 +2,7 @@ use rustc_hash::FxHashMap;
 
 use super::rendered_module::RenderedModule;
 
+#[allow(clippy::zero_sized_map_values)]
 #[derive(Debug, Clone)]
 pub struct OutputChunk {
   // PreRenderedChunk

--- a/crates/rolldown_common/src/types/rendered_module.rs
+++ b/crates/rolldown_common/src/types/rendered_module.rs
@@ -1,6 +1,4 @@
 #[derive(Debug, Clone)]
 pub struct RenderedModule {
-  // The code of the module is omit at now.
-  pub original_length: u32,
-  pub rendered_length: u32,
+  pub code: Option<String>,
 }

--- a/justfile
+++ b/justfile
@@ -78,6 +78,7 @@ lint-node:
     yarn lint-filename
     yarn lint
     yarn prettier:ci
+    yarn typecheck
 
 lint:
     just lint-rust

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.25",
+    "type-fest": "^4.12.0",
     "typescript": "^5.4.2",
     "unbuild": "^2.0.0",
     "vitest": "^1.3.1"

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,6 +1,6 @@
+import { RolldownOutput } from './objects/rolldown-output'
 import type { InputOptions, RolldownPlugin } from './options/input-options'
 import type { OutputOptions } from './options/output-options'
-import { RolldownOutput } from './utils'
 
 export { rolldown, experimental_scan } from './rolldown'
 
@@ -15,5 +15,5 @@ export type {
   InputOptions,
   OutputOptions,
   RolldownPlugin as Plugin,
-  RolldownOutput as RollupOutput,
+  RolldownOutput as RollupOutput
 }

--- a/packages/node/src/objects/output-bundle.ts
+++ b/packages/node/src/objects/output-bundle.ts
@@ -1,0 +1,5 @@
+import { RolldownOutputAsset, RolldownOutputChunk } from './rolldown-output';
+
+export interface OutputBundle {
+  [fileName: string]: RolldownOutputAsset | RolldownOutputChunk;
+}

--- a/packages/node/src/objects/rendered-module.ts
+++ b/packages/node/src/objects/rendered-module.ts
@@ -1,0 +1,1 @@
+export interface RenderedModule { }

--- a/packages/node/src/objects/rolldown-output.ts
+++ b/packages/node/src/objects/rolldown-output.ts
@@ -1,0 +1,43 @@
+import type { OutputAsset, OutputChunk, RollupOutput } from '../rollup'
+import { HasProperty, IsPropertiesEqual, IsPropertyEqual, TypeAssert } from '../utils/type-assert';
+import { RenderedModule } from './rendered-module';
+
+export interface RolldownOutputAsset {
+  type: 'asset';
+  fileName: string;
+  source: string | Uint8Array;
+}
+
+function _assertRolldownOutputAsset() {
+  type _ = TypeAssert<IsPropertiesEqual<RolldownOutputAsset, OutputAsset>>;
+}
+
+export interface RolldownOutputChunk {
+  type: 'chunk';
+  code: string;
+  isEntry: boolean;
+  exports: string[];
+  fileName: string;
+  modules: {
+    [id: string]: RenderedModule;
+  };
+  facadeModuleId: string | null;
+  isDynamicEntry: boolean;
+  moduleIds: string[];
+}
+
+function _assertRolldownOutputChunk() {
+  type _ = TypeAssert<IsPropertiesEqual<Omit<RolldownOutputChunk, 'modules'>, OutputChunk>>;
+}
+
+export interface RolldownOutput {
+  output: [
+    RolldownOutputChunk,
+    ...(RolldownOutputChunk | RolldownOutputAsset)[],
+  ]
+}
+
+
+function _assertRolldownOutput() {
+  type _ = TypeAssert<HasProperty<RolldownOutput, 'output'>>;
+}

--- a/packages/node/src/options/create-build-plugin-adapter.ts
+++ b/packages/node/src/options/create-build-plugin-adapter.ts
@@ -34,7 +34,7 @@ function writeBundle(hook: Plugin['writeBundle']) {
     }
     return async (outputs: Outputs) => {
       try {
-        // TODO outputOptions
+        // @ts-expect-error: FIXME: hyf0
         await hook.call({} as any, {} as any, transformToOutputBundle(outputs))
       } catch (error) {
         console.error(error)
@@ -51,10 +51,10 @@ function generateBundle(hook: Plugin['generateBundle']) {
     }
     return async (outputs: Outputs, isWrite: boolean) => {
       try {
-        // TODO outputOptions
         await hook.call(
           {} as any,
           {} as any,
+          // @ts-expect-error: FIXME: hyf0
           transformToOutputBundle(outputs),
           isWrite,
         )
@@ -127,6 +127,7 @@ function renderChunk(hook: Plugin['renderChunk']) {
         const value = await hook.call(
           {} as any,
           code,
+          // @ts-expect-error: FIXME: hyf0
           renderedChunk,
           {} as any,
           {} as any,

--- a/packages/node/src/rolldown-build.ts
+++ b/packages/node/src/rolldown-build.ts
@@ -1,15 +1,14 @@
 import { Bundler } from '@rolldown/node-binding'
 import { normalizeOutputOptions, OutputOptions } from './options/output-options'
-import type { RollupBuild, SerializedTimings } from './rollup-types'
-import { transformToRollupOutput, RolldownOutput, unimplemented } from './utils'
+import { transformToRollupOutput, unimplemented } from './utils'
+import { RolldownOutput } from './objects/rolldown-output'
+import { HasProperty, TypeAssert } from './utils/type-assert'
 
-export class RolldownBuild implements Omit<RollupBuild, 'generate' | 'write'> {
+export class RolldownBuild {
   #bundler: Bundler
   constructor(bundler: Bundler) {
     this.#bundler = bundler
   }
-
-  closed = false
 
   async generate(outputOptions: OutputOptions = {}): Promise<RolldownOutput> {
     const bindingOptions = normalizeOutputOptions(outputOptions)
@@ -22,23 +21,8 @@ export class RolldownBuild implements Omit<RollupBuild, 'generate' | 'write'> {
     const output = await this.#bundler.write(bindingOptions)
     return transformToRollupOutput(output) as RolldownOutput
   }
+}
 
-  async close() {
-    this.closed = true
-  }
-
-  // -- unimplemented
-
-  get cache(): undefined {
-    throw unimplemented()
-    return unimplemented()
-  }
-  get watchFiles(): string[] {
-    throw unimplemented()
-    return unimplemented()
-  }
-  get getTimings(): () => SerializedTimings {
-    throw unimplemented()
-    return unimplemented()
-  }
+function _assert() {
+  type _ = TypeAssert<HasProperty<RolldownBuild, 'generate' | 'write'>>
 }

--- a/packages/node/src/rollup-types.ts
+++ b/packages/node/src/rollup-types.ts
@@ -1,8 +1,5 @@
 export type {
-  RollupBuild,
-  RollupOutput,
   OutputOptions,
-  SerializedTimings,
   InputOptions,
   Plugin,
   OutputPlugin,

--- a/packages/node/src/utils/index.ts
+++ b/packages/node/src/utils/index.ts
@@ -16,4 +16,11 @@ export function unimplemented(info?: string): never {
   throw new Error('unimplemented')
 }
 
-export function noop(..._args: any[]) {}
+export function unreachable(info?: string): never {
+  if (info) {
+    throw new Error(`unreachable: ${info}`)
+  }
+  throw new Error('unreachable')
+}
+
+export function noop(..._args: any[]) { }

--- a/packages/node/src/utils/transform-to-rollup-output.ts
+++ b/packages/node/src/utils/transform-to-rollup-output.ts
@@ -1,91 +1,42 @@
 import { OutputAsset, OutputChunk, Outputs } from '@rolldown/node-binding'
-import type {
-  RollupOutput,
-  OutputChunk as RollupOutputChunk,
-  OutputAsset as RollupOutputAsset,
-  OutputBundle,
-} from '../rollup-types'
-import { unimplemented } from '.'
+import { RolldownOutput, RolldownOutputAsset, RolldownOutputChunk } from '../objects/rolldown-output'
+import { OutputBundle } from '../objects/output-bundle'
 
-function transformToRollupOutputChunk(chunk: OutputChunk): RollupOutputChunk {
+function transformToRollupOutputChunk(chunk: OutputChunk): RolldownOutputChunk {
   return {
     type: 'chunk',
     code: chunk.code,
     fileName: chunk.fileName,
-    // @ts-expect-error undefined can't assign to null
-    modules: chunk.modules,
+    modules: Object.fromEntries(Object.entries(chunk.modules).map(([key, _]) => [key, ({})])),
     exports: chunk.exports,
     isEntry: chunk.isEntry,
     facadeModuleId: chunk.facadeModuleId || null,
     isDynamicEntry: chunk.isDynamicEntry,
     moduleIds: chunk.moduleIds,
-    get dynamicImports() {
-      return unimplemented()
-    },
-    get implicitlyLoadedBefore() {
-      return unimplemented()
-    },
-    get importedBindings() {
-      return unimplemented()
-    },
-    get imports() {
-      return unimplemented()
-    },
-    get referencedFiles() {
-      return unimplemented()
-    },
-    get map() {
-      return unimplemented()
-    },
-    get isImplicitEntry() {
-      return unimplemented()
-    },
-    get name() {
-      return unimplemented()
-    },
-    get sourcemapFileName() {
-      return unimplemented()
-    },
-    get preliminaryFileName() {
-      return unimplemented()
-    },
+
   }
 }
 
-function transformToRollupOutputAsset(asset: OutputAsset): RollupOutputAsset {
+function transformToRollupOutputAsset(asset: OutputAsset): RolldownOutputAsset {
   return {
     type: 'asset',
     fileName: asset.fileName,
     source: asset.source,
-    get name() {
-      return unimplemented()
-    },
-    get needsCodeReference() {
-      return unimplemented()
-    },
   }
 }
 
-export function transformToRollupOutput(output: Outputs): RollupOutput {
+export function transformToRollupOutput(output: Outputs): RolldownOutput {
   const { chunks, assets } = output
-
+  const [firstChunk, ...restChunks] = chunks
   return {
-    // @ts-expect-error here chunks.length > 0
     output: [
-      ...chunks.map(transformToRollupOutputChunk),
+      transformToRollupOutputChunk(firstChunk),
+      ...restChunks.map(transformToRollupOutputChunk),
       ...assets.map(transformToRollupOutputAsset),
     ],
   }
 }
 
-type RolldownOutputChunk = OutputChunk & { type: 'chunk' }
-type RolldownOutputAsset = OutputAsset & { type: 'asset' }
-export interface RolldownOutput {
-  output: [
-    RolldownOutputChunk,
-    ...(RolldownOutputChunk | RolldownOutputAsset)[],
-  ]
-}
 
 export function transformToOutputBundle(output: Outputs): OutputBundle {
   return Object.fromEntries(

--- a/packages/node/src/utils/type-assert.ts
+++ b/packages/node/src/utils/type-assert.ts
@@ -1,0 +1,18 @@
+import type { IsEqual } from 'type-fest'
+
+export type TypeAssert<T extends true> = T;
+
+export type HasProperty<T, K extends string> = K extends keyof T ? true : false;
+
+export type IsPropertyEqual<A, B, Key extends keyof A & keyof B> = IsEqual<A[Key], B[Key]>;
+
+type IsValuesOfObjectAllTrue<T> = {
+  [K in keyof T]: T[K] extends true ? true : false
+}[keyof T] extends true ? true : false;
+
+export type ShowPropertiesEqualStatus<A, B> = {
+  // If `K` only exists in `A`, we consider they are equal.
+  [K in keyof A]: K extends keyof B ? IsEqual<A[K], B[K]> : true
+};
+
+export type IsPropertiesEqual<A, B> = IsValuesOfObjectAllTrue<ShowPropertiesEqualStatus<A, B>>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,6 +1799,7 @@ __metadata:
   dependencies:
     "@rolldown/node-binding": "workspace:*"
     "@types/node": "npm:^20.11.25"
+    type-fest: "npm:^4.12.0"
     typescript: "npm:^5.4.2"
     unbuild: "npm:^2.0.0"
     vitest: "npm:^1.3.1"
@@ -11680,7 +11681,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.2.0":
+"type-fest@npm:^4.12.0, type-fest@npm:^4.2.0":
   version: 4.12.0
   resolution: "type-fest@npm:4.12.0"
   checksum: 10/5869216e840c962942672623e0447ed342f1eb6dbed1874a09ba1944b268c793bd8b5607c9f96ee01363e859a93f32ad06ab71a7aab29ff896bf18d66602a37b


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Types in `@rolldown/node` is kind of over-complex and mix up with rollup's types. I think we need make types reliable to our users and use other ways to keep the compatibility with rollup's types.

Types should make user aware what features are available and what aren't.

---

https://github.com/rolldown-rs/rolldown/blob/f81f87dc4a67f18b8de26f3084d20e003aec3d68/crates/rolldown_common/src/types/rendered_module.rs#L4-L5

Above length is calculated based on utf-8 while rollup emits length based utf-16. Remove these currently, until we find a way to get correct result.

---



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
