### PR TITLE
chore(repo): make `cargo build` not failed due to undefined symbols of NAPI-RS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,15 @@
+[target.'cfg(target_vendor = "apple")']
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup,-no_fixup_chains"]
+
+# To be able to run unit tests on Linux, support compilation to 'x86_64-unknown-linux-gnu'.
+[target.'cfg(target_os = "linux")']
+rustflags = ["-C", "link-args=-Wl,--warn-unresolved-symbols"]
+
+# To be able to run unit tests on Windows, support compilation to 'x86_64-pc-windows-msvc'.
+[target.'cfg(target_os = "windows")']
+rustflags = ["-C", "link-args=/FORCE"]
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
* Adding rust-flags for all platforms

<!-- Thank you for contributing! -->

### Description

This solves the issue raised #752 where there was a build failure

```
rolldown/target/debug/deps/librolldown_wasm_binding.dylib" "-Wl,-dead_strip" "-dynamiclib" "-Wl,-dylib" "-nodefaultlibs"
  = note: Undefined symbols for architecture arm64:
            "_napi_add_env_cleanup_hook", referenced from:
                napi::bindgen_runtime::module_register::create_custom_gc::hd30a2de059007b41 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_create_error", referenced from:
                napi::error::JsError$LT$S$GT$::into_value::h46c6abfd44d271e4 in libnapi-312e8188eb3e0c97.rlib[15](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.12.rcgu.o)
            "_napi_create_function", referenced from:
                napi::bindgen_runtime::module_register::create_custom_gc::hd30a2de059007b41 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_create_object", referenced from:
                napi::bindgen_runtime::module_register::napi_register_module_v1::_$u7b$$u7b$closure$u7d$$u7d$::h540199059f944417 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
                napi::bindgen_runtime::module_register::napi_register_module_v1::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h93b1b4b6d80ac82b in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_create_reference", referenced from:
                napi::bindgen_runtime::module_register::napi_register_module_v1::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h93b1b4b6d80ac82b in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_create_string_utf8", referenced from:
                napi::error::JsError$LT$S$GT$::into_value::h46c6abfd44d271e4 in libnapi-312e8188eb3e0c97.rlib[15](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.12.rcgu.o)
                napi::error::JsError$LT$S$GT$::into_value::h46c6abfd44d271e4 in libnapi-312e8188eb3e0c97.rlib[15](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.12.rcgu.o)
                napi::bindgen_runtime::module_register::create_custom_gc::hd30a2de059007b41 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_create_threadsafe_function", referenced from:
                napi::bindgen_runtime::module_register::create_custom_gc::hd30a2de059007b41 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_define_class", referenced from:
                napi::bindgen_runtime::module_register::napi_register_module_v1::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h93b1b4b6d80ac82b in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_delete_reference", referenced from:
                napi::error::JsError$LT$S$GT$::into_value::h46c6abfd44d271e4 in libnapi-312e8188eb3e0c97.rlib[15](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.12.rcgu.o)
                napi::bindgen_runtime::module_register::custom_gc::h67496f5d9cf8c480 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_get_named_property", referenced from:
                napi::bindgen_runtime::module_register::napi_register_module_v1::_$u7b$$u7b$closure$u7d$$u7d$::h540199059f944417 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
                napi::bindgen_runtime::module_register::napi_register_module_v1::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h93b1b4b6d80ac82b in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_get_reference_value", referenced from:
                napi::error::JsError$LT$S$GT$::into_value::h46c6abfd44d271e4 in libnapi-312e8188eb3e0c97.rlib[15](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.12.rcgu.o)
            "_napi_reference_unref", referenced from:
                napi::bindgen_runtime::module_register::custom_gc::h67496f5d9cf8c480 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_set_named_property", referenced from:
                napi::bindgen_runtime::module_register::napi_register_module_v1::_$u7b$$u7b$closure$u7d$$u7d$::h540199059f944417 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
                napi::bindgen_runtime::module_register::napi_register_module_v1::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::hccff6d2be1eaf4f9 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
                napi::bindgen_runtime::module_register::napi_register_module_v1::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h93b1b4b6d80ac82b in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
                napi::bindgen_runtime::module_register::napi_register_module_v1::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h93b1b4b6d80ac82b in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_throw", referenced from:
                napi::error::JsError$LT$S$GT$::throw_into::hc7227cc59d6ef4a3 in libnapi-312e8188eb3e0c97.rlib[15](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.12.rcgu.o)
                napi::error::JsError$LT$S$GT$::throw_into::hc7227cc59d6ef4a3 in libnapi-312e8188eb3e0c97.rlib[15](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.12.rcgu.o)
            "_napi_throw_error", referenced from:
                napi::bindgen_runtime::module_register::noop::h4bc7baf793cf2531 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
            "_napi_unref_threadsafe_function", referenced from:
                napi::bindgen_runtime::module_register::create_custom_gc::hd30a2de059007b41 in libnapi-312e8188eb3e0c97.rlib[17](napi-312e8188eb3e0c97.napi.f8d7f44244e6e222-cgu.14.rcgu.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
``` 

Also added the rust-flags for other platforms

