### PR TITLE
chore: add js side minify benchmark

### DIFF
--- a/packages/bench/src/suites/index.js
+++ b/packages/bench/src/suites/index.js
@@ -16,6 +16,7 @@ export const suitesForCI = [
     },
     derived: {
       sourcemap: true,
+      minify: true,
     },
   },
   suiteRomeTs,
@@ -65,6 +66,34 @@ export function expandSuitesWithDerived(suites) {
       _.set(derived, 'esbuildOptions.sourcemap', true)
       _.set(derived, 'rolldownOptions.output.sourcemap', true)
       _.set(derived, 'rollupOptions.output.sourcemap', true)
+      expanded.push(derived)
+    }
+    if (suite.derived?.minify) {
+      const derived = _.cloneDeepWith(suite, (value) => {
+        // We should pay attention to this while using singletons in config
+        if (typeof value === 'function') {
+          return value
+        }
+      })
+      derived.title = `${suite.title}-minify`
+      delete derived.derived
+      _.set(derived, 'esbuildOptions.minify', true)
+      _.set(derived, 'rolldownOptions.output.minify', true)
+      expanded.push(derived)
+    }
+    if (suite.derived?.minify && suite.derived?.sourcemap) {
+      const derived = _.cloneDeepWith(suite, (value) => {
+        // We should pay attention to this while using singletons in config
+        if (typeof value === 'function') {
+          return value
+        }
+      })
+      derived.title = `${suite.title}-minify-sourcemap`
+      delete derived.derived
+      _.set(derived, 'esbuildOptions.sourcemap', true)
+      _.set(derived, 'rolldownOptions.output.sourcemap', true)
+      _.set(derived, 'esbuildOptions.minify', true)
+      _.set(derived, 'rolldownOptions.output.minify', true)
       expanded.push(derived)
     }
     return expanded

--- a/packages/bench/src/types.d.ts
+++ b/packages/bench/src/types.d.ts
@@ -8,6 +8,7 @@ export interface BenchSuite {
   derived?: {
     // Whether to have an extra round for benchmarking with enabling sourcemap
     sourcemap?: boolean
+    minify?: boolean
   }
   title: string
   inputs: string[]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It is result at my local.

```
threejs10x-minify:
  esbuild: 188.80ms (fastest)
  rolldown (default): 440.56ms
Summary(threejs10x-minify):
  esbuild is
  - 2.33 times faster than rolldown (default)
threejs10x-minify-sourcemap:
  esbuild: 297.87ms (fastest)
  rolldown (default): 633.30ms
Summary(threejs10x-minify-sourcemap):
  esbuild is
  - 2.13 times faster than rolldown (default)
```
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
