### PR TITLE
fix: deconflict `__require`

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -391,7 +391,10 @@ impl<'me, 'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'me, 'ast> {
           // use `__require` instead of `require`
           if rec.meta.contains(ImportRecordMeta::CALL_RUNTIME_REQUIRE) {
             *call_expr.callee.get_inner_expression_mut() =
-              self.snippet.builder.expression_identifier_reference(SPAN, "__require");
+              self.snippet.builder.expression_identifier_reference(
+                SPAN,
+                self.canonical_name_for_runtime("__require").as_str(),
+              );
           }
           match &self.ctx.modules[rec.resolved_module] {
             Module::Normal(importee) => {

--- a/crates/rolldown/tests/rolldown/misc/require_deconflict/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/require_deconflict/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "external": ["test-dep"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/misc/require_deconflict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/require_deconflict/artifacts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Assets
+
+## main.js
+
+```js
+
+
+//#region main.js
+const __require = "test";
+var main_default = () => __require$1("test-dep");
+
+//#endregion
+export { __require, main_default as default };
+```

--- a/crates/rolldown/tests/rolldown/misc/require_deconflict/main.js
+++ b/crates/rolldown/tests/rolldown/misc/require_deconflict/main.js
@@ -1,0 +1,2 @@
+export const __require = "test";
+export default () => require("test-dep");

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4687,6 +4687,10 @@ snapshot_kind: text
 
 - main-!~{000}~.js => main-_c385Qlb.js
 
+# tests/rolldown/misc/require_deconflict
+
+- main-!~{000}~.js => main-Cg-xrqI8.js
+
 # tests/rolldown/misc/use_strict/allow_parse_non_strict_code_in_cjs_format
 
 - main-!~{000}~.js => main-Bgdr1bun.js


### PR DESCRIPTION
### Description

It looks like `__require` is hard-coded on runtime side and don't get through deconflict. To fixed this, I used `canonical_name_for_runtime` similarly to other runtime variables.

_input_

```js
export const __require = "test";
export default () => require("test-dep");
```

_output: before_ 

```js
//#region rolldown:runtime
var __require$1 = ...

//#endregion
//#region main.js
const __require = "test";
var main_default = () => __require("test-dep"); // 👈 doesn't reference `__require$1`
```

_output: after_

```js
//#region rolldown:runtime
var __require$1 = ...

//#endregion
//#region main.js
const __require = "test";
var main_default = () => __require$1("test-dep");
```
