### PR TITLE
chore(rolldown): bump oxc to 0.24.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,9 +1392,9 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "oxc"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a925682ca355cce019b87ca10ba18f0cd4572c25f65abf2ccdfb197f8153dc2"
+checksum = "e661878abdc6fdf85c18a106961fb56884d2e129744285745b26ac2847c6c32d"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1427,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05d68ad13b331cb11c7bd272aae9d0ef362a64af757eb4e94b804dc6a0a1733"
+checksum = "20afc1d4a7b0b878d28f7b7f9f1f7ab670a7c7e8feb29101fb49eac1faa483fa"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -1437,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9893a73dc2603ef975dc88a1fd2b21b46e2caee3180ef975c90a45ad5494b60c"
+checksum = "1599f878d8ac6fcc229be06426f04134f7663dcd5c71046414d8ddd12a20ad3b"
 dependencies = [
  "bitflags 2.6.0",
  "num-bigint",
@@ -1451,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933eda966caeb7ba0809c14371be02d343e3ac12d302fbae3294b56fcb0aeb57"
+checksum = "d0a07c44bbe07756ba25605059fa4a94543f6a75730fd8bd1105795d0b3d668d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1462,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803642c69e854f679e57be63bbd0b0685aeed9f41f3e0629a47aba9a61517733"
+checksum = "e855fef3a078ea1e1751706b08c5f7e5e901a1a98b18f1ca8e9e06e505a2e035"
 dependencies = [
  "bitflags 2.6.0",
  "itertools 0.13.0",
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4749c99d5a6f212d4aafd029e7932f26eace16b07f211ffe3018295da177d6da"
+checksum = "b0fcfdf05f52463ba13d6d58c738a189441670b53b46e6f37788afb7b2e3c5de"
 dependencies = [
  "bitflags 2.6.0",
  "daachorse",
@@ -1490,14 +1490,13 @@ dependencies = [
  "oxc_sourcemap",
  "oxc_span",
  "oxc_syntax",
- "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69620353f047e96064ac42baa4663fdde0a0836a27f9bcb3bbf836aa7459d70"
+checksum = "c53d201660e8accd6e53f1af7efda36967316aa4263d0a6847c631bdd8705e0f"
 dependencies = [
  "miette",
  "owo-colors",
@@ -1507,15 +1506,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_index"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63c14b74e3fe05d75e217de6a152d9d40acc6e8d3a0096bb8bdf34c85cd0fab"
+checksum = "fa1d58c483b1ec74c7219b1525648b4b6beea7ff4685b02ad74693190df43308"
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d381c2ddadfd44ca3c2db8609b4e7ef6b236147e6d2c9ab4c8d7c50c2ce035"
+checksum = "682d80166e440ef1b7c384bc9b6762620029fe63771c98a59e4a252f408a3366"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1527,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22facd9b5a597dde6c3dcd00682611efe95808435c706bf71775c37a24764540"
+checksum = "28c3139067931258d3c3ace55b15e21c7213eeffb25921b3d85cfd653da35ca7"
 dependencies = [
  "itertools 0.13.0",
  "oxc_ast",
@@ -1540,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78aa5bbb0c06b6b6dd7de7743f12ad5a6123e65312c992b7b3db53eb978b7220"
+checksum = "a07330f266cd7d65b2c63c4c73f5f51c6acf37d23f26d58d9210b190624dbf0a"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1560,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea6fb997841162f4e00feaae0461cdfc7043c72561992a8aa2e7a6162d36cc8"
+checksum = "77ce38833b8b0d1121779b2ceaa9aa07d4142105ccc6941f73112a8d836b87cd"
 dependencies = [
  "assert-unchecked",
  "bitflags 2.6.0",
@@ -1598,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424858e08aac0601ef8a5968517cfd79ea5696e34dd93104828ac09eb02fef41"
+checksum = "6a5b6db9842811ac4534b89cd39a73c0af1cf1f986738a530ee3ffcaeb078763"
 dependencies = [
  "assert-unchecked",
  "indexmap",
@@ -1618,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe104c5eb96eba387d57928e8db2ea25370300253447ec9215992ee7925737e2"
+checksum = "29b246cb91d8982a1dc744c91764f174e60e4e3829e70c6746168c8d0537efa2"
 dependencies = [
  "base64-simd 0.8.0",
  "cfg-if",
@@ -1632,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13cc580c6acd555c8828b63ec5a7694123d65c9e402762052cbb604359f74b9"
+checksum = "e7a4f6e525a64e61bcfa256e4707e46be54f3261e0b524670d0a1c6827c28931"
 dependencies = [
  "compact_str",
  "miette",
@@ -1644,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07ce78403ec09c4988b8026c836eac5954517cf8def41dfb9183de080f11a2b"
+checksum = "bcb27d1a7e00a63e5d490fa4ee9a008d45e45db3d505ca21f0e63de2097cf743"
 dependencies = [
  "bitflags 2.6.0",
  "dashmap 6.0.1",
@@ -1663,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953371106fc1d7bbbb92a85e9510ababff92c90ae8a6308e8dae0e39c59c4460"
+checksum = "9a1a73aa255d4b832e0e63450ed841b5c9620ceaaf8e54bad9143af1869702c6"
 dependencies = [
  "napi",
  "napi-build",
@@ -1683,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a891ed8b68d7aa9380c4ac582c60a049a6511788ac3c83fa79ecfc7f1847d312"
+checksum = "8896a1ba84ae68925e5437e6f3e63cbfe13daa029f97166b68cd94c809b785a8"
 dependencies = [
  "dashmap 6.0.1",
  "indexmap",
@@ -1705,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd0a266a56d2723a5941052d2c5335cec8b2e93733cb7834506c876aef1527b"
+checksum = "8ebe424dba47c4cfff5f9bf72d0c27c8d855da3eae6c2eee14b795cc038af7aa"
 dependencies = [
  "compact_str",
  "memoffset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,9 +153,9 @@ vfs                 = "0.12.0"
 xxhash-rust         = "0.8.10"
 
 # oxc crates share the same version
-oxc                = { version = "0.24.2", features = ["sourcemap_concurrent", "transformer", "minifier", "semantic", "codegen"] }
-oxc_index          = { version = "0.24.2" }
-oxc_transform_napi = { version = "0.24.2" }
+oxc                = { version = "0.24.3", features = ["sourcemap_concurrent", "transformer", "minifier", "semantic", "codegen"] }
+oxc_index          = { version = "0.24.3" }
+oxc_transform_napi = { version = "0.24.3" }
 
 [profile.release]
 codegen-units = 1

--- a/crates/rolldown/tests/esbuild/dce/no_side_effects_comment/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/no_side_effects_comment/artifacts.snap
@@ -106,7 +106,7 @@ export { f as default };
 ```js
 
 //#region stmt-export-default-before-async-fn-anon.js
-async function stmt_export_default_before_async_fn_anon_default() {}
+/* #__NO_SIDE_EFFECTS__ */ async function stmt_export_default_before_async_fn_anon_default() {}
 
 //#endregion
 export { stmt_export_default_before_async_fn_anon_default as default };
@@ -116,7 +116,7 @@ export { stmt_export_default_before_async_fn_anon_default as default };
 ```js
 
 //#region stmt-export-default-before-async-fn-name.js
-async function f() {}
+/* #__NO_SIDE_EFFECTS__ */ async function f() {}
 
 //#endregion
 export { f as default };
@@ -126,7 +126,7 @@ export { f as default };
 ```js
 
 //#region stmt-export-default-before-async-gen-fn-anon.js
-async function* stmt_export_default_before_async_gen_fn_anon_default() {}
+/* #__NO_SIDE_EFFECTS__ */ async function* stmt_export_default_before_async_gen_fn_anon_default() {}
 
 //#endregion
 export { stmt_export_default_before_async_gen_fn_anon_default as default };
@@ -136,7 +136,7 @@ export { stmt_export_default_before_async_gen_fn_anon_default as default };
 ```js
 
 //#region stmt-export-default-before-async-gen-fn-name.js
-async function* f() {}
+/* #__NO_SIDE_EFFECTS__ */ async function* f() {}
 
 //#endregion
 export { f as default };
@@ -146,7 +146,7 @@ export { f as default };
 ```js
 
 //#region stmt-export-default-before-fn-anon.js
-function stmt_export_default_before_fn_anon_default() {}
+/* #__NO_SIDE_EFFECTS__ */ function stmt_export_default_before_fn_anon_default() {}
 
 //#endregion
 export { stmt_export_default_before_fn_anon_default as default };
@@ -156,7 +156,7 @@ export { stmt_export_default_before_fn_anon_default as default };
 ```js
 
 //#region stmt-export-default-before-fn-name.js
-function f() {}
+/* #__NO_SIDE_EFFECTS__ */ function f() {}
 
 //#endregion
 export { f as default };
@@ -166,7 +166,7 @@ export { f as default };
 ```js
 
 //#region stmt-export-default-before-gen-fn-anon.js
-function* stmt_export_default_before_gen_fn_anon_default() {}
+/* #__NO_SIDE_EFFECTS__ */ function* stmt_export_default_before_gen_fn_anon_default() {}
 
 //#endregion
 export { stmt_export_default_before_gen_fn_anon_default as default };
@@ -176,7 +176,7 @@ export { stmt_export_default_before_gen_fn_anon_default as default };
 ```js
 
 //#region stmt-export-default-before-gen-fn-name.js
-function* f() {}
+/* #__NO_SIDE_EFFECTS__ */ function* f() {}
 
 //#endregion
 export { f as default };
@@ -186,10 +186,10 @@ export { f as default };
 ```js
 
 //#region stmt-export-fn.js
-function a() {}
-function* b() {}
-async function c() {}
-async function* d() {}
+/* @__NO_SIDE_EFFECTS__ */ function a() {}
+/* @__NO_SIDE_EFFECTS__ */ function* b() {}
+/* @__NO_SIDE_EFFECTS__ */ async function c() {}
+/* @__NO_SIDE_EFFECTS__ */ async function* d() {}
 
 //#endregion
 export { a, b, c, d };
@@ -199,17 +199,17 @@ export { a, b, c, d };
 ```js
 
 //#region stmt-export-local.js
-var v0 = function() {};
+var v0 = /* #__NO_SIDE_EFFECTS__ */ function() {};
 var v1 = function() {};
-let l0 = function() {};
+let l0 = /* #__NO_SIDE_EFFECTS__ */ function() {};
 let l1 = function() {};
-const c0 = function() {};
+const c0 = /* #__NO_SIDE_EFFECTS__ */ function() {};
 const c1 = function() {};
-var v2 = () => {};
+var v2 = /* #__NO_SIDE_EFFECTS__ */ () => {};
 var v3 = () => {};
-let l2 = () => {};
+let l2 = /* #__NO_SIDE_EFFECTS__ */ () => {};
 let l3 = () => {};
-const c2 = () => {};
+const c2 = /* #__NO_SIDE_EFFECTS__ */ () => {};
 const c3 = () => {};
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/tree_shaking/pure_annotation/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/pure_annotation/artifacts.snap
@@ -18,7 +18,7 @@ const c = test();
 //#endregion
 //#region d.js
 function test2() {}
-const e = test2();
+const e = /* #__PURE__ */ test2();
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -142,16 +142,16 @@ expression: "snapshot_outputs.join(\"\\n\")"
 - stmt-export-default-after-fn-name_js-!~{00f}~.mjs => stmt-export-default-after-fn-name_js-6C8jVjN1.mjs
 - stmt-export-default-after-gen-fn-anon_js-!~{00g}~.mjs => stmt-export-default-after-gen-fn-anon_js-HIqHYRxS.mjs
 - stmt-export-default-after-gen-fn-name_js-!~{00h}~.mjs => stmt-export-default-after-gen-fn-name_js-iGWZdGhk.mjs
-- stmt-export-default-before-async-fn-anon_js-!~{00a}~.mjs => stmt-export-default-before-async-fn-anon_js-KlPlY6Zy.mjs
-- stmt-export-default-before-async-fn-name_js-!~{00b}~.mjs => stmt-export-default-before-async-fn-name_js-vYOur1vd.mjs
-- stmt-export-default-before-async-gen-fn-anon_js-!~{00c}~.mjs => stmt-export-default-before-async-gen-fn-anon_js-QzxrgjGw.mjs
-- stmt-export-default-before-async-gen-fn-name_js-!~{00d}~.mjs => stmt-export-default-before-async-gen-fn-name_js--HfYK_48.mjs
-- stmt-export-default-before-fn-anon_js-!~{006}~.mjs => stmt-export-default-before-fn-anon_js-Y3OEMRgq.mjs
-- stmt-export-default-before-fn-name_js-!~{007}~.mjs => stmt-export-default-before-fn-name_js-5N9LZwly.mjs
-- stmt-export-default-before-gen-fn-anon_js-!~{008}~.mjs => stmt-export-default-before-gen-fn-anon_js-4DRYHyMa.mjs
-- stmt-export-default-before-gen-fn-name_js-!~{009}~.mjs => stmt-export-default-before-gen-fn-name_js-pvTIXxqc.mjs
-- stmt-export-fn_js-!~{003}~.mjs => stmt-export-fn_js-Lg5fJ6sh.mjs
-- stmt-export-local_js-!~{005}~.mjs => stmt-export-local_js-uHmpXE13.mjs
+- stmt-export-default-before-async-fn-anon_js-!~{00a}~.mjs => stmt-export-default-before-async-fn-anon_js-YFTr91Qa.mjs
+- stmt-export-default-before-async-fn-name_js-!~{00b}~.mjs => stmt-export-default-before-async-fn-name_js-ZfeBiOfE.mjs
+- stmt-export-default-before-async-gen-fn-anon_js-!~{00c}~.mjs => stmt-export-default-before-async-gen-fn-anon_js-phpV7C28.mjs
+- stmt-export-default-before-async-gen-fn-name_js-!~{00d}~.mjs => stmt-export-default-before-async-gen-fn-name_js-5B12RTgx.mjs
+- stmt-export-default-before-fn-anon_js-!~{006}~.mjs => stmt-export-default-before-fn-anon_js-sLVm62ea.mjs
+- stmt-export-default-before-fn-name_js-!~{007}~.mjs => stmt-export-default-before-fn-name_js-DgmVSQbx.mjs
+- stmt-export-default-before-gen-fn-anon_js-!~{008}~.mjs => stmt-export-default-before-gen-fn-anon_js-0rvRU2sk.mjs
+- stmt-export-default-before-gen-fn-name_js-!~{009}~.mjs => stmt-export-default-before-gen-fn-name_js-f3p6_Y_E.mjs
+- stmt-export-fn_js-!~{003}~.mjs => stmt-export-fn_js-PD0nX_cF.mjs
+- stmt-export-local_js-!~{005}~.mjs => stmt-export-local_js-Z90-bMF5.mjs
 - stmt-fn_js-!~{002}~.mjs => stmt-fn_js-nGhExA7J.mjs
 - stmt-local_js-!~{004}~.mjs => stmt-local_js-6z8D7Phz.mjs
 
@@ -2157,7 +2157,7 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/rolldown/tree_shaking/pure_annotation
 
-- main-!~{000}~.mjs => main-XCncN_Yu.mjs
+- main-!~{000}~.mjs => main-DH-gdM9b.mjs
 
 # tests/rolldown/tree_shaking/unused_import_cjs
 


### PR DESCRIPTION
Regular version update.

Relevant PRs:

* https://github.com/oxc-project/oxc/pull/4898