### PR TITLE
refactor: remove `raw_text_to_esm` function.

### DIFF
--- a/crates/rolldown/src/utils/parse_to_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ast.rs
@@ -5,7 +5,7 @@ use oxc::{
   span::SourceType as OxcSourceType,
 };
 use rolldown_common::{ModuleType, NormalizedBundlerOptions};
-use rolldown_loader_utils::{binary_to_esm, json_to_esm, raw_text_to_esm, text_to_esm};
+use rolldown_loader_utils::{binary_to_esm, json_to_esm, text_to_esm};
 use rolldown_oxc_utils::{OxcAst, OxcCompiler};
 use rolldown_plugin::{HookTransformAstArgs, PluginDriver};
 
@@ -40,7 +40,7 @@ pub fn parse_to_ast(
     ModuleType::Tsx => (source, OxcParseType::Tsx),
     ModuleType::Json => (json_to_esm(&source)?.into(), OxcParseType::Js),
     ModuleType::Text => (text_to_esm(&source)?.into(), OxcParseType::Js),
-    ModuleType::Base64 | ModuleType::Dataurl => (raw_text_to_esm(&source).into(), OxcParseType::Js),
+    ModuleType::Base64 | ModuleType::Dataurl => (text_to_esm(&source)?.into(), OxcParseType::Js),
     ModuleType::Binary => (
       binary_to_esm(&source, options.platform, ROLLDOWN_RUNTIME_RESOURCE_ID).into(),
       OxcParseType::Js,

--- a/crates/rolldown_loader_utils/src/lib.rs
+++ b/crates/rolldown_loader_utils/src/lib.rs
@@ -1,9 +1,7 @@
 mod binary_to_esm;
 mod json_to_esm;
-mod raw_text_to_esm;
 mod text_to_esm;
 
 pub use binary_to_esm::binary_to_esm;
 pub use json_to_esm::json_to_esm;
-pub use raw_text_to_esm::raw_text_to_esm;
 pub use text_to_esm::text_to_esm;

--- a/crates/rolldown_loader_utils/src/raw_text_to_esm.rs
+++ b/crates/rolldown_loader_utils/src/raw_text_to_esm.rs
@@ -1,3 +1,0 @@
-pub fn raw_text_to_esm(source: &str) -> String {
-  ["export default '", source, "';"].concat()
-}


### PR DESCRIPTION
My previous pr #1367 includes `raw_text_to_esm`, but it is unnecessary due to the existing function `text_to_esm`, and it passes the test, and is better for normalizing chars.