### PR TITLE
fix(watcher): only watch same file once

### DIFF
--- a/crates/rolldown/src/watcher/watcher.rs
+++ b/crates/rolldown/src/watcher/watcher.rs
@@ -127,6 +127,13 @@ impl Watcher {
     };
     let mut inner = self.inner.lock().await;
     for file in &output.watch_files {
+      // we should skip the file that is already watched, here here some reasons:
+      // - The watching files has a ms level overhead.
+      // - Watching the same files multiple times will cost more overhead.
+      // TODO: tracking https://github.com/notify-rs/notify/issues/653
+      if self.watch_files.contains(file) {
+        continue;
+      }
       let path = Path::new(file.as_str());
       if path.exists() {
         let normalized_path = path.relative(&bundler.options.cwd);

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -188,11 +188,31 @@ test.sequential('watch include/exclude', async () => {
   // edit file
   fs.writeFileSync(input, 'console.log(2)')
   // wait for watcher to detect the change
-  await new Promise((resolve) => {
-    setTimeout(resolve, 50)
-  })
+  await waitBuildFinished()
   // The input is excluded, so the output file should not be updated
   expect(fs.readFileSync(output, 'utf-8').includes('console.log(1)')).toBe(true)
+
+  // revert change
+  fs.writeFileSync(input, 'console.log(1)\n')
+  await watcher.close()
+})
+
+test.sequential('(perf)watching same file multiply times', async () => {
+  const watcher = await watch({
+    input,
+    cwd: import.meta.dirname,
+  })
+
+  await waitBuildFinished()
+
+  // edit file
+  for (let i = 2; i < 20; i++) {
+    const change = `console.log(${i})`
+    fs.writeFileSync(input, change)
+    // wait for watcher to detect the change, the time should be less than 100ms
+    await waitBuildFinished()
+    expect(fs.readFileSync(output, 'utf-8').includes(change)).toBe(true)
+  }
 
   // revert change
   fs.writeFileSync(input, 'console.log(1)\n')

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -209,7 +209,7 @@ test.sequential('(perf)watching same file multiply times', async () => {
   for (let i = 2; i < 20; i++) {
     const change = `console.log(${i})`
     fs.writeFileSync(input, change)
-    // wait for watcher to detect the change, the time should be less than 100ms
+    // wait for watcher to detect the change, the time should be less than 50ms
     await waitBuildFinished()
     expect(fs.readFileSync(output, 'utf-8').includes(change)).toBe(true)
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Watching the same files multiple times will cost more overhead, so here avoid it.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
