### PR TITLE
feat: support throw some build_errors in  scan stage and link stage

### DIFF
--- a/crates/rolldown/src/module_loader/error.rs
+++ b/crates/rolldown/src/module_loader/error.rs
@@ -1,0 +1,6 @@
+use rolldown_resolver::ResolveError;
+
+pub enum ResolveDependenciesError {
+  AnyhowError(anyhow::Error),
+  ResolveError(Vec<ResolveError>),
+}

--- a/crates/rolldown/src/module_loader/mod.rs
+++ b/crates/rolldown/src/module_loader/mod.rs
@@ -1,3 +1,4 @@
+pub mod error;
 #[allow(clippy::module_inception)]
 pub mod module_loader;
 mod normal_module_task;

--- a/crates/rolldown/src/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/normal_module_task.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, vec};
 
 use anyhow::Result;
 use futures::future::join_all;
@@ -15,6 +15,7 @@ use rolldown_resolver::ResolveError;
 use sugar_path::SugarPath;
 
 use super::{task_context::TaskContext, Msg};
+use crate::module_loader::error::ResolveDependenciesError;
 use crate::{
   ast_scanner::{AstScanner, ScanResult},
   module_loader::NormalModuleTaskResult,
@@ -25,6 +26,7 @@ use crate::{
   },
   SharedOptions, SharedResolver,
 };
+
 pub struct NormalModuleTask {
   ctx: Arc<TaskContext>,
   module_id: NormalModuleId,
@@ -58,7 +60,9 @@ impl NormalModuleTask {
     }
   }
 
-  #[tracing::instrument(name="NormalModuleTask::run", level = "trace", skip_all, fields(module_path = ?self.resolved_path))]
+  #[tracing::instrument(name = "NormalModuleTask::run", level = "trace", skip_all, fields(
+    module_path = ? self.resolved_path
+  ))]
   pub async fn run(mut self) {
     match self.run_inner().await {
       Ok(()) => {
@@ -107,112 +111,135 @@ impl NormalModuleTask {
 
     let (scope, scan_result, ast_symbol, namespace_symbol) = self.scan(&mut ast, &source);
 
-    let resolved_deps =
-      self.resolve_dependencies(&scan_result.import_records, &mut warnings).await?;
+    let resolved_deps_res =
+      self.resolve_dependencies(&scan_result.import_records, &mut warnings).await;
 
-    let ScanResult {
-      named_imports,
-      named_exports,
-      stmt_infos,
-      import_records,
-      star_exports,
-      default_export_ref,
-      imports,
-      exports_kind,
-      repr_name,
-      warnings: scan_warnings,
-    } = scan_result;
-    warnings.extend(scan_warnings);
+    match resolved_deps_res {
+      Ok(resolved_deps) => {
+        let ScanResult {
+          named_imports,
+          named_exports,
+          stmt_infos,
+          import_records,
+          star_exports,
+          default_export_ref,
+          imports,
+          exports_kind,
+          repr_name,
+          warnings: scan_warnings,
+        } = scan_result;
+        warnings.extend(scan_warnings);
 
-    let mut imported_ids = vec![];
-    let mut dynamically_imported_ids = vec![];
+        let mut imported_ids = vec![];
+        let mut dynamically_imported_ids = vec![];
 
-    for (record, info) in import_records.iter().zip(&resolved_deps) {
-      if record.kind.is_static() {
-        imported_ids.push(Arc::clone(&info.path.path).into());
-      } else {
-        dynamically_imported_ids.push(Arc::clone(&info.path.path).into());
+        for (record, info) in import_records.iter().zip(&resolved_deps) {
+          if record.kind.is_static() {
+            imported_ids.push(Arc::clone(&info.path.path).into());
+          } else {
+            dynamically_imported_ids.push(Arc::clone(&info.path.path).into());
+          }
+        }
+
+        let resource_id = ResourceId::new(Arc::clone(&self.resolved_path.path));
+        let stable_resource_id = resource_id.stabilize(&self.ctx.input_options.cwd);
+
+        // The side effects priority is:
+        // 1. Hook side effects
+        // 2. Package.json side effects
+        // 3. Analyzed side effects
+        // We should skip the `check_side_effects_for` if the hook side effects is not `None`.
+        let lazy_check_side_effects = || {
+          self
+            .package_json
+            .as_ref()
+            .and_then(|p| {
+              p.check_side_effects_for(&stable_resource_id).map(DeterminedSideEffects::UserDefined)
+            })
+            .unwrap_or_else(|| {
+              let analyzed_side_effects = stmt_infos.iter().any(|stmt_info| stmt_info.side_effect);
+              DeterminedSideEffects::Analyzed(analyzed_side_effects)
+            })
+        };
+
+        let side_effects = match hook_side_effects {
+          Some(side_effects) => match side_effects {
+            HookSideEffects::True => DeterminedSideEffects::UserDefined(true),
+            HookSideEffects::False => DeterminedSideEffects::UserDefined(false),
+            HookSideEffects::NoTreeshake => unimplemented!(),
+          },
+          None => lazy_check_side_effects(),
+        };
+        // TODO: Should we check if there are `check_side_effects_for` returns false but there are side effects in the module?
+
+        let module = NormalModule {
+          source,
+          id: self.module_id,
+          repr_name,
+          stable_resource_id,
+          resource_id,
+          named_imports,
+          named_exports,
+          stmt_infos,
+          imports,
+          star_exports,
+          default_export_ref,
+          scope,
+          exports_kind,
+          namespace_symbol,
+          module_type: self.module_type,
+          debug_resource_id: self.resolved_path.debug_display(&self.ctx.input_options.cwd),
+          sourcemap_chain,
+          exec_order: u32::MAX,
+          is_user_defined_entry: self.is_user_defined_entry,
+          import_records: IndexVec::default(),
+          is_included: false,
+          importers: vec![],
+          dynamic_importers: vec![],
+          imported_ids,
+          dynamically_imported_ids,
+          package_json: self.package_json.take(),
+          side_effects,
+        };
+
+        self.ctx.plugin_driver.module_parsed(Arc::new(module.to_module_info())).await?;
+
+        self
+          .ctx
+          .tx
+          .send(Msg::NormalModuleDone(NormalModuleTaskResult {
+            resolved_deps,
+            module_id: self.module_id,
+            warnings,
+            ast_symbol,
+            module,
+            raw_import_records: import_records,
+            ast,
+          }))
+          .await
+          .expect("Send should not fail");
+        Ok(())
       }
-    }
-
-    let resource_id = ResourceId::new(Arc::clone(&self.resolved_path.path));
-    let stable_resource_id = resource_id.stabilize(&self.ctx.input_options.cwd);
-
-    // The side effects priority is:
-    // 1. Hook side effects
-    // 2. Package.json side effects
-    // 3. Analyzed side effects
-    // We should skip the `check_side_effects_for` if the hook side effects is not `None`.
-    let lazy_check_side_effects = || {
-      self
-        .package_json
-        .as_ref()
-        .and_then(|p| {
-          p.check_side_effects_for(&stable_resource_id).map(DeterminedSideEffects::UserDefined)
-        })
-        .unwrap_or_else(|| {
-          let analyzed_side_effects = stmt_infos.iter().any(|stmt_info| stmt_info.side_effect);
-          DeterminedSideEffects::Analyzed(analyzed_side_effects)
-        })
-    };
-
-    let side_effects = match hook_side_effects {
-      Some(side_effects) => match side_effects {
-        HookSideEffects::True => DeterminedSideEffects::UserDefined(true),
-        HookSideEffects::False => DeterminedSideEffects::UserDefined(false),
-        HookSideEffects::NoTreeshake => unimplemented!(),
+      Err(e) => match e {
+        ResolveDependenciesError::AnyhowError(ex) => Err(ex),
+        ResolveDependenciesError::ResolveError(ex) => {
+          for e in ex {
+            match e {
+              ResolveError::JSON(e) => {
+                let build_error =
+                  BuildError::unresolved_json_illegally(e.path, e.column, e.line, e.message);
+                self.errors.push(build_error);
+              }
+              _ => {
+                let build_error = BuildError::unresolved_other_unknown(e.to_string());
+                self.errors.push(build_error);
+              }
+            }
+          }
+          Ok(())
+        }
       },
-      None => lazy_check_side_effects(),
-    };
-    // TODO: Should we check if there are `check_side_effects_for` returns false but there are side effects in the module?
-
-    let module = NormalModule {
-      source,
-      id: self.module_id,
-      repr_name,
-      stable_resource_id,
-      resource_id,
-      named_imports,
-      named_exports,
-      stmt_infos,
-      imports,
-      star_exports,
-      default_export_ref,
-      scope,
-      exports_kind,
-      namespace_symbol,
-      module_type: self.module_type,
-      debug_resource_id: self.resolved_path.debug_display(&self.ctx.input_options.cwd),
-      sourcemap_chain,
-      exec_order: u32::MAX,
-      is_user_defined_entry: self.is_user_defined_entry,
-      import_records: IndexVec::default(),
-      is_included: false,
-      importers: vec![],
-      dynamic_importers: vec![],
-      imported_ids,
-      dynamically_imported_ids,
-      package_json: self.package_json.take(),
-      side_effects,
-    };
-
-    self.ctx.plugin_driver.module_parsed(Arc::new(module.to_module_info())).await?;
-
-    self
-      .ctx
-      .tx
-      .send(Msg::NormalModuleDone(NormalModuleTaskResult {
-        resolved_deps,
-        module_id: self.module_id,
-        warnings,
-        ast_symbol,
-        module,
-        raw_import_records: import_records,
-        ast,
-      }))
-      .await
-      .expect("Send should not fail");
-    Ok(())
+    }
   }
 
   fn scan(
@@ -289,7 +316,8 @@ impl NormalModuleTask {
     &mut self,
     dependencies: &IndexVec<ImportRecordId, RawImportRecord>,
     warnings: &mut Vec<BuildError>,
-  ) -> Result<IndexVec<ImportRecordId, ResolvedRequestInfo>> {
+  ) -> std::result::Result<IndexVec<ImportRecordId, ResolvedRequestInfo>, ResolveDependenciesError>
+  {
     let jobs = dependencies.iter_enumerated().map(|(idx, item)| {
       let specifier = item.module_request.clone();
       let input_options = Arc::clone(&self.ctx.input_options);
@@ -317,45 +345,48 @@ impl NormalModuleTask {
     let mut ret = IndexVec::with_capacity(dependencies.len());
     let mut build_errors = vec![];
     for resolved_id in resolved_ids {
-      let (specifier, idx, resolved_id) = resolved_id?;
-
       match resolved_id {
-        Ok(info) => {
-          ret.push(info);
+        Ok(resolved_id) => {
+          let (specifier, idx, resolved_id) = resolved_id;
+          match resolved_id {
+            Ok(info) => {
+              ret.push(info);
+            }
+            Err(e) => match &e {
+              ResolveError::NotFound(..) => {
+                warnings.push(
+                  BuildError::unresolved_import_treated_as_external(
+                    specifier.to_string(),
+                    self.resolved_path.path.to_string(),
+                    Some(e),
+                  )
+                  .with_severity_warning(),
+                );
+                ret.push(ResolvedRequestInfo {
+                  path: specifier.to_string().into(),
+                  module_type: ModuleType::Unknown,
+                  is_external: true,
+                  package_json: None,
+                  side_effects: None,
+                });
+              }
+              _ => {
+                build_errors.push((&dependencies[idx], e));
+              }
+            },
+          }
         }
-        Err(e) => match &e {
-          ResolveError::NotFound(..) => {
-            warnings.push(
-              BuildError::unresolved_import_treated_as_external(
-                specifier.to_string(),
-                self.resolved_path.path.to_string(),
-                Some(e),
-              )
-              .with_severity_warning(),
-            );
-            ret.push(ResolvedRequestInfo {
-              path: specifier.to_string().into(),
-              module_type: ModuleType::Unknown,
-              is_external: true,
-              package_json: None,
-              side_effects: None,
-            });
-          }
-          _ => {
-            build_errors.push((&dependencies[idx], e));
-          }
-        },
+        Err(e) => {
+          return Err(ResolveDependenciesError::AnyhowError(e));
+        }
       }
     }
 
     if build_errors.is_empty() {
       Ok(ret)
     } else {
-      let resolved_err = anyhow::format_err!(
-        "Unexpectedly failed to resolve dependencies of {importer}. Got errors {build_errors:#?}",
-        importer = self.resolved_path.path,
-      );
-      Err(resolved_err)
+      let resolved_err: Vec<ResolveError> = build_errors.into_iter().map(|x| x.1).collect();
+      Err(ResolveDependenciesError::ResolveError(resolved_err))
     }
   }
 }

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -70,7 +70,6 @@ impl ScanStage {
       ast_table,
     } = module_loader.fetch_all_modules(user_entries).await?;
     self.errors.extend(errors);
-
     Ok(ScanStageOutput {
       module_table,
       entry_points,
@@ -83,7 +82,6 @@ impl ScanStage {
   }
 
   /// Resolve `InputOptions.input`
-
   #[tracing::instrument(level = "debug", skip_all)]
   async fn resolve_user_defined_entries(
     &mut self,

--- a/crates/rolldown/tests/esbuild/packagejson/.test_package_json_syntax_error_trailing_comma/_config.json
+++ b/crates/rolldown/tests/esbuild/packagejson/.test_package_json_syntax_error_trailing_comma/_config.json
@@ -6,5 +6,6 @@
         "import": "./src/entry.js"
       }
     ]
-  }
+  },
+  "expectError": true
 }

--- a/crates/rolldown_error/src/build_error/error_constructors.rs
+++ b/crates/rolldown_error/src/build_error/error_constructors.rs
@@ -13,7 +13,9 @@ use crate::events::{
   forbid_const_assign::ForbidConstAssign, missing_export::MissingExport,
   sourcemap_error::SourceMapError, unresolved_entry::UnresolvedEntry,
   unresolved_import::UnresolvedImport,
-  unresolved_import_treated_as_external::UnresolvedImportTreatedAsExternal, NapiError,
+  unresolved_import_treated_as_external::UnresolvedImportTreatedAsExternal,
+  unresolved_json_illegally::UnresolvedJsonIllegally,
+  unresolved_other_unknown::UnresolvedOtherUnknown, NapiError,
 };
 
 impl BuildError {
@@ -54,6 +56,19 @@ impl BuildError {
       importer: importer.into(),
       resolve_error,
     })
+  }
+
+  pub fn unresolved_json_illegally(
+    path: PathBuf,
+    col: usize,
+    line: usize,
+    message: String,
+  ) -> Self {
+    Self::new_inner(UnresolvedJsonIllegally { path, col, line, message })
+  }
+
+  pub fn unresolved_other_unknown(message: String) -> Self {
+    Self::new_inner(UnresolvedOtherUnknown { message })
   }
 
   pub fn missing_export(

--- a/crates/rolldown_error/src/event_kind.rs
+++ b/crates/rolldown_error/src/event_kind.rs
@@ -4,6 +4,8 @@ pub enum EventKind {
   // --- These kinds are copied from rollup: https://github.com/rollup/rollup/blob/0b665c31833525c923c0fc20f43ebfca748c6670/src/utils/logs.ts#L102-L179
   UnresolvedEntry,
   UnresolvedImport,
+  UnresolvedJsonIllegally,
+  UnresolvedOtherUnknown,
   Eval,
   CircularDependency,
   SourcemapError,
@@ -23,6 +25,8 @@ impl Display for EventKind {
       // --- Copied from rollup
       EventKind::UnresolvedEntry => write!(f, "UNRESOLVED_ENTRY"),
       EventKind::UnresolvedImport => write!(f, "UNRESOLVED_IMPORT"),
+      EventKind::UnresolvedJsonIllegally => write!(f, "UNRESOLVED_JSON_ILLEGALLY"),
+      EventKind::UnresolvedOtherUnknown => write!(f, "UNRESOLVED_OTHER_UNKNOWN"),
       EventKind::IllegalReassignment => write!(f, "ILLEGAL_REASSIGNMENT"),
       EventKind::Eval => write!(f, "EVAL"),
       EventKind::SourcemapError => write!(f, "SOURCEMAP_ERROR"),

--- a/crates/rolldown_error/src/events/mod.rs
+++ b/crates/rolldown_error/src/events/mod.rs
@@ -13,6 +13,8 @@ pub mod sourcemap_error;
 pub mod unresolved_entry;
 pub mod unresolved_import;
 pub mod unresolved_import_treated_as_external;
+pub mod unresolved_json_illegally;
+pub mod unresolved_other_unknown;
 
 pub trait BuildEvent: Debug + Sync + Send {
   fn kind(&self) -> EventKind;

--- a/crates/rolldown_error/src/events/unresolved_json_illegally.rs
+++ b/crates/rolldown_error/src/events/unresolved_json_illegally.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+
+use super::BuildEvent;
+
+#[derive(Debug)]
+pub struct UnresolvedJsonIllegally {
+  pub(crate) line: usize,
+  pub(crate) col: usize,
+  pub(crate) path: PathBuf,
+  pub(crate) message: String,
+}
+
+impl BuildEvent for UnresolvedJsonIllegally {
+  fn kind(&self) -> crate::EventKind {
+    crate::EventKind::UnresolvedJsonIllegally
+  }
+
+  fn message(&self, opts: &crate::DiagnosticOptions) -> String {
+    format!(
+      "Could not resolve package json,path is {} issue location is line {} and col is {}. and detail is \n {}",
+      opts.stabilize_path(&self.path), self.line, self.col,self.message
+    )
+  }
+}

--- a/crates/rolldown_error/src/events/unresolved_other_unknown.rs
+++ b/crates/rolldown_error/src/events/unresolved_other_unknown.rs
@@ -1,0 +1,16 @@
+use super::BuildEvent;
+
+#[derive(Debug)]
+pub struct UnresolvedOtherUnknown {
+  pub(crate) message: String,
+}
+
+impl BuildEvent for UnresolvedOtherUnknown {
+  fn kind(&self) -> crate::EventKind {
+    crate::EventKind::UnresolvedJsonIllegally
+  }
+
+  fn message(&self, _opts: &crate::DiagnosticOptions) -> String {
+    format!("Could not resolve message is -> \n {}", self.message)
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

in the past code implementation

in the scan stage 

everyone will see the logic at https://github.com/rolldown/rolldown/blob/main/crates/rolldown/src/module_loader/normal_module_task.rs#L349

most of build error will be into as anyhow::Error and throw them in the "try_spawn_new_task"
https://github.com/rolldown/rolldown/blob/main/crates/rolldown/src/module_loader/module_loader.rs#L122

in the code stack 
“fetch_all_modules”
https://github.com/rolldown/rolldown/blob/main/crates/rolldown/src/stages/scan_stage.rs#L71

but  in the esbuild test case 

https://github.com/evanw/esbuild/blob/main/internal/bundler_tests/bundler_packagejson_test.go#L65
https://github.com/evanw/esbuild/blob/main/internal/bundler_tests/bundler_packagejson_test.go#L94

they are need rolldown-reoslver:ResovleError into be a BuildError and  throw them at the function bundleup in the same time .

so i change the code logic please master review it 

Thank you for your hard work and have a nice day.














