### PR TITLE
chore(node): export `NormalizedInputOptions` as a type instead of a class

### DIFF
--- a/packages/rolldown/src/options/normalized-input-options.ts
+++ b/packages/rolldown/src/options/normalized-input-options.ts
@@ -1,8 +1,13 @@
 import type { LogHandler } from '../rollup'
 import { BindingNormalizedOptions } from '../binding'
 
+export interface NormalizedInputOptions {
+  shimMissingExports: boolean
+  input: string[] | Record<string, string>
+}
+
 // TODO: I guess we make these getters enumerable so it act more like a plain object
-export class NormalizedInputOptions {
+export class NormalizedInputOptionsImpl implements NormalizedInputOptions {
   inner: BindingNormalizedOptions
   constructor(
     inner: BindingNormalizedOptions,

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -31,7 +31,7 @@ import {
   bindingifyTransformFilter,
 } from './bindingify-hook-filter'
 import type { BindingifyPluginArgs } from './bindingify-plugin'
-import { NormalizedInputOptions } from '../options/normalized-input-options'
+import { NormalizedInputOptionsImpl } from '../options/normalized-input-options'
 
 export function bindingifyBuildStart(
   args: BindingifyPluginArgs,
@@ -52,7 +52,7 @@ export function bindingifyBuildStart(
           args.onLog,
           args.logLevel,
         ),
-        new NormalizedInputOptions(opts, args.onLog),
+        new NormalizedInputOptionsImpl(opts, args.onLog),
       )
     },
     meta: bindingifyPluginHookMeta(meta),

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -13,7 +13,7 @@ import {
 } from './bindingify-plugin-hook-meta'
 import { transformToRenderedModule } from '../utils/transform-rendered-module'
 import type { BindingifyPluginArgs } from './bindingify-plugin'
-import { NormalizedInputOptions } from '../options/normalized-input-options'
+import { NormalizedInputOptionsImpl } from '../options/normalized-input-options'
 import {
   NormalizedOutputOptions,
   NormalizedOutputOptionsImpl,
@@ -39,7 +39,7 @@ export function bindingifyRenderStart(
           args.logLevel,
         ),
         new NormalizedOutputOptionsImpl(opts),
-        new NormalizedInputOptions(opts, args.onLog),
+        new NormalizedInputOptionsImpl(opts, args.onLog),
       )
     },
     meta: bindingifyPluginHookMeta(meta),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Align with rollup, `NormalizedInputOptions` is a type instead of real js value.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
