### PR TITLE
fix: prefix-only module is a builtin module

### DIFF
--- a/crates/rolldown_common/src/ecmascript/node_builtin_modules.rs
+++ b/crates/rolldown_common/src/ecmascript/node_builtin_modules.rs
@@ -76,7 +76,16 @@ pub const NODEJS_BUILTINS: &[&str] = &[
 /// Using `phf` should be faster, but it would increase the compile time, since this function is
 /// not frequently used, we use `binary_search` instead.
 pub fn is_builtin_modules(specifier: &str) -> bool {
-  let normalized_specifier =
-    if let Some(specifier) = specifier.strip_prefix("node:") { specifier } else { specifier };
-  NODEJS_BUILTINS.binary_search(&normalized_specifier).is_ok()
+  specifier.starts_with("node:") || NODEJS_BUILTINS.binary_search(&specifier).is_ok()
+}
+
+#[test]
+fn test_is_builtin_modules() {
+  // not prefix-only modules
+  assert!(is_builtin_modules("fs"));
+  assert!(is_builtin_modules("node:fs"));
+  // prefix-only modules
+  assert!(is_builtin_modules("node:test"));
+  // not a builtin module
+  assert!(!is_builtin_modules("unknown"));
 }

--- a/crates/rolldown_common/src/ecmascript/node_builtin_modules.rs
+++ b/crates/rolldown_common/src/ecmascript/node_builtin_modules.rs
@@ -73,10 +73,21 @@ pub const NODEJS_BUILTINS: &[&str] = &[
   "zlib",
 ];
 
+/// A list of prefix-only modules
+const NODEJS_PREFIXED_BUILTINS: &[&str] = &[
+  // https://nodejs.org/api/modules.html#built-in-modules-with-mandatory-node-prefix
+  "node:sea",
+  "node:test",
+  "node:test/reporters",
+  // https://nodejs.org/api/sqlite.html
+  "node:sqlite",
+];
+
 /// Using `phf` should be faster, but it would increase the compile time, since this function is
 /// not frequently used, we use `binary_search` instead.
 pub fn is_builtin_modules(specifier: &str) -> bool {
-  specifier.starts_with("node:") || NODEJS_BUILTINS.binary_search(&specifier).is_ok()
+  NODEJS_BUILTINS.binary_search(&specifier).is_ok()
+    || NODEJS_PREFIXED_BUILTINS.binary_search(&specifier).is_ok()
 }
 
 #[test]
@@ -88,4 +99,5 @@ fn test_is_builtin_modules() {
   assert!(is_builtin_modules("node:test"));
   // not a builtin module
   assert!(!is_builtin_modules("unknown"));
+  assert!(!is_builtin_modules("node:unknown"));
 }

--- a/crates/rolldown_common/src/ecmascript/node_builtin_modules.rs
+++ b/crates/rolldown_common/src/ecmascript/node_builtin_modules.rs
@@ -85,7 +85,7 @@ const NODEJS_PREFIXED_BUILTINS: &[&str] = &[
 
 /// Using `phf` should be faster, but it would increase the compile time, since this function is
 /// not frequently used, we use `binary_search` instead.
-pub fn is_builtin_modules(specifier: &str) -> bool {
+pub fn is_existing_node_builtin_modules(specifier: &str) -> bool {
   NODEJS_BUILTINS.binary_search(&specifier).is_ok()
     || NODEJS_PREFIXED_BUILTINS.binary_search(&specifier).is_ok()
 }
@@ -93,11 +93,11 @@ pub fn is_builtin_modules(specifier: &str) -> bool {
 #[test]
 fn test_is_builtin_modules() {
   // not prefix-only modules
-  assert!(is_builtin_modules("fs"));
-  assert!(is_builtin_modules("node:fs"));
+  assert!(is_existing_node_builtin_modules("fs"));
+  assert!(is_existing_node_builtin_modules("node:fs"));
   // prefix-only modules
-  assert!(is_builtin_modules("node:test"));
+  assert!(is_existing_node_builtin_modules("node:test"));
   // not a builtin module
-  assert!(!is_builtin_modules("unknown"));
-  assert!(!is_builtin_modules("node:unknown"));
+  assert!(!is_existing_node_builtin_modules("unknown"));
+  assert!(!is_existing_node_builtin_modules("node:unknown"));
 }

--- a/crates/rolldown_common/src/ecmascript/node_builtin_modules.rs
+++ b/crates/rolldown_common/src/ecmascript/node_builtin_modules.rs
@@ -86,8 +86,11 @@ const NODEJS_PREFIXED_BUILTINS: &[&str] = &[
 /// Using `phf` should be faster, but it would increase the compile time, since this function is
 /// not frequently used, we use `binary_search` instead.
 pub fn is_existing_node_builtin_modules(specifier: &str) -> bool {
+  if let Some(stripped) = specifier.strip_prefix("node:") {
+    return NODEJS_BUILTINS.binary_search(&stripped).is_ok()
+      || NODEJS_PREFIXED_BUILTINS.binary_search(&specifier).is_ok();
+  }
   NODEJS_BUILTINS.binary_search(&specifier).is_ok()
-    || NODEJS_PREFIXED_BUILTINS.binary_search(&specifier).is_ok()
 }
 
 #[test]

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -62,7 +62,7 @@ pub use crate::{
     ecma_asset_meta::EcmaAssetMeta,
     ecma_view::{EcmaModuleAstUsage, EcmaView, EcmaViewMeta, ImportMetaRolldownAssetReplacer},
     module_idx::ModuleIdx,
-    node_builtin_modules::is_builtin_modules,
+    node_builtin_modules::is_existing_node_builtin_modules,
   },
   file_emitter::{EmittedAsset, FileEmitter, SharedFileEmitter},
   module::{

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -2,7 +2,8 @@ use crate::{
   types::hook_resolve_id_skipped::HookResolveIdSkipped, HookResolveIdArgs, PluginDriver,
 };
 use rolldown_common::{
-  is_builtin_modules, ImportKind, ModuleDefFormat, ResolvedId, SharedNormalizedBundlerOptions,
+  is_existing_node_builtin_modules, ImportKind, ModuleDefFormat, ResolvedId,
+  SharedNormalizedBundlerOptions,
 };
 use rolldown_resolver::{ResolveError, Resolver};
 use std::{path::Path, sync::Arc};
@@ -183,7 +184,7 @@ fn resolve_id(
       ResolveError::Builtin { resolved, is_runtime_module } => Ok(Ok(ResolvedId {
         // `resolved` is always prefixed with "node:" in compliance with the ESM specification.
         // we needs to use `is_runtime_module` to get the original specifier
-        is_external_without_side_effects: is_builtin_modules(&resolved),
+        is_external_without_side_effects: is_existing_node_builtin_modules(&resolved),
         id: if resolved.starts_with("node:") && !is_runtime_module {
           resolved[5..].to_string().into()
         } else {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The list does not include prefix-only modules.
https://nodejs.org/api/module.html#modulebuiltinmodules:~:text=Note%3A%20the%20list%20doesn%27t%20contain%20prefix%2Donly%20modules%20like%20node%3Atest.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
