### PR TITLE
refactor: render chunk imports for format esm

### DIFF
--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -166,7 +166,7 @@ fn render_cjs_chunk_imports(ctx: &GenerateContext<'_>) -> String {
     if let RenderImportStmt::ExternalRenderImportStmt(stmt) = stmt {
       let has_specifiers = match &stmt.specifiers {
         RenderImportDeclarationSpecifier::ImportSpecifier(specifiers) => !specifiers.is_empty(),
-        RenderImportDeclarationSpecifier::ImportStarSpecifier(_) => true,
+        RenderImportDeclarationSpecifier::ImportStarSpecifier() => true,
       };
 
       let require_path_str = concat_string!("require(\"", &stmt.path, "\")");

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -1,18 +1,12 @@
 use arcstr::ArcStr;
 use itertools::Itertools;
-use rolldown_common::{ChunkKind, ExportsKind, Module, WrapKind};
+use rolldown_common::{ChunkKind, ExportsKind, Module, Specifier, WrapKind};
 use rolldown_sourcemap::SourceJoiner;
 use rolldown_utils::concat_string;
 
 use crate::{
-  ecmascript::ecma_generator::RenderedModuleSources,
-  types::generator::GenerateContext,
-  utils::chunk::{
-    collect_render_chunk_imports::{
-      collect_render_chunk_imports, RenderImportDeclarationSpecifier,
-    },
-    render_chunk_exports::render_chunk_exports,
-  },
+  ecmascript::ecma_generator::RenderedModuleSources, types::generator::GenerateContext,
+  utils::chunk::render_chunk_exports::render_chunk_exports,
 };
 
 pub fn render_esm<'code>(
@@ -112,52 +106,97 @@ pub fn render_esm<'code>(
 }
 
 fn render_esm_chunk_imports(ctx: &GenerateContext<'_>) -> String {
-  let render_import_stmts =
-    collect_render_chunk_imports(ctx.chunk, ctx.link_output, ctx.chunk_graph, &ctx.options.format);
-
   let mut s = String::new();
-  render_import_stmts.iter().for_each(|stmt| {
-    let path = stmt.path();
-    match &stmt.specifiers() {
-      RenderImportDeclarationSpecifier::ImportSpecifier(specifiers) => {
-        if specifiers.is_empty() {
-          s.push_str("import \"");
-          s.push_str(path);
-          s.push_str("\";\n");
+
+  ctx.chunk.imports_from_other_chunks.iter().for_each(|(exporter_id, items)| {
+    let importee_chunk = &ctx.chunk_graph.chunk_table[*exporter_id];
+    let mut default_alias = vec![];
+    let mut specifiers = items
+      .iter()
+      .filter_map(|item| {
+        let canonical_ref = ctx.link_output.symbol_db.canonical_ref_for(item.import_ref);
+        let imported = &ctx.chunk.canonical_names[&canonical_ref];
+        let Specifier::Literal(alias) = item.export_alias.as_ref().unwrap() else {
+          panic!("should not be star import from other chunks")
+        };
+        if alias == imported {
+          Some(alias.as_str().into())
         } else {
-          let mut default_alias = vec![];
-          let specifiers = specifiers
-            .iter()
-            .filter_map(|specifier| {
-              if let Some(alias) = &specifier.alias {
-                if specifier.imported == "default" {
-                  default_alias.push(alias.to_string());
-                  return None;
-                }
-                Some(concat_string!(specifier.imported, " as ", alias))
-              } else {
-                Some(specifier.imported.to_string())
-              }
-            })
-            .collect::<Vec<_>>();
-          s.push_str(&create_import_declaration(specifiers, &default_alias, path));
+          if alias.as_str() == "default" {
+            default_alias.push(imported.as_str().into());
+            return None;
+          }
+          Some(concat_string!(imported, " as ", alias))
         }
-      }
-      RenderImportDeclarationSpecifier::ImportStarSpecifier(alias) => {
-        s.push_str("import * as ");
-        s.push_str(alias);
-        s.push_str(" from \"");
-        s.push_str(path);
-        s.push_str("\";\n");
-      }
+      })
+      .collect::<Vec<_>>();
+    specifiers.sort_unstable();
+
+    s.push_str(&create_import_declaration(
+      specifiers,
+      &default_alias,
+      // TODO: filename relative to importee
+      &ctx.chunk.import_path_for(importee_chunk).into(),
+    ));
+  });
+
+  // render external imports
+  ctx.chunk.imports_from_external_modules.iter().for_each(|(importee_id, named_imports)| {
+    let importee = &ctx.link_output.module_table.modules[*importee_id]
+      .as_external()
+      .expect("Should be external module here");
+
+    let mut has_importee_imported = false;
+    let mut default_alias = vec![];
+    let mut specifiers = named_imports
+      .iter()
+      .filter_map(|item| {
+        let canonical_ref = &ctx.link_output.symbol_db.canonical_ref_for(item.imported_as);
+        if !ctx.link_output.used_symbol_refs.contains(canonical_ref) {
+          return None;
+        };
+        let alias = &ctx.chunk.canonical_names[canonical_ref];
+        match &item.imported {
+          Specifier::Star => {
+            has_importee_imported = true;
+            s.push_str("import * as ");
+            s.push_str(alias);
+            s.push_str(" from \"");
+            s.push_str(&importee.name);
+            s.push_str("\";\n");
+            None
+          }
+          Specifier::Literal(imported) => {
+            if alias == imported {
+              Some(alias.as_str().into())
+            } else {
+              if imported.as_str() == "default" {
+                default_alias.push(alias.as_str().into());
+                return None;
+              }
+              Some(concat_string!(imported, " as ", alias))
+            }
+          }
+        }
+      })
+      .collect::<Vec<_>>();
+    specifiers.sort_unstable();
+    default_alias.sort_unstable();
+
+    if !specifiers.is_empty()
+      || !default_alias.is_empty()
+      || (importee.side_effects.has_side_effects() && !has_importee_imported)
+    {
+      s.push_str(&create_import_declaration(specifiers, &default_alias, &importee.name));
     }
   });
+
   s
 }
 
 fn create_import_declaration(
   mut specifiers: Vec<String>,
-  default_alias: &[String],
+  default_alias: &[ArcStr],
   path: &ArcStr,
 ) -> String {
   let mut ret = String::new();
@@ -184,6 +223,10 @@ fn create_import_declaration(
     ret.push_str("import ");
     ret.push_str(first_default_alias);
     ret.push_str(" from \"");
+    ret.push_str(path);
+    ret.push_str("\";\n");
+  } else {
+    ret.push_str("import \"");
     ret.push_str(path);
     ret.push_str("\";\n");
   }

--- a/crates/rolldown/src/ecmascript/format/utils/mod.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/mod.rs
@@ -38,7 +38,7 @@ pub fn render_chunk_external_imports(
 
         let need_to_esm_wrapper = match &external_stmt.specifiers {
           RenderImportDeclarationSpecifier::ImportSpecifier(specifiers) => !specifiers.is_empty(),
-          RenderImportDeclarationSpecifier::ImportStarSpecifier(_) => true,
+          RenderImportDeclarationSpecifier::ImportStarSpecifier() => true,
         };
         if need_to_esm_wrapper {
           let to_esm_fn_name = &ctx.chunk.canonical_names[&ctx


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->



Consider the external imports is different at different format, Here separate it to avoid over-abstraction, i will remove `collect_render_chunk_imports` usage.
# Esm 
- The import star decl need to generate 
- The import named decl need to generate
# Other format
only have generate one stmt, like `const external = require('external')`