### PR TITLE
feat: warmup files

### DIFF
--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 anyhow             = { workspace = true }
 dunce              = { workspace = true }
 futures            = { workspace = true }
+glob               = { workspace = true }
 index_vec          = { workspace = true }
 once_cell          = { workspace = true }
 oxc                = { workspace = true }

--- a/crates/rolldown/src/module_loader/mod.rs
+++ b/crates/rolldown/src/module_loader/mod.rs
@@ -14,6 +14,7 @@ use self::{
 pub enum Msg {
   NormalModuleDone(NormalModuleTaskResult),
   RuntimeNormalModuleDone(RuntimeNormalModuleTaskResult),
+  RequestPrefetch(String),
   BuildErrors(Vec<BuildError>),
   Panics(anyhow::Error),
 }

--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -35,6 +35,8 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
     sourcemap_ignore_list: raw_options.sourcemap_ignore_list,
     sourcemap_path_transform: raw_options.sourcemap_path_transform,
     shim_missing_exports: raw_options.shim_missing_exports.unwrap_or(false),
+    warmup_files: raw_options.warmup_files,
+    warmup_files_exclude: raw_options.warmup_files_exclude,
   };
 
   NormalizeOptionsReturn { options: normalized, resolve_options: raw_resolve }

--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -61,4 +61,6 @@ pub struct BindingInputOptions {
   // extra
   pub cwd: String,
   // pub builtins: BuiltinsOptions,
+  pub warmup_files: Vec<String>,
+  pub warmup_files_exclude: Vec<String>,
 }

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -94,6 +94,8 @@ pub fn normalize_binding_options(
     footer: normalize_addon_option(output_options.footer),
     sourcemap_ignore_list,
     sourcemap_path_transform,
+    warmup_files: input_options.warmup_files,
+    warmup_files_exclude: input_options.warmup_files_exclude,
     // TODO(hyf0): remove this line, all options should set explicitly
     ..Default::default()
   };

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -66,6 +66,9 @@ pub struct BundlerOptions {
   pub sourcemap_path_transform: Option<SourceMapPathTransform>,
   // --- options for resolve
   pub resolve: Option<ResolveOptions>,
+
+  pub warmup_files: Vec<String>,
+  pub warmup_files_exclude: Vec<String>,
 }
 
 #[cfg(feature = "deserialize_bundler_options")]

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -29,4 +29,7 @@ pub struct NormalizedBundlerOptions {
   pub footer: Option<AddonOutputOption>,
   pub sourcemap_ignore_list: Option<SourceMapIgnoreList>,
   pub sourcemap_path_transform: Option<SourceMapPathTransform>,
+
+  pub warmup_files: Vec<String>,
+  pub warmup_files_exclude: Vec<String>,
 }

--- a/crates/rolldown_testing/_test.scheme.json
+++ b/crates/rolldown_testing/_test.scheme.json
@@ -36,6 +36,10 @@
   "definitions": {
     "BundlerOptions": {
       "type": "object",
+      "required": [
+        "warmupFiles",
+        "warmupFilesExclude"
+      ],
       "properties": {
         "banner": {
           "type": [
@@ -142,6 +146,18 @@
             "boolean",
             "null"
           ]
+        },
+        "warmupFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "warmupFilesExclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/examples/par-babel-rome-ts/rolldown.config.js
+++ b/examples/par-babel-rome-ts/rolldown.config.js
@@ -24,4 +24,10 @@ export default defineConfig({
       './tmp/bench/rome/src/tsconfig.json',
     ),
   },
+  warmupFiles: [
+    nodePath.join(REPO_ROOT, './tmp/bench/rome/src/rome/**/*.ts'),
+    nodePath.join(REPO_ROOT, './tmp/bench/rome/src/@romejs/*/*.ts'),
+    nodePath.join(REPO_ROOT, './tmp/bench/rome/src/@romejs/**/*.ts'),
+  ],
+  warmupFilesExclude: ['**/test-fixtures/**/*.ts', '**/*.test.ts'],
 })

--- a/packages/bench/src/suites/rome-ts.js
+++ b/packages/bench/src/suites/rome-ts.js
@@ -55,6 +55,11 @@ const rolldownOptions = [
           './tmp/bench/rome/src/tsconfig.json',
         ),
       },
+      warmupFiles: [
+        nodePath.join(REPO_ROOT, './tmp/bench/rome/src/rome/**/*.ts'),
+        // nodePath.join(REPO_ROOT, './tmp/bench/rome/src/@romejs/**/*.ts'),
+      ],
+      warmupFilesExclude: ['**/test-fixtures/**/*.ts', '**/*.test.ts'],
     },
   },
   {
@@ -72,6 +77,11 @@ const rolldownOptions = [
           './tmp/bench/rome/src/tsconfig.json',
         ),
       },
+      warmupFiles: [
+        nodePath.join(REPO_ROOT, './tmp/bench/rome/src/rome/**/*.ts'),
+        // nodePath.join(REPO_ROOT, './tmp/bench/rome/src/@romejs/**/*.ts'),
+      ],
+      warmupFilesExclude: ['**/test-fixtures/**/*.ts'],
     },
   },
   {
@@ -89,6 +99,11 @@ const rolldownOptions = [
           './tmp/bench/rome/src/tsconfig.json',
         ),
       },
+      warmupFiles: [
+        nodePath.join(REPO_ROOT, './tmp/bench/rome/src/rome/**/*.ts'),
+        // nodePath.join(REPO_ROOT, './tmp/bench/rome/src/@romejs/**/*.ts'),
+      ],
+      warmupFilesExclude: ['**/test-fixtures/**/*.ts'],
     },
   },
   {
@@ -106,6 +121,11 @@ const rolldownOptions = [
           './tmp/bench/rome/src/tsconfig.json',
         ),
       },
+      warmupFiles: [
+        nodePath.join(REPO_ROOT, './tmp/bench/rome/src/rome/**/*.ts'),
+        // nodePath.join(REPO_ROOT, './tmp/bench/rome/src/@romejs/**/*.ts'),
+      ],
+      warmupFilesExclude: ['**/test-fixtures/**/*.ts'],
     },
   },
 ]

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -85,6 +85,8 @@ export interface BindingInputOptions {
   platform?: 'node' | 'browser' | 'neutral'
   logLevel?: 'silent' | 'error' | 'warn' | 'info'
   cwd: string
+  warmupFiles: Array<string>
+  warmupFilesExclude: Array<string>
 }
 
 export interface BindingOutputOptions {

--- a/packages/rolldown/src/options/input-options-adapter.ts
+++ b/packages/rolldown/src/options/input-options-adapter.ts
@@ -24,6 +24,8 @@ export function createInputOptionsAdapter(
     platform: options.platform,
     shimMissingExports: options.shimMissingExports,
     logLevel: inputOptions.logLevel,
+    warmupFiles: options.warmupFiles,
+    warmupFilesExclude: options.warmupFilesExclude,
   }
 }
 

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -16,6 +16,8 @@ export interface InputOptions {
   platform?: BindingInputOptions['platform']
   shimMissingExports?: BindingInputOptions['shimMissingExports']
   logLevel?: BindingInputOptions['logLevel']
+  warmupFiles?: string[]
+  warmupFilesExclude?: string[]
 }
 
 export type RolldownResolveOptions = Omit<BindingResolveOptions, 'alias'> & {
@@ -29,6 +31,8 @@ export type RolldownNormalizedInputOptions = Omit<
   plugins: (Plugin | ParallelPlugin)[]
   resolve?: BindingResolveOptions
   platform?: BindingInputOptions['platform']
+  warmupFiles: string[]
+  warmupFilesExclude: string[]
 }
 
 export async function normalizeInputOptions(
@@ -42,6 +46,8 @@ export async function normalizeInputOptions(
     resolve: getResolve(config.resolve),
     platform: config.platform,
     shimMissingExports: config.shimMissingExports ?? false,
+    warmupFiles: config.warmupFiles ?? [],
+    warmupFilesExclude: config.warmupFilesExclude ?? [],
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Implemented `warmupFiles` (that works like [`server.warmup`](https://vitejs.dev/config/server-options.html#server-warmup) in Vite) to utilize parallelism when processing a single file is slow.

This does reduce ~150ms for the benchmark with parallel js plugins, but it still doesn't utilize the maximum parallelism.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
