### PR TITLE
feat: support `output.footer` in plugins.

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -84,11 +84,6 @@ impl Generator for EcmaGenerator {
         .await?
     };
 
-    // let footer = match ctx.options.footer.as_ref() {
-    //   Some(footer) => footer.call(&rendered_chunk).await?,
-    //   None => None,
-    // };
-
     let concat_source = match ctx.options.format {
       OutputFormat::Esm => match render_esm(ctx, rendered_module_sources, banner, footer) {
         Ok(concat_source) => concat_source,

--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -8,7 +8,7 @@ use rolldown_common::{
   AssetMeta, EcmaAssetMeta, ModuleId, ModuleIdx, OutputFormat, PreliminaryAsset, RenderedModule,
 };
 use rolldown_error::DiagnosableResult;
-use rolldown_plugin::HookBannerArgs;
+use rolldown_plugin::{HookBannerArgs, HookFooterArgs};
 use rolldown_sourcemap::Source;
 use rolldown_utils::rayon::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::FxHashMap;
@@ -73,10 +73,21 @@ impl Generator for EcmaGenerator {
         .await?
     };
 
-    let footer = match ctx.options.footer.as_ref() {
-      Some(footer) => footer.call(&rendered_chunk).await?,
-      None => None,
+    let footer = {
+      let footer = match ctx.options.footer.as_ref() {
+        Some(footer) => footer.call(&rendered_chunk).await?,
+        None => None,
+      };
+      ctx
+        .plugin_driver
+        .footer(HookFooterArgs { chunk: &rendered_chunk }, footer.unwrap_or_default())
+        .await?
     };
+
+    // let footer = match ctx.options.footer.as_ref() {
+    //   Some(footer) => footer.call(&rendered_chunk).await?,
+    //   None => None,
+    // };
 
     let concat_source = match ctx.options.format {
       OutputFormat::Esm => match render_esm(ctx, rendered_module_sources, banner, footer) {

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -128,6 +128,10 @@ pub struct BindingPluginOptions {
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
   pub banner: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
+
+  #[serde(skip_deserializing)]
+  #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
+  pub footer: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 }
 
 impl Debug for BindingPluginOptions {

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -183,7 +183,7 @@ impl Plugin for JsPlugin {
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
     args: &rolldown_plugin::HookFooterArgs,
-  ) -> rolldown_plugin::HookBannerOutputReturn {
+  ) -> rolldown_plugin::HookFooterOutputReturn {
     if let Some(cb) = &self.footer {
       Ok(
         cb.await_call((Arc::clone(ctx).into(), args.chunk.clone().into()))

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -179,6 +179,23 @@ impl Plugin for JsPlugin {
     }
   }
 
+  async fn footer(
+    &self,
+    ctx: &rolldown_plugin::SharedPluginContext,
+    args: &rolldown_plugin::HookFooterArgs,
+  ) -> rolldown_plugin::HookBannerOutputReturn {
+    if let Some(cb) = &self.footer {
+      Ok(
+        cb.await_call((Arc::clone(ctx).into(), args.chunk.clone().into()))
+          .await?
+          .map(TryInto::try_into)
+          .transpose()?,
+      )
+    } else {
+      Ok(None)
+    }
+  }
+
   async fn render_chunk(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -62,8 +62,8 @@ pub struct BundlerOptions {
   pub footer: Option<AddonOutputOption>,
   #[cfg_attr(
     feature = "deserialize_bundler_options",
-    serde(default, skip_deserializing),
-    schemars(skip)
+    serde(default, deserialize_with = "deserialize_addon"),
+    schemars(with = "Option<String>")
   )]
   pub sourcemap_ignore_list: Option<SourceMapIgnoreList>,
   #[cfg_attr(

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -62,8 +62,8 @@ pub struct BundlerOptions {
   pub footer: Option<AddonOutputOption>,
   #[cfg_attr(
     feature = "deserialize_bundler_options",
-    serde(default, deserialize_with = "deserialize_addon"),
-    schemars(with = "Option<String>")
+    serde(default, skip_deserializing),
+    schemars(skip)
   )]
   pub sourcemap_ignore_list: Option<SourceMapIgnoreList>,
   #[cfg_attr(

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -11,15 +11,16 @@ pub mod inner {
 
 pub use crate::{
   plugin::{
-    BoxPlugin, HookAugmentChunkHashReturn, HookBannerOutputReturn, HookLoadReturn, HookNoopReturn,
-    HookRenderChunkReturn, HookResolveIdReturn, HookTransformAstReturn, HookTransformReturn,
-    Plugin, SharedPlugin,
+    BoxPlugin, HookAugmentChunkHashReturn, HookBannerOutputReturn, HookFooterOutputReturn,
+    HookLoadReturn, HookNoopReturn, HookRenderChunkReturn, HookResolveIdReturn,
+    HookTransformAstReturn, HookTransformReturn, Plugin, SharedPlugin,
   },
   plugin_context::{PluginContext, SharedPluginContext},
   plugin_driver::{PluginDriver, SharedPluginDriver},
   transform_plugin_context::TransformPluginContext,
   types::hook_banner_args::HookBannerArgs,
   types::hook_build_end_args::HookBuildEndArgs,
+  types::hook_footer_args::HookFooterArgs,
   types::hook_load_args::HookLoadArgs,
   types::hook_load_output::HookLoadOutput,
   types::hook_render_chunk_args::HookRenderChunkArgs,

--- a/crates/rolldown_plugin/src/plugin.rs
+++ b/crates/rolldown_plugin/src/plugin.rs
@@ -3,8 +3,8 @@ use std::{any::Any, borrow::Cow, fmt::Debug, sync::Arc};
 use super::plugin_context::SharedPluginContext;
 use crate::{
   transform_plugin_context::TransformPluginContext,
-  types::hook_render_error::HookRenderErrorArgs,
   types::{
+    hook_footer_args::HookFooterArgs, hook_render_error::HookRenderErrorArgs,
     hook_transform_ast_args::HookTransformAstArgs, hook_transform_output::HookTransformOutput,
   },
   HookBannerArgs, HookBuildEndArgs, HookLoadArgs, HookLoadOutput, HookRenderChunkArgs,
@@ -23,6 +23,7 @@ pub type HookNoopReturn = Result<()>;
 pub type HookRenderChunkReturn = Result<Option<HookRenderChunkOutput>>;
 pub type HookAugmentChunkHashReturn = Result<Option<String>>;
 pub type HookBannerOutputReturn = Result<Option<String>>;
+pub type HookFooterOutputReturn = Result<Option<String>>;
 
 #[async_trait::async_trait]
 pub trait Plugin: Any + Debug + Send + Sync + 'static {
@@ -102,6 +103,14 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
     _ctx: &SharedPluginContext,
     _args: &HookBannerArgs,
   ) -> HookBannerOutputReturn {
+    Ok(None)
+  }
+
+  async fn footer(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookFooterArgs,
+  ) -> HookFooterOutputReturn {
     Ok(None)
   }
 

--- a/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
@@ -20,8 +20,8 @@ impl PluginDriver {
   ) -> Result<Option<String>> {
     for (plugin, ctx) in &self.plugins {
       if let Some(r) = plugin.banner(ctx, &args).await? {
-        banner.push_str(r.as_str());
         banner.push('\n');
+        banner.push_str(r.as_str());
       }
     }
     if banner.is_empty() {

--- a/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
@@ -1,5 +1,5 @@
 use crate::types::hook_render_error::HookRenderErrorArgs;
-use crate::{HookAugmentChunkHashReturn, HookNoopReturn, HookRenderChunkArgs};
+use crate::{HookAugmentChunkHashReturn, HookFooterArgs, HookNoopReturn, HookRenderChunkArgs};
 use crate::{HookBannerArgs, PluginDriver};
 use anyhow::{Ok, Result};
 use rolldown_common::{Output, RollupRenderedChunk};
@@ -20,14 +20,31 @@ impl PluginDriver {
   ) -> Result<Option<String>> {
     for (plugin, ctx) in &self.plugins {
       if let Some(r) = plugin.banner(ctx, &args).await? {
-        banner.push('\n');
         banner.push_str(r.as_str());
+        banner.push('\n');
       }
     }
     if banner.is_empty() {
       return Ok(None);
     }
     Ok(Some(banner))
+  }
+
+  pub async fn footer(
+    &self,
+    args: HookFooterArgs<'_>,
+    mut footer: String,
+  ) -> Result<Option<String>> {
+    for (plugin, ctx) in &self.plugins {
+      if let Some(r) = plugin.footer(ctx, &args).await? {
+        footer.push('\n');
+        footer.push_str(r.as_str());
+      }
+    }
+    if footer.is_empty() {
+      return Ok(None);
+    }
+    Ok(Some(footer))
   }
 
   pub async fn render_chunk(

--- a/crates/rolldown_plugin/src/types/hook_footer_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_footer_args.rs
@@ -1,0 +1,6 @@
+use rolldown_common::RollupRenderedChunk;
+
+#[derive(Debug)]
+pub struct HookFooterArgs<'a> {
+  pub chunk: &'a RollupRenderedChunk,
+}

--- a/crates/rolldown_plugin/src/types/mod.rs
+++ b/crates/rolldown_plugin/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod hook_banner_args;
 pub mod hook_build_end_args;
+pub mod hook_footer_args;
 pub mod hook_load_args;
 pub mod hook_load_output;
 pub mod hook_render_chunk_args;

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -199,6 +199,13 @@
             }
           ]
         },
+        "sourcemapIgnoreList": {
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "treeshake": {
           "$ref": "#/definitions/TreeshakeOptions"
         }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -199,13 +199,6 @@
             }
           ]
         },
-        "sourcemapIgnoreList": {
-          "readOnly": true,
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "treeshake": {
           "$ref": "#/definitions/TreeshakeOptions"
         }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -225,6 +225,7 @@ export interface BindingPluginOptions {
   generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>
   writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>
   banner?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+  footer?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
 }
 
 export interface BindingPluginWithIndex {

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -167,3 +167,23 @@ export function bindingifyBanner(
     )
   }
 }
+
+export function bindingifyFooter(
+  plugin: Plugin,
+  options: NormalizedInputOptions,
+  pluginContextData: PluginContextData,
+): BindingPluginOptions['footer'] {
+  const hook = plugin.footer
+  if (!hook) {
+    return undefined
+  }
+
+  const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
+
+  return async (ctx, chunk) => {
+    return handler.call(
+      new PluginContext(options, ctx, plugin, pluginContextData),
+      chunk,
+    )
+  }
+}

--- a/packages/rolldown/src/plugin/bindingify-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin.ts
@@ -17,6 +17,7 @@ import {
   bindingifyRenderError,
   bindingifyAugmentChunkHash,
   bindingifyBanner,
+  bindingifyFooter,
 } from './bindingify-output-hooks'
 
 import type { Plugin } from './index'
@@ -75,6 +76,6 @@ export function bindingifyPlugin(
       pluginContextData,
     ),
     banner: bindingifyBanner(plugin, options, pluginContextData),
-    footer: bindingifyBanner(plugin, options, pluginContextData),
+    footer: bindingifyFooter(plugin, options, pluginContextData),
   }
 }

--- a/packages/rolldown/src/plugin/bindingify-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin.ts
@@ -75,5 +75,6 @@ export function bindingifyPlugin(
       pluginContextData,
     ),
     banner: bindingifyBanner(plugin, options, pluginContextData),
+    footer: bindingifyBanner(plugin, options, pluginContextData),
   }
 }

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -178,7 +178,7 @@ export type SequentialPluginHooks =
   | 'renderChunk'
   | 'transform'
 
-export type AddonHooks = 'banner' /*| 'footer' | 'intro' | 'outro' */
+export type AddonHooks = 'banner' | 'footer' /* | 'intro' | 'outro' */
 
 export type OutputPluginHooks =
   | 'augmentChunkHash'

--- a/packages/rolldown/src/utils/compose-js-plugins.ts
+++ b/packages/rolldown/src/utils/compose-js-plugins.ts
@@ -83,6 +83,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
         }
         case 'augmentChunkHash':
         case 'banner':
+        case 'footer':
         case 'generateBundle':
         case 'moduleParsed':
         case 'onLog':
@@ -228,6 +229,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
         case 'name':
         case 'augmentChunkHash':
         case 'banner':
+        case 'footer':
         case 'generateBundle':
         case 'moduleParsed':
         case 'onLog':

--- a/packages/rolldown/tests/fixtures/output/format/iife/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/format/iife/basic/_config.ts
@@ -13,8 +13,7 @@ export default defineTest({
       "var myModule = (function() {
 
 
-      })();
-      "
+      })();"
     `)
   },
 })

--- a/packages/rolldown/tests/fixtures/output/format/iife/exports/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/format/iife/exports/_config.ts
@@ -23,8 +23,7 @@ export default defineTest({
       Object.defineProperty(exports, '__esModule', { value: true });
       exports.default = main_default;
       return exports;
-      })({}, node_path);
-      "
+      })({}, node_path);"
     `)
   },
 })

--- a/packages/rolldown/tests/fixtures/output/format/iife/globals/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/format/iife/globals/_config.ts
@@ -23,8 +23,7 @@ export default defineTest({
 
       //#endregion
       return main_default;
-      })(node_path);
-      "
+      })(node_path);"
     `)
   },
 })

--- a/packages/rolldown/tests/fixtures/output/hashFileNames/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/hashFileNames/_config.ts
@@ -70,33 +70,33 @@ export default defineTest({
           expect(chunk.preliminaryFileName).toMatchInlineSnapshot(
             `"main-!~{000}~.js"`,
           )
-          expect(chunk.fileName).toMatchInlineSnapshot(`"main-dauh_EvC.js"`)
+          expect(chunk.fileName).toMatchInlineSnapshot(`"main-WFHoSf5Y.js"`)
           expect(chunk.imports).toMatchInlineSnapshot(`
             [
-              "shared-Ho9DyHsQ.js",
+              "shared-GrsQyLjj.js",
             ]
           `)
           expect(chunk.dynamicImports).toMatchInlineSnapshot(
             `
             [
-              "dynamic-KDLER_NS.js",
+              "dynamic-erqzNh-Z.js",
             ]
           `,
           )
           break
 
         case path.join(__dirname, 'entry.js'):
-          expect(chunk.fileName).toMatchInlineSnapshot(`"entry-KQhJwwWI.js"`)
+          expect(chunk.fileName).toMatchInlineSnapshot(`"entry-A_XCu9lS.js"`)
           expect(chunk.imports).toMatchInlineSnapshot(`
             [
-              "shared-Ho9DyHsQ.js",
+              "shared-GrsQyLjj.js",
             ]
           `)
           expect(chunk.dynamicImports).toStrictEqual([])
           break
 
         case path.join(__dirname, 'dynamic.js'):
-          expect(chunk.fileName).toMatchInlineSnapshot(`"dynamic-KDLER_NS.js"`)
+          expect(chunk.fileName).toMatchInlineSnapshot(`"dynamic-erqzNh-Z.js"`)
           break
 
         default:

--- a/packages/rolldown/tests/fixtures/plugin/augment-chunk-hash/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/augment-chunk-hash/_config.ts
@@ -31,11 +31,11 @@ export default defineTest({
     for (const chunk of chunks) {
       switch (chunk.facadeModuleId) {
         case path.join(__dirname, 'main.js'):
-          expect(chunk.fileName).toMatchInlineSnapshot(`"main-OAA4AK8q.js"`)
+          expect(chunk.fileName).toMatchInlineSnapshot(`"main-M-2YP1Eg.js"`)
           break
 
         case path.join(__dirname, 'entry.js'):
-          expect(chunk.fileName).toMatchInlineSnapshot(`"entry-zyfuUVuU.js"`)
+          expect(chunk.fileName).toMatchInlineSnapshot(`"entry-LZxEycPx.js"`)
           break
 
         default:

--- a/packages/rolldown/tests/fixtures/plugin/footer/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/footer/_config.ts
@@ -10,7 +10,7 @@ export default defineTest({
     plugins: [
       {
         name: 'test-plugin',
-        banner: () => '/* Lorem ipsum */',
+        footer: () => '/* Lorem ipsum */',
       },
     ],
   },

--- a/packages/rolldown/tests/fixtures/plugin/footer/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/footer/main.js
@@ -1,0 +1,1 @@
+console.log()


### PR DESCRIPTION
resolves #1702.
Thanks to @komyg for your contribution! This PR involves some test errors. Check it out [here](https://github.com/rolldown/rolldown/pull/1702#issuecomment-2248059655).