### PR TITLE
feat(plugin/replace): objectGuards

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -290,6 +290,7 @@ impl TryFrom<BindingBuiltinPlugin> for Arc<dyn Pluginable> {
               |raw| (raw[0].clone(), raw[1].clone()),
             ),
             prevent_assignment: opts.prevent_assignment.unwrap_or(false),
+            object_guards: opts.object_guards.unwrap_or(false),
           }
         })))
       }
@@ -306,4 +307,5 @@ pub struct BindingReplacePluginConfig {
   #[napi(ts_type = "[string, string]")]
   pub delimiters: Option<Vec<String>>,
   pub prevent_assignment: Option<bool>,
+  pub object_guards: Option<bool>,
 }

--- a/crates/rolldown_plugin_replace/src/lib.rs
+++ b/crates/rolldown_plugin_replace/src/lib.rs
@@ -1,3 +1,4 @@
 mod plugin;
+mod utils;
 
 pub use plugin::{ReplaceOptions, ReplacePlugin};

--- a/crates/rolldown_plugin_replace/src/utils.rs
+++ b/crates/rolldown_plugin_replace/src/utils.rs
@@ -1,0 +1,52 @@
+use std::{collections::HashMap, sync::LazyLock};
+
+use fancy_regex::Regex;
+
+static OBJECT_RE: LazyLock<Regex> = LazyLock::new(|| {
+  let pattern = r"^([_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*)(\.([_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*))+$";
+  Regex::new(pattern).expect("Should be valid regex")
+});
+
+pub(crate) fn expand_typeof_replacements(
+  values: &HashMap<String, String>,
+) -> HashMap<String, String> {
+  values
+    .keys()
+    .filter_map(|key| {
+      if let Ok(true) = OBJECT_RE.is_match(key) {
+        Some(key.char_indices().filter_map(|(pos, c)| {
+          if c == '.' {
+            Some((format!("typeof {}", &key[0..pos]), "\"object\"".to_string()))
+          } else {
+            None
+          }
+        }))
+      } else {
+        None
+      }
+    })
+    .flatten()
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::HashMap;
+
+  use super::expand_typeof_replacements;
+
+  #[test]
+  fn test_expand() {
+    let map = HashMap::from([("a.b.c.d".to_string(), "x".to_string())]);
+
+    let result = expand_typeof_replacements(&map);
+
+    let expected = HashMap::from([
+      ("typeof a".to_string(), "\"object\"".to_string()),
+      ("typeof a.b".to_string(), "\"object\"".to_string()),
+      ("typeof a.b.c".to_string(), "\"object\"".to_string()),
+    ]);
+
+    assert_eq!(result, expected);
+  }
+}

--- a/crates/rolldown_plugin_replace/tests/form/process_check/artifacts.snap
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/artifacts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## input.mjs
+
+```js
+
+//#region input.js
+{
+	console.log("production");
+}
+
+//#endregion
+```

--- a/crates/rolldown_plugin_replace/tests/form/process_check/input.js
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/input.js
@@ -1,3 +1,3 @@
-if (typeof process !== 'undefined' && process.env.NODE_ENV === 'production') {
+if (typeof process !== 'undefined' && typeof process.env === "object" && process.env.NODE_ENV === 'production') {
   console.log('production');
 }

--- a/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
@@ -7,7 +7,6 @@ use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_con
 
 // Handles process type guards in replacements
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "TODO: implement the feature"]
 async fn process_check() {
   let cwd = abs_file_dir!();
 
@@ -21,7 +20,7 @@ async fn process_check() {
       vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
         values: [("process.env.NODE_ENV".to_string(), "\"production\"".to_string())].into(),
         prevent_assignment: true,
-        // TODO: object_guards: true
+        object_guards: true,
         ..Default::default()
       }))],
     )

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -359,6 +359,7 @@ export interface BindingReplacePluginConfig {
   values: Record<string, string>
   delimiters?: [string, string]
   preventAssignment?: boolean
+  objectGuards?: boolean
 }
 
 export interface BindingResolveOptions {


### PR DESCRIPTION
Related issue: #2057. This pr implements the same function with [rollup's](https://github.com/rollup/plugins/blob/master/packages/replace/README.md#objectguards)

Additionally, the rollup's `objectGuards` doesn't take effects actually, even in the test case's [snapshot](https://github.com/rollup/plugins/blob/master/packages/replace/test/snapshots/form.js.md?plain=1#L46). It caused by the wrong implementation of function [`expandTypeofReplacements`](https://github.com/rollup/plugins/blob/master/packages/replace/src/index.js#L41). In this pr, I rewrite this function and I plan to fix it in rollup


