### PR TITLE
fix(renovate): dependencyDashboard is not a preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>Boshen/renovate",
-    "helpers:pinGitHubActionDigestsToSemver",
-    "dependencyDashboard"
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "ignorePaths": [
     "**/node_modules/**",


### PR DESCRIPTION
https://developer.mend.io/github/rolldown/rolldown shows

```
Repository problems
These problems occurred while renovating this repository.

Reason: Cannot find preset's package (dependencyDashboard)

Message: undefined
```

