### PR TITLE
chore: add minify benchmark

### DIFF
--- a/crates/bench/benches/bundle.rs
+++ b/crates/bench/benches/bundle.rs
@@ -5,7 +5,7 @@ use rolldown_testing::utils::assert_bundled;
 fn criterion_benchmark(c: &mut Criterion) {
   let mut group = c.benchmark_group("bundle");
 
-  let derive_options = DeriveOptions { sourcemap: true };
+  let derive_options = DeriveOptions { sourcemap: true, minify: true };
 
   let items = [
     derive_benchmark_items(

--- a/crates/bench/benches/scan.rs
+++ b/crates/bench/benches/scan.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 fn criterion_benchmark(c: &mut Criterion) {
   let mut group = c.benchmark_group("scan");
 
-  let derive_options = DeriveOptions { sourcemap: true };
+  let derive_options = DeriveOptions { sourcemap: false, minify: false };
 
   let items = [
     derive_benchmark_items(

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -14,6 +14,7 @@ pub struct BenchItem {
 
 pub struct DeriveOptions {
   pub sourcemap: bool,
+  pub minify: bool,
 }
 
 pub fn derive_benchmark_items(
@@ -25,11 +26,36 @@ pub fn derive_benchmark_items(
     vec![BenchItem { name: name.clone(), options: Box::new(create_bundler_options.clone()) }];
 
   if derive_options.sourcemap {
+    let create_bundler_options = create_bundler_options.clone();
     ret.push(BenchItem {
       name: format!("{}-sourcemap", name),
       options: Box::new(move || {
         let mut options = create_bundler_options();
         options.sourcemap = Some(rolldown::SourceMapType::File);
+        options
+      }),
+    });
+  }
+
+  if derive_options.minify {
+    let create_bundler_options = create_bundler_options.clone();
+    ret.push(BenchItem {
+      name: format!("{}-minify", name),
+      options: Box::new(move || {
+        let mut options = create_bundler_options();
+        options.minify = Some(true);
+        options
+      }),
+    });
+  }
+
+  if derive_options.sourcemap && derive_options.minify {
+    ret.push(BenchItem {
+      name: format!("{}-minify-sourcemap", name),
+      options: Box::new(move || {
+        let mut options = create_bundler_options();
+        options.sourcemap = Some(rolldown::SourceMapType::File);
+        options.minify = Some(true);
         options
       }),
     });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The pr add the minify benchmark and minify-sourcemap benchmark. Here remove `scan-xx-sourcemap` benchmark, because it's sourcmap is unmeaning, it will not generate sourcemap.

Also add it to see for https://github.com/rolldown/rolldown/pull/1664. i think render chunk remapping case is small..

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
