### PR TITLE
fix(cli): normalize provided config path to satisfy esm-loader in windows 

### DIFF
--- a/packages/rolldown/src/cli/utils.ts
+++ b/packages/rolldown/src/cli/utils.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { pathToFileURL } from 'url'
 import { ERR_UNSUPPORTED_CONFIG_FORMAT } from './errors.js'
 import { RolldownConfigExport } from '../types/rolldown-config-export.js'
 
@@ -15,7 +16,9 @@ export async function loadConfig(
   if (!isSupportedFormat(configPath)) {
     throw new Error(ERR_UNSUPPORTED_CONFIG_FORMAT)
   }
-  return import(configPath).then((config) => config.default)
+  return import(pathToFileURL(configPath).toString()).then(
+    (config) => config.default,
+  )
 }
 
 /**


### PR DESCRIPTION
### Description
resolved issue with ESM loader on Windows by converting file paths to file:// URLs
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
#### before
![image](https://github.com/rolldown/rolldown/assets/22117876/98099a5c-3049-4089-acd9-5ef8e9652f17)

#### now
![image](https://github.com/rolldown/rolldown/assets/22117876/e087d5d0-3e0f-4838-8feb-711b4c3c083f)


### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
