### PR TITLE
chore: optimize sourcemap 

### DIFF
--- a/crates/rolldown_sourcemap/src/concat_sourcemap.rs
+++ b/crates/rolldown_sourcemap/src/concat_sourcemap.rs
@@ -7,51 +7,55 @@ use crate::SourceMap;
 pub fn concat_sourcemaps(
   content_and_sourcemaps: &[(String, Option<SourceMap>)],
 ) -> Result<(String, SourceMap), BuildError> {
-  let mut s = String::new();
+  let line_offsets: Vec<usize> =
+    content_and_sourcemaps.iter().map(|(content, _)| content.lines().count() + 1).collect();
+
+  let total_content = content_and_sourcemaps
+    .iter()
+    .map(|(content, _)| content.as_str())
+    .collect::<Vec<&str>>()
+    .join("\n");
+
   let mut map = ParcelSourcemap::new("");
   let mut line_offset = 0;
 
-  for (index, (content, sourcemap)) in content_and_sourcemaps.iter().enumerate() {
-    s.push_str(content);
-    if index != content_and_sourcemaps.len() - 1 {
-      s.push('\n');
-    }
-
-    if let Some(sourcemap) = sourcemap {
+  for (index, (_, sourcemap_option)) in content_and_sourcemaps.iter().enumerate() {
+    if let Some(sourcemap) = sourcemap_option {
       map
         .add_sourcemap(
           &mut sourcemap.get_inner().cloned().ok_or(BuildError::sourcemap_error(
             "concat sourcemap not inner sourcemap".to_string(),
           ))?,
-          line_offset.into(),
+          line_offset as i64,
         )
         .map_err(|e| BuildError::sourcemap_error(e.to_string()))?;
     }
-    line_offset += u32::try_from(content.lines().count() + 1)
-      .map_err(|e| BuildError::sourcemap_error(e.to_string()))?;
+
+    line_offset += line_offsets[index];
   }
 
-  Ok((s, map.into()))
+  Ok((total_content, map.into()))
 }
 
 #[cfg(test)]
 mod tests {
   use parcel_sourcemap::SourceMap;
-  use serde_json;
+  use serde_json::{self, Value};
   #[test]
   fn concat_sourcemaps_works() {
     let map = SourceMap::from_json(
-        "",
-        r#"{
-          "version":3,
-          "sourceRoot":"",
-          "mappings":"AAAA,SAAS,QAAQ,CAAC,IAAY;IAC5B,OAAO,CAAC,GAAG,CAAC,iBAAU,IAAI,CAAE,CAAC,CAAC;AAChC,CAAC",
-          "sources":["index.ts"],
-          "sourcesContent":["function sayHello(name: string) {\n  console.log(`Hello, ${name}`);\n}\n"],
-          "names":[]
-        }"#,
-    )
-    .unwrap().into();
+          "",
+          r#"{
+              "version":3,
+              "sourceRoot":null,
+              "mappings":"AAAA,SAAS,QAAQ,CAAC,IAAY;IAC5B,OAAO,CAAC,GAAG,CAAC,iBAAU,IAAI,CAAE,CAAC,CAAC;AAChC,CAAC",
+              "sources":["index.ts"],
+              "sourcesContent":["function sayHello(name: string) {\n  console.log(`Hello, ${name}`);\n}\n"],
+              "names":[]
+          }"#,
+      )
+      .unwrap().into();
+
     let content_and_sourcemaps = vec![
       ("\nconsole.log()".to_string(), None),
       (
@@ -60,28 +64,30 @@ mod tests {
       ),
     ];
 
-    let (content, mut map) =
+    let (content, mut map_result) =
       super::concat_sourcemaps(&content_and_sourcemaps).expect("should not fail");
 
     assert_eq!(
       content,
       "\nconsole.log()\nfunction sayHello(name: string) {\n  console.log(`Hello, ${name}`);\n}\n"
     );
-    let expected = r#"{
-      "version": 3,
-      "sources": [
-      "index.ts"
-    ],
-    "sourceRoot": null,
-    "sourcesContent": [
-        "function sayHello(name: string) {\n  console.log(`Hello, ${name}`);\n}\n"
-    ],
-    "names": [],
-    "mappings": ";;;AAAA,SAAS,QAAQ,CAAC,IAAY;IAC5B,OAAO,CAAC,GAAG,CAAC,iBAAU,IAAI,CAAE,CAAC,CAAC;AAChC,CAAC"
-  }"#;
-    assert_eq!(
-      map.to_json().as_str().parse::<serde_json::Value>().unwrap(),
-      expected.parse::<serde_json::Value>().unwrap()
-    );
+
+    let expected_json = serde_json::from_str::<Value>(r#"{
+          "version": 3,
+          "sources": ["index.ts"],
+          "sourceRoot": null,
+          "sourcesContent": ["function sayHello(name: string) {\n  console.log(`Hello, ${name}`);\n}\n"],
+          "names": [],
+          "mappings": ";;;AAAA,SAAS,QAAQ,CAAC,IAAY;IAC5B,OAAO,CAAC,GAAG,CAAC,iBAAU,IAAI,CAAE,CAAC,CAAC;AAChC,CAAC"
+      }"#).unwrap();
+
+    match map_result.to_json() {
+      Some(Ok(json_string)) => {
+        let actual_json = serde_json::from_str::<Value>(&json_string).unwrap();
+        assert_eq!(actual_json, expected_json);
+      }
+      Some(Err(e)) => panic!("Error generating JSON: {:?}", e),
+      None => panic!("JSON generation resulted in None"),
+    }
   }
 }

--- a/crates/rolldown_sourcemap/src/concat_sourcemap.rs
+++ b/crates/rolldown_sourcemap/src/concat_sourcemap.rs
@@ -10,7 +10,7 @@ pub fn concat_sourcemaps(
   let line_offsets: Vec<usize> =
     content_and_sourcemaps.iter().map(|(content, _)| content.lines().count() + 1).collect();
 
-  let total_content = content_and_sourcemaps
+  let sourcemap_content = content_and_sourcemaps
     .iter()
     .map(|(content, _)| content.as_str())
     .collect::<Vec<&str>>()
@@ -34,7 +34,7 @@ pub fn concat_sourcemaps(
     line_offset += line_offsets[index];
   }
 
-  Ok((total_content, map.into()))
+  Ok((sourcemap_content, map.into()))
 }
 
 #[cfg(test)]

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -86,7 +86,7 @@ pub fn collapse_sourcemaps(
 #[cfg(test)]
 mod tests {
   use crate::SourceMap;
-  use serde_json;
+  use serde_json::{self, Value};
   #[test]
   fn it_works() {
     let sourcemaps = vec![
@@ -118,8 +118,8 @@ mod tests {
 
     let result =
       super::collapse_sourcemaps(sourcemaps).expect("should not fail").unwrap().to_json();
-
-    let expected = r#"{
+    let expected_json = serde_json::from_str::<Value>(
+      r#"{
       "version": 3,
       "sources": [
       "index.ts"
@@ -136,10 +136,16 @@ mod tests {
       "concat"
     ],
     "mappings": "AAAA,SAAS,SAAS,CAAY,EAC5B,QAAQ,GAAG,CAAC,UAAA,MAAA,CAAU,GACxB"
-  }"#;
-    assert_eq!(
-      result.as_str().parse::<serde_json::Value>().unwrap(),
-      expected.parse::<serde_json::Value>().unwrap()
-    );
+  }"#,
+    )
+    .unwrap();
+    match result {
+      Some(Ok(json_string)) => {
+        let actual_json = serde_json::from_str::<Value>(&json_string).unwrap();
+        assert_eq!(actual_json, expected_json);
+      }
+      Some(Err(e)) => panic!("Error generating JSON: {:?}", e),
+      None => panic!("JSON generation resulted in None"),
+    }
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

1. Optimize concat_sourcemaps to calculate the offset in advance at the end of the judgment if you prevent repeated calculation in the loop

2. Fix the wrong test sourcemap type

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
