### PR TITLE
feat(rust): use `SymbolRefDbForModule` while scanning oxc AST

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -28,6 +28,8 @@ use rolldown_utils::path_ext::PathExt;
 use rustc_hash::FxHashMap;
 use sugar_path::SugarPath;
 
+use crate::types::symbol_ref_db::SymbolRefDbForModule;
+
 use super::types::ast_symbols::AstSymbols;
 
 #[derive(Debug)]
@@ -44,6 +46,7 @@ pub struct ScanResult {
   pub errors: Vec<BuildDiagnostic>,
   pub has_eval: bool,
   pub ast_usage: EcmaModuleAstUsage,
+  pub symbol_ref_db: SymbolRefDbForModule,
 }
 
 pub struct AstScanner<'me> {
@@ -110,6 +113,7 @@ impl<'me> AstScanner<'me> {
       has_eval: false,
       errors: Vec::new(),
       ast_usage: EcmaModuleAstUsage::empty(),
+      symbol_ref_db: SymbolRefDbForModule::default(),
     };
 
     Self {

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -18,6 +18,7 @@ use crate::{
   types::{
     ast_symbols::AstSymbols,
     module_factory::{CreateModuleContext, CreateModuleViewArgs},
+    symbol_ref_db::SymbolRefDbForModule,
   },
   utils::{
     make_ast_symbol_and_scope::make_ast_scopes_and_symbols,
@@ -58,7 +59,7 @@ pub struct CreateEcmaViewReturn {
   pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
   pub ast: EcmaAst,
-  pub symbols: AstSymbols,
+  pub symbols: SymbolRefDbForModule,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -115,6 +116,7 @@ pub async fn create_ecma_view<'any>(
     has_eval,
     errors,
     ast_usage,
+    mut symbol_ref_db,
   } = scan_result;
   if !errors.is_empty() {
     return Ok(Err(errors));
@@ -199,11 +201,13 @@ pub async fn create_ecma_view<'any>(
     ast_usage,
   };
 
+  symbol_ref_db.fill_classic_data(ast_symbol);
+
   Ok(Ok(CreateEcmaViewReturn {
     view,
     resolved_deps,
     raw_import_records: import_records,
     ast,
-    symbols: ast_symbol,
+    symbols: symbol_ref_db,
   }))
 }

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -12,7 +12,7 @@ use super::Msg;
 use crate::{
   ast_scanner::{AstScanner, ScanResult},
   runtime::{RuntimeModuleBrief, RUNTIME_MODULE_ID},
-  types::ast_symbols::AstSymbols,
+  types::{ast_symbols::AstSymbols, symbol_ref_db::SymbolRefDbForModule},
   utils::tweak_ast_for_scanning::tweak_ast_for_scanning,
 };
 pub struct RuntimeModuleTask {
@@ -23,7 +23,7 @@ pub struct RuntimeModuleTask {
 
 pub struct RuntimeModuleTaskResult {
   pub runtime: RuntimeModuleBrief,
-  pub ast_symbols: AstSymbols,
+  pub local_symbol_ref_db: SymbolRefDbForModule,
   pub ast: EcmaAst,
   // pub warnings: Vec<BuildError>,
   pub module: NormalModule,
@@ -74,7 +74,10 @@ impl RuntimeModuleTask {
       has_eval,
       errors: _,
       ast_usage,
+      mut symbol_ref_db,
     } = scan_result;
+
+    symbol_ref_db.fill_classic_data(ast_symbols);
 
     let module = NormalModule {
       idx: self.module_id,
@@ -118,7 +121,7 @@ impl RuntimeModuleTask {
 
     if let Err(_err) = self.tx.try_send(Msg::RuntimeNormalModuleDone(RuntimeModuleTaskResult {
       // warnings: self.warnings,
-      ast_symbols,
+      local_symbol_ref_db: symbol_ref_db,
       module,
       runtime,
       ast,

--- a/crates/rolldown/src/module_loader/task_result.rs
+++ b/crates/rolldown/src/module_loader/task_result.rs
@@ -3,7 +3,7 @@ use rolldown_common::{ImportRecordIdx, Module, ModuleIdx, RawImportRecord, Resol
 use rolldown_ecmascript::EcmaAst;
 use rolldown_error::BuildDiagnostic;
 
-use crate::types::ast_symbols::AstSymbols;
+use crate::types::symbol_ref_db::SymbolRefDbForModule;
 
 pub struct NormalModuleTaskResult {
   pub module_idx: ModuleIdx,
@@ -11,5 +11,5 @@ pub struct NormalModuleTaskResult {
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
   pub warnings: Vec<BuildDiagnostic>,
   pub module: Module,
-  pub ecma_related: Option<(EcmaAst, AstSymbols)>,
+  pub ecma_related: Option<(EcmaAst, SymbolRefDbForModule)>,
 }

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -90,7 +90,7 @@ impl<'a> LinkStage<'a> {
         .collect::<IndexVec<ModuleIdx, _>>(),
       module_table: scan_stage_output.module_table,
       entries: scan_stage_output.entry_points,
-      symbols: scan_stage_output.symbols,
+      symbols: scan_stage_output.symbol_ref_db,
       runtime: scan_stage_output.runtime,
       warnings: scan_stage_output.warnings,
       errors: scan_stage_output.errors,

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -30,7 +30,7 @@ pub struct ScanStageOutput {
   pub module_table: ModuleTable,
   pub index_ecma_ast: IndexEcmaAst,
   pub entry_points: Vec<EntryPoint>,
-  pub symbols: SymbolRefDb,
+  pub symbol_ref_db: SymbolRefDb,
   pub runtime: RuntimeModuleBrief,
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
@@ -69,7 +69,7 @@ impl ScanStage {
     let ModuleLoaderOutput {
       module_table,
       entry_points,
-      symbols,
+      symbol_ref_db,
       runtime,
       warnings,
       index_ecma_ast,
@@ -83,7 +83,7 @@ impl ScanStage {
     Ok(Ok(ScanStageOutput {
       module_table,
       entry_points,
-      symbols,
+      symbol_ref_db,
       runtime,
       warnings,
       index_ecma_ast,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We gonna remove `AstSymbols` and use oxc's `SymbolTable`/`Semantic` directly.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
