### PR TITLE
feat: support `output.intro` and `output.outro`.

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -78,20 +78,36 @@ impl Generator for EcmaGenerator {
       None => None,
     };
 
+    let intro = match ctx.options.intro.as_ref() {
+      Some(intro) => intro.call(&rendered_chunk).await?,
+      None => None,
+    };
+
+    let outro = match ctx.options.outro.as_ref() {
+      Some(outro) => outro.call(&rendered_chunk).await?,
+      None => None,
+    };
+
     let concat_source = match ctx.options.format {
-      OutputFormat::Esm => match render_esm(ctx, rendered_module_sources, banner, footer) {
-        Ok(concat_source) => concat_source,
-        Err(errors) => return Ok(Err(errors)),
-      },
-      OutputFormat::Cjs => match render_cjs(ctx, rendered_module_sources, banner, footer) {
-        Ok(concat_source) => concat_source,
-        Err(errors) => return Ok(Err(errors)),
-      },
-      OutputFormat::App => render_app(ctx, rendered_module_sources, banner, footer),
-      OutputFormat::Iife => match render_iife(ctx, rendered_module_sources, banner, footer, true) {
-        Ok(concat_source) => concat_source,
-        Err(errors) => return Ok(Err(errors)),
-      },
+      OutputFormat::Esm => {
+        match render_esm(ctx, rendered_module_sources, banner, footer, intro, outro) {
+          Ok(concat_source) => concat_source,
+          Err(errors) => return Ok(Err(errors)),
+        }
+      }
+      OutputFormat::Cjs => {
+        match render_cjs(ctx, rendered_module_sources, banner, footer, intro, outro) {
+          Ok(concat_source) => concat_source,
+          Err(errors) => return Ok(Err(errors)),
+        }
+      }
+      OutputFormat::App => render_app(ctx, rendered_module_sources, banner, footer, intro, outro),
+      OutputFormat::Iife => {
+        match render_iife(ctx, rendered_module_sources, banner, footer, intro, outro, true) {
+          Ok(concat_source) => concat_source,
+          Err(errors) => return Ok(Err(errors)),
+        }
+      }
     };
 
     let (content, mut map) = concat_source.content_and_sourcemap();

--- a/crates/rolldown/src/ecmascript/format/app.rs
+++ b/crates/rolldown/src/ecmascript/format/app.rs
@@ -7,11 +7,19 @@ pub fn render_app(
   module_sources: RenderedModuleSources,
   banner: Option<String>,
   footer: Option<String>,
+  intro: Option<String>,
+  outro: Option<String>,
 ) -> ConcatSource {
   let mut concat_source = ConcatSource::default();
 
   if let Some(banner) = banner {
     concat_source.add_source(Box::new(RawSource::new(banner)));
+  }
+
+  if let Some(intro) = intro {
+    if !intro.is_empty() {
+      concat_source.add_source(Box::new(RawSource::new(intro)));
+    }
   }
 
   // chunk content
@@ -22,6 +30,12 @@ pub fn render_app(
       }
     }
   });
+
+  if let Some(outro) = outro {
+    if !outro.is_empty() {
+      concat_source.add_source(Box::new(RawSource::new(outro)));
+    }
+  }
 
   if let Some(footer) = footer {
     concat_source.add_source(Box::new(RawSource::new(footer)));

--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -18,6 +18,8 @@ pub fn render_cjs(
   module_sources: RenderedModuleSources,
   banner: Option<String>,
   footer: Option<String>,
+  intro: Option<String>,
+  outro: Option<String>,
 ) -> DiagnosableResult<ConcatSource> {
   let mut concat_source = ConcatSource::default();
 
@@ -27,6 +29,12 @@ pub fn render_cjs(
 
   if determine_use_strict(ctx) {
     concat_source.add_source(Box::new(RawSource::new("\"use strict\";".to_string())));
+  }
+
+  if let Some(intro) = intro {
+    if !intro.is_empty() {
+      concat_source.add_source(Box::new(RawSource::new(intro)));
+    }
   }
 
   // Runtime module should be placed before the generated `requires` in CJS format.
@@ -58,6 +66,12 @@ pub fn render_cjs(
 
   if let Some(exports) = render_chunk_exports(ctx)? {
     concat_source.add_source(Box::new(RawSource::new(exports)));
+  }
+
+  if let Some(outro) = outro {
+    if !outro.is_empty() {
+      concat_source.add_source(Box::new(RawSource::new(outro)));
+    }
   }
 
   if let Some(footer) = footer {

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -18,11 +18,19 @@ pub fn render_esm(
   module_sources: RenderedModuleSources,
   banner: Option<String>,
   footer: Option<String>,
+  intro: Option<String>,
+  outro: Option<String>,
 ) -> DiagnosableResult<ConcatSource> {
   let mut concat_source = ConcatSource::default();
 
   if let Some(banner) = banner {
     concat_source.add_source(Box::new(RawSource::new(banner)));
+  }
+
+  if let Some(intro) = intro {
+    if !intro.is_empty() {
+      concat_source.add_source(Box::new(RawSource::new(intro)));
+    }
   }
 
   concat_source.add_source(Box::new(RawSource::new(render_esm_chunk_imports(ctx))));
@@ -59,7 +67,16 @@ pub fn render_esm(
   }
 
   if let Some(exports) = render_chunk_exports(ctx)? {
-    concat_source.add_source(Box::new(RawSource::new(exports)));
+    if exports.is_empty() {
+    } else {
+      concat_source.add_source(Box::new(RawSource::new(exports)));
+    }
+  }
+
+  if let Some(outro) = outro {
+    if !outro.is_empty() {
+      concat_source.add_source(Box::new(RawSource::new(outro)));
+    }
   }
 
   if let Some(footer) = footer {

--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -21,6 +21,8 @@ pub fn render_iife(
   module_sources: RenderedModuleSources,
   banner: Option<String>,
   footer: Option<String>,
+  intro: Option<String>,
+  outro: Option<String>,
   invoke: bool,
 ) -> DiagnosableResult<ConcatSource> {
   let mut concat_source = ConcatSource::default();
@@ -61,6 +63,12 @@ pub fn render_iife(
     concat_source.add_source(Box::new(RawSource::new("\"use strict\";".to_string())));
   }
 
+  if let Some(intro) = intro {
+    if !intro.is_empty() {
+      concat_source.add_source(Box::new(RawSource::new(intro)));
+    }
+  }
+
   concat_source.add_source(Box::new(RawSource::new(import_code)));
 
   // chunk content
@@ -79,6 +87,12 @@ pub fn render_iife(
     if named_exports {
       // We need to add `return exports;` here only if using `named`, because the default value is returned when using `default` in `render_chunk_exports`.
       concat_source.add_source(Box::new(RawSource::new("return exports;".to_string())));
+    }
+  }
+
+  if let Some(outro) = outro {
+    if !outro.is_empty() {
+      concat_source.add_source(Box::new(RawSource::new(outro)));
     }
   }
 

--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -81,18 +81,18 @@ pub fn render_iife(
     }
   });
 
+  if let Some(outro) = outro {
+    if !outro.is_empty() {
+      concat_source.add_source(Box::new(RawSource::new(outro)));
+    }
+  }
+
   // iife exports
   if let Some(exports) = render_chunk_exports(ctx)? {
     concat_source.add_source(Box::new(RawSource::new(exports)));
     if named_exports {
       // We need to add `return exports;` here only if using `named`, because the default value is returned when using `default` in `render_chunk_exports`.
       concat_source.add_source(Box::new(RawSource::new("return exports;".to_string())));
-    }
-  }
-
-  if let Some(outro) = outro {
-    if !outro.is_empty() {
-      concat_source.add_source(Box::new(RawSource::new(outro)));
     }
   }
 

--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -67,6 +67,8 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
       .into(),
     banner: raw_options.banner,
     footer: raw_options.footer,
+    intro: raw_options.intro,
+    outro: raw_options.outro,
     dir: raw_options.dir.unwrap_or_else(|| "dist".to_string()),
     format: raw_options.format.unwrap_or(crate::OutputFormat::Esm),
     exports: raw_options.exports.unwrap_or(crate::OutputExports::Auto),

--- a/crates/rolldown/tests/fixtures/misc/intro/cjs/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/intro/cjs/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "format": "cjs",
+    "intro": "console.log('hello world');"
+  }
+}

--- a/crates/rolldown/tests/fixtures/misc/intro/cjs/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/intro/cjs/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
     "format": "cjs",
-    "intro": "console.log('hello world');"
+    "intro": "// intro"
   }
 }

--- a/crates/rolldown/tests/fixtures/misc/intro/cjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/intro/cjs/artifacts.snap
@@ -9,7 +9,7 @@ input_file: crates/rolldown/tests/fixtures/misc/intro/cjs
 
 ```js
 "use strict";
-console.log('hello world');
+// intro
 
 //#region main.js
 var main_default = "banner";

--- a/crates/rolldown/tests/fixtures/misc/intro/cjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/intro/cjs/artifacts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/misc/intro/cjs
+---
+# Assets
+
+## main.cjs
+
+```js
+"use strict";
+console.log('hello world');
+
+//#region main.js
+var main_default = "banner";
+
+//#endregion
+module.exports = main_default;
+```

--- a/crates/rolldown/tests/fixtures/misc/intro/cjs/main.js
+++ b/crates/rolldown/tests/fixtures/misc/intro/cjs/main.js
@@ -1,0 +1,1 @@
+export default 'banner'

--- a/crates/rolldown/tests/fixtures/misc/intro/esm/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/intro/esm/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
     "format": "esm",
-    "intro": "console.log('hello world');"
+    "intro": "// intro"
   }
 }

--- a/crates/rolldown/tests/fixtures/misc/intro/esm/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/intro/esm/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "format": "esm",
+    "intro": "console.log('hello world');"
+  }
+}

--- a/crates/rolldown/tests/fixtures/misc/intro/esm/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/intro/esm/artifacts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/misc/intro/esm
+---
+# Assets
+
+## main.mjs
+
+```js
+console.log('hello world');
+
+//#region main.js
+var main_default = "banner";
+
+//#endregion
+export { main_default as default };
+```

--- a/crates/rolldown/tests/fixtures/misc/intro/esm/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/intro/esm/artifacts.snap
@@ -8,7 +8,7 @@ input_file: crates/rolldown/tests/fixtures/misc/intro/esm
 ## main.mjs
 
 ```js
-console.log('hello world');
+// intro
 
 //#region main.js
 var main_default = "banner";

--- a/crates/rolldown/tests/fixtures/misc/intro/esm/main.js
+++ b/crates/rolldown/tests/fixtures/misc/intro/esm/main.js
@@ -1,0 +1,1 @@
+export default 'banner'

--- a/crates/rolldown/tests/fixtures/misc/intro/iife/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/intro/iife/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "format": "iife",
+    "intro": "console.log('hello world');"
+  }
+}

--- a/crates/rolldown/tests/fixtures/misc/intro/iife/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/intro/iife/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
     "format": "iife",
-    "intro": "console.log('hello world');"
+    "intro": "// intro"
   }
 }

--- a/crates/rolldown/tests/fixtures/misc/intro/iife/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/intro/iife/artifacts.snap
@@ -11,7 +11,7 @@ input_file: crates/rolldown/tests/fixtures/misc/intro/iife
 (function() {
 
 "use strict";
-console.log('hello world');
+// intro
 
 //#region main.js
 var main_default = "banner";

--- a/crates/rolldown/tests/fixtures/misc/intro/iife/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/intro/iife/artifacts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/misc/intro/iife
+---
+# Assets
+
+## main.mjs
+
+```js
+(function() {
+
+"use strict";
+console.log('hello world');
+
+//#region main.js
+var main_default = "banner";
+
+//#endregion
+return main_default;
+})();
+```

--- a/crates/rolldown/tests/fixtures/misc/intro/iife/main.js
+++ b/crates/rolldown/tests/fixtures/misc/intro/iife/main.js
@@ -1,0 +1,1 @@
+export default 'banner'

--- a/crates/rolldown/tests/fixtures/misc/outro/cjs/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/outro/cjs/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "format": "cjs",
+    "outro": "console.log('hello world');"
+  }
+}

--- a/crates/rolldown/tests/fixtures/misc/outro/cjs/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/outro/cjs/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
     "format": "cjs",
-    "outro": "console.log('hello world');"
+    "outro": "// outro"
   }
 }

--- a/crates/rolldown/tests/fixtures/misc/outro/cjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/outro/cjs/artifacts.snap
@@ -15,5 +15,5 @@ var main_default = "banner";
 
 //#endregion
 module.exports = main_default;
-console.log('hello world');
+// outro
 ```

--- a/crates/rolldown/tests/fixtures/misc/outro/cjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/outro/cjs/artifacts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/misc/outro/cjs
+---
+# Assets
+
+## main.cjs
+
+```js
+"use strict";
+
+//#region main.js
+var main_default = "banner";
+
+//#endregion
+module.exports = main_default;
+console.log('hello world');
+```

--- a/crates/rolldown/tests/fixtures/misc/outro/cjs/main.js
+++ b/crates/rolldown/tests/fixtures/misc/outro/cjs/main.js
@@ -1,0 +1,1 @@
+export default 'banner'

--- a/crates/rolldown/tests/fixtures/misc/outro/esm/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/outro/esm/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "format": "esm",
+    "outro": "console.log('hello world');"
+  }
+}

--- a/crates/rolldown/tests/fixtures/misc/outro/esm/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/outro/esm/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
     "format": "esm",
-    "outro": "console.log('hello world');"
+    "outro": "// outro"
   }
 }

--- a/crates/rolldown/tests/fixtures/misc/outro/esm/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/outro/esm/artifacts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/misc/outro/esm
+---
+# Assets
+
+## main.mjs
+
+```js
+
+//#region main.js
+var main_default = "banner";
+
+//#endregion
+export { main_default as default };
+console.log('hello world');
+```

--- a/crates/rolldown/tests/fixtures/misc/outro/esm/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/outro/esm/artifacts.snap
@@ -14,5 +14,5 @@ var main_default = "banner";
 
 //#endregion
 export { main_default as default };
-console.log('hello world');
+// outro
 ```

--- a/crates/rolldown/tests/fixtures/misc/outro/esm/main.js
+++ b/crates/rolldown/tests/fixtures/misc/outro/esm/main.js
@@ -1,0 +1,1 @@
+export default 'banner'

--- a/crates/rolldown/tests/fixtures/misc/outro/iife/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/outro/iife/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "format": "iife",
+    "outro": "console.log('hello world');"
+  }
+}

--- a/crates/rolldown/tests/fixtures/misc/outro/iife/_config.json
+++ b/crates/rolldown/tests/fixtures/misc/outro/iife/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
     "format": "iife",
-    "outro": "console.log('hello world');"
+    "outro": "// outro"
   }
 }

--- a/crates/rolldown/tests/fixtures/misc/outro/iife/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/outro/iife/artifacts.snap
@@ -16,7 +16,7 @@ input_file: crates/rolldown/tests/fixtures/misc/outro/iife
 var main_default = "banner";
 
 //#endregion
+// outro
 return main_default;
-console.log('hello world');
 })();
 ```

--- a/crates/rolldown/tests/fixtures/misc/outro/iife/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/misc/outro/iife/artifacts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rolldown_testing/src/case/case.rs
+expression: content
+input_file: crates/rolldown/tests/fixtures/misc/outro/iife
+---
+# Assets
+
+## main.mjs
+
+```js
+(function() {
+
+"use strict";
+
+//#region main.js
+var main_default = "banner";
+
+//#endregion
+return main_default;
+console.log('hello world');
+})();
+```

--- a/crates/rolldown/tests/fixtures/misc/outro/iife/main.js
+++ b/crates/rolldown/tests/fixtures/misc/outro/iife/main.js
@@ -1,0 +1,1 @@
+export default 'banner'

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -1699,6 +1699,18 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - main-!~{000}~.mjs => main-TnUhQsWi.mjs
 
+# tests/fixtures/misc/intro/cjs
+
+- main-!~{000}~.cjs => main-aczCE6j4.cjs
+
+# tests/fixtures/misc/intro/esm
+
+- main-!~{000}~.mjs => main-Q4KqTqKe.mjs
+
+# tests/fixtures/misc/intro/iife
+
+- main-!~{000}~.mjs => main-4sZuT4ik.mjs
+
 # tests/fixtures/misc/issue_376
 
 - main-!~{000}~.mjs => main-EXizxPDM.mjs
@@ -1707,6 +1719,18 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - main-!~{000}~.mjs => main-Ak8YfHWG.mjs
 - main-Ak8YfHWG.mjs.map
+
+# tests/fixtures/misc/outro/cjs
+
+- main-!~{000}~.cjs => main-3VlHlmO3.cjs
+
+# tests/fixtures/misc/outro/esm
+
+- main-!~{000}~.mjs => main-rmwHGnWe.mjs
+
+# tests/fixtures/misc/outro/iife
+
+- main-!~{000}~.mjs => main-ir0CjhNB.mjs
 
 # tests/fixtures/misc/reexport_star
 

--- a/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/fixtures__filename_with_hash.snap
@@ -1701,15 +1701,15 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/misc/intro/cjs
 
-- main-!~{000}~.cjs => main-aczCE6j4.cjs
+- main-!~{000}~.cjs => main-qFgh1E_v.cjs
 
 # tests/fixtures/misc/intro/esm
 
-- main-!~{000}~.mjs => main-Q4KqTqKe.mjs
+- main-!~{000}~.mjs => main-7xnGS4Bc.mjs
 
 # tests/fixtures/misc/intro/iife
 
-- main-!~{000}~.mjs => main-4sZuT4ik.mjs
+- main-!~{000}~.mjs => main-s5GQ6pv_.mjs
 
 # tests/fixtures/misc/issue_376
 
@@ -1722,15 +1722,15 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/misc/outro/cjs
 
-- main-!~{000}~.cjs => main-3VlHlmO3.cjs
+- main-!~{000}~.cjs => main-rUVReNhA.cjs
 
 # tests/fixtures/misc/outro/esm
 
-- main-!~{000}~.mjs => main-rmwHGnWe.mjs
+- main-!~{000}~.mjs => main-M2gHFdT3.mjs
 
 # tests/fixtures/misc/outro/iife
 
-- main-!~{000}~.mjs => main-ir0CjhNB.mjs
+- main-!~{000}~.mjs => main-svvw3JyV.mjs
 
 # tests/fixtures/misc/reexport_star
 

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -51,12 +51,18 @@ pub struct BindingOutputOptions {
   // indent: true | string;
   // inlineDynamicImports: boolean;
   // interop: GetInterop;
-  // intro: () => string | Promise<string>;
+  #[derivative(Debug = "ignore")]
+  #[serde(skip_deserializing)]
+  #[napi(ts_type = "(chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>")]
+  pub intro: Option<AddonOutputOption>,
   // manualChunks: ManualChunksOption;
   // minifyInternalExports: boolean;
   // namespaceToStringTag: boolean;
   // noConflict: boolean;
-  // outro: () => string | Promise<string>;
+  #[derivative(Debug = "ignore")]
+  #[serde(skip_deserializing)]
+  #[napi(ts_type = "(chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>")]
+  pub outro: Option<AddonOutputOption>,
   // paths: OptionsPaths;
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(BindingBuiltinPlugin | BindingPluginOptions | undefined)[]")]

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -120,6 +120,8 @@ pub fn normalize_binding_options(
     sourcemap: output_options.sourcemap.map(Into::into),
     banner: normalize_addon_option(output_options.banner),
     footer: normalize_addon_option(output_options.footer),
+    intro: normalize_addon_option(output_options.intro),
+    outro: normalize_addon_option(output_options.outro),
     sourcemap_ignore_list,
     sourcemap_path_transform,
     exports: output_options.exports.map(|format_str| match format_str.as_str() {

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -62,6 +62,18 @@ pub struct BundlerOptions {
   pub footer: Option<AddonOutputOption>,
   #[cfg_attr(
     feature = "deserialize_bundler_options",
+    serde(default, deserialize_with = "deserialize_addon"),
+    schemars(with = "Option<String>")
+  )]
+  pub intro: Option<AddonOutputOption>,
+  #[cfg_attr(
+    feature = "deserialize_bundler_options",
+    serde(default, deserialize_with = "deserialize_addon"),
+    schemars(with = "Option<String>")
+  )]
+  pub outro: Option<AddonOutputOption>,
+  #[cfg_attr(
+    feature = "deserialize_bundler_options",
     serde(default, skip_deserializing),
     schemars(skip)
   )]

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -39,6 +39,8 @@ pub struct NormalizedBundlerOptions {
   pub sourcemap: SourceMapType,
   pub banner: Option<AddonOutputOption>,
   pub footer: Option<AddonOutputOption>,
+  pub intro: Option<AddonOutputOption>,
+  pub outro: Option<AddonOutputOption>,
   pub sourcemap_ignore_list: Option<SourceMapIgnoreList>,
   pub sourcemap_path_transform: Option<SourceMapPathTransform>,
   pub experimental: ExperimentalOptions,

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -141,6 +141,12 @@
             "$ref": "#/definitions/InputItem"
           }
         },
+        "intro": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "minify": {
           "type": [
             "boolean",
@@ -158,6 +164,12 @@
           }
         },
         "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "outro": {
           "type": [
             "string",
             "null"

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -193,6 +193,8 @@ export interface BindingOutputOptions {
   footer?: (chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>
   format?: 'es' | 'cjs' | 'iife'
   globals?: Record<string, string>
+  intro?: (chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>
+  outro?: (chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>
   plugins: (BindingBuiltinPlugin | BindingPluginOptions | undefined)[]
   sourcemap?: 'file' | 'inline' | 'hidden'
   sourcemapIgnoreList?: (source: string, sourcemapPath: string) => boolean

--- a/packages/rolldown/src/options/bindingify-output-options.ts
+++ b/packages/rolldown/src/options/bindingify-output-options.ts
@@ -17,6 +17,8 @@ export function bindingifyOutputOptions(
     assetFileNames,
     banner,
     footer,
+    intro,
+    outro,
   } = outputOptions
   return {
     dir,
@@ -36,6 +38,8 @@ export function bindingifyOutputOptions(
     sourcemapPathTransform,
     banner,
     footer,
+    intro,
+    outro,
     name,
     entryFileNames,
     chunkFileNames,

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -20,6 +20,8 @@ export interface NormalizedOutputOptions extends OutputOptions {
   sourcemapPathTransform: SourcemapPathTransformOption | undefined
   banner: AddonFunction
   footer: AddonFunction
+  intro: AddonFunction
+  outro: AddonFunction
   entryFileNames: string
   chunkFileNames: string
   assetFileNames: string

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -39,6 +39,8 @@ const outputOptionsSchema = z.strictObject({
     .optional(),
   banner: z.string().or(addonFunctionSchema).optional(),
   footer: z.string().or(addonFunctionSchema).optional(),
+  intro: z.string().or(addonFunctionSchema).optional(),
+  outro: z.string().or(addonFunctionSchema).optional(),
   entryFileNames: z.string().optional(),
   chunkFileNames: z.string().optional(),
   assetFileNames: z.string().optional(),

--- a/packages/rolldown/src/utils/normalize-output-options.ts
+++ b/packages/rolldown/src/utils/normalize-output-options.ts
@@ -33,6 +33,8 @@ export function normalizeOutputOptions(
     sourcemapPathTransform,
     banner: getAddon(opts, 'banner'),
     footer: getAddon(opts, 'footer'),
+    intro: getAddon(opts, 'intro'),
+    outro: getAddon(opts, 'outro'),
     // TODO support functions
     globals: globals ?? {},
     entryFileNames: entryFileNames ?? '[name].js',
@@ -69,7 +71,7 @@ function getFormat(
   }
 }
 
-const getAddon = <T extends 'banner' | 'footer'>(
+const getAddon = <T extends 'banner' | 'footer' | 'intro' | 'outro'>(
   config: OutputOptions,
   name: T,
 ): NormalizedOutputOptions[T] => {

--- a/packages/rolldown/tests/fixtures/output/intro/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/intro/string/_config.ts
@@ -1,0 +1,14 @@
+import type { RolldownOutputChunk } from 'rolldown'
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+
+const introText = '/* intro test */\n'
+
+export default defineTest({
+  config: {
+    output: {
+      format: 'iife',
+      intro: introText,
+    },
+  },
+})

--- a/packages/rolldown/tests/fixtures/output/intro/string/main.js
+++ b/packages/rolldown/tests/fixtures/output/intro/string/main.js
@@ -1,0 +1,1 @@
+export default 'intro string'

--- a/packages/rolldown/tests/fixtures/output/outro/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/outro/string/_config.ts
@@ -1,0 +1,14 @@
+import type { RolldownOutputChunk } from 'rolldown'
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+
+const outroText = '/* outro test */\n'
+
+export default defineTest({
+  config: {
+    format: 'iife',
+    output: {
+      outro: outroText,
+    },
+  },
+})

--- a/packages/rolldown/tests/fixtures/output/outro/string/main.js
+++ b/packages/rolldown/tests/fixtures/output/outro/string/main.js
@@ -1,0 +1,1 @@
+export default 'outro string'


### PR DESCRIPTION
Check it out [here](https://rollupjs.org/configuration-options/#output-intro-output-outro) in Rollup's documentation.

`intro` is after the `use strict`, and `outro` is before closing the wrapper function in IIFE, or before the footer in others.

Example [here](https://rollupjs.org/repl/?version=4.19.0&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQW51bGwlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIyY29kZSUyMiUzQSUyMmV4cG9ydCUyMGRlZmF1bHQlMjAlNUMlMjJleGFtcGxlJTVDJTIyJTIyJTJDJTIyaXNFbnRyeSUyMiUzQXRydWUlMkMlMjJuYW1lJTIyJTNBJTIybWFpbi5qcyUyMiU3RCUyQyU3QiUyMmNvZGUlMjIlM0ElMjJleHBvcnQlMjBjb25zdCUyMHF1eCUyMCUzRCUyMCdRVVgnJTNCJTIyJTJDJTIyaXNFbnRyeSUyMiUzQWZhbHNlJTJDJTIybmFtZSUyMiUzQSUyMnF1eC5qcyUyMiU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlMjJvdXRwdXQlMjIlM0ElN0IlMjJiYW5uZXIlMjIlM0ElMjIlMkYlMkYlMjBIZWxsbyUyQyUyMHdvcmxkISUyMFRoaXMlMjBpcyUyMGJhbm5lciUyMiUyQyUyMmVzTW9kdWxlJTIyJTNBJTIyaWYtZGVmYXVsdC1wcm9wJTIyJTJDJTIyZXhwb3J0cyUyMiUzQSUyMmF1dG8lMjIlMkMlMjJmb290ZXIlMjIlM0ElMjIlMkYlMkYlMjBIZWxsbyUyQyUyMHdvcmxkISUyMFRoaXMlMjBpcyUyMGZvb3RlciUyMiUyQyUyMmZvcm1hdCUyMiUzQSUyMmlpZmUlMjIlMkMlMjJpbnRybyUyMiUzQSUyMiUyRiUyRiUyMEhlbGxvJTJDJTIwd29ybGQhJTIwVGhpcyUyMGlzJTIwaW50cm8lMjIlMkMlMjJuYW1lJTIyJTNBJTIybXlCdW5kbGUlMjIlMkMlMjJvdXRybyUyMiUzQSUyMiUyRiUyRiUyMEhlbGxvJTJDJTIwd29ybGQhJTIwVGhpcyUyMGlzJTIwb3V0cm8lMjIlN0QlN0QlN0Q=). Issue related: #819, including `intro` and `outro`.