### PR TITLE
fix(plugin/replace): fix `object_guards` option

### DIFF
--- a/crates/rolldown_plugin_replace/tests/form/process_check/artifacts.snap
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 
 //#region input.js
-if (typeof process !== "undefined" && typeof process.env === "object" && true) {
+{
 	console.log("production");
 }
 


### PR DESCRIPTION
### Description

[@rollup/plugin-replace](https://www.npmjs.com/package/@rollup/plugin-replace)'s docs give this example for `objectGuards` option:

```js
replace({
  values: {
    'process.env.NODE_ENV': '"production"'
  }
});
```
```js
// Input
if (typeof process !== 'undefined' && process.env.NODE_ENV === 'production') {
  console.log('production');
}
// Without `objectGuards`
if (typeof process !== 'undefined' && 'production' === 'production') {
  console.log('production');
}
// With `objectGuards`
if ('object' !== 'undefined' && 'production' === 'production') {
  console.log('production');
}
```

Rolldown's version was not following this behavior. The example above was transformed to:

```js
if (typeof process !== "undefined" && true) {
  console.log("production");
}
```

This PR fixes that. The implementation now is almost identical to [Rollup's implementation](https://github.com/rollup/plugins/blob/master/packages/replace/src/index.js).