### PR TITLE
chore: rolldown bench was not running

### DIFF
--- a/packages/bench/src/run-bundler.js
+++ b/packages/bench/src/run-bundler.js
@@ -16,10 +16,6 @@ import { PROJECT_ROOT } from './utils.js'
  * @returns {RolldownBenchSuite[]}
  */
 export function getRolldownSuiteList(suite) {
-  if (!suite.rolldownOptions) {
-    return []
-  }
-
   const rolldownOptionsList = Array.isArray(suite.rolldownOptions)
     ? suite.rolldownOptions
     : [{ name: 'default', options: suite.rolldownOptions }]
@@ -35,7 +31,7 @@ export function getRolldownSuiteList(suite) {
  * @param {RolldownBenchSuite} suite
  */
 export async function runRolldown(suite) {
-  const { output: outputOptions = {}, ...inputOptions } = suite.options
+  const { output: outputOptions = {}, ...inputOptions } = suite.options ?? {}
   const build = await rolldown.rolldown({
     platform: 'node',
     input: suite.inputs,

--- a/packages/bench/src/types.d.ts
+++ b/packages/bench/src/types.d.ts
@@ -23,5 +23,5 @@ export interface RolldownBenchSuite {
   suiteName: string
   title: string
   inputs: string[]
-  options: RolldownOptions
+  options?: RolldownOptions
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I noticed that I broke the benchmark (`pnpm bench` in `packages/bench`). 🤦 It wasn't running rolldown for suites without rolldownOptions.

