### PR TITLE
docs: enable deep outline

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -157,7 +157,7 @@ export default defineConfig({
         },
       ],
     },
-
+    outline: 'deep',
     socialLinks: [
       { icon: 'x', link: 'https://twitter.com/rolldown_rs' },
       {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Enable deep outline will make the doc summary clear to find(the options page always need to it), and it could jump to the content after clicking.

<img width="399" alt="image" src="https://github.com/user-attachments/assets/a8444ef6-0134-483b-848e-cbeb5d7fbaeb" />

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
