### PR TITLE
fix: correct the behavior when multiple transform filter option are specified

### DIFF
--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -29,7 +29,6 @@ impl StringOrRegex {
 }
 
 /// `id` is the raw path of file used for `regex` testing
-/// `stable_id` is the relative path for cwd , used for `glob` testing
 /// Using `FilterResult` rather than `bool` for complicated scenario, e.g.
 /// If you have only one filter, just use `FilterResult#inner` to determine if the `id` is matched,
 /// for multiple filters, you should use `FilterResult` to determine if the `id` is matched.
@@ -150,7 +149,7 @@ pub fn filter_code(
       }
     }
   }
-  // If the path is neither matched the exclude nor include,
+  // If the code is neither matched the exclude nor include,
   // it should only considered should be included if the include pattern is empty
   match include {
     None => FilterResult::NoneMatch(true),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. If user specified multiple transform_filter option at the same time, 
now return false if match any `exclude`, return true  only all `include` are matched 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
