### PR TITLE
test:  enhance resolve extension alias test

### DIFF
--- a/crates/rolldown/tests/rolldown/function/resolve/extension_alias/_config.json
+++ b/crates/rolldown/tests/rolldown/function/resolve/extension_alias/_config.json
@@ -2,7 +2,7 @@
   "config": {
     
     "resolve": {
-      "extensionAlias": [[".js", [".ts",".js"]]]
+      "extensionAlias": [[".js", [".js",".ts"]]]
     }
   }
 }

--- a/crates/rolldown/tests/rolldown/function/resolve/extension_alias/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/resolve/extension_alias/artifacts.snap
@@ -7,8 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 
-//#region foo.ts
-var foo_default = "foo";
+//#region foo.js
+var foo_default = "js";
 
 //#endregion
 //#region main.ts

--- a/crates/rolldown/tests/rolldown/function/resolve/extension_alias/foo.js
+++ b/crates/rolldown/tests/rolldown/function/resolve/extension_alias/foo.js
@@ -1,0 +1,1 @@
+export default 'js'

--- a/crates/rolldown/tests/rolldown/function/resolve/extension_alias/main.js
+++ b/crates/rolldown/tests/rolldown/function/resolve/extension_alias/main.js
@@ -1,1 +1,0 @@
-export default 'js'

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -2054,7 +2054,7 @@ expression: output
 
 # tests/rolldown/function/resolve/extension_alias
 
-- main-!~{000}~.mjs => main-Shia6zBw.mjs
+- main-!~{000}~.mjs => main-deB7BKJg.mjs
 
 # tests/rolldown/function/resolve/node_modules_as_entries
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. the two tests in both the rust and js side test the same thing, so tweak the rust side a little, use this test to ensure when 
multi-target can be chosen,  always choose the first satisfy extension configured in resolve.extensionAlias`
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
