### PR TITLE
chore: silence rolldown warnings in tests

### DIFF
--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/should-not-match/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/should-not-match/_config.ts
@@ -1,6 +1,8 @@
 import { aliasPlugin } from 'rolldown/experimental'
 import { defineTest } from 'rolldown-tests'
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
+
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
@@ -10,9 +12,19 @@ export default defineTest({
         entries: [{ find: 'rolldown', replacement: '.' }],
       }),
     ],
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('UNRESOLVED_IMPORT')
+      expect(log.message).toContain(
+        "Could not resolve 'rolldownlib.js' in main.js",
+      )
+      onLogFn()
+    },
   },
   // cspell:ignore rolldownlib
   async afterTest() {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
+
     try {
       await import('./assert.mjs')
     } catch (err: any) {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/_config.ts
@@ -1,8 +1,6 @@
 import { buildImportAnalysisPlugin } from 'rolldown/experimental'
 import { defineTest } from 'rolldown-tests'
-import { expect, vi } from 'vitest'
-
-const onLogFn = vi.fn()
+import { expect } from 'vitest'
 
 export default defineTest({
   skipComposingJsPlugin: true,
@@ -34,20 +32,10 @@ export const __vitePreload = (v) => {
         isRelativeBase: false,
       }),
     ],
-    onLog(level, log) {
-      expect(level).toBe('warn')
-      expect(log.code).toBe('UNRESOLVED_IMPORT')
-      expect(log.message).toContain(
-        "Could not resolve 'node:assert' in main.js",
-      )
-      onLogFn()
-    },
+    external: ['node:assert'],
   },
   async afterTest(output) {
-    expect(onLogFn).toHaveBeenCalledTimes(1)
-
     await import('./assert.mjs')
-
     output.output.forEach((item) => {
       if (item.type === 'chunk' && item.name === 'main') {
         expect(item.code).to.not.includes('import.meta.url')

--- a/packages/rolldown/tests/fixtures/function/define/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/define/_config.ts
@@ -1,14 +1,26 @@
 import { defineTest } from 'rolldown-tests'
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
 import nodePath from 'node:path'
+
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
     define: {
       'process.env.NODE_ENV': '"production"',
     },
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('UNRESOLVED_IMPORT')
+      expect(log.message).toContain(
+        "Could not resolve 'node:assert' in main.js",
+      )
+      onLogFn()
+    },
   },
   async afterTest(output) {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
+
     await expect(output.output[0].code).toMatchFileSnapshot(
       nodePath.join(import.meta.dirname, 'output.snap'),
     )

--- a/packages/rolldown/tests/fixtures/function/define/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/define/_config.ts
@@ -1,26 +1,15 @@
 import { defineTest } from 'rolldown-tests'
-import { expect, vi } from 'vitest'
+import { expect } from 'vitest'
 import nodePath from 'node:path'
-
-const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
     define: {
       'process.env.NODE_ENV': '"production"',
     },
-    onLog(level, log) {
-      expect(level).toBe('warn')
-      expect(log.code).toBe('UNRESOLVED_IMPORT')
-      expect(log.message).toContain(
-        "Could not resolve 'node:assert' in main.js",
-      )
-      onLogFn()
-    },
+    external: ['node:assert'],
   },
   async afterTest(output) {
-    expect(onLogFn).toHaveBeenCalledTimes(1)
-
     await expect(output.output[0].code).toMatchFileSnapshot(
       nodePath.join(import.meta.dirname, 'output.snap'),
     )

--- a/packages/rolldown/tests/fixtures/jsx/refresh/_config.ts
+++ b/packages/rolldown/tests/fixtures/jsx/refresh/_config.ts
@@ -1,6 +1,8 @@
 import { defineTest } from 'rolldown-tests'
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
 import { getOutputChunk } from 'rolldown-tests/utils'
+
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
@@ -9,8 +11,18 @@ export default defineTest({
       refresh: true,
     },
     external: ['react'],
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('UNRESOLVED_IMPORT')
+      expect(log.message).toContain(
+        "Could not resolve 'react/jsx-runtime' in main.jsx",
+      )
+      onLogFn()
+    },
   },
   afterTest: (output) => {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
+
     const chunk = getOutputChunk(output)[0]
     expect(chunk.code.includes('$RefreshReg$')).toBe(true)
   },

--- a/packages/rolldown/tests/fixtures/jsx/refresh/_config.ts
+++ b/packages/rolldown/tests/fixtures/jsx/refresh/_config.ts
@@ -1,8 +1,6 @@
 import { defineTest } from 'rolldown-tests'
-import { expect, vi } from 'vitest'
+import { expect } from 'vitest'
 import { getOutputChunk } from 'rolldown-tests/utils'
-
-const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
@@ -10,19 +8,9 @@ export default defineTest({
     jsx: {
       refresh: true,
     },
-    external: ['react'],
-    onLog(level, log) {
-      expect(level).toBe('warn')
-      expect(log.code).toBe('UNRESOLVED_IMPORT')
-      expect(log.message).toContain(
-        "Could not resolve 'react/jsx-runtime' in main.jsx",
-      )
-      onLogFn()
-    },
+    external: ['react', 'react/jsx-runtime'],
   },
   afterTest: (output) => {
-    expect(onLogFn).toHaveBeenCalledTimes(1)
-
     const chunk = getOutputChunk(output)[0]
     expect(chunk.code.includes('$RefreshReg$')).toBe(true)
   },

--- a/packages/rolldown/tests/fixtures/misc/keep-names/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/keep-names/basic/_config.ts
@@ -1,23 +1,11 @@
 import { defineTest } from 'rolldown-tests'
-import { expect, vi } from 'vitest'
-
-const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
     keepNames: true,
-    onLog(level, log) {
-      expect(level).toBe('warn')
-      expect(log.code).toBe('UNRESOLVED_IMPORT')
-      expect(log.message).toContain(
-        "Could not resolve 'node:assert' in main.js",
-      )
-      onLogFn()
-    },
+    external: ['node:assert'],
   },
   afterTest: async () => {
-    expect(onLogFn).toHaveBeenCalledTimes(1)
-
     await import('./assert.mjs')
   },
 })

--- a/packages/rolldown/tests/fixtures/misc/keep-names/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/keep-names/basic/_config.ts
@@ -1,10 +1,23 @@
 import { defineTest } from 'rolldown-tests'
+import { expect, vi } from 'vitest'
+
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
     keepNames: true,
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('UNRESOLVED_IMPORT')
+      expect(log.message).toContain(
+        "Could not resolve 'node:assert' in main.js",
+      )
+      onLogFn()
+    },
   },
   afterTest: async () => {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
+
     await import('./assert.mjs')
   },
 })

--- a/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-false/_config.ts
@@ -1,6 +1,8 @@
 import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from 'rolldown-tests'
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
+
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
@@ -9,8 +11,15 @@ export default defineTest({
       format: 'iife',
       esModule: 'if-default-prop',
     },
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('MISSING_NAME_OPTION_FOR_IIFE_EXPORT')
+      onLogFn()
+    },
   },
   afterTest: (output) => {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
+
     expect(
       output.output
         .filter(({ type }) => type === 'chunk')

--- a/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-true/_config.ts
@@ -1,6 +1,8 @@
 import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from 'rolldown-tests'
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
+
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
@@ -9,8 +11,15 @@ export default defineTest({
       format: 'iife',
       esModule: 'if-default-prop',
     },
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('MISSING_NAME_OPTION_FOR_IIFE_EXPORT')
+      onLogFn()
+    },
   },
   afterTest: (output) => {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
+
     expect(
       output.output
         .filter(({ type }) => type === 'chunk')

--- a/packages/rolldown/tests/fixtures/output/format/iife/exports/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/format/iife/exports/_config.ts
@@ -1,5 +1,8 @@
 import { defineTest } from 'rolldown-tests'
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
+import type { LogLevel, RollupLog } from 'rolldown'
+
+const logs: Array<{ level: LogLevel; log: RollupLog }> = []
 
 export default defineTest({
   config: {
@@ -8,8 +11,20 @@ export default defineTest({
       exports: 'named',
       format: 'iife',
     },
+    onLog(level, log) {
+      logs.push({ level, log })
+    },
   },
   afterTest: (output) => {
+    expect(logs).toHaveLength(2)
+    expect(logs[0].level).toBe('warn')
+    expect(logs[0].log.code).toBe('MISSING_NAME_OPTION_FOR_IIFE_EXPORT')
+    expect(logs[1].level).toBe('warn')
+    expect(logs[1].log.code).toBe('MISSING_GLOBAL_NAME')
+    expect(logs[1].log.message).toContain(
+      'No name was provided for external module "node:path" in "output.globals" – guessing "node_path".',
+    )
+
     expect(output.output[0].code).toMatchInlineSnapshot(`
       "(function(exports, node_path) {
 

--- a/packages/rolldown/tests/fixtures/output/intro/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/intro/string/_config.ts
@@ -1,8 +1,9 @@
 import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from 'rolldown-tests'
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
 
 const introText = '/* intro test */\n'
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
@@ -10,5 +11,13 @@ export default defineTest({
       format: 'iife',
       intro: introText,
     },
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('MISSING_NAME_OPTION_FOR_IIFE_EXPORT')
+      onLogFn()
+    },
+  },
+  afterTest() {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
   },
 })

--- a/packages/rolldown/tests/fixtures/output/outro/string/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/outro/string/_config.ts
@@ -1,6 +1,8 @@
 import { defineTest } from 'rolldown-tests'
+import { expect, vi } from 'vitest'
 
 const outroText = '/* outro test */\n'
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
@@ -8,5 +10,13 @@ export default defineTest({
       format: 'iife',
       outro: outroText,
     },
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('MISSING_NAME_OPTION_FOR_IIFE_EXPORT')
+      onLogFn()
+    },
+  },
+  afterTest() {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
   },
 })

--- a/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
@@ -8,19 +8,19 @@ export default defineTest({
     plugins: [
       {
         name: 'test-plugin-context',
-        onLog: (level, log) => {
-          expect(level).toBe('warn')
-          expect(log.code).toBe('CYCLE_LOADING')
-          expect(log.message).toContain(
-            'cycle loading at test-plugin-context plugin',
-          )
-          onLogFn()
-        },
         async load(id) {
           this.load({ id })
         },
       },
     ],
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('CYCLE_LOADING')
+      expect(log.message).toContain(
+        'cycle loading at test-plugin-context plugin',
+      )
+      onLogFn()
+    },
   },
   afterTest: () => {
     expect(onLogFn).toHaveBeenCalledTimes(1)

--- a/packages/rolldown/tests/fixtures/plugin/load/guess-module-type/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/load/guess-module-type/_config.ts
@@ -1,6 +1,8 @@
 import { defineTest } from 'rolldown-tests'
 import * as fs from 'fs'
-import { vi } from 'vitest'
+import { expect, vi } from 'vitest'
+
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
@@ -16,6 +18,16 @@ export default defineTest({
         },
       },
     ],
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('UNRESOLVED_IMPORT')
+      expect(log.message).toContain(
+        "Could not resolve 'react/jsx-runtime' in main.jsx",
+      )
+      onLogFn()
+    },
   },
-  afterTest: (output) => {},
+  afterTest() {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
+  },
 })

--- a/packages/rolldown/tests/fixtures/plugin/load/guess-module-type/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/load/guess-module-type/_config.ts
@@ -1,8 +1,5 @@
 import { defineTest } from 'rolldown-tests'
 import * as fs from 'fs'
-import { expect, vi } from 'vitest'
-
-const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
@@ -18,16 +15,6 @@ export default defineTest({
         },
       },
     ],
-    onLog(level, log) {
-      expect(level).toBe('warn')
-      expect(log.code).toBe('UNRESOLVED_IMPORT')
-      expect(log.message).toContain(
-        "Could not resolve 'react/jsx-runtime' in main.jsx",
-      )
-      onLogFn()
-    },
-  },
-  afterTest() {
-    expect(onLogFn).toHaveBeenCalledTimes(1)
+    external: ['react/jsx-runtime'],
   },
 })

--- a/packages/rolldown/tests/fixtures/plugin/output-plugins/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/output-plugins/_config.ts
@@ -9,16 +9,6 @@ const onLogFn = vi.fn()
 export default defineTest({
   skipComposingJsPlugin: true, // Here mutate the test config at non-skipComposingJsPlugin test will be next skipComposingJsPlugin test failed.
   config: {
-    plugins: [
-      {
-        name: 'test-input-plugin',
-        onLog: (level, log) => {
-          expect(level).toBe('warn')
-          expect(log.code).toBe('INPUT_HOOK_IN_OUTPUT_PLUGIN')
-          onLogFn()
-        },
-      },
-    ],
     output: {
       plugins: [
         {
@@ -34,6 +24,11 @@ export default defineTest({
           renderStart: renderStartFn,
         },
       ],
+    },
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('INPUT_HOOK_IN_OUTPUT_PLUGIN')
+      onLogFn()
     },
   },
   afterTest: (output) => {

--- a/packages/rolldown/tests/fixtures/tree-shake/minify/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/minify/_config.ts
@@ -1,14 +1,26 @@
 import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from 'rolldown-tests'
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
+
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
     output: {
       minify: true,
     },
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('MINIFY_WARNING')
+      expect(log.message).toContain(
+        'Setting "minify: true" is not recommended for production use.',
+      )
+      onLogFn()
+    },
   },
   afterTest: (output) => {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
+
     output.output
       .filter(({ type }) => type === 'chunk')
       .forEach((chunk) => {

--- a/packages/rolldown/tests/fixtures/tree-shake/unused-external-import-stmt/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/unused-external-import-stmt/_config.ts
@@ -1,6 +1,8 @@
 import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from 'rolldown-tests'
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
+
+const onLogFn = vi.fn()
 
 export default defineTest({
   config: {
@@ -8,8 +10,18 @@ export default defineTest({
       moduleSideEffects: false,
     },
     external: ['test', 'unused-module'],
+    onLog(level, log) {
+      expect(level).toBe('warn')
+      expect(log.code).toBe('UNRESOLVED_IMPORT')
+      expect(log.message).toContain(
+        "Could not resolve 'unused-external-module' in main.js",
+      )
+      onLogFn()
+    },
   },
   afterTest: (output) => {
+    expect(onLogFn).toHaveBeenCalledTimes(1)
+
     output.output
       .filter(({ type }) => type === 'chunk')
       .forEach((chunk) => {

--- a/packages/rolldown/tests/module-federation/module-federation.test.ts
+++ b/packages/rolldown/tests/module-federation/module-federation.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from 'vitest'
+import { test, expect, describe, vi } from 'vitest'
 import { build } from 'rolldown'
 import { moduleFederationPlugin } from 'rolldown/experimental'
 import path from 'node:path'
@@ -41,6 +41,8 @@ describe('module-federation', () => {
       },
     })
 
+    const onLogFn = vi.fn()
+
     // build remote
     await build({
       input: './remote-expose.js',
@@ -77,7 +79,14 @@ describe('module-federation', () => {
         dir: 'dist/remote',
         chunkFileNames: '[name].js',
       },
+      onLog(level, log) {
+        expect(level).toBe('warn')
+        expect(log.code).toBe('EVAL')
+        onLogFn()
+      },
     })
+
+    expect(onLogFn).toHaveBeenCalledTimes(1)
 
     // Test the remote manifest json
     // @ts-ignore


### PR DESCRIPTION
### Description

Added `onLog` with assertions to tests that emit warnings. This will ensure that warnings are also covered by tests, while also silencing them so that they're not written to stderr (it makes Vitest output harder to read).