### PR TITLE
fix(node): fix webcontainer fallback for cjs rolldown + silence pkg.pr.new check error

### DIFF
--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -190,18 +190,18 @@ function patchBindingJs(): Plugin {
     name: 'patch-binding-js',
     transform: {
       filter: {
-        id: 'src/binding.js'
+        id: 'src/binding.js',
       },
-      handler(code, id, meta) {
-        console.log({id})
-        return code
-          // strip off unneeded createRequire in cjs, which breaks mjs
-          .replace('require = createRequire(__filename)', '')
-          // inject binding auto download fallback for webcontainer
-          .replace(
-          '\nif (!nativeBinding) {',
-          (s) =>
-            `
+      handler(code) {
+        return (
+          code
+            // strip off unneeded createRequire in cjs, which breaks mjs
+            .replace('require = createRequire(__filename)', '')
+            // inject binding auto download fallback for webcontainer
+            .replace(
+              '\nif (!nativeBinding) {',
+              (s) =>
+                `
 if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
   try {
     nativeBinding = require('./webcontainer-fallback.js');
@@ -210,9 +210,10 @@ if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
   }
 }
 ` + s,
+            )
         )
       },
-    }
+    },
   }
 }
 

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -3,7 +3,7 @@ import nodePath from 'node:path'
 import fsExtra from 'fs-extra'
 import { globSync } from 'glob'
 
-import { defineConfig, OutputOptions, rolldown } from './src/index'
+import { defineConfig, OutputOptions, rolldown, type Plugin } from './src/index'
 import pkgJson from './package.json' with { type: 'json' }
 import { colors } from './src/cli/colors'
 
@@ -153,37 +153,7 @@ const configs = defineConfig([
           })
         },
       },
-
-      {
-        name: 'cleanup binding.js',
-        transform: {
-          filter: {
-            code: {
-              include: ['require = createRequire(__filename)'],
-            },
-          },
-          handler(code, id) {
-            if (id.endsWith('binding.js')) {
-              const ret = code
-                .replace('require = createRequire(__filename)', '')
-                .replace(
-                  '\nif (!nativeBinding) {',
-                  (s) =>
-                    `
-if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
-  try {
-    nativeBinding = require('./webcontainer-fallback.js');
-  } catch (err) {
-    loadErrors.push(err)
-  }
-}
-` + s,
-                )
-              return ret
-            }
-          },
-        },
-      },
+      patchBindingJs(),
     ],
   },
   {
@@ -204,6 +174,7 @@ if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
           },
         },
       },
+      patchBindingJs(),
     ],
     output: {
       dir: outputDir,
@@ -213,6 +184,37 @@ if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
     },
   },
 ])
+
+function patchBindingJs(): Plugin {
+  return {
+    name: 'patch-binding-js',
+    transform: {
+      filter: {
+        id: 'src/binding.js'
+      },
+      handler(code, id, meta) {
+        console.log({id})
+        return code
+          // strip off unneeded createRequire in cjs, which breaks mjs
+          .replace('require = createRequire(__filename)', '')
+          // inject binding auto download fallback for webcontainer
+          .replace(
+          '\nif (!nativeBinding) {',
+          (s) =>
+            `
+if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
+  try {
+    nativeBinding = require('./webcontainer-fallback.js');
+  } catch (err) {
+    loadErrors.push(err)
+  }
+}
+` + s,
+        )
+      },
+    }
+  }
+}
 
 ;(async () => {
   for (const config of configs) {

--- a/packages/rolldown/src/webcontainer-fallback.js
+++ b/packages/rolldown/src/webcontainer-fallback.js
@@ -13,6 +13,7 @@ if (!fs.existsSync(bindingEntry)) {
 
   try {
     // check if pkg.pr.new
+    // TODO: this works only when demo project uses npm
     const info = JSON.parse(
       childProcess.execFileSync('npm', ['why', '--json', 'rolldown'], {
         encoding: 'utf-8',
@@ -23,9 +24,7 @@ if (!fs.existsSync(bindingEntry)) {
       const commit = spec.split('@').at(-1)
       bindingPkg = `https://pkg.pr.new/@rolldown/binding-wasm32-wasi@${commit}`
     }
-  } catch (e) {
-    console.error(e)
-  }
+  } catch {}
 
   fs.rmSync(baseDir, { recursive: true, force: true })
   fs.mkdirSync(baseDir, { recursive: true })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I had two oversights in https://github.com/rolldown/rolldown/pull/3922.
- `binding.js` patch wasn't applied for cjs build, so `require("rolldown")` was failing. https://stackblitz.com/edit/github-prwfj3pj-v8xbp6rq?file=package.json
- my quick pkg.pr.new check only works on npm and it causes a huge log on yarn (though it works) https://stackblitz.com/edit/github-prwfj3pj-xq2gbdvd?file=package.json. I removed console.error for now.