### PR TITLE
ci: move node-validation to seprate file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,36 +116,6 @@ jobs:
       - name: Run Test
         run: pnpm test
 
-  node-validation:
-    name: Node Validation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Install node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Oxc Lint
-        run: pnpm lint-code
-
-      - name: Lint Filename
-        run: pnpm lint-filename
-
-      - name: Format Check
-        run: pnpm format:ci
-
-      - name: Lint Spell
-        run: pnpm lint-spell
-
   # changesets:
   #   name: Changesets Status
   #   runs-on: ubuntu-latest

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -1,0 +1,40 @@
+name: Lint code
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+
+jobs:
+  node-validation:
+    name: Node Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Oxc Lint
+        run: pnpm lint-code
+
+      - name: Lint Filename
+        run: pnpm lint-filename
+
+      - name: Format Check
+        run: pnpm format:ci
+
+      - name: Lint Spell
+        run: pnpm lint-spell


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`pnpm format:ci` will format Markdown files. but the ci action will ignore markdown changes. So I think we should do a lint check in the new action.
### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
