### PR TITLE
fix(node): allow `output.minify: 'dce-only'`

### DIFF
--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -523,7 +523,9 @@ const OutputOptionsSchema = v.strictObject({
   cssChunkFileNames: v.optional(ChunkFileNamesSchema),
   sanitizeFileName: v.optional(SanitizeFileNameSchema),
   minify: v.pipe(
-    v.optional(v.union([v.boolean(), MinifyOptionsSchema])),
+    v.optional(
+      v.union([v.boolean(), v.string('dce-only'), MinifyOptionsSchema]),
+    ),
     v.description('Minify the bundled file'),
   ),
   name: v.pipe(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The option validation didn't allow `output.minify: 'dce-only'`.
```
Failed validate output options.
- For the "minify". Invalid type: Expected (boolean | Object) but received "dce-only".
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
