### PR TITLE
test(rollup): enable `catch-block-scope: uses correct scope in catch blocks`

### DIFF
--- a/packages/rollup-tests/src/failed-tests.json
+++ b/packages/rollup-tests/src/failed-tests.json
@@ -54,7 +54,6 @@
   "rollup@function@cannot-call-external-namespace: warns if code calls an external namespace",
   "rollup@function@cannot-call-internal-namespace: warns if code calls an internal namespace",
   "rollup@function@cannot-resolve-sourcemap-warning: handles when a sourcemap cannot be resolved in a warning",
-  "rollup@function@catch-block-scope: uses correct scope in catch blocks",
   "rollup@function@catch-dynamic-import-failure: allows catching failed dynamic imports",
   "rollup@function@chained-mutable-array-methods: recognizes side-effects when applying mutable array methods to chained array methods (#3555)",
   "rollup@function@check-exports-exportedBindings-as-a-supplementary-test: check exports and exportedBindings in moduleParsed as a supplementary test",

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,6 +1,6 @@
 {
   "failed": 0,
-  "skipFailed": 650,
+  "skipFailed": 649,
   "skipped": 0,
-  "passed": 268
+  "passed": 269
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -1,6 +1,6 @@
 |  | number |
 |----| ---- |
 | failed | 0|
-| skipFailed | 650|
+| skipFailed | 649|
 | skipped | 0|
-| passed | 268|
+| passed | 269|


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/rolldown/rolldown/issues/197.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
