### PR TITLE
chore: ignore procMacro `tracing::instrument` in RA

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,8 @@
     "tmp": true
   },
   "editor.wordWrap": "on",
-  "rust-analyzer.procMacro.ignored": { "napi-derive": ["napi"] }
+  "rust-analyzer.procMacro.ignored": {
+    "napi-derive": ["napi"],
+    "tracing": ["instrument"]
+  }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Autocompletion is not working in function that used `tracing::instrument`.
- It's also a waste of memory since it doesn't make any actual effect.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
