### PR TITLE
feat(node): allow `sourceRoot: null` in sourcemaps

### DIFF
--- a/packages/rolldown/src/types/sourcemap.ts
+++ b/packages/rolldown/src/types/sourcemap.ts
@@ -24,7 +24,14 @@ export function bindingifySourcemap(
         : {
             file: map.file ?? undefined,
             mappings: map.mappings,
-            sourceRoot: map.sourceRoot,
+            // according to the spec, `sourceRoot: null` is not valid,
+            // but some tools returns a sourcemap with it.
+            // in that case, napi-rs outputs an error which is difficult
+            // to understand by users ("Value is non of these types `String`, `BindingJsonSourcemap`").
+            // we convert it to undefined to skip that error.
+            // note that if `sourceRoot: null` is included in a string sourcemap,
+            // it will be converted to None by serde-json.
+            sourceRoot: map.sourceRoot ?? undefined,
             sources: map.sources?.map((s) => s ?? undefined),
             sourcesContent: map.sourcesContent?.map((s) => s ?? undefined),
             names: map.names,

--- a/packages/rolldown/tests/fixtures/plugin/transform/sourcemap-with-sourceroot-null/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/sourcemap-with-sourceroot-null/_config.ts
@@ -7,7 +7,6 @@ import {
 } from 'rolldown-tests/utils'
 import { SourceMapConsumer } from 'source-map'
 
-// Copy from "rollup@sourcemaps@transform-low-resolution: handles combining low-resolution and high-resolution source-maps when transforming@generates es".
 export default defineTest({
   config: {
     plugins: [
@@ -20,6 +19,7 @@ export default defineTest({
               version: 3,
               names: [],
               sources: ['test.tsx'],
+              // @ts-expect-error -- intentionally passing null
               sourceRoot: null,
               sourcesContent: ["export const foo = 'foo';\n"],
               mappings: 'AAAA,OAAO,MAAM,MAAM',

--- a/packages/rolldown/tests/fixtures/plugin/transform/sourcemap-with-sourceroot-null/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/sourcemap-with-sourceroot-null/_config.ts
@@ -19,8 +19,8 @@ export default defineTest({
               version: 3,
               names: [],
               sources: ['test.tsx'],
-              // @ts-expect-error -- intentionally passing null
-              sourceRoot: null,
+              // intentionally passing null
+              sourceRoot: null as unknown as string | undefined,
               sourcesContent: ["export const foo = 'foo';\n"],
               mappings: 'AAAA,OAAO,MAAM,MAAM',
             },

--- a/packages/rolldown/tests/fixtures/plugin/transform/sourcemap-with-sourceroot-null/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/sourcemap-with-sourceroot-null/_config.ts
@@ -1,0 +1,46 @@
+import { expect } from 'vitest'
+import { defineTest } from 'rolldown-tests'
+import {
+  getLocation,
+  getOutputAsset,
+  getOutputChunk,
+} from 'rolldown-tests/utils'
+import { SourceMapConsumer } from 'source-map'
+
+// Copy from "rollup@sourcemaps@transform-low-resolution: handles combining low-resolution and high-resolution source-maps when transforming@generates es".
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'test-plugin',
+        transform(code) {
+          return {
+            code,
+            map: {
+              version: 3,
+              names: [],
+              sources: ['test.tsx'],
+              sourceRoot: null,
+              sourcesContent: ["export const foo = 'foo';\n"],
+              mappings: 'AAAA,OAAO,MAAM,MAAM',
+            },
+          }
+        },
+      },
+    ],
+    output: {
+      sourcemap: true,
+    },
+  },
+  afterTest: async (output) => {
+    const code = getOutputChunk(output)[0].code
+    const map = getOutputAsset(output)[0].source as string
+    const smc = await new SourceMapConsumer(JSON.parse(map))
+
+    const generatedLoc = getLocation(code, code.indexOf(`"foo"`))
+    const originalLoc = smc.originalPositionFor(generatedLoc)
+
+    expect(originalLoc.line).toBe(1)
+    expect(originalLoc.column).toBe(19)
+  },
+})

--- a/packages/rolldown/tests/fixtures/plugin/transform/sourcemap-with-sourceroot-null/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/transform/sourcemap-with-sourceroot-null/main.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
According to the spec, `sourceRoot: null` is not valid, but some tools returns a sourcemap with it. In that case, napi-rs outputs an error which is difficult to understand by users ("Value is non of these types `String`, `BindingJsonSourcemap`").
In this PR, I added a code to convert null into undefined to skip that error.
Note that if `sourceRoot: null` is included in a string sourcemap, it will be converted to None by serde-json.

Alternatively, we can throw a more friendly error, but I guess we don't need to be that strict for the input. (Our output should conform the spec though)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
