### PR TITLE
refactor:  rename `BuildError` to `BuildDiagnostic`

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -19,7 +19,7 @@ use rolldown_common::{
   NamedImport, RawImportRecord, ResourceId, Specifier, StmtInfo, StmtInfos, SymbolRef,
 };
 use rolldown_ecmascript::{BindingIdentifierExt, BindingPatternExt};
-use rolldown_error::BuildError;
+use rolldown_error::BuildDiagnostic;
 use rolldown_rstr::{Rstr, ToRstr};
 use rolldown_utils::ecma_script::legitimize_identifier_name;
 use rolldown_utils::path_ext::PathExt;
@@ -39,7 +39,7 @@ pub struct ScanResult {
   pub default_export_ref: SymbolRef,
   pub imports: FxHashMap<Span, ImportRecordIdx>,
   pub exports_kind: ExportsKind,
-  pub warnings: Vec<BuildError>,
+  pub warnings: Vec<BuildDiagnostic>,
 }
 
 pub struct AstScanner<'me> {
@@ -471,7 +471,7 @@ impl<'me> AstScanner<'me> {
       for reference in self.scopes.get_resolved_references(symbol_id) {
         if reference.is_write() {
           self.result.warnings.push(
-            BuildError::forbid_const_assign(
+            BuildDiagnostic::forbid_const_assign(
               self.file_path.to_string(),
               self.source.clone(),
               self.symbols.get_name(symbol_id).into(),
@@ -502,7 +502,7 @@ impl<'me> AstScanner<'me> {
         }
         if ident.name == "eval" {
           self.result.warnings.push(
-            BuildError::eval(self.file_path.to_string(), self.source.clone(), ident.span)
+            BuildDiagnostic::eval(self.file_path.to_string(), self.source.clone(), ident.span)
               .with_severity_warning(),
           );
         }

--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use anyhow::Result;
 use rolldown_common::SharedFileEmitter;
-use rolldown_error::BuildError;
+use rolldown_error::BuildDiagnostic;
 use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_plugin::{
   HookBuildEndArgs, HookRenderErrorArgs, PluginDriver, SharedPlugin, SharedPluginDriver,
@@ -132,7 +132,7 @@ impl Bundler {
 
   fn normalize_error<T>(
     ret: &Result<T>,
-    errors_fn: impl Fn(&T) -> &[BuildError],
+    errors_fn: impl Fn(&T) -> &[BuildDiagnostic],
   ) -> Option<String> {
     ret.as_ref().map_or_else(
       |error| Some(error.to_string()),

--- a/crates/rolldown/src/module_loader/ecma_module_task.rs
+++ b/crates/rolldown/src/module_loader/ecma_module_task.rs
@@ -12,7 +12,7 @@ use rolldown_common::{
   ResolvedPath, ResolvedRequestInfo, ResourceId, StrOrBytes, SymbolRef, TreeshakeOptions,
 };
 use rolldown_ecmascript::EcmaAst;
-use rolldown_error::BuildError;
+use rolldown_error::BuildDiagnostic;
 use rolldown_plugin::{HookResolveIdExtraOptions, SharedPluginDriver};
 use rolldown_resolver::ResolveError;
 use rolldown_utils::{ecma_script::legitimize_identifier_name, path_ext::PathExt};
@@ -37,7 +37,7 @@ pub struct EcmaModuleTask {
   resolved_path: ResolvedPath,
   package_json: Option<Arc<PackageJson>>,
   module_type: ModuleDefFormat,
-  errors: Vec<BuildError>,
+  errors: Vec<BuildDiagnostic>,
   is_user_defined_entry: bool,
   side_effects: Option<HookSideEffects>,
 }
@@ -325,7 +325,7 @@ impl EcmaModuleTask {
   async fn resolve_dependencies(
     &mut self,
     dependencies: &IndexVec<ImportRecordIdx, RawImportRecord>,
-    warnings: &mut Vec<BuildError>,
+    warnings: &mut Vec<BuildDiagnostic>,
   ) -> Result<IndexVec<ImportRecordIdx, ResolvedRequestInfo>> {
     let jobs = dependencies.iter_enumerated().map(|(idx, item)| {
       let specifier = item.module_request.clone();
@@ -363,7 +363,7 @@ impl EcmaModuleTask {
         Err(e) => match &e {
           ResolveError::NotFound(..) => {
             warnings.push(
-              BuildError::unresolved_import_treated_as_external(
+              BuildDiagnostic::unresolved_import_treated_as_external(
                 specifier.to_string(),
                 self.resolved_path.path.to_string(),
                 Some(e),

--- a/crates/rolldown/src/module_loader/mod.rs
+++ b/crates/rolldown/src/module_loader/mod.rs
@@ -5,7 +5,7 @@ pub mod task_context;
 mod task_result;
 
 pub use module_loader::ModuleLoader;
-use rolldown_error::BuildError;
+use rolldown_error::BuildDiagnostic;
 
 use self::{
   runtime_ecma_module_task::RuntimeEcmaModuleTaskResult, task_result::NormalModuleTaskResult,
@@ -13,6 +13,6 @@ use self::{
 pub enum Msg {
   NormalModuleDone(NormalModuleTaskResult),
   RuntimeNormalModuleDone(RuntimeEcmaModuleTaskResult),
-  BuildErrors(Vec<BuildError>),
+  BuildErrors(Vec<BuildDiagnostic>),
   Panics(anyhow::Error),
 }

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -6,7 +6,7 @@ use rolldown_common::{
   ModuleIdx, ModuleTable, OutputFormat, ResolvedRequestInfo,
 };
 use rolldown_ecmascript::EcmaAst;
-use rolldown_error::BuildError;
+use rolldown_error::BuildDiagnostic;
 use rolldown_fs::OsFileSystem;
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_utils::rustc_hash::FxHashSetExt;
@@ -63,8 +63,8 @@ pub struct ModuleLoaderOutput {
   // Entries that user defined + dynamic import entries
   pub entry_points: Vec<EntryPoint>,
   pub runtime: RuntimeModuleBrief,
-  pub warnings: Vec<BuildError>,
-  pub errors: Vec<BuildError>,
+  pub warnings: Vec<BuildDiagnostic>,
+  pub errors: Vec<BuildDiagnostic>,
 }
 
 impl ModuleLoader {
@@ -185,7 +185,7 @@ impl ModuleLoader {
     }
 
     let mut errors = vec![];
-    let mut all_warnings: Vec<BuildError> = vec![];
+    let mut all_warnings: Vec<BuildDiagnostic> = vec![];
 
     let entries_count = user_defined_entries.len() + /* runtime */ 1;
     self.intermediate_normal_modules.modules.reserve(entries_count);

--- a/crates/rolldown/src/module_loader/task_result.rs
+++ b/crates/rolldown/src/module_loader/task_result.rs
@@ -3,7 +3,7 @@ use rolldown_common::{
   EcmaModule, ImportRecordIdx, ModuleIdx, RawImportRecord, ResolvedRequestInfo,
 };
 use rolldown_ecmascript::EcmaAst;
-use rolldown_error::BuildError;
+use rolldown_error::BuildDiagnostic;
 
 use crate::types::ast_symbols::AstSymbols;
 
@@ -12,7 +12,7 @@ pub struct NormalModuleTaskResult {
   pub ast_symbol: AstSymbols,
   pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedRequestInfo>,
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
-  pub warnings: Vec<BuildError>,
+  pub warnings: Vec<BuildDiagnostic>,
   pub module: EcmaModule,
   pub ast: EcmaAst,
 }

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -2,7 +2,7 @@ use futures::future::try_join_all;
 use indexmap::IndexSet;
 use oxc::index::{index_vec, IndexVec};
 use rolldown_common::{Asset, AssetMeta, Output, OutputAsset, OutputChunk, SourceMapType};
-use rolldown_error::BuildError;
+use rolldown_error::BuildDiagnostic;
 use sugar_path::SugarPath;
 
 use crate::{
@@ -83,7 +83,7 @@ impl<'a> GenerateStage<'a> {
 
           match self.options.sourcemap {
             SourceMapType::File => {
-              let source = match map.to_json_string().map_err(BuildError::sourcemap_error) {
+              let source = match map.to_json_string().map_err(BuildDiagnostic::sourcemap_error) {
                 Ok(source) => source,
                 Err(e) => {
                   self.link_output.errors.push(e);
@@ -98,7 +98,7 @@ impl<'a> GenerateStage<'a> {
               code.push_str(&format!("\n//# sourceMappingURL={map_filename}"));
             }
             SourceMapType::Inline => {
-              let data_url = match map.to_data_url().map_err(BuildError::sourcemap_error) {
+              let data_url = match map.to_data_url().map_err(BuildDiagnostic::sourcemap_error) {
                 Ok(data_url) => data_url,
                 Err(e) => {
                   self.link_output.errors.push(e);

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -55,7 +55,10 @@ pub enum MatchImportKind {
   // The import could not be evaluated due to a cycle
   Cycle,
   // The import resolved to multiple symbols via "export * from"
-  Ambiguous { symbol_ref: SymbolRef, potentially_ambiguous_symbol_refs: Vec<SymbolRef> },
+  Ambiguous {
+    symbol_ref: SymbolRef,
+    potentially_ambiguous_symbol_refs: Vec<SymbolRef>,
+  },
   NoMatch,
 }
 
@@ -238,8 +241,8 @@ struct BindImportsAndExportsContext<'a> {
   pub metas: &'a mut LinkingMetadataVec,
   pub symbols: &'a mut Symbols,
   pub input_options: &'a SharedOptions,
-  pub errors: Vec<BuildError>,
-  pub warnings: Vec<BuildError>,
+  pub errors: Vec<BuildDiagnostic>,
+  pub warnings: Vec<BuildDiagnostic>,
 }
 
 impl<'a> BindImportsAndExportsContext<'a> {
@@ -289,7 +292,7 @@ impl<'a> BindImportsAndExportsContext<'a> {
           );
 
           self.warnings.push(
-            BuildError::ambiguous_external_namespace(
+            BuildDiagnostic::ambiguous_external_namespace(
               importer,
               importee,
               module.source.clone(),

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -6,7 +6,7 @@ use rolldown_common::{
   SymbolRef, WrapKind,
 };
 use rolldown_ecmascript::EcmaAst;
-use rolldown_error::BuildError;
+use rolldown_error::BuildDiagnostic;
 use rolldown_utils::{
   ecma_script::legitimize_identifier_name,
   rayon::{ParallelBridge, ParallelIterator},
@@ -40,8 +40,8 @@ pub struct LinkStageOutput {
   pub metas: LinkingMetadataVec,
   pub symbols: Symbols,
   pub runtime: RuntimeModuleBrief,
-  pub warnings: Vec<BuildError>,
-  pub errors: Vec<BuildError>,
+  pub warnings: Vec<BuildDiagnostic>,
+  pub errors: Vec<BuildDiagnostic>,
   pub used_symbol_refs: FxHashSet<SymbolRef>,
   pub top_level_member_expr_resolved_cache: FxHashMap<SymbolRef, MemberChainToResolvedSymbolRef>,
 }
@@ -54,8 +54,8 @@ pub struct LinkStage<'a> {
   pub runtime: RuntimeModuleBrief,
   pub sorted_modules: Vec<ModuleIdx>,
   pub metas: LinkingMetadataVec,
-  pub warnings: Vec<BuildError>,
-  pub errors: Vec<BuildError>,
+  pub warnings: Vec<BuildDiagnostic>,
+  pub errors: Vec<BuildDiagnostic>,
   pub ast_table: IndexVec<ModuleIdx, EcmaAst>,
   pub input_options: &'a SharedOptions,
   pub used_symbol_refs: FxHashSet<SymbolRef>,

--- a/crates/rolldown/src/stages/link_stage/sort_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/sort_modules.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use rolldown_common::{Module, ModuleIdx};
-use rolldown_error::BuildError;
+use rolldown_error::BuildDiagnostic;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::LinkStage;
@@ -116,7 +116,7 @@ impl<'a> LinkStage<'a> {
           .filter_map(|id| self.module_table.modules[id].as_ecma())
           .map(|module| module.resource_id.to_string())
           .collect::<Vec<_>>();
-        self.warnings.push(BuildError::circular_dependency(paths).with_severity_warning());
+        self.warnings.push(BuildDiagnostic::circular_dependency(paths).with_severity_warning());
       }
     }
 

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -6,7 +6,7 @@ use futures::future::join_all;
 use oxc::index::IndexVec;
 use rolldown_common::{EntryPoint, ImportKind, ModuleIdx, ModuleTable, ResolvedRequestInfo};
 use rolldown_ecmascript::EcmaAst;
-use rolldown_error::BuildError;
+use rolldown_error::BuildDiagnostic;
 use rolldown_fs::OsFileSystem;
 use rolldown_plugin::{HookResolveIdExtraOptions, SharedPluginDriver};
 use rolldown_resolver::ResolveError;
@@ -24,7 +24,7 @@ pub struct ScanStage {
   plugin_driver: SharedPluginDriver,
   fs: OsFileSystem,
   resolver: SharedResolver,
-  pub errors: Vec<BuildError>,
+  pub errors: Vec<BuildDiagnostic>,
 }
 
 #[derive(Debug)]
@@ -34,8 +34,8 @@ pub struct ScanStageOutput {
   pub entry_points: Vec<EntryPoint>,
   pub symbols: Symbols,
   pub runtime: RuntimeModuleBrief,
-  pub warnings: Vec<BuildError>,
-  pub errors: Vec<BuildError>,
+  pub warnings: Vec<BuildDiagnostic>,
+  pub errors: Vec<BuildDiagnostic>,
 }
 
 impl ScanStage {
@@ -124,10 +124,10 @@ impl ScanStage {
         }
         Err(e) => match e {
           ResolveError::NotFound(..) => {
-            self.errors.push(BuildError::unresolved_entry(args.specifier, None));
+            self.errors.push(BuildDiagnostic::unresolved_entry(args.specifier, None));
           }
           ResolveError::PackagePathNotExported(..) => {
-            self.errors.push(BuildError::unresolved_entry(args.specifier, Some(e)));
+            self.errors.push(BuildDiagnostic::unresolved_entry(args.specifier, Some(e)));
           }
           _ => {
             return Err(e.into());

--- a/crates/rolldown/src/types/bundle_output.rs
+++ b/crates/rolldown/src/types/bundle_output.rs
@@ -1,9 +1,9 @@
 use rolldown_common::Output;
-use rolldown_error::BuildError;
+use rolldown_error::BuildDiagnostic;
 
 #[derive(Default)]
 pub struct BundleOutput {
-  pub warnings: Vec<BuildError>,
-  pub errors: Vec<BuildError>,
+  pub warnings: Vec<BuildDiagnostic>,
+  pub errors: Vec<BuildDiagnostic>,
   pub assets: Vec<Output>,
 }

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -14,7 +14,7 @@ use crate::{
 use napi::{tokio::sync::Mutex, Env};
 use napi_derive::napi;
 use rolldown::Bundler as NativeBundler;
-use rolldown_error::{BuildError, DiagnosticOptions};
+use rolldown_error::{BuildDiagnostic, DiagnosticOptions};
 
 #[napi]
 pub struct Bundler {
@@ -146,7 +146,7 @@ impl Bundler {
     result.map_err(|e| napi::Error::from_reason(format!("Rolldown internal error: {e}")))
   }
 
-  fn handle_errors(&self, errs: Vec<BuildError>) -> napi::Error {
+  fn handle_errors(&self, errs: Vec<BuildDiagnostic>) -> napi::Error {
     errs.into_iter().for_each(|err| {
       eprintln!(
         "{}",
@@ -157,7 +157,7 @@ impl Bundler {
   }
 
   #[allow(clippy::print_stdout, unused_must_use)]
-  async fn handle_warnings(&self, warnings: Vec<BuildError>) {
+  async fn handle_warnings(&self, warnings: Vec<BuildDiagnostic>) {
     if let Some(log_level) = self.log_level {
       if log_level == BindingLogLevel::Silent {
         return;

--- a/crates/rolldown_error/src/build_error/error_constructors.rs
+++ b/crates/rolldown_error/src/build_error/error_constructors.rs
@@ -4,7 +4,7 @@ use arcstr::ArcStr;
 use oxc::span::Span;
 use rolldown_resolver::ResolveError;
 
-use super::BuildError;
+use super::BuildDiagnostic;
 
 use crate::events::{
   ambiguous_external_namespace::AmbiguousExternalNamespace,
@@ -15,7 +15,7 @@ use crate::events::{
   unresolved_import_treated_as_external::UnresolvedImportTreatedAsExternal, NapiError,
 };
 
-impl BuildError {
+impl BuildDiagnostic {
   // --- Rollup related
   pub fn entry_cannot_be_external(unresolved_id: impl AsRef<Path>) -> Self {
     Self::new_inner(ExternalEntry { id: unresolved_id.as_ref().to_path_buf() })

--- a/crates/rolldown_error/src/build_error/mod.rs
+++ b/crates/rolldown_error/src/build_error/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 use self::severity::Severity;
 
 #[derive(Debug)]
-pub struct BuildError {
+pub struct BuildDiagnostic {
   inner: Box<dyn BuildEvent>,
   source: Option<Box<dyn std::error::Error + 'static + Send + Sync>>,
   severity: Severity,
@@ -17,16 +17,16 @@ pub struct BuildError {
 
 fn _assert_build_error_send_sync() {
   fn _assert_send_sync<T: Send + Sync>() {}
-  _assert_send_sync::<BuildError>();
+  _assert_send_sync::<BuildDiagnostic>();
 }
 
-impl Display for BuildError {
+impl Display for BuildDiagnostic {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     self.inner.message(&DiagnosticOptions::default()).fmt(f)
   }
 }
 
-impl BuildError {
+impl BuildDiagnostic {
   pub fn kind(&self) -> crate::event_kind::EventKind {
     self.inner.kind()
   }
@@ -64,17 +64,17 @@ impl BuildError {
   }
 }
 
-impl From<std::io::Error> for BuildError {
+impl From<std::io::Error> for BuildDiagnostic {
   fn from(e: std::io::Error) -> Self {
     Self::new_inner(e)
   }
 }
 
 #[cfg(feature = "napi")]
-impl From<napi::Error> for BuildError {
+impl From<napi::Error> for BuildDiagnostic {
   fn from(e: napi::Error) -> Self {
-    BuildError::napi_error(e.status.to_string(), e.reason)
+    BuildDiagnostic::napi_error(e.status.to_string(), e.reason)
   }
 }
 
-pub type BuildResult<T> = std::result::Result<T, BuildError>;
+pub type BuildResult<T> = std::result::Result<T, BuildDiagnostic>;

--- a/crates/rolldown_error/src/lib.rs
+++ b/crates/rolldown_error/src/lib.rs
@@ -5,7 +5,7 @@ mod events;
 mod types;
 
 pub use crate::{
-  build_error::{BuildError, BuildResult},
+  build_error::{BuildDiagnostic, BuildResult},
   event_kind::EventKind,
   types::diagnostic_options::DiagnosticOptions,
 };

--- a/crates/rolldown_testing/src/case/case.rs
+++ b/crates/rolldown_testing/src/case/case.rs
@@ -5,7 +5,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rolldown::BundleOutput;
 use rolldown_common::Output;
-use rolldown_error::{BuildError, DiagnosticOptions};
+use rolldown_error::{BuildDiagnostic, DiagnosticOptions};
 use rolldown_sourcemap::SourcemapVisualizer;
 
 pub struct Case {
@@ -124,7 +124,7 @@ impl Case {
     self.snapshot.push_str(&stats);
   }
 
-  fn render_errors_to_snapshot(&mut self, mut errors: Vec<BuildError>) {
+  fn render_errors_to_snapshot(&mut self, mut errors: Vec<BuildDiagnostic>) {
     self.snapshot.push_str("# Errors\n\n");
     errors.sort_by_key(|e| e.kind().to_string());
     let diagnostics = errors.into_iter().map(|e| {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. follow https://github.com/rolldown/rolldown/pull/1634, since we have https://github.com/rolldown/rolldown/pull/1634/files#diff-f68450ab0a8cfe082912fd82beb770be4085872ef174fd398796eb4eff2e8aceR237.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
