### PR TITLE
refactor: use address instead of span for `top_level_this_expr_set`

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -1,4 +1,5 @@
 use oxc::{
+  allocator::Address,
   ast::{
     ast::{self, BindingPatternKind, Expression, IdentifierReference},
     visit::walk,
@@ -198,7 +199,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
   fn visit_this_expression(&mut self, it: &ast::ThisExpression) {
     if !self.is_this_nested() {
-      self.top_level_this_expr_set.insert(it.span);
+      self.top_level_this_expr_set.insert(Address::from_ptr(it));
     }
     walk::walk_this_expression(self, it);
   }

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -5,6 +5,7 @@ mod new_url;
 pub mod side_effect_detector;
 
 use arcstr::ArcStr;
+use oxc::allocator::Address;
 use oxc::ast::ast::MemberExpression;
 use oxc::ast::{ast, AstKind};
 use oxc::semantic::{Reference, ScopeFlags, ScopeId, SymbolTable};
@@ -72,7 +73,7 @@ pub struct ScanResult {
   pub dynamic_import_rec_exports_usage: FxHashMap<ImportRecordIdx, DynamicImportExportsUsage>,
   /// `new URL('...', import.meta.url)`
   pub new_url_references: FxHashMap<Span, ImportRecordIdx>,
-  pub this_expr_replace_map: FxHashMap<Span, ThisExprReplaceKind>,
+  pub this_expr_replace_map: FxHashMap<Address, ThisExprReplaceKind>,
 }
 
 pub struct AstScanner<'me, 'ast> {
@@ -104,7 +105,7 @@ pub struct AstScanner<'me, 'ast> {
   dynamic_import_usage_info: DynamicImportUsageInfo,
   ignore_comment: &'static str,
   /// "top level" `this` AstNode range in source code
-  top_level_this_expr_set: FxHashSet<Span>,
+  top_level_this_expr_set: FxHashSet<Address>,
   /// A flag to resolve `this` appear with propertyKey in class
   is_nested_this_inside_class: bool,
 }

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -1,5 +1,5 @@
 use oxc::{
-  allocator::{self, IntoIn},
+  allocator::{self, GetAddress, IntoIn},
   ast::{
     ast::{self, BindingPatternKind, Expression, SimpleAssignmentTarget},
     match_member_expression,
@@ -265,7 +265,9 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         }
       }
       ast::Expression::ThisExpression(this_expr) => {
-        if let Some(kind) = self.ctx.module.ecma_view.this_expr_replace_map.get(&this_expr.span) {
+        if let Some(kind) =
+          self.ctx.module.ecma_view.this_expr_replace_map.get(&this_expr.address())
+        {
           match kind {
             ThisExprReplaceKind::Exports => {
               *expr = self.snippet.builder.expression_identifier_reference(SPAN, "exports");

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -1,6 +1,6 @@
 use arcstr::ArcStr;
 use bitflags::bitflags;
-use oxc::{semantic::SymbolId, span::Span};
+use oxc::{allocator::Address, semantic::SymbolId, span::Span};
 use oxc_index::IndexVec;
 use rolldown_rstr::Rstr;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
@@ -31,9 +31,9 @@ pub enum ThisExprReplaceKind {
 #[inline]
 #[allow(clippy::implicit_hasher)]
 pub fn generate_replace_this_expr_map(
-  set: &FxHashSet<Span>,
+  set: &FxHashSet<Address>,
   kind: ThisExprReplaceKind,
-) -> FxHashMap<Span, ThisExprReplaceKind> {
+) -> FxHashMap<Address, ThisExprReplaceKind> {
   set.iter().map(|span| (*span, kind)).collect()
 }
 
@@ -125,7 +125,7 @@ pub struct EcmaView {
   pub mutations: Vec<BoxedSourceMutation>,
   /// `Span` of `new URL('path', import.meta.url)` -> `ImportRecordIdx`
   pub new_url_references: FxHashMap<Span, ImportRecordIdx>,
-  pub this_expr_replace_map: FxHashMap<Span, ThisExprReplaceKind>,
+  pub this_expr_replace_map: FxHashMap<Address, ThisExprReplaceKind>,
 }
 
 bitflags! {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. As we discussed before, `Address` can be used unique identify the AstNode, so that we don't need https://github.com/rolldown/rolldown/blob/76aeae5ee613f2c501f96768f4562b314e6e6205/crates/rolldown/src/utils/ecma_visitors/mod.rs?plain=1#L14-L47 finally.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
