### PR TITLE
chore(benchmark): use criterion2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,15 +34,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anes"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
-name = "anstyle"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "735d4f398ca57cfa2880225c2bf81c3b9af3be5bb22e44ae70118dad38713e84"
 
 [[package]]
 name = "anyhow"
@@ -125,7 +119,7 @@ dependencies = [
 name = "bench"
 version = "0.1.0"
 dependencies = [
- "codspeed-criterion-compat",
+ "criterion2",
  "rolldown",
  "tokio",
 ]
@@ -141,6 +135,12 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "bpaf"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567fc5f0a754100df11b167b2a247b2366fc1ac18e9b776a07659be00878f681"
 
 [[package]]
 name = "bumpalo"
@@ -212,31 +212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
-dependencies = [
- "anstyle",
- "clap_lex",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
-
-[[package]]
 name = "clean-path"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,17 +226,6 @@ dependencies = [
  "colored",
  "libc",
  "serde_json",
-]
-
-[[package]]
-name = "codspeed-criterion-compat"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb377d73b85084b1ca5615e42fdbf3b52631d6d8feda4be6dfc2150646f53cea"
-dependencies = [
- "codspeed",
- "colored",
- "criterion",
 ]
 
 [[package]]
@@ -328,39 +292,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
+name = "criterion2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "8f29e2b09b5cf655d28af8865ffdf0da71b6c0c313915f27b2e28664d43e450a"
 dependencies = [
  "anes",
+ "bpaf",
  "cast",
  "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
+ "codspeed",
+ "colored",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
- "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools",
 ]
 
 [[package]]
@@ -650,21 +601,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -674,15 +614,6 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
-name = "js-sys"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
-dependencies = [
- "wasm-bindgen",
-]
 
 [[package]]
 name = "json-strip-comments"
@@ -1240,34 +1171,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "plotters"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -2112,16 +2015,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
-name = "web-sys"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,51 +75,50 @@ inconsistent_struct_constructor = "allow"
 single_match = "allow"
 
 [workspace.dependencies]
-anyhow                    = "1.0.82"
-ariadne                   = "0.4.0"
-async-channel             = "2.2.1"
-async-trait               = "0.1.80"
-codspeed-criterion-compat = "2.4"
-dashmap                   = "5.5.3"
-derivative                = "2.2.0"
-dunce                     = "1.0.4"                                                                          # Normalize Windows paths to the most compatible format, avoiding UNC where possible
-futures                   = "0.3.30"
-index_vec                 = "0.1.3"
-insta                     = "1.38.0"
-memchr                    = "2.7.2"
-mimalloc                  = "0.1.39"
-napi                      = { version = "3.0.0-alpha", features = ["async"] }
-napi-build                = { version = "2.1.3" }
-napi-derive               = { version = "3.0.0-alpha.1", default-features = false, features = ["type-def"] }
-once_cell                 = "1.19.0"
-oxc                       = { version = "0.12.4", features = ["sourcemap"] }
-oxc_resolver              = { version = "1.6.5", features = ["package_json_raw_json_api"] }
-rayon                     = "1.10.0"
-regex                     = "1.10.4"
-rolldown                  = { path = "./crates/rolldown" }
-rolldown_common           = { path = "./crates/rolldown_common" }
-rolldown_error            = { path = "./crates/rolldown_error" }
-rolldown_fs               = { path = "./crates/rolldown_fs" }
-rolldown_oxc_utils        = { path = "./crates/rolldown_oxc_utils" }
-rolldown_plugin           = { path = "./crates/rolldown_plugin" }
-rolldown_resolver         = { path = "./crates/rolldown_resolver" }
-rolldown_rstr             = { path = "./crates/rolldown_rstr" }
-rolldown_sourcemap        = { path = "./crates/rolldown_sourcemap" }
-rolldown_testing          = { path = "./crates/rolldown_testing" }
-rolldown_testing_config   = { path = "./crates/rolldown_testing_config" }
-rolldown_tracing          = { path = "./crates/rolldown_tracing" }
-rolldown_utils            = { path = "./crates/rolldown_utils" }
-rustc-hash                = "1.1.0"
-schemars                  = "0.8.16"
-self_cell                 = "1.0.3"
-serde                     = { version = "1.0.198", features = ["derive"] }
-serde_json                = "1.0.116"
-smallvec                  = "1.13.2"
-sugar_path                = { version = "1.2.0", features = ["cached_current_dir"] }
-testing_macros            = "0.2.13"
-tokio                     = { version = "1.37.0", default-features = false }
-tracing                   = "0.1.40"
-vfs                       = "0.12.0"
+anyhow                  = "1.0.82"
+ariadne                 = "0.4.0"
+async-channel           = "2.2.1"
+async-trait             = "0.1.80"
+dashmap                 = "5.5.3"
+derivative              = "2.2.0"
+dunce                   = "1.0.4"                                                                          # Normalize Windows paths to the most compatible format, avoiding UNC where possible
+futures                 = "0.3.30"
+index_vec               = "0.1.3"
+insta                   = "1.38.0"
+memchr                  = "2.7.2"
+mimalloc                = "0.1.39"
+napi                    = { version = "3.0.0-alpha", features = ["async"] }
+napi-build              = { version = "2.1.3" }
+napi-derive             = { version = "3.0.0-alpha.1", default-features = false, features = ["type-def"] }
+once_cell               = "1.19.0"
+oxc                     = { version = "0.12.4", features = ["sourcemap"] }
+oxc_resolver            = { version = "1.6.5", features = ["package_json_raw_json_api"] }
+rayon                   = "1.10.0"
+regex                   = "1.10.4"
+rolldown                = { path = "./crates/rolldown" }
+rolldown_common         = { path = "./crates/rolldown_common" }
+rolldown_error          = { path = "./crates/rolldown_error" }
+rolldown_fs             = { path = "./crates/rolldown_fs" }
+rolldown_oxc_utils      = { path = "./crates/rolldown_oxc_utils" }
+rolldown_plugin         = { path = "./crates/rolldown_plugin" }
+rolldown_resolver       = { path = "./crates/rolldown_resolver" }
+rolldown_rstr           = { path = "./crates/rolldown_rstr" }
+rolldown_sourcemap      = { path = "./crates/rolldown_sourcemap" }
+rolldown_testing        = { path = "./crates/rolldown_testing" }
+rolldown_testing_config = { path = "./crates/rolldown_testing_config" }
+rolldown_tracing        = { path = "./crates/rolldown_tracing" }
+rolldown_utils          = { path = "./crates/rolldown_utils" }
+rustc-hash              = "1.1.0"
+schemars                = "0.8.16"
+self_cell               = "1.0.3"
+serde                   = { version = "1.0.198", features = ["derive"] }
+serde_json              = "1.0.116"
+smallvec                = "1.13.2"
+sugar_path              = { version = "1.2.0", features = ["cached_current_dir"] }
+testing_macros          = "0.2.13"
+tokio                   = { version = "1.37.0", default-features = false }
+tracing                 = "0.1.40"
+vfs                     = "0.12.0"
 
 [profile.release]
 codegen-units = 1

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -14,9 +14,12 @@ doctest = false
 test    = false
 
 [dependencies]
-codspeed-criterion-compat = { workspace = true }
-rolldown                  = { path = "../rolldown" }
-tokio                     = { workspace = true, features = ["full"] }
+criterion = { package = "criterion2", version = "0.7.0", default-features = false }
+rolldown  = { path = "../rolldown" }
+tokio     = { workspace = true, features = ["full"] }
 [[bench]]
 harness = false
 name    = "threejs"
+
+[features]
+codspeed = ["criterion/codspeed"]

--- a/crates/bench/benches/threejs.rs
+++ b/crates/bench/benches/threejs.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use bench::join_by_repo_root;
-use codspeed_criterion_compat::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use rolldown::{BundlerOptions, SourceMapType};
 
 #[derive(Debug)]


### PR DESCRIPTION
I forked criterion to keep things updated:

[criterion] is [passively-maintained](https://github.com/bheisler/criterion.rs/blob/f1ea31a92ff919a455f36b13c9a45fd74559d0fe/Cargo.toml#L63C27-L63C48) with outdated dependencies.

This is fork is updated with:

* renovate bot dependency update
* builtin [codspeed](https://codspeed.io) feature
* `clap` replaced with [`bpaf`](https://github.com/pacak/bpaf) to reduce binary size and compilation time
* merged the `criterion-plot` crate into `criterion2`

As you can see, a lot of stuff is removed from Cargo.lock