### PR TITLE
refactor: remove unnecessary circular dependency check

### DIFF
--- a/crates/rolldown/src/stages/link_stage/sort_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/sort_modules.rs
@@ -107,8 +107,7 @@ impl LinkStage<'_> {
       }
     }
 
-    if self.options.checks.circular_dependency.unwrap_or(true) && !circular_dependencies.is_empty()
-    {
+    if !circular_dependencies.is_empty() {
       let cycles = circular_dependencies.into_iter().collect::<Vec<_>>();
       for cycle in cycles {
         let paths = cycle


### PR DESCRIPTION
### Description

The `unwrap_or(false)` and `unwrap_or(true)` are contradictory, and the actual logic depends on `!circular_dependencies.is_empty()`. Therefore, we can eliminate the unnecessary condition.

BTW, should we initialize the options in checks during the normalization of options?

https://github.com/rolldown/rolldown/blob/41516747902be37884a116f1aa3e9d0f4ae4f198/crates/rolldown/src/stages/link_stage/sort_modules.rs#L53

https://github.com/rolldown/rolldown/blob/41516747902be37884a116f1aa3e9d0f4ae4f198/crates/rolldown/src/stages/link_stage/sort_modules.rs#L110