### PR TITLE
fix: RollupPreRenderedChunk#exports

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -80,16 +80,6 @@ impl<'a> GenerateStage<'a> {
       })
       .collect::<Vec<_>>();
 
-    index_imports_from_other_chunks.iter_enumerated().for_each(|(chunk_id, importee_map)| {
-      chunk_graph.chunk_table[chunk_id].require_binding_names_for_other_chunks = importee_map
-        .keys()
-        .map(|id| {
-          let chunk = &chunk_graph.chunk_table[*id];
-          (*id, chunk.name.clone().unwrap().to_string())
-        })
-        .collect();
-    });
-
     let index_sorted_imports_from_other_chunks = index_imports_from_other_chunks
       .into_iter_enumerated()
       .collect_vec()

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -57,12 +57,18 @@ impl<'a> GenerateStage<'a> {
   pub async fn generate(&mut self) -> Result<BundleOutput> {
     let mut chunk_graph = self.generate_chunks().await?;
 
-    self.generate_chunk_name_and_preliminary_filenames(&mut chunk_graph).await?;
-
     self.compute_cross_chunk_links(&mut chunk_graph);
 
+    let index_chunk_id_to_name =
+      self.generate_chunk_name_and_preliminary_filenames(&mut chunk_graph).await?;
+
     chunk_graph.chunk_table.par_iter_mut().for_each(|chunk| {
-      deconflict_chunk_symbols(chunk, self.link_output, &self.options.format);
+      deconflict_chunk_symbols(
+        chunk,
+        self.link_output,
+        &self.options.format,
+        &index_chunk_id_to_name,
+      );
     });
 
     let ast_table_iter = self.link_output.ast_table.par_iter_mut();
@@ -127,9 +133,10 @@ impl<'a> GenerateStage<'a> {
   async fn generate_chunk_name_and_preliminary_filenames(
     &self,
     chunk_graph: &mut ChunkGraph,
-  ) -> anyhow::Result<()> {
+  ) -> anyhow::Result<FxHashMap<ChunkIdx, ArcStr>> {
     let modules = &self.link_output.module_table.modules;
 
+    let mut index_chunk_id_to_name = FxHashMap::default();
     let mut index_pre_generated_names: IndexVec<ChunkIdx, ArcStr> = chunk_graph
       .chunk_table
       .as_vec()
@@ -180,7 +187,7 @@ impl<'a> GenerateStage<'a> {
       let pre_generated_name = &mut index_pre_generated_names[*chunk_id];
       // Notice we didn't used deconflict name here, chunk names are allowed to be duplicated.
       chunk.name = Some(pre_generated_name.clone());
-
+      index_chunk_id_to_name.insert(*chunk_id, pre_generated_name.clone());
       let pre_rendered_chunk = generate_pre_rendered_chunk(chunk, self.link_output, self.options);
 
       let filename_template = chunk.filename_template(self.options, &pre_rendered_chunk).await?;
@@ -250,6 +257,6 @@ impl<'a> GenerateStage<'a> {
       chunk.css_preliminary_filename =
         Some(PreliminaryFilename::new(css_preliminary, css_hash_placeholder));
     }
-    Ok(())
+    Ok(index_chunk_id_to_name)
   }
 }

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/_config.json
@@ -1,0 +1,3 @@
+{
+  "snapshotOutputStats": true
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
@@ -1,0 +1,41 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## foo.js
+
+```js
+import { foo } from "./foo2.js";
+
+export { foo };
+```
+## foo2.js
+
+```js
+
+
+//#region foo.js
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo });
+const foo = 1;
+
+//#endregion
+export { foo, foo_exports };
+```
+## main.js
+
+```js
+import { foo_exports } from "./foo2.js";
+
+//#region main.js
+import("./foo.js");
+console.log(foo_exports);
+
+//#endregion
+```
+## Output Stats
+
+- foo.js, is_entry false, is_dynamic_entry true, exports ["foo"]
+- foo2.js, is_entry false, is_dynamic_entry false, exports ["foo", "foo_exports"]
+- main.js, is_entry true, is_dynamic_entry false, exports []

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/foo.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/foo.js
@@ -1,0 +1,1 @@
+export const foo = 1

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/main.js
@@ -1,0 +1,3 @@
+import * as fooNamespace from './foo.js';
+import('./foo.js')
+console.log(fooNamespace);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3866,6 +3866,12 @@ expression: output
 - dynamic-!~{004}~.js => dynamic-NChw5g6Q.js
 - share-!~{002}~.js => share-cLWtdHlT.js
 
+# tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file
+
+- main-!~{002}~.js => main-bFG4lmCL.js
+- foo-!~{003}~.js => foo-18TjqVsl.js
+- foo-!~{000}~.js => foo-9HeppbY4.js
+
 # tests/rolldown/code_splitting/ensure_side_effect_executed
 
 - entry_js-!~{000}~.js => entry_js-2jgRP-V5.js


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
close https://github.com/rolldown/rolldown/issues/2395

The reason is the `Chunk#exports_to_other_chunks`(at `compute_cross_chunk_links`) is not create at create `RollupPreRenderedChunk`(at `generate_chunk_name_and_preliminary_filenames`). So i moving the order to fix it.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
