### PR TITLE
fix(iife): `MISSING_NAME_OPTION_FOR_IIFE_EXPORT` is output even if nothing is exported from the entrypoint

### DIFF
--- a/crates/rolldown/src/ecmascript/format/utils/namespace.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/namespace.rs
@@ -64,50 +64,58 @@ pub fn generate_identifier(
   ctx: &mut GenerateContext<'_>,
   export_mode: &OutputExports,
 ) -> DiagnosableResult<(String, String)> {
-  if let Some(name) = &ctx.options.name {
-    // It is same as Rollup.
-    if name.contains('.') {
-      let (decl, expr) = generate_namespace_definition(name);
-      Ok((
-        decl,
-        // Extend the object if the `extend` option is enabled.
-        if ctx.options.extend && matches!(export_mode, OutputExports::Named) {
-          format!("{expr} = {expr} || {{}}")
-        } else {
-          expr
-        },
-      ))
-    } else if ctx.options.extend {
-      let caller = generate_caller(name.as_str());
-      if matches!(export_mode, OutputExports::Named) {
-        // In named exports, the `extend` option will make the assignment disappear and
-        // the modification will be done extending the existed object (the `name` option).
-        Ok((String::new(), format!("this{caller} = this{caller} || {{}}")))
-      } else {
-        Ok((
-          String::new(),
-          // If there isn't a name in default export, we shouldn't assign the function to `this[""]`.
-          // If there is, we should assign the function to `this["name"]`,
-          // because there isn't an object that we can extend.
-          if name.is_empty() { String::new() } else { format!("this{caller}") },
-        ))
-      }
-    } else if is_validate_assignee_identifier_name(name) {
-      // If valid, we can use the `var` statement to declare the variable.
-      Ok((String::new(), format!("var {name}")))
-    } else {
-      // This behavior is aligned with Rollup. If using `output.extend: true`, this error won't be triggered.
-      let name = ArcStr::from(name);
-      Err(vec![BuildDiagnostic::illegal_identifier_as_name(name)])
-    }
-  } else {
-    // If the `name` is empty, you may be impossible to call the result.
-    // But it is normal if we do not have exports.
-    // However, if there is no export, it is recommended to use `app` format.
+  // Handle the diagnostic warning
+  if ctx.options.name.is_none() && !matches!(export_mode, OutputExports::None) {
     ctx
       .warnings
       .push(BuildDiagnostic::missing_name_option_for_iife_export().with_severity_warning());
-    Ok((String::new(), String::new()))
+  }
+
+  // Early return if `name` is None
+  let Some(name) = &ctx.options.name else {
+    return Ok((String::new(), String::new()));
+  };
+
+  // It is same as Rollup.
+  if name.contains('.') {
+    let (decl, expr) = generate_namespace_definition(name);
+    // Extend the object if the `extend` option is enabled.
+    let final_expr = if ctx.options.extend && matches!(export_mode, OutputExports::Named) {
+      format!("{expr} = {expr} || {{}}")
+    } else {
+      expr
+    };
+
+    return Ok((decl, final_expr));
+  }
+
+  if ctx.options.extend {
+    let caller = generate_caller(name.as_str());
+    let final_expr = if matches!(export_mode, OutputExports::Named) {
+      // In named exports, the `extend` option will make the assignment disappear and
+      // the modification will be done extending the existed object (the `name` option).
+      format!("this{caller} = this{caller} || {{}}")
+    } else {
+      // If there isn't a name in default export, we shouldn't assign the function to `this[""]`.
+      // If there is, we should assign the function to `this["name"]`,
+      // because there isn't an object that we can extend.
+      if name.is_empty() {
+        String::new()
+      } else {
+        format!("this{caller}")
+      }
+    };
+
+    return Ok((String::new(), final_expr));
+  }
+
+  if is_validate_assignee_identifier_name(name) {
+    // If valid, we can use the `var` statement to declare the variable.
+    Ok((String::new(), format!("var {name}")))
+  } else {
+    // This behavior is aligned with Rollup. If using `output.extend: true`, this error won't be triggered.
+    let name = ArcStr::from(name);
+    Err(vec![BuildDiagnostic::illegal_identifier_as_name(name)])
   }
 }
 

--- a/crates/rolldown/src/ecmascript/format/utils/namespace.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/namespace.rs
@@ -65,7 +65,9 @@ pub fn generate_identifier(
   export_mode: &OutputExports,
 ) -> DiagnosableResult<(String, String)> {
   // Handle the diagnostic warning
-  if ctx.options.name.is_none() && !matches!(export_mode, OutputExports::None) {
+  if ctx.options.name.as_ref().map_or(true, String::is_empty)
+    && !matches!(export_mode, OutputExports::None)
+  {
     ctx
       .warnings
       .push(BuildDiagnostic::missing_name_option_for_iife_export().with_severity_warning());

--- a/crates/rolldown/tests/rolldown/function/extend/iife/no_name_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/no_name_default/artifacts.snap
@@ -1,6 +1,14 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
+# warnings
+
+## MISSING_NAME_OPTION_FOR_IIFE_EXPORT
+
+```text
+[MISSING_NAME_OPTION_FOR_IIFE_EXPORT] Warning: If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.
+
+```
 # Assets
 
 ## main.mjs

--- a/crates/rolldown/tests/rolldown/function/extend/iife/no_name_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/no_name_named/artifacts.snap
@@ -1,6 +1,14 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
+# warnings
+
+## MISSING_NAME_OPTION_FOR_IIFE_EXPORT
+
+```text
+[MISSING_NAME_OPTION_FOR_IIFE_EXPORT] Warning: If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.
+
+```
 # Assets
 
 ## main.mjs


### PR DESCRIPTION
### Description

closes #2255 

The main improvements include adding a check for `hasExports` and altering some of the structural writing, which makes the code clearer.

The following are the conditions for warning in `Rollup`.
```ts
if (hasExports && !name) {
	log(LOGLEVEL_WARN, logMissingNameOptionForIifeExport());
}
```
At present, there is no clue about `reexports`.
```ts
const renderedExports = exportMode === 'none' ? [] : this.getChunkExportDeclarations(format);
let hasExports = renderedExports.length > 0;
let hasDefaultExport = false;
for (const renderedDependence of renderedDependencies) {
	const { reexports } = renderedDependence;
	if (reexports?.length) {
		hasExports = true;
		if (!hasDefaultExport && reexports.some(reexport => reexport.reexported === 'default')) {
			hasDefaultExport = true;
		}
		if (format === 'es') {
			renderedDependence.reexports = reexports.filter(
				// eslint-disable-next-line unicorn/prefer-array-some
				({ reexported }) => !renderedExports.find(({ exported }) => exported === reexported)
			);
		}
	}
}
```
