### PR TITLE
perf(plugin_replace): set more reasonable number for regex `backtrack_limit`

### DIFF
--- a/crates/rolldown_plugin_replace/src/plugin.rs
+++ b/crates/rolldown_plugin_replace/src/plugin.rs
@@ -60,9 +60,11 @@ impl ReplacePlugin {
     let pattern = format!("{delimiter_left}({joined_keys}){delimiter_right}{lookahead}");
     Self {
       matcher: RegexBuilder::new(&pattern)
-        // Give a `usize::MAX` will cause bundle time tripled in some cases, so we need to use sensible limit
-        // to have a balance between performance and correctness.
-        .backtrack_limit(1_000_000)
+        // Set `backtrack_limit` for `delimiters` and `lookahead` because they contain backtracking pattern `!?` and `*`.
+        // Cannot set the number too low or it will be ignored by `fancy_regex::Error::RuntimeError` in `try_replace`.
+        // Setting `backtrack_limit` to a large number will cause huge performance regression.
+        // See <https://github.com/fancy-regex/fancy-regex/blob/main/PERFORMANCE.md#fancy-regex>.
+        .backtrack_limit(1000)
         .build()
         .unwrap_or_else(|_| panic!("Invalid regex {pattern:?}")),
       prevent_assignment: options.prevent_assignment,


### PR DESCRIPTION
Set `backtrack_limit` for `delimiters` and `lookahead` because they contain backtracking pattern `!?` and `*`.
Cannot set the number too low or it will be ignored by `fancy_regex::Error::RuntimeError` in `try_replace`.
Setting `backtrack_limit` to a large number will cause huge performance regression.
See <https://github.com/fancy-regex/fancy-regex/blob/main/PERFORMANCE.md#fancy-regex>.

---

Before:

24% program execution time

![image](https://github.com/user-attachments/assets/bf1d32d7-c8f9-43e6-9b2f-46ad9120847a)

After:

It's gone 

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/bc95b19c-faeb-4b60-9023-3d823827216d">
