### PR TITLE
chore: remove the side effects of `just test`

### DIFF
--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -687,7 +687,7 @@ export interface JsxOptions {
   /**
    * Enable React Fast Refresh .
    *
-   * Conforms to the implementation in {@link https://github.com/facebook/react/tree/main/packages/react-refresh}
+   * Conforms to the implementation in {@link https://github.com/facebook/react/tree/v18.3.1/packages/react-refresh}
    *
    * @default false
    */

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -210,7 +210,7 @@ test.sequential('PluginContext addWatchFile', async () => {
   })
 
   // edit file
-  fs.writeFileSync(foo, 'console.log(2)')
+  fs.writeFileSync(foo, 'console.log(2)\n')
   await waitUtil(() => {
     expect(changeFn).toBeCalled()
   })


### PR DESCRIPTION
### Description

I don't know if you've encountered this issue, but every time I run `just test` locally on `windows` and try to commit, it always causes extra snapshot updates.

![SKM9027MA5`J}4C9Y9IU@36](https://github.com/user-attachments/assets/7015c45e-76c3-4be4-893b-68eb7fcbd46d)
