### PR TITLE
chore(package/rolldown): stop inline dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "devDependencies": {
     "rolldown": "workspace:*",
-    "npm-rolldown": "npm:rolldown@0.10.3",
+    "npm-rolldown": "npm:rolldown@0.10.3-snapshot-94b1371-20240604051941",
     "@ls-lint/ls-lint": "^2.2.2",
     "@taplo/cli": "^0.7.0",
     "@types/node": "20.14.1",

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -91,20 +91,23 @@
     },
     "dtsHeader": "type MaybePromise<T> = T | Promise<T>\ntype Nullable<T> = T | null | undefined\ntype VoidNullable<T = void> = T | null | undefined | void\n"
   },
+  "dependencies": {
+    "zod": "^3.23.6",
+    "locate-character": "^3.0.0",
+    "mri": "^1.2.0",
+    "colorette": "^2.0.20",
+    "consola": "^3.2.3",
+    "citty": "^0.1.6"
+  },
   "devDependencies": {
     "@napi-rs/cli": "^3.0.0-alpha",
     "@napi-rs/wasm-runtime": "^0.2.3",
     "@rolldown/testing": "workspace:*",
-    "citty": "^0.1.6",
-    "colorette": "^2.0.20",
-    "consola": "^3.2.3",
     "emnapi": "^1.2.0",
     "esbuild": "^0.21.3",
     "execa": "^9.1.0",
     "fs-extra": "^11.2.0",
     "glob": "^10.4.1",
-    "locate-character": "^3.0.0",
-    "mri": "^1.2.0",
     "npm-run-all2": "^6.2.0",
     "rolldown": "workspace:*",
     "rollup": "^4.18.0",
@@ -126,8 +129,5 @@
     "@rolldown/binding-win32-arm64-msvc": "workspace:*",
     "@rolldown/binding-win32-ia32-msvc": "workspace:*",
     "@rolldown/binding-win32-x64-msvc": "workspace:*"
-  },
-  "dependencies": {
-    "zod": "^3.23.6"
   }
 }

--- a/packages/rolldown/rolldown.config.mjs
+++ b/packages/rolldown/rolldown.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from 'npm-rolldown'
+import pkgJson from './package.json' with { type: 'json' }
 import esbuild from 'esbuild'
 import nodePath from 'node:path'
 import fsExtra from 'fs-extra'
@@ -19,6 +20,11 @@ const shared = defineConfig({
     /rolldown-binding\..*\.wasm/,
     /@rolldown\/binding-.*/,
     /\.\/rolldown-binding\.wasi\.cjs/,
+    ...Object.keys(pkgJson.dependencies).filter(
+      (dep) =>
+        // `locate-character` only exports esm, so we have to inline it.
+        dep !== 'locate-character',
+    ),
   ],
   resolve: {
     extensions: ['.ts', '.js'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^15.2.2
         version: 15.2.2
       npm-rolldown:
-        specifier: npm:rolldown@0.10.3
-        version: rolldown@0.10.3
+        specifier: npm:rolldown@0.10.3-snapshot-94b1371-20240604051941
+        version: rolldown@0.10.3-snapshot-94b1371-20240604051941
       oxlint:
         specifier: 0.4.2
         version: 0.4.2
@@ -137,6 +137,21 @@ importers:
 
   packages/rolldown:
     dependencies:
+      citty:
+        specifier: ^0.1.6
+        version: 0.1.6
+      colorette:
+        specifier: ^2.0.20
+        version: 2.0.20
+      consola:
+        specifier: ^3.2.3
+        version: 3.2.3
+      locate-character:
+        specifier: ^3.0.0
+        version: 3.0.0
+      mri:
+        specifier: ^1.2.0
+        version: 1.2.0
       zod:
         specifier: ^3.23.6
         version: 3.23.8
@@ -184,15 +199,6 @@ importers:
       '@rolldown/testing':
         specifier: workspace:*
         version: link:../testing
-      citty:
-        specifier: ^0.1.6
-        version: 0.1.6
-      colorette:
-        specifier: ^2.0.20
-        version: 2.0.20
-      consola:
-        specifier: ^3.2.3
-        version: 3.2.3
       emnapi:
         specifier: ^1.2.0
         version: 1.2.0(node-addon-api@8.0.0)
@@ -208,12 +214,6 @@ importers:
       glob:
         specifier: ^10.4.1
         version: 10.4.1
-      locate-character:
-        specifier: ^3.0.0
-        version: 3.0.0
-      mri:
-        specifier: ^1.2.0
-        version: 1.2.0
       npm-run-all2:
         specifier: ^6.2.0
         version: 6.2.0
@@ -1802,7 +1802,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2425,58 +2424,58 @@ packages:
     resolution: {integrity: sha512-zU4vDfBUx/jUBPmR4CzCqPDOPObb/7iLT3UZvhXSJ8ZXDo9214V6agnJvxQ6bYBcypdiKva0hnb3tmo1chQBYg==}
     engines: {node: '>=16.14'}
 
-  '@rolldown/binding-darwin-arm64@0.10.3':
-    resolution: {integrity: sha512-7/UuA+M7tm37KKGSRU1GCYB3Z1pwbvkFacnZ2RH9mErkV/SEUVqbR5bjwJZmJbzu7eDzTmQNPJHO+GIIs4/ufw==}
+  '@rolldown/binding-darwin-arm64@0.10.3-snapshot-94b1371-20240604051941':
+    resolution: {integrity: sha512-PJ0ID+QBWiJO/0ZzS/LHirui3uMajSGORLBaa5ajQn8iCb5hayZh+MfSWKXS2hAqqYMZf0syxkfXFe94/2wzeg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@0.10.3':
-    resolution: {integrity: sha512-a69pCoskqsJQ3QXEkxW+lZj+UtomK7hz8PWRmt0d9K+E2BeRWEMmhJQGMfm7HAB1sOGP0wQr4H/PvLzmlO39gw==}
+  '@rolldown/binding-darwin-x64@0.10.3-snapshot-94b1371-20240604051941':
+    resolution: {integrity: sha512-kcMrvEMPJ+UeCBkOYBebYG70D4JAXS1HOB7oWg2/MHdy9U38ekWfZjE8oFFzG5m8jMFQAYWPNyQigAsGLV5WxA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-linux-arm-gnueabihf@0.10.3':
-    resolution: {integrity: sha512-UVoJoDBK077Ci0O8POvnlsvOc+X5cZEjinQQQAC29q3YDGLPh452cHGPNpggUsRZ8qDXelM7YhIXKx+yAZtUtA==}
+  '@rolldown/binding-linux-arm-gnueabihf@0.10.3-snapshot-94b1371-20240604051941':
+    resolution: {integrity: sha512-eRaPpyXWpvbvvxABnlkpG5y/FrfTLqivBx6t59nSFWNlZEkm+5jgmdtKiBve6zJ9OQA4IblJkW6MV32LhU2WDQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@0.10.3':
-    resolution: {integrity: sha512-3eGGRCsrmmuz4lZEr0Y0menxx/TbH6xDboWu0NXnpiBhbWQSmAXHCf+R1dJ6kX+yPTsFzqihCTsw2u0dWTYy/g==}
+  '@rolldown/binding-linux-arm64-gnu@0.10.3-snapshot-94b1371-20240604051941':
+    resolution: {integrity: sha512-wm0kQkd56g02Vp9VCmpYI9eDlmQuMJI6Ko9uO+xjO+nVF7bh8JoMZkzgZLEQNkiB+wGb145VBeWRqwRo3pMlxw==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@0.10.3':
-    resolution: {integrity: sha512-qfsYV4BHknoF3cQjXv17HR34sYsxgBvG+UZ8Vqwo+OR1jvi+dpvi8JebIdXRWwWG35svSIVRwa/J0QzosvdooQ==}
+  '@rolldown/binding-linux-arm64-musl@0.10.3-snapshot-94b1371-20240604051941':
+    resolution: {integrity: sha512-7D/2F3ysvX8r1jWKiIAXAw0ydbSvEbsB2r96lWGp2fftj1vSIoEnkOqd2wUuLavd8lhgqubo3bI/69AV/nztsw==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@0.10.3':
-    resolution: {integrity: sha512-C/VQ+Qe/oFYeGTWUQPWcobQvj5Tl55/WACh6NQYsqm9IT46FNidNWy0Tb3KK55+JPUV30p7S8jYNCJiy9EbYvw==}
+  '@rolldown/binding-linux-x64-gnu@0.10.3-snapshot-94b1371-20240604051941':
+    resolution: {integrity: sha512-f9WNuRH6Dm565fi7cqIxY/JWpQVoHxlA7CSG0brDePxTDvkAipkCOlvpWVPuX07ytBYEax9o7L9CGabM0e/X8Q==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@0.10.3':
-    resolution: {integrity: sha512-I3ZYqTa+SfJPVZ8BSsJFrhWgSFdES/oRlM/JMiAEAEowoLnUKOzHb89VAZ612TV6JzRIBPxCUykDYwRgSLwbVQ==}
+  '@rolldown/binding-linux-x64-musl@0.10.3-snapshot-94b1371-20240604051941':
+    resolution: {integrity: sha512-rGn4Wxdo7fu7TLZvIeJUhYwHsc36g1mk174JwXKn7C+ja9Y/cFhovdrnxPowponD545iLmWxSdfJbkHzWaI0Sg==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-wasm32-wasi@0.10.3':
-    resolution: {integrity: sha512-VCgJyNDT7V2A8GRwH6lVPrCavsDGwLO/dY6VP8d6jXLKNPpmwOlwO/AAovriXOb47UtzcXRCTnms/vNoMyNHkw==}
+  '@rolldown/binding-wasm32-wasi@0.10.3-snapshot-94b1371-20240604051941':
+    resolution: {integrity: sha512-HUnUuSy8qma1PwFiWU7FV+w2XL0umprnh/LswXuEKFLx3oF1u1+WT9SPjK6/ruOlQVSlGm3dwuAb0va2OlFXLQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@0.10.3':
-    resolution: {integrity: sha512-wnin4ovtl0yhJjKyORQRUUc0MLoeE8oE73KzjyVrp5u1H9ggpmef5ND97f5VluEoD0sYqt1WR2wxRB3n9Oky/w==}
+  '@rolldown/binding-win32-arm64-msvc@0.10.3-snapshot-94b1371-20240604051941':
+    resolution: {integrity: sha512-IsvR7reoxUZy0PZGSZzWoJpK2usTmPqxlkUSYnmeY//7ADBtD2vw2HecxZaQVS9umiS0AZylznApHW2FqawM5g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@0.10.3':
-    resolution: {integrity: sha512-tEFWf5fYbphWfNZfAoCTZZ1ySt8Eno6VQMnzBfmtQBfHnSQH70XvxCTpCT4TmQDDKxxE8P8RK8sPALdAN9jVQg==}
+  '@rolldown/binding-win32-ia32-msvc@0.10.3-snapshot-94b1371-20240604051941':
+    resolution: {integrity: sha512-InJNKTvW1EVLJRI4MnpoLzKrRiEJnvtWywQKcQPTqefjeU6plwALgSft7a+Q6X+ly891SZMkJqjYj7tbmspVwg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@0.10.3':
-    resolution: {integrity: sha512-pMwoq5ueO8Nu3/Ry9t4r99IzNq7y3di5M43qxPjsAG86I3tQGMh7AVTz1t/EbOpYHzzPQXb66A/9ZRDnqrzDag==}
+  '@rolldown/binding-win32-x64-msvc@0.10.3-snapshot-94b1371-20240604051941':
+    resolution: {integrity: sha512-zznplJQ3Knns5pMiTJnhYHIMSo0dNc4Umr0519qqCPiIVaFFTnhqTdKA2ELvCocsNH/I0EaVRAm9TPxuixjqwA==}
     cpu: [x64]
     os: [win32]
 
@@ -4751,8 +4750,8 @@ packages:
     engines: {node: '>= 0.10'}
     deprecated: Please use String.prototype.padEnd() over this package.
 
-  rolldown@0.10.3:
-    resolution: {integrity: sha512-5tMxuuYYWYiqeANvpTciucB3cHic2j0nFr8qErySvMUrwTftRL1YHQhCDiUVSE7w3b5fzwvHS98otQDO/opfew==}
+  rolldown@0.10.3-snapshot-94b1371-20240604051941:
+    resolution: {integrity: sha512-ssWjO82rq8vbfYW5JnWaY9f16XG2Lb3MggHlvDZpydDHrZ+xPfT6KtgnT2FCCotcXEyP+0JiWbd9xXFtD2nwwQ==}
     hasBin: true
 
   rollup-plugin-dts@6.1.0:
@@ -7397,39 +7396,39 @@ snapshots:
       write-file-atomic: 5.0.1
       write-yaml-file: 5.0.0
 
-  '@rolldown/binding-darwin-arm64@0.10.3':
+  '@rolldown/binding-darwin-arm64@0.10.3-snapshot-94b1371-20240604051941':
     optional: true
 
-  '@rolldown/binding-darwin-x64@0.10.3':
+  '@rolldown/binding-darwin-x64@0.10.3-snapshot-94b1371-20240604051941':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@0.10.3':
+  '@rolldown/binding-linux-arm-gnueabihf@0.10.3-snapshot-94b1371-20240604051941':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@0.10.3':
+  '@rolldown/binding-linux-arm64-gnu@0.10.3-snapshot-94b1371-20240604051941':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@0.10.3':
+  '@rolldown/binding-linux-arm64-musl@0.10.3-snapshot-94b1371-20240604051941':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@0.10.3':
+  '@rolldown/binding-linux-x64-gnu@0.10.3-snapshot-94b1371-20240604051941':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@0.10.3':
+  '@rolldown/binding-linux-x64-musl@0.10.3-snapshot-94b1371-20240604051941':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@0.10.3':
+  '@rolldown/binding-wasm32-wasi@0.10.3-snapshot-94b1371-20240604051941':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@0.10.3':
+  '@rolldown/binding-win32-arm64-msvc@0.10.3-snapshot-94b1371-20240604051941':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@0.10.3':
+  '@rolldown/binding-win32-ia32-msvc@0.10.3-snapshot-94b1371-20240604051941':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@0.10.3':
+  '@rolldown/binding-win32-x64-msvc@0.10.3-snapshot-94b1371-20240604051941':
     optional: true
 
   '@rollup/plugin-alias@5.1.0(rollup@3.29.4)':
@@ -9817,21 +9816,21 @@ snapshots:
 
   right-pad@1.0.1: {}
 
-  rolldown@0.10.3:
+  rolldown@0.10.3-snapshot-94b1371-20240604051941:
     dependencies:
       zod: 3.23.8
     optionalDependencies:
-      '@rolldown/binding-darwin-arm64': 0.10.3
-      '@rolldown/binding-darwin-x64': 0.10.3
-      '@rolldown/binding-linux-arm-gnueabihf': 0.10.3
-      '@rolldown/binding-linux-arm64-gnu': 0.10.3
-      '@rolldown/binding-linux-arm64-musl': 0.10.3
-      '@rolldown/binding-linux-x64-gnu': 0.10.3
-      '@rolldown/binding-linux-x64-musl': 0.10.3
-      '@rolldown/binding-wasm32-wasi': 0.10.3
-      '@rolldown/binding-win32-arm64-msvc': 0.10.3
-      '@rolldown/binding-win32-ia32-msvc': 0.10.3
-      '@rolldown/binding-win32-x64-msvc': 0.10.3
+      '@rolldown/binding-darwin-arm64': 0.10.3-snapshot-94b1371-20240604051941
+      '@rolldown/binding-darwin-x64': 0.10.3-snapshot-94b1371-20240604051941
+      '@rolldown/binding-linux-arm-gnueabihf': 0.10.3-snapshot-94b1371-20240604051941
+      '@rolldown/binding-linux-arm64-gnu': 0.10.3-snapshot-94b1371-20240604051941
+      '@rolldown/binding-linux-arm64-musl': 0.10.3-snapshot-94b1371-20240604051941
+      '@rolldown/binding-linux-x64-gnu': 0.10.3-snapshot-94b1371-20240604051941
+      '@rolldown/binding-linux-x64-musl': 0.10.3-snapshot-94b1371-20240604051941
+      '@rolldown/binding-wasm32-wasi': 0.10.3-snapshot-94b1371-20240604051941
+      '@rolldown/binding-win32-arm64-msvc': 0.10.3-snapshot-94b1371-20240604051941
+      '@rolldown/binding-win32-ia32-msvc': 0.10.3-snapshot-94b1371-20240604051941
+      '@rolldown/binding-win32-x64-msvc': 0.10.3-snapshot-94b1371-20240604051941
 
   rollup-plugin-dts@6.1.0(rollup@3.29.4)(typescript@5.4.5):
     dependencies:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently we use tsc to generate types and tsc won't inline types of dependencies. We need to add these dependencies to `dependencies `, so the types of users could be correct.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
