### PR TITLE
feat(experimental): support strict execution order

### DIFF
--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -92,10 +92,7 @@ impl LinkStage<'_> {
       let linking_info = &self.metas[module_id];
 
       let need_to_wrap = self.input_options.experimental.is_strict_execution_order_enabled()
-        || match linking_info.wrap_kind {
-          WrapKind::Cjs | WrapKind::Esm => true,
-          WrapKind::None => false,
-        };
+        || matches!(linking_info.wrap_kind, WrapKind::Cjs | WrapKind::Esm);
 
       if need_to_wrap {
         wrap_module_recursively(

--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -98,6 +98,7 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
     sourcemap_path_transform: raw_options.sourcemap_path_transform,
     shim_missing_exports: raw_options.shim_missing_exports.unwrap_or(false),
     module_types: loaders,
+    experimental: raw_options.experimental.unwrap_or_default(),
   };
 
   NormalizeOptionsReturn { options: normalized, resolve_options: raw_resolve }

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/_config.json
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ]
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/artifacts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict
+---
+# Assets
+
+## lazy-chunk.mjs
+
+```js
+import { foo } from "./user-lib.mjs";
+
+//#region lazy-chunk.js
+foo();
+
+//#endregion
+```
+## main.mjs
+
+```js
+import { foo } from "./user-lib.mjs";
+
+//#region polyfill.js
+Object.somePolyfilledFunction = () => {};
+
+//#endregion
+//#region main.js
+foo();
+
+//#endregion
+```
+## user-lib.mjs
+
+```js
+
+//#region user-lib.js
+Object.somePolyfilledFunction();
+async function foo() {
+	return import('./lazy-chunk.mjs');
+}
+
+//#endregion
+export { foo };
+```

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/lazy-chunk.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/lazy-chunk.js
@@ -1,0 +1,3 @@
+import {foo} from './user-lib';
+
+foo();

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/main.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/main.js
@@ -1,0 +1,4 @@
+import './polyfill';
+import {foo} from './user-lib';
+
+foo();

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/polyfill.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/polyfill.js
@@ -1,0 +1,1 @@
+Object.somePolyfilledFunction = () => {};

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/user-lib.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/user-lib.js
@@ -1,0 +1,5 @@
+Object.somePolyfilledFunction();
+
+export async function foo() {
+	return import('./lazy-chunk');
+}

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/_config.json
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
+    "experimental": {
+      "strictExecutionOrder": true
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/artifacts.snap
@@ -1,0 +1,58 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict
+---
+# Assets
+
+## lazy-chunk.mjs
+
+```js
+import { __esmMin, foo, init_user_lib } from "./user-lib.mjs";
+
+//#region lazy-chunk.js
+var init_lazy_chunk = __esmMin(() => {
+	init_user_lib();
+	foo();
+});
+
+//#endregion
+init_lazy_chunk();
+```
+## main.mjs
+
+```js
+import { __esmMin, foo, init_user_lib } from "./user-lib.mjs";
+
+//#region polyfill.js
+var init_polyfill = __esmMin(() => {
+	Object.somePolyfilledFunction = () => {};
+});
+
+//#endregion
+//#region main.js
+var init_main = __esmMin(() => {
+	init_polyfill();
+	init_user_lib();
+	foo();
+});
+
+//#endregion
+init_main();
+```
+## user-lib.mjs
+
+```js
+
+
+//#region user-lib.js
+async function foo() {
+	return import('./lazy-chunk.mjs');
+}
+var init_user_lib = __esmMin(() => {
+	Object.somePolyfilledFunction();
+});
+
+//#endregion
+export { __esmMin, foo, init_user_lib };
+```

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/lazy-chunk.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/lazy-chunk.js
@@ -1,0 +1,3 @@
+import {foo} from './user-lib';
+
+foo();

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/main.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/main.js
@@ -1,0 +1,4 @@
+import './polyfill';
+import {foo} from './user-lib';
+
+foo();

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/polyfill.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/polyfill.js
@@ -1,0 +1,1 @@
+Object.somePolyfilledFunction = () => {};

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/user-lib.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict/user-lib.js
@@ -1,0 +1,5 @@
+Object.somePolyfilledFunction();
+
+export async function foo() {
+	return import('./lazy-chunk');
+}

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/_config.json
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry1",
+        "import": "./entry1.js"
+      },
+      {
+        "name": "entry2",
+        "import": "./entry2.js"
+      }
+    ]
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/artifacts.snap
@@ -1,0 +1,36 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/strict
+---
+# Assets
+
+## entry1.mjs
+
+```js
+import "./run-dep.mjs";
+
+//#region init-dep-1.js
+global.foo = {log: () => console.log('foo.log() (from entry 1) called')};
+
+//#endregion
+```
+## entry2.mjs
+
+```js
+import "./run-dep.mjs";
+
+//#region init-dep-2.js
+global.foo = {log: () => console.log('foo.log() (from entry 2) called')};
+
+//#endregion
+```
+## run-dep.mjs
+
+```js
+
+//#region run-dep.js
+global.foo.log();
+
+//#endregion
+```

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/entry1.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/entry1.js
@@ -1,0 +1,2 @@
+import "./init-dep-1.js";
+import "./run-dep.js";  

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/entry2.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/entry2.js
@@ -1,0 +1,2 @@
+import "./init-dep-2.js";
+import "./run-dep.js";

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/init-dep-1.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/init-dep-1.js
@@ -1,0 +1,3 @@
+global.foo = {
+  log: () => console.log("foo.log() (from entry 1) called"),
+};

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/init-dep-2.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/init-dep-2.js
@@ -1,0 +1,3 @@
+global.foo = {
+  log: () => console.log("foo.log() (from entry 2) called"),
+};

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/run-dep.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict/run-dep.js
@@ -1,0 +1,1 @@
+global.foo.log();

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/_config.json
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/_config.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry1",
+        "import": "./entry1.js"
+      },
+      {
+        "name": "entry2",
+        "import": "./entry2.js"
+      }
+    ],
+    "experimental": {
+      "strictExecutionOrder": true
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/artifacts.snap
@@ -1,0 +1,60 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict
+---
+# Assets
+
+## entry1.mjs
+
+```js
+import { __esmMin, init_run_dep } from "./run-dep.mjs";
+
+//#region init-dep-1.js
+var init_init_dep_1 = __esmMin(() => {
+	global.foo = {log: () => console.log('foo.log() (from entry 1) called')};
+});
+
+//#endregion
+//#region entry1.js
+var init_entry1 = __esmMin(() => {
+	init_init_dep_1();
+	init_run_dep();
+});
+
+//#endregion
+init_entry1();
+```
+## entry2.mjs
+
+```js
+import { __esmMin, init_run_dep } from "./run-dep.mjs";
+
+//#region init-dep-2.js
+var init_init_dep_2 = __esmMin(() => {
+	global.foo = {log: () => console.log('foo.log() (from entry 2) called')};
+});
+
+//#endregion
+//#region entry2.js
+var init_entry2 = __esmMin(() => {
+	init_init_dep_2();
+	init_run_dep();
+});
+
+//#endregion
+init_entry2();
+```
+## run-dep.mjs
+
+```js
+
+
+//#region run-dep.js
+var init_run_dep = __esmMin(() => {
+	global.foo.log();
+});
+
+//#endregion
+export { __esmMin, init_run_dep };
+```

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/entry1.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/entry1.js
@@ -1,0 +1,2 @@
+import "./init-dep-1.js";
+import "./run-dep.js";  

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/entry2.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/entry2.js
@@ -1,0 +1,2 @@
+import "./init-dep-2.js";
+import "./run-dep.js";

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/init-dep-1.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/init-dep-1.js
@@ -1,0 +1,3 @@
+global.foo = {
+  log: () => console.log("foo.log() (from entry 1) called"),
+};

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/init-dep-2.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/init-dep-2.js
@@ -1,0 +1,3 @@
+global.foo = {
+  log: () => console.log("foo.log() (from entry 2) called"),
+};

--- a/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/run-dep.js
+++ b/crates/rolldown/tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict/run-dep.js
@@ -1,0 +1,1 @@
+global.foo.log();

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -1350,6 +1350,30 @@ expression: "snapshot_outputs.join(\"\\n\")"
 - ./entries/a.mjs => ./entries/a.mjs
 - ./entries/b.mjs => ./entries/b.mjs
 
+# tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict
+
+- lazy-chunk-!~{001}~.mjs => lazy-chunk-2BiCHA4p.mjs
+- main-!~{000}~.mjs => main-iG_FUyGI.mjs
+- user-lib-!~{002}~.mjs => user-lib-l9uk7Ws7.mjs
+
+# tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_2598/strict
+
+- lazy-chunk-!~{001}~.mjs => lazy-chunk-h-AaJoYY.mjs
+- main-!~{000}~.mjs => main-qa6GIi2S.mjs
+- user-lib-!~{002}~.mjs => user-lib-3ek3ZFYL.mjs
+
+# tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/non_strict
+
+- entry1-!~{000}~.mjs => entry1-yxVw-efc.mjs
+- entry2-!~{001}~.mjs => entry2-pCX9P-TF.mjs
+- run-dep-!~{002}~.mjs => run-dep-lAZRbUty.mjs
+
+# tests/fixtures/function/experimental/strict_execution_order/esbuild_issue_399/strict
+
+- entry1-!~{000}~.mjs => entry1-WkksSQeJ.mjs
+- entry2-!~{001}~.mjs => entry2-5fmw0cWc.mjs
+- run-dep-!~{002}~.mjs => run-dep-IYK8t2Cy.mjs
+
 # tests/fixtures/function/external/commonjs_reexport_external
 
 - main-!~{000}~.mjs => main-yyEbMiKG.mjs

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -125,6 +125,7 @@ pub fn normalize_binding_options(
       _ => panic!("Invalid format: {format_str}"),
     }),
     module_types,
+    experimental: None,
   };
 
   #[cfg(not(target_family = "wasm"))]

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, fmt::Debug, path::PathBuf};
 use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::{Deserialize, Deserializer};
+use types::experimental_options::ExperimentalOptions;
 
 use crate::{ModuleType, SourceMapIgnoreList};
 
@@ -76,6 +77,7 @@ pub struct BundlerOptions {
     schemars(with = "Option<bool>")
   )]
   pub treeshake: TreeshakeOptions,
+  pub experimental: Option<ExperimentalOptions>,
 }
 
 #[cfg(feature = "deserialize_bundler_options")]

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -1,0 +1,20 @@
+#[cfg(feature = "deserialize_bundler_options")]
+use schemars::JsonSchema;
+#[cfg(feature = "deserialize_bundler_options")]
+use serde::Deserialize;
+
+#[derive(Debug, Default)]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
+  serde(rename_all = "camelCase", deny_unknown_fields)
+)]
+pub struct ExperimentalOptions {
+  pub strict_execution_order: Option<bool>,
+}
+
+impl ExperimentalOptions {
+  pub fn is_strict_execution_order_enabled(&self) -> bool {
+    self.strict_execution_order.unwrap_or(false)
+  }
+}

--- a/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
@@ -1,3 +1,4 @@
+pub mod experimental_options;
 pub mod filename_template;
 pub mod input_item;
 pub mod is_external;

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -7,6 +7,7 @@ use rustc_hash::FxHashMap;
 
 use crate::ModuleType;
 
+use super::experimental_options::ExperimentalOptions;
 use super::treeshake::TreeshakeOptions;
 use super::{
   filename_template::FilenameTemplate, is_external::IsExternal,
@@ -38,4 +39,5 @@ pub struct NormalizedBundlerOptions {
   pub footer: Option<AddonOutputOption>,
   pub sourcemap_ignore_list: Option<SourceMapIgnoreList>,
   pub sourcemap_path_transform: Option<SourceMapPathTransform>,
+  pub experimental: ExperimentalOptions,
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -78,6 +78,16 @@
             "null"
           ]
         },
+        "experimental": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ExperimentalOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "external": {
           "type": [
             "array",
@@ -159,6 +169,18 @@
           ]
         },
         "treeshake": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExperimentalOptions": {
+      "type": "object",
+      "properties": {
+        "strictExecutionOrder": {
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This feature try to solve the execution order problem caused by rollup and esbuild's code splitting logic. The nature of these problem is that the execution order of shared modules are hoisted unexpectedly.

- https://github.com/evanw/esbuild/issues/399
- https://github.com/evanw/esbuild/issues/2598
- https://github.com/vitejs/vite/issues/5142

This is done by adding helper function to simulate the original the semantic esm input while keep the static linking between modules.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
