### PR TITLE
fix: pass `output.globals` to Rust side.

### DIFF
--- a/packages/rolldown/src/options/bindingify-output-options.ts
+++ b/packages/rolldown/src/options/bindingify-output-options.ts
@@ -20,6 +20,7 @@ export function bindingifyOutputOptions(
     intro,
     outro,
     esModule,
+    globals,
   } = outputOptions
   return {
     dir,
@@ -41,6 +42,7 @@ export function bindingifyOutputOptions(
     footer,
     intro,
     outro,
+    globals,
     esModule: bindingifyEsModule(esModule),
     name,
     entryFileNames,

--- a/packages/rolldown/tests/fixtures/output/format/iife/globals/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/format/iife/globals/_config.ts
@@ -6,6 +6,7 @@ export default defineTest({
     external: /node:path/,
     output: {
       format: 'iife',
+      name: 'module',
       globals: {
         'node:path': 'path',
       },
@@ -13,7 +14,7 @@ export default defineTest({
   },
   afterTest: (output) => {
     expect(output.output[0].code).toMatchInlineSnapshot(`
-      "(function(node_path) {
+      "var module = (function(node_path) {
 
       "use strict";
       const { join } = node_path;
@@ -23,7 +24,7 @@ export default defineTest({
 
       //#endregion
       return main_default;
-      })(node_path);"
+      })(path);"
     `)
   },
 })


### PR DESCRIPTION
Since I inadvertently omitted the `globals` parameter in the `packages/rolldown/src/options/bindingify-output-options.ts` file, the `output.globals` variable loses its intended effect on JavaScript configuration.

---

In my opinion, we can create a checklist for supporting options, particularly the output options. Please find below some areas that require modification:

- **`packages/rolldown/src/options/output-options.ts`:** The JavaScript side `defineConfig` type declaration.
- **`packages/rolldown/src/options/normalized-output-options.ts`:** The normalized JavaScript side type declaration.
- **`packages/rolldown/src/utils/normalize-output-options.ts`:** The transformer from the raw options to the normalized options in JavaScript.
- **`packages/rolldown/src/options/bindingify-output-options.ts`:** From normalized options to the bridge options (the communication between Rust and JavaScript sides). Note that the type declaration is generated by NAPI-RS.
- **`crates/rolldown_binding/src/options/binding_output_options/mod.rs`:** The binding declaration. It is not recommended to use union type here, as NAPI-RS may throw errors. **Remember to use `#[napi(ts_type = “…”)]` to declare your type and guarantee its correctness.**
- **`crates/rolldown_binding/src/utils/normalize_binding_options.rs`:** Normalize the option from the binding.
- **`crates/rolldown_common/src/inner_bundler_options/mod.rs`:** The inner bundler option.
- **`crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs`:** The normalized option that is used.

It is possible that we may discover a location (similar to the section in the contributor guide of the documentation) where our contributions can be acknowledged for completeness.