### PR TITLE
feat(plugin/replace): prevent assignment

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -289,6 +289,7 @@ impl TryFrom<BindingBuiltinPlugin> for Arc<dyn Pluginable> {
               || ReplaceOptions::default().delimiters,
               |raw| (raw[0].clone(), raw[1].clone()),
             ),
+            prevent_assignment: opts.prevent_assignment.unwrap_or(false),
           }
         })))
       }
@@ -304,4 +305,5 @@ pub struct BindingReplacePluginConfig {
   pub values: HashMap<String, String>,
   #[napi(ts_type = "[string, string]")]
   pub delimiters: Option<Vec<String>>,
+  pub prevent_assignment: Option<bool>,
 }

--- a/crates/rolldown_plugin_replace/tests/form/assignment/artifacts.snap
+++ b/crates/rolldown_plugin_replace/tests/form/assignment/artifacts.snap
@@ -1,0 +1,21 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## input.mjs
+
+```js
+
+//#region input.js
+process.env.DEBUG = "test";
+if (replaced === "production") {
+	console.log("");
+}
+if (world == "world") {
+	let hello = "world";
+	console.log(world);
+}
+
+//#endregion
+```

--- a/crates/rolldown_plugin_replace/tests/form/assignment/input.js
+++ b/crates/rolldown_plugin_replace/tests/form/assignment/input.js
@@ -1,1 +1,10 @@
 process.env.DEBUG = 'test';
+
+if (process.env.DEBUG === 'production') {
+  console.log('');
+}
+
+if (hello == 'world') {
+  let  hello = 'world';
+  console.log(hello);
+}

--- a/crates/rolldown_plugin_replace/tests/form/assignment/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/assignment/mod.rs
@@ -6,8 +6,7 @@ use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
 use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
 
 // doesn't replace lvalue in assignment
-// #[tokio::test(flavor = "multi_thread")]
-#[allow(dead_code)]
+#[tokio::test(flavor = "multi_thread")]
 async fn assignment() {
   let cwd = abs_file_dir!();
 
@@ -19,8 +18,12 @@ async fn assignment() {
         ..Default::default()
       },
       vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-        values: [("process.env.DEBUG".to_string(), "replaced".to_string())].into(),
-        // TODO: prevent_assignment: true
+        values: [
+          ("process.env.DEBUG".to_string(), "replaced".to_string()),
+          ("hello".to_string(), "world".to_string()),
+        ]
+        .into(),
+        prevent_assignment: true,
         ..Default::default()
       }))],
     )

--- a/crates/rolldown_plugin_replace/tests/form/delimiters/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/delimiters/mod.rs
@@ -19,6 +19,7 @@ async fn replace_strings() {
       vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
         values: [("original".to_string(), "replaced".to_string())].into(),
         delimiters: ("<%".to_string(), "%>".to_string()),
+        ..Default::default()
       }))],
     )
     .await;

--- a/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
@@ -6,8 +6,8 @@ use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
 use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
 
 // Handles process type guards in replacements
-// #[tokio::test(flavor = "multi_thread")]
-#[allow(dead_code)]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "TODO: implement the feature"]
 async fn process_check() {
   let cwd = abs_file_dir!();
 
@@ -20,7 +20,7 @@ async fn process_check() {
       },
       vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
         values: [("process.env.NODE_ENV".to_string(), "\"production\"".to_string())].into(),
-        // TODO: prevent_assignment: true
+        prevent_assignment: true,
         // TODO: object_guards: true
         ..Default::default()
       }))],

--- a/crates/rolldown_plugin_replace/tests/form/special_characters/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/special_characters/mod.rs
@@ -20,6 +20,7 @@ async fn special_characters() {
       vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
         values: [("require('one')".to_string(), "1".to_string())].into(),
         delimiters: (String::new(), String::new()),
+        ..Default::default()
       }))],
     )
     .await;

--- a/crates/rolldown_plugin_replace/tests/form/special_delimiters/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/special_delimiters/mod.rs
@@ -20,6 +20,7 @@ async fn special_delimiters() {
       vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
         values: [("special".to_string(), "replaced".to_string())].into(),
         delimiters: ("\\b".to_string(), "\\b".to_string()),
+        ..Default::default()
       }))],
     )
     .await;

--- a/crates/rolldown_plugin_replace/tests/form/ternary_operator/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/ternary_operator/mod.rs
@@ -24,7 +24,7 @@ async fn ternary_operator() {
           ("exprIfFalse".to_string(), "third".to_string()),
         ]
         .into(),
-        // TODO: prevent_assignment: true
+        prevent_assignment: true,
         ..Default::default()
       }))],
     )

--- a/crates/rolldown_plugin_replace/tests/form/typescript_declare/artifacts.snap
+++ b/crates/rolldown_plugin_replace/tests/form/typescript_declare/artifacts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## input.mjs
+
+```js
+
+//#region input.ts
+console.log(replaced);
+
+//#endregion
+```

--- a/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
@@ -27,8 +27,7 @@ impl Plugin for TestPlugin {
 }
 
 // doesn't replace lvalue in typescript declare
-// #[tokio::test(flavor = "multi_thread")]
-#[allow(dead_code)]
+#[tokio::test(flavor = "multi_thread")]
 async fn typescript_declare() {
   let cwd = abs_file_dir!();
   let code = Arc::new(Mutex::new(None));
@@ -43,7 +42,7 @@ async fn typescript_declare() {
       vec![
         Arc::new(ReplacePlugin::with_options(ReplaceOptions {
           values: [("NAME".to_string(), "replaced".to_string())].into(),
-          // TODO: prevent_assignment: true
+          prevent_assignment: true,
           ..Default::default()
         })),
         Arc::new(TestPlugin(Arc::clone(&code))),

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -349,6 +349,7 @@ export interface BindingRenderedModule {
 export interface BindingReplacePluginConfig {
   values: Record<string, string>
   delimiters?: [string, string]
+  preventAssignment?: boolean
 }
 
 export interface BindingResolveOptions {


### PR DESCRIPTION
related issue: #2057

This pr implements the same function with rollup's preventAssignment: https://github.com/rollup/plugins/blob/master/packages/replace/src/index.js#L77-L82

And part of the logic is put into the match loop, because of `fancy-regex`'s limitation that variable size of expression cannot be used in lookbehind (https://github.com/fancy-regex/fancy-regex/issues/74 and https://github.com/fancy-regex/fancy-regex/issues/109)