### PR TITLE
ci: only do cache warmup on main branch's latest commit

### DIFF
--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - main
 
+# Only do cache warmup on main branch's latest commit
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.ref_name != 'main' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   debug-build:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If a new commit merge in the main branch, it's meaningless to do cache warmup on old commits.

This PR cancel unfinished CI if new commit is showed to prevent wasting CI machine.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
