### PR TITLE
refactor(rust/plugin)!: drop `async_trait::async_trait` for writting `Plugin` and rename old `Plugin` to `Pluginable`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,7 +2137,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arcstr",
- "async-trait",
  "bitflags 2.6.0",
  "daachorse",
  "dunce",
@@ -2292,7 +2291,6 @@ dependencies = [
 name = "rolldown_plugin_data_url"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "base64-simd 0.8.0",
  "dashmap 6.0.1",
  "regex",
@@ -2306,7 +2304,6 @@ dependencies = [
 name = "rolldown_plugin_glob_import"
 version = "0.0.1"
 dependencies = [
- "async-trait",
  "glob",
  "oxc",
  "rolldown_plugin",
@@ -2317,7 +2314,6 @@ dependencies = [
 name = "rolldown_plugin_wasm"
 version = "0.0.1"
 dependencies = [
- "async-trait",
  "rolldown_common",
  "rolldown_plugin",
 ]

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -27,7 +27,7 @@ rolldown_ecmascript      = { workspace = true }
 rolldown_error           = { workspace = true }
 rolldown_fs              = { workspace = true, features = ["os"] }
 rolldown_loader_utils    = { workspace = true }
-rolldown_plugin          = { workspace = true }
+rolldown_plugin          = { workspace = true, features = ["inner"] }
 rolldown_plugin_data_url = { workspace = true }
 rolldown_resolver        = { workspace = true }
 rolldown_rstr            = { workspace = true }
@@ -42,7 +42,6 @@ tracing-chrome           = { workspace = true }
 xxhash-rust              = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]
-async-trait      = { workspace = true }
 glob             = { workspace = true }
 insta            = { workspace = true }
 rolldown_testing = { workspace = true }

--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -15,7 +15,8 @@ use rolldown_common::{NormalizedBundlerOptions, SharedFileEmitter};
 use rolldown_error::{BuildDiagnostic, DiagnosableResult};
 use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_plugin::{
-  HookBuildEndArgs, HookRenderErrorArgs, PluginDriver, SharedPlugin, SharedPluginDriver,
+  HookBuildEndArgs, HookRenderErrorArgs, PluginDriver, SharedPluginDriver,
+  __inner::SharedPluginable,
 };
 use tracing_chrome::FlushGuard;
 
@@ -33,7 +34,7 @@ impl Bundler {
     BundlerBuilder::default().with_options(options).build()
   }
 
-  pub fn with_plugins(options: BundlerOptions, plugins: Vec<SharedPlugin>) -> Self {
+  pub fn with_plugins(options: BundlerOptions, plugins: Vec<SharedPluginable>) -> Self {
     BundlerBuilder::default().with_options(options).with_plugins(plugins).build()
   }
 }

--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rolldown_common::FileEmitter;
 use rolldown_fs::OsFileSystem;
-use rolldown_plugin::{PluginDriver, SharedPlugin};
+use rolldown_plugin::{PluginDriver, __inner::SharedPluginable};
 use rolldown_resolver::Resolver;
 
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
 #[derive(Debug, Default)]
 pub struct BundlerBuilder {
   options: BundlerOptions,
-  plugins: Vec<SharedPlugin>,
+  plugins: Vec<SharedPluginable>,
 }
 
 impl BundlerBuilder {
@@ -51,7 +51,7 @@ impl BundlerBuilder {
   }
 
   #[must_use]
-  pub fn with_plugins(mut self, plugins: Vec<SharedPlugin>) -> Self {
+  pub fn with_plugins(mut self, plugins: Vec<SharedPluginable>) -> Self {
     self.plugins = plugins;
     self
   }

--- a/crates/rolldown/src/utils/apply_inner_plugins.rs
+++ b/crates/rolldown/src/utils/apply_inner_plugins.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use rolldown_plugin::SharedPlugin;
+use rolldown_plugin::__inner::SharedPluginable;
 
 /// Some builtin features of rolldown is implemented via plugins. However, though these features
 /// are implemented via plugins, users could not feel the existence of these plugins. And to do so,
 /// we need to apply these plugins after user's plugins to control the final order of plugins.
-pub fn apply_inner_plugins(user_plugins: &mut Vec<SharedPlugin>) {
+pub fn apply_inner_plugins(user_plugins: &mut Vec<SharedPluginable>) {
   user_plugins.push(Arc::new(rolldown_plugin_data_url::DataUrlPlugin::default()));
 }

--- a/crates/rolldown/src/utils/resolve_id.rs
+++ b/crates/rolldown/src/utils/resolve_id.rs
@@ -1,1 +1,1 @@
-pub use rolldown_plugin::inner::resolve_id_with_plugins as resolve_id;
+pub use rolldown_plugin::__inner::resolve_id_with_plugins as resolve_id;

--- a/crates/rolldown/tests/fixtures/issues/1733/mod.rs
+++ b/crates/rolldown/tests/fixtures/issues/1733/mod.rs
@@ -10,7 +10,6 @@ use sugar_path::SugarPath;
 #[derive(Debug)]
 struct ExternalCss;
 
-#[async_trait::async_trait]
 impl Plugin for ExternalCss {
   fn name(&self) -> Cow<'static, str> {
     "external-css".into()
@@ -19,7 +18,7 @@ impl Plugin for ExternalCss {
   async fn resolve_id(
     &self,
     _ctx: &SharedPluginContext,
-    args: &HookResolveIdArgs,
+    args: &HookResolveIdArgs<'_>,
   ) -> HookResolveIdReturn {
     if args.specifier.as_path().extension().map_or(false, |ext| ext.eq_ignore_ascii_case("css")) {
       let path = format!("rewritten-{}", args.specifier);

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use derivative::Derivative;
 use napi::JsUnknown;
 use napi_derive::napi;
-use rolldown_plugin::Plugin;
+use rolldown_plugin::__inner::Pluginable;
 use rolldown_plugin_glob_import::GlobImportPlugin;
 use rolldown_plugin_wasm::WasmPlugin;
 use serde::Deserialize;
@@ -32,7 +32,7 @@ pub enum BindingBuiltinPluginName {
   GlobImportPlugin,
 }
 
-impl From<BindingBuiltinPlugin> for Arc<dyn Plugin> {
+impl From<BindingBuiltinPlugin> for Arc<dyn Pluginable> {
   fn from(plugin: BindingBuiltinPlugin) -> Self {
     match plugin.name {
       BindingBuiltinPluginName::WasmPlugin => Arc::new(WasmPlugin {}),

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -2,7 +2,7 @@ use crate::types::{
   binding_module_info::BindingModuleInfo, binding_outputs::BindingOutputs,
   js_callback::MaybeAsyncJsCallbackExt,
 };
-use rolldown_plugin::{Plugin, SharedPlugin};
+use rolldown_plugin::{Plugin, __inner::SharedPluginable};
 use std::{borrow::Cow, ops::Deref, sync::Arc};
 
 use super::{binding_transform_context::BindingTransformPluginContext, BindingPluginOptions};
@@ -26,12 +26,11 @@ impl JsPlugin {
     Self { inner }
   }
 
-  pub(crate) fn new_shared(inner: BindingPluginOptions) -> SharedPlugin {
+  pub(crate) fn new_shared(inner: BindingPluginOptions) -> SharedPluginable {
     Arc::new(Self { inner })
   }
 }
 
-#[async_trait::async_trait]
 impl Plugin for JsPlugin {
   fn name(&self) -> Cow<'static, str> {
     Cow::Owned(self.name.clone())
@@ -52,7 +51,7 @@ impl Plugin for JsPlugin {
   async fn resolve_id(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    args: &rolldown_plugin::HookResolveIdArgs,
+    args: &rolldown_plugin::HookResolveIdArgs<'_>,
   ) -> rolldown_plugin::HookResolveIdReturn {
     if let Some(cb) = &self.resolve_id {
       Ok(
@@ -73,7 +72,7 @@ impl Plugin for JsPlugin {
   async fn resolve_dynamic_import(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    args: &rolldown_plugin::HookResolveDynamicImportArgs,
+    args: &rolldown_plugin::HookResolveDynamicImportArgs<'_>,
   ) -> rolldown_plugin::HookResolveIdReturn {
     if let Some(cb) = &self.resolve_dynamic_import {
       Ok(
@@ -93,7 +92,7 @@ impl Plugin for JsPlugin {
   async fn load(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    args: &rolldown_plugin::HookLoadArgs,
+    args: &rolldown_plugin::HookLoadArgs<'_>,
   ) -> rolldown_plugin::HookLoadReturn {
     if let Some(cb) = &self.load {
       Ok(
@@ -110,7 +109,7 @@ impl Plugin for JsPlugin {
   async fn transform(
     &self,
     ctx: &rolldown_plugin::TransformPluginContext<'_>,
-    args: &rolldown_plugin::HookTransformArgs,
+    args: &rolldown_plugin::HookTransformArgs<'_>,
   ) -> rolldown_plugin::HookTransformReturn {
     if let Some(cb) = &self.transform {
       Ok(
@@ -165,7 +164,7 @@ impl Plugin for JsPlugin {
   async fn banner(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    args: &rolldown_plugin::HookBannerArgs,
+    args: &rolldown_plugin::HookBannerArgs<'_>,
   ) -> rolldown_plugin::HookBannerOutputReturn {
     if let Some(cb) = &self.banner {
       Ok(
@@ -182,7 +181,7 @@ impl Plugin for JsPlugin {
   async fn footer(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    args: &rolldown_plugin::HookFooterArgs,
+    args: &rolldown_plugin::HookFooterArgs<'_>,
   ) -> rolldown_plugin::HookFooterOutputReturn {
     if let Some(cb) = &self.footer {
       Ok(
@@ -199,7 +198,7 @@ impl Plugin for JsPlugin {
   async fn render_chunk(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    args: &rolldown_plugin::HookRenderChunkArgs,
+    args: &rolldown_plugin::HookRenderChunkArgs<'_>,
   ) -> rolldown_plugin::HookRenderChunkReturn {
     if let Some(cb) = &self.render_chunk {
       Ok(

--- a/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 #[cfg(not(target_family = "wasm"))]
 use futures::future::{self, BoxFuture};
 #[cfg(not(target_family = "wasm"))]
-use rolldown_plugin::Plugin;
+use rolldown_plugin::__inner::Pluginable;
 
 use crate::worker_manager::WorkerManager;
 
@@ -25,7 +25,7 @@ impl ParallelJsPlugin {
   pub fn new_boxed(
     plugins: Vec<BindingPluginOptions>,
     worker_manager: Arc<WorkerManager>,
-  ) -> Box<dyn Plugin> {
+  ) -> Box<dyn Pluginable> {
     let plugins = plugins.into_iter().map(JsPlugin::new).collect::<Vec<_>>().into_boxed_slice();
     Box::new(Self { plugins, worker_manager })
   }
@@ -33,7 +33,7 @@ impl ParallelJsPlugin {
   pub fn new_shared(
     plugins: Vec<BindingPluginOptions>,
     worker_manager: Arc<WorkerManager>,
-  ) -> Arc<dyn Plugin> {
+  ) -> Arc<dyn Pluginable> {
     let plugins = plugins.into_iter().map(JsPlugin::new).collect::<Vec<_>>().into_boxed_slice();
     Arc::new(Self { plugins, worker_manager })
   }
@@ -66,7 +66,7 @@ impl ParallelJsPlugin {
 
 #[cfg(not(target_family = "wasm"))]
 #[async_trait::async_trait]
-impl Plugin for ParallelJsPlugin {
+impl Pluginable for ParallelJsPlugin {
   fn name(&self) -> Cow<'static, str> {
     self.first_plugin().name()
   }

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -9,7 +9,7 @@ use napi::Either;
 use rolldown::{
   AddonOutputOption, BundlerOptions, IsExternal, ModuleType, OutputExports, OutputFormat, Platform,
 };
-use rolldown_plugin::SharedPlugin;
+use rolldown_plugin::__inner::SharedPluginable;
 use std::collections::HashMap;
 use std::path::PathBuf;
 #[cfg(not(target_family = "wasm"))]
@@ -18,7 +18,7 @@ use std::sync::Arc;
 #[cfg_attr(target_family = "wasm", allow(unused))]
 pub struct NormalizeBindingOptionsReturn {
   pub bundler_options: BundlerOptions,
-  pub plugins: Vec<SharedPlugin>,
+  pub plugins: Vec<SharedPluginable>,
 }
 
 fn normalize_addon_option(
@@ -149,7 +149,7 @@ pub fn normalize_binding_options(
   let worker_manager = worker_manager.map(Arc::new);
 
   #[cfg(not(target_family = "wasm"))]
-  let plugins: Vec<SharedPlugin> = input_options
+  let plugins: Vec<SharedPluginable> = input_options
     .plugins
     .into_iter()
     .chain(output_options.plugins)
@@ -173,7 +173,7 @@ pub fn normalize_binding_options(
     .collect::<Vec<_>>();
 
   #[cfg(target_family = "wasm")]
-  let plugins: Vec<SharedPlugin> = input_options
+  let plugins: Vec<SharedPluginable> = input_options
     .plugins
     .into_iter()
     .chain(output_options.plugins)

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -8,6 +8,9 @@ version              = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+inner = []
+
 [lints]
 workspace = true
 

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -1,19 +1,23 @@
 mod plugin;
 mod plugin_context;
 mod plugin_driver;
+mod pluginable;
 mod transform_plugin_context;
 mod types;
 mod utils;
-/// For internal usage only
-pub mod inner {
+
+/// Only for usage by the rolldown's crate. Do not use this directly.
+#[cfg(feature = "inner")]
+pub mod __inner {
   pub use super::utils::resolve_id_with_plugins::resolve_id_with_plugins;
+  pub use crate::pluginable::{BoxPluginable, Pluginable, SharedPluginable};
 }
 
 pub use crate::{
   plugin::{
-    BoxPlugin, HookAugmentChunkHashReturn, HookBannerOutputReturn, HookFooterOutputReturn,
-    HookLoadReturn, HookNoopReturn, HookRenderChunkReturn, HookResolveIdReturn,
-    HookTransformAstReturn, HookTransformReturn, Plugin, SharedPlugin,
+    HookAugmentChunkHashReturn, HookBannerOutputReturn, HookFooterOutputReturn, HookLoadReturn,
+    HookNoopReturn, HookRenderChunkReturn, HookResolveIdReturn, HookTransformAstReturn,
+    HookTransformReturn, Plugin,
   },
   plugin_context::{PluginContext, SharedPluginContext},
   plugin_driver::{PluginDriver, SharedPluginDriver},

--- a/crates/rolldown_plugin/src/plugin.rs
+++ b/crates/rolldown_plugin/src/plugin.rs
@@ -25,7 +25,6 @@ pub type HookAugmentChunkHashReturn = Result<Option<String>>;
 pub type HookBannerOutputReturn = Result<Option<String>>;
 pub type HookFooterOutputReturn = Result<Option<String>>;
 
-#[async_trait::async_trait]
 pub trait Plugin: Any + Debug + Send + Sync + 'static {
   fn name(&self) -> Cow<'static, str>;
 
@@ -33,40 +32,131 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   // --- Build hooks ---
 
-  async fn build_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn {
-    Ok(())
-  }
-
-  async fn resolve_id(
+  fn build_start(
     &self,
     _ctx: &SharedPluginContext,
-    _args: &HookResolveIdArgs,
-  ) -> HookResolveIdReturn {
-    Ok(None)
+  ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
+    async { Ok(()) }
+  }
+
+  fn resolve_id(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookResolveIdArgs<'_>,
+  ) -> impl std::future::Future<Output = HookResolveIdReturn> + Send {
+    async { Ok(None) }
   }
 
   #[deprecated(
     note = "This hook is only for rollup compatibility, please use `resolve_id` instead."
   )]
-  async fn resolve_dynamic_import(
+  fn resolve_dynamic_import(
     &self,
     _ctx: &SharedPluginContext,
-    _args: &HookResolveDynamicImportArgs,
-  ) -> HookResolveIdReturn {
-    Ok(None)
+    _args: &HookResolveDynamicImportArgs<'_>,
+  ) -> impl std::future::Future<Output = HookResolveIdReturn> + Send {
+    async { Ok(None) }
   }
 
-  async fn load(&self, _ctx: &SharedPluginContext, _args: &HookLoadArgs) -> HookLoadReturn {
-    Ok(None)
+  fn load(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookLoadArgs<'_>,
+  ) -> impl std::future::Future<Output = HookLoadReturn> + Send {
+    async { Ok(None) }
   }
 
-  async fn transform(
+  fn transform(
     &self,
     _ctx: &TransformPluginContext<'_>,
-    _args: &HookTransformArgs,
-  ) -> HookTransformReturn {
-    Ok(None)
+    _args: &HookTransformArgs<'_>,
+  ) -> impl std::future::Future<Output = HookTransformReturn> + Send {
+    async { Ok(None) }
   }
+
+  fn module_parsed(
+    &self,
+    _ctx: &SharedPluginContext,
+    _module_info: Arc<ModuleInfo>,
+  ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
+    async { Ok(()) }
+  }
+
+  fn build_end(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: Option<&HookBuildEndArgs>,
+  ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
+    async { Ok(()) }
+  }
+
+  // --- Generate hooks ---
+
+  fn render_start(
+    &self,
+    _ctx: &SharedPluginContext,
+  ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
+    async { Ok(()) }
+  }
+
+  fn banner(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookBannerArgs<'_>,
+  ) -> impl std::future::Future<Output = HookBannerOutputReturn> + Send {
+    async { Ok(None) }
+  }
+
+  fn footer(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookFooterArgs<'_>,
+  ) -> impl std::future::Future<Output = HookFooterOutputReturn> + Send {
+    async { Ok(None) }
+  }
+
+  fn render_chunk(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookRenderChunkArgs<'_>,
+  ) -> impl std::future::Future<Output = HookRenderChunkReturn> + Send {
+    async { Ok(None) }
+  }
+
+  fn augment_chunk_hash(
+    &self,
+    _ctx: &SharedPluginContext,
+    _chunk: &RollupRenderedChunk,
+  ) -> impl std::future::Future<Output = HookAugmentChunkHashReturn> + Send {
+    async { Ok(None) }
+  }
+
+  fn render_error(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookRenderErrorArgs,
+  ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
+    async { Ok(()) }
+  }
+
+  fn generate_bundle(
+    &self,
+    _ctx: &SharedPluginContext,
+    _bundle: &mut Vec<Output>,
+    _is_write: bool,
+  ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
+    async { Ok(()) }
+  }
+
+  fn write_bundle(
+    &self,
+    _ctx: &SharedPluginContext,
+    _bundle: &mut Vec<Output>,
+  ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
+    async { Ok(()) }
+  }
+
+  // --- experimental hooks ---
 
   fn transform_ast(
     &self,
@@ -75,86 +165,4 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
   ) -> HookTransformAstReturn {
     Ok(args.ast)
   }
-
-  async fn module_parsed(
-    &self,
-    _ctx: &SharedPluginContext,
-    _module_info: Arc<ModuleInfo>,
-  ) -> HookNoopReturn {
-    Ok(())
-  }
-
-  async fn build_end(
-    &self,
-    _ctx: &SharedPluginContext,
-    _args: Option<&HookBuildEndArgs>,
-  ) -> HookNoopReturn {
-    Ok(())
-  }
-
-  // --- Generate hooks ---
-
-  async fn render_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn {
-    Ok(())
-  }
-
-  async fn banner(
-    &self,
-    _ctx: &SharedPluginContext,
-    _args: &HookBannerArgs,
-  ) -> HookBannerOutputReturn {
-    Ok(None)
-  }
-
-  async fn footer(
-    &self,
-    _ctx: &SharedPluginContext,
-    _args: &HookFooterArgs,
-  ) -> HookFooterOutputReturn {
-    Ok(None)
-  }
-
-  async fn render_chunk(
-    &self,
-    _ctx: &SharedPluginContext,
-    _args: &HookRenderChunkArgs,
-  ) -> HookRenderChunkReturn {
-    Ok(None)
-  }
-
-  async fn augment_chunk_hash(
-    &self,
-    _ctx: &SharedPluginContext,
-    _chunk: &RollupRenderedChunk,
-  ) -> HookAugmentChunkHashReturn {
-    Ok(None)
-  }
-
-  async fn render_error(
-    &self,
-    _ctx: &SharedPluginContext,
-    _args: &HookRenderErrorArgs,
-  ) -> HookNoopReturn {
-    Ok(())
-  }
-
-  async fn generate_bundle(
-    &self,
-    _ctx: &SharedPluginContext,
-    _bundle: &mut Vec<Output>,
-    _is_write: bool,
-  ) -> HookNoopReturn {
-    Ok(())
-  }
-
-  async fn write_bundle(
-    &self,
-    _ctx: &SharedPluginContext,
-    _bundle: &mut Vec<Output>,
-  ) -> HookNoopReturn {
-    Ok(())
-  }
 }
-
-pub type BoxPlugin = Box<dyn Plugin>;
-pub type SharedPlugin = Arc<dyn Plugin>;

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-  plugin::HookTransformAstReturn, types::hook_transform_ast_args::HookTransformAstArgs,
+  pluginable::HookTransformAstReturn, types::hook_transform_ast_args::HookTransformAstArgs,
   HookBuildEndArgs, HookLoadArgs, HookLoadReturn, HookNoopReturn, HookResolveDynamicImportArgs,
   HookResolveIdArgs, HookResolveIdReturn, HookTransformArgs, PluginDriver, TransformPluginContext,
 };

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Weak};
 use rolldown_common::{ModuleTable, SharedFileEmitter};
 use rolldown_resolver::Resolver;
 
-use crate::{plugin_context::SharedPluginContext, PluginContext, SharedPlugin};
+use crate::{__inner::SharedPluginable, plugin_context::SharedPluginContext, PluginContext};
 
 mod build_hooks;
 mod output_hooks;
@@ -11,12 +11,12 @@ mod output_hooks;
 pub type SharedPluginDriver = Arc<PluginDriver>;
 
 pub struct PluginDriver {
-  plugins: Vec<(SharedPlugin, SharedPluginContext)>,
+  plugins: Vec<(SharedPluginable, SharedPluginContext)>,
 }
 
 impl PluginDriver {
   pub fn new_shared(
-    plugins: Vec<SharedPlugin>,
+    plugins: Vec<SharedPluginable>,
     resolver: &Arc<Resolver>,
     file_emitter: &SharedFileEmitter,
   ) -> SharedPluginDriver {

--- a/crates/rolldown_plugin/src/pluginable.rs
+++ b/crates/rolldown_plugin/src/pluginable.rs
@@ -1,0 +1,287 @@
+use std::{any::Any, borrow::Cow, fmt::Debug, sync::Arc};
+
+use super::plugin_context::SharedPluginContext;
+use crate::{
+  transform_plugin_context::TransformPluginContext,
+  types::{
+    hook_footer_args::HookFooterArgs, hook_render_error::HookRenderErrorArgs,
+    hook_transform_ast_args::HookTransformAstArgs,
+  },
+  HookBannerArgs, HookBuildEndArgs, HookLoadArgs, HookRenderChunkArgs,
+  HookResolveDynamicImportArgs, HookResolveIdArgs, HookTransformArgs, Plugin,
+};
+use rolldown_common::{ModuleInfo, Output, RollupRenderedChunk};
+
+pub use crate::plugin::HookAugmentChunkHashReturn;
+pub use crate::plugin::HookBannerOutputReturn;
+pub use crate::plugin::HookFooterOutputReturn;
+pub use crate::plugin::HookLoadReturn;
+pub use crate::plugin::HookNoopReturn;
+pub use crate::plugin::HookRenderChunkReturn;
+pub use crate::plugin::HookResolveIdReturn;
+pub use crate::plugin::HookTransformAstReturn;
+pub use crate::plugin::HookTransformReturn;
+
+pub type BoxPluginable = Box<dyn Pluginable>;
+pub type SharedPluginable = Arc<dyn Pluginable>;
+
+/// `Pluginable` is under the hood trait that rolldown to run. It's not recommended to use this trait directly.
+/// To create a plugin, you should use [Plugin] trait instead.
+///
+/// The main reason we don't expose this trait is that it used `async_trait`, which make it rust-analyzer can't
+/// provide a good auto-completion experience.
+#[async_trait::async_trait]
+pub trait Pluginable: Any + Debug + Send + Sync + 'static {
+  fn name(&self) -> Cow<'static, str>;
+
+  // The `option` hook consider call at node side.
+
+  // --- Build hooks ---
+
+  async fn build_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn {
+    Ok(())
+  }
+
+  async fn resolve_id(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookResolveIdArgs,
+  ) -> HookResolveIdReturn {
+    Ok(None)
+  }
+
+  #[deprecated(
+    note = "This hook is only for rollup compatibility, please use `resolve_id` instead."
+  )]
+  async fn resolve_dynamic_import(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookResolveDynamicImportArgs,
+  ) -> HookResolveIdReturn {
+    Ok(None)
+  }
+
+  async fn load(&self, _ctx: &SharedPluginContext, _args: &HookLoadArgs) -> HookLoadReturn {
+    Ok(None)
+  }
+
+  async fn transform(
+    &self,
+    _ctx: &TransformPluginContext<'_>,
+    _args: &HookTransformArgs,
+  ) -> HookTransformReturn {
+    Ok(None)
+  }
+
+  fn transform_ast(
+    &self,
+    _ctx: &SharedPluginContext,
+    args: HookTransformAstArgs,
+  ) -> HookTransformAstReturn {
+    Ok(args.ast)
+  }
+
+  async fn module_parsed(
+    &self,
+    _ctx: &SharedPluginContext,
+    _module_info: Arc<ModuleInfo>,
+  ) -> HookNoopReturn {
+    Ok(())
+  }
+
+  async fn build_end(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: Option<&HookBuildEndArgs>,
+  ) -> HookNoopReturn {
+    Ok(())
+  }
+
+  // --- Generate hooks ---
+
+  async fn render_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn {
+    Ok(())
+  }
+
+  async fn banner(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookBannerArgs,
+  ) -> HookBannerOutputReturn {
+    Ok(None)
+  }
+
+  async fn footer(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookFooterArgs,
+  ) -> HookFooterOutputReturn {
+    Ok(None)
+  }
+
+  async fn render_chunk(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookRenderChunkArgs,
+  ) -> HookRenderChunkReturn {
+    Ok(None)
+  }
+
+  async fn augment_chunk_hash(
+    &self,
+    _ctx: &SharedPluginContext,
+    _chunk: &RollupRenderedChunk,
+  ) -> HookAugmentChunkHashReturn {
+    Ok(None)
+  }
+
+  async fn render_error(
+    &self,
+    _ctx: &SharedPluginContext,
+    _args: &HookRenderErrorArgs,
+  ) -> HookNoopReturn {
+    Ok(())
+  }
+
+  async fn generate_bundle(
+    &self,
+    _ctx: &SharedPluginContext,
+    _bundle: &mut Vec<Output>,
+    _is_write: bool,
+  ) -> HookNoopReturn {
+    Ok(())
+  }
+
+  async fn write_bundle(
+    &self,
+    _ctx: &SharedPluginContext,
+    _bundle: &mut Vec<Output>,
+  ) -> HookNoopReturn {
+    Ok(())
+  }
+}
+
+#[async_trait::async_trait]
+impl<T: Plugin> Pluginable for T {
+  fn name(&self) -> Cow<'static, str> {
+    Plugin::name(self)
+  }
+
+  async fn build_start(&self, ctx: &SharedPluginContext) -> HookNoopReturn {
+    Plugin::build_start(self, ctx).await
+  }
+
+  async fn resolve_id(
+    &self,
+    ctx: &SharedPluginContext,
+    args: &HookResolveIdArgs,
+  ) -> HookResolveIdReturn {
+    Plugin::resolve_id(self, ctx, args).await
+  }
+
+  #[allow(deprecated)]
+  async fn resolve_dynamic_import(
+    &self,
+    ctx: &SharedPluginContext,
+    args: &HookResolveDynamicImportArgs,
+  ) -> HookResolveIdReturn {
+    Plugin::resolve_dynamic_import(self, ctx, args).await
+  }
+
+  async fn load(&self, ctx: &SharedPluginContext, args: &HookLoadArgs) -> HookLoadReturn {
+    Plugin::load(self, ctx, args).await
+  }
+
+  async fn transform(
+    &self,
+    ctx: &TransformPluginContext<'_>,
+    args: &HookTransformArgs,
+  ) -> HookTransformReturn {
+    Plugin::transform(self, ctx, args).await
+  }
+
+  async fn module_parsed(
+    &self,
+    ctx: &SharedPluginContext,
+    module_info: Arc<ModuleInfo>,
+  ) -> HookNoopReturn {
+    Plugin::module_parsed(self, ctx, module_info).await
+  }
+
+  async fn build_end(
+    &self,
+    ctx: &SharedPluginContext,
+    args: Option<&HookBuildEndArgs>,
+  ) -> HookNoopReturn {
+    Plugin::build_end(self, ctx, args).await
+  }
+
+  async fn render_start(&self, ctx: &SharedPluginContext) -> HookNoopReturn {
+    Plugin::render_start(self, ctx).await
+  }
+
+  async fn banner(
+    &self,
+    ctx: &SharedPluginContext,
+    args: &HookBannerArgs,
+  ) -> HookBannerOutputReturn {
+    Plugin::banner(self, ctx, args).await
+  }
+
+  async fn footer(
+    &self,
+    ctx: &SharedPluginContext,
+    args: &HookFooterArgs,
+  ) -> HookFooterOutputReturn {
+    Plugin::footer(self, ctx, args).await
+  }
+
+  async fn render_chunk(
+    &self,
+    ctx: &SharedPluginContext,
+    args: &HookRenderChunkArgs,
+  ) -> HookRenderChunkReturn {
+    Plugin::render_chunk(self, ctx, args).await
+  }
+
+  async fn augment_chunk_hash(
+    &self,
+    ctx: &SharedPluginContext,
+    chunk: &RollupRenderedChunk,
+  ) -> HookAugmentChunkHashReturn {
+    Plugin::augment_chunk_hash(self, ctx, chunk).await
+  }
+
+  async fn render_error(
+    &self,
+    ctx: &SharedPluginContext,
+    args: &HookRenderErrorArgs,
+  ) -> HookNoopReturn {
+    Plugin::render_error(self, ctx, args).await
+  }
+
+  async fn generate_bundle(
+    &self,
+    ctx: &SharedPluginContext,
+    bundle: &mut Vec<Output>,
+    is_write: bool,
+  ) -> HookNoopReturn {
+    Plugin::generate_bundle(self, ctx, bundle, is_write).await
+  }
+
+  async fn write_bundle(
+    &self,
+    ctx: &SharedPluginContext,
+    bundle: &mut Vec<Output>,
+  ) -> HookNoopReturn {
+    Plugin::write_bundle(self, ctx, bundle).await
+  }
+
+  fn transform_ast(
+    &self,
+    ctx: &SharedPluginContext,
+    args: HookTransformAstArgs,
+  ) -> HookTransformAstReturn {
+    Plugin::transform_ast(self, ctx, args)
+  }
+}

--- a/crates/rolldown_plugin_data_url/Cargo.toml
+++ b/crates/rolldown_plugin_data_url/Cargo.toml
@@ -5,7 +5,6 @@ name    = "rolldown_plugin_data_url"
 version = "0.1.0"
 
 [dependencies]
-async-trait     = { workspace = true }
 base64-simd     = { workspace = true }
 dashmap         = { workspace = true }
 regex           = { workspace = true }

--- a/crates/rolldown_plugin_data_url/src/data_url_plugin.rs
+++ b/crates/rolldown_plugin_data_url/src/data_url_plugin.rs
@@ -21,79 +21,68 @@ pub struct DataUrlPlugin {
   resolved_data_url: DashMap<String, ResolvedDataUrl, FxBuildHasher>,
 }
 
-impl DataUrlPlugin {
-  async fn inner_resolve_id(
-    &self,
-    _ctx: &SharedPluginContext,
-    args: &HookResolveIdArgs<'_>,
-  ) -> HookResolveIdReturn {
-    if is_data_url(args.specifier) {
-      let Some(parsed) = parse_data_url(args.specifier) else {
-        return Ok(None);
-      };
-      let decoded_data = if parsed.is_base64 {
-        String::from_utf8(base64_simd::STANDARD.decode_to_vec(parsed.data)?)?
-      } else {
-        urlencoding::decode(parsed.data)?.into_owned()
-      };
-      let module_type = match parsed.mime {
-        "text/javascript" => ModuleType::Js,
-        "application/json" => ModuleType::Json,
-        _ => {
-          return Ok(None);
-        }
-      };
-
-      self
-        .resolved_data_url
-        .insert(args.specifier.to_string(), ResolvedDataUrl { module_type, data: decoded_data });
-
-      // Return the specifier as the id to tell rolldown that this data url is handled by the plugin. Don't fallback to
-      // the default resolve behavior and mark it as external.
-      return Ok(Some(HookResolveIdOutput {
-        id: args.specifier.to_string(),
-        ..Default::default()
-      }));
-    }
-    Ok(None)
-  }
-
-  async fn inner_load(
-    &self,
-    _ctx: &SharedPluginContext,
-    args: &HookLoadArgs<'_>,
-  ) -> HookLoadReturn {
-    if is_data_url(args.id) {
-      let Some(resolved) = self.resolved_data_url.get(args.id) else {
-        return Ok(None);
-      };
-
-      Ok(Some(HookLoadOutput {
-        code: resolved.data.clone(),
-        module_type: Some(resolved.module_type.clone()),
-        ..Default::default()
-      }))
-    } else {
-      Ok(None)
-    }
-  }
-}
-
-#[async_trait::async_trait]
 impl Plugin for DataUrlPlugin {
   fn name(&self) -> Cow<'static, str> {
     "rolldown:data-url".into()
   }
 
-  async fn resolve_id(
+  fn resolve_id(
     &self,
     _ctx: &SharedPluginContext,
-    args: &HookResolveIdArgs,
-  ) -> HookResolveIdReturn {
-    self.inner_resolve_id(_ctx, args).await
+    args: &HookResolveIdArgs<'_>,
+  ) -> impl std::future::Future<Output = HookResolveIdReturn> {
+    async {
+      if is_data_url(args.specifier) {
+        let Some(parsed) = parse_data_url(args.specifier) else {
+          return Ok(None);
+        };
+        let decoded_data = if parsed.is_base64 {
+          String::from_utf8(base64_simd::STANDARD.decode_to_vec(parsed.data)?)?
+        } else {
+          urlencoding::decode(parsed.data)?.into_owned()
+        };
+        let module_type = match parsed.mime {
+          "text/javascript" => ModuleType::Js,
+          "application/json" => ModuleType::Json,
+          _ => {
+            return Ok(None);
+          }
+        };
+
+        self
+          .resolved_data_url
+          .insert(args.specifier.to_string(), ResolvedDataUrl { module_type, data: decoded_data });
+
+        // Return the specifier as the id to tell rolldown that this data url is handled by the plugin. Don't fallback to
+        // the default resolve behavior and mark it as external.
+        return Ok(Some(HookResolveIdOutput {
+          id: args.specifier.to_string(),
+          ..Default::default()
+        }));
+      }
+      Ok(None)
+    }
   }
 
-  async fn load(&self, ctx: &SharedPluginContext, args: &HookLoadArgs) -> HookLoadReturn {
-    self.inner_load(ctx, args).await
+  fn load(
+    &self,
+    _ctx: &SharedPluginContext,
+    args: &HookLoadArgs<'_>,
+  ) -> impl std::future::Future<Output = HookLoadReturn> + Send {
+    async {
+      if is_data_url(args.id) {
+        let Some(resolved) = self.resolved_data_url.get(args.id) else {
+          return Ok(None);
+        };
+
+        Ok(Some(HookLoadOutput {
+          code: resolved.data.clone(),
+          module_type: Some(resolved.module_type.clone()),
+          ..Default::default()
+        }))
+      } else {
+        Ok(None)
+      }
+    }
   }
 }

--- a/crates/rolldown_plugin_data_url/src/lib.rs
+++ b/crates/rolldown_plugin_data_url/src/lib.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::manual_async_fn)]
 mod data_url_plugin;
 mod utils;
 

--- a/crates/rolldown_plugin_glob_import/Cargo.toml
+++ b/crates/rolldown_plugin_glob_import/Cargo.toml
@@ -12,7 +12,6 @@ version              = "0.0.1"
 workspace = true
 
 [dependencies]
-async-trait     = { workspace = true }
 glob            = { workspace = true }
 oxc             = { workspace = true }
 rolldown_plugin = { workspace = true }

--- a/crates/rolldown_plugin_glob_import/src/lib.rs
+++ b/crates/rolldown_plugin_glob_import/src/lib.rs
@@ -21,7 +21,6 @@ use sugar_path::SugarPath;
 #[derive(Debug)]
 pub struct GlobImportPlugin {}
 
-#[async_trait::async_trait]
 impl Plugin for GlobImportPlugin {
   fn name(&self) -> Cow<'static, str> {
     Cow::Borrowed("glob_import_plugin")

--- a/crates/rolldown_plugin_wasm/Cargo.toml
+++ b/crates/rolldown_plugin_wasm/Cargo.toml
@@ -12,6 +12,5 @@ version              = "0.0.1"
 workspace = true
 
 [dependencies]
-async-trait     = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }

--- a/crates/rolldown_plugin_wasm/src/lib.rs
+++ b/crates/rolldown_plugin_wasm/src/lib.rs
@@ -11,7 +11,6 @@ const WASM_RUNTIME: &str = "\0rolldown_wasm_runtime.js";
 #[derive(Debug)]
 pub struct WasmPlugin {}
 
-#[async_trait::async_trait]
 impl Plugin for WasmPlugin {
   fn name(&self) -> Cow<'static, str> {
     Cow::Borrowed("wasm_plugin")
@@ -20,7 +19,7 @@ impl Plugin for WasmPlugin {
   async fn resolve_id(
     &self,
     _ctx: &SharedPluginContext,
-    args: &HookResolveIdArgs,
+    args: &HookResolveIdArgs<'_>,
   ) -> HookResolveIdReturn {
     if args.specifier == WASM_RUNTIME {
       Ok(Some(HookResolveIdOutput { id: WASM_RUNTIME.to_string(), ..Default::default() }))
@@ -29,7 +28,7 @@ impl Plugin for WasmPlugin {
     }
   }
 
-  async fn load(&self, ctx: &SharedPluginContext, args: &HookLoadArgs) -> HookLoadReturn {
+  async fn load(&self, ctx: &SharedPluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
     if args.id == WASM_RUNTIME {
       return Ok(Some(HookLoadOutput {
         code: include_str!("wasm_runtime.js").to_string(),

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -2,8 +2,8 @@ use std::{borrow::Cow, path::Path, process::Command};
 
 use anyhow::Context;
 use rolldown::{
-  plugin::SharedPlugin, BundleOutput, Bundler, BundlerOptions, IsExternal, OutputFormat,
-  SourceMapType,
+  plugin::__inner::SharedPluginable, BundleOutput, Bundler, BundlerOptions, IsExternal,
+  OutputFormat, SourceMapType,
 };
 use rolldown_common::Output;
 use rolldown_error::DiagnosticOptions;
@@ -48,7 +48,11 @@ impl IntegrationTest {
     self.run_with_plugins(options, vec![]).await;
   }
 
-  pub async fn run_with_plugins(&self, mut options: BundlerOptions, plugins: Vec<SharedPlugin>) {
+  pub async fn run_with_plugins(
+    &self,
+    mut options: BundlerOptions,
+    plugins: Vec<SharedPluginable>,
+  ) {
     self.apply_test_defaults(&mut options);
 
     let mut bundler = Bundler::with_plugins(options, plugins);

--- a/cspell.json
+++ b/cspell.json
@@ -121,6 +121,7 @@
     "oxlint",
     "oxlintignore",
     "peekable",
+    "Pluginable",
     "proto",
     "realpath",
     "Renamer",
@@ -137,6 +138,7 @@
     "schemars",
     "serde",
     "sfnt",
+    "simd",
     "smallvec",
     "sourcemaps",
     "stackblitz",
@@ -170,7 +172,6 @@
     "webp",
     "Xiangjun",
     "Yinan",
-    "Yunfei",
-    "simd"
+    "Yunfei"
   ]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This is more about the dx of writing rust plugins. The old version relies on `async_trait::async_trait` which makes the rust-analyzer totally unusable.

Fortunally, rust support `async fn in trait` in stable version, though [there are problems](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#:~:text=Thankfully%2C%20we%20have,it%20like%20so%3A) and we have to define the `Plugin` trait in desugared version.

But for users that writes plugins they now could get auto completions from rust-analyzer. And the `impl Plugin` code is now just normal `async fn in trait` without relying on `async_trait::async_trait` anymore.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
