### PR TITLE
fix: Add namespace for each builtin plugin

### DIFF
--- a/crates/rolldown_plugin_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_dynamic_import_vars/src/lib.rs
@@ -24,7 +24,7 @@ pub struct DynamicImportVarsPlugin {}
 
 impl Plugin for DynamicImportVarsPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("dynamic_import_vars")
+    Cow::Borrowed("builtin:dynamic_import_vars")
   }
 
   async fn resolve_id(

--- a/crates/rolldown_plugin_glob_import/src/lib.rs
+++ b/crates/rolldown_plugin_glob_import/src/lib.rs
@@ -35,7 +35,7 @@ pub struct GlobImportPluginConfig {
 
 impl Plugin for GlobImportPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("glob_import_plugin")
+    Cow::Borrowed("builtin:glob_import_plugin")
   }
 
   fn transform_ast(

--- a/crates/rolldown_plugin_glob_import/src/lib.rs
+++ b/crates/rolldown_plugin_glob_import/src/lib.rs
@@ -35,7 +35,7 @@ pub struct GlobImportPluginConfig {
 
 impl Plugin for GlobImportPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("builtin:glob_import_plugin")
+    Cow::Borrowed("builtin:glob-import-plugin")
   }
 
   fn transform_ast(

--- a/crates/rolldown_plugin_load_fallback/src/lib.rs
+++ b/crates/rolldown_plugin_load_fallback/src/lib.rs
@@ -7,7 +7,7 @@ pub struct LoadFallbackPlugin {}
 
 impl Plugin for LoadFallbackPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("load-fallback")
+    Cow::Borrowed("builtin:load-fallback")
   }
 
   async fn load(&self, _ctx: &SharedPluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {

--- a/crates/rolldown_plugin_manifest/src/lib.rs
+++ b/crates/rolldown_plugin_manifest/src/lib.rs
@@ -27,7 +27,7 @@ pub struct ManifestPluginConfig {
 
 impl Plugin for ManifestPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("manifest_plugin")
+    Cow::Borrowed("builtin:manifest-plugin")
   }
 
   #[allow(clippy::case_sensitive_file_extension_comparisons)]

--- a/crates/rolldown_plugin_module_preload_polyfill/src/lib.rs
+++ b/crates/rolldown_plugin_module_preload_polyfill/src/lib.rs
@@ -21,7 +21,7 @@ pub struct ModulePreloadPolyfillPlugin {
 
 impl Plugin for ModulePreloadPolyfillPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("module_preload_polyfill")
+    Cow::Borrowed("builtin:module-preload-polyfill")
   }
 
   async fn resolve_id(

--- a/crates/rolldown_plugin_transform/src/lib.rs
+++ b/crates/rolldown_plugin_transform/src/lib.rs
@@ -40,7 +40,7 @@ pub struct TransformPlugin {
 /// only handle ecma like syntax, `jsx`,`tsx`,`ts`
 impl Plugin for TransformPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("transform")
+    Cow::Borrowed("builtin:transform")
   }
 
   async fn transform(

--- a/crates/rolldown_plugin_transform/src/lib.rs
+++ b/crates/rolldown_plugin_transform/src/lib.rs
@@ -40,7 +40,7 @@ pub struct TransformPlugin {
 /// only handle ecma like syntax, `jsx`,`tsx`,`ts`
 impl Plugin for TransformPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("module_preload_polyfill")
+    Cow::Borrowed("transform")
   }
 
   async fn transform(

--- a/crates/rolldown_plugin_wasm/src/lib.rs
+++ b/crates/rolldown_plugin_wasm/src/lib.rs
@@ -13,7 +13,7 @@ pub struct WasmPlugin {}
 
 impl Plugin for WasmPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("wasm_plugin")
+    Cow::Borrowed("builtin:wasm-plugin")
   }
 
   async fn resolve_id(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. use kebab case for naming plugin, just follow https://github.com/rolldown/vite/blob/3bf86e3f715c952a032b476b60c8c869e9c50f3f/packages/vite/src/node/plugins/dynamicImportVars.ts#L174-L174
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
