### PR TITLE
fix: remove name assignment in IIFE that doesn't have export.

### DIFF
--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -53,12 +53,17 @@ pub fn render_iife(
 
   concat_source.add_source(Box::new(RawSource::new(format!(
     "{}(function({}) {{\n",
-    if let Some(name) = &ctx.options.name {
-      format!("var {name} = ")
+    // Only IIFEs with exports requires the assignment.
+    if has_exports {
+      if let Some(name) = &ctx.options.name {
+        format!("var {name} = ")
+      } else {
+        ctx
+          .warnings
+          .push(BuildDiagnostic::missing_name_option_for_iife_export().with_severity_warning());
+        String::new()
+      }
     } else {
-      ctx
-        .warnings
-        .push(BuildDiagnostic::missing_name_option_for_iife_export().with_severity_warning());
       String::new()
     },
     input_args

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_no_bundle_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_no_bundle_iife/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry_js.mjs
 
 ```js
-var module = (function() {
+(function() {
 
 
 //#region entry.js

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/auto/none/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/auto/none/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.mjs
 
 ```js
-var module = (function() {
+(function() {
 
 
 //#region main.js

--- a/crates/rolldown/tests/rolldown/function/format/iife/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/basic/artifacts.snap
@@ -1,14 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# warnings
-
-## MISSING_NAME_OPTION_FOR_IIFE_EXPORT
-
-```text
-[MISSING_NAME_OPTION_FOR_IIFE_EXPORT] Warning: If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.
-
-```
 # Assets
 
 ## main.mjs

--- a/crates/rolldown/tests/rolldown/function/format/iife/external_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/external_modules/artifacts.snap
@@ -14,7 +14,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.mjs
 
 ```js
-var module = (function(node_path) {
+(function(node_path) {
 
 "use strict";
 const { default: nodePath } = node_path;

--- a/crates/rolldown/tests/rolldown/function/format/iife/external_modules_with_globals/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/external_modules_with_globals/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.mjs
 
 ```js
-var module = (function(node_path) {
+(function(node_path) {
 
 "use strict";
 const { default: nodePath } = node_path;

--- a/crates/rolldown/tests/rolldown/warnings/missing_global_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/missing_global_name/artifacts.snap
@@ -14,7 +14,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.mjs
 
 ```js
-var bundle = (function(node_path) {
+(function(node_path) {
 
 "use strict";
 const { join } = node_path;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -335,7 +335,7 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/esbuild/dce/tree_shaking_no_bundle_iife
 
-- entry_js-!~{000}~.mjs => entry_js-RCe4bw0b.mjs
+- entry_js-!~{000}~.mjs => entry_js-k-4tRlGF.mjs
 
 # tests/esbuild/dce/tree_shaking_object_property
 
@@ -1531,7 +1531,7 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/rolldown/function/export_mode/iife/auto/none
 
-- main-!~{000}~.mjs => main-A37QOJSD.mjs
+- main-!~{000}~.mjs => main-0fNgrTo8.mjs
 
 # tests/rolldown/function/export_mode/iife/default
 
@@ -1609,11 +1609,11 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/rolldown/function/format/iife/external_modules
 
-- main-!~{000}~.mjs => main--fT_EYD7.mjs
+- main-!~{000}~.mjs => main-Ss0NlRCd.mjs
 
 # tests/rolldown/function/format/iife/external_modules_with_globals
 
-- main-!~{000}~.mjs => main-HGvX_g3V.mjs
+- main-!~{000}~.mjs => main-MwWasrct.mjs
 
 # tests/rolldown/function/format/iife/iife_with_name
 
@@ -2110,7 +2110,7 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/rolldown/warnings/missing_global_name
 
-- main-!~{000}~.mjs => main-Nrqe9YQk.mjs
+- main-!~{000}~.mjs => main-o85_mt9N.mjs
 
 # tests/rolldown/warnings/missing_name_option_for_iife_export
 

--- a/packages/rolldown/tests/fixtures/output/format/iife/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/format/iife/basic/_config.ts
@@ -10,7 +10,7 @@ export default defineTest({
   },
   afterTest: (output) => {
     expect(output.output[0].code).toMatchInlineSnapshot(`
-      "var myModule = (function() {
+      "(function() {
 
 
       })();"


### PR DESCRIPTION
In Rollup, there is no assignment when the IIFE does not contain any exports. [REPL here](https://rollupjs.org/repl/?version=4.20.0&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQSUyMjAwJTIyJTJDJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMmNvZGUlMjIlM0ElMjIlMkYlMkYlMjBUUkVFLVNIQUtJTkclNUNuaW1wb3J0JTIwJTdCJTIwY3ViZSUyMCU3RCUyMGZyb20lMjAnLiUyRm1hdGhzLmpzJyUzQiU1Q24lNUNuY29uc29sZS5sb2coY3ViZSg1KSklM0IlMjAlMkYlMkYlMjAxMjUlMjIlMkMlMjJpc0VudHJ5JTIyJTNBdHJ1ZSUyQyUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTdEJTJDJTdCJTIyY29kZSUyMiUzQSUyMiUyRiUyRiUyMG1hdGhzLmpzJTVDbiU1Q24lMkYlMkYlMjBUaGlzJTIwZnVuY3Rpb24lMjBpc24ndCUyMHVzZWQlMjBhbnl3aGVyZSUyQyUyMHNvJTVDbiUyRiUyRiUyMFJvbGx1cCUyMGV4Y2x1ZGVzJTIwaXQlMjBmcm9tJTIwdGhlJTIwYnVuZGxlLi4uJTVDbmV4cG9ydCUyMGNvbnN0JTIwc3F1YXJlJTIwJTNEJTIweCUyMCUzRCUzRSUyMHglMjAqJTIweCUzQiU1Q24lNUNuJTJGJTJGJTIwVGhpcyUyMGZ1bmN0aW9uJTIwZ2V0cyUyMGluY2x1ZGVkJTVDbiUyRiUyRiUyMHJld3JpdGUlMjB0aGlzJTIwYXMlMjAlNjBzcXVhcmUoeCklMjAqJTIweCU2MCU1Q24lMkYlMkYlMjBhbmQlMjBzZWUlMjB3aGF0JTIwaGFwcGVucyElNUNuZXhwb3J0JTIwY29uc3QlMjBjdWJlJTIwJTNEJTIweCUyMCUzRCUzRSUyMHglMjAqJTIweCUyMColMjB4JTNCJTVDbiU1Q24lMkYlMkYlMjBUaGlzJTIwJTVDJTIyc2lkZSUyMGVmZmVjdCU1QyUyMiUyMGNyZWF0ZXMlMjBhJTIwZ2xvYmFsJTVDbiUyRiUyRiUyMHZhcmlhYmxlJTIwYW5kJTIwd2lsbCUyMG5vdCUyMGJlJTIwcmVtb3ZlZC4lNUNud2luZG93LmVmZmVjdDElMjAlM0QlMjAnY3JlYXRlZCclM0IlNUNuJTVDbmNvbnN0JTIwaW5jbHVkZUVmZmVjdCUyMCUzRCUyMGZhbHNlJTNCJTVDbmlmJTIwKGluY2x1ZGVFZmZlY3QpJTIwJTdCJTVDbiU1Q3QlMkYlMkYlMjBPbiUyMHRoZSUyMG90aGVyJTIwaGFuZCUyQyUyMHRoaXMlMjBpcyUyMG5ldmVyJTVDbiU1Q3QlMkYlMkYlMjBleGVjdXRlZCUyMGFuZCUyMHRodXMlMjByZW1vdmVkLiU1Q24lNUN0d2luZG93LmVmZmVjdDElMjAlM0QlMjAnbm90JTIwY3JlYXRlZCclM0IlNUNuJTdEJTIyJTJDJTIyaXNFbnRyeSUyMiUzQWZhbHNlJTJDJTIybmFtZSUyMiUzQSUyMm1hdGhzLmpzJTIyJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMm91dHB1dCUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmlpZmUlMjIlMkMlMjJuYW1lJTIyJTNBJTIybXlCdW5kbGUlMjIlN0QlMkMlMjJ0cmVlc2hha2UlMjIlM0F0cnVlJTdEJTdE).