### PR TITLE
chore: remove unused vitest config

### DIFF
--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -26,7 +26,6 @@
     "lodash-es": "^4.17.21",
     "rolldown": "workspace:*",
     "rollup": "^4.18.0",
-    "tinybench": "^3.0.0",
-    "vitest": "^3.0.1"
+    "tinybench": "^3.0.0"
   }
 }

--- a/packages/bench/vitest.config.ts
+++ b/packages/bench/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-// @ts-ignore: `@codspeed/vitest-plugin` doesn't specify `types` in `package.json#exports`.
-import codspeedPlugin from '@codspeed/vitest-plugin'
-
-export default defineConfig({
-  plugins: process.env.CI ? [codspeedPlugin()] : [],
-})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,9 +251,6 @@ importers:
       tinybench:
         specifier: ^3.0.0
         version: 3.1.1
-      vitest:
-        specifier: ^3.0.1
-        version: 3.0.6(@types/debug@4.1.12)(@types/node@22.13.4)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/rolldown:
     dependencies:
@@ -6892,7 +6889,7 @@ snapshots:
       '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6944,7 +6941,7 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.26.5
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -7534,7 +7531,7 @@ snapshots:
       '@babel/parser': 7.26.9
       '@babel/template': 7.26.9
       '@babel/types': 7.26.9
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -10157,6 +10154,10 @@ snapshots:
       ms: 2.0.0
 
   debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.0:
     dependencies:
       ms: 2.1.3
 


### PR DESCRIPTION
### Description

Leftover from #718. Prevents Vitest plugin for VS Code from erroring on startup.