### PR TITLE
chore: set tokio Runtime disable_lifo_slot

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,23 +1,27 @@
 # reference: https://github.com/rust-lang/cargo/issues/3946
 [env]
+RUSTFLAGS     = "--cfg tokio_unstable"
 WORKSPACE_DIR = { value = "", relative = true }
 
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+
 [alias]
+ls-lint     = "run --bin ls-lint"
 run-fixture = "run --bin run-fixture"
-ls-lint = "run --bin ls-lint"
 
 [target.'cfg(target_vendor = "apple")']
-rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup,-no_fixup_chains"]
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup,-no_fixup_chains", "--cfg", "tokio_unstable"]
 
 # To be able to run unit tests on Linux, support compilation to 'x86_64-unknown-linux-gnu'.
 [target.'cfg(target_os = "linux")']
-rustflags = ["-C", "link-args=-Wl,--warn-unresolved-symbols"]
+rustflags = ["-C", "link-args=-Wl,--warn-unresolved-symbols", "--cfg", "tokio_unstable"]
 
 # To be able to run unit tests on Windows, support compilation to 'x86_64-pc-windows-msvc'.
 [target.'cfg(target_env = "msvc")']
-rustflags = ["-C", "link-args=/FORCE"]
+rustflags = ["-C", "link-args=/FORCE", "--cfg", "tokio_unstable"]
 
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
+rustflags = ["-C", "target-feature=+crt-static", "--cfg", "tokio_unstable"]
 [target.i686-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
+rustflags = ["-C", "target-feature=+crt-static", "--cfg", "tokio_unstable"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,8 +45,8 @@
     "tmp": true
   },
   "editor.wordWrap": "on",
+  "rust-analyzer.cargo.cfgs": ["tokio_unstable"],
   "rust-analyzer.procMacro.ignored": {
-    "napi-derive": ["napi"],
     "tracing": ["instrument"]
   }
 }

--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -13,9 +13,24 @@
 // Looks redundant
 #![allow(clippy::missing_transmute_annotations)]
 
+use napi::{bindgen_prelude::create_custom_tokio_runtime, tokio};
+#[cfg(not(target_family = "wasm"))]
+use napi_derive::module_init;
+
 #[cfg(not(target_family = "wasm"))]
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(not(target_family = "wasm"))]
+#[module_init]
+pub fn init() {
+  let rt = tokio::runtime::Builder::new_multi_thread()
+    .disable_lifo_slot()
+    .enable_all()
+    .build()
+    .expect("Failed to create tokio runtime");
+  create_custom_tokio_runtime(rt);
+}
 
 pub mod bundler;
 pub mod options;

--- a/cspell.json
+++ b/cspell.json
@@ -81,6 +81,7 @@
     "consola",
     "Corasick",
     "corepack",
+    "cpus",
     "daachorse",
     "dashmap",
     "dataurl",


### PR DESCRIPTION
Disables the LIFO task scheduler heuristic for tokio scheduler, see: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.disable_lifo_slot