### PR TITLE
chore: 🤖 update diagnostic message

### DIFF
--- a/crates/rolldown/tests/rolldown/errors/unresolved_import/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/unresolved_import/basic/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## UNLOADABLE_DEPENDENCY
 
 ```text
-[UNLOADABLE_DEPENDENCY] Error: Could not resolve test.js
+[UNLOADABLE_DEPENDENCY] Error: Could not load test.js
    ╭─[entry.js:1:18]
    │
  1 │ import test from 'test.js'

--- a/crates/rolldown_error/src/events/unloadable_dependency.rs
+++ b/crates/rolldown_error/src/events/unloadable_dependency.rs
@@ -25,7 +25,7 @@ impl BuildEvent for UnloadableDependency {
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {
     format!(
-      "Could not resolve {}{} - {}.",
+      "Could not load {}{} - {}.",
       self.resolved,
       self
         .context
@@ -44,7 +44,7 @@ impl BuildEvent for UnloadableDependency {
     if let Some(context) = &self.context {
       let importer_file = diagnostic.add_file(context.importer_id.clone(), context.source.clone());
 
-      diagnostic.title = format!(r#"Could not resolve {}"#, self.resolved);
+      diagnostic.title = format!(r#"Could not load {}"#, self.resolved);
 
       diagnostic.add_label(
         &importer_file,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. This diagnostic is used after `load_source` so tweak the message into `load` instead of `resolve`
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
