### PR TITLE
refactor: remove all derived `Deserialize` in `rolldown_binding` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,7 +2468,6 @@ dependencies = [
  "rolldown_tracing",
  "rolldown_utils",
  "rustc-hash",
- "serde",
  "tracing",
 ]
 

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -45,7 +45,6 @@ rolldown_sourcemap                      = { workspace = true }
 rolldown_tracing                        = { workspace = true }
 rolldown_utils                          = { workspace = true }
 rustc-hash                              = { workspace = true }
-serde                                   = { workspace = true }
 tracing                                 = { workspace = true }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "freebsd"), not(target_family = "wasm")))'.dependencies]

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_checks_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_checks_options.rs
@@ -1,8 +1,5 @@
-use serde::Deserialize;
-
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingChecksOptions {
   pub circular_dependency: Option<bool>,
 }

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -1,8 +1,5 @@
-use serde::Deserialize;
-
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingExperimentalOptions {
   pub strict_execution_order: Option<bool>,
   pub disable_live_bindings: Option<bool>,

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_inject_import.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_inject_import.rs
@@ -1,12 +1,10 @@
 use napi::Either;
 use rolldown::InjectImport;
-use serde::Deserialize;
 
 pub type BindingInjectImport = Either<BindingInjectImportNamed, BindingInjectImportNamespace>;
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingInjectImportNamed {
   #[napi(ts_type = "true")]
   pub tag_named: bool,
@@ -16,8 +14,7 @@ pub struct BindingInjectImportNamed {
 }
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingInjectImportNamespace {
   #[napi(ts_type = "true")]
   pub tag_namespace: bool,

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_input_item.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_input_item.rs
@@ -1,8 +1,5 @@
-use serde::Deserialize;
-
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingInputItem {
   pub name: Option<String>,
   pub import: String,

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_resolve_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_resolve_options.rs
@@ -1,10 +1,8 @@
 use crate::types::binding_resolve_alias_item::AliasItem;
 use crate::types::binding_resolve_extension_alias::ExtensionAliasItem;
-use serde::Deserialize;
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingResolveOptions {
   // Option<Vec<(String, Vec<String>)>>> is better, maybe NAPI-RS should support tuples.
   pub alias: Option<Vec<AliasItem>>,

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_watch_option.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_watch_option.rs
@@ -1,12 +1,9 @@
-use serde::Deserialize;
-
 use crate::options::plugin::types::binding_js_or_regex::{
   bindingify_string_or_regex_array, BindingStringOrRegex,
 };
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingWatchOption {
   pub skip_write: Option<bool>,
   pub include: Option<Vec<BindingStringOrRegex>>,

--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -9,7 +9,6 @@ use crate::types::{
 use binding_inject_import::BindingInjectImport;
 use derive_more::Debug;
 use napi_derive::napi;
-use serde::Deserialize;
 
 use self::{binding_input_item::BindingInputItem, binding_resolve_options::BindingResolveOptions};
 
@@ -24,8 +23,7 @@ mod binding_resolve_options;
 mod treeshake;
 
 #[napi(object, object_to_js = false)]
-#[derive(Deserialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug)]
 pub struct BindingInputOptions {
   // Not going to be supported
   // @deprecated Use the "inlineDynamicImports" output option instead.
@@ -37,7 +35,6 @@ pub struct BindingInputOptions {
   // context?: string;
   // experimentalCacheExpiry?: number;
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "undefined | ((source: string, importer: string | undefined, isResolved: boolean) => boolean)"
   )]
@@ -52,7 +49,6 @@ pub struct BindingInputOptions {
   // moduleContext?: ((id: string) => string | null | void) | { [id: string]: string };
   // onwarn?: WarningHandlerWithDefault;
   // perf?: boolean;
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(BindingBuiltinPlugin | BindingPluginOptions | undefined)[]")]
   pub plugins: Vec<BindingPluginOrParallelJsPluginPlaceholder>,
   pub resolve: Option<BindingResolveOptions>,
@@ -65,16 +61,13 @@ pub struct BindingInputOptions {
   // pub treeshake: Option<bool>,
   #[napi(ts_type = "'node' | 'browser' | 'neutral'")]
   pub platform: Option<String>,
-  #[serde(skip_deserializing)]
   pub log_level: BindingLogLevel,
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(logLevel: 'debug' | 'warn' | 'info', log: BindingLog) => void")]
   pub on_log: BindingOnLog,
   // extra
   pub cwd: String,
   // pub builtins: BuiltinsOptions,
-  #[serde(skip_deserializing)]
   pub treeshake: Option<treeshake::BindingTreeshake>,
 
   // TODO(sapphi-red): remove `ts_type` and use HashMap<K, V, S> instead once https://github.com/napi-rs/napi-rs/pull/2384 is released
@@ -82,12 +75,10 @@ pub struct BindingInputOptions {
   pub module_types: Option<FxHashMap<String, String>>,
   pub define: Option<Vec<(/* Target to be replaced */ String, /* Replacement */ String)>>,
   pub drop_labels: Option<Vec<String>>,
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "Array<BindingInjectImportNamed | BindingInjectImportNamespace>")]
   pub inject: Option<Vec<BindingInjectImport>>,
   pub experimental: Option<binding_experimental_options::BindingExperimentalOptions>,
   pub profiler_names: Option<bool>,
-  #[serde(skip_deserializing)]
   #[debug(skip)]
   pub jsx: Option<JsxOptions>,
   pub watch: Option<BindingWatchOption>,

--- a/crates/rolldown_binding/src/options/binding_input_options/treeshake.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/treeshake.rs
@@ -3,7 +3,6 @@ use std::{fmt::Debug, sync::Arc};
 use napi::bindgen_prelude::Either3;
 use rolldown::{InnerOptions, ModuleSideEffects, ModuleSideEffectsRule};
 use rolldown_utils::js_regex::HybridRegex;
-use serde::Deserialize;
 
 use crate::{
   options::plugin::types::binding_js_or_regex::JsRegExp,
@@ -13,13 +12,10 @@ use crate::{
 pub(crate) type BindingModuleSideEffects =
   Either3<bool, Vec<BindingModuleSideEffectsRule>, JsCallback<(String, bool), Option<bool>>>;
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct BindingTreeshake {
   #[napi(
     ts_type = "boolean | BindingModuleSideEffectsRule[] | ((id: string, is_external: boolean) => boolean | undefined)"
   )]
-  #[serde(skip_deserializing, default = "default_module_side_effects")]
   pub module_side_effects: BindingModuleSideEffects,
   pub annotations: Option<bool>,
 }
@@ -32,13 +28,8 @@ impl Debug for BindingTreeshake {
   }
 }
 
-fn default_module_side_effects() -> BindingModuleSideEffects {
-  Either3::A(true)
-}
-
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingModuleSideEffectsRule {
   #[napi(ts_type = "RegExp | undefined")]
   pub test: Option<JsRegExp>,

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -9,7 +9,6 @@ use derive_more::Debug;
 use napi::Either;
 use napi_derive::napi;
 use rustc_hash::FxHashMap;
-use serde::Deserialize;
 use types::binding_advanced_chunks_options::BindingAdvancedChunksOptions;
 
 pub type AddonOutputOption = MaybeAsyncJsCallback<RenderedChunk, Option<String>>;
@@ -17,8 +16,7 @@ pub type ChunkFileNamesOutputOption = Either<String, JsCallback<PreRenderedChunk
 pub type GlobalsOutputOption = Either<FxHashMap<String, String>, JsCallback<String, String>>;
 
 #[napi(object, object_to_js = false)]
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct BindingOutputOptions {
   // --- Options Rolldown doesn't need to be supported
   // /** @deprecated Use the "renderDynamicImport" plugin hook instead. */
@@ -27,26 +25,21 @@ pub struct BindingOutputOptions {
   pub asset_file_names: Option<String>,
 
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "string | ((chunk: PreRenderedChunk) => string)")]
   pub entry_file_names: Option<ChunkFileNamesOutputOption>,
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "string | ((chunk: PreRenderedChunk) => string)")]
   pub chunk_file_names: Option<ChunkFileNamesOutputOption>,
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "string | ((chunk: PreRenderedChunk) => string)")]
   pub css_entry_file_names: Option<ChunkFileNamesOutputOption>,
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "string | ((chunk: PreRenderedChunk) => string)")]
   pub css_chunk_file_names: Option<ChunkFileNamesOutputOption>,
 
   // amd: NormalizedAmdOptions;
   // assetFileNames: string | ((chunkInfo: PreRenderedAsset) => string);
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>")]
   pub banner: Option<AddonOutputOption>,
   // chunkFileNames: string | ((chunkInfo: PreRenderedChunk) => string);
@@ -54,7 +47,6 @@ pub struct BindingOutputOptions {
   pub dir: Option<String>,
   pub file: Option<String>,
   // pub entry_file_names: String, // | ((chunkInfo: PreRenderedChunk) => string)
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "boolean | 'if-default-prop'")]
   pub es_module: Option<Either<bool, String>>,
   #[napi(ts_type = "'default' | 'named' | 'none' | 'auto'")]
@@ -63,7 +55,6 @@ pub struct BindingOutputOptions {
   pub external_live_bindings: Option<bool>,
   // footer: () => string | Promise<string>;
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>")]
   pub footer: Option<AddonOutputOption>,
   #[napi(ts_type = "'es' | 'cjs' | 'iife' | 'umd' | 'app'")]
@@ -71,7 +62,6 @@ pub struct BindingOutputOptions {
   // freeze: boolean;
   // generatedCode: NormalizedGeneratedCodeOptions;
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "Record<string, string> | ((name: string) => string)")]
   pub globals: Option<GlobalsOutputOption>,
   #[napi(ts_type = "'base64' | 'base36' | 'hex'")]
@@ -81,7 +71,6 @@ pub struct BindingOutputOptions {
   pub inline_dynamic_imports: Option<bool>,
   // interop: GetInterop;
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>")]
   pub intro: Option<AddonOutputOption>,
   // manualChunks: ManualChunksOption;
@@ -89,11 +78,9 @@ pub struct BindingOutputOptions {
   // namespaceToStringTag: boolean;
   // noConflict: boolean;
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(chunk: RenderedChunk) => MaybePromise<VoidNullable<string>>")]
   pub outro: Option<AddonOutputOption>,
   // paths: OptionsPaths;
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(BindingBuiltinPlugin | BindingPluginOptions | undefined)[]")]
   pub plugins: Vec<BindingPluginOrParallelJsPluginPlaceholder>,
   // preferConst: boolean;
@@ -103,12 +90,10 @@ pub struct BindingOutputOptions {
   #[napi(ts_type = "'file' | 'inline' | 'hidden'")]
   pub sourcemap: Option<String>,
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(source: string, sourcemapPath: string) => boolean")]
   pub sourcemap_ignore_list: Option<JsCallback<(String, String), bool>>,
   pub sourcemap_debug_ids: Option<bool>,
   #[debug(skip)]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(source: string, sourcemapPath: string) => string")]
   pub sourcemap_path_transform: Option<JsCallback<(String, String), String>>,
   // sourcemapExcludeSources: boolean;

--- a/crates/rolldown_binding/src/options/binding_output_options/types/binding_advanced_chunks_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/types/binding_advanced_chunks_options.rs
@@ -1,10 +1,7 @@
-use serde::Deserialize;
-
 use crate::options::plugin::types::binding_js_or_regex::BindingStringOrRegex;
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct BindingAdvancedChunksOptions {
   pub min_size: Option<f64>,
   pub min_share_count: Option<u32>,
@@ -12,8 +9,7 @@ pub struct BindingAdvancedChunksOptions {
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct BindingMatchGroup {
   pub name: String,
   pub test: Option<BindingStringOrRegex>,

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -20,7 +20,6 @@ use rolldown_plugin_vite_resolve::{
 use rolldown_plugin_wasm_fallback::WasmFallbackPlugin;
 use rolldown_plugin_wasm_helper::WasmHelperPlugin;
 use rustc_hash::FxHashMap;
-use serde::Deserialize;
 use std::sync::Arc;
 
 use super::types::binding_builtin_plugin_name::BindingBuiltinPluginName;
@@ -30,11 +29,9 @@ use crate::types::js_callback::{JsCallback, JsCallbackExt};
 
 #[allow(clippy::pub_underscore_fields)]
 #[napi(object)]
-#[derive(Deserialize)]
 pub struct BindingBuiltinPlugin {
   #[napi(js_name = "__name")]
   pub __name: BindingBuiltinPluginName,
-  #[serde(skip_deserializing)]
   pub options: Option<JsUnknown>,
 }
 
@@ -48,8 +45,7 @@ impl std::fmt::Debug for BindingBuiltinPlugin {
 }
 
 #[napi_derive::napi(object)]
-#[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingGlobImportPluginConfig {
   pub root: Option<String>,
   pub restore_query_extension: Option<bool>,
@@ -65,8 +61,7 @@ impl From<BindingGlobImportPluginConfig> for ImportGlobPluginConfig {
 }
 
 #[napi_derive::napi(object)]
-#[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingManifestPluginConfig {
   pub root: String,
   pub out_path: String,
@@ -81,8 +76,7 @@ impl From<BindingManifestPluginConfig> for ManifestPluginConfig {
 }
 
 #[napi_derive::napi(object)]
-#[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingModulePreloadPolyfillPluginConfig {
   pub skip: Option<bool>,
 }
@@ -118,8 +112,7 @@ impl TryFrom<BindingJsonPluginStringify> for JsonPluginStringify {
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingTransformPluginConfig {
   pub include: Option<Vec<BindingStringOrRegex>>,
   pub exclude: Option<Vec<BindingStringOrRegex>>,
@@ -130,23 +123,20 @@ pub struct BindingTransformPluginConfig {
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingAliasPluginConfig {
   pub entries: Vec<BindingAliasPluginAlias>,
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct BindingAliasPluginAlias {
   pub find: BindingStringOrRegex,
   pub replacement: String,
 }
 
 #[napi_derive::napi(object)]
-#[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct BindingBuildImportAnalysisPluginConfig {
   pub preload_code: String,
@@ -157,27 +147,22 @@ pub struct BindingBuildImportAnalysisPluginConfig {
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct BindingViteResolvePluginConfig {
   pub resolve_options: BindingViteResolvePluginResolveOptions,
   pub environment_consumer: String,
   pub environment_name: String,
-  #[serde(with = "EitherTrueVecStringDeserializeEnabler")]
   #[napi(ts_type = "true | string[]")]
   pub external: napi::Either<BindingTrueValue, Vec<String>>,
-  #[serde(with = "EitherTrueVecStringRegexDeserializeEnabler")]
   #[napi(ts_type = "true | Array<string | RegExp>")]
   pub no_external: napi::Either<BindingTrueValue, Vec<BindingStringOrRegex>>,
   pub dedupe: Vec<String>,
   #[debug("{}", if finalize_bare_specifier.is_some() { "Some(<finalize_bare_specifier>)" } else { "None" })]
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(resolvedId: string, rawId: string, importer: string | null | undefined) => VoidNullable<string>"
   )]
   pub finalize_bare_specifier: Option<JsCallback<(String, String, Option<String>), Option<String>>>,
   #[debug("{}", if finalize_bare_specifier.is_some() { "Some(<finalize_other_specifiers>)" } else { "None" })]
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(resolvedId: string, rawId: string) => VoidNullable<string>")]
   pub finalize_other_specifiers: Option<JsCallback<(String, String), Option<String>>>,
 
@@ -241,8 +226,7 @@ impl TryFrom<BindingViteResolvePluginConfig> for ViteResolveOptions {
 }
 
 #[napi_derive::napi(object)]
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct BindingViteResolvePluginResolveOptions {
   pub is_build: bool,
@@ -282,20 +266,6 @@ impl From<BindingViteResolvePluginResolveOptions> for ViteResolveResolveOptions 
       preserve_symlinks: value.preserve_symlinks,
     }
   }
-}
-
-#[derive(Deserialize)]
-#[serde(remote = "napi::bindgen_prelude::Either<BindingTrueValue, Vec<String>>")]
-enum EitherTrueVecStringDeserializeEnabler {
-  A(BindingTrueValue),
-  B(Vec<String>),
-}
-
-#[derive(Deserialize)]
-#[serde(remote = "napi::bindgen_prelude::Either<BindingTrueValue, Vec<BindingStringOrRegex>>")]
-enum EitherTrueVecStringRegexDeserializeEnabler {
-  A(BindingTrueValue),
-  B(Vec<BindingStringOrRegex>),
 }
 
 impl TryFrom<BindingBuildImportAnalysisPluginConfig> for BuildImportAnalysisPlugin {
@@ -447,8 +417,7 @@ impl TryFrom<BindingBuiltinPlugin> for Arc<dyn Pluginable> {
 }
 
 #[napi_derive::napi(object)]
-#[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingReplacePluginConfig {
   // It's ok we use `HashMap` here, because we don't care about the order of the keys.
   // TODO(sapphi-red): remove `ts_type` and use HashMap<K, V, S> instead once https://github.com/napi-rs/napi-rs/pull/2384 is released

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_hook_meta.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_hook_meta.rs
@@ -1,7 +1,6 @@
 use napi_derive::napi;
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 #[napi]
 pub enum BindingPluginOrder {
   Pre,
@@ -18,8 +17,7 @@ impl From<BindingPluginOrder> for rolldown_plugin::PluginOrder {
 }
 
 #[napi(object, object_to_js = false)]
-#[derive(Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct BindingPluginHookMeta {
   pub order: Option<BindingPluginOrder>,
 }

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -1,5 +1,4 @@
 use napi::bindgen_prelude::Either;
-use serde::Deserialize;
 use std::fmt::Debug;
 
 use crate::types::{
@@ -31,12 +30,10 @@ pub type BindingPluginOrParallelJsPluginPlaceholder =
   Option<Either<BindingPluginOptions, BindingBuiltinPlugin>>;
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct BindingPluginOptions {
   pub name: String,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable>"
   )]
@@ -44,7 +41,6 @@ pub struct BindingPluginOptions {
     Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingNormalizedOptions), ()>>,
   pub build_start_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, specifier: string, importer: Nullable<string>, options: BindingHookResolveIdExtraArgs) => MaybePromise<VoidNullable<BindingHookResolveIdOutput>>"
   )]
@@ -57,7 +53,6 @@ pub struct BindingPluginOptions {
   pub resolve_id_meta: Option<BindingPluginHookMeta>,
   pub resolve_id_filter: Option<BindingGeneralHookFilter>,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, specifier: string, importer: Nullable<string>) => MaybePromise<VoidNullable<BindingHookResolveIdOutput>>"
   )]
@@ -69,7 +64,6 @@ pub struct BindingPluginOptions {
   >,
   pub resolve_dynamic_import_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, id: string) => MaybePromise<VoidNullable<BindingHookLoadOutput>>"
   )]
@@ -78,7 +72,6 @@ pub struct BindingPluginOptions {
   pub load_meta: Option<BindingPluginHookMeta>,
   pub load_filter: Option<BindingGeneralHookFilter>,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx:  BindingTransformPluginContext, id: string, code: string, module_type: BindingTransformHookExtraArgs) => MaybePromise<VoidNullable<BindingHookTransformOutput>>"
   )]
@@ -91,14 +84,12 @@ pub struct BindingPluginOptions {
   pub transform_meta: Option<BindingPluginHookMeta>,
   pub transform_filter: Option<BindingTransformHookFilter>,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, module: BindingModuleInfo) => MaybePromise<VoidNullable>"
   )]
   pub module_parsed: Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingModuleInfo), ()>>,
   pub module_parsed_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, error?: (Error | BindingError)[]) => MaybePromise<VoidNullable>"
   )]
@@ -110,7 +101,6 @@ pub struct BindingPluginOptions {
   >,
   pub build_end_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, code: string, chunk: RenderedChunk, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>"
   )]
@@ -122,7 +112,6 @@ pub struct BindingPluginOptions {
   >,
   pub render_chunk_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => MaybePromise<void | string>"
   )]
@@ -130,18 +119,15 @@ pub struct BindingPluginOptions {
     Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
   pub augment_chunk_hash_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext, opts: BindingNormalizedOptions) => void")]
   pub render_start:
     Option<MaybeAsyncJsCallback<(BindingPluginContext, BindingNormalizedOptions), ()>>,
   pub render_start_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext, error: string) => void")]
   pub render_error: Option<MaybeAsyncJsCallback<(BindingPluginContext, String), ()>>,
   pub render_error_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<JsChangedOutputs>>"
   )]
@@ -153,7 +139,6 @@ pub struct BindingPluginOptions {
   >,
   pub generate_bundle_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, bundle: BindingOutputs, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<JsChangedOutputs>>"
   )]
@@ -165,39 +150,32 @@ pub struct BindingPluginOptions {
   >,
   pub write_bundle_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext) => MaybePromise<VoidNullable>")]
   pub close_bundle: Option<MaybeAsyncJsCallback<BindingPluginContext, ()>>,
   pub close_bundle_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(
     ts_type = "(ctx: BindingPluginContext, path: string, event: string) => MaybePromise<VoidNullable>"
   )]
   pub watch_change: Option<MaybeAsyncJsCallback<(BindingPluginContext, String, String), ()>>,
   pub watch_change_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext) => MaybePromise<VoidNullable>")]
   pub close_watcher: Option<MaybeAsyncJsCallback<BindingPluginContext, ()>>,
   pub close_watcher_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
   pub banner: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
   pub banner_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
   pub footer: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
   pub footer_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
   pub intro: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
   pub intro_meta: Option<BindingPluginHookMeta>,
 
-  #[serde(skip_deserializing)]
   #[napi(ts_type = "(ctx: BindingPluginContext, chunk: RenderedChunk) => void")]
   pub outro: Option<MaybeAsyncJsCallback<(BindingPluginContext, RenderedChunk), Option<String>>>,
   pub outro_meta: Option<BindingPluginHookMeta>,
@@ -210,8 +188,7 @@ impl Debug for BindingPluginOptions {
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingPluginWithIndex {
   pub index: u32,
   pub plugin: BindingPluginOptions,

--- a/crates/rolldown_binding/src/options/plugin/types/binding_asset_source.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_asset_source.rs
@@ -1,12 +1,9 @@
 use napi::bindgen_prelude::Buffer;
 use napi::Either;
-use serde::Deserialize;
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize)]
 pub struct BindingAssetSource {
   #[napi(ts_type = "string | Uint8Array")]
-  #[serde(skip_deserializing, default = "default_source")]
   pub inner: Either<String, Buffer>,
 }
 

--- a/crates/rolldown_binding/src/options/plugin/types/binding_builtin_plugin_name.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_builtin_plugin_name.rs
@@ -1,7 +1,6 @@
 use napi_derive::napi;
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 #[napi(string_enum)]
 pub enum BindingBuiltinPluginName {
   #[napi(value = "builtin:wasm-helper")]

--- a/crates/rolldown_binding/src/options/plugin/types/binding_emitted_asset.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_emitted_asset.rs
@@ -1,9 +1,7 @@
-use serde::Deserialize;
-
 use super::binding_asset_source::BindingAssetSource;
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Debug)]
+#[derive(Default, Debug)]
 pub struct BindingEmittedAsset {
   pub name: Option<String>,
   pub file_name: Option<String>,

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_filter.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_filter.rs
@@ -1,12 +1,10 @@
 use rolldown::ModuleType;
 use rolldown_plugin::{GeneralHookFilter, ResolvedIdHookFilter, TransformHookFilter};
-use serde::Deserialize;
 
 use super::binding_js_or_regex::{bindingify_string_or_regex_array, BindingStringOrRegex};
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
 pub struct BindingGeneralHookFilter {
   pub include: Option<Vec<BindingStringOrRegex>>,
   pub exclude: Option<Vec<BindingStringOrRegex>>,
@@ -35,8 +33,7 @@ impl TryFrom<BindingGeneralHookFilter> for ResolvedIdHookFilter {
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Deserialize, Default, Clone)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Clone)]
 pub struct BindingTransformHookFilter {
   pub code: Option<BindingGeneralHookFilter>,
   pub module_type: Option<Vec<String>>,

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_load_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_load_output.rs
@@ -1,12 +1,10 @@
 use rolldown::ModuleType;
-use serde::Deserialize;
 
 use super::binding_hook_side_effects::BindingHookSideEffects;
 use crate::types::binding_sourcemap::BindingSourcemap;
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug)]
 pub struct BindingHookLoadOutput {
   pub code: String,
   pub side_effects: Option<BindingHookSideEffects>,

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_render_chunk_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_render_chunk_output.rs
@@ -1,10 +1,7 @@
-use serde::Deserialize;
-
 use crate::types::binding_sourcemap::BindingSourcemap;
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug)]
 pub struct BindingHookRenderChunkOutput {
   pub code: String,
   pub map: Option<BindingSourcemap>,

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_extra_args.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_extra_args.rs
@@ -1,8 +1,5 @@
-use serde::Deserialize;
-
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug)]
 pub struct BindingHookResolveIdExtraArgs {
   pub custom: Option<u32>,
   pub is_entry: bool,

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_output.rs
@@ -1,10 +1,7 @@
-use serde::Deserialize;
-
 use super::binding_hook_side_effects::BindingHookSideEffects;
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug)]
 pub struct BindingHookResolveIdOutput {
   pub id: String,
   pub external: Option<bool>,

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_side_effects.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_side_effects.rs
@@ -1,7 +1,6 @@
 use napi_derive::napi;
-use serde::Deserialize;
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 #[napi]
 pub enum BindingHookSideEffects {
   True,

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_transform_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_transform_output.rs
@@ -1,12 +1,10 @@
 use rolldown::ModuleType;
-use serde::Deserialize;
 
 use super::binding_hook_side_effects::BindingHookSideEffects;
 use crate::types::binding_sourcemap::BindingSourcemap;
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug)]
 pub struct BindingHookTransformOutput {
   pub code: Option<String>,
   pub side_effects: Option<BindingHookSideEffects>,

--- a/crates/rolldown_binding/src/options/plugin/types/binding_js_or_regex.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_js_or_regex.rs
@@ -4,12 +4,11 @@ use napi::{
   bindgen_prelude::{FromNapiValue, Function, TypeName, ValidateNapiValue},
   sys, Either, Env, Error, JsObject, JsUnknown, NapiValue, Status,
 };
-use serde::{Deserialize, Deserializer};
 
 use rolldown_utils::js_regex::HybridRegex;
 use rolldown_utils::pattern_filter::StringOrRegex;
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct JsRegExp {
   pub source: String,
   pub flags: String,
@@ -52,15 +51,6 @@ pub struct BindingStringOrRegex(pub Either<String, JsRegExp>);
 impl FromNapiValue for BindingStringOrRegex {
   unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
     Ok(Self(Either::from_napi_value(env, napi_val)?))
-  }
-}
-
-impl<'de> Deserialize<'de> for BindingStringOrRegex {
-  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-  where
-    D: Deserializer<'de>,
-  {
-    Ok(Self(Either::A(String::deserialize(deserializer)?)))
   }
 }
 

--- a/crates/rolldown_binding/src/options/plugin/types/binding_limited_boolean.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_limited_boolean.rs
@@ -1,7 +1,6 @@
 use napi::bindgen_prelude::{FromNapiValue, ToNapiValue, TypeName, ValidateNapiValue};
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub struct LimitedBooleanValue<const VALUE: bool>();
 
 impl<const VALUE: bool> ValidateNapiValue for LimitedBooleanValue<VALUE> {}

--- a/crates/rolldown_binding/src/options/plugin/types/binding_plugin_context_resolve_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_plugin_context_resolve_options.rs
@@ -1,13 +1,11 @@
 use std::sync::Arc;
 
 use rolldown_plugin::{CustomField, PluginContextResolveOptions};
-use serde::Deserialize;
 
 use crate::options::plugin::JsPluginContextResolveCustomArgId;
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingPluginContextResolveOptions {
   #[napi(ts_type = "'import' | 'dynamic-import' | 'require-call'")]
   pub import_kind: Option<String>,

--- a/crates/rolldown_binding/src/options/plugin/types/binding_plugin_transform_extra_args.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_plugin_transform_extra_args.rs
@@ -1,8 +1,5 @@
-use serde::Deserialize;
-
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug)]
 pub struct BindingTransformHookExtraArgs {
   pub module_type: String,
 }

--- a/crates/rolldown_binding/src/types/binding_pre_rendered_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_pre_rendered_chunk.rs
@@ -1,8 +1,5 @@
-use serde::Deserialize;
-
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug)]
 pub struct PreRenderedChunk {
   pub name: String,
   pub is_entry: bool,

--- a/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
@@ -1,12 +1,10 @@
 use arcstr::ArcStr;
 use rustc_hash::FxHashMap;
-use serde::Deserialize;
 
 use super::binding_rendered_module::BindingRenderedModule;
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug)]
 pub struct RenderedChunk {
   // PreRenderedChunk
   pub name: String,
@@ -17,7 +15,6 @@ pub struct RenderedChunk {
   pub exports: Vec<String>,
   // RenderedChunk
   pub file_name: String,
-  #[serde(skip)]
   #[napi(ts_type = "Record<string, BindingRenderedModule>")]
   pub modules: BindingChunkModules,
   pub imports: Vec<String>,

--- a/crates/rolldown_binding/src/types/binding_resolve_alias_item.rs
+++ b/crates/rolldown_binding/src/types/binding_resolve_alias_item.rs
@@ -1,8 +1,5 @@
-use serde::Deserialize;
-
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct AliasItem {
   pub find: String,
   pub replacements: Vec<String>,

--- a/crates/rolldown_binding/src/types/binding_resolve_extension_alias.rs
+++ b/crates/rolldown_binding/src/types/binding_resolve_extension_alias.rs
@@ -1,8 +1,5 @@
-use serde::Deserialize;
-
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct ExtensionAliasItem {
   pub target: String,
   pub replacements: Vec<String>,

--- a/crates/rolldown_binding/src/types/binding_sourcemap.rs
+++ b/crates/rolldown_binding/src/types/binding_sourcemap.rs
@@ -1,15 +1,9 @@
 use napi::Either;
-use serde::Deserialize;
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
 pub struct BindingSourcemap {
-  #[serde(skip_deserializing, default = "default_sourcemap")]
   pub inner: Either<String, BindingJsonSourcemap>,
-}
-
-fn default_sourcemap() -> Either<String, BindingJsonSourcemap> {
-  Either::A(String::default())
 }
 
 impl TryFrom<BindingSourcemap> for rolldown_sourcemap::SourceMap {
@@ -24,7 +18,7 @@ impl TryFrom<BindingSourcemap> for rolldown_sourcemap::SourceMap {
   }
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Debug, Default)]
 #[napi_derive::napi(object)]
 pub struct BindingJsonSourcemap {
   pub file: Option<String>,

--- a/crates/rolldown_binding/src/watcher.rs
+++ b/crates/rolldown_binding/src/watcher.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use napi_derive::napi;
-use serde::Deserialize;
 
 use crate::bundler::{BindingBundlerOptions, Bundler};
 use crate::types::binding_watcher_event::BindingWatcherEvent;
@@ -14,8 +13,7 @@ use crate::utils::handle_result;
 use crate::types::js_callback::{MaybeAsyncJsCallback, MaybeAsyncJsCallbackExt};
 
 #[napi_derive::napi(object)]
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BindingNotifyOption {
   pub poll_interval: Option<u32>,
   pub compare_contents: Option<bool>,


### PR DESCRIPTION
### Description

closes #3109