### PR TITLE
feat(rust/plugin): Support `custom` in `PluginContextResolveOptions`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,6 +2287,7 @@ dependencies = [
  "rolldown_sourcemap",
  "rolldown_utils",
  "tracing",
+ "typedmap",
 ]
 
 [[package]]
@@ -2932,6 +2933,15 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "typedmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0a883093b9d4733a7a5ceb14b05bc2c51c21d8bbf1fd3d9de72a0821f4b910"
+dependencies = [
+ "dashmap 5.5.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ bitflags           = { version = "2.6.0" }
 oxc                = { version = "0.23.0", features = ["sourcemap_concurrent", "transformer", "minifier", "semantic", "codegen"] }
 oxc_index          = { version = "0.23.0" }
 oxc_transform_napi = { version = "0.23.0" }
+typedmap           = "0.5.0"
 [profile.release]
 codegen-units = 1
 lto           = true

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -114,7 +114,7 @@ impl ScanStage {
         true,
         ImportKind::Import,
         None,
-        None,
+        Arc::default(),
       )
       .await;
 

--- a/crates/rolldown/src/types/module_factory.rs
+++ b/crates/rolldown/src/types/module_factory.rs
@@ -70,7 +70,7 @@ impl<'a> CreateModuleContext<'a> {
       false,
       kind,
       None,
-      None,
+      Arc::default(),
     )
     .await?;
 

--- a/crates/rolldown/tests/rolldown/mod.rs
+++ b/crates/rolldown/tests/rolldown/mod.rs
@@ -1,2 +1,3 @@
 mod errors;
 mod issues;
+mod plugin;

--- a/crates/rolldown/tests/rolldown/plugin/mod.rs
+++ b/crates/rolldown/tests/rolldown/plugin/mod.rs
@@ -1,0 +1,1 @@
+mod plugin_context;

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/artifacts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.mjs
+
+```js
+
+//#region entry.js
+console.log(require("hello, world"));
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/entry.js
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/entry.js
@@ -1,0 +1,1 @@
+console.log(require('foo'))

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/mod.rs
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/mod.rs
@@ -1,0 +1,96 @@
+use std::{borrow::Cow, sync::Arc};
+
+use rolldown::{BundlerOptions, InputItem};
+use rolldown_plugin::{
+  typedmap::{TypedDashMap, TypedMapKey},
+  HookResolveIdArgs, HookResolveIdOutput, HookResolveIdReturn, Plugin, PluginContextResolveOptions,
+  SharedPluginContext,
+};
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+#[derive(Debug)]
+struct TestPluginCaller;
+
+#[derive(Hash, PartialEq, Eq)]
+struct MyArg {
+  id: usize,
+}
+
+impl TypedMapKey for MyArg {
+  type Value = String;
+}
+
+impl Plugin for TestPluginCaller {
+  fn name(&self) -> Cow<'static, str> {
+    "TestPluginCaller".into()
+  }
+
+  async fn resolve_id(
+    &self,
+    ctx: &SharedPluginContext,
+    args: &HookResolveIdArgs<'_>,
+  ) -> HookResolveIdReturn {
+    if args.specifier == "foo" {
+      let custom = TypedDashMap::default();
+      custom.insert(MyArg { id: 0 }, "hello, world".to_string());
+      let custom_resolve_ret = ctx
+        .resolve(
+          "test",
+          None,
+          Some(PluginContextResolveOptions { custom: Arc::new(custom), ..Default::default() }),
+        )
+        .await??;
+
+      if custom_resolve_ret.id == "hello, world" {
+        Ok(Some(HookResolveIdOutput {
+          id: "hello, world".to_string(),
+          external: Some(true),
+          ..Default::default()
+        }))
+      } else {
+        panic!("test")
+      }
+    } else {
+      Ok(None)
+    }
+  }
+}
+
+#[derive(Debug)]
+struct TestPluginReceiver;
+
+impl Plugin for TestPluginReceiver {
+  fn name(&self) -> Cow<'static, str> {
+    "TestPluginReceiver".into()
+  }
+
+  async fn resolve_id(
+    &self,
+    _ctx: &SharedPluginContext,
+    args: &HookResolveIdArgs<'_>,
+  ) -> HookResolveIdReturn {
+    if let Some(value) = args.custom.get::<MyArg>(&MyArg { id: 0 }) {
+      assert_eq!(value.as_str(), "hello, world");
+      return Ok(Some(HookResolveIdOutput { id: value.to_string(), ..Default::default() }));
+    }
+    Ok(None)
+  }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn allow_pass_custom_arg() {
+  let cwd = abs_file_dir!();
+
+  IntegrationTest::new(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec![InputItem {
+          name: Some("entry".to_string()),
+          import: "./entry.js".to_string(),
+        }]),
+        cwd: Some(cwd),
+        ..Default::default()
+      },
+      vec![Arc::new(TestPluginCaller), Arc::new(TestPluginReceiver)],
+    )
+    .await;
+}

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/mod.rs
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/mod.rs
@@ -1,0 +1,1 @@
+mod custom_arg_in_resolve;

--- a/crates/rolldown_binding/src/options/plugin/types/binding_plugin_context_resolve_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_plugin_context_resolve_options.rs
@@ -1,6 +1,10 @@
+use std::sync::Arc;
+
 use derivative::Derivative;
-use rolldown_plugin::PluginContextResolveOptions;
+use rolldown_plugin::{typedmap::TypedDashMap, PluginContextResolveOptions};
 use serde::Deserialize;
+
+use crate::options::plugin::JsPluginContextResolveCustomArgId;
 
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Deserialize, Derivative, Default)]
@@ -17,10 +21,14 @@ impl TryFrom<BindingPluginContextResolveOptions> for PluginContextResolveOptions
   type Error = String;
 
   fn try_from(value: BindingPluginContextResolveOptions) -> Result<Self, Self::Error> {
+    let custom = TypedDashMap::new();
+    if let Some(js_custom_id) = value.custom {
+      custom.insert(JsPluginContextResolveCustomArgId, js_custom_id);
+    }
     Ok(Self {
       import_kind: value.import_kind.as_deref().unwrap_or("import").try_into()?,
       skip_self: value.skip_self.unwrap_or(true),
-      custom: value.custom,
+      custom: Arc::new(custom),
     })
   }
 }

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -28,3 +28,4 @@ rolldown_resolver   = { workspace = true }
 rolldown_sourcemap  = { workspace = true }
 rolldown_utils      = { workspace = true }
 tracing             = { workspace = true }
+typedmap            = { workspace = true, features = ["dashmap"] }

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -37,3 +37,5 @@ pub use crate::{
   types::hook_transform_output::HookTransformOutput,
   types::plugin_context_resolve_options::PluginContextResolveOptions,
 };
+
+pub use typedmap;

--- a/crates/rolldown_plugin/src/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context.rs
@@ -60,7 +60,6 @@ impl PluginContext {
       importer,
       false,
       normalized_extra_options.import_kind,
-      normalized_extra_options.custom,
       if normalized_extra_options.skip_self {
         let mut skipped_resolve_calls = Vec::with_capacity(self.skipped_resolve_calls.len() + 1);
         skipped_resolve_calls.extend(self.skipped_resolve_calls.clone());
@@ -75,6 +74,7 @@ impl PluginContext {
       } else {
         None
       },
+      normalized_extra_options.custom,
     )
     .await
   }

--- a/crates/rolldown_plugin/src/types/hook_resolve_id_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_resolve_id_args.rs
@@ -1,12 +1,15 @@
+use std::sync::Arc;
+
 use rolldown_common::ImportKind;
+use typedmap::TypedDashMap;
 
 #[derive(Debug)]
 pub struct HookResolveIdArgs<'a> {
   pub importer: Option<&'a str>,
   pub specifier: &'a str,
   pub is_entry: bool,
-  pub custom: Option<u32>,
   // Rollup doesn't have a `kind` field, but rolldown supports cjs, css by default. So we need this
   // field to determine the import kind.
   pub kind: ImportKind,
+  pub custom: Arc<TypedDashMap>,
 }

--- a/crates/rolldown_plugin/src/types/plugin_context_resolve_options.rs
+++ b/crates/rolldown_plugin/src/types/plugin_context_resolve_options.rs
@@ -1,15 +1,17 @@
+use std::sync::Arc;
+
 use rolldown_common::ImportKind;
+use typedmap::TypedDashMap;
 
 #[derive(Debug)]
 pub struct PluginContextResolveOptions {
   pub import_kind: ImportKind,
   pub skip_self: bool,
-  /// The js side custom options is a complex js object, we can't directly convert it to rust struct. So here store a index to reference the js side custom options.
-  pub custom: Option<u32>,
+  pub custom: Arc<TypedDashMap>,
 }
 
 impl Default for PluginContextResolveOptions {
   fn default() -> Self {
-    Self { import_kind: ImportKind::Import, skip_self: true, custom: None }
+    Self { import_kind: ImportKind::Import, skip_self: true, custom: Arc::default() }
   }
 }

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -4,6 +4,7 @@ use crate::{
 use rolldown_common::{ImportKind, ModuleDefFormat, ResolvedId};
 use rolldown_resolver::{ResolveError, Resolver};
 use std::{path::Path, sync::Arc};
+use typedmap::TypedDashMap;
 
 fn is_http_url(s: &str) -> bool {
   s.starts_with("http://") || s.starts_with("https://") || s.starts_with("//")
@@ -21,8 +22,8 @@ pub async fn resolve_id_with_plugins(
   importer: Option<&str>,
   is_entry: bool,
   import_kind: ImportKind,
-  custom: Option<u32>,
   skipped_resolve_calls: Option<Vec<Arc<HookResolveIdSkipped>>>,
+  custom: Arc<TypedDashMap>,
 ) -> anyhow::Result<Result<ResolvedId, ResolveError>> {
   if matches!(import_kind, ImportKind::DynamicImport) {
     if let Some(r) = plugin_driver
@@ -31,8 +32,8 @@ pub async fn resolve_id_with_plugins(
           importer: importer.map(std::convert::AsRef::as_ref),
           specifier: request,
           is_entry,
-          custom,
           kind: import_kind,
+          custom: Arc::clone(&custom),
         },
         skipped_resolve_calls.as_ref(),
       )
@@ -55,8 +56,8 @@ pub async fn resolve_id_with_plugins(
         importer: importer.map(std::convert::AsRef::as_ref),
         specifier: request,
         is_entry,
-        custom,
         kind: import_kind,
+        custom: Arc::clone(&custom),
       },
       skipped_resolve_calls.as_ref(),
     )

--- a/cspell.json
+++ b/cspell.json
@@ -162,6 +162,7 @@
     "treeshake",
     "trivias",
     "Trivias",
+    "typedmap",
     "typeof",
     "typeofs",
     "underfin",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Base infra for #1874.

- `typedmap` is chosen due to have builtin support for `dashmap`. `anymap` requires wrapping in `Arc<Mutex<>>` and I don't want to do that.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
