### PR TITLE
fix(cjs): should generate correct expr for reference cross chunk symbols

### DIFF
--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -103,8 +103,12 @@ pub fn render_cjs<'code>(
       WrapKind::Esm => {
         // init_xxx()
         let wrapper_ref = entry_meta.wrapper_ref.as_ref().unwrap();
-        let wrapper_ref_name =
-          ctx.link_output.symbol_db.canonical_name_for(*wrapper_ref, &ctx.chunk.canonical_names);
+        let wrapper_ref_name = ctx.finalized_string_pattern_for_symbol_ref(
+          *wrapper_ref,
+          ctx.chunk_idx,
+          &ctx.chunk.canonical_names,
+        );
+        ctx.link_output.symbol_db.canonical_name_for(*wrapper_ref, &ctx.chunk.canonical_names);
         source_joiner.append_source(concat_string!(wrapper_ref_name, "();"));
       }
       WrapKind::Cjs => {

--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -1,8 +1,10 @@
 use rolldown_common::{
-  Chunk, ChunkIdx, InstantiatedChunk, ModuleRenderOutput, NormalizedBundlerOptions,
+  Chunk, ChunkIdx, InstantiatedChunk, ModuleRenderOutput, NormalizedBundlerOptions, SymbolRef,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_plugin::SharedPluginDriver;
+use rolldown_rstr::Rstr;
+use rustc_hash::FxHashMap;
 
 use crate::{chunk_graph::ChunkGraph, stages::link_stage::LinkStageOutput};
 
@@ -15,6 +17,60 @@ pub struct GenerateContext<'a> {
   pub plugin_driver: &'a SharedPluginDriver,
   pub warnings: Vec<BuildDiagnostic>,
   pub module_id_to_codegen_ret: Vec<Option<ModuleRenderOutput>>,
+}
+
+impl<'a> GenerateContext<'a> {
+  /// A `SymbolRef` might be identifier or a property access. This function will return correct string pattern for the symbol.
+  pub fn finalized_string_pattern_for_symbol_ref(
+    &self,
+    symbol_ref: SymbolRef,
+    cur_chunk_idx: ChunkIdx,
+    canonical_names: &FxHashMap<SymbolRef, Rstr>,
+  ) -> String {
+    let symbol_db = &self.link_output.symbol_db;
+    // let belong_to_chunk_idx =
+    // if !symbol_ref.is_declared_in_root_scope(self.ctx.symbol_db) {
+    //   // No fancy things on none root scope symbols
+    //   return self.snippet.id_ref_expr(self.canonical_name_for(symbol_ref), SPAN);
+    // }
+    let canonical_ref = symbol_db.canonical_ref_for(symbol_ref);
+    let canonical_symbol = symbol_db.get(canonical_ref);
+    let namespace_alias = &canonical_symbol.namespace_alias;
+    if let Some(_ns_alias) = namespace_alias {
+      // canonical_ref = ns_alias.namespace_ref;
+      // canonical_symbol = symbol_db.get(canonical_ref);
+      // Not sure if we need to handle this case
+      unreachable!("You run into a bug, please report it");
+    }
+
+    match self.options.format {
+      rolldown_common::OutputFormat::Cjs => {
+        let chunk_idx_of_canonical_symbol = canonical_symbol.chunk_id.unwrap_or_else(|| {
+          // Scoped symbols don't get assigned a `ChunkId`. There are skipped for performance reason, because they are surely
+          // belong to the chunk they are declared in and won't link to other chunks.
+          let symbol_name = canonical_ref.name(symbol_db);
+          panic!("{canonical_ref:?} {symbol_name:?} is not in any chunk, which isn't unexpected");
+        });
+
+        let is_symbol_in_other_chunk = cur_chunk_idx != chunk_idx_of_canonical_symbol;
+        if is_symbol_in_other_chunk {
+          // In cjs output, we need convert the `import { foo } from 'foo'; console.log(foo);`;
+          // If `foo` is split into another chunk, we need to convert the code `console.log(foo);` to `console.log(require_xxxx.foo);`
+          // instead of keeping `console.log(foo)` as we did in esm output. The reason here is wee need to keep live binding in cjs output.
+
+          let exported_name = &self.chunk_graph.chunk_table[chunk_idx_of_canonical_symbol]
+            .exports_to_other_chunks[&canonical_ref];
+
+          let require_binding = &self.chunk_graph.chunk_table[cur_chunk_idx]
+            .require_binding_names_for_other_chunks[&chunk_idx_of_canonical_symbol];
+          rolldown_utils::ecmascript::property_access_str(require_binding, exported_name)
+        } else {
+          symbol_db.canonical_name_for(canonical_ref, canonical_names).to_string()
+        }
+      }
+      _ => symbol_db.canonical_name_for(canonical_ref, canonical_names).to_string(),
+    }
+  }
 }
 
 pub struct GenerateOutput {

--- a/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/12/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/12/_config.json
@@ -11,7 +11,5 @@
     {
       "format": "cjs"
     }
-  ],
-  // FIXME(hyf): Wrong in cjs format
-  "expectExecuted": false
+  ]
 }

--- a/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/12/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/12/artifacts.snap
@@ -81,8 +81,8 @@ Variant: (format: Cjs)
 const require_foo = require('./foo2.js');
 
 //#region entry.js
-init_foo();
-const foo = (init_foo(), __toCommonJS(foo_exports));
+require_foo.init_foo();
+const foo = (require_foo.init_foo(), require_foo.__toCommonJS(require_foo.foo_exports));
 input.works = import("./foo.js").then((foo3) => foo.bar === 123 && foo.__esModule === true && require_foo.bar === 123 && void 0 === void 0 && foo3.bar === 123 && foo3.__esModule === void 0);
 
 //#endregion
@@ -93,7 +93,7 @@ input.works = import("./foo.js").then((foo3) => foo.bar === 123 && foo.__esModul
 "use strict";
 const require_foo = require('./foo2.js');
 
-init_foo();
+require_foo.init_foo();
 exports.bar = require_foo.bar
 ```
 ## foo2.js

--- a/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/13/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/13/_config.json
@@ -11,7 +11,5 @@
     {
       "format": "cjs"
     }
-  ],
-  // FIXME(hyf): Wrong in cjs format
-  "expectExecuted": false
+  ]
 }

--- a/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/13/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/13/artifacts.snap
@@ -53,8 +53,8 @@ Variant: (format: Cjs)
 const require_foo = require('./foo2.js');
 
 //#region entry.js
-init_foo();
-const foo = (init_foo(), __toCommonJS(foo_exports));
+require_foo.init_foo();
+const foo = (require_foo.init_foo(), require_foo.__toCommonJS(require_foo.foo_exports));
 input.works = import("./foo.js").then((foo3) => foo.bar === 123 && require_foo.bar === 123 && foo3.bar === 123 && foo[Math.random() < 1 && "__esModule"] === true && require_foo.foo_exports[Math.random() < 1 && "__esModule"] === void 0 && foo3[Math.random() < 1 && "__esModule"] === void 0);
 
 //#endregion
@@ -65,7 +65,7 @@ input.works = import("./foo.js").then((foo3) => foo.bar === 123 && require_foo.b
 "use strict";
 const require_foo = require('./foo2.js');
 
-init_foo();
+require_foo.init_foo();
 exports.bar = require_foo.bar
 ```
 ## foo2.js

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
@@ -63,7 +63,9 @@ init_foo();
 (2:10-0:0) "" --> (25:7-26:0) " 1;"
 (0:0-8:1) "import assert from \"node:assert\";\n\nconst a = 1;\n\nexport default function foo(a$1) {\n  assert.equal(a$1, a$1)\n  assert.equal(a, 1)\n}\n" --> (26:0-30:0) "\n} });\n\n//#endregion\n//#region bar.js"
 - ../bar.js
-(0:0-2:15) "import foo from './foo'\n\nexport default" --> (30:0-31:18) "\ninit_foo();\nvar bar_default ="
+(0:0-0:23) "import foo from './foo'" --> (30:0-30:10) "\ninit_foo("
+(0:23-0:0) "import foo from './foo'" --> (30:10-31:0) ");"
+(0:0-2:15) "import foo from './foo'\n\nexport default" --> (31:0-31:18) "\nvar bar_default ="
 (2:15-2:17) " {" --> (31:18-31:20) " {"
 (2:17-2:22) " foo " --> (31:20-31:31) " foo: foo$1"
 (2:22-2:23) "}" --> (31:31-35:0) " };\n\n//#endregion\n//#region main.js"

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
@@ -57,7 +57,9 @@ init_foo();
 (0:10-0:0) "const a = " --> (24:7-25:0) " 1;"
 (0:0-4:2) "const a = 1;\n\nexport function foo(a$1) {\n    console.log(a$1, a)\n}" --> (25:0-29:0) "\n} });\n\n//#endregion\n//#region bar.js"
 - ../bar.js
-(0:0-2:15) "import { foo } from './foo'\n\nexport default" --> (29:0-30:18) "\ninit_foo();\nvar bar_default ="
+(0:0-0:27) "import { foo } from './foo'" --> (29:0-29:10) "\ninit_foo("
+(0:27-0:0) "import { foo } from './foo'" --> (29:10-30:0) ");"
+(0:0-2:15) "import { foo } from './foo'\n\nexport default" --> (30:0-30:18) "\nvar bar_default ="
 (2:15-2:17) " {" --> (30:18-30:20) " {"
 (2:17-2:22) " foo " --> (30:20-30:31) " foo: foo$1"
 (2:22-2:23) "}" --> (30:31-34:0) " };\n\n//#endregion\n//#region main.js"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Root cause is that the final pattern of symbol might ends up with a `MemeberExpression` instead of pure identifer.

Seems all places use `SymbolRefDb#canonical_name_for` and `ScopeHoistingFinalizer#canonical_name_for` need to refactored.

@underfin cc

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
