### PR TITLE
fix(cli): `rolldown -c` should not print help messages

### DIFF
--- a/packages/rolldown/src/cli/arguments/index.ts
+++ b/packages/rolldown/src/cli/arguments/index.ts
@@ -122,7 +122,7 @@ export function parseCliArguments() {
         })
       } else {
         Object.defineProperty(values, option.name, {
-          value: option.value,
+          value: option.value ?? '',
           enumerable: true,
           configurable: true,
           writable: true,

--- a/packages/rolldown/src/cli/arguments/normalize.ts
+++ b/packages/rolldown/src/cli/arguments/normalize.ts
@@ -41,13 +41,10 @@ export function normalizeCliOptions(
     output: {} as OutputOptions,
     help: options.help ?? false,
     version: options.version ?? false,
-    config:
-      typeof options.config === 'boolean'
-        ? options.config
-          ? 'rolldown.config.js'
-          : ''
-        : (options.config ?? ''),
   } as NormalizedCliOptions
+  if (typeof options.config === 'string') {
+    result.config = options.config ? options.config : 'rolldown.config.js'
+  }
   const reservedKeys = ['help', 'version', 'config']
   const keysOfInput = inputCliOptionsSchema.keyof()._def.values as string[]
   // Because input is the positional args, we shouldn't include it in the input schema.


### PR DESCRIPTION
The `rolldown -c` command, which previously printed the help message, appears to be experiencing an issue with option handling.