### PR TITLE
fix: force cjs wrapper to be included in the output

### DIFF
--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -163,7 +163,7 @@ pub fn create_wrapper(
         } else {
           runtime.resolve_symbol("__commonJSMin").into()
         }],
-        side_effect: false,
+        side_effect: true,
         is_included: false,
         import_records: Vec::new(),
         debug_label: None,

--- a/crates/rolldown/tests/rolldown/issues/3367/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/3367/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.mjs"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/3367/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3367/artifacts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Assets
+
+## main.js
+
+```js
+
+
+//#region foo.js
+var require_foo = __commonJS({ "foo.js"(exports, module) {
+	module.exports = {};
+} });
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/issues/3367/foo.js
+++ b/crates/rolldown/tests/rolldown/issues/3367/foo.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/crates/rolldown/tests/rolldown/issues/3367/main.mjs
+++ b/crates/rolldown/tests/rolldown/issues/3367/main.mjs
@@ -1,0 +1,5 @@
+import './foo';
+
+if (false) {
+  foo.readFileSync();
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4564,6 +4564,10 @@ snapshot_kind: text
 - main2-!~{001}~.js => main2-Df1wJ9Xg.js
 - chunk-!~{002}~.js => chunk-CTfjR5yn.js
 
+# tests/rolldown/issues/3367
+
+- main-!~{000}~.js => main-CmNHUIHc.js
+
 # tests/rolldown/issues/376
 
 - main-!~{000}~.js => main-CfuHZZW7.js


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/rolldown/rolldown/issues/3367.

It's a problem due to https://github.com/rolldown/rolldown/pull/3343.

- Since `import 'cjs'` is consider removed in the final output, so it doesn't reference the `wrap_ref` anymore. It causes the `StmtInfo` that owns `wrap_ref` being not included in the treeshaking phase so that the `wrapping` behavior is gone.
- This PR, by making the `StmtInfo` that owns `wrap_ref` having side effect, fix the issue.



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
