### PR TITLE
fix: make just setup happy in windows

### DIFF
--- a/scripts/misc/setup-benchmark-input/util.js
+++ b/scripts/misc/setup-benchmark-input/util.js
@@ -1,9 +1,39 @@
 import fsExtra from 'fs-extra'
 
+let gitPathCache = ''
+
+/**
+ * @param {string} command
+ * @returns {Promise<boolean>}
+ */
+async function validateGitExecutable(command) {
+  try {
+    // if git executable not found, panic.
+    await $`${command} --version`
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function findGitExecutable() {
+  if (gitPathCache) return gitPathCache
+
+  const candidates = process.platform === 'win32' ? ['git.exe', 'git'] : ['git']
+  for (const candidate of candidates) {
+    if (await validateGitExecutable(candidate)) {
+      gitPathCache = candidate
+      return gitPathCache
+    }
+  }
+
+  throw new Error('Git executable not found.')
+}
+
 export async function cloneThreeJsIfNotExists() {
   if (!fsExtra.existsSync('./tmp/github/three')) {
     fsExtra.ensureDirSync('./tmp/github')
-    await $`git clone --branch r108 --depth 1 https://github.com/mrdoob/three.js.git ./tmp/github/three`
+    await $`${await findGitExecutable()} clone --branch r108 --depth 1 https://github.com/mrdoob/three.js.git ./tmp/github/three`
   } else {
     console.log('[skip] three.js already cloned')
   }
@@ -12,20 +42,21 @@ export async function cloneThreeJsIfNotExists() {
 export async function cloneRolldownBenchcasesIfNotExists() {
   if (!fsExtra.existsSync('./tmp/github/rolldown-benchcases')) {
     fsExtra.ensureDirSync('./tmp/github')
-    await $`git clone https://github.com/rolldown/benchcases.git ./tmp/github/rolldown-benchcases`
+    await $`${await findGitExecutable()} clone https://github.com/rolldown/benchcases.git ./tmp/github/rolldown-benchcases`
   } else {
     console.log('[skip] rolldown-benchcases already cloned')
   }
 }
 
 export async function fetchRomeIfNotExists() {
+  const gitPath = await findGitExecutable()
   if (!fsExtra.existsSync('./tmp/github/rome')) {
     fsExtra.ensureDirSync('./tmp/github/rome')
     cd('./tmp/github/rome')
-    await $`git init`
-    await $`git remote add origin https://github.com/romejs/rome.git`
-    await $`git fetch --depth 1 origin d95a3a7aab90773c9b36d9c82a08c8c4c6b68aa5`
-    await $`git checkout FETCH_HEAD`
+    await $`${gitPath} init`
+    await $`${gitPath} remote add origin https://github.com/romejs/rome.git`
+    await $`${gitPath} fetch --depth 1 origin d95a3a7aab90773c9b36d9c82a08c8c4c6b68aa5`
+    await $`${gitPath} checkout FETCH_HEAD`
     cd('../../..')
   } else {
     console.log('[skip] rome already cloned')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`just setup` stop when setup benchmark environment. Will throw error `no git found` if you install wsl ~or portable git~, a small fix to make `just setup` pass.
 
> [!NOTE] 
> The issue here is that WSL cannot execute .exe files directly. This fix prioritize using the system-installed Git first. If that fails, we will attempt to locate Git within the WSL image. If neither option succeeds, the program will panic.

<details>
<summary>Use git command (dead)</summary>
<pre><code>
(base) PS C:\rolldown> just setup                                 
just check-setup-prerequisites
node ./scripts/misc/setup-prerequisites/node.js
# Rust related setup
cargo install cargo-binstall
    Updating crates.io index
     Ignored package `cargo-binstall v1.10.19` is already installed, use --force to override                                                                                                                                       
cargo binstall taplo-cli cargo-insta cargo-deny cargo-shear -y
 INFO resolve: Resolving package: 'cargo-shear'
 INFO resolve: Resolving package: 'cargo-insta'
 INFO resolve: Resolving package: 'cargo-deny'
 INFO resolve: Resolving package: 'taplo-cli'
 INFO resolve: cargo-shear v1.1.4 is already installed, use --force to override
 INFO resolve: taplo-cli v0.9.3 is already installed, use --force to override
 INFO resolve: cargo-insta v1.42.0 is already installed, use --force to override
 INFO resolve: cargo-deny v0.16.3 is already installed, use --force to override
 INFO Done in 2.4611584s
# Node.js related setup
corepack enable
pnpm install
packages/rolldown/npm/darwin-arm64       |  WARN  Unsupported platform: wanted: {"cpu":["arm64"],"os":["darwin"],"libc":["any"]} (current: {"os":"win32","cpu":"x64","libc":"unknown"})
packages/rolldown/npm/darwin-x64         |  WARN  Unsupported platform: wanted: {"cpu":["x64"],"os":["darwin"],"libc":["any"]} (current: {"os":"win32","cpu":"x64","libc":"unknown"})
packages/rolldown/npm/freebsd-x64        |  WARN  Unsupported platform: wanted: {"cpu":["x64"],"os":["freebsd"],"libc":["any"]} (current: {"os":"win32","cpu":"x64","libc":"unknown"})
.../rolldown/npm/linux-arm-gnueabihf     |  WARN  Unsupported platform: wanted: {"cpu":["arm"],"os":["linux"],"libc":["any"]} (current: {"os":"win32","cpu":"x64","libc":"unknown"})
packages/rolldown/npm/linux-arm64-gnu    |  WARN  Unsupported platform: wanted: {"cpu":["arm64"],"os":["linux"],"libc":["glibc"]} (current: {"os":"win32","cpu":"x64","libc":"unknown"})
 WARN  6 other warnings
Scope: all 26 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date

devDependencies:
+ @actions/core 1.11.1
+ @babel/runtime 7.26.0
+ @ls-lint/ls-lint 2.2.3
+ @taplo/cli 0.7.0
+ @types/node 22.8.7
+ cjs-module-lexer 1.4.1
+ conventional-changelog-cli 5.0.0
+ cspell 8.15.7
+ husky 9.1.6
+ lint-staged 15.2.10
+ npm-run-all 4.1.5
+ oxlint 0.15.3
+ prettier 3.3.3
+ rolldown 1.0.0-beta.1 <- packages\rolldown
+ typescript 5.6.3

. prepare$ husky install
│ install command is DEPRECATED
└─ Done in 598ms
Done in 12s
just setup-submodule
git submodule update --init
just setup-bench
node ./scripts/misc/setup-benchmark-input/index.js
/bin/bash: line 1: git: command not found
C:\rolldown\node_modules\.pnpm\zx@8.2.0\node_modules\zx\build\core.cjs:203
          const output = new ProcessOutput(dto);
                         ^

ProcessOutput [Error]: /bin/bash: line 1: git: command not found
    at cloneThreeJsIfNotExists (file:///C:/rolldown/scripts/misc/setup-benchmark-input/util.js:6:12)
    exit code: 127 (Command not found)
    at EventEmitter.end (C:\rolldown\node_modules\.pnpm\zx@8.2.0\node_modules\zx\build\core.cjs:203:26)
    at EventEmitter.emit (node:events:525:35)
    at ChildProcess.<anonymous> (C:\rolldown\node_modules\.pnpm\zx@8.2.0\node_modules\zx\build\vendor-core.cjs:493:16)
    at Object.onceWrapper (node:events:628:26)
    at ChildProcess.emit (node:events:513:28)
    at maybeClose (node:internal/child_process:1101:16)
    at Socket.<anonymous> (node:internal/child_process:457:11)
    at Socket.emit (node:events:513:28)
    at Pipe.<anonymous> (node:net:351:12) {
  _code: [Getter],
  _signal: [Getter],
  _stdout: [Getter],
  _stderr: [Getter],
  _combined: [Getter],
  _duration: [Getter]
}

Node.js v23.5.0
error: Recipe `setup-bench` failed on line 25 with exit code 1
error: Recipe `setup` failed on line 18 with exit code 1
</code></pre>
</details>

<details>
<summary>Replace one git to git.exe command (ok)</summary>
<pre><code>
(base) PS C:\rolldown> just setup
just check-setup-prerequisites
node ./scripts/misc/setup-prerequisites/node.js
# Rust related setup
cargo install cargo-binstall
    Updating crates.io index
     Ignored package `cargo-binstall v1.10.19` is already installed, use --force to override
cargo binstall taplo-cli cargo-insta cargo-deny cargo-shear -y
 INFO resolve: Resolving package: 'cargo-deny'
 INFO resolve: Resolving package: 'cargo-shear'
 INFO resolve: Resolving package: 'cargo-insta'
 INFO resolve: Resolving package: 'taplo-cli'
 INFO resolve: taplo-cli v0.9.3 is already installed, use --force to override
 INFO resolve: cargo-shear v1.1.4 is already installed, use --force to override
 INFO resolve: cargo-deny v0.16.3 is already installed, use --force to override
 INFO resolve: cargo-insta v1.42.0 is already installed, use --force to override
 INFO Done in 1.376583s
# Node.js related setup
corepack enable
pnpm install
packages/rolldown/npm/darwin-arm64       |  WARN  Unsupported platform: wanted: {"cpu":["arm64"],"os":["darwin"],"libc":["any"]} (current: {"os":"win32","cpu":"x64","libc":"unknown"})
packages/rolldown/npm/darwin-x64         |  WARN  Unsupported platform: wanted: {"cpu":["x64"],"os":["darwin"],"libc":["any"]} (current: {"os":"win32","cpu":"x64","libc":"unknown"})
packages/rolldown/npm/freebsd-x64        |  WARN  Unsupported platform: wanted: {"cpu":["x64"],"os":["freebsd"],"libc":["any"]} (current: {"os":"win32","cpu":"x64","libc":"unknown"})
.../rolldown/npm/linux-arm-gnueabihf     |  WARN  Unsupported platform: wanted: {"cpu":["arm"],"os":["linux"],"libc":["any"]} (current: {"os":"win32","cpu":"x64","libc":"unknown"})
packages/rolldown/npm/linux-arm64-gnu    |  WARN  Unsupported platform: wanted: {"cpu":["arm64"],"os":["linux"],"libc":["glibc"]} (current: {"os":"win32","cpu":"x64","libc":"unknown"})
 WARN  6 other warnings
Scope: all 26 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date

devDependencies:
+ @actions/core 1.11.1
+ @babel/runtime 7.26.0
+ @ls-lint/ls-lint 2.2.3
+ @taplo/cli 0.7.0
+ @types/node 22.8.7
+ cjs-module-lexer 1.4.1
+ conventional-changelog-cli 5.0.0
+ cspell 8.15.7
+ husky 9.1.6
+ lint-staged 15.2.10
+ npm-run-all 4.1.5
+ oxlint 0.15.3
+ prettier 3.3.3
+ rolldown 1.0.0-beta.1 <- packages\rolldown
+ typescript 5.6.3

. prepare$ husky install
│ install command is DEPRECATED
└─ Done in 168ms
Done in 2.9s
just setup-submodule
git submodule update --init
just setup-bench
node ./scripts/misc/setup-benchmark-input/index.js
Cloning into './tmp/github/three'...
Note: switching to '7e0a78beb9317e580d7fa4da9b5b12be051c6feb'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

Updating files: 100% (3702/3702), done.
/bin/bash: line 1: git: command not found
C:\rolldown\node_modules\.pnpm\zx@8.2.0\node_modules\zx\build\core.cjs:203
          const output = new ProcessOutput(dto);
                         ^

ProcessOutput [Error]: /bin/bash: line 1: git: command not found
    at fetchRomeIfNotExists (file:///C:/rolldown/scripts/misc/setup-benchmark-input/util.js:25:12)
    exit code: 127 (Command not found)
    at EventEmitter.end (C:\rolldown\node_modules\.pnpm\zx@8.2.0\node_modules\zx\build\core.cjs:203:26)
    at EventEmitter.emit (node:events:525:35)
    at ChildProcess.<anonymous> (C:\rolldown\node_modules\.pnpm\zx@8.2.0\node_modules\zx\build\vendor-core.cjs:493:16)
    at Object.onceWrapper (node:events:628:26)
    at ChildProcess.emit (node:events:513:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5) {
  _code: [Getter],
  _signal: [Getter],
  _stdout: [Getter],
  _stderr: [Getter],
  _combined: [Getter],
  _duration: [Getter]
}

Node.js v23.5.0
error: Recipe `setup-bench` failed on line 25 with exit code 1
error: Recipe `setup` failed on line 18 with exit code 1
</code></pre>
</details>


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
