### PR TITLE
refactor(rust): return `Module` instead of `EcmaModule` in `EcmaModuleTask`

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_factory.rs
@@ -186,11 +186,10 @@ impl ModuleFactory for EcmaModuleFactory {
     };
 
     Ok(Ok(CreateModuleReturn {
-      module,
+      module: module.into(),
       resolved_deps,
       raw_import_records: import_records,
-      ecma_ast: ast,
-      ast_symbol,
+      ecma_related: Some((ast, ast_symbol)),
     }))
   }
 }

--- a/crates/rolldown/src/module_loader/task_result.rs
+++ b/crates/rolldown/src/module_loader/task_result.rs
@@ -1,5 +1,5 @@
 use oxc::index::IndexVec;
-use rolldown_common::{EcmaModule, ImportRecordIdx, ModuleIdx, RawImportRecord, ResolvedId};
+use rolldown_common::{ImportRecordIdx, Module, ModuleIdx, RawImportRecord, ResolvedId};
 use rolldown_ecmascript::EcmaAst;
 use rolldown_error::BuildDiagnostic;
 
@@ -7,10 +7,9 @@ use crate::types::ast_symbols::AstSymbols;
 
 pub struct NormalModuleTaskResult {
   pub module_idx: ModuleIdx,
-  pub ast_symbol: AstSymbols,
   pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
   pub warnings: Vec<BuildDiagnostic>,
-  pub module: EcmaModule,
-  pub ast: EcmaAst,
+  pub module: Module,
+  pub ecma_related: Option<(EcmaAst, AstSymbols)>,
 }

--- a/crates/rolldown/src/types/module_factory.rs
+++ b/crates/rolldown/src/types/module_factory.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use futures::future::join_all;
 use oxc::index::IndexVec;
 use rolldown_common::{
-  side_effects::HookSideEffects, EcmaModule, ImportRecordIdx, ModuleDefFormat, ModuleIdx,
-  ModuleType, RawImportRecord, ResolvedId, StrOrBytes,
+  side_effects::HookSideEffects, ImportRecordIdx, Module, ModuleDefFormat, ModuleIdx, ModuleType,
+  RawImportRecord, ResolvedId, StrOrBytes,
 };
 use rolldown_ecmascript::EcmaAst;
 use rolldown_error::{BuildDiagnostic, DiagnosableResult};
@@ -161,11 +161,10 @@ pub struct CreateModuleArgs {
 }
 
 pub struct CreateModuleReturn {
-  pub module: EcmaModule,
+  pub module: Module,
   pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
-  pub ast_symbol: AstSymbols,
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
-  pub ecma_ast: EcmaAst,
+  pub ecma_related: Option<(EcmaAst, AstSymbols)>,
 }
 
 pub trait ModuleFactory {

--- a/crates/rolldown_common/src/module/mod.rs
+++ b/crates/rolldown_common/src/module/mod.rs
@@ -1,6 +1,8 @@
 pub mod external_module;
 
-use crate::{EcmaModule, ExternalModule, ModuleIdx};
+use oxc::index::IndexVec;
+
+use crate::{EcmaAstIdx, EcmaModule, ExternalModule, ImportRecord, ImportRecordIdx, ModuleIdx};
 
 #[derive(Debug)]
 pub enum Module {
@@ -77,6 +79,20 @@ impl Module {
     match self {
       Module::External(v) => Some(v),
       Module::Ecma(_) => None,
+    }
+  }
+
+  pub fn set_import_records(&mut self, records: IndexVec<ImportRecordIdx, ImportRecord>) {
+    match self {
+      Module::Ecma(v) => v.import_records = records,
+      Module::External(v) => v.import_records = records,
+    }
+  }
+
+  pub fn set_ecma_ast_idx(&mut self, idx: EcmaAstIdx) {
+    match self {
+      Module::Ecma(v) => v.ecma_ast_idx = Some(idx),
+      Module::External(_) => panic!("set_ecma_ast_idx should be called on EcmaModule"),
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Gonna reuse `EcmaModuleTask` to create `CssModule`, since it also need to go through a bunch of plugin hooks. It's not worth to duplicate these code.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
