### PR TITLE
refactor(rust/plugin): remove all default impl method in `Pluginable`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,6 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-channel",
- "async-trait",
  "dashmap 6.0.1",
  "derivative",
  "futures",

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -16,7 +16,6 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow                      = { workspace = true }
 async-channel               = { workspace = true }
-async-trait                 = { workspace = true }
 dashmap                     = { workspace = true }
 derivative                  = { workspace = true }
 futures                     = { workspace = true }

--- a/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 #[cfg(not(target_family = "wasm"))]
 use futures::future::{self, BoxFuture};
+use rolldown_plugin::Plugin;
 #[cfg(not(target_family = "wasm"))]
 use rolldown_plugin::__inner::Pluginable;
 
@@ -65,15 +66,14 @@ impl ParallelJsPlugin {
 }
 
 #[cfg(not(target_family = "wasm"))]
-#[async_trait::async_trait]
-impl Pluginable for ParallelJsPlugin {
-  fn call_name(&self) -> Cow<'static, str> {
+impl Plugin for ParallelJsPlugin {
+  fn name(&self) -> Cow<'static, str> {
     self.first_plugin().call_name()
   }
 
   // --- Build hooks ---
 
-  async fn call_build_start(
+  async fn build_start(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
   ) -> rolldown_plugin::HookNoopReturn {
@@ -83,10 +83,10 @@ impl Pluginable for ParallelJsPlugin {
     Ok(())
   }
 
-  async fn call_resolve_id(
+  async fn resolve_id(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    args: &rolldown_plugin::HookResolveIdArgs,
+    args: &rolldown_plugin::HookResolveIdArgs<'_>,
   ) -> rolldown_plugin::HookResolveIdReturn {
     if self.first_plugin().resolve_id.is_some() {
       self.run_single(|plugin| plugin.call_resolve_id(ctx, args)).await
@@ -95,10 +95,10 @@ impl Pluginable for ParallelJsPlugin {
     }
   }
 
-  async fn call_load(
+  async fn load(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    args: &rolldown_plugin::HookLoadArgs,
+    args: &rolldown_plugin::HookLoadArgs<'_>,
   ) -> rolldown_plugin::HookLoadReturn {
     if self.first_plugin().load.is_some() {
       self.run_single(|plugin| plugin.call_load(ctx, args)).await
@@ -107,10 +107,10 @@ impl Pluginable for ParallelJsPlugin {
     }
   }
 
-  async fn call_transform(
+  async fn transform(
     &self,
     ctx: &rolldown_plugin::TransformPluginContext<'_>,
-    args: &rolldown_plugin::HookTransformArgs,
+    args: &rolldown_plugin::HookTransformArgs<'_>,
   ) -> rolldown_plugin::HookTransformReturn {
     if self.first_plugin().transform.is_some() {
       self.run_single(|plugin| plugin.call_transform(ctx, args)).await
@@ -119,7 +119,7 @@ impl Pluginable for ParallelJsPlugin {
     }
   }
 
-  async fn call_build_end(
+  async fn build_end(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
     args: Option<&rolldown_plugin::HookBuildEndArgs>,
@@ -130,10 +130,10 @@ impl Pluginable for ParallelJsPlugin {
     Ok(())
   }
 
-  async fn call_render_chunk(
+  async fn render_chunk(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    args: &rolldown_plugin::HookRenderChunkArgs,
+    args: &rolldown_plugin::HookRenderChunkArgs<'_>,
   ) -> rolldown_plugin::HookRenderChunkReturn {
     if self.first_plugin().render_chunk.is_some() {
       self.run_single(|plugin| plugin.call_render_chunk(ctx, args)).await
@@ -144,7 +144,7 @@ impl Pluginable for ParallelJsPlugin {
 
   // --- Output hooks ---
 
-  async fn call_generate_bundle(
+  async fn generate_bundle(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
     bundle: &mut Vec<rolldown_common::Output>,
@@ -157,7 +157,7 @@ impl Pluginable for ParallelJsPlugin {
     }
   }
 
-  async fn call_write_bundle(
+  async fn write_bundle(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
     bundle: &mut Vec<rolldown_common::Output>,

--- a/crates/rolldown_plugin/src/pluginable.rs
+++ b/crates/rolldown_plugin/src/pluginable.rs
@@ -38,17 +38,13 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   // --- Build hooks ---
 
-  async fn call_build_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn {
-    Ok(())
-  }
+  async fn call_build_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn;
 
   async fn call_resolve_id(
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookResolveIdArgs,
-  ) -> HookResolveIdReturn {
-    Ok(None)
-  }
+  ) -> HookResolveIdReturn;
 
   #[deprecated(
     note = "This hook is only for rollup compatibility, please use `resolve_id` instead."
@@ -57,108 +53,80 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookResolveDynamicImportArgs,
-  ) -> HookResolveIdReturn {
-    Ok(None)
-  }
+  ) -> HookResolveIdReturn;
 
-  async fn call_load(&self, _ctx: &SharedPluginContext, _args: &HookLoadArgs) -> HookLoadReturn {
-    Ok(None)
-  }
+  async fn call_load(&self, _ctx: &SharedPluginContext, _args: &HookLoadArgs) -> HookLoadReturn;
 
   async fn call_transform(
     &self,
     _ctx: &TransformPluginContext<'_>,
     _args: &HookTransformArgs,
-  ) -> HookTransformReturn {
-    Ok(None)
-  }
+  ) -> HookTransformReturn;
 
   fn call_transform_ast(
     &self,
     _ctx: &SharedPluginContext,
     args: HookTransformAstArgs,
-  ) -> HookTransformAstReturn {
-    Ok(args.ast)
-  }
+  ) -> HookTransformAstReturn;
 
   async fn call_module_parsed(
     &self,
     _ctx: &SharedPluginContext,
     _module_info: Arc<ModuleInfo>,
-  ) -> HookNoopReturn {
-    Ok(())
-  }
+  ) -> HookNoopReturn;
 
   async fn call_build_end(
     &self,
     _ctx: &SharedPluginContext,
     _args: Option<&HookBuildEndArgs>,
-  ) -> HookNoopReturn {
-    Ok(())
-  }
+  ) -> HookNoopReturn;
 
   // --- Generate hooks ---
 
-  async fn call_render_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn {
-    Ok(())
-  }
+  async fn call_render_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn;
 
   async fn call_banner(
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookBannerArgs,
-  ) -> HookBannerOutputReturn {
-    Ok(None)
-  }
+  ) -> HookBannerOutputReturn;
 
   async fn call_footer(
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookFooterArgs,
-  ) -> HookFooterOutputReturn {
-    Ok(None)
-  }
+  ) -> HookFooterOutputReturn;
 
   async fn call_render_chunk(
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookRenderChunkArgs,
-  ) -> HookRenderChunkReturn {
-    Ok(None)
-  }
+  ) -> HookRenderChunkReturn;
 
   async fn call_augment_chunk_hash(
     &self,
     _ctx: &SharedPluginContext,
     _chunk: &RollupRenderedChunk,
-  ) -> HookAugmentChunkHashReturn {
-    Ok(None)
-  }
+  ) -> HookAugmentChunkHashReturn;
 
   async fn call_render_error(
     &self,
     _ctx: &SharedPluginContext,
     _args: &HookRenderErrorArgs,
-  ) -> HookNoopReturn {
-    Ok(())
-  }
+  ) -> HookNoopReturn;
 
   async fn call_generate_bundle(
     &self,
     _ctx: &SharedPluginContext,
     _bundle: &mut Vec<Output>,
     _is_write: bool,
-  ) -> HookNoopReturn {
-    Ok(())
-  }
+  ) -> HookNoopReturn;
 
   async fn call_write_bundle(
     &self,
     _ctx: &SharedPluginContext,
     _bundle: &mut Vec<Output>,
-  ) -> HookNoopReturn {
-    Ok(())
-  }
+  ) -> HookNoopReturn;
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This ensure compiler checks that all methods of `Pluginable` will be implemented in `impl<T: plugin> Pluginable for T`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
