### PR TITLE
chore(rust): rename `BundleStage` to `GenerateStage`

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -11,7 +11,7 @@ use super::stages::{
 use crate::{
   bundler_builder::BundlerBuilder,
   error::{BatchedErrors, BatchedResult},
-  stages::{bundle_stage::BundleStage, scan_stage::ScanStage},
+  stages::{generate_stage::GenerateStage, scan_stage::ScanStage},
   types::bundle_output::BundleOutput,
   BundlerOptions, SharedOptions, SharedResolver,
 };
@@ -131,10 +131,10 @@ impl Bundler {
     let mut link_stage_output = self.try_build().await?;
     self.plugin_driver.render_start().await?;
 
-    let mut bundle_stage =
-      BundleStage::new(&mut link_stage_output, &self.options, &self.plugin_driver);
+    let mut generate_stage =
+      GenerateStage::new(&mut link_stage_output, &self.options, &self.plugin_driver);
 
-    let assets = bundle_stage.bundle().await?;
+    let assets = generate_stage.generate().await?;
 
     self.plugin_driver.generate_bundle(&assets, is_write).await?;
 

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -11,9 +11,9 @@ use crate::{
   utils::is_in_rust_test_mode,
 };
 
-use super::BundleStage;
+use super::GenerateStage;
 
-impl<'a> BundleStage<'a> {
+impl<'a> GenerateStage<'a> {
   fn determine_reachable_modules_for_entry(
     &self,
     module_id: NormalModuleId,

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, sync::Mutex};
 
 use crate::{chunk::CrossChunkImportItem, chunk_graph::ChunkGraph, utils::is_in_rust_test_mode};
 
-use super::BundleStage;
+use super::GenerateStage;
 use index_vec::{index_vec, IndexVec};
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use rolldown_common::{
@@ -17,7 +17,7 @@ type ChunkMetaImportsForExternalModules =
   IndexVec<ChunkId, FxHashMap<ExternalModuleId, Vec<NamedImport>>>;
 type ChunkMetaExports = IndexVec<ChunkId, FxHashSet<SymbolRef>>;
 
-impl<'a> BundleStage<'a> {
+impl<'a> GenerateStage<'a> {
   /// - Assign each symbol to the chunk it belongs to
   /// - Collect all referenced symbols and consider them potential imports
   fn collect_potential_chunk_imports(

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -21,13 +21,13 @@ use crate::{
 mod code_splitting;
 mod compute_cross_chunk_links;
 
-pub struct BundleStage<'a> {
+pub struct GenerateStage<'a> {
   link_output: &'a mut LinkStageOutput,
   options: &'a SharedOptions,
   plugin_driver: &'a SharedPluginDriver,
 }
 
-impl<'a> BundleStage<'a> {
+impl<'a> GenerateStage<'a> {
   pub fn new(
     link_output: &'a mut LinkStageOutput,
     options: &'a SharedOptions,
@@ -37,7 +37,7 @@ impl<'a> BundleStage<'a> {
   }
 
   #[tracing::instrument(skip_all)]
-  pub async fn bundle(&mut self) -> BatchedResult<Vec<Output>> {
+  pub async fn generate(&mut self) -> BatchedResult<Vec<Output>> {
     use rayon::prelude::*;
     tracing::info!("Start bundle stage");
     let mut chunk_graph = self.generate_chunks();

--- a/crates/rolldown/src/stages/mod.rs
+++ b/crates/rolldown/src/stages/mod.rs
@@ -1,3 +1,3 @@
-pub mod bundle_stage;
+pub mod generate_stage;
 pub mod link_stage;
 pub mod scan_stage;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This make term more clear to understand

--- old

A bundle process contains three stages:

scan -> link -> bundle(conflict with the upper bundle term)


--- new 

A bundle process contains three stages:

scan -> link -> generate




<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
