### PR TITLE
feat: add plugin context info/warn/error/debug

### DIFF
--- a/packages/rolldown/src/log/logHandler.ts
+++ b/packages/rolldown/src/log/logHandler.ts
@@ -1,0 +1,42 @@
+import { noop } from '../utils'
+import { LoggingFunctionWithPosition, LogHandler, RollupLog } from '../rollup'
+import {
+  LOG_LEVEL_WARN,
+  LogLevel,
+  LogLevelOption,
+  logLevelPriority,
+} from './logging'
+import { logInvalidLogPosition } from './logs'
+
+export const normalizeLog = (
+  log: RollupLog | string | (() => RollupLog | string),
+): RollupLog =>
+  typeof log === 'string'
+    ? { message: log }
+    : typeof log === 'function'
+      ? normalizeLog(log())
+      : log
+
+export function getLogHandler(
+  level: LogLevel,
+  code: string,
+  logger: LogHandler,
+  pluginName: string,
+  logLevel: LogLevelOption,
+): LoggingFunctionWithPosition {
+  if (logLevelPriority[level] < logLevelPriority[logLevel]) {
+    return noop
+  }
+  return (log, pos) => {
+    if (pos != null) {
+      logger(LOG_LEVEL_WARN, logInvalidLogPosition(pluginName))
+    }
+    log = normalizeLog(log)
+    if (log.code && !log.pluginCode) {
+      log.pluginCode = log.code
+    }
+    log.code = code
+    log.plugin = pluginName
+    logger(level, log)
+  }
+}

--- a/packages/rolldown/src/log/logging.ts
+++ b/packages/rolldown/src/log/logging.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+const LogLevelSchema = z
+  .literal('info')
+  .or(z.literal('debug'))
+  .or(z.literal('warn'))
+
+export type LogLevel = z.infer<typeof LogLevelSchema>
+
+export const LogLevelOptionSchema = LogLevelSchema.or(z.literal('silent'))
+
+export type LogLevelOption = z.infer<typeof LogLevelOptionSchema>
+
+export const LOG_LEVEL_SILENT: LogLevelOption = 'silent'
+// export const LOG_LEVEL_ERROR = 'error'
+export const LOG_LEVEL_WARN: LogLevel = 'warn'
+export const LOG_LEVEL_INFO: LogLevel = 'info'
+export const LOG_LEVEL_DEBUG: LogLevel = 'debug'
+
+export const logLevelPriority: Record<LogLevelOption, number> = {
+  [LOG_LEVEL_DEBUG]: 0,
+  [LOG_LEVEL_INFO]: 1,
+  [LOG_LEVEL_WARN]: 2,
+  [LOG_LEVEL_SILENT]: 3,
+}

--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -1,0 +1,46 @@
+import { RollupLog } from '../rollup'
+
+const INVALID_LOG_POSITION = 'INVALID_LOG_POSITION',
+  PLUGIN_ERROR = 'PLUGIN_ERROR'
+
+export function logInvalidLogPosition(pluginName: string): RollupLog {
+  return {
+    code: INVALID_LOG_POSITION,
+    message: `Plugin "${pluginName}" tried to add a file position to a log or warning. This is only supported in the "transform" hook at the moment and will be ignored.`,
+  }
+}
+
+export function logPluginError(
+  error: Omit<RollupLog, 'code'> & { code?: unknown },
+  plugin: string,
+  { hook, id }: { hook?: string; id?: string } = {},
+) {
+  const code = error.code
+  if (
+    !error.pluginCode &&
+    code != null &&
+    (typeof code !== 'string' || !code.startsWith('PLUGIN_'))
+  ) {
+    error.pluginCode = code
+  }
+  error.code = PLUGIN_ERROR
+  error.plugin = plugin
+  if (hook) {
+    error.hook = hook
+  }
+  if (id) {
+    error.id = id
+  }
+  return error as RollupLog
+}
+
+export function error(base: Error | RollupLog): never {
+  if (!(base instanceof Error)) {
+    base = Object.assign(new Error(base.message), base)
+    Object.defineProperty(base, 'name', {
+      value: 'RollupError',
+      writable: true,
+    })
+  }
+  throw base
+}

--- a/packages/rolldown/src/options/bindingify-input-options.ts
+++ b/packages/rolldown/src/options/bindingify-input-options.ts
@@ -55,6 +55,7 @@ export function bindingifyInputOptions(
       : undefined,
     platform: options.platform,
     shimMissingExports: options.shimMissingExports,
+    // @ts-ignore TODO: logLevel shouldn't include `error`
     logLevel: options.logLevel,
   }
 }

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -1,6 +1,7 @@
 import { Plugin, ParallelPlugin } from '../plugin'
 import { z } from 'zod'
 import * as zodExt from '../utils/zod-ext'
+import { LogLevelOptionSchema } from '../log/logging'
 
 const inputOptionsSchema = z.strictObject({
   input: z.string().or(z.string().array()).or(z.record(z.string())).optional(),
@@ -37,12 +38,7 @@ const inputOptionsSchema = z.strictObject({
     .or(z.literal('neutral'))
     .optional(),
   shimMissingExports: z.boolean().optional(),
-  logLevel: z
-    .literal('silent')
-    .or(z.literal('error'))
-    .or(z.literal('warn'))
-    .or(z.literal('info'))
-    .optional(),
+  logLevel: LogLevelOptionSchema.optional(),
 })
 
 export type InputOptions = z.infer<typeof inputOptionsSchema>

--- a/packages/rolldown/src/options/normalized-input-options.ts
+++ b/packages/rolldown/src/options/normalized-input-options.ts
@@ -8,5 +8,4 @@ import { Plugin, ParallelPlugin } from '../plugin'
 export interface NormalizedInputOptions extends InputOptions {
   input: RollupNormalizedInputOptions['input']
   plugins: (Plugin | ParallelPlugin)[]
-  onLog: LogHandler
 }

--- a/packages/rolldown/src/options/normalized-input-options.ts
+++ b/packages/rolldown/src/options/normalized-input-options.ts
@@ -1,8 +1,12 @@
-import type { NormalizedInputOptions as RollupNormalizedInputOptions } from '../rollup'
+import type {
+  LogHandler,
+  NormalizedInputOptions as RollupNormalizedInputOptions,
+} from '../rollup'
 import type { InputOptions } from './input-options'
 import { Plugin, ParallelPlugin } from '../plugin'
 
 export interface NormalizedInputOptions extends InputOptions {
   input: RollupNormalizedInputOptions['input']
   plugins: (Plugin | ParallelPlugin)[]
+  onLog: LogHandler
 }

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -7,24 +7,31 @@ import { transformToOutputBundle } from '../utils/transform-to-rollup-output'
 import { transformPluginContext } from './plugin-context'
 
 export function bindingifyRenderStart(
-  outputOptions: NormalizedOutputOptions,
+  plugin: Plugin,
   options: NormalizedInputOptions,
-  hook?: Plugin['renderStart'],
+  outputOptions: NormalizedOutputOptions,
 ): BindingPluginOptions['renderStart'] {
+  const hook = plugin.renderStart
   if (!hook) {
     return undefined
   }
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx) => {
-    handler.call(transformPluginContext(ctx), outputOptions, options)
+    handler.call(
+      transformPluginContext(options, ctx, plugin),
+      outputOptions,
+      options,
+    )
   }
 }
 
 export function bindingifyRenderChunk(
+  plugin: Plugin,
+  options: NormalizedInputOptions,
   outputOptions: NormalizedOutputOptions,
-  hook?: Plugin['renderChunk'],
 ): BindingPluginOptions['renderChunk'] {
+  const hook = plugin.renderChunk
   if (!hook) {
     return undefined
   }
@@ -32,7 +39,7 @@ export function bindingifyRenderChunk(
 
   return async (ctx, code, chunk) => {
     const ret = await handler.call(
-      transformPluginContext(ctx),
+      transformPluginContext(options, ctx, plugin),
       code,
       chunk,
       outputOptions,
@@ -58,22 +65,26 @@ export function bindingifyRenderChunk(
 }
 
 export function bindingifyRenderError(
-  hook?: Plugin['renderError'],
+  plugin: Plugin,
+  options: NormalizedInputOptions,
 ): BindingPluginOptions['renderError'] {
+  const hook = plugin.renderError
   if (!hook) {
     return undefined
   }
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, err) => {
-    handler.call(transformPluginContext(ctx), new Error(err))
+    handler.call(transformPluginContext(options, ctx, plugin), new Error(err))
   }
 }
 
 export function bindingifyGenerateBundle(
+  plugin: Plugin,
+  options: NormalizedInputOptions,
   outputOptions: NormalizedOutputOptions,
-  hook?: Plugin['generateBundle'],
 ): BindingPluginOptions['generateBundle'] {
+  const hook = plugin.generateBundle
   if (!hook) {
     return undefined
   }
@@ -81,7 +92,7 @@ export function bindingifyGenerateBundle(
 
   return async (ctx, bundle, isWrite) => {
     handler.call(
-      transformPluginContext(ctx),
+      transformPluginContext(options, ctx, plugin),
       outputOptions,
       transformToOutputBundle(bundle),
       isWrite,
@@ -89,9 +100,11 @@ export function bindingifyGenerateBundle(
   }
 }
 export function bindingifyWriteBundle(
+  plugin: Plugin,
+  options: NormalizedInputOptions,
   outputOptions: NormalizedOutputOptions,
-  hook?: Plugin['writeBundle'],
 ): BindingPluginOptions['writeBundle'] {
+  const hook = plugin.writeBundle
   if (!hook) {
     return undefined
   }
@@ -99,7 +112,7 @@ export function bindingifyWriteBundle(
 
   return async (ctx, bundle) => {
     handler.call(
-      transformPluginContext(ctx),
+      transformPluginContext(options, ctx, plugin),
       outputOptions,
       transformToOutputBundle(bundle),
     )

--- a/packages/rolldown/src/plugin/bindingify-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin.ts
@@ -29,26 +29,17 @@ export function bindingifyPlugin(
 ): BindingPluginOptions {
   return {
     name: plugin.name ?? 'unknown',
-    buildStart: bindingifyBuildStart(options, plugin.buildStart),
-    resolveId: bindingifyResolveId(plugin.resolveId),
-    resolveDynamicImport: bindingifyResolveDynamicImport(
-      plugin.resolveDynamicImport,
-    ),
-    buildEnd: bindingifyBuildEnd(plugin.buildEnd),
+    buildStart: bindingifyBuildStart(plugin, options),
+    resolveId: bindingifyResolveId(plugin, options),
+    resolveDynamicImport: bindingifyResolveDynamicImport(plugin, options),
+    buildEnd: bindingifyBuildEnd(plugin, options),
     transform: bindingifyTransform(plugin.transform),
-    moduleParsed: bindingifyModuleParsed(plugin.moduleParsed),
-    load: bindingifyLoad(plugin.load),
-    renderChunk: bindingifyRenderChunk(outputOptions, plugin.renderChunk),
-    renderStart: bindingifyRenderStart(
-      outputOptions,
-      options,
-      plugin.renderStart,
-    ),
-    renderError: bindingifyRenderError(plugin.renderError),
-    generateBundle: bindingifyGenerateBundle(
-      outputOptions,
-      plugin.generateBundle,
-    ),
-    writeBundle: bindingifyWriteBundle(outputOptions, plugin.writeBundle),
+    moduleParsed: bindingifyModuleParsed(plugin, options),
+    load: bindingifyLoad(plugin, options),
+    renderChunk: bindingifyRenderChunk(plugin, options, outputOptions),
+    renderStart: bindingifyRenderStart(plugin, options, outputOptions),
+    renderError: bindingifyRenderError(plugin, options),
+    generateBundle: bindingifyGenerateBundle(plugin, options, outputOptions),
+    writeBundle: bindingifyWriteBundle(plugin, options, outputOptions),
   }
 }

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -1,12 +1,51 @@
+import { RollupError, LoggingFunction } from '../rollup'
 import { BindingPluginContext } from '../binding'
+import { getLogHandler, normalizeLog } from '../log/logHandler'
+import { NormalizedInputOptions } from '../options/normalized-input-options'
+import type { Plugin } from './index'
+import { LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARN } from '../log/logging'
+import { error, logPluginError } from '../log/logs'
 
-export interface PluginContext {}
+export interface PluginContext {
+  debug: LoggingFunction
+  info: LoggingFunction
+  warn: LoggingFunction
+  error: (error: RollupError | string) => never
+}
 
 export function transformPluginContext(
+  options: NormalizedInputOptions,
   context: BindingPluginContext,
+  plugin: Plugin,
 ): PluginContext {
+  const { onLog } = options
+  const pluginName = plugin.name || 'unknown'
+  const logLevel = options.logLevel || LOG_LEVEL_INFO
   return {
     ...context,
-    // TODO error/warning
+    debug: getLogHandler(
+      LOG_LEVEL_DEBUG,
+      'PLUGIN_LOG',
+      onLog,
+      pluginName,
+      logLevel,
+    ),
+    warn: getLogHandler(
+      LOG_LEVEL_WARN,
+      'PLUGIN_WARNING',
+      onLog,
+      pluginName,
+      logLevel,
+    ),
+    info: getLogHandler(
+      LOG_LEVEL_INFO,
+      'PLUGIN_LOG',
+      onLog,
+      pluginName,
+      logLevel,
+    ),
+    error(e): never {
+      return error(logPluginError(normalizeLog(e), pluginName))
+    },
   }
 }

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -18,7 +18,8 @@ export function transformPluginContext(
   context: BindingPluginContext,
   plugin: Plugin,
 ): PluginContext {
-  const { onLog } = options
+  // TODO add `onLog` option
+  const onLog = () => {}
   const pluginName = plugin.name || 'unknown'
   const logLevel = options.logLevel || LOG_LEVEL_INFO
   return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The pr intend to compat `PluginContext#warn/info/error/debug` api. Because they called will direct call `onLog` option, so here only put it to js side is better. The code port from rollup, it is easy to compat rollup. 

For the rust plugins, we could add similar API at rust side and export the logs to js side, it only need some `RolldownLog/Error` binding, we can do it at future.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
