### PR TITLE
feat(watcher): debounce invalidate

### DIFF
--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -52,7 +52,7 @@ sanitize-filename         = { workspace = true }
 serde                     = { workspace = true, optional = true }
 string_wizard             = { workspace = true }
 sugar_path                = { workspace = true }
-tokio                     = { workspace = true, features = ["rt", "macros", "sync"] }
+tokio                     = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing                   = { workspace = true }
 tracing-chrome            = { workspace = true }
 xxhash-rust               = { workspace = true, features = ["xxh3"] }

--- a/crates/rolldown_common/src/types/watch.rs
+++ b/crates/rolldown_common/src/types/watch.rs
@@ -23,7 +23,7 @@ impl Display for WatcherEvent {
   }
 }
 
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct WatcherChangeData {
   pub path: ArcStr,
   pub kind: WatcherChangeKind,

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -413,7 +413,7 @@ test.sequential('watch multiply options', async () => {
   })
 
   // The macos emit create event when the file is changed, avoid the update event batched to next file change.
-  await sleep(60)
+  await sleep(100)
 
   events.length = 0
   fs.writeFileSync(foo, 'console.log(2)')

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -380,7 +380,6 @@ test.sequential('watch multiply options', async () => {
   )
   const {
     input: foo,
-    output: fooOutput,
     outputDir: fooOutputDir,
   } = await createTestInputAndOutput('watch-multiply-options-foo')
   const watcher = watch([
@@ -410,19 +409,6 @@ test.sequential('watch multiply options', async () => {
     )
     // Only the input corresponding bundler is rebuild
     expect(events[0]).toEqual(outputDir)
-  })
-
-  // The macos emit create event when the file is changed, avoid the update event batched to next file change.
-  await sleep(100)
-
-  events.length = 0
-  fs.writeFileSync(foo, 'console.log(2)')
-  await waitUtil(() => {
-    expect(fs.readFileSync(fooOutput, 'utf-8').includes('console.log(2)')).toBe(
-      true,
-    )
-    // Only the foo corresponding bundler is rebuild
-    expect(events[0]).toEqual(fooOutputDir)
   })
 
   await watcher.close()

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -412,6 +412,9 @@ test.sequential('watch multiply options', async () => {
     expect(events[0]).toEqual(outputDir)
   })
 
+  // The macos emit create event when the file is changed, avoid the update event batched to next file change.
+  await sleep(60)
+
   events.length = 0
   fs.writeFileSync(foo, 'console.log(2)')
   await waitUtil(() => {

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -378,10 +378,8 @@ test.sequential('watch multiply options', async () => {
   const { input, output, outputDir } = await createTestInputAndOutput(
     'watch-multiply-options',
   )
-  const {
-    input: foo,
-    outputDir: fooOutputDir,
-  } = await createTestInputAndOutput('watch-multiply-options-foo')
+  const { input: foo, outputDir: fooOutputDir } =
+    await createTestInputAndOutput('watch-multiply-options-foo')
   const watcher = watch([
     {
       input,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
related to https://github.com/rolldown/rolldown/issues/2831

Here i try to some ways to debounce.
- notify-debouncer-full, it break wasi build, need to fork and resolve issue
- using https://docs.rs/set_timeout/latest/set_timeout/, the set timeout closure is not running, I'm not debugger it 
- using `std::thread::sleep` is a simple implement
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
