### PR TITLE
feat(node): make `parseAst` compatible with rollup

### DIFF
--- a/packages/rolldown/src/parse-ast-index.ts
+++ b/packages/rolldown/src/parse-ast-index.ts
@@ -70,23 +70,40 @@ function normalizeParseError(
   return error(logParseError(message))
 }
 
+const defaultParserOptions: ParserOptions = {
+  lang: 'js',
+  preserveParens: false,
+  convertSpanUtf16: true,
+}
+
 // The api compat to rollup `parseAst` and `parseAstAsync`.
 
 export function parseAst(
-  filename: string,
   sourceText: string,
   options?: ParserOptions | undefined | null,
+  filename?: string,
 ): Program {
-  return wrap(parseSync(filename, sourceText, options), sourceText).program
+  return wrap(
+    parseSync(filename ?? 'file.js', sourceText, {
+      ...defaultParserOptions,
+      ...options,
+    }),
+    sourceText,
+  ).program
 }
 
 export async function parseAstAsync(
-  filename: string,
   sourceText: string,
   options?: ParserOptions | undefined | null,
+  filename?: string,
 ): Promise<Program> {
-  return wrap(await parseAsync(filename, sourceText, options), sourceText)
-    .program
+  return wrap(
+    await parseAsync(filename ?? 'file.js', sourceText, {
+      ...defaultParserOptions,
+      ...options,
+    }),
+    sourceText,
+  ).program
 }
 
 export type { ParseResult, ParserOptions }

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -194,6 +194,6 @@ export class PluginContext extends MinimalPluginContext {
     input: string,
     options?: ParserOptions | undefined | null,
   ): Program {
-    return parseAst('test.js', input, options)
+    return parseAst(input, options)
   }
 }

--- a/packages/rolldown/tests/parse-ast/parse-ast.test.ts
+++ b/packages/rolldown/tests/parse-ast/parse-ast.test.ts
@@ -2,18 +2,18 @@ import { parseAst, parseAstAsync } from 'rolldown/parseAst'
 import { test, expect } from 'vitest'
 
 test('rolldown/parseAst parseSync', async () => {
-  const result = parseAst('test.js', 'console.log("hello")')
+  const result = parseAst('console.log("hello")')
   expect(result.type).toBe('Program')
 })
 
 test('rolldown/parseAst parseAstAsync', async () => {
-  const result = await parseAstAsync('test.js', 'console.log("hello")')
+  const result = await parseAstAsync('console.log("hello")')
   expect(result.type).toBe('Program')
 })
 
 test('rolldown/parseAst parseSync + error', async () => {
   try {
-    parseAst('test.js', '\nconso le.log("hello")')
+    parseAst('\nconso le.log("hello")')
     expect.unreachable()
   } catch (error: any) {
     expect(error.message).toMatchInlineSnapshot(`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Based on the discussions in #3630, this PR makes `parseAst`'s default settings compatible with rollup. I also changed the parameter order to be the same with rollup.

close #3630

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
