### PR TITLE
fix: preserve this for PluginContext#emitFile

### DIFF
--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -143,7 +143,7 @@ export class PluginContext extends MinimalPluginContext {
     return { ...res, ...info }
   }
 
-  public emitFile(file: EmittedAsset | EmittedChunk): string {
+  public emitFile = (file: EmittedAsset | EmittedChunk): string => {
     // @ts-expect-error
     if (file.type === 'prebuilt-chunk') {
       return unimplemented('PluginContext.emitFile with type prebuilt-chunk')

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
@@ -4,6 +4,7 @@ import { getOutputAsset } from 'rolldown-tests/utils'
 import { expect } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
+import type { PluginContext } from 'rolldown'
 
 let referenceId: string
 
@@ -26,6 +27,7 @@ export default defineTest({
             source: 'emitted',
             originalFileName: ORIGINAL_FILE_NAME,
           })
+          testEmitFileThis(this.emitFile)
         },
         generateBundle() {
           expect(this.getFileName(referenceId)).toMatchInlineSnapshot(
@@ -64,3 +66,12 @@ export default defineTest({
     }
   },
 })
+
+function testEmitFileThis(emitFile: PluginContext['emitFile']) {
+  const emitted = emitFile({
+    type: 'asset',
+    name: 'emitFileThis.txt',
+    source: 'emitFileThis',
+  })
+  expect(emitted).toMatchInlineSnapshot(`"_emitted-C6bBH0W1.txt"`)
+}

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
@@ -73,5 +73,5 @@ function testEmitFileThis(emitFile: PluginContext['emitFile']) {
     name: 'emitFileThis.txt',
     source: 'emitFileThis',
   })
-  expect(emitted).toBeTypeOf("string")
+  expect(emitted).toBeTypeOf('string')
 }

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
@@ -73,5 +73,5 @@ function testEmitFileThis(emitFile: PluginContext['emitFile']) {
     name: 'emitFileThis.txt',
     source: 'emitFileThis',
   })
-  expect(emitted).toMatchInlineSnapshot(`"_emitted-C6bBH0W1.txt"`)
+  expect(emitted).toBeTypeOf("string")
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

similar to #3634 but for `this.emitFile`. It was used in astro.

I didn't convert all the methods for now as it's known there's some overhead of binding `this` (https://github.com/vitejs/vite/pull/15610).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
