### PR TITLE
feat: support function for `output.globals`

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -130,23 +130,23 @@ impl Generator for EcmaGenerator {
     let source_joiner = match ctx.options.format {
       OutputFormat::Esm => render_esm(
         ctx,
-        &rendered_module_sources,
+        hashbang,
         banner.as_deref(),
-        footer.as_deref(),
         intro.as_deref(),
         outro.as_deref(),
-        hashbang,
+        footer.as_deref(),
+        &rendered_module_sources,
       ),
       OutputFormat::Cjs => {
         match render_cjs(
-          &mut warnings,
           ctx,
-          &rendered_module_sources,
+          hashbang,
           banner.as_deref(),
-          footer.as_deref(),
           intro.as_deref(),
           outro.as_deref(),
-          hashbang,
+          footer.as_deref(),
+          &rendered_module_sources,
+          &mut warnings,
         ) {
           Ok(source_joiner) => source_joiner,
           Err(errors) => return Ok(Err(errors)),
@@ -154,38 +154,42 @@ impl Generator for EcmaGenerator {
       }
       OutputFormat::App => render_app(
         ctx,
-        &rendered_module_sources,
+        hashbang,
         banner.as_deref(),
-        footer.as_deref(),
         intro.as_deref(),
         outro.as_deref(),
-        hashbang,
+        footer.as_deref(),
+        &rendered_module_sources,
       ),
       OutputFormat::Iife => {
         match render_iife(
-          &mut warnings,
           ctx,
-          &rendered_module_sources,
+          hashbang,
           banner.as_deref(),
-          footer.as_deref(),
           intro.as_deref(),
           outro.as_deref(),
-          hashbang,
-        ) {
+          footer.as_deref(),
+          &rendered_module_sources,
+          &mut warnings,
+        )
+        .await
+        {
           Ok(source_joiner) => source_joiner,
           Err(errors) => return Ok(Err(errors)),
         }
       }
       OutputFormat::Umd => {
         match render_umd(
-          &mut warnings,
           ctx,
-          &rendered_module_sources,
           banner.as_deref(),
-          footer.as_deref(),
           intro.as_deref(),
           outro.as_deref(),
-        ) {
+          footer.as_deref(),
+          &rendered_module_sources,
+          &mut warnings,
+        )
+        .await
+        {
           Ok(source_joiner) => source_joiner,
           Err(errors) => return Ok(Err(errors)),
         }

--- a/crates/rolldown/src/ecmascript/format/app.rs
+++ b/crates/rolldown/src/ecmascript/format/app.rs
@@ -4,12 +4,12 @@ use crate::{ecmascript::ecma_generator::RenderedModuleSources, types::generator:
 
 pub fn render_app<'code>(
   _ctx: &GenerateContext<'_>,
-  module_sources: &'code RenderedModuleSources,
+  hashbang: Option<&'code str>,
   banner: Option<&'code str>,
-  footer: Option<&'code str>,
   intro: Option<&'code str>,
   outro: Option<&'code str>,
-  hashbang: Option<&'code str>,
+  footer: Option<&'code str>,
+  module_sources: &'code RenderedModuleSources,
 ) -> SourceJoiner<'code> {
   let mut source_joiner = SourceJoiner::default();
 

--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -15,14 +15,14 @@ use rolldown_utils::concat_string;
 
 #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 pub fn render_cjs<'code>(
-  warnings: &mut Vec<BuildDiagnostic>,
   ctx: &GenerateContext<'_>,
-  module_sources: &'code RenderedModuleSources,
+  hashbang: Option<&'code str>,
   banner: Option<&'code str>,
-  footer: Option<&'code str>,
   intro: Option<&'code str>,
   outro: Option<&'code str>,
-  hashbang: Option<&'code str>,
+  footer: Option<&'code str>,
+  module_sources: &'code RenderedModuleSources,
+  warnings: &mut Vec<BuildDiagnostic>,
 ) -> BuildResult<SourceJoiner<'code>> {
   let mut source_joiner = SourceJoiner::default();
 

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -11,12 +11,12 @@ use crate::{
 
 pub fn render_esm<'code>(
   ctx: &mut GenerateContext<'_>,
-  module_sources: &'code RenderedModuleSources,
+  hashbang: Option<&'code str>,
   banner: Option<&'code str>,
-  footer: Option<&'code str>,
   intro: Option<&'code str>,
   outro: Option<&'code str>,
-  hashbang: Option<&'code str>,
+  footer: Option<&'code str>,
+  module_sources: &'code RenderedModuleSources,
 ) -> SourceJoiner<'code> {
   let mut source_joiner = SourceJoiner::default();
 

--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -1,6 +1,7 @@
 use oxc::transformer::InjectGlobalVariablesConfig;
 use rolldown_common::{
-  Comments, InjectImport, ModuleType, NormalizedBundlerOptions, OutputFormat, Platform,
+  Comments, GlobalsOutputOption, InjectImport, ModuleType, NormalizedBundlerOptions, OutputFormat,
+  Platform,
 };
 use rolldown_error::{BuildDiagnostic, InvalidOptionType};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -61,8 +62,7 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
 
   loaders.extend(user_defined_loaders);
 
-  let globals: FxHashMap<String, String> =
-    raw_options.globals.map(|globals| globals.into_iter().collect()).unwrap_or_default();
+  let globals = raw_options.globals.unwrap_or(GlobalsOutputOption::FxHashMap(FxHashMap::default()));
 
   let oxc_inject_global_variables_config = InjectGlobalVariablesConfig::new(
     raw_options

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -1,7 +1,8 @@
 mod types;
 
-use crate::types::js_callback::{JsCallback, MaybeAsyncJsCallback};
 use std::collections::HashMap;
+
+use crate::types::js_callback::{JsCallback, MaybeAsyncJsCallback};
 
 use super::super::types::binding_rendered_chunk::RenderedChunk;
 use super::plugin::BindingPluginOrParallelJsPluginPlaceholder;
@@ -14,6 +15,7 @@ use types::binding_advanced_chunks_options::BindingAdvancedChunksOptions;
 
 pub type AddonOutputOption = MaybeAsyncJsCallback<RenderedChunk, Option<String>>;
 pub type ChunkFileNamesOutputOption = Either<String, JsCallback<PreRenderedChunk, String>>;
+pub type GlobalsOutputOption = Either<HashMap<String, String>, JsCallback<String, String>>;
 
 #[napi(object, object_to_js = false)]
 #[derive(Deserialize, Debug)]
@@ -69,7 +71,10 @@ pub struct BindingOutputOptions {
   pub format: Option<String>,
   // freeze: boolean;
   // generatedCode: NormalizedGeneratedCodeOptions;
-  pub globals: Option<HashMap<String, String>>,
+  #[debug(skip)]
+  #[serde(skip_deserializing)]
+  #[napi(ts_type = "Record<string, string> | ((name: string) => string)")]
+  pub globals: Option<GlobalsOutputOption>,
   #[napi(ts_type = "'base64' | 'base36' | 'hex'")]
   pub hash_characters: Option<String>,
   // hoistTransitiveImports: boolean;

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -5,6 +5,7 @@ use types::advanced_chunks_options::AdvancedChunksOptions;
 use types::checks_options::ChecksOptions;
 use types::comments::Comments;
 use types::inject_import::InjectImport;
+use types::output_option::GlobalsOutputOption;
 use types::target::ESTarget;
 use types::watch_option::WatchOption;
 
@@ -76,7 +77,12 @@ pub struct BundlerOptions {
   pub file: Option<String>,
   pub format: Option<OutputFormat>,
   pub exports: Option<OutputExports>,
-  pub globals: Option<HashMap<String, String>>,
+  #[cfg_attr(
+    feature = "deserialize_bundler_options",
+    serde(default, deserialize_with = "deserialize_globals"),
+    schemars(with = "Option<HashMap<String, String>>")
+  )]
+  pub globals: Option<GlobalsOutputOption>,
   pub sourcemap: Option<SourceMapType>,
   pub es_module: Option<EsModuleFlag>,
   pub drop_labels: Option<Vec<String>>,
@@ -179,6 +185,15 @@ where
   D: Deserializer<'de>,
 {
   let deserialized = Option::<String>::deserialize(deserializer)?;
+  Ok(deserialized.map(From::from))
+}
+
+#[cfg(feature = "deserialize_bundler_options")]
+fn deserialize_globals<'de, D>(deserializer: D) -> Result<Option<GlobalsOutputOption>, D::Error>
+where
+  D: Deserializer<'de>,
+{
+  let deserialized = Option::<HashMap<String, String>>::deserialize(deserializer)?;
   Ok(deserialized.map(From::from))
 }
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -21,7 +21,9 @@ use super::{
   source_map_type::SourceMapType, sourcemap_ignore_list::SourceMapIgnoreList,
   sourcemap_path_transform::SourceMapPathTransform,
 };
-use crate::{EsModuleFlag, HashCharacters, InjectImport, InputItem, ModuleType};
+use crate::{
+  EsModuleFlag, GlobalsOutputOption, HashCharacters, InjectImport, InputItem, ModuleType,
+};
 
 #[allow(clippy::struct_excessive_bools)] // Using raw booleans is more clear in this case
 #[derive(Debug)]
@@ -49,7 +51,7 @@ pub struct NormalizedBundlerOptions {
   pub exports: OutputExports,
   pub es_module: EsModuleFlag,
   pub hash_characters: HashCharacters,
-  pub globals: FxHashMap<String, String>,
+  pub globals: GlobalsOutputOption,
   pub sourcemap: Option<SourceMapType>,
   pub banner: Option<AddonOutputOption>,
   pub footer: Option<AddonOutputOption>,

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_option/globals.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_option/globals.rs
@@ -1,0 +1,37 @@
+use std::{collections::HashMap, fmt::Debug, future::Future, pin::Pin, sync::Arc};
+
+use rustc_hash::FxHashMap;
+
+pub type GlobalsFunction = dyn Fn(&str) -> Pin<Box<(dyn Future<Output = anyhow::Result<String>> + Send + 'static)>>
+  + Send
+  + Sync;
+
+#[derive(Clone)]
+pub enum GlobalsOutputOption {
+  FxHashMap(FxHashMap<String, String>),
+  Fn(Arc<GlobalsFunction>),
+}
+
+impl Debug for GlobalsOutputOption {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::FxHashMap(value) => write!(f, "GlobalsOutputOption::FxHashMap({value:?})"),
+      Self::Fn(_) => write!(f, "GlobalsOutputOption::Fn(...)"),
+    }
+  }
+}
+
+impl GlobalsOutputOption {
+  pub async fn call(&self, name: &str) -> Option<String> {
+    match self {
+      Self::FxHashMap(value) => value.get(name).cloned(),
+      Self::Fn(value) => value(name).await.ok(),
+    }
+  }
+}
+
+impl From<HashMap<String, String>> for GlobalsOutputOption {
+  fn from(value: HashMap<String, String>) -> Self {
+    Self::FxHashMap(value.into_iter().collect())
+  }
+}

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_option/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_option/mod.rs
@@ -1,5 +1,7 @@
 mod addon;
 mod chunk_filenames;
+mod globals;
 
 pub use addon::{AddonFunction, AddonOutputOption};
 pub use chunk_filenames::ChunkFilenamesOutputOption;
+pub use globals::GlobalsOutputOption;

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -28,7 +28,9 @@ pub mod bundler_options {
       normalized_bundler_options::{NormalizedBundlerOptions, SharedNormalizedBundlerOptions},
       output_exports::OutputExports,
       output_format::OutputFormat,
-      output_option::{AddonFunction, AddonOutputOption, ChunkFilenamesOutputOption},
+      output_option::{
+        AddonFunction, AddonOutputOption, ChunkFilenamesOutputOption, GlobalsOutputOption,
+      },
       platform::Platform,
       resolve_options::ResolveOptions,
       source_map_type::SourceMapType,

--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -4,8 +4,8 @@ use crate::source::Source;
 
 #[derive(Default)]
 pub struct SourceJoiner<'source> {
-  inner: Vec<Box<dyn Source + 'source>>,
-  prepend_source: Vec<Box<dyn Source + 'source>>,
+  inner: Vec<Box<dyn Source + Send + 'source>>,
+  prepend_source: Vec<Box<dyn Source + Send + 'source>>,
   enable_sourcemap: bool,
   names_len: usize,
   sources_len: usize,
@@ -14,14 +14,14 @@ pub struct SourceJoiner<'source> {
 }
 
 impl<'source> SourceJoiner<'source> {
-  pub fn append_source<T: Source + 'source>(&mut self, source: T) {
+  pub fn append_source<T: Source + Send + 'source>(&mut self, source: T) {
     if let Some(sourcemap) = source.sourcemap() {
       self.accumulate_sourcemap_data_size(sourcemap);
     }
     self.inner.push(Box::new(source));
   }
 
-  pub fn prepend_source(&mut self, source: Box<dyn Source + 'source>) {
+  pub fn prepend_source(&mut self, source: Box<dyn Source + Send + 'source>) {
     if let Some(sourcemap) = source.sourcemap() {
       self.accumulate_sourcemap_data_size(sourcemap);
     }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -366,7 +366,7 @@ export interface BindingOutputOptions {
   externalLiveBindings?: boolean
   footer?: (chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>
   format?: 'es' | 'cjs' | 'iife' | 'umd'
-  globals?: Record<string, string>
+  globals?: Record<string, string> | ((name: string) => string)
   hashCharacters?: 'base64' | 'base36' | 'hex'
   inlineDynamicImports?: boolean
   intro?: (chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -9,6 +9,7 @@ import type {
 import type {
   AddonFunction,
   ChunkFileNamesFunction,
+  GlobalsFunction,
   ModuleFormat,
   OutputCliOptions,
   OutputOptions,
@@ -37,6 +38,11 @@ const chunkFileNamesFunctionSchema = z
   .function()
   .args(zodExt.phantom<PreRenderedChunk>())
   .returns(z.string()) satisfies z.ZodType<ChunkFileNamesFunction>
+
+const GlobalsFunctionSchema = z
+  .function()
+  .args(z.string())
+  .returns(z.string()) satisfies z.ZodType<GlobalsFunction>
 
 const outputOptionsSchema = z.strictObject({
   dir: z
@@ -112,6 +118,7 @@ const outputOptionsSchema = z.strictObject({
   name: z.string().describe('Name for UMD / IIFE format outputs').optional(),
   globals: z
     .record(z.string())
+    .or(GlobalsFunctionSchema)
     .describe(
       'Global variable of UMD / IIFE dependencies (syntax: `key=value`)',
     )
@@ -177,6 +184,12 @@ export const outputCliOptionsSchema = outputOptionsSchema
       .boolean()
       .describe(
         'Always generate `__esModule` marks in non-ESM formats, defaults to `if-default-prop` (use `--no-esModule` to always disable)',
+      )
+      .optional(),
+    globals: z
+      .record(z.string())
+      .describe(
+        'Global variable of UMD / IIFE dependencies (syntax: `key=value`)',
       )
       .optional(),
     advancedChunks: z

--- a/packages/rolldown/src/types/output-options.ts
+++ b/packages/rolldown/src/types/output-options.ts
@@ -18,6 +18,8 @@ export type AddonFunction = (chunk: RenderedChunk) => string | Promise<string>
 
 export type ChunkFileNamesFunction = (chunkInfo: PreRenderedChunk) => string
 
+export type GlobalsFunction = (name: string) => string
+
 export interface OutputOptions {
   dir?: string
   file?: string
@@ -49,7 +51,7 @@ export interface OutputOptions {
   cssChunkFileNames?: string | ChunkFileNamesFunction
   minify?: boolean
   name?: string
-  globals?: Record<string, string>
+  globals?: Record<string, string> | GlobalsFunction
   externalLiveBindings?: boolean
   inlineDynamicImports?: boolean
   advancedChunks?: {
@@ -78,6 +80,7 @@ interface OverwriteOutputOptionsForCli {
   intro?: string
   outro?: string
   esModule?: boolean
+  globals?: Record<string, string>
   advancedChunks?: {
     minSize?: number
     minShareCount?: number

--- a/packages/rolldown/src/utils/normalize-output-options.ts
+++ b/packages/rolldown/src/utils/normalize-output-options.ts
@@ -47,7 +47,6 @@ export function normalizeOutputOptions(
     intro: getAddon(opts, 'intro'),
     outro: getAddon(opts, 'outro'),
     esModule,
-    // TODO support functions
     globals,
     entryFileNames,
     chunkFileNames,

--- a/packages/rolldown/tests/fixtures/output/format/iife/globals-with-function/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/format/iife/globals-with-function/_config.ts
@@ -1,0 +1,57 @@
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    external: /node:path/,
+    output: {
+      format: 'iife',
+      name: 'module',
+      globals: (name: string): string => {
+        if (name === 'node:path') {
+          return 'path'
+        }
+
+        return ''
+      },
+    },
+  },
+  afterTest: (output) => {
+    expect(output.output[0].code).toMatchInlineSnapshot(`
+      "var module = (function(node_path) {
+
+      "use strict";
+      //#region rolldown:runtime
+      var __create = Object.create;
+      var __defProp = Object.defineProperty;
+      var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+      var __getOwnPropNames = Object.getOwnPropertyNames;
+      var __getProtoOf = Object.getPrototypeOf;
+      var __hasOwnProp = Object.prototype.hasOwnProperty;
+      var __copyProps = (to, from, except, desc) => {
+      	if (from && typeof from === "object" || typeof from === "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
+      		key = keys[i];
+      		if (!__hasOwnProp.call(to, key) && key !== except) __defProp(to, key, {
+      			get: ((k) => from[k]).bind(null, key),
+      			enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+      		});
+      	}
+      	return to;
+      };
+      var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
+      	value: mod,
+      	enumerable: true
+      }) : target, mod));
+
+      //#endregion
+      node_path = __toESM(node_path);
+
+      //#region main.js
+      var main_default = node_path.join;
+
+      //#endregion
+      return main_default;
+      })(path);"
+    `)
+  },
+})

--- a/packages/rolldown/tests/fixtures/output/format/iife/globals-with-function/main.js
+++ b/packages/rolldown/tests/fixtures/output/format/iife/globals-with-function/main.js
@@ -1,0 +1,3 @@
+import { join } from 'node:path'
+
+export default join


### PR DESCRIPTION
### Description

closes #1925

Align with [rollup#output-globals](https://rollupjs.org/configuration-options/#output-globals)

https://github.com/rolldown/rolldown/blob/ab438c355063765640db18cb03b8d08fa2eee39d/packages/rolldown/src/utils/normalize-output-options.ts#L46-L47