### PR TITLE
chore: bypass ts-import equals dce testing

### DIFF
--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_bundle/bypass.md
@@ -1,5 +1,6 @@
 # Reason
-1. not support ts import equal
+1. rolldown is not ts aware, it's not possibly support for now
+2. sub optimal
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_elimination_test/bypass.md
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_elimination_test/bypass.md
@@ -1,5 +1,6 @@
 # Reason
-1. not support ts import equal
+1. rolldown is not ts aware, it's not possibly support for now
+2. sub optimal
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_tree_shaking_false/bypass.md
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_tree_shaking_false/bypass.md
@@ -1,5 +1,6 @@
 # Reason
-1. not support ts import equal
+1. rolldown is not ts aware, it's not possible to support for now
+2. sub optimal
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_tree_shaking_true/bypass.md
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_tree_shaking_true/bypass.md
@@ -1,5 +1,6 @@
 # Reason
-1. not support ts import equal
+1. rolldown is not ts aware, it's not possible to support for now
+2. sub optimal
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/bypass.md
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/bypass.md
@@ -1,5 +1,6 @@
 # Reason
-1. not support ts import equal
+1. rolldown is not ts aware, it's not possible to support for now
+2. sub optimal
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -78,6 +78,7 @@ pub struct BindingInputOptions {
 
   pub module_types: Option<HashMap<String, String>>,
   pub define: Option<Vec<(/* Target to be replaced */ String, /* Replacement */ String)>>,
+  pub drop_labels: Option<Vec<String>>,
   #[serde(skip_deserializing)]
   #[napi(ts_type = "Array<BindingInjectImportNamed | BindingInjectImportNamespace>")]
   pub inject: Option<Vec<BindingInjectImport>>,

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -204,8 +204,7 @@ pub fn normalize_binding_options(
     jsx: input_options.jsx.map(Into::into),
     watch: input_options.watch.map(TryInto::try_into).transpose()?,
     comments: None,
-    // TODO: binding
-    drop_labels: None,
+    drop_labels: input_options.drop_labels,
   };
 
   #[cfg(not(target_family = "wasm"))]

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -234,6 +234,7 @@ export interface BindingInputOptions {
   treeshake?: BindingTreeshake
   moduleTypes?: Record<string, string>
   define?: Array<[string, string]>
+  dropLabels?: Array<string>
   inject?: Array<BindingInjectImportNamed | BindingInjectImportNamespace>
   experimental?: BindingExperimentalOptions
   profilerNames?: boolean

--- a/packages/rolldown/src/options/bindingify-input-options.ts
+++ b/packages/rolldown/src/options/bindingify-input-options.ts
@@ -133,6 +133,7 @@ export function bindingifyInputOptions(
     profilerNames: options?.profilerNames,
     jsx: bindingifyJsx(options.jsx),
     watch: bindingifyWatch(options.watch),
+    dropLabels: options.dropLabels,
   }
 }
 

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -165,6 +165,7 @@ export const inputOptionsSchema = z.strictObject({
   profilerNames: z.boolean().optional(),
   jsx: jsxOptionsSchema.optional(),
   watch: watchOptionsSchema.or(z.literal(false)).optional(),
+  dropLabels: z.array(z.string()).optional(),
 }) satisfies z.ZodType<InputOptions>
 
 export const inputCliOptionsSchema = inputOptionsSchema

--- a/packages/rolldown/src/types/input-options.ts
+++ b/packages/rolldown/src/types/input-options.ts
@@ -126,6 +126,7 @@ export interface InputOptions {
   profilerNames?: boolean
   jsx?: JsxOptions
   watch?: WatchOptions | false
+  dropLabels?: string[]
 }
 
 interface OverwriteInputOptionsForCli {

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -27,6 +27,7 @@ OPTIONS
   --chunk-file-names <name>   .
   --cwd <cwd>                 Current working directory.
   --define <define>           Define global variables.
+  --drop-labels <drop-labels> .
   --entry-file-names <name>   .
   --es-module                 Always generate \`__esModule\` marks in non-ESM formats, defaults to \`if-default-prop\` (use \`--no-esModule\` to always disable).
   --exports <exports>         Specify a export mode (auto, named, default, none).

--- a/packages/rolldown/tests/fixtures/misc/drop-labels/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/drop-labels/basic/_config.ts
@@ -1,0 +1,12 @@
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    dropLabels: ['DROP'],
+  },
+  afterTest: (output) => {
+    expect(output.output[0].code).not.toContain('DROP')
+    expect(output.output[0].code).toContain('console.log')
+  },
+})

--- a/packages/rolldown/tests/fixtures/misc/drop-labels/basic/main.js
+++ b/packages/rolldown/tests/fixtures/misc/drop-labels/basic/main.js
@@ -1,0 +1,4 @@
+DROP: if (test) {
+}
+
+console.log('hello')

--- a/scripts/snap-diff/stats/aggregated-reason.md
+++ b/scripts/snap-diff/stats/aggregated-reason.md
@@ -101,12 +101,6 @@
 - crates/rolldown/tests/esbuild/loader/loader_file_public_path_css
 - crates/rolldown/tests/esbuild/loader/loader_file_relative_path_asset_names_css
 - crates/rolldown/tests/esbuild/loader/loader_file_relative_path_css
-## not support ts import equal
-- crates/rolldown/tests/esbuild/ts/ts_import_equals_bundle
-- crates/rolldown/tests/esbuild/ts/ts_import_equals_elimination_test
-- crates/rolldown/tests/esbuild/ts/ts_import_equals_tree_shaking_false
-- crates/rolldown/tests/esbuild/ts/ts_import_equals_tree_shaking_true
-- crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import
 ## throw should be kept
 - crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_intermediate_files_chain_all
 - crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_intermediate_files_chain_one

--- a/scripts/snap-diff/stats/stats.md
+++ b/scripts/snap-diff/stats/stats.md
@@ -1,7 +1,7 @@
 # Compatibility metric
 - total: 784
-- passed: 437
-- passed ratio: 55.74%
+- passed: 442
+- passed ratio: 56.38%
 # Compatibility metric details
 ## dce
 - total: 113
@@ -41,5 +41,5 @@
 - passed ratio: 91.30%
 ## ts
 - total: 81
-- passed: 28
-- passed ratio: 34.57%
+- passed: 33
+- passed ratio: 40.74%

--- a/scripts/snap-diff/summary/ts.md
+++ b/scripts/snap-diff/summary/ts.md
@@ -73,16 +73,6 @@
   diff
 ## [ts_implicit_extensions](../../../crates/rolldown/tests/esbuild/ts/ts_implicit_extensions/diff.md)
   diff
-## [ts_import_equals_bundle](../../../crates/rolldown/tests/esbuild/ts/ts_import_equals_bundle/diff.md)
-  diff
-## [ts_import_equals_elimination_test](../../../crates/rolldown/tests/esbuild/ts/ts_import_equals_elimination_test/diff.md)
-  diff
-## [ts_import_equals_tree_shaking_false](../../../crates/rolldown/tests/esbuild/ts/ts_import_equals_tree_shaking_false/diff.md)
-  diff
-## [ts_import_equals_tree_shaking_true](../../../crates/rolldown/tests/esbuild/ts/ts_import_equals_tree_shaking_true/diff.md)
-  diff
-## [ts_import_equals_undefined_import](../../../crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/diff.md)
-  diff
 ## [ts_import_in_node_modules_name_collision_with_css](../../../crates/rolldown/tests/esbuild/ts/ts_import_in_node_modules_name_collision_with_css/diff.md)
   diff
 ## [ts_import_mts](../../../crates/rolldown/tests/esbuild/ts/ts_import_mts/diff.md)
@@ -125,6 +115,11 @@
 ## [ts_abstract_class_field_use_assign](../../../crates/rolldown/tests/esbuild/ts/ts_abstract_class_field_use_assign/bypass.md)
 ## [ts_enum_define](../../../crates/rolldown/tests/esbuild/ts/ts_enum_define/bypass.md)
 ## [ts_export_namespace](../../../crates/rolldown/tests/esbuild/ts/ts_export_namespace/bypass.md)
+## [ts_import_equals_bundle](../../../crates/rolldown/tests/esbuild/ts/ts_import_equals_bundle/bypass.md)
+## [ts_import_equals_elimination_test](../../../crates/rolldown/tests/esbuild/ts/ts_import_equals_elimination_test/bypass.md)
+## [ts_import_equals_tree_shaking_false](../../../crates/rolldown/tests/esbuild/ts/ts_import_equals_tree_shaking_false/bypass.md)
+## [ts_import_equals_tree_shaking_true](../../../crates/rolldown/tests/esbuild/ts/ts_import_equals_tree_shaking_true/bypass.md)
+## [ts_import_equals_undefined_import](../../../crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/bypass.md)
 ## [ts_minified_bundle_es6](../../../crates/rolldown/tests/esbuild/ts/ts_minified_bundle_es6/bypass.md)
 ## [ts_minify_enum](../../../crates/rolldown/tests/esbuild/ts/ts_minify_enum/bypass.md)
 ## [ts_minify_namespace](../../../crates/rolldown/tests/esbuild/ts/ts_minify_namespace/bypass.md)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
**ts-import-equals** will be transformed into `var id = foo.bar` and this is considered as side effects, we can't support this until we are ts syntax aware.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
