### PR TITLE
chore(rust): unify naming conventions for built-in plugins

### DIFF
--- a/crates/rolldown_plugin_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_dynamic_import_vars/src/lib.rs
@@ -25,7 +25,7 @@ pub struct DynamicImportVarsPlugin {}
 
 impl Plugin for DynamicImportVarsPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("builtin:dynamic_import_vars")
+    Cow::Borrowed("builtin:dynamic-import-vars")
   }
 
   async fn resolve_id(

--- a/crates/rolldown_plugin_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_import_glob/src/lib.rs
@@ -37,7 +37,7 @@ pub struct ImportGlobPluginConfig {
 
 impl Plugin for ImportGlobPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("builtin:import-glob-plugin")
+    Cow::Borrowed("builtin:import-glob")
   }
 
   async fn transform_ast(

--- a/crates/rolldown_plugin_manifest/src/lib.rs
+++ b/crates/rolldown_plugin_manifest/src/lib.rs
@@ -21,7 +21,7 @@ pub struct ManifestPluginConfig {
 
 impl Plugin for ManifestPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("builtin:manifest-plugin")
+    Cow::Borrowed("builtin:manifest")
   }
 
   #[allow(clippy::case_sensitive_file_extension_comparisons)]

--- a/crates/rolldown_plugin_replace/src/plugin.rs
+++ b/crates/rolldown_plugin_replace/src/plugin.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::ops::Range;
 use std::{cmp::Reverse, sync::Arc};
 
@@ -170,7 +171,7 @@ impl ReplacePlugin {
 
 impl Plugin for ReplacePlugin {
   fn name(&self) -> std::borrow::Cow<'static, str> {
-    "builtin:replace".into()
+    Cow::Borrowed("builtin:replace")
   }
 
   async fn transform(

--- a/crates/rolldown_plugin_wasm_fallback/src/lib.rs
+++ b/crates/rolldown_plugin_wasm_fallback/src/lib.rs
@@ -7,7 +7,7 @@ pub struct WasmFallbackPlugin {}
 
 impl Plugin for WasmFallbackPlugin {
   fn name(&self) -> Cow<'static, str> {
-    Cow::Borrowed("builtin:wasm-fallback-plugin")
+    Cow::Borrowed("builtin:wasm-fallback")
   }
 
   #[allow(clippy::case_sensitive_file_extension_comparisons)]


### PR DESCRIPTION
### Description

Related to #3968 