### PR TITLE
fix: using sanitize_file_name to generate valid file name

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -11,6 +11,7 @@ use rolldown_utils::{
   path_buf_ext::PathBufExt,
   path_ext::PathExt,
   rayon::{IntoParallelRefIterator, ParallelBridge, ParallelIterator},
+  sanitize_file_name::sanitize_file_name,
 };
 use sugar_path::SugarPath;
 
@@ -142,7 +143,7 @@ impl<'a> GenerateStage<'a> {
                   .map(ArcStr::from)
                   .unwrap_or(arcstr::literal!("input"))
               } else {
-                ArcStr::from(module.id().as_path().representative_file_name().into_owned())
+                ArcStr::from(sanitize_file_name(module.id().as_path().representative_file_name()))
               };
               ChunkNameInfo { name: generated, explicit: false }
             }
@@ -157,7 +158,7 @@ impl<'a> GenerateStage<'a> {
                 || arcstr::literal!("chunk"),
                 |module_id| {
                   let module = &modules[*module_id];
-                  ArcStr::from(module.id().as_path().representative_file_name().into_owned())
+                  ArcStr::from(sanitize_file_name(module.id().as_path().representative_file_name()))
                 },
               ),
               explicit: false,

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -1,5 +1,6 @@
 use crate::{AssetSource, FileNameRenderOptions, NormalizedBundlerOptions, Output, OutputAsset};
 use dashmap::{DashMap, DashSet};
+use rolldown_utils::sanitize_file_name::sanitize_file_name;
 use rolldown_utils::xxhash::xxhash_base64_url;
 use std::ffi::OsStr;
 use std::path::Path;
@@ -58,8 +59,11 @@ impl FileEmitter {
     if file.file_name.is_none() {
       let path = file.name.as_deref().map(Path::new);
       let extension = path.and_then(|x| x.extension().and_then(OsStr::to_str));
+      let name = path
+        .and_then(|x| x.file_stem().and_then(OsStr::to_str))
+        .map(|x| sanitize_file_name(x.into()));
       let file_name = self.options.asset_filenames.render(&FileNameRenderOptions {
-        name: path.and_then(|x| x.file_stem().and_then(OsStr::to_str)),
+        name: name.as_deref(),
         hash: Some(&xxhash_base64_url(file.source.as_bytes()).as_str()[..8]),
         ext: extension,
       });

--- a/crates/rolldown_utils/src/lib.rs
+++ b/crates/rolldown_utils/src/lib.rs
@@ -14,6 +14,6 @@ pub mod path_ext;
 pub mod percent_encoding;
 pub mod rayon;
 pub mod rustc_hash;
+pub mod sanitize_file_name;
 pub mod xxhash;
-
 pub use bitset::BitSet;

--- a/crates/rolldown_utils/src/path_ext.rs
+++ b/crates/rolldown_utils/src/path_ext.rs
@@ -26,11 +26,6 @@ impl PathExt for std::path::Path {
 
   /// It doesn't ensure the file name is a valid identifier in JS.
   fn representative_file_name(&self) -> Cow<str> {
-    // Avoid file name contained an unexpected NUL byte.
-    if let Some(stripped) = self.to_string_lossy().strip_prefix('\0') {
-      return stripped.to_owned().into();
-    }
-
     let file_name =
       self.file_stem().map_or_else(|| self.to_string_lossy(), |stem| stem.to_string_lossy());
 
@@ -64,7 +59,4 @@ fn test_representative_file_name() {
 
   let path = cwd.join("vue").join("mod.ts");
   assert_eq!(path.representative_file_name(), "vue_mod");
-
-  let path = Path::new("\0/project/mod.ts");
-  assert_eq!(path.representative_file_name(), "/project/mod.ts");
 }

--- a/crates/rolldown_utils/src/sanitize_file_name.rs
+++ b/crates/rolldown_utils/src/sanitize_file_name.rs
@@ -1,0 +1,21 @@
+use std::borrow::Cow;
+
+// TODO support `output.sanitizeFileName`
+// Follow from https://github.com/rollup/rollup/blob/master/src/utils/sanitizeFileName.ts
+#[allow(clippy::needless_pass_by_value)]
+pub fn sanitize_file_name(str: Cow<str>) -> String {
+  let mut sanitized = String::with_capacity(str.len());
+  for char in str.chars() {
+    if char.is_ascii_alphanumeric() || matches!(char, '-' | '_') {
+      sanitized.push(char);
+    } else {
+      sanitized.push('_');
+    }
+  }
+  sanitized
+}
+
+#[test]
+fn test_sanitize_file_name() {
+  assert_eq!(sanitize_file_name("\0+a=Z_0-".into()), "__a_Z_0-");
+}

--- a/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
@@ -26,9 +26,9 @@ export default defineTest({
   afterTest(output) {
     expect(getOutputChunkNames(output)).toMatchInlineSnapshot(`
       [
+        "_module-KtCeJTRH.js",
         "entry.js",
         "main.js",
-        "module-NZqqXNZ9.js",
       ]
     `)
   },

--- a/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
@@ -24,6 +24,7 @@ export default defineTest({
     ],
   },
   afterTest(output) {
+    // cSpell:disable
     expect(getOutputChunkNames(output)).toMatchInlineSnapshot(`
       [
         "_module-KtCeJTRH.js",

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
@@ -42,7 +42,9 @@ export default defineTest({
     for (const asset of assets) {
       switch (asset.name) {
         case '+emitted.txt':
-          expect(asset.fileName).toMatchInlineSnapshot(`"_emitted-umwR9Fta.txt"`)
+          expect(asset.fileName).toMatchInlineSnapshot(
+            `"_emitted-umwR9Fta.txt"`,
+          )
           break
 
         case 'icon.png':

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
@@ -19,13 +19,13 @@ export default defineTest({
           // emit asset string source
           referenceId = this.emitFile({
             type: 'asset',
-            name: 'emitted.txt',
+            name: '+emitted.txt',
             source: 'emitted',
           })
         },
         generateBundle() {
           expect(this.getFileName(referenceId)).toMatchInlineSnapshot(
-            `"emitted-umwR9Fta.txt"`,
+            `"_emitted-umwR9Fta.txt"`,
           )
           // emit asset buffer source
           this.emitFile({
@@ -41,8 +41,8 @@ export default defineTest({
     const assets = getOutputAsset(output)
     for (const asset of assets) {
       switch (asset.name) {
-        case 'emitted.txt':
-          expect(asset.fileName).toMatchInlineSnapshot(`"emitted-umwR9Fta.txt"`)
+        case '+emitted.txt':
+          expect(asset.fileName).toMatchInlineSnapshot(`"_emitted-umwR9Fta.txt"`)
           break
 
         case 'icon.png':


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The rollup using `sanitizeFileName` to generate the valid file name, see [here](https://github.com/rollup/rollup/blob/master/src/utils/sanitizeFileName.ts). 

The related vite pr: https://github.com/vitejs/vite/pull/9737.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
