### PR TITLE
chore(rust/tracing): use async style by default and support `chrome-json-threaded`

### DIFF
--- a/crates/rolldown_tracing/src/lib.rs
+++ b/crates/rolldown_tracing/src/lib.rs
@@ -16,7 +16,6 @@ use tracing_subscriber::EnvFilter;
 
 static LOG_ENV_NAME: &str = "RD_LOG";
 static LOG_OUTPUT_ENV_NAME: &str = "RD_LOG_OUTPUT";
-static LOG_OUTPUT_STYLE_NAME: &str = "RD_LOG_OUTPUT_STYLE";
 
 static IS_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
@@ -34,11 +33,9 @@ pub fn try_init_tracing() -> Option<FlushGuard> {
   let env_filter = EnvFilter::from_env(LOG_ENV_NAME);
 
   match output_mode.as_str() {
-    "chrome-json" => {
-      let trace_style = match std::env::var(LOG_OUTPUT_STYLE_NAME).unwrap_or_default().as_str() {
-        "async" => TraceStyle::Async,
-        _ => TraceStyle::Threaded,
-      };
+    "chrome-json" | "chrome-json-threaded" => {
+      let trace_style =
+        if output_mode == "chrome-json" { TraceStyle::Async } else { TraceStyle::Threaded };
       let (chrome_layer, guard) = ChromeLayerBuilder::new().trace_style(trace_style).build();
       tracing_subscriber::registry().with(env_filter).with(chrome_layer).init();
       Some(guard)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If you set `RD_LOG_OUTPUT_STYLE=async` and add `#[tracing::instrument(level = "trace", skip_all)]` to https://github.com/rolldown/rolldown/blob/84dc41968d1952ce329478bfb382d5ea8e26df11/crates/rolldown_binding/src/options/plugin/js_plugin.rs#L84, you'll get the following result on perfetto.dev.

With single thread babel:
![image](https://github.com/rolldown/rolldown/assets/49056869/8cdbd4d0-51df-4e9a-ae5d-98433a03e9a8)

With parallel babel:
![image](https://github.com/rolldown/rolldown/assets/49056869/f4ab3d5d-e9ad-481a-bc24-0fb3055ab6ef)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
