### PR TITLE
fix: use timer instead of watcher worker

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -44,7 +44,6 @@
       "require": "./dist/cjs/parallel-plugin.cjs",
       "import": "./dist/esm/parallel-plugin.mjs"
     },
-    "./watcher-worker": "./dist/shared/watcher-worker.js",
     "./package.json": "./package.json"
   },
   "imports": {

--- a/packages/rolldown/rolldown.config.mjs
+++ b/packages/rolldown/rolldown.config.mjs
@@ -80,14 +80,6 @@ export default defineConfig([
             fsExtra.copyFileSync(file, nodePath.join(copyTo, fileName))
           })
 
-          // Move watcher-worker file to dist
-          const fileName = 'watcher-worker.js'
-          console.log('[build:done] Copying', fileName, 'to ./dist/shared')
-          fsExtra.copyFileSync(
-            nodePath.join('./src', fileName),
-            nodePath.join(copyTo, fileName),
-          )
-
           // Copy binding types and rollup types to dist
           const distTypesDir = nodePath.resolve(outputDir, 'types')
           fsExtra.ensureDirSync(distTypesDir)

--- a/packages/rolldown/src/watcher-worker.js
+++ b/packages/rolldown/src/watcher-worker.js
@@ -1,1 +1,0 @@
-while (true) {}

--- a/packages/rolldown/src/watcher.ts
+++ b/packages/rolldown/src/watcher.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process'
 import { BindingWatcher, BindingWatcherEvent } from './binding'
 import { MaybePromise } from './types/utils'
 
@@ -77,12 +76,9 @@ export class Watcher {
   // The rust side already create a thread for watcher, but it isn't at main thread.
   // So here we need to spawn a process to avoid main process exit util the user call `watcher.close()`.
   watch() {
-    const watcherWorkerPath = require.resolve('rolldown/watcher-worker')
-    const child = spawn(process.argv[0], [watcherWorkerPath], {
-      signal: this.controller.signal,
-    })
-    child.on('error', () => {
-      /* ignore AbortError */
+    const timer = setInterval(() => {}, 1e9 /* Low power usage */)
+    this.controller.signal.addEventListener('abort', () => {
+      clearTimeout(timer)
     })
   }
 }

--- a/packages/rolldown/src/watcher.ts
+++ b/packages/rolldown/src/watcher.ts
@@ -78,7 +78,7 @@ export class Watcher {
   watch() {
     const timer = setInterval(() => {}, 1e9 /* Low power usage */)
     this.controller.signal.addEventListener('abort', () => {
-      clearTimeout(timer)
+      clearInterval(timer)
     })
   }
 }


### PR DESCRIPTION
### Description

Half of #2634

Alternative to #2635

Let me know @underfin if this breaks something else, but I think it should be functionally equivalent and avoid an extra thread...