### PR TITLE
refactor: only run composing js plugin test at plugin test

### DIFF
--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -38,7 +38,13 @@ function main() {
     })
   }
 
-  for (const [testConfigPath, testConfig] of Object.entries(testConfigPaths)) {
+  const pluginTestConfigPaths = import.meta.glob<TestConfig>(
+    './fixtures/plugin/**/_config.ts',
+    { import: 'default', eager: true },
+  )
+  for (const [testConfigPath, testConfig] of Object.entries(
+    pluginTestConfigPaths,
+  )) {
     const dirPath = nodePath.dirname(testConfigPath)
     const testName = dirPath.replace('./fixtures/', '')
 

--- a/packages/rolldown/tests/fixtures/output/extend/false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/extend/false/_config.ts
@@ -1,11 +1,7 @@
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 
-let isComposingJs = false
 export default defineTest({
-  beforeTest(testKind) {
-    isComposingJs = testKind === 'compose-js-plugin'
-  },
   config: {
     output: {
       exports: 'named',
@@ -15,21 +11,7 @@ export default defineTest({
     },
   },
   afterTest: (output) => {
-    isComposingJs
-      ? expect(output.output[0].code).toMatchInlineSnapshot(`
-        "var module = (function(exports) {
-
-        "use strict";
-
-        //#region main.js
-        const main = "main";
-
-        //#endregion
-        exports.main = main
-        return exports;
-        })({});"
-      `)
-      : expect(output.output[0].code).toMatchInlineSnapshot(`
+    expect(output.output[0].code).toMatchInlineSnapshot(`
         "var module = (function(exports) {
 
         "use strict";

--- a/packages/rolldown/tests/fixtures/output/extend/true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/extend/true/_config.ts
@@ -1,10 +1,7 @@
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
-let isComposingJs = false
+
 export default defineTest({
-  beforeTest(testKind) {
-    isComposingJs = testKind === 'compose-js-plugin'
-  },
   config: {
     output: {
       exports: 'named',
@@ -14,20 +11,7 @@ export default defineTest({
     },
   },
   afterTest: (output) => {
-    isComposingJs
-      ? expect(output.output[0].code).toMatchInlineSnapshot(`
-        "(function(exports) {
-
-        "use strict";
-
-        //#region main.js
-        const main = "main";
-
-        //#endregion
-        exports.main = main
-        })(this.module = this.module || {});"
-      `)
-      : expect(output.output[0].code).toMatchInlineSnapshot(`
+    expect(output.output[0].code).toMatchInlineSnapshot(`
         "(function(exports) {
 
         "use strict";

--- a/packages/rolldown/tests/fixtures/output/extend/undefined/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/extend/undefined/_config.ts
@@ -1,10 +1,7 @@
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
-let isComposingJs = false
+
 export default defineTest({
-  beforeTest(testKind) {
-    isComposingJs = testKind === 'compose-js-plugin'
-  },
   config: {
     output: {
       exports: 'named',
@@ -13,21 +10,7 @@ export default defineTest({
     },
   },
   afterTest: (output) => {
-    isComposingJs
-      ? expect(output.output[0].code).toMatchInlineSnapshot(`
-        "var module = (function(exports) {
-
-        "use strict";
-
-        //#region main.js
-        const main = "main";
-
-        //#endregion
-        exports.main = main
-        return exports;
-        })({});"
-      `)
-      : expect(output.output[0].code).toMatchInlineSnapshot(`
+    expect(output.output[0].code).toMatchInlineSnapshot(`
         "var module = (function(exports) {
 
         "use strict";

--- a/packages/rolldown/tests/fixtures/output/format/iife/exports/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/format/iife/exports/_config.ts
@@ -1,10 +1,7 @@
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
-let isComposingJs = false
+
 export default defineTest({
-  beforeTest(testKind) {
-    isComposingJs = testKind === 'compose-js-plugin'
-  },
   config: {
     external: /node:path/,
     output: {
@@ -13,28 +10,7 @@ export default defineTest({
     },
   },
   afterTest: (output) => {
-    isComposingJs
-      ? expect(output.output[0].code).toMatchInlineSnapshot(`
-      "(function(exports, node_path) {
-
-      "use strict";
-      Object.defineProperty(exports, '__esModule', { value: true });
-      const { join } = node_path;
-
-      //#region main.js
-      var main_default = join;
-
-      //#endregion
-      Object.defineProperty(exports, 'default', {
-        enumerable: true,
-        get: function () {
-          return main_default;
-        }
-      });
-      return exports;
-      })({}, node_path);"
-    `)
-      : expect(output.output[0].code).toMatchInlineSnapshot(`
+    expect(output.output[0].code).toMatchInlineSnapshot(`
       "(function(exports, node_path) {
 
       "use strict";

--- a/packages/rolldown/tests/fixtures/output/format/iife/globals/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/format/iife/globals/_config.ts
@@ -1,11 +1,7 @@
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 
-let isComposingJs = false
 export default defineTest({
-  beforeTest(testKind) {
-    isComposingJs = testKind === 'compose-js-plugin'
-  },
   config: {
     external: /node:path/,
     output: {
@@ -17,21 +13,7 @@ export default defineTest({
     },
   },
   afterTest: (output) => {
-    isComposingJs
-      ? expect(output.output[0].code).toMatchInlineSnapshot(`
-      "var module = (function(node_path) {
-
-      "use strict";
-      const { join } = node_path;
-
-      //#region main.js
-      var main_default = join;
-
-      //#endregion
-      return main_default;
-      })(path);"
-    `)
-      : expect(output.output[0].code).toMatchInlineSnapshot(`
+    expect(output.output[0].code).toMatchInlineSnapshot(`
       "var module = (function(node_path) {
 
       "use strict";

--- a/packages/rolldown/tests/fixtures/output/hashFileNames/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/hashFileNames/_config.ts
@@ -7,11 +7,7 @@ import { RenderedChunk } from 'rolldown'
 
 const renderChunks: RenderedChunk[] = []
 
-let isComposingJs = false
 export default defineTest({
-  beforeTest(testKind) {
-    isComposingJs = testKind === 'compose-js-plugin'
-  },
   config: {
     input: ['main.js', 'entry.js'],
     output: {
@@ -57,82 +53,40 @@ export default defineTest({
     for (const chunk of chunks) {
       switch (chunk.facadeModuleId) {
         case path.join(__dirname, 'main.js'):
-          isComposingJs
-            ? expect(chunk.preliminaryFileName).toMatchInlineSnapshot(
-                `"main-!~{000}~.js"`,
-              )
-            : expect(chunk.preliminaryFileName).toMatchInlineSnapshot(
-                `"main-!~{000}~.js"`,
-              )
-          isComposingJs
-            ? expect(chunk.fileName).toMatchInlineSnapshot(`"main-iDGj1RBK.js"`)
-            : expect(chunk.fileName).toMatchInlineSnapshot(`"main-iDGj1RBK.js"`)
-          isComposingJs
-            ? expect(chunk.imports).toMatchInlineSnapshot(
-                `
+          expect(chunk.preliminaryFileName).toMatchInlineSnapshot(
+            `"main-!~{000}~.js"`,
+          )
+          expect(chunk.fileName).toMatchInlineSnapshot(`"main-iDGj1RBK.js"`)
+          expect(chunk.imports).toMatchInlineSnapshot(
+            `
             [
               "shared-GrsQyLjj.js",
             ]
           `,
-              )
-            : expect(chunk.imports).toMatchInlineSnapshot(
-                `
-            [
-              "shared-GrsQyLjj.js",
-            ]
-          `,
-              )
-          isComposingJs
-            ? expect(chunk.dynamicImports).toMatchInlineSnapshot(
-                `
+          )
+          expect(chunk.dynamicImports).toMatchInlineSnapshot(
+            `
           [
             "dynamic-NChw5g6Q.js",
           ]
                     `,
-              )
-            : expect(chunk.dynamicImports).toMatchInlineSnapshot(
-                `
-          [
-            "dynamic-NChw5g6Q.js",
-          ]
-                    `,
-              )
+          )
           break
 
         case path.join(__dirname, 'entry.js'):
-          isComposingJs
-            ? expect(chunk.fileName).toMatchInlineSnapshot(
-                `"entry-A_XCu9lS.js"`,
-              )
-            : expect(chunk.fileName).toMatchInlineSnapshot(
-                `"entry-A_XCu9lS.js"`,
-              )
-          isComposingJs
-            ? expect(chunk.imports).toMatchInlineSnapshot(
-                `
+          expect(chunk.fileName).toMatchInlineSnapshot(`"entry-A_XCu9lS.js"`)
+          expect(chunk.imports).toMatchInlineSnapshot(
+            `
             [
               "shared-GrsQyLjj.js",
             ]
           `,
-              )
-            : expect(chunk.imports).toMatchInlineSnapshot(
-                `
-            [
-              "shared-GrsQyLjj.js",
-            ]
-          `,
-              )
+          )
           expect(chunk.dynamicImports).toStrictEqual([])
           break
 
         case path.join(__dirname, 'dynamic.js'):
-          isComposingJs
-            ? expect(chunk.fileName).toMatchInlineSnapshot(
-                `"dynamic-NChw5g6Q.js"`,
-              )
-            : expect(chunk.fileName).toMatchInlineSnapshot(
-                `"dynamic-NChw5g6Q.js"`,
-              )
+          expect(chunk.fileName).toMatchInlineSnapshot(`"dynamic-NChw5g6Q.js"`)
           break
 
         default:

--- a/packages/rolldown/tests/fixtures/output/sourcemap/true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap/true/_config.ts
@@ -2,11 +2,8 @@
 import { expect } from 'vitest'
 import { getOutputFileNames } from '@tests/utils'
 import { defineTest } from '@tests'
-let isComposingJs = false
+
 export default defineTest({
-  beforeTest(testKind) {
-    isComposingJs = testKind === 'compose-js-plugin'
-  },
   config: {
     input: ['main.js'],
     output: {
@@ -22,16 +19,10 @@ export default defineTest({
 
     if (output.output[1].type === 'asset') {
       const map = JSON.parse(output.output[1].source.toString())
-      isComposingJs
-        ? expect(map.file).toMatchInlineSnapshot(`"main.js"`)
-        : expect(map.file).toMatchInlineSnapshot(`"main.js"`)
-      isComposingJs
-        ? expect(map.mappings).toMatchInlineSnapshot(
-            `";;AAAA,MAAa,MAAM;;;;ACEnB,QAAQ,IAAI,IAAI"`,
-          )
-        : expect(map.mappings).toMatchInlineSnapshot(
-            `";;AAAA,MAAa,MAAM;;;;ACEnB,QAAQ,IAAI,IAAI"`,
-          )
+      expect(map.file).toMatch('main.js')
+      expect(map.mappings).toMatchInlineSnapshot(
+        `";;AAAA,MAAa,MAAM;;;;ACEnB,QAAQ,IAAI,IAAI"`,
+      )
     }
   },
 })

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve/_config.ts
@@ -3,11 +3,8 @@ import { expect, vi } from 'vitest'
 import nodePath from 'node:path'
 
 const fn = vi.fn()
-let isComposingJs = false
+
 export default defineTest({
-  beforeTest(testKind) {
-    isComposingJs = testKind === 'compose-js-plugin'
-  },
   config: {
     plugins: [
       {
@@ -17,18 +14,8 @@ export default defineTest({
           if (!ret) {
             throw new Error('resolve failed')
           }
-          const { id, ...props } = ret
-          isComposingJs
-            ? expect(props).toMatchInlineSnapshot(`
-            {
-              "external": false,
-            }
-          `)
-            : expect(props).toMatchInlineSnapshot(`
-            {
-              "external": false,
-            }
-          `)
+          const { id, external } = ret
+          expect(external).toBe(false)
           expect(id).toEqual(nodePath.join(import.meta.dirname, 'main.js'))
           fn()
         },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `ComposingJsPlugin` test should run at plugin test, it will affect other snapshot test, the pr fixed it.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
