### PR TITLE
chore: only log files with spelling errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint-code": "oxlint -c .oxlintrc.json --ignore-path=.oxlintignore --import-plugin --jsdoc-plugin --deny-warnings",
     "lint-filename": "echo 'TODO: ls-lint is too slow now'",
     "lint-filename:bak": "ls-lint",
-    "lint-spell": "cspell \"**\"",
+    "lint-spell": "cspell \"**\" --no-progress",
     "lint-prettier": "prettier . '**/*.{js,ts,json,md,yml,yaml,vue}' -c",
     "lint-prettier:fix": "prettier . '**/*.{js,ts,json,md,yml,yaml,vue}' -w",
     "lint-toml": "taplo format --check",


### PR DESCRIPTION
- With issues:
```
(base) ethangoh@Ethans-MacBook-Pro rolldown % pnpm lint-spell

> monorepo@ lint-spell /Users/ethangoh/Developer/rolldown
> cspell "**" --no-progress

README.md:9:1 - Unknown word (slks)
CSpell: Files checked: 1810, Issues found: 1 in 1 file.
 ELIFECYCLE  Command failed with exit code 1.
```
- Without issue:
```
(base) ethangoh@Ethans-MacBook-Pro rolldown % pnpm lint-spell

> monorepo@ lint-spell /Users/ethangoh/Developer/rolldown
> cspell "**" --no-progress

CSpell: Files checked: 1810, Issues found: 0 in 0 files.
```

To enhance the clarity of the outcome and pinpoint the underlying issues (spelling errors).