### PR TITLE
feat: PluginContext.getFileName using emitted chunk reference id

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -240,6 +240,7 @@ impl ModuleLoader {
         id: self.try_spawn_new_task(info, None, true, None),
         kind: EntryPointKind::UserDefined,
         file_name: None,
+        reference_id: None,
       })
       .inspect(|e| {
         user_defined_entry_ids.insert(e.id);
@@ -360,7 +361,8 @@ impl ModuleLoader {
         ModuleLoaderMsg::FetchModule(resolve_id) => {
           self.try_spawn_new_task(resolve_id, None, false, None);
         }
-        ModuleLoaderMsg::AddEntryModule(data) => {
+        ModuleLoaderMsg::AddEntryModule(msg) => {
+          let data = msg.chunk;
           let result = load_entry_module(
             &self.shared_context.resolver,
             &self.shared_context.plugin_driver,
@@ -376,10 +378,11 @@ impl ModuleLoader {
             }
           };
           extra_entry_points.push(EntryPoint {
-            name: data.name.clone(),
+            name: data.name,
             id: self.try_spawn_new_task(resolved_id, None, true, None),
             kind: EntryPointKind::UserDefined,
-            file_name: data.file_name.clone(),
+            file_name: data.file_name,
+            reference_id: Some(msg.reference_id),
           });
         }
         ModuleLoaderMsg::BuildErrors(e) => {
@@ -458,6 +461,7 @@ impl ModuleLoader {
         id,
         kind: EntryPointKind::DynamicImport,
         file_name: None,
+        reference_id: None,
       }));
     }
 

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -378,10 +378,10 @@ impl ModuleLoader {
             }
           };
           extra_entry_points.push(EntryPoint {
-            name: data.name,
+            name: data.name.clone(),
             id: self.try_spawn_new_task(resolved_id, None, true, None),
             kind: EntryPointKind::UserDefined,
-            file_name: data.file_name,
+            file_name: data.file_name.clone(),
             reference_id: Some(msg.reference_id),
           });
         }

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -52,6 +52,7 @@ impl GenerateStage<'_> {
       };
       let chunk = chunk_graph.add_chunk(Chunk::new(
         entry_point.name.clone(),
+        entry_point.reference_id.clone(),
         entry_point.file_name.clone(),
         bits.clone(),
         vec![],
@@ -102,7 +103,7 @@ impl GenerateStage<'_> {
       if let Some(chunk_id) = bits_to_chunk.get(bits).copied() {
         chunk_graph.add_module_to_chunk(normal_module.idx, chunk_id);
       } else {
-        let chunk = Chunk::new(None, None, bits.clone(), vec![], ChunkKind::Common);
+        let chunk = Chunk::new(None, None, None, bits.clone(), vec![], ChunkKind::Common);
         let chunk_id = chunk_graph.add_chunk(chunk);
         chunk_graph.add_module_to_chunk(normal_module.idx, chunk_id);
         bits_to_chunk.insert(bits.clone(), chunk_id);
@@ -493,6 +494,7 @@ impl GenerateStage<'_> {
 
       let chunk = Chunk::new(
         Some(this_module_group.name.clone()),
+        None,
         None,
         index_splitting_info
           [this_module_group.modules.iter().next().copied().expect("must have one")]

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -138,12 +138,12 @@ pub fn finalize_assets(
         StrOrBytes::Bytes(_content) => {}
       }
 
-      asset.finalize(filename.to_string())
+      asset.finalize(filename)
     })
     .collect::<Vec<_>>()
     .into();
 
-  let index_asset_to_filename: IndexVec<AssetIdx, String> =
+  let index_asset_to_filename: IndexVec<AssetIdx, ArcStr> =
     assets.iter().map(|asset| asset.filename.clone()).collect::<Vec<_>>().into();
 
   assets.par_iter_mut().for_each(|asset| {
@@ -153,14 +153,14 @@ pub fn finalize_assets(
         .cross_chunk_imports
         .iter()
         .flat_map(|importee_idx| &index_chunk_to_assets[*importee_idx])
-        .map(|importee_asset_idx| index_asset_to_filename[*importee_asset_idx].clone().into())
+        .map(|importee_asset_idx| index_asset_to_filename[*importee_asset_idx].clone())
         .collect();
 
       ecma_meta.rendered_chunk.dynamic_imports = chunk
         .cross_chunk_dynamic_imports
         .iter()
         .flat_map(|importee_idx| &index_chunk_to_assets[*importee_idx])
-        .map(|importee_asset_idx| index_asset_to_filename[*importee_asset_idx].clone().into())
+        .map(|importee_asset_idx| index_asset_to_filename[*importee_asset_idx].clone())
         .collect();
     }
   });

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -29,8 +29,10 @@ pub struct Chunk {
   pub kind: ChunkKind,
   pub modules: Vec<ModuleIdx>,
   pub name: Option<ArcStr>,
-  // emit_chunk specifed filename
+  // emitted chunk specified filename, used to generate chunk filename
   pub file_name: Option<ArcStr>,
+  // emitted chunk corresponding reference_id, used to `PluginContext#getFileName` to search the emitted chunk name
+  pub reference_id: Option<ArcStr>,
   pub pre_rendered_chunk: Option<RollupPreRenderedChunk>,
   pub preliminary_filename: Option<PreliminaryFilename>,
   pub absolute_preliminary_filename: Option<String>,
@@ -55,12 +57,22 @@ pub struct Chunk {
 impl Chunk {
   pub fn new(
     name: Option<ArcStr>,
+    reference_id: Option<ArcStr>,
     file_name: Option<ArcStr>,
     bits: BitSet,
     modules: Vec<ModuleIdx>,
     kind: ChunkKind,
   ) -> Self {
-    Self { exec_order: u32::MAX, modules, name, file_name, bits, kind, ..Self::default() }
+    Self {
+      exec_order: u32::MAX,
+      modules,
+      name,
+      file_name,
+      reference_id,
+      bits,
+      kind,
+      ..Self::default()
+    }
   }
 
   pub fn has_side_effect(&self, runtime_id: ModuleIdx) -> bool {

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -69,7 +69,7 @@ pub use crate::{
     module_idx::ModuleIdx,
     node_builtin_modules::is_existing_node_builtin_modules,
   },
-  file_emitter::{EmittedAsset, EmittedChunk, FileEmitter, SharedFileEmitter},
+  file_emitter::{EmittedAsset, EmittedChunk, EmittedChunkInfo, FileEmitter, SharedFileEmitter},
   module::{
     external_module::ExternalModule,
     normal_module::{ModuleRenderArgs, NormalModule},
@@ -79,7 +79,7 @@ pub use crate::{
     runtime_module_brief::{RuntimeModuleBrief, RUNTIME_MODULE_ID},
     runtime_task_result::RuntimeModuleTaskResult,
     task_result::{EcmaRelated, NormalModuleTaskResult},
-    ModuleLoaderMsg,
+    AddEntryModuleMsg, ModuleLoaderMsg,
   },
   types::asset::Asset,
   types::asset_idx::AssetIdx,

--- a/crates/rolldown_common/src/module_loader/mod.rs
+++ b/crates/rolldown_common/src/module_loader/mod.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-
+use arcstr::ArcStr;
 use rolldown_error::BuildDiagnostic;
 use runtime_task_result::RuntimeModuleTaskResult;
 use task_result::NormalModuleTaskResult;
@@ -14,6 +13,11 @@ pub enum ModuleLoaderMsg {
   NormalModuleDone(NormalModuleTaskResult),
   RuntimeNormalModuleDone(RuntimeModuleTaskResult),
   FetchModule(ResolvedId),
-  AddEntryModule(Arc<EmittedChunk>),
+  AddEntryModule(AddEntryModuleMsg),
   BuildErrors(Vec<BuildDiagnostic>),
+}
+
+pub struct AddEntryModuleMsg {
+  pub chunk: EmittedChunk,
+  pub reference_id: ArcStr,
 }

--- a/crates/rolldown_common/src/module_loader/mod.rs
+++ b/crates/rolldown_common/src/module_loader/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arcstr::ArcStr;
 use rolldown_error::BuildDiagnostic;
 use runtime_task_result::RuntimeModuleTaskResult;
@@ -18,6 +20,6 @@ pub enum ModuleLoaderMsg {
 }
 
 pub struct AddEntryModuleMsg {
-  pub chunk: EmittedChunk,
+  pub chunk: Arc<EmittedChunk>,
   pub reference_id: ArcStr,
 }

--- a/crates/rolldown_common/src/types/asset.rs
+++ b/crates/rolldown_common/src/types/asset.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use arcstr::ArcStr;
 use rolldown_sourcemap::SourceMap;
 
 use crate::{ChunkIdx, InstantiationKind, PreliminaryFilename, StrOrBytes};
@@ -14,5 +15,5 @@ pub struct Asset {
   pub augment_chunk_hash: Option<String>,
   pub file_dir: PathBuf,
   pub preliminary_filename: PreliminaryFilename,
-  pub filename: String,
+  pub filename: ArcStr,
 }

--- a/crates/rolldown_common/src/types/entry_point.rs
+++ b/crates/rolldown_common/src/types/entry_point.rs
@@ -7,7 +7,10 @@ pub struct EntryPoint {
   pub name: Option<ArcStr>,
   pub id: ModuleIdx,
   pub kind: EntryPointKind,
+  // emitted chunk specified filename, used to generate chunk filename
   pub file_name: Option<ArcStr>,
+  // emitted chunk corresponding reference_id, used to `PluginContext#getFileName` to search the emitted chunk name
+  pub reference_id: Option<ArcStr>,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]

--- a/crates/rolldown_common/src/types/instantiated_chunk.rs
+++ b/crates/rolldown_common/src/types/instantiated_chunk.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use arcstr::ArcStr;
 use rolldown_sourcemap::SourceMap;
 
 use crate::{Asset, ChunkIdx, InstantiationKind, PreliminaryFilename, StrOrBytes};
@@ -18,7 +19,7 @@ pub struct InstantiatedChunk {
 }
 
 impl InstantiatedChunk {
-  pub fn finalize(self, filename: String) -> Asset {
+  pub fn finalize(self, filename: ArcStr) -> Asset {
     Asset {
       origin_chunk: self.origin_chunk,
       content: self.content,

--- a/crates/rolldown_plugin/src/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context.rs
@@ -170,7 +170,7 @@ impl PluginContextImpl {
   }
 
   pub async fn emit_chunk(&self, chunk: rolldown_common::EmittedChunk) -> anyhow::Result<ArcStr> {
-    self.file_emitter.emit_chunk(Arc::new(chunk)).await
+    self.file_emitter.emit_chunk(chunk).await
   }
 
   pub fn emit_file(

--- a/crates/rolldown_plugin/src/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context.rs
@@ -170,7 +170,7 @@ impl PluginContextImpl {
   }
 
   pub async fn emit_chunk(&self, chunk: rolldown_common::EmittedChunk) -> anyhow::Result<ArcStr> {
-    self.file_emitter.emit_chunk(chunk).await
+    self.file_emitter.emit_chunk(Arc::new(chunk)).await
   }
 
   pub fn emit_file(

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-chunk/_config.ts
@@ -1,43 +1,69 @@
 // cSpell:disable
 import { defineTest } from 'rolldown-tests'
-import { getOutputFileNames } from 'rolldown-tests/utils'
 import { expect } from 'vitest'
+
+let mainWithNameChunkReferenceId: string,
+  mainWithFileNameChunkReferenceId: string,
+  runOnceRenderChunk = false
+const emittedChunkPreliminaryFilenames: string[] = [],
+  emittedChunkFilenames: string[] = []
 
 export default defineTest({
   skipComposingJsPlugin: true,
   config: {
     output: {
-      entryFileNames: '[name].js',
-      chunkFileNames: '[name]-[hash].js',
+      entryFileNames: '[name].[hash].js',
     },
     plugins: [
       {
         name: 'test-plugin-context',
         buildStart() {
-          this.emitFile({
+          mainWithNameChunkReferenceId = this.emitFile({
             type: 'chunk',
             name: 'main-with-name',
             id: './main.js',
           })
-          this.emitFile({
+          mainWithFileNameChunkReferenceId = this.emitFile({
             type: 'chunk',
             fileName: 'main-with-fileName.js',
             id: './main.js',
           })
         },
+        renderChunk() {
+          if (runOnceRenderChunk) {
+            return
+          }
+          runOnceRenderChunk = true
+          emittedChunkPreliminaryFilenames.push(
+            this.getFileName(mainWithNameChunkReferenceId),
+          )
+          emittedChunkPreliminaryFilenames.push(
+            this.getFileName(mainWithFileNameChunkReferenceId),
+          )
+        },
+        generateBundle() {
+          emittedChunkFilenames.push(
+            this.getFileName(mainWithNameChunkReferenceId),
+          )
+          emittedChunkFilenames.push(
+            this.getFileName(mainWithFileNameChunkReferenceId),
+          )
+        },
       },
     ],
   },
   afterTest: (output) => {
-    expect(getOutputFileNames(output)).toMatchInlineSnapshot(
-      `
+    expect(emittedChunkPreliminaryFilenames).toMatchInlineSnapshot(`
       [
-        "main-Fv4vYntb.js",
+        "main-with-name.!~{001}~.js",
         "main-with-fileName.js",
-        "main-with-name.js",
-        "main.js",
       ]
-    `,
-    )
+    `)
+    expect(emittedChunkFilenames).toMatchInlineSnapshot(`
+      [
+        "main-with-name.gM07keqn.js",
+        "main-with-fileName.js",
+      ]
+    `)
   },
 })

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-chunk/_config.ts
@@ -28,6 +28,9 @@ export default defineTest({
             fileName: 'main-with-fileName.js',
             id: './main.js',
           })
+          expect(this.getFileName(mainWithFileNameChunkReferenceId)).toBe(
+            'main-with-fileName.js',
+          )
         },
         renderChunk() {
           if (runOnceRenderChunk) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Using emitChunk reference id to call `getFileName`,  the filename of `name` chunk has some cases at rollup.
- before `render_chunk` hook,  the filename is not generated.
- between `render_chunk` hook and `generate_bundle` hook，the filename is preliminary filename
- `generate_bundle` hook, the filename is final filename.

The filename of `fileName` chunk always is  the user provider filename.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
