### PR TITLE
refactor(app): store imports

### DIFF
--- a/crates/rolldown/src/module_finalizers/isolating/mod.rs
+++ b/crates/rolldown/src/module_finalizers/isolating/mod.rs
@@ -1,4 +1,8 @@
-use oxc::{allocator::Allocator, ast::ast::ObjectPropertyKind, span::CompactStr};
+use oxc::{
+  allocator::Allocator,
+  ast::ast::{ObjectPropertyKind, Statement},
+  span::CompactStr,
+};
 use rolldown_common::{AstScopes, EcmaModule, IndexModules};
 use rolldown_ecmascript::AstSnippet;
 use rustc_hash::FxHashSet;
@@ -18,6 +22,7 @@ pub struct IsolatingModuleFinalizer<'me, 'ast> {
   pub scope: &'me AstScopes,
   pub alloc: &'ast Allocator,
   pub snippet: AstSnippet<'ast>,
-  pub generated_imports: FxHashSet<CompactStr>,
+  pub generated_imports_set: FxHashSet<CompactStr>,
+  pub generated_imports: oxc::allocator::Vec<'ast, Statement<'ast>>,
   pub generated_exports: oxc::allocator::Vec<'ast, ObjectPropertyKind<'ast>>,
 }

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -106,7 +106,8 @@ impl<'a> GenerateStage<'a> {
                 symbols: &self.link_output.symbols,
               },
               snippet: AstSnippet::new(alloc),
-              generated_imports: FxHashSet::default(),
+              generated_imports_set: FxHashSet::default(),
+              generated_imports: oxc::allocator::Vec::new_in(alloc),
               generated_exports: oxc::allocator::Vec::new_in(alloc),
             };
             finalizer.visit_program(oxc_program);

--- a/crates/rolldown/tests/rolldown/function/format/app/export-named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/app/export-named/artifacts.snap
@@ -14,7 +14,6 @@ __export(exports, {
 	["some exports"]: () => foo
 });
 const foo = 1;
-;
 
 //#endregion
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -1652,7 +1652,7 @@ expression: "snapshot_outputs.join(\"\\n\")"
 
 # tests/rolldown/function/format/app/export-named
 
-- main-!~{000}~.mjs => main-Q-mN_1Ua.mjs
+- main-!~{000}~.mjs => main-ozdsIjSL.mjs
 
 # tests/rolldown/function/format/app/export-named-from
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Because the `exportAllDecl` will generate two statements, so here using stored imports to including them.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
