### PR TITLE
feat: expose app format option for hmr prototype

### DIFF
--- a/crates/rolldown/src/ecmascript/format/app.rs
+++ b/crates/rolldown/src/ecmascript/format/app.rs
@@ -1,9 +1,10 @@
+use rolldown_common::{ChunkKind, Module};
 use rolldown_sourcemap::SourceJoiner;
 
 use crate::{ecmascript::ecma_generator::RenderedModuleSources, types::generator::GenerateContext};
 
 pub fn render_app<'code>(
-  _ctx: &GenerateContext<'_>,
+  ctx: &GenerateContext<'_>,
   hashbang: Option<&'code str>,
   banner: Option<&'code str>,
   intro: Option<&'code str>,
@@ -25,13 +26,28 @@ pub fn render_app<'code>(
   }
 
   // chunk content
-  module_sources.iter().for_each(|(_, _, module_render_output)| {
+  module_sources.iter().for_each(|(module_idx, _, module_render_output)| {
     if let Some(emitted_sources) = module_render_output {
-      for source in emitted_sources.as_ref() {
+      source_joiner.append_source(format!(
+        "rolldown_runtime.define('{}',function(require, module, exports){{\n",
+        // Here need to care about virtual module `\0`, the oxc codegen will escape it, so here also escape it
+        ctx.link_output.module_table.modules[*module_idx].stable_id().escape_default()
+      ));
+      for source in emitted_sources.iter() {
         source_joiner.append_source(source);
       }
+      source_joiner.append_source("});".to_string());
     }
   });
+
+  if let ChunkKind::EntryPoint { module: entry_id, .. } = ctx.chunk.kind {
+    if let Module::Normal(entry_module) = &ctx.link_output.module_table.modules[entry_id] {
+      source_joiner.append_source(format!(
+        "rolldown_runtime.require('{}');",
+        entry_module.stable_id.escape_default()
+      ));
+    }
+  }
 
   if let Some(outro) = outro {
     source_joiner.append_source(outro);

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -67,7 +67,7 @@ pub struct BindingOutputOptions {
   #[serde(skip_deserializing)]
   #[napi(ts_type = "(chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>")]
   pub footer: Option<AddonOutputOption>,
-  #[napi(ts_type = "'es' | 'cjs' | 'iife' | 'umd'")]
+  #[napi(ts_type = "'es' | 'cjs' | 'iife' | 'umd' | 'app'")]
   pub format: Option<String>,
   // freeze: boolean;
   // generatedCode: NormalizedGeneratedCodeOptions;

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -101,6 +101,7 @@ pub struct BindingTransformPluginConfig {
   pub include: Option<Vec<BindingStringOrRegex>>,
   pub exclude: Option<Vec<BindingStringOrRegex>>,
   pub jsx_inject: Option<String>,
+  pub react_refresh: Option<bool>,
   pub targets: Option<String>,
 }
 
@@ -294,6 +295,7 @@ impl TryFrom<BindingTransformPluginConfig> for TransformPlugin {
       include: value.include.map(bindingify_string_or_regex_array).transpose()?.unwrap_or_default(),
       exclude: value.exclude.map(bindingify_string_or_regex_array).transpose()?.unwrap_or_default(),
       jsx_inject: value.jsx_inject,
+      react_refresh: value.react_refresh.unwrap_or_default(),
       targets: value.targets,
     })
   }

--- a/crates/rolldown_plugin_transform/src/lib.rs
+++ b/crates/rolldown_plugin_transform/src/lib.rs
@@ -2,7 +2,7 @@ use oxc::{
   codegen::{CodeGenerator, CodegenOptions, CodegenReturn},
   semantic::SemanticBuilder,
   span::SourceType,
-  transformer::{TransformOptions, Transformer},
+  transformer::{ReactRefreshOptions, TransformOptions, Transformer},
 };
 use rolldown_common::ModuleType;
 use rolldown_ecmascript::EcmaCompiler;
@@ -19,6 +19,7 @@ pub struct TransformPlugin {
   pub include: Vec<StringOrRegex>,
   pub exclude: Vec<StringOrRegex>,
   pub jsx_inject: Option<String>,
+  pub react_refresh: bool,
 
   // TODO: support specific transform options. Firstly we can use `targets` but we'd better allowing user to pass more options.
   pub targets: Option<String>,
@@ -70,6 +71,9 @@ impl Plugin for TransformPlugin {
       match args.module_type {
         ModuleType::Jsx | ModuleType::Tsx => {
           transformer_options.jsx.jsx_plugin = true;
+          if self.react_refresh {
+            transformer_options.jsx.refresh = Some(ReactRefreshOptions::default());
+          }
         }
         ModuleType::Ts => {}
         _ => {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -396,7 +396,7 @@ export interface BindingOutputOptions {
   extend?: boolean
   externalLiveBindings?: boolean
   footer?: (chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>
-  format?: 'es' | 'cjs' | 'iife' | 'umd'
+  format?: 'es' | 'cjs' | 'iife' | 'umd' | 'app'
   globals?: Record<string, string> | ((name: string) => string)
   hashCharacters?: 'base64' | 'base36' | 'hex'
   inlineDynamicImports?: boolean

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -524,6 +524,7 @@ export interface BindingTransformPluginConfig {
   include?: Array<BindingStringOrRegex>
   exclude?: Array<BindingStringOrRegex>
   jsxInject?: string
+  reactRefresh?: boolean
   targets?: string
 }
 

--- a/packages/rolldown/src/builtin-plugin/transform-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/transform-plugin.ts
@@ -20,10 +20,9 @@ function normalizeEcmaTransformPluginConfig(
     return undefined
   }
   let normalizedConfig: BindingTransformPluginConfig = {
-    jsxInject: config?.jsxInject,
+    ...config,
     exclude: normalizedStringOrRegex(config.exclude),
     include: normalizedStringOrRegex(config.include),
-    targets: config.targets,
   }
 
   return normalizedConfig

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -14,7 +14,7 @@ export type ModuleFormat =
   | 'commonjs'
   | 'iife'
   | 'umd'
-  | 'app'
+  | 'experimental-app'
 
 export type AddonFunction = (chunk: RenderedChunk) => string | Promise<string>
 

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -14,6 +14,7 @@ export type ModuleFormat =
   | 'commonjs'
   | 'iife'
   | 'umd'
+  | 'app'
 
 export type AddonFunction = (chunk: RenderedChunk) => string | Promise<string>
 

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -92,6 +92,9 @@ function bindingifyFormat(
     case 'umd': {
       return 'umd'
     }
+    case 'app': {
+      return 'app'
+    }
     default:
       unimplemented(`output.format: ${format}`)
   }

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -92,7 +92,7 @@ function bindingifyFormat(
     case 'umd': {
       return 'umd'
     }
-    case 'app': {
+    case 'experimental-app': {
       return 'app'
     }
     default:


### PR DESCRIPTION
### Description

Currently I'm trying a different approach from hmr-poc branch for implementing hmr. For this approach, for now I only need isolating module finalizer logic, so exposing current app format is sufficient to make prototype as in https://github.com/hi-ogawa/vite/pull/6. 

Since this PR's change is fairly minimal, I'm hoping that we can merge this to main, so that I can experiment further on the nightly release and iterate on it.

---

For the context, the idea I'm exploring is to give up `HmrModuleLoader` for now as I see some limitations (see  https://github.com/rolldown/rolldown/issues/2866), but instead, always do a full build and extract hmr chunk by comparing `chunk.modules` between two builds, which is fortunately available for js api.