### PR TITLE
ci: 🎡 replace rust benchmark result instead of append

### DIFF
--- a/.github/workflows/benchmark-rust.yml
+++ b/.github/workflows/benchmark-rust.yml
@@ -148,3 +148,4 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.bench_comparison.outputs.comment }}
           reactions-edit-mode: 'replace'
+          edit-mode: replace


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Closed https://github.com/rolldown/rolldown/issues/1094
### ref
1. https://github.com/peter-evans/create-or-update-comment?tab=readme-ov-file#where-to-find-the-id-of-a-comment
2. https://github.com/peter-evans/create-or-update-comment?tab=readme-ov-file#where-to-find-the-id-of-a-comment:~:text=with%20body.-,edit%2Dmode,-The%20mode%20when
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
