### PR TITLE
test(node/rolldown): enable type-checking on `_config.ts`

### DIFF
--- a/packages/rolldown/src/options/normalized-ecma-transform-plugin-config.ts
+++ b/packages/rolldown/src/options/normalized-ecma-transform-plugin-config.ts
@@ -3,7 +3,10 @@ import { BindingTransformPluginConfig } from '../binding'
 
 type TransformPattern = string | RegExp | RegExp[] | string[]
 // A temp config type for giving better user experience
-export type TransformPluginConfig = BindingTransformPluginConfig & {
+export type TransformPluginConfig = Omit<
+  BindingTransformPluginConfig,
+  'include' | 'exclude'
+> & {
   include?: TransformPattern
   exclude?: TransformPattern
 }

--- a/packages/rolldown/tests/fixtures/output/outro/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/outro/string/_config.ts
@@ -6,8 +6,8 @@ const outroText = '/* outro test */\n'
 
 export default defineTest({
   config: {
-    format: 'iife',
     output: {
+      format: 'iife',
       outro: outroText,
     },
   },

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve/_config.ts
@@ -10,7 +10,7 @@ export default defineTest({
       {
         name: 'test-plugin-context',
         async buildStart(this) {
-          const ret = await this.resolve('./main.js', null, null)
+          const ret = await this.resolve('./main.js')
           if (!ret) {
             throw new Error('resolve failed')
           }

--- a/packages/rolldown/tests/fixtures/plugin/plugin-order/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/plugin-order/_config.ts
@@ -101,24 +101,28 @@ export default defineTest({
         banner: {
           handler: () => {
             bannerCalls.push(postName)
+            return ''
           },
           order: 'post',
         },
         footer: {
           handler: () => {
             footerCalls.push(postName)
+            return ''
           },
           order: 'post',
         },
         intro: {
           handler: () => {
             introCalls.push(postName)
+            return ''
           },
           order: 'post',
         },
         outro: {
           handler: () => {
             outroCalls.push(postName)
+            return ''
           },
           order: 'post',
         },
@@ -194,24 +198,28 @@ export default defineTest({
         banner: {
           handler: () => {
             bannerCalls.push(preName)
+            return ''
           },
           order: 'pre',
         },
         footer: {
           handler: () => {
             footerCalls.push(preName)
+            return ''
           },
           order: 'pre',
         },
         intro: {
           handler: () => {
             introCalls.push(preName)
+            return ''
           },
           order: 'pre',
         },
         outro: {
           handler: () => {
             outroCalls.push(preName)
+            return ''
           },
           order: 'pre',
         },
@@ -253,15 +261,19 @@ export default defineTest({
         },
         banner: () => {
           bannerCalls.push(normalName)
+          return ''
         },
         footer: () => {
           footerCalls.push(normalName)
+          return ''
         },
         intro: () => {
           introCalls.push(normalName)
+          return ''
         },
         outro: () => {
           outroCalls.push(normalName)
+          return ''
         },
       },
     ],

--- a/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
@@ -40,7 +40,7 @@ export default defineTest({
       },
       {
         name: 'test-plugin-2',
-        writeBundle: (options, bundle, isWrite) => {
+        writeBundle: () => {
           calls.push('test-plugin-2')
         },
       },

--- a/packages/rolldown/tests/fixtures/sourcemap/inner/_config.ts
+++ b/packages/rolldown/tests/fixtures/sourcemap/inner/_config.ts
@@ -21,10 +21,13 @@ export default defineTest({
     expect(output.output[0].code).contains('//# sourceMappingURL=main.js.map')
     expect(output.output[0].sourcemapFileName).toBe('main.js.map')
     expect(output.output[0].map).toBeDefined()
-    const map = JSON.parse(output.output[1].source)
-    expect(map.file).toMatchInlineSnapshot(`"main.js"`)
-    expect(map.mappings).toMatchInlineSnapshot(
-      `";;AAAA,MAAa,MAAM;;;;ACEnB,QAAQ,IAAI,IAAI"`,
-    )
+
+    if (output.output[1].type === 'asset') {
+      const map = JSON.parse(output.output[1].source.toString())
+      expect(map.file).toMatchInlineSnapshot(`"main.js"`)
+      expect(map.mappings).toMatchInlineSnapshot(
+        `";;AAAA,MAAa,MAAM;;;;ACEnB,QAAQ,IAAI,IAAI"`,
+      )
+    }
   },
 })

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -5,7 +5,7 @@
     "tests/**/*.test.ts",
     "tests/**/_config.ts"
   ],
-  "exclude": ["src/*.js", "src/*.mjs", "src/*.cjs", "tests/fixtures/**"],
+  "exclude": ["src/*.js", "src/*.mjs", "src/*.cjs"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -59,7 +59,7 @@
 
     /* JavaScript Support */
     "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
-    "checkJs": true /* Enable error reporting in type-checked JavaScript files. */,
+    "checkJs": false /* Enable error reporting in type-checked JavaScript files. */,
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. all `_config.ts` are excluded by default, so ts language server can't give intelligence.
## Before
![image](https://github.com/user-attachments/assets/17ebc405-942c-4184-97f8-bba3f8a844c0)

## After
![image](https://github.com/user-attachments/assets/c9f8779c-1f37-4be7-9d60-0513eb882b2c)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
