### PR TITLE
fix: preserve js plugin hook error stacktrace 

### DIFF
--- a/crates/rolldown_binding/src/utils/mod.rs
+++ b/crates/rolldown_binding/src/utils/mod.rs
@@ -16,5 +16,8 @@ pub fn try_init_custom_trace_subscriber(napi_env: Env) {
 }
 
 pub fn handle_result<T>(result: anyhow::Result<T>) -> napi::Result<T> {
-  result.map_err(|e| napi::Error::from_reason(format!("Rolldown internal error: {e}")))
+  result.map_err(|e| match e.downcast::<napi::Error>() {
+    Ok(e) => e,
+    Err(e) => napi::Error::from_reason(format!("Rolldown internal error: {e}")),
+  })
 }

--- a/examples/basic-typescript/rolldown.config.js
+++ b/examples/basic-typescript/rolldown.config.js
@@ -10,4 +10,22 @@ export default defineConfig({
     // aligns with Vite in the future.
     conditionNames: ['import'],
   },
+  plugins: [
+    {
+      name: 'repro',
+      async resolveId() {
+        await testFn()
+      },
+    },
+  ],
 })
+
+async function testFn() {
+  await Promise.resolve()
+  await testMoreFn()
+}
+
+async function testMoreFn() {
+  await Promise.resolve()
+  throw new Error('test error!')
+}

--- a/examples/basic-typescript/rolldown.config.js
+++ b/examples/basic-typescript/rolldown.config.js
@@ -10,22 +10,4 @@ export default defineConfig({
     // aligns with Vite in the future.
     conditionNames: ['import'],
   },
-  plugins: [
-    {
-      name: 'repro',
-      async resolveId() {
-        await testFn()
-      },
-    },
-  ],
 })
-
-async function testFn() {
-  await Promise.resolve()
-  await testMoreFn()
-}
-
-async function testMoreFn() {
-  await Promise.resolve()
-  throw new Error('test error!')
-}

--- a/packages/rolldown/tests/fixtures/misc/plugin-error/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/plugin-error/_config.ts
@@ -1,0 +1,35 @@
+import { defineTest } from '@tests'
+import { assert, expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'plugin-error',
+        async resolveId() {
+          await errorFn1()
+        },
+      },
+    ],
+  },
+  catchError(e) {
+    assert(e instanceof Error)
+    expect(e).toMatchObject({
+      message: 'hi',
+      extraProp: 1234,
+    })
+    expect(e.stack).toContain('at errorFn2')
+    expect(e.stack).toContain('at errorFn1')
+    expect(e.stack).toContain('at PluginContext.resolveId')
+  },
+})
+
+async function errorFn1() {
+  await Promise.resolve()
+  await errorFn2()
+}
+
+async function errorFn2() {
+  await Promise.resolve()
+  throw Object.assign(new Error('hi'), { extraProp: 1234 })
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Related https://github.com/rolldown/rolldown/issues/2551

I'm not sure about the internal, but it looks like js error is stripped away during the conversion of anyhow::Result.

For the example, after the change, I get a following error

```
$ pnpm -C examples/basic-typescript build

> @example/typescript@ build /home/hiroshi/code/others/rolldown/examples/basic-typescript
> rolldown --config ./rolldown.config.js

file:///home/hiroshi/code/others/rolldown/examples/basic-typescript/rolldown.config.js:30
  throw new Error('test error!')
        ^

Error: test error!
    at testMoreFn (file:///home/hiroshi/code/others/rolldown/examples/basic-typescript/rolldown.config.js:30:9)
    at async testFn (file:///home/hiroshi/code/others/rolldown/examples/basic-typescript/rolldown.config.js:25:3)
    at async PluginContext.resolveId (file:///home/hiroshi/code/others/rolldown/examples/basic-typescript/rolldown.config.js:17:9)
    at async plugin (file:///home/hiroshi/code/others/rolldown/packages/rolldown/dist/shared/src_index-pEhJx8zp.mjs:1362:16)

Node.js v18.20.5
```