### PR TITLE
perf(rolldown): use `sort_unstable` variants

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -222,7 +222,7 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
 
     let mut shimmed_exports =
       self.ctx.linking_info.shimmed_missing_exports.iter().collect::<Vec<_>>();
-    shimmed_exports.sort_by_key(|(name, _)| name.as_str());
+    shimmed_exports.sort_unstable_by_key(|(name, _)| name.as_str());
     shimmed_exports.into_iter().for_each(|(_name, symbol_ref)| {
       debug_assert!(!self.ctx.module.stmt_infos.declared_stmts_by_symbol(symbol_ref).is_empty());
       let is_included: bool = self

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -286,7 +286,7 @@ impl ModuleLoader {
       self.intermediate_normal_modules.ast_table.into_iter().flatten().collect();
 
     let mut dynamic_import_entry_ids = dynamic_import_entry_ids.into_iter().collect::<Vec<_>>();
-    dynamic_import_entry_ids.sort_by_key(|id| &modules[*id].stable_resource_id);
+    dynamic_import_entry_ids.sort_unstable_by_key(|id| &modules[*id].stable_resource_id);
 
     entry_points.extend(dynamic_import_entry_ids.into_iter().map(|id| EntryPoint {
       name: None,

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -137,7 +137,7 @@ impl<'a> GenerateStage<'a> {
 
     // Sort modules in each chunk by execution order
     chunks.iter_mut().for_each(|chunk| {
-      chunk.modules.sort_by_key(|module_id| {
+      chunk.modules.sort_unstable_by_key(|module_id| {
         self.link_output.module_table.normal_modules[*module_id].exec_order
       });
     });

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -223,11 +223,8 @@ impl<'a> GenerateStage<'a> {
     }
 
     // Make sure order of assets are deterministic
-    assets.sort_by_cached_key(|item| match item {
-      // TODO: use `preliminary_filename` instead
-      Output::Asset(asset) => asset.filename.to_string(),
-      Output::Chunk(chunk) => chunk.preliminary_filename.to_string(),
-    });
+    // TODO: use `preliminary_filename` on `Output::Asset` instead
+    assets.sort_unstable_by(|a, b| a.filename().cmp(b.filename()));
 
     Ok(BundleOutput {
       assets,


### PR DESCRIPTION
Per `sort_unstable` contracts total ordering of comparator.

It is safe to use `sort_unstable` in these cases because the keys are primitives (`&str`), which provide guaranteed `Eq`.

I assume we have idempotent tests, we should add it otherwise.