### PR TITLE
fix: avoid watcher deadlock

### DIFF
--- a/crates/rolldown/src/watcher/watcher.rs
+++ b/crates/rolldown/src/watcher/watcher.rs
@@ -141,6 +141,8 @@ impl Watcher {
         }
       }
     }
+    // The inner mutex should be dropped to avoid deadlock with bundler lock at `Watcher::close`
+    std::mem::drop(inner);
     self.emitter.emit(WatcherEvent::Event, BundleEventKind::BundleEnd.into()).await?;
 
     self.running.store(false, Ordering::Relaxed);
@@ -158,6 +160,8 @@ impl Watcher {
     for path in self.watch_files.iter() {
       inner.unwatch(Path::new(path.as_str()))?;
     }
+    // The inner mutex should be dropped to avoid deadlock with bundler lock at `Watcher::run`
+    std::mem::drop(inner);
     // emit close event
     self.emitter.emit(WatcherEvent::Close, WatcherEventData::default()).await?;
     // call close watcher hook


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

close https://github.com/rolldown/rolldown/issues/2438#issuecomment-2434691950. The timeout is caused by deadlock.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
