### PR TITLE
fix: preserve external module side effects at format umd/iife

### DIFF
--- a/crates/rolldown/src/ecmascript/format/utils/mod.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/mod.rs
@@ -39,9 +39,8 @@ pub fn render_chunk_external_imports(
           ctx.chunk.canonical_name_by_token.get(&external_stmt.binding_name_token).unpack();
         match &external_stmt.specifiers {
           RenderImportDeclarationSpecifier::ImportSpecifier(specifiers) => {
-            // Empty specifiers can be ignored in IIFE.
             if specifiers.is_empty() {
-              None
+              Some(external_stmt)
             } else {
               let specifiers = specifiers
                 .iter()

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/artifacts.snap
@@ -1,8 +1,15 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # warnings
 
+## MISSING_GLOBAL_NAME
+
+```text
+[MISSING_GLOBAL_NAME] Warning: No name was provided for external module "foo" in "output.globals" – guessing "foo".
+
+```
 ## UNRESOLVED_IMPORT
 
 ```text
@@ -20,9 +27,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-(function() {
+(function(foo) {
 
 "use strict";
 
-})();
+})(foo);
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/diff.md
@@ -13,11 +13,11 @@ var mod = (() => {
 ```
 ### rolldown
 ```js
-(function() {
+(function(foo) {
 
 "use strict";
 
-})();
+})(foo);
 ```
 ### diff
 ```diff
@@ -30,6 +30,6 @@ var mod = (() => {
 -    __reExport(entry_exports, __require("foo"));
 -    return __toCommonJS(entry_exports);
 -})();
-+(function () {})();
++(function (foo) {})(foo);
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/artifacts.snap
@@ -1,8 +1,15 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # warnings
 
+## MISSING_GLOBAL_NAME
+
+```text
+[MISSING_GLOBAL_NAME] Warning: No name was provided for external module "foo" in "output.globals" – guessing "foo".
+
+```
 ## UNRESOLVED_IMPORT
 
 ```text
@@ -20,9 +27,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-(function() {
+(function(foo) {
 
 "use strict";
 
-})();
+})(foo);
 ```

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/diff.md
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_iife_no_bundle/diff.md
@@ -12,11 +12,11 @@ var mod = (() => {
 ```
 ### rolldown
 ```js
-(function() {
+(function(foo) {
 
 "use strict";
 
-})();
+})(foo);
 ```
 ### diff
 ```diff
@@ -29,6 +29,6 @@ var mod = (() => {
 -    __reExport(entry_exports, require("foo"));
 -    return __toCommonJS(entry_exports);
 -})();
-+(function () {})();
++(function (foo) {})(foo);
 
 ```

--- a/crates/rolldown/tests/rolldown/function/format/iife/external_modules/_config.json
+++ b/crates/rolldown/tests/rolldown/function/format/iife/external_modules/_config.json
@@ -2,7 +2,8 @@
   "config": {
     "format": "iife",
     "external": [
-      "node:path"
+      "node:path",
+      "node:fs"
     ],
     "name": "module"
   },

--- a/crates/rolldown/tests/rolldown/function/format/iife/external_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/external_modules/artifacts.snap
@@ -1,8 +1,15 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # warnings
 
+## MISSING_GLOBAL_NAME
+
+```text
+[MISSING_GLOBAL_NAME] Warning: No name was provided for external module "node:fs" in "output.globals" – guessing "node_fs".
+
+```
 ## MISSING_GLOBAL_NAME
 
 ```text
@@ -14,7 +21,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-(function(node_path) {
+(function(node_path, node_fs) {
 
 "use strict";
 const { default: nodePath } = node_path;
@@ -23,5 +30,5 @@ const { default: nodePath } = node_path;
 console.log(nodePath);
 
 //#endregion
-})(node_path);
+})(node_path, node_fs);
 ```

--- a/crates/rolldown/tests/rolldown/function/format/iife/external_modules/main.js
+++ b/crates/rolldown/tests/rolldown/function/format/iife/external_modules/main.js
@@ -1,2 +1,3 @@
 import nodePath from 'node:path'
+import fs from 'node:fs'
 console.log(nodePath)

--- a/crates/rolldown/tests/rolldown/function/format/umd/external_modules/_config.json
+++ b/crates/rolldown/tests/rolldown/function/format/umd/external_modules/_config.json
@@ -2,7 +2,8 @@
   "config": {
     "format": "umd",
     "external": [
-      "node:path"
+      "node:path",
+      "node:fs"
     ],
     "name": "module"
   },

--- a/crates/rolldown/tests/rolldown/function/format/umd/external_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/umd/external_modules/artifacts.snap
@@ -1,8 +1,15 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # warnings
 
+## MISSING_GLOBAL_NAME
+
+```text
+[MISSING_GLOBAL_NAME] Warning: No name was provided for external module "node:fs" in "output.globals" – guessing "node_fs".
+
+```
 ## MISSING_GLOBAL_NAME
 
 ```text
@@ -15,10 +22,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 (function(global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ?  factory(require('node:path')) :
-  typeof define === 'function' && define.amd ? define(['node:path'], factory) :
-  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.node_path));
-})(this, function(node_path) {
+  typeof exports === 'object' && typeof module !== 'undefined' ?  factory(require('node:path'), require('node:fs')) :
+  typeof define === 'function' && define.amd ? define(['node:path', 'node:fs'], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.node_path,global.node_fs));
+})(this, function(node_path, node_fs) {
 "use strict";
 const { default: nodePath } = node_path;
 

--- a/crates/rolldown/tests/rolldown/function/format/umd/external_modules/main.js
+++ b/crates/rolldown/tests/rolldown/function/format/umd/external_modules/main.js
@@ -1,2 +1,3 @@
 import nodePath from 'node:path'
+import fs from 'node:fs'
 console.log(nodePath)

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -2169,11 +2169,11 @@ snapshot_kind: text
 
 # tests/esbuild/importstar/re_export_star_external_iife
 
-- entry-!~{000}~.js => entry-CRJgxGwW.js
+- entry-!~{000}~.js => entry-C_-fjv1R.js
 
 # tests/esbuild/importstar/re_export_star_iife_no_bundle
 
-- entry-!~{000}~.js => entry-CRJgxGwW.js
+- entry-!~{000}~.js => entry-C_-fjv1R.js
 
 # tests/esbuild/importstar/re_export_star_name_collision_not_ambiguous_export
 
@@ -4311,7 +4311,7 @@ snapshot_kind: text
 
 # tests/rolldown/function/format/iife/external_modules
 
-- main-!~{000}~.js => main-DLCvegcv.js
+- main-!~{000}~.js => main-BpLY4dGu.js
 
 # tests/rolldown/function/format/iife/external_modules_with_globals
 
@@ -4339,7 +4339,7 @@ snapshot_kind: text
 
 # tests/rolldown/function/format/umd/external_modules
 
-- main-!~{000}~.js => main-C5f5HNCi.js
+- main-!~{000}~.js => main-Cux2vdjB.js
 
 # tests/rolldown/function/format/umd/external_modules_with_complex_globals
 

--- a/packages/rollup-tests/src/ignored-tests.js
+++ b/packages/rollup-tests/src/ignored-tests.js
@@ -76,11 +76,7 @@ const ignoreTests = [
   "rollup@form@export-all-multiple: correctly handles multiple export * declarations (#1252)@generates es",
   "rollup@form@hoisted-vars-in-dead-branches: renders hoisted variables in dead branches", // https://github.com/oxc-project/oxc/issues/7209
   "rollup@form@mutations-in-imports: track mutations of imports",
-
-  // The rolldown import external module is tree-shaked at format iife/umd
-  "rollup@form@handles-empty-imports-iife: handles empty imports when generating IIFE output", 
-  "rollup@form@handles-empty-imports-umd: handles empty imports when generating IIFE output",
-
+ 
   // The `this` related
   "rollup@form@proper-this-context: make sure \"this\" respects the context for arrow functions", 
   "rollup@form@this-is-undefined: top-level `this` expression is rewritten as `undefined`@generates es",
@@ -535,6 +531,8 @@ const ignoreTests = [
   "rollup@function@chunking-duplicate-reexport: handles duplicate reexports when using dynamic imports",
 
   // Passed, but the output snapshot is same as rollup
+  "rollup@form@handles-empty-imports-iife: handles empty imports when generating IIFE output", 
+  "rollup@form@handles-empty-imports-umd: handles empty imports when generating IIFE output",
   "rollup@form@slash-in-function-parameters: handles slashes in function parameters and correctly inserts missing ids@generates es",
   "rollup@form@render-named-export-declarations: renders named export declarations@generates es",
   "rollup@form@render-declaration-semicolons: properly inserts semi-colons after declarations (#1993)@generates es",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Here is a example to show diff.

``` .ts
//  Input
import 'external'

//  Output esm
import 'external'

// Output iife
(function (external){})(external)

```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
