### PR TITLE
chore(esbuild-diff): enable missing imporstar tests

### DIFF
--- a/crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified/_config.json
@@ -1,0 +1,12 @@
+{
+  "expectExecuted": false,
+	"config": {
+		"input": [
+			{
+				"name": "entry_js",
+				"import": "entry.js"
+			}
+		],
+		"format": "cjs"
+	}
+}

--- a/crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified/artifacts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry_js.cjs
+
+```js
+
+
+//#region entry.js
+var require_entry = __commonJSMin((exports, module) => {
+	module.exports = { foo: 123 };
+	console.log(require_entry());
+});
+
+//#endregion
+export default require_entry();
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified/diff.md
@@ -1,0 +1,44 @@
+## /out.js
+### esbuild
+```js
+// entry.js
+var r = s((f, e) => {
+  e.exports = { foo: 123 };
+  console.log(r());
+});
+module.exports = r();
+```
+### rolldown
+```js
+
+
+//#region entry.js
+var require_entry = __commonJSMin((exports, module) => {
+	module.exports = { foo: 123 };
+	console.log(require_entry());
+});
+
+//#endregion
+export default require_entry();
+
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.cjs
+@@ -1,5 +1,5 @@
+-var r = s((f, e) => {
+-    e.exports = { foo: 123 };
+-    console.log(r());
++var require_entry = __commonJSMin((exports, module) => {
++    module.exports = { foo: 123 };
++    console.log(require_entry());
+ });
+-module.exports = r();
+\ No newline at end of file
++export default require_entry();
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified/entry.js
@@ -1,0 +1,2 @@
+module.exports = {foo: 123}
+console.log(require('./entry'))

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ],
+    "format": "iife"
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife/artifacts.snap
@@ -1,0 +1,33 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## MISSING_NAME_OPTION_FOR_IIFE_EXPORT
+
+```text
+[MISSING_NAME_OPTION_FOR_IIFE_EXPORT] Warning: If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+(function(exports) {
+
+"use strict";
+
+//#region entry.js
+const foo = 123;
+
+//#endregion
+Object.defineProperty(exports, 'foo', {
+  enumerable: true,
+  get: function () {
+    return foo;
+  }
+});
+return exports;
+})({});
+```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife/diff.md
@@ -1,0 +1,51 @@
+## /out.js
+### esbuild
+```js
+(() => {
+  // entry.js
+  var foo = 123;
+})();
+```
+### rolldown
+```js
+(function(exports) {
+
+"use strict";
+
+//#region entry.js
+const foo = 123;
+
+//#endregion
+Object.defineProperty(exports, 'foo', {
+  enumerable: true,
+  get: function () {
+    return foo;
+  }
+});
+return exports;
+})({});
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,3 +1,10 @@
+-(() => {
+-    var foo = 123;
+-})();
+\ No newline at end of file
++(function (exports) {
++    const foo = 123;
++    Object.defineProperty(exports, 'foo', {
++        enumerable: true,
++        get: function () {
++            return foo;
++        }
++    });
++    return exports;
++}({}));
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife/entry.js
@@ -1,0 +1,2 @@
+export const foo = 123
+export * from './entry'

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/_config.json
@@ -1,0 +1,12 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ],
+    "format": "iife"
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/artifacts.snap
@@ -1,0 +1,33 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## MISSING_NAME_OPTION_FOR_IIFE_EXPORT
+
+```text
+[MISSING_NAME_OPTION_FOR_IIFE_EXPORT] Warning: If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+(function(exports) {
+
+"use strict";
+
+//#region entry.js
+const foo = 123;
+
+//#endregion
+Object.defineProperty(exports, 'foo', {
+  enumerable: true,
+  get: function () {
+    return foo;
+  }
+});
+return exports;
+})({});
+```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/diff.md
@@ -1,0 +1,59 @@
+## /out.js
+### esbuild
+```js
+var someName = (() => {
+  // entry.js
+  var entry_exports = {};
+  __export(entry_exports, {
+    foo: () => foo
+  });
+  var foo = 123;
+  return __toCommonJS(entry_exports);
+})();
+```
+### rolldown
+```js
+(function(exports) {
+
+"use strict";
+
+//#region entry.js
+const foo = 123;
+
+//#endregion
+Object.defineProperty(exports, 'foo', {
+  enumerable: true,
+  get: function () {
+    return foo;
+  }
+});
+return exports;
+})({});
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,6 +1,10 @@
+-var someName = (() => {
+-    var entry_exports = {};
+-    __export(entry_exports, { foo: () => foo });
+-    var foo = 123;
+-    return __toCommonJS(entry_exports);
+-})();
+\ No newline at end of file
++(function (exports) {
++    const foo = 123;
++    Object.defineProperty(exports, 'foo', {
++        enumerable: true,
++        get: function () {
++            return foo;
++        }
++    });
++    return exports;
++}({}));
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/entry.js
@@ -1,0 +1,2 @@
+export const foo = 123
+export * from './entry'

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture/_config.json
@@ -1,0 +1,11 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "./foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+import * as ns from "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(ns, ns.foo, foo);
+
+//#endregion
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture/diff.md
@@ -1,0 +1,31 @@
+## /out.js
+### esbuild
+```js
+import * as ns from "./foo";
+let foo = 234;
+console.log(ns, ns.foo, foo);
+```
+### rolldown
+```js
+import * as ns from "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(ns, ns.foo, foo);
+
+//#endregion
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,3 +1,3 @@
+ import * as ns from './foo';
+-let foo = 234;
++var foo = 234;
+ console.log(ns, ns.foo, foo);
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture/entry.js
@@ -1,0 +1,3 @@
+import * as ns from './foo'
+let foo = 234
+console.log(ns, ns.foo, foo)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture/_config.json
@@ -1,0 +1,11 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "./foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+import * as ns from "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(ns.foo, ns.foo, foo);
+
+//#endregion
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture/diff.md
@@ -1,0 +1,31 @@
+## /out.js
+### esbuild
+```js
+import * as ns from "./foo";
+let foo = 234;
+console.log(ns.foo, ns.foo, foo);
+```
+### rolldown
+```js
+import * as ns from "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(ns.foo, ns.foo, foo);
+
+//#endregion
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,3 +1,3 @@
+ import * as ns from './foo';
+-let foo = 234;
++var foo = 234;
+ console.log(ns.foo, ns.foo, foo);
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture/entry.js
@@ -1,0 +1,3 @@
+import * as ns from './foo'
+let foo = 234
+console.log(ns.foo, ns.foo, foo)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused/_config.json
@@ -1,0 +1,11 @@
+{
+  "expectExecuted":false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "./foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+import "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(foo);
+
+//#endregion
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused/diff.md
@@ -1,0 +1,31 @@
+## /out.js
+### esbuild
+```js
+import "./foo";
+let foo = 234;
+console.log(foo);
+```
+### rolldown
+```js
+import "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(foo);
+
+//#endregion
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,3 +1,3 @@
+ import './foo';
+-let foo = 234;
++var foo = 234;
+ console.log(foo);
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused/entry.js
@@ -1,0 +1,3 @@
+import * as ns from './foo'
+let foo = 234
+console.log(foo)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture/_config.json
@@ -1,0 +1,11 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "./foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+import * as ns from "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(ns, ns.foo, foo);
+
+//#endregion
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture/diff.md
@@ -1,0 +1,31 @@
+## /out.js
+### esbuild
+```js
+import * as ns from "./foo";
+let foo = 234;
+console.log(ns, ns.foo, foo);
+```
+### rolldown
+```js
+import * as ns from "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(ns, ns.foo, foo);
+
+//#endregion
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,3 +1,3 @@
+ import * as ns from './foo';
+-let foo = 234;
++var foo = 234;
+ console.log(ns, ns.foo, foo);
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture/entry.js
@@ -1,0 +1,3 @@
+import * as ns from './foo'
+let foo = 234
+console.log(ns, ns.foo, foo)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture/_config.json
@@ -1,0 +1,11 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "./foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+import * as ns from "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(ns.foo, ns.foo, foo);
+
+//#endregion
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture/diff.md
@@ -1,0 +1,31 @@
+## /out.js
+### esbuild
+```js
+import * as ns from "./foo";
+let foo = 234;
+console.log(ns.foo, ns.foo, foo);
+```
+### rolldown
+```js
+import * as ns from "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(ns.foo, ns.foo, foo);
+
+//#endregion
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,3 +1,3 @@
+ import * as ns from './foo';
+-let foo = 234;
++var foo = 234;
+ console.log(ns.foo, ns.foo, foo);
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture/entry.js
@@ -1,0 +1,3 @@
+import * as ns from './foo'
+let foo = 234
+console.log(ns.foo, ns.foo, foo)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused/_config.json
@@ -1,0 +1,11 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "./foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+import "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(foo);
+
+//#endregion
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused/diff.md
@@ -1,0 +1,32 @@
+## /out.js
+### esbuild
+```js
+import * as ns from "./foo";
+let foo = 234;
+console.log(foo);
+```
+### rolldown
+```js
+import "./foo";
+
+//#region entry.js
+let foo = 234;
+console.log(foo);
+
+//#endregion
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,3 +1,3 @@
+-import * as ns from './foo';
+-let foo = 234;
++import './foo';
++var foo = 234;
+ console.log(foo);
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused/entry.js
@@ -1,0 +1,3 @@
+import * as ns from './foo'
+let foo = 234
+console.log(foo)

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/_config.json
@@ -1,0 +1,12 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ],
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/artifacts.snap
@@ -1,0 +1,27 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.cjs
+
+```js
+"use strict";
+
+const out = __toESM(require("foo"));
+
+Object.defineProperty(exports, 'out', {
+  enumerable: true,
+  get: function () {
+    return out;
+  }
+});
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/diff.md
@@ -1,0 +1,45 @@
+## /out.js
+### esbuild
+```js
+var entry_exports = {};
+__export(entry_exports, {
+  out: () => out
+});
+module.exports = __toCommonJS(entry_exports);
+var out = __toESM(require("foo"));
+```
+### rolldown
+```js
+"use strict";
+
+const out = __toESM(require("foo"));
+
+Object.defineProperty(exports, 'out', {
+  enumerable: true,
+  get: function () {
+    return out;
+  }
+});
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.cjs
+@@ -1,4 +1,7 @@
+-var entry_exports = {};
+-__export(entry_exports, { out: () => out });
+-module.exports = __toCommonJS(entry_exports);
+-var out = __toESM(require('foo'));
+\ No newline at end of file
++var out = __toESM(require('foo'));
++Object.defineProperty(exports, 'out', {
++    enumerable: true,
++    get: function () {
++        return out;
++    }
++});
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/entry.js
@@ -1,0 +1,1 @@
+export * as out from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_es6_no_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_es6_no_bundle/_config.json
@@ -1,0 +1,11 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_es6_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_es6_no_bundle/artifacts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+import * as out from "foo";
+
+export { out };
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_es6_no_bundle/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_es6_no_bundle/entry.js
@@ -1,0 +1,1 @@
+export * as out from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/_config.json
@@ -1,0 +1,12 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ],
+    "format": "iife"
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/artifacts.snap
@@ -1,0 +1,42 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+## MISSING_NAME_OPTION_FOR_IIFE_EXPORT
+
+```text
+[MISSING_NAME_OPTION_FOR_IIFE_EXPORT] Warning: If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.
+
+```
+## MISSING_GLOBAL_NAME
+
+```text
+[MISSING_GLOBAL_NAME] Warning: No name was provided for external module "foo" in "output.globals" – guessing "foo".
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+(function(exports, foo) {
+
+"use strict";
+const out = foo;
+
+Object.defineProperty(exports, 'out', {
+  enumerable: true,
+  get: function () {
+    return out;
+  }
+});
+return exports;
+})({}, foo);
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/diff.md
@@ -1,0 +1,56 @@
+## /out.js
+### esbuild
+```js
+var mod = (() => {
+  // entry.js
+  var entry_exports = {};
+  __export(entry_exports, {
+    out: () => out
+  });
+  var out = __toESM(__require("foo"));
+  return __toCommonJS(entry_exports);
+})();
+```
+### rolldown
+```js
+(function(exports, foo) {
+
+"use strict";
+const out = foo;
+
+Object.defineProperty(exports, 'out', {
+  enumerable: true,
+  get: function () {
+    return out;
+  }
+});
+return exports;
+})({}, foo);
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,6 +1,10 @@
+-var mod = (() => {
+-    var entry_exports = {};
+-    __export(entry_exports, { out: () => out });
+-    var out = __toESM(__require('foo'));
+-    return __toCommonJS(entry_exports);
+-})();
+\ No newline at end of file
++(function (exports, foo) {
++    const out = foo;
++    Object.defineProperty(exports, 'out', {
++        enumerable: true,
++        get: function () {
++            return out;
++        }
++    });
++    return exports;
++}({}, foo));
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/entry.js
@@ -1,0 +1,1 @@
+export * as out from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/_config.json
@@ -1,0 +1,12 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ],
+    "format": "iife"
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/artifacts.snap
@@ -1,0 +1,42 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+## MISSING_NAME_OPTION_FOR_IIFE_EXPORT
+
+```text
+[MISSING_NAME_OPTION_FOR_IIFE_EXPORT] Warning: If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.
+
+```
+## MISSING_GLOBAL_NAME
+
+```text
+[MISSING_GLOBAL_NAME] Warning: No name was provided for external module "foo" in "output.globals" – guessing "foo".
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+(function(exports, foo) {
+
+"use strict";
+const out = foo;
+
+Object.defineProperty(exports, 'out', {
+  enumerable: true,
+  get: function () {
+    return out;
+  }
+});
+return exports;
+})({}, foo);
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/diff.md
@@ -1,0 +1,55 @@
+## /out.js
+### esbuild
+```js
+var mod = (() => {
+  var entry_exports = {};
+  __export(entry_exports, {
+    out: () => out
+  });
+  var out = __toESM(require("foo"));
+  return __toCommonJS(entry_exports);
+})();
+```
+### rolldown
+```js
+(function(exports, foo) {
+
+"use strict";
+const out = foo;
+
+Object.defineProperty(exports, 'out', {
+  enumerable: true,
+  get: function () {
+    return out;
+  }
+});
+return exports;
+})({}, foo);
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,6 +1,10 @@
+-var mod = (() => {
+-    var entry_exports = {};
+-    __export(entry_exports, { out: () => out });
+-    var out = __toESM(require('foo'));
+-    return __toCommonJS(entry_exports);
+-})();
+\ No newline at end of file
++(function (exports, foo) {
++    const out = foo;
++    Object.defineProperty(exports, 'out', {
++        enumerable: true,
++        get: function () {
++            return out;
++        }
++    });
++    return exports;
++}({}, foo));
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/entry.js
@@ -1,0 +1,1 @@
+export * as out from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/_config.json
@@ -1,0 +1,12 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ],
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/artifacts.snap
@@ -1,0 +1,27 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.cjs
+
+```js
+"use strict";
+var foo = require("foo");
+Object.keys(foo).forEach(function (k) {
+  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
+    enumerable: true,
+    get: function () { return foo[k]; }
+  });
+});
+require("foo");
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/diff.md
@@ -1,0 +1,45 @@
+## /out.js
+### esbuild
+```js
+var entry_exports = {};
+module.exports = __toCommonJS(entry_exports);
+__reExport(entry_exports, require("foo"), module.exports);
+```
+### rolldown
+```js
+"use strict";
+var foo = require("foo");
+Object.keys(foo).forEach(function (k) {
+  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
+    enumerable: true,
+    get: function () { return foo[k]; }
+  });
+});
+require("foo");
+
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.cjs
+@@ -1,3 +1,11 @@
+-var entry_exports = {};
+-module.exports = __toCommonJS(entry_exports);
+-__reExport(entry_exports, require('foo'), module.exports);
+\ No newline at end of file
++var foo = require('foo');
++Object.keys(foo).forEach(function (k) {
++    if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k))
++        Object.defineProperty(exports, k, {
++            enumerable: true,
++            get: function () {
++                return foo[k];
++            }
++        });
++});
++require('foo');
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/entry.js
@@ -1,0 +1,1 @@
+export * from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/_config.json
@@ -1,0 +1,11 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/artifacts.snap
@@ -1,0 +1,21 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+import "foo";
+
+export * from "foo"
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/diff.md
@@ -1,0 +1,24 @@
+## /out.js
+### esbuild
+```js
+export * from "foo";
+```
+### rolldown
+```js
+import "foo";
+
+export * from "foo"
+
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,1 +1,2 @@
++import 'foo';
+ export * from 'foo';
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/entry.js
@@ -1,0 +1,1 @@
+export * from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/_config.json
@@ -1,0 +1,12 @@
+{
+	"expectExecuted": false,
+	"config": {
+		"input": [
+			{
+				"name": "entry_js",
+				"import": "entry.js"
+			}
+		],
+		"format": "iife"
+	}
+}

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/artifacts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+(function() {
+
+"use strict";
+
+})();
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/diff.md
@@ -1,0 +1,36 @@
+## /out.js
+### esbuild
+```js
+var mod = (() => {
+  // entry.js
+  var entry_exports = {};
+  __reExport(entry_exports, __require("foo"));
+  return __toCommonJS(entry_exports);
+})();
+```
+### rolldown
+```js
+(function() {
+
+"use strict";
+
+})();
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,5 +1,2 @@
+-var mod = (() => {
+-    var entry_exports = {};
+-    __reExport(entry_exports, __require('foo'));
+-    return __toCommonJS(entry_exports);
+-})();
+\ No newline at end of file
++(function () {
++}());
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/entry.js
@@ -1,0 +1,1 @@
+export * from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/_config.json
@@ -1,0 +1,12 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "entry_js",
+        "import": "entry.js"
+      }
+    ],
+    "format": "iife"
+  }
+}

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/artifacts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: "foo" is imported by "entry.js", but could not be resolved – treating it as an external dependency.
+
+```
+# Assets
+
+## entry_js.mjs
+
+```js
+(function() {
+
+"use strict";
+
+})();
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/diff.md
@@ -1,0 +1,35 @@
+## /out.js
+### esbuild
+```js
+var mod = (() => {
+  var entry_exports = {};
+  __reExport(entry_exports, require("foo"));
+  return __toCommonJS(entry_exports);
+})();
+```
+### rolldown
+```js
+(function() {
+
+"use strict";
+
+})();
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry_js.mjs
+@@ -1,5 +1,2 @@
+-var mod = (() => {
+-    var entry_exports = {};
+-    __reExport(entry_exports, require('foo'));
+-    return __toCommonJS(entry_exports);
+-})();
+\ No newline at end of file
++(function () {
++}());
+\ No newline at end of file
+
+```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/entry.js
@@ -1,0 +1,1 @@
+export * from "foo"

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -545,9 +545,21 @@ expression: output
 
 - entry_js-!~{000}~.cjs => entry_js-mKIoiJrd.cjs
 
+# tests/esbuild/importstar/export_self_common_js_minified
+
+- entry_js-!~{000}~.cjs => entry_js-Nrr5cneU.cjs
+
 # tests/esbuild/importstar/export_self_es6
 
 - entry_js-!~{000}~.mjs => entry_js-_WUmd7Ck.mjs
+
+# tests/esbuild/importstar/export_self_iife
+
+- entry_js-!~{000}~.mjs => entry_js-MUKCSxUC.mjs
+
+# tests/esbuild/importstar/export_self_iife_with_name
+
+- entry_js-!~{000}~.mjs => entry_js-MUKCSxUC.mjs
 
 # tests/esbuild/importstar/import_export_other_as_namespace_common_js
 
@@ -633,6 +645,30 @@ expression: output
 
 - entry_js-!~{000}~.mjs => entry_js-BygGyWzE.mjs
 
+# tests/esbuild/importstar/import_star_mangle_no_bundle_capture
+
+- entry_js-!~{000}~.mjs => entry_js-_XdNvPI2.mjs
+
+# tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture
+
+- entry_js-!~{000}~.mjs => entry_js-n_Y5fwlk.mjs
+
+# tests/esbuild/importstar/import_star_mangle_no_bundle_unused
+
+- entry_js-!~{000}~.mjs => entry_js-WrapWXT3.mjs
+
+# tests/esbuild/importstar/import_star_no_bundle_capture
+
+- entry_js-!~{000}~.mjs => entry_js-_XdNvPI2.mjs
+
+# tests/esbuild/importstar/import_star_no_bundle_no_capture
+
+- entry_js-!~{000}~.mjs => entry_js-n_Y5fwlk.mjs
+
+# tests/esbuild/importstar/import_star_no_bundle_unused
+
+- entry_js-!~{000}~.mjs => entry_js-WrapWXT3.mjs
+
 # tests/esbuild/importstar/import_star_no_capture
 
 - entry_js-!~{000}~.mjs => entry_js-o4JnhJiy.mjs
@@ -697,6 +733,14 @@ expression: output
 
 - entry_js-!~{000}~.mjs => entry_js-3xo5jbbP.mjs
 
+# tests/esbuild/importstar/re_export_star_as_common_js_no_bundle
+
+- entry_js-!~{000}~.cjs => entry_js-k_XF-EgE.cjs
+
+# tests/esbuild/importstar/re_export_star_as_es6_no_bundle
+
+- entry_js-!~{000}~.mjs => entry_js-Hh289cnx.mjs
+
 # tests/esbuild/importstar/re_export_star_as_external_common_js
 
 - entry_js-!~{000}~.cjs => entry_js-k_XF-EgE.cjs
@@ -705,9 +749,25 @@ expression: output
 
 - entry_js-!~{000}~.mjs => entry_js-Hh289cnx.mjs
 
+# tests/esbuild/importstar/re_export_star_as_external_iife
+
+- entry_js-!~{000}~.mjs => entry_js-O0kO95RR.mjs
+
+# tests/esbuild/importstar/re_export_star_as_iife_no_bundle
+
+- entry_js-!~{000}~.mjs => entry_js-O0kO95RR.mjs
+
+# tests/esbuild/importstar/re_export_star_common_js_no_bundle
+
+- entry_js-!~{000}~.cjs => entry_js-ELPoWxMr.cjs
+
 # tests/esbuild/importstar/re_export_star_entry_point_and_inner_file
 
 - entry_js-!~{000}~.mjs => entry_js-nsOyjTyb.mjs
+
+# tests/esbuild/importstar/re_export_star_es6_no_bundle
+
+- entry_js-!~{000}~.mjs => entry_js-f7yUzi-B.mjs
 
 # tests/esbuild/importstar/re_export_star_external_common_js
 
@@ -716,6 +776,14 @@ expression: output
 # tests/esbuild/importstar/re_export_star_external_es6
 
 - entry_js-!~{000}~.mjs => entry_js-f7yUzi-B.mjs
+
+# tests/esbuild/importstar/re_export_star_external_iife
+
+- entry_js-!~{000}~.mjs => entry_js-AgsIhQIf.mjs
+
+# tests/esbuild/importstar/re_export_star_iife_no_bundle
+
+- entry_js-!~{000}~.mjs => entry_js-AgsIhQIf.mjs
 
 # tests/esbuild/importstar/re_export_star_name_collision_not_ambiguous_export
 

--- a/cspell.json
+++ b/cspell.json
@@ -25,7 +25,8 @@
     "/crates/rolldown/tests/esbuild/splitting/ignore-test.md",
     "/crates/rolldown_utils/src/light_guess.rs",
     "/pnpm-lock.yaml",
-    "*.wasm"
+    "*.wasm",
+    "*.go"
   ],
   "languageSettings": [
     {

--- a/scripts/misc/gen-esbuild-test.mjs
+++ b/scripts/misc/gen-esbuild-test.mjs
@@ -30,7 +30,11 @@ const __dirname = import.meta.dirname
 
 // 2. Set the tests root directory
 
-const TESTS_ROOT_DIR = path.resolve(__dirname, '../../crates/rolldown/tests/esbuild', SUITE_NAME)
+const TESTS_ROOT_DIR = path.resolve(
+  __dirname,
+  '../../crates/rolldown/tests/esbuild',
+  SUITE_NAME,
+)
 
 // 3. Download .go test source file located in the suites object
 //    for each suite and place it under "scripts" dir.
@@ -192,7 +196,7 @@ const source = await readTestSuiteSource(SUITE_NAME)
 console.log(source)
 
 // This is up to suit name
-const ignoreCases = suites[SUITE_NAME]?.ignoreCases ?? []
+// const ignoreCases = suites[SUITE_NAME]?.ignoreCases ?? []
 // Generic ignored pattern, maybe used in many suites
 // const ignoredTestPattern = [
 //   'ts',

--- a/scripts/misc/gen-esbuild-test.mjs
+++ b/scripts/misc/gen-esbuild-test.mjs
@@ -6,8 +6,6 @@ import * as path from 'node:path'
 import * as changeCase from 'change-case'
 import chalk from 'chalk'
 import * as dedent from 'dedent'
-import { fileURLToPath } from 'node:url'
-import { URL } from 'node:url'
 import * as nodeHttps from 'node:https'
 import * as nodeFs from 'node:fs'
 import * as fsExtra from 'fs-extra'
@@ -28,10 +26,11 @@ if (process.argv.length < 3) {
 const SUITE_NAME = process.argv[2]
 console.log(`Processing test suite: ${SUITE_NAME}`)
 
-// 2. Set the tests root directory
-const __dirname = fileURLToPath(new URL('.', import.meta.url))
+const __dirname = import.meta.dirname
 
-const TESTS_ROOT_DIR = path.resolve(__dirname, 'tests/esbuild', SUITE_NAME)
+// 2. Set the tests root directory
+
+const TESTS_ROOT_DIR = path.resolve(__dirname, '../../crates/rolldown/tests/esbuild', SUITE_NAME)
 
 // 3. Download .go test source file located in the suites object
 //    for each suite and place it under "scripts" dir.
@@ -82,15 +81,15 @@ const suites = /** @type {const} */ ({
       'dce_of_using_declarations',
     ],
   },
-  import_star: {
+  importstar: {
     name: 'import_star',
     sourcePath: './bundler_importstar_test.go',
     sourceGithubUrl:
-      'https://raw.githubusercontent.com/evanw/esbuild/blob/main/internal/bundler_tests/bundler_importstar_test.go',
+      'https://raw.githubusercontent.com/evanw/esbuild/main/internal/bundler_tests/bundler_importstar_test.go',
 
     ignoreCases: [],
   },
-  import_star_ts: {
+  importstar_ts: {
     name: 'import_star_ts',
     sourcePath: './bundler_importstar_ts_test.go',
     sourceGithubUrl:
@@ -98,7 +97,7 @@ const suites = /** @type {const} */ ({
 
     ignoreCases: [],
   },
-  bundler_ts: {
+  ts: {
     name: 'bundler_ts',
     sourcePath: './bundler_ts_test.go',
     sourceGithubUrl:
@@ -190,32 +189,33 @@ async function readTestSuiteSource(testSuiteName) {
 
 /** The contents of the .go test source file. {@link suites} */
 const source = await readTestSuiteSource(SUITE_NAME)
+console.log(source)
 
 // This is up to suit name
 const ignoreCases = suites[SUITE_NAME]?.ignoreCases ?? []
 // Generic ignored pattern, maybe used in many suites
-const ignoredTestPattern = [
-  'ts',
-  'txt',
-  'json',
-  'jsx',
-  'tsx',
-  'no_bundle',
-  'mangle',
-  'minify',
-  'minified',
-  'comments',
-  'fs',
-  'alias',
-  'node',
-  'decorator',
-  'iife',
-  'abs_path',
-  'inject',
-  'metafile',
-  'output_extension',
-  'top_level_return_forbidden',
-]
+// const ignoredTestPattern = [
+//   'ts',
+//   'txt',
+//   'json',
+//   'jsx',
+//   'tsx',
+//   'no_bundle',
+//   'mangle',
+//   'minify',
+//   'minified',
+//   'comments',
+//   'fs',
+//   'alias',
+//   'node',
+//   'decorator',
+//   'iife',
+//   'abs_path',
+//   'inject',
+//   'metafile',
+//   'output_extension',
+//   'top_level_return_forbidden',
+// ]
 
 let queryString = `
 (call_expression
@@ -283,15 +283,15 @@ for (let i = 0, len = tree.rootNode.namedChildren.length; i < len; i++) {
 
     console.log('testCaseName: ', testCaseName)
 
-    let isIgnored = false
+    // let isIgnored = false
     // Skip some test cases by ignoredTestName
-    if (ignoredTestPattern.some((name) => testCaseName?.includes(name))) {
-      isIgnored = true
-    }
+    // if (ignoredTestPattern.some((name) => testCaseName?.includes(name))) {
+    //   isIgnored = true
+    // }
     // @ts-ignore
-    if (ignoreCases.includes(testCaseName)) {
-      isIgnored = true
-    }
+    // if (ignoreCases.includes(testCaseName)) {
+    //   isIgnored = true
+    // }
     let bundle_field_list = query.captures(child).filter((item) => {
       return item.name === 'element_list'
     })
@@ -302,20 +302,6 @@ for (let i = 0, len = tree.rootNode.namedChildren.length; i < len; i++) {
     })
 
     const fileList = jsConfig['files']
-    // Skip jsx/ts/tsx files test case
-    if (
-      fileList.some(
-        (file) =>
-          file.name.endsWith('ts') ||
-          file.name.endsWith('tsx') ||
-          file.name.endsWith('jsx'),
-      )
-    ) {
-      isIgnored = true
-    }
-    if (isIgnored) {
-      testCaseName = `.${testCaseName}`
-    }
 
     const testDir = path.resolve(TESTS_ROOT_DIR, testCaseName)
     const ignoredTestDir = path.resolve(TESTS_ROOT_DIR, `.${testCaseName}`)

--- a/scripts/snap-diff/summary/importstar.md
+++ b/scripts/snap-diff/summary/importstar.md
@@ -13,12 +13,12 @@
   diff
 ## [export_self_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_self_common_js/diff.md)
   diff
-## export_self_common_js_minified
-  missing
-## export_self_iife
-  missing
-## export_self_iife_with_name
-  missing
+## [export_self_common_js_minified](../../../crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified/diff.md)
+  diff
+## [export_self_iife](../../../crates/rolldown/tests/esbuild/importstar/export_self_iife/diff.md)
+  diff
+## [export_self_iife_with_name](../../../crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/diff.md)
+  diff
 ## export_star_default_export_common_js
   missing
 ## import_default_namespace_combo_issue446
@@ -55,18 +55,18 @@
   diff
 ## [import_star_export_star_omit_ambiguous](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/diff.md)
   diff
-## import_star_mangle_no_bundle_capture
-  missing
-## import_star_mangle_no_bundle_no_capture
-  missing
-## import_star_mangle_no_bundle_unused
-  missing
-## import_star_no_bundle_capture
-  missing
-## import_star_no_bundle_no_capture
-  missing
-## import_star_no_bundle_unused
-  missing
+## [import_star_mangle_no_bundle_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture/diff.md)
+  diff
+## [import_star_mangle_no_bundle_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture/diff.md)
+  diff
+## [import_star_mangle_no_bundle_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused/diff.md)
+  diff
+## [import_star_no_bundle_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture/diff.md)
+  diff
+## [import_star_no_bundle_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture/diff.md)
+  diff
+## [import_star_no_bundle_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused/diff.md)
+  diff
 ## [import_star_no_capture](../../../crates/rolldown/tests/esbuild/importstar/import_star_no_capture/diff.md)
   diff
 ## [import_star_of_export_star_as](../../../crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/diff.md)
@@ -87,27 +87,25 @@
   diff
 ## [re_export_namespace_import_unused_missing_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6/diff.md)
   diff
-## re_export_star_as_common_js_no_bundle
-  missing
-## re_export_star_as_es6_no_bundle
-  missing
+## [re_export_star_as_common_js_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/diff.md)
+  diff
 ## [re_export_star_as_external_common_js](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_common_js/diff.md)
   diff
-## re_export_star_as_external_iife
-  missing
-## re_export_star_as_iife_no_bundle
-  missing
-## re_export_star_common_js_no_bundle
-  missing
+## [re_export_star_as_external_iife](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/diff.md)
+  diff
+## [re_export_star_as_iife_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/diff.md)
+  diff
+## [re_export_star_common_js_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/diff.md)
+  diff
 ## [re_export_star_entry_point_and_inner_file](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_entry_point_and_inner_file/diff.md)
   diff
-## re_export_star_es6_no_bundle
-  missing
+## [re_export_star_es6_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/diff.md)
+  diff
 ## [re_export_star_external_common_js](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_external_common_js/diff.md)
   diff
 ## [re_export_star_external_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_external_es6/diff.md)
   diff
-## re_export_star_external_iife
-  missing
-## re_export_star_iife_no_bundle
-  missing
+## [re_export_star_external_iife](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/diff.md)
+  diff
+## [re_export_star_iife_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/diff.md)
+  diff


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. enable importstar tests case that ignore by generator.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
