### PR TITLE
fix(plugin/replace): fix panic if `object_guards` enabled and simple values

### DIFF
--- a/crates/rolldown_plugin_replace/src/utils.rs
+++ b/crates/rolldown_plugin_replace/src/utils.rs
@@ -13,8 +13,8 @@ pub(crate) fn expand_typeof_replacements(
   let mut replacements: Vec<(String, String)> = Vec::new();
 
   for key in values.keys() {
-    if let Ok(matched) = OBJECT_RE.captures(key) {
-      let capture_str = matched.unwrap().get(0).unwrap().as_str();
+    if let Ok(Some(matched)) = OBJECT_RE.captures(key) {
+      let capture_str = matched.get(0).unwrap().as_str();
 
       let capture_vec: Vec<&str> = capture_str.split('.').collect::<Vec<&str>>();
 

--- a/crates/rolldown_plugin_replace/tests/form/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/mod.rs
@@ -4,6 +4,7 @@ mod match_variables;
 mod process_check;
 mod replace_nothing;
 mod replace_strings;
+mod simple_object_guards;
 mod special_characters;
 mod special_delimiters;
 mod ternary_operator;

--- a/crates/rolldown_plugin_replace/tests/form/simple_object_guards/artifacts.snap
+++ b/crates/rolldown_plugin_replace/tests/form/simple_object_guards/artifacts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## input.mjs
+
+```js
+
+//#region input.js
+[
+	bar,
+	foo.qux,
+	"bar"
+];
+
+//#endregion
+```

--- a/crates/rolldown_plugin_replace/tests/form/simple_object_guards/input.js
+++ b/crates/rolldown_plugin_replace/tests/form/simple_object_guards/input.js
@@ -1,0 +1,1 @@
+[foo, foo.qux, "foo"];

--- a/crates/rolldown_plugin_replace/tests/form/simple_object_guards/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/simple_object_guards/mod.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use rolldown::BundlerOptions;
+
+use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+
+// Handles process type guards in replacements
+#[tokio::test(flavor = "multi_thread")]
+async fn simple_object_guards() {
+  let cwd = abs_file_dir!();
+
+  IntegrationTest::new(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec!["./input.js".to_string().into()]),
+        cwd: Some(cwd),
+        ..Default::default()
+      },
+      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
+        values: [("foo".to_string(), "bar".to_string())].into(),
+        object_guards: true,
+        ..Default::default()
+      }))],
+    )
+    .await;
+}


### PR DESCRIPTION
### Description

Previously, if `object_guards` option enabled, and values to be replaced includes a string which doesn't match `xxx.yyy`, it would cause a panic.

The added test caused a panic before this PR.