### PR TITLE
refactor(rust): add `SymbolNameRefToken` instead of abusing `SymbolRef`

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -14,7 +14,7 @@ use oxc::transformer::ReplaceGlobalDefinesConfig;
 use rolldown_common::side_effects::{DeterminedSideEffects, HookSideEffects};
 use rolldown_common::{
   EntryPoint, EntryPointKind, ExternalModule, ImportKind, ImportRecordIdx, ImporterRecord, Module,
-  ModuleIdx, ModuleTable, ResolvedId, SymbolRefDb,
+  ModuleIdx, ModuleTable, ResolvedId, SymbolNameRefToken, SymbolRefDb,
 };
 use rolldown_error::{BuildDiagnostic, DiagnosableResult};
 use rolldown_fs::OsFileSystem;
@@ -171,16 +171,11 @@ impl ModuleLoader {
               },
             }
           };
-          // FIXME: ---- This is hack and should be removed
-          let symbol_ref = self
-            .symbol_ref_db
-            .create_symbol(idx, legitimize_identifier_name(&resolved_id.id).into());
-          // --- End of hack
           let ext = ExternalModule::new(
             idx,
             ArcStr::clone(&resolved_id.id),
             external_module_side_effects,
-            symbol_ref,
+            SymbolNameRefToken::new(idx, legitimize_identifier_name(&resolved_id.id).into()),
           );
           self.intermediate_normal_modules.modules[idx] = Some(ext.into());
           idx

--- a/crates/rolldown/src/utils/chunk/collect_render_chunk_imports.rs
+++ b/crates/rolldown/src/utils/chunk/collect_render_chunk_imports.rs
@@ -1,5 +1,5 @@
 use arcstr::ArcStr;
-use rolldown_common::{Chunk, Specifier, SymbolRef};
+use rolldown_common::{Chunk, Specifier, SymbolNameRefToken};
 
 use crate::{chunk_graph::ChunkGraph, stages::link_stage::LinkStageOutput};
 
@@ -16,7 +16,7 @@ pub enum RenderImportDeclarationSpecifier {
 
 pub struct ExternalRenderImportStmt {
   pub path: ArcStr,
-  pub symbol_ref: SymbolRef, // for cjs __toESM(require('foo')) and iife get deconflict name
+  pub binding_name_token: SymbolNameRefToken, // for cjs __toESM(require('foo')) and iife get deconflict name
   pub specifiers: RenderImportDeclarationSpecifier,
 }
 
@@ -109,7 +109,7 @@ pub fn collect_render_chunk_imports(
             render_import_stmts.push(RenderImportStmt::ExternalRenderImportStmt(
               ExternalRenderImportStmt {
                 path: importee.name.clone(),
-                symbol_ref: importee.symbol_ref,
+                binding_name_token: importee.name_token_for_external_binding.clone(),
                 specifiers: RenderImportDeclarationSpecifier::ImportStarSpecifier(
                   alias.as_str().into(),
                 ),
@@ -132,7 +132,7 @@ pub fn collect_render_chunk_imports(
       render_import_stmts.push(RenderImportStmt::ExternalRenderImportStmt(
         ExternalRenderImportStmt {
           path: importee.name.clone(),
-          symbol_ref: importee.symbol_ref,
+          binding_name_token: importee.name_token_for_external_binding.clone(),
           specifiers: RenderImportDeclarationSpecifier::ImportSpecifier(specifiers),
         },
       ));

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -21,7 +21,7 @@ pub fn deconflict_chunk_symbols(
       .iter()
       .filter_map(|(idx, _)| link_output.module_table.modules[*idx].as_external())
       .for_each(|external_module| {
-        renamer.add_top_level_symbol(external_module.symbol_ref);
+        renamer.add_root_symbol_name_ref_token(&external_module.name_token_for_external_binding);
       });
   }
 
@@ -83,5 +83,5 @@ pub fn deconflict_chunk_symbols(
   // rename non-top-level names
   renamer.rename_non_top_level_symbol(&chunk.modules, &link_output.module_table.modules);
 
-  chunk.canonical_names = renamer.into_canonical_names();
+  (chunk.canonical_names, chunk.canonical_name_by_token) = renamer.into_canonical_names();
 }

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -1,7 +1,7 @@
 // cSpell:disable
 use crate::{
   ChunkIdx, ChunkKind, FilenameTemplate, ModuleIdx, NamedImport, NormalizedBundlerOptions,
-  RollupPreRenderedChunk, SymbolRef,
+  RollupPreRenderedChunk, SymbolNameRefToken, SymbolRef,
 };
 pub mod chunk_table;
 pub mod types;
@@ -28,6 +28,7 @@ pub struct Chunk {
   pub css_preliminary_filename: Option<PreliminaryFilename>,
   pub css_absolute_preliminary_filename: Option<String>,
   pub canonical_names: FxHashMap<SymbolRef, Rstr>,
+  pub canonical_name_by_token: FxHashMap<SymbolNameRefToken, Rstr>,
   // Sorted by Module#stable_id of modules in the chunk
   pub cross_chunk_imports: Vec<ChunkIdx>,
   pub cross_chunk_dynamic_imports: Vec<ChunkIdx>,

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -98,6 +98,7 @@ pub use crate::{
   types::source_mutation::SourceMutation,
   types::stmt_info::{DebugStmtInfoForTreeShaking, StmtInfo, StmtInfoIdx, StmtInfos},
   types::str_or_bytes::StrOrBytes,
+  types::symbol_name_ref_token::SymbolNameRefToken,
   types::symbol_or_member_expr_ref::SymbolOrMemberExprRef,
   types::symbol_ref::SymbolRef,
   types::symbol_ref_db::{SymbolRefDb, SymbolRefDbForModule, SymbolRefFlags},

--- a/crates/rolldown_common/src/module/external_module.rs
+++ b/crates/rolldown_common/src/module/external_module.rs
@@ -1,5 +1,5 @@
 use crate::side_effects::DeterminedSideEffects;
-use crate::{ImportRecordIdx, ModuleIdx, ResolvedImportRecord, SymbolRef};
+use crate::{ImportRecordIdx, ModuleIdx, ResolvedImportRecord, SymbolNameRefToken};
 use arcstr::ArcStr;
 use oxc::index::IndexVec;
 
@@ -8,7 +8,7 @@ pub struct ExternalModule {
   pub idx: ModuleIdx,
   pub exec_order: u32,
   // Used for iife format to inject symbol and deconflict.
-  pub symbol_ref: SymbolRef,
+  pub name_token_for_external_binding: SymbolNameRefToken,
   pub name: ArcStr,
   pub import_records: IndexVec<ImportRecordIdx, ResolvedImportRecord>,
   pub side_effects: DeterminedSideEffects,
@@ -19,12 +19,12 @@ impl ExternalModule {
     idx: ModuleIdx,
     module_id: ArcStr,
     side_effects: DeterminedSideEffects,
-    symbol_ref: SymbolRef,
+    name_token_for_external_binding: SymbolNameRefToken,
   ) -> Self {
     Self {
       idx,
       exec_order: u32::MAX,
-      symbol_ref,
+      name_token_for_external_binding,
       name: module_id,
       import_records: IndexVec::default(),
       side_effects,

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -37,6 +37,7 @@ pub mod side_effects;
 pub mod source_mutation;
 pub mod stmt_info;
 pub mod str_or_bytes;
+pub mod symbol_name_ref_token;
 pub mod symbol_or_member_expr_ref;
 pub mod symbol_ref;
 pub mod symbol_ref_db;

--- a/crates/rolldown_common/src/types/symbol_name_ref_token.rs
+++ b/crates/rolldown_common/src/types/symbol_name_ref_token.rs
@@ -1,0 +1,24 @@
+use arcstr::ArcStr;
+
+use crate::ModuleIdx;
+
+/// A token that represents a symbol name in a module.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct SymbolNameRefToken {
+  owner: ModuleIdx,
+  value: ArcStr,
+}
+
+impl SymbolNameRefToken {
+  pub fn new(owner: ModuleIdx, value: ArcStr) -> Self {
+    Self { owner, value }
+  }
+
+  pub fn owner(&self) -> ModuleIdx {
+    self.owner
+  }
+
+  pub fn value(&self) -> &ArcStr {
+    &self.value
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
