### PR TITLE
chore(node): move options files to `options` folder

### DIFF
--- a/packages/rolldown/src/cli/arguments/normalize.ts
+++ b/packages/rolldown/src/cli/arguments/normalize.ts
@@ -7,8 +7,8 @@ import { setNestedProperty } from './utils'
 import { CliOptions, cliOptionsSchema } from './schema'
 import { inputCliOptionsSchema } from '../../options/input-options-schema'
 import { outputCliOptionsSchema } from '../../options/output-options-schema'
-import type { InputOptions } from '../../types/input-options'
-import type { OutputOptions } from '../../types/output-options'
+import type { InputOptions } from '../../options/input-options'
+import type { OutputOptions } from '../../options/output-options'
 
 export interface NormalizedCliOptions {
   input: InputOptions

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -9,8 +9,8 @@ import type {
   InputOption,
   ExternalOption,
   JsxOptions,
-} from './types/input-options'
-import type { ModuleFormat, OutputOptions } from './types/output-options'
+} from './options/input-options'
+import type { ModuleFormat, OutputOptions } from './options/output-options'
 import type { RolldownOptions } from './types/rolldown-options'
 import type {
   AsyncPluginHooks,

--- a/packages/rolldown/src/log/logger.ts
+++ b/packages/rolldown/src/log/logger.ts
@@ -17,7 +17,7 @@ import {
 } from './logging'
 import { error, logPluginError } from './logs'
 import { getLogHandler, normalizeLog } from './logHandler'
-import type { InputOptions } from '../types/input-options'
+import type { InputOptions } from '../options/input-options'
 import type { NormalizedInputOptions } from '../options/normalized-input-options'
 import path from 'node:path'
 import { VERSION } from '..'

--- a/packages/rolldown/src/options/input-options-schema.ts
+++ b/packages/rolldown/src/options/input-options-schema.ts
@@ -19,7 +19,7 @@ import type {
   ModuleTypes,
   InputOptions,
   WatchOptions,
-} from '../types/input-options'
+} from '../options/input-options'
 
 const inputOptionSchema = z
   .string()

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -7,7 +7,7 @@ import {
   RollupLogWithString,
 } from '../log/logging'
 import { TreeshakingOptions } from '../treeshake'
-import { NullValue, StringOrRegExp } from './utils'
+import { NullValue, StringOrRegExp } from '../types/utils'
 
 export type InputOption = string | string[] | Record<string, string>
 

--- a/packages/rolldown/src/options/normalized-input-options.ts
+++ b/packages/rolldown/src/options/normalized-input-options.ts
@@ -1,3 +1,3 @@
-import type { InputOptions } from '../types/input-options'
+import type { InputOptions } from '../options/input-options'
 
 export interface NormalizedInputOptions extends InputOptions {}

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -1,4 +1,4 @@
-import type { OutputOptions } from '../types/output-options'
+import type { OutputOptions } from '../options/output-options'
 
 export type InternalModuleFormat = 'es' | 'cjs' | 'iife' | 'umd'
 

--- a/packages/rolldown/src/options/output-options-schema.ts
+++ b/packages/rolldown/src/options/output-options-schema.ts
@@ -13,7 +13,7 @@ import type {
   ModuleFormat,
   OutputCliOptions,
   OutputOptions,
-} from '../types/output-options'
+} from '../options/output-options'
 
 const ModuleFormatSchema = z
   .literal('es')

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -1,4 +1,4 @@
-import type { StringOrRegExp } from './utils'
+import type { StringOrRegExp } from '../types/utils'
 import type { RenderedChunk, PreRenderedChunk } from '../binding'
 import {
   SourcemapIgnoreListOption,

--- a/packages/rolldown/src/options/watch-options.ts
+++ b/packages/rolldown/src/options/watch-options.ts
@@ -1,5 +1,5 @@
-import { InputOptions } from '../types/input-options'
-import { OutputOptions } from '../types/output-options'
+import { InputOptions } from '../options/input-options'
+import { OutputOptions } from '../options/output-options'
 
 export interface WatchOptions extends InputOptions {
   output?: OutputOptions

--- a/packages/rolldown/src/rolldown-build.ts
+++ b/packages/rolldown/src/rolldown-build.ts
@@ -1,8 +1,8 @@
 import { transformToRollupOutput } from './utils/transform-to-rollup-output'
 import { BundlerWithStopWorker, createBundler } from './utils/create-bundler'
 
-import type { InputOptions } from './types/input-options'
-import type { OutputOptions } from './types/output-options'
+import type { InputOptions } from './options/input-options'
+import type { OutputOptions } from './options/output-options'
 import type { RolldownOutput } from './types/rolldown-output'
 import type { HasProperty, TypeAssert } from './types/assert'
 

--- a/packages/rolldown/src/rolldown.ts
+++ b/packages/rolldown/src/rolldown.ts
@@ -1,4 +1,4 @@
-import type { InputOptions } from './types/input-options'
+import type { InputOptions } from './options/input-options'
 import { RolldownBuild } from './rolldown-build'
 import { Watcher } from './watcher'
 import { createBundler } from './utils/create-bundler'

--- a/packages/rolldown/src/types/rolldown-options.ts
+++ b/packages/rolldown/src/types/rolldown-options.ts
@@ -1,5 +1,5 @@
-import type { InputOptions } from '../types/input-options'
-import type { OutputOptions } from '../types/output-options'
+import type { InputOptions } from '../options/input-options'
+import type { OutputOptions } from '../options/output-options'
 
 export interface RolldownOptions extends InputOptions {
   // This is included for compatibility with config files but ignored by `rolldown.rolldown`

--- a/packages/rolldown/src/utils/create-bundler.ts
+++ b/packages/rolldown/src/utils/create-bundler.ts
@@ -6,8 +6,8 @@ import { bindingifyOutputOptions } from './bindingify-output-options'
 import { composeJsPlugins } from './compose-js-plugins'
 import { normalizePluginOption } from './normalize-plugin-option'
 import { initializeParallelPlugins } from './initialize-parallel-plugins'
-import type { InputOptions } from '../types/input-options'
-import type { OutputOptions } from '../types/output-options'
+import type { InputOptions } from '../options/input-options'
+import type { OutputOptions } from '../options/output-options'
 
 export async function createBundler(
   inputOptions: InputOptions,

--- a/packages/rolldown/src/utils/normalize-plugin-option.ts
+++ b/packages/rolldown/src/utils/normalize-plugin-option.ts
@@ -1,6 +1,6 @@
 import { asyncFlatten } from './async-flatten'
 import type { RolldownPlugin } from '../plugin'
-import type { InputOptions } from '../types/input-options'
+import type { InputOptions } from '../options/input-options'
 import type { OutputOptions, OutputPlugin } from '../rollup-types'
 
 export const normalizePluginOption: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Options is quite important concept in bundler, so we have an `options` folder to store related files instead of storing into the general `types` folder.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
