### PR TITLE
chore: use const `RUNTIME_MODULE_RUNTIME` as module id when create runtime module

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -11,6 +11,7 @@ use oxc_ecmascript::ToJsString;
 use rolldown_common::{
   dynamic_import_usage::DynamicImportExportsUsage, generate_replace_this_expr_map,
   EcmaModuleAstUsage, ImportKind, ImportRecordMeta, StmtInfoMeta, ThisExprReplaceKind,
+  RUNTIME_MODULE_ID,
 };
 use rolldown_ecmascript::ToSourceString;
 use rolldown_error::BuildDiagnostic;
@@ -298,9 +299,8 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
               Some(_) => true,
               _ => false,
             };
-            // TODO: the id should be `rolldown:runtime`
             // should not replace require in `runtime` code
-            if is_dummy_record && self.id.as_ref() != "runtime" {
+            if is_dummy_record && self.id.as_ref() != RUNTIME_MODULE_ID {
               let import_rec_idx = self.add_import_record(
                 "",
                 ImportKind::Require,

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -191,7 +191,7 @@ impl RuntimeModuleTask {
 
     let (symbol_table, scope) = ast.make_symbol_table_and_scope_tree();
     let ast_scope = AstScopes::new(scope);
-    let facade_path = ModuleId::new("runtime");
+    let facade_path = ModuleId::new(RUNTIME_MODULE_ID);
     let scanner = AstScanner::new(
       self.module_idx,
       &ast_scope,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
