### PR TITLE
refactor(node/rolldown): `normalizeHook` should consider meta props of hooks

### DIFF
--- a/packages/rolldown/src/constants/plugin.ts
+++ b/packages/rolldown/src/constants/plugin.ts
@@ -9,3 +9,36 @@ export type PluginProps = keyof Plugin
  * Names of all hooks in a `Plugin` object. Does not include `name` and `api`, since they are not hooks.
  */
 export type PluginHookNames = Exclude<PluginProps, 'name' | 'api'>
+
+// TODO: we need to make sure the defined hooks is the same as the actual hooks
+export const ENUMERATED_PLUGIN_HOOK_NAMES = [
+  // build hooks
+  'options',
+  'buildStart',
+  'resolveId',
+  'load',
+  'transform',
+  'moduleParsed',
+  'augmentChunkHash',
+  'buildEnd',
+  'onLog',
+  'resolveDynamicImport',
+  // generate hooks
+  'generateBundle',
+  'outputOptions',
+  'renderChunk',
+  'renderStart',
+  'renderError',
+  'writeBundle',
+  'footer',
+  'banner',
+  'intro',
+  'outro',
+] as const
+
+/**
+ * Use `isPluginHookName` rather than `PLUGIN_HOOK_NAMES_SET.has` to have a type-friendly check for a plugin hook name.
+ */
+export const PLUGIN_HOOK_NAMES_SET = new Set(
+  ENUMERATED_PLUGIN_HOOK_NAMES as readonly string[],
+)

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -28,7 +28,7 @@ export function bindingifyBuildStart(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx) => {
@@ -50,7 +50,7 @@ export function bindingifyBuildEnd(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, err) => {
@@ -72,7 +72,7 @@ export function bindingifyResolveId(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, specifier, importer, extraOptions) => {
@@ -127,7 +127,7 @@ export function bindingifyResolveDynamicImport(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, specifier, importer) => {
@@ -175,7 +175,7 @@ export function bindingifyTransform(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, code, id, meta) => {
@@ -227,7 +227,7 @@ export function bindingifyLoad(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, id) => {
@@ -292,7 +292,7 @@ export function bindingifyModuleParsed(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, moduleInfo) => {

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -22,7 +22,7 @@ export function bindingifyRenderStart(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx) => {
@@ -46,7 +46,7 @@ export function bindingifyRenderChunk(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, code, chunk) => {
@@ -87,7 +87,7 @@ export function bindingifyAugmentChunkHash(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, chunk) => {
@@ -109,7 +109,7 @@ export function bindingifyRenderError(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, err) => {
@@ -132,7 +132,7 @@ export function bindingifyGenerateBundle(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, bundle, isWrite) => {
@@ -156,7 +156,7 @@ export function bindingifyWriteBundle(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, bundle) => {
@@ -180,7 +180,7 @@ export function bindingifyBanner(
     return [undefined, undefined]
   }
 
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
   return [
     async (ctx, chunk) => {
       if (typeof handler === 'string') {
@@ -206,7 +206,7 @@ export function bindingifyFooter(
     return [undefined, undefined]
   }
 
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, chunk) => {
@@ -233,7 +233,7 @@ export function bindingifyIntro(
     return [undefined, undefined]
   }
 
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, chunk) => {
@@ -260,7 +260,7 @@ export function bindingifyOutro(
     return [undefined, undefined]
   }
 
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, chunk) => {

--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -25,7 +25,7 @@ export class PluginDriver {
       const name = plugin.name || 'unknown'
       const options = plugin.options
       if (options) {
-        const [handler, _optionsIgnoredSofar] = normalizeHook(options)
+        const { handler } = normalizeHook(options)
         const result = await handler.call(
           {
             debug: getLogHandler(
@@ -74,7 +74,7 @@ export class PluginDriver {
     for (const plugin of plugins) {
       const options = plugin.outputOptions
       if (options) {
-        const [handler, _optionsIgnoredSofar] = normalizeHook(options)
+        const { handler } = normalizeHook(options)
         const result = handler.call(null, outputOptions)
 
         if (result) {

--- a/packages/rolldown/src/utils/compose-js-plugins.ts
+++ b/packages/rolldown/src/utils/compose-js-plugins.ts
@@ -129,7 +129,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
           composed.buildStart = async function (options) {
             await Promise.all(
               batchedHandlers.map((handler) => {
-                const [handlerFn, _handlerOptions] = normalizeHook(handler)
+                const { handler: handlerFn } = normalizeHook(handler)
                 return handlerFn.call(this, options)
               }),
             )
@@ -142,7 +142,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
           const batchedHandlers = batchedHooks.load
           composed.load = async function (id) {
             for (const handler of batchedHandlers) {
-              const [handlerFn, _handlerOptions] = normalizeHook(handler)
+              const { handler: handlerFn } = normalizeHook(handler)
               const result = await handlerFn.call(this, id)
               if (!isNullish(result)) {
                 return result
@@ -167,7 +167,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
               moduleSideEffects = newModuleSideEffects ?? undefined
             }
             for (const handler of batchedHandlers) {
-              const [handlerFn, _handlerOptions] = normalizeHook(handler)
+              const { handler: handlerFn } = normalizeHook(handler)
               const result = await handlerFn.call(this, code, id, moduleType)
               if (!isNullish(result)) {
                 if (typeof result === 'string') {
@@ -213,7 +213,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
           composed.buildEnd = async function (err) {
             await Promise.all(
               batchedHandlers.map((handler) => {
-                const [handlerFn, _handlerOptions] = normalizeHook(handler)
+                const { handler: handlerFn } = normalizeHook(handler)
                 return handlerFn.call(this, err)
               }),
             )
@@ -226,7 +226,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
           const batchedHandlers = batchedHooks.renderChunk
           composed.renderChunk = async function (code, chunk, options) {
             for (const handler of batchedHandlers) {
-              const [handlerFn, _handlerOptions] = normalizeHook(handler)
+              const { handler: handlerFn } = normalizeHook(handler)
               const result = await handlerFn.call(this, code, chunk, options)
               if (!isNullish(result)) {
                 return result

--- a/packages/rolldown/src/utils/plugin/index.ts
+++ b/packages/rolldown/src/utils/plugin/index.ts
@@ -1,0 +1,7 @@
+import { PLUGIN_HOOK_NAMES_SET, PluginHookNames } from '../../constants/plugin'
+
+export function isPluginHookName(
+  hookName: string,
+): hookName is PluginHookNames {
+  return PLUGIN_HOOK_NAMES_SET.has(hookName)
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We gonna have a complex js plugin system considering the composing JS plugin logic. We need to build a solid infra to reduce errors. To do that:

- Dealing with plugin in a unite form is needed and it's also what this PR does.
- We need to make sure the types defined in different places are synced rather than copy around.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
