### PR TITLE
chore: deserialize TreeshakeOptions

### DIFF
--- a/crates/rolldown/tests/esbuild/dce/disable_tree_shaking/_config.json
+++ b/crates/rolldown/tests/esbuild/dce/disable_tree_shaking/_config.json
@@ -6,7 +6,7 @@
         "import": "entry.jsx"
       }
     ],
-    "treeshake": false,
+    "treeshake": "False",
     "external": [
       "react/jsx-runtime"
     ]

--- a/crates/rolldown/tests/esbuild/default/keep_names_class_static_name/_config.json
+++ b/crates/rolldown/tests/esbuild/default/keep_names_class_static_name/_config.json
@@ -6,6 +6,6 @@
         "import": "entry.js"
       }
     ],
-    "treeshake": false
+    "treeshake": "False"
   }
 }

--- a/crates/rolldown/tests/esbuild/default/var_relocating_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/default/var_relocating_bundle/_config.json
@@ -22,6 +22,6 @@
         "import": "function-nested.js"
       }
     ],
-    "treeshake": false
+    "treeshake": "False"
   }
 }

--- a/crates/rolldown/tests/esbuild/splitting/duplicate_chunk_collision/_config.json
+++ b/crates/rolldown/tests/esbuild/splitting/duplicate_chunk_collision/_config.json
@@ -18,6 +18,6 @@
         "import": "./d.js"
       }
     ],
-    "treeshake": false
+    "treeshake": "False"
   }
 }

--- a/crates/rolldown/tests/fixtures/cjs_compat/basic_commonjs/_config.json
+++ b/crates/rolldown/tests/fixtures/cjs_compat/basic_commonjs/_config.json
@@ -1,5 +1,5 @@
 {
   "config": {
-    "treeshake": false
+    "treeshake": "False"
   }
 }

--- a/crates/rolldown/tests/fixtures/deconflict/default_function/_config.json
+++ b/crates/rolldown/tests/fixtures/deconflict/default_function/_config.json
@@ -4,6 +4,6 @@
     "external": [
       "assert"
     ],
-    "treeshake": false
+    "treeshake": "False"
   }
 }

--- a/crates/rolldown/tests/fixtures/deconflict/wrapped_esm_default_function/_config.json
+++ b/crates/rolldown/tests/fixtures/deconflict/wrapped_esm_default_function/_config.json
@@ -4,6 +4,6 @@
     "external": [
       "node:assert"
     ],
-    "treeshake": false
+    "treeshake": "False"
   }
 }

--- a/crates/rolldown/tests/fixtures/deconflict/wrapped_esm_export_named_function/_config.json
+++ b/crates/rolldown/tests/fixtures/deconflict/wrapped_esm_export_named_function/_config.json
@@ -4,6 +4,6 @@
     "external": [
       "assert"
     ],
-    "treeshake": false
+    "treeshake": "False"
   }
 }

--- a/crates/rolldown/tests/fixtures/function/external/commonjs_reexport_external/_config.json
+++ b/crates/rolldown/tests/fixtures/function/external/commonjs_reexport_external/_config.json
@@ -4,6 +4,6 @@
     "external": [
       "external"
     ],
-    "treeshake": false
+    "treeshake": "False"
   }
 }

--- a/crates/rolldown/tests/fixtures/function/external/export_external/_config.json
+++ b/crates/rolldown/tests/fixtures/function/external/export_external/_config.json
@@ -4,6 +4,6 @@
     "external": [
       "external"
     ],
-    "treeshake": false
+    "treeshake": "False"
   }
 }

--- a/crates/rolldown/tests/fixtures/function/external/import_external/_config.json
+++ b/crates/rolldown/tests/fixtures/function/external/import_external/_config.json
@@ -4,6 +4,6 @@
     "external": [
       "external"
     ],
-    "treeshake": false
+    "treeshake": "False"
   }
 }

--- a/crates/rolldown/tests/fixtures/rollup/assignment-patterns/_config.json
+++ b/crates/rolldown/tests/fixtures/rollup/assignment-patterns/_config.json
@@ -3,6 +3,6 @@
     "external": [
       "assert"
     ],
-    "treeshake": false
+    "treeshake": "False"
   }
 }

--- a/crates/rolldown/tests/fixtures/tree_shaking/pure_annotation/_config.json
+++ b/crates/rolldown/tests/fixtures/tree_shaking/pure_annotation/_config.json
@@ -2,7 +2,7 @@
   "config": {
     "treeshake": {
       "Option": {
-        "module_side_effects": true
+        "moduleSideEffects": true
       }
     }
   }

--- a/crates/rolldown/tests/fixtures/tree_shaking/pure_annotation/_config.json
+++ b/crates/rolldown/tests/fixtures/tree_shaking/pure_annotation/_config.json
@@ -1,5 +1,9 @@
 {
   "config": {
-    "treeshake": true
+    "treeshake": {
+      "Option": {
+        "module_side_effects": true
+      }
+    }
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -72,11 +72,7 @@ pub struct BundlerOptions {
   pub module_types: Option<HashMap<String, ModuleType>>,
   // --- options for resolve
   pub resolve: Option<ResolveOptions>,
-  #[cfg_attr(
-    feature = "deserialize_bundler_options",
-    serde(deserialize_with = "deserialize_treeshake", default),
-    schemars(with = "Option<bool>")
-  )]
+  #[cfg_attr(feature = "deserialize_bundler_options", serde(default))]
   pub treeshake: TreeshakeOptions,
   pub experimental: Option<ExperimentalOptions>,
   pub minify: Option<bool>,
@@ -98,18 +94,4 @@ where
 {
   let deserialized = Option::<String>::deserialize(deserializer)?;
   Ok(deserialized.map(|s| AddonOutputOption::String(Some(s))))
-}
-
-#[cfg(feature = "deserialize_bundler_options")]
-fn deserialize_treeshake<'de, D>(deserializer: D) -> Result<TreeshakeOptions, D::Error>
-where
-  D: Deserializer<'de>,
-{
-  let deserialized = Option::<bool>::deserialize(deserializer)?;
-  match deserialized {
-    Some(false) => Ok(TreeshakeOptions::False),
-    Some(true) | None => Ok(TreeshakeOptions::Option(types::treeshake::InnerOptions {
-      module_side_effects: types::treeshake::ModuleSideEffects::Boolean(true),
-    })),
-  }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
@@ -40,7 +40,11 @@ impl TreeshakeOptions {
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "deserialize_bundler_options", derive(Deserialize, JsonSchema))]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
+  serde(rename_all = "camelCase", deny_unknown_fields)
+)]
 pub struct InnerOptions {
   #[cfg_attr(
     feature = "deserialize_bundler_options",

--- a/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
@@ -1,6 +1,11 @@
 use crate::types::js_regex::HybridRegex;
+#[cfg(feature = "deserialize_bundler_options")]
+use schemars::JsonSchema;
+#[cfg(feature = "deserialize_bundler_options")]
+use serde::{Deserialize, Deserializer};
 
 #[derive(Debug)]
+#[cfg_attr(feature = "deserialize_bundler_options", derive(Deserialize, JsonSchema))]
 pub enum TreeshakeOptions {
   False,
   Option(InnerOptions),
@@ -35,6 +40,24 @@ impl TreeshakeOptions {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "deserialize_bundler_options", derive(Deserialize, JsonSchema))]
 pub struct InnerOptions {
+  #[cfg_attr(
+    feature = "deserialize_bundler_options",
+    serde(deserialize_with = "deserialize_module_side_effects"),
+    schemars(with = "Option<bool>")
+  )]
   pub module_side_effects: ModuleSideEffects,
+}
+
+#[cfg(feature = "deserialize_bundler_options")]
+fn deserialize_module_side_effects<'de, D>(deserializer: D) -> Result<ModuleSideEffects, D::Error>
+where
+  D: Deserializer<'de>,
+{
+  let deserialized = Option::<bool>::deserialize(deserializer)?;
+  match deserialized {
+    Some(false) => Ok(ModuleSideEffects::Boolean(false)),
+    Some(true) | None => Ok(ModuleSideEffects::Boolean(true)),
+  }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -201,13 +201,14 @@
     "InnerOptions": {
       "type": "object",
       "properties": {
-        "module_side_effects": {
+        "moduleSideEffects": {
           "type": [
             "boolean",
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "InputItem": {
       "type": "object",

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -181,10 +181,7 @@
           ]
         },
         "treeshake": {
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "$ref": "#/definitions/TreeshakeOptions"
         }
       },
       "additionalProperties": false
@@ -200,6 +197,17 @@
         }
       },
       "additionalProperties": false
+    },
+    "InnerOptions": {
+      "type": "object",
+      "properties": {
+        "module_side_effects": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
     },
     "InputItem": {
       "type": "object",
@@ -392,6 +400,28 @@
         "File",
         "Inline",
         "Hidden"
+      ]
+    },
+    "TreeshakeOptions": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "False"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Option"
+          ],
+          "properties": {
+            "Option": {
+              "$ref": "#/definitions/InnerOptions"
+            }
+          },
+          "additionalProperties": false
+        }
       ]
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Before we can't add ` tree_shake: { modulesideEffects: false }` config, the pr intend to support it. The default sturcture is ugly, but it could be work at now.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
