### PR TITLE
feat: add support for outro as str

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -126,19 +126,19 @@ pub struct BindingPluginOptions {
   pub write_bundle: Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingOutputs), ()>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void)")]
+  #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
   pub banner: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void)")]
+  #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
   pub footer: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void)")]
+  #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
   pub intro: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void)")]
+  #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
   pub outro: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 }
 

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -138,7 +138,7 @@ pub struct BindingPluginOptions {
   pub intro: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
+  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string")]
   pub outro: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 }
 

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -126,19 +126,19 @@ pub struct BindingPluginOptions {
   pub write_bundle: Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingOutputs), ()>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string")]
+  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void)")]
   pub banner: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string")]
+  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void)")]
   pub footer: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string")]
+  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void)")]
   pub intro: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 
   #[serde(skip_deserializing)]
-  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string")]
+  #[napi(ts_type = "((ctx: BindingPluginContext, chunk: RenderedChunk) => void)")]
   pub outro: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
 }
 

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -231,10 +231,10 @@ export interface BindingPluginOptions {
   renderError?: (ctx: BindingPluginContext, error: string) => void
   generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>
   writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>
-  banner?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
-  footer?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
-  intro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
-  outro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
+  banner?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void)
+  footer?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void)
+  intro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void)
+  outro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void)
 }
 
 export interface BindingPluginWithIndex {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -231,10 +231,10 @@ export interface BindingPluginOptions {
   renderError?: (ctx: BindingPluginContext, error: string) => void
   generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>
   writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>
-  banner?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void)
-  footer?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void)
-  intro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void)
-  outro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void)
+  banner?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+  footer?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+  intro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+  outro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
 }
 
 export interface BindingPluginWithIndex {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -232,15 +232,9 @@ export interface BindingPluginOptions {
   generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>
   writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>
   banner?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
-<<<<<<< HEAD
   footer?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
   intro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
-  outro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
-=======
-  footer?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
-  intro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
   outro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
->>>>>>> 029a8562 (Add support for outro as str)
 }
 
 export interface BindingPluginWithIndex {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -232,9 +232,15 @@ export interface BindingPluginOptions {
   generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>
   writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>
   banner?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
+<<<<<<< HEAD
   footer?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
   intro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
   outro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+=======
+  footer?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+  intro?: (ctx: BindingPluginContext, chunk: RenderedChunk) => void
+  outro?: ((ctx: BindingPluginContext, chunk: RenderedChunk) => void) | string
+>>>>>>> 029a8562 (Add support for outro as str)
 }
 
 export interface BindingPluginWithIndex {

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -232,6 +232,10 @@ export function bindingifyOutro(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, chunk) => {
+    if (typeof handler !== 'function') {
+      return handler
+    }
+
     return handler.call(
       new PluginContext(options, ctx, plugin, pluginContextData),
       chunk,

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -160,7 +160,7 @@ export function bindingifyBanner(
 
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
   return async (ctx, chunk) => {
-    if (typeof handler !== 'function') {
+    if (typeof handler === 'string') {
       return handler
     }
 
@@ -184,7 +184,7 @@ export function bindingifyFooter(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, chunk) => {
-    if (typeof handler !== 'function') {
+    if (typeof handler === 'string') {
       return handler
     }
 
@@ -208,7 +208,7 @@ export function bindingifyIntro(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, chunk) => {
-    if (typeof handler !== 'function') {
+    if (typeof handler === 'string') {
       return handler
     }
 
@@ -232,7 +232,7 @@ export function bindingifyOutro(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, chunk) => {
-    if (typeof handler !== 'function') {
+    if (typeof handler === 'string') {
       return handler
     }
 

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -213,7 +213,7 @@ export type AddonHookFunction = (
   chunk: RenderedChunk,
 ) => string | Promise<string>
 
-export type AddonHook = AddonHookFunction
+export type AddonHook = string | AddonHookFunction
 
 export interface OutputPlugin
   extends Partial<{ [K in OutputPluginHooks]: PluginHooks[K] }>,

--- a/packages/rolldown/src/utils/normalize-hook.ts
+++ b/packages/rolldown/src/utils/normalize-hook.ts
@@ -1,25 +1,18 @@
 import type { ObjectHook } from '../plugin'
 import type { AnyFn, AnyObj } from '../types/utils'
 
-type NotFn<T> = T extends AnyFn ? never : T
-
-export function normalizeHook<H extends ObjectHook<AnyFn, AnyObj>>(
-  hook: H,
-): H extends ObjectHook<infer Handler, infer Options>
-  ? [Handler, NotFn<Options>]
-  : never {
+export function normalizeHook<T extends AnyFn | string>(
+  hook: ObjectHook<T, AnyObj>,
+): [T, AnyObj] {
   if (typeof hook === 'function') {
-    // @ts-expect-error
     return [hook, {}]
   }
 
   if (typeof hook === 'object') {
     const { handler, ...options } = hook
 
-    // @ts-expect-error
     return [handler, options]
   }
 
-  // @ts-expect-error
   return [hook, {}]
 }

--- a/packages/rolldown/tests/fixtures/plugin/outro-with-obj/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/outro-with-obj/_config.ts
@@ -10,7 +10,7 @@ export default defineTest({
     plugins: [
       {
         name: 'test-plugin',
-        outro: () => '/* Outro */',
+        outro: { handler: '/* Outro */' },
       },
     ],
   },

--- a/packages/rolldown/tests/fixtures/plugin/outro-with-obj/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/outro-with-obj/main.js
@@ -1,0 +1,1 @@
+console.log()

--- a/packages/rolldown/tests/fixtures/plugin/outro-with-str/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/outro-with-str/_config.ts
@@ -10,7 +10,7 @@ export default defineTest({
     plugins: [
       {
         name: 'test-plugin',
-        outro: () => '/* Outro */',
+        outro: '/* Outro */',
       },
     ],
   },

--- a/packages/rolldown/tests/fixtures/plugin/outro-with-str/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/outro-with-str/main.js
@@ -1,0 +1,1 @@
+console.log()


### PR DESCRIPTION
### Description

Add support for having `outro` as a `string` or an `object`.
