### PR TITLE
chore(oxlint): temporarily restore `.oxlintignore`

### DIFF
--- a/.oxlintignore
+++ b/.oxlintignore
@@ -1,0 +1,5 @@
+crates/**
+packages/rollup-tests/**
+packages/rolldown/tests/fixtures/**
+packages/rolldown/src/binding.d.ts
+rollup/**

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=18.20.3"
   },
   "scripts": {
-    "lint-code": "oxlint -c .oxlintrc.json --deny-warnings",
+    "lint-code": "oxlint -c .oxlintrc.json --ignore-path=.oxlintignore --deny-warnings",
     "lint-filename": "echo 'TODO: ls-lint is too slow now'",
     "lint-filename:bak": "ls-lint",
     "lint-spell": "cspell \"**\" --no-progress  --gitignore",


### PR DESCRIPTION
### Description

![image](https://github.com/user-attachments/assets/322b94a3-4056-46ba-8b7c-8abf9141ab02)

If we run `just lint`, we will find that `oxlint` cannot correctly handle the `ignorePatterns` in the `.oxlintrc.json` file. Therefore, we temporarily revert to using `.oxlintignore`.

Related to https://github.com/oxc-project/oxc/pull/8590