### PR TITLE
fix(rust): dynamically importing `JSON` with `output.advancedChunks.groups`

### DIFF
--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -234,8 +234,9 @@ fn json_object_expr_to_esm(
   // update module stmts info
   // clear stmt info, since we need to split `ObjectExpression` into multiple decl, the original stmt info is invalid.
   // preserve the first one, which is `NamespaceRef`
-  module.stmt_infos.drain(1.into()..);
-  let mut all_declared_symbols = vec![];
+  let stmt_info = module.stmt_infos.drain(1.into()..);
+  let mut all_declared_symbols =
+    stmt_info.flat_map(|info| info.referenced_symbols).collect::<Vec<_>>();
   for (i, (local, exported, _)) in declaration_binding_names.iter().enumerate() {
     let symbol_id = ast_scope.get_root_binding(local.as_str()).expect("should have binding");
     let symbol_ref = (module_idx, symbol_id).into();

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -470,7 +470,6 @@ impl<'a> LinkStage<'a> {
       |ecma_module| {
         let linking_info = &mut self.metas[ecma_module.idx];
 
-        // create_wrapper(ecma_module, linking_info, &mut self.symbols, &self.runtime, self.options);
         if let Some(entry) = self.entries.iter().find(|entry| entry.id == ecma_module.idx) {
           init_entry_point_stmt_info(linking_info, entry, &self.dynamic_import_exports_usage_map);
         }

--- a/crates/rolldown/tests/rolldown/issues/3437/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/3437/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "format": "esm",
+    "platform": "node",
+    "advancedChunks": {
+      "groups": [
+        {
+          "name": "rolldown",
+          "test": "rolldown:runtime",
+          "priority": 100
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/3437/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3437/artifacts.snap
@@ -1,0 +1,47 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+snapshot_kind: text
+---
+# Assets
+
+## main.js
+
+```js
+import { __esm } from "./rolldown.js";
+
+//#region main.js
+var init_main = __esm({ "main.js"() {
+	import("./square.js");
+} });
+
+//#endregion
+init_main();
+```
+## rolldown.js
+
+```js
+
+
+export { __esm, __export };
+```
+## square.js
+
+```js
+import { __esm, __export } from "./rolldown.js";
+
+//#region square.json
+var square_exports = {};
+__export(square_exports, {
+	default: () => square_default,
+	hello: () => hello
+});
+var hello, square_default;
+var square_exports = __esm({ "square.json"() {
+	hello = "world";
+	square_default = { hello };
+} });
+
+//#endregion
+square_exports();
+export { square_default as default, hello };
+```

--- a/crates/rolldown/tests/rolldown/issues/3437/main.js
+++ b/crates/rolldown/tests/rolldown/issues/3437/main.js
@@ -1,0 +1,1 @@
+import('./square.json');

--- a/crates/rolldown/tests/rolldown/issues/3437/square.json
+++ b/crates/rolldown/tests/rolldown/issues/3437/square.json
@@ -1,0 +1,1 @@
+{ "hello": "world" }

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4583,6 +4583,12 @@ snapshot_kind: text
 
 - main-!~{000}~.js => main-BIyVlF5M.js
 
+# tests/rolldown/issues/3437
+
+- main-!~{000}~.js => main-CbCVKMhq.js
+- rolldown-!~{001}~.js => rolldown-CDlmqcql.js
+- square-!~{003}~.js => square-DkQOo3Hc.js
+
 # tests/rolldown/issues/3438
 
 - main-!~{000}~.js => main-CvQmWIZr.js


### PR DESCRIPTION
### Description

closes #3437 

This issue was exposed after #3343. We will create the wrapper again in `create_exports_for_ecma_modules`, so the `__esm`'s `referenced_symbols` will not be affected by being cleared in `generate_lazy_export` (only json).

