### PR TITLE
chore(docs): fix the command instruction

### DIFF
--- a/docs/contrib-guide/docs.md
+++ b/docs/contrib-guide/docs.md
@@ -4,15 +4,17 @@ Rolldown is documented using [VitePress](https://vitepress.dev). You can find th
 
 To contribute to the documentation, you can start the docs dev server running on the project root:
 
+```sh
+pnpm run docs
 ```
-pnpm docs
-```
+
+Since the `pnpm docs` command is used for opening the module introduction in `npm`, you may use the command above.
 
 You can then edit the markdown files and see your changes instantly. The docs structure is configured at `docs/.vitepress/config.ts` (see the [Site Config Reference](https://vitepress.dev/reference/site-config)).
 
 If you'd like to review the built site, run in the project root:
 
-```
+```sh
 pnpm docs:build
 pnpm docs:preview
 ```


### PR DESCRIPTION
The `pnpm docs` command is used to open the official documentation website from `npm`. Therefore, we need to modify the command to `run docs`.

Additionally, shall we modify the `package.json`’s `name` field to `rolldown`? When running `pnpm docs` in the root directory, it will open `https://www.npmjs.com/package/monorepo`, as the `name` field is currently `rolldown`.
