### PR TITLE
fix: convert severity of missing_export diagnostic to warning when importee module is ts/tsx

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -610,13 +610,19 @@ impl BindImportsAndExportsContext<'_> {
         }
         MatchImportKind::NoMatch => {
           let importee = &self.index_modules[rec.resolved_module];
-          self.errors.push(BuildDiagnostic::missing_export(
+          let mut diagnostic = BuildDiagnostic::missing_export(
             module.stable_id.to_string(),
             importee.stable_id().to_string(),
             module.source.clone(),
             named_import.imported.to_string(),
             named_import.span_imported,
-          ));
+          );
+          if let Some(importer) = importee.as_normal() {
+            if matches!(importer.module_type, ModuleType::Ts | ModuleType::Tsx) {
+              diagnostic = diagnostic.with_severity_warning();
+            }
+          }
+          self.errors.push(diagnostic);
         }
       }
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. related to https://github.com/rolldown/rolldown/pull/4144#issuecomment-2811663851
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
