### PR TITLE
chore(rust): use `SymbolRef` for `NormalModule#named_imports`

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -29,7 +29,7 @@ use super::types::ast_symbols::AstSymbols;
 #[derive(Debug, Default)]
 pub struct ScanResult {
   pub repr_name: String,
-  pub named_imports: FxHashMap<SymbolId, NamedImport>,
+  pub named_imports: FxHashMap<SymbolRef, NamedImport>,
   pub named_exports: FxHashMap<Rstr, LocalExport>,
   pub stmt_infos: StmtInfos,
   pub import_records: IndexVec<ImportRecordId, RawImportRecord>,
@@ -158,7 +158,7 @@ impl<'me> AstScanner<'me> {
 
   fn add_named_import(&mut self, local: SymbolId, imported: &str, record_id: ImportRecordId) {
     self.result.named_imports.insert(
-      local,
+      (self.idx, local).into(),
       NamedImport {
         imported: Rstr::new(imported).into(),
         imported_as: (self.idx, local).into(),
@@ -169,7 +169,7 @@ impl<'me> AstScanner<'me> {
 
   fn add_star_import(&mut self, local: SymbolId, record_id: ImportRecordId) {
     self.result.named_imports.insert(
-      local,
+      (self.idx, local).into(),
       NamedImport { imported: Specifier::Star, imported_as: (self.idx, local).into(), record_id },
     );
   }
@@ -212,7 +212,7 @@ impl<'me> AstScanner<'me> {
     if name_import.imported.is_default() {
       self.result.import_records[record_id].contains_import_default = true;
     }
-    self.result.named_imports.insert(generated_imported_as_ref.symbol, name_import);
+    self.result.named_imports.insert(generated_imported_as_ref, name_import);
     self
       .result
       .named_exports
@@ -228,7 +228,7 @@ impl<'me> AstScanner<'me> {
     self.current_stmt_info.declared_symbols.push(generated_imported_as_ref);
     let name_import =
       NamedImport { imported: Specifier::Star, imported_as: generated_imported_as_ref, record_id };
-    self.result.named_imports.insert(generated_imported_as_ref.symbol, name_import);
+    self.result.named_imports.insert(generated_imported_as_ref, name_import);
     self.result.import_records[record_id].contains_import_star = true;
     self
       .result

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -186,7 +186,7 @@ impl<'a> LinkStage<'a> {
 
     for symbol_ref in potentially_ambiguous_symbol_refs {
       let importer = &modules[symbol_ref.owner];
-      if let Some(info) = importer.named_imports.get(&symbol_ref.symbol) {
+      if let Some(info) = importer.named_imports.get(&symbol_ref) {
         let importee_id = importer.import_records[info.record_id].resolved_module;
         let ModuleId::Normal(importee_id) = importee_id else {
           continue;

--- a/crates/rolldown/src/types/normal_module_builder.rs
+++ b/crates/rolldown/src/types/normal_module_builder.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use index_vec::IndexVec;
-use oxc::{semantic::SymbolId, span::Span};
+use oxc::span::Span;
 use rolldown_common::{
   AstScope, ExportsKind, ImportRecord, ImportRecordId, LocalExport, ModuleType, NamedImport,
   NormalModule, NormalModuleId, ResourceId, StmtInfos, SymbolRef,
@@ -15,7 +15,7 @@ pub struct NormalModuleBuilder {
   pub source: Option<Arc<str>>,
   pub repr_name: Option<String>,
   pub path: Option<ResourceId>,
-  pub named_imports: Option<FxHashMap<SymbolId, NamedImport>>,
+  pub named_imports: Option<FxHashMap<SymbolRef, NamedImport>>,
   pub named_exports: Option<FxHashMap<Rstr, LocalExport>>,
   pub stmt_infos: Option<StmtInfos>,
   pub import_records: Option<IndexVec<ImportRecordId, ImportRecord>>,

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -6,7 +6,7 @@ use crate::{
   StmtInfo, StmtInfos, SymbolRef,
 };
 use index_vec::IndexVec;
-use oxc::{semantic::SymbolId, span::Span};
+use oxc::span::Span;
 use rolldown_rstr::Rstr;
 use rustc_hash::FxHashMap;
 
@@ -22,7 +22,7 @@ pub struct NormalModule {
   pub repr_name: String,
   pub module_type: ModuleType,
   pub namespace_symbol: SymbolRef,
-  pub named_imports: FxHashMap<SymbolId, NamedImport>,
+  pub named_imports: FxHashMap<SymbolRef, NamedImport>,
   pub named_exports: FxHashMap<Rstr, LocalExport>,
   /// `stmt_infos[0]` represents the namespace binding statement
   pub stmt_infos: StmtInfos,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`SymbolId` is local thing while we interact with `SymbolRef` more frequently.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
