### PR TITLE
fix: align resolve behavior of `new URL(..., import.met.url)` with webpack

### DIFF
--- a/crates/rolldown/src/ast_scanner/new_url.rs
+++ b/crates/rolldown/src/ast_scanner/new_url.rs
@@ -34,7 +34,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     };
     let path = &first_arg_string_literal.value;
     let idx =
-      self.add_import_record(path, ImportKind::Import, expr.span, ImportRecordMeta::empty());
+      self.add_import_record(path, ImportKind::NewUrl, expr.span, ImportRecordMeta::empty());
     self.result.import_records[idx].asserted_module_type = Some(ModuleType::Asset);
     self.result.new_url_references.insert(expr.span, idx);
   }

--- a/crates/rolldown/tests/rolldown/topics/new_url/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/new_url/artifacts.snap
@@ -11,15 +11,17 @@ snapshot_kind: text
 ```js
 import assert from "node:assert";
 
+//#region main.js
+const url = new URL("assets/index-B0GLEKT9.txt", import.meta.url);
+const url2 = new URL("assets/index-B0GLEKT9.txt", import.meta.url);
+const url3 = new URL("assets/index-B0GLEKT9.txt", import.meta.url);
+assert.strictEqual(url.href, url3.href);
+assert.strictEqual(url2.href, url3.href);
+
+//#endregion
 //#region node_modules/foo/index.txt
 var foo_default = "assets/index-B0GLEKT9.txt";
 
 //#endregion
-//#region main.js
-const url = new URL("assets/index-B0GLEKT9.txt", import.meta.url);
-const url3 = new URL("assets/index-B0GLEKT9.txt", import.meta.url);
-assert.strictEqual(url.href, url3.href);
-
-//#endregion
-export { url, url3 };
+export { url, url2, url3 };
 ```

--- a/crates/rolldown/tests/rolldown/topics/new_url/main.js
+++ b/crates/rolldown/tests/rolldown/topics/new_url/main.js
@@ -3,9 +3,9 @@ import assert from 'node:assert'
 
 export const url = new URL('./node_modules/foo/index.txt', import.meta.url);
 
-// const url2 = new URL('node_modules/foo/index.txt', import.meta.url);
+export const url2 = new URL('node_modules/foo/index.txt', import.meta.url);
 
 export const url3 = new URL('foo', import.meta.url);
 
 assert.strictEqual(url.href, url3.href);
-// assert.strictEqual(url.href, url3.href);
+assert.strictEqual(url2.href, url3.href);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5133,7 +5133,7 @@ snapshot_kind: text
 
 # tests/rolldown/topics/new_url
 
-- main-!~{000}~.js => main-B7vXpKZd.js
+- main-!~{000}~.js => main-DaLi9F1d.js
 - assets/index-D25jITRo.txt
 
 # tests/rolldown/topics/npm_packages/util_deprecate

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -19,9 +19,14 @@ use oxc_resolver::{
 pub struct Resolver<T: FileSystem + Default = OsFileSystem> {
   cwd: PathBuf,
   default_resolver: ResolverGeneric<T>,
+  // Resolver for `import '...'` and `import(...)`
   import_resolver: ResolverGeneric<T>,
+  // Resolver for `require('...')`
   require_resolver: ResolverGeneric<T>,
+  // Resolver for `@import '...'` and `url('...')`
   css_resolver: ResolverGeneric<T>,
+  // Resolver for `new URL(..., import.meta.url)`
+  new_url_resolver: ResolverGeneric<T>,
   package_json_cache: DashMap<PathBuf, Arc<PackageJson>>,
 }
 
@@ -124,6 +129,11 @@ impl<F: FileSystem + Default> Resolver<F> {
       ..resolve_options_with_default_conditions.clone()
     };
 
+    let resolve_options_for_new_url = OxcResolverOptions {
+      prefer_relative: true,
+      ..resolve_options_with_default_conditions.clone()
+    };
+
     let default_resolver =
       ResolverGeneric::new_with_file_system(fs, resolve_options_with_default_conditions);
     let import_resolver =
@@ -131,6 +141,7 @@ impl<F: FileSystem + Default> Resolver<F> {
     let require_resolver =
       default_resolver.clone_with_options(resolve_options_with_require_conditions);
     let css_resolver = default_resolver.clone_with_options(resolve_options_for_css);
+    let new_url_resolver = default_resolver.clone_with_options(resolve_options_for_new_url);
 
     Self {
       cwd,
@@ -138,6 +149,7 @@ impl<F: FileSystem + Default> Resolver<F> {
       import_resolver,
       require_resolver,
       css_resolver,
+      new_url_resolver,
       package_json_cache: DashMap::default(),
     }
   }
@@ -163,7 +175,8 @@ impl<F: FileSystem + Default> Resolver<F> {
     is_user_defined_entry: bool,
   ) -> anyhow::Result<Result<ResolveReturn, ResolveError>> {
     let selected_resolver = match import_kind {
-      ImportKind::Import | ImportKind::DynamicImport | ImportKind::NewUrl => &self.import_resolver,
+      ImportKind::Import | ImportKind::DynamicImport => &self.import_resolver,
+      ImportKind::NewUrl => &self.new_url_resolver,
       ImportKind::Require => &self.require_resolver,
       ImportKind::AtImport | ImportKind::UrlImport => &self.css_resolver,
     };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

So the behavior is for bare identifier, bundler will resolve it as relative path first instead of npm modules. It means that `foo` would be resolve to `./foo.js` first. It'll hide the npm module `foo`.

More contexts:

- To prevent the above behavior, parcel supports [`npm:xxx` pattern](https://parceljs.org/blog/v2/#new-npm%3A-scheme) to force resolve to node modules first. Eg: `new URL("npm:foo", import.meta.url)`. 

This behavior is not supported by rolldown. We'll wait users feedbacks and see if we need to support this feature. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
