### PR TITLE
fix(node): should call hooks with await

### DIFF
--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -17,7 +17,7 @@ export function bindingifyBuildStart(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx) => {
-    handler.call(ctx, options)
+    await handler.call(ctx, options)
   }
 }
 
@@ -30,7 +30,7 @@ export function bindingifyBuildEnd(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (err) => {
-    handler.call(null, err ? new Error(err) : undefined)
+    await handler.call(null, err ? new Error(err) : undefined)
   }
 }
 
@@ -144,6 +144,6 @@ export function bindingifyModuleParsed(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, moduleInfo) => {
-    handler.call(ctx, transformModuleInfo(moduleInfo))
+    await handler.call(ctx, transformModuleInfo(moduleInfo))
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When building with Rolldown, add two `buildStart` hook，The plugin execution result is incorrect
```javascript
import { defineConfig } from 'rolldown'

async function sleep(duration) {
  return new Promise((resolve) => {
    setTimeout(() => {
      //here console  sleep
      console.log('sleep')
      resolve(duration)
    }, duration)
  })
}

export default defineConfig({
  input: './index.js',
  resolve: {
    conditionNames: ['import'],
  },
  plugins: [
    {
      name: 'build_start1',
      async buildStart(options) {
        console.log('1')
      //  here sleep 4000ms
        await sleep(4000)
      },
    },
    {
      name: 'build_start2',
      async buildStart(options) {
        console.log(2)
      },
    },
  ],
})

```
the result , `console.log(sleep)` execute after build end
![image](https://github.com/rolldown/rolldown/assets/17904663/53fbac5d-3652-4c46-8956-3423217632cd)



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
