### PR TITLE
fix: syntax error when use top level await with `strict_execution_order` option

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -8,7 +8,9 @@ use oxc::{
   },
   span::{Span, SPAN},
 };
-use rolldown_common::{ExportsKind, Module, StmtInfoIdx, SymbolRef, ThisExprReplaceKind, WrapKind};
+use rolldown_common::{
+  EcmaModuleAstUsage, ExportsKind, Module, StmtInfoIdx, SymbolRef, ThisExprReplaceKind, WrapKind,
+};
 use rolldown_ecmascript_utils::{ExpressionExt, TakeIn};
 use rustc_hash::FxHashSet;
 
@@ -190,6 +192,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
             stmts_inside_closure,
             self.ctx.options.profiler_names,
             &self.ctx.module.stable_id,
+            self.ctx.module.ast_usage.contains(EcmaModuleAstUsage::TopLevelAwait),
           ));
         }
         WrapKind::None => {}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
+    "experimental": {
+      "strictExecutionOrder": true
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/artifacts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Assets
+
+## main.js
+
+```js
+
+
+//#region foo.js
+var foo;
+var init_foo = __esm({ async "foo.js"() {
+	await 1e3;
+	foo = 123;
+} });
+
+//#endregion
+//#region main.js
+var init_main = __esm({ "main.js"() {
+	init_foo();
+	console.log(foo);
+} });
+
+//#endregion
+init_main();
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/foo.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/foo.js
@@ -1,0 +1,2 @@
+await 1000;
+export const foo = 123

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax/main.js
@@ -1,0 +1,2 @@
+import * as ns from './foo'
+console.log(ns.foo)

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4006,6 +4006,10 @@ snapshot_kind: text
 - entry2-!~{001}~.js => entry2-B5XU3PE7.js
 - run-dep-!~{002}~.js => run-dep-NL2vqItl.js
 
+# tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax
+
+- main-!~{000}~.js => main-C044ThMY.js
+
 # tests/rolldown/function/export_mode/cjs/auto/default
 
 - main-!~{000}~.js => main-BV29ae5y.js

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -145,6 +145,7 @@ bitflags! {
         const AllStaticExportPropertyAccess = 1 << 3;
         /// module.exports = require('mod');
         const IsCjsReexport = 1 << 4;
+        const TopLevelAwait = 1 << 5;
         const ModuleOrExports = Self::ModuleRef.bits() | Self::ExportsRef.bits();
     }
 }

--- a/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
@@ -448,6 +448,7 @@ impl<'ast> AstSnippet<'ast> {
     statements: allocator::Vec<'ast, Statement<'ast>>,
     profiler_names: bool,
     stable_id: &str,
+    is_async: bool,
   ) -> ast::Statement<'ast> {
     // () => { ... }
     let params = self.builder.formal_parameters(
@@ -474,7 +475,7 @@ impl<'ast> AstSnippet<'ast> {
             FunctionType::FunctionExpression,
             None,
             false,
-            false,
+            is_async,
             false,
             NONE,
             NONE,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. related to https://github.com/rolldown/rolldown/issues/3448
2. part of https://github.com/rolldown/rolldown/issues/3131
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
