### PR TITLE
feat: implement the rest branches in side effect detector

### DIFF
--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -744,14 +744,12 @@ mod test {
   }
 
   #[test]
-  fn test_for_statement() {
-    assert!(!get_statements_side_effect("for (;;) { }"));
-    assert!(get_statements_side_effect("for (let i = 0; i < 10; i++) { const a = 1; }"));
-    assert!(get_statements_side_effect("let f; for (;f();) { }"));
-    assert!(get_statements_side_effect("let f; for (;;f()) { }"));
-    // accessing global variable may have side effect
-    assert!(get_statements_side_effect("for (let i = 0; i < 10; i++) { bar; }"));
-    assert!(get_statements_side_effect("for (i = 0; i < 10; i++) { }"));
+  fn test_chain_expression() {
+    assert!(!get_statements_side_effect("Object.create"));
+    assert!(!get_statements_side_effect("Object?.create"));
+    assert!(!get_statements_side_effect("let a; /*#__PURE__*/ a?.()"));
+    assert!(get_statements_side_effect("let a, b; a?.b"));
+    assert!(get_statements_side_effect("let a; a?()"));
   }
 
   #[test]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -800,6 +800,15 @@ mod test {
   }
 
   #[test]
+  fn test_chain_expression() {
+    assert!(!get_statements_side_effect("Object.create"));
+    assert!(!get_statements_side_effect("Object?.create"));
+    assert!(!get_statements_side_effect("let a; /*#__PURE__*/ a?.()"));
+    assert!(get_statements_side_effect("let a; a?.b"));
+    assert!(get_statements_side_effect("let a; a?.()"));
+  }
+
+  #[test]
   fn test_other_statements() {
     assert!(get_statements_side_effect("debugger;"));
     assert!(get_statements_side_effect("debugger;"));
@@ -807,7 +816,6 @@ mod test {
     assert!(get_statements_side_effect("throw 1;"));
     assert!(get_statements_side_effect("with(a) { }"));
     assert!(get_statements_side_effect("await 1"));
-    assert!(get_statements_side_effect("let a; a?.b"));
     assert!(get_statements_side_effect("import('foo')"));
     assert!(get_statements_side_effect("let a; a``"));
     assert!(get_statements_side_effect("let a; a++"));

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -246,10 +246,11 @@ impl<'a> SideEffectDetector<'a> {
       | Expression::ImportExpression(_)
       | Expression::TaggedTemplateExpression(_)
       | Expression::UpdateExpression(_)
-      | Expression::YieldExpression(_)
+      | Expression::YieldExpression(_) => true,
 
-      // TODO: Implement these
-      | Expression::JSXElement(_) | Expression::JSXFragment(_) => true,
+      Expression::JSXElement(_) | Expression::JSXFragment(_) => {
+        unreachable!("jsx should be transpiled")
+      }
 
       Expression::ArrayExpression(expr) => expr.elements.iter().any(|elem| match elem {
         ArrayExpressionElement::SpreadElement(_) => true,

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -749,7 +749,7 @@ mod test {
     assert!(!get_statements_side_effect("Object?.create"));
     assert!(!get_statements_side_effect("let a; /*#__PURE__*/ a?.()"));
     assert!(get_statements_side_effect("let a, b; a?.b"));
-    assert!(get_statements_side_effect("let a; a?()"));
+    assert!(get_statements_side_effect("let a; a?.()"));
   }
 
   #[test]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -748,8 +748,9 @@ mod test {
     assert!(!get_statements_side_effect("Object.create"));
     assert!(!get_statements_side_effect("Object?.create"));
     assert!(!get_statements_side_effect("let a; /*#__PURE__*/ a?.()"));
-    assert!(get_statements_side_effect("let a, b; a?.b"));
+    assert!(get_statements_side_effect("let a; a?.b"));
     assert!(get_statements_side_effect("let a; a?.()"));
+    assert!(get_statements_side_effect("let a; a?.[a]"));
   }
 
   #[test]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -1,6 +1,6 @@
 use oxc::ast::ast::{
   Argument, ArrayExpressionElement, AssignmentTarget, AssignmentTargetPattern, BindingPatternKind,
-  ChainElement, Expression, ForStatementInit, ForStatementLeft, IdentifierReference, PropertyKey,
+  ChainElement, Expression, IdentifierReference, PropertyKey,
 };
 use oxc::ast::{match_expression, match_member_expression, Trivias};
 use rolldown_common::AstScopes;
@@ -756,7 +756,6 @@ mod test {
 
   #[test]
   fn test_other_statements() {
-    assert!(get_statements_side_effect("debugger;"));
     assert!(get_statements_side_effect("debugger;"));
     assert!(get_statements_side_effect("for (const k in {}) { }"));
     assert!(get_statements_side_effect("let a; for (const v of []) { a++ }"));


### PR DESCRIPTION
This PR implements all unimplemented side effect detectors except the two JSX-related ones. The JSX-related expressions are not implemented because I am not sure should JSX calls be always considered pure (although this seems true in esbuild). Tests included.