### PR TITLE
fix(packages/rolldown): export `package.json`

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -1,6 +1,5 @@
 {
   "name": "rolldown",
-  "type": "commonjs",
   "version": "0.12.2",
   "description": "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API.",
   "homepage": "https://rolldown.rs/",

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -1,11 +1,12 @@
 {
   "name": "rolldown",
+  "type": "commonjs",
   "version": "0.12.2",
   "description": "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API.",
   "homepage": "https://rolldown.rs/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rolldown/rolldown.git",
+    "url": "git+https://github.com/rolldown/rolldown.git",
     "directory": "packages/rolldown"
   },
   "license": "MIT",
@@ -43,7 +44,8 @@
       "types": "./dist/types/parallel-plugin.d.ts",
       "require": "./dist/cjs/parallel-plugin.cjs",
       "import": "./dist/esm/parallel-plugin.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "imports": {
     "#parallel-plugin-worker": "./dist/esm/parallel-plugin-worker.mjs"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Export `package.json` file to provide `version` field for downstream use.
- Fixes a minor issue on [publint](https://publint.dev/rolldown@0.12.2-snapshot-f90de4e-20240823002907). `The field value could be a full git URL like "git+https://github.com/rolldown/rolldown.git".`