### PR TITLE
chore: add repository.directory in package.json

### DIFF
--- a/crates/rolldown_binding_wasm/package.json
+++ b/crates/rolldown_binding_wasm/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rolldown/rolldown"
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "creates/rolldown_binding_wasm"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/rolldown/npm/android-arm-eabi/package.json
+++ b/packages/rolldown/npm/android-arm-eabi/package.json
@@ -34,5 +34,9 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldown/npm/android-arm-eabi"
+  }
 }

--- a/packages/rolldown/npm/android-arm64/package.json
+++ b/packages/rolldown/npm/android-arm64/package.json
@@ -34,5 +34,9 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/android-arm64"
+  }
 }

--- a/packages/rolldown/npm/darwin-arm64/package.json
+++ b/packages/rolldown/npm/darwin-arm64/package.json
@@ -34,5 +34,9 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/darwin-arm64"
+  }
 }

--- a/packages/rolldown/npm/darwin-x64/package.json
+++ b/packages/rolldown/npm/darwin-x64/package.json
@@ -34,5 +34,9 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/darwin-x64"
+  }
 }

--- a/packages/rolldown/npm/freebsd-x64/package.json
+++ b/packages/rolldown/npm/freebsd-x64/package.json
@@ -34,5 +34,9 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/freebsd-x64"
+  }
 }

--- a/packages/rolldown/npm/linux-arm-gnueabihf/package.json
+++ b/packages/rolldown/npm/linux-arm-gnueabihf/package.json
@@ -34,5 +34,9 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/linux-arm-gnueabihf"
+  }
 }

--- a/packages/rolldown/npm/linux-arm64-gnu/package.json
+++ b/packages/rolldown/npm/linux-arm64-gnu/package.json
@@ -34,7 +34,11 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/linux-arm64-gnu"
+  },
   "libc": [
     "glibc"
   ]

--- a/packages/rolldown/npm/linux-arm64-musl/package.json
+++ b/packages/rolldown/npm/linux-arm64-musl/package.json
@@ -34,7 +34,11 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/linux-arm64-musl"
+  },
   "libc": [
     "musl"
   ]

--- a/packages/rolldown/npm/linux-x64-gnu/package.json
+++ b/packages/rolldown/npm/linux-x64-gnu/package.json
@@ -34,7 +34,11 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/linux-x64-gnu"
+  },
   "libc": [
     "glibc"
   ]

--- a/packages/rolldown/npm/linux-x64-musl/package.json
+++ b/packages/rolldown/npm/linux-x64-musl/package.json
@@ -34,7 +34,11 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/linux-x64-musl"
+  },
   "libc": [
     "musl"
   ]

--- a/packages/rolldown/npm/win32-arm64-msvc/package.json
+++ b/packages/rolldown/npm/win32-arm64-msvc/package.json
@@ -34,5 +34,9 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/win32-arm64-msvc"
+  }
 }

--- a/packages/rolldown/npm/win32-ia32-msvc/package.json
+++ b/packages/rolldown/npm/win32-ia32-msvc/package.json
@@ -34,5 +34,9 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/win32-ia32-msvc"
+  }
 }

--- a/packages/rolldown/npm/win32-x64-msvc/package.json
+++ b/packages/rolldown/npm/win32-x64-msvc/package.json
@@ -34,5 +34,9 @@
     "access": "public"
   },
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldow/npm/win32-x64-msvc"
+  }
 }

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -3,7 +3,11 @@
   "version": "0.5.0",
   "description": "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API.",
   "homepage": "https://rolldown.rs/",
-  "repository": "https://github.com/rolldown/rolldown",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rolldown/rolldown.git",
+    "directory": "packages/rolldown"
+  },
   "license": "MIT",
   "keywords": [
     "webpack",


### PR DESCRIPTION
### Description

Adds repository.directory in package.json which specifies the monorepo workspace directory in which source code lives.

This will allow users browsing a specific `@rolldown/*` package on npmjs to directly jump to it's source code.
Docs: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository

### Test Plan

This will be verified on npm publish.

---
