### PR TITLE
refactor: replace rolldown type import in tests with defineTest helper function

### DIFF
--- a/packages/rolldown/tests/fixtures/external/array/_config.ts
+++ b/packages/rolldown/tests/fixtures/external/array/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 
 export default defineTest({
   config: {

--- a/packages/rolldown/tests/fixtures/external/array/_config.ts
+++ b/packages/rolldown/tests/fixtures/external/array/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests'
+import { defineTest } from '@tests/index'
 
 export default defineTest({
   config: {

--- a/packages/rolldown/tests/fixtures/external/function/_config.ts
+++ b/packages/rolldown/tests/fixtures/external/function/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import { expect } from 'vitest'
 import path from 'node:path'
 

--- a/packages/rolldown/tests/fixtures/external/function/_config.ts
+++ b/packages/rolldown/tests/fixtures/external/function/_config.ts
@@ -1,20 +1,14 @@
-import type { RollupOptions } from 'rolldown'
+import { defineTest } from '@tests/index'
 import { expect } from 'vitest'
 import path from 'node:path'
 
-const config: RollupOptions = {
-  external: (
-    source: string,
-    importer: string | undefined,
-    isResolved: boolean,
-  ) => {
-    expect(importer).toStrictEqual(path.join(__dirname, 'main.js'))
-    if (source.startsWith('external')) {
-      return true
-    }
+export default defineTest({
+  config: {
+    external: (source: string, importer: string | undefined) => {
+      expect(importer).toStrictEqual(path.join(__dirname, 'main.js'))
+      if (source.startsWith('external')) {
+        return true
+      }
+    },
   },
-}
-
-export default {
-  config,
-}
+})

--- a/packages/rolldown/tests/fixtures/external/regexp/_config.ts
+++ b/packages/rolldown/tests/fixtures/external/regexp/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 
 export default defineTest({
   config: {

--- a/packages/rolldown/tests/fixtures/external/regexp/_config.ts
+++ b/packages/rolldown/tests/fixtures/external/regexp/_config.ts
@@ -1,9 +1,7 @@
-import type { RollupOptions } from 'rolldown'
+import { defineTest } from '@tests/index'
 
-const config: RollupOptions = {
-  external: /external/,
-}
-
-export default {
-  config,
-}
+export default defineTest({
+  config: {
+    external: /external/,
+  },
+})

--- a/packages/rolldown/tests/fixtures/external/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/external/string/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 
 export default defineTest({
   config: {

--- a/packages/rolldown/tests/fixtures/external/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/external/string/_config.ts
@@ -1,9 +1,7 @@
-import type { RollupOptions } from 'rolldown'
+import { defineTest } from '@tests/index'
 
-const config: RollupOptions = {
-  external: 'external',
-}
-
-export default {
-  config,
-}
+export default defineTest({
+  config: {
+    external: 'external',
+  },
+})

--- a/packages/rolldown/tests/fixtures/input/array/_config.ts
+++ b/packages/rolldown/tests/fixtures/input/array/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputChunkNames } from '@tests/utils'

--- a/packages/rolldown/tests/fixtures/input/array/_config.ts
+++ b/packages/rolldown/tests/fixtures/input/array/_config.ts
@@ -1,15 +1,13 @@
-import type { RollupOptions, RollupOutput } from 'rolldown'
+import { defineTest } from '@tests/index'
 import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputChunkNames } from '@tests/utils'
 
-const config: RollupOptions = {
-  input: [path.join(__dirname, 'main.js'), path.join(__dirname, 'entry.js')],
-}
-
-export default {
-  config,
-  afterTest: function (output: RollupOutput) {
+export default defineTest({
+  config: {
+    input: [path.join(__dirname, 'main.js'), path.join(__dirname, 'entry.js')],
+  },
+  afterTest: function (output) {
     expect(getOutputChunkNames(output)).toMatchInlineSnapshot(`
       [
         "entry.js",
@@ -17,4 +15,4 @@ export default {
       ]
     `)
   },
-}
+})

--- a/packages/rolldown/tests/fixtures/input/object/_config.ts
+++ b/packages/rolldown/tests/fixtures/input/object/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputChunkNames } from '@tests/utils'

--- a/packages/rolldown/tests/fixtures/input/object/_config.ts
+++ b/packages/rolldown/tests/fixtures/input/object/_config.ts
@@ -1,18 +1,16 @@
-import type { RollupOptions, RollupOutput } from 'rolldown'
+import { defineTest } from '@tests/index'
 import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputChunkNames } from '@tests/utils'
 
-const config: RollupOptions = {
-  input: {
-    main: path.join(__dirname, 'main.js'),
-    entry: path.join(__dirname, 'entry.js'),
+export default defineTest({
+  config: {
+    input: {
+      main: path.join(__dirname, 'main.js'),
+      entry: path.join(__dirname, 'entry.js'),
+    },
   },
-}
-
-export default {
-  config,
-  afterTest: (output: RollupOutput) => {
+  afterTest: (output) => {
     expect(getOutputChunkNames(output)).toMatchInlineSnapshot(`
       [
         "entry.js",
@@ -20,4 +18,4 @@ export default {
       ]
     `)
   },
-}
+})

--- a/packages/rolldown/tests/fixtures/input/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/input/string/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputChunkNames } from '@tests/utils'

--- a/packages/rolldown/tests/fixtures/input/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/input/string/_config.ts
@@ -1,15 +1,13 @@
-import type { RollupOptions, RollupOutput } from 'rolldown'
+import { defineTest } from '@tests/index'
 import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputChunkNames } from '@tests/utils'
 
-const config: RollupOptions = {
-  input: path.join(__dirname, 'main.js'),
-}
-
-export default {
-  config,
-  afterTest: (output: RollupOutput) => {
+export default defineTest({
+  config: {
+    input: path.join(__dirname, 'main.js'),
+  },
+  afterTest: (output) => {
     expect(getOutputChunkNames(output)).toStrictEqual(['main.js'])
   },
-}
+})

--- a/packages/rolldown/tests/fixtures/output/banner/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/banner/_config.ts
@@ -1,23 +1,18 @@
-import type {
-  RollupOptions,
-  RolldownOutput,
-  RolldownOutputChunk,
-} from '../../../../src'
+import type { RolldownOutputChunk } from 'rolldown'
+import { defineTest } from '@tests/index'
 import { expect } from 'vitest'
 
 const bannerTxt = '// banner test\n'
 const banner = () => Promise.resolve().then(() => bannerTxt)
 
-const config: RollupOptions = {
-  external: [/external/, 'external-a'],
-  output: {
-    banner,
+export default defineTest({
+  config: {
+    external: [/external/, 'external-a'],
+    output: {
+      banner,
+    },
   },
-}
-
-export default {
-  config,
-  afterTest: (output: RolldownOutput) => {
+  afterTest: (output) => {
     expect(
       output.output
         .filter(({ type }) => type === 'chunk')
@@ -26,4 +21,4 @@ export default {
         ),
     ).toBe(true)
   },
-}
+})

--- a/packages/rolldown/tests/fixtures/output/banner/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/banner/_config.ts
@@ -1,5 +1,5 @@
 import type { RolldownOutputChunk } from 'rolldown'
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import { expect } from 'vitest'
 
 const bannerTxt = '// banner test\n'

--- a/packages/rolldown/tests/fixtures/output/footer/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/footer/_config.ts
@@ -1,5 +1,5 @@
 import type { RolldownOutputChunk } from 'rolldown'
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import { expect } from 'vitest'
 
 const footerTxt = '// footer test\n'

--- a/packages/rolldown/tests/fixtures/output/footer/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/footer/_config.ts
@@ -1,23 +1,18 @@
-import type {
-  RollupOptions,
-  RolldownOutput,
-  RolldownOutputChunk,
-} from '../../../../src'
+import type { RolldownOutputChunk } from 'rolldown'
+import { defineTest } from '@tests/index'
 import { expect } from 'vitest'
 
 const footerTxt = '// footer test\n'
 const footer = () => Promise.resolve().then(() => footerTxt)
 
-const config: RollupOptions = {
-  external: [/external/, 'external-a'],
-  output: {
-    footer,
+export default defineTest({
+  config: {
+    external: [/external/, 'external-a'],
+    output: {
+      footer,
+    },
   },
-}
-
-export default {
-  config,
-  afterTest: (output: RolldownOutput) => {
+  afterTest: (output) => {
     expect(
       output.output
         .filter(({ type }) => type === 'chunk')
@@ -26,4 +21,4 @@ export default {
         ),
     ).toBe(true)
   },
-}
+})

--- a/packages/rolldown/tests/fixtures/plugin/build-end/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/build-end/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import { expect, vi } from 'vitest'
 
 const buildEndFn = vi.fn()

--- a/packages/rolldown/tests/fixtures/plugin/build-start/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/build-start/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import { expect, vi } from 'vitest'
 
 const buildStartFn = vi.fn()

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
@@ -1,4 +1,4 @@
-import type { RollupOptions, RollupOutput } from 'rolldown'
+import { defineTest } from '@tests/index'
 import { expect, vi } from 'vitest'
 import path from 'node:path'
 import { OutputChunk } from 'rollup'
@@ -7,35 +7,33 @@ const entry = path.join(__dirname, './main.js')
 
 const generateBundleFn = vi.fn()
 
-const config: RollupOptions = {
-  input: entry,
-  plugins: [
-    {
-      name: 'test-plugin',
-      // @ts-expect-error
-      generateBundle: (options, bundle, isWrite) => {
-        generateBundleFn()
-        const chunk = bundle['main.js'] as OutputChunk
-        expect(chunk.code.indexOf('console.log') > -1).toBe(true)
-        expect(chunk.type).toBe('chunk')
-        expect(chunk.fileName).toBe('main.js')
-        expect(chunk.isEntry).toBe(true)
-        expect(chunk.isDynamicEntry).toBe(false)
-        expect(chunk.facadeModuleId).toBe(entry)
-        expect(chunk.exports.length).toBe(0)
-        expect(chunk.moduleIds).toStrictEqual([entry])
-        expect(Object.keys(chunk.modules).length).toBe(1)
-        // called bundle.generate()
-        expect(isWrite).toBe(true)
-      },
-    },
-  ],
-}
-
-export default {
+export default defineTest({
   skip: true,
-  config,
-  afterTest: (output: RollupOutput) => {
+  config: {
+    input: entry,
+    plugins: [
+      {
+        name: 'test-plugin',
+        // @ts-expect-error
+        generateBundle: (options, bundle, isWrite) => {
+          generateBundleFn()
+          const chunk = bundle['main.js'] as OutputChunk
+          expect(chunk.code.indexOf('console.log') > -1).toBe(true)
+          expect(chunk.type).toBe('chunk')
+          expect(chunk.fileName).toBe('main.js')
+          expect(chunk.isEntry).toBe(true)
+          expect(chunk.isDynamicEntry).toBe(false)
+          expect(chunk.facadeModuleId).toBe(entry)
+          expect(chunk.exports.length).toBe(0)
+          expect(chunk.moduleIds).toStrictEqual([entry])
+          expect(Object.keys(chunk.modules).length).toBe(1)
+          // called bundle.generate()
+          expect(isWrite).toBe(true)
+        },
+      },
+    ],
+  },
+  afterTest: () => {
     expect(generateBundleFn).toHaveBeenCalledTimes(1)
   },
-}
+})

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import { expect, vi } from 'vitest'
 import path from 'node:path'
 import { OutputChunk } from 'rollup'

--- a/packages/rolldown/tests/fixtures/plugin/load/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/load/_config.ts
@@ -1,39 +1,37 @@
-import type { RollupOptions, RollupOutput } from 'rolldown'
+import { defineTest } from '@tests/index'
 import { expect, vi } from 'vitest'
 
 const loadFn = vi.fn()
 
-const config: RollupOptions = {
-  plugins: [
-    {
-      name: 'test-plugin',
-      resolveId: function (id, importer, options) {
-        if (id === 'foo') {
-          return {
-            id,
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'test-plugin',
+        resolveId: function (id, importer, options) {
+          if (id === 'foo') {
+            return {
+              id,
+            }
           }
-        }
-      },
-      load: function (id) {
-        loadFn()
-        if (id === 'foo') {
-          return {
-            code: `console.log('foo')`,
+        },
+        load: function (id) {
+          loadFn()
+          if (id === 'foo') {
+            return {
+              code: `console.log('foo')`,
+            }
           }
-        }
+        },
+        transform: function (id, code) {
+          if (id === 'foo') {
+            expect(code).toStrictEqual('')
+          }
+        },
       },
-      transform: function (id, code) {
-        if (id === 'foo') {
-          expect(code).toStrictEqual('')
-        }
-      },
-    },
-  ],
-}
-
-export default {
-  config,
-  afterTest: (output: RollupOutput) => {
+    ],
+  },
+  afterTest: (output) => {
     expect(loadFn).toHaveBeenCalledTimes(2)
   },
-}
+})

--- a/packages/rolldown/tests/fixtures/plugin/load/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/load/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import { expect, vi } from 'vitest'
 
 const loadFn = vi.fn()

--- a/packages/rolldown/tests/fixtures/plugin/render-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/render-chunk/_config.ts
@@ -1,6 +1,6 @@
 import { expect, vi } from 'vitest'
 import path from 'node:path'
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 
 const entry = path.join(__dirname, './main.js')
 

--- a/packages/rolldown/tests/fixtures/plugin/resolve-id/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-id/_config.ts
@@ -1,4 +1,4 @@
-import type { RollupOptions, RollupOutput } from 'rolldown'
+import { defineTest } from '@tests/index'
 import { expect, vi } from 'vitest'
 import path from 'node:path'
 
@@ -6,62 +6,60 @@ const entry = path.join(__dirname, './main.js')
 
 const resolveIdFn = vi.fn()
 
-const config: RollupOptions = {
-  input: entry,
-  plugins: [
-    {
-      name: 'test-plugin',
-      resolveId: function (id, importer, options) {
-        resolveIdFn()
-        if (id === 'external') {
-          expect(importer).toStrictEqual(entry)
-          expect(options).toMatchObject({
-            isEntry: false,
-            kind: 'require-call',
-          })
-          return {
-            id,
-            external: true,
+export default defineTest({
+  config: {
+    input: entry,
+    plugins: [
+      {
+        name: 'test-plugin',
+        resolveId: function (id, importer, options) {
+          resolveIdFn()
+          if (id === 'external') {
+            expect(importer).toStrictEqual(entry)
+            expect(options).toMatchObject({
+              isEntry: false,
+              kind: 'require-call',
+            })
+            return {
+              id,
+              external: true,
+            }
           }
-        }
-        if (id === './foo') {
-          expect(importer).toStrictEqual(entry)
-          expect(options).toMatchObject({
-            isEntry: false,
-            kind: 'import-statement',
-          })
-          return {
-            id: path.join(__dirname, './foo.js'),
-            external: false,
+          if (id === './foo') {
+            expect(importer).toStrictEqual(entry)
+            expect(options).toMatchObject({
+              isEntry: false,
+              kind: 'import-statement',
+            })
+            return {
+              id: path.join(__dirname, './foo.js'),
+              external: false,
+            }
           }
-        }
-        // TODO: external dynamic import will loop
-        // if (id === 'dynamic') {
-        //   expect(importer).toStrictEqual(entry)
-        //   expect(options).toMatchObject({
-        //     isEntry: false,
-        //     kind: 'dynamic-import'
-        //   })
-        //   return {
-        //     id,
-        //     external: true
-        //   }
-        // }
-        if (id === entry) {
-          expect(importer).toBeUndefined()
-          expect(options).toMatchObject({
-            isEntry: true,
-            kind: 'import-statement',
-          })
-        }
+          // TODO: external dynamic import will loop
+          // if (id === 'dynamic') {
+          //   expect(importer).toStrictEqual(entry)
+          //   expect(options).toMatchObject({
+          //     isEntry: false,
+          //     kind: 'dynamic-import'
+          //   })
+          //   return {
+          //     id,
+          //     external: true
+          //   }
+          // }
+          if (id === entry) {
+            expect(importer).toBeUndefined()
+            expect(options).toMatchObject({
+              isEntry: true,
+              kind: 'import-statement',
+            })
+          }
+        },
       },
-    },
-  ],
-}
-
-export default {
-  config,
-  afterTest: (output: RollupOutput) => {
+    ],
+  },
+  afterTest: (output) => {
     expect(resolveIdFn).toHaveBeenCalledTimes(3)
   },
-}
+})

--- a/packages/rolldown/tests/fixtures/plugin/resolve-id/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-id/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import { expect, vi } from 'vitest'
 import path from 'node:path'
 

--- a/packages/rolldown/tests/fixtures/plugin/transform/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 import { expect, vi } from 'vitest'
 
 const transformFn = vi.fn()

--- a/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
@@ -1,7 +1,7 @@
 import { expect, vi } from 'vitest'
 import path from 'node:path'
 import { OutputChunk } from 'rollup'
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 
 const entry = path.join(__dirname, './main.js')
 

--- a/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
@@ -1,4 +1,3 @@
-import type { RollupOptions } from 'rolldown'
 import { expect, vi } from 'vitest'
 import path from 'node:path'
 import { OutputChunk } from 'rollup'
@@ -8,32 +7,30 @@ const entry = path.join(__dirname, './main.js')
 
 const writeBundleFn = vi.fn()
 
-const config: RollupOptions = {
-  input: entry,
-  plugins: [
-    {
-      name: 'test-plugin',
-      // @ts-expect-error
-      writeBundle: (_options, bundle) => {
-        writeBundleFn()
-        const chunk = bundle['main.js'] as OutputChunk
-        expect(chunk.code.indexOf('console.log') > -1).toBe(true)
-        expect(chunk.type).toBe('chunk')
-        expect(chunk.fileName).toBe('main.js')
-        expect(chunk.isEntry).toBe(true)
-        expect(chunk.isDynamicEntry).toBe(false)
-        expect(chunk.facadeModuleId).toBe(entry)
-        expect(chunk.exports.length).toBe(0)
-        expect(chunk.moduleIds).toStrictEqual([entry])
-        expect(Object.keys(chunk.modules).length).toBe(1)
-      },
-    },
-  ],
-}
-
 export default defineTest({
   skip: true,
-  config,
+  config: {
+    input: entry,
+    plugins: [
+      {
+        name: 'test-plugin',
+        // @ts-expect-error
+        writeBundle: (_options, bundle) => {
+          writeBundleFn()
+          const chunk = bundle['main.js'] as OutputChunk
+          expect(chunk.code.indexOf('console.log') > -1).toBe(true)
+          expect(chunk.type).toBe('chunk')
+          expect(chunk.fileName).toBe('main.js')
+          expect(chunk.isEntry).toBe(true)
+          expect(chunk.isDynamicEntry).toBe(false)
+          expect(chunk.facadeModuleId).toBe(entry)
+          expect(chunk.exports.length).toBe(0)
+          expect(chunk.moduleIds).toStrictEqual([entry])
+          expect(Object.keys(chunk.modules).length).toBe(1)
+        },
+      },
+    ],
+  },
   afterTest: () => {
     expect(writeBundleFn).toHaveBeenCalledTimes(1)
   },

--- a/packages/rolldown/tests/fixtures/resolve/alias/_config.ts
+++ b/packages/rolldown/tests/fixtures/resolve/alias/_config.ts
@@ -1,4 +1,4 @@
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 
 export default defineTest({
   config: {

--- a/packages/rolldown/tests/fixtures/sourcemap/inner/_config.ts
+++ b/packages/rolldown/tests/fixtures/sourcemap/inner/_config.ts
@@ -1,20 +1,17 @@
 // cSpell:disable
-import type { RollupOptions, RollupOutput } from 'rolldown'
 import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputFileNames } from '@tests/utils'
-import { defineTest } from '@tests'
-
-const config: RollupOptions = {
-  input: [path.join(__dirname, 'main.js')],
-  output: {
-    sourcemap: true,
-  },
-}
+import { defineTest } from '@tests/index'
 
 export default defineTest({
-  config,
-  afterTest: function (output: RollupOutput) {
+  config: {
+    input: [path.join(__dirname, 'main.js')],
+    output: {
+      sourcemap: true,
+    },
+  },
+  afterTest: function (output) {
     expect(getOutputFileNames(output)).toMatchInlineSnapshot(`
       [
         "main.js",

--- a/packages/rolldown/tests/fixtures/sourcemap/inner/_config.ts
+++ b/packages/rolldown/tests/fixtures/sourcemap/inner/_config.ts
@@ -2,7 +2,7 @@
 import path from 'node:path'
 import { expect } from 'vitest'
 import { getOutputFileNames } from '@tests/utils'
-import { defineTest } from '@tests/index'
+import { defineTest } from '@tests'
 
 export default defineTest({
   config: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
replace rolldown type import in tests with defineTest helper function 
fix for https://github.com/rolldown/rolldown/issues/695
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
