### PR TITLE
chore: use astring instead of `escodegen`

### DIFF
--- a/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/bypass.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/bypass.md
@@ -46,23 +46,22 @@ Object.defineProperty(exports, 'ns', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -2,8 +2,11 @@
-     'foo.js'(exports) {
+@@ -2,10 +2,11 @@
+     "foo.js"(exports) {
          exports.foo = 123;
      }
  });
 -var entry_exports = {};
--__export(entry_exports, { ns: () => ns });
--module.exports = __toCommonJS(entry_exports);
--var ns = __toESM(require_foo());
-\ No newline at end of file
+-__export(entry_exports, {
+-    ns: () => ns
 +var import_foo = __toESM(require_foo());
 +Object.defineProperty(exports, 'ns', {
 +    enumerable: true,
 +    get: function () {
 +        return import_foo;
 +    }
-+});
-\ No newline at end of file
+ });
+-module.exports = __toCommonJS(entry_exports);
+-var ns = __toESM(require_foo());
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_other_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_common_js/diff.md
@@ -43,23 +43,22 @@ Object.defineProperty(exports, 'bar', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -2,8 +2,11 @@
-     'foo.js'(exports) {
+@@ -2,10 +2,11 @@
+     "foo.js"(exports) {
          exports.foo = 123;
      }
  });
 -var entry_exports = {};
--__export(entry_exports, { bar: () => import_foo.bar });
+-__export(entry_exports, {
+-    bar: () => import_foo.bar
+-});
 -module.exports = __toCommonJS(entry_exports);
--var import_foo = __toESM(require_foo());
-\ No newline at end of file
-+var import_foo = __toESM(require_foo());
+ var import_foo = __toESM(require_foo());
 +Object.defineProperty(exports, 'bar', {
 +    enumerable: true,
 +    get: function () {
 +        return import_foo.bar;
 +    }
 +});
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/diff.md
@@ -45,23 +45,22 @@ Object.defineProperty(exports, 'y', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -2,8 +2,11 @@
-     'foo.js'(exports) {
+@@ -2,10 +2,11 @@
+     "foo.js"(exports) {
          exports.foo = 123;
      }
  });
 -var entry_exports = {};
--__export(entry_exports, { y: () => import_foo.x });
+-__export(entry_exports, {
+-    y: () => import_foo.x
+-});
 -module.exports = __toCommonJS(entry_exports);
--var import_foo = __toESM(require_foo());
-\ No newline at end of file
-+var import_foo = __toESM(require_foo());
+ var import_foo = __toESM(require_foo());
 +Object.defineProperty(exports, 'y', {
 +    enumerable: true,
 +    get: function () {
 +        return import_foo.x;
 +    }
 +});
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/diff.md
@@ -35,20 +35,19 @@ Object.defineProperty(exports, 'foo', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -1,5 +1,10 @@
+@@ -1,7 +1,12 @@
  var entry_exports = {};
- __export(entry_exports, { foo: () => foo });
+ __export(entry_exports, {
+     foo: () => foo
+ });
 -module.exports = __toCommonJS(entry_exports);
  var foo = 123;
--console.log(entry_exports);
-\ No newline at end of file
-+console.log(entry_exports);
+ console.log(entry_exports);
 +Object.defineProperty(exports, 'foo', {
 +    enumerable: true,
 +    get: function () {
 +        return foo;
 +    }
 +});
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/diff.md
@@ -45,29 +45,30 @@ Object.defineProperty(exports, 'foo', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -1,11 +1,16 @@
+@@ -1,13 +1,18 @@
 -var entry_exports = {};
--__export(entry_exports, { foo: () => foo });
+-__export(entry_exports, {
+-    foo: () => foo
+-});
 -module.exports = __toCommonJS(entry_exports);
 -var foo;
 +var entry_exports, foo;
  var init_entry = __esm({
-     'entry.js'() {
+     "entry.js"() {
 +        entry_exports = {};
-+        __export(entry_exports, { foo: () => foo });
++        __export(entry_exports, {
++            foo: () => foo
++        });
          foo = 123;
          console.log((init_entry(), __toCommonJS(entry_exports)));
      }
  });
--init_entry();
-\ No newline at end of file
-+init_entry();
+ init_entry();
 +Object.defineProperty(exports, 'foo', {
 +    enumerable: true,
 +    get: function () {
 +        return foo;
 +    }
 +});
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/diff.md
@@ -49,9 +49,7 @@ Object.defineProperty(exports, 'ns', {
      ns: () => entry_exports
  });
 -module.exports = __toCommonJS(entry_exports);
--var foo = 123;
-\ No newline at end of file
-+var foo = 123;
+ var foo = 123;
 +Object.defineProperty(exports, 'foo', {
 +    enumerable: true,
 +    get: function () {
@@ -64,6 +62,5 @@ Object.defineProperty(exports, 'ns', {
 +        return entry_exports;
 +    }
 +});
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_common_js/diff.md
@@ -30,19 +30,18 @@ Object.defineProperty(exports, 'foo', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -1,4 +1,7 @@
+@@ -1,6 +1,7 @@
 -var entry_exports = {};
--__export(entry_exports, { foo: () => foo });
+-__export(entry_exports, {
+-    foo: () => foo
+-});
 -module.exports = __toCommonJS(entry_exports);
--var foo = 123;
-\ No newline at end of file
-+var foo = 123;
+ var foo = 123;
 +Object.defineProperty(exports, 'foo', {
 +    enumerable: true,
 +    get: function () {
 +        return foo;
 +    }
 +});
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_common_js_minified/diff.md
@@ -28,19 +28,21 @@ export default require_entry();
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -1,5 +1,7 @@
+@@ -1,7 +1,9 @@
 -var r = s((f, e) => {
--    e.exports = { foo: 123 };
+-    e.exports = {
+-        foo: 123
+-    };
 -    console.log(r());
 +var require_entry = __commonJS({
-+    'entry.js'(exports, module) {
-+        module.exports = { foo: 123 };
++    "entry.js"(exports, module) {
++        module.exports = {
++            foo: 123
++        };
 +        console.log(require_entry());
 +    }
  });
 -module.exports = r();
-\ No newline at end of file
 +export default require_entry();
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife/diff.md
@@ -35,7 +35,6 @@ return exports;
 -(() => {
 -    var foo = 123;
 -})();
-\ No newline at end of file
 +(function (exports) {
 +    const foo = 123;
 +    Object.defineProperty(exports, 'foo', {
@@ -45,7 +44,6 @@ return exports;
 +        }
 +    });
 +    return exports;
-+}({}));
-\ No newline at end of file
++})({});
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/diff.md
@@ -36,14 +36,11 @@ return exports;
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,6 +1,10 @@
+@@ -1,8 +1,10 @@
 -var someName = (() => {
 -    var entry_exports = {};
--    __export(entry_exports, { foo: () => foo });
--    var foo = 123;
--    return __toCommonJS(entry_exports);
--})();
-\ No newline at end of file
+-    __export(entry_exports, {
+-        foo: () => foo
 +(function (exports) {
 +    const foo = 123;
 +    Object.defineProperty(exports, 'foo', {
@@ -51,9 +48,11 @@ return exports;
 +        get: function () {
 +            return foo;
 +        }
-+    });
+     });
+-    var foo = 123;
+-    return __toCommonJS(entry_exports);
+-})();
 +    return exports;
-+}({}));
-\ No newline at end of file
++})({});
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_star_default_export_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_star_default_export_common_js/diff.md
@@ -26,16 +26,13 @@ export { foo };
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,4 +1,4 @@
+@@ -1,6 +1,2 @@
 -var entry_exports = {};
--__export(entry_exports, { foo: () => foo });
+-__export(entry_exports, {
+-    foo: () => foo
+-});
 -module.exports = __toCommonJS(entry_exports);
--var foo = 'foo';
-\ No newline at end of file
-+var foo = 'foo';
-+export {
-+    foo
-+};
-\ No newline at end of file
+ var foo = "foo";
++export {foo};
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/diff.md
@@ -15,9 +15,8 @@ console.log(def, default2);
 --- esbuild	/out/external-default2.js
 +++ rolldown	
 @@ -1,2 +0,0 @@
--import def, { default as default2 } from 'external';
+-import def, {default as default2} from "external";
 -console.log(def, default2);
-\ No newline at end of file
 
 ```
 ## /out/external-ns.js
@@ -37,9 +36,8 @@ console.log(def, ns);
 --- esbuild	/out/external-ns.js
 +++ rolldown	
 @@ -1,2 +0,0 @@
--import def, * as ns from 'external';
+-import def, * as ns from "external";
 -console.log(def, ns);
-\ No newline at end of file
 
 ```
 ## /out/external-ns-default.js
@@ -59,9 +57,8 @@ console.log(def, ns, ns.default);
 --- esbuild	/out/external-ns-default.js
 +++ rolldown	
 @@ -1,2 +0,0 @@
--import def, * as ns from 'external';
+-import def, * as ns from "external";
 -console.log(def, ns, ns.default);
-\ No newline at end of file
 
 ```
 ## /out/external-ns-def.js
@@ -81,9 +78,8 @@ console.log(def, ns, ns.def);
 --- esbuild	/out/external-ns-def.js
 +++ rolldown	
 @@ -1,2 +0,0 @@
--import def, * as ns from 'external';
+-import def, * as ns from "external";
 -console.log(def, ns, ns.def);
-\ No newline at end of file
 
 ```
 ## /out/external-default.js
@@ -103,9 +99,8 @@ console.log(def, ns.default);
 --- esbuild	/out/external-default.js
 +++ rolldown	
 @@ -1,2 +0,0 @@
--import def, * as ns from 'external';
+-import def, * as ns from "external";
 -console.log(def, ns.default);
-\ No newline at end of file
 
 ```
 ## /out/external-def.js
@@ -125,9 +120,8 @@ console.log(def, ns.def);
 --- esbuild	/out/external-def.js
 +++ rolldown	
 @@ -1,2 +0,0 @@
--import def, * as ns from 'external';
+-import def, * as ns from "external";
 -console.log(def, ns.def);
-\ No newline at end of file
 
 ```
 ## /out/internal-default2.js
@@ -151,7 +145,6 @@ console.log(internal_default, internal_default);
 @@ -1,2 +0,0 @@
 -var internal_default = 123;
 -console.log(internal_default, internal_default);
-\ No newline at end of file
 
 ```
 ## /out/internal-ns.js
@@ -176,12 +169,13 @@ console.log(internal_default, internal_exports);
 ===================================================================
 --- esbuild	/out/internal-ns.js
 +++ rolldown	
-@@ -1,4 +0,0 @@
+@@ -1,6 +0,0 @@
 -var internal_exports = {};
--__export(internal_exports, { default: () => internal_default });
+-__export(internal_exports, {
+-    default: () => internal_default
+-});
 -var internal_default = 123;
 -console.log(internal_default, internal_exports);
-\ No newline at end of file
 
 ```
 ## /out/internal-ns-default.js
@@ -206,12 +200,13 @@ console.log(internal_default, internal_exports, internal_default);
 ===================================================================
 --- esbuild	/out/internal-ns-default.js
 +++ rolldown	
-@@ -1,4 +0,0 @@
+@@ -1,6 +0,0 @@
 -var internal_exports = {};
--__export(internal_exports, { default: () => internal_default });
+-__export(internal_exports, {
+-    default: () => internal_default
+-});
 -var internal_default = 123;
 -console.log(internal_default, internal_exports, internal_default);
-\ No newline at end of file
 
 ```
 ## /out/internal-ns-def.js
@@ -236,12 +231,13 @@ console.log(internal_default, internal_exports, void 0);
 ===================================================================
 --- esbuild	/out/internal-ns-def.js
 +++ rolldown	
-@@ -1,4 +0,0 @@
+@@ -1,6 +0,0 @@
 -var internal_exports = {};
--__export(internal_exports, { default: () => internal_default });
+-__export(internal_exports, {
+-    default: () => internal_default
+-});
 -var internal_default = 123;
 -console.log(internal_default, internal_exports, void 0);
-\ No newline at end of file
 
 ```
 ## /out/internal-default.js
@@ -265,7 +261,6 @@ console.log(internal_default, internal_default);
 @@ -1,2 +0,0 @@
 -var internal_default = 123;
 -console.log(internal_default, internal_default);
-\ No newline at end of file
 
 ```
 ## /out/internal-def.js
@@ -289,6 +284,5 @@ console.log(internal_default, void 0);
 @@ -1,2 +0,0 @@
 -var internal_default = 123;
 -console.log(internal_default, void 0);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/diff.md
@@ -38,20 +38,18 @@ export { import_foo as ns };
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -2,8 +2,8 @@
-     'foo.js'(exports) {
+@@ -2,10 +2,6 @@
+     "foo.js"(exports) {
          exports.foo = 123;
      }
  });
 -var entry_exports = {};
--__export(entry_exports, { ns: () => ns });
+-__export(entry_exports, {
+-    ns: () => ns
+-});
 -module.exports = __toCommonJS(entry_exports);
 -var ns = __toESM(require_foo());
-\ No newline at end of file
 +var import_foo = __toESM(require_foo());
-+export {
-+    import_foo as ns
-+};
-\ No newline at end of file
++export {import_foo as ns};
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_empty_file/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_empty_file/diff.md
@@ -31,19 +31,16 @@ console.log(
 ===================================================================
 --- esbuild	/out/entry-nope.js
 +++ rolldown	
-@@ -1,11 +0,0 @@
+@@ -1,9 +0,0 @@
 -var require_empty = __commonJS({
--    'empty.js'() {
--    }
+-    "empty.js"() {}
 -});
 -var require_empty2 = __commonJS({
--    'empty.cjs'() {
--    }
+-    "empty.cjs"() {}
 -});
 -var js = __toESM(require_empty());
 -var cjs = __toESM(require_empty2());
 -console.log(void 0, void 0, void 0);
-\ No newline at end of file
 
 ```
 ## /out/entry-default.js
@@ -79,18 +76,15 @@ console.log(
 ===================================================================
 --- esbuild	/out/entry-default.js
 +++ rolldown	
-@@ -1,11 +0,0 @@
+@@ -1,9 +0,0 @@
 -var require_empty = __commonJS({
--    'empty.js'() {
--    }
+-    "empty.js"() {}
 -});
 -var require_empty2 = __commonJS({
--    'empty.cjs'() {
--    }
+-    "empty.cjs"() {}
 -});
 -var js = __toESM(require_empty());
 -var cjs = __toESM(require_empty2());
 -console.log(js.default, void 0, cjs.default);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_side_effect_free_file/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_side_effect_free_file/diff.md
@@ -35,19 +35,18 @@ console.log(
 +++ rolldown	
 @@ -1,13 +0,0 @@
 -var require_no_side_effects = __commonJS({
--    'foo/no-side-effects.js'() {
--        console.log('js');
+-    "foo/no-side-effects.js"() {
+-        console.log("js");
 -    }
 -});
 -var require_no_side_effects2 = __commonJS({
--    'foo/no-side-effects.cjs'() {
--        console.log('cjs');
+-    "foo/no-side-effects.cjs"() {
+-        console.log("cjs");
 -    }
 -});
 -var js = __toESM(require_no_side_effects());
 -var cjs = __toESM(require_no_side_effects2());
 -console.log(void 0, void 0, void 0);
-\ No newline at end of file
 
 ```
 ## /out/entry-default.js
@@ -87,18 +86,17 @@ console.log(
 +++ rolldown	
 @@ -1,13 +0,0 @@
 -var require_no_side_effects = __commonJS({
--    'foo/no-side-effects.js'() {
--        console.log('js');
+-    "foo/no-side-effects.js"() {
+-        console.log("js");
 -    }
 -});
 -var require_no_side_effects2 = __commonJS({
--    'foo/no-side-effects.cjs'() {
--        console.log('cjs');
+-    "foo/no-side-effects.cjs"() {
+-        console.log("cjs");
 -    }
 -});
 -var js = __toESM(require_no_side_effects());
 -var cjs = __toESM(require_no_side_effects2());
 -console.log(js.default, void 0, cjs.default);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_self_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_self_common_js/diff.md
@@ -35,7 +35,7 @@ export default require_entry();
 +++ rolldown	entry_js.mjs
 @@ -1,8 +1,8 @@
  var require_entry = __commonJS({
-     'entry.js'(exports) {
+     "entry.js"(exports) {
          var import_entry = __toESM(require_entry());
          exports.foo = 123;
 -        console.log(import_entry.foo);
@@ -43,8 +43,6 @@ export default require_entry();
      }
  });
 -module.exports = require_entry();
-\ No newline at end of file
 +export default require_entry();
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/diff.md
@@ -46,15 +46,19 @@ assert.equal(ns2.foo, 123);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,9 +1,9 @@
+@@ -1,11 +1,11 @@
 -var foo_exports = {};
--__export(foo_exports, { foo: () => foo });
+-__export(foo_exports, {
+-    foo: () => foo
+-});
 -var foo;
 +var foo_exports, foo;
  var init_foo = __esm({
-     'foo.js'() {
+     "foo.js"() {
 +        foo_exports = {};
-+        __export(foo_exports, { foo: () => foo });
++        __export(foo_exports, {
++            foo: () => foo
++        });
          foo = 123;
      }
  });

--- a/crates/rolldown/tests/esbuild/importstar/import_star_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_capture/diff.md
@@ -37,17 +37,17 @@ assert.equal(foo, 234);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,5 +1,5 @@
+@@ -1,7 +1,7 @@
  var foo_exports = {};
--__export(foo_exports, { foo: () => foo });
+ __export(foo_exports, {
+-    foo: () => foo
++    foo: () => foo$1
+ });
 -var foo = 123;
 -var foo2 = 234;
 -console.log(foo_exports, foo, foo2);
-\ No newline at end of file
-+__export(foo_exports, { foo: () => foo$1 });
 +var foo$1 = 123;
 +var foo = 234;
 +console.log(foo_exports, foo$1, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/diff.md
@@ -43,17 +43,15 @@ assert.equal(foo, 234);
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -2,7 +2,7 @@
-     'foo.js'(exports) {
+     "foo.js"(exports) {
          exports.foo = 123;
      }
  });
 -var ns = __toESM(require_foo());
 -var foo2 = 234;
 -console.log(ns, ns.foo, foo2);
-\ No newline at end of file
 +var import_foo = __toESM(require_foo());
 +var foo = 234;
 +console.log(import_foo, import_foo.foo, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/diff.md
@@ -39,17 +39,15 @@ assert.equal(foo, 234);
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -2,7 +2,7 @@
-     'foo.js'(exports) {
+     "foo.js"(exports) {
          exports.foo = 123;
      }
  });
 -var ns = __toESM(require_foo());
 -var foo2 = 234;
 -console.log(ns.foo, ns.foo, foo2);
-\ No newline at end of file
 +var import_foo = __toESM(require_foo());
 +var foo = 234;
 +console.log(import_foo.foo, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_unused/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_unused/diff.md
@@ -38,7 +38,7 @@ assert.equal(foo, 234);
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -2,7 +2,7 @@
-     'foo.js'(exports) {
+     "foo.js"(exports) {
          exports.foo = 123;
      }
  });
@@ -46,6 +46,5 @@ assert.equal(foo, 234);
 +var import_foo = __toESM(require_foo());
  var foo = 234;
  console.log(foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/diff.md
@@ -36,17 +36,17 @@ assert.equal(foo, 234);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,5 +1,5 @@
+@@ -1,7 +1,7 @@
  var foo_exports = {};
--__export(foo_exports, { foo: () => foo });
+ __export(foo_exports, {
+-    foo: () => foo
++    foo: () => foo$1
+ });
 -var foo = 123;
 -var foo2 = 234;
 -console.log(foo_exports, foo_exports.foo, foo2);
-\ No newline at end of file
-+__export(foo_exports, { foo: () => foo$1 });
 +var foo$1 = 123;
 +var foo = 234;
 +console.log(foo_exports, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_no_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_no_capture/diff.md
@@ -33,16 +33,16 @@ assert.equal(foo, 234);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,5 +1,3 @@
+@@ -1,7 +1,3 @@
 -var foo_exports = {};
--__export(foo_exports, { foo: () => foo });
+-__export(foo_exports, {
+-    foo: () => foo
+-});
 -var foo = 123;
 -var foo2 = 234;
 -console.log(foo_exports.foo, foo_exports.foo, foo2);
-\ No newline at end of file
 +var foo$1 = 123;
 +var foo = 234;
 +console.log(foo$1, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/diff.md
@@ -37,17 +37,17 @@ assert.equal(foo, 234);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,5 +1,5 @@
+@@ -1,7 +1,7 @@
  var foo_exports = {};
--__export(foo_exports, { foo: () => foo });
+ __export(foo_exports, {
+-    foo: () => foo
++    foo: () => foo$1
+ });
 -var foo = 123;
 -var foo2 = 234;
 -console.log(foo_exports, foo_exports.foo, foo2);
-\ No newline at end of file
-+__export(foo_exports, { foo: () => foo$1 });
 +var foo$1 = 123;
 +var foo = 234;
 +console.log(foo_exports, foo$1, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_no_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_no_capture/diff.md
@@ -34,16 +34,16 @@ assert.equal(foo, 234);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,5 +1,3 @@
+@@ -1,7 +1,3 @@
 -var foo_exports = {};
--__export(foo_exports, { foo: () => foo });
+-__export(foo_exports, {
+-    foo: () => foo
+-});
 -var foo = 123;
 -var foo2 = 234;
 -console.log(foo_exports.foo, foo_exports.foo, foo2);
-\ No newline at end of file
 +var foo$1 = 123;
 +var foo = 234;
 +console.log(foo$1, foo$1, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/diff.md
@@ -42,17 +42,17 @@ assert.equal(foo, 234);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,5 +1,5 @@
+@@ -1,7 +1,7 @@
 +var foo$1 = 123;
  var bar_exports = {};
--__export(bar_exports, { foo: () => foo });
+ __export(bar_exports, {
+-    foo: () => foo
++    foo: () => foo$1
+ });
 -var foo = 123;
 -var foo2 = 234;
 -console.log(bar_exports, foo, foo2);
-\ No newline at end of file
-+__export(bar_exports, { foo: () => foo$1 });
 +var foo = 234;
 +console.log(bar_exports, foo$1, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_no_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_no_capture/diff.md
@@ -33,10 +33,8 @@ assert.equal(foo, 234);
 -var foo = 123;
 -var foo2 = 234;
 -console.log(foo, foo, foo2);
-\ No newline at end of file
 +var foo$1 = 123;
 +var foo = 234;
 +console.log(foo$1, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/diff.md
@@ -63,6 +63,5 @@ assert.deepEqual(common_exports, {
 -var x = 1;
 -var z = 4;
  console.log(common_exports);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_capture/diff.md
@@ -22,10 +22,9 @@ console.log(ns, ns.foo, foo);
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -1,3 +1,3 @@
- import * as ns from './foo';
+ import * as ns from "./foo";
 -let foo = 234;
 +var foo = 234;
  console.log(ns, ns.foo, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_no_capture/diff.md
@@ -22,10 +22,9 @@ console.log(ns.foo, ns.foo, foo);
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -1,3 +1,3 @@
- import * as ns from './foo';
+ import * as ns from "./foo";
 -let foo = 234;
 +var foo = 234;
  console.log(ns.foo, ns.foo, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_mangle_no_bundle_unused/diff.md
@@ -22,10 +22,9 @@ console.log(foo);
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -1,3 +1,3 @@
- import './foo';
+ import "./foo";
 -let foo = 234;
 +var foo = 234;
  console.log(foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_capture/diff.md
@@ -22,10 +22,9 @@ console.log(ns, ns.foo, foo);
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -1,3 +1,3 @@
- import * as ns from './foo';
+ import * as ns from "./foo";
 -let foo = 234;
 +var foo = 234;
  console.log(ns, ns.foo, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_no_capture/diff.md
@@ -22,10 +22,9 @@ console.log(ns.foo, ns.foo, foo);
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -1,3 +1,3 @@
- import * as ns from './foo';
+ import * as ns from "./foo";
 -let foo = 234;
 +var foo = 234;
  console.log(ns.foo, ns.foo, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_bundle_unused/diff.md
@@ -22,11 +22,10 @@ console.log(foo);
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -1,3 +1,3 @@
--import * as ns from './foo';
+-import * as ns from "./foo";
 -let foo = 234;
-+import './foo';
++import "./foo";
 +var foo = 234;
  console.log(foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_no_capture/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_no_capture/diff.md
@@ -33,10 +33,8 @@ assert.equal(foo, 234);
 -var foo = 123;
 -var foo2 = 234;
 -console.log(foo, foo, foo2);
-\ No newline at end of file
 +var foo$1 = 123;
 +var foo = 234;
 +console.log(foo$1, foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/diff.md
@@ -45,16 +45,21 @@ assert.deepEqual(foo_exports, { bar_ns: { bar: 123 } });
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,6 +1,7 @@
+@@ -1,10 +1,11 @@
 -var foo_exports = {};
--__export(foo_exports, { bar_ns: () => bar_exports });
+-__export(foo_exports, {
+-    bar_ns: () => bar_exports
+-});
  var bar_exports = {};
- __export(bar_exports, { bar: () => bar });
+ __export(bar_exports, {
+     bar: () => bar
+ });
  var bar = 123;
 +var foo_exports = {};
-+__export(foo_exports, { bar_ns: () => bar_exports });
-+console.log(foo_exports);
++__export(foo_exports, {
++    bar_ns: () => bar_exports
++});
  console.log(foo_exports);
-\ No newline at end of file
++console.log(foo_exports);
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/issue176/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/issue176/diff.md
@@ -37,15 +37,16 @@ console.log(JSON.stringify(folders_index_exports));
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,4 +1,4 @@
+@@ -1,6 +1,6 @@
 -var folders_exports = {};
--__export(folders_exports, { foo: () => foo });
- var foo = () => 'hi there';
--console.log(JSON.stringify(folders_exports));
-\ No newline at end of file
+-__export(folders_exports, {
++var foo = () => "hi there";
 +var folders_index_exports = {};
-+__export(folders_index_exports, { foo: () => foo });
++__export(folders_index_exports, {
+     foo: () => foo
+ });
+-var foo = () => "hi there";
+-console.log(JSON.stringify(folders_exports));
 +console.log(JSON.stringify(folders_index_exports));
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/diff.md
@@ -40,15 +40,13 @@ assert.equal(import_foo.foo, undefined);
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -2,6 +2,6 @@
-     'foo.js'(exports) {
+     "foo.js"(exports) {
          exports.x = 123;
      }
  });
 -var ns = __toESM(require_foo());
 -console.log(ns, ns.foo);
-\ No newline at end of file
 +var import_foo = __toESM(require_foo());
 +console.log(import_foo, import_foo.foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/diff.md
@@ -34,13 +34,12 @@ assert.deepEqual(foo_exports, { x: 123 });
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,4 +1,4 @@
- var foo_exports = {};
- __export(foo_exports, { x: () => x });
+@@ -2,5 +2,5 @@
+ __export(foo_exports, {
+     x: () => x
+ });
  var x = 123;
 -console.log(foo_exports, void 0);
-\ No newline at end of file
 +console.log(foo_exports.foo, foo_exports);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/diff.md
@@ -39,14 +39,14 @@ assert.equal(foo_exports.foo, undefined);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,4 +1,4 @@
+@@ -1,6 +1,6 @@
 +var x = 123;
  var foo_exports = {};
- __export(foo_exports, { x: () => x });
+ __export(foo_exports, {
+     x: () => x
+ });
 -var x = 123;
 -console.log(foo_exports, void 0);
-\ No newline at end of file
 +console.log(foo_exports, foo_exports.foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6/diff.md
@@ -29,13 +29,13 @@ assert.deepEqual(foo_exports.foo, void 0);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,1 +1,4 @@
+@@ -1,1 +1,6 @@
 -console.log(void 0);
-\ No newline at end of file
 +var x = 123;
 +var foo_exports = {};
-+__export(foo_exports, { x: () => x });
++__export(foo_exports, {
++    x: () => x
++});
 +console.log(foo_exports.foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_common_js/diff.md
@@ -36,15 +36,13 @@ assert.equal(import_foo.foo, undefined);
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -2,6 +2,6 @@
-     'foo.js'(exports) {
+     "foo.js"(exports) {
          exports.x = 123;
      }
  });
 -var ns = __toESM(require_foo());
 -console.log(ns.foo);
-\ No newline at end of file
 +var import_foo = __toESM(require_foo());
 +console.log(import_foo.foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_es6/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_es6/diff.md
@@ -26,13 +26,13 @@ assert.equal(foo_exports.foo, undefined);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,1 +1,4 @@
+@@ -1,1 +1,6 @@
 -console.log(void 0);
-\ No newline at end of file
 +var foo_exports = {};
-+__export(foo_exports, { x: () => x });
++__export(foo_exports, {
++    x: () => x
++});
 +var x = 123;
 +console.log(foo_exports.foo);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6/diff.md
@@ -33,13 +33,12 @@ assert.deepEqual(bar_exports, { x: 123 });
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,4 +1,4 @@
- var bar_exports = {};
- __export(bar_exports, { x: () => x });
+@@ -2,5 +2,5 @@
+ __export(bar_exports, {
+     x: () => x
+ });
  var x = 123;
 -console.log(bar_exports.foo);
-\ No newline at end of file
 +console.log(bar_exports);
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/diff.md
@@ -27,19 +27,18 @@ Object.defineProperty(exports, 'out', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -1,4 +1,7 @@
+@@ -1,6 +1,7 @@
 -var entry_exports = {};
--__export(entry_exports, { out: () => out });
+-__export(entry_exports, {
+-    out: () => out
+-});
 -module.exports = __toCommonJS(entry_exports);
--var out = __toESM(require('foo'));
-\ No newline at end of file
-+var out = __toESM(require('foo'));
+ var out = __toESM(require("foo"));
 +Object.defineProperty(exports, 'out', {
 +    enumerable: true,
 +    get: function () {
 +        return out;
 +    }
 +});
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_common_js/diff.md
@@ -28,19 +28,18 @@ Object.defineProperty(exports, 'out', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -1,4 +1,7 @@
+@@ -1,6 +1,7 @@
 -var entry_exports = {};
--__export(entry_exports, { out: () => out });
+-__export(entry_exports, {
+-    out: () => out
+-});
 -module.exports = __toCommonJS(entry_exports);
--var out = __toESM(require('foo'));
-\ No newline at end of file
-+var out = __toESM(require('foo'));
+ var out = __toESM(require("foo"));
 +Object.defineProperty(exports, 'out', {
 +    enumerable: true,
 +    get: function () {
 +        return out;
 +    }
 +});
-\ No newline at end of file
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/diff.md
@@ -33,14 +33,11 @@ return exports;
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,6 +1,10 @@
+@@ -1,8 +1,10 @@
 -var mod = (() => {
 -    var entry_exports = {};
--    __export(entry_exports, { out: () => out });
--    var out = __toESM(__require('foo'));
--    return __toCommonJS(entry_exports);
--})();
-\ No newline at end of file
+-    __export(entry_exports, {
+-        out: () => out
 +(function (exports, foo) {
 +    const out = foo;
 +    Object.defineProperty(exports, 'out', {
@@ -48,9 +45,11 @@ return exports;
 +        get: function () {
 +            return out;
 +        }
-+    });
+     });
+-    var out = __toESM(__require("foo"));
+-    return __toCommonJS(entry_exports);
+-})();
 +    return exports;
-+}({}, foo));
-\ No newline at end of file
++})({}, foo);
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/diff.md
@@ -32,14 +32,11 @@ return exports;
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,6 +1,10 @@
+@@ -1,8 +1,10 @@
 -var mod = (() => {
 -    var entry_exports = {};
--    __export(entry_exports, { out: () => out });
--    var out = __toESM(require('foo'));
--    return __toCommonJS(entry_exports);
--})();
-\ No newline at end of file
+-    __export(entry_exports, {
+-        out: () => out
 +(function (exports, foo) {
 +    const out = foo;
 +    Object.defineProperty(exports, 'out', {
@@ -47,9 +44,11 @@ return exports;
 +        get: function () {
 +            return out;
 +        }
-+    });
+     });
+-    var out = __toESM(require("foo"));
+-    return __toCommonJS(entry_exports);
+-})();
 +    return exports;
-+}({}, foo));
-\ No newline at end of file
++})({}, foo);
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/diff.md
@@ -24,22 +24,19 @@ require("foo");
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -1,3 +1,11 @@
+@@ -1,3 +1,10 @@
 -var entry_exports = {};
 -module.exports = __toCommonJS(entry_exports);
--__reExport(entry_exports, require('foo'), module.exports);
-\ No newline at end of file
-+var foo = require('foo');
+-__reExport(entry_exports, require("foo"), module.exports);
++var foo = require("foo");
 +Object.keys(foo).forEach(function (k) {
-+    if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k))
-+        Object.defineProperty(exports, k, {
-+            enumerable: true,
-+            get: function () {
-+                return foo[k];
-+            }
-+        });
++    if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
++        enumerable: true,
++        get: function () {
++            return foo[k];
++        }
++    });
 +});
-+require('foo');
-\ No newline at end of file
++require("foo");
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_entry_point_and_inner_file/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_entry_point_and_inner_file/diff.md
@@ -22,13 +22,14 @@ __reExport(inner_exports, require("b"));
 ===================================================================
 --- esbuild	/out/entry.js
 +++ rolldown	
-@@ -1,6 +0,0 @@
+@@ -1,8 +0,0 @@
 -var entry_exports = {};
--__export(entry_exports, { inner: () => inner_exports });
+-__export(entry_exports, {
+-    inner: () => inner_exports
+-});
 -module.exports = __toCommonJS(entry_exports);
--__reExport(entry_exports, require('a'), module.exports);
+-__reExport(entry_exports, require("a"), module.exports);
 -var inner_exports = {};
--__reExport(inner_exports, require('b'));
-\ No newline at end of file
+-__reExport(inner_exports, require("b"));
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/diff.md
@@ -17,8 +17,7 @@ export * from "foo"
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -1,1 +1,2 @@
-+import 'foo';
- export * from 'foo';
-\ No newline at end of file
++import "foo";
+ export * from "foo";
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_external_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_external_common_js/diff.md
@@ -25,22 +25,19 @@ require("foo");
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -1,3 +1,11 @@
+@@ -1,3 +1,10 @@
 -var entry_exports = {};
 -module.exports = __toCommonJS(entry_exports);
--__reExport(entry_exports, require('foo'), module.exports);
-\ No newline at end of file
-+var foo = require('foo');
+-__reExport(entry_exports, require("foo"), module.exports);
++var foo = require("foo");
 +Object.keys(foo).forEach(function (k) {
-+    if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k))
-+        Object.defineProperty(exports, k, {
-+            enumerable: true,
-+            get: function () {
-+                return foo[k];
-+            }
-+        });
++    if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
++        enumerable: true,
++        get: function () {
++            return foo[k];
++        }
++    });
 +});
-+require('foo');
-\ No newline at end of file
++require("foo");
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_external_es6/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_external_es6/diff.md
@@ -18,8 +18,7 @@ export * from "foo"
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
 @@ -1,1 +1,2 @@
-+import 'foo';
- export * from 'foo';
-\ No newline at end of file
++import "foo";
+ export * from "foo";
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/diff.md
@@ -22,15 +22,12 @@ var mod = (() => {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,5 +1,2 @@
+@@ -1,5 +1,1 @@
 -var mod = (() => {
 -    var entry_exports = {};
--    __reExport(entry_exports, __require('foo'));
+-    __reExport(entry_exports, __require("foo"));
 -    return __toCommonJS(entry_exports);
 -})();
-\ No newline at end of file
-+(function () {
-+}());
-\ No newline at end of file
++(function () {})();
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/diff.md
@@ -21,15 +21,12 @@ var mod = (() => {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,5 +1,2 @@
+@@ -1,5 +1,1 @@
 -var mod = (() => {
 -    var entry_exports = {};
--    __reExport(entry_exports, require('foo'));
+-    __reExport(entry_exports, require("foo"));
 -    return __toCommonJS(entry_exports);
 -})();
-\ No newline at end of file
-+(function () {
-+}());
-\ No newline at end of file
++(function () {})();
 
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,9 +396,6 @@ importers:
       '@types/diff':
         specifier: ^5.2.2
         version: 5.2.2
-      '@types/escodegen':
-        specifier: ^0.0.10
-        version: 0.0.10
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -414,9 +411,6 @@ importers:
       diff:
         specifier: ^7.0.0
         version: 7.0.0
-      escodegen:
-        specifier: ^2.1.0
-        version: 2.1.0
       estree-toolkit:
         specifier: ^1.7.8
         version: 1.7.8
@@ -2010,7 +2004,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2977,9 +2970,6 @@ packages:
   '@types/diff@5.2.2':
     resolution: {integrity: sha512-qVqLpd49rmJA2nZzLVsmfS/aiiBpfVE95dHhPVwG0NmSBAt+riPxnj53wq2oBq5m4Q2RF1IWFEUpnZTgrQZfEQ==}
 
-  '@types/escodegen@0.0.10':
-    resolution: {integrity: sha512-IVvcNLEFbiL17qiGRGzyfx/u9K6lA5w6wcQSIgv2h4JG3ZAFIY1Be9ITTSPuARIxRpzW54s8OvcF6PdonBbDzg==}
-
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -3932,19 +3922,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
-
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
 
   estree-toolkit@1.7.8:
     resolution: {integrity: sha512-v0Q0L+0agSDFe3x9Sj7aAzrI9afvsfr5r7AM2SNk/8bKYRQ3tUf4PQEUWe99LkWysmT1PsuSpW+W1w/xZmCKeg==}
@@ -8518,8 +8499,6 @@ snapshots:
 
   '@types/diff@5.2.2': {}
 
-  '@types/escodegen@0.0.10': {}
-
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.6
@@ -9713,17 +9692,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-
   esprima@4.0.1: {}
-
-  estraverse@5.3.0: {}
 
   estree-toolkit@1.7.8:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,9 @@ importers:
       acorn:
         specifier: ^8.12.1
         version: 8.12.1
+      astring:
+        specifier: ^1.9.0
+        version: 1.9.0
       diff:
         specifier: ^7.0.0
         version: 7.0.0
@@ -3299,6 +3302,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
 
   autoprefixer@10.4.19:
     resolution: {integrity: sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==}
@@ -8862,6 +8869,8 @@ snapshots:
       printable-characters: 1.0.42
 
   assertion-error@2.0.1: {}
+
+  astring@1.9.0: {}
 
   autoprefixer@10.4.19(postcss@8.4.47):
     dependencies:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -31,6 +31,7 @@
     "@types/lodash-es": "^4.17.12",
     "@types/markdown-it": "^14.1.2",
     "acorn": "^8.12.1",
+    "astring": "^1.9.0",
     "diff": "^7.0.0",
     "escodegen": "^2.1.0",
     "estree-toolkit": "^1.7.8",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -27,13 +27,11 @@
   "devDependencies": {
     "@oxc-node/core": "^0.0.15",
     "@types/diff": "^5.2.2",
-    "@types/escodegen": "^0.0.10",
     "@types/lodash-es": "^4.17.12",
     "@types/markdown-it": "^14.1.2",
     "acorn": "^8.12.1",
     "astring": "^1.9.0",
     "diff": "^7.0.0",
-    "escodegen": "^2.1.0",
     "estree-toolkit": "^1.7.8",
     "lodash-es": "^4.17.21",
     "markdown-it": "^14.1.0",

--- a/scripts/snap-diff/rewrite.ts
+++ b/scripts/snap-diff/rewrite.ts
@@ -1,5 +1,5 @@
 import * as acorn from 'acorn'
-import * as gen from 'escodegen'
+import * as gen from 'astring'
 import { traverse, builders as b, Scope, NodePath } from 'estree-toolkit'
 
 export function rewriteRolldown(code: string) {
@@ -82,7 +82,9 @@ export function rewriteRolldown(code: string) {
       }
     },
   })
-  return gen.generate(ast, {})
+  return gen.generate(ast, {
+    indent: '    ',
+  })
 }
 
 function extractAssertArgument(
@@ -110,5 +112,7 @@ export function rewriteEsbuild(code: string) {
     ecmaVersion: 'latest',
     sourceType: 'module',
   })
-  return gen.generate(ast, {})
+  return gen.generate(ast, {
+    indent: '    ',
+  })
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. escodegen doesn't support `var Bar = class {}` syntax(meet when I try to enable all tests in `default` category), and there is no way to customize the generator.
2. use `astring` instead, since it supports customized generator and has better maintaince
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
