### PR TITLE
fix: deconfilct chunk name after name generated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2921,6 +2921,7 @@ dependencies = [
  "futures",
  "indexmap",
  "infer",
+ "itoa",
  "memchr",
  "mime",
  "nom",
@@ -2933,6 +2934,7 @@ dependencies = [
  "rustc-hash",
  "serde_json",
  "simdutf8",
+ "sugar_path",
  "xxhash-rust",
 ]
 

--- a/crates/rolldown/tests/rolldown/function/chunk_filenames_function/a/foo.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_filenames_function/a/foo.js
@@ -1,0 +1,1 @@
+console.log('a/foo')

--- a/crates/rolldown/tests/rolldown/function/chunk_filenames_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/chunk_filenames_function/artifacts.snap
@@ -1,0 +1,33 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+
+//#region entry.js
+import("./foo.js");
+import("./foo2.js");
+
+//#endregion
+```
+## foo.js
+
+```js
+
+//#region a/foo.js
+console.log("a/foo");
+
+//#endregion
+```
+## foo2.js
+
+```js
+
+//#region b/foo.js
+console.log("b/foo");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/function/chunk_filenames_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/chunk_filenames_function/artifacts.snap
@@ -6,7 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-
 //#region entry.js
 import("./foo.js");
 import("./foo2.js");
@@ -16,7 +15,6 @@ import("./foo2.js");
 ## foo.js
 
 ```js
-
 //#region a/foo.js
 console.log("a/foo");
 
@@ -25,7 +23,6 @@ console.log("a/foo");
 ## foo2.js
 
 ```js
-
 //#region b/foo.js
 console.log("b/foo");
 

--- a/crates/rolldown/tests/rolldown/function/chunk_filenames_function/b/foo.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_filenames_function/b/foo.js
@@ -1,0 +1,1 @@
+console.log('b/foo')

--- a/crates/rolldown/tests/rolldown/function/chunk_filenames_function/entry.js
+++ b/crates/rolldown/tests/rolldown/function/chunk_filenames_function/entry.js
@@ -1,0 +1,2 @@
+import('./a/foo.js');
+import('./b/foo.js');

--- a/crates/rolldown/tests/rolldown/function/chunk_filenames_function/mod.rs
+++ b/crates/rolldown/tests/rolldown/function/chunk_filenames_function/mod.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use rolldown::{BundlerOptions, InputItem};
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test() {
+  let cwd = abs_file_dir!();
+
+  IntegrationTest::new(TestMeta { expect_error: false, ..Default::default() })
+    .run(BundlerOptions {
+      input: Some(vec![InputItem {
+        name: Some("entry".to_string()),
+        import: "entry.js".to_string(),
+      }]),
+      cwd: Some(cwd),
+      chunk_filenames: Some(rolldown::ChunkFilenamesOutputOption::Fn(Arc::new(|chunk| {
+        let name = format!("{}.js", chunk.name);
+        Box::pin(async move { Ok(name) })
+      }))),
+      ..Default::default()
+    })
+    .await;
+}

--- a/crates/rolldown/tests/rolldown/function/mod.rs
+++ b/crates/rolldown/tests/rolldown/function/mod.rs
@@ -1,1 +1,2 @@
 pub mod asset_filenames;
+pub mod chunk_filenames_function;

--- a/crates/rolldown/tests/rolldown/issues/4129/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4129/_config.json
@@ -1,4 +1,5 @@
 {
+  "expectExecuted": false,
   "config": {
     "experimental": {
       "hmr": {}

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -31,6 +31,7 @@ fast-glob = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 infer = { workspace = true }
+itoa = { workspace = true }
 memchr = { workspace = true }
 mime = { workspace = true }
 nom = { workspace = true }
@@ -42,6 +43,7 @@ rolldown_std_utils = { workspace = true }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 simdutf8 = { workspace = true }
+sugar_path = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/rolldown_utils/src/lib.rs
+++ b/crates/rolldown_utils/src/lib.rs
@@ -22,6 +22,7 @@ pub mod concat_string;
 pub mod hash_placeholder;
 pub mod index_vec_ext;
 pub mod js_regex;
+pub mod make_unique_name;
 pub mod pattern_filter;
 pub mod replace_all_placeholder;
 pub mod unique_arc;

--- a/crates/rolldown_utils/src/make_unique_name.rs
+++ b/crates/rolldown_utils/src/make_unique_name.rs
@@ -1,0 +1,72 @@
+use std::{collections::hash_map::Entry, ffi::OsStr};
+
+use arcstr::ArcStr;
+use rustc_hash::FxHashMap;
+use sugar_path::SugarPath;
+
+use crate::concat_string;
+
+#[allow(clippy::implicit_hasher)]
+pub fn make_unique_name(name: &ArcStr, used_name_counts: &mut FxHashMap<ArcStr, u32>) -> ArcStr {
+  let mut candidate = name.clone();
+  let extension = name
+    .as_path()
+    .extension()
+    .and_then(OsStr::to_str)
+    .map(|e| concat_string!(".", e))
+    .unwrap_or_default();
+  let file_name = &name[..name.len() - extension.len()];
+  loop {
+    match used_name_counts.entry(candidate.clone()) {
+      Entry::Occupied(mut occ) => {
+        // This name is already used
+        let next_count = *occ.get();
+        occ.insert(next_count + 1);
+        candidate = ArcStr::from(concat_string!(
+          file_name,
+          itoa::Buffer::new().format(next_count),
+          extension
+        ));
+      }
+      Entry::Vacant(vac) => {
+        // This is the first time we see this name
+        let name = vac.key().clone();
+        vac.insert(2);
+        break name;
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test() {
+    let mut used_name_counts = FxHashMap::default();
+
+    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &mut used_name_counts);
+    assert_eq!(unique_name.as_str(), "foo.js");
+
+    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &mut used_name_counts);
+    assert_eq!(unique_name.as_str(), "foo2.js");
+
+    let unique_name = make_unique_name(&ArcStr::from("foo2.js"), &mut used_name_counts);
+    assert_eq!(unique_name.as_str(), "foo22.js");
+  }
+
+  #[test]
+  fn test2() {
+    let mut used_name_counts = FxHashMap::default();
+
+    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &mut used_name_counts);
+    assert_eq!(unique_name.as_str(), "foo.js");
+
+    let unique_name = make_unique_name(&ArcStr::from("foo2.js"), &mut used_name_counts);
+    assert_eq!(unique_name.as_str(), "foo2.js");
+
+    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &mut used_name_counts);
+    assert_eq!(unique_name.as_str(), "foo3.js");
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
close https://github.com/rolldown/rolldown/issues/4177.

Here follow rollup deconfilct chunk name after name generated, it is used with `bundle` as `used_name_counts`, so here merge the js/css to one map.ref https://github.com/rollup/rollup/blob/master/src/Chunk.ts#L588

Extract it to an isolated function because the asset also could be using it.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
