### PR TITLE
chore: add fixme on use `span` identify top level member expr

### DIFF
--- a/crates/rolldown_common/src/types/member_expr_ref.rs
+++ b/crates/rolldown_common/src/types/member_expr_ref.rs
@@ -10,7 +10,9 @@ use crate::SymbolRef;
 pub struct MemberExprRef {
   pub object_ref: SymbolRef,
   pub props: Vec<CompactStr>,
-  // Span of the whole member expression
+  /// Span of the whole member expression
+  /// FIXME: use `AstNodeId` to identify the MemberExpr instead of `Span`
+  /// related discussion: https://github.com/rolldown/rolldown/pull/1818#discussion_r1699374441
   pub span: Span,
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Add a comment to avoid forgetting the issue about using span to identify `AstNode`.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
