### PR TITLE
refactor(rust/treeshaking): get resolved symbol of `MemberExprRef` in one go

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -16,8 +16,7 @@ use oxc::{
 };
 use rolldown_common::{
   AstScopes, ExportsKind, ImportKind, ImportRecordIdx, LocalExport, MemberExprRef, ModuleDefFormat,
-  ModuleId, ModuleIdx, NamedImport, RawImportRecord, Specifier, StmtInfo, StmtInfos,
-  SymbolOrMemberExprRef, SymbolRef,
+  ModuleId, ModuleIdx, NamedImport, RawImportRecord, Specifier, StmtInfo, StmtInfos, SymbolRef,
 };
 use rolldown_ecmascript::{BindingIdentifierExt, BindingPatternExt};
 use rolldown_error::{BuildDiagnostic, UnhandleableResult};
@@ -487,11 +486,16 @@ impl<'me> AstScanner<'me> {
     self.current_stmt_info.referenced_symbols.push(sym_ref.into());
   }
 
-  pub fn add_member_expr_reference(&mut self, object_ref: SymbolRef, props: Vec<CompactStr>) {
+  pub fn add_member_expr_reference(
+    &mut self,
+    object_ref: SymbolRef,
+    props: Vec<CompactStr>,
+    span: Span,
+  ) {
     self
       .current_stmt_info
       .referenced_symbols
-      .push(SymbolOrMemberExprRef::MemberExpr(MemberExprRef { object_ref, props }));
+      .push(MemberExprRef::new(object_ref, props, span).into());
   }
 
   fn is_top_level(&self, symbol_id: SymbolId) -> bool {

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/finalizer_context.rs
@@ -6,7 +6,6 @@ use rustc_hash::FxHashMap;
 use crate::{
   chunk_graph::ChunkGraph,
   runtime::RuntimeModuleBrief,
-  stages::link_stage::tree_shaking::MemberChainToResolvedSymbolRef,
   types::{
     linking_metadata::{LinkingMetadata, LinkingMetadataVec},
     symbols::Symbols,
@@ -25,8 +24,4 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub runtime: &'me RuntimeModuleBrief,
   pub chunk_graph: &'me ChunkGraph,
   pub options: &'me SharedOptions,
-  /// Used to cache result of top level member expr namespace object ref resolved result
-  /// Avoid to recalculate it when code generation phase.
-  pub top_level_member_expr_resolved_cache:
-    &'me FxHashMap<SymbolRef, MemberChainToResolvedSymbolRef>,
 }

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -1,5 +1,7 @@
 // cSpell:disable
 
+use std::borrow::Cow;
+
 use oxc::{
   allocator::{self, IntoIn},
   ast::{
@@ -7,7 +9,7 @@ use oxc::{
     visit::walk_mut,
     VisitMut,
   },
-  span::{CompactStr, GetSpan, Span, SPAN},
+  span::{GetSpan, Span, SPAN},
 };
 use rolldown_common::{ExportsKind, Module, ModuleType, SymbolRef, WrapKind};
 use rolldown_ecmascript::{AllocatorExt, ExpressionExt, StatementExt, TakeIn};
@@ -442,52 +444,27 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
     // rewrite `foo_ns.bar` to `bar` directly
     match expr {
       Expression::StaticMemberExpression(ref inner_expr) => {
-        let mut chain = vec![];
-        let mut cur = inner_expr;
-        let top_level_symbol = loop {
-          chain.push(cur.property.clone());
-          match cur.object {
-            ast::Expression::StaticMemberExpression(ref expr) => {
-              cur = expr;
-            }
-            ast::Expression::Identifier(ref ident) => {
-              break self.resolve_symbol_from_reference(ident);
-            }
-            _ => break None,
-          }
-        };
-        if let Some(symbol) = top_level_symbol {
-          chain.reverse();
-          let chain: Vec<CompactStr> =
-            chain.into_iter().map(|ident| ident.name.as_str().into()).collect::<Vec<_>>();
-          let replaced_expr = self
-            .ctx
-            .top_level_member_expr_resolved_cache
-            .get(&(self.ctx.id, symbol).into())
-            .and_then(|map| map.get(&chain.clone().into_boxed_slice()))
-            .map(|(symbol_ref, cursor, namespace_property_name)| {
-              let replaced_expr = if let Some(name) = self.try_canonical_name_for(*symbol_ref) {
-                let namespace_prop_chain =
-                  if let Some(namespace_property_name) = namespace_property_name {
-                    vec![namespace_property_name.as_str().into()]
-                  } else {
-                    vec![]
-                  };
-                self.snippet.member_expr_or_ident_ref(
-                  name.as_str(),
-                  &[&chain[*cursor..], &namespace_prop_chain].concat(),
-                  SPAN,
-                )
+        if let Some(resolved) =
+          self.ctx.linking_info.resolved_member_expr_refs.get(&inner_expr.span)
+        {
+          match resolved {
+            Some((object_ref, props)) => {
+              let canonical_ref = self.ctx.symbols.par_canonical_ref_for(*object_ref);
+              let canonical_symbol = self.ctx.symbols.get(canonical_ref);
+              let object_name = if let Some(ns_alias) = &canonical_symbol.namespace_alias {
+                let ns_name = self.canonical_name_for(ns_alias.namespace_ref);
+                // TODO(hyf0): should use ast instead of string
+                Cow::Owned(format!("{}.{}", ns_name, ns_alias.property_name).into())
               } else {
-                // Ambiguous symbol, replace the member expr with `undefined`, the runtime semantic
-                // will not change
-                self.snippet.id_ref_expr("undefined", SPAN)
+                Cow::Borrowed(self.canonical_name_for(canonical_ref))
               };
-
-              replaced_expr
-            });
-          if let Some(replaced_expr) = replaced_expr {
-            *expr = replaced_expr;
+              let replaced_expr =
+                self.snippet.member_expr_or_ident_ref(object_name.as_str(), props, inner_expr.span);
+              *expr = replaced_expr;
+            }
+            None => {
+              *expr = self.snippet.void_zero();
+            }
           }
         };
       }

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
@@ -1,7 +1,6 @@
 use oxc::{
   allocator::{Allocator, IntoIn},
   ast::ast::{self, IdentifierReference, Statement},
-  semantic::SymbolId,
   span::{Atom, SPAN},
 };
 use rolldown_common::{AstScopes, ImportRecordIdx, Module, SymbolRef, WrapKind};
@@ -223,9 +222,5 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     );
 
     vec![decl_stmt, export_call_stmt]
-  }
-
-  fn resolve_symbol_from_reference(&self, id_ref: &IdentifierReference) -> Option<SymbolId> {
-    id_ref.reference_id.get().and_then(|ref_id| self.scope.symbol_id_for(ref_id))
   }
 }

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -50,28 +50,30 @@ impl<'a> GenerateStage<'a> {
       // We need this step to include the runtime module, if there are symbols of it.
       // TODO: Maybe we should push runtime module to `LinkingMetadata::dependencies` while pushing the runtime symbols.
       stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
-        let canonical_ref = match reference_ref {
-          rolldown_common::SymbolOrMemberExprRef::Symbol(s) => {
-            self.link_output.symbols.par_canonical_ref_for(*s)
+        match reference_ref {
+          rolldown_common::SymbolOrMemberExprRef::Symbol(sym_ref) => {
+            let canonical_ref = self.link_output.symbols.par_canonical_ref_for(*sym_ref);
+            self.determine_reachable_modules_for_entry(
+              canonical_ref.owner,
+              entry_index,
+              module_to_bits,
+            );
           }
-          // try to resolve member expression to the pointed symbol
-          // fallback to namespace_ref if not found
-          rolldown_common::SymbolOrMemberExprRef::MemberExpr(member_expr) => self
-            .link_output
-            .top_level_member_expr_resolved_cache
-            .get(&member_expr.object_ref)
-            .and_then(|map| map.get(&member_expr.props.clone().into_boxed_slice()))
-            .map_or_else(
-              || self.link_output.symbols.par_canonical_ref_for(member_expr.object_ref),
-              |(finalized_symbol_ref, _, _)| *finalized_symbol_ref,
-            ),
+          rolldown_common::SymbolOrMemberExprRef::MemberExpr(member_expr) => {
+            if let Some(sym_ref) = member_expr.resolved_symbol_ref(&meta.resolved_member_expr_refs)
+            {
+              let canonical_ref = self.link_output.symbols.par_canonical_ref_for(sym_ref);
+              self.determine_reachable_modules_for_entry(
+                canonical_ref.owner,
+                entry_index,
+                module_to_bits,
+              );
+            } else {
+              // `None` means the member expression resolve to a ambiguous export, which means it actually resolve to nothing.
+              // It would be rewrite to `undefined` in the final code, so we don't need to include anything to make `undefined` work.
+            }
+          }
         };
-
-        self.determine_reachable_modules_for_entry(
-          canonical_ref.owner,
-          entry_index,
-          module_to_bits,
-        );
       });
     });
   }

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -89,9 +89,6 @@ impl<'a> GenerateStage<'a> {
               runtime: &self.link_output.runtime,
               chunk_graph: &chunk_graph,
               options: self.options,
-              top_level_member_expr_resolved_cache: &self
-                .link_output
-                .top_level_member_expr_resolved_cache,
             },
             ast,
           );

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -10,7 +10,7 @@ use rolldown_utils::{
   ecma_script::legitimize_identifier_name,
   rayon::{ParallelBridge, ParallelIterator},
 };
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 use crate::{
   runtime::RuntimeModuleBrief,
@@ -22,7 +22,7 @@ use crate::{
   SharedOptions,
 };
 
-use self::{tree_shaking::MemberChainToResolvedSymbolRef, wrapping::create_wrapper};
+use self::wrapping::create_wrapper;
 
 use super::scan_stage::ScanStageOutput;
 
@@ -43,7 +43,6 @@ pub struct LinkStageOutput {
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
   pub used_symbol_refs: FxHashSet<SymbolRef>,
-  pub top_level_member_expr_resolved_cache: FxHashMap<SymbolRef, MemberChainToResolvedSymbolRef>,
 }
 
 #[derive(Debug)]
@@ -59,7 +58,6 @@ pub struct LinkStage<'a> {
   pub ast_table: IndexEcmaAst,
   pub options: &'a SharedOptions,
   pub used_symbol_refs: FxHashSet<SymbolRef>,
-  pub top_level_member_expr_resolved_cache: FxHashMap<SymbolRef, MemberChainToResolvedSymbolRef>,
 }
 
 impl<'a> LinkStage<'a> {
@@ -98,7 +96,6 @@ impl<'a> LinkStage<'a> {
       ast_table: scan_stage_output.index_ecma_ast,
       options,
       used_symbol_refs: FxHashSet::default(),
-      top_level_member_expr_resolved_cache: FxHashMap::default(),
     }
   }
 
@@ -179,7 +176,6 @@ impl<'a> LinkStage<'a> {
       errors: self.errors,
       ast_table: self.ast_table,
       used_symbol_refs: self.used_symbol_refs,
-      top_level_member_expr_resolved_cache: self.top_level_member_expr_resolved_cache,
     }
   }
 

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -1,4 +1,7 @@
-use oxc::index::IndexVec;
+use oxc::{
+  index::IndexVec,
+  span::{CompactStr, Span},
+};
 use rolldown_common::{ModuleIdx, ResolvedExport, StmtInfoIdx, SymbolRef, WrapKind};
 use rolldown_rstr::Rstr;
 use rustc_hash::FxHashMap;
@@ -50,6 +53,8 @@ pub struct LinkingMetadata {
 
   /// The dependencies of the module. It means if you want include this module, you need to include these dependencies too.
   pub dependencies: Vec<ModuleIdx>,
+  // `None` the member expression resolve to a ambiguous export.
+  pub resolved_member_expr_refs: FxHashMap<Span, Option<(SymbolRef, Vec<CompactStr>)>>,
 }
 
 impl LinkingMetadata {

--- a/crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguous_warning/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguous_warning/artifacts.snap
@@ -1,6 +1,6 @@
 ---
-source: crates/rolldown/tests/common/case.rs
-expression: content
+source: crates/rolldown_testing/src/integration_test.rs
+expression: snapshot
 input_file: crates/rolldown/tests/esbuild/import_star/import_export_star_ambiguous_warning
 ---
 # Assets
@@ -20,7 +20,7 @@ const z = 4;
 //#endregion
 //#region entry.js
 assert.equal(x, 1);
-assert.equal(undefined, undefined);
+assert.equal(void 0, undefined);
 assert.equal(z, 4);
 
 //#endregion

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -602,7 +602,7 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/import_export_star_ambiguous_warning
 
-- entry_js-!~{000}~.mjs => entry_js-P1n8pGoa.mjs
+- entry_js-!~{000}~.mjs => entry_js-E-ikmnlw.mjs
 
 # tests/esbuild/import_star/import_of_export_star
 

--- a/crates/rolldown_common/src/types/member_expr_ref.rs
+++ b/crates/rolldown_common/src/types/member_expr_ref.rs
@@ -1,4 +1,5 @@
-use oxc::span::CompactStr;
+use oxc::span::{CompactStr, Span};
+use rustc_hash::FxHashMap;
 
 use crate::SymbolRef;
 
@@ -9,4 +10,32 @@ use crate::SymbolRef;
 pub struct MemberExprRef {
   pub object_ref: SymbolRef,
   pub props: Vec<CompactStr>,
+  // Span of the whole member expression
+  pub span: Span,
+}
+
+impl MemberExprRef {
+  pub fn new(object_ref: SymbolRef, props: Vec<CompactStr>, span: Span) -> Self {
+    Self { object_ref, props, span }
+  }
+
+  // #[allow(clippy::manual_map)]: Current code is more readable.
+  #[allow(clippy::manual_map)]
+  pub fn resolved_symbol_ref(
+    &self,
+    resolved_map: &FxHashMap<Span, Option<(SymbolRef, Vec<CompactStr>)>>,
+  ) -> Option<SymbolRef> {
+    if let Some(resolved) = resolved_map.get(&self.span) {
+      match resolved {
+        Some((sym_ref, _)) => Some(*sym_ref),
+        None => {
+          // This member expression resolve to a ambiguous export, which means it actually resolve to nothing.
+          // It would be rewrite to `undefined` in the final code.
+          None
+        }
+      }
+    } else {
+      Some(self.object_ref)
+    }
+  }
 }

--- a/crates/rolldown_common/src/types/symbol_or_member_expr_ref.rs
+++ b/crates/rolldown_common/src/types/symbol_or_member_expr_ref.rs
@@ -1,6 +1,4 @@
-use oxc::{semantic::SymbolId, span::CompactStr};
-
-use crate::{ModuleIdx, SymbolRef};
+use crate::SymbolRef;
 
 use super::member_expr_ref::MemberExprRef;
 
@@ -22,15 +20,9 @@ impl SymbolOrMemberExprRef {
   }
 }
 
-impl From<(ModuleIdx, SymbolId)> for SymbolOrMemberExprRef {
-  fn from(value: (ModuleIdx, SymbolId)) -> Self {
-    Self::Symbol(SymbolRef { owner: value.0, symbol: value.1 })
-  }
-}
-
-impl From<(ModuleIdx, SymbolId, Vec<CompactStr>)> for SymbolOrMemberExprRef {
-  fn from(value: (ModuleIdx, SymbolId, Vec<CompactStr>)) -> Self {
-    Self::MemberExpr(MemberExprRef { object_ref: (value.0, value.1).into(), props: value.2 })
+impl From<MemberExprRef> for SymbolOrMemberExprRef {
+  fn from(value: MemberExprRef) -> Self {
+    Self::MemberExpr(value)
   }
 }
 

--- a/cspell.json
+++ b/cspell.json
@@ -162,6 +162,7 @@
     "underfin",
     "unhandleable",
     "UNKEYED",
+    "unspanned",
     "urlencoding",
     "usize",
     "vecmap",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- This PR does does the same thing as the old code but storing the result in a map and use it directly rather do a resolving process with cache.
- This PR also split the member expression resolving logic into a extra step, it might slow down the performance but make the treeshaking process more clean and simple.
- https://github.com/rolldown/rolldown/pull/1805 rely on this PR, which makes the finalizing logic simpler.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
