### PR TITLE
ci: add `cargo-shear`; run `cargo shear --fix`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,15 @@ jobs:
       - name: Install Rust
         uses: moonrepo/setup-rust@v1
         with:
-          bins: just, taplo-cli
+          bins: just, taplo-cli, cargo-shear
           cache-base: main
           components: clippy,rustfmt
 
       - name: Lint
         run: just lint-rust
+
+      - name: Check unused dependencies
+        run: cargo shear
 
   cargo-test:
     needs: changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,14 +1376,12 @@ name = "rolldown"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "derivative",
  "dunce",
  "futures",
  "index_vec",
  "insta",
  "once_cell",
  "oxc",
- "regex",
  "rolldown_common",
  "rolldown_error",
  "rolldown_fs",
@@ -1437,7 +1435,6 @@ dependencies = [
  "once_cell",
  "oxc",
  "regex",
- "rolldown_error",
  "rolldown_fs",
  "rolldown_rstr",
  "rolldown_sourcemap",
@@ -1445,7 +1442,6 @@ dependencies = [
  "rustc-hash",
  "schemars",
  "serde",
- "serde_json",
  "sugar_path",
 ]
 
@@ -1485,7 +1481,6 @@ dependencies = [
  "async-trait",
  "futures",
  "rolldown_common",
- "rolldown_error",
  "rolldown_sourcemap",
  "tracing",
 ]
@@ -1542,10 +1537,8 @@ dependencies = [
 name = "rolldown_testing"
 version = "0.0.1"
 dependencies = [
- "rolldown_common",
  "rolldown_testing_config",
  "schemars",
- "serde",
  "serde_json",
 ]
 

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -13,13 +13,11 @@ workspace = true
 
 [dependencies]
 anyhow             = { workspace = true }
-derivative         = { workspace = true }
 dunce              = { workspace = true }
 futures            = { workspace = true }
 index_vec          = { workspace = true }
 once_cell          = { workspace = true }
 oxc                = { workspace = true }
-regex              = { workspace = true }
 rolldown_common    = { workspace = true }
 rolldown_error     = { workspace = true }
 rolldown_fs        = { workspace = true, features = ["os"] }

--- a/crates/rolldown_common/Cargo.toml
+++ b/crates/rolldown_common/Cargo.toml
@@ -19,7 +19,6 @@ index_vec          = { workspace = true }
 once_cell          = { workspace = true }
 oxc                = { workspace = true, features = ["semantic"] }
 regex              = { workspace = true }
-rolldown_error     = { workspace = true }
 rolldown_fs        = { workspace = true }
 rolldown_rstr      = { workspace = true }
 rolldown_sourcemap = { workspace = true }
@@ -27,7 +26,6 @@ rolldown_utils     = { workspace = true }
 rustc-hash         = { workspace = true }
 schemars           = { workspace = true }
 serde              = { workspace = true, features = ["derive"] }
-serde_json         = { workspace = true }
 sugar_path         = { workspace = true }
 
 [features]

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -16,6 +16,5 @@ anyhow             = { workspace = true }
 async-trait        = { workspace = true }
 futures            = { workspace = true }
 rolldown_common    = { workspace = true }
-rolldown_error     = { workspace = true }
 rolldown_sourcemap = { workspace = true }
 tracing            = { workspace = true }

--- a/crates/rolldown_testing/Cargo.toml
+++ b/crates/rolldown_testing/Cargo.toml
@@ -12,10 +12,8 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-rolldown_common         = { workspace = true, features = ["deserialize_bundler_options"] }
 rolldown_testing_config = { workspace = true }
 schemars                = { workspace = true }
-serde                   = { workspace = true, features = ["derive"] }
 serde_json              = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
closes #732

### Description

`cargo shear` is performing very well in oxc and Rspack, let's add it to Rolldown as well.