### PR TITLE
chore: ignore fixtures in rolldown tsconfig

### DIFF
--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -5,7 +5,7 @@
     "tests/**/*.test.ts",
     "tests/**/_config.ts"
   ],
-  "exclude": ["src/*.js", "src/*.mjs", "src/*.cjs"],
+  "exclude": ["src/*.js", "src/*.mjs", "src/*.cjs", "tests/fixtures/**"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 


### PR DESCRIPTION
Otherwise `just check-node` fails