### PR TITLE
chore(rust): rename `RolldownOutput` to `BundleOutput`

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -12,7 +12,7 @@ use crate::{
   bundler_builder::BundlerBuilder,
   error::{BatchedErrors, BatchedResult},
   stages::{bundle_stage::BundleStage, scan_stage::ScanStage},
-  types::rolldown_output::RolldownOutput,
+  types::bundle_output::BundleOutput,
   BundlerOptions, SharedOptions, SharedResolver,
 };
 
@@ -34,7 +34,7 @@ impl Bundler {
 }
 
 impl Bundler {
-  pub async fn write(&mut self) -> BatchedResult<RolldownOutput> {
+  pub async fn write(&mut self) -> BatchedResult<BundleOutput> {
     let dir = self.options.cwd.as_path().join(&self.options.dir).to_string_lossy().to_string();
 
     let output = self.bundle_up(true).await?;
@@ -63,7 +63,7 @@ impl Bundler {
     Ok(output)
   }
 
-  pub async fn generate(&mut self) -> BatchedResult<RolldownOutput> {
+  pub async fn generate(&mut self) -> BatchedResult<BundleOutput> {
     self.bundle_up(false).await
   }
 
@@ -126,7 +126,7 @@ impl Bundler {
   }
 
   #[tracing::instrument(skip_all)]
-  async fn bundle_up(&mut self, is_write: bool) -> BatchedResult<RolldownOutput> {
+  async fn bundle_up(&mut self, is_write: bool) -> BatchedResult<BundleOutput> {
     tracing::trace!("Options {:#?}", self.options);
     let mut link_stage_output = self.try_build().await?;
 
@@ -137,6 +137,6 @@ impl Bundler {
 
     self.plugin_driver.generate_bundle(&assets, is_write).await?;
 
-    Ok(RolldownOutput { warnings: std::mem::take(&mut link_stage_output.warnings), assets })
+    Ok(BundleOutput { warnings: std::mem::take(&mut link_stage_output.warnings), assets })
   }
 }

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -21,7 +21,7 @@ pub(crate) type SharedOptions = Arc<NormalizedBundlerOptions>;
 
 pub use crate::{
   bundler::Bundler, bundler_builder::BundlerBuilder, chunk::render_chunk::PreRenderedChunk,
-  types::rolldown_output::RolldownOutput,
+  types::bundle_output::BundleOutput,
 };
 
 pub use rolldown_common::bundler_options::*;

--- a/crates/rolldown/src/types/bundle_output.rs
+++ b/crates/rolldown/src/types/bundle_output.rs
@@ -1,7 +1,7 @@
 use rolldown_common::Output;
 use rolldown_error::BuildError;
 
-pub struct RolldownOutput {
+pub struct BundleOutput {
   pub warnings: Vec<BuildError>,
   pub assets: Vec<Output>,
 }

--- a/crates/rolldown/src/types/mod.rs
+++ b/crates/rolldown/src/types/mod.rs
@@ -3,6 +3,7 @@
 // operations on the data they store or only have simple getters and setters.
 
 pub mod ast_symbols;
+pub mod bundle_output;
 pub mod bundler_fs;
 pub mod linking_metadata;
 pub mod match_import_kind;
@@ -11,5 +12,4 @@ pub mod module_table;
 pub mod namespace_alias;
 pub mod normal_module_builder;
 pub mod resolved_request_info;
-pub mod rolldown_output;
 pub mod symbols;

--- a/crates/rolldown/tests/common/case.rs
+++ b/crates/rolldown/tests/common/case.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, path::Path};
 
 use super::fixture::Fixture;
-use rolldown::RolldownOutput;
+use rolldown::BundleOutput;
 use rolldown_common::Output;
 use rolldown_error::BuildError;
 use rolldown_sourcemap::SourcemapVisualizer;
@@ -43,7 +43,7 @@ impl Case {
     self.fixture.exec();
   }
 
-  fn render_assets_to_snapshot(&mut self, outputs: RolldownOutput) {
+  fn render_assets_to_snapshot(&mut self, outputs: BundleOutput) {
     let mut assets = outputs.assets;
     let warnings = outputs.warnings;
 

--- a/crates/rolldown/tests/common/fixture.rs
+++ b/crates/rolldown/tests/common/fixture.rs
@@ -4,7 +4,7 @@ use std::{
   process::Command,
 };
 
-use rolldown::{Bundler, RolldownOutput, SourceMapType};
+use rolldown::{BundleOutput, Bundler, SourceMapType};
 use rolldown_error::BuildError;
 use rolldown_testing::TestConfig;
 
@@ -90,7 +90,7 @@ impl Fixture {
     }
   }
 
-  pub async fn compile(&mut self) -> Result<RolldownOutput, Vec<BuildError>> {
+  pub async fn compile(&mut self) -> Result<BundleOutput, Vec<BuildError>> {
     let fixture_path = self.dir_path();
     let test_config = self.test_config();
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
