### PR TITLE
fix: option hook can be async and can return overwritten input options

### DIFF
--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -1,4 +1,4 @@
-import type { Plugin, ParallelPlugin } from '../plugin'
+import type { RolldownPlugin } from '../plugin'
 import { z } from 'zod'
 import * as zodExt from '../utils/zod-ext'
 import {
@@ -9,7 +9,6 @@ import {
   RollupLogWithStringSchema,
 } from '../log/logging'
 import { TreeshakingOptionsSchema, TreeshakingOptions } from '../treeshake'
-import { BuiltinPlugin } from '../plugin/bindingify-builtin-plugin'
 
 const inputOptionSchema = z
   .string()
@@ -28,10 +27,7 @@ const externalSchema = zodExt
 
 const inputOptionsSchema = z.strictObject({
   input: inputOptionSchema.optional(),
-  plugins: zodExt
-    .phantom<Plugin | ParallelPlugin | BuiltinPlugin>()
-    .array()
-    .optional(),
+  plugins: zodExt.phantom<RolldownPlugin>().array().optional(),
   external: externalSchema.optional(),
   resolve: z
     .strictObject({

--- a/packages/rolldown/src/options/normalized-input-options.ts
+++ b/packages/rolldown/src/options/normalized-input-options.ts
@@ -4,14 +4,13 @@ import type {
   NormalizedInputOptions as RollupNormalizedInputOptions,
 } from '../rollup'
 import type { InputOptions } from './input-options'
-import type { Plugin, ParallelPlugin } from '../plugin'
+import type { RolldownPlugin } from '../plugin'
 import type { LogLevel } from '../log/logging'
-import { BuiltinPlugin } from '../plugin/bindingify-builtin-plugin'
 import { NormalizedTreeshakingOptions } from '../../src/treeshake'
 
 export interface NormalizedInputOptions extends InputOptions {
   input: RollupNormalizedInputOptions['input']
-  plugins: (Plugin | ParallelPlugin | BuiltinPlugin)[]
+  plugins: RolldownPlugin[]
   onLog: (level: LogLevel, log: RollupLog) => void
   logLevel: LogLevelOption
   // After normalized, `false` will be converted to `undefined`, otherwise, default value will be assigned

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -20,6 +20,7 @@ import type { NormalizedOutputOptions } from '../options/normalized-output-optio
 import type { LogLevel } from '../log/logging'
 import type { RollupLog } from '../rollup'
 import type { MinimalPluginContext } from '../log/logger'
+import { InputOptions } from '..'
 
 type FormalHook<Handler extends AnyFn, HookOptions extends AnyObj = AnyObj> = {
   handler: Handler
@@ -75,7 +76,10 @@ export interface Plugin {
   >
 
   options?: ObjectHook<
-    (this: MinimalPluginContext, options: NormalizedInputOptions) => NullValue
+    (
+      this: MinimalPluginContext,
+      options: InputOptions,
+    ) => MaybePromise<NullValue | InputOptions>
   >
 
   // TODO find a way to make `this: PluginContext` work.

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -21,6 +21,7 @@ import type { LogLevel } from '../log/logging'
 import type { RollupLog } from '../rollup'
 import type { MinimalPluginContext } from '../log/logger'
 import { InputOptions } from '..'
+import { BuiltinPlugin } from './bindingify-builtin-plugin'
 
 type FormalHook<Handler extends AnyFn, HookOptions extends AnyObj = AnyObj> = {
   handler: Handler
@@ -196,6 +197,8 @@ export type ParallelPlugin = {
     options: unknown
   }
 }
+
+export type RolldownPlugin = Plugin | ParallelPlugin | BuiltinPlugin
 
 export type DefineParallelPluginResult<Options> = (
   options: Options,

--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -1,6 +1,6 @@
 import { getLogHandler, normalizeLog } from '../log/logHandler'
 import { LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARN } from '../log/logging'
-import { ParallelPlugin, Plugin } from './'
+import { ParallelPlugin, Plugin, RolldownPlugin } from './'
 import { error, logPluginError } from '../log/logs'
 import { NormalizedInputOptions } from '../options/normalized-input-options'
 import { NormalizedOutputOptions } from '../options/normalized-output-options'
@@ -83,9 +83,7 @@ export class PluginDriver {
   }
 }
 
-export function getObjectPlugins(
-  plugins: (Plugin | ParallelPlugin | BuiltinPlugin)[],
-): Plugin[] {
+export function getObjectPlugins(plugins: RolldownPlugin[]): Plugin[] {
   return plugins.filter((plugin) => {
     if ('_parallel' in plugin) {
       return undefined

--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -54,7 +54,6 @@ export class PluginDriver {
               logLevel,
             ),
           },
-          // TODO Here only support readonly access to the inputOptions at now
           inputOptions,
         )
 

--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -8,7 +8,9 @@ import { RollupError } from '../rollup'
 import { normalizeHook } from '../utils/normalize-hook'
 
 export class PluginDriver {
-  public callOptionsHook(inputOptions: NormalizedInputOptions) {
+  public async callOptionsHook(
+    inputOptions: NormalizedInputOptions,
+  ): Promise<NormalizedInputOptions> {
     const logLevel = inputOptions.logLevel
     const plugins = inputOptions.plugins.filter(
       (plugin) => !('_parallel' in plugin),
@@ -20,7 +22,7 @@ export class PluginDriver {
       const options = plugin.options
       if (options) {
         const [handler, _optionsIgnoredSofar] = normalizeHook(options)
-        handler.call(
+        const result = await handler.call(
           {
             debug: getLogHandler(
               LOG_LEVEL_DEBUG,
@@ -50,8 +52,14 @@ export class PluginDriver {
           // TODO Here only support readonly access to the inputOptions at now
           inputOptions,
         )
+
+        if (result) {
+          inputOptions = result
+        }
       }
     }
+
+    return inputOptions
   }
 
   public callOutputOptionsHook(

--- a/packages/rolldown/src/utils/create-bundler.ts
+++ b/packages/rolldown/src/utils/create-bundler.ts
@@ -14,9 +14,11 @@ export async function createBundler(
 ): Promise<{ bundler: Bundler; stopWorkers?: () => Promise<void> }> {
   const pluginDriver = new PluginDriver()
   // Convert `InputOptions` to `NormalizedInputOptions`.
-  const normalizedInputOptions = await normalizeInputOptions(inputOptions)
+  let normalizedInputOptions = await normalizeInputOptions(inputOptions)
 
-  pluginDriver.callOptionsHook(normalizedInputOptions)
+  normalizedInputOptions = await pluginDriver.callOptionsHook(
+    normalizedInputOptions,
+  )
 
   const parallelPluginInitResult = await initializeParallelPlugins(
     normalizedInputOptions.plugins,

--- a/packages/rolldown/src/utils/create-bundler.ts
+++ b/packages/rolldown/src/utils/create-bundler.ts
@@ -13,12 +13,9 @@ export async function createBundler(
   outputOptions: OutputOptions,
 ): Promise<{ bundler: Bundler; stopWorkers?: () => Promise<void> }> {
   const pluginDriver = new PluginDriver()
+  inputOptions = await pluginDriver.callOptionsHook(inputOptions)
   // Convert `InputOptions` to `NormalizedInputOptions`.
-  let normalizedInputOptions = await normalizeInputOptions(inputOptions)
-
-  normalizedInputOptions = await pluginDriver.callOptionsHook(
-    normalizedInputOptions,
-  )
+  const normalizedInputOptions = await normalizeInputOptions(inputOptions)
 
   const parallelPluginInitResult = await initializeParallelPlugins(
     normalizedInputOptions.plugins,

--- a/packages/rolldown/src/utils/normalize-input-options.ts
+++ b/packages/rolldown/src/utils/normalize-input-options.ts
@@ -1,3 +1,4 @@
+import { getObjectPlugins } from '../plugin/plugin-driver'
 import { getLogger, getOnLog } from '../log/logger'
 import { LOG_LEVEL_INFO } from '../log/logging'
 import type { InputOptions } from '../options/input-options'
@@ -13,7 +14,7 @@ export async function normalizeInputOptions(
   const treeshake = normalizeTreeshakeOptions(config.treeshake)
   const logLevel = config.logLevel || LOG_LEVEL_INFO
   const onLog = getLogger(
-    plugins.filter((plugin) => !('_parallel' in plugin)) as Plugin[],
+    getObjectPlugins(plugins),
     getOnLog(config, logLevel),
     logLevel,
   )

--- a/packages/rolldown/src/utils/normalize-plugin-option.ts
+++ b/packages/rolldown/src/utils/normalize-plugin-option.ts
@@ -1,13 +1,10 @@
 import type { OutputOptions, OutputPlugin } from '../rollup-types'
 import type { InputOptions } from '../options/input-options'
 import { asyncFlatten } from './async-flatten'
-import type { ParallelPlugin, Plugin } from '../plugin'
-import { BuiltinPlugin } from '../plugin/bindingify-builtin-plugin'
+import type { RolldownPlugin } from '../plugin'
 
 export const normalizePluginOption: {
-  (
-    plugins: InputOptions['plugins'],
-  ): Promise<(ParallelPlugin | Plugin | BuiltinPlugin)[]>
+  (plugins: InputOptions['plugins']): Promise<RolldownPlugin[]>
   (plugins: OutputOptions['plugins']): Promise<OutputPlugin[]>
   (plugins: unknown): Promise<any[]>
 } = async (plugins: any) => (await asyncFlatten([plugins])).filter(Boolean)

--- a/packages/rolldown/src/utils/normalize-plugin-option.ts
+++ b/packages/rolldown/src/utils/normalize-plugin-option.ts
@@ -2,9 +2,12 @@ import type { OutputOptions, OutputPlugin } from '../rollup-types'
 import type { InputOptions } from '../options/input-options'
 import { asyncFlatten } from './async-flatten'
 import type { ParallelPlugin, Plugin } from '../plugin'
+import { BuiltinPlugin } from '../plugin/bindingify-builtin-plugin'
 
 export const normalizePluginOption: {
-  (plugins: InputOptions['plugins']): Promise<(ParallelPlugin | Plugin)[]>
+  (
+    plugins: InputOptions['plugins'],
+  ): Promise<(ParallelPlugin | Plugin | BuiltinPlugin)[]>
   (plugins: OutputOptions['plugins']): Promise<OutputPlugin[]>
   (plugins: unknown): Promise<any[]>
 } = async (plugins: any) => (await asyncFlatten([plugins])).filter(Boolean)

--- a/packages/rolldown/tests/fixtures/plugin/options/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/options/_config.ts
@@ -1,6 +1,7 @@
 import { defineTest } from '@tests'
 import { expect, vi } from 'vitest'
 import path from 'node:path'
+import { getOutputChunk } from '@tests/utils'
 
 const fn = vi.fn()
 
@@ -17,7 +18,8 @@ export default defineTest({
       },
     ],
   },
-  afterTest: () => {
+  afterTest: (output) => {
     expect(fn).toHaveBeenCalledTimes(1)
+    expect(getOutputChunk(output).length).toBe(1)
   },
 })

--- a/packages/rolldown/tests/fixtures/plugin/options/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/options/_config.ts
@@ -1,14 +1,17 @@
 import { defineTest } from '@tests'
 import { expect, vi } from 'vitest'
+import path from 'node:path'
 
 const fn = vi.fn()
 
 export default defineTest({
   config: {
+    input: [],
     plugins: [
       {
         name: 'test-plugin',
-        options: function () {
+        options: function (opts) {
+          opts.input = [path.join(__dirname, 'main.js')]
           fn()
         },
       },

--- a/packages/rolldown/tests/fixtures/plugin/options/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/options/_config.ts
@@ -15,6 +15,7 @@ export default defineTest({
           expect(opts.input?.length).toBe(0)
           opts.input = [path.join(__dirname, 'main.js')]
           fn()
+          return opts
         },
       },
     ],

--- a/packages/rolldown/tests/fixtures/plugin/options/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/options/_config.ts
@@ -12,6 +12,7 @@ export default defineTest({
       {
         name: 'test-plugin',
         options: function (opts) {
+          expect(opts.input?.length).toBe(0)
           opts.input = [path.join(__dirname, 'main.js')]
           fn()
         },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `options` hook in Rollup can be used to overwrite the input options, by returning a new inputOptions object from the hook. It also can be async.

https://rollupjs.org/plugin-development/#options