### PR TITLE
refactor(rust): use typestate pattern on `ImportRecord`

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -256,7 +256,7 @@ impl ModuleLoader {
           } = task_result;
           all_warnings.extend(warnings);
 
-          let import_records: IndexVec<ImportRecordIdx, rolldown_common::ImportRecord> =
+          let import_records: IndexVec<ImportRecordIdx, rolldown_common::ResolvedImportRecord> =
             raw_import_records
               .into_iter()
               .zip(resolved_deps)
@@ -278,7 +278,7 @@ impl ModuleLoader {
                 {
                   dynamic_import_entry_ids.insert(id);
                 }
-                raw_rec.into_import_record(id)
+                raw_rec.into_resolved(id)
               })
               .collect::<IndexVec<ImportRecordIdx, _>>();
 

--- a/crates/rolldown_common/src/css/css_view.rs
+++ b/crates/rolldown_common/src/css/css_view.rs
@@ -1,10 +1,10 @@
 use arcstr::ArcStr;
 use oxc::index::IndexVec;
 
-use crate::{ImportRecord, ImportRecordIdx};
+use crate::{ImportRecordIdx, ResolvedImportRecord};
 
 #[derive(Debug)]
 pub struct CssView {
   pub source: ArcStr,
-  pub import_records: IndexVec<ImportRecordIdx, ImportRecord>,
+  pub import_records: IndexVec<ImportRecordIdx, ResolvedImportRecord>,
 }

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -5,8 +5,8 @@ use rolldown_rstr::Rstr;
 use rustc_hash::FxHashMap;
 
 use crate::{
-  side_effects::DeterminedSideEffects, AstScopes, EcmaAstIdx, ExportsKind, ImportRecord,
-  ImportRecordIdx, LocalExport, ModuleDefFormat, ModuleId, NamedImport, StmtInfos, SymbolRef,
+  side_effects::DeterminedSideEffects, AstScopes, EcmaAstIdx, ExportsKind, ImportRecordIdx,
+  LocalExport, ModuleDefFormat, ModuleId, NamedImport, ResolvedImportRecord, StmtInfos, SymbolRef,
 };
 
 #[derive(Debug)]
@@ -21,7 +21,7 @@ pub struct EcmaView {
   pub named_exports: FxHashMap<Rstr, LocalExport>,
   /// `stmt_infos[0]` represents the namespace binding statement
   pub stmt_infos: StmtInfos,
-  pub import_records: IndexVec<ImportRecordIdx, ImportRecord>,
+  pub import_records: IndexVec<ImportRecordIdx, ResolvedImportRecord>,
   /// The key is the `Span` of `ImportDeclaration`, `ImportExpression`, `ExportNamedDeclaration`, `ExportAllDeclaration`
   /// and `CallExpression`(only when the callee is `require`).
   pub imports: FxHashMap<Span, ImportRecordIdx>,

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -66,7 +66,9 @@ pub use crate::{
   types::exports_kind::ExportsKind,
   types::external_module_idx::ExternalModuleIdx,
   types::import_kind::ImportKind,
-  types::import_record::{ImportRecord, ImportRecordIdx, ImportRecordMeta, RawImportRecord},
+  types::import_record::{
+    ImportRecordIdx, ImportRecordMeta, RawImportRecord, ResolvedImportRecord,
+  },
   types::importer_record::ImporterRecord,
   types::instantiated_chunk::InstantiatedChunk,
   types::interop::Interop,

--- a/crates/rolldown_common/src/module/external_module.rs
+++ b/crates/rolldown_common/src/module/external_module.rs
@@ -1,5 +1,5 @@
 use crate::side_effects::DeterminedSideEffects;
-use crate::{ImportRecord, ImportRecordIdx, ModuleIdx, SymbolRef};
+use crate::{ImportRecordIdx, ModuleIdx, ResolvedImportRecord, SymbolRef};
 use arcstr::ArcStr;
 use oxc::index::IndexVec;
 
@@ -10,7 +10,7 @@ pub struct ExternalModule {
   // Used for iife format to inject symbol and deconflict.
   pub symbol_ref: SymbolRef,
   pub name: ArcStr,
-  pub import_records: IndexVec<ImportRecordIdx, ImportRecord>,
+  pub import_records: IndexVec<ImportRecordIdx, ResolvedImportRecord>,
   pub side_effects: DeterminedSideEffects,
 }
 

--- a/crates/rolldown_common/src/module/mod.rs
+++ b/crates/rolldown_common/src/module/mod.rs
@@ -4,8 +4,8 @@ pub mod normal_module;
 use oxc::index::IndexVec;
 
 use crate::{
-  types::interop, EcmaAstIdx, ExternalModule, ImportRecord, ImportRecordIdx, ModuleIdx,
-  NormalModule,
+  types::interop, EcmaAstIdx, ExternalModule, ImportRecordIdx, ModuleIdx, NormalModule,
+  ResolvedImportRecord,
 };
 
 #[derive(Debug)]
@@ -86,14 +86,14 @@ impl Module {
     }
   }
 
-  pub fn import_records(&self) -> &IndexVec<ImportRecordIdx, ImportRecord> {
+  pub fn import_records(&self) -> &IndexVec<ImportRecordIdx, ResolvedImportRecord> {
     match self {
       Module::Normal(v) => &v.import_records,
       Module::External(v) => &v.import_records,
     }
   }
 
-  pub fn set_import_records(&mut self, records: IndexVec<ImportRecordIdx, ImportRecord>) {
+  pub fn set_import_records(&mut self, records: IndexVec<ImportRecordIdx, ResolvedImportRecord>) {
     match self {
       Module::Normal(v) => v.import_records = records,
       Module::External(v) => v.import_records = records,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Typestate pattern would be great solution on solving having too many one-time-initialized option fields on structs.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
