### PR TITLE
fix: aovid preliminary filenames conflict

### DIFF
--- a/crates/rolldown_utils/src/hash_placeholder.rs
+++ b/crates/rolldown_utils/src/hash_placeholder.rs
@@ -24,21 +24,21 @@ const CHARS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTU
 const BASE: u32 = 64;
 
 fn to_base64(mut value: u32) -> String {
-  let mut buffer = [0u8; 6];
-  let mut index = 0;
+  let mut buffer = vec![];
 
   loop {
     let current_digit = value % BASE;
-    buffer[index] = CHARS[current_digit as usize];
+    let right = std::mem::replace(&mut buffer, vec![CHARS[current_digit as usize]]);
+    buffer.extend(right);
     value /= BASE;
-    index += 1;
 
     if value == 0 {
       break;
     }
   }
 
-  String::from_utf8_lossy(&buffer[..index]).into_owned()
+  // SAFETY: `buffer` is base64 characters, it is valid utf8 characters
+  unsafe { String::from_utf8_unchecked(buffer) }
 }
 
 #[derive(Debug, Default)]
@@ -126,8 +126,8 @@ fn test_to_base64() {
   assert_eq!(to_base64(0), "0");
   assert_eq!(to_base64(1), "1");
   assert_eq!(to_base64(10), "a");
-  assert_eq!(to_base64(64), "01");
+  assert_eq!(to_base64(64), "10");
   assert_eq!(to_base64(65), "11");
-  assert_eq!(to_base64(128), "02");
-  assert_eq!(to_base64(100_000_000), "04uZ5");
+  assert_eq!(to_base64(128), "20");
+  assert_eq!(to_base64(100_000_000), "5Zu40");
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

close https://github.com/rolldown/rolldown/issues/3443. The issue reason is `to_base64(128)` is `02`, `padStat(3, 0)` is `002`, it is same as  `to_base64(2)` is `2`, `padStat(3, 0)` is `002`.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
