### PR TITLE
feat: give warnings for cycle loading

### DIFF
--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -4,7 +4,8 @@ import type { RollupLog } from '../rollup'
 
 const INVALID_LOG_POSITION = 'INVALID_LOG_POSITION',
   PLUGIN_ERROR = 'PLUGIN_ERROR',
-  INPUT_HOOK_IN_OUTPUT_PLUGIN = 'INPUT_HOOK_IN_OUTPUT_PLUGIN'
+  INPUT_HOOK_IN_OUTPUT_PLUGIN = 'INPUT_HOOK_IN_OUTPUT_PLUGIN',
+  CYCLE_LOADING = 'CYCLE_LOADING'
 
 export function logInvalidLogPosition(pluginName: string): RollupLog {
   return {
@@ -20,6 +21,16 @@ export function logInputHookInOutputPlugin(
   return {
     code: INPUT_HOOK_IN_OUTPUT_PLUGIN,
     message: `The "${hookName}" hook used by the output plugin ${pluginName} is a build time hook and will not be run for that plugin. Either this plugin cannot be used as an output plugin, or it should have an option to configure it as an output plugin.`,
+  }
+}
+
+export function logCycleLoading(
+  pluginName: string,
+  moduleId: string,
+): RollupLog {
+  return {
+    code: CYCLE_LOADING,
+    message: `Found the module "${moduleId}" cycle loading at ${pluginName} plugin, it maybe blocking fetching modules.`,
   }
 }
 

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -290,6 +290,7 @@ export function bindingifyLoad(
           args.pluginContextData,
           args.onLog,
           args.logLevel,
+          id,
         ),
         id,
       )

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -14,6 +14,8 @@ import { SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF } from '../constants/plugin-co
 import { PartialNull } from '../types/utils'
 import { bindingifySideEffects } from '../utils/transform-side-effects'
 import type { LogHandler, LogLevelOption } from '../rollup'
+import { LOG_LEVEL_WARN } from '../log/logging'
+import { logCycleLoading } from '../log/logs'
 
 export interface EmittedAsset {
   type: 'asset'
@@ -67,8 +69,9 @@ export class PluginContext extends MinimalPluginContext {
     super(onLog, logLevel, plugin)
     this.load = async ({ id, ...options }) => {
       if (id === currentLoadingModule) {
-        throw new Error(
-          `Found the module ${id} cycle loading at ${plugin.name} plugin, you can't load it if the current loading or transforming is self.`,
+        onLog(
+          LOG_LEVEL_WARN,
+          logCycleLoading(plugin.name!, currentLoadingModule),
         )
       }
       // resolveDependencies always true at rolldown

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -62,9 +62,15 @@ export class PluginContext extends MinimalPluginContext {
     data: PluginContextData,
     onLog: LogHandler,
     logLevel: LogLevelOption,
+    currentLoadingModule?: string,
   ) {
     super(onLog, logLevel, plugin)
     this.load = async ({ id, ...options }) => {
+      if (id === currentLoadingModule) {
+        throw new Error(
+          `Found the module ${id} cycle loading at ${plugin.name} plugin, you can't load it if the current loading or transforming is self.`,
+        )
+      }
       // resolveDependencies always true at rolldown
       const moduleInfo = data.getModuleInfo(id, context)
       if (moduleInfo && moduleInfo.code !== null /* module already parsed */) {

--- a/packages/rolldown/src/plugin/transform-plugin-context.ts
+++ b/packages/rolldown/src/plugin/transform-plugin-context.ts
@@ -31,7 +31,7 @@ export class TransformPluginContext extends PluginContext {
     onLog: LogHandler,
     LogLevelOption: LogLevelOption,
   ) {
-    super(context, plugin, data, onLog, LogLevelOption)
+    super(context, plugin, data, onLog, LogLevelOption, moduleId)
     const getLogHandler =
       (handler: LoggingFunctionWithPosition): LoggingFunctionWithPosition =>
       (log, pos) => {

--- a/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
@@ -8,9 +8,7 @@ export default defineTest({
         name: 'test-plugin-context',
         async load(id) {
           try {
-            await this.load({
-              id,
-            })
+            await this.load({ id })
           } catch (e: any) {
             expect(e.message).toContain('cycle loading')
           }

--- a/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
@@ -1,19 +1,25 @@
 import { defineTest } from '@tests'
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
+
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
     plugins: [
       {
         name: 'test-plugin-context',
+        onLog: (level, log) => {
+          expect(level).toBe('warn')
+          expect(log.code).toBe('CYCLE_LOADING')
+          onLogFn()
+        },
         async load(id) {
-          try {
-            await this.load({ id })
-          } catch (e: any) {
-            expect(e.message).toContain('cycle loading')
-          }
+          this.load({ id })
         },
       },
     ],
+  },
+  afterTest: () => {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
   },
 })

--- a/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
@@ -1,0 +1,21 @@
+import { defineTest } from '@tests'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'test-plugin-context',
+        async load(id) {
+          try {
+            await this.load({
+              id,
+            })
+          } catch (e: any) {
+            expect(e.message).toContain('cycle loading')
+          }
+        },
+      },
+    ],
+  },
+})

--- a/packages/rollup-tests/src/ignored-passed-snapshot-different-tests.js
+++ b/packages/rollup-tests/src/ignored-passed-snapshot-different-tests.js
@@ -117,4 +117,6 @@ module.exports = [
     "rollup@form@external-empty-import-no-global: does not expect a global to be provided for empty imports (#1217)@generates es",
     "rollup@form@external-imports: prefixes global names with `global.` when creating UMD bundle (#57)@generates es",
     "rollup@form@super-classes@super-class-prototype-assignment: correctly resolves the prototype of the super class when assigning properites",
+    // passed, the rolldown give a specific warning
+    "rollup@function@preload-loading-module: waits for pre-loaded modules that are currently loading"
 ]

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -4,6 +4,11 @@
   "ignored": 35,
   "ignored(unsupported features)": 402,
   "ignored(treeshaking)": 285,
+<<<<<<< HEAD
   "ignored(behavior passed, snapshot different)": 113,
   "passed": 683
+=======
+  "ignored(behavior passed, snapshot different)": 114,
+  "passed": 681
+>>>>>>> 3cbe018d6 (chore: using warnings)
 }

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -4,11 +4,6 @@
   "ignored": 35,
   "ignored(unsupported features)": 402,
   "ignored(treeshaking)": 285,
-<<<<<<< HEAD
-  "ignored(behavior passed, snapshot different)": 113,
-  "passed": 683
-=======
   "ignored(behavior passed, snapshot different)": 114,
-  "passed": 681
->>>>>>> 3cbe018d6 (chore: using warnings)
+  "passed": 682
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -5,5 +5,10 @@
 | ignored | 35 |
 | ignored(unsupported features) | 402 |
 | ignored(treeshaking) | 285 |
+<<<<<<< HEAD
 | ignored(behavior passed, snapshot different) | 113 |
 | passed | 683 |
+=======
+| ignored(behavior passed, snapshot different) | 114 |
+| passed | 681 |
+>>>>>>> 3cbe018d6 (chore: using warnings)

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -5,10 +5,5 @@
 | ignored | 35 |
 | ignored(unsupported features) | 402 |
 | ignored(treeshaking) | 285 |
-<<<<<<< HEAD
-| ignored(behavior passed, snapshot different) | 113 |
-| passed | 683 |
-=======
 | ignored(behavior passed, snapshot different) | 114 |
-| passed | 681 |
->>>>>>> 3cbe018d6 (chore: using warnings)
+| passed | 682 |


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
close https://github.com/rolldown/rolldown/issues/2751#issuecomment-2482397149
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Because the `await load({ id })` will cause stuck, but `this.load({ id })` is not, so here give a warning for it.
