### PR TITLE
fix(node/plugin): ensure order for generateBundle and writeBundle hooks

### DIFF
--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -119,7 +119,7 @@ export function bindingifyGenerateBundle(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, bundle, isWrite) => {
-    handler.call(
+    await handler.call(
       new PluginContext(options, ctx, plugin, pluginContextData),
       outputOptions,
       transformToOutputBundle(bundle),
@@ -140,7 +140,7 @@ export function bindingifyWriteBundle(
   const [handler, _optionsIgnoredSofar] = normalizeHook(hook)
 
   return async (ctx, bundle) => {
-    handler.call(
+    await handler.call(
       new PluginContext(options, ctx, plugin, pluginContextData),
       outputOptions,
       transformToOutputBundle(bundle),

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -16,6 +16,9 @@ function main() {
 
     test.skipIf(testConfig.skip)(testName, async () => {
       try {
+        if (testConfig.beforeTest) {
+          await testConfig.beforeTest()
+        }
         const output = await compileFixture(
           nodePath.join(import.meta.dirname, dirPath),
           testConfig,
@@ -41,6 +44,9 @@ function main() {
         testConfig.config.experimental.enableComposingJsPlugins =
           testConfig.config.experimental.enableComposingJsPlugins ?? true
         try {
+          if (testConfig.beforeTest) {
+            await testConfig.beforeTest()
+          }
           const output = await compileFixture(
             nodePath.join(import.meta.dirname, dirPath),
             testConfig,

--- a/packages/rolldown/tests/src/types.ts
+++ b/packages/rolldown/tests/src/types.ts
@@ -4,5 +4,6 @@ export interface TestConfig {
   skip?: boolean
   skipComposingJsPlugin?: boolean
   config?: RolldownOptions
+  beforeTest?: () => Promise<void> | void
   afterTest?: (output: RolldownOutput) => Promise<void> | void
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
