### PR TITLE
fix(node/compose-plugins): Plugin that uses `order` meta is considered as not composable

### DIFF
--- a/packages/rolldown/src/constants/plugin.ts
+++ b/packages/rolldown/src/constants/plugin.ts
@@ -1,16 +1,5 @@
 import { Plugin } from '../plugin'
 
-/**
- * Names of all properties in a `Plugin` object. Includes `name` and `api`.
- */
-export type PluginProps = keyof Plugin
-
-/**
- * Names of all hooks in a `Plugin` object. Does not include `name` and `api`, since they are not hooks.
- */
-export type PluginHookNames = Exclude<PluginProps, 'name' | 'api'>
-
-// TODO: we need to make sure the defined hooks is the same as the actual hooks
 export const ENUMERATED_PLUGIN_HOOK_NAMES = [
   // build hooks
   'options',
@@ -37,8 +26,59 @@ export const ENUMERATED_PLUGIN_HOOK_NAMES = [
 ] as const
 
 /**
- * Use `isPluginHookName` rather than `PLUGIN_HOOK_NAMES_SET.has` to have a type-friendly check for a plugin hook name.
+ * Names of all properties in a `Plugin` object. Includes `name` and `api`.
  */
-export const PLUGIN_HOOK_NAMES_SET = new Set(
-  ENUMERATED_PLUGIN_HOOK_NAMES as readonly string[],
-)
+export type PluginProps = keyof Plugin
+
+type EnumeratedPluginHookNames = typeof ENUMERATED_PLUGIN_HOOK_NAMES
+/**
+ * Names of all hooks in a `Plugin` object. Does not include `name` and `api`, since they are not hooks.
+ */
+export type PluginHookNames = EnumeratedPluginHookNames[number]
+
+/**
+ * Names of all defined hooks. It's like
+ * ```ts
+ * type DefinedHookNames = {
+ *   options: 'options',
+ *   buildStart: 'buildStart',
+ *   ...
+ * }
+ * ```
+ */
+export type DefinedHookNames = {
+  readonly [K in PluginHookNames]: K
+}
+
+/**
+ * Names of all defined hooks. It's like
+ * ```js
+ * const DEFINED_HOOK_NAMES ={
+ *   options: 'options',
+ *   buildStart: 'buildStart',
+ *   ...
+ * }
+ * ```
+ */
+export const DEFINED_HOOK_NAMES: DefinedHookNames = {
+  [ENUMERATED_PLUGIN_HOOK_NAMES[0]]: ENUMERATED_PLUGIN_HOOK_NAMES[0],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[1]]: ENUMERATED_PLUGIN_HOOK_NAMES[1],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[2]]: ENUMERATED_PLUGIN_HOOK_NAMES[2],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[3]]: ENUMERATED_PLUGIN_HOOK_NAMES[3],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[4]]: ENUMERATED_PLUGIN_HOOK_NAMES[4],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[5]]: ENUMERATED_PLUGIN_HOOK_NAMES[5],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[6]]: ENUMERATED_PLUGIN_HOOK_NAMES[6],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[7]]: ENUMERATED_PLUGIN_HOOK_NAMES[7],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[8]]: ENUMERATED_PLUGIN_HOOK_NAMES[8],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[9]]: ENUMERATED_PLUGIN_HOOK_NAMES[9],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[10]]: ENUMERATED_PLUGIN_HOOK_NAMES[10],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[11]]: ENUMERATED_PLUGIN_HOOK_NAMES[11],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[12]]: ENUMERATED_PLUGIN_HOOK_NAMES[12],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[13]]: ENUMERATED_PLUGIN_HOOK_NAMES[13],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[14]]: ENUMERATED_PLUGIN_HOOK_NAMES[14],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[15]]: ENUMERATED_PLUGIN_HOOK_NAMES[15],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[16]]: ENUMERATED_PLUGIN_HOOK_NAMES[16],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[17]]: ENUMERATED_PLUGIN_HOOK_NAMES[17],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[18]]: ENUMERATED_PLUGIN_HOOK_NAMES[18],
+  [ENUMERATED_PLUGIN_HOOK_NAMES[19]]: ENUMERATED_PLUGIN_HOOK_NAMES[19],
+} as const

--- a/packages/rolldown/src/constants/plugin.ts
+++ b/packages/rolldown/src/constants/plugin.ts
@@ -9,3 +9,36 @@ export type PluginProps = keyof Plugin
  * Names of all hooks in a `Plugin` object. Does not include `name` and `api`, since they are not hooks.
  */
 export type PluginHookNames = Exclude<PluginProps, 'name' | 'api'>
+
+// TODO: we need to make sure the defined hooks is the same as the actual hooks
+export const ENUMERATED_PLUGIN_HOOK_NAMES = [
+  // build hooks
+  'options',
+  'buildStart',
+  'resolveId',
+  'load',
+  'transform',
+  'moduleParsed',
+  'augmentChunkHash',
+  'buildEnd',
+  'onLog',
+  'resolveDynamicImport',
+  // generate hooks
+  'generateBundle',
+  'outputOptions',
+  'renderChunk',
+  'renderStart',
+  'renderError',
+  'writeBundle',
+  'footer',
+  'banner',
+  'intro',
+  'outro',
+] as const
+
+/**
+ * Use `isPluginHookName` rather than `PLUGIN_HOOK_NAMES_SET.has` to have a type-friendly check for a plugin hook name.
+ */
+export const PLUGIN_HOOK_NAMES_SET = new Set(
+  ENUMERATED_PLUGIN_HOOK_NAMES as readonly string[],
+)

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -28,7 +28,7 @@ export function bindingifyBuildStart(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx) => {
@@ -50,7 +50,7 @@ export function bindingifyBuildEnd(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, err) => {
@@ -72,7 +72,7 @@ export function bindingifyResolveId(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, specifier, importer, extraOptions) => {
@@ -127,7 +127,7 @@ export function bindingifyResolveDynamicImport(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, specifier, importer) => {
@@ -175,7 +175,7 @@ export function bindingifyTransform(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, code, id, meta) => {
@@ -227,7 +227,7 @@ export function bindingifyLoad(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, id) => {
@@ -292,7 +292,7 @@ export function bindingifyModuleParsed(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, moduleInfo) => {

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -22,7 +22,7 @@ export function bindingifyRenderStart(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx) => {
@@ -46,7 +46,7 @@ export function bindingifyRenderChunk(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, code, chunk) => {
@@ -87,7 +87,7 @@ export function bindingifyAugmentChunkHash(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, chunk) => {
@@ -109,7 +109,7 @@ export function bindingifyRenderError(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, err) => {
@@ -132,7 +132,7 @@ export function bindingifyGenerateBundle(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, bundle, isWrite) => {
@@ -156,7 +156,7 @@ export function bindingifyWriteBundle(
   if (!hook) {
     return [undefined, undefined]
   }
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, bundle) => {
@@ -180,7 +180,7 @@ export function bindingifyBanner(
     return [undefined, undefined]
   }
 
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
   return [
     async (ctx, chunk) => {
       if (typeof handler === 'string') {
@@ -206,7 +206,7 @@ export function bindingifyFooter(
     return [undefined, undefined]
   }
 
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, chunk) => {
@@ -233,7 +233,7 @@ export function bindingifyIntro(
     return [undefined, undefined]
   }
 
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, chunk) => {
@@ -260,7 +260,7 @@ export function bindingifyOutro(
     return [undefined, undefined]
   }
 
-  const [handler, meta] = normalizeHook(hook)
+  const { handler, meta } = normalizeHook(hook)
 
   return [
     async (ctx, chunk) => {

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -22,6 +22,8 @@ import type { MinimalPluginContext } from '../log/logger'
 import { InputOptions, OutputOptions } from '..'
 import { BuiltinPlugin } from './builtin-plugin'
 import { ParallelPlugin } from './parallel-plugin'
+import type { DefinedHookNames } from '../constants/plugin'
+import { DEFINED_HOOK_NAMES } from '../constants/plugin'
 
 export type ModuleSideEffects = boolean | 'no-treeshake' | null
 
@@ -81,28 +83,31 @@ export type TransformResult =
   | (Partial<SourceDescription> & { moduleType?: ModuleType })
 
 export interface FunctionPluginHooks {
-  onLog: (
+  [DEFINED_HOOK_NAMES.onLog]: (
     this: MinimalPluginContext,
     level: LogLevel,
     log: RollupLog,
   ) => NullValue | boolean
 
-  options: (
+  [DEFINED_HOOK_NAMES.options]: (
     this: MinimalPluginContext,
     options: InputOptions,
   ) => NullValue | InputOptions
 
   // TODO find a way to make `this: PluginContext` work.
-  outputOptions: (
+  [DEFINED_HOOK_NAMES.outputOptions]: (
     this: null,
     options: OutputOptions,
   ) => NullValue | OutputOptions
 
   // --- Build hooks ---
 
-  buildStart: (this: PluginContext, options: NormalizedInputOptions) => void
+  [DEFINED_HOOK_NAMES.buildStart]: (
+    this: PluginContext,
+    options: NormalizedInputOptions,
+  ) => void
 
-  resolveId: (
+  [DEFINED_HOOK_NAMES.resolveId]: (
     this: PluginContext,
     source: string,
     importer: string | undefined,
@@ -113,34 +118,40 @@ export interface FunctionPluginHooks {
    * @deprecated
    * This hook is only for rollup plugin compatibility. Please use `resolveId` instead.
    */
-  resolveDynamicImport: (
+  [DEFINED_HOOK_NAMES.resolveDynamicImport]: (
     this: PluginContext,
     source: string,
     importer: string | undefined,
   ) => ResolveIdResult
 
-  load: (this: PluginContext, id: string) => MaybePromise<LoadResult>
+  [DEFINED_HOOK_NAMES.load]: (
+    this: PluginContext,
+    id: string,
+  ) => MaybePromise<LoadResult>
 
-  transform: (
+  [DEFINED_HOOK_NAMES.transform]: (
     this: TransformPluginContext,
     code: string,
     id: string,
     meta: BindingTransformHookExtraArgs & { moduleType: ModuleType },
   ) => TransformResult
 
-  moduleParsed: (this: PluginContext, moduleInfo: ModuleInfo) => void
+  [DEFINED_HOOK_NAMES.moduleParsed]: (
+    this: PluginContext,
+    moduleInfo: ModuleInfo,
+  ) => void
 
-  buildEnd: (this: PluginContext, err?: Error) => void
+  [DEFINED_HOOK_NAMES.buildEnd]: (this: PluginContext, err?: Error) => void
 
   // --- Generate hooks ---
 
-  renderStart: (
+  [DEFINED_HOOK_NAMES.renderStart]: (
     this: PluginContext,
     outputOptions: NormalizedOutputOptions,
     inputOptions: NormalizedInputOptions,
   ) => void
 
-  renderChunk: (
+  [DEFINED_HOOK_NAMES.renderChunk]: (
     this: PluginContext,
     code: string,
     chunk: RenderedChunk,
@@ -153,18 +164,21 @@ export interface FunctionPluginHooks {
         map?: SourceMapInput
       }
 
-  augmentChunkHash: (this: PluginContext, chunk: RenderedChunk) => string | void
+  [DEFINED_HOOK_NAMES.augmentChunkHash]: (
+    this: PluginContext,
+    chunk: RenderedChunk,
+  ) => string | void
 
-  renderError: (this: PluginContext, error: Error) => void
+  [DEFINED_HOOK_NAMES.renderError]: (this: PluginContext, error: Error) => void
 
-  generateBundle: (
+  [DEFINED_HOOK_NAMES.generateBundle]: (
     this: PluginContext,
     outputOptions: NormalizedOutputOptions,
     bundle: OutputBundle,
     isWrite: boolean,
   ) => void
 
-  writeBundle: (
+  [DEFINED_HOOK_NAMES.writeBundle]: (
     this: PluginContext,
     outputOptions: NormalizedOutputOptions,
     bundle: OutputBundle,
@@ -177,7 +191,10 @@ export type ObjectHookMeta<O = {}> = { order?: PluginOrder } & O
 
 export type ObjectHook<T, O = {}> = T | ({ handler: T } & ObjectHookMeta<O>)
 
-export type SyncPluginHooks = 'augmentChunkHash' | 'onLog' | 'outputOptions'
+export type SyncPluginHooks = DefinedHookNames[
+  | 'augmentChunkHash'
+  | 'onLog'
+  | 'outputOptions']
 // | 'renderDynamicImport'
 // | 'resolveFileUrl'
 // | 'resolveImportMeta'
@@ -187,27 +204,31 @@ export type AsyncPluginHooks = Exclude<
   SyncPluginHooks
 >
 
-export type FirstPluginHooks =
+export type FirstPluginHooks = DefinedHookNames[
   | 'load'
-  | 'renderDynamicImport'
+  // | 'renderDynamicImport'
   | 'resolveDynamicImport'
   // | 'resolveFileUrl'
-  | 'resolveId'
+  | 'resolveId']
 // | 'resolveImportMeta'
 // | 'shouldTransformCachedModule'
 
-export type SequentialPluginHooks =
+export type SequentialPluginHooks = DefinedHookNames[
   | 'augmentChunkHash'
   | 'generateBundle'
   | 'onLog'
   | 'options'
   | 'outputOptions'
   | 'renderChunk'
-  | 'transform'
+  | 'transform']
 
-export type AddonHooks = 'banner' | 'footer' | 'intro' | 'outro'
+export type AddonHooks = DefinedHookNames[
+  | 'banner'
+  | 'footer'
+  | 'intro'
+  | 'outro']
 
-export type OutputPluginHooks =
+export type OutputPluginHooks = DefinedHookNames[
   | 'augmentChunkHash'
   | 'generateBundle'
   | 'outputOptions'
@@ -217,7 +238,7 @@ export type OutputPluginHooks =
   | 'renderStart'
   // | 'resolveFileUrl'
   // | 'resolveImportMeta'
-  | 'writeBundle'
+  | 'writeBundle']
 
 export type ParallelPluginHooks = Exclude<
   keyof FunctionPluginHooks | AddonHooks,

--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -25,7 +25,7 @@ export class PluginDriver {
       const name = plugin.name || 'unknown'
       const options = plugin.options
       if (options) {
-        const [handler, _optionsIgnoredSofar] = normalizeHook(options)
+        const { handler } = normalizeHook(options)
         const result = await handler.call(
           {
             debug: getLogHandler(
@@ -74,7 +74,7 @@ export class PluginDriver {
     for (const plugin of plugins) {
       const options = plugin.outputOptions
       if (options) {
-        const [handler, _optionsIgnoredSofar] = normalizeHook(options)
+        const { handler } = normalizeHook(options)
         const result = handler.call(null, outputOptions)
 
         if (result) {

--- a/packages/rolldown/src/utils/compose-js-plugins.ts
+++ b/packages/rolldown/src/utils/compose-js-plugins.ts
@@ -129,7 +129,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
           composed.buildStart = async function (options) {
             await Promise.all(
               batchedHandlers.map((handler) => {
-                const [handlerFn, _handlerOptions] = normalizeHook(handler)
+                const { handler: handlerFn } = normalizeHook(handler)
                 return handlerFn.call(this, options)
               }),
             )
@@ -142,7 +142,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
           const batchedHandlers = batchedHooks.load
           composed.load = async function (id) {
             for (const handler of batchedHandlers) {
-              const [handlerFn, _handlerOptions] = normalizeHook(handler)
+              const { handler: handlerFn } = normalizeHook(handler)
               const result = await handlerFn.call(this, id)
               if (!isNullish(result)) {
                 return result
@@ -167,7 +167,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
               moduleSideEffects = newModuleSideEffects ?? undefined
             }
             for (const handler of batchedHandlers) {
-              const [handlerFn, _handlerOptions] = normalizeHook(handler)
+              const { handler: handlerFn } = normalizeHook(handler)
               const result = await handlerFn.call(this, code, id, moduleType)
               if (!isNullish(result)) {
                 if (typeof result === 'string') {
@@ -213,7 +213,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
           composed.buildEnd = async function (err) {
             await Promise.all(
               batchedHandlers.map((handler) => {
-                const [handlerFn, _handlerOptions] = normalizeHook(handler)
+                const { handler: handlerFn } = normalizeHook(handler)
                 return handlerFn.call(this, err)
               }),
             )
@@ -226,7 +226,7 @@ function createComposedPlugin(plugins: Plugin[]): Plugin {
           const batchedHandlers = batchedHooks.renderChunk
           composed.renderChunk = async function (code, chunk, options) {
             for (const handler of batchedHandlers) {
-              const [handlerFn, _handlerOptions] = normalizeHook(handler)
+              const { handler: handlerFn } = normalizeHook(handler)
               const result = await handlerFn.call(this, code, chunk, options)
               if (!isNullish(result)) {
                 return result

--- a/packages/rolldown/src/utils/plugin/index.ts
+++ b/packages/rolldown/src/utils/plugin/index.ts
@@ -1,7 +1,15 @@
-import { PLUGIN_HOOK_NAMES_SET, PluginHookNames } from '../../constants/plugin'
+import {
+  ENUMERATED_PLUGIN_HOOK_NAMES,
+  PluginHookNames,
+} from '../../constants/plugin'
 
-export function isPluginHookName(
-  hookName: string,
-): hookName is PluginHookNames {
-  return PLUGIN_HOOK_NAMES_SET.has(hookName)
-}
+export const isPluginHookName = (function () {
+  const PLUGIN_HOOK_NAMES_SET = new Set(
+    ENUMERATED_PLUGIN_HOOK_NAMES as readonly string[],
+  )
+  return function isPluginHookName(
+    hookName: string,
+  ): hookName is PluginHookNames {
+    return PLUGIN_HOOK_NAMES_SET.has(hookName)
+  }
+})()

--- a/packages/rolldown/src/utils/plugin/index.ts
+++ b/packages/rolldown/src/utils/plugin/index.ts
@@ -1,0 +1,7 @@
+import { PLUGIN_HOOK_NAMES_SET, PluginHookNames } from '../../constants/plugin'
+
+export function isPluginHookName(
+  hookName: string,
+): hookName is PluginHookNames {
+  return PLUGIN_HOOK_NAMES_SET.has(hookName)
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I'm thinking exposing `composeJsPlugin as composePlugins` to outside under `rolldown/experimental`, so we could write unite tests on `rolldown/tests`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
