### PR TITLE
feat(node): expose `RenderedModule` type

### DIFF
--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -2,6 +2,7 @@ import {
   RolldownOutput,
   OutputAsset,
   OutputChunk,
+  RenderedModule,
   RenderedChunk,
   SourceMap,
 } from './types/rolldown-output'
@@ -133,6 +134,7 @@ export type {
   WatchOptions,
   RolldownWatcher,
   BuildOptions,
+  RenderedModule,
   RenderedChunk,
   LogOrStringHandler,
   GetModuleInfo,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://github.com/rollup/rollup/blob/8b1c634d945dda9294cf579de68c4b223c618e7f/src/rollup/types.d.ts#L894-L900
It is used by Vite.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
