### PR TITLE
test(glob_plugin): remove redundant test

### DIFF
--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/vite/fixture-a/index.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/vite/fixture-a/index.ts
@@ -85,14 +85,6 @@ export const excludeSelfRaw = import.meta.glob('./*.ts', { query: '?raw' })
 // unresolved import
 // export const customQueryString = import.meta.glob('./*.ts', { query: 'custom' })
 
-// unresolved import
-// export const customQueryObject = import.meta.glob('./*.ts', {
-//   query: {
-//     foo: 'bar',
-//     raw: true,
-//   },
-// })
-
 export const parent = import.meta.glob('../../playground/src/*.ts', {
   query: '?url',
   import: 'default',


### PR DESCRIPTION
### Description

This case is already covered by https://github.com/rolldown/rolldown/blob/c4a1aae63f380ba7d21de405d6503593e28d75d3/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/query-object/main.js, so it's not worth adding additional plugin that would resolve this query.