### PR TITLE
feat(rust): don't generate sourcemap for virtual modules

### DIFF
--- a/crates/rolldown/src/chunk/mod.rs
+++ b/crates/rolldown/src/chunk/mod.rs
@@ -113,7 +113,7 @@ impl Chunk {
                 .expect_file()
                 .relative_path(&input_options.cwd)
                 .to_string_lossy().as_ref(),
-           !output_options.sourcemap.is_hidden() && m.sourcemap
+           !output_options.sourcemap.is_hidden() && !m.is_virtual
         );
         Some((
           m.resource_id.expect_file().to_string(),

--- a/crates/rolldown/src/chunk/mod.rs
+++ b/crates/rolldown/src/chunk/mod.rs
@@ -113,7 +113,7 @@ impl Chunk {
                 .expect_file()
                 .relative_path(&input_options.cwd)
                 .to_string_lossy().as_ref(),
-           !output_options.sourcemap.is_hidden()
+           !output_options.sourcemap.is_hidden() && m.sourcemap
         );
         Some((
           m.resource_id.expect_file().to_string(),

--- a/crates/rolldown/src/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/normal_module_task.rs
@@ -129,7 +129,7 @@ impl<'task> NormalModuleTask<'task> {
       module_type: self.module_type,
       pretty_path: Some(self.resolved_path.prettify(&self.ctx.input_options.cwd)),
       sourcemap_chain,
-      sourcemap: !self.resolved_path.is_virtual_module_path(),
+      is_virtual: self.resolved_path.is_virtual_module_path(),
       ..Default::default()
     };
 

--- a/crates/rolldown/src/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/normal_module_task.rs
@@ -129,6 +129,7 @@ impl<'task> NormalModuleTask<'task> {
       module_type: self.module_type,
       pretty_path: Some(self.resolved_path.prettify(&self.ctx.input_options.cwd)),
       sourcemap_chain,
+      sourcemap: !self.resolved_path.is_virtual_module_path(),
       ..Default::default()
     };
 

--- a/crates/rolldown/src/module_loader/runtime_normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_normal_module_task.rs
@@ -75,6 +75,7 @@ impl RuntimeNormalModuleTask {
     builder.namespace_symbol = Some(namespace_symbol);
     builder.pretty_path = Some("<runtime>".to_string());
     builder.is_user_defined_entry = Some(false);
+    builder.is_virtual = true;
 
     if let Err(_err) = self.tx.send(Msg::RuntimeNormalModuleDone(RuntimeNormalModuleTaskResult {
       warnings: self.warnings,

--- a/crates/rolldown/src/types/normal_module_builder.rs
+++ b/crates/rolldown/src/types/normal_module_builder.rs
@@ -29,7 +29,7 @@ pub struct NormalModuleBuilder {
   pub is_user_defined_entry: Option<bool>,
   pub pretty_path: Option<String>,
   pub sourcemap_chain: Vec<rolldown_sourcemap::SourceMap>,
-  pub sourcemap: bool,
+  pub is_virtual: bool,
 }
 
 impl NormalModuleBuilder {
@@ -55,7 +55,7 @@ impl NormalModuleBuilder {
       pretty_path: self.pretty_path.unwrap(),
       sourcemap_chain: self.sourcemap_chain,
       is_included: false,
-      sourcemap: self.sourcemap,
+      is_virtual: self.is_virtual,
     }
   }
 }

--- a/crates/rolldown/src/types/normal_module_builder.rs
+++ b/crates/rolldown/src/types/normal_module_builder.rs
@@ -29,6 +29,7 @@ pub struct NormalModuleBuilder {
   pub is_user_defined_entry: Option<bool>,
   pub pretty_path: Option<String>,
   pub sourcemap_chain: Vec<rolldown_sourcemap::SourceMap>,
+  pub sourcemap: bool,
 }
 
 impl NormalModuleBuilder {
@@ -54,6 +55,7 @@ impl NormalModuleBuilder {
       pretty_path: self.pretty_path.unwrap(),
       sourcemap_chain: self.sourcemap_chain,
       is_included: false,
+      sourcemap: self.sourcemap,
     }
   }
 }

--- a/crates/rolldown/tests/common/case.rs
+++ b/crates/rolldown/tests/common/case.rs
@@ -132,7 +132,6 @@ impl Case {
     self.snapshot.push_str("\n\n# Sourcemap Visualizer\n\n");
     let visualizer_result = assets
       .iter()
-      .filter(|asset| !asset.file_name().contains("$runtime$"))
       .filter_map(|asset| match asset {
         Output::Chunk(chunk) => chunk
           .map

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -37,6 +37,8 @@ pub struct NormalModule {
   pub default_export_ref: SymbolRef,
   pub sourcemap_chain: Vec<rolldown_sourcemap::SourceMap>,
   pub is_included: bool,
+  // The runtime module and module which path starts with `\0` shouldn't generate sourcemap. Ref see https://github.com/rollup/rollup/blob/master/src/Module.ts#L279.
+  pub sourcemap: bool,
 }
 
 impl NormalModule {

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -38,7 +38,7 @@ pub struct NormalModule {
   pub sourcemap_chain: Vec<rolldown_sourcemap::SourceMap>,
   pub is_included: bool,
   // The runtime module and module which path starts with `\0` shouldn't generate sourcemap. Ref see https://github.com/rollup/rollup/blob/master/src/Module.ts#L279.
-  pub sourcemap: bool,
+  pub is_virtual: bool,
 }
 
 impl NormalModule {

--- a/crates/rolldown_resolver/src/types/resolved_path.rs
+++ b/crates/rolldown_resolver/src/types/resolved_path.rs
@@ -38,6 +38,10 @@ impl ResolvedPath {
       pretty
     }
   }
+
+  pub fn is_virtual_module_path(&self) -> bool {
+    self.path.starts_with('\0')
+  }
 }
 
 #[test]
@@ -55,4 +59,10 @@ fn test() {
   let ignore_prettify_res = from_test.prettify(Path::new("./"));
 
   assert_eq!(ignore_prettify_res, "(ignored) resolved_path.rs");
+}
+
+#[test]
+fn is_virtual_module_path() {
+  assert!(ResolvedPath::from("\0a.js".to_string()).is_virtual_module_path());
+  assert!(!ResolvedPath::from("a.js".to_string()).is_virtual_module_path());
 }

--- a/packages/rollup-tests/src/failed-tests.json
+++ b/packages/rollup-tests/src/failed-tests.json
@@ -712,7 +712,6 @@
   "rollup@sourcemaps@basic-support: basic sourcemap support@generates es",
   "rollup@sourcemaps@combined-sourcemap-with-loader: get combined sourcemap in transforming with loader@generates es",
   "rollup@sourcemaps@combined-sourcemap: get combined sourcemap in transforming@generates es",
-  "rollup@sourcemaps@excludes-plugin-helpers: excludes plugin helpers from sources@generates es",
   "rollup@sourcemaps@existing-external-sourcemaps-combined: removes sourcemap comments@generates es",
   "rollup@sourcemaps@ignore-list-default: defaults to adding files within node_modules to the ignore list@generates es",
   "rollup@sourcemaps@ignore-list-false: accepts false for `sourcemapIgnoreList` to disable the default ignore-listing of node_modules@generates es",

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,6 +1,6 @@
 {
   "failed": 0,
-  "skipFailed": 681,
+  "skipFailed": 680,
   "skipped": 0,
-  "passed": 238
+  "passed": 239
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -1,6 +1,6 @@
 |  | number |
 |----| ---- |
 | failed | 0|
-| skipFailed | 681|
+| skipFailed | 680|
 | skipped | 0|
-| passed | 238|
+| passed | 239|


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The runtime module and module which path starts with `\0` shouldn't generate sourcemap. Ref see https://github.com/rollup/rollup/blob/master/src/Module.ts#L279.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Test Plan

Updated test.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---
