### PR TITLE
fix: dynamic import tree-shaking boundary issue caused by object rest pattern

### DIFF
--- a/crates/rolldown/src/ast_scanner/dynamic_import.rs
+++ b/crates/rolldown/src/ast_scanner/dynamic_import.rs
@@ -162,6 +162,26 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
             set.insert(binding_name.into());
           }
         }
+
+        if let Some(rest) = &obj.rest {
+          match &rest.argument.kind {
+            ast::BindingPatternKind::BindingIdentifier(id) => {
+              let symbol_id = id.symbol_id();
+              self
+                .dynamic_import_usage_info
+                .dynamic_import_binding_to_import_record_id
+                .insert(symbol_id, import_record_id);
+              self
+                .dynamic_import_usage_info
+                .dynamic_import_binding_reference_id
+                .extend(self.scopes.resolved_references[symbol_id].iter());
+            }
+            // If the rest argument is not a BindingIdentifier, this is an unexpected case
+            // because '...' must be followed by an identifier in declaration contexts.
+            _ => unreachable!(),
+          }
+        }
+
         return Some(set);
       }
       ast::BindingPatternKind::ArrayPattern(_) | ast::BindingPatternKind::AssignmentPattern(_) => {

--- a/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_then/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_then/artifacts.snap
@@ -8,6 +8,10 @@ snapshot_kind: text
 
 ```js
 
+//#region a.js
+const other = "other";
+
+//#endregion
 //#region a2.js
 const thing = "thing";
 
@@ -16,14 +20,18 @@ const thing = "thing";
 var foo = "foo";
 
 //#endregion
-export { foo, thing };
+export { foo, other, thing };
 ```
 ## main.js
 
 ```js
 
 //#region main.js
-import("./lib.js").then((ns) => [ns.foo, ns.thing]);
+import("./lib.js").then(({ foo, thing,...reset }) => [
+	foo,
+	thing,
+	reset.other
+]);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_then/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_then/artifacts.snap
@@ -27,11 +27,8 @@ export { foo, other, thing };
 ```js
 
 //#region main.js
-import("./lib.js").then(({ foo, thing,...reset }) => [
-	foo,
-	thing,
-	reset.other
-]);
+import("./lib.js").then((ns) => [ns.foo, ns.thing]);
+import("./lib.js").then(({ ...rest }) => rest.other);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_then/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_then/main.js
@@ -1,3 +1,3 @@
 // copy some tests from https://github.com/parcel-bundler/parcel/pull/5367/files
 // license: https://github.com/parcel-bundler/parcel/blob/a53f8f3ba1025c7ea8653e9719e0a61ef9717079/LICENSE
-import("./lib.js").then((ns) => [ns.foo, ns.thing]);
+import("./lib.js").then(({ foo, thing, ...reset }) => [foo, thing, reset.other]);

--- a/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_then/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_then/main.js
@@ -1,3 +1,4 @@
 // copy some tests from https://github.com/parcel-bundler/parcel/pull/5367/files
 // license: https://github.com/parcel-bundler/parcel/blob/a53f8f3ba1025c7ea8653e9719e0a61ef9717079/LICENSE
-import("./lib.js").then(({ foo, thing, ...reset }) => [foo, thing, reset.other]);
+import("./lib.js").then((ns) => [ns.foo, ns.thing]);
+import("./lib.js").then(({ ...rest }) => rest.other);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5199,8 +5199,8 @@ snapshot_kind: text
 
 # tests/rolldown/tree_shaking/dynamic_import_then
 
-- main-!~{000}~.js => main-DPq_p8ej.js
-- lib-!~{001}~.js => lib-D53kxRc8.js
+- main-!~{000}~.js => main-Bo7rYtyU.js
+- lib-!~{001}~.js => lib-DstV67NW.js
 
 # tests/rolldown/tree_shaking/dynamic_import_then_destructur
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5199,7 +5199,7 @@ snapshot_kind: text
 
 # tests/rolldown/tree_shaking/dynamic_import_then
 
-- main-!~{000}~.js => main-Bo7rYtyU.js
+- main-!~{000}~.js => main-Cqdz9-NE.js
 - lib-!~{001}~.js => lib-DstV67NW.js
 
 # tests/rolldown/tree_shaking/dynamic_import_then_destructur


### PR DESCRIPTION
### Description

Encountered this issue while attempting to handle advanced patterns.

https://github.com/rolldown/rolldown/blob/5d0ff351bffaab3da5077615553470c10d0699b4/crates/rolldown/src/ast_scanner/dynamic_import.rs#L188

Before this fix, even though we used the `rest` in the scope, the corresponding import would still be removed. @IWANABETHATGUY  cc