### PR TITLE
chore:  use npx lint-staged instead of pnpx lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpx lint-staged
+npx lint-staged


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
since it is faster
```
⋊> ~/D/r/rolldown on chore/use-npx-lint-staged ⨯ hyperfine --warmup 1 --runs 3 'pnpx lint-staged' 'npx lint-staged'                                                                  00:55:20
Benchmark 1: pnpx lint-staged
  Time (mean ± σ):     384.8 ms ±   4.5 ms    [User: 345.3 ms, System: 101.0 ms]
  Range (min … max):   380.2 ms … 389.2 ms    3 runs
 
Benchmark 2: npx lint-staged
  Time (mean ± σ):     310.7 ms ±   3.4 ms    [User: 333.0 ms, System: 78.2 ms]
  Range (min … max):   308.0 ms … 314.5 ms    3 runs
 
Summary
  'npx lint-staged' ran
    1.24 ± 0.02 times faster than 'pnpx lint-staged'
```
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
