### PR TITLE
fix: glob import from parent dir

### DIFF
--- a/crates/rolldown_plugin_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_import_glob/src/lib.rs
@@ -233,7 +233,7 @@ impl<'ast> GlobImportVisit<'ast, '_> {
       // TODO handle error
       for file in glob(&absolute_glob).unwrap() {
         let file = file.unwrap().as_path().relative(dir.as_ref()).to_slash_lossy().to_string();
-        let prefix = if file.starts_with(".") { "" } else { "./" };
+        let prefix = if file.starts_with('.') { "" } else { "./" };
         files.push(format!("{prefix}{file}"));
       }
     }
@@ -446,7 +446,7 @@ fn to_absolute_glob<'a>(
 
   if let Some(glob) = glob.strip_prefix('/') {
     ret.push_str(&Path::new(root).join(glob).to_slash_lossy());
-  } else if glob.starts_with(".") {
+  } else if glob.starts_with('.') {
     ret.push_str(&dir.join(glob).to_slash_lossy());
   } else if glob.starts_with("**") {
     ret.push_str(glob);

--- a/crates/rolldown_plugin_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_import_glob/src/lib.rs
@@ -233,7 +233,7 @@ impl<'ast> GlobImportVisit<'ast, '_> {
       // TODO handle error
       for file in glob(&absolute_glob).unwrap() {
         let file = file.unwrap().as_path().relative(dir.as_ref()).to_slash_lossy().to_string();
-        let prefix = if file.chars().nth(0).unwrap() == '.' { "" } else { "./" };
+        let prefix = if file.starts_with(".") { "" } else { "./" };
         files.push(format!("{prefix}{file}"));
       }
     }
@@ -446,9 +446,7 @@ fn to_absolute_glob<'a>(
 
   if let Some(glob) = glob.strip_prefix('/') {
     ret.push_str(&Path::new(root).join(glob).to_slash_lossy());
-  } else if let Some(glob) = glob.strip_prefix("./") {
-    ret.push_str(&dir.join(glob).to_slash_lossy());
-  } else if glob.starts_with("../") {
+  } else if glob.starts_with(".") {
     ret.push_str(&dir.join(glob).to_slash_lossy());
   } else if glob.starts_with("**") {
     ret.push_str(glob);

--- a/crates/rolldown_plugin_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_import_glob/src/lib.rs
@@ -233,7 +233,8 @@ impl<'ast> GlobImportVisit<'ast, '_> {
       // TODO handle error
       for file in glob(&absolute_glob).unwrap() {
         let file = file.unwrap().as_path().relative(dir.as_ref()).to_slash_lossy().to_string();
-        files.push(format!("./{file}"));
+        let prefix = if file.chars().nth(0).unwrap() == '.' { "" } else { "./" };
+        files.push(format!("{prefix}{file}"));
       }
     }
   }
@@ -439,19 +440,16 @@ fn to_absolute_glob<'a>(
     glob = &glob[1..];
   }
 
-  let dir = {
-    let dir = Path::new(importer).parent().unwrap_or_else(|| Path::new(root));
-    dir.to_slash_lossy()
-  };
+  let dir = Path::new(importer).parent().unwrap_or_else(|| Path::new(root));
 
   let mut ret = if let Some(pre) = pre { String::from(pre) } else { String::new() };
 
   if let Some(glob) = glob.strip_prefix('/') {
     ret.push_str(&Path::new(root).join(glob).to_slash_lossy());
   } else if let Some(glob) = glob.strip_prefix("./") {
-    ret.push_str(&Path::new(dir.as_ref()).join(glob).to_slash_lossy());
-  } else if let Some(glob) = glob.strip_prefix("../") {
-    ret.push_str(&Path::new(dir.as_ref()).join(glob).to_slash_lossy());
+    ret.push_str(&dir.join(glob).to_slash_lossy());
+  } else if glob.starts_with("../") {
+    ret.push_str(&dir.join(glob).to_slash_lossy());
   } else if glob.starts_with("**") {
     ret.push_str(glob);
   } else {
@@ -459,5 +457,5 @@ fn to_absolute_glob<'a>(
     // Needs to investigate if oxc resolver support this pattern
     return Err(anyhow::format_err!("Invalid glob pattern: {}", glob));
   };
-  Ok((ret, dir))
+  Ok((ret, dir.to_slash_lossy()))
 }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/parent/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/parent/_config.ts
@@ -1,0 +1,17 @@
+import { importGlobPlugin } from 'rolldown/experimental'
+import { defineTest } from 'rolldown-tests'
+import * as path from 'node:path'
+
+export default defineTest({
+  config: {
+    input: './src/main.js',
+    plugins: [
+      importGlobPlugin({
+        root: path.resolve(import.meta.dirname),
+      }),
+    ],
+  },
+  async afterTest() {
+    await import('./assert.mjs')
+  },
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/parent/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/parent/assert.mjs
@@ -1,0 +1,13 @@
+// @ts-nocheck
+import assert from 'node:assert'
+import modules from './dist/main'
+
+assert.strictEqual(Object.keys(modules).length, 2)
+
+modules['../dir/a.js']().then((m) => {
+  assert.strictEqual(m.default, 'a')
+})
+
+modules['../dir/b.js']().then((m) => {
+  assert.strictEqual(m.default, 'b')
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/parent/dir/a.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/parent/dir/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/parent/dir/b.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/parent/dir/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/parent/src/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/parent/src/main.js
@@ -1,0 +1,1 @@
+export default import.meta.glob('../dir/*.js');


### PR DESCRIPTION
### Description

If `import.meta.glob` pattern starts with `../`, it's currently resolved relative to current dir instead of parent dir.