### PR TITLE
perf: use `simdutf8` to validate UTF-8 when reading files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,6 +2279,7 @@ version = "0.1.0"
 dependencies = [
  "dunce",
  "oxc_resolver",
+ "simdutf8",
  "vfs",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ schemars            = "0.8.21"
 self_cell           = "1.0.4"
 serde               = { version = "1.0.203", features = ["derive"] }
 serde_json          = "1.0.117"
+simdutf8            = { version = "0.1.4", features = ["aarch64_neon"] }
 smallvec            = "1.13.2"
 sugar_path          = { version = "1.2.0", features = ["cached_current_dir"] }
 testing_macros      = "0.2.13"

--- a/crates/rolldown_fs/Cargo.toml
+++ b/crates/rolldown_fs/Cargo.toml
@@ -21,4 +21,5 @@ os     = []
 [dependencies]
 dunce        = { workspace = true }
 oxc_resolver = { workspace = true }
+simdutf8     = { workspace = true }
 vfs          = { workspace = true }

--- a/cspell.json
+++ b/cspell.json
@@ -146,6 +146,7 @@
     "sfnt",
     "sharedworker",
     "simd",
+    "simdutf",
     "smallvec",
     "sourcemaps",
     "stackblitz",


### PR DESCRIPTION
### Description

I'm not familiar with Rolldown's codebase, so I'm not sure whether this function is the main one used to read source text from files - so this may be in wrong place/not enough places.

`std::fs::read_to_string` internally calls `std::str::from_utf8` to check that the file is valid UTF-8. `str::from_utf8` is not so efficient as it doesn't use SIMD. `simduft8` should be faster.

I assume that this difference won't show up on benchmarks as they likely won't include IO. But I'd hope it'd have an effect in the real world. How would we go about testing that assumption? Are there any benchmarks which do exercise this function?