### PR TITLE
chore(repo/lint): prefer relative paths while using lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+npx lint-staged --relative

--- a/.oxlintignore
+++ b/.oxlintignore
@@ -1,5 +1,5 @@
 crates/**
 packages/rollup-tests/**
-packages/rolldown/tests/fixtures
+packages/rolldown/tests/fixtures/**
 packages/rolldown/src/binding.d.ts
 rollup/**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Seems that `oxlint --ignore-path=.oxlintignore` only ignore passed relative paths. If passing absolute path, oxlint would lint it always, this is not expected when commiting ignored files.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
