### PR TITLE
test: fix rolldown_sourcemap crate tests

### DIFF
--- a/crates/rolldown_sourcemap/Cargo.toml
+++ b/crates/rolldown_sourcemap/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [lib]
 bench   = false
 doctest = false
-test    = false
 
 [dependencies]
 memchr         = { workspace = true }

--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -103,12 +103,12 @@ fn test_concat_sourcemaps() {
 
   assert_eq!(
     &content,
-    r#"// banner
+    r"// banner
 
 console.log()
 const foo = 1;
 console.log(foo);
-"#
+"
   );
   assert_eq!(
     SourcemapVisualizer::new(&content, &map.unwrap()).into_visualizer_text(),


### PR DESCRIPTION
### Description

It looks like they weren't running and the code was stale with compile error. I removed `test = false` and made it up to date.