### PR TITLE
ci: only run codecov on the main branch

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,8 +5,8 @@ name: Code Coverage
 on:
   workflow_dispatch:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
     paths:
       - '**.rs'
       - '.github/workflows/codecov.yml'


### PR DESCRIPTION
I noticed that codecov is running on every push ... we only need to run it on main to track coverage.
