### PR TITLE
fix: avoid panic if member expr referneced to non-namespace symbol

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -61,7 +61,10 @@ impl<'a> GenerateStage<'a> {
             .top_level_member_expr_resolved_cache
             .get(&member_expr.object_ref)
             .and_then(|map| map.get(&member_expr.props.clone().into_boxed_slice()))
-            .map_or(member_expr.object_ref, |(finalized_symbol_ref, _, _)| *finalized_symbol_ref),
+            .map_or_else(
+              || self.link_output.symbols.par_canonical_ref_for(member_expr.object_ref),
+              |(finalized_symbol_ref, _, _)| *finalized_symbol_ref,
+            ),
         };
 
         self.determine_reachable_modules_for_entry(

--- a/crates/rolldown/tests/fixtures/tree_shaking/export_default/_config.json
+++ b/crates/rolldown/tests/fixtures/tree_shaking/export_default/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "treeshake": {
+      "moduleSideEffects": false
+    }
+  }
+}

--- a/crates/rolldown/tests/fixtures/tree_shaking/export_default/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/tree_shaking/export_default/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+expression: snapshot
+input_file: crates/rolldown/tests/fixtures/tree_shaking/export_default
+---
+# Assets
+
+## main.mjs
+
+```js
+
+//#region foo.js
+var foo_default = 1;
+
+//#endregion
+//#region export.js
+var export_default = {foo: foo_default};
+
+//#endregion
+//#region main.js
+export_default.foo;
+
+//#endregion
+```

--- a/crates/rolldown/tests/fixtures/tree_shaking/export_default/export.js
+++ b/crates/rolldown/tests/fixtures/tree_shaking/export_default/export.js
@@ -1,0 +1,3 @@
+import foo from "./foo";
+
+export default { foo };

--- a/crates/rolldown/tests/fixtures/tree_shaking/export_default/export_default.js
+++ b/crates/rolldown/tests/fixtures/tree_shaking/export_default/export_default.js
@@ -1,0 +1,1 @@
+export { default } from './export';

--- a/crates/rolldown/tests/fixtures/tree_shaking/export_default/foo.js
+++ b/crates/rolldown/tests/fixtures/tree_shaking/export_default/foo.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/crates/rolldown/tests/fixtures/tree_shaking/export_default/main.js
+++ b/crates/rolldown/tests/fixtures/tree_shaking/export_default/main.js
@@ -1,0 +1,4 @@
+import foo from './export_default';
+
+foo.foo;
+

--- a/crates/rolldown/tests/snapshots/integration_fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_fixtures__filename_with_hash.snap
@@ -1915,6 +1915,10 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - main-!~{000}~.mjs => main-WlVJrkq9.mjs
 
+# tests/fixtures/tree_shaking/export_default
+
+- main-!~{000}~.mjs => main-hAcQbq3h.mjs
+
 # tests/fixtures/tree_shaking/export_star
 
 - main-!~{000}~.mjs => main-D_8Z2hmK.mjs


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
