### PR TITLE
fix(rust): normalize path joining with glob on Windows

### DIFF
--- a/crates/rolldown_utils/src/join_path_with_glob.rs
+++ b/crates/rolldown_utils/src/join_path_with_glob.rs
@@ -1,0 +1,59 @@
+use std::{borrow::Cow, path::Path};
+
+use crate::pattern_filter::normalize_path;
+
+/// Joins a base path with a glob pattern, returning the joined pattern as a `Cow<'a, str>`.
+///
+/// For Windows, it normalizes the base path by replacing backslashes with forward slashes
+/// before joining with the glob pattern. It also ensures a forward slash separator
+/// between the base path and the glob if needed.
+///
+/// Note: This function only constructs the joined glob pattern string. It does not
+/// perform the actual globbing (finding matching files).
+///
+/// # Arguments
+///
+/// * `path`: The base directory path.
+/// * `glob`: The glob pattern to join with the base path.
+///
+/// # Returns
+///
+/// A `Cow<'a, str>` representing the joined glob pattern.
+pub fn join_path_with_glob<'a>(path: &'a str, glob: &'a str) -> Cow<'a, str> {
+  if glob.starts_with("**") || Path::new(glob).is_absolute() {
+    return Cow::Borrowed(glob);
+  }
+
+  let base = normalize_path(path);
+
+  #[cfg(windows)]
+  let base = if base.as_bytes().last().is_some_and(|&c| c != b'/') {
+    let mut p = String::with_capacity(base.len() + 1);
+    p.push_str(&base);
+    p.push('/');
+    Cow::Owned(p)
+  } else {
+    base
+  };
+
+  Cow::Owned(Path::new(base.as_ref()).join(glob).to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_join_path_with_glob_basic() {
+    assert_eq!(join_path_with_glob("path/to", "*.txt"), "path/to/*.txt");
+    assert_eq!(join_path_with_glob("path\\to", "*.txt"), "path/to/*.txt");
+    assert_eq!(join_path_with_glob("path\\to\\", "*.txt"), "path/to/*.txt");
+    assert_eq!(join_path_with_glob("C:\\path\\to", "*.txt"), "C:/path/to/*.txt");
+  }
+
+  #[test]
+  fn test_join_path_with_glob_glob_with_separator() {
+    assert_eq!(join_path_with_glob("path/to", "/*.txt"), "/*.txt");
+    assert_eq!(join_path_with_glob("C:\\path\\to", "/*.txt"), "C:/*.txt");
+  }
+}

--- a/crates/rolldown_utils/src/join_path_with_glob.rs
+++ b/crates/rolldown_utils/src/join_path_with_glob.rs
@@ -46,14 +46,18 @@ mod tests {
   #[test]
   fn test_join_path_with_glob_basic() {
     assert_eq!(join_path_with_glob("path/to", "*.txt"), "path/to/*.txt");
-    assert_eq!(join_path_with_glob("path\\to", "*.txt"), "path/to/*.txt");
-    assert_eq!(join_path_with_glob("path\\to\\", "*.txt"), "path/to/*.txt");
-    assert_eq!(join_path_with_glob("C:\\path\\to", "*.txt"), "C:/path/to/*.txt");
+    #[cfg(windows)]
+    {
+      assert_eq!(join_path_with_glob("path\\to", "*.txt"), "path/to/*.txt");
+      assert_eq!(join_path_with_glob("path\\to\\", "*.txt"), "path/to/*.txt");
+      assert_eq!(join_path_with_glob("C:\\path\\to", "*.txt"), "C:/path/to/*.txt");
+    }
   }
 
   #[test]
   fn test_join_path_with_glob_glob_with_separator() {
     assert_eq!(join_path_with_glob("path/to", "/*.txt"), "/*.txt");
+    #[cfg(windows)]
     assert_eq!(join_path_with_glob("C:\\path\\to", "/*.txt"), "C:/*.txt");
   }
 }

--- a/crates/rolldown_utils/src/lib.rs
+++ b/crates/rolldown_utils/src/lib.rs
@@ -21,6 +21,7 @@ pub mod clean_url;
 pub mod concat_string;
 pub mod hash_placeholder;
 pub mod index_vec_ext;
+pub mod join_path_with_glob;
 pub mod js_regex;
 pub mod pattern_filter;
 pub mod replace_all_placeholder;

--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -278,6 +278,7 @@ mod tests {
         cases: vec![("/virtual/foo*", FilterResult::Match(true))],
         cwd: None,
       },
+      #[cfg(windows)]
       TestCases {
         input_filter: InputFilter { include: glob_filter("foo/\\[*.js"), exclude: None },
         cases: vec![("C:\\path\\foo\\[bar.js", FilterResult::Match(true))],

--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -44,7 +44,7 @@ pub fn filter(
     for pattern in exclude {
       let v = match pattern.as_ref() {
         StringOrRegex::String(glob) => {
-          let glob = join_path_with_glob(glob, cwd);
+          let glob = join_path_with_glob(cwd, glob);
           glob_match(glob.as_bytes(), id.as_bytes())
         }
         StringOrRegex::Regex(re) => re.matches(&normalized_id),
@@ -58,7 +58,7 @@ pub fn filter(
     for pattern in include {
       let v = match pattern.as_ref() {
         StringOrRegex::String(glob) => {
-          let glob = join_path_with_glob(glob, cwd);
+          let glob = join_path_with_glob(cwd, glob);
           glob_match(glob.as_bytes(), id.as_bytes())
         }
         StringOrRegex::Regex(re) => re.matches(&normalized_id),


### PR DESCRIPTION
### Description

After submitting PR #4133, I discovered an issue with the `get_matcher_string` function in `pattern_filter`. Upon further investigation of other usages of `fast-glob`, it appears that this issue exists across those as well.

The issue stems from normalizing both the `path` and the `glob` by replacing `\\` with `/` on windows, but `\\` in a `glob` has special meaning, causing potential errors in the merged glob.

If you agree with this, I will apply the fix to other areas as well.