### PR TITLE
fix(rolldown/hash): caculate hash by scanning actually used dependencies and also prevent hash collision from different chunks that have the same content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,6 +1963,7 @@ dependencies = [
  "async-scoped",
  "base64",
  "futures",
+ "indexmap",
  "once_cell",
  "rayon",
  "regex",

--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -1,11 +1,19 @@
 use oxc_index::IndexVec;
-use rolldown_common::{ChunkId, NormalModuleId};
+use rolldown_common::{Chunk, ChunkId, NormalModuleId};
 
 use crate::type_alias::IndexChunks;
 
 #[derive(Debug)]
 pub struct ChunkGraph {
   pub chunks: IndexChunks,
+  pub sorted_chunk_ids: Vec<ChunkId>,
   pub user_defined_entry_chunk_ids: Vec<ChunkId>,
   pub module_to_chunk: IndexVec<NormalModuleId, Option<ChunkId>>,
+}
+
+impl ChunkGraph {
+  #[allow(unused)]
+  pub fn sorted_chunks(&self) -> impl Iterator<Item = &Chunk> {
+    self.sorted_chunk_ids.iter().map(move |&id| &self.chunks[id])
+  }
 }

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -1,5 +1,6 @@
 use std::hash::BuildHasherDefault;
 
+use itertools::Itertools;
 use oxc_index::IndexVec;
 use rolldown_common::{Chunk, ChunkId, ChunkKind, ImportKind, ModuleId, NormalModuleId};
 use rolldown_utils::BitSet;
@@ -141,6 +142,9 @@ impl<'a> GenerateStage<'a> {
       });
     });
 
-    ChunkGraph { chunks, module_to_chunk, user_defined_entry_chunk_ids }
+    let sorted_chunk_ids =
+      chunks.indices().sorted_by_key(|id| &chunks[*id].bits).collect::<Vec<_>>();
+
+    ChunkGraph { chunks, sorted_chunk_ids, module_to_chunk, user_defined_entry_chunk_ids }
   }
 }

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -179,9 +179,16 @@ impl<'a> GenerateStage<'a> {
         dynamic_imports: rendered_chunk.dynamic_imports,
         map,
         sourcemap_file_name,
-        preliminary_file_name,
+        preliminary_file_name: preliminary_file_name.to_string(),
       })));
     }
+
+    // Make sure order of assets are deterministic
+    assets.sort_by_cached_key(|item| match item {
+      // TODO: use `preliminary_file_name` instead
+      Output::Asset(asset) => asset.file_name.to_string(),
+      Output::Chunk(chunk) => chunk.preliminary_file_name.to_string(),
+    });
 
     Ok(BundleOutput {
       assets,

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -243,7 +243,7 @@ impl<'a> GenerateStage<'a> {
       .user_defined_entry_chunk_ids
       .iter()
       .copied()
-      .chain(chunk_graph.chunks.iter_enumerated().map(|(id, _)| id))
+      .chain(chunk_graph.sorted_chunk_ids.iter().copied())
       .collect::<Vec<_>>();
 
     chunk_ids.into_iter().for_each(|chunk_id| {

--- a/crates/rolldown/src/utils/hash_placeholder.rs
+++ b/crates/rolldown/src/utils/hash_placeholder.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
+use rolldown_utils::indexmap::FxIndexSet;
 use rustc_hash::FxHashMap;
 
 const HASH_PLACEHOLDER_LEFT: &str = "!~{";
@@ -13,7 +14,6 @@ const MAX_HASH_SIZE: usize = 22;
 // const DEFAULT_HASH_SIZE: usize = 8;
 
 static REPLACER_REGEX: Lazy<Regex> = Lazy::new(|| {
-  // let pattern = [HASH_PLACEHOLDER_LEFT, "[0-9a-zA-Z_$]{1,17}", HASH_PLACEHOLDER_RIGHT].concat();
   let pattern = "!~\\{[0-9a-zA-Z_$]{1,17}\\}~";
   Regex::new(pattern).expect("failed to compile regex")
 });
@@ -77,6 +77,15 @@ pub fn replace_facade_hash_replacement(
   match replaced {
     Cow::Borrowed(_) => source,
     Cow::Owned(s) => s,
+  }
+}
+
+pub fn extract_hash_placeholders(source: &str) -> FxIndexSet<String> {
+  let captures = REPLACER_REGEX.captures(source);
+  if let Some(captures) = captures {
+    captures.iter().map(|capture| capture.unwrap().as_str().to_string()).collect()
+  } else {
+    FxIndexSet::default()
   }
 }
 

--- a/crates/rolldown/tests/fixtures.rs
+++ b/crates/rolldown/tests/fixtures.rs
@@ -3,6 +3,7 @@ mod common;
 use std::path::{Component, PathBuf};
 
 use common::{Case, Fixture};
+use rolldown_common::Output;
 use sugar_path::SugarPath;
 use testing_macros::fixture;
 
@@ -35,8 +36,17 @@ async fn filename_with_hash() {
 
     let assets = fixture.bundle(false, true).await;
 
-    assets.assets.iter().for_each(|asset| {
-      snapshot_output.push_str(&format!("- {}\n", asset.file_name()));
+    assets.assets.iter().for_each(|asset| match asset {
+      Output::Asset(asset) => {
+        snapshot_output.push_str(&format!("- {}\n", asset.file_name));
+      }
+      Output::Chunk(chunk) => {
+        snapshot_output.push_str(&format!(
+          "- {} => {}\n",
+          chunk.preliminary_file_name.as_str(),
+          chunk.file_name.as_str()
+        ));
+      }
     });
 
     snapshot_outputs.push(snapshot_output);

--- a/crates/rolldown/tests/fixtures.rs
+++ b/crates/rolldown/tests/fixtures.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use std::path::PathBuf;
+use std::path::{Component, PathBuf};
 
 use common::{Case, Fixture};
 use sugar_path::SugarPath;
@@ -22,8 +22,8 @@ async fn filename_with_hash() {
   config_paths.sort_by_cached_key(|p| p.relative(&cwd));
 
   for path in config_paths {
-    if path.to_slash_lossy().contains('.') {
-      return;
+    if path.components().map(Component::as_os_str).any(|c| c.to_string_lossy().starts_with('.')) {
+      continue;
     }
     let mut snapshot_output = String::new();
     let config_path = path.canonicalize().unwrap();

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -4,13 +4,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 ---
 # tests/esbuild/dce/base64_loader_remove_unused
 
-- entry_js-!~{000}~.mjs => entry_js-a50D-tCc.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-a50D-tCc.mjs
 
 # tests/esbuild/dce/data_url_loader_remove_unused
 
-- entry_js-!~{000}~.mjs => entry_js-a50D-tCc.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-a50D-tCc.mjs
 
 # tests/esbuild/dce/dce_template_literal
 
@@ -30,13 +30,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/dce/file_loader_remove_unused
 
-- entry_js-!~{000}~.mjs => entry_js-a50D-tCc.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-a50D-tCc.mjs
 
 # tests/esbuild/dce/import_re_export_of_namespace_import
 
-- entry_js-!~{000}~.mjs => entry_js-c5EAqwgy.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-AWpG-C_M.mjs
+- entry_js-!~{000}~.mjs => entry_js-c5EAqwgy.mjs
 
 # tests/esbuild/dce/inline_function_call_for_init_decl
 
@@ -56,8 +56,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/dce/text_loader_remove_unused
 
-- entry_js-!~{000}~.mjs => entry_js-jE3smO-n.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-jE3smO-n.mjs
 
 # tests/esbuild/dce/tree_shaking_binary_operators
 
@@ -65,13 +65,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/dce/tree_shaking_import_identifier
 
-- entry_js-!~{000}~.mjs => entry_js-VY9fbi7V.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-VY9fbi7V.mjs
 
 # tests/esbuild/dce/tree_shaking_in_esm_wrapper
 
-- entry_js-!~{000}~.mjs => entry_js-Ot39bAO0.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- entry_js-!~{000}~.mjs => entry_js-Ot39bAO0.mjs
 
 # tests/esbuild/dce/tree_shaking_unary_operators
 
@@ -99,8 +99,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/common_js_from_es6
 
-- entry_js-!~{000}~.mjs => entry_js-4ti5rQwL.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- entry_js-!~{000}~.mjs => entry_js-4ti5rQwL.mjs
 
 # tests/esbuild/default/const_with_let
 
@@ -108,14 +108,14 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/dot_import
 
-- entry_js-!~{000}~.mjs => entry_js-qA3G3aMM.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-qA3G3aMM.mjs
 
 # tests/esbuild/default/duplicate_entry_point
 
-- entry_js-!~{000}~.mjs => entry_js-P03grTeI.mjs
-- entry2_js-!~{001}~.mjs => entry2_js-gLxkMptc.mjs
 - entry-!~{002}~.mjs => entry-DXoyZNA-.mjs
+- entry2_js-!~{001}~.mjs => entry2_js-gLxkMptc.mjs
+- entry_js-!~{000}~.mjs => entry_js-P03grTeI.mjs
 
 # tests/esbuild/default/dynamic_import_with_expression_cjs
 
@@ -123,13 +123,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910
 
-- entry_js-!~{000}~.mjs => entry_js-qwSWZfQl.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-FWY5Q29P.mjs
+- entry_js-!~{000}~.mjs => entry_js-qwSWZfQl.mjs
 
 # tests/esbuild/default/es6_from_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-lswHEC91.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-lswHEC91.mjs
 
 # tests/esbuild/default/export_chain
 
@@ -137,13 +137,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/export_forms_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-MwmhDoh9.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- entry_js-!~{000}~.mjs => entry_js-MwmhDoh9.mjs
 
 # tests/esbuild/default/export_forms_es6
 
-- entry_js-!~{000}~.mjs => entry_js-sos27Agl.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-sos27Agl.mjs
 
 # tests/esbuild/default/external_packages
 
@@ -159,8 +159,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/import_missing_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-BJkPislD.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-BJkPislD.mjs
 
 # tests/esbuild/default/import_then_catch
 
@@ -172,13 +172,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/nested_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-JTyNJTWq.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-JTyNJTWq.mjs
 
 # tests/esbuild/default/nested_es6_from_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-BAL2XoGB.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-BAL2XoGB.mjs
 
 # tests/esbuild/default/nested_require_without_call
 
@@ -190,8 +190,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/new_expression_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-8H4WN1WU.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-8H4WN1WU.mjs
 
 # tests/esbuild/default/no_overwrite_input_file_error
 
@@ -208,8 +208,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/re_export_common_js_as_es6
 
-- entry_js-!~{000}~.mjs => entry_js-WGnxJ-SI.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-WGnxJ-SI.mjs
 
 # tests/esbuild/default/re_export_default_internal
 
@@ -221,8 +221,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/require_child_dir_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-cjN4Bdij.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-cjN4Bdij.mjs
 
 # tests/esbuild/default/require_child_dir_es6
 
@@ -230,13 +230,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/require_main_cache_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-OFrWorTU.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-OFrWorTU.mjs
 
 # tests/esbuild/default/require_parent_dir_common_js
 
-- dir_entry_js-!~{000}~.mjs => dir_entry_js-TqGj3PVc.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- dir_entry_js-!~{000}~.mjs => dir_entry_js-TqGj3PVc.mjs
 
 # tests/esbuild/default/require_parent_dir_es6
 
@@ -252,8 +252,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/require_with_call_inside_try
 
-- entry_js-!~{000}~.mjs => entry_js-f3IEt299.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-f3IEt299.mjs
 
 # tests/esbuild/default/require_without_call
 
@@ -269,8 +269,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/simple_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-Kjt9Do6P.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-Kjt9Do6P.mjs
 
 # tests/esbuild/default/simple_es6
 
@@ -290,21 +290,21 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/use_strict_directive_bundle_issue1837
 
-- entry_js-!~{000}~.mjs => entry_js-iJ-IQkDg.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-iJ-IQkDg.mjs
 
 # tests/esbuild/default/var_relocating_bundle
 
-- top-level_js-!~{000}~.mjs => top-level_js-zFcTRQCq.mjs
-- nested_js-!~{001}~.mjs => nested_js-9gULdUmo.mjs
-- let_js-!~{002}~.mjs => let_js-NZtFdo_X.mjs
-- function_js-!~{003}~.mjs => function_js-508d9udD.mjs
 - function-nested_js-!~{004}~.mjs => function-nested_js-3Itl4oYw.mjs
+- function_js-!~{003}~.mjs => function_js-508d9udD.mjs
+- let_js-!~{002}~.mjs => let_js-NZtFdo_X.mjs
+- nested_js-!~{001}~.mjs => nested_js-9gULdUmo.mjs
+- top-level_js-!~{000}~.mjs => top-level_js-zFcTRQCq.mjs
 
 # tests/esbuild/import_star/export_self_as_namespace_es6
 
-- entry_js-!~{000}~.mjs => entry_js-Zjs8PpNg.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Zjs8PpNg.mjs
 
 # tests/esbuild/import_star/export_self_common_js
 
@@ -316,18 +316,18 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/import_export_other_as_namespace_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-YGsyDWpI.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-YGsyDWpI.mjs
 
 # tests/esbuild/import_star/import_export_self_as_namespace_es6
 
-- entry_js-!~{000}~.mjs => entry_js-Zjs8PpNg.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Zjs8PpNg.mjs
 
 # tests/esbuild/import_star/import_export_star_ambiguous_warning
 
-- entry_js-!~{000}~.mjs => entry_js-jEM63MHK.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-jEM63MHK.mjs
 
 # tests/esbuild/import_star/import_of_export_star
 
@@ -339,43 +339,43 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/import_self_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-5OrdrVz4.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-5OrdrVz4.mjs
 
 # tests/esbuild/import_star/import_star_and_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-Qo4uI9_R.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- entry_js-!~{000}~.mjs => entry_js-Qo4uI9_R.mjs
 
 # tests/esbuild/import_star/import_star_capture
 
-- entry_js-!~{000}~.mjs => entry_js-Nb59JZ9_.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Nb59JZ9_.mjs
 
 # tests/esbuild/import_star/import_star_common_js_capture
 
-- entry_js-!~{000}~.mjs => entry_js-uC4SyQQl.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-uC4SyQQl.mjs
 
 # tests/esbuild/import_star/import_star_common_js_no_capture
 
-- entry_js-!~{000}~.mjs => entry_js-omQ_zVuC.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-omQ_zVuC.mjs
 
 # tests/esbuild/import_star/import_star_common_js_unused
 
-- entry_js-!~{000}~.mjs => entry_js-r1zYVnBD.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-r1zYVnBD.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_capture
 
-- entry_js-!~{000}~.mjs => entry_js-Nb59JZ9_.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Nb59JZ9_.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_no_capture
 
-- entry_js-!~{000}~.mjs => entry_js-Rxv2YhfA.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Rxv2YhfA.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_unused
 
@@ -383,33 +383,33 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/import_star_export_star_as_capture
 
-- entry_js-!~{000}~.mjs => entry_js-Nb59JZ9_.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Nb59JZ9_.mjs
 
 # tests/esbuild/import_star/import_star_export_star_as_no_capture
 
-- entry_js-!~{000}~.mjs => entry_js-Rxv2YhfA.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Rxv2YhfA.mjs
 
 # tests/esbuild/import_star/import_star_export_star_as_unused
 
-- entry_js-!~{000}~.mjs => entry_js-ydely-ew.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-ydely-ew.mjs
 
 # tests/esbuild/import_star/import_star_export_star_capture
 
-- entry_js-!~{000}~.mjs => entry_js-XvODpbLo.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-XvODpbLo.mjs
 
 # tests/esbuild/import_star/import_star_export_star_no_capture
 
-- entry_js-!~{000}~.mjs => entry_js-zoqqsfeu.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-zoqqsfeu.mjs
 
 # tests/esbuild/import_star/import_star_export_star_omit_ambiguous
 
-- entry_js-!~{000}~.mjs => entry_js-gPlTS0bF.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-gPlTS0bF.mjs
 
 # tests/esbuild/import_star/import_star_export_star_unused
 
@@ -417,13 +417,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/import_star_no_capture
 
-- entry_js-!~{000}~.mjs => entry_js-Rxv2YhfA.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Rxv2YhfA.mjs
 
 # tests/esbuild/import_star/import_star_of_export_star_as
 
-- entry_js-!~{000}~.mjs => entry_js-8XORSYMb.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-8XORSYMb.mjs
 
 # tests/esbuild/import_star/import_star_unused
 
@@ -431,43 +431,43 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/issue176
 
-- entry_js-!~{000}~.mjs => entry_js-G1jzfW5F.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-G1jzfW5F.mjs
 
 # tests/esbuild/import_star/namespace_import_missing_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-t3Suhxx_.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-t3Suhxx_.mjs
 
 # tests/esbuild/import_star/namespace_import_missing_es6
 
-- entry_js-!~{000}~.mjs => entry_js-7oWuFBtK.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-7oWuFBtK.mjs
 
 # tests/esbuild/import_star/namespace_import_re_export_star_missing_es6
 
-- entry_js-!~{000}~.mjs => entry_js-i-Fd9UVH.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-i-Fd9UVH.mjs
 
 # tests/esbuild/import_star/namespace_import_re_export_star_unused_missing_es6
 
-- entry_js-!~{000}~.mjs => entry_js-3JnON20m.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-3JnON20m.mjs
 
 # tests/esbuild/import_star/namespace_import_unused_missing_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-GLIUkWiS.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-GLIUkWiS.mjs
 
 # tests/esbuild/import_star/namespace_import_unused_missing_es6
 
-- entry_js-!~{000}~.mjs => entry_js-Zagt51Rt.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Zagt51Rt.mjs
 
 # tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6
 
-- entry_js-!~{000}~.mjs => entry_js-kdwdpUqf.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-kdwdpUqf.mjs
 
 # tests/esbuild/import_star/other_file_import_export_self_as_namespace_unused_es6
 
@@ -475,23 +475,23 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/re_export_namespace_import_missing_es6
 
-- entry_js-!~{000}~.mjs => entry_js-GeAA33Yj.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-GeAA33Yj.mjs
 
 # tests/esbuild/import_star/re_export_namespace_import_unused_missing_es6
 
-- entry_js-!~{000}~.mjs => entry_js-SSs3UiOe.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-SSs3UiOe.mjs
 
 # tests/esbuild/import_star/re_export_other_file_export_self_as_namespace_es6
 
-- entry_js-!~{000}~.mjs => entry_js-c2v0AGZC.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-c2v0AGZC.mjs
 
 # tests/esbuild/import_star/re_export_other_file_import_export_self_as_namespace_es6
 
-- entry_js-!~{000}~.mjs => entry_js-c2v0AGZC.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-c2v0AGZC.mjs
 
 # tests/esbuild/import_star/re_export_star_as_external_common_js
 
@@ -503,8 +503,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/re_export_star_entry_point_and_inner_file
 
-- entry_js-!~{000}~.mjs => entry_js-1yhhclYV.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-1yhhclYV.mjs
 
 # tests/esbuild/import_star/re_export_star_external_common_js
 
@@ -536,8 +536,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/lower/lower_async_this2016_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-Ad0z75lz.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-Ad0z75lz.mjs
 
 # tests/esbuild/lower/lower_async_this2016_es6
 
@@ -645,8 +645,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/packagejson/test_package_json_bad_main
 
-- entry-!~{000}~.mjs => entry-N2N-2gTp.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-N2N-2gTp.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_index_no_ext
 
@@ -654,53 +654,53 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/packagejson/test_package_json_browser_issue2002_a
 
-- entry-!~{000}~.mjs => entry-Grp4OUuD.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-Grp4OUuD.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_issue2002_c
 
-- entry-!~{000}~.mjs => entry-aKM4d5_j.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-aKM4d5_j.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_avoid_missing
 
-- entry-!~{000}~.mjs => entry-9gRlHDBF.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-9gRlHDBF.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_module_disabled
 
-- entry-!~{000}~.mjs => entry-KD3UkCYm.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-KD3UkCYm.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_module_to_module
 
-- entry-!~{000}~.mjs => entry-uq7lnRgH.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-uq7lnRgH.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_module_to_relative
 
-- entry-!~{000}~.mjs => entry-krnhGpEH.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-krnhGpEH.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_native_module_disabled
 
-- entry-!~{000}~.mjs => entry-RHnxONui.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-RHnxONui.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_relative_disabled
 
-- entry-!~{000}~.mjs => entry-yMqIooMO.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-yMqIooMO.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_relative_to_module
 
-- entry-!~{000}~.mjs => entry-tva7ZXBf.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-tva7ZXBf.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_relative_to_relative
 
-- entry-!~{000}~.mjs => entry-xi9VMMro.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-xi9VMMro.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_no_ext
 
@@ -716,23 +716,23 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/packagejson/test_package_json_browser_over_main_node
 
-- entry-!~{000}~.mjs => entry-UoUzFxo1.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-UoUzFxo1.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_over_module_browser
 
-- entry-!~{000}~.mjs => entry-JIbWuyj_.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-JIbWuyj_.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_string
 
-- entry-!~{000}~.mjs => entry-n64V-Zp8.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-n64V-Zp8.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_with_main_node
 
-- entry-!~{000}~.mjs => entry-UoUzFxo1.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-UoUzFxo1.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_with_module_browser
 
@@ -740,38 +740,38 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/packagejson/test_package_json_disabled_type_module_issue3367
 
-- entry-!~{000}~.mjs => entry-RaFWGttt.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-RaFWGttt.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_browser
 
-- entry-!~{000}~.mjs => entry-3nf6Oa_i.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-3nf6Oa_i.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_force_module_before_main
 
-- entry-!~{000}~.mjs => entry-Betafk68.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-Betafk68.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_implicit_main
 
-- entry-!~{000}~.mjs => entry-Wo3WOs45.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-Wo3WOs45.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main
 
-- entry-!~{000}~.mjs => entry-Wo3WOs45.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-Wo3WOs45.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_same_file
 
-- entry-!~{000}~.mjs => entry-zxGCGekR.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-zxGCGekR.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_separate_files
 
-- entry-!~{000}~.mjs => entry-Betafk68.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-Betafk68.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_only
 
@@ -779,8 +779,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_require_only
 
-- entry-!~{000}~.mjs => entry-o5R7C6Po.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-o5R7C6Po.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_browser
 
@@ -807,8 +807,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/packagejson/test_package_json_exports_import_over_require
 
-- entry-!~{000}~.mjs => entry-bSaTO-KK.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-bSaTO-KK.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_neutral
 
@@ -832,8 +832,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/packagejson/test_package_json_exports_require_over_import
 
-- entry-!~{000}~.mjs => entry-RPehkXQS.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-RPehkXQS.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_wildcard
 
@@ -849,13 +849,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/packagejson/test_package_json_import_self_using_require
 
-- entry-!~{000}~.mjs => entry-JwFzZT2I.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-JwFzZT2I.mjs
 
 # tests/esbuild/packagejson/test_package_json_import_self_using_require_scoped
 
-- entry-!~{000}~.mjs => entry-JwFzZT2I.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-JwFzZT2I.mjs
 
 # tests/esbuild/packagejson/test_package_json_imports
 
@@ -871,13 +871,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/packagejson/test_package_json_main
 
-- entry-!~{000}~.mjs => entry-ZJ_oxjPL.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-ZJ_oxjPL.mjs
 
 # tests/esbuild/packagejson/test_package_json_main_fields_a
 
-- entry-!~{000}~.mjs => entry-ruZ1xbOz.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-ruZ1xbOz.mjs
 
 # tests/esbuild/packagejson/test_package_json_main_fields_b
 
@@ -889,8 +889,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/packagejson/test_package_json_neutral_explicit_main_fields
 
-- entry-!~{000}~.mjs => entry-UoUzFxo1.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-UoUzFxo1.mjs
 
 # tests/esbuild/splitting/assign-to-local
 
@@ -901,8 +901,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 # tests/esbuild/splitting/circular_reference_issue251
 
 - a-!~{000}~.mjs => a-Dp0eN-ZJ.mjs
-- b-!~{001}~.mjs => b-r-rPquvC.mjs
 - a~1-!~{002}~.mjs => a~1-1QJJkgOj.mjs
+- b-!~{001}~.mjs => b-r-rPquvC.mjs
 
 # tests/esbuild/splitting/cross_chunk_assignment_dependencies
 
@@ -913,28 +913,28 @@ expression: "snapshot_outputs.join(\"\\n\")"
 # tests/esbuild/splitting/duplicate_chunk_collision
 
 - a-!~{000}~.mjs => a-_w0taR1b.mjs
+- ab-!~{004}~.mjs => ab-cKY-d3KL.mjs
 - b-!~{001}~.mjs => b-olkBUWGd.mjs
 - c-!~{002}~.mjs => c-nB1waE7L.mjs
 - d-!~{003}~.mjs => d-23u0z093.mjs
 - d~1-!~{005}~.mjs => d~1-ot8CcU_S.mjs
-- ab-!~{004}~.mjs => ab-cKY-d3KL.mjs
 
 # tests/esbuild/splitting/dynamic-commonjs-into-es6
 
-- main-!~{000}~.mjs => main-hJ-rtw7N.mjs
-- foo-!~{001}~.mjs => foo-6VLOUb_v.mjs
 - $runtime$-!~{002}~.mjs => $runtime$-evkBfY1S.mjs
+- foo-!~{001}~.mjs => foo-6VLOUb_v.mjs
+- main-!~{000}~.mjs => main-hJ-rtw7N.mjs
 
 # tests/esbuild/splitting/dynamic-es6-into-es6
 
-- main-!~{000}~.mjs => main-aZfKZWQl.mjs
 - foo-!~{001}~.mjs => foo-y4QWWTtX.mjs
+- main-!~{000}~.mjs => main-aZfKZWQl.mjs
 
 # tests/esbuild/splitting/dynamic_and_not_dynamic_es6_into_es6
 
-- main-!~{000}~.mjs => main-8i8JF42P.mjs
 - foo-!~{001}~.mjs => foo-O6enMBv0.mjs
 - foo~1-!~{002}~.mjs => foo~1-Sof3A-nJ.mjs
+- main-!~{000}~.mjs => main-8i8JF42P.mjs
 
 # tests/esbuild/splitting/dynamic_import_issue_272
 
@@ -943,10 +943,10 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/splitting/hybrid_esm_and_cjs_issue617
 
-- a-!~{000}~.mjs => a-j8sPFyQR.mjs
-- b-!~{001}~.mjs => b-37AHhNXO.mjs
 - $runtime$-!~{003}~.mjs => $runtime$-6upNuhUk.mjs
+- a-!~{000}~.mjs => a-j8sPFyQR.mjs
 - a~1-!~{002}~.mjs => a~1-dKuKLwqf.mjs
+- b-!~{001}~.mjs => b-37AHhNXO.mjs
 
 # tests/esbuild/splitting/nested_directories
 
@@ -957,14 +957,14 @@ expression: "snapshot_outputs.join(\"\\n\")"
 # tests/esbuild/splitting/re_export_issue273
 
 - a-!~{000}~.mjs => a-h6hliDTl.mjs
-- b-!~{001}~.mjs => b-tekxdp99.mjs
 - a~1-!~{002}~.mjs => a~1-bC-OZCUw.mjs
+- b-!~{001}~.mjs => b-tekxdp99.mjs
 
 # tests/esbuild/splitting/shared-commonjs-into-es6
 
+- $runtime$-!~{003}~.mjs => $runtime$-t9w3LEYM.mjs
 - a-!~{000}~.mjs => a-UW6CzJN7.mjs
 - b-!~{001}~.mjs => b-h6eR_jS-.mjs
-- $runtime$-!~{003}~.mjs => $runtime$-t9w3LEYM.mjs
 - shared-!~{002}~.mjs => shared-He95S4k_.mjs
 
 # tests/esbuild/splitting/shared-es6-into-es6
@@ -981,97 +981,97 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/cjs_compat/basic_commonjs
 
-- main-!~{000}~.mjs => main-tOFH7NRF.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-KMO3JWcm.mjs
+- main-!~{000}~.mjs => main-tOFH7NRF.mjs
 
 # tests/fixtures/cjs_compat/cjs_entry
 
-- main-!~{000}~.mjs => main-MsyS7r4B.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-MsyS7r4B.mjs
 
 # tests/fixtures/cjs_compat/dynamic_cjs_entry
 
-- main-!~{000}~.mjs => main-_stJcfO2.mjs
-- cjs-!~{001}~.mjs => cjs-qtrxQfWU.mjs
 - $runtime$-!~{002}~.mjs => $runtime$-evkBfY1S.mjs
+- cjs-!~{001}~.mjs => cjs-qtrxQfWU.mjs
+- main-!~{000}~.mjs => main-_stJcfO2.mjs
 
 # tests/fixtures/cjs_compat/empty_file_should_be_treated_as_cjs/import
 
-- main-!~{000}~.mjs => main-JBLAWjNs.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-JBLAWjNs.mjs
 
 # tests/fixtures/cjs_compat/empty_file_should_be_treated_as_cjs/re_export
 
-- main-!~{000}~.mjs => main-JBLAWjNs.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-JBLAWjNs.mjs
 
 # tests/fixtures/cjs_compat/esm_require_cjs
 
-- main-!~{000}~.mjs => main-z04rJP3L.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-z04rJP3L.mjs
 
 # tests/fixtures/cjs_compat/esm_require_esm
 
-- main-!~{000}~.mjs => main-t5PgBB84.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- main-!~{000}~.mjs => main-t5PgBB84.mjs
 
 # tests/fixtures/cjs_compat/esm_require_esm_unused
 
-- main-!~{000}~.mjs => main-CbjTMjYQ.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- main-!~{000}~.mjs => main-CbjTMjYQ.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
 
-- main-!~{000}~.mjs => main-H9ncXSC9.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-H9ncXSC9.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import
 
-- main-!~{000}~.mjs => main-ejVOFsTW.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-ejVOFsTW.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
 
-- main-!~{000}~.mjs => main-TYCnsom9.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-Mp5R-3C4.mjs
+- main-!~{000}~.mjs => main-TYCnsom9.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
 
-- main-!~{000}~.mjs => main-Wj2uMhoR.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-Mp5R-3C4.mjs
+- main-!~{000}~.mjs => main-Wj2uMhoR.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
 
-- main-!~{000}~.mjs => main-uVU2cC_l.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-uVU2cC_l.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport
 
-- main-!~{000}~.mjs => main-J_oJ8eiV.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-J_oJ8eiV.mjs
 
 # tests/fixtures/cjs_compat/import_the_same_cjs_twice
 
-- main-!~{000}~.mjs => main-rIpTdR-D.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-rIpTdR-D.mjs
 
 # tests/fixtures/cjs_compat/mix-cjs-esm
 
-- main-kq71YIv7.mjs.map
-- main-!~{000}~.mjs => main-kq71YIv7.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-kq71YIv7.mjs
+- main-kq71YIv7.mjs.map
 
 # tests/fixtures/cjs_compat/multiple_circle_cjs_entries
 
-- a-!~{000}~.mjs => a-9Ad2JmEm.mjs
-- b-!~{001}~.mjs => b-6r3tQdv6.mjs
 - $runtime$-!~{003}~.mjs => $runtime$-jJEZqZu9.mjs
+- a-!~{000}~.mjs => a-9Ad2JmEm.mjs
 - a~1-!~{002}~.mjs => a~1-XBjiwYTN.mjs
+- b-!~{001}~.mjs => b-6r3tQdv6.mjs
 
 # tests/fixtures/cjs_compat/reexport_commonjs
 
-- main-!~{000}~.mjs => main-gBopYCj6.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-K_l5acij.mjs
+- main-!~{000}~.mjs => main-gBopYCj6.mjs
 
 # tests/fixtures/cjs_compat/require/create_require
 
@@ -1079,28 +1079,28 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/cjs_compat/require/require_cjs
 
-- main-k19F6glY.mjs.map
-- main-!~{000}~.mjs => main-k19F6glY.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-k19F6glY.mjs
+- main-k19F6glY.mjs.map
 
 # tests/fixtures/cjs_compat/require/require_esm
 
-- main-OJfTTu7b.mjs.map
-- main-!~{000}~.mjs => main-OJfTTu7b.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-FWY5Q29P.mjs
+- main-!~{000}~.mjs => main-OJfTTu7b.mjs
+- main-OJfTTu7b.mjs.map
 
 # tests/fixtures/code_splitting/basic
 
+- dynamic-!~{003}~.mjs => dynamic-pSjS7MtL.mjs
 - main1-!~{000}~.mjs => main1-viOQYRtE.mjs
 - main2-!~{001}~.mjs => main2-nzEnxP0_.mjs
-- dynamic-!~{003}~.mjs => dynamic-pSjS7MtL.mjs
 - share-!~{002}~.mjs => share-MuWQnCcv.mjs
 
 # tests/fixtures/code_splitting/ensure_side_effect_executed
 
-- entry_js-!~{000}~.mjs => entry_js-aMrgARrj.mjs
-- entry2_js-!~{001}~.mjs => entry2_js-ENf4Z9xp.mjs
 - entry-!~{002}~.mjs => entry-FYNiGCEm.mjs
+- entry2_js-!~{001}~.mjs => entry2_js-ENf4Z9xp.mjs
+- entry_js-!~{000}~.mjs => entry_js-aMrgARrj.mjs
 
 # tests/fixtures/code_splitting/ensure_side_effect_executed2
 
@@ -1114,43 +1114,43 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/deconflict/basic_scoped
 
-- main-U0xUKBal.mjs.map
 - main-!~{000}~.mjs => main-U0xUKBal.mjs
+- main-U0xUKBal.mjs.map
 
 # tests/fixtures/deconflict/complex_params_patterns
 
-- main-6AAXrAGx.mjs.map
 - main-!~{000}~.mjs => main-6AAXrAGx.mjs
+- main-6AAXrAGx.mjs.map
 
 # tests/fixtures/deconflict/conflict_between_global_and_local_binding
 
-- main-!~{000}~.mjs => main-tOEcGaC9.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-tOEcGaC9.mjs
 
 # tests/fixtures/deconflict/conflict_between_imported_and_local_binding
 
-- main-!~{000}~.mjs => main-UgkBYeKd.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-UgkBYeKd.mjs
 
 # tests/fixtures/deconflict/decl_complex_patterns
 
-- main-Qx1dhUrw.mjs.map
 - main-!~{000}~.mjs => main-Qx1dhUrw.mjs
+- main-Qx1dhUrw.mjs.map
 
 # tests/fixtures/deconflict/decl_nested_assign_pattern
 
-- main-12nbvJy_.mjs.map
 - main-!~{000}~.mjs => main-12nbvJy_.mjs
+- main-12nbvJy_.mjs.map
 
 # tests/fixtures/deconflict/default_function
 
-- main-mCrUgOwW.mjs.map
 - main-!~{000}~.mjs => main-mCrUgOwW.mjs
+- main-mCrUgOwW.mjs.map
 
 # tests/fixtures/deconflict/issue_364
 
-- main-ivEW-tP0.mjs.map
 - main-!~{000}~.mjs => main-ivEW-tP0.mjs
+- main-ivEW-tP0.mjs.map
 
 # tests/fixtures/deconflict/reserved_names
 
@@ -1158,15 +1158,15 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/deconflict/wrapped_esm_default_function
 
-- main-Hwm0PQEH.mjs.map
-- main-!~{000}~.mjs => main-Hwm0PQEH.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- main-!~{000}~.mjs => main-Hwm0PQEH.mjs
+- main-Hwm0PQEH.mjs.map
 
 # tests/fixtures/deconflict/wrapped_esm_export_named_function
 
-- main-puld6Obw.mjs.map
-- main-!~{000}~.mjs => main-puld6Obw.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- main-!~{000}~.mjs => main-puld6Obw.mjs
+- main-puld6Obw.mjs.map
 
 # tests/fixtures/errors/unresolved_entry
 
@@ -1189,14 +1189,14 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/function/external/splitting_with_external_module
 
-- main-!~{000}~.mjs => main-1dgL9psc.mjs
 - entry-!~{001}~.mjs => entry-ahgOZOc1.mjs
+- main-!~{000}~.mjs => main-1dgL9psc.mjs
 - share-!~{002}~.mjs => share-eIGIrVeP.mjs
 
 # tests/fixtures/function/resolve/browser_filed_false
 
-- package-!~{000}~.mjs => package-ukXkR4ik.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
+- package-!~{000}~.mjs => package-ukXkR4ik.mjs
 
 # tests/fixtures/function/resolve/node_modules_as_entries
 
@@ -1208,8 +1208,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/function/resolve/should_resolve_to_different_target_for_import_and_require
 
-- main-!~{000}~.mjs => main-CPUBIUg1.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-CPUBIUg1.mjs
 
 # tests/fixtures/function/shim_missing_exports/basic
 
@@ -1217,8 +1217,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/function/shim_missing_exports/basic_wrapped_esm
 
-- main-!~{000}~.mjs => main-F_sBnFAO.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-FWY5Q29P.mjs
+- main-!~{000}~.mjs => main-F_sBnFAO.mjs
 
 # tests/fixtures/function/shim_missing_exports/shake_unused_shimmed_exports
 
@@ -1234,19 +1234,19 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/issues/122/a
 
+- b-!~{003}~.mjs => b-91ZliBhV.mjs
+- c-!~{004}~.mjs => c-XewjZoRS.mjs
 - entry1-!~{000}~.mjs => entry1-_fcFnBsf.mjs
 - entry2-!~{001}~.mjs => entry2-HA1lKBk8.mjs
 - entry3-!~{002}~.mjs => entry3-bRT67heJ.mjs
-- c-!~{004}~.mjs => c-XewjZoRS.mjs
-- b-!~{003}~.mjs => b-91ZliBhV.mjs
 
 # tests/fixtures/issues/122/b
 
+- 1-!~{004}~.mjs => 1-Hl9Rv5WQ.mjs
+- 2-!~{003}~.mjs => 2-BzwAbMwC.mjs
 - a-!~{000}~.mjs => a-9ZdsWyCX.mjs
 - b-!~{001}~.mjs => b-Ryq1zljY.mjs
 - c-!~{002}~.mjs => c-Q0kP-AMp.mjs
-- 1-!~{004}~.mjs => 1-Hl9Rv5WQ.mjs
-- 2-!~{003}~.mjs => 2-BzwAbMwC.mjs
 
 # tests/fixtures/misc/ambiguous_star_export
 
@@ -1254,8 +1254,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/misc/basic
 
-- main-xHsOP41Q.mjs.map
 - main-!~{000}~.mjs => main-xHsOP41Q.mjs
+- main-xHsOP41Q.mjs.map
 
 # tests/fixtures/misc/basic_re_export
 
@@ -1263,9 +1263,9 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/misc/cjs_entry_as_dependency
 
+- $runtime$-!~{003}~.mjs => $runtime$-jJEZqZu9.mjs
 - main-!~{000}~.mjs => main-Mmg8ggdg.mjs
 - main2-!~{001}~.mjs => main2-L_rA1thF.mjs
-- $runtime$-!~{003}~.mjs => $runtime$-jJEZqZu9.mjs
 - main2~1-!~{002}~.mjs => main2~1-BsWPA0bS.mjs
 
 # tests/fixtures/misc/duplicate_entries
@@ -1276,8 +1276,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/misc/generate_valid_name_for_kebab_case_files
 
-- main-!~{000}~.mjs => main-VbkdPg3x.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-VbkdPg3x.mjs
 
 # tests/fixtures/misc/issue_376
 
@@ -1285,15 +1285,15 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/misc/object_shorthand_property
 
-- main-Iv9FQrYJ.mjs.map
 - main-!~{000}~.mjs => main-Iv9FQrYJ.mjs
+- main-Iv9FQrYJ.mjs.map
 
 # tests/fixtures/misc/reexport_star
 
-- main-!~{000}~.mjs => main-c0M85IIk.mjs
-- entry-!~{001}~.mjs => entry-vrwZ1g79.mjs
 - $runtime$-!~{003}~.mjs => $runtime$-Zk8jAI88.mjs
 - a-!~{002}~.mjs => a-FuDtRKXi.mjs
+- entry-!~{001}~.mjs => entry-vrwZ1g79.mjs
+- main-!~{000}~.mjs => main-c0M85IIk.mjs
 
 # tests/fixtures/misc/reexport_star_from_local_named_export
 
@@ -1301,9 +1301,9 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/misc/wrapped_esm
 
-- main-qrJngkK5.mjs.map
-- main-!~{000}~.mjs => main-qrJngkK5.mjs
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
+- main-!~{000}~.mjs => main-qrJngkK5.mjs
+- main-qrJngkK5.mjs.map
 
 # tests/fixtures/rollup/assignment-patterns
 

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -4,13 +4,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 ---
 # tests/esbuild/dce/base64_loader_remove_unused
 
-- entry_js-wRZBj5xW.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-rJVnsVA9.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/dce/data_url_loader_remove_unused
 
-- entry_js-wRZBj5xW.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-rJVnsVA9.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/dce/dce_template_literal
 
@@ -30,13 +30,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/dce/file_loader_remove_unused
 
-- entry_js-wRZBj5xW.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-rJVnsVA9.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/dce/import_re_export_of_namespace_import
 
-- entry_js-QP_Mrok_.mjs
-- $runtime$-IK9Iyt2s.mjs
+- entry_js-FlDMXACr.mjs
+- $runtime$--hm3E9-w.mjs
 
 # tests/esbuild/dce/inline_function_call_for_init_decl
 
@@ -56,8 +56,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/dce/text_loader_remove_unused
 
-- entry_js-NeyAh0wX.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-0fLA_3YA.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/dce/tree_shaking_binary_operators
 
@@ -65,13 +65,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/dce/tree_shaking_import_identifier
 
-- entry_js-7PcFFuL3.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-20_PQzF_.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/dce/tree_shaking_in_esm_wrapper
 
-- entry_js-cAq-Z1Y4.mjs
-- $runtime$-Z-c-hKoo.mjs
+- entry_js-IQEHRYOn.mjs
+- $runtime$-ZIDpBgQ2.mjs
 
 # tests/esbuild/dce/tree_shaking_unary_operators
 
@@ -99,12 +99,17 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/common_js_from_es6
 
-- entry_js-JJnM0w-y.mjs
-- $runtime$-Z-c-hKoo.mjs
+- entry_js-dz7OZAOJ.mjs
+- $runtime$-ZIDpBgQ2.mjs
 
 # tests/esbuild/default/const_with_let
 
 - entry_js-d1sNq3Xh.mjs
+
+# tests/esbuild/default/dot_import
+
+- entry_js-VjWmXPdB.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/default/duplicate_entry_point
 
@@ -112,15 +117,19 @@ expression: "snapshot_outputs.join(\"\\n\")"
 - entry2_js-retlWIJI.mjs
 - entry-PLV8EjsS.mjs
 
+# tests/esbuild/default/dynamic_import_with_expression_cjs
+
+- a_js--H6Kq6u1.cjs
+
 # tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910
 
-- entry_js-Fb0cs2MR.mjs
-- $runtime$-pI7lnPPu.mjs
+- entry_js-itX00WBi.mjs
+- $runtime$-F3klwW2A.mjs
 
 # tests/esbuild/default/es6_from_common_js
 
-- entry_js-alr1VI_I.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-inpBlmaj.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/default/export_chain
 
@@ -128,22 +137,30 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/export_forms_common_js
 
-- entry_js-pkODD-uo.mjs
-- $runtime$-Z-c-hKoo.mjs
+- entry_js-n99h6_AS.mjs
+- $runtime$-ZIDpBgQ2.mjs
 
 # tests/esbuild/default/export_forms_es6
 
-- entry_js-EnnaaOzj.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-4OJt4SMQ.mjs
+- $runtime$-LTBR7hwr.mjs
+
+# tests/esbuild/default/external_packages
+
+- entry_js-R_nBuZfH.mjs
 
 # tests/esbuild/default/forbid_const_assign_when_bundling
 
 - entry_js-eHT9gvE6.mjs
 
+# tests/esbuild/default/import_fs_node_common_js
+
+- entry_js-amqS_cwv.cjs
+
 # tests/esbuild/default/import_missing_common_js
 
-- entry_js-V5CIq315.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-ghp66N9t.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/default/import_then_catch
 
@@ -155,13 +172,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/nested_common_js
 
-- entry_js-VR_Z4xQM.mjs
-- $runtime$-UXfAy_R1.mjs
+- entry_js-hWpK256x.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/esbuild/default/nested_es6_from_common_js
 
-- entry_js-EuWryN5n.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-lbtddFCW.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/default/nested_require_without_call
 
@@ -173,8 +190,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/new_expression_common_js
 
-- entry_js-Tn2EAjWy.mjs
-- $runtime$-UXfAy_R1.mjs
+- entry_js-VGc5eaRo.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/esbuild/default/no_overwrite_input_file_error
 
@@ -191,8 +208,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/re_export_common_js_as_es6
 
-- entry_js-_dCFhw47.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-r0pkvMzG.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/default/re_export_default_internal
 
@@ -204,8 +221,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/require_child_dir_common_js
 
-- entry_js-hotXWPdm.mjs
-- $runtime$-UXfAy_R1.mjs
+- entry_js-rt6NcNNH.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/esbuild/default/require_child_dir_es6
 
@@ -213,13 +230,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/require_main_cache_common_js
 
-- entry_js-EncpfrJv.mjs
-- $runtime$-UXfAy_R1.mjs
+- entry_js-cN8LCxFM.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/esbuild/default/require_parent_dir_common_js
 
-- dir_entry_js-iYyW26rz.mjs
-- $runtime$-UXfAy_R1.mjs
+- dir_entry_js-rUmw4j2g.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/esbuild/default/require_parent_dir_es6
 
@@ -235,8 +252,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/require_with_call_inside_try
 
-- entry_js-UoF-GCJ1.mjs
-- $runtime$-UXfAy_R1.mjs
+- entry_js-jqgFQJMV.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/esbuild/default/require_without_call
 
@@ -252,8 +269,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/simple_common_js
 
-- entry_js-2acdTi1M.mjs
-- $runtime$-UXfAy_R1.mjs
+- entry_js-4hLD5gio.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/esbuild/default/simple_es6
 
@@ -273,8 +290,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/default/use_strict_directive_bundle_issue1837
 
-- entry_js-FHLXHsXC.mjs
-- $runtime$-UXfAy_R1.mjs
+- entry_js-dutYZUjh.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/esbuild/default/var_relocating_bundle
 
@@ -286,22 +303,31 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/export_self_as_namespace_es6
 
-- entry_js-SSzW-3uT.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-wR--ATA3.mjs
+- $runtime$-LTBR7hwr.mjs
+
+# tests/esbuild/import_star/export_self_common_js
+
+- entry_js-_TR1-BWY.cjs
 
 # tests/esbuild/import_star/export_self_es6
 
 - entry_js-nvU10OVq.mjs
 
+# tests/esbuild/import_star/import_export_other_as_namespace_common_js
+
+- entry_js-w_r3ZwWo.mjs
+- $runtime$-5vmYXDA_.mjs
+
 # tests/esbuild/import_star/import_export_self_as_namespace_es6
 
-- entry_js-SSzW-3uT.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-wR--ATA3.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_export_star_ambiguous_warning
 
-- entry_js-f7J5Bk7l.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-ZhPELjfZ.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_of_export_star
 
@@ -311,40 +337,45 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - entry_js-oagxpBfe.mjs
 
+# tests/esbuild/import_star/import_self_common_js
+
+- entry_js-oSfzDpJq.mjs
+- $runtime$-5vmYXDA_.mjs
+
 # tests/esbuild/import_star/import_star_and_common_js
 
-- entry_js-cJDp2q9k.mjs
-- $runtime$-Z-c-hKoo.mjs
+- entry_js-9gi2MYjo.mjs
+- $runtime$-ZIDpBgQ2.mjs
 
 # tests/esbuild/import_star/import_star_capture
 
-- entry_js-CK8ZS88o.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-Iwd3SCAO.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_star_common_js_capture
 
-- entry_js-5CRD1DXq.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-md5oqP5u.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/import_star/import_star_common_js_no_capture
 
-- entry_js-hv_DZYju.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-aGFIfNqq.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/import_star/import_star_common_js_unused
 
-- entry_js-4GzQ6wdf.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-sVlgQwZF.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_capture
 
-- entry_js-CK8ZS88o.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-Iwd3SCAO.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_no_capture
 
-- entry_js-sQCkSUP8.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-zIkCGGpk.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_unused
 
@@ -352,33 +383,33 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/import_star_export_star_as_capture
 
-- entry_js-CK8ZS88o.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-Iwd3SCAO.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_star_export_star_as_no_capture
 
-- entry_js-sQCkSUP8.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-zIkCGGpk.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_star_export_star_as_unused
 
-- entry_js-O_1O1ARU.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-YJn8_j1E.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_star_export_star_capture
 
-- entry_js-1xv8mngn.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-MQR2k0oo.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_star_export_star_no_capture
 
-- entry_js-_fTafR_z.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-0TPB_mr9.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_star_export_star_omit_ambiguous
 
-- entry_js-_e97A4iG.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-xfuL6sQJ.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_star_export_star_unused
 
@@ -386,13 +417,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/import_star_no_capture
 
-- entry_js-sQCkSUP8.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-zIkCGGpk.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_star_of_export_star_as
 
-- entry_js-9iB-WT_T.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-JLrC0oPm.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/import_star_unused
 
@@ -400,43 +431,43 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/issue176
 
-- entry_js-41ioCbxo.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-sZwUOJ8J.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/namespace_import_missing_common_js
 
-- entry_js-sdT7CaES.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-dOd3h6cr.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/import_star/namespace_import_missing_es6
 
-- entry_js-i_jTUTv7.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-C_y1eGe9.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/namespace_import_re_export_star_missing_es6
 
-- entry_js-FDHnHMA9.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-Trm2Ztpt.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/namespace_import_re_export_star_unused_missing_es6
 
-- entry_js-lS9HG4kP.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-ADCyEr_z.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/namespace_import_unused_missing_common_js
 
-- entry_js-9GYfTiAV.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-WuniMYOu.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/import_star/namespace_import_unused_missing_es6
 
-- entry_js-KaZsNW-d.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-5BKj3Zn3.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6
 
-- entry_js-JYDUAw4m.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-88mBc_xT.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/other_file_import_export_self_as_namespace_unused_es6
 
@@ -444,23 +475,40 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/re_export_namespace_import_missing_es6
 
-- entry_js-1n2UqwtF.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-0JbtI7Kp.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/re_export_namespace_import_unused_missing_es6
 
-- entry_js-wEPz_mQy.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-y65k3F21.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/re_export_other_file_export_self_as_namespace_es6
 
-- entry_js-3nwG86I-.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-e_21exxw.mjs
+- $runtime$-LTBR7hwr.mjs
 
 # tests/esbuild/import_star/re_export_other_file_import_export_self_as_namespace_es6
 
-- entry_js-3nwG86I-.mjs
-- $runtime$-q_K1VDSH.mjs
+- entry_js-e_21exxw.mjs
+- $runtime$-LTBR7hwr.mjs
+
+# tests/esbuild/import_star/re_export_star_as_external_common_js
+
+- entry_js-ExSCpg1O.cjs
+
+# tests/esbuild/import_star/re_export_star_as_external_es6
+
+- entry_js-1V20XJym.mjs
+
+# tests/esbuild/import_star/re_export_star_entry_point_and_inner_file
+
+- entry_js-mZtOu9jr.mjs
+- $runtime$-LTBR7hwr.mjs
+
+# tests/esbuild/import_star/re_export_star_external_common_js
+
+- entry_js-MRQxE4Fa.cjs
 
 # tests/esbuild/import_star/re_export_star_external_es6
 
@@ -482,16 +530,379 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - entry_js-xwGRq5T_.mjs
 
-# tests/esbuild/packagejson/main
+# tests/esbuild/lower/lower_async_es5
 
-- entry-PddIz6eA.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry_js-b0ZPZIig.mjs
+
+# tests/esbuild/lower/lower_async_this2016_common_js
+
+- entry_js-aQqFx9SN.mjs
+- $runtime$-dLAG8cVO.mjs
+
+# tests/esbuild/lower/lower_async_this2016_es6
+
+- entry_js-NPTCfsTm.mjs
+
+# tests/esbuild/lower/lower_for_await2015
+
+- entry_js-Z8GyVk22.mjs
+
+# tests/esbuild/lower/lower_for_await2017
+
+- entry_js-Z8GyVk22.mjs
+
+# tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493
+
+- entry_js-4hQJN7oL.mjs
+
+# tests/esbuild/lower/lower_private_class_accessor_order
+
+- entry_js-iVjUYHyh.mjs
+
+# tests/esbuild/lower/lower_private_class_brand_check_supported
+
+- entry_js-b0ZPZIig.mjs
+
+# tests/esbuild/lower/lower_private_class_brand_check_unsupported
+
+- entry_js-b0ZPZIig.mjs
+
+# tests/esbuild/lower/lower_private_class_field_order
+
+- entry_js-3Kcfybbw.mjs
+
+# tests/esbuild/lower/lower_private_class_field_static_issue1424
+
+- entry_js-ncENaqRA.mjs
+
+# tests/esbuild/lower/lower_private_class_method_order
+
+- entry_js-6jLBb9pP.mjs
+
+# tests/esbuild/lower/lower_private_class_static_accessor_order
+
+- entry_js-brZcjb57.mjs
+
+# tests/esbuild/lower/lower_private_class_static_field_order
+
+- entry_js-r2i8mfKU.mjs
+
+# tests/esbuild/lower/lower_private_class_static_method_order
+
+- entry_js-qESAUnA0.mjs
+
+# tests/esbuild/lower/lower_private_getter_setter2015
+
+- entry_js-YOc6RuZ1.mjs
+
+# tests/esbuild/lower/lower_private_getter_setter2019
+
+- entry_js-YOc6RuZ1.mjs
+
+# tests/esbuild/lower/lower_private_getter_setter2020
+
+- entry_js-YOc6RuZ1.mjs
+
+# tests/esbuild/lower/lower_private_getter_setter_next
+
+- entry_js-YOc6RuZ1.mjs
+
+# tests/esbuild/lower/lower_private_method2019
+
+- entry_js-7BN_aezx.mjs
+
+# tests/esbuild/lower/lower_private_method2020
+
+- entry_js-7BN_aezx.mjs
+
+# tests/esbuild/lower/lower_private_method_next
+
+- entry_js-7BN_aezx.mjs
+
+# tests/esbuild/lower/lower_private_method_with_modifiers2020
+
+- entry_js-TgKAvwGb.mjs
+
+# tests/esbuild/lower/lower_private_super_static_bundle_issue2158
+
+- entry_js-ROaZh-2S.mjs
+
+# tests/esbuild/lower/lower_reg_exp_name_collision
+
+- entry_js-SMVXimBu.mjs
+
+# tests/esbuild/lower/lower_template_object
+
+- entry_js-b0ZPZIig.mjs
+
+# tests/esbuild/lower/static_class_block_es2021
+
+- entry_js-qxotrxek.mjs
+
+# tests/esbuild/lower/static_class_block_es_next
+
+- entry_js-qxotrxek.mjs
+
+# tests/esbuild/packagejson/test_package_json_bad_main
+
+- entry-kmKFvDhA.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_index_no_ext
+
+- entry-_pHjhmHK.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_issue2002_a
+
+- entry--XlDW28x.mjs
+- $runtime$-dLAG8cVO.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_issue2002_c
+
+- entry-4WIqDoey.mjs
+- $runtime$-dLAG8cVO.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_map_avoid_missing
+
+- entry-qa3H14Dh.mjs
+- $runtime$-dLAG8cVO.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_map_module_disabled
+
+- entry-PjpOAspQ.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_map_module_to_module
+
+- entry-ewkAn3Nc.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_map_module_to_relative
+
+- entry-cwEZJvXL.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_map_native_module_disabled
+
+- entry-81vL3n-T.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_map_relative_disabled
+
+- entry-E7c4wZHe.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_map_relative_to_module
+
+- entry-2p2hTf0c.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_map_relative_to_relative
+
+- entry-NtjRy-Fn.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_no_ext
+
+- entry-iMmnB9H4.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_node_modules_index_no_ext
+
+- entry-XnlGkdGQ.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_node_modules_no_ext
+
+- entry-O-zJT0JW.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_over_main_node
+
+- entry-exxtr1AE.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_over_module_browser
+
+- entry-hlr6VjQh.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_string
+
+- entry-jn81TLjy.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_with_main_node
+
+- entry-exxtr1AE.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_browser_with_module_browser
+
+- entry-E-JeC86s.mjs
+
+# tests/esbuild/packagejson/test_package_json_disabled_type_module_issue3367
+
+- entry--M595VdO.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_browser
+
+- entry-4neC08JR.mjs
+- $runtime$-ZIDpBgQ2.mjs
+
+# tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_force_module_before_main
+
+- entry-KkEUt8lT.mjs
+- $runtime$-ZIDpBgQ2.mjs
+
+# tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_implicit_main
+
+- entry-PnzIDC2_.mjs
+- $runtime$-ZIDpBgQ2.mjs
+
+# tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main
+
+- entry-PnzIDC2_.mjs
+- $runtime$-ZIDpBgQ2.mjs
+
+# tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_same_file
+
+- entry-bz0BI4Dv.mjs
+- $runtime$-ZIDpBgQ2.mjs
+
+# tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_separate_files
+
+- entry-KkEUt8lT.mjs
+- $runtime$-ZIDpBgQ2.mjs
+
+# tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_only
+
+- entry-5sx4P-Fg.mjs
+
+# tests/esbuild/packagejson/test_package_json_dual_package_hazard_require_only
+
+- entry-r6q5F2NV.mjs
+- $runtime$-ZIDpBgQ2.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_browser
+
+- entry-7DRd-tfc.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_custom_conditions
+
+- entry-OwhoOCiW.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_entry_point_import_over_require
+
+- entry-YV5IjBHI.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_entry_point_main_only
+
+- entry-DCCuZ_Wo.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_entry_point_module_over_main
+
+- entry-SL5TQRan.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_entry_point_require_only
+
+
+# tests/esbuild/packagejson/test_package_json_exports_import_over_require
+
+- entry-sOF97diL.mjs
+- $runtime$-dLAG8cVO.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_neutral
+
+- entry-x-g3eIN1.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_node
+
+- entry-vPKXwIeX.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_not_exact_missing_extension
+
+- entry-5TVDkMnq.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_order_independent
+
+- entry-IpafjFgb.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_pattern_trailers
+
+- entry-FCVuvTmc.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_require_over_import
+
+- entry-PkaBGtDO.mjs
+- $runtime$-dLAG8cVO.mjs
+
+# tests/esbuild/packagejson/test_package_json_exports_wildcard
+
+- entry-yOOoIugb.mjs
+
+# tests/esbuild/packagejson/test_package_json_import_self_using_import
+
+- entry-qqHliUX2.mjs
+
+# tests/esbuild/packagejson/test_package_json_import_self_using_import_scoped
+
+- entry-qqHliUX2.mjs
+
+# tests/esbuild/packagejson/test_package_json_import_self_using_require
+
+- entry-3d3HKLkH.mjs
+- $runtime$-dLAG8cVO.mjs
+
+# tests/esbuild/packagejson/test_package_json_import_self_using_require_scoped
+
+- entry-3d3HKLkH.mjs
+- $runtime$-dLAG8cVO.mjs
+
+# tests/esbuild/packagejson/test_package_json_imports
+
+- entry-kL61DuZW.mjs
+
+# tests/esbuild/packagejson/test_package_json_imports_error_unsupported_directory_import
+
+- entry-9sM5IAkg.mjs
+
+# tests/esbuild/packagejson/test_package_json_imports_remap_to_other_package
+
+- entry-hUJpovHm.mjs
+
+# tests/esbuild/packagejson/test_package_json_main
+
+- entry-iQA8V1TL.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_main_fields_a
+
+- entry-9C9J0TQf.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/esbuild/packagejson/test_package_json_main_fields_b
+
+- entry-_LUuVvEG.mjs
+
+# tests/esbuild/packagejson/test_package_json_module
+
+- entry-wHCbE-sb.mjs
+
+# tests/esbuild/packagejson/test_package_json_neutral_explicit_main_fields
+
+- entry-exxtr1AE.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/esbuild/splitting/assign-to-local
 
 - a-_XWSW13g.mjs
 - b-HJyK04H3.mjs
 - shared-j5Ff6q07.mjs
+
+# tests/esbuild/splitting/circular_reference_issue251
+
+- a-06r_PdWn.mjs
+- b-06r_PdWn.mjs
+- a~1-dqCWCsVV.mjs
 
 # tests/esbuild/splitting/cross_chunk_assignment_dependencies
 
@@ -510,13 +921,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/splitting/dynamic-commonjs-into-es6
 
-- main-ZqD8gjUh.mjs
-- foo-CU9PLCFM.mjs
-- $runtime$-UXfAy_R1.mjs
+- main-QDMELkDA.mjs
+- foo-_zE0LWAK.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/esbuild/splitting/dynamic-es6-into-es6
 
-- main-fBTrTgKH.mjs
+- main-QDMELkDA.mjs
 - foo-pnPcej-0.mjs
 
 # tests/esbuild/splitting/dynamic_and_not_dynamic_es6_into_es6
@@ -527,15 +938,15 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/splitting/dynamic_import_issue_272
 
-- a-5lVutzQC.mjs
+- a-0X-TgeL0.mjs
 - b-z3RcbbOY.mjs
 
 # tests/esbuild/splitting/hybrid_esm_and_cjs_issue617
 
-- a-eTzMFeQH.mjs
-- b-We39kZhF.mjs
-- $runtime$-Z-c-hKoo.mjs
-- a~1-baXnHtKD.mjs
+- a-fs0iQPCG.mjs
+- b-Y80Iyxv-.mjs
+- $runtime$-ZIDpBgQ2.mjs
+- a~1-z6alrqdX.mjs
 
 # tests/esbuild/splitting/nested_directories
 
@@ -551,10 +962,10 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/splitting/shared-commonjs-into-es6
 
-- a-3G5V_sCq.mjs
-- b-g8lVLaS_.mjs
-- $runtime$-UXfAy_R1.mjs
-- shared-j8ukAKFw.mjs
+- a-wte9JIL-.mjs
+- b-Ndbz6ZLO.mjs
+- $runtime$-dLAG8cVO.mjs
+- shared-ikIudKEq.mjs
 
 # tests/esbuild/splitting/shared-es6-into-es6
 
@@ -568,33 +979,119 @@ expression: "snapshot_outputs.join(\"\\n\")"
 - b-B232sYxN.mjs
 - shared-77sYuFdk.mjs
 
-# tests/fixtures/ambiguous_star_export
+# tests/fixtures/cjs_compat/basic_commonjs
 
-- main-oGb5soj4.mjs
+- main-YHuBn402.mjs
+- $runtime$-F6CY4o_B.mjs
 
-# tests/fixtures/basic
+# tests/fixtures/cjs_compat/cjs_entry
 
-- main-goKjyff3.mjs.map
-- main-goKjyff3.mjs
+- main-ZR9tr1bF.mjs
+- $runtime$-dLAG8cVO.mjs
 
-# tests/fixtures/basic_commonjs
+# tests/fixtures/cjs_compat/dynamic_cjs_entry
 
-- main-HSYhN_K3.mjs
-- $runtime$-76fOA9tz.mjs
+- main-KhBMeVG7.mjs
+- cjs-i1AIgVIr.mjs
+- $runtime$-dLAG8cVO.mjs
 
-# tests/fixtures/basic_re_export
+# tests/fixtures/cjs_compat/empty_file_should_be_treated_as_cjs/import
 
-- main-mO2iY3R-.mjs
+- main-e5orE-FE.mjs
+- $runtime$-5vmYXDA_.mjs
 
-# tests/fixtures/circular_depency
+# tests/fixtures/cjs_compat/empty_file_should_be_treated_as_cjs/re_export
 
-- entry-ppagLKlq.mjs
-- main-ppagLKlq.mjs
-- entry~1-b0ZPZIig.mjs
+- main-e5orE-FE.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/fixtures/cjs_compat/esm_require_cjs
+
+- main-TtC2gsl3.mjs
+- $runtime$-dLAG8cVO.mjs
+
+# tests/fixtures/cjs_compat/esm_require_esm
+
+- main-RIc2g_QF.mjs
+- $runtime$-ZIDpBgQ2.mjs
+
+# tests/fixtures/cjs_compat/esm_require_esm_unused
+
+- main-YBAUptxE.mjs
+- $runtime$-ZIDpBgQ2.mjs
+
+# tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
+
+- main-UX-F6GVI.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import
+
+- main-t2biWwo0.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
+
+- main-JdybNPQw.mjs
+- $runtime$-WN7OzxbL.mjs
+
+# tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
+
+- main-ZopvgqJP.mjs
+- $runtime$-WN7OzxbL.mjs
+
+# tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
+
+- main-q63vb5Nm.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport
+
+- main-uqc5s493.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/fixtures/cjs_compat/import_the_same_cjs_twice
+
+- main-1tj50rfy.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/fixtures/cjs_compat/mix-cjs-esm
+
+- main-6eCEXnHB.mjs.map
+- main-6eCEXnHB.mjs
+- $runtime$-5vmYXDA_.mjs
+
+# tests/fixtures/cjs_compat/multiple_circle_cjs_entries
+
+- a-6DjfXSbq.mjs
+- b-gCJEgCBf.mjs
+- $runtime$-5vmYXDA_.mjs
+- a~1-Q-syfFyB.mjs
+
+# tests/fixtures/cjs_compat/reexport_commonjs
+
+- main-hKEfE7qX.mjs
+- $runtime$-eZyUBTpH.mjs
+
+# tests/fixtures/cjs_compat/require/create_require
+
+- main-ITXL_U98.mjs
+
+# tests/fixtures/cjs_compat/require/require_cjs
+
+- main-11xSWPPu.mjs.map
+- main-11xSWPPu.mjs
+- $runtime$-dLAG8cVO.mjs
+
+# tests/fixtures/cjs_compat/require/require_esm
+
+- main-EpUdRyqk.mjs.map
+- main-EpUdRyqk.mjs
+- $runtime$-F3klwW2A.mjs
 
 # tests/fixtures/code_splitting/basic
 
-- main1-r-0MJL-5.mjs
+- main1-5jPUbVtE.mjs
 - main2-w_GNefeL.mjs
 - dynamic-GEHD338z.mjs
 - share-SOE6O4SM.mjs
@@ -610,47 +1107,6 @@ expression: "snapshot_outputs.join(\"\\n\")"
 - a-3CfKunof.mjs
 - b-3CfKunof.mjs
 - shared-N5WFVGpv.mjs
-
-# tests/fixtures/compat/cjs_entry
-
-- main-OTdRCYV_.mjs
-- $runtime$-UXfAy_R1.mjs
-
-# tests/fixtures/compat/dynamic_cjs_entry
-
-- main-esNU5dY_.mjs
-- cjs-s1G658b7.mjs
-- $runtime$-UXfAy_R1.mjs
-
-# tests/fixtures/compat/empty_file_should_be_treated_as_cjs/import
-
-- main-X6_QwVIL.mjs
-- $runtime$-MEb4HyiP.mjs
-
-# tests/fixtures/compat/empty_file_should_be_treated_as_cjs/re_export
-
-- main-X6_QwVIL.mjs
-- $runtime$-MEb4HyiP.mjs
-
-# tests/fixtures/compat/esm_require_cjs
-
-- main-M6-rzLwY.mjs
-- $runtime$-UXfAy_R1.mjs
-
-# tests/fixtures/compat/esm_require_esm
-
-- main-07GXTKjT.mjs
-- $runtime$-Z-c-hKoo.mjs
-
-# tests/fixtures/compat/esm_require_esm_unused
-
-- main-oWY1aWaC.mjs
-- $runtime$-Z-c-hKoo.mjs
-
-# tests/fixtures/compat/import_the_same_cjs_twice
-
-- main-oP0xzrei.mjs
-- $runtime$-MEb4HyiP.mjs
 
 # tests/fixtures/deconflict/basic
 
@@ -668,13 +1124,13 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/deconflict/conflict_between_global_and_local_binding
 
-- main-BbKWUH9z.mjs
-- $runtime$-UXfAy_R1.mjs
+- main-50t-VPoe.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/fixtures/deconflict/conflict_between_imported_and_local_binding
 
-- main-SJob6gEf.mjs
-- $runtime$-UXfAy_R1.mjs
+- main-SoTiCm5X.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/fixtures/deconflict/decl_complex_patterns
 
@@ -702,40 +1158,36 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/deconflict/wrapped_esm_default_function
 
-- main-C_X9PBxc.mjs.map
-- main-C_X9PBxc.mjs
-- $runtime$-Z-c-hKoo.mjs
+- main-kzu-zWPT.mjs.map
+- main-kzu-zWPT.mjs
+- $runtime$-ZIDpBgQ2.mjs
 
 # tests/fixtures/deconflict/wrapped_esm_export_named_function
 
-- main-KrGzQPEm.mjs.map
-- main-KrGzQPEm.mjs
-- $runtime$-Z-c-hKoo.mjs
+- main-zsh8xh0p.mjs.map
+- main-zsh8xh0p.mjs
+- $runtime$-ZIDpBgQ2.mjs
 
 # tests/fixtures/errors/unresolved_entry
 
 
-# tests/fixtures/exec_order/basic
-
-- main-wosaaZwK.mjs
-
-# tests/fixtures/external/export_external
+# tests/fixtures/function/external/export_external
 
 - main-mwAasMX8.mjs
 
-# tests/fixtures/external/implicit_import_external
+# tests/fixtures/function/external/implicit_import_external
 
 - main-mXCdQe4v.mjs
 
-# tests/fixtures/external/import_external
+# tests/fixtures/function/external/import_external
 
 - main-iCe0vVJ6.mjs
 
-# tests/fixtures/external/keep_import_external_order
+# tests/fixtures/function/external/keep_import_external_order
 
 - main-QoOCMinU.mjs
 
-# tests/fixtures/external/splitting_with_external_module
+# tests/fixtures/function/external/splitting_with_external_module
 
 - main-DZatqKo2.mjs
 - entry-CqwYkjJP.mjs
@@ -743,8 +1195,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/function/resolve/browser_filed_false
 
-- package-Rumap1Qh.mjs
-- $runtime$-MEb4HyiP.mjs
+- package-mYmwIyWp.mjs
+- $runtime$-5vmYXDA_.mjs
 
 # tests/fixtures/function/resolve/node_modules_as_entries
 
@@ -756,8 +1208,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/function/resolve/should_resolve_to_different_target_for_import_and_require
 
-- main-Dh_r9BiR.mjs
-- $runtime$-UXfAy_R1.mjs
+- main-pHxv_TKm.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/fixtures/function/shim_missing_exports/basic
 
@@ -765,8 +1217,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/function/shim_missing_exports/basic_wrapped_esm
 
-- main-b_g5jfQ0.mjs
-- $runtime$-pI7lnPPu.mjs
+- main-4WHDbztR.mjs
+- $runtime$-F3klwW2A.mjs
 
 # tests/fixtures/function/shim_missing_exports/shake_unused_shimmed_exports
 
@@ -780,42 +1232,41 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - main-b0ZPZIig.mjs
 
-# tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
+# tests/fixtures/issues/122/a
 
-- main-BmjYmACO.mjs
-- $runtime$-MEb4HyiP.mjs
+- entry1-_-hODSmq.mjs
+- entry2-cRpXCgpz.mjs
+- entry3-zx049jFA.mjs
+- c-9JbBdQ6M.mjs
+- b-zc09EzHw.mjs
 
-# tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import
+# tests/fixtures/issues/122/b
 
-- main-i8MTt0Gj.mjs
-- $runtime$-MEb4HyiP.mjs
+- a-0K6j_oM4.mjs
+- b-0YiUqboJ.mjs
+- c--yrsonBz.mjs
+- 1-MkbJyCGk.mjs
+- 2-rlvhlgG0.mjs
 
-# tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
+# tests/fixtures/misc/ambiguous_star_export
 
-- main-NMgLEzKm.mjs
-- $runtime$-aNQ4BPjH.mjs
+- main-oGb5soj4.mjs
 
-# tests/fixtures/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
+# tests/fixtures/misc/basic
 
-- main-AxGURCmy.mjs
-- $runtime$-aNQ4BPjH.mjs
+- main-goKjyff3.mjs.map
+- main-goKjyff3.mjs
 
-# tests/fixtures/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
+# tests/fixtures/misc/basic_re_export
 
-- main-3cSpHY2c.mjs
-- $runtime$-MEb4HyiP.mjs
-
-# tests/fixtures/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport
-
-- main-Nz9rnyvk.mjs
-- $runtime$-MEb4HyiP.mjs
+- main-mO2iY3R-.mjs
 
 # tests/fixtures/misc/cjs_entry_as_dependency
 
-- main-fT3loXNG.mjs
-- main2-ZAjolxoW.mjs
-- $runtime$-MEb4HyiP.mjs
-- main2~1-zMP6nZW5.mjs
+- main-v8YsmN87.mjs
+- main2-yaBP-nSD.mjs
+- $runtime$-5vmYXDA_.mjs
+- main2~1-QiY6Zldg.mjs
 
 # tests/fixtures/misc/duplicate_entries
 
@@ -825,55 +1276,34 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/misc/generate_valid_name_for_kebab_case_files
 
-- main-c89RRSFp.mjs
-- $runtime$-UXfAy_R1.mjs
+- main-30Wgl4rl.mjs
+- $runtime$-dLAG8cVO.mjs
 
 # tests/fixtures/misc/issue_376
 
 - main-tH_XK2jX.mjs
 
-# tests/fixtures/mix-cjs-esm
-
-- main-JtErwRGT.mjs.map
-- main-JtErwRGT.mjs
-- $runtime$-MEb4HyiP.mjs
-
-# tests/fixtures/object_shorthand_property
+# tests/fixtures/misc/object_shorthand_property
 
 - main-IGISejGn.mjs.map
 - main-IGISejGn.mjs
 
-# tests/fixtures/reexport_commonjs
+# tests/fixtures/misc/reexport_star
 
-- main-kDEC13Hu.mjs
-- $runtime$-bXpUbT3V.mjs
+- main-Fmyz3KF5.mjs
+- entry-Fmyz3KF5.mjs
+- $runtime$-LTBR7hwr.mjs
+- a-kWDIpuyP.mjs
 
-# tests/fixtures/reexport_star
-
-- main-3JR_3wiT.mjs
-- entry-3JR_3wiT.mjs
-- $runtime$-q_K1VDSH.mjs
-- a-uKv6e4CK.mjs
-
-# tests/fixtures/reexport_star_from_local_named_export
+# tests/fixtures/misc/reexport_star_from_local_named_export
 
 - main-zePOg9Nq.mjs
 
-# tests/fixtures/require/create_require
+# tests/fixtures/misc/wrapped_esm
 
-- main-ITXL_U98.mjs
-
-# tests/fixtures/require/require_cjs
-
-- main-jklmAiZI.mjs.map
-- main-jklmAiZI.mjs
-- $runtime$-UXfAy_R1.mjs
-
-# tests/fixtures/require/require_esm
-
-- main-smYdxwc3.mjs.map
-- main-smYdxwc3.mjs
-- $runtime$-pI7lnPPu.mjs
+- main-FokCiBg7.mjs.map
+- main-FokCiBg7.mjs
+- $runtime$-ZIDpBgQ2.mjs
 
 # tests/fixtures/rollup/assignment-patterns
 
@@ -895,12 +1325,10 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - main-t1MmfxxF.mjs
 
-# tests/fixtures/warnings/basic
+# tests/fixtures/warnings/eval
 
 - main-FVcrgCyD.mjs
 
-# tests/fixtures/wrapped_esm
+# tests/fixtures/warnings/unresolved_import_treated_as_external
 
-- main-D7nd2r-Z.mjs.map
-- main-D7nd2r-Z.mjs
-- $runtime$-Z-c-hKoo.mjs
+- main-IG1h-nPm.mjs

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -4,1331 +4,1331 @@ expression: "snapshot_outputs.join(\"\\n\")"
 ---
 # tests/esbuild/dce/base64_loader_remove_unused
 
-- entry_js-rJVnsVA9.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-a50D-tCc.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/dce/data_url_loader_remove_unused
 
-- entry_js-rJVnsVA9.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-a50D-tCc.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/dce/dce_template_literal
 
-- entry_js-b0ZPZIig.mjs
+- entry_js-768RV9YH.mjs
 
 # tests/esbuild/dce/dce_type_of
 
-- entry_js-QNmQl-Q4.mjs
+- entry_js-yqaSMAng.mjs
 
 # tests/esbuild/dce/dce_type_of_equals_string
 
-- entry_js-rFbAl2MQ.mjs
+- entry_js-Cg3QacaM.mjs
 
 # tests/esbuild/dce/drop_label_tree_shaking_bug_issue3311
 
-- entry_js-Nsgo4OFw.mjs
+- entry_js-V4_lttMm.mjs
 
 # tests/esbuild/dce/file_loader_remove_unused
 
-- entry_js-rJVnsVA9.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-a50D-tCc.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/dce/import_re_export_of_namespace_import
 
-- entry_js-FlDMXACr.mjs
-- $runtime$--hm3E9-w.mjs
+- entry_js-c5EAqwgy.mjs
+- $runtime$-AWpG-C_M.mjs
 
 # tests/esbuild/dce/inline_function_call_for_init_decl
 
-- entry_js-zb9ANeDj.mjs
+- entry_js-o_cxoKSV.mjs
 
 # tests/esbuild/dce/remove_code_after_label_with_return
 
-- entry_js-b0ZPZIig.mjs
+- entry_js-768RV9YH.mjs
 
 # tests/esbuild/dce/remove_trailing_return
 
-- entry_js-EIzpGvjW.mjs
+- entry_js-0KHFRH8R.mjs
 
 # tests/esbuild/dce/remove_unused_import_meta
 
-- entry_js-mJH_R08y.mjs
+- entry_js-tiQvKDBq.mjs
 
 # tests/esbuild/dce/text_loader_remove_unused
 
-- entry_js-0fLA_3YA.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-jE3smO-n.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/dce/tree_shaking_binary_operators
 
-- entry_js-YOMVOouG.mjs
+- entry_js-xEJLYvwR.mjs
 
 # tests/esbuild/dce/tree_shaking_import_identifier
 
-- entry_js-20_PQzF_.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-VY9fbi7V.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/dce/tree_shaking_in_esm_wrapper
 
-- entry_js-IQEHRYOn.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- entry_js-Ot39bAO0.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/dce/tree_shaking_unary_operators
 
-- entry_js-1569tIl6.mjs
+- entry_js-MxqxhYGb.mjs
 
 # tests/esbuild/default/ambiguous_reexport_msg
 
-- entry_js-kqV4_A4m.mjs
+- entry_js-K2tYIvmv.mjs
 
 # tests/esbuild/default/arrow_fn_scope
 
-- entry_js-knWMXlT7.mjs
+- entry_js-bsd1Vt5x.mjs
 
 # tests/esbuild/default/auto_external
 
-- entry_js-8GMzEca-.mjs
+- entry_js-tYfXLfpU.mjs
 
 # tests/esbuild/default/avoid_tdz
 
-- entry_js-sn9RcHQl.mjs
+- entry_js-7w2tfinI.mjs
 
 # tests/esbuild/default/await_import_inside_try
 
-- entry_js-NUEjoY5v.mjs
+- entry_js-alYWxrrK.mjs
 
 # tests/esbuild/default/common_js_from_es6
 
-- entry_js-dz7OZAOJ.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- entry_js-4ti5rQwL.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/default/const_with_let
 
-- entry_js-d1sNq3Xh.mjs
+- entry_js-3MVisSSA.mjs
 
 # tests/esbuild/default/dot_import
 
-- entry_js-VjWmXPdB.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-qA3G3aMM.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/default/duplicate_entry_point
 
-- entry_js-retlWIJI.mjs
-- entry2_js-retlWIJI.mjs
-- entry-PLV8EjsS.mjs
+- entry_js-P03grTeI.mjs
+- entry2_js-gLxkMptc.mjs
+- entry-DXoyZNA-.mjs
 
 # tests/esbuild/default/dynamic_import_with_expression_cjs
 
-- a_js--H6Kq6u1.cjs
+- a_js-vtxMteYF.cjs
 
 # tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910
 
-- entry_js-itX00WBi.mjs
-- $runtime$-F3klwW2A.mjs
+- entry_js-qwSWZfQl.mjs
+- $runtime$-FWY5Q29P.mjs
 
 # tests/esbuild/default/es6_from_common_js
 
-- entry_js-inpBlmaj.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-lswHEC91.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/default/export_chain
 
-- entry_js-EnNjD5Yw.mjs
+- entry_js-dP8ZNNIo.mjs
 
 # tests/esbuild/default/export_forms_common_js
 
-- entry_js-n99h6_AS.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- entry_js-MwmhDoh9.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/default/export_forms_es6
 
-- entry_js-4OJt4SMQ.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-sos27Agl.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/default/external_packages
 
-- entry_js-R_nBuZfH.mjs
+- entry_js-qquV9Mgf.mjs
 
 # tests/esbuild/default/forbid_const_assign_when_bundling
 
-- entry_js-eHT9gvE6.mjs
+- entry_js-5eClpM70.mjs
 
 # tests/esbuild/default/import_fs_node_common_js
 
-- entry_js-amqS_cwv.cjs
+- entry_js-TE_F6vZL.cjs
 
 # tests/esbuild/default/import_missing_common_js
 
-- entry_js-ghp66N9t.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-BJkPislD.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/default/import_then_catch
 
-- entry_js-4ck2WnUy.mjs
+- entry_js-tWQeN0Ma.mjs
 
 # tests/esbuild/default/keep_names_class_static_name
 
-- entry_js-J5FVjBVa.mjs
+- entry_js-s9lvs6K0.mjs
 
 # tests/esbuild/default/nested_common_js
 
-- entry_js-hWpK256x.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry_js-JTyNJTWq.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/nested_es6_from_common_js
 
-- entry_js-lbtddFCW.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-BAL2XoGB.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/default/nested_require_without_call
 
-- entry_js-PDYdKbww.mjs
+- entry_js-EKmUjNd6.mjs
 
 # tests/esbuild/default/nested_scope_bug
 
-- entry_js-MPOZ-FKh.mjs
+- entry_js-FJIm2QaS.mjs
 
 # tests/esbuild/default/new_expression_common_js
 
-- entry_js-VGc5eaRo.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry_js-8H4WN1WU.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/no_overwrite_input_file_error
 
-- entry_js-PLV8EjsS.mjs
+- entry_js-8LrtHevd.mjs
 
 # tests/esbuild/default/outbase
 
-- c_js-9JbBdQ6M.mjs
-- d_js-4Ps9mOU5.mjs
+- c_js-Sfntij9A.mjs
+- d_js-A6twFbY_.mjs
 
 # tests/esbuild/default/quoted_property
 
-- entry_js-bpX_joLy.mjs
+- entry_js-z5zTfYuC.mjs
 
 # tests/esbuild/default/re_export_common_js_as_es6
 
-- entry_js-r0pkvMzG.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-WGnxJ-SI.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/default/re_export_default_internal
 
-- entry_js-_YZtULPo.mjs
+- entry_js-VAX5GNXh.mjs
 
 # tests/esbuild/default/relative_entry_point_error
 
-- entry-PLV8EjsS.mjs
+- entry-R3uYdA1l.mjs
 
 # tests/esbuild/default/require_child_dir_common_js
 
-- entry_js-rt6NcNNH.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry_js-cjN4Bdij.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/require_child_dir_es6
 
-- entry_js-IQTTUmuw.mjs
+- entry_js--0ookdtP.mjs
 
 # tests/esbuild/default/require_main_cache_common_js
 
-- entry_js-cN8LCxFM.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry_js-OFrWorTU.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/require_parent_dir_common_js
 
-- dir_entry_js-rUmw4j2g.mjs
-- $runtime$-dLAG8cVO.mjs
+- dir_entry_js-TqGj3PVc.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/require_parent_dir_es6
 
-- dir_entry_js-A8ZoGr8F.mjs
+- dir_entry_js-TffzVWBQ.mjs
 
 # tests/esbuild/default/require_property_access_common_js
 
-- entry_js-SWVDiOhy.mjs
+- entry_js-Q1RceOpL.mjs
 
 # tests/esbuild/default/require_resolve
 
-- entry_js-tbm-BoBZ.mjs
+- entry_js-Mv-t7hMH.mjs
 
 # tests/esbuild/default/require_with_call_inside_try
 
-- entry_js-jqgFQJMV.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry_js-f3IEt299.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/require_without_call
 
-- entry_js-BuvwGEwP.mjs
+- entry_js-eFlaDQif.mjs
 
 # tests/esbuild/default/require_without_call_inside_try
 
-- entry_js-RYzUwOJY.mjs
+- entry_js-CID1xcTR.mjs
 
 # tests/esbuild/default/reserve_props
 
-- entry_js-20tr2TKT.mjs
+- entry_js-Tyq-szys.mjs
 
 # tests/esbuild/default/simple_common_js
 
-- entry_js-4hLD5gio.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry_js-Kjt9Do6P.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/simple_es6
 
-- entry_js-vHtUVPr0.mjs
+- entry_js-Rjle9Mp7.mjs
 
 # tests/esbuild/default/strict_mode_nested_fn_decl_keep_names_variable_inlining_issue1552
 
-- entry_js-Yd7hdWwh.mjs
+- entry_js-aJPHBSXH.mjs
 
 # tests/esbuild/default/this_inside_function
 
-- entry_js-676kLNBp.mjs
+- entry_js-hp3wpnsR.mjs
 
 # tests/esbuild/default/use_strict_directive_bundle_esm_issue2264
 
-- entry_js-G27ZTstm.mjs
+- entry_js-S_UqMuPR.mjs
 
 # tests/esbuild/default/use_strict_directive_bundle_issue1837
 
-- entry_js-dutYZUjh.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry_js-iJ-IQkDg.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/var_relocating_bundle
 
-- top-level_js-0Pqt6OB8.mjs
-- nested_js-TqYfAGvA.mjs
-- let_js-zHQO5wQb.mjs
-- function_js-UIH1gRsA.mjs
-- function-nested_js-KZJZ9VL9.mjs
+- top-level_js-zFcTRQCq.mjs
+- nested_js-9gULdUmo.mjs
+- let_js-NZtFdo_X.mjs
+- function_js-508d9udD.mjs
+- function-nested_js-3Itl4oYw.mjs
 
 # tests/esbuild/import_star/export_self_as_namespace_es6
 
-- entry_js-wR--ATA3.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-Zjs8PpNg.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/export_self_common_js
 
-- entry_js-_TR1-BWY.cjs
+- entry_js-YfY-hhIK.cjs
 
 # tests/esbuild/import_star/export_self_es6
 
-- entry_js-nvU10OVq.mjs
+- entry_js-eZKpFnfR.mjs
 
 # tests/esbuild/import_star/import_export_other_as_namespace_common_js
 
-- entry_js-w_r3ZwWo.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-YGsyDWpI.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/import_export_self_as_namespace_es6
 
-- entry_js-wR--ATA3.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-Zjs8PpNg.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_export_star_ambiguous_warning
 
-- entry_js-ZhPELjfZ.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-jEM63MHK.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_of_export_star
 
-- entry_js-KMFAnqT2.mjs
+- entry_js-4wZYa_qP.mjs
 
 # tests/esbuild/import_star/import_of_export_star_of_import
 
-- entry_js-oagxpBfe.mjs
+- entry_js-9WNq1662.mjs
 
 # tests/esbuild/import_star/import_self_common_js
 
-- entry_js-oSfzDpJq.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-5OrdrVz4.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/import_star_and_common_js
 
-- entry_js-9gi2MYjo.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- entry_js-Qo4uI9_R.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/import_star/import_star_capture
 
-- entry_js-Iwd3SCAO.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-Nb59JZ9_.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_common_js_capture
 
-- entry_js-md5oqP5u.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-uC4SyQQl.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/import_star_common_js_no_capture
 
-- entry_js-aGFIfNqq.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-omQ_zVuC.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/import_star_common_js_unused
 
-- entry_js-sVlgQwZF.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-r1zYVnBD.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_capture
 
-- entry_js-Iwd3SCAO.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-Nb59JZ9_.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_no_capture
 
-- entry_js-zIkCGGpk.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-Rxv2YhfA.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_unused
 
-- entry_js-UvthDZZZ.mjs
+- entry_js-0ZgkONLo.mjs
 
 # tests/esbuild/import_star/import_star_export_star_as_capture
 
-- entry_js-Iwd3SCAO.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-Nb59JZ9_.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_as_no_capture
 
-- entry_js-zIkCGGpk.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-Rxv2YhfA.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_as_unused
 
-- entry_js-YJn8_j1E.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-ydely-ew.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_capture
 
-- entry_js-MQR2k0oo.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-XvODpbLo.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_no_capture
 
-- entry_js-0TPB_mr9.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-zoqqsfeu.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_omit_ambiguous
 
-- entry_js-xfuL6sQJ.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-gPlTS0bF.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_unused
 
-- entry_js-UvthDZZZ.mjs
+- entry_js-0ZgkONLo.mjs
 
 # tests/esbuild/import_star/import_star_no_capture
 
-- entry_js-zIkCGGpk.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-Rxv2YhfA.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_of_export_star_as
 
-- entry_js-JLrC0oPm.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-8XORSYMb.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_unused
 
-- entry_js-UvthDZZZ.mjs
+- entry_js-0ZgkONLo.mjs
 
 # tests/esbuild/import_star/issue176
 
-- entry_js-sZwUOJ8J.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-G1jzfW5F.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/namespace_import_missing_common_js
 
-- entry_js-dOd3h6cr.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-t3Suhxx_.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/namespace_import_missing_es6
 
-- entry_js-C_y1eGe9.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-7oWuFBtK.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/namespace_import_re_export_star_missing_es6
 
-- entry_js-Trm2Ztpt.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-i-Fd9UVH.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/namespace_import_re_export_star_unused_missing_es6
 
-- entry_js-ADCyEr_z.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-3JnON20m.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/namespace_import_unused_missing_common_js
 
-- entry_js-WuniMYOu.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry_js-GLIUkWiS.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/namespace_import_unused_missing_es6
 
-- entry_js-5BKj3Zn3.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-Zagt51Rt.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6
 
-- entry_js-88mBc_xT.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-kdwdpUqf.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/other_file_import_export_self_as_namespace_unused_es6
 
-- entry_js--NnGId1P.mjs
+- entry_js-9AmJ1Gkp.mjs
 
 # tests/esbuild/import_star/re_export_namespace_import_missing_es6
 
-- entry_js-0JbtI7Kp.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-GeAA33Yj.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/re_export_namespace_import_unused_missing_es6
 
-- entry_js-y65k3F21.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-SSs3UiOe.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/re_export_other_file_export_self_as_namespace_es6
 
-- entry_js-e_21exxw.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-c2v0AGZC.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/re_export_other_file_import_export_self_as_namespace_es6
 
-- entry_js-e_21exxw.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-c2v0AGZC.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/re_export_star_as_external_common_js
 
-- entry_js-ExSCpg1O.cjs
+- entry_js-xqfVgBNO.cjs
 
 # tests/esbuild/import_star/re_export_star_as_external_es6
 
-- entry_js-1V20XJym.mjs
+- entry_js-Hh289cnx.mjs
 
 # tests/esbuild/import_star/re_export_star_entry_point_and_inner_file
 
-- entry_js-mZtOu9jr.mjs
-- $runtime$-LTBR7hwr.mjs
+- entry_js-1yhhclYV.mjs
+- $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/re_export_star_external_common_js
 
-- entry_js-MRQxE4Fa.cjs
+- entry_js-rud5zVrH.cjs
 
 # tests/esbuild/import_star/re_export_star_external_es6
 
-- entry_js-IG1h-nPm.mjs
+- entry_js--Ducb3XN.mjs
 
 # tests/esbuild/import_star/re_export_star_name_collision_not_ambiguous_export
 
-- entry_js-wvmEH3MF.mjs
+- entry_js-Nok7HjpZ.mjs
 
 # tests/esbuild/import_star/re_export_star_name_collision_not_ambiguous_import
 
-- entry_js-ZSvF2NCU.mjs
+- entry_js-cxWW65mu.mjs
 
 # tests/esbuild/import_star/re_export_star_name_shadowing_not_ambiguous
 
-- entry_js-1tvWC_vK.mjs
+- entry_js-mlg8oAre.mjs
 
 # tests/esbuild/import_star/re_export_star_name_shadowing_not_ambiguous_re_export
 
-- entry_js-xwGRq5T_.mjs
+- entry_js-JPJ4y3_I.mjs
 
 # tests/esbuild/lower/lower_async_es5
 
-- entry_js-b0ZPZIig.mjs
+- entry_js-768RV9YH.mjs
 
 # tests/esbuild/lower/lower_async_this2016_common_js
 
-- entry_js-aQqFx9SN.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry_js-Ad0z75lz.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/lower/lower_async_this2016_es6
 
-- entry_js-NPTCfsTm.mjs
+- entry_js-JiRz4zy_.mjs
 
 # tests/esbuild/lower/lower_for_await2015
 
-- entry_js-Z8GyVk22.mjs
+- entry_js-l3XOrHvM.mjs
 
 # tests/esbuild/lower/lower_for_await2017
 
-- entry_js-Z8GyVk22.mjs
+- entry_js-l3XOrHvM.mjs
 
 # tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493
 
-- entry_js-4hQJN7oL.mjs
+- entry_js-14C4TPTg.mjs
 
 # tests/esbuild/lower/lower_private_class_accessor_order
 
-- entry_js-iVjUYHyh.mjs
+- entry_js-ByppGU64.mjs
 
 # tests/esbuild/lower/lower_private_class_brand_check_supported
 
-- entry_js-b0ZPZIig.mjs
+- entry_js-768RV9YH.mjs
 
 # tests/esbuild/lower/lower_private_class_brand_check_unsupported
 
-- entry_js-b0ZPZIig.mjs
+- entry_js-768RV9YH.mjs
 
 # tests/esbuild/lower/lower_private_class_field_order
 
-- entry_js-3Kcfybbw.mjs
+- entry_js-RuMA6KsR.mjs
 
 # tests/esbuild/lower/lower_private_class_field_static_issue1424
 
-- entry_js-ncENaqRA.mjs
+- entry_js-pBq_IsMb.mjs
 
 # tests/esbuild/lower/lower_private_class_method_order
 
-- entry_js-6jLBb9pP.mjs
+- entry_js-34lN_5-1.mjs
 
 # tests/esbuild/lower/lower_private_class_static_accessor_order
 
-- entry_js-brZcjb57.mjs
+- entry_js-hs0ITU8f.mjs
 
 # tests/esbuild/lower/lower_private_class_static_field_order
 
-- entry_js-r2i8mfKU.mjs
+- entry_js-EWIKKmXn.mjs
 
 # tests/esbuild/lower/lower_private_class_static_method_order
 
-- entry_js-qESAUnA0.mjs
+- entry_js-Iv_WCBqp.mjs
 
 # tests/esbuild/lower/lower_private_getter_setter2015
 
-- entry_js-YOc6RuZ1.mjs
+- entry_js-oztyDTOS.mjs
 
 # tests/esbuild/lower/lower_private_getter_setter2019
 
-- entry_js-YOc6RuZ1.mjs
+- entry_js-oztyDTOS.mjs
 
 # tests/esbuild/lower/lower_private_getter_setter2020
 
-- entry_js-YOc6RuZ1.mjs
+- entry_js-oztyDTOS.mjs
 
 # tests/esbuild/lower/lower_private_getter_setter_next
 
-- entry_js-YOc6RuZ1.mjs
+- entry_js-oztyDTOS.mjs
 
 # tests/esbuild/lower/lower_private_method2019
 
-- entry_js-7BN_aezx.mjs
+- entry_js-XYpLtkIm.mjs
 
 # tests/esbuild/lower/lower_private_method2020
 
-- entry_js-7BN_aezx.mjs
+- entry_js-XYpLtkIm.mjs
 
 # tests/esbuild/lower/lower_private_method_next
 
-- entry_js-7BN_aezx.mjs
+- entry_js-XYpLtkIm.mjs
 
 # tests/esbuild/lower/lower_private_method_with_modifiers2020
 
-- entry_js-TgKAvwGb.mjs
+- entry_js-Gl8LWG6F.mjs
 
 # tests/esbuild/lower/lower_private_super_static_bundle_issue2158
 
-- entry_js-ROaZh-2S.mjs
+- entry_js-y263I-2r.mjs
 
 # tests/esbuild/lower/lower_reg_exp_name_collision
 
-- entry_js-SMVXimBu.mjs
+- entry_js-WTSQ2kHq.mjs
 
 # tests/esbuild/lower/lower_template_object
 
-- entry_js-b0ZPZIig.mjs
+- entry_js-768RV9YH.mjs
 
 # tests/esbuild/lower/static_class_block_es2021
 
-- entry_js-qxotrxek.mjs
+- entry_js-aooHLG4F.mjs
 
 # tests/esbuild/lower/static_class_block_es_next
 
-- entry_js-qxotrxek.mjs
+- entry_js-aooHLG4F.mjs
 
 # tests/esbuild/packagejson/test_package_json_bad_main
 
-- entry-kmKFvDhA.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-N2N-2gTp.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_index_no_ext
 
-- entry-_pHjhmHK.mjs
+- entry-t2t75zSt.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_issue2002_a
 
-- entry--XlDW28x.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry-Grp4OUuD.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_issue2002_c
 
-- entry-4WIqDoey.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry-aKM4d5_j.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_avoid_missing
 
-- entry-qa3H14Dh.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry-9gRlHDBF.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_module_disabled
 
-- entry-PjpOAspQ.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-KD3UkCYm.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_module_to_module
 
-- entry-ewkAn3Nc.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-uq7lnRgH.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_module_to_relative
 
-- entry-cwEZJvXL.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-krnhGpEH.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_native_module_disabled
 
-- entry-81vL3n-T.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-RHnxONui.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_relative_disabled
 
-- entry-E7c4wZHe.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-yMqIooMO.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_relative_to_module
 
-- entry-2p2hTf0c.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-tva7ZXBf.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_relative_to_relative
 
-- entry-NtjRy-Fn.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-xi9VMMro.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_no_ext
 
-- entry-iMmnB9H4.mjs
+- entry-NKU4hPlA.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_node_modules_index_no_ext
 
-- entry-XnlGkdGQ.mjs
+- entry-pWKNbBGQ.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_node_modules_no_ext
 
-- entry-O-zJT0JW.mjs
+- entry-sWZyPErY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_over_main_node
 
-- entry-exxtr1AE.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-UoUzFxo1.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_over_module_browser
 
-- entry-hlr6VjQh.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-JIbWuyj_.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_string
 
-- entry-jn81TLjy.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-n64V-Zp8.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_with_main_node
 
-- entry-exxtr1AE.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-UoUzFxo1.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_with_module_browser
 
-- entry-E-JeC86s.mjs
+- entry-Gl72KJXS.mjs
 
 # tests/esbuild/packagejson/test_package_json_disabled_type_module_issue3367
 
-- entry--M595VdO.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-RaFWGttt.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_browser
 
-- entry-4neC08JR.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- entry-3nf6Oa_i.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_force_module_before_main
 
-- entry-KkEUt8lT.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- entry-Betafk68.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_implicit_main
 
-- entry-PnzIDC2_.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- entry-Wo3WOs45.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main
 
-- entry-PnzIDC2_.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- entry-Wo3WOs45.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_same_file
 
-- entry-bz0BI4Dv.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- entry-zxGCGekR.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_separate_files
 
-- entry-KkEUt8lT.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- entry-Betafk68.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_only
 
-- entry-5sx4P-Fg.mjs
+- entry-lZ8mNqnR.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_require_only
 
-- entry-r6q5F2NV.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- entry-o5R7C6Po.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_browser
 
-- entry-7DRd-tfc.mjs
+- entry-bOVF_gv-.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_custom_conditions
 
-- entry-OwhoOCiW.mjs
+- entry-a0bF4eQm.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_entry_point_import_over_require
 
-- entry-YV5IjBHI.mjs
+- entry-3tCW4XWQ.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_entry_point_main_only
 
-- entry-DCCuZ_Wo.mjs
+- entry-X0jnqyR8.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_entry_point_module_over_main
 
-- entry-SL5TQRan.mjs
+- entry-p66zakjQ.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_entry_point_require_only
 
 
 # tests/esbuild/packagejson/test_package_json_exports_import_over_require
 
-- entry-sOF97diL.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry-bSaTO-KK.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_neutral
 
-- entry-x-g3eIN1.mjs
+- entry-JF9d90w2.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_node
 
-- entry-vPKXwIeX.mjs
+- entry-4h1M45BS.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_not_exact_missing_extension
 
-- entry-5TVDkMnq.mjs
+- entry-z4MWU1jP.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_order_independent
 
-- entry-IpafjFgb.mjs
+- entry-4zUM8YPI.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_pattern_trailers
 
-- entry-FCVuvTmc.mjs
+- entry-pqRM6Awy.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_require_over_import
 
-- entry-PkaBGtDO.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry-RPehkXQS.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_wildcard
 
-- entry-yOOoIugb.mjs
+- entry-oEUWxLjK.mjs
 
 # tests/esbuild/packagejson/test_package_json_import_self_using_import
 
-- entry-qqHliUX2.mjs
+- entry-xhXOK5jN.mjs
 
 # tests/esbuild/packagejson/test_package_json_import_self_using_import_scoped
 
-- entry-qqHliUX2.mjs
+- entry-xhXOK5jN.mjs
 
 # tests/esbuild/packagejson/test_package_json_import_self_using_require
 
-- entry-3d3HKLkH.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry-JwFzZT2I.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_import_self_using_require_scoped
 
-- entry-3d3HKLkH.mjs
-- $runtime$-dLAG8cVO.mjs
+- entry-JwFzZT2I.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_imports
 
-- entry-kL61DuZW.mjs
+- entry-cZfpZxRv.mjs
 
 # tests/esbuild/packagejson/test_package_json_imports_error_unsupported_directory_import
 
-- entry-9sM5IAkg.mjs
+- entry-il8Vihdd.mjs
 
 # tests/esbuild/packagejson/test_package_json_imports_remap_to_other_package
 
-- entry-hUJpovHm.mjs
+- entry-UlXuFzMS.mjs
 
 # tests/esbuild/packagejson/test_package_json_main
 
-- entry-iQA8V1TL.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-ZJ_oxjPL.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_main_fields_a
 
-- entry-9C9J0TQf.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-ruZ1xbOz.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_main_fields_b
 
-- entry-_LUuVvEG.mjs
+- entry-ZuInevZl.mjs
 
 # tests/esbuild/packagejson/test_package_json_module
 
-- entry-wHCbE-sb.mjs
+- entry-5YTkTqn3.mjs
 
 # tests/esbuild/packagejson/test_package_json_neutral_explicit_main_fields
 
-- entry-exxtr1AE.mjs
-- $runtime$-5vmYXDA_.mjs
+- entry-UoUzFxo1.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/splitting/assign-to-local
 
-- a-_XWSW13g.mjs
-- b-HJyK04H3.mjs
-- shared-j5Ff6q07.mjs
+- a-KZ3yWiFy.mjs
+- b-sescAl-r.mjs
+- shared-eZE_MQu5.mjs
 
 # tests/esbuild/splitting/circular_reference_issue251
 
-- a-06r_PdWn.mjs
-- b-06r_PdWn.mjs
-- a~1-dqCWCsVV.mjs
+- a-Dp0eN-ZJ.mjs
+- b-r-rPquvC.mjs
+- a~1-1QJJkgOj.mjs
 
 # tests/esbuild/splitting/cross_chunk_assignment_dependencies
 
-- a-GAfEkhBz.mjs
-- b-3CfKunof.mjs
-- shared-PossxWD_.mjs
+- a-SkEk-0qP.mjs
+- b-IAQUKyjm.mjs
+- shared-qfXNz9pr.mjs
 
 # tests/esbuild/splitting/duplicate_chunk_collision
 
-- a--jUnewN_.mjs
-- b--jUnewN_.mjs
-- c-S8FEqMOR.mjs
-- d-S8FEqMOR.mjs
-- d~1--oOy2sQW.mjs
-- ab-fdOaNPnJ.mjs
+- a-6c_8_6PJ.mjs
+- b-hqvCqhgj.mjs
+- c-GcoI6NSv.mjs
+- d-FvXiEf_f.mjs
+- d~1-_GjC6vrH.mjs
+- ab-0xnqDU7x.mjs
 
 # tests/esbuild/splitting/dynamic-commonjs-into-es6
 
-- main-QDMELkDA.mjs
-- foo-_zE0LWAK.mjs
-- $runtime$-dLAG8cVO.mjs
+- main-hJ-rtw7N.mjs
+- foo-6VLOUb_v.mjs
+- $runtime$-evkBfY1S.mjs
 
 # tests/esbuild/splitting/dynamic-es6-into-es6
 
-- main-QDMELkDA.mjs
-- foo-pnPcej-0.mjs
+- main-aZfKZWQl.mjs
+- foo-y4QWWTtX.mjs
 
 # tests/esbuild/splitting/dynamic_and_not_dynamic_es6_into_es6
 
-- main-GwCqVkdJ.mjs
-- foo-WOsfWFxp.mjs
-- foo~1-pnPcej-0.mjs
+- main-8i8JF42P.mjs
+- foo-O6enMBv0.mjs
+- foo~1-Sof3A-nJ.mjs
 
 # tests/esbuild/splitting/dynamic_import_issue_272
 
-- a-0X-TgeL0.mjs
-- b-z3RcbbOY.mjs
+- a-lzkhn1t-.mjs
+- b-Ngqr-aWB.mjs
 
 # tests/esbuild/splitting/hybrid_esm_and_cjs_issue617
 
-- a-fs0iQPCG.mjs
-- b-Y80Iyxv-.mjs
-- $runtime$-ZIDpBgQ2.mjs
-- a~1-z6alrqdX.mjs
+- a-ehXIs1Q0.mjs
+- b-_ZC1yYMg.mjs
+- $runtime$-sLq7rqre.mjs
+- a~1-h7V72K_5.mjs
 
 # tests/esbuild/splitting/nested_directories
 
-- a-K4EOBJrC.mjs
-- b-elm0aqot.mjs
-- shared-Y8Wz-glY.mjs
+- a-1AmcEbF8.mjs
+- b-Ocnsf82U.mjs
+- shared-PMFWUU19.mjs
 
 # tests/esbuild/splitting/re_export_issue273
 
-- a-zoNK6lDC.mjs
-- b-zoNK6lDC.mjs
-- a~1-IFG6qtjQ.mjs
+- a-h6hliDTl.mjs
+- b-tekxdp99.mjs
+- a~1-bC-OZCUw.mjs
 
 # tests/esbuild/splitting/shared-commonjs-into-es6
 
-- a-wte9JIL-.mjs
-- b-Ndbz6ZLO.mjs
-- $runtime$-dLAG8cVO.mjs
-- shared-ikIudKEq.mjs
+- a-bbZoaN8Q.mjs
+- b-Nz9nzYcD.mjs
+- $runtime$-evkBfY1S.mjs
+- shared-nuzlCZ7S.mjs
 
 # tests/esbuild/splitting/shared-es6-into-es6
 
-- a-9m9PMLo5.mjs
-- b-4KFCPrjB.mjs
-- shared-lRt456VI.mjs
+- a-Bwt3h9ea.mjs
+- b-ScZk0JLh.mjs
+- shared-2UmobjmC.mjs
 
 # tests/esbuild/splitting/side_effects_without_dependencies
 
-- a-QLTCCela.mjs
-- b-B232sYxN.mjs
-- shared-77sYuFdk.mjs
+- a-nzNBC-qm.mjs
+- b-dXF-TF6V.mjs
+- shared-zquJkVnu.mjs
 
 # tests/fixtures/cjs_compat/basic_commonjs
 
-- main-YHuBn402.mjs
-- $runtime$-F6CY4o_B.mjs
+- main-tOFH7NRF.mjs
+- $runtime$-KMO3JWcm.mjs
 
 # tests/fixtures/cjs_compat/cjs_entry
 
-- main-ZR9tr1bF.mjs
-- $runtime$-dLAG8cVO.mjs
+- main-MsyS7r4B.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/cjs_compat/dynamic_cjs_entry
 
-- main-KhBMeVG7.mjs
-- cjs-i1AIgVIr.mjs
-- $runtime$-dLAG8cVO.mjs
+- main-_stJcfO2.mjs
+- cjs-qtrxQfWU.mjs
+- $runtime$-evkBfY1S.mjs
 
 # tests/fixtures/cjs_compat/empty_file_should_be_treated_as_cjs/import
 
-- main-e5orE-FE.mjs
-- $runtime$-5vmYXDA_.mjs
+- main-JBLAWjNs.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/empty_file_should_be_treated_as_cjs/re_export
 
-- main-e5orE-FE.mjs
-- $runtime$-5vmYXDA_.mjs
+- main-JBLAWjNs.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/esm_require_cjs
 
-- main-TtC2gsl3.mjs
-- $runtime$-dLAG8cVO.mjs
+- main-z04rJP3L.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/cjs_compat/esm_require_esm
 
-- main-RIc2g_QF.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- main-t5PgBB84.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/fixtures/cjs_compat/esm_require_esm_unused
 
-- main-YBAUptxE.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- main-CbjTMjYQ.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
 
-- main-UX-F6GVI.mjs
-- $runtime$-5vmYXDA_.mjs
+- main-H9ncXSC9.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import
 
-- main-t2biWwo0.mjs
-- $runtime$-5vmYXDA_.mjs
+- main-ejVOFsTW.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
 
-- main-JdybNPQw.mjs
-- $runtime$-WN7OzxbL.mjs
+- main-TYCnsom9.mjs
+- $runtime$-Mp5R-3C4.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
 
-- main-ZopvgqJP.mjs
-- $runtime$-WN7OzxbL.mjs
+- main-Wj2uMhoR.mjs
+- $runtime$-Mp5R-3C4.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
 
-- main-q63vb5Nm.mjs
-- $runtime$-5vmYXDA_.mjs
+- main-uVU2cC_l.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport
 
-- main-uqc5s493.mjs
-- $runtime$-5vmYXDA_.mjs
+- main-J_oJ8eiV.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/import_the_same_cjs_twice
 
-- main-1tj50rfy.mjs
-- $runtime$-5vmYXDA_.mjs
+- main-rIpTdR-D.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/mix-cjs-esm
 
-- main-6eCEXnHB.mjs.map
-- main-6eCEXnHB.mjs
-- $runtime$-5vmYXDA_.mjs
+- main-kq71YIv7.mjs.map
+- main-kq71YIv7.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/multiple_circle_cjs_entries
 
-- a-6DjfXSbq.mjs
-- b-gCJEgCBf.mjs
-- $runtime$-5vmYXDA_.mjs
-- a~1-Q-syfFyB.mjs
+- a-RxLY-5jA.mjs
+- b-dvtQ8qlZ.mjs
+- $runtime$-x7wFgY46.mjs
+- a~1--19YZtkL.mjs
 
 # tests/fixtures/cjs_compat/reexport_commonjs
 
-- main-hKEfE7qX.mjs
-- $runtime$-eZyUBTpH.mjs
+- main-gBopYCj6.mjs
+- $runtime$-K_l5acij.mjs
 
 # tests/fixtures/cjs_compat/require/create_require
 
-- main-ITXL_U98.mjs
+- main-jO-TlKzx.mjs
 
 # tests/fixtures/cjs_compat/require/require_cjs
 
-- main-11xSWPPu.mjs.map
-- main-11xSWPPu.mjs
-- $runtime$-dLAG8cVO.mjs
+- main-k19F6glY.mjs.map
+- main-k19F6glY.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/cjs_compat/require/require_esm
 
-- main-EpUdRyqk.mjs.map
-- main-EpUdRyqk.mjs
-- $runtime$-F3klwW2A.mjs
+- main-OJfTTu7b.mjs.map
+- main-OJfTTu7b.mjs
+- $runtime$-FWY5Q29P.mjs
 
 # tests/fixtures/code_splitting/basic
 
-- main1-5jPUbVtE.mjs
-- main2-w_GNefeL.mjs
-- dynamic-GEHD338z.mjs
-- share-SOE6O4SM.mjs
+- main1-qzNNY7k9.mjs
+- main2-e4uxuT8x.mjs
+- dynamic-BetMHB7Z.mjs
+- share-LWF0P6Y-.mjs
 
 # tests/fixtures/code_splitting/ensure_side_effect_executed
 
-- entry_js-retlWIJI.mjs
-- entry2_js-retlWIJI.mjs
-- entry-dWYJnVqt.mjs
+- entry_js-aMrgARrj.mjs
+- entry2_js-ENf4Z9xp.mjs
+- entry-FYNiGCEm.mjs
 
 # tests/fixtures/code_splitting/ensure_side_effect_executed2
 
-- a-3CfKunof.mjs
-- b-3CfKunof.mjs
-- shared-N5WFVGpv.mjs
+- a-aQtPzn6-.mjs
+- b-qe8TOhJq.mjs
+- shared-ACOB7Y24.mjs
 
 # tests/fixtures/deconflict/basic
 
-- main-5imSwRxT.mjs
+- main-S-XTf22h.mjs
 
 # tests/fixtures/deconflict/basic_scoped
 
-- main-0YR8BEAD.mjs.map
-- main-0YR8BEAD.mjs
+- main-U0xUKBal.mjs.map
+- main-U0xUKBal.mjs
 
 # tests/fixtures/deconflict/complex_params_patterns
 
-- main-rKyMfp6i.mjs.map
-- main-rKyMfp6i.mjs
+- main-6AAXrAGx.mjs.map
+- main-6AAXrAGx.mjs
 
 # tests/fixtures/deconflict/conflict_between_global_and_local_binding
 
-- main-50t-VPoe.mjs
-- $runtime$-dLAG8cVO.mjs
+- main-tOEcGaC9.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/deconflict/conflict_between_imported_and_local_binding
 
-- main-SoTiCm5X.mjs
-- $runtime$-dLAG8cVO.mjs
+- main-UgkBYeKd.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/deconflict/decl_complex_patterns
 
-- main-H-W3Yesg.mjs.map
-- main-H-W3Yesg.mjs
+- main-Qx1dhUrw.mjs.map
+- main-Qx1dhUrw.mjs
 
 # tests/fixtures/deconflict/decl_nested_assign_pattern
 
-- main-ZIW-rgWY.mjs.map
-- main-ZIW-rgWY.mjs
+- main-12nbvJy_.mjs.map
+- main-12nbvJy_.mjs
 
 # tests/fixtures/deconflict/default_function
 
-- main-_jDe_Lk3.mjs.map
-- main-_jDe_Lk3.mjs
+- main-mCrUgOwW.mjs.map
+- main-mCrUgOwW.mjs
 
 # tests/fixtures/deconflict/issue_364
 
-- main-6M8A8E5q.mjs.map
-- main-6M8A8E5q.mjs
+- main-ivEW-tP0.mjs.map
+- main-ivEW-tP0.mjs
 
 # tests/fixtures/deconflict/reserved_names
 
-- main-R98p_V0_.mjs
+- main-l74A9xAq.mjs
 
 # tests/fixtures/deconflict/wrapped_esm_default_function
 
-- main-kzu-zWPT.mjs.map
-- main-kzu-zWPT.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- main-Hwm0PQEH.mjs.map
+- main-Hwm0PQEH.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/fixtures/deconflict/wrapped_esm_export_named_function
 
-- main-zsh8xh0p.mjs.map
-- main-zsh8xh0p.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- main-puld6Obw.mjs.map
+- main-puld6Obw.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/fixtures/errors/unresolved_entry
 
 
 # tests/fixtures/function/external/export_external
 
-- main-mwAasMX8.mjs
+- main-dVl9dQVv.mjs
 
 # tests/fixtures/function/external/implicit_import_external
 
-- main-mXCdQe4v.mjs
+- main-27GsR61l.mjs
 
 # tests/fixtures/function/external/import_external
 
-- main-iCe0vVJ6.mjs
+- main-EY3aBkcP.mjs
 
 # tests/fixtures/function/external/keep_import_external_order
 
-- main-QoOCMinU.mjs
+- main-p0EOVxKl.mjs
 
 # tests/fixtures/function/external/splitting_with_external_module
 
-- main-DZatqKo2.mjs
-- entry-CqwYkjJP.mjs
-- share-V80RWhXp.mjs
+- main-1dgL9psc.mjs
+- entry-ahgOZOc1.mjs
+- share-eIGIrVeP.mjs
 
 # tests/fixtures/function/resolve/browser_filed_false
 
-- package-mYmwIyWp.mjs
-- $runtime$-5vmYXDA_.mjs
+- package-ukXkR4ik.mjs
+- $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/function/resolve/node_modules_as_entries
 
-- is-plain-obj-UtkJ5BV5.mjs
+- is-plain-obj-EhLWRH20.mjs
 
 # tests/fixtures/function/resolve/resolve_node_modules_by_default
 
-- main-UtkJ5BV5.mjs
+- main-HUNyhaNM.mjs
 
 # tests/fixtures/function/resolve/should_resolve_to_different_target_for_import_and_require
 
-- main-pHxv_TKm.mjs
-- $runtime$-dLAG8cVO.mjs
+- main-CPUBIUg1.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/function/shim_missing_exports/basic
 
-- main-7nrrdq6t.mjs
+- main-z7O5ieUj.mjs
 
 # tests/fixtures/function/shim_missing_exports/basic_wrapped_esm
 
-- main-4WHDbztR.mjs
-- $runtime$-F3klwW2A.mjs
+- main-F_sBnFAO.mjs
+- $runtime$-FWY5Q29P.mjs
 
 # tests/fixtures/function/shim_missing_exports/shake_unused_shimmed_exports
 
-- main-7nrrdq6t.mjs
+- main-z7O5ieUj.mjs
 
 # tests/fixtures/function/tree_shaking/unused_import_external
 
-- main-hA3nL9xn.mjs
+- main-Ix9nDVBV.mjs
 
 # tests/fixtures/function/tree_shaking/unused_import_named
 
-- main-b0ZPZIig.mjs
+- main-nyQrEnyN.mjs
 
 # tests/fixtures/issues/122/a
 
-- entry1-_-hODSmq.mjs
-- entry2-cRpXCgpz.mjs
-- entry3-zx049jFA.mjs
-- c-9JbBdQ6M.mjs
-- b-zc09EzHw.mjs
+- entry1-tPXhjC_p.mjs
+- entry2-1SmE8XOv.mjs
+- entry3-iKN341B1.mjs
+- c-QCZtDBVV.mjs
+- b-VNLg4mog.mjs
 
 # tests/fixtures/issues/122/b
 
-- a-0K6j_oM4.mjs
-- b-0YiUqboJ.mjs
-- c--yrsonBz.mjs
-- 1-MkbJyCGk.mjs
-- 2-rlvhlgG0.mjs
+- a-YQ1-nqTx.mjs
+- b-q0R1_s_7.mjs
+- c-Isvqc62I.mjs
+- 1-BqMrTXTX.mjs
+- 2-LSPOLd9h.mjs
 
 # tests/fixtures/misc/ambiguous_star_export
 
-- main-oGb5soj4.mjs
+- main-4CQEffTL.mjs
 
 # tests/fixtures/misc/basic
 
-- main-goKjyff3.mjs.map
-- main-goKjyff3.mjs
+- main-xHsOP41Q.mjs.map
+- main-xHsOP41Q.mjs
 
 # tests/fixtures/misc/basic_re_export
 
-- main-mO2iY3R-.mjs
+- main-EbG_zl4R.mjs
 
 # tests/fixtures/misc/cjs_entry_as_dependency
 
-- main-v8YsmN87.mjs
-- main2-yaBP-nSD.mjs
-- $runtime$-5vmYXDA_.mjs
-- main2~1-QiY6Zldg.mjs
+- main-qW_OzgXJ.mjs
+- main2-ZrEEjGxb.mjs
+- $runtime$-x7wFgY46.mjs
+- main2~1-5MlZc-S3.mjs
 
 # tests/fixtures/misc/duplicate_entries
 
-- main-7vNvwwut.mjs
-- main2-7vNvwwut.mjs
-- main~1-29bMZaWG.mjs
+- main-YO-s-G5j.mjs
+- main2-woVkPLUq.mjs
+- main~1-GsuoDQSa.mjs
 
 # tests/fixtures/misc/generate_valid_name_for_kebab_case_files
 
-- main-30Wgl4rl.mjs
-- $runtime$-dLAG8cVO.mjs
+- main-VbkdPg3x.mjs
+- $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/misc/issue_376
 
-- main-tH_XK2jX.mjs
+- main-eqVOd_ca.mjs
 
 # tests/fixtures/misc/object_shorthand_property
 
-- main-IGISejGn.mjs.map
-- main-IGISejGn.mjs
+- main-Iv9FQrYJ.mjs.map
+- main-Iv9FQrYJ.mjs
 
 # tests/fixtures/misc/reexport_star
 
-- main-Fmyz3KF5.mjs
-- entry-Fmyz3KF5.mjs
-- $runtime$-LTBR7hwr.mjs
-- a-kWDIpuyP.mjs
+- main-Ug5NKpb6.mjs
+- entry-n0mFBci1.mjs
+- $runtime$-Is3GYi3v.mjs
+- a-IxCNEurQ.mjs
 
 # tests/fixtures/misc/reexport_star_from_local_named_export
 
-- main-zePOg9Nq.mjs
+- main-Hw_z1K-p.mjs
 
 # tests/fixtures/misc/wrapped_esm
 
-- main-FokCiBg7.mjs.map
-- main-FokCiBg7.mjs
-- $runtime$-ZIDpBgQ2.mjs
+- main-qrJngkK5.mjs.map
+- main-qrJngkK5.mjs
+- $runtime$-vR6TnGxp.mjs
 
 # tests/fixtures/rollup/assignment-patterns
 
-- main-RClCATDF.mjs
+- main-M9e-PvSP.mjs
 
 # tests/fixtures/rollup/catch-scope-shadowing
 
-- main-OSwo6a1u.mjs
+- main-WM131bmY.mjs
 
 # tests/fixtures/rollup/object-spread-side-effect
 
-- main-ikTg5xsT.mjs
+- main-bffFh2nJ.mjs
 
 # tests/fixtures/rollup/preserve-for-of-iterable
 
-- main-Y-wzxAq3.mjs
+- main-Jck2JIxa.mjs
 
 # tests/fixtures/rollup/simplify-with-destructuring
 
-- main-t1MmfxxF.mjs
+- main-m9nnNuko.mjs
 
 # tests/fixtures/warnings/eval
 
-- main-FVcrgCyD.mjs
+- main-yOBrKQ94.mjs
 
 # tests/fixtures/warnings/unresolved_import_treated_as_external
 
-- main-IG1h-nPm.mjs
+- main-xG8X-m9p.mjs

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -4,1331 +4,1331 @@ expression: "snapshot_outputs.join(\"\\n\")"
 ---
 # tests/esbuild/dce/base64_loader_remove_unused
 
-- entry_js-a50D-tCc.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-a50D-tCc.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/dce/data_url_loader_remove_unused
 
-- entry_js-a50D-tCc.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-a50D-tCc.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/dce/dce_template_literal
 
-- entry_js-768RV9YH.mjs
+- entry_js-!~{000}~.mjs => entry_js-768RV9YH.mjs
 
 # tests/esbuild/dce/dce_type_of
 
-- entry_js-yqaSMAng.mjs
+- entry_js-!~{000}~.mjs => entry_js-yqaSMAng.mjs
 
 # tests/esbuild/dce/dce_type_of_equals_string
 
-- entry_js-Cg3QacaM.mjs
+- entry_js-!~{000}~.mjs => entry_js-Cg3QacaM.mjs
 
 # tests/esbuild/dce/drop_label_tree_shaking_bug_issue3311
 
-- entry_js-V4_lttMm.mjs
+- entry_js-!~{000}~.mjs => entry_js-V4_lttMm.mjs
 
 # tests/esbuild/dce/file_loader_remove_unused
 
-- entry_js-a50D-tCc.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-a50D-tCc.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/dce/import_re_export_of_namespace_import
 
-- entry_js-c5EAqwgy.mjs
-- $runtime$-AWpG-C_M.mjs
+- entry_js-!~{000}~.mjs => entry_js-c5EAqwgy.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-AWpG-C_M.mjs
 
 # tests/esbuild/dce/inline_function_call_for_init_decl
 
-- entry_js-o_cxoKSV.mjs
+- entry_js-!~{000}~.mjs => entry_js-o_cxoKSV.mjs
 
 # tests/esbuild/dce/remove_code_after_label_with_return
 
-- entry_js-768RV9YH.mjs
+- entry_js-!~{000}~.mjs => entry_js-768RV9YH.mjs
 
 # tests/esbuild/dce/remove_trailing_return
 
-- entry_js-0KHFRH8R.mjs
+- entry_js-!~{000}~.mjs => entry_js-0KHFRH8R.mjs
 
 # tests/esbuild/dce/remove_unused_import_meta
 
-- entry_js-tiQvKDBq.mjs
+- entry_js-!~{000}~.mjs => entry_js-tiQvKDBq.mjs
 
 # tests/esbuild/dce/text_loader_remove_unused
 
-- entry_js-jE3smO-n.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-jE3smO-n.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/dce/tree_shaking_binary_operators
 
-- entry_js-xEJLYvwR.mjs
+- entry_js-!~{000}~.mjs => entry_js-xEJLYvwR.mjs
 
 # tests/esbuild/dce/tree_shaking_import_identifier
 
-- entry_js-VY9fbi7V.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-VY9fbi7V.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/dce/tree_shaking_in_esm_wrapper
 
-- entry_js-Ot39bAO0.mjs
-- $runtime$-vR6TnGxp.mjs
+- entry_js-!~{000}~.mjs => entry_js-Ot39bAO0.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/dce/tree_shaking_unary_operators
 
-- entry_js-MxqxhYGb.mjs
+- entry_js-!~{000}~.mjs => entry_js-MxqxhYGb.mjs
 
 # tests/esbuild/default/ambiguous_reexport_msg
 
-- entry_js-K2tYIvmv.mjs
+- entry_js-!~{000}~.mjs => entry_js-K2tYIvmv.mjs
 
 # tests/esbuild/default/arrow_fn_scope
 
-- entry_js-bsd1Vt5x.mjs
+- entry_js-!~{000}~.mjs => entry_js-bsd1Vt5x.mjs
 
 # tests/esbuild/default/auto_external
 
-- entry_js-tYfXLfpU.mjs
+- entry_js-!~{000}~.mjs => entry_js-tYfXLfpU.mjs
 
 # tests/esbuild/default/avoid_tdz
 
-- entry_js-7w2tfinI.mjs
+- entry_js-!~{000}~.mjs => entry_js-7w2tfinI.mjs
 
 # tests/esbuild/default/await_import_inside_try
 
-- entry_js-alYWxrrK.mjs
+- entry_js-!~{000}~.mjs => entry_js-alYWxrrK.mjs
 
 # tests/esbuild/default/common_js_from_es6
 
-- entry_js-4ti5rQwL.mjs
-- $runtime$-vR6TnGxp.mjs
+- entry_js-!~{000}~.mjs => entry_js-4ti5rQwL.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/default/const_with_let
 
-- entry_js-3MVisSSA.mjs
+- entry_js-!~{000}~.mjs => entry_js-3MVisSSA.mjs
 
 # tests/esbuild/default/dot_import
 
-- entry_js-qA3G3aMM.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-qA3G3aMM.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/default/duplicate_entry_point
 
-- entry_js-P03grTeI.mjs
-- entry2_js-gLxkMptc.mjs
-- entry-DXoyZNA-.mjs
+- entry_js-!~{000}~.mjs => entry_js-P03grTeI.mjs
+- entry2_js-!~{001}~.mjs => entry2_js-gLxkMptc.mjs
+- entry-!~{002}~.mjs => entry-DXoyZNA-.mjs
 
 # tests/esbuild/default/dynamic_import_with_expression_cjs
 
-- a_js-vtxMteYF.cjs
+- a_js-!~{000}~.cjs => a_js-vtxMteYF.cjs
 
 # tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910
 
-- entry_js-qwSWZfQl.mjs
-- $runtime$-FWY5Q29P.mjs
+- entry_js-!~{000}~.mjs => entry_js-qwSWZfQl.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-FWY5Q29P.mjs
 
 # tests/esbuild/default/es6_from_common_js
 
-- entry_js-lswHEC91.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-lswHEC91.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/default/export_chain
 
-- entry_js-dP8ZNNIo.mjs
+- entry_js-!~{000}~.mjs => entry_js-dP8ZNNIo.mjs
 
 # tests/esbuild/default/export_forms_common_js
 
-- entry_js-MwmhDoh9.mjs
-- $runtime$-vR6TnGxp.mjs
+- entry_js-!~{000}~.mjs => entry_js-MwmhDoh9.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/default/export_forms_es6
 
-- entry_js-sos27Agl.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-sos27Agl.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/default/external_packages
 
-- entry_js-qquV9Mgf.mjs
+- entry_js-!~{000}~.mjs => entry_js-qquV9Mgf.mjs
 
 # tests/esbuild/default/forbid_const_assign_when_bundling
 
-- entry_js-5eClpM70.mjs
+- entry_js-!~{000}~.mjs => entry_js-5eClpM70.mjs
 
 # tests/esbuild/default/import_fs_node_common_js
 
-- entry_js-TE_F6vZL.cjs
+- entry_js-!~{000}~.cjs => entry_js-TE_F6vZL.cjs
 
 # tests/esbuild/default/import_missing_common_js
 
-- entry_js-BJkPislD.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-BJkPislD.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/default/import_then_catch
 
-- entry_js-tWQeN0Ma.mjs
+- entry_js-!~{000}~.mjs => entry_js-tWQeN0Ma.mjs
 
 # tests/esbuild/default/keep_names_class_static_name
 
-- entry_js-s9lvs6K0.mjs
+- entry_js-!~{000}~.mjs => entry_js-s9lvs6K0.mjs
 
 # tests/esbuild/default/nested_common_js
 
-- entry_js-JTyNJTWq.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-JTyNJTWq.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/nested_es6_from_common_js
 
-- entry_js-BAL2XoGB.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-BAL2XoGB.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/default/nested_require_without_call
 
-- entry_js-EKmUjNd6.mjs
+- entry_js-!~{000}~.mjs => entry_js-EKmUjNd6.mjs
 
 # tests/esbuild/default/nested_scope_bug
 
-- entry_js-FJIm2QaS.mjs
+- entry_js-!~{000}~.mjs => entry_js-FJIm2QaS.mjs
 
 # tests/esbuild/default/new_expression_common_js
 
-- entry_js-8H4WN1WU.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-8H4WN1WU.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/no_overwrite_input_file_error
 
-- entry_js-8LrtHevd.mjs
+- entry_js-!~{000}~.mjs => entry_js-8LrtHevd.mjs
 
 # tests/esbuild/default/outbase
 
-- c_js-Sfntij9A.mjs
-- d_js-A6twFbY_.mjs
+- c_js-!~{000}~.mjs => c_js-Sfntij9A.mjs
+- d_js-!~{001}~.mjs => d_js-A6twFbY_.mjs
 
 # tests/esbuild/default/quoted_property
 
-- entry_js-z5zTfYuC.mjs
+- entry_js-!~{000}~.mjs => entry_js-z5zTfYuC.mjs
 
 # tests/esbuild/default/re_export_common_js_as_es6
 
-- entry_js-WGnxJ-SI.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-WGnxJ-SI.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/default/re_export_default_internal
 
-- entry_js-VAX5GNXh.mjs
+- entry_js-!~{000}~.mjs => entry_js-VAX5GNXh.mjs
 
 # tests/esbuild/default/relative_entry_point_error
 
-- entry-R3uYdA1l.mjs
+- entry-!~{000}~.mjs => entry-R3uYdA1l.mjs
 
 # tests/esbuild/default/require_child_dir_common_js
 
-- entry_js-cjN4Bdij.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-cjN4Bdij.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/require_child_dir_es6
 
-- entry_js--0ookdtP.mjs
+- entry_js-!~{000}~.mjs => entry_js--0ookdtP.mjs
 
 # tests/esbuild/default/require_main_cache_common_js
 
-- entry_js-OFrWorTU.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-OFrWorTU.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/require_parent_dir_common_js
 
-- dir_entry_js-TqGj3PVc.mjs
-- $runtime$-6wzC9jCL.mjs
+- dir_entry_js-!~{000}~.mjs => dir_entry_js-TqGj3PVc.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/require_parent_dir_es6
 
-- dir_entry_js-TffzVWBQ.mjs
+- dir_entry_js-!~{000}~.mjs => dir_entry_js-TffzVWBQ.mjs
 
 # tests/esbuild/default/require_property_access_common_js
 
-- entry_js-Q1RceOpL.mjs
+- entry_js-!~{000}~.mjs => entry_js-Q1RceOpL.mjs
 
 # tests/esbuild/default/require_resolve
 
-- entry_js-Mv-t7hMH.mjs
+- entry_js-!~{000}~.mjs => entry_js-Mv-t7hMH.mjs
 
 # tests/esbuild/default/require_with_call_inside_try
 
-- entry_js-f3IEt299.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-f3IEt299.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/require_without_call
 
-- entry_js-eFlaDQif.mjs
+- entry_js-!~{000}~.mjs => entry_js-eFlaDQif.mjs
 
 # tests/esbuild/default/require_without_call_inside_try
 
-- entry_js-CID1xcTR.mjs
+- entry_js-!~{000}~.mjs => entry_js-CID1xcTR.mjs
 
 # tests/esbuild/default/reserve_props
 
-- entry_js-Tyq-szys.mjs
+- entry_js-!~{000}~.mjs => entry_js-Tyq-szys.mjs
 
 # tests/esbuild/default/simple_common_js
 
-- entry_js-Kjt9Do6P.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-Kjt9Do6P.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/simple_es6
 
-- entry_js-Rjle9Mp7.mjs
+- entry_js-!~{000}~.mjs => entry_js-Rjle9Mp7.mjs
 
 # tests/esbuild/default/strict_mode_nested_fn_decl_keep_names_variable_inlining_issue1552
 
-- entry_js-aJPHBSXH.mjs
+- entry_js-!~{000}~.mjs => entry_js-aJPHBSXH.mjs
 
 # tests/esbuild/default/this_inside_function
 
-- entry_js-hp3wpnsR.mjs
+- entry_js-!~{000}~.mjs => entry_js-hp3wpnsR.mjs
 
 # tests/esbuild/default/use_strict_directive_bundle_esm_issue2264
 
-- entry_js-S_UqMuPR.mjs
+- entry_js-!~{000}~.mjs => entry_js-S_UqMuPR.mjs
 
 # tests/esbuild/default/use_strict_directive_bundle_issue1837
 
-- entry_js-iJ-IQkDg.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-iJ-IQkDg.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/default/var_relocating_bundle
 
-- top-level_js-zFcTRQCq.mjs
-- nested_js-9gULdUmo.mjs
-- let_js-NZtFdo_X.mjs
-- function_js-508d9udD.mjs
-- function-nested_js-3Itl4oYw.mjs
+- top-level_js-!~{000}~.mjs => top-level_js-zFcTRQCq.mjs
+- nested_js-!~{001}~.mjs => nested_js-9gULdUmo.mjs
+- let_js-!~{002}~.mjs => let_js-NZtFdo_X.mjs
+- function_js-!~{003}~.mjs => function_js-508d9udD.mjs
+- function-nested_js-!~{004}~.mjs => function-nested_js-3Itl4oYw.mjs
 
 # tests/esbuild/import_star/export_self_as_namespace_es6
 
-- entry_js-Zjs8PpNg.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Zjs8PpNg.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/export_self_common_js
 
-- entry_js-YfY-hhIK.cjs
+- entry_js-!~{000}~.cjs => entry_js-YfY-hhIK.cjs
 
 # tests/esbuild/import_star/export_self_es6
 
-- entry_js-eZKpFnfR.mjs
+- entry_js-!~{000}~.mjs => entry_js-eZKpFnfR.mjs
 
 # tests/esbuild/import_star/import_export_other_as_namespace_common_js
 
-- entry_js-YGsyDWpI.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-YGsyDWpI.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/import_export_self_as_namespace_es6
 
-- entry_js-Zjs8PpNg.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Zjs8PpNg.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_export_star_ambiguous_warning
 
-- entry_js-jEM63MHK.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-jEM63MHK.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_of_export_star
 
-- entry_js-4wZYa_qP.mjs
+- entry_js-!~{000}~.mjs => entry_js-4wZYa_qP.mjs
 
 # tests/esbuild/import_star/import_of_export_star_of_import
 
-- entry_js-9WNq1662.mjs
+- entry_js-!~{000}~.mjs => entry_js-9WNq1662.mjs
 
 # tests/esbuild/import_star/import_self_common_js
 
-- entry_js-5OrdrVz4.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-5OrdrVz4.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/import_star_and_common_js
 
-- entry_js-Qo4uI9_R.mjs
-- $runtime$-vR6TnGxp.mjs
+- entry_js-!~{000}~.mjs => entry_js-Qo4uI9_R.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/import_star/import_star_capture
 
-- entry_js-Nb59JZ9_.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Nb59JZ9_.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_common_js_capture
 
-- entry_js-uC4SyQQl.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-uC4SyQQl.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/import_star_common_js_no_capture
 
-- entry_js-omQ_zVuC.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-omQ_zVuC.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/import_star_common_js_unused
 
-- entry_js-r1zYVnBD.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-r1zYVnBD.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_capture
 
-- entry_js-Nb59JZ9_.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Nb59JZ9_.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_no_capture
 
-- entry_js-Rxv2YhfA.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Rxv2YhfA.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_import_star_unused
 
-- entry_js-0ZgkONLo.mjs
+- entry_js-!~{000}~.mjs => entry_js-0ZgkONLo.mjs
 
 # tests/esbuild/import_star/import_star_export_star_as_capture
 
-- entry_js-Nb59JZ9_.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Nb59JZ9_.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_as_no_capture
 
-- entry_js-Rxv2YhfA.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Rxv2YhfA.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_as_unused
 
-- entry_js-ydely-ew.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-ydely-ew.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_capture
 
-- entry_js-XvODpbLo.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-XvODpbLo.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_no_capture
 
-- entry_js-zoqqsfeu.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-zoqqsfeu.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_omit_ambiguous
 
-- entry_js-gPlTS0bF.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-gPlTS0bF.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_export_star_unused
 
-- entry_js-0ZgkONLo.mjs
+- entry_js-!~{000}~.mjs => entry_js-0ZgkONLo.mjs
 
 # tests/esbuild/import_star/import_star_no_capture
 
-- entry_js-Rxv2YhfA.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Rxv2YhfA.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_of_export_star_as
 
-- entry_js-8XORSYMb.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-8XORSYMb.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/import_star_unused
 
-- entry_js-0ZgkONLo.mjs
+- entry_js-!~{000}~.mjs => entry_js-0ZgkONLo.mjs
 
 # tests/esbuild/import_star/issue176
 
-- entry_js-G1jzfW5F.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-G1jzfW5F.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/namespace_import_missing_common_js
 
-- entry_js-t3Suhxx_.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-t3Suhxx_.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/namespace_import_missing_es6
 
-- entry_js-7oWuFBtK.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-7oWuFBtK.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/namespace_import_re_export_star_missing_es6
 
-- entry_js-i-Fd9UVH.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-i-Fd9UVH.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/namespace_import_re_export_star_unused_missing_es6
 
-- entry_js-3JnON20m.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-3JnON20m.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/namespace_import_unused_missing_common_js
 
-- entry_js-GLIUkWiS.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry_js-!~{000}~.mjs => entry_js-GLIUkWiS.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/import_star/namespace_import_unused_missing_es6
 
-- entry_js-Zagt51Rt.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-Zagt51Rt.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/other_file_export_self_as_namespace_unused_es6
 
-- entry_js-kdwdpUqf.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-kdwdpUqf.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/other_file_import_export_self_as_namespace_unused_es6
 
-- entry_js-9AmJ1Gkp.mjs
+- entry_js-!~{000}~.mjs => entry_js-9AmJ1Gkp.mjs
 
 # tests/esbuild/import_star/re_export_namespace_import_missing_es6
 
-- entry_js-GeAA33Yj.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-GeAA33Yj.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/re_export_namespace_import_unused_missing_es6
 
-- entry_js-SSs3UiOe.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-SSs3UiOe.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/re_export_other_file_export_self_as_namespace_es6
 
-- entry_js-c2v0AGZC.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-c2v0AGZC.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/re_export_other_file_import_export_self_as_namespace_es6
 
-- entry_js-c2v0AGZC.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-c2v0AGZC.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/re_export_star_as_external_common_js
 
-- entry_js-xqfVgBNO.cjs
+- entry_js-!~{000}~.cjs => entry_js-xqfVgBNO.cjs
 
 # tests/esbuild/import_star/re_export_star_as_external_es6
 
-- entry_js-Hh289cnx.mjs
+- entry_js-!~{000}~.mjs => entry_js-Hh289cnx.mjs
 
 # tests/esbuild/import_star/re_export_star_entry_point_and_inner_file
 
-- entry_js-1yhhclYV.mjs
-- $runtime$-p3E6YEwS.mjs
+- entry_js-!~{000}~.mjs => entry_js-1yhhclYV.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-p3E6YEwS.mjs
 
 # tests/esbuild/import_star/re_export_star_external_common_js
 
-- entry_js-rud5zVrH.cjs
+- entry_js-!~{000}~.cjs => entry_js-rud5zVrH.cjs
 
 # tests/esbuild/import_star/re_export_star_external_es6
 
-- entry_js--Ducb3XN.mjs
+- entry_js-!~{000}~.mjs => entry_js--Ducb3XN.mjs
 
 # tests/esbuild/import_star/re_export_star_name_collision_not_ambiguous_export
 
-- entry_js-Nok7HjpZ.mjs
+- entry_js-!~{000}~.mjs => entry_js-Nok7HjpZ.mjs
 
 # tests/esbuild/import_star/re_export_star_name_collision_not_ambiguous_import
 
-- entry_js-cxWW65mu.mjs
+- entry_js-!~{000}~.mjs => entry_js-cxWW65mu.mjs
 
 # tests/esbuild/import_star/re_export_star_name_shadowing_not_ambiguous
 
-- entry_js-mlg8oAre.mjs
+- entry_js-!~{000}~.mjs => entry_js-mlg8oAre.mjs
 
 # tests/esbuild/import_star/re_export_star_name_shadowing_not_ambiguous_re_export
 
-- entry_js-JPJ4y3_I.mjs
+- entry_js-!~{000}~.mjs => entry_js-JPJ4y3_I.mjs
 
 # tests/esbuild/lower/lower_async_es5
 
-- entry_js-768RV9YH.mjs
+- entry_js-!~{000}~.mjs => entry_js-768RV9YH.mjs
 
 # tests/esbuild/lower/lower_async_this2016_common_js
 
-- entry_js-Ad0z75lz.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry_js-!~{000}~.mjs => entry_js-Ad0z75lz.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/lower/lower_async_this2016_es6
 
-- entry_js-JiRz4zy_.mjs
+- entry_js-!~{000}~.mjs => entry_js-JiRz4zy_.mjs
 
 # tests/esbuild/lower/lower_for_await2015
 
-- entry_js-l3XOrHvM.mjs
+- entry_js-!~{000}~.mjs => entry_js-l3XOrHvM.mjs
 
 # tests/esbuild/lower/lower_for_await2017
 
-- entry_js-l3XOrHvM.mjs
+- entry_js-!~{000}~.mjs => entry_js-l3XOrHvM.mjs
 
 # tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493
 
-- entry_js-14C4TPTg.mjs
+- entry_js-!~{000}~.mjs => entry_js-14C4TPTg.mjs
 
 # tests/esbuild/lower/lower_private_class_accessor_order
 
-- entry_js-ByppGU64.mjs
+- entry_js-!~{000}~.mjs => entry_js-ByppGU64.mjs
 
 # tests/esbuild/lower/lower_private_class_brand_check_supported
 
-- entry_js-768RV9YH.mjs
+- entry_js-!~{000}~.mjs => entry_js-768RV9YH.mjs
 
 # tests/esbuild/lower/lower_private_class_brand_check_unsupported
 
-- entry_js-768RV9YH.mjs
+- entry_js-!~{000}~.mjs => entry_js-768RV9YH.mjs
 
 # tests/esbuild/lower/lower_private_class_field_order
 
-- entry_js-RuMA6KsR.mjs
+- entry_js-!~{000}~.mjs => entry_js-RuMA6KsR.mjs
 
 # tests/esbuild/lower/lower_private_class_field_static_issue1424
 
-- entry_js-pBq_IsMb.mjs
+- entry_js-!~{000}~.mjs => entry_js-pBq_IsMb.mjs
 
 # tests/esbuild/lower/lower_private_class_method_order
 
-- entry_js-34lN_5-1.mjs
+- entry_js-!~{000}~.mjs => entry_js-34lN_5-1.mjs
 
 # tests/esbuild/lower/lower_private_class_static_accessor_order
 
-- entry_js-hs0ITU8f.mjs
+- entry_js-!~{000}~.mjs => entry_js-hs0ITU8f.mjs
 
 # tests/esbuild/lower/lower_private_class_static_field_order
 
-- entry_js-EWIKKmXn.mjs
+- entry_js-!~{000}~.mjs => entry_js-EWIKKmXn.mjs
 
 # tests/esbuild/lower/lower_private_class_static_method_order
 
-- entry_js-Iv_WCBqp.mjs
+- entry_js-!~{000}~.mjs => entry_js-Iv_WCBqp.mjs
 
 # tests/esbuild/lower/lower_private_getter_setter2015
 
-- entry_js-oztyDTOS.mjs
+- entry_js-!~{000}~.mjs => entry_js-oztyDTOS.mjs
 
 # tests/esbuild/lower/lower_private_getter_setter2019
 
-- entry_js-oztyDTOS.mjs
+- entry_js-!~{000}~.mjs => entry_js-oztyDTOS.mjs
 
 # tests/esbuild/lower/lower_private_getter_setter2020
 
-- entry_js-oztyDTOS.mjs
+- entry_js-!~{000}~.mjs => entry_js-oztyDTOS.mjs
 
 # tests/esbuild/lower/lower_private_getter_setter_next
 
-- entry_js-oztyDTOS.mjs
+- entry_js-!~{000}~.mjs => entry_js-oztyDTOS.mjs
 
 # tests/esbuild/lower/lower_private_method2019
 
-- entry_js-XYpLtkIm.mjs
+- entry_js-!~{000}~.mjs => entry_js-XYpLtkIm.mjs
 
 # tests/esbuild/lower/lower_private_method2020
 
-- entry_js-XYpLtkIm.mjs
+- entry_js-!~{000}~.mjs => entry_js-XYpLtkIm.mjs
 
 # tests/esbuild/lower/lower_private_method_next
 
-- entry_js-XYpLtkIm.mjs
+- entry_js-!~{000}~.mjs => entry_js-XYpLtkIm.mjs
 
 # tests/esbuild/lower/lower_private_method_with_modifiers2020
 
-- entry_js-Gl8LWG6F.mjs
+- entry_js-!~{000}~.mjs => entry_js-Gl8LWG6F.mjs
 
 # tests/esbuild/lower/lower_private_super_static_bundle_issue2158
 
-- entry_js-y263I-2r.mjs
+- entry_js-!~{000}~.mjs => entry_js-y263I-2r.mjs
 
 # tests/esbuild/lower/lower_reg_exp_name_collision
 
-- entry_js-WTSQ2kHq.mjs
+- entry_js-!~{000}~.mjs => entry_js-WTSQ2kHq.mjs
 
 # tests/esbuild/lower/lower_template_object
 
-- entry_js-768RV9YH.mjs
+- entry_js-!~{000}~.mjs => entry_js-768RV9YH.mjs
 
 # tests/esbuild/lower/static_class_block_es2021
 
-- entry_js-aooHLG4F.mjs
+- entry_js-!~{000}~.mjs => entry_js-aooHLG4F.mjs
 
 # tests/esbuild/lower/static_class_block_es_next
 
-- entry_js-aooHLG4F.mjs
+- entry_js-!~{000}~.mjs => entry_js-aooHLG4F.mjs
 
 # tests/esbuild/packagejson/test_package_json_bad_main
 
-- entry-N2N-2gTp.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-N2N-2gTp.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_index_no_ext
 
-- entry-t2t75zSt.mjs
+- entry-!~{000}~.mjs => entry-t2t75zSt.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_issue2002_a
 
-- entry-Grp4OUuD.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-Grp4OUuD.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_issue2002_c
 
-- entry-aKM4d5_j.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-aKM4d5_j.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_avoid_missing
 
-- entry-9gRlHDBF.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-9gRlHDBF.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_module_disabled
 
-- entry-KD3UkCYm.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-KD3UkCYm.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_module_to_module
 
-- entry-uq7lnRgH.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-uq7lnRgH.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_module_to_relative
 
-- entry-krnhGpEH.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-krnhGpEH.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_native_module_disabled
 
-- entry-RHnxONui.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-RHnxONui.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_relative_disabled
 
-- entry-yMqIooMO.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-yMqIooMO.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_relative_to_module
 
-- entry-tva7ZXBf.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-tva7ZXBf.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_relative_to_relative
 
-- entry-xi9VMMro.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-xi9VMMro.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_no_ext
 
-- entry-NKU4hPlA.mjs
+- entry-!~{000}~.mjs => entry-NKU4hPlA.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_node_modules_index_no_ext
 
-- entry-pWKNbBGQ.mjs
+- entry-!~{000}~.mjs => entry-pWKNbBGQ.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_node_modules_no_ext
 
-- entry-sWZyPErY.mjs
+- entry-!~{000}~.mjs => entry-sWZyPErY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_over_main_node
 
-- entry-UoUzFxo1.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-UoUzFxo1.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_over_module_browser
 
-- entry-JIbWuyj_.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-JIbWuyj_.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_string
 
-- entry-n64V-Zp8.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-n64V-Zp8.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_with_main_node
 
-- entry-UoUzFxo1.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-UoUzFxo1.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_with_module_browser
 
-- entry-Gl72KJXS.mjs
+- entry-!~{000}~.mjs => entry-Gl72KJXS.mjs
 
 # tests/esbuild/packagejson/test_package_json_disabled_type_module_issue3367
 
-- entry-RaFWGttt.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-RaFWGttt.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_browser
 
-- entry-3nf6Oa_i.mjs
-- $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-3nf6Oa_i.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_force_module_before_main
 
-- entry-Betafk68.mjs
-- $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-Betafk68.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_implicit_main
 
-- entry-Wo3WOs45.mjs
-- $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-Wo3WOs45.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main
 
-- entry-Wo3WOs45.mjs
-- $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-Wo3WOs45.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_same_file
 
-- entry-zxGCGekR.mjs
-- $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-zxGCGekR.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_separate_files
 
-- entry-Betafk68.mjs
-- $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-Betafk68.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_only
 
-- entry-lZ8mNqnR.mjs
+- entry-!~{000}~.mjs => entry-lZ8mNqnR.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_require_only
 
-- entry-o5R7C6Po.mjs
-- $runtime$-vR6TnGxp.mjs
+- entry-!~{000}~.mjs => entry-o5R7C6Po.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_browser
 
-- entry-bOVF_gv-.mjs
+- entry-!~{000}~.mjs => entry-bOVF_gv-.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_custom_conditions
 
-- entry-a0bF4eQm.mjs
+- entry-!~{000}~.mjs => entry-a0bF4eQm.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_entry_point_import_over_require
 
-- entry-3tCW4XWQ.mjs
+- entry-!~{000}~.mjs => entry-3tCW4XWQ.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_entry_point_main_only
 
-- entry-X0jnqyR8.mjs
+- entry-!~{000}~.mjs => entry-X0jnqyR8.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_entry_point_module_over_main
 
-- entry-p66zakjQ.mjs
+- entry-!~{000}~.mjs => entry-p66zakjQ.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_entry_point_require_only
 
 
 # tests/esbuild/packagejson/test_package_json_exports_import_over_require
 
-- entry-bSaTO-KK.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-bSaTO-KK.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_neutral
 
-- entry-JF9d90w2.mjs
+- entry-!~{000}~.mjs => entry-JF9d90w2.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_node
 
-- entry-4h1M45BS.mjs
+- entry-!~{000}~.mjs => entry-4h1M45BS.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_not_exact_missing_extension
 
-- entry-z4MWU1jP.mjs
+- entry-!~{000}~.mjs => entry-z4MWU1jP.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_order_independent
 
-- entry-4zUM8YPI.mjs
+- entry-!~{000}~.mjs => entry-4zUM8YPI.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_pattern_trailers
 
-- entry-pqRM6Awy.mjs
+- entry-!~{000}~.mjs => entry-pqRM6Awy.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_require_over_import
 
-- entry-RPehkXQS.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-RPehkXQS.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_wildcard
 
-- entry-oEUWxLjK.mjs
+- entry-!~{000}~.mjs => entry-oEUWxLjK.mjs
 
 # tests/esbuild/packagejson/test_package_json_import_self_using_import
 
-- entry-xhXOK5jN.mjs
+- entry-!~{000}~.mjs => entry-xhXOK5jN.mjs
 
 # tests/esbuild/packagejson/test_package_json_import_self_using_import_scoped
 
-- entry-xhXOK5jN.mjs
+- entry-!~{000}~.mjs => entry-xhXOK5jN.mjs
 
 # tests/esbuild/packagejson/test_package_json_import_self_using_require
 
-- entry-JwFzZT2I.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-JwFzZT2I.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_import_self_using_require_scoped
 
-- entry-JwFzZT2I.mjs
-- $runtime$-6wzC9jCL.mjs
+- entry-!~{000}~.mjs => entry-JwFzZT2I.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/esbuild/packagejson/test_package_json_imports
 
-- entry-cZfpZxRv.mjs
+- entry-!~{000}~.mjs => entry-cZfpZxRv.mjs
 
 # tests/esbuild/packagejson/test_package_json_imports_error_unsupported_directory_import
 
-- entry-il8Vihdd.mjs
+- entry-!~{000}~.mjs => entry-il8Vihdd.mjs
 
 # tests/esbuild/packagejson/test_package_json_imports_remap_to_other_package
 
-- entry-UlXuFzMS.mjs
+- entry-!~{000}~.mjs => entry-UlXuFzMS.mjs
 
 # tests/esbuild/packagejson/test_package_json_main
 
-- entry-ZJ_oxjPL.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-ZJ_oxjPL.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_main_fields_a
 
-- entry-ruZ1xbOz.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-ruZ1xbOz.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/packagejson/test_package_json_main_fields_b
 
-- entry-ZuInevZl.mjs
+- entry-!~{000}~.mjs => entry-ZuInevZl.mjs
 
 # tests/esbuild/packagejson/test_package_json_module
 
-- entry-5YTkTqn3.mjs
+- entry-!~{000}~.mjs => entry-5YTkTqn3.mjs
 
 # tests/esbuild/packagejson/test_package_json_neutral_explicit_main_fields
 
-- entry-UoUzFxo1.mjs
-- $runtime$-aUKPtNTY.mjs
+- entry-!~{000}~.mjs => entry-UoUzFxo1.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/esbuild/splitting/assign-to-local
 
-- a-KZ3yWiFy.mjs
-- b-sescAl-r.mjs
-- shared-eZE_MQu5.mjs
+- a-!~{000}~.mjs => a-KZ3yWiFy.mjs
+- b-!~{001}~.mjs => b-sescAl-r.mjs
+- shared-!~{002}~.mjs => shared-eZE_MQu5.mjs
 
 # tests/esbuild/splitting/circular_reference_issue251
 
-- a-Dp0eN-ZJ.mjs
-- b-r-rPquvC.mjs
-- a~1-1QJJkgOj.mjs
+- a-!~{000}~.mjs => a-Dp0eN-ZJ.mjs
+- b-!~{001}~.mjs => b-r-rPquvC.mjs
+- a~1-!~{002}~.mjs => a~1-1QJJkgOj.mjs
 
 # tests/esbuild/splitting/cross_chunk_assignment_dependencies
 
-- a-SkEk-0qP.mjs
-- b-IAQUKyjm.mjs
-- shared-qfXNz9pr.mjs
+- a-!~{000}~.mjs => a-SkEk-0qP.mjs
+- b-!~{001}~.mjs => b-IAQUKyjm.mjs
+- shared-!~{002}~.mjs => shared-qfXNz9pr.mjs
 
 # tests/esbuild/splitting/duplicate_chunk_collision
 
-- a-6c_8_6PJ.mjs
-- b-hqvCqhgj.mjs
-- c-GcoI6NSv.mjs
-- d-FvXiEf_f.mjs
-- d~1-_GjC6vrH.mjs
-- ab-0xnqDU7x.mjs
+- a-!~{000}~.mjs => a-_w0taR1b.mjs
+- b-!~{001}~.mjs => b-olkBUWGd.mjs
+- c-!~{002}~.mjs => c-nB1waE7L.mjs
+- d-!~{003}~.mjs => d-23u0z093.mjs
+- d~1-!~{005}~.mjs => d~1-ot8CcU_S.mjs
+- ab-!~{004}~.mjs => ab-cKY-d3KL.mjs
 
 # tests/esbuild/splitting/dynamic-commonjs-into-es6
 
-- main-hJ-rtw7N.mjs
-- foo-6VLOUb_v.mjs
-- $runtime$-evkBfY1S.mjs
+- main-!~{000}~.mjs => main-hJ-rtw7N.mjs
+- foo-!~{001}~.mjs => foo-6VLOUb_v.mjs
+- $runtime$-!~{002}~.mjs => $runtime$-evkBfY1S.mjs
 
 # tests/esbuild/splitting/dynamic-es6-into-es6
 
-- main-aZfKZWQl.mjs
-- foo-y4QWWTtX.mjs
+- main-!~{000}~.mjs => main-aZfKZWQl.mjs
+- foo-!~{001}~.mjs => foo-y4QWWTtX.mjs
 
 # tests/esbuild/splitting/dynamic_and_not_dynamic_es6_into_es6
 
-- main-8i8JF42P.mjs
-- foo-O6enMBv0.mjs
-- foo~1-Sof3A-nJ.mjs
+- main-!~{000}~.mjs => main-8i8JF42P.mjs
+- foo-!~{001}~.mjs => foo-O6enMBv0.mjs
+- foo~1-!~{002}~.mjs => foo~1-Sof3A-nJ.mjs
 
 # tests/esbuild/splitting/dynamic_import_issue_272
 
-- a-lzkhn1t-.mjs
-- b-Ngqr-aWB.mjs
+- a-!~{000}~.mjs => a-lzkhn1t-.mjs
+- b-!~{001}~.mjs => b-Ngqr-aWB.mjs
 
 # tests/esbuild/splitting/hybrid_esm_and_cjs_issue617
 
-- a-ehXIs1Q0.mjs
-- b-_ZC1yYMg.mjs
-- $runtime$-sLq7rqre.mjs
-- a~1-h7V72K_5.mjs
+- a-!~{000}~.mjs => a-j8sPFyQR.mjs
+- b-!~{001}~.mjs => b-37AHhNXO.mjs
+- $runtime$-!~{003}~.mjs => $runtime$-6upNuhUk.mjs
+- a~1-!~{002}~.mjs => a~1-dKuKLwqf.mjs
 
 # tests/esbuild/splitting/nested_directories
 
-- a-1AmcEbF8.mjs
-- b-Ocnsf82U.mjs
-- shared-PMFWUU19.mjs
+- a-!~{000}~.mjs => a-1AmcEbF8.mjs
+- b-!~{001}~.mjs => b-Ocnsf82U.mjs
+- shared-!~{002}~.mjs => shared-PMFWUU19.mjs
 
 # tests/esbuild/splitting/re_export_issue273
 
-- a-h6hliDTl.mjs
-- b-tekxdp99.mjs
-- a~1-bC-OZCUw.mjs
+- a-!~{000}~.mjs => a-h6hliDTl.mjs
+- b-!~{001}~.mjs => b-tekxdp99.mjs
+- a~1-!~{002}~.mjs => a~1-bC-OZCUw.mjs
 
 # tests/esbuild/splitting/shared-commonjs-into-es6
 
-- a-bbZoaN8Q.mjs
-- b-Nz9nzYcD.mjs
-- $runtime$-evkBfY1S.mjs
-- shared-nuzlCZ7S.mjs
+- a-!~{000}~.mjs => a-UW6CzJN7.mjs
+- b-!~{001}~.mjs => b-h6eR_jS-.mjs
+- $runtime$-!~{003}~.mjs => $runtime$-t9w3LEYM.mjs
+- shared-!~{002}~.mjs => shared-He95S4k_.mjs
 
 # tests/esbuild/splitting/shared-es6-into-es6
 
-- a-Bwt3h9ea.mjs
-- b-ScZk0JLh.mjs
-- shared-2UmobjmC.mjs
+- a-!~{000}~.mjs => a-Bwt3h9ea.mjs
+- b-!~{001}~.mjs => b-ScZk0JLh.mjs
+- shared-!~{002}~.mjs => shared-2UmobjmC.mjs
 
 # tests/esbuild/splitting/side_effects_without_dependencies
 
-- a-nzNBC-qm.mjs
-- b-dXF-TF6V.mjs
-- shared-zquJkVnu.mjs
+- a-!~{000}~.mjs => a-nzNBC-qm.mjs
+- b-!~{001}~.mjs => b-dXF-TF6V.mjs
+- shared-!~{002}~.mjs => shared-zquJkVnu.mjs
 
 # tests/fixtures/cjs_compat/basic_commonjs
 
-- main-tOFH7NRF.mjs
-- $runtime$-KMO3JWcm.mjs
+- main-!~{000}~.mjs => main-tOFH7NRF.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-KMO3JWcm.mjs
 
 # tests/fixtures/cjs_compat/cjs_entry
 
-- main-MsyS7r4B.mjs
-- $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-MsyS7r4B.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/cjs_compat/dynamic_cjs_entry
 
-- main-_stJcfO2.mjs
-- cjs-qtrxQfWU.mjs
-- $runtime$-evkBfY1S.mjs
+- main-!~{000}~.mjs => main-_stJcfO2.mjs
+- cjs-!~{001}~.mjs => cjs-qtrxQfWU.mjs
+- $runtime$-!~{002}~.mjs => $runtime$-evkBfY1S.mjs
 
 # tests/fixtures/cjs_compat/empty_file_should_be_treated_as_cjs/import
 
-- main-JBLAWjNs.mjs
-- $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-JBLAWjNs.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/empty_file_should_be_treated_as_cjs/re_export
 
-- main-JBLAWjNs.mjs
-- $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-JBLAWjNs.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/esm_require_cjs
 
-- main-z04rJP3L.mjs
-- $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-z04rJP3L.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/cjs_compat/esm_require_esm
 
-- main-t5PgBB84.mjs
-- $runtime$-vR6TnGxp.mjs
+- main-!~{000}~.mjs => main-t5PgBB84.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/fixtures/cjs_compat/esm_require_esm_unused
 
-- main-CbjTMjYQ.mjs
-- $runtime$-vR6TnGxp.mjs
+- main-!~{000}~.mjs => main-CbjTMjYQ.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
 
-- main-H9ncXSC9.mjs
-- $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-H9ncXSC9.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import
 
-- main-ejVOFsTW.mjs
-- $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-ejVOFsTW.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
 
-- main-TYCnsom9.mjs
-- $runtime$-Mp5R-3C4.mjs
+- main-!~{000}~.mjs => main-TYCnsom9.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-Mp5R-3C4.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
 
-- main-Wj2uMhoR.mjs
-- $runtime$-Mp5R-3C4.mjs
+- main-!~{000}~.mjs => main-Wj2uMhoR.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-Mp5R-3C4.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
 
-- main-uVU2cC_l.mjs
-- $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-uVU2cC_l.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport
 
-- main-J_oJ8eiV.mjs
-- $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-J_oJ8eiV.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/import_the_same_cjs_twice
 
-- main-rIpTdR-D.mjs
-- $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-rIpTdR-D.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/mix-cjs-esm
 
 - main-kq71YIv7.mjs.map
-- main-kq71YIv7.mjs
-- $runtime$-aUKPtNTY.mjs
+- main-!~{000}~.mjs => main-kq71YIv7.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/cjs_compat/multiple_circle_cjs_entries
 
-- a-RxLY-5jA.mjs
-- b-dvtQ8qlZ.mjs
-- $runtime$-x7wFgY46.mjs
-- a~1--19YZtkL.mjs
+- a-!~{000}~.mjs => a-9Ad2JmEm.mjs
+- b-!~{001}~.mjs => b-6r3tQdv6.mjs
+- $runtime$-!~{003}~.mjs => $runtime$-jJEZqZu9.mjs
+- a~1-!~{002}~.mjs => a~1-XBjiwYTN.mjs
 
 # tests/fixtures/cjs_compat/reexport_commonjs
 
-- main-gBopYCj6.mjs
-- $runtime$-K_l5acij.mjs
+- main-!~{000}~.mjs => main-gBopYCj6.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-K_l5acij.mjs
 
 # tests/fixtures/cjs_compat/require/create_require
 
-- main-jO-TlKzx.mjs
+- main-!~{000}~.mjs => main-jO-TlKzx.mjs
 
 # tests/fixtures/cjs_compat/require/require_cjs
 
 - main-k19F6glY.mjs.map
-- main-k19F6glY.mjs
-- $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-k19F6glY.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/cjs_compat/require/require_esm
 
 - main-OJfTTu7b.mjs.map
-- main-OJfTTu7b.mjs
-- $runtime$-FWY5Q29P.mjs
+- main-!~{000}~.mjs => main-OJfTTu7b.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-FWY5Q29P.mjs
 
 # tests/fixtures/code_splitting/basic
 
-- main1-qzNNY7k9.mjs
-- main2-e4uxuT8x.mjs
-- dynamic-BetMHB7Z.mjs
-- share-LWF0P6Y-.mjs
+- main1-!~{000}~.mjs => main1-viOQYRtE.mjs
+- main2-!~{001}~.mjs => main2-nzEnxP0_.mjs
+- dynamic-!~{003}~.mjs => dynamic-pSjS7MtL.mjs
+- share-!~{002}~.mjs => share-MuWQnCcv.mjs
 
 # tests/fixtures/code_splitting/ensure_side_effect_executed
 
-- entry_js-aMrgARrj.mjs
-- entry2_js-ENf4Z9xp.mjs
-- entry-FYNiGCEm.mjs
+- entry_js-!~{000}~.mjs => entry_js-aMrgARrj.mjs
+- entry2_js-!~{001}~.mjs => entry2_js-ENf4Z9xp.mjs
+- entry-!~{002}~.mjs => entry-FYNiGCEm.mjs
 
 # tests/fixtures/code_splitting/ensure_side_effect_executed2
 
-- a-aQtPzn6-.mjs
-- b-qe8TOhJq.mjs
-- shared-ACOB7Y24.mjs
+- a-!~{000}~.mjs => a-aQtPzn6-.mjs
+- b-!~{001}~.mjs => b-qe8TOhJq.mjs
+- shared-!~{002}~.mjs => shared-ACOB7Y24.mjs
 
 # tests/fixtures/deconflict/basic
 
-- main-S-XTf22h.mjs
+- main-!~{000}~.mjs => main-S-XTf22h.mjs
 
 # tests/fixtures/deconflict/basic_scoped
 
 - main-U0xUKBal.mjs.map
-- main-U0xUKBal.mjs
+- main-!~{000}~.mjs => main-U0xUKBal.mjs
 
 # tests/fixtures/deconflict/complex_params_patterns
 
 - main-6AAXrAGx.mjs.map
-- main-6AAXrAGx.mjs
+- main-!~{000}~.mjs => main-6AAXrAGx.mjs
 
 # tests/fixtures/deconflict/conflict_between_global_and_local_binding
 
-- main-tOEcGaC9.mjs
-- $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-tOEcGaC9.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/deconflict/conflict_between_imported_and_local_binding
 
-- main-UgkBYeKd.mjs
-- $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-UgkBYeKd.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/deconflict/decl_complex_patterns
 
 - main-Qx1dhUrw.mjs.map
-- main-Qx1dhUrw.mjs
+- main-!~{000}~.mjs => main-Qx1dhUrw.mjs
 
 # tests/fixtures/deconflict/decl_nested_assign_pattern
 
 - main-12nbvJy_.mjs.map
-- main-12nbvJy_.mjs
+- main-!~{000}~.mjs => main-12nbvJy_.mjs
 
 # tests/fixtures/deconflict/default_function
 
 - main-mCrUgOwW.mjs.map
-- main-mCrUgOwW.mjs
+- main-!~{000}~.mjs => main-mCrUgOwW.mjs
 
 # tests/fixtures/deconflict/issue_364
 
 - main-ivEW-tP0.mjs.map
-- main-ivEW-tP0.mjs
+- main-!~{000}~.mjs => main-ivEW-tP0.mjs
 
 # tests/fixtures/deconflict/reserved_names
 
-- main-l74A9xAq.mjs
+- main-!~{000}~.mjs => main-l74A9xAq.mjs
 
 # tests/fixtures/deconflict/wrapped_esm_default_function
 
 - main-Hwm0PQEH.mjs.map
-- main-Hwm0PQEH.mjs
-- $runtime$-vR6TnGxp.mjs
+- main-!~{000}~.mjs => main-Hwm0PQEH.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/fixtures/deconflict/wrapped_esm_export_named_function
 
 - main-puld6Obw.mjs.map
-- main-puld6Obw.mjs
-- $runtime$-vR6TnGxp.mjs
+- main-!~{000}~.mjs => main-puld6Obw.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/fixtures/errors/unresolved_entry
 
 
 # tests/fixtures/function/external/export_external
 
-- main-dVl9dQVv.mjs
+- main-!~{000}~.mjs => main-dVl9dQVv.mjs
 
 # tests/fixtures/function/external/implicit_import_external
 
-- main-27GsR61l.mjs
+- main-!~{000}~.mjs => main-27GsR61l.mjs
 
 # tests/fixtures/function/external/import_external
 
-- main-EY3aBkcP.mjs
+- main-!~{000}~.mjs => main-EY3aBkcP.mjs
 
 # tests/fixtures/function/external/keep_import_external_order
 
-- main-p0EOVxKl.mjs
+- main-!~{000}~.mjs => main-p0EOVxKl.mjs
 
 # tests/fixtures/function/external/splitting_with_external_module
 
-- main-1dgL9psc.mjs
-- entry-ahgOZOc1.mjs
-- share-eIGIrVeP.mjs
+- main-!~{000}~.mjs => main-1dgL9psc.mjs
+- entry-!~{001}~.mjs => entry-ahgOZOc1.mjs
+- share-!~{002}~.mjs => share-eIGIrVeP.mjs
 
 # tests/fixtures/function/resolve/browser_filed_false
 
-- package-ukXkR4ik.mjs
-- $runtime$-aUKPtNTY.mjs
+- package-!~{000}~.mjs => package-ukXkR4ik.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs
 
 # tests/fixtures/function/resolve/node_modules_as_entries
 
-- is-plain-obj-EhLWRH20.mjs
+- is-plain-obj-!~{000}~.mjs => is-plain-obj-EhLWRH20.mjs
 
 # tests/fixtures/function/resolve/resolve_node_modules_by_default
 
-- main-HUNyhaNM.mjs
+- main-!~{000}~.mjs => main-HUNyhaNM.mjs
 
 # tests/fixtures/function/resolve/should_resolve_to_different_target_for_import_and_require
 
-- main-CPUBIUg1.mjs
-- $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-CPUBIUg1.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/function/shim_missing_exports/basic
 
-- main-z7O5ieUj.mjs
+- main-!~{000}~.mjs => main-z7O5ieUj.mjs
 
 # tests/fixtures/function/shim_missing_exports/basic_wrapped_esm
 
-- main-F_sBnFAO.mjs
-- $runtime$-FWY5Q29P.mjs
+- main-!~{000}~.mjs => main-F_sBnFAO.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-FWY5Q29P.mjs
 
 # tests/fixtures/function/shim_missing_exports/shake_unused_shimmed_exports
 
-- main-z7O5ieUj.mjs
+- main-!~{000}~.mjs => main-z7O5ieUj.mjs
 
 # tests/fixtures/function/tree_shaking/unused_import_external
 
-- main-Ix9nDVBV.mjs
+- main-!~{000}~.mjs => main-Ix9nDVBV.mjs
 
 # tests/fixtures/function/tree_shaking/unused_import_named
 
-- main-nyQrEnyN.mjs
+- main-!~{000}~.mjs => main-nyQrEnyN.mjs
 
 # tests/fixtures/issues/122/a
 
-- entry1-tPXhjC_p.mjs
-- entry2-1SmE8XOv.mjs
-- entry3-iKN341B1.mjs
-- c-QCZtDBVV.mjs
-- b-VNLg4mog.mjs
+- entry1-!~{000}~.mjs => entry1-_fcFnBsf.mjs
+- entry2-!~{001}~.mjs => entry2-HA1lKBk8.mjs
+- entry3-!~{002}~.mjs => entry3-bRT67heJ.mjs
+- c-!~{004}~.mjs => c-XewjZoRS.mjs
+- b-!~{003}~.mjs => b-91ZliBhV.mjs
 
 # tests/fixtures/issues/122/b
 
-- a-YQ1-nqTx.mjs
-- b-q0R1_s_7.mjs
-- c-Isvqc62I.mjs
-- 1-BqMrTXTX.mjs
-- 2-LSPOLd9h.mjs
+- a-!~{000}~.mjs => a-9ZdsWyCX.mjs
+- b-!~{001}~.mjs => b-Ryq1zljY.mjs
+- c-!~{002}~.mjs => c-Q0kP-AMp.mjs
+- 1-!~{004}~.mjs => 1-Hl9Rv5WQ.mjs
+- 2-!~{003}~.mjs => 2-BzwAbMwC.mjs
 
 # tests/fixtures/misc/ambiguous_star_export
 
-- main-4CQEffTL.mjs
+- main-!~{000}~.mjs => main-4CQEffTL.mjs
 
 # tests/fixtures/misc/basic
 
 - main-xHsOP41Q.mjs.map
-- main-xHsOP41Q.mjs
+- main-!~{000}~.mjs => main-xHsOP41Q.mjs
 
 # tests/fixtures/misc/basic_re_export
 
-- main-EbG_zl4R.mjs
+- main-!~{000}~.mjs => main-EbG_zl4R.mjs
 
 # tests/fixtures/misc/cjs_entry_as_dependency
 
-- main-qW_OzgXJ.mjs
-- main2-ZrEEjGxb.mjs
-- $runtime$-x7wFgY46.mjs
-- main2~1-5MlZc-S3.mjs
+- main-!~{000}~.mjs => main-Mmg8ggdg.mjs
+- main2-!~{001}~.mjs => main2-L_rA1thF.mjs
+- $runtime$-!~{003}~.mjs => $runtime$-jJEZqZu9.mjs
+- main2~1-!~{002}~.mjs => main2~1-BsWPA0bS.mjs
 
 # tests/fixtures/misc/duplicate_entries
 
-- main-YO-s-G5j.mjs
-- main2-woVkPLUq.mjs
-- main~1-GsuoDQSa.mjs
+- main-!~{000}~.mjs => main-YO-s-G5j.mjs
+- main2-!~{001}~.mjs => main2-woVkPLUq.mjs
+- main~1-!~{002}~.mjs => main~1-GsuoDQSa.mjs
 
 # tests/fixtures/misc/generate_valid_name_for_kebab_case_files
 
-- main-VbkdPg3x.mjs
-- $runtime$-6wzC9jCL.mjs
+- main-!~{000}~.mjs => main-VbkdPg3x.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
 
 # tests/fixtures/misc/issue_376
 
-- main-eqVOd_ca.mjs
+- main-!~{000}~.mjs => main-eqVOd_ca.mjs
 
 # tests/fixtures/misc/object_shorthand_property
 
 - main-Iv9FQrYJ.mjs.map
-- main-Iv9FQrYJ.mjs
+- main-!~{000}~.mjs => main-Iv9FQrYJ.mjs
 
 # tests/fixtures/misc/reexport_star
 
-- main-Ug5NKpb6.mjs
-- entry-n0mFBci1.mjs
-- $runtime$-Is3GYi3v.mjs
-- a-IxCNEurQ.mjs
+- main-!~{000}~.mjs => main-c0M85IIk.mjs
+- entry-!~{001}~.mjs => entry-vrwZ1g79.mjs
+- $runtime$-!~{003}~.mjs => $runtime$-Zk8jAI88.mjs
+- a-!~{002}~.mjs => a-FuDtRKXi.mjs
 
 # tests/fixtures/misc/reexport_star_from_local_named_export
 
-- main-Hw_z1K-p.mjs
+- main-!~{000}~.mjs => main-Hw_z1K-p.mjs
 
 # tests/fixtures/misc/wrapped_esm
 
 - main-qrJngkK5.mjs.map
-- main-qrJngkK5.mjs
-- $runtime$-vR6TnGxp.mjs
+- main-!~{000}~.mjs => main-qrJngkK5.mjs
+- $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
 
 # tests/fixtures/rollup/assignment-patterns
 
-- main-M9e-PvSP.mjs
+- main-!~{000}~.mjs => main-M9e-PvSP.mjs
 
 # tests/fixtures/rollup/catch-scope-shadowing
 
-- main-WM131bmY.mjs
+- main-!~{000}~.mjs => main-WM131bmY.mjs
 
 # tests/fixtures/rollup/object-spread-side-effect
 
-- main-bffFh2nJ.mjs
+- main-!~{000}~.mjs => main-bffFh2nJ.mjs
 
 # tests/fixtures/rollup/preserve-for-of-iterable
 
-- main-Jck2JIxa.mjs
+- main-!~{000}~.mjs => main-Jck2JIxa.mjs
 
 # tests/fixtures/rollup/simplify-with-destructuring
 
-- main-m9nnNuko.mjs
+- main-!~{000}~.mjs => main-m9nnNuko.mjs
 
 # tests/fixtures/warnings/eval
 
-- main-yOBrKQ94.mjs
+- main-!~{000}~.mjs => main-yOBrKQ94.mjs
 
 # tests/fixtures/warnings/unresolved_import_treated_as_external
 
-- main-xG8X-m9p.mjs
+- main-!~{000}~.mjs => main-xG8X-m9p.mjs

--- a/crates/rolldown_common/src/types/output_chunk.rs
+++ b/crates/rolldown_common/src/types/output_chunk.rs
@@ -23,5 +23,5 @@ pub struct OutputChunk {
   pub code: String,
   pub map: Option<SourceMap>,
   pub sourcemap_file_name: Option<String>,
-  pub preliminary_file_name: ResourceId,
+  pub preliminary_file_name: String,
 }

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 base64      = { workspace = true }
 futures     = { workspace = true }
+indexmap    = { workspace = true }
 once_cell   = { workspace = true }
 regex       = { workspace = true }
 rustc-hash  = { workspace = true }

--- a/crates/rolldown_utils/src/bitset.rs
+++ b/crates/rolldown_utils/src/bitset.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Display};
 
-#[derive(Clone, PartialEq, Eq, Default, Hash)]
+#[derive(Clone, PartialEq, Eq, Default, Hash, PartialOrd, Ord)]
 pub struct BitSet {
   entries: Vec<u8>,
 }

--- a/crates/rolldown_utils/src/indexmap.rs
+++ b/crates/rolldown_utils/src/indexmap.rs
@@ -1,0 +1,7 @@
+use std::hash::BuildHasherDefault;
+
+use indexmap::{IndexMap, IndexSet};
+use rustc_hash::FxHasher;
+
+pub type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
+pub type FxIndexSet<T> = IndexSet<T, BuildHasherDefault<FxHasher>>;

--- a/crates/rolldown_utils/src/lib.rs
+++ b/crates/rolldown_utils/src/lib.rs
@@ -4,6 +4,7 @@ pub mod base64;
 mod bitset;
 pub mod debug;
 pub mod futures;
+pub mod indexmap;
 pub mod path_buf_ext;
 pub mod path_ext;
 pub mod rayon;

--- a/packages/rolldown/tests/fixtures/output/hashFileNames/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/hashFileNames/_config.ts
@@ -28,20 +28,20 @@ export default defineTest({
       switch (chunk.facadeModuleId) {
         case path.join(__dirname, 'main.js'):
           expect(chunk.fileName).toMatchInlineSnapshot(`"main-!~{000}~.js"`)
-          expect(chunk.imports[0]).toMatchInlineSnapshot(`"shared-!~{003}~.js"`)
+          expect(chunk.imports[0]).toMatchInlineSnapshot(`"shared-!~{002}~.js"`)
           expect(chunk.dynamicImports[0]).toMatchInlineSnapshot(
-            `"dynamic-!~{002}~.js"`,
+            `"dynamic-!~{003}~.js"`,
           )
           break
 
         case path.join(__dirname, 'entry.js'):
           expect(chunk.fileName).toMatchInlineSnapshot(`"entry-!~{001}~.js"`)
-          expect(chunk.imports[0]).toMatchInlineSnapshot(`"shared-!~{003}~.js"`)
+          expect(chunk.imports[0]).toMatchInlineSnapshot(`"shared-!~{002}~.js"`)
           expect(chunk.dynamicImports).toStrictEqual([])
           break
 
         case path.join(__dirname, 'dynamic.js'):
-          expect(chunk.fileName).toMatchInlineSnapshot(`"dynamic-!~{002}~.js"`)
+          expect(chunk.fileName).toMatchInlineSnapshot(`"dynamic-!~{003}~.js"`)
           break
 
         default:
@@ -57,21 +57,21 @@ export default defineTest({
           expect(chunk.preliminaryFileName).toMatchInlineSnapshot(
             `"main-!~{000}~.js"`,
           )
-          expect(chunk.fileName).toMatchInlineSnapshot(`"main-zpPZMo1b.js"`)
-          expect(chunk.imports[0]).toMatchInlineSnapshot(`"shared-RtRL5WZ7.js"`)
+          expect(chunk.fileName).toMatchInlineSnapshot(`"main-b4IqQb8v.js"`)
+          expect(chunk.imports[0]).toMatchInlineSnapshot(`"shared-HPOF0b0V.js"`)
           expect(chunk.dynamicImports[0]).toMatchInlineSnapshot(
-            `"dynamic-GEHD338z.js"`,
+            `"dynamic-GH3GEpHx.js"`,
           )
           break
 
         case path.join(__dirname, 'entry.js'):
-          expect(chunk.fileName).toMatchInlineSnapshot(`"entry-r47VG7AS.js"`)
-          expect(chunk.imports[0]).toMatchInlineSnapshot(`"shared-RtRL5WZ7.js"`)
+          expect(chunk.fileName).toMatchInlineSnapshot(`"entry-4V01jUNm.js"`)
+          expect(chunk.imports[0]).toMatchInlineSnapshot(`"shared-HPOF0b0V.js"`)
           expect(chunk.dynamicImports).toStrictEqual([])
           break
 
         case path.join(__dirname, 'dynamic.js'):
-          expect(chunk.fileName).toMatchInlineSnapshot(`"dynamic-GEHD338z.js"`)
+          expect(chunk.fileName).toMatchInlineSnapshot(`"dynamic-GH3GEpHx.js"`)
           break
 
         default:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Calculate chunk's dependencies by scanning `!~{xxx}~` that contained in rendered chunk code.
- Prevent different chunks that have same content from having the same hash

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
