### PR TITLE
refactor(rust): stop deriving `Clone` on `ModuleType`

### DIFF
--- a/crates/rolldown/src/module_loader/ecma_module_task.rs
+++ b/crates/rolldown/src/module_loader/ecma_module_task.rs
@@ -88,17 +88,17 @@ impl EcmaModuleTask {
     let module_type = {
       let ext =
         self.resolved_path.path.as_path().extension().and_then(|ext| ext.to_str()).unwrap_or("js");
-      let module_type = self.ctx.input_options.module_types.get(ext);
+      let module_type = self.ctx.input_options.module_types.get(ext).cloned();
 
       // FIXME: Once we support more types, we should return error instead of defaulting to JS.
-      module_type.copied().unwrap_or(ModuleType::Js)
+      module_type.unwrap_or(ModuleType::Js)
     };
 
     // Run plugin load to get content first, if it is None using read fs as fallback.
     let source = load_source(
       &self.ctx.plugin_driver,
       &self.resolved_path,
-      module_type,
+      module_type.clone(),
       &self.ctx.fs,
       &mut sourcemap_chain,
       &mut hook_side_effects,
@@ -120,7 +120,7 @@ impl EcmaModuleTask {
       &self.ctx.plugin_driver,
       Path::new(&self.resolved_path.path.as_ref()),
       &self.ctx.input_options,
-      module_type,
+      &module_type,
       source.clone(),
     )?;
 

--- a/crates/rolldown/src/utils/parse_to_ecma_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ecma_ast.rs
@@ -28,7 +28,7 @@ pub fn parse_to_ecma_ast(
   plugin_driver: &PluginDriver,
   path: &Path,
   options: &NormalizedBundlerOptions,
-  module_type: ModuleType,
+  module_type: &ModuleType,
   source: ArcStr,
 ) -> anyhow::Result<(EcmaAst, SymbolTable, ScopeTree)> {
   // 1. Transform the source to the type that rolldown supported.

--- a/crates/rolldown_common/src/inner_bundler_options/types/module_type.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/module_type.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
   derive(Deserialize, JsonSchema),
   serde(rename_all = "camelCase", deny_unknown_fields)
 )]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum ModuleType {
   Js,
   Jsx,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

preparation for https://github.com/rolldown/rolldown/pull/1632.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
