### PR TITLE
fix: emit error when `output.format` did not support `topLevelAwait`

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -111,8 +111,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
             self.source.clone(),
             it.span(),
             format!(
-              "Top-level await is currently not supported with the '{}' output format",
-              format
+              "Top-level await is currently not supported with the '{format}' output format",
             ),
           ));
         }
@@ -129,7 +128,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
           self.file_path.as_str().into(),
           self.source.clone(),
           it.span(),
-          format!("Top-level await is currently not supported with the '{}' output format", format),
+          format!("Top-level await is currently not supported with the '{format}' output format",),
         ));
       }
     }

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -16,6 +16,18 @@ use crate::utils::call_expression_ext::CallExpressionExt;
 use super::{side_effect_detector::SideEffectDetector, AstScanner};
 
 impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
+  fn enter_scope(
+    &mut self,
+    _flags: oxc::semantic::ScopeFlags,
+    scope_id: &std::cell::Cell<Option<oxc::semantic::ScopeId>>,
+  ) {
+    self.scope_stack.push(scope_id.get());
+  }
+
+  fn leave_scope(&mut self) {
+    self.scope_stack.pop();
+  }
+
   fn enter_node(&mut self, kind: oxc::ast::AstKind<'ast>) {
     self.visit_path.push(kind);
   }
@@ -91,7 +103,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
   }
 
   fn visit_for_of_statement(&mut self, it: &ast::ForOfStatement<'ast>) {
-    if it.r#await {
+    if it.r#await && self.is_top_level() {
       if let Some(format) = self.options.as_ref().map(|option| &option.format) {
         if !format.keep_esm_import_export_syntax() {
           self.result.errors.push(BuildDiagnostic::unsupported_feature(
@@ -112,7 +124,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
   fn visit_await_expression(&mut self, it: &ast::AwaitExpression<'ast>) {
     if let Some(format) = self.options.as_ref().map(|option| &option.format) {
-      if !format.keep_esm_import_export_syntax() {
+      if !format.keep_esm_import_export_syntax() && self.is_top_level() {
         self.result.errors.push(BuildDiagnostic::unsupported_feature(
           self.file_path.as_str().into(),
           self.source.clone(),

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -93,7 +93,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
   fn visit_for_of_statement(&mut self, it: &ast::ForOfStatement<'ast>) {
     if it.r#await {
       if let Some(format) = self.options.as_ref().map(|option| &option.format) {
-        if !format.keep_esm_import_export() {
+        if !format.keep_esm_import_export_syntax() {
           self.result.errors.push(BuildDiagnostic::unsupported_feature(
             self.file_path.as_str().into(),
             self.source.clone(),
@@ -112,7 +112,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
   fn visit_await_expression(&mut self, it: &ast::AwaitExpression<'ast>) {
     if let Some(format) = self.options.as_ref().map(|option| &option.format) {
-      if !format.keep_esm_import_export() {
+      if !format.keep_esm_import_export_syntax() {
         self.result.errors.push(BuildDiagnostic::unsupported_feature(
           self.file_path.as_str().into(),
           self.source.clone(),

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -29,6 +29,8 @@ use rolldown_utils::path_ext::PathExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 use sugar_path::SugarPath;
 
+use crate::SharedOptions;
+
 #[derive(Debug)]
 pub struct ScanResult {
   pub named_imports: FxHashMap<SymbolRef, NamedImport>,
@@ -79,6 +81,7 @@ pub struct AstScanner<'me, 'ast> {
   ast_usage: EcmaModuleAstUsage,
   cur_class_decl_and_symbol_referenced_ids: Option<(SymbolId, &'me Vec<ReferenceId>)>,
   visit_path: Vec<AstKind<'ast>>,
+  options: Option<&'me SharedOptions>,
 }
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
@@ -92,6 +95,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     source: &'me ArcStr,
     file_path: &'me ModuleId,
     comments: &'me oxc::allocator::Vec<'me, Comment>,
+    options: Option<&'me SharedOptions>,
   ) -> Self {
     let mut symbol_ref_db = SymbolRefDbForModule::new(symbol_table, idx, scope.root_scope_id());
     // This is used for converting "export default foo;" => "var default_symbol = foo;"
@@ -142,6 +146,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       ast_usage: EcmaModuleAstUsage::empty(),
       cur_class_decl_and_symbol_referenced_ids: None,
       visit_path: vec![],
+      options,
     }
   }
 

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -20,6 +20,7 @@ use crate::{
     make_ast_symbol_and_scope::make_ast_scopes_and_symbols,
     parse_to_ecma_ast::{parse_to_ecma_ast, ParseToEcmaAstResult},
   },
+  SharedOptions,
 };
 
 fn scan_ast(
@@ -29,6 +30,7 @@ fn scan_ast(
   symbols: SymbolTable,
   scopes: ScopeTree,
   module_def_format: ModuleDefFormat,
+  options: &SharedOptions,
 ) -> BuildResult<(AstScopes, ScanResult, SymbolRef)> {
   let (symbol_table, ast_scopes) = make_ast_scopes_and_symbols(symbols, scopes);
   let module_id = ModuleId::new(ArcStr::clone(id));
@@ -44,6 +46,7 @@ fn scan_ast(
     ast.source(),
     &module_id,
     ast.comments(),
+    Some(options),
   );
   let namespace_object_ref = scanner.namespace_object_ref;
   let scan_result = scanner.scan(ast.program())?;
@@ -87,6 +90,7 @@ pub async fn create_ecma_view<'any>(
     symbol_table,
     scope_tree,
     ctx.resolved_id.module_def_format,
+    &ctx.options,
   )?;
 
   let ScanResult {

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -90,7 +90,7 @@ pub async fn create_ecma_view<'any>(
     symbol_table,
     scope_tree,
     ctx.resolved_id.module_def_format,
-    &ctx.options,
+    ctx.options,
   )?;
 
   let ScanResult {

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -166,6 +166,7 @@ impl RuntimeModuleTask {
       source,
       &facade_path,
       ast.comments(),
+      None,
     );
     let namespace_object_ref = scanner.namespace_object_ref;
     let scan_result = scanner.scan(ast.program())?;

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -291,7 +291,7 @@ impl<'a> LinkStage<'a> {
             || is_external_dynamic_import(&self.module_table, rec, importer_idx)
           {
             if matches!(rec.kind, ImportKind::Require)
-              || !self.options.format.keep_esm_import_export()
+              || !self.options.format.keep_esm_import_export_syntax()
             {
               if self.options.format.should_call_runtime_require() {
                 stmt_info.referenced_symbols.push(self.runtime.resolve_symbol("__require").into());

--- a/crates/rolldown/tests/esbuild/default/top_level_await_cjs/_config.json
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_cjs/_config.json
@@ -8,5 +8,6 @@
       }
     ],
     "format": "cjs"
-  }
+  },
+  "expectError": true
 }

--- a/crates/rolldown/tests/esbuild/default/top_level_await_cjs/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_cjs/artifacts.snap
@@ -1,15 +1,30 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
-# Assets
+# Errors
 
-## entry.js
+## UNSUPPORTED_FEATURE
 
-```js
+```text
+[UNSUPPORTED_FEATURE] Error: Top-level await is currently not supported with the 'cjs' output format
+   ╭─[/home/victor/Documents/rolldown-rs/rolldown/crates/rolldown/tests/esbuild/default/top_level_await_cjs/entry.js:1:1]
+   │
+ 1 │ await foo;
+   │ ────┬────  
+   │     ╰────── 
+───╯
 
-//#region entry.js
-await foo;
-for await (foo of bar);
+```
+## UNSUPPORTED_FEATURE
 
-//#endregion
+```text
+[UNSUPPORTED_FEATURE] Error: Top-level await is currently not supported with the 'cjs' output format
+   ╭─[/home/victor/Documents/rolldown-rs/rolldown/crates/rolldown/tests/esbuild/default/top_level_await_cjs/entry.js:2:1]
+   │
+ 2 │ for await (foo of bar) ;
+   │ ────────────┬───────────  
+   │             ╰───────────── 
+───╯
+
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_cjs/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_cjs/artifacts.snap
@@ -8,7 +8,7 @@ snapshot_kind: text
 
 ```text
 [UNSUPPORTED_FEATURE] Error: Top-level await is currently not supported with the 'cjs' output format
-   ╭─[/home/victor/Documents/rolldown-rs/rolldown/crates/rolldown/tests/esbuild/default/top_level_await_cjs/entry.js:1:1]
+   ╭─[entry.js:1:1]
    │
  1 │ await foo;
    │ ────┬────  
@@ -20,7 +20,7 @@ snapshot_kind: text
 
 ```text
 [UNSUPPORTED_FEATURE] Error: Top-level await is currently not supported with the 'cjs' output format
-   ╭─[/home/victor/Documents/rolldown-rs/rolldown/crates/rolldown/tests/esbuild/default/top_level_await_cjs/entry.js:2:1]
+   ╭─[entry.js:2:1]
    │
  2 │ for await (foo of bar) ;
    │ ────────────┬───────────  

--- a/crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch/_config.json
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch/_config.json
@@ -6,7 +6,7 @@
         "import": "entry.js"
       }
     ],
-    "treeshake": false,
+    "treeshake": true,
     "format": "cjs"
   },
   "expectExecuted": false

--- a/crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -7,9 +8,4 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 
-//#region entry.js
-if (false) await foo;
-if (false) for await (foo of bar);
-
-//#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch/bypass.md
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch/bypass.md
@@ -1,5 +1,6 @@
 # Reason
-1. should not appear top level `await` in cjs
+1. this is expected, since we don't support `convertMode`
+2. the diff is because oxc eliminated the dead branch
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch/diff.md
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch/diff.md
@@ -11,21 +11,14 @@ if (false) for (foo of bar) ;
 ### rolldown
 ```js
 
-//#region entry.js
-if (false) await foo;
-if (false) for await (foo of bar);
-
-//#endregion
 ```
 ### diff
 ```diff
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,2 +1,2 @@
+@@ -1,2 +0,0 @@
 -if (false) foo;
 -if (false) for (foo of bar) ;
-+if (false) await foo;
-+if (false) for await (foo of bar) ;
 
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_iife/_config.json
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_iife/_config.json
@@ -5,7 +5,9 @@
         "name": "entry",
         "import": "entry.js"
       }
-    ]
+    ],
+    "format": "iife"
   },
-  "expectExecuted": false
+  "expectExecuted": false,
+  "expectError": true
 }

--- a/crates/rolldown/tests/esbuild/default/top_level_await_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_iife/artifacts.snap
@@ -1,15 +1,30 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
-# Assets
+# Errors
 
-## entry.js
+## UNSUPPORTED_FEATURE
 
-```js
+```text
+[UNSUPPORTED_FEATURE] Error: Top-level await is currently not supported with the 'iife' output format
+   ╭─[/home/victor/Documents/rolldown-rs/rolldown/crates/rolldown/tests/esbuild/default/top_level_await_iife/entry.js:1:1]
+   │
+ 1 │ await foo;
+   │ ────┬────  
+   │     ╰────── 
+───╯
 
-//#region entry.js
-await foo;
-for await (foo of bar);
+```
+## UNSUPPORTED_FEATURE
 
-//#endregion
+```text
+[UNSUPPORTED_FEATURE] Error: Top-level await is currently not supported with the 'iife' output format
+   ╭─[/home/victor/Documents/rolldown-rs/rolldown/crates/rolldown/tests/esbuild/default/top_level_await_iife/entry.js:2:1]
+   │
+ 2 │ for await (foo of bar) ;
+   │ ────────────┬───────────  
+   │             ╰───────────── 
+───╯
+
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_iife/artifacts.snap
@@ -8,7 +8,7 @@ snapshot_kind: text
 
 ```text
 [UNSUPPORTED_FEATURE] Error: Top-level await is currently not supported with the 'iife' output format
-   ╭─[/home/victor/Documents/rolldown-rs/rolldown/crates/rolldown/tests/esbuild/default/top_level_await_iife/entry.js:1:1]
+   ╭─[entry.js:1:1]
    │
  1 │ await foo;
    │ ────┬────  
@@ -20,7 +20,7 @@ snapshot_kind: text
 
 ```text
 [UNSUPPORTED_FEATURE] Error: Top-level await is currently not supported with the 'iife' output format
-   ╭─[/home/victor/Documents/rolldown-rs/rolldown/crates/rolldown/tests/esbuild/default/top_level_await_iife/entry.js:2:1]
+   ╭─[entry.js:2:1]
    │
  2 │ for await (foo of bar) ;
    │ ────────────┬───────────  

--- a/crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch/_config.json
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch/_config.json
@@ -7,7 +7,7 @@
       }
     ],
     "format": "iife",
-    "treeshake": false
+    "treeshake": true
   },
   "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -9,10 +10,5 @@ source: crates/rolldown_testing/src/integration_test.rs
 (function() {
 
 
-//#region entry.js
-if (false) await foo;
-if (false) for await (foo of bar);
-
-//#endregion
 })();
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch/bypass.md
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch/bypass.md
@@ -1,6 +1,6 @@
 # Reason
 1. this is expected, since we don't support `convertMode`
-2. the diff is because oxc elimincated the dead branch
+2. the diff is because oxc eliminated the dead branch
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch/bypass.md
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch/bypass.md
@@ -1,5 +1,6 @@
 # Reason
-1. should not appear `await`
+1. this is expected, since we don't support `convertMode`
+2. the diff is because oxc elimincated the dead branch
 # Diff
 ## /out.js
 ### esbuild
@@ -15,11 +16,6 @@
 (function() {
 
 
-//#region entry.js
-if (false) await foo;
-if (false) for await (foo of bar);
-
-//#endregion
 })();
 ```
 ### diff
@@ -27,20 +23,11 @@ if (false) for await (foo of bar);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,4 +1,9 @@
+@@ -1,4 +1,1 @@
 -(() => {
 -    if (false) foo;
 -    if (false) for (foo of bar) ;
 -})();
-+(function() {
-+
-+
-+//#region entry.js
-+if (false) await foo;
-+if (false) for await (foo of bar);
-+
-+//#endregion
-+})();
-\ No newline at end of file
++(function () {})();
 
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch/_config.json
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch/_config.json
@@ -6,7 +6,7 @@
         "import": "entry.js"
       }
     ],
-    "treeshake": false
+    "treeshake": true
   },
   "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 
@@ -7,9 +8,4 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 
-//#region entry.js
-if (false) await foo;
-if (false) for await (foo of bar);
-
-//#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch/bypass.md
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch/bypass.md
@@ -1,5 +1,6 @@
 # Reason
-1. should not appear `await`
+1. this is expected, since we don't support `convertMode`
+2. the diff is because oxc eliminated the dead branch
 # Diff
 ## /out.js
 ### esbuild
@@ -10,21 +11,14 @@ if (false) for (foo of bar) ;
 ### rolldown
 ```js
 
-//#region entry.js
-if (false) await foo;
-if (false) for await (foo of bar);
-
-//#endregion
 ```
 ### diff
 ```diff
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,2 +1,2 @@
+@@ -1,2 +0,0 @@
 -if (false) foo;
 -if (false) for (foo of bar) ;
-+if (false) await foo;
-+if (false) for await (foo of bar) ;
 
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch/_config.json
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch/_config.json
@@ -6,7 +6,7 @@
         "import": "entry.js"
       }
     ],
-    "treeshake": false,
+    "treeshake": true,
     "format": "iife"
   },
   "expectExecuted": false

--- a/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch/artifacts.snap
@@ -10,10 +10,5 @@ snapshot_kind: text
 (function() {
 
 
-//#region entry.js
-if (false) await foo;
-if (false) for await (foo of bar);
-
-//#endregion
 })();
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch/bypass.md
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch/bypass.md
@@ -1,5 +1,6 @@
 # Reason
-1. Strip `await` when format don't support top level await
+1. this is expected, since we don't support `convertMode`
+2. the diff is because oxc eliminated the dead branch
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch/diff.md
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch/diff.md
@@ -14,11 +14,6 @@
 (function() {
 
 
-//#region entry.js
-if (false) await foo;
-if (false) for await (foo of bar);
-
-//#endregion
 })();
 ```
 ### diff
@@ -26,20 +21,11 @@ if (false) for await (foo of bar);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,4 +1,9 @@
+@@ -1,4 +1,1 @@
 -(() => {
 -    if (false) foo;
 -    if (false) for (foo of bar) ;
 -})();
-+(function() {
-+
-+
-+//#region entry.js
-+if (false) await foo;
-+if (false) for await (foo of bar);
-+
-+//#endregion
-+})();
-\ No newline at end of file
++(function () {})();
 
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -1688,11 +1688,10 @@ snapshot_kind: text
 
 # tests/esbuild/default/top_level_await_cjs
 
-- entry-!~{000}~.js => entry-VXzlnig-.js
 
 # tests/esbuild/default/top_level_await_cjs_dead_branch
 
-- entry-!~{000}~.js => entry-oqFOgXef.js
+- entry-!~{000}~.js => entry-jF2aLy7c.js
 
 # tests/esbuild/default/top_level_await_esm
 
@@ -1712,11 +1711,10 @@ snapshot_kind: text
 
 # tests/esbuild/default/top_level_await_iife
 
-- entry-!~{000}~.js => entry-VXzlnig-.js
 
 # tests/esbuild/default/top_level_await_iife_dead_branch
 
-- entry-!~{000}~.js => entry-2jMdEfYq.js
+- entry-!~{000}~.js => entry-gy9jBlL5.js
 
 # tests/esbuild/default/top_level_await_no_bundle
 
@@ -1748,7 +1746,7 @@ snapshot_kind: text
 
 # tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch
 
-- entry-!~{000}~.js => entry-2jMdEfYq.js
+- entry-!~{000}~.js => entry-gy9jBlL5.js
 
 # tests/esbuild/default/top_level_return_forbidden_export
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -1726,7 +1726,7 @@ snapshot_kind: text
 
 # tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch
 
-- entry-!~{000}~.js => entry-oqFOgXef.js
+- entry-!~{000}~.js => entry-jF2aLy7c.js
 
 # tests/esbuild/default/top_level_await_no_bundle_dead_branch
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
@@ -24,7 +24,7 @@ impl OutputFormat {
   }
 
   #[inline]
-  pub fn keep_esm_import_export(&self) -> bool {
+  pub fn keep_esm_import_export_syntax(&self) -> bool {
     matches!(self, Self::Esm)
   }
 

--- a/crates/rolldown_error/src/build_error/error_constructors.rs
+++ b/crates/rolldown_error/src/build_error/error_constructors.rs
@@ -17,6 +17,7 @@ use crate::events::missing_name_option_for_umd_export::MissingNameOptionForUmdEx
 use crate::events::resolve_error::DiagnosableResolveError;
 use crate::events::unhandleable_error::UnhandleableError;
 use crate::events::unloadable_dependency::{UnloadableDependency, UnloadableDependencyContext};
+use crate::events::unsupported_feature::UnsupportedFeature;
 use crate::events::DiagnosableArcstr;
 use crate::events::{
   ambiguous_external_namespace::{AmbiguousExternalNamespace, AmbiguousExternalNamespaceModule},
@@ -174,6 +175,15 @@ impl BuildDiagnostic {
     stable_importer: String,
   ) -> Self {
     Self::new_inner(ImportIsUndefined { filename, source, span, name, stable_importer })
+  }
+
+  pub fn unsupported_feature(
+    filename: ArcStr,
+    source: ArcStr,
+    span: Span,
+    error_message: String,
+  ) -> Self {
+    Self::new_inner(UnsupportedFeature { filename, source, span, error_message })
   }
 
   // --- Rolldown related

--- a/crates/rolldown_error/src/event_kind.rs
+++ b/crates/rolldown_error/src/event_kind.rs
@@ -31,7 +31,7 @@ pub enum EventKind {
   CommonJsVariableInEsm,
   ExportUndefinedVariable,
   ImportIsUndefined,
-
+  UnsupportedFeature,
   UnhandleableError,
 }
 
@@ -67,6 +67,7 @@ impl Display for EventKind {
       },
       EventKind::ImportIsUndefined => write!(f, "IMPORT_IS_UNDEFINED"),
       EventKind::UnhandleableError => write!(f, "UNHANDLEABLE_ERROR"),
+      EventKind::UnsupportedFeature => write!(f, "UNSUPPORTED_FEATURE"),
     }
   }
 }

--- a/crates/rolldown_error/src/events/mod.rs
+++ b/crates/rolldown_error/src/events/mod.rs
@@ -31,6 +31,7 @@ pub mod unloadable_dependency;
 pub mod unresolved_entry;
 pub mod unresolved_import;
 pub mod unresolved_import_treated_as_external;
+pub mod unsupported_feature;
 
 pub trait BuildEvent: Debug + Sync + Send {
   fn kind(&self) -> EventKind;

--- a/crates/rolldown_error/src/events/unsupported_feature.rs
+++ b/crates/rolldown_error/src/events/unsupported_feature.rs
@@ -18,10 +18,11 @@ impl BuildEvent for UnsupportedFeature {
     crate::event_kind::EventKind::UnsupportedFeature
   }
 
-  fn on_diagnostic(&self, diagnostic: &mut Diagnostic, _opts: &DiagnosticOptions) {
+  fn on_diagnostic(&self, diagnostic: &mut Diagnostic, opts: &DiagnosticOptions) {
     diagnostic.title.clone_from(&self.error_message);
 
-    let file_id = diagnostic.add_file(self.filename.clone(), self.source.clone());
+    let file_id =
+      diagnostic.add_file(opts.stabilize_path(self.filename.as_str()), self.source.clone());
     diagnostic.add_label(&file_id, self.span.start..self.span.end, "".to_string());
   }
 

--- a/crates/rolldown_error/src/events/unsupported_feature.rs
+++ b/crates/rolldown_error/src/events/unsupported_feature.rs
@@ -23,7 +23,7 @@ impl BuildEvent for UnsupportedFeature {
 
     let file_id =
       diagnostic.add_file(opts.stabilize_path(self.filename.as_str()), self.source.clone());
-    diagnostic.add_label(&file_id, self.span.start..self.span.end, "".to_string());
+    diagnostic.add_label(&file_id, self.span.start..self.span.end, String::new());
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/unsupported_feature.rs
+++ b/crates/rolldown_error/src/events/unsupported_feature.rs
@@ -1,0 +1,31 @@
+use arcstr::ArcStr;
+use oxc::span::Span;
+
+use crate::{diagnostic::Diagnostic, types::diagnostic_options::DiagnosticOptions};
+
+use super::BuildEvent;
+
+#[derive(Debug)]
+pub struct UnsupportedFeature {
+  pub(crate) source: ArcStr,
+  pub(crate) filename: ArcStr,
+  pub(crate) span: Span,
+  pub(crate) error_message: String,
+}
+
+impl BuildEvent for UnsupportedFeature {
+  fn kind(&self) -> crate::event_kind::EventKind {
+    crate::event_kind::EventKind::UnsupportedFeature
+  }
+
+  fn on_diagnostic(&self, diagnostic: &mut Diagnostic, _opts: &DiagnosticOptions) {
+    diagnostic.title.clone_from(&self.error_message);
+
+    let file_id = diagnostic.add_file(self.filename.clone(), self.source.clone());
+    diagnostic.add_label(&file_id, self.span.start..self.span.end, "".to_string());
+  }
+
+  fn message(&self, _opts: &DiagnosticOptions) -> String {
+    self.error_message.clone()
+  }
+}

--- a/scripts/snap-diff/stats/aggregated-reason.md
+++ b/scripts/snap-diff/stats/aggregated-reason.md
@@ -316,14 +316,8 @@
 - crates/rolldown/tests/esbuild/default/top_level_await_allowed_import_with_splitting
 ## Can't disable bundle splitting
 - crates/rolldown/tests/esbuild/default/top_level_await_allowed_import_without_splitting
-## should not appear top level `await` in cjs
-- crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch
 ## should not appear `__commonJS`
 - crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch
-## should not appear `await`
-- crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch
-## Strip `await` when format don't support top level await
-- crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch
 ## inject path
 - crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_issue1837
 ## should not drop `'use strict'`

--- a/scripts/snap-diff/stats/aggregated-reason.md
+++ b/scripts/snap-diff/stats/aggregated-reason.md
@@ -154,9 +154,6 @@
 ## rolldown split chunks
 - crates/rolldown/tests/esbuild/default/import_namespace_this_value
 - crates/rolldown/tests/esbuild/default/multiple_entry_points_same_name_collision
-## should not appear `await`
-- crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch
-- crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch
 ## rolldown has redundant `import "external"`
 - crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle
 - crates/rolldown/tests/esbuild/importstar/re_export_star_external_es6
@@ -323,6 +320,8 @@
 - crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch
 ## should not appear `__commonJS`
 - crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch
+## should not appear `await`
+- crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch
 ## Strip `await` when format don't support top level await
 - crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch
 ## inject path

--- a/scripts/snap-diff/stats/stats.md
+++ b/scripts/snap-diff/stats/stats.md
@@ -1,7 +1,7 @@
 # Compatibility metric
 - total: 784
-- passed: 427
-- passed ratio: 54.46%
+- passed: 428
+- passed ratio: 54.59%
 # Compatibility metric details
 ## dce
 - total: 113
@@ -9,8 +9,8 @@
 - passed ratio: 68.14%
 ## default
 - total: 254
-- passed: 140
-- passed ratio: 55.12%
+- passed: 141
+- passed ratio: 55.51%
 ## glob
 - total: 9
 - passed: 1

--- a/scripts/snap-diff/stats/stats.md
+++ b/scripts/snap-diff/stats/stats.md
@@ -1,7 +1,7 @@
 # Compatibility metric
 - total: 784
-- passed: 428
-- passed ratio: 54.59%
+- passed: 431
+- passed ratio: 54.97%
 # Compatibility metric details
 ## dce
 - total: 113
@@ -9,8 +9,8 @@
 - passed ratio: 68.14%
 ## default
 - total: 254
-- passed: 141
-- passed ratio: 55.51%
+- passed: 144
+- passed ratio: 56.69%
 ## glob
 - total: 9
 - passed: 1

--- a/scripts/snap-diff/summary/default.md
+++ b/scripts/snap-diff/summary/default.md
@@ -213,8 +213,6 @@
   diff
 ## [top_level_await_forbidden_require_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/diff.md)
   diff
-## [top_level_await_iife_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch/diff.md)
-  diff
 ## [top_level_await_no_bundle_common_js_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch/diff.md)
   diff
 ## [top_level_await_no_bundle_iife_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch/diff.md)
@@ -363,6 +361,7 @@
 ## [source_map](../../../crates/rolldown/tests/esbuild/default/source_map/bypass.md)
 ## [strict_mode_nested_fn_decl_keep_names_variable_inlining_issue1552](../../../crates/rolldown/tests/esbuild/default/strict_mode_nested_fn_decl_keep_names_variable_inlining_issue1552/bypass.md)
 ## [switch_scope_no_bundle](../../../crates/rolldown/tests/esbuild/default/switch_scope_no_bundle/bypass.md)
+## [top_level_await_iife_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch/bypass.md)
 ## [use_strict_directive_bundle_cjs_issue2264](../../../crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_cjs_issue2264/bypass.md)
 ## [var_relocating_bundle](../../../crates/rolldown/tests/esbuild/default/var_relocating_bundle/bypass.md)
 ## [var_relocating_no_bundle](../../../crates/rolldown/tests/esbuild/default/var_relocating_no_bundle/bypass.md)

--- a/scripts/snap-diff/summary/default.md
+++ b/scripts/snap-diff/summary/default.md
@@ -209,13 +209,7 @@
   diff
 ## [top_level_await_allowed_import_without_splitting](../../../crates/rolldown/tests/esbuild/default/top_level_await_allowed_import_without_splitting/diff.md)
   diff
-## [top_level_await_cjs_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch/diff.md)
-  diff
 ## [top_level_await_forbidden_require_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/diff.md)
-  diff
-## [top_level_await_no_bundle_common_js_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch/diff.md)
-  diff
-## [top_level_await_no_bundle_iife_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch/diff.md)
   diff
 ## [use_strict_directive_bundle_iife_issue2264](../../../crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_iife_issue2264/diff.md)
   diff
@@ -361,7 +355,10 @@
 ## [source_map](../../../crates/rolldown/tests/esbuild/default/source_map/bypass.md)
 ## [strict_mode_nested_fn_decl_keep_names_variable_inlining_issue1552](../../../crates/rolldown/tests/esbuild/default/strict_mode_nested_fn_decl_keep_names_variable_inlining_issue1552/bypass.md)
 ## [switch_scope_no_bundle](../../../crates/rolldown/tests/esbuild/default/switch_scope_no_bundle/bypass.md)
+## [top_level_await_cjs_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_cjs_dead_branch/bypass.md)
 ## [top_level_await_iife_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_iife_dead_branch/bypass.md)
+## [top_level_await_no_bundle_common_js_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_common_js_dead_branch/bypass.md)
+## [top_level_await_no_bundle_iife_dead_branch](../../../crates/rolldown/tests/esbuild/default/top_level_await_no_bundle_iife_dead_branch/bypass.md)
 ## [use_strict_directive_bundle_cjs_issue2264](../../../crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_cjs_issue2264/bypass.md)
 ## [var_relocating_bundle](../../../crates/rolldown/tests/esbuild/default/var_relocating_bundle/bypass.md)
 ## [var_relocating_no_bundle](../../../crates/rolldown/tests/esbuild/default/var_relocating_no_bundle/bypass.md)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. related to https://github.com/evanw/esbuild/commit/5fe21253ee75fb4c5ea395a0877b2a5ab51c3575#diff-f312cd3ffe8d88cf424d3f0bd04b41e5b0ad36e549874b5688028bf9091a61f5L2238
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
