### PR TITLE
feat: add css module type to output options

### DIFF
--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -37,7 +37,8 @@ const moduleTypesSchema = z.record(
     .or(z.literal('base64'))
     .or(z.literal('dataurl'))
     .or(z.literal('binary'))
-    .or(z.literal('empty')),
+    .or(z.literal('empty'))
+    .or(z.literal('css')),
 )
 
 export const inputOptionsSchema = z.strictObject({


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://github.com/rolldown/rolldown/pull/2247 Added CSS module type support
This PR adds it to the schema

Related to https://github.com/rolldown/rolldown/issues/2329

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
