### PR TITLE
chore(justfile): fix test-update

### DIFF
--- a/justfile
+++ b/justfile
@@ -81,12 +81,13 @@ test-node-only preset="all" *args="":
     just _test-node-{{ preset }} {{ args }}
 
 _test-node-all *args="":
-    pnpm run --recursive --parallel --filter=!rollup-tests test {{ args }}
+    just _test-node-rolldown {{ args }}
     # We run rollup tests separately to have a clean output.
     pnpm run --filter rollup-tests test
 
 _test-node-rolldown *args:
-    pnpm run --filter rolldown test {{ args }}
+    pnpm run --filter rolldown-tests test:main {{ args }}
+    pnpm run --filter rolldown-tests test:watcher {{ args }}
 
 _test-node-rollup command="":
     pnpm run --filter rollup-tests test{{ command }}

--- a/justfile
+++ b/justfile
@@ -68,7 +68,7 @@ test: test-rust test-node
 # run all tests and update snapshot
 test-update:
     just test-rust
-    just test-node all -u
+    just test-node all --update
 
 test-rust:
     cargo test --workspace --exclude rolldown_binding

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -70,8 +70,6 @@
     "build-wasi:debug": "run-s build-binding build-binding:wasi build-node",
     "build-wasi:release": "run-s build-binding build-binding:wasi:release build-node",
     "# Scrips for checking #": "_",
-    "test": "pnpm run --filter rolldown-tests go",
-    "test:update": "vitest run -u",
     "type-check": "tsc"
   },
   "napi": {

--- a/packages/rolldown/tests/package.json
+++ b/packages/rolldown/tests/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "go": "npm run test:main && npm run test:watcher",
     "test:main": "cross-env RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run --exclude '**/watch.test.ts' --reporter verbose --hideSkippedTests",
     "test:watcher": "cross-env RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run watch.test.ts --reporter verbose --hideSkippedTests",
     "type-check": "tsc --noEmit"

--- a/packages/rollup-tests/package.json
+++ b/packages/rollup-tests/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "test": "mocha --file ./src/intercept/check.js test/test.js",
-    "test-u": "mocha --jobs 1 --file ./src/intercept/update-test-status.js test/test.js",
+    "test--update": "mocha --jobs 1 --file ./src/intercept/update-test-status.js test/test.js",
     "type-check": "tsc --noEmit"
   },
   "keywords": [],

--- a/packages/rollup-tests/package.json
+++ b/packages/rollup-tests/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "test": "mocha --file ./src/intercept/check.js test/test.js",
-    "test--update": "mocha --jobs 1 --file ./src/intercept/update-test-status.js test/test.js",
+    "test-u": "mocha --jobs 1 --file ./src/intercept/update-test-status.js test/test.js",
     "type-check": "tsc --noEmit"
   },
   "keywords": [],


### PR DESCRIPTION
### Description

              Seems this PR breaks `just test-node rolldown --update` @underfin cc

_Originally posted by @hyf0 in https://github.com/rolldown/rolldown/issues/3178#issuecomment-2562646748_
            

I don't know why it needs to be split. 
Perhaps we can control whether to run the watch-specific test cases separately using the `-t` command.