### PR TITLE
chore: remove extra external `node:assert` in test configs.

### DIFF
--- a/crates/rolldown/tests/rolldown/function/module_types/json/array/_config.json
+++ b/crates/rolldown/tests/rolldown/function/module_types/json/array/_config.json
@@ -1,5 +1,1 @@
-{
-  "config": {
-    "external": ["node:assert"]
-  }
-}
+{}

--- a/crates/rolldown/tests/rolldown/function/module_types/json/correct_semantic_of_import_and_require/_config.json
+++ b/crates/rolldown/tests/rolldown/function/module_types/json/correct_semantic_of_import_and_require/_config.json
@@ -1,5 +1,1 @@
-{
-  "config": {
-    "external": ["node:assert"]
-  }
-}
+{}

--- a/crates/rolldown/tests/rolldown/function/module_types/json/customize/_config.json
+++ b/crates/rolldown/tests/rolldown/function/module_types/json/customize/_config.json
@@ -1,6 +1,5 @@
 {
   "config": {
-    "external": ["node:assert"],
     "moduleTypes": {
       ".json2": "json"
     }

--- a/crates/rolldown/tests/rolldown/function/module_types/json/object/_config.json
+++ b/crates/rolldown/tests/rolldown/function/module_types/json/object/_config.json
@@ -1,5 +1,1 @@
-{
-  "config": {
-    "external": ["node:assert"]
-  }
-}
+{}

--- a/crates/rolldown/tests/rolldown/function/module_types/json/object_with_invalid_key/_config.json
+++ b/crates/rolldown/tests/rolldown/function/module_types/json/object_with_invalid_key/_config.json
@@ -1,5 +1,1 @@
-{
-  "config": {
-    "external": ["node:assert"]
-  }
-}
+{}

--- a/crates/rolldown/tests/rolldown/function/module_types/json/object_with_reserved_key/_config.json
+++ b/crates/rolldown/tests/rolldown/function/module_types/json/object_with_reserved_key/_config.json
@@ -1,5 +1,1 @@
-{
-  "config": {
-    "external": ["node:assert"]
-  }
-}
+{}

--- a/crates/rolldown/tests/rolldown/tree_shaking/json_object/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/json_object/_config.json
@@ -1,5 +1,1 @@
-{
-  "config": {
-    "external": ["node:assert"]
-  }
-}
+{}


### PR DESCRIPTION

              `node:assert` is external by default.

_Originally posted by @IWANABETHATGUY in https://github.com/rolldown/rolldown/pull/1746#discussion_r1693361950_
            