### PR TITLE
perf(sourcemap): do not allocate `ConcatSourceMapBuilder` unconditionally

### DIFF
--- a/crates/rolldown_sourcemap/src/concat_sourcemap.rs
+++ b/crates/rolldown_sourcemap/src/concat_sourcemap.rs
@@ -123,13 +123,14 @@ impl ConcatSource {
 
   pub fn content_and_sourcemap(self) -> (String, Option<SourceMap>) {
     let mut final_source = String::new();
-    let mut sourcemap_builder =
-      self.enable_sourcemap.then_some(ConcatSourceMapBuilder::with_capacity(
+    let mut sourcemap_builder = self.enable_sourcemap.then(|| {
+      ConcatSourceMapBuilder::with_capacity(
         self.names_len,
         self.sources_len,
         self.tokens_len,
         self.token_chunks_len,
-      ));
+      )
+    });
     let mut line_offset = 0;
     let source_len = self.prepend_source.len() + self.inner.len();
 


### PR DESCRIPTION
I noticed `ConcatSourceMapBuilder::with_capacity` getting called unconditionally, resulting unnecessary memory allocation when sourcemap is turned off.