### PR TITLE
chore: add rolldown website as homepage in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition    = "2021"
-homepage   = "https://github.com/rolldown/rolldown"
+homepage   = "https://rolldown.rs/"
 license    = "MIT"
 repository = "https://github.com/rolldown/rolldown"
 


### PR DESCRIPTION
### Description

Adds rolldown website as homepage in Cargo.toml

This will allow users viewing rolldown on creates website to access the website directly.
This is similar to how [biome_formatter](https://crates.io/crates/biome_formatter) has link to [biomejs.dev](https://biomejs.dev/) under Homepage.

Docs for homepage field https://doc.rust-lang.org/cargo/reference/manifest.html#the-homepage-field

### Test Plan

Can be verified on publish. The workspace crates already have `edition.workspace` set to true.

---
