### PR TITLE
feat(node): split interface for PluginContext types

### DIFF
--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -19,10 +19,10 @@ import { transformModuleInfo } from '../utils/transform-module-info'
 import path from 'node:path'
 import { bindingifySourcemap, ExistingRawSourceMap } from '../types/sourcemap'
 import {
-  PluginContext,
+  PluginContextImpl,
   PrivatePluginContextResolveOptions,
 } from './plugin-context'
-import { TransformPluginContext } from './transform-plugin-context'
+import { TransformPluginContextImpl } from './transform-plugin-context'
 import { bindingifySideEffects } from '../utils/transform-side-effects'
 import {
   PluginHookWithBindingExt,
@@ -50,7 +50,7 @@ export function bindingifyBuildStart(
   return {
     plugin: async (ctx, opts) => {
       await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -76,7 +76,7 @@ export function bindingifyBuildEnd(
   return {
     plugin: async (ctx, err) => {
       await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -120,7 +120,7 @@ export function bindingifyResolveId(
       }
 
       const ret = await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -177,7 +177,7 @@ export function bindingifyResolveDynamicImport(
   return {
     plugin: async (ctx, specifier, importer) => {
       const ret = await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -239,7 +239,7 @@ export function bindingifyTransform(
   return {
     plugin: async (ctx, code, id, meta) => {
       const ret = await handler.call(
-        new TransformPluginContext(
+        new TransformPluginContextImpl(
           args.outputOptions,
           ctx.inner(),
           args.plugin,
@@ -298,7 +298,7 @@ export function bindingifyLoad(
   return {
     plugin: async (ctx, id) => {
       const ret = await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -373,7 +373,7 @@ export function bindingifyModuleParsed(
   return {
     plugin: async (ctx, moduleInfo) => {
       await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -4,7 +4,7 @@ import {
   collectChangedBundle,
   transformToOutputBundle,
 } from '../utils/transform-to-rollup-output'
-import { PluginContext } from './plugin-context'
+import { PluginContextImpl } from './plugin-context'
 import { bindingifySourcemap } from '../types/sourcemap'
 import {
   PluginHookWithBindingExt,
@@ -29,7 +29,7 @@ export function bindingifyRenderStart(
   return {
     plugin: async (ctx, opts) => {
       handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -60,7 +60,7 @@ export function bindingifyRenderChunk(
   return {
     plugin: async (ctx, code, chunk, opts) => {
       const ret = await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -110,7 +110,7 @@ export function bindingifyAugmentChunkHash(
   return {
     plugin: async (ctx, chunk) => {
       return await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -137,7 +137,7 @@ export function bindingifyRenderError(
   return {
     plugin: async (ctx, err) => {
       handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -169,7 +169,7 @@ export function bindingifyGenerateBundle(
       } as ChangedOutputs
       const output = transformToOutputBundle(bundle, changed)
       await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -208,7 +208,7 @@ export function bindingifyWriteBundle(
       } as ChangedOutputs
       const output = transformToOutputBundle(bundle, changed)
       await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -241,7 +241,7 @@ export function bindingifyCloseBundle(
   return {
     plugin: async (ctx) => {
       await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -271,7 +271,7 @@ export function bindingifyBanner(
       }
 
       return handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -303,7 +303,7 @@ export function bindingifyFooter(
       }
 
       return handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -335,7 +335,7 @@ export function bindingifyIntro(
       }
 
       return handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -367,7 +367,7 @@ export function bindingifyOutro(
       }
 
       return handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,

--- a/packages/rolldown/src/plugin/bindingify-watch-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-watch-hooks.ts
@@ -1,7 +1,7 @@
 import { normalizeHook } from '../utils/normalize-hook'
 import type { BindingPluginOptions } from '../binding'
 import type { ChangeEvent } from './index'
-import { PluginContext } from './plugin-context'
+import { PluginContextImpl } from './plugin-context'
 import {
   PluginHookWithBindingExt,
   bindingifyPluginHookMeta,
@@ -20,7 +20,7 @@ export function bindingifyWatchChange(
   return {
     plugin: async (ctx, id, event) => {
       await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,
@@ -48,7 +48,7 @@ export function bindingifyCloseWatcher(
   return {
     plugin: async (ctx) => {
       await handler.call(
-        new PluginContext(
+        new PluginContextImpl(
           args.outputOptions,
           ctx,
           args.plugin,

--- a/packages/rolldown/src/plugin/minimal-plugin-context.ts
+++ b/packages/rolldown/src/plugin/minimal-plugin-context.ts
@@ -15,7 +15,16 @@ export interface PluginContextMeta {
   watchMode: boolean
 }
 
-export class MinimalPluginContext {
+export interface MinimalPluginContext {
+  readonly pluginName: string
+  error: (e: RollupError | string) => never
+  info: LoggingFunction
+  warn: LoggingFunction
+  debug: LoggingFunction
+  meta: PluginContextMeta
+}
+
+export class MinimalPluginContextImpl implements MinimalPluginContext {
   info: LoggingFunction
   warn: LoggingFunction
   debug: LoggingFunction

--- a/packages/rolldown/src/plugin/transform-plugin-context.ts
+++ b/packages/rolldown/src/plugin/transform-plugin-context.ts
@@ -9,14 +9,28 @@ import type {
   RollupError,
 } from '../types/misc'
 import { normalizeLog } from '../log/log-handler'
-import { PluginContext } from './plugin-context'
+import { PluginContextImpl, type PluginContext } from './plugin-context'
 import { augmentCodeLocation, error, logPluginError } from '../log/logs'
 import { PluginContextData } from './plugin-context-data'
 import type { Plugin } from './index'
 import { SourceMap } from '../types/rolldown-output'
 import { OutputOptions } from '../options/output-options'
 
-export class TransformPluginContext extends PluginContext {
+export interface TransformPluginContext extends PluginContext {
+  debug: LoggingFunctionWithPosition
+  info: LoggingFunctionWithPosition
+  warn: LoggingFunctionWithPosition
+  error(
+    e: RollupError | string,
+    pos?: number | { column: number; line: number },
+  ): never
+  getCombinedSourcemap(): SourceMap
+}
+
+export class TransformPluginContextImpl
+  extends PluginContextImpl
+  implements TransformPluginContext
+{
   constructor(
     outputOptions: OutputOptions,
     context: BindingPluginContext,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes this type error in rolldown-vite.
https://github.com/vitejs/rolldown-vite/actions/runs/13722891098/job/38382285643?pr=84#step:9:20
I'm not sure why but it seems classes and interfaces have a different semantics for declaration merging.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
