### PR TITLE
refactor(error): remove `UnhandleableResult`

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -22,7 +22,7 @@ use rolldown_common::{
   Specifier, StmtInfo, StmtInfos, SymbolRef, SymbolRefDbForModule, SymbolRefFlags,
 };
 use rolldown_ecmascript::{BindingIdentifierExt, BindingPatternExt};
-use rolldown_error::{BuildDiagnostic, CjsExportSpan, UnhandleableResult};
+use rolldown_error::{BuildDiagnostic, BuildResult, CjsExportSpan};
 use rolldown_rstr::Rstr;
 use rolldown_utils::ecma_script::legitimize_identifier_name;
 use rolldown_utils::path_ext::PathExt;
@@ -138,7 +138,7 @@ impl<'me> AstScanner<'me> {
     }
   }
 
-  pub fn scan(mut self, program: &Program<'_>) -> UnhandleableResult<ScanResult> {
+  pub fn scan(mut self, program: &Program<'_>) -> BuildResult<ScanResult> {
     self.visit_program(program);
     let mut exports_kind = ExportsKind::None;
 
@@ -203,7 +203,7 @@ impl<'me> AstScanner<'me> {
         if !scanned_symbols_in_root_scope.remove(&symbol_ref) {
           return Err(anyhow::format_err!(
             "Symbol ({name:?}, {symbol_id:?}, {scope_id:?}) is declared in the top-level scope but doesn't get scanned by the scanner",
-          ));
+          ))?;
         }
       }
       // if !scanned_top_level_symbols.is_empty() {

--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -157,7 +157,12 @@ impl Bundler {
     let mut link_stage_output = match self.try_build().await? {
       Ok(v) => v,
       Err(errors) => {
-        return Ok(BundleOutput { assets: vec![], warnings: vec![], errors, watch_files: vec![] })
+        return Ok(BundleOutput {
+          assets: vec![],
+          warnings: vec![],
+          errors: errors.into_vec(),
+          watch_files: vec![],
+        })
       }
     };
 

--- a/crates/rolldown/src/ecmascript/format/umd.rs
+++ b/crates/rolldown/src/ecmascript/format/umd.rs
@@ -164,7 +164,7 @@ fn render_iife_export(
   named_exports: bool,
 ) -> BuildResult<String> {
   if ctx.options.name.as_ref().map_or(true, String::is_empty) {
-    return Err(vec![BuildDiagnostic::missing_name_option_for_umd_export()]);
+    return Err(vec![BuildDiagnostic::missing_name_option_for_umd_export()].into());
   }
   let (stmt, namespace) = generate_namespace_definition(
     ctx.options.name.as_ref().expect("should have name"),

--- a/crates/rolldown/src/ecmascript/format/utils/namespace.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/namespace.rs
@@ -120,7 +120,7 @@ pub fn generate_identifier(
   } else {
     // This behavior is aligned with Rollup. If using `output.extend: true`, this error won't be triggered.
     let name = ArcStr::from(name);
-    Err(vec![BuildDiagnostic::illegal_identifier_as_name(name)])
+    Err(vec![BuildDiagnostic::illegal_identifier_as_name(name)].into())
   }
 }
 

--- a/crates/rolldown/src/module_loader/mod.rs
+++ b/crates/rolldown/src/module_loader/mod.rs
@@ -12,5 +12,4 @@ pub enum Msg {
   NormalModuleDone(NormalModuleTaskResult),
   RuntimeNormalModuleDone(RuntimeModuleTaskResult),
   BuildErrors(Vec<BuildDiagnostic>),
-  Panics(anyhow::Error),
 }

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -299,26 +299,12 @@ impl ModuleLoader {
         Msg::BuildErrors(e) => {
           errors.extend(e);
         }
-        // Expect cast to u32, since we are not going to have more than 2^32 tasks, or the
-        // `remaining` will overflow
-        #[allow(clippy::cast_possible_truncation)]
-        Msg::Panics(err) => {
-          // `self.remaining -1` for the panic task it self
-          self.remaining -= 1;
-          // gracefully shutdown all working thread, only receive and do not spawn
-          while self.remaining > 0 {
-            let mut task = Vec::with_capacity(self.remaining as usize);
-            let received = self.rx.recv_many(&mut task, self.remaining as usize).await;
-            self.remaining -= received as u32;
-          }
-          return Err(err);
-        }
       }
       self.remaining -= 1;
     }
 
     if !errors.is_empty() {
-      return Ok(Err(errors));
+      return Ok(Err(errors.into()));
     }
 
     let modules: IndexVec<ModuleIdx, Module> = self

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -8,7 +8,6 @@ use rolldown_utils::{ecma_script::legitimize_identifier_name, path_ext::PathExt}
 use std::sync::Arc;
 use sugar_path::SugarPath;
 
-use anyhow::Result;
 use rolldown_common::{
   ImportKind, ImportRecordIdx, ModuleDefFormat, ModuleId, ModuleIdx, ModuleType, NormalModule,
   RawImportRecord, ResolvedId, StrOrBytes,
@@ -68,14 +67,14 @@ impl ModuleTask {
           self.ctx.tx.send(Msg::BuildErrors(self.errors)).await.expect("Send should not fail");
         }
       }
-      Err(err) => {
-        self.ctx.tx.send(Msg::Panics(err)).await.expect("Send should not fail");
+      Err(errs) => {
+        self.ctx.tx.send(Msg::BuildErrors(errs.into_vec())).await.expect("Send should not fail");
       }
     }
   }
 
   #[expect(clippy::too_many_lines)]
-  async fn run_inner(&mut self) -> Result<()> {
+  async fn run_inner(&mut self) -> BuildResult<()> {
     let mut hook_side_effects = self.resolved_id.side_effects.take();
     let mut sourcemap_chain = vec![];
     let mut warnings = vec![];
@@ -131,7 +130,7 @@ impl ModuleTask {
       return Err(anyhow::format_err!(
         "`{:?}` is not specified module type,  rolldown can't handle this asset correctly. Please use the load/transform hook to transform the resource",
         self.resolved_id.id
-      ));
+      ))?;
     };
 
     let repr_name = self.resolved_id.id.as_path().representative_file_name().into_owned();
@@ -172,13 +171,7 @@ impl ModuleTask {
       ast,
       symbols,
       raw_import_records: ecma_raw_import_records,
-    } = match ret {
-      Ok(ret) => ret,
-      Err(errs) => {
-        self.errors.extend(errs);
-        return Ok(());
-      }
-    };
+    } = ret;
 
     if !matches!(module_type, ModuleType::Css) {
       raw_import_records = ecma_raw_import_records;
@@ -194,7 +187,7 @@ impl ModuleTask {
     {
       Ok(deps) => deps,
       Err(errs) => {
-        self.errors.extend(errs);
+        self.errors.extend(errs.into_vec());
         return Ok(());
       }
     };
@@ -367,7 +360,7 @@ impl ModuleTask {
     if build_errors.is_empty() {
       Ok(Ok(ret))
     } else {
-      Ok(Err(build_errors))
+      Ok(Err(build_errors.into()))
     }
   }
 }

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -6,7 +6,7 @@ use rolldown_common::{
   ModuleDefFormat, ModuleId, ModuleIdx, ModuleType, NormalModule, SymbolRef, SymbolRefDbForModule,
 };
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
-use rolldown_error::{BuildDiagnostic, BuildResult, UnhandleableResult};
+use rolldown_error::{BuildDiagnostic, BuildResult};
 use rustc_hash::FxHashSet;
 
 use super::Msg;
@@ -45,12 +45,12 @@ impl RuntimeModuleTask {
   pub fn run(mut self) -> anyhow::Result<()> {
     let source: ArcStr = arcstr::literal!(include_str!("../runtime/runtime-without-comments.js"));
 
-    let ecma_ast_result = self.make_ecma_ast(RUNTIME_MODULE_ID, &source)?;
+    let ecma_ast_result = self.make_ecma_ast(RUNTIME_MODULE_ID, &source);
 
     let ecma_ast_result = match ecma_ast_result {
       Ok(ecma_ast_result) => ecma_ast_result,
       Err(errs) => {
-        self.errors.extend(errs);
+        self.errors.extend(errs.into_vec());
         return Ok(());
       }
     };
@@ -135,21 +135,11 @@ impl RuntimeModuleTask {
     Ok(())
   }
 
-  fn make_ecma_ast(
-    &mut self,
-    filename: &str,
-    source: &ArcStr,
-  ) -> UnhandleableResult<BuildResult<MakeEcmaAstResult>> {
+  fn make_ecma_ast(&mut self, filename: &str, source: &ArcStr) -> BuildResult<MakeEcmaAstResult> {
     let source_type = SourceType::default();
 
-    let parse_result = EcmaCompiler::parse(filename, source, source_type);
+    let mut ast = EcmaCompiler::parse(filename, source, source_type)?;
 
-    let mut ast = match parse_result {
-      Ok(ast) => ast,
-      Err(errs) => {
-        return Ok(Err(errs));
-      }
-    };
     tweak_ast_for_scanning(&mut ast, false);
 
     let (mut symbol_table, scope) = ast.make_symbol_table_and_scope_tree();
@@ -172,6 +162,6 @@ impl RuntimeModuleTask {
     let namespace_object_ref = scanner.namespace_object_ref;
     let scan_result = scanner.scan(ast.program())?;
 
-    Ok(Ok(MakeEcmaAstResult { ast, ast_scope, scan_result, namespace_object_ref }))
+    Ok(MakeEcmaAstResult { ast, ast_scope, scan_result, namespace_object_ref })
   }
 }

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -228,7 +228,7 @@ impl<'a> GenerateStage<'a> {
         });
         warnings.extend(generate_output.warnings);
       }
-      Err(e) => errors.extend(e),
+      Err(e) => errors.extend(e.into_vec()),
     });
 
     index_chunk_to_assets.iter_mut().for_each(|assets| {

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -153,7 +153,7 @@ impl ScanStage {
     }
 
     if !errors.is_empty() {
-      return Ok(Err(errors));
+      return Ok(Err(errors.into()));
     }
 
     Ok(Ok(ret))

--- a/crates/rolldown/src/utils/chunk/determine_export_mode.rs
+++ b/crates/rolldown/src/utils/chunk/determine_export_mode.rs
@@ -15,21 +15,27 @@ pub fn determine_export_mode(
     OutputExports::Named => Ok(OutputExports::Named),
     OutputExports::Default => {
       if exports.len() != 1 || exports[0].0.as_str() != "default" {
-        return Err(vec![BuildDiagnostic::invalid_export_option(
-          "default".into(),
-          module.stable_id.as_str().into(),
-          exports.iter().map(|(name, _)| name.as_str().into()).collect(),
-        )]);
+        return Err(
+          vec![BuildDiagnostic::invalid_export_option(
+            "default".into(),
+            module.stable_id.as_str().into(),
+            exports.iter().map(|(name, _)| name.as_str().into()).collect(),
+          )]
+          .into(),
+        );
       }
       Ok(OutputExports::Default)
     }
     OutputExports::None => {
       if !exports.is_empty() {
-        return Err(vec![BuildDiagnostic::invalid_export_option(
-          "none".into(),
-          module.stable_id.as_str().into(),
-          exports.iter().map(|(name, _)| name.as_str().into()).collect(),
-        )]);
+        return Err(
+          vec![BuildDiagnostic::invalid_export_option(
+            "none".into(),
+            module.stable_id.as_str().into(),
+            exports.iter().map(|(name, _)| name.as_str().into()).collect(),
+          )]
+          .into(),
+        );
       }
       Ok(OutputExports::None)
     }

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -119,7 +119,7 @@ impl Bundler {
         self.handle_warnings(output.warnings).await;
       }
       Err(errs) => {
-        return Err(self.handle_errors(errs));
+        return Err(self.handle_errors(errs.into_vec()));
       }
     }
 

--- a/crates/rolldown_error/src/build_error/mod.rs
+++ b/crates/rolldown_error/src/build_error/mod.rs
@@ -1,10 +1,12 @@
 pub mod error_constructors;
 pub mod severity;
-use std::fmt::Display;
+use std::{
+  fmt::Display,
+  ops::{Deref, DerefMut},
+};
 
 use crate::{
-  diagnostic::Diagnostic, events::BuildEvent, type_aliases::BatchedBuildDiagnostic,
-  types::diagnostic_options::DiagnosticOptions,
+  diagnostic::Diagnostic, events::BuildEvent, types::diagnostic_options::DiagnosticOptions,
 };
 
 use self::severity::Severity;
@@ -80,6 +82,51 @@ impl From<napi::Error> for BuildDiagnostic {
 
 impl From<BuildDiagnostic> for BatchedBuildDiagnostic {
   fn from(v: BuildDiagnostic) -> Self {
-    vec![v]
+    Self::new(vec![v])
+  }
+}
+
+impl From<anyhow::Error> for BatchedBuildDiagnostic {
+  fn from(err: anyhow::Error) -> Self {
+    Self::new(vec![BuildDiagnostic::unhandleable_error(err)])
+  }
+}
+
+impl From<Vec<BuildDiagnostic>> for BatchedBuildDiagnostic {
+  fn from(v: Vec<BuildDiagnostic>) -> Self {
+    Self::new(v)
+  }
+}
+
+impl From<anyhow::Error> for BuildDiagnostic {
+  fn from(err: anyhow::Error) -> Self {
+    BuildDiagnostic::unhandleable_error(err)
+  }
+}
+
+#[derive(Debug, Default)]
+pub struct BatchedBuildDiagnostic(Vec<BuildDiagnostic>);
+
+impl BatchedBuildDiagnostic {
+  pub fn new(vec: Vec<BuildDiagnostic>) -> Self {
+    Self(vec)
+  }
+
+  pub fn into_vec(self) -> Vec<BuildDiagnostic> {
+    self.0
+  }
+}
+
+impl Deref for BatchedBuildDiagnostic {
+  type Target = Vec<BuildDiagnostic>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for BatchedBuildDiagnostic {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
   }
 }

--- a/crates/rolldown_error/src/lib.rs
+++ b/crates/rolldown_error/src/lib.rs
@@ -15,7 +15,7 @@ pub use crate::{
   events::invalid_option::InvalidOptionTypes,
   events::unloadable_dependency::UnloadableDependencyContext,
   events::DiagnosableArcstr,
-  type_aliases::{BuildResult, UnaryBuildResult, UnhandleableResult},
+  type_aliases::{BuildResult, UnaryBuildResult},
   types::diagnostic_options::DiagnosticOptions,
 };
 

--- a/crates/rolldown_error/src/type_aliases.rs
+++ b/crates/rolldown_error/src/type_aliases.rs
@@ -1,17 +1,5 @@
-use crate::BuildDiagnostic;
-
-pub type BatchedBuildDiagnostic = Vec<BuildDiagnostic>;
+use crate::{build_error::BatchedBuildDiagnostic, BuildDiagnostic};
 
 pub type UnaryBuildResult<T> = std::result::Result<T, BuildDiagnostic>;
 
 pub type BuildResult<T> = Result<T, BatchedBuildDiagnostic>;
-
-/// This is used for returning errors that are not expected to be handled by rolldown. Such as
-/// - Error of converting u64 to usize in a platform that usize is 32-bit.
-/// - ...
-///   Handling such errors is meaningless.
-///
-/// Notice:
-/// - We might mark some errors as unhandleable for faster development, but we should convert them
-///   to `BuildDiagnostic` to provide better error messages to users.
-pub type UnhandleableResult<T> = anyhow::Result<T>;

--- a/crates/rolldown_error/src/types/result_ext.rs
+++ b/crates/rolldown_error/src/types/result_ext.rs
@@ -8,9 +8,9 @@ pub trait ResultExt<Val> {
   fn map_error_to_unhandleable(self) -> UnaryBuildResult<Val>;
 }
 
-impl<Val, Err> ResultExt<Val> for Result<Val, Err>
+impl<Val, Err_> ResultExt<Val> for Result<Val, Err_>
 where
-  Err: StdError + Send + Sync + 'static,
+  Err_: StdError + Send + Sync + 'static,
 {
   fn map_error_to_unhandleable(self) -> UnaryBuildResult<Val> {
     self.map_err(|err| {

--- a/packages/rolldown/tests/plugin/plugin.test.ts
+++ b/packages/rolldown/tests/plugin/plugin.test.ts
@@ -122,9 +122,7 @@ test('call transformContext error', async () => {
     })
     await build.write({})
   } catch (error: any) {
-    expect(error.message).toMatchInlineSnapshot(
-      `"Rolldown internal error: GenericFailure, RollupError: transform hook error"`,
-    )
+    expect(error.message).toMatchInlineSnapshot(`"Build failed"`)
   }
 })
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We used to try to strongly distinguish two kinds of error.

- Program error, not related to bundling, such as convert u64 to usize in u32-based platform
- Business error, such as importing a file which doesn't exist while bundling.

After a long time practicing, these two kinds of error aren't show much differences for writhing web bundler. In fact, they share a same and important characteristic which is to break the control flow.

So we don't need to make strong distinguish anymore and they are all treated and handled by the same error mechanism in rolldown.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
