### PR TITLE
chore: remove vitest ambient types

### DIFF
--- a/packages/rolldown/tests/tsconfig.json
+++ b/packages/rolldown/tests/tsconfig.json
@@ -39,8 +39,6 @@
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     "types": [
       "node",
-      "vitest/globals",
-      "vitest/importMeta",
       "vite/client"
     ] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */


### PR DESCRIPTION
### Description

`vitest/globals` is for auto-importing `describe`, `it`, `expect` like jest https://vitest.dev/config/#globals, but it's not enabled and thus it's a false type.