### PR TITLE
fix: avoid one JsError into_unknown twice

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_error.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_error.rs
@@ -20,7 +20,7 @@ impl BindingHookError {
   }
 
   #[napi(getter)]
-  pub fn errors(&self, env: Env) -> napi::Result<Vec<napi::JsUnknown>> {
+  pub fn errors(&self, env: Env) -> napi::Result<Vec<napi::Either<napi::JsError, napi::JsObject>>> {
     self
       .errors
       .iter()

--- a/crates/rolldown_binding/src/types/watcher.rs
+++ b/crates/rolldown_binding/src/types/watcher.rs
@@ -111,7 +111,10 @@ impl BindingWatcherEvent {
   }
 
   #[napi]
-  pub fn errors(&mut self, env: Env) -> napi::Result<Vec<napi::JsUnknown>> {
+  pub fn errors(
+    &mut self,
+    env: Env,
+  ) -> napi::Result<Vec<napi::Either<napi::JsError, napi::JsObject>>> {
     if let rolldown_common::WatcherEvent::Event(rolldown_common::BundleEvent::Error(
       rolldown_common::OutputsDiagnostics { diagnostics, cwd },
     )) = &mut self.inner

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -16,7 +16,7 @@ export declare class BindingCallableBuiltinPlugin {
 }
 
 export declare class BindingHookError {
-  get errors(): Array<unknown>
+  get errors(): Array<Error | object>
 }
 
 export declare class BindingLog {
@@ -92,7 +92,7 @@ export declare class BindingOutputChunk {
 export declare class BindingOutputs {
   get chunks(): Array<BindingOutputChunk>
   get assets(): Array<BindingOutputAsset>
-  get errors(): Array<unknown>
+  get errors(): Array<Error | object>
 }
 
 export declare class BindingPluginContext {
@@ -129,7 +129,7 @@ export declare class BindingWatcherEvent {
   watchChangeData(): BindingWatcherChangeData
   bundleEndData(): BindingBundleEndEventData
   bundleEventKind(): string
-  errors(): Array<unknown>
+  errors(): Array<Error | object>
 }
 
 export declare class Bundler {

--- a/packages/rolldown/src/utils/error.ts
+++ b/packages/rolldown/src/utils/error.ts
@@ -1,6 +1,6 @@
 import { RollupError } from '../rollup'
 
-export function normalizeErrors(rawErrors: unknown[]) {
+export function normalizeErrors(rawErrors: (object | Error)[]) {
   const errors = rawErrors.map((e) =>
     e instanceof Error
       ? e


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

related https://github.com/rolldown/rolldown/pull/3009 tests failed. The `JsError::into_unknown` is not safe if called twice, it will cause segment fault at https://github.com/napi-rs/napi-rs/blob/main/crates/napi/src/error.rs#L245. So here using `Either` instead of `JsUnknown`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
