### PR TITLE
chore(infra): replace `npm-run-all` with `npm-run-all2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dprint": "^0.49.1",
     "husky": "^9.0.0",
     "lint-staged": "^15.2.5",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^7.0.0",
     "oxlint": "^0.16.0",
     "rolldown": "workspace:*",
     "typescript": "^5.6.3"

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -131,7 +131,6 @@
     "fs-extra": "^11.2.0",
     "glob": "^11.0.0",
     "locate-character": "^3.0.0",
-    "npm-run-all2": "^7.0.0",
     "oxc-parser": "^0.61.0",
     "remeda": "^2.10.0",
     "rolldown": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,9 @@ importers:
       lint-staged:
         specifier: ^15.2.5
         version: 15.5.0
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
+      npm-run-all2:
+        specifier: ^7.0.0
+        version: 7.0.2
       oxlint:
         specifier: ^0.16.0
         version: 0.16.3
@@ -306,9 +306,6 @@ importers:
       locate-character:
         specifier: ^3.0.0
         version: 3.0.0
-      npm-run-all2:
-        specifier: ^7.0.0
-        version: 7.0.2
       oxc-parser:
         specifier: ^0.61.0
         version: 0.61.2


### PR DESCRIPTION
### Description

Consolidate to use `npm-run-all2` across the project.