### PR TITLE
fix: Allowing gcc builds on windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,7 +13,7 @@ rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup,-no_fixup_chains"]
 rustflags = ["-C", "link-args=-Wl,--warn-unresolved-symbols"]
 
 # To be able to run unit tests on Windows, support compilation to 'x86_64-pc-windows-msvc'.
-[target.'cfg(target_os = "windows")']
+[target.'cfg(target_env = "msvc")']
 rustflags = ["-C", "link-args=/FORCE"]
 
 [target.x86_64-pc-windows-msvc]


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
gcc runs on windows, gcc does not accept /FORCE

![image](https://github.com/user-attachments/assets/55f1eb19-284d-46cc-97ce-802a855de2a2)
