### PR TITLE
chore: move cargo shear to lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,6 @@ jobs:
       - name: Lint
         run: just lint-rust
 
-      - name: Check unused dependencies
-        run: cargo shear
-
   cargo-test:
     needs: changes
     strategy:

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ _default:
 setup:
   # Rust related setup
   cargo install cargo-binstall
-  cargo binstall taplo-cli cargo-insta cargo-deny -y
+  cargo binstall taplo-cli cargo-insta cargo-deny cargo-shear -y
   # Node.js related setup
   corepack enable
   pnpm install
@@ -90,6 +90,7 @@ fmt:
 fmt-rust:
     cargo fmt --all -- --emit=files
     taplo fmt
+    cargo shear --fix
 
 fmt-repo:
     pnpm lint-prettier:fix
@@ -104,6 +105,7 @@ lint:
 lint-rust:
     cargo fmt --all -- --check
     cargo clippy --workspace --all-targets -- --deny warnings
+    cargo shear
 
 lint-node:
     pnpm lint-code


### PR DESCRIPTION
This PR moves `cargo shear` into `lint-rust`, so that `just roll` can also execute this command.