### PR TITLE
refactor(rolldown_resolver): simplify `Resolver#resolve` return type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,6 @@ dependencies = [
 name = "rolldown_resolver"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arcstr",
  "dashmap 6.1.0",
  "itertools 0.13.0",

--- a/crates/rolldown_resolver/Cargo.toml
+++ b/crates/rolldown_resolver/Cargo.toml
@@ -16,7 +16,6 @@ doctest = false
 workspace = true
 
 [dependencies]
-anyhow          = { workspace = true }
 arcstr          = { workspace = true }
 dashmap         = { workspace = true }
 itertools       = { workspace = true }


### PR DESCRIPTION
### Description

Remove unnecessary `anyhow::Result`