### PR TITLE
refactor(node): remove webcontainer fallback for pkg.pr.new

### DIFF
--- a/packages/rolldown/src/webcontainer-fallback.js
+++ b/packages/rolldown/src/webcontainer-fallback.js
@@ -9,23 +9,7 @@ const baseDir = `/tmp/rolldown-${version}`
 const bindingEntry = `${baseDir}/node_modules/@rolldown/binding-wasm32-wasi/rolldown-binding.wasi.cjs`
 
 if (!fs.existsSync(bindingEntry)) {
-  let bindingPkg = `@rolldown/binding-wasm32-wasi@${version}`
-
-  try {
-    // check if pkg.pr.new
-    // TODO: this works only when demo project uses npm
-    const info = JSON.parse(
-      childProcess.execFileSync('npm', ['why', '--json', 'rolldown'], {
-        encoding: 'utf-8',
-      }),
-    )
-    const spec = info[0].dependents[0].spec
-    if (spec.startsWith('https://pkg.pr.new/')) {
-      const commit = spec.split('@').at(-1)
-      bindingPkg = `https://pkg.pr.new/@rolldown/binding-wasm32-wasi@${commit}`
-    }
-  } catch {}
-
+  const bindingPkg = `@rolldown/binding-wasm32-wasi@${version}`
   fs.rmSync(baseDir, { recursive: true, force: true })
   fs.mkdirSync(baseDir, { recursive: true })
   // eslint-disable-next-line: no-console


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I think this (unreliable) fallback wasn't really necessary since if users are directly trying rolldown from pkg.pr.new, they are modifying package.json manually, so they can just grab `https://pkg.pr.new/@rolldown/wasi@xxx` directly instead of `https://pkg.pr.new/rolldown@xxx`.

Note that if users are trying `rolldown-vite` from pkg.pr.new, that continues to work since `rolldown-vite` has a dependency on `rolldown` as a legitimate npm package.