### PR TITLE
fix: `eslint/no-unsafe-optional-chaining` violation

### DIFF
--- a/packages/rolldown/src/cli/arguments/index.ts
+++ b/packages/rolldown/src/cli/arguments/index.ts
@@ -96,7 +96,7 @@ export function parseCliArguments() {
         })
       } else if (type === 'object' && typeof option.value === 'string') {
         const [key, value] = option.value
-          ?.split(',')
+          .split(',')
           .map((x) => x.split('='))[0]
         if (!values[option.name]) {
           Object.defineProperty(values, option.name, {

--- a/packages/rolldown/src/cli/arguments/index.ts
+++ b/packages/rolldown/src/cli/arguments/index.ts
@@ -95,9 +95,7 @@ export function parseCliArguments() {
           writable: true,
         })
       } else if (type === 'object' && typeof option.value === 'string') {
-        const [key, value] = option.value
-          .split(',')
-          .map((x) => x.split('='))[0]
+        const [key, value] = option.value.split(',').map((x) => x.split('='))[0]
         if (!values[option.name]) {
           Object.defineProperty(values, option.name, {
             value: {},


### PR DESCRIPTION
### Description

Fixes a violation of `eslint/no-unsafe-optional-chaining` caught by oxlint. This is part of an ongoing effort to keep our ecosystem CI green. Thank you for using oxlint ⚓ 