### PR TITLE
fix: add return source logic when file not downloaded and add loader …

### DIFF
--- a/scripts/misc/gen-esbuild-test.mjs
+++ b/scripts/misc/gen-esbuild-test.mjs
@@ -128,6 +128,13 @@ const suites = /** @type {const} */ ({
       'lower_using_unsupported_using_and_async',
     ],
   },
+  loader: {
+    name: 'loader',
+    sourcePath: './bundler_loader_test.go',
+    sourceGithubUrl:
+      'https://raw.githubusercontent.com/evanw/esbuild/main/internal/bundler_tests/bundler_loader_test.go',
+    ignoreCases: [],
+  },
 })
 /**
  * The key of the suites constant. {@link suites}
@@ -167,6 +174,7 @@ async function readTestSuiteSource(testSuiteName) {
         // save under scripts directory
         await fsp.writeFile(sourcePath, text)
         console.log(`Downloaded and saved at ${sourcePath}.`)
+        return fs.readFileSync(sourcePath).toString()
       } else {
         throw new Error('Unexpected shape of source file')
       }


### PR DESCRIPTION
…suite

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

in the old logic 

when the script exec " return fs.readFileSync(sourcePath).toString()"  and  golang file not downloaded and happend exception 

the logic will try to download file but not return the golang code source 

i fix it and return the expect code 

please review it thank you master and have nice day 


