### PR TITLE
chore(tests/rust): name is required for InputItem.

### DIFF
--- a/crates/rolldown_testing/_test.schema.json
+++ b/crates/rolldown_testing/_test.schema.json
@@ -149,7 +149,8 @@
     "InputItem": {
       "type": "object",
       "required": [
-        "import"
+        "import",
+        "name"
       ],
       "properties": {
         "import": {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

if any one test-case not specify `name` of `InputItem` in `_config.json`, executing `just test-rust` would be wrong, like below:

![image](https://github.com/rolldown/rolldown/assets/19543313/acec1c0d-e81e-4d0f-a8bf-b19a6ea517be)

vscode would give us a warning-level diagnosis.
![image](https://github.com/rolldown/rolldown/assets/19543313/40faa5a7-f383-4ab5-b2d7-eee949271c98)
![image](https://github.com/rolldown/rolldown/assets/19543313/b684d289-eda1-4b95-b97c-50a2650f396b)
