### PR TITLE
fix: clear js side cache at bundle fininsh

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -213,6 +213,10 @@ impl Bundler {
       .generate_bundle(&mut output.assets, is_write, &self.options, &mut output.warnings)
       .await?;
 
+    if let Some(invalidate_js_side_cache) = &self.options.invalidate_js_side_cache {
+      invalidate_js_side_cache.call().await?;
+    }
+
     self.merge_immutable_fields_for_cache(link_stage_output.symbol_db);
 
     if self.options.is_hmr_enabled() {

--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -255,6 +255,7 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
     make_absolute_externals_relative: raw_options
       .make_absolute_externals_relative
       .unwrap_or_default(),
+    invalidate_js_side_cache: raw_options.invalidate_js_side_cache,
   };
 
   NormalizeOptionsReturn { options: normalized, resolve_options: raw_resolve, warnings }

--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -98,4 +98,8 @@ pub struct BindingInputOptions {
   pub defer_sync_scan_data: Option<BindingDeferSyncScanDataOption>,
   pub make_absolute_externals_relative: Option<BindingMakeAbsoluteExternalsRelative>,
   pub debug: Option<BindingDebugOptions>,
+  #[debug(skip)]
+  #[napi(ts_type = "() => void")]
+  // TODO: The `FnArgs<()>` is not supported.
+  pub invalidate_js_side_cache: Option<JsCallback<FnArgs<(Option<bool>,)>, ()>>,
 }

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -5,6 +5,7 @@ use types::advanced_chunks_options::AdvancedChunksOptions;
 use types::comments::Comments;
 use types::debug_options::DebugOptions;
 use types::inject_import::InjectImport;
+use types::invalidate_js_side_cache::InvalidateJsSideCache;
 use types::jsx::Jsx;
 use types::make_absolute_externals_relative::MakeAbsoluteExternalsRelative;
 use types::minify_options::RawMinifyOptions;
@@ -190,6 +191,12 @@ pub struct BundlerOptions {
   pub defer_sync_scan_data: Option<DeferSyncScanDataOption>,
   pub make_absolute_externals_relative: Option<MakeAbsoluteExternalsRelative>,
   pub debug: Option<DebugOptions>,
+  #[cfg_attr(
+    feature = "deserialize_bundler_options",
+    serde(default, skip_deserializing),
+    schemars(skip)
+  )]
+  pub invalidate_js_side_cache: Option<InvalidateJsSideCache>,
 }
 
 impl BundlerOptions {

--- a/crates/rolldown_common/src/inner_bundler_options/types/invalidate_js_side_cache.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/invalidate_js_side_cache.rs
@@ -1,0 +1,21 @@
+use std::sync::Arc;
+use std::{future::Future, pin::Pin};
+
+use derive_more::Debug;
+
+pub type InvalidateJsSideCacheFn =
+  dyn Fn() -> Pin<Box<(dyn Future<Output = anyhow::Result<()>> + Send + 'static)>> + Send + Sync;
+
+#[derive(Clone, Debug)]
+#[debug("InvalidateJsSideCacheFn::Fn(...)")]
+pub struct InvalidateJsSideCache(Arc<InvalidateJsSideCacheFn>);
+
+impl InvalidateJsSideCache {
+  pub fn new(f: Arc<InvalidateJsSideCacheFn>) -> Self {
+    Self(f)
+  }
+
+  pub async fn call(&self) -> anyhow::Result<()> {
+    self.0().await
+  }
+}

--- a/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
@@ -9,6 +9,7 @@ pub mod hash_characters;
 pub mod hmr_options;
 pub mod inject_import;
 pub mod input_item;
+pub mod invalidate_js_side_cache;
 pub mod is_external;
 pub mod jsx;
 pub mod make_absolute_externals_relative;

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -26,8 +26,8 @@ use super::{
 };
 use crate::{
   DeferSyncScanDataOption, EmittedAsset, EsModuleFlag, FilenameTemplate, GlobalsOutputOption,
-  HashCharacters, InjectImport, InputItem, MakeAbsoluteExternalsRelative, ModuleType,
-  RollupPreRenderedAsset,
+  HashCharacters, InjectImport, InputItem, InvalidateJsSideCache, MakeAbsoluteExternalsRelative,
+  ModuleType, RollupPreRenderedAsset,
 };
 
 #[allow(clippy::struct_excessive_bools)] // Using raw booleans is more clear in this case
@@ -90,6 +90,7 @@ pub struct NormalizedBundlerOptions {
   pub defer_sync_scan_data: Option<DeferSyncScanDataOption>,
   pub transform_options: TransformOptions,
   pub make_absolute_externals_relative: MakeAbsoluteExternalsRelative,
+  pub invalidate_js_side_cache: Option<InvalidateJsSideCache>,
 }
 
 // This is only used for testing
@@ -148,6 +149,7 @@ impl Default for NormalizedBundlerOptions {
       transform_options: Default::default(),
       make_absolute_externals_relative: Default::default(),
       jsx: Default::default(),
+      invalidate_js_side_cache: Default::default(),
     }
   }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -30,6 +30,7 @@ pub mod bundler_options {
       hmr_options::HmrOptions,
       inject_import::InjectImport,
       input_item::InputItem,
+      invalidate_js_side_cache::InvalidateJsSideCache,
       is_external::IsExternal,
       jsx::{Jsx, NormalizedJsxOptions},
       make_absolute_externals_relative::MakeAbsoluteExternalsRelative,

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -419,6 +419,7 @@ export interface BindingInputOptions {
   deferSyncScanData?: undefined | (() => BindingDeferSyncScanData[])
   makeAbsoluteExternalsRelative?: BindingMakeAbsoluteExternalsRelative
   debug?: BindingDebugOptions
+  invalidateJsSideCache?: () => void
 }
 
 export interface BindingIsolatedDeclarationPluginConfig {

--- a/packages/rolldown/src/plugin/plugin-context-data.ts
+++ b/packages/rolldown/src/plugin/plugin-context-data.ts
@@ -9,7 +9,7 @@ export class PluginContextData {
   moduleOptionMap: Map<string, ModuleOptions> = new Map();
   resolveOptionsMap: Map<number, PluginContextResolveOptions> = new Map();
   loadModulePromiseMap: Map<string, Promise<void>> = new Map();
-  meta: RenderedChunkMeta | null = null;
+  renderedChunkMeta: RenderedChunkMeta | null = null;
 
   updateModuleOption(id: string, option: ModuleOptions): ModuleOptions {
     const existing = this.moduleOptionMap.get(id);
@@ -92,10 +92,15 @@ export class PluginContextData {
   }
 
   setRenderChunkMeta(meta: RenderedChunkMeta): void {
-    this.meta = meta;
+    this.renderedChunkMeta = meta;
   }
 
   getRenderChunkMeta(): RenderedChunkMeta | null {
-    return this.meta;
+    return this.renderedChunkMeta;
+  }
+
+  clear(): void {
+    this.renderedChunkMeta = null;
+    this.loadModulePromiseMap.clear();
   }
 }

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -98,6 +98,7 @@ export function bindingifyInputOptions(
       inputOptions.makeAbsoluteExternalsRelative,
     ),
     debug: inputOptions.debug,
+    invalidateJsSideCache: pluginContextData.clear.bind(pluginContextData),
   };
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The PluginContextData has some cache.
- The `renderChunk#meta#chunks` binding cache
- The `loadModulePromiseMap` stored load successful module

The cache need to clear at hmr or watch rebuild.
- The hmr need to call js side `bundle.write()`.
- The watch rebuild need to call rust `bundle.bundle_write`.

Here using a binding function to do it at bundle finished.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
