### PR TITLE
chore(repo/vscode): ignored expanding `#[napi]` macro

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,5 +44,6 @@
     "temp": true,
     "tmp": true
   },
-  "editor.wordWrap": "on"
+  "editor.wordWrap": "on",
+  "rust-analyzer.procMacro.ignored": { "napi-derive": ["napi"] }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

because vscode refuses to autocomplete/autosuggest code when using the #[napi] macro
use .vscode/setting.json file for fix napi-rs IDE support problem maybe more convenient for every forks.
