### PR TITLE
chore(renovate): split rust / npm changes

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -36,7 +36,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Rust
-      uses: Boshen/setup-rust@main
+      uses: oxc-project/setup-rust@v1.0.0
       with:
         components: ${{ inputs.components }}
         tools: ${{ inputs.tools }}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,16 +14,6 @@
       "matchDepNames": ["oxlint"],
       "rangeStrategy": "replace",
       "groupName": "oxlint"
-    },
-    {
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "matchUpdateTypes": ["minor", "patch"]
     }
-  ],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true,
-    "extends": ["schedule:weekly"]
-  }
+  ]
 }


### PR DESCRIPTION
Let's make the renovate behaviour consistent for Rolldown and Oxc.

See https://github.com/Boshen/renovate/blob/main/default.json
