### PR TITLE
feat: glob import plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,6 +1880,7 @@ dependencies = [
  "rolldown_common",
  "rolldown_error",
  "rolldown_plugin",
+ "rolldown_plugin_glob_import",
  "rolldown_plugin_wasm",
  "rolldown_sourcemap",
  "rolldown_tracing",
@@ -1957,10 +1958,23 @@ dependencies = [
  "anyhow",
  "async-trait",
  "rolldown_common",
+ "rolldown_oxc_utils",
  "rolldown_resolver",
  "rolldown_sourcemap",
  "rolldown_utils",
  "tracing",
+]
+
+[[package]]
+name = "rolldown_plugin_glob_import"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "glob",
+ "oxc",
+ "rolldown_common",
+ "rolldown_plugin",
+ "sugar_path",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,6 @@ dependencies = [
  "async-trait",
  "glob",
  "oxc",
- "rolldown_common",
  "rolldown_plugin",
  "sugar_path",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,21 +76,22 @@ single_match      = "allow"
 single_match_else = "allow"
 
 [workspace.dependencies]
-rolldown                = { version = "0.1.0", path = "./crates/rolldown" }
-rolldown_common         = { version = "0.0.1", path = "./crates/rolldown_common" }
-rolldown_error          = { version = "0.0.1", path = "./crates/rolldown_error" }
-rolldown_fs             = { version = "0.1.0", path = "./crates/rolldown_fs" }
-rolldown_loader_utils   = { version = "0.1.0", path = "./crates/rolldown_loader_utils" }
-rolldown_oxc_utils      = { version = "0.1.0", path = "./crates/rolldown_oxc_utils" }
-rolldown_plugin         = { version = "0.1.0", path = "./crates/rolldown_plugin" }
-rolldown_plugin_wasm    = { version = "0.0.1", path = "./crates/rolldown_plugin_wasm" }
-rolldown_resolver       = { version = "0.0.1", path = "./crates/rolldown_resolver" }
-rolldown_rstr           = { version = "0.0.1", path = "./crates/rolldown_rstr" }
-rolldown_sourcemap      = { version = "0.1.0", path = "./crates/rolldown_sourcemap" }
-rolldown_testing        = { version = "0.0.1", path = "./crates/rolldown_testing" }
-rolldown_testing_config = { version = "0.0.1", path = "./crates/rolldown_testing_config" }
-rolldown_tracing        = { version = "0.0.1", path = "./crates/rolldown_tracing" }
-rolldown_utils          = { version = "0.0.1", path = "./crates/rolldown_utils" }
+rolldown                    = { version = "0.1.0", path = "./crates/rolldown" }
+rolldown_common             = { version = "0.0.1", path = "./crates/rolldown_common" }
+rolldown_error              = { version = "0.0.1", path = "./crates/rolldown_error" }
+rolldown_fs                 = { version = "0.1.0", path = "./crates/rolldown_fs" }
+rolldown_loader_utils       = { version = "0.1.0", path = "./crates/rolldown_loader_utils" }
+rolldown_oxc_utils          = { version = "0.1.0", path = "./crates/rolldown_oxc_utils" }
+rolldown_plugin             = { version = "0.1.0", path = "./crates/rolldown_plugin" }
+rolldown_plugin_glob_import = { version = "0.0.1", path = "./crates/rolldown_plugin_glob_import" }
+rolldown_plugin_wasm        = { version = "0.0.1", path = "./crates/rolldown_plugin_wasm" }
+rolldown_resolver           = { version = "0.0.1", path = "./crates/rolldown_resolver" }
+rolldown_rstr               = { version = "0.0.1", path = "./crates/rolldown_rstr" }
+rolldown_sourcemap          = { version = "0.1.0", path = "./crates/rolldown_sourcemap" }
+rolldown_testing            = { version = "0.0.1", path = "./crates/rolldown_testing" }
+rolldown_testing_config     = { version = "0.0.1", path = "./crates/rolldown_testing_config" }
+rolldown_tracing            = { version = "0.0.1", path = "./crates/rolldown_tracing" }
+rolldown_utils              = { version = "0.0.1", path = "./crates/rolldown_utils" }
 
 anyhow             = "1.0.86"
 ariadne            = "0.4.1"

--- a/crates/rolldown/src/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/normal_module_task.rs
@@ -14,7 +14,7 @@ use rolldown_common::{
 };
 use rolldown_error::BuildError;
 use rolldown_oxc_utils::OxcAst;
-use rolldown_plugin::{HookResolveIdExtraOptions, HookTransformAstArgs, SharedPluginDriver};
+use rolldown_plugin::{HookResolveIdExtraOptions, SharedPluginDriver};
 use rolldown_resolver::ResolveError;
 use rolldown_utils::{ecma_script::legitimize_identifier_name, path_ext::PathExt};
 use sugar_path::SugarPath;
@@ -116,16 +116,12 @@ impl NormalModuleTask {
     .into();
 
     let (mut ast, symbols, scopes) = parse_to_ast(
+      &self.ctx.plugin_driver,
       Path::new(&self.resolved_path.path.as_ref()),
       &self.ctx.input_options,
       module_type,
       Arc::clone(&source),
     )?;
-
-    ast = self
-      .ctx
-      .plugin_driver
-      .transform_ast(HookTransformAstArgs { cwd: &self.ctx.input_options.cwd, ast })?;
 
     let (scope, scan_result, ast_symbol, namespace_object_ref) =
       self.scan(&mut ast, &source, symbols, scopes);

--- a/crates/rolldown/src/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/normal_module_task.rs
@@ -14,7 +14,7 @@ use rolldown_common::{
 };
 use rolldown_error::BuildError;
 use rolldown_oxc_utils::OxcAst;
-use rolldown_plugin::{HookResolveIdExtraOptions, SharedPluginDriver};
+use rolldown_plugin::{HookResolveIdExtraOptions, HookTransformAstArgs, SharedPluginDriver};
 use rolldown_resolver::ResolveError;
 use rolldown_utils::{ecma_script::legitimize_identifier_name, path_ext::PathExt};
 use sugar_path::SugarPath;
@@ -122,8 +122,12 @@ impl NormalModuleTask {
       Arc::clone(&source),
     )?;
 
-    let (scope, scan_result, ast_symbol, namespace_object_ref) =
-      self.scan(&mut ast, &source, symbols, scopes);
+    ast = self
+      .ctx
+      .plugin_driver
+      .transform_ast(HookTransformAstArgs { cwd: &self.ctx.input_options.cwd, ast })?;
+
+    let (scope, scan_result, ast_symbol, namespace_object_ref) = self.scan(&mut ast, &source);
 
     let resolved_deps =
       self.resolve_dependencies(&scan_result.import_records, &mut warnings).await?;

--- a/crates/rolldown/src/module_loader/normal_module_task.rs
+++ b/crates/rolldown/src/module_loader/normal_module_task.rs
@@ -127,7 +127,8 @@ impl NormalModuleTask {
       .plugin_driver
       .transform_ast(HookTransformAstArgs { cwd: &self.ctx.input_options.cwd, ast })?;
 
-    let (scope, scan_result, ast_symbol, namespace_object_ref) = self.scan(&mut ast, &source);
+    let (scope, scan_result, ast_symbol, namespace_object_ref) =
+      self.scan(&mut ast, &source, symbols, scopes);
 
     let resolved_deps =
       self.resolve_dependencies(&scan_result.import_records, &mut warnings).await?;

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -14,27 +14,28 @@ workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow               = { workspace = true }
-async-channel        = { workspace = true }
-async-trait          = { workspace = true }
-dashmap              = { workspace = true }
-derivative           = { workspace = true }
-futures              = { workspace = true }
-napi                 = { workspace = true }
-napi-derive          = { workspace = true }
-once_cell            = { workspace = true }
-oxc_transform_napi   = { workspace = true }
-rolldown             = { workspace = true }
-rolldown_common      = { workspace = true }
-rolldown_error       = { workspace = true, features = ["napi"] }
-rolldown_plugin      = { workspace = true }
-rolldown_plugin_wasm = { workspace = true }
-rolldown_sourcemap   = { workspace = true }
-rolldown_tracing     = { workspace = true }
-rolldown_utils       = { workspace = true }
-rustc-hash           = { workspace = true }
-serde                = { workspace = true }
-tracing              = { workspace = true }
+anyhow                      = { workspace = true }
+async-channel               = { workspace = true }
+async-trait                 = { workspace = true }
+dashmap                     = { workspace = true }
+derivative                  = { workspace = true }
+futures                     = { workspace = true }
+napi                        = { workspace = true }
+napi-derive                 = { workspace = true }
+once_cell                   = { workspace = true }
+oxc_transform_napi          = { workspace = true }
+rolldown                    = { workspace = true }
+rolldown_common             = { workspace = true }
+rolldown_error              = { workspace = true, features = ["napi"] }
+rolldown_plugin             = { workspace = true }
+rolldown_plugin_glob_import = { workspace = true }
+rolldown_plugin_wasm        = { workspace = true }
+rolldown_sourcemap          = { workspace = true }
+rolldown_tracing            = { workspace = true }
+rolldown_utils              = { workspace = true }
+rustc-hash                  = { workspace = true }
+serde                       = { workspace = true }
+tracing                     = { workspace = true }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_family = "wasm")))'.dependencies]
 mimalloc = { workspace = true }

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -36,7 +36,7 @@ impl From<BindingBuiltinPlugin> for Arc<dyn Plugin> {
   fn from(plugin: BindingBuiltinPlugin) -> Self {
     match plugin.name {
       BindingBuiltinPluginName::WasmPlugin => Arc::new(WasmPlugin {}),
-      BindingBuiltinPluginName::GlobImportPlugin => Box::new(GlobImportPlugin {}),
+      BindingBuiltinPluginName::GlobImportPlugin => Arc::new(GlobImportPlugin {}),
     }
   }
 }

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -4,6 +4,7 @@ use derivative::Derivative;
 use napi::JsUnknown;
 use napi_derive::napi;
 use rolldown_plugin::Plugin;
+use rolldown_plugin_glob_import::GlobImportPlugin;
 use rolldown_plugin_wasm::WasmPlugin;
 use serde::Deserialize;
 
@@ -28,12 +29,14 @@ impl std::fmt::Debug for BindingBuiltinPlugin {
 #[napi]
 pub enum BindingBuiltinPluginName {
   WasmPlugin,
+  GlobImportPlugin,
 }
 
 impl From<BindingBuiltinPlugin> for Arc<dyn Plugin> {
   fn from(plugin: BindingBuiltinPlugin) -> Self {
     match plugin.name {
       BindingBuiltinPluginName::WasmPlugin => Arc::new(WasmPlugin {}),
+      BindingBuiltinPluginName::GlobImportPlugin => Box::new(GlobImportPlugin {}),
     }
   }
 }

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 anyhow             = { workspace = true }
 async-trait        = { workspace = true }
 rolldown_common    = { workspace = true }
+rolldown_oxc_utils = { workspace = true }
 rolldown_resolver  = { workspace = true }
 rolldown_sourcemap = { workspace = true }
 rolldown_utils     = { workspace = true }

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -12,7 +12,7 @@ pub mod inner {
 pub use crate::{
   plugin::{
     BoxPlugin, HookAugmentChunkHashReturn, HookLoadReturn, HookNoopReturn, HookRenderChunkReturn,
-    HookResolveIdReturn, HookTransformReturn, Plugin, SharedPlugin,
+    HookResolveIdReturn, HookTransformAstReturn, HookTransformReturn, Plugin, SharedPlugin,
   },
   plugin_context::{PluginContext, SharedPluginContext},
   plugin_driver::{PluginDriver, SharedPluginDriver},
@@ -28,5 +28,6 @@ pub use crate::{
   types::hook_resolve_id_extra_options::HookResolveIdExtraOptions,
   types::hook_resolve_id_output::HookResolveIdOutput,
   types::hook_transform_args::HookTransformArgs,
+  types::hook_transform_ast_args::HookTransformAstArgs,
   types::plugin_context_resolve_options::PluginContextResolveOptions,
 };

--- a/crates/rolldown_plugin/src/plugin.rs
+++ b/crates/rolldown_plugin/src/plugin.rs
@@ -2,14 +2,17 @@ use std::{any::Any, borrow::Cow, fmt::Debug, sync::Arc};
 
 use super::plugin_context::SharedPluginContext;
 use crate::{
-  transform_plugin_context::TransformPluginContext, types::hook_render_error::HookRenderErrorArgs,
+  transform_plugin_context::TransformPluginContext,
+  types::{hook_render_error::HookRenderErrorArgs, hook_transform_ast_args::HookTransformAstArgs},
   HookBuildEndArgs, HookLoadArgs, HookLoadOutput, HookRenderChunkArgs, HookRenderChunkOutput,
   HookResolveDynamicImportArgs, HookResolveIdArgs, HookResolveIdOutput, HookTransformArgs,
 };
 use anyhow::Result;
 use rolldown_common::{ModuleInfo, Output, RenderedChunk};
+use rolldown_oxc_utils::OxcAst;
 
 pub type HookResolveIdReturn = Result<Option<HookResolveIdOutput>>;
+pub type HookTransformAstReturn = Result<OxcAst>;
 pub type HookTransformReturn = Result<Option<HookLoadOutput>>;
 pub type HookLoadReturn = Result<Option<HookLoadOutput>>;
 pub type HookNoopReturn = Result<()>;
@@ -57,6 +60,14 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
     _args: &HookTransformArgs,
   ) -> HookTransformReturn {
     Ok(None)
+  }
+
+  fn transform_ast(
+    &self,
+    _ctx: &SharedPluginContext,
+    args: HookTransformAstArgs,
+  ) -> HookTransformAstReturn {
+    Ok(args.ast)
   }
 
   async fn module_parsed(

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
+  plugin::HookTransformAstReturn, types::hook_transform_ast_args::HookTransformAstArgs,
   HookBuildEndArgs, HookLoadArgs, HookLoadReturn, HookNoopReturn, HookResolveDynamicImportArgs,
   HookResolveIdArgs, HookResolveIdReturn, HookTransformArgs, PluginDriver, TransformPluginContext,
 };
@@ -104,6 +105,14 @@ impl PluginDriver {
       }
     }
     Ok(code)
+  }
+
+  pub fn transform_ast(&self, mut args: HookTransformAstArgs) -> HookTransformAstReturn {
+    for (plugin, ctx) in &self.plugins {
+      args.ast =
+        plugin.transform_ast(ctx, HookTransformAstArgs { cwd: args.cwd, ast: args.ast })?;
+    }
+    Ok(args.ast)
   }
 
   pub async fn module_parsed(&self, module_info: Arc<ModuleInfo>) -> HookNoopReturn {

--- a/crates/rolldown_plugin/src/types/hook_transform_ast_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_transform_ast_args.rs
@@ -1,0 +1,9 @@
+use std::path::PathBuf;
+
+use rolldown_oxc_utils::OxcAst;
+
+#[derive(Debug)]
+pub struct HookTransformAstArgs<'a> {
+  pub cwd: &'a PathBuf,
+  pub ast: OxcAst,
+}

--- a/crates/rolldown_plugin/src/types/mod.rs
+++ b/crates/rolldown_plugin/src/types/mod.rs
@@ -9,4 +9,5 @@ pub mod hook_resolve_id_args;
 pub mod hook_resolve_id_extra_options;
 pub mod hook_resolve_id_output;
 pub mod hook_transform_args;
+pub mod hook_transform_ast_args;
 pub mod plugin_context_resolve_options;

--- a/crates/rolldown_plugin_glob_import/Cargo.toml
+++ b/crates/rolldown_plugin_glob_import/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+edition.workspace    = true
+homepage.workspace   = true
+license.workspace    = true
+name                 = "rolldown_plugin_glob_import"
+repository.workspace = true
+version              = "0.0.1"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait     = { workspace = true }
+glob            = { workspace = true }
+oxc             = { workspace = true }
+rolldown_common = { workspace = true }
+rolldown_plugin = { workspace = true }
+sugar_path      = { workspace = true }

--- a/crates/rolldown_plugin_glob_import/Cargo.toml
+++ b/crates/rolldown_plugin_glob_import/Cargo.toml
@@ -15,6 +15,5 @@ workspace = true
 async-trait     = { workspace = true }
 glob            = { workspace = true }
 oxc             = { workspace = true }
-rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
 sugar_path      = { workspace = true }

--- a/crates/rolldown_plugin_glob_import/src/lib.rs
+++ b/crates/rolldown_plugin_glob_import/src/lib.rs
@@ -1,0 +1,325 @@
+use glob::glob;
+use oxc::{
+  allocator::Vec,
+  ast::{
+    ast::{
+      Argument, ArrayExpressionElement, ArrowFunctionExpression, BindingIdentifier, Expression,
+      FormalParameterKind, ImportDeclarationSpecifier, ImportDefaultSpecifier,
+      ImportNamespaceSpecifier, ImportOrExportKind, ImportSpecifier, ModuleDeclaration,
+      ModuleExportName, ObjectPropertyKind, PropertyKey, PropertyKind, Statement,
+    },
+    AstBuilder, VisitMut,
+  },
+  span::{Span, SPAN},
+};
+use rolldown_plugin::{HookTransformAstArgs, HookTransformAstReturn, Plugin, SharedPluginContext};
+use std::{
+  borrow::Cow,
+  path::{Path, PathBuf},
+};
+use sugar_path::SugarPath;
+
+#[derive(Debug)]
+pub struct GlobImportPlugin {}
+
+#[async_trait::async_trait]
+impl Plugin for GlobImportPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    Cow::Borrowed("glob_import_plugin")
+  }
+
+  fn transform_ast(
+    &self,
+    _ctx: &SharedPluginContext,
+    mut args: HookTransformAstArgs,
+  ) -> HookTransformAstReturn {
+    args.ast.program.with_mut(|fields| {
+      let ast_builder = AstBuilder::new(fields.allocator);
+      let mut visitor = GlobImportVisit {
+        cwd: args.cwd,
+        import_decls: ast_builder.new_vec(),
+        ast_builder,
+        current: 0,
+      };
+      visitor.visit_program(fields.program);
+      if !visitor.import_decls.is_empty() {
+        fields.program.body.extend(visitor.import_decls);
+      }
+    });
+    Ok(args.ast)
+  }
+}
+
+#[derive(Debug, Default)]
+pub struct ImportGlobOptions {
+  import: Option<String>,
+  eager: Option<bool>,
+}
+
+pub struct GlobImportVisit<'ast, 'a> {
+  cwd: &'a PathBuf,
+  ast_builder: AstBuilder<'ast>,
+  import_decls: Vec<'ast, Statement<'ast>>,
+  current: usize,
+}
+
+impl<'ast, 'a> VisitMut<'ast> for GlobImportVisit<'ast, 'a> {
+  #[allow(clippy::too_many_lines)]
+  fn visit_expression(&mut self, expr: &mut Expression<'ast>) {
+    if let Expression::CallExpression(call_expr) = expr {
+      match &call_expr.callee {
+        Expression::StaticMemberExpression(e) => {
+          if e.property.name == "glob" {
+            match &e.object {
+              Expression::MetaProperty(p) => {
+                if p.meta.name == "import" && p.property.name == "meta" {
+                  let mut files = vec![];
+                  // import.meta.glob('./dir/*.js')
+                  // import.meta.glob(['./dir/*.js', './dir2/*.js'])
+                  if let Some(expr) = call_expr.arguments.first() {
+                    let mut glob_exprs = vec![];
+                    match expr {
+                      Argument::StringLiteral(str) => {
+                        glob_exprs.push(str.value.as_str());
+                      }
+                      Argument::ArrayExpression(array_expr) => {
+                        for expr in &array_expr.elements {
+                          if let ArrayExpressionElement::StringLiteral(str) = expr {
+                            glob_exprs.push(str.value.as_str());
+                          }
+                        }
+                      }
+                      _ => {}
+                    }
+
+                    for glob_expr in glob_exprs {
+                      let path = Path::new(self.cwd).join(Path::new(glob_expr));
+                      if path.is_absolute() {
+                        if let Some(path) = path.to_str() {
+                          for file in glob(path).unwrap() {
+                            let file = file
+                              .unwrap()
+                              .as_path()
+                              .relative(self.cwd)
+                              .to_slash_lossy()
+                              .to_string();
+                            files.push(format!("./{file}"));
+                          }
+                        }
+                      }
+                    }
+                  }
+
+                  // import.meta.glob('./dir/*.js', { import: 'setup' })
+                  let mut opts = ImportGlobOptions::default();
+                  if let Some(Argument::ObjectExpression(obj)) = call_expr.arguments.get(1) {
+                    for prop in &obj.properties {
+                      if let ObjectPropertyKind::ObjectProperty(p) = prop {
+                        if let PropertyKind::Init = p.kind {
+                          if let Some(key) = match &p.key {
+                            PropertyKey::StringLiteral(str) => Some(str.value.as_str()),
+                            PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+                            _ => None,
+                          } {
+                            match key {
+                              "import" => {
+                                if let Expression::StringLiteral(str) = &p.value {
+                                  opts.import = Some(str.value.as_str().to_string());
+                                }
+                              }
+                              "eager" => {
+                                if let Expression::BooleanLiteral(bool) = &p.value {
+                                  opts.eager = Some(bool.value);
+                                }
+                              }
+                              _ => {}
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+
+                  // {
+                  //   './dir/ind.js': __glob__0_0_,
+                  //   './dir/foo.js': () => import('./dir/foo.js'),
+                  //   './dir/bar.js': () => import('./dir/bar.js').then((m) => m.setup),
+                  // }
+                  let properties = files.iter().enumerate().map(|(index, file)| {
+                    let value = if opts.eager.unwrap_or_default() {
+                      // import * as __glob__0 from './dir/foo.js'
+                      // const modules = {
+                      //   './dir/foo.js': __glob__0,
+                      // }
+                      let name = format!("__glob__{}_{index}_", self.current);
+
+                      let module_specifier = match opts.import.as_deref() {
+                        Some("default") => ImportDeclarationSpecifier::ImportDefaultSpecifier(
+                          self.ast_builder.alloc(ImportDefaultSpecifier {
+                            span: SPAN,
+                            local: BindingIdentifier::new(SPAN, self.ast_builder.new_atom(&name)),
+                          }),
+                        ),
+                        Some("*") | None => ImportDeclarationSpecifier::ImportNamespaceSpecifier(
+                          self.ast_builder.alloc(ImportNamespaceSpecifier {
+                            span: SPAN,
+                            local: BindingIdentifier::new(SPAN, self.ast_builder.new_atom(&name)),
+                          }),
+                        ),
+                        Some(import) => ImportDeclarationSpecifier::ImportSpecifier(
+                          self.ast_builder.alloc(ImportSpecifier {
+                            span: SPAN,
+                            local: BindingIdentifier::new(SPAN, self.ast_builder.new_atom(&name)),
+                            imported: ModuleExportName::IdentifierReference(
+                              self.ast_builder.identifier_reference(SPAN, import),
+                            ),
+                            import_kind: ImportOrExportKind::Value,
+                          }),
+                        ),
+                      };
+
+                      self.import_decls.push(self.ast_builder.module_declaration(
+                        ModuleDeclaration::ImportDeclaration(self.ast_builder.import_declaration(
+                          SPAN,
+                          Some(self.ast_builder.new_vec_single(module_specifier)),
+                          self.ast_builder.string_literal(Span::default(), file),
+                          None,
+                          ImportOrExportKind::Value,
+                        )),
+                      ));
+
+                      self.ast_builder.identifier_reference_expression(
+                        self.ast_builder.identifier_reference(SPAN, &name),
+                      )
+                    } else {
+                      // import('./dir/bar.js')
+                      let mut import_expression = self.ast_builder.import_expression(
+                        SPAN,
+                        self.ast_builder.literal_string_expression(
+                          self.ast_builder.string_literal(Span::default(), file),
+                        ),
+                        self.ast_builder.new_vec(),
+                      );
+                      // import('./dir/foo.js').then((m) => m.setup)
+                      if let Some(import) = &opts.import {
+                        if import != "*" {
+                          import_expression = self.ast_builder.call_expression(
+                            SPAN,
+                            self.ast_builder.static_member_expression(
+                              SPAN,
+                              import_expression,
+                              self.ast_builder.identifier_name(SPAN, "then"),
+                              false,
+                            ),
+                            self.ast_builder.new_vec_single(Argument::ArrowFunctionExpression(
+                              self.ast_builder.alloc(ArrowFunctionExpression::new(
+                                SPAN,
+                                true,
+                                false,
+                                self.ast_builder.formal_parameters(
+                                  SPAN,
+                                  FormalParameterKind::ArrowFormalParameters,
+                                  self.ast_builder.new_vec_single(
+                                    self.ast_builder.formal_parameter(
+                                      SPAN,
+                                      self.ast_builder.binding_pattern(
+                                        self.ast_builder.binding_pattern_identifier(
+                                          BindingIdentifier::new(
+                                            SPAN,
+                                            self.ast_builder.new_atom("m"),
+                                          ),
+                                        ),
+                                        None,
+                                        false,
+                                      ),
+                                      None,
+                                      false,
+                                      false,
+                                      self.ast_builder.new_vec(),
+                                    ),
+                                  ),
+                                  None,
+                                ),
+                                self.ast_builder.function_body(
+                                  SPAN,
+                                  self.ast_builder.new_vec(),
+                                  self.ast_builder.new_vec_single(
+                                    self.ast_builder.expression_statement(
+                                      SPAN,
+                                      self.ast_builder.static_member_expression(
+                                        SPAN,
+                                        self.ast_builder.identifier_reference_expression(
+                                          self.ast_builder.identifier_reference(SPAN, "m"),
+                                        ),
+                                        self.ast_builder.identifier_name(SPAN, import),
+                                        false,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                                None,
+                                None,
+                              )),
+                            )),
+                            false,
+                            None,
+                          );
+                        }
+                      }
+
+                      // () => import('./dir/bar.js') or () => import('./dir/foo.js').then((m) => m.setup)
+                      self.ast_builder.arrow_function_expression(
+                        SPAN,
+                        true,
+                        false,
+                        self.ast_builder.formal_parameters(
+                          SPAN,
+                          FormalParameterKind::ArrowFormalParameters,
+                          self.ast_builder.new_vec(),
+                          None,
+                        ),
+                        self.ast_builder.function_body(
+                          SPAN,
+                          self.ast_builder.new_vec(),
+                          self.ast_builder.new_vec_from_iter(vec![self
+                            .ast_builder
+                            .expression_statement(SPAN, import_expression)]),
+                        ),
+                        None,
+                        None,
+                      )
+                    };
+
+                    ObjectPropertyKind::ObjectProperty(self.ast_builder.object_property(
+                      SPAN,
+                      PropertyKind::Init,
+                      self.ast_builder.property_key_expression(
+                        self.ast_builder.literal_string_expression(
+                          self.ast_builder.string_literal(Span::default(), file),
+                        ),
+                      ),
+                      value,
+                      None,
+                      false,
+                      false,
+                      false,
+                    ))
+                  });
+
+                  *expr = self.ast_builder.object_expression(
+                    call_expr.span,
+                    self.ast_builder.new_vec_from_iter(properties),
+                    None,
+                  );
+                  self.current += 1;
+                }
+              }
+              _ => {}
+            }
+          }
+        }
+        _ => {}
+      }
+    }
+  }
+}

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -102,7 +102,8 @@ export interface BindingBuiltinPlugin {
 }
 
 export enum BindingBuiltinPluginName {
-  WasmPlugin = 0
+  WasmPlugin = 0,
+  GlobImportPlugin = 1
 }
 
 export interface BindingEmittedAsset {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -89,7 +89,7 @@ export interface AliasItem {
 }
 
 export interface ArrowFunctionsBindingOptions {
-  spec: boolean
+  spec?: boolean
 }
 
 export interface BindingAssetSource {
@@ -259,10 +259,10 @@ export interface IsolatedDeclarationsResult {
 }
 
 export interface ReactBindingOptions {
-  runtime: 'classic' | 'automatic'
-  development: boolean
-  throwIfNamespace: boolean
-  pure: boolean
+  runtime?: 'classic' | 'automatic'
+  development?: boolean
+  throwIfNamespace?: boolean
+  pure?: boolean
   importSource?: string
   pragma?: string
   pragmaFrag?: string
@@ -294,34 +294,33 @@ export interface Sourcemap {
   names?: Array<string>
 }
 
-function transform(filename: string, sourceText: string, options: TransformBindingOptions): TransformResult
+function transform(filename: string, sourceText: string, options?: TransformBindingOptions | undefined | null): TransformResult
 
 export interface TransformBindingOptions {
-  typescript: TypeScriptBindingOptions
-  react: ReactBindingOptions
-  es2015: Es2015BindingOptions
+  typescript?: TypeScriptBindingOptions
+  react?: ReactBindingOptions
+  es2015?: Es2015BindingOptions
   /**
-   * Enable Sourcemaps
+   * Enable Sourcemap
    *
    * * `true` to generate a sourcemap for the code and include it in the result object.
    *
    * Default: false
    */
-  sourcemaps: boolean
+  sourcemap?: boolean
 }
 
 export interface TransformResult {
   sourceText: string
-  /** Sourcemap */
   map?: Sourcemap
   errors: Array<string>
 }
 
 export interface TypeScriptBindingOptions {
-  jsxPragma: string
-  jsxPragmaFrag: string
-  onlyRemoveTypeImports: boolean
-  allowNamespaces: boolean
-  allowDeclareFields: boolean
+  jsxPragma?: string
+  jsxPragmaFrag?: string
+  onlyRemoveTypeImports?: boolean
+  allowNamespaces?: boolean
+  allowDeclareFields?: boolean
 }
 

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -31,7 +31,10 @@ import { defineParallelPlugin, DefineParallelPluginResult } from './plugin'
 import { defineConfig } from './utils/define-config'
 import { rolldown, experimental_scan } from './rolldown'
 import { ConfigExport } from './types/config-export'
-import { BuiltinWasmPlugin } from './plugin/bindingify-builtin-plugin'
+import {
+  BuiltinGlobImportPlugin,
+  BuiltinWasmPlugin,
+} from './plugin/bindingify-builtin-plugin'
 import { RolldownBuild } from './rolldown-build'
 import { InternalModuleFormat } from './options/bindingify-output-options'
 import {
@@ -56,6 +59,7 @@ export {
   experimental_scan,
   transform,
   BuiltinWasmPlugin,
+  BuiltinGlobImportPlugin,
 }
 
 export type {

--- a/packages/rolldown/src/plugin/bindingify-builtin-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-builtin-plugin.ts
@@ -16,6 +16,12 @@ export class BuiltinWasmPlugin extends BuiltinPlugin {
   }
 }
 
+export class BuiltinGlobImportPlugin extends BuiltinPlugin {
+  constructor(options?: unknown) {
+    super(BindingBuiltinPluginName.GlobImportPlugin, options)
+  }
+}
+
 export function bindingifyBuiltInPlugin(
   plugin: BuiltinPlugin,
 ): BindingBuiltinPlugin {

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -21,7 +21,7 @@ function main() {
           testConfig,
         )
         if (testConfig.afterTest) {
-          testConfig.afterTest(output)
+          await testConfig.afterTest(output)
         }
       } catch (err) {
         throw new Error(`Failed in ${testConfigPath}`, { cause: err })

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/_config.ts
@@ -1,0 +1,11 @@
+import { BuiltinGlobImportPlugin } from '../../../../../'
+import { defineTest } from '@tests'
+
+export default defineTest({
+  config: {
+    plugins: [new BuiltinGlobImportPlugin()],
+  },
+  async afterTest() {
+    await import('./assert.mjs')
+  },
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/_config.ts
@@ -1,4 +1,4 @@
-import { BuiltinGlobImportPlugin } from '../../../../../'
+import { BuiltinGlobImportPlugin } from 'rolldown'
 import { defineTest } from '@tests'
 
 export default defineTest({

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/assert.mjs
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import assert from 'node:assert'
 import { modules1, modules2 } from './dist/main'
 

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/assert.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert'
+import { modules1, modules2 } from './dist/main'
+
+modules1['./dir/index.js']().then((m) => {
+  assert.strictEqual(m.default, 'dir')
+  assert.strictEqual(m.value, 1)
+})
+
+modules2['./dir/index.js']().then((m) => {
+  assert.strictEqual(m, 1)
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/dir/index.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/dir/index.js
@@ -1,0 +1,2 @@
+export default 'dir'
+export const value = 1

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/basic/main.js
@@ -1,0 +1,5 @@
+const modules1 = import.meta.glob('./dir/*.js')
+
+const modules2 = import.meta.glob('./dir/*.js', { import: 'value' })
+
+export { modules1, modules2 }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/_config.ts
@@ -1,0 +1,11 @@
+import { BuiltinGlobImportPlugin } from '../../../../../'
+import { defineTest } from '@tests'
+
+export default defineTest({
+  config: {
+    plugins: [new BuiltinGlobImportPlugin()],
+  },
+  async afterTest() {
+    await import('./assert.mjs')
+  },
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/_config.ts
@@ -1,4 +1,4 @@
-import { BuiltinGlobImportPlugin } from '../../../../../'
+import { BuiltinGlobImportPlugin } from 'rolldown'
 import { defineTest } from '@tests'
 
 export default defineTest({

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/assert.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert'
+import { modules1, modules2, modules3, modules4 } from './dist/main'
+
+assert.strictEqual(modules1['./dir/index.js'].value, 1)
+assert.strictEqual(modules1['./dir/index.js'].default, 'dir')
+
+assert.strictEqual(modules2['./dir/index.js'], 1)
+
+assert.strictEqual(modules3['./dir/index.js'].value, 1)
+assert.strictEqual(modules3['./dir/index.js'].default, 'dir')
+
+assert.strictEqual(modules4['./dir/index.js'], 'dir')

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/assert.mjs
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import assert from 'node:assert'
 import { modules1, modules2, modules3, modules4 } from './dist/main'
 

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/dir/index.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/dir/index.js
@@ -1,0 +1,2 @@
+export default 'dir'
+export const value = 1

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/eager/main.js
@@ -1,0 +1,15 @@
+const modules1 = import.meta.glob('./dir/*.js', { eager: true })
+
+const modules2 = import.meta.glob('./dir/*.js', {
+  import: 'value',
+  eager: true,
+})
+
+const modules3 = import.meta.glob('./dir/*.js', { import: '*', eager: true })
+
+const modules4 = import.meta.glob('./dir/*.js', {
+  import: 'default',
+  eager: true,
+})
+
+export { modules1, modules2, modules3, modules4 }

--- a/packages/rolldown/tests/src/types.ts
+++ b/packages/rolldown/tests/src/types.ts
@@ -3,5 +3,5 @@ import type { RolldownOptions, RolldownOutput } from 'rolldown'
 export interface TestConfig {
   skip?: boolean
   config?: RolldownOptions
-  afterTest?: (output: RolldownOutput) => void
+  afterTest?: (output: RolldownOutput) => Promise<void> | void
 }

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -5,7 +5,7 @@
     "tests/**/*.test.ts",
     "tests/**/_config.ts"
   ],
-  "exclude": ["src/*.js", "src/*.mjs", "src/*.cjs"],
+  "exclude": ["src/*.js", "src/*.mjs", "src/*.cjs", "**/tests/**/assert.mjs"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -5,7 +5,7 @@
     "tests/**/*.test.ts",
     "tests/**/_config.ts"
   ],
-  "exclude": ["src/*.js", "src/*.mjs", "src/*.cjs", "**/tests/**/assert.mjs"],
+  "exclude": ["src/*.js", "src/*.mjs", "src/*.cjs", "tests/**/assert.mjs"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -5,7 +5,7 @@
     "tests/**/*.test.ts",
     "tests/**/_config.ts"
   ],
-  "exclude": ["src/*.js", "src/*.mjs", "src/*.cjs", "tests/**/assert.mjs"],
+  "exclude": ["src/*.js", "src/*.mjs", "src/*.cjs"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.pure-js.json",
-  "include": ["ci/**/*.js", "meta/**/*.js", "misc/**/*.js", "misc/**/*.d.ts"],
+  "include": ["ci/**/*.js", "meta/**/*.js", "misc/**/*.js", "misc/**/*.d.ts"]
 }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "../tsconfig.pure-js.json",
   "include": ["ci/**/*.js", "meta/**/*.js", "misc/**/*.js", "misc/**/*.d.ts"],
-  "exclude": ["**/tests/**/assert.mjs"]
 }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "../tsconfig.pure-js.json",
-  "include": ["ci/**/*.js", "meta/**/*.js", "misc/**/*.js", "misc/**/*.d.ts"]
+  "include": ["ci/**/*.js", "meta/**/*.js", "misc/**/*.js", "misc/**/*.d.ts"],
+  "exclude": ["**/tests/**/assert.mjs"]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The pr intend to implement Vite GlobImportPlugin, doc is https://vitejs.dev/guide/features.html#glob-import. 

Before we discussed using `transform` hook return `ast` to do it, it can't implement because we always need to re-parse and re-codegen for it. So here add `transform_ast` hook to do this, if you any ideas, I'm feel free using `transform` hook to do it.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
