### PR TITLE
fix(build): handle empty dependencies in rolldown configuration

### DIFF
--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -102,7 +102,7 @@ function withShared(
       /\.\/rolldown-binding\.wasi\.cjs/,
       // some dependencies, e.g. zod, cannot be inlined because their types
       // are used in public APIs
-      ...Object.keys(pkgJson.dependencies),
+      ...Object.keys(pkgJson.dependencies ?? {}),
       bindingFileWasi,
       bindingFileWasiBrowser,
     ],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The current implementation assumes `pkgJson.dependencies` always exists and attempts to spread its keys into the external array. 

However, some packages might be dependency-free or only have `devDependencies` and `peerDependencies` without any direct runtime dependencies.

> Note: The issue is straightforward - it occurs when `Object.keys` is called on undefined dependencies, so maybe it's ok that there's no reproduction link provided as the fix is self-explanatory :)
