### PR TITLE
refactor(rust): apply `clippy::redundant_clone`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ inconsistent_struct_constructor = "allow"
 single_match      = "allow"
 single_match_else = "allow"
 
+# Though the following are nursery rules, they’re still useful.
+redundant_clone = "warn"
+
 [workspace.dependencies]
 criterion2                              = { version = "2.0.0", default-features = false }
 css-module-lexer                        = "0.0.15"

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -98,8 +98,7 @@ impl<'name> Renamer<'name> {
   }
 
   pub fn create_conflictless_name(&mut self, hint: &str) -> String {
-    let hint = Rstr::new(hint);
-    let mut conflictless_name = hint.clone();
+    let mut conflictless_name = Rstr::new(hint);
     loop {
       match self.used_canonical_names.entry(conflictless_name.clone()) {
         Entry::Occupied(mut occ) => {
@@ -119,8 +118,8 @@ impl<'name> Renamer<'name> {
 
   #[allow(dead_code)]
   pub fn add_symbol_name_ref_token(&mut self, token: &SymbolNameRefToken) {
-    let hint = Rstr::new(token.value());
-    let mut conflictless_name = hint.clone();
+    let hint = token.value();
+    let mut conflictless_name = Rstr::new(hint);
     loop {
       match self.used_canonical_names.entry(conflictless_name.clone()) {
         Entry::Occupied(mut occ) => {
@@ -135,7 +134,7 @@ impl<'name> Renamer<'name> {
         }
       }
     }
-    self.canonical_token_to_name.insert(token.clone(), conflictless_name.clone());
+    self.canonical_token_to_name.insert(token.clone(), conflictless_name);
   }
 
   // non-top-level symbols won't be linked cross-module. So the canonical `SymbolRef` for them are themselves.

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -133,7 +133,7 @@ pub fn normalize_binding_options(
       let ts_fn = Arc::clone(&ts_fn);
       Box::pin(async move {
         ts_fn
-          .invoke_async((source.to_string(), importer.map(|v| v.to_string()), is_resolved).into())
+          .invoke_async((source.to_string(), importer, is_resolved).into())
           .await
           .map_err(anyhow::Error::from)
       })

--- a/crates/rolldown_plugin_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_import_glob/src/lib.rs
@@ -184,7 +184,7 @@ fn extract_import_glob_options(arg: &Argument, opts: &mut ImportGlobOptions) {
                 Expression::NullLiteral(_) => "null".to_string(),
                 _ => return None,
               };
-              Some((key, value.to_string()))
+              Some((key, value))
             })
             .collect::<FxHashMap<String, String>>();
           if !map.is_empty() {

--- a/crates/rolldown_plugin_module_federation/src/lib.rs
+++ b/crates/rolldown_plugin_module_federation/src/lib.rs
@@ -103,7 +103,6 @@ impl ModuleFederationPlugin {
       .replace("__PLUGINS__", &self.generate_runtime_plugins())
       .replace("__SHARED__", &self.generate_shared_modules())
       .replace("__NAME__", &concat_string!("'", &self.options.name, "'"))
-      .to_string()
   }
 
   pub fn generate_init_host_code(&self) -> String {
@@ -136,7 +135,6 @@ impl ModuleFederationPlugin {
       .replace("__PLUGINS__", &self.generate_runtime_plugins())
       .replace("__NAME__", &concat_string!("'", &self.options.name, "'"))
       .replace("__SHARED__", &self.generate_shared_modules())
-      .to_string()
   }
 
   pub fn generate_runtime_plugins(&self) -> String {
@@ -346,8 +344,7 @@ impl Plugin for ModuleFederationPlugin {
       return Ok(Some(rolldown_plugin::HookLoadOutput {
         code: include_str!("runtime/init-remote-module.js")
           .replace("__MODULE_ID__", &concat_string!("'", remote_module_id, "'"))
-          .replace("__IS__SHARED__", "false")
-          .to_string(),
+          .replace("__IS__SHARED__", "false"),
         ..Default::default()
       }));
     }
@@ -356,16 +353,13 @@ impl Plugin for ModuleFederationPlugin {
       return Ok(Some(rolldown_plugin::HookLoadOutput {
         code: include_str!("runtime/init-remote-module.js")
           .replace("__MODULE_ID__", &concat_string!("'", remote_module_id, "'"))
-          .replace("__IS__SHARED__", "true")
-          .to_string(),
+          .replace("__IS__SHARED__", "true"),
         ..Default::default()
       }));
     }
     if detect_remote_module_type(args.id, &self.options).is_some() {
       return Ok(Some(rolldown_plugin::HookLoadOutput {
-        code: include_str!("runtime/remote-module.js")
-          .replace("__REMOTE__MODULE__ID__", args.id)
-          .to_string(),
+        code: include_str!("runtime/remote-module.js").replace("__REMOTE__MODULE__ID__", args.id),
         ..Default::default()
       }));
     }

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -98,7 +98,7 @@ fn test_collapse_sourcemaps() {
       ..CodegenOptions::default()
     })
     .build(&ret1.program);
-  source_joiner.append_source(SourceMapSource::new(code.clone(), map.as_ref().unwrap().clone()));
+  source_joiner.append_source(SourceMapSource::new(code, map.as_ref().unwrap().clone()));
 
   let filename = "bar.js".to_string();
   let source_text = "const bar = 2; console.log(bar);\n".to_string();
@@ -109,7 +109,7 @@ fn test_collapse_sourcemaps() {
       ..CodegenOptions::default()
     })
     .build(&ret2.program);
-  source_joiner.append_source(SourceMapSource::new(code.clone(), map.as_ref().unwrap().clone()));
+  source_joiner.append_source(SourceMapSource::new(code, map.as_ref().unwrap().clone()));
 
   let (source_text, source_map) = source_joiner.join();
 

--- a/crates/rolldown_sourcemap/src/source_joiner.rs
+++ b/crates/rolldown_sourcemap/src/source_joiner.rs
@@ -97,7 +97,7 @@ fn test_concat_sourcemaps() {
       ..CodegenOptions::default()
     })
     .build(&ret1.program);
-  source_joiner.append_source(SourceMapSource::new(code.clone(), map.as_ref().unwrap().clone()));
+  source_joiner.append_source(SourceMapSource::new(code, map.as_ref().unwrap().clone()));
 
   let (content, map) = source_joiner.join();
 


### PR DESCRIPTION
### Description

Inspired by the recent adoption of clippy nursery rules in `oxc`, I think we could also enable some rules to optimize our code.