### PR TITLE
feat(output/cjs): on demand shorthand export pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,6 +2316,7 @@ dependencies = [
  "anyhow",
  "append-only-vec",
  "arcstr",
+ "bitflags 2.6.0",
  "daachorse",
  "dunce",
  "futures",

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 anyhow                   = { workspace = true }
 append-only-vec          = { workspace = true }
 arcstr                   = { workspace = true }
+bitflags                 = { workspace = true }
 daachorse                = { workspace = true }
 dunce                    = { workspace = true }
 futures                  = { workspace = true }

--- a/crates/rolldown/src/types/symbol_ref_db.rs
+++ b/crates/rolldown/src/types/symbol_ref_db.rs
@@ -20,15 +20,19 @@ pub struct SymbolRefDataClassic {
   pub chunk_id: Option<ChunkIdx>,
 }
 
-#[derive(Debug)]
-pub struct SymbolRefData {
-  /// `None` means we don't know if this symbol is reassigned or not.
-  pub is_reassigned: Option<bool>,
+bitflags::bitflags! {
+  #[derive(Debug, Default)]
+  pub struct SymbolRefFlags: u8 {
+    const IS_NOT_REASSIGNED = 1;
+    /// If this symbol is declared by `const`. Eg. `const a = 1;`
+    const IS_CONST = 1 << 1;
+  }
 }
 
 #[derive(Debug, Default)]
 pub struct SymbolRefDbForModule {
-  pub data: FxHashMap<SymbolId, SymbolRefData>,
+  // Only some symbols would be cared about, so we use a hashmap to store the flags.
+  pub flags: FxHashMap<SymbolId, SymbolRefFlags>,
   pub classic_data: IndexVec<SymbolId, SymbolRefDataClassic>,
 }
 
@@ -127,5 +131,9 @@ impl SymbolRefDb {
       canonical = founded;
     }
     canonical
+  }
+
+  pub fn get_flags(&self, refer: SymbolRef) -> Option<&SymbolRefFlags> {
+    self.inner[refer.owner].flags.get(&refer.symbol)
   }
 }

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
@@ -16,10 +16,5 @@ const foo = 123;
 console.log(entry_exports);
 
 //#endregion
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/diff.md
@@ -22,12 +22,7 @@ const foo = 123;
 console.log(entry_exports);
 
 //#endregion
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 
 ```
 ### diff
@@ -35,7 +30,7 @@ Object.defineProperty(exports, 'foo', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -1,7 +1,12 @@
+@@ -1,7 +1,7 @@
  var entry_exports = {};
  __export(entry_exports, {
      foo: () => foo
@@ -43,11 +38,6 @@ Object.defineProperty(exports, 'foo', {
 -module.exports = __toCommonJS(entry_exports);
  var foo = 123;
  console.log(entry_exports);
-+Object.defineProperty(exports, 'foo', {
-+    enumerable: true,
-+    get: function () {
-+        return foo;
-+    }
-+});
++exports.foo = foo;
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
@@ -20,10 +20,5 @@ var init_entry = __esm({ "entry.js"() {
 
 //#endregion
 init_entry();
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/diff.md
@@ -32,12 +32,7 @@ var init_entry = __esm({ "entry.js"() {
 
 //#endregion
 init_entry();
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 
 ```
 ### diff
@@ -45,7 +40,7 @@ Object.defineProperty(exports, 'foo', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -1,13 +1,18 @@
+@@ -1,13 +1,13 @@
 -var entry_exports = {};
 -__export(entry_exports, {
 -    foo: () => foo
@@ -64,11 +59,6 @@ Object.defineProperty(exports, 'foo', {
      }
  });
  init_entry();
-+Object.defineProperty(exports, 'foo', {
-+    enumerable: true,
-+    get: function () {
-+        return foo;
-+    }
-+});
++exports.foo = foo;
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
@@ -18,12 +18,7 @@ __export(entry_exports, {
 const foo = 123;
 
 //#endregion
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 Object.defineProperty(exports, 'ns', {
   enumerable: true,
   get: function () {

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/diff.md
@@ -24,12 +24,7 @@ __export(entry_exports, {
 const foo = 123;
 
 //#endregion
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 Object.defineProperty(exports, 'ns', {
   enumerable: true,
   get: function () {
@@ -43,19 +38,14 @@ Object.defineProperty(exports, 'ns', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -2,6 +2,17 @@
+@@ -2,6 +2,12 @@
  __export(entry_exports, {
      foo: () => foo,
      ns: () => entry_exports
  });
 -module.exports = __toCommonJS(entry_exports);
  var foo = 123;
-+Object.defineProperty(exports, 'foo', {
-+    enumerable: true,
-+    get: function () {
-+        return foo;
-+    }
-+});
++exports.foo = foo;
 +Object.defineProperty(exports, 'ns', {
 +    enumerable: true,
 +    get: function () {

--- a/crates/rolldown/tests/esbuild/importstar/export_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_common_js/artifacts.snap
@@ -12,10 +12,5 @@ source: crates/rolldown_testing/src/integration_test.rs
 const foo = 123;
 
 //#endregion
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_common_js/diff.md
@@ -17,12 +17,7 @@ var foo = 123;
 const foo = 123;
 
 //#endregion
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 
 ```
 ### diff
@@ -30,18 +25,13 @@ Object.defineProperty(exports, 'foo', {
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.cjs
-@@ -1,6 +1,7 @@
+@@ -1,6 +1,2 @@
 -var entry_exports = {};
 -__export(entry_exports, {
 -    foo: () => foo
 -});
 -module.exports = __toCommonJS(entry_exports);
  var foo = 123;
-+Object.defineProperty(exports, 'foo', {
-+    enumerable: true,
-+    get: function () {
-+        return foo;
-+    }
-+});
++exports.foo = foo;
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife/artifacts.snap
@@ -22,12 +22,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 const foo = 123;
 
 //#endregion
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 return exports;
 })({});
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife/diff.md
@@ -16,12 +16,7 @@
 const foo = 123;
 
 //#endregion
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 return exports;
 })({});
 
@@ -31,18 +26,13 @@ return exports;
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,3 +1,10 @@
+@@ -1,3 +1,5 @@
 -(() => {
 -    var foo = 123;
 -})();
 +(function (exports) {
 +    const foo = 123;
-+    Object.defineProperty(exports, 'foo', {
-+        enumerable: true,
-+        get: function () {
-+            return foo;
-+        }
-+    });
++    exports.foo = foo;
 +    return exports;
 +})({});
 

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/artifacts.snap
@@ -22,12 +22,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 const foo = 123;
 
 //#endregion
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 return exports;
 })({});
 ```

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/diff.md
@@ -21,12 +21,7 @@ var someName = (() => {
 const foo = 123;
 
 //#endregion
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 return exports;
 })({});
 
@@ -36,22 +31,18 @@ return exports;
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry_js.mjs
-@@ -1,8 +1,10 @@
+@@ -1,8 +1,5 @@
 -var someName = (() => {
 -    var entry_exports = {};
 -    __export(entry_exports, {
 -        foo: () => foo
-+(function (exports) {
-+    const foo = 123;
-+    Object.defineProperty(exports, 'foo', {
-+        enumerable: true,
-+        get: function () {
-+            return foo;
-+        }
-     });
+-    });
 -    var foo = 123;
 -    return __toCommonJS(entry_exports);
 -})();
++(function (exports) {
++    const foo = 123;
++    exports.foo = foo;
 +    return exports;
 +})({});
 

--- a/crates/rolldown/tests/rolldown/function/es_module/always/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/always/artifacts.snap
@@ -16,18 +16,8 @@ const validator = "if_default_prop_false";
 const value = true;
 
 //#endregion
-Object.defineProperty(exports, 'validator', {
-  enumerable: true,
-  get: function () {
-    return validator;
-  }
-});
-Object.defineProperty(exports, 'value', {
-  enumerable: true,
-  get: function () {
-    return value;
-  }
-});
+exports.validator = validator
+exports.value = value
 return exports;
 })({});
 ```

--- a/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_cjs_false/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_cjs_false/artifacts.snap
@@ -13,16 +13,6 @@ const validator = "if_default_prop_false";
 const value = true;
 
 //#endregion
-Object.defineProperty(exports, 'validator', {
-  enumerable: true,
-  get: function () {
-    return validator;
-  }
-});
-Object.defineProperty(exports, 'value', {
-  enumerable: true,
-  get: function () {
-    return value;
-  }
-});
+exports.validator = validator
+exports.value = value
 ```

--- a/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_cjs_true/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_cjs_true/artifacts.snap
@@ -20,10 +20,5 @@ Object.defineProperty(exports, 'default', {
     return main_default;
   }
 });
-Object.defineProperty(exports, 'value', {
-  enumerable: true,
-  get: function () {
-    return value;
-  }
-});
+exports.value = value
 ```

--- a/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_iife_false/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_iife_false/artifacts.snap
@@ -15,18 +15,8 @@ const validator = "if_default_prop_false";
 const value = true;
 
 //#endregion
-Object.defineProperty(exports, 'validator', {
-  enumerable: true,
-  get: function () {
-    return validator;
-  }
-});
-Object.defineProperty(exports, 'value', {
-  enumerable: true,
-  get: function () {
-    return value;
-  }
-});
+exports.validator = validator
+exports.value = value
 return exports;
 })({});
 ```

--- a/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_iife_true/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_iife_true/artifacts.snap
@@ -22,12 +22,7 @@ Object.defineProperty(exports, 'default', {
     return main_default;
   }
 });
-Object.defineProperty(exports, 'value', {
-  enumerable: true,
-  get: function () {
-    return value;
-  }
-});
+exports.value = value
 return exports;
 })({});
 ```

--- a/crates/rolldown/tests/rolldown/function/es_module/never/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/never/artifacts.snap
@@ -15,18 +15,8 @@ const validator = "if_default_prop_false";
 const value = true;
 
 //#endregion
-Object.defineProperty(exports, 'validator', {
-  enumerable: true,
-  get: function () {
-    return validator;
-  }
-});
-Object.defineProperty(exports, 'value', {
-  enumerable: true,
-  get: function () {
-    return value;
-  }
-});
+exports.validator = validator
+exports.value = value
 return exports;
 })({});
 ```

--- a/crates/rolldown/tests/rolldown/function/export_mode/cjs/auto/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/cjs/auto/named/artifacts.snap
@@ -14,10 +14,5 @@ function a() {
 }
 
 //#endregion
-Object.defineProperty(exports, 'a', {
-  enumerable: true,
-  get: function () {
-    return a;
-  }
-});
+exports.a = a
 ```

--- a/crates/rolldown/tests/rolldown/function/export_mode/cjs/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/cjs/named/artifacts.snap
@@ -22,12 +22,7 @@ function a() {
 var main_default = example();
 
 //#endregion
-Object.defineProperty(exports, 'a', {
-  enumerable: true,
-  get: function () {
-    return a;
-  }
-});
+exports.a = a
 Object.defineProperty(exports, 'default', {
   enumerable: true,
   get: function () {

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
@@ -32,12 +32,7 @@ function aaa() {
 }
 
 //#endregion
-Object.defineProperty(exports, 'aaa', {
-  enumerable: true,
-  get: function () {
-    return aaa;
-  }
-});
+exports.aaa = aaa
 Object.defineProperty(exports, 'default', {
   enumerable: true,
   get: function () {

--- a/crates/rolldown/tests/rolldown/function/extend/iife/namespace_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/namespace_named/artifacts.snap
@@ -19,18 +19,8 @@ const a = 1;
 const b = 2;
 
 //#endregion
-Object.defineProperty(exports, 'a', {
-  enumerable: true,
-  get: function () {
-    return a;
-  }
-});
-Object.defineProperty(exports, 'b', {
-  enumerable: true,
-  get: function () {
-    return b;
-  }
-});
+exports.a = a
+exports.b = b
 })(this.test.module = this.test.module || {});
   }
 }

--- a/crates/rolldown/tests/rolldown/function/extend/iife/no_name_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/no_name_named/artifacts.snap
@@ -23,17 +23,7 @@ const a = 1;
 const b = 2;
 
 //#endregion
-Object.defineProperty(exports, 'a', {
-  enumerable: true,
-  get: function () {
-    return a;
-  }
-});
-Object.defineProperty(exports, 'b', {
-  enumerable: true,
-  get: function () {
-    return b;
-  }
-});
+exports.a = a
+exports.b = b
 })(this[""] = this[""] || {});
 ```

--- a/crates/rolldown/tests/rolldown/function/extend/iife/non_namespace_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/non_namespace_named/artifacts.snap
@@ -18,18 +18,8 @@ const a = 1;
 const b = 2;
 
 //#endregion
-Object.defineProperty(exports, 'a', {
-  enumerable: true,
-  get: function () {
-    return a;
-  }
-});
-Object.defineProperty(exports, 'b', {
-  enumerable: true,
-  get: function () {
-    return b;
-  }
-});
+exports.a = a
+exports.b = b
 })(this.module = this.module || {});
   }
 }

--- a/crates/rolldown/tests/rolldown/function/external_live_bindings/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external_live_bindings/artifacts.snap
@@ -14,12 +14,7 @@ const { read, readFile, readFileSync, readSync } = __toESM(require("node:fs"));
 const nonExternal = "nonExternal";
 
 //#endregion
-Object.defineProperty(exports, 'nonExternal', {
-  enumerable: true,
-  get: function () {
-    return nonExternal;
-  }
-});
+exports.nonExternal = nonExternal
 exports.read = read
 exports.readFile = readFile
 exports.readFileSync = readFileSync

--- a/crates/rolldown/tests/rolldown/function/format/cjs/conflict_exports_key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/conflict_exports_key/artifacts.snap
@@ -12,10 +12,5 @@ source: crates/rolldown_testing/src/integration_test.rs
 const exports$1 = "exports";
 
 //#endregion
-Object.defineProperty(exports, 'exports', {
-  enumerable: true,
-  get: function () {
-    return exports$1;
-  }
-});
+exports.exports = exports$1
 ```

--- a/crates/rolldown/tests/rolldown/function/format/cjs/import_export_unicode/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/import_export_unicode/artifacts.snap
@@ -12,10 +12,5 @@ source: crates/rolldown_testing/src/integration_test.rs
 const devil = "devil";
 
 //#endregion
-Object.defineProperty(exports, '😈', {
-  enumerable: true,
-  get: function () {
-    return devil;
-  }
-});
+exports["😈"] = devil
 ```

--- a/crates/rolldown/tests/rolldown/function/format/cjs/shared_entry_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/shared_entry_modules/artifacts.snap
@@ -9,12 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 "use strict";
 const require_main = require('./main.cjs');
 
-Object.defineProperty(exports, 'value', {
-  enumerable: true,
-  get: function () {
-    return require_main.value;
-  }
-});
+exports.value = require_main.value
 ```
 ## entry2.cjs
 
@@ -22,12 +17,7 @@ Object.defineProperty(exports, 'value', {
 "use strict";
 const require_main = require('./main.cjs');
 
-Object.defineProperty(exports, 'value', {
-  enumerable: true,
-  get: function () {
-    return require_main.value;
-  }
-});
+exports.value = require_main.value
 ```
 ## main.cjs
 

--- a/crates/rolldown/tests/rolldown/function/format/iife/conflict_exports_key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/conflict_exports_key/artifacts.snap
@@ -14,12 +14,7 @@ var module = (function(exports) {
 const exports$1 = "exports";
 
 //#endregion
-Object.defineProperty(exports, 'exports', {
-  enumerable: true,
-  get: function () {
-    return exports$1;
-  }
-});
+exports.exports = exports$1
 return exports;
 })({});
 ```

--- a/crates/rolldown/tests/rolldown/function/format/iife/conflict_exports_key_loop/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/conflict_exports_key_loop/artifacts.snap
@@ -15,18 +15,8 @@ const exports$1 = "exports";
 const exports$1$1 = "exports$1";
 
 //#endregion
-Object.defineProperty(exports, 'exports', {
-  enumerable: true,
-  get: function () {
-    return exports$1;
-  }
-});
-Object.defineProperty(exports, 'exports$1', {
-  enumerable: true,
-  get: function () {
-    return exports$1$1;
-  }
-});
+exports.exports = exports$1
+exports.exports$1 = exports$1$1
 return exports;
 })({});
 ```

--- a/crates/rolldown/tests/rolldown/function/format/iife/iife_with_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/iife_with_name/artifacts.snap
@@ -14,12 +14,7 @@ var module = (function(exports) {
 const value = 1;
 
 //#endregion
-Object.defineProperty(exports, 'value', {
-  enumerable: true,
-  get: function () {
-    return value;
-  }
-});
+exports.value = value
 return exports;
 })({});
 ```

--- a/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name/artifacts.snap
@@ -18,12 +18,7 @@ this.namespace.module = (function(exports) {
 const value = 1;
 
 //#endregion
-Object.defineProperty(exports, 'value', {
-  enumerable: true,
-  get: function () {
-    return value;
-  }
-});
+exports.value = value
 return exports;
 })({});
   }

--- a/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name_reserved/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name_reserved/artifacts.snap
@@ -18,12 +18,7 @@ this["1"]["2"] = (function(exports) {
 const value = 1;
 
 //#endregion
-Object.defineProperty(exports, 'value', {
-  enumerable: true,
-  get: function () {
-    return value;
-  }
-});
+exports.value = value
 return exports;
 })({});
   }

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
@@ -29,10 +29,5 @@ var init_main = __esm({ "main.js"() {
 
 //#endregion
 init_main();
-Object.defineProperty(exports, 'main', {
-  enumerable: true,
-  get: function () {
-    return main;
-  }
-});
+exports.main = main
 ```

--- a/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/exports/artifacts.snap
@@ -16,28 +16,13 @@ const devil = "devil";
 var main_default = "default";
 
 //#endregion
-Object.defineProperty(exports, 'a', {
-  enumerable: true,
-  get: function () {
-    return a;
-  }
-});
-Object.defineProperty(exports, 'b', {
-  enumerable: true,
-  get: function () {
-    return b;
-  }
-});
+exports.a = a
+exports.b = b
 Object.defineProperty(exports, 'default', {
   enumerable: true,
   get: function () {
     return main_default;
   }
 });
-Object.defineProperty(exports, '😈', {
-  enumerable: true,
-  get: function () {
-    return devil;
-  }
-});
+exports["😈"] = devil
 ```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_binding_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_binding_cjs/artifacts.snap
@@ -25,16 +25,6 @@ Object.defineProperty(exports, 'default', {
     return count;
   }
 });
-Object.defineProperty(exports, 'inc', {
-  enumerable: true,
-  get: function () {
-    return inc;
-  }
-});
-Object.defineProperty(exports, 'reset', {
-  enumerable: true,
-  get: function () {
-    return reset;
-  }
-});
+exports.inc = inc
+exports.reset = reset
 ```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_expr_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_expr_cjs/artifacts.snap
@@ -26,16 +26,6 @@ Object.defineProperty(exports, 'default', {
     return main_default;
   }
 });
-Object.defineProperty(exports, 'inc', {
-  enumerable: true,
-  get: function () {
-    return inc;
-  }
-});
-Object.defineProperty(exports, 'reset', {
-  enumerable: true,
-  get: function () {
-    return reset;
-  }
-});
+exports.inc = inc
+exports.reset = reset
 ```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_cjs/artifacts.snap
@@ -24,16 +24,6 @@ Object.defineProperty(exports, 'count', {
     return count;
   }
 });
-Object.defineProperty(exports, 'inc', {
-  enumerable: true,
-  get: function () {
-    return inc;
-  }
-});
-Object.defineProperty(exports, 'reset', {
-  enumerable: true,
-  get: function () {
-    return reset;
-  }
-});
+exports.inc = inc
+exports.reset = reset
 ```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
@@ -40,18 +40,8 @@ Object.defineProperty(exports, 'count', {
     return require_shared.count;
   }
 });
-Object.defineProperty(exports, 'inc', {
-  enumerable: true,
-  get: function () {
-    return require_shared.inc;
-  }
-});
-Object.defineProperty(exports, 'reset', {
-  enumerable: true,
-  get: function () {
-    return require_shared.reset;
-  }
-});
+exports.inc = require_shared.inc
+exports.reset = require_shared.reset
 ```
 ## shared.cjs
 

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs/artifacts.snap
@@ -1,0 +1,38 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.cjs
+
+```js
+"use strict";
+
+//#region main.js
+const short1 = "";
+let short2 = "";
+function short3() {}
+class short4 {}
+let nonShort1 = "";
+nonShort1 = "";
+function nonShort2() {}
+nonShort2 = () => {};
+
+//#endregion
+Object.defineProperty(exports, 'nonShort1', {
+  enumerable: true,
+  get: function () {
+    return nonShort1;
+  }
+});
+Object.defineProperty(exports, 'nonShort2', {
+  enumerable: true,
+  get: function () {
+    return nonShort2;
+  }
+});
+exports.short1 = short1
+exports.short2 = short2
+exports.short3 = short3
+exports.short4 = short4
+```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs/main.js
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs/main.js
@@ -1,0 +1,15 @@
+export const short1 = ''
+
+export let short2 = ''
+
+export function short3() {}
+
+export class short4 {}
+
+export let nonShort1 = ''
+// Trigger a re-assignment
+nonShort1 = ''
+
+export function nonShort2() {}
+// Trigger a re-assignment
+nonShort2 = () => {}

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_cjs/artifacts.snap
@@ -20,10 +20,5 @@ Object.defineProperty(exports, 'default', {
     return main_default;
   }
 });
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 ```

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/artifacts.snap
@@ -15,12 +15,7 @@ Object.defineProperty(exports, 'default', {
     return require_main.main_default;
   }
 });
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return require_main.foo;
-  }
-});
+exports.foo = require_main.foo
 ```
 ## entry2.cjs
 
@@ -34,12 +29,7 @@ Object.defineProperty(exports, 'default', {
     return require_main.main_default;
   }
 });
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return require_main.foo;
-  }
-});
+exports.foo = require_main.foo
 ```
 ## main.cjs
 

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
@@ -31,10 +31,5 @@ Object.defineProperty(exports, 'default', {
     return main_default;
   }
 });
-Object.defineProperty(exports, 'foo', {
-  enumerable: true,
-  get: function () {
-    return foo;
-  }
-});
+exports.foo = foo
 ```

--- a/crates/rolldown/tests/rolldown/warnings/mixed_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/mixed_export/artifacts.snap
@@ -24,12 +24,7 @@ var main_default = 1;
 const a = 2;
 
 //#endregion
-Object.defineProperty(exports, 'a', {
-  enumerable: true,
-  get: function () {
-    return a;
-  }
-});
+exports.a = a
 Object.defineProperty(exports, 'default', {
   enumerable: true,
   get: function () {

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -1597,15 +1597,15 @@ expression: output
 
 # tests/esbuild/importstar/export_self_and_import_self_common_js
 
-- entry_js-!~{000}~.cjs => entry_js-32I83GKt.cjs
+- entry_js-!~{000}~.cjs => entry_js-oU3JDK9e.cjs
 
 # tests/esbuild/importstar/export_self_and_require_self_common_js
 
-- entry_js-!~{000}~.cjs => entry_js-LN6d6btj.cjs
+- entry_js-!~{000}~.cjs => entry_js-_3d1EiSj.cjs
 
 # tests/esbuild/importstar/export_self_as_namespace_common_js
 
-- entry_js-!~{000}~.cjs => entry_js-lkGhL6zP.cjs
+- entry_js-!~{000}~.cjs => entry_js-gNYuDDcK.cjs
 
 # tests/esbuild/importstar/export_self_as_namespace_es6
 
@@ -1613,7 +1613,7 @@ expression: output
 
 # tests/esbuild/importstar/export_self_common_js
 
-- entry_js-!~{000}~.cjs => entry_js-mKIoiJrd.cjs
+- entry_js-!~{000}~.cjs => entry_js-0ATAi2At.cjs
 
 # tests/esbuild/importstar/export_self_common_js_minified
 
@@ -1625,11 +1625,11 @@ expression: output
 
 # tests/esbuild/importstar/export_self_iife
 
-- entry_js-!~{000}~.mjs => entry_js-MUKCSxUC.mjs
+- entry_js-!~{000}~.mjs => entry_js-6mga-qt9.mjs
 
 # tests/esbuild/importstar/export_self_iife_with_name
 
-- entry_js-!~{000}~.mjs => entry_js-MUKCSxUC.mjs
+- entry_js-!~{000}~.mjs => entry_js-6mga-qt9.mjs
 
 # tests/esbuild/importstar/export_star_default_export_common_js
 
@@ -2833,27 +2833,27 @@ expression: output
 
 # tests/rolldown/function/es_module/always
 
-- main-!~{000}~.mjs => main-GMcEoSM-.mjs
+- main-!~{000}~.mjs => main-yZBgcOx8.mjs
 
 # tests/rolldown/function/es_module/if_default_prop_cjs_false
 
-- main-!~{000}~.cjs => main-T0mAU_XW.cjs
+- main-!~{000}~.cjs => main-30YAhiLI.cjs
 
 # tests/rolldown/function/es_module/if_default_prop_cjs_true
 
-- main-!~{000}~.cjs => main-yN0ScSi8.cjs
+- main-!~{000}~.cjs => main-s6lBS-nX.cjs
 
 # tests/rolldown/function/es_module/if_default_prop_iife_false
 
-- main-!~{000}~.mjs => main-MTVu9T3l.mjs
+- main-!~{000}~.mjs => main-il7etjKO.mjs
 
 # tests/rolldown/function/es_module/if_default_prop_iife_true
 
-- main-!~{000}~.mjs => main-6o0sUXXk.mjs
+- main-!~{000}~.mjs => main-mXJljSaH.mjs
 
 # tests/rolldown/function/es_module/never
 
-- main-!~{000}~.mjs => main-MTVu9T3l.mjs
+- main-!~{000}~.mjs => main-il7etjKO.mjs
 
 # tests/rolldown/function/experimental/disable_live_bindings
 
@@ -2889,7 +2889,7 @@ expression: output
 
 # tests/rolldown/function/export_mode/cjs/auto/named
 
-- main-!~{000}~.cjs => main-5VkOU269.cjs
+- main-!~{000}~.cjs => main-YgL8NzzT.cjs
 
 # tests/rolldown/function/export_mode/cjs/auto/none
 
@@ -2901,7 +2901,7 @@ expression: output
 
 # tests/rolldown/function/export_mode/cjs/named
 
-- main-!~{000}~.cjs => main-sFhd45Xb.cjs
+- main-!~{000}~.cjs => main-0e3VMrlb.cjs
 
 # tests/rolldown/function/export_mode/iife/auto/none
 
@@ -2913,7 +2913,7 @@ expression: output
 
 # tests/rolldown/function/export_mode/iife/named
 
-- main-!~{000}~.mjs => main-okYdXZxm.mjs
+- main-!~{000}~.mjs => main-HAK-qBWy.mjs
 
 # tests/rolldown/function/extend/iife/namespace_default
 
@@ -2921,7 +2921,7 @@ expression: output
 
 # tests/rolldown/function/extend/iife/namespace_named
 
-- main-!~{000}~.mjs => main-qFuUsGqX.mjs
+- main-!~{000}~.mjs => main-rL3LHKnm.mjs
 
 # tests/rolldown/function/extend/iife/no_name_default
 
@@ -2929,7 +2929,7 @@ expression: output
 
 # tests/rolldown/function/extend/iife/no_name_named
 
-- main-!~{000}~.mjs => main-tJ5KtzCN.mjs
+- main-!~{000}~.mjs => main-ns0qmxoX.mjs
 
 # tests/rolldown/function/extend/iife/non_namespace_default
 
@@ -2937,7 +2937,7 @@ expression: output
 
 # tests/rolldown/function/extend/iife/non_namespace_named
 
-- main-!~{000}~.mjs => main-4I1iemMj.mjs
+- main-!~{000}~.mjs => main-hQyvdNWe.mjs
 
 # tests/rolldown/function/external/commonjs_reexport_external
 
@@ -2967,7 +2967,7 @@ expression: output
 
 # tests/rolldown/function/external_live_bindings
 
-- main-!~{000}~.cjs => main-9oedPrfh.cjs
+- main-!~{000}~.cjs => main-GR0OBaTv.cjs
 
 # tests/rolldown/function/format/app/export-all
 
@@ -3009,11 +3009,11 @@ expression: output
 
 # tests/rolldown/function/format/cjs/conflict_exports_key
 
-- main-!~{000}~.cjs => main-MV9F9603.cjs
+- main-!~{000}~.cjs => main-jdlDcA1w.cjs
 
 # tests/rolldown/function/format/cjs/import_export_unicode
 
-- main-!~{000}~.cjs => main-7KKR3ylp.cjs
+- main-!~{000}~.cjs => main-f8iv2A1p.cjs
 
 # tests/rolldown/function/format/cjs/plain_import_should_not_introduce_to_esm
 
@@ -3027,8 +3027,8 @@ expression: output
 
 # tests/rolldown/function/format/cjs/shared_entry_modules
 
-- entry1-!~{000}~.cjs => entry1-i7oOHHhW.cjs
-- entry2-!~{001}~.cjs => entry2-TTCbXWhM.cjs
+- entry1-!~{000}~.cjs => entry1-PgX-GK0n.cjs
+- entry2-!~{001}~.cjs => entry2-CBMQoYM-.cjs
 - main-!~{002}~.cjs => main-g4RbwWfd.cjs
 
 # tests/rolldown/function/format/esm/import_export_unicode
@@ -3037,11 +3037,11 @@ expression: output
 
 # tests/rolldown/function/format/iife/conflict_exports_key
 
-- main-!~{000}~.mjs => main-oG2zLm_0.mjs
+- main-!~{000}~.mjs => main-9xKZl1DX.mjs
 
 # tests/rolldown/function/format/iife/conflict_exports_key_loop
 
-- main-!~{000}~.mjs => main-jqeYIu7y.mjs
+- main-!~{000}~.mjs => main-V-atYJ0A.mjs
 
 # tests/rolldown/function/format/iife/external_modules
 
@@ -3053,15 +3053,15 @@ expression: output
 
 # tests/rolldown/function/format/iife/iife_with_name
 
-- main-!~{000}~.mjs => main--FmiP1j0.mjs
+- main-!~{000}~.mjs => main-rjxy_9GP.mjs
 
 # tests/rolldown/function/format/iife/namespaced_name
 
-- main-!~{000}~.mjs => main-ELPzdqJs.mjs
+- main-!~{000}~.mjs => main-C9oGkn5P.mjs
 
 # tests/rolldown/function/format/iife/namespaced_name_reserved
 
-- main-!~{000}~.mjs => main-i2p4fCcn.mjs
+- main-!~{000}~.mjs => main-rnVxjHfw.mjs
 
 # tests/rolldown/function/inject
 
@@ -3429,7 +3429,7 @@ expression: output
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs
 
-- entry-!~{000}~.cjs => entry-9O3jXKw7.cjs
+- entry-!~{000}~.cjs => entry-jl1ZvnLv.cjs
 
 # tests/rolldown/sourcemap/inline_url_relative_to_file
 
@@ -3442,7 +3442,7 @@ expression: output
 
 # tests/rolldown/topics/cjs_module_lexer_compat/exports
 
-- main-!~{000}~.cjs => main-HEXq7EWu.cjs
+- main-!~{000}~.cjs => main-p3qJDBr-.cjs
 
 # tests/rolldown/topics/css/basic
 
@@ -3512,7 +3512,7 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/default_export_binding_cjs
 
-- main-!~{000}~.cjs => main-M49-3Ili.cjs
+- main-!~{000}~.cjs => main-Pxgut0pz.cjs
 
 # tests/rolldown/topics/live_bindings/default_export_binding_in_common_chunks
 
@@ -3530,7 +3530,7 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/default_export_expr_cjs
 
-- main-!~{000}~.cjs => main-uib-aQoT.cjs
+- main-!~{000}~.cjs => main-XVReus72.cjs
 
 # tests/rolldown/topics/live_bindings/default_export_expr_in_common_chunks
 
@@ -3548,7 +3548,7 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/named_exports_cjs
 
-- main-!~{000}~.cjs => main-QjzSNBfw.cjs
+- main-!~{000}~.cjs => main-SywckwVS.cjs
 
 # tests/rolldown/topics/live_bindings/named_exports_in_common_chunks
 
@@ -3558,9 +3558,13 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs
 
-- main-!~{000}~.cjs => main-h7mF_ZsM.cjs
+- main-!~{000}~.cjs => main-TRJKnzGC.cjs
 - async-entry-!~{003}~.cjs => async-entry-bLPO79el.cjs
 - shared-!~{001}~.cjs => shared-PsOvd2ew.cjs
+
+# tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs
+
+- main-!~{000}~.cjs => main-Bl7D8wL8.cjs
 
 # tests/rolldown/topics/npm_packages/util_deprecate
 
@@ -3572,7 +3576,7 @@ expression: output
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_cjs
 
-- main-!~{000}~.cjs => main-XnUXw2Fp.cjs
+- main-!~{000}~.cjs => main-MYJJIqOM.cjs
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries
 
@@ -3582,8 +3586,8 @@ expression: output
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs
 
-- entry-!~{000}~.cjs => entry-Mw6RYPz7.cjs
-- entry2-!~{001}~.cjs => entry2-gf69CcN4.cjs
+- entry-!~{000}~.cjs => entry-w-f9pX8F.cjs
+- entry2-!~{001}~.cjs => entry2-7png3w-D.cjs
 - main-!~{002}~.cjs => main--L-FB-fk.cjs
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped
@@ -3598,7 +3602,7 @@ expression: output
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs
 
-- main-!~{000}~.cjs => main-p3cPDql9.cjs
+- main-!~{000}~.cjs => main-Gf0fLxp1.cjs
 
 # tests/rolldown/tree_shaking/advanced_barrel_exports
 
@@ -3675,7 +3679,7 @@ expression: output
 
 # tests/rolldown/warnings/mixed_export
 
-- main-!~{000}~.mjs => main-1v1Ck7af.mjs
+- main-!~{000}~.mjs => main-zXjtdAhE.mjs
 
 # tests/rolldown/warnings/unresolved_import_treated_as_external
 

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -75,12 +75,7 @@ const { read, readFile, readFileSync, readSync } = node_fs;
 const nonExternal = "nonExternal";
 
 //#endregion
-Object.defineProperty(exports, 'nonExternal', {
-  enumerable: true,
-  get: function () {
-    return nonExternal;
-  }
-});
+exports.nonExternal = nonExternal
 exports.read = read
 exports.readFile = readFile
 exports.readFileSync = readFileSync

--- a/packages/rolldown/tests/fixtures/output/extend/false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/extend/false/_config.ts
@@ -17,40 +17,30 @@ export default defineTest({
   afterTest: (output) => {
     isComposingJs
       ? expect(output.output[0].code).toMatchInlineSnapshot(`
-      "var module = (function(exports) {
+        "var module = (function(exports) {
 
-      "use strict";
+        "use strict";
 
-      //#region main.js
-      const main = "main";
+        //#region main.js
+        const main = "main";
 
-      //#endregion
-      Object.defineProperty(exports, 'main', {
-        enumerable: true,
-        get: function () {
-          return main;
-        }
-      });
-      return exports;
-      })({});"
-    `)
+        //#endregion
+        exports.main = main
+        return exports;
+        })({});"
+      `)
       : expect(output.output[0].code).toMatchInlineSnapshot(`
-      "var module = (function(exports) {
+        "var module = (function(exports) {
 
-      "use strict";
+        "use strict";
 
-      //#region main.js
-      const main = "main";
+        //#region main.js
+        const main = "main";
 
-      //#endregion
-      Object.defineProperty(exports, 'main', {
-        enumerable: true,
-        get: function () {
-          return main;
-        }
-      });
-      return exports;
-      })({});"
-    `)
+        //#endregion
+        exports.main = main
+        return exports;
+        })({});"
+      `)
   },
 })

--- a/packages/rolldown/tests/fixtures/output/extend/true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/extend/true/_config.ts
@@ -16,38 +16,28 @@ export default defineTest({
   afterTest: (output) => {
     isComposingJs
       ? expect(output.output[0].code).toMatchInlineSnapshot(`
-      "(function(exports) {
+        "(function(exports) {
 
-      "use strict";
+        "use strict";
 
-      //#region main.js
-      const main = "main";
+        //#region main.js
+        const main = "main";
 
-      //#endregion
-      Object.defineProperty(exports, 'main', {
-        enumerable: true,
-        get: function () {
-          return main;
-        }
-      });
-      })(this.module = this.module || {});"
-    `)
+        //#endregion
+        exports.main = main
+        })(this.module = this.module || {});"
+      `)
       : expect(output.output[0].code).toMatchInlineSnapshot(`
-      "(function(exports) {
+        "(function(exports) {
 
-      "use strict";
+        "use strict";
 
-      //#region main.js
-      const main = "main";
+        //#region main.js
+        const main = "main";
 
-      //#endregion
-      Object.defineProperty(exports, 'main', {
-        enumerable: true,
-        get: function () {
-          return main;
-        }
-      });
-      })(this.module = this.module || {});"
-    `)
+        //#endregion
+        exports.main = main
+        })(this.module = this.module || {});"
+      `)
   },
 })

--- a/packages/rolldown/tests/fixtures/output/extend/undefined/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/extend/undefined/_config.ts
@@ -15,40 +15,30 @@ export default defineTest({
   afterTest: (output) => {
     isComposingJs
       ? expect(output.output[0].code).toMatchInlineSnapshot(`
-      "var module = (function(exports) {
+        "var module = (function(exports) {
 
-      "use strict";
+        "use strict";
 
-      //#region main.js
-      const main = "main";
+        //#region main.js
+        const main = "main";
 
-      //#endregion
-      Object.defineProperty(exports, 'main', {
-        enumerable: true,
-        get: function () {
-          return main;
-        }
-      });
-      return exports;
-      })({});"
-    `)
+        //#endregion
+        exports.main = main
+        return exports;
+        })({});"
+      `)
       : expect(output.output[0].code).toMatchInlineSnapshot(`
-      "var module = (function(exports) {
+        "var module = (function(exports) {
 
-      "use strict";
+        "use strict";
 
-      //#region main.js
-      const main = "main";
+        //#region main.js
+        const main = "main";
 
-      //#endregion
-      Object.defineProperty(exports, 'main', {
-        enumerable: true,
-        get: function () {
-          return main;
-        }
-      });
-      return exports;
-      })({});"
-    `)
+        //#endregion
+        exports.main = main
+        return exports;
+        })({});"
+      `)
   },
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

```js
export const short1 = ''

export let short2 = ''

export function short3() {}

export class short4 {}

export let nonShort1 = ''
// Trigger a re-assignment
nonShort1 = ''

export function nonShort2() {}
// Trigger a re-assignment
nonShort2 = () => {}
```

would become

```js
"use strict";
//#region main.js
const short1 = "";
let short2 = "";
function short3() {}
class short4 {}
let nonShort1 = "";
nonShort1 = "";
function nonShort2() {}
nonShort2 = () => {};
//#endregion
Object.defineProperty(exports, 'nonShort1', {
  enumerable: true,
  get: function () {
    return nonShort1;
  }
});
Object.defineProperty(exports, 'nonShort2', {
  enumerable: true,
  get: function () {
    return nonShort2;
  }
});
exports.short1 = short1
exports.short2 = short2
exports.short3 = short3
exports.short4 = short4
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
