### PR TITLE
refactor: passing data of `BindingOutputs` lazily

### DIFF
--- a/crates/rolldown/src/stages/bundle_stage/mod.rs
+++ b/crates/rolldown/src/stages/bundle_stage/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
   chunk::ChunkRenderReturn,
   chunk_graph::ChunkGraph,
@@ -102,7 +104,7 @@ impl<'a> BundleStage<'a> {
                 unsafe { String::from_utf8_unchecked(buf) }
               };
               let map_file_name = format!("{}.map", rendered_chunk.file_name);
-              assets.push(Output::Asset(Box::new(OutputAsset {
+              assets.push(Output::Asset(Arc::new(OutputAsset {
                 file_name: map_file_name.clone(),
                 source: map,
               })));
@@ -117,7 +119,7 @@ impl<'a> BundleStage<'a> {
           }
         }
         let sourcemap_file_name = map.as_ref().map(|_| format!("{}.map", rendered_chunk.file_name));
-        assets.push(Output::Chunk(Box::new(OutputChunk {
+        assets.push(Output::Chunk(Arc::new(OutputChunk {
           file_name: rendered_chunk.file_name,
           code,
           is_entry: rendered_chunk.is_entry,

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -85,7 +85,7 @@ impl Bundler {
 
     Self::handle_warnings(outputs.warnings);
 
-    Ok(outputs.assets.into())
+    Ok(BindingOutputs::new(outputs.assets))
   }
 
   #[instrument(skip_all)]
@@ -104,7 +104,7 @@ impl Bundler {
 
     Self::handle_warnings(outputs.warnings);
 
-    Ok(outputs.assets.into())
+    Ok(BindingOutputs::new(outputs.assets))
   }
 
   fn handle_errors(errs: BatchedErrors) -> napi::Error {

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -1,4 +1,4 @@
-use crate::types::js_callback::MaybeAsyncJsCallbackExt;
+use crate::types::{binding_outputs::BindingOutputs, js_callback::MaybeAsyncJsCallbackExt};
 use rolldown_plugin::Plugin;
 use std::{borrow::Cow, ops::Deref, sync::Arc};
 
@@ -122,7 +122,7 @@ impl Plugin for JsPlugin {
     is_write: bool,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.generate_bundle {
-      cb.await_call((bundle.clone().into(), is_write)).await?;
+      cb.await_call((BindingOutputs::new(bundle.clone()), is_write)).await?;
     }
     Ok(())
   }
@@ -133,7 +133,7 @@ impl Plugin for JsPlugin {
     bundle: &Vec<rolldown_common::Output>,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.write_bundle {
-      cb.await_call(bundle.clone().into()).await?;
+      cb.await_call(BindingOutputs::new(bundle.clone())).await?;
     }
     Ok(())
   }

--- a/crates/rolldown_binding/src/types/binding_output_asset.rs
+++ b/crates/rolldown_binding/src/types/binding_output_asset.rs
@@ -1,13 +1,15 @@
+use std::sync::Arc;
+
 use napi_derive::napi;
 
 #[napi]
 pub struct BindingOutputAsset {
-  inner: Box<rolldown_common::OutputAsset>,
+  inner: Arc<rolldown_common::OutputAsset>,
 }
 
 #[napi]
 impl BindingOutputAsset {
-  pub fn new(inner: Box<rolldown_common::OutputAsset>) -> Self {
+  pub fn new(inner: Arc<rolldown_common::OutputAsset>) -> Self {
     Self { inner }
   }
 

--- a/crates/rolldown_binding/src/types/binding_output_asset.rs
+++ b/crates/rolldown_binding/src/types/binding_output_asset.rs
@@ -1,17 +1,23 @@
-use derivative::Derivative;
-use serde::Deserialize;
+use napi_derive::napi;
 
-#[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Derivative)]
-#[serde(rename_all = "camelCase")]
-#[derivative(Debug)]
+#[napi]
 pub struct BindingOutputAsset {
-  pub file_name: String,
-  pub source: String,
+  inner: Box<rolldown_common::OutputAsset>,
 }
 
-impl From<Box<rolldown_common::OutputAsset>> for BindingOutputAsset {
-  fn from(chunk: Box<rolldown_common::OutputAsset>) -> Self {
-    Self { source: chunk.source, file_name: chunk.file_name }
+#[napi]
+impl BindingOutputAsset {
+  pub fn new(inner: Box<rolldown_common::OutputAsset>) -> Self {
+    Self { inner }
+  }
+
+  #[napi(getter)]
+  pub fn file_name(&self) -> String {
+    self.inner.file_name.clone()
+  }
+
+  #[napi(getter)]
+  pub fn source(&self) -> String {
+    self.inner.source.clone()
   }
 }

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use napi_derive::napi;
 
@@ -6,12 +6,12 @@ use crate::types::binding_rendered_module::BindingRenderedModule;
 
 #[napi]
 pub struct BindingOutputChunk {
-  inner: Box<rolldown_common::OutputChunk>,
+  inner: Arc<rolldown_common::OutputChunk>,
 }
 
 #[napi]
 impl BindingOutputChunk {
-  pub fn new(inner: Box<rolldown_common::OutputChunk>) -> Self {
+  pub fn new(inner: Arc<rolldown_common::OutputChunk>) -> Self {
     Self { inner }
   }
 

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -1,48 +1,73 @@
 use std::collections::HashMap;
 
-use derivative::Derivative;
-use serde::Deserialize;
+use napi_derive::napi;
 
 use crate::types::binding_rendered_module::BindingRenderedModule;
 
-#[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Derivative)]
-#[serde(rename_all = "camelCase")]
-#[derivative(Debug)]
+#[napi]
 pub struct BindingOutputChunk {
-  // PreRenderedChunk
-  pub is_entry: bool,
-  pub is_dynamic_entry: bool,
-  pub facade_module_id: Option<String>,
-  pub module_ids: Vec<String>,
-  pub exports: Vec<String>,
-  // RenderedChunk
-  pub file_name: String,
-  #[serde(skip_deserializing)]
-  pub modules: HashMap<String, BindingRenderedModule>,
-  // OutputChunk
-  pub code: String,
-  pub map: Option<String>,
-  pub sourcemap_file_name: Option<String>,
+  inner: Box<rolldown_common::OutputChunk>,
 }
 
-impl From<Box<rolldown_common::OutputChunk>> for BindingOutputChunk {
-  fn from(chunk: Box<rolldown_common::OutputChunk>) -> Self {
-    Self {
-      code: chunk.code,
-      file_name: chunk.file_name,
-      is_entry: chunk.is_entry,
-      is_dynamic_entry: chunk.is_dynamic_entry,
-      facade_module_id: chunk.facade_module_id,
-      modules: chunk.modules.into_iter().map(|(key, value)| (key, value.into())).collect(),
-      exports: chunk.exports,
-      module_ids: chunk.module_ids,
-      map: chunk.map.map(|map| {
-        let mut buf = vec![];
-        map.to_writer(&mut buf).unwrap();
-        unsafe { String::from_utf8_unchecked(buf) }
-      }),
-      sourcemap_file_name: chunk.sourcemap_file_name,
-    }
+#[napi]
+impl BindingOutputChunk {
+  pub fn new(inner: Box<rolldown_common::OutputChunk>) -> Self {
+    Self { inner }
+  }
+
+  #[napi(getter)]
+  pub fn is_entry(&self) -> bool {
+    self.inner.is_entry
+  }
+
+  #[napi(getter)]
+  pub fn is_dynamic_entry(&self) -> bool {
+    self.inner.is_dynamic_entry
+  }
+
+  #[napi(getter)]
+  pub fn facade_module_id(&self) -> Option<String> {
+    self.inner.facade_module_id.clone()
+  }
+
+  #[napi(getter)]
+  pub fn module_ids(&self) -> Vec<String> {
+    self.inner.module_ids.clone()
+  }
+
+  #[napi(getter)]
+  pub fn exports(&self) -> Vec<String> {
+    self.inner.exports.clone()
+  }
+
+  // RenderedChunk
+  #[napi(getter)]
+  pub fn file_name(&self) -> String {
+    self.inner.file_name.clone()
+  }
+
+  #[napi(getter)]
+  pub fn modules(&self) -> HashMap<String, BindingRenderedModule> {
+    self.inner.modules.clone().into_iter().map(|(key, value)| (key, value.into())).collect()
+  }
+
+  // OutputChunk
+  #[napi(getter)]
+  pub fn code(&self) -> String {
+    self.inner.code.clone()
+  }
+
+  #[napi(getter)]
+  pub fn map(&self) -> Option<String> {
+    self.inner.map.as_ref().map(|map| {
+      let mut buf = vec![];
+      map.to_writer(&mut buf).unwrap();
+      unsafe { String::from_utf8_unchecked(buf) }
+    })
+  }
+
+  #[napi(getter)]
+  pub fn sourcemap_file_name(&self) -> Option<String> {
+    self.inner.sourcemap_file_name.clone()
   }
 }

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use napi_derive::napi;
 
 use super::{binding_output_asset::BindingOutputAsset, binding_output_chunk::BindingOutputChunk};
@@ -18,7 +20,9 @@ impl BindingOutputs {
     let mut chunks: Vec<BindingOutputChunk> = vec![];
 
     self.inner.iter().for_each(|o| match o {
-      rolldown_common::Output::Chunk(chunk) => chunks.push(BindingOutputChunk::new(chunk.clone())),
+      rolldown_common::Output::Chunk(chunk) => {
+        chunks.push(BindingOutputChunk::new(Arc::clone(chunk)));
+      }
       rolldown_common::Output::Asset(_) => {}
     });
 
@@ -30,7 +34,9 @@ impl BindingOutputs {
     let mut assets: Vec<BindingOutputAsset> = vec![];
 
     self.inner.iter().for_each(|o| match o {
-      rolldown_common::Output::Asset(asset) => assets.push(BindingOutputAsset::new(asset.clone())),
+      rolldown_common::Output::Asset(asset) => {
+        assets.push(BindingOutputAsset::new(Arc::clone(asset)));
+      }
       rolldown_common::Output::Chunk(_) => {}
     });
     assets

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -1,27 +1,41 @@
-use derivative::Derivative;
-use serde::Deserialize;
+use napi::Either;
+use napi_derive::napi;
 
 use super::{binding_output_asset::BindingOutputAsset, binding_output_chunk::BindingOutputChunk};
 
-#[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Derivative)]
-#[serde(rename_all = "camelCase")]
-#[derivative(Debug)]
+pub type BindingOutput = Either<BindingOutputChunk, BindingOutputAsset>;
+
+#[napi]
 pub struct BindingOutputs {
-  pub chunks: Vec<BindingOutputChunk>,
-  pub assets: Vec<BindingOutputAsset>,
+  inner: Vec<rolldown_common::Output>,
 }
 
-impl From<Vec<rolldown_common::Output>> for BindingOutputs {
-  fn from(outputs: Vec<rolldown_common::Output>) -> Self {
-    let mut chunks: Vec<BindingOutputChunk> = vec![];
-    let mut assets: Vec<BindingOutputAsset> = vec![];
+#[napi]
+impl BindingOutputs {
+  pub fn new(inner: Vec<rolldown_common::Output>) -> Self {
+    Self { inner }
+  }
 
-    outputs.into_iter().for_each(|o| match o {
-      rolldown_common::Output::Chunk(chunk) => chunks.push(chunk.into()),
-      rolldown_common::Output::Asset(asset) => assets.push(asset.into()),
+  #[napi(getter)]
+  pub fn chunks(&self) -> Vec<BindingOutputChunk> {
+    let mut chunks: Vec<BindingOutputChunk> = vec![];
+
+    self.inner.iter().for_each(|o| match o {
+      rolldown_common::Output::Chunk(chunk) => chunks.push(BindingOutputChunk::new(chunk.clone())),
+      rolldown_common::Output::Asset(_) => {}
     });
 
-    Self { chunks, assets }
+    chunks
+  }
+
+  #[napi(getter)]
+  pub fn assets(&self) -> Vec<BindingOutputAsset> {
+    let mut assets: Vec<BindingOutputAsset> = vec![];
+
+    self.inner.iter().for_each(|o| match o {
+      rolldown_common::Output::Asset(asset) => assets.push(BindingOutputAsset::new(asset.clone())),
+      rolldown_common::Output::Chunk(_) => {}
+    });
+    assets
   }
 }

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -1,9 +1,6 @@
-use napi::Either;
 use napi_derive::napi;
 
 use super::{binding_output_asset::BindingOutputAsset, binding_output_chunk::BindingOutputChunk};
-
-pub type BindingOutput = Either<BindingOutputChunk, BindingOutputAsset>;
 
 #[napi]
 pub struct BindingOutputs {

--- a/crates/rolldown_common/src/types/output.rs
+++ b/crates/rolldown_common/src/types/output.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::OutputChunk;
 
 #[derive(Debug, Clone)]
@@ -8,8 +10,8 @@ pub struct OutputAsset {
 
 #[derive(Debug, Clone)]
 pub enum Output {
-  Chunk(Box<OutputChunk>),
-  Asset(Box<OutputAsset>),
+  Chunk(Arc<OutputChunk>),
+  Asset(Arc<OutputAsset>),
 }
 
 impl Output {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1,6 +1,29 @@
 type MaybePromise<T> = T | Promise<T>
 type Nullable<T> = T | null | undefined
 type VoidNullable<T = void> = T | null | undefined | void
+export class BindingOutputAsset {
+  get fileName(): string
+  get source(): string
+}
+
+export class BindingOutputChunk {
+  get isEntry(): boolean
+  get isDynamicEntry(): boolean
+  get facadeModuleId(): string | null
+  get moduleIds(): Array<string>
+  get exports(): Array<string>
+  get fileName(): string
+  get modules(): Record<string, BindingRenderedModule>
+  get code(): string
+  get map(): string | null
+  get sourcemapFileName(): string | null
+}
+
+export class BindingOutputs {
+  get chunks(): Array<BindingOutputChunk>
+  get assets(): Array<BindingOutputAsset>
+}
+
 export class BindingPluginContext {
   resolve(
     specifier: string,
@@ -57,24 +80,6 @@ export interface BindingInputOptions {
   cwd: string
 }
 
-export interface BindingOutputAsset {
-  fileName: string
-  source: string
-}
-
-export interface BindingOutputChunk {
-  isEntry: boolean
-  isDynamicEntry: boolean
-  facadeModuleId?: string
-  moduleIds: Array<string>
-  exports: Array<string>
-  fileName: string
-  modules: Record<string, BindingRenderedModule>
-  code: string
-  map?: string
-  sourcemapFileName?: string
-}
-
 export interface BindingOutputOptions {
   entryFileNames?: string
   chunkFileNames?: string
@@ -89,11 +94,6 @@ export interface BindingOutputOptions {
   format?: 'es' | 'cjs'
   plugins: Array<BindingPluginOptions>
   sourcemap?: 'file' | 'inline' | 'hidden'
-}
-
-export interface BindingOutputs {
-  chunks: Array<BindingOutputChunk>
-  assets: Array<BindingOutputAsset>
 }
 
 export interface BindingPluginContextResolveOptions {

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -337,5 +337,8 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
+module.exports.BindingOutputAsset = nativeBinding.BindingOutputAsset
+module.exports.BindingOutputChunk = nativeBinding.BindingOutputChunk
+module.exports.BindingOutputs = nativeBinding.BindingOutputs
 module.exports.BindingPluginContext = nativeBinding.BindingPluginContext
 module.exports.Bundler = nativeBinding.Bundler

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -15,17 +15,25 @@ function transformToRollupOutputChunk(
 ): RolldownOutputChunk {
   return {
     type: 'chunk',
-    code: chunk.code,
+    get code() {
+      return chunk.code
+    },
     fileName: chunk.fileName,
-    modules: Object.fromEntries(
-      Object.entries(chunk.modules).map(([key, _]) => [key, {}]),
-    ),
+    get modules() {
+      return Object.fromEntries(
+        Object.entries(chunk.modules).map(([key, _]) => [key, {}]),
+      )
+    },
     exports: chunk.exports,
     isEntry: chunk.isEntry,
     facadeModuleId: chunk.facadeModuleId || null,
     isDynamicEntry: chunk.isDynamicEntry,
-    moduleIds: chunk.moduleIds,
-    map: chunk.map ? JSON.parse(chunk.map) : null,
+    get moduleIds() {
+      return chunk.moduleIds
+    },
+    get map() {
+      return chunk.map ? JSON.parse(chunk.map) : null
+    },
     sourcemapFileName: chunk.sourcemapFileName || null,
   }
 }
@@ -36,7 +44,9 @@ function transformToRollupOutputAsset(
   return {
     type: 'asset',
     fileName: asset.fileName,
-    source: asset.source,
+    get source() {
+      return asset.source
+    },
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Lazy get BindingOutputs  fields to improve performance.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Not need.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
