### PR TITLE
feat: export jsx related options

### DIFF
--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -123,6 +123,7 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
     checks: raw_options.checks.unwrap_or_default(),
     // https://github.com/evanw/esbuild/blob/d34e79e2a998c21bb71d57b92b0017ca11756912/internal/bundler/bundler.go#L2767
     profiler_names: raw_options.profiler_names.unwrap_or(!raw_options.minify.unwrap_or(false)),
+    jsx: raw_options.jsx,
   };
 
   NormalizeOptionsReturn { options: normalized, resolve_options: raw_resolve }

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -63,6 +63,9 @@ impl PreProcessEcmaAst {
           }
           OxcParseType::Ts => {}
         }
+        if let Some(jsx) = &bundle_options.jsx {
+          transformer_options.react = jsx.clone();
+        }
 
         Transformer::new(fields.allocator, path, fields.source, trivias, transformer_options)
           .build_with_symbols_and_scopes(symbols, scopes, fields.program)

--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -1,5 +1,5 @@
 // cSpell:disable
-
+use oxc_transform_napi::transform::JsxOptions;
 use std::collections::HashMap;
 
 use crate::types::{
@@ -13,10 +13,10 @@ use serde::Deserialize;
 use self::{binding_input_item::BindingInputItem, binding_resolve_options::BindingResolveOptions};
 
 use super::plugin::BindingPluginOrParallelJsPluginPlaceholder;
-
 mod binding_experimental_options;
 pub mod binding_inject_import;
 mod binding_input_item;
+// mod binding_jsx_options;
 mod binding_resolve_options;
 mod treeshake;
 
@@ -82,6 +82,9 @@ pub struct BindingInputOptions {
   pub inject: Option<Vec<BindingInjectImport>>,
   pub experimental: Option<binding_experimental_options::BindingExperimentalOptions>,
   pub profiler_names: Option<bool>,
+  #[serde(skip_deserializing)]
+  #[derivative(Debug = "ignore")]
+  pub jsx: Option<JsxOptions>,
 }
 
 pub type BindingOnLog = Option<JsCallback<(String, BindingLog), ()>>;

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -201,6 +201,7 @@ pub fn normalize_binding_options(
     }),
     checks: None,
     profiler_names: input_options.profiler_names,
+    jsx: input_options.jsx.map(|inner| inner.into()),
   };
 
   #[cfg(not(target_family = "wasm"))]

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -201,7 +201,7 @@ pub fn normalize_binding_options(
     }),
     checks: None,
     profiler_names: input_options.profiler_names,
-    jsx: input_options.jsx.map(|inner| inner.into()),
+    jsx: input_options.jsx.map(Into::into),
   };
 
   #[cfg(not(target_family = "wasm"))]

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -1,3 +1,4 @@
+use oxc::transformer::JsxOptions;
 use rolldown_utils::indexmap::FxIndexMap;
 use std::{collections::HashMap, fmt::Debug, path::PathBuf};
 use types::advanced_chunks_options::AdvancedChunksOptions;
@@ -134,6 +135,8 @@ pub struct BundlerOptions {
   pub inline_dynamic_imports: Option<bool>,
   pub advanced_chunks: Option<AdvancedChunksOptions>,
   pub checks: Option<ChecksOptions>,
+  #[cfg_attr(feature = "deserialize_bundler_options", serde(default), schemars(skip))]
+  pub jsx: Option<JsxOptions>,
 }
 
 #[cfg(feature = "deserialize_bundler_options")]

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use oxc::transformer::InjectGlobalVariablesConfig;
+use oxc::transformer::{InjectGlobalVariablesConfig, JsxOptions};
 use rustc_hash::FxHashMap;
 
 use super::advanced_chunks_options::AdvancedChunksOptions;
@@ -63,6 +63,7 @@ pub struct NormalizedBundlerOptions {
   pub advanced_chunks: Option<AdvancedChunksOptions>,
   pub checks: ChecksOptions,
   pub profiler_names: bool,
+  pub jsx: Option<JsxOptions>,
 }
 
 pub type SharedNormalizedBundlerOptions = Arc<NormalizedBundlerOptions>;

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -759,3 +759,4 @@ export interface TypeScriptOptions {
    */
   rewriteImportExtensions?: 'rewrite' | 'remove' | boolean
 }
+

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -233,6 +233,7 @@ export interface BindingInputOptions {
   inject?: Array<BindingInjectImportNamed | BindingInjectImportNamespace>
   experimental?: BindingExperimentalOptions
   profilerNames?: boolean
+  jsx?: JsxOptions
 }
 
 export interface BindingJsonPluginConfig {

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -8,6 +8,7 @@ import type {
   ExternalOption,
   InputOption,
   InputOptions,
+  JsxOptions,
 } from './options/input-options'
 import type { ModuleFormat, OutputOptions } from './options/output-options'
 import type { RolldownOptions } from './types/rolldown-options'
@@ -101,6 +102,7 @@ export type {
   ExistingRawSourceMap,
   SourceMapInput,
   OutputBundle,
+  JsxOptions,
 }
 
 // Exports for compatibility

--- a/packages/rolldown/src/options/bindingify-input-options.ts
+++ b/packages/rolldown/src/options/bindingify-input-options.ts
@@ -129,6 +129,7 @@ export function bindingifyInputOptions(
       disableLiveBindings: options.experimental?.disableLiveBindings,
     },
     profilerNames: options?.profilerNames,
+    jsx: bindingifyJsx(options.jsx),
   }
 }
 
@@ -163,5 +164,26 @@ function bindingifyInput(
     return Object.entries(input).map((value) => {
       return { name: value[0], import: value[1] }
     })
+  }
+}
+
+function bindingifyJsx(
+  input: NormalizedInputOptions['jsx'],
+): BindingInputOptions['jsx'] {
+  if (input) {
+    const mode = input.mode ?? 'classic'
+    return {
+      runtime: mode,
+      importSource:
+        mode === 'classic'
+          ? input.importSource
+          : mode === 'automatic'
+            ? input.jsxImportSource
+            : undefined,
+      pragma: input.factory,
+      pragmaFrag: input.fragment,
+      development: input.development,
+      refresh: input.refresh,
+    }
   }
 }

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -40,6 +40,30 @@ const moduleTypesSchema = z.record(
     .or(z.literal('empty')),
 )
 
+const jsxOptionsSchema = z.strictObject({
+  mode: z
+    .literal('classic')
+    .or(z.literal('automatic'))
+    .describe('Jsx transformation mode')
+    .optional(), // The rollup preserve is not supported at now
+  factory: z.string().describe('Jsx element transformation').optional(),
+  fragment: z.string().describe('Jsx fragment transformation').optional(),
+  importSource: z
+    .string()
+    .describe('Import the factory of element and fragment if mode is classic')
+    .optional(),
+  jsxImportSource: z
+    .string()
+    .describe('Import the factory of element and fragment if mode is automatic')
+    .optional(),
+  refresh: z.boolean().describe('React refresh transformation').optional(),
+  development: z
+    .boolean()
+    .describe('Development specific information')
+    .optional(),
+  // The rollup preset is not supported at now
+})
+
 export const inputOptionsSchema = z.strictObject({
   input: inputOptionSchema.optional(),
   plugins: zodExt.phantom<RolldownPluginRec>().array().optional(),
@@ -108,6 +132,7 @@ export const inputOptionsSchema = z.strictObject({
   define: z.record(z.string()).describe('define global variables').optional(),
   inject: z.record(z.string().or(z.tuple([z.string(), z.string()]))).optional(),
   profilerNames: z.boolean().optional(),
+  jsx: jsxOptionsSchema.optional(),
 })
 
 export const inputCliOptionsSchema = inputOptionsSchema
@@ -173,3 +198,5 @@ export type InputOptions = Omit<
 > &
   OverwriteInputOptionsWithDoc
 export type ExternalOption = z.infer<typeof externalSchema>
+
+export type JsxOptions = z.infer<typeof jsxOptionsSchema>

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -34,6 +34,13 @@ OPTIONS
   --inject <inject>           Inject import statements on demand.
   --inline-dynamic-imports    Inline dynamic imports.
   --intro <intro>             Code to insert the top of the bundled file (inside the wrapper function).
+  --jsx.development           Development specific information.
+  --jsx.factory <jsx.factory> Jsx element transformation.
+  --jsx.fragment <jsx.fragment>Jsx fragment transformation.
+  --jsx.import-source <jsx.import-source>Import the factory of element and fragment if mode is classic.
+  --jsx.jsx-import-source <jsx.jsx-import-source>Import the factory of element and fragment if mode is automatic.
+  --jsx.mode <jsx.mode>       Jsx transformation mode.
+  --jsx.refresh               React refresh transformation.
   --log-level <log-level>     Log level (silent, info, debug, warn).
   --module-types <types>      Module types for customized extensions.
   --no-external-live-bindings Use external live bindings.

--- a/packages/rolldown/tests/fixtures/jsx/mode/automatic/_config.ts
+++ b/packages/rolldown/tests/fixtures/jsx/mode/automatic/_config.ts
@@ -1,0 +1,17 @@
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+import { getOutputChunk } from '@tests/utils'
+
+export default defineTest({
+  config: {
+    input: 'main.jsx',
+    jsx: {
+      mode: 'automatic',
+    },
+    external: ['react/jsx-runtime'],
+  },
+  afterTest: (output) => {
+    const chunk = getOutputChunk(output)[0]
+    expect(chunk.code.includes('react/jsx-runtime')).toBe(true)
+  },
+})

--- a/packages/rolldown/tests/fixtures/jsx/mode/automatic/main.jsx
+++ b/packages/rolldown/tests/fixtures/jsx/mode/automatic/main.jsx
@@ -1,0 +1,1 @@
+console.log(<div>test</div>)

--- a/packages/rolldown/tests/fixtures/jsx/mode/classic/_config.ts
+++ b/packages/rolldown/tests/fixtures/jsx/mode/classic/_config.ts
@@ -1,0 +1,17 @@
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+import { getOutputChunk } from '@tests/utils'
+
+export default defineTest({
+  config: {
+    input: 'main.jsx',
+    jsx: {
+      mode: 'classic',
+    },
+    external: ['react'],
+  },
+  afterTest: (output) => {
+    const chunk = getOutputChunk(output)[0]
+    expect(chunk.code.includes('React.createElement')).toBe(true)
+  },
+})

--- a/packages/rolldown/tests/fixtures/jsx/mode/classic/main.jsx
+++ b/packages/rolldown/tests/fixtures/jsx/mode/classic/main.jsx
@@ -1,0 +1,1 @@
+console.log(<div>test</div>)

--- a/packages/rolldown/tests/fixtures/jsx/refresh/_config.ts
+++ b/packages/rolldown/tests/fixtures/jsx/refresh/_config.ts
@@ -1,0 +1,17 @@
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+import { getOutputChunk } from '@tests/utils'
+
+export default defineTest({
+  config: {
+    input: 'main.jsx',
+    jsx: {
+      refresh: true,
+    },
+    external: ['react'],
+  },
+  afterTest: (output) => {
+    const chunk = getOutputChunk(output)[0]
+    expect(chunk.code.includes('$RefreshReg$')).toBe(true)
+  },
+})

--- a/packages/rolldown/tests/fixtures/jsx/refresh/main.jsx
+++ b/packages/rolldown/tests/fixtures/jsx/refresh/main.jsx
@@ -1,0 +1,3 @@
+function App() {
+  return <div>test</div>
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The pr intend to export the  jsx related options. The rust side using oxc options to avoid duplicate code. The node side as compatible as possible to rollup jsx options, ref https://rollupjs.org/configuration-options/#jsx.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
