### PR TITLE
fix(rust): avoid panic when `assetFileNames` hash length exceeds `22`

### DIFF
--- a/crates/rolldown/tests/rolldown/function/asset_filenames/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/asset_filenames/artifacts.snap
@@ -14,7 +14,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 
 ```
-## res-B_SY1GJM-B.js
+## res-B_SY1GJM-B-B_SY1GJMMBYNiYRwHTBqq.js
 
 ```js
 

--- a/crates/rolldown/tests/rolldown/function/asset_filenames/mod.rs
+++ b/crates/rolldown/tests/rolldown/function/asset_filenames/mod.rs
@@ -47,7 +47,7 @@ async fn test() {
         }]),
         cwd: Some(cwd),
         asset_filenames: Some(AssetFilenamesOutputOption::String(
-          "[name]-[hash]-[hash:1].js".into(),
+          "[name]-[hash]-[hash:1]-[hash:23].js".into(),
         )),
         ..Default::default()
       },

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -187,7 +187,7 @@ impl FileEmitter {
       let mut filename = filename_template.render(
         name,
         Some(extension.unwrap_or_default()),
-        Some(|len: Option<usize>| &hash[..len.unwrap_or(8)]),
+        Some(|len: Option<usize>| &hash[..len.map_or(8, |len| len.min(21))]),
       );
 
       // deconflict file name

--- a/crates/rolldown_plugin_isolated_declaration/tests/external/main.ts
+++ b/crates/rolldown_plugin_isolated_declaration/tests/external/main.ts
@@ -1,3 +1,3 @@
-import type * as fs from 'node:fs'
+import type * as fs from 'node:fs';
 
-export type { fs }
+export type { fs };


### PR DESCRIPTION
### Description

closes #4016 

I will improve the related test cases based on https://github.com/rolldown/rolldown/pull/3761 in a follow-up.