### PR TITLE
test: resolve processes not exiting in test cases

### DIFF
--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -204,10 +204,10 @@ describe('watch cli', () => {
     const controller = new AbortController()
     execa({
       cwd,
+      reject: false,
       cancelSignal: controller.signal,
-      gracefulCancel: true,
     })`rolldown index.ts -d dist -w -s`
-    waitUtil(() => {
+    await waitUtil(() => {
       expect(fs.existsSync(path.join(cwd, 'dist'))).toBe(true)
       expect(fs.existsSync(path.join(cwd, 'dist/index.js.map'))).toBe(true)
     })
@@ -219,10 +219,10 @@ describe('watch cli', () => {
     const controller = new AbortController()
     execa({
       cwd,
+      reject: false,
       cancelSignal: controller.signal,
-      gracefulCancel: true,
     })`rolldown -c rolldown.config.ts -d watch-dist-options -w`
-    waitUtil(() => {
+    await waitUtil(() => {
       expect(fs.existsSync(path.join(cwd, 'watch-dist-options/esm.js'))).toBe(
         true,
       )
@@ -238,10 +238,10 @@ describe('watch cli', () => {
     const controller = new AbortController()
     execa({
       cwd,
+      reject: false,
       cancelSignal: controller.signal,
-      gracefulCancel: true,
     })`rolldown -c rolldown.config.ts -d watch-dist-output -w`
-    waitUtil(() => {
+    await waitUtil(() => {
       expect(fs.existsSync(path.join(cwd, 'watch-dist-output/esm.js'))).toBe(
         true,
       )


### PR DESCRIPTION
### Description

When using `gracefulCancel: true`, the termination signal can only be obtained via `getCancelSignal`, but our watch implementation uses `onExit`, which causes the process to never terminate.

```bash
Error: Build failed with 1 error:
[plugin shim]
Error: EBUSY: resource busy or locked, copyfile 'D:\shulaoda\rolldown\packages\rolldown\src\rolldown-binding.win32-x64-msvc.node' -> 'D:\shulaoda\rolldown\packages\rolldown\dist\shared\rolldown-binding.win32-x64-msvc.node'
```

![image](https://github.com/user-attachments/assets/5dfe157c-6b09-46aa-bd6f-9dae8eafe783)
