### PR TITLE
TEST feat: eliminate_unnecessary_default

### DIFF
--- a/crates/rolldown/src/ast_scanner/esmodule_flag_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/esmodule_flag_analyzer.rs
@@ -1,0 +1,159 @@
+use oxc::ast::{
+  ast::{self, Expression, IdentifierReference, PropertyKey},
+  AstKind,
+};
+use rolldown_ecmascript_utils::ExpressionExt;
+
+use super::AstScanner;
+
+impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
+  pub fn check_es_module_flag(
+    &self,
+    ident: &IdentifierReference<'ast>,
+    ty: EsModuleFlagCheckType,
+  ) -> Option<bool> {
+    let cursor = self.visit_path.len() - 1;
+    let parent = self.visit_path.get(cursor)?;
+    match parent {
+      AstKind::MemberExpression(member_expr) => match ty {
+        // two scenarios:
+        // 1. module.exports.__esModule = true;
+        // 2. Object.defineProperty(module.exports, "__esModule", { value: true });
+        EsModuleFlagCheckType::ModuleExportsAssignment => {
+          let property_name = member_expr.static_property_name()?;
+          if property_name != "exports" {
+            return Some(false);
+          }
+          let parent_parent_kind = self.visit_path.get(cursor - 1)?;
+          match parent_parent_kind {
+            AstKind::MemberExpression(parent_parent) => {
+              let property_name = parent_parent.static_property_name()?;
+              if property_name != "__esModule" {
+                return Some(false);
+              }
+              let parent_parent_parent_kind = self.visit_path.get(cursor - 2)?;
+              let parent_parent_parent = parent_parent_parent_kind.as_assignment_expression()?;
+              let ast::Expression::BooleanLiteral(bool_lit) = &parent_parent_parent.right else {
+                return Some(false);
+              };
+              Some(bool_lit.value)
+            }
+            AstKind::CallExpression(parent_parent) => {
+              let callee = parent_parent.callee.as_member_expression()?;
+              let key_eq_object =
+                callee.object().as_identifier().is_some_and(|item| item.name == "Object");
+              let property_eq_define_property = callee.static_property_name()? == "defineProperty";
+              if !(key_eq_object && property_eq_define_property) {
+                return Some(false);
+              }
+              let first = parent_parent.arguments.get(0)?;
+              let is_same_ident_ref = first
+                .as_expression()
+                .and_then(|item| item.as_identifier())
+                .is_some_and(|item| item.reference_id() == ident.reference_id());
+              if !is_same_ident_ref {
+                return Some(false);
+              }
+              let second = parent_parent.arguments.get(1)?;
+              let is_es_module = second
+                .as_expression()
+                .and_then(|item| item.as_string_literal())
+                .is_some_and(|item| item.value == "__esModule");
+              if !is_es_module {
+                return Some(false);
+              }
+              let third = parent_parent.arguments.get(2)?;
+              let flag = third
+                .as_expression()
+                .and_then(|item| match item {
+                  Expression::ObjectExpression(expr) => Some(expr),
+                  _ => None,
+                })
+                .is_some_and(|obj_expr| match obj_expr.properties.as_slice() {
+                  [ast::ObjectPropertyKind::ObjectProperty(kind)] => match (&kind.key, &kind.value)
+                  {
+                    (PropertyKey::StaticIdentifier(id), Expression::BooleanLiteral(bool_lit)) => {
+                      id.name == "value" && bool_lit.value
+                    }
+                    _ => false,
+                  },
+                  _ => false,
+                });
+              if !flag {
+                return Some(false);
+              }
+              Some(true)
+            }
+            _ => None,
+          }
+        }
+        // one scenario:
+        // 1. exports.__esModule = true;
+        EsModuleFlagCheckType::ExportsAssignment => {
+          let property_name = member_expr.static_property_name()?;
+          if property_name != "__esModule" {
+            return Some(false);
+          }
+          let parent_parent_kind = self.visit_path.get(cursor - 1)?;
+          let parent_parent = parent_parent_kind.as_assignment_expression()?;
+
+          let ast::Expression::BooleanLiteral(bool_lit) = &parent_parent.right else {
+            return Some(false);
+          };
+          Some(bool_lit.value)
+        }
+      },
+      AstKind::CallExpression(call_expr) => {
+        // one scenario:
+        // 1. Object.defineProperty(exports, "__esModule", { value: true });
+        let first = call_expr.arguments.get(0)?;
+        let is_same_ident_ref = first
+          .as_expression()
+          .and_then(|item| item.as_identifier())
+          .is_some_and(|item| item.reference_id() == ident.reference_id());
+        if !is_same_ident_ref {
+          return Some(false);
+        }
+        let second = call_expr.arguments.get(1)?;
+        let is_es_module = second
+          .as_expression()
+          .and_then(|item| item.as_string_literal())
+          .is_some_and(|item| item.value == "__esModule");
+        if !is_es_module {
+          return Some(false);
+        }
+
+        let third = call_expr.arguments.get(2)?;
+        let flag = third
+          .as_expression()
+          .and_then(|item| match item {
+            Expression::ObjectExpression(expr) => Some(expr),
+            _ => None,
+          })
+          .is_some_and(|obj_expr| match obj_expr.properties.as_slice() {
+            [ast::ObjectPropertyKind::ObjectProperty(kind)] => match (&kind.key, &kind.value) {
+              (PropertyKey::StaticIdentifier(id), Expression::BooleanLiteral(bool_lit)) => {
+                id.name == "value" && bool_lit.value
+              }
+              _ => false,
+            },
+            _ => false,
+          });
+        if !flag {
+          return Some(false);
+        }
+        let callee = call_expr.callee.as_member_expression()?;
+        let key_eq_object =
+          callee.object().as_identifier().is_some_and(|item| item.name == "Object");
+        let property_eq_define_property = callee.static_property_name()? == "defineProperty";
+        Some(key_eq_object && property_eq_define_property)
+      }
+      _ => None,
+    }
+  }
+}
+
+pub enum EsModuleFlagCheckType {
+  ModuleExportsAssignment,
+  ExportsAssignment,
+}

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -14,6 +14,12 @@ use rolldown_ecmascript_utils::{ExpressionExt, TakeIn};
 use super::ScopeHoistingFinalizer;
 
 impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
+  fn enter_node(&mut self, kind: oxc::ast::AstType) {
+    self.ancestor_type.push(kind);
+  }
+  fn leave_node(&mut self, _: oxc::ast::AstType) {
+    self.ancestor_type.pop();
+  }
   #[allow(clippy::too_many_lines)]
   fn visit_program(&mut self, program: &mut ast::Program<'ast>) {
     // Drop the hashbang since we already store them in ast_scan phase and

--- a/crates/rolldown/src/utils/mod.rs
+++ b/crates/rolldown/src/utils/mod.rs
@@ -38,6 +38,7 @@ pub fn finalize_normal_module(
       scope: &module.scope,
       snippet: AstSnippet::new(alloc),
       comments: oxc_program.comments.take_in(alloc),
+      ancestor_type: vec![],
     };
     finalizer.visit_program(oxc_program);
     oxc_program.comments = finalizer.comments.take_in(alloc);

--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
@@ -24,8 +24,8 @@ let bar = 123;
 //#endregion
 //#region entry.js
 console.log(exports, module.exports);
-node_assert.default.deepEqual(test_exports$1, { foo: 123 });
-node_assert.default.deepEqual(test_exports, { bar: 123 });
+node_assert.deepEqual(test_exports$1, { foo: 123 });
+node_assert.deepEqual(test_exports, { bar: 123 });
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_issue1837/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_issue1837/artifacts.snap
@@ -28,7 +28,7 @@ var require_cjs = __commonJS({ "cjs.js"(exports) {
 
 //#endregion
 //#region entry.js
-node_assert.default.deepEqual(require_cjs(), { foo: process });
+node_assert.deepEqual(require_cjs(), { foo: process });
 
 //#endregion
 })(node_assert);

--- a/crates/rolldown/tests/esbuild/importstar/import_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_self_common_js/artifacts.snap
@@ -14,7 +14,7 @@ const node_assert = __toESM(require("node:assert"));
 var require_entry = __commonJS({ "entry.js"(exports) {
 	var import_entry = __toESM(require_entry());
 	exports.foo = 123;
-	node_assert.default.equal(import_entry.foo, undefined);
+	node_assert.equal(import_entry.foo, undefined);
 } });
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/artifacts.snap
@@ -19,9 +19,9 @@ var require_foo = __commonJS({ "foo.js"(exports) {
 //#region entry.js
 var import_foo = __toESM(require_foo());
 let foo = 234;
-node_assert.default.equal(import_foo.foo, 123);
-node_assert.default.equal(import_foo.foo, 123);
-node_assert.default.equal(foo, 234);
+node_assert.equal(import_foo.foo, 123);
+node_assert.equal(import_foo.foo, 123);
+node_assert.equal(foo, 234);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/cjs_esmodule_flag1.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/cjs_esmodule_flag1.js
@@ -1,0 +1,2 @@
+exports.foo = 1000;
+exports.__esModule = true;

--- a/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/cjs_esmodule_flag2.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/cjs_esmodule_flag2.js
@@ -1,0 +1,2 @@
+exports.foo = 1000;
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/cjs_esmodule_flag3.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/cjs_esmodule_flag3.js
@@ -1,0 +1,2 @@
+exports.foo = 1000;
+exports.__esModule = true;

--- a/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/cjs_esmodule_flag4.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/cjs_esmodule_flag4.js
@@ -1,0 +1,2 @@
+exports.foo = 1000;
+Object.defineProperty(module.exports, "__esModule", { value: true });

--- a/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/commonjs_without_module_exports.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/commonjs_without_module_exports.js
@@ -1,0 +1,2 @@
+exports.default = 1000;
+exports.foo = 1000;

--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_module_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_module_cjs/artifacts.snap
@@ -13,7 +13,7 @@ const node_assert = require_share$1.__toESM(require("node:assert"));
 
 //#region main1.js
 var import_share = require_share$1.__toESM(require_share$1.require_share());
-node_assert.default.equal((0, import_share.share)(), 1);
+node_assert.equal((0, import_share.share)(), 1);
 
 //#endregion
 ```
@@ -26,7 +26,7 @@ const node_assert = require_share$1.__toESM(require("node:assert"));
 
 //#region main2.js
 var import_share = require_share$1.__toESM(require_share$1.require_share());
-node_assert.default.equal((0, import_share.share)(), 1);
+node_assert.equal((0, import_share.share)(), 1);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/issues/2859/1/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2859/1/artifacts.snap
@@ -68,7 +68,7 @@ const assert = __toESM(require("assert"));
 //#region main.js
 Promise.resolve().then(function() {
 	return require("./lib.js");
-}).then((exports$1) => assert.default.deepStrictEqual({ ...exports$1 }, {
+}).then((exports$1) => assert.deepStrictEqual({ ...exports$1 }, {
 	foo: "foo",
 	bar: "bar",
 	default: "default"

--- a/crates/rolldown/tests/rolldown/issues/2859/2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2859/2/artifacts.snap
@@ -52,7 +52,7 @@ bar = "bar";
 var main_default = "default";
 Promise.resolve().then(function() {
 	return require("./main.js");
-}).then((exports$1) => assert.default.deepStrictEqual({ ...exports$1 }, {
+}).then((exports$1) => assert.deepStrictEqual({ ...exports$1 }, {
 	foo: "foo",
 	bar: "bar",
 	default: "default"

--- a/crates/rolldown/tests/rolldown/issues/2903/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2903/artifacts.snap
@@ -25,7 +25,7 @@ const require_chunk = require('./chunk.js');
 const node_path = require_chunk.__toESM(require("node:path"));
 
 //#region main.js
-var main_default = node_path.default.join;
+var main_default = node_path.join;
 
 //#endregion
 module.exports = main_default;
@@ -38,7 +38,7 @@ const require_chunk = require('./chunk.js');
 const node_fs = require_chunk.__toESM(require("node:fs"));
 
 //#region main2.js
-var main2_default = node_fs.default.existsSync;
+var main2_default = node_fs.existsSync;
 
 //#endregion
 module.exports = main2_default;

--- a/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/artifacts.snap
@@ -19,7 +19,7 @@ var require_cjs = __commonJS({ "cjs.js"(exports, module) {
 //#endregion
 //#region main.js
 var import_cjs = __toESM(require_cjs());
-node_assert.default.deepEqual(import_cjs.default, { default: {} });
+node_assert.deepEqual(import_cjs.default, { default: {} });
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs/artifacts.snap
@@ -12,9 +12,9 @@ snapshot_kind: text
 const node_assert = __toESM(require("node:assert"));
 
 //#region main.js
-node_assert.default.equal(require("url").pathToFileURL(__filename), require("url").pathToFileURL(__filename).href);
-node_assert.default.equal(__dirname, __dirname);
-node_assert.default.equal(__filename, __filename);
+node_assert.equal(require("url").pathToFileURL(__filename), require("url").pathToFileURL(__filename).href);
+node_assert.equal(__dirname, __dirname);
+node_assert.equal(__filename, __filename);
 
 //#endregion
 //# sourceMappingURL=main.js.map
@@ -24,21 +24,21 @@ node_assert.default.equal(__filename, __filename);
 
 ```
 - ../main.js
-(2:0) "assert." --> (27:0) "node_assert.default."
-(2:7) "equal(" --> (27:20) "equal("
-(2:13) "require(" --> (27:26) "require("
-(2:21) "\"url\")" --> (27:34) "\"url\")"
-(2:27) "." --> (27:40) "."
-(2:28) "pathToFileURL(" --> (27:41) "pathToFileURL("
-(2:42) "__filename)" --> (27:55) "__filename)"
-(2:53) ", import.meta.url)" --> (27:66) ", require(\"url\").pathToFileURL(__filename).href)"
-(2:71) "\n" --> (27:114) ";\n"
-(3:0) "assert." --> (28:0) "node_assert.default."
-(3:7) "equal(" --> (28:20) "equal("
-(3:13) "__dirname, import.meta.dirname)" --> (28:26) "__dirname, __dirname)"
-(3:44) "\n" --> (28:47) ";\n"
-(4:0) "assert." --> (29:0) "node_assert.default."
-(4:7) "equal(" --> (29:20) "equal("
-(4:13) "__filename, import.meta.filename)" --> (29:26) "__filename, __filename)"
-(4:46) "\n" --> (29:49) ";\n"
+(2:0) "assert." --> (27:0) "node_assert."
+(2:7) "equal(" --> (27:12) "equal("
+(2:13) "require(" --> (27:18) "require("
+(2:21) "\"url\")" --> (27:26) "\"url\")"
+(2:27) "." --> (27:32) "."
+(2:28) "pathToFileURL(" --> (27:33) "pathToFileURL("
+(2:42) "__filename)" --> (27:47) "__filename)"
+(2:53) ", import.meta.url)" --> (27:58) ", require(\"url\").pathToFileURL(__filename).href)"
+(2:71) "\n" --> (27:106) ";\n"
+(3:0) "assert." --> (28:0) "node_assert."
+(3:7) "equal(" --> (28:12) "equal("
+(3:13) "__dirname, import.meta.dirname)" --> (28:18) "__dirname, __dirname)"
+(3:44) "\n" --> (28:39) ";\n"
+(4:0) "assert." --> (29:0) "node_assert."
+(4:7) "equal(" --> (29:12) "equal("
+(4:13) "__filename, import.meta.filename)" --> (29:18) "__filename, __filename)"
+(4:46) "\n" --> (29:41) ";\n"
 ```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_binding_in_common_chunks_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_binding_in_common_chunks_cjs/artifacts.snap
@@ -23,11 +23,11 @@ function inc() {
 //#endregion
 //#region async-entry.js
 reset();
-node_assert.default.strictEqual(count, 0);
-node_assert.default.strictEqual(count, count);
+node_assert.strictEqual(count, 0);
+node_assert.strictEqual(count, count);
 inc();
-node_assert.default.strictEqual(count, 1);
-node_assert.default.strictEqual(count, count);
+node_assert.strictEqual(count, 1);
+node_assert.strictEqual(count, count);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_expr_in_common_chunks_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_expr_in_common_chunks_cjs/artifacts.snap
@@ -24,11 +24,11 @@ var shared_default = count;
 //#endregion
 //#region async-entry.js
 reset();
-node_assert.default.strictEqual(shared_default, 0);
-node_assert.default.strictEqual(shared_default, shared_default);
+node_assert.strictEqual(shared_default, 0);
+node_assert.strictEqual(shared_default, shared_default);
 inc();
-node_assert.default.strictEqual(shared_default, 0);
-node_assert.default.strictEqual(shared_default, shared_default);
+node_assert.strictEqual(shared_default, 0);
+node_assert.strictEqual(shared_default, shared_default);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
@@ -14,14 +14,14 @@ const node_assert = __toESM(require("node:assert"));
 
 //#region async-entry.js
 require_shared.reset();
-node_assert.default.strictEqual(require_shared.count, 0);
-node_assert.default.strictEqual(require_shared.count, require_shared.count);
+node_assert.strictEqual(require_shared.count, 0);
+node_assert.strictEqual(require_shared.count, require_shared.count);
 require_shared.inc();
-node_assert.default.strictEqual(require_shared.count, 1);
-node_assert.default.strictEqual(require_shared.count, require_shared.count);
+node_assert.strictEqual(require_shared.count, 1);
+node_assert.strictEqual(require_shared.count, require_shared.count);
 require_shared.inc();
-node_assert.default.strictEqual(require_shared.count, 2);
-node_assert.default.strictEqual(require_shared.count, require_shared.count);
+node_assert.strictEqual(require_shared.count, 2);
+node_assert.strictEqual(require_shared.count, require_shared.count);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/npm_packages/util_deprecate/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/npm_packages/util_deprecate/artifacts.snap
@@ -22,7 +22,7 @@ var require_node = __commonJS({ "../../../../../../../node_modules/.pnpm/util-de
 //#endregion
 //#region main.js
 const exports$1 = require_node();
-node_assert.default.strictEqual(node_util.deprecate, exports$1);
+node_assert.strictEqual(node_util.deprecate, exports$1);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -839,7 +839,7 @@ snapshot_kind: text
 
 # tests/esbuild/default/exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-B0-3jBbo.js
+- entry-!~{000}~.js => entry-Bc2cAwIR.js
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
@@ -1767,7 +1767,7 @@ snapshot_kind: text
 
 # tests/esbuild/default/use_strict_directive_bundle_issue1837
 
-- entry-!~{000}~.js => entry-Dun7SgTF.js
+- entry-!~{000}~.js => entry-DAzIstOn.js
 
 # tests/esbuild/default/use_strict_directive_minify_no_bundle
 
@@ -1944,7 +1944,7 @@ snapshot_kind: text
 
 # tests/esbuild/importstar/import_self_common_js
 
-- entry-!~{000}~.js => entry-Cua-elBI.js
+- entry-!~{000}~.js => entry-CPiMeMTq.js
 
 # tests/esbuild/importstar/import_star_and_common_js
 
@@ -1960,7 +1960,7 @@ snapshot_kind: text
 
 # tests/esbuild/importstar/import_star_common_js_no_capture
 
-- entry-!~{000}~.js => entry-qmN_Oxc_.js
+- entry-!~{000}~.js => entry-CKyHJ9Oo.js
 
 # tests/esbuild/importstar/import_star_common_js_unused
 
@@ -3802,8 +3802,8 @@ snapshot_kind: text
 
 # tests/rolldown/code_splitting/format_cjs_with_module_cjs
 
-- main1-!~{000}~.js => main1-DfLRKT4o.js
-- main2-!~{001}~.js => main2-C7PwSLJW.js
+- main1-!~{000}~.js => main1-DnquK2hi.js
+- main2-!~{001}~.js => main2-CUDYSyaq.js
 - share-!~{002}~.js => share-nzv4KVp1.js
 
 # tests/rolldown/code_splitting/import_export_unicode
@@ -4502,8 +4502,8 @@ snapshot_kind: text
 
 # tests/rolldown/issues/2903
 
-- main-!~{000}~.js => main-Be69oBDG.js
-- main2-!~{001}~.js => main2-EKxH9I8y.js
+- main-!~{000}~.js => main-CsPFHj9_.js
+- main2-!~{001}~.js => main2-_2rLatJU.js
 - chunk-!~{002}~.js => chunk-CrpGerW8.js
 
 # tests/rolldown/issues/2903_2
@@ -4635,7 +4635,7 @@ snapshot_kind: text
 
 # tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format
 
-- main-!~{000}~.js => main-Cio9eETQ.js
+- main-!~{000}~.js => main-RgUYxKfl.js
 
 # tests/rolldown/misc/wrapped_esm
 
@@ -4766,11 +4766,11 @@ snapshot_kind: text
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/26
 
-- entry-!~{000}~.js => entry-BZrpy6wF.js
+- entry-!~{000}~.js => entry-BEtNUzIC.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/27
 
-- entry-!~{000}~.js => entry-CcqbmhYR.js
+- entry-!~{000}~.js => entry-CZQ4IxoN.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/28
 
@@ -4876,27 +4876,27 @@ snapshot_kind: text
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/50
 
-- entry-!~{000}~.js => entry-CCDxkJSk.js
+- entry-!~{000}~.js => entry-Bkp1aobe.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/51
 
-- entry-!~{000}~.js => entry-DzTWYJoG.js
+- entry-!~{000}~.js => entry-GOuqJgh8.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/52
 
-- entry-!~{000}~.js => entry-Dqixz_6_.js
+- entry-!~{000}~.js => entry-DLOVReU2.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/53
 
-- entry-!~{000}~.js => entry-amgtY4TE.js
+- entry-!~{000}~.js => entry-D7TQ0PgC.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/54
 
-- entry-!~{000}~.js => entry-D-1zEUZR.js
+- entry-!~{000}~.js => entry-Bg8s-LQs.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/55
 
-- entry-!~{000}~.js => entry-BzuKCjaP.js
+- entry-!~{000}~.js => entry-BxFX-I2O.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/56
 
@@ -5029,8 +5029,8 @@ snapshot_kind: text
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 
-- main-!~{000}~.js => main-BsHwzpVr.js
-- main-BsHwzpVr.js.map
+- main-!~{000}~.js => main-BCI16y_X.js
+- main-BCI16y_X.js.map
 
 # tests/rolldown/topics/keep_names/declaration
 
@@ -5055,8 +5055,8 @@ snapshot_kind: text
 
 # tests/rolldown/topics/live_bindings/default_export_binding_in_common_chunks_cjs
 
-- main-!~{000}~.js => main-Bgp745YR.js
-- async-entry-!~{001}~.js => async-entry-C3udqLaX.js
+- main-!~{000}~.js => main-D8e76SWZ.js
+- async-entry-!~{001}~.js => async-entry-3H1biw0s.js
 
 # tests/rolldown/topics/live_bindings/default_export_expr
 
@@ -5073,8 +5073,8 @@ snapshot_kind: text
 
 # tests/rolldown/topics/live_bindings/default_export_expr_in_common_chunks_cjs
 
-- main-!~{000}~.js => main-ykrUhC6W.js
-- async-entry-!~{001}~.js => async-entry-BSDgWi21.js
+- main-!~{000}~.js => main-BsKYy0bt.js
+- async-entry-!~{001}~.js => async-entry-B1rCbKO5.js
 
 # tests/rolldown/topics/live_bindings/named_exports
 
@@ -5093,7 +5093,7 @@ snapshot_kind: text
 # tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs
 
 - main-!~{000}~.js => main-BjIYVEi3.js
-- async-entry-!~{003}~.js => async-entry-BnjgiQak.js
+- async-entry-!~{003}~.js => async-entry-O39oeSvo.js
 - shared-!~{001}~.js => shared-DTDWOKER.js
 
 # tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs
@@ -5130,7 +5130,7 @@ snapshot_kind: text
 
 # tests/rolldown/topics/npm_packages/util_deprecate
 
-- main-!~{000}~.js => main-CGUvyXC5.js
+- main-!~{000}~.js => main-Dk7WdBZU.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export
 

--- a/examples/basic-vue/cjs.js
+++ b/examples/basic-vue/cjs.js
@@ -1,0 +1,7 @@
+// cjsModuleWithEsModule.js
+Object.defineProperty(exports, '__esModule', { value: true })
+exports.default = function () {
+  console.log('Hello from default export')
+}
+exports.name = 'Jack'
+exports.age = 16


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description


To ensure that the behavior remains consistent with the previous interop behavior after removing the `default` property access, we need to identify all cases where `import_default_alias.default == import_default_alias`. This can be inferred from the runtime.

```js
var __toESM = (mod, isNodeMode, target) => {
    return (
        (target = mod != null ? __create(__getProtoOf(mod)) : {}),
        __copyProps(
            isNodeMode || !mod || !mod.__esModule
                ? __defProp(target, "default", {
                        value: mod,
                        enumerable: true,
                    })
                : target,
            mod,
        )
    );
};
```

It is not difficult to see that the conditions are:
1. `isNodeMode` is `true || 1`
2. The module itself is an empty module
3. `mod.__esModule` is false

Condition one can be obtained from [this link](https://github.com/rolldown/rolldown/blob/eb47e2a4b5e07de61e6eb8101f4f07ecbf7c9c30/crates/rolldown_common/src/module/normal_module.rs?plain=1#L191-L201).
Condition two can be inferred through analysis; an empty module will default to being treated as `esm`, so the only case is `module.exports = undefined`.
Condition three can also be inferred through analysis, almost done in https://github.com/rolldown/rolldown/pull/3257.

However, it is important to note that when accessing the property `default` after `import_default_alias`, an unsafe situation may arise. For example:
```js
// index.js
import foo from './foo.js';
console.log(foo.default.bar === 123);
// foo.js
module.exports = { default: { bar: 123 } };
```

Here, condition 1 is not satisfied, condition 2 is not satisfied, but condition 3 is satisfied. Therefore, after `__toEsm`, the `mod` object will be transformed into:
```js
{
  default: { default: { bar: 123 } }
}
```
In this case, `foo.default.bar` is no longer equal to `foo.default.default.bar`. Specifically,
`foo.default.bar === undefined`, 
`foo.default.default.bar === 123`.

Currently, there are two solutions:
- One approach is to allow the `VisitMut` trait to access the parent node so that when rewriting `import_default_alias`, it knows whether the `default` property is accessed.
    - **Advantages**: This method is relatively intuitive and has low overhead.
    - **Disadvantages**: Currently, the `Traverse` trait requires mutating semantic data. We cannot mutate semantic data in the `module_finalizer` phase (which violates borrow rules). We need to implement something similar to a `TraverseSimple` trait in oxc that does not change the semantic data version but allows access to parent nodes during AST mutation.
- The other approach involves recording each time a `MemberExpression` is accessed, checking the span during the rewrite of `IdentifierReference` to see if it meets the conditions. 
    - **Disadvantages**: This method has higher overhead (compared to the first solution) and requires additional data structures for recording.

--- 


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
