### PR TITLE
fix(plugin): ensure correct execution order

### DIFF
--- a/packages/rolldown/src/log/logger.ts
+++ b/packages/rolldown/src/log/logger.ts
@@ -21,6 +21,7 @@ import type { InputOptions } from '../options/input-options'
 import type { NormalizedInputOptions } from '../options/normalized-input-options'
 import path from 'node:path'
 import { VERSION } from '..'
+import { getSortedPlugins } from '../plugin/plugin-driver'
 
 export interface PluginContextMeta {
   rollupVersion: string
@@ -86,7 +87,7 @@ export function getLogger(
     if (logPriority < minimalPriority) {
       return
     }
-    for (const plugin of plugins) {
+    for (const plugin of getSortedPlugins('onLog', plugins)) {
       if (skipped.has(plugin)) continue
 
       const { onLog: pluginOnLog } = plugin

--- a/packages/rolldown/tests/fixtures/plugin/plugin-order/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/plugin-order/_config.ts
@@ -1,317 +1,86 @@
 import { expect } from 'vitest'
 import { defineTest } from '@tests'
+import { Plugin } from '@tests/types'
 
-const preName = 'test-plugin-pre'
-const normalName = 'test-plugin-normal'
-const postName = 'test-plugin-post'
+const plugins: Plugin[] = []
+const hooks = [
+  'augmentChunkHash',
+  'buildEnd',
+  'buildStart',
+  'generateBundle',
+  'writeBundle',
+  'load',
+  'moduleParsed',
+  'options',
+  'outputOptions',
+  // 'renderDynamicImport',
+  // 'renderError'
+  'renderChunk',
+  'renderStart',
+  'resolveDynamicImport',
+  // 'resolveFileUrl',
+  'resolveId',
+  // 'resolveImportMeta',
+  // 'shouldTransformCachedModule',
+  'transform',
+  'banner',
+  'footer',
+  'intro',
+  'outro',
+  'onLog',
+]
 
-// TODO
-// The `buildStart` is run in parallel, so the order is not stable. If we need to implement `sequential`, we need to care the order.
-// The `resolveDynamicImport/renderError` not tested.
+const calledHooks: Record<string, string[]> = {}
+for (const hook of hooks) {
+  calledHooks[hook] = []
+}
 
-const expectedCallsResult = [preName, normalName, postName]
-
-const resolveIdCalls: string[] = []
-const buildStartCalls: string[] = []
-const renderChunkCalls: string[] = []
-const buildEndCalls: string[] = []
-const transformCalls: string[] = []
-const moduleParsedCalls: string[] = []
-const loadCalls: string[] = []
-const augmentChunkHashCalls: string[] = []
-const renderStartCalls: string[] = []
-const generateBundleCalls: string[] = []
-const writeBundleCalls: string[] = []
-const bannerCalls: string[] = []
-const footerCalls: string[] = []
-const introCalls: string[] = []
-const outroCalls: string[] = []
+addPlugin(null)
+addPlugin('pre')
+addPlugin('post')
+addPlugin('post')
+addPlugin('pre')
+addPlugin()
+function addPlugin(order?: 'pre' | 'post' | null) {
+  const name = `${order}-${plugins.length}`
+  const plugin = { name } as Plugin
+  for (const hook of hooks) {
+    // @ts-expect-error hook is keyof Plugin
+    plugin[hook] = {
+      order,
+      handler() {
+        if (!calledHooks[hook].includes(name)) {
+          calledHooks[hook].push(name)
+        }
+      },
+    }
+  }
+  plugins.push(plugin)
+}
 
 export default defineTest({
   config: {
     plugins: [
+      ...plugins,
       {
-        name: postName,
-        buildStart: {
-          handler: () => {
-            buildStartCalls.push(postName)
-          },
-          order: 'post',
-        },
-        resolveId: {
-          handler: () => {
-            resolveIdCalls.push(postName)
-          },
-          order: 'post',
-        },
-        buildEnd: {
-          handler: () => {
-            buildEndCalls.push(postName)
-          },
-          order: 'post',
-        },
-        transform: {
-          handler: () => {
-            transformCalls.push(postName)
-          },
-          order: 'post',
-        },
-        moduleParsed: {
-          handler: () => {
-            moduleParsedCalls.push(postName)
-          },
-          order: 'post',
-        },
-        load: {
-          handler: () => {
-            loadCalls.push(postName)
-          },
-          order: 'post',
-        },
-        renderChunk: {
-          handler: () => {
-            renderChunkCalls.push(postName)
-          },
-          order: 'post',
-        },
-        augmentChunkHash: {
-          handler: () => {
-            augmentChunkHashCalls.push(postName)
-          },
-          order: 'post',
-        },
-        renderStart: {
-          handler: () => {
-            renderStartCalls.push(postName)
-          },
-          order: 'post',
-        },
-        generateBundle: {
-          handler: () => {
-            generateBundleCalls.push(postName)
-          },
-          order: 'post',
-        },
-        writeBundle: {
-          handler: () => {
-            writeBundleCalls.push(postName)
-          },
-          order: 'post',
-        },
-        banner: {
-          handler: () => {
-            bannerCalls.push(postName)
-            return ''
-          },
-          order: 'post',
-        },
-        footer: {
-          handler: () => {
-            footerCalls.push(postName)
-            return ''
-          },
-          order: 'post',
-        },
-        intro: {
-          handler: () => {
-            introCalls.push(postName)
-            return ''
-          },
-          order: 'post',
-        },
-        outro: {
-          handler: () => {
-            outroCalls.push(postName)
-            return ''
-          },
-          order: 'post',
-        },
-      },
-      {
-        name: preName,
-        buildStart: {
-          handler: () => {
-            buildStartCalls.push(preName)
-          },
-          order: 'pre',
-        },
-        resolveId: {
-          handler: () => {
-            resolveIdCalls.push(preName)
-          },
-          order: 'pre',
-        },
-        buildEnd: {
-          handler: () => {
-            buildEndCalls.push(preName)
-          },
-          order: 'pre',
-        },
-        transform: {
-          handler: () => {
-            transformCalls.push(preName)
-          },
-          order: 'pre',
-        },
-        moduleParsed: {
-          handler: () => {
-            moduleParsedCalls.push(preName)
-          },
-          order: 'pre',
-        },
-        load: {
-          handler: () => {
-            loadCalls.push(preName)
-          },
-          order: 'pre',
-        },
-        renderChunk: {
-          handler: () => {
-            renderChunkCalls.push(preName)
-          },
-          order: 'pre',
-        },
-        augmentChunkHash: {
-          handler: () => {
-            augmentChunkHashCalls.push(preName)
-          },
-          order: 'pre',
-        },
-        renderStart: {
-          handler: () => {
-            renderStartCalls.push(preName)
-          },
-          order: 'pre',
-        },
-        generateBundle: {
-          handler: () => {
-            generateBundleCalls.push(preName)
-          },
-          order: 'pre',
-        },
-        writeBundle: {
-          handler: () => {
-            writeBundleCalls.push(preName)
-          },
-          order: 'pre',
-        },
-        banner: {
-          handler: () => {
-            bannerCalls.push(preName)
-            return ''
-          },
-          order: 'pre',
-        },
-        footer: {
-          handler: () => {
-            footerCalls.push(preName)
-            return ''
-          },
-          order: 'pre',
-        },
-        intro: {
-          handler: () => {
-            introCalls.push(preName)
-            return ''
-          },
-          order: 'pre',
-        },
-        outro: {
-          handler: () => {
-            outroCalls.push(preName)
-            return ''
-          },
-          order: 'pre',
-        },
-      },
-      {
-        name: normalName,
-        buildStart: () => {
-          buildStartCalls.push(normalName)
-        },
-        resolveId: () => {
-          resolveIdCalls.push(normalName)
-        },
-        buildEnd: () => {
-          buildEndCalls.push(normalName)
-        },
-        transform: () => {
-          transformCalls.push(normalName)
-        },
-        moduleParsed: () => {
-          moduleParsedCalls.push(normalName)
-        },
-        load: () => {
-          loadCalls.push(normalName)
-        },
-        renderChunk: () => {
-          renderChunkCalls.push(normalName)
-        },
-        augmentChunkHash: () => {
-          augmentChunkHashCalls.push(normalName)
-        },
-        renderStart: () => {
-          renderStartCalls.push(normalName)
-        },
-        generateBundle: () => {
-          generateBundleCalls.push(normalName)
-        },
-        writeBundle: () => {
-          writeBundleCalls.push(normalName)
-        },
-        banner: () => {
-          bannerCalls.push(normalName)
-          return ''
-        },
-        footer: () => {
-          footerCalls.push(normalName)
-          return ''
-        },
-        intro: () => {
-          introCalls.push(normalName)
-          return ''
-        },
-        outro: () => {
-          outroCalls.push(normalName)
-          return ''
+        name: 'add-log',
+        buildStart() {
+          this.warn('a warning')
         },
       },
     ],
   },
   skipComposingJsPlugin: true,
-  beforeTest: () => {
-    resolveIdCalls.length = 0
-    // buildStartCalls.length = 0
-    renderChunkCalls.length = 0
-    buildEndCalls.length = 0
-    resolveIdCalls.length = 0
-    transformCalls.length = 0
-    moduleParsedCalls.length = 0
-    loadCalls.length = 0
-    augmentChunkHashCalls.length = 0
-    renderStartCalls.length = 0
-    generateBundleCalls.length = 0
-    writeBundleCalls.length = 0
-    bannerCalls.length = 0
-    footerCalls.length = 0
-    introCalls.length = 0
-    outroCalls.length = 0
-  },
   afterTest: () => {
-    expect(resolveIdCalls).toStrictEqual(expectedCallsResult)
-    // expect(buildStartCalls).toStrictEqual(expectedCallsResult)
-    expect(renderChunkCalls).toStrictEqual(expectedCallsResult)
-    expect(buildEndCalls).toStrictEqual(expectedCallsResult)
-    expect(transformCalls).toStrictEqual(expectedCallsResult)
-    expect(moduleParsedCalls).toStrictEqual(expectedCallsResult)
-    expect(loadCalls).toStrictEqual(expectedCallsResult)
-    expect(augmentChunkHashCalls).toStrictEqual(expectedCallsResult)
-    expect(renderStartCalls).toStrictEqual(expectedCallsResult)
-    expect(generateBundleCalls).toStrictEqual(expectedCallsResult)
-    expect(writeBundleCalls).toStrictEqual(expectedCallsResult)
-    expect(bannerCalls).toStrictEqual(expectedCallsResult)
-    expect(footerCalls).toStrictEqual(expectedCallsResult)
-    expect(introCalls).toStrictEqual(expectedCallsResult)
-    expect(outroCalls).toStrictEqual(expectedCallsResult)
+    for (const hook of hooks) {
+      expect(calledHooks[hook]).toStrictEqual([
+        'pre-1',
+        'pre-4',
+        'null-0',
+        'undefined-5',
+        'post-2',
+        'post-3',
+      ])
+    }
   },
 })

--- a/packages/rolldown/tests/fixtures/plugin/plugin-order/dynamic.js
+++ b/packages/rolldown/tests/fixtures/plugin/plugin-order/dynamic.js
@@ -1,0 +1,1 @@
+console.log(1)

--- a/packages/rolldown/tests/fixtures/plugin/plugin-order/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/plugin-order/main.js
@@ -1,0 +1,1 @@
+import('./dynamic')

--- a/packages/rolldown/tests/src/types.ts
+++ b/packages/rolldown/tests/src/types.ts
@@ -9,3 +9,5 @@ export interface TestConfig {
   afterTest?: (output: RolldownOutput) => Promise<void> | void
   catchError?: (err: unknown) => Promise<void> | void
 }
+
+export type { Plugin } from 'rolldown'

--- a/packages/rollup-tests/src/ignored-tests.js
+++ b/packages/rollup-tests/src/ignored-tests.js
@@ -16,9 +16,6 @@ const ignoreTests = [
   // Need to investigate
   'rollup@function@bundle-facade-order: respects the order of entry points when there are additional facades for chunks',
 
-  // Not supported
-  'rollup@function@enforce-plugin-order: allows to enforce plugin hook order',
- 
   // The test case import test.js from rollup package, it's dependencies can't be resolved.
   "rollup@function@relative-outside-external: correctly resolves relative external imports from outside directories",
   // Ignore skipIfWindows test avoid test status error
@@ -115,6 +112,10 @@ const ignoreTests = [
 
   // The plugin sequential is not supported
   "rollup@function@enforce-sequential-plugin-order: allows to enforce sequential plugin hook order for parallel plugin hooks",
+
+
+  // `renderDynamicImport/resolveFileUrl/resolveImportMeta/shouldTransformCachedModule` hooks not supported
+  'rollup@function@enforce-plugin-order: allows to enforce plugin hook order',
 
   // The output plugins hooks is not working as expected
   "rollup@function@options-in-renderstart: makes input and output options available in renderStart",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- support js side hooks plugin order
- disable `buildStart` hook run in parallel, it break plugin order behavior. We could make the plugin run in parallel for supported hooks at future.
- refactor plugin order test follow rollup test