### PR TITLE
refactor(rust): use `Default` trait to simplify `SymbolRefDataClassic` init

### DIFF
--- a/crates/rolldown_common/src/types/ast_scopes.rs
+++ b/crates/rolldown_common/src/types/ast_scopes.rs
@@ -76,10 +76,10 @@ impl AstScopes {
       .facade_scoping
       .mutated_symbol_id_to_names
       .insert(SymbolId::new(symbol_id), name.to_string());
-    self.facade_scoping.facade_symbol_classic_data.insert(
-      SymbolId::new(symbol_id),
-      SymbolRefDataClassic { link: None, chunk_id: None, namespace_alias: None },
-    );
+    self
+      .facade_scoping
+      .facade_symbol_classic_data
+      .insert(SymbolId::new(symbol_id), SymbolRefDataClassic::default());
     SymbolId::new(symbol_id)
   }
 

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -10,7 +10,7 @@ use crate::{AstScopes, ChunkIdx, ModuleIdx, SymbolRef};
 
 use super::namespace_alias::NamespaceAlias;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SymbolRefDataClassic {
   /// For case `import {a} from 'foo.cjs';console.log(a)`, the symbol `a` reference to `module.exports.a` of `foo.cjs`.
   /// So we will transform the code into `console.log(foo_ns.a)`. `foo_ns` is the namespace symbol of `foo.cjs and `a` is the property name.
@@ -59,14 +59,9 @@ impl SymbolRefDbForModule {
       owner_idx,
       root_scope_id: top_level_scope_id,
       classic_data: IndexVec::from_vec(vec![
-        SymbolRefDataClassic {
-          link: None,
-          chunk_id: None,
-          namespace_alias: None,
-        };
+        SymbolRefDataClassic::default();
         scoping.symbols_len()
       ]),
-
       ast_scopes: AstScopes::new(scoping),
       flags: FxHashMap::default(),
     }


### PR DESCRIPTION
### Description

Implement `Default` for `SymbolRefDataClassic` to simplify initialization.
