### PR TITLE
chore: update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: "\U0001F41E Bug report"
 title: '[Bug]: '
-labels: ['needs-triage', 'bug']
+labels: ['needs-triage']
+type: 'Bug'
 description: Create a report to help us improve
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,8 @@
 name: "\U0001F680 New feature"
 title: '[Feature Request]: '
 description: Suggest an idea for Rolldown
-labels: ['needs-triage', 'feat']
+labels: ['needs-triage']
+type: 'Feature'
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Since github has support `type` https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax, we don't need to add `tag` like `feature` and `bug` anymore, this pr use type instead.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
