### PR TITLE
refactor(rust): simplify `match` branch logic

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -97,13 +97,15 @@ impl Generator for EcmaGenerator {
       ctx.chunk.pre_rendered_chunk.as_ref().expect("Should have pre-rendered chunk"),
       ctx.chunk_graph,
     ));
-    let hashbang = match ctx.chunk.user_defined_entry_module(&ctx.link_output.module_table) {
-      Some(normal_module) => normal_module
-        .ecma_view
-        .hashbang_range
-        .map(|range| &normal_module.source[range.start as usize..range.end as usize]),
-      None => None,
-    };
+
+    let hashbang = ctx.chunk.user_defined_entry_module(&ctx.link_output.module_table).and_then(
+      |normal_module| {
+        normal_module
+          .ecma_view
+          .hashbang_range
+          .map(|range| &normal_module.source[range.start as usize..range.end as usize])
+      },
+    );
 
     let banner = {
       let injection = match ctx.options.banner.as_ref() {

--- a/crates/string_wizard/src/magic_string/mod.rs
+++ b/crates/string_wizard/src/magic_string/mod.rs
@@ -212,13 +212,10 @@ impl<'a> Iterator for IterChunks<'a> {
   type Item = &'a Chunk<'a>;
 
   fn next(&mut self) -> Option<Self::Item> {
-    match self.next {
-      None => None,
-      Some(idx) => {
-        let chunk = &self.chunks[idx];
-        self.next = chunk.next;
-        Some(chunk)
-      }
-    }
+    self.next.map(|idx| {
+      let chunk = &self.chunks[idx];
+      self.next = chunk.next;
+      chunk
+    })
   }
 }


### PR DESCRIPTION
### Description

Simplify `match` logic using syntactic sugar.