### PR TITLE
perf(plugin/replace): `expand_typeof_replacements` use regex crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,6 +2531,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fancy-regex",
+ "regex",
  "rolldown",
  "rolldown_plugin",
  "rolldown_testing",

--- a/crates/rolldown_plugin_replace/Cargo.toml
+++ b/crates/rolldown_plugin_replace/Cargo.toml
@@ -9,6 +9,7 @@ version              = "0.1.0"
 [dependencies]
 anyhow          = { workspace = true }
 fancy-regex     = { workspace = true }
+regex           = { workspace = true }
 rolldown_plugin = { path = "../rolldown_plugin" }
 rustc-hash      = { workspace = true }
 string_wizard   = { workspace = true }

--- a/crates/rolldown_plugin_replace/src/utils.rs
+++ b/crates/rolldown_plugin_replace/src/utils.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::LazyLock};
 
-use fancy_regex::Regex;
+use regex::Regex;
 
 static OBJECT_RE: LazyLock<Regex> = LazyLock::new(|| {
   let pattern = r"^([_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*)(\.([_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*))+$";
@@ -13,10 +13,8 @@ pub(crate) fn expand_typeof_replacements(
   let mut replacements: Vec<(String, String)> = Vec::new();
 
   for key in values.keys() {
-    if let Ok(Some(matched)) = OBJECT_RE.captures(key) {
-      let capture_str = matched.get(0).unwrap().as_str();
-
-      let capture_vec: Vec<&str> = capture_str.split('.').collect::<Vec<&str>>();
+    if OBJECT_RE.is_match(key) {
+      let capture_vec: Vec<&str> = key.split('.').collect::<Vec<&str>>();
 
       let capture_arr = capture_vec.as_slice();
 


### PR DESCRIPTION
### Description

The regex used in `expand_typeof_replacements` is not "fancy", so can just use `regex` crate. `fancy_regex` would just delegate to `regex` crate anyway, but it's a waste of time for it to examine the regex to discover that. Cut out the middleman!