### PR TITLE
refactor(rust): remove unproper usage related to `ModuleId`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,6 +2568,7 @@ name = "rolldown_binding"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arcstr",
  "async-channel",
  "dashmap 6.1.0",
  "derive_more",
@@ -2795,6 +2796,7 @@ dependencies = [
 name = "rolldown_plugin_manifest"
 version = "0.1.0"
 dependencies = [
+ "arcstr",
  "rolldown_common",
  "rolldown_plugin",
  "rustc-hash",

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -95,7 +95,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
   fn visit_for_of_statement(&mut self, it: &ast::ForOfStatement<'ast>) {
     if it.r#await && self.is_top_level() && !self.options.format.keep_esm_import_export_syntax() {
       self.result.errors.push(BuildDiagnostic::unsupported_feature(
-        self.file_path.as_str().into(),
+        self.id.resource_id().clone(),
         self.source.clone(),
         it.span(),
         format!(
@@ -111,7 +111,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
   fn visit_await_expression(&mut self, it: &ast::AwaitExpression<'ast>) {
     if !self.options.format.keep_esm_import_export_syntax() && self.is_top_level() {
       self.result.errors.push(BuildDiagnostic::unsupported_feature(
-        self.file_path.as_str().into(),
+        self.id.resource_id().clone(),
         self.source.clone(),
         it.span(),
         format!(
@@ -288,12 +288,8 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
             // improve treeshaking performance. https://github.com/evanw/esbuild/blob/360d47230813e67d0312ad754cad2b6ee09b151b/internal/js_ast/js_ast.go#L1288-L1291
             self.result.has_eval = true;
             self.result.warnings.push(
-              BuildDiagnostic::eval(
-                self.file_path.to_string(),
-                self.source.clone(),
-                ident_ref.span,
-              )
-              .with_severity_warning(),
+              BuildDiagnostic::eval(self.id.to_string(), self.source.clone(), ident_ref.span)
+                .with_severity_warning(),
             );
           }
           "require" => {

--- a/crates/rolldown/src/ast_scanner/import_assign_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/import_assign_analyzer.rs
@@ -23,7 +23,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       if is_namespace {
         if let Some((span, name)) = self.get_span_if_namespace_specifier_updated() {
           self.result.errors.push(BuildDiagnostic::assign_to_import(
-            self.file_path.inner().clone(),
+            self.id.resource_id().clone(),
             self.source.clone(),
             span,
             name.into(),
@@ -34,7 +34,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       let reference_flag = self.scopes.references[ident.reference_id()].flags();
       if reference_flag.is_write() {
         self.result.errors.push(BuildDiagnostic::assign_to_import(
-          self.file_path.inner().clone(),
+          self.id.resource_id().clone(),
           self.source.clone(),
           ident.span,
           ident.name.as_str().into(),

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -75,7 +75,7 @@ pub struct AstScanner<'me, 'ast> {
   idx: ModuleIdx,
   source: &'me ArcStr,
   module_type: ModuleDefFormat,
-  file_path: &'me ModuleId,
+  id: &'me ModuleId,
   scopes: &'me AstScopes,
   comments: &'me oxc::allocator::Vec<'me, Comment>,
   current_stmt_info: StmtInfo,
@@ -168,7 +168,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       cjs_module_ident: None,
       cjs_exports_ident: None,
       source,
-      file_path,
+      id: file_path,
       comments,
       ast_usage: EcmaModuleAstUsage::empty(),
       cur_class_decl_and_symbol_referenced_ids: None,
@@ -201,7 +201,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       if let Some(start) = self.cjs_module_ident {
         self.result.warnings.push(
           BuildDiagnostic::commonjs_variable_in_esm(
-            self.file_path.to_string(),
+            self.id.to_string(),
             self.source.clone(),
             // SAFETY: we checked at the beginning
             self.esm_export_keyword.expect("should have start offset"),
@@ -213,7 +213,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       if let Some(start) = self.cjs_exports_ident {
         self.result.warnings.push(
           BuildDiagnostic::commonjs_variable_in_esm(
-            self.file_path.to_string(),
+            self.id.to_string(),
             self.source.clone(),
             // SAFETY: we checked at the beginning
             self.esm_export_keyword.expect("should have start offset"),
@@ -504,7 +504,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
           self.add_local_export(spec.exported.name().as_str(), local_symbol_id, spec.span);
         } else {
           self.result.errors.push(BuildDiagnostic::export_undefined_variable(
-            self.file_path.to_string(),
+            self.id.to_string(),
             self.source.clone(),
             spec.local.span(),
             ArcStr::from(spec.local.name().as_str()),
@@ -661,7 +661,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       let symbol_id = reference.symbol_id()?;
       if self.result.symbol_ref_db.get_flags(symbol_id).is_const_variable() {
         self.result.errors.push(BuildDiagnostic::forbid_const_assign(
-          self.file_path.to_string(),
+          self.id.to_string(),
           self.source.clone(),
           self.result.symbol_ref_db.get_name(symbol_id).into(),
           self.result.symbol_ref_db.get_span(symbol_id),

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -288,7 +288,7 @@ impl LinkStage<'_> {
                       );
                       warnings.push(
                         BuildDiagnostic::import_is_undefined(
-                          ArcStr::from(module.id.as_str()),
+                          module.id.resource_id().clone(),
                           module.source.clone(),
                           member_expr_ref.span,
                           ArcStr::from(name.as_str()),

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -3,7 +3,7 @@ use std::{hash::Hash, mem};
 use arcstr::ArcStr;
 use itertools::Itertools;
 use oxc_index::{index_vec, IndexVec};
-use rolldown_common::{AssetIdx, HashCharacters, InstantiationKind, ModuleId, StrOrBytes};
+use rolldown_common::{AssetIdx, HashCharacters, InstantiationKind, StrOrBytes};
 #[cfg(not(target_family = "wasm"))]
 use rolldown_utils::rayon::IndexedParallelIterator;
 use rolldown_utils::{
@@ -106,7 +106,7 @@ pub fn finalize_assets(
     .map(|(asset_idx, mut asset)| {
       let asset_idx = AssetIdx::from(asset_idx);
 
-      let filename: ModuleId = replace_placeholder_with_hash(
+      let filename: ArcStr = replace_placeholder_with_hash(
         asset.preliminary_filename.as_str(),
         &final_hashes_by_placeholder,
       )

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -16,6 +16,7 @@ doctest    = false
 
 [dependencies]
 anyhow                                  = { workspace = true }
+arcstr                                  = { workspace = true }
 async-channel                           = { workspace = true }
 dashmap                                 = { workspace = true }
 derive_more                             = { workspace = true }

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use arcstr::ArcStr;
 use napi_derive::napi;
 use rolldown_sourcemap::SourceMap;
 
@@ -59,12 +60,12 @@ impl BindingOutputChunk {
 
   #[napi(getter)]
   pub fn imports(&self) -> Vec<String> {
-    self.inner.imports.iter().map(|x| x.to_string()).collect()
+    self.inner.imports.iter().map(ArcStr::to_string).collect()
   }
 
   #[napi(getter)]
   pub fn dynamic_imports(&self) -> Vec<String> {
-    self.inner.dynamic_imports.iter().map(|x| x.to_string()).collect()
+    self.inner.dynamic_imports.iter().map(ArcStr::to_string).collect()
   }
 
   // OutputChunk

--- a/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
@@ -1,3 +1,4 @@
+use arcstr::ArcStr;
 use napi::{
   bindgen_prelude::ToNapiValue,
   sys::{napi_env, napi_value},
@@ -40,8 +41,8 @@ impl From<rolldown_common::RollupRenderedChunk> for RenderedChunk {
       exports: value.exports,
       file_name: value.filename.to_string(),
       modules: BindingChunkModules::new(value.modules),
-      imports: value.imports.iter().map(|x| x.to_string()).collect(),
-      dynamic_imports: value.dynamic_imports.iter().map(|x| x.to_string()).collect(),
+      imports: value.imports.iter().map(ArcStr::to_string).collect(),
+      dynamic_imports: value.dynamic_imports.iter().map(ArcStr::to_string).collect(),
     }
   }
 }

--- a/crates/rolldown_common/src/chunk/types/preliminary_filename.rs
+++ b/crates/rolldown_common/src/chunk/types/preliminary_filename.rs
@@ -1,12 +1,12 @@
 use std::ops::Deref;
 
-use crate::ModuleId;
+use arcstr::ArcStr;
 
 #[derive(Debug, Clone)]
 /// Represents a filename that might contains hash placeholder.
 pub struct PreliminaryFilename {
   /// Might contains preliminary hash
-  filename: ModuleId,
+  filename: ArcStr,
   /// Something like `!~{abcd}~`
   hash_placeholder: Option<String>,
 }
@@ -22,7 +22,7 @@ impl PreliminaryFilename {
 }
 
 impl Deref for PreliminaryFilename {
-  type Target = ModuleId;
+  type Target = ArcStr;
 
   fn deref(&self) -> &Self::Target {
     &self.filename

--- a/crates/rolldown_common/src/types/module_id.rs
+++ b/crates/rolldown_common/src/types/module_id.rs
@@ -8,29 +8,28 @@ use sugar_path::SugarPath;
 /// - It will be used to identify the module in the whole bundle.
 /// - Users could stored the `ModuleId` to track the module in different stages/hooks.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
-pub struct ModuleId(ArcStr);
+pub struct ModuleId {
+  // Id that rolldown uses to call `read_to_string` or `read` to get the content of the module.
+  resource_id: ArcStr,
+}
 
 impl ModuleId {
   pub fn new(value: impl Into<ArcStr>) -> Self {
-    Self(value.into())
+    Self { resource_id: value.into() }
   }
 
-  pub fn inner(&self) -> &ArcStr {
-    &self.0
-  }
-
-  pub fn as_str(&self) -> &str {
-    &self.0
+  pub fn resource_id(&self) -> &ArcStr {
+    &self.resource_id
   }
 
   pub fn stabilize(&self, cwd: &Path) -> String {
-    stabilize_module_id(&self.0, cwd)
+    stabilize_module_id(&self.resource_id, cwd)
   }
 }
 
 impl AsRef<str> for ModuleId {
   fn as_ref(&self) -> &str {
-    &self.0
+    &self.resource_id
   }
 }
 
@@ -38,7 +37,7 @@ impl std::ops::Deref for ModuleId {
   type Target = str;
 
   fn deref(&self) -> &Self::Target {
-    &self.0
+    &self.resource_id
   }
 }
 
@@ -50,13 +49,13 @@ impl From<String> for ModuleId {
 
 impl From<ArcStr> for ModuleId {
   fn from(value: ArcStr) -> Self {
-    Self(value)
+    Self::new(value)
   }
 }
 
 impl ModuleId {
   pub fn relative_path(&self, root: impl AsRef<Path>) -> PathBuf {
-    let path = self.0.as_path();
+    let path = self.resource_id.as_path();
     path.relative(root)
   }
 }

--- a/crates/rolldown_common/src/types/output_chunk.rs
+++ b/crates/rolldown_common/src/types/output_chunk.rs
@@ -16,10 +16,10 @@ pub struct OutputChunk {
   pub module_ids: Vec<ModuleId>,
   pub exports: Vec<String>,
   // RenderedChunk
-  pub filename: ModuleId,
+  pub filename: ArcStr,
   pub modules: FxHashMap<ModuleId, RenderedModule>,
-  pub imports: Vec<ModuleId>,
-  pub dynamic_imports: Vec<ModuleId>,
+  pub imports: Vec<ArcStr>,
+  pub dynamic_imports: Vec<ArcStr>,
   // OutputChunk
   pub code: String,
   pub map: Option<SourceMap>,

--- a/crates/rolldown_common/src/types/rollup_rendered_chunk.rs
+++ b/crates/rolldown_common/src/types/rollup_rendered_chunk.rs
@@ -14,9 +14,9 @@ pub struct RollupRenderedChunk {
   pub module_ids: Vec<ModuleId>,
   pub exports: Vec<String>,
   // RenderedChunk
-  pub filename: ModuleId,
+  pub filename: ArcStr,
   pub modules: FxHashMap<ModuleId, RenderedModule>,
-  pub imports: Vec<ModuleId>,
-  pub dynamic_imports: Vec<ModuleId>,
+  pub imports: Vec<ArcStr>,
+  pub dynamic_imports: Vec<ArcStr>,
   pub debug_id: u128,
 }

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -103,7 +103,7 @@ impl PluginDriver {
   }
 
   pub fn set_module_info(&self, module_id: &ModuleId, module_info: Arc<ModuleInfo>) {
-    self.modules.insert(module_id.as_str().into(), module_info);
+    self.modules.insert(module_id.resource_id().into(), module_info);
   }
 
   pub async fn set_context_load_modules_tx(
@@ -115,7 +115,7 @@ impl PluginDriver {
   }
 
   pub async fn mark_context_load_modules_loaded(&self, module_id: &ModuleId) -> anyhow::Result<()> {
-    if let Some((_, callback)) = self.context_load_modules.remove(module_id.as_str()) {
+    if let Some((_, callback)) = self.context_load_modules.remove(module_id.resource_id()) {
       callback().await?;
     }
     Ok(())

--- a/crates/rolldown_plugin_manifest/Cargo.toml
+++ b/crates/rolldown_plugin_manifest/Cargo.toml
@@ -12,6 +12,7 @@ version              = "0.1.0"
 workspace = true
 
 [dependencies]
+arcstr          = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
 rustc-hash      = { workspace = true }

--- a/crates/rolldown_plugin_manifest/src/lib.rs
+++ b/crates/rolldown_plugin_manifest/src/lib.rs
@@ -1,4 +1,5 @@
-use rolldown_common::{EmittedAsset, ModuleId, Output, OutputAsset, OutputChunk};
+use arcstr::ArcStr;
+use rolldown_common::{EmittedAsset, Output, OutputAsset, OutputChunk};
 use rolldown_plugin::{HookNoopReturn, Plugin, PluginContext};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
@@ -149,7 +150,7 @@ impl ManifestPlugin {
   fn get_chunk_name(&self, chunk: &OutputChunk) -> String {
     get_chunk_original_file_name(chunk, &self.config.root)
   }
-  fn get_internal_imports(&self, bundle: &Vec<Output>, imports: &Vec<ModuleId>) -> Vec<String> {
+  fn get_internal_imports(&self, bundle: &Vec<Output>, imports: &Vec<ArcStr>) -> Vec<String> {
     let mut filtered_imports = vec![];
     for file in imports {
       for chunk in bundle {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Part of https://github.com/rolldown/rolldown/issues/3000.

`ModuleId` is so far made of by `resourceId` only. But we will laterly add `ModuleType` as part of it in #3000.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
