### PR TITLE
chore(node): standalone type check on `rolldown-tests`

### DIFF
--- a/packages/rolldown/build.mts
+++ b/packages/rolldown/build.mts
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { defineConfig, rolldown } from './src/index'
 import pkgJson from './package.json' with { type: 'json' }
 import nodePath from 'node:path'

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -111,9 +111,11 @@
     }
   },
   "devDependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.0",
     "@napi-rs/cli": "^3.0.0-alpha.60",
     "@napi-rs/wasm-runtime": "^0.2.4",
     "@rolldown/testing": "workspace:*",
+    "@types/fs-extra": "^11.0.4",
     "@types/lodash-es": "^4.17.12",
     "colorette": "^2.0.20",
     "consola": "^3.2.3",
@@ -127,14 +129,12 @@
     "rolldown": "workspace:*",
     "rollup": "^4.18.0",
     "signal-exit": "4.1.0",
+    "source-map": "^0.7.4",
     "tsx": "^4.19.2",
     "type-fest": "^4.20.0",
     "unbuild": "^2.0.0",
-    "vite": "^5.2.13",
     "why-is-node-running": "^3.0.0",
-    "zod-to-json-schema": "^3.23.2",
-    "@jridgewell/sourcemap-codec": "^1.5.0",
-    "source-map": "^0.7.4"
+    "zod-to-json-schema": "^3.23.2"
   },
   "optionalDependencies": {
     "@rolldown/binding-darwin-arm64": "workspace:*",

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -5,7 +5,7 @@ import { bindingifyBuiltInPlugin } from '../builtin-plugin/utils'
 import { BuiltinPlugin } from '../builtin-plugin/constructors'
 import { arraify, unsupported } from './misc'
 import { normalizedStringOrRegex } from './normalize-string-or-regex'
-import type { RolldownPlugin } from '..'
+import type { RolldownPlugin } from 'rolldown'
 import type { InputOptions } from '../options/input-options'
 import type { OutputOptions } from '../options/output-options'
 import type {

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
@@ -1,7 +1,7 @@
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 import path from 'node:path'
-import type { RolldownOutputChunk } from '../../../../src'
+import type { RolldownOutputChunk } from 'rolldown'
 import { getOutputChunk } from '@tests/utils'
 
 const entry = path.join(__dirname, './main.js')

--- a/packages/rolldown/tests/fixtures/plugin/hybrid-plugin/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/hybrid-plugin/_config.ts
@@ -2,7 +2,7 @@ import { expect } from 'vitest'
 import path from 'node:path'
 import { defineTest } from '@tests'
 import { loadFallbackPlugin } from 'rolldown/experimental'
-import { RolldownPlugin } from '@src/plugin'
+import { RolldownPlugin } from 'rolldown'
 
 const entry = path.join(__dirname, './main.js')
 

--- a/packages/rolldown/tests/fixtures/plugin/nested-and-async-plugin/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/nested-and-async-plugin/_config.ts
@@ -1,4 +1,4 @@
-import { InputOptions } from '@src/index'
+import { InputOptions } from 'rolldown'
 import { defineTest } from '@tests'
 
 const pluginA = {

--- a/packages/rolldown/tests/fixtures/plugin/normalized-option/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/normalized-option/_config.ts
@@ -1,10 +1,7 @@
 import { expect } from 'vitest'
 import path from 'node:path'
 import { defineTest } from '@tests'
-import {
-  NormalizedInputOptions,
-  NormalizedOutputOptions,
-} from '../../../../src'
+import { NormalizedInputOptions, NormalizedOutputOptions } from 'rolldown'
 
 const entry = path.join(__dirname, './main.js')
 

--- a/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
@@ -1,7 +1,7 @@
 import { expect } from 'vitest'
 import path from 'node:path'
 import fs from 'node:fs'
-import type { RolldownOutputChunk } from '../../../../src'
+import type { RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 
 const entry = path.join(__dirname, './main.js')

--- a/packages/rolldown/tests/package.json
+++ b/packages/rolldown/tests/package.json
@@ -3,11 +3,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "go": "cross-env RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run --reporter verbose --hideSkippedTests"
+    "go": "cross-env RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run --reporter verbose --hideSkippedTests",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "rolldown": "workspace:*",
     "cross-env": "^7.0.3",
+    "rolldown": "workspace:*",
+    "vite": "^5.0.0",
     "vitest": "^2.0.0"
   }
 }

--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -2,7 +2,7 @@ import {
   RollupOutput,
   RolldownOutputChunk,
   RolldownOutputAsset,
-} from '../../src'
+} from 'rolldown'
 import nodePath from 'node:path'
 import assert from 'node:assert'
 import { workspaceRoot } from '@rolldown/testing'

--- a/packages/rolldown/tests/tsconfig.json
+++ b/packages/rolldown/tests/tsconfig.json
@@ -1,6 +1,5 @@
 {
-  "include": ["src/**/*", "build.mts"],
-  "exclude": ["src/*.js", "src/*.mjs", "src/*.cjs", "dist/**"],
+  "include": ["src/*", "src/**/*", "**/_config.ts", "**/*.test.ts"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
@@ -29,13 +28,20 @@
     /* Modules */
     "module": "ESNext" /* Specify what module code is generated. */,
     "rootDir": "./" /* Specify the root folder within your source files. */,
-    "moduleResolution": "Bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
-    // "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
-    // "paths": {} /* Specify a set of entries that re-map imports to additional lookup locations. */,
+    "moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
+    "paths": {
+      "@tests/*": ["src/*.ts"],
+      "@tests": ["src/index.ts"],
+      "@src/*": ["../src/*"]
+    } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     "types": [
-      "node"
+      "node",
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client"
     ] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
@@ -43,13 +49,16 @@
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */
     "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
-    "checkJs": true /* Enable error reporting in type-checked JavaScript files. */,
+    // Tsc will include imported files, even if they are not match the include pattern. And we will imported the `dist` files to perform some
+    // assertions, and they shouldn't be type checked. We current use disable checkJs to avoid this issue.
+    "checkJs": false /* Enable error reporting in type-checked JavaScript files. */,
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
@@ -58,12 +67,11 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    "noEmit": true /* Disable emitting files from a compilation. */,
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
-    "noEmit": true /* Disable emitting files from a compilation. */,
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
@@ -75,11 +83,11 @@
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
     /* Interop Constraints */
     "isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
@@ -92,6 +100,7 @@
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */

--- a/packages/rolldown/tsconfig.dts.json
+++ b/packages/rolldown/tsconfig.dts.json
@@ -30,16 +30,12 @@
     "module": "ESNext" /* Specify what module code is generated. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
     "moduleResolution": "Bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
-    "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
-    "paths": {
-      "@tests/*": ["tests/src/*"],
-      "@tests": ["tests/src/index.ts"]
-    } /* Specify a set of entries that re-map imports to additional lookup locations. */,
+    // "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
+    // "paths": {} /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     "types": [
-      "node",
-      "vite/client"
+      "node"
     ] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 1.2.2
       vitepress:
         specifier: ^1.5.0
-        version: 1.5.0(@algolia/client-search@5.12.0)(@types/node@22.8.7)(change-case@5.4.4)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(terser@5.36.0)(typescript@5.6.3)
+        version: 1.5.0(@algolia/client-search@5.12.0)(@types/node@22.8.7)(change-case@5.4.4)(postcss@8.4.49)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(terser@5.36.0)(typescript@5.6.3)
       vitepress-plugin-group-icons:
         specifier: ^1.0.0
         version: 1.3.0
@@ -232,6 +232,9 @@ importers:
       '@rolldown/testing':
         specifier: workspace:*
         version: link:../testing
+      '@types/fs-extra':
+        specifier: ^11.0.4
+        version: 11.0.4
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -283,9 +286,6 @@ importers:
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.6.3)
-      vite:
-        specifier: ^5.2.13
-        version: 5.4.10(@types/node@22.8.7)(terser@5.36.0)
       why-is-node-running:
         specifier: ^3.0.0
         version: 3.2.1
@@ -329,6 +329,9 @@ importers:
       rolldown:
         specifier: workspace:*
         version: link:..
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.10(@types/node@22.8.7)(terser@5.36.0)
       vitest:
         specifier: ^2.0.0
         version: 2.1.4(@types/node@22.8.7)(terser@5.36.0)
@@ -2157,6 +2160,7 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
+    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -5462,6 +5466,10 @@ packages:
 
   postcss@8.4.47:
     resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.24.3:
@@ -11571,6 +11579,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.4.49:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   preact@10.24.3: {}
 
   prettier@3.3.3: {}
@@ -12375,7 +12389,7 @@ snapshots:
   vite@5.4.10(@types/node@22.8.7)(terser@5.36.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.47
+      postcss: 8.4.49
       rollup: 4.24.3
     optionalDependencies:
       '@types/node': 22.8.7
@@ -12390,7 +12404,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vitepress@1.5.0(@algolia/client-search@5.12.0)(@types/node@22.8.7)(change-case@5.4.4)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(terser@5.36.0)(typescript@5.6.3):
+  vitepress@1.5.0(@algolia/client-search@5.12.0)(@types/node@22.8.7)(change-case@5.4.4)(postcss@8.4.49)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(terser@5.36.0)(typescript@5.6.3):
     dependencies:
       '@docsearch/css': 3.6.3
       '@docsearch/js': 3.6.3(@algolia/client-search@5.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)
@@ -12411,7 +12425,7 @@ snapshots:
       vite: 5.4.10(@types/node@22.8.7)(terser@5.36.0)
       vue: 3.5.12(typescript@5.6.3)
     optionalDependencies:
-      postcss: 8.4.47
+      postcss: 8.4.49
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Achieve the goal said in https://github.com/rolldown/rolldown/pull/2959.

> - For example. we don't allow to write `@src` in `src` code due to some reasons, but it's ok to write in `tests`.
> - we have auto completions for `import.meta.viteMeta` in `src` code. But it's only exist in `tests` code.


- Clean import.meta

<img width="586" alt="image" src="https://github.com/user-attachments/assets/98709807-daff-4d7a-84f7-6ae916389fc3">

- No `@` aliasing.

<img width="613" alt="image" src="https://github.com/user-attachments/assets/80cc14ea-d761-4f34-aae1-73004df2f9c6">



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
