### PR TITLE
feat: add support for banner as str

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -126,7 +126,7 @@ pub struct BindingPluginOptions {
   pub write_bundle: Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingOutputs), ()>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
+  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string")]
   pub banner: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -229,7 +229,7 @@ export interface BindingPluginOptions {
   renderError?: (ctx: BindingPluginContext, error: string) => void
   generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>
   writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>
-  banner?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+  banner?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
   footer?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
   intro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
   outro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -159,8 +159,11 @@ export function bindingifyBanner(
   }
 
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
-
   return async (ctx, chunk) => {
+    if (typeof handler !== 'function') {
+      return handler
+    }
+
     return handler.call(
       new PluginContext(options, ctx, plugin, pluginContextData),
       chunk,

--- a/packages/rolldown/src/utils/normalize-hook.ts
+++ b/packages/rolldown/src/utils/normalize-hook.ts
@@ -12,8 +12,14 @@ export function normalizeHook<H extends ObjectHook<AnyFn, AnyObj>>(
     // @ts-expect-error
     return [hook, {}]
   }
-  const { handler, ...options } = hook
+
+  if (typeof hook === 'object') {
+    const { handler, ...options } = hook
+
+    // @ts-expect-error
+    return [handler, options]
+  }
 
   // @ts-expect-error
-  return [handler, options]
+  return [hook, {}]
 }

--- a/packages/rolldown/tests/fixtures/plugin/banner-with-obj/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/banner-with-obj/_config.ts
@@ -10,7 +10,9 @@ export default defineTest({
     plugins: [
       {
         name: 'test-plugin',
-        banner: '/* Banner */',
+        banner: {
+          handler: '/* Banner */',
+        },
       },
     ],
   },

--- a/packages/rolldown/tests/fixtures/plugin/banner-with-obj/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/banner-with-obj/main.js
@@ -1,0 +1,1 @@
+console.log()

--- a/packages/rolldown/tests/fixtures/plugin/banner-with-str/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/banner-with-str/_config.ts
@@ -1,0 +1,20 @@
+import { expect, vi } from 'vitest'
+import path from 'node:path'
+import { defineTest } from '@tests'
+
+const entry = path.join(__dirname, './main.js')
+
+export default defineTest({
+  config: {
+    input: entry,
+    plugins: [
+      {
+        name: 'test-plugin',
+        banner: '/* Lorem ipsum */',
+      },
+    ],
+  },
+  afterTest: (output) => {
+    expect(output.output[0].code).toContain('/* Lorem ipsum */')
+  },
+})

--- a/packages/rolldown/tests/fixtures/plugin/banner-with-str/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/banner-with-str/main.js
@@ -1,0 +1,1 @@
+console.log()


### PR DESCRIPTION
### Description

According to the [Rollup docs](https://rollupjs.org/configuration-options/#output-banner-output-footer), the `banner` can either be a function or a `string`. This PR adds support for having the `banner` as a `string`.


