### PR TITLE
fix(tasks/generator): ensure `just update-generated-code` runs correctly on `Windows`

### DIFF
--- a/tasks/generator/src/output/rust.rs
+++ b/tasks/generator/src/output/rust.rs
@@ -30,7 +30,7 @@ pub fn rust_fmt(source_text: &str) -> String {
     .stdin(Stdio::piped())
     .stdout(Stdio::piped())
     .spawn()
-    .expect("Failed to run rustfmt (is it installed?)");
+    .expect("Failed to run `rustfmt` (is it installed?)");
 
   let stdin = rustfmt.stdin.as_mut().unwrap();
   stdin.write_all(source_text.as_bytes()).unwrap();
@@ -41,18 +41,19 @@ pub fn rust_fmt(source_text: &str) -> String {
 }
 
 pub fn ecma_fmt(source_text: &str, path: &str) -> String {
-  let mut rustfmt = Command::new("npx")
+  let npx = if cfg!(target_os = "windows") { "npx.cmd" } else { "npx" };
+  let mut npx = Command::new(npx)
     .args(["prettier", "--stdin-filepath", path])
     .stdin(Stdio::piped())
     .stdout(Stdio::piped())
     .spawn()
-    .expect("Failed to run rustfmt (is it installed?)");
+    .expect("Failed to run `npx prettier` (is it installed?)");
 
-  let stdin = rustfmt.stdin.as_mut().unwrap();
+  let stdin = npx.stdin.as_mut().unwrap();
   stdin.write_all(source_text.as_bytes()).unwrap();
   stdin.flush().unwrap();
 
-  let output = rustfmt.wait_with_output().unwrap();
+  let output = npx.wait_with_output().unwrap();
   String::from_utf8(output.stdout).unwrap()
 }
 


### PR DESCRIPTION
### Description

Rust's `Command` by default looks for `npx.exe`, but `Node.js` only provides `npx` and `npx.cmd` as executables.

```sh
cargo run --bin generator 
   Compiling generator v0.1.0 (D:\shulaoda\rolldown\tasks\generator)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.02s
     Running `target\debug\generator.exe`
"packages/rolldown/src/options/generated/checks-options.ts"

thread 'main' panicked at tasks\generator\src\output\rust.rs:53:17:
Error { kind: NotFound, message: "program not found" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: process didn't exit successfully: `target\debug\generator.exe` (exit code: 101)
error: Recipe `update-generated-code` failed on line 66 with exit code 1
```