### PR TITLE
chore: compat rollup watch:false

### DIFF
--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -146,7 +146,7 @@ export const inputOptionsSchema = z.strictObject({
   inject: z.record(z.string().or(z.tuple([z.string(), z.string()]))).optional(),
   profilerNames: z.boolean().optional(),
   jsx: jsxOptionsSchema.optional(),
-  watch: watchOptionsSchema.optional(),
+  watch: watchOptionsSchema.or(z.literal(false)).optional(),
 })
 
 export const inputCliOptionsSchema = inputOptionsSchema


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Because the rolldown options is not support array of configurations, the `watch` `false` is nothing to do at now, here only make typing compat to rollup. ref https://rollupjs.org/configuration-options/#watch

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
