### PR TITLE
refactor: annotate the type to be consistent with all_warnings

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -318,7 +318,7 @@ impl ModuleLoader {
     user_defined_entries: Vec<(Option<ArcStr>, ResolvedId)>,
     changed_resolved_ids: Vec<ResolvedId>,
   ) -> BuildResult<ModuleLoaderOutput> {
-    let mut errors = vec![];
+    let mut errors: Vec<BuildDiagnostic> = vec![];
     let mut all_warnings: Vec<BuildDiagnostic> = vec![];
 
     let entries_count = user_defined_entries.len() + /* runtime */ 1;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Annotate type for `errors` to maintain consistent code style with `all_warnings`.