### PR TITLE
fix!: remove glob filter support for resolveId hook

### DIFF
--- a/docs/guide/plugin-development.md
+++ b/docs/guide/plugin-development.md
@@ -91,3 +91,9 @@ interface HookFilter {
   code?: StringFilter
 }
 ````
+
+The following properties are supported by each hooks:
+
+- `resolveId` hook: `id` (only `RegExp`)
+- `load` hook: `id`
+- `transform` hook: `id`, `moduleType`, `code`

--- a/packages/rolldown/src/plugin/hook-filter.ts
+++ b/packages/rolldown/src/plugin/hook-filter.ts
@@ -2,11 +2,11 @@ import type { MaybeArray } from '../types/utils'
 import type { StringOrRegExp } from '../types/utils'
 import type { ModuleType } from '../index'
 
-export type StringFilter =
-  | MaybeArray<StringOrRegExp>
+export type StringFilter<Value = StringOrRegExp> =
+  | MaybeArray<Value>
   | {
-      include?: MaybeArray<StringOrRegExp>
-      exclude?: MaybeArray<StringOrRegExp>
+      include?: MaybeArray<Value>
+      exclude?: MaybeArray<Value>
     }
 
 interface FormalModuleTypeFilter {

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -24,7 +24,7 @@ import type { ParallelPlugin } from './parallel-plugin'
 import type { DefinedHookNames } from '../constants/plugin'
 import type { DEFINED_HOOK_NAMES } from '../constants/plugin'
 import type { SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF } from '../constants/plugin-context'
-import type { HookFilter } from './hook-filter'
+import type { HookFilter, StringFilter } from './hook-filter'
 import { RenderedChunk } from '../types/rolldown-output'
 
 export type ModuleSideEffects = boolean | 'no-treeshake' | null
@@ -267,9 +267,11 @@ export type ParallelPluginHooks = Exclude<
 export type HookFilterExtension<K extends keyof FunctionPluginHooks> =
   K extends 'transform'
     ? { filter?: HookFilter }
-    : K extends 'load' | 'resolveId'
+    : K extends 'load'
       ? { filter?: Pick<HookFilter, 'id'> }
-      : {}
+      : K extends 'resolveId'
+        ? { filter?: { id: StringFilter<RegExp> } }
+        : {}
 
 export type PluginHooks = {
   [K in keyof FunctionPluginHooks]: ObjectHook<


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Removed the string (glob) id filter support for resolveId hook.
Globs are meant to be matched against absolute path. On the other hand, raw ids (specifiers) can be relative paths. The semantics of matching relative paths with globs are not clear and is confusing.

This PR only removes the ability from the types as that was easier and it would not break existing plugins (if exists).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
