### PR TITLE
refactor: improve the error return type for `GenerateStage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,7 +2525,6 @@ dependencies = [
 name = "rolldown_ecmascript"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "either",
  "oxc",

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -20,7 +20,7 @@ pub type IndexSplittingInfo = IndexVec<ModuleIdx, SplittingInfo>;
 
 impl<'a> GenerateStage<'a> {
   #[tracing::instrument(level = "debug", skip_all)]
-  pub async fn generate_chunks(&mut self) -> anyhow::Result<ChunkGraph> {
+  pub async fn generate_chunks(&mut self) -> ChunkGraph {
     if matches!(self.options.format, OutputFormat::Iife | OutputFormat::Umd) {
       let user_defined_entry_count =
         self.link_output.entries.iter().filter(|entry| entry.kind.is_user_defined()).count();
@@ -212,7 +212,7 @@ impl<'a> GenerateStage<'a> {
     chunk_graph.sorted_chunk_idx_vec = sorted_chunk_idx_vec;
     chunk_graph.entry_module_to_entry_chunk = entry_module_to_entry_chunk;
 
-    Ok(chunk_graph)
+    chunk_graph
   }
 
   fn determine_reachable_modules_for_entry(

--- a/crates/rolldown/src/stages/generate_stage/minify_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/minify_assets.rs
@@ -1,4 +1,5 @@
 use rolldown_ecmascript::EcmaCompiler;
+use rolldown_error::BuildResult;
 use rolldown_sourcemap::collapse_sourcemaps;
 use rolldown_utils::rayon::{IntoParallelRefMutIterator, ParallelIterator};
 
@@ -7,7 +8,7 @@ use crate::type_alias::IndexAssets;
 use super::GenerateStage;
 
 impl GenerateStage<'_> {
-  pub fn minify_assets(&mut self, assets: &mut IndexAssets) -> anyhow::Result<()> {
+  pub fn minify_assets(&mut self, assets: &mut IndexAssets) -> BuildResult<()> {
     if self.options.minify {
       assets.par_iter_mut().try_for_each(|asset| -> anyhow::Result<()> {
         match asset.meta {
@@ -17,7 +18,7 @@ impl GenerateStage<'_> {
               asset.content.try_as_inner_str()?,
               asset.map.is_some(),
               &asset.filename,
-            )?;
+            );
             asset.content = minified_content.into();
             match (&asset.map, &new_map) {
               (Some(origin_map), Some(new_map)) => {

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -65,7 +65,7 @@ impl<'a> GenerateStage<'a> {
   pub async fn generate(&mut self) -> BuildResult<BundleOutput> {
     self.plugin_driver.render_start(self.options).await?;
 
-    let mut chunk_graph = self.generate_chunks().await?;
+    let mut chunk_graph = self.generate_chunks().await;
     if chunk_graph.chunk_table.len() > 1 {
       validate_options_for_multi_chunk_output(self.options)?;
     }
@@ -149,7 +149,7 @@ impl<'a> GenerateStage<'a> {
   async fn generate_chunk_name_and_preliminary_filenames(
     &self,
     chunk_graph: &mut ChunkGraph,
-  ) -> anyhow::Result<FxHashMap<ChunkIdx, ArcStr>> {
+  ) -> BuildResult<FxHashMap<ChunkIdx, ArcStr>> {
     let modules = &self.link_output.module_table.modules;
 
     let mut index_chunk_id_to_name = FxHashMap::default();

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -205,7 +205,7 @@ impl<'a> GenerateStage<'a> {
     chunk_graph: &ChunkGraph,
     errors: &mut Vec<BuildDiagnostic>,
     warnings: &mut Vec<BuildDiagnostic>,
-  ) -> anyhow::Result<(IndexInstantiatedChunks, IndexChunkToAssets)> {
+  ) -> BuildResult<(IndexInstantiatedChunks, IndexChunkToAssets)> {
     let mut index_chunk_to_assets: IndexChunkToAssets =
       index_vec![FxIndexSet::default(); chunk_graph.chunk_table.len()];
     let mut index_preliminary_assets: IndexInstantiatedChunks =

--- a/crates/rolldown_ecmascript/Cargo.toml
+++ b/crates/rolldown_ecmascript/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 
 
 [dependencies]
-anyhow         = { workspace = true }
 arcstr         = { workspace = true }
 either         = { workspace = true }
 oxc            = { workspace = true }

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -109,7 +109,7 @@ impl EcmaCompiler {
     source_text: &str,
     enable_sourcemap: bool,
     filename: &str,
-  ) -> anyhow::Result<(String, Option<SourceMap>)> {
+  ) -> (String, Option<SourceMap>) {
     let allocator = Allocator::default();
     let program = Parser::new(&allocator, source_text, SourceType::default()).parse().program;
     let program = allocator.alloc(program);
@@ -123,7 +123,7 @@ impl EcmaCompiler {
       })
       .with_mangler(ret.mangler)
       .build(program);
-    Ok((ret.code, ret.map))
+    (ret.code, ret.map)
   }
 }
 


### PR DESCRIPTION
### Description

- Remove unnecessary usages of `anyhow::Result`
- Use `BuildResult` instead of `anyhow::Result` for the methods of `GenerateStage`