### PR TITLE
feat(node/composingJsPlugins): support `resolveId` hook

### DIFF
--- a/packages/rolldown/src/constants/plugin-context.ts
+++ b/packages/rolldown/src/constants/plugin-context.ts
@@ -1,0 +1,9 @@
+/**
+ * If Composed plugins call `this.resolve` with `skipSelf: true`, the composed plugins will be skipped as a whole.
+ * To prevent that, we use this symbol to store the actual caller of `this.resolve` with `skipSelf: true`. And we
+ * will modify the skipSelf option to `false` and use this symbol to skip the caller itself in the composed plugins
+ * internally.
+ */
+export const SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF: unique symbol = Symbol(
+  'plugin-context-resolve-caller',
+)

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -24,6 +24,7 @@ import { BuiltinPlugin } from './builtin-plugin'
 import { ParallelPlugin } from './parallel-plugin'
 import type { DefinedHookNames } from '../constants/plugin'
 import { DEFINED_HOOK_NAMES } from '../constants/plugin'
+import { SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF } from '../constants/plugin-context'
 
 export type ModuleSideEffects = boolean | 'no-treeshake' | null
 
@@ -72,6 +73,10 @@ interface ResolveIdExtraOptions {
   custom?: CustomPluginOptions
   isEntry: boolean
   kind: 'import' | 'dynamic-import' | 'require-call'
+}
+
+export interface PrivateResolveIdExtraOptions extends ResolveIdExtraOptions {
+  [SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF]?: symbol
 }
 
 export type ResolveIdResult = string | NullValue | false | PartialResolvedId

--- a/packages/rolldown/src/plugin/plugin-context-data.ts
+++ b/packages/rolldown/src/plugin/plugin-context-data.ts
@@ -1,12 +1,13 @@
 import { BindingPluginContext } from '../binding'
-import { CustomPluginOptions, ModuleInfo, ModuleOptions } from '..'
+import { ModuleInfo, ModuleOptions } from '..'
 import { transformModuleInfo } from '../utils/transform-module-info'
+import { PluginContextResolveOptions } from './plugin-context'
 
 export class PluginContextData {
   modules = new Map<string, ModuleInfo>()
   moduleIds: Array<string> | null = null
   moduleOptionMap = new Map<string, ModuleOptions>()
-  resolveCustomMap = new Map<number, CustomPluginOptions>()
+  resolveOptionsMap = new Map<number, PluginContextResolveOptions>()
 
   updateModuleOption(id: string, option: ModuleOptions) {
     const existing = this.moduleOptionMap.get(id)
@@ -52,17 +53,17 @@ export class PluginContextData {
     return [].values()
   }
 
-  setResolveCustom(custom: CustomPluginOptions): number {
-    const index = Object.keys(this.resolveCustomMap).length
-    this.resolveCustomMap.set(index, custom)
+  saveResolveOptions(options: PluginContextResolveOptions): number {
+    const index = this.resolveOptionsMap.size
+    this.resolveOptionsMap.set(index, options)
     return index
   }
 
-  getResolveCustom(index: number) {
-    return this.resolveCustomMap.get(index)
+  getSavedResolveOptions(receipt: number) {
+    return this.resolveOptionsMap.get(receipt)
   }
 
-  removeResolveCustom(index: number) {
-    this.resolveCustomMap.delete(index)
+  removeSavedResolveOptions(receipt: number) {
+    this.resolveOptionsMap.delete(receipt)
   }
 }

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve2/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve2/_config.ts
@@ -1,0 +1,60 @@
+import { defineTest } from '@tests'
+import { expect, vi } from 'vitest'
+
+const fnA = vi.fn()
+const fnB = vi.fn()
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'tester',
+        async resolveId(id) {
+          fnA()
+          if (id === 'test-skip-self-false') {
+            // Prevent recursive call
+            return 'return-by-tester'
+          }
+          const skipSelfTrue = await this.resolve(
+            'test-skip-self-true',
+            undefined,
+            {
+              skipSelf: true,
+            },
+          )
+          expect(skipSelfTrue?.id).toBe('return-by-tester2')
+          const skipSelfFalse = await this.resolve(
+            'test-skip-self-false',
+            undefined,
+            {
+              skipSelf: false,
+            },
+          )
+          expect(skipSelfFalse?.id).toBe('return-by-tester')
+
+          if (!id.startsWith('test')) {
+            // let `main.js` pass
+            return null
+          }
+          return 'return-by-tester'
+        },
+      },
+      {
+        name: 'tester2',
+        async resolveId(id) {
+          fnB()
+
+          if (!id.startsWith('test')) {
+            // let `main.js` pass
+            return null
+          }
+          return 'return-by-tester2'
+        },
+      },
+    ],
+  },
+  afterTest: () => {
+    expect(fnA).toHaveBeenCalledTimes(2)
+    expect(fnB).toHaveBeenCalledTimes(2)
+  },
+})


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

You could actually call `this.resolveId` in `buildStart`... hooks, so the current bailout logic is wrong. To get a correct semantic, we probably need to bailout all hooks that could call `this.resolveId`. This basically make `composingJsPlugins` unuseable.

However, this PR solve the issue partially, which means, with this PR, we could ensure the correct semantic of calling `this.resolve` in `resolveId` hook.

Fixes for other hooks would be raised later. Basically we need intercept all hooks's `PluginContext` for plugins that implemented `resolveId` hook.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
