### PR TITLE
refactor(rust/napi): prefer using `Either<String, ThreadSafeFunction >`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1243,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.0.0-alpha.8"
+version = "3.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743b5a7769f54c95e20a26d9e66d1b43d5622b7dc8ec8f97b51ed8c58633841f"
+checksum = "63b6831e153625954de1e7c1b42176babad91282b85a2f39002ea51c9421f6aa"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -55,7 +55,6 @@ impl Bundler {
       if worker_count > 0 { Some(WorkerManager::new(worker_count)) } else { None };
 
     let ret = normalize_binding_options(
-      env,
       input_options,
       output_options,
       #[cfg(not(target_family = "wasm"))]

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -7,14 +7,13 @@ use super::super::types::binding_rendered_chunk::RenderedChunk;
 use super::plugin::BindingPluginOrParallelJsPluginPlaceholder;
 use crate::types::binding_pre_rendered_chunk::PreRenderedChunk;
 use derivative::Derivative;
-use napi::bindgen_prelude::FunctionRef;
 use napi::Either;
 use napi_derive::napi;
 use serde::Deserialize;
 use types::binding_advanced_chunks_options::BindingAdvancedChunksOptions;
 
 pub type AddonOutputOption = MaybeAsyncJsCallback<RenderedChunk, Option<String>>;
-pub type ChunkFileNamesOutputOption = Either<String, FunctionRef<PreRenderedChunk, String>>;
+pub type ChunkFileNamesOutputOption = Either<String, JsCallback<PreRenderedChunk, String>>;
 
 #[napi(object, object_to_js = false)]
 #[derive(Deserialize, Derivative)]

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -8,7 +8,7 @@ use crate::{
   options::plugin::JsPlugin,
   types::{binding_rendered_chunk::RenderedChunk, js_callback::MaybeAsyncJsCallbackExt},
 };
-use napi::{bindgen_prelude::Either, Env};
+use napi::bindgen_prelude::Either;
 use rolldown::{
   AddonOutputOption, AdvancedChunksOptions, BundlerOptions, ChunkFilenamesOutputOption, IsExternal,
   MatchGroup, ModuleType, OutputExports, OutputFormat, Platform,
@@ -45,32 +45,22 @@ fn normalize_addon_option(
 }
 
 fn normalize_chunk_file_names_option(
-  env: Env,
   option: Option<ChunkFileNamesOutputOption>,
 ) -> napi::Result<Option<ChunkFilenamesOutputOption>> {
   option
     .map(move |value| match value {
       Either::A(str) => Ok(ChunkFilenamesOutputOption::String(str)),
-      Either::B(func) => {
-        let func = func
-          .borrow_back(&env)?
-          .build_threadsafe_function()
-          .callee_handled::<false>()
-          .weak::<true>()
-          .build()?;
-        Ok(ChunkFilenamesOutputOption::Fn(Box::new(move |chunk| {
-          let func = func.clone();
-          let chunk = chunk.clone();
-          Box::pin(async move { func.call_async(chunk.into()).await.map_err(anyhow::Error::from) })
-        })))
-      }
+      Either::B(func) => Ok(ChunkFilenamesOutputOption::Fn(Box::new(move |chunk| {
+        let func = func.clone();
+        let chunk = chunk.clone();
+        Box::pin(async move { func.invoke_async(chunk.into()).await.map_err(anyhow::Error::from) })
+      }))),
     })
     .transpose()
 }
 
 #[allow(clippy::too_many_lines)]
 pub fn normalize_binding_options(
-  env: Env,
   input_options: crate::options::BindingInputOptions,
   output_options: crate::options::BindingOutputOptions,
   #[cfg(not(target_family = "wasm"))] mut parallel_plugins_map: Option<
@@ -147,8 +137,8 @@ pub fn normalize_binding_options(
       .map_err(|err| napi::Error::new(napi::Status::GenericFailure, err))?,
     shim_missing_exports: input_options.shim_missing_exports,
     name: output_options.name,
-    entry_filenames: normalize_chunk_file_names_option(env, output_options.entry_file_names)?,
-    chunk_filenames: normalize_chunk_file_names_option(env, output_options.chunk_file_names)?,
+    entry_filenames: normalize_chunk_file_names_option(output_options.entry_file_names)?,
+    chunk_filenames: normalize_chunk_file_names_option(output_options.chunk_file_names)?,
     asset_filenames: output_options.asset_file_names,
     dir: output_options.dir,
     sourcemap: output_options.sourcemap.map(Into::into),


### PR DESCRIPTION
`ThreadSafeFunction` can be used in `Either` after this [version](https://github.com/napi-rs/napi-rs/releases/tag/napi%403.0.0-alpha.9) . This pull request uses this feature to prevent passing env to`normalize_binding_options`.