### PR TITLE
fix(cli): Make the CLI output color correctly

### DIFF
--- a/packages/rolldown/build.config.ts
+++ b/packages/rolldown/build.config.ts
@@ -21,6 +21,9 @@ export default defineBuildConfig({
     emitCJS: true,
     cjsBridge: true,
     inlineDependencies: true,
+    resolve: {
+      exportConditions: ['node'],
+    }
   },
   hooks: {
     'build:done'(_ctx) {

--- a/packages/rolldown/build.config.ts
+++ b/packages/rolldown/build.config.ts
@@ -23,7 +23,7 @@ export default defineBuildConfig({
     inlineDependencies: true,
     resolve: {
       exportConditions: ['node'],
-    }
+    },
   },
   hooks: {
     'build:done'(_ctx) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

rolldown cli is not outputting color correctly.

Currently Output:
<img width="862" alt="image" src="https://github.com/rolldown/rolldown/assets/72989/bb704ec0-67cb-4790-a896-7a35ca573a88">


Expected Output:

<img width="846" alt="image" src="https://github.com/rolldown/rolldown/assets/72989/9b2e4cf4-1e38-4446-b5a2-559b43a5ccef">

### Issue Cause

The cause of this issue is that the [`consola`](https://github.com/unjs/consola) reporter used by `citty` for console output is `FancyReporter`, but `BrowserRepoter`.

https://github.com/unjs/consola/blob/24c98ceb90c269a170fd116134d91803a89f2c9d/src/index.ts#L23-L29

FancyReportor was not used because the process was not resolved at bundling time. The `isCI` and `isTest` flags are provided by [`std-env`](https://github.com/unjs/std-env). They also depend on process on the `std-env` side.

/cc @pi0
if you have anything to add about citty's bundle, Please feel free to comment

### Affected of this PR

In this PR, add `node` to the `rollup.resolve.exportConditions` option in `build.config.ts`.

This option is effectively the same as `@rollup/plugin-node-resolve`.
https://github.com/rollup/plugins/blob/master/packages/node-resolve/README.md#exportconditions

Adding this option will cause unbuild to build with Node.js exports resolution.

The CLI entry `src/cli/index.ts` will work correctly with this resolution.

Adding this option also resolves the dependency on the rolldown entry `src/index.ts` with Node.js exports resolution, but currently has no effect on rolldown.

Here is the output of unbuild when built with and without the `rollup.resolve.exportConditions` option added

before:
```
✔ Build succeeded for rolldown                                                                                                                                           2:13:39
  dist/index.cjs (total size: 22 kB, chunk size: 331 B, exports: defineConfig, experimental_scan, rolldown)                                                               2:13:39
  └─ dist/shared/rolldown.fa75f2f3.cjs (21.7 kB)

  dist/cli.cjs (total size: 55.6 kB, chunk size: 33.9 kB)                                                                                                                 2:13:39
  └─ dist/shared/rolldown.fa75f2f3.cjs (21.7 kB)
  📦 ../../node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs (13.9 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/core.mjs (9.79 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/utils.mjs (2.79 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/browser.mjs (1.75 kB)
  dist/index.mjs (total size: 21.9 kB, chunk size: 234 B, exports: defineConfig, experimental_scan, rolldown)                                                             2:13:39
  └─ dist/shared/rolldown.e237f599.mjs (21.7 kB)

  dist/cli.mjs (total size: 54.9 kB, chunk size: 33.3 kB)                                                                                                                 2:13:39
  └─ dist/shared/rolldown.e237f599.mjs (21.7 kB)
  📦 ../../node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs (13.9 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/core.mjs (9.79 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/utils.mjs (2.75 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/browser.mjs (1.75 kB)
Σ Total dist size (byte size): 444 kB
```

after:
```
✔ Build succeeded for rolldown                                                                                                                                           2:14:44
  dist/index.cjs (total size: 22 kB, chunk size: 331 B, exports: defineConfig, experimental_scan, rolldown)                                                               2:14:44
  └─ dist/shared/rolldown.fa75f2f3.cjs (21.7 kB)

  dist/cli.cjs (total size: 92.9 kB, chunk size: 71.2 kB, exports: colors, getDefaultExportFromCjs, isUnicodeSupported)                                                   2:14:44
  └─ dist/shared/rolldown.fa75f2f3.cjs (21.7 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.36c0034f.mjs (33.1 kB)
  📦 ../../node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs (13.9 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/core.mjs (9.79 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/utils.mjs (6.87 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.06ad8a64.mjs (1.64 kB)
  dist/index.mjs (total size: 21.9 kB, chunk size: 234 B, exports: defineConfig, experimental_scan, rolldown)                                                             2:14:44
  └─ dist/shared/rolldown.e237f599.mjs (21.7 kB)

  dist/cli.mjs (total size: 92 kB, chunk size: 70.4 kB, exports: c, g, i)                                                                                                 2:14:44
  └─ dist/shared/rolldown.e237f599.mjs (21.7 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.36c0034f.mjs (33 kB)
  📦 ../../node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs (13.9 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/core.mjs (9.79 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/utils.mjs (6.83 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.06ad8a64.mjs (1.62 kB)
Σ Total dist size (byte size): 941 kB
```

Overall, the bundle size has increased, but only the cli entry has increased, not the rolldown entry.

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
