### PR TITLE
refactor(rust): simplify logic with `if let` and remove redundant conditions

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -350,22 +350,16 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     ident_ref: &IdentifierReference,
   ) -> Option<()> {
     let parent = self.visit_path.last()?;
-    match parent {
-      AstKind::CallExpression(_) => {
-        match ident_ref.name.as_str() {
-          "eval" => {
-            // TODO: esbuild track has_eval for each scope, this could reduce bailout range, and may
-            // improve treeshaking performance. https://github.com/evanw/esbuild/blob/360d47230813e67d0312ad754cad2b6ee09b151b/internal/js_ast/js_ast.go#L1288-L1291
-            self.result.has_eval = true;
-            self.result.warnings.push(
-              BuildDiagnostic::eval(self.id.to_string(), self.source.clone(), ident_ref.span)
-                .with_severity_warning(),
-            );
-          }
-          _ => {}
-        }
+    if let AstKind::CallExpression(_) = parent {
+      if ident_ref.name == "eval" {
+        // TODO: esbuild track has_eval for each scope, this could reduce bailout range, and may
+        // improve treeshaking performance. https://github.com/evanw/esbuild/blob/360d47230813e67d0312ad754cad2b6ee09b151b/internal/js_ast/js_ast.go#L1288-L1291
+        self.result.has_eval = true;
+        self.result.warnings.push(
+          BuildDiagnostic::eval(self.id.to_string(), self.source.clone(), ident_ref.span)
+            .with_severity_warning(),
+        );
       }
-      _ => {}
     }
     None
   }


### PR DESCRIPTION
### Description

- Simplify logic by replacing nested `match` with `if let`
- Removing redundant conditions