### PR TITLE
chore(infra): dprint fmt

### DIFF
--- a/crates/rolldown_plugin_isolated_declaration/tests/external/main.ts
+++ b/crates/rolldown_plugin_isolated_declaration/tests/external/main.ts
@@ -1,3 +1,3 @@
-import type * as fs from 'node:fs'
+import type * as fs from 'node:fs';
 
-export type { fs }
+export type { fs };

--- a/dprint.json
+++ b/dprint.json
@@ -19,6 +19,7 @@
     "crates/rolldown_testing/_config.schema.json",
     "packages/rolldown/src/binding.d.ts",
     "packages/rolldown/src/binding.js",
+    "packages/rolldown/src/browser.js",
     "packages/rolldown/src/rolldown-binding.wasi-browser.js",
     "packages/rolldown/src/rolldown-binding.wasi.cjs",
     "packages/rolldown/src/wasi-worker-browser.mjs",

--- a/packages/rolldown/src/browser.js
+++ b/packages/rolldown/src/browser.js
@@ -1,1 +1,1 @@
-export * from '@rolldown/binding-wasm32-wasi';
+export * from '@rolldown/binding-wasm32-wasi'


### PR DESCRIPTION
### Description

The `browser.js` is automatically generated because we should exclude it.