### PR TITLE
chore(rust): set release profile values explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,5 +164,7 @@ oxc_transform_napi = { version = "0.25.0" }
 
 [profile.release]
 codegen-units = 1
-lto           = true
-strip         = "symbols"
+debug         = false     # Set to `true` for debug information
+lto           = "fat"
+opt-level     = 3
+strip         = "symbols" # Set to `false` for debug information


### PR DESCRIPTION
I think it's better to show these values explicitly, feel free to disagree otherwise.