### PR TITLE
test(use_strict): rolldown should allow to parse non-strict code

### DIFF
--- a/crates/rolldown/tests/fixtures/misc/use_strict/allow_parse_non_strict_code_in_cjs_format/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/use_strict/allow_parse_non_strict_code_in_cjs_format/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "format": "cjs"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/fixtures/misc/use_strict/allow_parse_non_strict_code_in_cjs_format/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/use_strict/allow_parse_non_strict_code_in_cjs_format/artifacts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rolldown/tests/common/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/misc/use_strict/allow_parse_non_strict_code_in_cjs_format
+---
+# Assets
+
+## main.cjs
+
+```js
+const { __commonJSMin, __toESM } = require("./$runtime$.cjs");
+
+// cjs.js
+var require_cjs = __commonJSMin((exports, module) => {
+	module.exports = function foo$1(arguments) {
+	};
+});
+
+// main.js
+var import_cjs = __toESM(require_cjs());
+console.log(import_cjs.default);
+```

--- a/crates/rolldown/tests/fixtures/misc/use_strict/allow_parse_non_strict_code_in_cjs_format/cjs.js
+++ b/crates/rolldown/tests/fixtures/misc/use_strict/allow_parse_non_strict_code_in_cjs_format/cjs.js
@@ -1,0 +1,2 @@
+// `arguments` is a reserved word in strict mode
+module.exports = function foo(arguments) {}

--- a/crates/rolldown/tests/fixtures/misc/use_strict/allow_parse_non_strict_code_in_cjs_format/main.js
+++ b/crates/rolldown/tests/fixtures/misc/use_strict/allow_parse_non_strict_code_in_cjs_format/main.js
@@ -1,0 +1,4 @@
+import foo from './cjs'
+console.log(foo)
+
+export {}

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -1542,6 +1542,11 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - main-!~{000}~.mjs => main-Hw_z1K-p.mjs
 
+# tests/fixtures/misc/use_strict/allow_parse_non_strict_code_in_cjs_format
+
+- $runtime$-!~{001}~.cjs => $runtime$-Erv9vQWi.cjs
+- main-!~{000}~.cjs => main-7S31PJNc.cjs
+
 # tests/fixtures/misc/use_strict/emit_use_strict_with_strict_cjs_in_cjs_format
 
 - $runtime$-!~{001}~.cjs => $runtime$-Erv9vQWi.cjs


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
