### PR TITLE
refactor(test): remove support for `_test.cjs`

### DIFF
--- a/crates/rolldown/tests/rolldown/function/format/cjs/import_export_unicode/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/import_export_unicode/_test.mjs
@@ -1,3 +1,4 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const assert = require('assert')
 const { '😈': devil } = require('./dist/main.js')
 

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_shared_entries_cjs/_test.mjs
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_shared_entries_cjs/_test.mjs
@@ -1,3 +1,4 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const { readFile: readFile2 } = require('./dist/entry.js')
 const { readFile: readFile3 } = require('./dist/entry2.js')
 const { readFile } = require('node:fs')

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/_test.mjs
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/_test.mjs
@@ -1,3 +1,4 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const { readFile: readFile2 } = require('./dist/entry.js');
 const { readFile } = require('fs');
 const assert = require('assert');

--- a/crates/rolldown/tests/rolldown/sourcemap/debug_ids/_test.mjs
+++ b/crates/rolldown/tests/rolldown/sourcemap/debug_ids/_test.mjs
@@ -1,3 +1,4 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const fs = require('node:fs');
 const assert = require('node:assert');
 const path = require('node:path');

--- a/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/export_star_from_external/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/export_star_from_external/_test.mjs
@@ -1,9 +1,10 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const fs = require('node:fs');
 const assert = require('node:assert');
 const path = require('node:path');
 const { parse } = require('cjs-module-lexer');
 
-const parsed = parse(fs.readFileSync(path.resolve(__dirname, 'dist/main.js'), 'utf8'));
+const parsed = parse(fs.readFileSync(path.resolve(import.meta.dirname, 'dist/main.js'), 'utf8'));
 parsed.reexports.sort();
 assert.deepStrictEqual(parsed, {
   exports: [],

--- a/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/exports/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/exports/_test.mjs
@@ -1,9 +1,10 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const fs = require('node:fs');
 const assert = require('node:assert');
 const path = require('node:path');
 const { parse } = require('cjs-module-lexer');
 
-const parsed = parse(fs.readFileSync(path.resolve(__dirname, 'dist/main.js'), 'utf8'));
+const parsed = parse(fs.readFileSync(path.resolve(import.meta.dirname, 'dist/main.js'), 'utf8'));
 parsed.exports.sort();
 assert.deepStrictEqual(parsed, {
   exports: [ '__esModule', 'a', 'b', '😈', 'default'].sort(),

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_binding_cjs/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_binding_cjs/_test.mjs
@@ -1,3 +1,4 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const assert = require('node:assert')
 const main = require('./dist/main.js')
 

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_expr_cjs/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_expr_cjs/_test.mjs
@@ -1,7 +1,8 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const assert = require('node:assert')
 const main = require('./dist/main.js')
 
 main.reset()
 assert.strictEqual(main.default, 0)
-inc()
+main.inc()
 assert.strictEqual(main.default, 0)

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_cjs/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_cjs/_test.mjs
@@ -1,3 +1,4 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const assert = require('assert')
 const main = require('./dist/main.js')
 

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/_test.mjs
@@ -1,3 +1,4 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const assert = require('assert')
 const main = require('./dist/main.js')
 

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/.named_export_in_wrapped_and_shared_entries_cjs/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/.named_export_in_wrapped_and_shared_entries_cjs/_test.mjs
@@ -1,8 +1,10 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const assert = require('node:assert');
-const entry = require('./dist/entry.js');
-const entry2 = require('./dist/entry2.js');
-
+const entry = require('./dist/entry.cjs');
+const entry2 = require('./dist/entry2.cjs');
 assert.deepStrictEqual(entry.foo, 'foo');
 assert.deepStrictEqual(entry.foo, entry2.foo);
 assert.deepStrictEqual(entry.default, 'main');
 assert.deepStrictEqual(entry.default, entry2.default);
+
+console.log(import.meta.filename, module.exports)

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_cjs/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_cjs/_test.mjs
@@ -1,3 +1,4 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const assert = require('node:assert');
 const main = require('./dist/main.js');
 

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/_test.mjs
@@ -1,9 +1,9 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const assert = require('node:assert');
-const entry = require('./dist/entry.cjs');
-const entry2 = require('./dist/entry2.cjs');
+const entry = require('./dist/entry.js');
+const entry2 = require('./dist/entry2.js');
+
 assert.deepStrictEqual(entry.foo, 'foo');
 assert.deepStrictEqual(entry.foo, entry2.foo);
 assert.deepStrictEqual(entry.default, 'main');
 assert.deepStrictEqual(entry.default, entry2.default);
-
-console.log(__filename, module.exports)

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/_test.mjs
@@ -1,3 +1,4 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
 const assert = require('node:assert');
 const main = require('./dist/main.js');
 

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -462,16 +462,7 @@ impl IntegrationTest {
       package_json.write_all(serde_json::to_string_pretty(&json).unwrap().as_bytes()).unwrap();
     }
 
-    let mut test_script = cwd.join("_test.mjs");
-
-    let mut is_cjs_test_script = false;
-    if is_output_cjs {
-      let cjs_test_script = cwd.join("_test.cjs");
-      if cjs_test_script.is_dir() {
-        test_script = cjs_test_script;
-        is_cjs_test_script = true;
-      }
-    }
+    let test_script = cwd.join("_test.mjs");
 
     let mut node_command = Command::new("node");
 
@@ -491,12 +482,8 @@ impl IntegrationTest {
         .collect::<Vec<_>>();
 
       compiled_entries.iter().for_each(|entry| {
-        if is_cjs_test_script {
-          node_command.arg("--require");
-        } else {
-          node_command.arg("--import");
-        }
-        if cfg!(target_os = "windows") && !is_cjs_test_script {
+        node_command.arg("--import");
+        if cfg!(target_os = "windows") {
           // Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs.
           node_command.arg(format!("file://{}", entry.to_str().expect("should be valid utf8")));
         } else {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Follow up of https://github.com/rolldown/rolldown/pull/2788.

- `_test.mjs` could be used under any format now.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
