### PR TITLE
refactor(app): transform import declaration

### DIFF
--- a/crates/rolldown/src/module_finalizers/isolating/mod.rs
+++ b/crates/rolldown/src/module_finalizers/isolating/mod.rs
@@ -1,17 +1,22 @@
 use oxc::allocator::Allocator;
-use rolldown_common::{EcmaModule, IndexModules};
+use rolldown_common::{AstScopes, EcmaModule, IndexModules, SymbolRef};
 use rolldown_ecmascript::AstSnippet;
+use rustc_hash::FxHashSet;
+
+use crate::types::symbols::Symbols;
 
 mod impl_visit_mut;
 
 pub struct IsolatingModuleFinalizerContext<'me> {
   pub module: &'me EcmaModule,
   pub modules: &'me IndexModules,
+  pub symbols: &'me Symbols,
 }
 
 pub struct IsolatingModuleFinalizer<'me, 'ast> {
   pub ctx: &'me IsolatingModuleFinalizerContext<'me>,
-  // pub scope: &'me AstScopes,
+  pub scope: &'me AstScopes,
   pub alloc: &'ast Allocator,
   pub snippet: AstSnippet<'ast>,
+  pub generated_imports: FxHashSet<SymbolRef>,
 }

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use arcstr::ArcStr;
 use oxc::{ast::VisitMut, index::IndexVec};
 use rolldown_ecmascript::AstSnippet;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use rolldown_common::{ChunkIdx, ChunkKind, FileNameRenderOptions, Module, PreliminaryFilename};
 use rolldown_plugin::SharedPluginDriver;
@@ -99,12 +99,14 @@ impl<'a> GenerateStage<'a> {
             let (oxc_program, alloc) = (fields.program, fields.allocator);
             let mut finalizer = IsolatingModuleFinalizer {
               alloc,
-              // scope: &module.scope,
+              scope: &module.scope,
               ctx: &IsolatingModuleFinalizerContext {
                 module,
                 modules: &self.link_output.module_table.modules,
+                symbols: &self.link_output.symbols,
               },
               snippet: AstSnippet::new(alloc),
+              generated_imports: FxHashSet::default(),
             };
             finalizer.visit_program(oxc_program);
           });

--- a/crates/rolldown/tests/rolldown/function/format/app/multiple_entry_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/app/multiple_entry_modules/artifacts.snap
@@ -13,9 +13,9 @@ export default function square(x) {
 
 //#endregion
 //#region cube.js
-var { default: square } = __static_import("square.js");
+var square_ns = require("./square.js");
 export default function cube(x) {
-	return square(x) * x;
+	return square_ns.default(x) * x;
 }
 
 //#endregion
@@ -24,15 +24,15 @@ export default function cube(x) {
 
 ```js
 //#region hyper-cube.js
-var { default: cube } = __static_import("cube.js");
+var cube_ns = require("./cube.js");
 export default function hyperCube(x) {
-	return cube(x) * x;
+	return cube_ns.default(x) * x;
 }
 
 //#endregion
 //#region main.js
-var { default: hyperCube } = __static_import("hyper-cube.js");
-console.log(hyperCube(5));
+var hyper_cube_ns = require("./hyper-cube.js");
+console.log(hyper_cube_ns.default(5));
 
 //#endregion
 ```
@@ -40,8 +40,8 @@ console.log(hyperCube(5));
 
 ```js
 //#region other-entry.js
-var { default: cube } = __static_import("cube.js");
-console.log(cube(5));
+var cube_ns = require("./cube.js");
+console.log(cube_ns.default(5));
 
 //#endregion
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -1652,9 +1652,9 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/rolldown/function/format/app/multiple_entry_modules
 
-- main-!~{000}~.mjs => main-soihLkqo.mjs
-- other-entry-!~{001}~.mjs => other-entry-coajbluq.mjs
-- cube-!~{002}~.mjs => cube-UC9SFjeM.mjs
+- main-!~{000}~.mjs => main-imdddhb2.mjs
+- other-entry-!~{001}~.mjs => other-entry-UkXCP9mG.mjs
+- cube-!~{002}~.mjs => cube-oE71YyBO.mjs
 
 # tests/rolldown/function/format/cjs/conflict_exports_key
 

--- a/crates/rolldown_ecmascript/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript/src/ast_snippet.rs
@@ -2,8 +2,9 @@ use oxc::{
   allocator::{self, Allocator, Box, IntoIn},
   ast::{
     ast::{
-      self, Argument, BindingIdentifier, BindingRestElement, ImportOrExportKind, Statement,
-      TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration, TSTypeParameterInstantiation,
+      self, Argument, BindingIdentifier, BindingRestElement, Expression, ImportOrExportKind,
+      Statement, TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration,
+      TSTypeParameterInstantiation, VariableDeclarationKind,
     },
     AstBuilder,
   },
@@ -553,6 +554,42 @@ impl<'ast> AstSnippet<'ast> {
       SPAN,
       ast::VariableDeclarationKind::Var,
       declarations,
+      false,
+    ))
+  }
+
+  pub fn require_call_expr(&self, source: &str) -> Expression<'ast> {
+    self.builder.expression_call(
+      SPAN,
+      self.builder.expression_identifier_reference(SPAN, "require"),
+      None::<TSTypeParameterInstantiation>,
+      self.builder.vec1(
+        self.builder.argument_expression(self.builder.expression_string_literal(SPAN, source)),
+      ),
+      false,
+    )
+  }
+
+  pub fn variable_declarator_require_call_stmt(
+    &self,
+    source: &str,
+    assignee: &str,
+    span: Span,
+  ) -> Statement<'ast> {
+    self.builder.statement_declaration(self.builder.declaration_variable(
+      span,
+      VariableDeclarationKind::Var,
+      self.builder.vec1(self.builder.variable_declarator(
+        SPAN,
+        VariableDeclarationKind::Var,
+        self.builder.binding_pattern(
+          self.builder.binding_pattern_kind_binding_identifier(SPAN, assignee),
+          None::<TSTypeAnnotation>,
+          false,
+        ),
+        Some(self.require_call_expr(source)),
+        false,
+      )),
       false,
     ))
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Before `const { default, a, b: b2 } = __static_import('xxx')` will make the live binding invalid, so here fixed it.