### PR TITLE
fix(rolldown_utils): normalize ids before filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2885,6 +2885,7 @@ dependencies = [
  "async-scoped",
  "base-encode",
  "base64-simd",
+ "cow-utils",
  "criterion2",
  "dashmap",
  "fast-glob",

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -25,6 +25,7 @@ anyhow             = { workspace = true }
 arcstr             = { workspace = true }
 base-encode        = { workspace = true }
 base64-simd        = { workspace = true }
+cow-utils          = { workspace = true }
 dashmap            = { workspace = true }
 fast-glob          = { workspace = true }
 futures            = { workspace = true }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Normalize `\` to `/` before running the hook filter for ids so that plugins don't have to write `foo[/\]bar`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
