### PR TITLE
feat: add `withFilter` util function

### DIFF
--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -44,7 +44,7 @@ import type {
   SourceDescription,
   TransformResult,
 } from './plugin';
-export {withFilter} from './plugin';
+export { withFilter } from './plugin';
 import type {
   HookFilter,
   ModuleTypeFilter,

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -44,6 +44,7 @@ import type {
   SourceDescription,
   TransformResult,
 } from './plugin';
+export {withFilter} from './plugin';
 import type {
   HookFilter,
   ModuleTypeFilter,

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -28,7 +28,7 @@ import type { PluginContext } from './plugin-context';
 import type { TransformPluginContext } from './transform-plugin-context';
 
 export type ModuleSideEffects = boolean | 'no-treeshake' | null;
-export {withFilter} from './with-filter'
+export { withFilter } from './with-filter';
 
 // ref: https://github.com/microsoft/TypeScript/issues/33471#issuecomment-1376364329
 export type ModuleType =

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -28,6 +28,7 @@ import type { PluginContext } from './plugin-context';
 import type { TransformPluginContext } from './transform-plugin-context';
 
 export type ModuleSideEffects = boolean | 'no-treeshake' | null;
+export {withFilter} from './with-filter'
 
 // ref: https://github.com/microsoft/TypeScript/issues/33471#issuecomment-1376364329
 export type ModuleType =

--- a/packages/rolldown/src/plugin/with-filter.ts
+++ b/packages/rolldown/src/plugin/with-filter.ts
@@ -1,44 +1,42 @@
-import { HookFilterExtension, Plugin } from "..";
+import { HookFilterExtension, Plugin } from '..';
 
 type OverrideFilterObject = {
-	transform?: HookFilterExtension<"transform">["filter"];
-	resolveId?: HookFilterExtension<"resolveId">["filter"];
-	load?: HookFilterExtension<"load">["filter"];
+  transform?: HookFilterExtension<'transform'>['filter'];
+  resolveId?: HookFilterExtension<'resolveId'>['filter'];
+  load?: HookFilterExtension<'load'>['filter'];
 };
 // TODO: maybe we should also change the name as well ?
 // my proposal is `${import.meta.filename}@${name}`
 export function withFilter<A, T extends Plugin<A>>(
-	plugin: T,
-	filter_obj: OverrideFilterObject,
+  plugin: T,
+  filter_obj: OverrideFilterObject,
 ): T {
-  plugin['transform']
-	Object.keys(plugin).forEach((key) => {
-		switch (key) {
-			case "transform":
-      case "resolveId":
-      case "load":
+  plugin['transform'];
+  Object.keys(plugin).forEach((key) => {
+    switch (key) {
+      case 'transform':
+      case 'resolveId':
+      case 'load':
         if (!plugin[key]) {
           return;
         }
-				if (typeof plugin[key] === "object") {
-					plugin[key].filter = filter_obj[key] ?? plugin[key].filter;
-				} else {
+        if (typeof plugin[key] === 'object') {
+          plugin[key].filter = filter_obj[key] ?? plugin[key].filter;
+        } else {
           // We could either remove the `@ts-expect-error` and duplicate case `transform`, `resolveId` and `load`
           // or use `@ts-expect-error` to just ignore the type error
-          // Prefer simplicity because we already checked before 
-					plugin[key] = {
+          // Prefer simplicity because we already checked before
+          plugin[key] = {
             // @ts-expect-error
             handler: plugin[key],
             // @ts-expect-error
             filter: filter_obj[key],
-          }
+          };
         }
         break;
-			default:
+      default:
         break;
-		}
-	});
-	return plugin;
+    }
+  });
+  return plugin;
 }
-
-

--- a/packages/rolldown/src/plugin/with-filter.ts
+++ b/packages/rolldown/src/plugin/with-filter.ts
@@ -1,0 +1,44 @@
+import { HookFilterExtension, Plugin } from "..";
+
+type OverrideFilterObject = {
+	transform?: HookFilterExtension<"transform">["filter"];
+	resolveId?: HookFilterExtension<"resolveId">["filter"];
+	load?: HookFilterExtension<"load">["filter"];
+};
+// TODO: maybe we should also change the name as well ?
+// my proposal is `${import.meta.filename}@${name}`
+export function withFilter<A, T extends Plugin<A>>(
+	plugin: T,
+	filter_obj: OverrideFilterObject,
+): T {
+  plugin['transform']
+	Object.keys(plugin).forEach((key) => {
+		switch (key) {
+			case "transform":
+      case "resolveId":
+      case "load":
+        if (!plugin[key]) {
+          return;
+        }
+				if (typeof plugin[key] === "object") {
+					plugin[key].filter = filter_obj[key] ?? plugin[key].filter;
+				} else {
+          // We could either remove the `@ts-expect-error` and duplicate case `transform`, `resolveId` and `load`
+          // or use `@ts-expect-error` to just ignore the type error
+          // Prefer simplicity because we already checked before 
+					plugin[key] = {
+            // @ts-expect-error
+            handler: plugin[key],
+            // @ts-expect-error
+            filter: filter_obj[key],
+          }
+        }
+        break;
+			default:
+        break;
+		}
+	});
+	return plugin;
+}
+
+

--- a/packages/rolldown/tests/fixtures/plugin/transform/with-filter/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/with-filter/_config.ts
@@ -1,0 +1,67 @@
+import { withFilter } from "rolldown";
+import { defineTest } from "rolldown-tests";
+import { expect, vi } from "vitest";
+
+const transformFn = vi.fn();
+const transformFn2 = vi.fn();
+const transformFn3 = vi.fn();
+
+export default defineTest({
+	skipComposingJsPlugin: true,
+	config: {
+		plugins: [
+			withFilter(
+				{
+					name: "test-plugin",
+					// should override the original filter
+					transform: {
+						filter: {
+							id: /\.[j|t]s$/,
+						},
+						handler(_, _id) {
+							transformFn();
+						},
+					},
+				},
+				{
+					transform: {
+						id: /\.vue$/,
+					},
+				},
+			),
+			withFilter(
+				{
+					name: "test-plugin2",
+					// should add filter to transform function
+					transform() {
+						transformFn2();
+					},
+				},
+				{
+					transform: {
+						id: /\.vue$/,
+					},
+				},
+			),
+			withFilter(
+				{
+					name: "test-plugin3",
+					// should have no effects
+					transform() {
+						transformFn3();
+					},
+				},
+				{
+					resolveId: {
+						id: /\.vue$/,
+					},
+				},
+			),
+		],
+	},
+	afterTest: () => {
+		expect(transformFn).toHaveBeenCalledTimes(0);
+		expect(transformFn2).toHaveBeenCalledTimes(0);
+		expect(transformFn3).toHaveBeenCalledTimes(3);
+	},
+});

--- a/packages/rolldown/tests/fixtures/plugin/transform/with-filter/a.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/with-filter/a.ts
@@ -1,0 +1,1 @@
+export const a = 1000

--- a/packages/rolldown/tests/fixtures/plugin/transform/with-filter/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/transform/with-filter/main.js
@@ -1,0 +1,2 @@
+import './foo'
+import './a.ts'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. `withFilter` gives the user the abiliity to filter hook call for that ecosystem plugin that are not ready to migrate.  
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
