### PR TITLE
fix(resolve): treat builtin modules as external by default while targeting `node` platform

### DIFF
--- a/crates/rolldown/tests/fixtures/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic/_config.json
+++ b/crates/rolldown/tests/fixtures/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "platform": "node"
+  },
+  "_comment": "TODO: wait for https://github.com/rolldown/rolldown/issues/1189",
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/fixtures/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic/artifacts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rolldown/tests/common/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic
+---
+# Assets
+
+## main.mjs
+
+```js
+import * as fs from "fs";
+import * as nodeFs from "node:fs";
+
+// main.js
+console.log(fs, nodeFs, require('path'), require('node:path'));
+```

--- a/crates/rolldown/tests/fixtures/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic/main.js
+++ b/crates/rolldown/tests/fixtures/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic/main.js
@@ -1,0 +1,4 @@
+import * as fs from 'fs'
+import * as nodeFs from 'node:fs'
+
+console.log(fs, nodeFs, require('path'), require('node:path'))

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -1282,6 +1282,10 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - main-!~{000}~.cjs => main-rClOc9Ow.cjs
 
+# tests/fixtures/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic
+
+- main-!~{000}~.mjs => main-tAxph1ul.mjs
+
 # tests/fixtures/function/resolve/browser_filed_false
 
 - $runtime$-!~{001}~.mjs => $runtime$-aUKPtNTY.mjs

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -60,6 +60,11 @@ impl<F: FileSystem + Default> Resolver<F> {
       _ => vec![],
     });
 
+    let builtin_modules = match platform {
+      Platform::Node => true,
+      Platform::Browser | Platform::Neutral => false,
+    };
+
     let resolve_options_with_default_conditions = OxcResolverOptions {
       tsconfig: raw_resolve.tsconfig_filename.map(|p| TsconfigOptions {
         config_file: p.into(),
@@ -99,7 +104,7 @@ impl<F: FileSystem + Default> Resolver<F> {
       restrictions: vec![],
       roots: vec![],
       symlinks: raw_resolve.symlinks.unwrap_or(true),
-      builtin_modules: false,
+      builtin_modules,
     };
     let resolve_options_with_import_conditions = OxcResolverOptions {
       condition_names: import_conditions,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This is also a preparation for fixing #1185.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
