### PR TITLE
fix: fix `absolute_preliminary_filename` not taking `options.cwd` into account

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -232,10 +232,14 @@ impl<'a> GenerateStage<'a> {
       });
 
       chunk.name = Some(chunk_name);
-      chunk.absolute_preliminary_filename =
-        Some(preliminary.absolutize_with(&self.options.dir).expect_into_string());
-      chunk.css_absolute_preliminary_filename =
-        Some(css_preliminary.absolutize_with(&self.options.dir).expect_into_string());
+      chunk.absolute_preliminary_filename = Some(
+        preliminary.absolutize_with(self.options.cwd.join(&self.options.dir)).expect_into_string(),
+      );
+      chunk.css_absolute_preliminary_filename = Some(
+        css_preliminary
+          .absolutize_with(self.options.cwd.join(&self.options.dir))
+          .expect_into_string(),
+      );
       chunk.preliminary_filename = Some(PreliminaryFilename::new(preliminary, hash_placeholder));
       chunk.css_preliminary_filename =
         Some(PreliminaryFilename::new(css_preliminary, css_hash_placeholder));


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

While making a previous PR, I noticed `absolutize_with` is only using `options.dir` but not `options.cwd`. It looks like `absolute_preliminary_filename` is only for obtaining a relative path between chunks (namely `Chunk::import_path_for`), so the base path doesn't seem to matter, but I thought this is not intended.