### PR TITLE
fix: ensure transform hook return vaild sourcemap to binding

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -134,7 +134,9 @@
     "vite": "^5.2.13",
     "vitest": "^2.0.0",
     "why-is-node-running": "^3.0.0",
-    "zod-to-json-schema": "^3.23.2"
+    "zod-to-json-schema": "^3.23.2",
+    "@jridgewell/sourcemap-codec": "^1.5.0",
+    "source-map": "^0.7.4"
   },
   "optionalDependencies": {
     "@rolldown/binding-darwin-arm64": "workspace:*",

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -10,7 +10,10 @@ import type {
   PrivateResolveIdExtraOptions,
   SourceDescription,
 } from './index'
-import { isEmptySourcemapFiled } from '../utils/transform-sourcemap'
+import {
+  isEmptySourcemapFiled,
+  normalizeTransformHookSourcemap,
+} from '../utils/transform-sourcemap'
 import { transformModuleInfo } from '../utils/transform-module-info'
 import path from 'node:path'
 import { bindingifySourcemap, ExistingRawSourceMap } from '../types/sourcemap'
@@ -261,7 +264,9 @@ export function bindingifyTransform(
 
       return {
         code: ret.code,
-        map: bindingifySourcemap(ret.map),
+        map: bindingifySourcemap(
+          normalizeTransformHookSourcemap(id, code, ret.map),
+        ),
         sideEffects: bindingifySideEffects(ret.moduleSideEffects),
         moduleType: ret.moduleType,
       }

--- a/packages/rolldown/src/utils/transform-sourcemap.ts
+++ b/packages/rolldown/src/utils/transform-sourcemap.ts
@@ -1,3 +1,5 @@
+import { ExistingRawSourceMap, SourceMapInput } from '../types/sourcemap'
+
 export function isEmptySourcemapFiled(
   array: undefined | (string | null)[],
 ): boolean {
@@ -8,4 +10,28 @@ export function isEmptySourcemapFiled(
     return true
   }
   return false
+}
+
+export function normalizeTransformHookSourcemap(
+  id: string,
+  originalCode: string,
+  rawMap?: SourceMapInput,
+) {
+  if (!rawMap) {
+    return
+  }
+  // If sourcemap hasn't `sourcesContent` and `sources`, using original code to fill it.
+  // The rust side already has the feature at `crates/rolldown_plugin/src/plugin_driver/build_hooks.rs#transform`.
+  // but it could be failed at `rolldown_sourcemap::SourceMap::from_json`, because the map is invalid.
+  let map =
+    typeof rawMap === 'object'
+      ? rawMap
+      : (JSON.parse(rawMap) as ExistingRawSourceMap)
+  if (map && isEmptySourcemapFiled(map.sourcesContent)) {
+    map.sourcesContent = [originalCode]
+  }
+  if (map && isEmptySourcemapFiled(map.sources)) {
+    map.sources = [id]
+  }
+  return map
 }

--- a/packages/rolldown/tests/fixtures/plugin/transform/invalid-sourcemap/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/invalid-sourcemap/_config.ts
@@ -1,0 +1,42 @@
+import { defineTest } from '@tests'
+import { expect, vi } from 'vitest'
+import { encode } from '@jridgewell/sourcemap-codec'
+import { getLocation, getOutputAsset, getOutputChunk } from '@tests/utils'
+import { SourceMapConsumer } from 'source-map'
+
+// Copy from "rollup@sourcemaps@transform-low-resolution: handles combining low-resolution and high-resolution source-maps when transforming@generates es".
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'test-plugin',
+        transform(code) {
+          // each entry of each line consist of
+          // [generatedColumn, sourceIndex, sourceLine, sourceColumn];
+          // this mapping only maps the second line to the first with no column
+          // details
+          const decodedMap = [[], [[0, 0, 0, 0]]]
+          return {
+            code: `console.log('added');\n${code}`,
+            // @ts-expect-error typing is not same as rollup
+            map: { mappings: encode(decodedMap) }, // The invalid map used `sourceIndex`, but not `sources` field
+          }
+        },
+      },
+    ],
+    output: {
+      sourcemap: true,
+    },
+  },
+  afterTest: async (output) => {
+    const code = getOutputChunk(output)[0].code
+    const map = getOutputAsset(output)[0].source as string
+    const smc = await new SourceMapConsumer(JSON.parse(map))
+
+    const generatedLoc = getLocation(code, code.indexOf(`"baz"`))
+    const originalLoc = smc.originalPositionFor(generatedLoc)
+
+    expect(originalLoc.line).toBe(1)
+    expect(originalLoc.column).toBe(0)
+  },
+})

--- a/packages/rolldown/tests/fixtures/plugin/transform/invalid-sourcemap/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/transform/invalid-sourcemap/main.js
@@ -1,0 +1,1 @@
+export let foo = 'bar'; foo += 'baz';

--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -62,3 +62,26 @@ assert.deepEqual(testsDir().split(nodePath.sep).slice(-4), [
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
+
+export function getLocation(source: string, search: string | number) {
+  var lines = source.split('\n')
+  var length_ = lines.length
+
+  var lineStart = 0
+  var index
+
+  const charIndex = typeof search === 'number' ? search : source.indexOf(search)
+
+  for (index = 0; index < length_; index += 1) {
+    var line = lines[index]
+    var lineEnd = lineStart + line.length + 1 // +1 for newline
+
+    if (lineEnd > charIndex) {
+      return { line: index + 1, column: charIndex - lineStart }
+    }
+
+    lineStart = lineEnd
+  }
+
+  throw new Error('Could not determine location of character')
+}

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -306,7 +306,7 @@
 
 ## Features
 
-### The `import.meta.ROLLUP_FILE_URL_<referenceId> is` not supported
+### The `import.meta.ROLLUP_FILE_URL_<referenceId>` is not supported
  - rollup@form@emit-asset-file: supports emitting assets from plugin hooks@generates es
  - rollup@form@emit-uint8array-no-buffer: supports emitting assets as Uint8Arrays when Buffer is not available@generates es
 

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -306,6 +306,10 @@
 
 ## Features
 
+### The `import.meta.ROLLUP_FILE_URL_<referenceId> is` not supported
+ - rollup@form@emit-asset-file: supports emitting assets from plugin hooks@generates es
+ - rollup@form@emit-uint8array-no-buffer: supports emitting assets as Uint8Arrays when Buffer is not available@generates es
+
 ### The rollup treat non-js-extensions module as js module, but the rolldown wiill guess the module type by externsion
  - rollup@function@non-js-extensions: non .js extensions are preserved
 
@@ -362,6 +366,13 @@
 
 ### escaping external id is not supported
  - rollup@form@quote-id: handles escaping for external ids@generates es
+
+### remove `use strict` from function body
+ - rollup@function@function-use-strict-directive-removed: should delete use strict from function body
+
+### comment related
+ - rollup@form@comment-before-import: preserves comments before imports@generates es
+ - rollup@form@comment-start-inside-comment: properly remove coments above import statements@generates es
 
 ### The namespace object is not compatible with rollup
  - rollup@function@namespaces-have-null-prototype: creates namespaces with null prototypes
@@ -424,6 +435,7 @@
  - rollup@function@logging@promote-log-to-error: allows turning logs into errors
 
 ### The error/warning not implement
+ - rollup@function@transform-without-sourcemap-render-chunk: preserves sourcemap chains when transforming
  - rollup@function@non-function-hook-async: throws when providing a value for an async function hook
  - rollup@function@non-function-hook-sync: throws when providing a value for a sync function hook
  - rollup@function@export-type-mismatch-b: export type must be auto, default, named or none

--- a/packages/rollup-tests/src/ignored-passed-snapshot-different-tests.js
+++ b/packages/rollup-tests/src/ignored-passed-snapshot-different-tests.js
@@ -1,8 +1,6 @@
 // cSpell:disable
 module.exports = [
     // Passed, but the output snapshot is same as rollup
-    "rollup@form@sourcemaps-external: correct sourcemaps are written (separate file)@generates es", // the mappping is not same as rollup
-    "rollup@form@sourcemaps-hidden: correct sourcemaps are written (separate file) without comment@generates es", // the mappping is not same as rollup
     "rollup@form@catch-parameter-shadowing: the parameter of a catch block should correctly shadow an import (#1391)",// rollup not deconflict
     "rollup@form@body-less-for-loops: supports body-less for loops",// rollup not deconflict
     "rollup@form@import-specifier-deshadowing: deshadows aliased import bindings@generates es", // rollup not deconflict
@@ -117,6 +115,18 @@ module.exports = [
     "rollup@form@external-empty-import-no-global: does not expect a global to be provided for empty imports (#1217)@generates es",
     "rollup@form@external-imports: prefixes global names with `global.` when creating UMD bundle (#57)@generates es",
     "rollup@form@super-classes@super-class-prototype-assignment: correctly resolves the prototype of the super class when assigning properites",
+
+    // Passed, but sourcemap/code is different from rollup
+    "rollup@function@sourcemap-true-generatebundle: emits sourcemaps before generateBundle hook", 
+    "rollup@function@sourcemap-inline-generatebundle: includes inline sourcemap comments in generateBundle hook",  
+    "rollup@form@sourcemaps-external: correct sourcemaps are written (separate file)@generates es", // the mappping is not same as rollup
+    "rollup@form@sourcemaps-hidden: correct sourcemaps are written (separate file) without comment@generates es", // the mappping is not same as rollup
+    "rollup@sourcemaps@render-chunk-babili: generates valid sourcemap when source could not be determined@generates es", // The rolldown output chunk including `module comment` caused line offset, the rollup provider the fake sourcemap can't remapping.
+    "rollup@form@render-chunk-plugin-sourcemaps: supports returning undefined source maps from render chunk hooks, when source maps are enabled@generates es", // the mappping is not same as rollup, the `sources/sourcesContent` perseved original sourcemap is correct
+    "rollup@sourcemaps@transform-low-resolution: handles combining low-resolution and high-resolution source-maps when transforming@generates es",// the input string `'bar'`, the rolldown output `"bar"`, caused search original position failed
+    "rollup@sourcemaps@names: names are recovered (https://github.com/rollup/rollup/issues/101)@generates es", // the inputs string `Object.create( Bar.prototype )`, the rolldown output `Object.create(Bar.prototype)`, caused search original position failed
+    "rollup@sourcemaps@basic-support: basic sourcemap support@generates es",// the inputs string `console.log( 'hello from main.js' )`, the rolldown output `console.log("hello from main.js")`, caused search original position failed
+
     // passed, the rolldown give a specific warning
     "rollup@function@preload-loading-module: waits for pre-loaded modules that are currently loading"
 ]

--- a/packages/rollup-tests/src/ignored-tests.js
+++ b/packages/rollup-tests/src/ignored-tests.js
@@ -1,11 +1,5 @@
 // cSpell:disable
 const ignoreTests = [
-
-  // --- following tests will hang forever ---
-
-  // FATAL ERROR: threadsafe_function.rs:573
-  'rollup@function@external-ignore-reserved-null-marker: external function ignores \\0 started ids',
-
   // Need to investigate
   'rollup@function@bundle-facade-order: respects the order of entry points when there are additional facades for chunks',
 
@@ -16,8 +10,6 @@ const ignoreTests = [
   'rollup@function@symlink: follows symlinks',
   "rollup@form@sourcemaps-inline: correct sourcemaps are written (inline)@generates es",
 
-  // The rolldown output chunk including `module comment` caused line offset, the rollup provider the fake sourcemap can't remapping.
-  "rollup@sourcemaps@render-chunk-babili: generates valid sourcemap when source could not be determined@generates es",
   // Here has unexpected error `Error: nul byte found in provided data at position: 0` from rust due to #967.
   // It crashed at call `banner` function at rust. 
   "rollup@sourcemaps@excludes-plugin-helpers: excludes plugin helpers from sources@generates es",
@@ -42,33 +34,12 @@ const ignoreTests = [
   "rollup@function@class-name-conflict: preserves class names even if the class is renamed",
   "rollup@form@assignment-to-exports-class-declaration: does not rewrite class expression IDs@generates es",
 
-  // comment related
-  "rollup@form@comment-before-import: preserves comments before imports@generates es",
-  "rollup@form@comment-start-inside-comment: properly remove coments above import statements@generates es",
-
-  // The output code/sourcemap is not same as rollup,
-  "rollup@function@sourcemap-true-generatebundle: emits sourcemaps before generateBundle hook",
-  "rollup@function@sourcemap-inline-generatebundle: includes inline sourcemap comments in generateBundle hook",
-
-  // import.meta.ROLLUP_FILE_URL_<referenceId> is not supported
-  "rollup@form@emit-asset-file: supports emitting assets from plugin hooks@generates es",
-  "rollup@form@emit-uint8array-no-buffer: supports emitting assets as Uint8Arrays when Buffer is not available@generates es",
-
   // Module meta related
   // Shouldn't modify meta objects passed in resolveId hook
   "rollup@function@custom-module-options: supports adding custom options to modules",
 
-  // Should delete use strict from function body
-  "rollup@function@function-use-strict-directive-removed: should delete use strict from function body",
-
   // The sourcemap related
-  "rollup@function@handles-stringified-sourcemaps: handles transforms that return stringified source maps (#377)",
-  "rollup@function@transform-without-sourcemap-render-chunk: preserves sourcemap chains when transforming",
-  "rollup@sourcemaps@basic-support: basic sourcemap support@generates es",
-  "rollup@sourcemaps@names: names are recovered (https://github.com/rollup/rollup/issues/101)@generates es",
-  "rollup@sourcemaps@single-length-segments: handles single-length sourcemap segments@generates es",
-  "rollup@sourcemaps@transform-low-resolution: handles combining low-resolution and high-resolution source-maps when transforming@generates es",
-  "rollup@form@render-chunk-plugin-sourcemaps: supports returning undefined source maps from render chunk hooks, when source maps are enabled@generates es", // file not expected
+  "rollup@sourcemaps@single-length-segments: handles single-length sourcemap segments@generates es", // the source filed has error 
 ]
 
 module.exports = {

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,9 +1,9 @@
 {
   "failed": 0,
   "skipFailed": 0,
-  "ignored": 35,
-  "ignored(unsupported features)": 402,
+  "ignored": 20,
+  "ignored(unsupported features)": 408,
   "ignored(treeshaking)": 285,
-  "ignored(behavior passed, snapshot different)": 114,
-  "passed": 682
+  "ignored(behavior passed, snapshot different)": 121,
+  "passed": 684
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -2,8 +2,8 @@
 |----| ---- |
 | failed | 0 |
 | skipFailed | 0 |
-| ignored | 35 |
-| ignored(unsupported features) | 402 |
+| ignored | 20 |
+| ignored(unsupported features) | 408 |
 | ignored(treeshaking) | 285 |
-| ignored(behavior passed, snapshot different) | 114 |
-| passed | 682 |
+| ignored(behavior passed, snapshot different) | 121 |
+| passed | 684 |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
         specifier: workspace:*
         version: link:npm/win32-x64-msvc
     devDependencies:
+      '@jridgewell/sourcemap-codec':
+        specifier: ^1.5.0
+        version: 1.5.0
       '@napi-rs/cli':
         specifier: ^3.0.0-alpha.60
         version: 3.0.0-alpha.64(@emnapi/runtime@1.3.0)(@types/node@22.8.7)(emnapi@1.3.1(node-addon-api@8.2.1))
@@ -274,6 +277,9 @@ importers:
       signal-exit:
         specifier: 4.1.0
         version: 4.1.0
+      source-map:
+        specifier: ^0.7.4
+        version: 0.7.4
       tsx:
         specifier: ^4.19.2
         version: 4.19.2


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `transform` hook maybe return an invalid sourcemap, the added test is an example, it used the `sourceIndex`, but not the `sources` field. The pr fixed it to avoid failed at `rolldown_sourcemap::SourceMap::from_json`. 

The rust side already has the feature at `crates/rolldown_plugin/src/plugin_driver/build_hooks.rs#transform`, it also is valid if the rust plugins provider an invalid sourcemap. Maybe we could remove it at rust side if we could ensure a valid sourcemap, i think it could be preserved at now because it is sugar to usage.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
