### PR TITLE
chore(deps): bump oxlint to v0.15.0

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,7 +8,7 @@
     ],
     "unicorn/prefer-node-protocol": "error",
     "import/namespace": [
-      "allow",
+      "error",
       {
         "allowComputed": true
       }

--- a/examples/par-plugin/parallel-babel-plugin/index.js
+++ b/examples/par-plugin/parallel-babel-plugin/index.js
@@ -1,4 +1,4 @@
-import { defineParallelPlugin } from 'rolldown'
+import { defineParallelPlugin } from 'rolldown/experimental'
 import path from 'node:path'
 
 /** @type {import('rolldown').DefineParallelPluginResult<void>} */

--- a/examples/par-plugin/parallel-esbuild-plugin/index.js
+++ b/examples/par-plugin/parallel-esbuild-plugin/index.js
@@ -1,4 +1,4 @@
-import { defineParallelPlugin } from 'rolldown'
+import { defineParallelPlugin } from 'rolldown/experimental'
 import path from 'node:path'
 
 /** @type {import('rolldown').DefineParallelPluginResult<void>} */

--- a/examples/par-plugin/parallel-noop-plugin/index.js
+++ b/examples/par-plugin/parallel-noop-plugin/index.js
@@ -1,4 +1,4 @@
-import { defineParallelPlugin } from 'rolldown'
+import { defineParallelPlugin } from 'rolldown/experimental'
 import path from 'node:path'
 
 /** @type {import('rolldown').DefineParallelPluginResult<void>} */

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "husky": "^9.0.0",
     "lint-staged": "^15.2.5",
     "npm-run-all": "^4.1.5",
-    "oxlint": "0.14.1",
+    "oxlint": "0.15.0",
     "prettier": "^3.3.1",
     "rolldown": "workspace:*",
     "typescript": "^5.6.3",

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -8,11 +8,18 @@
     "type-check": "tsc"
   },
   "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "vue": "^3.4.27",
+    "vue-router": "^4.3.2"
+  },
+  "devDependencies": {
     "@babel/core": "^7.24.7",
     "@babel/preset-env": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
+    "@types/babel__core": "7.20.5",
     "@types/lodash": "^4.17.5",
     "chalk": "^5.3.0",
     "esbuild": "^0.24.0",
@@ -20,12 +27,5 @@
     "rolldown": "workspace:*",
     "rollup": "^4.18.0",
     "tinybench": "^3.0.0"
-  },
-  "devDependencies": {
-    "@types/babel__core": "7.20.5",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "vue": "^3.4.27",
-    "vue-router": "^4.3.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       oxlint:
-        specifier: 0.14.1
-        version: 0.14.1
+        specifier: 0.15.0
+        version: 0.15.0
       prettier:
         specifier: ^3.3.1
         version: 3.3.3
@@ -121,6 +121,19 @@ importers:
 
   packages/bench:
     dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.0.0(react@19.0.0)
+      vue:
+        specifier: ^3.4.27
+        version: 3.5.12(typescript@5.6.3)
+      vue-router:
+        specifier: ^4.3.2
+        version: 4.4.5(vue@3.5.12(typescript@5.6.3))
+    devDependencies:
       '@babel/core':
         specifier: ^7.24.7
         version: 7.26.0
@@ -136,6 +149,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^15.2.3
         version: 15.3.0(rollup@4.24.3)
+      '@types/babel__core':
+        specifier: 7.20.5
+        version: 7.20.5
       '@types/lodash':
         specifier: ^4.17.5
         version: 4.17.13
@@ -157,22 +173,6 @@ importers:
       tinybench:
         specifier: ^3.0.0
         version: 3.0.3
-    devDependencies:
-      '@types/babel__core':
-        specifier: 7.20.5
-        version: 7.20.5
-      react:
-        specifier: ^19.0.0
-        version: 19.0.0
-      react-dom:
-        specifier: ^19.0.0
-        version: 19.0.0(react@19.0.0)
-      vue:
-        specifier: ^3.4.27
-        version: 3.5.12(typescript@5.6.3)
-      vue-router:
-        specifier: ^4.3.2
-        version: 4.4.5(vue@3.5.12(typescript@5.6.3))
 
   packages/rolldown:
     dependencies:
@@ -2160,7 +2160,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2718,43 +2717,43 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/darwin-arm64@0.14.1':
-    resolution: {integrity: sha512-P76G8QCHOkLm+8HYk2/5uR4sPnx6uxE5Y8ik8dgCV0XjrNR+/Sg8v2aQ1BmWeEnPGkBXTt1VSECO9BdT1HVeDw==}
+  '@oxlint/darwin-arm64@0.15.0':
+    resolution: {integrity: sha512-Y4yFRquejyuI/3dyBxLvc8lbwM8Hf/8e0YH9QwQPD9+dgzgOnF818/+OKVE4bDH/V7nWyw4hIQQibMcPvg038g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/darwin-x64@0.14.1':
-    resolution: {integrity: sha512-bFsNkDtiDEhBKsX2DGLGCVhaRSDP2VgnNHOejjVnLK2LURvOglHMrp4NXxxtHArPAfiP6oezja6q8GmsQbcZ4w==}
+  '@oxlint/darwin-x64@0.15.0':
+    resolution: {integrity: sha512-l0NksXD2HSzb/u7RXH1kPNtwOXevkvS4vH7pMDiSrfIbtZTx10YgiLy5zFkFbipJRLmIZUdG+9JEjepsy9S3Ig==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/linux-arm64-gnu@0.14.1':
-    resolution: {integrity: sha512-OWJY1qxJgsaLyQvh97MdpI2Mr8FD90ssGw8o0rG63lWIc3PJESmq9NKU0ZwwUbPbbEpKmwdG3aiZRjh4G1k0cQ==}
+  '@oxlint/linux-arm64-gnu@0.15.0':
+    resolution: {integrity: sha512-Yt2LGRfMwPXrMelEqbbkWFcL50ulAUUqMrfcNYB+H/9S8KF4PSMDRm642VV4949xC3XzkjoL3ZMyKQQKMRWC+Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/linux-arm64-musl@0.14.1':
-    resolution: {integrity: sha512-GPbggyGQV4+5JzpA7l+1liPHkzCDB9ZyPLcHpRtNJJfTQ60JnBww4l3eR7LCukiAor6Sxmlbl+t1OZGjL3zUUA==}
+  '@oxlint/linux-arm64-musl@0.15.0':
+    resolution: {integrity: sha512-+H6CIbejZyE3sc3StoYImqZL3z2zNbv5L547ATLHGyQ5b2JrXMuJ/lqIaNdAa24BehJ6g+/swBIIE5Pk65K3PA==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/linux-x64-gnu@0.14.1':
-    resolution: {integrity: sha512-4ug2y9fEa2MB4wAFfITkm1oJ2m14YjWQaKxKN9bRazPng2k3wivVAvwc6tKj866HftZxXo3FlOIrE1YP6BxcSw==}
+  '@oxlint/linux-x64-gnu@0.15.0':
+    resolution: {integrity: sha512-e/KSj4fg5EFdK/bJLJjGRzaw2KZdYgr2mTt3k9HF9YIGl0UnBoX5h+q0hJ9scDTNNailT8qytvOjuiUhyJpAPA==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/linux-x64-musl@0.14.1':
-    resolution: {integrity: sha512-bsG5ZxFWKml6BQMHbusvNsEU3O0a5BurlrtdXyxlOBZyrWyG6v3pcXM+NX4YT8gaeoK71iCH5I+ymwI9KOwO/w==}
+  '@oxlint/linux-x64-musl@0.15.0':
+    resolution: {integrity: sha512-lOXNTYw7kelNkJPQlrLlk5E8f/ROZFcGOGR5VKHCI+/53QTX/WY5kMo7JOaRyJ+jnNdeN1HW70oRQPjtAujjxw==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/win32-arm64@0.14.1':
-    resolution: {integrity: sha512-Soc3kRTqz++kleXz+Y4IlfiGY+cwXlOiLCVwcRMAnY+TSaP4h2tPXN/cbOypsE7PPq2/kk7JPGUaEKZ/i4G23A==}
+  '@oxlint/win32-arm64@0.15.0':
+    resolution: {integrity: sha512-Hms4Ld6uAOKpbLq27MUqQzffxd71+pK96mzK3YULrkASzIa7AZdtNlRBqfqVRuXCiuxPxT6PhfcriURwsvD/YA==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/win32-x64@0.14.1':
-    resolution: {integrity: sha512-qyjlv5XPxKJ1g9F4ZpNP0m/I2tgHj4lebmyAveaLos3RZWut983WaK3abq4Mr74mIiwfyLA67/m2khG5aXYN2Q==}
+  '@oxlint/win32-x64@0.15.0':
+    resolution: {integrity: sha512-AF0t15GJLoVcMqvbpHwYFHx2o9HkMuEt6GEipPMZ9gaNx1yp6NrP655jywNzhbKHSd6wxSY+CH7aRI9QjdtG1w==}
     cpu: [x64]
     os: [win32]
 
@@ -5146,8 +5145,8 @@ packages:
   oxc-transform@0.35.0:
     resolution: {integrity: sha512-biVB7H7ZxuAQYbMJPUZw1umT7nzDU44tEBYyqMgLle0mnAbi9AetadIqTpjAp8KmcOYpG6VmvGeFPxWihFCWFQ==}
 
-  oxlint@0.14.1:
-    resolution: {integrity: sha512-FwcjPfQu806ibSv73Y9tUM8ezUyd811dp3JwEEOC/dIAgd93egRsRNnFauuAq/WuTjIDv73tbr9hB8MziH31Eg==}
+  oxlint@0.15.0:
+    resolution: {integrity: sha512-hIED9mcs8c0dnNuQEzXRPXOo09HoOVh60LSD48EQHwcHlcFheMfW5OkLWQvinDkG/1n5qt+zWopQGaKFgmtXPw==}
     engines: {node: '>=14.*'}
     hasBin: true
 
@@ -8516,28 +8515,28 @@ snapshots:
   '@oxc-transform/binding-win32-x64-msvc@0.35.0':
     optional: true
 
-  '@oxlint/darwin-arm64@0.14.1':
+  '@oxlint/darwin-arm64@0.15.0':
     optional: true
 
-  '@oxlint/darwin-x64@0.14.1':
+  '@oxlint/darwin-x64@0.15.0':
     optional: true
 
-  '@oxlint/linux-arm64-gnu@0.14.1':
+  '@oxlint/linux-arm64-gnu@0.15.0':
     optional: true
 
-  '@oxlint/linux-arm64-musl@0.14.1':
+  '@oxlint/linux-arm64-musl@0.15.0':
     optional: true
 
-  '@oxlint/linux-x64-gnu@0.14.1':
+  '@oxlint/linux-x64-gnu@0.15.0':
     optional: true
 
-  '@oxlint/linux-x64-musl@0.14.1':
+  '@oxlint/linux-x64-musl@0.15.0':
     optional: true
 
-  '@oxlint/win32-arm64@0.14.1':
+  '@oxlint/win32-arm64@0.15.0':
     optional: true
 
-  '@oxlint/win32-x64@0.14.1':
+  '@oxlint/win32-x64@0.15.0':
     optional: true
 
   '@parcel/watcher-android-arm64@2.4.1':
@@ -11364,16 +11363,16 @@ snapshots:
       '@oxc-transform/binding-win32-arm64-msvc': 0.35.0
       '@oxc-transform/binding-win32-x64-msvc': 0.35.0
 
-  oxlint@0.14.1:
+  oxlint@0.15.0:
     optionalDependencies:
-      '@oxlint/darwin-arm64': 0.14.1
-      '@oxlint/darwin-x64': 0.14.1
-      '@oxlint/linux-arm64-gnu': 0.14.1
-      '@oxlint/linux-arm64-musl': 0.14.1
-      '@oxlint/linux-x64-gnu': 0.14.1
-      '@oxlint/linux-x64-musl': 0.14.1
-      '@oxlint/win32-arm64': 0.14.1
-      '@oxlint/win32-x64': 0.14.1
+      '@oxlint/darwin-arm64': 0.15.0
+      '@oxlint/darwin-x64': 0.15.0
+      '@oxlint/linux-arm64-gnu': 0.15.0
+      '@oxlint/linux-arm64-musl': 0.15.0
+      '@oxlint/linux-x64-gnu': 0.15.0
+      '@oxlint/linux-x64-musl': 0.15.0
+      '@oxlint/win32-arm64': 0.15.0
+      '@oxlint/win32-x64': 0.15.0
 
   p-defer@1.0.0: {}
 


### PR DESCRIPTION
### Description

Related to https://github.com/oxc-project/oxc/pull/7720

Changelog: https://github.com/oxc-project/oxc/releases/tag/oxlint_v0.15.0

The main task is to restore the rule that was temporarily disabled in #3066.