### PR TITLE
docs: update reference to rolldown testing config schema

### DIFF
--- a/web/docs/contrib-guide/testing.md
+++ b/web/docs/contrib-guide/testing.md
@@ -27,7 +27,7 @@ For all available options, you could refer to
 
 - https://github.com/rolldown/rolldown/blob/main/crates/rolldown_testing_config/src/lib.rs
 - https://github.com/rolldown/rolldown/blob/main/crates/rolldown_common/src/inner_bundler_options/mod.rs
-- https://github.com/rolldown/rolldown/blob/main/crates/rolldown_testing/_test.scheme.json
+- https://github.com/rolldown/rolldown/blob/main/crates/rolldown_testing/_config.schema.json
 
 - `main.js` is the default entry of the test case, if `input.input` is not specified in `_test.json`.
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

PRs #1025 and #1042 renamed the `rolldown_testing` config schema file. This PR adjusts sources to changes.