### PR TITLE
fix:  dicable dce when disable tree shake

### DIFF
--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -105,14 +105,16 @@ impl PreProcessEcmaAst {
         self.ast_changed = true;
       }
 
-      // Perform dead code elimination.
-      // NOTE: `CompressOptions::dead_code_elimination` will remove `ParenthesizedExpression`s from the AST.
-      let compressor = Compressor::new(allocator, CompressOptions::dead_code_elimination());
-      if self.ast_changed {
-        let semantic_ret = SemanticBuilder::new(source).with_stats(self.stats).build(program);
-        (symbols, scopes) = semantic_ret.semantic.into_symbol_table_and_scope_tree();
+      if bundle_options.treeshake.enabled() {
+        // Perform dead code elimination.
+        // NOTE: `CompressOptions::dead_code_elimination` will remove `ParenthesizedExpression`s from the AST.
+        let compressor = Compressor::new(allocator, CompressOptions::dead_code_elimination());
+        if self.ast_changed {
+          let semantic_ret = SemanticBuilder::new(source).with_stats(self.stats).build(program);
+          (symbols, scopes) = semantic_ret.semantic.into_symbol_table_and_scope_tree();
+        }
+        compressor.build_with_symbols_and_scopes(symbols, scopes, program);
       }
-      compressor.build_with_symbols_and_scopes(symbols, scopes, program);
 
       Ok(())
     })?;

--- a/crates/rolldown/tests/esbuild/default/var_relocating_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/default/var_relocating_bundle/_config.json
@@ -21,7 +21,6 @@
         "name": "function-nested_js",
         "import": "function-nested.js"
       }
-    ],
-    "treeshake": false
+    ]
   }
 }

--- a/crates/rolldown/tests/esbuild/default/var_relocating_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/var_relocating_bundle/artifacts.snap
@@ -79,13 +79,11 @@ x();
 ```js
 
 //#region top-level.js
-var a;
 for (var b; 0;);
 for (var e of []);
 for (var { f, x: [g] } of []);
 for (var h in {});
 for (var { j, x: [k] } in {});
-function l() {}
 
 //#endregion
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -515,7 +515,7 @@ expression: output
 
 # tests/esbuild/default/var_relocating_bundle
 
-- top-level_js-!~{000}~.mjs => top-level_js-aLnr7tad.mjs
+- top-level_js-!~{000}~.mjs => top-level_js-MmvXL_FE.mjs
 - nested_js-!~{001}~.mjs => nested_js-9dHTQmah.mjs
 - let_js-!~{002}~.mjs => let_js-lSQgoT-J.mjs
 - function_js-!~{003}~.mjs => function_js-qCnX__e4.mjs

--- a/crates/rolldown_plugin_replace/tests/form/process_check/artifacts.snap
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 
 //#region input.js
-{
+if ("object" !== "undefined" && "object" === "object" && "production" === "production") {
 	console.log("production");
 }
 

--- a/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use rolldown::BundlerOptions;
+use rolldown::{BundlerOptions, TreeshakeOptions};
 
 use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
 use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
@@ -15,6 +15,7 @@ async fn process_check() {
       BundlerOptions {
         input: Some(vec!["./input.js".to_string().into()]),
         cwd: Some(cwd),
+        treeshake: TreeshakeOptions::Boolean(false),
         ..Default::default()
       },
       vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
              It would be better to disable DCE for this test, so can see the actual output from replace plugin, but I couldn't figure our how to do that. In Rollup, `treeshake: false` does that, but `treeshake: TreeshakeOptions::Boolean(false)` seemed to have no effect.

_Originally posted by @overlookmotel in https://github.com/rolldown/rolldown/pull/2322#discussion_r1775296379_
            
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
