### PR TITLE
chore(esbuild-diff): add relative path tosummary

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 set windows-shell := ["powershell"]
 set shell := ["bash", "-cu"]
-
+alias ued := update-esbuild-diff
 _default:
     just --list -u
 

--- a/scripts/snap-diff/runner.js
+++ b/scripts/snap-diff/runner.js
@@ -104,7 +104,7 @@ function getSummaryMarkdown(diffList, snapshotCategory) {
       testDir,
     )
     if (diff.diffResult === 'missing') {
-      markdown += `## [${diff.name}](${relativePath})\n`
+      markdown += `## ${diff.name}\n`
       markdown += `  missing\n`
       continue
     }

--- a/scripts/snap-diff/runner.js
+++ b/scripts/snap-diff/runner.js
@@ -53,7 +53,7 @@ export function run(includeList) {
     diffList.sort((a, b) => {
       return a.name.localeCompare(b.name)
     })
-    let summaryMarkdown = getSummaryMarkdown(diffList)
+    let summaryMarkdown = getSummaryMarkdown(diffList, snapCategory)
     fs.writeFileSync(
       path.join(import.meta.dirname, './summary/', `${snapCategory}.md`),
       summaryMarkdown,
@@ -93,17 +93,23 @@ function writeDiffToTestcaseDir(dir, diffResult) {
 
 /**
  * @param {Array<{diffResult: ReturnType<diffCase>, name: string}>} diffList
+ * @param {string} snapshotCategory
  */
-function getSummaryMarkdown(diffList) {
+function getSummaryMarkdown(diffList, snapshotCategory) {
   let markdown = `# Failed Cases\n`
   for (let diff of diffList) {
+    let testDir = path.join(esbuildTestDir, snapshotCategory, diff.name)
+    let relativePath = path.relative(
+      path.join(import.meta.dirname, 'summary'),
+      testDir,
+    )
     if (diff.diffResult === 'missing') {
-      markdown += `## ${diff.name}\n`
+      markdown += `## [${diff.name}](${relativePath})\n`
       markdown += `  missing\n`
       continue
     }
     if (diff.diffResult !== 'same') {
-      markdown += `## ${diff.name}\n`
+      markdown += `## [${diff.name}](${relativePath}/diff.md)\n`
       markdown += `  diff\n`
     }
   }

--- a/scripts/snap-diff/summary/importstar.md
+++ b/scripts/snap-diff/summary/importstar.md
@@ -1,153 +1,153 @@
 # Failed Cases
-## [export_other_as_namespace_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/)
+## [export_other_as_namespace_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/diff.md)
   diff
-## export_other_common_js
+## [export_other_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_other_common_js/diff.md)
   diff
-## export_other_nested_common_js
+## [export_other_nested_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/diff.md)
   diff
-## export_self_and_import_self_common_js
+## [export_self_and_import_self_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js)
   missing
-## export_self_and_require_self_common_js
+## [export_self_and_require_self_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js)
   missing
-## export_self_as_namespace_common_js
+## [export_self_as_namespace_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/diff.md)
   diff
-## export_self_as_namespace_es6
+## [export_self_as_namespace_es6](../../../crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6/diff.md)
   diff
-## export_self_common_js
+## [export_self_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_self_common_js/diff.md)
   diff
-## export_self_common_js_minified
+## [export_self_common_js_minified](../../../crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified)
   missing
-## export_self_es6
+## [export_self_es6](../../../crates/rolldown/tests/esbuild/importstar/export_self_es6/diff.md)
   diff
-## export_self_iife
+## [export_self_iife](../../../crates/rolldown/tests/esbuild/importstar/export_self_iife)
   missing
-## export_self_iife_with_name
+## [export_self_iife_with_name](../../../crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name)
   missing
-## export_star_default_export_common_js
+## [export_star_default_export_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_star_default_export_common_js)
   missing
-## import_default_namespace_combo_issue446
+## [import_default_namespace_combo_issue446](../../../crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446)
   missing
-## import_export_other_as_namespace_common_js
+## [import_export_other_as_namespace_common_js](../../../crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/diff.md)
   diff
-## import_export_self_as_namespace_es6
+## [import_export_self_as_namespace_es6](../../../crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6/diff.md)
   diff
-## import_export_star_ambiguous_warning
+## [import_export_star_ambiguous_warning](../../../crates/rolldown/tests/esbuild/importstar/import_export_star_ambiguous_warning/diff.md)
   diff
-## import_namespace_undefined_property_empty_file
+## [import_namespace_undefined_property_empty_file](../../../crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_empty_file)
   missing
-## import_namespace_undefined_property_side_effect_free_file
+## [import_namespace_undefined_property_side_effect_free_file](../../../crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_side_effect_free_file)
   missing
-## import_of_export_star
+## [import_of_export_star](../../../crates/rolldown/tests/esbuild/importstar/import_of_export_star/diff.md)
   diff
-## import_of_export_star_of_import
+## [import_of_export_star_of_import](../../../crates/rolldown/tests/esbuild/importstar/import_of_export_star_of_import/diff.md)
   diff
-## import_self_common_js
+## [import_self_common_js](../../../crates/rolldown/tests/esbuild/importstar/import_self_common_js/diff.md)
   diff
-## import_star_and_common_js
+## [import_star_and_common_js](../../../crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/diff.md)
   diff
-## import_star_capture
+## [import_star_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_capture/diff.md)
   diff
-## import_star_common_js_capture
+## [import_star_common_js_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/diff.md)
   diff
-## import_star_common_js_no_capture
+## [import_star_common_js_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/diff.md)
   diff
-## import_star_common_js_unused
+## [import_star_common_js_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_common_js_unused/diff.md)
   diff
-## import_star_export_import_star_capture
+## [import_star_export_import_star_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/diff.md)
   diff
-## import_star_export_import_star_no_capture
+## [import_star_export_import_star_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_no_capture/diff.md)
   diff
-## import_star_export_import_star_unused
+## [import_star_export_import_star_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_unused/diff.md)
   diff
-## import_star_export_star_as_capture
+## [import_star_export_star_as_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/diff.md)
   diff
-## import_star_export_star_as_no_capture
+## [import_star_export_star_as_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_no_capture/diff.md)
   diff
-## import_star_export_star_as_unused
+## [import_star_export_star_as_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_unused/diff.md)
   diff
-## import_star_export_star_capture
+## [import_star_export_star_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/diff.md)
   diff
-## import_star_export_star_no_capture
+## [import_star_export_star_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_star_no_capture/diff.md)
   diff
-## import_star_export_star_omit_ambiguous
+## [import_star_export_star_omit_ambiguous](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/diff.md)
   diff
-## import_star_export_star_unused
+## [import_star_export_star_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_star_unused/diff.md)
   diff
-## import_star_mangle_no_bundle_capture
+## [import_star_mangle_no_bundle_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture)
   missing
-## import_star_mangle_no_bundle_no_capture
+## [import_star_mangle_no_bundle_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture)
   missing
-## import_star_mangle_no_bundle_unused
+## [import_star_mangle_no_bundle_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused)
   missing
-## import_star_no_bundle_capture
+## [import_star_no_bundle_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture)
   missing
-## import_star_no_bundle_no_capture
+## [import_star_no_bundle_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture)
   missing
-## import_star_no_bundle_unused
+## [import_star_no_bundle_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused)
   missing
-## import_star_no_capture
+## [import_star_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_capture/diff.md)
   diff
-## import_star_of_export_star_as
+## [import_star_of_export_star_as](../../../crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/diff.md)
   diff
-## import_star_unused
+## [import_star_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_unused/diff.md)
   diff
-## issue176
+## [issue176](../../../crates/rolldown/tests/esbuild/importstar/issue176/diff.md)
   diff
-## namespace_import_missing_common_js
+## [namespace_import_missing_common_js](../../../crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/diff.md)
   diff
-## namespace_import_missing_es6
+## [namespace_import_missing_es6](../../../crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/diff.md)
   diff
-## namespace_import_re_export_star_missing_es6
+## [namespace_import_re_export_star_missing_es6](../../../crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/diff.md)
   diff
-## namespace_import_re_export_star_unused_missing_es6
+## [namespace_import_re_export_star_unused_missing_es6](../../../crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6/diff.md)
   diff
-## namespace_import_unused_missing_common_js
+## [namespace_import_unused_missing_common_js](../../../crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_common_js/diff.md)
   diff
-## namespace_import_unused_missing_es6
+## [namespace_import_unused_missing_es6](../../../crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_es6/diff.md)
   diff
-## other_file_export_self_as_namespace_unused_es6
+## [other_file_export_self_as_namespace_unused_es6](../../../crates/rolldown/tests/esbuild/importstar/other_file_export_self_as_namespace_unused_es6/diff.md)
   diff
-## other_file_import_export_self_as_namespace_unused_es6
+## [other_file_import_export_self_as_namespace_unused_es6](../../../crates/rolldown/tests/esbuild/importstar/other_file_import_export_self_as_namespace_unused_es6/diff.md)
   diff
-## re_export_namespace_import_missing_es6
+## [re_export_namespace_import_missing_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/diff.md)
   diff
-## re_export_namespace_import_unused_missing_es6
+## [re_export_namespace_import_unused_missing_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6/diff.md)
   diff
-## re_export_other_file_export_self_as_namespace_es6
+## [re_export_other_file_export_self_as_namespace_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6/diff.md)
   diff
-## re_export_other_file_import_export_self_as_namespace_es6
+## [re_export_other_file_import_export_self_as_namespace_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/diff.md)
   diff
-## re_export_star_as_common_js_no_bundle
+## [re_export_star_as_common_js_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle)
   missing
-## re_export_star_as_es6_no_bundle
+## [re_export_star_as_es6_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_es6_no_bundle)
   missing
-## re_export_star_as_external_common_js
+## [re_export_star_as_external_common_js](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_common_js/diff.md)
   diff
-## re_export_star_as_external_es6
+## [re_export_star_as_external_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_es6/diff.md)
   diff
-## re_export_star_as_external_iife
+## [re_export_star_as_external_iife](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife)
   missing
-## re_export_star_as_iife_no_bundle
+## [re_export_star_as_iife_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle)
   missing
-## re_export_star_common_js_no_bundle
+## [re_export_star_common_js_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle)
   missing
-## re_export_star_entry_point_and_inner_file
+## [re_export_star_entry_point_and_inner_file](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_entry_point_and_inner_file/diff.md)
   diff
-## re_export_star_es6_no_bundle
+## [re_export_star_es6_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle)
   missing
-## re_export_star_external_common_js
+## [re_export_star_external_common_js](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_external_common_js/diff.md)
   diff
-## re_export_star_external_es6
+## [re_export_star_external_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_external_es6/diff.md)
   diff
-## re_export_star_external_iife
+## [re_export_star_external_iife](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife)
   missing
-## re_export_star_iife_no_bundle
+## [re_export_star_iife_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle)
   missing
-## re_export_star_name_collision_not_ambiguous_export
+## [re_export_star_name_collision_not_ambiguous_export](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_collision_not_ambiguous_export/diff.md)
   diff
-## re_export_star_name_collision_not_ambiguous_import
+## [re_export_star_name_collision_not_ambiguous_import](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_collision_not_ambiguous_import/diff.md)
   diff
-## re_export_star_name_shadowing_not_ambiguous
+## [re_export_star_name_shadowing_not_ambiguous](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_shadowing_not_ambiguous/diff.md)
   diff
-## re_export_star_name_shadowing_not_ambiguous_re_export
+## [re_export_star_name_shadowing_not_ambiguous_re_export](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_shadowing_not_ambiguous_re_export/diff.md)
   diff

--- a/scripts/snap-diff/summary/importstar.md
+++ b/scripts/snap-diff/summary/importstar.md
@@ -5,9 +5,9 @@
   diff
 ## [export_other_nested_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/diff.md)
   diff
-## [export_self_and_import_self_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js)
+## export_self_and_import_self_common_js
   missing
-## [export_self_and_require_self_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js)
+## export_self_and_require_self_common_js
   missing
 ## [export_self_as_namespace_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/diff.md)
   diff
@@ -15,17 +15,17 @@
   diff
 ## [export_self_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_self_common_js/diff.md)
   diff
-## [export_self_common_js_minified](../../../crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified)
+## export_self_common_js_minified
   missing
 ## [export_self_es6](../../../crates/rolldown/tests/esbuild/importstar/export_self_es6/diff.md)
   diff
-## [export_self_iife](../../../crates/rolldown/tests/esbuild/importstar/export_self_iife)
+## export_self_iife
   missing
-## [export_self_iife_with_name](../../../crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name)
+## export_self_iife_with_name
   missing
-## [export_star_default_export_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_star_default_export_common_js)
+## export_star_default_export_common_js
   missing
-## [import_default_namespace_combo_issue446](../../../crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446)
+## import_default_namespace_combo_issue446
   missing
 ## [import_export_other_as_namespace_common_js](../../../crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/diff.md)
   diff
@@ -33,9 +33,9 @@
   diff
 ## [import_export_star_ambiguous_warning](../../../crates/rolldown/tests/esbuild/importstar/import_export_star_ambiguous_warning/diff.md)
   diff
-## [import_namespace_undefined_property_empty_file](../../../crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_empty_file)
+## import_namespace_undefined_property_empty_file
   missing
-## [import_namespace_undefined_property_side_effect_free_file](../../../crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_side_effect_free_file)
+## import_namespace_undefined_property_side_effect_free_file
   missing
 ## [import_of_export_star](../../../crates/rolldown/tests/esbuild/importstar/import_of_export_star/diff.md)
   diff
@@ -73,17 +73,17 @@
   diff
 ## [import_star_export_star_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_star_unused/diff.md)
   diff
-## [import_star_mangle_no_bundle_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture)
+## import_star_mangle_no_bundle_capture
   missing
-## [import_star_mangle_no_bundle_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture)
+## import_star_mangle_no_bundle_no_capture
   missing
-## [import_star_mangle_no_bundle_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused)
+## import_star_mangle_no_bundle_unused
   missing
-## [import_star_no_bundle_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture)
+## import_star_no_bundle_capture
   missing
-## [import_star_no_bundle_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture)
+## import_star_no_bundle_no_capture
   missing
-## [import_star_no_bundle_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused)
+## import_star_no_bundle_unused
   missing
 ## [import_star_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_capture/diff.md)
   diff
@@ -117,31 +117,31 @@
   diff
 ## [re_export_other_file_import_export_self_as_namespace_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/diff.md)
   diff
-## [re_export_star_as_common_js_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle)
+## re_export_star_as_common_js_no_bundle
   missing
-## [re_export_star_as_es6_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_es6_no_bundle)
+## re_export_star_as_es6_no_bundle
   missing
 ## [re_export_star_as_external_common_js](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_common_js/diff.md)
   diff
 ## [re_export_star_as_external_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_es6/diff.md)
   diff
-## [re_export_star_as_external_iife](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife)
+## re_export_star_as_external_iife
   missing
-## [re_export_star_as_iife_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle)
+## re_export_star_as_iife_no_bundle
   missing
-## [re_export_star_common_js_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle)
+## re_export_star_common_js_no_bundle
   missing
 ## [re_export_star_entry_point_and_inner_file](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_entry_point_and_inner_file/diff.md)
   diff
-## [re_export_star_es6_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle)
+## re_export_star_es6_no_bundle
   missing
 ## [re_export_star_external_common_js](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_external_common_js/diff.md)
   diff
 ## [re_export_star_external_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_external_es6/diff.md)
   diff
-## [re_export_star_external_iife](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife)
+## re_export_star_external_iife
   missing
-## [re_export_star_iife_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle)
+## re_export_star_iife_no_bundle
   missing
 ## [re_export_star_name_collision_not_ambiguous_export](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_collision_not_ambiguous_export/diff.md)
   diff

--- a/scripts/snap-diff/summary/importstar.md
+++ b/scripts/snap-diff/summary/importstar.md
@@ -1,5 +1,5 @@
 # Failed Cases
-## export_other_as_namespace_common_js
+## [export_other_as_namespace_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/)
   diff
 ## export_other_common_js
   diff


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. add a link to the summary title, so it jumps to the related `diff.md` after clicking
2. you could try it here, https://github.com/rolldown/rolldown/blob/fix/add-relative-path-tosummary/scripts/snap-diff/summary/importstar.md
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
