### PR TITLE
fix: glob import plugin support `./**.js` syntax

### DIFF
--- a/crates/rolldown_plugin_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_import_glob/src/lib.rs
@@ -414,7 +414,7 @@ impl<'ast, 'a> GlobImportVisit<'ast, 'a> {
 /// hack some syntax that `glob` did not support
 /// 1. `**.js` -> `*.js`
 fn preprocess_glob_expr(glob_expr: &str) -> String {
-  let mut parts = glob_expr.split("/").peekable();
+  let mut parts = glob_expr.split('/').peekable();
   let mut new_glob_expr = String::with_capacity(glob_expr.len());
   while let Some(part) = parts.next() {
     new_glob_expr.push_str(&part.replace("**.", "*."));

--- a/crates/rolldown_plugin_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_import_glob/src/lib.rs
@@ -113,7 +113,6 @@ impl<'ast, 'a> VisitMut<'ast> for GlobImportVisit<'ast, 'a> {
                   //   './dir/foo.js': () => import('./dir/foo.js'),
                   //   './dir/bar.js': () => import('./dir/bar.js').then((m) => m.setup),
                   // }
-
                   *expr = self.generate_glob_object_expression(&files, &opts, call_expr.span);
                   self.current += 1;
                 }
@@ -223,7 +222,7 @@ impl<'ast, 'a> GlobImportVisit<'ast, 'a> {
     }
 
     for glob_expr in glob_exprs {
-      let path = Path::new(self.cwd).join(Path::new(glob_expr));
+      let path = Path::new(self.cwd).join(Path::new(&preprocess_glob_expr(glob_expr)));
       if path.is_absolute() {
         if let Some(path) = path.to_str() {
           // TODO handle error
@@ -410,4 +409,18 @@ impl<'ast, 'a> GlobImportVisit<'ast, 'a> {
     let properties = self.ast_builder.vec_from_iter(properties);
     self.ast_builder.expression_object(call_expr_span, properties, None)
   }
+}
+
+/// hack some syntax that `glob` did not support
+/// 1. `**.js` -> `*.js`
+fn preprocess_glob_expr(glob_expr: &str) -> String {
+  let mut parts = glob_expr.split("/").peekable();
+  let mut new_glob_expr = String::with_capacity(glob_expr.len());
+  while let Some(part) = parts.next() {
+    new_glob_expr.push_str(&part.replace("**.", "*."));
+    if parts.peek().is_some() {
+      new_glob_expr.push('/');
+    }
+  }
+  new_glob_expr
 }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/star_star_dot_syntax/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/star_star_dot_syntax/_config.ts
@@ -1,0 +1,16 @@
+import { importGlobPlugin } from 'rolldown/experimental'
+import { defineTest } from '@tests'
+import * as path from 'node:path'
+
+export default defineTest({
+  config: {
+    plugins: [
+      importGlobPlugin({
+        root: path.resolve(import.meta.dirname),
+      }),
+    ],
+  },
+  async afterTest() {
+    await import('./assert.mjs')
+  },
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/star_star_dot_syntax/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/star_star_dot_syntax/assert.mjs
@@ -1,6 +1,6 @@
 // @ts-nocheck
-import assert from "node:assert";
-import { m1 } from "./dist/main";
+import assert from 'node:assert'
+import { m1 } from './dist/main'
 
-let m = m1["./dir/a.js"];
-assert.strictEqual(m.default, "a");
+let m = m1['./dir/a.js']
+assert.strictEqual(m.default, 'a')

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/star_star_dot_syntax/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/star_star_dot_syntax/assert.mjs
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import assert from "node:assert";
+import { m1 } from "./dist/main";
+
+let m = m1["./dir/a.js"];
+assert.strictEqual(m.default, "a");

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/star_star_dot_syntax/dir/a.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/star_star_dot_syntax/dir/a.js
@@ -1,0 +1,1 @@
+export default 'a'

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/star_star_dot_syntax/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/star_star_dot_syntax/main.js
@@ -1,0 +1,3 @@
+const m1 = import.meta.glob('./dir/**.js', { eager: true })
+
+export { m1 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Closed #2298
2. crate `glob` did not support this syntax, so did some hack
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
