### PR TITLE
fix(cli): remove duplicate error message in stack trace

### DIFF
--- a/packages/rolldown/src/cli/index.ts
+++ b/packages/rolldown/src/cli/index.ts
@@ -28,6 +28,9 @@ async function main() {
 }
 
 main().catch((err) => {
+  if (typeof err.stack === 'string') {
+    err.stack = err.replace(err.message, '')
+  }
   logger.error(err)
   process.exit(1)
 })

--- a/packages/rolldown/src/cli/index.ts
+++ b/packages/rolldown/src/cli/index.ts
@@ -29,7 +29,7 @@ async function main() {
 
 main().catch((err) => {
   if (typeof err.stack === 'string') {
-    err.stack = err.replace(err.message, '')
+    err.stack = err.stack.replace(err.message, '')
   }
   logger.error(err)
   process.exit(1)

--- a/packages/rolldown/src/cli/index.ts
+++ b/packages/rolldown/src/cli/index.ts
@@ -27,8 +27,8 @@ async function main() {
   showHelp()
 }
 
-main().catch((err) => {
-  if (typeof err.stack === 'string') {
+main().catch((err: unknown) => {
+  if (err instanceof Error && typeof err.stack === 'string') {
     err.stack = err.stack.replace(err.message, '')
   }
   logger.error(err)


### PR DESCRIPTION
### Description

`Consola` does not automatically remove duplicate content from the stack and message, resulting in error messages being printed twice.

See https://stackblitz.com/edit/github-xv4yss-itp7xjer?file=package.json,README.md,src%2Fentry.js