### PR TITLE
perf: replace data url parse with nom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,7 +2484,7 @@ name = "rolldown_plugin_data_url"
 version = "0.1.0"
 dependencies = [
  "base64-simd",
- "regex",
+ "nom",
  "rolldown_common",
  "rolldown_plugin",
  "rolldown_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ mime                = "0.3.17"
 napi                = { version = "3.0.0-alpha.31", features = ["async", "anyhow"] }
 napi-build          = { version = "2.1.5" }
 napi-derive         = { version = "3.0.0-alpha.28", default-features = false, features = ["type-def"] }
+nom                 = "8.0.0"
 notify              = { version = "8.0.0" }
 phf                 = "0.11.3"
 rayon               = "1.10.0"

--- a/crates/rolldown_plugin_data_url/Cargo.toml
+++ b/crates/rolldown_plugin_data_url/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 
 [dependencies]
 base64-simd     = { workspace = true }
-regex           = { workspace = true }
+nom             = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_utils  = { workspace = true }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

The less we use `LazyLock` and `thread_local!`, the lower the probability we encounter strange issues on the Linux platform.

### Description

```txt
running 2 tests
test tests::nom   ... bench:         478.47 ns/iter (+/- 23.38)
test tests::regex ... bench:       3,223.12 ns/iter (+/- 109.90)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 2.20s
```

Benchmark:

```rust
#![feature(test)]

extern crate test;

use std::sync::LazyLock;

use nom::{
    bytes::complete::{tag, take_till, take_while},
    character::complete::char,
    combinator::{map, opt, recognize},
    error::Error,
    sequence::preceded,
    IResult, Parser,
};
use regex::Regex;

const URLS: &[&str] = &[
    // Data URLs
    "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==",
    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
    "  data:text/html,<h1>Hello World</h1>",
    "data:,Hello%2C%20World!",
    "data:text/plain;charset=UTF-8,Hello%20World",
    "data:application/json,{\"message\":\"Hello\"}",
    "data:text/css;base64,Ym9keXtjb2xvcjpyZWQ7fQ=="
];

static DATA_URL_RE: LazyLock<Regex> = LazyLock::new(|| {
    Regex::new("^data:([^/]+\\/[^;]+)(;charset=[^;]+)?(;base64)?,([\\s\\S]*)$").unwrap()
});

pub struct ParsedDataUrl<'a> {
    pub mime: &'a str,
    pub is_base64: bool,
    pub data: &'a str,
}

#[inline]
// Parse the data URL with a more flexible approach
fn parse_data_url_nom(input: &str) -> IResult<&str, ParsedDataUrl> {
  // Start with "data:" prefix
  let (input, _) = tag("data:")(input)?;

  // Parse the MIME type
  let (input, mime) = recognize(take_till(|c| c == ';' || c == ',')).parse(input)?;

  // Handle the case where there's no charset or base64 marker
  if let Ok((remaining, data)) =
    preceded(char::<_, Error<_>>(','), take_while(|_| true)).parse(input)
  {
    return Ok((
      remaining,
      ParsedDataUrl { mime: mime.trim(), is_base64: false, data: data.trim() },
    ));
  }

  // Parse optional charset
  let (input, _) =
    opt(preceded(tag(";charset="), take_till(|c| c == ';' || c == ','))).parse(input)?;

  // Check for base64 encoding
  let (input, is_base64) = map(opt(tag(";base64")), |opt_tag| opt_tag.is_some()).parse(input)?;

  // Parse the data part after the comma
  let (remaining, data) = preceded(char(','), take_while(|_| true)).parse(input)?;

  Ok((remaining, ParsedDataUrl { mime: mime.trim(), is_base64, data: data.trim() }))
}

pub fn parse_data_url(dataurl: &str) -> Option<ParsedDataUrl> {
  match parse_data_url_nom(dataurl) {
    Ok((_, parsed)) => Some(parsed),
    Err(_) => None,
  }
}


pub fn parse_data_url_regex(dataurl: &str) -> Option<ParsedDataUrl> {
    let captures = DATA_URL_RE.captures(dataurl)?;
    let mime = captures.get(1).map(|m| m.as_str())?;
    let is_base64 = captures.get(3).is_some();
    let data = captures.get(4).map(|m| m.as_str())?;
    Some(ParsedDataUrl {
        mime: mime.trim(),
        is_base64,
        data: data.trim(),
    })
}

#[cfg(test)]
mod tests {
    use test::{black_box, Bencher};

    use super::*;

    #[bench]
    fn nom(b: &mut Bencher) {
        b.iter(|| {
            for url in URLS {
                black_box(parse_data_url(url));
            }
        });
    }

    #[bench]
    fn regex(b: &mut Bencher) {
        b.iter(|| {
            for url in URLS {
                black_box(parse_data_url_regex(url));
            }
        });
    }
}

```
