### PR TITLE
chore(ci/publish): improve canary version releasing

### DIFF
--- a/.github/workflows/publish-nightly-canary.yml
+++ b/.github/workflows/publish-nightly-canary.yml
@@ -1,4 +1,4 @@
-name: A - Release Canary/Nightly
+name: A - Publish Nightly/Canary
 
 on:
   # Manually released. This will publish under the canary npm tag.
@@ -74,19 +74,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.ROLLDOWN_NPM_TOKEN }}
 
       - name: Canary/Nightly Versioning
-        run: node ./scripts/misc/bump-version.js snapshot
-
-      - name: Publish(Dry Run)
-        run: |
-          pnpm publish -r --tag ${{ needs.plan.outputs.npm-tag }} --dry-run --no-git-checks
-        env:
-          NPM_TOKEN: ${{ secrets.ROLLDOWN_NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node ./scripts/misc/bump-version.js commit
 
       - name: Publish
-        run: |
-          pnpm publish -r --tag ${{ needs.plan.outputs.npm-tag }} --no-git-checks
-        env:
-          NPM_TOKEN: ${{ secrets.ROLLDOWN_NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
+        run: node ./scripts/ci/publish-rolldown-to-npm.js ${{ needs.plan.outputs.npm-tag }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@actions/core": "^1.11.1",
+    "@babel/runtime": "7.26.0",
     "@ls-lint/ls-lint": "^2.2.3",
     "@taplo/cli": "^0.7.0",
     "@types/node": "22.8.7",
@@ -41,8 +43,7 @@
     "oxlint": "0.15.0",
     "prettier": "^3.3.1",
     "rolldown": "workspace:*",
-    "typescript": "^5.6.3",
-    "@babel/runtime": "7.26.0"
+    "typescript": "^5.6.3"
   },
   "prettier": {
     "printWidth": 80,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@actions/core':
+        specifier: ^1.11.1
+        version: 1.11.1
       '@babel/runtime':
         specifier: 7.26.0
         version: 7.26.0
@@ -461,6 +464,18 @@ importers:
         version: 0.24.3
 
 packages:
+
+  '@actions/core@1.11.1':
+    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
+
+  '@actions/exec@1.1.1':
+    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+
+  '@actions/http-client@2.2.3':
+    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+
+  '@actions/io@1.1.3':
+    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
 
   '@algolia/autocomplete-core@1.9.3':
     resolution: {integrity: sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==}
@@ -2030,6 +2045,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
   '@gwhitney/detect-indent@7.0.1':
     resolution: {integrity: sha512-7bQW+gkKa2kKZPeJf6+c6gFK9ARxQfn+FKy9ScTBppyKRWH2KzsmweXUoklqeEiHiNVWaeP5csIdsNq6w7QhzA==}
     engines: {node: '>=12.20'}
@@ -2160,6 +2179,7 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
+    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -6033,6 +6053,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
   typanion@3.14.0:
     resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
 
@@ -6095,6 +6119,10 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  undici@5.28.4:
+    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
+    engines: {node: '>=14.0'}
 
   unicode-canonical-property-names-ecmascript@1.0.4:
     resolution: {integrity: sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==}
@@ -6500,6 +6528,22 @@ packages:
     hasBin: true
 
 snapshots:
+
+  '@actions/core@1.11.1':
+    dependencies:
+      '@actions/exec': 1.1.1
+      '@actions/http-client': 2.2.3
+
+  '@actions/exec@1.1.1':
+    dependencies:
+      '@actions/io': 1.1.3
+
+  '@actions/http-client@2.2.3':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 5.28.4
+
+  '@actions/io@1.1.3': {}
 
   '@algolia/autocomplete-core@1.9.3(@algolia/client-search@5.12.0)(algoliasearch@5.12.0)(search-insights@2.14.0)':
     dependencies:
@@ -7912,6 +7956,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.24.0':
     optional: true
+
+  '@fastify/busboy@2.1.1': {}
 
   '@gwhitney/detect-indent@7.0.1': {}
 
@@ -12235,6 +12281,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel@0.0.6: {}
+
   typanion@3.14.0: {}
 
   type-fest@0.20.2: {}
@@ -12325,6 +12373,10 @@ snapshots:
       - vue-tsc
 
   undici-types@6.19.8: {}
+
+  undici@5.28.4:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   unicode-canonical-property-names-ecmascript@1.0.4: {}
 

--- a/scripts/ci/publish-rolldown-to-npm.js
+++ b/scripts/ci/publish-rolldown-to-npm.js
@@ -1,0 +1,68 @@
+import { $, ProcessOutput } from 'zx'
+import { assertRunningScriptFromRepoRoot } from '../meta/utils.js'
+import * as actionsCore from '@actions/core'
+import { REPO_ROOT } from '../meta/constants.js'
+
+/**
+ *
+ * @returns {Promise<string>}
+ */
+async function getCurrentVersion() {
+  const pkgPath = path.resolve(REPO_ROOT, './packages/rolldown/package.json')
+  const result = await import(pkgPath, {
+    assert: {
+      type: 'json',
+    },
+  })
+  return result.default.version
+}
+
+/**
+ *
+ * @param {string} version
+ */
+async function isVersionExists(version) {
+  try {
+    const result = await $({ quiet: true })`npm show rolldown@${version}`
+    return result.exitCode === 0
+  } catch (cause) {
+    if (
+      cause instanceof ProcessOutput &&
+      cause.stderr.includes('No match found for version')
+    ) {
+      return false
+    }
+    throw new Error(
+      `Unexpected error happened when checking if rolldown@${version} exist.`,
+      { cause },
+    )
+  }
+}
+
+/**
+ *
+ * @param {string} version
+ * @param {string} tag
+ */
+async function publish(version, tag) {
+  if (await isVersionExists(version)) {
+    await $`pnpm dist-tag add rolldown@${version} ${tag}`
+    actionsCore.info(`Version ${version} exists, just add dist-tag ${tag}`)
+    return
+  }
+  // Let's try dry-run first
+  await $`pnpm publish -r --tag ${tag} --dry-run --no-git-checks`
+  await $`pnpm publish -r --tag ${tag} --no-git-checks`
+}
+
+// --- main
+
+assertRunningScriptFromRepoRoot()
+
+const tag = process.argv[2]?.trim()
+
+if (!tag) {
+  throw new Error('Npm tag must be provided')
+}
+
+publish(await getCurrentVersion(), tag)

--- a/scripts/misc/bump-version.js
+++ b/scripts/misc/bump-version.js
@@ -6,12 +6,16 @@ import path from 'node:path'
 import { findWorkspacePackagesNoCheck } from '@pnpm/find-workspace-packages'
 import { REPO_ROOT } from '../meta/constants.js'
 
+/**
+ * @typedef {'major' | 'minor' | 'patch'  | 'commit'} PresetVersion
+ */
+
 async function getCommitId() {
   const result = await $`git rev-parse --short HEAD`
   return result.stdout.replace('\n', '')
 }
 
-async function getLastVersion() {
+async function getCurrentVersion() {
   const pkgPath = path.resolve(REPO_ROOT, './packages/rolldown/package.json')
   const result = await import(pkgPath, {
     assert: {
@@ -23,38 +27,32 @@ async function getLastVersion() {
 
 /**
  *
- * @param {string} lastVersion
+ * @param {PresetVersion} preset
  */
-async function getSnapshotVersion(lastVersion) {
-  const commitId = await getCommitId()
-  const dateTime = new Date()
-    .toISOString()
-    .replace(/\.\d{3}Z$/, '')
-    .replace(/[^\d]/g, '')
-  return `${lastVersion}-snapshot-${commitId}-${dateTime}`
+async function genVersionByPreset(preset) {
+  const currentVersion = await getCurrentVersion()
+  switch (preset) {
+    case 'major':
+    case 'minor':
+    case 'patch': {
+      const v = semver.inc(currentVersion, preset)
+      if (!v) {
+        throw new Error(`Failed to bump version with preset ${preset}`)
+      }
+      return v
+    }
+    case 'commit':
+      const commitId = await getCommitId()
+      return `${currentVersion}+commit.${commitId}` // Example: 0.15.1+commit.1234567
+  }
 }
 
 /**
  *
- * @param {'major' | 'minor' | 'patch' | 'snapshot'} version
+ * @param {string} nextVersion
  */
-async function bumpVersion(version) {
-  const allowedVersion = ['major', 'minor', 'patch', 'snapshot']
-  if (!allowedVersion.includes(version)) {
-    throw new Error(
-      `version must be one of ${allowedVersion}, but you passed ${version}`,
-    )
-  }
+async function bumpVersion(nextVersion) {
   const root = process.cwd()
-
-  const lastVersion = await getLastVersion()
-  const nextVersion = await (() => {
-    if (version === 'snapshot') {
-      return getSnapshotVersion(lastVersion)
-    } else {
-      return semver.inc(lastVersion, version)
-    }
-  })()
 
   const workspaces = await findWorkspacePackagesNoCheck(root)
   for (const workspace of workspaces) {
@@ -73,14 +71,30 @@ async function bumpVersion(version) {
   }
 }
 
-const version = process.argv[2]
-
-if (!version) {
-  console.error(
-    "You must pass a version to bump. e.g. 'major', 'minor', 'patch', 'canary'",
-  )
-  process.exit(1)
+/**
+ *
+ * @param {string} arg
+ * @returns {arg is PresetVersion}
+ */
+function isPresetArg(arg) {
+  return ['major', 'minor', 'patch', 'commit'].includes(arg)
 }
 
-// @ts-expect-error
-await bumpVersion(version)
+// --- main
+
+const inputVersion = process.argv[2]?.trim()
+
+if (!inputVersion) {
+  throw new Error('You must pass a version to bump')
+}
+
+if (isPresetArg(inputVersion)) {
+  await bumpVersion(await genVersionByPreset(inputVersion))
+} else {
+  if (!semver.valid(inputVersion)) {
+    throw new Error(
+      `You must pass a valid semver version instead of '${inputVersion}'`,
+    )
+  }
+  await bumpVersion(inputVersion)
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

What this PR does:

- Canary version pattern is now `version+commit.[commitHash]` and follow the rule of [semver](https://semver.org/#:~:text=Build%20metadata%20MAY%20be%20denoted%20by%20appending%20a%20plus%20sign%20and%20a%20series%20of%20dot%20separated%20identifiers%20immediately%20following%20the%20patch%20or%20pre%2Drelease%20version.). Eg: 0.15.1+commit.1234567. Closes https://github.com/rolldown/rolldown/issues/1402.
- Since we use commit hash as the part of canary version, now unchanged code won't be publish duplicately.
- Prepare fix for https://github.com/rolldown/rolldown/issues/1579.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
