### PR TITLE
perf(rolldown): only recreate semantic data when ast is changed in pre_process_ecma_ast

### DIFF
--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -27,6 +27,9 @@ pub fn pre_process_ecma_ast(
   replace_global_define_config: Option<&ReplaceGlobalDefinesConfig>,
   bundle_options: &NormalizedBundlerOptions,
 ) -> anyhow::Result<(EcmaAst, SymbolTable, ScopeTree)> {
+  // Only recreate semantic data if ast is changed.
+  let mut ast_changed = false;
+
   // Build initial semantic data and check for semantic errors.
   let semantic_ret = ast.program.with_mut(|WithMutFields { program, source, .. }| {
     SemanticBuilder::new(source, source_type).build(program)
@@ -69,12 +72,14 @@ pub fn pre_process_ecma_ast(
 
     symbols = ret.symbols;
     scopes = ret.scopes;
+    ast_changed = true;
   }
 
   ast.program.with_mut(|WithMutFields { allocator, program, .. }| -> anyhow::Result<()> {
     // Use built-in define plugin.
     if let Some(replace_global_define_config) = replace_global_define_config {
       ReplaceGlobalDefines::new(allocator, replace_global_define_config.clone()).build(program);
+      ast_changed = true;
     }
 
     if !bundle_options.inject.is_empty() {
@@ -83,11 +88,18 @@ pub fn pre_process_ecma_ast(
         bundle_options.oxc_inject_global_variables_config.clone(),
       )
       .build(&mut symbols, &mut scopes, program);
+      ast_changed = true;
     }
 
     // Perform dead code elimination.
     let options = CompressOptions::dead_code_elimination();
-    Compressor::new(allocator, options).build(program);
+    let compressor = Compressor::new(allocator, options);
+    if ast_changed {
+      // This method recreates symbols and scopes.
+      compressor.build(program);
+    } else {
+      compressor.build_with_symbols_and_scopes(symbols, scopes, program);
+    }
 
     Ok(())
   })?;
@@ -98,7 +110,7 @@ pub fn pre_process_ecma_ast(
     EnsureSpanUniqueness::new().visit_program(fields.program);
   });
 
-  // We have to re-create the symbol table and scope tree after the transformation so far to make sure they are up-to-date.
+  // NOTE: Recreate semantic data because AST is changed in the transformations above.
   let (symbols, scopes) = ast.make_symbol_table_and_scope_tree();
 
   Ok((ast, symbols, scopes))


### PR DESCRIPTION
Semantic data do not need to be recreated if ast is unchanged.

I intend to improve this situation later on, but this is a good first step.

* https://github.com/oxc-project/oxc/issues/5390
* https://github.com/oxc-project/backlog/issues/85
