### PR TITLE
refactor: transform source

### DIFF
--- a/crates/rolldown/src/utils/transform_source.rs
+++ b/crates/rolldown/src/utils/transform_source.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use rolldown_common::ModuleType;
 use rolldown_common::{side_effects::HookSideEffects, ResolvedId};
-use rolldown_plugin::{HookTransformArgs, PluginDriver};
+use rolldown_plugin::PluginDriver;
 use rolldown_sourcemap::SourceMap;
 
+#[inline]
 pub async fn transform_source(
   plugin_driver: &PluginDriver,
   resolved_id: &ResolvedId,
@@ -12,13 +13,5 @@ pub async fn transform_source(
   side_effects: &mut Option<HookSideEffects>,
   module_type: &mut ModuleType,
 ) -> Result<String> {
-  plugin_driver
-    .transform(
-      &HookTransformArgs { id: &resolved_id.id, code: &source, module_type: &ModuleType::Empty },
-      sourcemap_chain,
-      side_effects,
-      &source,
-      module_type,
-    )
-    .await
+  plugin_driver.transform(&resolved_id.id, source, sourcemap_chain, side_effects, module_type).await
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Here has some changes at here.

- avoid unnecessarily `to_string`
- avoid creating unnecessarily `HookTransformArgs`
- perf: avod create the sourcemap if the code hasn't changed, the vite has some usages.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
