### PR TITLE
feat: add hmr runtime implement option

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -27,10 +27,11 @@ impl From<BindingExperimentalOptions> for rolldown_common::ExperimentalOptions {
 pub struct BindingExperimentalHmrOptions {
   pub host: Option<String>,
   pub port: Option<u16>,
+  pub implement: Option<String>,
 }
 
 impl From<BindingExperimentalHmrOptions> for rolldown_common::HmrOptions {
   fn from(value: BindingExperimentalHmrOptions) -> Self {
-    Self { host: value.host, port: value.port }
+    Self { host: value.host, port: value.port, implement: value.implement }
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/hmr_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/hmr_options.rs
@@ -14,4 +14,6 @@ pub struct HmrOptions {
   pub host: Option<String>,
   /// Port that `DevRuntime` will connect to using WebSocket.
   pub port: Option<u16>,
+  /// Custom hmr runtime implementation.
+  pub implement: Option<String>,
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -757,6 +757,13 @@
             "null"
           ]
         },
+        "implement": {
+          "description": "Custom hmr runtime implementation.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "port": {
           "description": "Port that `DevRuntime` will connect to using WebSocket.",
           "type": [

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -291,6 +291,7 @@ export interface BindingEmittedChunk {
 export interface BindingExperimentalHmrOptions {
   host?: string
   port?: number
+  implement?: string
 }
 
 export interface BindingExperimentalOptions {

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -74,7 +74,11 @@ export interface WatchOptions {
 
 export type MakeAbsoluteExternalsRelative = boolean | 'ifRelativeSource';
 
-export type HmrOptions = boolean | { host?: string; port?: number };
+export type HmrOptions = boolean | {
+  host?: string;
+  port?: number;
+  implement?: string;
+};
 
 export interface InputOptions {
   input?: InputOption;

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -320,6 +320,7 @@ const HmrSchema = v.union([
   v.strictObject({
     port: v.optional(v.number()),
     host: v.optional(v.string()),
+    implement: v.optional(v.string()),
   }),
 ]);
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Since the vite client has many logic need to migrate, it is difficult to migrate into rolldown. eg

- hmr API https://vite.dev/guide/api-hmr.html
- hmr related update logic 
- ws msg/failed reconnection/token validation
- error overlay

I intend to allow vite custom implement hmr runtime, it only using the rolldown hmr module runner related runtime, [rolldown-vite ref here](https://github.com/vitejs/rolldown-vite/pull/107/commits/744fe8b3e5705ed0153a797a99b45a1ae8a64e5c#diff-6ad771c6844f5f02e8fb4d6cf54ca9eaa7c93d8db04b8f002782f6d89c0ebdd5.). It is easy to make the vite features is compat to original logic.

Update:
After the pr, the rolldown only need to make sure some features is correct.
- initial chunk execution
- hmr chunk execution
- hmr relate API scanner and calculate hmr boundaries
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
