### PR TITLE
refactor:  simplify inserting stmts at the front of program body

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -202,12 +202,11 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
     // 3. hoisted_names
     // 4. wrapped module declaration
     let declaration_of_module_namespace_object = if is_namespace_referenced {
-      let mut stmts = self.generate_declaration_of_module_namespace_object();
+      let stmts = self.generate_declaration_of_module_namespace_object();
       if needs_wrapper {
         stmts
       } else {
-        stmts.extend(program.body.take_in(self.alloc));
-        program.body.extend(stmts);
+        program.body.splice(0..0, stmts);
         vec![]
       }
     } else {


### PR DESCRIPTION

Codebase simplification:

* [`crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs`](diffhunk://#diff-538fbb60868c8a2fff29b32bec0f81a30325ed6cbd8dcfaecc091c40fccc33e6L205-R209): Replaced the use of `extend` and `take_in` with `splice` to simplify the insertion of statements into the `program.body`.<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
