### PR TITLE
chore(clippy): support more nursery rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,13 @@ single_match      = "allow"
 single_match_else = "allow"
 
 # Though the following are nursery rules, they’re still useful.
-redundant_clone = "warn"
+debug_assert_with_mut_call    = "warn"
+iter_on_single_items          = "allow"
+needless_pass_by_ref_mut      = "allow"
+redundant_clone               = "warn"
+redundant_pub_crate           = "allow"
+significant_drop_in_scrutinee = "allow"
+unused_peekable               = "warn"
 
 [workspace.dependencies]
 criterion2                              = { version = "2.0.0", default-features = false }


### PR DESCRIPTION
### Description

Related to #3670

I ported several key clippy nursery rules from `oxc` and plan to enable the rules one by one.