### PR TITLE
perf: use multi threaded Runtime on wasi target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,15 +3,16 @@
 WORKSPACE_DIR = { value = "", relative = true }
 
 [alias]
+ls-lint     = "run --bin ls-lint"
 run-fixture = "run --bin run-fixture"
-ls-lint = "run --bin ls-lint"
 
 [target.'cfg(target_vendor = "apple")']
 rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup,-no_fixup_chains"]
 
 # To be able to run unit tests on Linux, support compilation to 'x86_64-unknown-linux-gnu'.
-[target.'cfg(target_os = "linux")']
-rustflags = ["-C", "link-args=-Wl,--warn-unresolved-symbols"]
+# pthread_key_create() destructors and segfault after a DSO unloading https://sourceware.org/bugzilla/show_bug.cgi?id=21031
+[target.'cfg(all(target_os = "linux", target_env = "gnu"))']
+rustflags = ["-C", "link-args=-Wl,--warn-unresolved-symbols", "-C", "link-args=-Wl,-z,nodelete"]
 
 # To be able to run unit tests on Windows, support compilation to 'x86_64-pc-windows-msvc'.
 [target.'cfg(target_env = "msvc")']
@@ -19,5 +20,9 @@ rustflags = ["-C", "link-args=/FORCE"]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+
 [target.i686-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.wasm32-wasip1-threads]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ codegen-units = 16
 debug         = 'full'
 inherits      = "release"
 lto           = "thin"
-opt-level     = "z"
+opt-level     = "s"
 strip         = "none"
 
 [workspace.lints.clippy]
@@ -147,7 +147,7 @@ jsonschema          = { version = "0.29.0", default-features = false }
 memchr              = "2.7.2"
 mimalloc-safe       = "0.1.49"
 mime                = "0.3.17"
-napi                = { version = "3.0.0-alpha.31", features = ["async", "anyhow"] }
+napi                = { version = "3.0.0-alpha.33", features = ["async", "anyhow"] }
 napi-build          = { version = "2.1.5" }
 napi-derive         = { version = "3.0.0-alpha.28", default-features = false, features = ["type-def"] }
 nom                 = "8.0.0"

--- a/crates/rolldown_binding/build.rs
+++ b/crates/rolldown_binding/build.rs
@@ -1,5 +1,5 @@
 fn main() {
   use napi_build::setup;
-
+  println!("cargo::rustc-check-cfg=cfg(tokio_unstable)");
   setup();
 }

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -48,10 +48,6 @@ impl Bundler {
     let log_level = input_options.log_level;
     let on_log = input_options.on_log.take();
 
-    #[cfg(target_family = "wasm")]
-    // if we don't perform this warmup, the following call to `std::fs` will stuck
-    if let Ok(_) = std::fs::metadata(std::env::current_dir()?) {};
-
     #[cfg(not(target_family = "wasm"))]
     let worker_count =
       parallel_plugins_registry.as_ref().map(|registry| registry.worker_count).unwrap_or_default();

--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -13,6 +13,8 @@
 // Looks redundant
 #![allow(clippy::missing_transmute_annotations)]
 
+use napi_derive::napi;
+
 #[cfg(not(target_family = "wasm"))]
 #[global_allocator]
 static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
@@ -27,3 +29,23 @@ pub use oxc_transform_napi;
 mod generated;
 pub mod watcher;
 pub mod worker_manager;
+
+#[napi]
+/// Shutdown the tokio runtime manually.
+///
+/// This is required for the wasm target with `tokio_unstable` cfg.
+/// In the wasm runtime, the `park` threads will hang there until the tokio::Runtime is shutdown.
+pub fn shutdown_async_runtime() {
+  #[cfg(all(target_family = "wasm", tokio_unstable))]
+  napi::bindgen_prelude::shutdown_async_runtime();
+}
+
+#[napi]
+/// Start the async runtime manually.
+///
+/// This is required when the async runtime is shutdown manually.
+/// Usually it's used in test.
+pub fn start_async_runtime() {
+  #[cfg(all(target_family = "wasm", tokio_unstable))]
+  napi::bindgen_prelude::start_async_runtime();
+}

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -24,7 +24,7 @@ export class RolldownBuild {
 
   get closed(): boolean {
     // If the bundler has not yet been created, it is not closed.
-    return this.#bundler ? this.#bundler.bundler.closed : false
+    return this.#bundler?.bundler.closed ?? false
   }
 
   // Create bundler for each `bundle.write/generate`
@@ -33,7 +33,7 @@ export class RolldownBuild {
     isClose?: boolean,
   ): Promise<BundlerWithStopWorker> {
     if (this.#bundler) {
-      this.#bundler.stopWorkers?.()
+      await this.#bundler.stopWorkers?.()
     }
     return (this.#bundler = await createBundler(
       this.#inputOptions,
@@ -58,12 +58,11 @@ export class RolldownBuild {
 
   async close(): Promise<void> {
     // Create new one bundler to run `closeBundle` hook, here using `isClose` flag to avoid call `outputOptions` hook.
-    const { bundler, stopWorkers } = await this.#getBundlerWithStopWorker(
-      {},
-      true,
-    )
+    const { bundler, stopWorkers, shutdown } =
+      await this.#getBundlerWithStopWorker({}, true)
     await stopWorkers?.()
     await bundler.close()
+    shutdown()
   }
 
   async [Symbol.asyncDispose](): Promise<void> {

--- a/packages/rolldown/src/api/watch/watcher.ts
+++ b/packages/rolldown/src/api/watch/watcher.ts
@@ -1,4 +1,4 @@
-import { BindingWatcher } from '../../binding'
+import { BindingWatcher, shutdownAsyncRuntime } from '../../binding'
 import { LOG_LEVEL_WARN } from '../../log/logging'
 import { logMultiplyNotifyOption } from '../../log/logs'
 import { WatchOptions } from '../../options/watch-options'
@@ -39,6 +39,7 @@ export class Watcher {
       await stop?.()
     }
     await this.inner.close()
+    shutdownAsyncRuntime()
   }
 
   start(): void {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -739,29 +739,6 @@ export interface CompilerAssumptions {
   setPublicClassFields?: boolean
 }
 
-export interface DecoratorOptions {
-  /**
-   * Enables experimental support for decorators, which is a version of decorators that predates the TC39 standardization process.
-   *
-   * Decorators are a language feature which hasn’t yet been fully ratified into the JavaScript specification.
-   * This means that the implementation version in TypeScript may differ from the implementation in JavaScript when it it decided by TC39.
-   *
-   * @see https://www.typescriptlang.org/tsconfig/#experimentalDecorators
-   * @default false
-   */
-  legacy?: boolean
-  /**
-   * Enables emitting decorator metadata.
-   *
-   * This option the same as [emitDecoratorMetadata](https://www.typescriptlang.org/tsconfig/#emitDecoratorMetadata)
-   * in TypeScript, and it only works when `legacy` is true.
-   *
-   * @see https://www.typescriptlang.org/tsconfig/#emitDecoratorMetadata
-   * @default false
-   */
-  emitDecoratorMetadata?: boolean
-}
-
 export interface DynamicImport {
   start: number
   end: number
@@ -1209,6 +1186,14 @@ export type Severity =  'Error'|
 'Warning'|
 'Advice';
 
+/**
+ * Shutdown the tokio runtime manually.
+ *
+ * This is required for the wasm target with `tokio_unstable` cfg.
+ * In the wasm runtime, the `park` threads will hang there until the tokio::Runtime is shutdown.
+ */
+export declare function shutdownAsyncRuntime(): void
+
 export interface SourceMap {
   file?: string
   mappings: string
@@ -1224,6 +1209,14 @@ export interface Span {
   start: number
   end: number
 }
+
+/**
+ * Start the async runtime manually.
+ *
+ * This is required when the async runtime is shutdown manually.
+ * Usually it's used in test.
+ */
+export declare function startAsyncRuntime(): void
 
 export interface StaticExport {
   start: number

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -406,4 +406,6 @@ module.exports.parseSyncRaw = nativeBinding.parseSyncRaw
 module.exports.rawTransferSupported = nativeBinding.rawTransferSupported
 module.exports.registerPlugins = nativeBinding.registerPlugins
 module.exports.Severity = nativeBinding.Severity
+module.exports.shutdownAsyncRuntime = nativeBinding.shutdownAsyncRuntime
+module.exports.startAsyncRuntime = nativeBinding.startAsyncRuntime
 module.exports.transform = nativeBinding.transform

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -96,4 +96,6 @@ export const parseSyncRaw = __napiModule.exports.parseSyncRaw
 export const rawTransferSupported = __napiModule.exports.rawTransferSupported
 export const registerPlugins = __napiModule.exports.registerPlugins
 export const Severity = __napiModule.exports.Severity
+export const shutdownAsyncRuntime = __napiModule.exports.shutdownAsyncRuntime
+export const startAsyncRuntime = __napiModule.exports.startAsyncRuntime
 export const transform = __napiModule.exports.transform

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -121,4 +121,6 @@ module.exports.parseSyncRaw = __napiModule.exports.parseSyncRaw
 module.exports.rawTransferSupported = __napiModule.exports.rawTransferSupported
 module.exports.registerPlugins = __napiModule.exports.registerPlugins
 module.exports.Severity = __napiModule.exports.Severity
+module.exports.shutdownAsyncRuntime = __napiModule.exports.shutdownAsyncRuntime
+module.exports.startAsyncRuntime = __napiModule.exports.startAsyncRuntime
 module.exports.transform = __napiModule.exports.transform

--- a/packages/rolldown/src/utils/create-bundler.ts
+++ b/packages/rolldown/src/utils/create-bundler.ts
@@ -1,7 +1,9 @@
-import { Bundler } from '../binding'
+import { Bundler, startAsyncRuntime, shutdownAsyncRuntime } from '../binding'
 import type { InputOptions } from '../options/input-options'
 import type { OutputOptions } from '../options/output-options'
 import { createBundlerOptions } from './create-bundler-option'
+
+let asyncRuntimeShutdown = false
 
 export async function createBundler(
   inputOptions: InputOptions,
@@ -14,10 +16,18 @@ export async function createBundler(
     isClose,
   )
 
+  if (asyncRuntimeShutdown) {
+    startAsyncRuntime()
+  }
+
   try {
     return {
       bundler: new Bundler(option.bundlerOptions),
       stopWorkers: option.stopWorkers,
+      shutdown: () => {
+        shutdownAsyncRuntime()
+        asyncRuntimeShutdown = true
+      },
     }
   } catch (e) {
     await option.stopWorkers?.()
@@ -28,4 +38,5 @@ export async function createBundler(
 export interface BundlerWithStopWorker {
   bundler: Bundler
   stopWorkers?: () => Promise<void>
+  shutdown: () => void
 }


### PR DESCRIPTION
Our wasm is becoming much faster.

| Example | Before (ms) | After (ms) | Improvement |
|---------|-------------|------------|-------------|
| basic-typescript | 117.34 | 55.60 | 52.6% |
| basic-vue | 163.86 | 99.08 | 39.5% |
| module-federation-host | 246.13 | 166.41 | 32.4% |
| module-federation-remote | 158.86 | 94.10 | 40.8% |
| rollup-plugin-esbuild | 162.65 | 55.72 | 65.7% |

### Before:
```
❯ NAPI_RS_FORCE_WASI=1 pnpm --filter '@example/*' run --sequential build
Scope: 7 of 32 workspace projects

> @example/typescript@ build /Users/brooklyn/workspace/github/rolldown/examples/basic-typescript
> rolldown --config ./rolldown.config.js

(node:35743) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
<DIR>/entry.js  chunk │ size: 0.23 kB                                                                                                                                                                     
                                                                                                                                                                                                          
✔ Finished in 117.34 ms                                                                                                                                                                                  

> @example/vue@ build /Users/brooklyn/workspace/github/rolldown/examples/basic-vue
> rolldown --config ./rolldown.config.js

(node:35766) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
<DIR>/index.js  chunk │ size: 189.82 kB                                                                                                                                                                   
                                                                                                                                                                                                          
✔ Finished in 163.86 ms                                                                                                                                                                                  

> @example/module-federation-host@ build /Users/brooklyn/workspace/github/rolldown/examples/module-federation/host
> rolldown --config ./rolldown.config.mjs

(node:35884) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
     ╭─[ ../../../node_modules/.pnpm/@module-federation+sdk@0.8.12/node_modules/@module-federation/sdk/dist/index.esm.mjs:668:84 ]
     │
 668 │             script.runInThisContext()(scriptContext.exports, scriptContext.module, eval('require'), urlDirname, filename);
     │                                                                                    ──┬─  
     │                                                                                      ╰─── Use of `eval` function here.
─────╯

<DIR>/index.html                asset │ size:   0.18 kB                                                                                                                                                   
<DIR>/chunk-CL_AAsb7.js         chunk │ size:   1.27 kB                                                                                                                                                   
<DIR>/react-qUm3Fhlg.js         chunk │ size:  44.59 kB                                                                                                                                                   
<DIR>/mf_init-host-DFq2F4mD.js  chunk │ size: 122.83 kB                                                                                                                                                   
<DIR>/index.js                  chunk │ size: 774.53 kB                                                                                                                                                   
                                                                                                                                                                                                          
✔ Finished in 246.13 ms                                                                                                                                                                                  

> @example/module-federation-remote@ build /Users/brooklyn/workspace/github/rolldown/examples/module-federation/remote
> rolldown --config ./rolldown.config.mjs

[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
     ╭─[ ../../../node_modules/.pnpm/@module-federation+sdk@0.8.12/node_modules/@module-federation/sdk/dist/index.esm.mjs:668:84 ]
     │
 668 │             script.runInThisContext()(scriptContext.exports, scriptContext.module, eval('require'), urlDirname, filename);
     │                                                                                    ──┬─  
     │                                                                                      ╰─── Use of `eval` function here.
─────╯

<DIR>/mf-manifest.json       asset │ size:   1.42 kB                                                                                                                                                      
<DIR>/chunk-CL_AAsb7.js      chunk │ size:   1.27 kB                                                                                                                                                      
<DIR>/remote-entry.js        chunk │ size:   1.69 kB                                                                                                                                                      
<DIR>/button.js              chunk │ size:  21.08 kB                                                                                                                                                      
<DIR>/react-qUm3Fhlg.js      chunk │ size:  44.59 kB                                                                                                                                                      
<DIR>/index.esm-CwvxJll3.js  chunk │ size: 121.55 kB                                                                                                                                                      
                                                                                                                                                                                                          
✔ Finished in 158.86 ms                                                                                                                                                                                  

> @example/par-plugin@ build /Users/brooklyn/workspace/github/rolldown/examples/par-plugin
> echo success

success

> @example/rollup-plugin-esbuild@ build /Users/brooklyn/workspace/github/rolldown/examples/rollup-plugin-esbuild
> rolldown --config ./rolldown.config.js

(Use `node --trace-warnings ...` to show where the warning was created)
<DIR>/main.js  chunk │ size: 4.13 kB                                                                                                                                                                      
                                                                                                                                                                                                          
✔ Finished in 162.65 ms
```

### After

```
❯ NAPI_RS_FORCE_WASI=1 pnpm --filter '@example/*' run --sequential build
Scope: 7 of 32 workspace projects

> @example/typescript@ build /Users/brooklyn/workspace/github/rolldown/examples/basic-typescript
> rolldown --config ./rolldown.config.js

(node:27912) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
<DIR>/entry.js  chunk │ size: 0.23 kB                                                                                                                                                                     
                                                                                                                                                                                                          
✔ Finished in 55.60 ms                                                                                                                                                                                   

> @example/vue@ build /Users/brooklyn/workspace/github/rolldown/examples/basic-vue
> rolldown --config ./rolldown.config.js

(node:27935) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
<DIR>/index.js  chunk │ size: 189.82 kB                                                                                                                                                                   
                                                                                                                                                                                                          
✔ Finished in 99.08 ms                                                                                                                                                                                   

> @example/module-federation-host@ build /Users/brooklyn/workspace/github/rolldown/examples/module-federation/host
> rolldown --config ./rolldown.config.mjs

(node:28055) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
     ╭─[ ../../../node_modules/.pnpm/@module-federation+sdk@0.8.12/node_modules/@module-federation/sdk/dist/index.esm.mjs:668:84 ]
     │
 668 │             script.runInThisContext()(scriptContext.exports, scriptContext.module, eval('require'), urlDirname, filename);
     │                                                                                    ──┬─  
     │                                                                                      ╰─── Use of `eval` function here.
─────╯

<DIR>/index.html                asset │ size:   0.18 kB                                                                                                                                                   
<DIR>/chunk-CL_AAsb7.js         chunk │ size:   1.27 kB                                                                                                                                                   
<DIR>/react-qUm3Fhlg.js         chunk │ size:  44.59 kB                                                                                                                                                   
<DIR>/mf_init-host-DFq2F4mD.js  chunk │ size: 122.83 kB                                                                                                                                                   
<DIR>/index.js                  chunk │ size: 774.53 kB                                                                                                                                                   
                                                                                                                                                                                                          
✔ Finished in 166.41 ms                                                                                                                                                                                  

> @example/module-federation-remote@ build /Users/brooklyn/workspace/github/rolldown/examples/module-federation/remote
> rolldown --config ./rolldown.config.mjs

(node:28120) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
[EVAL] Warning: Use of `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
     ╭─[ ../../../node_modules/.pnpm/@module-federation+sdk@0.8.12/node_modules/@module-federation/sdk/dist/index.esm.mjs:668:84 ]
     │
 668 │             script.runInThisContext()(scriptContext.exports, scriptContext.module, eval('require'), urlDirname, filename);
     │                                                                                    ──┬─  
     │                                                                                      ╰─── Use of `eval` function here.
─────╯

<DIR>/mf-manifest.json       asset │ size:   1.42 kB                                                                                                                                                      
<DIR>/chunk-CL_AAsb7.js      chunk │ size:   1.27 kB                                                                                                                                                      
<DIR>/remote-entry.js        chunk │ size:   1.69 kB                                                                                                                                                      
<DIR>/button.js              chunk │ size:  21.08 kB                                                                                                                                                      
<DIR>/react-qUm3Fhlg.js      chunk │ size:  44.59 kB                                                                                                                                                      
<DIR>/index.esm-CwvxJll3.js  chunk │ size: 121.55 kB                                                                                                                                                      
                                                                                                                                                                                                          
✔ Finished in 94.10 ms                                                                                                                                                                                   

> @example/par-plugin@ build /Users/brooklyn/workspace/github/rolldown/examples/par-plugin
> echo success

success

> @example/rollup-plugin-esbuild@ build /Users/brooklyn/workspace/github/rolldown/examples/rollup-plugin-esbuild
> rolldown --config ./rolldown.config.js

(node:28171) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
<DIR>/main.js  chunk │ size: 4.13 kB                                                                                                                                                                      
                                                                                                                                                                                                          
✔ Finished in 55.72 ms                  
```