### PR TITLE
fix: should not set default value for treeshake in cli normalization

### DIFF
--- a/packages/rolldown/src/parse-ast-index.ts
+++ b/packages/rolldown/src/parse-ast-index.ts
@@ -56,7 +56,7 @@ function normalizeParseError(
       e.message +
       '\n' +
       e.labels
-        .map((label) => {
+        .map((label: any) => {
           const location = locate(sourceText, label.start, { offsetLine: 1 })
           if (!location) {
             return

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -256,7 +256,7 @@ const InputCliOverrideSchema = v.strictObject({
     v.description('Inject import statements on demand'),
   ),
   treeshake: v.pipe(
-    v.optional(v.boolean(), true),
+    v.optional(v.boolean()),
     v.description('enable treeshaking'),
   ),
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Close #3392
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
