### PR TITLE
refactor(watcher): make WatcherEventData structured

### DIFF
--- a/crates/rolldown/src/watcher/emitter.rs
+++ b/crates/rolldown/src/watcher/emitter.rs
@@ -7,7 +7,9 @@ use rolldown_common::{WatcherEvent, WatcherEventData};
 pub type SharedWatcherEmitter = Arc<WatcherEmitter>;
 
 pub type Listener = Box<
-  dyn Fn(&WatcherEventData) -> Pin<Box<(dyn Future<Output = anyhow::Result<()>> + Send + 'static)>>
+  dyn Fn(
+      Arc<WatcherEventData>,
+    ) -> Pin<Box<(dyn Future<Output = anyhow::Result<()>> + Send + 'static)>>
     + Send
     + Sync,
 >;
@@ -23,15 +25,15 @@ impl WatcherEmitter {
 
   #[allow(clippy::needless_pass_by_value)]
   pub async fn emit(&self, event: WatcherEvent, data: WatcherEventData) -> Result<()> {
+    let data = Arc::new(data);
     if let Some(listeners) = self.listeners.get(&event) {
       for listener in listeners.iter() {
-        listener(&data).await?;
+        listener(Arc::clone(&data)).await?;
       }
     }
     Ok(())
   }
 
-  #[allow(dead_code)]
   pub fn on(&self, event: WatcherEvent, listener: Listener) {
     self.listeners.entry(event).or_default().push(Box::new(listener));
   }

--- a/crates/rolldown/src/watcher/watcher.rs
+++ b/crates/rolldown/src/watcher/watcher.rs
@@ -4,7 +4,7 @@ use notify::{
   event::ModifyKind, Config, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher,
 };
 use rolldown_common::{
-  BundleEndEventData, BundleEventKind, WatcherChange, WatcherChangeKind, WatcherEvent,
+  BundleEndEventData, BundleEventKind, WatcherChangeData, WatcherChangeKind, WatcherEvent,
   WatcherEventData,
 };
 use rolldown_error::{BuildResult, DiagnosticOptions, ResultExt};
@@ -165,7 +165,8 @@ impl Watcher {
             WatcherEvent::Event,
             BundleEventKind::BundleEnd(BundleEndEventData {
               output: bundler.options.cwd.join(&bundler.options.dir).to_string_lossy().to_string(),
-              duration: start_time.elapsed().as_millis().to_string(),
+              #[allow(clippy::cast_possible_truncation)]
+              duration: start_time.elapsed().as_millis() as u32,
             })
             .into(),
           )
@@ -222,7 +223,7 @@ impl Watcher {
 pub async fn on_change(watcher: &Arc<Watcher>, path: &str, kind: WatcherChangeKind) {
   let _ = watcher
     .emitter
-    .emit(WatcherEvent::Change, WatcherChange { path: path.into(), kind }.into())
+    .emit(WatcherEvent::Change, WatcherChangeData { path: path.into(), kind }.into())
     .await
     .map_err(|e| eprintln!("Rolldown internal error: {e:?}"));
   let bundler = watcher.bundler.lock().await;

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -123,7 +123,7 @@ pub use crate::{
   types::symbol_ref::SymbolRef,
   types::symbol_ref_db::{SymbolRefDb, SymbolRefDbForModule, SymbolRefFlags},
   types::watch::{
-    BundleEndEventData, BundleEventKind, WatcherChange, WatcherChangeKind, WatcherEvent,
+    BundleEndEventData, BundleEventKind, WatcherChangeData, WatcherChangeKind, WatcherEvent,
     WatcherEventData,
   },
   types::wrap_kind::WrapKind,

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -8,6 +8,11 @@ export interface RenderedModule {
   renderedLength: number
 }
 
+export declare class BindingBundleEndEventData {
+  output: string
+  duration: number
+}
+
 export declare class BindingCallableBuiltinPlugin {
   name: string
   constructor(plugin: BindingBuiltinPlugin)
@@ -81,8 +86,20 @@ export declare class BindingTransformPluginContext {
 
 export declare class BindingWatcher {
   close(): Promise<void>
-  on(event: BindingWatcherEvent, listener: (data?: Record<string, string>) => void): void
+  on(event: BindingWatcherEvent, listener: (data: BindingWatcherEventData) => void): void
   start(): Promise<void>
+}
+
+export declare class BindingWatcherChangeData {
+  path: string
+  kind: string
+}
+
+export declare class BindingWatcherEventData {
+  watchChangeData(): BindingWatcherChangeData
+  bundleEndData(): BindingBundleEndEventData
+  bundleEventKind(): string
+  error(): string
 }
 
 export declare class Bundler {

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -364,6 +364,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
+module.exports.BindingBundleEndEventData = nativeBinding.BindingBundleEndEventData
 module.exports.BindingCallableBuiltinPlugin = nativeBinding.BindingCallableBuiltinPlugin
 module.exports.BindingLog = nativeBinding.BindingLog
 module.exports.BindingModuleInfo = nativeBinding.BindingModuleInfo
@@ -374,6 +375,8 @@ module.exports.BindingPluginContext = nativeBinding.BindingPluginContext
 module.exports.BindingRenderedModule = nativeBinding.BindingRenderedModule
 module.exports.BindingTransformPluginContext = nativeBinding.BindingTransformPluginContext
 module.exports.BindingWatcher = nativeBinding.BindingWatcher
+module.exports.BindingWatcherChangeData = nativeBinding.BindingWatcherChangeData
+module.exports.BindingWatcherEventData = nativeBinding.BindingWatcherEventData
 module.exports.Bundler = nativeBinding.Bundler
 module.exports.ParallelJsPluginRegistry = nativeBinding.ParallelJsPluginRegistry
 module.exports.BindingBuiltinPluginName = nativeBinding.BindingBuiltinPluginName

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -153,7 +153,12 @@ function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__BindingWatcher_struct_123']?.()
   __napiInstance.exports['__napi_register__BindingWatcher_impl_127']?.()
   __napiInstance.exports['__napi_register__BindingWatcherEvent_128']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherEventData_struct_129']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherEventData_impl_134']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherChangeData_struct_135']?.()
+  __napiInstance.exports['__napi_register__BindingBundleEndEventData_struct_136']?.()
 }
+export const BindingBundleEndEventData = __napiModule.exports.BindingBundleEndEventData
 export const BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
 export const BindingLog = __napiModule.exports.BindingLog
 export const BindingModuleInfo = __napiModule.exports.BindingModuleInfo
@@ -164,6 +169,8 @@ export const BindingPluginContext = __napiModule.exports.BindingPluginContext
 export const BindingRenderedModule = __napiModule.exports.BindingRenderedModule
 export const BindingTransformPluginContext = __napiModule.exports.BindingTransformPluginContext
 export const BindingWatcher = __napiModule.exports.BindingWatcher
+export const BindingWatcherChangeData = __napiModule.exports.BindingWatcherChangeData
+export const BindingWatcherEventData = __napiModule.exports.BindingWatcherEventData
 export const Bundler = __napiModule.exports.Bundler
 export const ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
 export const BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -177,7 +177,12 @@ function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__BindingWatcher_struct_123']?.()
   __napiInstance.exports['__napi_register__BindingWatcher_impl_127']?.()
   __napiInstance.exports['__napi_register__BindingWatcherEvent_128']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherEventData_struct_129']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherEventData_impl_134']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherChangeData_struct_135']?.()
+  __napiInstance.exports['__napi_register__BindingBundleEndEventData_struct_136']?.()
 }
+module.exports.BindingBundleEndEventData = __napiModule.exports.BindingBundleEndEventData
 module.exports.BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
 module.exports.BindingLog = __napiModule.exports.BindingLog
 module.exports.BindingModuleInfo = __napiModule.exports.BindingModuleInfo
@@ -188,6 +193,8 @@ module.exports.BindingPluginContext = __napiModule.exports.BindingPluginContext
 module.exports.BindingRenderedModule = __napiModule.exports.BindingRenderedModule
 module.exports.BindingTransformPluginContext = __napiModule.exports.BindingTransformPluginContext
 module.exports.BindingWatcher = __napiModule.exports.BindingWatcher
+module.exports.BindingWatcherChangeData = __napiModule.exports.BindingWatcherChangeData
+module.exports.BindingWatcherEventData = __napiModule.exports.BindingWatcherEventData
 module.exports.Bundler = __napiModule.exports.Bundler
 module.exports.ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
 module.exports.BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName

--- a/packages/rolldown/src/watcher.ts
+++ b/packages/rolldown/src/watcher.ts
@@ -44,24 +44,26 @@ export class Watcher {
         break
       case 'event':
         this.inner.on(BindingWatcherEvent.Event, async (data) => {
-          switch (data!.code) {
+          const code = data.bundleEventKind()
+          switch (code) {
             case 'BUNDLE_END':
+              const { duration, output } = data.bundleEndData()
               await listener({
                 code: 'BUNDLE_END',
-                duration: Number(data!.duration),
-                output: [data!.output], // rolldown doesn't support arraying configure output
+                duration,
+                output: [output], // rolldown doesn't support arraying configure output
               })
               break
 
             case 'ERROR':
               await listener({
                 code: 'ERROR',
-                error: { message: data!.error },
+                error: { message: data.error() },
               })
               break
 
             default:
-              await listener(data)
+              await listener({ code })
               break
           }
         })
@@ -75,7 +77,8 @@ export class Watcher {
 
       case 'change':
         this.inner.on(BindingWatcherEvent.Change, async (data) => {
-          await listener(data!.id, { event: data!.kind as ChangeEvent })
+          const { path, kind } = data.watchChangeData()
+          await listener(path, { event: kind as ChangeEvent })
         })
         break
       default:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Before using `hashmap<string, string>` has more Inconvenient to express number and more complex sturcture.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
