### PR TITLE
chore(cli): improve the output format of errors

### DIFF
--- a/packages/rolldown/src/utils/error.ts
+++ b/packages/rolldown/src/utils/error.ts
@@ -16,11 +16,12 @@ export function normalizeErrors(rawErrors: (BindingError | Error)[]): Error {
   // combine error messages as a top level error
   let summary = `Build failed with ${errors.length} error${errors.length < 2 ? '' : 's'}:\n`
   for (let i = 0; i < errors.length; i++) {
+    summary += '\n'
     if (i >= 5) {
-      summary += '\n...'
+      summary += '...'
       break
     }
-    summary += getErrorMessage(errors[i]) + '\n'
+    summary += getErrorMessage(errors[i])
   }
   const wrapper = new Error(summary)
   // expose individual errors as getters so that


### PR DESCRIPTION
### Description

Reduce the spacing between the error and the stack trace, and add a blank line between the error summary and its content.
Make the error summary, content, and stack trace clearly hierarchical and distinct.

Before: 
![JXRSUCI7MMJWKF@L _7}9MH](https://github.com/user-attachments/assets/6327ddf1-7ee8-4ad4-ba5f-bfec4694e835)

After:
![WTEHUDYY04UWCT$A@K{2FGS](https://github.com/user-attachments/assets/05cc4218-81c0-4ce2-929e-082843b8e259)
