### PR TITLE
chore: add `lint-repo` as a subcommand to `lint` in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -99,6 +99,7 @@ fmt-repo:
 lint:
     just lint-rust
     just lint-node
+    just lint-repo
 
 lint-rust:
     cargo fmt --all -- --check


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. so developers don't need to `just lint` and then run `just lint-repo`
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
