### PR TITLE
feat: preserve class names when renaming declarations

### DIFF
--- a/crates/rolldown/src/finalizer/impl_visit_mut_for_finalizer.rs
+++ b/crates/rolldown/src/finalizer/impl_visit_mut_for_finalizer.rs
@@ -310,6 +310,26 @@ impl<'ast, 'me: 'ast> VisitMut<'ast> for Finalizer<'me, 'ast> {
     }
   }
 
+  fn visit_class(&mut self, class: &mut ast::Class<'ast>) {
+    // Visit children without `visit_binding_identifier` as we don't want to rename class and cause runtime difference
+
+    for decorator in class.decorators.iter_mut() {
+      self.visit_decorator(decorator);
+    }
+
+    if let Some(parameters) = &mut class.type_parameters {
+      self.visit_ts_type_parameter_declaration(parameters);
+    }
+
+    if let Some(super_class) = &mut class.super_class {
+      self.visit_class_heritage(super_class);
+    }
+    if let Some(super_parameters) = &mut class.super_type_parameters {
+      self.visit_ts_type_parameter_instantiation(super_parameters);
+    }
+    self.visit_class_body(&mut class.body);
+  }
+
   #[allow(clippy::collapsible_else_if)]
   fn visit_expression(&mut self, expr: &mut ast::Expression<'ast>) {
     if let Some(call_expr) = expr.as_call_expression() {

--- a/crates/rolldown/tests/esbuild/default/keep_names_class_static_name/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/keep_names_class_static_name/artifacts.snap
@@ -33,27 +33,27 @@ class F {
 	static ['name']=0;
 
 }
-let a = class a$1 {
+let a = class a {
 	static foo;
 
 };
-let b = class b$1 {
+let b = class b {
 	static name;
 
 };
-let c = class c$1 {
+let c = class c {
 	static name(){
 	}
 };
-let d = class d$1 {
+let d = class d {
 	static get name(){
 	}
 };
-let e = class e$1 {
+let e = class e {
 	static set name(x){
 	}
 };
-let f = class f$1 {
+let f = class f {
 	static ['name']=0;
 
 };

--- a/packages/rollup-tests/src/failed-tests.json
+++ b/packages/rollup-tests/src/failed-tests.json
@@ -91,7 +91,6 @@
   "rollup@function@class-name-conflict-2: does not shadow variables when preserving class names",
   "rollup@function@class-name-conflict-3: does not shadow variables when preserving class names",
   "rollup@function@class-name-conflict-4: does not shadow variables when preserving class names",
-  "rollup@function@class-name-conflict: preserves class names even if the class is renamed",
   "rollup@function@class-prop-returns: does not remove calls to props without value",
   "rollup@function@code-splitting-export-default-from-entry: correctly imports the default from an entry point",
   "rollup@function@compact-multiple-imports: correctly handles empty external imports in compact mode",

--- a/packages/rollup-tests/src/intercept/check.js
+++ b/packages/rollup-tests/src/intercept/check.js
@@ -51,6 +51,7 @@ afterEach(function updateStatus() {
   }
   const state = this.currentTest.state
   if (state === 'failed') {
+    console.error(this.currentTest.err)
     status.failed += 1
     failedTests.add(calcTestId(this.currentTest))
   } else if (state === 'passed') {

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,6 +1,6 @@
 {
   "failed": 0,
-  "skipFailed": 657,
+  "skipFailed": 656,
   "skipped": 0,
-  "passed": 235
+  "passed": 236
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -1,6 +1,6 @@
 |  | number |
 |----| ---- |
 | failed | 0|
-| skipFailed | 657|
+| skipFailed | 656|
 | skipped | 0|
-| passed | 235|
+| passed | 236|


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR 
is solving -->

Preserve class names when fixing naming collisions.

When variable name clashes:
```ts
const a = class {}
```

becomes:
```ts
const a$1 = class a {}
```

When class name clashes:

```ts
class A {}
```

becomes:

```ts
var A$1 = class A {} 
```

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Enabled `rollup@function@class-name-conflict` test.

This is my first actual Rust PR, so there could be issues.

---
