### PR TITLE
chore: disable all Rust doc tests

### DIFF
--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -8,6 +8,9 @@ version              = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+
 [lints]
 workspace = true
 

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [lib]
 crate-type = ["cdylib"]
+doctest    = false
 
 [dependencies]
 anyhow                              = { workspace = true }

--- a/crates/rolldown_common/Cargo.toml
+++ b/crates/rolldown_common/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+
 [lints]
 workspace = true
 

--- a/crates/rolldown_css/Cargo.toml
+++ b/crates/rolldown_css/Cargo.toml
@@ -6,6 +6,9 @@ name                 = "rolldown_css"
 repository.workspace = true
 version              = "0.1.0"
 
+[lib]
+doctest = false
+
 [dependencies]
 anyhow       = { workspace = true }
 lightningcss = { workspace = true, features = ["into_owned"] }

--- a/crates/rolldown_ecmascript/Cargo.toml
+++ b/crates/rolldown_ecmascript/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace    = true
 repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+
 [lints]
 workspace = true
 

--- a/crates/rolldown_error/Cargo.toml
+++ b/crates/rolldown_error/Cargo.toml
@@ -10,6 +10,9 @@ homepage.workspace   = true
 license.workspace    = true
 repository.workspace = true
 
+[lib]
+doctest = false
+
 [lints]
 workspace = true
 

--- a/crates/rolldown_fs/Cargo.toml
+++ b/crates/rolldown_fs/Cargo.toml
@@ -8,6 +8,9 @@ version              = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+
 [lints]
 workspace = true
 

--- a/crates/rolldown_loader_utils/Cargo.toml
+++ b/crates/rolldown_loader_utils/Cargo.toml
@@ -6,6 +6,9 @@ name                 = "rolldown_loader_utils"
 repository.workspace = true
 version              = "0.1.0"
 
+[lib]
+doctest = false
+
 [dependencies]
 anyhow          = { workspace = true }
 rolldown_common = { workspace = true }

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -8,6 +8,9 @@ version              = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+
 [features]
 inner = []
 

--- a/crates/rolldown_plugin_data_url/Cargo.toml
+++ b/crates/rolldown_plugin_data_url/Cargo.toml
@@ -4,6 +4,9 @@ license = "MIT"
 name    = "rolldown_plugin_data_url"
 version = "0.1.0"
 
+[lib]
+doctest = false
+
 [dependencies]
 base64-simd     = { workspace = true }
 dashmap         = { workspace = true }

--- a/crates/rolldown_plugin_dynamic_import_vars/Cargo.toml
+++ b/crates/rolldown_plugin_dynamic_import_vars/Cargo.toml
@@ -8,6 +8,9 @@ version              = "0.0.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+
 [lints]
 workspace = true
 

--- a/crates/rolldown_plugin_glob_import/Cargo.toml
+++ b/crates/rolldown_plugin_glob_import/Cargo.toml
@@ -8,6 +8,9 @@ version              = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+
 [lints]
 workspace = true
 

--- a/crates/rolldown_plugin_wasm/Cargo.toml
+++ b/crates/rolldown_plugin_wasm/Cargo.toml
@@ -8,6 +8,9 @@ version              = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+
 [lints]
 workspace = true
 

--- a/crates/rolldown_resolver/Cargo.toml
+++ b/crates/rolldown_resolver/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace    = true
 repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+
 [lints]
 workspace = true
 

--- a/crates/rolldown_rstr/Cargo.toml
+++ b/crates/rolldown_rstr/Cargo.toml
@@ -8,6 +8,9 @@ version              = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+
 [dependencies]
 oxc = { workspace = true }
 

--- a/crates/rolldown_testing/Cargo.toml
+++ b/crates/rolldown_testing/Cargo.toml
@@ -8,6 +8,10 @@ homepage.workspace   = true
 license.workspace    = true
 repository.workspace = true
 
+[lib]
+doctest = false
+test    = false
+
 [lints]
 workspace = true
 
@@ -32,5 +36,7 @@ schemars                = { workspace = true }
 serde_json              = { workspace = true }
 
 [[bin]]
-name = "run-fixture"
-path = "./bin/run-fixture.rs"
+doctest = false
+name    = "run-fixture"
+path    = "./bin/run-fixture.rs"
+test    = false

--- a/crates/rolldown_testing_config/Cargo.toml
+++ b/crates/rolldown_testing_config/Cargo.toml
@@ -8,6 +8,10 @@ version              = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+doctest = false
+test    = false
+
 [dependencies]
 rolldown_common = { workspace = true, features = ["deserialize_bundler_options"] }
 schemars        = { workspace = true }

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace   = true
 license.workspace    = true
 repository.workspace = true
 
+[lib]
+doctest = false
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
Because they are slow to compile and we don't use them. Local `cargo test` run is improved by a few seconds.

I also disabled test compilations in all test utility crates.