### PR TITLE
perf(rolldown): use starts_with instead of regex in resolve

### DIFF
--- a/crates/rolldown/src/utils/resolve_id.rs
+++ b/crates/rolldown/src/utils/resolve_id.rs
@@ -1,17 +1,18 @@
 use std::path::Path;
 
-use once_cell::sync::Lazy;
-use regex::Regex;
 use rolldown_common::ModuleType;
 use rolldown_error::BuildResult;
 use rolldown_plugin::{HookResolveIdArgs, HookResolveIdExtraOptions, SharedPluginDriver};
 
 use crate::{types::resolved_request_info::ResolvedRequestInfo, SharedResolver};
 
-static HTTP_URL_REGEX: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"^(https?:)?\/\/").expect("Init HTTP_URL_REGEX failed"));
-static DATA_URL_REGEX: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"^\s*data:").expect("Init DATA_URL_REGEX failed"));
+fn is_http_url(s: &str) -> bool {
+  s.starts_with("http://") || s.starts_with("https://") || s.starts_with("//")
+}
+
+fn is_data_url(s: &str) -> bool {
+  s.trim_start().starts_with("data:")
+}
 
 #[allow(clippy::no_effect_underscore_binding)]
 pub async fn resolve_id(
@@ -40,7 +41,7 @@ pub async fn resolve_id(
   }
 
   // Auto external http url or data url
-  if HTTP_URL_REGEX.is_match(request) || DATA_URL_REGEX.is_match(request) {
+  if is_http_url(request) || is_data_url(request) {
     return Ok(Ok(ResolvedRequestInfo {
       path: request.to_string().into(),
       module_type: ModuleType::Unknown,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Created a minimal bench suites to test the performance difference between the Regex and the `starts_with`:

```rust
#![feature(test)]

extern crate test;

const URLS: &[&str] = &[
    "https://www.google.com/webhp?hl=en&amp;ictx=2&amp;sa=X&amp;ved=0ahUKEwil_oSxzJj8AhVtEFkFHTHnCGQQPQgI",
    "https://support.google.com/websearch/?p=ws_results_help&amp;hl=en-CA&amp;fg=1",
    "https://en.wikipedia.org/wiki/Dog#Roles_with_humans",
    "https://www.tiktok.com/@aguyandagolden/video/7133277734310038830",
    "https://business.twitter.com/en/help/troubleshooting/how-twitter-ads-work.html?ref=web-twc-ao-gbl-adsinfo&utm_source=twc&utm_medium=web&utm_campaign=ao&utm_content=adsinfo",
    "https://images-na.ssl-images-amazon.com/images/I/41Gc3C8UysL.css?AUIClients/AmazonGatewayAuiAssets",
    "https://www.reddit.com/?after=t3_zvz1ze",
    "https://www.reddit.com/login/?dest=https%3A%2F%2Fwww.reddit.com%2F",
    "postgresql://other:9818274x1!!@localhost:5432/otherdb?connect_timeout=10&application_name=myapp",
    "http://192.168.1.1",            // ipv4
    "http://[2606:4700:4700::1111]", // ipv6
    "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D",
    " http://www.google.com",
    " data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D",
];

fn is_http_url(s: &str) -> bool {
    s.starts_with("http://") || s.starts_with("https://") || s.starts_with("//")
}

fn is_data_url(s: &str) -> bool {
    s.trim_start().starts_with("data:")
}

#[cfg(test)]
mod tests {
    use test::{black_box, Bencher};

    use super::*;

    #[bench]
    fn starts_with_http(b: &mut Bencher) {
        b.iter(|| {
            for url in URLS {
                black_box(is_http_url(url));
            }
        });
    }

    #[bench]
    fn regex_http(b: &mut Bencher) {
        let reg = regex::Regex::new(r"^(https?:)?\/\/").expect("Init HTTP_URL_REGEX failed");

        b.iter(|| {
            for url in URLS {
                black_box(reg.is_match(url));
            }
        });
    }

    #[bench]
    fn starts_with_data(b: &mut Bencher) {
        b.iter(|| {
            for url in URLS {
                black_box(is_data_url(url));
            }
        });
    }

    #[bench]
    fn regex_data(b: &mut Bencher) {
        let reg = regex::Regex::new(r"^\s*data:").expect("Init DATA_URL_REGEX failed");

        b.iter(|| {
            for url in URLS {
                black_box(reg.is_match(url));
            }
        });
    }
}
```

here is the result:

```text
❯ cargo bench
    Finished `bench` profile [optimized] target(s) in 0.00s
     Running unittests src/lib.rs (target/release/deps/bench_regex-326801d6e8cb7dbb)

running 4 tests
test tests::regex_data       ... bench:         180 ns/iter (+/- 1)
test tests::regex_http       ... bench:         224 ns/iter (+/- 3)
test tests::starts_with_data ... bench:          38 ns/iter (+/- 0)
test tests::starts_with_http ... bench:           2 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 1.28s
```
