### PR TITLE
chore: add task name prefix for tasks in `lint-repo`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint-prettier:fix": "prettier . '**/*.{js,ts,json,md,yml,yaml,vue}' -w",
     "lint-toml": "taplo format --check",
     "lint-toml:fix": "taplo format",
-    "lint-repo": "npm-run-all --parallel lint-prettier lint-toml lint-spell",
+    "lint-repo": "npm-run-all -l --parallel lint-prettier lint-toml lint-spell",
     "build": "echo \"Use just build\"",
     "build:release": "echo \"Use just build native release\"",
     "test": "echo \"Use just test-node\"",


### PR DESCRIPTION
Utilize the `--label-name` options to display the task name, such as `lint-pretter`, as the prefix in the `npm-run-all` command. This approach enhances the user experience by providing a more intuitive and visually appealing display of lint errors.

This does not impact the core, so self-assigned.
