### PR TITLE
perf(rust): use `into_owned` instead of `to_string` to avoid unnecessary allocation

### DIFF
--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -82,7 +82,7 @@ fn get_matcher_string<'a>(glob: &'a str, cwd: &'a str) -> Cow<'a, str> {
     normalize_path(glob)
   } else {
     let final_path = Path::new(cwd).join(glob);
-    Cow::Owned(normalize_path(final_path.to_string_lossy().as_ref()).to_string())
+    Cow::Owned(normalize_path(&final_path.to_string_lossy()).into_owned())
   }
 }
 


### PR DESCRIPTION
### Description

For `Cow<str>`, calling `to_string` always results in a new allocation, even if the variant is `Cow::Owned`.