### PR TITLE
fix: same filenames cause bundle error

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -184,9 +184,6 @@ impl<'a> GenerateStage<'a> {
       let chunk_name_info = &mut index_pre_generated_names[*chunk_id];
 
       let chunk_name = if chunk_name_info.explicit {
-        if used_name_map.contains_key(&chunk_name_info.name) {
-          return Err(anyhow::anyhow!("Chunk name `{}` is already used", chunk_name_info.name));
-        }
         chunk_name_info.name.clone()
       } else {
         let chunk_name = match used_name_map.entry(chunk_name_info.name.clone()) {

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -184,6 +184,9 @@ impl<'a> GenerateStage<'a> {
       let chunk_name_info = &mut index_pre_generated_names[*chunk_id];
 
       let chunk_name = if chunk_name_info.explicit {
+        if used_name_map.contains_key(&chunk_name_info.name) {
+          return Err(anyhow::anyhow!("Chunk name `{}` is already used", chunk_name_info.name));
+        }
         chunk_name_info.name.clone()
       } else {
         let chunk_name = match used_name_map.entry(chunk_name_info.name.clone()) {

--- a/packages/rolldown/src/options/bindingify-input-options.ts
+++ b/packages/rolldown/src/options/bindingify-input-options.ts
@@ -3,7 +3,6 @@ import type {
   BindingInjectImportNamed,
   BindingInjectImportNamespace,
 } from '../binding'
-import nodePath from 'node:path'
 import { bindingifyPlugin } from '../plugin/bindingify-plugin'
 import type { NormalizedInputOptions } from './normalized-input-options'
 import { arraify } from '../utils/misc'
@@ -145,9 +144,7 @@ function bindingifyInput(
 ): BindingInputOptions['input'] {
   if (Array.isArray(input)) {
     return input.map((src) => {
-      const name = nodePath.parse(src).name
       return {
-        name,
         import: src,
       }
     })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

close #1944 

I have thought about it and feel that `@IWANABETHATGUY`'s viewpoint and solution may be more reasonable.

              Looks like `rollup` did not do chunk name deconflict.

_Originally posted by @IWANABETHATGUY in https://github.com/rolldown/rolldown/issues/1944#issuecomment-2282812102_
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
