### PR TITLE
chore(test): pre-import test config files by`import.meta.glob`

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -80,8 +80,7 @@
     "rollup": "^4.12.1",
     "type-fest": "^4.12.0",
     "unbuild": "^2.0.0",
-    "vitest": "^1.3.1",
-    "fast-glob": "^3.3.2"
+    "vitest": "^1.3.1"
   },
   "optionalDependencies": {
     "@rolldown/binding-darwin-arm64": "workspace:*",

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -80,6 +80,7 @@
     "rollup": "^4.12.1",
     "type-fest": "^4.12.0",
     "unbuild": "^2.0.0",
+    "vite": "^5.1.5",
     "vitest": "^1.3.1"
   },
   "optionalDependencies": {

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -26,7 +26,7 @@ function main() {
           testConfig.afterTest(output)
         }
       } catch (err) {
-        throw new Error(`Failed in ${testConfigPath}`)
+        throw new Error(`Failed in ${testConfigPath}`, { cause: err })
       }
     })
   }

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -2,39 +2,29 @@ import { test } from 'vitest'
 import type { TestConfig } from './src/types'
 import { InputOptions, OutputOptions, rolldown } from 'rolldown'
 import nodePath from 'node:path'
-import * as fastGlob from 'fast-glob'
-import { loadTestConfig } from '@tests/utils'
 
 main()
 
 function main() {
-  const fixturesPath = nodePath.join(__dirname, 'fixtures')
-  const testConfigPaths = fastGlob.sync('fixtures/**/_config.ts', {
-    absolute: true,
-    cwd: __dirname,
-  })
-  for (const testConfigPath of testConfigPaths) {
-    const dirPath = nodePath.relative(
-      fixturesPath,
-      nodePath.dirname(testConfigPath),
-    )
-    test(dirPath, async (ctx) => {
-      const testConfig = await loadTestConfig(testConfigPath)
-      if (testConfig.skip) {
-        ctx.skip()
-        return
-      }
+  const testConfigPaths = import.meta.glob<TestConfig>(
+    './fixtures/**/_config.ts',
+    { import: 'default', eager: true },
+  )
+  for (const [testConfigPath, testConfig] of Object.entries(testConfigPaths)) {
+    const dirPath = nodePath.dirname(testConfigPath)
+    const testName = dirPath.replace('./fixtures/', '')
 
+    test.skipIf(testConfig.skip)(testName, async () => {
       try {
         const output = await compileFixture(
-          nodePath.dirname(testConfigPath),
+          nodePath.join(import.meta.dirname, dirPath),
           testConfig,
         )
         if (testConfig.afterTest) {
           testConfig.afterTest(output)
         }
       } catch (err) {
-        throw new Error(`Failed in ${testConfigPath}`, { cause: err })
+        throw new Error(`Failed in ${testConfigPath}`)
       }
     })
   }

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 import { test } from 'vitest'
 import type { TestConfig } from './src/types'
 import { InputOptions, OutputOptions, rolldown } from 'rolldown'

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -1,5 +1,3 @@
-/// <reference types="vite/client" />
-
 import { test } from 'vitest'
 import type { TestConfig } from './src/types'
 import { InputOptions, OutputOptions, rolldown } from 'rolldown'

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -42,7 +42,9 @@
     } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": [
+      "vite/client"
+    ] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -42,7 +42,7 @@
     } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    "types": [] /* Specify type package names to be included without being referenced in a source file. */,
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -42,9 +42,7 @@
     } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    "types": [
-      "vite/client"
-    ] /* Specify type package names to be included without being referenced in a source file. */,
+    "types": [] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -43,6 +43,7 @@
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     "types": [
+      "node",
       "vite/client"
     ] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,9 +133,6 @@ importers:
       consola:
         specifier: ^3.2.3
         version: 3.2.3
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       glob:
         specifier: ^10.3.10
         version: 10.3.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.4.3)
+      vite:
+        specifier: ^5.1.5
+        version: 5.1.6(@types/node@20.11.26)
       vitest:
         specifier: ^1.3.1
         version: 1.3.1(@types/node@20.11.26)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Get all configs at compile time. It won't slow down spawning tests.

One downside is that we can't get the type of import.meta.glob from `vitest`

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
