### PR TITLE
test: test transform with empty sourcemap

### DIFF
--- a/packages/rolldown/tests/fixtures/misc/repro/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/repro/_config.ts
@@ -1,0 +1,58 @@
+import { defineTest } from '@tests'
+import { getLocation } from '@tests/utils'
+import { SourceMapConsumer } from 'source-map'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    output: {
+      sourcemap: 'inline',
+    },
+    plugins: [
+      {
+        name: 'repro',
+        transform(_code, id) {
+          if (id.includes('dep2')) {
+            return {
+              code: `export default "dep2-generated"`,
+              map: { mappings: '' },
+            }
+          }
+        },
+      },
+    ],
+  },
+  async afterTest(output) {
+    const chunk = output.output[0]
+    const code = chunk.code
+    const smc = await new SourceMapConsumer(chunk.map!)
+    expect([
+      smc.originalPositionFor(getLocation(code, code.indexOf(`dep1-test`))),
+      smc.originalPositionFor(
+        getLocation(code, code.indexOf(`dep2-generated`)),
+      ),
+      smc.originalPositionFor(getLocation(code, code.indexOf(`dep3-test`))),
+    ]).toMatchInlineSnapshot(`
+      [
+        {
+          "column": 15,
+          "line": 1,
+          "name": null,
+          "source": "../dep1.js",
+        },
+        {
+          "column": null,
+          "line": null,
+          "name": null,
+          "source": null,
+        },
+        {
+          "column": 15,
+          "line": 1,
+          "name": null,
+          "source": "../dep3.js",
+        },
+      ]
+    `)
+  },
+})

--- a/packages/rolldown/tests/fixtures/misc/repro/dep1.js
+++ b/packages/rolldown/tests/fixtures/misc/repro/dep1.js
@@ -1,0 +1,1 @@
+export default "dep1-test"

--- a/packages/rolldown/tests/fixtures/misc/repro/dep2.js
+++ b/packages/rolldown/tests/fixtures/misc/repro/dep2.js
@@ -1,0 +1,1 @@
+export default "dep2-test"

--- a/packages/rolldown/tests/fixtures/misc/repro/dep3.js
+++ b/packages/rolldown/tests/fixtures/misc/repro/dep3.js
@@ -1,0 +1,1 @@
+export default "dep3-test"

--- a/packages/rolldown/tests/fixtures/misc/repro/main.js
+++ b/packages/rolldown/tests/fixtures/misc/repro/main.js
@@ -1,0 +1,4 @@
+import dep1 from "./dep1"
+import dep2 from "./dep2"
+import dep3 from "./dep3"
+console.log(dep1, dep2, dep3)


### PR DESCRIPTION
### Description

- related https://github.com/rolldown/rolldown/issues/3090

I added rolldown side test for https://github.com/rolldown/rolldown/issues/3090 since it involves more moving parts than just concatenating, which is tested in oxc-sourcemap.