### PR TITLE
feat: handle `proposal-json-superset` chars with iteration of superset-contained string

### DIFF
--- a/crates/rolldown_lang_json/src/lib.rs
+++ b/crates/rolldown_lang_json/src/lib.rs
@@ -1,11 +1,14 @@
+use std::borrow::Cow;
+
 use anyhow::Ok;
 use rolldown_utils::ecma_script::is_validate_identifier_name;
 use serde_json::Value;
-// TODO: handling https://github.com/tc39/proposal-json-superset
+// TODO: handling https://github.com/tc39/proposal-json-superset // Fixing by Ethan Goh (@7086cmd) in this issue.
 
 pub fn json_to_esm(json: &str) -> anyhow::Result<String> {
+  let json = escape_json_superset(json);
   // TODO: use zero-copy deserialization
-  let json_value: Value = serde_json::from_str(json)?;
+  let json_value: Value = serde_json::from_str(&json)?;
 
   match json_value {
     Value::Object(map) => {
@@ -37,5 +40,21 @@ pub fn json_to_esm(json: &str) -> anyhow::Result<String> {
       let json_str = serde_json::to_string(&json_value)?;
       Ok(format!("export default {json_str}"))
     }
+  }
+}
+
+fn escape_json_superset(json: &str) -> Cow<str> {
+  if json.contains('\u{2028}') || json.contains('\u{2029}') {
+    let mut escaped = String::with_capacity(json.len());
+    for c in json.chars() {
+      match c {
+        '\u{2028}' => escaped.push_str("\\u2028"),
+        '\u{2029}' => escaped.push_str("\\u2029"),
+        _ => escaped.push(c),
+      }
+    }
+    Cow::Owned(escaped)
+  } else {
+    Cow::Borrowed(json)
   }
 }


### PR DESCRIPTION
### Description

The crate `rolldown_lang_json` has a `TODO` related to the `JSON superset` proposal. It may solve this handling task with the mention of iterating the string.

Since I am not a professional Rust developer but a high-school student, I may not sync the PR process immediately. I just read a little of the project, and I hope my efforts will improve the repository a little bit :)

This PR creates a function named `escape_json_superset`, returns a `Cow::<str>`, and checks if the JSON string contains specific characters. If so, the function will iterate the string and replace the UTF-8 char, and use `\u2028` or `\u2029` instead.