### PR TITLE
chore(justfile): add `just run` command for running local build

### DIFF
--- a/justfile
+++ b/justfile
@@ -135,6 +135,10 @@ build target="native" mode="debug":
 _build-native-debug:
     just build native debug
 
+# `just build && just run` to run the local build
+run:
+    ./packages/rolldown/bin/cli.js
+
 # BENCHING
 
 bench-rust:

--- a/justfile
+++ b/justfile
@@ -137,7 +137,7 @@ _build-native-debug:
 
 # `just build && just run` to run the local build
 run:
-    ./packages/rolldown/bin/cli.js
+    pnpm run rolldown
 
 # BENCHING
 


### PR DESCRIPTION
I couldn't find a `run` command anywhere.