### PR TITLE
chore: use a conflict less env name to determine rolldown test

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -69,7 +69,7 @@
     "build-wasi:debug": "run-s build-binding:wasi build-node",
     "build-wasi:release": "run-s build-binding:wasi:release build-node",
     "# Scrips for checking #": "_",
-    "test": "cross-env TEST=1 vitest run --reporter verbose --hideSkippedTests",
+    "test": "cross-env ROLLDOWN_TEST=1 vitest run --reporter verbose --hideSkippedTests",
     "test:update": "vitest run -u",
     "type-check": "tsc"
   },

--- a/packages/rolldown/src/cli/utils.ts
+++ b/packages/rolldown/src/cli/utils.ts
@@ -6,7 +6,7 @@ import type { ConfigExport } from '../types/config-export'
 /**
  * Console logger
  */
-export const logger = process.env.TEST
+export const logger = process.env.ROLLDOWN_TEST
   ? createTestingLogger()
   : createConsola({
       formatOptions: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
from

              Perhaps a more unique env identifier such as `ROLLDOWN_TEST` would be better since `TEST` is too common in development and may conflict with users' env

_Originally posted by @ikkz in https://github.com/rolldown/rolldown/pull/1995#discussion_r1719519450_
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
