### PR TITLE
refactor(node/types)!: remove compat exports for rollup

### DIFF
--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -7,7 +7,7 @@ import { NormalizedCliOptions } from '../arguments/normalize'
 import { arraify } from '../../utils/misc'
 import { rolldown } from '../../api/rolldown'
 import { watch as rolldownWatch } from '../../api/watch'
-import type { RolldownOptions, RolldownOutput, RollupOutput } from '../..'
+import type { RolldownOptions, RolldownOutput } from '../..'
 import { loadConfig } from '../load-config'
 
 export async function bundleWithConfig(
@@ -163,7 +163,7 @@ type OutputEntry = {
   size: number
 }
 
-function collectOutputEntries(output: RollupOutput['output']): OutputEntry[] {
+function collectOutputEntries(output: RolldownOutput['output']): OutputEntry[] {
   return output.map((chunk) => ({
     type: chunk.type,
     fileName: chunk.fileName,

--- a/packages/rolldown/src/cli/load-config.ts
+++ b/packages/rolldown/src/cli/load-config.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import { ConfigExport } from '../types/config-export'
 import { pathToFileURL } from 'node:url'
 import { rolldown } from '../api/rolldown'
-import { RolldownOutputChunk } from '../types/rolldown-output'
+import { OutputChunk } from '../types/rolldown-output'
 
 export async function loadTsConfig(configFile: string): Promise<ConfigExport> {
   const file = await bundleTsConfig(configFile)
@@ -60,8 +60,7 @@ async function bundleTsConfig(configFile: string): Promise<string> {
   })
 
   return result.output.find(
-    (chunk): chunk is RolldownOutputChunk =>
-      chunk.type === 'chunk' && chunk.isEntry,
+    (chunk): chunk is OutputChunk => chunk.type === 'chunk' && chunk.isEntry,
   )!.fileName
 }
 

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -1,8 +1,8 @@
 import {
   RolldownOutput,
-  RolldownOutputAsset,
-  RolldownOutputChunk,
-  RolldownRenderedChunk,
+  OutputAsset,
+  OutputChunk,
+  RenderedChunk,
   SourceMap,
 } from './types/rolldown-output'
 import type {
@@ -63,8 +63,8 @@ export { defineConfig, rolldown, watch, build }
 export const VERSION: string = version
 
 export type {
-  RolldownOutputAsset,
-  RolldownOutputChunk,
+  OutputAsset,
+  OutputChunk,
   RolldownOptions,
   RolldownOutput,
   RolldownBuild,
@@ -110,17 +110,7 @@ export type {
   WatchOptions,
   RolldownWatcher,
   BuildOptions,
+  RenderedChunk,
 }
 
-// Exports for compatibility
-
-export type {
-  RolldownOutput as RollupOutput,
-  RolldownOptions as RollupOptions,
-  RolldownBuild as RollupBuild,
-  RolldownOutputChunk as OutputChunk,
-  RolldownOutputAsset as OutputAsset,
-  RolldownRenderedChunk as RenderedChunk,
-  RolldownWatcher as RollupWatcher,
-}
 export type { RollupError, RollupLog, LoggingFunction } from './rollup'

--- a/packages/rolldown/src/options/output-options-schema.ts
+++ b/packages/rolldown/src/options/output-options-schema.ts
@@ -14,7 +14,7 @@ import type {
   OutputCliOptions,
   OutputOptions,
 } from '../options/output-options'
-import { RolldownRenderedChunk } from '../types/rolldown-output'
+import { RenderedChunk } from '../types/rolldown-output'
 
 const ModuleFormatSchema = z
   .literal('es')
@@ -30,7 +30,7 @@ const ModuleFormatSchema = z
 
 const addonFunctionSchema = z
   .function()
-  .args(zodExt.phantom<RolldownRenderedChunk>())
+  .args(zodExt.phantom<RenderedChunk>())
   .returns(
     z.string().or(z.promise(z.string())),
   ) satisfies z.ZodType<AddonFunction>

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -5,7 +5,7 @@ import {
   SourcemapPathTransformOption,
 } from '../rollup'
 import { RolldownOutputPluginOption } from '../plugin'
-import { RolldownRenderedChunk } from '../types/rolldown-output'
+import { RenderedChunk } from '../types/rolldown-output'
 
 export type ModuleFormat =
   | 'es'
@@ -17,9 +17,7 @@ export type ModuleFormat =
   | 'umd'
   | 'experimental-app'
 
-export type AddonFunction = (
-  chunk: RolldownRenderedChunk,
-) => string | Promise<string>
+export type AddonFunction = (chunk: RenderedChunk) => string | Promise<string>
 
 export type ChunkFileNamesFunction = (chunkInfo: PreRenderedChunk) => string
 

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -25,7 +25,7 @@ import type { DefinedHookNames } from '../constants/plugin'
 import type { DEFINED_HOOK_NAMES } from '../constants/plugin'
 import type { SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF } from '../constants/plugin-context'
 import type { HookFilter } from './hook-filter'
-import { RolldownRenderedChunk } from '../types/rolldown-output'
+import { RenderedChunk } from '../types/rolldown-output'
 
 export type ModuleSideEffects = boolean | 'no-treeshake' | null
 
@@ -158,7 +158,7 @@ export interface FunctionPluginHooks {
   [DEFINED_HOOK_NAMES.renderChunk]: (
     this: PluginContext,
     code: string,
-    chunk: RolldownRenderedChunk,
+    chunk: RenderedChunk,
     outputOptions: NormalizedOutputOptions,
   ) =>
     | NullValue
@@ -170,7 +170,7 @@ export interface FunctionPluginHooks {
 
   [DEFINED_HOOK_NAMES.augmentChunkHash]: (
     this: PluginContext,
-    chunk: RolldownRenderedChunk,
+    chunk: RenderedChunk,
   ) => string | void
 
   [DEFINED_HOOK_NAMES.renderError]: (this: PluginContext, error: Error) => void
@@ -281,7 +281,7 @@ export type PluginHooks = {
 
 export type AddonHookFunction = (
   this: PluginContext,
-  chunk: RolldownRenderedChunk,
+  chunk: RenderedChunk,
 ) => string | Promise<string>
 
 export type AddonHook = string | AddonHookFunction

--- a/packages/rolldown/src/types/output-bundle.ts
+++ b/packages/rolldown/src/types/output-bundle.ts
@@ -1,8 +1,5 @@
-import type {
-  RolldownOutputAsset,
-  RolldownOutputChunk,
-} from './rolldown-output'
+import type { OutputAsset, OutputChunk } from './rolldown-output'
 
 export interface OutputBundle {
-  [fileName: string]: RolldownOutputAsset | RolldownOutputChunk
+  [fileName: string]: OutputAsset | OutputChunk
 }

--- a/packages/rolldown/src/types/rolldown-output.ts
+++ b/packages/rolldown/src/types/rolldown-output.ts
@@ -1,9 +1,7 @@
 import { AssetSource } from '../utils/asset-source'
-import type { OutputAsset, OutputChunk } from '../rollup'
-import type { HasProperty, IsPropertiesEqual, TypeAssert } from './assert'
-import type { RenderedChunk } from '../binding'
+import type { RenderedChunk as BindingRenderedChunk } from '../binding'
 
-export interface RolldownOutputAsset {
+export interface OutputAsset {
   type: 'asset'
   fileName: string
   /** @deprecated Use "originalFileNames" instead. */
@@ -13,10 +11,6 @@ export interface RolldownOutputAsset {
   /** @deprecated Use "names" instead. */
   name: string | undefined
   names: string[]
-}
-
-function _assertRolldownOutputAsset() {
-  type _ = TypeAssert<IsPropertiesEqual<RolldownOutputAsset, OutputAsset>>
 }
 
 export interface SourceMap {
@@ -30,18 +24,18 @@ export interface SourceMap {
   toUrl(): string
 }
 
-export interface RolldownRenderedModule {
+export interface RenderedModule {
   readonly code: string | null
   renderedLength: number
 }
 
-export interface RolldownRenderedChunk extends Omit<RenderedChunk, 'modules'> {
+export interface RenderedChunk extends Omit<BindingRenderedChunk, 'modules'> {
   modules: {
-    [id: string]: RolldownRenderedModule
+    [id: string]: RenderedModule
   }
 }
 
-export interface RolldownOutputChunk {
+export interface OutputChunk {
   type: 'chunk'
   code: string
   name: string
@@ -49,7 +43,7 @@ export interface RolldownOutputChunk {
   exports: string[]
   fileName: string
   modules: {
-    [id: string]: RolldownRenderedModule
+    [id: string]: RenderedModule
   }
   imports: string[]
   dynamicImports: string[]
@@ -61,19 +55,6 @@ export interface RolldownOutputChunk {
   preliminaryFileName: string
 }
 
-function _assertRolldownOutputChunk() {
-  type _ = TypeAssert<
-    IsPropertiesEqual<Omit<RolldownOutputChunk, 'modules' | 'map'>, OutputChunk>
-  >
-}
-
 export interface RolldownOutput {
-  output: [
-    RolldownOutputChunk,
-    ...(RolldownOutputChunk | RolldownOutputAsset)[],
-  ]
-}
-
-function _assertRolldownOutput() {
-  type _ = TypeAssert<HasProperty<RolldownOutput, 'output'>>
+  output: [OutputChunk, ...(OutputChunk | OutputAsset)[]]
 }

--- a/packages/rolldown/src/utils/transform-rendered-chunk.ts
+++ b/packages/rolldown/src/utils/transform-rendered-chunk.ts
@@ -1,10 +1,10 @@
-import { RenderedChunk } from '../binding'
-import { RolldownRenderedChunk } from '../types/rolldown-output'
+import { RenderedChunk as BindingRenderedChunk } from '../binding'
+import { RenderedChunk } from '../types/rolldown-output'
 import { transformToRenderedModule } from './transform-rendered-module'
 
 export function transformRenderedChunk(
-  chunk: RenderedChunk,
-): RolldownRenderedChunk {
+  chunk: BindingRenderedChunk,
+): RenderedChunk {
   return {
     ...chunk,
     get modules() {
@@ -14,9 +14,9 @@ export function transformRenderedChunk(
 }
 
 export function transformChunkModules(
-  modules: RenderedChunk['modules'],
-): RolldownRenderedChunk['modules'] {
-  const result: RolldownRenderedChunk['modules'] = {}
+  modules: BindingRenderedChunk['modules'],
+): RenderedChunk['modules'] {
+  const result: RenderedChunk['modules'] = {}
   for (const [id, mod] of Object.entries(modules)) {
     result[id] = transformToRenderedModule(mod)
   }

--- a/packages/rolldown/src/utils/transform-rendered-module.ts
+++ b/packages/rolldown/src/utils/transform-rendered-module.ts
@@ -1,9 +1,9 @@
 import { BindingRenderedModule } from '../binding'
-import { RolldownRenderedModule } from '../types/rolldown-output'
+import { RenderedModule } from '../types/rolldown-output'
 
 export function transformToRenderedModule(
   bindingRenderedModule: BindingRenderedModule,
-): RolldownRenderedModule {
+): RenderedModule {
   return {
     get code() {
       return bindingRenderedModule.code

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -1,8 +1,8 @@
 import type {
   SourceMap,
   RolldownOutput,
-  RolldownOutputAsset,
-  RolldownOutputChunk,
+  OutputAsset,
+  OutputChunk,
 } from '../types/rolldown-output'
 import type { OutputBundle } from '../types/output-bundle'
 import type {
@@ -40,7 +40,7 @@ function transformToRollupSourceMap(map: string): SourceMap {
 function transformToRollupOutputChunk(
   bindingChunk: BindingOutputChunk,
   changed?: ChangedOutputs,
-): RolldownOutputChunk {
+): OutputChunk {
   const chunk = {
     type: 'chunk',
     get code() {
@@ -71,14 +71,14 @@ function transformToRollupOutputChunk(
     },
     sourcemapFileName: bindingChunk.sourcemapFileName || null,
     preliminaryFileName: bindingChunk.preliminaryFileName,
-  } as RolldownOutputChunk
+  } as OutputChunk
   const cache: Record<string | symbol, any> = {}
   return new Proxy(chunk, {
     get(target, p) {
       if (p in cache) {
         return cache[p]
       }
-      return target[p as keyof RolldownOutputChunk]
+      return target[p as keyof OutputChunk]
     },
     set(target, p, newValue): boolean {
       cache[p] = newValue
@@ -91,7 +91,7 @@ function transformToRollupOutputChunk(
 function transformToRollupOutputAsset(
   bindingAsset: BindingOutputAsset,
   changed?: ChangedOutputs,
-): RolldownOutputAsset {
+): OutputAsset {
   const asset = {
     type: 'asset',
     fileName: bindingAsset.fileName,
@@ -102,14 +102,14 @@ function transformToRollupOutputAsset(
     },
     name: bindingAsset.name ?? undefined,
     names: bindingAsset.names,
-  } as RolldownOutputAsset
+  } as OutputAsset
   const cache: Record<string | symbol, any> = {}
   return new Proxy(asset, {
     get(target, p) {
       if (p in cache) {
         return cache[p]
       }
-      return target[p as keyof RolldownOutputAsset]
+      return target[p as keyof OutputAsset]
     },
     set(target, p, newValue): boolean {
       cache[p] = newValue

--- a/packages/rolldown/tests/fixtures/output/banner/async-function/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/banner/async-function/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/banner/function/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/banner/function/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/banner/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/banner/string/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/es-module/common-chunks/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/common-chunks/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/es-module/false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/false/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-false/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-true/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/es-module/true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/true/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/fileNames/function/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/fileNames/function/_config.ts
@@ -1,4 +1,7 @@
-import type { RolldownOutputChunk, PreRenderedChunk } from 'rolldown'
+import type {
+  OutputChunk as RolldownOutputChunk,
+  PreRenderedChunk,
+} from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/fileNames/hash/base36/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/fileNames/hash/base36/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/fileNames/hash/base64/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/fileNames/hash/base64/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/fileNames/hash/hex/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/fileNames/hash/hex/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/fileNames/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/fileNames/string/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/footer/async-function/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/footer/async-function/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/footer/function/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/footer/function/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/footer/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/footer/string/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/intro/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/intro/string/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/output/outro/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/outro/string/_config.ts
@@ -1,6 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
-import { expect } from 'vitest'
 
 const outroText = '/* outro test */\n'
 

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
@@ -1,7 +1,7 @@
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 import path from 'node:path'
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { getOutputChunk } from '@tests/utils'
 
 const entry = path.join(__dirname, './main.js')

--- a/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
@@ -1,7 +1,7 @@
 import { expect } from 'vitest'
 import path from 'node:path'
 import fs from 'node:fs'
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 
 const entry = path.join(__dirname, './main.js')

--- a/packages/rolldown/tests/fixtures/tree-shake/annotations/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/annotations/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/tree-shake/const-folding/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/const-folding/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-function/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-function/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-rule-single/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-rule-single/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-rules-priority/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-rules-priority/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-rules/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-rules/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/tree-shake/unused-external-import-stmt/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/unused-external-import-stmt/_config.ts
@@ -1,4 +1,4 @@
-import type { RolldownOutputChunk } from 'rolldown'
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from '@tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -1,7 +1,7 @@
 import {
-  RollupOutput,
-  RolldownOutputChunk,
-  RolldownOutputAsset,
+  RolldownOutput as RollupOutput,
+  OutputChunk as RolldownOutputChunk,
+  OutputAsset as RolldownOutputAsset,
 } from 'rolldown'
 import nodePath from 'node:path'
 import assert from 'node:assert'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

After some discussion, we intend to remove these types to have a clean code.

This affects rolldown-vite. @sapphi-red cc

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
