### PR TITLE
chore: refactor ast snippet

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -513,7 +513,7 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
                   self.canonical_name_for(importee.namespace_object_ref);
                 *expr = self.snippet.promise_resolve_then_call_expr(
                   expr.span(),
-                  self.snippet.new_vec_single(self.snippet.return_stmt(
+                  self.snippet.builder.vec1(self.snippet.return_stmt(
                     self.snippet.seq2_in_paren_expr(
                       self.snippet.call_expr_expr(importee_wrapper_ref_name),
                       self.snippet.id_ref_expr(importee_namespace_name, SPAN),
@@ -529,7 +529,7 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
 
                 *expr = self.snippet.promise_resolve_then_call_expr(
                   expr.span(),
-                  self.snippet.new_vec_single(self.snippet.return_stmt(
+                  self.snippet.builder.vec1(self.snippet.return_stmt(
                     self.snippet.call_expr_with_arg_expr_expr(
                       to_esm_fn_name,
                       self.snippet.call_expr_expr(importee_wrapper_ref_name),

--- a/crates/rolldown_ecmascript/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript/src/ast_snippet.rs
@@ -1,11 +1,9 @@
-use std::default;
-
 use oxc::{
   allocator::{self, Allocator, Box, IntoIn},
   ast::{
     ast::{
-      self, BindingRestElement, ImportOrExportKind, Statement, StaticMemberExpression,
-      TSTypeAnnotation, TSTypeParameterDeclaration,
+      self, BindingRestElement, ImportOrExportKind, Statement, TSTypeAnnotation,
+      TSTypeParameterDeclaration,
     },
     AstBuilder,
   },
@@ -182,7 +180,7 @@ impl<'ast> AstSnippet<'ast> {
     name: PassedStr,
     init: ast::Expression<'ast>,
   ) -> ast::Declaration<'ast> {
-    let mut declarations = self.builder.vec1(self.builder.variable_declarator(
+    let declarations = self.builder.vec1(self.builder.variable_declarator(
       SPAN,
       ast::VariableDeclarationKind::Var,
       self.builder.binding_pattern(
@@ -208,7 +206,7 @@ impl<'ast> AstSnippet<'ast> {
     name: PassedStr,
     init: ast::Expression<'ast>,
   ) -> Box<'ast, ast::VariableDeclaration<'ast>> {
-    let mut declarations = self.builder.vec1(self.builder.variable_declarator(
+    let declarations = self.builder.vec1(self.builder.variable_declarator(
       SPAN,
       ast::VariableDeclarationKind::Var,
       self.builder.binding_pattern(
@@ -222,7 +220,7 @@ impl<'ast> AstSnippet<'ast> {
     self.builder.alloc_variable_declaration(
       SPAN,
       ast::VariableDeclarationKind::Var,
-      self.builder.vec(),
+      declarations,
       false,
     )
   }
@@ -414,7 +412,7 @@ impl<'ast> AstSnippet<'ast> {
   /// () => xx
   /// ```
   pub fn only_return_arrow_expr(&self, expr: ast::Expression<'ast>) -> ast::Expression<'ast> {
-    let mut statements = self.builder.vec1(ast::Statement::ExpressionStatement(
+    let statements = self.builder.vec1(ast::Statement::ExpressionStatement(
       self.builder.alloc_expression_statement(SPAN, expr),
     ));
     ast::Expression::ArrowFunctionExpression(self.builder.alloc_arrow_function_expression(
@@ -451,15 +449,14 @@ impl<'ast> AstSnippet<'ast> {
   }
 
   pub fn import_star_stmt(&self, source: PassedStr, as_name: PassedStr) -> ast::Statement<'ast> {
-    let mut specifiers =
-      self.builder.vec1(ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(
-        self.builder.alloc_import_namespace_specifier(SPAN, self.id(as_name, SPAN)),
-      ));
+    let specifiers = self.builder.vec1(ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(
+      self.builder.alloc_import_namespace_specifier(SPAN, self.id(as_name, SPAN)),
+    ));
     ast::Statement::ImportDeclaration(self.builder.alloc_import_declaration(
       SPAN,
       Some(specifiers),
       self.string_literal(source, SPAN),
-      Default::default(),
+      None,
       ImportOrExportKind::Value,
     ))
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Using `ast` builder API instead of constructing ast by hand, avoid hiding none `oxc` offered default value, e.g. https://github.com/rolldown/rolldown/blob/5c5bf4884da5c28eea3c235c7239b41cf5de585c/crates/rolldown_ecmascript/src/allocator_helpers/take_in/impl_for_oxc_ast.rs#L341-L345
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
