### PR TITLE
refactor: remove pointless `Cow` in `Renamer`

### DIFF
--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -21,7 +21,7 @@ pub fn deconflict_chunk_symbols(
     .flat_map(|m| m.scope.root_unresolved_references().keys().map(Cow::Borrowed))
     .for_each(|name| {
       // global names should be reserved
-      renamer.reserve(Cow::Owned(name.to_rstr()));
+      renamer.reserve(name.to_rstr());
     });
 
   // Though, those symbols in `imports_from_other_chunks` doesn't belong to this chunk, but in the final output, they still behave


### PR DESCRIPTION
### Description

`Renamer::used_canonical_names` was an `FxHashMap<Cow<'name, Rstr>, u32>`. But its keys are always `Cow::Owned`,  so the `Cow` wrapper serves no purpose and is pure overhead. Replace it with `FxHashMap<Rstr, u32>`.

I happened to come across this while looking at the renaming algorithm.