### PR TITLE
chore(ci): label new PRs with `needs-triage` tag automatically

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+# https://github.com/actions/labeler
+
+# Add 'needs-triage' label to any PR that is opened against the `main` branch
+needs-triage:
+  - base-branch: 'main'

--- a/.github/workflows/automate-labeling.yml
+++ b/.github/workflows/automate-labeling.yml
@@ -16,9 +16,11 @@ jobs:
 
   remove-needs-triage-when-assigned:
     if: github.event.action == 'assigned'
-    uses: actions-cool/issues-helper@v3
-    with:
-      actions: 'remove-labels'
-      token: ${{ secrets.GITHUB_TOKEN }}
-      issue-number: ${{ github.event.pull_request.number }}
-      labels: 'needs-triage'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'remove-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          labels: 'needs-triage'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,7 @@
 name: 'Automate labeling'
-on: pull_request
+on:
+  pull_request:
+    types: [opened, assigned]
 
 jobs:
   # Labele the PR based on the configuration in `.github/labeler.yml` using https://github.com/actions/labeler

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,14 +1,22 @@
-name: 'Pull Request Labeler'
-on:
-  pull_request:
-    types: [opened]
+name: 'Automate labeling'
+on: pull_request
 
 jobs:
+  # Labele the PR based on the configuration in `.github/labeler.yml` using https://github.com/actions/labeler
   labeler:
+    if: github.event.action == 'opened'
     permissions:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # See `.github/labeler.yml` for the configuration
       - uses: actions/labeler@v5
+
+  remove-needs-triage-when-assigned:
+    if: github.event.action == 'assigned'
+    uses: actions-cool/issues-helper@v3
+    with:
+      actions: 'remove-labels'
+      token: ${{ secrets.GITHUB_TOKEN }}
+      issue-number: ${{ github.event.pull_request.number }}
+      labels: 'needs-triage'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: 'Pull Request Labeler'
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # See `.github/labeler.yml` for the configuration
+      - uses: actions/labeler@v5


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We could use this to tell if the PR is reviewed or not.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
