### PR TITLE
refactor(rust): add `EcmaAstIdx` to index `EcmaAst`

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -36,7 +36,12 @@ impl Generator for EcmaGenerator {
         (
           m.idx,
           m.id.clone(),
-          render_ecma_module(m, &ctx.link_output.ast_table[m.idx], m.id.as_ref(), ctx.options),
+          render_ecma_module(
+            m,
+            &ctx.link_output.ast_table[m.ecma_ast_idx()].0,
+            m.id.as_ref(),
+            ctx.options,
+          ),
         )
       })
       .collect::<Vec<_>>();

--- a/crates/rolldown/src/ecmascript/ecma_module_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_factory.rs
@@ -156,6 +156,7 @@ impl ModuleFactory for EcmaModuleFactory {
     // TODO: Should we check if there are `check_side_effects_for` returns false but there are side effects in the module?
     let module = EcmaModule {
       source: ast.source().clone(),
+      ecma_ast_idx: None,
       idx: ctx.module_index,
       repr_name,
       stable_id,

--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -28,7 +28,7 @@ pub fn render_cjs(
     .filter_map(|id| ctx.link_output.module_table.modules[*id].as_ecma())
     .all(|ecma_module| {
       let is_esm = matches!(&ecma_module.exports_kind, ExportsKind::Esm);
-      is_esm || ctx.link_output.ast_table[ecma_module.idx].contains_use_strict
+      is_esm || ctx.link_output.ast_table[ecma_module.ecma_ast_idx()].0.contains_use_strict
     });
 
   if are_modules_all_strict {

--- a/crates/rolldown/src/module_loader/runtime_ecma_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_ecma_module_task.rs
@@ -77,6 +77,7 @@ impl RuntimeEcmaModuleTask {
     let module = EcmaModule {
       source,
       idx: self.module_id,
+      ecma_ast_idx: None,
       repr_name,
       stable_id: RUNTIME_MODULE_ID.to_string(),
       id: ModuleId::new(RUNTIME_MODULE_ID),

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -62,14 +62,14 @@ impl<'a> GenerateStage<'a> {
       deconflict_chunk_symbols(chunk, self.link_output);
     });
 
-    let ast_table_iter = self.link_output.ast_table.iter_mut_enumerated();
+    let ast_table_iter = self.link_output.ast_table.iter_mut();
     ast_table_iter
       .par_bridge()
-      .filter(|(id, _)| {
-        self.link_output.module_table.modules[*id].as_ecma().map_or(false, |m| m.is_included)
+      .filter(|(_ast, owner)| {
+        self.link_output.module_table.modules[*owner].as_ecma().map_or(false, |m| m.is_included)
       })
-      .for_each(|(id, ast)| {
-        let Module::Ecma(module) = &self.link_output.module_table.modules[id] else {
+      .for_each(|(ast, owner)| {
+        let Module::Ecma(module) = &self.link_output.module_table.modules[*owner] else {
           return;
         };
         let chunk_id = chunk_graph.module_to_chunk[module.idx].unwrap();

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -5,7 +5,6 @@ use rolldown_common::{
   EntryPoint, ExportsKind, ImportKind, Module, ModuleIdx, ModuleTable, OutputFormat, StmtInfo,
   SymbolRef, WrapKind,
 };
-use rolldown_ecmascript::EcmaAst;
 use rolldown_error::BuildDiagnostic;
 use rolldown_utils::{
   ecma_script::legitimize_identifier_name,
@@ -15,6 +14,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
   runtime::RuntimeModuleBrief,
+  type_alias::IndexEcmaAst,
   types::{
     linking_metadata::{LinkingMetadata, LinkingMetadataVec},
     symbols::Symbols,
@@ -35,7 +35,7 @@ mod wrapping;
 pub struct LinkStageOutput {
   pub module_table: ModuleTable,
   pub entries: Vec<EntryPoint>,
-  pub ast_table: IndexVec<ModuleIdx, EcmaAst>,
+  pub ast_table: IndexEcmaAst,
   // pub sorted_modules: Vec<NormalModuleId>,
   pub metas: LinkingMetadataVec,
   pub symbols: Symbols,
@@ -56,7 +56,7 @@ pub struct LinkStage<'a> {
   pub metas: LinkingMetadataVec,
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
-  pub ast_table: IndexVec<ModuleIdx, EcmaAst>,
+  pub ast_table: IndexEcmaAst,
   pub input_options: &'a SharedOptions,
   pub used_symbol_refs: FxHashSet<SymbolRef>,
   pub top_level_member_expr_resolved_cache: FxHashMap<SymbolRef, MemberChainToResolvedSymbolRef>,

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use arcstr::ArcStr;
 use futures::future::join_all;
-use oxc::index::IndexVec;
-use rolldown_common::{EntryPoint, ImportKind, ModuleIdx, ModuleTable, ResolvedId};
-use rolldown_ecmascript::EcmaAst;
+use rolldown_common::{EntryPoint, ImportKind, ModuleTable, ResolvedId};
 use rolldown_error::{BuildDiagnostic, DiagnosableResult};
 use rolldown_fs::OsFileSystem;
 use rolldown_plugin::{HookResolveIdExtraOptions, SharedPluginDriver};
@@ -14,6 +12,7 @@ use rolldown_resolver::ResolveError;
 use crate::{
   module_loader::{module_loader::ModuleLoaderOutput, ModuleLoader},
   runtime::RuntimeModuleBrief,
+  type_alias::IndexEcmaAst,
   types::symbols::Symbols,
   utils::resolve_id::resolve_id,
   SharedOptions, SharedResolver,
@@ -29,7 +28,7 @@ pub struct ScanStage {
 #[derive(Debug)]
 pub struct ScanStageOutput {
   pub module_table: ModuleTable,
-  pub index_ecma_ast: IndexVec<ModuleIdx, EcmaAst>,
+  pub index_ecma_ast: IndexEcmaAst,
   pub entry_points: Vec<EntryPoint>,
   pub symbols: Symbols,
   pub runtime: RuntimeModuleBrief,

--- a/crates/rolldown/src/type_alias.rs
+++ b/crates/rolldown/src/type_alias.rs
@@ -1,8 +1,10 @@
 use indexmap::IndexSet;
 use oxc::index::IndexVec;
-use rolldown_common::{Asset, AssetIdx, Chunk, ChunkIdx, PreliminaryAsset};
+use rolldown_common::{Asset, AssetIdx, Chunk, ChunkIdx, EcmaAstIdx, ModuleIdx, PreliminaryAsset};
+use rolldown_ecmascript::EcmaAst;
 
 pub type IndexChunks = IndexVec<ChunkIdx, Chunk>;
 pub type IndexChunkToAssets = IndexVec<ChunkIdx, IndexSet<AssetIdx>>;
 pub type IndexAssets = IndexVec<AssetIdx, Asset>;
 pub type IndexPreliminaryAssets = IndexVec<AssetIdx, PreliminaryAsset>;
+pub type IndexEcmaAst = IndexVec<EcmaAstIdx, (EcmaAst, ModuleIdx)>;

--- a/crates/rolldown_common/src/ecmascript/ecma_module.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_module.rs
@@ -6,7 +6,7 @@ use crate::{
   ImportRecordIdx, LocalExport, ModuleDefFormat, ModuleId, ModuleIdx, ModuleInfo, NamedImport,
   StmtInfo, StmtInfos, SymbolRef,
 };
-use crate::{IndexModules, ModuleType};
+use crate::{EcmaAstIdx, IndexModules, ModuleType};
 use arcstr::ArcStr;
 use oxc::index::IndexVec;
 use oxc::span::Span;
@@ -18,6 +18,7 @@ pub struct EcmaModule {
   pub exec_order: u32,
   pub source: ArcStr,
   pub idx: ModuleIdx,
+  pub ecma_ast_idx: Option<EcmaAstIdx>,
   pub is_user_defined_entry: bool,
   pub id: ModuleId,
   /// `stable_id` is calculated based on `id` to be stable across machine and os.
@@ -145,6 +146,10 @@ impl EcmaModule {
   //     });
   //   }
   // }
+
+  pub fn ecma_ast_idx(&self) -> EcmaAstIdx {
+    self.ecma_ast_idx.expect("ecma_ast_idx should be set in this stage")
+  }
 }
 
 #[derive(Debug)]

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -52,6 +52,7 @@ pub use crate::{
   types::bundler_file_system::BundlerFileSystem,
   types::chunk_idx::ChunkIdx,
   types::chunk_kind::ChunkKind,
+  types::ecma_ast_idx::EcmaAstIdx,
   types::entry_point::{EntryPoint, EntryPointKind},
   types::exports_kind::ExportsKind,
   types::external_module_idx::ExternalModuleIdx,

--- a/crates/rolldown_common/src/types/ecma_ast_idx.rs
+++ b/crates/rolldown_common/src/types/ecma_ast_idx.rs
@@ -1,0 +1,3 @@
+oxc::index::define_index_type! {
+  pub struct EcmaAstIdx = u32;
+}

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -6,6 +6,7 @@ pub mod ast_scopes;
 pub mod bundler_file_system;
 pub mod chunk_idx;
 pub mod chunk_kind;
+pub mod ecma_ast_idx;
 pub mod entry_point;
 pub mod exports_kind;
 pub mod external_module_idx;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Plain `CssModule` is gonna have a `ModuleIdx`, but it doesn't have a `EcmaAst`. So we use `EcmaAstIdx` instead of `ModuleIdx` anymore.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
