### PR TITLE
chore(rust/dep): update to `napi@3.0.0-alpha.22` to handle `\0` without shims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.0.0-alpha.21"
+version = "3.0.0-alpha.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2609cc2422b18e6edcc0fa876947d93ba4e1f8f5f6613478ef2914773dec65"
+checksum = "04aea9dbe75cd1a1abecf8a66fba1e694c12ce6e6e4e11824dc274e141a6c251"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -1333,9 +1333,9 @@ checksum = "e1c0f5d67ee408a4685b61f5ab7e58605c8ae3f2b4189f0127d804ff13d5560a"
 
 [[package]]
 name = "napi-derive"
-version = "3.0.0-alpha.20"
+version = "3.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c9ed3c0ea428883cb24daa3ccda6930dd48e972b633ba9840554af58fe5063"
+checksum = "c12428d113f2b64cf827a144dddaf2df50c4d93d655d57d83745c2a281e6ec62"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -1346,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "2.0.0-alpha.20"
+version = "2.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67583aedddafcbe9719dac100301f7f3f350e4796d30bf28bff16e964b535581"
+checksum = "7a5122d26b6f849e524f1b92107364f2b4e9a2e8d41a77b3d6c5b3af75801c60"
 dependencies = [
  "convert_case",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,9 +140,9 @@ lightningcss        = { version = "1.0.0-alpha.57" }
 memchr              = "2.7.2"
 mimalloc            = "0.1.42"
 mime                = "0.3.17"
-napi                = { version = "3.0.0-alpha.21", features = ["async", "anyhow"] }
+napi                = { version = "3.0.0-alpha.22", features = ["async", "anyhow"] }
 napi-build          = { version = "2.1.3" }
-napi-derive         = { version = "3.0.0-alpha.20", default-features = false, features = ["type-def"] }
+napi-derive         = { version = "3.0.0-alpha.21", default-features = false, features = ["type-def"] }
 notify              = { version = "7.0.0" }
 phf                 = "0.11.2"
 rayon               = "1.10.0"

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -54,7 +54,7 @@ impl BindingOutputChunk {
 
   #[napi(getter, ts_return_type = "Record<string, BindingRenderedModule>")]
   pub fn modules(&self) -> BindingChunkModules {
-    BindingChunkModules::new(self.inner.modules.clone())
+    self.inner.modules.iter().map(|(key, value)| (key.to_string(), value.clone().into())).collect()
   }
 
   #[napi(getter)]

--- a/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
@@ -1,10 +1,4 @@
 use arcstr::ArcStr;
-use napi::{
-  bindgen_prelude::ToNapiValue,
-  sys::{napi_env, napi_value},
-  Env,
-};
-use rolldown_common::{ModuleId, RenderedModule};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
@@ -40,48 +34,15 @@ impl From<rolldown_common::RollupRenderedChunk> for RenderedChunk {
       module_ids: value.module_ids.into_iter().map(|x| x.to_string()).collect(),
       exports: value.exports,
       file_name: value.filename.to_string(),
-      modules: BindingChunkModules::new(value.modules),
+      modules: value
+        .modules
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value.into()))
+        .collect(),
       imports: value.imports.iter().map(ArcStr::to_string).collect(),
       dynamic_imports: value.dynamic_imports.iter().map(ArcStr::to_string).collect(),
     }
   }
 }
 
-// use own map wrapper to workaround "\0" issue
-// https://github.com/napi-rs/napi-rs/blob/f116eaf5e54090db4dca8a00ccdb684543a39e86/crates/napi/src/bindgen_runtime/js_values/map.rs#L26
-#[derive(Default, Debug)]
-pub struct BindingChunkModules(FxHashMap<ModuleId, RenderedModule>);
-
-impl BindingChunkModules {
-  pub fn new(map: FxHashMap<ModuleId, RenderedModule>) -> Self {
-    Self(map)
-  }
-}
-
-impl napi::bindgen_prelude::FromNapiValue for BindingChunkModules {
-  unsafe fn from_napi_value(
-    _env: napi::sys::napi_env,
-    _napi_val: napi::sys::napi_value,
-  ) -> napi::Result<Self> {
-    unimplemented!()
-  }
-}
-
-impl ToNapiValue for BindingChunkModules {
-  unsafe fn to_napi_value(raw_env: napi_env, val: Self) -> napi::Result<napi_value> {
-    let env = Env::from(raw_env);
-    let obj = ToNapiValue::to_napi_value(raw_env, env.create_object()?)?;
-    for (k, v) in val.0 {
-      let status = napi::sys::napi_set_property(
-        raw_env,
-        obj,
-        ToNapiValue::to_napi_value(raw_env, k.to_string())?,
-        ToNapiValue::to_napi_value(raw_env, Into::<BindingRenderedModule>::into(v.clone()))?,
-      );
-      if status != napi::sys::Status::napi_ok {
-        return Err(napi::Error::from_status(napi::Status::from(status)));
-      }
-    }
-    Ok(obj)
-  }
-}
+pub type BindingChunkModules = FxHashMap<String, BindingRenderedModule>;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/rolldown/rolldown/issues/1115.

@hi-ogawa cc

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
