### PR TITLE
fix: typo in example code

### DIFF
--- a/docs/guide/in-depth/tla-in-rolldown.md
+++ b/docs/guide/in-depth/tla-in-rolldown.md
@@ -25,7 +25,7 @@ A real-world example would looks like
 import { bar } from './sync.js';
 import { foo1 } from './tla1.js';
 import { foo2 } from './tla2.js';
-console.log(foo, foo2, bar);
+console.log(foo1, foo2, bar);
 
 // tla1.js
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Change 'foo' to 'foo1' in example code.