### PR TITLE
ci: add node-version input to CI workflows for better version management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,11 @@ jobs:
     strategy:
       matrix:
         target: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [20]
     uses: ./.github/workflows/reusable-node-test.yml
     with:
       os: ${{ matrix.target }}
+      node-version: ${{ matrix.node-version }}
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}
 
   wasi-test:

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -9,6 +9,9 @@ on:
       changed:
         required: true
         type: boolean
+      node-version:
+        required: true
+        type: string
 
 jobs:
   run:
@@ -23,7 +26,7 @@ jobs:
         with:
           submodules: true # Pull submodules for additional files
 
-      - name: Setup Node
+      - name: Setup Node for Development
         uses: ./.github/actions/setup-node
 
       - name: Setup Rust
@@ -37,6 +40,11 @@ jobs:
 
       - name: Type Check
         run: pnpm type-check
+
+      - name: Setup Node for Testing
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: ${{ inputs.node-version }}
 
       - name: Node Test
         run: pnpm run --recursive --parallel --filter=!rollup-tests test


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Prepare for enabling CI for node18. Part of https://github.com/rolldown/rolldown/issues/1378.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
