### PR TITLE
perf(rust): avoid unnecessary `into_owned` on `Cow<str>`

### DIFF
--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -186,11 +186,11 @@ impl ModuleTask {
       }
     }
 
-    let repr_name = self.resolved_id.id.as_path().representative_file_name().into_owned();
-    let repr_name = legitimize_identifier_name(&repr_name);
+    let repr_name = self.resolved_id.id.as_path().representative_file_name();
+    let repr_name = legitimize_identifier_name(&repr_name).into_owned();
 
     let module = NormalModule {
-      repr_name: repr_name.into_owned(),
+      repr_name,
       stable_id,
       id,
       debug_id: self.resolved_id.debug_id(&self.ctx.options.cwd),

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -119,7 +119,6 @@ pub fn finalize_assets(
         asset.preliminary_filename.as_str(),
         &final_hashes_by_placeholder,
       )
-      .into_owned()
       .into();
 
       if let InstantiationKind::Ecma(ecma_meta) = &mut asset.kind {


### PR DESCRIPTION
### Description

Avoid unnecessary `into_owned` on `Cow<str>`.