### PR TITLE
fix: build-binding script should reuse passed args

### DIFF
--- a/packages/rolldown/build-binding.js
+++ b/packages/rolldown/build-binding.js
@@ -3,15 +3,8 @@ const fs = require('fs-extra')
 const glob = require('glob')
 const path = require('node:path')
 
-const nodeFiles = glob.globSync(
-  [path.resolve(__dirname, 'src/rolldown-binding.*.node')],
-  {
-    absolute: true,
-  },
-)
-nodeFiles.forEach((file) => {
-  fs.rmSync(file)
-})
+const args = process.argv.slice(2)
+console.log(`args: `, args)
 
 const cmd = spawn(
   'npx',
@@ -30,6 +23,7 @@ const cmd = spawn(
     'binding.d.ts',
     '--no-const-enum',
     '--no-dts-cache',
+    ...args,
   ],
   {
     stdio: 'inherit', // Directly inherit stdio (preserves colors)
@@ -41,6 +35,26 @@ const cmd = spawn(
 // Inspect exit code
 cmd.on('close', (code) => {
   if (code !== 0) {
+    const nodeFiles = glob.globSync(
+      [path.resolve(__dirname, 'src/rolldown-binding.*.node')],
+      {
+        absolute: true,
+      },
+    )
+    nodeFiles.forEach((file) => {
+      fs.rmSync(file)
+    })
+
+    const wasmFiles = glob.globSync(
+      [path.resolve(__dirname, './src/rolldown-binding.*.wasm')],
+      {
+        absolute: true,
+      },
+    )
+
+    wasmFiles.forEach((file) => {
+      fs.rmSync(file)
+    })
     console.error('Command failed!')
     process.exit(code)
   }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -405,6 +405,7 @@ export interface BindingJsWatchChangeEvent {
   event: string
 }
 
+/** TODO: support `preserve-react` mode */
 export type BindingJsx =
   | { type: 'Disable' }
   | { type: 'Preserve' }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Before I omit the passed args, which leads always build the debug napi build.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
