### PR TITLE
fix: avoid call outputOptions hook at close

### DIFF
--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -29,6 +29,7 @@ export class RolldownBuild {
   // Create bundler for each `bundle.write/generate`
   async #getBundlerWithStopWorker(
     outputOptions: OutputOptions,
+    isClose?: boolean,
   ): Promise<BundlerWithStopWorker> {
     if (this.#bundler) {
       this.#bundler.stopWorkers?.()
@@ -36,6 +37,7 @@ export class RolldownBuild {
     return (this.#bundler = await createBundler(
       this.#inputOptions,
       outputOptions,
+      isClose,
     ))
   }
 
@@ -52,7 +54,11 @@ export class RolldownBuild {
   }
 
   async close(): Promise<void> {
-    const { bundler, stopWorkers } = await this.#getBundlerWithStopWorker({})
+    // Create new one bundler to run `closeBundle` hook, here using `isClose` flag to avoid call `outputOptions` hook.
+    const { bundler, stopWorkers } = await this.#getBundlerWithStopWorker(
+      {},
+      true,
+    )
     await stopWorkers?.()
     await bundler.close()
   }

--- a/packages/rolldown/src/utils/create-bundler-option.ts
+++ b/packages/rolldown/src/utils/create-bundler-option.ts
@@ -23,6 +23,7 @@ import type { OutputOptions } from '../options/output-options'
 export async function createBundlerOptions(
   inputOptions: InputOptions,
   outputOptions: OutputOptions,
+  isClose?: boolean,
 ): Promise<BundlerOptionWithStopWorker> {
   if (inputOptions.treeshake !== undefined) {
     validateTreeShakingOptions(inputOptions.treeshake)
@@ -38,11 +39,13 @@ export async function createBundlerOptions(
     logLevel,
   )
 
-  // The `outputOptions` hook is called with the input plugins and the output plugins
-  outputOptions = PluginDriver.callOutputOptionsHook(
-    [...inputPlugins, ...outputPlugins],
-    outputOptions,
-  )
+  if (!isClose) {
+    // The `outputOptions` hook is called with the input plugins and the output plugins
+    outputOptions = PluginDriver.callOutputOptionsHook(
+      [...inputPlugins, ...outputPlugins],
+      outputOptions,
+    )
+  }
 
   if (outputOptions.minify === true) {
     onLog(LOG_LEVEL_WARN, logMinifyWarning())

--- a/packages/rolldown/src/utils/create-bundler.ts
+++ b/packages/rolldown/src/utils/create-bundler.ts
@@ -6,8 +6,13 @@ import { createBundlerOptions } from './create-bundler-option'
 export async function createBundler(
   inputOptions: InputOptions,
   outputOptions: OutputOptions,
+  isClose?: boolean,
 ): Promise<BundlerWithStopWorker> {
-  const option = await createBundlerOptions(inputOptions, outputOptions)
+  const option = await createBundlerOptions(
+    inputOptions,
+    outputOptions,
+    isClose,
+  )
 
   try {
     return {

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -197,8 +197,10 @@ exports[`config > no package.json > should allow multiply options 1`] = `
 "
 `;
 
-exports[`config > no package.json > should allow multiply output + call options hook once 1`] = `
+exports[`config > no package.json > should allow multiply output + call options hook once  + call outputOptions hook 1`] = `
 "called options hook
+called output options hook
+called output options hook
 <DIR>/esm.js  chunk │ size: 0.18 kB
 <DIR>/cjs.js  chunk │ size: 0.19 kB
 
@@ -224,8 +226,10 @@ exports[`config > no package.json > should resolve rolldown.config.cjs 1`] = `
 "
 `;
 
-exports[`watch cli > should allow multiply output + + call options hook once 1`] = `
+exports[`watch cli > should allow multiply output + call options hook once + call outputOptions hook 1`] = `
 "called options hook
+called output options hook
+called output options hook
 <DIR>/esm.js  chunk │ size: 0.18 kB
 <DIR>/cjs.js  chunk │ size: 0.19 kB
 

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -173,7 +173,7 @@ describe('config', () => {
       expect(cleanStdout(status.stdout)).toMatchSnapshot()
     })
 
-    it('should allow multiply output + call options hook once', async () => {
+    it('should allow multiply output + call options hook once  + call outputOptions hook', async () => {
       const cwd = cliFixturesDir('config-multiply-output-with-options-hooks')
       const status = await $({
         cwd,
@@ -261,7 +261,7 @@ describe('watch cli', () => {
     controller.abort()
   })
 
-  it('should allow multiply output + + call options hook once', async () => {
+  it('should allow multiply output + call options hook once + call outputOptions hook', async () => {
     const cwd = cliFixturesDir('config-multiply-output-with-options-hooks')
     const status = await $({ cwd })`rolldown -c`
     expect(cleanStdout(status.stdout)).toMatchSnapshot()

--- a/packages/rolldown/tests/cli/fixtures/config-multiply-output-with-options-hooks/rolldown.config.ts
+++ b/packages/rolldown/tests/cli/fixtures/config-multiply-output-with-options-hooks/rolldown.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
       options: function () {
         console.log('called options hook')
       },
+      outputOptions: function () {
+        console.log('called output options hook')
+      },
     },
   ],
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
close https://github.com/rolldown/rolldown/issues/3570
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
