### PR TITLE
fix(splitting): indirect external symbol

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -554,7 +554,14 @@ impl BindImportsAndExportsContext<'_> {
 
       let rec = &module.import_records[named_import.record_id];
       let is_external = matches!(self.index_modules[rec.resolved_module], Module::External(_));
-      if is_esm && is_external {
+
+      if is_esm
+        && is_external
+        && self.metas[module_id]
+          .resolved_exports
+          .iter()
+          .all(|(_, resolved_export)| resolved_export.symbol_ref != *imported_as_ref)
+      {
         if let Specifier::Literal(ref name) = named_import.imported {
           self
             .external_import_binding_merger

--- a/crates/rolldown/tests/esbuild/default/forbid_string_export_names_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/forbid_string_export_names_no_bundle/artifacts.snap
@@ -8,11 +8,11 @@ snapshot_kind: text
 
 ```js
 import * as name_space from "./foo";
-import { 'name 1' as name_1, 'same name' as same_name } from "./foo";
+import { 'name 1' as name_2, 'same name' as same_name } from "./foo";
 
 //#region entry.js
 let ok = true;
 
 //#endregion
-export { name_1 as 'name 2', name_space as 'name space', ok as 'not ok', ok, same_name as 'same name' };
+export { name_2 as 'name 2', name_space as 'name space', ok as 'not ok', ok, same_name as 'same name' };
 ```

--- a/crates/rolldown/tests/esbuild/default/forbid_string_import_names_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/forbid_string_import_names_bundle/artifacts.snap
@@ -21,7 +21,7 @@ snapshot_kind: text
 ## entry.js
 
 ```js
-import { 'some import' as some_import } from "external";
+import { 'some import' as nested } from "external";
 
-export { some_import as nested };
+export { nested };
 ```

--- a/crates/rolldown/tests/esbuild/default/forbid_string_import_names_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/forbid_string_import_names_no_bundle/artifacts.snap
@@ -7,11 +7,11 @@ snapshot_kind: text
 ## entry.js
 
 ```js
-import { 'an import' as an_import, 'another import' as another_import } from "./foo";
+import { 'an import' as an_import, 'another import' as an_export } from "./foo";
 
 //#region entry.js
 an_import();
 
 //#endregion
-export { another_import as 'an export' };
+export { an_export as 'an export' };
 ```

--- a/crates/rolldown/tests/rolldown/function/external/export_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/export_external/artifacts.snap
@@ -9,15 +9,15 @@ snapshot_kind: text
 ```js
 import * as ext1 from "external";
 import * as ext from "external";
-import { a, b } from "external";
+import { a, a as a$1, a as a1, b, b as b$1, b as b1 } from "external";
 
 //#region foo.js
-const a1 = 1;
-console.log(a1);
+const a1$1 = 1;
+console.log(a1$1);
 
 //#endregion
 //#region main.js
-console.log(ext, a, b, ext1, a, b);
+console.log(ext, a1, b1, ext1, a$1, b$1);
 
 //#endregion
 export { a, b };

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/_config.json
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/_config.json
@@ -1,0 +1,5 @@
+{
+    "config": {
+        "external": ["node:fs"]
+    }
+}

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/artifacts.snap
@@ -23,6 +23,11 @@ export { read };
 ```js
 import { read } from "./indirect2.js";
 
+//#region read.js
+const read$1 = 1;
+console.log(read$1);
+
+//#endregion
 //#region main.js
 console.log(read);
 import("./indirect.js");

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/artifacts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Assets
+
+## indirect.js
+
+```js
+import { read } from "./indirect2.js";
+
+export { read };
+```
+## indirect2.js
+
+```js
+import { read } from "node:fs";
+
+export { read };
+```
+## main.js
+
+```js
+import { read } from "./indirect2.js";
+
+//#region main.js
+console.log(read);
+import("./indirect.js");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/indirect.js
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/indirect.js
@@ -1,0 +1,1 @@
+export { read } from "node:fs";

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/main.js
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/main.js
@@ -1,0 +1,5 @@
+import { read } from './indirect'
+
+console.log(read)
+
+import('./indirect')

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/main.js
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/main.js
@@ -1,4 +1,5 @@
 import { read } from './indirect'
+import "./read";
 
 console.log(read)
 

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/read.js
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/read.js
@@ -1,0 +1,2 @@
+const read = 1;
+console.log(read);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4131,7 +4131,7 @@ snapshot_kind: text
 
 # tests/rolldown/function/external/splitting_indirect_external_symbol
 
-- main-!~{002}~.js => main-o2wyWrFD.js
+- main-!~{002}~.js => main-DN6hqTye.js
 - indirect-!~{003}~.js => indirect-C8E1UGaS.js
 - indirect-!~{000}~.js => indirect-DRby1-0L.js
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -875,15 +875,15 @@ snapshot_kind: text
 
 # tests/esbuild/default/forbid_string_export_names_no_bundle
 
-- entry-!~{000}~.js => entry-DL-6Pfck.js
+- entry-!~{000}~.js => entry-tCArwM3B.js
 
 # tests/esbuild/default/forbid_string_import_names_bundle
 
-- entry-!~{000}~.js => entry-BxM_7lX3.js
+- entry-!~{000}~.js => entry-D-RVKiCJ.js
 
 # tests/esbuild/default/forbid_string_import_names_no_bundle
 
-- entry-!~{000}~.js => entry-Dnm4H9T8.js
+- entry-!~{000}~.js => entry-Dx4EArSC.js
 
 # tests/esbuild/default/hashbang_banner_use_strict_order
 
@@ -4115,7 +4115,7 @@ snapshot_kind: text
 
 # tests/rolldown/function/external/export_external
 
-- main-!~{000}~.js => main-CxwuX0jJ.js
+- main-!~{000}~.js => main-bboG_iKl.js
 
 # tests/rolldown/function/external/implicit_import_external
 
@@ -4128,6 +4128,12 @@ snapshot_kind: text
 # tests/rolldown/function/external/keep_import_external_order
 
 - main-!~{000}~.js => main-DOm1fgFc.js
+
+# tests/rolldown/function/external/splitting_indirect_external_symbol
+
+- main-!~{002}~.js => main-o2wyWrFD.js
+- indirect-!~{003}~.js => indirect-C8E1UGaS.js
+- indirect-!~{000}~.js => indirect-DRby1-0L.js
 
 # tests/rolldown/function/external/splitting_with_external_module
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix nuxt + rolldown crashes at crates/rolldown_common/src/types/symbol_ref_db.rs, ref https://github.com/vitejs/vite-ecosystem-ci/blob/rolldown-vite/README-temp.md#nuxt.

The issue happened because we merge all external symbol to one, but not consider the exported external symbol is could split, the referenced external symbol is used other chunks exported symbols, the symbol is not deconflicted at importer chunk.

The pr intend to avoid connecting cross module symbols from external modules, it will ensure correctness for calculate cross  module symbols. Here is a [esbuild repl](https://hyrious.me/esbuild-repl/?version=0.24.0&b=e%00entry.js%00import+%7B+read+%7D+from+%27.%2Findirect%27%0A%0Aconsole.log%28read%29%0A%0Aimport%28%27.%2Findirect%27%29&b=%00indirect.js%00export+%7B+read+%7D+from+%22node%3Aassert%22%3B&o=%7B%0A++bundle%3A+true%2C%0A++outdir%3A+%27dist%27%2C%0A++external%3A+%5B%27node%3Aassert%27%5D%2C%0A++format%3A+%27esm%27%2C%0A++keepNames%3A+true%2C%0A++splitting%3A+true%0A%7D). It meaning we only merge import symbols from external modules, if it is exported, it can't be merged.



<br class="Apple-interchange-newline">

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
