### PR TITLE
ci: don't publish every commit of main branch to `pkg.pr.new`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,16 +157,3 @@ jobs:
 
       - name: Lint Toml
         run: pnpm lint-toml
-
-  pkg-preview:
-    name: Pkg Preview
-    needs:
-      - cargo-deny
-      - rust-validation
-      - cargo-test
-      - node-test
-      - wasi-test
-      - node-validation
-      - repo-validation
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    uses: ./.github/workflows/preview-commit.yml

--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -1,5 +1,5 @@
 # https://github.com/stackblitz-labs/pkg.pr.new
-name: Preview Commit
+name: Publish to pkg.pr.new
 
 on:
   workflow_call:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Preview could be triggered manually. https://github.com/rolldown/rolldown/actions
- Trigged on every main branch commit is a waste.
  - I believe github has a limit on repo which could run how many jobs in the same time, this slow down the whole CI of the repo.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
