### PR TITLE
refactor: implement `ConcatSource` again

### DIFF
--- a/crates/rolldown/src/chunk/mod.rs
+++ b/crates/rolldown/src/chunk/mod.rs
@@ -14,7 +14,9 @@ use rolldown_common::{
 };
 use rolldown_error::BuildError;
 use rolldown_rstr::Rstr;
-use rolldown_sourcemap::{collapse_sourcemaps, concat_sourcemaps, SourceMap};
+use rolldown_sourcemap::{
+  collapse_sourcemaps, ConcatSource, RawSource, SourceMap, SourceMapSource,
+};
 use rolldown_utils::BitSet;
 use rustc_hash::FxHashMap;
 
@@ -87,10 +89,11 @@ impl Chunk {
   ) -> BatchedResult<ChunkRenderReturn> {
     use rayon::prelude::*;
     let mut rendered_modules = FxHashMap::default();
-    let mut content_and_sourcemaps = vec![];
+    let mut concat_source = ConcatSource::default();
 
-    content_and_sourcemaps
-      .push((self.render_imports_for_esm(graph, chunk_graph).to_string(), None));
+    concat_source.add_source(Box::new(RawSource::new(
+      self.render_imports_for_esm(graph, chunk_graph).to_string(),
+    )));
 
     self
       .modules
@@ -139,13 +142,14 @@ impl Chunk {
       .try_for_each(
         |(module_path, rendered_module, rendered_content, map)| -> Result<(), BuildError> {
           if let Some(rendered_content) = rendered_content {
-            content_and_sourcemaps.push((
-              rendered_content,
-              match map {
-                None => None,
-                Some(v) => v?,
-              },
-            ));
+            if let Some(map) = match map {
+              None => None,
+              Some(v) => v?,
+            } {
+              concat_source.add_source(Box::new(SourceMapSource::new(rendered_content, map)));
+            } else {
+              concat_source.add_source(Box::new(RawSource::new(rendered_content)));
+            }
           }
           rendered_modules.insert(module_path, rendered_module);
           Ok(())
@@ -153,19 +157,11 @@ impl Chunk {
       )?;
 
     if let Some(exports) = self.render_exports(graph, output_options) {
-      content_and_sourcemaps.push((exports.to_string(), None));
+      concat_source.add_source(Box::new(RawSource::new(exports.to_string())));
     }
 
-    if output_options.sourcemap.is_hidden() {
-      return Ok(ChunkRenderReturn {
-        code: content_and_sourcemaps.into_iter().map(|(c, _)| c).collect::<Vec<_>>().join("\n"),
-        map: None,
-        rendered_modules,
-      });
-    }
+    let (content, map) = concat_source.content_and_sourcemap();
 
-    let (content, map) = concat_sourcemaps(&content_and_sourcemaps)?;
-
-    Ok(ChunkRenderReturn { code: content, map: Some(map), rendered_modules })
+    Ok(ChunkRenderReturn { code: content, map, rendered_modules })
   }
 }

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -2,7 +2,7 @@
 pub use sourcemap::{SourceMap, SourceMapBuilder};
 mod concat_sourcemap;
 
-pub use concat_sourcemap::concat_sourcemaps;
+pub use concat_sourcemap::{ConcatSource, RawSource, SourceMapSource};
 use rolldown_error::BuildError;
 
 pub fn collapse_sourcemaps(


### PR DESCRIPTION
This reverts rolldown/rolldown#612 and also solve the benchmark performance problems.