### PR TITLE
fix: extend PluginContext with MinimalPluginContext

### DIFF
--- a/packages/rolldown/src/log/logger.ts
+++ b/packages/rolldown/src/log/logger.ts
@@ -15,18 +15,48 @@ import {
   type LogLevelOption,
   type LogLevel,
 } from './logging'
-import { error } from './logs'
-import { normalizeLog } from './logHandler'
+import { error, logPluginError } from './logs'
+import { getLogHandler, normalizeLog } from './logHandler'
 import type { InputOptions } from '../options/input-options'
 import type { NormalizedInputOptions } from '../options/normalized-input-options'
 import path from 'node:path'
 
-export interface MinimalPluginContext {
+export class MinimalPluginContext {
   debug: LoggingFunction
-  error: (error: RollupError | string) => never
   info: LoggingFunction
   // meta: PluginContextMeta;
   warn: LoggingFunction
+  readonly error: (error: RollupError | string) => never
+
+  constructor(options: NormalizedInputOptions, plugin: Plugin) {
+    const onLog = options.onLog
+    const pluginName = plugin.name || 'unknown'
+    const logLevel = options.logLevel
+    this.debug = getLogHandler(
+      LOG_LEVEL_DEBUG,
+      'PLUGIN_LOG',
+      onLog,
+      pluginName,
+      logLevel,
+    )
+    this.info = getLogHandler(
+      LOG_LEVEL_INFO,
+      'PLUGIN_LOG',
+      onLog,
+      pluginName,
+      logLevel,
+    )
+    this.warn = getLogHandler(
+      LOG_LEVEL_WARN,
+      'PLUGIN_WARNING',
+      onLog,
+      pluginName,
+      logLevel,
+    )
+    this.error = (e): never => {
+      return error(logPluginError(normalizeLog(e), pluginName))
+    }
+  }
 }
 
 export function getLogger(

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -1,6 +1,4 @@
-import type { RollupError, LoggingFunction } from '../rollup'
 import type { BindingPluginContext } from '../binding'
-import { getLogHandler, normalizeLog } from '../log/logHandler'
 import type { NormalizedInputOptions } from '../options/normalized-input-options'
 import type {
   CustomPluginOptions,
@@ -8,8 +6,7 @@ import type {
   Plugin,
   ResolvedId,
 } from './index'
-import { LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARN } from '../log/logging'
-import { error, logPluginError } from '../log/logs'
+import { MinimalPluginContext } from '../log/logger'
 import { AssetSource, bindingAssetSource } from '../utils/asset-source'
 import { unimplemented, unsupported } from '../utils/misc'
 import { ModuleInfo } from '../types/module-info'
@@ -36,11 +33,7 @@ export interface PrivatePluginContextResolveOptions
   [SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF]?: symbol
 }
 
-export class PluginContext {
-  debug: LoggingFunction
-  info: LoggingFunction
-  warn: LoggingFunction
-  readonly error: (error: RollupError | string) => never
+export class PluginContext extends MinimalPluginContext {
   readonly resolve: (
     source: string,
     importer?: string,
@@ -62,33 +55,7 @@ export class PluginContext {
     plugin: Plugin,
     data: PluginContextData,
   ) {
-    const onLog = options.onLog
-    const pluginName = plugin.name || 'unknown'
-    const logLevel = options.logLevel
-    this.debug = getLogHandler(
-      LOG_LEVEL_DEBUG,
-      'PLUGIN_LOG',
-      onLog,
-      pluginName,
-      logLevel,
-    )
-    this.warn = getLogHandler(
-      LOG_LEVEL_WARN,
-      'PLUGIN_WARNING',
-      onLog,
-      pluginName,
-      logLevel,
-    )
-    this.info = getLogHandler(
-      LOG_LEVEL_INFO,
-      'PLUGIN_LOG',
-      onLog,
-      pluginName,
-      logLevel,
-    )
-    this.error = (e): never => {
-      return error(logPluginError(normalizeLog(e), pluginName))
-    }
+    super(options, plugin)
     this.resolve = async (source, importer, options) => {
       let receipt: number | undefined = undefined
       if (options != null) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

rollup's `PluginContext` type extends `MinimalPluginContext` type.
https://github.com/rollup/rollup/blob/89a68c2a69eefaaf5544f83367f31d98360354ed/src/rollup/types.d.ts#L237
Vite's type augmentation relies on that fact.
https://github.com/vitejs/vite/blob/08ff23319964903b9f380859c216b10e577ddb6f/packages/vite/src/node/plugin.ts#L81-L84
But rolldown's `PluginContext` type was not extending `MinimalPluginContext` type and the type augmentation was not working.

This PR makes `PluginContext` type to extend `MinimalPluginContext` type to improve compat.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

