### PR TITLE
refactor(rolldown_plugin_json): rename `is_build` to `minify`

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -89,9 +89,9 @@ pub struct BindingModulePreloadPolyfillPluginConfig {
 #[napi_derive::napi(object)]
 #[derive(Debug, Default)]
 pub struct BindingJsonPluginConfig {
-  pub stringify: Option<BindingJsonPluginStringify>,
-  pub is_build: Option<bool>,
+  pub minify: Option<bool>,
   pub named_exports: Option<bool>,
+  pub stringify: Option<BindingJsonPluginStringify>,
 }
 
 #[derive(Debug)]
@@ -365,9 +365,9 @@ impl TryFrom<BindingBuiltinPlugin> for Arc<dyn Pluginable> {
           BindingJsonPluginConfig::default()
         };
         Arc::new(JsonPlugin {
-          stringify: config.stringify.map(TryInto::try_into).transpose()?.unwrap_or_default(),
-          is_build: config.is_build.unwrap_or_default(),
+          minify: config.minify.unwrap_or_default(),
           named_exports: config.named_exports.unwrap_or_default(),
+          stringify: config.stringify.map(TryInto::try_into).transpose()?.unwrap_or_default(),
         })
       }
       BindingBuiltinPluginName::BuildImportAnalysis => {

--- a/crates/rolldown_plugin_json/src/lib.rs
+++ b/crates/rolldown_plugin_json/src/lib.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 #[derive(Debug, Default)]
 pub struct JsonPlugin {
-  pub is_build: bool,
+  pub minify: bool,
   pub named_exports: bool,
   pub stringify: JsonPluginStringify,
 }
@@ -44,7 +44,7 @@ impl Plugin for JsonPlugin {
     let is_stringify = self.stringify != JsonPluginStringify::False
       && (self.stringify == JsonPluginStringify::True || code.len() > utils::THRESHOLD_SIZE);
     if !is_name_exports && is_stringify {
-      let json = if self.is_build {
+      let json = if self.minify {
         // TODO(perf): find better way than https://github.com/rolldown/vite/blob/3bf86e3f/packages/vite/src/node/plugins/json.ts#L55-L57
         let value = serde_json::from_str::<Value>(code)?;
         Cow::Owned(serde_json::to_string(&value)?)

--- a/crates/rolldown_plugin_json/src/utils.rs
+++ b/crates/rolldown_plugin_json/src/utils.rs
@@ -55,7 +55,8 @@ pub fn strip_bom(code: &str) -> &str {
   code.strip_prefix("\u{FEFF}").unwrap_or(code)
 }
 
-pub fn serialize_value(value: &Value) -> Result<String, serde_json::Error> {
+#[inline]
+fn serialize_value(value: &Value) -> Result<String, serde_json::Error> {
   let value_as_string = serde_json::to_string(value)?;
   if value_as_string.len() > THRESHOLD_SIZE && value.is_object() {
     let value = serde_json::to_string(&value_as_string)?;

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -410,9 +410,9 @@ export interface BindingIsolatedDeclarationPluginConfig {
 }
 
 export interface BindingJsonPluginConfig {
-  stringify?: BindingJsonPluginStringify
-  isBuild?: boolean
+  minify?: boolean
   namedExports?: boolean
+  stringify?: BindingJsonPluginStringify
 }
 
 export type BindingJsonPluginStringify =

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/build/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/build/_config.ts
@@ -4,7 +4,7 @@ import { expect } from 'vitest'
 
 export default defineTest({
   config: {
-    plugins: [jsonPlugin({ stringify: true, isBuild: true })],
+    plugins: [jsonPlugin({ stringify: true, minify: true })],
   },
   async afterTest(output) {
     expect(output.output[0].code).toContain(

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/named-exports/_config.ts
@@ -5,7 +5,7 @@ import { expect } from 'vitest'
 export default defineTest({
   config: {
     plugins: [
-      jsonPlugin({ stringify: false, isBuild: true, namedExports: true }),
+      jsonPlugin({ stringify: false, minify: true, namedExports: true }),
     ],
   },
   async afterTest(output) {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects-named/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects-named/_config.ts
@@ -6,9 +6,9 @@ export default defineTest({
   config: {
     plugins: [
       jsonPlugin({
+        minify: false,
         stringify: true,
         namedExports: true,
-        isBuild: false,
       }),
     ],
   },

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/side-effects/_config.ts
@@ -4,7 +4,7 @@ import { expect } from 'vitest'
 
 export default defineTest({
   config: {
-    plugins: [jsonPlugin({ stringify: true, isBuild: false })],
+    plugins: [jsonPlugin({ stringify: true, minify: false })],
   },
   async afterTest(output) {
     expect(output.output[0].code).not.toContain(`JSON.parse`)

--- a/packages/rolldown/tests/fixtures/builtin-plugin/json/vite/6/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/json/vite/6/_config.ts
@@ -7,7 +7,7 @@ export default defineTest({
   config: {
     input: 'main.js',
     plugins: [
-      jsonPlugin({ namedExports: false, stringify: true, isBuild: true }),
+      jsonPlugin({ namedExports: false, stringify: true, minify: true }),
       {
         name: 'test-plugin',
         async transform(code, id) {


### PR DESCRIPTION
### Description

Related to #3968 

The meaning of `is_build` was not intuitive, so I decided to rename it to `minify`. I will also add a `README.md` later to explain the meaning of each option.