### PR TITLE
feat(cli): resolve `rolldown.config` by default when `-c` is unspecified

### DIFF
--- a/packages/rolldown/src/cli/arguments/normalize.ts
+++ b/packages/rolldown/src/cli/arguments/normalize.ts
@@ -42,7 +42,7 @@ export function normalizeCliOptions(
     watch: options.watch ?? false,
   } as NormalizedCliOptions
   if (typeof options.config === 'string') {
-    result.config = options.config ? options.config : 'rolldown.config.js'
+    result.config = options.config
   }
   const reservedKeys = ['help', 'version', 'config', 'watch']
   const keysOfInput = (inputCliOptionsSchema as Z.AnyZodObject).keyof()._def

--- a/packages/rolldown/src/cli/index.ts
+++ b/packages/rolldown/src/cli/index.ts
@@ -8,7 +8,7 @@ import { version } from '../../package.json'
 async function main() {
   const cliOptions = parseCliArguments()
 
-  if (cliOptions.config) {
+  if (cliOptions.config || cliOptions.config === '') {
     await bundleWithConfig(cliOptions.config, cliOptions)
     return
   }

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -208,3 +208,9 @@ exports[`config > no package.json > should bundle in ext-js-syntax-cjs 1`] = `
 
 "
 `;
+
+exports[`config > no package.json > should resolve rolldown.config.cjs 1`] = `
+"<DIR>/index.js  chunk │ size: 0.13 kB
+
+"
+`;

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -181,7 +181,7 @@ describe('config', () => {
     })
 
     it('should failed to resolve rolldown.config files', async () => {
-      const cwd = cliFixturesDir('ext-js-syntax-esm')
+      const cwd = cliFixturesDir('cli-without-config')
       try {
         const _ = await $({ cwd })`rolldown -c`
       } catch (err) {

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -172,6 +172,22 @@ describe('config', () => {
       expect(status.exitCode).toBe(0)
       expect(cleanStdout(status.stdout)).toMatchSnapshot()
     })
+
+    it('should resolve rolldown.config.cjs', async () => {
+      const cwd = cliFixturesDir('cli-with-config')
+      const status = await $({ cwd })`rolldown -c`
+      expect(status.exitCode).toBe(0)
+      expect(cleanStdout(status.stdout)).toMatchSnapshot()
+    })
+
+    it('should failed to resolve rolldown.config files', async () => {
+      const cwd = cliFixturesDir('ext-js-syntax-esm')
+      try {
+        const _ = await $({ cwd })`rolldown -c`
+      } catch (err) {
+        expect(err).not.toBeUndefined()
+      }
+    })
   })
 })
 

--- a/packages/rolldown/tests/cli/fixtures/cli-with-config/index.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-with-config/index.js
@@ -1,0 +1,1 @@
+export default 'hello, world!'

--- a/packages/rolldown/tests/cli/fixtures/cli-with-config/rolldown.config.cjs
+++ b/packages/rolldown/tests/cli/fixtures/cli-with-config/rolldown.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  input: 'index.js',
+}

--- a/packages/rolldown/tests/cli/fixtures/cli-without-config/index.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-without-config/index.js
@@ -1,0 +1,1 @@
+export default 'hello, world!'


### PR DESCRIPTION
### Description

Related to #3248