### PR TITLE
refactor(rust): simplify the usage of `ModuleId::new`

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -67,7 +67,7 @@ pub async fn create_ecma_view(
   ctx: &mut CreateModuleContext<'_>,
   args: CreateModuleViewArgs,
 ) -> BuildResult<CreateEcmaViewReturn> {
-  let id = ModuleId::new(ArcStr::clone(&ctx.resolved_id.id));
+  let id = ModuleId::new(&ctx.resolved_id.id);
   let stable_id = id.stabilize(&ctx.options.cwd);
 
   let parse_result = parse_to_ecma_ast(

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -88,7 +88,7 @@ impl ModuleTask {
 
   #[expect(clippy::too_many_lines)]
   async fn run_inner(&mut self) -> BuildResult<()> {
-    let id = ModuleId::new(ArcStr::clone(&self.resolved_id.id));
+    let id = ModuleId::new(&self.resolved_id.id);
 
     // Add watch files for watcher recover if build errors occurred.
     self.ctx.plugin_driver.watch_files.insert(self.resolved_id.id.clone());


### PR DESCRIPTION
### Description

Since `ModuleId::new` is defined as `pub fn new(value: impl Into<ArcStr>) -> Self`, and `ArcStr` implements `From<&ArcStr>`, we can simplify its usage. The behavior remains exactly the same before and after simplification.