### PR TITLE
refactor: using reference at generate diagnostic

### DIFF
--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -202,7 +202,7 @@ impl Bundler {
             BindingLog {
               code: warning.kind().to_string(),
               message: warning
-                .into_diagnostic_with(&DiagnosticOptions { cwd: self.cwd.clone() })
+                .to_diagnostic_with(&DiagnosticOptions { cwd: self.cwd.clone() })
                 .to_color_string(),
             },
           ))

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -30,7 +30,7 @@ impl BindingOutputs {
   pub fn errors(&mut self, env: Env) -> napi::Result<Vec<napi::JsUnknown>> {
     if let Some(BindingOutputsDiagnostics { diagnostics, cwd }) = &self.error {
       return diagnostics
-        .into_iter()
+        .iter()
         .map(|diagnostic| to_js_diagnostic(diagnostic, cwd.clone(), env))
         .collect();
     }

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -28,10 +28,10 @@ impl BindingOutputs {
 
   #[napi(getter)]
   pub fn errors(&mut self, env: Env) -> napi::Result<Vec<napi::JsUnknown>> {
-    if let Some(BindingOutputsDiagnostics { diagnostics, cwd }) = std::mem::take(&mut self.error) {
+    if let Some(BindingOutputsDiagnostics { diagnostics, cwd }) = &self.error {
       return diagnostics
         .into_iter()
-        .map(|diagnostic| to_js_diagnostic(&diagnostic, cwd.clone(), env))
+        .map(|diagnostic| to_js_diagnostic(diagnostic, cwd.clone(), env))
         .collect();
     }
     Ok(vec![])
@@ -100,7 +100,7 @@ pub fn to_js_diagnostic(
   env: Env,
 ) -> napi::Result<napi::JsUnknown> {
   match diagnostic.downcast_napi_error() {
-    Ok(napi_error) => Ok(napi::JsError::from(napi_error).into_unknown(env)),
+    Ok(napi_error) => Ok(napi::JsError::from(napi_error.clone()).into_unknown(env)),
     Err(error) => {
       let mut object = env.create_object()?;
       object.set("kind", error.kind().to_string())?;

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -31,7 +31,7 @@ impl BindingOutputs {
     if let Some(BindingOutputsDiagnostics { diagnostics, cwd }) = std::mem::take(&mut self.error) {
       return diagnostics
         .into_iter()
-        .map(|diagnostic| into_js_diagnostic(diagnostic, cwd.clone(), env))
+        .map(|diagnostic| to_js_diagnostic(&diagnostic, cwd.clone(), env))
         .collect();
     }
     Ok(vec![])
@@ -94,8 +94,8 @@ pub struct BindingOutputsDiagnostics {
   cwd: std::path::PathBuf,
 }
 
-pub fn into_js_diagnostic(
-  diagnostic: BuildDiagnostic,
+pub fn to_js_diagnostic(
+  diagnostic: &BuildDiagnostic,
   cwd: std::path::PathBuf,
   env: Env,
 ) -> napi::Result<napi::JsUnknown> {
@@ -106,7 +106,7 @@ pub fn into_js_diagnostic(
       object.set("kind", error.kind().to_string())?;
       object.set(
         "message",
-        error.into_diagnostic_with(&DiagnosticOptions { cwd: cwd.clone() }).to_color_string(),
+        error.to_diagnostic_with(&DiagnosticOptions { cwd: cwd.clone() }).to_color_string(),
       )?;
       Ok(object.into_unknown())
     }

--- a/crates/rolldown_binding/src/types/watcher.rs
+++ b/crates/rolldown_binding/src/types/watcher.rs
@@ -5,7 +5,7 @@ use napi_derive::napi;
 
 use crate::utils::handle_result;
 
-use super::{binding_outputs::into_js_diagnostic, js_callback::MaybeAsyncJsCallback};
+use super::{binding_outputs::to_js_diagnostic, js_callback::MaybeAsyncJsCallback};
 use crate::types::js_callback::MaybeAsyncJsCallbackExt;
 
 #[napi]
@@ -118,7 +118,7 @@ impl BindingWatcherEvent {
     {
       std::mem::take(diagnostics)
         .into_iter()
-        .map(|diagnostic| into_js_diagnostic(diagnostic, cwd.clone(), env))
+        .map(|diagnostic| to_js_diagnostic(&diagnostic, cwd.clone(), env))
         .collect()
     } else {
       unreachable!("Expected WatcherEvent::Event(BundleEventKind::Error)")

--- a/crates/rolldown_binding/src/types/watcher.rs
+++ b/crates/rolldown_binding/src/types/watcher.rs
@@ -116,10 +116,7 @@ impl BindingWatcherEvent {
       rolldown_common::OutputsDiagnostics { diagnostics, cwd },
     )) = &mut self.inner
     {
-      std::mem::take(diagnostics)
-        .into_iter()
-        .map(|diagnostic| to_js_diagnostic(&diagnostic, cwd.clone(), env))
-        .collect()
+      diagnostics.iter().map(|diagnostic| to_js_diagnostic(diagnostic, cwd.clone(), env)).collect()
     } else {
       unreachable!("Expected WatcherEvent::Event(BundleEventKind::Error)")
     }

--- a/crates/rolldown_error/src/build_error/mod.rs
+++ b/crates/rolldown_error/src/build_error/mod.rs
@@ -51,11 +51,11 @@ impl BuildDiagnostic {
     self
   }
 
-  pub fn into_diagnostic(self) -> Diagnostic {
-    self.into_diagnostic_with(&DiagnosticOptions::default())
+  pub fn to_diagnostic(&self) -> Diagnostic {
+    self.to_diagnostic_with(&DiagnosticOptions::default())
   }
 
-  pub fn into_diagnostic_with(self, opts: &DiagnosticOptions) -> Diagnostic {
+  pub fn to_diagnostic_with(&self, opts: &DiagnosticOptions) -> Diagnostic {
     let mut diagnostic =
       Diagnostic::new(self.kind().to_string(), self.inner.message(opts), self.severity);
     self.inner.on_diagnostic(&mut diagnostic, opts);
@@ -63,8 +63,8 @@ impl BuildDiagnostic {
   }
 
   #[cfg(feature = "napi")]
-  pub fn downcast_napi_error(self) -> Result<napi::Error, Self> {
-    match self.napi_error {
+  pub fn downcast_napi_error(&self) -> Result<&napi::Error, &Self> {
+    match &self.napi_error {
       Some(napi_error) => Ok(napi_error),
       None => Err(self),
     }

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -244,7 +244,7 @@ impl IntegrationTest {
       errors.sort_by_key(|e| e.kind().to_string());
       let diagnostics = errors
         .into_iter()
-        .map(|e| (e.kind(), e.into_diagnostic_with(&DiagnosticOptions { cwd: cwd.to_path_buf() })));
+        .map(|e| (e.kind(), e.to_diagnostic_with(&DiagnosticOptions { cwd: cwd.to_path_buf() })));
 
       let mut rendered_diagnostics = diagnostics
         .map(|(code, diagnostic)| {
@@ -271,7 +271,7 @@ impl IntegrationTest {
       snapshot.push_str("# warnings\n\n");
       let diagnostics = warnings
         .into_iter()
-        .map(|e| (e.kind(), e.into_diagnostic_with(&DiagnosticOptions { cwd: cwd.to_path_buf() })));
+        .map(|e| (e.kind(), e.to_diagnostic_with(&DiagnosticOptions { cwd: cwd.to_path_buf() })));
       let mut rendered_diagnostics = diagnostics
         .map(|(code, diagnostic)| {
           [

--- a/crates/rolldown_testing/src/utils.rs
+++ b/crates/rolldown_testing/src/utils.rs
@@ -45,7 +45,7 @@ pub fn stringify_bundle_output(output: BundleOutput, cwd: &Path) -> String {
     ret.push_str("# warnings\n\n");
     let diagnostics = warnings
       .into_iter()
-      .map(|e| (e.kind(), e.into_diagnostic_with(&DiagnosticOptions { cwd: cwd.to_path_buf() })));
+      .map(|e| (e.kind(), e.to_diagnostic_with(&DiagnosticOptions { cwd: cwd.to_path_buf() })));
     let rendered = diagnostics
       .flat_map(|(code, diagnostic)| {
         [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Refactor it because the `BuildEnd#error` need to use it, prepare for https://github.com/rolldown/rolldown/pull/2973.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
