### PR TITLE
refactor: ast scanner `resolve_identifier_reference`

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -657,32 +657,20 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     None
   }
 
-  /// resolve the symbol from the identifier reference, and return if it is a root symbol
-  fn resolve_identifier_to_root_symbol(
+  /// return a `Some(SymbolRef)` if the identifier referenced a top level `IdentBinding`
+  fn resolve_identifier_reference(
     &mut self,
     ident: &IdentifierReference,
-  ) -> Option<SymbolRef> {
-    let symbol_id = self.resolve_symbol_from_reference(ident);
-    match symbol_id {
+  ) -> IdentifierReferenceKind {
+    match self.resolve_symbol_from_reference(ident) {
       Some(symbol_id) => {
         if self.is_root_symbol(symbol_id) {
-          Some((self.idx, symbol_id).into())
+          IdentifierReferenceKind::Root((self.idx, symbol_id).into())
         } else {
-          None
+          IdentifierReferenceKind::Other
         }
       }
-      None => {
-        // atom cmp is not `O(1)`, so if the module already contains both `module` and `exports`,
-        // don't need to check it again.
-        if !self.ast_usage.contains(EcmaModuleAstUsage::ModuleOrExports) {
-          match ident.name.as_str() {
-            "module" => self.ast_usage.insert(EcmaModuleAstUsage::ModuleRef),
-            "exports" => self.ast_usage.insert(EcmaModuleAstUsage::ExportsRef),
-            _ => {}
-          }
-        }
-        None
-      }
+      None => IdentifierReferenceKind::Global,
     }
   }
 
@@ -708,5 +696,25 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   pub fn is_global_identifier_reference(&self, ident: &IdentifierReference) -> bool {
     let symbol_id = self.resolve_symbol_from_reference(ident);
     symbol_id.is_none()
+  }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum IdentifierReferenceKind {
+  /// global variable
+  Global,
+  /// top level variable
+  Root(SymbolRef),
+  /// rest
+  Other,
+}
+
+impl IdentifierReferenceKind {
+  /// Returns `true` if the identifier reference kind is [`Global`].
+  ///
+  /// [`Global`]: IdentifierReferenceKind::Global
+  #[must_use]
+  pub fn is_global(&self) -> bool {
+    matches!(self, Self::Global)
   }
 }

--- a/crates/rolldown/tests/esbuild/default/direct_eval_tainting_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/direct_eval_tainting_no_bundle/artifacts.snap
@@ -1,20 +1,9 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # warnings
 
-## EVAL
-
-```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
-    ╭─[entry.js:25:2]
-    │
- 25 │     eval('add(1, 2)')
-    │     ──┬─  
-    │       ╰─── Use `eval` function here.
-────╯
-
-```
 ## EVAL
 
 ```text


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Before many sub visitor analyze code in a top down way, e.g.
https://github.com/rolldown/rolldown/blob/2f7cbff55e3be3da26f383215417174e84d2a936/crates/rolldown/src/ast_scanner/impl_visit.rs#L178-L191, 
```
VisitCallExpr -> it.callee -> identifierRefer, 
VIsitIdentifierReference -> some logic
```
A top down way may visit the same node multiple time.

in this pr, try to convert some visitors a top down way to a bottom up way and reduce duplicated visit
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
