### PR TITLE
fix: rolldown test config priority

### DIFF
--- a/packages/rolldown/test/runner.ts
+++ b/packages/rolldown/test/runner.ts
@@ -47,12 +47,12 @@ function normalizedOptions(caseRoot: string, config?: RollupOptions) {
   const output = config?.output ?? {}
 
   return {
+    ...config,
     input: config?.input ?? path.join(caseRoot, 'main.js'),
     output: {
       dir: output.dir ?? path.join(caseRoot, 'dist'),
       ...output,
     },
-    ...config,
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`config` will overwrite the `input` & `output` config in test runner

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
