### PR TITLE
feat(rolldown_plugin_transform): support both target & browserslist

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -103,7 +103,8 @@ pub struct BindingTransformPluginConfig {
   pub exclude: Option<Vec<BindingStringOrRegex>>,
   pub jsx_inject: Option<String>,
   pub react_refresh: Option<bool>,
-  pub targets: Option<String>,
+  pub target: Option<String>,
+  pub browserslist: Option<String>,
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
@@ -308,7 +309,8 @@ impl TryFrom<BindingTransformPluginConfig> for TransformPlugin {
       exclude: value.exclude.map(bindingify_string_or_regex_array).transpose()?.unwrap_or_default(),
       jsx_inject: value.jsx_inject,
       react_refresh: value.react_refresh.unwrap_or_default(),
-      targets: value.targets,
+      target: value.target,
+      browserslist: value.browserslist,
     })
   }
 }

--- a/crates/rolldown_plugin_transform/src/lib.rs
+++ b/crates/rolldown_plugin_transform/src/lib.rs
@@ -21,6 +21,7 @@ pub struct TransformPlugin {
   pub jsx_inject: Option<String>,
   pub react_refresh: bool,
 
+  // TODO: support specific transform options. Firstly we can use `target` & `browserslist` but we'd better allowing user to pass more options.
   pub target: Option<String>,
   pub browserslist: Option<String>,
 }

--- a/crates/rolldown_plugin_transform/src/lib.rs
+++ b/crates/rolldown_plugin_transform/src/lib.rs
@@ -61,16 +61,15 @@ impl Plugin for TransformPlugin {
     };
 
     let env = if self.target.is_some() && self.browserslist.is_some() {
-      return Err(anyhow::anyhow!(
-        "Cannot specify both `target` and `browserslist` at the same time"
-      ));
+      Err("Cannot specify both `target` and `browserslist` at the same time".to_string())
     } else if let Some(target) = &self.target {
-      EnvOptions::from_target(target).expect("Failed to create transform options")
+      EnvOptions::from_target(target)
     } else if let Some(browserslist) = &self.browserslist {
-      EnvOptions::from_browserslist_query(browserslist).expect("Failed to create transform options")
+      EnvOptions::from_browserslist_query(browserslist)
     } else {
-      EnvOptions::default()
-    };
+      Ok(EnvOptions::default())
+    }
+    .map_err(|e| anyhow::anyhow!(e))?;
 
     let ret = ast.program.with_mut(move |fields| {
       let mut transformer_options = TransformOptions { env, ..TransformOptions::default() };

--- a/crates/rolldown_plugin_transform/src/lib.rs
+++ b/crates/rolldown_plugin_transform/src/lib.rs
@@ -21,8 +21,8 @@ pub struct TransformPlugin {
   pub jsx_inject: Option<String>,
   pub react_refresh: bool,
 
-  // TODO: support specific transform options. Firstly we can use `targets` but we'd better allowing user to pass more options.
-  pub targets: Option<String>,
+  pub target: Option<String>,
+  pub browserslist: Option<String>,
 }
 
 /// only handle ecma like syntax, `jsx`,`tsx`,`ts`
@@ -58,16 +58,21 @@ impl Plugin for TransformPlugin {
         return Err(anyhow::format_err!("Error occurred when parsing {}\n: {:?}", args.id, errs));
       }
     };
+
+    let env = if self.target.is_some() && self.browserslist.is_some() {
+      return Err(anyhow::anyhow!(
+        "Cannot specify both `target` and `browserslist` at the same time"
+      ));
+    } else if let Some(target) = &self.target {
+      EnvOptions::from_target(target).expect("Failed to create transform options")
+    } else if let Some(browserslist) = &self.browserslist {
+      EnvOptions::from_browserslist_query(browserslist).expect("Failed to create transform options")
+    } else {
+      EnvOptions::default()
+    };
+
     let ret = ast.program.with_mut(move |fields| {
-      let mut transformer_options = if let Some(targets) = &self.targets {
-        TransformOptions {
-          env: EnvOptions::from_browserslist_query(targets)
-            .expect("Failed to create transform options"),
-          ..TransformOptions::default()
-        }
-      } else {
-        TransformOptions::default()
-      };
+      let mut transformer_options = TransformOptions { env, ..TransformOptions::default() };
       match args.module_type {
         ModuleType::Jsx | ModuleType::Tsx => {
           transformer_options.jsx.jsx_plugin = true;
@@ -136,6 +141,6 @@ impl TransformPlugin {
   }
 
   pub fn from_targets(targets: Option<String>) -> Self {
-    Self { targets, ..Default::default() }
+    Self { target: targets, ..Default::default() }
   }
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -527,7 +527,8 @@ export interface BindingTransformPluginConfig {
   exclude?: Array<BindingStringOrRegex>
   jsxInject?: string
   reactRefresh?: boolean
-  targets?: string
+  target?: string
+  browserslist?: string
 }
 
 export interface BindingTreeshake {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/targets/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/targets/_config.ts
@@ -8,7 +8,7 @@ export default defineTest({
     plugins: [
       transformPlugin({
         exclude: ['node_modules/**'],
-        targets: 'chrome 49',
+        browserslist: 'chrome 49',
       }),
     ],
   },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Support both `target` & `browserslist`, and it's required by downstream https://github.com/sxzz/tsdown