### PR TITLE
feat: export hookFilter extension types

### DIFF
--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -35,7 +35,13 @@ import type {
   ResolvedId,
   SourceDescription,
   TransformResult,
+  HookFilterExtension,
 } from './plugin'
+import type {
+  HookFilter,
+  StringFilter,
+  ModuleTypeFilter,
+} from './plugin/hook-filter'
 import type { LogOrStringHandler } from './log/logging'
 import { DefineParallelPluginResult } from './plugin/parallel-plugin'
 import { defineConfig } from './utils/define-config'
@@ -95,6 +101,10 @@ export type {
   LoadResult,
   TransformResult,
   ResolveIdResult,
+  HookFilterExtension,
+  HookFilter,
+  StringFilter,
+  ModuleTypeFilter,
   PluginContext,
   TransformPluginContext,
   ObjectHook,

--- a/packages/rolldown/src/plugin/hook-filter.ts
+++ b/packages/rolldown/src/plugin/hook-filter.ts
@@ -13,7 +13,7 @@ interface FormalModuleTypeFilter {
   include?: ModuleType[]
 }
 
-type ModuleTypeFilter = ModuleType[] | FormalModuleTypeFilter
+export type ModuleTypeFilter = ModuleType[] | FormalModuleTypeFilter
 
 export interface HookFilter {
   /**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

So that I can use it here
https://github.com/vitejs/vite/blob/b44e3d43db65babe1c32e143964add02e080dc15/packages/vite/src/node/plugin.ts#L98
and also to implement filter on Vite's plugin container side later.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
