### PR TITLE
refactor(rust): stop taking internal reference of oxc's `SymbolTable`

### DIFF
--- a/crates/rolldown/src/ast_scanner/dynamic_import.rs
+++ b/crates/rolldown/src/ast_scanner/dynamic_import.rs
@@ -23,8 +23,12 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       return None;
     }
 
-    let reference =
-      self.scopes.references.get(ident.reference_id()).expect("should have reference");
+    let reference = self
+      .result
+      .symbol_ref_db
+      .references
+      .get(ident.reference_id())
+      .expect("should have reference");
 
     // panic because if program reached here, means the BindingIdentifier has referenced the
     // IdentifierReference, but IdentifierReference did not saved the related `SymbolId`
@@ -157,7 +161,8 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
               continue;
             }
           };
-          let is_used = !self.scopes.resolved_references[binding_symbol_id].is_empty();
+          let is_used =
+            !self.result.symbol_ref_db.resolved_references[binding_symbol_id].is_empty();
           if is_used {
             set.insert(binding_name.into());
           }
@@ -174,7 +179,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
               self
                 .dynamic_import_usage_info
                 .dynamic_import_binding_reference_id
-                .extend(self.scopes.resolved_references[symbol_id].iter());
+                .extend(self.result.symbol_ref_db.resolved_references[symbol_id].iter());
             }
             // If the rest argument is not a BindingIdentifier, this is an unexpected case
             // because '...' must be followed by an identifier in declaration contexts.
@@ -196,7 +201,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     self
       .dynamic_import_usage_info
       .dynamic_import_binding_reference_id
-      .extend(self.scopes.resolved_references[symbol_id].iter());
+      .extend(self.result.symbol_ref_db.resolved_references[symbol_id].iter());
     Some(FxHashSet::default())
   }
 }

--- a/crates/rolldown/src/ast_scanner/import_assign_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/import_assign_analyzer.rs
@@ -31,7 +31,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
           return;
         }
       }
-      let reference_flag = self.scopes.references[ident.reference_id()].flags();
+      let reference_flag = self.result.symbol_ref_db.references[ident.reference_id()].flags();
       if reference_flag.is_write() {
         self.result.errors.push(BuildDiagnostic::assign_to_import(
           self.id.resource_id().clone(),

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -514,7 +514,11 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     &mut self,
     call_expr: &mut ast::CallExpression<'ast>,
   ) -> Option<Expression<'ast>> {
-    if call_expr.is_global_require_call(self.scope) && !call_expr.span.is_unspanned() {
+    if call_expr.is_global_require_call(
+      self.scope,
+      self.ctx.symbol_db.this_method_should_be_removed_get_symbol_table(self.ctx.id),
+    ) && !call_expr.span.is_unspanned()
+    {
       //  `require` calls that can't be recognized by rolldown are ignored in scanning, so they were not stored in `NomralModule#imports`.
       //  we just keep these `require` calls as it is
       if let Some(rec_id) = self.ctx.module.imports.get(&call_expr.span).copied() {

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
@@ -38,7 +38,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       // But we don't care about them in this method. This method is only used to check if a `IdentifierReference` from user code is a global variable.
       return false;
     };
-    self.scope.is_unresolved(reference_id)
+    self.scope.is_unresolved(
+      reference_id,
+      self.ctx.symbol_db.this_method_should_be_removed_get_symbol_table(self.ctx.id),
+    )
   }
 
   pub fn canonical_name_for(&self, symbol: SymbolRef) -> &'me Rstr {

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/rename.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/rename.rs
@@ -18,7 +18,10 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     let reference_id = id_ref.reference_id.get()?;
 
     // we will hit this branch if the reference points to a global variable
-    let symbol_id = self.scope.symbol_id_for(reference_id)?;
+    let symbol_id = self.scope.symbol_id_for(
+      reference_id,
+      self.ctx.symbol_db.this_method_should_be_removed_get_symbol_table(self.ctx.id),
+    )?;
 
     let symbol_ref: SymbolRef = (self.ctx.id, symbol_id).into();
     let mut expr = self.finalized_expr_for_symbol_ref(symbol_ref, is_callee);
@@ -54,7 +57,10 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     let reference_id = id_ref.reference_id.get()?;
 
     // we will hit this branch if the reference points to a global variable
-    let symbol_id = self.scope.symbol_id_for(reference_id)?;
+    let symbol_id = self.scope.symbol_id_for(
+      reference_id,
+      self.ctx.symbol_db.this_method_should_be_removed_get_symbol_table(self.ctx.id),
+    )?;
 
     let symbol_ref: SymbolRef = (self.ctx.id, symbol_id).into();
     let canonical_ref = self.ctx.symbol_db.canonical_ref_for(symbol_ref);
@@ -104,7 +110,10 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
 
     let reference_id = target_id_ref.reference_id.get()?;
 
-    let symbol_id = self.scope.symbol_id_for(reference_id)?;
+    let symbol_id = self.scope.symbol_id_for(
+      reference_id,
+      self.ctx.symbol_db.this_method_should_be_removed_get_symbol_table(self.ctx.id),
+    )?;
 
     let symbol_ref: SymbolRef = (self.ctx.id, symbol_id).into();
     let canonical_ref = self.ctx.symbol_db.canonical_ref_for(symbol_ref);

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -179,12 +179,8 @@ impl RuntimeModuleTask {
       ast.contains_use_strict = pre_processor.contains_use_strict;
     });
 
-    let (mut symbol_table, scope) = ast.make_symbol_table_and_scope_tree();
-    let ast_scope = AstScopes::new(
-      scope,
-      std::mem::take(&mut symbol_table.references),
-      std::mem::take(&mut symbol_table.resolved_references),
-    );
+    let (symbol_table, scope) = ast.make_symbol_table_and_scope_tree();
+    let ast_scope = AstScopes::new(scope);
     let facade_path = ModuleId::new("runtime");
     let scanner = AstScanner::new(
       self.module_idx,

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -206,7 +206,7 @@ fn json_object_expr_to_esm(
 
   // recreate semantic data
   #[allow(clippy::cast_possible_truncation)]
-  let (mut symbol_table, scope) = ecma_ast.make_symbol_table_and_scope_tree_with_semantic_builder(
+  let (symbol_table, scope) = ecma_ast.make_symbol_table_and_scope_tree_with_semantic_builder(
     SemanticBuilder::new().with_scope_tree_child_ids(true).with_stats(Stats {
       nodes: declaration_binding_names.len().next_power_of_two() as u32,
       scopes: 1,
@@ -219,11 +219,7 @@ fn json_object_expr_to_esm(
 
   // update semantic data of module
   let root_scope_id = scope.root_scope_id();
-  let ast_scope = AstScopes::new(
-    scope,
-    std::mem::take(&mut symbol_table.references),
-    std::mem::take(&mut symbol_table.resolved_references),
-  );
+  let ast_scope = AstScopes::new(scope);
   let mut symbol_ref_db = SymbolRefDbForModule::new(symbol_table, module_idx, root_scope_id);
 
   let legitimized_repr_name = legitimize_identifier_name(&module.repr_name);

--- a/crates/rolldown/src/utils/call_expression_ext.rs
+++ b/crates/rolldown/src/utils/call_expression_ext.rs
@@ -1,19 +1,19 @@
-use oxc::ast::ast;
+use oxc::{ast::ast, semantic::SymbolTable};
 use rolldown_common::AstScopes;
 
 pub trait CallExpressionExt<'ast> {
-  fn is_global_require_call(&self, scope: &AstScopes) -> bool;
+  fn is_global_require_call(&self, scope: &AstScopes, symbol_table: &SymbolTable) -> bool;
 }
 
 impl<'ast> CallExpressionExt<'ast> for ast::CallExpression<'ast> {
-  fn is_global_require_call(&self, scope: &AstScopes) -> bool {
+  fn is_global_require_call(&self, scope: &AstScopes, symbol_table: &SymbolTable) -> bool {
     match &self.callee {
       ast::Expression::Identifier(ident) if ident.name == "require" => {
         let Some(ref_id) = ident.reference_id.get() else {
           // `require(...)` inserted by bundler does not have a reference id
           return true;
         };
-        scope.is_unresolved(ref_id)
+        scope.is_unresolved(ref_id, symbol_table)
       }
       _ => false,
     }

--- a/crates/rolldown/src/utils/make_ast_symbol_and_scope.rs
+++ b/crates/rolldown/src/utils/make_ast_symbol_and_scope.rs
@@ -5,11 +5,7 @@ pub fn make_ast_scopes_and_symbols(
   symbols: SymbolTable,
   scopes: ScopeTree,
 ) -> (SymbolTable, AstScopes) {
-  let mut symbols = symbols;
-  let ast_scope = AstScopes::new(
-    scopes,
-    std::mem::take(&mut symbols.references),
-    std::mem::take(&mut symbols.resolved_references),
-  );
+  let symbols = symbols;
+  let ast_scope = AstScopes::new(scopes);
   (symbols, ast_scope)
 }

--- a/crates/rolldown_common/src/types/ast_scopes.rs
+++ b/crates/rolldown_common/src/types/ast_scopes.rs
@@ -1,35 +1,35 @@
-use oxc::semantic::{Reference, ReferenceId, ScopeTree, SymbolId};
-use oxc_index::IndexVec;
+use oxc::semantic::{Reference, ReferenceId, ScopeTree, SymbolId, SymbolTable};
 
 #[derive(Debug)]
 pub struct AstScopes {
   inner: ScopeTree,
-  pub references: IndexVec<ReferenceId, Reference>,
-  pub resolved_references: IndexVec<SymbolId, Vec<ReferenceId>>,
 }
 
 impl AstScopes {
-  pub fn new(
-    inner: ScopeTree,
-    references: IndexVec<ReferenceId, Reference>,
-    resolved_references: IndexVec<SymbolId, Vec<ReferenceId>>,
-  ) -> Self {
-    Self { inner, references, resolved_references }
+  pub fn new(inner: ScopeTree) -> Self {
+    Self { inner }
   }
 
-  pub fn is_unresolved(&self, reference_id: ReferenceId) -> bool {
-    self.references[reference_id].symbol_id().is_none()
+  pub fn is_unresolved(&self, reference_id: ReferenceId, symbol_table: &SymbolTable) -> bool {
+    symbol_table.references[reference_id].symbol_id().is_none()
   }
 
-  pub fn symbol_id_for(&self, reference_id: ReferenceId) -> Option<SymbolId> {
-    self.references[reference_id].symbol_id()
+  pub fn symbol_id_for(
+    &self,
+    reference_id: ReferenceId,
+    symbol_table: &SymbolTable,
+  ) -> Option<SymbolId> {
+    symbol_table.references[reference_id].symbol_id()
   }
 
-  pub fn get_resolved_references(
+  pub fn get_resolved_references<'table>(
     &self,
     symbol_id: SymbolId,
-  ) -> impl Iterator<Item = &Reference> + '_ {
-    self.resolved_references[symbol_id].iter().map(|reference_id| &self.references[*reference_id])
+    symbol_table: &'table SymbolTable,
+  ) -> impl Iterator<Item = &'table Reference> + 'table {
+    symbol_table.resolved_references[symbol_id]
+      .iter()
+      .map(|reference_id| &symbol_table.references[*reference_id])
   }
 }
 

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -186,6 +186,10 @@ impl SymbolRefDb {
     let local_db = self.inner[refer.owner].unpack_ref();
     local_db.get_scope_id(refer.symbol) == local_db.root_scope_id
   }
+
+  pub fn this_method_should_be_removed_get_symbol_table(&self, owner: ModuleIdx) -> &SymbolTable {
+    self.inner[owner].unpack_ref()
+  }
 }
 
 pub trait GetLocalDb {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/rolldown/rolldown/issues/3188.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
