### PR TITLE
chore(rolldown_binding): remove unnecessary `type_aliases.rs`

### DIFF
--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -23,6 +23,5 @@ pub mod parallel_js_plugin_registry;
 pub mod types;
 pub mod utils;
 pub use oxc_transform_napi;
-mod type_aliases;
 pub mod watcher;
 pub mod worker_manager;

--- a/crates/rolldown_binding/src/type_aliases.rs
+++ b/crates/rolldown_binding/src/type_aliases.rs
@@ -1,7 +1,0 @@
-use std::sync::Mutex;
-
-use rolldown_utils::unique_arc::{UniqueArc, WeakRef};
-#[allow(dead_code)]
-pub type UniqueArcMutex<T> = UniqueArc<Mutex<T>>;
-#[allow(dead_code)]
-pub type WeakRefMutex<T> = WeakRef<Mutex<T>>;


### PR DESCRIPTION
### Description

Managing `type_aliases.rs` in the project root is less ideal than moving it to `types/mod.rs`, making the structure clearer and more organized.

I'm not sure if it is a good idea and it's just my personal suggestion. Feel free to close it if it's not suitable.