### PR TITLE
feat: support plugin.order 

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -17,14 +17,31 @@ use super::{
 };
 
 #[napi_derive::napi(object, object_to_js = false)]
+#[derive(Default)]
+pub struct HookOption {
+  #[napi(ts_type = "'pre'|'post'|null")]
+  pub order: Option<String>,
+  pub sequential: Option<bool>,
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
+pub struct BuildStartHookOption {
+  #[napi(ts_type = "(ctx: BindingPluginContext) => MaybePromise<VoidNullable>")]
+  pub handler: MaybeAsyncJsCallback<BindingPluginContext, ()>,
+  #[napi(ts_type = "'pre'|'post'|null")]
+  pub order: Option<String>,
+  pub sequential: Option<bool>,
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct BindingPluginOptions {
   pub name: String,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(ctx: BindingPluginContext) => MaybePromise<VoidNullable>")]
-  pub build_start: Option<MaybeAsyncJsCallback<BindingPluginContext, ()>>,
+  #[napi(ts_type = "BuildStartHookOption")]
+  pub build_start: Option<BuildStartHookOption>,
 
   #[serde(skip_deserializing)]
   #[napi(

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -34,6 +34,19 @@ pub struct BuildStartHookOption {
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
+pub struct ResolveIdHookOption {
+  #[napi(
+    ts_type = "(specifier: string, importer: Nullable<string>, options: BindingHookResolveIdExtraOptions) => MaybePromise<VoidNullable<BindingHookResolveIdOutput>>"
+  )]
+  pub handler: MaybeAsyncJsCallback<
+    (String, Option<String>, BindingHookResolveIdExtraOptions),
+    Option<BindingHookResolveIdOutput>,
+  >,
+  #[napi(ts_type = "'pre'|'post'|null")]
+  pub order: Option<String>,
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct BindingPluginOptions {
@@ -44,15 +57,8 @@ pub struct BindingPluginOptions {
   pub build_start: Option<BuildStartHookOption>,
 
   #[serde(skip_deserializing)]
-  #[napi(
-    ts_type = "(specifier: string, importer: Nullable<string>, options: BindingHookResolveIdExtraOptions) => MaybePromise<VoidNullable<BindingHookResolveIdOutput>>"
-  )]
-  pub resolve_id: Option<
-    MaybeAsyncJsCallback<
-      (String, Option<String>, BindingHookResolveIdExtraOptions),
-      Option<BindingHookResolveIdOutput>,
-    >,
-  >,
+  #[napi(ts_type = "ResolveIdHookOption")]
+  pub resolve_id: Option<ResolveIdHookOption>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(id: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>")]

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -45,6 +45,13 @@ pub struct ResolveIdHookOption {
   #[napi(ts_type = "'pre'|'post'|null")]
   pub order: Option<String>,
 }
+#[napi_derive::napi(object, object_to_js = false)]
+pub struct LoadOption {
+  #[napi(ts_type = "(id: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>")]
+  pub handler: MaybeAsyncJsCallback<String, Option<BindingHookLoadOutput>>,
+  #[napi(ts_type = "'pre'|'post'|null")]
+  pub order: Option<String>,
+}
 
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Deserialize, Default)]
@@ -61,8 +68,8 @@ pub struct BindingPluginOptions {
   pub resolve_id: Option<ResolveIdHookOption>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(id: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>")]
-  pub load: Option<MaybeAsyncJsCallback<String, Option<BindingHookLoadOutput>>>,
+  #[napi(ts_type = "LoadOption")]
+  pub load: Option<LoadOption>,
 
   #[serde(skip_deserializing)]
   #[napi(

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -54,6 +54,16 @@ pub struct LoadOption {
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
+pub struct TransformOption {
+  #[napi(
+    ts_type = "(id: string, code: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>"
+  )]
+  pub handler: MaybeAsyncJsCallback<(String, String), Option<BindingHookLoadOutput>>,
+  #[napi(ts_type = "'pre'|'post'|null")]
+  pub order: Option<String>,
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct BindingPluginOptions {
@@ -72,10 +82,8 @@ pub struct BindingPluginOptions {
   pub load: Option<LoadOption>,
 
   #[serde(skip_deserializing)]
-  #[napi(
-    ts_type = "(id: string, code: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>"
-  )]
-  pub transform: Option<MaybeAsyncJsCallback<(String, String), Option<BindingHookLoadOutput>>>,
+  #[napi(ts_type = "TransformOption")]
+  pub transform: Option<TransformOption>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(error: Nullable<string>) => MaybePromise<VoidNullable>")]

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -52,7 +52,6 @@ pub struct LoadOption {
   #[napi(ts_type = "'pre'|'post'|null")]
   pub order: Option<String>,
 }
-
 #[napi_derive::napi(object, object_to_js = false)]
 pub struct TransformOption {
   #[napi(
@@ -61,6 +60,40 @@ pub struct TransformOption {
   pub handler: MaybeAsyncJsCallback<(String, String), Option<BindingHookLoadOutput>>,
   #[napi(ts_type = "'pre'|'post'|null")]
   pub order: Option<String>,
+}
+#[napi_derive::napi(object, object_to_js = false)]
+pub struct BuildEndHookOption {
+  #[napi(ts_type = "(error: Nullable<string>) => MaybePromise<VoidNullable>")]
+  pub handler: MaybeAsyncJsCallback<Option<String>, ()>,
+  #[napi(ts_type = "'pre'|'post'|null")]
+  pub order: Option<String>,
+  pub sequential: Option<bool>,
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
+pub struct RenderChunkOption {
+  #[napi(
+    ts_type = "(code: string, chunk: RenderedChunk) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>"
+  )]
+  pub handler: MaybeAsyncJsCallback<(String, RenderedChunk), Option<BindingHookRenderChunkOutput>>,
+  #[napi(ts_type = "'pre'|'post'|null")]
+  pub order: Option<String>,
+}
+#[napi_derive::napi(object, object_to_js = false)]
+pub struct GenerateBundleOption {
+  #[napi(ts_type = "(bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>")]
+  pub handler: MaybeAsyncJsCallback<(BindingOutputs, bool), ()>,
+  #[napi(ts_type = "'pre'|'post'|null")]
+  pub order: Option<String>,
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
+pub struct WriteBundleOption {
+  #[napi(ts_type = "(bundle: BindingOutputs) => MaybePromise<VoidNullable>")]
+  pub handler: MaybeAsyncJsCallback<BindingOutputs, ()>,
+  #[napi(ts_type = "'pre'|'post'|null")]
+  pub order: Option<String>,
+  pub sequential: Option<bool>,
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
@@ -86,23 +119,20 @@ pub struct BindingPluginOptions {
   pub transform: Option<TransformOption>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(error: Nullable<string>) => MaybePromise<VoidNullable>")]
-  pub build_end: Option<MaybeAsyncJsCallback<Option<String>, ()>>,
+  #[napi(ts_type = "BuildEndHookOption")]
+  pub build_end: Option<BuildEndHookOption>,
 
   #[serde(skip_deserializing)]
-  #[napi(
-    ts_type = "(code: string, chunk: RenderedChunk) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>"
-  )]
-  pub render_chunk:
-    Option<MaybeAsyncJsCallback<(String, RenderedChunk), Option<BindingHookRenderChunkOutput>>>,
+  #[napi(ts_type = "RenderChunkOption")]
+  pub render_chunk: Option<RenderChunkOption>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>")]
-  pub generate_bundle: Option<MaybeAsyncJsCallback<(BindingOutputs, bool), ()>>,
+  #[napi(ts_type = "GenerateBundleOption")]
+  pub generate_bundle: Option<GenerateBundleOption>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(bundle: BindingOutputs) => MaybePromise<VoidNullable>")]
-  pub write_bundle: Option<MaybeAsyncJsCallback<BindingOutputs, ()>>,
+  #[napi(ts_type = "WriteBundleOption")]
+  pub write_bundle: Option<WriteBundleOption>,
 }
 
 impl Debug for BindingPluginOptions {

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -68,8 +68,15 @@ impl Plugin for JsPlugin {
     _ctx: &rolldown_plugin::SharedPluginContext,
     args: &rolldown_plugin::HookLoadArgs,
   ) -> rolldown_plugin::HookLoadReturn {
-    if let Some(cb) = &self.load {
-      Ok(cb.await_call(args.id.to_string()).await?.map(TryInto::try_into).transpose()?)
+    if let Some(hookOption) = &self.load {
+      Ok(
+        hookOption
+          .handler
+          .await_call(args.id.to_string())
+          .await?
+          .map(TryInto::try_into)
+          .transpose()?,
+      )
     } else {
       Ok(None)
     }

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -46,15 +46,17 @@ impl Plugin for JsPlugin {
     _ctx: &rolldown_plugin::SharedPluginContext,
     args: &rolldown_plugin::HookResolveIdArgs,
   ) -> rolldown_plugin::HookResolveIdReturn {
-    if let Some(cb) = &self.resolve_id {
+    if let Some(hookOption) = &self.resolve_id {
       Ok(
-        cb.await_call((
-          args.source.to_string(),
-          args.importer.map(str::to_string),
-          args.options.clone().into(),
-        ))
-        .await?
-        .map(Into::into),
+        hookOption
+          .handler
+          .await_call((
+            args.source.to_string(),
+            args.importer.map(str::to_string),
+            args.options.clone().into(),
+          ))
+          .await?
+          .map(Into::into),
       )
     } else {
       Ok(None)

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -35,8 +35,8 @@ impl Plugin for JsPlugin {
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
   ) -> rolldown_plugin::HookNoopReturn {
-    if let Some(cb) = &self.build_start {
-      cb.await_call(Arc::clone(ctx).into()).await?;
+    if let Some(hook_option) = &self.build_start {
+      hook_option.handler.await_call(Arc::clone(ctx).into()).await?;
     }
     Ok(())
   }

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -46,9 +46,9 @@ impl Plugin for JsPlugin {
     _ctx: &rolldown_plugin::SharedPluginContext,
     args: &rolldown_plugin::HookResolveIdArgs,
   ) -> rolldown_plugin::HookResolveIdReturn {
-    if let Some(hookOption) = &self.resolve_id {
+    if let Some(hook_option) = &self.resolve_id {
       Ok(
-        hookOption
+        hook_option
           .handler
           .await_call((
             args.source.to_string(),
@@ -68,9 +68,9 @@ impl Plugin for JsPlugin {
     _ctx: &rolldown_plugin::SharedPluginContext,
     args: &rolldown_plugin::HookLoadArgs,
   ) -> rolldown_plugin::HookLoadReturn {
-    if let Some(hookOption) = &self.load {
+    if let Some(hook_option) = &self.load {
       Ok(
-        hookOption
+        hook_option
           .handler
           .await_call(args.id.to_string())
           .await?
@@ -87,9 +87,11 @@ impl Plugin for JsPlugin {
     _ctx: &rolldown_plugin::SharedPluginContext,
     args: &rolldown_plugin::HookTransformArgs,
   ) -> rolldown_plugin::HookTransformReturn {
-    if let Some(cb) = &self.transform {
+    if let Some(hook_option) = &self.transform {
       Ok(
-        cb.await_call((args.code.to_string(), args.id.to_string()))
+        hook_option
+          .handler
+          .await_call((args.code.to_string(), args.id.to_string()))
           .await?
           .map(TryInto::try_into)
           .transpose()?,

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -106,8 +106,8 @@ impl Plugin for JsPlugin {
     _ctx: &rolldown_plugin::SharedPluginContext,
     args: Option<&rolldown_plugin::HookBuildEndArgs>,
   ) -> rolldown_plugin::HookNoopReturn {
-    if let Some(cb) = &self.build_end {
-      cb.await_call(args.map(|a| a.error.to_string())).await?;
+    if let Some(hook_option) = &self.build_end {
+      hook_option.handler.await_call(args.map(|a| a.error.to_string())).await?;
     }
     Ok(())
   }
@@ -117,8 +117,14 @@ impl Plugin for JsPlugin {
     _ctx: &rolldown_plugin::SharedPluginContext,
     args: &rolldown_plugin::HookRenderChunkArgs,
   ) -> rolldown_plugin::HookRenderChunkReturn {
-    if let Some(cb) = &self.render_chunk {
-      Ok(cb.await_call((args.code.to_string(), args.chunk.clone().into())).await?.map(Into::into))
+    if let Some(hook_option) = &self.render_chunk {
+      Ok(
+        hook_option
+          .handler
+          .await_call((args.code.to_string(), args.chunk.clone().into()))
+          .await?
+          .map(Into::into),
+      )
     } else {
       Ok(None)
     }
@@ -132,8 +138,8 @@ impl Plugin for JsPlugin {
     bundle: &Vec<rolldown_common::Output>,
     is_write: bool,
   ) -> rolldown_plugin::HookNoopReturn {
-    if let Some(cb) = &self.generate_bundle {
-      cb.await_call((BindingOutputs::new(bundle.clone()), is_write)).await?;
+    if let Some(hook_option) = &self.generate_bundle {
+      hook_option.handler.await_call((BindingOutputs::new(bundle.clone()), is_write)).await?;
     }
     Ok(())
   }
@@ -143,8 +149,8 @@ impl Plugin for JsPlugin {
     _ctx: &rolldown_plugin::SharedPluginContext,
     bundle: &Vec<rolldown_common::Output>,
   ) -> rolldown_plugin::HookNoopReturn {
-    if let Some(cb) = &self.write_bundle {
-      cb.await_call(BindingOutputs::new(bundle.clone())).await?;
+    if let Some(hook_option) = &self.write_bundle {
+      hook_option.handler.await_call(BindingOutputs::new(bundle.clone())).await?;
     }
     Ok(())
   }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -102,7 +102,7 @@ export interface BindingPluginContextResolveOptions {
 
 export interface BindingPluginOptions {
   name: string
-  buildStart?: (ctx: BindingPluginContext) => MaybePromise<VoidNullable>
+  buildStart?: BuildStartHookOption
   resolveId?: (
     specifier: string,
     importer: Nullable<string>,
@@ -139,6 +139,17 @@ export interface BindingResolveOptions {
   mainFiles?: Array<string>
   modules?: Array<string>
   symlinks?: boolean
+}
+
+export interface BuildStartHookOption {
+  handler: (ctx: BindingPluginContext) => MaybePromise<VoidNullable>
+  order?: 'pre' | 'post' | null
+  sequential?: boolean
+}
+
+export interface HookOption {
+  order?: 'pre' | 'post' | null
+  sequential?: boolean
 }
 
 export interface RenderedChunk {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -103,11 +103,7 @@ export interface BindingPluginContextResolveOptions {
 export interface BindingPluginOptions {
   name: string
   buildStart?: BuildStartHookOption
-  resolveId?: (
-    specifier: string,
-    importer: Nullable<string>,
-    options: BindingHookResolveIdExtraOptions,
-  ) => MaybePromise<VoidNullable<BindingHookResolveIdOutput>>
+  resolveId?: ResolveIdHookOption
   load?: (id: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>
   transform?: (
     id: string,
@@ -160,4 +156,13 @@ export interface RenderedChunk {
   exports: Array<string>
   fileName: string
   modules: Record<string, BindingRenderedModule>
+}
+
+export interface ResolveIdHookOption {
+  handler: (
+    specifier: string,
+    importer: Nullable<string>,
+    options: BindingHookResolveIdExtraOptions,
+  ) => MaybePromise<VoidNullable<BindingHookResolveIdOutput>>
+  order?: 'pre' | 'post' | null
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -106,16 +106,10 @@ export interface BindingPluginOptions {
   resolveId?: ResolveIdHookOption
   load?: LoadOption
   transform?: TransformOption
-  buildEnd?: (error: Nullable<string>) => MaybePromise<VoidNullable>
-  renderChunk?: (
-    code: string,
-    chunk: RenderedChunk,
-  ) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>
-  generateBundle?: (
-    bundle: BindingOutputs,
-    isWrite: boolean,
-  ) => MaybePromise<VoidNullable>
-  writeBundle?: (bundle: BindingOutputs) => MaybePromise<VoidNullable>
+  buildEnd?: BuildEndHookOption
+  renderChunk?: RenderChunkOption
+  generateBundle?: GenerateBundleOption
+  writeBundle?: WriteBundleOption
 }
 
 export interface BindingRenderedModule {
@@ -134,10 +128,24 @@ export interface BindingResolveOptions {
   symlinks?: boolean
 }
 
+export interface BuildEndHookOption {
+  handler: (error: Nullable<string>) => MaybePromise<VoidNullable>
+  order?: 'pre' | 'post' | null
+  sequential?: boolean
+}
+
 export interface BuildStartHookOption {
   handler: (ctx: BindingPluginContext) => MaybePromise<VoidNullable>
   order?: 'pre' | 'post' | null
   sequential?: boolean
+}
+
+export interface GenerateBundleOption {
+  handler: (
+    bundle: BindingOutputs,
+    isWrite: boolean,
+  ) => MaybePromise<VoidNullable>
+  order?: 'pre' | 'post' | null
 }
 
 export interface HookOption {
@@ -147,6 +155,14 @@ export interface HookOption {
 
 export interface LoadOption {
   handler: (id: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>
+  order?: 'pre' | 'post' | null
+}
+
+export interface RenderChunkOption {
+  handler: (
+    code: string,
+    chunk: RenderedChunk,
+  ) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>
   order?: 'pre' | 'post' | null
 }
 
@@ -175,4 +191,10 @@ export interface TransformOption {
     code: string,
   ) => MaybePromise<VoidNullable<BindingHookLoadOutput>>
   order?: 'pre' | 'post' | null
+}
+
+export interface WriteBundleOption {
+  handler: (bundle: BindingOutputs) => MaybePromise<VoidNullable>
+  order?: 'pre' | 'post' | null
+  sequential?: boolean
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -105,10 +105,7 @@ export interface BindingPluginOptions {
   buildStart?: BuildStartHookOption
   resolveId?: ResolveIdHookOption
   load?: LoadOption
-  transform?: (
-    id: string,
-    code: string,
-  ) => MaybePromise<VoidNullable<BindingHookLoadOutput>>
+  transform?: TransformOption
   buildEnd?: (error: Nullable<string>) => MaybePromise<VoidNullable>
   renderChunk?: (
     code: string,
@@ -169,5 +166,13 @@ export interface ResolveIdHookOption {
     importer: Nullable<string>,
     options: BindingHookResolveIdExtraOptions,
   ) => MaybePromise<VoidNullable<BindingHookResolveIdOutput>>
+  order?: 'pre' | 'post' | null
+}
+
+export interface TransformOption {
+  handler: (
+    id: string,
+    code: string,
+  ) => MaybePromise<VoidNullable<BindingHookLoadOutput>>
   order?: 'pre' | 'post' | null
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -104,7 +104,7 @@ export interface BindingPluginOptions {
   name: string
   buildStart?: BuildStartHookOption
   resolveId?: ResolveIdHookOption
-  load?: (id: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>
+  load?: LoadOption
   transform?: (
     id: string,
     code: string,
@@ -146,6 +146,11 @@ export interface BuildStartHookOption {
 export interface HookOption {
   order?: 'pre' | 'post' | null
   sequential?: boolean
+}
+
+export interface LoadOption {
+  handler: (id: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>
+  order?: 'pre' | 'post' | null
 }
 
 export interface RenderedChunk {

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -1,8 +1,9 @@
 import { normalizeHook } from '../utils/normalize-hook'
-import type { BindingPluginOptions } from '../binding'
+import type { BindingPluginOptions, HookOption } from '../binding'
 
-import type { Plugin } from './index'
+import type { Hook, Plugin } from './index'
 import { RolldownNormalizedInputOptions } from '../options/input-options'
+import { AnyFn } from 'src/types/utils'
 
 export function bindingifyBuildStart(
   options: RolldownNormalizedInputOptions,
@@ -11,10 +12,14 @@ export function bindingifyBuildStart(
   if (!hook) {
     return undefined
   }
-  const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
+  const [handler, option] = normalizeHook<Hook<AnyFn, HookOption>>(hook)
 
-  return async (ctx) => {
-    handler.call(ctx, options)
+  return {
+    handler: async (ctx) => {
+      handler.call(ctx, options)
+    },
+    order: option.order,
+    sequential: option.sequential,
   }
 }
 

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -46,24 +46,27 @@ export function bindingifyResolveId(
   if (!hook) {
     return undefined
   }
-  const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
+  const [handler, option] = normalizeHook<Hook<AnyFn, HookOption>>(hook)
 
-  return async (specifier, importer, options) => {
-    const ret = await handler.call(
-      null,
-      specifier,
-      importer ?? undefined,
-      options,
-    )
-    if (ret == false || ret == null) {
-      return
-    }
-    if (typeof ret === 'string') {
-      return {
-        id: ret,
+  return {
+    handler: async (specifier, importer, options) => {
+      const ret = await handler.call(
+        null,
+        specifier,
+        importer ?? undefined,
+        options,
+      )
+      if (ret == false || ret == null) {
+        return
       }
-    }
-    return ret
+      if (typeof ret === 'string') {
+        return {
+          id: ret,
+        }
+      }
+      return ret
+    },
+    order: option.order,
   }
 }
 

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -76,22 +76,25 @@ export function bindingifyTransform(
   if (!hook) {
     return undefined
   }
-  const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
+  const [handler, option] = normalizeHook<Hook<AnyFn, HookOption>>(hook)
 
-  return async (code, id) => {
-    const ret = await handler.call(null, code, id)
+  return {
+    handler: async (code, id) => {
+      const ret = await handler.call(null, code, id)
 
-    if (ret == null) {
-      return
-    }
+      if (ret == null) {
+        return
+      }
 
-    const retCode = typeof ret === 'string' ? ret : ret.code
-    const retMap = typeof ret === 'string' ? undefined : ret.map
+      const retCode = typeof ret === 'string' ? ret : ret.code
+      const retMap = typeof ret === 'string' ? undefined : ret.map
 
-    return {
-      code: retCode,
-      map: retMap ?? undefined,
-    }
+      return {
+        code: retCode,
+        map: retMap ?? undefined,
+      }
+    },
+    order: option.order,
   }
 }
 

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -29,14 +29,17 @@ export function bindingifyBuildEnd(
   if (!hook) {
     return undefined
   }
-  const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
+  const [handler, option] = normalizeHook<Hook<AnyFn, HookOption>>(hook)
 
-  return async (err) => {
-    try {
-      handler.call(null, err ?? undefined)
-    } catch (error) {
-      console.error(error)
-    }
+  return {
+    handler: async (err) => {
+      try {
+        handler.call(null, err ?? undefined)
+      } catch (error) {
+        console.error(error)
+      }
+    },
+    order: option.order,
   }
 }
 
@@ -132,17 +135,20 @@ export function bindingifyRenderChunk(
   if (!hook) {
     return undefined
   }
-  const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
+  const [handler, option] = normalizeHook<Hook<AnyFn, HookOption>>(hook)
 
-  return async (code, chunk) => {
-    const ret = await handler.call(null, code, chunk)
+  return {
+    handler: async (code, chunk) => {
+      const ret = await handler.call(null, code, chunk)
 
-    if (ret == null) {
-      return
-    }
+      if (ret == null) {
+        return
+      }
 
-    return {
-      code: ret,
-    }
+      return {
+        code: ret,
+      }
+    },
+    order: option.order,
   }
 }

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -101,22 +101,25 @@ export function bindingifyLoad(
   if (!hook) {
     return undefined
   }
-  const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
+  const [handler, option] = normalizeHook<Hook<AnyFn, HookOption>>(hook)
 
-  return async (id) => {
-    const ret = await handler.call(null, id)
+  return {
+    handler: async (id) => {
+      const ret = await handler.call(null, id)
 
-    if (ret == null) {
-      return
-    }
+      if (ret == null) {
+        return
+      }
 
-    const retCode = typeof ret === 'string' ? ret : ret.code
-    const retMap = typeof ret === 'string' ? undefined : ret.map
+      const retCode = typeof ret === 'string' ? ret : ret.code
+      const retMap = typeof ret === 'string' ? undefined : ret.map
 
-    return {
-      code: retCode,
-      map: retMap ?? undefined,
-    }
+      return {
+        code: retCode,
+        map: retMap ?? undefined,
+      }
+    },
+    order: option.order,
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
⚠️This pr is under construction

support plugin attr order:
[rollup doc](https://rollupjs.org/plugin-development/#build-hooks)
> order: "pre" | "post" | null
> If there are several plugins implementing this hook, either run this plugin first ("pre"), last ("post"), or in the user-specified > position (no value or null).
```js
export default function resolveFirst() {
	return {
		name: 'resolve-first',
		resolveId: {
			order: 'pre',
			handler(source) {
				if (source === 'external') {
					return { id: source, external: true };
				}
				return null;
			}
		}
	};
}
```
If several plugins use "pre" or "post", Rollup runs them in the user-specified order. This option can be used for all plugin hooks. For parallel hooks, it changes the order in which the synchronous part of the hook is run.

## confusion
I want to sort the plugins , i think it should implementation in PluginDriver.
site: crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
```js
impl PluginDriver {
  pub async fn build_start(&self) -> HookNoopReturn {
    // TODO should call `build_start` of all plugins in parallel
    for (plugin:&Box<dyn Plugin>, ctx) in &self.plugins {
      plugin.build_start(ctx).await?;
    }
    Ok(())
  }
}
```
but beacause of plugin type is  ```&Box<dyn Plugin>```,i cant get buildstart hook options although i delivery attribute order.
i want to change plugin type to JsPlugin,but JsPlugin is define in crates rolldown_binding.This does not seem to be a dependency.
so how can i get completly plugin.build_start? I admit I'm not very familiar with rust...