### PR TITLE
refactor(browser): drop cdn import of browser

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -32,7 +32,7 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "browser": "./dist/browser-bundler.mjs",
+      "browser": "./dist/browser.mjs",
       "required": "./dist/index.cjs",
       "import": "./dist/index.mjs"
     },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -64,6 +64,7 @@
     "build:release": "pnpm run --sequential \"/^build-(types|pkg:release)$/\"",
     "build-pkg:debug": "pnpm run --filter rolldown build-browser:debug",
     "build-pkg:release": "pnpm run --filter rolldown build-browser:release",
+    "build-node": "cross-env BROWSER_PKG=1 pnpm run --filter rolldown build-node",
     "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -53,7 +53,7 @@ if (isBrowserPkg) {
       browserBuild: true,
       output: {
         format: 'esm',
-        file: nodePath.resolve(outputDir, 'browser-bundler.mjs'),
+        file: nodePath.resolve(outputDir, 'browser.mjs'),
       },
     }),
   );


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Due to browser policies, cross-origin Web Workers cannot work when [`crossOriginIsolated === true`](https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated), making CDN imports impossible. Additionally, there is a lack of compelling use cases for this feature.

If anyone can bypass the policies, feel free to re-implement this feature.