### PR TITLE
chore: use `cargo-autoinherit` to DRY up Cargo.toml manifests in a workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,50 +75,55 @@ inconsistent_struct_constructor = "allow"
 single_match = "allow"
 
 [workspace.dependencies]
-anyhow                  = "1.0.82"
-ariadne                 = "0.4.0"
-async-channel           = "2.2.1"
-async-trait             = "0.1.80"
-dashmap                 = "5.5.3"
-derivative              = "2.2.0"
-dunce                   = "1.0.4"                                                                          # Normalize Windows paths to the most compatible format, avoiding UNC where possible
-futures                 = "0.3.30"
-index_vec               = "0.1.3"
-insta                   = "1.38.0"
-memchr                  = "2.7.2"
-mimalloc                = "0.1.39"
-napi                    = { version = "3.0.0-alpha", features = ["async"] }
-napi-build              = { version = "2.1.3" }
-napi-derive             = { version = "3.0.0-alpha.1", default-features = false, features = ["type-def"] }
-once_cell               = "1.19.0"
-oxc                     = { version = "0.12.4", features = ["sourcemap"] }
-oxc_resolver            = { version = "1.6.5", features = ["package_json_raw_json_api"] }
-rayon                   = "1.10.0"
-regex                   = "1.10.4"
-rolldown                = { path = "./crates/rolldown" }
-rolldown_common         = { path = "./crates/rolldown_common" }
-rolldown_error          = { path = "./crates/rolldown_error" }
-rolldown_fs             = { path = "./crates/rolldown_fs" }
-rolldown_oxc_utils      = { path = "./crates/rolldown_oxc_utils" }
-rolldown_plugin         = { path = "./crates/rolldown_plugin" }
-rolldown_resolver       = { path = "./crates/rolldown_resolver" }
-rolldown_rstr           = { path = "./crates/rolldown_rstr" }
-rolldown_sourcemap      = { path = "./crates/rolldown_sourcemap" }
-rolldown_testing        = { path = "./crates/rolldown_testing" }
-rolldown_testing_config = { path = "./crates/rolldown_testing_config" }
-rolldown_tracing        = { path = "./crates/rolldown_tracing" }
-rolldown_utils          = { path = "./crates/rolldown_utils" }
-rustc-hash              = "1.1.0"
-schemars                = "0.8.16"
-self_cell               = "1.0.3"
-serde                   = { version = "1.0.198", features = ["derive"] }
-serde_json              = "1.0.116"
-smallvec                = "1.13.2"
-sugar_path              = { version = "1.2.0", features = ["cached_current_dir"] }
-testing_macros          = "0.2.13"
-tokio                   = { version = "1.37.0", default-features = false }
-tracing                 = "0.1.40"
-vfs                     = "0.12.0"
+rolldown                = { version = "0.1.0", path = "./crates/rolldown" }
+rolldown_common         = { version = "0.0.1", path = "./crates/rolldown_common" }
+rolldown_error          = { version = "0.0.1", path = "./crates/rolldown_error" }
+rolldown_fs             = { version = "0.1.0", path = "./crates/rolldown_fs" }
+rolldown_oxc_utils      = { version = "0.1.0", path = "./crates/rolldown_oxc_utils" }
+rolldown_plugin         = { version = "0.1.0", path = "./crates/rolldown_plugin" }
+rolldown_resolver       = { version = "0.0.1", path = "./crates/rolldown_resolver" }
+rolldown_rstr           = { version = "0.0.1", path = "./crates/rolldown_rstr" }
+rolldown_sourcemap      = { version = "0.1.0", path = "./crates/rolldown_sourcemap" }
+rolldown_testing        = { version = "0.0.1", path = "./crates/rolldown_testing" }
+rolldown_testing_config = { version = "0.0.1", path = "./crates/rolldown_testing_config" }
+rolldown_tracing        = { version = "0.0.1", path = "./crates/rolldown_tracing" }
+rolldown_utils          = { version = "0.0.1", path = "./crates/rolldown_utils" }
+
+anyhow                   = "1.0.82"
+ariadne                  = "0.4.0"
+async-channel            = "2.2.1"
+async-trait              = "0.1.80"
+console_error_panic_hook = "0.1.7"
+dashmap                  = "5.5.3"
+derivative               = "2.2.0"
+dunce                    = "1.0.4"                                                                          # Normalize Windows paths to the most compatible format, avoiding UNC where possible
+futures                  = "0.3.30"
+index_vec                = "0.1.3"
+insta                    = "1.38.0"
+memchr                   = "2.7.2"
+mimalloc                 = "0.1.39"
+napi                     = { version = "3.0.0-alpha", features = ["async"] }
+napi-build               = { version = "2.1.3" }
+napi-derive              = { version = "3.0.0-alpha.1", default-features = false, features = ["type-def"] }
+once_cell                = "1.19.0"
+oxc                      = { version = "0.12.4", features = ["sourcemap"] }
+oxc_resolver             = { version = "1.6.5", features = ["package_json_raw_json_api"] }
+rayon                    = "1.10.0"
+regex                    = "1.10.4"
+rustc-hash               = "1.1.0"
+schemars                 = "0.8.16"
+self_cell                = "1.0.3"
+serde                    = { version = "1.0.198", features = ["derive"] }
+serde_json               = "1.0.116"
+smallvec                 = "1.13.2"
+sugar_path               = { version = "1.2.0", features = ["cached_current_dir"] }
+testing_macros           = "0.2.13"
+tokio                    = { version = "1.37.0", default-features = false }
+tracing                  = "0.1.40"
+tracing-chrome           = "0.7.2"
+tracing-subscriber       = "0.3.18"
+vfs                      = "0.12.0"
+wasm-bindgen             = "0.2.92"
 
 [profile.release]
 codegen-units = 1

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -33,7 +33,7 @@ sugar_path         = { workspace = true }
 tokio              = { workspace = true, features = ["rt", "macros", "sync"] }
 tracing            = { workspace = true }
 
-[dev_dependencies]
+[dev-dependencies]
 insta            = { workspace = true }
 rolldown_testing = { workspace = true }
 testing_macros   = { workspace = true }

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -40,4 +40,4 @@ mimalloc = { workspace = true }
 mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
 
 [build-dependencies]
-napi-build = "2"
+napi-build = { workspace = true }

--- a/crates/rolldown_binding_wasm/Cargo.toml
+++ b/crates/rolldown_binding_wasm/Cargo.toml
@@ -18,6 +18,6 @@ crate-type = ["cdylib"]
 rolldown     = { workspace = true }
 rolldown_fs  = { workspace = true, features = ["memory"] }
 tokio        = { workspace = true, default-features = false, features = ["rt", "macros", "sync"] }
-wasm-bindgen = "0.2.92"
+wasm-bindgen = { workspace = true }
 
-console_error_panic_hook = "0.1.7"
+console_error_panic_hook = { workspace = true }

--- a/crates/rolldown_tracing/Cargo.toml
+++ b/crates/rolldown_tracing/Cargo.toml
@@ -20,5 +20,5 @@ test    = false
 
 [dependencies]
 tracing            = { workspace = true }
-tracing-chrome     = "0.7.2"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-chrome     = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This provides unified dependency management.

See https://github.com/mainmatter/cargo-autoinherit for details

