### PR TITLE
feat(node): remove `implements` from PluginContext types

### DIFF
--- a/packages/rolldown/src/plugin/minimal-plugin-context.ts
+++ b/packages/rolldown/src/plugin/minimal-plugin-context.ts
@@ -8,6 +8,7 @@ import { LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARN } from '../log/logging'
 import { error, logPluginError } from '../log/logs'
 import { getLogHandler, normalizeLog } from '../log/log-handler'
 import { VERSION } from '..'
+import type { Extends, TypeAssert } from '../types/assert'
 
 export interface PluginContextMeta {
   rollupVersion: string
@@ -24,7 +25,7 @@ export interface MinimalPluginContext {
   meta: PluginContextMeta
 }
 
-export class MinimalPluginContextImpl implements MinimalPluginContext {
+export class MinimalPluginContextImpl {
   info: LoggingFunction
   warn: LoggingFunction
   debug: LoggingFunction
@@ -67,4 +68,10 @@ export class MinimalPluginContextImpl implements MinimalPluginContext {
   public error(e: RollupError | string): never {
     return error(logPluginError(normalizeLog(e), this.pluginName))
   }
+}
+
+function _assert() {
+  // adding implements to class disallows extending PluginContext by declaration merging
+  // instead check that MinimalPluginContextImpl is assignable to MinimalPluginContext here
+  type _ = TypeAssert<Extends<MinimalPluginContextImpl, MinimalPluginContext>>
 }

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -22,6 +22,7 @@ import { logCycleLoading } from '../log/logs'
 import { OutputOptions } from '../options/output-options'
 import { parseAst } from '../parse-ast-index'
 import { Program } from '@oxc-project/types'
+import type { Extends, TypeAssert } from '../types/assert'
 
 export interface EmittedAsset {
   type: 'asset'
@@ -72,10 +73,7 @@ export interface PluginContext extends MinimalPluginContext {
   ): Promise<ResolvedId | null>
 }
 
-export class PluginContextImpl
-  extends MinimalPluginContextImpl
-  implements PluginContext
-{
+export class PluginContextImpl extends MinimalPluginContextImpl {
   getModuleInfo: GetModuleInfo
   constructor(
     private outputOptions: OutputOptions,
@@ -221,4 +219,10 @@ export class PluginContextImpl
   ): Program {
     return parseAst(input, options)
   }
+}
+
+function _assert() {
+  // adding implements to class disallows extending PluginContext by declaration merging
+  // instead check that PluginContextImpl is assignable to PluginContext here
+  type _ = TypeAssert<Extends<PluginContextImpl, PluginContext>>
 }

--- a/packages/rolldown/src/plugin/transform-plugin-context.ts
+++ b/packages/rolldown/src/plugin/transform-plugin-context.ts
@@ -15,6 +15,7 @@ import { PluginContextData } from './plugin-context-data'
 import type { Plugin } from './index'
 import { SourceMap } from '../types/rolldown-output'
 import { OutputOptions } from '../options/output-options'
+import type { Extends, TypeAssert } from '../types/assert'
 
 export interface TransformPluginContext extends PluginContext {
   debug: LoggingFunctionWithPosition
@@ -27,10 +28,7 @@ export interface TransformPluginContext extends PluginContext {
   getCombinedSourcemap(): SourceMap
 }
 
-export class TransformPluginContextImpl
-  extends PluginContextImpl
-  implements TransformPluginContext
-{
+export class TransformPluginContextImpl extends PluginContextImpl {
   constructor(
     outputOptions: OutputOptions,
     context: BindingPluginContext,
@@ -72,4 +70,12 @@ export class TransformPluginContextImpl
   public getCombinedSourcemap(): SourceMap {
     return JSON.parse(this.inner.getCombinedSourcemap())
   }
+}
+
+function _assert() {
+  // adding implements to class disallows extending PluginContext by declaration merging
+  // instead check that TransformPluginContextImpl is assignable to TransformPluginContext here
+  type _ = TypeAssert<
+    Extends<TransformPluginContextImpl, TransformPluginContext>
+  >
 }

--- a/packages/rolldown/src/types/assert.ts
+++ b/packages/rolldown/src/types/assert.ts
@@ -24,4 +24,6 @@ export type IsPropertiesEqual<A, B> = IsValuesOfObjectAllTrue<
   ShowPropertiesEqualStatus<A, B>
 >
 
+export type Extends<A, B> = A extends B ? true : false
+
 export type AssertNever<T extends never> = T


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

follow up to #3802

It seems having `implements` here disallows extending PluginContext types.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
