### PR TITLE
perf(rolldown): use `itoa` for integer to string conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,7 @@ dependencies = [
  "indexmap",
  "insta",
  "itertools 0.13.0",
+ "itoa",
  "memchr",
  "oxc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ indexmap            = "2.2.6"
 infer               = "0.16.0"
 insta               = "1.39.0"
 itertools           = "0.13.0"
+itoa                = "1.0.11"
 json-strip-comments = "1.0.4"
 jsonschema          = { version = "0.18.0", default-features = false }
 lightningcss        = { version = "1.0.0-alpha.57" }

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -23,6 +23,7 @@ dunce                    = { workspace = true }
 futures                  = { workspace = true }
 indexmap                 = { workspace = true }
 itertools                = { workspace = true }
+itoa                     = { workspace = true }
 memchr                   = { workspace = true }
 oxc                      = { workspace = true }
 regex                    = { workspace = true }

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -69,7 +69,10 @@ impl<'name> Renamer<'name> {
             Entry::Occupied(mut occ) => {
               let next_conflict_index = *occ.get() + 1;
               *occ.get_mut() = next_conflict_index;
-              candidate_name = Cow::Owned(format!("{original_name}${next_conflict_index}",).into());
+              candidate_name = Cow::Owned(
+                format!("{original_name}${}", itoa::Buffer::new().format(next_conflict_index))
+                  .into(),
+              );
             }
             Entry::Vacant(vac) => {
               vac.insert(0);
@@ -93,7 +96,9 @@ impl<'name> Renamer<'name> {
         Entry::Occupied(mut occ) => {
           let next_conflict_index = *occ.get() + 1;
           *occ.get_mut() = next_conflict_index;
-          conflictless_name = Cow::Owned(format!("{hint}${next_conflict_index}",).into());
+          conflictless_name = Cow::Owned(
+            format!("{hint}${}", itoa::Buffer::new().format(next_conflict_index)).into(),
+          );
         }
         Entry::Vacant(vac) => {
           vac.insert(0);
@@ -134,7 +139,8 @@ impl<'name> Renamer<'name> {
               .any(|used_canonical_names| used_canonical_names.contains_key(&candidate_name));
 
             if is_shadowed {
-              candidate_name = Cow::Owned(format!("{binding_name}${count}").into());
+              candidate_name =
+                Cow::Owned(format!("{binding_name}${}", itoa::Buffer::new().format(count)).into());
               count += 1;
             } else {
               used_canonical_names_for_this_scope.insert(candidate_name.clone(), 0);

--- a/cspell.json
+++ b/cspell.json
@@ -97,6 +97,7 @@
     "insta",
     "instanceof",
     "Itertools",
+    "itoa",
     "iwanabethatguy",
     "izip",
     "Jrcy",


### PR DESCRIPTION

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/3f10e605-b41d-4561-819b-95cfa74e53ef">

```rust
let i: u32 = 0;
format!("{i}");
```

is really costly in Rust as it involves heap allocation.

> This crate provides a fast conversion of integer primitives to decimal strings.
> The implementation comes straight from libcore but avoids the performance penalty of going through core::fmt::Formatter.

I haven't checked the rest of the codebase for such patterns, feel free to change them.

