### PR TITLE
chore(rolldown_debug): add necessary features for `tracing-subscriber`

### DIFF
--- a/crates/rolldown_debug/Cargo.toml
+++ b/crates/rolldown_debug/Cargo.toml
@@ -12,7 +12,7 @@ serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 tracing = { workspace = true, features = ["valuable"] }
 tracing-serde = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter", "json", "valuable"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json", "registry", "std", "valuable"] }
 
 [lints]
 workspace = true

--- a/crates/rolldown_debug/Cargo.toml
+++ b/crates/rolldown_debug/Cargo.toml
@@ -12,7 +12,7 @@ serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 tracing = { workspace = true, features = ["valuable"] }
 tracing-serde = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json", "registry", "std", "valuable"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json", "valuable"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
### Description

This is a rather peculiar bug that typically doesn't occur. However, when you add a test case in any plugin crate and run it, the issue will be exposed.

Add below to `crates/rolldown_plugin_load_fallback/src/lib.rs` and run it:

```rust
#[test]
fn test() {
  println!("hello world");
}
```

Then you will get this error:

```rust
error[E0433]: failed to resolve: could not find `fmt` in `tracing_subscriber`
   --> crates\rolldown_debug\src\debug_formatter.rs:11:3
    |
11  |   fmt::{FmtContext, FormatEvent, FormatFields, format::Writer},
    |   ^^^ could not find `fmt` in `tracing_subscriber`
```