### PR TITLE
chore(renovate): apply pinGitHubActionDigestsToSemver

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>Boshen/renovate", ":dependencyDashboard"],
+  "extends": [
+    "github>Boshen/renovate",
+    "helpers:pinGitHubActionDigestsToSemver",
+    "dependencyDashboard"
+  ],
   "ignorePaths": [
     "**/node_modules/**",
     "**/examples/**",


### PR DESCRIPTION
Make GitHub Actions slightly safer by pinning their versions to commits

Response to recent event: https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/
