### PR TITLE
refactor(rust/plugin): add `call` prefix to `Pluginable` to avoid conflict naming

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
@@ -67,76 +67,76 @@ impl ParallelJsPlugin {
 #[cfg(not(target_family = "wasm"))]
 #[async_trait::async_trait]
 impl Pluginable for ParallelJsPlugin {
-  fn name(&self) -> Cow<'static, str> {
-    self.first_plugin().name()
+  fn call_name(&self) -> Cow<'static, str> {
+    self.first_plugin().call_name()
   }
 
   // --- Build hooks ---
 
-  async fn build_start(
+  async fn call_build_start(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
   ) -> rolldown_plugin::HookNoopReturn {
     if self.first_plugin().build_start.is_some() {
-      self.run_all(|plugin| plugin.build_start(ctx)).await?;
+      self.run_all(|plugin| plugin.call_build_start(ctx)).await?;
     }
     Ok(())
   }
 
-  async fn resolve_id(
+  async fn call_resolve_id(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
     args: &rolldown_plugin::HookResolveIdArgs,
   ) -> rolldown_plugin::HookResolveIdReturn {
     if self.first_plugin().resolve_id.is_some() {
-      self.run_single(|plugin| plugin.resolve_id(ctx, args)).await
+      self.run_single(|plugin| plugin.call_resolve_id(ctx, args)).await
     } else {
       Ok(None)
     }
   }
 
-  async fn load(
+  async fn call_load(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
     args: &rolldown_plugin::HookLoadArgs,
   ) -> rolldown_plugin::HookLoadReturn {
     if self.first_plugin().load.is_some() {
-      self.run_single(|plugin| plugin.load(ctx, args)).await
+      self.run_single(|plugin| plugin.call_load(ctx, args)).await
     } else {
       Ok(None)
     }
   }
 
-  async fn transform(
+  async fn call_transform(
     &self,
     ctx: &rolldown_plugin::TransformPluginContext<'_>,
     args: &rolldown_plugin::HookTransformArgs,
   ) -> rolldown_plugin::HookTransformReturn {
     if self.first_plugin().transform.is_some() {
-      self.run_single(|plugin| plugin.transform(ctx, args)).await
+      self.run_single(|plugin| plugin.call_transform(ctx, args)).await
     } else {
       Ok(None)
     }
   }
 
-  async fn build_end(
+  async fn call_build_end(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
     args: Option<&rolldown_plugin::HookBuildEndArgs>,
   ) -> rolldown_plugin::HookNoopReturn {
     if self.first_plugin().build_end.is_some() {
-      self.run_all(|plugin| plugin.build_end(ctx, args)).await?;
+      self.run_all(|plugin| plugin.call_build_end(ctx, args)).await?;
     }
     Ok(())
   }
 
-  async fn render_chunk(
+  async fn call_render_chunk(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
     args: &rolldown_plugin::HookRenderChunkArgs,
   ) -> rolldown_plugin::HookRenderChunkReturn {
     if self.first_plugin().render_chunk.is_some() {
-      self.run_single(|plugin| plugin.render_chunk(ctx, args)).await
+      self.run_single(|plugin| plugin.call_render_chunk(ctx, args)).await
     } else {
       Ok(None)
     }
@@ -144,26 +144,26 @@ impl Pluginable for ParallelJsPlugin {
 
   // --- Output hooks ---
 
-  async fn generate_bundle(
+  async fn call_generate_bundle(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
     bundle: &mut Vec<rolldown_common::Output>,
     is_write: bool,
   ) -> rolldown_plugin::HookNoopReturn {
     if self.first_plugin().generate_bundle.is_some() {
-      self.run_single(|plugin| plugin.generate_bundle(ctx, bundle, is_write)).await
+      self.run_single(|plugin| plugin.call_generate_bundle(ctx, bundle, is_write)).await
     } else {
       Ok(())
     }
   }
 
-  async fn write_bundle(
+  async fn call_write_bundle(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
     bundle: &mut Vec<rolldown_common::Output>,
   ) -> rolldown_plugin::HookNoopReturn {
     if self.first_plugin().write_bundle.is_some() {
-      self.run_single(|plugin| plugin.write_bundle(ctx, bundle)).await
+      self.run_single(|plugin| plugin.call_write_bundle(ctx, bundle)).await
     } else {
       Ok(())
     }

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -16,7 +16,8 @@ impl PluginDriver {
     let ret = {
       #[cfg(not(target_arch = "wasm32"))]
       {
-        block_on_spawn_all(self.plugins.iter().map(|(plugin, ctx)| plugin.build_start(ctx))).await
+        block_on_spawn_all(self.plugins.iter().map(|(plugin, ctx)| plugin.call_build_start(ctx)))
+          .await
       }
       #[cfg(target_arch = "wasm32")]
       {
@@ -26,7 +27,7 @@ impl PluginDriver {
         // I guess we need some rust experts here.
         let mut futures = vec![];
         for (plugin, ctx) in &self.plugins {
-          futures.push(plugin.build_start(ctx));
+          futures.push(plugin.call_build_start(ctx));
         }
         block_on_spawn_all(futures.into_iter()).await
       }
@@ -41,7 +42,7 @@ impl PluginDriver {
 
   pub async fn resolve_id(&self, args: &HookResolveIdArgs<'_>) -> HookResolveIdReturn {
     for (plugin, ctx) in &self.plugins {
-      if let Some(r) = plugin.resolve_id(ctx, args).await? {
+      if let Some(r) = plugin.call_resolve_id(ctx, args).await? {
         return Ok(Some(r));
       }
     }
@@ -55,7 +56,7 @@ impl PluginDriver {
     args: &HookResolveDynamicImportArgs<'_>,
   ) -> HookResolveIdReturn {
     for (plugin, ctx) in &self.plugins {
-      if let Some(r) = plugin.resolve_dynamic_import(ctx, args).await? {
+      if let Some(r) = plugin.call_resolve_dynamic_import(ctx, args).await? {
         return Ok(Some(r));
       }
     }
@@ -64,7 +65,7 @@ impl PluginDriver {
 
   pub async fn load(&self, args: &HookLoadArgs<'_>) -> HookLoadReturn {
     for (plugin, ctx) in &self.plugins {
-      if let Some(r) = plugin.load(ctx, args).await? {
+      if let Some(r) = plugin.call_load(ctx, args).await? {
         return Ok(Some(r));
       }
     }
@@ -81,7 +82,7 @@ impl PluginDriver {
     let mut code = args.code.to_string();
     for (plugin, ctx) in &self.plugins {
       if let Some(r) = plugin
-        .transform(
+        .call_transform(
           &TransformPluginContext::new(Arc::clone(ctx), sourcemap_chain, original_code, args.id),
           &HookTransformArgs { id: args.id, code: &code },
         )
@@ -112,21 +113,21 @@ impl PluginDriver {
   pub fn transform_ast(&self, mut args: HookTransformAstArgs) -> HookTransformAstReturn {
     for (plugin, ctx) in &self.plugins {
       args.ast =
-        plugin.transform_ast(ctx, HookTransformAstArgs { cwd: args.cwd, ast: args.ast })?;
+        plugin.call_transform_ast(ctx, HookTransformAstArgs { cwd: args.cwd, ast: args.ast })?;
     }
     Ok(args.ast)
   }
 
   pub async fn module_parsed(&self, module_info: Arc<ModuleInfo>) -> HookNoopReturn {
     for (plugin, ctx) in &self.plugins {
-      plugin.module_parsed(ctx, Arc::clone(&module_info)).await?;
+      plugin.call_module_parsed(ctx, Arc::clone(&module_info)).await?;
     }
     Ok(())
   }
 
   pub async fn build_end(&self, args: Option<&HookBuildEndArgs>) -> HookNoopReturn {
     for (plugin, ctx) in &self.plugins {
-      plugin.build_end(ctx, args).await?;
+      plugin.call_build_end(ctx, args).await?;
     }
     Ok(())
   }

--- a/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
@@ -8,7 +8,7 @@ use rolldown_sourcemap::SourceMap;
 impl PluginDriver {
   pub async fn render_start(&self) -> HookNoopReturn {
     for (plugin, ctx) in &self.plugins {
-      plugin.render_start(ctx).await?;
+      plugin.call_render_start(ctx).await?;
     }
     Ok(())
   }
@@ -19,7 +19,7 @@ impl PluginDriver {
     mut banner: String,
   ) -> Result<Option<String>> {
     for (plugin, ctx) in &self.plugins {
-      if let Some(r) = plugin.banner(ctx, &args).await? {
+      if let Some(r) = plugin.call_banner(ctx, &args).await? {
         banner.push('\n');
         banner.push_str(r.as_str());
       }
@@ -36,7 +36,7 @@ impl PluginDriver {
     mut footer: String,
   ) -> Result<Option<String>> {
     for (plugin, ctx) in &self.plugins {
-      if let Some(r) = plugin.footer(ctx, &args).await? {
+      if let Some(r) = plugin.call_footer(ctx, &args).await? {
         footer.push('\n');
         footer.push_str(r.as_str());
       }
@@ -53,7 +53,7 @@ impl PluginDriver {
   ) -> Result<(String, Vec<SourceMap>)> {
     let mut sourcemap_chain = vec![];
     for (plugin, ctx) in &self.plugins {
-      if let Some(r) = plugin.render_chunk(ctx, &args).await? {
+      if let Some(r) = plugin.call_render_chunk(ctx, &args).await? {
         args.code = r.code;
         if let Some(map) = r.map {
           sourcemap_chain.push(map);
@@ -69,7 +69,7 @@ impl PluginDriver {
   ) -> HookAugmentChunkHashReturn {
     let mut hash = None;
     for (plugin, ctx) in &self.plugins {
-      if let Some(plugin_hash) = plugin.augment_chunk_hash(ctx, chunk).await? {
+      if let Some(plugin_hash) = plugin.call_augment_chunk_hash(ctx, chunk).await? {
         hash.get_or_insert_with(String::default).push_str(&plugin_hash);
       }
     }
@@ -78,14 +78,14 @@ impl PluginDriver {
 
   pub async fn render_error(&self, args: &HookRenderErrorArgs) -> HookNoopReturn {
     for (plugin, ctx) in &self.plugins {
-      plugin.render_error(ctx, args).await?;
+      plugin.call_render_error(ctx, args).await?;
     }
     Ok(())
   }
 
   pub async fn generate_bundle(&self, bundle: &mut Vec<Output>, is_write: bool) -> HookNoopReturn {
     for (plugin, ctx) in &self.plugins {
-      plugin.generate_bundle(ctx, bundle, is_write).await?;
+      plugin.call_generate_bundle(ctx, bundle, is_write).await?;
       ctx.file_emitter.add_additional_files(bundle);
     }
     Ok(())
@@ -93,7 +93,7 @@ impl PluginDriver {
 
   pub async fn write_bundle(&self, bundle: &mut Vec<Output>) -> HookNoopReturn {
     for (plugin, ctx) in &self.plugins {
-      plugin.write_bundle(ctx, bundle).await?;
+      plugin.call_write_bundle(ctx, bundle).await?;
       ctx.file_emitter.add_additional_files(bundle);
     }
     Ok(())

--- a/crates/rolldown_plugin/src/pluginable.rs
+++ b/crates/rolldown_plugin/src/pluginable.rs
@@ -32,17 +32,17 @@ pub type SharedPluginable = Arc<dyn Pluginable>;
 /// provide a good auto-completion experience.
 #[async_trait::async_trait]
 pub trait Pluginable: Any + Debug + Send + Sync + 'static {
-  fn name(&self) -> Cow<'static, str>;
+  fn call_name(&self) -> Cow<'static, str>;
 
   // The `option` hook consider call at node side.
 
   // --- Build hooks ---
 
-  async fn build_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn {
+  async fn call_build_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn {
     Ok(())
   }
 
-  async fn resolve_id(
+  async fn call_resolve_id(
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookResolveIdArgs,
@@ -53,7 +53,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
   #[deprecated(
     note = "This hook is only for rollup compatibility, please use `resolve_id` instead."
   )]
-  async fn resolve_dynamic_import(
+  async fn call_resolve_dynamic_import(
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookResolveDynamicImportArgs,
@@ -61,11 +61,11 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     Ok(None)
   }
 
-  async fn load(&self, _ctx: &SharedPluginContext, _args: &HookLoadArgs) -> HookLoadReturn {
+  async fn call_load(&self, _ctx: &SharedPluginContext, _args: &HookLoadArgs) -> HookLoadReturn {
     Ok(None)
   }
 
-  async fn transform(
+  async fn call_transform(
     &self,
     _ctx: &TransformPluginContext<'_>,
     _args: &HookTransformArgs,
@@ -73,7 +73,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     Ok(None)
   }
 
-  fn transform_ast(
+  fn call_transform_ast(
     &self,
     _ctx: &SharedPluginContext,
     args: HookTransformAstArgs,
@@ -81,7 +81,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     Ok(args.ast)
   }
 
-  async fn module_parsed(
+  async fn call_module_parsed(
     &self,
     _ctx: &SharedPluginContext,
     _module_info: Arc<ModuleInfo>,
@@ -89,7 +89,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     Ok(())
   }
 
-  async fn build_end(
+  async fn call_build_end(
     &self,
     _ctx: &SharedPluginContext,
     _args: Option<&HookBuildEndArgs>,
@@ -99,11 +99,11 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   // --- Generate hooks ---
 
-  async fn render_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn {
+  async fn call_render_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn {
     Ok(())
   }
 
-  async fn banner(
+  async fn call_banner(
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookBannerArgs,
@@ -111,7 +111,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     Ok(None)
   }
 
-  async fn footer(
+  async fn call_footer(
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookFooterArgs,
@@ -119,7 +119,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     Ok(None)
   }
 
-  async fn render_chunk(
+  async fn call_render_chunk(
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookRenderChunkArgs,
@@ -127,7 +127,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     Ok(None)
   }
 
-  async fn augment_chunk_hash(
+  async fn call_augment_chunk_hash(
     &self,
     _ctx: &SharedPluginContext,
     _chunk: &RollupRenderedChunk,
@@ -135,7 +135,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     Ok(None)
   }
 
-  async fn render_error(
+  async fn call_render_error(
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookRenderErrorArgs,
@@ -143,7 +143,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     Ok(())
   }
 
-  async fn generate_bundle(
+  async fn call_generate_bundle(
     &self,
     _ctx: &SharedPluginContext,
     _bundle: &mut Vec<Output>,
@@ -152,7 +152,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     Ok(())
   }
 
-  async fn write_bundle(
+  async fn call_write_bundle(
     &self,
     _ctx: &SharedPluginContext,
     _bundle: &mut Vec<Output>,
@@ -163,15 +163,15 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
 #[async_trait::async_trait]
 impl<T: Plugin> Pluginable for T {
-  fn name(&self) -> Cow<'static, str> {
+  fn call_name(&self) -> Cow<'static, str> {
     Plugin::name(self)
   }
 
-  async fn build_start(&self, ctx: &SharedPluginContext) -> HookNoopReturn {
+  async fn call_build_start(&self, ctx: &SharedPluginContext) -> HookNoopReturn {
     Plugin::build_start(self, ctx).await
   }
 
-  async fn resolve_id(
+  async fn call_resolve_id(
     &self,
     ctx: &SharedPluginContext,
     args: &HookResolveIdArgs,
@@ -180,7 +180,7 @@ impl<T: Plugin> Pluginable for T {
   }
 
   #[allow(deprecated)]
-  async fn resolve_dynamic_import(
+  async fn call_resolve_dynamic_import(
     &self,
     ctx: &SharedPluginContext,
     args: &HookResolveDynamicImportArgs,
@@ -188,11 +188,11 @@ impl<T: Plugin> Pluginable for T {
     Plugin::resolve_dynamic_import(self, ctx, args).await
   }
 
-  async fn load(&self, ctx: &SharedPluginContext, args: &HookLoadArgs) -> HookLoadReturn {
+  async fn call_load(&self, ctx: &SharedPluginContext, args: &HookLoadArgs) -> HookLoadReturn {
     Plugin::load(self, ctx, args).await
   }
 
-  async fn transform(
+  async fn call_transform(
     &self,
     ctx: &TransformPluginContext<'_>,
     args: &HookTransformArgs,
@@ -200,7 +200,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::transform(self, ctx, args).await
   }
 
-  async fn module_parsed(
+  async fn call_module_parsed(
     &self,
     ctx: &SharedPluginContext,
     module_info: Arc<ModuleInfo>,
@@ -208,7 +208,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::module_parsed(self, ctx, module_info).await
   }
 
-  async fn build_end(
+  async fn call_build_end(
     &self,
     ctx: &SharedPluginContext,
     args: Option<&HookBuildEndArgs>,
@@ -216,11 +216,11 @@ impl<T: Plugin> Pluginable for T {
     Plugin::build_end(self, ctx, args).await
   }
 
-  async fn render_start(&self, ctx: &SharedPluginContext) -> HookNoopReturn {
+  async fn call_render_start(&self, ctx: &SharedPluginContext) -> HookNoopReturn {
     Plugin::render_start(self, ctx).await
   }
 
-  async fn banner(
+  async fn call_banner(
     &self,
     ctx: &SharedPluginContext,
     args: &HookBannerArgs,
@@ -228,7 +228,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::banner(self, ctx, args).await
   }
 
-  async fn footer(
+  async fn call_footer(
     &self,
     ctx: &SharedPluginContext,
     args: &HookFooterArgs,
@@ -236,7 +236,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::footer(self, ctx, args).await
   }
 
-  async fn render_chunk(
+  async fn call_render_chunk(
     &self,
     ctx: &SharedPluginContext,
     args: &HookRenderChunkArgs,
@@ -244,7 +244,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::render_chunk(self, ctx, args).await
   }
 
-  async fn augment_chunk_hash(
+  async fn call_augment_chunk_hash(
     &self,
     ctx: &SharedPluginContext,
     chunk: &RollupRenderedChunk,
@@ -252,7 +252,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::augment_chunk_hash(self, ctx, chunk).await
   }
 
-  async fn render_error(
+  async fn call_render_error(
     &self,
     ctx: &SharedPluginContext,
     args: &HookRenderErrorArgs,
@@ -260,7 +260,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::render_error(self, ctx, args).await
   }
 
-  async fn generate_bundle(
+  async fn call_generate_bundle(
     &self,
     ctx: &SharedPluginContext,
     bundle: &mut Vec<Output>,
@@ -269,7 +269,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::generate_bundle(self, ctx, bundle, is_write).await
   }
 
-  async fn write_bundle(
+  async fn call_write_bundle(
     &self,
     ctx: &SharedPluginContext,
     bundle: &mut Vec<Output>,
@@ -277,7 +277,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::write_bundle(self, ctx, bundle).await
   }
 
-  fn transform_ast(
+  fn call_transform_ast(
     &self,
     ctx: &SharedPluginContext,
     args: HookTransformAstArgs,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`Pluginable` is internal type. We could use unfriendly name in it, since it won't exposed to users.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
