### PR TITLE
chore: make watcher test stable

### DIFF
--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -54,6 +54,7 @@ import { ExistingRawSourceMap, SourceMapInput } from './types/sourcemap'
 import { OutputBundle } from './types/output-bundle'
 import { version } from '../package.json'
 import { WatchOptions } from './options/watch-option'
+import { Watcher } from './watcher'
 
 export { defineConfig, rolldown, watch }
 export const VERSION: string = version
@@ -105,6 +106,7 @@ export type {
   OutputBundle,
   JsxOptions,
   WatchOptions,
+  Watcher,
 }
 
 // Exports for compatibility


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Here using retry sometimes to make the test stable. The `perf)watching same file multiply times` is removed, because it is meaningless at here, i will add benchmark to instead of it at next.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
