### PR TITLE
feat: optimize dep unchanged

### DIFF
--- a/crates/rolldown_common/src/ecmascript/module_idx.rs
+++ b/crates/rolldown_common/src/ecmascript/module_idx.rs
@@ -1,4 +1,5 @@
 oxc_index::define_index_type! {
+    #[derive(Default)]
     pub struct ModuleIdx = u32;
 }
 

--- a/crates/rolldown_common/src/types/module_id.rs
+++ b/crates/rolldown_common/src/types/module_id.rs
@@ -7,7 +7,7 @@ use sugar_path::SugarPath;
 /// `ModuleId` is the unique string identifier for each module.
 /// - It will be used to identify the module in the whole bundle.
 /// - Users could stored the `ModuleId` to track the module in different stages/hooks.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
 pub struct ModuleId {
   // Id that rolldown uses to call `read_to_string` or `read` to get the content of the module.
   resource_id: ArcStr,

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -41,6 +41,18 @@ pub struct SymbolRefDbForModule {
   pub classic_data: IndexVec<SymbolId, SymbolRefDataClassic>,
 }
 
+impl Default for SymbolRefDbForModule {
+  fn default() -> Self {
+    Self {
+      owner_idx: ModuleIdx::new(0),
+      root_scope_id: ScopeId::new(0),
+      ast_scopes: AstScopes::new(Scoping::default()),
+      flags: FxHashMap::default(),
+      classic_data: IndexVec::default(),
+    }
+  }
+}
+
 impl SymbolRefDbForModule {
   pub fn new(scoping: Scoping, owner_idx: ModuleIdx, top_level_scope_id: ScopeId) -> Self {
     Self {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This pull request can ensure that if a module is modified without changing its dependency, only that module will be rebuilt. Before that, the sub-dependency graph of that module will be appended to the rebuild queue.
1. I  merged `intermediate.importers` into `cache. importers` because the `fetch_modules` will access the module even if the module is not changed, before It is ok because the subgraph will be always rebuild, https://github.com/rolldown/rolldown/blob/4092483d2b287e0f4619544275b2063c8f309fd1/crates/rolldown/src/module_loader/module_loader.rs?plain=1#L409-L413, the `idx` will be always allocated before access. Now, since the idx will not always be allocated if the dependency is not changed, if we use `HybridIndexVec`, it will panic at runtime.
2. Another notable I passed the owned cache instead of `cache.module_id_to_idx`, this is because we now have two global maintained field instead of one, maybe more in the future. Passing them one by one may make the function signature hard to read in the future, 
Now the cache has different semantics in different context,
   - In full build, it is almost identical as before.
   - In HMR and incremental rebuild, it has some globally maintained data structure we could modify on the fly during the module loading.
Taking ownership is fine. The program will immediately panic if you don't set it back when you use it, and it is only used in a few places. I don't use mutable references, because that will propagate the lifetime marking everywhere.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
