### PR TITLE
fix: make diagnostic message for eval build event easier to understand

### DIFF
--- a/crates/rolldown/tests/esbuild/dce/const_value_inlining_direct_eval/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/const_value_inlining_direct_eval/artifacts.snap
@@ -1,42 +1,41 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ nested-eval.js:3:17 ]
    │
  3 │     console.log(x, eval('x'))
    │                    ──┬─  
-   │                      ╰─── Use `eval` function here.
+   │                      ╰─── Use of `eval` function here.
 ───╯
 
 ```
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ top-level-eval.js:2:16 ]
    │
  2 │ console.log(x, eval('x'))
    │                ──┬─  
-   │                  ╰─── Use `eval` function here.
+   │                  ╰─── Use of `eval` function here.
 ───╯
 
 ```
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ ts-namespace-eval.ts:3:17 ]
    │
  3 │     console.log(x, eval('x'))
    │                    ──┬─  
-   │                      ╰─── Use `eval` function here.
+   │                      ╰─── Use of `eval` function here.
 ───╯
 
 ```

--- a/crates/rolldown/tests/esbuild/dce/remove_unused_imports_eval/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/remove_unused_imports_eval/artifacts.snap
@@ -1,18 +1,17 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ entry.js:4:1 ]
    │
  4 │ eval('foo(a, b, c)')
    │ ──┬─  
-   │   ╰─── Use `eval` function here.
+   │   ╰─── Use of `eval` function here.
 ───╯
 
 ```

--- a/crates/rolldown/tests/esbuild/dce/remove_unused_imports_eval_ts/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/remove_unused_imports_eval_ts/artifacts.snap
@@ -1,18 +1,17 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ entry.ts:4:1 ]
    │
  4 │ eval('foo(a, b, c)')
    │ ──┬─  
-   │   ╰─── Use `eval` function here.
+   │   ╰─── Use of `eval` function here.
 ───╯
 
 ```

--- a/crates/rolldown/tests/esbuild/default/direct_eval_tainting_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/direct_eval_tainting_no_bundle/artifacts.snap
@@ -1,30 +1,29 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
     ╭─[ entry.js:29:34 ]
     │
  29 │     function containsDirectEval() { eval() }
     │                                     ──┬─  
-    │                                       ╰─── Use `eval` function here.
+    │                                       ╰─── Use of `eval` function here.
 ────╯
 
 ```
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ entry.js:5:2 ]
    │
  5 │     eval('add(1, 2)')
    │     ──┬─  
-   │       ╰─── Use `eval` function here.
+   │       ╰─── Use of `eval` function here.
 ───╯
 
 ```

--- a/crates/rolldown/tests/esbuild/lower/lower_nested_function_direct_eval/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_nested_function_direct_eval/artifacts.snap
@@ -1,78 +1,77 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ 2.js:1:28 ]
    │
  1 │ if (foo) { function x() {} eval('') }
    │                            ──┬─  
-   │                              ╰─── Use `eval` function here.
+   │                              ╰─── Use of `eval` function here.
 ───╯
 
 ```
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ 3.js:1:39 ]
    │
  1 │ if (foo) { function x() {} if (bar) { eval('') } }
    │                                       ──┬─  
-   │                                         ╰─── Use `eval` function here.
+   │                                         ╰─── Use of `eval` function here.
 ───╯
 
 ```
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ 4.js:1:12 ]
    │
  1 │ if (foo) { eval(''); function x() {} }
    │            ──┬─  
-   │              ╰─── Use `eval` function here.
+   │              ╰─── Use of `eval` function here.
 ───╯
 
 ```
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ 6.js:1:42 ]
    │
  1 │ 'use strict'; if (foo) { function x() {} eval('') }
    │                                          ──┬─  
-   │                                            ╰─── Use `eval` function here.
+   │                                            ╰─── Use of `eval` function here.
 ───╯
 
 ```
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ 7.js:1:53 ]
    │
  1 │ 'use strict'; if (foo) { function x() {} if (bar) { eval('') } }
    │                                                     ──┬─  
-   │                                                       ╰─── Use `eval` function here.
+   │                                                       ╰─── Use of `eval` function here.
 ───╯
 
 ```
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ 8.js:1:26 ]
    │
  1 │ 'use strict'; if (foo) { eval(''); function x() {} }
    │                          ──┬─  
-   │                            ╰─── Use `eval` function here.
+   │                            ╰─── Use of `eval` function here.
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_eval/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_eval/artifacts.snap
@@ -1,18 +1,17 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ main.js:2:1 ]
    │
  2 │ eval("ns.a")
    │ ──┬─  
-   │   ╰─── Use `eval` function here.
+   │   ╰─── Use of `eval` function here.
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/warnings/eval/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/eval/artifacts.snap
@@ -1,18 +1,17 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
    ╭─[ main.js:1:13 ]
    │
  1 │ console.log(eval('let a = 100'))
    │             ──┬─  
-   │               ╰─── Use `eval` function here.
+   │               ╰─── Use of `eval` function here.
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/warnings/minified-with-eval/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/minified-with-eval/artifacts.snap
@@ -1,14 +1,13 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
 ## EVAL
 
 ```text
-[EVAL] Warning: Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.
- - Use `eval` function here. in main.js at 560..564
+[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
+ - Use of `eval` function here. in main.js at 560..564
 
 ```
 # Assets

--- a/crates/rolldown_error/src/events/eval.rs
+++ b/crates/rolldown_error/src/events/eval.rs
@@ -19,7 +19,7 @@ impl BuildEvent for Eval {
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {
     format!(
-      "Use of eval in '{}' is strongly discouraged as it poses security risks and may cause issues with minification.",
+      "Use of `eval` function in '{}' is strongly discouraged as it poses security risks and may cause issues with minification.",
       self.filename
     )
   }
@@ -27,14 +27,14 @@ impl BuildEvent for Eval {
   fn on_diagnostic(&self, diagnostic: &mut Diagnostic, opts: &DiagnosticOptions) {
     let filename = opts.stabilize_path(&self.filename);
 
-    diagnostic.title = "Use of eval is strongly discouraged as it poses security risks and may cause issues with minification.".to_string();
+    diagnostic.title = "Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.".to_string();
 
     let file_id = diagnostic.add_file(filename, self.source.clone());
 
     diagnostic.add_label(
       &file_id,
       self.span.start..self.span.end,
-      "Use `eval` function here.".to_string(),
+      "Use of `eval` function here.".to_string(),
     );
   }
 }


### PR DESCRIPTION
Fixes #3759

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Make all three messages match and more explicit. The diagnostic messages now doesn't sound like it's demanding to use the `eval` function.

Regenerating the snapshots removed the "snapshot_kind: text" lines. Is this expected or did I do something wrong?

This is my first contribution to rolldown after my first contribution to oxc a few days ago. I look forward to the future of both projects, their positive impact on web development and more opportunities for me to support and contribute.