### PR TITLE
chore: add `cspell` to `lint-staged`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "*.{js,ts,json,md,yml,yaml,vue}": [
       "prettier --write",
       "pnpm lint-code -- --fix"
-    ]
+    ],
+    "*": "cspell --no-progress --gitignore --no-must-find-files"
   }
 }


### PR DESCRIPTION
### Description

Each time we commit code, if there are spelling issues detected by `cspell`, we would have to re-commit and re-run CI. Therefore, we can add `cspell` to `lint-staged` to catch these issues earlier and avoid unnecessary commits.