### PR TITLE
feat(plugin/transformer): support `targets` key for options.

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -113,6 +113,7 @@ pub struct BindingTransformPluginConfig {
   pub include: Option<Vec<BindingStringOrRegex>>,
   pub exclude: Option<Vec<BindingStringOrRegex>>,
   pub jsx_inject: Option<String>,
+  pub targets: Option<String>,
 }
 
 #[napi_derive::napi(object)]
@@ -197,6 +198,7 @@ impl TryFrom<BindingTransformPluginConfig> for TransformPlugin {
       include: normalized_include,
       exclude: normalized_exclude,
       jsx_inject: value.jsx_inject,
+      targets: value.targets,
     })
   }
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -425,6 +425,7 @@ export interface BindingTransformPluginConfig {
   include?: Array<BindingStringOrRegex>
   exclude?: Array<BindingStringOrRegex>
   jsxInject?: string
+  targets?: string
 }
 
 export interface BindingTreeshake {

--- a/packages/rolldown/src/options/normalized-ecma-transform-plugin-config.ts
+++ b/packages/rolldown/src/options/normalized-ecma-transform-plugin-config.ts
@@ -21,6 +21,7 @@ export function normalizeEcmaTransformPluginConfig(
     jsxInject: config?.jsxInject,
     exclude: normalizedStringOrRegex(config.exclude),
     include: normalizedStringOrRegex(config.include),
+    targets: config.targets,
   }
 
   return normalizedConfig

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/targets/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/targets/_config.ts
@@ -8,7 +8,7 @@ export default defineTest({
     plugins: [
       transformPlugin({
         exclude: ['node_modules/**'],
-        targets: 'chrome 49'
+        targets: 'chrome 49',
       }),
     ],
   },

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/targets/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/targets/_config.ts
@@ -1,0 +1,18 @@
+import { transformPlugin } from 'rolldown/experimental'
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    input: './main.ts',
+    plugins: [
+      transformPlugin({
+        exclude: ['node_modules/**'],
+        targets: 'chrome 49'
+      }),
+    ],
+  },
+  async afterTest(src) {
+    expect(src.output[0].code.includes('||=')).toBe(false)
+  },
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/targets/main.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/targets/main.ts
@@ -1,0 +1,10 @@
+let a = 0;
+let b = 0;
+let obj = { a: { b: 0 } };
+let c = 0;
+
+a ||= b;
+obj.a.b ||= c;
+
+a &&= b;
+obj.a.b &&= c;

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/targets/main.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/targets/main.ts
@@ -1,10 +1,10 @@
-let a = 0;
-let b = 0;
-let obj = { a: { b: 0 } };
-let c = 0;
+let a = 0
+let b = 0
+let obj = { a: { b: 0 } }
+let c = 0
 
-a ||= b;
-obj.a.b ||= c;
+a ||= b
+obj.a.b ||= c
 
-a &&= b;
-obj.a.b &&= c;
+a &&= b
+obj.a.b &&= c


### PR DESCRIPTION
The `oxc_transformer` supports parsing the options from the `targets` argument.

Incidentally, would it be feasible to consolidate these two `Transformer` instances into a single entity? In my opinion, this could lead to significant performance optimization.