### PR TITLE
chore(renovate): group updates for patch and minor

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,24 +12,34 @@
   ],
   "packageRules": [
     {
+      "automerge": true,
+      "matchUpdateTypes": ["patch", "minor", "lockFileMaintenance", "pin"]
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["rustc", "oxlint"]
+    },
+    {
+      "automerge": true,
+      "matchUpdateTypes": ["patch"],
+      "excludePackageNames": ["rustc", "oxlint"],
+      "groupName": "patch dependencies"
+    },
+    {
+      "automerge": true,
+      "matchUpdateTypes": ["minor"],
+      "excludePackageNames": ["rustc"],
+      "groupName": "minor dependencies"
+    },
+    {
+      "automerge": true,
+      "matchPackagePrefixes": ["@types/"],
+      "groupName": "`@types/*` dependencies"
+    },
+    {
       "matchPackageNames": ["napi", "napi-build", "napi-derive"],
       "rangeStrategy": "replace",
       "groupName": "napi-rs"
-    },
-    {
-      "automerge": true,
-      "autoApprove": true,
-      "matchUpdateTypes": ["minor", "patch", "pin", "lockFileMaintenance"]
-    },
-    {
-      "automerge": true,
-      "autoApprove": true,
-      "matchPackagePrefixes": ["@types/"]
-    },
-    {
-      "groupName": "rust toolchain",
-      "matchManagers": ["custom.regex"],
-      "matchPackageNames": ["rustc"]
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- patch and minor updates now would be grouped together except the `rustc` bumping. `rustc` is still updated per PR not grouped.
- renovate doesn't support built-in autoApprove for github. So the related config is removed. We gonna use https://github.com/apps/renovate-approve instead.

We might need to only group patch updates, since minor updates may have a big chance to break CI.  However, let's see how it goes now.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
