### PR TITLE
test(rust/preserve_semantic_of_entries_exports): add `named_export_in_shared_entries`

### DIFF
--- a/crates/rolldown/tests/fixtures/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
@@ -38,6 +38,7 @@ var init_main = __esmMin(() => {
 });
 
 //#endregion
+init_main();
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.main = main;
 ```

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries/_config.json
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "./main.js"
+      },
+      {
+        "name": "entry2",
+        "import": "./main.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries/_test.mjs
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries/_test.mjs
@@ -1,0 +1,7 @@
+import assert from 'node:assert'
+import * as entry from './dist/entry.mjs'
+import * as entry2 from './dist/entry2.mjs'
+assert.deepStrictEqual(entry.foo, 'foo')
+assert.deepStrictEqual(entry.foo, entry2.foo)
+assert.deepStrictEqual(entry.default, 'main')
+assert.deepStrictEqual(entry.default, entry2.default)

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries/artifacts.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+expression: snapshot
+input_file: crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries
+---
+# Assets
+
+## entry.mjs
+
+```js
+import { foo, main_default } from "./main.mjs";
+
+export { main_default as default, foo };
+```
+## entry2.mjs
+
+```js
+import { foo, main_default } from "./main.mjs";
+
+export { main_default as default, foo };
+```
+## main.mjs
+
+```js
+
+//#region main.js
+const foo = "foo";
+var main_default = "main";
+
+//#endregion
+export { foo, main_default };
+```

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries/main.js
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries/main.js
@@ -1,0 +1,2 @@
+export const foo = 'foo'
+export default 'main'

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/_config.json
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "./main.js"
+      },
+      {
+        "name": "entry2",
+        "import": "./main.js"
+      }
+    ],
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/_test.cjs
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/_test.cjs
@@ -1,0 +1,8 @@
+const assert = require('node:assert');
+const entry = require('./dist/entry.cjs');
+const entry2 = require('./dist/entry2.cjs');
+
+assert.deepStrictEqual(entry.foo, 'foo');
+assert.deepStrictEqual(entry.foo, entry2.foo);
+assert.deepStrictEqual(entry.default, 'main');
+assert.deepStrictEqual(entry.default, entry2.default);

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/artifacts.snap
@@ -1,0 +1,41 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+expression: snapshot
+input_file: crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs
+---
+# Assets
+
+## entry.cjs
+
+```js
+"use strict";
+const { foo, main_default } = require("./main.cjs");
+
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.default = main_default;
+exports.foo = foo;
+```
+## entry2.cjs
+
+```js
+"use strict";
+const { foo, main_default } = require("./main.cjs");
+
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.default = main_default;
+exports.foo = foo;
+```
+## main.cjs
+
+```js
+"use strict";
+
+//#region main.js
+const foo = "foo";
+var main_default = "main";
+
+//#endregion
+exports.foo = foo;
+exports.main_default = main_default;
+
+```

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/main.js
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/main.js
@@ -1,0 +1,2 @@
+export const foo = 'foo'
+export default 'main'

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/_config.json
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/_test.cjs
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/_test.cjs
@@ -1,0 +1,5 @@
+const assert = require('node:assert');
+const main = require('./dist/main.cjs');
+
+assert.deepStrictEqual(main.foo, 'foo');
+assert.deepStrictEqual(main.default, 'main');

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
@@ -1,0 +1,40 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+expression: snapshot
+input_file: crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs
+---
+# warnings
+
+## CIRCULAR_DEPENDENCY
+
+```text
+[CIRCULAR_DEPENDENCY] Warning: Circular dependency: main.js -> main.js.
+
+```
+# Assets
+
+## main.cjs
+
+```js
+"use strict";
+
+
+//#region main.js
+var main_ns, foo, main_default;
+var init_main = __esmMin(() => {
+	main_ns = {};
+	__export(main_ns, {
+		default: () => main_default,
+		foo: () => foo
+	});
+	foo = "foo";
+	main_default = "main";
+	console.log((init_main(), __toCommonJS(main_ns)));
+});
+
+//#endregion
+init_main();
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.default = main_default;
+exports.foo = foo;
+```

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/main.js
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/main.js
@@ -1,0 +1,3 @@
+export const foo = 'foo'
+export default 'main'
+console.log(require('./main.js'))

--- a/crates/rolldown/tests/snapshots/integration_fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_fixtures__filename_with_hash.snap
@@ -1931,6 +1931,18 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - main-!~{000}~.cjs => main-GxxA_HM4.cjs
 
+# tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries
+
+- entry-!~{000}~.mjs => entry-Y-RDbzBd.mjs
+- entry2-!~{001}~.mjs => entry2-Im-kL3TM.mjs
+- main-!~{002}~.mjs => main-tLfW5JrW.mjs
+
+# tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs
+
+- entry-!~{000}~.cjs => entry-gqBX5LOD.cjs
+- entry2-!~{001}~.cjs => entry2-XBbIzskY.cjs
+- main-!~{002}~.cjs => main-gZTUV6Cq.cjs
+
 # tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped
 
 - main-!~{000}~.mjs => main-G-5DXUYT.mjs

--- a/crates/rolldown/tests/snapshots/integration_fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_fixtures__filename_with_hash.snap
@@ -1921,7 +1921,7 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/fixtures/semantic/export_star_from_external_as_wrapped_entry_cjs
 
-- entry-!~{000}~.cjs => entry-UJgHXded.cjs
+- entry-!~{000}~.cjs => entry-_7zisNXa.cjs
 
 # tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export
 
@@ -1934,6 +1934,10 @@ expression: "snapshot_outputs.join(\"\\n\")"
 # tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped
 
 - main-!~{000}~.mjs => main-G-5DXUYT.mjs
+
+# tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs
+
+- main-!~{000}~.cjs => main-r8r46VsZ.cjs
 
 # tests/fixtures/tree_shaking/advanced_barrel_exports
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
