### PR TITLE
fix(node/rolldown): mark all tsfn as weak to avoid long exit time

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -2,10 +2,11 @@
 
 use std::collections::HashMap;
 
-use crate::types::{binding_log::BindingLog, binding_log_level::BindingLogLevel};
+use crate::types::{
+  binding_log::BindingLog, binding_log_level::BindingLogLevel, js_callback::JsCallback,
+};
 use binding_inject_import::BindingInjectImport;
 use derivative::Derivative;
-use napi::threadsafe_function::ThreadsafeFunction;
 use napi_derive::napi;
 use serde::Deserialize;
 
@@ -37,9 +38,7 @@ pub struct BindingInputOptions {
   #[napi(
     ts_type = "undefined | ((source: string, importer: string | undefined, isResolved: boolean) => boolean)"
   )]
-  pub external: Option<
-    ThreadsafeFunction<(String, Option<String>, bool), bool, (String, Option<String>, bool), false>,
-  >,
+  pub external: Option<JsCallback<(String, Option<String>, bool), bool>>,
   pub input: Vec<BindingInputItem>,
   // makeAbsoluteExternalsRelative?: boolean | 'ifRelativeSource';
   // /** @deprecated Use the "manualChunks" output option instead. */
@@ -82,5 +81,4 @@ pub struct BindingInputOptions {
   pub inject: Option<Vec<BindingInjectImport>>,
 }
 
-pub type BindingOnLog =
-  Option<ThreadsafeFunction<(String, BindingLog), (), (String, BindingLog), false>>;
+pub type BindingOnLog = Option<JsCallback<(String, BindingLog), ()>>;

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -1,4 +1,4 @@
-use crate::types::js_callback::MaybeAsyncJsCallback;
+use crate::types::js_callback::{JsCallback, MaybeAsyncJsCallback};
 use std::collections::HashMap;
 
 use super::super::types::binding_rendered_chunk::RenderedChunk;
@@ -6,7 +6,6 @@ use super::plugin::BindingPluginOrParallelJsPluginPlaceholder;
 use crate::types::binding_pre_rendered_chunk::PreRenderedChunk;
 use derivative::Derivative;
 use napi::bindgen_prelude::FunctionRef;
-use napi::threadsafe_function::ThreadsafeFunction;
 use napi::Either;
 use napi_derive::napi;
 use serde::Deserialize;
@@ -89,13 +88,11 @@ pub struct BindingOutputOptions {
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(source: string, sourcemapPath: string) => boolean")]
-  pub sourcemap_ignore_list:
-    Option<ThreadsafeFunction<(String, String), bool, (String, String), false>>,
+  pub sourcemap_ignore_list: Option<JsCallback<(String, String), bool>>,
   #[derivative(Debug = "ignore")]
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(source: string, sourcemapPath: string) => string")]
-  pub sourcemap_path_transform:
-    Option<ThreadsafeFunction<(String, String), String, (String, String), false>>,
+  pub sourcemap_path_transform: Option<JsCallback<(String, String), String>>,
   // sourcemapExcludeSources: boolean;
   // sourcemapFile: string | undefined;
   // strict: boolean;

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -1,5 +1,8 @@
-use crate::options::binding_inject_import::normalize_binding_inject_import;
 use crate::options::ChunkFileNamesOutputOption;
+use crate::{
+  options::binding_inject_import::normalize_binding_inject_import,
+  types::js_callback::JsCallbackExt,
+};
 #[cfg_attr(target_family = "wasm", allow(unused))]
 use crate::{
   options::plugin::JsPlugin,
@@ -80,7 +83,7 @@ pub fn normalize_binding_options(
       let ts_fn = ts_fn.clone();
       Box::pin(async move {
         ts_fn
-          .call_async((source.to_string(), importer.map(|v| v.to_string()), is_resolved))
+          .invoke_async((source.to_string(), importer.map(|v| v.to_string()), is_resolved))
           .await
           .map_err(anyhow::Error::from)
       })
@@ -93,7 +96,7 @@ pub fn normalize_binding_options(
       let source = source.to_string();
       let sourcemap_path = sourcemap_path.to_string();
       Box::pin(async move {
-        ts_fn.call_async((source, sourcemap_path)).await.map_err(anyhow::Error::from)
+        ts_fn.invoke_async((source, sourcemap_path)).await.map_err(anyhow::Error::from)
       })
     }))
   });
@@ -104,7 +107,7 @@ pub fn normalize_binding_options(
       let source = source.to_string();
       let sourcemap_path = sourcemap_path.to_string();
       Box::pin(async move {
-        ts_fn.call_async((source, sourcemap_path)).await.map_err(anyhow::Error::from)
+        ts_fn.invoke_async((source, sourcemap_path)).await.map_err(anyhow::Error::from)
       })
     }))
   });

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -51,8 +51,12 @@ fn normalize_chunk_file_names_option(
     .map(move |value| match value {
       Either::A(str) => Ok(ChunkFilenamesOutputOption::String(str)),
       Either::B(func) => {
-        let func =
-          func.borrow_back(&env)?.build_threadsafe_function().callee_handled::<false>().build()?;
+        let func = func
+          .borrow_back(&env)?
+          .build_threadsafe_function()
+          .callee_handled::<false>()
+          .weak::<true>()
+          .build()?;
         Ok(ChunkFilenamesOutputOption::Fn(Box::new(move |chunk| {
           let func = func.clone();
           let chunk = chunk.clone();

--- a/packages/rolldown/src/cli/index.ts
+++ b/packages/rolldown/src/cli/index.ts
@@ -10,7 +10,7 @@ async function main() {
 
   if (cliOptions.config) {
     await bundleWithConfig(cliOptions.config, cliOptions)
-    process.exit(0)
+    return
   }
 
   if ('input' in cliOptions.input) {

--- a/packages/rolldown/src/cli/index.ts
+++ b/packages/rolldown/src/cli/index.ts
@@ -16,12 +16,12 @@ async function main() {
   if ('input' in cliOptions.input) {
     // If input is specified, we will bundle with the input options
     await bundleWithCliOptions(cliOptions)
-    process.exit(0)
+    return
   }
 
   if (cliOptions.version) {
     logger.log(`rolldown v${version}`)
-    process.exit(0)
+    return
   }
 
   showHelp()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
- Closes https://github.com/rolldown/rolldown/issues/928.
- Closes https://github.com/rolldown/rolldown/pull/985.

Notice that this will break the implementation of `ParallelPlugin` due to worker doesn't support creating weak tsfn https://github.com/rolldown/rolldown/pull/985#issuecomment-2081384205.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
