### PR TITLE
chore(rolldown_plugin): use doc(hidden) instead of feature flag

### DIFF
--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -39,7 +39,7 @@ rolldown_ecmascript_utils = { workspace = true }
 rolldown_error            = { workspace = true }
 rolldown_fs               = { workspace = true, features = ["os"] }
 rolldown_loader_utils     = { workspace = true }
-rolldown_plugin           = { workspace = true, features = ["inner"] }
+rolldown_plugin           = { workspace = true }
 rolldown_plugin_data_url  = { workspace = true }
 rolldown_resolver         = { workspace = true }
 rolldown_rstr             = { workspace = true }

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -13,7 +13,6 @@ doctest = false
 
 [features]
 default = ["serde"]
-inner   = []
 serde   = ["dep:serde", "oxc_index/serde"]
 
 [lints]

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -9,7 +9,7 @@ mod types;
 mod utils;
 
 /// Only for usage by the rolldown's crate. Do not use this directly.
-#[cfg(feature = "inner")]
+#[doc(hidden)]
 pub mod __inner {
   pub use super::utils::resolve_id_with_plugins::{
     resolve_id_check_external, resolve_id_with_plugins,

--- a/crates/rolldown_plugin_dynamic_import_vars/Cargo.toml
+++ b/crates/rolldown_plugin_dynamic_import_vars/Cargo.toml
@@ -21,4 +21,4 @@ glob            = { workspace = true }
 memchr          = { workspace = true }
 oxc             = { workspace = true }
 phf             = { workspace = true, features = ["phf_macros"] }
-rolldown_plugin = { workspace = true, features = ["inner"] }
+rolldown_plugin = { workspace = true }


### PR DESCRIPTION
There are many IDE errors like this

![CleanShot 2025-02-28 at 22 13 35@2x](https://github.com/user-attachments/assets/a0281f50-8906-401a-9cc8-a76944c25f63)
