### PR TITLE
refactor: should render output without taking ownerships

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -125,7 +125,7 @@ impl Generator for EcmaGenerator {
     let source_joiner = match ctx.options.format {
       OutputFormat::Esm => render_esm(
         ctx,
-        rendered_module_sources,
+        &rendered_module_sources,
         banner.as_deref(),
         footer.as_deref(),
         intro.as_deref(),
@@ -135,7 +135,7 @@ impl Generator for EcmaGenerator {
       OutputFormat::Cjs => {
         match render_cjs(
           ctx,
-          rendered_module_sources,
+          &rendered_module_sources,
           banner.as_deref(),
           footer.as_deref(),
           intro.as_deref(),
@@ -148,7 +148,7 @@ impl Generator for EcmaGenerator {
       }
       OutputFormat::App => render_app(
         ctx,
-        rendered_module_sources,
+        &rendered_module_sources,
         banner.as_deref(),
         footer.as_deref(),
         intro.as_deref(),
@@ -158,7 +158,7 @@ impl Generator for EcmaGenerator {
       OutputFormat::Iife => {
         match render_iife(
           ctx,
-          rendered_module_sources,
+          &rendered_module_sources,
           banner.as_deref(),
           footer.as_deref(),
           intro.as_deref(),
@@ -172,7 +172,7 @@ impl Generator for EcmaGenerator {
       OutputFormat::Umd => {
         match render_umd(
           ctx,
-          rendered_module_sources,
+          &rendered_module_sources,
           banner.as_deref(),
           footer.as_deref(),
           intro.as_deref(),

--- a/crates/rolldown/src/ecmascript/format/app.rs
+++ b/crates/rolldown/src/ecmascript/format/app.rs
@@ -4,7 +4,7 @@ use crate::{ecmascript::ecma_generator::RenderedModuleSources, types::generator:
 
 pub fn render_app<'code>(
   _ctx: &GenerateContext<'_>,
-  module_sources: RenderedModuleSources,
+  module_sources: &'code RenderedModuleSources,
   banner: Option<&'code str>,
   footer: Option<&'code str>,
   intro: Option<&'code str>,
@@ -25,7 +25,7 @@ pub fn render_app<'code>(
   }
 
   // chunk content
-  module_sources.into_iter().for_each(|(_, _, module_render_output)| {
+  module_sources.iter().for_each(|(_, _, module_render_output)| {
     if let Some(emitted_sources) = module_render_output {
       for source in emitted_sources {
         source_joiner.append_source(source);

--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -19,7 +19,7 @@ use rolldown_sourcemap::SourceJoiner;
 #[allow(clippy::too_many_lines)]
 pub fn render_cjs<'code>(
   ctx: &mut GenerateContext<'_>,
-  module_sources: RenderedModuleSources,
+  module_sources: &'code RenderedModuleSources,
   banner: Option<&'code str>,
   footer: Option<&'code str>,
   intro: Option<&'code str>,
@@ -91,7 +91,7 @@ pub fn render_cjs<'code>(
 
   // Runtime module should be placed before the generated `requires` in CJS format.
   // Because, we might need to generate `__toESM(require(...))` that relies on the runtime module.
-  let mut module_sources_peekable = module_sources.into_iter().peekable();
+  let mut module_sources_peekable = module_sources.iter().peekable();
   match module_sources_peekable.peek() {
     Some((id, _, _)) if *id == ctx.link_output.runtime.id() => {
       if let (_, _module_id, Some(emitted_sources)) =

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -16,7 +16,7 @@ use crate::{
 
 pub fn render_esm<'code>(
   ctx: &mut GenerateContext<'_>,
-  module_sources: RenderedModuleSources,
+  module_sources: &'code RenderedModuleSources,
   banner: Option<&'code str>,
   footer: Option<&'code str>,
   intro: Option<&'code str>,
@@ -61,7 +61,7 @@ pub fn render_esm<'code>(
   }
 
   // chunk content
-  module_sources.into_iter().for_each(|(_, _, module_render_output)| {
+  module_sources.iter().for_each(|(_, _, module_render_output)| {
     if let Some(emitted_sources) = module_render_output {
       for source in emitted_sources {
         source_joiner.append_source(source);

--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -45,7 +45,7 @@ use super::utils::{render_chunk_external_imports, render_factory_parameters};
 /// The main function for rendering the IIFE format chunks.
 pub fn render_iife<'code>(
   ctx: &mut GenerateContext<'_>,
-  module_sources: RenderedModuleSources,
+  module_sources: &'code RenderedModuleSources,
   banner: Option<&'code str>,
   footer: Option<&'code str>,
   intro: Option<&'code str>,
@@ -139,7 +139,7 @@ pub fn render_iife<'code>(
 
   // chunk content
   // TODO indent chunk content for iife format
-  module_sources.into_iter().for_each(|(_, _, module_render_output)| {
+  module_sources.iter().for_each(|(_, _, module_render_output)| {
     if let Some(emitted_sources) = module_render_output {
       for source in emitted_sources {
         source_joiner.append_source(source);

--- a/crates/rolldown/src/ecmascript/format/umd.rs
+++ b/crates/rolldown/src/ecmascript/format/umd.rs
@@ -24,7 +24,7 @@ use super::utils::{
 
 pub fn render_umd<'code>(
   ctx: &mut GenerateContext<'_>,
-  module_sources: RenderedModuleSources,
+  module_sources: &'code RenderedModuleSources,
   banner: Option<&'code str>,
   footer: Option<&'code str>,
   intro: Option<&'code str>,
@@ -106,7 +106,7 @@ pub fn render_umd<'code>(
 
   // chunk content
   // TODO indent chunk content
-  module_sources.into_iter().for_each(|(_, _, module_render_output)| {
+  module_sources.iter().for_each(|(_, _, module_render_output)| {
     if let Some(emitted_sources) = module_render_output {
       for source in emitted_sources {
         source_joiner.append_source(source);

--- a/crates/rolldown_sourcemap/src/source.rs
+++ b/crates/rolldown_sourcemap/src/source.rs
@@ -100,7 +100,7 @@ impl Source for SourceMapSource {
   }
 }
 
-impl Source for Box<dyn Source + Send> {
+impl<'a> Source for &'a Box<dyn Source + Send> {
   fn sourcemap(&self) -> Option<&SourceMap> {
     self.as_ref().sourcemap()
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- It's not nescessay to take the ownership while rendering output. 
- Consider that `RenderedModuleSources` might be reused during different builds in the future.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
