### PR TITLE
feat: add `defineConfig` overload

### DIFF
--- a/packages/rolldown/src/utils/define-config.ts
+++ b/packages/rolldown/src/utils/define-config.ts
@@ -1,5 +1,9 @@
+import type { RolldownOptions } from '../types/rolldown-options'
 import type { ConfigExport } from '../types/config-export'
 
+export function defineConfig(config: RolldownOptions): RolldownOptions
+export function defineConfig(config: RolldownOptions[]): RolldownOptions[]
+export function defineConfig(config: ConfigExport): ConfigExport
 export function defineConfig(config: ConfigExport): ConfigExport {
   return config
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds some overload to make `defineConfig({})` to return `RolldownOptions` type instead of `RolldownOptions | RolldownOptions[]`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
