### PR TITLE
refactor(package/rolldown): resolve circular dependency

### DIFF
--- a/packages/rolldown/src/log/logHandler.ts
+++ b/packages/rolldown/src/log/logHandler.ts
@@ -1,4 +1,4 @@
-import { noop } from '../utils'
+import { noop } from '../utils/misc'
 import type {
   LoggingFunctionWithPosition,
   LogHandler,

--- a/packages/rolldown/src/options/bindingify-input-options.ts
+++ b/packages/rolldown/src/options/bindingify-input-options.ts
@@ -2,7 +2,7 @@ import type { BindingInputOptions } from '../binding'
 import nodePath from 'node:path'
 import { bindingifyPlugin } from '../plugin/bindingify-plugin'
 import type { NormalizedInputOptions } from './normalized-input-options'
-import { arraify } from '@src/utils'
+import { arraify } from '@src/utils/misc'
 import type { NormalizedOutputOptions } from './normalized-output-options'
 import type { LogLevelOption } from '@src/log/logging'
 import {

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -6,7 +6,7 @@ import type { Plugin } from './index'
 import { LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARN } from '../log/logging'
 import { error, logPluginError } from '../log/logs'
 import { AssetSource, bindingAssetSource } from '../utils/asset-source'
-import { unimplemented } from '@src/utils'
+import { unimplemented } from '@src/utils/misc'
 
 export interface EmittedAsset {
   type: 'asset'

--- a/packages/rolldown/src/utils/index.ts
+++ b/packages/rolldown/src/utils/index.ts
@@ -6,27 +6,4 @@ export * from './create-bundler'
 export * from './transform-sourcemap'
 export * from './transform-module-info'
 export * from './code-frame'
-
-export function arraify<T>(value: T | T[]): T[] {
-  return Array.isArray(value) ? value : [value]
-}
-
-export function unimplemented(info?: string): never {
-  if (info) {
-    throw new Error(`unimplemented: ${info}`)
-  }
-  throw new Error('unimplemented')
-}
-
-export function unreachable(info?: string): never {
-  if (info) {
-    throw new Error(`unreachable: ${info}`)
-  }
-  throw new Error('unreachable')
-}
-
-export function unsupported(info: string): never {
-  throw new Error(`Rolldown unsupported api: ${info}`)
-}
-
-export function noop(..._args: any[]) {}
+export * from './misc'

--- a/packages/rolldown/src/utils/misc.ts
+++ b/packages/rolldown/src/utils/misc.ts
@@ -1,0 +1,23 @@
+export function arraify<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value]
+}
+
+export function unimplemented(info?: string): never {
+  if (info) {
+    throw new Error(`unimplemented: ${info}`)
+  }
+  throw new Error('unimplemented')
+}
+
+export function unreachable(info?: string): never {
+  if (info) {
+    throw new Error(`unreachable: ${info}`)
+  }
+  throw new Error('unreachable')
+}
+
+export function unsupported(info: string): never {
+  throw new Error(`Rolldown unsupported api: ${info}`)
+}
+
+export function noop(..._args: any[]) {}

--- a/packages/rolldown/src/utils/normalize-output-options.ts
+++ b/packages/rolldown/src/utils/normalize-output-options.ts
@@ -1,5 +1,5 @@
 import type { OutputOptions } from '@src/options/output-options'
-import { unimplemented } from '.'
+import { unimplemented } from './misc'
 import type { NormalizedOutputOptions } from '@src/options/normalized-output-options'
 
 export function normalizeOutputOptions(

--- a/packages/rolldown/src/utils/transform-module-info.ts
+++ b/packages/rolldown/src/utils/transform-module-info.ts
@@ -1,6 +1,6 @@
 import type { ModuleInfo } from '../types/module-info'
 import type { BindingModuleInfo } from '../binding'
-import { unsupported } from '.'
+import { unsupported } from './misc'
 
 export function transformModuleInfo(info: BindingModuleInfo): ModuleInfo {
   return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

![image](https://github.com/rolldown/rolldown/assets/19543313/70ff5c67-454e-4816-a7d8-4e86d2172b76)

![image](https://github.com/rolldown/rolldown/assets/19543313/ca7ddc0d-ecee-48cc-b852-053fdb90963a)

this pr try to resolve CIRCULAR_DEPENDENCY issue when build Rolldown package. I attempt to reorganize the module to do it, could it be a appropriate refactor?
