### PR TITLE
fix(resolver): ensure we always pass an absolute path to oxc_resolver

### DIFF
--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -66,9 +66,12 @@ impl<F: FileSystem + Default> Resolver<F> {
     };
 
     let resolve_options_with_default_conditions = OxcResolverOptions {
-      tsconfig: raw_resolve.tsconfig_filename.map(|p| TsconfigOptions {
-        config_file: p.into(),
-        references: oxc_resolver::TsconfigReferences::Disabled,
+      tsconfig: raw_resolve.tsconfig_filename.map(|p| {
+        let path = PathBuf::from(&p);
+        TsconfigOptions {
+          config_file: if path.is_relative() { cwd.join(path) } else { path },
+          references: oxc_resolver::TsconfigReferences::Disabled,
+        }
       }),
       alias: raw_resolve
         .alias


### PR DESCRIPTION
### Description

closes #1441

not sure how to write a test for this so any advice would be much appreciated
