### PR TITLE
refactor: shared module table at PluginContext

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -11,6 +11,7 @@ use crate::{
   BundlerOptions, SharedOptions, SharedResolver,
 };
 use anyhow::Result;
+use rolldown_common::SharedModuleTable;
 use rolldown_error::BuildError;
 use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_plugin::{BoxPlugin, HookBuildEndArgs, HookRenderErrorArgs, SharedPluginDriver};
@@ -23,6 +24,7 @@ pub struct Bundler {
   pub(crate) fs: OsFileSystem,
   pub(crate) resolver: SharedResolver,
   pub(crate) _log_guard: Option<FlushGuard>,
+  pub(crate) module_table: SharedModuleTable,
 }
 
 impl Bundler {
@@ -81,6 +83,7 @@ impl Bundler {
       Arc::clone(&self.plugin_driver),
       self.fs.clone(),
       Arc::clone(&self.resolver),
+      Arc::clone(&self.module_table),
     )
     .scan()
     .await;

--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -1,5 +1,6 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
+use rolldown_common::ModuleTable;
 use rolldown_fs::OsFileSystem;
 use rolldown_plugin::{BoxPlugin, PluginDriver};
 use rolldown_resolver::Resolver;
@@ -24,12 +25,15 @@ impl BundlerBuilder {
     let resolver: SharedResolver =
       Resolver::new(resolve_options, options.platform, options.cwd.clone(), OsFileSystem).into();
 
+    let module_table = Arc::new(RwLock::new(ModuleTable::default()));
+
     Bundler {
-      plugin_driver: PluginDriver::new_shared(self.plugins, &resolver),
+      plugin_driver: PluginDriver::new_shared(self.plugins, &resolver, &module_table),
       resolver,
       options: Arc::new(options),
       fs: OsFileSystem,
       _log_guard: maybe_guard,
+      module_table,
     }
   }
 

--- a/crates/rolldown/src/stages/link_stage/sort_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/sort_modules.rs
@@ -41,10 +41,12 @@ impl<'a> LinkStage<'a> {
 
     let mut stack_indexes_of_executing_id = FxHashMap::default();
     let mut executed_ids = FxHashSet::default();
-    executed_ids
-      .shrink_to(self.module_table.normal_modules.len() + self.module_table.external_modules.len());
 
-    let mut sorted_modules = Vec::with_capacity(self.module_table.normal_modules.len());
+    let mut module_table = self.module_table.write().expect("should get module table write lock");
+
+    executed_ids.shrink_to(module_table.normal_modules.len() + module_table.external_modules.len());
+
+    let mut sorted_modules = Vec::with_capacity(module_table.normal_modules.len());
     let mut next_exec_order = 0;
     let mut circular_dependencies = FxHashSet::default();
     while let Some(status) = execution_stack.pop() {
@@ -76,7 +78,7 @@ impl<'a> LinkStage<'a> {
             stack_indexes_of_executing_id.insert(id, execution_stack.len() - 1);
 
             if let ModuleId::Normal(module_id) = id {
-              let module = &self.module_table.normal_modules[module_id];
+              let module = &module_table.normal_modules[module_id];
               execution_stack.extend(
                 module
                   .import_records
@@ -93,13 +95,13 @@ impl<'a> LinkStage<'a> {
           executed_ids.insert(id);
           match id {
             ModuleId::Normal(id) => {
-              let module = &mut self.module_table.normal_modules[id];
+              let module = &mut module_table.normal_modules[id];
               debug_assert!(module.exec_order == u32::MAX);
               module.exec_order = next_exec_order;
               sorted_modules.push(id);
             }
             ModuleId::External(id) => {
-              let module = &mut self.module_table.external_modules[id];
+              let module = &mut module_table.external_modules[id];
               debug_assert!(module.exec_order == u32::MAX);
               module.exec_order = next_exec_order;
             }
@@ -117,7 +119,7 @@ impl<'a> LinkStage<'a> {
         let paths = cycle
           .iter()
           .filter_map(|id| id.as_normal())
-          .map(|id| self.module_table.normal_modules[id].resource_id.to_string())
+          .map(|id| module_table.normal_modules[id].resource_id.to_string())
           .collect::<Vec<_>>();
         self.warnings.push(BuildError::circular_dependency(paths).with_severity_warning());
       }

--- a/crates/rolldown/src/types/module_render_output.rs
+++ b/crates/rolldown/src/types/module_render_output.rs
@@ -1,9 +1,8 @@
-use rolldown_common::{RenderedModule, ResourceId};
+use rolldown_common::{NormalModuleId, RenderedModule};
 use rolldown_sourcemap::SourceMap;
 
-pub struct ModuleRenderOutput<'a> {
-  pub module_path: ResourceId,
-  pub module_pretty_path: &'a str,
+pub struct ModuleRenderOutput {
+  pub module_id: NormalModuleId,
   pub rendered_module: RenderedModule,
   pub rendered_content: String,
   pub sourcemap: Option<SourceMap>,

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -6,14 +6,14 @@ use rolldown_rstr::ToRstr;
 
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn deconflict_chunk_symbols(chunk: &mut Chunk, link_output: &LinkStageOutput) {
-  let mut renamer =
-    Renamer::new(&link_output.symbols, link_output.module_table.normal_modules.len());
+  let module_table = &link_output.module_table.read().expect("should get module table read lock");
+  let mut renamer = Renamer::new(&link_output.symbols, module_table.normal_modules.len());
 
   chunk
     .modules
     .iter()
     .copied()
-    .map(|id| &link_output.module_table.normal_modules[id])
+    .map(|id| &module_table.normal_modules[id])
     .flat_map(|m| m.scope.root_unresolved_references().keys().map(Cow::Borrowed))
     .for_each(|name| {
       // global names should be reserved
@@ -30,7 +30,7 @@ pub fn deconflict_chunk_symbols(chunk: &mut Chunk, link_output: &LinkStageOutput
     .copied()
     // Starts with entry module
     .rev()
-    .map(|id| &link_output.module_table.normal_modules[id])
+    .map(|id| &module_table.normal_modules[id])
     .for_each(|module| {
       module
         .stmt_infos
@@ -43,7 +43,7 @@ pub fn deconflict_chunk_symbols(chunk: &mut Chunk, link_output: &LinkStageOutput
     });
 
   // rename non-top-level names
-  renamer.rename_non_top_level_symbol(&chunk.modules, &link_output.module_table.normal_modules);
+  renamer.rename_non_top_level_symbol(&chunk.modules, &module_table.normal_modules);
 
   chunk.canonical_names = renamer.into_canonical_names();
 }

--- a/crates/rolldown/src/utils/chunk/mod.rs
+++ b/crates/rolldown/src/utils/chunk/mod.rs
@@ -18,19 +18,20 @@ pub fn generate_pre_rendered_chunk(
   graph: &LinkStageOutput,
   output_options: &SharedOptions,
 ) -> PreRenderedChunk {
+  let module_table = &graph.module_table.read().expect("should get module table read lock");
   PreRenderedChunk {
     is_entry: matches!(&chunk.kind, ChunkKind::EntryPoint { is_user_defined, .. } if *is_user_defined),
     is_dynamic_entry: matches!(&chunk.kind, ChunkKind::EntryPoint { is_user_defined, .. } if !*is_user_defined),
     facade_module_id: match &chunk.kind {
       ChunkKind::EntryPoint { module, .. } => {
-        Some(graph.module_table.normal_modules[*module].resource_id.clone())
+        Some(module_table.normal_modules[*module].resource_id.clone())
       }
       ChunkKind::Common => None,
     },
     module_ids: chunk
       .modules
       .iter()
-      .map(|id| graph.module_table.normal_modules[*id].resource_id.clone())
+      .map(|id| module_table.normal_modules[*id].resource_id.clone())
       .collect(),
     exports: get_chunk_export_names(chunk, graph, output_options),
   }

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -8,6 +8,7 @@ pub fn render_chunk_exports(
   graph: &LinkStageOutput,
   output_options: &SharedOptions,
 ) -> Option<String> {
+  let module_table = graph.module_table.read().expect("should get module table read lock");
   if let ChunkKind::EntryPoint { module: entry_module_id, .. } = &this.kind {
     let linking_info = &graph.metas[*entry_module_id];
     if matches!(linking_info.wrap_kind, WrapKind::Cjs) {
@@ -18,7 +19,7 @@ pub fn render_chunk_exports(
               panic!(
                 "Cannot find canonical name for wrap ref {:?} of {:?}",
                 linking_info.wrapper_ref.unwrap(),
-                graph.module_table.normal_modules[*entry_module_id].resource_id
+                module_table.normal_modules[*entry_module_id].resource_id
               )
             });
           return Some(format!("export default {wrap_ref_name}();\n"));

--- a/crates/rolldown/src/utils/chunk/render_chunk_imports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_imports.rs
@@ -10,6 +10,7 @@ pub fn render_chunk_imports(
   chunk_graph: &ChunkGraph,
   options: &SharedOptions,
 ) -> String {
+  let module_table = graph.module_table.read().expect("should get module table read lock");
   let mut s = String::new();
   let imports_from_external_modules = &chunk.imports_from_external_modules;
 
@@ -58,7 +59,7 @@ pub fn render_chunk_imports(
     };
 
   imports_from_external_modules.iter().for_each(|(importee_id, named_imports)| {
-    let importee = &graph.module_table.external_modules[*importee_id];
+    let importee = &module_table.external_modules[*importee_id];
     let mut is_importee_imported = false;
     let mut import_items = named_imports
       .iter()

--- a/crates/rolldown/src/utils/render_normal_module.rs
+++ b/crates/rolldown/src/utils/render_normal_module.rs
@@ -1,15 +1,15 @@
-use rolldown_common::{NormalModule, RenderedModule};
+use rolldown_common::{NormalModule, NormalModuleId, RenderedModule};
 use rolldown_oxc_utils::{OxcAst, OxcCompiler};
 use rolldown_sourcemap::{collapse_sourcemaps, lines_count};
 
 use crate::{types::module_render_output::ModuleRenderOutput, SharedOptions};
 
-pub fn render_normal_module<'a>(
-  module: &'a NormalModule,
+pub fn render_normal_module(
+  module_id: NormalModuleId,
+  module: &NormalModule,
   ast: &OxcAst,
-  source_name: &str,
   options: &SharedOptions,
-) -> Option<ModuleRenderOutput<'a>> {
+) -> Option<ModuleRenderOutput> {
   if ast.is_body_empty() {
     None
   } else {
@@ -18,11 +18,10 @@ pub fn render_normal_module<'a>(
     // Because oxc codegen sourcemap is last of sourcemap chain,
     // If here no extra sourcemap need remapping, we using it as final module sourcemap.
     // So here make sure using correct `source_name` and `source_content.
-    let render_output = OxcCompiler::print(ast, source_name, enable_sourcemap);
+    let render_output = OxcCompiler::print(ast, module.resource_id.as_ref(), enable_sourcemap);
 
     Some(ModuleRenderOutput {
-      module_path: module.resource_id.clone(),
-      module_pretty_path: &module.pretty_path,
+      module_id,
       rendered_module: RenderedModule { code: None },
       // Search lines count from rendered content has a little overhead, so make it at parallel.
       lines_count: lines_count(&render_output.source_text),

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::{
   types::importer_record::ImporterRecord,
   types::module_id::ModuleId,
   types::module_info::ModuleInfo,
-  types::module_table::{ExternalModuleVec, ModuleTable, NormalModuleVec},
+  types::module_table::{ExternalModuleVec, ModuleTable, NormalModuleVec, SharedModuleTable},
   types::module_type::ModuleType,
   types::named_export::LocalExport,
   types::named_import::{NamedImport, Specifier},

--- a/crates/rolldown_common/src/types/module_table.rs
+++ b/crates/rolldown_common/src/types/module_table.rs
@@ -1,11 +1,15 @@
+use std::sync::{Arc, RwLock};
+
 use crate::{ExternalModule, ExternalModuleId, NormalModule, NormalModuleId};
 use oxc_index::IndexVec;
 
 pub type NormalModuleVec = IndexVec<NormalModuleId, NormalModule>;
 pub type ExternalModuleVec = IndexVec<ExternalModuleId, ExternalModule>;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ModuleTable {
   pub normal_modules: NormalModuleVec,
   pub external_modules: ExternalModuleVec,
 }
+
+pub type SharedModuleTable = Arc<RwLock<ModuleTable>>;

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, Weak};
 
+use rolldown_common::SharedModuleTable;
 use rolldown_resolver::Resolver;
 
 use crate::{plugin_context::SharedPluginContext, BoxPlugin, PluginContext};
@@ -14,7 +15,11 @@ pub struct PluginDriver {
 }
 
 impl PluginDriver {
-  pub fn new_shared(plugins: Vec<BoxPlugin>, resolver: &Arc<Resolver>) -> SharedPluginDriver {
+  pub fn new_shared(
+    plugins: Vec<BoxPlugin>,
+    resolver: &Arc<Resolver>,
+    module_table: &SharedModuleTable,
+  ) -> SharedPluginDriver {
     Arc::new_cyclic(|plugin_driver| {
       let with_context = plugins
         .into_iter()
@@ -24,6 +29,7 @@ impl PluginDriver {
             PluginContext {
               plugin_driver: Weak::clone(plugin_driver),
               resolver: Arc::clone(resolver),
+              module_table: Arc::clone(module_table),
             }
             .into(),
           )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The pr intend to support `PluginContext#getModuleInfo`, before i already support `NormalModule` cast to `ModuleInfo`, it only work at `moduleParesd` hook. But the `PluginContext#getModuleInfo` need to valid at plugin lifetime. I consider two ways to support it.

A. Add a `moduleInfos`(Dashmap) to owner `ModuleInfo`at `PluginContext`, but it need to set the module info when the `ModuleInfo` fields change, it need to re-set many times, due to https://rollupjs.org/plugin-development/#this-getmoduleinfo. It also has some overhead if the plugin not used it.
B. Shared `ModuleTable` at `PluginContext`, the typing is `Arc<RwLock<ModuleTable>>`, we only need to muate it at module loader and sort modules, it always do it at single thread, so we are using `RwLock` to avoid caused performance regression if lock conflict. Other, The`ModuleInfo` will be lazy, if you used it, it will cast from `NormalModule`.

The pr intend to implement `B`, it is sound good to me. If you have some good ideas, please let know.

The mutate `SharedModuleTable` is not finished at module loader, it look like is complex, i intend to do it at next pr.