### PR TITLE
refactor: resolve emit chunk id

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -3,6 +3,7 @@ use super::runtime_module_task::RuntimeModuleTask;
 use super::task_context::TaskContextMeta;
 use crate::module_loader::task_context::TaskContext;
 use crate::type_alias::IndexEcmaAst;
+use crate::utils::resolve_id::resolve_id;
 use arcstr::ArcStr;
 use oxc::semantic::{ScopeId, SymbolTable};
 use oxc::transformer::ReplaceGlobalDefinesConfig;
@@ -15,9 +16,11 @@ use rolldown_common::{
   ModuleTable, ModuleType, NormalModuleTaskResult, ResolvedId, RuntimeModuleBrief,
   RuntimeModuleTaskResult, SymbolRefDb, SymbolRefDbForModule, TreeshakeOptions, RUNTIME_MODULE_ID,
 };
+use rolldown_error::ResultExt;
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_fs::OsFileSystem;
 use rolldown_plugin::SharedPluginDriver;
+use rolldown_resolver::ResolveError;
 use rolldown_utils::ecmascript::legitimize_identifier_name;
 use rolldown_utils::indexmap::FxIndexSet;
 use rolldown_utils::rayon::{IntoParallelIterator, ParallelIterator};
@@ -357,11 +360,38 @@ impl ModuleLoader {
           self.try_spawn_new_task(resolve_id, None, false, None);
         }
         ModuleLoaderMsg::AddEntryModule(data) => {
+          let result = resolve_id(
+            &self.shared_context.resolver,
+            &self.shared_context.plugin_driver,
+            data.id.as_str(),
+            data.importer.as_deref(),
+            true,
+            ImportKind::Import,
+            None,
+            Arc::default(),
+            true,
+          )
+          .await?;
+          let resolved_id = match result {
+            Ok(result) => result,
+            Err(e) => {
+              match e {
+                ResolveError::NotFound(_) => {
+                  errors.push(BuildDiagnostic::unresolved_entry(data.id.as_str(), None));
+                }
+                ResolveError::PackagePathNotExported(..) => {
+                  errors.push(BuildDiagnostic::unresolved_entry(data.id.as_str(), Some(e)));
+                }
+                _ => errors.push(Err(e).map_err_to_unhandleable()?),
+              }
+              continue;
+            }
+          };
           extra_entry_points.push(EntryPoint {
-            name: data.name,
-            id: self.try_spawn_new_task(data.resolved_id, None, true, None),
+            name: data.name.clone(),
+            id: self.try_spawn_new_task(resolved_id, None, true, None),
             kind: EntryPointKind::UserDefined,
-            file_name: data.file_name,
+            file_name: data.file_name.clone(),
           });
         }
         ModuleLoaderMsg::BuildErrors(e) => {

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -3,19 +3,18 @@ use std::sync::Arc;
 use arcstr::ArcStr;
 use futures::future::join_all;
 use rolldown_common::{
-  dynamic_import_usage::DynamicImportExportsUsage, Cache, EntryPoint, ImportKind, ModuleIdx,
-  ModuleTable, ResolvedId, RuntimeModuleBrief, SymbolRefDb,
+  dynamic_import_usage::DynamicImportExportsUsage, Cache, EntryPoint, ModuleIdx, ModuleTable,
+  ResolvedId, RuntimeModuleBrief, SymbolRefDb,
 };
-use rolldown_error::{BuildDiagnostic, BuildResult, ResultExt};
+use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_fs::OsFileSystem;
 use rolldown_plugin::SharedPluginDriver;
-use rolldown_resolver::ResolveError;
 use rustc_hash::FxHashMap;
 
 use crate::{
   module_loader::{module_loader::ModuleLoaderOutput, ModuleLoader},
   type_alias::IndexEcmaAst,
-  utils::resolve_id::resolve_id,
+  utils::load_entry_module::load_entry_module,
   SharedOptions, SharedResolver,
 };
 
@@ -97,26 +96,9 @@ impl ScanStage {
     let plugin_driver = &self.plugin_driver;
 
     let resolved_ids = join_all(self.options.input.iter().map(|input_item| async move {
-      struct Args<'a> {
-        specifier: &'a str,
-      }
+      let resolved = load_entry_module(resolver, plugin_driver, &input_item.import, None).await;
 
-      let args = Args { specifier: &input_item.import };
-      let resolved = resolve_id(
-        resolver,
-        plugin_driver,
-        args.specifier,
-        None,
-        true,
-        ImportKind::Import,
-        None,
-        Arc::default(),
-        true,
-      )
-      .await;
-
-      resolved
-        .map(|info| (args, info.map(|info| ((input_item.name.clone().map(ArcStr::from)), info))))
+      resolved.map(|info| (input_item.name.as_ref().map(Into::into), info))
     }))
     .await;
 
@@ -125,25 +107,11 @@ impl ScanStage {
     let mut errors = vec![];
 
     for resolve_id in resolved_ids {
-      let (args, resolve_id) = resolve_id?;
-
       match resolve_id {
         Ok(item) => {
-          if item.1.is_external {
-            errors.push(BuildDiagnostic::entry_cannot_be_external(item.1.id.to_string()));
-            continue;
-          }
           ret.push(item);
         }
-        Err(e) => match e {
-          ResolveError::NotFound(_) => {
-            errors.push(BuildDiagnostic::unresolved_entry(args.specifier, None));
-          }
-          ResolveError::PackagePathNotExported(..) => {
-            errors.push(BuildDiagnostic::unresolved_entry(args.specifier, Some(e)));
-          }
-          _ => return Err(e).map_err_to_unhandleable()?,
-        },
+        Err(e) => errors.push(e),
       }
     }
 

--- a/crates/rolldown/src/utils/load_entry_module.rs
+++ b/crates/rolldown/src/utils/load_entry_module.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use crate::utils::resolve_id::resolve_id;
+use crate::SharedResolver;
+use rolldown_common::{ImportKind, ResolvedId};
+use rolldown_error::ResultExt;
+use rolldown_error::{BuildDiagnostic, SingleBuildResult};
+use rolldown_plugin::SharedPluginDriver;
+use rolldown_resolver::ResolveError;
+
+pub async fn load_entry_module(
+  resolver: &SharedResolver,
+  plugin_driver: &SharedPluginDriver,
+  id: &str,
+  importer: Option<&str>,
+) -> SingleBuildResult<ResolvedId> {
+  let result = resolve_id(
+    resolver,
+    plugin_driver,
+    id,
+    importer,
+    true,
+    ImportKind::Import,
+    None,
+    Arc::default(),
+    true,
+  )
+  .await?;
+
+  match result {
+    Ok(result) => {
+      if result.is_external {
+        Err(BuildDiagnostic::entry_cannot_be_external(result.id.to_string()))
+      } else {
+        Ok(result)
+      }
+    }
+    Err(e) => match e {
+      ResolveError::NotFound(_) => Err(BuildDiagnostic::unresolved_entry(id, None)),
+      ResolveError::PackagePathNotExported(..) => {
+        Err(BuildDiagnostic::unresolved_entry(id, Some(e)))
+      }
+      _ => Err(e).map_err_to_unhandleable()?,
+    },
+  }
+}

--- a/crates/rolldown/src/utils/mod.rs
+++ b/crates/rolldown/src/utils/mod.rs
@@ -12,6 +12,7 @@ pub mod augment_chunk_hash;
 pub mod chunk;
 pub mod ecma_visitors;
 pub mod extract_meaningful_input_name_from_path;
+pub mod load_entry_module;
 pub mod load_source;
 pub mod normalize_options;
 pub mod parse_to_ecma_ast;

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -1,6 +1,5 @@
 use crate::{
-  ExtraEntryModuleData, FileNameRenderOptions, ModuleLoaderMsg, NormalizedBundlerOptions, Output,
-  OutputAsset, ResolvedId, StrOrBytes,
+  FileNameRenderOptions, ModuleLoaderMsg, NormalizedBundlerOptions, Output, OutputAsset, StrOrBytes,
 };
 use anyhow::Context;
 use arcstr::ArcStr;
@@ -38,7 +37,7 @@ pub struct FileEmitter {
   source_hash_to_reference_id: FxDashMap<ArcStr, ArcStr>,
   names: FxDashMap<ArcStr, u32>,
   files: FxDashMap<ArcStr, OutputAsset>,
-  chunks: FxDashMap<ArcStr, EmittedChunk>,
+  chunks: FxDashMap<ArcStr, Arc<EmittedChunk>>,
   base_reference_id: AtomicUsize,
   options: Arc<NormalizedBundlerOptions>,
   /// Mark the files that have been emitted to bundle.
@@ -59,11 +58,7 @@ impl FileEmitter {
     }
   }
 
-  pub async fn emit_chunk(
-    &self,
-    chunk: EmittedChunk,
-    resolved_id: ResolvedId,
-  ) -> anyhow::Result<ArcStr> {
+  pub async fn emit_chunk(&self, chunk: Arc<EmittedChunk>) -> anyhow::Result<ArcStr> {
     let reference_id = self.assign_reference_id(Some(chunk.id.as_str().into()));
     self
     .tx
@@ -73,7 +68,7 @@ impl FileEmitter {
     .context(
       "The `PluginContext.emitFile` with `type: 'chunk'` only work at `resolveId/load/transform/moduleParsed` hooks.",
     )?
-    .send(ModuleLoaderMsg::AddEntryModule(ExtraEntryModuleData { file_name: chunk.file_name.clone(), name: chunk.name.clone(), resolved_id }))
+    .send(ModuleLoaderMsg::AddEntryModule(Arc::clone(&chunk)))
     .await?;
     self.chunks.insert(reference_id.clone(), chunk);
     Ok(reference_id)

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -78,7 +78,7 @@ pub use crate::{
     runtime_module_brief::{RuntimeModuleBrief, RUNTIME_MODULE_ID},
     runtime_task_result::RuntimeModuleTaskResult,
     task_result::{EcmaRelated, NormalModuleTaskResult},
-    ExtraEntryModuleData, ModuleLoaderMsg,
+    ModuleLoaderMsg,
   },
   types::asset::Asset,
   types::asset_idx::AssetIdx,

--- a/crates/rolldown_common/src/module_loader/mod.rs
+++ b/crates/rolldown_common/src/module_loader/mod.rs
@@ -1,9 +1,10 @@
-use arcstr::ArcStr;
+use std::sync::Arc;
+
 use rolldown_error::BuildDiagnostic;
 use runtime_task_result::RuntimeModuleTaskResult;
 use task_result::NormalModuleTaskResult;
 
-use crate::ResolvedId;
+use crate::{EmittedChunk, ResolvedId};
 
 pub mod runtime_module_brief;
 pub mod runtime_task_result;
@@ -13,12 +14,6 @@ pub enum ModuleLoaderMsg {
   NormalModuleDone(NormalModuleTaskResult),
   RuntimeNormalModuleDone(RuntimeModuleTaskResult),
   FetchModule(ResolvedId),
-  AddEntryModule(ExtraEntryModuleData),
+  AddEntryModule(Arc<EmittedChunk>),
   BuildErrors(Vec<BuildDiagnostic>),
-}
-
-pub struct ExtraEntryModuleData {
-  pub file_name: Option<ArcStr>,
-  pub name: Option<ArcStr>,
-  pub resolved_id: ResolvedId,
 }

--- a/crates/rolldown_plugin/src/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context.rs
@@ -170,11 +170,7 @@ impl PluginContextImpl {
   }
 
   pub async fn emit_chunk(&self, chunk: rolldown_common::EmittedChunk) -> anyhow::Result<ArcStr> {
-    let resolved_id = self
-      .resolve(&chunk.id, chunk.importer.as_deref(), None)
-      .await?
-      .map_err(|e| anyhow::format_err!("Failed to resolve emitted chunk id: {}", e))?;
-    self.file_emitter.emit_chunk(chunk, resolved_id).await
+    self.file_emitter.emit_chunk(Arc::new(chunk)).await
   }
 
   pub fn emit_file(&self, file: rolldown_common::EmittedAsset) -> ArcStr {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Here should avoid using `PluginContext.resolve` to resolve id, it don't need to care about `skip_self` things, it will increase complex for it, ref https://github.com/rolldown/rolldown/pull/3330/files#r1915880632. 
The rollup only resolve it with `resolve_id_with_plugins`, ref https://github.com/rollup/rollup/blob/master/src/ModuleLoader.ts#L670.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
