### PR TITLE
fix(node): make `in` for additional properties in OutputChunk work

### DIFF
--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -85,6 +85,10 @@ function transformToRollupOutputChunk(
       changed?.updated.add(bindingChunk.fileName)
       return true
     },
+    has(target, p): boolean {
+      if (p in cache) return true
+      return p in target
+    },
   })
 }
 

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
@@ -9,6 +9,10 @@ const entry = path.join(__dirname, './main.js')
 
 const calls: string[] = []
 
+type RolldownOutputChunkWithCustomProperty = RolldownOutputChunk & {
+  customProperty: string
+}
+
 export default defineTest({
   config: {
     input: [entry, path.join(__dirname, './index.js')],
@@ -37,6 +41,12 @@ export default defineTest({
           expect(isWrite).toBe(true)
           // Mutate chunk
           chunk.code = 'console.error()'
+          ;(chunk as RolldownOutputChunkWithCustomProperty).customProperty =
+            'customProperty'
+          expect(
+            (chunk as RolldownOutputChunkWithCustomProperty).customProperty,
+          ).toBe('customProperty')
+          expect('customProperty' in chunk).toBe(true)
           // Delete chunk
           delete bundle['index.js']
           delete bundle['share.js']


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`foo in outputChunk` did not work when `foo` is a property that does not exist in `OutputChunk`.
This PR fixes that for
https://github.com/withastro/astro/blob/3842ce5ec9471d358042b3d9ef697cf06c7a91f6/packages/astro/src/core/build/plugins/plugin-css.ts#L109

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
