### PR TITLE
ci:  single fork test case

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -70,7 +70,7 @@
     "build-wasi:debug": "run-s build-binding:wasi build-node",
     "build-wasi:release": "run-s build-binding:wasi:release build-node",
     "# Scrips for checking #": "_",
-    "test": "cross-env ROLLDOWN_TEST=1 vitest run --reporter verbose --hideSkippedTests",
+    "test": "cross-env RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run --reporter verbose --hideSkippedTests",
     "test:update": "vitest run -u",
     "type-check": "tsc"
   },

--- a/packages/rolldown/vitest.config.mts
+++ b/packages/rolldown/vitest.config.mts
@@ -11,9 +11,9 @@ export default defineConfig({
     pool: 'forks',
     poolOptions: {
       forks: {
-        singleFork: true
-      }
-    }
+        singleFork: true,
+      },
+    },
   },
   resolve: {
     alias: {

--- a/packages/rolldown/vitest.config.mts
+++ b/packages/rolldown/vitest.config.mts
@@ -8,6 +8,12 @@ export default defineConfig({
     disableConsoleIntercept: true,
     // https://vitest.dev/api/mock.html#mockreset, since we run each test twice, so we need to reset the mockReset for each run
     mockReset: true,
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true
+      }
+    }
   },
   resolve: {
     alias: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
try to solve flacky ci, 
1. Using fork will process a new process rather than using a thread pool, the thread will share some resources while the process not. 
![image](https://github.com/user-attachments/assets/47c3a03f-e8bb-4597-b563-5e36283ee4ac)
2. test time increase 1s. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
