### PR TITLE
fix: prevent crashes with dynamic imports using variable paths when `inlineDynamicImports` is enabled

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -565,8 +565,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     import_expr: &mut ImportExpression<'ast>,
   ) -> Option<Expression<'ast>> {
     if self.ctx.options.inline_dynamic_imports {
-      let rec_id = self.ctx.module.imports[&import_expr.span];
-      let rec = &self.ctx.module.import_records[rec_id];
+      let rec_id = self.ctx.module.imports.get(&import_expr.span)?;
+      let rec = &self.ctx.module.import_records[*rec_id];
       let importee_id = rec.resolved_module;
       match &self.ctx.modules[importee_id] {
         Module::Normal(importee) => {

--- a/crates/rolldown/tests/rolldown/issues/2833/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/2833/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
+    "inlineDynamicImports": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/2833/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2833/artifacts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Assets
+
+## main.js
+
+```js
+
+//#region main.js
+{
+	const path = "./foo.js";
+	import(path);
+}
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/issues/2833/main.js
+++ b/crates/rolldown/tests/rolldown/issues/2833/main.js
@@ -1,0 +1,4 @@
+{
+  const path = './foo.js';
+  import(path);
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4433,6 +4433,10 @@ snapshot_kind: text
 
 - main-!~{000}~.js => main-DfNBBl1O.js
 
+# tests/rolldown/issues/2833
+
+- main-!~{000}~.js => main-Dr53fwGV.js
+
 # tests/rolldown/issues/376
 
 - main-!~{000}~.js => main-CfuHZZW7.js


### PR DESCRIPTION
### Description

closes #2833 