### PR TITLE
refactor: improve dx in `ScanStage#scan`

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -73,10 +73,10 @@ pub struct ModuleLoaderOutput {
 
 impl ModuleLoader {
   pub fn new(
-    options: SharedOptions,
-    plugin_driver: SharedPluginDriver,
     fs: OsFileSystem,
+    options: SharedOptions,
     resolver: SharedResolver,
+    plugin_driver: SharedPluginDriver,
   ) -> BuildResult<Self> {
     // 1024 should be enough for most cases
     // over 1024 pending tasks are insane
@@ -240,9 +240,9 @@ impl ModuleLoader {
   pub async fn fetch_all_modules(
     mut self,
     user_defined_entries: Vec<(Option<ArcStr>, ResolvedId)>,
-  ) -> anyhow::Result<BuildResult<ModuleLoaderOutput>> {
+  ) -> BuildResult<ModuleLoaderOutput> {
     if self.options.input.is_empty() {
-      return Err(anyhow::format_err!("You must supply options.input to rolldown"));
+      return Err(anyhow::anyhow!("You must supply options.input to rolldown").into());
     }
 
     self.shared_context.plugin_driver.set_context_load_modules_tx(Some(self.tx.clone())).await;
@@ -385,7 +385,7 @@ impl ModuleLoader {
     }
 
     if !errors.is_empty() {
-      return Ok(Err(errors.into()));
+      return Err(errors.into());
     }
 
     let dynamic_import_exports_usage_map = dynamic_import_exports_usage_pairs.into_iter().fold(
@@ -446,7 +446,7 @@ impl ModuleLoader {
       }));
     }
 
-    Ok(Ok(ModuleLoaderOutput {
+    Ok(ModuleLoaderOutput {
       module_table: ModuleTable { modules },
       symbol_ref_db: self.symbol_ref_db,
       index_ecma_ast: self.intermediate_normal_modules.index_ecma_ast,
@@ -454,6 +454,6 @@ impl ModuleLoader {
       runtime: runtime_brief.expect("Failed to find runtime module. This should not happen"),
       warnings: all_warnings,
       dynamic_import_exports_usage_map,
-    }))
+    })
   }
 }

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -242,7 +242,7 @@ impl ModuleLoader {
     user_defined_entries: Vec<(Option<ArcStr>, ResolvedId)>,
   ) -> BuildResult<ModuleLoaderOutput> {
     if self.options.input.is_empty() {
-      return Err(anyhow::anyhow!("You must supply options.input to rolldown").into());
+      Err(anyhow::anyhow!("You must supply options.input to rolldown"))?;
     }
 
     self.shared_context.plugin_driver.set_context_load_modules_tx(Some(self.tx.clone())).await;

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -51,7 +51,7 @@ impl ScanStage {
   #[tracing::instrument(level = "debug", skip_all)]
   pub async fn scan(&mut self) -> BuildResult<ScanStageOutput> {
     if self.options.input.is_empty() {
-      return Err(anyhow::anyhow!("You must supply options.input to rolldown").into());
+      Err(anyhow::anyhow!("You must supply options.input to rolldown"))?;
     }
 
     self.plugin_driver.build_start(&self.options).await?;

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -51,24 +51,19 @@ impl ScanStage {
   #[tracing::instrument(level = "debug", skip_all)]
   pub async fn scan(&mut self) -> BuildResult<ScanStageOutput> {
     if self.options.input.is_empty() {
-      return Err(anyhow::format_err!("You must supply options.input to rolldown").into());
+      return Err(anyhow::anyhow!("You must supply options.input to rolldown").into());
     }
 
     self.plugin_driver.build_start(&self.options).await?;
 
     let module_loader = ModuleLoader::new(
-      Arc::clone(&self.options),
-      Arc::clone(&self.plugin_driver),
       self.fs,
+      Arc::clone(&self.options),
       Arc::clone(&self.resolver),
+      Arc::clone(&self.plugin_driver),
     )?;
 
-    let user_entries = match self.resolve_user_defined_entries().await? {
-      Ok(entries) => entries,
-      Err(errors) => {
-        return Err(errors);
-      }
-    };
+    let user_entries = self.resolve_user_defined_entries().await??;
 
     let ModuleLoaderOutput {
       module_table,
@@ -78,12 +73,7 @@ impl ScanStage {
       warnings,
       index_ecma_ast,
       dynamic_import_exports_usage_map,
-    } = match module_loader.fetch_all_modules(user_entries).await? {
-      Ok(output) => output,
-      Err(errors) => {
-        return Err(errors);
-      }
-    };
+    } = module_loader.fetch_all_modules(user_entries).await?;
 
     Ok(ScanStageOutput {
       module_table,
@@ -97,7 +87,6 @@ impl ScanStage {
   }
 
   /// Resolve `InputOptions.input`
-
   #[tracing::instrument(level = "debug", skip_all)]
   #[allow(clippy::type_complexity)]
   async fn resolve_user_defined_entries(
@@ -145,7 +134,7 @@ impl ScanStage {
           ret.push(item);
         }
         Err(e) => match e {
-          ResolveError::NotFound(..) => {
+          ResolveError::NotFound(_) => {
             errors.push(BuildDiagnostic::unresolved_entry(args.specifier, None));
           }
           ResolveError::PackagePathNotExported(..) => {


### PR DESCRIPTION
### Description

- Replace `anyhow::format_err!` with `anyhow::anyhow!` for consistency, since `format_err` is an alias within `anyhow`.
-  Simplify the error return types of `resolve_user_defined_entries` and `fetch_all_modules`, as their errors will be uniformly handled by the `BuildResult<ScanStageOutput>` return type in `scan`.
- Simplify `return Err(anyhow::anyhow!(..).into());` to `Err(anyhow::anyhow!(..))?;`.

The modification to simplify the error return type of `fetch_all_modules` might have drawbacks, as we may need the `Result` return type in other places used in the future?

BTW, I noticed that `ModuleLoaderOutput` and `ScanStageOutput` have identical fields. Should we unify them? However, keeping them separate might be better, as we may need to change them independently in the future.

Feel free to close this, as these are just some personal suggestions I had while learning `rolldown`.