### PR TITLE
perf(rolldown_sourcemap): pre-allocate memory in `join` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,6 +2886,7 @@ dependencies = [
 name = "rolldown_sourcemap"
 version = "0.1.0"
 dependencies = [
+ "criterion2",
  "memchr",
  "oxc",
  "rolldown_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ base-encode         = "0.3.1"
 base64-simd         = "0.8.0"
 bitflags            = { version = "2.6.0" }
 cow-utils           = "0.1.3"
+criterion2          = { version = "2.0.0", default-features = false }
 daachorse           = "1.0.0"
 dashmap             = "6.0.0"
 derive_more         = { version = "1.0.0", features = ["debug"] }
@@ -167,6 +168,7 @@ typedmap            = "0.5.0"
 urlencoding         = "2.1.3"
 vfs                 = "0.12.0"
 xxhash-rust         = "0.8.10"
+
 
 # oxc crates share the same version
 oxc                = { version = "0.36.0", features = ["sourcemap_concurrent", "transformer", "minifier", "semantic", "codegen"] }

--- a/crates/rolldown_sourcemap/Cargo.toml
+++ b/crates/rolldown_sourcemap/Cargo.toml
@@ -22,3 +22,11 @@ memchr         = { workspace = true }
 oxc            = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash     = { workspace = true }
+
+[dev-dependencies]
+criterion2 = { workspace = true, default-features = false }
+
+
+[[bench]]
+harness = false
+name    = "join"

--- a/crates/rolldown_sourcemap/benches/join.rs
+++ b/crates/rolldown_sourcemap/benches/join.rs
@@ -1,0 +1,21 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rolldown_sourcemap::SourceJoiner;
+
+fn criterion_benchmark(c: &mut Criterion) {
+  let mut group = c.benchmark_group("join");
+  // A module that is 1kb in size
+  let a_norma_module = " ".repeat(1024);
+
+  group.bench_function("join", move |b| {
+    let mut joiner = SourceJoiner::default();
+    for _ in 0..1024 {
+      joiner.append_source(a_norma_module.as_str());
+    }
+    b.iter(move || {
+      black_box(joiner.join());
+    });
+  });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/rolldown_sourcemap/benches/join.rs
+++ b/crates/rolldown_sourcemap/benches/join.rs
@@ -8,8 +8,8 @@ fn criterion_benchmark(c: &mut Criterion) {
 
   group.bench_function("join", move |b| {
     let mut joiner = SourceJoiner::default();
-    for _ in 0..1024 {
-      joiner.append_source(a_norma_module.as_str());
+    for _ in 0..10_000 {
+      joiner.append_source(a_norma_module.clone());
     }
     b.iter(move || {
       black_box(joiner.join());

--- a/crates/rolldown_sourcemap/src/source.rs
+++ b/crates/rolldown_sourcemap/src/source.rs
@@ -1,4 +1,4 @@
-use oxc::sourcemap::{ConcatSourceMapBuilder, SourceMap};
+use oxc::sourcemap::SourceMap;
 
 use crate::lines_count;
 
@@ -8,13 +8,6 @@ pub trait Source {
   fn lines_count(&self) -> u32 {
     lines_count(self.content())
   }
-  #[allow(clippy::wrong_self_convention)]
-  fn join(
-    &self,
-    final_source: &mut String,
-    sourcemap_builder: &mut Option<ConcatSourceMapBuilder>,
-    line_offset: u32,
-  );
 }
 
 impl<'a> Source for &'a str {
@@ -25,15 +18,6 @@ impl<'a> Source for &'a str {
   fn content(&self) -> &str {
     self
   }
-
-  fn join(
-    &self,
-    final_source: &mut String,
-    _sourcemap_builder: &mut Option<ConcatSourceMapBuilder>,
-    _line_offset: u32,
-  ) {
-    final_source.push_str(self);
-  }
 }
 
 impl Source for String {
@@ -43,15 +27,6 @@ impl Source for String {
 
   fn content(&self) -> &str {
     self
-  }
-
-  fn join(
-    &self,
-    source: &mut String,
-    _sourcemap_builder: &mut Option<ConcatSourceMapBuilder>,
-    _line_offset: u32,
-  ) {
-    source.push_str(self);
   }
 }
 
@@ -87,19 +62,6 @@ impl Source for SourceMapSource {
   fn lines_count(&self) -> u32 {
     self.pre_computed_lines_count.unwrap_or_else(|| lines_count(&self.content))
   }
-
-  fn join(
-    &self,
-    source: &mut String,
-    sourcemap_builder: &mut Option<ConcatSourceMapBuilder>,
-    line_offset: u32,
-  ) {
-    if let Some(sourcemap_builder) = sourcemap_builder {
-      sourcemap_builder.add_sourcemap(&self.sourcemap, line_offset);
-    }
-
-    source.push_str(&self.content);
-  }
 }
 
 impl<'a> Source for &'a Box<dyn Source + Send + Sync> {
@@ -113,14 +75,5 @@ impl<'a> Source for &'a Box<dyn Source + Send + Sync> {
 
   fn lines_count(&self) -> u32 {
     self.as_ref().lines_count()
-  }
-
-  fn join(
-    &self,
-    source: &mut String,
-    sourcemap_builder: &mut Option<ConcatSourceMapBuilder>,
-    line_offset: u32,
-  ) {
-    self.as_ref().join(source, sourcemap_builder, line_offset);
   }
 }

--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -28,7 +28,7 @@ impl<'source> SourceJoiner<'source> {
     self.prepend_source.push(source);
   }
 
-  pub fn join(self) -> (String, Option<SourceMap>) {
+  pub fn join(&self) -> (String, Option<SourceMap>) {
     let mut final_source = String::new();
     let mut sourcemap_builder = self.enable_sourcemap.then(|| {
       ConcatSourceMapBuilder::with_capacity(

--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -29,7 +29,15 @@ impl<'source> SourceJoiner<'source> {
   }
 
   pub fn join(&self) -> (String, Option<SourceMap>) {
-    let mut final_source = String::new();
+    let sources_len = self.prepend_source.len() + self.inner.len();
+    let sources_iter = self.prepend_source.iter().chain(self.inner.iter()).enumerate();
+
+    let size_hint_of_ret_source = sources_iter.clone().map(|(_idx, source)| source.content().len()).sum::<usize>()
+        + /* Each source we will emit a '\n' but exclude last one */ (sources_len - /* Exclude the last source  */ 1);
+    let mut ret_source = String::with_capacity(size_hint_of_ret_source);
+
+    let mut line_offset = 0;
+
     let mut sourcemap_builder = self.enable_sourcemap.then(|| {
       ConcatSourceMapBuilder::with_capacity(
         self.names_len,
@@ -38,18 +46,19 @@ impl<'source> SourceJoiner<'source> {
         self.token_chunks_len,
       )
     });
-    let mut line_offset = 0;
-    let source_len = self.prepend_source.len() + self.inner.len();
-
-    for (index, source) in self.prepend_source.iter().chain(self.inner.iter()).enumerate() {
-      source.join(&mut final_source, &mut sourcemap_builder, line_offset);
-      if index < source_len - 1 {
-        final_source.push('\n');
+    for (index, source) in sources_iter {
+      if let Some(sourcemap_builder) = &mut sourcemap_builder {
+        source.sourcemap().inspect(|map| {
+          sourcemap_builder.add_sourcemap(map, line_offset);
+        });
+      }
+      ret_source.push_str(source.content());
+      if index < sources_len - 1 {
+        ret_source.push('\n');
         line_offset += source.lines_count() + 1; // +1 for the newline
       }
     }
-
-    (final_source, sourcemap_builder.map(ConcatSourceMapBuilder::into_sourcemap))
+    (ret_source, sourcemap_builder.map(ConcatSourceMapBuilder::into_sourcemap))
   }
 
   fn accumulate_sourcemap_data_size(&mut self, hint: &SourceMap) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Local benchmark data

```
// Without pre-allocation
join/join               time:   [1.7542 ms 1.8115 ms 1.8710 ms]


// With pre-allocation
join/join               time:   [323.86 µs 324.37 µs 325.07 µs]
                        change: [−83.121% −82.664% −82.187%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
