### PR TITLE
refactor(rust): improve the DX of `ModuleTask#run_inner`

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -62,10 +62,9 @@ pub async fn create_ecma_view(
   ctx: &mut CreateModuleContext<'_>,
   args: CreateModuleViewArgs,
 ) -> BuildResult<CreateEcmaViewReturn> {
-  let parse_result = parse_to_ecma_ast(ctx, args.source.clone())?;
-
+  let CreateModuleViewArgs { source, sourcemap_chain, hook_side_effects } = args;
   let ParseToEcmaAstResult { mut ast, symbol_table, scope_tree, has_lazy_export, warning } =
-    parse_result;
+    parse_to_ecma_ast(ctx, source)?;
 
   ctx.warnings.extend(warning);
 
@@ -130,7 +129,7 @@ pub async fn create_ecma_view(
         DeterminedSideEffects::Analyzed(analyzed_side_effects)
       })
   };
-  let side_effects = match args.hook_side_effects {
+  let side_effects = match hook_side_effects {
     Some(side_effects) => match side_effects {
       HookSideEffects::True => lazy_check_side_effects(),
       HookSideEffects::False => DeterminedSideEffects::UserDefined(false),
@@ -176,7 +175,7 @@ pub async fn create_ecma_view(
     exports_kind,
     namespace_object_ref,
     def_format: ctx.resolved_id.module_def_format,
-    sourcemap_chain: args.sourcemap_chain,
+    sourcemap_chain,
     import_records: IndexVec::default(),
     importers: FxIndexSet::default(),
     dynamic_importers: FxIndexSet::default(),

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -15,9 +15,9 @@ use std::sync::Arc;
 use sugar_path::SugarPath;
 
 use rolldown_common::{
-  EcmaRelated, ImportKind, ImportRecordIdx, ImportRecordMeta, ModuleDefFormat, ModuleId, ModuleIdx,
-  ModuleInfo, ModuleLoaderMsg, ModuleType, NormalModule, NormalModuleTaskResult, RawImportRecord,
-  ResolvedId, StrOrBytes, RUNTIME_MODULE_ID,
+  ImportKind, ImportRecordIdx, ImportRecordMeta, ModuleDefFormat, ModuleId, ModuleIdx, ModuleInfo,
+  ModuleLoaderMsg, ModuleType, NormalModule, NormalModuleTaskResult, RawImportRecord, ResolvedId,
+  StrOrBytes, RUNTIME_MODULE_ID,
 };
 use rolldown_error::{
   BuildDiagnostic, BuildResult, DiagnosableArcstr, UnloadableDependencyContext,
@@ -113,26 +113,25 @@ impl ModuleTask {
     let (mut source, module_type) =
       self.load_source_phase(&mut sourcemap_chain, &mut hook_side_effects).await?;
 
-    let asset_view = if matches!(module_type, ModuleType::Asset) {
-      let asset_source = source.into_bytes();
-      source = StrOrBytes::Str(String::new());
-      Some(create_asset_view(asset_source.into()))
-    } else {
-      None
-    };
-
     let stable_id = id.stabilize(&self.ctx.options.cwd);
     let mut raw_import_records = IndexVec::default();
 
-    let css_view = if matches!(module_type, ModuleType::Css) {
-      let css_source: ArcStr = source.try_into_string()?.into();
-      // FIXME: This makes creating `EcmaView` rely on creating `CssView` first, while they should be done in parallel.
-      source = StrOrBytes::Str(String::new());
-      let create_ret = create_css_view(&stable_id, &css_source);
-      raw_import_records = create_ret.1;
-      Some(create_ret.0)
-    } else {
-      None
+    let (asset_view, css_view) = match module_type {
+      ModuleType::Asset => {
+        let asset_source = source.into_bytes();
+        let asset_view = create_asset_view(asset_source.into());
+        source = StrOrBytes::Str(String::new());
+        (Some(asset_view), None)
+      }
+      ModuleType::Css => {
+        let css_source: ArcStr = source.try_into_string()?.into();
+        // FIXME: This makes creating `EcmaView` rely on creating `CssView` first, while they should be done in parallel.
+        let (css_view, css_raw_import_records) = create_css_view(&stable_id, &css_source);
+        raw_import_records = css_raw_import_records;
+        source = StrOrBytes::Str(String::new());
+        (None, Some(css_view))
+      }
+      _ => (None, None),
     };
 
     let mut warnings = vec![];
@@ -153,15 +152,12 @@ impl ModuleTask {
     .await?;
 
     let CreateEcmaViewReturn {
-      view: mut ecma_view,
-      ast,
-      symbols,
+      mut ecma_view,
+      ecma_related,
       raw_import_records: ecma_raw_import_records,
-      dynamic_import_rec_exports_usage,
-      ast_scope,
     } = ret;
 
-    if !matches!(module_type, ModuleType::Css) {
+    if css_view.is_none() {
       raw_import_records = ecma_raw_import_records;
     }
 
@@ -174,7 +170,7 @@ impl ModuleTask {
       )
       .await?;
 
-    if !matches!(module_type, ModuleType::Css) {
+    if css_view.is_none() {
       for (record, info) in raw_import_records.iter().zip(&resolved_deps) {
         match record.kind {
           ImportKind::Import | ImportKind::Require | ImportKind::NewUrl => {
@@ -211,26 +207,16 @@ impl ModuleTask {
     self.ctx.plugin_driver.module_parsed(Arc::clone(&module_info)).await?;
     self.ctx.plugin_driver.mark_context_load_modules_loaded(&module.id).await?;
 
-    if self
-      .ctx
-      .tx
-      .send(ModuleLoaderMsg::NormalModuleDone(NormalModuleTaskResult {
-        module: module.into(),
-        ecma_related: Some(EcmaRelated {
-          ast,
-          symbols,
-          dynamic_import_rec_exports_usage,
-          ast_scope,
-        }),
-        resolved_deps,
-        raw_import_records,
-        warnings,
-      }))
-      .await
-      .is_err()
-    {
-      // The main thread is dead, nothing we can do to handle these send failures.
-    }
+    let result = ModuleLoaderMsg::NormalModuleDone(NormalModuleTaskResult {
+      module: module.into(),
+      ecma_related: Some(ecma_related),
+      resolved_deps,
+      raw_import_records,
+      warnings,
+    });
+
+    // If the main thread is dead, nothing we can do to handle these send failures.
+    let _ = self.ctx.tx.send(result).await;
 
     Ok(())
   }

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -138,6 +138,7 @@ impl ModuleTask {
 
     let ret = create_ecma_view(
       &mut CreateModuleContext {
+        stable_id: &stable_id,
         module_index: self.module_idx,
         plugin_driver: &self.ctx.plugin_driver,
         resolved_id: &self.resolved_id,

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -162,19 +162,18 @@ impl RuntimeModuleTask {
       })
       .collect();
 
-    if let Err(_err) =
-      self.tx.try_send(ModuleLoaderMsg::RuntimeNormalModuleDone(RuntimeModuleTaskResult {
-        ast,
-        module,
-        runtime,
-        resolved_deps,
-        raw_import_records,
-        ast_scope,
-        local_symbol_ref_db: symbol_ref_db,
-      }))
-    {
-      // hyf0: If main thread is dead, we should handle errors of main thread. So we just ignore the error here.
-    };
+    let result = ModuleLoaderMsg::RuntimeNormalModuleDone(RuntimeModuleTaskResult {
+      ast,
+      module,
+      runtime,
+      resolved_deps,
+      raw_import_records,
+      ast_scope,
+      local_symbol_ref_db: symbol_ref_db,
+    });
+
+    // If the main thread is dead, nothing we can do to handle these send failures.
+    let _ = self.tx.try_send(result);
 
     Ok(())
   }

--- a/crates/rolldown/src/types/module_factory.rs
+++ b/crates/rolldown/src/types/module_factory.rs
@@ -9,6 +9,7 @@ use rolldown_sourcemap::SourceMap;
 use crate::SharedOptions;
 
 pub struct CreateModuleContext<'a> {
+  pub stable_id: &'a str,
   pub module_index: ModuleIdx,
   pub plugin_driver: &'a SharedPluginDriver,
   pub resolved_id: &'a ResolvedId,


### PR DESCRIPTION
### Description

- Avoiding the destructuring and reinitialization of `ecma_related`.
- Avoiding duplicate calculation of `stable_id`.
- Avoiding source clone in `create_ecma_view`.