### PR TITLE
refactor(binding): remove BindingOutputs unsafe code

### DIFF
--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -6,8 +6,7 @@ use crate::{
   options::{BindingInputOptions, BindingOnLog, BindingOutputOptions},
   parallel_js_plugin_registry::ParallelJsPluginRegistry,
   types::{
-    binding_log::BindingLog, binding_log_level::BindingLogLevel,
-    binding_outputs::FinalBindingOutputs,
+    binding_log::BindingLog, binding_log_level::BindingLogLevel, binding_outputs::BindingOutputs,
   },
   utils::{normalize_binding_options::normalize_binding_options, try_init_custom_trace_subscriber},
 };
@@ -73,13 +72,13 @@ impl Bundler {
 
   #[napi]
   #[tracing::instrument(level = "debug", skip_all)]
-  pub async fn write(&self) -> napi::Result<FinalBindingOutputs> {
+  pub async fn write(&self) -> napi::Result<BindingOutputs> {
     self.write_impl().await
   }
 
   #[napi]
   #[tracing::instrument(level = "debug", skip_all)]
-  pub async fn generate(&self) -> napi::Result<FinalBindingOutputs> {
+  pub async fn generate(&self) -> napi::Result<BindingOutputs> {
     self.generate_impl().await
   }
 
@@ -118,7 +117,7 @@ impl Bundler {
   }
 
   #[allow(clippy::significant_drop_tightening)]
-  pub async fn write_impl(&self) -> napi::Result<FinalBindingOutputs> {
+  pub async fn write_impl(&self) -> napi::Result<BindingOutputs> {
     let mut bundler_core = self.inner.try_lock().map_err(|_| {
       napi::Error::from_reason("Failed to lock the bundler. Is another operation in progress?")
     })?;
@@ -131,11 +130,11 @@ impl Bundler {
 
     self.handle_warnings(outputs.warnings).await;
 
-    Ok(FinalBindingOutputs::new(outputs.assets))
+    Ok(outputs.assets.into())
   }
 
   #[allow(clippy::significant_drop_tightening)]
-  pub async fn generate_impl(&self) -> napi::Result<FinalBindingOutputs> {
+  pub async fn generate_impl(&self) -> napi::Result<BindingOutputs> {
     let mut bundler_core = self.inner.try_lock().map_err(|_| {
       napi::Error::from_reason("Failed to lock the bundler. Is another operation in progress?")
     })?;
@@ -148,7 +147,7 @@ impl Bundler {
 
     self.handle_warnings(outputs.warnings).await;
 
-    Ok(FinalBindingOutputs::new(outputs.assets))
+    Ok(outputs.assets.into())
   }
 
   #[allow(clippy::significant_drop_tightening)]

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -3,8 +3,10 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 use crate::types::{
-  binding_module_info::BindingModuleInfo, binding_outputs::BindingOutputs,
-  binding_rendered_chunk::RenderedChunk, js_callback::MaybeAsyncJsCallback,
+  binding_module_info::BindingModuleInfo,
+  binding_outputs::{BindingOutputs, JsChangedOutputs},
+  binding_rendered_chunk::RenderedChunk,
+  js_callback::MaybeAsyncJsCallback,
 };
 
 use super::{
@@ -131,17 +133,18 @@ pub struct BindingPluginOptions {
 
   #[serde(skip_deserializing)]
   #[napi(
-    ts_type = "(ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>"
+    ts_type = "(ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable<JsChangedOutputs>>"
   )]
   pub generate_bundle:
-    Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingOutputs, bool), ()>>,
+    Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingOutputs, bool), JsChangedOutputs>>,
   pub generate_bundle_meta: Option<BindingPluginHookMeta>,
 
   #[serde(skip_deserializing)]
   #[napi(
-    ts_type = "(ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>"
+    ts_type = "(ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable<JsChangedOutputs>>"
   )]
-  pub write_bundle: Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingOutputs), ()>>,
+  pub write_bundle:
+    Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingOutputs), JsChangedOutputs>>,
   pub write_bundle_meta: Option<BindingPluginHookMeta>,
 
   #[serde(skip_deserializing)]

--- a/crates/rolldown_binding/src/type_aliases.rs
+++ b/crates/rolldown_binding/src/type_aliases.rs
@@ -1,6 +1,7 @@
 use std::sync::Mutex;
 
 use rolldown_utils::unique_arc::{UniqueArc, WeakRef};
-
+#[allow(dead_code)]
 pub type UniqueArcMutex<T> = UniqueArc<Mutex<T>>;
+#[allow(dead_code)]
 pub type WeakRefMutex<T> = WeakRef<Mutex<T>>;

--- a/crates/rolldown_binding/src/types/binding_output_asset.rs
+++ b/crates/rolldown_binding/src/types/binding_output_asset.rs
@@ -4,12 +4,12 @@ use crate::options::plugin::types::binding_asset_source::BindingAssetSource;
 
 #[napi]
 pub struct BindingOutputAsset {
-  inner: &'static mut rolldown_common::OutputAsset,
+  inner: rolldown_common::OutputAsset,
 }
 
 #[napi]
 impl BindingOutputAsset {
-  pub fn new(inner: &'static mut rolldown_common::OutputAsset) -> Self {
+  pub fn new(inner: rolldown_common::OutputAsset) -> Self {
     Self { inner }
   }
 
@@ -28,13 +28,27 @@ impl BindingOutputAsset {
     self.inner.source.clone().into()
   }
 
-  #[napi(setter, js_name = "source")]
-  pub fn set_source(&mut self, source: BindingAssetSource) {
-    self.inner.source = source.into();
-  }
-
   #[napi(getter)]
   pub fn name(&self) -> Option<String> {
     self.inner.name.clone()
+  }
+}
+
+#[napi(object)]
+pub struct JsOutputAsset {
+  pub name: Option<String>,
+  pub original_file_name: Option<String>,
+  pub filename: String,
+  pub source: BindingAssetSource,
+}
+
+impl From<JsOutputAsset> for rolldown_common::OutputAsset {
+  fn from(asset: JsOutputAsset) -> Self {
+    Self {
+      name: asset.name,
+      original_file_name: asset.original_file_name,
+      filename: asset.filename.into(),
+      source: asset.source.into(),
+    }
   }
 }

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -3,16 +3,18 @@ use std::collections::HashMap;
 use napi_derive::napi;
 use rolldown_sourcemap::SourceMap;
 
-use crate::types::binding_rendered_module::BindingRenderedModule;
+use super::{binding_rendered_module::BindingRenderedModule, binding_sourcemap::BindingSourcemap};
+
+// Here using `napi` `getter` fields to avoid the cost of serialize larger data to js side.
 
 #[napi]
 pub struct BindingOutputChunk {
-  inner: &'static mut rolldown_common::OutputChunk,
+  inner: rolldown_common::OutputChunk,
 }
 
 #[napi]
 impl BindingOutputChunk {
-  pub fn new(inner: &'static mut rolldown_common::OutputChunk) -> Self {
+  pub fn new(inner: rolldown_common::OutputChunk) -> Self {
     Self { inner }
   }
 
@@ -63,11 +65,6 @@ impl BindingOutputChunk {
     self.inner.imports.iter().map(|x| x.to_string()).collect()
   }
 
-  #[napi(setter, js_name = "imports")]
-  pub fn set_imports(&mut self, imports: Vec<String>) {
-    self.inner.imports = imports.into_iter().map(Into::into).collect();
-  }
-
   #[napi(getter)]
   pub fn dynamic_imports(&self) -> Vec<String> {
     self.inner.dynamic_imports.iter().map(|x| x.to_string()).collect()
@@ -79,23 +76,9 @@ impl BindingOutputChunk {
     self.inner.code.clone()
   }
 
-  #[napi(setter, js_name = "code")]
-  pub fn set_code(&mut self, code: String) {
-    self.inner.code = code;
-  }
-
   #[napi(getter)]
   pub fn map(&self) -> napi::Result<Option<String>> {
     Ok(self.inner.map.as_ref().map(SourceMap::to_json_string))
-  }
-
-  #[napi(setter, js_name = "map")]
-  pub fn set_map(&mut self, map: String) -> napi::Result<()> {
-    self.inner.map = Some(
-      SourceMap::from_json_string(map.as_str())
-        .map_err(|e| napi::Error::from_reason(format!("{e:?}")))?,
-    );
-    Ok(())
   }
 
   #[napi(getter)]
@@ -111,5 +94,49 @@ impl BindingOutputChunk {
   #[napi(getter)]
   pub fn name(&self) -> String {
     self.inner.name.to_string()
+  }
+}
+
+#[napi(object)]
+pub struct JsOutputChunk {
+  // PreRenderedChunk
+  pub name: String,
+  pub is_entry: bool,
+  pub is_dynamic_entry: bool,
+  pub facade_module_id: Option<String>,
+  pub module_ids: Vec<String>,
+  pub exports: Vec<String>,
+  // RenderedChunk
+  pub filename: String,
+  pub modules: HashMap<String, BindingRenderedModule>,
+  pub imports: Vec<String>,
+  pub dynamic_imports: Vec<String>,
+  // OutputChunk
+  pub code: String,
+  pub map: Option<BindingSourcemap>,
+  pub sourcemap_filename: Option<String>,
+  pub preliminary_filename: String,
+}
+
+impl TryFrom<JsOutputChunk> for rolldown_common::OutputChunk {
+  type Error = anyhow::Error;
+
+  fn try_from(chunk: JsOutputChunk) -> Result<Self, Self::Error> {
+    Ok(Self {
+      name: chunk.name.into(),
+      is_entry: chunk.is_entry,
+      is_dynamic_entry: chunk.is_dynamic_entry,
+      facade_module_id: chunk.facade_module_id.map(Into::into),
+      module_ids: chunk.module_ids.into_iter().map(Into::into).collect(),
+      exports: chunk.exports,
+      filename: chunk.filename.into(),
+      modules: chunk.modules.into_iter().map(|(key, value)| (key.into(), value.into())).collect(),
+      imports: chunk.imports.into_iter().map(Into::into).collect(),
+      dynamic_imports: chunk.dynamic_imports.into_iter().map(Into::into).collect(),
+      code: chunk.code,
+      map: chunk.map.map(TryInto::try_into).transpose()?,
+      sourcemap_filename: chunk.sourcemap_filename,
+      preliminary_filename: chunk.preliminary_filename,
+    })
   }
 }

--- a/crates/rolldown_binding/src/types/binding_rendered_module.rs
+++ b/crates/rolldown_binding/src/types/binding_rendered_module.rs
@@ -18,3 +18,9 @@ impl From<rolldown_common::RenderedModule> for BindingRenderedModule {
     Self { code: value.code }
   }
 }
+
+impl From<BindingRenderedModule> for rolldown_common::RenderedModule {
+  fn from(value: BindingRenderedModule) -> Self {
+    Self { code: value.code }
+  }
+}

--- a/crates/rolldown_common/src/types/output.rs
+++ b/crates/rolldown_common/src/types/output.rs
@@ -2,7 +2,7 @@ use arcstr::ArcStr;
 
 use crate::{AssetSource, OutputChunk};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OutputAsset {
   pub name: Option<String>,
   pub original_file_name: Option<String>,
@@ -10,7 +10,7 @@ pub struct OutputAsset {
   pub source: AssetSource,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Output {
   Chunk(Box<OutputChunk>),
   Asset(Box<OutputAsset>),

--- a/crates/rolldown_common/src/types/output_chunk.rs
+++ b/crates/rolldown_common/src/types/output_chunk.rs
@@ -6,7 +6,7 @@ use crate::ModuleId;
 
 use super::rendered_module::RenderedModule;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OutputChunk {
   // PreRenderedChunk
   pub name: ArcStr,

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -20,7 +20,6 @@ export declare class BindingOutputAsset {
   get fileName(): string
   get originalFileName(): string | null
   get source(): BindingAssetSource
-  set source(source: BindingAssetSource)
   get name(): string | null
 }
 
@@ -33,22 +32,17 @@ export declare class BindingOutputChunk {
   get fileName(): string
   get modules(): Record<string, BindingRenderedModule>
   get imports(): Array<string>
-  set imports(imports: Array<string>)
   get dynamicImports(): Array<string>
   get code(): string
-  set code(code: string)
   get map(): string | null
-  set map(map: string)
   get sourcemapFileName(): string | null
   get preliminaryFileName(): string
   get name(): string
 }
 
-/** The `BindingOutputs` owner `Vec<Output>` the mutable reference, it avoid `Clone` at call `writeBundle/generateBundle` hook, and make it mutable. */
 export declare class BindingOutputs {
   get chunks(): Array<BindingOutputChunk>
   get assets(): Array<BindingOutputAsset>
-  delete(fileName: string): void
 }
 
 export declare class BindingPluginContext {
@@ -65,19 +59,10 @@ export declare class BindingTransformPluginContext {
 
 export declare class Bundler {
   constructor(inputOptions: BindingInputOptions, outputOptions: BindingOutputOptions, parallelPluginsRegistry?: ParallelJsPluginRegistry | undefined | null)
-  write(): Promise<FinalBindingOutputs>
-  generate(): Promise<FinalBindingOutputs>
+  write(): Promise<BindingOutputs>
+  generate(): Promise<BindingOutputs>
   scan(): Promise<void>
   close(): Promise<void>
-}
-
-/**
- * The `FinalBindingOutputs` is used at `write()` or `generate()`, it is similar to `BindingOutputs`, if using `BindingOutputs` has unexpected behavior.
- * TODO find a way to export it gracefully.
- */
-export declare class FinalBindingOutputs {
-  get chunks(): Array<BindingOutputChunk>
-  get assets(): Array<BindingOutputAsset>
 }
 
 export declare class ParallelJsPluginRegistry {
@@ -350,9 +335,9 @@ export interface BindingPluginOptions {
   renderStartMeta?: BindingPluginHookMeta
   renderError?: (ctx: BindingPluginContext, error: string) => void
   renderErrorMeta?: BindingPluginHookMeta
-  generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable>
+  generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean) => MaybePromise<VoidNullable<JsChangedOutputs>>
   generateBundleMeta?: BindingPluginHookMeta
-  writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable>
+  writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs) => MaybePromise<VoidNullable<JsChangedOutputs>>
   writeBundleMeta?: BindingPluginHookMeta
   closeBundle?: (ctx: BindingPluginContext) => MaybePromise<VoidNullable>
   closeBundleMeta?: BindingPluginHookMeta
@@ -470,6 +455,36 @@ export interface IsolatedDeclarationsResult {
   code: string
   map?: SourceMap
   errors: Array<string>
+}
+
+export interface JsChangedOutputs {
+  chunks: Array<JsOutputChunk>
+  assets: Array<JsOutputAsset>
+  deleted: Array<string>
+}
+
+export interface JsOutputAsset {
+  name?: string
+  originalFileName?: string
+  filename: string
+  source: BindingAssetSource
+}
+
+export interface JsOutputChunk {
+  name: string
+  isEntry: boolean
+  isDynamicEntry: boolean
+  facadeModuleId?: string
+  moduleIds: Array<string>
+  exports: Array<string>
+  filename: string
+  modules: Record<string, BindingRenderedModule>
+  imports: Array<string>
+  dynamicImports: Array<string>
+  code: string
+  map?: BindingSourcemap
+  sourcemapFilename?: string
+  preliminaryFilename: string
 }
 
 /**

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -369,7 +369,6 @@ module.exports.BindingOutputs = nativeBinding.BindingOutputs
 module.exports.BindingPluginContext = nativeBinding.BindingPluginContext
 module.exports.BindingTransformPluginContext = nativeBinding.BindingTransformPluginContext
 module.exports.Bundler = nativeBinding.Bundler
-module.exports.FinalBindingOutputs = nativeBinding.FinalBindingOutputs
 module.exports.ParallelJsPluginRegistry = nativeBinding.ParallelJsPluginRegistry
 module.exports.BindingBuiltinPluginName = nativeBinding.BindingBuiltinPluginName
 module.exports.BindingHookSideEffects = nativeBinding.BindingHookSideEffects

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -123,20 +123,21 @@ function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__BindingModuleInfo_struct_62']?.()
   __napiInstance.exports['__napi_register__BindingModuleInfo_impl_64']?.()
   __napiInstance.exports['__napi_register__BindingOutputAsset_struct_65']?.()
-  __napiInstance.exports['__napi_register__BindingOutputAsset_impl_71']?.()
+  __napiInstance.exports['__napi_register__BindingOutputAsset_impl_70']?.()
+  __napiInstance.exports['__napi_register__JsOutputAsset_struct_71']?.()
   __napiInstance.exports['__napi_register__BindingOutputChunk_struct_72']?.()
-  __napiInstance.exports['__napi_register__BindingOutputChunk_impl_90']?.()
-  __napiInstance.exports['__napi_register__BindingOutputs_struct_91']?.()
-  __napiInstance.exports['__napi_register__BindingOutputs_impl_95']?.()
-  __napiInstance.exports['__napi_register__FinalBindingOutputs_struct_96']?.()
-  __napiInstance.exports['__napi_register__FinalBindingOutputs_impl_99']?.()
-  __napiInstance.exports['__napi_register__PreRenderedChunk_struct_100']?.()
-  __napiInstance.exports['__napi_register__RenderedChunk_struct_101']?.()
-  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_102']?.()
-  __napiInstance.exports['__napi_register__AliasItem_struct_103']?.()
-  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_104']?.()
-  __napiInstance.exports['__napi_register__BindingSourcemap_struct_105']?.()
-  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_106']?.()
+  __napiInstance.exports['__napi_register__BindingOutputChunk_impl_87']?.()
+  __napiInstance.exports['__napi_register__JsOutputChunk_struct_88']?.()
+  __napiInstance.exports['__napi_register__BindingOutputs_struct_89']?.()
+  __napiInstance.exports['__napi_register__BindingOutputs_impl_92']?.()
+  __napiInstance.exports['__napi_register__JsChangedOutputs_struct_93']?.()
+  __napiInstance.exports['__napi_register__PreRenderedChunk_struct_94']?.()
+  __napiInstance.exports['__napi_register__RenderedChunk_struct_95']?.()
+  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_96']?.()
+  __napiInstance.exports['__napi_register__AliasItem_struct_97']?.()
+  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_98']?.()
+  __napiInstance.exports['__napi_register__BindingSourcemap_struct_99']?.()
+  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_100']?.()
 }
 export const BindingLog = __napiModule.exports.BindingLog
 export const BindingModuleInfo = __napiModule.exports.BindingModuleInfo
@@ -146,7 +147,6 @@ export const BindingOutputs = __napiModule.exports.BindingOutputs
 export const BindingPluginContext = __napiModule.exports.BindingPluginContext
 export const BindingTransformPluginContext = __napiModule.exports.BindingTransformPluginContext
 export const Bundler = __napiModule.exports.Bundler
-export const FinalBindingOutputs = __napiModule.exports.FinalBindingOutputs
 export const ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
 export const BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName
 export const BindingHookSideEffects = __napiModule.exports.BindingHookSideEffects

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -147,20 +147,21 @@ function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__BindingModuleInfo_struct_62']?.()
   __napiInstance.exports['__napi_register__BindingModuleInfo_impl_64']?.()
   __napiInstance.exports['__napi_register__BindingOutputAsset_struct_65']?.()
-  __napiInstance.exports['__napi_register__BindingOutputAsset_impl_71']?.()
+  __napiInstance.exports['__napi_register__BindingOutputAsset_impl_70']?.()
+  __napiInstance.exports['__napi_register__JsOutputAsset_struct_71']?.()
   __napiInstance.exports['__napi_register__BindingOutputChunk_struct_72']?.()
-  __napiInstance.exports['__napi_register__BindingOutputChunk_impl_90']?.()
-  __napiInstance.exports['__napi_register__BindingOutputs_struct_91']?.()
-  __napiInstance.exports['__napi_register__BindingOutputs_impl_95']?.()
-  __napiInstance.exports['__napi_register__FinalBindingOutputs_struct_96']?.()
-  __napiInstance.exports['__napi_register__FinalBindingOutputs_impl_99']?.()
-  __napiInstance.exports['__napi_register__PreRenderedChunk_struct_100']?.()
-  __napiInstance.exports['__napi_register__RenderedChunk_struct_101']?.()
-  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_102']?.()
-  __napiInstance.exports['__napi_register__AliasItem_struct_103']?.()
-  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_104']?.()
-  __napiInstance.exports['__napi_register__BindingSourcemap_struct_105']?.()
-  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_106']?.()
+  __napiInstance.exports['__napi_register__BindingOutputChunk_impl_87']?.()
+  __napiInstance.exports['__napi_register__JsOutputChunk_struct_88']?.()
+  __napiInstance.exports['__napi_register__BindingOutputs_struct_89']?.()
+  __napiInstance.exports['__napi_register__BindingOutputs_impl_92']?.()
+  __napiInstance.exports['__napi_register__JsChangedOutputs_struct_93']?.()
+  __napiInstance.exports['__napi_register__PreRenderedChunk_struct_94']?.()
+  __napiInstance.exports['__napi_register__RenderedChunk_struct_95']?.()
+  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_96']?.()
+  __napiInstance.exports['__napi_register__AliasItem_struct_97']?.()
+  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_98']?.()
+  __napiInstance.exports['__napi_register__BindingSourcemap_struct_99']?.()
+  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_100']?.()
 }
 module.exports.BindingLog = __napiModule.exports.BindingLog
 module.exports.BindingModuleInfo = __napiModule.exports.BindingModuleInfo
@@ -170,7 +171,6 @@ module.exports.BindingOutputs = __napiModule.exports.BindingOutputs
 module.exports.BindingPluginContext = __napiModule.exports.BindingPluginContext
 module.exports.BindingTransformPluginContext = __napiModule.exports.BindingTransformPluginContext
 module.exports.Bundler = __napiModule.exports.Bundler
-module.exports.FinalBindingOutputs = __napiModule.exports.FinalBindingOutputs
 module.exports.ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
 module.exports.BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName
 module.exports.BindingHookSideEffects = __napiModule.exports.BindingHookSideEffects

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -2,105 +2,184 @@ import type {
   RolldownOutput,
   RolldownOutputAsset,
   RolldownOutputChunk,
-  SourceMap,
 } from '../types/rolldown-output'
 import type { OutputBundle } from '../types/output-bundle'
 import type {
   BindingOutputAsset,
   BindingOutputChunk,
   BindingOutputs,
-  FinalBindingOutputs,
+  JsChangedOutputs,
+  JsOutputAsset,
+  JsOutputChunk,
 } from '../binding'
 import {
   AssetSource,
   bindingAssetSource,
   transformAssetSource,
 } from './asset-source'
+import { bindingifySourcemap } from '../types/sourcemap'
 
 function transformToRollupOutputChunk(
-  chunk: BindingOutputChunk,
+  bindingChunk: BindingOutputChunk,
+  changed?: ChangedOutputs,
 ): RolldownOutputChunk {
-  return {
+  const chunk = {
     type: 'chunk',
     get code() {
-      return chunk.code
+      return bindingChunk.code
     },
-    set code(code: string) {
-      chunk.code = code
-    },
-    fileName: chunk.fileName,
-    name: chunk.name,
+    fileName: bindingChunk.fileName,
+    name: bindingChunk.name,
     get modules() {
       return Object.fromEntries(
-        Object.entries(chunk.modules).map(([key, _]) => [key, {}]),
+        Object.entries(bindingChunk.modules).map(([key, _]) => [key, {}]),
       )
     },
     get imports() {
-      return chunk.imports
-    },
-    set imports(imports: string[]) {
-      chunk.imports = imports
+      return bindingChunk.imports
     },
     get dynamicImports() {
-      return chunk.dynamicImports
+      return bindingChunk.dynamicImports
     },
-    exports: chunk.exports,
-    isEntry: chunk.isEntry,
-    facadeModuleId: chunk.facadeModuleId || null,
-    isDynamicEntry: chunk.isDynamicEntry,
+    exports: bindingChunk.exports,
+    isEntry: bindingChunk.isEntry,
+    facadeModuleId: bindingChunk.facadeModuleId || null,
+    isDynamicEntry: bindingChunk.isDynamicEntry,
     get moduleIds() {
-      return chunk.moduleIds
+      return bindingChunk.moduleIds
     },
     get map() {
-      return chunk.map ? JSON.parse(chunk.map) : null
+      return bindingChunk.map ? JSON.parse(bindingChunk.map) : null
     },
-    set map(map: SourceMap) {
-      chunk.map = JSON.stringify(map)
+    sourcemapFileName: bindingChunk.sourcemapFileName || null,
+    preliminaryFileName: bindingChunk.preliminaryFileName,
+  } as RolldownOutputChunk
+  const cache: Record<string | symbol, any> = {}
+  return new Proxy(chunk, {
+    get(target, p) {
+      if (p in cache) {
+        return cache[p]
+      }
+      return target[p as keyof RolldownOutputChunk]
     },
-    sourcemapFileName: chunk.sourcemapFileName || null,
-    preliminaryFileName: chunk.preliminaryFileName,
-  }
+    set(target, p, newValue): boolean {
+      cache[p] = newValue
+      changed?.updated.add(bindingChunk.fileName)
+      return true
+    },
+  })
 }
 
 function transformToRollupOutputAsset(
-  asset: BindingOutputAsset,
+  bindingAsset: BindingOutputAsset,
+  changed?: ChangedOutputs,
 ): RolldownOutputAsset {
-  return {
+  const asset = {
     type: 'asset',
-    fileName: asset.fileName,
-    originalFileName: asset.originalFileName || null,
+    fileName: bindingAsset.fileName,
+    originalFileName: bindingAsset.originalFileName || null,
     get source(): AssetSource {
-      return transformAssetSource(asset.source)
+      return transformAssetSource(bindingAsset.source)
     },
-    set source(source: AssetSource) {
-      asset.source = bindingAssetSource(source)
+    name: bindingAsset.name ?? undefined,
+  } as RolldownOutputAsset
+  const cache: Record<string | symbol, any> = {}
+  return new Proxy(asset, {
+    get(target, p) {
+      if (p in cache) {
+        return cache[p]
+      }
+      return target[p as keyof RolldownOutputAsset]
     },
-    name: asset.name ?? undefined,
-  }
+    set(target, p, newValue): boolean {
+      cache[p] = newValue
+      changed?.updated.add(bindingAsset.fileName)
+      return true
+    },
+  })
 }
 
 export function transformToRollupOutput(
-  output: BindingOutputs | FinalBindingOutputs,
+  output: BindingOutputs,
+  changed?: ChangedOutputs,
 ): RolldownOutput {
   const { chunks, assets } = output
   return {
     output: [
-      ...chunks.map(transformToRollupOutputChunk),
-      ...assets.map(transformToRollupOutputAsset),
+      ...chunks.map((chunk) => transformToRollupOutputChunk(chunk, changed)),
+      ...assets.map((asset) => transformToRollupOutputAsset(asset, changed)),
     ],
   } as RolldownOutput
 }
 
-export function transformToOutputBundle(output: BindingOutputs): OutputBundle {
+export function transformToOutputBundle(
+  output: BindingOutputs,
+  changed: ChangedOutputs,
+): OutputBundle {
   const bundle = Object.fromEntries(
-    transformToRollupOutput(output).output.map((item) => [item.fileName, item]),
+    transformToRollupOutput(output, changed).output.map((item) => [
+      item.fileName,
+      item,
+    ]),
   )
   return new Proxy(bundle, {
     deleteProperty(target, property): boolean {
       if (typeof property === 'string') {
-        output.delete(property)
+        changed.deleted.add(property)
       }
       return true
     },
   })
+}
+
+export interface ChangedOutputs {
+  updated: Set<string>
+  deleted: Set<string>
+}
+
+// TODO find a way only transfer the changed part to rust side.
+export function collectChangedBundle(
+  changed: ChangedOutputs,
+  bundle: OutputBundle,
+): JsChangedOutputs {
+  const assets: Array<JsOutputAsset> = []
+  const chunks: Array<JsOutputChunk> = []
+
+  for (const key in bundle) {
+    if (changed.updated.has(key)) {
+      const item = bundle[key]
+      if (item.type === 'asset') {
+        assets.push({
+          filename: item.fileName,
+          originalFileName: item.originalFileName || undefined,
+          source: bindingAssetSource(item.source),
+          name: item.name,
+        })
+      } else {
+        chunks.push({
+          code: item.code,
+          filename: item.fileName,
+          name: item.name,
+          isEntry: item.isEntry,
+          exports: item.exports,
+          modules: Object.fromEntries(
+            Object.entries(item.modules).map(([key, _]) => [key, {}]),
+          ),
+          imports: item.imports,
+          dynamicImports: item.dynamicImports,
+          facadeModuleId: item.facadeModuleId || undefined,
+          isDynamicEntry: item.isDynamicEntry,
+          moduleIds: item.moduleIds,
+          map: bindingifySourcemap(item.map),
+          sourcemapFilename: item.sourcemapFileName || undefined,
+          preliminaryFilename: item.preliminaryFileName,
+        })
+      }
+    }
+  }
+  return {
+    assets,
+    chunks,
+    deleted: Array.from(changed.deleted),
+  }
 }

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -146,35 +146,36 @@ export function collectChangedBundle(
   const chunks: Array<JsOutputChunk> = []
 
   for (const key in bundle) {
-    if (changed.updated.has(key)) {
-      const item = bundle[key]
-      if (item.type === 'asset') {
-        assets.push({
-          filename: item.fileName,
-          originalFileName: item.originalFileName || undefined,
-          source: bindingAssetSource(item.source),
-          name: item.name,
-        })
-      } else {
-        chunks.push({
-          code: item.code,
-          filename: item.fileName,
-          name: item.name,
-          isEntry: item.isEntry,
-          exports: item.exports,
-          modules: Object.fromEntries(
-            Object.entries(item.modules).map(([key, _]) => [key, {}]),
-          ),
-          imports: item.imports,
-          dynamicImports: item.dynamicImports,
-          facadeModuleId: item.facadeModuleId || undefined,
-          isDynamicEntry: item.isDynamicEntry,
-          moduleIds: item.moduleIds,
-          map: bindingifySourcemap(item.map),
-          sourcemapFilename: item.sourcemapFileName || undefined,
-          preliminaryFilename: item.preliminaryFileName,
-        })
-      }
+    if (changed.deleted.has(key) || !changed.updated.has(key)) {
+      continue
+    }
+    const item = bundle[key]
+    if (item.type === 'asset') {
+      assets.push({
+        filename: item.fileName,
+        originalFileName: item.originalFileName || undefined,
+        source: bindingAssetSource(item.source),
+        name: item.name,
+      })
+    } else {
+      chunks.push({
+        code: item.code,
+        filename: item.fileName,
+        name: item.name,
+        isEntry: item.isEntry,
+        exports: item.exports,
+        modules: Object.fromEntries(
+          Object.entries(item.modules).map(([key, _]) => [key, {}]),
+        ),
+        imports: item.imports,
+        dynamicImports: item.dynamicImports,
+        facadeModuleId: item.facadeModuleId || undefined,
+        isDynamicEntry: item.isDynamicEntry,
+        moduleIds: item.moduleIds,
+        map: bindingifySourcemap(item.map),
+        sourcemapFilename: item.sourcemapFileName || undefined,
+        preliminaryFilename: item.preliminaryFileName,
+      })
     }
   }
   return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

### Pervious Implment

It has larger overhead with  transfer the larger data from rust side to js side, so https://github.com/rolldown/rolldown/pull/696 make the `BindingOutputChunk` fields lazily.

But it is difficult to mutate `BindingOutputs` from js side, here using unsafe code `std::mem::transmute` to make`&mut OutputChunk` static. It could be work, but it is caused some memory issue at rolldown-vite worker test and vitepress.

### The pr implement

Consider avoid  larger overhead with  transfer the larger data from rust side to js side, here also keep logic of `BindingOutputChunk` fields lazily. Here only change `&mut OutputChunk` to `OutputChunk`, it is from clone. So the rust side has two `OutputChunk`. 
Because the  `BindingOutputChunk`  take the `OutputChunk` ownership to js side, here couldn't directly use it after js side changed it. So here collect the changed data at js side, then transfer the data to rust side, the rust side merge the changed data to original `OutputChunk`.

> I have try to avoid clone using `BindingOutputs` owner `UniqueArc<OutputChunk>` and `BindingOutputChunk` owner `WeakRef<OutputChunk>`, make it could be mutated at rust side, but it is failed with mutate operation at rolldown-vite, I'm not find reason about it, but the idea also is bad for the pr implement, it also could be panic..... The pr implement also could be remove `FinalBindingOutputs` bindings, it is a good way to avoid it.
>  Maybe we could using the idea to avoid clone and the mutate operation using the pr implement.

The disadvantage is here need to transfer data from js side to rust side, the user maybe only changed one fileds, the pr implement need to pass all fields to rust side, it also has space that can be optimized. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
