### PR TITLE
refactor: simplify return type of `resolve_user_defined_entries`

### DIFF
--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -6,7 +6,7 @@ use rolldown_common::{
   dynamic_import_usage::DynamicImportExportsUsage, EntryPoint, ImportKind, ModuleIdx, ModuleTable,
   ResolvedId, RuntimeModuleBrief, SymbolRefDb,
 };
-use rolldown_error::{BuildDiagnostic, BuildResult};
+use rolldown_error::{BuildDiagnostic, BuildResult, ResultExt};
 use rolldown_fs::OsFileSystem;
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_resolver::ResolveError;
@@ -139,7 +139,7 @@ impl ScanStage {
           ResolveError::PackagePathNotExported(..) => {
             errors.push(BuildDiagnostic::unresolved_entry(args.specifier, Some(e)));
           }
-          _ => return Err(e)?,
+          _ => return Err(e).map_err_to_unhandleable()?,
         },
       }
     }

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use anyhow::Result;
 use arcstr::ArcStr;
 use futures::future::join_all;
 use rolldown_common::{
@@ -63,7 +62,7 @@ impl ScanStage {
       Arc::clone(&self.plugin_driver),
     )?;
 
-    let user_entries = self.resolve_user_defined_entries().await??;
+    let user_entries = self.resolve_user_defined_entries().await?;
 
     let ModuleLoaderOutput {
       module_table,
@@ -88,10 +87,9 @@ impl ScanStage {
 
   /// Resolve `InputOptions.input`
   #[tracing::instrument(level = "debug", skip_all)]
-  #[allow(clippy::type_complexity)]
   async fn resolve_user_defined_entries(
     &mut self,
-  ) -> Result<BuildResult<Vec<(Option<ArcStr>, ResolvedId)>>> {
+  ) -> BuildResult<Vec<(Option<ArcStr>, ResolvedId)>> {
     let resolver = &self.resolver;
     let plugin_driver = &self.plugin_driver;
 
@@ -99,6 +97,7 @@ impl ScanStage {
       struct Args<'a> {
         specifier: &'a str,
       }
+
       let args = Args { specifier: &input_item.import };
       let resolved = resolve_id(
         resolver,
@@ -140,17 +139,15 @@ impl ScanStage {
           ResolveError::PackagePathNotExported(..) => {
             errors.push(BuildDiagnostic::unresolved_entry(args.specifier, Some(e)));
           }
-          _ => {
-            return Err(e.into());
-          }
+          _ => return Err(e)?,
         },
       }
     }
 
     if !errors.is_empty() {
-      return Ok(Err(errors.into()));
+      Err(errors)?;
     }
 
-    Ok(Ok(ret))
+    Ok(ret)
   }
 }

--- a/crates/rolldown_error/src/build_error/mod.rs
+++ b/crates/rolldown_error/src/build_error/mod.rs
@@ -120,12 +120,6 @@ impl From<anyhow::Error> for BuildDiagnostic {
   }
 }
 
-impl From<oxc_resolver::ResolveError> for BatchedBuildDiagnostic {
-  fn from(err: oxc_resolver::ResolveError) -> Self {
-    Self::new(vec![BuildDiagnostic::unhandleable_error(err.into())])
-  }
-}
-
 #[derive(Debug, Default)]
 pub struct BatchedBuildDiagnostic(Vec<BuildDiagnostic>);
 

--- a/crates/rolldown_error/src/build_error/mod.rs
+++ b/crates/rolldown_error/src/build_error/mod.rs
@@ -120,6 +120,12 @@ impl From<anyhow::Error> for BuildDiagnostic {
   }
 }
 
+impl From<oxc_resolver::ResolveError> for BatchedBuildDiagnostic {
+  fn from(err: oxc_resolver::ResolveError) -> Self {
+    Self::new(vec![BuildDiagnostic::unhandleable_error(err.into())])
+  }
+}
+
 #[derive(Debug, Default)]
 pub struct BatchedBuildDiagnostic(Vec<BuildDiagnostic>);
 


### PR DESCRIPTION
### Description

We have implemented our own `DiagnosableResolveError` which is from `oxc_resolver::ResolveError`, but its applicability was too limited, so I decided to retain the original error handling logic, which is based on errors converted from `anyhow::Error`.

https://github.com/rolldown/rolldown/blob/a519f4c704baf83ad0f4dce383cdcc88783c15ef/crates/rolldown_error/src/events/resolve_error.rs#L7-L13