### PR TITLE
chore: skip pure transformation test case

### DIFF
--- a/crates/rolldown/tests/esbuild/lower/class_super_this_issue242_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/class_super_this_issue242_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_async2016_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_async2016_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_async2017_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_async2017_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_async_super_es2016_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_super_es2016_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_async_super_es2017_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_super_es2017_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_class_field2020_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_class_field2020_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_class_field_next_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_class_field_next_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_export_star_as_name_collision_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_export_star_as_name_collision_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_object_spread_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_object_spread_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_optional_catch_name_collision_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_optional_catch_name_collision_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_private_class_expr2020_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_class_expr2020_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2015_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2015_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild
@@ -21,7 +23,7 @@ class Foo {
     __privateSet(this, _x, __privateGet(this, _x) * 1);
     __privateSet(this, _x, __privateGet(this, _x) / 1);
     __privateSet(this, _x, __privateGet(this, _x) % 1);
-    __privateSet(this, _x, __privateGet(this, _x) ** 1);
+    __privateSet(this, _x, __pow(__privateGet(this, _x), 1));
     __privateSet(this, _x, __privateGet(this, _x) << 1);
     __privateSet(this, _x, __privateGet(this, _x) >> 1);
     __privateSet(this, _x, __privateGet(this, _x) >>> 1);
@@ -64,7 +66,7 @@ _x = new WeakMap();
 -        __privateSet(this, _x, __privateGet(this, _x) * 1);
 -        __privateSet(this, _x, __privateGet(this, _x) / 1);
 -        __privateSet(this, _x, __privateGet(this, _x) % 1);
--        __privateSet(this, _x, __privateGet(this, _x) ** 1);
+-        __privateSet(this, _x, __pow(__privateGet(this, _x), 1));
 -        __privateSet(this, _x, __privateGet(this, _x) << 1);
 -        __privateSet(this, _x, __privateGet(this, _x) >> 1);
 -        __privateSet(this, _x, __privateGet(this, _x) >>> 1);

--- a/crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2019_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2019_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild
@@ -14,6 +16,7 @@ class Foo {
     --__privateWrapper(this, _x)._;
   }
   binary() {
+    var _a;
     __privateSet(this, _x, 1);
     __privateSet(this, _x, __privateGet(this, _x) + 1);
     __privateSet(this, _x, __privateGet(this, _x) - 1);
@@ -29,7 +32,7 @@ class Foo {
     __privateSet(this, _x, __privateGet(this, _x) ^ 1);
     __privateGet(this, _x) && __privateSet(this, _x, 1);
     __privateGet(this, _x) || __privateSet(this, _x, 1);
-    __privateGet(this, _x) ?? __privateSet(this, _x, 1);
+    (_a = __privateGet(this, _x)) != null ? _a : __privateSet(this, _x, 1);
   }
 }
 _x = new WeakMap();
@@ -43,7 +46,7 @@ _x = new WeakMap();
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,31 +0,0 @@
+@@ -1,32 +0,0 @@
 -var _x;
 -class Foo {
 -    constructor() {
@@ -56,6 +59,7 @@ _x = new WeakMap();
 -        --__privateWrapper(this, _x)._;
 -    }
 -    binary() {
+-        var _a;
 -        __privateSet(this, _x, 1);
 -        __privateSet(this, _x, __privateGet(this, _x) + 1);
 -        __privateSet(this, _x, __privateGet(this, _x) - 1);
@@ -71,7 +75,7 @@ _x = new WeakMap();
 -        __privateSet(this, _x, __privateGet(this, _x) ^ 1);
 -        __privateGet(this, _x) && __privateSet(this, _x, 1);
 -        __privateGet(this, _x) || __privateSet(this, _x, 1);
--        __privateGet(this, _x) ?? __privateSet(this, _x, 1);
+-        (_a = __privateGet(this, _x)) != null ? _a : __privateSet(this, _x, 1);
 -    }
 -}
 -_x = new WeakMap();

--- a/crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2020_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2020_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild
@@ -14,14 +16,13 @@ class Foo {
     --__privateWrapper(this, _x)._;
   }
   binary() {
-    var _a;
     __privateSet(this, _x, 1);
     __privateSet(this, _x, __privateGet(this, _x) + 1);
     __privateSet(this, _x, __privateGet(this, _x) - 1);
     __privateSet(this, _x, __privateGet(this, _x) * 1);
     __privateSet(this, _x, __privateGet(this, _x) / 1);
     __privateSet(this, _x, __privateGet(this, _x) % 1);
-    __privateSet(this, _x, __pow(__privateGet(this, _x), 1));
+    __privateSet(this, _x, __privateGet(this, _x) ** 1);
     __privateSet(this, _x, __privateGet(this, _x) << 1);
     __privateSet(this, _x, __privateGet(this, _x) >> 1);
     __privateSet(this, _x, __privateGet(this, _x) >>> 1);
@@ -30,7 +31,7 @@ class Foo {
     __privateSet(this, _x, __privateGet(this, _x) ^ 1);
     __privateGet(this, _x) && __privateSet(this, _x, 1);
     __privateGet(this, _x) || __privateSet(this, _x, 1);
-    (_a = __privateGet(this, _x)) != null ? _a : __privateSet(this, _x, 1);
+    __privateGet(this, _x) ?? __privateSet(this, _x, 1);
   }
 }
 _x = new WeakMap();
@@ -44,7 +45,7 @@ _x = new WeakMap();
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,32 +0,0 @@
+@@ -1,31 +0,0 @@
 -var _x;
 -class Foo {
 -    constructor() {
@@ -57,14 +58,13 @@ _x = new WeakMap();
 -        --__privateWrapper(this, _x)._;
 -    }
 -    binary() {
--        var _a;
 -        __privateSet(this, _x, 1);
 -        __privateSet(this, _x, __privateGet(this, _x) + 1);
 -        __privateSet(this, _x, __privateGet(this, _x) - 1);
 -        __privateSet(this, _x, __privateGet(this, _x) * 1);
 -        __privateSet(this, _x, __privateGet(this, _x) / 1);
 -        __privateSet(this, _x, __privateGet(this, _x) % 1);
--        __privateSet(this, _x, __pow(__privateGet(this, _x), 1));
+-        __privateSet(this, _x, __privateGet(this, _x) ** 1);
 -        __privateSet(this, _x, __privateGet(this, _x) << 1);
 -        __privateSet(this, _x, __privateGet(this, _x) >> 1);
 -        __privateSet(this, _x, __privateGet(this, _x) >>> 1);
@@ -73,7 +73,7 @@ _x = new WeakMap();
 -        __privateSet(this, _x, __privateGet(this, _x) ^ 1);
 -        __privateGet(this, _x) && __privateSet(this, _x, 1);
 -        __privateGet(this, _x) || __privateSet(this, _x, 1);
--        (_a = __privateGet(this, _x)) != null ? _a : __privateSet(this, _x, 1);
+-        __privateGet(this, _x) ?? __privateSet(this, _x, 1);
 -    }
 -}
 -_x = new WeakMap();

--- a/crates/rolldown/tests/esbuild/lower/lower_private_field_assignments_next_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_field_assignments_next_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain2019_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain2019_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain2020_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain2020_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain_next_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain_next_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2016_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2016_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2021_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2021_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_static_super_es2016_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_super_es2016_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/lower_static_super_es2021_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_super_es2021_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/ts_lower_class_field2020_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/ts_lower_class_field2020_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/ts_lower_class_private_field_next_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/ts_lower_class_private_field_next_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/ts_lower_object_rest2017_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/ts_lower_object_rest2017_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/ts_lower_object_rest2018_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/ts_lower_object_rest2018_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/ts_lower_private_field_optional_chain2015_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/ts_lower_private_field_optional_chain2015_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/crates/rolldown/tests/esbuild/lower/ts_lower_private_static_members2015_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/ts_lower_private_static_members2015_no_bundle/bypass.md
@@ -1,3 +1,5 @@
+# Reason
+1. pure transformation is handled by `oxc-transform`
 # Diff
 ## /out.js
 ### esbuild

--- a/scripts/snap-diff/stats/stats.md
+++ b/scripts/snap-diff/stats/stats.md
@@ -1,7 +1,7 @@
 # Compatibility metric
 - total: 784
-- passed: 448
-- passed ratio: 57.14%
+- passed: 476
+- passed ratio: 60.71%
 # Compatibility metric details
 ## dce
 - total: 113
@@ -29,8 +29,8 @@
 - passed ratio: 34.33%
 ## lower
 - total: 79
-- passed: 4
-- passed ratio: 5.06%
+- passed: 32
+- passed ratio: 40.51%
 ## packagejson
 - total: 59
 - passed: 47

--- a/scripts/snap-diff/summary/lower.md
+++ b/scripts/snap-diff/summary/lower.md
@@ -1,6 +1,4 @@
 # Failed Cases
-## [class_super_this_issue242_no_bundle](../../../crates/rolldown/tests/esbuild/lower/class_super_this_issue242_no_bundle/diff.md)
-  diff
 ## [java_script_auto_accessor_es_next](../../../crates/rolldown/tests/esbuild/lower/java_script_auto_accessor_es_next/diff.md)
   diff
 ## [java_script_auto_accessor_es2021](../../../crates/rolldown/tests/esbuild/lower/java_script_auto_accessor_es2021/diff.md)
@@ -19,27 +17,13 @@
   diff
 ## [lower_async_generator_no_await](../../../crates/rolldown/tests/esbuild/lower/lower_async_generator_no_await/diff.md)
   diff
-## [lower_async_super_es2016_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_async_super_es2016_no_bundle/diff.md)
-  diff
-## [lower_async_super_es2017_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_async_super_es2017_no_bundle/diff.md)
-  diff
 ## [lower_async_this2016_common_js](../../../crates/rolldown/tests/esbuild/lower/lower_async_this2016_common_js/diff.md)
   diff
 ## [lower_async_this2016_es6](../../../crates/rolldown/tests/esbuild/lower/lower_async_this2016_es6/diff.md)
   diff
-## [lower_async2016_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_async2016_no_bundle/diff.md)
-  diff
-## [lower_async2017_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_async2017_no_bundle/diff.md)
-  diff
-## [lower_class_field_next_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_class_field_next_no_bundle/diff.md)
-  diff
 ## [lower_class_field_strict_tsconfig_json2020](../../../crates/rolldown/tests/esbuild/lower/lower_class_field_strict_tsconfig_json2020/diff.md)
   diff
-## [lower_class_field2020_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_class_field2020_no_bundle/diff.md)
-  diff
 ## [lower_export_star_as_name_collision](../../../crates/rolldown/tests/esbuild/lower/lower_export_star_as_name_collision/diff.md)
-  diff
-## [lower_export_star_as_name_collision_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_export_star_as_name_collision_no_bundle/diff.md)
   diff
 ## [lower_for_await2015](../../../crates/rolldown/tests/esbuild/lower/lower_for_await2015/diff.md)
   diff
@@ -49,17 +33,11 @@
   diff
 ## [lower_nullish_coalescing_assignment_issue1493](../../../crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/diff.md)
   diff
-## [lower_object_spread_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_object_spread_no_bundle/diff.md)
-  diff
-## [lower_optional_catch_name_collision_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_optional_catch_name_collision_no_bundle/diff.md)
-  diff
 ## [lower_private_class_accessor_order](../../../crates/rolldown/tests/esbuild/lower/lower_private_class_accessor_order/diff.md)
   diff
 ## [lower_private_class_brand_check_supported](../../../crates/rolldown/tests/esbuild/lower/lower_private_class_brand_check_supported/diff.md)
   diff
 ## [lower_private_class_brand_check_unsupported](../../../crates/rolldown/tests/esbuild/lower/lower_private_class_brand_check_unsupported/diff.md)
-  diff
-## [lower_private_class_expr2020_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_class_expr2020_no_bundle/diff.md)
   diff
 ## [lower_private_class_field_order](../../../crates/rolldown/tests/esbuild/lower/lower_private_class_field_order/diff.md)
   diff
@@ -72,20 +50,6 @@
 ## [lower_private_class_static_field_order](../../../crates/rolldown/tests/esbuild/lower/lower_private_class_static_field_order/diff.md)
   diff
 ## [lower_private_class_static_method_order](../../../crates/rolldown/tests/esbuild/lower/lower_private_class_static_method_order/diff.md)
-  diff
-## [lower_private_field_assignments_next_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_assignments_next_no_bundle/diff.md)
-  diff
-## [lower_private_field_assignments2015_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2015_no_bundle/diff.md)
-  diff
-## [lower_private_field_assignments2019_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2019_no_bundle/diff.md)
-  diff
-## [lower_private_field_assignments2020_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2020_no_bundle/diff.md)
-  diff
-## [lower_private_field_optional_chain_next_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain_next_no_bundle/diff.md)
-  diff
-## [lower_private_field_optional_chain2019_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain2019_no_bundle/diff.md)
-  diff
-## [lower_private_field_optional_chain2020_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain2020_no_bundle/diff.md)
   diff
 ## [lower_private_getter_setter2015](../../../crates/rolldown/tests/esbuild/lower/lower_private_getter_setter2015/diff.md)
   diff
@@ -107,14 +71,6 @@
   diff
 ## [lower_static_async_arrow_super_setter_es2016](../../../crates/rolldown/tests/esbuild/lower/lower_static_async_arrow_super_setter_es2016/diff.md)
   diff
-## [lower_static_async_super_es2016_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2016_no_bundle/diff.md)
-  diff
-## [lower_static_async_super_es2021_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2021_no_bundle/diff.md)
-  diff
-## [lower_static_super_es2016_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_static_super_es2016_no_bundle/diff.md)
-  diff
-## [lower_static_super_es2021_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_static_super_es2021_no_bundle/diff.md)
-  diff
 ## [lower_strict_mode_syntax](../../../crates/rolldown/tests/esbuild/lower/lower_strict_mode_syntax/diff.md)
   diff
 ## [lower_template_object](../../../crates/rolldown/tests/esbuild/lower/lower_template_object/diff.md)
@@ -135,19 +91,7 @@
   diff
 ## [ts_lower_class_field_strict_tsconfig_json2020](../../../crates/rolldown/tests/esbuild/lower/ts_lower_class_field_strict_tsconfig_json2020/diff.md)
   diff
-## [ts_lower_class_field2020_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_class_field2020_no_bundle/diff.md)
-  diff
-## [ts_lower_class_private_field_next_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_class_private_field_next_no_bundle/diff.md)
-  diff
-## [ts_lower_object_rest2017_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_object_rest2017_no_bundle/diff.md)
-  diff
-## [ts_lower_object_rest2018_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_object_rest2018_no_bundle/diff.md)
-  diff
 ## [ts_lower_private_field_and_method_avoid_name_collision2015](../../../crates/rolldown/tests/esbuild/lower/ts_lower_private_field_and_method_avoid_name_collision2015/diff.md)
-  diff
-## [ts_lower_private_field_optional_chain2015_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_private_field_optional_chain2015_no_bundle/diff.md)
-  diff
-## [ts_lower_private_static_members2015_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_private_static_members2015_no_bundle/diff.md)
   diff
 # Passed Cases
 ## [lower_private_getter_setter_next](../../../crates/rolldown/tests/esbuild/lower/lower_private_getter_setter_next)
@@ -155,3 +99,31 @@
 ## [lower_private_super_es2022](../../../crates/rolldown/tests/esbuild/lower/lower_private_super_es2022)
 ## [lower_private_super_static_bundle_issue2158](../../../crates/rolldown/tests/esbuild/lower/lower_private_super_static_bundle_issue2158)
 # Bypassed Cases
+## [class_super_this_issue242_no_bundle](../../../crates/rolldown/tests/esbuild/lower/class_super_this_issue242_no_bundle/bypass.md)
+## [lower_async_super_es2016_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_async_super_es2016_no_bundle/bypass.md)
+## [lower_async_super_es2017_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_async_super_es2017_no_bundle/bypass.md)
+## [lower_async2016_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_async2016_no_bundle/bypass.md)
+## [lower_async2017_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_async2017_no_bundle/bypass.md)
+## [lower_class_field_next_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_class_field_next_no_bundle/bypass.md)
+## [lower_class_field2020_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_class_field2020_no_bundle/bypass.md)
+## [lower_export_star_as_name_collision_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_export_star_as_name_collision_no_bundle/bypass.md)
+## [lower_object_spread_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_object_spread_no_bundle/bypass.md)
+## [lower_optional_catch_name_collision_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_optional_catch_name_collision_no_bundle/bypass.md)
+## [lower_private_class_expr2020_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_class_expr2020_no_bundle/bypass.md)
+## [lower_private_field_assignments_next_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_assignments_next_no_bundle/bypass.md)
+## [lower_private_field_assignments2015_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2015_no_bundle/bypass.md)
+## [lower_private_field_assignments2019_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2019_no_bundle/bypass.md)
+## [lower_private_field_assignments2020_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_assignments2020_no_bundle/bypass.md)
+## [lower_private_field_optional_chain_next_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain_next_no_bundle/bypass.md)
+## [lower_private_field_optional_chain2019_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain2019_no_bundle/bypass.md)
+## [lower_private_field_optional_chain2020_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_private_field_optional_chain2020_no_bundle/bypass.md)
+## [lower_static_async_super_es2016_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2016_no_bundle/bypass.md)
+## [lower_static_async_super_es2021_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2021_no_bundle/bypass.md)
+## [lower_static_super_es2016_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_static_super_es2016_no_bundle/bypass.md)
+## [lower_static_super_es2021_no_bundle](../../../crates/rolldown/tests/esbuild/lower/lower_static_super_es2021_no_bundle/bypass.md)
+## [ts_lower_class_field2020_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_class_field2020_no_bundle/bypass.md)
+## [ts_lower_class_private_field_next_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_class_private_field_next_no_bundle/bypass.md)
+## [ts_lower_object_rest2017_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_object_rest2017_no_bundle/bypass.md)
+## [ts_lower_object_rest2018_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_object_rest2018_no_bundle/bypass.md)
+## [ts_lower_private_field_optional_chain2015_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_private_field_optional_chain2015_no_bundle/bypass.md)
+## [ts_lower_private_static_members2015_no_bundle](../../../crates/rolldown/tests/esbuild/lower/ts_lower_private_static_members2015_no_bundle/bypass.md)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Those tests are pure transformation, those tests are hard to align since `oxc` follows babel, and esbuild has their own transformation algorithm and *runtime*
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
