### PR TITLE
feat(json_plugin): add named_exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,7 +2649,6 @@ dependencies = [
 name = "rolldown_plugin_json"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "memchr",
  "regex",
  "rolldown_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,7 +2649,9 @@ dependencies = [
 name = "rolldown_plugin_json"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "memchr",
+ "regex",
  "rolldown_common",
  "rolldown_plugin",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,9 +2650,9 @@ name = "rolldown_plugin_json"
 version = "0.1.0"
 dependencies = [
  "memchr",
- "regex",
  "rolldown_common",
  "rolldown_plugin",
+ "rolldown_utils",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ itertools           = "0.13.0"
 itoa                = "1.0.11"
 json-strip-comments = "1.0.4"
 jsonschema          = { version = "0.26.0", default-features = false }
+lazy_static         = "1.5.0"
 lightningcss        = { version = "1.0.0-alpha.57" }
 memchr              = "2.7.2"
 mimalloc            = "0.1.42"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,6 @@ itertools           = "0.13.0"
 itoa                = "1.0.11"
 json-strip-comments = "1.0.4"
 jsonschema          = { version = "0.26.0", default-features = false }
-lazy_static         = "1.5.0"
 lightningcss        = { version = "1.0.0-alpha.57" }
 memchr              = "2.7.2"
 mimalloc            = "0.1.42"

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -93,6 +93,7 @@ pub struct BindingModulePreloadPolyfillPluginConfig {
 pub struct BindingJsonPluginConfig {
   pub stringify: Option<bool>,
   pub is_build: Option<bool>,
+  pub named_exports: Option<bool>,
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
@@ -377,6 +378,7 @@ impl TryFrom<BindingBuiltinPlugin> for Arc<dyn Pluginable> {
         Arc::new(JsonPlugin {
           stringify: config.stringify.unwrap_or_default(),
           is_build: config.is_build.unwrap_or_default(),
+          named_exports: config.named_exports.unwrap_or_default(),
         })
       }
       BindingBuiltinPluginName::BuildImportAnalysis => {

--- a/crates/rolldown_plugin_json/Cargo.toml
+++ b/crates/rolldown_plugin_json/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 memchr          = { workspace = true }
-regex           = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_utils  = { workspace = true }
 serde_json      = { workspace = true }

--- a/crates/rolldown_plugin_json/Cargo.toml
+++ b/crates/rolldown_plugin_json/Cargo.toml
@@ -15,7 +15,9 @@ doctest = false
 workspace = true
 
 [dependencies]
+lazy_static     = { workspace = true }
 memchr          = { workspace = true }
+regex           = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
 serde_json      = { workspace = true }

--- a/crates/rolldown_plugin_json/Cargo.toml
+++ b/crates/rolldown_plugin_json/Cargo.toml
@@ -15,7 +15,6 @@ doctest = false
 workspace = true
 
 [dependencies]
-lazy_static     = { workspace = true }
 memchr          = { workspace = true }
 regex           = { workspace = true }
 rolldown_common = { workspace = true }

--- a/crates/rolldown_plugin_json/src/lib.rs
+++ b/crates/rolldown_plugin_json/src/lib.rs
@@ -139,7 +139,7 @@ fn make_legal_identifier(ident: &str) -> String {
 
 fn to_esm(data: Value, named_exports: bool) -> String {
   if !named_exports || !data.is_object() {
-    return format!("export default {}", data);
+    return format!("export default {};\n", data);
   }
 
   let mut default_export_rows = vec![];

--- a/crates/rolldown_plugin_json/src/lib.rs
+++ b/crates/rolldown_plugin_json/src/lib.rs
@@ -107,7 +107,7 @@ fn to_esm(data: &Value, named_exports: bool) -> String {
   let mut default_export_rows = vec![];
   let mut named_export_code = String::new();
   for (key, value) in data.as_object().unwrap() {
-    if rolldown_utils::ecma_script::is_validate_assignee_identifier_name(key) {
+    if rolldown_utils::ecmascript::is_validate_assignee_identifier_name(key) {
       default_export_rows.push(Cow::Borrowed(key));
       named_export_code += &format!("export const {key} = {value};\n");
     } else {

--- a/crates/rolldown_plugin_json/src/lib.rs
+++ b/crates/rolldown_plugin_json/src/lib.rs
@@ -1,12 +1,29 @@
+use lazy_static::lazy_static;
 use rolldown_common::ModuleType;
 use rolldown_plugin::{HookTransformOutput, Plugin};
 use serde_json::Value;
 use std::borrow::Cow;
 
+const RESERVED_WORDS: &str =
+  "break case class catch const continue debugger default delete do else export extends finally for function if import in instanceof let new return super switch this throw try typeof var void while with yield enum await implements package protected static interface private public";
+const BUILTINS: &str =
+  "arguments Infinity NaN undefined null true false eval uneval isFinite isNaN parseFloat parseInt decodeURI decodeURIComponent encodeURI encodeURIComponent escape unescape Object Function Boolean Symbol Error EvalError InternalError RangeError ReferenceError SyntaxError TypeError URIError Number Math Date String RegExp Array Int8Array Uint8Array Uint8ClampedArray Int16Array Uint16Array Int32Array Uint32Array Float32Array Float64Array Map Set WeakMap WeakSet SIMD ArrayBuffer DataView JSON Promise Generator GeneratorFunction Reflect Proxy Intl";
+
+lazy_static! {
+  static ref FORBIDDEN_IDENTIFIERS: std::collections::HashSet<&'static str> = {
+    let mut set = std::collections::HashSet::from_iter(
+      RESERVED_WORDS.split_whitespace().chain(BUILTINS.split_whitespace()),
+    );
+    set.insert("");
+    set
+  };
+}
+
 #[derive(Debug, Default)]
 pub struct JsonPlugin {
   pub stringify: bool,
-  pub is_build: bool, // TODO: support namedExports in rolldown json https://github.com/rolldown/vite/blob/3bf86e3f715c952a032b476b60c8c869e9c50f3f/packages/vite/src/node/plugins/json.ts#L69-L69
+  pub is_build: bool,
+  pub named_exports: bool,
 }
 
 impl Plugin for JsonPlugin {
@@ -24,9 +41,9 @@ impl Plugin for JsonPlugin {
       return Ok(None);
     }
     let code = strip_bom(args.code);
+    let value = serde_json::from_str::<Value>(code)?;
     if self.stringify {
       let normalized_code = if self.is_build {
-        let value = serde_json::from_str::<Value>(code)?;
         let str = serde_json::to_string(&value)?;
         // TODO: perf: find better way than https://github.com/rolldown/vite/blob/3bf86e3f715c952a032b476b60c8c869e9c50f3f/packages/vite/src/node/plugins/json.ts#L55-L57
         let str = serde_json::to_string(&str)?;
@@ -40,8 +57,14 @@ impl Plugin for JsonPlugin {
         ..Default::default()
       }));
     }
-    // let default json handler to transform json
-    Ok(None)
+
+    let output = to_esm(value, self.named_exports);
+
+    return Ok(Some(HookTransformOutput {
+      code: Some(output),
+      module_type: Some(ModuleType::Js),
+      ..Default::default()
+    }));
   }
 }
 
@@ -92,9 +115,42 @@ fn is_special_query(ext: &str) -> bool {
   false
 }
 
+fn make_legal_identifier(ident: &str) -> String {
+  // convert hyphenated word to camel case
+  let hyphen_re = regex::Regex::new(r"-(\w)").unwrap();
+  let ident =
+    hyphen_re.replace_all(ident, |capture: &regex::Captures<'_>| capture[1].to_ascii_uppercase());
+  // convert invalid ch to underline
+  let invalid_chars_re = regex::Regex::new(r"[^$_a-zA-Z0-9]").unwrap();
+  let ident = invalid_chars_re.replace_all(&ident, "_");
+
+  ident.to_string()
+}
+
+fn to_esm(data: Value, named_exports: bool) -> String {
+  if !named_exports || !data.is_object() {
+    return format!("export default {}", data);
+  }
+
+  let mut default_export_rows = vec![];
+  let mut named_export_code = String::new();
+  for (key, value) in data.as_object().unwrap() {
+    if key == &make_legal_identifier(key) {
+      default_export_rows.push(Cow::Borrowed(key));
+      named_export_code += &format!("export const {key} = {value};\n");
+    } else {
+      default_export_rows.push(Cow::Owned(format!("\"{key}\": {value},\n",)));
+    }
+  }
+  let default_export_code: String = default_export_rows.iter().map(|s| s.as_str()).collect();
+  let default_export_code = format!("export default {{\n{default_export_code}\n}};\n");
+
+  format!("{named_export_code}{default_export_code}")
+}
+
 #[cfg(test)]
 mod test {
-  use crate::{is_json_ext, is_special_query};
+  use crate::{is_json_ext, is_special_query, to_esm};
 
   #[test]
   fn json_ext() {
@@ -115,5 +171,17 @@ mod test {
 
     assert!(!is_special_query("test?&woer"));
     assert!(!is_special_query("test?&sharedworker1"));
+  }
+
+  #[test]
+  fn to_esm_named_exports_object() {
+    let data = serde_json::json!({"name": "name"});
+    assert_eq!("export const name = \"name\";\nexport default {\nname\n};\n", to_esm(data, true));
+  }
+
+  #[test]
+  fn to_esm_named_exports_literal() {
+    let data = serde_json::json!(1);
+    assert_eq!("export default 1;\n", to_esm(data, true));
   }
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -350,6 +350,7 @@ export interface BindingInputOptions {
 export interface BindingJsonPluginConfig {
   stringify?: boolean
   isBuild?: boolean
+  namedExports?: boolean
 }
 
 export interface BindingJsonSourcemap {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/_config.ts
@@ -1,0 +1,15 @@
+import { jsonPlugin } from 'rolldown/experimental'
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    plugins: [
+      jsonPlugin({ stringify: false, isBuild: true, namedExports: true }),
+    ],
+  },
+  async afterTest(output) {
+    expect(output.output[0].code).toContain(`const name = "stringify";`)
+    await import('./assert.mjs')
+  },
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/assert.mjs
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import assert from 'node:assert'
+import { name, json } from './dist/main'
+
+assert(name === 'stringify')
+assert(name === json.name)

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/assert.mjs
@@ -4,3 +4,4 @@ import { name, json } from './dist/main'
 
 assert(name === 'stringify')
 assert(name === json.name)
+assert(json.const === true)

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/main.js
@@ -1,0 +1,3 @@
+import json, { name } from './package.json'
+
+export { name, json }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/package.json
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "stringify"
+}

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/package.json
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "stringify"
+  "name": "stringify",
+  "const": true
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Support `namedExports` for builtin json plugin.

### Impl

If `stringify` not set, transform the json to js object with the `named_exports` property.