### PR TITLE
feat(rust/advance-chunks): should include matched module's dependencies too

### DIFF
--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/.gitignore
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/_config.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "advancedChunks": {
+      "groups": [
+        {
+          "test": "[\\\\/]node_modules",
+          "name": "other-libs",
+          "priority": 0
+        },
+        {
+          "test": "node_modules[\\\\/]+lib-ui",
+          "name": "ui",
+          "priority": 10
+        }
+      ]
+    }
+  },
+  "hiddenRuntimeModule": false
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
@@ -1,0 +1,54 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.mjs
+
+```js
+import { lib_ui_index_ns } from "./ui.mjs";
+import { lib_npm_a_index_ns, lib_npm_b_index_ns } from "./other-libs.mjs";
+
+export { lib_npm_a_index_ns as libA, lib_npm_b_index_ns as libB, lib_ui_index_ns as ui };
+```
+## other-libs.mjs
+
+```js
+import { __export } from "./ui.mjs";
+
+//#region node_modules/lib-npm-a/index.js
+var lib_npm_a_index_ns = {};
+__export(lib_npm_a_index_ns, { default: () => lib_npm_a_index_default });
+var lib_npm_a_index_default = "npm-a";
+
+//#endregion
+//#region node_modules/lib-npm-b/index.js
+var lib_npm_b_index_ns = {};
+__export(lib_npm_b_index_ns, { default: () => lib_npm_b_index_default });
+var lib_npm_b_index_default = "npm-b";
+
+//#endregion
+export { lib_npm_a_index_ns, lib_npm_b_index_ns };
+```
+## ui.mjs
+
+```js
+
+//#region rolldown:runtime
+var __defProp = Object.defineProperty;
+var __export = (target, all) => {
+	for (var name in all) __defProp(target, name, {
+		get: all[name],
+		enumerable: true
+	});
+};
+
+//#endregion
+//#region node_modules/lib-ui/index.js
+var lib_ui_index_ns = {};
+__export(lib_ui_index_ns, { default: () => lib_ui_index_default });
+var lib_ui_index_default = "ui";
+
+//#endregion
+export { __export, lib_ui_index_ns };
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/main.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/main.js
@@ -1,0 +1,9 @@
+import * as ui from 'lib-ui'
+import * as libA from 'lib-npm-a'
+import * as libB from 'lib-npm-b'
+
+export {
+  ui,
+  libA,
+  libB
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-npm-a/index.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-npm-a/index.js
@@ -1,0 +1,1 @@
+export default 'npm-a'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-npm-a/package.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-npm-a/package.json
@@ -1,0 +1,3 @@
+{
+    "exports": "./index.js"
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-npm-b/index.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-npm-b/index.js
@@ -1,0 +1,1 @@
+export default 'npm-b'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-npm-b/package.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-npm-b/package.json
@@ -1,0 +1,3 @@
+{
+    "exports": "./index.js"
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-ui/index.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-ui/index.js
@@ -1,0 +1,1 @@
+export default 'ui'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-ui/package.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/node_modules/lib-ui/package.json
@@ -1,0 +1,3 @@
+{
+    "exports": "./index.js"
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -1464,6 +1464,12 @@ expression: "snapshot_outputs.join(\"\\n\")"
 - b-!~{001}~.mjs => b--_DvZU4q.mjs
 - common-!~{002}~.mjs => common-FR5ObYUG.mjs
 
+# tests/rolldown/function/advanced_chunks/split_node_modules
+
+- main-!~{000}~.mjs => main-M6jfBy0m.mjs
+- other-libs-!~{003}~.mjs => other-libs-U1jz6W1o.mjs
+- ui-!~{001}~.mjs => ui-a1Jazfmy.mjs
+
 # tests/rolldown/function/define/node_env
 
 - main-!~{000}~.mjs => main-zmFhpGWu.mjs


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Consider case

```js
// index.js

import { a } from './a'
import './b'

console.log(a)

// a.js

export const a = 'a

// b.js

import { a } from './a'
console.log(a)

```

Notice that `b.js` rely on `a.js`'s export. If we move `b.js` to a new chunk `vendor.js` and don't touch `a.js`.

The output would be

### main.js
```js
// a.js

const a = 'a'

// index.js

console.log(a)

```

### `vendor.js`

```js
import { a } from './main'
// Wrong here. Entry chunk `main.js` doesn't export `a`. Dependencies of the module in common chunk must be in common chunk too.

// b.js

console.log(a)

```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
