### PR TITLE
chore: update `.prettierignore` and `rolldown-binding.wasi`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,3 +20,4 @@ packages/rolldown/src/rolldown-binding.wasi.cjs
 packages/rolldown/src/wasi-worker-browser.mjs
 packages/rolldown/src/wasi-worker.mjs
 packages/rolldown/tests/fixtures/**/*.js
+packages/rolldown/tests/cli/fixtures/**/*.js

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -155,19 +155,21 @@ function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__JsChangedOutputs_struct_149']?.()
   __napiInstance.exports['__napi_register__BindingError_struct_150']?.()
   __napiInstance.exports['__napi_register__RenderedChunk_struct_151']?.()
-  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_152']?.()
-  __napiInstance.exports['__napi_register__BindingRenderedModule_impl_154']?.()
-  __napiInstance.exports['__napi_register__AliasItem_struct_155']?.()
-  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_156']?.()
-  __napiInstance.exports['__napi_register__BindingSourcemap_struct_157']?.()
-  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_158']?.()
-  __napiInstance.exports['__napi_register__BindingWatcherEvent_struct_159']?.()
-  __napiInstance.exports['__napi_register__BindingWatcherEvent_impl_165']?.()
-  __napiInstance.exports['__napi_register__BindingWatcherChangeData_struct_166']?.()
-  __napiInstance.exports['__napi_register__BindingBundleEndEventData_struct_167']?.()
-  __napiInstance.exports['__napi_register__BindingNotifyOption_struct_168']?.()
-  __napiInstance.exports['__napi_register__BindingWatcher_struct_169']?.()
-  __napiInstance.exports['__napi_register__BindingWatcher_impl_173']?.()
+  __napiInstance.exports['__napi_register__RenderedChunk_impl_162']?.()
+  __napiInstance.exports['__napi_register__BindingModules_struct_163']?.()
+  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_164']?.()
+  __napiInstance.exports['__napi_register__BindingRenderedModule_impl_166']?.()
+  __napiInstance.exports['__napi_register__AliasItem_struct_167']?.()
+  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_168']?.()
+  __napiInstance.exports['__napi_register__BindingSourcemap_struct_169']?.()
+  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_170']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherEvent_struct_171']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherEvent_impl_177']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherChangeData_struct_178']?.()
+  __napiInstance.exports['__napi_register__BindingBundleEndEventData_struct_179']?.()
+  __napiInstance.exports['__napi_register__BindingNotifyOption_struct_180']?.()
+  __napiInstance.exports['__napi_register__BindingWatcher_struct_181']?.()
+  __napiInstance.exports['__napi_register__BindingWatcher_impl_185']?.()
 }
 export const BindingBundleEndEventData = __napiModule.exports.BindingBundleEndEventData
 export const BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
@@ -186,6 +188,7 @@ export const BindingWatcherChangeData = __napiModule.exports.BindingWatcherChang
 export const BindingWatcherEvent = __napiModule.exports.BindingWatcherEvent
 export const Bundler = __napiModule.exports.Bundler
 export const ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
+export const RenderedChunk = __napiModule.exports.RenderedChunk
 export const BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName
 export const BindingHookSideEffects = __napiModule.exports.BindingHookSideEffects
 export const BindingLogLevel = __napiModule.exports.BindingLogLevel

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -179,19 +179,21 @@ function __napi_rs_initialize_modules(__napiInstance) {
   __napiInstance.exports['__napi_register__JsChangedOutputs_struct_149']?.()
   __napiInstance.exports['__napi_register__BindingError_struct_150']?.()
   __napiInstance.exports['__napi_register__RenderedChunk_struct_151']?.()
-  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_152']?.()
-  __napiInstance.exports['__napi_register__BindingRenderedModule_impl_154']?.()
-  __napiInstance.exports['__napi_register__AliasItem_struct_155']?.()
-  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_156']?.()
-  __napiInstance.exports['__napi_register__BindingSourcemap_struct_157']?.()
-  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_158']?.()
-  __napiInstance.exports['__napi_register__BindingWatcherEvent_struct_159']?.()
-  __napiInstance.exports['__napi_register__BindingWatcherEvent_impl_165']?.()
-  __napiInstance.exports['__napi_register__BindingWatcherChangeData_struct_166']?.()
-  __napiInstance.exports['__napi_register__BindingBundleEndEventData_struct_167']?.()
-  __napiInstance.exports['__napi_register__BindingNotifyOption_struct_168']?.()
-  __napiInstance.exports['__napi_register__BindingWatcher_struct_169']?.()
-  __napiInstance.exports['__napi_register__BindingWatcher_impl_173']?.()
+  __napiInstance.exports['__napi_register__RenderedChunk_impl_162']?.()
+  __napiInstance.exports['__napi_register__BindingModules_struct_163']?.()
+  __napiInstance.exports['__napi_register__BindingRenderedModule_struct_164']?.()
+  __napiInstance.exports['__napi_register__BindingRenderedModule_impl_166']?.()
+  __napiInstance.exports['__napi_register__AliasItem_struct_167']?.()
+  __napiInstance.exports['__napi_register__ExtensionAliasItem_struct_168']?.()
+  __napiInstance.exports['__napi_register__BindingSourcemap_struct_169']?.()
+  __napiInstance.exports['__napi_register__BindingJsonSourcemap_struct_170']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherEvent_struct_171']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherEvent_impl_177']?.()
+  __napiInstance.exports['__napi_register__BindingWatcherChangeData_struct_178']?.()
+  __napiInstance.exports['__napi_register__BindingBundleEndEventData_struct_179']?.()
+  __napiInstance.exports['__napi_register__BindingNotifyOption_struct_180']?.()
+  __napiInstance.exports['__napi_register__BindingWatcher_struct_181']?.()
+  __napiInstance.exports['__napi_register__BindingWatcher_impl_185']?.()
 }
 module.exports.BindingBundleEndEventData = __napiModule.exports.BindingBundleEndEventData
 module.exports.BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
@@ -210,6 +212,7 @@ module.exports.BindingWatcherChangeData = __napiModule.exports.BindingWatcherCha
 module.exports.BindingWatcherEvent = __napiModule.exports.BindingWatcherEvent
 module.exports.Bundler = __napiModule.exports.Bundler
 module.exports.ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
+module.exports.RenderedChunk = __napiModule.exports.RenderedChunk
 module.exports.BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName
 module.exports.BindingHookSideEffects = __napiModule.exports.BindingHookSideEffects
 module.exports.BindingLogLevel = __napiModule.exports.BindingLogLevel


### PR DESCRIPTION
### Description

Related to #3267

After completing the relevant tests, run `just lint`:

```bash
[lint-prettier] [warn] packages/rolldown/tests/cli/fixtures/config-multiply-options/watch-dist-options/cjs.js
[lint-prettier] [warn] packages/rolldown/tests/cli/fixtures/config-multiply-options/watch-dist-options/esm.js
[lint-prettier] [warn] packages/rolldown/tests/cli/fixtures/config-multiply-output/watch-dist-output/cjs.js
[lint-prettier] [warn] packages/rolldown/tests/cli/fixtures/config-multiply-output/watch-dist-output/esm.js
[lint-prettier] [warn] Code style issues found in 4 files. Run Prettier with --write to fix.
[lint-prettier]  ELIFECYCLE  Command failed with exit code 1.
ERROR: "lint-prettier" exited with 1.
```