### PR TITLE
chore(renovate): automate bumping process of deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,42 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":disablePeerDependencies"],
-  "labels": ["dependencies"],
+  "extends": [
+    "config:best-practices",
+    ":automergeStableNonMajor",
+    ":automergeRequireAllStatusChecks",
+    ":automergePr",
+    ":automergeTypes"
+  ],
   "ignorePaths": [
     "**/node_modules/**",
-    "**/bower_components/**",
-    "**/vendor/**",
     "**/examples/**",
-    "**/__tests__/**",
-    "**/test/**",
-    "**/__fixtures__/**"
+    "**/crates/rolldown/tests/**"
   ],
   "packageRules": [
     {
       "matchPackageNames": ["napi", "napi-build", "napi-derive"],
       "rangeStrategy": "replace",
       "groupName": "napi-rs"
-    },
-    {
-      "matchPackageNames": ["oxlint"],
-      "rangeStrategy": "replace",
-      "groupName": "oxlint"
-    },
-    {
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "matchPackagePatterns": ["*"],
-      "excludePackagePatterns": ["oxlint"],
-      "matchUpdateTypes": ["minor", "patch"]
     }
   ],
-  "commitMessagePrefix": "chore: ",
-  "commitMessageAction": "bump up",
-  "commitMessageTopic": "{{depName}} version",
-  "ignoreDeps": [],
-  "postUpdateOptions": ["pnpmDedupe"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "extends": ["schedule:weekly"]
-  }
+  "postUpdateOptions": ["pnpmDedupe"]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I looked the https://docs.renovatebot.com/upgrade-best-practices/#use-the-configbest-practices-preset guide and don't see anything negative. So I think it's ok we just follow the guide. Also I try to automate the renovate as possible by merging minor and patch changes automatically if the CI passed.

This PR

- Follow the https://docs.renovatebot.com/upgrade-best-practices/#use-the-configbest-practices-preset guide
- Automerge merge changes for patch and minor updates https://docs.renovatebot.com/presets-default/#automergestablenonmajor
- Update @types/* packages automatically if tests pass.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
