### PR TITLE
feat(rust): add normalModule to module_parsed hook

### DIFF
--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -205,7 +205,7 @@ impl ModuleTask {
 
     let module_info = Arc::new(module.to_module_info(Some(&raw_import_records)));
     self.ctx.plugin_driver.set_module_info(&module.id, Arc::clone(&module_info));
-    self.ctx.plugin_driver.module_parsed(Arc::clone(&module_info)).await?;
+    self.ctx.plugin_driver.module_parsed(Arc::clone(&module_info), &module).await?;
     self.ctx.plugin_driver.mark_context_load_modules_loaded(&module.id).await?;
 
     let result = ModuleLoaderMsg::NormalModuleDone(NormalModuleTaskResult {

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -7,6 +7,7 @@ use crate::types::{
 use anyhow::Ok;
 use napi::bindgen_prelude::FnArgs;
 use rolldown::ModuleType;
+use rolldown_common::NormalModule;
 use rolldown_plugin::{Plugin, __inner::SharedPluginable, typedmap::TypedMapKey};
 use rolldown_utils::pattern_filter::{self, FilterResult};
 use std::{
@@ -233,6 +234,7 @@ impl Plugin for JsPlugin {
     &self,
     ctx: &rolldown_plugin::PluginContext,
     module_info: Arc<rolldown_common::ModuleInfo>,
+    _normal_module: &NormalModule,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.module_parsed {
       cb.await_call((ctx.clone().into(), BindingModuleInfo::new(module_info)).into()).await?;

--- a/crates/rolldown_plugin/src/plugin.rs
+++ b/crates/rolldown_plugin/src/plugin.rs
@@ -13,7 +13,7 @@ use crate::{
   HookTransformArgs, HookWriteBundleArgs, SharedTransformPluginContext,
 };
 use anyhow::Result;
-use rolldown_common::{ModuleInfo, RollupRenderedChunk, WatcherChangeKind};
+use rolldown_common::{ModuleInfo, NormalModule, RollupRenderedChunk, WatcherChangeKind};
 use rolldown_ecmascript::EcmaAst;
 
 pub type HookResolveIdReturn = Result<Option<HookResolveIdOutput>>;
@@ -99,6 +99,7 @@ pub trait Plugin: Any + Debug + Send + Sync + 'static {
     &self,
     _ctx: &PluginContext,
     _module_info: Arc<ModuleInfo>,
+    _normal_module: &NormalModule,
   ) -> impl std::future::Future<Output = HookNoopReturn> + Send {
     async { Ok(()) }
   }

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -11,7 +11,8 @@ use crate::{
 };
 use anyhow::Result;
 use rolldown_common::{
-  side_effects::HookSideEffects, ModuleInfo, ModuleType, SharedNormalizedBundlerOptions,
+  side_effects::HookSideEffects, ModuleInfo, ModuleType, NormalModule,
+  SharedNormalizedBundlerOptions,
 };
 use rolldown_sourcemap::SourceMap;
 use rolldown_utils::unique_arc::UniqueArc;
@@ -260,11 +261,15 @@ impl PluginDriver {
     Ok(args.ast)
   }
 
-  pub async fn module_parsed(&self, module_info: Arc<ModuleInfo>) -> HookNoopReturn {
+  pub async fn module_parsed(
+    &self,
+    module_info: Arc<ModuleInfo>,
+    normal_module: &NormalModule,
+  ) -> HookNoopReturn {
     for (_, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_module_parsed_meta)
     {
-      plugin.call_module_parsed(ctx, Arc::clone(&module_info)).await?;
+      plugin.call_module_parsed(ctx, Arc::clone(&module_info), normal_module).await?;
     }
     Ok(())
   }

--- a/crates/rolldown_plugin/src/pluginable.rs
+++ b/crates/rolldown_plugin/src/pluginable.rs
@@ -12,7 +12,7 @@ use crate::{
   HookResolveIdArgs, HookTransformArgs, Plugin, SharedTransformPluginContext,
 };
 use anyhow::Ok;
-use rolldown_common::{ModuleInfo, RollupRenderedChunk, WatcherChangeKind};
+use rolldown_common::{ModuleInfo, NormalModule, RollupRenderedChunk, WatcherChangeKind};
 
 pub use crate::plugin::HookAugmentChunkHashReturn;
 pub use crate::plugin::HookLoadReturn;
@@ -89,6 +89,7 @@ pub trait Pluginable: Any + Debug + Send + Sync + 'static {
     &self,
     _ctx: &PluginContext,
     _module_info: Arc<ModuleInfo>,
+    _normal_module: &NormalModule,
   ) -> HookNoopReturn;
 
   fn call_module_parsed_meta(&self) -> Option<PluginHookMeta>;
@@ -276,8 +277,9 @@ impl<T: Plugin> Pluginable for T {
     &self,
     ctx: &PluginContext,
     module_info: Arc<ModuleInfo>,
+    normal_module: &NormalModule,
   ) -> HookNoopReturn {
-    Plugin::module_parsed(self, ctx, module_info).await
+    Plugin::module_parsed(self, ctx, module_info, normal_module).await
   }
 
   fn call_module_parsed_meta(&self) -> Option<PluginHookMeta> {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add the normalModule to `module_parsed` hook, because the mf need to visit `NormalModule#exports_kind`.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
