### PR TITLE
perf(link_stage): improve `LinkStage#wrap_modules`

### DIFF
--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
 ---
 # Assets
 


### PR DESCRIPTION
### Description

When `need_to_wrap` is `true`, `wrap_module_recursively` is executed, causing `module.import_records.iter()` to be processed repeatedly. We can optimize this to avoid redundant iterations.

https://github.com/rolldown/rolldown/blob/42ee4c997588b2ee205eceae36b48a18c95aed96/crates/rolldown/src/stages/link_stage/wrapping.rs#L89-L101