### PR TITLE
feat: `RollupLog` compat of `UNRESOLVED_IMPORT` warning

### DIFF
--- a/crates/rolldown/tests/esbuild/default/external_wildcard_does_not_match_entry_point/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_wildcard_does_not_match_entry_point/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "foo" in entry.js
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'foo' in entry.js
    ╭─[ entry.js:1:8 ]
    │
  1 │ import "foo"

--- a/crates/rolldown/tests/esbuild/default/external_with_wildcard/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_with_wildcard/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Errors
 
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Error: Could not resolve "./file.ping" in entry.js
+[UNRESOLVED_IMPORT] Error: Could not resolve './file.ping' in entry.js
     ╭─[ entry.js:10:8 ]
     │
  10 │ import "./file.ping";
@@ -19,7 +18,7 @@ snapshot_kind: text
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Error: Could not resolve "/dir/file.gif" in entry.js
+[UNRESOLVED_IMPORT] Error: Could not resolve '/dir/file.gif' in entry.js
    ╭─[ entry.js:9:8 ]
    │
  9 │ import "/dir/file.gif";
@@ -31,7 +30,7 @@ snapshot_kind: text
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Error: Could not resolve "/sassets/images/test.jpg" in entry.js
+[UNRESOLVED_IMPORT] Error: Could not resolve '/sassets/images/test.jpg' in entry.js
    ╭─[ entry.js:8:8 ]
    │
  8 │ import "/sassets/images/test.jpg";

--- a/crates/rolldown/tests/esbuild/default/forbid_string_import_names_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/forbid_string_import_names_bundle/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "external" in nested.js
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'external' in nested.js
    ╭─[ nested.js:1:41 ]
    │
  1 │ import { "some import" as nested } from "external"

--- a/crates/rolldown/tests/esbuild/default/package_alias/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/package_alias/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@abs-path/pkg7/foo" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@abs-path/pkg7/foo' in entry.js
    ╭─[ entry.js:7:8 ]
    │
  7 │ import "@abs-path/pkg7/foo"
@@ -20,7 +20,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@scope-only/pkg8" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@scope-only/pkg8' in entry.js
    ╭─[ entry.js:8:8 ]
    │
  8 │ import "@scope-only/pkg8"

--- a/crates/rolldown/tests/esbuild/default/package_alias_match_longest/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/package_alias_match_longest/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "pkg/bar/baz" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve 'pkg/bar/baz' in entry.js
    ╭─[ entry.js:5:8 ]
    │
  5 │ import "pkg/bar/baz"
@@ -20,7 +20,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "pkg/baz" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve 'pkg/baz' in entry.js
    ╭─[ entry.js:6:8 ]
    │
  6 │ import "pkg/baz"
@@ -34,7 +34,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "pkg/foo/bar/baz" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve 'pkg/foo/bar/baz' in entry.js
    ╭─[ entry.js:4:8 ]
    │
  4 │ import "pkg/foo/bar/baz"

--- a/crates/rolldown/tests/esbuild/default/require_bad_argument_count/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_bad_argument_count/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "a" in entry.js
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'a' in entry.js
    ╭─[ entry.js:2:9 ]
    │
  2 │ require("a", "b")

--- a/crates/rolldown/tests/esbuild/default/to_esm_wrapper_omission/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/to_esm_wrapper_omission/artifacts.snap
@@ -1,21 +1,8 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
-## UNRESOLVED_IMPORT
-
-```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "k_WRAP" in entry.js
-    ╭─[ entry.js:29:12 ]
-    │
- 29 │ x = import("k_WRAP")
-    │            ────┬───  
-    │                ╰───── Module not found, treating it as an external dependency
-────╯
-
-```
 ## UNRESOLVED_IMPORT
 
 ```text
@@ -133,6 +120,18 @@ snapshot_kind: text
  26 │ import * as j from 'j_WRAP'
     │                    ────┬───  
     │                        ╰───── Module not found, treating it as an external dependency
+────╯
+
+```
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'k_WRAP' in entry.js
+    ╭─[ entry.js:29:12 ]
+    │
+ 29 │ x = import("k_WRAP")
+    │            ────┬───  
+    │                ╰───── Module not found, treating it as an external dependency
 ────╯
 
 ```

--- a/crates/rolldown/tests/esbuild/default/warnings_inside_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/warnings_inside_node_modules/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@plugin/bad-typeof.js" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@plugin/bad-typeof.js' in entry.js
    ╭─[ entry.js:5:83 ]
    │
  5 │ import "./bad-typeof.js";      import "./node_modules/bad-typeof.js";      import "@plugin/bad-typeof.js"
@@ -20,7 +20,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@plugin/delete-super.js" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@plugin/delete-super.js' in entry.js
     ╭─[ entry.js:11:83 ]
     │
  11 │ import "./delete-super.js";    import "./node_modules/delete-super.js";    import "@plugin/delete-super.js"
@@ -34,7 +34,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@plugin/dup-case.js" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@plugin/dup-case.js' in entry.js
    ╭─[ entry.js:1:83 ]
    │
  1 │ import "./dup-case.js";        import "./node_modules/dup-case.js";        import "@plugin/dup-case.js"
@@ -48,7 +48,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@plugin/equals-nan.js" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@plugin/equals-nan.js' in entry.js
    ╭─[ entry.js:7:83 ]
    │
  7 │ import "./equals-nan.js";      import "./node_modules/equals-nan.js";      import "@plugin/equals-nan.js"
@@ -62,7 +62,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@plugin/equals-neg-zero.js" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@plugin/equals-neg-zero.js' in entry.js
    ╭─[ entry.js:6:83 ]
    │
  6 │ import "./equals-neg-zero.js"; import "./node_modules/equals-neg-zero.js"; import "@plugin/equals-neg-zero.js"
@@ -76,7 +76,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@plugin/equals-object.js" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@plugin/equals-object.js' in entry.js
    ╭─[ entry.js:8:83 ]
    │
  8 │ import "./equals-object.js";   import "./node_modules/equals-object.js";   import "@plugin/equals-object.js"
@@ -90,7 +90,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@plugin/not-in.js" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@plugin/not-in.js' in entry.js
    ╭─[ entry.js:2:83 ]
    │
  2 │ import "./not-in.js";          import "./node_modules/not-in.js";          import "@plugin/not-in.js"
@@ -104,7 +104,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@plugin/not-instanceof.js" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@plugin/not-instanceof.js' in entry.js
    ╭─[ entry.js:3:83 ]
    │
  3 │ import "./not-instanceof.js";  import "./node_modules/not-instanceof.js";  import "@plugin/not-instanceof.js"
@@ -118,7 +118,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@plugin/read-setter.js" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@plugin/read-setter.js' in entry.js
     ╭─[ entry.js:10:83 ]
     │
  10 │ import "./read-setter.js";     import "./node_modules/read-setter.js";     import "@plugin/read-setter.js"
@@ -132,7 +132,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@plugin/return-asi.js" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@plugin/return-asi.js' in entry.js
    ╭─[ entry.js:4:83 ]
    │
  4 │ import "./return-asi.js";      import "./node_modules/return-asi.js";      import "@plugin/return-asi.js"
@@ -146,7 +146,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "@plugin/write-getter.js" in entry.js
+[RESOLVE_ERROR] Error: Could not resolve '@plugin/write-getter.js' in entry.js
    ╭─[ entry.js:9:83 ]
    │
  9 │ import "./write-getter.js";    import "./node_modules/write-getter.js";    import "@plugin/write-getter.js"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "foo" in entry.js
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'foo' in entry.js
    ╭─[ entry.js:1:22 ]
    │
  1 │ export * as out from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_es6_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_es6_no_bundle/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "foo" in entry.js
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'foo' in entry.js
    ╭─[ entry.js:1:22 ]
    │
  1 │ export * as out from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
@@ -13,7 +12,7 @@ snapshot_kind: text
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "foo" in entry.js
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'foo' in entry.js
    ╭─[ entry.js:1:22 ]
    │
  1 │ export * as out from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
@@ -13,7 +12,7 @@ snapshot_kind: text
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "foo" in entry.js
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'foo' in entry.js
    ╭─[ entry.js:1:22 ]
    │
  1 │ export * as out from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_common_js_no_bundle/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "foo" in entry.js
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'foo' in entry.js
    ╭─[ entry.js:1:15 ]
    │
  1 │ export * from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_es6_no_bundle/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "foo" in entry.js
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'foo' in entry.js
    ╭─[ entry.js:1:15 ]
    │
  1 │ export * from "foo"

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_external_iife/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "foo" in entry.js
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'foo' in entry.js
    ╭─[ entry.js:1:15 ]
    │
  1 │ export * from "foo"

--- a/crates/rolldown/tests/esbuild/loader/jsx_automatic_no_name_collision/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/jsx_automatic_no_name_collision/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## UNRESOLVED_IMPORT
 
 ```text
-[UNRESOLVED_IMPORT] Warning: Could not resolve "@remix-run/react" in entry.jsx
+[UNRESOLVED_IMPORT] Warning: Could not resolve '@remix-run/react' in entry.jsx
    ╭─[ entry.jsx:1:22 ]
    │
  1 │ import { Link } from "@remix-run/react"

--- a/crates/rolldown/tests/rolldown/errors/resolve_unexport_path_of_package/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/resolve_unexport_path_of_package/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Errors
 
 ## RESOLVE_ERROR
 
 ```text
-[RESOLVE_ERROR] Error: Could not resolve "test/abc" in main.js
+[RESOLVE_ERROR] Error: Could not resolve 'test/abc' in main.js
    ╭─[ main.js:1:22 ]
    │
  1 │ import { test } from "test/abc"

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -207,6 +207,8 @@ impl Bundler {
                 message: warning
                   .to_diagnostic_with(&DiagnosticOptions { cwd: self.cwd.clone() })
                   .to_color_string(),
+                id: warning.id(),
+                exporter: warning.exporter(),
               },
             )
               .into(),

--- a/crates/rolldown_binding/src/types/binding_log.rs
+++ b/crates/rolldown_binding/src/types/binding_log.rs
@@ -1,7 +1,9 @@
 use napi_derive::napi;
 
-#[napi]
+#[napi(object)]
 pub struct BindingLog {
   pub code: String,
   pub message: String,
+  pub id: Option<String>,
+  pub exporter: Option<String>,
 }

--- a/crates/rolldown_error/src/build_error/mod.rs
+++ b/crates/rolldown_error/src/build_error/mod.rs
@@ -70,6 +70,14 @@ impl BuildDiagnostic {
     }
   }
 
+  pub fn id(&self) -> Option<String> {
+    self.inner.id()
+  }
+
+  pub fn exporter(&self) -> Option<String> {
+    self.inner.exporter()
+  }
+
   // --- private
 
   fn new_inner(inner: impl Into<Box<dyn BuildEvent>>) -> Self {

--- a/crates/rolldown_error/src/events/mod.rs
+++ b/crates/rolldown_error/src/events/mod.rs
@@ -43,6 +43,16 @@ pub trait BuildEvent: Debug + Sync + Send {
   fn message(&self, opts: &DiagnosticOptions) -> String;
 
   fn on_diagnostic(&self, _diagnostic: &mut Diagnostic, _opts: &DiagnosticOptions) {}
+
+  // extra properties to match RollupLog interface
+  // https://rollupjs.org/configuration-options/#onlog
+  fn id(&self) -> Option<String> {
+    None
+  }
+
+  fn exporter(&self) -> Option<String> {
+    None
+  }
 }
 
 impl<T: BuildEvent + 'static> From<T> for Box<dyn BuildEvent>

--- a/crates/rolldown_error/src/events/resolve_error.rs
+++ b/crates/rolldown_error/src/events/resolve_error.rs
@@ -15,10 +15,11 @@ pub struct DiagnosableResolveError {
 
 impl DiagnosableResolveError {
   fn importee_str(&self) -> &str {
-    match &self.importee {
+    let s = match &self.importee {
       DiagnosableArcstr::String(str) => str.as_str(),
       DiagnosableArcstr::Span(span) => &self.source.as_str()[*span],
-    }
+    };
+    &s[1..s.len() - 1]
   }
 }
 
@@ -29,7 +30,7 @@ impl BuildEvent for DiagnosableResolveError {
 
   fn message(&self, opts: &DiagnosticOptions) -> String {
     format!(
-      "Could not resolve {} in {}",
+      "Could not resolve '{}' in {}",
       self.importee_str(),
       opts.stabilize_path(self.importer_id.as_str())
     )

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -20,11 +20,6 @@ export declare class BindingError {
   message: string
 }
 
-export declare class BindingLog {
-  code: string
-  message: string
-}
-
 export declare class BindingModuleInfo {
   id: string
   importers: Array<string>
@@ -412,6 +407,13 @@ export type BindingJsx =
   | { type: 'Disable' }
   | { type: 'Preserve' }
   | { type: 'Enable', field0: JsxOptions }
+
+export interface BindingLog {
+  code: string
+  message: string
+  id?: string
+  exporter?: string
+}
 
 export declare enum BindingLogLevel {
   Silent = 0,

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -373,7 +373,6 @@ if (!nativeBinding) {
 module.exports.BindingBundleEndEventData = nativeBinding.BindingBundleEndEventData
 module.exports.BindingCallableBuiltinPlugin = nativeBinding.BindingCallableBuiltinPlugin
 module.exports.BindingError = nativeBinding.BindingError
-module.exports.BindingLog = nativeBinding.BindingLog
 module.exports.BindingModuleInfo = nativeBinding.BindingModuleInfo
 module.exports.BindingNormalizedOptions = nativeBinding.BindingNormalizedOptions
 module.exports.BindingOutputAsset = nativeBinding.BindingOutputAsset

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -63,7 +63,6 @@ const {
 export const BindingBundleEndEventData = __napiModule.exports.BindingBundleEndEventData
 export const BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
 export const BindingError = __napiModule.exports.BindingError
-export const BindingLog = __napiModule.exports.BindingLog
 export const BindingModuleInfo = __napiModule.exports.BindingModuleInfo
 export const BindingNormalizedOptions = __napiModule.exports.BindingNormalizedOptions
 export const BindingOutputAsset = __napiModule.exports.BindingOutputAsset

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -88,7 +88,6 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
 module.exports.BindingBundleEndEventData = __napiModule.exports.BindingBundleEndEventData
 module.exports.BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
 module.exports.BindingError = __napiModule.exports.BindingError
-module.exports.BindingLog = __napiModule.exports.BindingLog
 module.exports.BindingModuleInfo = __napiModule.exports.BindingModuleInfo
 module.exports.BindingNormalizedOptions = __napiModule.exports.BindingNormalizedOptions
 module.exports.BindingOutputAsset = __napiModule.exports.BindingOutputAsset

--- a/packages/rolldown/tests/fixtures/topics/rollup-log/unresolved-import/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/rollup-log/unresolved-import/_config.ts
@@ -17,7 +17,7 @@ export default defineTest({
     // spread object to test enumerable properties
     expect({ ...log }).toEqual({
       code: 'UNRESOLVED_IMPORT',
-      exporter: '"@rolldown/test-unresolved-import"',
+      exporter: '@rolldown/test-unresolved-import',
       id: expect.stringContaining('main.js'),
       message: expect.any(String),
     })

--- a/packages/rolldown/tests/fixtures/topics/rollup-log/unresolved-import/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/rollup-log/unresolved-import/_config.ts
@@ -1,0 +1,25 @@
+import { defineTest } from 'rolldown-tests'
+import { expect, vi } from 'vitest'
+
+const fn = vi.fn()
+
+export default defineTest({
+  config: {
+    onLog(_level, log) {
+      fn(log)
+    },
+  },
+  beforeTest: () => {
+    fn.mockClear()
+  },
+  afterTest: () => {
+    const log = fn.mock.calls[0][0]
+    // spread object to test enumerable properties
+    expect({ ...log }).toEqual({
+      code: 'UNRESOLVED_IMPORT',
+      exporter: '"@rolldown/test-unresolved-import"',
+      id: expect.stringContaining('main.js'),
+      message: expect.any(String),
+    })
+  },
+})

--- a/packages/rolldown/tests/fixtures/topics/rollup-log/unresolved-import/main.js
+++ b/packages/rolldown/tests/fixtures/topics/rollup-log/unresolved-import/main.js
@@ -1,0 +1,1 @@
+import "@rolldown/test-unresolved-import";


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Part of https://github.com/rolldown/rolldown/issues/3558

There are quite a few extra properties https://rollupjs.org/configuration-options/#onlog. For now, I added a compatible properties only for  `UNRESOLVED_IMPORT` since this one is used by Vite.

I also changed from `#[napi]` to `#[napi(object)]`, so it won't wrapped as class and object properties are visible from `console.log(log)`.