### PR TITLE
feat(string_wizard): add `serde` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,6 +1731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eca5d9726cd0a6e433debe003b7bc88b2ecad0bb6109f0cef7c55e692139a34"
 dependencies = [
  "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -3157,6 +3158,7 @@ dependencies = [
  "oxc_index",
  "oxc_sourcemap",
  "rustc-hash",
+ "serde",
 ]
 
 [[package]]

--- a/crates/string_wizard/Cargo.toml
+++ b/crates/string_wizard/Cargo.toml
@@ -11,10 +11,15 @@ version     = "0.0.24"
 oxc_index     = { workspace = true }
 oxc_sourcemap = { workspace = true, optional = true }
 rustc-hash    = { workspace = true }
+serde         = { workspace = true, optional = true }
 
 [dev-dependencies]
 insta = { workspace = true }
 
 [features]
 default   = ["sourcemap"]
+serde     = ["dep:serde", "oxc_index/serde"]
 sourcemap = ["dep:oxc_sourcemap"]
+
+[package.metadata.cargo-shear]
+ignored = ["serde"]


### PR DESCRIPTION
When `string_wizard` is used inside `oxc`, and with `oxc_index` having the `serde` feature enabled, feature unification breaks apart. And there is no way to force enable a dependencie's dependency's feature. This is the last resort :-(

```
error[E0433]: failed to resolve: use of undeclared crate or module `serde`
 --> crates/string_wizard/src/chunk.rs:5:1
  |
5 | / oxc_index::define_index_type! {
6 | |     pub struct ChunkIdx = u32;
7 | | }
  | |_^ use of undeclared crate or module `serde`
  |
  = note: this error originates in the macro `$crate::__internal_maybe_index_impl_serde` which comes from the expansion of the macro `oxc_index::define_index_type` (in Nightly builds, run with -Z macro-backtrace for more info)
```