### PR TITLE
chore(bench/node): bundling `rome-ts` with rolldown

### DIFF
--- a/packages/bench/src/suites.js
+++ b/packages/bench/src/suites.js
@@ -62,6 +62,8 @@ export const suites = expandSuitesWithDerived([
         'zlib',
         'inspector',
       ],
+      // Need this due rome is not written with `isolatedModules: true`
+      shimMissingExports: true,
       plugins: [
         {
           name: '@rolldown/plugin-esbuild',
@@ -91,7 +93,7 @@ export const suites = expandSuitesWithDerived([
         ),
       },
     },
-    disableBundler: ['rolldown', 'rollup'],
+    disableBundler: ['rollup'],
   },
   {
     title: 'react-stack',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://github.com/rolldown/rolldown/blob/c304a0dcde43234654626f8695cd745f37de4d33/packages/bench/src/suites.js#L65-L85

Since rolldown doesn't support transpile typescript natively, so we use esbuild to transpile typescript code :).

```
// esbuild.transformSync

rome-ts:
  esbuild: 59.02ms (fastest)
  rolldown: 471.67ms
Summary(rome-ts):
  esbuild is
  - 7.99 times faster than rolldown
  
// await esbuild.transform

rome-ts:
  esbuild: 55.27ms (fastest)
  rolldown: 154.02ms
Summary(rome-ts):
  esbuild is
  - 2.79 times faster than rolldown
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
