### PR TITLE
chore(infra): ignore generated bindings type from `rolldown_debug_action`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ packages/**/THIRD-PARTY-LICENSE
 !/packages/rolldown/tests/fixtures/**/node_modules
 
 .spr.yml
+
+# generated bindings type
+crates/rolldown_debug_action/bindings/**


### PR DESCRIPTION
### Description

Running `just build` will automatically clean up, but `just test` will cause it to persist.