### PR TITLE
chore(tracing): fix LOG_OUTPUT comment

### DIFF
--- a/crates/rolldown_tracing/src/lib.rs
+++ b/crates/rolldown_tracing/src/lib.rs
@@ -1,6 +1,6 @@
 /// Some guidelines for tracing:
 /// - By default, only allow tracing events from crates of this repo.
-/// - Using `LOG_OUTPUT=chrome` to collect tracing events into a json file.
+/// - Using `LOG_LAYER=chrome` to collect tracing events into a json file.
 ///   - This only works on using `@rolldown/node`. If you are running rolldown in rust, this doesn't works.
 /// - Using `RUST_LOG=TRACE` to enable tracing or other values for more specific tracing.
 ///   - See  https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax for more syntax details.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This comment should be `LOG_LAYER` instead of `LOG_OUTPUT`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

https://github.com/rolldown/rolldown/blob/cff55de13d250a131daea59a0861a03fa11435bc/crates/rolldown_binding/src/utils/mod.rs#L6
