### PR TITLE
refactor: mark Program as covariant and borrow it directly

### DIFF
--- a/crates/rolldown/src/ast_scanner/side_effect_detector.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector.rs
@@ -332,25 +332,23 @@ mod test {
       .with_jsx(true)
       .with_typescript(false);
     let ast = OxcCompiler::parse(code, source_type);
-    ast.with(|fields| {
-      let ast_scope = {
-        let semantic = OxcAst::make_semantic(fields.source, fields.program, source_type);
-        let (mut symbol_table, scope) = semantic.into_symbol_table_and_scope_tree();
-        AstScope::new(
-          scope,
-          std::mem::take(&mut symbol_table.references),
-          std::mem::take(&mut symbol_table.resolved_references),
-        )
-      };
+    let ast_scope = {
+      let semantic = OxcAst::make_semantic(ast.source(), ast.program(), source_type);
+      let (mut symbol_table, scope) = semantic.into_symbol_table_and_scope_tree();
+      AstScope::new(
+        scope,
+        std::mem::take(&mut symbol_table.references),
+        std::mem::take(&mut symbol_table.resolved_references),
+      )
+    };
 
-      let has_side_effect = fields
-        .program
-        .body
-        .iter()
-        .any(|stmt| SideEffectDetector::new(&ast_scope).detect_side_effect_of_stmt(stmt));
+    let has_side_effect = ast
+      .program()
+      .body
+      .iter()
+      .any(|stmt| SideEffectDetector::new(&ast_scope).detect_side_effect_of_stmt(stmt));
 
-      has_side_effect
-    })
+    has_side_effect
   }
 
   #[test]

--- a/crates/rolldown/src/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/normal_module_task.rs
@@ -186,7 +186,7 @@ impl NormalModuleTask {
     );
     let namespace_symbol = scanner.namespace_ref;
     program.hoist_import_export_from_stmts();
-    let scan_result = program.with(|f| scanner.scan(f.program));
+    let scan_result = scanner.scan(program.program());
 
     (program, ast_scope, scan_result, symbol_for_module, namespace_symbol)
   }

--- a/crates/rolldown/src/module_loader/runtime_normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_normal_module_task.rs
@@ -113,7 +113,7 @@ impl RuntimeNormalModuleTask {
     );
     let namespace_symbol = scanner.namespace_ref;
     ast.hoist_import_export_from_stmts();
-    let scan_result = ast.with(|f| scanner.scan(f.program));
+    let scan_result = scanner.scan(ast.program());
 
     (ast, ast_scope, scan_result, symbol_for_module, namespace_symbol)
   }

--- a/crates/rolldown_oxc_utils/src/compiler.rs
+++ b/crates/rolldown_oxc_utils/src/compiler.rs
@@ -19,14 +19,12 @@ impl OxcCompiler {
     OxcAst { inner }
   }
   pub fn print(ast: &OxcAst, source_name: &str, enable_source_map: bool) -> CodegenReturn {
-    ast.with(|fields| {
-      let codegen = Codegen::<false>::new(
-        source_name,
-        fields.source,
-        CodegenOptions { enable_typescript: false, enable_source_map },
-      );
-      codegen.build(fields.program)
-    })
+    let codegen = Codegen::<false>::new(
+      source_name,
+      ast.source(),
+      CodegenOptions { enable_typescript: false, enable_source_map },
+    );
+    codegen.build(ast.program())
   }
 }
 

--- a/crates/rolldown_oxc_utils/src/lib.rs
+++ b/crates/rolldown_oxc_utils/src/lib.rs
@@ -9,5 +9,5 @@ pub use crate::{
   ast_snippet::AstSnippet,
   compiler::OxcCompiler,
   ext::{BindingIdentifierExt, BindingPatternExt, ExpressionExt, StatementExt},
-  oxc_ast::{OxcAst, WithFields, WithFieldsMut},
+  oxc_ast::{OxcAst, WithFieldsMut},
 };


### PR DESCRIPTION

### Description

`Program` is now covariant over the allocator lifetime because of https://github.com/oxc-project/oxc/pull/2943. We can borrow it directly from `OxcAst` without `with_dependent`.