### PR TITLE
test(rust/preserve_semantic_of_entries_exports): add `named_export_in_wrapped_and_shared_entries`

### DIFF
--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/_config.json
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "./main.js"
+      },
+      {
+        "name": "entry2",
+        "import": "./main.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/_test.mjs
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/_test.mjs
@@ -1,0 +1,7 @@
+import assert from 'node:assert'
+import * as entry from './dist/entry.mjs'
+import * as entry2 from './dist/entry2.mjs'
+assert.deepStrictEqual(entry.foo, 'foo')
+assert.deepStrictEqual(entry.foo, entry2.foo)
+assert.deepStrictEqual(entry.default, 'main')
+assert.deepStrictEqual(entry.default, entry2.default)

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
@@ -1,0 +1,52 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+expression: snapshot
+input_file: crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries
+---
+# warnings
+
+## CIRCULAR_DEPENDENCY
+
+```text
+[CIRCULAR_DEPENDENCY] Warning: Circular dependency: main.js -> main.js.
+
+```
+# Assets
+
+## entry.mjs
+
+```js
+import { foo, init_main, main_default } from "./main.mjs";
+
+init_main();
+export { main_default as default, foo };
+```
+## entry2.mjs
+
+```js
+import { foo, init_main, main_default } from "./main.mjs";
+
+init_main();
+export { main_default as default, foo };
+```
+## main.mjs
+
+```js
+
+
+//#region main.js
+var main_ns, foo, main_default;
+var init_main = __esmMin(() => {
+	main_ns = {};
+	__export(main_ns, {
+		default: () => main_default,
+		foo: () => foo
+	});
+	foo = "foo";
+	main_default = "main";
+	console.log((init_main(), __toCommonJS(main_ns)));
+});
+
+//#endregion
+export { foo, init_main, main_default };
+```

--- a/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/main.js
+++ b/crates/rolldown/tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/main.js
@@ -1,0 +1,3 @@
+export const foo = 'foo'
+export default 'main'
+console.log(require('./main.js'))

--- a/crates/rolldown/tests/snapshots/integration_fixtures__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_fixtures__filename_with_hash.snap
@@ -1947,6 +1947,12 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 - main-!~{000}~.mjs => main-G-5DXUYT.mjs
 
+# tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries
+
+- entry-!~{000}~.mjs => entry--4BUJ2yJ.mjs
+- entry2-!~{001}~.mjs => entry2-ECOtWpfw.mjs
+- main-!~{002}~.mjs => main-CskDtby4.mjs
+
 # tests/fixtures/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs
 
 - main-!~{000}~.cjs => main-r8r46VsZ.cjs


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
