### PR TITLE
perf(rolldown): remove `AppendOnlyVec`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -141,7 +141,6 @@ impl GenerateStage<'_> {
     index_cross_chunk_dynamic_imports: &mut IndexCrossChunkDynamicImports,
   ) {
     let symbols = &self.link_output.symbol_db;
-    let chunk_id_to_symbols_vec = append_only_vec::AppendOnlyVec::new();
 
     let chunks_iter = multizip((
       chunk_graph.chunk_table.iter_enumerated(),
@@ -150,125 +149,128 @@ impl GenerateStage<'_> {
       index_cross_chunk_dynamic_imports.iter_mut(),
     ));
 
-    chunks_iter.par_bridge().for_each(
-      |(
-        (chunk_id, chunk),
-        depended_symbols,
-        imports_from_external_modules,
-        cross_chunk_dynamic_imports,
-      )| {
-        let mut symbol_needs_to_assign = vec![];
-        chunk.modules.iter().copied().for_each(|module_id| {
-          let Module::Normal(module) = &self.link_output.module_table.modules[module_id] else {
-            return;
-          };
-          module
-            .import_records
-            .iter()
-            .inspect(|rec| {
-              if let Module::Normal(importee_module) =
+    let chunk_id_to_symbols_vec = chunks_iter
+      .par_bridge()
+      .map(
+        |(
+          (chunk_id, chunk),
+          depended_symbols,
+          imports_from_external_modules,
+          cross_chunk_dynamic_imports,
+        )| {
+          let mut symbol_needs_to_assign = vec![];
+          chunk.modules.iter().copied().for_each(|module_id| {
+            let Module::Normal(module) = &self.link_output.module_table.modules[module_id] else {
+              return;
+            };
+            module
+              .import_records
+              .iter()
+              .inspect(|rec| {
+                if let Module::Normal(importee_module) =
+                  &self.link_output.module_table.modules[rec.resolved_module]
+                {
+                  // the the resolved module is not included in module graph, skip
+                  // TODO: Is that possible that the module of the record is a external module?
+                  if !importee_module.meta.is_included() {
+                    return;
+                  }
+                  if matches!(rec.kind, ImportKind::DynamicImport) {
+                    let importee_chunk = chunk_graph.module_to_chunk[importee_module.idx]
+                      .expect("importee chunk should exist");
+                    cross_chunk_dynamic_imports.insert(importee_chunk);
+                  }
+                }
+              })
+              .filter(|rec| {
+                matches!(rec.kind, ImportKind::Import)
+                  && !rec.meta.contains(ImportRecordMeta::IS_EXPORT_STAR)
+              })
+              .filter_map(|rec| {
+                self.link_output.module_table.modules[rec.resolved_module].as_external()
+              })
+              .for_each(|importee| {
+                // Ensure the external module is imported in case it has side effects.
+                imports_from_external_modules.entry(importee.idx).or_default();
+              });
+
+            module.named_imports.iter().for_each(|(_, import)| {
+              let rec = &module.import_records[import.record_id];
+              if let Module::External(importee) =
                 &self.link_output.module_table.modules[rec.resolved_module]
               {
-                // the the resolved module is not included in module graph, skip
-                // TODO: Is that possible that the module of the record is a external module?
-                if !importee_module.meta.is_included() {
-                  return;
-                }
-                if matches!(rec.kind, ImportKind::DynamicImport) {
-                  let importee_chunk = chunk_graph.module_to_chunk[importee_module.idx]
-                    .expect("importee chunk should exist");
-                  cross_chunk_dynamic_imports.insert(importee_chunk);
-                }
+                imports_from_external_modules.entry(importee.idx).or_default().push(import.clone());
               }
-            })
-            .filter(|rec| {
-              matches!(rec.kind, ImportKind::Import)
-                && !rec.meta.contains(ImportRecordMeta::IS_EXPORT_STAR)
-            })
-            .filter_map(|rec| {
-              self.link_output.module_table.modules[rec.resolved_module].as_external()
-            })
-            .for_each(|importee| {
-              // Ensure the external module is imported in case it has side effects.
-              imports_from_external_modules.entry(importee.idx).or_default();
             });
 
-          module.named_imports.iter().for_each(|(_, import)| {
-            let rec = &module.import_records[import.record_id];
-            if let Module::External(importee) =
-              &self.link_output.module_table.modules[rec.resolved_module]
-            {
-              imports_from_external_modules.entry(importee.idx).or_default().push(import.clone());
-            }
-          });
+            module.stmt_infos.iter().for_each(|stmt_info| {
+              if !stmt_info.is_included {
+                return;
+              }
+              stmt_info.declared_symbols.iter().for_each(|declared| {
+                symbol_needs_to_assign.push(*declared);
+              });
 
-          module.stmt_infos.iter().for_each(|stmt_info| {
-            if !stmt_info.is_included {
-              return;
-            }
-            stmt_info.declared_symbols.iter().for_each(|declared| {
-              symbol_needs_to_assign.push(*declared);
-            });
-
-            stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
-              match reference_ref {
-                rolldown_common::SymbolOrMemberExprRef::Symbol(referenced) => {
-                  let mut canonical_ref = symbols.canonical_ref_for(*referenced);
-                  if let Some(namespace_alias) = &symbols.get(canonical_ref).namespace_alias {
-                    canonical_ref = namespace_alias.namespace_ref;
-                  }
-                  depended_symbols.insert(canonical_ref);
-                }
-                rolldown_common::SymbolOrMemberExprRef::MemberExpr(member_expr) => {
-                  if let Some(sym_ref) = member_expr.resolved_symbol_ref(
-                    &self.link_output.metas[module.idx].resolved_member_expr_refs,
-                  ) {
-                    let mut canonical_ref = self.link_output.symbol_db.canonical_ref_for(sym_ref);
-                    let symbol = symbols.get(canonical_ref);
-                    if let Some(ref ns_alias) = symbol.namespace_alias {
-                      canonical_ref = ns_alias.namespace_ref;
+              stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
+                match reference_ref {
+                  rolldown_common::SymbolOrMemberExprRef::Symbol(referenced) => {
+                    let mut canonical_ref = symbols.canonical_ref_for(*referenced);
+                    if let Some(namespace_alias) = &symbols.get(canonical_ref).namespace_alias {
+                      canonical_ref = namespace_alias.namespace_ref;
                     }
                     depended_symbols.insert(canonical_ref);
-                  } else {
-                    // `None` means the member expression resolve to a ambiguous export, which means it actually resolve to nothing.
-                    // It would be rewrite to `undefined` in the final code, so we don't need to include anything to make `undefined` work.
                   }
-                }
-              };
+                  rolldown_common::SymbolOrMemberExprRef::MemberExpr(member_expr) => {
+                    if let Some(sym_ref) = member_expr.resolved_symbol_ref(
+                      &self.link_output.metas[module.idx].resolved_member_expr_refs,
+                    ) {
+                      let mut canonical_ref = self.link_output.symbol_db.canonical_ref_for(sym_ref);
+                      let symbol = symbols.get(canonical_ref);
+                      if let Some(ref ns_alias) = symbol.namespace_alias {
+                        canonical_ref = ns_alias.namespace_ref;
+                      }
+                      depended_symbols.insert(canonical_ref);
+                    } else {
+                      // `None` means the member expression resolve to a ambiguous export, which means it actually resolve to nothing.
+                      // It would be rewrite to `undefined` in the final code, so we don't need to include anything to make `undefined` work.
+                    }
+                  }
+                };
+              });
             });
           });
-        });
 
-        if let Some(entry_id) = &chunk.entry_module_idx() {
-          let entry = &self.link_output.module_table.modules[*entry_id].as_normal().unwrap();
-          let entry_meta = &self.link_output.metas[entry.idx];
+          if let Some(entry_id) = &chunk.entry_module_idx() {
+            let entry = &self.link_output.module_table.modules[*entry_id].as_normal().unwrap();
+            let entry_meta = &self.link_output.metas[entry.idx];
 
-          if !matches!(entry_meta.wrap_kind, WrapKind::Cjs) {
-            for export_ref in entry_meta.resolved_exports.values() {
-              let mut canonical_ref = symbols.canonical_ref_for(export_ref.symbol_ref);
-              let symbol = symbols.get(canonical_ref);
-              if let Some(ns_alias) = &symbol.namespace_alias {
-                canonical_ref = ns_alias.namespace_ref;
+            if !matches!(entry_meta.wrap_kind, WrapKind::Cjs) {
+              for export_ref in entry_meta.resolved_exports.values() {
+                let mut canonical_ref = symbols.canonical_ref_for(export_ref.symbol_ref);
+                let symbol = symbols.get(canonical_ref);
+                if let Some(ns_alias) = &symbol.namespace_alias {
+                  canonical_ref = ns_alias.namespace_ref;
+                }
+                depended_symbols.insert(canonical_ref);
               }
-              depended_symbols.insert(canonical_ref);
+            }
+
+            if !matches!(entry_meta.wrap_kind, WrapKind::None) {
+              depended_symbols
+                .insert(entry_meta.wrapper_ref.expect("cjs should be wrapped in esm output"));
+            }
+
+            if matches!(self.options.format, OutputFormat::Cjs)
+              && matches!(entry.exports_kind, ExportsKind::Esm)
+            {
+              depended_symbols.insert(self.link_output.runtime.resolve_symbol("__toCommonJS"));
+              depended_symbols.insert(entry.namespace_object_ref);
             }
           }
-
-          if !matches!(entry_meta.wrap_kind, WrapKind::None) {
-            depended_symbols
-              .insert(entry_meta.wrapper_ref.expect("cjs should be wrapped in esm output"));
-          }
-
-          if matches!(self.options.format, OutputFormat::Cjs)
-            && matches!(entry.exports_kind, ExportsKind::Esm)
-          {
-            depended_symbols.insert(self.link_output.runtime.resolve_symbol("__toCommonJS"));
-            depended_symbols.insert(entry.namespace_object_ref);
-          }
-        }
-        chunk_id_to_symbols_vec.push((chunk_id, symbol_needs_to_assign));
-      },
-    );
+          (chunk_id, symbol_needs_to_assign)
+        },
+      )
+      .collect::<Vec<_>>();
     // shadowing previous immutable borrow
     let symbols = &mut self.link_output.symbol_db;
     for (chunk_id, symbol_list) in chunk_id_to_symbols_vec {

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -1,6 +1,5 @@
 use std::{ptr::addr_of, sync::Mutex};
 
-use append_only_vec::AppendOnlyVec;
 use oxc_index::IndexVec;
 use rolldown_common::{
   dynamic_import_usage::DynamicImportExportsUsage, EntryPoint, ExportsKind, ImportKind,
@@ -221,88 +220,146 @@ impl<'a> LinkStage<'a> {
   #[tracing::instrument(level = "debug", skip_all)]
   fn reference_needed_symbols(&mut self) {
     let symbols = Mutex::new(&mut self.symbols);
-    let record_meta_update_pending_pairs_list = AppendOnlyVec::new();
     let keep_names = self.options.keep_names;
-    self.module_table.modules.par_iter().filter_map(Module::as_normal).for_each(|importer| {
-      let mut record_meta_pairs: Vec<(ImportRecordIdx, ImportRecordMeta)> = vec![];
-      let importer_idx = importer.idx;
-      // safety: No race conditions here:
-      // - Mutating on `stmt_infos` is isolated in threads for each module
-      // - Mutating on `stmt_infos` doesn't rely on other mutating operations of other modules
-      // - Mutating and parallel reading is in different memory locations
-      let stmt_infos = unsafe { &mut *(addr_of!(importer.stmt_infos).cast_mut()) };
-      // store the symbol reference to the declared statement index
-      let mut declared_symbol_for_stmt_pairs = vec![];
-      stmt_infos.infos.iter_mut_enumerated().for_each(|(stmt_idx, stmt_info)| {
-        stmt_info.import_records.iter().for_each(|rec_id| {
-          let rec = &importer.import_records[*rec_id];
-          let rec_resolved_module = &self.module_table.modules[rec.resolved_module];
-          if !rec_resolved_module.is_normal()
-            || is_external_dynamic_import(&self.module_table, rec, importer_idx)
-          {
-            if matches!(rec.kind, ImportKind::Require)
-              || !self.options.format.keep_esm_import_export_syntax()
+    let record_meta_update_pending_pairs_list = self
+      .module_table
+      .modules
+      .par_iter()
+      .filter_map(Module::as_normal)
+      .map(|importer| {
+        let mut record_meta_pairs: Vec<(ImportRecordIdx, ImportRecordMeta)> = vec![];
+        let importer_idx = importer.idx;
+        // safety: No race conditions here:
+        // - Mutating on `stmt_infos` is isolated in threads for each module
+        // - Mutating on `stmt_infos` doesn't rely on other mutating operations of other modules
+        // - Mutating and parallel reading is in different memory locations
+        let stmt_infos = unsafe { &mut *(addr_of!(importer.stmt_infos).cast_mut()) };
+        // store the symbol reference to the declared statement index
+        let mut declared_symbol_for_stmt_pairs = vec![];
+        stmt_infos.infos.iter_mut_enumerated().for_each(|(stmt_idx, stmt_info)| {
+          stmt_info.import_records.iter().for_each(|rec_id| {
+            let rec = &importer.import_records[*rec_id];
+            let rec_resolved_module = &self.module_table.modules[rec.resolved_module];
+            if !rec_resolved_module.is_normal()
+              || is_external_dynamic_import(&self.module_table, rec, importer_idx)
             {
-              if self.options.format.should_call_runtime_require()
-                && self.options.polyfill_require_for_esm_format_with_node_platform()
+              if matches!(rec.kind, ImportKind::Require)
+                || !self.options.format.keep_esm_import_export_syntax()
               {
-                stmt_info.referenced_symbols.push(self.runtime.resolve_symbol("__require").into());
-                record_meta_pairs.push((*rec_id, ImportRecordMeta::CALL_RUNTIME_REQUIRE));
+                if self.options.format.should_call_runtime_require()
+                  && self.options.polyfill_require_for_esm_format_with_node_platform()
+                {
+                  stmt_info
+                    .referenced_symbols
+                    .push(self.runtime.resolve_symbol("__require").into());
+                  record_meta_pairs.push((*rec_id, ImportRecordMeta::CALL_RUNTIME_REQUIRE));
+                }
               }
             }
-          }
-          match rec_resolved_module {
-            Module::External(importee) => {
-              // Make sure symbols from external modules are included and de_conflicted
-              match rec.kind {
-                ImportKind::Import => {
-                  let is_reexport_all = rec.meta.contains(ImportRecordMeta::IS_EXPORT_STAR);
-                  if is_reexport_all {
-                    // export * from 'external' would be just removed. So it references nothing.
-                    rec.namespace_ref.set_name(
-                      &mut symbols.lock().unwrap(),
-                      &concat_string!("import_", legitimize_identifier_name(&importee.name)),
-                    );
-                  } else {
-                    // import ... from 'external' or export ... from 'external'
-                    if matches!(
-                      self.options.format,
-                      OutputFormat::Cjs | OutputFormat::Iife | OutputFormat::Umd
-                    ) && !rec.meta.contains(ImportRecordMeta::IS_PLAIN_IMPORT)
-                    {
-                      stmt_info.side_effect = true;
-                      stmt_info
-                        .referenced_symbols
-                        .push(self.runtime.resolve_symbol("__toESM").into());
+            match rec_resolved_module {
+              Module::External(importee) => {
+                // Make sure symbols from external modules are included and de_conflicted
+                match rec.kind {
+                  ImportKind::Import => {
+                    let is_reexport_all = rec.meta.contains(ImportRecordMeta::IS_EXPORT_STAR);
+                    if is_reexport_all {
+                      // export * from 'external' would be just removed. So it references nothing.
+                      rec.namespace_ref.set_name(
+                        &mut symbols.lock().unwrap(),
+                        &concat_string!("import_", legitimize_identifier_name(&importee.name)),
+                      );
+                    } else {
+                      // import ... from 'external' or export ... from 'external'
+                      if matches!(
+                        self.options.format,
+                        OutputFormat::Cjs | OutputFormat::Iife | OutputFormat::Umd
+                      ) && !rec.meta.contains(ImportRecordMeta::IS_PLAIN_IMPORT)
+                      {
+                        stmt_info.side_effect = true;
+                        stmt_info
+                          .referenced_symbols
+                          .push(self.runtime.resolve_symbol("__toESM").into());
+                      }
                     }
                   }
+                  _ => {}
                 }
-                _ => {}
               }
-            }
-            Module::Normal(importee) => {
-              let importee_linking_info = &self.metas[importee.idx];
-              match rec.kind {
-                ImportKind::Import => {
-                  let is_reexport_all = rec.meta.contains(ImportRecordMeta::IS_EXPORT_STAR);
-                  match importee_linking_info.wrap_kind {
-                    WrapKind::None => {
-                      // for case:
-                      // ```js
-                      // // index.js
-                      // export * from './foo'; /* importee wrap kind is `none`, but since `foo` has dynamic_export, we need to preserve the `__reExport(index_exports, foo_ns)` */
-                      //
-                      // // foo.js
-                      // export * from './bar' /* importee wrap kind is `cjs`, preserve by
-                      // default*/
-                      //
-                      // // bar.js
-                      // module.exports = 1000
-                      // ```
-                      if is_reexport_all {
-                        let meta = &self.metas[importee.idx];
-                        if meta.has_dynamic_exports {
+              Module::Normal(importee) => {
+                let importee_linking_info = &self.metas[importee.idx];
+                match rec.kind {
+                  ImportKind::Import => {
+                    let is_reexport_all = rec.meta.contains(ImportRecordMeta::IS_EXPORT_STAR);
+                    match importee_linking_info.wrap_kind {
+                      WrapKind::None => {
+                        // for case:
+                        // ```js
+                        // // index.js
+                        // export * from './foo'; /* importee wrap kind is `none`, but since `foo` has dynamic_export, we need to preserve the `__reExport(index_exports, foo_ns)` */
+                        //
+                        // // foo.js
+                        // export * from './bar' /* importee wrap kind is `cjs`, preserve by
+                        // default*/
+                        //
+                        // // bar.js
+                        // module.exports = 1000
+                        // ```
+                        if is_reexport_all {
+                          let meta = &self.metas[importee.idx];
+                          if meta.has_dynamic_exports {
+                            stmt_info.side_effect = true;
+                            stmt_info
+                              .referenced_symbols
+                              .push(self.runtime.resolve_symbol("__reExport").into());
+                            stmt_info.referenced_symbols.push(importer.namespace_object_ref.into());
+                            stmt_info.referenced_symbols.push(importee.namespace_object_ref.into());
+                          }
+                        }
+                      }
+                      WrapKind::Cjs => {
+                        if is_reexport_all {
                           stmt_info.side_effect = true;
+                          // Turn `export * from 'bar_cjs'` into `__reExport(foo_exports, __toESM(require_bar_cjs()))`
+                          // Reference to `require_bar_cjs`
+                          stmt_info
+                            .referenced_symbols
+                            .push(importee_linking_info.wrapper_ref.unwrap().into());
+                          stmt_info
+                            .referenced_symbols
+                            .push(self.runtime.resolve_symbol("__toESM").into());
+                          stmt_info
+                            .referenced_symbols
+                            .push(self.runtime.resolve_symbol("__reExport").into());
+                          stmt_info.referenced_symbols.push(importer.namespace_object_ref.into());
+                        } else {
+                          stmt_info.side_effect = importee.side_effects.has_side_effects();
+                          // Turn `import * as bar from 'bar_cjs'` into `var import_bar_cjs = __toESM(require_bar_cjs())`
+                          // Turn `import { prop } from 'bar_cjs'; prop;` into `var import_bar_cjs = __toESM(require_bar_cjs()); import_bar_cjs.prop;`
+                          // Reference to `require_bar_cjs`
+                          stmt_info
+                            .referenced_symbols
+                            .push(importee_linking_info.wrapper_ref.unwrap().into());
+                          // dbg!(&importee_linking_info.wrapper_ref);
+                          stmt_info
+                            .referenced_symbols
+                            .push(self.runtime.resolve_symbol("__toESM").into());
+                          declared_symbol_for_stmt_pairs.push((stmt_idx, rec.namespace_ref));
+                          rec.namespace_ref.set_name(
+                            &mut symbols.lock().unwrap(),
+                            &concat_string!("import_", importee.repr_name),
+                          );
+                        }
+                      }
+                      WrapKind::Esm => {
+                        stmt_info.side_effect = true;
+                        // Turn `import ... from 'bar_esm'` into `init_bar_esm()`
+                        // Reference to `init_foo`
+                        stmt_info
+                          .referenced_symbols
+                          .push(importee_linking_info.wrapper_ref.unwrap().into());
+                        if is_reexport_all && importee_linking_info.has_dynamic_exports {
+                          // Turn `export * from 'bar_esm'` into `init_bar_esm();__reExport(foo_exports, bar_esm_exports);`
+                          // something like `__reExport(foo_exports, other_exports)`
                           stmt_info
                             .referenced_symbols
                             .push(self.runtime.resolve_symbol("__reExport").into());
@@ -311,126 +368,75 @@ impl<'a> LinkStage<'a> {
                         }
                       }
                     }
+                  }
+                  ImportKind::Require => match importee_linking_info.wrap_kind {
+                    WrapKind::None => {}
                     WrapKind::Cjs => {
-                      if is_reexport_all {
-                        stmt_info.side_effect = true;
-                        // Turn `export * from 'bar_cjs'` into `__reExport(foo_exports, __toESM(require_bar_cjs()))`
-                        // Reference to `require_bar_cjs`
-                        stmt_info
-                          .referenced_symbols
-                          .push(importee_linking_info.wrapper_ref.unwrap().into());
-                        stmt_info
-                          .referenced_symbols
-                          .push(self.runtime.resolve_symbol("__toESM").into());
-                        stmt_info
-                          .referenced_symbols
-                          .push(self.runtime.resolve_symbol("__reExport").into());
-                        stmt_info.referenced_symbols.push(importer.namespace_object_ref.into());
-                      } else {
-                        stmt_info.side_effect = importee.side_effects.has_side_effects();
-                        // Turn `import * as bar from 'bar_cjs'` into `var import_bar_cjs = __toESM(require_bar_cjs())`
-                        // Turn `import { prop } from 'bar_cjs'; prop;` into `var import_bar_cjs = __toESM(require_bar_cjs()); import_bar_cjs.prop;`
-                        // Reference to `require_bar_cjs`
-                        stmt_info
-                          .referenced_symbols
-                          .push(importee_linking_info.wrapper_ref.unwrap().into());
-                        // dbg!(&importee_linking_info.wrapper_ref);
-                        stmt_info
-                          .referenced_symbols
-                          .push(self.runtime.resolve_symbol("__toESM").into());
-                        declared_symbol_for_stmt_pairs.push((stmt_idx, rec.namespace_ref));
-                        rec.namespace_ref.set_name(
-                          &mut symbols.lock().unwrap(),
-                          &concat_string!("import_", importee.repr_name),
-                        );
-                      }
-                    }
-                    WrapKind::Esm => {
-                      stmt_info.side_effect = true;
-                      // Turn `import ... from 'bar_esm'` into `init_bar_esm()`
-                      // Reference to `init_foo`
+                      // something like `require_foo()`
+                      // Reference to `require_foo`
                       stmt_info
                         .referenced_symbols
                         .push(importee_linking_info.wrapper_ref.unwrap().into());
-                      if is_reexport_all && importee_linking_info.has_dynamic_exports {
-                        // Turn `export * from 'bar_esm'` into `init_bar_esm();__reExport(foo_exports, bar_esm_exports);`
-                        // something like `__reExport(foo_exports, other_exports)`
-                        stmt_info
-                          .referenced_symbols
-                          .push(self.runtime.resolve_symbol("__reExport").into());
-                        stmt_info.referenced_symbols.push(importer.namespace_object_ref.into());
-                        stmt_info.referenced_symbols.push(importee.namespace_object_ref.into());
-                      }
                     }
-                  }
-                }
-                ImportKind::Require => match importee_linking_info.wrap_kind {
-                  WrapKind::None => {}
-                  WrapKind::Cjs => {
-                    // something like `require_foo()`
-                    // Reference to `require_foo`
-                    stmt_info
-                      .referenced_symbols
-                      .push(importee_linking_info.wrapper_ref.unwrap().into());
-                  }
-                  WrapKind::Esm => {
-                    // convert require record into `(init_foo(), __toCommonJS(foo_exports))` if
-                    // `require('xxx)` is used, else convert it to `init_foo()`
-                    stmt_info
-                      .referenced_symbols
-                      .push(importee_linking_info.wrapper_ref.unwrap().into());
-                    stmt_info.referenced_symbols.push(importee.namespace_object_ref.into());
-
-                    if !rec.meta.contains(ImportRecordMeta::IS_REQUIRE_UNUSED) {
+                    WrapKind::Esm => {
+                      // convert require record into `(init_foo(), __toCommonJS(foo_exports))` if
+                      // `require('xxx)` is used, else convert it to `init_foo()`
                       stmt_info
                         .referenced_symbols
-                        .push(self.runtime.resolve_symbol("__toCommonJS").into());
-                    }
-                  }
-                },
-                ImportKind::DynamicImport => {
-                  if self.options.inline_dynamic_imports {
-                    match importee_linking_info.wrap_kind {
-                      WrapKind::None => {}
-                      WrapKind::Cjs => {
-                        //  `__toESM(require_foo())`
+                        .push(importee_linking_info.wrapper_ref.unwrap().into());
+                      stmt_info.referenced_symbols.push(importee.namespace_object_ref.into());
+
+                      if !rec.meta.contains(ImportRecordMeta::IS_REQUIRE_UNUSED) {
                         stmt_info
                           .referenced_symbols
-                          .push(importee_linking_info.wrapper_ref.unwrap().into());
-                        stmt_info
-                          .referenced_symbols
-                          .push(self.runtime.resolve_symbol("__toESM").into());
-                      }
-                      WrapKind::Esm => {
-                        // `(init_foo(), foo_exports)`
-                        stmt_info
-                          .referenced_symbols
-                          .push(importee_linking_info.wrapper_ref.unwrap().into());
-                        stmt_info.referenced_symbols.push(importee.namespace_object_ref.into());
+                          .push(self.runtime.resolve_symbol("__toCommonJS").into());
                       }
                     }
+                  },
+                  ImportKind::DynamicImport => {
+                    if self.options.inline_dynamic_imports {
+                      match importee_linking_info.wrap_kind {
+                        WrapKind::None => {}
+                        WrapKind::Cjs => {
+                          //  `__toESM(require_foo())`
+                          stmt_info
+                            .referenced_symbols
+                            .push(importee_linking_info.wrapper_ref.unwrap().into());
+                          stmt_info
+                            .referenced_symbols
+                            .push(self.runtime.resolve_symbol("__toESM").into());
+                        }
+                        WrapKind::Esm => {
+                          // `(init_foo(), foo_exports)`
+                          stmt_info
+                            .referenced_symbols
+                            .push(importee_linking_info.wrapper_ref.unwrap().into());
+                          stmt_info.referenced_symbols.push(importee.namespace_object_ref.into());
+                        }
+                      }
+                    }
                   }
+                  ImportKind::AtImport => {
+                    unreachable!("A Js module would never import a CSS module via `@import`");
+                  }
+                  ImportKind::UrlImport => {
+                    unreachable!("A Js module would never import a CSS module via `url()`");
+                  }
+                  ImportKind::NewUrl => {}
                 }
-                ImportKind::AtImport => {
-                  unreachable!("A Js module would never import a CSS module via `@import`");
-                }
-                ImportKind::UrlImport => {
-                  unreachable!("A Js module would never import a CSS module via `url()`");
-                }
-                ImportKind::NewUrl => {}
               }
             }
+          });
+          if keep_names && stmt_info.meta.intersects(StmtInfoMeta::KeepNamesType) {
+            stmt_info.referenced_symbols.push(self.runtime.resolve_symbol("__name").into());
           }
         });
-        if keep_names && stmt_info.meta.intersects(StmtInfoMeta::KeepNamesType) {
-          stmt_info.referenced_symbols.push(self.runtime.resolve_symbol("__name").into());
+        for (stmt_idx, symbol_ref) in declared_symbol_for_stmt_pairs {
+          stmt_infos.declare_symbol_for_stmt(stmt_idx, symbol_ref);
         }
-      });
-      for (stmt_idx, symbol_ref) in declared_symbol_for_stmt_pairs {
-        stmt_infos.declare_symbol_for_stmt(stmt_idx, symbol_ref);
-      }
-      record_meta_update_pending_pairs_list.push((importer_idx, record_meta_pairs));
-    });
+        (importer_idx, record_meta_pairs)
+      })
+      .collect::<Vec<_>>();
 
     // merge import_record.meta
     for (module_idx, record_meta_pairs) in record_meta_update_pending_pairs_list {


### PR DESCRIPTION
It's still costly to sync the atomics in `AppendOnlyVec`: https://docs.rs/append-only-vec/latest/src/append_only_vec/lib.rs.html#41-45

A simple map + collect should suffice.

<img width="1857" alt="image" src="https://github.com/user-attachments/assets/faaed3e9-c62e-440c-8545-350fbf8c71ae" />
