### PR TITLE
style(node/lint): prepare codebase for no-unused-vars

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,9 @@
 {
   "rules": {
-    "no-unused-vars": ["warn", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
+    "no-unused-vars": [
+      "warn",
+      { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }
+    ],
     "unicorn/prefer-node-protocol": "error",
     "import/namespace": [
       "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,5 +1,6 @@
 {
   "rules": {
+    "no-unused-vars": ["warn", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
     "unicorn/prefer-node-protocol": "error",
     "import/namespace": [
       "error",

--- a/examples/par-plugin/parallel-babel-plugin/impl.js
+++ b/examples/par-plugin/parallel-babel-plugin/impl.js
@@ -21,7 +21,6 @@ export const babelPlugin = () => {
     transform(code, id) {
       const ext = nodePath.extname(id)
       if (ext === '.ts' || ext === '.tsx') {
-        let now = performance.now()
         const ast = babel.parseSync(code, {
           ...partialConfig?.options,
           filename: id,
@@ -29,14 +28,12 @@ export const babelPlugin = () => {
         if (!ast || !partialConfig || !partialConfig.options) {
           throw new Error('failed to parse')
         }
-        let diffAst = performance.now() - now
         const ret = /** @type {babel.BabelFileResult} */ (
           babel.transformFromAstSync(ast, code, {
             ...partialConfig?.options,
             filename: id,
           })
         )
-        let diffTrans = performance.now() - now - diffAst
         return { code: /** @type {string} */ (ret.code) }
       }
     },

--- a/examples/par-plugin/parallel-esbuild-plugin/impl.js
+++ b/examples/par-plugin/parallel-esbuild-plugin/impl.js
@@ -37,7 +37,6 @@ export const pluginAsync = () => {
     name: '@rolldown/plugin-esbuild',
     async transform(code, id) {
       const ext = nodePath.extname(id)
-      const now = performance.now()
       if (ext === '.ts' || ext === '.tsx') {
         const ret = await esbuild.transform(code, {
           platform: 'node',

--- a/packages/rolldown/src/utils/normalize-output-options.ts
+++ b/packages/rolldown/src/utils/normalize-output-options.ts
@@ -28,7 +28,7 @@ export function normalizeOutputOptions(
         ? sourcemapIgnoreList
         : sourcemapIgnoreList === false
           ? () => false
-          : (relativeSourcePath: string, sourcemapPath: string) =>
+          : (relativeSourcePath: string, _sourcemapPath: string) =>
               relativeSourcePath.includes('node_modules'),
     sourcemapPathTransform,
     banner: getAddon(opts, 'banner'),

--- a/packages/rolldown/tests/plugin/plugin.test.ts
+++ b/packages/rolldown/tests/plugin/plugin.test.ts
@@ -9,7 +9,7 @@ async function buildWithPlugin(plugin: Plugin) {
       plugins: [plugin],
     })
     await build.write({})
-  } catch (error) {
+  } catch {
     // Here `renderError` test will crash it, here avoid bubble it.
     // console.log(error)
   }

--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -4,7 +4,6 @@ import {
   RolldownOutputAsset,
 } from '../../src'
 import nodePath from 'node:path'
-import nodeUrl from 'node:url'
 import assert from 'node:assert'
 import { workspaceRoot } from '@rolldown/testing'
 

--- a/scripts/misc/gen-esbuild-test.mjs
+++ b/scripts/misc/gen-esbuild-test.mjs
@@ -8,7 +8,6 @@ import chalk from 'chalk'
 import * as dedent from 'dedent'
 import { fileURLToPath } from 'node:url'
 import { URL } from 'node:url'
-import { warn } from 'node:console'
 import * as nodeHttps from 'node:https'
 import * as nodeFs from 'node:fs'
 import * as fsExtra from 'fs-extra'
@@ -161,7 +160,7 @@ async function readTestSuiteSource(testSuiteName) {
   const sourcePath = path.resolve(__dirname, testSuite.sourcePath)
   try {
     return fs.readFileSync(sourcePath).toString()
-  } catch (err1) {
+  } catch {
     console.log(`Could not read .go source file from ${sourcePath}.`)
     console.log(`Attempting to download it from ${testSuite.sourceGithubUrl}.`)
     console.log('...')


### PR DESCRIPTION
### Description
Oxlint will be adding [no-unused-vars](https://github.com/oxc-project/oxc/pull/4445) soon, which will add warnings to all unused variables. This PR updates Rolldown's `.oxlintrc.json` and cleans up some code to prevent your CI from failing.
