### PR TITLE
chore: remove unused warning in wasi building.

### DIFF
--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -22,6 +22,6 @@ pub mod options;
 pub mod parallel_js_plugin_registry;
 pub mod types;
 pub mod utils;
-mod worker_manager;
 pub use oxc_transform_napi;
 mod type_aliases;
+pub mod worker_manager;

--- a/crates/rolldown_binding/src/options/plugin/mod.rs
+++ b/crates/rolldown_binding/src/options/plugin/mod.rs
@@ -2,11 +2,14 @@ pub mod binding_plugin_context;
 mod binding_plugin_options;
 mod binding_transform_context;
 mod js_plugin;
-mod parallel_js_plugin;
 pub mod types;
 
 pub use binding_plugin_options::*;
 pub use js_plugin::*;
-pub use parallel_js_plugin::*;
 mod binding_builtin_plugin;
 mod binding_plugin_hook_meta;
+
+#[cfg(not(target_family = "wasm"))]
+mod parallel_js_plugin;
+#[cfg(not(target_family = "wasm"))]
+pub use parallel_js_plugin::*;

--- a/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 #[cfg(not(target_family = "wasm"))]
 use futures::future::{self, BoxFuture};
+#[cfg(not(target_family = "wasm"))]
 use rolldown_plugin::Plugin;
 #[cfg(not(target_family = "wasm"))]
 use rolldown_plugin::__inner::Pluginable;

--- a/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_family = "wasm"))]
+
 #[cfg(not(target_family = "wasm"))]
 use std::borrow::Cow;
 use std::sync::Arc;

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -1,10 +1,7 @@
 use crate::options::binding_inject_import::normalize_binding_inject_import;
-#[cfg_attr(target_family = "wasm", allow(unused))]
 use crate::{
   options::plugin::JsPlugin,
-  options::plugin::ParallelJsPlugin,
   types::{binding_rendered_chunk::RenderedChunk, js_callback::MaybeAsyncJsCallbackExt},
-  worker_manager::WorkerManager,
 };
 use napi::bindgen_prelude::Either;
 use rolldown::{
@@ -14,6 +11,9 @@ use rolldown_plugin::__inner::SharedPluginable;
 use rolldown_utils::indexmap::FxIndexMap;
 use std::collections::HashMap;
 use std::path::PathBuf;
+
+#[cfg(not(target_family = "wasm"))]
+use crate::{options::plugin::ParallelJsPlugin, worker_manager::WorkerManager};
 #[cfg(not(target_family = "wasm"))]
 use std::sync::Arc;
 

--- a/crates/rolldown_binding/src/worker_manager.rs
+++ b/crates/rolldown_binding/src/worker_manager.rs
@@ -1,7 +1,8 @@
+#![cfg(not(target_family = "wasm"))]
+
 use async_channel::{Receiver, Sender};
 
 #[derive(Debug)]
-#[allow(unused)]
 pub struct WorkerManager {
   free_workers_sender: Sender<u16>,
   free_workers_receiver: Receiver<u16>,


### PR DESCRIPTION
Remove the warning:

```
warning: unused import: `rolldown_plugin::Plugin`
 --> crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs:7:5
  |
7 | use rolldown_plugin::Plugin;
  |     ^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```