### PR TITLE
refactor(rolldown_sourcemap): tweak `line_count` related code

### DIFF
--- a/crates/bench/benches/remapping.rs
+++ b/crates/bench/benches/remapping.rs
@@ -41,16 +41,14 @@ fn criterion_benchmark(c: &mut Criterion) {
 
   // simulate render-chunk-remapping
   let mut sourcemap_chain = vec![];
-  let line = code.matches('\n').count() as u32;
   let mut source_joiner = SourceJoiner::default();
   let mut sources = vec![];
   for i in 0..3 {
     sources.push(format!("{i}.js"));
-    source_joiner.append_source(SourceMapSource::new(
-      code.clone(),
-      map.as_ref().unwrap().clone(),
-      line,
-    ));
+    source_joiner.append_source(
+      SourceMapSource::new(code.clone(), map.as_ref().unwrap().clone())
+        .with_pre_compute_sourcemap_data(true),
+    );
   }
   let (source_text, mut source_map) = source_joiner.join();
   // The sources should be different at common case.

--- a/crates/rolldown/src/utils/render_ecma_module.rs
+++ b/crates/rolldown/src/utils/render_ecma_module.rs
@@ -1,5 +1,5 @@
 use rolldown_common::{ModuleRenderOutput, NormalModule, NormalizedBundlerOptions};
-use rolldown_sourcemap::{collapse_sourcemaps, lines_count, Source, SourceMapSource};
+use rolldown_sourcemap::{collapse_sourcemaps, Source, SourceMapSource};
 
 pub fn render_ecma_module(
   module: &NormalModule,
@@ -31,8 +31,10 @@ pub fn render_ecma_module(
       };
 
       if let Some(sourcemap) = sourcemap {
-        let lines_count = lines_count(&render_output.code);
-        sources.push(Box::new(SourceMapSource::new(render_output.code, sourcemap, lines_count)));
+        sources.push(Box::new(
+          SourceMapSource::new(render_output.code, sourcemap)
+            .with_pre_compute_sourcemap_data(options.is_sourcemap_enabled()),
+        ));
       } else {
         sources.push(Box::new(render_output.code));
       }

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -73,3 +73,9 @@ pub struct NormalizedBundlerOptions {
 }
 
 pub type SharedNormalizedBundlerOptions = Arc<NormalizedBundlerOptions>;
+
+impl NormalizedBundlerOptions {
+  pub fn is_sourcemap_enabled(&self) -> bool {
+    self.sourcemap.is_some()
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- use the faster `line_count` function in all places
- only pre compute sourcemap data in parallel if necessary
- hide the pre-compute logic inside the function, so people don't bother to understand why we compute it and pass it instead of compute it when we needed.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
