### PR TITLE
chore: pin pnpm version to avoid break netlify build

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,10 @@
       "groupName": "oxlint"
     },
     {
+      "matchPackageNames": ["pnpm"],
+      "enabled": false
+    },
+    {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "matchUpdateTypes": ["minor", "patch"]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "monorepo",
   "description": "Rollup in Rust",
   "private": true,
-  "packageManager": "pnpm@10.4.1",
+  "packageManager": "pnpm@9.15.4",
   "engines": {
     "node": ">=18.20.3"
   },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. netlify build is broken again see https://github.com/rolldown/rolldown/pull/3599#issuecomment-2661915468, I pin the pnpm for now to avoid broken netlify build
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
