### PR TITLE
ci(release): generate npm provenance for non-normal version

### DIFF
--- a/.github/workflows/publish-nightly-canary.yml
+++ b/.github/workflows/publish-nightly-canary.yml
@@ -1,4 +1,4 @@
-name: A - Publish Nightly/Canary
+name: Publish Nightly/Canary
 
 on:
   # Manually released. This will publish under the canary npm tag.
@@ -33,7 +33,6 @@ jobs:
     if: github.repository == 'rolldown/rolldown'
     runs-on: ubuntu-latest
     permissions:
-      contents: write # for softprops/action-gh-release@v1
       id-token: write # for `npm publish --provenance`
     needs:
       - plan
@@ -91,3 +90,5 @@ jobs:
 
       - name: Publish
         run: node ./scripts/ci/publish-rolldown-to-npm.js ${{ needs.plan.outputs.npm-tag }}
+        env:
+          NPM_CONFIG_PROVENANCE: true # https://github.com/pnpm/pnpm/issues/6435


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/rolldown/rolldown/issues/3202.

https://www.npmjs.com/package/rolldown/v/0.15.1-commit.47f9075

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
