### PR TITLE
refactor: apply `clippy::iter_on_single_items`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ single_match_else = "allow"
 
 # Though the following are nursery rules, they’re still useful.
 debug_assert_with_mut_call    = "warn"
-iter_on_single_items          = "allow"
+iter_on_single_items          = "warn"
 needless_pass_by_ref_mut      = "warn"
 redundant_clone               = "warn"
 redundant_pub_crate           = "warn"

--- a/crates/rolldown_plugin_replace/tests/form/delimiters/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/delimiters/mod.rs
@@ -21,7 +21,7 @@ async fn replace_strings() {
       ..Default::default()
     },
     vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-      values: [("original".to_string(), "replaced".to_string())].into_iter().collect(),
+      values: std::iter::once(("original".to_string(), "replaced".to_string())).collect(),
       delimiters: Some(("<%".to_string(), "%>".to_string())),
       sourcemap: true,
       ..Default::default()

--- a/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
@@ -23,8 +23,7 @@ async fn process_check() {
       ..Default::default()
     },
     vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-      values: [("process.env.NODE_ENV".to_string(), "\"production\"".to_string())]
-        .into_iter()
+      values: std::iter::once(("process.env.NODE_ENV".to_string(), "\"production\"".to_string()))
         .collect(),
       prevent_assignment: true,
       sourcemap: true,

--- a/crates/rolldown_plugin_replace/tests/form/replace_nothing/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/replace_nothing/mod.rs
@@ -17,7 +17,7 @@ async fn replace_strings() {
         ..Default::default()
       },
       vec![Arc::new(ReplacePlugin::new(
-        [("typeof window".to_string(), "\"object\"".to_string())].into_iter().collect(),
+        std::iter::once(("typeof window".to_string(), "\"object\"".to_string())).collect(),
       ))],
     )
     .await;

--- a/crates/rolldown_plugin_replace/tests/form/simple_object_guards/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/simple_object_guards/mod.rs
@@ -18,7 +18,7 @@ async fn simple_object_guards() {
         ..Default::default()
       },
       vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-        values: [("foo".to_string(), "bar".to_string())].into_iter().collect(),
+        values: std::iter::once(("foo".to_string(), "bar".to_string())).collect(),
         object_guards: true,
         ..Default::default()
       }))],

--- a/crates/rolldown_plugin_replace/tests/form/special_characters/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/special_characters/mod.rs
@@ -22,7 +22,7 @@ async fn special_characters() {
       ..Default::default()
     },
     vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-      values: [("require('one')".to_string(), "1".to_string())].into_iter().collect(),
+      values: std::iter::once(("require('one')".to_string(), "1".to_string())).collect(),
       delimiters: Some((String::new(), String::new())),
       sourcemap: true,
       ..Default::default()

--- a/crates/rolldown_plugin_replace/tests/form/special_delimiters/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/special_delimiters/mod.rs
@@ -22,7 +22,7 @@ async fn special_delimiters() {
       ..Default::default()
     },
     vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-      values: [("special".to_string(), "replaced".to_string())].into_iter().collect(),
+      values: std::iter::once(("special".to_string(), "replaced".to_string())).collect(),
       delimiters: Some(("\\b".to_string(), "\\b".to_string())),
       sourcemap: true,
       ..Default::default()

--- a/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
@@ -47,7 +47,7 @@ async fn typescript_declare() {
     },
     vec![
       Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-        values: [("NAME".to_string(), "replaced".to_string())].into_iter().collect(),
+        values: std::iter::once(("NAME".to_string(), "replaced".to_string())).collect(),
         prevent_assignment: true,
         sourcemap: true,
         ..Default::default()

--- a/crates/rolldown_testing/src/fixture.rs
+++ b/crates/rolldown_testing/src/fixture.rs
@@ -34,8 +34,7 @@ impl Fixture {
 
     options.canonicalize_option_path();
 
-    let configs = [NamedBundlerOptions { options: options.clone(), name: None }]
-      .into_iter()
+    let configs = std::iter::once(NamedBundlerOptions { options: options.clone(), name: None })
       .chain(config_variants.into_iter().map(|variant| NamedBundlerOptions {
         options: variant.apply(&options),
         name: Some(variant.to_string()),


### PR DESCRIPTION
### Description

Related to #3670

Currently, this issue only exists in the test cases, but to prevent potential bad code in the future, I am enabling the `clippy::iter_on_single_items` rule.