### PR TITLE
fix(rust): should not hard code `output.dir`

### DIFF
--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -78,7 +78,7 @@ pub fn normalize_options(
       .chunk_file_names
       .unwrap_or_else(|| "[name]-[hash].js".to_string())
       .into(),
-    dir: "dist".to_string(),
+    dir: raw_output.dir.unwrap_or_else(|| "dist".to_string()),
     format: raw_output.format.unwrap_or(crate::OutputFormat::Esm),
     sourcemap: raw_output.sourcemap.unwrap_or(SourceMapType::Hidden),
   };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

out `dir` is hard code in `normalize_options`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
