### PR TITLE
feat: support `css` module type in dataurl.

### DIFF
--- a/crates/rolldown_plugin_data_url/src/data_url_plugin.rs
+++ b/crates/rolldown_plugin_data_url/src/data_url_plugin.rs
@@ -44,6 +44,7 @@ impl Plugin for DataUrlPlugin {
         let module_type = match parsed.mime {
           "text/javascript" => ModuleType::Js,
           "application/json" => ModuleType::Json,
+          "text/css" => ModuleType::Css,
           _ => {
             return Ok(None);
           }

--- a/crates/rolldown_utils/src/base64.rs
+++ b/crates/rolldown_utils/src/base64.rs
@@ -5,7 +5,3 @@ pub fn to_url_safe_base64(input: impl AsRef<[u8]>) -> String {
 pub fn to_standard_base64(input: impl AsRef<[u8]>) -> String {
   base64_simd::STANDARD.encode_to_string(input)
 }
-
-pub fn from_standard_base64(input: impl AsRef<[u8]>) -> anyhow::Result<Vec<u8>> {
-  Ok(base64_simd::STANDARD.decode_to_vec(input)?)
-}


### PR DESCRIPTION
Due to the absence of bundle CSS support, the availability of ESbuild tests remains undefined.

Let’s remove the unused functionality in `base64.rs`.