### PR TITLE
feat(rust): improve error message of unknown return value of `JsCallback`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,7 @@ dependencies = [
  "rolldown_plugin",
  "rolldown_sourcemap",
  "rolldown_tracing",
+ "rolldown_utils",
  "rustc-hash",
  "serde",
  "tracing",
@@ -1490,7 +1491,9 @@ dependencies = [
  "async-scoped",
  "base64",
  "futures",
+ "once_cell",
  "rayon",
+ "regex",
  "xxhash-rust",
 ]
 

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -29,6 +29,7 @@ rolldown_error     = { workspace = true, features = ["napi"] }
 rolldown_plugin    = { workspace = true }
 rolldown_sourcemap = { workspace = true }
 rolldown_tracing   = { workspace = true }
+rolldown_utils     = { workspace = true }
 rustc-hash         = { workspace = true }
 serde              = { workspace = true }
 tracing            = { workspace = true }

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -15,6 +15,8 @@ workspace = true
 [dependencies]
 base64      = { workspace = true }
 futures     = { workspace = true }
+once_cell   = { workspace = true }
+regex       = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/rolldown_utils/src/debug.rs
+++ b/crates/rolldown_utils/src/debug.rs
@@ -1,0 +1,32 @@
+use std::borrow::Cow;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+static MODULE_MATCHER_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?:\w+::)").unwrap());
+
+pub fn pretty_type_name<T: ?Sized>() -> Cow<'static, str> {
+  let type_name = std::any::type_name::<T>();
+  prettify_type_name(type_name)
+}
+
+fn prettify_type_name(name: &str) -> Cow<str> {
+  MODULE_MATCHER_RE.replace_all(name, "")
+}
+
+#[test]
+fn test_pretty_type_name() {
+  struct Custom;
+  assert_eq!(pretty_type_name::<std::option::Option<std::string::String>>(), "Option<String>");
+  assert_eq!(pretty_type_name::<std::option::Option<Custom>>(), "Option<Custom>");
+}
+
+#[test]
+fn test_prettify_type_name() {
+  assert_eq!(
+    prettify_type_name("napi::threadsafe_function::ThreadsafeFunction<rolldown_binding::types::binding_rendered_chunk::RenderedChunk, napi::bindgen_runtime::js_values::either::Either<napi::bindgen_runtime::js_values::either::Either<napi::bindgen_runtime::js_values::promise::Promise<core::option::Option<alloc::string::String>>, core::option::Option<alloc::string::String>>, napi::threadsafe_function::UnknownReturnValue>, false>"),
+    "ThreadsafeFunction<RenderedChunk, Either<Either<Promise<Option<String>>, Option<String>>, UnknownReturnValue>, false>"
+  );
+}
+
+// Caused by: Error: Rolldown internal error: InvalidArg, Unknown return value. Cannot convert to `core::option::Option<alloc::string::String>` in `napi::threadsafe_function::ThreadsafeFunction<rolldown_binding::types::binding_rendered_chunk::RenderedChunk, napi::bindgen_runtime::js_values::either::Either<napi::bindgen_runtime::js_values::either::Either<napi::bindgen_runtime::js_values::promise::Promise<core::option::Option<alloc::string::String>>, core::option::Option<alloc::string::String>>, napi::threadsafe_function::UnknownReturnValue>, false>`.

--- a/crates/rolldown_utils/src/lib.rs
+++ b/crates/rolldown_utils/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod base64;
 mod bitset;
+pub mod debug;
 pub mod futures;
 pub mod rayon;
 pub mod xxhash;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Now we get error message

```
Caused by: Error: Rolldown internal error: InvalidArg, UNKNOWN_RETURN_VALUE. Cannot convert unknown to `Option<String>` in ThreadsafeFunction<RenderedChunk, Either<Either<Promise<Option<String>>, Option<String>>, UnknownReturnValue>, false>.
```

instead of

```
Caused by: Error: Rolldown internal error: InvalidArg, Unknown return value. Cannot convert to core::option::Option<alloc::string::String>.
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
