### PR TITLE
fix: allow mutating `chunk.imports` and more

### DIFF
--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -122,5 +122,7 @@ pub fn update_output_chunk(
 ) -> anyhow::Result<()> {
   chunk.code = js_chunk.code;
   chunk.map = js_chunk.map.map(TryInto::try_into).transpose()?;
+  chunk.imports = js_chunk.imports.into_iter().map(Into::into).collect();
+  chunk.dynamic_imports = js_chunk.dynamic_imports.into_iter().map(Into::into).collect();
   Ok(())
 }

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -166,7 +166,7 @@ export function collectChangedBundle(
         name: item.name,
       })
     } else {
-      // not all properties are allowed to be mutated on js side
+      // not all properties modifications are reflected to rust side
       chunks.push({
         code: item.code,
         filename: item.fileName,

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -166,7 +166,7 @@ export function collectChangedBundle(
         name: item.name,
       })
     } else {
-      // only `code` and `map` are allowed to be mutated on js
+      // not all properties are allowed to be mutated on js side
       chunks.push({
         code: item.code,
         filename: item.fileName,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://github.com/rolldown/rolldown/pull/2993 made a regression in rolldown/vite since it mutates `chunk.imports` https://github.com/vitejs/vite/blob/8f0a9dcff112c866d9aa911647fd3cf9adc50bf1/packages/vite/src/node/plugins/css.ts#L1011-L1029 and this test case failed https://github.com/vitejs/vite/blob/8f0a9dcff112c866d9aa911647fd3cf9adc50bf1/playground/html/__tests__/html.spec.ts#L186-L188

I confirmed the test passed locally with this PR.