### PR TITLE
refactor: use `ArcStr` everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2218,6 +2218,7 @@ name = "rolldown_ecmascript"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arcstr",
  "oxc",
  "self_cell",
  "smallvec",
@@ -2227,6 +2228,7 @@ dependencies = [
 name = "rolldown_error"
 version = "0.0.1"
 dependencies = [
+ "arcstr",
  "ariadne",
  "napi",
  "oxc",

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -1,6 +1,7 @@
 pub mod impl_visit;
 pub mod side_effect_detector;
 
+use arcstr::ArcStr;
 use oxc::index::IndexVec;
 use oxc::{
   ast::{
@@ -23,7 +24,6 @@ use rolldown_rstr::{Rstr, ToRstr};
 use rolldown_utils::ecma_script::legitimize_identifier_name;
 use rolldown_utils::path_ext::PathExt;
 use rustc_hash::FxHashMap;
-use std::sync::Arc;
 use sugar_path::SugarPath;
 
 use super::types::ast_symbols::AstSymbols;
@@ -44,7 +44,7 @@ pub struct ScanResult {
 
 pub struct AstScanner<'me> {
   idx: ModuleIdx,
-  source: &'me Arc<str>,
+  source: &'me ArcStr,
   module_type: ModuleDefFormat,
   file_path: &'me ResourceId,
   scopes: &'me AstScopes,
@@ -68,7 +68,7 @@ impl<'me> AstScanner<'me> {
     symbols: &'me mut AstSymbols,
     repr_name: String,
     module_type: ModuleDefFormat,
-    source: &'me Arc<str>,
+    source: &'me ArcStr,
     file_path: &'me ResourceId,
     trivias: &'me Trivias,
   ) -> Self {
@@ -473,7 +473,7 @@ impl<'me> AstScanner<'me> {
           self.result.warnings.push(
             BuildError::forbid_const_assign(
               self.file_path.to_string(),
-              Arc::clone(self.source),
+              self.source.clone(),
               self.symbols.get_name(symbol_id).into(),
               self.symbols.get_span(symbol_id),
               reference.span(),
@@ -502,7 +502,7 @@ impl<'me> AstScanner<'me> {
         }
         if ident.name == "eval" {
           self.result.warnings.push(
-            BuildError::eval(self.file_path.to_string(), Arc::clone(self.source), ident.span)
+            BuildError::eval(self.file_path.to_string(), self.source.clone(), ident.span)
               .with_severity_warning(),
           );
         }

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use once_cell::sync::Lazy;
 use oxc::ast::ast::{
   Argument, ArrayExpressionElement, BindingPatternKind, Expression, IdentifierReference,
@@ -43,12 +41,12 @@ static SIDE_EFFECT_FREE_MEMBER_EXPR_3: Lazy<FxHashSet<(&'static str, &'static st
 /// Detect if a statement "may" have side effect.
 pub struct SideEffectDetector<'a> {
   pub scope: &'a AstScopes,
-  pub source: &'a Arc<str>,
+  pub source: &'a str,
   pub trivias: &'a Trivias,
 }
 
 impl<'a> SideEffectDetector<'a> {
-  pub fn new(scope: &'a AstScopes, source: &'a Arc<str>, trivias: &'a Trivias) -> Self {
+  pub fn new(scope: &'a AstScopes, source: &'a str, trivias: &'a Trivias) -> Self {
     Self { scope, source, trivias }
   }
 

--- a/crates/rolldown/src/module_loader/ecma_module_task.rs
+++ b/crates/rolldown/src/module_loader/ecma_module_task.rs
@@ -1,6 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use anyhow::Result;
+use arcstr::ArcStr;
 use futures::future::join_all;
 use oxc::{
   index::IndexVec,
@@ -105,7 +106,7 @@ impl EcmaModuleTask {
     .await?;
 
     // Run plugin transform.
-    let source: Arc<str> = transform_source(
+    let source: ArcStr = transform_source(
       &self.ctx.plugin_driver,
       &self.resolved_path,
       source,
@@ -120,7 +121,7 @@ impl EcmaModuleTask {
       Path::new(&self.resolved_path.path.as_ref()),
       &self.ctx.input_options,
       module_type,
-      Arc::clone(&source),
+      source.clone(),
     )?;
 
     let (scope, scan_result, ast_symbol, namespace_object_ref) =
@@ -246,7 +247,7 @@ impl EcmaModuleTask {
   fn scan(
     &self,
     ast: &mut EcmaAst,
-    source: &Arc<str>,
+    source: &ArcStr,
     symbols: SymbolTable,
     scopes: ScopeTree,
   ) -> (AstScopes, ScanResult, AstSymbols, SymbolRef) {

--- a/crates/rolldown/src/module_loader/runtime_ecma_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_ecma_module_task.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-
+use arcstr::ArcStr;
 use oxc::index::IndexVec;
 use oxc::span::SourceType;
 use rolldown_common::{
@@ -44,7 +43,7 @@ impl RuntimeEcmaModuleTask {
 
   #[tracing::instrument(name = "RuntimeNormalModuleTaskResult::run", level = "debug", skip_all)]
   pub fn run(self) -> anyhow::Result<()> {
-    let source: Arc<str> = include_str!("../runtime/runtime-without-comments.js").into();
+    let source: ArcStr = arcstr::literal!(include_str!("../runtime/runtime-without-comments.js"));
 
     let MakeEcmaAstResult { ast, ast_scope, scan_result, ast_symbols, namespace_object_ref } =
       self.make_ecma_ast(&source)?;
@@ -108,9 +107,9 @@ impl RuntimeEcmaModuleTask {
     Ok(())
   }
 
-  fn make_ecma_ast(&self, source: &Arc<str>) -> anyhow::Result<MakeEcmaAstResult> {
+  fn make_ecma_ast(&self, source: &ArcStr) -> anyhow::Result<MakeEcmaAstResult> {
     let source_type = SourceType::default();
-    let mut ast = EcmaCompiler::parse(Arc::clone(source), source_type)?;
+    let mut ast = EcmaCompiler::parse(source, source_type)?;
     tweak_ast_for_scanning(&mut ast);
 
     let (mut symbol_table, scope) = ast.make_symbol_table_and_scope_tree();

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -1,8 +1,6 @@
 // TODO: The current implementation for matching imports is enough so far but incomplete. It needs to be refactored
 // if we want more enhancements related to exports.
 
-use std::sync::Arc;
-
 use rolldown_common::{
   ExportsKind, IndexModules, Module, ModuleIdx, ModuleType, ResolvedExport, Specifier, SymbolRef,
 };
@@ -283,7 +281,7 @@ impl<'a> BindImportsAndExportsContext<'a> {
           self.errors.push(BuildError::missing_export(
             module.stable_resource_id.to_string(),
             importee.stable_resource_id().to_string(),
-            Arc::clone(&module.source),
+            module.source.clone(),
             named_import.imported.to_string(),
             named_import.span_imported,
           ));

--- a/crates/rolldown/src/utils/parse_to_ecma_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ecma_ast.rs
@@ -1,5 +1,6 @@
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 
+use arcstr::ArcStr;
 use oxc::{
   semantic::{ScopeTree, SymbolTable},
   span::SourceType as OxcSourceType,
@@ -28,10 +29,8 @@ pub fn parse_to_ecma_ast(
   path: &Path,
   options: &NormalizedBundlerOptions,
   module_type: ModuleType,
-  source: impl Into<Arc<str>>,
+  source: ArcStr,
 ) -> anyhow::Result<(EcmaAst, SymbolTable, ScopeTree)> {
-  let source: Arc<str> = source.into();
-
   // 1. Transform the source to the type that rolldown supported.
   let (source, parsed_type) = match module_type {
     ModuleType::Js => (source, OxcParseType::Js),
@@ -58,7 +57,7 @@ pub fn parse_to_ecma_ast(
     }
   };
 
-  let mut ecma_ast = EcmaCompiler::parse(Arc::clone(&source), oxc_source_type)?;
+  let mut ecma_ast = EcmaCompiler::parse(&source, oxc_source_type)?;
 
   ecma_ast =
     plugin_driver.transform_ast(HookTransformAstArgs { cwd: &options.cwd, ast: ecma_ast })?;

--- a/crates/rolldown_common/src/ecmascript/ecma_module.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_module.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 use crate::side_effects::DeterminedSideEffects;
 use crate::{
@@ -7,6 +7,7 @@ use crate::{
   StmtInfo, StmtInfos, SymbolRef,
 };
 use crate::{IndexModules, ModuleType};
+use arcstr::ArcStr;
 use oxc::index::IndexVec;
 use oxc::span::Span;
 use rolldown_rstr::Rstr;
@@ -15,7 +16,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 #[derive(Debug)]
 pub struct EcmaModule {
   pub exec_order: u32,
-  pub source: Arc<str>,
+  pub source: ArcStr,
   pub idx: ModuleIdx,
   pub is_user_defined_entry: bool,
   pub resource_id: ResourceId,
@@ -77,7 +78,7 @@ impl EcmaModule {
 
   pub fn to_module_info(&self) -> ModuleInfo {
     ModuleInfo {
-      code: Some(Arc::clone(&self.source)),
+      code: Some(self.source.clone()),
       id: self.resource_id.clone(),
       is_entry: self.is_user_defined_entry,
       importers: {

--- a/crates/rolldown_common/src/types/module_info.rs
+++ b/crates/rolldown_common/src/types/module_info.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
+use arcstr::ArcStr;
 
 use crate::ResourceId;
 
 #[derive(Debug)]
 pub struct ModuleInfo {
-  pub code: Option<Arc<str>>,
+  pub code: Option<ArcStr>,
   pub id: ResourceId,
   pub is_entry: bool,
   pub importers: Vec<ResourceId>,

--- a/crates/rolldown_ecmascript/Cargo.toml
+++ b/crates/rolldown_ecmascript/Cargo.toml
@@ -13,8 +13,8 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
-oxc    = { workspace = true, features = ["semantic", "codegen"] }
-
+anyhow    = { workspace = true }
+arcstr    = { workspace = true }
+oxc       = { workspace = true, features = ["semantic", "codegen"] }
 self_cell = { workspace = true }
 smallvec  = { workspace = true }

--- a/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
@@ -1,6 +1,7 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 use crate::EcmaCompiler;
+use arcstr::ArcStr;
 use oxc::ast::Trivias;
 use oxc::{allocator::Allocator, ast::ast::Program, span::SourceType};
 
@@ -19,7 +20,7 @@ pub struct EcmaAst {
 }
 
 impl EcmaAst {
-  pub fn source(&self) -> &Arc<str> {
+  pub fn source(&self) -> &ArcStr {
     &self.program.borrow_owner().source
   }
 

--- a/crates/rolldown_ecmascript/src/ecma_ast/program_cell.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/program_cell.rs
@@ -1,10 +1,9 @@
-use std::sync::Arc;
-
+use arcstr::ArcStr;
 use oxc::{allocator::Allocator, ast::ast::Program};
 use self_cell::self_cell;
 
 pub struct ProgramCellOwner {
-  pub source: Arc<str>,
+  pub source: ArcStr,
   pub allocator: Allocator,
 }
 
@@ -52,7 +51,7 @@ impl ProgramCell {
 }
 
 pub struct WithMutFields<'outer, 'inner> {
-  pub source: &'inner Arc<str>,
+  pub source: &'inner ArcStr,
   pub allocator: &'inner Allocator,
   pub program: &'outer mut Program<'inner>,
 }

--- a/crates/rolldown_error/Cargo.toml
+++ b/crates/rolldown_error/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+arcstr            = { workspace = true }
 ariadne           = { workspace = true }
 napi              = { workspace = true, optional = true }
 oxc               = { workspace = true }

--- a/crates/rolldown_error/src/build_error/error_constructors.rs
+++ b/crates/rolldown_error/src/build_error/error_constructors.rs
@@ -1,8 +1,6 @@
-use std::{
-  path::{Path, PathBuf},
-  sync::Arc,
-};
+use std::path::{Path, PathBuf};
 
+use arcstr::ArcStr;
 use oxc::span::Span;
 use rolldown_resolver::ResolveError;
 
@@ -59,7 +57,7 @@ impl BuildError {
   pub fn missing_export(
     stable_importer: String,
     stable_importee: String,
-    importer_source: Arc<str>,
+    importer_source: ArcStr,
     imported_specifier: String,
     imported_specifier_span: Span,
   ) -> Self {
@@ -76,7 +74,7 @@ impl BuildError {
 
   pub fn forbid_const_assign(
     filename: String,
-    source: Arc<str>,
+    source: ArcStr,
     name: String,
     reference_span: Span,
     re_assign_span: Span,
@@ -88,7 +86,7 @@ impl BuildError {
     Self::new_inner(NapiError { status, reason })
   }
 
-  pub fn eval(filename: String, source: Arc<str>, span: Span) -> Self {
+  pub fn eval(filename: String, source: ArcStr, span: Span) -> Self {
     Self::new_inner(Eval { filename, span, source })
   }
 }

--- a/crates/rolldown_error/src/diagnostic.rs
+++ b/crates/rolldown_error/src/diagnostic.rs
@@ -1,21 +1,22 @@
 use crate::build_error::severity::Severity;
+use arcstr::ArcStr;
 use ariadne::{sources, Config, Label, Report, ReportBuilder, ReportKind};
-use std::{fmt::Display, ops::Range, sync::Arc};
+use std::{fmt::Display, ops::Range};
 
 #[derive(Debug, Clone)]
-pub struct DiagnosticFileId(Arc<str>);
+pub struct DiagnosticFileId(ArcStr);
 
 #[derive(Debug, Clone)]
 pub struct Diagnostic {
   pub(crate) kind: String,
   pub(crate) title: String,
-  pub(crate) files: Vec<(/* filename */ Arc<str>, /* file content */ Arc<str>)>,
-  pub(crate) labels: Vec<Label<(/* filename */ Arc<str>, Range<usize>)>>,
+  pub(crate) files: Vec<(/* filename */ ArcStr, /* file content */ ArcStr)>,
+  pub(crate) labels: Vec<Label<(/* filename */ ArcStr, Range<usize>)>>,
   pub(crate) severity: Severity,
 }
 
-type AriadneReportBuilder = ReportBuilder<'static, (Arc<str>, Range<usize>)>;
-type AriadneReport = Report<'static, (Arc<str>, Range<usize>)>;
+type AriadneReportBuilder = ReportBuilder<'static, (ArcStr, Range<usize>)>;
+type AriadneReport = Report<'static, (ArcStr, Range<usize>)>;
 
 impl Diagnostic {
   pub(crate) fn new(kind: String, summary: String, severity: Severity) -> Self {
@@ -24,13 +25,13 @@ impl Diagnostic {
 
   pub(crate) fn add_file(
     &mut self,
-    filename: impl Into<Arc<str>>,
-    content: impl Into<Arc<str>>,
+    filename: impl Into<ArcStr>,
+    content: impl Into<ArcStr>,
   ) -> DiagnosticFileId {
     let filename = filename.into();
     let content = content.into();
     debug_assert!(self.files.iter().all(|(id, _)| id != &filename));
-    self.files.push((Arc::clone(&filename), content));
+    self.files.push((filename.clone(), content));
     DiagnosticFileId(filename)
   }
 
@@ -42,7 +43,7 @@ impl Diagnostic {
   ) -> &mut Self {
     let range = range.into();
     let range = range.start as usize..range.end as usize;
-    let label = Label::new((Arc::clone(&file_id.0), range)).with_message(message);
+    let label = Label::new((file_id.0.clone(), range)).with_message(message);
     self.labels.push(label);
     self
   }

--- a/crates/rolldown_error/src/events/eval.rs
+++ b/crates/rolldown_error/src/events/eval.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-
+use arcstr::ArcStr;
 use oxc::span::Span;
 
 use crate::{diagnostic::Diagnostic, types::diagnostic_options::DiagnosticOptions};
@@ -9,7 +8,7 @@ use super::BuildEvent;
 #[derive(Debug)]
 pub struct Eval {
   pub filename: String,
-  pub source: Arc<str>,
+  pub source: ArcStr,
   pub span: Span,
 }
 
@@ -27,7 +26,7 @@ impl BuildEvent for Eval {
 
     diagnostic.title = "Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.".to_string();
 
-    let file_id = diagnostic.add_file(filename, Arc::clone(&self.source));
+    let file_id = diagnostic.add_file(filename, self.source.clone());
 
     diagnostic.add_label(
       &file_id,

--- a/crates/rolldown_error/src/events/forbid_const_assign.rs
+++ b/crates/rolldown_error/src/events/forbid_const_assign.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-
+use arcstr::ArcStr;
 use oxc::span::Span;
 
 use crate::{diagnostic::Diagnostic, types::diagnostic_options::DiagnosticOptions};
@@ -9,7 +8,7 @@ use super::BuildEvent;
 #[derive(Debug)]
 pub struct ForbidConstAssign {
   pub filename: String,
-  pub source: Arc<str>,
+  pub source: ArcStr,
   pub name: String,
   pub reference_span: Span,
   pub re_assign_span: Span,
@@ -27,7 +26,7 @@ impl BuildEvent for ForbidConstAssign {
     let filename = opts.stabilize_path(&self.filename);
     diagnostic.title = format!("Unexpected re-assignment of const variable `{0}`", self.name);
 
-    let file_id = diagnostic.add_file(filename, Arc::clone(&self.source));
+    let file_id = diagnostic.add_file(filename, self.source.clone());
     diagnostic
       .add_label(
         &file_id,

--- a/crates/rolldown_error/src/events/missing_export.rs
+++ b/crates/rolldown_error/src/events/missing_export.rs
@@ -1,7 +1,7 @@
+use arcstr::ArcStr;
 use oxc::span::Span;
 
 use crate::{event_kind::EventKind, types::diagnostic_options::DiagnosticOptions};
-use std::sync::Arc;
 
 use super::BuildEvent;
 
@@ -9,7 +9,7 @@ use super::BuildEvent;
 pub struct MissingExport {
   pub stable_importer: String,
   pub stable_importee: String,
-  pub importer_source: Arc<str>,
+  pub importer_source: ArcStr,
   pub imported_specifier: String,
   pub imported_specifier_span: Span,
 }
@@ -32,7 +32,7 @@ impl BuildEvent for MissingExport {
     _opts: &DiagnosticOptions,
   ) {
     let importer_file =
-      diagnostic.add_file(self.stable_importer.clone(), Arc::clone(&self.importer_source));
+      diagnostic.add_file(self.stable_importer.clone(), self.importer_source.clone());
 
     diagnostic.title =
       format!(r#""{}" is not exported by "{}"."#, self.imported_specifier, &self.stable_importee);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Advantages of `ArcStr`

- Small size, which is u32 rather than usize. 
- No atomic operations on static str. https://docs.rs/arcstr/latest/arcstr/struct.ArcStr.html#what-does-zero-cost-literals-mean
- https://docs.rs/arcstr/latest/arcstr/struct.ArcStr.html#benefits-of-arcstr-over-arcstr

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
