### PR TITLE
fix: fix `ROLLUP_FILE_URL` for emitted chunks

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
@@ -475,10 +475,6 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   fn rewrite_rollup_file_url(&self, property_name: &str) -> Option<Expression<'ast>> {
     // rewrite `import.meta.ROLLUP_FILE_URL_<referenceId>`
     if let Some(reference_id) = property_name.strip_prefix("ROLLUP_FILE_URL_") {
-      // compute relative path from chunk to asset
-      // TODO:
-      // preliminary_filename for chunk is not available from file_emitter.get_file_name
-      // but we can probably get it from Chunk.reference_id and Chunk.preliminary_filename
       let asset_file_name = match self.ctx.file_emitter.get_file_name(reference_id) {
         Ok(asset_file_name) => asset_file_name,
         Err(_error) => {

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
@@ -475,14 +475,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   fn rewrite_rollup_file_url(&self, property_name: &str) -> Option<Expression<'ast>> {
     // rewrite `import.meta.ROLLUP_FILE_URL_<referenceId>`
     if let Some(reference_id) = property_name.strip_prefix("ROLLUP_FILE_URL_") {
-      let asset_file_name = match self.ctx.file_emitter.get_file_name(reference_id) {
-        Ok(asset_file_name) => asset_file_name,
-        Err(_error) => {
-          // TODO: emit warning diagnostics?
-          return None;
-        }
-      };
       // compute relative path from chunk to asset
+      let Ok(asset_file_name) = self.ctx.file_emitter.get_file_name(reference_id) else {
+        return None;
+      };
       let absolute_asset_file_name = asset_file_name
         .absolutize_with(self.ctx.options.cwd.as_path().join(&self.ctx.options.out_dir));
       let importer_chunk_id = self.ctx.chunk_graph.module_to_chunk[self.ctx.module.idx]

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
@@ -476,9 +476,17 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // rewrite `import.meta.ROLLUP_FILE_URL_<referenceId>`
     if let Some(reference_id) = property_name.strip_prefix("ROLLUP_FILE_URL_") {
       // compute relative path from chunk to asset
-      let Ok(asset_file_name) = self.ctx.file_emitter.get_file_name(reference_id) else {
-        return None;
+      // TODO:
+      // preliminary_filename for chunk is not available from file_emitter.get_file_name
+      // but we can probably get it from Chunk.reference_id and Chunk.preliminary_filename
+      let asset_file_name = match self.ctx.file_emitter.get_file_name(reference_id) {
+        Ok(asset_file_name) => asset_file_name,
+        Err(_error) => {
+          // TODO: emit warning diagnostics?
+          return None;
+        }
       };
+      // compute relative path from chunk to asset
       let absolute_asset_file_name = asset_file_name
         .absolutize_with(self.ctx.options.cwd.as_path().join(&self.ctx.options.out_dir));
       let importer_chunk_id = self.ctx.chunk_graph.module_to_chunk[self.ctx.module.idx]

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -4,6 +4,7 @@ use arcstr::ArcStr;
 use futures::future::try_join_all;
 use oxc::ast::VisitMut;
 use oxc_index::IndexVec;
+use render_chunk_to_assets::set_emitted_chunk_preliminary_filenames2;
 use rolldown_ecmascript_utils::AstSnippet;
 use rolldown_error::BuildResult;
 use rolldown_std_utils::OptionExt;
@@ -75,6 +76,7 @@ impl<'a> GenerateStage<'a> {
     let index_chunk_id_to_name =
       self.generate_chunk_name_and_preliminary_filenames(&mut chunk_graph).await?;
     self.patch_asset_modules(&chunk_graph);
+    set_emitted_chunk_preliminary_filenames2(&self.plugin_driver.file_emitter, &chunk_graph);
 
     chunk_graph.chunk_table.par_iter_mut().for_each(|chunk| {
       deconflict_chunk_symbols(

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -4,7 +4,7 @@ use arcstr::ArcStr;
 use futures::future::try_join_all;
 use oxc::ast::VisitMut;
 use oxc_index::IndexVec;
-use render_chunk_to_assets::set_emitted_chunk_preliminary_filenames2;
+use render_chunk_to_assets::set_emitted_chunk_preliminary_filenames;
 use rolldown_ecmascript_utils::AstSnippet;
 use rolldown_error::BuildResult;
 use rolldown_std_utils::OptionExt;
@@ -76,7 +76,7 @@ impl<'a> GenerateStage<'a> {
     let index_chunk_id_to_name =
       self.generate_chunk_name_and_preliminary_filenames(&mut chunk_graph).await?;
     self.patch_asset_modules(&chunk_graph);
-    set_emitted_chunk_preliminary_filenames2(&self.plugin_driver.file_emitter, &chunk_graph);
+    set_emitted_chunk_preliminary_filenames(&self.plugin_driver.file_emitter, &chunk_graph);
 
     chunk_graph.chunk_table.par_iter_mut().for_each(|chunk| {
       deconflict_chunk_symbols(

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -349,6 +349,19 @@ fn get_sorting_file_type(output: &Output) -> SortingFileType {
   }
 }
 
+pub fn set_emitted_chunk_preliminary_filenames2(
+  file_emitter: &SharedFileEmitter,
+  chunk_graph: &ChunkGraph,
+) {
+  let emitted_chunk_info = chunk_graph.chunk_table.chunks.iter().filter_map(|chunk| {
+    chunk.reference_id.as_ref().map(|reference_id| EmittedChunkInfo {
+      reference_id: reference_id.clone(),
+      filename: chunk.preliminary_filename.as_ref().unwrap().deref().clone(),
+    })
+  });
+  file_emitter.set_emitted_chunk_info(emitted_chunk_info);
+}
+
 fn set_emitted_chunk_preliminary_filenames(
   file_emitter: &SharedFileEmitter,
   instantiated_chunks: &IndexInstantiatedChunks,

--- a/packages/rolldown/tests/fixtures/misc/rollup-file-url-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/rollup-file-url-chunk/_config.ts
@@ -16,10 +16,9 @@ export default defineTest({
         transform(_code, id) {
           // replace `?chunk-url` module with a reference to the chunk
           if (id.endsWith('?chunk-url')) {
-            const entry = id.replace('?chunk-url', '')
             const referenceId = this.emitFile({
               type: 'chunk',
-              id: entry,
+              id: id.replace('?chunk-url', ''),
             })
             return `export default import.meta.ROLLUP_FILE_URL_${referenceId}`
           }

--- a/packages/rolldown/tests/fixtures/misc/rollup-file-url-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/rollup-file-url-chunk/_config.ts
@@ -1,0 +1,40 @@
+import { defineTest } from 'rolldown-tests'
+import { expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'chunk-url',
+        load(id) {
+          // similar to vite:load-fallback
+          if (id.endsWith('?chunk-url')) {
+            return fs.readFileSync(id.replace('?chunk-url', ''), 'utf-8')
+          }
+        },
+        transform(_code, id) {
+          // replace `?chunk-url` module with a reference to the chunk
+          if (id.endsWith('?chunk-url')) {
+            const entry = id.replace('?chunk-url', '')
+            const referenceId = this.emitFile({
+              type: 'chunk',
+              id: entry,
+            })
+            return `export default import.meta.ROLLUP_FILE_URL_${referenceId}`
+          }
+        },
+      },
+    ],
+  },
+  afterTest: async () => {
+    const main = await import('./dist/main.js' as string)
+    const depUrl = new URL(
+      main.default,
+      new URL('./dist/main.js', import.meta.url),
+    ).href
+    const dep = await import(depUrl)
+    expect(dep.default).toBe('dep.js')
+  },
+})

--- a/packages/rolldown/tests/fixtures/misc/rollup-file-url-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/rollup-file-url-chunk/_config.ts
@@ -1,7 +1,6 @@
 import { defineTest } from 'rolldown-tests'
 import { expect } from 'vitest'
 import fs from 'node:fs'
-import path from 'node:path'
 
 export default defineTest({
   config: {

--- a/packages/rolldown/tests/fixtures/misc/rollup-file-url-chunk/dep.js
+++ b/packages/rolldown/tests/fixtures/misc/rollup-file-url-chunk/dep.js
@@ -1,0 +1,1 @@
+export default "dep.js"

--- a/packages/rolldown/tests/fixtures/misc/rollup-file-url-chunk/main.js
+++ b/packages/rolldown/tests/fixtures/misc/rollup-file-url-chunk/main.js
@@ -1,0 +1,2 @@
+import depUrl from './dep.js?chunk-url'
+export default depUrl


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Follow up to https://github.com/rolldown/rolldown/pull/3488. I forgot to test `emitFile({ type: "chunk" })` case and I just realized it's not working on https://github.com/hi-ogawa/vite-environment-examples/pull/154.

Currently, `FileEmitter::emitted_chunks` is not defined during scope hoisting finalizer, but it looks possible to define it earlier right after `generate_chunk_name_and_preliminary_filenames` instead of waiting until `instantiate_chunks`.