### PR TITLE
refactor(rust): make `SharedOptions` always exist on `AstScanner`

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -25,7 +25,7 @@ use rolldown_common::dynamic_import_usage::{DynamicImportExportsUsage, DynamicIm
 use rolldown_common::{
   AstScopes, EcmaModuleAstUsage, ExportsKind, ImportKind, ImportRecordIdx, ImportRecordMeta,
   LocalExport, MemberExprRef, ModuleDefFormat, ModuleId, ModuleIdx, NamedImport, RawImportRecord,
-  Specifier, StmtInfo, StmtInfos, SymbolRef, SymbolRefDbForModule, SymbolRefFlags, ROLLDOWN_IGNORE,
+  Specifier, StmtInfo, StmtInfos, SymbolRef, SymbolRefDbForModule, SymbolRefFlags,
 };
 use rolldown_ecmascript_utils::{BindingIdentifierExt, BindingPatternExt};
 use rolldown_error::{BuildDiagnostic, BuildResult, CjsExportSpan};
@@ -94,7 +94,7 @@ pub struct AstScanner<'me, 'ast> {
   cur_class_decl_and_symbol_referenced_ids: Option<(SymbolId, &'me Vec<ReferenceId>)>,
   visit_path: Vec<AstKind<'ast>>,
   scope_stack: Vec<Option<ScopeId>>,
-  options: Option<&'me SharedOptions>,
+  options: &'me SharedOptions,
   dynamic_import_usage_info: DynamicImportUsageInfo,
   ignore_comment: &'static str,
 }
@@ -110,7 +110,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     source: &'me ArcStr,
     file_path: &'me ModuleId,
     comments: &'me oxc::allocator::Vec<'me, Comment>,
-    options: Option<&'me SharedOptions>,
+    options: &'me SharedOptions,
   ) -> Self {
     let mut symbol_ref_db = SymbolRefDbForModule::new(symbol_table, idx, scope.root_scope_id());
     // This is used for converting "export default foo;" => "var default_symbol = foo;"
@@ -163,7 +163,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       ast_usage: EcmaModuleAstUsage::empty(),
       cur_class_decl_and_symbol_referenced_ids: None,
       visit_path: vec![],
-      ignore_comment: options.map_or(ROLLDOWN_IGNORE, |opt| opt.experimental.get_ignore_comment()),
+      ignore_comment: options.experimental.get_ignore_comment(),
       options,
       scope_stack: vec![],
       dynamic_import_usage_info: DynamicImportUsageInfo::default(),

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -46,7 +46,7 @@ fn scan_ast(
     ast.source(),
     &module_id,
     ast.comments(),
-    Some(options),
+    options,
   );
   let namespace_object_ref = scanner.namespace_object_ref;
   let scan_result = scanner.scan(ast.program())?;

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -190,7 +190,7 @@ impl RuntimeModuleTask {
       source,
       &facade_path,
       ast.comments(),
-      None,
+      &self.options,
     );
     let namespace_object_ref = scanner.namespace_object_ref;
     let scan_result = scanner.scan(ast.program())?;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Just improve the dx of using options in `AstScanner` and reduce some `is_some_and()` calls.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
