### PR TITLE
refactor(rust): wrap ecma-related fields

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -187,7 +187,6 @@ impl ModuleViewFactory for EcmaModuleViewFactory {
       namespace_object_ref,
       def_format: ctx.resolved_id.module_def_format,
       sourcemap_chain: args.sourcemap_chain,
-      is_user_defined_entry: ctx.is_user_defined_entry,
       import_records: IndexVec::default(),
       is_included: false,
       importers: vec![],

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -1,5 +1,5 @@
 use arcstr::ArcStr;
-use oxc::{index::IndexVec, span::Span};
+use oxc::span::Span;
 use rolldown_rstr::Rstr;
 use rolldown_utils::{ecma_script::legitimize_identifier_name, path_ext::PathExt};
 use std::sync::Arc;
@@ -152,7 +152,6 @@ impl ModuleTask {
         warnings: &mut warnings,
         module_type: module_type.clone(),
         resolver: &self.ctx.resolver,
-        is_user_defined_entry: self.is_user_defined_entry,
         replace_global_define_config: self.ctx.meta.replace_global_define_config.clone(),
       },
       CreateModuleViewArgs { source, sourcemap_chain, hook_side_effects },
@@ -178,31 +177,11 @@ impl ModuleTask {
       stable_id,
       id,
       debug_id: self.resolved_id.debug_id(&self.ctx.options.cwd),
-      sourcemap_chain: ecma_view.sourcemap_chain,
-      source: ecma_view.source,
-      ecma_ast_idx: None,
       idx: self.module_idx,
-      named_imports: ecma_view.named_imports,
-      named_exports: ecma_view.named_exports,
-      stmt_infos: ecma_view.stmt_infos,
-      imports: ecma_view.imports,
-      star_exports: ecma_view.star_exports,
-      default_export_ref: ecma_view.default_export_ref,
-      scope: ecma_view.scope,
-      exports_kind: ecma_view.exports_kind,
-      namespace_object_ref: ecma_view.namespace_object_ref,
-      def_format: ecma_view.def_format,
       exec_order: u32::MAX,
       is_user_defined_entry: self.is_user_defined_entry,
-      import_records: IndexVec::default(),
-      is_included: false,
-      importers: vec![],
-      dynamic_importers: vec![],
-      imported_ids: ecma_view.imported_ids,
-      dynamically_imported_ids: ecma_view.dynamically_imported_ids,
-      side_effects: ecma_view.side_effects,
       module_type: module_type.clone(),
-      has_eval: ecma_view.has_eval,
+      ecma_view,
       css_view,
     };
 

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -2,8 +2,8 @@ use arcstr::ArcStr;
 use oxc::index::IndexVec;
 use oxc::span::SourceType;
 use rolldown_common::{
-  side_effects::DeterminedSideEffects, AstScopes, EcmaModule, ExportsKind, ModuleDefFormat,
-  ModuleId, ModuleIdx, ModuleType, SymbolRef,
+  side_effects::DeterminedSideEffects, AstScopes, EcmaModule, EcmaView, ExportsKind,
+  ModuleDefFormat, ModuleId, ModuleIdx, ModuleType, SymbolRef,
 };
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
 use rolldown_error::{BuildDiagnostic, DiagnosableResult, UnhandleableResult};
@@ -76,36 +76,41 @@ impl RuntimeModuleTask {
     } = scan_result;
 
     let module = EcmaModule {
-      source,
       idx: self.module_id,
-      ecma_ast_idx: None,
       repr_name: "rolldown_runtime".to_string(),
       stable_id: RUNTIME_MODULE_ID.to_string(),
       id: ModuleId::new(RUNTIME_MODULE_ID),
-      named_imports,
-      named_exports,
-      stmt_infos,
-      imports,
-      star_exports,
-      default_export_ref,
-      scope: ast_scope,
-      exports_kind: ExportsKind::Esm,
-      namespace_object_ref,
-      def_format: ModuleDefFormat::EsmMjs,
+
       debug_id: RUNTIME_MODULE_ID.to_string(),
       exec_order: u32::MAX,
       is_user_defined_entry: false,
-      import_records: IndexVec::default(),
-      is_included: false,
-      sourcemap_chain: vec![],
-      // The internal runtime module `importers/imported` should be skip.
-      importers: vec![],
-      dynamic_importers: vec![],
-      imported_ids: vec![],
-      dynamically_imported_ids: vec![],
-      side_effects: DeterminedSideEffects::Analyzed(false),
       module_type: ModuleType::Js,
-      has_eval,
+
+      ecma_view: EcmaView {
+        ecma_ast_idx: None,
+        source,
+
+        import_records: IndexVec::default(),
+        is_included: false,
+        sourcemap_chain: vec![],
+        // The internal runtime module `importers/imported` should be skip.
+        importers: vec![],
+        dynamic_importers: vec![],
+        imported_ids: vec![],
+        dynamically_imported_ids: vec![],
+        side_effects: DeterminedSideEffects::Analyzed(false),
+        has_eval,
+        named_imports,
+        named_exports,
+        stmt_infos,
+        imports,
+        star_exports,
+        default_export_ref,
+        scope: ast_scope,
+        exports_kind: ExportsKind::Esm,
+        namespace_object_ref,
+        def_format: ModuleDefFormat::EsmMjs,
+      },
       css_view: None,
     };
 

--- a/crates/rolldown/src/types/module_factory.rs
+++ b/crates/rolldown/src/types/module_factory.rs
@@ -26,7 +26,6 @@ pub struct CreateModuleContext<'a> {
   pub module_type: ModuleType,
   pub warnings: &'a mut Vec<BuildDiagnostic>,
   pub resolver: &'a SharedResolver,
-  pub is_user_defined_entry: bool,
   pub replace_global_define_config: Option<ReplaceGlobalDefinesConfig>,
 }
 

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -12,7 +12,6 @@ use crate::{
 pub struct EcmaView {
   pub source: ArcStr,
   pub ecma_ast_idx: Option<EcmaAstIdx>,
-  pub is_user_defined_entry: bool,
   pub has_eval: bool,
   pub def_format: ModuleDefFormat,
   /// Represents [Module Namespace Object](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We need to mark `ecma_view` optional in the future, so we need to move all related fields to `ecma_view` first.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
