### PR TITLE
fix:  create `__commonJS`  second param on demand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,6 +2267,7 @@ dependencies = [
  "anyhow",
  "append-only-vec",
  "arcstr",
+ "bitflags 2.6.0",
  "daachorse",
  "dunce",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,6 @@ dependencies = [
  "anyhow",
  "append-only-vec",
  "arcstr",
- "bitflags 2.6.0",
  "daachorse",
  "dunce",
  "futures",

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 anyhow                   = { workspace = true }
 append-only-vec          = { workspace = true }
 arcstr                   = { workspace = true }
-bitflags                 = { workspace = true }
 daachorse                = { workspace = true }
 dunce                    = { workspace = true }
 futures                  = { workspace = true }

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 anyhow                   = { workspace = true }
 append-only-vec          = { workspace = true }
 arcstr                   = { workspace = true }
+bitflags                 = { workspace = true }
 daachorse                = { workspace = true }
 dunce                    = { workspace = true }
 futures                  = { workspace = true }

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -2,7 +2,6 @@ pub mod impl_visit;
 pub mod side_effect_detector;
 
 use arcstr::ArcStr;
-use bitflags::Flags;
 use oxc::ast::ast;
 use oxc::index::IndexVec;
 use oxc::{

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -5,8 +5,8 @@ use oxc::{
 };
 use rolldown_common::{
   side_effects::{DeterminedSideEffects, HookSideEffects},
-  AstScopes, EcmaView, ModuleDefFormat, ModuleId, ModuleIdx, ModuleType, ModuleView, SymbolRef,
-  TreeshakeOptions,
+  AstScopes, EcmaModuleAstUsage, EcmaView, ModuleDefFormat, ModuleId, ModuleIdx, ModuleType,
+  ModuleView, SymbolRef, TreeshakeOptions,
 };
 use rolldown_ecmascript::EcmaAst;
 use rolldown_error::{DiagnosableResult, UnhandleableResult};
@@ -114,6 +114,7 @@ impl ModuleViewFactory for EcmaModuleViewFactory {
       warnings: scan_warnings,
       has_eval,
       errors,
+      ast_usage,
     } = scan_result;
     if !errors.is_empty() {
       return Ok(Err(errors));
@@ -195,6 +196,7 @@ impl ModuleViewFactory for EcmaModuleViewFactory {
       dynamically_imported_ids,
       side_effects,
       has_eval,
+      ast_usage,
     };
 
     Ok(Ok(CreateModuleViewReturn {

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -5,8 +5,8 @@ use oxc::{
 };
 use rolldown_common::{
   side_effects::{DeterminedSideEffects, HookSideEffects},
-  AstScopes, EcmaView, ModuleDefFormat, ModuleId, ModuleIdx, ModuleType,
-  ModuleView, SymbolRef, TreeshakeOptions,
+  AstScopes, EcmaView, ModuleDefFormat, ModuleId, ModuleIdx, ModuleType, ModuleView, SymbolRef,
+  TreeshakeOptions,
 };
 use rolldown_ecmascript::EcmaAst;
 use rolldown_error::{DiagnosableResult, UnhandleableResult};

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -5,7 +5,7 @@ use oxc::{
 };
 use rolldown_common::{
   side_effects::{DeterminedSideEffects, HookSideEffects},
-  AstScopes, EcmaModuleAstUsage, EcmaView, ModuleDefFormat, ModuleId, ModuleIdx, ModuleType,
+  AstScopes, EcmaView, ModuleDefFormat, ModuleId, ModuleIdx, ModuleType,
   ModuleView, SymbolRef, TreeshakeOptions,
 };
 use rolldown_ecmascript::EcmaAst;

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -226,6 +226,7 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
             wrap_ref_name,
             commonjs_ref_name,
             old_body,
+            self.ctx.module.ast_usage,
           ));
         }
         WrapKind::Esm => {

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -73,6 +73,7 @@ impl RuntimeModuleTask {
       warnings: _,
       has_eval,
       errors: _,
+      ast_usage,
     } = scan_result;
 
     let module = NormalModule {
@@ -110,6 +111,7 @@ impl RuntimeModuleTask {
         exports_kind: ExportsKind::Esm,
         namespace_object_ref,
         def_format: ModuleDefFormat::EsmMjs,
+        ast_usage,
       },
       css_view: None,
     };

--- a/crates/rolldown/src/types/module_factory.rs
+++ b/crates/rolldown/src/types/module_factory.rs
@@ -1,4 +1,5 @@
 use arcstr::ArcStr;
+use bitflags::bitflags;
 use futures::future::join_all;
 use oxc::index::IndexVec;
 use oxc::minifier::ReplaceGlobalDefinesConfig;

--- a/crates/rolldown/src/types/module_factory.rs
+++ b/crates/rolldown/src/types/module_factory.rs
@@ -1,5 +1,4 @@
 use arcstr::ArcStr;
-use bitflags::bitflags;
 use futures::future::join_all;
 use oxc::index::IndexVec;
 use oxc::minifier::ReplaceGlobalDefinesConfig;

--- a/crates/rolldown/tests/esbuild/dce/dce_var_exports/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/dce_var_exports/artifacts.snap
@@ -39,7 +39,7 @@ export default require_b();
 import { __commonJSMin } from "./chunk.mjs";
 
 //#region c.js
-var require_c = __commonJSMin((exports, module) => {
+var require_c = __commonJSMin((exports) => {
 	var module = { bar: 123 };
 	exports.foo = module;
 });

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region node_modules/demo-pkg/index.js
-var require_demo_pkg_index = __commonJSMin((exports, module) => {
+var require_demo_pkg_index = __commonJSMin((exports) => {
 	exports.foo = 123;
 	console.log("hello");
 });

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region node_modules/demo-pkg/index.js
-var require_demo_pkg_index = __commonJSMin((exports, module) => {
+var require_demo_pkg_index = __commonJSMin((exports) => {
 	exports.foo = 123;
 	console.log("hello");
 });

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region node_modules/demo-pkg/index.js
-var require_demo_pkg_index = __commonJSMin((exports, module) => {
+var require_demo_pkg_index = __commonJSMin((exports) => {
 	exports.foo = 123;
 	console.log("hello");
 });

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_true_keep_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_true_keep_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region node_modules/demo-pkg/index.js
-var require_demo_pkg_index = __commonJSMin((exports, module) => {
+var require_demo_pkg_index = __commonJSMin((exports) => {
 	exports.foo = 123;
 	console.log("hello");
 });

--- a/crates/rolldown/tests/esbuild/default/dot_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/dot_import/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region index.js
-var require_dot_import_index = __commonJSMin((exports, module) => {
+var require_dot_import_index = __commonJSMin((exports) => {
 	exports.x = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/default/es6_from_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/es6_from_common_js/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.foo = function() {
 		return "foo";
 	};
@@ -18,7 +18,7 @@ var require_foo = __commonJSMin((exports, module) => {
 
 //#endregion
 //#region bar.js
-var require_bar = __commonJSMin((exports, module) => {
+var require_bar = __commonJSMin((exports) => {
 	exports.bar = function() {
 		return "bar";
 	};

--- a/crates/rolldown/tests/esbuild/default/import_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_missing_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.x = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/default/nested_es6_from_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/nested_es6_from_common_js/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.fn = function() {
 		return 123;
 	};

--- a/crates/rolldown/tests/esbuild/default/re_export_common_js_as_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/re_export_common_js_as_es6/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.bar = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/default/require_main_cache_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_main_cache_common_js/artifacts.snap
@@ -15,7 +15,7 @@ var require_is_main = __commonJSMin((exports, module) => {
 
 //#endregion
 //#region entry.js
-var require_entry = __commonJSMin(() => {
+var require_entry = __commonJSMin((exports, module) => {
 	console.log("is main:", require.main === module);
 	console.log(require_is_main());
 	console.log("cache:", require.cache);

--- a/crates/rolldown/tests/esbuild/default/require_main_cache_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_main_cache_common_js/artifacts.snap
@@ -15,7 +15,7 @@ var require_is_main = __commonJSMin((exports, module) => {
 
 //#endregion
 //#region entry.js
-var require_entry = __commonJSMin((exports, module) => {
+var require_entry = __commonJSMin(() => {
 	console.log("is main:", require.main === module);
 	console.log(require_is_main());
 	console.log("cache:", require.cache);

--- a/crates/rolldown/tests/esbuild/default/require_with_call_inside_try/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_with_call_inside_try/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region entry.js
-var require_entry = __commonJSMin((exports, module) => {
+var require_entry = __commonJSMin((exports) => {
 	try {
 		const supportsColor = require("supports-color");
 		if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {

--- a/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_issue1837/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_issue1837/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region cjs.js
-var require_cjs = __commonJSMin((exports, module) => {
+var require_cjs = __commonJSMin((exports) => {
 	exports.foo = process;
 });
 

--- a/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.foo = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/importstar/export_other_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.foo = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.foo = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.foo = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/importstar/import_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_self_common_js/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region entry.js
-var require_entry = __commonJSMin((exports, module) => {
+var require_entry = __commonJSMin((exports) => {
 	var import_entry = __toESM(require_entry());
 	exports.foo = 123;
 	assert.equal(import_entry.foo, undefined);

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.foo = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.foo = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_unused/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_unused/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.foo = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.x = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_common_js/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.x = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/lower/lower_async_this2016_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_this2016_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region entry.js
-var require_entry = __commonJSMin((exports, module) => {
+var require_entry = __commonJSMin((exports) => {
 	exports.foo = async () => this;
 });
 

--- a/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_issue2002_a/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_issue2002_a/artifacts.snap
@@ -9,13 +9,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region src/node_modules/sub/bar.js
-var require_bar = __commonJSMin((exports, module) => {
+var require_bar = __commonJSMin(() => {
 	works();
 });
 
 //#endregion
 //#region src/node_modules/pkg/sub/foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin(() => {
 	require_bar();
 });
 

--- a/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_issue2002_b/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_issue2002_b/artifacts.snap
@@ -17,7 +17,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region src/node_modules/pkg/sub/foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin(() => {
 	require("sub");
 });
 

--- a/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_issue2002_c/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_issue2002_c/artifacts.snap
@@ -9,13 +9,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region src/node_modules/sub/index.js
-var require_sub_index = __commonJSMin((exports, module) => {
+var require_sub_index = __commonJSMin(() => {
 	works();
 });
 
 //#endregion
 //#region src/node_modules/pkg/sub/foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin(() => {
 	require_sub_index();
 });
 

--- a/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_map_module_disabled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_map_module_disabled/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region (ignored) node_modules/demo-pkg
-var require_demo_pkg = __commonJSMin((exports, module) => {});
+var require_demo_pkg = __commonJSMin(() => {});
 
 //#endregion
 //#region node_modules/demo-pkg/index.js

--- a/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_map_native_module_disabled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_map_native_module_disabled/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region (ignored) node_modules/demo-pkg
-var require_demo_pkg = __commonJSMin((exports, module) => {});
+var require_demo_pkg = __commonJSMin(() => {});
 
 //#endregion
 //#region node_modules/demo-pkg/index.js

--- a/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_map_relative_disabled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/test_package_json_browser_map_relative_disabled/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region (ignored) node_modules/demo-pkg/util-node.js
-var require_util_node = __commonJSMin((exports, module) => {});
+var require_util_node = __commonJSMin(() => {});
 
 //#endregion
 //#region node_modules/demo-pkg/main.js

--- a/crates/rolldown/tests/esbuild/packagejson/test_package_json_disabled_type_module_issue3367/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/test_package_json_disabled_type_module_issue3367/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region (ignored) 
-var require_test_package_json_disabled_type_module_issue3367 = __commonJSMin((exports, module) => {});
+var require_test_package_json_disabled_type_module_issue3367 = __commonJSMin(() => {});
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/packagejson/test_package_json_exports_import_over_require/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/test_package_json_exports_import_over_require/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region node_modules/pkg/require.js
-var require_require = __commonJSMin((exports, module) => {
+var require_require = __commonJSMin(() => {
 	console.log("FAILURE");
 });
 

--- a/crates/rolldown/tests/esbuild/packagejson/test_package_json_exports_require_over_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/test_package_json_exports_require_over_import/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region node_modules/pkg/require.js
-var require_require = __commonJSMin((exports, module) => {
+var require_require = __commonJSMin(() => {
 	console.log("SUCCESS");
 });
 

--- a/crates/rolldown/tests/esbuild/splitting/dynamic-commonjs-into-es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/dynamic-commonjs-into-es6/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.bar = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/splitting/dynamic_and_not_dynamic_commonjs_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/dynamic_and_not_dynamic_commonjs_into_es6/artifacts.snap
@@ -17,7 +17,7 @@ export default require_foo();
 
 
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {
+var require_foo = __commonJSMin((exports) => {
 	exports.bar = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/splitting/missing_lazy_export_missing_lazy_export/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/missing_lazy_export_missing_lazy_export/artifacts.snap
@@ -31,7 +31,7 @@ assert.deepEqual(bar(), [undefined]);
 
 
 //#region empty.js
-var require_empty = __commonJSMin((exports, module) => {});
+var require_empty = __commonJSMin(() => {});
 
 //#endregion
 //#region common.js

--- a/crates/rolldown/tests/esbuild/splitting/shared-commonjs-into-es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/shared-commonjs-into-es6/artifacts.snap
@@ -33,7 +33,7 @@ assert.equal(foo, 123);
 
 
 //#region shared.js
-var require_shared = __commonJSMin((exports, module) => {
+var require_shared = __commonJSMin((exports) => {
 	exports.foo = 123;
 });
 

--- a/crates/rolldown/tests/esbuild/ts/ts_import_cts/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_cts/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region required.cjs
-var require_required = __commonJSMin((exports, module) => {
+var require_required = __commonJSMin(() => {
 	console.log("works");
 });
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/empty_file_should_be_treated_as_cjs/import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/empty_file_should_be_treated_as_cjs/import/artifacts.snap
@@ -9,11 +9,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region star-empty.js
-var require_star_empty = __commonJSMin((exports, module) => {});
+var require_star_empty = __commonJSMin(() => {});
 
 //#endregion
 //#region default-empty.js
-var require_default_empty = __commonJSMin((exports, module) => {});
+var require_default_empty = __commonJSMin(() => {});
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/cjs_compat/empty_file_should_be_treated_as_cjs/re_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/empty_file_should_be_treated_as_cjs/re_export/artifacts.snap
@@ -9,11 +9,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region star-empty.js
-var require_star_empty = __commonJSMin((exports, module) => {});
+var require_star_empty = __commonJSMin(() => {});
 
 //#endregion
 //#region default-empty.js
-var require_default_empty = __commonJSMin((exports, module) => {});
+var require_default_empty = __commonJSMin(() => {});
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/cjs_compat/exoprt_star_of_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/exoprt_star_of_cjs/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region c.js
-var require_c = __commonJSMin((exports, module) => {
+var require_c = __commonJSMin((exports) => {
 	exports.test = 1000;
 });
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region commonjs.js
-var require_commonjs = __commonJSMin((exports, module) => {
+var require_commonjs = __commonJSMin((exports) => {
 	exports.a = 1;
 });
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region commonjs.js
-var require_commonjs = __commonJSMin((exports, module) => {
+var require_commonjs = __commonJSMin((exports) => {
 	exports.a = 1;
 });
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import/artifacts.snap
@@ -10,7 +10,7 @@ import { default as assert } from "node:assert";
 
 
 //#region commonjs.js
-var require_commonjs = __commonJSMin((exports, module) => {
+var require_commonjs = __commonJSMin((exports) => {
 	exports.a = 1;
 });
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import/artifacts.snap
@@ -10,13 +10,13 @@ import { default as assert } from "node:assert";
 
 
 //#region commonjs.js
-var require_commonjs = __commonJSMin((exports, module) => {
+var require_commonjs = __commonJSMin((exports) => {
 	exports.a = 1;
 });
 
 //#endregion
 //#region commonjs2.js
-var require_commonjs2 = __commonJSMin((exports, module) => {
+var require_commonjs2 = __commonJSMin((exports) => {
 	exports.a = 2;
 });
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region commonjs.js
-var require_commonjs = __commonJSMin((exports, module) => {
+var require_commonjs = __commonJSMin((exports) => {
 	exports.a = 1;
 });
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
@@ -31,7 +31,7 @@ module.exports = 1;
 
 //#endregion
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {});
+var require_foo = __commonJSMin(() => {});
 
 //#endregion
 //#region esm-export-cjs-require.js
@@ -71,7 +71,7 @@ var import_esm_import_cjs_export = __toESM(require_esm_import_cjs_export());
 (0:7-0:17) "exports = " --> (27:7-27:17) ".exports ="
 (0:17-1:24) "1;\nexport const value = 1;" --> (27:17-31:0) " 1;\n\n//#endregion\n//#region foo.js"
 - ../foo.js
-(0:0-0:0) "" --> (31:0-35:0) "\nvar require_foo = __commonJSMin((exports, module) => {});\n\n//#endregion\n//#region esm-export-cjs-require.js"
+(0:0-0:0) "" --> (31:0-35:0) "\nvar require_foo = __commonJSMin(() => {});\n\n//#endregion\n//#region esm-export-cjs-require.js"
 - ../esm-export-cjs-require.js
 (0:0-1:24) "require('./foo')\nexport const value = 1;" --> (35:0-39:0) "\nrequire_foo();\n\n//#endregion\n//#region esm-import-cjs-export.js"
 - ../esm-import-cjs-export.js

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
@@ -21,7 +21,7 @@ Promise.resolve().then(function() {
 
 //#endregion
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {});
+var require_foo = __commonJSMin(() => {});
 
 //#endregion
 //#region cjs.js

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
@@ -21,7 +21,7 @@ Promise.resolve().then(function() {
 
 //#endregion
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {});
+var require_foo = __commonJSMin(() => {});
 
 //#endregion
 //#region cjs.js

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
@@ -23,7 +23,7 @@ Promise.resolve().then(function() {
 
 //#endregion
 //#region foo.js
-var require_foo = __commonJSMin((exports, module) => {});
+var require_foo = __commonJSMin(() => {});
 
 //#endregion
 //#region cjs.js

--- a/crates/rolldown/tests/rolldown/function/resolve/browser_filed_false/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/resolve/browser_filed_false/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region (ignored) node_modules/package/util.js
-var require_util = __commonJSMin((exports, module) => {});
+var require_util = __commonJSMin(() => {});
 
 //#endregion
 //#region node_modules/package/index.js

--- a/crates/rolldown/tests/rolldown/issues/2038/b/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2038/b/artifacts.snap
@@ -20,7 +20,7 @@ export { a };
 
 
 //#region c.js
-var require_c = __commonJSMin((exports, module) => {
+var require_c = __commonJSMin((exports) => {
 	const test$1 = 1000;
 	exports.test = test$1;
 });

--- a/crates/rolldown/tests/rolldown/issues/2085/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2085/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region b.js
-var require_b = __commonJSMin((exports, module) => {
+var require_b = __commonJSMin((exports) => {
 	exports._default = function test() {
 		return "f";
 	};

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -49,7 +49,7 @@ expression: output
 
 - a_js-!~{000}~.mjs => a_js-MuJz0uQJ.mjs
 - b_js-!~{001}~.mjs => b_js--76NcZal.mjs
-- c_js-!~{002}~.mjs => c_js-w9rDIcPn.mjs
+- c_js-!~{002}~.mjs => c_js-7sPN0ve_.mjs
 - chunk-!~{003}~.mjs => chunk-_lRte01J.mjs
 
 # tests/esbuild/dce/disable_tree_shaking
@@ -159,7 +159,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_common_js
 
-- src_entry_js-!~{000}~.mjs => src_entry_js-yvyAenx0.mjs
+- src_entry_js-!~{000}~.mjs => src_entry_js-a5z_Cl2B.mjs
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6
 
@@ -167,7 +167,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js
 
-- src_entry_js-!~{000}~.mjs => src_entry_js-kHQ8m-ho.mjs
+- src_entry_js-!~{000}~.mjs => src_entry_js-f_UM1wyW.mjs
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_named_import_es6
 
@@ -175,7 +175,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js
 
-- src_entry_js-!~{000}~.mjs => src_entry_js-OkOzB_3o.mjs
+- src_entry_js-!~{000}~.mjs => src_entry_js-Tsv64LZC.mjs
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6
 
@@ -212,7 +212,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_true_keep_common_js
 
-- src_entry_js-!~{000}~.mjs => src_entry_js-z2EAaego.mjs
+- src_entry_js-!~{000}~.mjs => src_entry_js-hVFUxuvE.mjs
 
 # tests/esbuild/dce/package_json_side_effects_true_keep_es6
 
@@ -324,7 +324,7 @@ expression: output
 
 # tests/esbuild/default/dot_import
 
-- entry_js-!~{000}~.mjs => entry_js-fM-5Vm8-.mjs
+- entry_js-!~{000}~.mjs => entry_js-NPBE2cuj.mjs
 
 # tests/esbuild/default/duplicate_entry_point
 
@@ -342,7 +342,7 @@ expression: output
 
 # tests/esbuild/default/es6_from_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-7EI9oUK8.mjs
+- entry_js-!~{000}~.mjs => entry_js-SEWONjZf.mjs
 
 # tests/esbuild/default/export_chain
 
@@ -378,7 +378,7 @@ expression: output
 
 # tests/esbuild/default/import_missing_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-BRe2j-qJ.mjs
+- entry_js-!~{000}~.mjs => entry_js-Tp85tLi-.mjs
 
 # tests/esbuild/default/import_then_catch
 
@@ -398,7 +398,7 @@ expression: output
 
 # tests/esbuild/default/nested_es6_from_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-UG7JLqny.mjs
+- entry_js-!~{000}~.mjs => entry_js-HH9_NyVf.mjs
 
 # tests/esbuild/default/nested_require_without_call
 
@@ -427,7 +427,7 @@ expression: output
 
 # tests/esbuild/default/re_export_common_js_as_es6
 
-- entry_js-!~{000}~.mjs => entry_js-sIRGNuko.mjs
+- entry_js-!~{000}~.mjs => entry_js-Io8IWysW.mjs
 
 # tests/esbuild/default/re_export_default_external_common_js
 
@@ -455,7 +455,7 @@ expression: output
 
 # tests/esbuild/default/require_main_cache_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-5kDxb2ia.mjs
+- entry_js-!~{000}~.mjs => entry_js-hw6Zfefe.mjs
 
 # tests/esbuild/default/require_parent_dir_common_js
 
@@ -475,7 +475,7 @@ expression: output
 
 # tests/esbuild/default/require_with_call_inside_try
 
-- entry_js-!~{000}~.mjs => entry_js-gCvkw3AP.mjs
+- entry_js-!~{000}~.mjs => entry_js-OxKVkTx0.mjs
 
 # tests/esbuild/default/require_without_call
 
@@ -511,7 +511,7 @@ expression: output
 
 # tests/esbuild/default/use_strict_directive_bundle_issue1837
 
-- entry_js-!~{000}~.mjs => entry_js-IsvrlqwA.mjs
+- entry_js-!~{000}~.mjs => entry_js-bqKKsvWo.mjs
 
 # tests/esbuild/default/var_relocating_bundle
 
@@ -523,15 +523,15 @@ expression: output
 
 # tests/esbuild/importstar/export_other_as_namespace_common_js
 
-- entry_js-!~{000}~.cjs => entry_js-hv-uu-4A.cjs
+- entry_js-!~{000}~.cjs => entry_js-mcdpojUH.cjs
 
 # tests/esbuild/importstar/export_other_common_js
 
-- entry_js-!~{000}~.cjs => entry_js-R7RFZmNQ.cjs
+- entry_js-!~{000}~.cjs => entry_js-tRGrSnUm.cjs
 
 # tests/esbuild/importstar/export_other_nested_common_js
 
-- entry_js-!~{000}~.cjs => entry_js-YGOj8nbf.cjs
+- entry_js-!~{000}~.cjs => entry_js-6LcNe-Z3.cjs
 
 # tests/esbuild/importstar/export_self_as_namespace_common_js
 
@@ -551,7 +551,7 @@ expression: output
 
 # tests/esbuild/importstar/import_export_other_as_namespace_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-zk2aMjWa.mjs
+- entry_js-!~{000}~.mjs => entry_js-bgAJgOS5.mjs
 
 # tests/esbuild/importstar/import_export_self_as_namespace_es6
 
@@ -571,7 +571,7 @@ expression: output
 
 # tests/esbuild/importstar/import_self_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-aJIS-FgI.mjs
+- entry_js-!~{000}~.mjs => entry_js-aHCBLcQs.mjs
 
 # tests/esbuild/importstar/import_star_and_common_js
 
@@ -583,15 +583,15 @@ expression: output
 
 # tests/esbuild/importstar/import_star_common_js_capture
 
-- entry_js-!~{000}~.mjs => entry_js-tDRdEgO1.mjs
+- entry_js-!~{000}~.mjs => entry_js-S6eTdkhr.mjs
 
 # tests/esbuild/importstar/import_star_common_js_no_capture
 
-- entry_js-!~{000}~.mjs => entry_js-yBFn7023.mjs
+- entry_js-!~{000}~.mjs => entry_js-3ZBSPDrW.mjs
 
 # tests/esbuild/importstar/import_star_common_js_unused
 
-- entry_js-!~{000}~.mjs => entry_js-rY5t4XFn.mjs
+- entry_js-!~{000}~.mjs => entry_js-jQx5FbpG.mjs
 
 # tests/esbuild/importstar/import_star_export_import_star_capture
 
@@ -651,7 +651,7 @@ expression: output
 
 # tests/esbuild/importstar/namespace_import_missing_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-yZtp5QwF.mjs
+- entry_js-!~{000}~.mjs => entry_js-Kw2NMCmu.mjs
 
 # tests/esbuild/importstar/namespace_import_missing_es6
 
@@ -667,7 +667,7 @@ expression: output
 
 # tests/esbuild/importstar/namespace_import_unused_missing_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-nsbMxosn.mjs
+- entry_js-!~{000}~.mjs => entry_js-MbQcG-gu.mjs
 
 # tests/esbuild/importstar/namespace_import_unused_missing_es6
 
@@ -803,7 +803,7 @@ expression: output
 
 # tests/esbuild/lower/lower_async_this2016_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-pptpntuC.mjs
+- entry_js-!~{000}~.mjs => entry_js-JQNmSdR6.mjs
 
 # tests/esbuild/lower/lower_async_this2016_es6
 
@@ -919,15 +919,15 @@ expression: output
 
 # tests/esbuild/packagejson/test_package_json_browser_issue2002_a
 
-- entry-!~{000}~.mjs => entry-UjPvOFeZ.mjs
+- entry-!~{000}~.mjs => entry-L0WLVhDm.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_issue2002_b
 
-- entry-!~{000}~.mjs => entry-TTM55Vns.mjs
+- entry-!~{000}~.mjs => entry-7GxlqIoi.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_issue2002_c
 
-- entry-!~{000}~.mjs => entry-K7AkxeYK.mjs
+- entry-!~{000}~.mjs => entry-enxbG0Fu.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_avoid_missing
 
@@ -935,7 +935,7 @@ expression: output
 
 # tests/esbuild/packagejson/test_package_json_browser_map_module_disabled
 
-- entry-!~{000}~.mjs => entry-z2viltAe.mjs
+- entry-!~{000}~.mjs => entry-VO_8gEHg.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_module_to_module
 
@@ -947,11 +947,11 @@ expression: output
 
 # tests/esbuild/packagejson/test_package_json_browser_map_native_module_disabled
 
-- entry-!~{000}~.mjs => entry-qL_rTdAJ.mjs
+- entry-!~{000}~.mjs => entry-2q8JX9fy.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_relative_disabled
 
-- entry-!~{000}~.mjs => entry-7Bavp9qq.mjs
+- entry-!~{000}~.mjs => entry-vBWklLn2.mjs
 
 # tests/esbuild/packagejson/test_package_json_browser_map_relative_to_module
 
@@ -995,7 +995,7 @@ expression: output
 
 # tests/esbuild/packagejson/test_package_json_disabled_type_module_issue3367
 
-- entry-!~{000}~.mjs => entry-tuJ11ucK.mjs
+- entry-!~{000}~.mjs => entry-tFKk1quL.mjs
 
 # tests/esbuild/packagejson/test_package_json_dual_package_hazard_import_and_require_force_module_before_main
 
@@ -1054,7 +1054,7 @@ expression: output
 
 # tests/esbuild/packagejson/test_package_json_exports_import_over_require
 
-- entry-!~{000}~.mjs => entry-URLTxIhR.mjs
+- entry-!~{000}~.mjs => entry-9us_zpoe.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_neutral
 
@@ -1078,7 +1078,7 @@ expression: output
 
 # tests/esbuild/packagejson/test_package_json_exports_require_over_import
 
-- entry-!~{000}~.mjs => entry-NRIlp1mQ.mjs
+- entry-!~{000}~.mjs => entry-MAw780Dn.mjs
 
 # tests/esbuild/packagejson/test_package_json_exports_wildcard
 
@@ -1169,8 +1169,8 @@ expression: output
 
 # tests/esbuild/splitting/dynamic-commonjs-into-es6
 
-- main-!~{000}~.mjs => main-Bo_YiqV2.mjs
-- foo-!~{001}~.mjs => foo-kM_xxysr.mjs
+- main-!~{000}~.mjs => main-fnRjFlTz.mjs
+- foo-!~{001}~.mjs => foo-kr5BXF0m.mjs
 
 # tests/esbuild/splitting/dynamic-es6-into-es6
 
@@ -1179,9 +1179,9 @@ expression: output
 
 # tests/esbuild/splitting/dynamic_and_not_dynamic_commonjs_into_es6
 
-- main-!~{002}~.mjs => main-qXhz3g4Z.mjs
-- foo-!~{000}~.mjs => foo-18ZVXg86.mjs
-- foo-!~{003}~.mjs => foo-4X_CT7hq.mjs
+- main-!~{002}~.mjs => main-_Y3VhRjZ.mjs
+- foo-!~{000}~.mjs => foo-Z-5FwRaV.mjs
+- foo-!~{003}~.mjs => foo-mEN4zk4v.mjs
 
 # tests/esbuild/splitting/dynamic_and_not_dynamic_es6_into_es6
 
@@ -1206,9 +1206,9 @@ expression: output
 
 # tests/esbuild/splitting/missing_lazy_export_missing_lazy_export
 
-- a-!~{000}~.mjs => a-xlQ1stBN.mjs
-- b-!~{001}~.mjs => b-nVNV-mDP.mjs
-- common-!~{002}~.mjs => common-xrksA0Zw.mjs
+- a-!~{000}~.mjs => a-OcWI90AU.mjs
+- b-!~{001}~.mjs => b-nzfUnSny.mjs
+- common-!~{002}~.mjs => common-3XhiUPTq.mjs
 
 # tests/esbuild/splitting/nested_directories
 
@@ -1224,9 +1224,9 @@ expression: output
 
 # tests/esbuild/splitting/shared-commonjs-into-es6
 
-- a-!~{000}~.mjs => a-WaDkqQhG.mjs
-- b-!~{001}~.mjs => b-ONQ83EA-.mjs
-- shared-!~{002}~.mjs => shared-e2XpuGQT.mjs
+- a-!~{000}~.mjs => a-UiyItDkV.mjs
+- b-!~{001}~.mjs => b--bCOMcMQ.mjs
+- shared-!~{002}~.mjs => shared-_0o3HBD1.mjs
 
 # tests/esbuild/splitting/shared-es6-into-es6
 
@@ -1278,7 +1278,7 @@ expression: output
 
 # tests/esbuild/ts/ts_import_cts
 
-- entry_ts-!~{000}~.mjs => entry_ts-ZIvpO329.mjs
+- entry_ts-!~{000}~.mjs => entry_ts-vT5pDkou.mjs
 
 # tests/esbuild/ts/ts_import_empty_namespace
 
@@ -1307,11 +1307,11 @@ expression: output
 
 # tests/rolldown/cjs_compat/empty_file_should_be_treated_as_cjs/import
 
-- main-!~{000}~.mjs => main-Rgs3DqId.mjs
+- main-!~{000}~.mjs => main-wgjA1LVF.mjs
 
 # tests/rolldown/cjs_compat/empty_file_should_be_treated_as_cjs/re_export
 
-- main-!~{000}~.mjs => main-Rgs3DqId.mjs
+- main-!~{000}~.mjs => main-wgjA1LVF.mjs
 
 # tests/rolldown/cjs_compat/esm_require_cjs
 
@@ -1327,23 +1327,23 @@ expression: output
 
 # tests/rolldown/cjs_compat/exoprt_star_of_cjs
 
-- main-!~{000}~.mjs => main-k8MoOPrd.mjs
+- main-!~{000}~.mjs => main-qbzJTFIH.mjs
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
 
-- main-!~{000}~.mjs => main--NqEbfmk.mjs
+- main-!~{000}~.mjs => main-R_dMgztk.mjs
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import
 
-- main-!~{000}~.mjs => main-ruto2Jvz.mjs
+- main-!~{000}~.mjs => main-OT2SIIdk.mjs
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
 
-- main-!~{000}~.mjs => main-pVXIOwI3.mjs
+- main-!~{000}~.mjs => main-PIfrrWGZ.mjs
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
 
-- main-!~{000}~.mjs => main-TdhICskj.mjs
+- main-!~{000}~.mjs => main-7gQHOHOx.mjs
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
 
@@ -1351,7 +1351,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport
 
-- main-!~{000}~.mjs => main-TqLLZpBX.mjs
+- main-!~{000}~.mjs => main-kWrqO15_.mjs
 
 # tests/rolldown/cjs_compat/import_the_same_cjs_twice
 
@@ -1359,8 +1359,8 @@ expression: output
 
 # tests/rolldown/cjs_compat/mix-cjs-esm
 
-- main-!~{000}~.mjs => main-FCgUAtG5.mjs
-- main-FCgUAtG5.mjs.map
+- main-!~{000}~.mjs => main-Q1OaUen3.mjs
+- main-Q1OaUen3.mjs.map
 
 # tests/rolldown/cjs_compat/multiple_circle_cjs_entries
 
@@ -1749,15 +1749,15 @@ expression: output
 
 # tests/rolldown/function/inline_dynamic_imports/cjs
 
-- main-!~{000}~.cjs => main-YOG_JDtb.cjs
+- main-!~{000}~.cjs => main-rGqZqVPs.cjs
 
 # tests/rolldown/function/inline_dynamic_imports/esm
 
-- main-!~{000}~.mjs => main-tTDeZg9m.mjs
+- main-!~{000}~.mjs => main-MiXdf5g1.mjs
 
 # tests/rolldown/function/inline_dynamic_imports/iife
 
-- main-!~{000}~.mjs => main-vhQGOxfx.mjs
+- main-!~{000}~.mjs => main-93ybF6Qh.mjs
 
 # tests/rolldown/function/intro/cjs
 
@@ -1890,7 +1890,7 @@ expression: output
 
 # tests/rolldown/function/resolve/browser_filed_false
 
-- package-!~{000}~.mjs => package-8XWe7Fph.mjs
+- package-!~{000}~.mjs => package-curvaJUq.mjs
 
 # tests/rolldown/function/resolve/node_modules_as_entries
 
@@ -1962,16 +1962,16 @@ expression: output
 # tests/rolldown/issues/2038/b
 
 - main-!~{000}~.mjs => main-TP2rdK-V.mjs
-- a-!~{005}~.mjs => a-y79_SXBl.mjs
-- b-!~{001}~.mjs => b-UzgP2o6k.mjs
-- b-!~{003}~.mjs => b-nwSP4SZi.mjs
+- a-!~{005}~.mjs => a-MCQG5QYr.mjs
+- b-!~{001}~.mjs => b--Gv3Tmv6.mjs
+- b-!~{003}~.mjs => b-73VfkHO4.mjs
 
 # tests/rolldown/issues/2085
 
 - main-!~{000}~.mjs => main-z4J9H7Dl.mjs
-- a-!~{003}~.mjs => a-bM_gsBSF.mjs
-- a-!~{001}~.mjs => a-jx75PpPL.mjs
-- c-!~{005}~.mjs => c-idcE24nQ.mjs
+- a-!~{001}~.mjs => a-aSH9h6xX.mjs
+- a-!~{003}~.mjs => a-gsLK93pz.mjs
+- c-!~{005}~.mjs => c-MGypi4qO.mjs
 
 # tests/rolldown/issues/2300
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -455,7 +455,7 @@ expression: output
 
 # tests/esbuild/default/require_main_cache_common_js
 
-- entry_js-!~{000}~.mjs => entry_js-hw6Zfefe.mjs
+- entry_js-!~{000}~.mjs => entry_js-5kDxb2ia.mjs
 
 # tests/esbuild/default/require_parent_dir_common_js
 

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -1,4 +1,5 @@
 use arcstr::ArcStr;
+use bitflags::bitflags;
 use oxc::{index::IndexVec, span::Span};
 use rolldown_rstr::Rstr;
 use rustc_hash::FxHashMap;
@@ -40,4 +41,14 @@ pub struct EcmaView {
   // the module ids imported by this module via dynamic import()
   pub dynamically_imported_ids: Vec<ModuleId>,
   pub side_effects: DeterminedSideEffects,
+  pub ast_usage: EcmaModuleAstUsage,
+}
+
+bitflags! {
+    #[derive(Debug, Clone, Copy)]
+    pub struct EcmaModuleAstUsage: u8 {
+        const ModuleRef = 1;
+        const ExportsRef = 1 << 1;
+        const ModuleOrExports = Self::ModuleRef.bits() | Self::ExportsRef.bits();
+    }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -46,7 +46,11 @@ pub use crate::{
     Chunk,
   },
   css::{css_module::CssModule, css_module_idx::CssModuleIdx, css_view::CssView},
-  ecmascript::{ecma_asset_meta::EcmaAssetMeta, ecma_view::EcmaView, module_idx::ModuleIdx},
+  ecmascript::{
+    ecma_asset_meta::EcmaAssetMeta,
+    ecma_view::{EcmaModuleAstUsage, EcmaView},
+    module_idx::ModuleIdx,
+  },
   file_emitter::{EmittedAsset, FileEmitter, SharedFileEmitter},
   module::{external_module::ExternalModule, normal_module::NormalModule, Module},
   types::asset::Asset,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. ref https://github.com/evanw/esbuild/blob/9c13ae1f06dfa909eb4a53882e3b7e4216a503fe/internal/linker/linker.go#L4811-L4818
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
