### PR TITLE
perf(rolldown_plugin_replace): replace static Regex with pure function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,6 +2571,7 @@ dependencies = [
 name = "rolldown_plugin_replace"
 version = "0.1.0"
 dependencies = [
+ "oxc",
  "regex",
  "regress",
  "rolldown",

--- a/crates/rolldown_plugin_replace/Cargo.toml
+++ b/crates/rolldown_plugin_replace/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 version              = "0.1.0"
 
 [dependencies]
+oxc             = { workspace = true }
 regex           = { workspace = true }
 regress         = { workspace = true }
 rolldown_plugin = { path = "../rolldown_plugin" }


### PR DESCRIPTION
### Benchmark

```
running 2 tests
test tests::pure_function ... bench:          80.56 ns/iter (+/- 12.09)
test tests::regex         ... bench:         201.07 ns/iter (+/- 6.74)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 1.20s
```

```rust
#![feature(test)]

#[cfg(test)]
extern crate test;

use std::sync::LazyLock;

use regex::Regex;

// A long JavaScript snippet to test variable declaration detection
const VARIABLE_DECLARATION_PREFIXES: &[&str] = &[
    // JavaScript code with various variable declarations
    "process.env.NODE_ENV = 'development';",
    "const process = { env: { NODE_ENV: 'development' } };",
    "if (process.env.NODE_ENV === 'development') { }",
    "for (let i = 0; i < 10; i++) { }",
    "class Example { constructor() { } }",
    "const v = 'development';",
    "let v = 'development';",
    "var v = 'development';",
    "function process() { }",
    "const obj = { method() { } }",
    "// This is a comment with const ",
    "/* Multi-line comment with let ",
    "console.log('not a declaration'); const ",
    "export const ",
    "import { useState } from 'react'; const ",
    "async function fetch() { }",
    "try { }",
    "catch (error) { }",
    "finally { }",
    "const v = \"development\";",
];

static NON_ASSIGNMENT_MATCHER: LazyLock<Regex> =
    LazyLock::new(|| Regex::new("\\b(?:const|let|var)\\s+$").expect("Should be valid regex"));

// Checks if the given string ends with a variable declaration keyword (const, let, var)
// followed by whitespace, which would indicate the start of a variable declaration.
fn is_variable_declaration_prefix(s: &str) -> bool {
    // First check if there's any whitespace at the end
    if !s.ends_with(|c: char| c.is_whitespace()) {
        return false;
    }

    // Trim the trailing whitespace
    let s = s.trim_end();

    // Check for word boundary before the keywords
    (s.ends_with("const")
        && (s.len() == 5 || !s.chars().nth(s.len() - 6).unwrap_or(' ').is_alphanumeric()))
        || (s.ends_with("let")
            && (s.len() == 3 || !s.chars().nth(s.len() - 4).unwrap_or(' ').is_alphanumeric()))
        || (s.ends_with("var")
            && (s.len() == 3 || !s.chars().nth(s.len() - 4).unwrap_or(' ').is_alphanumeric()))
}

fn is_variable_declaration_prefix_regex(s: &str) -> bool {
    NON_ASSIGNMENT_MATCHER.is_match(s)
}

#[cfg(test)]
mod tests {
    use test::{black_box, Bencher};

    use super::*;

    #[bench]
    fn pure_function(b: &mut Bencher) {
        b.iter(|| {
            for prefix in VARIABLE_DECLARATION_PREFIXES {
                black_box(is_variable_declaration_prefix(prefix));
            }
        });
    }

    #[bench]
    fn regex(b: &mut Bencher) {
        b.iter(|| {
            for prefix in VARIABLE_DECLARATION_PREFIXES {
                black_box(is_variable_declaration_prefix_regex(prefix));
            }
        });
    }
}

```