### PR TITLE
chore(node): hard code `@rolldown/binding-...` in `optionalDependencies`

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -45,7 +45,6 @@
     "format-generated-binding-files": "prettier --write src/binding.js src/binding.d.ts",
     "build-binding": "napi build -o=./src --manifest-path ../../crates/rolldown_binding/Cargo.toml --platform -p rolldown_binding --js binding.js --dts binding.d.ts --dts-header \"type MaybePromise<T> = T | Promise<T>\"",
     "build-binding:release": "napi build -o=./src --release --manifest-path ../../crates/rolldown_binding/Cargo.toml --platform -p rolldown_binding --js binding.js --dts binding.d.ts --dts-header \"type MaybePromise<T> = T | Promise<T>\"",
-    "prepublishOnly": "napi prepublish -p ./npm --tag-style npm",
     "# Scrips for node #": "_",
     "build-node": "unbuild",
     "build": "pnpm build-binding && pnpm build-node && pnpm format-generated-binding-files",
@@ -81,5 +80,17 @@
     "type-fest": "^4.12.0",
     "unbuild": "^2.0.0",
     "vitest": "^1.3.1"
+  },
+  "optionalDependencies": {
+    "@rolldown/binding-darwin-x64": "workspace:*",
+    "@rolldown/binding-win32-x64-msvc": "workspace:*",
+    "@rolldown/binding-linux-x64-gnu": "workspace:*",
+    "@rolldown/binding-linux-x64-musl": "workspace:*",
+    "@rolldown/binding-win32-ia32-msvc": "workspace:*",
+    "@rolldown/binding-linux-arm-gnueabihf": "workspace:*",
+    "@rolldown/binding-linux-arm64-gnu": "workspace:*",
+    "@rolldown/binding-darwin-arm64": "workspace:*",
+    "@rolldown/binding-linux-arm64-musl": "workspace:*",
+    "@rolldown/binding-win32-arm64-msvc": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,37 @@ importers:
         version: 4.3.0(vue@3.4.21)
 
   packages/rolldown:
+    optionalDependencies:
+      '@rolldown/binding-darwin-arm64':
+        specifier: workspace:*
+        version: link:npm/darwin-arm64
+      '@rolldown/binding-darwin-x64':
+        specifier: workspace:*
+        version: link:npm/darwin-x64
+      '@rolldown/binding-linux-arm-gnueabihf':
+        specifier: workspace:*
+        version: link:npm/linux-arm-gnueabihf
+      '@rolldown/binding-linux-arm64-gnu':
+        specifier: workspace:*
+        version: link:npm/linux-arm64-gnu
+      '@rolldown/binding-linux-arm64-musl':
+        specifier: workspace:*
+        version: link:npm/linux-arm64-musl
+      '@rolldown/binding-linux-x64-gnu':
+        specifier: workspace:*
+        version: link:npm/linux-x64-gnu
+      '@rolldown/binding-linux-x64-musl':
+        specifier: workspace:*
+        version: link:npm/linux-x64-musl
+      '@rolldown/binding-win32-arm64-msvc':
+        specifier: workspace:*
+        version: link:npm/win32-arm64-msvc
+      '@rolldown/binding-win32-ia32-msvc':
+        specifier: workspace:*
+        version: link:npm/win32-ia32-msvc
+      '@rolldown/binding-win32-x64-msvc':
+        specifier: workspace:*
+        version: link:npm/win32-x64-msvc
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.0.0-alpha.43
@@ -120,6 +151,26 @@ importers:
       vitest:
         specifier: ^1.3.1
         version: 1.3.1(@types/node@20.11.26)
+
+  packages/rolldown/npm/darwin-arm64: {}
+
+  packages/rolldown/npm/darwin-x64: {}
+
+  packages/rolldown/npm/linux-arm-gnueabihf: {}
+
+  packages/rolldown/npm/linux-arm64-gnu: {}
+
+  packages/rolldown/npm/linux-arm64-musl: {}
+
+  packages/rolldown/npm/linux-x64-gnu: {}
+
+  packages/rolldown/npm/linux-x64-musl: {}
+
+  packages/rolldown/npm/win32-arm64-msvc: {}
+
+  packages/rolldown/npm/win32-ia32-msvc: {}
+
+  packages/rolldown/npm/win32-x64-msvc: {}
 
   packages/rollup-tests:
     dependencies:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`napi pre-publish` will create github release under the hood. It's not easy to config it depend on if we want release nightly or not.

context:

- `napi pre-publish` will create `npm` folder in place folder and attach correct dependencies to `package.json#optionalDependencies`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
