### PR TITLE
fix: run just setup limited node version

### DIFF
--- a/docs/contrib-guide/setup-the-project.md
+++ b/docs/contrib-guide/setup-the-project.md
@@ -69,7 +69,7 @@ Rolldown is built on Rust and requires `rustup` and `cargo` to exist in your env
 
 Rolldown is a npm package built with [NAPI-RS](https://napi.rs/) and is published to the npm registry, and as such requires Node.js and pnpm (for dependency management).
 
-We recommend installing Node.js with a version manager, like [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm). Make sure to install and use Node.js version 18.18.0+, which is the minimum requirement for this project. You can skip this step if you are already using a Node.js version manager of your choice and on a Node.js version that meets the requirement.
+We recommend installing Node.js with a version manager, like [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm). Make sure to install and use Node.js version {{ data.nodeVersion }}+, which is the minimum requirement for this project. You can skip this step if you are already using a Node.js version manager of your choice and on a Node.js version that meets the requirement.
 
 #### Setup pnpm
 

--- a/docs/contrib-guide/setup-the-project.md
+++ b/docs/contrib-guide/setup-the-project.md
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+  import { data } from '../data-loading/node-version.data.js'
+</script>
+
 # Setup the project
 
 ## Prerequisites
@@ -33,7 +37,7 @@ cargo install just
 
 :::
 
-- Install Node.js >= 20.11 / 21.2
+- Install Node.js >= {{ data.nodeVersion }} / 21.2.0
 
 ## `just setup`
 

--- a/docs/data-loading/node-version.data.js
+++ b/docs/data-loading/node-version.data.js
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const nodeVersion = readFileSync(
+  path.join(__dirname, '../../.node-version'),
+  'utf8',
+).trim()
+
+export default {
+  load() {
+    return {
+      nodeVersion,
+    }
+  },
+}


### PR DESCRIPTION
### Description

When I was building the project from scratch need NODE version >= 20.14.0;
but docs show me is 20.11.0
<img width="760" alt="image" src="https://github.com/user-attachments/assets/4191e9c0-0a3d-4f80-bde2-cef304a5454a" />

When I read the source code, I found running `just setup` also running `node ./scripts/misc/setup-prerequisites/node.js` and min nodeVersion is used `.node-version`(20.14.0)
