### PR TITLE
fix: don't enable drop_console when compress is true

### DIFF
--- a/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
@@ -84,7 +84,7 @@ impl MinifyOptionsObject {
   pub fn to_oxc_minifier_options(&self, target: ESTarget) -> oxc::minifier::MinifierOptions {
     oxc::minifier::MinifierOptions {
       mangle: self.mangle.then_some(MangleOptions { top_level: true, debug: false }),
-      compress: Some(CompressOptions { target, drop_debugger: true, drop_console: true })
+      compress: Some(CompressOptions { target, drop_debugger: false, drop_console: false })
         .filter(|_| self.compress),
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Closed https://github.com/rolldown/rolldown/issues/3637
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
