### PR TITLE
chore(deps): bump `@napi-rs/cli`

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -117,7 +117,7 @@
   },
   "devDependencies": {
     "@jridgewell/sourcemap-codec": "^1.5.0",
-    "@napi-rs/cli": "^3.0.0-alpha.65",
+    "@napi-rs/cli": "^3.0.0-alpha.70",
     "@napi-rs/wasm-runtime": "^0.2.4",
     "@oxc-node/core": "^0.0.17",
     "@rolldown/testing": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,8 +296,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@napi-rs/cli':
-        specifier: ^3.0.0-alpha.65
-        version: 3.0.0-alpha.65(@emnapi/runtime@1.3.1)(@types/node@22.10.7)(emnapi@1.3.1(node-addon-api@8.3.0))
+        specifier: ^3.0.0-alpha.70
+        version: 3.0.0-alpha.70(@emnapi/runtime@1.3.1)(@types/node@22.10.7)(emnapi@1.3.1(node-addon-api@8.3.0))
       '@napi-rs/wasm-runtime':
         specifier: ^0.2.4
         version: 0.2.6
@@ -2036,7 +2036,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2052,8 +2051,8 @@ packages:
   '@module-federation/sdk@0.8.9':
     resolution: {integrity: sha512-QJ60itWC/SPjqduT7wDiF8UGwVU/yJ/Sz+QbnoxB9b7gNLzvI//swAXTo9eOtKsCy/V2BMwjt0F3eOcfnaqllA==}
 
-  '@napi-rs/cli@3.0.0-alpha.65':
-    resolution: {integrity: sha512-Ka6TnnqUt9kI+slxe91GCSzuvoDAtqXMkcQfpMdpdHrUWI4LaWiSsG2ChyTHJmN0Tu/fC1ISv8dFpfEDdqSjOg==}
+  '@napi-rs/cli@3.0.0-alpha.70':
+    resolution: {integrity: sha512-hYZuA1gXO7hx9sXzz4qCVBevh46unQMXRvgUhg2kHctnHJNOKKOjNcxM3OF7o60olzlNsjQ1SpzySWlYn/JLSg==}
     engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
@@ -2065,15 +2064,15 @@ packages:
       emnapi:
         optional: true
 
-  '@napi-rs/cross-toolchain@0.0.16':
-    resolution: {integrity: sha512-jwdjHT5L0m9MH0CmzDwPp0ckn/UO7afHCsPeo7NugHUvYgvlgS7SWhdMVgIgJW2HHqhcW/2nhaLLGpAU1c7QRQ==}
+  '@napi-rs/cross-toolchain@0.0.19':
+    resolution: {integrity: sha512-StHXqYANdTaMFqJJ3JXHqKQMylOzOJPcrOCd9Nt2NIGfvfaXK3SzpmNfkJimkOAYfTsfpfuRERsML0bUZCpHBQ==}
     peerDependencies:
-      '@napi-rs/cross-toolchain-arm64-target-aarch64': ^0.0.16
-      '@napi-rs/cross-toolchain-arm64-target-armv7': ^0.0.16
-      '@napi-rs/cross-toolchain-arm64-target-x86_64': ^0.0.16
-      '@napi-rs/cross-toolchain-x64-target-aarch64': ^0.0.16
-      '@napi-rs/cross-toolchain-x64-target-armv7': ^0.0.16
-      '@napi-rs/cross-toolchain-x64-target-x86_64': ^0.0.16
+      '@napi-rs/cross-toolchain-arm64-target-aarch64': ^0.0.19
+      '@napi-rs/cross-toolchain-arm64-target-armv7': ^0.0.19
+      '@napi-rs/cross-toolchain-arm64-target-x86_64': ^0.0.19
+      '@napi-rs/cross-toolchain-x64-target-aarch64': ^0.0.19
+      '@napi-rs/cross-toolchain-x64-target-armv7': ^0.0.19
+      '@napi-rs/cross-toolchain-x64-target-x86_64': ^0.0.19
     peerDependenciesMeta:
       '@napi-rs/cross-toolchain-arm64-target-aarch64':
         optional: true
@@ -8145,10 +8144,10 @@ snapshots:
     dependencies:
       isomorphic-rslog: 0.0.7
 
-  '@napi-rs/cli@3.0.0-alpha.65(@emnapi/runtime@1.3.1)(@types/node@22.10.7)(emnapi@1.3.1(node-addon-api@8.3.0))':
+  '@napi-rs/cli@3.0.0-alpha.70(@emnapi/runtime@1.3.1)(@types/node@22.10.7)(emnapi@1.3.1(node-addon-api@8.3.0))':
     dependencies:
       '@inquirer/prompts': 7.2.3(@types/node@22.10.7)
-      '@napi-rs/cross-toolchain': 0.0.16
+      '@napi-rs/cross-toolchain': 0.0.19
       '@napi-rs/wasm-tools': 0.0.2
       '@octokit/rest': 21.1.0
       clipanion: 3.2.1(typanion@3.14.0)
@@ -8173,7 +8172,7 @@ snapshots:
       - '@types/node'
       - supports-color
 
-  '@napi-rs/cross-toolchain@0.0.16':
+  '@napi-rs/cross-toolchain@0.0.19':
     dependencies:
       '@napi-rs/lzma': 1.4.1
       '@napi-rs/tar': 0.1.4


### PR DESCRIPTION
### Description

              > Can you check the binary diff?

I need to check later as I encountered some issues while running `just build` and `just build native release`.

```bash
Syntax Error: Unexpected token 's', " string\n/*"... is not valid JSON
    at JSON.parse (<anonymous>)
    at file:///D:/shulaoda/rolldown/node_modules/.pnpm/@napi-rs+cli@3.0.0-alpha.65_@emnapi+runtime@1.3.1_@types+node@22.10.7_emnapi@1.3.1_node-addon-api@8.3.0_/node_modules/@napi-rs/cli/dist/utils/typegen.js:128:21
    at Array.map (<anonymous>)
    at readIntermediateTypeFile (file:///D:/shulaoda/rolldown/node_modules/.pnpm/@napi-rs+cli@3.0.0-alpha.65_@emnapi+runtime@1.3.1_@types+node@22.10.7_emnapi@1.3.1_node-addon-api@8.3.0_/node_modules/@napi-rs/cli/dist/utils/typegen.js:120:10)
    at async processTypeDef (file:///D:/shulaoda/rolldown/node_modules/.pnpm/@napi-rs+cli@3.0.0-alpha.65_@emnapi+runtime@1.3.1_@types+node@22.10.7_emnapi@1.3.1_node-addon-api@8.3.0_/node_modules/@napi-rs/cli/dist/utils/typegen.js:61:18)
    at async Builder.generateTypeDef (file:///D:/shulaoda/rolldown/node_modules/.pnpm/@napi-rs+cli@3.0.0-alpha.65_@emnapi+runtime@1.3.1_@types+node@22.10.7_emnapi@1.3.1_node-addon-api@8.3.0_/node_modules/@napi-rs/cli/dist/api/build.js:584:34)
    at async Builder.postBuild (file:///D:/shulaoda/rolldown/node_modules/.pnpm/@napi-rs+cli@3.0.0-alpha.65_@emnapi+runtime@1.3.1_@types+node@22.10.7_emnapi@1.3.1_node-addon-api@8.3.0_/node_modules/@napi-rs/cli/dist/api/build.js:450:28)
    at async BuildCommand.execute (file:///D:/shulaoda/rolldown/node_modules/.pnpm/@napi-rs+cli@3.0.0-alpha.65_@emnapi+runtime@1.3.1_@types+node@22.10.7_emnapi@1.3.1_node-addon-api@8.3.0_/node_modules/@napi-rs/cli/dist/commands/build.js:17:25)
    at async BuildCommand.validateAndExecute (D:\shulaoda\rolldown\node_modules\.pnpm\clipanion@3.2.1_typanion@3.14.0\node_modules\clipanion\lib\advanced\Command.js:73:26)
    at async Cli.run (D:\shulaoda\rolldown\node_modules\.pnpm\clipanion@3.2.1_typanion@3.14.0\node_modules\clipanion\lib\advanced\Cli.js:223:24)
 ELIFECYCLE  Command failed with exit code 1.
ERROR: "build-binding" exited with 1.
```

_Originally posted by @shulaoda in https://github.com/rolldown/rolldown/issues/3450#issuecomment-2621126794_
            
I spent a lot of time troubleshooting and found that the issue seemed to be related to the `@napi-rs/cli`. After updating it, the problem no longer occurred. To prevent others from encountering the same issue, I’ve updated it.