### PR TITLE
fix: rolldown example root is empty in debug mode

### DIFF
--- a/crates/rolldown/examples/basic.rs
+++ b/crates/rolldown/examples/basic.rs
@@ -5,7 +5,10 @@ use sugar_path::SugarPathBuf;
 #[tokio::main]
 async fn main() {
   rolldown_tracing::try_init_tracing();
-  let root = PathBuf::from(&std::env::var("CARGO_MANIFEST_DIR").unwrap());
+  let root = PathBuf::from(
+    &std::env::var("CARGO_MANIFEST_DIR")
+      .unwrap_or(std::env::current_dir().unwrap().display().to_string()),
+  );
   let cwd = root.join("./examples").into_normalize();
   let mut bundler = Bundler::new(InputOptions {
     input: vec![


### PR DESCRIPTION
The root variable of the file path crates/rolldown/examples/basic.rs is empty in debug mode