### PR TITLE
docs: add title bar for `code block`

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitepress'
 import {
   groupIconMdPlugin,
   groupIconVitePlugin,
+  localIconLoader,
 } from 'vitepress-plugin-group-icons'
 
 // https://vitepress.dev/reference/site-config
@@ -140,6 +141,10 @@ export default defineConfig({
         customIcon: {
           homebrew: 'logos:homebrew',
           cargo: 'vscode-icons:file-type-cargo',
+          rolldown: localIconLoader(
+            import.meta.url,
+            '../public/lightning-down.svg',
+          ),
         },
       }),
     ],

--- a/docs/guide/config/config.md
+++ b/docs/guide/config/config.md
@@ -2,7 +2,7 @@
 
 It is recommended to utilize a configuration file rather than directly invoking the CLI to access Rolldown during development. You can create a `rolldown.config.js` file within the root directory of your project.
 
-```js
+```js [rolldown.config.js]
 export default {
   input: 'src/main.ts',
   output: {
@@ -15,7 +15,7 @@ At present, our support is limited to JavaScript files. TypeScript and JSON conf
 
 It is more recommended to utilize the `defineConfig` method to support type annotation and intellisense.
 
-```js
+```js [rolldown.config.js]
 import { defineConfig } from 'rolldown'
 
 export default defineConfig({
@@ -28,7 +28,7 @@ export default defineConfig({
 
 You can also specify multiple configurations as an array, and Rolldown will bundle them in parallel.
 
-```js
+```js [rolldown.config.js]
 import { defineConfig } from 'rolldown'
 
 export default defineConfig([

--- a/docs/guide/in-depth/module-type.md
+++ b/docs/guide/in-depth/module-type.md
@@ -14,8 +14,7 @@ Rolldown uses the extension of the file to determine what the `Module Type` is, 
 
 In this case, users need to tell rolldown what the `Module Type` is for `.data` extension by configuring `moduleTypes` field in `rolldown.config.mjs`.
 
-```js
-// rolldown.config.mjs
+```js [rolldown.config.mjs]
 export default {
   moduleTypes: {
     '.data': 'json',

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,9 +2,7 @@
 
 ## Installation
 
-### package.json
-
-```json
+```json [package.json]
 {
   "name": "project",
   "type": "module",
@@ -17,9 +15,7 @@
 }
 ```
 
-### rolldown.config.js
-
-```js
+```js [rolldown.config.js]
 import { defineConfig } from 'rolldown'
 
 export default defineConfig({


### PR DESCRIPTION
## Description

With the support of [vitepress-plugin-group-icons](https://vp.yuy1n.io/features.html#%F0%9F%AA%A7-title-bar), we can add title bar for `code block` now.

- [**Preview**](https://deploy-preview-2353--rolldown-rs.netlify.app/guide/)

### After:

<img width="724" alt="image" src="https://github.com/user-attachments/assets/3e51e48d-84ae-4010-bb5b-7e46c8303fa3">


