### PR TITLE
feat(app): rewrite export default declaration

### DIFF
--- a/crates/rolldown/src/module_finalizers/isolating/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/isolating/impl_visit_mut.rs
@@ -134,7 +134,10 @@ impl<'me, 'ast> IsolatingModuleFinalizer<'me, 'ast> {
           "default",
           self.snippet.id_ref_expr(default_export_ref, SPAN),
         ));
-        self.snippet.var_decl_stmt(default_export_ref, decl.to_expression_mut().take_in(self.alloc))
+        self
+          .snippet
+          .builder
+          .statement_expression(SPAN, decl.to_expression_mut().take_in(self.alloc))
       }
       ast::ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
         let from =
@@ -144,7 +147,10 @@ impl<'me, 'ast> IsolatingModuleFinalizer<'me, 'ast> {
             .snippet
             .object_property_kind_object_property("default", self.snippet.id_ref_expr(from, SPAN)),
         );
-        self.snippet.var_decl_stmt(from, Expression::FunctionExpression(func.take_in(self.alloc)))
+        self
+          .snippet
+          .builder
+          .statement_expression(SPAN, Expression::FunctionExpression(func.take_in(self.alloc)))
       }
       ast::ExportDefaultDeclarationKind::ClassDeclaration(class) => {
         let from =
@@ -154,7 +160,10 @@ impl<'me, 'ast> IsolatingModuleFinalizer<'me, 'ast> {
             .snippet
             .object_property_kind_object_property("default", self.snippet.id_ref_expr(from, SPAN)),
         );
-        self.snippet.var_decl_stmt(from, Expression::ClassExpression(class.take_in(self.alloc)))
+        self
+          .snippet
+          .builder
+          .statement_expression(SPAN, Expression::ClassExpression(class.take_in(self.alloc)))
       }
       ast::ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => {
         unreachable!("ExportDefaultDeclaration TSInterfaceDeclaration should be removed")

--- a/crates/rolldown/src/module_finalizers/isolating/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/isolating/impl_visit_mut.rs
@@ -1,4 +1,4 @@
-use oxc::ast::ast::{self, Expression, Statement};
+use oxc::ast::ast::{self, ExportDefaultDeclarationKind, Expression, Statement};
 use oxc::ast::visit::walk_mut;
 use oxc::ast::VisitMut;
 use oxc::span::SPAN;
@@ -21,15 +21,33 @@ impl<'me, 'ast> VisitMut<'ast> for IsolatingModuleFinalizer<'me, 'ast> {
       ));
     }
 
+    // Generate export statements, using `Object.defineProperty`
+    if !self.generated_exports.is_empty() {
+      program.body.push(self.snippet.builder.statement_expression(
+        SPAN,
+        self.snippet.alloc_call_expr_with_2arg_expr_expr(
+          "__export",
+          self.snippet.id_ref_expr("exports", SPAN),
+          Expression::ObjectExpression(self.snippet.builder.alloc_object_expression(
+            SPAN,
+            self.snippet.builder.vec_from_iter(self.generated_exports.drain(..)),
+            None,
+          )),
+        ),
+      ));
+    }
+
     program.body.extend(original_body);
   }
 
   fn visit_statement(&mut self, stmt: &mut Statement<'ast>) {
-    match &stmt {
+    match stmt {
       Statement::ImportDeclaration(import_decl) => {
         *stmt = self.transform_import_declaration(import_decl);
       }
-      ast::Statement::ExportDefaultDeclaration(_default_decl) => {}
+      ast::Statement::ExportDefaultDeclaration(export_default_decl) => {
+        *stmt = self.transform_export_default_declaration(export_default_decl);
+      }
       _ => {}
     };
     walk_mut::walk_statement(self, stmt);
@@ -100,6 +118,47 @@ impl<'me, 'ast> IsolatingModuleFinalizer<'me, 'ast> {
         )
       }
       Module::External(_) => unimplemented!(),
+    }
+  }
+
+  pub fn transform_export_default_declaration(
+    &mut self,
+    export_default_decl: &mut ast::ExportDefaultDeclaration<'ast>,
+  ) -> Statement<'ast> {
+    // TODO deconflict default_export_ref
+    let default_export_ref = self.ctx.symbols.get_original_name(self.ctx.module.default_export_ref);
+
+    match &mut export_default_decl.declaration {
+      decl @ ast::match_expression!(ExportDefaultDeclarationKind) => {
+        self.generated_exports.push(self.snippet.object_property_kind_object_property(
+          "default",
+          self.snippet.id_ref_expr(default_export_ref, SPAN),
+        ));
+        self.snippet.var_decl_stmt(default_export_ref, decl.to_expression_mut().take_in(self.alloc))
+      }
+      ast::ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
+        let from =
+          func.id.as_ref().map_or(default_export_ref.as_str(), |ident| ident.name.as_str());
+        self.generated_exports.push(
+          self
+            .snippet
+            .object_property_kind_object_property("default", self.snippet.id_ref_expr(from, SPAN)),
+        );
+        self.snippet.var_decl_stmt(from, Expression::FunctionExpression(func.take_in(self.alloc)))
+      }
+      ast::ExportDefaultDeclarationKind::ClassDeclaration(class) => {
+        let from =
+          class.id.as_ref().map_or(default_export_ref.as_str(), |ident| ident.name.as_str());
+        self.generated_exports.push(
+          self
+            .snippet
+            .object_property_kind_object_property("default", self.snippet.id_ref_expr(from, SPAN)),
+        );
+        self.snippet.var_decl_stmt(from, Expression::ClassExpression(class.take_in(self.alloc)))
+      }
+      ast::ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => {
+        unreachable!("ExportDefaultDeclaration TSInterfaceDeclaration should be removed")
+      }
     }
   }
 }

--- a/crates/rolldown/src/module_finalizers/isolating/mod.rs
+++ b/crates/rolldown/src/module_finalizers/isolating/mod.rs
@@ -1,4 +1,4 @@
-use oxc::allocator::Allocator;
+use oxc::{allocator::Allocator, ast::ast::ObjectPropertyKind};
 use rolldown_common::{AstScopes, EcmaModule, IndexModules, SymbolRef};
 use rolldown_ecmascript::AstSnippet;
 use rustc_hash::FxHashSet;
@@ -19,4 +19,5 @@ pub struct IsolatingModuleFinalizer<'me, 'ast> {
   pub alloc: &'ast Allocator,
   pub snippet: AstSnippet<'ast>,
   pub generated_imports: FxHashSet<SymbolRef>,
+  pub generated_exports: oxc::allocator::Vec<'ast, ObjectPropertyKind<'ast>>,
 }

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -107,6 +107,7 @@ impl<'a> GenerateStage<'a> {
               },
               snippet: AstSnippet::new(alloc),
               generated_imports: FxHashSet::default(),
+              generated_exports: oxc::allocator::Vec::new_in(alloc),
             };
             finalizer.visit_program(oxc_program);
           });

--- a/crates/rolldown/tests/rolldown/function/format/app/multiple_entry_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/app/multiple_entry_modules/artifacts.snap
@@ -8,17 +8,19 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 //#region square.js
 __toCommonJS(exports);
-export default function square(x) {
+__export(exports, { default: () => square });
+var square = function square(x) {
 	return x * x;
-}
+};
 
 //#endregion
 //#region cube.js
 __toCommonJS(exports);
+__export(exports, { default: () => cube });
 var square_ns = require("./square.js");
-export default function cube(x) {
+var cube = function cube(x) {
 	return square_ns.default(x) * x;
-}
+};
 
 //#endregion
 ```
@@ -27,10 +29,11 @@ export default function cube(x) {
 ```js
 //#region hyper-cube.js
 __toCommonJS(exports);
+__export(exports, { default: () => hyperCube });
 var cube_ns = require("./cube.js");
-export default function hyperCube(x) {
+var hyperCube = function hyperCube(x) {
 	return cube_ns.default(x) * x;
-}
+};
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/function/format/app/multiple_entry_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/app/multiple_entry_modules/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#region square.js
 __toCommonJS(exports);
 __export(exports, { default: () => square });
-var square = function square(x) {
+function square(x) {
 	return x * x;
 };
 
@@ -18,7 +18,7 @@ var square = function square(x) {
 __toCommonJS(exports);
 __export(exports, { default: () => cube });
 var square_ns = require("./square.js");
-var cube = function cube(x) {
+function cube(x) {
 	return square_ns.default(x) * x;
 };
 
@@ -31,7 +31,7 @@ var cube = function cube(x) {
 __toCommonJS(exports);
 __export(exports, { default: () => hyperCube });
 var cube_ns = require("./cube.js");
-var hyperCube = function hyperCube(x) {
+function hyperCube(x) {
 	return cube_ns.default(x) * x;
 };
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -1652,9 +1652,9 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/rolldown/function/format/app/multiple_entry_modules
 
-- main-!~{000}~.mjs => main-8a7NhD9M.mjs
+- main-!~{000}~.mjs => main-f0bilmlc.mjs
 - other-entry-!~{001}~.mjs => other-entry-_h9L-_ju.mjs
-- cube-!~{002}~.mjs => cube-eS0g6Lf2.mjs
+- cube-!~{002}~.mjs => cube-3Z6fb5GF.mjs
 
 # tests/rolldown/function/format/cjs/conflict_exports_key
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -1652,9 +1652,9 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/rolldown/function/format/app/multiple_entry_modules
 
-- main-!~{000}~.mjs => main-3oXOJHGq.mjs
+- main-!~{000}~.mjs => main-8a7NhD9M.mjs
 - other-entry-!~{001}~.mjs => other-entry-_h9L-_ju.mjs
-- cube-!~{002}~.mjs => cube-RDAQ4pQN.mjs
+- cube-!~{002}~.mjs => cube-eS0g6Lf2.mjs
 
 # tests/rolldown/function/format/cjs/conflict_exports_key
 

--- a/crates/rolldown_ecmascript/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript/src/ast_snippet.rs
@@ -3,8 +3,8 @@ use oxc::{
   ast::{
     ast::{
       self, Argument, BindingIdentifier, BindingRestElement, Expression, ImportOrExportKind,
-      Statement, TSThisParameter, TSTypeAnnotation, TSTypeParameterDeclaration,
-      TSTypeParameterInstantiation, VariableDeclarationKind,
+      ObjectPropertyKind, PropertyKind, Statement, TSThisParameter, TSTypeAnnotation,
+      TSTypeParameterDeclaration, TSTypeParameterInstantiation, VariableDeclarationKind,
     },
     AstBuilder,
   },
@@ -651,6 +651,24 @@ impl<'ast> AstSnippet<'ast> {
     ast::Statement::ReturnStatement(
       ast::ReturnStatement { argument: Some(argument), ..TakeIn::dummy(self.alloc()) }
         .into_in(self.alloc()),
+    )
+  }
+
+  // create `a: () => expr` for  `{ a: () => expr }``
+  pub fn object_property_kind_object_property(
+    &self,
+    key: PassedStr,
+    expr: ast::Expression<'ast>,
+  ) -> ObjectPropertyKind<'ast> {
+    self.builder.object_property_kind_object_property(
+      SPAN,
+      PropertyKind::Init,
+      self.builder.property_key_expression(self.id_ref_expr(key, SPAN)),
+      self.only_return_arrow_expr(expr),
+      None,
+      true,
+      false,
+      false,
     )
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Using `Object.defineProperty` to generate exports, it will make sure the live binding valid.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
