### PR TITLE
fix(ci/windows): exclude `rolldown_binding` while running rust tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           filters: |
             rust-changes: &rust-changes
               - 'crates/**'
+              - '.github/workflows/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'

--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -25,7 +25,7 @@ jobs:
           cache-base: main
 
       - name: Build
-        run: cargo test --no-run
+        run: cargo test --workspace --exclude rolldown_binding --no-run
 
       - name: Run Test
-        run: just test-rust
+        run: cargo test --workspace --exclude rolldown_binding --nocapture


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
