### PR TITLE
chore(test): fix cargo test by add rt-multi-thread flag for tokio.

### DIFF
--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -32,10 +32,11 @@ rolldown_tracing   = { workspace = true }
 rolldown_utils     = { workspace = true }
 rustc-hash         = { workspace = true }
 sugar_path         = { workspace = true }
-tokio              = { workspace = true, features = ["rt", "macros", "sync", "rt-multi-thread"] }
+tokio              = { workspace = true, features = ["rt", "macros", "sync"] }
 tracing            = { workspace = true }
 
 [dev_dependencies]
 insta            = { workspace = true }
 rolldown_testing = { workspace = true }
 testing_macros   = { workspace = true }
+tokio              = { workspace = true, features = ["rt", "macros", "sync", "rt-multi-thread"] }

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -39,4 +39,4 @@ tracing            = { workspace = true }
 insta            = { workspace = true }
 rolldown_testing = { workspace = true }
 testing_macros   = { workspace = true }
-tokio              = { workspace = true, features = ["rt", "macros", "sync", "rt-multi-thread"] }
+tokio            = { workspace = true, features = ["rt", "macros", "sync", "rt-multi-thread"] }

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -32,7 +32,7 @@ rolldown_tracing   = { workspace = true }
 rolldown_utils     = { workspace = true }
 rustc-hash         = { workspace = true }
 sugar_path         = { workspace = true }
-tokio              = { workspace = true, features = ["rt", "macros", "sync"] }
+tokio              = { workspace = true, features = ["rt", "macros", "sync", "rt-multi-thread"] }
 tracing            = { workspace = true }
 
 [dev_dependencies]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When I run `cargo test` in path `rolldown/crates/rolldown`, I got error like this.
```bash
chieh@DESKTOP-UQLGHI4 MINGW64 ~/Documents/code/rolldown/crates/rolldown (main)
$ cargo test
   Compiling rolldown v0.1.0 (C:\Users\chieh\Documents\code\rolldown\crates\rolldown)
error: The default runtime flavor is `multi_thread`, but the `rt-multi-thread` feature is disabled.
 --> crates\rolldown\examples\basic.rs:5:1
  |
5 | #[tokio::main]
  | ^^^^^^^^^^^^^^
  |
  = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z 
macro-backtrace for more info)
```
it can be fixed by add `rt-multi-thread` flag for tokio.

Some info about this: [tokio - Multi-Thread Scheduler](https://docs.rs/tokio/latest/tokio/runtime/index.html#multi-thread-scheduler), [tokio - entry.rs](https://github.com/tokio-rs/tokio/blob/1f6fc55917f971791d76dc91cce795e656c0e0d3/tokio-macros/src/entry.rs#L146)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
