### PR TITLE
fix: make default sanitizeFilename compatible with rollup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,7 +2206,6 @@ dependencies = [
  "rolldown_std_utils",
  "rolldown_utils",
  "rustc-hash",
- "sanitize-filename",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/rolldown_common/Cargo.toml
+++ b/crates/rolldown_common/Cargo.toml
@@ -35,7 +35,6 @@ rolldown_sourcemap  = { workspace = true }
 rolldown_std_utils  = { workspace = true }
 rolldown_utils      = { workspace = true }
 rustc-hash          = { workspace = true }
-sanitize-filename   = { workspace = true }
 schemars            = { workspace = true, optional = true }
 serde               = { workspace = true, features = ["derive"], optional = true }
 serde_json          = { workspace = true }

--- a/crates/rolldown_common/src/inner_bundler_options/types/sanitize_filename.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/sanitize_filename.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Debug, future::Future, pin::Pin, sync::Arc};
 
 use arcstr::ArcStr;
+use rolldown_utils::sanitize_filename::default_sanitize_file_name;
 
 type SanitizeFileNameFunction = dyn Fn(&str) -> Pin<Box<(dyn Future<Output = anyhow::Result<String>> + Send + 'static)>>
   + Send
@@ -32,7 +33,7 @@ impl SanitizeFilename {
     match self {
       Self::Boolean(value) => {
         if *value {
-          Ok(sanitize_filename::sanitize(name).into())
+          Ok(default_sanitize_file_name(name).into())
         } else {
           Ok(name.into())
         }
@@ -45,7 +46,7 @@ impl SanitizeFilename {
     match self {
       Self::Boolean(value) => {
         if *value {
-          sanitize_filename::sanitize(name).into()
+          default_sanitize_file_name(name).into()
         } else {
           name.into()
         }

--- a/crates/rolldown_utils/src/lib.rs
+++ b/crates/rolldown_utils/src/lib.rs
@@ -14,6 +14,7 @@ pub mod mime;
 pub mod percent_encoding;
 pub mod rayon;
 pub mod rustc_hash;
+pub mod sanitize_filename;
 pub mod xxhash;
 pub use bitset::BitSet;
 pub mod clean_url;

--- a/crates/rolldown_utils/src/sanitize_filename.rs
+++ b/crates/rolldown_utils/src/sanitize_filename.rs
@@ -1,0 +1,65 @@
+macro_rules! matches_invalid_chars {
+  ($chars:ident) => {
+    matches!($chars,
+      '\u{0000}'
+        ..='\u{001f}'
+          | '"'
+          | '#'
+          | '$'
+          | '%'
+          | '&'
+          | '*'
+          | '+'
+          | ','
+          | ':'
+          | ';'
+          | '<'
+          | '='
+          | '>'
+          | '?'
+          | '['
+          | ']'
+          | '@'
+          | '`'
+          | '{'
+          | '|'
+          | '}'
+          | '\u{007f}'
+    )
+  };
+}
+
+// Follow from https://github.com/rollup/rollup/blob/master/src/utils/sanitizeFileName.ts
+pub fn default_sanitize_file_name(str: &str) -> String {
+  let mut sanitized = String::with_capacity(str.len());
+  let mut chars = str.chars();
+
+  // A `:` is only allowed as part of a windows drive letter (ex: C:\foo)
+  // Otherwise, avoid them because they can refer to NTFS alternate data streams.
+  if starts_with_windows_drive(str) {
+    sanitized.push(chars.next().unwrap());
+    sanitized.push(chars.next().unwrap());
+  }
+
+  for char in chars {
+    if matches_invalid_chars!(char) {
+      sanitized.push('_');
+    } else {
+      sanitized.push(char);
+    }
+  }
+  sanitized
+}
+
+fn starts_with_windows_drive(str: &str) -> bool {
+  let mut chars = str.chars();
+  if !chars.next().is_some_and(|c| c.is_ascii_alphabetic()) {
+    return false;
+  }
+  chars.next().is_some_and(|c| c == ':')
+}
+
+#[test]
+fn test_sanitize_file_name() {
+  assert_eq!(default_sanitize_file_name("\0+a=Z_0-"), "__a_Z_0-");
+}

--- a/cspell.json
+++ b/cspell.json
@@ -132,6 +132,7 @@
     "nocheck",
     "nodenext",
     "notjson",
+    "NTFS",
     "onwarn",
     "outdir",
     "outro",

--- a/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
@@ -29,7 +29,7 @@ export default defineTest({
     expect(getOutputChunkNames(output)).toStrictEqual([
       'entry.js',
       'main.js',
-      '_module-Br9N4WKJ.js',
+      '_module-gUXl6Us6.js',
     ])
   },
 })

--- a/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
@@ -29,7 +29,7 @@ export default defineTest({
     expect(getOutputChunkNames(output)).toStrictEqual([
       'entry.js',
       'main.js',
-      'module-Br9N4WKJ.js',
+      '_module-Br9N4WKJ.js',
     ])
   },
 })

--- a/packages/rolldown/tests/fixtures/output/sanitizeFilename/true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sanitizeFilename/true/_config.ts
@@ -25,7 +25,7 @@ export default defineTest({
   afterTest: (output) => {
     expect(getOutputFileNames(output)).toMatchInlineSnapshot(`
       [
-        "assets/emitted-umwR9Fta.txt",
+        "assets/_emitted-umwR9Fta.txt",
         "main.js",
       ]
     `)

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
@@ -29,7 +29,7 @@ export default defineTest({
         },
         generateBundle() {
           expect(this.getFileName(referenceId)).toMatchInlineSnapshot(
-            `"+emitted-umwR9Fta.txt"`,
+            `"_emitted-umwR9Fta.txt"`,
           )
           // emit asset buffer source
           this.emitFile({
@@ -48,7 +48,7 @@ export default defineTest({
         case '+emitted.txt':
           expect(asset.names).toStrictEqual(['+emitted.txt'])
           expect(asset.fileName).toMatchInlineSnapshot(
-            `"+emitted-umwR9Fta.txt"`,
+            `"_emitted-umwR9Fta.txt"`,
           )
           expect(asset.originalFileName).toBe(ORIGINAL_FILE_NAME)
           expect(asset.originalFileNames).toStrictEqual([ORIGINAL_FILE_NAME])


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

#3418 changed the default sanitizeFilename behavior and broke some tests in Vite.
This PR fixes that and also improves the compatibility with rollup a bit more than the previous implementation before #3418.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
