### PR TITLE
chore(rust): remove extra spaces in CJS.

### DIFF
--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -66,11 +66,10 @@ pub fn render_cjs(
     enumerable: true,
     get: function () { return $NAME[k]; }
   });
-});
-            ".replace("$NAME", binding_ref_name);
-            concat_source.add_source(Box::new(RawSource::new(format!("var {} = require(\"{}\");", binding_ref_name,&importee.stable_id()))));
-                          concat_source.add_source(Box::new(RawSource::new(import_stmt)));
+});".replace("$NAME", binding_ref_name);
 
+          concat_source.add_source(Box::new(RawSource::new(format!("var {} = require(\"{}\");", binding_ref_name,&importee.stable_id()))));
+          concat_source.add_source(Box::new(RawSource::new(import_stmt)));
         });
         Some(export_mode)
       } else {
@@ -78,8 +77,7 @@ pub fn render_cjs(
         None
       }
     } else {
-      // The entry module should always be an ECMAScript module, so it is unreachable.
-      None
+      unreachable!("Entry module should be an ECMAScript module");
     }
   } else {
     // No need for common chunks to determine the export mode.

--- a/crates/rolldown/tests/esbuild/import_star/re_export_star_external_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/import_star/re_export_star_external_common_js/artifacts.snap
@@ -14,7 +14,6 @@ Object.keys(foo).forEach(function (k) {
     get: function () { return foo[k]; }
   });
 });
-            
 
 require("foo");
 

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_shared_entries_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_shared_entries_cjs/artifacts.snap
@@ -14,7 +14,6 @@ Object.keys(node_fs).forEach(function (k) {
     get: function () { return node_fs[k]; }
   });
 });
-            
 const require_main = require('./main.cjs');
 
 ```
@@ -29,7 +28,6 @@ Object.keys(node_fs).forEach(function (k) {
     get: function () { return node_fs[k]; }
   });
 });
-            
 const require_main = require('./main.cjs');
 
 ```

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
@@ -22,7 +22,6 @@ Object.keys(node_fs).forEach(function (k) {
     get: function () { return node_fs[k]; }
   });
 });
-            
 
 require("node:fs");
 

--- a/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/export_star_from_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/export_star_from_external/artifacts.snap
@@ -14,7 +14,6 @@ Object.keys(node_path).forEach(function (k) {
     get: function () { return node_path[k]; }
   });
 });
-            
 var node_fs = require("node:fs");
 Object.keys(node_fs).forEach(function (k) {
   if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
@@ -22,7 +21,6 @@ Object.keys(node_fs).forEach(function (k) {
     get: function () { return node_fs[k]; }
   });
 });
-            
 
 require("node:fs");
 require("node:path");

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -762,7 +762,7 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/import_star/re_export_star_external_common_js
 
-- entry_js-!~{000}~.cjs => entry_js-thBqv2Ua.cjs
+- entry_js-!~{000}~.cjs => entry_js-ratFTsiz.cjs
 
 # tests/esbuild/import_star/re_export_star_external_es6
 
@@ -1881,8 +1881,8 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/rolldown/semantic/export_star_from_external_as_shared_entries_cjs
 
-- entry-!~{000}~.cjs => entry-sKmPv7dJ.cjs
-- entry2-!~{001}~.cjs => entry2-BExs248V.cjs
+- entry-!~{000}~.cjs => entry-PFtRvfoG.cjs
+- entry2-!~{001}~.cjs => entry2-0jBTaTYb.cjs
 - main-!~{002}~.cjs => main-XDF8DtJv.cjs
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry
@@ -1891,11 +1891,11 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs
 
-- entry-!~{000}~.cjs => entry-JDQ_cJTu.cjs
+- entry-!~{000}~.cjs => entry-jVNreXaR.cjs
 
 # tests/rolldown/topics/cjs_module_lexer_compat/export_star_from_external
 
-- main-!~{000}~.cjs => main-CghQHSuN.cjs
+- main-!~{000}~.cjs => main-_wRUc9QU.cjs
 
 # tests/rolldown/topics/cjs_module_lexer_compat/exports
 


### PR DESCRIPTION
There are some extra blanks after the field:

```js
"Object.keys($NAME).forEach(function (k) {
  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
    enumerable: true,
    get: function () { return $NAME[k]; }
  });
});
```
For example:
![QQ_1723044960308](https://github.com/user-attachments/assets/7af57401-1773-43df-afee-e48197c6d93d)

