### PR TITLE
test: add tests for replace plugin

### DIFF
--- a/crates/rolldown_plugin_replace/tests/form/assignment/input.js
+++ b/crates/rolldown_plugin_replace/tests/form/assignment/input.js
@@ -1,0 +1,1 @@
+process.env.DEBUG = 'test';

--- a/crates/rolldown_plugin_replace/tests/form/assignment/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/assignment/mod.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use rolldown::BundlerOptions;
+
+use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+
+// doesn't replace lvalue in assignment
+// #[tokio::test(flavor = "multi_thread")]
+#[allow(dead_code)]
+async fn assignment() {
+  let cwd = abs_file_dir!();
+
+  IntegrationTest::new(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec!["./input.js".to_string().into()]),
+        cwd: Some(cwd),
+        ..Default::default()
+      },
+      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
+        values: [("process.env.DEBUG".to_string(), "replaced".to_string())].into(),
+        // TODO: prevent_assignment: true
+        ..Default::default()
+      }))],
+    )
+    .await;
+}

--- a/crates/rolldown_plugin_replace/tests/form/match_variables/artifacts.snap
+++ b/crates/rolldown_plugin_replace/tests/form/match_variables/artifacts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## input.mjs
+
+```js
+
+//#region input.js
+console.log("beta version 1.0.0");
+
+//#endregion
+```

--- a/crates/rolldown_plugin_replace/tests/form/match_variables/input.js
+++ b/crates/rolldown_plugin_replace/tests/form/match_variables/input.js
@@ -1,0 +1,1 @@
+console.log('BUILD version BUILD_VERSION');

--- a/crates/rolldown_plugin_replace/tests/form/match_variables/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/match_variables/mod.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use rolldown::BundlerOptions;
+
+use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+
+// matches most specific variables
+#[tokio::test(flavor = "multi_thread")]
+async fn match_variables() {
+  let cwd = abs_file_dir!();
+
+  IntegrationTest::new(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec!["./input.js".to_string().into()]),
+        cwd: Some(cwd),
+        ..Default::default()
+      },
+      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
+        values: [
+          ("BUILD".to_string(), "beta".to_string()),
+          ("BUILD_VERSION".to_string(), "1.0.0".to_string()),
+        ]
+        .into(),
+        ..Default::default()
+      }))],
+    )
+    .await;
+}

--- a/crates/rolldown_plugin_replace/tests/form/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/mod.rs
@@ -1,3 +1,10 @@
+mod assignment;
 mod delimiters;
+mod match_variables;
+mod process_check;
 mod replace_nothing;
 mod replace_strings;
+mod special_characters;
+mod special_delimiters;
+mod ternary_operator;
+mod typescript_declare;

--- a/crates/rolldown_plugin_replace/tests/form/process_check/input.js
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/input.js
@@ -1,0 +1,3 @@
+if (typeof process !== 'undefined' && process.env.NODE_ENV === 'production') {
+  console.log('production');
+}

--- a/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use rolldown::BundlerOptions;
+
+use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+
+// Handles process type guards in replacements
+// #[tokio::test(flavor = "multi_thread")]
+#[allow(dead_code)]
+async fn process_check() {
+  let cwd = abs_file_dir!();
+
+  IntegrationTest::new(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec!["./input.js".to_string().into()]),
+        cwd: Some(cwd),
+        ..Default::default()
+      },
+      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
+        values: [("process.env.NODE_ENV".to_string(), "\"production\"".to_string())].into(),
+        // TODO: prevent_assignment: true
+        // TODO: object_guards: true
+        ..Default::default()
+      }))],
+    )
+    .await;
+}

--- a/crates/rolldown_plugin_replace/tests/form/special_characters/artifacts.snap
+++ b/crates/rolldown_plugin_replace/tests/form/special_characters/artifacts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## input.mjs
+
+```js
+
+//#region input.js
+const one = 1;
+console.log(one);
+
+//#endregion
+```

--- a/crates/rolldown_plugin_replace/tests/form/special_characters/input.js
+++ b/crates/rolldown_plugin_replace/tests/form/special_characters/input.js
@@ -1,0 +1,3 @@
+const one = require('one');
+
+console.log(one);

--- a/crates/rolldown_plugin_replace/tests/form/special_characters/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/special_characters/mod.rs
@@ -1,0 +1,26 @@
+use std::sync::Arc;
+
+use rolldown::BundlerOptions;
+
+use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+
+// supports special characters
+#[tokio::test(flavor = "multi_thread")]
+async fn special_characters() {
+  let cwd = abs_file_dir!();
+
+  IntegrationTest::new(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec!["./input.js".to_string().into()]),
+        cwd: Some(cwd),
+        ..Default::default()
+      },
+      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
+        values: [("require('one')".to_string(), "1".to_string())].into(),
+        delimiters: (String::new(), String::new()),
+      }))],
+    )
+    .await;
+}

--- a/crates/rolldown_plugin_replace/tests/form/special_delimiters/artifacts.snap
+++ b/crates/rolldown_plugin_replace/tests/form/special_delimiters/artifacts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## input.mjs
+
+```js
+
+//#region input.js
+console.log(`
+  replaced
+  (replaced)
+  specially
+  especial
+  replaced.doSomething()
+`);
+
+//#endregion
+```

--- a/crates/rolldown_plugin_replace/tests/form/special_delimiters/input.js
+++ b/crates/rolldown_plugin_replace/tests/form/special_delimiters/input.js
@@ -1,0 +1,7 @@
+console.log(`
+  special
+  (special)
+  specially
+  especial
+  special.doSomething()
+`);

--- a/crates/rolldown_plugin_replace/tests/form/special_delimiters/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/special_delimiters/mod.rs
@@ -1,0 +1,26 @@
+use std::sync::Arc;
+
+use rolldown::BundlerOptions;
+
+use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+
+// allows delimiters with special characters
+#[tokio::test(flavor = "multi_thread")]
+async fn special_delimiters() {
+  let cwd = abs_file_dir!();
+
+  IntegrationTest::new(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec!["./input.js".to_string().into()]),
+        cwd: Some(cwd),
+        ..Default::default()
+      },
+      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
+        values: [("special".to_string(), "replaced".to_string())].into(),
+        delimiters: ("\\b".to_string(), "\\b".to_string()),
+      }))],
+    )
+    .await;
+}

--- a/crates/rolldown_plugin_replace/tests/form/ternary_operator/artifacts.snap
+++ b/crates/rolldown_plugin_replace/tests/form/ternary_operator/artifacts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## input.mjs
+
+```js
+
+//#region input.js
+first ? second : third;
+console.log(first, second, third);
+
+//#endregion
+```

--- a/crates/rolldown_plugin_replace/tests/form/ternary_operator/input.js
+++ b/crates/rolldown_plugin_replace/tests/form/ternary_operator/input.js
@@ -1,0 +1,2 @@
+condition ? exprIfTrue : exprIfFalse;
+console.log(condition, exprIfTrue, exprIfFalse);

--- a/crates/rolldown_plugin_replace/tests/form/ternary_operator/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/ternary_operator/mod.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+
+use rolldown::BundlerOptions;
+
+use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+
+// replaces value inside ternary operators
+#[tokio::test(flavor = "multi_thread")]
+async fn ternary_operator() {
+  let cwd = abs_file_dir!();
+
+  IntegrationTest::new(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec!["./input.js".to_string().into()]),
+        cwd: Some(cwd),
+        ..Default::default()
+      },
+      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
+        values: [
+          ("condition".to_string(), "first".to_string()),
+          ("exprIfTrue".to_string(), "second".to_string()),
+          ("exprIfFalse".to_string(), "third".to_string()),
+        ]
+        .into(),
+        // TODO: prevent_assignment: true
+        ..Default::default()
+      }))],
+    )
+    .await;
+}

--- a/crates/rolldown_plugin_replace/tests/form/typescript_declare/input.ts
+++ b/crates/rolldown_plugin_replace/tests/form/typescript_declare/input.ts
@@ -1,0 +1,2 @@
+declare const NAME: string
+console.log(NAME)

--- a/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use rolldown::BundlerOptions;
+
+use rolldown_plugin::{HookTransformArgs, HookTransformReturn, Plugin, TransformPluginContext};
+use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+use std::sync::Mutex;
+
+#[derive(Debug)]
+struct TestPlugin(Arc<Mutex<Option<String>>>);
+
+impl Plugin for TestPlugin {
+  fn name(&self) -> std::borrow::Cow<'static, str> {
+    "test-plugin".into()
+  }
+
+  fn transform(
+    &self,
+    _ctx: &TransformPluginContext<'_>,
+    args: &HookTransformArgs<'_>,
+  ) -> impl std::future::Future<Output = HookTransformReturn> + Send {
+    let mut code = self.0.lock().unwrap();
+    *code = Some(args.code.clone());
+    async { Ok(None) }
+  }
+}
+
+// doesn't replace lvalue in typescript declare
+// #[tokio::test(flavor = "multi_thread")]
+#[allow(dead_code)]
+async fn typescript_declare() {
+  let cwd = abs_file_dir!();
+  let code = Arc::new(Mutex::new(None));
+
+  IntegrationTest::new(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec!["./input.ts".to_string().into()]),
+        cwd: Some(cwd),
+        ..Default::default()
+      },
+      vec![
+        Arc::new(ReplacePlugin::with_options(ReplaceOptions {
+          values: [("NAME".to_string(), "replaced".to_string())].into(),
+          // TODO: prevent_assignment: true
+          ..Default::default()
+        })),
+        Arc::new(TestPlugin(Arc::clone(&code))),
+      ],
+    )
+    .await;
+
+  let replaced = "declare const NAME: string\nconsole.log(replaced)\n";
+  assert_eq!(*code.lock().unwrap().as_ref().unwrap(), replaced);
+}

--- a/cspell.json
+++ b/cspell.json
@@ -183,6 +183,7 @@
     "webp",
     "Xiangjun",
     "Yinan",
-    "Yunfei"
+    "Yunfei",
+    "lvalue"
   ]
 }


### PR DESCRIPTION
related issue: #2057 

migrated from https://github.com/rollup/plugins/tree/master/packages/replace/test/fixtures/form

These tests have not been included in this pr:
- replacement-function: ~~will be added once I implement support for function as `Replacement`~~
- observe-plugin-options: we already have separated `values` and plugin options so it is unnecessary