### PR TITLE
refactor(css): replace `lightningcss` with `css-module-lexer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "css-module-lexer"
+version = "0.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3cb070d213f1295804b62e861ba5d05435497591212a55826af6d54b2447c8"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,6 +2441,7 @@ dependencies = [
  "anyhow",
  "append-only-vec",
  "arcstr",
+ "css-module-lexer",
  "daachorse",
  "dashmap 6.1.0",
  "dunce",
@@ -2441,7 +2451,6 @@ dependencies = [
  "insta",
  "itertools 0.13.0",
  "itoa",
- "lightningcss",
  "memchr",
  "notify",
  "oxc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ single_match      = "allow"
 single_match_else = "allow"
 
 [workspace.dependencies]
+css-module-lexer                        = "0.0.14"
 rolldown                                = { version = "0.1.0", path = "./crates/rolldown" }
 rolldown_common                         = { version = "0.1.0", path = "./crates/rolldown_common" }
 rolldown_ecmascript                     = { version = "0.1.0", path = "./crates/rolldown_ecmascript" }
@@ -104,7 +105,6 @@ rolldown_testing                        = { version = "0.1.0", path = "./crates/
 rolldown_testing_config                 = { version = "0.1.0", path = "./crates/rolldown_testing_config" }
 rolldown_tracing                        = { version = "0.1.0", path = "./crates/rolldown_tracing" }
 rolldown_utils                          = { version = "0.1.0", path = "./crates/rolldown_utils" }
-
 
 anyhow              = "1.0.86"
 append-only-vec     = { version = "0.1.5" }

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 anyhow                   = { workspace = true }
 append-only-vec          = { workspace = true }
 arcstr                   = { workspace = true }
+css-module-lexer         = { workspace = true }
 daachorse                = { workspace = true }
 dashmap                  = { workspace = true }
 dunce                    = { workspace = true }
@@ -25,7 +26,6 @@ futures                  = { workspace = true }
 indexmap                 = { workspace = true }
 itertools                = { workspace = true }
 itoa                     = { workspace = true }
-lightningcss             = { workspace = true, features = ["into_owned", "visitor"] }
 memchr                   = { workspace = true }
 notify                   = { workspace = true }
 oxc                      = { workspace = true }

--- a/crates/rolldown/src/css/mod.rs
+++ b/crates/rolldown/src/css/mod.rs
@@ -1,13 +1,7 @@
 pub mod css_generator;
 
-use std::convert::Infallible;
-
 use arcstr::ArcStr;
-use lightningcss::{
-  stylesheet::{ParserOptions, StyleSheet},
-  visit_types,
-  visitor::{Visit, VisitTypes, Visitor},
-};
+
 use oxc::{
   index::{Idx, IndexVec},
   semantic::SymbolId,
@@ -17,47 +11,27 @@ use rolldown_common::{
 };
 
 pub fn create_css_view(
-  id: String,
+  _id: &str,
   source: &ArcStr,
-) -> anyhow::Result<(CssView, IndexVec<ImportRecordIdx, RawImportRecord>)> {
-  let options = ParserOptions { filename: id, ..Default::default() };
-  let mut stylesheet =
-    StyleSheet::parse(source, options).map_err(lightningcss::error::Error::into_owned)?;
-  let mut scanner = CssAstScanner::default();
+) -> (CssView, IndexVec<ImportRecordIdx, RawImportRecord>) {
+  let (lexed_deps, _warnings) =
+    css_module_lexer::collect_dependencies(source, css_module_lexer::Mode::Css);
 
-  stylesheet.visit(&mut scanner)?;
+  let mut dependencies: IndexVec<ImportRecordIdx, RawImportRecord> = IndexVec::default();
 
-  Ok((
-    CssView { source: source.clone(), import_records: IndexVec::default() },
-    scanner.dependencies,
-  ))
-}
-
-#[derive(Default)]
-pub struct CssAstScanner {
-  pub dependencies: IndexVec<ImportRecordIdx, RawImportRecord>,
-}
-
-impl<'i> Visitor<'i> for CssAstScanner {
-  type Error = Infallible;
-
-  fn visit_types(&self) -> VisitTypes {
-    visit_types!(URLS | RULES)
-  }
-
-  fn visit_rule(&mut self, rule: &mut lightningcss::rules::CssRule<'i>) -> Result<(), Self::Error> {
-    match rule {
-      lightningcss::rules::CssRule::Import(import_rule) => {
-        self.dependencies.push(RawImportRecord::new(
-          import_rule.url.to_string().into(),
+  for lexed_dep in lexed_deps {
+    match lexed_dep {
+      css_module_lexer::Dependency::Import { request, range, .. } => {
+        dependencies.push(RawImportRecord::new(
+          request.into(),
           ImportKind::AtImport,
-          // FIXME: this is meaningless for CSS's at import
           SymbolRef::from((ModuleIdx::from_raw(0), SymbolId::from_usize(0))),
-          0,
+          range.start,
         ));
       }
       _ => {}
     }
-    Ok(())
   }
+
+  (CssView { source: source.clone(), import_records: IndexVec::default() }, dependencies)
 }

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -144,7 +144,7 @@ impl ModuleTask {
       let css_source: ArcStr = source.try_into_string()?.into();
       // FIXME: This makes creating `EcmaView` rely on creating `CssView` first, while they should be done in parallel.
       source = StrOrBytes::Str(String::new());
-      let create_ret = create_css_view(stable_id.clone(), &css_source)?;
+      let create_ret = create_css_view(&stable_id, &css_source);
       raw_import_records = create_ret.1;
       Some(create_ret.0)
     } else {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Lightningcss doesn't expose `Span` or similar things, so we so far use `css-module-lexer` for just making it work.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
