### PR TITLE
refactor: replace qualified path with use for `oxc::ast::ast`

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -113,7 +113,7 @@ impl<'me, 'ast> Visit<'ast> for AstScanner<'me> {
         self.try_diagnostic_forbid_const_assign(id_ref);
       }
       // Detect `module.exports` and `exports.ANY`
-      AssignmentTarget::StaticMemberExpression(member_expr) => match member_expr.object {
+      ast::AssignmentTarget::StaticMemberExpression(member_expr) => match member_expr.object {
         Expression::Identifier(ref id) => {
           if id.name == "module"
             && self.resolve_identifier_to_top_level_symbol(id).is_none()

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -1,6 +1,6 @@
 use oxc::{
   ast::{
-    ast::{self, Argument, AssignmentTarget, Expression, IdentifierReference, MemberExpression},
+    ast::{self, Expression, IdentifierReference, MemberExpression},
     visit::walk,
     Visit,
   },
@@ -96,7 +96,7 @@ impl<'me, 'ast> Visit<'ast> for AstScanner<'me> {
   }
 
   fn visit_import_expression(&mut self, expr: &ast::ImportExpression<'ast>) {
-    if let Expression::StringLiteral(request) = &expr.source {
+    if let ast::Expression::StringLiteral(request) = &expr.source {
       let id = self.add_import_record(
         request.value.as_str(),
         ImportKind::DynamicImport,
@@ -109,7 +109,7 @@ impl<'me, 'ast> Visit<'ast> for AstScanner<'me> {
 
   fn visit_assignment_expression(&mut self, node: &ast::AssignmentExpression<'ast>) {
     match &node.left {
-      AssignmentTarget::AssignmentTargetIdentifier(id_ref) => {
+      ast::AssignmentTarget::AssignmentTargetIdentifier(id_ref) => {
         self.try_diagnostic_forbid_const_assign(id_ref);
       }
       // Detect `module.exports` and `exports.ANY`
@@ -159,7 +159,7 @@ impl<'me, 'ast> Visit<'ast> for AstScanner<'me> {
       _ => {}
     }
     if expr.is_global_require_call(self.scopes) {
-      if let Some(Argument::StringLiteral(request)) = &expr.arguments.first() {
+      if let Some(ast::Argument::StringLiteral(request)) = &expr.arguments.first() {
         let id =
           self.add_import_record(request.value.as_str(), ImportKind::Require, request.span().start);
         self.result.imports.insert(expr.span, id);

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -2,13 +2,13 @@ pub mod impl_visit;
 pub mod side_effect_detector;
 
 use arcstr::ArcStr;
+use oxc::ast::ast;
 use oxc::index::IndexVec;
 use oxc::{
   ast::{
     ast::{
-      Declaration, ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration,
-      IdentifierReference, ImportDeclaration, ImportDeclarationSpecifier, ModuleDeclaration,
-      Program,
+      ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, IdentifierReference,
+      ImportDeclaration, ModuleDeclaration, Program,
     },
     Trivias, Visit,
   },
@@ -430,7 +430,7 @@ impl<'me> AstScanner<'me> {
       });
       if let Some(decl) = decl.declaration.as_ref() {
         match decl {
-          Declaration::VariableDeclaration(var_decl) => {
+          ast::Declaration::VariableDeclaration(var_decl) => {
             var_decl.declarations.iter().for_each(|decl| {
               decl.id.binding_identifiers().into_iter().for_each(|id| {
                 self.result.named_exports.insert(
@@ -443,11 +443,11 @@ impl<'me> AstScanner<'me> {
               });
             });
           }
-          Declaration::FunctionDeclaration(fn_decl) => {
+          ast::Declaration::FunctionDeclaration(fn_decl) => {
             let id = fn_decl.id.as_ref().unwrap();
             self.add_local_export(id.name.as_str(), id.expect_symbol_id(), id.span);
           }
-          Declaration::ClassDeclaration(cls_decl) => {
+          ast::Declaration::ClassDeclaration(cls_decl) => {
             let id = cls_decl.id.as_ref().unwrap();
             self.add_local_export(id.name.as_str(), id.expect_symbol_id(), id.span);
           }
@@ -471,15 +471,15 @@ impl<'me> AstScanner<'me> {
     use oxc::ast::ast::ExportDefaultDeclarationKind;
     let local_binding_for_default_export = match &decl.declaration {
       oxc::ast::match_expression!(ExportDefaultDeclarationKind) => None,
-      ExportDefaultDeclarationKind::FunctionDeclaration(fn_decl) => fn_decl
+      ast::ExportDefaultDeclarationKind::FunctionDeclaration(fn_decl) => fn_decl
         .id
         .as_ref()
         .map(|id| (rolldown_ecmascript::BindingIdentifierExt::expect_symbol_id(id), id.span)),
-      ExportDefaultDeclarationKind::ClassDeclaration(cls_decl) => cls_decl
+      ast::ExportDefaultDeclarationKind::ClassDeclaration(cls_decl) => cls_decl
         .id
         .as_ref()
         .map(|id| (rolldown_ecmascript::BindingIdentifierExt::expect_symbol_id(id), id.span)),
-      ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => unreachable!(),
+      ast::ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => unreachable!(),
     };
 
     let (reference, span) = local_binding_for_default_export
@@ -503,7 +503,7 @@ impl<'me> AstScanner<'me> {
 
     let Some(specifiers) = &decl.specifiers else { return };
     specifiers.iter().for_each(|spec| match spec {
-      ImportDeclarationSpecifier::ImportSpecifier(spec) => {
+      ast::ImportDeclarationSpecifier::ImportSpecifier(spec) => {
         let sym = spec.local.expect_symbol_id();
         let imported = spec.imported.name();
         self.add_named_import(sym, imported.as_str(), rec_id, spec.imported.span());
@@ -511,11 +511,11 @@ impl<'me> AstScanner<'me> {
           self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
         }
       }
-      ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
+      ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
         self.add_named_import(spec.local.expect_symbol_id(), "default", rec_id, spec.span);
         self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
       }
-      ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
+      ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
         self.add_star_import(spec.local.expect_symbol_id(), rec_id, spec.span);
         self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_STAR);
       }
@@ -523,19 +523,19 @@ impl<'me> AstScanner<'me> {
   }
   fn scan_module_decl(&mut self, decl: &ModuleDeclaration) {
     match decl {
-      ModuleDeclaration::ImportDeclaration(decl) => {
+      ast::ModuleDeclaration::ImportDeclaration(decl) => {
         self.esm_import_keyword.get_or_insert(Span::new(decl.span.start, decl.span.start + 6));
         self.scan_import_decl(decl);
       }
-      ModuleDeclaration::ExportAllDeclaration(decl) => {
+      ast::ModuleDeclaration::ExportAllDeclaration(decl) => {
         self.set_esm_export_keyword(Span::new(decl.span.start, decl.span.start + 6));
         self.scan_export_all_decl(decl);
       }
-      ModuleDeclaration::ExportNamedDeclaration(decl) => {
+      ast::ModuleDeclaration::ExportNamedDeclaration(decl) => {
         self.set_esm_export_keyword(Span::new(decl.span.start, decl.span.start + 6));
         self.scan_export_named_decl(decl);
       }
-      ModuleDeclaration::ExportDefaultDeclaration(decl) => {
+      ast::ModuleDeclaration::ExportDefaultDeclaration(decl) => {
         self.set_esm_export_keyword(Span::new(decl.span.start, decl.span.start + 6));
         self.scan_export_default_decl(decl);
       }

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -6,8 +6,9 @@ use oxc::index::IndexVec;
 use oxc::{
   ast::{
     ast::{
-      ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, IdentifierReference,
-      ImportDeclaration, ModuleDeclaration, Program,
+      Declaration, ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration,
+      IdentifierReference, ImportDeclaration, ImportDeclarationSpecifier, ModuleDeclaration,
+      Program,
     },
     Trivias, Visit,
   },
@@ -429,7 +430,7 @@ impl<'me> AstScanner<'me> {
       });
       if let Some(decl) = decl.declaration.as_ref() {
         match decl {
-          oxc::ast::ast::Declaration::VariableDeclaration(var_decl) => {
+          Declaration::VariableDeclaration(var_decl) => {
             var_decl.declarations.iter().for_each(|decl| {
               decl.id.binding_identifiers().into_iter().for_each(|id| {
                 self.result.named_exports.insert(
@@ -442,11 +443,11 @@ impl<'me> AstScanner<'me> {
               });
             });
           }
-          oxc::ast::ast::Declaration::FunctionDeclaration(fn_decl) => {
+          Declaration::FunctionDeclaration(fn_decl) => {
             let id = fn_decl.id.as_ref().unwrap();
             self.add_local_export(id.name.as_str(), id.expect_symbol_id(), id.span);
           }
-          oxc::ast::ast::Declaration::ClassDeclaration(cls_decl) => {
+          Declaration::ClassDeclaration(cls_decl) => {
             let id = cls_decl.id.as_ref().unwrap();
             self.add_local_export(id.name.as_str(), id.expect_symbol_id(), id.span);
           }
@@ -470,15 +471,15 @@ impl<'me> AstScanner<'me> {
     use oxc::ast::ast::ExportDefaultDeclarationKind;
     let local_binding_for_default_export = match &decl.declaration {
       oxc::ast::match_expression!(ExportDefaultDeclarationKind) => None,
-      oxc::ast::ast::ExportDefaultDeclarationKind::FunctionDeclaration(fn_decl) => fn_decl
+      ExportDefaultDeclarationKind::FunctionDeclaration(fn_decl) => fn_decl
         .id
         .as_ref()
         .map(|id| (rolldown_ecmascript::BindingIdentifierExt::expect_symbol_id(id), id.span)),
-      oxc::ast::ast::ExportDefaultDeclarationKind::ClassDeclaration(cls_decl) => cls_decl
+      ExportDefaultDeclarationKind::ClassDeclaration(cls_decl) => cls_decl
         .id
         .as_ref()
         .map(|id| (rolldown_ecmascript::BindingIdentifierExt::expect_symbol_id(id), id.span)),
-      oxc::ast::ast::ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => unreachable!(),
+      ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => unreachable!(),
     };
 
     let (reference, span) = local_binding_for_default_export
@@ -502,7 +503,7 @@ impl<'me> AstScanner<'me> {
 
     let Some(specifiers) = &decl.specifiers else { return };
     specifiers.iter().for_each(|spec| match spec {
-      oxc::ast::ast::ImportDeclarationSpecifier::ImportSpecifier(spec) => {
+      ImportDeclarationSpecifier::ImportSpecifier(spec) => {
         let sym = spec.local.expect_symbol_id();
         let imported = spec.imported.name();
         self.add_named_import(sym, imported.as_str(), rec_id, spec.imported.span());
@@ -510,11 +511,11 @@ impl<'me> AstScanner<'me> {
           self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
         }
       }
-      oxc::ast::ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
+      ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
         self.add_named_import(spec.local.expect_symbol_id(), "default", rec_id, spec.span);
         self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
       }
-      oxc::ast::ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
+      ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
         self.add_star_import(spec.local.expect_symbol_id(), rec_id, spec.span);
         self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_STAR);
       }
@@ -522,19 +523,19 @@ impl<'me> AstScanner<'me> {
   }
   fn scan_module_decl(&mut self, decl: &ModuleDeclaration) {
     match decl {
-      oxc::ast::ast::ModuleDeclaration::ImportDeclaration(decl) => {
+      ModuleDeclaration::ImportDeclaration(decl) => {
         self.esm_import_keyword.get_or_insert(Span::new(decl.span.start, decl.span.start + 6));
         self.scan_import_decl(decl);
       }
-      oxc::ast::ast::ModuleDeclaration::ExportAllDeclaration(decl) => {
+      ModuleDeclaration::ExportAllDeclaration(decl) => {
         self.set_esm_export_keyword(Span::new(decl.span.start, decl.span.start + 6));
         self.scan_export_all_decl(decl);
       }
-      oxc::ast::ast::ModuleDeclaration::ExportNamedDeclaration(decl) => {
+      ModuleDeclaration::ExportNamedDeclaration(decl) => {
         self.set_esm_export_keyword(Span::new(decl.span.start, decl.span.start + 6));
         self.scan_export_named_decl(decl);
       }
-      oxc::ast::ast::ModuleDeclaration::ExportDefaultDeclaration(decl) => {
+      ModuleDeclaration::ExportDefaultDeclaration(decl) => {
         self.set_esm_export_keyword(Span::new(decl.span.start, decl.span.start + 6));
         self.scan_export_default_decl(decl);
       }

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -1,11 +1,8 @@
 use oxc::ast::ast::{
-  Argument, ArrayExpressionElement, AssignmentTarget, AssignmentTargetPattern, BindingPatternKind,
-  CallExpression, ChainElement, Expression, IdentifierReference, ModuleDeclaration,
-  ObjectPropertyKind, PropertyKey,
+  self, Argument, ArrayExpressionElement, AssignmentTarget, AssignmentTargetPattern,
+  BindingPatternKind, CallExpression, ChainElement, Expression, IdentifierReference, PropertyKey,
 };
-use oxc::ast::{
-  match_declaration, match_expression, match_member_expression, match_module_declaration, Trivias,
-};
+use oxc::ast::{match_expression, match_member_expression, Trivias};
 use rolldown_common::AstScopes;
 use rustc_hash::FxHashSet;
 use std::sync::LazyLock;
@@ -82,7 +79,7 @@ impl<'a> SideEffectDetector<'a> {
   }
 
   /// ref: https://github.com/evanw/esbuild/blob/360d47230813e67d0312ad754cad2b6ee09b151b/internal/js_ast/js_ast_helpers.go#L2298-L2393
-  fn detect_side_effect_of_class(&mut self, cls: &oxc::ast::ast::Class) -> bool {
+  fn detect_side_effect_of_class(&mut self, cls: &ast::Class) -> bool {
     use oxc::ast::ast::ClassElement;
     if !cls.decorators.is_empty() {
       return true;
@@ -125,7 +122,7 @@ impl<'a> SideEffectDetector<'a> {
     })
   }
 
-  fn detect_side_effect_of_member_expr(&self, expr: &oxc::ast::ast::MemberExpression) -> bool {
+  fn detect_side_effect_of_member_expr(&self, expr: &ast::MemberExpression) -> bool {
     // MemberExpression is considered having side effect by default, unless it's some builtin global variables.
     let Some((ref_id, chains)) = extract_member_expr_chain(expr, 3) else {
       return true;
@@ -184,7 +181,7 @@ impl<'a> SideEffectDetector<'a> {
       | Expression::StringLiteral(_) => false,
       Expression::ObjectExpression(obj_expr) => {
         obj_expr.properties.iter().any(|obj_prop| match obj_prop {
-          ObjectPropertyKind::ObjectProperty(prop) => {
+          ast::ObjectPropertyKind::ObjectProperty(prop) => {
             let key_side_effect = self.detect_side_effect_of_property_key(&prop.key, prop.computed);
             if key_side_effect {
               return true;
@@ -198,7 +195,7 @@ impl<'a> SideEffectDetector<'a> {
             }
             self.detect_side_effect_of_expr(&prop.value)
           }
-          ObjectPropertyKind::SpreadProperty(_) => {
+          ast::ObjectPropertyKind::SpreadProperty(_) => {
             // ...[expression] is considered as having side effect.
             // see crates/rolldown/tests/fixtures/rollup/object-spread-side-effect
             true
@@ -294,10 +291,7 @@ impl<'a> SideEffectDetector<'a> {
     }
   }
 
-  fn detect_side_effect_of_var_decl(
-    &mut self,
-    var_decl: &oxc::ast::ast::VariableDeclaration,
-  ) -> bool {
+  fn detect_side_effect_of_var_decl(&mut self, var_decl: &ast::VariableDeclaration) -> bool {
     var_decl.declarations.iter().any(|declarator| {
       // Whether to destructure import.meta
       if let BindingPatternKind::ObjectPattern(ref obj_pat) = declarator.id.kind {
@@ -317,7 +311,7 @@ impl<'a> SideEffectDetector<'a> {
     })
   }
 
-  fn detect_side_effect_of_decl(&mut self, decl: &oxc::ast::ast::Declaration) -> bool {
+  fn detect_side_effect_of_decl(&mut self, decl: &ast::Declaration) -> bool {
     use oxc::ast::ast::Declaration;
     match decl {
       Declaration::VariableDeclaration(var_decl) => self.detect_side_effect_of_var_decl(var_decl),
@@ -336,7 +330,7 @@ impl<'a> SideEffectDetector<'a> {
 
   fn detect_side_effect_of_using_declarators(
     &self,
-    declarators: &[oxc::ast::ast::VariableDeclarator],
+    declarators: &[ast::VariableDeclarator],
   ) -> bool {
     declarators.iter().any(|decl| {
       decl.init.as_ref().map_or(false, |init| match init {
@@ -355,34 +349,36 @@ impl<'a> SideEffectDetector<'a> {
   }
 
   #[allow(clippy::too_many_lines)]
-  pub fn detect_side_effect_of_stmt(&mut self, stmt: &oxc::ast::ast::Statement) -> bool {
+  pub fn detect_side_effect_of_stmt(&mut self, stmt: &ast::Statement) -> bool {
     use oxc::ast::ast::Statement;
     match stmt {
-      match_declaration!(Statement) => self.detect_side_effect_of_decl(stmt.to_declaration()),
+      oxc::ast::match_declaration!(Statement) => {
+        self.detect_side_effect_of_decl(stmt.to_declaration())
+      }
       Statement::ExpressionStatement(expr) => self.detect_side_effect_of_expr(&expr.expression),
-      match_module_declaration!(Statement) => match stmt.to_module_declaration() {
-        ModuleDeclaration::ExportAllDeclaration(_) => true,
-        ModuleDeclaration::ImportDeclaration(_) => {
+      oxc::ast::match_module_declaration!(Statement) => match stmt.to_module_declaration() {
+        ast::ModuleDeclaration::ExportAllDeclaration(_) => true,
+        ast::ModuleDeclaration::ImportDeclaration(_) => {
           // We consider `import ...` has no side effect. However, `import ...` might be rewritten to other statements by the bundler.
           // In that case, we will mark the statement as having side effect in link stage.
           false
         }
-        ModuleDeclaration::ExportDefaultDeclaration(default_decl) => {
+        ast::ModuleDeclaration::ExportDefaultDeclaration(default_decl) => {
           use oxc::ast::ast::ExportDefaultDeclarationKind;
           match &default_decl.declaration {
             decl @ oxc::ast::match_expression!(ExportDefaultDeclarationKind) => {
               self.detect_side_effect_of_expr(decl.to_expression())
             }
-            ExportDefaultDeclarationKind::FunctionDeclaration(_) => false,
-            ExportDefaultDeclarationKind::ClassDeclaration(decl) => {
+            ast::ExportDefaultDeclarationKind::FunctionDeclaration(_) => false,
+            ast::ExportDefaultDeclarationKind::ClassDeclaration(decl) => {
               self.detect_side_effect_of_class(decl)
             }
-            ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => {
+            ast::ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => {
               unreachable!("ts should be transpiled")
             }
           }
         }
-        ModuleDeclaration::ExportNamedDeclaration(named_decl) => {
+        ast::ModuleDeclaration::ExportNamedDeclaration(named_decl) => {
           if named_decl.source.is_some() {
             // `export { ... } from '...'` is considered as side effect.
             true
@@ -393,8 +389,8 @@ impl<'a> SideEffectDetector<'a> {
               .map_or(false, |decl| self.detect_side_effect_of_decl(decl))
           }
         }
-        ModuleDeclaration::TSExportAssignment(_)
-        | ModuleDeclaration::TSNamespaceExportDeclaration(_) => {
+        ast::ModuleDeclaration::TSExportAssignment(_)
+        | ast::ModuleDeclaration::TSNamespaceExportDeclaration(_) => {
           unreachable!("ts should be transpiled")
         }
       },
@@ -450,7 +446,7 @@ impl<'a> SideEffectDetector<'a> {
     }
   }
 
-  fn detect_side_effect_of_block(&mut self, block: &oxc::ast::ast::BlockStatement) -> bool {
+  fn detect_side_effect_of_block(&mut self, block: &ast::BlockStatement) -> bool {
     block.body.iter().any(|stmt| self.detect_side_effect_of_stmt(stmt))
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. we don't need to worry about the conflicting since the naming only used for AstNode
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
