### PR TITLE
chore: improve paths configuration and update "how to use" section

### DIFF
--- a/scripts/gen-esbuild-test.js
+++ b/scripts/gen-esbuild-test.js
@@ -9,12 +9,12 @@ import chalk from 'chalk'
 import * as dedent from 'dedent'
 
 // How to use this script
-// 1. Set the root directory (relative to scripts dir)
+// 1. Set the tests root directory
 
-/** Relative to scripts dir. Expected values: '../crates/rolldown' or './', or your variant.  */
-const TESTS_ROOT_DIR = './'
+const TESTS_ROOT_DIR = import.meta.dirname
+// const TESTS_ROOT_DIR = path.resolve(import.meta.dirname, '..crates/rolldown')
 
-// 2. Set the test suite name. Refer to the 'suites' constant object for possible variants.
+// 2. Set the test suite name.
 
 /** @type {TestSuiteName} {@link suites} */
 const SUITE_NAME = 'default'
@@ -184,13 +184,11 @@ for (let i = 0, len = tree.rootNode.namedChildren.length; i < len; i++) {
       continue
     }
     const testDir = path.resolve(
-      import.meta.dirname,
       TESTS_ROOT_DIR,
       `tests/esbuild/${SUITE_NAME}`,
       testCaseName,
     )
     const ignoredTestDir = path.resolve(
-      import.meta.dirname,
       TESTS_ROOT_DIR,
       `tests/esbuild/${SUITE_NAME}`,
       `.${testCaseName}`,

--- a/scripts/gen-esbuild-test.js
+++ b/scripts/gen-esbuild-test.js
@@ -185,11 +185,13 @@ for (let i = 0, len = tree.rootNode.namedChildren.length; i < len; i++) {
       continue
     }
     const testDir = path.resolve(
+      import.meta.dirname,
       TESTS_ROOT_DIR,
       `tests/esbuild/${SUITE_NAME}`,
       testCaseName,
     )
     const ignoredTestDir = path.resolve(
+      import.meta.dirname,
       TESTS_ROOT_DIR,
       `tests/esbuild/${SUITE_NAME}`,
       `.${testCaseName}`,

--- a/scripts/gen-esbuild-test.js
+++ b/scripts/gen-esbuild-test.js
@@ -11,9 +11,20 @@ import * as dedent from 'dedent'
 const __dirname = import.meta.dirname
 
 // How to use this script
-// 1. Adding a test golang file under this dir or wherever you want, and modify the source path
-// 2. `let testDir = path.resolve(__dirname, "test", testCaseName);` Modify this testDir, by default,
-// The script will generate testCases under `${__dirname}/test`
+// 1. Set the root directory where the 'tests/esbuild' directory will be created.
+//    By default, it's the 'scripts' directory (import.meta.dirname).
+
+/** Expected values: '../crates/rolldown' or import.meta.dirname, or your variant.  */
+const TESTS_ROOT_DIR = import.meta.dirname
+
+// 2. Set the test suite name. Refer to the 'suites' constant object for possible variants.
+
+/** @type {TestSuiteName} {@link suites} */
+const SUITE_NAME = 'default'
+
+// 3. Download .go test source file located in the suites object
+//    for each suite and place it under "scripts" dir.
+//    (You can skip this step, the script can download it for you)
 
 /**
  * Constant object containing test suites.
@@ -91,11 +102,57 @@ async function readTestSuiteSource(testSuiteName) {
   }
 }
 
-/** @type {TestSuiteName} */
-const TEST_SUITE_NAME = 'default'
-const currentSuite = suites[TEST_SUITE_NAME]
+/**
+ * Figures out the path for test directories for a specific test case.
+ * @param {string} testsRootDir - The directory where the 'tests/esbuild' directory will be created.
+ * @param {TestSuiteName} suiteName - The name of the test suite, 'tests/esbuild/default'.
+ * @param {string} testCaseName - current test case. tests/esbuild/default/preserve_key_comment
+ * @param {string} [testsEsbuild='tests/esbuild'] - Defaults to 'tests/esbuild'. Pass another path if needed.
+ * @returns {{testDir: string; ignoredTestDir: string; testDirExistsAndNotEmpty: boolean}} - The paths for the test directories and the corresponding ignored test directories.
+ *
+ * @example
+ * ```
+ * const SUITE_NAME = 'defaut'
+ * // Change this constant to 'import.meta.dirname' to generate tests under the 'scripts' directory.
+ * const TESTS_ROOT_DIR = '../crates/rolldown'
+ * const testCaseName = 'preserve_key_comment'
+ * const { testDir, ignoredTestDir } = resolveTestCaseDirs(TESTS_ROOT_DIR, SUITE_NAME, testCaseName)
+ * //  start_of_global_path/rolldown/crates/rolldown/tests/esbuild/default/preserve_key_comment,
+ * //  start_of_global_path/rolldown/crates/rolldown/tests/esbuild/default/.preserve_key_comment
+ * ```
+ */
+function resolveTestCaseDir(
+  testsRootDir,
+  suiteName,
+  testCaseName,
+  testsEsbuild = 'tests/esbuild',
+) {
+  const esbuildTestDir = path.resolve(
+    import.meta.dirname,
+    testsRootDir,
+    testsEsbuild,
+  )
+
+  const testDir = path.resolve(esbuildTestDir, suiteName, testCaseName)
+  const ignoredTestDir = path.resolve(
+    esbuildTestDir,
+    suiteName,
+    `.${testCaseName}`,
+  )
+
+  const testDirExistsAndNotEmpty =
+    (fs.existsSync(testDir) && !isDirEmptySync(testDir)) ||
+    (fs.existsSync(ignoredTestDir) && !isDirEmptySync(ignoredTestDir))
+
+  return {
+    testDir,
+    ignoredTestDir,
+    testDirExistsAndNotEmpty,
+  }
+}
+
 /** The contents of the .go test source file. {@link suites} */
-const source = await readTestSuiteSource(TEST_SUITE_NAME)
+const source = await readTestSuiteSource(SUITE_NAME)
 const ignoredTestName = [
   'ts',
   'txt',
@@ -178,22 +235,15 @@ for (let i = 0, len = tree.rootNode.namedChildren.length; i < len; i++) {
     if (ignoredTestName.some((name) => testCaseName.includes(name))) {
       continue
     }
-    let testDir = path.resolve(
-      __dirname,
-      `../crates/rolldown/tests/esbuild/${currentSuite.name}`,
+
+    const { testDir, testDirExistsAndNotEmpty } = resolveTestCaseDir(
+      TESTS_ROOT_DIR,
+      SUITE_NAME,
       testCaseName,
-    )
-    let ignoredTestDir = path.resolve(
-      __dirname,
-      `../crates/rolldown/tests/esbuild/${currentSuite.name}`,
-      `.${testCaseName}`,
     )
 
     // Cause if you withdraw directory in git system, git will cleanup dir but leave the directory alone
-    if (
-      (fs.existsSync(testDir) && !isDirEmptySync(testDir)) ||
-      (fs.existsSync(ignoredTestDir) && !isDirEmptySync(ignoredTestDir))
-    ) {
+    if (testDirExistsAndNotEmpty) {
       continue
     } else {
       fs.ensureDirSync(testDir)

--- a/scripts/gen-esbuild-test.js
+++ b/scripts/gen-esbuild-test.js
@@ -9,15 +9,19 @@ import chalk from 'chalk'
 import * as dedent from 'dedent'
 
 // How to use this script
-// 1. Set the tests root directory
 
-const TESTS_ROOT_DIR = import.meta.dirname
-// const TESTS_ROOT_DIR = path.resolve(import.meta.dirname, '..crates/rolldown')
-
-// 2. Set the test suite name.
+// 1. Set the test suite name.
 
 /** @type {TestSuiteName} {@link suites} */
 const SUITE_NAME = 'default'
+
+// 2. Set the tests root directory
+
+const TESTS_ROOT_DIR = path.resolve(
+  import.meta.dirname,
+  'tests/esbuild',
+  SUITE_NAME,
+)
 
 // 3. Download .go test source file located in the suites object
 //    for each suite and place it under "scripts" dir.
@@ -183,16 +187,8 @@ for (let i = 0, len = tree.rootNode.namedChildren.length; i < len; i++) {
     if (ignoredTestName.some((name) => testCaseName.includes(name))) {
       continue
     }
-    const testDir = path.resolve(
-      TESTS_ROOT_DIR,
-      `tests/esbuild/${SUITE_NAME}`,
-      testCaseName,
-    )
-    const ignoredTestDir = path.resolve(
-      TESTS_ROOT_DIR,
-      `tests/esbuild/${SUITE_NAME}`,
-      `.${testCaseName}`,
-    )
+    const testDir = path.resolve(TESTS_ROOT_DIR, testCaseName)
+    const ignoredTestDir = path.resolve(TESTS_ROOT_DIR, `.${testCaseName}`)
 
     // Cause if you withdraw directory in git system, git will cleanup dir but leave the directory alone
     if (

--- a/scripts/gen-esbuild-test.js
+++ b/scripts/gen-esbuild-test.js
@@ -9,11 +9,10 @@ import chalk from 'chalk'
 import * as dedent from 'dedent'
 
 // How to use this script
-// 1. Set the root directory where the 'tests/esbuild' directory will be created.
-//    By default, it's the 'scripts' directory (import.meta.dirname).
+// 1. Set the root directory (relative to scripts dir)
 
-/** Expected values: '../crates/rolldown' or import.meta.dirname, or your variant.  */
-const TESTS_ROOT_DIR = import.meta.dirname
+/** Relative to scripts dir. Expected values: '../crates/rolldown' or './', or your variant.  */
+const TESTS_ROOT_DIR = './'
 
 // 2. Set the test suite name. Refer to the 'suites' constant object for possible variants.
 

--- a/scripts/gen-esbuild-test.js
+++ b/scripts/gen-esbuild-test.js
@@ -112,7 +112,7 @@ async function readTestSuiteSource(testSuiteName) {
  *
  * @example
  * ```
- * const SUITE_NAME = 'defaut'
+ * const SUITE_NAME = 'default'
  * // Change this constant to 'import.meta.dirname' to generate tests under the 'scripts' directory.
  * const TESTS_ROOT_DIR = '../crates/rolldown'
  * const testCaseName = 'preserve_key_comment'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

1. Added the resolveTestCaseDir function to simplify the main loop code
2. Created the TESTS_ROOT_DIR constant and placed it at the top of the file for easy configuration from one place.
3. Updated the 'How to use this script' section.

Note: I want to point out, that first version of script had. But was removed later.
```js
// TODO Add a `.` prefix instead of skipping rest of the code.
```
![image](https://github.com/rolldown/rolldown/assets/79873939/bb6f6cdf-651e-4acf-9f9c-7b4a95b1b63d)
https://github.com/rolldown/rolldown/pull/105/commits/4a4a3f149cc3caf7a436ebe3a6b9b28019044dba

That script, as i understand, never generated prefixed with `.` directories for skipped tests.
But there are prefixed with dot skipped tests in  /crates/rolldown/tests/esbuild/
Maybe, it  was generated some other way.
Just want to point, maybe we still need to generate dot-prefixed directories for skipped tests. Maybe the deletion of the TODO comment was accidental.



### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

