### PR TITLE
refactor(rust): derive `Clone` on `BundlerOptions`

### DIFF
--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -57,7 +57,7 @@ pub fn render_cjs<'code>(
         // Only `named` export can we render the namespace markers.
         if matches!(&export_mode, OutputExports::Named) {
           if let Some(marker) =
-            render_namespace_markers(&ctx.options.es_module, has_default_export, false)
+            render_namespace_markers(ctx.options.es_module, has_default_export, false)
           {
             source_joiner.append_source(marker.to_string());
           }
@@ -143,7 +143,7 @@ pub fn render_cjs<'code>(
 // Make sure the imports generate stmts keep live bindings.
 fn render_cjs_chunk_imports(ctx: &GenerateContext<'_>) -> String {
   let render_import_stmts =
-    collect_render_chunk_imports(ctx.chunk, ctx.link_output, ctx.chunk_graph, &ctx.options.format);
+    collect_render_chunk_imports(ctx.chunk, ctx.link_output, ctx.chunk_graph, ctx.options.format);
 
   let mut s = String::new();
 

--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -86,7 +86,7 @@ pub fn render_iife<'code>(
 
   // Generate the identifier for the IIFE wrapper function.
   // You can refer to the function for more details.
-  let (definition, assignment) = generate_identifier(ctx, &export_mode)?;
+  let (definition, assignment) = generate_identifier(ctx, export_mode)?;
 
   let exports_prefix = if has_exports && named_exports {
     if ctx.options.extend {
@@ -131,8 +131,7 @@ pub fn render_iife<'code>(
   }
 
   if named_exports {
-    if let Some(marker) =
-      render_namespace_markers(&ctx.options.es_module, has_default_export, false)
+    if let Some(marker) = render_namespace_markers(ctx.options.es_module, has_default_export, false)
     {
       source_joiner.append_source(marker);
     }

--- a/crates/rolldown/src/ecmascript/format/umd.rs
+++ b/crates/rolldown/src/ecmascript/format/umd.rs
@@ -95,8 +95,7 @@ pub fn render_umd<'code>(
   }
 
   if named_exports {
-    if let Some(marker) =
-      render_namespace_markers(&ctx.options.es_module, has_default_export, false)
+    if let Some(marker) = render_namespace_markers(ctx.options.es_module, has_default_export, false)
     {
       source_joiner.append_source(marker.to_string());
     }

--- a/crates/rolldown/src/ecmascript/format/utils/mod.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/mod.rs
@@ -27,7 +27,7 @@ pub fn render_chunk_external_imports(
   ctx: &GenerateContext<'_>,
 ) -> (String, Vec<ExternalRenderImportStmt>) {
   let render_import_stmts =
-    collect_render_chunk_imports(ctx.chunk, ctx.link_output, ctx.chunk_graph, &ctx.options.format);
+    collect_render_chunk_imports(ctx.chunk, ctx.link_output, ctx.chunk_graph, ctx.options.format);
 
   let mut import_code = String::new();
   let externals = render_import_stmts

--- a/crates/rolldown/src/ecmascript/format/utils/namespace.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/namespace.rs
@@ -65,7 +65,7 @@ pub fn generate_namespace_definition(
 /// As for the namespaced name (including `.`), please refer to the `generate_namespace_definition` function.
 pub fn generate_identifier(
   ctx: &mut GenerateContext<'_>,
-  export_mode: &OutputExports,
+  export_mode: OutputExports,
 ) -> BuildResult<(String, String)> {
   // Handle the diagnostic warning
   if ctx.options.name.as_ref().map_or(true, String::is_empty)

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -78,7 +78,7 @@ impl<'a> GenerateStage<'a> {
       deconflict_chunk_symbols(
         chunk,
         self.link_output,
-        &self.options.format,
+        self.options.format,
         &index_chunk_id_to_name,
       );
     });

--- a/crates/rolldown/src/utils/chunk/collect_render_chunk_imports.rs
+++ b/crates/rolldown/src/utils/chunk/collect_render_chunk_imports.rs
@@ -32,7 +32,7 @@ pub fn collect_render_chunk_imports(
   chunk: &Chunk,
   graph: &LinkStageOutput,
   _chunk_graph: &ChunkGraph,
-  format: &OutputFormat,
+  format: OutputFormat,
 ) -> Vec<RenderImportStmt> {
   let mut render_import_stmts = vec![];
 

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashMap;
 pub fn deconflict_chunk_symbols(
   chunk: &mut Chunk,
   link_output: &LinkStageOutput,
-  format: &OutputFormat,
+  format: OutputFormat,
   index_chunk_id_to_name: &FxHashMap<ChunkIdx, ArcStr>,
 ) {
   let mut renamer =

--- a/crates/rolldown/src/utils/chunk/namespace_marker.rs
+++ b/crates/rolldown/src/utils/chunk/namespace_marker.rs
@@ -2,7 +2,7 @@ use rolldown_common::EsModuleFlag;
 
 /// Combine the `es_module_flag` and whether it has a default export to determine if there need
 /// to have a namespace marker in the output.
-pub fn determine_es_module(es_module_flag: &EsModuleFlag, has_default_export: bool) -> bool {
+pub fn determine_es_module(es_module_flag: EsModuleFlag, has_default_export: bool) -> bool {
   match es_module_flag {
     EsModuleFlag::Always => true,
     EsModuleFlag::IfDefaultProp if has_default_export => true,
@@ -15,7 +15,7 @@ pub fn determine_es_module(es_module_flag: &EsModuleFlag, has_default_export: bo
 /// Since rolldown doesn't support `generatedCode.symbol` yet,
 /// it's not possible to use `Symbol.toStringTag` in the output.
 pub fn render_namespace_markers(
-  es_module_flag: &EsModuleFlag,
+  es_module_flag: EsModuleFlag,
   has_default_export: bool,
   // TODO namespace_to_string_tag
   namespace_to_string_tag: bool,

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -38,7 +38,7 @@ pub struct Renamer<'name> {
 }
 
 impl<'name> Renamer<'name> {
-  pub fn new(symbols: &'name SymbolRefDb, _modules_len: usize, format: &OutputFormat) -> Self {
+  pub fn new(symbols: &'name SymbolRefDb, _modules_len: usize, format: OutputFormat) -> Self {
     // Port from https://github.com/rollup/rollup/blob/master/src/Chunk.ts#L1377-L1394.
     let manual_reserved = match format {
       OutputFormat::Esm | OutputFormat::App => vec![],

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -33,7 +33,7 @@ fn normalize_addon_option(
   addon_option: Option<crate::options::AddonOutputOption>,
 ) -> Option<AddonOutputOption> {
   addon_option.map(move |value| {
-    AddonOutputOption::Fn(Box::new(move |chunk| {
+    AddonOutputOption::Fn(Arc::new(move |chunk| {
       let fn_js = Arc::clone(&value);
       let chunk = chunk.clone();
       Box::pin(async move {
@@ -49,7 +49,7 @@ fn normalize_chunk_file_names_option(
   option
     .map(move |value| match value {
       Either::A(str) => Ok(ChunkFilenamesOutputOption::String(str)),
-      Either::B(func) => Ok(ChunkFilenamesOutputOption::Fn(Box::new(move |chunk| {
+      Either::B(func) => Ok(ChunkFilenamesOutputOption::Fn(Arc::new(move |chunk| {
         let func = Arc::clone(&func);
         let chunk = chunk.clone();
         Box::pin(async move { func.invoke_async(chunk.into()).await.map_err(anyhow::Error::from) })
@@ -85,7 +85,7 @@ pub fn normalize_binding_options(
   });
 
   let sourcemap_ignore_list = output_options.sourcemap_ignore_list.map(|ts_fn| {
-    rolldown::SourceMapIgnoreList::new(Box::new(move |source, sourcemap_path| {
+    rolldown::SourceMapIgnoreList::new(Arc::new(move |source, sourcemap_path| {
       let ts_fn = Arc::clone(&ts_fn);
       let source = source.to_string();
       let sourcemap_path = sourcemap_path.to_string();
@@ -96,7 +96,7 @@ pub fn normalize_binding_options(
   });
 
   let sourcemap_path_transform = output_options.sourcemap_path_transform.map(|ts_fn| {
-    rolldown::SourceMapPathTransform::new(Box::new(move |source, sourcemap_path| {
+    rolldown::SourceMapPathTransform::new(Arc::new(move |source, sourcemap_path| {
       let ts_fn = Arc::clone(&ts_fn);
       let source = source.to_string();
       let sourcemap_path = sourcemap_path.to_string();

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -27,7 +27,7 @@ use crate::{ChunkFilenamesOutputOption, ModuleType, SourceMapIgnoreList};
 
 pub mod types;
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_common/src/inner_bundler_options/types/advanced_chunks_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/advanced_chunks_options.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::{Deserialize, Deserializer};
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),
@@ -16,7 +16,7 @@ pub struct AdvancedChunksOptions {
   pub groups: Option<Vec<MatchGroup>>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_common/src/inner_bundler_options/types/checks_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/checks_options.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::Deserialize;
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_common/src/inner_bundler_options/types/comments.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/comments.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::Deserialize;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_common/src/inner_bundler_options/types/es_module_flag.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/es_module_flag.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 /// > export of this module corresponds to the `.default` property of the exported object.
 /// >
 /// > *From rollupjs.org*
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::Deserialize;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_common/src/inner_bundler_options/types/inject_import.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/inject_import.rs
@@ -26,7 +26,7 @@ use serde::Deserialize;
 /// import object_assign from "es6-object-assign";
 /// console.log(object_assign({ a: 1 }, { b: 2 }));
 ///```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_common/src/inner_bundler_options/types/input_item.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/input_item.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::Deserialize;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "deserialize_bundler_options", derive(Deserialize, JsonSchema))]
 pub struct InputItem {
   pub name: Option<String>,

--- a/crates/rolldown_common/src/inner_bundler_options/types/is_external.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/is_external.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::ops::Deref;
 use std::pin::Pin;
+use std::sync::Arc;
 
 type Inner = dyn Fn(
     &str,         // specifier
@@ -12,7 +13,8 @@ type Inner = dyn Fn(
   + Sync
   + 'static;
 
-pub struct IsExternal(Box<Inner>);
+#[derive(Clone)]
+pub struct IsExternal(Arc<Inner>);
 
 impl Deref for IsExternal {
   type Target = Inner;
@@ -34,7 +36,7 @@ impl IsExternal {
       + Sync
       + 'static,
   {
-    Self(Box::new(f))
+    Self(Arc::new(f))
   }
 
   pub fn from_vec(value: Vec<String>) -> Self {

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_exports.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_exports.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::Deserialize;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use std::fmt::Display;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_option/addon.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_option/addon.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 
 use crate::RollupRenderedChunk;
 
@@ -10,9 +11,10 @@ pub type AddonFunction = dyn Fn(
   + Send
   + Sync;
 
+#[derive(Clone)]
 pub enum AddonOutputOption {
   String(Option<String>),
-  Fn(Box<AddonFunction>),
+  Fn(Arc<AddonFunction>),
 }
 
 impl Debug for AddonOutputOption {

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_option/chunk_filenames.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_option/chunk_filenames.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, future::Future, pin::Pin};
+use std::{fmt::Debug, future::Future, pin::Pin, sync::Arc};
 
 use crate::RollupPreRenderedChunk;
 
@@ -8,9 +8,10 @@ type ChunkFilenamesFunction = dyn Fn(
   + Send
   + Sync;
 
+#[derive(Clone)]
 pub enum ChunkFilenamesOutputOption {
   String(String),
-  Fn(Box<ChunkFilenamesFunction>),
+  Fn(Arc<ChunkFilenamesFunction>),
 }
 
 impl Debug for ChunkFilenamesOutputOption {

--- a/crates/rolldown_common/src/inner_bundler_options/types/resolve_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/resolve_options.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 /// A simple wrapper around `oxc_resolver::ResolveOptions` to make it easier to use in the `rolldown_resolver` crate.
 /// See [oxc_resolver::ResolveOptions](https://docs.rs/oxc_resolver/latest/oxc_resolver/struct.ResolveOptions.html) for more information.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_common/src/inner_bundler_options/types/source_map_type.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/source_map_type.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::Deserialize;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "deserialize_bundler_options", derive(Deserialize, JsonSchema))]
 pub enum SourceMapType {
   File,

--- a/crates/rolldown_common/src/inner_bundler_options/types/sourcemap_ignore_list.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/sourcemap_ignore_list.rs
@@ -1,11 +1,13 @@
 use std::fmt::Debug;
+use std::sync::Arc;
 use std::{future::Future, pin::Pin};
 
 pub type SourceMapIgnoreListFn = dyn Fn(&str, &str) -> Pin<Box<(dyn Future<Output = anyhow::Result<bool>> + Send + 'static)>>
   + Send
   + Sync;
 
-pub struct SourceMapIgnoreList(Box<SourceMapIgnoreListFn>);
+#[derive(Clone)]
+pub struct SourceMapIgnoreList(Arc<SourceMapIgnoreListFn>);
 
 impl Debug for SourceMapIgnoreList {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -14,7 +16,7 @@ impl Debug for SourceMapIgnoreList {
 }
 
 impl SourceMapIgnoreList {
-  pub fn new(f: Box<SourceMapIgnoreListFn>) -> Self {
+  pub fn new(f: Arc<SourceMapIgnoreListFn>) -> Self {
     Self(f)
   }
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/sourcemap_path_transform.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/sourcemap_path_transform.rs
@@ -1,11 +1,13 @@
 use std::fmt::Debug;
+use std::sync::Arc;
 use std::{future::Future, pin::Pin};
 
 type SourceMapPathTransformFn = dyn Fn(&str, &str) -> Pin<Box<(dyn Future<Output = anyhow::Result<String>> + Send + 'static)>>
   + Send
   + Sync;
 
-pub struct SourceMapPathTransform(Box<SourceMapPathTransformFn>);
+#[derive(Clone)]
+pub struct SourceMapPathTransform(Arc<SourceMapPathTransformFn>);
 
 impl Debug for SourceMapPathTransform {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -14,7 +16,7 @@ impl Debug for SourceMapPathTransform {
 }
 
 impl SourceMapPathTransform {
-  pub fn new(f: Box<SourceMapPathTransformFn>) -> Self {
+  pub fn new(f: Arc<SourceMapPathTransformFn>) -> Self {
     Self(f)
   }
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::{Deserialize, Deserializer};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),
@@ -22,13 +22,13 @@ impl Default for TreeshakeOptions {
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ModuleSideEffects {
   ModuleSideEffectsRules(Vec<ModuleSideEffectsRule>),
   Boolean(bool),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ModuleSideEffectsRule {
   pub test: Option<HybridRegex>,
   pub external: Option<bool>,
@@ -75,7 +75,7 @@ impl TreeshakeOptions {
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_common/src/inner_bundler_options/types/watch_option.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/watch_option.rs
@@ -6,7 +6,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::{Deserialize, Deserializer};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),
@@ -40,7 +40,7 @@ where
   Ok(deserialized.map(|v| v.into_iter().map(StringOrRegex::String).collect::<Vec<_>>()))
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
   derive(Deserialize, JsonSchema),

--- a/crates/rolldown_utils/src/js_regex.rs
+++ b/crates/rolldown_utils/src/js_regex.rs
@@ -5,7 +5,7 @@ use crate::concat_string;
 /// According to the doc of `regress`, https://docs.rs/regress/0.10.0/regress/#comparison-to-regex-crate
 /// **regress supports features that regex does not, in particular backreferences and zero-width lookaround assertions.**
 /// these features are not commonly used, so in most cases the slow path will not be reached.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum HybridRegex {
   Optimize(regex::Regex),
   Ecma(regress::Regex),

--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -1,7 +1,7 @@
 use crate::js_regex::HybridRegex;
 use glob_match::glob_match;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum StringOrRegex {
   String(String),
   Regex(HybridRegex),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This is used support the need that is creating different bundler with small differences, such as two bundlers, one for server, one for client.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
