### PR TITLE
fix:  remove none relative path alias replacement

### DIFF
--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/at-alias-prefix/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/at-alias-prefix/_config.ts
@@ -2,15 +2,11 @@ import { aliasPlugin } from 'rolldown/experimental'
 import { defineTest } from '@tests'
 
 export default defineTest({
-  skip: true,
   config: {
     input: './main.js',
     plugins: [
       aliasPlugin({
-        entries: [
-          { find: '@src', replacement: 'src' },
-          { find: '@utils', replacement: './utils' },
-        ],
+        entries: [{ find: '@utils', replacement: './utils' }],
       }),
     ],
   },

--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/at-alias-prefix/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/at-alias-prefix/assert.mjs
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import assert from "node:assert";
-import { b } from "./dist/main";
+import assert from 'node:assert'
+import { b } from './dist/main'
 
-assert.strictEqual(b, 2);
+assert.strictEqual(b, 2)

--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/at-alias-prefix/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/at-alias-prefix/assert.mjs
@@ -1,6 +1,5 @@
 // @ts-nocheck
-import assert from 'node:assert'
-import { a, b } from './dist/main'
+import assert from "node:assert";
+import { b } from "./dist/main";
 
-assert.strictEqual(a, 1)
-assert.strictEqual(b, 2)
+assert.strictEqual(b, 2);

--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/at-alias-prefix/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/at-alias-prefix/main.js
@@ -1,4 +1,3 @@
-import { a } from '@src/index.js'
 import { b } from '@utils/index.js'
 
-export { a, b }
+export { b }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/at-alias-prefix/src/index.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/at-alias-prefix/src/index.js
@@ -1,1 +1,0 @@
-export const a = 1


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Close #2288 
2. Both webpack and rollup don't support none relative path alias replacement by default
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
