### PR TITLE
fix: exit process when build finishes

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -32,7 +32,7 @@ pub struct BindingInputOptions {
   #[napi(
     ts_type = "undefined | ((source: string, importer: string | undefined, isResolved: boolean) => boolean)"
   )]
-  pub external: Option<ThreadsafeFunction<(String, Option<String>, bool), bool, false>>,
+  pub external: Option<ThreadsafeFunction<(String, Option<String>, bool), bool, false, true>>,
   pub input: Vec<BindingInputItem>,
   // makeAbsoluteExternalsRelative?: boolean | 'ifRelativeSource';
   // /** @deprecated Use the "manualChunks" output option instead. */

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -7,7 +7,7 @@ use napi::threadsafe_function::ThreadsafeFunction;
 use napi_derive::napi;
 use serde::Deserialize;
 
-pub type AddonOutputOption = MaybeAsyncJsCallback<RenderedChunk, Option<String>, true>;
+pub type AddonOutputOption = MaybeAsyncJsCallback<RenderedChunk, Option<String>>;
 
 #[napi(object, object_to_js = false)]
 #[derive(Deserialize, Derivative)]

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -7,7 +7,7 @@ use napi::threadsafe_function::ThreadsafeFunction;
 use napi_derive::napi;
 use serde::Deserialize;
 
-pub type AddonOutputOption = MaybeAsyncJsCallback<RenderedChunk, Option<String>>;
+pub type AddonOutputOption = MaybeAsyncJsCallback<RenderedChunk, Option<String>, true>;
 
 #[napi(object, object_to_js = false)]
 #[derive(Deserialize, Derivative)]
@@ -67,11 +67,11 @@ pub struct BindingOutputOptions {
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(source: string, sourcemapPath: string) => boolean")]
-  pub sourcemap_ignore_list: Option<ThreadsafeFunction<(String, String), bool, false>>,
+  pub sourcemap_ignore_list: Option<ThreadsafeFunction<(String, String), bool, false, true>>,
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(source: string, sourcemapPath: string) => string")]
-  pub sourcemap_path_transform: Option<ThreadsafeFunction<(String, String), String, false>>,
+  pub sourcemap_path_transform: Option<ThreadsafeFunction<(String, String), String, false, true>>,
   // sourcemapExcludeSources: boolean;
   // sourcemapFile: string | undefined;
   // strict: boolean;

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -92,7 +92,7 @@ impl<const WEAK: bool> Debug for BindingPluginOptions<WEAK> {
 }
 
 impl FromNapiValue for BindingPluginOptions<true> {
-  #[allow(deprecated)] // cb.unref is deprecated, fix napi_derive to support const generics with
+  #[allow(deprecated)] // cb.unref is deprecated, fix napi_derive to support const generics
   unsafe fn from_napi_value(
     env: napi::sys::napi_env,
     napi_val: napi::sys::napi_value,

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -28,7 +28,7 @@ pub struct BindingPluginOptions<const WEAK: bool = false> {
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext) => MaybePromise<VoidNullable>")]
-  pub build_start: Option<MaybeAsyncJsCallback<BindingPluginContext, (), false>>,
+  pub build_start: Option<MaybeAsyncJsCallback<BindingPluginContext, (), WEAK>>,
 
   #[serde(skip_deserializing)]
   #[napi(
@@ -38,52 +38,52 @@ pub struct BindingPluginOptions<const WEAK: bool = false> {
     MaybeAsyncJsCallback<
       (String, Option<String>, BindingHookResolveIdExtraOptions),
       Option<BindingHookResolveIdOutput>,
-      false,
+      WEAK,
     >,
   >,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(id: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>")]
-  pub load: Option<MaybeAsyncJsCallback<String, Option<BindingHookLoadOutput>, false>>,
+  pub load: Option<MaybeAsyncJsCallback<String, Option<BindingHookLoadOutput>, WEAK>>,
 
   #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(id: string, code: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>"
   )]
-  pub transform: Option<MaybeAsyncJsCallback<(String, String), Option<BindingHookLoadOutput>, false>>,
+  pub transform: Option<MaybeAsyncJsCallback<(String, String), Option<BindingHookLoadOutput>, WEAK>>,
 
   #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, module: BindingModuleInfo) => MaybePromise<VoidNullable>"
   )]
-  pub module_parsed: Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingModuleInfo), (), false>>,
+  pub module_parsed: Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingModuleInfo), (), WEAK>>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(error: Nullable<string>) => MaybePromise<VoidNullable>")]
-  pub build_end: Option<MaybeAsyncJsCallback<Option<String>, (), false>>,
+  pub build_end: Option<MaybeAsyncJsCallback<Option<String>, (), WEAK>>,
 
   #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(code: string, chunk: RenderedChunk) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>"
   )]
   pub render_chunk:
-    Option<MaybeAsyncJsCallback<(String, RenderedChunk), Option<BindingHookRenderChunkOutput>, false>>,
+    Option<MaybeAsyncJsCallback<(String, RenderedChunk), Option<BindingHookRenderChunkOutput>, WEAK>>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "() => void")]
-  pub render_start: Option<MaybeAsyncJsCallback<(), (), false>>,
+  pub render_start: Option<MaybeAsyncJsCallback<(), (), WEAK>>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(error: string) => void")]
-  pub render_error: Option<MaybeAsyncJsCallback<String, (), false>>,
+  pub render_error: Option<MaybeAsyncJsCallback<String, (), WEAK>>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>")]
-  pub generate_bundle: Option<MaybeAsyncJsCallback<(BindingOutputs, bool), (), false>>,
+  pub generate_bundle: Option<MaybeAsyncJsCallback<(BindingOutputs, bool), (), WEAK>>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(bundle: BindingOutputs) => MaybePromise<VoidNullable>")]
-  pub write_bundle: Option<MaybeAsyncJsCallback<BindingOutputs, (), false>>,
+  pub write_bundle: Option<MaybeAsyncJsCallback<BindingOutputs, (), WEAK>>,
 }
 
 impl<const WEAK: bool> Debug for BindingPluginOptions<WEAK> {
@@ -92,65 +92,6 @@ impl<const WEAK: bool> Debug for BindingPluginOptions<WEAK> {
   }
 }
 
-impl FromNapiValue for BindingPluginOptions<true> {
-  #[allow(deprecated)] // cb.unref is deprecated, fix napi_derive to support const generics
-  unsafe fn from_napi_value(
-    env: napi::sys::napi_env,
-    napi_val: napi::sys::napi_value,
-  ) -> napi::Result<Self> {
-    let mut false_options = BindingPluginOptions::<false>::from_napi_value(env, napi_val)?;
-    let env = &napi::Env::from_raw(env);
-
-    if let Some(cb) = &mut false_options.build_start {
-      cb.unref(env)?;
-    }
-    if let Some(cb) = &mut false_options.resolve_id {
-      cb.unref(env)?;
-    }
-    if let Some(cb) = &mut false_options.load {
-      cb.unref(env)?;
-    }
-    if let Some(cb) = &mut false_options.transform {
-      cb.unref(env)?;
-    }
-    if let Some(cb) = &mut false_options.module_parsed {
-      cb.unref(env)?;
-    }
-    if let Some(cb) = &mut false_options.build_end {
-      cb.unref(env)?;
-    }
-    if let Some(cb) = &mut false_options.render_chunk {
-      cb.unref(env)?;
-    }
-    if let Some(cb) = &mut false_options.render_start {
-      cb.unref(env)?;
-    }
-    if let Some(cb) = &mut false_options.render_error {
-      cb.unref(env)?;
-    }
-    if let Some(cb) = &mut false_options.generate_bundle {
-      cb.unref(env)?;
-    }
-    if let Some(cb) = &mut false_options.write_bundle {
-      cb.unref(env)?;
-    }
-
-    Ok(Self {
-      name: false_options.name,
-      build_start: false_options.build_start,
-      resolve_id: false_options.resolve_id,
-      load: false_options.load,
-      transform: false_options.transform,
-      module_parsed: false_options.module_parsed,
-      build_end: false_options.build_end,
-      render_chunk: false_options.render_chunk,
-      render_start: false_options.render_start,
-      render_error: false_options.render_error,
-      generate_bundle: false_options.generate_bundle,
-      write_bundle: false_options.write_bundle,
-    })
-  }
-}
 
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Debug, Deserialize, Default)]

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -28,7 +28,7 @@ pub struct BindingPluginOptions<const WEAK: bool = false> {
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext) => MaybePromise<VoidNullable>")]
-  pub build_start: Option<MaybeAsyncJsCallback<BindingPluginContext, ()>>,
+  pub build_start: Option<MaybeAsyncJsCallback<BindingPluginContext, (), false>>,
 
   #[serde(skip_deserializing)]
   #[napi(
@@ -38,51 +38,52 @@ pub struct BindingPluginOptions<const WEAK: bool = false> {
     MaybeAsyncJsCallback<
       (String, Option<String>, BindingHookResolveIdExtraOptions),
       Option<BindingHookResolveIdOutput>,
+      false,
     >,
   >,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(id: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>")]
-  pub load: Option<MaybeAsyncJsCallback<String, Option<BindingHookLoadOutput>>>,
+  pub load: Option<MaybeAsyncJsCallback<String, Option<BindingHookLoadOutput>, false>>,
 
   #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(id: string, code: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>"
   )]
-  pub transform: Option<MaybeAsyncJsCallback<(String, String), Option<BindingHookLoadOutput>>>,
+  pub transform: Option<MaybeAsyncJsCallback<(String, String), Option<BindingHookLoadOutput>, false>>,
 
   #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, module: BindingModuleInfo) => MaybePromise<VoidNullable>"
   )]
-  pub module_parsed: Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingModuleInfo), ()>>,
+  pub module_parsed: Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingModuleInfo), (), false>>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(error: Nullable<string>) => MaybePromise<VoidNullable>")]
-  pub build_end: Option<MaybeAsyncJsCallback<Option<String>, ()>>,
+  pub build_end: Option<MaybeAsyncJsCallback<Option<String>, (), false>>,
 
   #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(code: string, chunk: RenderedChunk) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>"
   )]
   pub render_chunk:
-    Option<MaybeAsyncJsCallback<(String, RenderedChunk), Option<BindingHookRenderChunkOutput>>>,
+    Option<MaybeAsyncJsCallback<(String, RenderedChunk), Option<BindingHookRenderChunkOutput>, false>>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "() => void")]
-  pub render_start: Option<MaybeAsyncJsCallback<(), ()>>,
+  pub render_start: Option<MaybeAsyncJsCallback<(), (), false>>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(error: string) => void")]
-  pub render_error: Option<MaybeAsyncJsCallback<String, ()>>,
+  pub render_error: Option<MaybeAsyncJsCallback<String, (), false>>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>")]
-  pub generate_bundle: Option<MaybeAsyncJsCallback<(BindingOutputs, bool), ()>>,
+  pub generate_bundle: Option<MaybeAsyncJsCallback<(BindingOutputs, bool), (), false>>,
 
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(bundle: BindingOutputs) => MaybePromise<VoidNullable>")]
-  pub write_bundle: Option<MaybeAsyncJsCallback<BindingOutputs, ()>>,
+  pub write_bundle: Option<MaybeAsyncJsCallback<BindingOutputs, (), false>>,
 }
 
 impl<const WEAK: bool> Debug for BindingPluginOptions<WEAK> {
@@ -156,5 +157,5 @@ impl FromNapiValue for BindingPluginOptions<true> {
 #[serde(rename_all = "camelCase")]
 pub struct BindingPluginWithIndex {
   pub index: u32,
-  pub plugin: BindingPluginOptions,
+  pub plugin: BindingPluginOptions<false>,
 }

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -8,31 +8,31 @@ use std::{borrow::Cow, ops::Deref, sync::Arc};
 use super::BindingPluginOptions;
 
 #[derive(Debug)]
-pub struct JsPlugin {
-  pub(crate) inner: BindingPluginOptions,
+pub struct JsPlugin<const WEAK: bool = false> {
+  pub(crate) inner: BindingPluginOptions<WEAK>,
 }
 
-impl Deref for JsPlugin {
-  type Target = BindingPluginOptions;
+impl<const WEAK: bool> Deref for JsPlugin<WEAK> {
+  type Target = BindingPluginOptions<WEAK>;
 
   fn deref(&self) -> &Self::Target {
     &self.inner
   }
 }
 
-impl JsPlugin {
+impl<const WEAK: bool> JsPlugin<WEAK> {
   #[cfg_attr(target_family = "wasm", allow(unused))]
-  pub(super) fn new(inner: BindingPluginOptions) -> Self {
+  pub(super) fn new(inner: BindingPluginOptions<WEAK>) -> Self {
     Self { inner }
   }
 
-  pub(crate) fn new_boxed(inner: BindingPluginOptions) -> Box<dyn Plugin> {
+  pub(crate) fn new_boxed(inner: BindingPluginOptions<WEAK>) -> Box<dyn Plugin> {
     Box::new(Self { inner })
   }
 }
 
 #[async_trait::async_trait]
-impl Plugin for JsPlugin {
+impl<const WEAK: bool> Plugin for JsPlugin<WEAK> {
   fn name(&self) -> Cow<'static, str> {
     Cow::Owned(self.name.clone())
   }

--- a/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
@@ -23,7 +23,7 @@ pub struct ParallelJsPlugin {
 #[cfg(not(target_family = "wasm"))]
 impl ParallelJsPlugin {
   pub fn new_boxed(
-    plugins: Vec<BindingPluginOptions>,
+    plugins: Vec<BindingPluginOptions<false>>,
     worker_manager: Arc<WorkerManager>,
   ) -> Box<dyn Plugin> {
     let plugins = plugins.into_iter().map(JsPlugin::new).collect::<Vec<_>>().into_boxed_slice();

--- a/crates/rolldown_binding/src/parallel_js_plugin_registry.rs
+++ b/crates/rolldown_binding/src/parallel_js_plugin_registry.rs
@@ -14,7 +14,7 @@ use std::{
 
 type PluginsInSingleWorker = Vec<BindingPluginWithIndex>;
 type PluginsList = Vec<PluginsInSingleWorker>;
-pub(crate) type PluginValues = FxHashMap<usize, Vec<BindingPluginOptions>>;
+pub(crate) type PluginValues = FxHashMap<usize, Vec<BindingPluginOptions<false>>>;
 
 static PLUGINS_MAP: Lazy<DashMap<u16, PluginsList>> = Lazy::new(DashMap::default);
 static NEXT_ID: AtomicU16 = AtomicU16::new(1);
@@ -44,7 +44,7 @@ impl ParallelJsPluginRegistry {
   pub fn take_plugin_values(&self) -> PluginValues {
     let plugins_list = PLUGINS_MAP.remove(&self.id).expect("plugin list already taken").1;
 
-    let mut map: FxHashMap<usize, Vec<BindingPluginOptions>> =
+    let mut map: FxHashMap<usize, Vec<BindingPluginOptions<false>>> =
       FxHashMap::with_capacity_and_hasher(plugins_list[0].len(), BuildHasherDefault::default());
     for plugins in plugins_list {
       for plugin in plugins {

--- a/crates/rolldown_binding/src/types/js_callback.rs
+++ b/crates/rolldown_binding/src/types/js_callback.rs
@@ -65,18 +65,20 @@ use rolldown_utils::debug::pretty_type_name;
 /// - Rust(Simplified): `MaybeAsyncJsCallback<(Option<String>, i32), Option<i32>>`
 /// - Js: `(a: string | null | undefined, b: number) => Promise<number | null | undefined | void> | number | null | undefined | void`
 /// - Js(Simplified): `(a: Nullable<string>, b: number) => MaybePromise<VoidNullable<number>>`
-pub type JsCallback<Args, Ret> = ThreadsafeFunction<Args, Either<Ret, UnknownReturnValue>, false>;
+pub type JsCallback<Args, Ret, const WEAK: bool = false> =
+  ThreadsafeFunction<Args, Either<Ret, UnknownReturnValue>, false, WEAK>;
 
 /// Shortcut for `JsCallback<..., Either<Promise<Ret>, Ret>>`, which could be simplified to `MaybeAsyncJsCallback<..., Ret>`.
-pub type MaybeAsyncJsCallback<Args, Ret> =
-  ThreadsafeFunction<Args, Either<Either<Promise<Ret>, Ret>, UnknownReturnValue>, false>;
+pub type MaybeAsyncJsCallback<Args, Ret, const WEAK: bool = false> =
+  ThreadsafeFunction<Args, Either<Either<Promise<Ret>, Ret>, UnknownReturnValue>, false, WEAK>;
 
-pub trait MaybeAsyncJsCallbackExt<Args, Ret> {
+pub trait MaybeAsyncJsCallbackExt<Args, Ret, const WEAK: bool = false> {
   /// Call Js function asynchronously in rust. If the Js function returns `Promise<T>`, it will unwrap/await the promise and return `T`.
   fn await_call(&self, args: Args) -> impl Future<Output = Result<Ret, napi::Error>> + Send;
 }
 
-impl<Args, Ret> MaybeAsyncJsCallbackExt<Args, Ret> for JsCallback<Args, Either<Promise<Ret>, Ret>>
+impl<Args, Ret, const WEAK: bool> MaybeAsyncJsCallbackExt<Args, Ret, WEAK>
+  for JsCallback<Args, Either<Promise<Ret>, Ret>, WEAK>
 where
   Args: 'static + Send,
   Ret: 'static + Send + FromNapiValue,

--- a/crates/rolldown_binding/src/types/js_callback.rs
+++ b/crates/rolldown_binding/src/types/js_callback.rs
@@ -65,14 +65,14 @@ use rolldown_utils::debug::pretty_type_name;
 /// - Rust(Simplified): `MaybeAsyncJsCallback<(Option<String>, i32), Option<i32>>`
 /// - Js: `(a: string | null | undefined, b: number) => Promise<number | null | undefined | void> | number | null | undefined | void`
 /// - Js(Simplified): `(a: Nullable<string>, b: number) => MaybePromise<VoidNullable<number>>`
-pub type JsCallback<Args, Ret, const WEAK: bool = false> =
+pub type JsCallback<Args, Ret, const WEAK: bool = true> =
   ThreadsafeFunction<Args, Either<Ret, UnknownReturnValue>, false, WEAK>;
 
 /// Shortcut for `JsCallback<..., Either<Promise<Ret>, Ret>>`, which could be simplified to `MaybeAsyncJsCallback<..., Ret>`.
-pub type MaybeAsyncJsCallback<Args, Ret, const WEAK: bool = false> =
+pub type MaybeAsyncJsCallback<Args, Ret, const WEAK: bool = true> =
   ThreadsafeFunction<Args, Either<Either<Promise<Ret>, Ret>, UnknownReturnValue>, false, WEAK>;
 
-pub trait MaybeAsyncJsCallbackExt<Args, Ret, const WEAK: bool = false> {
+pub trait MaybeAsyncJsCallbackExt<Args, Ret, const WEAK: bool = true> {
   /// Call Js function asynchronously in rust. If the Js function returns `Promise<T>`, it will unwrap/await the promise and return `T`.
   fn await_call(&self, args: Args) -> impl Future<Output = Result<Ret, napi::Error>> + Send;
 }

--- a/cspell.json
+++ b/cspell.json
@@ -120,6 +120,7 @@
     "transpiling",
     "treeshake",
     "underfin",
+    "unref",
     "UNKEYED",
     "vite",
     "vitepress",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The cli didn't exit process immediately after the build finished. This PR fixes that.

But I'm not sure why it did exit the process after some seconds even if the thread safe functions are not "weak".

We can add a test by using [`why-is-node-running`](https://www.npmjs.com/package/why-is-node-running). I didn't add it though.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
