### PR TITLE
feat: assignment expr side effect detector

### DIFF
--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -153,7 +153,6 @@ impl<'a> SideEffectDetector<'a> {
         !object_pattern.properties.is_empty() || object_pattern.rest.is_some()
       }
     }
-
   }
 
   #[allow(clippy::too_many_lines)]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -151,8 +151,7 @@ impl<'a> SideEffectDetector<'a> {
       | Expression::ArrowFunctionExpression(_)
       | Expression::MetaProperty(_)
       | Expression::ThisExpression(_)
-      | Expression::StringLiteral(_)
-      | Expression::Super(_) => false,
+      | Expression::StringLiteral(_) => false,
       Expression::ObjectExpression(obj_expr) => {
         obj_expr.properties.iter().any(|obj_prop| match obj_prop {
           oxc::ast::ast::ObjectPropertyKind::ObjectProperty(prop) => {
@@ -236,8 +235,10 @@ impl<'a> SideEffectDetector<'a> {
           true
         }
       }
+
       // TODO: Implement these
-      Expression::AwaitExpression(_)
+      Expression::Super(_)
+      | Expression::AwaitExpression(_)
       | Expression::ChainExpression(_)
       | Expression::ImportExpression(_)
       | Expression::TaggedTemplateExpression(_)

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -718,12 +718,12 @@ mod test {
     // accessing global variable may have side effect
     assert!(get_statements_side_effect("b = 1"));
     assert!(get_statements_side_effect("let a; a = b"));
+    assert!(get_statements_side_effect("let a; a.b = 1"));
+    assert!(get_statements_side_effect("let a; a['b'] = 1"));
+    assert!(get_statements_side_effect("let a; a = a.b"));
     assert!(get_statements_side_effect("let a, b; ({ a } = b)"));
     assert!(get_statements_side_effect("let a, b; ({ ...a } = b)"));
     assert!(get_statements_side_effect("let a, b; [ a ] = b"));
     assert!(get_statements_side_effect("let a, b; [ ...a ] = b"));
-    assert!(get_statements_side_effect("let a; a.b = 1"));
-    assert!(get_statements_side_effect("let a; a['b'] = 1"));
-    assert!(get_statements_side_effect("let a; a = a.b"));
   }
 }

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -140,20 +140,20 @@ impl<'a> SideEffectDetector<'a> {
   }
 
   fn detect_side_effect_of_assignment_target(expr: &AssignmentTarget) -> bool {
-    if let Some(pattern) = expr.as_assignment_target_pattern() {
-      match pattern {
-        // {} = expr
-        AssignmentTargetPattern::ArrayAssignmentTarget(array_pattern) => {
-          !array_pattern.elements.is_empty() || array_pattern.rest.is_some()
-        }
-        // [] = expr
-        AssignmentTargetPattern::ObjectAssignmentTarget(object_pattern) => {
-          !object_pattern.properties.is_empty() || object_pattern.rest.is_some()
-        }
+    let Some(pattern) = expr.as_assignment_target_pattern() else {
+      return true;
+    };
+    match pattern {
+      // {} = expr
+      AssignmentTargetPattern::ArrayAssignmentTarget(array_pattern) => {
+        !array_pattern.elements.is_empty() || array_pattern.rest.is_some()
       }
-    } else {
-      true
+      // [] = expr
+      AssignmentTargetPattern::ObjectAssignmentTarget(object_pattern) => {
+        !object_pattern.properties.is_empty() || object_pattern.rest.is_some()
+      }
     }
+
   }
 
   #[allow(clippy::too_many_lines)]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -1,6 +1,6 @@
 use oxc::ast::ast::{
-  Argument, ArrayExpressionElement, AssignmentTargetPattern, BindingPatternKind, Expression,
-  IdentifierReference, PropertyKey,
+  Argument, ArrayExpressionElement, AssignmentTarget, AssignmentTargetPattern, BindingPatternKind,
+  Expression, IdentifierReference, PropertyKey,
 };
 use oxc::ast::{match_expression, Trivias};
 use rolldown_common::AstScopes;
@@ -139,6 +139,23 @@ impl<'a> SideEffectDetector<'a> {
     }
   }
 
+  fn detect_side_effect_of_assignment_target(expr: &AssignmentTarget) -> bool {
+    if let Some(pattern) = expr.as_assignment_target_pattern() {
+      match pattern {
+        // {} = expr
+        AssignmentTargetPattern::ArrayAssignmentTarget(array_pattern) => {
+          !array_pattern.elements.is_empty() || array_pattern.rest.is_some()
+        }
+        // [] = expr
+        AssignmentTargetPattern::ObjectAssignmentTarget(object_pattern) => {
+          !object_pattern.properties.is_empty() || object_pattern.rest.is_some()
+        }
+      }
+    } else {
+      true
+    }
+  }
+
   #[allow(clippy::too_many_lines)]
   fn detect_side_effect_of_expr(&mut self, expr: &oxc::ast::ast::Expression) -> bool {
     match expr {
@@ -220,20 +237,8 @@ impl<'a> SideEffectDetector<'a> {
         self.detect_side_effect_of_expr(&private_in_expr.right)
       }
       Expression::AssignmentExpression(expr) => {
-        if let Some(pattern) = expr.left.as_assignment_target_pattern() {
-          match pattern {
-            // {} = expr
-            AssignmentTargetPattern::ArrayAssignmentTarget(array_pattern) => {
-              !array_pattern.elements.is_empty() || array_pattern.rest.is_some()
-            }
-            // [] = expr
-            AssignmentTargetPattern::ObjectAssignmentTarget(object_pattern) => {
-              !object_pattern.properties.is_empty() || object_pattern.rest.is_some()
-            }
-          }
-        } else {
-          true
-        }
+        Self::detect_side_effect_of_assignment_target(&expr.left)
+          || self.detect_side_effect_of_expr(&expr.right)
       }
 
       // TODO: Implement these
@@ -707,6 +712,7 @@ mod test {
     assert!(get_statements_side_effect("let a, b; a = b; a = b = 1"));
     // accessing global variable may have side effect
     assert!(get_statements_side_effect("b = 1"));
+    assert!(get_statements_side_effect("[] = b"));
     assert!(get_statements_side_effect("let a; a = b"));
     assert!(get_statements_side_effect("let a; a.b = 1"));
     assert!(get_statements_side_effect("let a; a['b'] = 1"));


### PR DESCRIPTION
This PR implements the logic for `AssignmentExpression` in `SideEffectDetector`. Tests included.

- Empty destructoring patterns like `[] = a`, `{} = a` are considered side-effect-less when `a` is a local variable. However, it seems that neither Rollup nor Esbuild considered this case.
- Should expressions like `{ defineProperty: x } = Object` be specially treated? This will introduce lots of complexity, but the usage seems too rare.