### PR TITLE
chore: avoid init class public fileds

### DIFF
--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -17,10 +17,7 @@ export class BuiltinPlugin {
     public name: BindingBuiltinPluginName,
     // NOTE: has `_` to avoid conflict with `options` hook
     public _options?: unknown,
-  ) {
-    this.name = name
-    this._options = _options
-  }
+  ) {}
 }
 
 export function modulePreloadPolyfillPlugin(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

avoid gnereate code like this.

``` .js
var BuiltinPlugin = class {
	constructor(name, _options) {
		this.name = name;
		this._options = _options;
		this.name = name;
		this._options = _options;
	}
};
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
