### PR TITLE
feat: support `preserve` for `outputOptions#comments`

### DIFF
--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -117,7 +117,7 @@ pub struct BindingOutputOptions {
   #[napi(ts_type = "boolean | 'dce-only' | BindingMinifyOptions")]
   pub minify: Option<Either3<bool, String, BindingMinifyOptions>>,
   pub advanced_chunks: Option<BindingAdvancedChunksOptions>,
-  #[napi(ts_type = "'none' | 'preserve-legal'")]
+  #[napi(ts_type = "'none' | 'preserve' | 'preserve-legal'")]
   pub comments: Option<String>,
   pub polyfill_require: Option<bool>,
   pub target: Option<String>,

--- a/crates/rolldown_binding/src/types/binding_normalized_options.rs
+++ b/crates/rolldown_binding/src/types/binding_normalized_options.rs
@@ -244,7 +244,7 @@ impl BindingNormalizedOptions {
     self.inner.polyfill_require
   }
 
-  #[napi(getter, ts_return_type = "'none' | 'preserve-legal'")]
+  #[napi(getter, ts_return_type = "'none' | 'preserve' | 'preserve-legal'")]
   pub fn comments(&self) -> String {
     self.inner.comments.to_string()
   }

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -308,7 +308,8 @@ pub fn normalize_binding_options(
       .comments
       .map(|inner| match inner.as_str() {
         "none" => Ok(rolldown::Comments::None),
-        "preserve-legal" => Ok(rolldown::Comments::Preserve),
+        "preserve" => Ok(rolldown::Comments::Preserve),
+        "preserve-legal" => Ok(rolldown::Comments::PreserveLegal),
         _ => Err(napi::Error::new(
           napi::Status::GenericFailure,
           format!("Invalid valid for `comments` option: {inner}"),

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -60,7 +60,7 @@ export declare class BindingNormalizedOptions {
   get sourcemapDebugIds(): boolean
   get minify(): false | BindingMinifyOptions
   get polyfillRequire(): boolean
-  get comments(): 'none' | 'preserve-legal'
+  get comments(): 'none' | 'preserve' | 'preserve-legal'
 }
 
 export declare class BindingOutputAsset {
@@ -563,7 +563,7 @@ export interface BindingOutputOptions {
   sourcemapPathTransform?: (source: string, sourcemapPath: string) => string
   minify?: boolean | 'dce-only' | BindingMinifyOptions
   advancedChunks?: BindingAdvancedChunksOptions
-  comments?: 'none' | 'preserve-legal'
+  comments?: 'none' | 'preserve' | 'preserve-legal'
   polyfillRequire?: boolean
   target?: string
 }

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -44,7 +44,7 @@ export interface NormalizedOutputOptions {
   sourcemapIgnoreList: SourcemapIgnoreListOption;
   sourcemapPathTransform: SourcemapPathTransformOption | undefined;
   minify: false | BindingMinifyOptions;
-  comments: 'none' | 'preserve-legal';
+  comments: 'none' | 'preserve' | 'preserve-legal';
   polyfillRequire: boolean;
   plugins: RolldownPlugin[];
 }
@@ -165,7 +165,7 @@ export class NormalizedOutputOptionsImpl implements NormalizedOutputOptions {
     return this.inner.minify;
   }
 
-  get comments(): 'none' | 'preserve-legal' {
+  get comments(): 'none' | 'preserve' | 'preserve-legal' {
     return this.inner.comments;
   }
 

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -191,9 +191,10 @@ export interface OutputOptions {
    * Control comments in the output.
    *
    * - `none`: no comments
+   * - `preserve`: preserve all comments except legal comments
    * - `preserve-legal`: preserve comments that contain `@license`, `@preserve` or starts with `//!` `/*!`
    */
-  comments?: 'none' | 'preserve-legal';
+  comments?: 'none' | 'preserve' | 'preserve-legal';
   plugins?: RolldownOutputPluginOption;
   polyfillRequire?: boolean;
   target?: ESTarget;

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -642,7 +642,13 @@ const OutputOptionsSchema = v.strictObject({
   ),
   advancedChunks: v.optional(AdvancedChunksSchema),
   comments: v.pipe(
-    v.optional(v.union([v.literal('none'), v.literal('preserve-legal')])),
+    v.optional(
+      v.union([
+        v.literal('none'),
+        v.literal('preserve'),
+        v.literal('preserve-legal'),
+      ]),
+    ),
     v.description('Control comments in the output'),
   ),
   target: v.pipe(

--- a/packages/rolldown/tests/fixtures/function/comments/none/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/comments/none/_config.ts
@@ -1,0 +1,16 @@
+import nodePath from 'node:path'
+import { expect } from 'vitest'
+import { defineTest } from 'rolldown-tests'
+
+export default defineTest({
+  config: {
+    output: {
+      comments: 'none',
+    },
+  },
+  afterTest(output) {
+    expect(output.output[0].code).toMatchFileSnapshot(
+      nodePath.join(import.meta.dirname, 'output.snap'),
+    )
+  },
+})

--- a/packages/rolldown/tests/fixtures/function/comments/none/main.js
+++ b/packages/rolldown/tests/fixtures/function/comments/none/main.js
@@ -1,0 +1,26 @@
+//! <script>foo</script>
+export let x
+
+// Normal comments
+console.log('in a') //! Copyright notice 1
+
+console.log('in b') // Normal comments
+
+// console.log('in c')
+
+//! Legal comments1
+/*! Legal comments2 */
+foo;bar;
+
+/**
+ * test
+ */
+export function test() {
+
+}
+
+export default () => {
+  /**
+   * @preserve
+   */
+}

--- a/packages/rolldown/tests/fixtures/function/comments/none/output.snap
+++ b/packages/rolldown/tests/fixtures/function/comments/none/output.snap
@@ -1,0 +1,18 @@
+
+//#region main.js
+let x;
+console.log("in a");
+console.log("in b");
+//! Legal comments1
+/*! Legal comments2 */
+foo;
+bar;
+function test() {}
+var main_default = () => {
+	/**
+	* @preserve
+	*/
+};
+
+//#endregion
+export { main_default as default, test, x };

--- a/packages/rolldown/tests/fixtures/function/comments/preserve-legal/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/comments/preserve-legal/_config.ts
@@ -1,0 +1,17 @@
+import nodePath from 'node:path'
+import { expect } from 'vitest'
+import { defineTest } from 'rolldown-tests'
+
+export default defineTest({
+  config: {
+    input: '../none/main.js',
+    output: {
+      comments: 'preserve-legal',
+    },
+  },
+  afterTest(output) {
+    expect(output.output[0].code).toMatchFileSnapshot(
+      nodePath.join(import.meta.dirname, 'output.snap'),
+    )
+  },
+})

--- a/packages/rolldown/tests/fixtures/function/comments/preserve-legal/output.snap
+++ b/packages/rolldown/tests/fixtures/function/comments/preserve-legal/output.snap
@@ -1,0 +1,18 @@
+
+//#region ../none/main.js
+let x;
+console.log("in a");
+console.log("in b");
+//! Legal comments1
+/*! Legal comments2 */
+foo;
+bar;
+function test() {}
+var main_default = () => {
+	/**
+	* @preserve
+	*/
+};
+
+//#endregion
+export { main_default as default, test, x };

--- a/packages/rolldown/tests/fixtures/function/comments/preserve/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/comments/preserve/_config.ts
@@ -1,0 +1,17 @@
+import nodePath from 'node:path'
+import { expect } from 'vitest'
+import { defineTest } from 'rolldown-tests'
+
+export default defineTest({
+  config: {
+    input: '../none/main.js',
+    output: {
+      comments: 'preserve',
+    },
+  },
+  afterTest(output) {
+    expect(output.output[0].code).toMatchFileSnapshot(
+      nodePath.join(import.meta.dirname, 'output.snap'),
+    )
+  },
+})

--- a/packages/rolldown/tests/fixtures/function/comments/preserve/output.snap
+++ b/packages/rolldown/tests/fixtures/function/comments/preserve/output.snap
@@ -1,0 +1,18 @@
+
+//#region ../none/main.js
+let x;
+console.log("in a");
+console.log("in b");
+//! Legal comments1
+/*! Legal comments2 */
+foo;
+bar;
+function test() {}
+var main_default = () => {
+	/**
+	* @preserve
+	*/
+};
+
+//#endregion
+export { main_default as default, test, x };


### PR DESCRIPTION
### Description

This PR was initially created to address the inconsistency between `preserve-legal` and `Comments::Preserve`.

https://github.com/rolldown/rolldown/blob/f1c8656cd231ddff20ded658665a987a78e41fd6/crates/rolldown_binding/src/utils/normalize_binding_options.rs#L230-L234


Later, I realized that the `preserve` option would be exposed, so I added it to the default options type for `comments`.

https://github.com/rolldown/rolldown/blob/9cd90be46446794693d3f55d6b851bd01bed2847/crates/rolldown_binding/src/types/binding_normalized_options.rs#L234-L237
