### PR TITLE
refactor(node/types): remove unnecessary `OverwriteInputOptionsWithDoc`

### DIFF
--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -16,7 +16,7 @@ import type {
   InputOption,
   JsxOptions,
   ModuleTypes,
-  RawInputOptions,
+  InputOptions,
   WatchOptions,
 } from '../types/input-options'
 import type { StringOrRegExp } from '../types/utils'
@@ -165,7 +165,7 @@ export const inputOptionsSchema = z.strictObject({
   profilerNames: z.boolean().optional(),
   jsx: jsxOptionsSchema.optional(),
   watch: watchOptionsSchema.or(z.literal(false)).optional(),
-}) satisfies z.ZodType<RawInputOptions>
+}) satisfies z.ZodType<InputOptions>
 
 export const inputCliOptionsSchema = inputOptionsSchema
   .extend({

--- a/packages/rolldown/src/types/input-options.ts
+++ b/packages/rolldown/src/types/input-options.ts
@@ -56,7 +56,7 @@ export interface WatchOptions {
   chokidar?: any
 }
 
-export interface RawInputOptions {
+export interface InputOptions {
   input?: InputOption
   plugins?: RolldownPluginRec[]
   external?: ExternalOption
@@ -99,33 +99,6 @@ export interface RawInputOptions {
     disableLiveBindings?: boolean
   }
   define?: Record<string, string>
-  inject?: Record<string, string | [string, string]>
-  profilerNames?: boolean
-  jsx?: JsxOptions
-  watch?: WatchOptions | false
-}
-
-interface OverwriteInputOptionsForCli {
-  external?: string[]
-  inject?: Record<string, string>
-  treeshake?: boolean
-}
-
-export type InputCliOptions = Omit<
-  RawInputOptions,
-  | keyof OverwriteInputOptionsForCli
-  | 'input'
-  | 'plugins'
-  | 'onwarn'
-  | 'onLog'
-  | 'resolve'
-  | 'experimental'
-  | 'profilerNames'
-  | 'watch'
-> &
-  OverwriteInputOptionsForCli
-
-interface OverwriteInputOptionsWithDoc {
   /**
    * Inject import statements on demand.
    *
@@ -149,11 +122,28 @@ interface OverwriteInputOptionsWithDoc {
    * }
    * ```
    */
-  inject?: RawInputOptions['inject']
+  inject?: Record<string, string | [string, string]>
+  profilerNames?: boolean
+  jsx?: JsxOptions
+  watch?: WatchOptions | false
 }
 
-export type InputOptions = Omit<
-  RawInputOptions,
-  keyof OverwriteInputOptionsWithDoc
+interface OverwriteInputOptionsForCli {
+  external?: string[]
+  inject?: Record<string, string>
+  treeshake?: boolean
+}
+
+export type InputCliOptions = Omit<
+  InputOptions,
+  | keyof OverwriteInputOptionsForCli
+  | 'input'
+  | 'plugins'
+  | 'onwarn'
+  | 'onLog'
+  | 'resolve'
+  | 'experimental'
+  | 'profilerNames'
+  | 'watch'
 > &
-  OverwriteInputOptionsWithDoc
+  OverwriteInputOptionsForCli


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We now could write jsdoc directly after #2611. No need to have a new type anymore.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
