### PR TITLE
fix: add `dataurl` in json config syntax.

### DIFF
--- a/crates/rolldown_common/src/inner_bundler_options/types/module_type.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/module_type.rs
@@ -36,6 +36,7 @@ impl FromStr for ModuleType {
       "json" => Ok(Self::Json),
       "text" => Ok(Self::Text),
       "base64" => Ok(Self::Base64),
+      "dataurl" => Ok(Self::Dataurl),
       "binary" => Ok(Self::Binary),
       "empty" => Ok(Self::Empty),
       _ => Err(format!("Unknown module type: {s}")),

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -80,10 +80,10 @@ const inputOptionsSchema = z.strictObject({
         .or(z.literal('jsx'))
         .or(z.literal('ts'))
         .or(z.literal('tsx'))
-        .or(z.literal('empty'))
         .or(z.literal('json'))
         .or(z.literal('text'))
         .or(z.literal('base64'))
+        .or(z.literal('dataurl'))
         .or(z.literal('binary'))
         .or(z.literal('empty')),
     )


### PR DESCRIPTION
I am sorry for appearing here with "faint" modifications :( and forgot to configure the `DataURL` in several places.

- `crates/rolldown_common/src/inner_bundler_options/types/module_type.rs`: add `"dataurl" => Ok(Self::Dataurl)` for implementing `FromStr`.
- `packages/rolldown/src/options/input-options.ts`: add `dataurl` for the config file and remove the duplicated `empty` loader.

And I sorted the options in the file above following the enum definition in `module_type.rs`.

I am sure that I will create more technical pull requests ahead :)

By the way, since the academic exam has ended, I am now willing to contribute more :)