### PR TITLE
fix: fix `\0` in `JsChangedOutputs.chunks`

### DIFF
--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -166,15 +166,14 @@ export function collectChangedBundle(
         name: item.name,
       })
     } else {
+      // only `code` and `map` are allowed to be mutated on js
       chunks.push({
         code: item.code,
         filename: item.fileName,
         name: item.name,
         isEntry: item.isEntry,
         exports: item.exports,
-        modules: Object.fromEntries(
-          Object.entries(item.modules).map(([key, _]) => [key, {} as any]),
-        ),
+        modules: {},
         imports: item.imports,
         dynamicImports: item.dynamicImports,
         facadeModuleId: item.facadeModuleId || undefined,

--- a/packages/rolldown/tests/fixtures/misc/virtual/chunk-modules/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/virtual/chunk-modules/_config.ts
@@ -1,5 +1,5 @@
 import { defineTest } from '@tests'
-import { expect, vi } from 'vitest'
+import { expect, vi, assert } from 'vitest'
 
 const fn = vi.fn()
 
@@ -29,6 +29,11 @@ export default defineTest({
         banner(chunk) {
           fn('plugin.banner', chunk.modules['\0module'].code)
           return ''
+        },
+        generateBundle(_, bundle) {
+          const chunk = bundle['main.js']
+          assert(chunk.type === 'chunk')
+          chunk.code += '\n// edit!\n'
         },
       },
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,12 +109,6 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rolldown
 
-  examples/repro:
-    devDependencies:
-      rolldown:
-        specifier: workspace:*
-        version: link:../../packages/rolldown
-
   examples/rollup-plugin-esbuild:
     dependencies:
       rollup-plugin-esbuild:


### PR DESCRIPTION
### Description

After https://github.com/rolldown/rolldown/pull/2991, I now get a following error when mutating a bundle with `chunk.modules` including `\0`:

```
Build failed with 1 error:
Error: nul byte found in provided data at position: 0 on JsOutputChunk.modules on JsChangedOutputs.chunks
```

Since we don't consider mutating `chunk.modules` as per https://github.com/rolldown/rolldown/pull/2993, we can pass back an empty object, so `\0` won't get triggered when moving `JsOutputChunk` back to rust.