### PR TITLE
chore: add rolldown website as homepage in package.json

### DIFF
--- a/packages/rolldown/npm/android-arm-eabi/package.json
+++ b/packages/rolldown/npm/android-arm-eabi/package.json
@@ -33,5 +33,6 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown"
 }

--- a/packages/rolldown/npm/android-arm64/package.json
+++ b/packages/rolldown/npm/android-arm64/package.json
@@ -33,5 +33,6 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown"
 }

--- a/packages/rolldown/npm/darwin-arm64/package.json
+++ b/packages/rolldown/npm/darwin-arm64/package.json
@@ -33,5 +33,6 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown"
 }

--- a/packages/rolldown/npm/darwin-x64/package.json
+++ b/packages/rolldown/npm/darwin-x64/package.json
@@ -33,5 +33,6 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown"
 }

--- a/packages/rolldown/npm/freebsd-x64/package.json
+++ b/packages/rolldown/npm/freebsd-x64/package.json
@@ -33,5 +33,6 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown"
 }

--- a/packages/rolldown/npm/linux-arm-gnueabihf/package.json
+++ b/packages/rolldown/npm/linux-arm-gnueabihf/package.json
@@ -33,5 +33,6 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown"
 }

--- a/packages/rolldown/npm/linux-arm64-gnu/package.json
+++ b/packages/rolldown/npm/linux-arm64-gnu/package.json
@@ -33,6 +33,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown",
   "libc": [
     "glibc"

--- a/packages/rolldown/npm/linux-arm64-musl/package.json
+++ b/packages/rolldown/npm/linux-arm64-musl/package.json
@@ -33,6 +33,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown",
   "libc": [
     "musl"

--- a/packages/rolldown/npm/linux-x64-gnu/package.json
+++ b/packages/rolldown/npm/linux-x64-gnu/package.json
@@ -33,6 +33,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown",
   "libc": [
     "glibc"

--- a/packages/rolldown/npm/linux-x64-musl/package.json
+++ b/packages/rolldown/npm/linux-x64-musl/package.json
@@ -33,6 +33,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown",
   "libc": [
     "musl"

--- a/packages/rolldown/npm/win32-arm64-msvc/package.json
+++ b/packages/rolldown/npm/win32-arm64-msvc/package.json
@@ -33,5 +33,6 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown"
 }

--- a/packages/rolldown/npm/win32-ia32-msvc/package.json
+++ b/packages/rolldown/npm/win32-ia32-msvc/package.json
@@ -33,5 +33,6 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown"
 }

--- a/packages/rolldown/npm/win32-x64-msvc/package.json
+++ b/packages/rolldown/npm/win32-x64-msvc/package.json
@@ -33,5 +33,6 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown"
 }

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -2,6 +2,7 @@
   "name": "rolldown",
   "version": "0.5.0",
   "description": "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API.",
+  "homepage": "https://rolldown.rs/",
   "repository": "https://github.com/rolldown/rolldown",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Description

Adds rolldown website as homepage in package.json

This will allow users viewing rolldown on npmjs website to access the website directly.
It's similar to how [vite](https://www.npmjs.com/package/vite) links to [vitejs.dev](https://vitejs.dev/) under homepage.

Docs for package.json homepage: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#homepage

### Test Plan

N/A

---
