### PR TITLE
chore(esbuild-diff): bypass esbuild diff.md

### DIFF
--- a/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/bypass.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/bypass.md
@@ -1,3 +1,6 @@
+# Reason
+1. cjs module lexer can't recognize esbuild interop code
+# Diff
 ## /out.js
 ### esbuild
 ```js

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint-code": "oxlint -c .oxlintrc.json --ignore-path=.oxlintignore --import-plugin --jsdoc-plugin --deny-warnings",
     "lint-filename": "echo 'TODO: ls-lint is too slow now'",
     "lint-filename:bak": "ls-lint",
-    "lint-spell": "cspell \"**\" --no-progress",
+    "lint-spell": "cspell \"**\" --no-progress  --gitignore",
     "lint-prettier": "prettier . '**/*.{js,ts,json,md,yml,yaml,vue}' -c",
     "lint-prettier:fix": "prettier . '**/*.{js,ts,json,md,yml,yaml,vue}' -w",
     "lint-toml": "taplo format --check",

--- a/scripts/snap-diff/diff.ts
+++ b/scripts/snap-diff/diff.ts
@@ -1,77 +1,77 @@
-import * as diff from "diff";
-import { rewriteEsbuild, rewriteRolldown } from "./rewrite.js";
+import * as diff from 'diff'
+import { rewriteEsbuild, rewriteRolldown } from './rewrite.js'
 /**
  * our filename generate logic is not the same as esbuild
  * so hardcode some filename remapping
  */
 function defaultResolveFunction(
-	esbuildFilename: string,
-	rolldownFilename: string,
+  esbuildFilename: string,
+  rolldownFilename: string,
 ) {
-	if (esbuildFilename === "/out.js" && /entry_js\.*/.test(rolldownFilename)) {
-		return true;
-	}
+  if (esbuildFilename === '/out.js' && /entry_js\.*/.test(rolldownFilename)) {
+    return true
+  }
 }
 /**
  * TODO: custom resolve
  */
 export function diffCase(
-	esbuildSnap: {
-		name: string;
-		sourceList: Array<{ name: string; content: string }>;
-	},
-	rolldownSnap: Array<{ filename: string; content: string }> | undefined,
+  esbuildSnap: {
+    name: string
+    sourceList: Array<{ name: string; content: string }>
+  },
+  rolldownSnap: Array<{ filename: string; content: string }> | undefined,
 ):
-	| "bypass"
-	| "missing"
-	| Array<{
-			esbuildName: string;
-			rolldownName: string;
-			esbuild: string;
-			rolldown: string;
-			diff: string;
-	  }>
-	| "same" {
-	if (!rolldownSnap) {
-		return "missing";
-	}
-	let diffList = [];
-	for (let esbuildSource of esbuildSnap.sourceList) {
-		let matchedSource = rolldownSnap.find((rolldownSource) => {
-			if (defaultResolveFunction(esbuildSource.name, rolldownSource.filename)) {
-				return true;
-			}
-			return rolldownSnap.find((snap) => {
-				return snap.filename == esbuildSource.name;
-			});
-		}) ?? { content: "", filename: "" };
-		let esbuildContent = rewriteEsbuild(esbuildSource.content);
-		let rolldownContent = rewriteRolldown(matchedSource.content);
+  | 'bypass'
+  | 'missing'
+  | Array<{
+      esbuildName: string
+      rolldownName: string
+      esbuild: string
+      rolldown: string
+      diff: string
+    }>
+  | 'same' {
+  if (!rolldownSnap) {
+    return 'missing'
+  }
+  let diffList = []
+  for (let esbuildSource of esbuildSnap.sourceList) {
+    let matchedSource = rolldownSnap.find((rolldownSource) => {
+      if (defaultResolveFunction(esbuildSource.name, rolldownSource.filename)) {
+        return true
+      }
+      return rolldownSnap.find((snap) => {
+        return snap.filename == esbuildSource.name
+      })
+    }) ?? { content: '', filename: '' }
+    let esbuildContent = rewriteEsbuild(esbuildSource.content)
+    let rolldownContent = rewriteRolldown(matchedSource.content)
 
-		if (matchedSource.content !== esbuildSource.content) {
-			let structuredPatch = diff.structuredPatch(
-				"esbuild",
-				"rolldown",
-				esbuildContent,
-				rolldownContent,
-				esbuildSource.name,
-				matchedSource.filename,
-			);
-			let formatDiff = "";
-			if (structuredPatch.hunks.length > 0) {
-				formatDiff = diff.formatPatch(structuredPatch);
-				diffList.push({
-					esbuildName: esbuildSource.name,
-					rolldownName: matchedSource.filename,
-					esbuild: esbuildSource.content,
-					rolldown: matchedSource.content,
-					diff: formatDiff,
-				});
-			}
-		}
-	}
-	if (diffList.length === 0) {
-		return "same";
-	}
-	return diffList;
+    if (matchedSource.content !== esbuildSource.content) {
+      let structuredPatch = diff.structuredPatch(
+        'esbuild',
+        'rolldown',
+        esbuildContent,
+        rolldownContent,
+        esbuildSource.name,
+        matchedSource.filename,
+      )
+      let formatDiff = ''
+      if (structuredPatch.hunks.length > 0) {
+        formatDiff = diff.formatPatch(structuredPatch)
+        diffList.push({
+          esbuildName: esbuildSource.name,
+          rolldownName: matchedSource.filename,
+          esbuild: esbuildSource.content,
+          rolldown: matchedSource.content,
+          diff: formatDiff,
+        })
+      }
+    }
+  }
+  if (diffList.length === 0) {
+    return 'same'
+  }
+  return diffList
 }

--- a/scripts/snap-diff/diff.ts
+++ b/scripts/snap-diff/diff.ts
@@ -1,76 +1,77 @@
-import * as diff from 'diff'
-import { rewriteEsbuild, rewriteRolldown } from './rewrite.js'
+import * as diff from "diff";
+import { rewriteEsbuild, rewriteRolldown } from "./rewrite.js";
 /**
  * our filename generate logic is not the same as esbuild
  * so hardcode some filename remapping
  */
 function defaultResolveFunction(
-  esbuildFilename: string,
-  rolldownFilename: string,
+	esbuildFilename: string,
+	rolldownFilename: string,
 ) {
-  if (esbuildFilename === '/out.js' && /entry_js\.*/.test(rolldownFilename)) {
-    return true
-  }
+	if (esbuildFilename === "/out.js" && /entry_js\.*/.test(rolldownFilename)) {
+		return true;
+	}
 }
 /**
  * TODO: custom resolve
  */
 export function diffCase(
-  esbuildSnap: {
-    name: string
-    sourceList: Array<{ name: string; content: string }>
-  },
-  rolldownSnap: Array<{ filename: string; content: string }> | undefined,
+	esbuildSnap: {
+		name: string;
+		sourceList: Array<{ name: string; content: string }>;
+	},
+	rolldownSnap: Array<{ filename: string; content: string }> | undefined,
 ):
-  | 'missing'
-  | Array<{
-      esbuildName: string
-      rolldownName: string
-      esbuild: string
-      rolldown: string
-      diff: string
-    }>
-  | 'same' {
-  if (!rolldownSnap) {
-    return 'missing'
-  }
-  let diffList = []
-  for (let esbuildSource of esbuildSnap.sourceList) {
-    let matchedSource = rolldownSnap.find((rolldownSource) => {
-      if (defaultResolveFunction(esbuildSource.name, rolldownSource.filename)) {
-        return true
-      }
-      return rolldownSnap.find((snap) => {
-        return snap.filename == esbuildSource.name
-      })
-    }) ?? { content: '', filename: '' }
-    let esbuildContent = rewriteEsbuild(esbuildSource.content)
-    let rolldownContent = rewriteRolldown(matchedSource.content)
+	| "bypass"
+	| "missing"
+	| Array<{
+			esbuildName: string;
+			rolldownName: string;
+			esbuild: string;
+			rolldown: string;
+			diff: string;
+	  }>
+	| "same" {
+	if (!rolldownSnap) {
+		return "missing";
+	}
+	let diffList = [];
+	for (let esbuildSource of esbuildSnap.sourceList) {
+		let matchedSource = rolldownSnap.find((rolldownSource) => {
+			if (defaultResolveFunction(esbuildSource.name, rolldownSource.filename)) {
+				return true;
+			}
+			return rolldownSnap.find((snap) => {
+				return snap.filename == esbuildSource.name;
+			});
+		}) ?? { content: "", filename: "" };
+		let esbuildContent = rewriteEsbuild(esbuildSource.content);
+		let rolldownContent = rewriteRolldown(matchedSource.content);
 
-    if (matchedSource.content !== esbuildSource.content) {
-      let structuredPatch = diff.structuredPatch(
-        'esbuild',
-        'rolldown',
-        esbuildContent,
-        rolldownContent,
-        esbuildSource.name,
-        matchedSource.filename,
-      )
-      let formatDiff = ''
-      if (structuredPatch.hunks.length > 0) {
-        formatDiff = diff.formatPatch(structuredPatch)
-        diffList.push({
-          esbuildName: esbuildSource.name,
-          rolldownName: matchedSource.filename,
-          esbuild: esbuildSource.content,
-          rolldown: matchedSource.content,
-          diff: formatDiff,
-        })
-      }
-    }
-  }
-  if (diffList.length === 0) {
-    return 'same'
-  }
-  return diffList
+		if (matchedSource.content !== esbuildSource.content) {
+			let structuredPatch = diff.structuredPatch(
+				"esbuild",
+				"rolldown",
+				esbuildContent,
+				rolldownContent,
+				esbuildSource.name,
+				matchedSource.filename,
+			);
+			let formatDiff = "";
+			if (structuredPatch.hunks.length > 0) {
+				formatDiff = diff.formatPatch(structuredPatch);
+				diffList.push({
+					esbuildName: esbuildSource.name,
+					rolldownName: matchedSource.filename,
+					esbuild: esbuildSource.content,
+					rolldown: matchedSource.content,
+					diff: formatDiff,
+				});
+			}
+		}
+	}
+	if (diffList.length === 0) {
+		return "same";
+	}
+	return diffList;
 }

--- a/scripts/snap-diff/runner.ts
+++ b/scripts/snap-diff/runner.ts
@@ -1,112 +1,185 @@
-import * as path from 'node:path'
-import * as fs from 'node:fs'
-import { parseEsbuildSnap, parseRolldownSnap } from './snap-parser.js'
-import { diffCase } from './diff'
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { parseEsbuildSnap, parseRolldownSnap } from "./snap-parser.js";
+import { diffCase } from "./diff";
+import { diffCss } from "diff";
 const esbuildTestDir = path.join(
-  import.meta.dirname,
-  '../../crates/rolldown/tests/esbuild',
-)
+	import.meta.dirname,
+	"../../crates/rolldown/tests/esbuild",
+);
 
 export function getEsbuildSnapFile(
-  includeList: string[],
+	includeList: string[],
 ): Array<{ normalizedName: string; content: string }> {
-  let dirname = path.resolve(import.meta.dirname, './esbuild-snapshots/')
-  let fileList = fs.readdirSync(dirname)
-  let ret = fileList
-    .filter((filename) => {
-      return includeList.length === 0 || includeList.includes(filename)
-    })
-    .map((filename) => {
-      let name = path.parse(filename).name
-      let [_, ...rest] = name.split('_')
-      let normalizedName = rest.join('_')
-      let content = fs.readFileSync(path.join(dirname, filename), 'utf-8')
-      return { normalizedName, content }
-    })
-  return ret
+	let dirname = path.resolve(import.meta.dirname, "./esbuild-snapshots/");
+	let fileList = fs.readdirSync(dirname);
+	let ret = fileList
+		.filter((filename) => {
+			return includeList.length === 0 || includeList.includes(filename);
+		})
+		.map((filename) => {
+			let name = path.parse(filename).name;
+			let [_, ...rest] = name.split("_");
+			let normalizedName = rest.join("_");
+			let content = fs.readFileSync(path.join(dirname, filename), "utf-8");
+			return { normalizedName, content };
+		});
+	return ret;
 }
 
 export function run(includeList: string[]) {
-  let snapfileList = getEsbuildSnapFile(includeList)
-  // esbuild snapshot_x.txt
-  for (let snapFile of snapfileList) {
-    let { normalizedName: snapCategory, content } = snapFile
-    let parsedEsbuildSnap = parseEsbuildSnap(content)
-    // singleEsbuildSnapshot
-    let diffList = []
-    for (let snap of parsedEsbuildSnap) {
-      let rolldownTestPath = path.join(esbuildTestDir, snapCategory, snap.name)
-      let rolldownSnap = getRolldownSnap(rolldownTestPath)
-      let parsedRolldownSnap = parseRolldownSnap(rolldownSnap)
-      let diffResult = diffCase(snap, parsedRolldownSnap)
-      if (typeof diffResult !== 'string') {
-        writeDiffToTestcaseDir(rolldownTestPath, diffResult)
-      } else {
-        let diffMarkdownPath = path.join(rolldownTestPath, 'diff.md')
-        if (diffResult === 'same' && fs.existsSync(diffMarkdownPath)) {
-          // this happens when we fixing some issues and the snapshot is align with esbuild,
-          fs.rmSync(diffMarkdownPath, {})
-        }
-      }
-      diffList.push({ diffResult, name: snap.name })
-    }
-    diffList.sort((a, b) => {
-      return a.name.localeCompare(b.name)
-    })
-    let summaryMarkdown = getSummaryMarkdown(diffList, snapCategory)
-    fs.writeFileSync(
-      path.join(import.meta.dirname, './summary/', `${snapCategory}.md`),
-      summaryMarkdown,
-    )
-  }
+	let snapfileList = getEsbuildSnapFile(includeList);
+	// esbuild snapshot_x.txt
+	for (let snapFile of snapfileList) {
+		let { normalizedName: snapCategory, content } = snapFile;
+		let parsedEsbuildSnap = parseEsbuildSnap(content);
+		// singleEsbuildSnapshot
+		let diffList = [];
+		for (let snap of parsedEsbuildSnap) {
+			let rolldownTestPath = path.join(esbuildTestDir, snapCategory, snap.name);
+			let rolldownSnap = getRolldownSnap(rolldownTestPath);
+			let parsedRolldownSnap = parseRolldownSnap(rolldownSnap);
+			let diffResult = diffCase(snap, parsedRolldownSnap);
+			// if the testdir has a `bypass.md`, we skip generate `diff.md`,
+			// append the diff result to `bypass.md` instead
+			let bypassMarkdownPath = path.join(rolldownTestPath, "bypass.md");
+			let diffMarkdownPath = path.join(rolldownTestPath, "diff.md");
+
+			if (fs.existsSync(bypassMarkdownPath)) {
+				if (fs.existsSync(diffMarkdownPath)) {
+					fs.rmSync(diffMarkdownPath, {});
+				}
+				updateBypassMarkdown(bypassMarkdownPath, diffResult);
+				diffResult = "bypass";
+			} else {
+				if (typeof diffResult !== "string") {
+					writeDiffMarkdownToTestcaseDir(diffResult, rolldownTestPath);
+				} else {
+					if (diffResult === "same" && fs.existsSync(diffMarkdownPath)) {
+						// this happens when we fixing some issues and the snapshot is align with esbuild,
+						fs.rmSync(diffMarkdownPath, {});
+					}
+				}
+			}
+			diffList.push({ diffResult, name: snap.name });
+		}
+		diffList.sort((a, b) => {
+			return a.name.localeCompare(b.name);
+		});
+		let summaryMarkdown = getSummaryMarkdown(diffList, snapCategory);
+		fs.writeFileSync(
+			path.join(import.meta.dirname, "./summary/", `${snapCategory}.md`),
+			summaryMarkdown,
+		);
+	}
 }
 
 function getRolldownSnap(caseDir: string) {
-  let artifactsPath = path.join(caseDir, 'artifacts.snap')
-  if (fs.existsSync(artifactsPath)) {
-    return fs.readFileSync(artifactsPath, 'utf-8')
-  }
+	let artifactsPath = path.join(caseDir, "artifacts.snap");
+	if (fs.existsSync(artifactsPath)) {
+		return fs.readFileSync(artifactsPath, "utf-8");
+	}
 }
 
-function writeDiffToTestcaseDir(
-  dir: string,
-  diffResult: ReturnType<typeof diffCase>,
+function writeDiffMarkdownToTestcaseDir(
+	diffResult: ReturnType<typeof diffCase>,
+	dir: string,
 ) {
-  // this seems redundant, just help ts type infer
-  if (typeof diffResult === 'string') {
-    return
-  }
-  let markdown = ''
-  for (let d of diffResult) {
-    markdown += `## ${d.esbuildName}\n`
-    markdown += `### esbuild\n\`\`\`js\n${d.esbuild}\n\`\`\`\n`
-    markdown += `### rolldown\n\`\`\`js\n${d.rolldown}\n\`\`\`\n`
-    markdown += `### diff\n\`\`\`diff\n${d.diff}\n\`\`\`\n`
-  }
-  fs.writeFileSync(path.join(dir, 'diff.md'), markdown)
+	// this seems redundant, just help ts type infer
+	if (typeof diffResult === "string") {
+		return;
+	}
+	let markdown = getDiffMarkdown(diffResult);
+	fs.writeFileSync(path.join(dir, "diff.md"), markdown);
+}
+
+function getDiffMarkdown(diffResult: ReturnType<typeof diffCase>) {
+	if (typeof diffResult === "string") {
+		throw new Error("diffResult should not be string");
+	}
+	let markdown = "";
+	for (let d of diffResult) {
+		markdown += `## ${d.esbuildName}\n`;
+		markdown += `### esbuild\n\`\`\`js\n${d.esbuild}\n\`\`\`\n`;
+		markdown += `### rolldown\n\`\`\`js\n${d.rolldown}\n\`\`\`\n`;
+		markdown += `### diff\n\`\`\`diff\n${d.diff}\n\`\`\`\n`;
+	}
+	return markdown;
 }
 
 function getSummaryMarkdown(
-  diffList: Array<{ diffResult: ReturnType<typeof diffCase>; name: string }>,
-  snapshotCategory: string,
+	diffList: Array<{ diffResult: ReturnType<typeof diffCase>; name: string }>,
+	snapshotCategory: string,
 ) {
-  let markdown = `# Failed Cases\n`
-  for (let diff of diffList) {
-    let testDir = path.join(esbuildTestDir, snapshotCategory, diff.name)
-    let relativePath = path.relative(
-      path.join(import.meta.dirname, 'summary'),
-      testDir,
-    )
-    const posixPath = relativePath.replaceAll('\\', '/')
-    if (diff.diffResult === 'missing') {
-      markdown += `## ${diff.name}\n`
-      markdown += `  missing\n`
-      continue
-    }
-    if (diff.diffResult !== 'same') {
-      markdown += `## [${diff.name}](${posixPath}/diff.md)\n`
-      markdown += `  diff\n`
-    }
-  }
-  return markdown
+	let bypassList = [];
+	let failedList = [];
+	let passList = [];
+	for (let diff of diffList) {
+		if (diff.diffResult === "bypass") {
+			bypassList.push(diff);
+		} else if (diff.diffResult === "same") {
+			passList.push(diff);
+		} else {
+			failedList.push(diff);
+		}
+	}
+	let markdown = `# Failed Cases\n`;
+	for (let diff of failedList) {
+		let testDir = path.join(esbuildTestDir, snapshotCategory, diff.name);
+		let relativePath = path.relative(
+			path.join(import.meta.dirname, "summary"),
+			testDir,
+		);
+		const posixPath = relativePath.replaceAll("\\", "/");
+		if (diff.diffResult === "missing") {
+			markdown += `## ${diff.name}\n`;
+			markdown += `  missing\n`;
+			continue;
+		}
+		if (diff.diffResult !== "same") {
+			markdown += `## [${diff.name}](${posixPath}/diff.md)\n`;
+			markdown += `  diff\n`;
+		}
+	}
+
+	markdown += `# Passed Cases\n`;
+	for (let diff of passList) {
+		let testDir = path.join(esbuildTestDir, snapshotCategory, diff.name);
+		let relativePath = path.relative(
+			path.join(import.meta.dirname, "summary"),
+			testDir,
+		);
+		const posixPath = relativePath.replaceAll("\\", "/");
+		markdown += `## [${diff.name}](${posixPath})\n`;
+	}
+
+	markdown += `# Bypassed Cases\n`;
+	for (let diff of bypassList) {
+		let testDir = path.join(esbuildTestDir, snapshotCategory, diff.name);
+		let relativePath = path.relative(
+			path.join(import.meta.dirname, "summary"),
+			testDir,
+		);
+		const posixPath = relativePath.replaceAll("\\", "/");
+		markdown += `## [${diff.name}](${posixPath}/bypass.md)\n`;
+	}
+
+	return markdown;
+}
+
+function updateBypassMarkdown(
+	bypassMarkdownPath: string,
+	diffResult: ReturnType<typeof diffCase>,
+) {
+	let bypassContent = fs.readFileSync(bypassMarkdownPath, "utf-8");
+
+	let res = /# Diff/.exec(bypassContent);
+	if (res) {
+		bypassContent = bypassContent.slice(0, res.index);
+	}
+	let diffMarkdown = getDiffMarkdown(diffResult);
+	bypassContent = bypassContent.trimEnd();
+	bypassContent += "\n# Diff\n";
+	bypassContent += diffMarkdown;
+	fs.writeFileSync(bypassMarkdownPath, bypassContent);
 }

--- a/scripts/snap-diff/runner.ts
+++ b/scripts/snap-diff/runner.ts
@@ -1,185 +1,184 @@
-import * as path from "node:path";
-import * as fs from "node:fs";
-import { parseEsbuildSnap, parseRolldownSnap } from "./snap-parser.js";
-import { diffCase } from "./diff";
-import { diffCss } from "diff";
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+import { parseEsbuildSnap, parseRolldownSnap } from './snap-parser.js'
+import { diffCase } from './diff'
 const esbuildTestDir = path.join(
-	import.meta.dirname,
-	"../../crates/rolldown/tests/esbuild",
-);
+  import.meta.dirname,
+  '../../crates/rolldown/tests/esbuild',
+)
 
 export function getEsbuildSnapFile(
-	includeList: string[],
+  includeList: string[],
 ): Array<{ normalizedName: string; content: string }> {
-	let dirname = path.resolve(import.meta.dirname, "./esbuild-snapshots/");
-	let fileList = fs.readdirSync(dirname);
-	let ret = fileList
-		.filter((filename) => {
-			return includeList.length === 0 || includeList.includes(filename);
-		})
-		.map((filename) => {
-			let name = path.parse(filename).name;
-			let [_, ...rest] = name.split("_");
-			let normalizedName = rest.join("_");
-			let content = fs.readFileSync(path.join(dirname, filename), "utf-8");
-			return { normalizedName, content };
-		});
-	return ret;
+  let dirname = path.resolve(import.meta.dirname, './esbuild-snapshots/')
+  let fileList = fs.readdirSync(dirname)
+  let ret = fileList
+    .filter((filename) => {
+      return includeList.length === 0 || includeList.includes(filename)
+    })
+    .map((filename) => {
+      let name = path.parse(filename).name
+      let [_, ...rest] = name.split('_')
+      let normalizedName = rest.join('_')
+      let content = fs.readFileSync(path.join(dirname, filename), 'utf-8')
+      return { normalizedName, content }
+    })
+  return ret
 }
 
 export function run(includeList: string[]) {
-	let snapfileList = getEsbuildSnapFile(includeList);
-	// esbuild snapshot_x.txt
-	for (let snapFile of snapfileList) {
-		let { normalizedName: snapCategory, content } = snapFile;
-		let parsedEsbuildSnap = parseEsbuildSnap(content);
-		// singleEsbuildSnapshot
-		let diffList = [];
-		for (let snap of parsedEsbuildSnap) {
-			let rolldownTestPath = path.join(esbuildTestDir, snapCategory, snap.name);
-			let rolldownSnap = getRolldownSnap(rolldownTestPath);
-			let parsedRolldownSnap = parseRolldownSnap(rolldownSnap);
-			let diffResult = diffCase(snap, parsedRolldownSnap);
-			// if the testdir has a `bypass.md`, we skip generate `diff.md`,
-			// append the diff result to `bypass.md` instead
-			let bypassMarkdownPath = path.join(rolldownTestPath, "bypass.md");
-			let diffMarkdownPath = path.join(rolldownTestPath, "diff.md");
+  let snapfileList = getEsbuildSnapFile(includeList)
+  // esbuild snapshot_x.txt
+  for (let snapFile of snapfileList) {
+    let { normalizedName: snapCategory, content } = snapFile
+    let parsedEsbuildSnap = parseEsbuildSnap(content)
+    // singleEsbuildSnapshot
+    let diffList = []
+    for (let snap of parsedEsbuildSnap) {
+      let rolldownTestPath = path.join(esbuildTestDir, snapCategory, snap.name)
+      let rolldownSnap = getRolldownSnap(rolldownTestPath)
+      let parsedRolldownSnap = parseRolldownSnap(rolldownSnap)
+      let diffResult = diffCase(snap, parsedRolldownSnap)
+      // if the testdir has a `bypass.md`, we skip generate `diff.md`,
+      // append the diff result to `bypass.md` instead
+      let bypassMarkdownPath = path.join(rolldownTestPath, 'bypass.md')
+      let diffMarkdownPath = path.join(rolldownTestPath, 'diff.md')
 
-			if (fs.existsSync(bypassMarkdownPath)) {
-				if (fs.existsSync(diffMarkdownPath)) {
-					fs.rmSync(diffMarkdownPath, {});
-				}
-				updateBypassMarkdown(bypassMarkdownPath, diffResult);
-				diffResult = "bypass";
-			} else {
-				if (typeof diffResult !== "string") {
-					writeDiffMarkdownToTestcaseDir(diffResult, rolldownTestPath);
-				} else {
-					if (diffResult === "same" && fs.existsSync(diffMarkdownPath)) {
-						// this happens when we fixing some issues and the snapshot is align with esbuild,
-						fs.rmSync(diffMarkdownPath, {});
-					}
-				}
-			}
-			diffList.push({ diffResult, name: snap.name });
-		}
-		diffList.sort((a, b) => {
-			return a.name.localeCompare(b.name);
-		});
-		let summaryMarkdown = getSummaryMarkdown(diffList, snapCategory);
-		fs.writeFileSync(
-			path.join(import.meta.dirname, "./summary/", `${snapCategory}.md`),
-			summaryMarkdown,
-		);
-	}
+      if (fs.existsSync(bypassMarkdownPath)) {
+        if (fs.existsSync(diffMarkdownPath)) {
+          fs.rmSync(diffMarkdownPath, {})
+        }
+        updateBypassMarkdown(bypassMarkdownPath, diffResult)
+        diffResult = 'bypass'
+      } else {
+        if (typeof diffResult !== 'string') {
+          writeDiffMarkdownToTestcaseDir(diffResult, rolldownTestPath)
+        } else {
+          if (diffResult === 'same' && fs.existsSync(diffMarkdownPath)) {
+            // this happens when we fixing some issues and the snapshot is align with esbuild,
+            fs.rmSync(diffMarkdownPath, {})
+          }
+        }
+      }
+      diffList.push({ diffResult, name: snap.name })
+    }
+    diffList.sort((a, b) => {
+      return a.name.localeCompare(b.name)
+    })
+    let summaryMarkdown = getSummaryMarkdown(diffList, snapCategory)
+    fs.writeFileSync(
+      path.join(import.meta.dirname, './summary/', `${snapCategory}.md`),
+      summaryMarkdown,
+    )
+  }
 }
 
 function getRolldownSnap(caseDir: string) {
-	let artifactsPath = path.join(caseDir, "artifacts.snap");
-	if (fs.existsSync(artifactsPath)) {
-		return fs.readFileSync(artifactsPath, "utf-8");
-	}
+  let artifactsPath = path.join(caseDir, 'artifacts.snap')
+  if (fs.existsSync(artifactsPath)) {
+    return fs.readFileSync(artifactsPath, 'utf-8')
+  }
 }
 
 function writeDiffMarkdownToTestcaseDir(
-	diffResult: ReturnType<typeof diffCase>,
-	dir: string,
+  diffResult: ReturnType<typeof diffCase>,
+  dir: string,
 ) {
-	// this seems redundant, just help ts type infer
-	if (typeof diffResult === "string") {
-		return;
-	}
-	let markdown = getDiffMarkdown(diffResult);
-	fs.writeFileSync(path.join(dir, "diff.md"), markdown);
+  // this seems redundant, just help ts type infer
+  if (typeof diffResult === 'string') {
+    return
+  }
+  let markdown = getDiffMarkdown(diffResult)
+  fs.writeFileSync(path.join(dir, 'diff.md'), markdown)
 }
 
 function getDiffMarkdown(diffResult: ReturnType<typeof diffCase>) {
-	if (typeof diffResult === "string") {
-		throw new Error("diffResult should not be string");
-	}
-	let markdown = "";
-	for (let d of diffResult) {
-		markdown += `## ${d.esbuildName}\n`;
-		markdown += `### esbuild\n\`\`\`js\n${d.esbuild}\n\`\`\`\n`;
-		markdown += `### rolldown\n\`\`\`js\n${d.rolldown}\n\`\`\`\n`;
-		markdown += `### diff\n\`\`\`diff\n${d.diff}\n\`\`\`\n`;
-	}
-	return markdown;
+  if (typeof diffResult === 'string') {
+    throw new Error('diffResult should not be string')
+  }
+  let markdown = ''
+  for (let d of diffResult) {
+    markdown += `## ${d.esbuildName}\n`
+    markdown += `### esbuild\n\`\`\`js\n${d.esbuild}\n\`\`\`\n`
+    markdown += `### rolldown\n\`\`\`js\n${d.rolldown}\n\`\`\`\n`
+    markdown += `### diff\n\`\`\`diff\n${d.diff}\n\`\`\`\n`
+  }
+  return markdown
 }
 
 function getSummaryMarkdown(
-	diffList: Array<{ diffResult: ReturnType<typeof diffCase>; name: string }>,
-	snapshotCategory: string,
+  diffList: Array<{ diffResult: ReturnType<typeof diffCase>; name: string }>,
+  snapshotCategory: string,
 ) {
-	let bypassList = [];
-	let failedList = [];
-	let passList = [];
-	for (let diff of diffList) {
-		if (diff.diffResult === "bypass") {
-			bypassList.push(diff);
-		} else if (diff.diffResult === "same") {
-			passList.push(diff);
-		} else {
-			failedList.push(diff);
-		}
-	}
-	let markdown = `# Failed Cases\n`;
-	for (let diff of failedList) {
-		let testDir = path.join(esbuildTestDir, snapshotCategory, diff.name);
-		let relativePath = path.relative(
-			path.join(import.meta.dirname, "summary"),
-			testDir,
-		);
-		const posixPath = relativePath.replaceAll("\\", "/");
-		if (diff.diffResult === "missing") {
-			markdown += `## ${diff.name}\n`;
-			markdown += `  missing\n`;
-			continue;
-		}
-		if (diff.diffResult !== "same") {
-			markdown += `## [${diff.name}](${posixPath}/diff.md)\n`;
-			markdown += `  diff\n`;
-		}
-	}
+  let bypassList = []
+  let failedList = []
+  let passList = []
+  for (let diff of diffList) {
+    if (diff.diffResult === 'bypass') {
+      bypassList.push(diff)
+    } else if (diff.diffResult === 'same') {
+      passList.push(diff)
+    } else {
+      failedList.push(diff)
+    }
+  }
+  let markdown = `# Failed Cases\n`
+  for (let diff of failedList) {
+    let testDir = path.join(esbuildTestDir, snapshotCategory, diff.name)
+    let relativePath = path.relative(
+      path.join(import.meta.dirname, 'summary'),
+      testDir,
+    )
+    const posixPath = relativePath.replaceAll('\\', '/')
+    if (diff.diffResult === 'missing') {
+      markdown += `## ${diff.name}\n`
+      markdown += `  missing\n`
+      continue
+    }
+    if (diff.diffResult !== 'same') {
+      markdown += `## [${diff.name}](${posixPath}/diff.md)\n`
+      markdown += `  diff\n`
+    }
+  }
 
-	markdown += `# Passed Cases\n`;
-	for (let diff of passList) {
-		let testDir = path.join(esbuildTestDir, snapshotCategory, diff.name);
-		let relativePath = path.relative(
-			path.join(import.meta.dirname, "summary"),
-			testDir,
-		);
-		const posixPath = relativePath.replaceAll("\\", "/");
-		markdown += `## [${diff.name}](${posixPath})\n`;
-	}
+  markdown += `# Passed Cases\n`
+  for (let diff of passList) {
+    let testDir = path.join(esbuildTestDir, snapshotCategory, diff.name)
+    let relativePath = path.relative(
+      path.join(import.meta.dirname, 'summary'),
+      testDir,
+    )
+    const posixPath = relativePath.replaceAll('\\', '/')
+    markdown += `## [${diff.name}](${posixPath})\n`
+  }
 
-	markdown += `# Bypassed Cases\n`;
-	for (let diff of bypassList) {
-		let testDir = path.join(esbuildTestDir, snapshotCategory, diff.name);
-		let relativePath = path.relative(
-			path.join(import.meta.dirname, "summary"),
-			testDir,
-		);
-		const posixPath = relativePath.replaceAll("\\", "/");
-		markdown += `## [${diff.name}](${posixPath}/bypass.md)\n`;
-	}
+  markdown += `# Bypassed Cases\n`
+  for (let diff of bypassList) {
+    let testDir = path.join(esbuildTestDir, snapshotCategory, diff.name)
+    let relativePath = path.relative(
+      path.join(import.meta.dirname, 'summary'),
+      testDir,
+    )
+    const posixPath = relativePath.replaceAll('\\', '/')
+    markdown += `## [${diff.name}](${posixPath}/bypass.md)\n`
+  }
 
-	return markdown;
+  return markdown
 }
 
 function updateBypassMarkdown(
-	bypassMarkdownPath: string,
-	diffResult: ReturnType<typeof diffCase>,
+  bypassMarkdownPath: string,
+  diffResult: ReturnType<typeof diffCase>,
 ) {
-	let bypassContent = fs.readFileSync(bypassMarkdownPath, "utf-8");
+  let bypassContent = fs.readFileSync(bypassMarkdownPath, 'utf-8')
 
-	let res = /# Diff/.exec(bypassContent);
-	if (res) {
-		bypassContent = bypassContent.slice(0, res.index);
-	}
-	let diffMarkdown = getDiffMarkdown(diffResult);
-	bypassContent = bypassContent.trimEnd();
-	bypassContent += "\n# Diff\n";
-	bypassContent += diffMarkdown;
-	fs.writeFileSync(bypassMarkdownPath, bypassContent);
+  let res = /# Diff/.exec(bypassContent)
+  if (res) {
+    bypassContent = bypassContent.slice(0, res.index)
+  }
+  let diffMarkdown = getDiffMarkdown(diffResult)
+  bypassContent = bypassContent.trimEnd()
+  bypassContent += '\n# Diff\n'
+  bypassContent += diffMarkdown
+  fs.writeFileSync(bypassMarkdownPath, bypassContent)
 }

--- a/scripts/snap-diff/runner.ts
+++ b/scripts/snap-diff/runner.ts
@@ -39,7 +39,7 @@ export function run(includeList: string[]) {
       let rolldownSnap = getRolldownSnap(rolldownTestPath)
       let parsedRolldownSnap = parseRolldownSnap(rolldownSnap)
       let diffResult = diffCase(snap, parsedRolldownSnap)
-      // if the testdir has a `bypass.md`, we skip generate `diff.md`,
+      // if the testDir has a `bypass.md`, we skip generate `diff.md`,
       // append the diff result to `bypass.md` instead
       let bypassMarkdownPath = path.join(rolldownTestPath, 'bypass.md')
       let diffMarkdownPath = path.join(rolldownTestPath, 'diff.md')

--- a/scripts/snap-diff/summary/importstar.md
+++ b/scripts/snap-diff/summary/importstar.md
@@ -1,6 +1,4 @@
 # Failed Cases
-## [export_other_as_namespace_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/diff.md)
-  diff
 ## [export_other_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_other_common_js/diff.md)
   diff
 ## [export_other_nested_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/diff.md)
@@ -109,3 +107,27 @@
   diff
 ## [re_export_star_iife_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/diff.md)
   diff
+# Passed Cases
+## [export_self_as_namespace_es6](../../../crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6)
+## [export_self_es6](../../../crates/rolldown/tests/esbuild/importstar/export_self_es6)
+## [import_export_self_as_namespace_es6](../../../crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6)
+## [import_export_star_ambiguous_warning](../../../crates/rolldown/tests/esbuild/importstar/import_export_star_ambiguous_warning)
+## [import_of_export_star](../../../crates/rolldown/tests/esbuild/importstar/import_of_export_star)
+## [import_of_export_star_of_import](../../../crates/rolldown/tests/esbuild/importstar/import_of_export_star_of_import)
+## [import_star_export_import_star_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_unused)
+## [import_star_export_star_as_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_unused)
+## [import_star_export_star_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_export_star_unused)
+## [import_star_unused](../../../crates/rolldown/tests/esbuild/importstar/import_star_unused)
+## [other_file_export_self_as_namespace_unused_es6](../../../crates/rolldown/tests/esbuild/importstar/other_file_export_self_as_namespace_unused_es6)
+## [other_file_import_export_self_as_namespace_unused_es6](../../../crates/rolldown/tests/esbuild/importstar/other_file_import_export_self_as_namespace_unused_es6)
+## [re_export_namespace_import_missing_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6)
+## [re_export_other_file_export_self_as_namespace_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6)
+## [re_export_other_file_import_export_self_as_namespace_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6)
+## [re_export_star_as_es6_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_es6_no_bundle)
+## [re_export_star_as_external_es6](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_es6)
+## [re_export_star_name_collision_not_ambiguous_export](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_collision_not_ambiguous_export)
+## [re_export_star_name_collision_not_ambiguous_import](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_collision_not_ambiguous_import)
+## [re_export_star_name_shadowing_not_ambiguous](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_shadowing_not_ambiguous)
+## [re_export_star_name_shadowing_not_ambiguous_re_export](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_shadowing_not_ambiguous_re_export)
+# Bypassed Cases
+## [export_other_as_namespace_common_js](../../../crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/bypass.md)

--- a/scripts/snap-diff/summary/importstar.md
+++ b/scripts/snap-diff/summary/importstar.md
@@ -107,6 +107,18 @@
   diff
 ## [re_export_star_iife_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/diff.md)
   diff
+## re_export_star_external_iife
+  missing
+## re_export_star_iife_no_bundle
+  missing
+## [re_export_star_name_collision_not_ambiguous_import](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_collision_not_ambiguous_import/diff.md)
+  diff
+## [re_export_star_name_collision_not_ambiguous_import](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_collision_not_ambiguous_import/diff.md)
+  diff
+## re_export_star_external_iife
+  missing
+## re_export_star_iife_no_bundle
+  missing
 # Passed Cases
 ## [export_self_as_namespace_es6](../../../crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6)
 ## [export_self_es6](../../../crates/rolldown/tests/esbuild/importstar/export_self_es6)

--- a/scripts/snap-diff/summary/importstar.md
+++ b/scripts/snap-diff/summary/importstar.md
@@ -107,18 +107,6 @@
   diff
 ## [re_export_star_iife_no_bundle](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/diff.md)
   diff
-## re_export_star_external_iife
-  missing
-## re_export_star_iife_no_bundle
-  missing
-## [re_export_star_name_collision_not_ambiguous_import](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_collision_not_ambiguous_import/diff.md)
-  diff
-## [re_export_star_name_collision_not_ambiguous_import](../../../crates/rolldown/tests/esbuild/importstar/re_export_star_name_collision_not_ambiguous_import/diff.md)
-  diff
-## re_export_star_external_iife
-  missing
-## re_export_star_iife_no_bundle
-  missing
 # Passed Cases
 ## [export_self_as_namespace_es6](../../../crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6)
 ## [export_self_es6](../../../crates/rolldown/tests/esbuild/importstar/export_self_es6)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. add bypass mechanism to bypass some test case that semantic and runtime behavior same as esbuild, but it's impossible to ignore noise like
    - deconflict order, we starts with `root` and esbuild starts with `leaf` module
    -  esbuild cjs interop can't be recognized by cjs-module-lexer, our impl is compatible with it. 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
