### PR TITLE
chore(rolldown): disable `tsBuildInfoFile`

### DIFF
--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -15,7 +15,6 @@
     "outDir": "./dist/types",
     "resolveJsonModule": true,
     "noEmit": false,
-    "tsBuildInfoFile": ".tsbuildinfo",
     "emitDeclarationOnly": true
   }
 }


### PR DESCRIPTION
If the `dist` folder does not exist but the `tsBuildInfoFile` is present, dts files will not be emitted.

No idea, it could be a bug of TS.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
