### PR TITLE
refactor(cli): avoid outputting unnecessary error prefixes

### DIFF
--- a/packages/rolldown/src/utils/error.ts
+++ b/packages/rolldown/src/utils/error.ts
@@ -42,6 +42,12 @@ export function normalizeErrors(rawErrors: (BindingError | Error)[]): Error {
 }
 
 function getErrorMessage(e: RollupError): string {
+  // If the `kind` field is present, we assume it represents
+  // a custom error defined by rolldown on the rust side.
+  if (Object.hasOwn(e, 'kind')) {
+    return e.message
+  }
+
   let s = ''
   if (e.plugin) {
     s += `[plugin ${e.plugin}]`

--- a/packages/rolldown/tests/error/__snapshots__/error.test.ts.snap
+++ b/packages/rolldown/tests/error/__snapshots__/error.test.ts.snap
@@ -13,12 +13,12 @@ Error: js side error
 exports[`Error output format > should correctly output the custom error defined on the rust side 1`] = `
 "Build failed with 1 error:
 
-[31m[UNRESOLVED_IMPORT] Error:[0m Could not resolve './world' in error.js
-   [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0m error.js:1:19 [38;5;246m][0m
-   [38;5;246m│[0m
- [38;5;246m1 │[0m [38;5;249mi[0m[38;5;249mm[0m[38;5;249mp[0m[38;5;249mo[0m[38;5;249mr[0m[38;5;249mt[0m[38;5;249m [0m[38;5;249mh[0m[38;5;249me[0m[38;5;249ml[0m[38;5;249ml[0m[38;5;249mo[0m[38;5;249m [0m[38;5;249mf[0m[38;5;249mr[0m[38;5;249mo[0m[38;5;249mm[0m[38;5;249m [0m'./world'
- [38;5;240m  │[0m                   ────┬────  
- [38;5;240m  │[0m                       ╰────── Module not found.
-[38;5;246m───╯[0m
+[UNRESOLVED_IMPORT] Error: Could not resolve './world' in error.js
+   ╭─[ error.js:1:19 ]
+   │
+ 1 │ import hello from './world'
+   │                   ────┬────  
+   │                       ╰────── Module not found.
+───╯
 "
 `;

--- a/packages/rolldown/tests/error/__snapshots__/error.test.ts.snap
+++ b/packages/rolldown/tests/error/__snapshots__/error.test.ts.snap
@@ -1,16 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`should correctly output the custom error defined on the js side 1`] = `
+exports[`Error output format > should correctly output the custom error defined on the js side 1`] = `
 "Build failed with 1 error:
 
 [plugin test-plugin]
 Error: js side error
-    at PluginContextImpl.buildEnd (D:\\shulaoda\\rolldown\\packages\\rolldown\\tests\\error\\error.test.ts:135:19)
-    at plugin (D:\\shulaoda\\rolldown\\packages\\rolldown\\dist\\shared\\src-DEf1-YJM.mjs:1357:18)
-    at plugin.<computed> (D:\\shulaoda\\rolldown\\packages\\rolldown\\dist\\shared\\src-DEf1-YJM.mjs:1963:18)"
+    at PluginContextImpl.buildEnd (error.test.ts:148:21)
+    at plugin (src-DEf1-YJM.mjs:1357:18)
+    at plugin.<computed> (src-DEf1-YJM.mjs:1963:18)"
 `;
 
-exports[`should correctly output the custom error defined on the rust side 1`] = `
+exports[`Error output format > should correctly output the custom error defined on the rust side 1`] = `
 "Build failed with 1 error:
 
 [31m[UNRESOLVED_IMPORT] Error:[0m Could not resolve './world' in error.js

--- a/packages/rolldown/tests/error/__snapshots__/error.test.ts.snap
+++ b/packages/rolldown/tests/error/__snapshots__/error.test.ts.snap
@@ -1,15 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Error output format > should correctly output the custom error defined on the js side 1`] = `
-"Build failed with 1 error:
-
-[plugin test-plugin]
-Error: js side error
-    at PluginContextImpl.buildEnd (error.test.ts:148:21)
-    at plugin (src-DEf1-YJM.mjs:1357:18)
-    at plugin.<computed> (src-DEf1-YJM.mjs:1963:18)"
-`;
-
 exports[`Error output format > should correctly output the custom error defined on the rust side 1`] = `
 "Build failed with 1 error:
 

--- a/packages/rolldown/tests/error/__snapshots__/error.test.ts.snap
+++ b/packages/rolldown/tests/error/__snapshots__/error.test.ts.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should correctly output the custom error defined on the js side 1`] = `
+"Build failed with 1 error:
+
+[plugin test-plugin]
+Error: js side error
+    at PluginContextImpl.buildEnd (D:\\shulaoda\\rolldown\\packages\\rolldown\\tests\\error\\error.test.ts:135:19)
+    at plugin (D:\\shulaoda\\rolldown\\packages\\rolldown\\dist\\shared\\src-DEf1-YJM.mjs:1357:18)
+    at plugin.<computed> (D:\\shulaoda\\rolldown\\packages\\rolldown\\dist\\shared\\src-DEf1-YJM.mjs:1963:18)"
+`;
+
+exports[`should correctly output the custom error defined on the rust side 1`] = `
+"Build failed with 1 error:
+
+[31m[UNRESOLVED_IMPORT] Error:[0m Could not resolve './world' in error.js
+   [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0m error.js:1:19 [38;5;246m][0m
+   [38;5;246m│[0m
+ [38;5;246m1 │[0m [38;5;249mi[0m[38;5;249mm[0m[38;5;249mp[0m[38;5;249mo[0m[38;5;249mr[0m[38;5;249mt[0m[38;5;249m [0m[38;5;249mh[0m[38;5;249me[0m[38;5;249ml[0m[38;5;249ml[0m[38;5;249mo[0m[38;5;249m [0m[38;5;249mf[0m[38;5;249mr[0m[38;5;249mo[0m[38;5;249mm[0m[38;5;249m [0m'./world'
+ [38;5;240m  │[0m                   ────┬────  
+ [38;5;240m  │[0m                       ╰────── Module not found.
+[38;5;246m───╯[0m
+"
+`;

--- a/packages/rolldown/tests/error/error.js
+++ b/packages/rolldown/tests/error/error.js
@@ -1,0 +1,3 @@
+import hello from './world'
+
+console.log(hello)

--- a/packages/rolldown/tests/error/error.test.ts
+++ b/packages/rolldown/tests/error/error.test.ts
@@ -122,3 +122,35 @@ test('call transformContext error', async () => {
   })
   expect(error!.message).toContain('transform hook error')
 })
+
+test('should correctly output the custom error defined on the js side', async () => {
+  try {
+    const build = await rolldown({
+      input: './main.js',
+      cwd: import.meta.dirname,
+      plugins: [
+        {
+          name: 'test-plugin',
+          buildEnd() {
+            throw new Error('js side error')
+          },
+        },
+      ],
+    })
+    await build.write()
+  } catch (error: any) {
+    expect(error.message).toMatchSnapshot()
+  }
+})
+
+test('should correctly output the custom error defined on the rust side', async () => {
+  try {
+    const build = await rolldown({
+      input: './error.js',
+      cwd: import.meta.dirname,
+    })
+    await build.write()
+  } catch (error: any) {
+    expect(error.message).toMatchSnapshot()
+  }
+})

--- a/packages/rolldown/tests/error/error.test.ts
+++ b/packages/rolldown/tests/error/error.test.ts
@@ -164,7 +164,11 @@ describe('Error output format', () => {
       })
       await build.write()
     } catch (error: any) {
-      expect(error.message).toMatchSnapshot()
+      expect(removeAnsiColors(error.message)).toMatchSnapshot()
     }
   })
 })
+
+function removeAnsiColors(str: string) {
+    return str.replace(/\x1b\[[0-9;]*m/g, '');
+}

--- a/packages/rolldown/tests/error/error.test.ts
+++ b/packages/rolldown/tests/error/error.test.ts
@@ -129,7 +129,7 @@ describe('Error output format', () => {
       .split('\n')
       .map((line) => {
         return line.replace(
-          /at (.*?) \((?:(.*[\/\\])?([^\/\\]+):)?(\d+:\d+)\)/,
+          /at (.*?) \((?:(.*[/\\])?([^/\\]+):)?(\d+:\d+)\)/,
           'at $1 ($3:$4)',
         )
       })
@@ -164,11 +164,7 @@ describe('Error output format', () => {
       })
       await build.write()
     } catch (error: any) {
-      const message = error.message.replace(
-        /at (.*?) \((?:(.*[\/\\])?([^\/\\]+):)?(\d+:\d+)\)/,
-        'at $1 ($3:$4)',
-      )
-      expect(message).toMatchSnapshot()
+      expect(error.message).toMatchSnapshot()
     }
   })
 })

--- a/packages/rolldown/tests/error/error.test.ts
+++ b/packages/rolldown/tests/error/error.test.ts
@@ -124,38 +124,6 @@ test('call transformContext error', async () => {
 })
 
 describe('Error output format', () => {
-  function cleanStack(stack: string) {
-    return stack
-      .split('\n')
-      .map((line) => {
-        return line.replace(
-          /at (.*?) \((?:(.*[/\\])?([^/\\]+):)?(\d+:\d+)\)/,
-          'at $1 ($3:$4)',
-        )
-      })
-      .join('\n')
-  }
-
-  test('should correctly output the custom error defined on the js side', async () => {
-    try {
-      const build = await rolldown({
-        input: './main.js',
-        cwd: import.meta.dirname,
-        plugins: [
-          {
-            name: 'test-plugin',
-            buildEnd() {
-              throw new Error('js side error')
-            },
-          },
-        ],
-      })
-      await build.write()
-    } catch (error: any) {
-      expect(cleanStack(error.message)).toMatchSnapshot()
-    }
-  })
-
   test('should correctly output the custom error defined on the rust side', async () => {
     try {
       const build = await rolldown({

--- a/packages/rolldown/tests/error/error.test.ts
+++ b/packages/rolldown/tests/error/error.test.ts
@@ -169,6 +169,7 @@ describe('Error output format', () => {
   })
 })
 
+// oxlint-disable no-control-regex
 function removeAnsiColors(str: string) {
-    return str.replace(/\x1b\[[0-9;]*m/g, '');
+  return str.replace(/\x1b\[[0-9;]*m/g, '')
 }


### PR DESCRIPTION
### Description

              The white color `Error:` prefix seems redundant

_Originally posted by @IWANABETHATGUY in https://github.com/rolldown/rolldown/issues/3840#issuecomment-2720482085_
            