### PR TITLE
feat(rust): render external imports after normal imports

### DIFF
--- a/crates/rolldown/tests/fixtures/deconflict/conflict_between_global_and_local_binding/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/deconflict/conflict_between_global_and_local_binding/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/fixtures/deconflict/conflict_between_global_an
 ## main.mjs
 
 ```js
-import { default as assert } from "node:assert";
 import { __commonJSMin } from "./$runtime$.mjs";
+import { default as assert } from "node:assert";
 
 // main.js
 var require_main = __commonJSMin((exports, module) => {

--- a/crates/rolldown/tests/fixtures/deconflict/conflict_between_imported_and_local_binding/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/deconflict/conflict_between_imported_and_local_binding/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/fixtures/deconflict/conflict_between_imported_
 ## main.mjs
 
 ```js
-import { default as assert } from "node:assert";
 import { __commonJSMin } from "./$runtime$.mjs";
+import { default as assert } from "node:assert";
 
 // main.js
 var require_main = __commonJSMin((exports, module) => {

--- a/crates/rolldown/tests/fixtures/deconflict/wrapped_esm_default_function/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/deconflict/wrapped_esm_default_function/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/fixtures/deconflict/wrapped_esm_default_functi
 ## main.mjs
 
 ```js
-import { default as assert } from "assert";
 import { __esmMin, __export, __toCommonJS } from "./$runtime$.mjs";
+import { default as assert } from "assert";
 
 // foo.js
 function foo$1(a$1$1) {

--- a/crates/rolldown/tests/fixtures/deconflict/wrapped_esm_export_named_function/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/deconflict/wrapped_esm_export_named_function/artifacts.snap
@@ -8,8 +8,8 @@ input_file: crates/rolldown/tests/fixtures/deconflict/wrapped_esm_export_named_f
 ## main.mjs
 
 ```js
-import { default as assert } from "assert";
 import { __esmMin, __export, __toCommonJS } from "./$runtime$.mjs";
+import { default as assert } from "assert";
 
 // foo.js
 function foo$1(a$1$1) {

--- a/crates/rolldown/tests/fixtures/function/external/splitting_with_external_module/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/function/external/splitting_with_external_module/artifacts.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/rolldown/tests/common/case.rs
 expression: content
-input_file: crates/rolldown/tests/fixtures/external/splitting_with_external_module
+input_file: crates/rolldown/tests/fixtures/function/external/splitting_with_external_module
 ---
 # Assets
 
@@ -16,8 +16,8 @@ console.log(value);
 ## main.mjs
 
 ```js
-import { default as assert } from "assert";
 import { value } from "./share.mjs";
+import { default as assert } from "assert";
 
 // main.js
 assert(value === 1);

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -1172,12 +1172,12 @@ expression: "snapshot_outputs.join(\"\\n\")"
 # tests/fixtures/deconflict/conflict_between_global_and_local_binding
 
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
-- main-!~{000}~.mjs => main-tOEcGaC9.mjs
+- main-!~{000}~.mjs => main-yq81GCoq.mjs
 
 # tests/fixtures/deconflict/conflict_between_imported_and_local_binding
 
 - $runtime$-!~{001}~.mjs => $runtime$-6wzC9jCL.mjs
-- main-!~{000}~.mjs => main-UgkBYeKd.mjs
+- main-!~{000}~.mjs => main-jGSEfPCH.mjs
 
 # tests/fixtures/deconflict/decl_complex_patterns
 
@@ -1206,14 +1206,14 @@ expression: "snapshot_outputs.join(\"\\n\")"
 # tests/fixtures/deconflict/wrapped_esm_default_function
 
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
-- main-!~{000}~.mjs => main-Hwm0PQEH.mjs
-- main-Hwm0PQEH.mjs.map
+- main-!~{000}~.mjs => main-p6u6QFeo.mjs
+- main-p6u6QFeo.mjs.map
 
 # tests/fixtures/deconflict/wrapped_esm_export_named_function
 
 - $runtime$-!~{001}~.mjs => $runtime$-vR6TnGxp.mjs
-- main-!~{000}~.mjs => main-puld6Obw.mjs
-- main-puld6Obw.mjs.map
+- main-!~{000}~.mjs => main-_ZUi0Cvz.mjs
+- main-_ZUi0Cvz.mjs.map
 
 # tests/fixtures/errors/unresolved_entry
 
@@ -1237,7 +1237,7 @@ expression: "snapshot_outputs.join(\"\\n\")"
 # tests/fixtures/function/external/splitting_with_external_module
 
 - entry-!~{001}~.mjs => entry-ahgOZOc1.mjs
-- main-!~{000}~.mjs => main-1dgL9psc.mjs
+- main-!~{000}~.mjs => main-LeJVwZoF.mjs
 - share-!~{002}~.mjs => share-eIGIrVeP.mjs
 
 # tests/fixtures/function/resolve/browser_filed_false


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

See https://github.com/rolldown/rolldown/blob/5c3b4fbb732dda092bc5298b2ad1b85786735977/crates/rolldown/tests/esbuild/import_star/re_export_star_as_external_common_js/artifacts.snap#L19-L20 for why.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
