### PR TITLE
fix(rust): cacluate order of import chunks by global module execution order

### DIFF
--- a/crates/rolldown/tests/fixtures/issues/122/a/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/issues/122/a/artifacts.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/rolldown/tests/common/case.rs
 expression: content
-input_file: crates/rolldown/tests/fixtures/issue/122/a
+input_file: crates/rolldown/tests/fixtures/issues/122/a
 ---
 # Assets
 
@@ -25,14 +25,14 @@ import "./c.mjs";
 ## entry2.mjs
 
 ```js
-import "./b.mjs";
 import "./c.mjs";
+import "./b.mjs";
 ```
 ## entry3.mjs
 
 ```js
-import "./b.mjs";
 import "./c.mjs";
+import "./b.mjs";
 
 // a.js
 console.log('a');

--- a/crates/rolldown/tests/fixtures/issues/122/b/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/issues/122/b/artifacts.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/rolldown/tests/common/case.rs
 expression: content
-input_file: crates/rolldown/tests/fixtures/issue/122
+input_file: crates/rolldown/tests/fixtures/issues/122/b
 ---
 # Assets
 
@@ -29,8 +29,8 @@ console.log('a');
 ## b.mjs
 
 ```js
-import "./2.mjs";
 import "./1.mjs";
+import "./2.mjs";
 
 // b.js
 console.log('a');

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -1375,15 +1375,15 @@ expression: "snapshot_outputs.join(\"\\n\")"
 - b-!~{003}~.mjs => b-91ZliBhV.mjs
 - c-!~{004}~.mjs => c-XewjZoRS.mjs
 - entry1-!~{000}~.mjs => entry1-_fcFnBsf.mjs
-- entry2-!~{001}~.mjs => entry2-HA1lKBk8.mjs
-- entry3-!~{002}~.mjs => entry3-bRT67heJ.mjs
+- entry2-!~{001}~.mjs => entry2-jt0I7hrk.mjs
+- entry3-!~{002}~.mjs => entry3-hyni2iWP.mjs
 
 # tests/fixtures/issues/122/b
 
 - 1-!~{004}~.mjs => 1-Hl9Rv5WQ.mjs
 - 2-!~{003}~.mjs => 2-BzwAbMwC.mjs
 - a-!~{000}~.mjs => a-9ZdsWyCX.mjs
-- b-!~{001}~.mjs => b-Ryq1zljY.mjs
+- b-!~{001}~.mjs => b-PViJx8IB.mjs
 - c-!~{002}~.mjs => c-Q0kP-AMp.mjs
 
 # tests/fixtures/misc/ambiguous_star_export

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -16,6 +16,7 @@ use self::types::{
 
 #[derive(Debug, Default)]
 pub struct Chunk {
+  pub exec_order: u32,
   pub kind: ChunkKind,
   pub modules: Vec<NormalModuleId>,
   pub name: Option<String>,
@@ -40,7 +41,7 @@ impl Chunk {
     modules: Vec<NormalModuleId>,
     kind: ChunkKind,
   ) -> Self {
-    Self { modules, name, bits, kind, ..Self::default() }
+    Self { exec_order: u32::MAX, modules, name, bits, kind, ..Self::default() }
   }
 
   pub fn filename_template<'a>(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR make the chunk order is more predictable. Chunk will be executed first if it contains the module that executed first. 

The old order has a bug. Solving that bug need to calculate every module's full dependencies of each chunk. It's not worth it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
