### PR TITLE
refactor(rust): change `Symbols` to `SymbolRefDb`

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -5,8 +5,8 @@ use oxc::{
 };
 use rolldown_common::{
   side_effects::{DeterminedSideEffects, HookSideEffects},
-  AstScopes, EcmaView, ModuleDefFormat, ModuleId, ModuleIdx, ModuleType, ModuleView, SymbolRef,
-  TreeshakeOptions,
+  AstScopes, EcmaView, ImportRecordIdx, ModuleDefFormat, ModuleId, ModuleIdx, ModuleType,
+  RawImportRecord, ResolvedId, SymbolRef, TreeshakeOptions,
 };
 use rolldown_ecmascript::EcmaAst;
 use rolldown_error::{DiagnosableResult, UnhandleableResult};
@@ -17,9 +17,7 @@ use crate::{
   ast_scanner::{AstScanner, ScanResult},
   types::{
     ast_symbols::AstSymbols,
-    module_factory::{
-      CreateModuleContext, CreateModuleViewArgs, CreateModuleViewReturn, ModuleViewFactory,
-    },
+    module_factory::{CreateModuleContext, CreateModuleViewArgs},
   },
   utils::{
     make_ast_symbol_and_scope::make_ast_scopes_and_symbols,
@@ -27,183 +25,185 @@ use crate::{
   },
 };
 
-pub struct EcmaModuleViewFactory;
+fn scan_ast(
+  module_idx: ModuleIdx,
+  id: &ArcStr,
+  ast: &mut EcmaAst,
+  symbols: SymbolTable,
+  scopes: ScopeTree,
+  module_def_format: ModuleDefFormat,
+) -> UnhandleableResult<(AstScopes, ScanResult, AstSymbols, SymbolRef)> {
+  let (mut ast_symbols, ast_scopes) = make_ast_scopes_and_symbols(symbols, scopes);
+  let module_id = ModuleId::new(ArcStr::clone(id));
+  let repr_name = module_id.as_path().representative_file_name();
+  let repr_name = legitimize_identifier_name(&repr_name);
 
-impl EcmaModuleViewFactory {
-  fn scan_ast(
-    module_idx: ModuleIdx,
-    id: &ArcStr,
-    ast: &mut EcmaAst,
-    symbols: SymbolTable,
-    scopes: ScopeTree,
-    module_def_format: ModuleDefFormat,
-  ) -> UnhandleableResult<(AstScopes, ScanResult, AstSymbols, SymbolRef)> {
-    let (mut ast_symbols, ast_scopes) = make_ast_scopes_and_symbols(symbols, scopes);
-    let module_id = ModuleId::new(ArcStr::clone(id));
-    let repr_name = module_id.as_path().representative_file_name();
-    let repr_name = legitimize_identifier_name(&repr_name);
+  let scanner = AstScanner::new(
+    module_idx,
+    &ast_scopes,
+    &mut ast_symbols,
+    &repr_name,
+    module_def_format,
+    ast.source(),
+    &module_id,
+    &ast.trivias,
+  );
+  let namespace_object_ref = scanner.namespace_object_ref;
+  let scan_result = scanner.scan(ast.program())?;
 
-    let scanner = AstScanner::new(
-      module_idx,
-      &ast_scopes,
-      &mut ast_symbols,
-      &repr_name,
-      module_def_format,
-      ast.source(),
-      &module_id,
-      &ast.trivias,
-    );
-    let namespace_object_ref = scanner.namespace_object_ref;
-    let scan_result = scanner.scan(ast.program())?;
-
-    Ok((ast_scopes, scan_result, ast_symbols, namespace_object_ref))
-  }
+  Ok((ast_scopes, scan_result, ast_symbols, namespace_object_ref))
+}
+pub struct CreateEcmaViewReturn {
+  pub view: EcmaView,
+  pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
+  pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
+  pub ast: EcmaAst,
+  pub symbols: AstSymbols,
 }
 
-impl ModuleViewFactory for EcmaModuleViewFactory {
-  #[allow(clippy::too_many_lines)]
-  async fn create_module_view<'any>(
-    ctx: &mut CreateModuleContext<'any>,
-    args: CreateModuleViewArgs,
-  ) -> anyhow::Result<DiagnosableResult<CreateModuleViewReturn>> {
-    let id = ModuleId::new(ArcStr::clone(&ctx.resolved_id.id));
-    let stable_id = id.stabilize(&ctx.options.cwd);
+#[allow(clippy::too_many_lines)]
+pub async fn create_ecma_view<'any>(
+  ctx: &mut CreateModuleContext<'any>,
+  args: CreateModuleViewArgs,
+) -> UnhandleableResult<DiagnosableResult<CreateEcmaViewReturn>> {
+  let id = ModuleId::new(ArcStr::clone(&ctx.resolved_id.id));
+  let stable_id = id.stabilize(&ctx.options.cwd);
 
-    let parse_result = parse_to_ecma_ast(
-      ctx.plugin_driver,
-      ctx.resolved_id.id.as_path(),
-      &stable_id,
-      ctx.options,
-      &ctx.module_type,
-      args.source.clone(),
-      ctx.replace_global_define_config.as_ref(),
-    )?;
+  let parse_result = parse_to_ecma_ast(
+    ctx.plugin_driver,
+    ctx.resolved_id.id.as_path(),
+    &stable_id,
+    ctx.options,
+    &ctx.module_type,
+    args.source.clone(),
+    ctx.replace_global_define_config.as_ref(),
+  )?;
 
-    let ParseToEcmaAstResult { mut ast, symbol_table, scope_tree, source } = match parse_result {
-      Ok(parse_result) => parse_result,
-      Err(errs) => {
-        return Ok(Err(errs));
-      }
-    };
-
-    let (scope, scan_result, ast_symbol, namespace_object_ref) = Self::scan_ast(
-      ctx.module_index,
-      &ctx.resolved_id.id,
-      &mut ast,
-      symbol_table,
-      scope_tree,
-      ctx.resolved_id.module_def_format,
-    )?;
-
-    let resolved_deps = match ctx.resolve_dependencies(&scan_result.import_records, source).await? {
-      Ok(deps) => deps,
-      Err(errs) => {
-        return Ok(Err(errs));
-      }
-    };
-
-    let ScanResult {
-      named_imports,
-      named_exports,
-      stmt_infos,
-      import_records,
-      star_exports,
-      default_export_ref,
-      imports,
-      exports_kind,
-      warnings: scan_warnings,
-      has_eval,
-      errors,
-      ast_usage,
-    } = scan_result;
-    if !errors.is_empty() {
-      return Ok(Err(errors));
+  let ParseToEcmaAstResult { mut ast, symbol_table, scope_tree, source } = match parse_result {
+    Ok(parse_result) => parse_result,
+    Err(errs) => {
+      return Ok(Err(errs));
     }
-    ctx.warnings.extend(scan_warnings);
+  };
 
-    let mut imported_ids = vec![];
-    let mut dynamically_imported_ids = vec![];
+  let (scope, scan_result, ast_symbol, namespace_object_ref) = scan_ast(
+    ctx.module_index,
+    &ctx.resolved_id.id,
+    &mut ast,
+    symbol_table,
+    scope_tree,
+    ctx.resolved_id.module_def_format,
+  )?;
 
-    for (record, info) in import_records.iter().zip(&resolved_deps) {
-      if record.kind.is_static() {
-        imported_ids.push(ArcStr::clone(&info.id).into());
-      } else {
-        dynamically_imported_ids.push(ArcStr::clone(&info.id).into());
-      }
+  let resolved_deps = match ctx.resolve_dependencies(&scan_result.import_records, source).await? {
+    Ok(deps) => deps,
+    Err(errs) => {
+      return Ok(Err(errs));
     }
+  };
 
-    // The side effects priority is:
-    // 1. Hook side effects
-    // 2. Package.json side effects
-    // 3. Analyzed side effects
-    // We should skip the `check_side_effects_for` if the hook side effects is not `None`.
-    let lazy_check_side_effects = || {
-      if matches!(ctx.module_type, ModuleType::Css) {
-        // CSS modules are considered to have side effects by default
-        return DeterminedSideEffects::Analyzed(true);
-      }
-      ctx
-        .resolved_id
-        .package_json
-        .as_ref()
-        .and_then(|p| p.check_side_effects_for(&stable_id).map(DeterminedSideEffects::UserDefined))
-        .unwrap_or_else(|| {
-          let analyzed_side_effects = stmt_infos.iter().any(|stmt_info| stmt_info.side_effect);
-          DeterminedSideEffects::Analyzed(analyzed_side_effects)
-        })
-    };
-    let side_effects = match args.hook_side_effects {
-      Some(side_effects) => match side_effects {
-        HookSideEffects::True => lazy_check_side_effects(),
-        HookSideEffects::False => DeterminedSideEffects::UserDefined(false),
-        HookSideEffects::NoTreeshake => DeterminedSideEffects::NoTreeshake,
-      },
-      // If user don't specify the side effects, we use fallback value from `option.treeshake.moduleSideEffects`;
-      None => match ctx.options.treeshake {
-        // Actually this convert is not necessary, just for passing type checking
-        TreeshakeOptions::Boolean(false) => DeterminedSideEffects::NoTreeshake,
-        TreeshakeOptions::Boolean(true) => unreachable!(),
-        TreeshakeOptions::Option(ref opt) => {
-          if opt.module_side_effects.resolve(&stable_id) {
-            lazy_check_side_effects()
-          } else {
-            DeterminedSideEffects::UserDefined(false)
-          }
-        }
-      },
-    };
-
-    // TODO: Should we check if there are `check_side_effects_for` returns false but there are side effects in the module?
-    let module = EcmaView {
-      source: ast.source().clone(),
-      ecma_ast_idx: None,
-      named_imports,
-      named_exports,
-      stmt_infos,
-      imports,
-      star_exports,
-      default_export_ref,
-      scope,
-      exports_kind,
-      namespace_object_ref,
-      def_format: ctx.resolved_id.module_def_format,
-      sourcemap_chain: args.sourcemap_chain,
-      import_records: IndexVec::default(),
-      is_included: false,
-      importers: vec![],
-      dynamic_importers: vec![],
-      imported_ids,
-      dynamically_imported_ids,
-      side_effects,
-      has_eval,
-      ast_usage,
-    };
-
-    Ok(Ok(CreateModuleViewReturn {
-      view: ModuleView::Ecma(module),
-      resolved_deps,
-      raw_import_records: import_records,
-      ecma_related: Some((ast, ast_symbol)),
-    }))
+  let ScanResult {
+    named_imports,
+    named_exports,
+    stmt_infos,
+    import_records,
+    star_exports,
+    default_export_ref,
+    imports,
+    exports_kind,
+    warnings: scan_warnings,
+    has_eval,
+    errors,
+    ast_usage,
+  } = scan_result;
+  if !errors.is_empty() {
+    return Ok(Err(errors));
   }
+  ctx.warnings.extend(scan_warnings);
+
+  let mut imported_ids = vec![];
+  let mut dynamically_imported_ids = vec![];
+
+  for (record, info) in import_records.iter().zip(&resolved_deps) {
+    if record.kind.is_static() {
+      imported_ids.push(ArcStr::clone(&info.id).into());
+    } else {
+      dynamically_imported_ids.push(ArcStr::clone(&info.id).into());
+    }
+  }
+
+  // The side effects priority is:
+  // 1. Hook side effects
+  // 2. Package.json side effects
+  // 3. Analyzed side effects
+  // We should skip the `check_side_effects_for` if the hook side effects is not `None`.
+  let lazy_check_side_effects = || {
+    if matches!(ctx.module_type, ModuleType::Css) {
+      // CSS modules are considered to have side effects by default
+      return DeterminedSideEffects::Analyzed(true);
+    }
+    ctx
+      .resolved_id
+      .package_json
+      .as_ref()
+      .and_then(|p| p.check_side_effects_for(&stable_id).map(DeterminedSideEffects::UserDefined))
+      .unwrap_or_else(|| {
+        let analyzed_side_effects = stmt_infos.iter().any(|stmt_info| stmt_info.side_effect);
+        DeterminedSideEffects::Analyzed(analyzed_side_effects)
+      })
+  };
+  let side_effects = match args.hook_side_effects {
+    Some(side_effects) => match side_effects {
+      HookSideEffects::True => lazy_check_side_effects(),
+      HookSideEffects::False => DeterminedSideEffects::UserDefined(false),
+      HookSideEffects::NoTreeshake => DeterminedSideEffects::NoTreeshake,
+    },
+    // If user don't specify the side effects, we use fallback value from `option.treeshake.moduleSideEffects`;
+    None => match ctx.options.treeshake {
+      // Actually this convert is not necessary, just for passing type checking
+      TreeshakeOptions::Boolean(false) => DeterminedSideEffects::NoTreeshake,
+      TreeshakeOptions::Boolean(true) => unreachable!(),
+      TreeshakeOptions::Option(ref opt) => {
+        if opt.module_side_effects.resolve(&stable_id) {
+          lazy_check_side_effects()
+        } else {
+          DeterminedSideEffects::UserDefined(false)
+        }
+      }
+    },
+  };
+
+  // TODO: Should we check if there are `check_side_effects_for` returns false but there are side effects in the module?
+  let view = EcmaView {
+    source: ast.source().clone(),
+    ecma_ast_idx: None,
+    named_imports,
+    named_exports,
+    stmt_infos,
+    imports,
+    star_exports,
+    default_export_ref,
+    scope,
+    exports_kind,
+    namespace_object_ref,
+    def_format: ctx.resolved_id.module_def_format,
+    sourcemap_chain: args.sourcemap_chain,
+    import_records: IndexVec::default(),
+    is_included: false,
+    importers: vec![],
+    dynamic_importers: vec![],
+    imported_ids,
+    dynamically_imported_ids,
+    side_effects,
+    has_eval,
+    ast_usage,
+  };
+
+  Ok(Ok(CreateEcmaViewReturn {
+    view,
+    resolved_deps,
+    raw_import_records: import_records,
+    ast,
+    symbols: ast_symbol,
+  }))
 }

--- a/crates/rolldown/src/module_finalizers/isolating/mod.rs
+++ b/crates/rolldown/src/module_finalizers/isolating/mod.rs
@@ -7,14 +7,14 @@ use rolldown_common::{AstScopes, IndexModules, NormalModule};
 use rolldown_ecmascript::AstSnippet;
 use rustc_hash::FxHashSet;
 
-use crate::types::symbols::Symbols;
+use crate::types::symbol_ref_db::SymbolRefDb;
 
 mod impl_visit_mut;
 
 pub struct IsolatingModuleFinalizerContext<'me> {
   pub module: &'me NormalModule,
   pub modules: &'me IndexModules,
-  pub symbols: &'me Symbols,
+  pub symbols: &'me SymbolRefDb,
 }
 
 pub struct IsolatingModuleFinalizer<'me, 'ast> {

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/finalizer_context.rs
@@ -8,7 +8,7 @@ use crate::{
   runtime::RuntimeModuleBrief,
   types::{
     linking_metadata::{LinkingMetadata, LinkingMetadataVec},
-    symbols::Symbols,
+    symbol_ref_db::SymbolRefDb,
   },
   SharedOptions,
 };
@@ -19,7 +19,7 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub modules: &'me IndexModules,
   pub linking_info: &'me LinkingMetadata,
   pub linking_infos: &'me LinkingMetadataVec,
-  pub symbols: &'me Symbols,
+  pub symbols: &'me SymbolRefDb,
   pub canonical_names: &'me FxHashMap<SymbolRef, Rstr>,
   pub runtime: &'me RuntimeModuleBrief,
   pub chunk_graph: &'me ChunkGraph,

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -17,7 +17,8 @@ use rustc_hash::FxHashMap;
 
 use crate::{
   types::{
-    linking_metadata::LinkingMetadataVec, namespace_alias::NamespaceAlias, symbols::Symbols,
+    linking_metadata::LinkingMetadataVec, namespace_alias::NamespaceAlias,
+    symbol_ref_db::SymbolRefDb,
   },
   SharedOptions,
 };
@@ -349,7 +350,7 @@ impl<'link> LinkStage<'link> {
 struct BindImportsAndExportsContext<'a> {
   pub normal_modules: &'a IndexModules,
   pub metas: &'a mut LinkingMetadataVec,
-  pub symbols: &'a mut Symbols,
+  pub symbols: &'a mut SymbolRefDb,
   pub options: &'a SharedOptions,
   pub errors: Vec<BuildDiagnostic>,
   pub warnings: Vec<BuildDiagnostic>,
@@ -433,10 +434,10 @@ impl<'a> BindImportsAndExportsContext<'a> {
           ));
         }
         MatchImportKind::Normal { symbol } => {
-          self.symbols.union(*imported_as_ref, symbol);
+          self.symbols.link(*imported_as_ref, symbol);
         }
         MatchImportKind::Namespace { namespace_ref } => {
-          self.symbols.union(*imported_as_ref, namespace_ref);
+          self.symbols.link(*imported_as_ref, namespace_ref);
         }
         MatchImportKind::NormalAndNamespace { namespace_ref, alias } => {
           self.symbols.get_mut(*imported_as_ref).namespace_alias =

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -17,7 +17,7 @@ use crate::{
   type_alias::IndexEcmaAst,
   types::{
     linking_metadata::{LinkingMetadata, LinkingMetadataVec},
-    symbols::Symbols,
+    symbol_ref_db::SymbolRefDb,
   },
   SharedOptions,
 };
@@ -38,7 +38,7 @@ pub struct LinkStageOutput {
   pub ast_table: IndexEcmaAst,
   // pub sorted_modules: Vec<NormalModuleId>,
   pub metas: LinkingMetadataVec,
-  pub symbols: Symbols,
+  pub symbols: SymbolRefDb,
   pub runtime: RuntimeModuleBrief,
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
@@ -49,7 +49,7 @@ pub struct LinkStageOutput {
 pub struct LinkStage<'a> {
   pub module_table: ModuleTable,
   pub entries: Vec<EntryPoint>,
-  pub symbols: Symbols,
+  pub symbols: SymbolRefDb,
   pub runtime: RuntimeModuleBrief,
   pub sorted_modules: Vec<ModuleIdx>,
   pub metas: LinkingMetadataVec,

--- a/crates/rolldown/src/stages/link_stage/tree_shaking.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking.rs
@@ -1,5 +1,5 @@
 use crate::types::linking_metadata::LinkingMetadataVec;
-use crate::types::symbols::Symbols;
+use crate::types::symbol_ref_db::SymbolRefDb;
 use oxc::index::IndexVec;
 use rolldown_common::side_effects::DeterminedSideEffects;
 use rolldown_common::{
@@ -13,7 +13,7 @@ use super::LinkStage;
 
 struct Context<'a> {
   modules: &'a IndexModules,
-  symbols: &'a Symbols,
+  symbols: &'a SymbolRefDb,
   is_included_vec: &'a mut IndexVec<ModuleIdx, IndexVec<StmtInfoIdx, bool>>,
   is_module_included_vec: &'a mut IndexVec<ModuleIdx, bool>,
   tree_shaking: bool,

--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -8,7 +8,7 @@ use crate::{
   runtime::RuntimeModuleBrief,
   types::{
     linking_metadata::{LinkingMetadata, LinkingMetadataVec},
-    symbols::Symbols,
+    symbol_ref_db::SymbolRefDb,
   },
 };
 
@@ -138,7 +138,7 @@ impl LinkStage<'_> {
 pub fn create_wrapper(
   module: &mut NormalModule,
   linking_info: &mut LinkingMetadata,
-  symbols: &mut Symbols,
+  symbols: &mut SymbolRefDb,
   runtime: &RuntimeModuleBrief,
   options: &NormalizedBundlerOptions,
 ) {

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -13,7 +13,7 @@ use crate::{
   module_loader::{module_loader::ModuleLoaderOutput, ModuleLoader},
   runtime::RuntimeModuleBrief,
   type_alias::IndexEcmaAst,
-  types::symbols::Symbols,
+  types::symbol_ref_db::SymbolRefDb,
   utils::resolve_id::resolve_id,
   SharedOptions, SharedResolver,
 };
@@ -30,7 +30,7 @@ pub struct ScanStageOutput {
   pub module_table: ModuleTable,
   pub index_ecma_ast: IndexEcmaAst,
   pub entry_points: Vec<EntryPoint>,
-  pub symbols: Symbols,
+  pub symbols: SymbolRefDb,
   pub runtime: RuntimeModuleBrief,
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,

--- a/crates/rolldown/src/types/mod.rs
+++ b/crates/rolldown/src/types/mod.rs
@@ -10,4 +10,4 @@ pub mod linking_metadata;
 pub mod module_factory;
 pub mod namespace_alias;
 pub mod oxc_parse_type;
-pub mod symbols;
+pub mod symbol_ref_db;

--- a/crates/rolldown/src/types/module_factory.rs
+++ b/crates/rolldown/src/types/module_factory.rs
@@ -5,9 +5,8 @@ use oxc::minifier::ReplaceGlobalDefinesConfig;
 use oxc::span::Span;
 use rolldown_common::{
   side_effects::HookSideEffects, ImportKind, ImportRecordIdx, ModuleDefFormat, ModuleIdx,
-  ModuleType, ModuleView, RawImportRecord, ResolvedId, StrOrBytes,
+  ModuleType, RawImportRecord, ResolvedId, StrOrBytes,
 };
-use rolldown_ecmascript::EcmaAst;
 use rolldown_error::{BuildDiagnostic, DiagnosableResult};
 use rolldown_plugin::{SharedPluginDriver, __inner::resolve_id_check_external};
 use rolldown_resolver::ResolveError;
@@ -15,8 +14,6 @@ use rolldown_sourcemap::SourceMap;
 use std::sync::Arc;
 
 use crate::{runtime::RUNTIME_MODULE_ID, SharedOptions, SharedResolver};
-
-use super::ast_symbols::AstSymbols;
 
 pub struct CreateModuleContext<'a> {
   pub module_index: ModuleIdx,
@@ -141,18 +138,4 @@ pub struct CreateModuleViewArgs {
   pub source: StrOrBytes,
   pub sourcemap_chain: Vec<SourceMap>,
   pub hook_side_effects: Option<HookSideEffects>,
-}
-
-pub struct CreateModuleViewReturn {
-  pub view: ModuleView,
-  pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
-  pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
-  pub ecma_related: Option<(EcmaAst, AstSymbols)>,
-}
-
-pub trait ModuleViewFactory {
-  async fn create_module_view(
-    ctx: &mut CreateModuleContext,
-    args: CreateModuleViewArgs,
-  ) -> anyhow::Result<DiagnosableResult<CreateModuleViewReturn>>;
 }

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 
-use crate::types::symbols::Symbols;
+use crate::types::symbol_ref_db::SymbolRefDb;
 
 #[derive(Debug)]
 pub struct Renamer<'name> {
@@ -30,11 +30,11 @@ pub struct Renamer<'name> {
   ///
   used_canonical_names: FxHashMap<Rstr, u32>,
   canonical_names: FxHashMap<SymbolRef, Rstr>,
-  symbols: &'name Symbols,
+  symbols: &'name SymbolRefDb,
 }
 
 impl<'name> Renamer<'name> {
-  pub fn new(symbols: &'name Symbols, _modules_len: usize, format: &OutputFormat) -> Self {
+  pub fn new(symbols: &'name SymbolRefDb, _modules_len: usize, format: &OutputFormat) -> Self {
     // Port from https://github.com/rollup/rollup/blob/master/src/Chunk.ts#L1377-L1394.
     let manual_reserved = match format {
       OutputFormat::Esm | OutputFormat::App => vec![],

--- a/crates/rolldown_common/src/types/symbol_ref.rs
+++ b/crates/rolldown_common/src/types/symbol_ref.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{IndexModules, Module, ModuleIdx, Specifier};
 
-/// Crossing module ref between symbols
+/// `SymbolRef` is used to represent a symbol in a module when there are multiple modules.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SymbolRef {
   pub owner: ModuleIdx,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`SymbolTable` is already used by oxc. So we will use `XxxDb` style for indicate-based data design.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
