### PR TITLE
fix: preserve `chunk.modules` after `generateBundle` mutation

### DIFF
--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -119,25 +119,11 @@ pub struct JsOutputChunk {
   pub preliminary_filename: String,
 }
 
-impl TryFrom<JsOutputChunk> for rolldown_common::OutputChunk {
-  type Error = anyhow::Error;
-
-  fn try_from(chunk: JsOutputChunk) -> Result<Self, Self::Error> {
-    Ok(Self {
-      name: chunk.name.into(),
-      is_entry: chunk.is_entry,
-      is_dynamic_entry: chunk.is_dynamic_entry,
-      facade_module_id: chunk.facade_module_id.map(Into::into),
-      module_ids: chunk.module_ids.into_iter().map(Into::into).collect(),
-      exports: chunk.exports,
-      filename: chunk.filename.into(),
-      modules: chunk.modules.into_iter().map(|(key, value)| (key.into(), value.into())).collect(),
-      imports: chunk.imports.into_iter().map(Into::into).collect(),
-      dynamic_imports: chunk.dynamic_imports.into_iter().map(Into::into).collect(),
-      code: chunk.code,
-      map: chunk.map.map(TryInto::try_into).transpose()?,
-      sourcemap_filename: chunk.sourcemap_filename,
-      preliminary_filename: chunk.preliminary_filename,
-    })
-  }
+pub fn update_output_chunk(
+  chunk: &mut rolldown_common::OutputChunk,
+  js_chunk: JsOutputChunk,
+) -> anyhow::Result<()> {
+  chunk.code = js_chunk.code;
+  chunk.map = js_chunk.map.map(TryInto::try_into).transpose()?;
+  Ok(())
 }

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -77,7 +77,7 @@ pub fn update_outputs(
         rolldown_common::Output::Chunk(old_chunk) => {
           update_output_chunk(old_chunk, chunk)?;
         }
-        _ => {}
+        rolldown_common::Output::Asset(_) => {}
       };
     }
   }

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -1,6 +1,6 @@
 use super::{
   binding_output_asset::{BindingOutputAsset, JsOutputAsset},
-  binding_output_chunk::{BindingOutputChunk, JsOutputChunk},
+  binding_output_chunk::{update_output_chunk, BindingOutputChunk, JsOutputChunk},
 };
 use napi::Env;
 use napi_derive::napi;
@@ -73,7 +73,12 @@ pub fn update_outputs(
 ) -> anyhow::Result<()> {
   for chunk in changed.chunks {
     if let Some(index) = outputs.iter().position(|o| o.filename() == chunk.filename) {
-      outputs[index] = rolldown_common::Output::Chunk(Box::new(chunk.try_into()?));
+      match &mut outputs[index] {
+        rolldown_common::Output::Chunk(old_chunk) => {
+          update_output_chunk(old_chunk, chunk)?;
+        }
+        _ => {}
+      };
     }
   }
   for asset in changed.assets {

--- a/crates/rolldown_binding/src/types/binding_rendered_module.rs
+++ b/crates/rolldown_binding/src/types/binding_rendered_module.rs
@@ -29,12 +29,6 @@ impl From<rolldown_common::RenderedModule> for BindingRenderedModule {
   }
 }
 
-impl From<BindingRenderedModule> for rolldown_common::RenderedModule {
-  fn from(value: BindingRenderedModule) -> Self {
-    value.inner
-  }
-}
-
 impl FromNapiValue for BindingRenderedModule {
   unsafe fn from_napi_value(
     _env: napi::sys::napi_env,

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
@@ -62,5 +62,8 @@ export default defineTest({
     const chunks = getOutputChunk(output)
     expect(chunks.length).toBe(1)
     expect(chunks[0].code).toBe('console.error()')
+    expect(Object.values(chunks[0].modules)[0].code).toBe(
+      '//#region main.js\nconsole.log();\n\n//#endregion',
+    )
   },
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- closes https://github.com/rolldown/rolldown/issues/2992

Assuming bundle mutation is likely only for `code` and `map`, I simplified `update_outputs` to only deal with minimal fields. I'm not sure if this misses some odd edge cases, but I feel this is a reasonable limitation.

Solving this correctly would require copying entire `chunk.modules` back and forth and I felt performance concerns would be bigger for this case at least.