### PR TITLE
chore:  add span of `module_request` in  raw import record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,6 +2203,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arcstr",
+ "bitflags 2.6.0",
  "dashmap 6.0.1",
  "glob-match",
  "lightningcss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,10 +143,10 @@ urlencoding        = "2.1.3"
 vfs                = "0.12.0"
 xxhash-rust        = "0.8.10"
 # oxc crates share the same version
+bitflags           = { version = "2.6.0" }
 oxc                = { version = "0.23.0", features = ["sourcemap_concurrent", "transformer", "minifier", "semantic", "codegen"] }
 oxc_index          = { version = "0.23.0" }
 oxc_transform_napi = { version = "0.23.0" }
-
 [profile.release]
 codegen-units = 1
 lto           = true

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -96,7 +96,11 @@ impl<'me, 'ast> Visit<'ast> for AstScanner<'me> {
 
   fn visit_import_expression(&mut self, expr: &oxc::ast::ast::ImportExpression<'ast>) {
     if let oxc::ast::ast::Expression::StringLiteral(request) = &expr.source {
-      let id = self.add_import_record(request.value.as_str(), ImportKind::DynamicImport);
+      let id = self.add_import_record(
+        request.value.as_str(),
+        ImportKind::DynamicImport,
+        expr.source.span().start,
+      );
       self.result.imports.insert(expr.span, id);
     }
     walk::walk_import_expression(self, expr);
@@ -115,7 +119,8 @@ impl<'me, 'ast> Visit<'ast> for AstScanner<'me> {
   fn visit_call_expression(&mut self, expr: &oxc::ast::ast::CallExpression<'ast>) {
     if expr.is_global_require_call(self.scopes) {
       if let Some(oxc::ast::ast::Argument::StringLiteral(request)) = &expr.arguments.first() {
-        let id = self.add_import_record(request.value.as_str(), ImportKind::Require);
+        let id =
+          self.add_import_record(request.value.as_str(), ImportKind::Require, request.span().start);
         self.result.imports.insert(expr.span, id);
       }
     }

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -15,9 +15,9 @@ use oxc::{
   span::{CompactStr, GetSpan, Span},
 };
 use rolldown_common::{
-  AstScopes, ExportsKind, ImportKind, ImportRecordIdx, ImportRecordMeta, ImporterRecord,
-  LocalExport, MemberExprRef, ModuleDefFormat, ModuleId, ModuleIdx, NamedImport, RawImportRecord,
-  Specifier, StmtInfo, StmtInfos, SymbolRef,
+  AstScopes, ExportsKind, ImportKind, ImportRecordIdx, ImportRecordMeta, LocalExport,
+  MemberExprRef, ModuleDefFormat, ModuleId, ModuleIdx, NamedImport, RawImportRecord, Specifier,
+  StmtInfo, StmtInfos, SymbolRef,
 };
 use rolldown_ecmascript::{BindingIdentifierExt, BindingPatternExt};
 use rolldown_error::{BuildDiagnostic, CjsExportSpan, UnhandleableResult};
@@ -337,9 +337,7 @@ impl<'me> AstScanner<'me> {
       span_imported,
     };
     if name_import.imported.is_default() {
-      self.result.import_records[record_id]
-        .import_record_meta
-        .insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
+      self.result.import_records[record_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
     }
     self.result.named_exports.insert(
       export_name.into(),
@@ -365,9 +363,7 @@ impl<'me> AstScanner<'me> {
       record_id,
     };
 
-    self.result.import_records[record_id]
-      .import_record_meta
-      .insert(ImportRecordMeta::CONTAINS_IMPORT_STAR);
+    self.result.import_records[record_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_STAR);
     self.result.named_exports.insert(
       export_name.into(),
       LocalExport { referenced: generated_imported_as_ref, span: name_import.span_imported },
@@ -406,9 +402,7 @@ impl<'me> AstScanner<'me> {
       self.result.imports.insert(decl.span, record_id);
       // `export {} from '...'`
       if decl.specifiers.is_empty() {
-        self.result.import_records[record_id]
-          .import_record_meta
-          .insert(ImportRecordMeta::IS_PLAIN_IMPORT);
+        self.result.import_records[record_id].meta.insert(ImportRecordMeta::IS_PLAIN_IMPORT);
       }
     } else {
       decl.specifiers.iter().for_each(|spec| {
@@ -488,9 +482,7 @@ impl<'me> AstScanner<'me> {
     self.result.imports.insert(decl.span, rec_id);
     // // `import '...'` or `import {} from '...'`
     if decl.specifiers.as_ref().map_or(true, |s| s.is_empty()) {
-      self.result.import_records[rec_id]
-        .import_record_meta
-        .insert(ImportRecordMeta::IS_PLAIN_IMPORT);
+      self.result.import_records[rec_id].meta.insert(ImportRecordMeta::IS_PLAIN_IMPORT);
     }
 
     let Some(specifiers) = &decl.specifiers else { return };
@@ -500,22 +492,16 @@ impl<'me> AstScanner<'me> {
         let imported = spec.imported.name();
         self.add_named_import(sym, imported.as_str(), rec_id, spec.imported.span());
         if imported == "default" {
-          self.result.import_records[rec_id]
-            .import_record_meta
-            .insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
+          self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
         }
       }
       oxc::ast::ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
         self.add_named_import(spec.local.expect_symbol_id(), "default", rec_id, spec.span);
-        self.result.import_records[rec_id]
-          .import_record_meta
-          .insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
+        self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
       }
       oxc::ast::ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
         self.add_star_import(spec.local.expect_symbol_id(), rec_id, spec.span);
-        self.result.import_records[rec_id]
-          .import_record_meta
-          .insert(ImportRecordMeta::CONTAINS_IMPORT_STAR);
+        self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_STAR);
       }
     });
   }

--- a/crates/rolldown_common/Cargo.toml
+++ b/crates/rolldown_common/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [dependencies]
 anyhow             = { workspace = true }
 arcstr             = { workspace = true }
+bitflags           = { workspace = true }
 dashmap            = { workspace = true }
 glob-match         = { workspace = true }
 lightningcss       = { workspace = true }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -58,7 +58,9 @@ pub use crate::{
   types::entry_point::{EntryPoint, EntryPointKind},
   types::exports_kind::ExportsKind,
   types::external_module_idx::ExternalModuleIdx,
-  types::import_record::{ImportKind, ImportRecord, ImportRecordIdx, RawImportRecord},
+  types::import_record::{
+    ImportKind, ImportRecord, ImportRecordIdx, ImportRecordMeta, RawImportRecord,
+  },
   types::importer_record::ImporterRecord,
   types::js_regex,
   types::member_expr_ref::MemberExprRef,

--- a/crates/rolldown_common/src/types/import_record.rs
+++ b/crates/rolldown_common/src/types/import_record.rs
@@ -52,23 +52,35 @@ pub struct RawImportRecord {
   pub kind: ImportKind,
   /// See [ImportRecord] for more details.
   pub namespace_ref: SymbolRef,
-  /// See [ImportRecord] for more details.
-  pub contains_import_star: bool,
-  /// See [ImportRecord] for more details.
-  pub contains_import_default: bool,
-  /// See [ImportRecord] for more details.
-  pub is_plain_import: bool,
+  pub module_request_start: u32,
+  pub import_record_meta: ImportRecordMeta,
+}
+
+bitflags::bitflags! {
+  #[derive(Debug)]
+  pub struct ImportRecordMeta: u8 {
+    /// See [ImportRecord] for more details.
+    const CONTAINS_IMPORT_STAR = 1;
+    /// See [ImportRecord] for more details.
+    const CONTAINS_IMPORT_DEFAULT = 1 << 1;
+    /// See [ImportRecord] for more details.
+    const IS_PLAIN_IMPORT = 1 << 2;
+  }
 }
 
 impl RawImportRecord {
-  pub fn new(specifier: Rstr, kind: ImportKind, namespace_ref: SymbolRef) -> Self {
+  pub fn new(
+    specifier: Rstr,
+    kind: ImportKind,
+    namespace_ref: SymbolRef,
+    module_request_start: u32,
+  ) -> Self {
     Self {
       module_request: specifier,
       kind,
       namespace_ref,
-      contains_import_default: false,
-      contains_import_star: false,
-      is_plain_import: false,
+      module_request_start,
+      import_record_meta: ImportRecordMeta::empty(),
     }
   }
 
@@ -78,9 +90,13 @@ impl RawImportRecord {
       resolved_module,
       kind: self.kind,
       namespace_ref: self.namespace_ref,
-      contains_import_star: self.contains_import_star,
-      contains_import_default: self.contains_import_default,
-      is_plain_import: self.is_plain_import,
+      contains_import_star: self
+        .import_record_meta
+        .contains(ImportRecordMeta::CONTAINS_IMPORT_STAR),
+      contains_import_default: self
+        .import_record_meta
+        .contains(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT),
+      is_plain_import: self.import_record_meta.contains(ImportRecordMeta::IS_PLAIN_IMPORT),
     }
   }
 }

--- a/crates/rolldown_common/src/types/import_record.rs
+++ b/crates/rolldown_common/src/types/import_record.rs
@@ -87,8 +87,9 @@ impl RawImportRecord {
     }
   }
 
+  #[allow(clippy::cast_possible_truncation)]
   pub fn module_request_end(&self) -> u32 {
-    self.module_request_start + self.module_request.len() as u32 + 2 // +2 for quotes
+    self.module_request_start + self.module_request.len() as u32 + 2u32 // +2 for quotes
   }
 
   pub fn into_import_record(self, resolved_module: ModuleIdx) -> ImportRecord {

--- a/crates/rolldown_common/src/types/import_record.rs
+++ b/crates/rolldown_common/src/types/import_record.rs
@@ -52,6 +52,9 @@ pub struct RawImportRecord {
   pub kind: ImportKind,
   /// See [ImportRecord] for more details.
   pub namespace_ref: SymbolRef,
+  /// Why use start_offset instead of `Span`? Cause, directly pass `Span` will increase the type
+  /// size from `40` to `48`(8 bytes alignment). Since the `RawImportRecord` will be created multiple time,
+  /// Using this trick could save some memory.
   pub module_request_start: u32,
   pub meta: ImportRecordMeta,
 }
@@ -82,6 +85,10 @@ impl RawImportRecord {
       module_request_start,
       meta: ImportRecordMeta::empty(),
     }
+  }
+
+  pub fn module_request_end(&self) -> u32 {
+    self.module_request_start + self.module_request.len() as u32 + 2 // +2 for quotes
   }
 
   pub fn into_import_record(self, resolved_module: ModuleIdx) -> ImportRecord {

--- a/crates/rolldown_common/src/types/import_record.rs
+++ b/crates/rolldown_common/src/types/import_record.rs
@@ -53,17 +53,17 @@ pub struct RawImportRecord {
   /// See [ImportRecord] for more details.
   pub namespace_ref: SymbolRef,
   pub module_request_start: u32,
-  pub import_record_meta: ImportRecordMeta,
+  pub meta: ImportRecordMeta,
 }
 
 bitflags::bitflags! {
   #[derive(Debug)]
   pub struct ImportRecordMeta: u8 {
-    /// See [ImportRecord] for more details.
+    /// If it is `import * as ns from '...'` or `export * as ns from '...'`
     const CONTAINS_IMPORT_STAR = 1;
-    /// See [ImportRecord] for more details.
+    /// If it is `import def from '...'`, `import { default as def }`, `export { default as def }` or `export { default } from '...'`
     const CONTAINS_IMPORT_DEFAULT = 1 << 1;
-    /// See [ImportRecord] for more details.
+    /// If it is `import {} from '...'` or `import '...'`
     const IS_PLAIN_IMPORT = 1 << 2;
   }
 }
@@ -80,7 +80,7 @@ impl RawImportRecord {
       kind,
       namespace_ref,
       module_request_start,
-      import_record_meta: ImportRecordMeta::empty(),
+      meta: ImportRecordMeta::empty(),
     }
   }
 
@@ -90,13 +90,7 @@ impl RawImportRecord {
       resolved_module,
       kind: self.kind,
       namespace_ref: self.namespace_ref,
-      contains_import_star: self
-        .import_record_meta
-        .contains(ImportRecordMeta::CONTAINS_IMPORT_STAR),
-      contains_import_default: self
-        .import_record_meta
-        .contains(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT),
-      is_plain_import: self.import_record_meta.contains(ImportRecordMeta::IS_PLAIN_IMPORT),
+      meta: self.meta,
     }
   }
 }
@@ -110,10 +104,5 @@ pub struct ImportRecord {
   /// We will turn `import { foo } from './cjs.js'; console.log(foo);` to `var import_foo = require_cjs(); console.log(importcjs.foo)`;
   /// `namespace_ref` represent the potential `import_foo` in above example. It's useless if we imported n esm module.
   pub namespace_ref: SymbolRef,
-  /// If it is `import * as ns from '...'` or `export * as ns from '...'`
-  pub contains_import_star: bool,
-  /// If it is `import def from '...'`, `import { default as def }`, `export { default as def }` or `export { default } from '...'`
-  pub contains_import_default: bool,
-  /// If it is `import {} from '...'` or `import '...'`
-  pub is_plain_import: bool,
+  pub meta: ImportRecordMeta,
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. This pr add the ability to get the span of `module_request`.
2. Aiming to keep the type size unchanged, I did some refactors, If I add `Span` directly the type size will increase from `40` to `48` bytes.

Related to https://github.com/rolldown/rolldown/pull/1866
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
