### PR TITLE
feat(rust): pass `NormalizedOutputOptions` in `renderChunk` hook

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -41,7 +41,7 @@ impl<'a> GenerateStage<'a> {
     let (mut instantiated_chunks, index_chunk_to_assets) =
       self.instantiate_chunks(chunk_graph, &mut errors, &mut warnings).await?;
 
-    render_chunks(self.plugin_driver, &mut instantiated_chunks).await?;
+    render_chunks(self.plugin_driver, &mut instantiated_chunks, self.options).await?;
 
     augment_chunk_hash(self.plugin_driver, &mut instantiated_chunks).await?;
 

--- a/crates/rolldown/src/utils/render_chunks.rs
+++ b/crates/rolldown/src/utils/render_chunks.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use futures::future::try_join_all;
-use rolldown_common::InstantiationKind;
+use rolldown_common::{InstantiationKind, SharedNormalizedBundlerOptions};
 use rolldown_plugin::{HookRenderChunkArgs, SharedPluginDriver};
 use rolldown_sourcemap::collapse_sourcemaps;
 
@@ -10,6 +10,7 @@ use crate::type_alias::IndexInstantiatedChunks;
 pub async fn render_chunks<'a>(
   plugin_driver: &SharedPluginDriver,
   assets: &mut IndexInstantiatedChunks,
+  options: &SharedNormalizedBundlerOptions,
 ) -> Result<()> {
   try_join_all(assets.iter_mut().map(|asset| async move {
     // TODO(hyf0): To be refactor:
@@ -20,6 +21,7 @@ pub async fn render_chunks<'a>(
         .render_chunk(HookRenderChunkArgs {
           code: asset.content.clone().try_into_inner_string()?,
           chunk: &ecma_meta.rendered_chunk,
+          options,
         })
         .await?;
 

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -107,11 +107,11 @@ pub struct BindingPluginOptions {
 
   #[serde(skip_deserializing)]
   #[napi(
-    ts_type = "(ctx: BindingPluginContext, code: string, chunk: RenderedChunk) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>"
+    ts_type = "(ctx: BindingPluginContext, code: string, chunk: RenderedChunk, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>"
   )]
   pub render_chunk: Option<
     MaybeAsyncJsCallback<
-      (BindingPluginContext, String, RenderedChunk),
+      (BindingPluginContext, String, RenderedChunk, BindingNormalizedOptions),
       Option<BindingHookRenderChunkOutput>,
     >,
   >,

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -314,10 +314,15 @@ impl Plugin for JsPlugin {
   ) -> rolldown_plugin::HookRenderChunkReturn {
     if let Some(cb) = &self.render_chunk {
       Ok(
-        cb.await_call((ctx.clone().into(), args.code.to_string(), args.chunk.clone().into()))
-          .await?
-          .map(TryInto::try_into)
-          .transpose()?,
+        cb.await_call((
+          ctx.clone().into(),
+          args.code.to_string(),
+          args.chunk.clone().into(),
+          BindingNormalizedOptions::new(Arc::clone(args.options)),
+        ))
+        .await?
+        .map(TryInto::try_into)
+        .transpose()?,
       )
     } else {
       Ok(None)

--- a/crates/rolldown_plugin/src/types/hook_render_chunk_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_render_chunk_args.rs
@@ -1,7 +1,8 @@
-use rolldown_common::RollupRenderedChunk;
+use rolldown_common::{RollupRenderedChunk, SharedNormalizedBundlerOptions};
 
 #[derive(Debug)]
 pub struct HookRenderChunkArgs<'a> {
+  pub options: &'a SharedNormalizedBundlerOptions,
   pub code: String,
   pub chunk: &'a RollupRenderedChunk,
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -424,7 +424,7 @@ export interface BindingPluginOptions {
   moduleParsedMeta?: BindingPluginHookMeta
   buildEnd?: (ctx: BindingPluginContext, error: Nullable<string>) => MaybePromise<VoidNullable>
   buildEndMeta?: BindingPluginHookMeta
-  renderChunk?: (ctx: BindingPluginContext, code: string, chunk: RenderedChunk) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>
+  renderChunk?: (ctx: BindingPluginContext, code: string, chunk: RenderedChunk, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>
   renderChunkMeta?: BindingPluginHookMeta
   augmentChunkHash?: (ctx: BindingPluginContext, chunk: RenderedChunk) => MaybePromise<void | string>
   augmentChunkHashMeta?: BindingPluginHookMeta

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -55,7 +55,7 @@ export function bindingifyRenderChunk(
   const { handler, meta } = normalizeHook(hook)
 
   return {
-    plugin: async (ctx, code, chunk) => {
+    plugin: async (ctx, code, chunk, opts) => {
       Object.entries(chunk.modules).forEach(([key, module]) => {
         chunk.modules[key] = transformToRenderedModule(module)
       })
@@ -70,8 +70,7 @@ export function bindingifyRenderChunk(
         ),
         code,
         chunk,
-        // TODO(hyf0): pass `BindingNormalizedOptions` in `renderChunk` hook
-        {} as NormalizedOutputOptions,
+        new NormalizedOutputOptionsImpl(opts),
       )
 
       if (ret == null) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This was needed for Vite.

refs #2902, #2906

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
