### PR TITLE
feat: add support for intro as str

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -134,7 +134,7 @@ pub struct BindingPluginOptions {
   pub footer: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
+  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string")]
   pub intro: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -232,8 +232,13 @@ export interface BindingPluginOptions {
   generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>
   writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>
   banner?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
+<<<<<<< HEAD
   footer?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
   intro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+=======
+  footer?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+  intro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
+>>>>>>> a4749b09 (Add support for intro as str)
   outro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
 }
 

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -232,13 +232,8 @@ export interface BindingPluginOptions {
   generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>
   writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>
   banner?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
-<<<<<<< HEAD
   footer?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
-  intro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
-=======
-  footer?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
   intro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
->>>>>>> a4749b09 (Add support for intro as str)
   outro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
 }
 

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -208,6 +208,10 @@ export function bindingifyIntro(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, chunk) => {
+    if (typeof handler !== 'function') {
+      return handler
+    }
+
     return handler.call(
       new PluginContext(options, ctx, plugin, pluginContextData),
       chunk,

--- a/packages/rolldown/tests/fixtures/plugin/intro-with-obj/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/intro-with-obj/_config.ts
@@ -10,7 +10,7 @@ export default defineTest({
     plugins: [
       {
         name: 'test-plugin',
-        intro: () => '/* Intro */',
+        intro: { handler: '/* Intro */' },
       },
     ],
   },

--- a/packages/rolldown/tests/fixtures/plugin/intro-with-obj/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/intro-with-obj/main.js
@@ -1,0 +1,1 @@
+console.log()

--- a/packages/rolldown/tests/fixtures/plugin/intro-with-str/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/intro-with-str/_config.ts
@@ -10,7 +10,7 @@ export default defineTest({
     plugins: [
       {
         name: 'test-plugin',
-        intro: () => '/* Intro */',
+        intro: '/* Intro */',
       },
     ],
   },

--- a/packages/rolldown/tests/fixtures/plugin/intro-with-str/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/intro-with-str/main.js
@@ -1,0 +1,1 @@
+console.log()


### PR DESCRIPTION
### Description

Add support for having `intro` as a `string` or an `object`.
