### PR TITLE
feat: store pervious build module info and using it at next hmr module loader

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -30,9 +30,9 @@ pub struct Bundler {
   pub(crate) resolver: SharedResolver,
   pub(crate) file_emitter: SharedFileEmitter,
   pub(crate) _log_guard: Option<FlushGuard>,
-  pub(crate) last_module_table: ModuleTable,
-  pub(crate) last_module_id_to_modules: FxHashMap<ArcStr, ModuleIdx>,
-  pub(crate) last_index_ecma_ast: IndexEcmaAst,
+  pub(crate) previous_module_table: ModuleTable,
+  pub(crate) previous_module_id_to_modules: FxHashMap<ArcStr, ModuleIdx>,
+  pub(crate) pervious_index_ecma_ast: IndexEcmaAst,
 }
 
 impl Bundler {
@@ -134,9 +134,9 @@ impl Bundler {
       Arc::clone(&self.plugin_driver),
       self.fs,
       Arc::clone(&self.resolver),
-      std::mem::take(&mut self.last_module_id_to_modules),
-      std::mem::take(&mut self.last_module_table),
-      std::mem::take(&mut self.last_index_ecma_ast),
+      std::mem::take(&mut self.previous_module_id_to_modules),
+      std::mem::take(&mut self.previous_module_table),
+      std::mem::take(&mut self.pervious_index_ecma_ast),
     )?;
 
     let output = match hmr_module_loader.fetch_changed_modules(changed_files).await? {
@@ -147,9 +147,9 @@ impl Bundler {
     };
 
     // store last build modules info
-    self.last_module_table = output.module_table;
-    self.last_module_id_to_modules = output.module_id_to_modules;
-    self.last_index_ecma_ast = output.index_ecma_ast;
+    self.previous_module_table = output.module_table;
+    self.previous_module_id_to_modules = output.module_id_to_modules;
+    self.pervious_index_ecma_ast = output.index_ecma_ast;
 
     Ok(HmrOutput { warnings: output.warnings, errors: vec![] })
   }
@@ -198,9 +198,9 @@ impl Bundler {
     self.plugin_driver.generate_bundle(&mut output.assets, is_write).await?;
 
     // store last build modules info
-    self.last_module_table = link_stage_output.module_table;
-    self.last_module_id_to_modules = link_stage_output.module_id_to_modules;
-    self.last_index_ecma_ast = link_stage_output.ast_table;
+    self.previous_module_table = link_stage_output.module_table;
+    self.previous_module_id_to_modules = link_stage_output.module_id_to_modules;
+    self.pervious_index_ecma_ast = link_stage_output.ast_table;
 
     Ok(output)
   }

--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -6,17 +6,21 @@ use super::stages::{
 };
 use crate::{
   bundler_builder::BundlerBuilder,
+  module_loader::hmr_module_loader::HmrModuleLoader,
   stages::{generate_stage::GenerateStage, scan_stage::ScanStage},
-  types::bundle_output::BundleOutput,
+  type_alias::IndexEcmaAst,
+  types::{bundle_output::BundleOutput, hmr_output::HmrOutput},
   BundlerOptions, SharedOptions, SharedResolver,
 };
 use anyhow::Result;
-use rolldown_common::{NormalizedBundlerOptions, SharedFileEmitter};
+use arcstr::ArcStr;
+use rolldown_common::{ModuleIdx, ModuleTable, NormalizedBundlerOptions, SharedFileEmitter};
 use rolldown_error::{BuildDiagnostic, DiagnosableResult};
 use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_plugin::{
   HookBuildEndArgs, HookRenderErrorArgs, SharedPluginDriver, __inner::SharedPluginable,
 };
+use rustc_hash::FxHashMap;
 use tracing_chrome::FlushGuard;
 
 pub struct Bundler {
@@ -26,6 +30,9 @@ pub struct Bundler {
   pub(crate) resolver: SharedResolver,
   pub(crate) file_emitter: SharedFileEmitter,
   pub(crate) _log_guard: Option<FlushGuard>,
+  pub(crate) last_module_table: ModuleTable,
+  pub(crate) last_module_id_to_modules: FxHashMap<ArcStr, ModuleIdx>,
+  pub(crate) last_index_ecma_ast: IndexEcmaAst,
 }
 
 impl Bundler {
@@ -121,8 +128,30 @@ impl Bundler {
   }
 
   #[allow(clippy::unused_async)]
-  pub async fn hmr_rebuild(&mut self, _changed_files: Vec<String>) -> Result<()> {
-    unimplemented!()
+  pub async fn hmr_rebuild(&mut self, changed_files: Vec<String>) -> Result<HmrOutput> {
+    let hmr_module_loader = HmrModuleLoader::new(
+      Arc::clone(&self.options),
+      Arc::clone(&self.plugin_driver),
+      self.fs,
+      Arc::clone(&self.resolver),
+      std::mem::take(&mut self.last_module_id_to_modules),
+      std::mem::take(&mut self.last_module_table),
+      std::mem::take(&mut self.last_index_ecma_ast),
+    )?;
+
+    let output = match hmr_module_loader.fetch_changed_modules(changed_files).await? {
+      Ok(output) => output,
+      Err(errors) => {
+        return Ok(HmrOutput { warnings: vec![], errors });
+      }
+    };
+
+    // store last build modules info
+    self.last_module_table = output.module_table;
+    self.last_module_id_to_modules = output.module_id_to_modules;
+    self.last_index_ecma_ast = output.index_ecma_ast;
+
+    Ok(HmrOutput { warnings: output.warnings, errors: vec![] })
   }
 
   async fn try_build(&mut self) -> Result<DiagnosableResult<LinkStageOutput>> {
@@ -167,6 +196,11 @@ impl Bundler {
     self.file_emitter.add_additional_files(&mut output.assets);
 
     self.plugin_driver.generate_bundle(&mut output.assets, is_write).await?;
+
+    // store last build modules info
+    self.last_module_table = link_stage_output.module_table;
+    self.last_module_id_to_modules = link_stage_output.module_id_to_modules;
+    self.last_index_ecma_ast = link_stage_output.ast_table;
 
     Ok(output)
   }

--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -43,9 +43,9 @@ impl BundlerBuilder {
       options,
       fs: OsFileSystem,
       _log_guard: maybe_guard,
-      last_module_table: ModuleTable::default(),
-      last_module_id_to_modules: FxHashMap::default(),
-      last_index_ecma_ast: IndexVec::default(),
+      previous_module_table: ModuleTable::default(),
+      previous_module_id_to_modules: FxHashMap::default(),
+      pervious_index_ecma_ast: IndexVec::default(),
     }
   }
 

--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
-use rolldown_common::FileEmitter;
+use oxc::index::IndexVec;
+use rolldown_common::{FileEmitter, ModuleTable};
 use rolldown_fs::OsFileSystem;
 use rolldown_plugin::{PluginDriver, __inner::SharedPluginable};
 use rolldown_resolver::Resolver;
+use rustc_hash::FxHashMap;
 
 use crate::{
   utils::{
@@ -41,6 +43,9 @@ impl BundlerBuilder {
       options,
       fs: OsFileSystem,
       _log_guard: maybe_guard,
+      last_module_table: ModuleTable::default(),
+      last_module_id_to_modules: FxHashMap::default(),
+      last_index_ecma_ast: IndexVec::default(),
     }
   }
 

--- a/crates/rolldown/src/module_loader/hmr_module_loader.rs
+++ b/crates/rolldown/src/module_loader/hmr_module_loader.rs
@@ -27,9 +27,9 @@ pub struct HmrIntermediateNormalModules {
 }
 
 impl HmrIntermediateNormalModules {
-  pub fn new(last_module_table: ModuleTable, index_ecma_ast: IndexEcmaAst) -> Self {
+  pub fn new(previous_module_table: ModuleTable, index_ecma_ast: IndexEcmaAst) -> Self {
     Self {
-      modules: last_module_table.modules.into_iter().map(Some).collect::<IndexVec<_, _>>(),
+      modules: previous_module_table.modules.into_iter().map(Some).collect::<IndexVec<_, _>>(),
       index_ecma_ast,
     }
   }
@@ -66,9 +66,9 @@ impl HmrModuleLoader {
     plugin_driver: SharedPluginDriver,
     fs: OsFileSystem,
     resolver: SharedResolver,
-    last_module_id_to_modules: FxHashMap<ArcStr, ModuleIdx>,
-    last_module_table: ModuleTable,
-    last_index_ecma_ast: IndexEcmaAst,
+    previous_module_id_to_modules: FxHashMap<ArcStr, ModuleIdx>,
+    previous_module_table: ModuleTable,
+    pervious_index_ecma_ast: IndexEcmaAst,
   ) -> anyhow::Result<Self> {
     // 1024 should be enough for most cases
     // over 1024 pending tasks are insane
@@ -99,14 +99,14 @@ impl HmrModuleLoader {
     });
 
     let intermediate_normal_modules =
-      HmrIntermediateNormalModules::new(last_module_table, last_index_ecma_ast);
+      HmrIntermediateNormalModules::new(previous_module_table, pervious_index_ecma_ast);
     let symbols = Symbols::default();
 
     Ok(Self {
       shared_context: common_data,
       rx,
       options,
-      visited: last_module_id_to_modules,
+      visited: previous_module_id_to_modules,
       remaining: 0,
       intermediate_normal_modules,
       symbols,

--- a/crates/rolldown/src/module_loader/hmr_module_loader.rs
+++ b/crates/rolldown/src/module_loader/hmr_module_loader.rs
@@ -1,11 +1,8 @@
 use super::module_task::{ModuleTask, ModuleTaskOwner};
-use super::runtime_module_task::RuntimeModuleTask;
 use super::task_context::TaskContextMeta;
 use super::task_result::NormalModuleTaskResult;
 use super::Msg;
-use crate::module_loader::runtime_module_task::RuntimeModuleTaskResult;
 use crate::module_loader::task_context::TaskContext;
-use crate::runtime::{RuntimeModuleBrief, RUNTIME_MODULE_ID};
 use crate::type_alias::IndexEcmaAst;
 use crate::types::symbols::Symbols;
 use arcstr::ArcStr;
@@ -14,76 +11,68 @@ use oxc::minifier::ReplaceGlobalDefinesConfig;
 use oxc::span::Span;
 use rolldown_common::side_effects::{DeterminedSideEffects, HookSideEffects};
 use rolldown_common::{
-  EntryPoint, EntryPointKind, ExternalModule, ImportKind, ImportRecordIdx, ImporterRecord, Module,
-  ModuleIdx, ModuleTable, ResolvedId,
+  ExternalModule, ImportRecordIdx, Module, ModuleDefFormat, ModuleIdx, ModuleTable, ResolvedId,
 };
 use rolldown_error::{BuildDiagnostic, DiagnosableResult};
 use rolldown_fs::OsFileSystem;
 use rolldown_plugin::SharedPluginDriver;
-use rolldown_utils::rustc_hash::FxHashSetExt;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
 use crate::{SharedOptions, SharedResolver};
 
-pub struct IntermediateNormalModules {
+pub struct HmrIntermediateNormalModules {
   pub modules: IndexVec<ModuleIdx, Option<Module>>,
-  pub importers: IndexVec<ModuleIdx, Vec<ImporterRecord>>,
   pub index_ecma_ast: IndexEcmaAst,
 }
 
-impl IntermediateNormalModules {
-  pub fn new() -> Self {
+impl HmrIntermediateNormalModules {
+  pub fn new(last_module_table: ModuleTable, index_ecma_ast: IndexEcmaAst) -> Self {
     Self {
-      modules: IndexVec::new(),
-      importers: IndexVec::new(),
-      index_ecma_ast: IndexVec::default(),
+      modules: last_module_table.modules.into_iter().map(Some).collect::<IndexVec<_, _>>(),
+      index_ecma_ast,
     }
   }
 
   pub fn alloc_ecma_module_idx(&mut self, symbols: &mut Symbols) -> ModuleIdx {
     let id = self.modules.push(None);
-    self.importers.push(Vec::new());
     symbols.alloc_one();
     id
   }
 }
 
-pub struct ModuleLoader {
+pub struct HmrModuleLoader {
   options: SharedOptions,
   shared_context: Arc<TaskContext>,
   rx: tokio::sync::mpsc::Receiver<Msg>,
   visited: FxHashMap<ArcStr, ModuleIdx>,
-  runtime_id: ModuleIdx,
   remaining: u32,
-  intermediate_normal_modules: IntermediateNormalModules,
+  intermediate_normal_modules: HmrIntermediateNormalModules,
   symbols: Symbols,
 }
 
-pub struct ModuleLoaderOutput {
+pub struct HmrModuleLoaderOutput {
   // Stored all modules
   pub module_table: ModuleTable,
   pub module_id_to_modules: FxHashMap<ArcStr, ModuleIdx>,
   pub index_ecma_ast: IndexEcmaAst,
-  pub symbols: Symbols,
-  // Entries that user defined + dynamic import entries
-  pub entry_points: Vec<EntryPoint>,
-  pub runtime: RuntimeModuleBrief,
+  //   pub symbols: Symbols,
   pub warnings: Vec<BuildDiagnostic>,
 }
 
-impl ModuleLoader {
+impl HmrModuleLoader {
   pub fn new(
     options: SharedOptions,
     plugin_driver: SharedPluginDriver,
     fs: OsFileSystem,
     resolver: SharedResolver,
+    last_module_id_to_modules: FxHashMap<ArcStr, ModuleIdx>,
+    last_module_table: ModuleTable,
+    last_index_ecma_ast: IndexEcmaAst,
   ) -> anyhow::Result<Self> {
     // 1024 should be enough for most cases
     // over 1024 pending tasks are insane
     let (tx, rx) = tokio::sync::mpsc::channel::<Msg>(1024);
-
-    let tx_to_runtime_module = tx.clone();
 
     let meta = TaskContextMeta {
       replace_global_define_config: if options.define.is_empty() {
@@ -109,32 +98,16 @@ impl ModuleLoader {
       meta,
     });
 
-    let mut intermediate_normal_modules = IntermediateNormalModules::new();
-    let mut symbols = Symbols::default();
-    let runtime_id = intermediate_normal_modules.alloc_ecma_module_idx(&mut symbols);
-
-    let task = RuntimeModuleTask::new(runtime_id, tx_to_runtime_module);
-
-    #[cfg(target_family = "wasm")]
-    {
-      task.run().unwrap();
-    }
-    // task is sync, but execution time is too short at the moment
-    // so we are using spawn instead of spawn_blocking here to avoid an additional blocking thread creation within tokio
-    #[cfg(not(target_family = "wasm"))]
-    {
-      let handle = tokio::runtime::Handle::current();
-      handle.spawn(async { task.run() });
-    }
+    let intermediate_normal_modules =
+      HmrIntermediateNormalModules::new(last_module_table, last_index_ecma_ast);
+    let symbols = Symbols::default();
 
     Ok(Self {
       shared_context: common_data,
       rx,
       options,
-      visited: FxHashMap::from_iter([(RUNTIME_MODULE_ID.into(), runtime_id)]),
-      runtime_id,
-      // runtime module is always there
-      remaining: 1,
+      visited: last_module_id_to_modules,
+      remaining: 0,
       intermediate_normal_modules,
       symbols,
     })
@@ -200,39 +173,48 @@ impl ModuleLoader {
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
-  pub async fn fetch_all_modules(
+  pub async fn fetch_changed_modules(
     mut self,
-    user_defined_entries: Vec<(Option<ArcStr>, ResolvedId)>,
-  ) -> anyhow::Result<DiagnosableResult<ModuleLoaderOutput>> {
+    changed_modules: Vec<String>,
+  ) -> anyhow::Result<DiagnosableResult<HmrModuleLoaderOutput>> {
     if self.options.input.is_empty() {
       return Err(anyhow::format_err!("You must supply options.input to rolldown"));
     }
 
+    // spawn valid changed modules
+    changed_modules
+      .into_iter()
+      .filter_map(|m| self.visited.get(m.as_str()).map(|idx| (m, idx)))
+      .for_each(|(m, idx)| {
+        self.remaining += 1;
+
+        let task = ModuleTask::new(
+          Arc::clone(&self.shared_context),
+          *idx,
+          ResolvedId {
+            id: m.into(),
+            ignored: false,
+            module_def_format: ModuleDefFormat::Unknown,
+            is_external: false,
+            package_json: None,
+            side_effects: None,
+          },
+          None,
+        );
+        #[cfg(target_family = "wasm")]
+        {
+          let handle = tokio::runtime::Handle::current();
+          // could not block_on/spawn the main thread in WASI
+          std::thread::spawn(move || {
+            handle.spawn(task.run());
+          });
+        }
+        #[cfg(not(target_family = "wasm"))]
+        tokio::spawn(task.run());
+      });
+
     let mut errors = vec![];
     let mut all_warnings: Vec<BuildDiagnostic> = vec![];
-
-    let entries_count = user_defined_entries.len() + /* runtime */ 1;
-    self.intermediate_normal_modules.modules.reserve(entries_count);
-    self.intermediate_normal_modules.index_ecma_ast.reserve(entries_count);
-
-    // Store the already consider as entry module
-    let mut user_defined_entry_ids = FxHashSet::with_capacity(user_defined_entries.len());
-
-    let mut entry_points = user_defined_entries
-      .into_iter()
-      .map(|(name, info)| EntryPoint {
-        name,
-        id: self.try_spawn_new_task(info, /* is_user_defined_entry */ None),
-        kind: EntryPointKind::UserDefined,
-      })
-      .inspect(|e| {
-        user_defined_entry_ids.insert(e.id);
-      })
-      .collect::<Vec<_>>();
-
-    let mut dynamic_import_entry_ids = FxHashSet::default();
-
-    let mut runtime_brief: Option<RuntimeModuleBrief> = None;
 
     while self.remaining > 0 {
       let Some(msg) = self.rx.recv().await else {
@@ -262,16 +244,6 @@ impl ModuleLoader {
                   Span::new(raw_rec.module_request_start, raw_rec.module_request_end()),
                 );
                 let id = self.try_spawn_new_task(info, Some(owner));
-                // Dynamic imported module will be considered as an entry
-                self.intermediate_normal_modules.importers[id].push(ImporterRecord {
-                  kind: raw_rec.kind,
-                  importer_path: module.id().to_string().into(),
-                });
-                if matches!(raw_rec.kind, ImportKind::DynamicImport)
-                  && !user_defined_entry_ids.contains(&id)
-                {
-                  dynamic_import_entry_ids.insert(id);
-                }
                 raw_rec.into_import_record(id)
               })
               .collect::<IndexVec<ImportRecordIdx, _>>();
@@ -284,14 +256,8 @@ impl ModuleLoader {
           }
           self.intermediate_normal_modules.modules[module_idx] = Some(module);
         }
-        Msg::RuntimeNormalModuleDone(task_result) => {
-          let RuntimeModuleTaskResult { ast_symbols, mut module, runtime, ast } = task_result;
-          let ast_idx = self.intermediate_normal_modules.index_ecma_ast.push((ast, module.idx));
-          module.ecma_ast_idx = Some(ast_idx);
-          self.intermediate_normal_modules.modules[self.runtime_id] = Some(module.into());
-
-          self.symbols.add_ast_symbols(self.runtime_id, ast_symbols);
-          runtime_brief = Some(runtime);
+        Msg::RuntimeNormalModuleDone(_) => {
+          unreachable!("Runtime module should not be done at hmr module loader");
         }
         Msg::BuildErrors(e) => {
           errors.extend(e);
@@ -318,47 +284,14 @@ impl ModuleLoader {
       return Ok(Err(errors));
     }
 
-    let modules: IndexVec<ModuleIdx, Module> = self
-      .intermediate_normal_modules
-      .modules
-      .into_iter()
-      .flatten()
-      .enumerate()
-      .map(|(id, mut module)| {
-        if let Some(module) = module.as_ecma_mut() {
-          // Note: (Compat to rollup)
-          // The `dynamic_importers/importers` should be added after `module_parsed` hook.
-          for importer in std::mem::take(&mut self.intermediate_normal_modules.importers[id]) {
-            if importer.kind.is_static() {
-              module.importers.push(importer.importer_path);
-            } else {
-              module.dynamic_importers.push(importer.importer_path);
-            }
-          }
-        }
-        module
-      })
-      .collect();
+    let modules: IndexVec<ModuleIdx, Module> =
+      self.intermediate_normal_modules.modules.into_iter().flatten().collect();
 
-    // if `inline_dynamic_imports` is set to be true, here we should not put dynamic imports to entries
-    if !self.options.inline_dynamic_imports {
-      let mut dynamic_import_entry_ids = dynamic_import_entry_ids.into_iter().collect::<Vec<_>>();
-      dynamic_import_entry_ids.sort_unstable_by_key(|id| modules[*id].stable_id());
-
-      entry_points.extend(dynamic_import_entry_ids.into_iter().map(|id| EntryPoint {
-        name: None,
-        id,
-        kind: EntryPointKind::DynamicImport,
-      }));
-    }
-
-    Ok(Ok(ModuleLoaderOutput {
+    Ok(Ok(HmrModuleLoaderOutput {
       module_table: ModuleTable { modules },
       module_id_to_modules: self.visited,
-      symbols: self.symbols,
+      //   symbols: self.symbols,
       index_ecma_ast: self.intermediate_normal_modules.index_ecma_ast,
-      entry_points,
-      runtime: runtime_brief.expect("Failed to find runtime module. This should not happen"),
       warnings: all_warnings,
     }))
   }

--- a/crates/rolldown/src/module_loader/mod.rs
+++ b/crates/rolldown/src/module_loader/mod.rs
@@ -1,3 +1,4 @@
+pub mod hmr_module_loader;
 pub mod module_loader;
 mod module_task;
 mod runtime_module_task;

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -1,5 +1,6 @@
 use std::{ptr::addr_of, sync::Mutex};
 
+use arcstr::ArcStr;
 use oxc::index::IndexVec;
 use rolldown_common::{
   EntryPoint, ExportsKind, ImportKind, ImportRecordMeta, Module, ModuleIdx, ModuleTable,
@@ -10,7 +11,7 @@ use rolldown_utils::{
   ecma_script::legitimize_identifier_name,
   rayon::{ParallelBridge, ParallelIterator},
 };
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
   runtime::RuntimeModuleBrief,
@@ -34,6 +35,7 @@ mod wrapping;
 #[derive(Debug)]
 pub struct LinkStageOutput {
   pub module_table: ModuleTable,
+  pub module_id_to_modules: FxHashMap<ArcStr, ModuleIdx>,
   pub entries: Vec<EntryPoint>,
   pub ast_table: IndexEcmaAst,
   // pub sorted_modules: Vec<NormalModuleId>,
@@ -48,6 +50,7 @@ pub struct LinkStageOutput {
 #[derive(Debug)]
 pub struct LinkStage<'a> {
   pub module_table: ModuleTable,
+  pub module_id_to_modules: FxHashMap<ArcStr, ModuleIdx>,
   pub entries: Vec<EntryPoint>,
   pub symbols: Symbols,
   pub runtime: RuntimeModuleBrief,
@@ -89,6 +92,7 @@ impl<'a> LinkStage<'a> {
         })
         .collect::<IndexVec<ModuleIdx, _>>(),
       module_table: scan_stage_output.module_table,
+      module_id_to_modules: scan_stage_output.module_id_to_modules,
       entries: scan_stage_output.entry_points,
       symbols: scan_stage_output.symbols,
       runtime: scan_stage_output.runtime,
@@ -114,6 +118,7 @@ impl<'a> LinkStage<'a> {
 
     LinkStageOutput {
       module_table: self.module_table,
+      module_id_to_modules: self.module_id_to_modules,
       entries: self.entries,
       // sorted_modules: self.sorted_modules,
       metas: self.metas,

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 use anyhow::Result;
 use arcstr::ArcStr;
 use futures::future::join_all;
-use rolldown_common::{EntryPoint, ImportKind, ModuleTable, ResolvedId};
+use rolldown_common::{EntryPoint, ImportKind, ModuleIdx, ModuleTable, ResolvedId};
 use rolldown_error::{BuildDiagnostic, DiagnosableResult};
 use rolldown_fs::OsFileSystem;
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_resolver::ResolveError;
+use rustc_hash::FxHashMap;
 
 use crate::{
   module_loader::{module_loader::ModuleLoaderOutput, ModuleLoader},
@@ -28,6 +29,7 @@ pub struct ScanStage {
 #[derive(Debug)]
 pub struct ScanStageOutput {
   pub module_table: ModuleTable,
+  pub module_id_to_modules: FxHashMap<ArcStr, ModuleIdx>,
   pub index_ecma_ast: IndexEcmaAst,
   pub entry_points: Vec<EntryPoint>,
   pub symbols: Symbols,
@@ -73,6 +75,7 @@ impl ScanStage {
       runtime,
       warnings,
       index_ecma_ast,
+      module_id_to_modules,
     } = match module_loader.fetch_all_modules(user_entries).await? {
       Ok(output) => output,
       Err(errors) => {
@@ -82,6 +85,7 @@ impl ScanStage {
 
     Ok(Ok(ScanStageOutput {
       module_table,
+      module_id_to_modules,
       entry_points,
       symbols,
       runtime,

--- a/crates/rolldown/src/types/hmr_output.rs
+++ b/crates/rolldown/src/types/hmr_output.rs
@@ -1,0 +1,7 @@
+use rolldown_error::BuildDiagnostic;
+
+#[derive(Default)]
+pub struct HmrOutput {
+  pub warnings: Vec<BuildDiagnostic>,
+  pub errors: Vec<BuildDiagnostic>,
+}

--- a/crates/rolldown/src/types/mod.rs
+++ b/crates/rolldown/src/types/mod.rs
@@ -6,6 +6,7 @@ pub mod ast_symbols;
 pub mod bundle_output;
 pub mod bundler_fs;
 pub mod generator;
+pub mod hmr_output;
 pub mod linking_metadata;
 pub mod module_factory;
 pub mod namespace_alias;

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -157,8 +157,13 @@ impl Bundler {
       napi::Error::from_reason("Failed to lock the bundler. Is another operation in progress?")
     })?;
 
-    let _ = bundler_core.hmr_rebuild(changed_files).await;
+    let output = bundler_core.hmr_rebuild(changed_files).await?;
 
+    if !output.errors.is_empty() {
+      return Err(self.handle_errors(output.errors));
+    }
+
+    self.handle_warnings(output.warnings).await;
     Ok(())
   }
 

--- a/crates/rolldown_common/src/types/module_table.rs
+++ b/crates/rolldown_common/src/types/module_table.rs
@@ -4,7 +4,7 @@ use oxc::index::IndexVec;
 pub type IndexModules = IndexVec<ModuleIdx, Module>;
 pub type IndexExternalModules = IndexVec<ExternalModuleIdx, ExternalModule>;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ModuleTable {
   pub modules: IndexModules,
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Here create new `HmrModuleLoader` to scan modules which imported from changed modules. The `changed modules` will direct spawn new task using previous module id.

The `HmrIntermediateNormalModules` comes from the previous module info, so here we could to re-using more logic from `ModuleLoader`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
