### PR TITLE
fix(plugin/replace): handle backtrack limit exceeded error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,6 +2439,7 @@ dependencies = [
 name = "rolldown_plugin_replace"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "fancy-regex",
  "rolldown",
  "rolldown_plugin",

--- a/crates/rolldown_plugin_replace/Cargo.toml
+++ b/crates/rolldown_plugin_replace/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 version              = "0.1.0"
 
 [dependencies]
+anyhow          = { workspace = true }
 fancy-regex     = { workspace = true }
 rolldown_plugin = { path = "../rolldown_plugin" }
 rustc-hash      = { workspace = true }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Solves https://github.com/rolldown/rolldown/pull/2056#issuecomment-2316570663.

The cause is that `fancy_regex` will limit the times of doing backtrack. If reach limit, `fancy_regex` will throw a error. The  `continue` in old code causes a infinite loop if there is error happed.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
