### PR TITLE
chore: add a dummy version for `rolldown-tests`

### DIFF
--- a/packages/rolldown/tests/package.json
+++ b/packages/rolldown/tests/package.json
@@ -1,5 +1,6 @@
 {
   "name": "rolldown-tests",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://github.com/rolldown/rolldown/actions/runs/12871307325/job/35885093058

<img width="872" alt="image" src="https://github.com/user-attachments/assets/3f68b225-9fd1-4555-aa44-4722b112011f" />

https://github.com/pnpm/pnpm/issues/5094

pnpm requires a version field even on private packages.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
