### PR TITLE
feat(advanced-chunks): support `minModuleSize` and `maxModuleSize` options

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -352,6 +352,20 @@ impl GenerateStage<'_> {
           continue;
         }
 
+        let allow_min_module_size =
+          match_group.min_module_size.map_or(chunking_options.min_module_size, Some);
+        let allow_max_module_size =
+          match_group.max_module_size.map_or(chunking_options.max_module_size, Some);
+
+        let is_min_module_size_satisfied = allow_min_module_size
+          .map_or(true, |min_module_size| normal_module.size() >= min_module_size);
+        let is_max_module_size_satisfied = allow_max_module_size
+          .map_or(true, |max_module_size| normal_module.size() <= max_module_size);
+
+        if !is_min_module_size_satisfied || !is_max_module_size_satisfied {
+          continue;
+        }
+
         if let Some(allow_min_share_count) =
           match_group.min_share_count.map_or(chunking_options.min_share_count, Some)
         {

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -212,6 +212,8 @@ pub fn normalize_binding_options(
     advanced_chunks: output_options.advanced_chunks.map(|inner| AdvancedChunksOptions {
       min_size: inner.min_size,
       min_share_count: inner.min_share_count,
+      min_module_size: None,
+      max_module_size: None,
       groups: inner.groups.map(|inner| {
         inner
           .into_iter()
@@ -221,6 +223,8 @@ pub fn normalize_binding_options(
             priority: item.priority,
             min_size: item.min_size,
             min_share_count: item.min_share_count,
+            max_module_size: None,
+            min_module_size: None,
           })
           .collect::<Vec<_>>()
       }),

--- a/crates/rolldown_common/src/inner_bundler_options/types/advanced_chunks_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/advanced_chunks_options.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Deserializer};
 pub struct AdvancedChunksOptions {
   pub min_share_count: Option<u32>,
   pub min_size: Option<f64>,
+  pub min_module_size: Option<f64>,
+  pub max_module_size: Option<f64>,
   pub groups: Option<Vec<MatchGroup>>,
 }
 
@@ -34,6 +36,8 @@ pub struct MatchGroup {
   pub priority: Option<u32>,
   pub min_size: Option<f64>,
   pub min_share_count: Option<u32>,
+  pub min_module_size: Option<f64>,
+  pub max_module_size: Option<f64>,
 }
 
 #[cfg(feature = "deserialize_bundler_options")]

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -323,6 +323,11 @@ impl NormalModule {
       stmt_info_idx,
     });
   }
+
+  #[expect(clippy::cast_precision_loss)]
+  pub fn size(&self) -> f64 {
+    self.ecma_view.source.len() as f64
+  }
 }
 
 #[derive(Debug)]

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -72,6 +72,20 @@
             "$ref": "#/definitions/MatchGroup"
           }
         },
+        "maxModuleSize": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "minModuleSize": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
         "minShareCount": {
           "type": [
             "integer",
@@ -695,6 +709,20 @@
         "name"
       ],
       "properties": {
+        "maxModuleSize": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "minModuleSize": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
         "minShareCount": {
           "type": [
             "integer",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- It's an option for filter out modules based on their sizes.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
