### PR TITLE
feat: use better diagnostic for `ReplaceGlobalDefinesConfig`

### DIFF
--- a/crates/rolldown/tests/rolldown/errors/invalid_define_config/key/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/invalid_define_config/key/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "define": {
+      "6": "undefined",
+      "a.6.b": "undefined",
+      "abc.*": "undefined"
+    }
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/invalid_define_config/key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/invalid_define_config/key/artifacts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Errors
+
+## INVALID_DEFINE_CONFIG
+
+```text
+[INVALID_DEFINE_CONFIG] Error: `6` is not an identifier.
+
+```

--- a/crates/rolldown/tests/rolldown/errors/invalid_define_config/key/main.js
+++ b/crates/rolldown/tests/rolldown/errors/invalid_define_config/key/main.js
@@ -1,0 +1,1 @@
+console.log("hello world")

--- a/crates/rolldown/tests/rolldown/errors/invalid_define_config/value/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/invalid_define_config/value/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "define": {
+      "key": "{ a = 1 }"
+    }
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/invalid_define_config/value/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/invalid_define_config/value/artifacts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Errors
+
+## INVALID_DEFINE_CONFIG
+
+```text
+[INVALID_DEFINE_CONFIG] Error: Invalid assignment in object literal
+
+```

--- a/crates/rolldown/tests/rolldown/errors/invalid_define_config/value/main.js
+++ b/crates/rolldown/tests/rolldown/errors/invalid_define_config/value/main.js
@@ -1,0 +1,1 @@
+console.log("hello world")

--- a/crates/rolldown_error/src/build_error/error_constructors.rs
+++ b/crates/rolldown_error/src/build_error/error_constructors.rs
@@ -11,6 +11,7 @@ use crate::events::assign_to_import::AssignToImport;
 use crate::events::export_undefined_variable::ExportUndefinedVariable;
 use crate::events::illegal_identifier_as_name::IllegalIdentifierAsName;
 use crate::events::import_is_undefined::ImportIsUndefined;
+use crate::events::invalid_define_config::InvalidDefineConfig;
 use crate::events::invalid_option::{InvalidOption, InvalidOptionType};
 use crate::events::json_parse::JsonParse;
 use crate::events::missing_global_name::MissingGlobalName;
@@ -281,6 +282,10 @@ impl BuildDiagnostic {
     let start_offset = line_column_to_byte_offset(source.as_str(), line - 1, column - 1);
     let span = Span::new(start_offset as u32, start_offset as u32);
     Self::new_inner(JsonParse { filename, source, span, message })
+  }
+
+  pub fn invalid_define_config(message: String) -> Self {
+    Self::new_inner(InvalidDefineConfig { message })
   }
 
   pub fn unhandleable_error(err: anyhow::Error) -> Self {

--- a/crates/rolldown_error/src/event_kind.rs
+++ b/crates/rolldown_error/src/event_kind.rs
@@ -35,6 +35,7 @@ pub enum EventKind {
   UnhandleableError,
   AssignToImport,
   JsonParse,
+  InvalidDefineConfig,
 }
 
 impl Display for EventKind {
@@ -72,6 +73,7 @@ impl Display for EventKind {
       EventKind::UnsupportedFeature => write!(f, "UNSUPPORTED_FEATURE"),
       EventKind::AssignToImport => write!(f, "ASSIGN_TO_IMPORT"),
       EventKind::JsonParse => write!(f, "JSON_PARSE"),
+      EventKind::InvalidDefineConfig => write!(f, "INVALID_DEFINE_CONFIG"),
     }
   }
 }

--- a/crates/rolldown_error/src/events/invalid_define_config.rs
+++ b/crates/rolldown_error/src/events/invalid_define_config.rs
@@ -1,0 +1,18 @@
+use crate::{event_kind::EventKind, types::diagnostic_options::DiagnosticOptions};
+
+use super::BuildEvent;
+
+#[derive(Debug)]
+pub struct InvalidDefineConfig {
+  pub message: String,
+}
+
+impl BuildEvent for InvalidDefineConfig {
+  fn kind(&self) -> crate::event_kind::EventKind {
+    EventKind::InvalidDefineConfig
+  }
+
+  fn message(&self, _opts: &DiagnosticOptions) -> String {
+    self.message.clone()
+  }
+}

--- a/crates/rolldown_error/src/events/mod.rs
+++ b/crates/rolldown_error/src/events/mod.rs
@@ -17,6 +17,7 @@ pub mod external_entry;
 pub mod forbid_const_assign;
 pub mod illegal_identifier_as_name;
 pub mod import_is_undefined;
+pub mod invalid_define_config;
 pub mod invalid_export_option;
 pub mod invalid_option;
 pub mod json_parse;


### PR DESCRIPTION
### Description

Related PR https://github.com/oxc-project/oxc/pull/7439

I'm not sure if it's worth adding a `EventKind::InvalidDefineConfig` for `ReplaceGlobalDefinesConfig`.

https://github.com/rolldown/rolldown/blob/52e0d11c4e3b655f4d6e76226b2e70086d41de44/crates/rolldown/src/module_loader/module_loader.rs#L89-L96
