### PR TITLE
refactor(rust): remove unnecessary `module_idx`

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -260,12 +260,11 @@ impl ModuleLoader {
       match msg {
         ModuleLoaderMsg::NormalModuleDone(task_result) => {
           let NormalModuleTaskResult {
-            module_idx,
-            resolved_deps,
             mut module,
+            mut ecma_related,
+            resolved_deps,
             raw_import_records,
             warnings,
-            mut ecma_related,
           } = task_result;
           all_warnings.extend(warnings);
           let mut dynamic_import_rec_exports_usage = ecma_related
@@ -312,13 +311,16 @@ impl ModuleLoader {
               .collect::<IndexVec<ImportRecordIdx, _>>();
 
           module.set_import_records(import_records);
+
+          let module_idx = module.idx();
           if let Some(EcmaRelated { ast, symbols, ast_scope, .. }) = ecma_related {
-            let ast_idx = self.intermediate_normal_modules.index_ecma_ast.push((ast, module.idx()));
+            let ast_idx = self.intermediate_normal_modules.index_ecma_ast.push((ast, module_idx));
             let ast_scope_idx = self.intermediate_normal_modules.index_ast_scope.push(ast_scope);
             module.set_ecma_ast_idx(ast_idx);
             module.set_ast_scope_idx(ast_scope_idx);
             self.symbol_ref_db.store_local_db(module_idx, symbols);
           }
+
           self.intermediate_normal_modules.modules[module_idx] = Some(module);
           self.remaining -= 1;
         }

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -215,17 +215,16 @@ impl ModuleTask {
       .ctx
       .tx
       .send(ModuleLoaderMsg::NormalModuleDone(NormalModuleTaskResult {
-        resolved_deps,
-        module_idx: self.module_idx,
-        warnings,
+        module: module.into(),
         ecma_related: Some(EcmaRelated {
           ast,
           symbols,
           dynamic_import_rec_exports_usage,
           ast_scope,
         }),
-        module: module.into(),
+        resolved_deps,
         raw_import_records,
+        warnings,
       }))
       .await
       .is_err()

--- a/crates/rolldown_common/src/module_loader/task_result.rs
+++ b/crates/rolldown_common/src/module_loader/task_result.rs
@@ -1,5 +1,5 @@
 use crate::{
-  dynamic_import_usage::DynamicImportExportsUsage, AstScopes, ImportRecordIdx, Module, ModuleIdx,
+  dynamic_import_usage::DynamicImportExportsUsage, AstScopes, ImportRecordIdx, Module,
   RawImportRecord, ResolvedId, SymbolRefDbForModule,
 };
 use oxc_index::IndexVec;
@@ -8,12 +8,11 @@ use rolldown_error::BuildDiagnostic;
 use rustc_hash::FxHashMap;
 
 pub struct NormalModuleTaskResult {
-  pub module_idx: ModuleIdx,
+  pub module: Module,
+  pub ecma_related: Option<EcmaRelated>,
   pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
   pub warnings: Vec<BuildDiagnostic>,
-  pub module: Module,
-  pub ecma_related: Option<EcmaRelated>,
 }
 
 pub struct EcmaRelated {


### PR DESCRIPTION
### Description

`NormalModuleTaskResult#module_idx` is unnecessary.