### PR TITLE
fix: fix build output to stdout

### DIFF
--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -58,7 +58,9 @@ export async function bundleWithCliOptions(
       if (outputs.length > 1) {
         logger.log(`\n${colors.cyan(colors.bold(`|→ ${file.fileName}:`))}\n`)
       }
-      logger.log(file.type === 'asset' ? file.source : file.code)
+      // avoid consola since it doesn't print it as raw string
+      // eslint-disable-next-line no-console
+      console.log(file.type === 'asset' ? file.source : file.code)
     }
   } finally {
     await build.close()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Closes https://github.com/rolldown/rolldown/issues/3142

Consola has some automatic formatting for backtick and underscore, so we need to avoid that here https://github.com/unjs/consola/blob/e510121bb9e53f099c9e3387f8467e3b30bf9edf/src/reporters/fancy.ts#L135-L143.

_example: test.js_

```js
console.log(" `hello` _world_ ")
```

_before_

![image](https://github.com/user-attachments/assets/a81fb35c-79d7-4de0-b153-69aa8a31c2ed)

_after_

![image](https://github.com/user-attachments/assets/e15959f8-7108-44de-b33f-9c49ae3b8a0a)
