### PR TITLE
refactor: bindingfy sourcemap

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_load_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_load_output.rs
@@ -2,6 +2,7 @@ use derivative::Derivative;
 use serde::Deserialize;
 
 use super::binding_hook_side_effects::BindingHookSideEffects;
+use crate::types::binding_sourcemap::BindingSourcemap;
 
 #[napi_derive::napi(object)]
 #[derive(Deserialize, Default, Derivative)]
@@ -9,8 +10,8 @@ use super::binding_hook_side_effects::BindingHookSideEffects;
 #[derivative(Debug)]
 pub struct BindingHookLoadOutput {
   pub code: String,
-  pub map: Option<String>,
   pub side_effects: Option<BindingHookSideEffects>,
+  pub map: Option<BindingSourcemap>,
 }
 
 impl TryFrom<BindingHookLoadOutput> for rolldown_plugin::HookLoadOutput {
@@ -19,13 +20,7 @@ impl TryFrom<BindingHookLoadOutput> for rolldown_plugin::HookLoadOutput {
   fn try_from(value: BindingHookLoadOutput) -> Result<Self, Self::Error> {
     Ok(rolldown_plugin::HookLoadOutput {
       code: value.code,
-      map: value
-        .map
-        .map(|content| {
-          rolldown_sourcemap::SourceMap::from_json_string(&content)
-            .map_err(|e| anyhow::format_err!("SOURCEMAP_ERROR: {:?}", e))
-        })
-        .transpose()?,
+      map: value.map.map(TryInto::try_into).transpose()?,
       side_effects: value.side_effects.map(Into::into),
     })
   }

--- a/crates/rolldown_binding/src/types/mod.rs
+++ b/crates/rolldown_binding/src/types/mod.rs
@@ -7,4 +7,5 @@ pub mod binding_outputs;
 pub mod binding_rendered_chunk;
 pub mod binding_rendered_module;
 pub mod binding_resolve_alias_item;
+pub mod binding_sourcemap;
 pub mod js_callback;

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -1,9 +1,9 @@
 // cSpell:disable
 pub use concat_sourcemap::{ConcatSource, RawSource, Source, SourceMapSource};
-pub use oxc::sourcemap::{SourceMap, SourcemapVisualizer};
+pub use oxc::sourcemap::SourceMapBuilder;
+pub use oxc::sourcemap::{JSONSourceMap, SourceMap, SourcemapVisualizer};
 mod lines_count;
 pub use lines_count::lines_count;
-use oxc::sourcemap::SourceMapBuilder;
 mod concat_sourcemap;
 
 pub fn collapse_sourcemaps(mut sourcemap_chain: Vec<&SourceMap>) -> Option<SourceMap> {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -107,13 +107,13 @@ export interface BindingEmittedAsset {
 
 export interface BindingHookLoadOutput {
   code: string
-  map?: string
   sideEffects?: BindingHookSideEffects
+  map?: BindingSourcemap
 }
 
 export interface BindingHookRenderChunkOutput {
   code: string
-  map?: string
+  map?: BindingSourcemap
 }
 
 export interface BindingHookResolveIdExtraOptions {
@@ -148,6 +148,15 @@ export interface BindingInputOptions {
   logLevel?: BindingLogLevel
   onLog: (logLevel: 'debug' | 'warn' | 'info', log: BindingLog) => void
   cwd: string
+}
+
+export interface BindingJsonSourcemap {
+  file?: string
+  mappings?: string
+  sourceRoot?: string
+  sources?: Array<string | undefined | null>
+  sourcesContent?: Array<string | undefined | null>
+  names?: Array<string>
 }
 
 export enum BindingLogLevel {
@@ -218,6 +227,10 @@ export interface BindingResolveOptions {
   modules?: Array<string>
   symlinks?: boolean
   tsconfigFilename?: string
+}
+
+export interface BindingSourcemap {
+  inner: string | BindingJSONSourcemap
 }
 
 export function registerPlugins(id: number, plugins: PluginsInSingleWorker): void

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -10,7 +10,7 @@ import { NormalizedInputOptions } from '../options/normalized-input-options'
 import { isEmptySourcemapFiled } from '../utils/transform-sourcemap'
 import { transformModuleInfo } from '../utils/transform-module-info'
 import path from 'node:path'
-import type { SourceMapInputObject } from '../types/sourcemap'
+import { bidingSourcemap, type SourceMapInputObject } from '../types/sourcemap'
 import { PluginContext } from './plugin-context'
 import { TransformPluginContext } from './transfrom-plugin-context'
 import { bindingifySideEffects } from '../utils/transform-side-effects'
@@ -159,7 +159,7 @@ export function bindingifyTransform(
 
     return {
       code: ret.code,
-      map: typeof ret.map === 'object' ? JSON.stringify(ret.map) : ret.map,
+      map: bidingSourcemap(ret.map),
       sideEffects: bindingifySideEffects(ret.moduleSideEffects),
     }
   }
@@ -206,7 +206,7 @@ export function bindingifyLoad(
 
     const result = {
       code: ret.code,
-      map: JSON.stringify(map),
+      map: bidingSourcemap(map),
     }
 
     if (ret.moduleSideEffects !== null) {

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -10,7 +10,10 @@ import { NormalizedInputOptions } from '../options/normalized-input-options'
 import { isEmptySourcemapFiled } from '../utils/transform-sourcemap'
 import { transformModuleInfo } from '../utils/transform-module-info'
 import path from 'node:path'
-import { bidingSourcemap, type SourceMapInputObject } from '../types/sourcemap'
+import {
+  bindingifySourcemap,
+  type SourceMapInputObject,
+} from '../types/sourcemap'
 import { PluginContext } from './plugin-context'
 import { TransformPluginContext } from './transfrom-plugin-context'
 import { bindingifySideEffects } from '../utils/transform-side-effects'
@@ -159,7 +162,7 @@ export function bindingifyTransform(
 
     return {
       code: ret.code,
-      map: bidingSourcemap(ret.map),
+      map: bindingifySourcemap(ret.map),
       sideEffects: bindingifySideEffects(ret.moduleSideEffects),
     }
   }
@@ -206,7 +209,7 @@ export function bindingifyLoad(
 
     const result = {
       code: ret.code,
-      map: bidingSourcemap(map),
+      map: bindingifySourcemap(map),
     }
 
     if (ret.moduleSideEffects !== null) {

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -5,7 +5,7 @@ import type { Plugin } from './index'
 import { transformToOutputBundle } from '../utils/transform-to-rollup-output'
 import { PluginContext } from './plugin-context'
 import { NormalizedOutputOptions } from '@src/options/normalized-output-options'
-import { bidingSourcemap } from '../types/sourcemap'
+import { bindingifySourcemap } from '../types/sourcemap'
 
 export function bindingifyRenderStart(
   plugin: Plugin,
@@ -60,7 +60,7 @@ export function bindingifyRenderChunk(
 
     return {
       code: ret.code,
-      map: bidingSourcemap(ret.map),
+      map: bindingifySourcemap(ret.map),
     }
   }
 }

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -5,6 +5,7 @@ import type { Plugin } from './index'
 import { transformToOutputBundle } from '../utils/transform-to-rollup-output'
 import { PluginContext } from './plugin-context'
 import { NormalizedOutputOptions } from '@src/options/normalized-output-options'
+import { bidingSourcemap } from '../types/sourcemap'
 
 export function bindingifyRenderStart(
   plugin: Plugin,
@@ -59,7 +60,7 @@ export function bindingifyRenderChunk(
 
     return {
       code: ret.code,
-      map: typeof ret.map === 'object' ? JSON.stringify(ret.map) : ret.map,
+      map: bidingSourcemap(ret.map),
     }
   }
 }

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -110,7 +110,7 @@ export interface Plugin {
       | string
       | {
           code: string
-          map?: string | null | SourceMapInput
+          map?: SourceMapInput
           moduleSideEffects?: ModuleSideEffects
         }
     >
@@ -143,7 +143,7 @@ export interface Plugin {
       | string
       | {
           code: string
-          map?: string | null | SourceMapInput
+          map?: SourceMapInput
         }
     >
   >

--- a/packages/rolldown/src/types/sourcemap.ts
+++ b/packages/rolldown/src/types/sourcemap.ts
@@ -1,7 +1,7 @@
 import { BindingSourcemap } from '../binding'
 
 export interface SourceMapInputObject {
-  file?: string
+  file?: string | null
   mappings: string
   names?: string[]
   sources?: (string | null)[]
@@ -16,5 +16,17 @@ export function bidingSourcemap(
   map?: SourceMapInput,
 ): undefined | BindingSourcemap {
   if (map == null) return
-  return { inner: map }
+  return {
+    inner:
+      typeof map === 'string'
+        ? map
+        : {
+            file: map.file ?? undefined,
+            mappings: map.mappings,
+            sourceRoot: map.sourceRoot,
+            sources: map.sources?.map((s) => s ?? undefined),
+            sourcesContent: map.sourcesContent?.map((s) => s ?? undefined),
+            names: map.names,
+          },
+  }
 }

--- a/packages/rolldown/src/types/sourcemap.ts
+++ b/packages/rolldown/src/types/sourcemap.ts
@@ -1,3 +1,5 @@
+import { BindingSourcemap } from '../binding'
+
 export interface SourceMapInputObject {
   file?: string
   mappings: string
@@ -9,3 +11,10 @@ export interface SourceMapInputObject {
 }
 
 export type SourceMapInput = SourceMapInputObject | string | null
+
+export function bidingSourcemap(
+  map?: SourceMapInput,
+): undefined | BindingSourcemap {
+  if (map == null) return
+  return { inner: map }
+}

--- a/packages/rolldown/src/types/sourcemap.ts
+++ b/packages/rolldown/src/types/sourcemap.ts
@@ -12,7 +12,7 @@ export interface SourceMapInputObject {
 
 export type SourceMapInput = SourceMapInputObject | string | null
 
-export function bidingSourcemap(
+export function bindingifySourcemap(
   map?: SourceMapInput,
 ): undefined | BindingSourcemap {
   if (map == null) return


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It avoid convert `JSON.stringfy` map at js side, it is unnecessary overhead.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
