### PR TITLE
fix(cli): with `--file` or `-o`, shouldn't print bundle output to stdout

### DIFF
--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -32,7 +32,7 @@ export async function bundleWithConfig(
 export async function bundleWithCliOptions(
   cliOptions: NormalizedCliOptions,
 ): Promise<void> {
-  if (cliOptions.output.dir) {
+  if (cliOptions.output.dir || cliOptions.output.file) {
     const operation = cliOptions.watch ? watchInner : bundleInner
     await operation({}, cliOptions)
     return


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
