### PR TITLE
refactor(rust/plugin): rename `SharedPluginContext` to `PluginContext`

### DIFF
--- a/crates/rolldown/tests/rolldown/errors/entry_cannot_be_external/mod.rs
+++ b/crates/rolldown/tests/rolldown/errors/entry_cannot_be_external/mod.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, sync::Arc};
 
 use rolldown::{BundlerOptions, InputItem};
 use rolldown_plugin::{
-  HookResolveIdArgs, HookResolveIdOutput, HookResolveIdReturn, Plugin, SharedPluginContext,
+  HookResolveIdArgs, HookResolveIdOutput, HookResolveIdReturn, Plugin, PluginContext,
 };
 use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
 
@@ -16,7 +16,7 @@ impl Plugin for TestPlugin {
 
   async fn resolve_id(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     args: &HookResolveIdArgs<'_>,
   ) -> HookResolveIdReturn {
     if args.specifier == "ext" {

--- a/crates/rolldown/tests/rolldown/errors/unresolved_import/basic/mod.rs
+++ b/crates/rolldown/tests/rolldown/errors/unresolved_import/basic/mod.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, sync::Arc};
 
 use rolldown::{BundlerOptions, InputItem};
 use rolldown_plugin::{
-  HookResolveIdArgs, HookResolveIdOutput, HookResolveIdReturn, Plugin, SharedPluginContext,
+  HookResolveIdArgs, HookResolveIdOutput, HookResolveIdReturn, Plugin, PluginContext,
 };
 use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
 
@@ -16,7 +16,7 @@ impl Plugin for UnresolvedImport {
 
   async fn resolve_id(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     args: &HookResolveIdArgs<'_>,
   ) -> HookResolveIdReturn {
     if args.specifier == "test.js" {

--- a/crates/rolldown/tests/rolldown/issues/1733/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/1733/mod.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, sync::Arc};
 
 use rolldown::{BundlerOptions, InputItem};
 use rolldown_plugin::{
-  HookResolveIdArgs, HookResolveIdOutput, HookResolveIdReturn, Plugin, SharedPluginContext,
+  HookResolveIdArgs, HookResolveIdOutput, HookResolveIdReturn, Plugin, PluginContext,
 };
 use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
 use sugar_path::SugarPath;
@@ -17,7 +17,7 @@ impl Plugin for ExternalCss {
 
   async fn resolve_id(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     args: &HookResolveIdArgs<'_>,
   ) -> HookResolveIdReturn {
     if args.specifier.as_path().extension().map_or(false, |ext| ext.eq_ignore_ascii_case("css")) {

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/mod.rs
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/mod.rs
@@ -3,8 +3,8 @@ use std::{borrow::Cow, sync::Arc};
 use rolldown::{BundlerOptions, InputItem};
 use rolldown_plugin::{
   typedmap::{TypedDashMap, TypedMapKey},
-  HookResolveIdArgs, HookResolveIdOutput, HookResolveIdReturn, Plugin, PluginContextResolveOptions,
-  SharedPluginContext,
+  HookResolveIdArgs, HookResolveIdOutput, HookResolveIdReturn, Plugin, PluginContext,
+  PluginContextResolveOptions,
 };
 use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
 #[derive(Debug)]
@@ -26,7 +26,7 @@ impl Plugin for TestPluginCaller {
 
   async fn resolve_id(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     args: &HookResolveIdArgs<'_>,
   ) -> HookResolveIdReturn {
     if args.specifier == "foo" {
@@ -65,7 +65,7 @@ impl Plugin for TestPluginReceiver {
 
   async fn resolve_id(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     args: &HookResolveIdArgs<'_>,
   ) -> HookResolveIdReturn {
     if let Some(value) = args.custom.get::<MyArg>(&MyArg { id: 0 }) {

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use napi_derive::napi;
 
-use rolldown_plugin::SharedPluginContext;
+use rolldown_plugin::PluginContext;
 
 use crate::{types::binding_module_info::BindingModuleInfo, utils::napi_error};
 
@@ -14,7 +14,7 @@ use super::types::{
 #[napi]
 pub struct BindingPluginContext {
   #[allow(dead_code)]
-  inner: SharedPluginContext,
+  inner: PluginContext,
 }
 
 #[napi]
@@ -63,8 +63,8 @@ impl BindingPluginContext {
   }
 }
 
-impl From<SharedPluginContext> for BindingPluginContext {
-  fn from(inner: SharedPluginContext) -> Self {
+impl From<PluginContext> for BindingPluginContext {
+  fn from(inner: PluginContext) -> Self {
     Self { inner }
   }
 }

--- a/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use napi_derive::napi;
 
 use rolldown_plugin::TransformPluginContext;
@@ -26,6 +24,6 @@ impl BindingTransformPluginContext {
 
   #[napi]
   pub fn inner(&self) -> BindingPluginContext {
-    Arc::clone(&self.inner.inner).into()
+    self.inner.inner.clone().into()
   }
 }

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -57,10 +57,10 @@ impl Plugin for JsPlugin {
 
   async fn build_start(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.build_start {
-      cb.await_call(Arc::clone(ctx).into()).await?;
+      cb.await_call(ctx.clone().into()).await?;
     }
     Ok(())
   }
@@ -71,7 +71,7 @@ impl Plugin for JsPlugin {
 
   async fn resolve_id(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookResolveIdArgs<'_>,
   ) -> rolldown_plugin::HookResolveIdReturn {
     if let Some(cb) = &self.resolve_id {
@@ -81,7 +81,7 @@ impl Plugin for JsPlugin {
         .map(|v| *v);
       Ok(
         cb.await_call((
-          Arc::clone(ctx).into(),
+          ctx.clone().into(),
           args.specifier.to_string(),
           args.importer.map(str::to_string),
           BindingHookResolveIdExtraArgs {
@@ -104,13 +104,13 @@ impl Plugin for JsPlugin {
 
   async fn resolve_dynamic_import(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookResolveIdArgs<'_>,
   ) -> rolldown_plugin::HookResolveIdReturn {
     if let Some(cb) = &self.resolve_dynamic_import {
       Ok(
         cb.await_call((
-          Arc::clone(ctx).into(),
+          ctx.clone().into(),
           args.specifier.to_string(),
           args.importer.map(str::to_string),
         ))
@@ -128,12 +128,12 @@ impl Plugin for JsPlugin {
 
   async fn load(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookLoadArgs<'_>,
   ) -> rolldown_plugin::HookLoadReturn {
     if let Some(cb) = &self.load {
       Ok(
-        cb.await_call((Arc::clone(ctx).into(), args.id.to_string()))
+        cb.await_call((ctx.clone().into(), args.id.to_string()))
           .await?
           .map(TryInto::try_into)
           .transpose()?,
@@ -175,11 +175,11 @@ impl Plugin for JsPlugin {
 
   async fn module_parsed(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     module_info: Arc<rolldown_common::ModuleInfo>,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.module_parsed {
-      cb.await_call((Arc::clone(ctx).into(), BindingModuleInfo::new(module_info))).await?;
+      cb.await_call((ctx.clone().into(), BindingModuleInfo::new(module_info))).await?;
     }
     Ok(())
   }
@@ -190,11 +190,11 @@ impl Plugin for JsPlugin {
 
   async fn build_end(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: Option<&rolldown_plugin::HookBuildEndArgs>,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.build_end {
-      cb.await_call((Arc::clone(ctx).into(), args.map(|a| a.error.to_string()))).await?;
+      cb.await_call((ctx.clone().into(), args.map(|a| a.error.to_string()))).await?;
     }
     Ok(())
   }
@@ -207,10 +207,10 @@ impl Plugin for JsPlugin {
 
   async fn render_start(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.render_start {
-      cb.await_call(Arc::clone(ctx).into()).await?;
+      cb.await_call(ctx.clone().into()).await?;
     }
     Ok(())
   }
@@ -221,12 +221,12 @@ impl Plugin for JsPlugin {
 
   async fn banner(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookInjectionArgs<'_>,
   ) -> rolldown_plugin::HookInjectionOutputReturn {
     if let Some(cb) = &self.banner {
       Ok(
-        cb.await_call((Arc::clone(ctx).into(), args.chunk.clone().into()))
+        cb.await_call((ctx.clone().into(), args.chunk.clone().into()))
           .await?
           .map(TryInto::try_into)
           .transpose()?,
@@ -242,12 +242,12 @@ impl Plugin for JsPlugin {
 
   async fn intro(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookInjectionArgs<'_>,
   ) -> rolldown_plugin::HookInjectionOutputReturn {
     if let Some(cb) = &self.intro {
       Ok(
-        cb.await_call((Arc::clone(ctx).into(), args.chunk.clone().into()))
+        cb.await_call((ctx.clone().into(), args.chunk.clone().into()))
           .await?
           .map(TryInto::try_into)
           .transpose()?,
@@ -263,12 +263,12 @@ impl Plugin for JsPlugin {
 
   async fn outro(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookInjectionArgs<'_>,
   ) -> rolldown_plugin::HookInjectionOutputReturn {
     if let Some(cb) = &self.outro {
       Ok(
-        cb.await_call((Arc::clone(ctx).into(), args.chunk.clone().into()))
+        cb.await_call((ctx.clone().into(), args.chunk.clone().into()))
           .await?
           .map(TryInto::try_into)
           .transpose()?,
@@ -284,12 +284,12 @@ impl Plugin for JsPlugin {
 
   async fn footer(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookInjectionArgs<'_>,
   ) -> rolldown_plugin::HookInjectionOutputReturn {
     if let Some(cb) = &self.footer {
       Ok(
-        cb.await_call((Arc::clone(ctx).into(), args.chunk.clone().into()))
+        cb.await_call((ctx.clone().into(), args.chunk.clone().into()))
           .await?
           .map(TryInto::try_into)
           .transpose()?,
@@ -305,12 +305,12 @@ impl Plugin for JsPlugin {
 
   async fn render_chunk(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookRenderChunkArgs<'_>,
   ) -> rolldown_plugin::HookRenderChunkReturn {
     if let Some(cb) = &self.render_chunk {
       Ok(
-        cb.await_call((Arc::clone(ctx).into(), args.code.to_string(), args.chunk.clone().into()))
+        cb.await_call((ctx.clone().into(), args.code.to_string(), args.chunk.clone().into()))
           .await?
           .map(TryInto::try_into)
           .transpose()?,
@@ -326,11 +326,11 @@ impl Plugin for JsPlugin {
 
   async fn augment_chunk_hash(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     chunk: &rolldown_common::RollupRenderedChunk,
   ) -> rolldown_plugin::HookAugmentChunkHashReturn {
     if let Some(cb) = &self.augment_chunk_hash {
-      Ok(cb.await_call((Arc::clone(ctx).into(), chunk.clone().into())).await?)
+      Ok(cb.await_call((ctx.clone().into(), chunk.clone().into())).await?)
     } else {
       Ok(None)
     }
@@ -342,11 +342,11 @@ impl Plugin for JsPlugin {
 
   async fn render_error(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookRenderErrorArgs,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.render_error {
-      cb.await_call((Arc::clone(ctx).into(), args.error.to_string())).await?;
+      cb.await_call((ctx.clone().into(), args.error.to_string())).await?;
     }
     Ok(())
   }
@@ -357,13 +357,13 @@ impl Plugin for JsPlugin {
 
   async fn generate_bundle(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     bundle: &mut Vec<rolldown_common::Output>,
     is_write: bool,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.generate_bundle {
       let old_bundle = UniqueArc::new(Mutex::new(mem::take(bundle)));
-      cb.await_call((Arc::clone(ctx).into(), BindingOutputs::new(old_bundle.weak_ref()), is_write))
+      cb.await_call((ctx.clone().into(), BindingOutputs::new(old_bundle.weak_ref()), is_write))
         .await?;
       *bundle = old_bundle.into_inner().into_inner()?;
     }
@@ -376,12 +376,12 @@ impl Plugin for JsPlugin {
 
   async fn write_bundle(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     bundle: &mut Vec<rolldown_common::Output>,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.write_bundle {
       let old_bundle = UniqueArc::new(Mutex::new(mem::take(bundle)));
-      cb.await_call((Arc::clone(ctx).into(), BindingOutputs::new(old_bundle.weak_ref()))).await?;
+      cb.await_call((ctx.clone().into(), BindingOutputs::new(old_bundle.weak_ref()))).await?;
       *bundle = old_bundle.into_inner().into_inner()?;
     }
     Ok(())

--- a/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
@@ -75,7 +75,7 @@ impl Plugin for ParallelJsPlugin {
 
   async fn build_start(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
   ) -> rolldown_plugin::HookNoopReturn {
     if self.first_plugin().build_start.is_some() {
       self.run_all(|plugin| plugin.call_build_start(ctx)).await?;
@@ -85,7 +85,7 @@ impl Plugin for ParallelJsPlugin {
 
   async fn resolve_id(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookResolveIdArgs<'_>,
   ) -> rolldown_plugin::HookResolveIdReturn {
     if self.first_plugin().resolve_id.is_some() {
@@ -97,7 +97,7 @@ impl Plugin for ParallelJsPlugin {
 
   async fn load(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookLoadArgs<'_>,
   ) -> rolldown_plugin::HookLoadReturn {
     if self.first_plugin().load.is_some() {
@@ -121,7 +121,7 @@ impl Plugin for ParallelJsPlugin {
 
   async fn build_end(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: Option<&rolldown_plugin::HookBuildEndArgs>,
   ) -> rolldown_plugin::HookNoopReturn {
     if self.first_plugin().build_end.is_some() {
@@ -132,7 +132,7 @@ impl Plugin for ParallelJsPlugin {
 
   async fn render_chunk(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookRenderChunkArgs<'_>,
   ) -> rolldown_plugin::HookRenderChunkReturn {
     if self.first_plugin().render_chunk.is_some() {
@@ -146,7 +146,7 @@ impl Plugin for ParallelJsPlugin {
 
   async fn generate_bundle(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     bundle: &mut Vec<rolldown_common::Output>,
     is_write: bool,
   ) -> rolldown_plugin::HookNoopReturn {
@@ -159,7 +159,7 @@ impl Plugin for ParallelJsPlugin {
 
   async fn write_bundle(
     &self,
-    ctx: &rolldown_plugin::SharedPluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     bundle: &mut Vec<rolldown_common::Output>,
   ) -> rolldown_plugin::HookNoopReturn {
     if self.first_plugin().write_bundle.is_some() {

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -21,7 +21,7 @@ pub use crate::{
     HookRenderChunkReturn, HookResolveIdReturn, HookTransformAstReturn, HookTransformReturn,
     Plugin,
   },
-  plugin_context::{PluginContext, SharedPluginContext},
+  plugin_context::PluginContext,
   plugin_driver::{PluginDriver, SharedPluginDriver},
   plugin_hook_meta::{PluginHookMeta, PluginOrder},
   transform_plugin_context::TransformPluginContext,

--- a/crates/rolldown_plugin/src/plugin.rs
+++ b/crates/rolldown_plugin/src/plugin.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, borrow::Cow, fmt::Debug, sync::Arc};
 
-use super::plugin_context::SharedPluginContext;
+use super::plugin_context::PluginContext;
 use crate::{
   plugin_hook_meta::PluginHookMeta,
   transform_plugin_context::TransformPluginContext,
@@ -33,7 +33,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn build_start(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
   ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
     async { Ok(()) }
   }
@@ -44,7 +44,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn resolve_id(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookResolveIdArgs<'_>,
   ) -> impl std::future::Future<Output = HookResolveIdReturn> + Send {
     async { Ok(None) }
@@ -59,7 +59,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
   )]
   fn resolve_dynamic_import(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookResolveIdArgs<'_>,
   ) -> impl std::future::Future<Output = HookResolveIdReturn> + Send {
     async { Ok(None) }
@@ -71,7 +71,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn load(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookLoadArgs<'_>,
   ) -> impl std::future::Future<Output = HookLoadReturn> + Send {
     async { Ok(None) }
@@ -95,7 +95,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn module_parsed(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _module_info: Arc<ModuleInfo>,
   ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
     async { Ok(()) }
@@ -107,7 +107,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn build_end(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: Option<&HookBuildEndArgs>,
   ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
     async { Ok(()) }
@@ -121,7 +121,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn render_start(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
   ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
     async { Ok(()) }
   }
@@ -132,7 +132,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn banner(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookInjectionArgs<'_>,
   ) -> impl std::future::Future<Output = HookInjectionOutputReturn> + Send {
     async { Ok(None) }
@@ -144,7 +144,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn footer(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookInjectionArgs<'_>,
   ) -> impl std::future::Future<Output = HookInjectionOutputReturn> + Send {
     async { Ok(None) }
@@ -156,7 +156,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn intro(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookInjectionArgs<'_>,
   ) -> impl std::future::Future<Output = HookInjectionOutputReturn> + Send {
     async { Ok(None) }
@@ -168,7 +168,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn outro(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookInjectionArgs<'_>,
   ) -> impl std::future::Future<Output = HookInjectionOutputReturn> + Send {
     async { Ok(None) }
@@ -180,7 +180,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn render_chunk(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookRenderChunkArgs<'_>,
   ) -> impl std::future::Future<Output = HookRenderChunkReturn> + Send {
     async { Ok(None) }
@@ -192,7 +192,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn augment_chunk_hash(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _chunk: &RollupRenderedChunk,
   ) -> impl std::future::Future<Output = HookAugmentChunkHashReturn> + Send {
     async { Ok(None) }
@@ -204,7 +204,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn render_error(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookRenderErrorArgs,
   ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
     async { Ok(()) }
@@ -216,7 +216,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn generate_bundle(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _bundle: &mut Vec<Output>,
     _is_write: bool,
   ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
@@ -229,7 +229,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn write_bundle(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _bundle: &mut Vec<Output>,
   ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
     async { Ok(()) }
@@ -243,7 +243,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
 
   fn transform_ast(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     args: HookTransformAstArgs,
   ) -> HookTransformAstReturn {
     Ok(args.ast)

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -84,14 +84,15 @@ impl PluginDriver {
       }
       if let Some(r) = plugin
         .call_resolve_id(
-          &skipped_resolve_calls
-            .map(|skipped_resolve_calls| {
+          &skipped_resolve_calls.map_or_else(
+            || ctx.clone(),
+            |skipped_resolve_calls| {
               PluginContext::new_shared_with_skipped_resolve_calls(
                 ctx,
                 skipped_resolve_calls.clone(),
               )
-            })
-            .unwrap_or(Arc::clone(ctx)),
+            },
+          ),
           args,
         )
         .await?
@@ -119,14 +120,15 @@ impl PluginDriver {
       }
       if let Some(r) = plugin
         .call_resolve_dynamic_import(
-          &skipped_resolve_calls
-            .map(|skipped_resolve_calls| {
+          &skipped_resolve_calls.map_or_else(
+            || ctx.clone(),
+            |skipped_resolve_calls| {
               PluginContext::new_shared_with_skipped_resolve_calls(
                 ctx,
                 skipped_resolve_calls.clone(),
               )
-            })
-            .unwrap_or(Arc::clone(ctx)),
+            },
+          ),
           args,
         )
         .await?
@@ -158,7 +160,7 @@ impl PluginDriver {
     for (_, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_transform_meta) {
       if let Some(r) = plugin
         .call_transform(
-          &TransformPluginContext::new(Arc::clone(ctx), sourcemap_chain, original_code, args.id),
+          &TransformPluginContext::new(ctx.clone(), sourcemap_chain, original_code, args.id),
           &HookTransformArgs { id: args.id, code: &code, module_type: &*module_type },
         )
         .await?

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -9,9 +9,10 @@ use rolldown_resolver::Resolver;
 
 use crate::{
   __inner::SharedPluginable,
+  plugin_context::PluginContextImpl,
   type_aliases::{IndexPluginContext, IndexPluginable},
   types::plugin_idx::PluginIdx,
-  PluginContext, PluginHookMeta, PluginOrder, SharedPluginContext,
+  PluginContext, PluginHookMeta, PluginOrder,
 };
 
 mod build_hooks;
@@ -38,7 +39,7 @@ impl PluginDriver {
       plugins.into_iter().for_each(|plugin| {
         let plugin_idx = index_plugins.push(Arc::clone(&plugin));
         index_contexts.push(
-          PluginContext {
+          PluginContextImpl {
             skipped_resolve_calls: vec![],
             plugin_idx,
             plugin_driver: Weak::clone(plugin_driver),
@@ -69,7 +70,7 @@ impl PluginDriver {
       self.plugins.iter().zip(self.contexts.iter()).for_each(|(plugin, ctx)| {
         let plugin_idx = index_plugins.push(Arc::clone(plugin));
         index_contexts.push(
-          PluginContext {
+          PluginContextImpl {
             skipped_resolve_calls: vec![],
             plugin_idx,
             plugin_driver: Weak::clone(plugin_driver),
@@ -92,7 +93,7 @@ impl PluginDriver {
   pub fn iter_plugin_with_context_by_order<'me>(
     &'me self,
     ordered_plugins: &'me [PluginIdx],
-  ) -> impl Iterator<Item = (PluginIdx, &SharedPluginable, &SharedPluginContext)> + 'me {
+  ) -> impl Iterator<Item = (PluginIdx, &SharedPluginable, &PluginContext)> + 'me {
     ordered_plugins.iter().copied().map(move |idx| {
       let plugin = &self.plugins[idx];
       let context = &self.contexts[idx];

--- a/crates/rolldown_plugin/src/pluginable.rs
+++ b/crates/rolldown_plugin/src/pluginable.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, borrow::Cow, fmt::Debug, sync::Arc};
 
-use super::plugin_context::SharedPluginContext;
+use super::plugin_context::PluginContext;
 use crate::{
   plugin_hook_meta::PluginHookMeta,
   transform_plugin_context::TransformPluginContext,
@@ -34,13 +34,13 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   // --- Build hooks ---
 
-  async fn call_build_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn;
+  async fn call_build_start(&self, _ctx: &PluginContext) -> HookNoopReturn;
 
   fn call_build_start_meta(&self) -> Option<PluginHookMeta>;
 
   async fn call_resolve_id(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookResolveIdArgs,
   ) -> HookResolveIdReturn;
 
@@ -51,13 +51,13 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
   )]
   async fn call_resolve_dynamic_import(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookResolveIdArgs,
   ) -> HookResolveIdReturn;
 
   fn call_resolve_dynamic_import_meta(&self) -> Option<PluginHookMeta>;
 
-  async fn call_load(&self, _ctx: &SharedPluginContext, _args: &HookLoadArgs) -> HookLoadReturn;
+  async fn call_load(&self, _ctx: &PluginContext, _args: &HookLoadArgs) -> HookLoadReturn;
 
   fn call_load_meta(&self) -> Option<PluginHookMeta>;
 
@@ -71,7 +71,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   fn call_transform_ast(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     args: HookTransformAstArgs,
   ) -> HookTransformAstReturn;
 
@@ -79,7 +79,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   async fn call_module_parsed(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _module_info: Arc<ModuleInfo>,
   ) -> HookNoopReturn;
 
@@ -87,7 +87,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   async fn call_build_end(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: Option<&HookBuildEndArgs>,
   ) -> HookNoopReturn;
 
@@ -95,13 +95,13 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   // --- Generate hooks ---
 
-  async fn call_render_start(&self, _ctx: &SharedPluginContext) -> HookNoopReturn;
+  async fn call_render_start(&self, _ctx: &PluginContext) -> HookNoopReturn;
 
   fn call_render_start_meta(&self) -> Option<PluginHookMeta>;
 
   async fn call_banner(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookInjectionArgs,
   ) -> HookInjectionOutputReturn;
 
@@ -109,7 +109,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   async fn call_footer(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookInjectionArgs,
   ) -> HookInjectionOutputReturn;
 
@@ -117,7 +117,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   async fn call_intro(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookInjectionArgs,
   ) -> HookInjectionOutputReturn;
 
@@ -125,7 +125,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   async fn call_outro(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookInjectionArgs,
   ) -> HookInjectionOutputReturn;
 
@@ -133,7 +133,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   async fn call_render_chunk(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookRenderChunkArgs,
   ) -> HookRenderChunkReturn;
 
@@ -141,7 +141,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   async fn call_augment_chunk_hash(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _chunk: &RollupRenderedChunk,
   ) -> HookAugmentChunkHashReturn;
 
@@ -149,7 +149,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   async fn call_render_error(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _args: &HookRenderErrorArgs,
   ) -> HookNoopReturn;
 
@@ -157,7 +157,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   async fn call_generate_bundle(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _bundle: &mut Vec<Output>,
     _is_write: bool,
   ) -> HookNoopReturn;
@@ -166,7 +166,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
 
   async fn call_write_bundle(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     _bundle: &mut Vec<Output>,
   ) -> HookNoopReturn;
 
@@ -179,7 +179,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::name(self)
   }
 
-  async fn call_build_start(&self, ctx: &SharedPluginContext) -> HookNoopReturn {
+  async fn call_build_start(&self, ctx: &PluginContext) -> HookNoopReturn {
     Plugin::build_start(self, ctx).await
   }
 
@@ -189,7 +189,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_resolve_id(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     args: &HookResolveIdArgs,
   ) -> HookResolveIdReturn {
     Plugin::resolve_id(self, ctx, args).await
@@ -202,7 +202,7 @@ impl<T: Plugin> Pluginable for T {
   #[allow(deprecated)]
   async fn call_resolve_dynamic_import(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     args: &HookResolveIdArgs,
   ) -> HookResolveIdReturn {
     Plugin::resolve_dynamic_import(self, ctx, args).await
@@ -212,7 +212,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::resolve_dynamic_import_meta(self)
   }
 
-  async fn call_load(&self, ctx: &SharedPluginContext, args: &HookLoadArgs) -> HookLoadReturn {
+  async fn call_load(&self, ctx: &PluginContext, args: &HookLoadArgs) -> HookLoadReturn {
     Plugin::load(self, ctx, args).await
   }
 
@@ -234,7 +234,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_module_parsed(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     module_info: Arc<ModuleInfo>,
   ) -> HookNoopReturn {
     Plugin::module_parsed(self, ctx, module_info).await
@@ -246,7 +246,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_build_end(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     args: Option<&HookBuildEndArgs>,
   ) -> HookNoopReturn {
     Plugin::build_end(self, ctx, args).await
@@ -256,7 +256,7 @@ impl<T: Plugin> Pluginable for T {
     Plugin::build_end_meta(self)
   }
 
-  async fn call_render_start(&self, ctx: &SharedPluginContext) -> HookNoopReturn {
+  async fn call_render_start(&self, ctx: &PluginContext) -> HookNoopReturn {
     Plugin::render_start(self, ctx).await
   }
 
@@ -266,7 +266,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_banner(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     args: &HookInjectionArgs,
   ) -> HookInjectionOutputReturn {
     Plugin::banner(self, ctx, args).await
@@ -278,7 +278,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_footer(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     args: &HookInjectionArgs,
   ) -> HookInjectionOutputReturn {
     Plugin::footer(self, ctx, args).await
@@ -290,7 +290,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_intro(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     args: &HookInjectionArgs,
   ) -> HookInjectionOutputReturn {
     Plugin::intro(self, ctx, args).await
@@ -302,7 +302,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_outro(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     args: &HookInjectionArgs,
   ) -> HookInjectionOutputReturn {
     Plugin::outro(self, ctx, args).await
@@ -314,7 +314,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_render_chunk(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     args: &HookRenderChunkArgs,
   ) -> HookRenderChunkReturn {
     Plugin::render_chunk(self, ctx, args).await
@@ -326,7 +326,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_augment_chunk_hash(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     chunk: &RollupRenderedChunk,
   ) -> HookAugmentChunkHashReturn {
     Plugin::augment_chunk_hash(self, ctx, chunk).await
@@ -338,7 +338,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_render_error(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     args: &HookRenderErrorArgs,
   ) -> HookNoopReturn {
     Plugin::render_error(self, ctx, args).await
@@ -350,7 +350,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_generate_bundle(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     bundle: &mut Vec<Output>,
     is_write: bool,
   ) -> HookNoopReturn {
@@ -363,7 +363,7 @@ impl<T: Plugin> Pluginable for T {
 
   async fn call_write_bundle(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     bundle: &mut Vec<Output>,
   ) -> HookNoopReturn {
     Plugin::write_bundle(self, ctx, bundle).await
@@ -375,7 +375,7 @@ impl<T: Plugin> Pluginable for T {
 
   fn call_transform_ast(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     args: HookTransformAstArgs,
   ) -> HookTransformAstReturn {
     Plugin::transform_ast(self, ctx, args)

--- a/crates/rolldown_plugin/src/transform_plugin_context.rs
+++ b/crates/rolldown_plugin/src/transform_plugin_context.rs
@@ -1,10 +1,10 @@
-use crate::SharedPluginContext;
+use crate::PluginContext;
 use rolldown_sourcemap::SourceMap;
 
 #[allow(unused)]
 #[derive(Debug)]
 pub struct TransformPluginContext<'a> {
-  pub inner: SharedPluginContext,
+  pub inner: PluginContext,
   sourcemap_chain: &'a Vec<SourceMap>,
   original_code: &'a str,
   id: &'a str,
@@ -12,7 +12,7 @@ pub struct TransformPluginContext<'a> {
 
 impl<'a> TransformPluginContext<'a> {
   pub fn new(
-    inner: SharedPluginContext,
+    inner: PluginContext,
     sourcemap_chain: &'a Vec<SourceMap>,
     original_code: &'a str,
     id: &'a str,

--- a/crates/rolldown_plugin/src/type_aliases.rs
+++ b/crates/rolldown_plugin/src/type_aliases.rs
@@ -1,6 +1,6 @@
 use oxc_index::IndexVec;
 
-use crate::{__inner::SharedPluginable, types::plugin_idx::PluginIdx, SharedPluginContext};
+use crate::{__inner::SharedPluginable, types::plugin_idx::PluginIdx, PluginContext};
 
 pub type IndexPluginable = IndexVec<PluginIdx, SharedPluginable>;
-pub type IndexPluginContext = IndexVec<PluginIdx, SharedPluginContext>;
+pub type IndexPluginContext = IndexVec<PluginIdx, PluginContext>;

--- a/crates/rolldown_plugin_data_url/src/data_url_plugin.rs
+++ b/crates/rolldown_plugin_data_url/src/data_url_plugin.rs
@@ -4,7 +4,7 @@ use dashmap::DashMap;
 use rolldown_common::ModuleType;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
-  HookResolveIdReturn, Plugin, SharedPluginContext,
+  HookResolveIdReturn, Plugin, PluginContext,
 };
 use rustc_hash::FxBuildHasher;
 
@@ -28,7 +28,7 @@ impl Plugin for DataUrlPlugin {
 
   fn resolve_id(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     args: &HookResolveIdArgs<'_>,
   ) -> impl std::future::Future<Output = HookResolveIdReturn> {
     async {
@@ -66,7 +66,7 @@ impl Plugin for DataUrlPlugin {
 
   fn load(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     args: &HookLoadArgs<'_>,
   ) -> impl std::future::Future<Output = HookLoadReturn> + Send {
     async {

--- a/crates/rolldown_plugin_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_dynamic_import_vars/src/lib.rs
@@ -9,7 +9,7 @@ use oxc::{
 use parse_pattern::{parse_pattern, DynamicImportPattern, DynamicImportRequest};
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
-  HookResolveIdReturn, HookTransformAstArgs, HookTransformAstReturn, Plugin, SharedPluginContext,
+  HookResolveIdReturn, HookTransformAstArgs, HookTransformAstReturn, Plugin, PluginContext,
 };
 use std::borrow::Cow;
 use to_glob::to_glob_pattern;
@@ -29,7 +29,7 @@ impl Plugin for DynamicImportVarsPlugin {
 
   async fn resolve_id(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     args: &HookResolveIdArgs<'_>,
   ) -> HookResolveIdReturn {
     if args.specifier == DYNAMIC_IMPORT_HELPER {
@@ -39,7 +39,7 @@ impl Plugin for DynamicImportVarsPlugin {
     }
   }
 
-  async fn load(&self, _ctx: &SharedPluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
+  async fn load(&self, _ctx: &PluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
     if args.id == DYNAMIC_IMPORT_HELPER {
       Ok(Some(HookLoadOutput {
         code: include_str!("dynamic_import_helper.js").to_string(),
@@ -52,7 +52,7 @@ impl Plugin for DynamicImportVarsPlugin {
 
   fn transform_ast(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     mut args: HookTransformAstArgs,
   ) -> HookTransformAstReturn {
     // TODO: Ignore if includes a marker like "/* @rolldown-ignore */"

--- a/crates/rolldown_plugin_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_import_glob/src/lib.rs
@@ -12,7 +12,7 @@ use oxc::{
   },
   span::{Span, SPAN},
 };
-use rolldown_plugin::{HookTransformAstArgs, HookTransformAstReturn, Plugin, SharedPluginContext};
+use rolldown_plugin::{HookTransformAstArgs, HookTransformAstReturn, Plugin, PluginContext};
 use rustc_hash::FxHashMap;
 use std::{
   borrow::Cow,
@@ -40,7 +40,7 @@ impl Plugin for ImportGlobPlugin {
 
   fn transform_ast(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     mut args: HookTransformAstArgs,
   ) -> HookTransformAstReturn {
     args.ast.program.with_mut(|fields| {

--- a/crates/rolldown_plugin_load_fallback/src/lib.rs
+++ b/crates/rolldown_plugin_load_fallback/src/lib.rs
@@ -1,4 +1,4 @@
-use rolldown_plugin::{HookLoadArgs, HookLoadOutput, HookLoadReturn, Plugin, SharedPluginContext};
+use rolldown_plugin::{HookLoadArgs, HookLoadOutput, HookLoadReturn, Plugin, PluginContext};
 use rolldown_utils::path_ext::clean_url;
 use std::borrow::Cow;
 
@@ -10,7 +10,7 @@ impl Plugin for LoadFallbackPlugin {
     Cow::Borrowed("builtin:load-fallback")
   }
 
-  async fn load(&self, _ctx: &SharedPluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
+  async fn load(&self, _ctx: &PluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
     let normalized_id = clean_url(args.id);
     let code = std::fs::read_to_string(normalized_id)?;
     Ok(Some(HookLoadOutput { code, ..Default::default() }))

--- a/crates/rolldown_plugin_manifest/src/lib.rs
+++ b/crates/rolldown_plugin_manifest/src/lib.rs
@@ -1,5 +1,5 @@
 use rolldown_common::{EmittedAsset, ModuleId, Output, OutputAsset, OutputChunk};
-use rolldown_plugin::{HookNoopReturn, Plugin, SharedPluginContext};
+use rolldown_plugin::{HookNoopReturn, Plugin, PluginContext};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
 use std::{borrow::Cow, collections::BTreeMap, path::Path, rc::Rc, sync::LazyLock};
@@ -33,7 +33,7 @@ impl Plugin for ManifestPlugin {
   #[allow(clippy::case_sensitive_file_extension_comparisons)]
   async fn generate_bundle(
     &self,
-    ctx: &SharedPluginContext,
+    ctx: &PluginContext,
     bundle: &mut Vec<Output>,
     _is_write: bool,
   ) -> HookNoopReturn {

--- a/crates/rolldown_plugin_module_preload_polyfill/src/lib.rs
+++ b/crates/rolldown_plugin_module_preload_polyfill/src/lib.rs
@@ -1,7 +1,7 @@
 use rolldown_common::side_effects::HookSideEffects;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
-  HookResolveIdReturn, Plugin, SharedPluginContext,
+  HookResolveIdReturn, Plugin, PluginContext,
 };
 use std::borrow::Cow;
 
@@ -26,7 +26,7 @@ impl Plugin for ModulePreloadPolyfillPlugin {
 
   async fn resolve_id(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     args: &HookResolveIdArgs<'_>,
   ) -> HookResolveIdReturn {
     Ok((args.specifier == MODULE_PRELOAD_POLYFILL).then(|| HookResolveIdOutput {
@@ -35,7 +35,7 @@ impl Plugin for ModulePreloadPolyfillPlugin {
     }))
   }
 
-  async fn load(&self, _ctx: &SharedPluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
+  async fn load(&self, _ctx: &PluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
     if self.skip {
       return Ok(Some(HookLoadOutput::default()));
     }

--- a/crates/rolldown_plugin_wasm/src/lib.rs
+++ b/crates/rolldown_plugin_wasm/src/lib.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, fs, path::Path};
 use rolldown_common::{AssetSource, EmittedAsset};
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
-  HookResolveIdReturn, Plugin, SharedPluginContext,
+  HookResolveIdReturn, Plugin, PluginContext,
 };
 
 const WASM_RUNTIME: &str = "\0rolldown_wasm_runtime.js";
@@ -18,7 +18,7 @@ impl Plugin for WasmPlugin {
 
   async fn resolve_id(
     &self,
-    _ctx: &SharedPluginContext,
+    _ctx: &PluginContext,
     args: &HookResolveIdArgs<'_>,
   ) -> HookResolveIdReturn {
     if args.specifier == WASM_RUNTIME {
@@ -28,7 +28,7 @@ impl Plugin for WasmPlugin {
     }
   }
 
-  async fn load(&self, ctx: &SharedPluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
+  async fn load(&self, ctx: &PluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
     if args.id == WASM_RUNTIME {
       return Ok(Some(HookLoadOutput {
         code: include_str!("wasm_runtime.js").to_string(),

--- a/crates/rolldown_plugin_wasm_fallback/src/lib.rs
+++ b/crates/rolldown_plugin_wasm_fallback/src/lib.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use rolldown_plugin::{HookLoadArgs, HookLoadReturn, Plugin, SharedPluginContext};
+use rolldown_plugin::{HookLoadArgs, HookLoadReturn, Plugin, PluginContext};
 
 #[derive(Debug)]
 pub struct WasmFallbackPlugin {}
@@ -11,7 +11,7 @@ impl Plugin for WasmFallbackPlugin {
   }
 
   #[allow(clippy::case_sensitive_file_extension_comparisons)]
-  async fn load(&self, _ctx: &SharedPluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
+  async fn load(&self, _ctx: &PluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
     if args.id.ends_with(".wasm") {
       // TODO: Replace the link here after rolldown's document is ready
       Err(anyhow::anyhow!(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`Shared` is a detail that is no need to be told to outside. It's also meaningless to repeat it in every place.