### PR TITLE
chore(rust/tracing): output args by default for `chrome-json` mode

### DIFF
--- a/crates/rolldown_tracing/src/lib.rs
+++ b/crates/rolldown_tracing/src/lib.rs
@@ -36,7 +36,8 @@ pub fn try_init_tracing() -> Option<FlushGuard> {
     "chrome-json" | "chrome-json-threaded" => {
       let trace_style =
         if output_mode == "chrome-json" { TraceStyle::Async } else { TraceStyle::Threaded };
-      let (chrome_layer, guard) = ChromeLayerBuilder::new().trace_style(trace_style).build();
+      let (chrome_layer, guard) =
+        ChromeLayerBuilder::new().trace_style(trace_style).include_args(true).build();
       tracing_subscriber::registry().with(env_filter).with(chrome_layer).init();
       Some(guard)
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
![image](https://github.com/user-attachments/assets/95d5224a-4445-4db5-8cd6-a3cb72dc374e)

so that I can view the values on perfetto.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
