### PR TITLE
chore: remove unnecessary clippy allow directives

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -17,7 +17,7 @@ use crate::utils::call_expression_ext::CallExpressionExt;
 use super::ScopeHoistingFinalizer;
 
 impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
-  #[allow(clippy::too_many_lines, clippy::match_same_arms)]
+  #[allow(clippy::too_many_lines)]
   fn visit_program(&mut self, program: &mut ast::Program<'ast>) {
     let old_body = program.body.take_in(self.alloc);
 

--- a/crates/rolldown/src/module_loader/mod.rs
+++ b/crates/rolldown/src/module_loader/mod.rs
@@ -1,4 +1,3 @@
-#[allow(clippy::module_inception)]
 pub mod module_loader;
 mod normal_module_task;
 mod runtime_normal_module_task;

--- a/crates/rolldown/src/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/normal_module_task.rs
@@ -242,7 +242,6 @@ impl NormalModuleTask {
     (ast_scopes, scan_result, ast_symbols, namespace_object_ref)
   }
 
-  #[allow(clippy::option_if_let_else)]
   pub(crate) async fn resolve_id(
     input_options: &SharedOptions,
     resolver: &SharedResolver,

--- a/crates/rolldown/src/utils/chunk/render_chunk.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk.rs
@@ -29,7 +29,6 @@ use super::{
   render_chunk_imports::render_chunk_imports,
 };
 
-#[allow(clippy::unnecessary_wraps, clippy::cast_possible_truncation)]
 #[tracing::instrument(level = "trace", skip_all)]
 pub async fn render_chunk(
   this: &Chunk,

--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -1,7 +1,6 @@
 use rolldown_common::{Loader, NormalizedBundlerOptions, Platform, SourceMapType};
 use rustc_hash::FxHashMap;
 
-#[allow(clippy::struct_field_names)]
 pub struct NormalizeOptionsReturn {
   pub options: NormalizedBundlerOptions,
   pub resolve_options: rolldown_resolver::ResolveOptions,

--- a/crates/rolldown_common/src/types/output_chunk.rs
+++ b/crates/rolldown_common/src/types/output_chunk.rs
@@ -5,7 +5,6 @@ use crate::ResourceId;
 
 use super::rendered_module::RenderedModule;
 
-#[allow(clippy::zero_sized_map_values)]
 #[derive(Debug)]
 pub struct OutputChunk {
   // PreRenderedChunk

--- a/crates/rolldown_plugin/src/plugin.rs
+++ b/crates/rolldown_plugin/src/plugin.rs
@@ -77,7 +77,6 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   // --- Generate hooks ---
 
-  #[allow(clippy::ptr_arg)]
   async fn render_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn {
     Ok(())
   }
@@ -106,7 +105,6 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
     Ok(())
   }
 
-  #[allow(clippy::ptr_arg)]
   async fn generate_bundle(
     &self,
     _ctx: &SharedPluginContext,
@@ -116,7 +114,6 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
     Ok(())
   }
 
-  #[allow(clippy::ptr_arg)]
   async fn write_bundle(
     &self,
     _ctx: &SharedPluginContext,

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -70,7 +70,6 @@ impl PluginDriver {
     Ok(None)
   }
 
-  #[allow(clippy::unnecessary_cast)]
   pub async fn transform(
     &self,
     args: &HookTransformArgs<'_>,
@@ -89,11 +88,11 @@ impl PluginDriver {
       {
         if let Some(mut map) = r.map {
           // If sourcemap  hasn't `sources`, using original id to fill it.
-          if map.get_source(0 as u32).map_or(true, str::is_empty) {
+          if map.get_source(0).map_or(true, str::is_empty) {
             map.set_sources(vec![args.id]);
           }
           // If sourcemap hasn't `sourcesContent`, using original code to fill it.
-          if map.get_source_content(0 as u32).map_or(true, str::is_empty) {
+          if map.get_source_content(0).map_or(true, str::is_empty) {
             map.set_source_contents(vec![&code]);
           }
           sourcemap_chain.push(map);

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -143,8 +143,6 @@ pub struct ResolveReturn {
 }
 
 impl<F: FileSystem + Default> Resolver<F> {
-  // clippy::option_if_let_else: I think the current code is more readable.
-  #[allow(clippy::missing_errors_doc, clippy::option_if_let_else)]
   pub fn resolve(
     &self,
     importer: Option<&Path>,

--- a/crates/rolldown_sourcemap/src/concat_sourcemap.rs
+++ b/crates/rolldown_sourcemap/src/concat_sourcemap.rs
@@ -74,7 +74,6 @@ impl Source for SourceMapSource {
     self.lines_count
   }
 
-  #[allow(clippy::cast_possible_truncation)]
   fn into_concat_source(
     &self,
     final_source: &mut String,
@@ -111,7 +110,6 @@ impl ConcatSource {
     self.prepend_source.push(source);
   }
 
-  #[allow(clippy::cast_possible_truncation)]
   pub fn content_and_sourcemap(self) -> (String, Option<SourceMap>) {
     let mut final_source = String::new();
     let mut sourcemap_builder = self.enable_sourcemap.then_some(ConcatSourceMapBuilder::default());


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR addresses the removal of unnecessary clippy::allow directives.

Changes are just remove the `#[allow(clippy::...)]` and unnecessary cast.