### PR TITLE
chore: add step to check for minimum node version during setup

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,6 +7,7 @@ _default:
     just --list -u
 
 setup:
+    just check-setup-prerequisites
     # Rust related setup
     cargo install cargo-binstall
     cargo binstall taplo-cli cargo-insta cargo-deny cargo-shear -y
@@ -148,3 +149,5 @@ bump packages *args:
 changelog:
     pnpm conventional-changelog --preset angular --i CHANGELOG.md --same-file --pkg=./packages/rolldown/package.json
 
+check-setup-prerequisites:
+    node ./scripts/misc/setup-prerequisites/node.js

--- a/scripts/misc/setup-prerequisites/node.js
+++ b/scripts/misc/setup-prerequisites/node.js
@@ -1,6 +1,10 @@
-const MIN_MAJOR_VERSION = 20
-const MIN_MINOR_VERSION = 14
-const MIN_PATCH_VERSION = 0
+import { readFileSync } from 'node:fs'
+
+const nodeVersion = readFileSync('.node-version', 'utf8').trim()
+
+const [MIN_MAJOR_VERSION, MIN_MINOR_VERSION, MIN_PATCH_VERSION] = nodeVersion
+  .split('.')
+  .map(Number)
 
 const [major, minor, patch] = process.versions.node.split('.').map(Number)
 

--- a/scripts/misc/setup-prerequisites/node.js
+++ b/scripts/misc/setup-prerequisites/node.js
@@ -1,0 +1,17 @@
+const MIN_MAJOR_VERSION = 20
+const MIN_MINOR_VERSION = 14
+const MIN_PATCH_VERSION = 0
+
+const [major, minor, patch] = process.versions.node.split('.').map(Number)
+
+if (
+  major < MIN_MAJOR_VERSION ||
+  (major === MIN_MAJOR_VERSION && minor < MIN_MINOR_VERSION) ||
+  (major === MIN_MAJOR_VERSION &&
+    minor === MIN_MINOR_VERSION &&
+    patch < MIN_PATCH_VERSION)
+) {
+  throw new Error(
+    `Node.js version must be at least ${MIN_MAJOR_VERSION}.${MIN_MINOR_VERSION}.${MIN_PATCH_VERSION}`,
+  )
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Using a NodeJS version less than what is in the .node-version file gives a cryptic error, see screenshot below

<img width="859" alt="Screenshot 2024-10-12 at 10 57 21 AM" src="https://github.com/user-attachments/assets/4e27e7ef-0453-4039-9aed-8f1c6c6c9260">

This PR adds a check if the user has the minimum required version installed

When minimum version is not installed, the script errors out early

<img width="739" alt="Screenshot 2024-10-12 at 10 56 41 AM" src="https://github.com/user-attachments/assets/8b3be929-1e53-4c71-b621-c366ce969488">


When the installed version is above the minimum, the script works as expected

<img width="755" alt="Screenshot 2024-10-12 at 10 57 50 AM" src="https://github.com/user-attachments/assets/fd87f3c4-7968-4ce7-93b8-67f2b048c554">

 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
