### PR TITLE
chore: Revert "chore: add `dprint` to onlyBuiltDependencies"

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,3 @@ packages:
   - examples/module-federation/*
   - scripts
   - crates/rolldown/tests/rolldown/topics/npm_packages
-
-onlyBuiltDependencies:
-  - dprint


### PR DESCRIPTION
Reverts rolldown/rolldown#4162

This cause publish CI failed on freebsd target: https://github.com/rolldown/rolldown/actions/runs/14526940029/job/40760153154.