### PR TITLE
refactor(rolldown_plugin_transform): unify some `typescript` options from custom config and tsconfig

### DIFF
--- a/crates/rolldown_plugin_transform/src/types/mod.rs
+++ b/crates/rolldown_plugin_transform/src/types/mod.rs
@@ -1,3 +1,4 @@
 pub mod decorator_options;
 pub mod jsx_options;
 pub mod transform_options;
+pub mod typescript_options;

--- a/crates/rolldown_plugin_transform/src/types/transform_options.rs
+++ b/crates/rolldown_plugin_transform/src/types/transform_options.rs
@@ -1,6 +1,9 @@
 use itertools::Either;
 
-use super::{decorator_options::DecoratorOptions, jsx_options::JsxOptions};
+use super::{
+  decorator_options::DecoratorOptions, jsx_options::JsxOptions,
+  typescript_options::TypeScriptOptions,
+};
 
 #[derive(Debug, Default, Clone)]
 pub struct TransformOptions {
@@ -9,4 +12,6 @@ pub struct TransformOptions {
   pub jsx: Option<Either<String, JsxOptions>>,
 
   pub decorator: Option<DecoratorOptions>,
+
+  pub typescript: Option<TypeScriptOptions>,
 }

--- a/crates/rolldown_plugin_transform/src/types/typescript_options.rs
+++ b/crates/rolldown_plugin_transform/src/types/typescript_options.rs
@@ -1,0 +1,40 @@
+use itertools::Either;
+
+#[derive(Debug, Default, Clone)]
+pub struct TypeScriptOptions {
+  pub jsx_pragma: Option<String>,
+  pub jsx_pragma_frag: Option<String>,
+  pub only_remove_type_imports: Option<bool>,
+  pub allow_namespaces: Option<bool>,
+  pub allow_declare_fields: Option<bool>,
+  /// Also generate a `.d.ts` declaration file for TypeScript files.
+  ///
+  /// The source file must be compliant with all
+  /// [`isolatedDeclarations`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#isolated-declarations)
+  /// requirements.
+  ///
+  /// @default false
+  pub declaration: Option<IsolatedDeclarationsOptions>,
+  /// Rewrite or remove TypeScript import/export declaration extensions.
+  ///
+  /// - When set to `rewrite`, it will change `.ts`, `.mts`, `.cts` extensions to `.js`, `.mjs`, `.cjs` respectively.
+  /// - When set to `remove`, it will remove `.ts`/`.mts`/`.cts`/`.tsx` extension entirely.
+  /// - When set to `true`, it's equivalent to `rewrite`.
+  /// - When set to `false` or omitted, no changes will be made to the extensions.
+  ///
+  /// @default false
+  pub rewrite_import_extensions: Option<Either<bool, String>>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct IsolatedDeclarationsOptions {
+  /// Do not emit declarations for code that has an @internal annotation in its JSDoc comment.
+  /// This is an internal compiler option; use at your own risk, because the compiler does not check that the result is valid.
+  ///
+  /// Default: `false`
+  ///
+  /// See <https://www.typescriptlang.org/tsconfig/#stripInternal>
+  pub strip_internal: Option<bool>,
+
+  pub sourcemap: Option<bool>,
+}

--- a/crates/rolldown_plugin_transform/src/utils.rs
+++ b/crates/rolldown_plugin_transform/src/utils.rs
@@ -158,6 +158,21 @@ impl TransformPlugin {
 
           transform_options.decorator = Some(decorator);
         }
+
+        // | preserveValueImports | importsNotUsedAsValues | verbatimModuleSyntax | onlyRemoveTypeImports |
+        // | -------------------- | ---------------------- | -------------------- |---------------------- |
+        // | false                | remove                 | false                | false                 |
+        // | false                | preserve, error        | -                    | -                     |
+        // | true                 | remove                 | -                    | -                     |
+        // | true                 | preserve, error        | true                 | true                  |
+        // TODO(shulaoda): port the rest logic of the `typescript` option
+        if compiler_options.verbatim_module_syntax.is_some() {
+          let mut typescript = transform_options.typescript.unwrap_or_default();
+
+          typescript.only_remove_type_imports = compiler_options.verbatim_module_syntax;
+
+          transform_options.typescript = Some(typescript);
+        }
       }
     }
 

--- a/cspell.json
+++ b/cspell.json
@@ -187,6 +187,7 @@
     "sfnt",
     "shaked",
     "sharedworker",
+    "shulaoda",
     "simd",
     "simdutf",
     "smallvec",


### PR DESCRIPTION
### Description

Related to #3968

Some fields are missing in `compiler_options`, and I’m going to submit a PR to `oxc-resolver` to address this.