### PR TITLE
chore!: temporarily disable `getCombinedSourcemap` functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,12 +819,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "index_vec"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74086667896a940438f2118212f313abba4aff3831fef6f4b17d02add5c8bb60"
-
-[[package]]
 name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,7 +1898,6 @@ dependencies = [
  "rolldown_resolver",
  "rolldown_sourcemap",
  "rolldown_utils",
- "string_wizard",
  "tracing",
 ]
 
@@ -2218,18 +2211,6 @@ name = "str_indices"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9557cb6521e8d009c51a8666f09356f4b817ba9ba0981a305bd86aee47bd35c"
-
-[[package]]
-name = "string_wizard"
-version = "0.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039009dc25d078912442e9b4488b6a905f152afce2c129b7305f2d939f4328f2"
-dependencies = [
- "index_vec",
- "once_cell",
- "oxc_sourcemap",
- "rustc-hash 1.1.0",
-]
 
 [[package]]
 name = "sugar_path"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,6 @@ self_cell          = "1.0.4"
 serde              = { version = "1.0.203", features = ["derive"] }
 serde_json         = "1.0.117"
 smallvec           = "1.13.2"
-string_wizard      = { version = "0.0.21", features = ["source_map"] }
 sugar_path         = { version = "1.2.0", features = ["cached_current_dir"] }
 testing_macros     = "0.2.13"
 tokio              = { version = "1.38.0", default-features = false }

--- a/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
@@ -18,11 +18,11 @@ impl BindingTransformPluginContext {
     Self { inner }
   }
 
-  #[napi]
-  pub fn get_combined_sourcemap(&self) -> napi::Result<String> {
-    let sourcemap = self.inner.get_combined_sourcemap();
-    sourcemap.to_json_string().map_err(|e| napi::Error::from_reason(format!("{e:?}")))
-  }
+  // #[napi]
+  // pub fn get_combined_sourcemap(&self) -> napi::Result<String> {
+  //   let sourcemap = self.inner.get_combined_sourcemap();
+  //   sourcemap.to_json_string().map_err(|e| napi::Error::from_reason(format!("{e:?}")))
+  // }
 
   #[napi]
   pub fn inner(&self) -> BindingPluginContext {

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -18,5 +18,4 @@ rolldown_common    = { workspace = true }
 rolldown_resolver  = { workspace = true }
 rolldown_sourcemap = { workspace = true }
 rolldown_utils     = { workspace = true }
-string_wizard      = { workspace = true }
 tracing            = { workspace = true }

--- a/crates/rolldown_plugin/src/transform_plugin_context.rs
+++ b/crates/rolldown_plugin/src/transform_plugin_context.rs
@@ -1,6 +1,5 @@
 use crate::SharedPluginContext;
-use rolldown_sourcemap::{collapse_sourcemaps, SourceMap};
-use string_wizard::{MagicString, SourceMapOptions};
+use rolldown_sourcemap::SourceMap;
 
 #[allow(unused)]
 #[derive(Debug)]
@@ -21,25 +20,25 @@ impl<'a> TransformPluginContext<'a> {
     Self { inner, sourcemap_chain, original_code, id }
   }
 
-  pub fn get_combined_sourcemap(&self) -> SourceMap {
-    if self.sourcemap_chain.is_empty() {
-      self.create_sourcemap()
-    } else if self.sourcemap_chain.len() == 1 {
-      // TODO (fix): clone is not necessary
-      self.sourcemap_chain.first().expect("should have one sourcemap").clone()
-    } else {
-      let sourcemap_chain = self.sourcemap_chain.iter().collect::<Vec<_>>();
-      // TODO Here could be cache result for pervious sourcemap_chain, only remapping new sourcemap chain
-      collapse_sourcemaps(sourcemap_chain).unwrap_or_else(|| self.create_sourcemap())
-    }
-  }
+  // pub fn get_combined_sourcemap(&self) -> SourceMap {
+  //   if self.sourcemap_chain.is_empty() {
+  //     self.create_sourcemap()
+  //   } else if self.sourcemap_chain.len() == 1 {
+  //     // TODO (fix): clone is not necessary
+  //     self.sourcemap_chain.first().expect("should have one sourcemap").clone()
+  //   } else {
+  //     let sourcemap_chain = self.sourcemap_chain.iter().collect::<Vec<_>>();
+  //     // TODO Here could be cache result for pervious sourcemap_chain, only remapping new sourcemap chain
+  //     collapse_sourcemaps(sourcemap_chain).unwrap_or_else(|| self.create_sourcemap())
+  //   }
+  // }
 
-  fn create_sourcemap(&self) -> SourceMap {
-    let magic_string = MagicString::new(self.original_code);
-    magic_string.source_map(SourceMapOptions {
-      hires: true,
-      include_content: true,
-      source: self.id.into(),
-    })
-  }
+  // fn create_sourcemap(&self) -> SourceMap {
+  //   let magic_string = MagicString::new(self.original_code);
+  //   magic_string.source_map(SourceMapOptions {
+  //     hires: true,
+  //     include_content: true,
+  //     source: self.id.into(),
+  //   })
+  // }
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -56,7 +56,6 @@ export class BindingPluginContext {
 }
 
 export class BindingTransformPluginContext {
-  getCombinedSourcemap(): string
   inner(): BindingPluginContext
 }
 

--- a/packages/rolldown/src/plugin/transfrom-plugin-context.ts
+++ b/packages/rolldown/src/plugin/transfrom-plugin-context.ts
@@ -21,7 +21,7 @@ export class TransformPluginContext {
     pos?: number | { column: number; line: number },
   ) => never
   resolve: BindingPluginContext['resolve']
-  getCombinedSourcemap: () => SourceMap
+  // getCombinedSourcemap: () => SourceMap
   emitFile: (file: EmittedAsset) => string
   getFileName: (referenceId: string) => string
   parse: (input: string, options?: any) => any
@@ -57,7 +57,7 @@ export class TransformPluginContext {
     }
     this.resolve = context.resolve
     this.parse = context.parse
-    this.getCombinedSourcemap = () => JSON.parse(inner.getCombinedSourcemap())
+    // this.getCombinedSourcemap = () => JSON.parse(inner.getCombinedSourcemap())
     this.emitFile = context.emitFile
     this.getFileName = context.getFileName
   }

--- a/packages/rollup-tests/src/failed-tests.json
+++ b/packages/rollup-tests/src/failed-tests.json
@@ -679,6 +679,8 @@
   "rollup@function@wraps-object-expressions-as-statements: wraps object expressions that have become statements",
   "rollup@function@wraps-simplified-expressions: wraps simplified expressions that have become callees if necessary",
   "rollup@sourcemaps@basic-support: basic sourcemap support@generates es",
+  "rollup@sourcemaps@combined-sourcemap-with-loader: get combined sourcemap in transforming with loader@generates es",
+  "rollup@sourcemaps@combined-sourcemap: get combined sourcemap in transforming@generates es",
   "rollup@sourcemaps@existing-external-sourcemaps-combined: removes sourcemap comments@generates es",
   "rollup@sourcemaps@names: names are recovered (https://github.com/rollup/rollup/issues/101)@generates es",
   "rollup@sourcemaps@single-length-segments: handles single-length sourcemap segments@generates es",

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,6 +1,6 @@
 {
   "failed": 0,
-  "skipFailed": 631,
+  "skipFailed": 633,
   "skipped": 0,
-  "passed": 286
+  "passed": 284
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -1,6 +1,6 @@
 |  | number |
 |----| ---- |
 | failed | 0|
-| skipFailed | 631|
+| skipFailed | 633|
 | skipped | 0|
-| passed | 286|
+| passed | 284|


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The base infra this feature rely on was built in a wrong way, which makes updating/using different version of `oxc` are very unfriendly.

The right way to fix it has been described in https://github.com/rolldown/rolldown/pull/1364#issuecomment-2165146752, but it seems that currently no one has the time to apply the fix that is friendly to the future. I believe this situation blocks our fast development loops. 

Since that was the case, I think the short term to fix it is just removing the feature temporarily.

---

@Boshen @underfin cc

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
