### PR TITLE
test(rust): allow to write comments in `_config.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,8 @@
   },
   "files.associations": {
     "*.snap": "markdown",
-    "*.snap.new": "markdown"
+    "*.snap.new": "markdown",
+    "_config.json": "jsonc"
   },
   "git.ignoreLimitWarning": true,
   "json.schemas": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,9 +963,12 @@ dependencies = [
 
 [[package]]
 name = "json-strip-comments"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d129799327c8f80861e467c59b825ba24c277dba6ad0d71a141dc98f9e04ee"
+checksum = "b271732a960335e715b6b2ae66a086f115c74eb97360e996d2bd809bfc063bba"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "jsonschema"
@@ -2399,6 +2402,7 @@ dependencies = [
  "anyhow",
  "dunce",
  "insta",
+ "json-strip-comments",
  "jsonschema",
  "regex",
  "rolldown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,53 +97,55 @@ rolldown_testing_config                 = { version = "0.1.0", path = "./crates/
 rolldown_tracing                        = { version = "0.1.0", path = "./crates/rolldown_tracing" }
 rolldown_utils                          = { version = "0.1.0", path = "./crates/rolldown_utils" }
 
-anyhow             = "1.0.86"
-arcstr             = "1.2.0"
-ariadne            = "0.4.1"
-async-channel      = "2.3.1"
-async-scoped       = { version = "0.9.0" }
-async-trait        = "0.1.80"
-base64-simd        = "0.8.0"
-bitflags           = { version = "2.6.0" }
-daachorse          = "1.0.0"
-dashmap            = "6.0.0"
-derivative         = "2.2.0"
-dunce              = "1.0.4"                                                                        # Normalize Windows paths to the most compatible format, avoiding UNC where possible
-futures            = "0.3.30"
-glob               = "0.3.1"
-glob-match         = "0.2.1"
-indexmap           = "2.2.6"
-infer              = "0.16.0"
-insta              = "1.39.0"
-itertools          = "0.13.0"
-jsonschema         = { version = "0.18.0", default-features = false }
-lightningcss       = { version = "1.0.0-alpha.57" }
-memchr             = "2.7.2"
-mimalloc           = "0.1.42"
-mime               = "0.3.17"
-napi               = { version = "3.0.0-alpha", features = ["async"] }
-napi-build         = { version = "2.1.3" }
-napi-derive        = { version = "3.0.0-alpha", default-features = false, features = ["type-def"] }
-oxc_resolver       = { version = "1.9.0" }
-phf                = "0.11.2"
-rayon              = "1.10.0"
-regex              = "1.10.5"
-rustc-hash         = "2.0.0"
-schemars           = "0.8.21"
-self_cell          = "1.0.4"
-serde              = { version = "1.0.203", features = ["derive"] }
-serde_json         = "1.0.117"
-smallvec           = "1.13.2"
-sugar_path         = { version = "1.2.0", features = ["cached_current_dir"] }
-testing_macros     = "0.2.13"
-tokio              = { version = "1.38.0", default-features = false }
-tracing            = "0.1.40"
-tracing-chrome     = "0.7.2"
-tracing-subscriber = { version = "0.3.18", default-features = false }
-typedmap           = "0.5.0"
-urlencoding        = "2.1.3"
-vfs                = "0.12.0"
-xxhash-rust        = "0.8.10"
+
+anyhow              = "1.0.86"
+arcstr              = "1.2.0"
+ariadne             = "0.4.1"
+async-channel       = "2.3.1"
+async-scoped        = { version = "0.9.0" }
+async-trait         = "0.1.80"
+base64-simd         = "0.8.0"
+bitflags            = { version = "2.6.0" }
+daachorse           = "1.0.0"
+dashmap             = "6.0.0"
+derivative          = "2.2.0"
+dunce               = "1.0.4"                                                                        # Normalize Windows paths to the most compatible format, avoiding UNC where possible
+futures             = "0.3.30"
+glob                = "0.3.1"
+glob-match          = "0.2.1"
+indexmap            = "2.2.6"
+infer               = "0.16.0"
+insta               = "1.39.0"
+itertools           = "0.13.0"
+json-strip-comments = "1.0.4"
+jsonschema          = { version = "0.18.0", default-features = false }
+lightningcss        = { version = "1.0.0-alpha.57" }
+memchr              = "2.7.2"
+mimalloc            = "0.1.42"
+mime                = "0.3.17"
+napi                = { version = "3.0.0-alpha", features = ["async"] }
+napi-build          = { version = "2.1.3" }
+napi-derive         = { version = "3.0.0-alpha", default-features = false, features = ["type-def"] }
+oxc_resolver        = { version = "1.9.0" }
+phf                 = "0.11.2"
+rayon               = "1.10.0"
+regex               = "1.10.5"
+rustc-hash          = "2.0.0"
+schemars            = "0.8.21"
+self_cell           = "1.0.4"
+serde               = { version = "1.0.203", features = ["derive"] }
+serde_json          = "1.0.117"
+smallvec            = "1.13.2"
+sugar_path          = { version = "1.2.0", features = ["cached_current_dir"] }
+testing_macros      = "0.2.13"
+tokio               = { version = "1.38.0", default-features = false }
+tracing             = "0.1.40"
+tracing-chrome      = "0.7.2"
+tracing-subscriber  = { version = "0.3.18", default-features = false }
+typedmap            = "0.5.0"
+urlencoding         = "2.1.3"
+vfs                 = "0.12.0"
+xxhash-rust         = "0.8.10"
 
 # oxc crates share the same version
 oxc                = { version = "0.23.1", features = ["sourcemap_concurrent", "transformer", "minifier", "semantic", "codegen"] }

--- a/crates/rolldown_testing/Cargo.toml
+++ b/crates/rolldown_testing/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 anyhow                  = { workspace = true }
 dunce                   = { workspace = true }
 insta                   = { workspace = true }
+json-strip-comments     = { workspace = true }
 jsonschema              = { workspace = true }
 regex                   = { workspace = true }
 rolldown                = { workspace = true }

--- a/crates/rolldown_testing/src/test_config.rs
+++ b/crates/rolldown_testing/src/test_config.rs
@@ -24,8 +24,11 @@ static COMPILED_SCHEMA: LazyLock<JSONSchema> = LazyLock::new(|| {
 });
 
 pub fn read_test_config(config_path: &std::path::Path) -> TestConfig {
-  let config_str = fs::read_to_string(config_path)
+  let mut config_str = fs::read_to_string(config_path)
     .unwrap_or_else(|e| panic!("Failed to read config file in {config_path:?}. Got {e:?}"));
+
+  json_strip_comments::strip(&mut config_str)
+    .unwrap_or_else(|e| panic!("Failed to strip comments of {config_path:?}. Got {e:?}"));
 
   let config_json: serde_json::Value =
     serde_json::from_str(&config_str).expect("Failed to parse test config file");

--- a/docs/contrib-guide/testing.md
+++ b/docs/contrib-guide/testing.md
@@ -31,7 +31,7 @@ For all available options, you could refer to
 
 - `main.js` is the default entry of the test case, if `config.input` is not specified in `_config.json`.
 - Rolldown will bundle the input into `/dist`, and execute every entry file in `/dist` orderly. You might thinking it as running `node --import ./dist/entry1.mjs --import ./dist/entry2.mjs --import ./dist/entry3.mjs --eval ""`.
-  - If there is a `_test.mjs`/`_test.cjs` in the test case folder, only `_test.mjs`/`_test.cjs` will be executed. If you want to execute compiled entries, you need to import them manully in `_test.mjs`/`_test.cjs`.
+  - If there is a `_test.mjs`/`_test.cjs` in the test case folder, only `_test.mjs`/`_test.cjs` will be executed. If you want to execute compiled entries, you need to import them manually in `_test.mjs`/`_test.cjs`.
 
 ### Function-complete tests in rust
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I'm not sure how if other IDE behave well on treating `.json` as `.jsonc`. I'm opened to change all `_config.json` to `_config.jsonc` if it's considered as more proper.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
