### PR TITLE
chore: bump `oxc_resolver` to v1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,10 +1607,11 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f862ee8e1ba728378ac7e007de195ae00fbb21337ef152380c052cc07e2ee2"
+checksum = "e7fe4d07afdfcf6b1d7fb952e6691d82692a54b71964a377cf49f3e47dac283d"
 dependencies = [
+ "cfg-if",
  "dashmap 6.0.1",
  "dunce",
  "indexmap",
@@ -1619,6 +1620,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "serde",
  "serde_json",
+ "simdutf8",
  "thiserror",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ mime                = "0.3.17"
 napi                = { version = "3.0.0-alpha", features = ["async", "anyhow"] }
 napi-build          = { version = "2.1.3" }
 napi-derive         = { version = "3.0.0-alpha", default-features = false, features = ["type-def"] }
-oxc_resolver        = { version = "1.9.0" }
+oxc_resolver        = { version = "1.11.0" }
 phf                 = "0.11.2"
 rayon               = "1.10.0"
 regex               = "1.10.5"


### PR DESCRIPTION
This updates the remaining utf8 checking code https://github.com/oxc-project/oxc-resolver/pull/237


Before:

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/443c7f0e-d0da-40b8-8a45-19dc1d0dc3e7">

After:

(`read_to_string` is gone, the cumulated time is a bit faster on a M2)

<img width="1389" alt="image" src="https://github.com/user-attachments/assets/af86d463-911a-4532-acfd-3832f3bc5cfc">
