### PR TITLE
chore: remove unnecessary config file `rusty-hook.toml`

### DIFF
--- a/rusty-hook.toml
+++ b/rusty-hook.toml
@@ -1,5 +1,0 @@
-[hooks]
-pre-commit = "just check-typo && just fmt && just lint"
-
-[logging]
-verbose = true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Initially, we used `rusty-hook` to integrate with `pre-commit` (PR #5). However, due to some oversight, we accidentally removed it (PR #536), while the `rusty-hook.toml` configuration file was still retained. Maybe we can restore its use.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
