### PR TITLE
chore: improve cli bundle command

### DIFF
--- a/packages/rolldown/src/cli/utils.ts
+++ b/packages/rolldown/src/cli/utils.ts
@@ -1,5 +1,5 @@
-import { pathToFileURL } from 'node:url'
 import nodePath from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { createConsola } from 'consola'
 import type { ConfigExport } from '../types/config-export'
 


### PR DESCRIPTION
### Description

We now support `output.file`, so I have made improvements to it and aligned it with `rollup`.

https://github.com/rolldown/rolldown/blob/176666fa328cf77657addaa04787061e9ac836b1/packages/rolldown/src/cli/commands/bundle.ts#L33