### PR TITLE
fix(node): make `name` property required for plugins

### DIFF
--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -290,7 +290,7 @@ export interface OutputPlugin
   extends Partial<{ [K in OutputPluginHooks]: PluginHooks[K] }>,
     Partial<{ [K in AddonHooks]: ObjectHook<AddonHook> }> {
   // cacheKey?: string
-  name?: string
+  name: string
   // version?: string
 }
 

--- a/packages/rolldown/tests/fixtures/misc/virtual/chunk-modules/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/virtual/chunk-modules/_config.ts
@@ -13,6 +13,7 @@ export default defineTest({
     },
     plugins: [
       {
+        name: 'virtual-module',
         resolveId(id) {
           if (id === '\0module') {
             return id

--- a/packages/rolldown/tests/fixtures/misc/virtual/import-directly/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/virtual/import-directly/_config.ts
@@ -7,6 +7,7 @@ export default defineTest({
   config: {
     plugins: [
       {
+        name: 'virtual-module',
         resolveId(id) {
           if (id === '\0module') {
             return id

--- a/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
@@ -9,6 +9,7 @@ export default defineTest({
     input: ['main.js', 'entry.js'],
     plugins: [
       {
+        name: 'virtual-module',
         resolveId(id) {
           if (id === '\0module') {
             return id

--- a/packages/rolldown/tests/fixtures/plugin/load/virtual-entry/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/load/virtual-entry/_config.ts
@@ -12,6 +12,7 @@ export default defineTest({
     },
     plugins: [
       {
+        name: 'virtual-entry',
         resolveId(source) {
           if (source === entryName) {
             return source

--- a/packages/rolldown/tests/fixtures/topics/virtual-module/virtual-entry/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/virtual-module/virtual-entry/_config.ts
@@ -7,6 +7,7 @@ export default defineTest({
     input: 'test',
     plugins: [
       {
+        name: 'virtual-module',
         resolveId(id) {
           if (id === 'test') {
             return '\0virtual:test'

--- a/packages/rolldown/tests/fixtures/tree-shake/const-folding/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/const-folding/_config.ts
@@ -6,6 +6,7 @@ export default defineTest({
   config: {
     plugins: [
       {
+        name: 'replace NODE_ENV',
         transform: (code, id) => {
           const res = code.replace(
             'process.env.NODE_ENV',

--- a/packages/rolldown/tests/plugin/plugin.test.ts
+++ b/packages/rolldown/tests/plugin/plugin.test.ts
@@ -35,6 +35,7 @@ describe('Plugin buildEnd hook', async () => {
   test('call buildEnd hook with error', async () => {
     const buildEndFn = vi.fn()
     const error = await buildWithPlugin({
+      name: 'test',
       buildStart() {
         throw new Error('buildStart error')
       },
@@ -50,6 +51,7 @@ describe('Plugin buildEnd hook', async () => {
   test('call buildEnd hook without error', async () => {
     const buildEndFn = vi.fn()
     const error = await buildWithPlugin({
+      name: 'test',
       buildEnd: (error) => {
         buildEndFn()
         expect(error).toBeUndefined()
@@ -64,6 +66,7 @@ describe('Plugin closeBundle hook', async () => {
   test('call closeBundle hook if has error', async () => {
     const closeBundleFn = vi.fn()
     const error = await buildWithPlugin({
+      name: 'test',
       load() {
         throw new Error('load error')
       },
@@ -82,6 +85,7 @@ describe('Plugin closeBundle hook', async () => {
       cwd: import.meta.dirname,
       plugins: [
         {
+          name: 'test',
           closeBundle: () => {
             closeBundleFn()
           },
@@ -110,6 +114,7 @@ describe('Plugin closeBundle hook', async () => {
 
 test('call transformContext error', async () => {
   const error = await buildWithPlugin({
+    name: 'test',
     transform() {
       this.error('transform hook error')
     },

--- a/packages/rolldown/tests/plugin/plugin.test.ts
+++ b/packages/rolldown/tests/plugin/plugin.test.ts
@@ -18,6 +18,7 @@ test('Plugin renderError hook', async () => {
   const renderErrorFn = vi.fn()
   const renderChunkFn = vi.fn()
   const error = await buildWithPlugin({
+    name: 'test',
     renderStart() {
       renderChunkFn()
       throw new Error('renderStart error')

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -13,6 +13,7 @@ test.sequential('watch', async () => {
     output: { file: output },
     plugins: [
       {
+        name: 'test watchChange',
         watchChange(id, event) {
           // The macos emit create event when the file is changed, not sure the reason,
           // so here only check the update event
@@ -23,6 +24,7 @@ test.sequential('watch', async () => {
         },
       },
       {
+        name: 'test closeWatcher',
         closeWatcher() {
           closeWatcherFn()
         },
@@ -55,6 +57,7 @@ test.sequential('watch files after scan stage', async () => {
     output: { file: output },
     plugins: [
       {
+        name: 'test',
         renderStart() {
           fs.writeFileSync(input, 'console.log(2)')
         },
@@ -211,6 +214,7 @@ test.sequential('PluginContext addWatchFile', async () => {
     output: { file: output },
     plugins: [
       {
+        name: 'test',
         buildStart() {
           this.addWatchFile(foo)
         },
@@ -317,6 +321,7 @@ test.sequential('error handling + plugin error', async () => {
     output: { file: output },
     plugins: [
       {
+        name: 'test',
         transform() {
           this.error('plugin error')
         },
@@ -425,6 +430,7 @@ test.sequential('warning for multiply notify options', async () => {
       },
       plugins: [
         {
+          name: 'test',
           onLog: (level, log) => {
             onLogFn()
             expect(level).toBe('warn')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`name` is required for rollup
https://github.com/rollup/rollup/blob/7a8ac460c62b0406a749e367dbd0b74973282449/src/rollup/types.d.ts#L518

`name` is useful for debugging purpose.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
