### PR TITLE
fix(isolated_declaration): skip external id

### DIFF
--- a/crates/rolldown_plugin_isolated_declaration/src/lib.rs
+++ b/crates/rolldown_plugin_isolated_declaration/src/lib.rs
@@ -6,7 +6,7 @@ use oxc::{
   codegen::{CodeGenerator, CodegenOptions},
   isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions},
 };
-use rolldown_common::ModuleType;
+use rolldown_common::{ModuleType, ResolvedExternal};
 use rolldown_plugin::{Plugin, PluginHookMeta, PluginOrder};
 use sugar_path::SugarPath;
 use type_import_visitor::TypeImportVisitor;
@@ -37,7 +37,9 @@ impl Plugin for IsolatedDeclarationPlugin {
 
       for specifier in type_import_specifiers {
         let resolved_id = ctx.resolve(&specifier, Some(args.id), None).await??;
-        ctx.load(&resolved_id.id, None, None).await?;
+        if matches!(resolved_id.external, ResolvedExternal::Bool(false)) {
+          ctx.load(&resolved_id.id, None, None).await?;
+        }
       }
 
       let ret = args.ast.program.with_mut(|fields| {

--- a/crates/rolldown_plugin_isolated_declaration/tests/external/_config.json
+++ b/crates/rolldown_plugin_isolated_declaration/tests/external/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "external": ["node:fs"]
+  }
+}

--- a/crates/rolldown_plugin_isolated_declaration/tests/external/artifacts.snap
+++ b/crates/rolldown_plugin_isolated_declaration/tests/external/artifacts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.d.ts
+
+```ts
+import type * as fs from "node:fs";
+export type  { fs };
+
+```
+## main.js
+
+```js
+
+```

--- a/crates/rolldown_plugin_isolated_declaration/tests/external/main.ts
+++ b/crates/rolldown_plugin_isolated_declaration/tests/external/main.ts
@@ -1,0 +1,3 @@
+import type * as fs from 'node:fs'
+
+export type { fs }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes

```
❯ rolldown -c

 ERROR  Build failed with 2 errors:                                                                                                                                                       

[UNLOADABLE_DEPENDENCY] Error: Could not load magic-string-ast - No such file or directory (os error 2).

[UNLOADABLE_DEPENDENCY] Error: Could not load oxc-parser - No such file or directory (os error 2).

```