### PR TITLE
feat: add side effect detection for most of the statements

### DIFF
--- a/crates/rolldown/src/ast_scanner/side_effect_detector.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector.rs
@@ -259,6 +259,9 @@ impl<'a> SideEffectDetector<'a> {
       Statement::ReturnStatement(ret_stmt) => {
         ret_stmt.argument.as_ref().map_or(false, |expr| self.detect_side_effect_of_expr(expr))
       }
+      Statement::LabeledStatement(labeled_stmt) => {
+        self.detect_side_effect_of_stmt(&labeled_stmt.body)
+      }
       Statement::EmptyStatement(_)
       | Statement::ContinueStatement(_)
       | Statement::BreakStatement(_) => false,
@@ -266,7 +269,6 @@ impl<'a> SideEffectDetector<'a> {
       | Statement::ForInStatement(_)
       | Statement::ForOfStatement(_)
       | Statement::ForStatement(_)
-      | Statement::LabeledStatement(_)
       | Statement::SwitchStatement(_)
       | Statement::ThrowStatement(_)
       | Statement::TryStatement(_)
@@ -456,5 +458,14 @@ mod test {
     assert!(!get_statements_side_effect("return 1;"));
     // accessing global variable may have side effect
     assert!(get_statements_side_effect("return bar;"));
+  }
+
+  #[test]
+  fn test_labeled_statement() {
+    assert!(!get_statements_side_effect("label: { }"));
+    assert!(!get_statements_side_effect("label: { const a = 1; }"));
+    // accessing global variable may have side effect
+    assert!(get_statements_side_effect("label: { const a = 1; bar; }"));
+    assert!(get_statements_side_effect("label: { bar; }"));
   }
 }

--- a/crates/rolldown/src/ast_scanner/side_effect_detector.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector.rs
@@ -240,8 +240,10 @@ impl<'a> SideEffectDetector<'a> {
           unreachable!("ts should be transpiled")
         }
       },
-      Statement::BlockStatement(_)
-      | Statement::BreakStatement(_)
+      Statement::BlockStatement(block) => {
+        block.body.iter().any(|stmt| self.detect_side_effect_of_stmt(stmt))
+      }
+      Statement::BreakStatement(_)
       | Statement::DebuggerStatement(_)
       | Statement::DoWhileStatement(_)
       | Statement::EmptyStatement(_)
@@ -379,5 +381,15 @@ mod test {
     assert!(get_statements_side_effect("true ? bar : true"));
     assert!(get_statements_side_effect("foo ? true : false"));
     assert!(get_statements_side_effect("true ? bar : true"));
+  }
+
+  #[test]
+  fn test_block_statement() {
+    assert!(!get_statements_side_effect("{ }"));
+    assert!(!get_statements_side_effect("{ const a = 1; }"));
+    assert!(!get_statements_side_effect("{ const a = 1; const b = 2; }"));
+
+    // accessing global variable may have side effect
+    assert!(get_statements_side_effect("{ const a = 1; bar; }"));
   }
 }

--- a/crates/rolldown/src/ast_scanner/side_effect_detector.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector.rs
@@ -256,8 +256,8 @@ impl<'a> SideEffectDetector<'a> {
           || self.detect_side_effect_of_stmt(&if_stmt.consequent)
           || if_stmt.alternate.as_ref().map_or(false, |stmt| self.detect_side_effect_of_stmt(stmt))
       }
-      Statement::BreakStatement(_)
-      | Statement::DebuggerStatement(_)
+      Statement::ContinueStatement(_) | Statement::BreakStatement(_) => false,
+      Statement::DebuggerStatement(_)
       | Statement::EmptyStatement(_)
       | Statement::ForInStatement(_)
       | Statement::ForOfStatement(_)
@@ -267,8 +267,7 @@ impl<'a> SideEffectDetector<'a> {
       | Statement::SwitchStatement(_)
       | Statement::ThrowStatement(_)
       | Statement::TryStatement(_)
-      | Statement::WithStatement(_)
-      | Statement::ContinueStatement(_) => true,
+      | Statement::WithStatement(_) => true,
     }
   }
 }
@@ -430,5 +429,15 @@ mod test {
     assert!(get_statements_side_effect("if (bar) { const a = 1; }"));
     assert!(get_statements_side_effect("if (true) { const a = 1; bar; }"));
     assert!(get_statements_side_effect("if (true) { bar; }"));
+  }
+
+  #[test]
+  fn test_continue_statement() {
+    assert!(!get_statements_side_effect("while (true) { continue; }"));
+  }
+
+  #[test]
+  fn test_break_statement() {
+    assert!(!get_statements_side_effect("while (true) { break; }"));
   }
 }

--- a/crates/rolldown/src/ast_scanner/side_effect_detector.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector.rs
@@ -240,9 +240,7 @@ impl<'a> SideEffectDetector<'a> {
           unreachable!("ts should be transpiled")
         }
       },
-      Statement::BlockStatement(block) => {
-        block.body.iter().any(|stmt| self.detect_side_effect_of_stmt(stmt))
-      }
+      Statement::BlockStatement(block) => self.detect_side_effect_of_block(block),
       Statement::DoWhileStatement(do_while) => {
         self.detect_side_effect_of_stmt(&do_while.body)
           || self.detect_side_effect_of_expr(&do_while.test)

--- a/crates/rolldown/src/ast_scanner/side_effect_detector.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector.rs
@@ -259,9 +259,10 @@ impl<'a> SideEffectDetector<'a> {
       Statement::ReturnStatement(ret_stmt) => {
         ret_stmt.argument.as_ref().map_or(false, |expr| self.detect_side_effect_of_expr(expr))
       }
-      Statement::ContinueStatement(_) | Statement::BreakStatement(_) => false,
+      Statement::EmptyStatement(_)
+      | Statement::ContinueStatement(_)
+      | Statement::BreakStatement(_) => false,
       Statement::DebuggerStatement(_)
-      | Statement::EmptyStatement(_)
       | Statement::ForInStatement(_)
       | Statement::ForOfStatement(_)
       | Statement::ForStatement(_)
@@ -431,6 +432,12 @@ mod test {
     assert!(get_statements_side_effect("if (bar) { const a = 1; }"));
     assert!(get_statements_side_effect("if (true) { const a = 1; bar; }"));
     assert!(get_statements_side_effect("if (true) { bar; }"));
+  }
+
+  #[test]
+  fn test_empty_statement() {
+    assert!(!get_statements_side_effect(";"));
+    assert!(!get_statements_side_effect(";;"));
   }
 
   #[test]

--- a/packages/rollup-tests/src/failed-tests.json
+++ b/packages/rollup-tests/src/failed-tests.json
@@ -598,6 +598,7 @@
   "rollup@function@preserves-catch-argument: does not replace argument to catch block (#1462)",
   "rollup@function@preserves-default-exports-used-locally: preserves default exports that are only used locally (#984)",
   "rollup@function@preserves-function-expression-names: does not rewrite function expression names incorrectly (#1083)",
+  "rollup@function@preserves-var-declarations-in-dead-branches: preserves var declarations in dead branches (#977)",
   "rollup@function@prevent-asi-with-line-comments: prevent semicolon insertion for return statements when there are line comments",
   "rollup@function@prevent-context-resolve-loop: prevents infinite loops when several plugins are calling this.resolve in resolveId",
   "rollup@function@prevent-tree-shaking-asi: prevent automatic semicolon insertion from changing behaviour when tree-shaking",

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,6 +1,6 @@
 {
   "failed": 0,
-  "skipFailed": 657,
+  "skipFailed": 658,
   "skipped": 0,
-  "passed": 235
+  "passed": 234
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -1,6 +1,6 @@
 |  | number |
 |----| ---- |
 | failed | 0|
-| skipFailed | 657|
+| skipFailed | 658|
 | skipped | 0|
-| passed | 235|
+| passed | 234|


### PR DESCRIPTION
### Description

Implemented side effect detection for:
* BlockStatement
* DoWhileStatement
* WhileStatement
* IfStatement
* ReturnStatement
* LabeledStatement
* TryStatement
* EmptyStatement
* ContinueStatement
* BreakStatement
* SwitchStatement

### Test Plan

Rust tests added.

Actually disabled one failing Rollup test:

```js
if ( false ) {
	var foo;
}

assert.equal( foo, undefined );
```

After implementing side effect detection for `if` test is now failing. This is because `VariableDeclaration` without `init` is considered side effect free right now.
`VariableDeclaration` needs a better detection. It is not side effect free if it is being referenced.