### PR TITLE
feat(node): support passing `custom` in `PluginContext#resolve`

### DIFF
--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -106,9 +106,17 @@ impl ScanStage {
         specifier: &'a str,
       }
       let args = Args { specifier: &input_item.import };
-      let resolved =
-        resolve_id(resolver, plugin_driver, args.specifier, None, true, ImportKind::Import, None)
-          .await;
+      let resolved = resolve_id(
+        resolver,
+        plugin_driver,
+        args.specifier,
+        None,
+        true,
+        ImportKind::Import,
+        None,
+        None,
+      )
+      .await;
 
       resolved
         .map(|info| (args, info.map(|info| ((input_item.name.clone().map(ArcStr::from)), info))))

--- a/crates/rolldown/src/types/module_factory.rs
+++ b/crates/rolldown/src/types/module_factory.rs
@@ -62,9 +62,17 @@ impl<'a> CreateModuleContext<'a> {
       }));
     }
 
-    let resolved_id =
-      resolve_id::resolve_id(resolver, plugin_driver, specifier, Some(importer), false, kind, None)
-        .await?;
+    let resolved_id = resolve_id::resolve_id(
+      resolver,
+      plugin_driver,
+      specifier,
+      Some(importer),
+      false,
+      kind,
+      None,
+      None,
+    )
+    .await?;
 
     match resolved_id {
       Ok(mut resolved_id) => {

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -63,7 +63,11 @@ impl Plugin for JsPlugin {
           Arc::clone(ctx).into(),
           args.specifier.to_string(),
           args.importer.map(str::to_string),
-          BindingHookResolveIdExtraOptions { is_entry: args.is_entry, kind: args.kind.to_string() },
+          BindingHookResolveIdExtraOptions {
+            is_entry: args.is_entry,
+            kind: args.kind.to_string(),
+            custom: args.custom,
+          },
         ))
         .await?
         .map(Into::into),

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_extra_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_extra_options.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 #[serde(rename_all = "camelCase")]
 #[derivative(Debug)]
 pub struct BindingHookResolveIdExtraOptions {
+  pub custom: Option<u32>,
   pub is_entry: bool,
   #[napi(ts_type = "'import' | 'dynamic-import' | 'require-call'")]
   pub kind: String,

--- a/crates/rolldown_binding/src/options/plugin/types/binding_plugin_context_resolve_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_plugin_context_resolve_options.rs
@@ -10,6 +10,7 @@ pub struct BindingPluginContextResolveOptions {
   #[napi(ts_type = "'import' | 'dynamic-import' | 'require-call'")]
   pub import_kind: Option<String>,
   pub skip_self: Option<bool>,
+  pub custom: Option<u32>,
 }
 
 impl TryFrom<BindingPluginContextResolveOptions> for PluginContextResolveOptions {
@@ -19,6 +20,7 @@ impl TryFrom<BindingPluginContextResolveOptions> for PluginContextResolveOptions
     Ok(Self {
       import_kind: value.import_kind.as_deref().unwrap_or("import").try_into()?,
       skip_self: value.skip_self.unwrap_or(true),
+      custom: value.custom,
     })
   }
 }

--- a/crates/rolldown_plugin/src/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context.rs
@@ -60,6 +60,7 @@ impl PluginContext {
       importer,
       false,
       normalized_extra_options.import_kind,
+      normalized_extra_options.custom,
       if normalized_extra_options.skip_self {
         let mut skipped_resolve_calls = Vec::with_capacity(self.skipped_resolve_calls.len() + 1);
         skipped_resolve_calls.extend(self.skipped_resolve_calls.clone());

--- a/crates/rolldown_plugin/src/types/hook_resolve_id_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_resolve_id_args.rs
@@ -5,6 +5,7 @@ pub struct HookResolveIdArgs<'a> {
   pub importer: Option<&'a str>,
   pub specifier: &'a str,
   pub is_entry: bool,
+  pub custom: Option<u32>,
   // Rollup doesn't have a `kind` field, but rolldown supports cjs, css by default. So we need this
   // field to determine the import kind.
   pub kind: ImportKind,

--- a/crates/rolldown_plugin/src/types/plugin_context_resolve_options.rs
+++ b/crates/rolldown_plugin/src/types/plugin_context_resolve_options.rs
@@ -4,10 +4,12 @@ use rolldown_common::ImportKind;
 pub struct PluginContextResolveOptions {
   pub import_kind: ImportKind,
   pub skip_self: bool,
+  /// The js side custom options is a complex js object, we can't directly convert it to rust struct. So here store a index to reference the js side custom options.
+  pub custom: Option<u32>,
 }
 
 impl Default for PluginContextResolveOptions {
   fn default() -> Self {
-    Self { import_kind: ImportKind::Import, skip_self: true }
+    Self { import_kind: ImportKind::Import, skip_self: true, custom: None }
   }
 }

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -13,6 +13,7 @@ fn is_data_url(s: &str) -> bool {
   s.trim_start().starts_with("data:")
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn resolve_id_with_plugins(
   resolver: &Resolver,
   plugin_driver: &PluginDriver,
@@ -20,6 +21,7 @@ pub async fn resolve_id_with_plugins(
   importer: Option<&str>,
   is_entry: bool,
   import_kind: ImportKind,
+  custom: Option<u32>,
   skipped_resolve_calls: Option<Vec<Arc<HookResolveIdSkipped>>>,
 ) -> anyhow::Result<Result<ResolvedId, ResolveError>> {
   if matches!(import_kind, ImportKind::DynamicImport) {
@@ -29,6 +31,7 @@ pub async fn resolve_id_with_plugins(
           importer: importer.map(std::convert::AsRef::as_ref),
           specifier: request,
           is_entry,
+          custom,
           kind: import_kind,
         },
         skipped_resolve_calls.as_ref(),
@@ -52,6 +55,7 @@ pub async fn resolve_id_with_plugins(
         importer: importer.map(std::convert::AsRef::as_ref),
         specifier: request,
         is_entry,
+        custom,
         kind: import_kind,
       },
       skipped_resolve_calls.as_ref(),

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -133,6 +133,7 @@ export interface BindingHookRenderChunkOutput {
 }
 
 export interface BindingHookResolveIdExtraOptions {
+  custom?: number
   isEntry: boolean
   kind: 'import' | 'dynamic-import' | 'require-call'
 }
@@ -228,6 +229,7 @@ export interface BindingPluginContextResolvedId {
 export interface BindingPluginContextResolveOptions {
   importKind?: 'import' | 'dynamic-import' | 'require-call'
   skipSelf?: boolean
+  custom?: number
 }
 
 export interface BindingPluginOptions {

--- a/packages/rolldown/src/options/bindingify-input-options.ts
+++ b/packages/rolldown/src/options/bindingify-input-options.ts
@@ -9,11 +9,13 @@ import {
   bindingifyBuiltInPlugin,
   BuiltinPlugin,
 } from '../plugin/builtin-plugin'
+import { PluginContextData } from '../plugin/plugin-context-data'
 
 export function bindingifyInputOptions(
   options: NormalizedInputOptions,
   outputOptions: NormalizedOutputOptions,
 ): BindingInputOptions {
+  const pluginContextData = new PluginContextData()
   return {
     input: bindingifyInput(options.input),
     plugins: options.plugins.map((plugin) => {
@@ -23,7 +25,7 @@ export function bindingifyInputOptions(
       if (plugin instanceof BuiltinPlugin) {
         return bindingifyBuiltInPlugin(plugin)
       }
-      return bindingifyPlugin(plugin, options, outputOptions)
+      return bindingifyPlugin(plugin, options, outputOptions, pluginContextData)
     }),
     cwd: options.cwd ?? process.cwd(),
     external: options.external

--- a/packages/rolldown/src/parallel-plugin-worker.ts
+++ b/packages/rolldown/src/parallel-plugin-worker.ts
@@ -5,6 +5,7 @@ import type { defineParallelPluginImplementation } from './parallel-plugin'
 import { bindingifyPlugin } from './plugin/bindingify-plugin'
 import type { NormalizedInputOptions } from './options/normalized-input-options'
 import type { NormalizedOutputOptions } from './options/normalized-output-options'
+import { PluginContextData } from './plugin/plugin-context-data'
 
 const { registryId, pluginInfos, threadNumber } = workerData as WorkerData
 
@@ -26,6 +27,8 @@ const { registryId, pluginInfos, threadNumber } = workerData as WorkerData
             plugin,
             {} as NormalizedInputOptions,
             {} as NormalizedOutputOptions,
+            // TODO need to find a way to share pluginContextData
+            new PluginContextData(),
           ),
         }
       }),

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -69,7 +69,13 @@ export function bindingifyResolveId(
       new PluginContext(options, ctx, plugin, pluginContextData),
       specifier,
       importer ?? undefined,
-      extraOptions,
+      {
+        ...extraOptions,
+        custom:
+          typeof extraOptions.custom === 'number'
+            ? pluginContextData.getResolveCustom(extraOptions.custom)
+            : undefined,
+      },
     )
     if (ret == false || ret == null) {
       return

--- a/packages/rolldown/src/plugin/bindingify-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin.ts
@@ -32,8 +32,8 @@ export function bindingifyPlugin(
   plugin: Plugin,
   options: NormalizedInputOptions,
   outputOptions: NormalizedOutputOptions,
+  pluginContextData: PluginContextData,
 ): BindingPluginOptions {
-  const pluginContextData = new PluginContextData()
   return {
     name: plugin.name ?? 'unknown',
     buildStart: bindingifyBuildStart(plugin, options, pluginContextData),

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -50,6 +50,12 @@ export interface SourceDescription extends Partial<PartialNull<ModuleOptions>> {
   map?: SourceMapInput
 }
 
+interface ResolveIdExtraOptions {
+  custom?: CustomPluginOptions
+  isEntry: boolean
+  kind: 'import' | 'dynamic-import' | 'require-call'
+}
+
 export type ResolveIdResult = string | NullValue | false | PartialResolvedId
 
 export type LoadResult = NullValue | string | SourceDescription
@@ -82,7 +88,7 @@ export interface FunctionPluginHooks {
     this: PluginContext,
     source: string,
     importer: string | undefined,
-    extraOptions: BindingHookResolveIdExtraOptions,
+    extraOptions: ResolveIdExtraOptions,
   ) => ResolveIdResult
 
   /**

--- a/packages/rolldown/src/plugin/plugin-context-data.ts
+++ b/packages/rolldown/src/plugin/plugin-context-data.ts
@@ -61,4 +61,8 @@ export class PluginContextData {
   getResolveCustom(index: number) {
     return this.resolveCustomMap.get(index)
   }
+
+  removeResolveCustom(index: number) {
+    this.resolveCustomMap.delete(index)
+  }
 }

--- a/packages/rolldown/src/plugin/plugin-context-data.ts
+++ b/packages/rolldown/src/plugin/plugin-context-data.ts
@@ -1,11 +1,12 @@
 import { BindingPluginContext } from '../binding'
-import { ModuleInfo, ModuleOptions } from '..'
+import { CustomPluginOptions, ModuleInfo, ModuleOptions } from '..'
 import { transformModuleInfo } from '../utils/transform-module-info'
 
 export class PluginContextData {
   modules = new Map<string, ModuleInfo>()
   moduleIds: Array<string> | null = null
   moduleOptionMap = new Map<string, ModuleOptions>()
+  resolveCustomMap = new Map<number, CustomPluginOptions>()
 
   updateModuleOption(id: string, option: ModuleOptions) {
     const existing = this.moduleOptionMap.get(id)
@@ -17,6 +18,10 @@ export class PluginContextData {
     } else {
       this.moduleOptionMap.set(id, option)
     }
+  }
+
+  getModuleOption(id: string) {
+    return this.moduleOptionMap.get(id)
   }
 
   getModuleInfo(id: string, context: BindingPluginContext) {
@@ -45,5 +50,15 @@ export class PluginContextData {
       return moduleIds.values()
     }
     return [].values()
+  }
+
+  setResolveCustom(custom: CustomPluginOptions): number {
+    const index = Object.keys(this.resolveCustomMap).length
+    this.resolveCustomMap.set(index, custom)
+    return index
+  }
+
+  getResolveCustom(index: number) {
+    return this.resolveCustomMap.get(index)
   }
 }

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -2,7 +2,12 @@ import type { RollupError, LoggingFunction } from '../rollup'
 import type { BindingPluginContext } from '../binding'
 import { getLogHandler, normalizeLog } from '../log/logHandler'
 import type { NormalizedInputOptions } from '../options/normalized-input-options'
-import type { Plugin } from './index'
+import type {
+  CustomPluginOptions,
+  ModuleOptions,
+  Plugin,
+  ResolvedId,
+} from './index'
 import { LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARN } from '../log/logging'
 import { error, logPluginError } from '../log/logs'
 import { AssetSource, bindingAssetSource } from '../utils/asset-source'
@@ -24,7 +29,16 @@ export class PluginContext {
   info: LoggingFunction
   warn: LoggingFunction
   error: (error: RollupError | string) => never
-  resolve: BindingPluginContext['resolve']
+  resolve: (
+    source: string,
+    importer?: string,
+    options?: {
+      // assertions?: Record<string, string>
+      custom?: CustomPluginOptions
+      // isEntry?: boolean
+      skipSelf?: boolean
+    },
+  ) => Promise<ResolvedId | null>
   emitFile: (file: EmittedAsset) => string
   getFileName: (referenceId: string) => string
   getModuleInfo: (id: string) => ModuleInfo | null
@@ -67,7 +81,24 @@ export class PluginContext {
     this.error = (e): never => {
       return error(logPluginError(normalizeLog(e), pluginName))
     }
-    this.resolve = context.resolve.bind(context)
+    this.resolve = async (
+      source: string,
+      importer?: string,
+      options?: {
+        // assertions?: Record<string, string>
+        custom?: CustomPluginOptions
+        // isEntry?: boolean
+        skipSelf?: boolean
+      },
+    ) => {
+      const res = await context.resolve(source, importer, {
+        custom: options?.custom && data.setResolveCustom(options.custom),
+        skipSelf: options?.skipSelf,
+      })
+      if (res == null) return null
+      const info = data.getModuleOption(res.id) || ({} as ModuleOptions)
+      return { ...res, ...info }
+    }
     this.emitFile = (file: EmittedAsset): string => {
       if (file.type !== 'asset') {
         return unimplemented(

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -91,10 +91,12 @@ export class PluginContext {
         skipSelf?: boolean
       },
     ) => {
+      let custom = options?.custom && data.setResolveCustom(options.custom)
       const res = await context.resolve(source, importer, {
-        custom: options?.custom && data.setResolveCustom(options.custom),
+        custom,
         skipSelf: options?.skipSelf,
       })
+      typeof custom === 'number' && data.removeResolveCustom(custom)
       if (res == null) return null
       const info = data.getModuleOption(res.id) || ({} as ModuleOptions)
       return { ...res, ...info }

--- a/packages/rollup-tests/src/failed-tests.json
+++ b/packages/rollup-tests/src/failed-tests.json
@@ -102,7 +102,6 @@
   "rollup@function@custom-path-resolver-plural-b: resolver error is not caught",
   "rollup@function@custom-path-resolver-plural: uses custom path resolvers (plural)",
   "rollup@function@custom-path-resolver-sync: uses a custom path resolver (synchronous)",
-  "rollup@function@custom-resolve-options: supports custom resolve options",
   "rollup@function@cycles-default-anonymous-function-hoisted: Anonymous function declarations are hoisted",
   "rollup@function@cycles-defaults: cycles work with default exports",
   "rollup@function@cycles-export-star: does not stack overflow on `export * from X` cycles",

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,6 +1,6 @@
 {
   "failed": 0,
-  "skipFailed": 633,
+  "skipFailed": 632,
   "skipped": 0,
-  "passed": 284
+  "passed": 285
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -1,6 +1,6 @@
 |  | number |
 |----| ---- |
 | failed | 0|
-| skipFailed | 633|
+| skipFailed | 632|
 | skipped | 0|
-| passed | 284|
+| passed | 285|


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The pr intend to support `PluginContext#resolve#option#cutsom`, it will be transfer to `ResolveId#ResolveOption#custom`  to do some plugin resolve logic.

It is used at vite resolver, and the struct is complex, see [here](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/resolve.ts#L181).  We can't directly convert it to rust struct. So here store a index to reference the js side custom options. It is difficult to expand, but i think it's less usage at rust side plugins, we could improve it if we have demand.

Other things, here fixed a logic about `PluginContextData`, it should be singleton, But it make complex to shared data at  parallel worker plugin, We could leave it at now util we find a good idea.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
