### PR TITLE
fix: top level this substitution

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -242,7 +242,9 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
   fn visit_property_key(&mut self, it: &ast::PropertyKey<'ast>) {
     let pre_is_nested_this_inside_class = self.is_nested_this_inside_class;
-    self.is_nested_this_inside_class = false;
+    if let Some(AstKind::ClassBody(_)) = self.visit_path.iter().rev().nth(1) {
+      self.is_nested_this_inside_class = false;
+    }
     walk::walk_property_key(self, it);
     self.is_nested_this_inside_class = pre_is_nested_this_inside_class;
   }

--- a/crates/rolldown/tests/rolldown/misc/top_level_this_substitution/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/top_level_this_substitution/_config.json
@@ -1,0 +1,6 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "format": "esm"
+  }
+}

--- a/crates/rolldown/tests/rolldown/misc/top_level_this_substitution/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/top_level_this_substitution/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Assets
+
+## main.js
+
+```js
+
+
+//#region main.js
+var require_main = __commonJS({ "main.js"(exports) {
+	var BaseNode = class extends Callable {
+		referencesById = children.reduce((result, child) => Object.assign(result, child.referencesById), { [this.id]: this });
+		[exports.id] = this;
+	};
+	console.log(`BaseNode: `, BaseNode);
+} });
+
+//#endregion
+export default require_main();
+
+```

--- a/crates/rolldown/tests/rolldown/misc/top_level_this_substitution/main.js
+++ b/crates/rolldown/tests/rolldown/misc/top_level_this_substitution/main.js
@@ -1,0 +1,9 @@
+class BaseNode extends Callable {
+  // should not be replaced
+  referencesById = children.reduce((result, child) => Object.assign(result, child.referencesById), { [this.id]: this });
+  // should replace
+  [this.id] = this;
+}
+
+console.log(`BaseNode: `, BaseNode)
+

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4698,6 +4698,10 @@ snapshot_kind: text
 
 - main-!~{000}~.js => main-jIhBklo0.js
 
+# tests/rolldown/misc/top_level_this_substitution
+
+- main-!~{000}~.js => main-CNQqEHP_.js
+
 # tests/rolldown/misc/use_strict/allow_parse_non_strict_code_in_cjs_format
 
 - main-!~{000}~.js => main-Dcb_TlVd.js


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. ref https://hyrious.me/esbuild-repl/?version=0.23.0&b=e%00entry.js%00class+BaseNode+extends+Callable+%7B%0A++%2F%2F+should+not+be+replaced%0A++referencesById+%3D+children.reduce%28%28result%2C+child%29+%3D%3E+Object.assign%28result%2C+child.referencesById%29%2C+%7B+%5Bthis.id%5D%3A+this+%7D%29%3B%0A++%2F%2F+should+replace%0A++%5Bthis.id%5D+%3D+this%3B%0A%7D%0A%0Aconsole.log%28%60BaseNode%3A+%60%2C+BaseNode%29%0A%0A&b=%00file.js%00&o=%7B%0A++treeShaking%3A+true%2C%0A++external%3A+%5B%22c%22%2C+%22a%22%2C+%22b%22%5D%2C%0A%22bundle%22%3A+true%2C%0Aformat%3A+%22esm%22%0A%7D
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
