### PR TITLE
chore: remove unnecessary command in `justfile` and add doc for `just fix`

### DIFF
--- a/docs/contrib-guide/building-and-running.md
+++ b/docs/contrib-guide/building-and-running.md
@@ -16,7 +16,7 @@ You could get a list of available commands by running the command `just` only.
 - `just test` - Runs all tests.
 - `just lint` - Lint the codebase.
 - `just fmt` - Fix formatting issues.
-- `just fix` - Fix formatting and some linting issues.
+- `just fix` - Fix formatting and linting issues.
 
 > Most of commands will run both Rust and Node.js scripts. To only target one, append `-rust` or `-node` to the just command. For example, `just lint-rust` or `just check-node`.
 

--- a/docs/contrib-guide/building-and-running.md
+++ b/docs/contrib-guide/building-and-running.md
@@ -16,6 +16,7 @@ You could get a list of available commands by running the command `just` only.
 - `just test` - Runs all tests.
 - `just lint` - Lint the codebase.
 - `just fmt` - Fix formatting issues.
+- `just fix` - Fix formatting and some linting issues.
 
 > Most of commands will run both Rust and Node.js scripts. To only target one, append `-rust` or `-node` to the just command. For example, `just lint-rust` or `just check-node`.
 

--- a/justfile
+++ b/justfile
@@ -80,7 +80,6 @@ _test-node-rollup command="":
     pnpm run --filter rollup-tests test{{ command }}
 
 # Fix formatting issues both for Rust, Node.js and all files in the repository
-
 fmt: fmt-rust fmt-repo
 
 fmt-rust:
@@ -92,7 +91,7 @@ fmt-repo:
     pnpm lint-prettier:fix
     pnpm lint-toml:fix
 
-# lint the codebase
+# Lint the codebase
 lint: lint-rust lint-node lint-repo
 
 lint-rust:
@@ -106,12 +105,12 @@ lint-node:
 lint-repo:
     pnpm lint-repo
 
+# Fix formatting and some linting issues
 fix: fix-rust fix-repo
 
 fix-rust:
     just fmt-rust
     cargo fix --allow-dirty
-    cargo shear --fix
 
 fix-repo:
     pnpm lint-code --fix

--- a/justfile
+++ b/justfile
@@ -85,7 +85,6 @@ fmt: fmt-rust fmt-repo
 fmt-rust:
     cargo fmt --all -- --emit=files
     taplo fmt
-    cargo shear --fix
 
 fmt-repo:
     pnpm lint-prettier:fix
@@ -111,6 +110,7 @@ fix: fix-rust fix-repo
 fix-rust:
     just fmt-rust
     cargo fix --allow-dirty
+    cargo shear --fix
 
 fix-repo:
     pnpm lint-code --fix


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Related to #2000 

Because `cargo shear --fix` exists in `fmt-rust`.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
