### PR TITLE
refactor: avoid unsafe code at BindingOutputs

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -63,7 +63,7 @@ impl Bundler {
         .map_err(|err| anyhow::anyhow!("Failed to write file in {:?}", dest).context(err))?;
     }
 
-    self.plugin_driver.write_bundle(&mut output.assets).await?;
+    output.assets = self.plugin_driver.write_bundle(output.assets).await?;
 
     Ok(output)
   }
@@ -160,7 +160,7 @@ impl Bundler {
     // Add additional files from build plugins.
     self.file_emitter.add_additional_files(&mut output.assets);
 
-    self.plugin_driver.generate_bundle(&mut output.assets, is_write).await?;
+    output.assets = self.plugin_driver.generate_bundle(output.assets, is_write).await?;
 
     Ok(output)
   }

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 #[cfg(not(target_family = "wasm"))]
 use crate::worker_manager::WorkerManager;
@@ -6,8 +6,7 @@ use crate::{
   options::{BindingInputOptions, BindingOnLog, BindingOutputOptions},
   parallel_js_plugin_registry::ParallelJsPluginRegistry,
   types::{
-    binding_log::BindingLog, binding_log_level::BindingLogLevel,
-    binding_outputs::FinalBindingOutputs,
+    binding_log::BindingLog, binding_log_level::BindingLogLevel, binding_outputs::BindingOutputs,
   },
   utils::{normalize_binding_options::normalize_binding_options, try_init_custom_trace_subscriber},
 };
@@ -73,13 +72,13 @@ impl Bundler {
 
   #[napi]
   #[tracing::instrument(level = "debug", skip_all)]
-  pub async fn write(&self) -> napi::Result<FinalBindingOutputs> {
+  pub async fn write(&self) -> napi::Result<BindingOutputs> {
     self.write_impl().await
   }
 
   #[napi]
   #[tracing::instrument(level = "debug", skip_all)]
-  pub async fn generate(&self) -> napi::Result<FinalBindingOutputs> {
+  pub async fn generate(&self) -> napi::Result<BindingOutputs> {
     self.generate_impl().await
   }
 
@@ -112,7 +111,7 @@ impl Bundler {
   }
 
   #[allow(clippy::significant_drop_tightening)]
-  pub async fn write_impl(&self) -> napi::Result<FinalBindingOutputs> {
+  pub async fn write_impl(&self) -> napi::Result<BindingOutputs> {
     let mut bundler_core = self.inner.try_lock().map_err(|_| {
       napi::Error::from_reason("Failed to lock the bundler. Is another operation in progress?")
     })?;
@@ -125,11 +124,13 @@ impl Bundler {
 
     self.handle_warnings(outputs.warnings).await;
 
-    Ok(FinalBindingOutputs::new(outputs.assets))
+    Ok(BindingOutputs::new(Arc::new(std::sync::Mutex::new(std::cell::RefCell::new(
+      outputs.assets,
+    )))))
   }
 
   #[allow(clippy::significant_drop_tightening)]
-  pub async fn generate_impl(&self) -> napi::Result<FinalBindingOutputs> {
+  pub async fn generate_impl(&self) -> napi::Result<BindingOutputs> {
     let mut bundler_core = self.inner.try_lock().map_err(|_| {
       napi::Error::from_reason("Failed to lock the bundler. Is another operation in progress?")
     })?;
@@ -142,7 +143,9 @@ impl Bundler {
 
     self.handle_warnings(outputs.warnings).await;
 
-    Ok(FinalBindingOutputs::new(outputs.assets))
+    Ok(BindingOutputs::new(Arc::new(std::sync::Mutex::new(std::cell::RefCell::new(
+      outputs.assets,
+    )))))
   }
 
   fn handle_result<T>(result: anyhow::Result<T>) -> napi::Result<T> {

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -305,7 +305,7 @@ impl Plugin for JsPlugin {
       bundle = Arc::into_inner(output)
         .expect("bundle should have one reference")
         .into_inner()
-        .expect("bundle should get inner from lock")
+        .expect("bundle should get inner")
         .into_inner();
     }
     Ok(bundle)
@@ -322,7 +322,7 @@ impl Plugin for JsPlugin {
       bundle = Arc::into_inner(output)
         .expect("bundle should have one reference")
         .into_inner()
-        .expect("bundle should get inner from lock")
+        .expect("bundle should get inner")
         .into_inner();
     }
     Ok(bundle)

--- a/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
@@ -147,25 +147,23 @@ impl Plugin for ParallelJsPlugin {
   async fn generate_bundle(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    bundle: &mut Vec<rolldown_common::Output>,
+    mut bundle: Vec<rolldown_common::Output>,
     is_write: bool,
-  ) -> rolldown_plugin::HookNoopReturn {
+  ) -> rolldown_plugin::HookGenerateBundleReturn {
     if self.first_plugin().generate_bundle.is_some() {
-      self.run_single(|plugin| plugin.call_generate_bundle(ctx, bundle, is_write)).await
-    } else {
-      Ok(())
+      bundle = self.run_single(|plugin| plugin.call_generate_bundle(ctx, bundle, is_write)).await?;
     }
+    Ok(bundle)
   }
 
   async fn write_bundle(
     &self,
     ctx: &rolldown_plugin::SharedPluginContext,
-    bundle: &mut Vec<rolldown_common::Output>,
-  ) -> rolldown_plugin::HookNoopReturn {
+    mut bundle: Vec<rolldown_common::Output>,
+  ) -> rolldown_plugin::HookWriteBundleReturn {
     if self.first_plugin().write_bundle.is_some() {
-      self.run_single(|plugin| plugin.call_write_bundle(ctx, bundle)).await
-    } else {
-      Ok(())
+      bundle = self.run_single(|plugin| plugin.call_write_bundle(ctx, bundle)).await?;
     }
+    Ok(bundle)
   }
 }

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -23,12 +23,18 @@ impl BindingOutputs {
   pub fn chunks(&mut self) -> Vec<BindingOutputChunk> {
     let mut chunks: Vec<BindingOutputChunk> = vec![];
 
-    self.inner.lock().expect("should have lock").borrow_mut().iter_mut().for_each(|o| match o {
-      rolldown_common::Output::Chunk(chunk) => {
-        chunks.push(BindingOutputChunk::new(unsafe { std::mem::transmute(chunk.as_mut()) }));
-      }
-      rolldown_common::Output::Asset(_) => {}
-    });
+    self
+      .inner
+      .lock()
+      .expect("should hasn't lock at BindingOutputs")
+      .borrow_mut()
+      .iter_mut()
+      .for_each(|o| match o {
+        rolldown_common::Output::Chunk(chunk) => {
+          chunks.push(BindingOutputChunk::new(unsafe { std::mem::transmute(chunk.as_mut()) }));
+        }
+        rolldown_common::Output::Asset(_) => {}
+      });
 
     chunks
   }
@@ -37,18 +43,24 @@ impl BindingOutputs {
   pub fn assets(&mut self) -> Vec<BindingOutputAsset> {
     let mut assets: Vec<BindingOutputAsset> = vec![];
 
-    self.inner.lock().expect("should have lock").borrow_mut().iter_mut().for_each(|o| match o {
-      rolldown_common::Output::Asset(asset) => {
-        assets.push(BindingOutputAsset::new(unsafe { std::mem::transmute(asset.as_mut()) }));
-      }
-      rolldown_common::Output::Chunk(_) => {}
-    });
+    self
+      .inner
+      .lock()
+      .expect("should hasn't lock at BindingOutputs")
+      .borrow_mut()
+      .iter_mut()
+      .for_each(|o| match o {
+        rolldown_common::Output::Asset(asset) => {
+          assets.push(BindingOutputAsset::new(unsafe { std::mem::transmute(asset.as_mut()) }));
+        }
+        rolldown_common::Output::Chunk(_) => {}
+      });
     assets
   }
 
   #[napi]
   pub fn delete(&mut self, file_name: String) {
-    let inner = self.inner.lock().expect("should have lock");
+    let inner = self.inner.lock().expect("should hasn't lock at BindingOutputs");
     let index = { inner.borrow().iter().position(|o| o.filename() == file_name) };
     if let Some(index) = index {
       inner.borrow_mut().remove(index);

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -1,16 +1,21 @@
+use std::{
+  cell::RefCell,
+  sync::{Arc, Mutex},
+  vec,
+};
+
 use napi_derive::napi;
 
 use super::{binding_output_asset::BindingOutputAsset, binding_output_chunk::BindingOutputChunk};
 
-/// The `BindingOutputs` owner `Vec<Output>` the mutable reference, it avoid `Clone` at call `writeBundle/generateBundle` hook, and make it mutable.
 #[napi]
 pub struct BindingOutputs {
-  inner: &'static mut Vec<rolldown_common::Output>,
+  inner: Arc<Mutex<RefCell<Vec<rolldown_common::Output>>>>,
 }
 
 #[napi]
 impl BindingOutputs {
-  pub fn new(inner: &'static mut Vec<rolldown_common::Output>) -> Self {
+  pub fn new(inner: Arc<Mutex<RefCell<Vec<rolldown_common::Output>>>>) -> Self {
     Self { inner }
   }
 
@@ -18,7 +23,7 @@ impl BindingOutputs {
   pub fn chunks(&mut self) -> Vec<BindingOutputChunk> {
     let mut chunks: Vec<BindingOutputChunk> = vec![];
 
-    self.inner.iter_mut().for_each(|o| match o {
+    self.inner.lock().expect("should have lock").borrow_mut().iter_mut().for_each(|o| match o {
       rolldown_common::Output::Chunk(chunk) => {
         chunks.push(BindingOutputChunk::new(unsafe { std::mem::transmute(chunk.as_mut()) }));
       }
@@ -32,7 +37,7 @@ impl BindingOutputs {
   pub fn assets(&mut self) -> Vec<BindingOutputAsset> {
     let mut assets: Vec<BindingOutputAsset> = vec![];
 
-    self.inner.iter_mut().for_each(|o| match o {
+    self.inner.lock().expect("should have lock").borrow_mut().iter_mut().for_each(|o| match o {
       rolldown_common::Output::Asset(asset) => {
         assets.push(BindingOutputAsset::new(unsafe { std::mem::transmute(asset.as_mut()) }));
       }
@@ -43,49 +48,18 @@ impl BindingOutputs {
 
   #[napi]
   pub fn delete(&mut self, file_name: String) {
-    if let Some(index) = self.inner.iter().position(|o| o.filename() == file_name) {
-      self.inner.remove(index);
+    let inner = self.inner.lock().expect("should have lock");
+    let index = { inner.borrow().iter().position(|o| o.filename() == file_name) };
+    if let Some(index) = index {
+      inner.borrow_mut().remove(index);
     }
   }
-}
 
-/// The `FinalBindingOutputs` is used at `write()` or `generate()`, it is similar to `BindingOutputs`, if using `BindingOutputs` has unexpected behavior.
-/// TODO find a way to export it gracefully.
-#[napi]
-pub struct FinalBindingOutputs {
-  inner: Vec<rolldown_common::Output>,
-}
-
-#[napi]
-impl FinalBindingOutputs {
-  pub fn new(inner: Vec<rolldown_common::Output>) -> Self {
-    Self { inner }
-  }
-
-  #[napi(getter)]
-  pub fn chunks(&mut self) -> Vec<BindingOutputChunk> {
-    let mut chunks: Vec<BindingOutputChunk> = vec![];
-
-    self.inner.iter_mut().for_each(|o| match o {
-      rolldown_common::Output::Chunk(chunk) => {
-        chunks.push(BindingOutputChunk::new(unsafe { std::mem::transmute(chunk.as_mut()) }));
-      }
-      rolldown_common::Output::Asset(_) => {}
-    });
-
-    chunks
-  }
-
-  #[napi(getter)]
-  pub fn assets(&mut self) -> Vec<BindingOutputAsset> {
-    let mut assets: Vec<BindingOutputAsset> = vec![];
-
-    self.inner.iter_mut().for_each(|o| match o {
-      rolldown_common::Output::Asset(asset) => {
-        assets.push(BindingOutputAsset::new(unsafe { std::mem::transmute(asset.as_mut()) }));
-      }
-      rolldown_common::Output::Chunk(_) => {}
-    });
-    assets
+  /// TODO
+  /// The napi look like is not drop the strut after the function call, so we need to call it manually.
+  #[allow(clippy::should_implement_trait)]
+  #[napi]
+  pub fn drop(&mut self) {
+    let _ = std::mem::replace(&mut self.inner, Arc::new(Mutex::new(RefCell::new(vec![]))));
   }
 }

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -16,9 +16,9 @@ pub mod __inner {
 
 pub use crate::{
   plugin::{
-    HookAugmentChunkHashReturn, HookInjectionOutputReturn, HookLoadReturn, HookNoopReturn,
-    HookRenderChunkReturn, HookResolveIdReturn, HookTransformAstReturn, HookTransformReturn,
-    Plugin,
+    HookAugmentChunkHashReturn, HookGenerateBundleReturn, HookInjectionOutputReturn,
+    HookLoadReturn, HookNoopReturn, HookRenderChunkReturn, HookResolveIdReturn,
+    HookTransformAstReturn, HookTransformReturn, HookWriteBundleReturn, Plugin,
   },
   plugin_context::{PluginContext, SharedPluginContext},
   plugin_driver::{PluginDriver, SharedPluginDriver},

--- a/crates/rolldown_plugin/src/plugin.rs
+++ b/crates/rolldown_plugin/src/plugin.rs
@@ -22,6 +22,8 @@ pub type HookNoopReturn = Result<()>;
 pub type HookRenderChunkReturn = Result<Option<HookRenderChunkOutput>>;
 pub type HookAugmentChunkHashReturn = Result<Option<String>>;
 pub type HookInjectionOutputReturn = Result<Option<String>>;
+pub type HookGenerateBundleReturn = Result<Vec<Output>>;
+pub type HookWriteBundleReturn = Result<Vec<Output>>;
 
 pub trait Plugin: Any + Debug + Send + Sync + 'static {
   fn name(&self) -> Cow<'static, str>;
@@ -156,18 +158,18 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
   fn generate_bundle(
     &self,
     _ctx: &SharedPluginContext,
-    _bundle: &mut Vec<Output>,
+    bundle: Vec<Output>,
     _is_write: bool,
-  ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
-    async { Ok(()) }
+  ) -> impl std::future::Future<Output = HookGenerateBundleReturn> + Send {
+    async { Ok(bundle) }
   }
 
   fn write_bundle(
     &self,
     _ctx: &SharedPluginContext,
-    _bundle: &mut Vec<Output>,
-  ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
-    async { Ok(()) }
+    bundle: Vec<Output>,
+  ) -> impl std::future::Future<Output = HookWriteBundleReturn> + Send {
+    async { Ok(bundle) }
   }
 
   // --- experimental hooks ---

--- a/crates/rolldown_plugin/src/pluginable.rs
+++ b/crates/rolldown_plugin/src/pluginable.rs
@@ -4,8 +4,9 @@ use super::plugin_context::SharedPluginContext;
 use crate::{
   transform_plugin_context::TransformPluginContext,
   types::{hook_render_error::HookRenderErrorArgs, hook_transform_ast_args::HookTransformAstArgs},
-  HookBuildEndArgs, HookInjectionArgs, HookInjectionOutputReturn, HookLoadArgs,
-  HookRenderChunkArgs, HookResolveIdArgs, HookTransformArgs, Plugin,
+  HookBuildEndArgs, HookGenerateBundleReturn, HookInjectionArgs, HookInjectionOutputReturn,
+  HookLoadArgs, HookRenderChunkArgs, HookResolveIdArgs, HookTransformArgs, HookWriteBundleReturn,
+  Plugin,
 };
 use rolldown_common::{ModuleInfo, Output, RollupRenderedChunk};
 
@@ -125,15 +126,15 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
   async fn call_generate_bundle(
     &self,
     _ctx: &SharedPluginContext,
-    _bundle: &mut Vec<Output>,
+    _bundle: Vec<Output>,
     _is_write: bool,
-  ) -> HookNoopReturn;
+  ) -> HookGenerateBundleReturn;
 
   async fn call_write_bundle(
     &self,
     _ctx: &SharedPluginContext,
-    _bundle: &mut Vec<Output>,
-  ) -> HookNoopReturn;
+    _bundle: Vec<Output>,
+  ) -> HookWriteBundleReturn;
 }
 
 #[async_trait::async_trait]
@@ -254,17 +255,17 @@ impl<T: Plugin> Pluginable for T {
   async fn call_generate_bundle(
     &self,
     ctx: &SharedPluginContext,
-    bundle: &mut Vec<Output>,
+    bundle: Vec<Output>,
     is_write: bool,
-  ) -> HookNoopReturn {
+  ) -> HookGenerateBundleReturn {
     Plugin::generate_bundle(self, ctx, bundle, is_write).await
   }
 
   async fn call_write_bundle(
     &self,
     ctx: &SharedPluginContext,
-    bundle: &mut Vec<Output>,
-  ) -> HookNoopReturn {
+    bundle: Vec<Output>,
+  ) -> HookWriteBundleReturn {
     Plugin::write_bundle(self, ctx, bundle).await
   }
 

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -43,11 +43,15 @@ export declare class BindingOutputChunk {
   get name(): string
 }
 
-/** The `BindingOutputs` owner `Vec<Output>` the mutable reference, it avoid `Clone` at call `writeBundle/generateBundle` hook, and make it mutable. */
 export declare class BindingOutputs {
   get chunks(): Array<BindingOutputChunk>
   get assets(): Array<BindingOutputAsset>
   delete(fileName: string): void
+  /**
+   * TODO
+   * The napi look like is not drop the strut after the function call, so we need to call it manually.
+   */
+  drop(): void
 }
 
 export declare class BindingPluginContext {
@@ -64,18 +68,9 @@ export declare class BindingTransformPluginContext {
 
 export declare class Bundler {
   constructor(inputOptions: BindingInputOptions, outputOptions: BindingOutputOptions, parallelPluginsRegistry?: ParallelJsPluginRegistry | undefined | null)
-  write(): Promise<FinalBindingOutputs>
-  generate(): Promise<FinalBindingOutputs>
+  write(): Promise<BindingOutputs>
+  generate(): Promise<BindingOutputs>
   scan(): Promise<void>
-}
-
-/**
- * The `FinalBindingOutputs` is used at `write()` or `generate()`, it is similar to `BindingOutputs`, if using `BindingOutputs` has unexpected behavior.
- * TODO find a way to export it gracefully.
- */
-export declare class FinalBindingOutputs {
-  get chunks(): Array<BindingOutputChunk>
-  get assets(): Array<BindingOutputAsset>
 }
 
 export declare class ParallelJsPluginRegistry {

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -369,7 +369,6 @@ module.exports.BindingOutputs = nativeBinding.BindingOutputs
 module.exports.BindingPluginContext = nativeBinding.BindingPluginContext
 module.exports.BindingTransformPluginContext = nativeBinding.BindingTransformPluginContext
 module.exports.Bundler = nativeBinding.Bundler
-module.exports.FinalBindingOutputs = nativeBinding.FinalBindingOutputs
 module.exports.ParallelJsPluginRegistry = nativeBinding.ParallelJsPluginRegistry
 module.exports.BindingBuiltinPluginName = nativeBinding.BindingBuiltinPluginName
 module.exports.BindingHookSideEffects = nativeBinding.BindingHookSideEffects

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -119,12 +119,14 @@ export function bindingifyGenerateBundle(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, bundle, isWrite) => {
-    handler.call(
+    const result = await handler.call(
       new PluginContext(options, ctx, plugin, pluginContextData),
       outputOptions,
       transformToOutputBundle(bundle),
       isWrite,
     )
+    bundle.drop()
+    return result
   }
 }
 export function bindingifyWriteBundle(
@@ -140,11 +142,13 @@ export function bindingifyWriteBundle(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, bundle) => {
-    handler.call(
+    const result = handler.call(
       new PluginContext(options, ctx, plugin, pluginContextData),
       outputOptions,
       transformToOutputBundle(bundle),
     )
+    bundle.drop()
+    return result
   }
 }
 

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -108,14 +108,12 @@ function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__BindingOutputChunk_struct_53']?.()
   __napiInstance.exports['__napi_register__BindingOutputChunk_impl_71']?.()
   __napiInstance.exports['__napi_register__BindingOutputs_struct_72']?.()
-  __napiInstance.exports['__napi_register__BindingOutputs_impl_76']?.()
-  __napiInstance.exports['__napi_register__FinalBindingOutputs_struct_77']?.()
-  __napiInstance.exports['__napi_register__FinalBindingOutputs_impl_80']?.()
-  __napiInstance.exports['__napi_register__RenderedChunk_struct_81']?.()
-  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_82']?.()
-  __napiInstance.exports['__napi_register__AliasItem_struct_83']?.()
-  __napiInstance.exports['__napi_register__BindingSourcemap_struct_84']?.()
-  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_85']?.()
+  __napiInstance.exports['__napi_register__BindingOutputs_impl_77']?.()
+  __napiInstance.exports['__napi_register__RenderedChunk_struct_78']?.()
+  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_79']?.()
+  __napiInstance.exports['__napi_register__AliasItem_struct_80']?.()
+  __napiInstance.exports['__napi_register__BindingSourcemap_struct_81']?.()
+  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_82']?.()
 }
 export const BindingLog = __napiModule.exports.BindingLog
 export const BindingModuleInfo = __napiModule.exports.BindingModuleInfo
@@ -125,7 +123,6 @@ export const BindingOutputs = __napiModule.exports.BindingOutputs
 export const BindingPluginContext = __napiModule.exports.BindingPluginContext
 export const BindingTransformPluginContext = __napiModule.exports.BindingTransformPluginContext
 export const Bundler = __napiModule.exports.Bundler
-export const FinalBindingOutputs = __napiModule.exports.FinalBindingOutputs
 export const ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
 export const BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName
 export const BindingHookSideEffects = __napiModule.exports.BindingHookSideEffects

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -132,14 +132,12 @@ function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__BindingOutputChunk_struct_53']?.()
   __napiInstance.exports['__napi_register__BindingOutputChunk_impl_71']?.()
   __napiInstance.exports['__napi_register__BindingOutputs_struct_72']?.()
-  __napiInstance.exports['__napi_register__BindingOutputs_impl_76']?.()
-  __napiInstance.exports['__napi_register__FinalBindingOutputs_struct_77']?.()
-  __napiInstance.exports['__napi_register__FinalBindingOutputs_impl_80']?.()
-  __napiInstance.exports['__napi_register__RenderedChunk_struct_81']?.()
-  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_82']?.()
-  __napiInstance.exports['__napi_register__AliasItem_struct_83']?.()
-  __napiInstance.exports['__napi_register__BindingSourcemap_struct_84']?.()
-  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_85']?.()
+  __napiInstance.exports['__napi_register__BindingOutputs_impl_77']?.()
+  __napiInstance.exports['__napi_register__RenderedChunk_struct_78']?.()
+  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_79']?.()
+  __napiInstance.exports['__napi_register__AliasItem_struct_80']?.()
+  __napiInstance.exports['__napi_register__BindingSourcemap_struct_81']?.()
+  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_82']?.()
 }
 module.exports.BindingLog = __napiModule.exports.BindingLog
 module.exports.BindingModuleInfo = __napiModule.exports.BindingModuleInfo
@@ -149,7 +147,6 @@ module.exports.BindingOutputs = __napiModule.exports.BindingOutputs
 module.exports.BindingPluginContext = __napiModule.exports.BindingPluginContext
 module.exports.BindingTransformPluginContext = __napiModule.exports.BindingTransformPluginContext
 module.exports.Bundler = __napiModule.exports.Bundler
-module.exports.FinalBindingOutputs = __napiModule.exports.FinalBindingOutputs
 module.exports.ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
 module.exports.BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName
 module.exports.BindingHookSideEffects = __napiModule.exports.BindingHookSideEffects

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -9,7 +9,6 @@ import type {
   BindingOutputAsset,
   BindingOutputChunk,
   BindingOutputs,
-  FinalBindingOutputs,
 } from '../binding'
 import {
   AssetSource,
@@ -79,7 +78,7 @@ function transformToRollupOutputAsset(
 }
 
 export function transformToRollupOutput(
-  output: BindingOutputs | FinalBindingOutputs,
+  output: BindingOutputs,
 ): RolldownOutput {
   const { chunks, assets } = output
   return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `BindingOutputs` previous using `std::mem:: transmute` to owner `Vec<Output>` mutate reference, but meet segment fault at `delete bundle[key]`.

The pr intend to avoid using unsafe code to do it, here using `Arc<Mutex<RefCell<Vec<Output>>>>` instead of it, it means we need to owner `Vec<Output>` and return `Vec<Output>`  at `generateBundle` and `writeBundle` hook. 
Here not change the `generateBundle#bundle` to  `Arc<Mutex<RefCell<Vec<Output>>>>`, because it will make the rust side API is difficult to mutate. I only create it and take it to  `Vec<Output>` at binding side. 

Here meet one problem is the napi does not drop the struct to free the reference number of`Arc<Mutex<RefCell<Vec<Output>>>>`, so here i manually to drop it.

The pervious `FinalBindingOutputs` also could be using it at now, so i updated it.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
