### PR TITLE
docs: update bluesky link

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -131,7 +131,7 @@ export default defineConfig({
       { icon: 'x', link: 'https://twitter.com/rolldown_rs' },
       {
         icon: 'bluesky',
-        link: 'https://bsky.app/profile/rolldown.bsky.social',
+        link: 'https://bsky.app/profile/rolldown.rs',
       },
       { icon: 'discord', link: 'https://chat.rolldown.rs' },
       { icon: 'github', link: 'https://github.com/rolldown/rolldown' },


### PR DESCRIPTION
### Description

Bluesky link on https://rolldown.rs/ points towards old handle. This PR solves this by updating the URL to https://bsky.app/profile/rolldown.rs.
