### PR TITLE
feat: add support for footer as str

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -130,7 +130,7 @@ pub struct BindingPluginOptions {
   pub banner: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
+  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string")]
   pub footer: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -232,7 +232,7 @@ export interface BindingPluginOptions {
   generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>
   writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>
   banner?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
-  footer?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+  footer?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
   intro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
   outro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
 }

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -184,6 +184,10 @@ export function bindingifyFooter(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, chunk) => {
+    if (typeof handler !== 'function') {
+      return handler
+    }
+
     return handler.call(
       new PluginContext(options, ctx, plugin, pluginContextData),
       chunk,

--- a/packages/rolldown/tests/fixtures/plugin/footer-with-obj/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/footer-with-obj/_config.ts
@@ -10,7 +10,7 @@ export default defineTest({
     plugins: [
       {
         name: 'test-plugin',
-        footer: () => '/* Footer */',
+        footer: { handler: '/* Footer */' },
       },
     ],
   },

--- a/packages/rolldown/tests/fixtures/plugin/footer-with-obj/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/footer-with-obj/main.js
@@ -1,0 +1,1 @@
+console.log()

--- a/packages/rolldown/tests/fixtures/plugin/footer-with-str/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/footer-with-str/_config.ts
@@ -10,7 +10,7 @@ export default defineTest({
     plugins: [
       {
         name: 'test-plugin',
-        footer: () => '/* Footer */',
+        footer: '/* Footer */',
       },
     ],
   },

--- a/packages/rolldown/tests/fixtures/plugin/footer-with-str/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/footer-with-str/main.js
@@ -1,0 +1,1 @@
+console.log()


### PR DESCRIPTION
### Description

According to the [Rollup docs](https://rollupjs.org/configuration-options/#output-banner-output-footer), the `footer` can either be a function or a `string`. This PR adds support for having the `footer` as a `string`.


