### PR TITLE
fix: sort NODEJS_PREFIXED_BUILTINS

### DIFF
--- a/crates/rolldown_common/src/ecmascript/node_builtin_modules.rs
+++ b/crates/rolldown_common/src/ecmascript/node_builtin_modules.rs
@@ -4,10 +4,9 @@ use oxc_resolver::NODEJS_BUILTINS;
 const NODEJS_PREFIXED_BUILTINS: &[&str] = &[
   // https://nodejs.org/api/modules.html#built-in-modules-with-mandatory-node-prefix
   "node:sea",
+  "node:sqlite",
   "node:test",
   "node:test/reporters",
-  // https://nodejs.org/api/sqlite.html
-  "node:sqlite",
 ];
 
 /// Using `phf` should be faster, but it would increase the compile time, since this function is


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This should be sorted because we are calling `binary_search` here.
https://github.com/rolldown/rolldown/blob/78749354b8bd65833a2313402f65dc06638d37af/crates/rolldown_common/src/ecmascript/node_builtin_modules.rs#L17

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
