### PR TITLE
feat: support `RenderedModule.renderedLength`

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
   types::generator::{GenerateContext, GenerateOutput, Generator},
   utils::{chunk::generate_rendered_chunk, render_ecma_module::render_ecma_module},
@@ -21,7 +23,8 @@ use super::format::{
   app::render_app, cjs::render_cjs, esm::render_esm, iife::render_iife, umd::render_umd,
 };
 
-pub type RenderedModuleSources = Vec<(ModuleIdx, ModuleId, Option<Vec<Box<dyn Source + Send>>>)>;
+pub type RenderedModuleSources =
+  Vec<(ModuleIdx, ModuleId, Option<Arc<[Box<dyn Source + Send + Sync>]>>)>;
 
 pub struct EcmaGenerator;
 

--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -51,10 +51,10 @@ impl Generator for EcmaGenerator {
       })
       .collect::<Vec<_>>();
 
-    rendered_module_sources.iter().for_each(|(_, module_id, _)| {
+    rendered_module_sources.iter().for_each(|(_, module_id, sources)| {
       // FIXME: NAPI-RS used CStr under the hood, so it can't handle null byte in the string.
       if !module_id.starts_with('\0') {
-        rendered_modules.insert(module_id.clone(), RenderedModule { code: None });
+        rendered_modules.insert(module_id.clone(), RenderedModule::new(sources.clone()));
       }
     });
 

--- a/crates/rolldown/src/ecmascript/format/app.rs
+++ b/crates/rolldown/src/ecmascript/format/app.rs
@@ -27,7 +27,7 @@ pub fn render_app<'code>(
   // chunk content
   module_sources.iter().for_each(|(_, _, module_render_output)| {
     if let Some(emitted_sources) = module_render_output {
-      for source in emitted_sources {
+      for source in emitted_sources.as_ref() {
         source_joiner.append_source(source);
       }
     }

--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -97,7 +97,7 @@ pub fn render_cjs<'code>(
       if let (_, _module_id, Some(emitted_sources)) =
         module_sources_peekable.next().expect("Must have module")
       {
-        for source in emitted_sources {
+        for source in emitted_sources.as_ref() {
           source_joiner.append_source(source);
         }
       }
@@ -110,7 +110,7 @@ pub fn render_cjs<'code>(
   // chunk content
   module_sources_peekable.for_each(|(_, _, module_render_output)| {
     if let Some(emitted_sources) = module_render_output {
-      for source in emitted_sources {
+      for source in emitted_sources.as_ref() {
         source_joiner.append_source(source);
       }
     }

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -63,7 +63,7 @@ pub fn render_esm<'code>(
   // chunk content
   module_sources.iter().for_each(|(_, _, module_render_output)| {
     if let Some(emitted_sources) = module_render_output {
-      for source in emitted_sources {
+      for source in emitted_sources.as_ref() {
         source_joiner.append_source(source);
       }
     }

--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -141,7 +141,7 @@ pub fn render_iife<'code>(
   // TODO indent chunk content for iife format
   module_sources.iter().for_each(|(_, _, module_render_output)| {
     if let Some(emitted_sources) = module_render_output {
-      for source in emitted_sources {
+      for source in emitted_sources.as_ref() {
         source_joiner.append_source(source);
       }
     }

--- a/crates/rolldown/src/ecmascript/format/umd.rs
+++ b/crates/rolldown/src/ecmascript/format/umd.rs
@@ -108,7 +108,7 @@ pub fn render_umd<'code>(
   // TODO indent chunk content
   module_sources.iter().for_each(|(_, _, module_render_output)| {
     if let Some(emitted_sources) = module_render_output {
-      for source in emitted_sources {
+      for source in emitted_sources.as_ref() {
         source_joiner.append_source(source);
       }
     }

--- a/crates/rolldown/src/utils/render_ecma_module.rs
+++ b/crates/rolldown/src/utils/render_ecma_module.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use rolldown_common::{ModuleRenderOutput, NormalModule, NormalizedBundlerOptions};
 use rolldown_sourcemap::{collapse_sourcemaps, Source, SourceMapSource};
 
@@ -5,11 +7,11 @@ pub fn render_ecma_module(
   module: &NormalModule,
   options: &NormalizedBundlerOptions,
   render_output: ModuleRenderOutput,
-) -> Option<Vec<Box<dyn Source + Send>>> {
+) -> Option<Arc<[Box<dyn Source + Send + Sync>]>> {
   if render_output.code.is_empty() {
     None
   } else {
-    let mut sources: Vec<Box<dyn rolldown_sourcemap::Source + Send>> = vec![];
+    let mut sources: Vec<Box<dyn rolldown_sourcemap::Source + Send + Sync>> = vec![];
     sources
       .push(Box::new(format!("//#region {debug_module_id}", debug_module_id = module.debug_id)));
 
@@ -44,6 +46,6 @@ pub fn render_ecma_module(
 
     sources.push(Box::new("//#endregion"));
 
-    Some(sources)
+    Some(Arc::from(sources.into_boxed_slice()))
   }
 }

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -49,7 +49,7 @@ impl BindingOutputChunk {
     self.inner.filename.to_string()
   }
 
-  #[napi(getter)]
+  #[napi(getter, ts_return_type = "Record<string, RenderedModule>")]
   pub fn modules(&self) -> HashMap<String, BindingRenderedModule> {
     self
       .inner
@@ -108,6 +108,7 @@ pub struct JsOutputChunk {
   pub exports: Vec<String>,
   // RenderedChunk
   pub filename: String,
+  #[napi(ts_type = "Record<string, RenderedModule>")]
   pub modules: HashMap<String, BindingRenderedModule>,
   pub imports: Vec<String>,
   pub dynamic_imports: Vec<String>,

--- a/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
@@ -18,6 +18,7 @@ pub struct RenderedChunk {
   // RenderedChunk
   pub file_name: String,
   #[serde(skip)]
+  #[napi(ts_type = "Record<string, RenderedModule>")]
   pub modules: HashMap<String, BindingRenderedModule>,
   pub imports: Vec<String>,
   pub dynamic_imports: Vec<String>,

--- a/crates/rolldown_binding/src/types/binding_rendered_module.rs
+++ b/crates/rolldown_binding/src/types/binding_rendered_module.rs
@@ -1,10 +1,20 @@
+use napi::bindgen_prelude::FromNapiValue;
+use napi_derive::napi;
+use rolldown_common::RenderedModule;
 use std::fmt::Debug;
 
-use napi_derive::napi;
-
-#[napi(object)]
+#[napi]
 pub struct BindingRenderedModule {
-  pub code: Option<String>,
+  #[napi(skip)]
+  pub inner: RenderedModule,
+}
+
+#[napi]
+impl BindingRenderedModule {
+  #[napi(getter)]
+  pub fn code(&self) -> Option<String> {
+    self.inner.code()
+  }
 }
 
 impl Debug for BindingRenderedModule {
@@ -15,12 +25,21 @@ impl Debug for BindingRenderedModule {
 
 impl From<rolldown_common::RenderedModule> for BindingRenderedModule {
   fn from(value: rolldown_common::RenderedModule) -> Self {
-    Self { code: value.code }
+    Self { inner: value }
   }
 }
 
 impl From<BindingRenderedModule> for rolldown_common::RenderedModule {
   fn from(value: BindingRenderedModule) -> Self {
-    Self { code: value.code }
+    value.inner
+  }
+}
+
+impl FromNapiValue for BindingRenderedModule {
+  unsafe fn from_napi_value(
+    _env: napi::sys::napi_env,
+    _napi_val: napi::sys::napi_value,
+  ) -> napi::Result<Self> {
+    Ok(BindingRenderedModule { inner: RenderedModule { inner_code: None } })
   }
 }

--- a/crates/rolldown_binding/src/types/binding_rendered_module.rs
+++ b/crates/rolldown_binding/src/types/binding_rendered_module.rs
@@ -40,6 +40,6 @@ impl FromNapiValue for BindingRenderedModule {
     _env: napi::sys::napi_env,
     _napi_val: napi::sys::napi_value,
   ) -> napi::Result<Self> {
-    Ok(BindingRenderedModule { inner: RenderedModule { inner_code: None } })
+    Ok(BindingRenderedModule { inner: RenderedModule::default() })
   }
 }

--- a/crates/rolldown_common/src/types/rendered_module.rs
+++ b/crates/rolldown_common/src/types/rendered_module.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, sync::Arc};
 
-use rolldown_sourcemap::Source;
+use rolldown_sourcemap::{Source, SourceJoiner};
 
 #[derive(Clone)]
 pub struct RenderedModule {
@@ -19,9 +19,14 @@ impl RenderedModule {
   }
 
   pub fn code(&self) -> Option<String> {
-    self
-      .inner_code
-      .as_ref()
-      .and_then(|sources| sources.get(1).map(|source| source.content().to_string()))
+    self.inner_code.as_ref().and_then(|sources| {
+      let mut joiner = SourceJoiner::default();
+
+      for source in sources.iter() {
+        joiner.append_source(source);
+      }
+
+      Some(joiner.join().0)
+    })
   }
 }

--- a/crates/rolldown_common/src/types/rendered_module.rs
+++ b/crates/rolldown_common/src/types/rendered_module.rs
@@ -1,4 +1,27 @@
-#[derive(Debug, Clone)]
+use std::{fmt::Debug, sync::Arc};
+
+use rolldown_sourcemap::Source;
+
+#[derive(Clone)]
 pub struct RenderedModule {
-  pub code: Option<String>,
+  pub inner_code: Option<Arc<[Box<dyn Source + Send + Sync>]>>,
+}
+
+impl Debug for RenderedModule {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("RenderedModule").finish()
+  }
+}
+
+impl RenderedModule {
+  pub fn new(sources: Option<Arc<[Box<dyn Source + Send + Sync>]>>) -> Self {
+    Self { inner_code: sources }
+  }
+
+  pub fn code(&self) -> Option<String> {
+    self
+      .inner_code
+      .as_ref()
+      .and_then(|sources| sources.get(1).map(|source| source.content().to_string()))
+  }
 }

--- a/crates/rolldown_common/src/types/rendered_module.rs
+++ b/crates/rolldown_common/src/types/rendered_module.rs
@@ -2,9 +2,9 @@ use std::{fmt::Debug, sync::Arc};
 
 use rolldown_sourcemap::{Source, SourceJoiner};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct RenderedModule {
-  pub inner_code: Option<Arc<[Box<dyn Source + Send + Sync>]>>,
+  inner_code: Option<Arc<[Box<dyn Source + Send + Sync>]>>,
 }
 
 impl Debug for RenderedModule {
@@ -19,14 +19,14 @@ impl RenderedModule {
   }
 
   pub fn code(&self) -> Option<String> {
-    self.inner_code.as_ref().and_then(|sources| {
+    self.inner_code.as_ref().map(|sources| {
       let mut joiner = SourceJoiner::default();
 
       for source in sources.iter() {
         joiner.append_source(source);
       }
 
-      Some(joiner.join().0)
+      joiner.join().0
     })
   }
 }

--- a/crates/rolldown_sourcemap/src/source.rs
+++ b/crates/rolldown_sourcemap/src/source.rs
@@ -102,7 +102,7 @@ impl Source for SourceMapSource {
   }
 }
 
-impl<'a> Source for &'a Box<dyn Source + Send> {
+impl<'a> Source for &'a Box<dyn Source + Send + Sync> {
   fn sourcemap(&self) -> Option<&SourceMap> {
     self.as_ref().sourcemap()
   }

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -97,7 +97,7 @@
         "fs": true
       }
     },
-    "dtsHeader": "type MaybePromise<T> = T | Promise<T>\ntype Nullable<T> = T | null | undefined\ntype VoidNullable<T = void> = T | null | undefined | void\nexport type BindingStringOrRegex = string | RegExp\n\n"
+    "dtsHeader": "type MaybePromise<T> = T | Promise<T>\ntype Nullable<T> = T | null | undefined\ntype VoidNullable<T = void> = T | null | undefined | void\nexport type BindingStringOrRegex = string | RegExp\n\nexport interface RenderedModule {\n  readonly code: string | null\n  renderedLength: number\n}\n\n"
   },
   "dependencies": {
     "zod": "^3.23.8"

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -3,6 +3,11 @@ type Nullable<T> = T | null | undefined
 type VoidNullable<T = void> = T | null | undefined | void
 export type BindingStringOrRegex = string | RegExp
 
+export interface RenderedModule {
+  readonly code: string | null
+  renderedLength: number
+}
+
 export declare class BindingLog {
   code: string
   message: string
@@ -32,7 +37,7 @@ export declare class BindingOutputChunk {
   get moduleIds(): Array<string>
   get exports(): Array<string>
   get fileName(): string
-  get modules(): Record<string, BindingRenderedModule>
+  get modules(): Record<string, RenderedModule>
   get imports(): Array<string>
   get dynamicImports(): Array<string>
   get code(): string
@@ -537,7 +542,7 @@ export interface JsOutputChunk {
   moduleIds: Array<string>
   exports: Array<string>
   filename: string
-  modules: Record<string, BindingRenderedModule>
+  modules: Record<string, RenderedModule>
   imports: Array<string>
   dynamicImports: Array<string>
   code: string
@@ -676,7 +681,7 @@ export interface RenderedChunk {
   moduleIds: Array<string>
   exports: Array<string>
   fileName: string
-  modules: Record<string, BindingRenderedModule>
+  modules: Record<string, RenderedModule>
   imports: Array<string>
   dynamicImports: Array<string>
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -57,6 +57,10 @@ export declare class BindingPluginContext {
   addWatchFile(file: string): void
 }
 
+export declare class BindingRenderedModule {
+  get code(): string | null
+}
+
 export declare class BindingTransformPluginContext {
   inner(): BindingPluginContext
 }
@@ -395,10 +399,6 @@ export declare enum BindingPluginOrder {
 export interface BindingPluginWithIndex {
   index: number
   plugin: BindingPluginOptions
-}
-
-export interface BindingRenderedModule {
-  code?: string
 }
 
 export interface BindingReplacePluginConfig {

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -370,6 +370,7 @@ module.exports.BindingOutputAsset = nativeBinding.BindingOutputAsset
 module.exports.BindingOutputChunk = nativeBinding.BindingOutputChunk
 module.exports.BindingOutputs = nativeBinding.BindingOutputs
 module.exports.BindingPluginContext = nativeBinding.BindingPluginContext
+module.exports.BindingRenderedModule = nativeBinding.BindingRenderedModule
 module.exports.BindingTransformPluginContext = nativeBinding.BindingTransformPluginContext
 module.exports.BindingWatcher = nativeBinding.BindingWatcher
 module.exports.Bundler = nativeBinding.Bundler

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -16,6 +16,7 @@ import {
   bindingifyPluginHookMeta,
 } from './bindingify-plugin-hook-meta'
 import { transformToRenderedModule } from '../utils/transform-rendered-module'
+import { RenderedChunk } from '../rollup'
 
 export function bindingifyRenderStart(
   plugin: Plugin,
@@ -55,14 +56,14 @@ export function bindingifyRenderChunk(
 
   return {
     plugin: async (ctx, code, chunk) => {
-      for (const key in chunk.modules) {
-        chunk.modules[key] = transformToRenderedModule(chunk.modules[key])
-      }
+      Object.entries(chunk.modules).forEach(([key, module]) => {
+        chunk.modules[key] = transformToRenderedModule(module)
+      })
 
       const ret = await handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
         code,
-        chunk,
+        chunk as RenderedChunk,
         outputOptions,
       )
 
@@ -102,7 +103,7 @@ export function bindingifyAugmentChunkHash(
     plugin: async (ctx, chunk) => {
       return await handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
-        chunk,
+        chunk as RenderedChunk,
       )
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -231,7 +232,7 @@ export function bindingifyBanner(
 
       return handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
-        chunk,
+        chunk as RenderedChunk,
       )
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -258,7 +259,7 @@ export function bindingifyFooter(
 
       return handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
-        chunk,
+        chunk as RenderedChunk,
       )
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -285,7 +286,7 @@ export function bindingifyIntro(
 
       return handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
-        chunk,
+        chunk as RenderedChunk,
       )
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -312,7 +313,7 @@ export function bindingifyOutro(
 
       return handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
-        chunk,
+        chunk as RenderedChunk,
       )
     },
     meta: bindingifyPluginHookMeta(meta),

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -16,7 +16,6 @@ import {
   bindingifyPluginHookMeta,
 } from './bindingify-plugin-hook-meta'
 import { transformToRenderedModule } from '../utils/transform-rendered-module'
-import { RenderedChunk } from '../rollup'
 
 export function bindingifyRenderStart(
   plugin: Plugin,
@@ -63,7 +62,7 @@ export function bindingifyRenderChunk(
       const ret = await handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
         code,
-        chunk as RenderedChunk,
+        chunk,
         outputOptions,
       )
 
@@ -101,9 +100,13 @@ export function bindingifyAugmentChunkHash(
 
   return {
     plugin: async (ctx, chunk) => {
+      Object.entries(chunk.modules).forEach(([key, module]) => {
+        chunk.modules[key] = transformToRenderedModule(module)
+      })
+
       return await handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
-        chunk as RenderedChunk,
+        chunk,
       )
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -232,7 +235,7 @@ export function bindingifyBanner(
 
       return handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
-        chunk as RenderedChunk,
+        chunk,
       )
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -259,7 +262,7 @@ export function bindingifyFooter(
 
       return handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
-        chunk as RenderedChunk,
+        chunk,
       )
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -286,7 +289,7 @@ export function bindingifyIntro(
 
       return handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
-        chunk as RenderedChunk,
+        chunk,
       )
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -313,7 +316,7 @@ export function bindingifyOutro(
 
       return handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
-        chunk as RenderedChunk,
+        chunk,
       )
     },
     meta: bindingifyPluginHookMeta(meta),

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -15,6 +15,7 @@ import {
   PluginHookWithBindingExt,
   bindingifyPluginHookMeta,
 } from './bindingify-plugin-hook-meta'
+import { transformToRenderedModule } from '../utils/transform-rendered-module'
 
 export function bindingifyRenderStart(
   plugin: Plugin,
@@ -54,6 +55,10 @@ export function bindingifyRenderChunk(
 
   return {
     plugin: async (ctx, code, chunk) => {
+      for (const key in chunk.modules) {
+        chunk.modules[key] = transformToRenderedModule(chunk.modules[key])
+      }
+
       const ret = await handler.call(
         new PluginContext(options, ctx, plugin, pluginContextData),
         code,

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -1,7 +1,6 @@
 import type {
   BindingHookResolveIdExtraArgs,
   BindingTransformHookExtraArgs,
-  RenderedChunk,
 } from '../binding'
 import type { NormalizedInputOptions } from '../options/normalized-input-options'
 import type {
@@ -17,7 +16,7 @@ import { PluginContext } from './plugin-context'
 import type { TransformPluginContext } from './transform-plugin-context'
 import type { NormalizedOutputOptions } from '../options/normalized-output-options'
 import type { LogLevel } from '../log/logging'
-import type { RollupLog } from '../rollup'
+import type { RollupLog, RenderedChunk } from '../rollup'
 import type { MinimalPluginContext } from '../log/logger'
 import { InputOptions, OutputOptions } from '..'
 import { BuiltinPlugin } from './builtin-plugin'

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -1,6 +1,7 @@
 import type {
   BindingHookResolveIdExtraArgs,
   BindingTransformHookExtraArgs,
+  RenderedChunk,
 } from '../binding'
 import type { NormalizedInputOptions } from '../options/normalized-input-options'
 import type {
@@ -16,7 +17,7 @@ import { PluginContext } from './plugin-context'
 import type { TransformPluginContext } from './transform-plugin-context'
 import type { NormalizedOutputOptions } from '../options/normalized-output-options'
 import type { LogLevel } from '../log/logging'
-import type { RollupLog, RenderedChunk } from '../rollup'
+import type { RollupLog } from '../rollup'
 import type { MinimalPluginContext } from '../log/logger'
 import { InputOptions, OutputOptions } from '..'
 import { BuiltinPlugin } from './builtin-plugin'

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -138,13 +138,14 @@ function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__PreRenderedChunk_struct_102']?.()
   __napiInstance.exports['__napi_register__RenderedChunk_struct_103']?.()
   __napiInstance.exports['__napi_register__BindingRenderedModule_struct_104']?.()
-  __napiInstance.exports['__napi_register__AliasItem_struct_105']?.()
-  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_106']?.()
-  __napiInstance.exports['__napi_register__BindingSourcemap_struct_107']?.()
-  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_108']?.()
-  __napiInstance.exports['__napi_register__BindingWatcher_struct_109']?.()
-  __napiInstance.exports['__napi_register__BindingWatcher_impl_112']?.()
-  __napiInstance.exports['__napi_register__BindingWatcherEvent_113']?.()
+  __napiInstance.exports['__napi_register__BindingRenderedModule_impl_106']?.()
+  __napiInstance.exports['__napi_register__AliasItem_struct_107']?.()
+  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_108']?.()
+  __napiInstance.exports['__napi_register__BindingSourcemap_struct_109']?.()
+  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_110']?.()
+  __napiInstance.exports['__napi_register__BindingWatcher_struct_111']?.()
+  __napiInstance.exports['__napi_register__BindingWatcher_impl_114']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherEvent_115']?.()
 }
 export const BindingLog = __napiModule.exports.BindingLog
 export const BindingModuleInfo = __napiModule.exports.BindingModuleInfo
@@ -152,6 +153,7 @@ export const BindingOutputAsset = __napiModule.exports.BindingOutputAsset
 export const BindingOutputChunk = __napiModule.exports.BindingOutputChunk
 export const BindingOutputs = __napiModule.exports.BindingOutputs
 export const BindingPluginContext = __napiModule.exports.BindingPluginContext
+export const BindingRenderedModule = __napiModule.exports.BindingRenderedModule
 export const BindingTransformPluginContext = __napiModule.exports.BindingTransformPluginContext
 export const BindingWatcher = __napiModule.exports.BindingWatcher
 export const Bundler = __napiModule.exports.Bundler

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -162,13 +162,14 @@ function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__PreRenderedChunk_struct_102']?.()
   __napiInstance.exports['__napi_register__RenderedChunk_struct_103']?.()
   __napiInstance.exports['__napi_register__BindingRenderedModule_struct_104']?.()
-  __napiInstance.exports['__napi_register__AliasItem_struct_105']?.()
-  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_106']?.()
-  __napiInstance.exports['__napi_register__BindingSourcemap_struct_107']?.()
-  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_108']?.()
-  __napiInstance.exports['__napi_register__BindingWatcher_struct_109']?.()
-  __napiInstance.exports['__napi_register__BindingWatcher_impl_112']?.()
-  __napiInstance.exports['__napi_register__BindingWatcherEvent_113']?.()
+  __napiInstance.exports['__napi_register__BindingRenderedModule_impl_106']?.()
+  __napiInstance.exports['__napi_register__AliasItem_struct_107']?.()
+  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_108']?.()
+  __napiInstance.exports['__napi_register__BindingSourcemap_struct_109']?.()
+  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_110']?.()
+  __napiInstance.exports['__napi_register__BindingWatcher_struct_111']?.()
+  __napiInstance.exports['__napi_register__BindingWatcher_impl_114']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherEvent_115']?.()
 }
 module.exports.BindingLog = __napiModule.exports.BindingLog
 module.exports.BindingModuleInfo = __napiModule.exports.BindingModuleInfo
@@ -176,6 +177,7 @@ module.exports.BindingOutputAsset = __napiModule.exports.BindingOutputAsset
 module.exports.BindingOutputChunk = __napiModule.exports.BindingOutputChunk
 module.exports.BindingOutputs = __napiModule.exports.BindingOutputs
 module.exports.BindingPluginContext = __napiModule.exports.BindingPluginContext
+module.exports.BindingRenderedModule = __napiModule.exports.BindingRenderedModule
 module.exports.BindingTransformPluginContext = __napiModule.exports.BindingTransformPluginContext
 module.exports.BindingWatcher = __napiModule.exports.BindingWatcher
 module.exports.Bundler = __napiModule.exports.Bundler

--- a/packages/rolldown/src/types/rendered-module.ts
+++ b/packages/rolldown/src/types/rendered-module.ts
@@ -1,4 +1,0 @@
-export interface RenderedModule {
-  readonly code: string | null
-  renderedLength: number
-}

--- a/packages/rolldown/src/types/rendered-module.ts
+++ b/packages/rolldown/src/types/rendered-module.ts
@@ -1,1 +1,4 @@
-export interface RenderedModule {}
+export interface RenderedModule {
+  readonly code: string | null
+  renderedLength: number
+}

--- a/packages/rolldown/src/types/rolldown-output.ts
+++ b/packages/rolldown/src/types/rolldown-output.ts
@@ -1,7 +1,7 @@
 import { AssetSource } from '../utils/asset-source'
 import type { OutputAsset, OutputChunk } from '../rollup'
 import type { HasProperty, IsPropertiesEqual, TypeAssert } from './assert'
-import type { RenderedModule } from './rendered-module'
+import type { RenderedModule } from '../binding'
 
 export interface RolldownOutputAsset {
   type: 'asset'

--- a/packages/rolldown/src/utils/transform-rendered-module.ts
+++ b/packages/rolldown/src/utils/transform-rendered-module.ts
@@ -1,0 +1,15 @@
+import { RenderedModule } from '../types/rendered-module'
+import { BindingRenderedModule } from '../binding'
+
+export function transformToRenderedModule(
+  bindingRenderedModule: BindingRenderedModule,
+): RenderedModule {
+  return {
+    get code() {
+      return bindingRenderedModule.code
+    },
+    get renderedLength() {
+      return bindingRenderedModule.code?.length || 0
+    },
+  }
+}

--- a/packages/rolldown/src/utils/transform-rendered-module.ts
+++ b/packages/rolldown/src/utils/transform-rendered-module.ts
@@ -1,8 +1,7 @@
-import { RenderedModule } from '../types/rendered-module'
-import { BindingRenderedModule } from '../binding'
+import { RenderedModule } from '../binding'
 
 export function transformToRenderedModule(
-  bindingRenderedModule: BindingRenderedModule,
+  bindingRenderedModule: RenderedModule,
 ): RenderedModule {
   return {
     get code() {

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -18,6 +18,7 @@ import {
   transformAssetSource,
 } from './asset-source'
 import { bindingifySourcemap } from '../types/sourcemap'
+import { transformToRenderedModule } from './transform-rendered-module'
 
 function transformToRollupOutputChunk(
   bindingChunk: BindingOutputChunk,
@@ -32,7 +33,10 @@ function transformToRollupOutputChunk(
     name: bindingChunk.name,
     get modules() {
       return Object.fromEntries(
-        Object.entries(bindingChunk.modules).map(([key, _]) => [key, {}]),
+        Object.entries(bindingChunk.modules).map(([key, value]) => [
+          key,
+          transformToRenderedModule(value),
+        ]),
       )
     },
     get imports() {
@@ -165,7 +169,7 @@ export function collectChangedBundle(
         isEntry: item.isEntry,
         exports: item.exports,
         modules: Object.fromEntries(
-          Object.entries(item.modules).map(([key, _]) => [key, {}]),
+          Object.entries(item.modules).map(([key, _]) => [key, {} as any]),
         ),
         imports: item.imports,
         dynamicImports: item.dynamicImports,

--- a/packages/rolldown/tests/fixtures/plugin/augment-chunk-hash/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/augment-chunk-hash/_config.ts
@@ -22,9 +22,11 @@ export default defineTest({
         name: 'test-plugin',
         augmentChunkHash: (chunk) => {
           fn()
-          expect(Object.values(chunk.modules)[0].code).toBe('console.log();\n')
-          expect(Object.values(chunk.modules)[0].renderedLength).toBe(15)
           if (chunk.fileName.includes('entry')) {
+            expect(Object.values(chunk.modules)[0].code).toBe(
+              '//#region entry.js\nconsole.log();\n\n//#endregion',
+            )
+            expect(Object.values(chunk.modules)[0].renderedLength).toBe(47)
             return 'entry-hash'
           }
         },

--- a/packages/rolldown/tests/fixtures/plugin/augment-chunk-hash/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/augment-chunk-hash/_config.ts
@@ -22,6 +22,8 @@ export default defineTest({
         name: 'test-plugin',
         augmentChunkHash: (chunk) => {
           fn()
+          expect(Object.values(chunk.modules)[0].code).toBe('console.log();\n')
+          expect(Object.values(chunk.modules)[0].renderedLength).toBe(15)
           if (chunk.fileName.includes('entry')) {
             return 'entry-hash'
           }

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
@@ -26,8 +26,10 @@ export default defineTest({
           expect(chunk.imports).toStrictEqual(['share.js'])
           expect(chunk.moduleIds).toStrictEqual([entry])
           expect(Object.keys(chunk.modules).length).toBe(1)
-          expect(Object.values(chunk.modules)[0].code).toBe('console.log();\n')
-          expect(Object.values(chunk.modules)[0].renderedLength).toBe(15)
+          expect(Object.values(chunk.modules)[0].code).toBe(
+            '//#region main.js\nconsole.log();\n\n//#endregion',
+          )
+          expect(Object.values(chunk.modules)[0].renderedLength).toBe(46)
           // called bundle.generate()
           expect(isWrite).toBe(true)
           // Mutate chunk

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
@@ -26,6 +26,8 @@ export default defineTest({
           expect(chunk.imports).toStrictEqual(['share.js'])
           expect(chunk.moduleIds).toStrictEqual([entry])
           expect(Object.keys(chunk.modules).length).toBe(1)
+          expect(Object.values(chunk.modules)[0].code).toBe('console.log();\n')
+          expect(Object.values(chunk.modules)[0].renderedLength).toBe(15)
           // called bundle.generate()
           expect(isWrite).toBe(true)
           // Mutate chunk

--- a/packages/rolldown/tests/fixtures/plugin/render-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/render-chunk/_config.ts
@@ -24,6 +24,8 @@ export default defineTest({
           expect(chunk.imports).toStrictEqual([])
           expect(chunk.moduleIds).toStrictEqual([entry])
           expect(Object.keys(chunk.modules).length).toBe(1)
+          expect(Object.values(chunk.modules)[0].code).toBe('console.log();\n')
+          expect(Object.values(chunk.modules)[0].renderedLength).toBe(15)
           return 'render-chunk-code'
         },
       },

--- a/packages/rolldown/tests/fixtures/plugin/render-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/render-chunk/_config.ts
@@ -24,8 +24,10 @@ export default defineTest({
           expect(chunk.imports).toStrictEqual([])
           expect(chunk.moduleIds).toStrictEqual([entry])
           expect(Object.keys(chunk.modules).length).toBe(1)
-          expect(Object.values(chunk.modules)[0].code).toBe('console.log();\n')
-          expect(Object.values(chunk.modules)[0].renderedLength).toBe(15)
+          expect(Object.values(chunk.modules)[0].code).toBe(
+            '//#region main.js\nconsole.log();\n\n//#endregion',
+          )
+          expect(Object.values(chunk.modules)[0].renderedLength).toBe(46)
           return 'render-chunk-code'
         },
       },


### PR DESCRIPTION
### Description

closes #2686

There are still two remaining issues:

- Our `codegen` differs from `rollup`, and it appends `\n` by default at the end
- The chunk traversal order in our implementation does not match that of `rollup`

This is just a simple attempt, and feel free to close it at any time.


