### PR TITLE
refactor: using `skip` to skip first element in `include_module`

### DIFF
--- a/crates/rolldown/src/stages/link_stage/tree_shaking.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking.rs
@@ -25,12 +25,9 @@ struct Context<'a> {
 /// if no export is used, and the module has no side effects, the module should not be included
 fn include_module(ctx: &mut Context, module: &EcmaModule) {
   fn forcefully_include_all_statements(ctx: &mut Context, module: &EcmaModule) {
-    module.stmt_infos.iter_enumerated().for_each(|(stmt_info_id, _stmt_info)| {
-      // Skip the first statement, which is the namespace object. It should be included only if it is used no matter
-      // tree shaking is enabled or not.
-      if stmt_info_id.index() == 0 {
-        return;
-      }
+    // Skip the first statement, which is the namespace object. It should be included only if it is used no matter
+    // tree shaking is enabled or not.
+    module.stmt_infos.iter_enumerated().skip(1).for_each(|(stmt_info_id, _stmt_info)| {
       include_statement(ctx, module, stmt_info_id);
     });
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
