### PR TITLE
refactor(node): using prototype define methods for PluginContext

### DIFF
--- a/packages/rolldown/src/log/logger.ts
+++ b/packages/rolldown/src/log/logger.ts
@@ -66,6 +66,7 @@ export function getLogger(
                 watchMode: false,
               },
               warn: getLogHandler(LOG_LEVEL_WARN),
+              pluginName: plugin.name || 'unknown',
             },
             level,
             log,

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -1,4 +1,4 @@
-import { unsupported, type UnsupportedFnRet } from '../utils/misc'
+import { unsupported } from '../utils/misc'
 import type { BindingNormalizedOptions } from '../binding'
 import type {
   SourcemapIgnoreListOption,
@@ -45,13 +45,17 @@ export interface NormalizedOutputOptions {
 function mapFunctionOption<T>(
   option: T | undefined,
   name: string,
-): T | ReturnType<typeof unsupported> {
+): T | (() => never) {
   return typeof option === 'undefined'
-    ? unsupported(
-        `You should not take \`NormalizedOutputOptions#${name}\` and call it directly`,
-      )
+    ? () => {
+        unsupported(
+          `You should not take \`NormalizedOutputOptions#${name}\` and call it directly`,
+        )
+      }
     : option
 }
+
+type UnsupportedFnRet = () => never
 
 // TODO: I guess we make these getters enumerable so it act more like a plain object
 export class NormalizedOutputOptionsImpl implements NormalizedOutputOptions {

--- a/packages/rolldown/src/plugin/minimal-plugin-context.ts
+++ b/packages/rolldown/src/plugin/minimal-plugin-context.ts
@@ -4,7 +4,6 @@ import type {
   LogLevelOption,
   RollupError,
 } from '../rollup'
-import type { Plugin } from '../plugin'
 import { LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARN } from '../log/logging'
 import { error, logPluginError } from '../log/logs'
 import { getLogHandler, normalizeLog } from '../log/logHandler'
@@ -21,10 +20,12 @@ export class MinimalPluginContext {
   warn: LoggingFunction
   debug: LoggingFunction
   meta: PluginContextMeta
-  readonly error: (error: RollupError | string) => never
 
-  constructor(onLog: LogHandler, logLevel: LogLevelOption, plugin: Plugin) {
-    const pluginName = plugin.name || 'unknown'
+  constructor(
+    onLog: LogHandler,
+    logLevel: LogLevelOption,
+    readonly pluginName: string,
+  ) {
     this.debug = getLogHandler(
       LOG_LEVEL_DEBUG,
       'PLUGIN_LOG',
@@ -46,13 +47,15 @@ export class MinimalPluginContext {
       pluginName,
       logLevel,
     )
-    this.error = (e): never => {
-      return error(logPluginError(normalizeLog(e), pluginName))
-    }
+
     this.meta = {
       rollupVersion: '4.23.0',
       rolldownVersion: VERSION,
       watchMode: false,
     }
+  }
+
+  public error(e: RollupError | string): never {
+    return error(logPluginError(normalizeLog(e), this.pluginName))
   }
 }

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -38,116 +38,127 @@ export interface PrivatePluginContextResolveOptions
 }
 
 export class PluginContext extends MinimalPluginContext {
-  readonly load: (
+  constructor(
+    private context: BindingPluginContext,
+    plugin: Plugin,
+    private data: PluginContextData,
+    private onLog: LogHandler,
+    logLevel: LogLevelOption,
+    private currentLoadingModule?: string,
+  ) {
+    super(onLog, logLevel, plugin.name!)
+  }
+
+  public async load(
     options: { id: string; resolveDependencies?: boolean } & Partial<
       PartialNull<ModuleOptions>
     >,
-  ) => Promise<ModuleInfo>
-  readonly resolve: (
+  ): Promise<ModuleInfo> {
+    const id = options.id
+    if (id === this.currentLoadingModule) {
+      this.onLog(
+        LOG_LEVEL_WARN,
+        logCycleLoading(super.pluginName, this.currentLoadingModule),
+      )
+    }
+    // resolveDependencies always true at rolldown
+    const moduleInfo = this.data.getModuleInfo(id, this.context)
+    if (moduleInfo && moduleInfo.code !== null /* module already parsed */) {
+      return moduleInfo
+    }
+    const rawOptions = {
+      meta: options.meta || {},
+      moduleSideEffects: options.moduleSideEffects || null,
+    }
+    this.data.updateModuleOption(id, rawOptions)
+
+    async function createLoadModulePromise(
+      context: BindingPluginContext,
+      data: PluginContextData,
+    ) {
+      const loadPromise = data.loadModulePromiseMap.get(id)
+      if (loadPromise) {
+        return loadPromise
+      }
+      let resolveFn
+      // TODO: If is not resolved, we need to set a time to avoid waiting.
+      const promise = new Promise<void>((resolve, _) => {
+        resolveFn = resolve
+      })
+      data.loadModulePromiseMap.set(id, promise)
+      try {
+        await context.load(
+          id,
+          bindingifySideEffects(options.moduleSideEffects),
+          resolveFn!,
+        )
+      } finally {
+        // If the load module has failed, avoid it re-load using unresolved promise.
+        data.loadModulePromiseMap.delete(id)
+      }
+      return promise
+    }
+
+    // Here using one promise to avoid pass more callback to rust side, it only accept one callback, other will be ignored.
+    await createLoadModulePromise(this.context, this.data)
+    return this.data.getModuleInfo(id, this.context)!
+  }
+
+  public async resolve(
     source: string,
     importer?: string,
     options?: PluginContextResolveOptions,
-  ) => Promise<ResolvedId | null>
-  readonly emitFile: (file: EmittedAsset) => string
-  readonly getFileName: (referenceId: string) => string
-  readonly getModuleInfo: (id: string) => ModuleInfo | null
-  readonly getModuleIds: () => IterableIterator<string>
-  readonly addWatchFile: (id: string) => void
+  ): Promise<ResolvedId | null> {
+    let receipt: number | undefined = undefined
+    if (options != null) {
+      receipt = this.data.saveResolveOptions(options)
+    }
+    const res = await this.context.resolve(source, importer, {
+      custom: receipt,
+      skipSelf: options?.skipSelf,
+    })
+    if (receipt != null) {
+      this.data.removeSavedResolveOptions(receipt)
+    }
+
+    if (res == null) return null
+    const info = this.data.getModuleOption(res.id) || ({} as ModuleOptions)
+    return { ...res, ...info }
+  }
+
+  public emitFile(file: EmittedAsset): string {
+    if (file.type !== 'asset') {
+      return unimplemented(
+        'PluginContext.emitFile: only asset type is supported',
+      )
+    }
+    return this.context.emitFile({
+      ...file,
+      originalFileName: file.originalFileName || undefined,
+      source: bindingAssetSource(file.source),
+    })
+  }
+
+  public getFileName(referenceId: string): string {
+    return this.context.getFileName(referenceId)
+  }
+
+  public getModuleInfo(id: string): ModuleInfo | null {
+    return this.data.getModuleInfo(id, this.context)
+  }
+
+  public getModuleIds(): IterableIterator<string> {
+    return this.data.getModuleIds(this.context)
+  }
+
+  public addWatchFile(id: string): void {
+    this.context.addWatchFile(id)
+  }
+
   /**
    * @deprecated This rollup API won't be supported by rolldown. Using this API will cause runtime error.
    */
-  readonly parse: (input: string, options?: any) => any
-
-  constructor(
-    context: BindingPluginContext,
-    plugin: Plugin,
-    data: PluginContextData,
-    onLog: LogHandler,
-    logLevel: LogLevelOption,
-    currentLoadingModule?: string,
-  ) {
-    super(onLog, logLevel, plugin)
-    this.load = async ({ id, ...options }) => {
-      if (id === currentLoadingModule) {
-        onLog(
-          LOG_LEVEL_WARN,
-          logCycleLoading(plugin.name!, currentLoadingModule),
-        )
-      }
-      // resolveDependencies always true at rolldown
-      const moduleInfo = data.getModuleInfo(id, context)
-      if (moduleInfo && moduleInfo.code !== null /* module already parsed */) {
-        return moduleInfo
-      }
-      const rawOptions = {
-        meta: options.meta || {},
-        moduleSideEffects: options.moduleSideEffects || null,
-      }
-      data.updateModuleOption(id, rawOptions)
-
-      async function createLoadModulePromise() {
-        const loadPromise = data.loadModulePromiseMap.get(id)
-        if (loadPromise) {
-          return loadPromise
-        }
-        let resolveFn
-        // TODO: If is not resolved, we need to set a time to avoid waiting.
-        const promise = new Promise<void>((resolve, _) => {
-          resolveFn = resolve
-        })
-        data.loadModulePromiseMap.set(id, promise)
-        try {
-          await context.load(
-            id,
-            bindingifySideEffects(options.moduleSideEffects),
-            resolveFn!,
-          )
-        } finally {
-          // If the load module has failed, avoid it re-load using unresolved promise.
-          data.loadModulePromiseMap.delete(id)
-        }
-        return promise
-      }
-
-      // Here using one promise to avoid pass more callback to rust side, it only accept one callback, other will be ignored.
-      await createLoadModulePromise()
-      return data.getModuleInfo(id, context)!
-    }
-    this.resolve = async (source, importer, options) => {
-      let receipt: number | undefined = undefined
-      if (options != null) {
-        receipt = data.saveResolveOptions(options)
-      }
-      const res = await context.resolve(source, importer, {
-        custom: receipt,
-        skipSelf: options?.skipSelf,
-      })
-      if (receipt != null) {
-        data.removeSavedResolveOptions(receipt)
-      }
-
-      if (res == null) return null
-      const info = data.getModuleOption(res.id) || ({} as ModuleOptions)
-      return { ...res, ...info }
-    }
-    this.emitFile = (file: EmittedAsset): string => {
-      if (file.type !== 'asset') {
-        return unimplemented(
-          'PluginContext.emitFile: only asset type is supported',
-        )
-      }
-      return context.emitFile({
-        ...file,
-        originalFileName: file.originalFileName || undefined,
-        source: bindingAssetSource(file.source),
-      })
-    }
-    this.getFileName = context.getFileName.bind(context)
-    this.getModuleInfo = (id: string) => data.getModuleInfo(id, context)
-    this.getModuleIds = () => data.getModuleIds(context)
-    this.parse = unsupported(
-      '`PluginContext#parse` is not supported by rolldown.',
-    )
-    this.addWatchFile = context.addWatchFile.bind(context)
+  public parse(_input: string, _options?: any): any {
+    unsupported('`PluginContext#parse` is not supported by rolldown.')
   }
 }

--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -59,6 +59,7 @@ export class PluginDriver {
               name,
               logLevel,
             ),
+            pluginName: name,
           },
           inputOptions,
         )

--- a/packages/rolldown/src/utils/misc.ts
+++ b/packages/rolldown/src/utils/misc.ts
@@ -19,11 +19,7 @@ export function unreachable(info?: string): never {
   }
   throw new Error('unreachable')
 }
-export function unsupported(info: string): () => never {
-  return () => {
-    throw new Error(`UNSUPPORTED: ${info}`)
-  }
+export function unsupported(info: string): never {
+  throw new Error(`UNSUPPORTED: ${info}`)
 }
-export type UnsupportedFnRet = ReturnType<typeof unsupported>
-
 export function noop(..._args: any[]): void {}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Here has the benchmark `prototype-vs-this`
- create method and call it, see https://jsperf.app/prototype-vs-this 
- create method, see https://jsperf.app/prototype-vs-this/67

Using prototype-defined methods always wins.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
