### PR TITLE
chore: downgrade pnpm manager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "monorepo",
   "description": "Rollup in Rust",
   "private": true,
-  "packageManager": "pnpm@10.2.1+48adf39a4ab751eda7b73b99447d1f0b6d227e02",
+  "packageManager": "pnpm@9.15.4",
   "engines": {
     "node": ">=18.20.3"
   },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. related to https://github.com/rolldown/rolldown/pull/3539, after upgrading the pnpm version, our netlify broke, so revert it for now.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
