### PR TITLE
fix(docs): update requirement of node version in contribution guide

### DIFF
--- a/web/docs/contrib-guide/setup-the-project.md
+++ b/web/docs/contrib-guide/setup-the-project.md
@@ -33,7 +33,7 @@ cargo install just
 
 :::
 
-- Install Node.js >= 18.18.0
+- Install Node.js >= 20.11 / 21.2
 
 ## `just setup`
 


### PR DESCRIPTION
### Description

https://github.com/rolldown/rolldown/blob/8231eb8d4650e7f56fb3832bcc4b0f18686c796f/packages/rolldown/rolldown.config.mjs#L32
the usage of `import.meta.dirname` causes error, it was add in v21.2.0, v20.11.0 according to https://nodejs.org/api/esm.html#importmetadirname
```
ERROR The "paths[0]" argument must be of type string. Received undefined 6:23:18 PM

at new NodeError (node:internal/errors:405:5)
at validateString (node:internal/validators:162:11)
at Object.resolve (node:path:1097:7)
at rolldown.config.mjs:32:24
at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
at async ModuleLoader.import (node:internal/modules/esm/loader:337:24)
at async ensureConfig (/home/dev/projects/rolldown/node_modules/.pnpm/rolldown@0.10.3-snapshot-94b1371-20240604051941/node_modules/rolldown/dist/esm/cli.mjs:543:24)
at async bundle (/home/dev/projects/rolldown/node_modules/.pnpm/rolldown@0.10.3-snapshot-94b1371-20240604051941/node_modules/rolldown/dist/esm/cli.mjs:632:17)
at async Object.run (/home/dev/projects/rolldown/node_modules/.pnpm/rolldown@0.10.3-snapshot-94b1371-20240604051941/node_modules/rolldown/dist/esm/cli.mjs:765:4)
at async runCommand (/home/dev/projects/rolldown/node_modules/.pnpm/rolldown@0.10.3-snapshot-94b1371-20240604051941/node_modules/rolldown/dist/esm/cli.mjs:416:13)

ERROR The "paths[0]" argument must be of type string. Received undefined 6:23:18 PM

 ELIFECYCLE  Command failed with exit code 1.
```