### PR TITLE
ci: install toolchain in FreeBSD build

### DIFF
--- a/.github/workflows/reusable-release-build.yml
+++ b/.github/workflows/reusable-release-build.yml
@@ -143,6 +143,7 @@ jobs:
             curl https://sh.rustup.rs -sSf --output rustup.sh
             sh rustup.sh -y --profile minimal --default-toolchain stable
             source "$HOME/.cargo/env"
+            rustup toolchain install
             echo "~~~~ rustc --version ~~~~"
             rustc --version
             echo "~~~~ node -v ~~~~"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The nightly release failed: https://github.com/rolldown/rolldown/actions/runs/13643182894/job/38139825439#step:3:266
Probably because of this change in rustup:
https://github.com/rust-lang/rustup/blob/master/CHANGELOG.md#1280---2025-03-04:~:text=rustup%20will%20no%20longer%20automatically%20install%20the%20active%20toolchain%20if%20it%20is%20not%20installed.%20pr%233985

This PR adds `rustup toolchain install` command to be run to ensure the toolchain is installed.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
