### PR TITLE
chore(rolldown): oxc v0.57.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,9 +1539,9 @@ checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "oxc"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae6276febbc5abc1f1e4cf49167d54ab341818656ae4f622d5992b65fcdd371"
+checksum = "918d8f6deffeb380427e17bfc2d63c38f30e485af3a285faa6ca87d8c8a37a0d"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cc5cd078806a1b7061fa146dc4228a57d0765da6c85e99500d069b86f57e94"
+checksum = "d92b3f2a5e042d3e7d21aab5896d3f02d657c4b3cae42aa2a5842ebd018ec194"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -1616,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4722414ac21a2e28a16b76de8390672c01a39adcb703d405b848149cfaeeaf7"
+checksum = "864754f59a7965a83bf47c376f97ac1937dedd415c367f7e6b7d6499453aaad4"
 dependencies = [
  "bitflags 2.9.0",
  "cow-utils",
@@ -1633,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1505d8622b2ea6ed0274f355bd5e4ee3f09df5d9b39c8a3a673f344d87b82a"
+checksum = "0f1b369ef5a746cfd3400047f0ec972d66fe75ee5ab5fbfa8f1699e7a3b86724"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1644,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf45370c6da0dd142a70468e5b25127d6a34caa71056105c85087559c8ee9afb"
+checksum = "7874fe470308c6882fbeb42953896a21ea727d76165bfa80613dab0abbf72254"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1656,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96be30717d29eb7d1780758d033e92fcc208b8cce83b3b4869d2155fa4c9b7bd"
+checksum = "ff4ba4ecfa3296e937a3173f3a6b7e98446fed48e182d03f0955729f74b219c1"
 dependencies = [
  "bitflags 2.9.0",
  "itertools",
@@ -1671,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fd891e06aa19c7d22e129d366e55644ffeed99167e3495dcaec8149a0631b3"
+checksum = "6eb495fd82a33f1d40ea0c27d1db81772946b26a4a236de411a83511aa628a96"
 dependencies = [
  "bitflags 2.9.0",
  "cow-utils",
@@ -1692,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb49a2ee880952c2079b61851ecc35d7671d9d3509e306f5e704ccacd2783984"
+checksum = "3454bded31b396d75d4ebad5fbdc547ad544b47556b540925be24a874e1d87d8"
 dependencies = [
  "assert-unchecked",
  "ropey",
@@ -1702,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea83fe2415b0580980ac83364c1ae943f8ee9c00becf5395a89e800a9526a080"
+checksum = "27cd28f66608e282c1384a877505d3678e099bc3cef6856bc55e2ef60f5344b2"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1712,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7e7bcc382cf901e93a16f86e70f2737c507aaa833656b0d8484d64f8ae358a"
+checksum = "43b9a66f69c6dcc78bf1c164e1e98b4494ba71fbf1b17ebd8940b936902e68ec"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1726,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb66484735d21f096b07c894badc96d89a0c6d31b4bdd46b33b3e44da9b97ac"
+checksum = "5aa7a068d758764707466b733f92ad66bbe91d5c66ce562d868dff8a7ae72b09"
 dependencies = [
  "itoa",
  "oxc_data_structures",
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef3dd6adb0d0db5a04d3833636a175fe84d217ab1bc805789ce5993c82804df"
+checksum = "1c529d255e1b3d12b4bb88a430997bd8fd846d6ae6644ba4954c138b3277c87d"
 dependencies = [
  "bitflags 2.9.0",
  "oxc_allocator",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8069aaf088ccaee383e008ff29d407c2c88b4ff8694f7e34a9d6aaf202c81e71"
+checksum = "f4f5ae1f1f842c714f3144036a644ee275c8a360fd50ac6f295ce52e468cee53"
 dependencies = [
  "fixedbitset",
  "itertools",
@@ -1781,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db16b19f75f29b9502b651c6ffae09366d43fd91decf5535d80c634f8e7e21d"
+checksum = "9e4030f603ae314c93b761753969328e96960a853f443fdeaf8c9b2273f7971e"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1803,9 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffcb56062ef22a06dd151cd334c028afab9499bcc8e4977bcf8edfdb1566334"
+checksum = "e5425b126612c6611ae36ae4cd556662976a87a3932b146b31495647f199d7de"
 dependencies = [
  "napi",
  "napi-build",
@@ -1815,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7414e779b9723b0bd2880fe69b0ee517e583f88c5118a7c9053cf3317b95b1"
+checksum = "71d48cff62f816c27be1912d1d173140602214c8eec38f1e98e77270f39e0ce6"
 dependencies = [
  "assert-unchecked",
  "bitflags 2.9.0",
@@ -1838,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c639077959e7d7ac12179064a7b0e0baaced23aa709f692ff5c323156e6e15"
+checksum = "f0bc04eceb34246000fa142769f4ca9bfe10edf282ef21375982aa897f69e4e8"
 dependencies = [
  "napi",
  "napi-build",
@@ -1854,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18196c212eac24a7faf613e373e5f9317d3542578a088d01dc1a548fa1e1cb3"
+checksum = "3a49d5d6ede8d8740b25743a78c2fb45859099ba89d88425b1b3d6a433dda352"
 dependencies = [
  "oxc_allocator",
  "oxc_ast_macros",
@@ -1889,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4556f1c700baaec8589872ddf2af41d9a964db52fdbec9a5d07d7477dce45cf8"
+checksum = "c7b84c302f11c87b330b5e3f02f3efc4cd1ea44e8553551d6e245cb161dcc6ef"
 dependencies = [
  "assert-unchecked",
  "itertools",
@@ -1930,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318f925e26bd118adc082d290538d07611fe2434987a5c60cf5084381ecb42e6"
+checksum = "cf5d0e27b520397a9d0a99dfa21d9c29fa389f34719aff30f6c5468498d603d9"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1944,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb68ceb7c6902f3043fe8fe49bb886826b1d7741dc2904337297d53692b1b9c"
+checksum = "e91fdded3cdce1641b8ee44a223be03dca3def248120cbe3fe0492a14bd8a744"
 dependencies = [
  "assert-unchecked",
  "bitflags 2.9.0",
@@ -1967,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eeec6aab0446b329787412aa29e6fb0db159e95f9f3a84b19e9a113cc3a6290"
+checksum = "510c9dc7a176864b9a50f556187ec8b6f8a7d0712760c4c3781b090b7e188bd7"
 dependencies = [
  "napi",
  "napi-build",
@@ -1982,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e44f0de58265ac636680ced8189b6eec24ab8c026847a41d1281f4e0218f59"
+checksum = "a60ff98162541d5abb139ca2b939cff6488faf0e78e7002e15f806bed1eff532"
 dependencies = [
  "base64",
  "compact_str",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.56.5"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a090c9cd461d468f5faf3fe3f56378a4e27d80febe34ad39f2a04920f594d4"
+checksum = "77703db3bd925f63fd688e3858ecd48d4b1a455a64f4c54bec6baae50af03cab"
 dependencies = [
  "compact_str",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ xxhash-rust         = "0.8.10"
 
 
 # oxc crates with the same version
-oxc = { version = "0.56.0", features = [
+oxc = { version = "0.57.0", features = [
   "ast_visit",
   "transformer",
   "minifier",
@@ -186,8 +186,8 @@ oxc = { version = "0.56.0", features = [
   "codegen",
   "serialize",
 ] }
-oxc_parser_napi = { version = "0.56.0" }
-oxc_transform_napi = { version = "0.56.0" }
+oxc_parser_napi = { version = "0.57.0" }
+oxc_transform_napi = { version = "0.57.0" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/crates/rolldown/src/ast_scanner/dynamic_import.rs
+++ b/crates/rolldown/src/ast_scanner/dynamic_import.rs
@@ -23,12 +23,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       return None;
     }
 
-    let reference = self
-      .result
-      .symbol_ref_db
-      .references
-      .get(ident.reference_id())
-      .expect("should have reference");
+    let reference = self.result.symbol_ref_db.get_reference(ident.reference_id());
 
     // panic because if program reached here, means the BindingIdentifier has referenced the
     // IdentifierReference, but IdentifierReference did not saved the related `SymbolId`

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -47,7 +47,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     for (idx, stmt) in program.body.iter().enumerate() {
       self.current_stmt_info.stmt_idx = Some(idx.into());
       self.current_stmt_info.side_effect = SideEffectDetector::new(
-        &self.result.ast_scope,
+        &self.result.symbol_ref_db.ast_scopes,
         // In `NormalModule` the options is always `Some`, for `RuntimeModule` always enable annotations
         !self.options.treeshake.annotations(),
         // Use a static value instead of `options` property access to avoid function call

--- a/crates/rolldown/src/ast_scanner/import_assign_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/import_assign_analyzer.rs
@@ -13,7 +13,7 @@ use super::AstScanner;
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   pub fn check_import_assign(&mut self, ident: &IdentifierReference, symbol_id: SymbolId) {
-    let symbol_flag = self.result.symbol_ref_db.get_flags(symbol_id);
+    let symbol_flag = self.result.symbol_ref_db.symbol_flags(symbol_id);
     if symbol_flag.contains(SymbolFlags::Import) {
       let symbol_ref: SymbolRef = (self.idx, symbol_id).into();
       let is_namespace = self
@@ -32,7 +32,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
           return;
         }
       }
-      let reference_flag = self.result.symbol_ref_db.references[ident.reference_id()].flags();
+      let reference_flag = self.result.symbol_ref_db.get_reference(ident.reference_id()).flags();
       if reference_flag.is_write() {
         self.result.errors.push(BuildDiagnostic::assign_to_import(
           self.id.resource_id().clone(),

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/utils.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/utils.rs
@@ -1,6 +1,6 @@
 use oxc::{
   ast::ast::{self, Expression, MemberExpression},
-  semantic::{ReferenceId, SymbolTable},
+  semantic::{ReferenceId, Scoping},
   span::Atom,
   syntax::operator::{BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator},
 };
@@ -23,13 +23,13 @@ fn merged_known_primitive_types(
   scope: &AstScopes,
   left: &Expression,
   right: &Expression,
-  symbol_table: &SymbolTable,
+  scoping: &Scoping,
 ) -> PrimitiveType {
-  let left_type = known_primitive_type(scope, left, symbol_table);
+  let left_type = known_primitive_type(scope, left, scoping);
   if left_type == PrimitiveType::Unknown {
     return PrimitiveType::Unknown;
   }
-  let right_type = known_primitive_type(scope, right, symbol_table);
+  let right_type = known_primitive_type(scope, right, scoping);
   if right_type == PrimitiveType::Unknown {
     return PrimitiveType::Unknown;
   }
@@ -43,13 +43,12 @@ fn merged_known_primitive_types(
 pub fn known_primitive_type(
   scope: &AstScopes,
   expr: &Expression,
-  symbol_table: &SymbolTable,
+  scoping: &Scoping,
 ) -> PrimitiveType {
   match expr {
     Expression::NullLiteral(_) => PrimitiveType::Null,
     Expression::Identifier(id)
-      if id.name == "undefined"
-        && scope.is_unresolved(id.reference_id.get().unwrap(), symbol_table) =>
+      if id.name == "undefined" && scope.is_unresolved(id.reference_id.get().unwrap(), scoping) =>
     {
       PrimitiveType::Undefined
     }
@@ -77,7 +76,7 @@ pub fn known_primitive_type(
       UnaryOperator::LogicalNot | UnaryOperator::Delete => PrimitiveType::Boolean,
       UnaryOperator::UnaryPlus => PrimitiveType::Number, // Cannot be bigint because that throws an exception
       UnaryOperator::UnaryNegation | UnaryOperator::BitwiseNot => {
-        let value = known_primitive_type(scope, &e.argument, symbol_table);
+        let value = known_primitive_type(scope, &e.argument, scoping);
         if value == PrimitiveType::BigInt {
           return PrimitiveType::BigInt;
         }
@@ -89,11 +88,11 @@ pub fn known_primitive_type(
     },
     Expression::LogicalExpression(e) => match e.operator {
       LogicalOperator::Or | LogicalOperator::And => {
-        merged_known_primitive_types(scope, &e.left, &e.right, symbol_table)
+        merged_known_primitive_types(scope, &e.left, &e.right, scoping)
       }
       LogicalOperator::Coalesce => {
-        let left = known_primitive_type(scope, &e.left, symbol_table);
-        let right = known_primitive_type(scope, &e.right, symbol_table);
+        let left = known_primitive_type(scope, &e.left, scoping);
+        let right = known_primitive_type(scope, &e.right, scoping);
         if left == PrimitiveType::Null || left == PrimitiveType::Undefined {
           return right;
         }
@@ -120,8 +119,8 @@ pub fn known_primitive_type(
       | BinaryOperator::Instanceof
       | BinaryOperator::In => PrimitiveType::Boolean,
       BinaryOperator::Addition => {
-        let left = known_primitive_type(scope, &e.left, symbol_table);
-        let right = known_primitive_type(scope, &e.right, symbol_table);
+        let left = known_primitive_type(scope, &e.left, scoping);
+        let right = known_primitive_type(scope, &e.right, scoping);
         if left == PrimitiveType::String || right == PrimitiveType::String {
           PrimitiveType::String
         } else if left == PrimitiveType::BigInt && right == PrimitiveType::BigInt {
@@ -153,10 +152,10 @@ pub fn known_primitive_type(
 
     Expression::AssignmentExpression(e) => match e.operator {
       oxc::syntax::operator::AssignmentOperator::Assign => {
-        known_primitive_type(scope, &e.right, symbol_table)
+        known_primitive_type(scope, &e.right, scoping)
       }
       oxc::syntax::operator::AssignmentOperator::Addition => {
-        let right = known_primitive_type(scope, &e.right, symbol_table);
+        let right = known_primitive_type(scope, &e.right, scoping);
         if right == PrimitiveType::String {
           PrimitiveType::String
         } else {
@@ -186,18 +185,14 @@ pub fn can_change_strict_to_loose(
   scope: &AstScopes,
   a: &Expression,
   b: &Expression,
-  symbol_table: &SymbolTable,
+  scoping: &Scoping,
 ) -> bool {
-  let x = known_primitive_type(scope, a, symbol_table);
-  let y = known_primitive_type(scope, b, symbol_table);
+  let x = known_primitive_type(scope, a, scoping);
+  let y = known_primitive_type(scope, b, scoping);
   x == y && !matches!(x, PrimitiveType::Unknown | PrimitiveType::Mixed)
 }
 
-pub fn is_primitive_literal(
-  scope: &AstScopes,
-  expr: &Expression,
-  symbol_table: &SymbolTable,
-) -> bool {
+pub fn is_primitive_literal(scope: &AstScopes, expr: &Expression, scoping: &Scoping) -> bool {
   match expr {
     Expression::NullLiteral(_)
     | Expression::BooleanLiteral(_)
@@ -206,14 +201,14 @@ pub fn is_primitive_literal(
     | Expression::BigIntLiteral(_) => true,
     // Include `+1` / `-1`.
     Expression::UnaryExpression(e) => match e.operator {
-      UnaryOperator::Void => is_primitive_literal(scope, &e.argument, symbol_table),
+      UnaryOperator::Void => is_primitive_literal(scope, &e.argument, scoping),
       UnaryOperator::UnaryNegation | UnaryOperator::UnaryPlus => {
         matches!(e.argument, Expression::NumericLiteral(_))
       }
       _ => false,
     },
     Expression::Identifier(id)
-      if id.name == "undefined" && scope.is_unresolved(id.reference_id(), symbol_table) =>
+      if id.name == "undefined" && scope.is_unresolved(id.reference_id(), scoping) =>
     {
       true
     }
@@ -282,10 +277,10 @@ pub fn is_side_effect_free_unbound_identifier_ref(
   value: &Expression,
   guard_condition: &Expression,
   mut is_yes_branch: bool,
-  symbol_table: &SymbolTable,
+  scoping: &Scoping,
 ) -> Option<bool> {
   let ident = value.as_identifier()?;
-  let is_unresolved = scope.is_unresolved(ident.reference_id(), symbol_table);
+  let is_unresolved = scope.is_unresolved(ident.reference_id(), scoping);
   if !is_unresolved {
     return Some(false);
   }
@@ -357,7 +352,7 @@ pub fn is_side_effect_free_unbound_identifier_ref(
 pub fn maybe_side_effect_free_global_constructor(
   scope: &AstScopes,
   expr: &ast::NewExpression<'_>,
-  symbol_table: &oxc::semantic::SymbolTable,
+  symbol_table: &Scoping,
 ) -> bool {
   let Some(ident) = expr.callee.as_identifier() else {
     return false;

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -27,7 +27,7 @@ pub async fn create_ecma_view(
   args: CreateModuleViewArgs,
 ) -> BuildResult<CreateEcmaViewReturn> {
   let CreateModuleViewArgs { source, sourcemap_chain, hook_side_effects } = args;
-  let ParseToEcmaAstResult { ast, symbol_table, scope_tree, has_lazy_export, warning } =
+  let ParseToEcmaAstResult { ast, scoping, has_lazy_export, warning } =
     parse_to_ecma_ast(ctx, source)?;
 
   ctx.warnings.extend(warning);
@@ -39,8 +39,7 @@ pub async fn create_ecma_view(
 
   let scanner = AstScanner::new(
     ctx.module_index,
-    scope_tree,
-    symbol_table,
+    scoping,
     &repr_name,
     ctx.resolved_id.module_def_format,
     ast.source(),
@@ -62,7 +61,6 @@ pub async fn create_ecma_view(
     has_eval,
     errors,
     ast_usage,
-    ast_scope,
     symbol_ref_db: symbols,
     self_referenced_class_decl_symbol_ids,
     hashbang_range,
@@ -98,7 +96,6 @@ pub async fn create_ecma_view(
     stmt_infos,
     imports,
     default_export_ref,
-    ast_scope_idx: None,
     exports_kind,
     namespace_object_ref,
     def_format: ctx.resolved_id.module_def_format,
@@ -127,7 +124,7 @@ pub async fn create_ecma_view(
     hmr_info,
   };
 
-  let ecma_related = EcmaRelated { ast, symbols, ast_scope, dynamic_import_rec_exports_usage };
+  let ecma_related = EcmaRelated { ast, symbols, dynamic_import_rec_exports_usage };
   Ok(CreateEcmaViewReturn { ecma_view, ecma_related, raw_import_records })
 }
 

--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -76,15 +76,14 @@ impl HmrManager {
       // TODO: We should get newest source and ast directly from module, but now we just manually fetch them.
       let source: String = std::fs::read_to_string(filename.as_str()).map_err_to_unhandleable()?;
       let mut ast = EcmaCompiler::parse(&filename, source, SourceType::default())?;
-      let (symbol_table, scope_tree) = ast.make_symbol_table_and_scope_tree();
+      let scoping = ast.make_scoping();
 
       ast.program.with_mut(|fields| {
         let mut finalizer = HmrAstFinalizer {
           modules: &self.module_db.modules,
           alloc: fields.allocator,
           snippet: AstSnippet::new(fields.allocator),
-          scopes: &scope_tree,
-          symbols: &symbol_table,
+          scoping: &scoping,
           import_binding: FxHashMap::default(),
           module: changed_module,
           exports: FxHashMap::default(),

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
@@ -650,7 +650,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   ) -> Option<ast::Declaration<'ast>> {
     let scope_id = class.scope_id.get()?;
 
-    if self.scope.get_parent_id(scope_id) != Some(self.scope.root_scope_id()) {
+    if self.scope.scope_parent_id(scope_id) != Some(self.scope.root_scope_id()) {
       return None;
     };
 

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -3,10 +3,10 @@ use super::runtime_module_task::RuntimeModuleTask;
 use super::task_context::TaskContextMeta;
 use crate::ecmascript::ecma_module_view_factory::normalize_side_effects;
 use crate::module_loader::task_context::TaskContext;
-use crate::type_alias::{IndexAstScope, IndexEcmaAst};
+use crate::type_alias::IndexEcmaAst;
 use crate::utils::load_entry_module::load_entry_module;
 use arcstr::ArcStr;
-use oxc::semantic::{ScopeId, SymbolTable};
+use oxc::semantic::{ScopeId, Scoping};
 use oxc::transformer::ReplaceGlobalDefinesConfig;
 use oxc_index::IndexVec;
 use rolldown_common::dynamic_import_usage::DynamicImportExportsUsage;
@@ -35,7 +35,6 @@ pub struct IntermediateNormalModules {
   pub modules: IndexVec<ModuleIdx, Option<Module>>,
   pub importers: IndexVec<ModuleIdx, Vec<ImporterRecord>>,
   pub index_ecma_ast: IndexEcmaAst,
-  pub index_ast_scope: IndexAstScope,
 }
 
 impl IntermediateNormalModules {
@@ -44,7 +43,6 @@ impl IntermediateNormalModules {
       modules: IndexVec::new(),
       importers: IndexVec::new(),
       index_ecma_ast: IndexVec::default(),
-      index_ast_scope: IndexVec::default(),
     }
   }
 
@@ -71,7 +69,6 @@ pub struct ModuleLoaderOutput {
   // Stored all modules
   pub module_table: ModuleTable,
   pub index_ecma_ast: IndexEcmaAst,
-  pub index_ast_scope: IndexAstScope,
   pub symbol_ref_db: SymbolRefDb,
   // Entries that user defined + dynamic import entries
   pub entry_points: Vec<EntryPoint>,
@@ -187,7 +184,7 @@ impl ModuleLoader {
 
           self.symbol_ref_db.store_local_db(
             idx,
-            SymbolRefDbForModule::new(SymbolTable::default(), idx, ScopeId::new(0)),
+            SymbolRefDbForModule::new(Scoping::default(), idx, ScopeId::new(0)),
           );
           let symbol_ref = self.symbol_ref_db.create_facade_root_symbol_ref(
             idx,
@@ -228,7 +225,6 @@ impl ModuleLoader {
     let entries_count = user_defined_entries.len() + /* runtime */ 1;
     self.intermediate_normal_modules.modules.reserve(entries_count);
     self.intermediate_normal_modules.index_ecma_ast.reserve(entries_count);
-    self.intermediate_normal_modules.index_ast_scope.reserve(entries_count);
 
     // Store the already consider as entry module
     let mut user_defined_entry_ids = FxHashSet::with_capacity(user_defined_entries.len());
@@ -328,11 +324,9 @@ impl ModuleLoader {
           module.set_import_records(import_records);
 
           let module_idx = module.idx();
-          if let Some(EcmaRelated { ast, symbols, ast_scope, .. }) = ecma_related {
+          if let Some(EcmaRelated { ast, symbols, .. }) = ecma_related {
             let ast_idx = self.intermediate_normal_modules.index_ecma_ast.push((ast, module_idx));
-            let ast_scope_idx = self.intermediate_normal_modules.index_ast_scope.push(ast_scope);
             module.set_ecma_ast_idx(ast_idx);
-            module.set_ast_scope_idx(ast_scope_idx);
             self.symbol_ref_db.store_local_db(module_idx, symbols);
           }
 
@@ -347,7 +341,6 @@ impl ModuleLoader {
             ast,
             raw_import_records,
             resolved_deps,
-            ast_scope,
           } = task_result;
           let import_records: IndexVec<ImportRecordIdx, rolldown_common::ResolvedImportRecord> =
             raw_import_records
@@ -383,9 +376,7 @@ impl ModuleLoader {
               })
               .collect::<IndexVec<ImportRecordIdx, _>>();
           let ast_idx = self.intermediate_normal_modules.index_ecma_ast.push((ast, module.idx));
-          let ast_scope_idx = self.intermediate_normal_modules.index_ast_scope.push(ast_scope);
           module.ecma_ast_idx = Some(ast_idx);
-          module.ast_scope_idx = Some(ast_scope_idx);
           module.import_records = import_records;
           self.intermediate_normal_modules.modules[self.runtime_id] = Some(module.into());
 
@@ -553,7 +544,6 @@ impl ModuleLoader {
       module_table: ModuleTable { modules },
       symbol_ref_db: self.symbol_ref_db,
       index_ecma_ast: self.intermediate_normal_modules.index_ecma_ast,
-      index_ast_scope: self.intermediate_normal_modules.index_ast_scope,
       entry_points,
       runtime: runtime_brief.expect("Failed to find runtime module. This should not happen"),
       warnings: all_warnings,

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -97,8 +97,7 @@ impl<'a> GenerateStage<'a> {
         let Module::Normal(module) = &self.link_output.module_table.modules[*owner] else {
           return;
         };
-        let ast_scope_idx = module.ecma_view.ast_scope_idx.expect("scope idx should be set");
-        let ast_scope = &self.link_output.ast_scope_table[ast_scope_idx];
+        let ast_scope = &self.link_output.symbol_db[module.idx].as_ref().unwrap().ast_scopes;
         let chunk_id = chunk_graph.module_to_chunk[module.idx].unwrap();
         let chunk = &chunk_graph.chunk_table[chunk_id];
         let linking_info = &self.link_output.metas[module.idx];

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -10,7 +10,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
   SharedOptions,
-  type_alias::{IndexAstScope, IndexEcmaAst},
+  type_alias::IndexEcmaAst,
   types::linking_metadata::{LinkingMetadata, LinkingMetadataVec},
 };
 
@@ -38,7 +38,6 @@ pub struct LinkStageOutput {
   pub runtime: RuntimeModuleBrief,
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
-  pub ast_scope_table: IndexAstScope,
   pub used_symbol_refs: FxHashSet<SymbolRef>,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
   pub lived_entry_points: FxHashSet<ModuleIdx>,
@@ -55,7 +54,6 @@ pub struct LinkStage<'a> {
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
   pub ast_table: IndexEcmaAst,
-  pub ast_scope_table: IndexAstScope,
   pub options: &'a SharedOptions,
   pub used_symbol_refs: FxHashSet<SymbolRef>,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
@@ -90,7 +88,6 @@ impl<'a> LinkStage<'a> {
         })
         .collect::<IndexVec<ModuleIdx, _>>(),
       module_table: scan_stage_output.module_table,
-      ast_scope_table: scan_stage_output.index_ast_scope,
       entries: scan_stage_output.entry_points,
       symbols: scan_stage_output.symbol_ref_db,
       runtime: scan_stage_output.runtime,
@@ -132,7 +129,6 @@ impl<'a> LinkStage<'a> {
       ast_table: self.ast_table,
       used_symbol_refs: self.used_symbol_refs,
       dynamic_import_exports_usage_map: self.dynamic_import_exports_usage_map,
-      ast_scope_table: self.ast_scope_table,
     }
   }
 

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxHashMap;
 use crate::{
   SharedOptions, SharedResolver,
   module_loader::{ModuleLoader, module_loader::ModuleLoaderOutput},
-  type_alias::{IndexAstScope, IndexEcmaAst},
+  type_alias::IndexEcmaAst,
   utils::load_entry_module::load_entry_module,
 };
 
@@ -30,7 +30,6 @@ pub struct ScanStage {
 pub struct ScanStageOutput {
   pub module_table: ModuleTable,
   pub index_ecma_ast: IndexEcmaAst,
-  pub index_ast_scope: IndexAstScope,
   pub entry_points: Vec<EntryPoint>,
   pub symbol_ref_db: SymbolRefDb,
   pub runtime: RuntimeModuleBrief,
@@ -85,7 +84,6 @@ impl ScanStage {
       warnings,
       index_ecma_ast,
       dynamic_import_exports_usage_map,
-      index_ast_scope,
     } = module_loader.fetch_all_modules(user_entries).await?;
 
     self.plugin_driver.file_emitter.set_context_load_modules_tx(None).await;
@@ -93,7 +91,6 @@ impl ScanStage {
     self.plugin_driver.set_context_load_modules_tx(None).await;
 
     Ok(ScanStageOutput {
-      index_ast_scope,
       module_table,
       entry_points,
       symbol_ref_db,

--- a/crates/rolldown/src/type_alias.rs
+++ b/crates/rolldown/src/type_alias.rs
@@ -1,7 +1,5 @@
 use oxc_index::IndexVec;
-use rolldown_common::{
-  Asset, AssetIdx, AstScopeIdx, AstScopes, ChunkIdx, EcmaAstIdx, InstantiatedChunk, ModuleIdx,
-};
+use rolldown_common::{Asset, AssetIdx, ChunkIdx, EcmaAstIdx, InstantiatedChunk, ModuleIdx};
 use rolldown_ecmascript::EcmaAst;
 use rolldown_utils::indexmap::FxIndexSet;
 
@@ -9,4 +7,3 @@ pub type IndexChunkToAssets = IndexVec<ChunkIdx, FxIndexSet<AssetIdx>>;
 pub type IndexAssets = IndexVec<AssetIdx, Asset>;
 pub type IndexInstantiatedChunks = IndexVec<AssetIdx, InstantiatedChunk>;
 pub type IndexEcmaAst = IndexVec<EcmaAstIdx, (EcmaAst, ModuleIdx)>;
-pub type IndexAstScope = IndexVec<AstScopeIdx, AstScopes>;

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -51,9 +51,13 @@ pub fn deconflict_chunk_symbols(
     .copied()
     .filter_map(|id| link_output.module_table.modules[id].as_normal())
     .flat_map(|m| {
-      let ast_scope =
-        &link_output.ast_scope_table[m.ast_scope_idx.expect("ast_scope_idx should be set")];
-      ast_scope.root_unresolved_references().keys().map(Cow::Borrowed)
+      link_output.symbol_db[m.idx]
+        .as_ref()
+        .unwrap()
+        .ast_scopes
+        .root_unresolved_references()
+        .keys()
+        .map(Cow::Borrowed)
     })
     .for_each(|name| {
       // global names should be reserved
@@ -120,11 +124,7 @@ pub fn deconflict_chunk_symbols(
     });
 
   // rename non-top-level names
-  renamer.rename_non_root_symbol(
-    &chunk.modules,
-    &link_output.module_table.modules,
-    &link_output.ast_scope_table,
-  );
+  renamer.rename_non_root_symbol(&chunk.modules, link_output);
 
   (chunk.canonical_names, chunk.canonical_name_by_token) = renamer.into_canonical_names();
 }

--- a/crates/rolldown/src/utils/parse_to_ecma_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ecma_ast.rs
@@ -1,10 +1,7 @@
 use std::path::Path;
 
 use arcstr::ArcStr;
-use oxc::{
-  semantic::{ScopeTree, SymbolTable},
-  span::SourceType as OxcSourceType,
-};
+use oxc::{semantic::Scoping, span::SourceType as OxcSourceType};
 use rolldown_common::{ModuleType, NormalizedBundlerOptions, RUNTIME_MODULE_ID, StrOrBytes};
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
 use rolldown_error::{BuildDiagnostic, BuildResult};
@@ -29,8 +26,7 @@ fn pure_esm_js_oxc_source_type() -> OxcSourceType {
 
 pub struct ParseToEcmaAstResult {
   pub ast: EcmaAst,
-  pub symbol_table: SymbolTable,
-  pub scope_tree: ScopeTree,
+  pub scoping: Scoping,
   pub has_lazy_export: bool,
   pub warning: Vec<BuildDiagnostic>,
 }

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -1,8 +1,7 @@
 use oxc::semantic::ScopeId;
 use oxc::syntax::keyword::{GLOBAL_OBJECTS, RESERVED_KEYWORDS};
 use rolldown_common::{
-  AstScopes, IndexModules, ModuleIdx, NormalModule, OutputFormat, SymbolNameRefToken, SymbolRef,
-  SymbolRefDb,
+  AstScopes, ModuleIdx, NormalModule, OutputFormat, SymbolNameRefToken, SymbolRef, SymbolRefDb,
 };
 use rolldown_rstr::{Rstr, ToRstr};
 use rolldown_utils::rustc_hash::FxHashMapExt;
@@ -14,7 +13,7 @@ use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 
-use crate::type_alias::IndexAstScope;
+use crate::stages::link_stage::LinkStageOutput;
 
 #[derive(Debug)]
 pub struct Renamer<'name> {
@@ -142,8 +141,7 @@ impl<'name> Renamer<'name> {
   pub fn rename_non_root_symbol(
     &mut self,
     modules_in_chunk: &[ModuleIdx],
-    modules: &IndexModules,
-    ast_scope_table: &IndexAstScope,
+    link_stage_output: &LinkStageOutput,
   ) {
     #[tracing::instrument(level = "trace", skip_all)]
     fn rename_symbols_of_nested_scopes<'name>(
@@ -186,19 +184,19 @@ impl<'name> Renamer<'name> {
       });
 
       stack.push(Cow::Owned(used_canonical_names_for_this_scope));
-      let child_scopes = ast_scope.get_child_ids(scope_id);
+      let child_scopes = ast_scope.get_scope_child_ids(scope_id);
       child_scopes.iter().for_each(|scope_id| {
         rename_symbols_of_nested_scopes(module, *scope_id, stack, canonical_names, ast_scope);
       });
       stack.pop();
     }
 
+    let modules = &link_stage_output.module_table.modules;
     let copied_scope_iter =
       modules_in_chunk.par_iter().copied().filter_map(|id| modules[id].as_normal()).flat_map(
         |module| {
-          let ast_scope_idx = module.ast_scope_idx.expect("ast_scope_idx should be set");
-          let ast_scope = &ast_scope_table[ast_scope_idx];
-          let child_scopes: &[ScopeId] = ast_scope.get_child_ids(ast_scope.root_scope_id());
+          let ast_scope = &link_stage_output.symbol_db[module.idx].as_ref().unwrap().ast_scopes;
+          let child_scopes: &[ScopeId] = ast_scope.get_scope_child_ids(ast_scope.root_scope_id());
 
           child_scopes.into_par_iter().map(|child_scope_id| {
             let mut stack = vec![Cow::Borrowed(&self.used_canonical_names)];

--- a/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/artifacts.snap
@@ -7,32 +7,32 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/checkPrivateRedeclaration.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/checkPrivateRedeclaration.js
 function _checkPrivateRedeclaration(e, t) {
 	if (t.has(e)) throw new TypeError("Cannot initialize the same private elements twice on an object");
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldInitSpec.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldInitSpec.js
 function _classPrivateFieldInitSpec(e, t, a) {
 	_checkPrivateRedeclaration(e, t), t.set(e, a);
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/assertClassBrand.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/assertClassBrand.js
 function _assertClassBrand(e, t, n) {
 	if ("function" == typeof e ? e === t : e.has(t)) return arguments.length < 3 ? t : n;
 	throw new TypeError("Private element is not present on this object");
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldGet2.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldGet2.js
 function _classPrivateFieldGet2(s, a) {
 	return s.get(_assertClassBrand(s, a));
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldSet2.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldSet2.js
 function _classPrivateFieldSet2(s, a, r) {
 	return s.set(_assertClassBrand(s, a), r), r;
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/diff.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/diff.md
@@ -16,32 +16,32 @@ export {
 ### rolldown
 ```js
 
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/checkPrivateRedeclaration.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/checkPrivateRedeclaration.js
 function _checkPrivateRedeclaration(e, t) {
 	if (t.has(e)) throw new TypeError("Cannot initialize the same private elements twice on an object");
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldInitSpec.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldInitSpec.js
 function _classPrivateFieldInitSpec(e, t, a) {
 	_checkPrivateRedeclaration(e, t), t.set(e, a);
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/assertClassBrand.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/assertClassBrand.js
 function _assertClassBrand(e, t, n) {
 	if ("function" == typeof e ? e === t : e.has(t)) return arguments.length < 3 ? t : n;
 	throw new TypeError("Private element is not present on this object");
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldGet2.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldGet2.js
 function _classPrivateFieldGet2(s, a) {
 	return s.get(_assertClassBrand(s, a));
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldSet2.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldSet2.js
 function _classPrivateFieldSet2(s, a, r) {
 	return s.set(_assertClassBrand(s, a), r), r;
 }

--- a/crates/rolldown/tests/rolldown/resolve/ts_config_option_merge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/ts_config_option_merge/artifacts.snap
@@ -14,7 +14,7 @@ function add(a, b) {
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/decorateParam.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/decorateParam.js
 function __decorateParam(paramIndex, decorator) {
 	return function(target, key) {
 		decorator(target, key, paramIndex);
@@ -22,7 +22,7 @@ function __decorateParam(paramIndex, decorator) {
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.56.5/node_modules/@oxc-project/runtime/src/helpers/esm/decorate.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.57.0/node_modules/@oxc-project/runtime/src/helpers/esm/decorate.js
 function __decorate(decorators, target, key, desc) {
 	var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
 	if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -2652,7 +2652,7 @@ expression: output
 
 # tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493
 
-- entry-!~{000}~.js => entry-C122K0Rw.js
+- entry-!~{000}~.js => entry-Czp7t5To.js
 
 # tests/esbuild/lower/lower_object_spread_no_bundle
 
@@ -4764,7 +4764,7 @@ expression: output
 
 # tests/rolldown/resolve/ts_config_option_merge
 
-- main-!~{000}~.js => main-2RmycSr1.js
+- main-!~{000}~.js => main-e8eh7dwc.js
 
 # tests/rolldown/resolve/wildcard_alias
 

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -7,8 +7,8 @@ use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-  AstScopeIdx, EcmaAstIdx, ExportsKind, HmrInfo, ImportRecordIdx, LocalExport, ModuleDefFormat,
-  ModuleId, NamedImport, ResolvedImportRecord, SourceMutation, StmtInfoIdx, StmtInfos, SymbolRef,
+  EcmaAstIdx, ExportsKind, HmrInfo, ImportRecordIdx, LocalExport, ModuleDefFormat, ModuleId,
+  NamedImport, ResolvedImportRecord, SourceMutation, StmtInfoIdx, StmtInfos, SymbolRef,
   side_effects::DeterminedSideEffects, types::source_mutation::BoxedSourceMutation,
 };
 
@@ -72,7 +72,6 @@ pub struct EcmaView {
   /// and `CallExpression`(only when the callee is `require`).
   pub imports: FxHashMap<Span, ImportRecordIdx>,
   pub exports_kind: ExportsKind,
-  pub ast_scope_idx: Option<AstScopeIdx>,
   pub default_export_ref: SymbolRef,
   pub sourcemap_chain: Vec<rolldown_sourcemap::SourceMap>,
   // the ids of all modules that statically import this module

--- a/crates/rolldown_common/src/module/mod.rs
+++ b/crates/rolldown_common/src/module/mod.rs
@@ -5,8 +5,7 @@ use oxc_index::IndexVec;
 use rolldown_std_utils::OptionExt;
 
 use crate::{
-  AstScopeIdx, EcmaAstIdx, ExternalModule, ImportRecordIdx, ModuleIdx, NormalModule,
-  ResolvedImportRecord,
+  EcmaAstIdx, ExternalModule, ImportRecordIdx, ModuleIdx, NormalModule, ResolvedImportRecord,
 };
 
 #[derive(Debug)]
@@ -111,13 +110,6 @@ impl Module {
     match self {
       Module::Normal(v) => v.ecma_ast_idx = Some(idx),
       Module::External(_) => panic!("set_ecma_ast_idx should be called on EcmaModule"),
-    }
-  }
-
-  pub fn set_ast_scope_idx(&mut self, idx: AstScopeIdx) {
-    match self {
-      Module::Normal(v) => v.ast_scope_idx = Some(idx),
-      Module::External(_) => panic!("set_ast_scope_idx should be called on EcmaModule"),
     }
   }
 

--- a/crates/rolldown_common/src/module_loader/runtime_task_result.rs
+++ b/crates/rolldown_common/src/module_loader/runtime_task_result.rs
@@ -1,9 +1,7 @@
 use oxc_index::IndexVec;
 use rolldown_ecmascript::EcmaAst;
 
-use crate::{
-  AstScopes, ImportRecordIdx, NormalModule, RawImportRecord, ResolvedId, SymbolRefDbForModule,
-};
+use crate::{ImportRecordIdx, NormalModule, RawImportRecord, ResolvedId, SymbolRefDbForModule};
 
 use super::runtime_module_brief::RuntimeModuleBrief;
 
@@ -11,7 +9,6 @@ pub struct RuntimeModuleTaskResult {
   pub runtime: RuntimeModuleBrief,
   pub local_symbol_ref_db: SymbolRefDbForModule,
   pub ast: EcmaAst,
-  pub ast_scope: AstScopes,
   pub module: NormalModule,
   pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,

--- a/crates/rolldown_common/src/module_loader/task_result.rs
+++ b/crates/rolldown_common/src/module_loader/task_result.rs
@@ -1,5 +1,5 @@
 use crate::{
-  AstScopes, ImportRecordIdx, Module, RawImportRecord, ResolvedId, SymbolRefDbForModule,
+  ImportRecordIdx, Module, RawImportRecord, ResolvedId, SymbolRefDbForModule,
   dynamic_import_usage::DynamicImportExportsUsage,
 };
 use oxc_index::IndexVec;
@@ -18,6 +18,5 @@ pub struct NormalModuleTaskResult {
 pub struct EcmaRelated {
   pub ast: EcmaAst,
   pub symbols: SymbolRefDbForModule,
-  pub ast_scope: AstScopes,
   pub dynamic_import_rec_exports_usage: FxHashMap<ImportRecordIdx, DynamicImportExportsUsage>,
 }

--- a/crates/rolldown_common/src/types/ast_scopes.rs
+++ b/crates/rolldown_common/src/types/ast_scopes.rs
@@ -1,40 +1,42 @@
-use oxc::semantic::{Reference, ReferenceId, ScopeTree, SymbolId, SymbolTable};
+use oxc::semantic::{Reference, ReferenceId, Scoping, SymbolId};
 
 #[derive(Debug)]
 pub struct AstScopes {
-  inner: ScopeTree,
+  scoping: Scoping,
 }
 
 impl AstScopes {
-  pub fn new(inner: ScopeTree) -> Self {
-    Self { inner }
+  pub fn new(inner: Scoping) -> Self {
+    Self { scoping: inner }
   }
 
-  pub fn is_unresolved(&self, reference_id: ReferenceId, symbol_table: &SymbolTable) -> bool {
-    symbol_table.references[reference_id].symbol_id().is_none()
+  pub fn is_unresolved(&self, reference_id: ReferenceId, scoping: &Scoping) -> bool {
+    scoping.get_reference(reference_id).symbol_id().is_none()
   }
 
-  pub fn symbol_id_for(
-    &self,
-    reference_id: ReferenceId,
-    symbol_table: &SymbolTable,
-  ) -> Option<SymbolId> {
-    symbol_table.references[reference_id].symbol_id()
+  pub fn symbol_id_for(&self, reference_id: ReferenceId, scoping: &Scoping) -> Option<SymbolId> {
+    scoping.get_reference(reference_id).symbol_id()
   }
 
   pub fn get_resolved_references<'table>(
     &self,
     symbol_id: SymbolId,
-    symbol_table: &'table SymbolTable,
+    scoping: &'table Scoping,
   ) -> impl Iterator<Item = &'table Reference> + 'table + use<'table> {
-    symbol_table.get_resolved_references(symbol_id)
+    scoping.get_resolved_references(symbol_id)
   }
 }
 
 impl std::ops::Deref for AstScopes {
-  type Target = ScopeTree;
+  type Target = Scoping;
 
   fn deref(&self) -> &Self::Target {
-    &self.inner
+    &self.scoping
+  }
+}
+
+impl std::ops::DerefMut for AstScopes {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.scoping
   }
 }

--- a/crates/rolldown_common/src/types/symbol_ref.rs
+++ b/crates/rolldown_common/src/types/symbol_ref.rs
@@ -20,11 +20,11 @@ impl From<(ModuleIdx, SymbolId)> for SymbolRef {
 
 impl SymbolRef {
   pub fn name<'db>(&self, db: &'db SymbolRefDb) -> &'db str {
-    db.inner[self.owner].unpack_ref().get_name(self.symbol)
+    db[self.owner].unpack_ref().symbol_name(self.symbol)
   }
 
   pub fn set_name(&self, db: &mut SymbolRefDb, name: &str) {
-    db.inner[self.owner].unpack_ref_mut().set_name(self.symbol, name);
+    db[self.owner].unpack_ref_mut().set_symbol_name(self.symbol, name);
   }
 
   /// Not all symbols have flags info, we only care about part of them.

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -1,14 +1,13 @@
-use std::ops::{Deref, DerefMut};
+use std::ops::{Deref, DerefMut, Index, IndexMut};
 
-use oxc::semantic::SymbolId;
-use oxc::semantic::{NodeId, ScopeId, SymbolFlags, SymbolTable};
+use oxc::semantic::{NodeId, ScopeId, Scoping, SymbolFlags, SymbolId};
 use oxc::span::SPAN;
 use oxc_index::IndexVec;
 use rolldown_rstr::Rstr;
 use rolldown_std_utils::OptionExt;
 use rustc_hash::FxHashMap;
 
-use crate::{ChunkIdx, ModuleIdx, SymbolRef};
+use crate::{AstScopes, ChunkIdx, ModuleIdx, SymbolRef};
 
 use super::namespace_alias::NamespaceAlias;
 
@@ -37,22 +36,22 @@ bitflags::bitflags! {
 pub struct SymbolRefDbForModule {
   owner_idx: ModuleIdx,
   root_scope_id: ScopeId,
-  pub(crate) symbol_table: SymbolTable,
+  pub ast_scopes: AstScopes,
   // Only some symbols would be cared about, so we use a hashmap to store the flags.
   pub flags: FxHashMap<SymbolId, SymbolRefFlags>,
   pub classic_data: IndexVec<SymbolId, SymbolRefDataClassic>,
 }
 
 impl SymbolRefDbForModule {
-  pub fn new(symbol_table: SymbolTable, owner_idx: ModuleIdx, top_level_scope_id: ScopeId) -> Self {
+  pub fn new(scoping: Scoping, owner_idx: ModuleIdx, top_level_scope_id: ScopeId) -> Self {
     Self {
       owner_idx,
       root_scope_id: top_level_scope_id,
-      classic_data: symbol_table
-        .names()
+      classic_data: scoping
+        .symbol_names()
         .map(|_name| SymbolRefDataClassic { link: None, chunk_id: None, namespace_alias: None })
         .collect(),
-      symbol_table,
+      ast_scopes: AstScopes::new(scoping),
       flags: FxHashMap::default(),
     }
   }
@@ -64,7 +63,7 @@ impl SymbolRefDbForModule {
       chunk_id: None,
       namespace_alias: None,
     });
-    let symbol_id = self.symbol_table.create_symbol(
+    let symbol_id = self.ast_scopes.create_symbol(
       SPAN,
       name,
       SymbolFlags::empty(),
@@ -84,23 +83,37 @@ impl SymbolRefDbForModule {
 }
 
 impl Deref for SymbolRefDbForModule {
-  type Target = SymbolTable;
+  type Target = Scoping;
 
   fn deref(&self) -> &Self::Target {
-    &self.symbol_table
+    &self.ast_scopes
   }
 }
 
 impl DerefMut for SymbolRefDbForModule {
   fn deref_mut(&mut self) -> &mut Self::Target {
-    &mut self.symbol_table
+    &mut self.ast_scopes
   }
 }
 
 // Information about symbols for all modules
 #[derive(Debug, Default)]
 pub struct SymbolRefDb {
-  pub(crate) inner: IndexVec<ModuleIdx, Option<SymbolRefDbForModule>>,
+  inner: IndexVec<ModuleIdx, Option<SymbolRefDbForModule>>,
+}
+
+impl Index<ModuleIdx> for SymbolRefDb {
+  type Output = Option<SymbolRefDbForModule>;
+
+  fn index(&self, index: ModuleIdx) -> &Self::Output {
+    self.inner.index(index)
+  }
+}
+
+impl IndexMut<ModuleIdx> for SymbolRefDb {
+  fn index_mut(&mut self, index: ModuleIdx) -> &mut Self::Output {
+    self.inner.index_mut(index)
+  }
 }
 
 impl SymbolRefDb {
@@ -179,10 +192,10 @@ impl SymbolRefDb {
 
   pub fn is_declared_in_root_scope(&self, refer: SymbolRef) -> bool {
     let local_db = self.inner[refer.owner].unpack_ref();
-    local_db.get_scope_id(refer.symbol) == local_db.root_scope_id
+    local_db.symbol_scope_id(refer.symbol) == local_db.root_scope_id
   }
 
-  pub fn this_method_should_be_removed_get_symbol_table(&self, owner: ModuleIdx) -> &SymbolTable {
+  pub fn this_method_should_be_removed_get_symbol_table(&self, owner: ModuleIdx) -> &Scoping {
     self.inner[owner].unpack_ref()
   }
 }

--- a/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
@@ -1,6 +1,6 @@
 use oxc::{
   ast::ast::Program,
-  semantic::{ScopeTree, Semantic, SemanticBuilder, SymbolTable},
+  semantic::{Scoping, Semantic, SemanticBuilder},
 };
 
 use crate::EcmaAst;
@@ -15,20 +15,16 @@ impl EcmaAst {
     semantic
   }
 
-  pub fn make_symbol_table_and_scope_tree(&self) -> (SymbolTable, ScopeTree) {
-    self.program.with_dependent(|_owner, dep| {
-      let semantic = Self::make_semantic(&dep.program);
-      semantic.into_symbol_table_and_scope_tree()
-    })
+  pub fn make_scoping(&self) -> Scoping {
+    self.program.with_dependent(|_owner, dep| Self::make_semantic(&dep.program).into_scoping())
   }
 
   pub fn make_symbol_table_and_scope_tree_with_semantic_builder<'a>(
     &'a self,
     semantic_builder: SemanticBuilder<'a>,
-  ) -> (SymbolTable, ScopeTree) {
-    self.program.with_dependent::<'a, (SymbolTable, ScopeTree)>(|_owner, dep| {
-      let semantic = semantic_builder.build(&dep.program).semantic;
-      semantic.into_symbol_table_and_scope_tree()
+  ) -> Scoping {
+    self.program.with_dependent::<'a, Scoping>(|_owner, dep| {
+      semantic_builder.build(&dep.program).semantic.into_scoping()
     })
   }
 }

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/call_expression_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/call_expression_ext.rs
@@ -1,19 +1,19 @@
-use oxc::{ast::ast, semantic::SymbolTable};
+use oxc::{ast::ast, semantic::Scoping};
 use rolldown_common::AstScopes;
 
 pub trait CallExpressionExt<'ast> {
-  fn is_global_require_call(&self, scope: &AstScopes, symbol_table: &SymbolTable) -> bool;
+  fn is_global_require_call(&self, scope: &AstScopes, scoping: &Scoping) -> bool;
 }
 
 impl<'ast> CallExpressionExt<'ast> for ast::CallExpression<'ast> {
-  fn is_global_require_call(&self, scope: &AstScopes, symbol_table: &SymbolTable) -> bool {
+  fn is_global_require_call(&self, scope: &AstScopes, scoping: &Scoping) -> bool {
     match &self.callee {
       ast::Expression::Identifier(ident) if ident.name == "require" => {
         let Some(ref_id) = ident.reference_id.get() else {
           // `require(...)` inserted by bundler does not have a reference id
           return true;
         };
-        scope.is_unresolved(ref_id, symbol_table)
+        scope.is_unresolved(ref_id, scoping)
       }
       _ => false,
     }

--- a/crates/rolldown_plugin_transform/src/lib.rs
+++ b/crates/rolldown_plugin_transform/src/lib.rs
@@ -87,10 +87,9 @@ impl Plugin for TransformPlugin {
         }
       }
 
-      let (symbols, scopes) =
-        SemanticBuilder::new().build(fields.program).semantic.into_symbol_table_and_scope_tree();
+      let scoping = SemanticBuilder::new().build(fields.program).semantic.into_scoping();
       Transformer::new(fields.allocator, Path::new(args.id), &transformer_options)
-        .build_with_symbols_and_scopes(symbols, scopes, fields.program)
+        .build_with_scoping(scoping, fields.program)
     });
     if !ret.errors.is_empty() {
       // TODO: better error handling

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@actions/core": "^1.11.1",
     "@babel/runtime": "7.26.9",
     "@oxc-node/core": "^0.0.20",
-    "@oxc-project/runtime": "0.56.5",
+    "@oxc-project/runtime": "0.57.0",
     "@taplo/cli": "^0.7.0",
     "@types/node": "22.13.10",
     "cjs-module-lexer": "^2.0.0",

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -104,12 +104,12 @@
     "dtsHeader": "type MaybePromise<T> = T | Promise<T>\ntype Nullable<T> = T | null | undefined\ntype VoidNullable<T = void> = T | null | undefined | void\nexport type BindingStringOrRegex = string | RegExp\n\n"
   },
   "dependencies": {
-    "@oxc-project/types": "0.56.5",
+    "@oxc-project/types": "0.57.0",
     "@valibot/to-json-schema": "1.0.0-rc.0",
     "valibot": "1.0.0-rc.3"
   },
   "peerDependencies": {
-    "@oxc-project/runtime": "0.56.5"
+    "@oxc-project/runtime": "0.57.0"
   },
   "peerDependenciesMeta": {
     "@oxc-project/runtime": {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1104,11 +1104,11 @@ export interface ParserOptions {
    */
   astType?: 'js' | 'ts'
   /**
-   * Emit `ParenthesizedExpression` in AST.
+   * Emit `ParenthesizedExpression` and `TSParenthesizedType` in AST.
    *
    * If this option is true, parenthesized expressions are represented by
-   * (non-standard) `ParenthesizedExpression` nodes that have a single `expression` property
-   * containing the expression inside parentheses.
+   * (non-standard) `ParenthesizedExpression` and `TSParenthesizedType` nodes that
+   * have a single `expression` property containing the expression inside parentheses.
    *
    * @default true
    */

--- a/packages/rollup-tests/package.json
+++ b/packages/rollup-tests/package.json
@@ -14,7 +14,7 @@
     "mocha": "^11.0.0",
     "rolldown": "workspace:*",
     "source-map-support": "^0.5.21",
-    "oxc-transform": "0.56.5",
+    "oxc-transform": "0.57.0",
     "cross-env": "^7.0.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.0.20
         version: 0.0.20
       '@oxc-project/runtime':
-        specifier: 0.56.5
-        version: 0.56.5
+        specifier: 0.57.0
+        version: 0.57.0
       '@taplo/cli':
         specifier: ^0.7.0
         version: 0.7.0
@@ -123,7 +123,7 @@ importers:
         version: link:../../packages/rolldown
       unplugin-isolated-decl:
         specifier: ^0.8.1
-        version: 0.8.3(oxc-transform@0.56.5)(rollup@4.35.0)(typescript@5.8.2)
+        version: 0.8.3(oxc-transform@0.57.0)(rollup@4.35.0)(typescript@5.8.2)
 
   examples/module-federation:
     devDependencies:
@@ -252,11 +252,11 @@ importers:
   packages/rolldown:
     dependencies:
       '@oxc-project/runtime':
-        specifier: 0.56.5
-        version: 0.56.5
+        specifier: 0.57.0
+        version: 0.57.0
       '@oxc-project/types':
-        specifier: 0.56.5
-        version: 0.56.5
+        specifier: 0.57.0
+        version: 0.57.0
       '@valibot/to-json-schema':
         specifier: 1.0.0-rc.0
         version: 1.0.0-rc.0(valibot@1.0.0-rc.3(typescript@5.8.2))
@@ -448,8 +448,8 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       oxc-transform:
-        specifier: 0.56.5
-        version: 0.56.5
+        specifier: 0.57.0
+        version: 0.57.0
       rolldown:
         specifier: workspace:*
         version: link:../rolldown
@@ -2608,71 +2608,71 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-project/runtime@0.56.5':
-    resolution: {integrity: sha512-0wTlk+E8pEpwHgelXKONnbuk0+OlUd+In7ONETcnCi+5ciDkN9uaCLIeGZG4qO1zNW2KDmzuABHroF46cu4/0A==}
+  '@oxc-project/runtime@0.57.0':
+    resolution: {integrity: sha512-ib1XYIU+M1xXTW3vauJ7M+nwSgt9pe1lnnE9bicyxOwyATW1MKVXOeRUMD+t1rKkM/mfFIvDgcjMDSd4DwUpOA==}
     engines: {node: '>=6.9.0'}
 
   '@oxc-project/types@0.37.0':
     resolution: {integrity: sha512-9shvIr/cpoNo5cX8nWdZmviHLJSidjZy4M0MyfR6ucREZBtABTNBIa1a4emWUJ3qAMwJW6G1v0zm8K2rj9Pf4A==}
 
-  '@oxc-project/types@0.56.5':
-    resolution: {integrity: sha512-skY3kOJwp22W4RkaadH1hZ3hqFHjkRrIIE0uQ4VUg+/Chvbl+2pF+B55IrIk2dgsKXS57YEUsJuN6I6s4rgFjA==}
+  '@oxc-project/types@0.57.0':
+    resolution: {integrity: sha512-UnR+Y4KxX/UxUPSIuM7BezELIE7tkgAWPEsFgv17aIFbej5L7LrFC9BupWT2Xus2/JZQ9WwugjHXFXg7MgFjBg==}
 
-  '@oxc-transform/binding-darwin-arm64@0.56.5':
-    resolution: {integrity: sha512-OlLgqKlWqA5A5IW3/YOKV2egeT/h/I36FjB88f07xbOGn/4B1Zj8TeIyvW49rbvi2edz6z5roPzp/CV/htXVHQ==}
+  '@oxc-transform/binding-darwin-arm64@0.57.0':
+    resolution: {integrity: sha512-+REtd8qTuvhDYx8H363HlNEtqajMcwbjYRlXkCdJT6/QhA/uKrEYtdedip/E/+FMTLNMC6VkYFm76uR4Xoph3w==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-transform/binding-darwin-x64@0.56.5':
-    resolution: {integrity: sha512-4dEIUwNa+GVz+9nD/Yh9bC3hBL0m6/FQD/p0cTJNVTD8NCuuvHVb4wtIQMbzeROZILrYYDnb7y+WA6MiONVGlA==}
+  '@oxc-transform/binding-darwin-x64@0.57.0':
+    resolution: {integrity: sha512-Dr6LkbDkbXyGYZz5xeTvCF7jhutDJlE3ySxsYRShATA3u58fNKwCMCuHpR/g1XQK7WVnitgdAtOpmZYMu7Td/g==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-transform/binding-linux-arm-gnueabihf@0.56.5':
-    resolution: {integrity: sha512-Py/EGK8xSpC/u5TiXG13BihNaV9uoix4G4XMveNlpeOZI7t4SPkCVLQu5X6+4gdEEaJ7km+rrmjXLmrHfWQnjA==}
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.57.0':
+    resolution: {integrity: sha512-DzKzP8CO6GBe+BpOY0YZeM1V3VXk8zNeo/eHUwfMedmFhmoOmcVty0AWgBip8yJER1uQGVt8vUxkzAG0eGNkUg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-transform/binding-linux-arm64-gnu@0.56.5':
-    resolution: {integrity: sha512-EEgK8RIbJRdLXHJS1VqrEgaMdcwu25xgGZACrSdqmGTAxP5jGwMXModcOdb7a0qiZpyMBEwM3Sa/u0kflJFYLQ==}
+  '@oxc-transform/binding-linux-arm64-gnu@0.57.0':
+    resolution: {integrity: sha512-wr9cHCATHYJjjKynLUlP2uFJEMk940R5/2eWxJRTFsFJR+A1b0pV4/kySSPOs6tNdesTq/SXYpEggoEI4sSivQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-transform/binding-linux-arm64-musl@0.56.5':
-    resolution: {integrity: sha512-SwFBYSWS/GGBqMTqrNoN0IXFRhhey3euBe6a+QPKaI4RHC0jAxJIVIG5dRUjgPg4eAtnpbkWR+1MNk38mF6RiQ==}
+  '@oxc-transform/binding-linux-arm64-musl@0.57.0':
+    resolution: {integrity: sha512-iGh033MUSV8BFUaST88u7oeZpWK07cR9hq4ugfGUEhNrycwB4WyYICt8hg30UEJbGPZV4D304SADoVvGEZIwSA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-transform/binding-linux-x64-gnu@0.56.5':
-    resolution: {integrity: sha512-/egcz00fX5/oRArkmnE6CbRC6aZSOPi/+08AnN5E80iK1K47AB9tWWaA0wS1eI4glDIXlcupH3lYzxSS2qcbBg==}
+  '@oxc-transform/binding-linux-x64-gnu@0.57.0':
+    resolution: {integrity: sha512-f/lQUXhFZdefxeytm5aBKBoDv+e1T6ymyBXDXKsAvSCro04akjc94eSSll9nxEs1euVRy8QWc1rSOD77ORwfuA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-transform/binding-linux-x64-musl@0.56.5':
-    resolution: {integrity: sha512-W7hFOx+hvvhB7dmDNYllEInWJrjBrnrsDLZ5/hcqDenLphj7EBfCDDhBMmwgcMCbAc8OIYW/dFMWlTTAPYMZ4Q==}
+  '@oxc-transform/binding-linux-x64-musl@0.57.0':
+    resolution: {integrity: sha512-FvQnlKpYsrkbFn3UgcBmvG9Ne30xPEYFVx1KMGfmIjsJCSCIpHq/GpLG8oIcCjn9tzRwscwpC6vV83zQ+BTmRA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-transform/binding-wasm32-wasi@0.56.5':
-    resolution: {integrity: sha512-6sbMQmFTwiG5tJuUtFFUiyy3wapjzBTTr6uFR6aeaRu8V9yeCaM8O2LXa1g+Lo+t1RUDcIjGxXB+hAgzN3+5wA==}
+  '@oxc-transform/binding-wasm32-wasi@0.57.0':
+    resolution: {integrity: sha512-BTPP87BPa/fEthR7K891hwtsld3z5qWWa5YxBV01GTf588F1YdOr6sGFsz/mi8YIzNUDkSy/h7YCbLzeEqXAXQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@oxc-transform/binding-win32-arm64-msvc@0.56.5':
-    resolution: {integrity: sha512-kdejF9Q+Ig/xZ+VcJlGusOw22vVNIsP18MlR4TMTuoOcxkz9/bUQg+oj17V/gATmR5LZDXUU05CQLsdJgrCT6w==}
+  '@oxc-transform/binding-win32-arm64-msvc@0.57.0':
+    resolution: {integrity: sha512-RtJzv+ZFLKVJ6b7o6F+OEoGGWVVxGx3pdrFHWAddiQQh5FFBuQYUwa6bCn7xwCMbHg5ZssUVasmLMbqQN1w6qg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-transform/binding-win32-x64-msvc@0.56.5':
-    resolution: {integrity: sha512-/gmPYm+U5R/B81NTQfWOVlpxHooBjcZxPeGHHbh2nuRzrpxAE1fdXktZ2IbpOWCT5sRrAlY6ubQigfJJHKy1uA==}
+  '@oxc-transform/binding-win32-x64-msvc@0.57.0':
+    resolution: {integrity: sha512-6OnEFCAJv+i7ol25aEVlwHO8qPPXj0YHlETdId18NBzThlqjTRDTyJuvsGUtbktgELqX3VFseijjmByRoytlwA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [win32]
@@ -5323,8 +5323,8 @@ packages:
   oxc-parser@0.37.0:
     resolution: {integrity: sha512-s5GDqjuFI0R3iEYvrQ0YOxBAOi601wCNAUodco8aA7D7qJu6pRb32qmqi5rhzJM4si3M5XQSr5CSDBhdGJl3Ig==}
 
-  oxc-transform@0.56.5:
-    resolution: {integrity: sha512-cLIZZqdwLpBBTZ9ILNpcGQUrqvgLKpo1+wx9CHimORs4Q6HUMjOYK65aZzyi5pIfBGzq0j3avK7rufpik0vzlA==}
+  oxc-transform@0.57.0:
+    resolution: {integrity: sha512-1iYLJDKVKySPYTdpUgWFTNnH45i1Ru5wH85CUn/8EOTVs53R+htTV70li+aSeSwdd/2NMnDByfAnh6cg7VvWiQ==}
     engines: {node: '>=14.0.0'}
 
   oxlint@0.15.13:
@@ -8704,42 +8704,42 @@ snapshots:
   '@oxc-parser/binding-win32-x64-msvc@0.37.0':
     optional: true
 
-  '@oxc-project/runtime@0.56.5': {}
+  '@oxc-project/runtime@0.57.0': {}
 
   '@oxc-project/types@0.37.0': {}
 
-  '@oxc-project/types@0.56.5': {}
+  '@oxc-project/types@0.57.0': {}
 
-  '@oxc-transform/binding-darwin-arm64@0.56.5':
+  '@oxc-transform/binding-darwin-arm64@0.57.0':
     optional: true
 
-  '@oxc-transform/binding-darwin-x64@0.56.5':
+  '@oxc-transform/binding-darwin-x64@0.57.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm-gnueabihf@0.56.5':
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.57.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm64-gnu@0.56.5':
+  '@oxc-transform/binding-linux-arm64-gnu@0.57.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm64-musl@0.56.5':
+  '@oxc-transform/binding-linux-arm64-musl@0.57.0':
     optional: true
 
-  '@oxc-transform/binding-linux-x64-gnu@0.56.5':
+  '@oxc-transform/binding-linux-x64-gnu@0.57.0':
     optional: true
 
-  '@oxc-transform/binding-linux-x64-musl@0.56.5':
+  '@oxc-transform/binding-linux-x64-musl@0.57.0':
     optional: true
 
-  '@oxc-transform/binding-wasm32-wasi@0.56.5':
+  '@oxc-transform/binding-wasm32-wasi@0.57.0':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.7
     optional: true
 
-  '@oxc-transform/binding-win32-arm64-msvc@0.56.5':
+  '@oxc-transform/binding-win32-arm64-msvc@0.57.0':
     optional: true
 
-  '@oxc-transform/binding-win32-x64-msvc@0.56.5':
+  '@oxc-transform/binding-win32-x64-msvc@0.57.0':
     optional: true
 
   '@oxlint/darwin-arm64@0.15.13':
@@ -11750,18 +11750,18 @@ snapshots:
       '@oxc-parser/binding-win32-arm64-msvc': 0.37.0
       '@oxc-parser/binding-win32-x64-msvc': 0.37.0
 
-  oxc-transform@0.56.5:
+  oxc-transform@0.57.0:
     optionalDependencies:
-      '@oxc-transform/binding-darwin-arm64': 0.56.5
-      '@oxc-transform/binding-darwin-x64': 0.56.5
-      '@oxc-transform/binding-linux-arm-gnueabihf': 0.56.5
-      '@oxc-transform/binding-linux-arm64-gnu': 0.56.5
-      '@oxc-transform/binding-linux-arm64-musl': 0.56.5
-      '@oxc-transform/binding-linux-x64-gnu': 0.56.5
-      '@oxc-transform/binding-linux-x64-musl': 0.56.5
-      '@oxc-transform/binding-wasm32-wasi': 0.56.5
-      '@oxc-transform/binding-win32-arm64-msvc': 0.56.5
-      '@oxc-transform/binding-win32-x64-msvc': 0.56.5
+      '@oxc-transform/binding-darwin-arm64': 0.57.0
+      '@oxc-transform/binding-darwin-x64': 0.57.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.57.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.57.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.57.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.57.0
+      '@oxc-transform/binding-linux-x64-musl': 0.57.0
+      '@oxc-transform/binding-wasm32-wasi': 0.57.0
+      '@oxc-transform/binding-win32-arm64-msvc': 0.57.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.57.0
 
   oxlint@0.15.13:
     optionalDependencies:
@@ -12925,7 +12925,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-isolated-decl@0.8.3(oxc-transform@0.56.5)(rollup@4.35.0)(typescript@5.8.2):
+  unplugin-isolated-decl@0.8.3(oxc-transform@0.57.0)(rollup@4.35.0)(typescript@5.8.2):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.35.0)
       debug: 4.4.0(supports-color@8.1.1)
@@ -12933,7 +12933,7 @@ snapshots:
       oxc-parser: 0.37.0
       unplugin: 1.16.1
     optionalDependencies:
-      oxc-transform: 0.56.5
+      oxc-transform: 0.57.0
       typescript: 5.8.2
     transitivePeerDependencies:
       - rollup


### PR DESCRIPTION
The next version of Oxc combined `SymbolTable` and `ScopeTree` into a single struct called `Scoping`. The motivation is to heavily optimize related data structures in a wholesale.

I temporarily moved `AstScopes` into `SymbolDb` and removed the extra `AstScopes` `IndexVec` storage.

We need to refactor relevant code after this PR.