### PR TITLE
chore(deps): bump `fast-glob` to v0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "fast-glob"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eca69ef247d19faa15ac0156968637440824e5ff22baa5ee0cd35b2f7ea6a0f"
+checksum = "a43e28342e6608e53d694e6a12f56ebd1c9228df61b8edbe6a9a882cab5f4a93"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ daachorse           = "1.0.0"
 dashmap             = "6.0.0"
 derive_more         = { version = "2.0.1", features = ["debug"] }
 dunce               = "1.0.4"                                                                           # Normalize Windows paths to the most compatible format, avoiding UNC where possible
-fast-glob           = "0.4.3"
+fast-glob           = "0.4.4"
 futures             = "0.3.30"
 glob                = "0.3.1"
 heck                = { version = "0.5.0" }


### PR DESCRIPTION
### Description

Related to https://github.com/shulaoda/fast-glob/pull/10

Fixed some matching issues.