### PR TITLE
docs: less ambiguous hook filter usage

### DIFF
--- a/docs/guide/plugin-development.md
+++ b/docs/guide/plugin-development.md
@@ -57,28 +57,29 @@ In addition to `id`, you can also filter based on `moduleType` and the module's 
 interface HookFilter {
   /**
    * This filter is used to do a pre-test to determine whether the hook should be called.
+   * 
    * @example
-   * // Filter out all `id`s that contain `node_modules` in the path.
+   * Include all `id`s that contain `node_modules` in the path.
    * ```js
    * { id: 'node_modules' }
    * ```
    * @example
-   * // Filter out all `id`s that contain `node_modules` or `src` in the path.
+   * Include all `id`s that contain `node_modules` or `src` in the path.
    * ```js
    * { id: ['node_modules', 'src'] }
    * ```
    * @example
-   * // Filter out all `id`s that start with `http`
+   * Include all `id`s that start with `http`
    * ```js
    * { id: /^http/ }
    * ```
    * @example
-   * // Exclude all `id`s that contain `node_modules` in the path.
+   * Exclude all `id`s that contain `node_modules` in the path.
    * ```js
    * { id: { exclude: 'node_modules' } }
    * ```
    * @example
-   * // Formal pattern
+   * Formal pattern to define includes and excludes.
    * ```
    * { id : {
    *   include: ["foo", /bar/],

--- a/docs/guide/plugin-development.md
+++ b/docs/guide/plugin-development.md
@@ -57,7 +57,7 @@ In addition to `id`, you can also filter based on `moduleType` and the module's 
 interface HookFilter {
   /**
    * This filter is used to do a pre-test to determine whether the hook should be called.
-   * 
+   *
    * @example
    * Include all `id`s that contain `node_modules` in the path.
    * ```js

--- a/packages/rolldown/src/plugin/hook-filter.ts
+++ b/packages/rolldown/src/plugin/hook-filter.ts
@@ -18,28 +18,29 @@ export type ModuleTypeFilter = ModuleType[] | FormalModuleTypeFilter
 export interface HookFilter {
   /**
    * This filter is used to do a pre-test to determine whether the hook should be called.
+   * 
    * @example
-   * // Filter out all `id`s that contain `node_modules` in the path.
+   * Include all `id`s that contain `node_modules` in the path.
    * ```js
    * { id: 'node_modules' }
    * ```
    * @example
-   * // Filter out all `id`s that contain `node_modules` or `src` in the path.
+   * Include all `id`s that contain `node_modules` or `src` in the path.
    * ```js
    * { id: ['node_modules', 'src'] }
    * ```
    * @example
-   * // Filter out all `id`s that start with `http`
+   * Include all `id`s that start with `http`
    * ```js
    * { id: /^http/ }
    * ```
    * @example
-   * // Exclude all `id`s that contain `node_modules` in the path.
+   * Exclude all `id`s that contain `node_modules` in the path.
    * ```js
    * { id: { exclude: 'node_modules' } }
    * ```
    * @example
-   * // Formal pattern
+   * Formal pattern to define includes and excludes.
    * ```
    * { id : {
    *   include: ["foo", /bar/],

--- a/packages/rolldown/src/plugin/hook-filter.ts
+++ b/packages/rolldown/src/plugin/hook-filter.ts
@@ -18,7 +18,7 @@ export type ModuleTypeFilter = ModuleType[] | FormalModuleTypeFilter
 export interface HookFilter {
   /**
    * This filter is used to do a pre-test to determine whether the hook should be called.
-   * 
+   *
    * @example
    * Include all `id`s that contain `node_modules` in the path.
    * ```js


### PR DESCRIPTION
This PR replaces "filter out" with "include" to ensure users understand easier whether the entries are included or excluded