### PR TITLE
fix: add `sequential?: boolean` type for rollup compat

### DIFF
--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -272,10 +272,15 @@ export type PluginHooks = {
     K extends AsyncPluginHooks
       ? MakeAsync<FunctionPluginHooks[K]>
       : FunctionPluginHooks[K],
-    HookFilterExtension<K>
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    // TODO
-    // K extends ParallelPluginHooks ? { sequential?: boolean } : {}
+    HookFilterExtension<K> &
+      (K extends ParallelPluginHooks ? {
+        /**
+         * @deprecated
+         * this is only for rollup Plugin type compatibility.
+         * hooks always work as `sequential: true`.
+         */
+        sequential?: boolean
+      } : {})
   >
 }
 

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -273,14 +273,16 @@ export type PluginHooks = {
       ? MakeAsync<FunctionPluginHooks[K]>
       : FunctionPluginHooks[K],
     HookFilterExtension<K> &
-      (K extends ParallelPluginHooks ? {
-        /**
-         * @deprecated
-         * this is only for rollup Plugin type compatibility.
-         * hooks always work as `sequential: true`.
-         */
-        sequential?: boolean
-      } : {})
+      (K extends ParallelPluginHooks
+        ? {
+            /**
+             * @deprecated
+             * this is only for rollup Plugin type compatibility.
+             * hooks always work as `sequential: true`.
+             */
+            sequential?: boolean
+          }
+        : {})
   >
 }
 

--- a/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/write-bundle/_config.ts
@@ -40,8 +40,20 @@ export default defineTest({
       },
       {
         name: 'test-plugin-2',
-        writeBundle: () => {
-          calls.push('test-plugin-2')
+        writeBundle: {
+          sequential: true,
+          async handler() {
+            calls.push('test-plugin-2')
+          },
+        },
+      },
+      {
+        name: 'test-plugin-3',
+        writeBundle: {
+          sequential: false,
+          async handler() {
+            calls.push('test-plugin-3')
+          },
         },
       },
     ],
@@ -50,6 +62,10 @@ export default defineTest({
     calls.length = 0
   },
   afterTest: () => {
-    expect(calls).toStrictEqual(['test-plugin', 'test-plugin-2'])
+    expect(calls).toStrictEqual([
+      'test-plugin',
+      'test-plugin-2',
+      'test-plugin-3',
+    ])
   },
 })


### PR DESCRIPTION
### Description

I added a fake "deprecated" type to reduce a churn due to ecosystem failing by ts error (see https://github.com/vitejs/vite-ecosystem-ci/blob/rolldown-vite/README-temp.md and also my plugin hit by this too https://github.com/hi-ogawa/vite-plugins/pull/673).

As I wrote in https://github.com/rolldown/rolldown/issues/3337#issuecomment-2586039789, Rolldown's plugin hook always works same as rollup's `sequential: true` and this behavior is likely good for the ecosystem since people mostly needed `sequential: true` to avoid running `writeBundle` hooks in parallel on rollup.

I think the test added in https://github.com/rolldown/rolldown/pull/1913 already verifies such sequential behavior.