### PR TITLE
feat: expose `cwd` in input options

### DIFF
--- a/packages/rolldown/src/options/input-options-adapter.ts
+++ b/packages/rolldown/src/options/input-options-adapter.ts
@@ -14,7 +14,7 @@ export function createInputOptionsAdapter(
       // @ts-expect-error
       bindingifyPlugin(plugin, options),
     ),
-    cwd: process.cwd(),
+    cwd: inputOptions.cwd ?? process.cwd(),
     external: inputOptions.external ? options.external : undefined,
     resolve: options.resolve,
   }

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -12,6 +12,7 @@ export interface InputOptions {
   plugins?: Plugin[]
   external?: RollupInputOptions['external']
   resolve?: RolldownResolveOptions
+  cwd?: string
 }
 
 export type RolldownResolveOptions = Omit<BindingResolveOptions, 'alias'> & {

--- a/packages/rolldown/tests/cli/fixtures/basic/rolldown.config.js
+++ b/packages/rolldown/tests/cli/fixtures/basic/rolldown.config.js
@@ -1,24 +1,15 @@
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-
 export default {
-  // input: 'src/index.js',
-  input: path.resolve(__dirname, 'src/index.js'),
+  input: 'src/index.js',
   output: [
     {
-      // dir: 'build',
-      // file: 'build/bundle.js',
-      dir: path.resolve(__dirname, 'build'),
-      file: path.resolve(__dirname, 'build/bundle.js'),
+      dir: 'build',
+      file: 'build/bundle.js',
     },
   ],
   resolve: {
     conditionNames: ['import'],
     alias: {
-      // modules: 'src/modules',
-      modules: path.resolve(__dirname, 'src/modules'),
+      modules: 'src/modules',
     },
   },
 }

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -33,11 +33,6 @@ function main() {
 async function compileFixture(fixturePath: string, config: TestConfig) {
   let outputOptions: OutputOptions = config.config?.output ?? {}
   delete config.config?.output
-  outputOptions = {
-    dir: outputOptions.dir ?? nodePath.join(fixturePath, 'dist'),
-    ...outputOptions,
-  }
-
   const inputOptions: InputOptions = {
     input: 'main.js',
     cwd: fixturePath,

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -39,7 +39,8 @@ async function compileFixture(fixturePath: string, config: TestConfig) {
   }
 
   const inputOptions: InputOptions = {
-    input: config.config?.input ?? nodePath.join(fixturePath, 'main.js'),
+    input: 'main.js',
+    cwd: fixturePath,
     ...config.config,
   }
   const build = await rolldown(inputOptions)

--- a/packages/rolldown/tests/fixtures/input/array/_config.ts
+++ b/packages/rolldown/tests/fixtures/input/array/_config.ts
@@ -1,11 +1,10 @@
 import { defineTest } from '@tests'
-import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputChunkNames } from '@tests/utils'
 
 export default defineTest({
   config: {
-    input: [path.join(__dirname, 'main.js'), path.join(__dirname, 'entry.js')],
+    input: ['main.js', 'entry.js'],
   },
   afterTest: function (output) {
     expect(getOutputChunkNames(output)).toMatchInlineSnapshot(`

--- a/packages/rolldown/tests/fixtures/input/object/_config.ts
+++ b/packages/rolldown/tests/fixtures/input/object/_config.ts
@@ -1,13 +1,12 @@
 import { defineTest } from '@tests'
-import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputChunkNames } from '@tests/utils'
 
 export default defineTest({
   config: {
     input: {
-      main: path.join(__dirname, 'main.js'),
-      entry: path.join(__dirname, 'entry.js'),
+      main: 'main.js',
+      entry: 'entry.js',
     },
   },
   afterTest: (output) => {

--- a/packages/rolldown/tests/fixtures/input/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/input/string/_config.ts
@@ -1,11 +1,10 @@
 import { defineTest } from '@tests'
-import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputChunkNames } from '@tests/utils'
 
 export default defineTest({
   config: {
-    input: path.join(__dirname, 'main.js'),
+    input: 'main.js',
   },
   afterTest: (output) => {
     expect(getOutputChunkNames(output)).toStrictEqual(['main.js'])

--- a/packages/rolldown/tests/fixtures/sourcemap/inner/_config.ts
+++ b/packages/rolldown/tests/fixtures/sourcemap/inner/_config.ts
@@ -1,12 +1,11 @@
 // cSpell:disable
-import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputFileNames } from '@tests/utils'
 import { defineTest } from '@tests'
 
 export default defineTest({
   config: {
-    input: [path.join(__dirname, 'main.js')],
+    input: ['main.js'],
     output: {
       sourcemap: true,
     },


### PR DESCRIPTION
Exposes `cwd` prop in `InputOptions` and updates rolldown tests to
leverage it. Closes #687
