### PR TITLE
fix:  cli doesn't show config loading error details

### DIFF
--- a/packages/rolldown/src/cli/index.ts
+++ b/packages/rolldown/src/cli/index.ts
@@ -28,6 +28,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  logger.error(err)
+  console.error(err)
   process.exit(1)
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. related to https://github.com/rolldown/rolldown/issues/2705, as 
https://github.com/rolldown/rolldown/pull/2707#issuecomment-2470659332 said, this is caused by `consola` not support display `Error.cause` 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
