### PR TITLE
chore(types): make types friendly to `isolatedDeclarations`

### DIFF
--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -57,7 +57,7 @@ export class RolldownBuild {
     await bundler.close()
   }
 
-  async [Symbol.asyncDispose]() {
+  async [Symbol.asyncDispose](): Promise<void> {
     await this.close()
   }
 }

--- a/packages/rolldown/src/api/watch/watch-emitter.ts
+++ b/packages/rolldown/src/api/watch/watch-emitter.ts
@@ -63,7 +63,7 @@ export class WatcherEmitter {
     return this
   }
 
-  async onEvent(event: BindingWatcherEvent) {
+  async onEvent(event: BindingWatcherEvent): Promise<void> {
     const listeners = this.listeners.get(event.eventKind() as WatcherEvent)
     if (listeners) {
       switch (event.eventKind()) {

--- a/packages/rolldown/src/api/watch/watcher.ts
+++ b/packages/rolldown/src/api/watch/watcher.ts
@@ -25,7 +25,7 @@ export class Watcher {
     this.stopWorkers = stopWorkers
   }
 
-  async close() {
+  async close(): Promise<void> {
     if (this.closed) return
     this.closed = true
     for (const stop of this.stopWorkers) {
@@ -34,7 +34,7 @@ export class Watcher {
     await this.inner.close()
   }
 
-  start() {
+  start(): void {
     // run first build after listener is attached
     process.nextTick(() =>
       this.inner.start(this.emitter.onEvent.bind(this.emitter)),
@@ -45,7 +45,7 @@ export class Watcher {
 export async function createWatcher(
   emitter: WatcherEmitter,
   input: WatchOptions | WatchOptions[],
-) {
+): Promise<void> {
   const options = Array.isArray(input) ? input : [input]
   const bundlerOptions = await Promise.all(
     options.map((option) => createBundlerOptions(option, option.output || {})),

--- a/packages/rolldown/src/builtin-plugin/alias-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/alias-plugin.ts
@@ -10,6 +10,6 @@ type AliasPluginConfig = {
   entries: AliasPluginAlias[]
 }
 
-export function aliasPlugin(config: AliasPluginConfig) {
+export function aliasPlugin(config: AliasPluginConfig): BuiltinPlugin {
   return new BuiltinPlugin('builtin:alias', config)
 }

--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -22,47 +22,51 @@ export class BuiltinPlugin {
 
 export function modulePreloadPolyfillPlugin(
   config?: BindingModulePreloadPolyfillPluginConfig,
-) {
+): BuiltinPlugin {
   return new BuiltinPlugin('builtin:module-preload-polyfill', config)
 }
 
-export function dynamicImportVarsPlugin() {
+export function dynamicImportVarsPlugin(): BuiltinPlugin {
   return new BuiltinPlugin('builtin:dynamic-import-vars')
 }
 
-export function importGlobPlugin(config?: BindingGlobImportPluginConfig) {
+export function importGlobPlugin(
+  config?: BindingGlobImportPluginConfig,
+): BuiltinPlugin {
   return new BuiltinPlugin('builtin:import-glob', config)
 }
 
-export function manifestPlugin(config?: BindingManifestPluginConfig) {
+export function manifestPlugin(
+  config?: BindingManifestPluginConfig,
+): BuiltinPlugin {
   return new BuiltinPlugin('builtin:manifest', config)
 }
 
-export function wasmHelperPlugin() {
+export function wasmHelperPlugin(): BuiltinPlugin {
   return new BuiltinPlugin('builtin:wasm-helper')
 }
 
-export function wasmFallbackPlugin() {
+export function wasmFallbackPlugin(): BuiltinPlugin {
   return new BuiltinPlugin('builtin:wasm-fallback')
 }
 
-export function loadFallbackPlugin() {
+export function loadFallbackPlugin(): BuiltinPlugin {
   return new BuiltinPlugin('builtin:load-fallback')
 }
 
-export function jsonPlugin(config?: BindingJsonPluginConfig) {
+export function jsonPlugin(config?: BindingJsonPluginConfig): BuiltinPlugin {
   return new BuiltinPlugin('builtin:json', config)
 }
 
 export function buildImportAnalysisPlugin(
   config: BindingBuildImportAnalysisPluginConfig,
-) {
+): BuiltinPlugin {
   return new BuiltinPlugin('builtin:build-import-analysis', config)
 }
 
 export function viteResolvePlugin(
   config: Omit<BindingViteResolvePluginConfig, 'runtime'>,
-) {
+): BuiltinPlugin {
   const builtinPlugin = new BuiltinPlugin('builtin:vite-resolve', {
     ...config,
     runtime: process.versions.deno

--- a/packages/rolldown/src/builtin-plugin/replace-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/replace-plugin.ts
@@ -30,6 +30,6 @@ import { BuiltinPlugin } from './constructors'
 export function replacePlugin(
   values: BindingReplacePluginConfig['values'] = {},
   options: Omit<BindingReplacePluginConfig, 'values'> = {},
-) {
+): BuiltinPlugin {
   return new BuiltinPlugin('builtin:replace', { ...options, values })
 }

--- a/packages/rolldown/src/builtin-plugin/transform-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/transform-plugin.ts
@@ -28,7 +28,7 @@ function normalizeEcmaTransformPluginConfig(
   return normalizedConfig
 }
 
-export function transformPlugin(config?: TransformPluginConfig) {
+export function transformPlugin(config?: TransformPluginConfig): BuiltinPlugin {
   return new BuiltinPlugin(
     'builtin:transform',
     normalizeEcmaTransformPluginConfig(config),

--- a/packages/rolldown/src/cli/arguments/index.ts
+++ b/packages/rolldown/src/cli/arguments/index.ts
@@ -7,12 +7,24 @@ import {
   kebabCaseToCamelCase,
 } from './utils'
 import { parseArgs } from 'node:util'
-import { normalizeCliOptions } from './normalize'
+import { normalizeCliOptions, type NormalizedCliOptions } from './normalize'
 import { logger } from '../utils'
+import type { Schema } from './types'
 
-export const flattenedSchema = flattenSchema(objectSchema.properties)
+export const flattenedSchema: Record<string, Schema> = flattenSchema(
+  objectSchema.properties,
+)
 
-export const options = Object.fromEntries(
+export const options: {
+  [k: string]: {
+    type: 'boolean' | 'string'
+    multiple: boolean
+    short?: string
+    default?: boolean | string | string[]
+    hint?: string
+    description: string
+  }
+} = Object.fromEntries(
   Object.entries(flattenedSchema).map(([key, schema]) => {
     const config = Object.getOwnPropertyDescriptor(alias, key)?.value as
       | OptionConfig
@@ -52,7 +64,7 @@ export const options = Object.fromEntries(
 
 export type ParseArgsOptions = typeof options
 
-export function parseCliArguments() {
+export function parseCliArguments(): NormalizedCliOptions {
   const { values, tokens, positionals } = parseArgs({
     options,
     tokens: true,

--- a/packages/rolldown/src/cli/arguments/utils.ts
+++ b/packages/rolldown/src/cli/arguments/utils.ts
@@ -44,7 +44,7 @@ export function setNestedProperty<T extends object, K>(
   obj: T,
   path: string,
   value: K,
-) {
+): void {
   const keys = path.split('.') as (keyof T)[]
   let current: any = obj
 

--- a/packages/rolldown/src/cli/colors.ts
+++ b/packages/rolldown/src/cli/colors.ts
@@ -1,9 +1,46 @@
 import { env } from 'node:process'
-import { createColors } from 'colorette'
+import { Color, createColors } from 'colorette'
 
 // @see https://no-color.org
 // @see https://www.npmjs.com/package/chalk
-export const { bold, cyan, dim, gray, green, red, underline, yellow } =
-  createColors({
-    useColor: env.FORCE_COLOR !== '0' && !env.NO_COLOR,
-  })
+const {
+  bold,
+  cyan,
+  dim,
+  gray,
+  green,
+  red,
+  underline,
+  yellow,
+}: {
+  bold: Color
+  cyan: Color
+  dim: Color
+  gray: Color
+  green: Color
+  red: Color
+  underline: Color
+  yellow: Color
+} = createColors({
+  useColor: env.FORCE_COLOR !== '0' && !env.NO_COLOR,
+})
+
+export const colors: {
+  bold: Color
+  cyan: Color
+  dim: Color
+  gray: Color
+  green: Color
+  red: Color
+  underline: Color
+  yellow: Color
+} = {
+  bold,
+  cyan,
+  dim,
+  gray,
+  green,
+  red,
+  underline,
+  yellow,
+}

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 import { onExit } from 'signal-exit'
-import * as colors from '../colors'
+import { colors } from '../colors'
 import { ensureConfig, logger } from '../utils'
 import { NormalizedCliOptions } from '../arguments/normalize'
 import { arraify } from '../../utils/misc'
@@ -12,7 +12,7 @@ import type { RolldownOptions, RolldownOutput, RollupOutput } from '../..'
 export async function bundleWithConfig(
   configPath: string,
   cliOptions: NormalizedCliOptions,
-) {
+): Promise<void> {
   const config = await ensureConfig(configPath)
 
   if (!config) {
@@ -27,7 +27,9 @@ export async function bundleWithConfig(
   }
 }
 
-export async function bundleWithCliOptions(cliOptions: NormalizedCliOptions) {
+export async function bundleWithCliOptions(
+  cliOptions: NormalizedCliOptions,
+): Promise<void> {
   if (cliOptions.output.dir) {
     const operation = cliOptions.watch ? watchInner : bundleInner
     await operation({}, cliOptions)

--- a/packages/rolldown/src/cli/commands/help.ts
+++ b/packages/rolldown/src/cli/commands/help.ts
@@ -3,13 +3,13 @@ import {
   version,
   description,
 } from '../../../package.json' assert { type: 'json' }
-import { bold, cyan, gray, underline } from '../colors'
+import { colors } from '../colors'
 import { options } from '../arguments'
 import { camelCaseToKebabCase } from '../arguments/utils'
 
-const introduction = `${gray(`${description} (rolldown v${version})`)}
+const introduction = `${colors.gray(`${description} (rolldown v${version})`)}
 
-${bold(underline('USAGE'))} ${cyan('rolldown -c <config>')} or ${cyan('rolldown <input> <options>')}`
+${colors.bold(colors.underline('USAGE'))} ${colors.cyan('rolldown -c <config>')} or ${colors.cyan('rolldown <input> <options>')}`
 
 const examples = [
   {
@@ -42,10 +42,10 @@ const notes = [
   'For more information, please visit https://rolldown.rs/.',
 ]
 
-export function showHelp() {
+export function showHelp(): void {
   logger.log(introduction)
   logger.log('')
-  logger.log(`${bold(underline('OPTIONS'))}`)
+  logger.log(`${colors.bold(colors.underline('OPTIONS'))}`)
   logger.log('')
   logger.log(
     Object.entries(options)
@@ -77,7 +77,7 @@ export function showHelp() {
           description = description[0].toUpperCase() + description.slice(1)
         }
         return (
-          cyan(optionStr.padEnd(30)) +
+          colors.cyan(optionStr.padEnd(30)) +
           description +
           (description && description?.endsWith('.') ? '' : '.')
         )
@@ -85,16 +85,16 @@ export function showHelp() {
       .join('\n'),
   )
   logger.log('')
-  logger.log(`${bold(underline('EXAMPLES'))}`)
+  logger.log(`${colors.bold(colors.underline('EXAMPLES'))}`)
   logger.log('')
   examples.forEach(({ title, command }, ord) => {
     logger.log(`  ${ord + 1}. ${title}:`)
-    logger.log(`    ${cyan(command)}`)
+    logger.log(`    ${colors.cyan(command)}`)
     logger.log('')
   })
-  logger.log(`${bold(underline('NOTES'))}`)
+  logger.log(`${colors.bold(colors.underline('NOTES'))}`)
   logger.log('')
   notes.forEach((note) => {
-    logger.log(`  * ${gray(note)}`)
+    logger.log(`  * ${colors.gray(note)}`)
   })
 }

--- a/packages/rolldown/src/cli/utils.ts
+++ b/packages/rolldown/src/cli/utils.ts
@@ -1,12 +1,13 @@
 import nodePath from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { createConsola } from 'consola'
+import { type ConsolaInstance, createConsola } from 'consola'
 import type { ConfigExport } from '../types/config-export'
 
 /**
  * Console logger
  */
-export const logger = process.env.ROLLDOWN_TEST
+export const logger: Record<string, any> | ConsolaInstance = process.env
+  .ROLLDOWN_TEST
   ? createTestingLogger()
   : createConsola({
       formatOptions: {

--- a/packages/rolldown/src/constants/plugin.ts
+++ b/packages/rolldown/src/constants/plugin.ts
@@ -25,7 +25,14 @@ export const ENUMERATED_OUTPUT_PLUGIN_HOOK_NAMES = [
   'generateBundle',
 ] as const
 
-export const ENUMERATED_PLUGIN_HOOK_NAMES = [
+export const ENUMERATED_PLUGIN_HOOK_NAMES: [
+  ...typeof ENUMERATED_INPUT_PLUGIN_HOOK_NAMES,
+  ...typeof ENUMERATED_OUTPUT_PLUGIN_HOOK_NAMES,
+  'footer',
+  'banner',
+  'intro',
+  'outro',
+] = [
   // build hooks
   ...ENUMERATED_INPUT_PLUGIN_HOOK_NAMES,
   // generate hooks

--- a/packages/rolldown/src/log/locate-character/index.d.ts
+++ b/packages/rolldown/src/log/locate-character/index.d.ts
@@ -1,0 +1,22 @@
+export function getLocator(
+  source: string,
+  options?: Options | undefined,
+): (search: string | number, index?: number | undefined) => Location | undefined
+
+export function locate(
+  source: string,
+  search: string | number,
+  options?: Options | undefined,
+): Location | undefined
+export type Location = Location_1
+interface Options {
+  offsetLine?: number
+  offsetColumn?: number
+  startIndex?: number
+}
+
+interface Location_1 {
+  line: number
+  column: number
+  character: number
+}

--- a/packages/rolldown/src/log/logger.ts
+++ b/packages/rolldown/src/log/logger.ts
@@ -84,7 +84,7 @@ export function getLogger(
 export const getOnLog = (
   config: InputOptions,
   logLevel: LogLevelOption,
-  printLog = defaultPrintLog,
+  printLog: LogHandler = defaultPrintLog,
 ): LogHandler => {
   const { onwarn, onLog } = config
   const defaultOnLog = getDefaultOnLog(printLog, onwarn)

--- a/packages/rolldown/src/options/input-options-schema.ts
+++ b/packages/rolldown/src/options/input-options-schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import * as zodExt from '../utils/zod-ext'
-import { underline, gray, yellow, dim } from '../cli/colors'
+import { colors } from '../cli/colors'
 import {
   LogLevelOptionSchema,
   LogLevelSchema,
@@ -128,7 +128,7 @@ export const inputOptionsSchema = z.strictObject({
     .or(z.literal('browser'))
     .or(z.literal('neutral'))
     .describe(
-      `Platform for which the code should be generated (node, ${underline('browser')}, neutral)`,
+      `Platform for which the code should be generated (node, ${colors.underline('browser')}, neutral)`,
     )
     .optional(),
   shimMissingExports: z
@@ -137,7 +137,7 @@ export const inputOptionsSchema = z.strictObject({
     .optional(),
   treeshake: TreeshakingOptionsSchema.optional(),
   logLevel: LogLevelOptionSchema.describe(
-    `Log level (${dim('silent')}, ${underline(gray('info'))}, debug, ${yellow('warn')})`,
+    `Log level (${colors.dim('silent')}, ${colors.underline(colors.gray('info'))}, debug, ${colors.yellow('warn')})`,
   ).optional(),
   onLog: z
     .function()

--- a/packages/rolldown/src/options/normalized-input-options.ts
+++ b/packages/rolldown/src/options/normalized-input-options.ts
@@ -19,19 +19,19 @@ export class NormalizedInputOptionsImpl implements NormalizedInputOptions {
     this.inner = inner
   }
 
-  get shimMissingExports() {
+  get shimMissingExports(): boolean {
     return this.inner.shimMissingExports
   }
 
-  get input() {
+  get input(): string[] | Record<string, string> {
     return this.inner.input
   }
 
-  get cwd() {
+  get cwd(): string | undefined {
     return this.inner.cwd ?? undefined
   }
 
-  get platform() {
+  get platform(): 'browser' | 'node' | 'neutral' {
     return this.inner.platform
   }
 }

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -1,4 +1,4 @@
-import { unsupported } from '../utils/misc'
+import { unsupported, type UnsupportedFnRet } from '../utils/misc'
 import type { BindingNormalizedOptions } from '../binding'
 import type {
   SourcemapIgnoreListOption,
@@ -61,115 +61,115 @@ export class NormalizedOutputOptionsImpl implements NormalizedOutputOptions {
     this.inner = inner
   }
 
-  get dir() {
+  get dir(): string | undefined {
     return this.inner.dir ?? undefined
   }
 
-  get entryFileNames() {
+  get entryFileNames(): string | UnsupportedFnRet {
     return mapFunctionOption(this.inner.entryFilenames, 'entryFileNames')
   }
 
-  get chunkFileNames() {
+  get chunkFileNames(): string | UnsupportedFnRet {
     return mapFunctionOption(this.inner.chunkFilenames, 'chunkFileNames')
   }
 
-  get assetFileNames() {
+  get assetFileNames(): string {
     return this.inner.assetFilenames
   }
 
-  get format() {
+  get format(): 'es' | 'cjs' | 'app' | 'iife' | 'umd' {
     return this.inner.format
   }
 
-  get exports() {
+  get exports(): 'default' | 'named' | 'none' | 'auto' {
     return this.inner.exports
   }
 
-  get sourcemap() {
+  get sourcemap(): boolean | 'inline' | 'hidden' {
     return this.inner.sourcemap
   }
 
-  get cssEntryFileNames() {
+  get cssEntryFileNames(): string | UnsupportedFnRet {
     return mapFunctionOption(this.inner.cssEntryFilenames, 'cssEntryFileNames')
   }
 
-  get cssChunkFileNames() {
+  get cssChunkFileNames(): string | UnsupportedFnRet {
     return mapFunctionOption(this.inner.cssChunkFilenames, 'cssChunkFileNames')
   }
 
-  get shimMissingExports() {
+  get shimMissingExports(): boolean {
     return this.inner.shimMissingExports
   }
 
-  get name() {
+  get name(): string | undefined {
     return this.inner.name ?? undefined
   }
 
-  get file() {
+  get file(): string | undefined {
     return this.inner.file ?? undefined
   }
 
-  get inlineDynamicImports() {
+  get inlineDynamicImports(): boolean {
     return this.inner.inlineDynamicImports
   }
 
-  get externalLiveBindings() {
+  get externalLiveBindings(): boolean {
     return this.inner.externalLiveBindings
   }
 
-  get banner() {
+  get banner(): string | UnsupportedFnRet | undefined {
     return mapFunctionOption(this.inner.banner, 'banner') ?? undefined
   }
 
-  get footer() {
+  get footer(): string | UnsupportedFnRet | undefined {
     return mapFunctionOption(this.inner.footer, 'footer') ?? undefined
   }
 
-  get intro() {
+  get intro(): string | UnsupportedFnRet | undefined {
     return mapFunctionOption(this.inner.intro, 'intro') ?? undefined
   }
 
-  get outro() {
+  get outro(): string | UnsupportedFnRet | undefined {
     return mapFunctionOption(this.inner.outro, 'outro') ?? undefined
   }
 
-  get esModule() {
+  get esModule(): boolean | 'if-default-prop' {
     return this.inner.esModule
   }
 
-  get extend() {
+  get extend(): boolean {
     return this.inner.extend
   }
 
-  get globals() {
+  get globals(): Record<string, string> | UnsupportedFnRet {
     return mapFunctionOption(this.inner.globals, 'globals')
   }
 
-  get hashCharacters() {
+  get hashCharacters(): 'base64' | 'base36' | 'hex' {
     return this.inner.hashCharacters
   }
 
-  get sourcemapDebugIds() {
+  get sourcemapDebugIds(): boolean {
     return this.inner.sourcemapDebugIds
   }
 
-  get sourcemapIgnoreList() {
+  get sourcemapIgnoreList(): UnsupportedFnRet | undefined {
     return mapFunctionOption(void 0, 'sourcemapIgnoreList')
   }
 
-  get sourcemapPathTransform() {
+  get sourcemapPathTransform(): UnsupportedFnRet | undefined {
     return mapFunctionOption(void 0, 'sourcemapPathTransform')
   }
 
-  get minify() {
+  get minify(): boolean {
     return this.inner.minify
   }
 
-  get comments() {
+  get comments(): 'none' | 'preserve-legal' {
     return this.inner.comments
   }
 
-  get polyfillRequire() {
+  get polyfillRequire(): boolean {
     return this.inner.polyfillRequire
   }
 }

--- a/packages/rolldown/src/options/output-options-schema.ts
+++ b/packages/rolldown/src/options/output-options-schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import * as zodExt from '../utils/zod-ext'
-import { bold, underline } from '../cli/colors'
+import { colors } from '../cli/colors'
 import type { PreRenderedChunk } from '../binding'
 import type {
   SourcemapIgnoreListOption,
@@ -25,7 +25,7 @@ const ModuleFormatSchema = z
   .or(z.literal('iife'))
   .or(z.literal('umd'))
   .describe(
-    `Output format of the generated bundle (supports ${underline('esm')}, cjs, and iife)`,
+    `Output format of the generated bundle (supports ${colors.underline('esm')}, cjs, and iife)`,
   ) satisfies z.ZodType<ModuleFormat>
 
 const addonFunctionSchema = z
@@ -57,7 +57,7 @@ const outputOptionsSchema = z.strictObject({
     .or(z.literal('default'))
     .or(z.literal('none'))
     .describe(
-      `Specify a export mode (${underline('auto')}, named, default, none)`,
+      `Specify a export mode (${colors.underline('auto')}, named, default, none)`,
     )
     .optional(),
   hashCharacters: z
@@ -72,7 +72,7 @@ const outputOptionsSchema = z.strictObject({
     .or(z.literal('inline'))
     .or(z.literal('hidden'))
     .describe(
-      `Generate sourcemap (\`-s inline\` for inline, or ${bold('pass the `-s` on the last argument if you want to generate `.map` file')})`,
+      `Generate sourcemap (\`-s inline\` for inline, or ${colors.bold('pass the `-s` on the last argument if you want to generate `.map` file')})`,
     )
     .optional(),
   sourcemapIgnoreList: z
@@ -161,7 +161,7 @@ const getAddonDescription = (
   placement: 'bottom' | 'top',
   wrapper: 'inside' | 'outside',
 ) => {
-  return `Code to insert the ${bold(placement)} of the bundled file (${bold(wrapper)} the wrapper function)`
+  return `Code to insert the ${colors.bold(placement)} of the bundled file (${colors.bold(wrapper)} the wrapper function)`
 }
 
 export const outputCliOptionsSchema = outputOptionsSchema

--- a/packages/rolldown/src/plugin/parallel-plugin-implementation.ts
+++ b/packages/rolldown/src/plugin/parallel-plugin-implementation.ts
@@ -15,6 +15,9 @@ export function defineParallelPluginImplementation<Options>(
     Options: Options,
     context: Context,
   ) => MaybePromise<ParallelPluginImplementation>,
-) {
+): (
+  Options: Options,
+  context: Context,
+) => MaybePromise<ParallelPluginImplementation> {
   return plugin
 }

--- a/packages/rolldown/src/plugin/plugin-context-data.ts
+++ b/packages/rolldown/src/plugin/plugin-context-data.ts
@@ -2,13 +2,14 @@ import { BindingPluginContext } from '../binding'
 import { ModuleOptions } from '..'
 import { transformModuleInfo } from '../utils/transform-module-info'
 import { PluginContextResolveOptions } from './plugin-context'
+import type { ModuleInfo } from '../types/module-info'
 
 export class PluginContextData {
-  moduleOptionMap = new Map<string, ModuleOptions>()
-  resolveOptionsMap = new Map<number, PluginContextResolveOptions>()
+  moduleOptionMap: Map<string, ModuleOptions> = new Map()
+  resolveOptionsMap: Map<number, PluginContextResolveOptions> = new Map()
   loadModulePromiseMap: Map<string, Promise<void>> = new Map()
 
-  updateModuleOption(id: string, option: ModuleOptions) {
+  updateModuleOption(id: string, option: ModuleOptions): void {
     const existing = this.moduleOptionMap.get(id)
     if (existing) {
       if (option.moduleSideEffects != null) {
@@ -22,7 +23,7 @@ export class PluginContextData {
     }
   }
 
-  getModuleOption(id: string) {
+  getModuleOption(id: string): ModuleOptions {
     const option = this.moduleOptionMap.get(id)
     if (!option) {
       const raw: ModuleOptions = {
@@ -35,7 +36,7 @@ export class PluginContextData {
     return option
   }
 
-  getModuleInfo(id: string, context: BindingPluginContext) {
+  getModuleInfo(id: string, context: BindingPluginContext): ModuleInfo | null {
     const bindingInfo = context.getModuleInfo(id)
     if (bindingInfo) {
       const info = transformModuleInfo(bindingInfo, this.getModuleOption(id))
@@ -44,7 +45,7 @@ export class PluginContextData {
     return null
   }
 
-  getModuleIds(context: BindingPluginContext) {
+  getModuleIds(context: BindingPluginContext): ArrayIterator<string> {
     const moduleIds = context.getModuleIds()
     return moduleIds.values()
   }
@@ -55,11 +56,13 @@ export class PluginContextData {
     return index
   }
 
-  getSavedResolveOptions(receipt: number) {
+  getSavedResolveOptions(
+    receipt: number,
+  ): PluginContextResolveOptions | undefined {
     return this.resolveOptionsMap.get(receipt)
   }
 
-  removeSavedResolveOptions(receipt: number) {
+  removeSavedResolveOptions(receipt: number): void {
     this.resolveOptionsMap.delete(receipt)
   }
 }

--- a/packages/rolldown/src/treeshake/module-side-effects.ts
+++ b/packages/rolldown/src/treeshake/module-side-effects.ts
@@ -28,7 +28,6 @@ export const TreeshakingOptionsSchema = z
     annotations: z.boolean().optional(),
   })
   .passthrough()
-
   .or(z.boolean())
 
 export type TreeshakingOptions = z.infer<typeof TreeshakingOptionsSchema>

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -5,7 +5,7 @@ import { bindingifyBuiltInPlugin } from '../builtin-plugin/utils'
 import { BuiltinPlugin } from '../builtin-plugin/constructors'
 import { arraify, unsupported } from './misc'
 import { normalizedStringOrRegex } from './normalize-string-or-regex'
-import type { RolldownPlugin } from 'rolldown'
+import type { RolldownPlugin } from '../plugin'
 import type { InputOptions } from '../options/input-options'
 import type { OutputOptions } from '../options/output-options'
 import type {

--- a/packages/rolldown/src/utils/error.ts
+++ b/packages/rolldown/src/utils/error.ts
@@ -1,6 +1,6 @@
 import { RollupError } from '../rollup'
 
-export function normalizeErrors(rawErrors: (object | Error)[]) {
+export function normalizeErrors(rawErrors: (object | Error)[]): Error {
   const errors = rawErrors.map((e) =>
     e instanceof Error
       ? e

--- a/packages/rolldown/src/utils/initialize-parallel-plugins.ts
+++ b/packages/rolldown/src/utils/initialize-parallel-plugins.ts
@@ -15,7 +15,15 @@ type ParallelPluginInfo = {
   options: unknown
 }
 
-export async function initializeParallelPlugins(plugins: RolldownPlugin[]) {
+export async function initializeParallelPlugins(
+  plugins: RolldownPlugin[],
+): Promise<
+  | {
+      registry: ParallelJsPluginRegistry
+      stopWorkers: () => Promise<void>
+    }
+  | undefined
+> {
   const pluginInfos: ParallelPluginInfo[] = []
   for (const [index, plugin] of plugins.entries()) {
     if ('_parallel' in plugin) {
@@ -43,7 +51,7 @@ export function initializeWorkers(
   registryId: number,
   count: number,
   pluginInfos: ParallelPluginInfo[],
-) {
+): Promise<Worker[]> {
   return Promise.all(
     Array.from({ length: count }, (_, i) =>
       initializeWorker(registryId, pluginInfos, i),

--- a/packages/rolldown/src/utils/misc.ts
+++ b/packages/rolldown/src/utils/misc.ts
@@ -19,11 +19,11 @@ export function unreachable(info?: string): never {
   }
   throw new Error('unreachable')
 }
-
 export function unsupported(info: string): () => never {
   return () => {
     throw new Error(`UNSUPPORTED: ${info}`)
   }
 }
+export type UnsupportedFnRet = ReturnType<typeof unsupported>
 
-export function noop(..._args: any[]) {}
+export function noop(..._args: any[]): void {}

--- a/packages/rolldown/src/utils/normalize-hook.ts
+++ b/packages/rolldown/src/utils/normalize-hook.ts
@@ -4,7 +4,15 @@ import { unreachable } from './misc'
 
 export function normalizeHook<Hook extends ObjectHook<AnyFn | string>>(
   hook: Hook,
-) {
+): Hook extends ObjectHook<infer RawHook, infer CustomOptions>
+  ? Hook extends RawHook
+    ? never
+    : {
+        handler: RawHook
+        options: CustomOptions
+        meta: ObjectHookMeta
+      }
+  : never {
   type Return =
     Hook extends ObjectHook<infer RawHook, infer CustomOptions>
       ? Hook extends RawHook

--- a/packages/rolldown/src/utils/normalize-plugin-option.ts
+++ b/packages/rolldown/src/utils/normalize-plugin-option.ts
@@ -17,7 +17,7 @@ export const normalizePluginOption: {
 export function checkOutputPluginOption(
   plugins: RolldownOutputPlugin[],
   onLog: LogHandler,
-) {
+): RolldownOutputPlugin[] {
   for (const plugin of plugins) {
     for (const hook of ENUMERATED_INPUT_PLUGIN_HOOK_NAMES) {
       if (hook in plugin) {

--- a/packages/rolldown/src/utils/plugin/index.ts
+++ b/packages/rolldown/src/utils/plugin/index.ts
@@ -3,7 +3,9 @@ import {
   PluginHookNames,
 } from '../../constants/plugin'
 
-export const isPluginHookName = (function () {
+export const isPluginHookName: (
+  hookName: string,
+) => hookName is PluginHookNames = (function () {
   const PLUGIN_HOOK_NAMES_SET = new Set(
     ENUMERATED_PLUGIN_HOOK_NAMES as readonly string[],
   )

--- a/packages/rolldown/src/utils/transform-sourcemap.ts
+++ b/packages/rolldown/src/utils/transform-sourcemap.ts
@@ -1,4 +1,4 @@
-import { ExistingRawSourceMap, SourceMapInput } from '../types/sourcemap'
+import { type ExistingRawSourceMap, SourceMapInput } from '../types/sourcemap'
 
 export function isEmptySourcemapFiled(
   array: undefined | (string | null)[],
@@ -16,7 +16,7 @@ export function normalizeTransformHookSourcemap(
   id: string,
   originalCode: string,
   rawMap?: SourceMapInput,
-) {
+): ExistingRawSourceMap | undefined {
   if (!rawMap) {
     return
   }

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -133,7 +133,7 @@ export function transformToRollupOutput(
   } as RolldownOutput
 }
 
-export function handleOutputErrors(output: BindingOutputs) {
+export function handleOutputErrors(output: BindingOutputs): void {
   const rawErrors = output.errors
   if (rawErrors.length > 0) {
     throw normalizeErrors(rawErrors)

--- a/packages/rolldown/src/utils/zod-ext.ts
+++ b/packages/rolldown/src/utils/zod-ext.ts
@@ -1,26 +1,37 @@
+import type Z from 'zod'
 import { z } from 'zod'
 
-export const stringOrRegExp = () => z.string().or(z.instanceof(RegExp))
+export const stringOrRegExp = (): Z.ZodUnion<
+  [Z.ZodString, Z.ZodType<RegExp, Z.ZodTypeDef, RegExp>]
+> => z.string().or(z.instanceof(RegExp))
 
-export const optionalStringArray = () => z.string().array().optional()
+export const optionalStringArray = (): Z.ZodOptional<
+  Z.ZodArray<Z.ZodString, 'many'>
+> => z.string().array().optional()
 
 const returnTrue = () => true
 
 /**
  * We use this to ensure the type of a value is `T` but the value is not checked.
  */
-export const phantom = <T>() => z.custom<T>(returnTrue)
+export const phantom = <T>(): Z.ZodType<T> => z.custom<T>(returnTrue)
 
 /**
  * @description Shortcut for `T | null | undefined | void`
  */
-export const voidNullableWith = <T extends z.ZodTypeAny>(t: T) => {
+export const voidNullableWith = <T extends z.ZodTypeAny>(
+  t: T,
+): Z.ZodUnion<
+  [Z.ZodUnion<[Z.ZodUnion<[Z.ZodVoid, Z.ZodNull]>, Z.ZodUndefined]>, T]
+> => {
   return voidNullable().or(t)
 }
 
 /**
  * @description Shortcut for `T | null | undefined | void`
  */
-export const voidNullable = () => {
+export const voidNullable = (): Z.ZodUnion<
+  [Z.ZodUnion<[Z.ZodVoid, Z.ZodNull]>, Z.ZodUndefined]
+> => {
   return z.void().or(z.null()).or(z.undefined())
 }

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -48,12 +48,12 @@
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */
-    "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
-    "checkJs": true /* Enable error reporting in type-checked JavaScript files. */,
+    // "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
+    // "checkJs": true /* Enable error reporting in type-checked JavaScript files. */,
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
@@ -79,6 +79,7 @@
 
     /* Interop Constraints */
     "isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
+    // "isolatedDeclarations": true,
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- All changes are just adding explicit types.

Only 12 errors left and they are related to schemas. It's quite hard to add explicit types for these schemas. Inferred types are to complex.
```
Found 12 errors in 5 files.

Errors  Files
     1  src/cli/arguments/schema.ts:7
     5  src/log/logging.ts:10
     2  src/options/input-options-schema.ts:106
     1  src/options/output-options-schema.ts:167
     3  src/treeshake/module-side-effects.ts:7
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
