### PR TITLE
refactor(rolldown_plugin_transform): port `loadTsconfigJsonForFile` logic from `rolldown-vite`

### DIFF
--- a/crates/rolldown_plugin/src/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context.rs
@@ -52,6 +52,10 @@ impl PluginContext {
   pub fn options(&self) -> &NormalizedBundlerOptions {
     &self.options
   }
+
+  pub fn resolver(&self) -> &Resolver {
+    &self.resolver
+  }
 }
 
 impl Deref for PluginContext {


### PR DESCRIPTION
### Description

Related to #3968
