### PR TITLE
fix(node): add rolldown dist typing check

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -21,6 +21,7 @@
     "/packages/rolldown/npm",
     "scripts/snap-diff/**/*.{txt,md}",
     "packages/rolldown/src/binding.cjs",
+    "packages/rolldown/src/binding.js",
     "/CHANGELOG.md",
     "/crates/rolldown/tests/esbuild/splitting/ignore-test.md",
     "/packages/rollup-tests/src/ignored-by-unsupported-features.md",

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -150,7 +150,7 @@ const configs = defineConfig([
       },
 
       {
-        name: 'cleanup binding.cjs',
+        name: 'cleanup binding.js',
         transform: {
           filter: {
             code: {
@@ -158,7 +158,7 @@ const configs = defineConfig([
             },
           },
           handler(code, id) {
-            if (id.endsWith('binding.cjs')) {
+            if (id.endsWith('binding.js')) {
               const ret = code.replace(
                 'require = createRequire(__filename)',
                 '',
@@ -198,6 +198,8 @@ const configs = defineConfig([
   },
 ])
 
-for (const config of configs) {
-  await (await rolldown(config)).write(config.output as OutputOptions)
-}
+;(async () => {
+  for (const config of configs) {
+    await (await rolldown(config)).write(config.output as OutputOptions)
+  }
+})()

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -26,7 +26,6 @@
   "bin": {
     "rolldown": "./bin/cli.js"
   },
-  "type": "module",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/types/index.d.ts",
   "exports": {
@@ -62,19 +61,19 @@
   "scripts": {
     "# Scrips for binding #": "_",
     "artifacts": "napi artifacts --cwd ./src --package-json-path ../package.json -o=../artifacts --npm-dir ../npm",
-    "build-binding": "napi build -o=./src --manifest-path ../../crates/rolldown_binding/Cargo.toml --platform -p rolldown_binding --js binding.cjs --dts binding.d.ts --no-const-enum",
+    "build-binding": "napi build -o=./src --manifest-path ../../crates/rolldown_binding/Cargo.toml --platform -p rolldown_binding --js binding.js --dts binding.d.ts --no-const-enum",
     "build-binding:release": "pnpm build-binding --release",
     "build-binding:wasi": "pnpm build-binding --target wasm32-wasip1-threads",
     "build-binding:wasi:release": "pnpm build-binding --profile release-wasi --target wasm32-wasip1-threads",
     "# Scrips for node #": "_",
     "bak_build-node": "unbuild",
-    "build-node": "node --import @oxc-node/core/register ./build.ts",
+    "build-node": "tsx ./build.ts",
     "build-types": "tsc -p ./tsconfig.json",
-    "build-native:debug": "run-s build-binding build-types build-node build-type-check",
-    "build-native:release": "run-s build-binding:release build-types build-node build-type-check",
+    "build-native:debug": "run-s build-binding build-types build-node build-types-check",
+    "build-native:release": "run-s build-binding:release build-types build-node build-types-check",
     "build-wasi:debug": "run-s build-binding build-binding:wasi build-node",
     "build-wasi:release": "run-s build-binding build-binding:wasi:release build-node",
-    "build-type-check": "tsc -p ./tsconfig.check.json",
+    "build-types-check": "tsc -p ./tsconfig.check.json",
     "# Scrips for docs #": "_",
     "extract-options-doc": "typedoc"
   },

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -70,10 +70,11 @@
     "bak_build-node": "unbuild",
     "build-node": "node --import @oxc-node/core/register ./build.ts",
     "build-types": "tsc -p ./tsconfig.json",
-    "build-native:debug": "run-s build-binding build-types build-node",
-    "build-native:release": "run-s build-binding:release build-types build-node",
+    "build-native:debug": "run-s build-binding build-types build-node build-type-check",
+    "build-native:release": "run-s build-binding:release build-types build-node build-type-check",
     "build-wasi:debug": "run-s build-binding build-binding:wasi build-node",
     "build-wasi:release": "run-s build-binding build-binding:wasi:release build-node",
+    "build-type-check": "tsc -p ./tsconfig.check.json",
     "# Scrips for docs #": "_",
     "extract-options-doc": "typedoc"
   },

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -745,6 +745,12 @@ export interface EcmaScriptModule {
   importMetas: Array<Span>
 }
 
+export interface ErrorLabel {
+  message?: string
+  start: number
+  end: number
+}
+
 export interface Es2015Options {
   /** Transform arrow functions into function expressions. */
   arrowFunction?: ArrowFunctionsOptions
@@ -1007,6 +1013,13 @@ export interface OverwriteOptions {
   contentOnly: boolean
 }
 
+export interface OxcError {
+  severity: Severity
+  message: string
+  labels: Array<ErrorLabel>
+  helpMessage?: string
+}
+
 /**
  * Parse asynchronously.
  *
@@ -1066,6 +1079,21 @@ export interface ReactRefreshOptions {
 }
 
 export declare function registerPlugins(id: number, plugins: Array<BindingPluginWithIndex>): void
+
+export type Severity =  'Error'|
+'Warning'|
+'Advice';
+
+export interface SourceMap {
+  file?: string
+  mappings: string
+  names: Array<string>
+  sourceRoot?: string
+  sources: Array<string>
+  sourcesContent?: Array<string>
+  version: number
+  x_google_ignoreList?: Array<number>
+}
 
 export interface SourceMapOptions {
   includeContent?: boolean

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -398,4 +398,5 @@ module.exports.parseAsync = nativeBinding.parseAsync
 module.exports.parseSync = nativeBinding.parseSync
 module.exports.parseWithoutReturn = nativeBinding.parseWithoutReturn
 module.exports.registerPlugins = nativeBinding.registerPlugins
+module.exports.Severity = nativeBinding.Severity
 module.exports.transform = nativeBinding.transform

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -58,28 +58,32 @@ const {
 })
 
 function __napi_rs_initialize_modules(__napiInstance) {
+  __napiInstance.exports['__napi_register__OxcError_struct_0']?.()
+  __napiInstance.exports['__napi_register__ErrorLabel_struct_1']?.()
+  __napiInstance.exports['__napi_register__Severity_2']?.()
+  __napiInstance.exports['__napi_register__SourceMap_struct_0']?.()
   __napiInstance.exports['__napi_register__IsolatedDeclarationsResult_struct_0']?.()
+  __napiInstance.exports['__napi_register__MagicString_struct_0']?.()
   __napiInstance.exports['__napi_register__IsolatedDeclarationsOptions_struct_1']?.()
   __napiInstance.exports['__napi_register__isolated_declaration_2']?.()
-  __napiInstance.exports['__napi_register__TransformResult_struct_3']?.()
-  __napiInstance.exports['__napi_register__MagicString_struct_0']?.()
-  __napiInstance.exports['__napi_register__TransformOptions_struct_4']?.()
-  __napiInstance.exports['__napi_register__CompilerAssumptions_struct_5']?.()
-  __napiInstance.exports['__napi_register__TypeScriptOptions_struct_6']?.()
   __napiInstance.exports['__napi_register__LineColumn_struct_1']?.()
   __napiInstance.exports['__napi_register__OverwriteOptions_struct_2']?.()
   __napiInstance.exports['__napi_register__SourceMapOptions_struct_3']?.()
+  __napiInstance.exports['__napi_register__TransformResult_struct_3']?.()
   __napiInstance.exports['__napi_register__GenerateDecodedMapOptions_struct_4']?.()
+  __napiInstance.exports['__napi_register__TransformOptions_struct_4']?.()
+  __napiInstance.exports['__napi_register__CompilerAssumptions_struct_5']?.()
+  __napiInstance.exports['__napi_register__TypeScriptOptions_struct_6']?.()
   __napiInstance.exports['__napi_register__JsxOptions_struct_7']?.()
   __napiInstance.exports['__napi_register__ReactRefreshOptions_struct_8']?.()
+  __napiInstance.exports['__napi_register__MagicString_impl_24']?.()
   __napiInstance.exports['__napi_register__ArrowFunctionsOptions_struct_9']?.()
   __napiInstance.exports['__napi_register__Es2015Options_struct_10']?.()
   __napiInstance.exports['__napi_register__Helpers_struct_11']?.()
   __napiInstance.exports['__napi_register__HelperMode_12']?.()
-  __napiInstance.exports['__napi_register__transform_13']?.()
-  __napiInstance.exports['__napi_register__MagicString_impl_24']?.()
   __napiInstance.exports['__napi_register__ParserOptions_struct_25']?.()
   __napiInstance.exports['__napi_register__ParseResult_struct_26']?.()
+  __napiInstance.exports['__napi_register__transform_13']?.()
   __napiInstance.exports['__napi_register__ParseResult_impl_32']?.()
   __napiInstance.exports['__napi_register__Comment_struct_33']?.()
   __napiInstance.exports['__napi_register__EcmaScriptModule_struct_34']?.()
@@ -236,4 +240,5 @@ export const parseAsync = __napiModule.exports.parseAsync
 export const parseSync = __napiModule.exports.parseSync
 export const parseWithoutReturn = __napiModule.exports.parseWithoutReturn
 export const registerPlugins = __napiModule.exports.registerPlugins
+export const Severity = __napiModule.exports.Severity
 export const transform = __napiModule.exports.transform

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -82,28 +82,32 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
 })
 
 function __napi_rs_initialize_modules(__napiInstance) {
+  __napiInstance.exports['__napi_register__OxcError_struct_0']?.()
+  __napiInstance.exports['__napi_register__ErrorLabel_struct_1']?.()
+  __napiInstance.exports['__napi_register__Severity_2']?.()
+  __napiInstance.exports['__napi_register__SourceMap_struct_0']?.()
   __napiInstance.exports['__napi_register__IsolatedDeclarationsResult_struct_0']?.()
+  __napiInstance.exports['__napi_register__MagicString_struct_0']?.()
   __napiInstance.exports['__napi_register__IsolatedDeclarationsOptions_struct_1']?.()
   __napiInstance.exports['__napi_register__isolated_declaration_2']?.()
-  __napiInstance.exports['__napi_register__TransformResult_struct_3']?.()
-  __napiInstance.exports['__napi_register__MagicString_struct_0']?.()
-  __napiInstance.exports['__napi_register__TransformOptions_struct_4']?.()
-  __napiInstance.exports['__napi_register__CompilerAssumptions_struct_5']?.()
-  __napiInstance.exports['__napi_register__TypeScriptOptions_struct_6']?.()
   __napiInstance.exports['__napi_register__LineColumn_struct_1']?.()
   __napiInstance.exports['__napi_register__OverwriteOptions_struct_2']?.()
   __napiInstance.exports['__napi_register__SourceMapOptions_struct_3']?.()
+  __napiInstance.exports['__napi_register__TransformResult_struct_3']?.()
   __napiInstance.exports['__napi_register__GenerateDecodedMapOptions_struct_4']?.()
+  __napiInstance.exports['__napi_register__TransformOptions_struct_4']?.()
+  __napiInstance.exports['__napi_register__CompilerAssumptions_struct_5']?.()
+  __napiInstance.exports['__napi_register__TypeScriptOptions_struct_6']?.()
   __napiInstance.exports['__napi_register__JsxOptions_struct_7']?.()
   __napiInstance.exports['__napi_register__ReactRefreshOptions_struct_8']?.()
+  __napiInstance.exports['__napi_register__MagicString_impl_24']?.()
   __napiInstance.exports['__napi_register__ArrowFunctionsOptions_struct_9']?.()
   __napiInstance.exports['__napi_register__Es2015Options_struct_10']?.()
   __napiInstance.exports['__napi_register__Helpers_struct_11']?.()
   __napiInstance.exports['__napi_register__HelperMode_12']?.()
-  __napiInstance.exports['__napi_register__transform_13']?.()
-  __napiInstance.exports['__napi_register__MagicString_impl_24']?.()
   __napiInstance.exports['__napi_register__ParserOptions_struct_25']?.()
   __napiInstance.exports['__napi_register__ParseResult_struct_26']?.()
+  __napiInstance.exports['__napi_register__transform_13']?.()
   __napiInstance.exports['__napi_register__ParseResult_impl_32']?.()
   __napiInstance.exports['__napi_register__Comment_struct_33']?.()
   __napiInstance.exports['__napi_register__EcmaScriptModule_struct_34']?.()
@@ -260,4 +264,5 @@ module.exports.parseAsync = __napiModule.exports.parseAsync
 module.exports.parseSync = __napiModule.exports.parseSync
 module.exports.parseWithoutReturn = __napiModule.exports.parseWithoutReturn
 module.exports.registerPlugins = __napiModule.exports.registerPlugins
+module.exports.Severity = __napiModule.exports.Severity
 module.exports.transform = __napiModule.exports.transform

--- a/packages/rolldown/tsconfig.check.json
+++ b/packages/rolldown/tsconfig.check.json
@@ -12,6 +12,5 @@
     "exactOptionalPropertyTypes": true,
     "resolveJsonModule": true
   },
-  "include": ["dist/types/**/*.d.ts"],
-  "exclude": []
+  "include": ["dist/types/**/*.d.ts"]
 }

--- a/packages/rolldown/tsconfig.check.json
+++ b/packages/rolldown/tsconfig.check.json
@@ -1,0 +1,20 @@
+{
+  // copied from Vite
+  // https://github.com/vitejs/vite/blob/1465b2064ee23ac5df5414b13355a394ccd931af/packages/vite/tsconfig.check.json
+  "compilerOptions": {
+    "target": "ES2020",
+    "moduleResolution": "node16",
+    "module": "node16",
+    "lib": ["ES2020", "ESNext.Disposable", "DOM"], // ES2020 is very conservative check for client types, could be bumped if needed
+    "types": [], // Avoid checking unrelated node_modules types
+    "noEmit": true,
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    // check only package exports
+    "dist/types/index.d.ts",
+    "dist/types/parallel-plugin.d.ts"
+  ]
+}

--- a/packages/rolldown/tsconfig.check.json
+++ b/packages/rolldown/tsconfig.check.json
@@ -5,16 +5,13 @@
     "target": "ES2020",
     "moduleResolution": "node16",
     "module": "node16",
-    "lib": ["ES2020", "ESNext.Disposable", "DOM"], // ES2020 is very conservative check for client types, could be bumped if needed
-    "types": [], // Avoid checking unrelated node_modules types
+    "lib": ["ES2020", "ESNext.Disposable"], // ES2020 is very conservative check for client types, could be bumped if needed
+    "types": ["node"], // Avoid checking unrelated node_modules types
     "noEmit": true,
     "strict": true,
     "exactOptionalPropertyTypes": true,
     "resolveJsonModule": true
   },
-  "include": [
-    // check only package exports
-    "dist/types/index.d.ts",
-    "dist/types/parallel-plugin.d.ts"
-  ]
+  "include": ["dist/types/**/*.d.ts"],
+  "exclude": []
 }

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -7,7 +7,7 @@
     "*.cjs",
     "dist",
     "lib",
-    "./src/log/locate-character" // the extracted .d.ts from js files has typing error.
+    "./src/log/locate-character" // the extracted .d.ts from js files has typing error, ignore it because it's not used
   ],
   "compilerOptions": {
     "composite": true,

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -7,7 +7,7 @@
     "*.cjs",
     "dist",
     "lib",
-    "./src/log/locate-character"
+    "./src/log/locate-character" // the extracted .d.ts from js files has typing error.
   ],
   "compilerOptions": {
     "rootDir": "./src",

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -10,10 +10,12 @@
     "./src/log/locate-character" // the extracted .d.ts from js files has typing error.
   ],
   "compilerOptions": {
+    "composite": true,
     "rootDir": "./src",
     "outDir": "./dist/types",
     "resolveJsonModule": true,
     "noEmit": false,
+    "tsBuildInfoFile": ".tsbuildinfo",
     "emitDeclarationOnly": true
   }
 }

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -3,12 +3,12 @@
   "include": ["./src/**/*"],
   "exclude": ["*.js", "*.mjs", "*.cjs", "dist", "lib"],
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
     "outDir": "./dist/types",
     "resolveJsonModule": true,
     "noEmit": false,
-    "tsBuildInfoFile": ".tsbuildinfo",
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "isolatedModules": true,
+    "isolatedDeclarations": true
   }
 }

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -1,14 +1,19 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*"],
-  "exclude": ["*.js", "*.mjs", "*.cjs", "dist", "lib"],
+  "exclude": [
+    "*.js",
+    "*.mjs",
+    "*.cjs",
+    "dist",
+    "lib",
+    "./src/log/locate-character"
+  ],
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/types",
     "resolveJsonModule": true,
     "noEmit": false,
-    "emitDeclarationOnly": true,
-    "isolatedModules": true,
-    "isolatedDeclarations": true
+    "emitDeclarationOnly": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2032,7 +2032,6 @@ packages:
 
   '@ls-lint/ls-lint@2.2.3':
     resolution: {integrity: sha512-ekM12jNm/7O2I/hsRv9HvYkRdfrHpiV1epVuI2NP+eTIcEgdIdKkKCs9KgQydu/8R5YXTov9aHdOgplmCHLupw==}
-    cpu: [x64, arm64, s390x]
     os: [darwin, linux, win32]
     hasBin: true
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

close https://github.com/rolldown/rolldown/issues/3407. The error happened because the rolldown package added `type: module` at https://github.com/rolldown/rolldown/pull/3376, it will make typing check failed at `node16`, ref https://www.typescriptlang.org/docs/handbook/modules/reference.html#module-format-detection.

The `type: module` added by using oxc-node build, if changed build file to `build.mts` will caused error at https://github.com/oxc-project/oxc-node/issues/45. So i revert it to `tsx` build. Here also add `build-types-check` to avoid regression.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
