### PR TITLE
fix: check dummy record in all import_records.iter

### DIFF
--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -172,7 +172,11 @@ impl ModuleTask {
       .await?;
 
     if css_view.is_none() {
-      for (record, info) in raw_import_records.iter().zip(&resolved_deps) {
+      for (record, info) in raw_import_records
+        .iter()
+        .filter(|rec| !rec.meta.contains(ImportRecordMeta::IS_DUMMY))
+        .zip(&resolved_deps)
+      {
         match record.kind {
           ImportKind::Import | ImportKind::Require | ImportKind::NewUrl => {
             ecma_view.imported_ids.insert(ArcStr::clone(&info.id).into());

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -339,7 +339,9 @@ impl<'a> GenerateStage<'a> {
         if let Some(css_view) =
           module.as_normal_mut().and_then(|normal_module| normal_module.css_view.as_mut())
         {
-          for (idx, record) in css_view.import_records.iter_enumerated() {
+          for (idx, record) in
+            css_view.import_records.iter_enumerated().filter(|(_idx, rec)| !rec.is_dummy())
+          {
             if let Some(asset_filename) = module_idx_to_filenames.get(&record.resolved_module) {
               let span = css_view.record_idx_to_span[idx];
               css_view

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/determine_side_effects.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/determine_side_effects.rs
@@ -15,22 +15,14 @@ impl LinkStage<'_> {
 
     fn determine_side_effects_for_module(
       cache: &mut IndexSideEffectsCache,
-      module_id: ModuleIdx,
-      normal_modules: &IndexModules,
+      module_idx: ModuleIdx,
+      modules: &IndexModules,
     ) -> DeterminedSideEffects {
-      let Some(module) = normal_modules.get(module_id) else {
-        // It could be a module that could not be analyzed statically.
-        // ```js
-        // export default function() {
-        //   require(window.something);
-        // }
-        // ```
-        return DeterminedSideEffects::Analyzed(true);
-      };
+      let module = &modules[module_idx];
 
-      match &mut cache[module_id] {
+      match &mut cache[module_idx] {
         SideEffectCache::None => {
-          cache[module_id] = SideEffectCache::Visited;
+          cache[module_idx] = SideEffectCache::Visited;
         }
         SideEffectCache::Visited => {
           return *module.side_effects();
@@ -49,21 +41,17 @@ impl LinkStage<'_> {
         DeterminedSideEffects::Analyzed(v) if v => *module.side_effects(),
         // this branch means the side effects of the module is analyzed `false`
         DeterminedSideEffects::Analyzed(_) => match module {
-          Module::Normal(module) => {
-            DeterminedSideEffects::Analyzed(module.import_records.iter().any(|import_record| {
-              determine_side_effects_for_module(
-                cache,
-                import_record.resolved_module,
-                normal_modules,
-              )
-              .has_side_effects()
-            }))
-          }
+          Module::Normal(module) => DeterminedSideEffects::Analyzed(
+            module.import_records.iter().filter(|rec| !rec.is_dummy()).any(|import_record| {
+              determine_side_effects_for_module(cache, import_record.resolved_module, modules)
+                .has_side_effects()
+            }),
+          ),
           Module::External(module) => module.side_effects,
         },
       };
 
-      cache[module_id] = SideEffectCache::Cache(ret);
+      cache[module_idx] = SideEffectCache::Cache(ret);
 
       ret
     }

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -178,7 +178,9 @@ impl NormalModule {
     modules: &'me IndexModules,
   ) -> impl Iterator<Item = ImportRecordIdx> + 'me {
     self.ecma_view.import_records.iter_enumerated().filter_map(move |(rec_id, rec)| {
-      if !rec.meta.contains(ImportRecordMeta::IS_EXPORT_STAR) {
+      if !rec.meta.contains(ImportRecordMeta::IS_EXPORT_STAR)
+        || rec.meta.contains(ImportRecordMeta::IS_DUMMY)
+      {
         return None;
       }
       match modules[rec.resolved_module] {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. from https://github.com/rolldown/rolldown/pull/3928#discussion_r2008700361 cc @hyf0 
check all `imports_records.iter` is dummy record is enough.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
