### PR TITLE
fix: soucemap file should be a path basename

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -64,7 +64,7 @@ impl<'a> GenerateStage<'a> {
         if let Some(map) = map.as_mut() {
           let file_base_name =
             Path::new(rendered_chunk.filename.as_str()).file_name().expect("should have file name");
-          map.set_file(&file_base_name.to_string_lossy().as_ref());
+          map.set_file(file_base_name.to_string_lossy().as_ref());
 
           let map_filename = format!("{}.map", rendered_chunk.filename.as_str());
           let map_path = file_dir.join(&map_filename);

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -62,7 +62,9 @@ impl<'a> GenerateStage<'a> {
         let mut code = code.try_into_string()?;
         let rendered_chunk = ecma_meta.rendered_chunk;
         if let Some(map) = map.as_mut() {
-          map.set_file(&rendered_chunk.filename);
+          let file_base_name =
+            Path::new(rendered_chunk.filename.as_str()).file_name().expect("should have file name");
+          map.set_file(&file_base_name.to_string_lossy().to_string());
 
           let map_filename = format!("{}.map", rendered_chunk.filename.as_str());
           let map_path = file_dir.join(&map_filename);

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -64,7 +64,7 @@ impl<'a> GenerateStage<'a> {
         if let Some(map) = map.as_mut() {
           let file_base_name =
             Path::new(rendered_chunk.filename.as_str()).file_name().expect("should have file name");
-          map.set_file(&file_base_name.to_string_lossy().to_string());
+          map.set_file(&file_base_name.to_string_lossy().as_ref());
 
           let map_filename = format!("{}.map", rendered_chunk.filename.as_str());
           let map_path = file_dir.join(&map_filename);

--- a/packages/rollup-tests/src/ignored-tests.js
+++ b/packages/rollup-tests/src/ignored-tests.js
@@ -79,15 +79,6 @@ const ignoreTests = [
   "rollup@function@class-name-conflict-4: does not shadow variables when preserving class names",
   "rollup@function@class-name-conflict: preserves class names even if the class is renamed",
 
-  // https://github.com/rolldown/rolldown/issues/2569
-  "rollup@sourcemaps@ignore-list-default: defaults to adding files within node_modules to the ignore list@generates es",
-  "rollup@sourcemaps@ignore-list-false: accepts false for `sourcemapIgnoreList` to disable the default ignore-listing of node_modules@generates es",
-  "rollup@sourcemaps@ignore-list-source-files: populates ignore list@generates es",
-  "rollup@sourcemaps@ignore-list-sourcemap-path: correctly passes source map path@generates es",
-  "rollup@sourcemaps@relative-paths: source paths are relative with relative dest (#344)@generates es",
-  "rollup@sourcemaps@transform-full-source-paths: provides the full source map path when transforming source maps@generates es",
-  "rollup@sourcemaps@transform-source-paths: transform sourcemap paths (#2168)@generates es",
-
   // Format cjs
   "rollup@function@default-export-with-null-prototype: default exports of objects with null prototypes are supported",
 

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,7 +1,7 @@
 {
   "failed": 0,
   "skipFailed": 0,
-  "ignored": 379,
+  "ignored": 372,
   "skipped": 0,
-  "passed": 550
+  "passed": 557
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -2,6 +2,6 @@
 |----| ---- |
 | failed | 0|
 | skipFailed | 0|
-| ignored | 379|
+| ignored | 372|
 | skipped | 0|
-| passed | 550|
+| passed | 557|


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
close #2569. The soucemap `file` should be a path basename. ref https://github.com/rollup/rollup/blob/master/src/utils/collapseSourcemaps.ts#L223
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
