### PR TITLE
fix:  module preload-polyfill plugin only intercept `RESOLVED_MODULE_PRELOAD_POLYFILL_ID`

### DIFF
--- a/crates/rolldown_plugin_module_preload_polyfill/src/lib.rs
+++ b/crates/rolldown_plugin_module_preload_polyfill/src/lib.rs
@@ -36,13 +36,18 @@ impl Plugin for ModulePreloadPolyfillPlugin {
   }
 
   async fn load(&self, _ctx: &PluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
-    if self.skip {
-      return Ok(Some(HookLoadOutput::default()));
+    if args.id == RESOLVED_MODULE_PRELOAD_POLYFILL_ID {
+      if self.skip {
+        return Ok(Some(HookLoadOutput { code: String::new(), ..Default::default() }));
+      }
+
+      Ok(Some(HookLoadOutput {
+        code: format!("{IS_MODERN_FLAG}&&{}", include_str!("module_preload_polyfill.js")),
+        side_effects: Some(HookSideEffects::True),
+        ..Default::default()
+      }))
+    } else {
+      Ok(None)
     }
-    Ok((args.id == RESOLVED_MODULE_PRELOAD_POLYFILL_ID).then(|| HookLoadOutput {
-      code: format!("{IS_MODERN_FLAG}&&{}", include_str!("module_preload_polyfill.js")),
-      side_effects: Some(HookSideEffects::True),
-      ..Default::default()
-    }))
   }
 }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/module_preload_polyfill/skip/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/module_preload_polyfill/skip/_config.ts
@@ -1,7 +1,6 @@
 import { modulePreloadPolyfillPlugin } from 'rolldown/experimental'
 import { RolldownOutput } from 'rolldown'
 import { defineTest } from '@tests'
-import * as path from 'path'
 import { expect } from 'vitest'
 
 export default defineTest({
@@ -14,6 +13,7 @@ export default defineTest({
   },
 
   afterTest(output: RolldownOutput) {
-    expect(output.output[0].code.length).toBe(0)
+    expect(output.output[0].code.length).not.toBe(0)
+    expect(output.output[0].code).contain('this should be kept')
   },
 })

--- a/packages/rolldown/tests/fixtures/builtin-plugin/module_preload_polyfill/skip/lib.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/module_preload_polyfill/skip/lib.js
@@ -1,0 +1,1 @@
+console.log('this should be kept')

--- a/packages/rolldown/tests/fixtures/builtin-plugin/module_preload_polyfill/skip/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/module_preload_polyfill/skip/main.js
@@ -1,1 +1,2 @@
 import 'vite/modulepreload-polyfill'
+import './lib.js'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
