### PR TITLE
fix(cli): fix and improve error message when validating cli options

### DIFF
--- a/packages/rolldown/src/cli/arguments/normalize.ts
+++ b/packages/rolldown/src/cli/arguments/normalize.ts
@@ -29,9 +29,7 @@ export function normalizeCliOptions(
   const [data, errors] = validateCliOptions<CliOptions>(cliOptions)
   if (errors?.length) {
     errors.forEach((error) => {
-      logger.error(
-        `Invalid value for option ${error}. You can use \`rolldown -h\` to see the help.`,
-      )
+      logger.error(`${error}. You can use \`rolldown -h\` to see the help.`)
     })
     process.exit(1)
   }

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -679,9 +679,10 @@ export function validateCliOptions<T>(options: T): [T, string[]?] {
 
   return [
     parsed.output as T,
-    parsed.issues
-      ?.map((issue) => issue.path?.join(', '))
-      .filter((v) => v !== undefined),
+    parsed.issues?.map((issue) => {
+      const option = issue.path?.map((pathItem) => pathItem.key).join(' ')
+      return `Invalid value for option ${option}: ${issue.message}`
+    }),
   ]
 }
 

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -196,6 +196,12 @@ exports[`cli options for bundling > should handle single string options 1`] = `
 "
 `;
 
+exports[`cli options for bundling > validate cli options 1`] = `
+"Command failed with exit code 1: rolldown index.ts --format INCORRECT
+
+Invalid value for option format: Invalid type: Expected ("es" | "cjs" | "esm" | "module" | "commonjs" | "iife" | "umd") but received "INCORRECT". You can use \`rolldown -h\` to see the help."
+`;
+
 exports[`config > should allow loading cts config 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -103,6 +103,16 @@ describe('cli options for bundling', () => {
     expect(status.exitCode).toBe(0)
     expect(cleanStdout(status.stdout)).toMatchSnapshot()
   })
+
+  it('validate cli options', async () => {
+    const cwd = cliFixturesDir('cli-option-object')
+    try {
+      await $({ cwd })`rolldown index.ts --format INCORRECT`
+      expect.unreachable()
+    } catch (error: any) {
+      expect(error.message).matchSnapshot()
+    }
+  })
 })
 
 describe('config', () => {


### PR DESCRIPTION
### Description
Previously the path items were just joined together despite them being objects.
This lead to [object Object] being printed instead of the option that failed the validation.
Also the helpful message of the issue was omitted from the output.

### Before

npx rolldown --module-types .png=INCORRECT
> Invalid value for option [object Object], [object Object]. You can use rolldown -h to see the help.

npx rolldown --format INCORRECT
> Invalid value for option [object Object]. You can use rolldown -h to see the help.

### After

npx rolldown --module-types .png=INCORRECT
> Invalid value for option moduleTypes .png: Invalid type: Expected ("base64" | "binary" | "css" | "dataurl" | "empty" | "js" | "json" | "jsx" | "text" | "ts" | "tsx") but received "INCORRECT". You can use rolldown -h to see the help.

npx rolldown --format INCORRECT
> Invalid value for option format: Invalid type: Expected ("es" | "cjs" | "esm" | "module" | "commonjs" | "iife" | "umd") but received "INCORRECT". You can use rolldown -h to see the help.