### PR TITLE
fix: rolldown typing

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_extra_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_extra_options.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 #[derivative(Debug)]
 pub struct BindingHookResolveIdExtraOptions {
   pub is_entry: bool,
+  #[napi(ts_type = "'import' | 'dynamic-import' | 'require-call'")]
   pub kind: String,
 }
 

--- a/crates/rolldown_binding/src/parallel_js_plugin_registry.rs
+++ b/crates/rolldown_binding/src/parallel_js_plugin_registry.rs
@@ -79,7 +79,7 @@ impl FromNapiValue for ParallelJsPluginRegistry {
 }
 
 #[napi]
-pub fn register_plugins(id: u16, plugins: PluginsInSingleWorker) {
+pub fn register_plugins(id: u16, plugins: Vec<BindingPluginWithIndex>) {
   if let Some(mut existing_plugins) = PLUGINS_MAP.get_mut(&id) {
     existing_plugins.push(plugins);
   }

--- a/packages/rolldown/rolldown.config.mjs
+++ b/packages/rolldown/rolldown.config.mjs
@@ -28,9 +28,6 @@ const shared = defineConfig({
   ],
   resolve: {
     extensions: ['.ts', '.js'],
-    alias: {
-      '@src': nodePath.resolve(import.meta.dirname, 'src'),
-    },
   },
 })
 
@@ -107,6 +104,18 @@ export default defineConfig([
             const fileName = nodePath.basename(file)
             console.log('[build:done] Copying', file, 'to ./dist/shared')
             fsExtra.copyFileSync(file, nodePath.join(copyTo, fileName))
+          })
+
+          // Copy binding types and rollup types to dist
+          const distTypesDir = nodePath.resolve(outputDir, 'types')
+          fsExtra.ensureDirSync(distTypesDir)
+          const types = globSync(['./src/*.d.ts'], {
+            absolute: true,
+          })
+          types.forEach((file) => {
+            const fileName = nodePath.basename(file)
+            console.log('[build:done] Copying', file, 'to ./dist/shared')
+            fsExtra.copyFileSync(file, nodePath.join(distTypesDir, fileName))
           })
         },
       },

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -118,7 +118,7 @@ export interface BindingHookRenderChunkOutput {
 
 export interface BindingHookResolveIdExtraOptions {
   isEntry: boolean
-  kind: string
+  kind: 'import' | 'dynamic-import' | 'require-call'
 }
 
 export interface BindingHookResolveIdOutput {
@@ -233,7 +233,7 @@ export interface BindingSourcemap {
   inner: string | BindingJSONSourcemap
 }
 
-export function registerPlugins(id: number, plugins: PluginsInSingleWorker): void
+export function registerPlugins(id: number, plugins: Array<BindingPluginWithIndex>): void
 
 export interface RenderedChunk {
   isEntry: boolean

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -1,5 +1,5 @@
 import { performance } from 'node:perf_hooks'
-import { rolldown } from '@src/rolldown'
+import { rolldown } from '../../rolldown'
 import type { RolldownOptions, RolldownOutput, RollupOutput } from '../../index'
 import { arraify } from '../../utils/index'
 import { ensureConfig, logger } from '../utils'

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -2,7 +2,7 @@ import { RolldownOutput, RolldownOutputChunk } from './types/rolldown-output'
 import type { InputOptions } from './options/input-options'
 import type { OutputOptions } from './options/output-options'
 import type { RolldownOptions } from './types/rolldown-options'
-import type { Plugin } from './plugin'
+import type { ImportKind, Plugin } from './plugin'
 import { defineParallelPlugin, DefineParallelPluginResult } from './plugin'
 import { defineConfig } from './utils/define-config'
 import { rolldown, experimental_scan } from './rolldown'
@@ -26,6 +26,7 @@ export type {
   Plugin,
   DefineParallelPluginResult,
   ConfigExport,
+  ImportKind,
 }
 
 // Exports for compatibility

--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -1,4 +1,4 @@
-import { getCodeFrame } from '@src/utils/code-frame'
+import { getCodeFrame } from '../utils/code-frame'
 import { locate } from 'locate-character'
 import type { RollupLog } from '../rollup'
 

--- a/packages/rolldown/src/options/bindingify-input-options.ts
+++ b/packages/rolldown/src/options/bindingify-input-options.ts
@@ -2,9 +2,9 @@ import type { BindingInputOptions } from '../binding'
 import nodePath from 'node:path'
 import { bindingifyPlugin } from '../plugin/bindingify-plugin'
 import type { NormalizedInputOptions } from './normalized-input-options'
-import { arraify } from '@src/utils/misc'
+import { arraify } from '../utils/misc'
 import type { NormalizedOutputOptions } from './normalized-output-options'
-import type { LogLevelOption } from '@src/log/logging'
+import type { LogLevelOption } from '../log/logging'
 import {
   bindingifyBuiltInPlugin,
   BuiltinPlugin,

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -4,7 +4,7 @@ import type {
 } from '../rollup'
 import type { OutputOptions } from './output-options'
 import type { Plugin, ParallelPlugin } from '../plugin'
-import type { RenderedChunk } from '@src/binding'
+import type { RenderedChunk } from '../binding'
 
 type InternalModuleFormat = 'es' | 'cjs'
 

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -4,8 +4,8 @@ import type { NormalizedInputOptions } from '../options/normalized-input-options
 import type { Plugin } from './index'
 import { transformToOutputBundle } from '../utils/transform-to-rollup-output'
 import { PluginContext } from './plugin-context'
-import { NormalizedOutputOptions } from '@src/options/normalized-output-options'
 import { bindingifySourcemap } from '../types/sourcemap'
+import { NormalizedOutputOptions } from '../options/normalized-output-options'
 
 export function bindingifyRenderStart(
   plugin: Plugin,

--- a/packages/rolldown/src/plugin/bindingify-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin.ts
@@ -20,7 +20,7 @@ import {
 
 import type { Plugin } from './index'
 import type { NormalizedInputOptions } from '../options/normalized-input-options'
-import type { NormalizedOutputOptions } from '@src/options/normalized-output-options'
+import type { NormalizedOutputOptions } from '../options/normalized-output-options'
 
 // Note: because napi not catch error, so we need to catch error and print error to debugger in adapter.
 export function bindingifyPlugin(

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -10,7 +10,7 @@ import type { ModuleInfo } from '../types/module-info'
 import type { OutputBundle } from '../types/output-bundle'
 import type { PluginContext } from './plugin-context'
 import type { TransformPluginContext } from './transfrom-plugin-context'
-import type { NormalizedOutputOptions } from '@src/options/normalized-output-options'
+import type { NormalizedOutputOptions } from '../options/normalized-output-options'
 import type { LogLevel } from '../log/logging'
 import type { RollupLog } from '../rollup'
 import type { MinimalPluginContext } from '../log/logger'
@@ -24,6 +24,8 @@ export type Hook<Handler extends AnyFn, HookOptions extends AnyObj = AnyObj> =
   | Handler
 
 export type ModuleSideEffects = boolean | 'no-treeshake' | null
+
+export type ImportKind = BindingHookResolveIdExtraOptions['kind']
 
 export type ResolveIdResult =
   | string

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -6,7 +6,7 @@ import type { Plugin } from './index'
 import { LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARN } from '../log/logging'
 import { error, logPluginError } from '../log/logs'
 import { AssetSource, bindingAssetSource } from '../utils/asset-source'
-import { unimplemented } from '@src/utils/misc'
+import { unimplemented } from '../utils/misc'
 
 export interface EmittedAsset {
   type: 'asset'

--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -4,7 +4,7 @@ import { Plugin } from './'
 import { error, logPluginError } from '../log/logs'
 import { NormalizedInputOptions } from '../options/normalized-input-options'
 import { NormalizedOutputOptions } from '../options/normalized-output-options'
-import { RollupError } from '@src/rollup'
+import { RollupError } from '../rollup'
 import { normalizeHook } from '../utils/normalize-hook'
 
 export class PluginDriver {

--- a/packages/rolldown/src/plugin/transfrom-plugin-context.ts
+++ b/packages/rolldown/src/plugin/transfrom-plugin-context.ts
@@ -1,16 +1,16 @@
 import type {
   BindingPluginContext,
   BindingTransformPluginContext,
-} from '@src/binding'
-import type { SourceMap } from '@src/types/rolldown-output'
+} from '../binding'
+import type { SourceMap } from '../types/rolldown-output'
 import type {
   LoggingFunction,
   LoggingFunctionWithPosition,
   RollupError,
 } from '../rollup'
-import { normalizeLog } from '@src/log/logHandler'
+import { normalizeLog } from '../log/logHandler'
 import type { EmittedAsset, PluginContext } from './plugin-context'
-import { augmentCodeLocation } from '@src/log/logs'
+import { augmentCodeLocation } from '../log/logs'
 
 export class TransformPluginContext {
   debug: LoggingFunction

--- a/packages/rolldown/src/utils/create-bundler.ts
+++ b/packages/rolldown/src/utils/create-bundler.ts
@@ -1,11 +1,11 @@
-import { bindingifyInputOptions } from '@src/options/bindingify-input-options'
+import { bindingifyInputOptions } from '../options/bindingify-input-options'
 import { Bundler } from '../binding'
 import type { InputOptions } from '../options/input-options'
 import type { OutputOptions } from '../options/output-options'
 import { initializeParallelPlugins } from './initialize-parallel-plugins'
 import { normalizeInputOptions } from './normalize-input-options'
 import { normalizeOutputOptions } from './normalize-output-options'
-import { bindingifyOutputOptions } from '@src/options/bindingify-output-options'
+import { bindingifyOutputOptions } from '../options/bindingify-output-options'
 import { PluginDriver } from '../plugin/plugin-driver'
 
 export async function createBundler(

--- a/packages/rolldown/src/utils/normalize-output-options.ts
+++ b/packages/rolldown/src/utils/normalize-output-options.ts
@@ -1,6 +1,6 @@
-import type { OutputOptions } from '@src/options/output-options'
+import type { OutputOptions } from '../options/output-options'
 import { unimplemented } from './misc'
-import type { NormalizedOutputOptions } from '@src/options/normalized-output-options'
+import type { NormalizedOutputOptions } from '../options/normalized-output-options'
 
 export function normalizeOutputOptions(
   opts: OutputOptions,

--- a/packages/rolldown/src/utils/transform-side-effects.ts
+++ b/packages/rolldown/src/utils/transform-side-effects.ts
@@ -1,4 +1,4 @@
-import { BindingHookSideEffects } from '@src/binding'
+import { BindingHookSideEffects } from '../binding'
 import { ModuleSideEffects } from '../plugin'
 
 export function bindingifySideEffects(

--- a/packages/rolldown/tsconfig.dts.json
+++ b/packages/rolldown/tsconfig.dts.json
@@ -33,8 +33,7 @@
     "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
     "paths": {
       "@tests/*": ["tests/src/*"],
-      "@tests": ["tests/src/index.ts"],
-      "@src/*": ["src/*"]
+      "@tests": ["tests/src/index.ts"]
     } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The original typing has some errors.
1. the dist types not `binding.d.ts` and `rollup.d.ts`, the `tsc` couldn't move them to type dist, it need to copy manually.
2. the alias path is not replaced at dist typing, tsc provides `typescript-transform-paths` to resolve them, but it has noise at build, so here remove alias path usages.

Other, we could build binding files to `/rolldown/bidings/` instead of `/rolldown/src/`, it avoids moving binary files manually.