### PR TITLE
perf: `into_binding_chunk_modules` when chunk is large 

### DIFF
--- a/crates/rolldown/src/utils/chunk/mod.rs
+++ b/crates/rolldown/src/utils/chunk/mod.rs
@@ -56,7 +56,7 @@ pub fn generate_rendered_chunk(
       .as_deref()
       .expect("should have preliminary_filename")
       .clone(),
-    modules: render_modules,
+    modules: render_modules.into(),
     imports: chunk
       .cross_chunk_imports
       .iter()

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -6,8 +6,8 @@ use rolldown_sourcemap::SourceMap;
 use rustc_hash::FxBuildHasher;
 
 use super::{
-  binding_rendered_chunk::into_binding_chunk_modules,
-  binding_rendered_module::BindingRenderedModule, binding_sourcemap::BindingSourcemap,
+  binding_rendered_chunk::BindingModules, binding_rendered_module::BindingRenderedModule,
+  binding_sourcemap::BindingSourcemap,
 };
 
 // Here using `napi` `getter` fields to avoid the cost of serialize larger data to js side.
@@ -55,8 +55,8 @@ impl BindingOutputChunk {
   }
 
   #[napi(getter)]
-  pub fn modules(&self) -> HashMap<String, BindingRenderedModule, FxBuildHasher> {
-    into_binding_chunk_modules(&self.inner.modules)
+  pub fn modules(&self) -> BindingModules {
+    (&self.inner.modules).into()
   }
 
   #[napi(getter)]

--- a/crates/rolldown_binding/src/types/binding_rendered_module.rs
+++ b/crates/rolldown_binding/src/types/binding_rendered_module.rs
@@ -4,6 +4,7 @@ use rolldown_common::RenderedModule;
 use std::fmt::Debug;
 
 #[napi]
+#[derive(Clone)]
 pub struct BindingRenderedModule {
   #[napi(skip)]
   pub inner: RenderedModule,

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -114,7 +114,7 @@ pub use crate::{
   types::named_import::{NamedImport, Specifier},
   types::namespace_alias::NamespaceAlias,
   types::output::{Output, OutputAsset},
-  types::output_chunk::OutputChunk,
+  types::output_chunk::{Modules, OutputChunk},
   types::outputs_diagnostics::OutputsDiagnostics,
   types::package_json::PackageJson,
   types::rendered_module::RenderedModule,

--- a/crates/rolldown_common/src/types/output_chunk.rs
+++ b/crates/rolldown_common/src/types/output_chunk.rs
@@ -18,7 +18,7 @@ pub struct OutputChunk {
   pub exports: Vec<Rstr>,
   // RenderedChunk
   pub filename: ArcStr,
-  pub modules: FxHashMap<ModuleId, RenderedModule>,
+  pub modules: Modules,
   pub imports: Vec<ArcStr>,
   pub dynamic_imports: Vec<ArcStr>,
   // OutputChunk
@@ -26,4 +26,25 @@ pub struct OutputChunk {
   pub map: Option<SourceMap>,
   pub sourcemap_filename: Option<String>,
   pub preliminary_filename: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Modules {
+  pub key_to_index: FxHashMap<ModuleId, usize>,
+  pub value: Vec<RenderedModule>,
+}
+
+impl From<FxHashMap<ModuleId, RenderedModule>> for Modules {
+  fn from(value: FxHashMap<ModuleId, RenderedModule>) -> Self {
+    let mut key_to_index = FxHashMap::default();
+    let value = value
+      .into_iter()
+      .enumerate()
+      .map(|(index, (key, value))| {
+        key_to_index.insert(key, index);
+        value
+      })
+      .collect();
+    Self { key_to_index, value }
+  }
 }

--- a/crates/rolldown_common/src/types/rollup_rendered_chunk.rs
+++ b/crates/rolldown_common/src/types/rollup_rendered_chunk.rs
@@ -1,8 +1,9 @@
 use arcstr::ArcStr;
 use rolldown_rstr::Rstr;
-use rustc_hash::FxHashMap;
 
-use crate::{ModuleId, RenderedModule};
+use crate::ModuleId;
+
+use super::output_chunk::Modules;
 
 // The prefix `Rollup` shows that this is struct is designed for compatibility with Rollup. Adding the `Rollup` prefix to show how much types are only used for compatibility with Rollup.
 #[derive(Debug, Clone)]
@@ -16,7 +17,7 @@ pub struct RollupRenderedChunk {
   pub exports: Vec<Rstr>,
   // RenderedChunk
   pub filename: ArcStr,
-  pub modules: FxHashMap<ModuleId, RenderedModule>,
+  pub modules: Modules,
   pub imports: Vec<ArcStr>,
   pub dynamic_imports: Vec<ArcStr>,
   pub debug_id: u128,

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -84,7 +84,7 @@ export declare class BindingOutputChunk {
   get moduleIds(): Array<string>
   get exports(): Array<string>
   get fileName(): string
-  get modules(): Record<string, BindingRenderedModule>
+  get modules(): BindingModules
   get imports(): Array<string>
   get dynamicImports(): Array<string>
   get code(): string
@@ -151,6 +151,19 @@ export declare class ParallelJsPluginRegistry {
   id: number
   workerCount: number
   constructor(workerCount: number)
+}
+
+export declare class RenderedChunk {
+  get name(): string
+  get isEntry(): boolean
+  get isDynamicEntry(): boolean
+  get facadeModuleId(): string | null
+  get moduleIds(): Array<string>
+  get exports(): Array<string>
+  get fileName(): string
+  get modules(): BindingModules
+  get imports(): Array<string>
+  get dynamicImports(): Array<string>
 }
 
 export interface AliasItem {
@@ -393,6 +406,11 @@ export interface BindingMatchGroup {
 
 export interface BindingModulePreloadPolyfillPluginConfig {
   skip?: boolean
+}
+
+export interface BindingModules {
+  value: Array<BindingRenderedModule>
+  idToIndex: Record<string, number>
 }
 
 export interface BindingModuleSideEffectsRule {
@@ -826,19 +844,6 @@ export interface ReactRefreshOptions {
 }
 
 export declare function registerPlugins(id: number, plugins: Array<BindingPluginWithIndex>): void
-
-export interface RenderedChunk {
-  name: string
-  isEntry: boolean
-  isDynamicEntry: boolean
-  facadeModuleId?: string
-  moduleIds: Array<string>
-  exports: Array<string>
-  fileName: string
-  modules: Record<string, BindingRenderedModule>
-  imports: Array<string>
-  dynamicImports: Array<string>
-}
 
 export type Severity =  'Error'|
 'Warning'|

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -381,6 +381,7 @@ module.exports.BindingWatcherChangeData = nativeBinding.BindingWatcherChangeData
 module.exports.BindingWatcherEvent = nativeBinding.BindingWatcherEvent
 module.exports.Bundler = nativeBinding.Bundler
 module.exports.ParallelJsPluginRegistry = nativeBinding.ParallelJsPluginRegistry
+module.exports.RenderedChunk = nativeBinding.RenderedChunk
 module.exports.BindingBuiltinPluginName = nativeBinding.BindingBuiltinPluginName
 module.exports.BindingHookSideEffects = nativeBinding.BindingHookSideEffects
 module.exports.BindingLogLevel = nativeBinding.BindingLogLevel

--- a/packages/rolldown/src/types/rolldown-output.ts
+++ b/packages/rolldown/src/types/rolldown-output.ts
@@ -33,6 +33,15 @@ export interface RenderedChunk extends Omit<BindingRenderedChunk, 'modules'> {
   modules: {
     [id: string]: RenderedModule
   }
+  name: string
+  isEntry: boolean
+  isDynamicEntry: boolean
+  facadeModuleId: string | null
+  moduleIds: Array<string>
+  exports: Array<string>
+  fileName: string
+  imports: Array<string>
+  dynamicImports: Array<string>
 }
 
 export interface OutputChunk {

--- a/packages/rolldown/src/utils/transform-rendered-chunk.ts
+++ b/packages/rolldown/src/utils/transform-rendered-chunk.ts
@@ -6,7 +6,33 @@ export function transformRenderedChunk(
   chunk: BindingRenderedChunk,
 ): RenderedChunk {
   return {
-    ...chunk,
+    get name() {
+      return chunk.name
+    },
+    get isEntry() {
+      return chunk.isEntry
+    },
+    get isDynamicEntry() {
+      return chunk.isDynamicEntry
+    },
+    get facadeModuleId() {
+      return chunk.facadeModuleId
+    },
+    get moduleIds() {
+      return chunk.moduleIds
+    },
+    get exports() {
+      return chunk.exports
+    },
+    get fileName() {
+      return chunk.fileName
+    },
+    get imports() {
+      return chunk.imports
+    },
+    get dynamicImports() {
+      return chunk.dynamicImports
+    },
     get modules() {
       return transformChunkModules(chunk.modules)
     },
@@ -17,7 +43,8 @@ export function transformChunkModules(
   modules: BindingRenderedChunk['modules'],
 ): RenderedChunk['modules'] {
   const result: RenderedChunk['modules'] = {}
-  for (const [id, mod] of Object.entries(modules)) {
+  for (const [id, index] of Object.entries(modules.idToIndex)) {
+    let mod = modules.value[index]
     result[id] = transformToRenderedModule(mod)
   }
   return result


### PR DESCRIPTION
<!-- Thank you for contributing! -->
# benchmark/apps/10000

## Before

![image](https://github.com/user-attachments/assets/3da681b3-e3e9-4f5c-b945-3e93f62b2ae2)

### profile
![image](https://github.com/user-attachments/assets/9ad475f7-ce3c-450b-85ce-7fcc28143791)
![image](https://github.com/user-attachments/assets/3d5c139c-5ff3-4c57-a936-8e6324a270cc)
The `to_napi_value` cost about 130ms, seems `napi` has huge overhead when convert complex `HashMap` to 
JsObject
## After
![image](https://github.com/user-attachments/assets/334d3662-cba3-4601-bab7-8544c1676bf7)
![image](https://github.com/user-attachments/assets/f357b3cd-7eb1-40af-8a61-154a151334c5)
the `to_napi` cost is gone
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
