### PR TITLE
feat: emit error for non-resolved absolute path

### DIFF
--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -376,7 +376,8 @@ impl ModuleTask {
           match &e {
             ResolveError::NotFound(..) => {
               // https://github.com/rollup/rollup/blob/49b57c2b30d55178a7316f23cc9ccc457e1a2ee7/src/ModuleLoader.ts#L643-L646
-              if ecmascript::is_relative_specifier(&specifier) {
+              if ecmascript::is_path_like_specifier(&specifier) {
+                // Unlike rollup, we also emit errors for absolute path
                 build_errors.push(
                   BuildDiagnostic::resolve_error(
                     source.clone(),

--- a/crates/rolldown/tests/esbuild/default/external_with_wildcard/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_with_wildcard/artifacts.snap
@@ -16,3 +16,27 @@ snapshot_kind: text
 ────╯
 
 ```
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: Could not resolve "/dir/file.gif" in entry.js
+   ╭─[entry.js:9:8]
+   │
+ 9 │ import "/dir/file.gif";
+   │        ───────┬───────  
+   │               ╰───────── Module not found.
+───╯
+
+```
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: Could not resolve "/sassets/images/test.jpg" in entry.js
+   ╭─[entry.js:8:8]
+   │
+ 8 │ import "/sassets/images/test.jpg";
+   │        ─────────────┬────────────  
+   │                     ╰────────────── Module not found.
+───╯
+
+```

--- a/crates/rolldown/tests/esbuild/default/import_abs_path_as_dir/_config.json
+++ b/crates/rolldown/tests/esbuild/default/import_abs_path_as_dir/_config.json
@@ -5,7 +5,8 @@
         "name": "entry",
         "import": "entry.js"
       }
-    ]
+    ],
+    "external": ["/Users/user/project/node_modules/pkg/index"]
   },
   "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/default/import_abs_path_as_dir/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_abs_path_as_dir/artifacts.snap
@@ -1,20 +1,7 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
-# warnings
-
-## UNRESOLVED_IMPORT
-
-```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve '/Users/user/project/node_modules/pkg/index' in entry.js
-   ╭─[entry.js:1:17]
-   │
- 1 │ import pkg from '/Users/user/project/node_modules/pkg/index'
-   │                 ──────────────────────┬─────────────────────  
-   │                                       ╰─────────────────────── Module not found, treating it as an external dependency
-───╯
-
-```
 # Assets
 
 ## entry.js

--- a/crates/rolldown/tests/esbuild/default/import_abs_path_as_file/_config.json
+++ b/crates/rolldown/tests/esbuild/default/import_abs_path_as_file/_config.json
@@ -5,7 +5,8 @@
         "name": "entry",
         "import": "entry.js"
       }
-    ]
+    ],
+    "external": ["/Users/user/project/node_modules/pkg/index"]
   },
   "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/default/import_abs_path_as_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_abs_path_as_file/artifacts.snap
@@ -1,20 +1,7 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
-# warnings
-
-## UNRESOLVED_IMPORT
-
-```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve '/Users/user/project/node_modules/pkg/index' in entry.js
-   ╭─[entry.js:1:17]
-   │
- 1 │ import pkg from '/Users/user/project/node_modules/pkg/index'
-   │                 ──────────────────────┬─────────────────────  
-   │                                       ╰─────────────────────── Module not found, treating it as an external dependency
-───╯
-
-```
 # Assets
 
 ## entry.js

--- a/crates/rolldown/tests/esbuild/default/import_abs_path_with_query_parameter/_config.json
+++ b/crates/rolldown/tests/esbuild/default/import_abs_path_with_query_parameter/_config.json
@@ -5,7 +5,8 @@
         "name": "entry",
         "import": "entry.js"
       }
-    ]
+    ],
+    "external": ["/Users/user/project/file.txt?foo", "/Users/user/project/file.txt#bar"]
   },
   "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/default/import_abs_path_with_query_parameter/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_abs_path_with_query_parameter/artifacts.snap
@@ -1,32 +1,7 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
-# warnings
-
-## UNRESOLVED_IMPORT
-
-```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve '/Users/user/project/file.txt#bar' in entry.js
-   ╭─[entry.js:3:17]
-   │
- 3 │ import bar from '/Users/user/project/file.txt#bar'
-   │                 ─────────────────┬────────────────  
-   │                                  ╰────────────────── Module not found, treating it as an external dependency
-───╯
-
-```
-## UNRESOLVED_IMPORT
-
-```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve '/Users/user/project/file.txt?foo' in entry.js
-   ╭─[entry.js:2:17]
-   │
- 2 │ import foo from '/Users/user/project/file.txt?foo'
-   │                 ─────────────────┬────────────────  
-   │                                  ╰────────────────── Module not found, treating it as an external dependency
-───╯
-
-```
 # Assets
 
 ## entry.js

--- a/crates/rolldown_utils/src/ecmascript.rs
+++ b/crates/rolldown_utils/src/ecmascript.rs
@@ -1,5 +1,5 @@
 use oxc::syntax::{identifier, keyword};
-use std::borrow::Cow;
+use std::{borrow::Cow, path::Path};
 
 use crate::concat_string;
 
@@ -72,5 +72,14 @@ fn test_legitimize_identifier_name() {
 }
 
 pub fn is_relative_specifier(specifier: &str) -> bool {
+  // `Path::is_relative` is not used here because it consider implicit relative path as relative path. such
+  // as `Path::new("foo.txt")` is considered as a relative path.
   specifier.starts_with("./") || specifier.starts_with("../")
+}
+
+/// Check if the specifier is a path-like specifier. E.g. `./foo`, `../foo`, `/foo`, `C:\foo`, `file:///foo`
+pub fn is_path_like_specifier(specifier: &str) -> bool {
+  is_relative_specifier(specifier)
+    || Path::new(specifier).is_absolute()
+    || specifier.starts_with('/') // Though starting with `/` is not a absolute path in Windows, we still consider it as a path-like specifier.
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

A further step for #3074. Both for improving UX by emitting errors for non-resolved __file__ paths.

For non-file paths, such as `foo`, rolldown will only emit warnings and auto external it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
