### PR TITLE
chore: reduce node benchmark iteration time

### DIFF
--- a/packages/bench/benches/ci.js
+++ b/packages/bench/benches/ci.js
@@ -9,7 +9,11 @@ const DIRNAME = nodePath.dirname(nodeUrl.fileURLToPath(import.meta.url))
 const PROJECT_ROOT = nodePath.resolve(DIRNAME, '..')
 const REPO_ROOT = nodePath.resolve(PROJECT_ROOT, '../..')
 
-const bench = new tinyBench.Bench()
+const bench = new tinyBench.Bench({
+  iterations: 10,
+  warmupIterations: 5,
+})
+bench.threshold = 1
 
 for (const suite of expandSuitesWithDerived(suitesForCI)) {
   const rolldownSuiteList = getRolldownSuiteList(suite)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
the default bench iteration time is too high, so reduce iteration time to avoid github CI auto terminated.
ref https://github.com/tinylibs/tinybench/blob/main/src/constants.ts#L1034-L1038
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
