### PR TITLE
feat: use `BuildResult` for `validate_options_for_multi_chunk_output`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -113,8 +113,7 @@ impl<'a> GenerateStage<'a> {
       && chunk_graph.chunk_table.len() > 1
     {
       self.link_output.errors.push(BuildDiagnostic::invalid_option(
-        InvalidOptionTypes::UnsupportedCodeSplittingFormat,
-        self.options.format.to_string(),
+        InvalidOptionTypes::UnsupportedCodeSplittingFormat(self.options.format.to_string()),
       ));
     }
 

--- a/crates/rolldown/src/utils/chunk/validate_options_for_multi_chunk_output.rs
+++ b/crates/rolldown/src/utils/chunk/validate_options_for_multi_chunk_output.rs
@@ -1,15 +1,10 @@
 use rolldown_common::NormalizedBundlerOptions;
+use rolldown_error::{BuildDiagnostic, BuildResult, InvalidOptionTypes};
 
 pub fn validate_options_for_multi_chunk_output(
   options: &NormalizedBundlerOptions,
-) -> anyhow::Result<()> {
-  // TODO: use `BuildResult`
-
-  if options.file.is_some() {
-    return Err(anyhow::format_err!(
-      r#"When building multiple chunks, the `dir` option must be used, not `file`. To inline dynamic imports, set the `inlineDynamicImports` option"#
-    ));
-  }
-
-  Ok(())
+) -> BuildResult<()> {
+  options.file.as_ref().map_or(Ok(()), |_| {
+    Err(BuildDiagnostic::invalid_option(InvalidOptionTypes::InvalidOutputFile).into())
+  })
 }

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/invalid-output-file/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/invalid-output-file/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "file": "dist.js",
+    "name": "wrap"
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/invalid-output-file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/invalid-output-file/artifacts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Errors
+
+## INVALID_OPTION
+
+```text
+[INVALID_OPTION] Error: Invalid value for option "output.file" - when building multiple chunks, the "output.dir" option must be used, not "output.file". To inline dynamic imports, set the "inlineDynamicImports" option.
+
+```

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/invalid-output-file/lib.js
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/invalid-output-file/lib.js
@@ -1,0 +1,1 @@
+export default 2;

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/invalid-output-file/main.js
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/invalid-output-file/main.js
@@ -1,0 +1,1 @@
+import('./lib.js').then(console.log)

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/unsupported_code_splitting_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/unsupported_code_splitting_format/artifacts.snap
@@ -7,6 +7,6 @@ snapshot_kind: text
 ## INVALID_OPTION
 
 ```text
-[INVALID_OPTION] Error: Invalid value "iife" for option "format". UMD and IIFE are not supported for code splitting. You may set `output.inlineDynamicImports` to `true` when using dynamic imports.
+[INVALID_OPTION] Error: Invalid value "iife" for option "output.format" - UMD and IIFE are not supported for code splitting. You may set `output.inlineDynamicImports` to `true` when using dynamic imports.
 
 ```

--- a/crates/rolldown_error/src/build_error/error_constructors.rs
+++ b/crates/rolldown_error/src/build_error/error_constructors.rs
@@ -241,8 +241,8 @@ impl BuildDiagnostic {
     Self::new_inner(ForbidConstAssign { filename, source, name, reference_span, re_assign_span })
   }
 
-  pub fn invalid_option(situation: InvalidOptionTypes, option: String) -> Self {
-    Self::new_inner(InvalidOption { invalid_option_types: situation, option })
+  pub fn invalid_option(situation: InvalidOptionTypes) -> Self {
+    Self::new_inner(InvalidOption { invalid_option_types: situation })
   }
 
   #[cfg(feature = "napi")]

--- a/crates/rolldown_error/src/events/invalid_option.rs
+++ b/crates/rolldown_error/src/events/invalid_option.rs
@@ -3,13 +3,13 @@ use crate::{DiagnosticOptions, EventKind};
 
 #[derive(Debug)]
 pub enum InvalidOptionTypes {
-  UnsupportedCodeSplittingFormat,
+  UnsupportedCodeSplittingFormat(String),
+  InvalidOutputFile,
 }
 
 #[derive(Debug)]
 pub struct InvalidOption {
   pub invalid_option_types: InvalidOptionTypes,
-  pub option: String,
 }
 
 impl BuildEvent for InvalidOption {
@@ -19,9 +19,10 @@ impl BuildEvent for InvalidOption {
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {
     match &self.invalid_option_types {
-      InvalidOptionTypes::UnsupportedCodeSplittingFormat => {
-        format!("Invalid value \"{}\" for option \"format\". UMD and IIFE are not supported for code splitting. You may set `output.inlineDynamicImports` to `true` when using dynamic imports.", self.option)
+      InvalidOptionTypes::UnsupportedCodeSplittingFormat(format) => {
+        format!("Invalid value \"{format}\" for option \"output.format\" - UMD and IIFE are not supported for code splitting. You may set `output.inlineDynamicImports` to `true` when using dynamic imports.")
       }
+      InvalidOptionTypes::InvalidOutputFile => "Invalid value for option \"output.file\" - when building multiple chunks, the \"output.dir\" option must be used, not \"output.file\". To inline dynamic imports, set the \"inlineDynamicImports\" option.".to_string(),
     }
   }
 }


### PR DESCRIPTION
### Description

Related to #2565

https://github.com/rolldown/rolldown/blob/d796b1efa9bd973b60e012ff5bccdb05ee157593/crates/rolldown/src/utils/chunk/validate_options_for_multi_chunk_output.rs#L3-L6