### PR TITLE
refactor(rust/plugin)!: rename `HookResolveIdArgs#source` to `HookResolveIdArgs#specifier`

### DIFF
--- a/crates/rolldown/tests/fixtures/issues/1733/mod.rs
+++ b/crates/rolldown/tests/fixtures/issues/1733/mod.rs
@@ -21,8 +21,8 @@ impl Plugin for ExternalCss {
     _ctx: &SharedPluginContext,
     args: &HookResolveIdArgs,
   ) -> HookResolveIdReturn {
-    if args.source.as_path().extension().map_or(false, |ext| ext.eq_ignore_ascii_case("css")) {
-      let path = format!("rewritten-{}", args.source);
+    if args.specifier.as_path().extension().map_or(false, |ext| ext.eq_ignore_ascii_case("css")) {
+      let path = format!("rewritten-{}", args.specifier);
       return Ok(Some(HookResolveIdOutput {
         id: path,
         external: Some(true),

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -58,7 +58,7 @@ impl Plugin for JsPlugin {
       Ok(
         cb.await_call((
           Arc::clone(ctx).into(),
-          args.source.to_string(),
+          args.specifier.to_string(),
           args.importer.map(str::to_string),
           args.options.clone().into(),
         ))

--- a/crates/rolldown_plugin/src/types/hook_resolve_id_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_resolve_id_args.rs
@@ -3,6 +3,6 @@ use super::hook_resolve_id_extra_options::HookResolveIdExtraOptions;
 #[derive(Debug)]
 pub struct HookResolveIdArgs<'a> {
   pub importer: Option<&'a str>,
-  pub source: &'a str,
+  pub specifier: &'a str,
   pub options: HookResolveIdExtraOptions,
 }

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -45,7 +45,7 @@ pub async fn resolve_id_with_plugins(
   if let Some(r) = plugin_driver
     .resolve_id(&HookResolveIdArgs {
       importer: importer.map(std::convert::AsRef::as_ref),
-      source: request,
+      specifier: request,
       options,
     })
     .await?

--- a/crates/rolldown_plugin_wasm/src/lib.rs
+++ b/crates/rolldown_plugin_wasm/src/lib.rs
@@ -22,7 +22,7 @@ impl Plugin for WasmPlugin {
     _ctx: &SharedPluginContext,
     args: &HookResolveIdArgs,
   ) -> HookResolveIdReturn {
-    if args.source == WASM_RUNTIME {
+    if args.specifier == WASM_RUNTIME {
       Ok(Some(HookResolveIdOutput { id: WASM_RUNTIME.to_string(), ..Default::default() }))
     } else {
       Ok(None)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`source` is really a confusing name compared to `specifier`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
