### PR TITLE
feat: add filter for rolldown runner script

### DIFF
--- a/packages/rolldown/test/runner.ts
+++ b/packages/rolldown/test/runner.ts
@@ -4,18 +4,21 @@ import { InputOptions, OutputOptions, RollupOptions, rolldown } from '../src'
 import path from 'node:path'
 import fs from 'node:fs'
 
-runCases()
+runCases(process.env.TEST_FILTER)
 
-function runCases() {
+function runCases(filterStr?: string) {
   const testCasesRoot = path.join(__dirname, 'cases')
   const cases = fs.readdirSync(testCasesRoot)
+  const filter = filterStr?.trim() ? filterStr.trim().split(',') : []
 
   for (const name of cases) {
-    describe(name, async () => {
-      const subCasesRoot = path.join(testCasesRoot, name)
-      const subCases = fs.readdirSync(subCasesRoot)
+    const subCasesRoot = path.join(testCasesRoot, name)
+    const subCases = fs.readdirSync(subCasesRoot)
+    const filterCases = subCases.filter(subCase => !filter.length || filter.includes(subCase) || filter.includes(name) || filter.includes(`${name}/${subCase}`))
 
-      for (const subCaseName of subCases) {
+    if(!filterCases.length) continue
+    describe(name, async () => {
+      for (const subCaseName of filterCases) {
         const caseRoot = path.join(subCasesRoot, subCaseName)
         const caseConfig = await getCaseConfig(caseRoot)
         if (!caseConfig) {

--- a/packages/rolldown/test/runner.ts
+++ b/packages/rolldown/test/runner.ts
@@ -14,9 +14,15 @@ function runCases(filterStr?: string) {
   for (const name of cases) {
     const subCasesRoot = path.join(testCasesRoot, name)
     const subCases = fs.readdirSync(subCasesRoot)
-    const filterCases = subCases.filter(subCase => !filter.length || filter.includes(subCase) || filter.includes(name) || filter.includes(`${name}/${subCase}`))
+    const filterCases = subCases.filter(
+      (subCase) =>
+        !filter.length ||
+        filter.includes(subCase) ||
+        filter.includes(name) ||
+        filter.includes(`${name}/${subCase}`),
+    )
 
-    if(!filterCases.length) continue
+    if (!filterCases.length) continue
     describe(name, async () => {
       for (const subCaseName of filterCases) {
         const caseRoot = path.join(subCasesRoot, subCaseName)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
add `TEST_FILTER` for runner script, so that we can use test like that
`TEST_FILTER=input pnpm test`;  *just run for input cases*
`TEST_FILTER=input/string pnpm test`; *just run for input/string case*
`TEST_FILTER=string pnpm test`; *just run for string cases*

**But I'm not sure does this worked for windows system**


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
