### PR TITLE
fix: making return type compatible with rollup/parseAst

### DIFF
--- a/packages/rolldown/src/parse-ast-index.ts
+++ b/packages/rolldown/src/parse-ast-index.ts
@@ -1,3 +1,4 @@
+import { Program } from '@oxc-project/types'
 import { parseSync, parseAsync } from './binding'
 import type { ParseResult, ParserOptions } from './binding'
 import { locate } from './log/locate-character'
@@ -75,16 +76,17 @@ export function parseAst(
   filename: string,
   sourceText: string,
   options?: ParserOptions | undefined | null,
-): ParseResult {
-  return wrap(parseSync(filename, sourceText, options), sourceText)
+): Program {
+  return wrap(parseSync(filename, sourceText, options), sourceText).program
 }
 
 export async function parseAstAsync(
   filename: string,
   sourceText: string,
   options?: ParserOptions | undefined | null,
-): Promise<ParseResult> {
+): Promise<Program> {
   return wrap(await parseAsync(filename, sourceText, options), sourceText)
+    .program
 }
 
 export type { ParseResult, ParserOptions }

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -1,4 +1,4 @@
-import type { BindingPluginContext } from '../binding'
+import type { BindingPluginContext, ParserOptions } from '../binding'
 import type {
   CustomPluginOptions,
   ModuleOptions,
@@ -7,7 +7,7 @@ import type {
 } from './index'
 import { MinimalPluginContext } from '../plugin/minimal-plugin-context'
 import { AssetSource, bindingAssetSource } from '../utils/asset-source'
-import { unimplemented, unsupported } from '../utils/misc'
+import { unimplemented } from '../utils/misc'
 import { ModuleInfo } from '../types/module-info'
 import { PluginContextData } from './plugin-context-data'
 import { SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF } from '../constants/plugin-context'
@@ -17,6 +17,8 @@ import type { LogHandler, LogLevelOption } from '../types/misc'
 import { LOG_LEVEL_WARN } from '../log/logging'
 import { logCycleLoading } from '../log/logs'
 import { OutputOptions } from '../options/output-options'
+import { parseAst } from '../parse-ast-index'
+import { Program } from '@oxc-project/types'
 
 export interface EmittedAsset {
   type: 'asset'
@@ -188,10 +190,10 @@ export class PluginContext extends MinimalPluginContext {
     this.context.addWatchFile(id)
   }
 
-  /**
-   * @deprecated This rollup API won't be supported by rolldown. Using this API will cause runtime error.
-   */
-  public parse(_input: string, _options?: any): any {
-    unsupported('`PluginContext#parse` is not supported by rolldown.')
+  public parse(
+    input: string,
+    options?: ParserOptions | undefined | null,
+  ): Program {
+    return parseAst('test.js', input, options)
   }
 }

--- a/packages/rolldown/tests/parse-ast/parse-ast.test.ts
+++ b/packages/rolldown/tests/parse-ast/parse-ast.test.ts
@@ -3,18 +3,17 @@ import { test, expect } from 'vitest'
 
 test('rolldown/parseAst parseSync', async () => {
   const result = parseAst('test.js', 'console.log("hello")')
-  expect(result.program.type).toBe('Program')
+  expect(result.type).toBe('Program')
 })
 
 test('rolldown/parseAst parseAstAsync', async () => {
   const result = await parseAstAsync('test.js', 'console.log("hello")')
-  expect(result.program.type).toBe('Program')
+  expect(result.type).toBe('Program')
 })
 
 test('rolldown/parseAst parseSync + error', async () => {
-  const result = parseAst('test.js', '\nconso le.log("hello")')
   try {
-    result.program
+    parseAst('test.js', '\nconso le.log("hello")')
     expect.unreachable()
   } catch (error: any) {
     expect(error.message).toMatchInlineSnapshot(`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. see https://github.com/rollup/rollup/blob/master/src/utils/parseAst.ts
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
