### PR TITLE
chore: fix vitest warnings

### DIFF
--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/query-object/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/query-object/_config.ts
@@ -20,17 +20,17 @@ export default defineTest({
     ],
   },
   async afterTest(output: RolldownOutput) {
-    output.output.forEach((chunk) => {
+    output.output.forEach(async (chunk) => {
       if (chunk.type === 'chunk') {
         switch (chunk.name) {
           case 'b': {
-            expect(chunk.code).toMatchFileSnapshot(
+            await expect(chunk.code).toMatchFileSnapshot(
               path.resolve(import.meta.dirname, 'dir/b.js.snap'),
             )
             break
           }
           case 'dir_index': {
-            expect(chunk.code).toMatchFileSnapshot(
+            await expect(chunk.code).toMatchFileSnapshot(
               path.resolve(import.meta.dirname, 'dir/index.js.snap'),
             )
             break

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/query/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/query/_config.ts
@@ -20,17 +20,17 @@ export default defineTest({
     ],
   },
   async afterTest(output: RolldownOutput) {
-    output.output.forEach((chunk) => {
+    output.output.forEach(async (chunk) => {
       if (chunk.type === 'chunk') {
         switch (chunk.name) {
           case 'b': {
-            expect(chunk.code).toMatchFileSnapshot(
+            await expect(chunk.code).toMatchFileSnapshot(
               path.resolve(import.meta.dirname, 'dir/b.js.snap'),
             )
             break
           }
           case 'dir_index': {
-            expect(chunk.code).toMatchFileSnapshot(
+            await expect(chunk.code).toMatchFileSnapshot(
               path.resolve(import.meta.dirname, 'dir/index.js.snap'),
             )
             break

--- a/packages/rolldown/tests/fixtures/builtin-plugin/module_preload_polyfill/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/module_preload_polyfill/basic/_config.ts
@@ -8,9 +8,8 @@ export default defineTest({
   config: {
     plugins: [modulePreloadPolyfillPlugin()],
   },
-
-  afterTest(output: RolldownOutput) {
-    expect(output.output[0].code).toMatchFileSnapshot(
+  async afterTest(output: RolldownOutput) {
+    await expect(output.output[0].code).toMatchFileSnapshot(
       path.resolve(import.meta.dirname, 'main.js.snap'),
     )
   },

--- a/packages/rolldown/tests/fixtures/function/comments/preserve-legal-comments/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/comments/preserve-legal-comments/_config.ts
@@ -8,8 +8,8 @@ export default defineTest({
       comments: 'preserve-legal',
     },
   },
-  afterTest: function (output) {
-    expect(output.output[0].code).toMatchFileSnapshot(
+  async afterTest(output) {
+    await expect(output.output[0].code).toMatchFileSnapshot(
       nodePath.join(import.meta.dirname, 'output.snap'),
     )
   },

--- a/packages/rolldown/tests/fixtures/function/define/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/define/_config.ts
@@ -8,8 +8,8 @@ export default defineTest({
       'process.env.NODE_ENV': '"production"',
     },
   },
-  afterTest: function (output) {
-    expect(output.output[0].code).toMatchFileSnapshot(
+  async afterTest(output) {
+    await expect(output.output[0].code).toMatchFileSnapshot(
       nodePath.join(import.meta.dirname, 'output.snap'),
     )
   },

--- a/packages/rolldown/tests/fixtures/function/inject/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/inject/_config.ts
@@ -17,8 +17,8 @@ export default defineTest({
     },
     external: ['node:assert'],
   },
-  afterTest: function (output) {
-    expect(output.output[0].code).toMatchFileSnapshot(
+  async afterTest(output) {
+    await expect(output.output[0].code).toMatchFileSnapshot(
       nodePath.join(import.meta.dirname, 'output.snap'),
     )
   },


### PR DESCRIPTION
### Description

Fixes the following warning:
`Promise returned by expect(actual).toMatchFileSnapshot(expected) was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.`