### PR TITLE
chore: improve the successful output of setup in `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ setup:
   pnpm install
   just setup-submodule
   just setup-bench
-  echo "✅✅✅ Setup complete!"
+  @echo "✅✅✅ Setup complete!"
 
 setup-submodule:
   git submodule update --init


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When studying `just`, I found that `echo` can cause duplicate output, so we should change it to `@echo`. This issue is too insignificant, I hope this PR is useful.

<img width="218" alt="image" src="https://github.com/user-attachments/assets/465836ea-4e59-4b54-b98f-e274bd0a5824">

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
