### PR TITLE
fix(glob_import): return absolute paths for absolute globs

### DIFF
--- a/crates/rolldown_plugin_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_import_glob/src/lib.rs
@@ -244,7 +244,7 @@ fn extract_import_glob_options(arg: &Argument, opts: &mut ImportGlobOptions) {
 }
 
 impl<'ast> GlobImportVisit<'ast, '_> {
-  fn eval_glob_expr(&self, arg: &Argument, files: &mut std::vec::Vec<String>) {
+  fn eval_glob_expr(&self, arg: &Argument, files: &mut std::vec::Vec<(String, String)>) {
     let mut positive_globs = vec![];
     let mut negated_globs = vec![];
     match arg {
@@ -282,6 +282,10 @@ impl<'ast> GlobImportVisit<'ast, '_> {
       })
       .collect::<std::vec::Vec<_>>();
 
+    let is_relative = positive_globs.iter().all(|g| g.starts_with('.'));
+
+    let self_path = self.format_path(Path::new(self.id), Some(dir));
+
     for glob_expr in positive_globs {
       let processed_glob_expr = preprocess_glob_expr(glob_expr);
       let absolute_glob = to_absolute_glob(&processed_glob_expr, dir, root).unwrap();
@@ -291,41 +295,55 @@ impl<'ast> GlobImportVisit<'ast, '_> {
         if negated_globs.iter().any(|g| g.matches_path(&file)) {
           continue;
         }
-        let file = file.relative(dir).to_slash_lossy().to_string();
-        if file == self.id.relative(dir).to_slash_lossy() {
+        let import_path = self.format_path(&file, Some(dir));
+        if import_path == self_path {
           continue;
         }
-        let prefix = if file.starts_with('.') { "" } else { "./" };
-        files.push(format!("{prefix}{file}"));
+        let file_path =
+          if is_relative { import_path.clone() } else { self.format_path(&file, None) };
+        files.push((file_path, import_path));
       }
     }
+  }
+
+  fn format_path(&self, path: &Path, relative_to: Option<&Path>) -> String {
+    let dir = relative_to.unwrap_or(self.root);
+    let path = path.relative(dir).to_slash_lossy().to_string();
+    let prefix = if path.starts_with('.') {
+      ""
+    } else if relative_to.is_some() {
+      "./"
+    } else {
+      "/"
+    };
+    format!("{prefix}{path}")
   }
 
   #[allow(clippy::too_many_lines, clippy::cast_possible_truncation)]
   fn generate_glob_object_expression(
     &mut self,
-    files: &[String],
+    files: &[(String, String)],
     opts: &ImportGlobOptions,
     call_expr_span: Span,
     omit_keys: bool,
     omit_values: bool,
   ) -> Expression<'ast> {
-    let properties = files.iter().enumerate().map(|(index, file)| {
+    let properties = files.iter().enumerate().map(|(index, (file_path, import_path))| {
       let formatted_file = if let Some(query) = &opts.query {
         let normalized_query = if query == "?raw" {
           query
         } else {
           let file_extension =
-            Path::new(&file).extension().unwrap_or_default().to_str().unwrap_or_default();
+            Path::new(&import_path).extension().unwrap_or_default().to_str().unwrap_or_default();
           if !file_extension.is_empty() && self.restore_query_extension {
             &format!("{query}&lang.{file_extension}")
           } else {
             query
           }
         };
-        Cow::Owned(format!("{file}{normalized_query}"))
+        Cow::Owned(format!("{import_path}{normalized_query}"))
       } else {
-        Cow::Borrowed(file)
+        Cow::Borrowed(import_path)
       };
 
       let value = if omit_values {
@@ -466,7 +484,7 @@ impl<'ast> GlobImportVisit<'ast, '_> {
         )
       };
 
-      (file, value)
+      (file_path, value)
     });
 
     if omit_keys {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/absolute-glob-expr/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/absolute-glob-expr/assert.mjs
@@ -3,6 +3,6 @@ import assert from 'node:assert'
 import { m1, m2, m3 } from './dist/main'
 
 assert.strictEqual(m1['./dir/a.js'].default, 'a')
-assert.strictEqual(m2['./dir/a.js'].default, 'a')
+assert.strictEqual(m2['/src/dir/a.js'].default, 'a')
 
 assert.strictEqual(m3['./dir/a.js'].default, 'a')

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/vite/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/vite/_config.ts
@@ -23,6 +23,9 @@ export default defineTest({
             const res = fs.readFileSync(id.slice(0, -4), 'utf-8')
             return `export default ${JSON.stringify(res)}`
           }
+          if (id.endsWith('?url')) {
+            return `export default '/path/to/module.js'`
+          }
           if (id.endsWith('?base64')) {
             const res = fs.readFileSync(id.slice(0, -7), 'utf-8')
             return `export default ${JSON.stringify(btoa(res))}`

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/vite/fixture-a/index.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/vite/fixture-a/index.ts
@@ -89,11 +89,10 @@ export const parent = import.meta.glob('../../playground/src/*.ts', {
   import: 'default',
 })
 
-// unloadable dependency
-// export const rootMixedRelative = import.meta.glob(
-//   ['/*.ts', '../fixture-b/*.ts'],
-//   { query: '?url', import: 'default' },
-// )
+export const rootMixedRelative = import.meta.glob(
+  ['/*.ts', '../fixture-b/*.ts'],
+  { query: '?url', import: 'default' },
+)
 
 export const cleverCwd1 = import.meta.glob(
   './node_modules/framework/**/*.page.js',

--- a/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/vite/fixture-a/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/glob-import/vite/fixture-a/index.ts.snap
@@ -86,6 +86,12 @@ const excludeSelf = { "./sibling.ts": () => import("./sibling.js") };
 const excludeSelfRaw = { "./sibling.ts": () => import("./sibling3.js") };
 const customQueryString = { "./sibling.ts": () => import("./sibling2.js") };
 const parent = {};
+const rootMixedRelative = {
+	"/_config.ts": () => import("./_config.js").then((m) => m.default),
+	"/fixture-b/a.ts": () => import("./a6.js").then((m) => m.default),
+	"/fixture-b/b.ts": () => import("./b6.js").then((m) => m.default),
+	"/fixture-b/index.ts": () => import("./fixture-b.js").then((m) => m.default)
+};
 const cleverCwd1 = { "./node_modules/framework/pages/hello.page.js": () => import("./hello.page.js") };
 const cleverCwd2 = {
 	"./modules/a.ts": () => import("./a.js"),
@@ -95,4 +101,4 @@ const cleverCwd2 = {
 };
 
 //#endregion
-export { basic, basicEager, basicEagerWithObjectKeys, basicEagerWithObjectValues, basicWithObjectKeys, basicWithObjectValues, cleverCwd1, cleverCwd2, customQueryString, eagerAs, excludeSelf, excludeSelfRaw, ignore, ignoreWithObjectKeys, ignoreWithObjectValues, namedDefault, namedDefaultWithObjectKeys, namedDefaultWithObjectValues, namedEager, namedEagerWithObjectKeys, namedEagerWithObjectValues, parent, rawImportModule };
+export { basic, basicEager, basicEagerWithObjectKeys, basicEagerWithObjectValues, basicWithObjectKeys, basicWithObjectValues, cleverCwd1, cleverCwd2, customQueryString, eagerAs, excludeSelf, excludeSelfRaw, ignore, ignoreWithObjectKeys, ignoreWithObjectValues, namedDefault, namedDefaultWithObjectKeys, namedDefaultWithObjectValues, namedEager, namedEagerWithObjectKeys, namedEagerWithObjectValues, parent, rawImportModule, rootMixedRelative };


### PR DESCRIPTION
### Description

Vite plugin:
- https://github.com/vitejs/vite/blob/ce0ccc6c33544a14728fff4b84c746c9682f9878/packages/vite/src/node/plugins/importMetaGlob.ts#L312
- https://github.com/vitejs/vite/blob/ce0ccc6c33544a14728fff4b84c746c9682f9878/packages/vite/src/node/plugins/importMetaGlob.ts#L441-L450

Vite test:
- https://github.com/vitejs/vite/blob/ce0ccc6c33544a14728fff4b84c746c9682f9878/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap#L84