### PR TITLE
fix:  JSON.parse() should not have side effect

### DIFF
--- a/crates/rolldown_plugin_json/src/lib.rs
+++ b/crates/rolldown_plugin_json/src/lib.rs
@@ -30,9 +30,9 @@ impl Plugin for JsonPlugin {
         let str = serde_json::to_string(&value)?;
         // TODO: perf: find better way than https://github.com/rolldown/vite/blob/3bf86e3f715c952a032b476b60c8c869e9c50f3f/packages/vite/src/node/plugins/json.ts#L55-L57
         let str = serde_json::to_string(&str)?;
-        format!("export default JSON.parse({str})")
+        format!("export default /*#__PURE__*/ JSON.parse({str})")
       } else {
-        format!("export default JSON.parse({})", serde_json::to_string(code)?)
+        format!("export default /*#__PURE__*/ JSON.parse({})", serde_json::to_string(code)?)
       };
       return Ok(Some(HookTransformOutput {
         code: Some(normalized_code),

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/_config.ts
@@ -7,9 +7,7 @@ export default defineTest({
     plugins: [jsonPlugin({ stringify: true, isBuild: false })],
   },
   async afterTest(output) {
-    expect(output.output[0].code).not.toContain(
-      `JSON.parse`,
-    )
+    expect(output.output[0].code).not.toContain(`JSON.parse`)
     await import('./assert.mjs')
   },
 })

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/_config.ts
@@ -1,0 +1,15 @@
+import { jsonPlugin } from 'rolldown/experimental'
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    plugins: [jsonPlugin({ stringify: true, isBuild: false })],
+  },
+  async afterTest(output) {
+    expect(output.output[0].code).not.toContain(
+      `JSON.parse`,
+    )
+    await import('./assert.mjs')
+  },
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/assert.mjs
@@ -1,0 +1,5 @@
+// @ts-nocheck
+import assert from 'node:assert'
+import { name } from './dist/main'
+
+assert(name === 1)

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/main.js
@@ -1,0 +1,3 @@
+import json from './package.json'
+
+export const name = 1

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/package.json
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "stringify"
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Before the test case will fail, since `JSON.parse` is considered to have side effects.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
