### PR TITLE
refactor(rust): remove the `FileSystem` generic in `Bundler`

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
-use rolldown_common::BundlerFileSystem;
-use rolldown_fs::OsFileSystem;
+use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_plugin::{BoxPlugin, HookBuildEndArgs, SharedPluginDriver};
 
 use sugar_path::AsPath;
@@ -22,15 +21,15 @@ use crate::{
   InputOptions, OutputOptions, SharedResolver,
 };
 
-pub struct Bundler<Fs: BundlerFileSystem> {
+pub struct Bundler {
   pub(crate) input_options: SharedNormalizedInputOptions,
   pub(crate) output_options: NormalizedOutputOptions,
   pub(crate) plugin_driver: SharedPluginDriver,
-  pub(crate) fs: Fs,
-  pub(crate) resolver: SharedResolver<Fs>,
+  pub(crate) fs: OsFileSystem,
+  pub(crate) resolver: SharedResolver,
 }
 
-impl Bundler<OsFileSystem> {
+impl Bundler {
   pub fn new(input_options: InputOptions, output_options: OutputOptions) -> Self {
     BundlerBuilder::default()
       .with_input_options(input_options)
@@ -51,7 +50,7 @@ impl Bundler<OsFileSystem> {
   }
 }
 
-impl<T: BundlerFileSystem> Bundler<T> {
+impl Bundler {
   pub async fn write(&mut self) -> BatchedResult<RolldownOutput> {
     let dir =
       self.input_options.cwd.as_path().join(&self.output_options.dir).to_string_lossy().to_string();

--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use rolldown_common::BundlerFileSystem;
+use rolldown_fs::OsFileSystem;
 use rolldown_plugin::{BoxPlugin, PluginDriver};
 use rolldown_resolver::Resolver;
 
@@ -9,26 +9,26 @@ use crate::{
   Bundler, InputOptions, OutputOptions,
 };
 
-pub struct BundlerBuilder<Fs: BundlerFileSystem> {
+#[derive(Debug, Default)]
+pub struct BundlerBuilder {
   input_options: InputOptions,
   output_options: OutputOptions,
-  fs: Fs,
   plugins: Vec<BoxPlugin>,
 }
 
-impl<Fs: BundlerFileSystem> BundlerBuilder<Fs> {
-  pub fn build(self) -> Bundler<Fs> {
+impl BundlerBuilder {
+  pub fn build(self) -> Bundler {
     rolldown_tracing::try_init_tracing();
 
     let NormalizeOptionsReturn { input_options, output_options, resolve_options } =
       normalize_options(self.input_options, self.output_options);
 
     Bundler {
-      resolver: Resolver::new(resolve_options, input_options.cwd.clone(), self.fs.clone()).into(),
+      resolver: Resolver::new(resolve_options, input_options.cwd.clone(), OsFileSystem).into(),
       plugin_driver: PluginDriver::new_shared(self.plugins),
       input_options: Arc::new(input_options),
       output_options,
-      fs: self.fs,
+      fs: OsFileSystem,
     }
   }
 
@@ -48,25 +48,5 @@ impl<Fs: BundlerFileSystem> BundlerBuilder<Fs> {
   pub fn with_output_options(mut self, output_options: OutputOptions) -> Self {
     self.output_options = output_options;
     self
-  }
-
-  pub fn with_file_system<NewFs: BundlerFileSystem>(self, fs: NewFs) -> BundlerBuilder<NewFs> {
-    BundlerBuilder {
-      input_options: self.input_options,
-      fs,
-      plugins: self.plugins,
-      output_options: self.output_options,
-    }
-  }
-}
-
-impl<Fs: BundlerFileSystem> Default for BundlerBuilder<Fs> {
-  fn default() -> Self {
-    Self {
-      input_options: InputOptions::default(),
-      fs: Fs::default(),
-      plugins: vec![],
-      output_options: OutputOptions::default(),
-    }
   }
 }

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -14,9 +14,10 @@ mod utils;
 
 use std::sync::Arc;
 
+use rolldown_fs::OsFileSystem;
 use rolldown_resolver::Resolver;
 
-pub(crate) type SharedResolver<T> = Arc<Resolver<T>>;
+pub(crate) type SharedResolver = Arc<Resolver<OsFileSystem>>;
 
 pub use crate::{
   bundler::Bundler,

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -6,7 +6,7 @@ use rolldown_common::{
   NormalModule, NormalModuleId, ResourceId,
 };
 use rolldown_error::BuildError;
-use rolldown_fs::FileSystem;
+use rolldown_fs::OsFileSystem;
 use rolldown_oxc_utils::OxcProgram;
 use rolldown_plugin::SharedPluginDriver;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -44,9 +44,9 @@ impl IntermediateNormalModules {
   }
 }
 
-pub struct ModuleLoader<T: FileSystem + Default> {
+pub struct ModuleLoader {
   input_options: SharedNormalizedInputOptions,
-  common_data: ModuleTaskCommonData<T>,
+  common_data: ModuleTaskCommonData,
   rx: tokio::sync::mpsc::UnboundedReceiver<Msg>,
   visited: FxHashMap<FilePath, ModuleId>,
   runtime_id: Option<NormalModuleId>,
@@ -67,12 +67,12 @@ pub struct ModuleLoaderOutput {
   pub warnings: Vec<BuildError>,
 }
 
-impl<T: FileSystem + 'static + Default> ModuleLoader<T> {
+impl ModuleLoader {
   pub fn new(
     input_options: SharedNormalizedInputOptions,
     plugin_driver: SharedPluginDriver,
-    fs: T,
-    resolver: SharedResolver<T>,
+    fs: OsFileSystem,
+    resolver: SharedResolver,
   ) -> Self {
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Msg>();
 

--- a/crates/rolldown/src/module_loader/module_task_context.rs
+++ b/crates/rolldown/src/module_loader/module_task_context.rs
@@ -1,4 +1,4 @@
-use rolldown_fs::FileSystem;
+use rolldown_fs::OsFileSystem;
 use rolldown_plugin::SharedPluginDriver;
 
 use crate::{options::normalized_input_options::SharedNormalizedInputOptions, SharedResolver};
@@ -6,15 +6,15 @@ use crate::{options::normalized_input_options::SharedNormalizedInputOptions, Sha
 use super::Msg;
 
 /// Used to store common data shared between all tasks.
-pub struct ModuleTaskCommonData<T: FileSystem + Default> {
+pub struct ModuleTaskCommonData {
   pub input_options: SharedNormalizedInputOptions,
   pub tx: tokio::sync::mpsc::UnboundedSender<Msg>,
-  pub resolver: SharedResolver<T>,
-  pub fs: T,
+  pub resolver: SharedResolver,
+  pub fs: OsFileSystem,
   pub plugin_driver: SharedPluginDriver,
 }
 
-impl<T: FileSystem + Default> ModuleTaskCommonData<T> {
+impl ModuleTaskCommonData {
   pub unsafe fn assume_static(&self) -> &'static Self {
     std::mem::transmute(self)
   }

--- a/crates/rolldown/src/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/normal_module_task.rs
@@ -7,10 +7,8 @@ use rolldown_common::{
   AstScope, FilePath, ImportRecordId, ModuleType, NormalModuleId, RawImportRecord, ResolvedPath,
   ResourceId, SymbolRef,
 };
-use rolldown_fs::FileSystem;
 use rolldown_oxc_utils::{OxcCompiler, OxcProgram};
 use rolldown_plugin::{HookResolveIdExtraOptions, SharedPluginDriver};
-use rolldown_resolver::Resolver;
 use sugar_path::AsPath;
 
 use super::{module_task_context::ModuleTaskCommonData, Msg};
@@ -24,18 +22,19 @@ use crate::{
     resolved_request_info::ResolvedRequestInfo,
   },
   utils::{load_source::load_source, resolve_id::resolve_id, transform_source::transform_source},
+  SharedResolver,
 };
-pub struct NormalModuleTask<'task, T: FileSystem + Default> {
-  ctx: &'task ModuleTaskCommonData<T>,
+pub struct NormalModuleTask<'task> {
+  ctx: &'task ModuleTaskCommonData,
   module_id: NormalModuleId,
   resolved_path: ResolvedPath,
   module_type: ModuleType,
   errors: BatchedErrors,
 }
 
-impl<'task, T: FileSystem + Default + 'static> NormalModuleTask<'task, T> {
+impl<'task> NormalModuleTask<'task> {
   pub fn new(
-    ctx: &'task ModuleTaskCommonData<T>,
+    ctx: &'task ModuleTaskCommonData,
     id: NormalModuleId,
     path: ResolvedPath,
     module_type: ModuleType,
@@ -203,9 +202,9 @@ impl<'task, T: FileSystem + Default + 'static> NormalModuleTask<'task, T> {
   }
 
   #[allow(clippy::option_if_let_else)]
-  pub(crate) async fn resolve_id<F: FileSystem + Default>(
+  pub(crate) async fn resolve_id(
     input_options: &SharedNormalizedInputOptions,
-    resolver: &Resolver<F>,
+    resolver: &SharedResolver,
     plugin_driver: &SharedPluginDriver,
     importer: &FilePath,
     specifier: &str,

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
 
 use index_vec::IndexVec;
-use rolldown_common::{
-  BundlerFileSystem, EntryPoint, ImportKind, IntoBatchedResult, NormalModuleId,
-};
+use rolldown_common::{EntryPoint, ImportKind, IntoBatchedResult, NormalModuleId};
 use rolldown_error::BuildError;
-use rolldown_fs::FileSystem;
+use rolldown_fs::OsFileSystem;
 use rolldown_oxc_utils::OxcProgram;
 use rolldown_plugin::{HookResolveIdExtraOptions, SharedPluginDriver};
 use rolldown_utils::block_on_spawn_all;
@@ -22,11 +20,11 @@ use crate::{
   SharedResolver,
 };
 
-pub struct ScanStage<Fs: FileSystem + Default> {
+pub struct ScanStage {
   input_options: SharedNormalizedInputOptions,
   plugin_driver: SharedPluginDriver,
-  fs: Fs,
-  resolver: SharedResolver<Fs>,
+  fs: OsFileSystem,
+  resolver: SharedResolver,
 }
 
 #[derive(Debug)]
@@ -39,12 +37,12 @@ pub struct ScanStageOutput {
   pub warnings: Vec<BuildError>,
 }
 
-impl<Fs: BundlerFileSystem> ScanStage<Fs> {
+impl ScanStage {
   pub fn new(
     input_options: SharedNormalizedInputOptions,
     plugin_driver: SharedPluginDriver,
-    fs: Fs,
-    resolver: SharedResolver<Fs>,
+    fs: OsFileSystem,
+    resolver: SharedResolver,
   ) -> Self {
     Self { input_options, plugin_driver, fs, resolver }
   }

--- a/crates/rolldown/src/utils/resolve_id.rs
+++ b/crates/rolldown/src/utils/resolve_id.rs
@@ -2,11 +2,9 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rolldown_common::{FilePath, ModuleType};
 use rolldown_error::BuildError;
-use rolldown_fs::FileSystem;
 use rolldown_plugin::{HookResolveIdArgs, HookResolveIdExtraOptions, SharedPluginDriver};
-use rolldown_resolver::Resolver;
 
-use crate::types::resolved_request_info::ResolvedRequestInfo;
+use crate::{types::resolved_request_info::ResolvedRequestInfo, SharedResolver};
 
 static HTTP_URL_REGEX: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^(https?:)?\/\/").expect("Init HTTP_URL_REGEX failed"));
@@ -14,8 +12,8 @@ static DATA_URL_REGEX: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^\s*data:").expect("Init DATA_URL_REGEX failed"));
 
 #[allow(clippy::no_effect_underscore_binding)]
-pub async fn resolve_id<T: FileSystem + Default>(
-  resolver: &Resolver<T>,
+pub async fn resolve_id(
+  resolver: &SharedResolver,
   plugin_driver: &SharedPluginDriver,
   request: &str,
   importer: Option<&FilePath>,

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -1,7 +1,6 @@
 use napi::{tokio::sync::Mutex, Env};
 use napi_derive::napi;
 use rolldown::Bundler as NativeBundler;
-use rolldown_fs::OsFileSystem;
 use tracing::instrument;
 
 use crate::{
@@ -12,7 +11,7 @@ use crate::{
 
 #[napi]
 pub struct Bundler {
-  inner: Mutex<NativeBundler<OsFileSystem>>,
+  inner: Mutex<NativeBundler>,
 }
 
 #[napi]

--- a/crates/rolldown_binding_wasm/src/lib.rs
+++ b/crates/rolldown_binding_wasm/src/lib.rs
@@ -45,7 +45,7 @@ pub fn bundle(file_list: Vec<FileItem>) -> Vec<AssetItem> {
   panic::set_hook(Box::new(console_error_panic_hook::hook));
   let result =
     tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
-      let memory_fs = MemoryFileSystem::new(
+      let _memory_fs = MemoryFileSystem::new(
         &file_list.iter().map(|item| (&item.path, &item.content)).collect::<Vec<_>>(),
       );
       let input = file_list
@@ -60,7 +60,7 @@ pub fn bundle(file_list: Vec<FileItem>) -> Vec<AssetItem> {
           }
         })
         .collect::<Vec<_>>();
-      let mut bundler = BundlerBuilder::<MemoryFileSystem>::default()
+      let mut bundler = BundlerBuilder::default()
         .with_input_options(InputOptions {
           input,
           cwd: Some("/".into()),
@@ -68,7 +68,6 @@ pub fn bundle(file_list: Vec<FileItem>) -> Vec<AssetItem> {
           treeshake: Some(false),
           resolve: None,
         })
-        .with_file_system(memory_fs)
         .build();
 
       match bundler.write().await {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR breaks wasm binding and playground. I will fix it in another PR with different implementation. The current one cause a lot of complexity due to passing generic pararams.

@houyunlu cc

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
