### PR TITLE
fix: update package.json engines node minimal version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@9.12.3",
   "engines": {
-    "node": ">=18.20.3"
+    "node": ">=20.14.0"
   },
   "scripts": {
     "lint-code": "oxlint -c .oxlintrc.json --ignore-path=.oxlintignore --deny-warnings",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

scripts/misc/setup-prerequisites/node.js check node minimal version is read .node-version(20.14.0)

so package.json engines node should 20.14.0

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
