### PR TITLE
feat(node/rolldown): support `define` functionality

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -74,6 +74,7 @@ pub struct BindingInputOptions {
   pub treeshake: Option<treeshake::BindingTreeshake>,
 
   pub module_types: Option<HashMap<String, String>>,
+  pub define: Option<Vec<(/* Target to be replaced */ String, /* Replacement */ String)>>,
 }
 
 pub type BindingOnLog =

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -10,6 +10,7 @@ use rolldown::{
   AddonOutputOption, BundlerOptions, IsExternal, ModuleType, OutputExports, OutputFormat, Platform,
 };
 use rolldown_plugin::__inner::SharedPluginable;
+use rolldown_utils::indexmap::FxIndexMap;
 use std::collections::HashMap;
 use std::path::PathBuf;
 #[cfg(not(target_family = "wasm"))]
@@ -145,7 +146,7 @@ pub fn normalize_binding_options(
     minify: output_options.minify,
     css_entry_filenames: None,
     css_chunk_filenames: None,
-    define: None,
+    define: input_options.define.map(FxIndexMap::from_iter),
   };
 
   #[cfg(not(target_family = "wasm"))]

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -181,6 +181,7 @@ export interface BindingInputOptions {
   cwd: string
   treeshake?: BindingTreeshake
   moduleTypes?: Record<string, string>
+  define?: Array<[string, string]>
 }
 
 export interface BindingJsonSourcemap {

--- a/packages/rolldown/src/options/bindingify-input-options.ts
+++ b/packages/rolldown/src/options/bindingify-input-options.ts
@@ -72,6 +72,7 @@ export function bindingifyInputOptions(
     },
     treeshake: options.treeshake,
     moduleTypes: options.moduleTypes,
+    define: options.define ? Object.entries(options.define) : undefined,
   }
 }
 

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -93,6 +93,7 @@ const inputOptionsSchema = z.strictObject({
       enableComposingJsPlugins: z.boolean().optional(),
     })
     .optional(),
+  define: z.record(z.string()).optional(),
 })
 
 export type InputOption = z.infer<typeof inputOptionSchema>

--- a/packages/rolldown/tests/fixtures/function/define/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/define/_config.ts
@@ -1,0 +1,14 @@
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    define: {
+      'process.env.NODE_ENV': '"production"',
+    },
+  },
+  afterTest: function (output) {
+    expect(output.output[0].code).not.includes('process.env.NODE_ENV')
+    expect(output.output[0].code).includes('production')
+  },
+})

--- a/packages/rolldown/tests/fixtures/function/define/main.js
+++ b/packages/rolldown/tests/fixtures/function/define/main.js
@@ -1,0 +1,1 @@
+console.log(process.env.NODE_ENV)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #186.

So far the target expr could only be identifier or member expression, but the replacement could be any expr. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
