### PR TITLE
fix: deduplicate assets if an explicit fileName is not provided

### DIFF
--- a/packages/rolldown/tests/fixtures/output/assetFileNames/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/assetFileNames/_config.ts
@@ -11,7 +11,7 @@ export default defineTest({
       {
         name: 'test-plugin',
         async buildStart() {
-          // the asset file name should be deconflict
+          // deduplicate assets if an explicit fileName is not provided
           this.emitFile({
             type: 'asset',
             name: 'emitted.txt',
@@ -21,6 +21,12 @@ export default defineTest({
             type: 'asset',
             name: 'emitted.txt',
             source: 'emitted',
+          })
+          // the asset file name should be deconflict
+          this.emitFile({
+            type: 'asset',
+            name: 'emitted.txt',
+            source: 'foo',
           })
         },
       },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
close https://github.com/rolldown/rolldown/issues/2207
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
