### PR TITLE
refactor(rust/chunk): replace usages related to `Chunk#kind` with more abstract method

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -64,21 +64,15 @@ impl Generator for EcmaGenerator {
       ctx.chunk.pre_rendered_chunk.as_ref().expect("Should have pre-rendered chunk"),
       ctx.chunk_graph,
     );
-    let hashbang = match ctx.chunk.kind {
-      rolldown_common::ChunkKind::EntryPoint { is_user_defined, module, .. } if is_user_defined => {
-        let module = &ctx.link_output.module_table.modules[module];
-        match module {
-          rolldown_common::Module::Normal(normal_module) => {
-            let source = &normal_module.source;
-            normal_module
-              .ecma_view
-              .hashbang_range
-              .map(|range| &source.as_str()[range.start as usize..range.end as usize])
-          }
-          rolldown_common::Module::External(_) => None,
-        }
+    let hashbang = match ctx.chunk.user_defined_entry_module(&ctx.link_output.module_table) {
+      Some(normal_module) => {
+        let source = &normal_module.source;
+        normal_module
+          .ecma_view
+          .hashbang_range
+          .map(|range| &source.as_str()[range.start as usize..range.end as usize])
       }
-      _ => None,
+      None => None,
     };
 
     let banner = {

--- a/crates/rolldown/src/ecmascript/format/umd.rs
+++ b/crates/rolldown/src/ecmascript/format/umd.rs
@@ -44,12 +44,10 @@ pub async fn render_umd<'code>(
   let has_exports = !export_items.is_empty();
   let has_default_export = export_items.iter().any(|(name, _)| name.as_str() == "default");
 
-  let entry_module = match ctx.chunk.kind {
-    ChunkKind::EntryPoint { module, .. } => {
-      &ctx.link_output.module_table.modules[module].as_normal().expect("should be normal module")
-    }
-    ChunkKind::Common => unreachable!("umd should be entry point chunk"),
-  };
+  let entry_module = ctx
+    .chunk
+    .entry_module(&ctx.link_output.module_table)
+    .expect("iife format only have entry chunk");
 
   // We need to transform the `OutputExports::Auto` to suitable `OutputExports`.
   let export_mode = determine_export_mode(warnings, ctx, entry_module, &export_items)?;

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -237,7 +237,7 @@ impl<'a> GenerateStage<'a> {
           });
         });
 
-        if let ChunkKind::EntryPoint { module: entry_id, .. } = &chunk.kind {
+        if let Some(entry_id) = &chunk.entry_module_idx() {
           let entry = &self.link_output.module_table.modules[*entry_id].as_normal().unwrap();
           let entry_meta = &self.link_output.metas[entry.idx];
 

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -27,8 +27,8 @@ pub fn deconflict_chunk_symbols(
         renamer.add_symbol_in_root_scope(external_module.namespace_ref);
       });
 
-    match chunk.kind {
-      ChunkKind::EntryPoint { module, .. } => {
+    match chunk.entry_module_idx() {
+      Some(module) => {
         let entry_module =
           link_output.module_table.modules[module].as_normal().expect("should be normal module");
         link_output.metas[entry_module.idx].star_exports_from_external_modules.iter().for_each(
@@ -41,7 +41,7 @@ pub fn deconflict_chunk_symbols(
           },
         );
       }
-      ChunkKind::Common => {}
+      None => {}
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`Chunk#kind` might get removed/refactored in the future, because it can't represent a entry chunk is both user-defined and async entry.

```js
// main.js

import('./main.js')
```

`main` chunk is both a user-defined and async entry chunk.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
