### PR TITLE
chore: remove unnecessary `@ts-ignore`

### DIFF
--- a/packages/bench/vue-entry.js
+++ b/packages/bench/vue-entry.js
@@ -1,7 +1,6 @@
 import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
 
-// @ts-ignore
 const router = createRouter({
   history: createWebHistory(),
 })

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -142,22 +142,16 @@ export function bindingifyResolveId(
         }
       }
 
-      const result: BindingHookResolveIdOutput = {
-        id: ret.id,
-        external: ret.external,
-      }
-
-      if (ret.moduleSideEffects !== null) {
-        // @ts-ignore TODO The typing should import from binding
-        result.sideEffects = bindingifySideEffects(ret.moduleSideEffects)
-      }
-
       args.pluginContextData.updateModuleOption(ret.id, {
         meta: ret.meta || {},
         moduleSideEffects: ret.moduleSideEffects || null,
       })
 
-      return result
+      return {
+        id: ret.id,
+        external: ret.external,
+        sideEffects: bindingifySideEffects(ret.moduleSideEffects),
+      }
     },
     meta: bindingifyPluginHookMeta(meta),
     // @ts-ignore
@@ -308,25 +302,19 @@ export function bindingifyLoad(
         return { code: ret }
       }
 
-      let map = preProcessSourceMap(ret, id)
-
-      const result = {
-        code: ret.code,
-        map: map !== undefined ? bindingifySourcemap(map) : undefined,
-        moduleType: ret.moduleType,
-      }
-
-      if (ret.moduleSideEffects !== null) {
-        // @ts-ignore TODO The typing should import from binding
-        result.sideEffects = bindingifySideEffects(ret.moduleSideEffects)
-      }
-
       args.pluginContextData.updateModuleOption(id, {
         meta: ret.meta || {},
         moduleSideEffects: ret.moduleSideEffects || null,
       })
 
-      return result
+      let map = preProcessSourceMap(ret, id)
+
+      return {
+        code: ret.code,
+        map: bindingifySourcemap(map),
+        moduleType: ret.moduleType,
+        sideEffects: bindingifySideEffects(ret.moduleSideEffects),
+      }
     },
     meta: bindingifyPluginHookMeta(meta),
     // @ts-ignore

--- a/packages/rolldown/src/plugin/bindingify-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin.ts
@@ -145,7 +145,6 @@ export function bindingifyPlugin(
     moduleParsedMeta,
     load,
     loadMeta,
-    // @ts-ignore
     loadFilter,
     renderChunk,
     renderChunkMeta,

--- a/packages/rolldown/tests/fixtures/misc/module-types/vue-ext-without-module-mapping/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/module-types/vue-ext-without-module-mapping/_config.ts
@@ -3,7 +3,6 @@ import { defineTest } from '@tests'
 export default defineTest({
   config: {},
   afterTest: async () => {
-    // @ts-ignore
     await import('./assert.mjs')
   },
 })

--- a/packages/rolldown/tests/fixtures/plugin/transform/invalid-sourcemap/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/invalid-sourcemap/_config.ts
@@ -1,5 +1,5 @@
+import { expect } from 'vitest'
 import { defineTest } from '@tests'
-import { expect, vi } from 'vitest'
 import { encode } from '@jridgewell/sourcemap-codec'
 import { getLocation, getOutputAsset, getOutputChunk } from '@tests/utils'
 import { SourceMapConsumer } from 'source-map'

--- a/packages/rolldown/tests/fixtures/resolve/module-css-should-have-high-priority/_config.ts
+++ b/packages/rolldown/tests/fixtures/resolve/module-css-should-have-high-priority/_config.ts
@@ -8,7 +8,6 @@ export default defineTest({
     },
   },
   afterTest() {
-    // @ts-ignore
     import('./assert.mjs')
   },
 })

--- a/scripts/misc/gen-esbuild-test.mjs
+++ b/scripts/misc/gen-esbuild-test.mjs
@@ -258,7 +258,6 @@ for (let i = 0, len = tree.rootNode.namedChildren.length; i < len; i++) {
     // if (ignoredTestPattern.some((name) => testCaseName?.includes(name))) {
     //   isIgnored = true
     // }
-    // @ts-ignore
     // if (ignoreCases.includes(testCaseName)) {
     //   isIgnored = true
     // }


### PR DESCRIPTION
### Description

I will work on resolving the ts type issues related to `filter` next PR.

https://github.com/rolldown/rolldown/blob/0535a45140334005d359aa8f11bf9c1acd7c3e52/packages/rolldown/src/plugin/bindingify-build-hooks.ts#L163-L165