### PR TITLE
fix(cli): more tree-shaking

### DIFF
--- a/packages/rolldown/src/cli/index.ts
+++ b/packages/rolldown/src/cli/index.ts
@@ -4,15 +4,15 @@ import consola from 'consola'
 import { defineCommand, runMain, showUsage } from 'citty'
 import { loadConfig } from './utils.js'
 import { bundle } from './commands/bundle'
-import pkgJson from '../../package.json' assert { type: 'json' }
+import { version, description } from '../../package.json' assert { type: 'json' }
 
 const DEFAULT_CONFIG_FILENAME = 'rolldown.config.js'
 
 const main = defineCommand({
   meta: {
     name: 'rolldown',
-    version: pkgJson.version,
-    description: pkgJson.description,
+    version,
+    description
   },
   args: {
     config: {

--- a/packages/rolldown/src/cli/index.ts
+++ b/packages/rolldown/src/cli/index.ts
@@ -4,7 +4,10 @@ import consola from 'consola'
 import { defineCommand, runMain, showUsage } from 'citty'
 import { loadConfig } from './utils.js'
 import { bundle } from './commands/bundle'
-import { version, description } from '../../package.json' assert { type: 'json' }
+import {
+  version,
+  description,
+} from '../../package.json' assert { type: 'json' }
 
 const DEFAULT_CONFIG_FILENAME = 'rolldown.config.js'
 
@@ -12,7 +15,7 @@ const main = defineCommand({
   meta: {
     name: 'rolldown',
     version,
-    description
+    description,
   },
   args: {
     config: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

before:
```
✔ Build succeeded for rolldown                                                                                                                                           3:00:36
  dist/index.cjs (total size: 22 kB, chunk size: 331 B, exports: defineConfig, experimental_scan, rolldown)                                                               3:00:36
  └─ dist/shared/rolldown.fa75f2f3.cjs (21.7 kB)

  dist/cli.cjs (total size: 92.9 kB, chunk size: 71.2 kB, exports: colors, getDefaultExportFromCjs, isUnicodeSupported)                                                   3:00:36
  └─ dist/shared/rolldown.fa75f2f3.cjs (21.7 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.36c0034f.mjs (33.1 kB)
  📦 ../../node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs (13.9 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/core.mjs (9.79 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/utils.mjs (6.87 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.06ad8a64.mjs (1.64 kB)
  dist/index.mjs (total size: 21.9 kB, chunk size: 234 B, exports: defineConfig, experimental_scan, rolldown)                                                             3:00:36
  └─ dist/shared/rolldown.e237f599.mjs (21.7 kB)

  dist/cli.mjs (total size: 92 kB, chunk size: 70.4 kB, exports: c, g, i)                                                                                                 3:00:36
  └─ dist/shared/rolldown.e237f599.mjs (21.7 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.36c0034f.mjs (33 kB)
  📦 ../../node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs (13.9 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/core.mjs (9.79 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/utils.mjs (6.83 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.06ad8a64.mjs (1.62 kB)
Σ Total dist size (byte size): 941 kB
```

after:
```
✔ Build succeeded for rolldown                                                                                                                                           3:00:56
  dist/index.cjs (total size: 22 kB, chunk size: 331 B, exports: defineConfig, experimental_scan, rolldown)                                                               3:00:56
  └─ dist/shared/rolldown.fa75f2f3.cjs (21.7 kB)

  dist/cli.cjs (total size: 90.1 kB, chunk size: 68.4 kB, exports: colors, getDefaultExportFromCjs, isUnicodeSupported)                                                   3:00:56
  └─ dist/shared/rolldown.fa75f2f3.cjs (21.7 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.36c0034f.mjs (33.1 kB)
  📦 ../../node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs (13.9 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/core.mjs (9.79 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/utils.mjs (6.87 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.06ad8a64.mjs (1.64 kB)
  dist/index.mjs (total size: 21.9 kB, chunk size: 234 B, exports: defineConfig, experimental_scan, rolldown)                                                             3:00:56
  └─ dist/shared/rolldown.e237f599.mjs (21.7 kB)

  dist/cli.mjs (total size: 89.2 kB, chunk size: 67.6 kB, exports: c, g, i)                                                                                               3:00:56
  └─ dist/shared/rolldown.e237f599.mjs (21.7 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.36c0034f.mjs (33 kB)
  📦 ../../node_modules/.pnpm/citty@0.1.6/node_modules/citty/dist/index.mjs (13.9 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/core.mjs (9.79 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/utils.mjs (6.83 kB)
  📦 ../../node_modules/.pnpm/consola@3.2.3/node_modules/consola/dist/shared/consola.06ad8a64.mjs (1.62 kB)
Σ Total dist size (byte size): 935 kB
```

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
