### PR TITLE
feat: add invalid export option to generate diagnostic

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -1,5 +1,5 @@
 use crate::{
-  types::generator::{GenerateContext, Generator},
+  types::generator::{GenerateContext, GenerateOutput, Generator},
   utils::{chunk::generate_rendered_chunk, render_ecma_module::render_ecma_module},
 };
 
@@ -21,9 +21,7 @@ pub struct EcmaGenerator;
 
 impl Generator for EcmaGenerator {
   #[allow(clippy::too_many_lines)]
-  async fn render_preliminary_assets<'a>(
-    ctx: &GenerateContext<'a>,
-  ) -> Result<Vec<PreliminaryAsset>> {
+  async fn render_preliminary_assets<'a>(ctx: &mut GenerateContext<'a>) -> Result<GenerateOutput> {
     let mut rendered_modules = FxHashMap::default();
 
     let rendered_module_sources = ctx
@@ -106,18 +104,22 @@ impl Generator for EcmaGenerator {
       map.set_sources(sources.iter().map(std::convert::AsRef::as_ref).collect::<Vec<_>>());
     }
 
-    Ok(vec![PreliminaryAsset {
-      origin_chunk: ctx.chunk_idx,
-      content,
-      map,
-      meta: AssetMeta::from(EcmaAssetMeta { rendered_chunk }),
-      augment_chunk_hash: None,
-      file_dir: file_dir.to_path_buf(),
-      preliminary_filename: ctx
-        .chunk
-        .preliminary_filename
-        .clone()
-        .expect("should have preliminary filename"),
-    }])
+    Ok(GenerateOutput {
+      assets: vec![PreliminaryAsset {
+        origin_chunk: ctx.chunk_idx,
+        content,
+        map,
+        meta: AssetMeta::from(EcmaAssetMeta { rendered_chunk }),
+        augment_chunk_hash: None,
+        file_dir: file_dir.to_path_buf(),
+        preliminary_filename: ctx
+          .chunk
+          .preliminary_filename
+          .clone()
+          .expect("should have preliminary filename"),
+      }],
+      errors: std::mem::take(&mut ctx.errors),
+      warnings: std::mem::take(&mut ctx.warnings),
+    })
   }
 }

--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub fn render_cjs(
-  ctx: &GenerateContext<'_>,
+  ctx: &mut GenerateContext<'_>,
   module_sources: RenderedModuleSources,
   banner: Option<String>,
   footer: Option<String>,
@@ -66,9 +66,7 @@ pub fn render_cjs(
     }
   });
 
-  if let Some(exports) =
-    render_chunk_exports(ctx.chunk, &ctx.link_output.runtime, ctx.link_output, ctx.options)
-  {
+  if let Some(exports) = render_chunk_exports(ctx) {
     concat_source.add_source(Box::new(RawSource::new(exports)));
   }
 

--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -1,4 +1,5 @@
 use rolldown_common::ExportsKind;
+use rolldown_error::DiagnosableResult;
 use rolldown_sourcemap::{ConcatSource, RawSource};
 
 use crate::{
@@ -17,7 +18,7 @@ pub fn render_cjs(
   module_sources: RenderedModuleSources,
   banner: Option<String>,
   footer: Option<String>,
-) -> ConcatSource {
+) -> DiagnosableResult<ConcatSource> {
   let mut concat_source = ConcatSource::default();
 
   // Add `use strict` directive if needed. This must come before the banner, because users might use banner to add hashbang.
@@ -66,7 +67,7 @@ pub fn render_cjs(
     }
   });
 
-  if let Some(exports) = render_chunk_exports(ctx) {
+  if let Some(exports) = render_chunk_exports(ctx)? {
     concat_source.add_source(Box::new(RawSource::new(exports)));
   }
 
@@ -74,7 +75,7 @@ pub fn render_cjs(
     concat_source.add_source(Box::new(RawSource::new(footer)));
   }
 
-  concat_source
+  Ok(concat_source)
 }
 
 fn render_cjs_chunk_imports(ctx: &GenerateContext<'_>) -> String {

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -1,4 +1,5 @@
 use rolldown_common::{ChunkKind, WrapKind};
+use rolldown_error::DiagnosableResult;
 use rolldown_sourcemap::{ConcatSource, RawSource};
 
 use crate::{
@@ -17,7 +18,7 @@ pub fn render_esm(
   module_sources: RenderedModuleSources,
   banner: Option<String>,
   footer: Option<String>,
-) -> ConcatSource {
+) -> DiagnosableResult<ConcatSource> {
   let mut concat_source = ConcatSource::default();
 
   if let Some(banner) = banner {
@@ -57,7 +58,7 @@ pub fn render_esm(
     }
   }
 
-  if let Some(exports) = render_chunk_exports(ctx) {
+  if let Some(exports) = render_chunk_exports(ctx)? {
     concat_source.add_source(Box::new(RawSource::new(exports)));
   }
 
@@ -65,7 +66,7 @@ pub fn render_esm(
     concat_source.add_source(Box::new(RawSource::new(footer)));
   }
 
-  concat_source
+  Ok(concat_source)
 }
 
 fn render_esm_chunk_imports(ctx: &GenerateContext<'_>) -> String {

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub fn render_esm(
-  ctx: &GenerateContext<'_>,
+  ctx: &mut GenerateContext<'_>,
   module_sources: RenderedModuleSources,
   banner: Option<String>,
   footer: Option<String>,
@@ -57,9 +57,7 @@ pub fn render_esm(
     }
   }
 
-  if let Some(exports) =
-    render_chunk_exports(ctx.chunk, &ctx.link_output.runtime, ctx.link_output, ctx.options)
-  {
+  if let Some(exports) = render_chunk_exports(ctx) {
     concat_source.add_source(Box::new(RawSource::new(exports)));
   }
 

--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -5,11 +5,11 @@ use crate::{
     determine_export_mode, get_export_items, render_chunk_exports,
   },
 };
-use rolldown_common::OutputExports;
+use rolldown_common::{ChunkKind, OutputExports};
 use rolldown_sourcemap::{ConcatSource, RawSource};
 
 pub fn render_iife(
-  ctx: &GenerateContext<'_>,
+  ctx: &mut GenerateContext<'_>,
   module_sources: RenderedModuleSources,
   banner: Option<String>,
   footer: Option<String>,
@@ -20,11 +20,18 @@ pub fn render_iife(
     concat_source.add_source(Box::new(RawSource::new(banner)));
   }
   // iife wrapper start
-  let has_exports = !get_export_items(ctx.chunk, ctx.link_output).is_empty();
+  let export_items = get_export_items(ctx.chunk, ctx.link_output);
+  let has_exports = !export_items.is_empty();
   // Since before rendering the `determine_export_mode` runs, `unwrap` here won't cause panic.
   // FIXME do not call `determine_export_mode` twice
+  let entry_module = match ctx.chunk.kind {
+    ChunkKind::EntryPoint { module, .. } => {
+      &ctx.link_output.module_table.modules[module].as_ecma().expect("should be ecma module")
+    }
+    ChunkKind::Common => unreachable!("iife should be entry point chunk"),
+  };
   let named_exports = matches!(
-    determine_export_mode(ctx.chunk, &ctx.options.exports, ctx.link_output).unwrap(),
+    determine_export_mode(&mut ctx.errors, &ctx.options.exports, entry_module, &export_items),
     OutputExports::Named
   );
 
@@ -48,9 +55,7 @@ pub fn render_iife(
   });
 
   // iife exports
-  if let Some(exports) =
-    render_chunk_exports(ctx.chunk, &ctx.link_output.runtime, ctx.link_output, ctx.options)
-  {
+  if let Some(exports) = render_chunk_exports(ctx) {
     concat_source.add_source(Box::new(RawSource::new(exports)));
     if named_exports {
       // We need to add `return exports;` here only if using `named`, because the default value is returned when using `default` in `render_chunk_exports`.

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -112,17 +112,7 @@ impl<'a> GenerateStage<'a> {
         }
       });
 
-    let mut assets = self.render_chunk_to_assets(&mut chunk_graph).await?;
-
-    // Make sure order of assets are deterministic
-    // TODO: use `preliminary_filename` on `Output::Asset` instead
-    assets.sort_unstable_by(|a, b| a.filename().cmp(b.filename()));
-
-    Ok(BundleOutput {
-      assets,
-      warnings: std::mem::take(&mut self.link_output.warnings),
-      errors: std::mem::take(&mut self.link_output.errors),
-    })
+    self.render_chunk_to_assets(&mut chunk_graph).await
   }
 
   // Notices:

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -159,21 +159,22 @@ impl<'a> GenerateStage<'a> {
         link_output: self.link_output,
         chunk_graph,
         plugin_driver: self.plugin_driver,
-        errors: vec![],
         warnings: vec![],
       };
       EcmaGenerator::render_preliminary_assets(&mut ctx).await
     }))
     .await?
     .into_iter()
-    .for_each(|generate_output| {
-      generate_output.assets.into_iter().for_each(|asset| {
-        let origin_chunk = asset.origin_chunk;
-        let asset_idx = index_preliminary_assets.push(asset);
-        index_chunk_to_assets[origin_chunk].insert(asset_idx);
-      });
-      errors.extend(generate_output.errors);
-      warnings.extend(generate_output.warnings);
+    .for_each(|result| match result {
+      Ok(generate_output) => {
+        generate_output.assets.into_iter().for_each(|asset| {
+          let origin_chunk = asset.origin_chunk;
+          let asset_idx = index_preliminary_assets.push(asset);
+          index_chunk_to_assets[origin_chunk].insert(asset_idx);
+        });
+        warnings.extend(generate_output.warnings);
+      }
+      Err(e) => errors.extend(e),
     });
 
     index_chunk_to_assets.iter_mut().for_each(|assets| {

--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -1,5 +1,5 @@
 use rolldown_common::{Chunk, ChunkIdx, NormalizedBundlerOptions, PreliminaryAsset};
-use rolldown_error::BuildDiagnostic;
+use rolldown_error::{BuildDiagnostic, DiagnosableResult};
 use rolldown_plugin::SharedPluginDriver;
 
 use crate::{chunk_graph::ChunkGraph, stages::link_stage::LinkStageOutput};
@@ -11,16 +11,16 @@ pub struct GenerateContext<'a> {
   pub link_output: &'a LinkStageOutput,
   pub chunk_graph: &'a ChunkGraph,
   pub plugin_driver: &'a SharedPluginDriver,
-  pub errors: Vec<BuildDiagnostic>,
   pub warnings: Vec<BuildDiagnostic>,
 }
 
 pub struct GenerateOutput {
   pub assets: Vec<PreliminaryAsset>,
-  pub errors: Vec<BuildDiagnostic>,
   pub warnings: Vec<BuildDiagnostic>,
 }
 
 pub trait Generator {
-  async fn render_preliminary_assets(ctx: &mut GenerateContext) -> anyhow::Result<GenerateOutput>;
+  async fn render_preliminary_assets(
+    ctx: &mut GenerateContext,
+  ) -> anyhow::Result<DiagnosableResult<GenerateOutput>>;
 }

--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -1,4 +1,5 @@
 use rolldown_common::{Chunk, ChunkIdx, NormalizedBundlerOptions, PreliminaryAsset};
+use rolldown_error::BuildDiagnostic;
 use rolldown_plugin::SharedPluginDriver;
 
 use crate::{chunk_graph::ChunkGraph, stages::link_stage::LinkStageOutput};
@@ -10,10 +11,16 @@ pub struct GenerateContext<'a> {
   pub link_output: &'a LinkStageOutput,
   pub chunk_graph: &'a ChunkGraph,
   pub plugin_driver: &'a SharedPluginDriver,
+  pub errors: Vec<BuildDiagnostic>,
+  pub warnings: Vec<BuildDiagnostic>,
+}
+
+pub struct GenerateOutput {
+  pub assets: Vec<PreliminaryAsset>,
+  pub errors: Vec<BuildDiagnostic>,
+  pub warnings: Vec<BuildDiagnostic>,
 }
 
 pub trait Generator {
-  async fn render_preliminary_assets(
-    ctx: &GenerateContext,
-  ) -> anyhow::Result<Vec<PreliminaryAsset>>;
+  async fn render_preliminary_assets(ctx: &mut GenerateContext) -> anyhow::Result<GenerateOutput>;
 }

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -1,35 +1,33 @@
 use rolldown_common::{
-  Chunk, ChunkKind, ExportsKind, NormalizedBundlerOptions, OutputExports, OutputFormat, SymbolRef,
-  WrapKind,
+  Chunk, ChunkKind, EcmaModule, ExportsKind, NormalizedBundlerOptions, OutputExports, OutputFormat,
+  SymbolRef, WrapKind,
 };
+use rolldown_error::BuildDiagnostic;
 use rolldown_rstr::Rstr;
 use rolldown_utils::ecma_script::is_validate_identifier_name;
 
-use crate::{runtime::RuntimeModuleBrief, stages::link_stage::LinkStageOutput};
+use crate::{stages::link_stage::LinkStageOutput, types::generator::GenerateContext};
 
-pub fn render_chunk_exports(
-  this: &Chunk,
-  _runtime: &RuntimeModuleBrief,
-  graph: &LinkStageOutput,
-  output_options: &NormalizedBundlerOptions,
-) -> Option<String> {
-  let export_items = get_export_items(this, graph);
+#[allow(clippy::too_many_lines)]
+pub fn render_chunk_exports(ctx: &mut GenerateContext<'_>) -> Option<String> {
+  let GenerateContext { chunk, link_output, options, errors, .. } = ctx;
+  let export_items = get_export_items(chunk, link_output);
 
   if export_items.is_empty() {
     return None;
   }
 
-  match output_options.format {
+  match options.format {
     OutputFormat::Esm => {
       let mut s = String::new();
       let rendered_items = export_items
         .into_iter()
         .map(|(exported_name, export_ref)| {
-          let canonical_ref = graph.symbols.par_canonical_ref_for(export_ref);
-          let symbol = graph.symbols.get(canonical_ref);
-          let canonical_name = &this.canonical_names[&canonical_ref];
+          let canonical_ref = link_output.symbols.par_canonical_ref_for(export_ref);
+          let symbol = link_output.symbols.get(canonical_ref);
+          let canonical_name = &chunk.canonical_names[&canonical_ref];
           if let Some(ns_alias) = &symbol.namespace_alias {
-            let canonical_ns_name = &this.canonical_names[&ns_alias.namespace_ref];
+            let canonical_ns_name = &chunk.canonical_names[&ns_alias.namespace_ref];
             let property_name = &ns_alias.property_name;
             s.push_str(&format!("var {canonical_name} = {canonical_ns_name}.{property_name};\n"));
           }
@@ -48,22 +46,24 @@ pub fn render_chunk_exports(
     }
     OutputFormat::Cjs | OutputFormat::Iife => {
       let mut s = String::new();
-      match this.kind {
+      match chunk.kind {
         ChunkKind::EntryPoint { module, .. } => {
-          let module = &graph.module_table.modules[module].as_ecma().unwrap();
+          let module =
+            &link_output.module_table.modules[module].as_ecma().expect("should be ecma module");
           if matches!(module.exports_kind, ExportsKind::Esm) {
-            let export_mode = determine_export_mode(this, &output_options.exports, graph).unwrap();
+            let export_mode =
+              determine_export_mode(errors, &options.exports, module, &export_items);
             if matches!(export_mode, OutputExports::Named) {
               s.push_str("Object.defineProperty(exports, '__esModule', { value: true });\n");
             }
             let rendered_items = export_items
               .into_iter()
               .map(|(exported_name, export_ref)| {
-                let canonical_ref = graph.symbols.par_canonical_ref_for(export_ref);
-                let symbol = graph.symbols.get(canonical_ref);
-                let canonical_name = &this.canonical_names[&canonical_ref];
+                let canonical_ref = link_output.symbols.par_canonical_ref_for(export_ref);
+                let symbol = link_output.symbols.get(canonical_ref);
+                let canonical_name = &chunk.canonical_names[&canonical_ref];
                 if let Some(ns_alias) = &symbol.namespace_alias {
-                  let canonical_ns_name = &this.canonical_names[&ns_alias.namespace_ref];
+                  let canonical_ns_name = &chunk.canonical_names[&ns_alias.namespace_ref];
                   let property_name = &ns_alias.property_name;
                   s.push_str(&format!(
                     "var {canonical_name} = {canonical_ns_name}.{property_name};\n"
@@ -79,7 +79,7 @@ pub fn render_chunk_exports(
                     }
                   }
                   OutputExports::Default => {
-                    if matches!(output_options.format, OutputFormat::Cjs) {
+                    if matches!(options.format, OutputFormat::Cjs) {
                       format!("module.exports = {canonical_name};")
                     } else {
                       format!("return {canonical_name};")
@@ -95,16 +95,16 @@ pub fn render_chunk_exports(
         }
         ChunkKind::Common => {
           export_items.into_iter().for_each(|(exported_name, export_ref)| {
-            let canonical_ref = graph.symbols.par_canonical_ref_for(export_ref);
-            let symbol = graph.symbols.get(canonical_ref);
-            let canonical_name = &this.canonical_names[&canonical_ref];
+            let canonical_ref = link_output.symbols.par_canonical_ref_for(export_ref);
+            let symbol = link_output.symbols.get(canonical_ref);
+            let canonical_name = &chunk.canonical_names[&canonical_ref];
             let assignee_name = if is_validate_identifier_name(&exported_name) {
               format!("exports.{exported_name}")
             } else {
               format!("exports['{exported_name}']")
             };
             if let Some(ns_alias) = &symbol.namespace_alias {
-              let canonical_ns_name = &this.canonical_names[&ns_alias.namespace_ref];
+              let canonical_ns_name = &chunk.canonical_names[&ns_alias.namespace_ref];
               let property_name = &ns_alias.property_name;
               s.push_str(&format!("{assignee_name} = {canonical_ns_name}.{property_name};;\n"));
             } else {
@@ -120,8 +120,8 @@ pub fn render_chunk_exports(
   }
 }
 
-pub fn get_export_items(this: &Chunk, graph: &LinkStageOutput) -> Vec<(Rstr, SymbolRef)> {
-  match this.kind {
+pub fn get_export_items(chunk: &Chunk, graph: &LinkStageOutput) -> Vec<(Rstr, SymbolRef)> {
+  match chunk.kind {
     ChunkKind::EntryPoint { module, .. } => {
       let meta = &graph.metas[module];
       meta
@@ -130,7 +130,7 @@ pub fn get_export_items(this: &Chunk, graph: &LinkStageOutput) -> Vec<(Rstr, Sym
         .collect::<Vec<_>>()
     }
     ChunkKind::Common => {
-      let mut tmp = this
+      let mut tmp = chunk
         .exports_to_other_chunks
         .iter()
         .map(|(export_ref, alias)| (alias.clone(), *export_ref))
@@ -144,12 +144,12 @@ pub fn get_export_items(this: &Chunk, graph: &LinkStageOutput) -> Vec<(Rstr, Sym
 }
 
 pub fn get_chunk_export_names(
-  this: &Chunk,
+  chunk: &Chunk,
   graph: &LinkStageOutput,
   options: &NormalizedBundlerOptions,
 ) -> Vec<String> {
   if matches!(options.format, OutputFormat::Esm) {
-    if let ChunkKind::EntryPoint { module: entry_id, .. } = &this.kind {
+    if let ChunkKind::EntryPoint { module: entry_id, .. } = &chunk.kind {
       let entry_meta = &graph.metas[*entry_id];
       if matches!(entry_meta.wrap_kind, WrapKind::Cjs) {
         return vec!["default".to_string()];
@@ -157,7 +157,7 @@ pub fn get_chunk_export_names(
     }
   }
 
-  get_export_items(this, graph)
+  get_export_items(chunk, graph)
     .into_iter()
     .map(|(exported_name, _)| exported_name.to_string())
     .collect::<Vec<_>>()
@@ -165,40 +165,41 @@ pub fn get_chunk_export_names(
 
 // Port from https://github.com/rollup/rollup/blob/master/src/utils/getExportMode.ts
 pub fn determine_export_mode(
-  this: &Chunk,
+  errors: &mut Vec<BuildDiagnostic>,
   export_mode: &OutputExports,
-  graph: &LinkStageOutput,
-) -> anyhow::Result<OutputExports> {
-  let export_items = get_export_items(this, graph);
-
+  module: &EcmaModule,
+  exports: &[(Rstr, SymbolRef)],
+) -> OutputExports {
   match export_mode {
-    OutputExports::Named => Ok(OutputExports::Named),
+    OutputExports::Named => OutputExports::Named,
     OutputExports::Default => {
-      if export_items.len() != 1 || export_items[0].0.as_str() != "default" {
-        // TODO improve the backtrace
-        anyhow::bail!(
-          "Chunk was specified for `output.exports`, but entry module has invalid exports"
-        );
+      if exports.len() != 1 || exports[0].0.as_str() != "default" {
+        errors.push(BuildDiagnostic::invalid_export_option(
+          "default".into(),
+          module.stable_id.as_str().into(),
+          exports.iter().map(|(name, _)| name.as_str().into()).collect(),
+        ));
       }
-      Ok(OutputExports::Default)
+      OutputExports::Default
     }
     OutputExports::None => {
-      if !export_items.is_empty() {
-        // TODO improve the backtrace
-        anyhow::bail!(
-          "Chunk was specified for `output.exports`, but entry module has invalid exports"
-        );
+      if !exports.is_empty() {
+        errors.push(BuildDiagnostic::invalid_export_option(
+          "none".into(),
+          module.stable_id.as_str().into(),
+          exports.iter().map(|(name, _)| name.as_str().into()).collect(),
+        ));
       }
-      Ok(OutputExports::None)
+      OutputExports::None
     }
     OutputExports::Auto => {
-      if export_items.is_empty() {
-        Ok(OutputExports::None)
-      } else if export_items.len() == 1 && export_items[0].0.as_str() == "default" {
-        Ok(OutputExports::Default)
+      if exports.is_empty() {
+        OutputExports::None
+      } else if exports.len() == 1 && exports[0].0.as_str() == "default" {
+        OutputExports::Default
       } else {
         // TODO add warnings
-        Ok(OutputExports::Named)
+        OutputExports::Named
       }
     }
   }

--- a/crates/rolldown/tests/fixtures/errors/invalid_export_option/default/_config.json
+++ b/crates/rolldown/tests/fixtures/errors/invalid_export_option/default/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "exports": "default",
+    "format": "cjs"
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/fixtures/errors/invalid_export_option/default/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/errors/invalid_export_option/default/artifacts.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/errors/invalid_export_option/default
+---
+# Errors
+
+## INVALID_EXPORT_OPTION
+
+```text
+[INVALID_EXPORT_OPTION] Error: "default" was specified for "output.exports", but entry module "main.js" has the following exports: "value".
+
+```

--- a/crates/rolldown/tests/fixtures/errors/invalid_export_option/default/main.js
+++ b/crates/rolldown/tests/fixtures/errors/invalid_export_option/default/main.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/crates/rolldown/tests/fixtures/errors/invalid_export_option/none/_config.json
+++ b/crates/rolldown/tests/fixtures/errors/invalid_export_option/none/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "exports": "none",
+    "format": "cjs"
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/fixtures/errors/invalid_export_option/none/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/errors/invalid_export_option/none/artifacts.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/errors/invalid_export_option/none
+---
+# Errors
+
+## INVALID_EXPORT_OPTION
+
+```text
+[INVALID_EXPORT_OPTION] Error: "none" was specified for "output.exports", but entry module "main.js" has the following exports: "value".
+
+```

--- a/crates/rolldown/tests/fixtures/errors/invalid_export_option/none/main.js
+++ b/crates/rolldown/tests/fixtures/errors/invalid_export_option/none/main.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -1430,6 +1430,14 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - main-!~{000}~.mjs => main-07HwCbF6.mjs
 
+# tests/fixtures/errors/invalid_export_option/default
+
+- main-!~{000}~.cjs => main-7m2R9ZCz.cjs
+
+# tests/fixtures/errors/invalid_export_option/none
+
+- main-!~{000}~.cjs => main-O74eNlgq.cjs
+
 # tests/fixtures/errors/missing_export
 
 - main-!~{000}~.mjs => main-MsirdRn5.mjs

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -1432,11 +1432,9 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/errors/invalid_export_option/default
 
-- main-!~{000}~.cjs => main-7m2R9ZCz.cjs
 
 # tests/fixtures/errors/invalid_export_option/none
 
-- main-!~{000}~.cjs => main-O74eNlgq.cjs
 
 # tests/fixtures/errors/missing_export
 

--- a/crates/rolldown_error/src/build_error/error_constructors.rs
+++ b/crates/rolldown_error/src/build_error/error_constructors.rs
@@ -12,6 +12,7 @@ use crate::events::{
   eval::Eval,
   external_entry::ExternalEntry,
   forbid_const_assign::ForbidConstAssign,
+  invalid_export_option::InvalidExportOption,
   missing_export::MissingExport,
   parse_error::ParseError,
   sourcemap_error::SourceMapError,
@@ -89,6 +90,14 @@ impl BuildDiagnostic {
       imported_specifier,
       imported_specifier_span,
     })
+  }
+
+  pub fn invalid_export_option(
+    export_mode: ArcStr,
+    entry_module: ArcStr,
+    export_keys: Vec<ArcStr>,
+  ) -> Self {
+    Self::new_inner(InvalidExportOption { export_mode, export_keys, entry_module })
   }
 
   // --- Rolldown related

--- a/crates/rolldown_error/src/event_kind.rs
+++ b/crates/rolldown_error/src/event_kind.rs
@@ -11,6 +11,7 @@ pub enum EventKind {
   CircularDependency,
   SourcemapError,
   MissingExport,
+  InvalidExportOption,
   // --- These kinds are rolldown specific
   IllegalReassignment,
   // !! Only add new kind if it's not covered by the kinds from rollup !!
@@ -33,6 +34,7 @@ impl Display for EventKind {
       EventKind::SourcemapError => write!(f, "SOURCEMAP_ERROR"),
       EventKind::CircularDependency => write!(f, "CIRCULAR_DEPENDENCY"),
       EventKind::MissingExport => write!(f, "MISSING_EXPORT"),
+      EventKind::InvalidExportOption => write!(f, "INVALID_EXPORT_OPTION"),
       // --- Rolldown specific
       EventKind::NapiError => write!(f, "NAPI_ERROR"),
       EventKind::IoError => write!(f, "IO_ERROR"),

--- a/crates/rolldown_error/src/events/invalid_export_option.rs
+++ b/crates/rolldown_error/src/events/invalid_export_option.rs
@@ -1,0 +1,26 @@
+use crate::{event_kind::EventKind, types::diagnostic_options::DiagnosticOptions};
+use arcstr::ArcStr;
+
+use super::BuildEvent;
+
+#[derive(Debug)]
+pub struct InvalidExportOption {
+  pub export_mode: ArcStr,
+  pub entry_module: ArcStr,
+  pub export_keys: Vec<ArcStr>,
+}
+
+impl BuildEvent for InvalidExportOption {
+  fn kind(&self) -> crate::event_kind::EventKind {
+    EventKind::InvalidExportOption
+  }
+
+  fn message(&self, _opts: &DiagnosticOptions) -> String {
+    format!(
+      r#""{}" was specified for "output.exports", but entry module "{}" has the following exports: {}."#,
+      self.export_mode,
+      &self.entry_module,
+      &self.export_keys.iter().map(|k| format!(r#""{k}""#)).collect::<Vec<_>>().join(", ")
+    )
+  }
+}

--- a/crates/rolldown_error/src/events/mod.rs
+++ b/crates/rolldown_error/src/events/mod.rs
@@ -9,6 +9,7 @@ pub mod circular_dependency;
 pub mod eval;
 pub mod external_entry;
 pub mod forbid_const_assign;
+pub mod invalid_export_option;
 pub mod missing_export;
 pub mod parse_error;
 pub mod sourcemap_error;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The pr implement two things.

1. Add diagnostic to `GenerateContext`, it used for collect diagnostic at generate stage.
2. Collect InvalidExportOption errors.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
