### PR TITLE
refactor(rust): simplify `scan_ast` and `make_ecma_ast`

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -46,7 +46,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     for (idx, stmt) in program.body.iter().enumerate() {
       self.current_stmt_info.stmt_idx = Some(idx);
       self.current_stmt_info.side_effect = SideEffectDetector::new(
-        self.scopes,
+        &self.result.ast_scope,
         self.source,
         self.comments,
         // In `NormalModule` the options is always `Some`, for `RuntimeModule` always enable annotations

--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -60,13 +60,10 @@ impl Generator for EcmaGenerator {
       ctx.chunk_graph,
     );
     let hashbang = match ctx.chunk.user_defined_entry_module(&ctx.link_output.module_table) {
-      Some(normal_module) => {
-        let source = &normal_module.source;
-        normal_module
-          .ecma_view
-          .hashbang_range
-          .map(|range| &source.as_str()[range.start as usize..range.end as usize])
-      }
+      Some(normal_module) => normal_module
+        .ecma_view
+        .hashbang_range
+        .map(|range| &normal_module.source[range.start as usize..range.end as usize]),
       None => None,
     };
 

--- a/crates/rolldown_common/src/module_loader/runtime_task_result.rs
+++ b/crates/rolldown_common/src/module_loader/runtime_task_result.rs
@@ -12,7 +12,6 @@ pub struct RuntimeModuleTaskResult {
   pub local_symbol_ref_db: SymbolRefDbForModule,
   pub ast: EcmaAst,
   pub ast_scope: AstScopes,
-  // pub warnings: Vec<BuildError>,
   pub module: NormalModule,
   pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,


### PR DESCRIPTION
### Description

Concentrate the required variables from `AstScanner` into the scan result.