### PR TITLE
perf: avoid unnecessary allocation

### DIFF
--- a/crates/rolldown/src/module_loader/runtime_ecma_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_ecma_module_task.rs
@@ -36,8 +36,7 @@ impl RuntimeEcmaModuleTask {
 
   #[tracing::instrument(name = "RuntimeNormalModuleTaskResult::run", level = "debug", skip_all)]
   pub fn run(self) -> anyhow::Result<()> {
-    let source: Arc<str> =
-      include_str!("../runtime/runtime-without-comments.js").to_string().into();
+    let source: Arc<str> = include_str!("../runtime/runtime-without-comments.js").into();
 
     let (ast, scope, scan_result, symbol, namespace_object_ref) = self.make_ast(&source)?;
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Remove unnecessary memory allocation of `include_str!().to_string`
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
