### PR TITLE
chore: bump and unpin pnpm version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,10 +16,6 @@
       "groupName": "oxlint"
     },
     {
-      "matchPackageNames": ["pnpm"],
-      "enabled": false
-    },
-    {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "matchUpdateTypes": ["minor", "patch"]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "monorepo",
   "description": "Rollup in Rust",
   "private": true,
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@10.6.5",
   "engines": {
     "node": ">=18.20.3"
   },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Since we pin our node version to `22.14.0` the install pnpm issues should be fixed, unpin and bump to latest pnpm
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
