### PR TITLE
refactor: PluginContext#getModuleInfo

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -166,14 +166,6 @@ impl Bundler {
       }
     };
 
-    self.plugin_driver.set_module_table(unsafe {
-      // Can't ensure the safety here. It's only a temporary solution.
-      // - We won't mutate the `module_table` in the generate stage.
-      // - We transmute the stacked reference to a static lifetime and it haven't met errors due to we happen
-      // to only need to access the `module_table` during this function call.
-      std::mem::transmute(&link_stage_output.module_table)
-    });
-
     self.plugin_driver.render_start().await?;
 
     let mut output = {

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -323,12 +323,19 @@ impl ModuleLoader {
         if let Some(module) = module.as_normal_mut() {
           // Note: (Compat to rollup)
           // The `dynamic_importers/importers` should be added after `module_parsed` hook.
-          for importer in std::mem::take(&mut self.intermediate_normal_modules.importers[id]) {
+          let importers = std::mem::take(&mut self.intermediate_normal_modules.importers[id]);
+          for importer in &importers {
             if importer.kind.is_static() {
-              module.importers.push(importer.importer_path);
+              module.importers.push(importer.importer_path.clone());
             } else {
-              module.dynamic_importers.push(importer.importer_path);
+              module.dynamic_importers.push(importer.importer_path.clone());
             }
+          }
+          if !importers.is_empty() {
+            self
+              .shared_context
+              .plugin_driver
+              .set_module_info(&module.id, Arc::new(module.to_module_info()));
           }
         }
         module

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -13,7 +13,7 @@ use oxc::transformer::ReplaceGlobalDefinesConfig;
 use rolldown_common::side_effects::{DeterminedSideEffects, HookSideEffects};
 use rolldown_common::{
   EntryPoint, EntryPointKind, ExternalModule, ImportKind, ImportRecordIdx, ImporterRecord, Module,
-  ModuleIdx, ModuleTable, ResolvedId, SymbolNameRefToken, SymbolRefDb,
+  ModuleId, ModuleIdx, ModuleTable, ResolvedId, SymbolNameRefToken, SymbolRefDb,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_fs::OsFileSystem;
@@ -272,7 +272,7 @@ impl ModuleLoader {
                 // Dynamic imported module will be considered as an entry
                 self.intermediate_normal_modules.importers[id].push(ImporterRecord {
                   kind: raw_rec.kind,
-                  importer_path: module.id().to_string().into(),
+                  importer_path: ModuleId::new(module.id()),
                 });
                 if matches!(raw_rec.kind, ImportKind::DynamicImport)
                   && !user_defined_entry_ids.contains(&id)

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -228,7 +228,9 @@ impl ModuleTask {
       asset_view,
     };
 
-    self.ctx.plugin_driver.module_parsed(Arc::new(module.to_module_info())).await?;
+    let module_info = Arc::new(module.to_module_info());
+    self.ctx.plugin_driver.set_module_info(&module.id, Arc::clone(&module_info));
+    self.ctx.plugin_driver.module_parsed(module_info).await?;
 
     if let Err(_err) = self
       .ctx

--- a/crates/rolldown/src/watcher/watcher.rs
+++ b/crates/rolldown/src/watcher/watcher.rs
@@ -114,8 +114,8 @@ impl Watcher {
     self.emitter.emit(WatcherEvent::Event, BundleEventKind::Start.into()).await?;
 
     self.emitter.emit(WatcherEvent::Event, BundleEventKind::BundleStart.into()).await?;
-    bundler.plugin_driver = bundler.plugin_driver.new_shared_from_self();
-    bundler.file_emitter.clear();
+
+    bundler.plugin_driver.clear();
 
     let output = {
       if bundler.options.watch.skip_write {

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use napi_derive::napi;
 
 use rolldown_plugin::PluginContext;
@@ -53,11 +51,11 @@ impl BindingPluginContext {
 
   #[napi]
   pub fn get_module_info(&self, module_id: String) -> Option<BindingModuleInfo> {
-    self.inner.get_module_info(&module_id).map(|info| BindingModuleInfo::new(Arc::new(info)))
+    self.inner.get_module_info(&module_id).map(BindingModuleInfo::new)
   }
 
   #[napi]
-  pub fn get_module_ids(&self) -> Option<Vec<String>> {
+  pub fn get_module_ids(&self) -> Vec<String> {
     self.inner.get_module_ids()
   }
 

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -52,7 +52,7 @@ export declare class BindingPluginContext {
   emitFile(file: BindingEmittedAsset): string
   getFileName(referenceId: string): string
   getModuleInfo(moduleId: string): BindingModuleInfo | null
-  getModuleIds(): Array<string> | null
+  getModuleIds(): Array<string>
   addWatchFile(file: string): void
 }
 

--- a/packages/rolldown/src/plugin/plugin-context-data.ts
+++ b/packages/rolldown/src/plugin/plugin-context-data.ts
@@ -1,11 +1,9 @@
 import { BindingPluginContext } from '../binding'
-import { ModuleInfo, ModuleOptions } from '..'
+import { ModuleOptions } from '..'
 import { transformModuleInfo } from '../utils/transform-module-info'
 import { PluginContextResolveOptions } from './plugin-context'
 
 export class PluginContextData {
-  modules = new Map<string, ModuleInfo>()
-  moduleIds: Array<string> | null = null
   moduleOptionMap = new Map<string, ModuleOptions>()
   resolveOptionsMap = new Map<number, PluginContextResolveOptions>()
 
@@ -26,31 +24,20 @@ export class PluginContextData {
   }
 
   getModuleInfo(id: string, context: BindingPluginContext) {
-    if (this.modules.has(id)) {
-      return this.modules.get(id) ?? null
-    }
     const bindingInfo = context.getModuleInfo(id)
     if (bindingInfo) {
       const info = transformModuleInfo(
         bindingInfo,
         this.moduleOptionMap.get(id)!,
       )
-      this.modules.set(id, info)
       return info
     }
     return null
   }
 
   getModuleIds(context: BindingPluginContext) {
-    if (this.moduleIds) {
-      return this.moduleIds.values()
-    }
     const moduleIds = context.getModuleIds()
-    if (moduleIds) {
-      this.moduleIds = moduleIds
-      return moduleIds.values()
-    }
-    return [].values()
+    return moduleIds.values()
   }
 
   saveResolveOptions(options: PluginContextResolveOptions): number {

--- a/packages/rolldown/tests/fixtures/plugin/context/get-module-info/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/get-module-info/_config.ts
@@ -17,7 +17,9 @@ export default defineTest({
           }
         },
         renderStart() {
+          let count = 0
           for (const id of this.getModuleIds()) {
+            count++
             const moduleInfo = this.getModuleInfo(id)!
             switch (moduleInfo.id) {
               case path.join(import.meta.dirname, 'main.js'):
@@ -49,6 +51,7 @@ export default defineTest({
                 break
             }
           }
+          expect(count).toBe(3)
         },
       },
     ],

--- a/packages/rolldown/tests/fixtures/plugin/context/get-module-info/dynamic.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/get-module-info/dynamic.js
@@ -1,0 +1,1 @@
+export const bar = 'dynamic'

--- a/packages/rolldown/tests/fixtures/plugin/context/get-module-info/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/get-module-info/main.js
@@ -1,0 +1,3 @@
+import { foo } from './static.js'
+
+export const result = [foo, import('./dynamic.js')]

--- a/packages/rolldown/tests/fixtures/plugin/context/get-module-info/static.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/get-module-info/static.js
@@ -1,0 +1,1 @@
+export const foo = 'static'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The pr refactor the `PluginContext#getModuleInfo` implementation, using `PluginDriver#modules` to store module info table instead of using reference `ModuleTable`. It has some advantages.
- remove unsafe reference `ModuleTable`
- make https://github.com/rolldown/rolldown/issues/2392 has a chance could be fixed.
- make `PluginContext#load` logic easy to do, if the module already exit, here doesn't need to fetch it.

Here maybe has some performance regression because we need to `set_module_info` when some fields change, but it is acceptable. Because the operation almost happened at `ModuleTask`, only has overhead at refresh `importers/dynamic_importers` at main thread.

