### PR TITLE
refactor(node/rolldown): single source of truth for plugin hooks

### DIFF
--- a/packages/rolldown/src/constants/plugin.ts
+++ b/packages/rolldown/src/constants/plugin.ts
@@ -1,16 +1,5 @@
 import { Plugin } from '../plugin'
 
-/**
- * Names of all properties in a `Plugin` object. Includes `name` and `api`.
- */
-export type PluginProps = keyof Plugin
-
-/**
- * Names of all hooks in a `Plugin` object. Does not include `name` and `api`, since they are not hooks.
- */
-export type PluginHookNames = Exclude<PluginProps, 'name' | 'api'>
-
-// TODO: we need to make sure the defined hooks is the same as the actual hooks
 export const ENUMERATED_PLUGIN_HOOK_NAMES = [
   // build hooks
   'options',
@@ -37,8 +26,59 @@ export const ENUMERATED_PLUGIN_HOOK_NAMES = [
 ] as const
 
 /**
- * Use `isPluginHookName` rather than `PLUGIN_HOOK_NAMES_SET.has` to have a type-friendly check for a plugin hook name.
+ * Names of all properties in a `Plugin` object. Includes `name` and `api`.
  */
-export const PLUGIN_HOOK_NAMES_SET = new Set(
-  ENUMERATED_PLUGIN_HOOK_NAMES as readonly string[],
-)
+export type PluginProps = keyof Plugin
+
+type EnumeratedPluginHookNames = typeof ENUMERATED_PLUGIN_HOOK_NAMES
+/**
+ * Names of all hooks in a `Plugin` object. Does not include `name` and `api`, since they are not hooks.
+ */
+export type PluginHookNames = EnumeratedPluginHookNames[number]
+
+/**
+ * Names of all defined hooks. It's like
+ * ```ts
+ * type DefinedHookNames = {
+ *   options: 'options',
+ *   buildStart: 'buildStart',
+ *   ...
+ * }
+ * ```
+ */
+export type DefinedHookNames = {
+  readonly [K in PluginHookNames]: K
+}
+
+/**
+ * Names of all defined hooks. It's like
+ * ```js
+ * const DEFINED_HOOK_NAMES ={
+ *   options: 'options',
+ *   buildStart: 'buildStart',
+ *   ...
+ * }
+ * ```
+ */
+export const DEFINED_HOOK_NAMES: DefinedHookNames = {
+  [ENUMERATED_PLUGIN_HOOK_NAMES[0]]: ENUMERATED_PLUGIN_HOOK_NAMES[0],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[1]]: ENUMERATED_PLUGIN_HOOK_NAMES[1],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[2]]: ENUMERATED_PLUGIN_HOOK_NAMES[2],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[3]]: ENUMERATED_PLUGIN_HOOK_NAMES[3],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[4]]: ENUMERATED_PLUGIN_HOOK_NAMES[4],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[5]]: ENUMERATED_PLUGIN_HOOK_NAMES[5],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[6]]: ENUMERATED_PLUGIN_HOOK_NAMES[6],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[7]]: ENUMERATED_PLUGIN_HOOK_NAMES[7],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[8]]: ENUMERATED_PLUGIN_HOOK_NAMES[8],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[9]]: ENUMERATED_PLUGIN_HOOK_NAMES[9],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[10]]: ENUMERATED_PLUGIN_HOOK_NAMES[10],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[11]]: ENUMERATED_PLUGIN_HOOK_NAMES[11],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[12]]: ENUMERATED_PLUGIN_HOOK_NAMES[12],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[13]]: ENUMERATED_PLUGIN_HOOK_NAMES[13],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[14]]: ENUMERATED_PLUGIN_HOOK_NAMES[14],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[15]]: ENUMERATED_PLUGIN_HOOK_NAMES[15],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[16]]: ENUMERATED_PLUGIN_HOOK_NAMES[16],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[17]]: ENUMERATED_PLUGIN_HOOK_NAMES[17],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[18]]: ENUMERATED_PLUGIN_HOOK_NAMES[18],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[19]]: ENUMERATED_PLUGIN_HOOK_NAMES[19],
+} as const

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -22,6 +22,8 @@ import type { MinimalPluginContext } from '../log/logger'
 import { InputOptions, OutputOptions } from '..'
 import { BuiltinPlugin } from './builtin-plugin'
 import { ParallelPlugin } from './parallel-plugin'
+import type { DefinedHookNames } from '../constants/plugin'
+import { DEFINED_HOOK_NAMES } from '../constants/plugin'
 
 export type ModuleSideEffects = boolean | 'no-treeshake' | null
 
@@ -81,28 +83,31 @@ export type TransformResult =
   | (Partial<SourceDescription> & { moduleType?: ModuleType })
 
 export interface FunctionPluginHooks {
-  onLog: (
+  [DEFINED_HOOK_NAMES.onLog]: (
     this: MinimalPluginContext,
     level: LogLevel,
     log: RollupLog,
   ) => NullValue | boolean
 
-  options: (
+  [DEFINED_HOOK_NAMES.options]: (
     this: MinimalPluginContext,
     options: InputOptions,
   ) => NullValue | InputOptions
 
   // TODO find a way to make `this: PluginContext` work.
-  outputOptions: (
+  [DEFINED_HOOK_NAMES.outputOptions]: (
     this: null,
     options: OutputOptions,
   ) => NullValue | OutputOptions
 
   // --- Build hooks ---
 
-  buildStart: (this: PluginContext, options: NormalizedInputOptions) => void
+  [DEFINED_HOOK_NAMES.buildStart]: (
+    this: PluginContext,
+    options: NormalizedInputOptions,
+  ) => void
 
-  resolveId: (
+  [DEFINED_HOOK_NAMES.resolveId]: (
     this: PluginContext,
     source: string,
     importer: string | undefined,
@@ -113,34 +118,40 @@ export interface FunctionPluginHooks {
    * @deprecated
    * This hook is only for rollup plugin compatibility. Please use `resolveId` instead.
    */
-  resolveDynamicImport: (
+  [DEFINED_HOOK_NAMES.resolveDynamicImport]: (
     this: PluginContext,
     source: string,
     importer: string | undefined,
   ) => ResolveIdResult
 
-  load: (this: PluginContext, id: string) => MaybePromise<LoadResult>
+  [DEFINED_HOOK_NAMES.load]: (
+    this: PluginContext,
+    id: string,
+  ) => MaybePromise<LoadResult>
 
-  transform: (
+  [DEFINED_HOOK_NAMES.transform]: (
     this: TransformPluginContext,
     code: string,
     id: string,
     meta: BindingTransformHookExtraArgs & { moduleType: ModuleType },
   ) => TransformResult
 
-  moduleParsed: (this: PluginContext, moduleInfo: ModuleInfo) => void
+  [DEFINED_HOOK_NAMES.moduleParsed]: (
+    this: PluginContext,
+    moduleInfo: ModuleInfo,
+  ) => void
 
-  buildEnd: (this: PluginContext, err?: Error) => void
+  [DEFINED_HOOK_NAMES.buildEnd]: (this: PluginContext, err?: Error) => void
 
   // --- Generate hooks ---
 
-  renderStart: (
+  [DEFINED_HOOK_NAMES.renderStart]: (
     this: PluginContext,
     outputOptions: NormalizedOutputOptions,
     inputOptions: NormalizedInputOptions,
   ) => void
 
-  renderChunk: (
+  [DEFINED_HOOK_NAMES.renderChunk]: (
     this: PluginContext,
     code: string,
     chunk: RenderedChunk,
@@ -153,18 +164,21 @@ export interface FunctionPluginHooks {
         map?: SourceMapInput
       }
 
-  augmentChunkHash: (this: PluginContext, chunk: RenderedChunk) => string | void
+  [DEFINED_HOOK_NAMES.augmentChunkHash]: (
+    this: PluginContext,
+    chunk: RenderedChunk,
+  ) => string | void
 
-  renderError: (this: PluginContext, error: Error) => void
+  [DEFINED_HOOK_NAMES.renderError]: (this: PluginContext, error: Error) => void
 
-  generateBundle: (
+  [DEFINED_HOOK_NAMES.generateBundle]: (
     this: PluginContext,
     outputOptions: NormalizedOutputOptions,
     bundle: OutputBundle,
     isWrite: boolean,
   ) => void
 
-  writeBundle: (
+  [DEFINED_HOOK_NAMES.writeBundle]: (
     this: PluginContext,
     outputOptions: NormalizedOutputOptions,
     bundle: OutputBundle,
@@ -177,7 +191,10 @@ export type ObjectHookMeta<O = {}> = { order?: PluginOrder } & O
 
 export type ObjectHook<T, O = {}> = T | ({ handler: T } & ObjectHookMeta<O>)
 
-export type SyncPluginHooks = 'augmentChunkHash' | 'onLog' | 'outputOptions'
+export type SyncPluginHooks = DefinedHookNames[
+  | 'augmentChunkHash'
+  | 'onLog'
+  | 'outputOptions']
 // | 'renderDynamicImport'
 // | 'resolveFileUrl'
 // | 'resolveImportMeta'
@@ -187,27 +204,31 @@ export type AsyncPluginHooks = Exclude<
   SyncPluginHooks
 >
 
-export type FirstPluginHooks =
+export type FirstPluginHooks = DefinedHookNames[
   | 'load'
-  | 'renderDynamicImport'
+  // | 'renderDynamicImport'
   | 'resolveDynamicImport'
   // | 'resolveFileUrl'
-  | 'resolveId'
+  | 'resolveId']
 // | 'resolveImportMeta'
 // | 'shouldTransformCachedModule'
 
-export type SequentialPluginHooks =
+export type SequentialPluginHooks = DefinedHookNames[
   | 'augmentChunkHash'
   | 'generateBundle'
   | 'onLog'
   | 'options'
   | 'outputOptions'
   | 'renderChunk'
-  | 'transform'
+  | 'transform']
 
-export type AddonHooks = 'banner' | 'footer' | 'intro' | 'outro'
+export type AddonHooks = DefinedHookNames[
+  | 'banner'
+  | 'footer'
+  | 'intro'
+  | 'outro']
 
-export type OutputPluginHooks =
+export type OutputPluginHooks = DefinedHookNames[
   | 'augmentChunkHash'
   | 'generateBundle'
   | 'outputOptions'
@@ -217,7 +238,7 @@ export type OutputPluginHooks =
   | 'renderStart'
   // | 'resolveFileUrl'
   // | 'resolveImportMeta'
-  | 'writeBundle'
+  | 'writeBundle']
 
 export type ParallelPluginHooks = Exclude<
   keyof FunctionPluginHooks | AddonHooks,

--- a/packages/rolldown/src/utils/plugin/index.ts
+++ b/packages/rolldown/src/utils/plugin/index.ts
@@ -1,7 +1,15 @@
-import { PLUGIN_HOOK_NAMES_SET, PluginHookNames } from '../../constants/plugin'
+import {
+  ENUMERATED_PLUGIN_HOOK_NAMES,
+  PluginHookNames,
+} from '../../constants/plugin'
 
-export function isPluginHookName(
-  hookName: string,
-): hookName is PluginHookNames {
-  return PLUGIN_HOOK_NAMES_SET.has(hookName)
-}
+export const isPluginHookName = (function () {
+  const PLUGIN_HOOK_NAMES_SET = new Set(
+    ENUMERATED_PLUGIN_HOOK_NAMES as readonly string[],
+  )
+  return function isPluginHookName(
+    hookName: string,
+  ): hookName is PluginHookNames {
+    return PLUGIN_HOOK_NAMES_SET.has(hookName)
+  }
+})()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This prevent bugs of forgetting define hooks in multiple places.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
