### PR TITLE
feat(rust): add `comments` option

### DIFF
--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -1,5 +1,5 @@
 use oxc::transformer::InjectGlobalVariablesConfig;
-use rolldown_common::{InjectImport, ModuleType, NormalizedBundlerOptions, Platform};
+use rolldown_common::{Comments, InjectImport, ModuleType, NormalizedBundlerOptions, Platform};
 use rustc_hash::FxHashMap;
 
 pub struct NormalizeOptionsReturn {
@@ -127,6 +127,7 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
     profiler_names: raw_options.profiler_names.unwrap_or(!raw_options.minify.unwrap_or(false)),
     jsx: raw_options.jsx,
     watch: raw_options.watch.unwrap_or_default(),
+    comments: raw_options.comments.unwrap_or(Comments::Preserve),
   };
 
   NormalizeOptionsReturn { options: normalized, resolve_options: raw_resolve }

--- a/crates/rolldown/tests/rolldown/function/comments/none/_config.json
+++ b/crates/rolldown/tests/rolldown/function/comments/none/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "comments": "none"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/function/comments/none/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/comments/none/artifacts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Assets
+
+## main.js
+
+```js
+
+//#region main.js
+foo;
+bar;
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/function/comments/none/main.js
+++ b/crates/rolldown/tests/rolldown/function/comments/none/main.js
@@ -1,0 +1,3 @@
+/* comments1 */
+/* comments2 */
+foo;bar;

--- a/crates/rolldown/tests/rolldown/function/comments/preserve/_config.json
+++ b/crates/rolldown/tests/rolldown/function/comments/preserve/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "comments": "preserve"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/function/comments/preserve/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/comments/preserve/artifacts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Assets
+
+## main.js
+
+```js
+
+//#region main.js
+foo;
+bar;
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/function/comments/preserve/main.js
+++ b/crates/rolldown/tests/rolldown/function/comments/preserve/main.js
@@ -1,0 +1,3 @@
+/* comments1 */
+/* comments2 */
+foo;bar;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4003,6 +4003,14 @@ snapshot_kind: text
 - other-libs-!~{003}~.js => other-libs-y1JszJk0.js
 - ui-!~{001}~.js => ui-H_NLoFET.js
 
+# tests/rolldown/function/comments/none
+
+- main-!~{000}~.js => main-TEEZnbpv.js
+
+# tests/rolldown/function/comments/preserve
+
+- main-!~{000}~.js => main-TEEZnbpv.js
+
 # tests/rolldown/function/define/node_env
 
 - main-!~{000}~.js => main-281Y6vFN.js

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -203,6 +203,7 @@ pub fn normalize_binding_options(
     profiler_names: input_options.profiler_names,
     jsx: input_options.jsx.map(Into::into),
     watch: input_options.watch.map(TryInto::try_into).transpose()?,
+    comments: None,
   };
 
   #[cfg(not(target_family = "wasm"))]

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -3,6 +3,7 @@ use rolldown_utils::indexmap::FxIndexMap;
 use std::{collections::HashMap, fmt::Debug, path::PathBuf};
 use types::advanced_chunks_options::AdvancedChunksOptions;
 use types::checks_options::ChecksOptions;
+use types::comments::Comments;
 use types::inject_import::InjectImport;
 use types::watch_option::WatchOption;
 
@@ -145,6 +146,7 @@ pub struct BundlerOptions {
   )]
   pub jsx: Option<JsxOptions>,
   pub watch: Option<WatchOption>,
+  pub comments: Option<Comments>,
 }
 
 #[cfg(feature = "deserialize_bundler_options")]

--- a/crates/rolldown_common/src/inner_bundler_options/types/comments.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/comments.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "deserialize_bundler_options")]
+use schemars::JsonSchema;
+#[cfg(feature = "deserialize_bundler_options")]
+use serde::Deserialize;
+
+#[derive(Debug)]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
+  serde(rename_all = "camelCase", deny_unknown_fields)
+)]
+pub enum Comments {
+  /// Don't preserve any comment
+  None,
+  /// Keep comments as much as possible
+  Preserve,
+}

--- a/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod advanced_chunks_options;
 pub mod checks_options;
+pub mod comments;
 pub mod es_module_flag;
 pub mod experimental_options;
 pub mod filename_template;

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -9,6 +9,7 @@ use rustc_hash::FxHashMap;
 
 use super::advanced_chunks_options::AdvancedChunksOptions;
 use super::checks_options::ChecksOptions;
+use super::comments::Comments;
 use super::experimental_options::ExperimentalOptions;
 use super::output_option::ChunkFilenamesOutputOption;
 use super::treeshake::TreeshakeOptions;
@@ -68,6 +69,7 @@ pub struct NormalizedBundlerOptions {
   pub profiler_names: bool,
   pub jsx: Option<JsxOptions>,
   pub watch: WatchOption,
+  pub comments: Comments,
 }
 
 pub type SharedNormalizedBundlerOptions = Arc<NormalizedBundlerOptions>;

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -15,6 +15,7 @@ pub mod bundler_options {
   pub use crate::inner_bundler_options::{
     types::{
       advanced_chunks_options::{AdvancedChunksOptions, MatchGroup},
+      comments::Comments,
       es_module_flag::EsModuleFlag,
       experimental_options::ExperimentalOptions,
       filename_template::{FileNameRenderOptions, FilenameTemplate},

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -62,6 +62,16 @@ impl EcmaCompiler {
       .build(ast.program())
   }
 
+  pub fn print_with(ast: &EcmaAst, options: PrintOptions) -> CodegenReturn {
+    CodeGenerator::new()
+      .with_options(CodegenOptions {
+        comments: options.comments,
+        source_map_path: options.sourcemap.then(|| PathBuf::from(options.filename)),
+        ..CodegenOptions::default()
+      })
+      .build(ast.program())
+  }
+
   pub fn minify(
     source_text: &str,
     enable_sourcemap: bool,
@@ -89,4 +99,10 @@ fn basic_test() {
   let ast = EcmaCompiler::parse("", "const a = 1;".to_string(), SourceType::default()).unwrap();
   let code = EcmaCompiler::print(&ast, "", false).code;
   assert_eq!(code, "const a = 1;\n");
+}
+
+pub struct PrintOptions {
+  pub comments: bool,
+  pub filename: String,
+  pub sourcemap: bool,
 }

--- a/crates/rolldown_ecmascript/src/lib.rs
+++ b/crates/rolldown_ecmascript/src/lib.rs
@@ -3,5 +3,5 @@ mod ecma_compiler;
 
 pub use crate::{
   ecma_ast::{program_cell::WithMutFields, EcmaAst, ToSourceString},
-  ecma_compiler::EcmaCompiler,
+  ecma_compiler::{EcmaCompiler, PrintOptions},
 };

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -125,6 +125,16 @@
             "null"
           ]
         },
+        "comments": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Comments"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "cssChunkFilenames": {
           "type": [
             "string",
@@ -388,6 +398,24 @@
         }
       },
       "additionalProperties": false
+    },
+    "Comments": {
+      "oneOf": [
+        {
+          "description": "Don't preserve any comment",
+          "type": "string",
+          "enum": [
+            "none"
+          ]
+        },
+        {
+          "description": "Keep comments as much as possible",
+          "type": "string",
+          "enum": [
+            "preserve"
+          ]
+        }
+      ]
     },
     "Duration": {
       "type": "object",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Since we have a feature-complete js compiler, instead of using `legalComments`, we gonna have a more general name `comments` for controlling behavior related to comments. @yyx990803 cc

This PR adds two option:
- Preserve all comments as possible
- Remove all comments

I'll add legal-comments-related feature in later PRs.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
