### PR TITLE
chore: cleanup napi-rs artifacts

### DIFF
--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -167,18 +167,6 @@ export interface ArrowFunctionsOptions {
   spec?: boolean
 }
 
-export interface ArrowFunctionsOptions {
-  /**
-   * This option enables the following:
-   * * Wrap the generated function in .bind(this) and keeps uses of this inside the function as-is, instead of using a renamed this.
-   * * Add a runtime check to ensure the functions are not instantiated.
-   * * Add names to arrow functions.
-   *
-   * @default false
-   */
-  spec?: boolean
-}
-
 export interface BindingAdvancedChunksOptions {
   minSize?: number
   minShareCount?: number
@@ -596,11 +584,6 @@ export interface Es2015Options {
   arrowFunction?: ArrowFunctionsOptions
 }
 
-export interface Es2015Options {
-  /** Transform arrow functions into function expressions. */
-  arrowFunction?: ArrowFunctionsOptions
-}
-
 export interface ExtensionAliasItem {
   target: string
   replacements: Array<string>
@@ -620,25 +603,6 @@ export interface IsolatedDeclarationsOptions {
    */
   stripInternal?: boolean
   sourcemap?: boolean
-}
-
-export interface IsolatedDeclarationsOptions {
-  /**
-   * Do not emit declarations for code that has an @internal annotation in its JSDoc comment.
-   * This is an internal compiler option; use at your own risk, because the compiler does not check that the result is valid.
-   *
-   * Default: `false`
-   *
-   * See <https://www.typescriptlang.org/tsconfig/#stripInternal>
-   */
-  stripInternal?: boolean
-  sourcemap?: boolean
-}
-
-export interface IsolatedDeclarationsResult {
-  code: string
-  map?: SourceMap
-  errors: Array<string>
 }
 
 export interface IsolatedDeclarationsResult {
@@ -765,101 +729,6 @@ export interface JsxOptions {
   /**
    * Enable React Fast Refresh .
    *
-   * Conforms to the implementation in {@link https://github.com/facebook/react/tree/main/packages/react-refresh}
-   *
-   * @default false
-   */
-  refresh?: boolean | ReactRefreshOptions
-}
-
-/**
- * Configure how TSX and JSX are transformed.
- *
- * @see {@link https://babeljs.io/docs/babel-plugin-transform-react-jsx#options}
- */
-export interface JsxOptions {
-  /**
-   * Decides which runtime to use.
-   *
-   * - 'automatic' - auto-import the correct JSX factories
-   * - 'classic' - no auto-import
-   *
-   * @default 'automatic'
-   */
-  runtime?: 'classic' | 'automatic'
-  /**
-   * Emit development-specific information, such as `__source` and `__self`.
-   *
-   * @default false
-   *
-   * @see {@link https://babeljs.io/docs/babel-plugin-transform-react-jsx-development}
-   */
-  development?: boolean
-  /**
-   * Toggles whether or not to throw an error if an XML namespaced tag name
-   * is used.
-   *
-   * Though the JSX spec allows this, it is disabled by default since React's
-   * JSX does not currently have support for it.
-   *
-   * @default true
-   */
-  throwIfNamespace?: boolean
-  /**
-   * Enables `@babel/plugin-transform-react-pure-annotations`.
-   *
-   * It will mark top-level React method calls as pure for tree shaking.
-   *
-   * @see {@link https://babeljs.io/docs/en/babel-plugin-transform-react-pure-annotations}
-   *
-   * @default true
-   */
-  pure?: boolean
-  /**
-   * Replaces the import source when importing functions.
-   *
-   * @default 'react'
-   */
-  importSource?: string
-  /**
-   * Replace the function used when compiling JSX expressions. It should be a
-   * qualified name (e.g. `React.createElement`) or an identifier (e.g.
-   * `createElement`).
-   *
-   * Only used for `classic` {@link runtime}.
-   *
-   * @default 'React.createElement'
-   */
-  pragma?: string
-  /**
-   * Replace the component used when compiling JSX fragments. It should be a
-   * valid JSX tag name.
-   *
-   * Only used for `classic` {@link runtime}.
-   *
-   * @default 'React.Fragment'
-   */
-  pragmaFrag?: string
-  /**
-   * When spreading props, use `Object.assign` directly instead of an extend helper.
-   *
-   * Only used for `classic` {@link runtime}.
-   *
-   * @default false
-   */
-  useBuiltIns?: boolean
-  /**
-   * When spreading props, use inline object with spread elements directly
-   * instead of an extend helper or Object.assign.
-   *
-   * Only used for `classic` {@link runtime}.
-   *
-   * @default false
-   */
-  useSpread?: boolean
-  /**
-   * Enable React Fast Refresh .
-   *
    * Conforms to the implementation in {@link https://github.com/facebook/react/tree/v18.3.1/packages/react-refresh}
    *
    * @default false
@@ -874,22 +743,6 @@ export interface PreRenderedChunk {
   facadeModuleId?: string
   moduleIds: Array<string>
   exports: Array<string>
-}
-
-export interface ReactRefreshOptions {
-  /**
-   * Specify the identifier of the refresh registration variable.
-   *
-   * @default `$RefreshReg$`.
-   */
-  refreshReg?: string
-  /**
-   * Specify the identifier of the refresh signature variable.
-   *
-   * @default `$RefreshSig$`.
-   */
-  refreshSig?: string
-  emitFullSignatures?: boolean
 }
 
 export interface ReactRefreshOptions {
@@ -934,17 +787,6 @@ export interface SourceMap {
   x_google_ignoreList?: Array<number>
 }
 
-export interface SourceMap {
-  file?: string
-  mappings: string
-  names: Array<string>
-  sourceRoot?: string
-  sources: Array<string>
-  sourcesContent?: Array<string>
-  version: number
-  x_google_ignoreList?: Array<number>
-}
-
 /**
  * Transpile a JavaScript or TypeScript into a target ECMAScript version.
  *
@@ -958,40 +800,6 @@ export interface SourceMap {
  * errors that occurred during parsing or transformation.
  */
 export declare function transform(filename: string, sourceText: string, options?: TransformOptions | undefined | null): TransformResult
-
-/**
- * Options for transforming a JavaScript or TypeScript file.
- *
- * @see {@link transform}
- */
-export interface TransformOptions {
-  sourceType?: 'script' | 'module' | 'unambiguous' | undefined
-  /** Treat the source text as `js`, `jsx`, `ts`, or `tsx`. */
-  lang?: 'js' | 'jsx' | 'ts' | 'tsx'
-  /**
-   * The current working directory. Used to resolve relative paths in other
-   * options.
-   */
-  cwd?: string
-  /**
-   * Enable source map generation.
-   *
-   * When `true`, the `sourceMap` field of transform result objects will be populated.
-   *
-   * @default false
-   *
-   * @see {@link SourceMap}
-   */
-  sourcemap?: boolean
-  /** Configure how TypeScript is transformed. */
-  typescript?: TypeScriptOptions
-  /** Configure how TSX and JSX are transformed. */
-  jsx?: JsxOptions
-  /** Define Plugin */
-  define?: Record<string, string>
-  /** Inject Plugin */
-  inject?: Record<string, string | [string, string]>
-}
 
 /**
  * Options for transforming a JavaScript or TypeScript file.
@@ -1082,75 +890,6 @@ export interface TransformResult {
    * list.
    */
   errors: Array<string>
-}
-
-export interface TransformResult {
-  /**
-   * The transformed code.
-   *
-   * If parsing failed, this will be an empty string.
-   */
-  code: string
-  /**
-   * The source map for the transformed code.
-   *
-   * This will be set if {@link TransformOptions#sourcemap} is `true`.
-   */
-  map?: SourceMap
-  /**
-   * The `.d.ts` declaration file for the transformed code. Declarations are
-   * only generated if `declaration` is set to `true` and a TypeScript file
-   * is provided.
-   *
-   * If parsing failed and `declaration` is set, this will be an empty string.
-   *
-   * @see {@link TypeScriptOptions#declaration}
-   * @see [declaration tsconfig option](https://www.typescriptlang.org/tsconfig/#declaration)
-   */
-  declaration?: string
-  /**
-   * Declaration source map. Only generated if both
-   * {@link TypeScriptOptions#declaration declaration} and
-   * {@link TransformOptions#sourcemap sourcemap} are set to `true`.
-   */
-  declarationMap?: SourceMap
-  /**
-   * Parse and transformation errors.
-   *
-   * Oxc's parser recovers from common syntax errors, meaning that
-   * transformed code may still be available even if there are errors in this
-   * list.
-   */
-  errors: Array<string>
-}
-
-export interface TypeScriptOptions {
-  jsxPragma?: string
-  jsxPragmaFrag?: string
-  onlyRemoveTypeImports?: boolean
-  allowNamespaces?: boolean
-  allowDeclareFields?: boolean
-  /**
-   * Also generate a `.d.ts` declaration file for TypeScript files.
-   *
-   * The source file must be compliant with all
-   * [`isolatedDeclarations`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#isolated-declarations)
-   * requirements.
-   *
-   * @default false
-   */
-  declaration?: IsolatedDeclarationsOptions
-  /**
-   * Rewrite or remove TypeScript import/export declaration extensions.
-   *
-   * - When set to `rewrite`, it will change `.ts`, `.mts`, `.cts` extensions to `.js`, `.mjs`, `.cjs` respectively.
-   * - When set to `remove`, it will remove `.ts`/`.mts`/`.cts`/`.tsx` extension entirely.
-   * - When set to `true`, it's equivalent to `rewrite`.
-   * - When set to `false` or omitted, no changes will be made to the extensions.
-   *
-   * @default false
-   */
-  rewriteImportExtensions?: 'rewrite' | 'remove' | boolean
 }
 
 export interface TypeScriptOptions {

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -59,16 +59,6 @@ const {
 
 function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__SourceMap_struct_0']?.()
-  __napiInstance.exports['__napi_register__IsolatedDeclarationsResult_struct_1']?.()
-  __napiInstance.exports['__napi_register__IsolatedDeclarationsOptions_struct_2']?.()
-  __napiInstance.exports['__napi_register__TransformResult_struct_3']?.()
-  __napiInstance.exports['__napi_register__TransformOptions_struct_4']?.()
-  __napiInstance.exports['__napi_register__TypeScriptOptions_struct_5']?.()
-  __napiInstance.exports['__napi_register__JsxOptions_struct_6']?.()
-  __napiInstance.exports['__napi_register__ReactRefreshOptions_struct_7']?.()
-  __napiInstance.exports['__napi_register__ArrowFunctionsOptions_struct_8']?.()
-  __napiInstance.exports['__napi_register__Es2015Options_struct_9']?.()
-  __napiInstance.exports['__napi_register__SourceMap_struct_0']?.()
   __napiInstance.exports['__napi_register__IsolatedDeclarationsResult_struct_0']?.()
   __napiInstance.exports['__napi_register__IsolatedDeclarationsOptions_struct_1']?.()
   __napiInstance.exports['__napi_register__isolated_declaration_2']?.()

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -83,16 +83,6 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
 
 function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__SourceMap_struct_0']?.()
-  __napiInstance.exports['__napi_register__IsolatedDeclarationsResult_struct_1']?.()
-  __napiInstance.exports['__napi_register__IsolatedDeclarationsOptions_struct_2']?.()
-  __napiInstance.exports['__napi_register__TransformResult_struct_3']?.()
-  __napiInstance.exports['__napi_register__TransformOptions_struct_4']?.()
-  __napiInstance.exports['__napi_register__TypeScriptOptions_struct_5']?.()
-  __napiInstance.exports['__napi_register__JsxOptions_struct_6']?.()
-  __napiInstance.exports['__napi_register__ReactRefreshOptions_struct_7']?.()
-  __napiInstance.exports['__napi_register__ArrowFunctionsOptions_struct_8']?.()
-  __napiInstance.exports['__napi_register__Es2015Options_struct_9']?.()
-  __napiInstance.exports['__napi_register__SourceMap_struct_0']?.()
   __napiInstance.exports['__napi_register__IsolatedDeclarationsResult_struct_0']?.()
   __napiInstance.exports['__napi_register__IsolatedDeclarationsOptions_struct_1']?.()
   __napiInstance.exports['__napi_register__isolated_declaration_2']?.()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I don't know what's going on, but there were many duplicate entries in `binding.d.ts` and `wasi` files. After cleaning up `target` dir locally and re-running `just build`, I got something clean, so I pushed it here. Is this just me or maybe napi-rs cache issue? :thinking: 

---

Looking at the published version https://unpkg.com/browse/rolldown@0.15.0-snapshot-22747a3-20241206003640/dist/types/binding.d.ts, it has a same content as this PR (i.e. without duplicate entries).