### PR TITLE
docs: fix light mode modal link

### DIFF
--- a/docs/.vitepress/theme/components/RolldownVideoModal.vue
+++ b/docs/.vitepress/theme/components/RolldownVideoModal.vue
@@ -129,7 +129,6 @@ onKeyStroke('Escape', () => {
   font-weight: bold;
   color: var(--vp-c-text-1);
   & a {
-    color: white;
     transition: color 0.25s;
     display: inline;
     &:hover {


### PR DESCRIPTION
The link to the `rolldown-vite` guide was not visible in light mode.

Reported by @AndrewBogdanovTSS