### PR TITLE
fix: remove `__toCommonJS` if it is plain require

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -414,12 +414,16 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
                   if matches!(importee.exports_kind, ExportsKind::CommonJs) {
                     *expr = self.snippet.call_expr_expr(wrap_ref_name);
                   } else {
-                    let ns_name = self.canonical_name_for(importee.namespace_object_ref);
-                    let to_commonjs_ref_name = self.canonical_name_for_runtime("__toCommonJS");
-                    *expr = self.snippet.seq2_in_paren_expr(
-                      self.snippet.call_expr_expr(wrap_ref_name),
-                      self.snippet.call_expr_with_arg_expr(to_commonjs_ref_name, ns_name),
-                    );
+                    if rec.meta.contains(ImportRecordMeta::IS_REQUIRE_UNUSED) {
+                      *expr = self.snippet.call_expr_expr(wrap_ref_name);
+                    } else {
+                      let ns_name = self.canonical_name_for(importee.namespace_object_ref);
+                      let to_commonjs_ref_name = self.canonical_name_for_runtime("__toCommonJS");
+                      *expr = self.snippet.seq2_in_paren_expr(
+                        self.snippet.call_expr_expr(wrap_ref_name),
+                        self.snippet.call_expr_with_arg_expr(to_commonjs_ref_name, ns_name),
+                      );
+                    }
                   }
                 }
               }

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -413,15 +413,18 @@ impl<'a> LinkStage<'a> {
                       .push(importee_linking_info.wrapper_ref.unwrap().into());
                   }
                   WrapKind::Esm => {
-                    // something like `(init_foo(), toCommonJS(foo_exports))`
-                    // Reference to `init_foo`
+                    // convert require record into `(init_foo(), __toCommonJS(foo_exports))` if
+                    // `require('xxx)` is used, else convert it to `init_foo()`
                     stmt_info
                       .referenced_symbols
                       .push(importee_linking_info.wrapper_ref.unwrap().into());
-                    stmt_info
-                      .referenced_symbols
-                      .push(self.runtime.resolve_symbol("__toCommonJS").into());
                     stmt_info.referenced_symbols.push(importee.namespace_object_ref.into());
+
+                    if !rec.meta.contains(ImportRecordMeta::IS_REQUIRE_UNUSED) {
+                      stmt_info
+                        .referenced_symbols
+                        .push(self.runtime.resolve_symbol("__toCommonJS").into());
+                    }
                   }
                 },
                 ImportKind::DynamicImport => {

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -19,7 +20,7 @@ var init_index_module = __esm({ "node_modules/demo-pkg/index-module.js"() {
 
 //#endregion
 //#region src/require-demo-pkg.js
-init_index_module(), __toCommonJS(index_module_exports);
+init_index_module();
 
 //#endregion
 //#region src/entry.js

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/diff.md
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/diff.md
@@ -41,7 +41,7 @@ var init_index_module = __esm({ "node_modules/demo-pkg/index-module.js"() {
 
 //#endregion
 //#region src/require-demo-pkg.js
-init_index_module(), __toCommonJS(index_module_exports);
+init_index_module();
 
 //#endregion
 //#region src/entry.js
@@ -74,7 +74,7 @@ console.log("unused import");
  });
 -init_index_main();
 -init_index_main();
-+(init_index_module(), __toCommonJS(index_module_exports));
++init_index_module();
 +init_index_module();
  console.log("unused import");
 

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -19,7 +20,7 @@ var init_index_module = __esm({ "node_modules/demo-pkg/index-module.js"() {
 
 //#endregion
 //#region src/require-demo-pkg.js
-init_index_module(), __toCommonJS(index_module_exports);
+init_index_module();
 
 //#endregion
 //#region src/entry.js

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/diff.md
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/diff.md
@@ -38,7 +38,7 @@ var init_index_module = __esm({ "node_modules/demo-pkg/index-module.js"() {
 
 //#endregion
 //#region src/require-demo-pkg.js
-init_index_module(), __toCommonJS(index_module_exports);
+init_index_module();
 
 //#endregion
 //#region src/entry.js
@@ -70,7 +70,7 @@ console.log("unused import");
      }
  });
 -init_index_main();
-+(init_index_module(), __toCommonJS(index_module_exports));
++init_index_module();
 +init_index_module();
  console.log("unused import");
 

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
@@ -20,7 +20,7 @@ var init_demo_pkg = __esm({ "node_modules/demo-pkg/index.js"() {
 
 //#endregion
 //#region src/entry.js
-init_demo_pkg(), __toCommonJS(demo_pkg_exports);
+init_demo_pkg();
 console.log("unused import");
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/bypass.md
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/bypass.md
@@ -1,5 +1,5 @@
 # Reason
-1. double module initialization
+1. different file system
 # Diff
 ## /out.js
 ### esbuild
@@ -36,7 +36,7 @@ var init_demo_pkg = __esm({ "node_modules/demo-pkg/index.js"() {
 
 //#endregion
 //#region src/entry.js
-init_demo_pkg(), __toCommonJS(demo_pkg_exports);
+init_demo_pkg();
 console.log("unused import");
 
 //#endregion
@@ -46,7 +46,7 @@ console.log("unused import");
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	src_entry.js
-@@ -3,11 +3,11 @@
+@@ -3,9 +3,9 @@
      foo: () => foo
  });
  var foo;
@@ -57,8 +57,5 @@ console.log("unused import");
          console.log("hello");
      }
  });
--init_demo_pkg();
-+(init_demo_pkg(), __toCommonJS(demo_pkg_exports));
- console.log("unused import");
 
 ```

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_export_star_side_effects_false/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_export_star_side_effects_false/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # warnings
 
@@ -35,7 +36,7 @@ var init_button = __esm({ "node_modules/pkg/button.css"() {} });
 
 //#endregion
 //#region node_modules/pkg/components.jsx
-init_button(), __toCommonJS(button_exports);
+init_button();
 const Button = () => _jsx$1("button", {});
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_export_star_side_effects_false/diff.md
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_export_star_side_effects_false/diff.md
@@ -29,7 +29,7 @@ var init_button = __esm({ "node_modules/pkg/button.css"() {} });
 
 //#endregion
 //#region node_modules/pkg/components.jsx
-init_button(), __toCommonJS(button_exports);
+init_button();
 const Button = () => _jsx$1("button", {});
 
 //#endregion
@@ -57,7 +57,7 @@ render(_jsx(Button, {}));
 -require_button();
 -var Button = () => React.createElement("button", null);
 -render(React.createElement(Button, null));
-+(init_button(), __toCommonJS(button_exports));
++init_button();
 +var Button = () => _jsx$1("button", {});
 +render(_jsx(Button, {}));
 

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_export_star_side_effects_false_only_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_export_star_side_effects_false_only_js/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # warnings
 
@@ -35,7 +36,7 @@ var init_button = __esm({ "node_modules/pkg/button.css"() {} });
 
 //#endregion
 //#region node_modules/pkg/components.jsx
-init_button(), __toCommonJS(button_exports);
+init_button();
 const Button = () => _jsx$1("button", {});
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_export_star_side_effects_false_only_js/diff.md
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_export_star_side_effects_false_only_js/diff.md
@@ -29,7 +29,7 @@ var init_button = __esm({ "node_modules/pkg/button.css"() {} });
 
 //#endregion
 //#region node_modules/pkg/components.jsx
-init_button(), __toCommonJS(button_exports);
+init_button();
 const Button = () => _jsx$1("button", {});
 
 //#endregion
@@ -56,7 +56,7 @@ render(_jsx(Button, {}));
 -require_button();
 -var Button = () => React.createElement("button", null);
 -render(React.createElement(Button, null));
-+(init_button(), __toCommonJS(button_exports));
++init_button();
 +var Button = () => _jsx$1("button", {});
 +render(_jsx(Button, {}));
 

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_re_export_side_effects_false/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_re_export_side_effects_false/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # warnings
 
@@ -35,7 +36,7 @@ var init_button = __esm({ "node_modules/pkg/button.css"() {} });
 
 //#endregion
 //#region node_modules/pkg/components.jsx
-init_button(), __toCommonJS(button_exports);
+init_button();
 const Button = () => _jsx$1("button", {});
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_re_export_side_effects_false/diff.md
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_re_export_side_effects_false/diff.md
@@ -29,7 +29,7 @@ var init_button = __esm({ "node_modules/pkg/button.css"() {} });
 
 //#endregion
 //#region node_modules/pkg/components.jsx
-init_button(), __toCommonJS(button_exports);
+init_button();
 const Button = () => _jsx$1("button", {});
 
 //#endregion
@@ -56,7 +56,7 @@ render(_jsx(Button, {}));
 -require_button();
 -var Button = () => React.createElement("button", null);
 -render(React.createElement(Button, null));
-+(init_button(), __toCommonJS(button_exports));
++init_button();
 +var Button = () => _jsx$1("button", {});
 +render(_jsx(Button, {}));
 

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_re_export_side_effects_false_only_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_re_export_side_effects_false_only_js/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # warnings
 
@@ -35,7 +36,7 @@ var init_button = __esm({ "node_modules/pkg/button.css"() {} });
 
 //#endregion
 //#region node_modules/pkg/components.jsx
-init_button(), __toCommonJS(button_exports);
+init_button();
 const Button = () => _jsx$1("button", {});
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_re_export_side_effects_false_only_js/diff.md
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_js_with_associated_css_re_export_side_effects_false_only_js/diff.md
@@ -29,7 +29,7 @@ var init_button = __esm({ "node_modules/pkg/button.css"() {} });
 
 //#endregion
 //#region node_modules/pkg/components.jsx
-init_button(), __toCommonJS(button_exports);
+init_button();
 const Button = () => _jsx$1("button", {});
 
 //#endregion
@@ -56,7 +56,7 @@ render(_jsx(Button, {}));
 -require_button();
 -var Button = () => React.createElement("button", null);
 -render(React.createElement(Button, null));
-+(init_button(), __toCommonJS(button_exports));
++init_button();
 +var Button = () => _jsx$1("button", {});
 +render(_jsx(Button, {}));
 

--- a/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -102,13 +103,13 @@ var init_h = __esm({ "h.js"() {
 
 //#endregion
 //#region entry.js
-init_commonjs(), __toCommonJS(commonjs_exports);
-init_c(), __toCommonJS(c_exports);
-init_d(), __toCommonJS(d_exports);
-init_e(), __toCommonJS(e_exports);
-init_f(), __toCommonJS(f_exports);
-init_g(), __toCommonJS(g_exports);
-init_h(), __toCommonJS(h_exports);
+init_commonjs();
+init_c();
+init_d();
+init_e();
+init_f();
+init_g();
+init_h();
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/export_forms_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/default/export_forms_common_js/diff.md
@@ -237,13 +237,13 @@ var init_h = __esm({ "h.js"() {
 
 //#endregion
 //#region entry.js
-init_commonjs(), __toCommonJS(commonjs_exports);
-init_c(), __toCommonJS(c_exports);
-init_d(), __toCommonJS(d_exports);
-init_e(), __toCommonJS(e_exports);
-init_f(), __toCommonJS(f_exports);
-init_g(), __toCommonJS(g_exports);
-init_h(), __toCommonJS(h_exports);
+init_commonjs();
+init_c();
+init_d();
+init_e();
+init_f();
+init_g();
+init_h();
 
 //#endregion
 ```
@@ -280,7 +280,7 @@ init_h(), __toCommonJS(h_exports);
  });
  var g_exports = {};
  __export(g_exports, {
-@@ -87,19 +87,19 @@
+@@ -87,14 +87,14 @@
      "g.js"() {}
  });
  var h_exports = {};
@@ -296,19 +296,7 @@ init_h(), __toCommonJS(h_exports);
 +        foo.prop = 123;
      }
  });
--init_commonjs();
--init_c();
--init_d();
--init_e();
--init_f();
--init_g();
--init_h();
-+(init_commonjs(), __toCommonJS(commonjs_exports));
-+(init_c(), __toCommonJS(c_exports));
-+(init_d(), __toCommonJS(d_exports));
-+(init_e(), __toCommonJS(e_exports));
-+(init_f(), __toCommonJS(f_exports));
-+(init_g(), __toCommonJS(g_exports));
-+(init_h(), __toCommonJS(h_exports));
+ init_commonjs();
+ init_c();
 
 ```

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -44,11 +45,11 @@ var init_e = __esm({ "e.js"() {} });
 
 //#endregion
 //#region entry.js
-init_a(), __toCommonJS(a_exports);
-init_b(), __toCommonJS(b_exports);
-init_c(), __toCommonJS(c_exports);
-init_d(), __toCommonJS(d_exports);
-init_e(), __toCommonJS(e_exports);
+init_a();
+init_b();
+init_c();
+init_d();
+init_e();
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/diff.md
@@ -105,11 +105,11 @@ var init_e = __esm({ "e.js"() {} });
 
 //#endregion
 //#region entry.js
-init_a(), __toCommonJS(a_exports);
-init_b(), __toCommonJS(b_exports);
-init_c(), __toCommonJS(c_exports);
-init_d(), __toCommonJS(d_exports);
-init_e(), __toCommonJS(e_exports);
+init_a();
+init_b();
+init_c();
+init_d();
+init_e();
 
 //#endregion
 ```
@@ -118,7 +118,7 @@ init_e(), __toCommonJS(e_exports);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,44 +1,43 @@
+@@ -1,42 +1,41 @@
 +import * as ns$3 from "x";
 +import * as ns$2 from "x";
 +import * as ns$1 from "x";
@@ -169,15 +169,8 @@ init_e(), __toCommonJS(e_exports);
 -    }
 +    "e.js"() {}
  });
--init_a();
--init_b();
--init_c();
--init_d();
--init_e();
-+(init_a(), __toCommonJS(a_exports));
-+(init_b(), __toCommonJS(b_exports));
-+(init_c(), __toCommonJS(c_exports));
-+(init_d(), __toCommonJS(d_exports));
-+(init_e(), __toCommonJS(e_exports));
+ init_a();
+ init_b();
+ init_c();
 
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
@@ -36,8 +36,8 @@ var init_a = __esm({ "a.js"() {
 //#endregion
 //#region entry.js
 var require_entry = __commonJS({ "entry.js"() {
-	init_a(), __toCommonJS(a_exports);
-	init_b(), __toCommonJS(b_exports);
+	init_a();
+	init_b();
 	require_c();
 	require_entry();
 	await 0;

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/artifacts.snap
@@ -27,8 +27,8 @@ var init_a = __esm({ "a.js"() {} });
 //#endregion
 //#region entry.js
 var require_entry = __commonJS({ "entry.js"() {
-	init_a(), __toCommonJS(a_exports);
-	init_b(), __toCommonJS(b_exports);
+	init_a();
+	init_b();
 	require_c();
 	require_entry();
 } });

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/diff.md
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/diff.md
@@ -65,8 +65,8 @@ var init_a = __esm({ "a.js"() {} });
 //#endregion
 //#region entry.js
 var require_entry = __commonJS({ "entry.js"() {
-	init_a(), __toCommonJS(a_exports);
-	init_b(), __toCommonJS(b_exports);
+	init_a();
+	init_b();
 	require_c();
 	require_entry();
 } });
@@ -108,13 +108,11 @@ var require_entry = __commonJS({ "entry.js"() {
 -    var init_entry = __esm({
 +    var require_entry = __commonJS({
          "entry.js"() {
--            init_a();
--            init_b();
+             init_a();
+             init_b();
 -            init_c();
 -            init_entry();
 -            if (false) for (let x of y) ;
-+            (init_a(), __toCommonJS(a_exports));
-+            (init_b(), __toCommonJS(b_exports));
 +            require_c();
 +            require_entry();
          }

--- a/crates/rolldown/tests/rolldown/cjs_compat/require/require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require/require_esm/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -14,7 +15,7 @@ var init_esm = __esm({ "esm.js"() {} });
 
 //#endregion
 //#region main.js
-init_esm(), __toCommonJS(esm_exports);
+init_esm();
 var esm = (init_esm(), __toCommonJS(esm_exports));
 
 //#endregion
@@ -27,7 +28,7 @@ var esm = (init_esm(), __toCommonJS(esm_exports));
 - ../esm.js
 (0:0-1:1) "export { }\n" --> (23:0-28:0) "\nvar esm_exports = {};\nvar init_esm = __esm({ \"esm.js\"() {} });\n\n//#endregion\n//#region main.js"
 - ../main.js
-(0:0-1:0) "require('./esm.js');" --> (28:0-29:0) "\ninit_esm(), __toCommonJS(esm_exports);"
+(0:0-1:0) "require('./esm.js');" --> (28:0-29:0) "\ninit_esm();"
 (1:0-1:4) "\nvar" --> (29:0-29:4) "\nvar"
 (1:4-0:0) "" --> (29:4-29:11) " esm = "
 (0:0-2:1) "require('./esm.js');\nvar esm = require('./esm.js');\n" --> (29:11-32:33) "(init_esm(), __toCommonJS(esm_exports));\n\n//#endregion\n//# sourceMappingURL=main.js.map"

--- a/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/_config.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "treeshake": false
+  }
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
@@ -26,6 +26,9 @@ var a = (1, init_esm(), __toCommonJS(esm_exports));
 function foo() {
 	return init_esm(), __toCommonJS(esm_exports);
 }
+console.log((1, init_esm(), 1));
+console.log((1, init_esm(), __toCommonJS(esm_exports)));
+console.log((1, (init_esm(), __toCommonJS(esm_exports)) + 1, 200));
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
@@ -11,15 +11,21 @@ snapshot_kind: text
 
 //#region esm.js
 var esm_exports = {};
-__export(esm_exports, { default: () => esm_default });
-var esm_default;
+__export(esm_exports, { a: () => a$1 });
+var a$1;
 var init_esm = __esm({ "esm.js"() {
-	esm_default = "esm";
+	a$1 = 100;
 } });
 
 //#endregion
 //#region main.js
 init_esm();
+1, init_esm();
+var a = (1, init_esm(), __toCommonJS(esm_exports));
+(init_esm(), __toCommonJS(esm_exports)).default;
+function foo() {
+	return init_esm(), __toCommonJS(esm_exports);
+}
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/esm.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/esm.js
@@ -1,0 +1,1 @@
+export const a = 100;

--- a/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/main.js
@@ -1,0 +1,7 @@
+require('./esm.js'); // unused
+(1, require('./esm.js')); // unused
+var a = (1, require("./esm.js")); // Used
+require("./esm.js").default; // used
+function foo() {
+  return require("./esm.js") // Used
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/main.js
@@ -5,3 +5,6 @@ require("./esm.js").default; // used
 function foo() {
   return require("./esm.js") // Used
 }
+console.log((1, require("./esm.js"), 1)); // Not Used
+console.log((1, require("./esm.js"))); // Used
+console.log((1, require("./esm.js") + 1, 200)); // Used

--- a/crates/rolldown/tests/rolldown/function/shim_missing_exports/basic_wrapped_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/shim_missing_exports/basic_wrapped_esm/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -18,7 +19,7 @@ var init_foo = __esm({ "foo.js"() {
 //#endregion
 //#region main.js
 init_foo();
-init_foo(), __toCommonJS(foo_exports);
+init_foo();
 
 //#endregion
 export { missing };

--- a/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -34,7 +35,7 @@ var init_foo = __esm({ "foo.js"() {
 
 //#endregion
 //#region main.js
-init_foo(), __toCommonJS(foo_exports);
+init_foo();
 
 //#endregion
 //# sourceMappingURL=main.js.map
@@ -44,42 +45,42 @@ init_foo(), __toCommonJS(foo_exports);
 
 ```
 - ../foo.js
-(0:0-2:7) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, {f: g = 1} = {};\nexport" --> (29:0-41:0) "\nvar foo_exports = {};\n__export(foo_exports, {\n\ta: () => a,\n\tb: () => b,\n\tbar: () => bar,\n\tc: () => c,\n\td: () => d,\n\tdefault: () => baz,\n\te: () => e,\n\tfoo: () => foo,\n\tg: () => g\n});"
-(2:7-2:16) " function" --> (41:0-41:9) "\nfunction"
-(2:16-2:22) " foo()" --> (41:9-41:15) " foo()"
-(2:22-2:25) " { " --> (41:15-41:16) " "
-(2:25-0:0) "" --> (41:16-42:0) "{}"
-(0:0-0:15) "export var a, [" --> (42:0-44:2) "\nvar a, b, c, d, e, g, bar, baz;\nvar init_foo = __esm({ \"foo.js\"() {\n\t"
-(0:15-0:0) "export var a, [" --> (44:2-44:4) "[b"
-(0:0-0:20) "export var a, [b] = " --> (44:4-44:7) "] ="
-(0:20-0:22) "[]" --> (44:7-44:8) " "
-(0:22-0:0) "export var a, [b] = []" --> (44:8-45:0) "[];"
-(0:0-0:25) "export var a, [b] = [], [" --> (45:0-45:2) "\n\t"
-(0:25-0:29) "c = " --> (45:2-45:6) "[c ="
-(0:29-0:0) "export var a, [b] = [], [c = " --> (45:6-45:8) " 1"
-(0:0-0:34) "export var a, [b] = [], [c = 1] = " --> (45:8-45:11) "] ="
-(0:34-0:36) "[]" --> (45:11-45:12) " "
-(0:36-0:0) "export var a, [b] = [], [c = 1] = []" --> (45:12-46:0) "[];"
-(0:0-1:20) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} =" --> (46:0-46:8) "\n\t({e} ="
-(1:20-1:22) " {" --> (46:8-46:9) " "
-(1:22-0:0) "" --> (46:9-47:0) "{});"
-(0:0-1:25) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, " --> (47:0-47:3) "\n\t("
-(1:25-1:28) "{f:" --> (47:3-47:6) "{f:"
-(1:28-1:32) " g =" --> (47:6-47:10) " g ="
-(1:32-0:0) "" --> (47:10-47:12) " 1"
-(0:0-1:37) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, {f: g = 1} =" --> (47:12-47:15) "} ="
-(1:37-1:39) " {" --> (47:15-47:16) " "
-(1:39-0:0) "" --> (47:16-48:0) "{});"
-(0:0-3:13) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, {f: g = 1} = {};\nexport function foo() { }\nexport class" --> (48:0-48:1) "\n"
-(3:13-3:7) " class" --> (48:1-48:7) "\tbar ="
-(3:7-3:17) " class bar" --> (48:7-48:13) " class"
-(3:17-3:20) " { " --> (48:13-48:14) " "
-(3:20-0:0) "" --> (48:14-49:0) "{};"
-(0:0-4:21) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, {f: g = 1} = {};\nexport function foo() { }\nexport class bar { }\nexport default class" --> (49:0-49:1) "\n"
-(4:21-4:15) " class" --> (49:1-49:7) "\tbaz ="
-(4:15-4:25) " class baz" --> (49:7-49:13) " class"
-(4:25-4:28) " { " --> (49:13-49:14) " "
-(4:28-0:0) "" --> (49:14-50:0) "{};"
-(0:0-8:1) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, {f: g = 1} = {};\nexport function foo() { }\nexport class bar { }\nexport default class baz { }\n\n\nexport { }\n" --> (50:0-54:0) "\n} });\n\n//#endregion\n//#region main.js"
-(0:0-1:1) "require('./foo')\n" --> (54:0-57:33) "\ninit_foo(), __toCommonJS(foo_exports);\n\n//#endregion\n//# sourceMappingURL=main.js.map"
+(0:0-2:7) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, {f: g = 1} = {};\nexport" --> (16:0-28:0) "\nvar foo_exports = {};\n__export(foo_exports, {\n\ta: () => a,\n\tb: () => b,\n\tbar: () => bar,\n\tc: () => c,\n\td: () => d,\n\tdefault: () => baz,\n\te: () => e,\n\tfoo: () => foo,\n\tg: () => g\n});"
+(2:7-2:16) " function" --> (28:0-28:9) "\nfunction"
+(2:16-2:22) " foo()" --> (28:9-28:15) " foo()"
+(2:22-2:25) " { " --> (28:15-28:16) " "
+(2:25-0:0) "" --> (28:16-29:0) "{}"
+(0:0-0:15) "export var a, [" --> (29:0-31:2) "\nvar a, b, c, d, e, g, bar, baz;\nvar init_foo = __esm({ \"foo.js\"() {\n\t"
+(0:15-0:0) "export var a, [" --> (31:2-31:4) "[b"
+(0:0-0:20) "export var a, [b] = " --> (31:4-31:7) "] ="
+(0:20-0:22) "[]" --> (31:7-31:8) " "
+(0:22-0:0) "export var a, [b] = []" --> (31:8-32:0) "[];"
+(0:0-0:25) "export var a, [b] = [], [" --> (32:0-32:2) "\n\t"
+(0:25-0:29) "c = " --> (32:2-32:6) "[c ="
+(0:29-0:0) "export var a, [b] = [], [c = " --> (32:6-32:8) " 1"
+(0:0-0:34) "export var a, [b] = [], [c = 1] = " --> (32:8-32:11) "] ="
+(0:34-0:36) "[]" --> (32:11-32:12) " "
+(0:36-0:0) "export var a, [b] = [], [c = 1] = []" --> (32:12-33:0) "[];"
+(0:0-1:20) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} =" --> (33:0-33:8) "\n\t({e} ="
+(1:20-1:22) " {" --> (33:8-33:9) " "
+(1:22-0:0) "" --> (33:9-34:0) "{});"
+(0:0-1:25) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, " --> (34:0-34:3) "\n\t("
+(1:25-1:28) "{f:" --> (34:3-34:6) "{f:"
+(1:28-1:32) " g =" --> (34:6-34:10) " g ="
+(1:32-0:0) "" --> (34:10-34:12) " 1"
+(0:0-1:37) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, {f: g = 1} =" --> (34:12-34:15) "} ="
+(1:37-1:39) " {" --> (34:15-34:16) " "
+(1:39-0:0) "" --> (34:16-35:0) "{});"
+(0:0-3:13) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, {f: g = 1} = {};\nexport function foo() { }\nexport class" --> (35:0-35:1) "\n"
+(3:13-3:7) " class" --> (35:1-35:7) "\tbar ="
+(3:7-3:17) " class bar" --> (35:7-35:13) " class"
+(3:17-3:20) " { " --> (35:13-35:14) " "
+(3:20-0:0) "" --> (35:14-36:0) "{};"
+(0:0-4:21) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, {f: g = 1} = {};\nexport function foo() { }\nexport class bar { }\nexport default class" --> (36:0-36:1) "\n"
+(4:21-4:15) " class" --> (36:1-36:7) "\tbaz ="
+(4:15-4:25) " class baz" --> (36:7-36:13) " class"
+(4:25-4:28) " { " --> (36:13-36:14) " "
+(4:28-0:0) "" --> (36:14-37:0) "{};"
+(0:0-8:1) "export var a, [b] = [], [c = 1] = [];\nexport var d, {e} = {}, {f: g = 1} = {};\nexport function foo() { }\nexport class bar { }\nexport default class baz { }\n\n\nexport { }\n" --> (37:0-41:0) "\n} });\n\n//#endregion\n//#region main.js"
+(0:0-1:1) "require('./foo')\n" --> (41:0-44:33) "\ninit_foo();\n\n//#endregion\n//# sourceMappingURL=main.js.map"
 ```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -31,7 +32,7 @@ var bar_default = { foo: foo$1 };
 const a = 2;
 const { foo } = bar_default;
 assert.strictEqual(typeof foo, "function");
-init_foo(), __toCommonJS(foo_exports);
+init_foo();
 
 //#endregion
 //# sourceMappingURL=main.js.map
@@ -41,45 +42,45 @@ init_foo(), __toCommonJS(foo_exports);
 
 ```
 - ../foo.js
-(0:0-4:15) "import assert from \"node:assert\";\n\nconst a = 1;\n\nexport default" --> (30:0-32:0) "\nvar foo_exports = {};\n__export(foo_exports, { default: () => foo$1 });"
-(4:15-4:24) " function" --> (32:0-32:9) "\nfunction"
-(4:24-4:28) " foo" --> (32:9-32:15) " foo$1"
-(4:28-4:33) "(a$1)" --> (32:15-32:22) "(a$1$1)"
-(4:33-5:2) " {\n " --> (32:22-33:0) " {"
-(5:2-5:9) " assert" --> (33:0-33:10) "\n\tassert$1"
-(5:9-5:15) ".equal" --> (33:10-33:16) ".equal"
-(5:15-5:20) "(a$1," --> (33:16-33:23) "(a$1$1,"
-(5:20-5:24) " a$1" --> (33:23-33:29) " a$1$1"
-(5:24-6:2) ")\n " --> (33:29-34:0) ");"
-(6:2-6:9) " assert" --> (34:0-34:10) "\n\tassert$1"
-(6:9-6:15) ".equal" --> (34:10-34:16) ".equal"
-(6:15-6:18) "(a," --> (34:16-34:21) "(a$1,"
-(6:18-6:20) " 1" --> (34:21-34:23) " 1"
-(6:20-7:1) ")\n" --> (34:23-35:0) ");"
-(7:1-0:0) "" --> (35:0-36:0) "\n}"
-(0:0-2:6) "import assert from \"node:assert\";\n\nconst" --> (36:0-38:1) "\nvar a$1;\nvar init_foo = __esm({ \"foo.js\"() {\n"
-(2:6-2:10) " a =" --> (38:1-38:7) "\ta$1 ="
-(2:10-0:0) "" --> (38:7-39:0) " 1;"
-(0:0-8:1) "import assert from \"node:assert\";\n\nconst a = 1;\n\nexport default function foo(a$1) {\n  assert.equal(a$1, a$1)\n  assert.equal(a, 1)\n}\n" --> (39:0-43:0) "\n} });\n\n//#endregion\n//#region bar.js"
+(0:0-4:15) "import assert from \"node:assert\";\n\nconst a = 1;\n\nexport default" --> (17:0-19:0) "\nvar foo_exports = {};\n__export(foo_exports, { default: () => foo$1 });"
+(4:15-4:24) " function" --> (19:0-19:9) "\nfunction"
+(4:24-4:28) " foo" --> (19:9-19:15) " foo$1"
+(4:28-4:33) "(a$1)" --> (19:15-19:22) "(a$1$1)"
+(4:33-5:2) " {\n " --> (19:22-20:0) " {"
+(5:2-5:9) " assert" --> (20:0-20:10) "\n\tassert$1"
+(5:9-5:15) ".equal" --> (20:10-20:16) ".equal"
+(5:15-5:20) "(a$1," --> (20:16-20:23) "(a$1$1,"
+(5:20-5:24) " a$1" --> (20:23-20:29) " a$1$1"
+(5:24-6:2) ")\n " --> (20:29-21:0) ");"
+(6:2-6:9) " assert" --> (21:0-21:10) "\n\tassert$1"
+(6:9-6:15) ".equal" --> (21:10-21:16) ".equal"
+(6:15-6:18) "(a," --> (21:16-21:21) "(a$1,"
+(6:18-6:20) " 1" --> (21:21-21:23) " 1"
+(6:20-7:1) ")\n" --> (21:23-22:0) ");"
+(7:1-0:0) "" --> (22:0-23:0) "\n}"
+(0:0-2:6) "import assert from \"node:assert\";\n\nconst" --> (23:0-25:1) "\nvar a$1;\nvar init_foo = __esm({ \"foo.js\"() {\n"
+(2:6-2:10) " a =" --> (25:1-25:7) "\ta$1 ="
+(2:10-0:0) "" --> (25:7-26:0) " 1;"
+(0:0-8:1) "import assert from \"node:assert\";\n\nconst a = 1;\n\nexport default function foo(a$1) {\n  assert.equal(a$1, a$1)\n  assert.equal(a, 1)\n}\n" --> (26:0-30:0) "\n} });\n\n//#endregion\n//#region bar.js"
 - ../bar.js
-(0:0-2:15) "import foo from './foo'\n\nexport default" --> (43:0-44:18) "\ninit_foo();\nvar bar_default ="
-(2:15-2:17) " {" --> (44:18-44:20) " {"
-(2:17-2:22) " foo " --> (44:20-44:31) " foo: foo$1"
-(2:22-2:23) "}" --> (44:31-48:0) " };\n\n//#endregion\n//#region main.js"
+(0:0-2:15) "import foo from './foo'\n\nexport default" --> (30:0-31:18) "\ninit_foo();\nvar bar_default ="
+(2:15-2:17) " {" --> (31:18-31:20) " {"
+(2:17-2:22) " foo " --> (31:20-31:31) " foo: foo$1"
+(2:22-2:23) "}" --> (31:31-35:0) " };\n\n//#endregion\n//#region main.js"
 - ../main.js
-(3:0-3:6) "\nconst" --> (48:0-48:6) "\nconst"
-(3:6-3:10) " a =" --> (48:6-48:10) " a ="
-(3:10-5:0) " 2; // make foo `a` conflict\n" --> (48:10-49:0) " 2;"
-(5:0-5:6) "\nconst" --> (49:0-49:6) "\nconst"
-(5:6-5:8) " {" --> (49:6-49:8) " {"
-(5:8-5:13) " foo " --> (49:8-49:13) " foo "
-(5:13-5:16) "} =" --> (49:13-49:16) "} ="
-(5:16-7:0) " bar\n" --> (49:16-50:0) " bar_default;"
-(7:0-7:7) "\nassert" --> (50:0-50:7) "\nassert"
-(7:7-7:26) ".strictEqual(typeof" --> (50:7-50:26) ".strictEqual(typeof"
-(7:26-7:31) " foo," --> (50:26-50:31) " foo,"
-(7:31-7:42) " 'function'" --> (50:31-50:42) " \"function\""
-(7:42-9:0) ")\n" --> (50:42-51:0) ");"
-(9:0-0:0) "" --> (51:0-51:0) ""
-(0:0-10:1) "import assert from 'node:assert'\nimport bar from './bar'\n\nconst a = 2; // make foo `a` conflict\n\nconst { foo } = bar\n\nassert.strictEqual(typeof foo, 'function')\n\nrequire('./foo')\n" --> (51:0-54:33) "\ninit_foo(), __toCommonJS(foo_exports);\n\n//#endregion\n//# sourceMappingURL=main.js.map"
+(3:0-3:6) "\nconst" --> (35:0-35:6) "\nconst"
+(3:6-3:10) " a =" --> (35:6-35:10) " a ="
+(3:10-5:0) " 2; // make foo `a` conflict\n" --> (35:10-36:0) " 2;"
+(5:0-5:6) "\nconst" --> (36:0-36:6) "\nconst"
+(5:6-5:8) " {" --> (36:6-36:8) " {"
+(5:8-5:13) " foo " --> (36:8-36:13) " foo "
+(5:13-5:16) "} =" --> (36:13-36:16) "} ="
+(5:16-7:0) " bar\n" --> (36:16-37:0) " bar_default;"
+(7:0-7:7) "\nassert" --> (37:0-37:7) "\nassert"
+(7:7-7:26) ".strictEqual(typeof" --> (37:7-37:26) ".strictEqual(typeof"
+(7:26-7:31) " foo," --> (37:26-37:31) " foo,"
+(7:31-7:42) " 'function'" --> (37:31-37:42) " \"function\""
+(7:42-9:0) ")\n" --> (37:42-38:0) ");"
+(9:0-0:0) "" --> (38:0-38:0) ""
+(0:0-10:1) "import assert from 'node:assert'\nimport bar from './bar'\n\nconst a = 2; // make foo `a` conflict\n\nconst { foo } = bar\n\nassert.strictEqual(typeof foo, 'function')\n\nrequire('./foo')\n" --> (38:0-41:33) "\ninit_foo();\n\n//#endregion\n//# sourceMappingURL=main.js.map"
 ```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -30,7 +31,7 @@ var bar_default = { foo: foo$1 };
 const a = 2;
 const { foo } = bar_default;
 assert.strictEqual(typeof foo, "function");
-init_foo(), __toCommonJS(foo_exports);
+init_foo();
 
 //#endregion
 //# sourceMappingURL=main.js.map
@@ -40,40 +41,40 @@ init_foo(), __toCommonJS(foo_exports);
 
 ```
 - ../foo.js
-(0:0-2:7) "const a = 1;\n\nexport" --> (30:0-32:0) "\nvar foo_exports = {};\n__export(foo_exports, { foo: () => foo$1 });"
-(2:7-2:16) " function" --> (32:0-32:9) "\nfunction"
-(2:16-2:20) " foo" --> (32:9-32:15) " foo$1"
-(2:20-2:25) "(a$1)" --> (32:15-32:22) "(a$1$1)"
-(2:25-3:4) " {\n   " --> (32:22-33:0) " {"
-(3:4-3:12) " console" --> (33:0-33:9) "\n\tconsole"
-(3:12-3:16) ".log" --> (33:9-33:13) ".log"
-(3:16-3:21) "(a$1," --> (33:13-33:20) "(a$1$1,"
-(3:21-3:23) " a" --> (33:20-33:24) " a$1"
-(3:23-4:1) ")\n" --> (33:24-34:0) ");"
-(4:1-0:0) "" --> (34:0-35:0) "\n}"
-(0:0-0:6) "const " --> (35:0-37:1) "\nvar a$1;\nvar init_foo = __esm({ \"foo.js\"() {\n"
-(0:6-0:10) "a = " --> (37:1-37:7) "\ta$1 ="
-(0:10-0:0) "const a = " --> (37:7-38:0) " 1;"
-(0:0-4:2) "const a = 1;\n\nexport function foo(a$1) {\n    console.log(a$1, a)\n}" --> (38:0-42:0) "\n} });\n\n//#endregion\n//#region bar.js"
+(0:0-2:7) "const a = 1;\n\nexport" --> (17:0-19:0) "\nvar foo_exports = {};\n__export(foo_exports, { foo: () => foo$1 });"
+(2:7-2:16) " function" --> (19:0-19:9) "\nfunction"
+(2:16-2:20) " foo" --> (19:9-19:15) " foo$1"
+(2:20-2:25) "(a$1)" --> (19:15-19:22) "(a$1$1)"
+(2:25-3:4) " {\n   " --> (19:22-20:0) " {"
+(3:4-3:12) " console" --> (20:0-20:9) "\n\tconsole"
+(3:12-3:16) ".log" --> (20:9-20:13) ".log"
+(3:16-3:21) "(a$1," --> (20:13-20:20) "(a$1$1,"
+(3:21-3:23) " a" --> (20:20-20:24) " a$1"
+(3:23-4:1) ")\n" --> (20:24-21:0) ");"
+(4:1-0:0) "" --> (21:0-22:0) "\n}"
+(0:0-0:6) "const " --> (22:0-24:1) "\nvar a$1;\nvar init_foo = __esm({ \"foo.js\"() {\n"
+(0:6-0:10) "a = " --> (24:1-24:7) "\ta$1 ="
+(0:10-0:0) "const a = " --> (24:7-25:0) " 1;"
+(0:0-4:2) "const a = 1;\n\nexport function foo(a$1) {\n    console.log(a$1, a)\n}" --> (25:0-29:0) "\n} });\n\n//#endregion\n//#region bar.js"
 - ../bar.js
-(0:0-2:15) "import { foo } from './foo'\n\nexport default" --> (42:0-43:18) "\ninit_foo();\nvar bar_default ="
-(2:15-2:17) " {" --> (43:18-43:20) " {"
-(2:17-2:22) " foo " --> (43:20-43:31) " foo: foo$1"
-(2:22-2:23) "}" --> (43:31-47:0) " };\n\n//#endregion\n//#region main.js"
+(0:0-2:15) "import { foo } from './foo'\n\nexport default" --> (29:0-30:18) "\ninit_foo();\nvar bar_default ="
+(2:15-2:17) " {" --> (30:18-30:20) " {"
+(2:17-2:22) " foo " --> (30:20-30:31) " foo: foo$1"
+(2:22-2:23) "}" --> (30:31-34:0) " };\n\n//#endregion\n//#region main.js"
 - ../main.js
-(3:0-3:6) "\nconst" --> (47:0-47:6) "\nconst"
-(3:6-3:10) " a =" --> (47:6-47:10) " a ="
-(3:10-5:0) " 2; // make foo `a` conflict\n" --> (47:10-48:0) " 2;"
-(5:0-5:6) "\nconst" --> (48:0-48:6) "\nconst"
-(5:6-5:8) " {" --> (48:6-48:8) " {"
-(5:8-5:13) " foo " --> (48:8-48:13) " foo "
-(5:13-5:16) "} =" --> (48:13-48:16) "} ="
-(5:16-7:0) " bar\n" --> (48:16-49:0) " bar_default;"
-(7:0-7:7) "\nassert" --> (49:0-49:7) "\nassert"
-(7:7-7:26) ".strictEqual(typeof" --> (49:7-49:26) ".strictEqual(typeof"
-(7:26-7:31) " foo," --> (49:26-49:31) " foo,"
-(7:31-7:42) " 'function'" --> (49:31-49:42) " \"function\""
-(7:42-9:0) ")\n" --> (49:42-50:0) ");"
-(9:0-0:0) "" --> (50:0-50:0) ""
-(0:0-9:17) "import assert from 'assert'\nimport bar from './bar'\n\nconst a = 2; // make foo `a` conflict\n\nconst { foo } = bar\n\nassert.strictEqual(typeof foo, 'function')\n\nrequire('./foo')" --> (50:0-53:33) "\ninit_foo(), __toCommonJS(foo_exports);\n\n//#endregion\n//# sourceMappingURL=main.js.map"
+(3:0-3:6) "\nconst" --> (34:0-34:6) "\nconst"
+(3:6-3:10) " a =" --> (34:6-34:10) " a ="
+(3:10-5:0) " 2; // make foo `a` conflict\n" --> (34:10-35:0) " 2;"
+(5:0-5:6) "\nconst" --> (35:0-35:6) "\nconst"
+(5:6-5:8) " {" --> (35:6-35:8) " {"
+(5:8-5:13) " foo " --> (35:8-35:13) " foo "
+(5:13-5:16) "} =" --> (35:13-35:16) "} ="
+(5:16-7:0) " bar\n" --> (35:16-36:0) " bar_default;"
+(7:0-7:7) "\nassert" --> (36:0-36:7) "\nassert"
+(7:7-7:26) ".strictEqual(typeof" --> (36:7-36:26) ".strictEqual(typeof"
+(7:26-7:31) " foo," --> (36:26-36:31) " foo,"
+(7:31-7:42) " 'function'" --> (36:31-36:42) " \"function\""
+(7:42-9:0) ")\n" --> (36:42-37:0) ");"
+(9:0-0:0) "" --> (37:0-37:0) ""
+(0:0-9:17) "import assert from 'assert'\nimport bar from './bar'\n\nconst a = 2; // make foo `a` conflict\n\nconst { foo } = bar\n\nassert.strictEqual(typeof foo, 'function')\n\nrequire('./foo')" --> (37:0-40:33) "\ninit_foo();\n\n//#endregion\n//# sourceMappingURL=main.js.map"
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3867,7 +3867,7 @@ snapshot_kind: text
 
 # tests/rolldown/cjs_compat/require_call_expr_unused
 
-- main-!~{000}~.js => main-6qc2lsBr.js
+- main-!~{000}~.js => main-oei2Xjj9.js
 
 # tests/rolldown/code_splitting/basic
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -276,7 +276,7 @@ snapshot_kind: text
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main
 
-- src_entry-!~{000}~.js => src_entry-bXR-mQSu.js
+- src_entry-!~{000}~.js => src_entry-7ZSq8M-X.js
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_module
 
@@ -292,7 +292,7 @@ snapshot_kind: text
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main
 
-- src_entry-!~{000}~.js => src_entry-bXR-mQSu.js
+- src_entry-!~{000}~.js => src_entry-7ZSq8M-X.js
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_module
 
@@ -345,7 +345,7 @@ snapshot_kind: text
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6
 
-- src_entry-!~{000}~.js => src_entry-xFhaH9Us.js
+- src_entry-!~{000}~.js => src_entry-iS1C-6ik.js
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js
 
@@ -496,23 +496,23 @@ snapshot_kind: text
 
 # tests/esbuild/dce/tree_shaking_js_with_associated_css_export_star_side_effects_false
 
-- test-!~{000}~.js => test-anEgNndy.js
+- test-!~{000}~.js => test-GiQqw0Rc.js
 - test.css
-- test-anEgNndy.js.map
+- test-GiQqw0Rc.js.map
 
 # tests/esbuild/dce/tree_shaking_js_with_associated_css_export_star_side_effects_false_only_js
 
-- test-!~{000}~.js => test-anEgNndy.js
+- test-!~{000}~.js => test-GiQqw0Rc.js
 - test.css
 
 # tests/esbuild/dce/tree_shaking_js_with_associated_css_re_export_side_effects_false
 
-- test-!~{000}~.js => test-anEgNndy.js
+- test-!~{000}~.js => test-GiQqw0Rc.js
 - test.css
 
 # tests/esbuild/dce/tree_shaking_js_with_associated_css_re_export_side_effects_false_only_js
 
-- test-!~{000}~.js => test-anEgNndy.js
+- test-!~{000}~.js => test-GiQqw0Rc.js
 - test.css
 
 # tests/esbuild/dce/tree_shaking_js_with_associated_css_unused_nested_import_side_effects_false
@@ -752,7 +752,7 @@ snapshot_kind: text
 
 # tests/esbuild/default/export_forms_common_js
 
-- entry-!~{000}~.js => entry-yLS2uCyQ.js
+- entry-!~{000}~.js => entry-x_Vr2eT2.js
 
 # tests/esbuild/default/export_forms_es6
 
@@ -809,7 +809,7 @@ snapshot_kind: text
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
-- entry-!~{000}~.js => entry-nKeclh5H.js
+- entry-!~{000}~.js => entry-Zg5LI-EP.js
 
 # tests/esbuild/default/external_module_exclusion_package
 
@@ -1700,11 +1700,11 @@ snapshot_kind: text
 
 # tests/esbuild/default/top_level_await_forbidden_require
 
-- entry-!~{000}~.js => entry-3qm8mbke.js
+- entry-!~{000}~.js => entry-_U0aM875.js
 
 # tests/esbuild/default/top_level_await_forbidden_require_dead_branch
 
-- entry-!~{000}~.js => entry-YKsu5RIe.js
+- entry-!~{000}~.js => entry-S0r_hR4N.js
 
 # tests/esbuild/default/top_level_await_iife
 
@@ -3796,7 +3796,7 @@ snapshot_kind: text
 
 # tests/rolldown/cjs_compat/esm_require_esm_unused
 
-- main-!~{000}~.js => main-8xsjWCm4.js
+- main-!~{000}~.js => main-3ZCERtsI.js
 
 # tests/rolldown/cjs_compat/exoprt_star_of_cjs
 
@@ -3862,8 +3862,12 @@ snapshot_kind: text
 
 # tests/rolldown/cjs_compat/require/require_esm
 
-- main-!~{000}~.js => main-V4GNbUh6.js
-- main-V4GNbUh6.js.map
+- main-!~{000}~.js => main-yj-9jT2S.js
+- main-yj-9jT2S.js.map
+
+# tests/rolldown/cjs_compat/require_call_expr_unused
+
+- main-!~{000}~.js => main-6qc2lsBr.js
 
 # tests/rolldown/code_splitting/basic
 
@@ -4468,7 +4472,7 @@ snapshot_kind: text
 
 # tests/rolldown/function/shim_missing_exports/basic_wrapped_esm
 
-- main-!~{000}~.js => main-sFlj_-w5.js
+- main-!~{000}~.js => main-_lDRZbJ7.js
 
 # tests/rolldown/function/shim_missing_exports/shake_unused_shimmed_exports
 
@@ -4638,8 +4642,8 @@ snapshot_kind: text
 
 # tests/rolldown/misc/wrapped_esm
 
-- main-!~{000}~.js => main-C7qpmxS2.js
-- main-C7qpmxS2.js.map
+- main-!~{000}~.js => main-muea_9_K.js
+- main-muea_9_K.js.map
 
 # tests/rolldown/resolve/hash_tag_as_dir_name
 
@@ -4747,13 +4751,13 @@ snapshot_kind: text
 
 # tests/rolldown/topics/deconflict/wrapped_esm_default_function
 
-- main-!~{000}~.js => main-7eEJ6hiU.js
-- main-7eEJ6hiU.js.map
+- main-!~{000}~.js => main-EEJeog8f.js
+- main-EEJeog8f.js.map
 
 # tests/rolldown/topics/deconflict/wrapped_esm_export_named_function
 
-- main-!~{000}~.js => main-6Bfknxp0.js
-- main-6Bfknxp0.js.map
+- main-!~{000}~.js => main-T2XGgYGO.js
+- main-T2XGgYGO.js.map
 
 # tests/rolldown/topics/live_bindings/default_export_binding
 

--- a/crates/rolldown_common/src/types/import_record.rs
+++ b/crates/rolldown_common/src/types/import_record.rs
@@ -39,6 +39,8 @@ bitflags::bitflags! {
     const IS_EXPORT_START = 1 << 4;
     ///  Tell the finalizer to use the runtime "__require()" instead of "require()"
     const CALL_RUNTIME_REQUIRE = 1 << 5;
+    ///  `require('mod')` is used to load the module only
+    const IS_REQUIRE_UNUSED = 1 << 6;
   }
 }
 

--- a/scripts/snap-diff/stats/aggregated-reason.md
+++ b/scripts/snap-diff/stats/aggregated-reason.md
@@ -108,10 +108,6 @@
 - crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_intermediate_files_chain_one
 - crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_intermediate_files_diamond
 - crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_intermediate_files_used
-## double module initialization
-- crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main
-- crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main
-- crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6
 ## not support import attributes
 - crates/rolldown/tests/esbuild/default/comment_preservation_import_assertions
 - crates/rolldown/tests/esbuild/default/metafile_import_with_type_json
@@ -141,6 +137,9 @@
 ## low priority
 - crates/rolldown/tests/esbuild/dce/drop_label_tree_shaking_bug_issue3311
 - crates/rolldown/tests/esbuild/dce/drop_labels
+## double module initialization
+- crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main
+- crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main
 ## comments codegen
 - crates/rolldown/tests/esbuild/default/comment_preservation
 - crates/rolldown/tests/esbuild/default/comment_preservation_transform_jsx

--- a/scripts/snap-diff/stats/stats.md
+++ b/scripts/snap-diff/stats/stats.md
@@ -1,12 +1,12 @@
 # Compatibility metric
 - total: 784
-- passed: 360
-- passed ratio: 45.92%
+- passed: 361
+- passed ratio: 46.05%
 # Compatibility metric details
 ## dce
 - total: 113
-- passed: 72
-- passed ratio: 63.72%
+- passed: 73
+- passed ratio: 64.60%
 ## default
 - total: 254
 - passed: 127

--- a/scripts/snap-diff/summary/dce.md
+++ b/scripts/snap-diff/summary/dce.md
@@ -47,8 +47,6 @@
   diff
 ## [package_json_side_effects_false_intermediate_files_used](../../../crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_intermediate_files_used/diff.md)
   diff
-## [package_json_side_effects_false_keep_bare_import_and_require_es6](../../../crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/diff.md)
-  diff
 ## [package_json_side_effects_false_one_fork](../../../crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_one_fork/diff.md)
   diff
 ## [pure_calls_with_spread](../../../crates/rolldown/tests/esbuild/dce/pure_calls_with_spread/diff.md)
@@ -143,6 +141,7 @@
 ## [multiple_declaration_tree_shaking_minify_syntax](../../../crates/rolldown/tests/esbuild/dce/multiple_declaration_tree_shaking_minify_syntax/bypass.md)
 ## [nested_function_inlining_with_spread](../../../crates/rolldown/tests/esbuild/dce/nested_function_inlining_with_spread/bypass.md)
 ## [package_json_side_effects_false_keep_bare_import_and_require_common_js](../../../crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_common_js/bypass.md)
+## [package_json_side_effects_false_keep_bare_import_and_require_es6](../../../crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/bypass.md)
 ## [package_json_side_effects_false_keep_named_import_common_js](../../../crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js/bypass.md)
 ## [package_json_side_effects_false_keep_star_import_common_js](../../../crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js/bypass.md)
 ## [package_json_side_effects_true_keep_common_js](../../../crates/rolldown/tests/esbuild/dce/package_json_side_effects_true_keep_common_js/bypass.md)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. esbuild will not call (init_xxx(), __toCommonJS(xxx_exports))` if the require is just a plain `require` call expr
https://hyrious.me/esbuild-repl/?version=0.23.0&b=e%00entry.js%00%2F%2F+MULTIPLE+ENTRY+MODULES%0Arequire%28%27.%2Fhyper-cube.js%27%29%0A&b=%00hyper-cube.js%00%0A%2F%2F+This+is+only+imported+by+one+entry+module+and%0A%2F%2F+shares+a+chunk+with+that+module%0Aexport+default+function+hyperCube%28x%29+%7B%0A%09return+cube%28x%29+*+x%3B%0A%7D%0A&o=%7B%0A++treeShaking%3A+true%2C%0A++bundle%3A+true%2C%0A%7D
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
