### PR TITLE
perf(rolldown): avoid calling `f64.to_string()`

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/rename.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/rename.rs
@@ -34,7 +34,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         // `foo()` might be transformed to `xxx.foo()`. To keep the semantic of callee's `this` binding,
         // we need to wrap the transformed callee. Make it like `(0, xxx.foo)()`.
         let wrapped_callee =
-          self.snippet.seq2_in_paren_expr(self.snippet.number_expr(0.0), access_expr);
+          self.snippet.seq2_in_paren_expr(self.snippet.number_expr(0.0, "0"), access_expr);
         wrapped_callee
       } else {
         access_expr

--- a/crates/rolldown_oxc_utils/src/ast_snippet.rs
+++ b/crates/rolldown_oxc_utils/src/ast_snippet.rs
@@ -364,12 +364,12 @@ impl<'ast> AstSnippet<'ast> {
   /// ```js
   /// 42
   /// ```
-  pub fn number_expr(&self, value: f64) -> ast::Expression<'ast> {
+  pub fn number_expr(&self, value: f64, raw: &str) -> ast::Expression<'ast> {
     ast::Expression::NumericLiteral(
       ast::NumericLiteral {
         span: TakeIn::dummy(self.alloc),
         value,
-        raw: self.alloc.alloc(value.to_string()),
+        raw: self.alloc.alloc_str(raw),
         base: oxc::syntax::number::NumberBase::Decimal,
       }
       .into_in(self.alloc),
@@ -411,7 +411,7 @@ impl<'ast> AstSnippet<'ast> {
     ast::Expression::UnaryExpression(
       ast::UnaryExpression {
         operator: UnaryOperator::Void,
-        argument: self.number_expr(0.0),
+        argument: self.number_expr(0.0, "0"),
         ..TakeIn::dummy(self.alloc)
       }
       .into_in(self.alloc),


### PR DESCRIPTION
Found huge allocation counts that can be avoided

<img width="1184" alt="image" src="https://github.com/rolldown/rolldown/assets/1430279/45210163-7cd2-4566-972b-9b6696a627cc">

