### PR TITLE
fix(node): allow updating sourcemap.debugId by plugins

### DIFF
--- a/crates/rolldown_binding/src/types/binding_sourcemap.rs
+++ b/crates/rolldown_binding/src/types/binding_sourcemap.rs
@@ -27,13 +27,16 @@ pub struct BindingJsonSourcemap {
   pub sources: Option<Vec<Option<String>>>,
   pub sources_content: Option<Vec<Option<String>>>,
   pub names: Option<Vec<String>>,
+  pub debug_id: Option<String>,
+  #[napi(js_name = "x_google_ignoreList")]
+  pub x_google_ignore_list: Option<Vec<u32>>,
 }
 
 impl TryFrom<BindingJsonSourcemap> for rolldown_sourcemap::SourceMap {
   type Error = anyhow::Error;
 
   fn try_from(value: BindingJsonSourcemap) -> Result<Self, Self::Error> {
-    rolldown_sourcemap::SourceMap::from_json(rolldown_sourcemap::JSONSourceMap {
+    let mut map = rolldown_sourcemap::SourceMap::from_json(rolldown_sourcemap::JSONSourceMap {
       file: value.file,
       mappings: value.mappings.unwrap_or_default(),
       source_root: value.source_root,
@@ -45,8 +48,12 @@ impl TryFrom<BindingJsonSourcemap> for rolldown_sourcemap::SourceMap {
         .collect(),
       sources_content: value.sources_content,
       names: value.names.unwrap_or_default(),
-      debug_id: None,
+      debug_id: value.debug_id,
     })
-    .map_err(|e| anyhow::format_err!("Convert json sourcemap error: {:?}", e))
+    .map_err(|e| anyhow::format_err!("Convert json sourcemap error: {:?}", e))?;
+    if let Some(ignore_list) = value.x_google_ignore_list {
+      map.set_x_google_ignore_list(ignore_list);
+    }
+    Ok(map)
   }
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -397,6 +397,8 @@ export interface BindingJsonSourcemap {
   sources?: Array<string | undefined | null>
   sourcesContent?: Array<string | undefined | null>
   names?: Array<string>
+  debugId?: string
+  x_google_ignoreList?: Array<number>
 }
 
 export interface BindingJsWatchChangeEvent {

--- a/packages/rolldown/src/types/rolldown-output.ts
+++ b/packages/rolldown/src/types/rolldown-output.ts
@@ -20,6 +20,8 @@ export interface SourceMap {
   sources: string[]
   sourcesContent: string[]
   version: number
+  debugId?: string
+  x_google_ignoreList?: number[]
   toString(): string
   toUrl(): string
 }

--- a/packages/rolldown/src/types/sourcemap.ts
+++ b/packages/rolldown/src/types/sourcemap.ts
@@ -1,4 +1,5 @@
 import { BindingSourcemap } from '../binding'
+import type { SourceMap } from './rolldown-output'
 
 export interface ExistingRawSourceMap {
   file?: string | null
@@ -14,7 +15,7 @@ export interface ExistingRawSourceMap {
 export type SourceMapInput = ExistingRawSourceMap | string | null
 
 export function bindingifySourcemap(
-  map?: SourceMapInput,
+  map?: SourceMapInput | SourceMap,
 ): undefined | BindingSourcemap {
   if (map == null) return
   return {
@@ -31,10 +32,16 @@ export function bindingifySourcemap(
             // we convert it to undefined to skip that error.
             // note that if `sourceRoot: null` is included in a string sourcemap,
             // it will be converted to None by serde-json.
-            sourceRoot: map.sourceRoot ?? undefined,
+            sourceRoot:
+              'sourceRoot' in map ? (map.sourceRoot ?? undefined) : undefined,
             sources: map.sources?.map((s) => s ?? undefined),
             sourcesContent: map.sourcesContent?.map((s) => s ?? undefined),
             names: map.names,
+            x_google_ignoreList:
+              'x_google_ignoreList' in map
+                ? map.x_google_ignoreList
+                : undefined,
+            debugId: 'debugId' in map ? map.debugId : undefined,
           },
   }
 }

--- a/packages/rolldown/src/types/sourcemap.ts
+++ b/packages/rolldown/src/types/sourcemap.ts
@@ -37,10 +37,7 @@ export function bindingifySourcemap(
             sources: map.sources?.map((s) => s ?? undefined),
             sourcesContent: map.sourcesContent?.map((s) => s ?? undefined),
             names: map.names,
-            x_google_ignoreList:
-              'x_google_ignoreList' in map
-                ? map.x_google_ignoreList
-                : undefined,
+            x_google_ignoreList: map.x_google_ignoreList,
             debugId: 'debugId' in map ? map.debugId : undefined,
           },
   }

--- a/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/generate-bundle/_config.ts
@@ -62,10 +62,40 @@ export default defineTest({
           calls.push('test-plugin-2')
         },
       },
+      {
+        name: 'test-update-sourcemap',
+        generateBundle(_options, bundle) {
+          const chunk = bundle['main.js'] as RolldownOutputChunk
+          const map = chunk.map!
+          map.file = 'updated-' + map.file
+          map.mappings = ';' + map.mappings
+          map.sources.push('updated-source.js')
+          map.sourcesContent.push('console.log("updated")')
+          map.names.push('updated-name')
+          map.x_google_ignoreList = [0]
+          map.debugId = 'updated-debugId'
+          chunk.map = map
+        },
+      },
+      {
+        name: 'test-read-updated-sourcemap',
+        generateBundle(_options, bundle) {
+          const chunk = bundle['main.js'] as RolldownOutputChunk
+          const map = chunk.map!
+          expect(map.file).toBe('updated-main.js')
+          expect(map.mappings).toMatch(/^;/)
+          expect(map.sources.at(-1)).toBe('updated-source.js')
+          expect(map.sourcesContent.at(-1)).toBe('console.log("updated")')
+          expect(map.names.at(-1)).toBe('updated-name')
+          expect(map.x_google_ignoreList).toStrictEqual([0])
+          expect(map.debugId).toBe('updated-debugId')
+        },
+      },
     ],
     output: {
       chunkFileNames: '[name].js',
       sourcemap: true,
+      sourcemapDebugIds: true,
     },
   },
   beforeTest: () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Allow updating sourcemap.debugId and sourcemap.x_google_ignoreList by plugins.

It is used here in Vite:
https://github.com/rolldown/vite/blob/40a300ab92acf2548bfeb86b7d720026da8657a8/packages/vite/src/node/plugins/importAnalysisBuild.ts#L722-L736

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
