### PR TITLE
perf(rolldown): build oxc semantic data only once

### DIFF
--- a/crates/rolldown/src/utils/make_ast_symbol_and_scope.rs
+++ b/crates/rolldown/src/utils/make_ast_symbol_and_scope.rs
@@ -1,15 +1,18 @@
+use oxc::semantic::{ScopeTree, SymbolTable};
 use rolldown_common::AstScopes;
-use rolldown_oxc_utils::OxcAst;
 
 use crate::types::ast_symbols::AstSymbols;
 
-pub fn make_ast_scopes_and_symbols(ast: &OxcAst) -> (AstScopes, AstSymbols) {
-  let (mut symbol_table, scope) = ast.make_symbol_table_and_scope_tree();
+pub fn make_ast_scopes_and_symbols(
+  symbols: SymbolTable,
+  scopes: ScopeTree,
+) -> (AstSymbols, AstScopes) {
+  let mut symbols = symbols;
   let ast_scope = AstScopes::new(
-    scope,
-    std::mem::take(&mut symbol_table.references),
-    std::mem::take(&mut symbol_table.resolved_references),
+    scopes,
+    std::mem::take(&mut symbols.references),
+    std::mem::take(&mut symbols.resolved_references),
   );
-  let ast_symbols = AstSymbols::from_symbol_table(symbol_table);
-  (ast_scope, ast_symbols)
+  let ast_symbols = AstSymbols::from_symbol_table(symbols);
+  (ast_symbols, ast_scope)
 }

--- a/crates/rolldown/src/utils/parse_to_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ast.rs
@@ -1,6 +1,9 @@
 use std::{path::Path, sync::Arc};
 
-use oxc::span::SourceType as OxcSourceType;
+use oxc::{
+  semantic::{ScopeTree, SymbolTable},
+  span::SourceType as OxcSourceType,
+};
 use rolldown_common::{ModuleType, NormalizedBundlerOptions};
 use rolldown_loader_utils::{base64_to_esm, binary_to_esm, json_to_esm, text_to_esm};
 use rolldown_oxc_utils::{OxcAst, OxcCompiler};
@@ -24,7 +27,7 @@ pub fn parse_to_ast(
   options: &NormalizedBundlerOptions,
   module_type: ModuleType,
   source: impl Into<Arc<str>>,
-) -> anyhow::Result<OxcAst> {
+) -> anyhow::Result<(OxcAst, SymbolTable, ScopeTree)> {
   let source: Arc<str> = source.into();
 
   // 1. Transform the source to the type that rolldown supported.
@@ -55,7 +58,5 @@ pub fn parse_to_ast(
 
   let oxc_ast = OxcCompiler::parse(Arc::clone(&source), oxc_source_type)?;
 
-  let valid_js_ast = pre_process_ast(oxc_ast, &parsed_type, path, oxc_source_type)?;
-
-  Ok(valid_js_ast)
+  pre_process_ast(oxc_ast, &parsed_type, path, oxc_source_type)
 }


### PR DESCRIPTION
It was accidental that oxc semantic data is built twice during the whole process. This PR passes the built semantic into the transformer so it is not built twice.

