### PR TITLE
refactor: use macros to reduce duplicated codes in injection fields.

### DIFF
--- a/crates/rolldown/src/ecmascript/format/app.rs
+++ b/crates/rolldown/src/ecmascript/format/app.rs
@@ -1,6 +1,9 @@
 use rolldown_sourcemap::{ConcatSource, RawSource};
 
-use crate::{ecmascript::ecma_generator::RenderedModuleSources, types::generator::GenerateContext};
+use crate::{
+  append_injection, ecmascript::ecma_generator::RenderedModuleSources,
+  types::generator::GenerateContext,
+};
 
 pub fn render_app(
   _ctx: &GenerateContext<'_>,
@@ -12,15 +15,7 @@ pub fn render_app(
 ) -> ConcatSource {
   let mut concat_source = ConcatSource::default();
 
-  if let Some(banner) = banner {
-    concat_source.add_source(Box::new(RawSource::new(banner)));
-  }
-
-  if let Some(intro) = intro {
-    if !intro.is_empty() {
-      concat_source.add_source(Box::new(RawSource::new(intro)));
-    }
-  }
+  append_injection!(concat_source, banner, intro);
 
   // chunk content
   module_sources.into_iter().for_each(|(_, _, module_render_output)| {
@@ -31,15 +26,7 @@ pub fn render_app(
     }
   });
 
-  if let Some(outro) = outro {
-    if !outro.is_empty() {
-      concat_source.add_source(Box::new(RawSource::new(outro)));
-    }
-  }
-
-  if let Some(footer) = footer {
-    concat_source.add_source(Box::new(RawSource::new(footer)));
-  }
+  append_injection!(concat_source, footer, outro);
 
   concat_source
 }

--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -2,6 +2,7 @@ use rolldown_error::DiagnosableResult;
 use rolldown_sourcemap::{ConcatSource, RawSource};
 
 use crate::{
+  append_injection,
   ecmascript::ecma_generator::RenderedModuleSources,
   types::generator::GenerateContext,
   utils::chunk::{
@@ -23,19 +24,13 @@ pub fn render_cjs(
 ) -> DiagnosableResult<ConcatSource> {
   let mut concat_source = ConcatSource::default();
 
-  if let Some(banner) = banner {
-    concat_source.add_source(Box::new(RawSource::new(banner)));
-  }
+  append_injection!(concat_source, banner);
 
   if determine_use_strict(ctx) {
     concat_source.add_source(Box::new(RawSource::new("\"use strict\";".to_string())));
   }
 
-  if let Some(intro) = intro {
-    if !intro.is_empty() {
-      concat_source.add_source(Box::new(RawSource::new(intro)));
-    }
-  }
+  append_injection!(concat_source, intro);
 
   // Runtime module should be placed before the generated `requires` in CJS format.
   // Because, we might need to generate `__toESM(require(...))` that relies on the runtime module.
@@ -68,15 +63,7 @@ pub fn render_cjs(
     concat_source.add_source(Box::new(RawSource::new(exports)));
   }
 
-  if let Some(outro) = outro {
-    if !outro.is_empty() {
-      concat_source.add_source(Box::new(RawSource::new(outro)));
-    }
-  }
-
-  if let Some(footer) = footer {
-    concat_source.add_source(Box::new(RawSource::new(footer)));
-  }
+  append_injection!(concat_source, outro, footer);
 
   Ok(concat_source)
 }

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -3,6 +3,7 @@ use rolldown_error::DiagnosableResult;
 use rolldown_sourcemap::{ConcatSource, RawSource};
 
 use crate::{
+  append_injection,
   ecmascript::ecma_generator::RenderedModuleSources,
   types::generator::GenerateContext,
   utils::chunk::{
@@ -23,15 +24,7 @@ pub fn render_esm(
 ) -> DiagnosableResult<ConcatSource> {
   let mut concat_source = ConcatSource::default();
 
-  if let Some(banner) = banner {
-    concat_source.add_source(Box::new(RawSource::new(banner)));
-  }
-
-  if let Some(intro) = intro {
-    if !intro.is_empty() {
-      concat_source.add_source(Box::new(RawSource::new(intro)));
-    }
-  }
+  append_injection!(concat_source, banner, intro);
 
   concat_source.add_source(Box::new(RawSource::new(render_esm_chunk_imports(ctx))));
 
@@ -73,15 +66,7 @@ pub fn render_esm(
     }
   }
 
-  if let Some(outro) = outro {
-    if !outro.is_empty() {
-      concat_source.add_source(Box::new(RawSource::new(outro)));
-    }
-  }
-
-  if let Some(footer) = footer {
-    concat_source.add_source(Box::new(RawSource::new(footer)));
-  }
+  append_injection!(concat_source, outro, footer);
 
   Ok(concat_source)
 }

--- a/crates/rolldown/src/ecmascript/format/mod.rs
+++ b/crates/rolldown/src/ecmascript/format/mod.rs
@@ -2,3 +2,4 @@ pub mod app;
 pub mod cjs;
 pub mod esm;
 pub mod iife;
+pub mod utils;

--- a/crates/rolldown/src/ecmascript/format/utils.rs
+++ b/crates/rolldown/src/ecmascript/format/utils.rs
@@ -1,0 +1,10 @@
+#[macro_export]
+macro_rules! append_injection {
+  ($concat_source:ident, $( $injection_name:ident ),*) => {
+    $(
+      if let Some($injection_name) = $injection_name {
+        $concat_source.add_source(Box::new(RawSource::new($injection_name)));
+      }
+    )*
+  };
+}

--- a/crates/rolldown/tests/fixtures/function/outro/iife/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/function/outro/iife/artifacts.snap
@@ -1,7 +1,7 @@
 ---
-source: crates/rolldown_testing/src/case/case.rs
-expression: content
-input_file: crates/rolldown/tests/fixtures/misc/outro/iife
+source: crates/rolldown_testing/src/integration_test.rs
+expression: snapshot
+input_file: crates/rolldown/tests/fixtures/function/outro/iife
 ---
 # Assets
 
@@ -16,7 +16,7 @@ input_file: crates/rolldown/tests/fixtures/misc/outro/iife
 var main_default = "banner";
 
 //#endregion
-// outro
 return main_default;
+// outro
 })();
 ```

--- a/crates/rolldown/tests/snapshots/integration_fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_fixtures__filename_with_hash.snap
@@ -1704,7 +1704,7 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/function/outro/iife
 
-- main-!~{000}~.mjs => main-svvw3JyV.mjs
+- main-!~{000}~.mjs => main-rzBDQzY9.mjs
 
 # tests/fixtures/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic
 

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -132,6 +132,14 @@ pub struct BindingPluginOptions {
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
   pub footer: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
+
+  #[serde(skip_deserializing)]
+  #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
+  pub intro: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
+
+  #[serde(skip_deserializing)]
+  #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
+  pub outro: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 }
 
 impl Debug for BindingPluginOptions {

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -162,12 +162,47 @@ impl Plugin for JsPlugin {
     Ok(())
   }
 
+  // TODO use macros to generate these hooks
   async fn banner(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    args: &rolldown_plugin::HookBannerArgs,
-  ) -> rolldown_plugin::HookBannerOutputReturn {
+    args: &rolldown_plugin::HookInjectionArgs,
+  ) -> rolldown_plugin::HookInjectionOutputReturn {
     if let Some(cb) = &self.banner {
+      Ok(
+        cb.await_call((Arc::clone(ctx).into(), args.chunk.clone().into()))
+          .await?
+          .map(TryInto::try_into)
+          .transpose()?,
+      )
+    } else {
+      Ok(None)
+    }
+  }
+
+  async fn intro(
+    &self,
+    ctx: &rolldown_plugin::SharedPluginContext,
+    args: &rolldown_plugin::HookInjectionArgs,
+  ) -> rolldown_plugin::HookInjectionOutputReturn {
+    if let Some(cb) = &self.intro {
+      Ok(
+        cb.await_call((Arc::clone(ctx).into(), args.chunk.clone().into()))
+          .await?
+          .map(TryInto::try_into)
+          .transpose()?,
+      )
+    } else {
+      Ok(None)
+    }
+  }
+
+  async fn outro(
+    &self,
+    ctx: &rolldown_plugin::SharedPluginContext,
+    args: &rolldown_plugin::HookInjectionArgs,
+  ) -> rolldown_plugin::HookInjectionOutputReturn {
+    if let Some(cb) = &self.outro {
       Ok(
         cb.await_call((Arc::clone(ctx).into(), args.chunk.clone().into()))
           .await?
@@ -182,8 +217,8 @@ impl Plugin for JsPlugin {
   async fn footer(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    args: &rolldown_plugin::HookFooterArgs,
-  ) -> rolldown_plugin::HookFooterOutputReturn {
+    args: &rolldown_plugin::HookInjectionArgs,
+  ) -> rolldown_plugin::HookInjectionOutputReturn {
     if let Some(cb) = &self.footer {
       Ok(
         cb.await_call((Arc::clone(ctx).into(), args.chunk.clone().into()))

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -3,6 +3,7 @@ mod plugin_context;
 mod plugin_driver;
 mod transform_plugin_context;
 mod types;
+#[macro_use]
 mod utils;
 /// For internal usage only
 pub mod inner {
@@ -11,16 +12,15 @@ pub mod inner {
 
 pub use crate::{
   plugin::{
-    BoxPlugin, HookAugmentChunkHashReturn, HookBannerOutputReturn, HookFooterOutputReturn,
-    HookLoadReturn, HookNoopReturn, HookRenderChunkReturn, HookResolveIdReturn,
-    HookTransformAstReturn, HookTransformReturn, Plugin, SharedPlugin,
+    BoxPlugin, HookAugmentChunkHashReturn, HookInjectionOutputReturn, HookLoadReturn,
+    HookNoopReturn, HookRenderChunkReturn, HookResolveIdReturn, HookTransformAstReturn,
+    HookTransformReturn, Plugin, SharedPlugin,
   },
   plugin_context::{PluginContext, SharedPluginContext},
   plugin_driver::{PluginDriver, SharedPluginDriver},
   transform_plugin_context::TransformPluginContext,
-  types::hook_banner_args::HookBannerArgs,
   types::hook_build_end_args::HookBuildEndArgs,
-  types::hook_footer_args::HookFooterArgs,
+  types::hook_injection_args::HookInjectionArgs,
   types::hook_load_args::HookLoadArgs,
   types::hook_load_output::HookLoadOutput,
   types::hook_render_chunk_args::HookRenderChunkArgs,

--- a/crates/rolldown_plugin/src/plugin.rs
+++ b/crates/rolldown_plugin/src/plugin.rs
@@ -4,10 +4,10 @@ use super::plugin_context::SharedPluginContext;
 use crate::{
   transform_plugin_context::TransformPluginContext,
   types::{
-    hook_footer_args::HookFooterArgs, hook_render_error::HookRenderErrorArgs,
-    hook_transform_ast_args::HookTransformAstArgs, hook_transform_output::HookTransformOutput,
+    hook_render_error::HookRenderErrorArgs, hook_transform_ast_args::HookTransformAstArgs,
+    hook_transform_output::HookTransformOutput,
   },
-  HookBannerArgs, HookBuildEndArgs, HookLoadArgs, HookLoadOutput, HookRenderChunkArgs,
+  HookBuildEndArgs, HookInjectionArgs, HookLoadArgs, HookLoadOutput, HookRenderChunkArgs,
   HookRenderChunkOutput, HookResolveDynamicImportArgs, HookResolveIdArgs, HookResolveIdOutput,
   HookTransformArgs,
 };
@@ -22,8 +22,7 @@ pub type HookLoadReturn = Result<Option<HookLoadOutput>>;
 pub type HookNoopReturn = Result<()>;
 pub type HookRenderChunkReturn = Result<Option<HookRenderChunkOutput>>;
 pub type HookAugmentChunkHashReturn = Result<Option<String>>;
-pub type HookBannerOutputReturn = Result<Option<String>>;
-pub type HookFooterOutputReturn = Result<Option<String>>;
+pub type HookInjectionOutputReturn = Result<Option<String>>;
 
 #[async_trait::async_trait]
 pub trait Plugin: Any + Debug + Send + Sync + 'static {
@@ -98,19 +97,36 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
     Ok(())
   }
 
+  // TODO use macros to
   async fn banner(
     &self,
     _ctx: &SharedPluginContext,
-    _args: &HookBannerArgs,
-  ) -> HookBannerOutputReturn {
+    _args: &HookInjectionArgs,
+  ) -> HookInjectionOutputReturn {
     Ok(None)
   }
 
   async fn footer(
     &self,
     _ctx: &SharedPluginContext,
-    _args: &HookFooterArgs,
-  ) -> HookFooterOutputReturn {
+    _args: &HookInjectionArgs,
+  ) -> HookInjectionOutputReturn {
+    Ok(None)
+  }
+
+  async fn intro(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookInjectionArgs,
+  ) -> HookInjectionOutputReturn {
+    Ok(None)
+  }
+
+  async fn outro(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookInjectionArgs,
+  ) -> HookInjectionOutputReturn {
     Ok(None)
   }
 

--- a/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
@@ -1,6 +1,7 @@
+use crate::define_injection_hooks;
 use crate::types::hook_render_error::HookRenderErrorArgs;
-use crate::{HookAugmentChunkHashReturn, HookFooterArgs, HookNoopReturn, HookRenderChunkArgs};
-use crate::{HookBannerArgs, PluginDriver};
+use crate::{HookAugmentChunkHashReturn, HookNoopReturn, HookRenderChunkArgs};
+use crate::{HookInjectionArgs, PluginDriver};
 use anyhow::{Ok, Result};
 use rolldown_common::{Output, RollupRenderedChunk};
 use rolldown_sourcemap::SourceMap;
@@ -13,39 +14,7 @@ impl PluginDriver {
     Ok(())
   }
 
-  pub async fn banner(
-    &self,
-    args: HookBannerArgs<'_>,
-    mut banner: String,
-  ) -> Result<Option<String>> {
-    for (plugin, ctx) in &self.plugins {
-      if let Some(r) = plugin.banner(ctx, &args).await? {
-        banner.push('\n');
-        banner.push_str(r.as_str());
-      }
-    }
-    if banner.is_empty() {
-      return Ok(None);
-    }
-    Ok(Some(banner))
-  }
-
-  pub async fn footer(
-    &self,
-    args: HookFooterArgs<'_>,
-    mut footer: String,
-  ) -> Result<Option<String>> {
-    for (plugin, ctx) in &self.plugins {
-      if let Some(r) = plugin.footer(ctx, &args).await? {
-        footer.push('\n');
-        footer.push_str(r.as_str());
-      }
-    }
-    if footer.is_empty() {
-      return Ok(None);
-    }
-    Ok(Some(footer))
-  }
+  define_injection_hooks!(banner, footer, intro, outro);
 
   pub async fn render_chunk(
     &self,

--- a/crates/rolldown_plugin/src/types/hook_footer_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_footer_args.rs
@@ -1,6 +1,0 @@
-use rolldown_common::RollupRenderedChunk;
-
-#[derive(Debug)]
-pub struct HookFooterArgs<'a> {
-  pub chunk: &'a RollupRenderedChunk,
-}

--- a/crates/rolldown_plugin/src/types/hook_injection_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_injection_args.rs
@@ -1,6 +1,6 @@
 use rolldown_common::RollupRenderedChunk;
 
 #[derive(Debug)]
-pub struct HookBannerArgs<'a> {
+pub struct HookInjectionArgs<'a> {
   pub chunk: &'a RollupRenderedChunk,
 }

--- a/crates/rolldown_plugin/src/types/mod.rs
+++ b/crates/rolldown_plugin/src/types/mod.rs
@@ -1,6 +1,5 @@
-pub mod hook_banner_args;
 pub mod hook_build_end_args;
-pub mod hook_footer_args;
+pub mod hook_injection_args;
 pub mod hook_load_args;
 pub mod hook_load_output;
 pub mod hook_render_chunk_args;

--- a/crates/rolldown_plugin/src/utils/injection_hook_macros.rs
+++ b/crates/rolldown_plugin/src/utils/injection_hook_macros.rs
@@ -1,0 +1,38 @@
+#[macro_export]
+macro_rules! define_injection_hooks {
+  ($( $injection_name:ident ),*) => {
+    $(
+      pub async fn $injection_name(
+        &self,
+        args: HookInjectionArgs<'_>,
+        mut $injection_name: String,
+      ) -> Result<Option<String>> {
+        for (plugin, ctx) in &self.plugins {
+          if let Some(r) = plugin.$injection_name(ctx, &args).await? {
+            $injection_name.push('\n');
+            $injection_name.push_str(r.as_str());
+          }
+        }
+        if $injection_name.is_empty() {
+          return Ok(None);
+        }
+        Ok(Some($injection_name))
+      }
+    )*
+  };
+}
+
+#[macro_export]
+macro_rules! define_injection_hooks_trait {
+  ($( $injection_name:ident ),*) => {
+    $(
+      async fn $injection_name(
+        &self,
+        _ctx: &SharedPluginContext,
+        _args: &HookInjectionArgs,
+      ) -> HookInjectionOutputReturn {
+        Ok(None)
+      }
+    )*
+  };
+}

--- a/crates/rolldown_plugin/src/utils/mod.rs
+++ b/crates/rolldown_plugin/src/utils/mod.rs
@@ -1,1 +1,2 @@
+pub mod injection_hook_macros;
 pub mod resolve_id_with_plugins;

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -228,6 +228,8 @@ export interface BindingPluginOptions {
   writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>
   banner?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
   footer?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+  intro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+  outro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
 }
 
 export interface BindingPluginWithIndex {

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -187,3 +187,43 @@ export function bindingifyFooter(
     )
   }
 }
+
+export function bindingifyIntro(
+  plugin: Plugin,
+  options: NormalizedInputOptions,
+  pluginContextData: PluginContextData,
+): BindingPluginOptions['intro'] {
+  const hook = plugin.intro
+  if (!hook) {
+    return undefined
+  }
+
+  const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
+
+  return async (ctx, chunk) => {
+    return handler.call(
+      new PluginContext(options, ctx, plugin, pluginContextData),
+      chunk,
+    )
+  }
+}
+
+export function bindingifyOutro(
+  plugin: Plugin,
+  options: NormalizedInputOptions,
+  pluginContextData: PluginContextData,
+): BindingPluginOptions['outro'] {
+  const hook = plugin.outro
+  if (!hook) {
+    return undefined
+  }
+
+  const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
+
+  return async (ctx, chunk) => {
+    return handler.call(
+      new PluginContext(options, ctx, plugin, pluginContextData),
+      chunk,
+    )
+  }
+}

--- a/packages/rolldown/src/plugin/bindingify-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin.ts
@@ -18,6 +18,8 @@ import {
   bindingifyAugmentChunkHash,
   bindingifyBanner,
   bindingifyFooter,
+  bindingifyIntro,
+  bindingifyOutro,
 } from './bindingify-output-hooks'
 
 import type { Plugin } from './index'
@@ -77,5 +79,7 @@ export function bindingifyPlugin(
     ),
     banner: bindingifyBanner(plugin, options, pluginContextData),
     footer: bindingifyFooter(plugin, options, pluginContextData),
+    intro: bindingifyIntro(plugin, options, pluginContextData),
+    outro: bindingifyOutro(plugin, options, pluginContextData),
   }
 }

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -178,7 +178,7 @@ export type SequentialPluginHooks =
   | 'renderChunk'
   | 'transform'
 
-export type AddonHooks = 'banner' | 'footer' /* | 'intro' | 'outro' */
+export type AddonHooks = 'banner' | 'footer' | 'intro' | 'outro'
 
 export type OutputPluginHooks =
   | 'augmentChunkHash'

--- a/packages/rolldown/src/utils/compose-js-plugins.ts
+++ b/packages/rolldown/src/utils/compose-js-plugins.ts
@@ -84,6 +84,8 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
         case 'augmentChunkHash':
         case 'banner':
         case 'footer':
+        case 'intro':
+        case 'outro':
         case 'generateBundle':
         case 'moduleParsed':
         case 'onLog':
@@ -230,6 +232,8 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
         case 'augmentChunkHash':
         case 'banner':
         case 'footer':
+        case 'intro':
+        case 'outro':
         case 'generateBundle':
         case 'moduleParsed':
         case 'onLog':

--- a/packages/rolldown/tests/fixtures/plugin/intro/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/intro/_config.ts
@@ -1,0 +1,20 @@
+import { expect, vi } from 'vitest'
+import path from 'node:path'
+import { defineTest } from '@tests'
+
+const entry = path.join(__dirname, './main.js')
+
+export default defineTest({
+  config: {
+    input: entry,
+    plugins: [
+      {
+        name: 'test-plugin',
+        intro: () => '/* Lorem ipsum */',
+      },
+    ],
+  },
+  afterTest: (output) => {
+    expect(output.output[0].code).toContain('/* Lorem ipsum */')
+  },
+})

--- a/packages/rolldown/tests/fixtures/plugin/intro/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/intro/main.js
@@ -1,0 +1,1 @@
+console.log()

--- a/packages/rolldown/tests/fixtures/plugin/outro/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/outro/_config.ts
@@ -1,0 +1,20 @@
+import { expect, vi } from 'vitest'
+import path from 'node:path'
+import { defineTest } from '@tests'
+
+const entry = path.join(__dirname, './main.js')
+
+export default defineTest({
+  config: {
+    input: entry,
+    plugins: [
+      {
+        name: 'test-plugin',
+        outro: () => '/* Lorem ipsum */',
+      },
+    ],
+  },
+  afterTest: (output) => {
+    expect(output.output[0].code).toContain('/* Lorem ipsum */')
+  },
+})

--- a/packages/rolldown/tests/fixtures/plugin/outro/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/outro/main.js
@@ -1,0 +1,1 @@
+console.log()


### PR DESCRIPTION
#### Introduction

This PR introduces several improvements and new features, focusing on code optimization and support for additional plugin functionalities.

#### Contents

1. **Code Optimization using Macros:**
    - Introduced macros to reduce duplicated code in `ecma_generator.rs`, specifically targeting the format renderers.
    - The `Plugin` trait is excluded from macro optimization due to an issue with async traits not being compatible with the macros.

2. **Plugin Enhancements:**
    - Added support for `intro` and `outro` in plugins, using #1713 as a reference example.

By utilizing macros, we've significantly reduced the amount of duplicated code, making the codebase cleaner and easier to maintain.