### PR TITLE
perf: improve the String concatenation performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,6 +2949,7 @@ dependencies = [
  "async-scoped",
  "base-encode",
  "base64-simd 0.8.0",
+ "criterion2",
  "futures",
  "glob-match",
  "indexmap",
@@ -2963,6 +2964,7 @@ dependencies = [
  "regress",
  "rolldown_std_utils",
  "rustc-hash",
+ "simdutf8",
  "sugar_path",
  "xxhash-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ single_match      = "allow"
 single_match_else = "allow"
 
 [workspace.dependencies]
+criterion2                              = { version = "2.0.0", default-features = false }
 css-module-lexer                        = "0.0.15"
 rolldown                                = { version = "0.1.0", path = "./crates/rolldown" }
 rolldown_common                         = { version = "0.1.0", path = "./crates/rolldown_common" }
@@ -119,7 +120,6 @@ base-encode         = "0.3.1"
 base64-simd         = "0.8.0"
 bitflags            = { version = "2.6.0" }
 cow-utils           = "0.1.3"
-criterion2          = { version = "2.0.0", default-features = false }
 daachorse           = "1.0.0"
 dashmap             = "6.0.0"
 derive_more         = { version = "1.0.0", features = ["debug"] }
@@ -155,7 +155,7 @@ schemars            = "0.8.21"
 self_cell           = "1.0.4"
 serde               = { version = "1.0.203", features = ["derive"] }
 serde_json          = "1.0.117"
-simdutf8            = { version = "0.1.4", features = ["aarch64_neon"] }
+simdutf8            = { version = "0.1.5" }
 smallvec            = "1.13.2"
 string_wizard       = { path = "./crates/string_wizard" }
 sugar_path          = { version = "1.2.0", features = ["cached_current_dir"] }

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 test    = false
 
 [dependencies]
-criterion2         = { version = "2.0.0", default-features = false }
+criterion2         = { workspace = true }
 oxc                = { workspace = true }
 rolldown           = { workspace = true }
 rolldown_sourcemap = { workspace = true }

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -30,6 +30,7 @@ use rolldown_common::{
 use rolldown_ecmascript_utils::{BindingIdentifierExt, BindingPatternExt};
 use rolldown_error::{BuildDiagnostic, BuildResult, CjsExportSpan};
 use rolldown_rstr::Rstr;
+use rolldown_utils::concat_string;
 use rolldown_utils::ecmascript::legitimize_identifier_name;
 use rolldown_utils::path_ext::PathExt;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -114,9 +115,9 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     // This is used for converting "export default foo;" => "var default_symbol = foo;"
     let legitimized_repr_name = legitimize_identifier_name(repr_name);
     let default_export_ref = symbol_ref_db
-      .create_facade_root_symbol_ref(format!("{legitimized_repr_name}_default").into());
+      .create_facade_root_symbol_ref(concat_string!(legitimized_repr_name, "_default").into());
 
-    let name = format!("{legitimized_repr_name}_exports");
+    let name = concat_string!(legitimized_repr_name, "_exports");
     let namespace_object_ref = symbol_ref_db.create_facade_root_symbol_ref(name.into());
 
     let result = ScanResult {
@@ -278,9 +279,10 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     // to `var import_foo = __toESM(require_foo())`, so we create a symbol for `import_foo` here. Notice that we
     // just create the symbol. If the symbol is finally used would be determined in the linking stage.
     let namespace_ref: SymbolRef = self.result.symbol_ref_db.create_facade_root_symbol_ref(
-      format!(
-        "#LOCAL_NAMESPACE_IN_{}#",
-        itoa::Buffer::new().format(self.current_stmt_info.stmt_idx.unwrap_or_default())
+      concat_string!(
+        "#LOCAL_NAMESPACE_IN_",
+        itoa::Buffer::new().format(self.current_stmt_info.stmt_idx.unwrap_or_default()),
+        "#"
       )
       .into(),
     );
@@ -388,7 +390,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         let importee_repr =
           self.result.import_records[record_id].module_request.as_path().representative_file_name();
         let importee_repr = legitimize_identifier_name(&importee_repr);
-        format!("{importee_repr}_default").into()
+        concat_string!(importee_repr, "_default").into()
       } else {
         export_name.into()
       });

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -2,6 +2,7 @@ use arcstr::ArcStr;
 use itertools::Itertools;
 use rolldown_common::{ChunkKind, ExportsKind, Module, WrapKind};
 use rolldown_sourcemap::SourceJoiner;
+use rolldown_utils::concat_string;
 
 use crate::{
   ecmascript::ecma_generator::RenderedModuleSources,
@@ -53,8 +54,7 @@ pub fn render_esm<'code>(
           })
           .dedup()
           .for_each(|ext_name| {
-            let import_stmt = format!("export * from \"{}\"\n", &ext_name);
-            source_joiner.append_source(import_stmt);
+            source_joiner.append_source(concat_string!("export * from \"", ext_name, "\"\n"));
           });
       }
     }
@@ -77,14 +77,18 @@ pub fn render_esm<'code>(
         let wrapper_ref = entry_meta.wrapper_ref.as_ref().unwrap();
         let wrapper_ref_name =
           ctx.link_output.symbol_db.canonical_name_for(*wrapper_ref, &ctx.chunk.canonical_names);
-        source_joiner.append_source(format!("{wrapper_ref_name}();",));
+        source_joiner.append_source(concat_string!(wrapper_ref_name.as_str(), "();"));
       }
       WrapKind::Cjs => {
         // "export default require_xxx();"
         let wrapper_ref = entry_meta.wrapper_ref.as_ref().unwrap();
         let wrapper_ref_name =
           ctx.link_output.symbol_db.canonical_name_for(*wrapper_ref, &ctx.chunk.canonical_names);
-        source_joiner.append_source(format!("export default {wrapper_ref_name}();\n"));
+        source_joiner.append_source(concat_string!(
+          "export default ",
+          wrapper_ref_name.as_str(),
+          "();\n"
+        ));
       }
       WrapKind::None => {}
     }
@@ -117,7 +121,9 @@ fn render_esm_chunk_imports(ctx: &GenerateContext<'_>) -> String {
     match &stmt.specifiers() {
       RenderImportDeclarationSpecifier::ImportSpecifier(specifiers) => {
         if specifiers.is_empty() {
-          s.push_str(&format!("import \"{path}\";\n",));
+          s.push_str("import \"");
+          s.push_str(path);
+          s.push_str("\";\n");
         } else {
           let mut default_alias = vec![];
           let specifiers = specifiers
@@ -128,7 +134,7 @@ fn render_esm_chunk_imports(ctx: &GenerateContext<'_>) -> String {
                   default_alias.push(alias.to_string());
                   return None;
                 }
-                Some(format!("{} as {alias}", specifier.imported))
+                Some(concat_string!(specifier.imported, " as ", alias))
               } else {
                 Some(specifier.imported.to_string())
               }
@@ -138,7 +144,11 @@ fn render_esm_chunk_imports(ctx: &GenerateContext<'_>) -> String {
         }
       }
       RenderImportDeclarationSpecifier::ImportStarSpecifier(alias) => {
-        s.push_str(&format!("import * as {alias} from \"{path}\";\n",));
+        s.push_str("import * as ");
+        s.push_str(alias);
+        s.push_str(" from \"");
+        s.push_str(path);
+        s.push_str("\";\n");
       }
     }
   });
@@ -155,7 +165,7 @@ fn create_import_declaration(
     [] => None,
     [first] => Some(first),
     [first, rest @ ..] => {
-      specifiers.extend(rest.iter().map(|item| format!("default as {item}",)));
+      specifiers.extend(rest.iter().map(|item| concat_string!("default as ", item)));
       Some(first)
     }
   };
@@ -165,9 +175,17 @@ fn create_import_declaration(
       ret.push_str(first_default_alias);
       ret.push_str(", ");
     }
-    ret.push_str(&format!("{{ {} }} from \"{path}\";\n", specifiers.join(", ")));
+    ret.push_str("{ ");
+    ret.push_str(&specifiers.join(", "));
+    ret.push_str(" } from \"");
+    ret.push_str(path);
+    ret.push_str("\";\n");
   } else if let Some(first_default_alias) = first_default_alias {
-    ret.push_str(&format!("import {first_default_alias} from \"{path}\";\n"));
+    ret.push_str("import ");
+    ret.push_str(first_default_alias);
+    ret.push_str(" from \"");
+    ret.push_str(path);
+    ret.push_str("\";\n");
   }
   ret
 }

--- a/crates/rolldown/src/ecmascript/format/utils/namespace.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/namespace.rs
@@ -8,7 +8,7 @@ use crate::types::generator::GenerateContext;
 use arcstr::ArcStr;
 use rolldown_common::OutputExports;
 use rolldown_error::{BuildDiagnostic, BuildResult};
-use rolldown_utils::ecmascript::is_validate_assignee_identifier_name;
+use rolldown_utils::{concat_string, ecmascript::is_validate_assignee_identifier_name};
 
 /// According to the amount of `.` in the name (levels),
 /// it generates the initialization code and the final code.
@@ -130,9 +130,9 @@ pub fn generate_identifier(
 /// - Otherwise, it will generate a caller like `["if"]`.
 pub fn render_property_access(name: &str) -> String {
   if is_validate_assignee_identifier_name(name) {
-    format!(".{name}")
+    concat_string!(".", name)
   } else {
-    format!("[\"{name}\"]")
+    concat_string!("[\"", name, "\"]")
   }
 }
 

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -13,6 +13,7 @@ use rolldown_common::{
 };
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_utils::{
+  concat_string,
   extract_hash_pattern::extract_hash_pattern,
   hash_placeholder::HashPlaceholderGenerator,
   path_buf_ext::PathBufExt,
@@ -197,7 +198,7 @@ impl<'a> GenerateStage<'a> {
               let next_count = *occ.get();
               occ.insert(next_count + 1);
               candidate =
-                ArcStr::from(format!("{}{}", name, itoa::Buffer::new().format(next_count)));
+                ArcStr::from(concat_string!(name, itoa::Buffer::new().format(next_count)).as_str());
             }
             Entry::Vacant(vac) => {
               // This is the first time we see this name

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -359,7 +359,7 @@ impl<'a> BindImportsAndExportsContext<'a> {
       let match_import_span = tracing::trace_span!(
         "MATCH_IMPORT",
         module_id = module.stable_id,
-        imported_specifier = format!("{}", named_import.imported)
+        imported_specifier = named_import.imported.to_string()
       );
       let _enter = match_import_span.enter();
 
@@ -512,7 +512,7 @@ impl<'a> BindImportsAndExportsContext<'a> {
       "TRACKING_MATCH_IMPORT",
       importer = normal_modules[tracker.importer].stable_id(),
       importee = normal_modules[tracker.importee].stable_id(),
-      imported_specifier = format!("{}", tracker.imported)
+      imported_specifier = tracker.imported.to_string()
     );
     let _enter = tracking_span.enter();
 

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -9,6 +9,7 @@ use rolldown_common::{
 };
 use rolldown_error::BuildDiagnostic;
 use rolldown_utils::{
+  concat_string,
   ecmascript::legitimize_identifier_name,
   index_vec_ext::IndexVecExt,
   rayon::{IntoParallelRefIterator, ParallelIterator},
@@ -288,7 +289,7 @@ impl<'a> LinkStage<'a> {
                     // export * from 'external' would be just removed. So it references nothing.
                     rec.namespace_ref.set_name(
                       &mut symbols.lock().unwrap(),
-                      &format!("import_{}", legitimize_identifier_name(&importee.name)),
+                      &concat_string!("import_", legitimize_identifier_name(&importee.name)),
                     );
                   } else {
                     // import ... from 'external' or export ... from 'external'
@@ -368,7 +369,7 @@ impl<'a> LinkStage<'a> {
                         declared_symbol_for_stmt_pairs.push((stmt_idx, rec.namespace_ref));
                         rec.namespace_ref.set_name(
                           &mut symbols.lock().unwrap(),
-                          &format!("import_{}", &importee.repr_name),
+                          &concat_string!("import_", importee.repr_name),
                         );
                       }
                     }

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -7,6 +7,7 @@ use rolldown_common::{
 };
 use rolldown_rstr::Rstr;
 use rolldown_utils::{
+  concat_string,
   ecmascript::{is_validate_identifier_name, property_access_str},
   indexmap::FxIndexSet,
 };
@@ -34,19 +35,27 @@ pub fn render_chunk_exports(
           if let Some(ns_alias) = &symbol.namespace_alias {
             let canonical_ns_name = &chunk.canonical_names[&ns_alias.namespace_ref];
             let property_name = &ns_alias.property_name;
-            s.push_str(&format!("var {canonical_name} = {canonical_ns_name}.{property_name};\n"));
+            s.push_str(&concat_string!(
+              "var ",
+              canonical_name,
+              " = ",
+              canonical_ns_name,
+              ".",
+              property_name,
+              ";\n"
+            ));
           }
 
           if canonical_name == &exported_name {
-            format!("{canonical_name}")
+            Cow::Borrowed(canonical_name.as_str())
           } else if is_validate_identifier_name(&exported_name) {
-            format!("{canonical_name} as {exported_name}")
+            Cow::Owned(concat_string!(canonical_name, " as ", exported_name))
           } else {
-            format!("{canonical_name} as '{exported_name}'")
+            Cow::Owned(concat_string!(canonical_name, " as '", exported_name, "'"))
           }
         })
         .collect::<Vec<_>>();
-      s.push_str(&format!("export {{ {} }};", rendered_items.join(", "),));
+      s.push_str(&concat_string!("export { ", rendered_items.join(", "), " };"));
       Some(s)
     }
     OutputFormat::Cjs | OutputFormat::Iife | OutputFormat::Umd => {
@@ -78,8 +87,11 @@ pub fn render_chunk_exports(
                   if is_this_symbol_point_to_other_chunk {
                     let require_binding = &ctx.chunk.require_binding_names_for_other_chunks
                       [&canonical_ref_owner_chunk_idx];
-                    canonical_name =
-                      Cow::Owned(Rstr::new(&format!("{require_binding}.{canonical_name}")));
+                    canonical_name = Cow::Owned(Rstr::new(&concat_string!(
+                      require_binding,
+                      ".",
+                      canonical_name.as_str()
+                    )));
                   };
                   canonical_name.clone()
                 };
@@ -92,26 +104,31 @@ pub fn render_chunk_exports(
                       options,
                       &link_output.module_table.modules,
                     ) {
-                      format!(
-                        "Object.defineProperty(exports, '{exported_name}', {{
+                      concat_string!(
+                        "Object.defineProperty(exports, '",
+                        exported_name.as_str(),
+                        "', {
   enumerable: true,
-  get: function () {{
-    return {exported_value};
-  }}
-}});"
+  get: function () {
+    return ",
+                        exported_value.as_str(),
+                        ";
+  }
+});"
                       )
                     } else {
-                      format!(
-                        "{left_value} = {exported_value}",
-                        left_value = property_access_str("exports", &exported_name)
+                      concat_string!(
+                        property_access_str("exports", exported_name.as_str()),
+                        " = ",
+                        exported_value.as_str()
                       )
                     }
                   }
                   Some(OutputExports::Default) => {
                     if matches!(options.format, OutputFormat::Cjs) {
-                      format!("module.exports = {canonical_name};")
+                      concat_string!("module.exports = ", canonical_name.as_str(), ";")
                     } else {
-                      format!("return {canonical_name};")
+                      concat_string!("return ", canonical_name.as_str(), ";")
                     }
                   }
                   Some(OutputExports::None) => String::new(),
@@ -153,22 +170,31 @@ pub fn render_chunk_exports(
             if let Some(ns_alias) = &symbol.namespace_alias {
               let canonical_ns_name = &chunk.canonical_names[&ns_alias.namespace_ref];
               let property_name = &ns_alias.property_name;
-              s.push_str(&format!(
-                "Object.defineProperty(exports, '{exported_name}', {{
+              s.push_str(&concat_string!(
+                "Object.defineProperty(exports, '",
+                exported_name,
+                "', {
   enumerable: true,
-  get: function () {{
-    return {canonical_ns_name}.{property_name};
-  }}
-}});\n"
+  get: function () {
+    return ",
+                canonical_ns_name,
+                ".",
+                property_name,
+                ";\n  }
+});\n"
               ));
             } else {
-              s.push_str(&format!(
-                "Object.defineProperty(exports, '{exported_name}', {{
+              s.push_str(&concat_string!(
+                "Object.defineProperty(exports, '",
+                exported_name,
+                "', {
   enumerable: true,
-  get: function () {{
-    return {canonical_name};
-  }}
-}});"
+  get: function () {
+    return ",
+                canonical_name,
+                ";
+  }
+});"
               ));
             };
           });

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -4,7 +4,10 @@ use rolldown_common::{
   IndexModules, ModuleIdx, NormalModule, OutputFormat, SymbolNameRefToken, SymbolRef, SymbolRefDb,
 };
 use rolldown_rstr::{Rstr, ToRstr};
-use rolldown_utils::rayon::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rolldown_utils::{
+  concat_string,
+  rayon::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator},
+};
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
@@ -71,7 +74,7 @@ impl<'name> Renamer<'name> {
               let next_conflict_index = *occ.get() + 1;
               *occ.get_mut() = next_conflict_index;
               candidate_name =
-                format!("{original_name}${}", itoa::Buffer::new().format(next_conflict_index))
+                concat_string!(original_name, "$", itoa::Buffer::new().format(next_conflict_index))
                   .into();
             }
             Entry::Vacant(vac) => {
@@ -97,7 +100,7 @@ impl<'name> Renamer<'name> {
           let next_conflict_index = *occ.get() + 1;
           *occ.get_mut() = next_conflict_index;
           conflictless_name =
-            format!("{hint}${}", itoa::Buffer::new().format(next_conflict_index)).into();
+            concat_string!(hint, "$", itoa::Buffer::new().format(next_conflict_index)).into();
         }
         Entry::Vacant(vac) => {
           vac.insert(0);
@@ -118,7 +121,7 @@ impl<'name> Renamer<'name> {
           let next_conflict_index = *occ.get() + 1;
           *occ.get_mut() = next_conflict_index;
           conflictless_name =
-            format!("{hint}${}", itoa::Buffer::new().format(next_conflict_index)).into();
+            concat_string!(hint, "$", itoa::Buffer::new().format(next_conflict_index)).into();
         }
         Entry::Vacant(vac) => {
           vac.insert(0);
@@ -156,7 +159,7 @@ impl<'name> Renamer<'name> {
 
             if is_shadowed {
               candidate_name =
-                format!("{binding_name}${}", itoa::Buffer::new().format(count)).into();
+                concat_string!(binding_name, "$", itoa::Buffer::new().format(count)).into();
               count += 1;
             } else {
               used_canonical_names_for_this_scope.insert(candidate_name.clone(), 0);

--- a/crates/rolldown/src/utils/render_ecma_module.rs
+++ b/crates/rolldown/src/utils/render_ecma_module.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use rolldown_common::{ModuleRenderOutput, NormalModule, NormalizedBundlerOptions};
 use rolldown_sourcemap::{collapse_sourcemaps, Source, SourceMapSource};
+use rolldown_utils::concat_string;
 
 pub fn render_ecma_module(
   module: &NormalModule,
@@ -12,8 +13,7 @@ pub fn render_ecma_module(
     None
   } else {
     let mut sources: Vec<Box<dyn rolldown_sourcemap::Source + Send + Sync>> = vec![];
-    sources
-      .push(Box::new(format!("//#region {debug_module_id}", debug_module_id = module.debug_id)));
+    sources.push(Box::new(concat_string!("//#region ", module.debug_id)));
 
     let enable_sourcemap = options.sourcemap.is_some() && !module.is_virtual();
 

--- a/crates/rolldown_rstr/src/lib.rs
+++ b/crates/rolldown_rstr/src/lib.rs
@@ -49,6 +49,12 @@ impl Deref for Rstr {
   }
 }
 
+impl AsRef<str> for Rstr {
+  fn as_ref(&self) -> &str {
+    self.0.as_str()
+  }
+}
+
 impl Display for Rstr {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     self.as_str().fmt(f)

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -12,6 +12,11 @@ repository.workspace = true
 [lib]
 doctest = false
 
+[[bench]]
+harness = false
+name    = "concat_string"
+path    = "bench/concat_string.rs"
+
 [lints]
 workspace = true
 
@@ -33,6 +38,7 @@ regex              = { workspace = true }
 regress            = { workspace = true }
 rolldown_std_utils = { workspace = true }
 rustc-hash         = { workspace = true }
+simdutf8           = { workspace = true }
 sugar_path         = { workspace = true }
 xxhash-rust        = { workspace = true, features = ["xxh3"] }
 
@@ -40,3 +46,6 @@ xxhash-rust        = { workspace = true, features = ["xxh3"] }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 async-scoped = { workspace = true, features = ["use-tokio"] }
 rayon        = { workspace = true }
+
+[dev-dependencies]
+criterion2 = { workspace = true }

--- a/crates/rolldown_utils/bench/concat_string.rs
+++ b/crates/rolldown_utils/bench/concat_string.rs
@@ -1,0 +1,33 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rolldown_utils::{concat_string, mime::MimeExt};
+
+fn bench_concat_string(c: &mut Criterion) {
+  let mut group = c.benchmark_group("concat_string");
+  let long1 = "a".repeat(1000);
+  let long2 = "b".repeat(1000);
+  let base64 = "base64".repeat(1000);
+
+  let mime_ext = MimeExt { mime: "image/png".parse().unwrap(), is_utf8_encoded: true };
+
+  // Mix of String and str
+  group.bench_function("mixed_types_concat", |b| {
+    let mime_ext_string = mime_ext.to_string();
+    b.iter(|| black_box(concat_string!("data:", mime_ext_string, ";base64,", base64)));
+  });
+  group.bench_function("mixed_types_format", |b| {
+    b.iter(|| black_box(format!("data:{mime_ext};base64,{base64}")));
+  });
+
+  // Longer strings
+  group.bench_function("long_strings_concat", |b| {
+    b.iter(|| black_box(concat_string!(long1.as_str(), long2.as_str())));
+  });
+  group.bench_function("long_strings_format", |b| {
+    b.iter(|| black_box(format!("{long1}{long2}")));
+  });
+
+  group.finish();
+}
+
+criterion_group!(benches, bench_concat_string);
+criterion_main!(benches);

--- a/crates/rolldown_utils/src/concat_string.rs
+++ b/crates/rolldown_utils/src/concat_string.rs
@@ -1,0 +1,77 @@
+// https://github.com/FaultyRAM/concat-string
+//
+// Copyright (c) 2017-2018 FaultyRAM
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
+// distributed except according to those terms.
+
+//! Macros for concatenating string slices into owned strings.
+//!
+//! This crate provides the `concat_string!` macro for efficiently concatenating string slices into
+//! owned strings. `concat_string!` accepts any number of arguments that implement `AsRef<str>` and
+//! creates a `String` with the appropriate capacity, without the need for format strings and their
+//! associated runtime overhead.
+//!
+//! # Example
+//!
+//! ```rust
+//! #[macro_use(concat_string)]
+//! extern crate concat_string;
+//!
+//! fn main() {
+//!     println!("{}", concat_string!("Hello", String::from(" "), "world"));
+//! }
+//! ```
+
+#[macro_export]
+/// Concatenates a series of string slices into an owned string.
+///
+/// This macro accepts zero or more arguments, where each argument implements `AsRef<str>`, and
+/// efficiently combines their string representations into a `String` in order of declaration.
+///
+/// This is mainly useful for cases where the cost of parsing a format string outweighs the cost
+/// of converting its arguments. Because `concat_string` avoids format strings entirely, it can
+/// achieve a higher level of performance than using `format!` or other formatting utilities that
+/// return a `String`.
+///
+/// # Example
+///
+/// ```rust
+/// use rolldown_utils::concat_string;
+///
+/// println!("{}", concat_string!("Hello", String::from(" "), "world"));
+/// ```
+macro_rules! concat_string {
+    () => { String::with_capacity(0) };
+    ($($s:expr),+) => {{
+        use std::ops::AddAssign;
+        let mut len = 0;
+        $(len.add_assign(AsRef::<str>::as_ref(&$s).len());)+
+        let mut buf = String::with_capacity(len);
+        $(buf.push_str($s.as_ref());)+
+        buf
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+  #[test]
+  fn concat_string_0_args() {
+    let s = concat_string!();
+    assert_eq!(s, String::new());
+  }
+
+  #[test]
+  fn concat_string_1_arg() {
+    let s = concat_string!("foo");
+    assert_eq!(s, String::from("foo"));
+  }
+
+  #[test]
+  fn concat_string_str_string() {
+    let s = concat_string!("foo", String::from("bar"));
+    assert_eq!(s, String::from("foobar"));
+  }
+}

--- a/crates/rolldown_utils/src/dataurl.rs
+++ b/crates/rolldown_utils/src/dataurl.rs
@@ -1,12 +1,15 @@
-use crate::{mime::MimeExt, percent_encoding::encode_as_percent_escaped};
+use crate::{concat_string, mime::MimeExt, percent_encoding::encode_as_percent_escaped};
 
 /// Returns shorter of either a base64-encoded or percent-escaped data URL
 // adapted from https://github.com/evanw/esbuild/blob/67cbf87a4909d87a902ca8c3b69ab5330defab0a/internal/helpers/dataurl.go by @ikkz
 pub fn encode_as_shortest_dataurl(mime_ext: &MimeExt, buf: &[u8]) -> String {
   let base64 = crate::base64::to_standard_base64(buf);
-  let base64_url = format!("data:{mime_ext};base64,{base64}");
+  let mime_ext_string = mime_ext.to_string();
+  let base64_url = concat_string!("data:", mime_ext_string, ";base64,", base64);
 
-  match encode_as_percent_escaped(buf).map(|encoded| format!("data:{mime_ext},{encoded}",)) {
+  match encode_as_percent_escaped(buf)
+    .map(|encoded| concat_string!("data:", mime_ext_string, ",", encoded))
+  {
     Some(percent_url) if percent_url.len() < base64_url.len() => percent_url,
     _ => base64_url,
   }

--- a/crates/rolldown_utils/src/ecmascript.rs
+++ b/crates/rolldown_utils/src/ecmascript.rs
@@ -1,6 +1,8 @@
 use oxc::syntax::{identifier, keyword};
 use std::borrow::Cow;
 
+use crate::concat_string;
+
 pub fn is_validate_identifier_name(name: &str) -> bool {
   identifier::is_identifier_name(name)
 }
@@ -48,9 +50,9 @@ pub fn legitimize_identifier_name(name: &str) -> Cow<str> {
 
 pub fn property_access_str(obj: &str, prop: &str) -> String {
   if is_validate_identifier_name(prop) {
-    format!("{obj}.{prop}")
+    concat_string!(obj, ".", prop)
   } else {
-    format!("{obj}[\"{prop}\"]")
+    concat_string!(obj, "[", "\"", prop, "\"]")
   }
 }
 

--- a/crates/rolldown_utils/src/js_regex.rs
+++ b/crates/rolldown_utils/src/js_regex.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+use crate::concat_string;
+
 /// According to the doc of `regress`, https://docs.rs/regress/0.10.0/regress/#comparison-to-regex-crate
 /// **regress supports features that regex does not, in particular backreferences and zero-width lookaround assertions.**
 /// these features are not commonly used, so in most cases the slow path will not be reached.
@@ -18,7 +20,8 @@ impl HybridRegex {
   }
 
   pub fn with_flags(pattern: &str, flags: &str) -> anyhow::Result<Self> {
-    let regex_pattern = if flags.is_empty() { pattern } else { &format!("(?{flags}){pattern}") };
+    let regex_pattern =
+      if flags.is_empty() { pattern } else { &concat_string!("(?", flags, ")", pattern) };
 
     match regex::Regex::new(regex_pattern).map(HybridRegex::Optimize) {
       Ok(reg) => Ok(reg),

--- a/crates/rolldown_utils/src/lib.rs
+++ b/crates/rolldown_utils/src/lib.rs
@@ -18,6 +18,7 @@ pub mod rustc_hash;
 pub mod sanitize_file_name;
 pub mod xxhash;
 pub use bitset::BitSet;
+pub mod concat_string;
 pub mod extract_hash_pattern;
 pub mod hash_placeholder;
 pub mod index_vec_ext;

--- a/crates/rolldown_utils/src/mime.rs
+++ b/crates/rolldown_utils/src/mime.rs
@@ -2,8 +2,8 @@ use crate::light_guess::{self, RawMimeExt};
 use mime::Mime;
 use std::{fmt::Display, path::Path, str::FromStr};
 
-fn is_texture(data: &[u8]) -> bool {
-  std::str::from_utf8(data).is_ok()
+fn is_valid_utf8(data: &[u8]) -> bool {
+  simdutf8::basic::from_utf8(data).is_ok()
 }
 
 #[derive(Debug)]
@@ -47,7 +47,7 @@ pub fn guess_mime(path: &Path, data: &[u8]) -> anyhow::Result<MimeExt> {
     return Ok((Mime::from_str(inferred.mime_type())?, false).into());
   }
 
-  if is_texture(data) || data.is_empty() {
+  if is_valid_utf8(data) || data.is_empty() {
     return Ok((mime::TEXT_PLAIN, true).into());
   }
 


### PR DESCRIPTION
Considering
```rust
  let base64 = "base64".repeat(1000);

  let mime_ext = MimeExt { mime: "image/png".parse().unwrap(), is_utf8_encoded: true };

  // Mix of String and str
  group.bench_function("mixed_types_concat", |b| {
    let mime_ext_string = mime_ext.to_string();
    b.iter(|| black_box(concat_string!("data:", mime_ext_string, ";base64,", base64)));
  });
  group.bench_function("mixed_types_format", |b| {
    b.iter(|| black_box(format!("data:{mime_ext};base64,{base64}")));
  });
```

`concat_string` is 2x faster than `format!`

```
concat_string/mixed_types_concat
                        time:   [98.035 ns 101.56 ns 105.10 ns]
                        change: [+8.7720% +13.706% +18.797%] (p = 0.00 < 0.05)
                        Performance has regressed.
concat_string/mixed_types_format
                        time:   [217.54 ns 221.50 ns 225.72 ns]
                        change: [+2.2251% +4.5076% +6.7315%] (p = 0.00 < 0.05)
                        Performance has regressed.
```