### PR TITLE
chore:  add test-node-only command

### DIFF
--- a/justfile
+++ b/justfile
@@ -65,21 +65,21 @@ test-rust:
     cargo test --no-fail-fast
 
 # Supported presets: all, rolldown, rollup
-test-node preset="all" *args="":
+test-node preset="all" *args="": _build-native-debug
+    just _test-node-{{preset}} {{args}}
+
+test-node-only preset="all" *args="":
     just _test-node-{{preset}} {{args}}
 
 _test-node-all:
-  just build native debug
   pnpm run --recursive --parallel --filter=!rollup-tests test 
   # We run rollup tests separately to have a clean output.
   pnpm run --filter rollup-tests test
 
 _test-node-rolldown *args:
-  just build native debug
   pnpm run --filter rolldown test {{args}}
 
 _test-node-rollup command="":
-  just build native debug
   pnpm run --filter rollup-tests test{{command}}
 
 # Fix formatting issues both for Rust, Node.js and all files in the repository
@@ -117,6 +117,8 @@ lint-repo:
 build target="native" mode="debug":
   pnpm run --filter rolldown build-{{target}}:{{mode}}
 
+_build-native-debug:
+  just build native debug
 # BENCHING
 
 bench-rust:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. add `test-node-only` command in justfile,  this allows us to run the test rather than test after the build, which could save a few seconds.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
