### PR TITLE
chore: change error kind naming convention

### DIFF
--- a/crates/rolldown_error/src/event_kind.rs
+++ b/crates/rolldown_error/src/event_kind.rs
@@ -1,17 +1,19 @@
+//! Naming convention:
+//! - All kinds that will terminate the build process should be named with a postfix "Error".
 use std::fmt::Display;
 
 pub enum EventKind {
   // --- These kinds are copied from rollup: https://github.com/rollup/rollup/blob/0b665c31833525c923c0fc20f43ebfca748c6670/src/utils/logs.ts#L102-L179
-  AmbiguousExternalNamespace,
+  AmbiguousExternalNamespaceError,
   CircularDependency,
   Eval,
-  IllegalIdentifierAsName,
-  InvalidExportOption,
-  InvalidOption,
-  MissingExport,
+  IllegalIdentifierAsNameError,
+  InvalidExportOptionError,
+  InvalidOptionError,
+  MissingExportError,
   MissingGlobalName,
   MissingNameOptionForIifeExport,
-  MissingNameOptionForUmdExport,
+  MissingNameOptionForUmdExportError,
   MixedExport,
   ParseError,
   SourcemapError,
@@ -21,19 +23,19 @@ pub enum EventKind {
   // !! Only add new kind if it's not covered by the kinds from rollup !!
 
   // --- These kinds are derived from esbuild
-  AssignToImport,
+  AssignToImportError,
   CommonJsVariableInEsm,
-  ExportUndefinedVariable,
+  ExportUndefinedVariableError,
   ImportIsUndefined,
-  UnsupportedFeature,
+  UnsupportedFeatureError,
 
   // --- These kinds are rolldown specific
-  JsonParse,
-  IllegalReassignment,
-  InvalidDefineConfig,
+  JsonParseError,
+  IllegalReassignmentError,
+  InvalidDefineConfigError,
   ResolveError(Option<&'static str>),
   UnhandleableError,
-  UnloadableDependency,
+  UnloadableDependencyError,
 
   // TODO remove following kinds
   IoError,
@@ -44,17 +46,19 @@ impl Display for EventKind {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
       // --- Copied from rollup
-      EventKind::AmbiguousExternalNamespace => write!(f, "AMBIGUOUS_EXTERNAL_NAMESPACES"),
+      EventKind::AmbiguousExternalNamespaceError => write!(f, "AMBIGUOUS_EXTERNAL_NAMESPACES"),
       EventKind::CircularDependency => write!(f, "CIRCULAR_DEPENDENCY"),
       EventKind::Eval => write!(f, "EVAL"),
-      EventKind::IllegalIdentifierAsName => write!(f, "ILLEGAL_IDENTIFIER_AS_NAME"),
-      EventKind::InvalidExportOption => write!(f, "INVALID_EXPORT_OPTION"),
-      EventKind::InvalidOption => write!(f, "INVALID_OPTION"),
+      EventKind::IllegalIdentifierAsNameError => write!(f, "ILLEGAL_IDENTIFIER_AS_NAME"),
+      EventKind::InvalidExportOptionError => write!(f, "INVALID_EXPORT_OPTION"),
+      EventKind::InvalidOptionError => write!(f, "INVALID_OPTION"),
       EventKind::MixedExport => write!(f, "MIXED_EXPORT"),
       EventKind::MissingGlobalName => write!(f, "MISSING_GLOBAL_NAME"),
       EventKind::MissingNameOptionForIifeExport => write!(f, "MISSING_NAME_OPTION_FOR_IIFE_EXPORT"),
-      EventKind::MissingNameOptionForUmdExport => write!(f, "MISSING_NAME_OPTION_FOR_UMD_EXPORT"),
-      EventKind::MissingExport => write!(f, "MISSING_EXPORT"),
+      EventKind::MissingNameOptionForUmdExportError => {
+        write!(f, "MISSING_NAME_OPTION_FOR_UMD_EXPORT")
+      }
+      EventKind::MissingExportError => write!(f, "MISSING_EXPORT"),
       EventKind::ParseError => write!(f, "PARSE_ERROR"),
       EventKind::SourcemapError => write!(f, "SOURCEMAP_ERROR"),
       EventKind::UnresolvedEntry => write!(f, "UNRESOLVED_ENTRY"),
@@ -62,22 +66,22 @@ impl Display for EventKind {
       EventKind::FilenameConflict => write!(f, "FILE_NAME_CONFLICT"),
 
       // --- Derived from esbuild
-      EventKind::AssignToImport => write!(f, "ASSIGN_TO_IMPORT"),
+      EventKind::AssignToImportError => write!(f, "ASSIGN_TO_IMPORT"),
       EventKind::CommonJsVariableInEsm => write!(f, "COMMONJS_VARIABLE_IN_ESM"),
-      EventKind::ExportUndefinedVariable => write!(f, "EXPORT_UNDEFINED_VARIABLE"),
+      EventKind::ExportUndefinedVariableError => write!(f, "EXPORT_UNDEFINED_VARIABLE"),
       EventKind::ImportIsUndefined => write!(f, "IMPORT_IS_UNDEFINED"),
-      EventKind::UnsupportedFeature => write!(f, "UNSUPPORTED_FEATURE"),
+      EventKind::UnsupportedFeatureError => write!(f, "UNSUPPORTED_FEATURE"),
 
       // --- Rolldown specific
-      EventKind::JsonParse => write!(f, "JSON_PARSE"),
-      EventKind::IllegalReassignment => write!(f, "ILLEGAL_REASSIGNMENT"),
-      EventKind::InvalidDefineConfig => write!(f, "INVALID_DEFINE_CONFIG"),
+      EventKind::JsonParseError => write!(f, "JSON_PARSE"),
+      EventKind::IllegalReassignmentError => write!(f, "ILLEGAL_REASSIGNMENT"),
+      EventKind::InvalidDefineConfigError => write!(f, "INVALID_DEFINE_CONFIG"),
       EventKind::ResolveError(title) => match title {
         Some(title) => write!(f, "{title}"),
         None => write!(f, "RESOLVE_ERROR"),
       },
       EventKind::UnhandleableError => write!(f, "UNHANDLEABLE_ERROR"),
-      EventKind::UnloadableDependency => write!(f, "UNLOADABLE_DEPENDENCY"),
+      EventKind::UnloadableDependencyError => write!(f, "UNLOADABLE_DEPENDENCY"),
 
       // TODO remove following kinds
       EventKind::IoError => write!(f, "IO_ERROR"),

--- a/crates/rolldown_error/src/events/ambiguous_external_namespace.rs
+++ b/crates/rolldown_error/src/events/ambiguous_external_namespace.rs
@@ -22,7 +22,7 @@ pub struct AmbiguousExternalNamespace {
 
 impl BuildEvent for AmbiguousExternalNamespace {
   fn kind(&self) -> EventKind {
-    EventKind::AmbiguousExternalNamespace
+    EventKind::AmbiguousExternalNamespaceError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/assign_to_import.rs
+++ b/crates/rolldown_error/src/events/assign_to_import.rs
@@ -16,7 +16,7 @@ pub struct AssignToImport {
 
 impl BuildEvent for AssignToImport {
   fn kind(&self) -> crate::event_kind::EventKind {
-    crate::event_kind::EventKind::AssignToImport
+    crate::event_kind::EventKind::AssignToImportError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/export_undefined_variable.rs
+++ b/crates/rolldown_error/src/events/export_undefined_variable.rs
@@ -15,7 +15,7 @@ pub struct ExportUndefinedVariable {
 
 impl BuildEvent for ExportUndefinedVariable {
   fn kind(&self) -> crate::event_kind::EventKind {
-    crate::event_kind::EventKind::ExportUndefinedVariable
+    crate::event_kind::EventKind::ExportUndefinedVariableError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/forbid_const_assign.rs
+++ b/crates/rolldown_error/src/events/forbid_const_assign.rs
@@ -16,7 +16,7 @@ pub struct ForbidConstAssign {
 
 impl BuildEvent for ForbidConstAssign {
   fn kind(&self) -> crate::event_kind::EventKind {
-    crate::event_kind::EventKind::IllegalReassignment
+    crate::event_kind::EventKind::IllegalReassignmentError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/illegal_identifier_as_name.rs
+++ b/crates/rolldown_error/src/events/illegal_identifier_as_name.rs
@@ -9,7 +9,7 @@ pub struct IllegalIdentifierAsName {
 
 impl BuildEvent for IllegalIdentifierAsName {
   fn kind(&self) -> EventKind {
-    EventKind::IllegalIdentifierAsName
+    EventKind::IllegalIdentifierAsNameError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/invalid_define_config.rs
+++ b/crates/rolldown_error/src/events/invalid_define_config.rs
@@ -9,7 +9,7 @@ pub struct InvalidDefineConfig {
 
 impl BuildEvent for InvalidDefineConfig {
   fn kind(&self) -> crate::event_kind::EventKind {
-    EventKind::InvalidDefineConfig
+    EventKind::InvalidDefineConfigError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/invalid_export_option.rs
+++ b/crates/rolldown_error/src/events/invalid_export_option.rs
@@ -12,7 +12,7 @@ pub struct InvalidExportOption {
 
 impl BuildEvent for InvalidExportOption {
   fn kind(&self) -> crate::event_kind::EventKind {
-    EventKind::InvalidExportOption
+    EventKind::InvalidExportOptionError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/invalid_option.rs
+++ b/crates/rolldown_error/src/events/invalid_option.rs
@@ -15,7 +15,7 @@ pub struct InvalidOption {
 
 impl BuildEvent for InvalidOption {
   fn kind(&self) -> EventKind {
-    EventKind::InvalidOption
+    EventKind::InvalidOptionError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/json_parse.rs
+++ b/crates/rolldown_error/src/events/json_parse.rs
@@ -15,7 +15,7 @@ pub struct JsonParse {
 
 impl BuildEvent for JsonParse {
   fn kind(&self) -> crate::event_kind::EventKind {
-    crate::event_kind::EventKind::JsonParse
+    crate::event_kind::EventKind::JsonParseError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/missing_export.rs
+++ b/crates/rolldown_error/src/events/missing_export.rs
@@ -16,7 +16,7 @@ pub struct MissingExport {
 
 impl BuildEvent for MissingExport {
   fn kind(&self) -> crate::event_kind::EventKind {
-    EventKind::MissingExport
+    EventKind::MissingExportError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/missing_name_option_for_umd_export.rs
+++ b/crates/rolldown_error/src/events/missing_name_option_for_umd_export.rs
@@ -6,7 +6,7 @@ pub struct MissingNameOptionForUmdExport {}
 
 impl BuildEvent for MissingNameOptionForUmdExport {
   fn kind(&self) -> EventKind {
-    EventKind::MissingNameOptionForUmdExport
+    EventKind::MissingNameOptionForUmdExportError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/unloadable_dependency.rs
+++ b/crates/rolldown_error/src/events/unloadable_dependency.rs
@@ -20,7 +20,7 @@ pub struct UnloadableDependency {
 
 impl BuildEvent for UnloadableDependency {
   fn kind(&self) -> crate::event_kind::EventKind {
-    crate::event_kind::EventKind::UnloadableDependency
+    crate::event_kind::EventKind::UnloadableDependencyError
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/crates/rolldown_error/src/events/unsupported_feature.rs
+++ b/crates/rolldown_error/src/events/unsupported_feature.rs
@@ -15,7 +15,7 @@ pub struct UnsupportedFeature {
 
 impl BuildEvent for UnsupportedFeature {
   fn kind(&self) -> crate::event_kind::EventKind {
-    crate::event_kind::EventKind::UnsupportedFeature
+    crate::event_kind::EventKind::UnsupportedFeatureError
   }
 
   fn on_diagnostic(&self, diagnostic: &mut Diagnostic, opts: &DiagnosticOptions) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Change the naming convention for preparing auto-generated `options.check` 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
