### PR TITLE
ci: remove setup dev drive action and add approve action

### DIFF
--- a/.github/workflows/automate-labeling.yml
+++ b/.github/workflows/automate-labeling.yml
@@ -25,3 +25,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           labels: 'needs-triage'
+
+  approval-if-self-assigned:
+    # Requirements:
+    # - The PR is created by the actor
+    # - The PR is assigned to the actor
+    # - The operation is done by the actor
+    if: github.event.action == 'assigned' && github.event.assignee.login == github.actor && github.event.pull_request.user.login == github.actor
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -18,17 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Unsung heros of the internet, who led me here to speed up window's slowness:
-      # https://github.com/actions/cache/issues/752#issuecomment-1847036770
-      # https://github.com/astral-sh/uv/blob/502e04200d52de30d3159894833b3db4f0d6644d/.github/workflows/ci.yml#L158
-      - name: Setup Dev Drive for Windows
-        uses: samypr100/setup-dev-drive@v3
-        if: ${{ runner.os == 'Windows' }}
-        with:
-          workspace-copy: true
-          drive-size: 8GB
-          drive-format: NTFS
-
       - name: Setup Node
         uses: ./.github/actions/setup-node
 

--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           workspace-copy: true
           drive-size: 8GB
+          drive-format: NTFS
 
       - name: Setup Node
         uses: ./.github/actions/setup-node

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -23,17 +23,6 @@ jobs:
         with:
           submodules: true # Pull submodules for additional files
 
-      # Unsung heros of the internet, who led me here to speed up window's slowness:
-      # https://github.com/actions/cache/issues/752#issuecomment-1847036770
-      # https://github.com/astral-sh/uv/blob/502e04200d52de30d3159894833b3db4f0d6644d/.github/workflows/ci.yml#L158
-      - name: Setup Dev Drive for Windows
-        uses: samypr100/setup-dev-drive@v3
-        if: ${{ runner.os == 'Windows' }}
-        with:
-          workspace-copy: true
-          drive-size: 8GB
-          drive-format: NTFS
-
       - name: Setup Node
         uses: ./.github/actions/setup-node
 

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           workspace-copy: true
           drive-size: 8GB
+          drive-format: NTFS
 
       - name: Setup Node
         uses: ./.github/actions/setup-node

--- a/.github/workflows/reusable-wasi-test.yml
+++ b/.github/workflows/reusable-wasi-test.yml
@@ -23,17 +23,6 @@ jobs:
         with:
           submodules: true # Pull submodules for additional files
 
-      # Unsung heros of the internet, who led me here to speed up window's slowness:
-      # https://github.com/actions/cache/issues/752#issuecomment-1847036770
-      # https://github.com/astral-sh/uv/blob/502e04200d52de30d3159894833b3db4f0d6644d/.github/workflows/ci.yml#L158
-      - name: Setup Dev Drive for Windows
-        uses: samypr100/setup-dev-drive@v3
-        if: ${{ runner.os == 'Windows' }}
-        with:
-          workspace-copy: true
-          drive-size: 8G
-          drive-format: NTFS
-
       - name: Setup Node
         uses: ./.github/actions/setup-node
 

--- a/.github/workflows/reusable-wasi-test.yml
+++ b/.github/workflows/reusable-wasi-test.yml
@@ -31,7 +31,8 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         with:
           workspace-copy: true
-          drive-size: 8GB
+          drive-size: 8G
+          drive-format: NTFS
 
       - name: Setup Node
         uses: ./.github/actions/setup-node


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Setup dev drive action doesn't reduce CI time.
- Make sure hot fix PR also could be enqueued in merge queue using approval action.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
