### PR TITLE
fix: check falsy plugin in options hook

### DIFF
--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -300,5 +300,8 @@ export interface Plugin<A = any> extends OutputPlugin, Partial<PluginHooks> {
 }
 
 export type RolldownPlugin<A = any> = Plugin<A> | BuiltinPlugin | ParallelPlugin
+export type RolldownPluginOption<A = any> = NullValue<RolldownPlugin<A>> | false
 // A recursive type definition for `RolldownPlugin`, this type is used internally for `config.plugins`
-export type RolldownPluginRec<A = any> = RolldownPlugin<A> | RolldownPlugin<A>[]
+export type RolldownPluginRec<A = any> =
+  | RolldownPluginOption<A>
+  | RolldownPluginOption<A>[]

--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -99,6 +99,9 @@ export class PluginDriver {
 
 export function getObjectPlugins(plugins: RolldownPluginRec[]): Plugin[] {
   return plugins.filter((plugin) => {
+    if (!plugin) {
+      return undefined
+    }
     if ('_parallel' in plugin) {
       return undefined
     }

--- a/packages/rolldown/tests/fixtures/plugin/falsy/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/falsy/_config.ts
@@ -1,0 +1,7 @@
+import { defineTest } from '@tests'
+
+export default defineTest({
+  config: {
+    plugins: [null, undefined, false],
+  },
+})

--- a/packages/rolldown/tests/fixtures/plugin/falsy/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/falsy/main.js
@@ -1,0 +1,1 @@
+console.log()


### PR DESCRIPTION
According to rollup's document, `config.plugins` supports falsy values. And in rolldown's [code](https://github.com/rolldown/rolldown/blob/f3a159b51ce05b6b513d121d279cd3b9a799544a/packages/rolldown/src/utils/normalize-plugin-option.ts#L10), it indeed implement this feature.

However, this [line](https://github.com/rolldown/rolldown/pull/2670/files#diff-48cd2591bdcb44946219841aaccab8eb2d54381960f9607cb7542c40f446d92eR105) doesn't take possible falsy values into consideration, which cause's error:
```
file:///Users/miles/Desktop/projects/xxx/node_modules/.pnpm/rolldown@https+++pkg.pr.new+rolldown@a50a3b2/node_modules/rolldown/dist/shared/src_index-Nma-IVaO.mjs:997
                if ("_parallel"in plugin) {
                               ^

TypeError: Cannot use 'in' operator to search for '_parallel' in false
    at file:///Users/miles/Desktop/projects/xxx/node_modules/.pnpm/rolldown@https+++pkg.pr.new+rolldown@a50a3b2/node_modules/rolldown/dist/shared/src_index-Nma-IVaO.mjs:997:18
    at Array.filter (<anonymous>)
    at getObjectPlugins (file:///Users/miles/Desktop/projects/xxx/node_modules/.pnpm/rolldown@https+++pkg.pr.new+rolldown@a50a3b2/node_modules/rolldown/dist/shared/src_index-Nma-IVaO.mjs:996:17)
    at PluginDriver.callOptionsHook (file:///Users/miles/Desktop/projects/xxx/node_modules/.pnpm/rolldown@https+++pkg.pr.new+rolldown@a50a3b2/node_modules/rolldown/dist/shared/src_index-Nma-IVaO.mjs:955:47)
    at createBundler (file:///Users/miles/Desktop/projects/xxx/node_modules/.pnpm/rolldown@https+++pkg.pr.new+rolldown@a50a3b2/node_modules/rolldown/dist/shared/src_index-Nma-IVaO.mjs:2642:36)
    at watch (file:///Users/miles/Desktop/projects/xxx/node_modules/.pnpm/rolldown@https+++pkg.pr.new+rolldown@a50a3b2/node_modules/rolldown/dist/shared/src_index-Nma-IVaO.mjs:2758:63)
    at file:///Users/miles/Desktop/projects/xxx/cli.js:50:25
```

This pr
- add falsy types in config plugin's declaration
- and check it at the necessary possible