### PR TITLE
docs(contrib): add coding style for naming in rust

### DIFF
--- a/docs/contrib-guide/coding-style.md
+++ b/docs/contrib-guide/coding-style.md
@@ -2,6 +2,14 @@
 
 We recommend to follow these guidelines when writing code for rolldown. They aren't very strict rules since we want to be flexible and we understand that under certain circumstances some of them can be counterproductive. Just try to follow as many of them as possible:
 
+## Namings
+
+### Rust
+
+We tend to follow the suggestions of [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/). They are authored largely by the Rust library team, based on experiences building the Rust standard library and other crates in the Rust ecosystem.
+
+We understand that there are cases that rules don't apply, but you should try to follow them as much as possible.
+
 ## Adding tests
 
 In generate, we have two environments for running different purposes of tests. See [Testing](./testing.md) for more information.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The naming style is not a strict rule, as the book said

> These guidelines should not in any way be considered a mandate that crate authors must follow, though they may find that crates that conform well to these guidelines integrate better with the existing crate ecosystem than those that do not.

It's ok to violate these suggestions, but you should have a reasonable explanation, such as the book didn't cover this pattern, instead of personal habit.

- I'm open to other styles. But following https://rust-lang.github.io/api-guidelines/ should be more pratical choice than others due to

>  They are authored largely by the Rust library team, based on experiences building the Rust standard library and other crates in the Rust ecosystem.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
