### PR TITLE
fix: deconflict export alias

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -10,6 +10,7 @@ use rolldown_common::{
   ModuleIdx, NamedImport, OutputFormat, SymbolRef, WrapKind,
 };
 use rolldown_rstr::{Rstr, ToRstr};
+use rolldown_utils::concat_string;
 use rolldown_utils::indexmap::FxIndexSet;
 use rolldown_utils::rayon::IntoParallelIterator;
 use rolldown_utils::rayon::{ParallelBridge, ParallelIterator};
@@ -373,15 +374,24 @@ impl GenerateStage<'_> {
       {
         let original_name: rolldown_rstr::Rstr =
           chunk_export.name(&self.link_output.symbol_db).to_rstr();
-        let key: Cow<'_, Rstr> = Cow::Owned(original_name.clone());
-        let count = name_count.entry(key).or_insert(0u32);
-        let alias = if *count == 0 {
-          original_name.clone()
-        } else {
-          format!("{original_name}${}", itoa::Buffer::new().format(*count)).into()
-        };
-        chunk.exports_to_other_chunks.insert(chunk_export, alias.clone());
-        *count += 1;
+        let mut candidate_name = original_name.clone();
+        loop {
+          let key: Cow<'_, Rstr> = Cow::Owned(candidate_name.clone());
+          match name_count.entry(key) {
+            std::collections::hash_map::Entry::Occupied(mut occ) => {
+              let next_conflict_index = *occ.get() + 1;
+              *occ.get_mut() = next_conflict_index;
+              candidate_name =
+                concat_string!(original_name, "$", itoa::Buffer::new().format(next_conflict_index))
+                  .into();
+            }
+            std::collections::hash_map::Entry::Vacant(vac) => {
+              vac.insert(0);
+              break;
+            }
+          }
+        }
+        chunk.exports_to_other_chunks.insert(chunk_export, candidate_name.clone());
       }
     }
 

--- a/crates/rolldown/tests/rolldown/issues/3438/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/3438/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "input": [
+      {"import": "./main.js", "name": "main" }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/3438/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3438/artifacts.snap
@@ -1,0 +1,83 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Assets
+
+## main.js
+
+```js
+import { clear } from "./repro12.js";
+import { clear$1, clear$2 } from "./repro22.js";
+import { clear$1$3, clear$2$1, clear$3 } from "./repro32.js";
+
+//#region main.js
+var main_default = [
+	clear,
+	clear$2,
+	clear$1,
+	clear$3,
+	clear$1$3,
+	clear$2$1,
+	() => import("./repro1.js"),
+	() => import("./repro2.js"),
+	() => import("./repro3.js")
+];
+
+//#endregion
+export { main_default as default };
+```
+## repro1.js
+
+```js
+import { clear } from "./repro12.js";
+
+export { clear };
+```
+## repro12.js
+
+```js
+
+//#region repro1.js
+const clear = "repro1_clear";
+
+//#endregion
+export { clear };
+```
+## repro2.js
+
+```js
+import { clear$1, clear$2 as clear } from "./repro22.js";
+
+export { clear, clear$1 };
+```
+## repro22.js
+
+```js
+
+//#region repro2.js
+const clear$1 = "repro2_clear$1";
+const clear = "repro2_clear";
+
+//#endregion
+export { clear$1, clear as clear$2 };
+```
+## repro3.js
+
+```js
+import { clear$1$3 as clear$1, clear$2$1 as clear$2, clear$3 as clear } from "./repro32.js";
+
+export { clear, clear$1, clear$2 };
+```
+## repro32.js
+
+```js
+
+//#region repro3.js
+const clear$2 = "repro3_clear$2";
+const clear$1 = "repro3_clear$1";
+const clear = "repro3_clear";
+
+//#endregion
+export { clear$1 as clear$1$3, clear$2 as clear$2$1, clear as clear$3 };
+```

--- a/crates/rolldown/tests/rolldown/issues/3438/main.js
+++ b/crates/rolldown/tests/rolldown/issues/3438/main.js
@@ -1,0 +1,15 @@
+import { clear as repro1_clear } from "./repro1.js"
+import { clear as repro2_clear, clear$1 as repro2_clear$1 } from "./repro2.js"
+import { clear as repro3_clear, clear$1 as repro3_clear$1, clear$2 as repro3_clear$2 } from "./repro3.js"
+
+export default [
+  repro1_clear,
+  repro2_clear,
+  repro2_clear$1,
+  repro3_clear,
+  repro3_clear$1,
+  repro3_clear$2,
+  () => import("./repro1.js"),
+  () => import("./repro2.js"),
+  () => import("./repro3.js"),
+]

--- a/crates/rolldown/tests/rolldown/issues/3438/repro1.js
+++ b/crates/rolldown/tests/rolldown/issues/3438/repro1.js
@@ -1,0 +1,1 @@
+export const clear = "repro1_clear"

--- a/crates/rolldown/tests/rolldown/issues/3438/repro2.js
+++ b/crates/rolldown/tests/rolldown/issues/3438/repro2.js
@@ -1,0 +1,2 @@
+export const clear$1 = "repro2_clear$1";
+export const clear = "repro2_clear";

--- a/crates/rolldown/tests/rolldown/issues/3438/repro3.js
+++ b/crates/rolldown/tests/rolldown/issues/3438/repro3.js
@@ -1,0 +1,3 @@
+export const clear$2 = "repro3_clear$2";
+export const clear$1 = "repro3_clear$1";
+export const clear = "repro3_clear";

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4578,6 +4578,16 @@ snapshot_kind: text
 
 - main-!~{000}~.js => main-BIyVlF5M.js
 
+# tests/rolldown/issues/3438
+
+- main-!~{006}~.js => main-wJYlTcNT.js
+- repro1-!~{007}~.js => repro1-BKdSHZG0.js
+- repro1-!~{000}~.js => repro1-BMOe3HZY.js
+- repro2-!~{002}~.js => repro2-BSAS-PUl.js
+- repro2-!~{009}~.js => repro2-Bnzlnm9X.js
+- repro3-!~{00b}~.js => repro3-BQ08GX7m.js
+- repro3-!~{004}~.js => repro3-qSe7JEtT.js
+
 # tests/rolldown/issues/376
 
 - main-!~{000}~.js => main-CfuHZZW7.js


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Closes https://github.com/rolldown/rolldown/issues/3438

I copied a deconflict loop from chunk-level renamer:

https://github.com/rolldown/rolldown/blob/8655a95035ff4c9f00a9862d4c035ad503025aee/crates/rolldown/src/utils/renamer.rs#L75-L91