### PR TITLE
chore: improve watch test

### DIFF
--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -170,7 +170,7 @@ test.sequential('PluginContext addWatchFile', async () => {
   expect(changeFn).toBeCalled()
 
   // revert change
-  fs.writeFileSync(foo, 'console.log(1)')
+  fs.writeFileSync(foo, 'console.log(1)\n')
   await watcher.close()
 })
 
@@ -195,7 +195,7 @@ test.sequential('watch include/exclude', async () => {
   expect(fs.readFileSync(output, 'utf-8').includes('console.log(1)')).toBe(true)
 
   // revert change
-  fs.writeFileSync(input, 'console.log(1)')
+  fs.writeFileSync(input, 'console.log(1)\n')
   await watcher.close()
 })
 


### PR DESCRIPTION
### Description

Every time I run `just test`, the js snapshots of the watch test get updated. If we mistakenly `git add` them, the `lint-staged` pre-commit hook will throw an error during commit, which can often be confusing.

![image](https://github.com/user-attachments/assets/d8c4f9ce-c4d7-4c43-bc73-942ef24128b8)

