### PR TITLE
perf(rolldown_binding): upgrade napi-build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.1.5"
+version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40685973218af4aa4b42486652692c294c44b5a67e4b2202df721c9063f2e51c"
+checksum = "e28acfa557c083f6e254a786e01ba253fc56f18ee000afcd4f79af735f73a6da"
 
 [[package]]
 name = "napi-derive"


### PR DESCRIPTION
Ref: https://github.com/napi-rs/napi-rs/pull/2523

### Performance Comparison: Before vs After

*My mac is on low power mode during the benchmark*

| Example | Before (ms) | After (ms) | Difference (ms) | Improvement (%) |
|---------|------------|------------|-----------------|-----------------|
| @example/typescript | 62.50 | 52.78 | -9.72 | 15.55% |
| @example/vue | 109.41 | 98.47 | -10.94 | 10.00% |
| @example/module-federation-host | 165.38 | 159.82 | -5.56 | 3.36% |
| @example/module-federation-remote | 110.44 | 95.87 | -14.57 | 13.19% |
| @example/rollup-plugin-esbuild | 65.82 | 68.91 | +3.09 | -4.69% |
| **Average** | **102.71** | **95.17** | **-7.54** | **7.34%** |
