### PR TITLE
docs(contrib): add `Etiquette` chapter

### DIFF
--- a/web/docs/.vitepress/config.ts
+++ b/web/docs/.vitepress/config.ts
@@ -63,6 +63,10 @@ export default defineConfig({
       '/contrib-guide/': [
         { text: 'Overview', link: '/contrib-guide/' },
         {
+          text: 'Etiquette',
+          link: 'https://developer.mozilla.org/en-US/docs/MDN/Community/Open_source_etiquette',
+        },
+        {
           text: 'Development',
           items: [
             {

--- a/web/docs/contrib-guide/index.md
+++ b/web/docs/contrib-guide/index.md
@@ -24,6 +24,12 @@ We accept pull requests for all bugs, fixes, improvements, and new features. Bef
 
 For setting up the project's development environment, see [Project Setup](./setup-the-project.md).
 
+:::info
+
+Please read the [Etiquette](https://developer.mozilla.org/en-US/docs/MDN/Community/Open_source_etiquette) chapter before submitting a pull request.
+
+:::
+
 ### Branch organization
 
 Submit all pull requests directly to the `main` branch. We only use separate branches for upcoming releases / breaking changes, otherwise, everything points to main.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add etiquette link that point to https://developer.mozilla.org/en-US/docs/MDN/Community/Open_source_etiquette.


It's good that MDN have one of talking etiquette in open source, so we don't have write it again.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
