### PR TITLE
refactor(rust/test): don't execute bundle entries automatically if there is `_test.mjs`/`_test.cjs`

### DIFF
--- a/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed/_test.mjs
+++ b/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed/_test.mjs
@@ -1,2 +1,5 @@
+import './dist/entry_js.mjs'
+import './dist/entry2_js.mjs'
+
 import assert from 'assert';
 assert(globalThis.sideEffectExecuted, 'side effect not executed')

--- a/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed2/_test.mjs
+++ b/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed2/_test.mjs
@@ -1,2 +1,5 @@
+import './dist/a.mjs'
+import './dist/b.mjs'
+
 import assert from 'assert';
 assert(globalThis.sideEffectExecuted, 'side effect not executed')

--- a/docs/contrib-guide/testing.md
+++ b/docs/contrib-guide/testing.md
@@ -30,8 +30,8 @@ For all available options, you could refer to
 - https://github.com/rolldown/rolldown/blob/main/crates/rolldown_testing/_config.schema.json
 
 - `main.js` is the default entry of the test case, if `config.input` is not specified in `_config.json`.
-
-Rolldown will bundle the input into `/dist`, and using the same `node` instance to execute every entry file in `/dist` orderly. If `_test.mjs` is found in test case folder, it will be executed after all entry points are executed.
+- Rolldown will bundle the input into `/dist`, and execute every entry file in `/dist` orderly. You might thinking it as running `node --import ./dist/entry1.mjs --import ./dist/entry2.mjs --import ./dist/entry3.mjs --eval ""`.
+  - If there is a `_test.mjs`/`_test.cjs` in the test case folder, only `_test.mjs`/`_test.cjs` will be executed. If you want to execute compiled entries, you need to import them manully in `_test.mjs`/`_test.cjs`.
 
 ### Function-complete tests in rust
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We need `_test.mjs` to write some assertions while bundled output is invalid to execute.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
