### PR TITLE
refactor: avoid sourcemap clone

### DIFF
--- a/crates/rolldown/src/chunk/mod.rs
+++ b/crates/rolldown/src/chunk/mod.rs
@@ -4,6 +4,8 @@ pub mod render_chunk;
 mod render_chunk_exports;
 mod render_chunk_imports;
 
+use std::sync::Arc;
+
 use index_vec::IndexVec;
 use rolldown_common::ChunkId;
 
@@ -123,9 +125,9 @@ impl Chunk {
           if output_options.sourcemap.is_hidden() {
             None
           } else {
-            let mut sourcemap_chain = m.sourcemap_chain.iter().collect::<Vec<_>>();
-            if let Some(Some(sourcemap)) = rendered_output.as_ref().map(|x| x.source_map.as_ref()) {
-              sourcemap_chain.push(sourcemap);
+            let mut sourcemap_chain = m.sourcemap_chain.iter().map(Arc::clone).collect::<Vec<_>>();
+            if let Some(Some(sourcemap)) = rendered_output.map(|x| x.source_map) {
+              sourcemap_chain.push(Arc::new(sourcemap));
             }
             Some(collapse_sourcemaps(sourcemap_chain))
           },

--- a/crates/rolldown/src/types/normal_module_builder.rs
+++ b/crates/rolldown/src/types/normal_module_builder.rs
@@ -28,8 +28,8 @@ pub struct NormalModuleBuilder {
   pub module_type: ModuleType,
   pub is_user_defined_entry: Option<bool>,
   pub pretty_path: Option<String>,
-  pub is_virtual: bool,
   pub sourcemap_chain: Vec<Arc<rolldown_sourcemap::SourceMap>>,
+  pub is_virtual: bool,
 }
 
 impl NormalModuleBuilder {

--- a/crates/rolldown/src/types/normal_module_builder.rs
+++ b/crates/rolldown/src/types/normal_module_builder.rs
@@ -28,8 +28,8 @@ pub struct NormalModuleBuilder {
   pub module_type: ModuleType,
   pub is_user_defined_entry: Option<bool>,
   pub pretty_path: Option<String>,
-  pub sourcemap_chain: Vec<rolldown_sourcemap::SourceMap>,
   pub is_virtual: bool,
+  pub sourcemap_chain: Vec<Arc<rolldown_sourcemap::SourceMap>>,
 }
 
 impl NormalModuleBuilder {

--- a/crates/rolldown/src/utils/load_source.rs
+++ b/crates/rolldown/src/utils/load_source.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use rolldown_common::ResolvedPath;
 use rolldown_plugin::{HookLoadArgs, PluginDriver};
 use rolldown_sourcemap::SourceMap;
@@ -9,12 +11,12 @@ pub async fn load_source(
   plugin_driver: &PluginDriver,
   resolved_path: &ResolvedPath,
   fs: &dyn rolldown_fs::FileSystem,
-  sourcemap_chain: &mut Vec<SourceMap>,
+  sourcemap_chain: &mut Vec<Arc<SourceMap>>,
 ) -> Result<String, BatchedErrors> {
   let source =
     if let Some(r) = plugin_driver.load(&HookLoadArgs { id: &resolved_path.path }).await? {
       if let Some(map) = r.map {
-        sourcemap_chain.push(map);
+        sourcemap_chain.push(Arc::new(map));
       }
       r.code
     } else if resolved_path.ignored {

--- a/crates/rolldown/src/utils/transform_source.rs
+++ b/crates/rolldown/src/utils/transform_source.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use rolldown_common::ResolvedPath;
 use rolldown_plugin::{HookTransformArgs, PluginDriver};
 use rolldown_sourcemap::SourceMap;
@@ -8,7 +10,7 @@ pub async fn transform_source(
   plugin_driver: &PluginDriver,
   resolved_path: &ResolvedPath,
   source: String,
-  sourcemap_chain: &mut Vec<SourceMap>,
+  sourcemap_chain: &mut Vec<Arc<SourceMap>>,
 ) -> Result<String, BatchedErrors> {
   let (code, map_chain) =
     plugin_driver.transform(&HookTransformArgs { id: &resolved_path.path, code: &source }).await?;

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -35,7 +35,7 @@ pub struct NormalModule {
   pub exports_kind: ExportsKind,
   pub scope: AstScope,
   pub default_export_ref: SymbolRef,
-  pub sourcemap_chain: Vec<rolldown_sourcemap::SourceMap>,
+  pub sourcemap_chain: Vec<Arc<rolldown_sourcemap::SourceMap>>,
   pub is_included: bool,
   // The runtime module and module which path starts with `\0` shouldn't generate sourcemap. Ref see https://github.com/rollup/rollup/blob/master/src/Module.ts#L279.
   pub is_virtual: bool,

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
   HookBuildEndArgs, HookLoadArgs, HookLoadReturn, HookNoopReturn, HookRenderChunkArgs,
   HookResolveIdArgs, HookResolveIdReturn, HookTransformArgs, PluginDriver,
@@ -35,7 +37,7 @@ impl PluginDriver {
   pub async fn transform(
     &self,
     args: &HookTransformArgs<'_>,
-  ) -> Result<(String, Vec<SourceMap>), BuildError> {
+  ) -> Result<(String, Vec<Arc<SourceMap>>), BuildError> {
     let mut sourcemap_chain = vec![];
     let mut code = args.code.to_string();
     for (plugin, ctx) in &self.plugins {
@@ -44,7 +46,7 @@ impl PluginDriver {
       {
         code = r.code;
         if let Some(map) = r.map {
-          sourcemap_chain.push(map);
+          sourcemap_chain.push(Arc::new(map));
         }
       }
     }

--- a/crates/rolldown_sourcemap/src/concat_sourcemap.rs
+++ b/crates/rolldown_sourcemap/src/concat_sourcemap.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 // cSpell:disable
 use oxc::sourcemap::{ConcatSourceMapBuilder, SourceMap};
 
@@ -44,11 +46,11 @@ impl Source for RawSource {
 
 pub struct SourceMapSource {
   content: String,
-  sourcemap: SourceMap,
+  sourcemap: Arc<SourceMap>,
 }
 
 impl SourceMapSource {
-  pub fn new(content: String, sourcemap: SourceMap) -> Self {
+  pub fn new(content: String, sourcemap: Arc<SourceMap>) -> Self {
     Self { content, sourcemap }
   }
 }
@@ -141,7 +143,7 @@ mod tests {
           "names":[]
         }"#
     )
-    .unwrap(),
+    .unwrap().into(),
     )));
 
     let (content, map) = {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Using `Arc<SourceMap>` instead of `SourceMap` to avoid clone overhead.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan
Not need.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
