### PR TITLE
refactor(rust): simplify `keep_name_statement_to_insert`

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/finalizer_context.rs
@@ -1,4 +1,3 @@
-use oxc::semantic::SymbolId;
 use rolldown_common::{
   ChunkIdx, IndexModules, ModuleIdx, NormalModule, RuntimeModuleBrief, SharedFileEmitter,
   SymbolRef, SymbolRefDb,
@@ -26,6 +25,6 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub chunk_graph: &'me ChunkGraph,
   pub options: &'me SharedOptions,
   pub cur_stmt_index: usize,
-  pub keep_name_statement_to_insert: Vec<(usize, SymbolId, Rstr, Rstr)>,
+  pub keep_name_statement_to_insert: Vec<(usize, Rstr, Rstr)>,
   pub file_emitter: &'me SharedFileEmitter,
 }

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -237,20 +237,20 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
 
   fn visit_statements(&mut self, it: &mut allocator::Vec<'ast, ast::Statement<'ast>>) {
     let previous_stmt_index = self.ctx.cur_stmt_index;
-    let previous_keep_name_statement = std::mem::take(&mut self.ctx.keep_name_statement_to_insert);
+    let mut previous_keep_name_statement =
+      std::mem::take(&mut self.ctx.keep_name_statement_to_insert);
+
     for (i, stmt) in it.iter_mut().enumerate() {
       self.ctx.cur_stmt_index = i;
       self.visit_statement(stmt);
     }
 
     // TODO: perf it
-    for (stmt_index, _symbol_id, original_name, new_name) in
-      self.ctx.keep_name_statement_to_insert.iter().rev()
-    {
-      it.insert(*stmt_index, self.snippet.keep_name_call_expr_stmt(original_name, new_name));
+    std::mem::swap(&mut self.ctx.keep_name_statement_to_insert, &mut previous_keep_name_statement);
+    for (stmt_index, original_name, new_name) in previous_keep_name_statement.into_iter().rev() {
+      it.insert(stmt_index, self.snippet.keep_name_call_expr_stmt(&original_name, &new_name));
     }
     self.ctx.cur_stmt_index = previous_stmt_index;
-    self.ctx.keep_name_statement_to_insert = previous_keep_name_statement;
   }
 
   fn visit_identifier_reference(&mut self, ident: &mut ast::IdentifierReference) {


### PR DESCRIPTION
### Description

Since `SymbolId` is currently unnecessary, we can remove it along with its related logic.