### PR TITLE
build(docs): ignore `#` symbols that aren't used as the title mark

### DIFF
--- a/docs/data-loading/options-doc.data.ts
+++ b/docs/data-loading/options-doc.data.ts
@@ -134,7 +134,7 @@ function renderOptionsDocToMarkdown(item: OptionsDoc): string {
   ].join('\n')
 }
 
-const titleMarkRegex = /(#+)/g
+const titleMarkRegex = /^(#+)/gm
 
 /**
  * This function replaces `#` marks in the content with the proper number of `#` marks for the given level.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
