### PR TITLE
refactor(rust): improve esModule type in binding

### DIFF
--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -5,6 +5,7 @@ use super::super::types::binding_rendered_chunk::RenderedChunk;
 use super::plugin::BindingPluginOrParallelJsPluginPlaceholder;
 use derivative::Derivative;
 use napi::threadsafe_function::ThreadsafeFunction;
+use napi::Either;
 use napi_derive::napi;
 use serde::Deserialize;
 
@@ -32,8 +33,9 @@ pub struct BindingOutputOptions {
   // compact: boolean;
   pub dir: Option<String>,
   // pub entry_file_names: String, // | ((chunkInfo: PreRenderedChunk) => string)
-  #[napi(ts_type = "'always' | 'never' | 'if-default-prop'")]
-  pub es_module: Option<String>,
+  #[serde(skip_deserializing)]
+  #[napi(ts_type = "boolean | 'if-default-prop'")]
+  pub es_module: Option<Either<bool, String>>,
   #[napi(ts_type = "'default' | 'named' | 'none' | 'auto'")]
   pub exports: Option<String>,
   // extend: boolean;

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -121,8 +121,8 @@ pub fn normalize_binding_options(
     dir: output_options.dir,
     sourcemap: output_options.sourcemap.map(Into::into),
     es_module: output_options.es_module.map(|es_module| match es_module {
-      Either::A(a) => a.into(),
-      Either::B(b) => b.into(),
+      Either::A(es_module_bool) => es_module_bool.into(),
+      Either::B(es_module_string) => es_module_string.into(),
     }),
     banner: normalize_addon_option(output_options.banner),
     footer: normalize_addon_option(output_options.footer),

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -120,7 +120,10 @@ pub fn normalize_binding_options(
     asset_filenames: output_options.asset_file_names,
     dir: output_options.dir,
     sourcemap: output_options.sourcemap.map(Into::into),
-    es_module: output_options.es_module.map(Into::into),
+    es_module: output_options.es_module.map(|es_module| match es_module {
+      Either::A(a) => a.into(),
+      Either::B(b) => b.into(),
+    }),
     banner: normalize_addon_option(output_options.banner),
     footer: normalize_addon_option(output_options.footer),
     intro: normalize_addon_option(output_options.intro),

--- a/crates/rolldown_common/src/inner_bundler_options/types/es_module_flag.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/es_module_flag.rs
@@ -53,13 +53,22 @@ pub enum EsModuleFlag {
   IfDefaultProp,
 }
 
+impl From<bool> for EsModuleFlag {
+  fn from(value: bool) -> Self {
+    if value {
+      Self::Always
+    } else {
+      Self::Never
+    }
+  }
+}
+
 impl From<String> for EsModuleFlag {
   fn from(value: String) -> Self {
-    match value.as_str() {
-      "always" => Self::Always,
-      "never" => Self::Never,
-      "if-default-prop" => Self::IfDefaultProp,
-      _ => unreachable!("unknown es module type"),
+    if value == "if-default-prop" {
+      Self::IfDefaultProp
+    } else {
+      unreachable!("unknown es module type")
     }
   }
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -233,7 +233,7 @@ export interface BindingOutputOptions {
   assetFileNames?: string
   banner?: (chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>
   dir?: string
-  esModule?: 'always' | 'never' | 'if-default-prop'
+  esModule?: boolean | 'if-default-prop'
   exports?: 'default' | 'named' | 'none' | 'auto'
   footer?: (chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>
   format?: 'es' | 'cjs' | 'iife'

--- a/packages/rolldown/src/options/bindingify-output-options.ts
+++ b/packages/rolldown/src/options/bindingify-output-options.ts
@@ -79,15 +79,9 @@ function bindingifyEsModule(
 ): BindingOutputOptions['esModule'] {
   switch (esModule) {
     case true:
-      return 'always'
-
     case false:
-      return 'never'
-
     case 'if-default-prop':
-    case undefined:
-      return 'if-default-prop'
-
+      return esModule
     default:
       throw new Error(`unknown esModule: ${esModule}`)
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Related to #1888 

Due to some mistakes, I mistakenly believed that it was not possible to use `napi-rs`'s `Either` for value passing in Rolldown. You can refer to this issue https://github.com/napi-rs/napi-rs/issues/2215 for more details.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
