### PR TITLE
feat(output): support emit output of iife format

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -500,9 +500,8 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
         let rec_id = self.ctx.module.imports[&import_expr.span];
         let rec = &self.ctx.module.import_records[rec_id];
         let importee_id = rec.resolved_module;
-        match importee_id {
-          ModuleIdx::Ecma(importee_id) => {
-            let importee = &self.ctx.modules[importee_id];
+        match &self.ctx.modules[importee_id] {
+          Module::Ecma(importee) => {
             let importee_linking_info = &self.ctx.linking_infos[importee_id];
             match importee_linking_info.wrap_kind {
               WrapKind::Esm => {
@@ -539,7 +538,7 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
               WrapKind::None => {}
             }
           }
-          ModuleIdx::External(_) => {
+          Module::External(_) => {
             // iife format doesn't support external module
           }
         }

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -505,6 +505,7 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
             let importee_linking_info = &self.ctx.linking_infos[importee_id];
             match importee_linking_info.wrap_kind {
               WrapKind::Esm => {
+                // `(init_foo(), j)`
                 let importee_linking_info = &self.ctx.linking_infos[importee_id];
                 let importee_wrapper_ref_name =
                   self.canonical_name_for(importee_linking_info.wrapper_ref.unwrap());
@@ -521,6 +522,7 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
                 );
               }
               WrapKind::Cjs => {
+                //  `__toESM(require_foo())`
                 let to_esm_fn_name = self.canonical_name_for_runtime("__toESM");
                 let importee_wrapper_ref_name =
                   self.canonical_name_for(importee_linking_info.wrapper_ref.unwrap());

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -2,13 +2,9 @@ use std::cmp::Ordering;
 
 use itertools::Itertools;
 use oxc::index::IndexVec;
-<<<<<<< HEAD
-use rolldown_common::{Chunk, ChunkIdx, ChunkKind, ImportKind, Module, ModuleIdx};
-=======
 use rolldown_common::{
-  Chunk, ChunkIdx, ChunkKind, EcmaModuleIdx, EntryPointKind, ImportKind, ModuleIdx, OutputFormat,
+  Chunk, ChunkIdx, ChunkKind, EntryPointKind, ImportKind, Module, ModuleIdx, OutputFormat,
 };
->>>>>>> 076b949a (feat: support format iife for single entry)
 use rolldown_utils::{rustc_hash::FxHashMapExt, BitSet};
 use rustc_hash::FxHashMap;
 
@@ -41,16 +37,11 @@ impl<'a> GenerateStage<'a> {
       if let Module::Ecma(importee) = &self.link_output.module_table.modules[rec.resolved_module] {
         // Module imported dynamically will be considered as an entry,
         // so we don't need to include it in this chunk
-<<<<<<< HEAD
-        if !matches!(rec.kind, ImportKind::DynamicImport) {
-          self.determine_reachable_modules_for_entry(importee.idx, entry_index, module_to_bits);
-=======
         if !matches!(rec.kind, ImportKind::DynamicImport)
       // IIFE format should inline dynamic imports
           || matches!(self.options.format, OutputFormat::Iife)
         {
-          self.determine_reachable_modules_for_entry(importee_id, entry_index, module_to_bits);
->>>>>>> 076b949a (feat: support format iife for single entry)
+          self.determine_reachable_modules_for_entry(importee.idx, entry_index, module_to_bits);
         }
       }
     });

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -2,9 +2,7 @@ use std::cmp::Ordering;
 
 use itertools::Itertools;
 use oxc::index::IndexVec;
-use rolldown_common::{
-  Chunk, ChunkIdx, ChunkKind, EntryPointKind, ImportKind, Module, ModuleIdx, OutputFormat,
-};
+use rolldown_common::{Chunk, ChunkIdx, ChunkKind, ImportKind, Module, ModuleIdx, OutputFormat};
 use rolldown_utils::{rustc_hash::FxHashMapExt, BitSet};
 use rustc_hash::FxHashMap;
 
@@ -90,13 +88,6 @@ impl<'a> GenerateStage<'a> {
       FxHashMap::with_capacity(self.link_output.entries.len());
     // Create chunk for each static and dynamic entry
     for (entry_index, entry_point) in self.link_output.entries.iter().enumerate() {
-      // IIFE format should inline dynamic imports
-      if matches!(self.options.format, OutputFormat::Iife)
-        && matches!(entry_point.kind, EntryPointKind::DynamicImport)
-      {
-        continue;
-      }
-
       let count: u32 = entry_index.try_into().expect("Too many entries, u32 overflowed.");
       let mut bits = BitSet::new(entries_len);
       bits.set_bit(count);
@@ -122,12 +113,6 @@ impl<'a> GenerateStage<'a> {
 
     // Determine which modules belong to which chunk. A module could belong to multiple chunks.
     self.link_output.entries.iter().enumerate().for_each(|(i, entry_point)| {
-      // IIFE format should inline dynamic imports
-      if matches!(self.options.format, OutputFormat::Iife)
-        && matches!(entry_point.kind, EntryPointKind::DynamicImport)
-      {
-        return;
-      }
       self.determine_reachable_modules_for_entry(
         entry_point.id,
         i.try_into().expect("Too many entries, u32 overflowed."),

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -97,7 +97,7 @@ pub fn render_chunk_exports(
 
       Some(s)
     }
-    OutputFormat::App => None,
+    OutputFormat::App | OutputFormat::Iife => None,
   }
 }
 

--- a/crates/rolldown/src/utils/chunk/render_chunk_imports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_imports.rs
@@ -27,7 +27,7 @@ pub fn render_chunk_imports(
         format!("{imported}: {alias}")
       }
     }
-    OutputFormat::App => {
+    OutputFormat::App | OutputFormat::Iife => {
       unreachable!("App format doesn't need to generate imports")
     }
   };
@@ -47,7 +47,7 @@ pub fn render_chunk_imports(
         import_items.join(", "),
       ));
     }
-    OutputFormat::App => {
+    OutputFormat::App | OutputFormat::Iife => {
       unreachable!("App format doesn't need to generate imports")
     }
   };
@@ -60,7 +60,7 @@ pub fn render_chunk_imports(
       OutputFormat::Cjs => {
         output.push_str(&format!("require(\"{importee_module_specifier}\");\n"));
       }
-      OutputFormat::App => {
+      OutputFormat::App | OutputFormat::Iife => {
         unreachable!("App format doesn't need to generate imports")
       }
     };
@@ -129,7 +129,7 @@ pub fn render_chunk_imports(
                   "const {alias} = {to_esm_fn_name}(require(\"{importee_name}\"));\n",
                 ));
               }
-              OutputFormat::App => {}
+              OutputFormat::App | OutputFormat::Iife => {}
             }
 
             None
@@ -157,7 +157,7 @@ pub fn render_chunk_imports(
             importee_module_specifier = &importee.name
           ));
         }
-        OutputFormat::App => {
+        OutputFormat::App | OutputFormat::Iife => {
           unreachable!("App format doesn't need to generate imports")
         }
       }

--- a/crates/rolldown/tests/fixtures/code_splitting/basic/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/code_splitting/basic/artifacts.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/rolldown/tests/common/case.rs
+source: crates/rolldown_testing/src/case/case.rs
 expression: content
 input_file: crates/rolldown/tests/fixtures/code_splitting/basic
 ---

--- a/crates/rolldown/tests/fixtures/format/iife/_config.json
+++ b/crates/rolldown/tests/fixtures/format/iife/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+     "format": "iife"
+  },
+  "expectExecuted": true
+}

--- a/crates/rolldown/tests/fixtures/format/iife/_config.json
+++ b/crates/rolldown/tests/fixtures/format/iife/_config.json
@@ -1,6 +1,5 @@
 {
   "config": {
      "format": "iife"
-  },
-  "expectExecuted": true
+  }
 }

--- a/crates/rolldown/tests/fixtures/format/iife/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/format/iife/artifacts.snap
@@ -1,0 +1,47 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/format/iife
+---
+# Assets
+
+## main.mjs
+
+```js
+
+(function() {
+
+
+//#region main.js
+Promise.resolve().then(function() {
+	return __toESM(require_foo());
+});
+Promise.resolve().then(function() {
+	return __toESM(require_cjs());
+});
+Promise.resolve().then(function() {
+	return (init_esm(), esm_ns);
+});
+
+//#endregion
+//#region cjs.js
+var require_cjs = __commonJSMin((exports, module) => {
+	module.exports = 1;
+});
+
+//#endregion
+//#region esm.js
+var esm_ns, value;
+var init_esm = __esmMin(() => {
+	esm_ns = {};
+	__export(esm_ns, {value: () => value});
+	value = 1;
+});
+
+//#endregion
+//#region foo.js
+var require_foo = __commonJSMin((exports, module) => {});
+
+//#endregion
+});
+```

--- a/crates/rolldown/tests/fixtures/format/iife/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/format/iife/artifacts.snap
@@ -24,6 +24,10 @@ Promise.resolve().then(function() {
 });
 
 //#endregion
+//#region foo.js
+var require_foo = __commonJSMin((exports, module) => {});
+
+//#endregion
 //#region cjs.js
 var require_cjs = __commonJSMin((exports, module) => {
 	module.exports = 1;
@@ -37,10 +41,6 @@ var init_esm = __esmMin(() => {
 	__export(esm_ns, {value: () => value});
 	value = 1;
 });
-
-//#endregion
-//#region foo.js
-var require_foo = __commonJSMin((exports, module) => {});
 
 //#endregion
 });

--- a/crates/rolldown/tests/fixtures/format/iife/cjs.js
+++ b/crates/rolldown/tests/fixtures/format/iife/cjs.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/crates/rolldown/tests/fixtures/format/iife/esm.js
+++ b/crates/rolldown/tests/fixtures/format/iife/esm.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/crates/rolldown/tests/fixtures/format/iife/main.js
+++ b/crates/rolldown/tests/fixtures/format/iife/main.js
@@ -1,0 +1,4 @@
+import('./foo');
+import('./cjs');
+import('./esm');
+

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -1338,7 +1338,7 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/format/iife
 
-- main-!~{000}~.mjs => main-TFddYbNz.mjs
+- main-!~{000}~.mjs => main-ak-eGAeR.mjs
 
 # tests/fixtures/function/dir/should_generate_correct_relative_import_path
 

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -1336,6 +1336,10 @@ expression: "snapshot_outputs.join(\"\\n\")"
 # tests/fixtures/errors/unresolved_entry
 
 
+# tests/fixtures/format/iife
+
+- main-!~{000}~.mjs => main-TFddYbNz.mjs
+
 # tests/fixtures/function/dir/should_generate_correct_relative_import_path
 
 - ./chunks/async.mjs => ./chunks/async.mjs

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -40,7 +40,7 @@ pub struct BindingOutputOptions {
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>")]
   pub footer: Option<AddonOutputOption>,
-  #[napi(ts_type = "'es' | 'cjs'")]
+  #[napi(ts_type = "'es' | 'cjs' | 'iife'")]
   pub format: Option<String>,
   // freeze: boolean;
   // generatedCode: NormalizedGeneratedCodeOptions;

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -122,6 +122,7 @@ pub fn normalize_binding_options(
     format: output_options.format.map(|format_str| match format_str.as_str() {
       "es" => OutputFormat::Esm,
       "cjs" => OutputFormat::Cjs,
+      "iife" => OutputFormat::Iife,
       _ => panic!("Invalid format: {format_str}"),
     }),
     module_types,

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
@@ -13,10 +13,11 @@ pub enum OutputFormat {
   Esm,
   Cjs,
   App,
+  Iife,
 }
 
 impl OutputFormat {
   pub fn requires_scope_hoisting(&self) -> bool {
-    matches!(self, Self::Esm | Self::Cjs)
+    matches!(self, Self::Esm | Self::Cjs | Self::Iife)
   }
 }

--- a/crates/rolldown_ecmascript/src/allocator_helpers/take_in/impl_for_oxc_ast.rs
+++ b/crates/rolldown_ecmascript/src/allocator_helpers/take_in/impl_for_oxc_ast.rs
@@ -404,3 +404,9 @@ impl<'ast> TakeIn<'ast> for ast::BindingProperty<'ast> {
     }
   }
 }
+
+impl<'ast> TakeIn<'ast> for ast::ReturnStatement<'ast> {
+  fn dummy(alloc: &'ast Allocator) -> Self {
+    Self { span: TakeIn::dummy(alloc), argument: TakeIn::dummy(alloc) }
+  }
+}

--- a/crates/rolldown_ecmascript/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript/src/ast_snippet.rs
@@ -1,6 +1,9 @@
 use oxc::{
   allocator::{self, Allocator, Box, IntoIn},
-  ast::ast::{self, Statement, StaticMemberExpression},
+  ast::ast::{
+    self, Argument, CallExpression, FormalParameterKind, FormalParameters, Function, FunctionBody,
+    Statement, StaticMemberExpression,
+  },
   span::{Atom, CompactStr, Span, SPAN},
   syntax::operator::UnaryOperator,
 };
@@ -17,6 +20,13 @@ pub struct AstSnippet<'ast> {
 impl<'ast> AstSnippet<'ast> {
   pub fn new(alloc: &'ast Allocator) -> Self {
     Self { alloc }
+  }
+
+  #[inline]
+  pub fn new_vec_single<T>(&self, value: T) -> allocator::Vec<'ast, T> {
+    let mut vec = allocator::Vec::with_capacity_in(1, self.alloc);
+    vec.push(value);
+    vec
   }
 
   pub fn atom(&self, value: &str) -> Atom<'ast> {
@@ -515,6 +525,70 @@ impl<'ast> AstSnippet<'ast> {
         ..TakeIn::dummy(self.alloc)
       }
       .into_in(self.alloc),
+    )
+  }
+
+  // Promise.resolve().then(function() {})
+  pub fn promise_resolve_then_call_expr(
+    &self,
+    span: Span,
+    statements: allocator::Vec<'ast, Statement<'ast>>,
+  ) -> ast::Expression<'ast> {
+    ast::Expression::CallExpression(Box::new_in(
+      CallExpression {
+        span,
+        arguments: self.new_vec_single(Argument::FunctionExpression(Box::new_in(
+          Function {
+            r#type: ast::FunctionType::FunctionExpression,
+            params: Box::new_in(
+              FormalParameters {
+                kind: FormalParameterKind::FormalParameter,
+                items: allocator::Vec::new_in(self.alloc),
+                ..TakeIn::dummy(self.alloc)
+              },
+              self.alloc,
+            ),
+            body: Some(Box::new_in(
+              FunctionBody { statements, ..TakeIn::dummy(self.alloc) },
+              self.alloc,
+            )),
+            ..TakeIn::dummy(self.alloc)
+          },
+          self.alloc,
+        ))),
+        callee: ast::Expression::StaticMemberExpression(
+          StaticMemberExpression {
+            object: ast::Expression::CallExpression(
+              ast::CallExpression {
+                callee: ast::Expression::StaticMemberExpression(Box::new_in(
+                  StaticMemberExpression {
+                    object: self.id_ref_expr("Promise", SPAN),
+                    property: self.id_name("resolve", SPAN),
+                    ..TakeIn::dummy(self.alloc)
+                  },
+                  self.alloc,
+                )),
+                ..TakeIn::dummy(self.alloc)
+              }
+              .into_in(self.alloc),
+            ),
+            property: self.id_name("then", SPAN),
+            ..TakeIn::dummy(self.alloc)
+          }
+          .into_in(self.alloc),
+        ),
+        type_parameters: None,
+        optional: false,
+      },
+      self.alloc,
+    ))
+  }
+
+  // return xxx
+  pub fn return_stmt(&self, argument: ast::Expression<'ast>) -> ast::Statement<'ast> {
+    ast::Statement::ReturnStatement(
+      ast::ReturnStatement { argument: Some(argument), ..TakeIn::dummy(self.alloc) }
+        .into_in(self.alloc),
     )
   }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -204,7 +204,8 @@
       "enum": [
         "esm",
         "cjs",
-        "app"
+        "app",
+        "iife"
       ]
     },
     "Platform": {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -189,7 +189,7 @@ export interface BindingOutputOptions {
   dir?: string
   exports?: 'default' | 'named' | 'none' | 'auto'
   footer?: (chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>
-  format?: 'es' | 'cjs'
+  format?: 'es' | 'cjs' | 'iife'
   plugins: (BindingBuiltinPlugin | BindingPluginOptions | undefined)[]
   sourcemap?: 'file' | 'inline' | 'hidden'
   sourcemapIgnoreList?: (source: string, sourcemapPath: string) => boolean

--- a/packages/rolldown/src/options/bindingify-output-options.ts
+++ b/packages/rolldown/src/options/bindingify-output-options.ts
@@ -27,6 +27,8 @@ export function bindingifyOutputOptions(
           return 'es'
         case 'cjs':
           return 'cjs'
+        case 'iife':
+          return 'iife'
       }
     })(),
     exports,

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -6,7 +6,7 @@ import type { OutputOptions } from './output-options'
 import type { Plugin, ParallelPlugin } from '../plugin'
 import type { RenderedChunk } from '../binding'
 
-type InternalModuleFormat = 'es' | 'cjs'
+type InternalModuleFormat = 'es' | 'cjs' | 'iife'
 
 type AddonFunction = (chunk: RenderedChunk) => string | Promise<string>
 

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -8,6 +8,7 @@ const ModuleFormatSchema = z
   .or(z.literal('esm'))
   .or(z.literal('module'))
   .or(z.literal('commonjs'))
+  .or(z.literal('iife'))
   .optional()
 
 const addonFunctionSchema = z

--- a/packages/rolldown/src/utils/normalize-output-options.ts
+++ b/packages/rolldown/src/utils/normalize-output-options.ts
@@ -54,6 +54,10 @@ function getFormat(
       return 'cjs'
     }
 
+    case 'iife': {
+      return 'iife'
+    }
+
     default:
       unimplemented(`output.format: ${format}`)
   }

--- a/packages/rolldown/tests/fixtures/output/format/iife/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/format/iife/_config.ts
@@ -1,0 +1,18 @@
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    output: {
+      format: 'iife',
+    },
+  },
+  afterTest: (output) => {
+    expect(output.output[0].code).toMatchInlineSnapshot(`
+      "
+      (function() {
+
+      });"
+    `)
+  },
+})


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The pr intend to spport iife format, the result of rollup and esbuild has some different.

Here is a [esbuild example](https://esbuild.github.io/try/#YgAwLjIzLjAALS1mb3JtYXQ9aWlmZSAtLWJ1bmRsZSAtLW91dGRpcj0iZGlzdCIAZQBlbnRyeS5qcwBpbXBvcnQoIi4vY2pzIikKaW1wb3J0KCIuL2VzbSIpLnRoZW4oKG0pID0+IG0udmFsdWUpAABjanMuanMAY29uc29sZS5sb2coKQBlAGVzbS5qcwBleHBvcnQgY29uc3QgdmFsdWUgPSAx) and [rollup example](https://rollupjs.org/repl/?version=4.18.1&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQSUyMiUyMiUyQyUyMm1vZHVsZXMlMjIlM0ElNUIlN0IlMjJjb2RlJTIyJTNBJTIyaW1wb3J0KCcuJTJGbW9kdWxlXzEnKSUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTJDJTIybmFtZSUyMiUzQSUyMm1haW4uanMlMjIlN0QlMkMlN0IlMjJjb2RlJTIyJTNBJTIyJTIyJTJDJTIyaXNFbnRyeSUyMiUzQWZhbHNlJTJDJTIybmFtZSUyMiUzQSUyMm1vZHVsZV8xLmpzJTIyJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMm91dHB1dCUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmlpZmUlMjIlN0QlN0QlN0Q=).

Difference: The esbuild will wrapper esm if an inline dynamic module because it needs to execute lazily. The pr also port behavior form esbuild.

For iife format other issues, let us track at [here](https://github.com/rolldown/rolldown/issues/1569)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
