### PR TITLE
refactor(rust): make js and css chunk have their own unique names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,7 +2582,6 @@ dependencies = [
  "memchr",
  "notify",
  "oxc",
- "regex",
  "rolldown_common",
  "rolldown_ecmascript",
  "rolldown_error",
@@ -2963,6 +2962,7 @@ name = "rolldown_utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arcstr",
  "async-scoped",
  "base64-simd 0.8.0",
  "futures",

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -29,7 +29,6 @@ itoa                     = { workspace = true }
 memchr                   = { workspace = true }
 notify                   = { workspace = true }
 oxc                      = { workspace = true }
-regex                    = { workspace = true }
 rolldown_common          = { workspace = true }
 rolldown_ecmascript      = { workspace = true }
 rolldown_error           = { workspace = true }

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -11,6 +11,7 @@ use rolldown_common::{ChunkIdx, ChunkKind, FileNameRenderOptions, Module, Prelim
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_utils::{
   extract_hash_pattern::extract_hash_pattern,
+  hash_placeholder::HashPlaceholderGenerator,
   path_buf_ext::PathBufExt,
   path_ext::PathExt,
   rayon::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator},
@@ -29,7 +30,6 @@ use crate::{
     chunk::{deconflict_chunk_symbols::deconflict_chunk_symbols, generate_pre_rendered_chunk},
     extract_meaningful_input_name_from_path::try_extract_meaningful_input_name_from_path,
     finalize_normal_module,
-    hash_placeholder::HashPlaceholderGenerator,
   },
   BundleOutput, SharedOptions,
 };
@@ -176,44 +176,18 @@ impl<'a> GenerateStage<'a> {
       .into();
 
     let mut hash_placeholder_generator = HashPlaceholderGenerator::default();
-    let mut used_name_counts: FxHashMap<ArcStr, u32> = FxHashMap::default();
-    for chunk_id in &chunk_graph.sorted_chunk_idx_vec {
-      let chunk = &mut chunk_graph.chunk_table[*chunk_id];
-      if chunk.preliminary_filename.is_some() {
-        // Already generated
-        continue;
-      }
 
-      let pre_generated_name = &mut index_pre_generated_names[*chunk_id];
-      // Notice we didn't used deconflict name here, chunk names are allowed to be duplicated.
-      chunk.name = Some(pre_generated_name.clone());
-      index_chunk_id_to_name.insert(*chunk_id, pre_generated_name.clone());
-      let pre_rendered_chunk = generate_pre_rendered_chunk(chunk, self.link_output, self.options);
-
-      let filename_template = chunk.filename_template(self.options, &pre_rendered_chunk).await?;
-      let css_filename_template =
-        chunk.css_filename_template(self.options, &pre_rendered_chunk).await?;
-      let asset_filename_template = &self.options.asset_filenames;
-      let extracted_hash_pattern = extract_hash_pattern(filename_template.template());
-      let extracted_css_hash_pattern = extract_hash_pattern(css_filename_template.template());
-      let extracted_asset_hash_pattern = extract_hash_pattern(asset_filename_template.template());
-
-      let need_to_ensure_unique =
-        extracted_hash_pattern.is_none() || extracted_css_hash_pattern.is_none();
-      let chunk_name = if need_to_ensure_unique {
-        let original_name = &pre_generated_name;
-        let mut candidate = pre_generated_name.clone();
+    let create_make_unique_name = |mut used_name_counts: FxHashMap<ArcStr, u32>| {
+      move |name: &ArcStr| {
+        let mut candidate = name.clone();
         loop {
           match used_name_counts.entry(candidate.clone()) {
             Entry::Occupied(mut occ) => {
               // This name is already used
               let next_count = *occ.get();
               occ.insert(next_count + 1);
-              candidate = ArcStr::from(format!(
-                "{}{}",
-                original_name,
-                itoa::Buffer::new().format(next_count)
-              ));
+              candidate =
+                ArcStr::from(format!("{}{}", name, itoa::Buffer::new().format(next_count)));
             }
             Entry::Vacant(vac) => {
               // This is the first time we see this name
@@ -223,47 +197,34 @@ impl<'a> GenerateStage<'a> {
             }
           };
         }
-      } else {
-        used_name_counts.insert(pre_generated_name.clone(), 2);
-        pre_generated_name.clone()
-      };
+      }
+    };
+    let mut make_unique_name_for_ecma_chunk = create_make_unique_name(FxHashMap::default());
+    let mut make_unique_name_for_css_chunk = create_make_unique_name(FxHashMap::default());
 
-      let hash_placeholder =
-        extracted_hash_pattern.map(|p| hash_placeholder_generator.generate(p.len.unwrap_or(8)));
+    for chunk_id in &chunk_graph.sorted_chunk_idx_vec {
+      let chunk = &mut chunk_graph.chunk_table[*chunk_id];
+      if chunk.preliminary_filename.is_some() {
+        // Already generated
+        continue;
+      }
 
-      let css_hash_placeholder =
-        extracted_css_hash_pattern.map(|p| hash_placeholder_generator.generate(p.len.unwrap_or(8)));
+      let pre_generated_chunk_name = &mut index_pre_generated_names[*chunk_id];
+      // Notice we didn't used deconflict name here, chunk names are allowed to be duplicated.
+      chunk.name = Some(pre_generated_chunk_name.clone());
+      index_chunk_id_to_name.insert(*chunk_id, pre_generated_chunk_name.clone());
+      let pre_rendered_chunk = generate_pre_rendered_chunk(chunk, self.link_output, self.options);
 
-      chunk.modules.iter().copied().filter_map(|idx| modules[idx].as_normal()).for_each(|module| {
-        if module.asset_view.is_some() {
-          let hash_placeholder = extracted_asset_hash_pattern
-            .as_ref()
-            .map(|p| hash_placeholder_generator.generate(p.len.unwrap_or(8)));
-          let name = module.id.as_path().file_stem().and_then(|s| s.to_str()).unpack();
-          let preliminary = asset_filename_template.render(&FileNameRenderOptions {
-            name: Some(name),
-            hash: hash_placeholder.as_deref(),
-            ext: module.id.as_path().extension().and_then(|s| s.to_str()),
-          });
+      let asset_filename_template = &self.options.asset_filenames;
+      let extracted_asset_hash_pattern = extract_hash_pattern(asset_filename_template.template());
 
-          chunk.asset_absolute_preliminary_filenames.insert(
-            module.idx,
-            preliminary
-              .absolutize_with(self.options.cwd.join(&self.options.dir))
-              .expect_into_string(),
-          );
-          chunk
-            .asset_preliminary_filenames
-            .insert(module.idx, PreliminaryFilename::new(preliminary, hash_placeholder));
-        }
-      });
-
-      let ecma_preliminary_filename = chunk
+      let preliminary_filename = chunk
         .generate_preliminary_filename(
           self.options,
           &pre_rendered_chunk,
-          &chunk_name,
-          hash_placeholder.as_deref(),
+          pre_generated_chunk_name,
+          &mut hash_placeholder_generator,
+          &mut make_unique_name_for_ecma_chunk,
         )
         .await?;
 
@@ -271,15 +232,41 @@ impl<'a> GenerateStage<'a> {
         .generate_css_preliminary_filename(
           self.options,
           &pre_rendered_chunk,
-          &chunk_name,
-          hash_placeholder.as_deref(),
+          pre_generated_chunk_name,
+          &mut hash_placeholder_generator,
+          &mut make_unique_name_for_css_chunk,
         )
         .await?;
+
+      chunk.modules.iter().copied().filter_map(|idx| modules[idx].as_normal()).for_each(|module| {
+        if module.asset_view.is_some() {
+          let hash_placeholder = extracted_asset_hash_pattern
+            .as_ref()
+            .map(|p| hash_placeholder_generator.generate(p.len.unwrap_or(8)));
+          let name = module.id.as_path().file_stem().and_then(|s| s.to_str()).unpack();
+          let preliminary = PreliminaryFilename::new(
+            asset_filename_template.render(&FileNameRenderOptions {
+              name: Some(name),
+              hash: hash_placeholder.as_deref(),
+              ext: module.id.as_path().extension().and_then(|s| s.to_str()),
+            }),
+            hash_placeholder,
+          );
+
+          chunk.asset_absolute_preliminary_filenames.insert(
+            module.idx,
+            preliminary
+              .absolutize_with(self.options.cwd.join(&self.options.dir))
+              .expect_into_string(),
+          );
+          chunk.asset_preliminary_filenames.insert(module.idx, preliminary);
+        }
+      });
 
       chunk.pre_rendered_chunk = Some(pre_rendered_chunk);
 
       chunk.absolute_preliminary_filename = Some(
-        ecma_preliminary_filename
+        preliminary_filename
           .absolutize_with(self.options.cwd.join(&self.options.dir))
           .expect_into_string(),
       );
@@ -288,10 +275,8 @@ impl<'a> GenerateStage<'a> {
           .absolutize_with(self.options.cwd.join(&self.options.dir))
           .expect_into_string(),
       );
-      chunk.preliminary_filename =
-        Some(PreliminaryFilename::new(ecma_preliminary_filename, hash_placeholder));
-      chunk.css_preliminary_filename =
-        Some(PreliminaryFilename::new(css_preliminary_filename, css_hash_placeholder));
+      chunk.preliminary_filename = Some(preliminary_filename);
+      chunk.css_preliminary_filename = Some(css_preliminary_filename);
     }
     Ok(index_chunk_id_to_name)
   }

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -8,6 +8,7 @@ use rolldown_common::{AssetIdx, InstantiationKind, ModuleId, StrOrBytes};
 use rolldown_utils::rayon::IndexedParallelIterator;
 use rolldown_utils::{
   base64::to_url_safe_base64,
+  hash_placeholder::{extract_hash_placeholders, replace_placeholder_with_hash},
   rayon::{
     IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
   },
@@ -19,7 +20,6 @@ use xxhash_rust::xxh3::Xxh3;
 use crate::{
   chunk_graph::ChunkGraph,
   type_alias::{IndexAssets, IndexChunkToAssets, IndexInstantiatedChunks},
-  utils::hash_placeholder::{extract_hash_placeholders, replace_placeholder_with_hash},
 };
 
 #[tracing::instrument(level = "debug", skip_all)]

--- a/crates/rolldown/src/utils/mod.rs
+++ b/crates/rolldown/src/utils/mod.rs
@@ -11,7 +11,6 @@ pub mod call_expression_ext;
 pub mod chunk;
 pub mod ecma_visitors;
 pub mod extract_meaningful_input_name_from_path;
-pub mod hash_placeholder;
 pub mod load_source;
 pub mod make_ast_symbol_and_scope;
 pub mod normalize_options;

--- a/crates/rolldown/tests/esbuild/loader/loader_file_one_source_two_different_output_paths_css/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_file_one_source_two_different_output_paths_css/artifacts.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
-## common-[hash].css
+## common-YiR-P8G6.css
 
 ```css
 div {

--- a/crates/rolldown/tests/rolldown/topics/css/align_vite/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/css/align_vite/artifacts.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
-## common-imported-by-js-[hash].css
+## common-imported-by-js-Vgk26GTt.css
 
 ```css
 body {
@@ -19,7 +20,7 @@ body {
 ```js
 
 ```
-## entry-a-[hash].css
+## entry-a-q4WTqDTG.css
 
 ```css
 
@@ -42,7 +43,7 @@ console.log("entry-a");
 
 //#endregion
 ```
-## entry-b-[hash].css
+## entry-b-H6QOhB-3.css
 
 ```css
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -1102,91 +1102,91 @@ snapshot_kind: text
 # tests/esbuild/default/legal_comments_avoid_slash_tag_end_of_file
 
 - entry-!~{000}~.js => entry-RtPgLOy2.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_avoid_slash_tag_external
 
 - entry-!~{000}~.js => entry-RtPgLOy2.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_avoid_slash_tag_inline
 
 - entry-!~{000}~.js => entry-RtPgLOy2.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_end_of_file
 
 - entry-!~{000}~.js => entry-vqlQgaqL.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_escape_slash_script_and_style_end_of_file
 
 - entry-!~{000}~.js => entry-OEGDqerq.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_escape_slash_script_and_style_external
 
 - entry-!~{000}~.js => entry-OEGDqerq.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_external
 
 - entry-!~{000}~.js => entry-vqlQgaqL.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_inline
 
 - entry-!~{000}~.js => entry-vqlQgaqL.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_linked
 
 - entry-!~{000}~.js => entry-vqlQgaqL.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_many_end_of_file
 
 - entry-!~{000}~.js => entry-0KABFbSF.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_many_linked
 
 - entry-!~{000}~.js => entry-0KABFbSF.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_modify_indent
 
 - entry-!~{000}~.js => entry-O9DPNVPI.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_no_escape_slash_script_end_of_file
 
 - entry-!~{000}~.js => entry-OEGDqerq.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_no_escape_slash_style_end_of_file
 
 - entry-!~{000}~.js => entry-OEGDqerq.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/legal_comments_none
 
 - entry-!~{000}~.js => entry-vqlQgaqL.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/mangle_no_quoted_props
@@ -1327,13 +1327,13 @@ snapshot_kind: text
 # tests/esbuild/default/metafile_no_bundle
 
 - entry-!~{000}~.js => entry-aGukXlqQ.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 
 # tests/esbuild/default/metafile_various_cases
 
 - entry-!~{000}~.js => entry-CtcGwjNP.js
-- entry2-!~{001}~.js => entry2-AX3jMTeb.js
+- entry-!~{001}~.js => entry-wuCqC14M.js
 - entry2.css
 - dynamic-!~{002}~.js => dynamic-hx382zUK.js
 
@@ -2340,7 +2340,7 @@ snapshot_kind: text
 # tests/esbuild/loader/loader_copy_with_bundle_entry_point
 
 - src_entry-!~{000}~.js => src_entry-ioDHherq.js
-- src_entry2-!~{001}~.js => src_entry2-04Duh52x.js
+- src_entry-!~{001}~.js => src_entry-ER1HhN-W.js
 - src_entry2.css
 - assets_some-!~{002}~.js => assets_some-W0fyymA3.js
 - some-!~{003}~.js => some-3vTMswRN.js
@@ -2441,7 +2441,7 @@ snapshot_kind: text
 - entries_other_entry-!~{001}~.js => entries_other_entry-QV0jCcba.js
 - entries_other_entry.css
 - common-!~{002}~.js => common-qY6_Q_4n.js
-- common-qY6_Q_4n.css
+- common-6iTYFrj-.css
 
 # tests/esbuild/loader/loader_file_one_source_two_different_output_paths_js
 
@@ -4696,11 +4696,11 @@ snapshot_kind: text
 
 - main-!~{000}~.js => main-6o6OfP3k.js
 - entry-a-!~{003}~.js => entry-a-28M3Od9p.js
-- entry-a-28M3Od9p.css
+- entry-a-PDikT8S0.css
 - entry-b-!~{005}~.js => entry-b-3rOg4Zu0.js
-- entry-b-3rOg4Zu0.css
+- entry-b-nsNNDpQm.css
 - common-imported-by-js-!~{001}~.js => common-imported-by-js-7GYix6i6.js
-- common-imported-by-js-7GYix6i6.css
+- common-imported-by-js-N1DCKFms.css
 
 # tests/rolldown/topics/css/basic
 

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 anyhow             = { workspace = true }
+arcstr             = { workspace = true }
 base64-simd        = { workspace = true }
 futures            = { workspace = true }
 glob-match         = { workspace = true }

--- a/crates/rolldown_utils/src/hash_placeholder.rs
+++ b/crates/rolldown_utils/src/hash_placeholder.rs
@@ -2,9 +2,10 @@ use std::borrow::Cow;
 
 use arcstr::ArcStr;
 use regex::{Captures, Regex};
-use rolldown_utils::indexmap::FxIndexSet;
 use rustc_hash::FxHashMap;
 use std::sync::LazyLock;
+
+use crate::indexmap::FxIndexSet;
 
 const HASH_PLACEHOLDER_LEFT: &str = "!~{";
 const HASH_PLACEHOLDER_RIGHT: &str = "}~";
@@ -76,6 +77,7 @@ impl HashPlaceholderGenerator {
 /// ```js
 /// import { foo } from "foo.xx__hash.js";
 /// ```
+#[expect(clippy::implicit_hasher)]
 pub fn replace_placeholder_with_hash<'a>(
   source: impl Into<Cow<'a, str>>,
   final_hashes_by_placeholder: &FxHashMap<ArcStr, &'a str>,

--- a/crates/rolldown_utils/src/lib.rs
+++ b/crates/rolldown_utils/src/lib.rs
@@ -19,6 +19,7 @@ pub mod sanitize_file_name;
 pub mod xxhash;
 pub use bitset::BitSet;
 pub mod extract_hash_pattern;
+pub mod hash_placeholder;
 pub mod index_vec_ext;
 pub mod js_regex;
 pub mod pattern_filter;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR make the js and css chunk not share the same `used_name_counts`, because they have their own unique extension `.js` and `.css`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
