### PR TITLE
refactor: move parallel js plugin registry ownership to rust side

### DIFF
--- a/crates/rolldown_binding/src/parallel_js_plugin_registry.rs
+++ b/crates/rolldown_binding/src/parallel_js_plugin_registry.rs
@@ -1,48 +1,35 @@
 use crate::options::plugin::{BindingPluginOptions, BindingPluginWithIndex};
 use dashmap::DashMap;
-use napi::{
-  bindgen_prelude::{FromNapiValue, Object, ObjectFinalize},
-  Env, JsUnknown,
-};
+use napi::bindgen_prelude::External;
 use napi_derive::napi;
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 use std::{
   hash::BuildHasherDefault,
-  sync::atomic::{self, AtomicU16},
+  sync::{
+    atomic::{self, AtomicU16},
+    Arc, Mutex, Weak,
+  },
 };
 
 type PluginsInSingleWorker = Vec<BindingPluginWithIndex>;
 type PluginsList = Vec<PluginsInSingleWorker>;
 pub(crate) type PluginValues = FxHashMap<usize, Vec<BindingPluginOptions>>;
 
-static PLUGINS_MAP: Lazy<DashMap<u16, PluginsList>> = Lazy::new(DashMap::default);
+static REGISTRY_MAP: Lazy<DashMap<u16, Weak<ParallelJsPluginRegistry>>> =
+  Lazy::new(DashMap::default);
 static NEXT_ID: AtomicU16 = AtomicU16::new(1);
 
-#[napi(custom_finalize)]
 pub struct ParallelJsPluginRegistry {
-  #[napi(writable = false)]
   pub id: u16,
-  #[napi(writable = false)]
   pub worker_count: u16,
+  plugins: Mutex<Option<PluginsList>>,
 }
 
 #[napi]
 impl ParallelJsPluginRegistry {
-  #[napi(constructor)]
-  pub fn new(worker_count: u16) -> napi::Result<Self> {
-    if worker_count == 0 {
-      return Err(napi::Error::from_reason("worker count should be bigger than 0"));
-    }
-
-    let id = NEXT_ID.fetch_add(1, atomic::Ordering::Relaxed);
-    PLUGINS_MAP.insert(id, vec![]);
-
-    Ok(Self { id, worker_count })
-  }
-
   pub fn take_plugin_values(&self) -> PluginValues {
-    let plugins_list = PLUGINS_MAP.remove(&self.id).expect("plugin list already taken").1;
+    let plugins_list = self.plugins.lock().unwrap().take().expect("plugin list already taken");
 
     let mut map: FxHashMap<usize, Vec<BindingPluginOptions>> =
       FxHashMap::with_capacity_and_hasher(plugins_list[0].len(), BuildHasherDefault::default());
@@ -56,33 +43,39 @@ impl ParallelJsPluginRegistry {
   }
 }
 
-impl ObjectFinalize for ParallelJsPluginRegistry {
-  fn finalize(self, mut _env: Env) -> napi::Result<()> {
-    PLUGINS_MAP.remove(&self.id);
-    Ok(())
-  }
-}
-
-impl FromNapiValue for ParallelJsPluginRegistry {
-  unsafe fn from_napi_value(
-    env: napi::sys::napi_env,
-    napi_val: napi::sys::napi_value,
-  ) -> napi::Result<Self> {
-    let unknown = JsUnknown::from_napi_value(env, napi_val)?;
-    if !ParallelJsPluginRegistry::instance_of(env.into(), &unknown)? {
-      return Err(napi::Error::from_status(napi::Status::GenericFailure));
-    }
-
-    let object: Object = unknown.cast();
-    let id: u16 = object.get_named_property_unchecked("id")?;
-    let worker_count: u16 = object.get_named_property_unchecked("workerCount")?;
-    Ok(Self { id, worker_count })
+impl Drop for ParallelJsPluginRegistry {
+  fn drop(&mut self) {
+    REGISTRY_MAP.remove(&self.id);
   }
 }
 
 #[napi]
+pub fn create_parallel_js_plugin_registry(
+  worker_count: u16,
+) -> napi::Result<External<Arc<ParallelJsPluginRegistry>>> {
+  if worker_count == 0 {
+    return Err(napi::Error::from_reason("worker count should be bigger than 0"));
+  }
+
+  let id = NEXT_ID.fetch_add(1, atomic::Ordering::Relaxed);
+  let plugins: PluginsList = vec![];
+  let registry =
+    Arc::new(ParallelJsPluginRegistry { id, worker_count, plugins: Mutex::new(Some(plugins)) });
+  REGISTRY_MAP.insert(id, Arc::downgrade(&registry));
+
+  Ok(External::new(registry))
+}
+
+#[napi]
+pub fn get_registry_id(registry: &External<Arc<ParallelJsPluginRegistry>>) -> u16 {
+  registry.as_ref().id
+}
+
+#[napi]
 pub fn register_plugins(id: u16, plugins: PluginsInSingleWorker) {
-  if let Some(mut existing_plugins) = PLUGINS_MAP.get_mut(&id) {
-    existing_plugins.push(plugins);
+  if let Some(registry) = REGISTRY_MAP.get_mut(&id).and_then(|x| x.upgrade()) {
+    if let Some(existing_plugins) = registry.plugins.lock().unwrap().as_mut() {
+      existing_plugins.push(plugins);
+    }
   }
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1,6 +1,11 @@
 type MaybePromise<T> = T | Promise<T>
-type Nullable<T> = T | null | undefined
-type VoidNullable<T = void> = T | null | undefined | void
+
+export class ExternalObject<T> {
+  readonly '': {
+    readonly '': unique symbol
+    [K: symbol]: T
+  }
+}
 export class BindingOutputAsset {
   get fileName(): string
   get source(): string
@@ -36,17 +41,11 @@ export class Bundler {
   constructor(
     inputOptions: BindingInputOptions,
     outputOptions: BindingOutputOptions,
-    parallelPluginsRegistry?: ParallelJsPluginRegistry | undefined | null,
+    parallelPluginsRegistry: OptionExtended,
   )
   write(): Promise<BindingOutputs>
   generate(): Promise<BindingOutputs>
   scan(): Promise<void>
-}
-
-export class ParallelJsPluginRegistry {
-  id: number
-  workerCount: number
-  constructor(workerCount: number)
 }
 
 export interface AliasItem {
@@ -163,6 +162,14 @@ export interface BindingResolveOptions {
   symlinks?: boolean
   tsconfigFilename?: string
 }
+
+export function createParallelJsPluginRegistry(
+  workerCount: number,
+): ExternalObject<ParallelJsPluginRegistry>
+
+export function getRegistryId(
+  registry: ExternalObject<ParallelJsPluginRegistry>,
+): number
 
 export function registerPlugins(
   id: number,

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -366,5 +366,7 @@ module.exports.BindingOutputChunk = nativeBinding.BindingOutputChunk
 module.exports.BindingOutputs = nativeBinding.BindingOutputs
 module.exports.BindingPluginContext = nativeBinding.BindingPluginContext
 module.exports.Bundler = nativeBinding.Bundler
-module.exports.ParallelJsPluginRegistry = nativeBinding.ParallelJsPluginRegistry
+module.exports.createParallelJsPluginRegistry =
+  nativeBinding.createParallelJsPluginRegistry
+module.exports.getRegistryId = nativeBinding.getRegistryId
 module.exports.registerPlugins = nativeBinding.registerPlugins

--- a/packages/rolldown/src/utils/initialize-parallel-plugins.ts
+++ b/packages/rolldown/src/utils/initialize-parallel-plugins.ts
@@ -1,7 +1,7 @@
 import { Worker } from 'node:worker_threads'
 import { availableParallelism } from 'node:os'
 import { ParallelPlugin, Plugin } from '../plugin'
-import { ParallelJsPluginRegistry } from '../binding'
+import { createParallelJsPluginRegistry, getRegistryId } from '../binding'
 
 export type WorkerData = {
   registryId: number
@@ -30,8 +30,8 @@ export async function initializeParallelPlugins(
   }
 
   const count = Math.min(availableParallelism(), 8)
-  const parallelJsPluginRegistry = new ParallelJsPluginRegistry(count)
-  const registryId = parallelJsPluginRegistry.id
+  const parallelJsPluginRegistry = createParallelJsPluginRegistry(count)
+  const registryId = getRegistryId(parallelJsPluginRegistry)
 
   const workers = await initializeWorkers(registryId, count, pluginInfos)
   const stopWorkers = async () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Moved parallel js plugin registry ownership to rust side to avoid `ObjectFinalize`.
@hyf0 It's still PoC state but I'd like to know your thoughts about going this way.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
