### PR TITLE
fix: shouldn't generate unused `__toESM` calls

### DIFF
--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_common_js/artifacts.snap
@@ -14,7 +14,6 @@ var require_demo_pkg = __commonJS({ "node_modules/demo-pkg/index.js"(exports) {
 	exports.foo = 123;
 	console.log("hello");
 } });
-var import_demo_pkg = __toESM(require_demo_pkg());
 
 //#endregion
 //#region src/entry.js

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_common_js/bypass.md
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_common_js/bypass.md
@@ -26,7 +26,6 @@ var require_demo_pkg = __commonJS({ "node_modules/demo-pkg/index.js"(exports) {
 	exports.foo = 123;
 	console.log("hello");
 } });
-var import_demo_pkg = __toESM(require_demo_pkg());
 
 //#endregion
 //#region src/entry.js
@@ -40,7 +39,7 @@ console.log("unused import");
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	src_entry.js
-@@ -1,8 +1,9 @@
+@@ -1,6 +1,6 @@
  var require_demo_pkg = __commonJS({
 -    "Users/user/project/node_modules/demo-pkg/index.js"(exports) {
 +    "node_modules/demo-pkg/index.js"(exports) {
@@ -48,8 +47,5 @@ console.log("unused import");
          console.log("hello");
      }
  });
-+var import_demo_pkg = __toESM(require_demo_pkg());
- require_demo_pkg();
- console.log("unused import");
 
 ```

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_true_keep_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_true_keep_common_js/artifacts.snap
@@ -14,7 +14,6 @@ var require_demo_pkg = __commonJS({ "node_modules/demo-pkg/index.js"(exports) {
 	exports.foo = 123;
 	console.log("hello");
 } });
-var import_demo_pkg = __toESM(require_demo_pkg());
 
 //#endregion
 //#region src/entry.js

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_true_keep_common_js/bypass.md
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_true_keep_common_js/bypass.md
@@ -25,7 +25,6 @@ var require_demo_pkg = __commonJS({ "node_modules/demo-pkg/index.js"(exports) {
 	exports.foo = 123;
 	console.log("hello");
 } });
-var import_demo_pkg = __toESM(require_demo_pkg());
 
 //#endregion
 //#region src/entry.js
@@ -38,7 +37,7 @@ console.log("unused import");
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	src_entry.js
-@@ -1,6 +1,6 @@
+@@ -1,8 +1,7 @@
  var require_demo_pkg = __commonJS({
 -    "Users/user/project/node_modules/demo-pkg/index.js"(exports) {
 +    "node_modules/demo-pkg/index.js"(exports) {
@@ -46,5 +45,7 @@ console.log("unused import");
          console.log("hello");
      }
  });
+-var import_demo_pkg = __toESM(require_demo_pkg());
+ console.log("unused import");
 
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
@@ -17,7 +17,6 @@ var init_something = __esm({ "something.js"() {} });
 var require_c = __commonJS({ "c.js"() {
 	await 0;
 } });
-var import_c = __toESM(require_c());
 
 //#endregion
 //#region b.js

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/artifacts.snap
@@ -21,7 +21,6 @@ snapshot_kind: text
 
 //#region c.js
 var require_c = __commonJS({ "c.js"() {} });
-var import_c = __toESM(require_c());
 
 //#endregion
 //#region b.js

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/bypass.md
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/bypass.md
@@ -52,7 +52,6 @@
 
 //#region c.js
 var require_c = __commonJS({ "c.js"() {} });
-var import_c = __toESM(require_c());
 
 //#endregion
 //#region b.js
@@ -83,7 +82,7 @@ return require_entry();
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,31 +1,23 @@
+@@ -1,31 +1,22 @@
 -(() => {
 -    var c_exports = {};
 -    var init_c = __esm({
@@ -94,7 +93,6 @@ return require_entry();
 +    var require_c = __commonJS({
 +        "c.js"() {}
      });
-+    var import_c = __toESM(require_c());
      var b_exports = {};
      var init_b = __esm({
 -        "b.js"() {

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_unused/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_unused/artifacts.snap
@@ -14,7 +14,6 @@ import assert from "node:assert";
 var require_foo = __commonJS({ "foo.js"(exports) {
 	exports.foo = 123;
 } });
-var import_foo = __toESM(require_foo());
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_unused/bypass.md
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_unused/bypass.md
@@ -26,7 +26,6 @@ import assert from "node:assert";
 var require_foo = __commonJS({ "foo.js"(exports) {
 	exports.foo = 123;
 } });
-var import_foo = __toESM(require_foo());
 
 //#endregion
 //#region entry.js
@@ -40,13 +39,12 @@ assert.equal(foo, 234);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -2,7 +2,7 @@
+@@ -2,7 +2,6 @@
      "foo.js"(exports) {
          exports.foo = 123;
      }
  });
 -var ns = __toESM(require_foo());
-+var import_foo = __toESM(require_foo());
  var foo = 234;
  console.log(foo);
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/exoprt_star_of_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/exoprt_star_of_cjs/artifacts.snap
@@ -13,7 +13,6 @@ snapshot_kind: text
 var require_c = __commonJS({ "c.js"(exports) {
 	exports.test = 1e3;
 } });
-var import_c = __toESM(require_c());
 
 //#endregion
 //#region b.js

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import/artifacts.snap
@@ -14,7 +14,6 @@ import assert from "node:assert";
 var require_commonjs = __commonJS({ "commonjs.js"(exports) {
 	exports.a = 1;
 } });
-var import_commonjs = __toESM(require_commonjs());
 
 //#endregion
 //#region proxy.js

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import/artifacts.snap
@@ -14,14 +14,12 @@ import assert from "node:assert";
 var require_commonjs = __commonJS({ "commonjs.js"(exports) {
 	exports.a = 1;
 } });
-var import_commonjs = __toESM(require_commonjs());
 
 //#endregion
 //#region commonjs2.js
 var require_commonjs2 = __commonJS({ "commonjs2.js"(exports) {
 	exports.a = 2;
 } });
-var import_commonjs2 = __toESM(require_commonjs2());
 
 //#endregion
 //#region proxy.js

--- a/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
@@ -33,7 +33,6 @@ module.exports = 1;
 //#endregion
 //#region foo.js
 var require_foo = __commonJS({ "foo.js"() {} });
-var import_foo = __toESM(require_foo());
 
 //#endregion
 //#region esm-export-cjs-require.js
@@ -44,7 +43,6 @@ require_foo();
 var require_esm_import_cjs_export = __commonJS({ "esm-import-cjs-export.js"(exports, module) {
 	module.exports = 1;
 } });
-var import_esm_import_cjs_export = __toESM(require_esm_import_cjs_export());
 
 //#endregion
 //#region cjs.js
@@ -70,20 +68,20 @@ assert.equal(import_cjs.a, undefined);
 (0:7) "exports = " --> (29:7) "exports = "
 (0:17) "1;\n" --> (29:17) "1;\n"
 - ../esm-export-cjs-require.js
-(0:0) "require('./foo')\n" --> (38:0) "require_foo();\n"
+(0:0) "require('./foo')\n" --> (37:0) "require_foo();\n"
 - ../esm-import-cjs-export.js
-(1:0) "module." --> (43:0) "\tmodule."
-(1:7) "exports = " --> (43:8) "exports = "
-(1:17) "1" --> (43:18) "1;\n"
+(1:0) "module." --> (42:0) "\tmodule."
+(1:7) "exports = " --> (42:8) "exports = "
+(1:17) "1" --> (42:18) "1;\n"
 - ../cjs.js
-(0:0) "module." --> (50:0) "\tmodule."
-(0:7) "exports = " --> (50:8) "exports = "
-(0:17) "1;" --> (50:18) "1;\n"
+(0:0) "module." --> (48:0) "\tmodule."
+(0:7) "exports = " --> (48:8) "exports = "
+(0:17) "1;" --> (48:18) "1;\n"
 - ../esm-import-cjs-require.js
-(2:0) "require('./foo')\n" --> (56:0) "require_foo();\n"
-(3:0) "assert." --> (57:0) "assert."
-(3:7) "equal(" --> (57:7) "equal("
-(3:13) "a, " --> (57:13) "import_cjs.a, "
-(3:16) "undefined)" --> (57:27) "undefined)"
-(3:26) "\n" --> (57:37) ";\n"
+(2:0) "require('./foo')\n" --> (54:0) "require_foo();\n"
+(3:0) "assert." --> (55:0) "assert."
+(3:7) "equal(" --> (55:7) "equal("
+(3:13) "a, " --> (55:13) "import_cjs.a, "
+(3:16) "undefined)" --> (55:27) "undefined)"
+(3:26) "\n" --> (55:37) ";\n"
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/multiple_circle_cjs_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/multiple_circle_cjs_entries/artifacts.snap
@@ -21,14 +21,12 @@ export default require_a();
 var require_b = __commonJS({ "b.js"(exports, module) {
 	module.exports = "b";
 } });
-var import_b = __toESM(require_b());
 
 //#endregion
 //#region a.js
 var require_a = __commonJS({ "a.js"(exports, module) {
 	module.exports = "a";
 } });
-var import_a = __toESM(require_a());
 
 //#endregion
 export { require_a, require_b };

--- a/crates/rolldown/tests/rolldown/issues/2903_4/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2903_4/artifacts.snap
@@ -16,12 +16,6 @@ Object.defineProperty(exports, '__commonJS', {
     return __commonJS;
   }
 });
-Object.defineProperty(exports, '__toESM', {
-  enumerable: true,
-  get: function () {
-    return __toESM;
-  }
-});
 ```
 ## main.js
 
@@ -32,7 +26,6 @@ const require_chunk = require('./chunk.js');
 var require_cjs_dep = require_chunk.__commonJS({ "cjs-dep.js"(exports, module) {
 	module.exports = console.log("cjs-dep");
 } });
-var import_cjs_dep = require_chunk.__toESM(require_cjs_dep());
 
 //#endregion
 ```
@@ -45,7 +38,6 @@ const require_chunk = require('./chunk.js');
 var require_cjs_dep2 = require_chunk.__commonJS({ "cjs-dep2.js"(exports, module) {
 	module.exports = console.log("cjs-dep2");
 } });
-var import_cjs_dep2 = require_chunk.__toESM(require_cjs_dep2());
 
 //#endregion
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -390,7 +390,7 @@ snapshot_kind: text
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_common_js
 
-- src_entry-!~{000}~.js => src_entry-CTlSlzwS.js
+- src_entry-!~{000}~.js => src_entry-C1_bM_IH.js
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6
 
@@ -455,7 +455,7 @@ snapshot_kind: text
 
 # tests/esbuild/dce/package_json_side_effects_true_keep_common_js
 
-- src_entry-!~{000}~.js => src_entry-CzVovYe7.js
+- src_entry-!~{000}~.js => src_entry-BuZUgjf8.js
 
 # tests/esbuild/dce/package_json_side_effects_true_keep_es6
 
@@ -1699,11 +1699,11 @@ snapshot_kind: text
 
 # tests/esbuild/default/top_level_await_forbidden_require
 
-- entry-!~{000}~.js => entry-DyyBMBkV.js
+- entry-!~{000}~.js => entry-bg0ZuHRM.js
 
 # tests/esbuild/default/top_level_await_forbidden_require_dead_branch
 
-- entry-!~{000}~.js => entry-BYpXJ55m.js
+- entry-!~{000}~.js => entry-CjA06sAA.js
 
 # tests/esbuild/default/top_level_await_iife_dead_branch
 
@@ -1964,7 +1964,7 @@ snapshot_kind: text
 
 # tests/esbuild/importstar/import_star_common_js_unused
 
-- entry-!~{000}~.js => entry-DedZYym4.js
+- entry-!~{000}~.js => entry-DWljR0-a.js
 
 # tests/esbuild/importstar/import_star_export_import_star_capture
 
@@ -3696,7 +3696,7 @@ snapshot_kind: text
 
 # tests/rolldown/cjs_compat/exoprt_star_of_cjs
 
-- main-!~{000}~.js => main-CwRNmve4.js
+- main-!~{000}~.js => main-C2u52yTr.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
 
@@ -3708,11 +3708,11 @@ snapshot_kind: text
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
 
-- main-!~{000}~.js => main-C7Stnvyg.js
+- main-!~{000}~.js => main-DzxePG0p.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
 
-- main-!~{000}~.js => main-CgnYM4l8.js
+- main-!~{000}~.js => main-C-Ar6s-k.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
 
@@ -3732,14 +3732,14 @@ snapshot_kind: text
 
 # tests/rolldown/cjs_compat/mix-cjs-esm
 
-- main-!~{000}~.js => main-CHsy3Qsk.js
-- main-CHsy3Qsk.js.map
+- main-!~{000}~.js => main-QyMkrf0L.js
+- main-QyMkrf0L.js.map
 
 # tests/rolldown/cjs_compat/multiple_circle_cjs_entries
 
-- a-!~{000}~.js => a-CJh1wGYA.js
-- b-!~{001}~.js => b-CZKqeSHa.js
-- a-!~{002}~.js => a-DMz6_JJ1.js
+- a-!~{000}~.js => a-BmyHgSN5.js
+- b-!~{001}~.js => b-DFfZhfD4.js
+- a-!~{002}~.js => a-BFQkvuGY.js
 
 # tests/rolldown/cjs_compat/node_module_commonjs
 
@@ -4560,9 +4560,9 @@ snapshot_kind: text
 
 # tests/rolldown/issues/2903_4
 
-- main-!~{000}~.js => main-NdJAqb49.js
-- main2-!~{001}~.js => main2-Df1wJ9Xg.js
-- chunk-!~{002}~.js => chunk-CTfjR5yn.js
+- main-!~{000}~.js => main-CFIqMfxf.js
+- main2-!~{001}~.js => main2-D_QQV5U8.js
+- chunk-!~{002}~.js => chunk-CiU4nd6f.js
 
 # tests/rolldown/issues/3367
 

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -282,7 +282,6 @@ impl NormalModule {
       declared_symbols: vec![esm_namespace_ref_derived_from_module_exports],
       referenced_symbols: vec![wrap_ref.into(), runtime_module.resolve_symbol("__toESM").into()],
       debug_label: Some("esm_namespace_ref_derived_from_module_exports".to_string()),
-      side_effect: true,
       ..Default::default()
     });
 
@@ -302,7 +301,7 @@ impl NormalModule {
     runtime_module: &RuntimeModuleBrief,
     wrap_ref: SymbolRef,
   ) {
-    if self.esm_namespace_in_cjs.is_some() {
+    if self.esm_namespace_in_cjs_node_mode.is_some() {
       return;
     }
     let esm_namespace_ref_derived_from_module_exports = symbol_db.create_facade_root_symbol_ref(
@@ -314,7 +313,7 @@ impl NormalModule {
       stmt_idx: None,
       declared_symbols: vec![esm_namespace_ref_derived_from_module_exports],
       referenced_symbols: vec![wrap_ref.into(), runtime_module.resolve_symbol("__toESM").into()],
-      debug_label: Some("esm_namespace_ref_derived_from_module_exports".to_string()),
+      debug_label: Some("esm_namespace_ref_derived_from_module_exports node".to_string()),
       ..Default::default()
     });
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/rolldown/rolldown/issues/3359

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
