### PR TITLE
perf(rust): avoid unnecessary source clone

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -271,8 +271,7 @@ impl<'a> GenerateStage<'a> {
             .asset_filename_template(&RollupPreRenderedAsset {
               names: vec![name.clone()],
               original_file_names: vec![],
-              // TODO: avoid source clone
-              source: asset_view.source.clone().to_vec().into(),
+              source: asset_view.source.to_vec().into(),
             })
             .await?;
 


### PR DESCRIPTION
### Description

Avoid unnecessary source clone:
https://github.com/rolldown/rolldown/blob/72028a534c25e8dd1f7f402fa0308f6a6c0a164d/crates/rolldown/src/stages/generate_stage/mod.rs#L274-L275