### PR TITLE
chore(rolldown): clean module-export-import stuff

### DIFF
--- a/packages/rolldown/src/parallel-plugin-worker.ts
+++ b/packages/rolldown/src/parallel-plugin-worker.ts
@@ -1,9 +1,9 @@
 import { parentPort, workerData } from 'node:worker_threads'
-import { BindingOutputOptions, registerPlugins } from './binding'
+import { type BindingOutputOptions, registerPlugins } from './binding'
 import type { WorkerData } from './utils/initialize-parallel-plugins'
 import type { defineParallelPluginImplementation } from './parallel-plugin'
 import { bindingifyPlugin } from './plugin/bindingify-plugin'
-import { RolldownNormalizedInputOptions } from './options/input-options'
+import type { RolldownNormalizedInputOptions } from './options/input-options'
 
 const { registryId, pluginInfos, threadNumber } = workerData as WorkerData
 

--- a/packages/rolldown/src/parallel-plugin.ts
+++ b/packages/rolldown/src/parallel-plugin.ts
@@ -1,9 +1,5 @@
-import {
+export {
   defineParallelPluginImplementation,
-  ParallelPluginImplementation,
-  Context,
+  type ParallelPluginImplementation,
+  type Context,
 } from './plugin/parallel-plugin-implementation'
-
-export { defineParallelPluginImplementation }
-
-export type { ParallelPluginImplementation, Context }

--- a/packages/rolldown/src/plugin/bindingify-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin.ts
@@ -17,8 +17,8 @@ import {
 } from './bindingify-output-hooks'
 
 import type { Plugin } from './index'
-import { RolldownNormalizedInputOptions } from '../options/input-options'
-import { NormalizedOutputOptions } from '../options/output-options'
+import type { RolldownNormalizedInputOptions } from '../options/input-options'
+import type { NormalizedOutputOptions } from '../options/output-options'
 
 // Note: because napi not catch error, so we need to catch error and print error to debugger in adapter.
 export function bindingifyPlugin(

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -1,17 +1,16 @@
-import {
+import type {
   BindingHookResolveIdExtraOptions,
   BindingPluginContext,
   RenderedChunk,
   BindingOutputs,
   BindingOutputOptions,
-  BindingInputOptions,
 } from '../binding'
-import { RolldownNormalizedInputOptions } from '../options/input-options'
+import type { RolldownNormalizedInputOptions } from '../options/input-options'
 import { AnyFn, AnyObj, NullValue, MaybePromise } from '../types/utils'
-import { SourceMapInput } from '../types/sourcemap'
+import type { SourceMapInput } from '../types/sourcemap'
 import { pathToFileURL } from 'node:url'
-import { NormalizedOutputOptions } from '../options/output-options'
-import { ModuleInfo } from '../types/module-info'
+import type { NormalizedOutputOptions } from '../options/output-options'
+import type { ModuleInfo } from '../types/module-info'
 
 // Use a type alias here, we might wrap `BindingPluginContext` in the future
 type PluginContext = BindingPluginContext

--- a/packages/rolldown/src/rolldown-build.ts
+++ b/packages/rolldown/src/rolldown-build.ts
@@ -1,9 +1,9 @@
 import { Bundler } from './binding'
-import { normalizeOutputOptions, OutputOptions } from './options/output-options'
-import { createBundler, transformToRollupOutput, unimplemented } from './utils'
-import { RolldownOutput } from './types/rolldown-output'
-import { HasProperty, TypeAssert } from './utils/type-assert'
-import { InputOptions } from './options/input-options'
+import type { OutputOptions } from './options/output-options'
+import { createBundler, transformToRollupOutput } from './utils'
+import type { RolldownOutput } from './types/rolldown-output'
+import type { HasProperty, TypeAssert } from './utils/type-assert'
+import type { InputOptions } from './options/input-options'
 
 export class RolldownBuild {
   #inputOptions: InputOptions

--- a/packages/rolldown/src/rolldown.ts
+++ b/packages/rolldown/src/rolldown.ts
@@ -1,4 +1,4 @@
-import { InputOptions } from './options/input-options'
+import type { InputOptions } from './options/input-options'
 import { RolldownBuild } from './rolldown-build'
 import { createBundler } from './utils'
 

--- a/packages/rolldown/src/types/output-bundle.ts
+++ b/packages/rolldown/src/types/output-bundle.ts
@@ -1,4 +1,7 @@
-import { RolldownOutputAsset, RolldownOutputChunk } from './rolldown-output'
+import type {
+  RolldownOutputAsset,
+  RolldownOutputChunk,
+} from './rolldown-output'
 
 export interface OutputBundle {
   [fileName: string]: RolldownOutputAsset | RolldownOutputChunk

--- a/packages/rolldown/src/types/rolldown-config-export.ts
+++ b/packages/rolldown/src/types/rolldown-config-export.ts
@@ -1,3 +1,3 @@
-import { RolldownOptions } from './rolldown-options'
+import type { RolldownOptions } from './rolldown-options'
 
 export type RolldownConfigExport = RolldownOptions | RolldownOptions[]

--- a/packages/rolldown/src/types/rolldown-options.ts
+++ b/packages/rolldown/src/types/rolldown-options.ts
@@ -1,5 +1,5 @@
-import { InputOptions } from '../options/input-options'
-import { OutputOptions } from '../options/output-options'
+import type { InputOptions } from '../options/input-options'
+import type { OutputOptions } from '../options/output-options'
 
 export interface RolldownOptions extends InputOptions {
   // This is included for compatibility with config files but ignored by `rolldown.rolldown`

--- a/packages/rolldown/src/types/rolldown-output.ts
+++ b/packages/rolldown/src/types/rolldown-output.ts
@@ -1,11 +1,10 @@
-import type { OutputAsset, OutputChunk, RollupOutput } from '../rollup'
-import {
+import type { OutputAsset, OutputChunk } from '../rollup'
+import type {
   HasProperty,
   IsPropertiesEqual,
-  IsPropertyEqual,
   TypeAssert,
 } from '../utils/type-assert'
-import { RenderedModule } from './rendered-module'
+import type { RenderedModule } from './rendered-module'
 
 export interface RolldownOutputAsset {
   type: 'asset'

--- a/packages/rolldown/src/utils/create-bundler.ts
+++ b/packages/rolldown/src/utils/create-bundler.ts
@@ -5,7 +5,7 @@ import {
 } from '../options/input-options'
 import { createInputOptionsAdapter } from '../options/input-options-adapter'
 import {
-  OutputOptions,
+  type OutputOptions,
   normalizeOutputOptions,
 } from '../options/output-options'
 import { initializeParallelPlugins } from './initialize-parallel-plugins'

--- a/packages/rolldown/src/utils/define-config.ts
+++ b/packages/rolldown/src/utils/define-config.ts
@@ -1,4 +1,4 @@
-import { RolldownConfigExport } from '../types/rolldown-config-export'
+import type { RolldownConfigExport } from '../types/rolldown-config-export'
 
 export function defineConfig(
   config: RolldownConfigExport,

--- a/packages/rolldown/src/utils/initialize-parallel-plugins.ts
+++ b/packages/rolldown/src/utils/initialize-parallel-plugins.ts
@@ -1,6 +1,6 @@
 import { Worker } from 'node:worker_threads'
 import { availableParallelism } from 'node:os'
-import { ParallelPlugin, Plugin } from '../plugin'
+import type { ParallelPlugin, Plugin } from '../plugin'
 import { ParallelJsPluginRegistry } from '../binding'
 
 export type WorkerData = {

--- a/packages/rolldown/src/utils/normalize-plugin-option.ts
+++ b/packages/rolldown/src/utils/normalize-plugin-option.ts
@@ -1,7 +1,7 @@
 import type { OutputOptions, OutputPlugin } from '../rollup-types'
 import type { InputOptions } from '../options/input-options'
 import { asyncFlatten } from './async-flatten'
-import { ParallelPlugin, Plugin } from '../plugin'
+import type { ParallelPlugin, Plugin } from '../plugin'
 
 export const normalizePluginOption: {
   (plugins: InputOptions['plugins']): Promise<(ParallelPlugin | Plugin)[]>

--- a/packages/rolldown/src/utils/transform-module-info.ts
+++ b/packages/rolldown/src/utils/transform-module-info.ts
@@ -1,5 +1,5 @@
-import { ModuleInfo } from '../types/module-info'
-import { BindingModuleInfo } from '../binding'
+import type { ModuleInfo } from '../types/module-info'
+import type { BindingModuleInfo } from '../binding'
 import { unsupported } from '.'
 
 export function transformModuleInfo(info: BindingModuleInfo): ModuleInfo {

--- a/packages/rolldown/src/utils/transform-sourcemap.ts
+++ b/packages/rolldown/src/utils/transform-sourcemap.ts
@@ -1,5 +1,3 @@
-import { SourceMapInput } from '../types/sourcemap'
-
 export function isEmptySourcemapFiled(
   array: undefined | (string | null)[],
 ): boolean {

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   RolldownOutput,
   RolldownOutputAsset,
   RolldownOutputChunk,
 } from '../types/rolldown-output'
-import { OutputBundle } from '../types/output-bundle'
-import {
+import type { OutputBundle } from '../types/output-bundle'
+import type {
   BindingOutputAsset,
   BindingOutputChunk,
   BindingOutputs,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Do some cleanings.
1. clean unused symbols declared in import specifiers.
2. mark type imports, distinguish them with non-type imports.
3. simplify grammar, change code from `import ...; export ...;` to `export ... from ...;`