### PR TITLE
feat(cli): support array output

### DIFF
--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -1,4 +1,4 @@
-import { defineConfig, rolldown } from './src/index'
+import { defineConfig, OutputOptions, rolldown } from './src/index'
 import pkgJson from './package.json' with { type: 'json' }
 import nodePath from 'node:path'
 import fsExtra from 'fs-extra'
@@ -173,6 +173,6 @@ const configs = defineConfig([
 
 ;(async () => {
   for (const config of configs) {
-    await (await rolldown(config)).write(config.output)
+    await (await rolldown(config)).write(config.output as OutputOptions)
   }
 })()

--- a/packages/rolldown/src/api/build.ts
+++ b/packages/rolldown/src/api/build.ts
@@ -1,14 +1,16 @@
-import type { RolldownOptions } from '../types/rolldown-options'
+import { InputOptions } from '../options/input-options'
+import { OutputOptions } from '../options/output-options'
 import type { RolldownOutput } from '../types/rolldown-output'
 import { rolldown } from './rolldown'
 
-export interface BuildOptions extends RolldownOptions {
+export interface BuildOptions extends InputOptions {
   /**
    * Write the output to the file system
    *
    * @default true
    */
   write?: boolean
+  output?: OutputOptions
 }
 
 async function build(options: BuildOptions): Promise<RolldownOutput>

--- a/packages/rolldown/src/api/watch/watcher.ts
+++ b/packages/rolldown/src/api/watch/watcher.ts
@@ -6,6 +6,7 @@ import {
   BundlerOptionWithStopWorker,
   createBundlerOptions,
 } from '../../utils/create-bundler-option'
+import { arraify } from '../../utils/misc'
 import { WatcherEmitter } from './watch-emitter'
 
 export class Watcher {
@@ -51,9 +52,15 @@ export async function createWatcher(
   emitter: WatcherEmitter,
   input: WatchOptions | WatchOptions[],
 ): Promise<void> {
-  const options = Array.isArray(input) ? input : [input]
+  const options = arraify(input)
   const bundlerOptions = await Promise.all(
-    options.map((option) => createBundlerOptions(option, option.output || {})),
+    options
+      .map((option) =>
+        arraify(option.output || {}).map((output) =>
+          createBundlerOptions(option, output),
+        ),
+      )
+      .flat(),
   )
   const notifyOptions = getValidNotifyOption(bundlerOptions)
   const bindingWatcher = new BindingWatcher(

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -7,7 +7,7 @@ import { NormalizedCliOptions } from '../arguments/normalize'
 import { arraify } from '../../utils/misc'
 import { rolldown } from '../../api/rolldown'
 import { watch as rolldownWatch } from '../../api/watch'
-import type { RolldownOptions, RolldownOutput } from '../..'
+import type { ConfigExport, RolldownOutput } from '../..'
 import { loadConfig } from '../load-config'
 
 export async function bundleWithConfig(
@@ -22,10 +22,10 @@ export async function bundleWithConfig(
   }
 
   // TODO: Could add more validation/diagnostics here to emit a nice error message
-  const configList = arraify(config)
-  const operation = cliOptions.watch ? watchInner : bundleInner
-  for (const config of configList) {
-    await operation(config, cliOptions)
+  if (cliOptions.watch) {
+    await watchInner(config, cliOptions)
+  } else {
+    await bundleInner(config, cliOptions)
   }
 }
 
@@ -68,19 +68,25 @@ export async function bundleWithCliOptions(
 }
 
 async function watchInner(
-  options: RolldownOptions,
+  config: ConfigExport,
   cliOptions: NormalizedCliOptions,
 ) {
   // Only if watch is true in CLI can we use watch mode.
   // We should not make it `await`, as it never ends.
-  const watcher = await rolldownWatch({
-    ...options,
-    ...cliOptions.input,
-    output: {
-      ...options?.output,
-      ...cliOptions.output,
-    },
+
+  let normalizedConfig = arraify(config).map((option) => {
+    return {
+      ...option,
+      ...cliOptions.input,
+      output: arraify(option.output || {}).map((output) => {
+        return {
+          ...output,
+          ...cliOptions.output,
+        }
+      }),
+    }
   })
+  const watcher = await rolldownWatch(normalizedConfig)
 
   onExit((code: number | null | undefined) => {
     Promise.resolve(watcher.close()).finally(() => {
@@ -125,29 +131,39 @@ async function watchInner(
 }
 
 async function bundleInner(
-  options: RolldownOptions,
+  config: ConfigExport,
   cliOptions: NormalizedCliOptions,
 ) {
   const startTime = performance.now()
 
-  const build = await rolldown({ ...options, ...cliOptions.input })
-  try {
-    const bundleOutput = await build.write({
-      ...options?.output,
-      ...cliOptions.output,
-    })
+  const result = []
 
-    const endTime = performance.now()
-
-    printBundleOutputPretty(bundleOutput)
-
-    logger.log(``)
-    const duration = endTime - startTime
-    // If the build time is more than 1s, we should display it in seconds.
-    logger.success(`Finished in ${colors.bold(ms(duration))}`)
-  } finally {
-    await build.close()
+  const configList = arraify(config)
+  for (const config of configList) {
+    const outputList = arraify(config.output || {})
+    for (const output of outputList) {
+      // run multiply instance at sequential
+      const build = await rolldown({ ...config, ...cliOptions.input })
+      try {
+        result.push(
+          await build.write({
+            ...output,
+            ...cliOptions.output,
+          }),
+        )
+      } finally {
+        await build.close()
+      }
+    }
   }
+
+  result.forEach(printBundleOutputPretty)
+  logger.log(``)
+
+  const endTime = performance.now()
+  const duration = endTime - startTime
+  // If the build time is more than 1s, we should display it in seconds.
+  logger.success(`Finished in ${colors.bold(ms(duration))}`)
 }
 
 function printBundleOutputPretty(output: RolldownOutput) {

--- a/packages/rolldown/src/options/watch-options.ts
+++ b/packages/rolldown/src/options/watch-options.ts
@@ -2,5 +2,5 @@ import { InputOptions } from '../options/input-options'
 import { OutputOptions } from '../options/output-options'
 
 export interface WatchOptions extends InputOptions {
-  output?: OutputOptions
+  output?: OutputOptions | OutputOptions[]
 }

--- a/packages/rolldown/src/types/rolldown-options.ts
+++ b/packages/rolldown/src/types/rolldown-options.ts
@@ -2,5 +2,5 @@ import type { InputOptions } from '../options/input-options'
 import type { OutputOptions } from '../options/output-options'
 
 export interface RolldownOptions extends InputOptions {
-  output?: OutputOptions
+  output?: OutputOptions | OutputOptions[]
 }

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -183,6 +183,20 @@ exports[`config > no package.json > should allow loading ts config with tsx 1`] 
 "
 `;
 
+exports[`config > no package.json > should allow multiply options 1`] = `
+"<DIR>/esm.js  chunk │ size: 0.14 kB
+<DIR>/cjs.js  chunk │ size: 0.15 kB
+
+"
+`;
+
+exports[`config > no package.json > should allow multiply output 1`] = `
+"<DIR>/esm.js  chunk │ size: 0.14 kB
+<DIR>/cjs.js  chunk │ size: 0.15 kB
+
+"
+`;
+
 exports[`config > no package.json > should bundle in ext-js-syntax-cjs 1`] = `
 "<DIR>/index.js  chunk │ size: 0.13 kB
 

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -147,6 +147,24 @@ describe('config', () => {
       expect(status.exitCode).toBe(0)
       expect(cleanStdout(status.stdout)).toMatchSnapshot()
     })
+
+    it('should allow multiply options', async () => {
+      const cwd = cliFixturesDir('config-multiply-options')
+      const status = await $({
+        cwd,
+      })`rolldown -c rolldown.config.ts`
+      expect(status.exitCode).toBe(0)
+      expect(cleanStdout(status.stdout)).toMatchSnapshot()
+    })
+
+    it('should allow multiply output', async () => {
+      const cwd = cliFixturesDir('config-multiply-output')
+      const status = await $({
+        cwd,
+      })`rolldown -c rolldown.config.ts`
+      expect(status.exitCode).toBe(0)
+      expect(cleanStdout(status.stdout)).toMatchSnapshot()
+    })
   })
 })
 
@@ -165,6 +183,38 @@ describe('watch cli', () => {
       subprocess.kill('SIGINT')
       expect(fs.existsSync(path.join(cwd, 'dist'))).toBe(true)
       expect(fs.existsSync(path.join(cwd, 'dist/index.js.map'))).toBe(true)
+    }, 300)
+  })
+
+  it('should allow multiply options', async () => {
+    const cwd = cliFixturesDir('config-multiply-options')
+    const subprocess = execa({
+      cwd,
+    })`rolldown -c rolldown.config.ts -d watch-dist-options -w`
+    setTimeout(() => {
+      subprocess.kill('SIGINT')
+      expect(fs.existsSync(path.join(cwd, 'watch-dist-options/esm.js'))).toBe(
+        true,
+      )
+      expect(fs.existsSync(path.join(cwd, 'watch-dist-options/cjs.js'))).toBe(
+        true,
+      )
+    }, 300)
+  })
+
+  it('should allow multiply output', async () => {
+    const cwd = cliFixturesDir('config-multiply-output')
+    const subprocess = execa({
+      cwd,
+    })`rolldown -c rolldown.config.ts -d watch-dist-output -w`
+    setTimeout(() => {
+      subprocess.kill('SIGINT')
+      expect(fs.existsSync(path.join(cwd, 'watch-dist-output/esm.js'))).toBe(
+        true,
+      )
+      expect(fs.existsSync(path.join(cwd, 'watch-dist-output/cjs.js'))).toBe(
+        true,
+      )
     }, 300)
   })
 })

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, it, expect } from 'vitest'
 import { $, execa } from 'execa'
 import { stripAnsi } from 'consola/utils'
-import { testsDir } from '@tests/utils'
+import { testsDir, waitUtil } from '@tests/utils'
 import path from 'node:path'
 import fs from 'node:fs'
 
@@ -178,43 +178,54 @@ describe('watch cli', () => {
 
   it('should handle output options', async () => {
     const cwd = cliFixturesDir('watch-cli-option')
-    const subprocess = execa({ cwd })`rolldown index.ts -d dist -w -s`
-    setTimeout(() => {
-      subprocess.kill('SIGINT')
+    const controller = new AbortController()
+    execa({
+      cwd,
+      cancelSignal: controller.signal,
+      gracefulCancel: true,
+    })`rolldown index.ts -d dist -w -s`
+    waitUtil(() => {
       expect(fs.existsSync(path.join(cwd, 'dist'))).toBe(true)
       expect(fs.existsSync(path.join(cwd, 'dist/index.js.map'))).toBe(true)
-    }, 300)
+    })
+    controller.abort()
   })
 
   it('should allow multiply options', async () => {
     const cwd = cliFixturesDir('config-multiply-options')
-    const subprocess = execa({
+    const controller = new AbortController()
+    execa({
       cwd,
+      cancelSignal: controller.signal,
+      gracefulCancel: true,
     })`rolldown -c rolldown.config.ts -d watch-dist-options -w`
-    setTimeout(() => {
-      subprocess.kill('SIGINT')
+    waitUtil(() => {
       expect(fs.existsSync(path.join(cwd, 'watch-dist-options/esm.js'))).toBe(
         true,
       )
       expect(fs.existsSync(path.join(cwd, 'watch-dist-options/cjs.js'))).toBe(
         true,
       )
-    }, 300)
+    })
+    controller.abort()
   })
 
   it('should allow multiply output', async () => {
     const cwd = cliFixturesDir('config-multiply-output')
-    const subprocess = execa({
+    const controller = new AbortController()
+    execa({
       cwd,
+      cancelSignal: controller.signal,
+      gracefulCancel: true,
     })`rolldown -c rolldown.config.ts -d watch-dist-output -w`
-    setTimeout(() => {
-      subprocess.kill('SIGINT')
+    waitUtil(() => {
       expect(fs.existsSync(path.join(cwd, 'watch-dist-output/esm.js'))).toBe(
         true,
       )
       expect(fs.existsSync(path.join(cwd, 'watch-dist-output/cjs.js'))).toBe(
         true,
       )
-    }, 300)
+    })
+    controller.abort()
   })
 })

--- a/packages/rolldown/tests/cli/fixtures/config-multiply-options/.gitignore
+++ b/packages/rolldown/tests/cli/fixtures/config-multiply-options/.gitignore
@@ -1,0 +1,1 @@
+watch-dist-options

--- a/packages/rolldown/tests/cli/fixtures/config-multiply-options/index.js
+++ b/packages/rolldown/tests/cli/fixtures/config-multiply-options/index.js
@@ -1,0 +1,1 @@
+export default 'hello, world!'

--- a/packages/rolldown/tests/cli/fixtures/config-multiply-options/rolldown.config.ts
+++ b/packages/rolldown/tests/cli/fixtures/config-multiply-options/rolldown.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'rolldown'
+
+export default defineConfig([
+  {
+    input: 'index.js',
+    output: {
+      format: 'esm',
+      entryFileNames: 'esm.js',
+    },
+  },
+  {
+    input: 'index.js',
+    output: {
+      format: 'cjs',
+      entryFileNames: 'cjs.js',
+    },
+  },
+])

--- a/packages/rolldown/tests/cli/fixtures/config-multiply-output/.gitignore
+++ b/packages/rolldown/tests/cli/fixtures/config-multiply-output/.gitignore
@@ -1,0 +1,1 @@
+watch-dist-output

--- a/packages/rolldown/tests/cli/fixtures/config-multiply-output/index.js
+++ b/packages/rolldown/tests/cli/fixtures/config-multiply-output/index.js
@@ -1,0 +1,1 @@
+export default 'hello, world!'

--- a/packages/rolldown/tests/cli/fixtures/config-multiply-output/rolldown.config.ts
+++ b/packages/rolldown/tests/cli/fixtures/config-multiply-output/rolldown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'rolldown'
+
+export default defineConfig({
+  input: 'index.js',
+  output: [
+    {
+      format: 'esm',
+      entryFileNames: 'esm.js',
+    },
+    {
+      format: 'cjs',
+      entryFileNames: 'cjs.js',
+    },
+  ],
+})

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -81,12 +81,17 @@ function main() {
 }
 
 async function compileFixture(fixturePath: string, config: TestConfig) {
-  let outputOptions: OutputOptions = config.config?.output ?? {}
+  if (Array.isArray(config.config?.output)) {
+    throw new Error(
+      'The multiply output configure is not support at test runner',
+    )
+  }
+  let outputOptions = config.config?.output ?? {}
   const inputOptions: InputOptions = {
     input: 'main.js',
     cwd: fixturePath,
     ...config.config,
   }
   const build = await rolldown(inputOptions)
-  return await build.write(outputOptions)
+  return await build.write(outputOptions as OutputOptions)
 }

--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -85,3 +85,14 @@ export function getLocation(source: string, search: string | number) {
 
   throw new Error('Could not determine location of character')
 }
+
+export async function waitUtil(expectFn: () => void) {
+  for (let tries = 0; tries < 20; tries++) {
+    try {
+      await expectFn()
+      return
+    } catch {}
+    await sleep(50)
+  }
+  expectFn()
+}

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -2,7 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { watch, RolldownWatcher } from 'rolldown'
 import fs from 'node:fs'
 import path from 'node:path'
-import { sleep } from '@tests/utils'
+import { sleep, waitUtil } from '@tests/utils'
 
 test.sequential('watch', async () => {
   const { input, output } = await createTestInputAndOutput('watch')
@@ -469,17 +469,6 @@ async function createTestInputAndOutput(dirname: string, content?: string) {
   const outputDir = path.join(dir, './dist')
   const output = path.join(outputDir, 'main.js')
   return { input, output, dir, outputDir }
-}
-
-async function waitUtil(expectFn: () => void) {
-  for (let tries = 0; tries < 20; tries++) {
-    try {
-      await expectFn()
-      return
-    } catch {}
-    await sleep(50)
-  }
-  expectFn()
 }
 
 async function waitBuildFinished(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

close https://github.com/rolldown/rolldown/issues/3200. 

The previous implement is incorrect for array option. Here is summary for `watch-cli` and `build-cli` at now.

# `build-cli` 
-  normalized option to flat it
-  run each build at sequential
-  print log
# `watch-cli`
The `WatchOptions` also need to support array output if we support it at `RolldownOptions`, it is corresponding at rollup. 
- normalized option to flat it 
- create bundlers
- start notify watcher
- run each build(watching files) + print log
- waiting changes