### PR TITLE
refactor(infra): change schema name from camelCase to PascalCase

### DIFF
--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -11,7 +11,7 @@ import type {
   SourcemapPathTransformOption,
 } from '../types/misc'
 
-const stringOrRegExpSchema = v.union([v.string(), v.instance(RegExp)])
+const StringOrRegExpSchema = v.union([v.string(), v.instance(RegExp)])
 
 const LogLevelSchema = v.union([
   v.literal('debug'),
@@ -27,15 +27,15 @@ const RollupLogWithStringSchema = v.union([RollupLogSchema, v.string()])
 
 /// --- InputSchema ---
 
-const inputOptionSchema = v.union([
+const InputOptionSchema = v.union([
   v.string(),
   v.array(v.string()),
   v.record(v.string(), v.string()),
 ])
 
-const externalSchema = v.union([
-  stringOrRegExpSchema,
-  v.array(stringOrRegExpSchema),
+const ExternalSchema = v.union([
+  StringOrRegExpSchema,
+  v.array(StringOrRegExpSchema),
   v.pipe(
     v.function(),
     v.args(v.tuple([v.string(), v.optional(v.string()), v.boolean()])),
@@ -43,7 +43,7 @@ const externalSchema = v.union([
   ),
 ])
 
-const moduleTypesSchema = v.record(
+const ModuleTypesSchema = v.record(
   v.string(),
   v.union([
     v.literal('base64'),
@@ -60,7 +60,7 @@ const moduleTypesSchema = v.record(
   ]),
 )
 
-const jsxOptionsSchema = v.strictObject({
+const JsxOptionsSchema = v.strictObject({
   development: v.pipe(
     v.optional(v.boolean()),
     v.description('Development specific information'),
@@ -95,13 +95,13 @@ const jsxOptionsSchema = v.strictObject({
   ),
 })
 
-const watchOptionsSchema = v.strictObject({
+const WatchOptionsSchema = v.strictObject({
   chokidar: v.optional(v.any()),
   exclude: v.optional(
-    v.union([stringOrRegExpSchema, v.array(stringOrRegExpSchema)]),
+    v.union([StringOrRegExpSchema, v.array(StringOrRegExpSchema)]),
   ),
   include: v.optional(
-    v.union([stringOrRegExpSchema, v.array(stringOrRegExpSchema)]),
+    v.union([StringOrRegExpSchema, v.array(StringOrRegExpSchema)]),
   ),
   notify: v.pipe(
     v.optional(
@@ -118,7 +118,7 @@ const watchOptionsSchema = v.strictObject({
   ),
 })
 
-const checksOptionsSchema = v.strictObject({
+const ChecksOptionsSchema = v.strictObject({
   circularDependency: v.pipe(
     v.optional(v.boolean()),
     v.description(
@@ -127,7 +127,7 @@ const checksOptionsSchema = v.strictObject({
   ),
 })
 
-const resolveOptionsSchema = v.strictObject({
+const ResolveOptionsSchema = v.strictObject({
   alias: v.optional(
     v.record(v.string(), v.union([v.string(), v.array(v.string())])),
   ),
@@ -182,11 +182,11 @@ const OnwarnSchema = v.pipe(
   ),
 )
 
-const inputOptionsSchema = v.strictObject({
-  input: v.optional(inputOptionSchema),
+const InputOptionsSchema = v.strictObject({
+  input: v.optional(InputOptionSchema),
   plugins: v.optional(v.custom<RolldownPluginOption>(() => true)),
-  external: v.optional(externalSchema),
-  resolve: v.optional(resolveOptionsSchema),
+  external: v.optional(ExternalSchema),
+  resolve: v.optional(ResolveOptionsSchema),
   cwd: v.pipe(
     v.optional(v.string()),
     v.description('Current working directory'),
@@ -213,7 +213,7 @@ const inputOptionsSchema = v.strictObject({
   onLog: v.optional(OnLogSchema),
   onwarn: v.optional(OnwarnSchema),
   moduleTypes: v.pipe(
-    v.optional(moduleTypesSchema),
+    v.optional(ModuleTypesSchema),
     v.description('Module types for customized extensions'),
   ),
   experimental: v.optional(
@@ -235,16 +235,16 @@ const inputOptionsSchema = v.strictObject({
     ),
   ),
   profilerNames: v.optional(v.boolean()),
-  jsx: v.optional(jsxOptionsSchema),
-  watch: v.optional(v.union([watchOptionsSchema, v.literal(false)])),
+  jsx: v.optional(JsxOptionsSchema),
+  watch: v.optional(v.union([WatchOptionsSchema, v.literal(false)])),
   dropLabels: v.pipe(
     v.optional(v.array(v.string())),
     v.description('Remove labeled statements with these label names'),
   ),
-  checks: v.optional(checksOptionsSchema),
+  checks: v.optional(ChecksOptionsSchema),
 })
 
-const inputCliOverrideSchema = v.strictObject({
+const InputCliOverrideSchema = v.strictObject({
   external: v.pipe(
     v.optional(v.array(v.string())),
     v.description(
@@ -261,10 +261,10 @@ const inputCliOverrideSchema = v.strictObject({
   ),
 })
 
-const inputCliOptionsSchema = v.omit(
+const InputCliOptionsSchema = v.omit(
   v.strictObject({
-    ...inputOptionsSchema.entries,
-    ...inputCliOverrideSchema.entries,
+    ...InputOptionsSchema.entries,
+    ...InputCliOverrideSchema.entries,
   }),
   [
     'input',
@@ -305,7 +305,7 @@ const ModuleFormatSchema = v.union([
   v.literal('umd'),
 ])
 
-const addonFunctionSchema = v.pipe(
+const AddonFunctionSchema = v.pipe(
   v.function(),
   v.args(v.tuple([v.custom<RenderedChunk>(() => true)])),
   v.returnsAsync(
@@ -316,7 +316,7 @@ const addonFunctionSchema = v.pipe(
   ),
 )
 
-const chunkFileNamesSchema = v.union([
+const ChunkFileNamesSchema = v.union([
   v.string(),
   v.pipe(
     v.function(),
@@ -331,7 +331,7 @@ const GlobalsFunctionSchema = v.pipe(
   v.returns(v.string()),
 )
 
-const advancedChunksSchema = v.strictObject({
+const AdvancedChunksSchema = v.strictObject({
   minSize: v.optional(v.number()),
   minShareCount: v.optional(v.number()),
   groups: v.optional(
@@ -347,7 +347,7 @@ const advancedChunksSchema = v.strictObject({
   ),
 })
 
-const outputOptionsSchema = v.strictObject({
+const OutputOptionsSchema = v.strictObject({
   dir: v.pipe(
     v.optional(v.string()),
     v.description('Output directory, defaults to `dist` if `file` is not set'),
@@ -393,10 +393,10 @@ const outputOptionsSchema = v.strictObject({
   sourcemapPathTransform: v.optional(
     v.custom<SourcemapPathTransformOption>(() => true),
   ),
-  banner: v.optional(v.union([v.string(), addonFunctionSchema])),
-  footer: v.optional(v.union([v.string(), addonFunctionSchema])),
-  intro: v.optional(v.union([v.string(), addonFunctionSchema])),
-  outro: v.optional(v.union([v.string(), addonFunctionSchema])),
+  banner: v.optional(v.union([v.string(), AddonFunctionSchema])),
+  footer: v.optional(v.union([v.string(), AddonFunctionSchema])),
+  intro: v.optional(v.union([v.string(), AddonFunctionSchema])),
+  outro: v.optional(v.union([v.string(), AddonFunctionSchema])),
   extend: v.pipe(
     v.optional(v.boolean()),
     v.description(
@@ -408,10 +408,10 @@ const outputOptionsSchema = v.strictObject({
     v.optional(v.string()),
     v.description('Name pattern for asset files'),
   ),
-  entryFileNames: v.optional(chunkFileNamesSchema),
-  chunkFileNames: v.optional(chunkFileNamesSchema),
-  cssEntryFileNames: v.optional(chunkFileNamesSchema),
-  cssChunkFileNames: v.optional(chunkFileNamesSchema),
+  entryFileNames: v.optional(ChunkFileNamesSchema),
+  chunkFileNames: v.optional(ChunkFileNamesSchema),
+  cssEntryFileNames: v.optional(ChunkFileNamesSchema),
+  cssChunkFileNames: v.optional(ChunkFileNamesSchema),
   minify: v.pipe(
     v.optional(v.boolean()),
     v.description('Minify the bundled file'),
@@ -436,7 +436,7 @@ const outputOptionsSchema = v.strictObject({
     v.optional(v.boolean(), false),
     v.description('Inline dynamic imports'),
   ),
-  advancedChunks: v.optional(advancedChunksSchema),
+  advancedChunks: v.optional(AdvancedChunksSchema),
   comments: v.pipe(
     v.optional(v.union([v.literal('none'), v.literal('preserve-legal')])),
     v.description('Control comments in the output'),
@@ -454,7 +454,7 @@ const getAddonDescription = (
   return `Code to insert the ${colors.bold(placement)} of the bundled file (${colors.bold(wrapper)} the wrapper function)`
 }
 
-const outputCliOverrideSchema = v.strictObject({
+const OutputCliOverrideSchema = v.strictObject({
   // Reject all functions in CLI
   entryFileNames: v.pipe(
     v.optional(v.string()),
@@ -520,17 +520,17 @@ const outputCliOverrideSchema = v.strictObject({
   ),
 })
 
-const outputCliOptionsSchema = v.omit(
+const OutputCliOptionsSchema = v.omit(
   v.strictObject({
-    ...outputOptionsSchema.entries,
-    ...outputCliOverrideSchema.entries,
+    ...OutputOptionsSchema.entries,
+    ...OutputCliOverrideSchema.entries,
   }),
   ['sourcemapIgnoreList', 'sourcemapPathTransform'],
 )
 
 /// --- CliSchema ---
 
-const cliOptionsSchema = v.strictObject({
+const CliOptionsSchema = v.strictObject({
   config: v.pipe(
     v.optional(v.union([v.string(), v.boolean()])),
     v.description('Path to the config file (default: `rolldown.config.js`)'),
@@ -545,8 +545,8 @@ const cliOptionsSchema = v.strictObject({
     v.optional(v.boolean()),
     v.description('Watch files in bundle and rebuild on changes'),
   ),
-  ...inputCliOptionsSchema.entries,
-  ...outputCliOptionsSchema.entries,
+  ...InputCliOptionsSchema.entries,
+  ...OutputCliOptionsSchema.entries,
 })
 
 export function validateTreeShakingOptions(options: TreeshakingOptions): void {
@@ -554,7 +554,7 @@ export function validateTreeShakingOptions(options: TreeshakingOptions): void {
 }
 
 export function validateCliOptions<T>(options: T): [T, string[]?] {
-  let parsed = v.safeParse(cliOptionsSchema, options)
+  let parsed = v.safeParse(CliOptionsSchema, options)
 
   return [
     parsed.output as T,
@@ -565,13 +565,13 @@ export function validateCliOptions<T>(options: T): [T, string[]?] {
 }
 
 export function getInputCliKeys(): string[] {
-  return v.keyof(inputCliOptionsSchema).options
+  return v.keyof(InputCliOptionsSchema).options
 }
 
 export function getOutputCliKeys(): string[] {
-  return v.keyof(outputCliOptionsSchema).options
+  return v.keyof(OutputCliOptionsSchema).options
 }
 
 export function getJsonSchema(): ObjectSchema {
-  return toJsonSchema(cliOptionsSchema) as ObjectSchema
+  return toJsonSchema(CliOptionsSchema) as ObjectSchema
 }


### PR DESCRIPTION
### Description

closes #3099 

The related task has been completed, and I have aligned the schema naming convention with `valibot`.