### PR TITLE
fix: correct the TS type of the banner ts-binding

### DIFF
--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -20,7 +20,7 @@ pub struct BindingOutputOptions {
   // assetFileNames: string | ((chunkInfo: PreRenderedAsset) => string);
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "string | ((chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>)")]
+  #[napi(ts_type = "VoidNullable<string> | ((chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>)")]
   pub banner: Option<JsAsyncCallback<RenderedChunk, Option<String>>>,
   // chunkFileNames: string | ((chunkInfo: PreRenderedChunk) => string);
   // compact: boolean;

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -20,7 +20,7 @@ pub struct BindingOutputOptions {
   // assetFileNames: string | ((chunkInfo: PreRenderedAsset) => string);
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "undefined | string | ((chunk: RenderedChunk) => string | Promise<String>)")]
+  #[napi(ts_type = "string | ((chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>)")]
   pub banner: Option<JsAsyncCallback<RenderedChunk, Option<String>>>,
   // chunkFileNames: string | ((chunkInfo: PreRenderedChunk) => string);
   // compact: boolean;

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -20,7 +20,7 @@ pub struct BindingOutputOptions {
   // assetFileNames: string | ((chunkInfo: PreRenderedAsset) => string);
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "VoidNullable<string> | ((chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>)")]
+  #[napi(ts_type = "Nullable<string> | ((chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>)")]
   pub banner: Option<JsAsyncCallback<RenderedChunk, Option<String>>>,
   // chunkFileNames: string | ((chunkInfo: PreRenderedChunk) => string);
   // compact: boolean;

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -20,7 +20,9 @@ pub struct BindingOutputOptions {
   // assetFileNames: string | ((chunkInfo: PreRenderedAsset) => string);
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "Nullable<string> | ((chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>)")]
+  #[napi(
+    ts_type = "Nullable<string> | ((chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>)"
+  )]
   pub banner: Option<JsAsyncCallback<RenderedChunk, Option<String>>>,
   // chunkFileNames: string | ((chunkInfo: PreRenderedChunk) => string);
   // compact: boolean;

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -79,9 +79,8 @@ export interface BindingOutputOptions {
   entryFileNames?: string
   chunkFileNames?: string
   banner?:
-    | undefined
-    | string
-    | ((chunk: RenderedChunk) => string | Promise<String>)
+    | Nullable<string>
+    | ((chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>)
   dir?: string
   exports?: 'default' | 'named' | 'none' | 'auto'
   format?: 'es' | 'cjs'


### PR DESCRIPTION
### Description

This changes the type to be `VoidNullable<string> | ((chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>")`.

Resolves #682
