### PR TITLE
test: handle external dynamic import in `plugin/resolve-id/basic`

### DIFF
--- a/packages/rolldown/tests/fixtures/plugin/resolve-id/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-id/basic/_config.ts
@@ -36,18 +36,17 @@ export default defineTest({
               external: false,
             }
           }
-          // TODO: external dynamic import will loop
-          // if (id === 'dynamic') {
-          //   expect(importer).toStrictEqual(entry)
-          //   expect(options).toMatchObject({
-          //     isEntry: false,
-          //     kind: 'dynamic-import'
-          //   })
-          //   return {
-          //     id,
-          //     external: true
-          //   }
-          // }
+          if (id === 'dynamic') {
+            expect(importer).toStrictEqual(entry)
+            expect(options).toMatchObject({
+              isEntry: false,
+              kind: 'dynamic-import',
+            })
+            return {
+              id,
+              external: true,
+            }
+          }
           if (id === entry) {
             expect(importer).toBeUndefined()
             expect(options).toMatchObject({
@@ -59,7 +58,7 @@ export default defineTest({
       },
     ],
   },
-  afterTest: (output) => {
-    expect(resolveIdFn).toHaveBeenCalledTimes(3)
+  afterTest: () => {
+    expect(resolveIdFn).toHaveBeenCalledTimes(4)
   },
 })

--- a/packages/rolldown/tests/fixtures/plugin/resolve-id/basic/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-id/basic/main.js
@@ -2,4 +2,4 @@ import './foo'
 
 require('external')
 
-// import('dynamic')
+import('dynamic')


### PR DESCRIPTION
### Description

It can now be properly enabled.

https://github.com/rolldown/rolldown/blob/60d7b16675a18df42e3cec0a5b74d0838e65694c/packages/rolldown/tests/fixtures/plugin/resolve-id/basic/_config.ts#L39