### PR TITLE
fix(rolldown): remove `console.log`

### DIFF
--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -90,7 +90,6 @@ export function bindingifyResolveId(
     return {}
   }
   const { handler, meta, options } = normalizeHook(hook)
-  console.log(options)
 
   return {
     plugin: async (ctx, specifier, importer, extraOptions) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Remove accidentally introduced `console.log`.