### PR TITLE
perf: dataurl

### DIFF
--- a/crates/rolldown_utils/src/percent_encoding.rs
+++ b/crates/rolldown_utils/src/percent_encoding.rs
@@ -1,7 +1,8 @@
 /// Authored by @ikkz and adapted by @7086cmd.
-use std::fmt::Write;
 use std::str;
 
+const HEX: [char; 16] =
+  ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];
 // adapted from "https://github.com/evanw/esbuild/blob/67cbf87a4909d87a902ca8c3b69ab5330defab0a/scripts/dataurl-escapes.html" for how this was derived
 pub fn encode_as_percent_escaped(buf: &[u8]) -> Option<String> {
   if let Ok(text) = str::from_utf8(buf) {
@@ -23,7 +24,9 @@ pub fn encode_as_percent_escaped(buf: &[u8]) -> Option<String> {
           && chars[i + 1].is_ascii_hexdigit()
           && chars[i + 2].is_ascii_hexdigit())
       {
-        write!(url, "%{:02X}", c as u32).unwrap();
+        url.push('%');
+        url.push(HEX[c as usize >> 4]);
+        url.push(HEX[c as usize & 15]);
       } else {
         url.push(c);
       }

--- a/crates/rolldown_utils/src/percent_encoding.rs
+++ b/crates/rolldown_utils/src/percent_encoding.rs
@@ -5,36 +5,36 @@ const HEX: [char; 16] =
   ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];
 // adapted from "https://github.com/evanw/esbuild/blob/67cbf87a4909d87a902ca8c3b69ab5330defab0a/scripts/dataurl-escapes.html" for how this was derived
 pub fn encode_as_percent_escaped(buf: &[u8]) -> Option<String> {
-  if let Ok(text) = str::from_utf8(buf) {
-    let mut url = String::with_capacity(text.len() * 3);
-    let chars = text.chars().collect::<Vec<_>>();
-    let mut trailing_start = chars.len();
-    while trailing_start > 0 {
-      let c = chars[trailing_start - 1];
-      if c > 0x20 as char || matches!(c, '\t' | '\n' | '\r') {
-        break;
+  str::from_utf8(buf)
+    .map(|text| {
+      let mut url = String::with_capacity(text.len() * 3);
+      let chars = text.chars().collect::<Vec<_>>();
+      let mut trailing_start = chars.len();
+      while trailing_start > 0 {
+        let c = chars[trailing_start - 1];
+        if c > 0x20 as char || matches!(c, '\t' | '\n' | '\r') {
+          break;
+        }
+        trailing_start -= 1;
       }
-      trailing_start -= 1;
-    }
-    for (i, &c) in chars.iter().enumerate() {
-      if matches!(c, '\t' | '\n' | '\r' | '#')
-        || i >= trailing_start
-        || (c == '%'
-          && i + 2 < chars.len()
-          && chars[i + 1].is_ascii_hexdigit()
-          && chars[i + 2].is_ascii_hexdigit())
-      {
-        url.push('%');
-        url.push(HEX[c as usize >> 4]);
-        url.push(HEX[c as usize & 15]);
-      } else {
-        url.push(c);
+      for (i, &c) in chars.iter().enumerate() {
+        if matches!(c, '\t' | '\n' | '\r' | '#')
+          || i >= trailing_start
+          || (c == '%'
+            && i + 2 < chars.len()
+            && chars[i + 1].is_ascii_hexdigit()
+            && chars[i + 2].is_ascii_hexdigit())
+        {
+          url.push('%');
+          url.push(HEX[c as usize >> 4]);
+          url.push(HEX[c as usize & 15]);
+        } else {
+          url.push(c);
+        }
       }
-    }
-    Some(url)
-  } else {
-    None
-  }
+      url
+    })
+    .ok()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
inspired by https://github.com/evanw/esbuild/blob/360d47230813e67d0312ad754cad2b6ee09b151b/internal/helpers/dataurl.go#L54-L56
1. write fmt have a lots of overhead, use char push instead of `fmt::Write` could be twice faster than before.
use this ad hoc bench: 

<details>
<summary>ad hoc bench code</summary>

```rs
use std::fmt::Write;
use std::str;
use std::time::Instant;

fn main() {
    let str = "
%, %3, %33, %333
%, %e, %ee, %eee
%, %E, %EE, %EEE
";
    let start = Instant::now();
    for i in 0..10000 {
        _ = encode_as_percent_escaped(str.as_bytes());
    }
    dbg!(&start.elapsed());

    let start = Instant::now();
    for i in 0..10000 {
        _ = encode_as_percent_escaped2(str.as_bytes());
    }
    dbg!(&start.elapsed());
}

pub fn encode_as_percent_escaped(buf: &[u8]) -> Option<String> {
    if let Ok(text) = str::from_utf8(buf) {
        let mut url = String::with_capacity(text.len() * 3);
        let chars = text.chars().collect::<Vec<_>>();
        let mut trailing_start = chars.len();
        while trailing_start > 0 {
            let c = chars[trailing_start - 1];
            if c > 0x20 as char || matches!(c, '\t' | '\n' | '\r') {
                break;
            }
            trailing_start -= 1;
        }
        for (i, &c) in chars.iter().enumerate() {
            if matches!(c, '\t' | '\n' | '\r' | '#')
                || i >= trailing_start
                || (c == '%'
                    && i + 2 < chars.len()
                    && chars[i + 1].is_ascii_hexdigit()
                    && chars[i + 2].is_ascii_hexdigit())
            {
                write!(url, "%{:02X}", c as u8).unwrap();
            } else {
                url.push(c);
            }
        }
        Some(url)
    } else {
        None
    }
}

const bytes: [char; 16] = [
    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
];
pub fn encode_as_percent_escaped2(buf: &[u8]) -> Option<String> {
    if let Ok(text) = str::from_utf8(buf) {
        let mut url = String::with_capacity(text.len() * 3);
        let chars = text.chars().collect::<Vec<_>>();
        let mut trailing_start = chars.len();
        while trailing_start > 0 {
            let c = chars[trailing_start - 1];
            if c > 0x20 as char || matches!(c, '\t' | '\n' | '\r') {
                break;
            }
            trailing_start -= 1;
        }
        for (i, &c) in chars.iter().enumerate() {
            if matches!(c, '\t' | '\n' | '\r' | '#')
                || i >= trailing_start
                || (c == '%'
                    && i + 2 < chars.len()
                    && chars[i + 1].is_ascii_hexdigit()
                    && chars[i + 2].is_ascii_hexdigit())
            {
                url.push('%');
                url.push(bytes[c as usize >> 4]);
                url.push(bytes[c as usize & 15]);
            } else {
                url.push(c);
            }
        }
        Some(url)
    } else {
        None
    }
}
```
</details>

```bash
[src/main.rs:15:5] &start.elapsed() = 3.879561ms
[src/main.rs:21:5] &start.elapsed() = 1.616217ms
```
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
