### PR TITLE
perf: use jemalloc on systems that performs better, and mimalloc on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +1844,7 @@ dependencies = [
  "dashmap",
  "derivative",
  "futures",
+ "jemallocator",
  "mimalloc",
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ glob-match         = "0.2.1"
 indexmap           = "2.2.6"
 insta              = "1.39.0"
 itertools          = "0.13.0"
+jemallocator       = "0.5.4"
 jsonschema         = { version = "0.18.0", default-features = false }
 memchr             = "2.7.2"
 mimalloc           = "0.1.42"

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -35,11 +35,11 @@ rustc-hash           = { workspace = true }
 serde                = { workspace = true }
 tracing              = { workspace = true }
 
-[target.'cfg(all(not(target_os = "linux"), not(target_family = "wasm")))'.dependencies]
-mimalloc = { workspace = true }
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = { workspace = true }
 
-[target.'cfg(all(target_os = "linux"))'.dependencies]
-mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
+[target.'cfg(target_os = "windows")'.dependencies]
+mimalloc = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }

--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -13,9 +13,13 @@
 // Looks redundant
 #![allow(clippy::missing_transmute_annotations)]
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(not(target_env = "msvc"))]
 #[global_allocator]
-static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[cfg(target_os = "windows")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 pub mod bundler;
 pub mod options;


### PR DESCRIPTION
I forgot how I ended up with this setting for `oxlint`, but it was from trial-and-error :sweat_and_smile:

Due to the use of bumpalo arena allocator, my guess is that jemalloc performs better under less allocation pressure.

In the triangle benchmark, this reduced build time from 42ms to 39ms.