### PR TITLE
chore: add plugin execution time tracing

### DIFF
--- a/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
@@ -7,19 +7,27 @@ use anyhow::{Ok, Result};
 use rolldown_common::{Output, RollupRenderedChunk, SharedNormalizedBundlerOptions};
 use rolldown_error::BuildDiagnostic;
 use rolldown_sourcemap::SourceMap;
+use tracing::{Instrument, debug_span};
 
 impl PluginDriver {
   pub async fn render_start(&self, opts: &SharedNormalizedBundlerOptions) -> HookNoopReturn {
     for (_, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_render_start_meta)
     {
-      plugin.call_render_start(ctx, &crate::HookRenderStartArgs { options: opts }).await?;
+      plugin
+        .call_render_start(ctx, &crate::HookRenderStartArgs { options: opts })
+        .instrument(debug_span!("render_start_hook", plugin_name = plugin.call_name().as_ref()))
+        .await?;
     }
     Ok(())
   }
 
   pub async fn banner(&self, args: HookAddonArgs, mut banner: String) -> Result<Option<String>> {
     for (_, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_banner_meta) {
-      if let Some(r) = plugin.call_banner(ctx, &args).await? {
+      if let Some(r) = plugin
+        .call_banner(ctx, &args)
+        .instrument(debug_span!("banner_hook", plugin_name = plugin.call_name().as_ref()))
+        .await?
+      {
         banner.push('\n');
         banner.push_str(r.as_str());
       }
@@ -32,7 +40,11 @@ impl PluginDriver {
 
   pub async fn footer(&self, args: HookAddonArgs, mut footer: String) -> Result<Option<String>> {
     for (_, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_footer_meta) {
-      if let Some(r) = plugin.call_footer(ctx, &args).await? {
+      if let Some(r) = plugin
+        .call_footer(ctx, &args)
+        .instrument(debug_span!("footer_hook", plugin_name = plugin.call_name().as_ref()))
+        .await?
+      {
         footer.push('\n');
         footer.push_str(r.as_str());
       }
@@ -45,7 +57,11 @@ impl PluginDriver {
 
   pub async fn intro(&self, args: HookAddonArgs, mut intro: String) -> Result<Option<String>> {
     for (_, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_intro_meta) {
-      if let Some(r) = plugin.call_intro(ctx, &args).await? {
+      if let Some(r) = plugin
+        .call_intro(ctx, &args)
+        .instrument(debug_span!("intro_hook", plugin_name = plugin.call_name().as_ref()))
+        .await?
+      {
         intro.push('\n');
         intro.push_str(r.as_str());
       }
@@ -58,7 +74,11 @@ impl PluginDriver {
 
   pub async fn outro(&self, args: HookAddonArgs, mut outro: String) -> Result<Option<String>> {
     for (_, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_outro_meta) {
-      if let Some(r) = plugin.call_outro(ctx, &args).await? {
+      if let Some(r) = plugin
+        .call_outro(ctx, &args)
+        .instrument(debug_span!("outro_hook", plugin_name = plugin.call_name().as_ref()))
+        .await?
+      {
         outro.push('\n');
         outro.push_str(r.as_str());
       }
@@ -76,7 +96,11 @@ impl PluginDriver {
     let mut sourcemap_chain = vec![];
     for (_, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_render_chunk_meta)
     {
-      if let Some(r) = plugin.call_render_chunk(ctx, &args).await? {
+      if let Some(r) = plugin
+        .call_render_chunk(ctx, &args)
+        .instrument(debug_span!("render_chunk_hook", plugin_name = plugin.call_name().as_ref()))
+        .await?
+      {
         args.code = r.code;
         if let Some(map) = r.map {
           sourcemap_chain.push(map);
@@ -94,7 +118,14 @@ impl PluginDriver {
     for (_, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_augment_chunk_hash_meta)
     {
-      if let Some(plugin_hash) = plugin.call_augment_chunk_hash(ctx, Arc::clone(&chunk)).await? {
+      if let Some(plugin_hash) = plugin
+        .call_augment_chunk_hash(ctx, Arc::clone(&chunk))
+        .instrument(debug_span!(
+          "augment_chunk_hash_hook",
+          plugin_name = plugin.call_name().as_ref()
+        ))
+        .await?
+      {
         hash.get_or_insert_with(String::default).push_str(&plugin_hash);
       }
     }
@@ -104,7 +135,10 @@ impl PluginDriver {
   pub async fn render_error(&self, args: &HookRenderErrorArgs<'_>) -> HookNoopReturn {
     for (_, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_render_error_meta)
     {
-      plugin.call_render_error(ctx, args).await?;
+      plugin
+        .call_render_error(ctx, args)
+        .instrument(debug_span!("render_error_hook", plugin_name = plugin.call_name().as_ref()))
+        .await?;
     }
     Ok(())
   }
@@ -120,7 +154,10 @@ impl PluginDriver {
       self.iter_plugin_with_context_by_order(&self.order_by_generate_bundle_meta)
     {
       let mut args = crate::HookGenerateBundleArgs { is_write, bundle, options: opts };
-      plugin.call_generate_bundle(ctx, &mut args).await?;
+      plugin
+        .call_generate_bundle(ctx, &mut args)
+        .instrument(debug_span!("generate_bundle_hook", plugin_name = plugin.call_name().as_ref()))
+        .await?;
       ctx.file_emitter.add_additional_files(bundle, warnings);
     }
     Ok(())
@@ -136,7 +173,10 @@ impl PluginDriver {
     {
       let mut args = crate::HookWriteBundleArgs { bundle, options: opts };
 
-      plugin.call_write_bundle(ctx, &mut args).await?;
+      plugin
+        .call_write_bundle(ctx, &mut args)
+        .instrument(debug_span!("write_bundle_hook", plugin_name = plugin.call_name().as_ref()))
+        .await?;
       ctx.file_emitter.add_additional_files(bundle, warnings);
     }
     Ok(())
@@ -145,7 +185,10 @@ impl PluginDriver {
   pub async fn close_bundle(&self) -> HookNoopReturn {
     for (_, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_close_bundle_meta)
     {
-      plugin.call_close_bundle(ctx).await?;
+      plugin
+        .call_close_bundle(ctx)
+        .instrument(debug_span!("close_bundle_hook", plugin_name = plugin.call_name().as_ref(),))
+        .await?;
     }
     Ok(())
   }

--- a/examples/basic-vue/rolldown.config.js
+++ b/examples/basic-vue/rolldown.config.js
@@ -1,25 +1,38 @@
-import { defineConfig } from 'rolldown';
+import { defineConfig } from "rolldown";
 
 export default defineConfig({
-  input: './index.js',
-  resolve: {
-    // This needs to be explicitly set for now because oxc resolver doesn't
-    // assume default exports conditions. Rolldown will ship with a default that
-    // aligns with Vite in the future.
-    conditionNames: ['import'],
-  },
-  output: {
-    plugins: [
-      {
-        name: 'test-plugin',
-        outputOptions: function(options) {
-          options.banner = '/* banner */';
-          return options;
-        },
+	input: "./index.js",
+	resolve: {
+		// This needs to be explicitly set for now because oxc resolver doesn't
+		// assume default exports conditions. Rolldown will ship with a default that
+		// aligns with Vite in the future.
+		conditionNames: ["import"],
+	},
+	plugins: [
+		{
+			name: "test-plugin",
+			async closeBundle() {
+        await new Promise((resolve) => {
+          setTimeout(() => {
+            console.log("test-plugin closeBundle");
+            resolve();
+          }, 1000);
+        });
       },
-    ],
-  },
-  experimental: {
-    enableComposingJsPlugins: true,
-  },
+		},
+	],
+	output: {
+		plugins: [
+			{
+				name: "test-plugin",
+				outputOptions: function (options) {
+					options.banner = "/* banner */";
+					return options;
+				},
+			},
+		],
+	},
+	experimental: {
+		enableComposingJsPlugins: true,
+	},
 });

--- a/examples/basic-vue/rolldown.config.js
+++ b/examples/basic-vue/rolldown.config.js
@@ -1,38 +1,25 @@
-import { defineConfig } from "rolldown";
+import { defineConfig } from 'rolldown';
 
 export default defineConfig({
-	input: "./index.js",
-	resolve: {
-		// This needs to be explicitly set for now because oxc resolver doesn't
-		// assume default exports conditions. Rolldown will ship with a default that
-		// aligns with Vite in the future.
-		conditionNames: ["import"],
-	},
-	plugins: [
-		{
-			name: "test-plugin",
-			async closeBundle() {
-        await new Promise((resolve) => {
-          setTimeout(() => {
-            console.log("test-plugin closeBundle");
-            resolve();
-          }, 1000);
-        });
+  input: './index.js',
+  resolve: {
+    // This needs to be explicitly set for now because oxc resolver doesn't
+    // assume default exports conditions. Rolldown will ship with a default that
+    // aligns with Vite in the future.
+    conditionNames: ['import'],
+  },
+  output: {
+    plugins: [
+      {
+        name: 'test-plugin',
+        outputOptions: function(options) {
+          options.banner = '/* banner */';
+          return options;
+        },
       },
-		},
-	],
-	output: {
-		plugins: [
-			{
-				name: "test-plugin",
-				outputOptions: function (options) {
-					options.banner = "/* banner */";
-					return options;
-				},
-			},
-		],
-	},
-	experimental: {
-		enableComposingJsPlugins: true,
-	},
+    ],
+  },
+  experimental: {
+    enableComposingJsPlugins: true,
+  },
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. for plugin: 
```js
plugins: [
		{
			name: "test-plugin",
			async closeBundle() {
        await new Promise((resolve) => {
          setTimeout(() => {
            console.log("test-plugin closeBundle");
            resolve();
          }, 1000);
        });
      },
		},
	],
```
It generate tracing output: 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DaCYGtH24FteGhZViwCT/d4091115-f362-4c83-9692-2619ee94a2fb.png)
### Ref
https://docs.rs/tracing/latest/tracing/span/struct.Span.html#examples
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
