### PR TITLE
fix:  incorrect point free function call

### DIFF
--- a/packages/rolldown/src/utils/compose-js-plugins.ts
+++ b/packages/rolldown/src/utils/compose-js-plugins.ts
@@ -240,7 +240,7 @@ function isComposablePlugin(plugin: RolldownPlugin): plugin is Plugin {
     return false
   }
 
-  if (Object.keys(plugin).some(k => unsupportedHooks.has(k))) {
+  if (Object.keys(plugin).some((k) => unsupportedHooks.has(k))) {
     return false
   }
 

--- a/packages/rolldown/src/utils/compose-js-plugins.ts
+++ b/packages/rolldown/src/utils/compose-js-plugins.ts
@@ -240,7 +240,7 @@ function isComposablePlugin(plugin: RolldownPlugin): plugin is Plugin {
     return false
   }
 
-  if (Object.keys(plugin).some(unsupportedHooks.has)) {
+  if (Object.keys(plugin).some(k => unsupportedHooks.has(k))) {
     return false
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. At the beginning, I want the code more point free, but it is wrong in javascript, which would throw a runtime error 
```bash
TypeError: Method Set.prototype.has called on incompatible receiver undefined
    at has (<anonymous>)
    at Array.forEach (<anonymous>)

```
unless you write the code like: 

```js
  if (Object.keys(plugin).some(Set.prototype.has.bind(unsupportedHooks))) {
    return false
  }
```
This is ugly either, so let's revert it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
