### PR TITLE
perf: skip empty js hook for js plugin

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -34,6 +34,7 @@ pub type BindingPluginOrParallelJsPluginPlaceholder =
 #[derive(Default)]
 pub struct BindingPluginOptions {
   pub name: String,
+  pub hook_usage: u32,
   #[napi(
     ts_type = "(ctx: BindingPluginContext, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable>"
   )]

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -540,7 +540,7 @@ impl Plugin for JsPlugin {
   }
 
   fn register_hook_usage(&self) -> HookUsage {
-    HookUsage::all()
+    HookUsage::from_bits(self.inner.hook_usage).expect("Failed to register hook usage")
   }
 }
 

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -366,7 +366,7 @@ impl PluginDriver {
     for (plugin_idx, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_build_end_meta)
     {
-      if !self.plugin_usage_vec[plugin_idx].contains(HookUsage::Transform) {
+      if !self.plugin_usage_vec[plugin_idx].contains(HookUsage::BuildEnd) {
         continue;
       }
       plugin

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -587,6 +587,7 @@ export interface BindingPluginHookMeta {
 
 export interface BindingPluginOptions {
   name: string
+  hookUsage: number
   buildStart?: (ctx: BindingPluginContext, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable>
   buildStartMeta?: BindingPluginHookMeta
   resolveId?: (ctx: BindingPluginContext, specifier: string, importer: Nullable<string>, options: BindingHookResolveIdExtraArgs) => MaybePromise<VoidNullable<BindingHookResolveIdOutput>>

--- a/packages/rolldown/src/plugin/bindingify-plugin.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin.ts
@@ -31,6 +31,7 @@ import {
   bindingifyCloseWatcher,
   bindingifyWatchChange,
 } from './bindingify-watch-hooks';
+import { extractHookUsage } from './generated/hook-usage';
 import type { Plugin, RolldownPlugin } from './index';
 import { PluginContextData } from './plugin-context-data';
 
@@ -137,6 +138,7 @@ export function bindingifyPlugin(
 
   const { plugin: closeWatcher, meta: closeWatcherMeta } =
     bindingifyCloseWatcher(args);
+  let hookUsage = extractHookUsage(plugin).inner();
   const result: BindingPluginOptions = {
     // The plugin name already normalized at `normalizePlugins`, see `packages/rolldown/src/utils/normalize-plugin-option.ts`
     name: plugin.name!,
@@ -184,6 +186,7 @@ export function bindingifyPlugin(
     watchChangeMeta,
     closeWatcher,
     closeWatcherMeta,
+    hookUsage,
   };
   return wrapHandlers(result);
 }

--- a/packages/rolldown/src/plugin/generated/hook-usage.ts
+++ b/packages/rolldown/src/plugin/generated/hook-usage.ts
@@ -26,7 +26,8 @@ export enum HookUsageKind {
 }
 
 export class HookUsage {
-  constructor(public bitflag: bigint) {}
+  private bitflag: bigint = BigInt(0);
+  constructor() {}
 
   union(kind: HookUsageKind): void {
     this.bitflag |= BigInt(kind);
@@ -38,4 +39,91 @@ export class HookUsage {
   inner(): number {
     return Number(this.bitflag);
   }
+}
+
+import { Plugin } from '../..';
+export function extractHookUsage(plugin: Plugin): HookUsage {
+  let hookUsage = new HookUsage();
+
+  if (plugin.buildStart) {
+    hookUsage.union(HookUsageKind.buildStart);
+  }
+
+  if (plugin.resolveId) {
+    hookUsage.union(HookUsageKind.resolveId);
+  }
+
+  if (plugin.resolveDynamicImport) {
+    hookUsage.union(HookUsageKind.resolveDynamicImport);
+  }
+
+  if (plugin.load) {
+    hookUsage.union(HookUsageKind.load);
+  }
+
+  if (plugin.transform) {
+    hookUsage.union(HookUsageKind.transform);
+  }
+
+  if (plugin.moduleParsed) {
+    hookUsage.union(HookUsageKind.moduleParsed);
+  }
+
+  if (plugin.buildEnd) {
+    hookUsage.union(HookUsageKind.buildEnd);
+  }
+
+  if (plugin.renderStart) {
+    hookUsage.union(HookUsageKind.renderStart);
+  }
+
+  if (plugin.renderError) {
+    hookUsage.union(HookUsageKind.renderError);
+  }
+
+  if (plugin.renderChunk) {
+    hookUsage.union(HookUsageKind.renderChunk);
+  }
+
+  if (plugin.augmentChunkHash) {
+    hookUsage.union(HookUsageKind.augmentChunkHash);
+  }
+
+  if (plugin.generateBundle) {
+    hookUsage.union(HookUsageKind.generateBundle);
+  }
+
+  if (plugin.writeBundle) {
+    hookUsage.union(HookUsageKind.writeBundle);
+  }
+
+  if (plugin.closeBundle) {
+    hookUsage.union(HookUsageKind.closeBundle);
+  }
+
+  if (plugin.watchChange) {
+    hookUsage.union(HookUsageKind.watchChange);
+  }
+
+  if (plugin.closeWatcher) {
+    hookUsage.union(HookUsageKind.closeWatcher);
+  }
+
+  if (plugin.banner) {
+    hookUsage.union(HookUsageKind.banner);
+  }
+
+  if (plugin.footer) {
+    hookUsage.union(HookUsageKind.footer);
+  }
+
+  if (plugin.intro) {
+    hookUsage.union(HookUsageKind.intro);
+  }
+
+  if (plugin.outro) {
+    hookUsage.union(HookUsageKind.outro);
+  }
+
+  return hookUsage;
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->


## With 1000 empty plugin(only have name), use `10000` case, 
#### Main 
```bash
Benchmark 1: node --run build:rolldown
  Time (mean ± σ):     953.0 ms ±   6.0 ms    [User: 15170.3 ms, System: 875.5 ms]
  Range (min … max):   947.8 ms … 959.5 ms    3 runs
```

chrome-trace json size: 
![image](https://github.com/user-attachments/assets/459f8b51-beec-4d6e-991e-511a9fe859cd)
This is only partial trace json file, I need to terminate it because it stuck my computer.

#### This branch
```bash
Benchmark 1: node --run build:rolldown
  Time (mean ± σ):     584.0 ms ±   6.7 ms    [User: 2775.2 ms, System: 1057.3 ms]
  Range (min … max):   577.2 ms … 590.5 ms    3 runs
```
Tracing chrome-json: 161MB


## With zero plugin
#### Main
```bash
Benchmark 1: node --run build:rolldown
  Time (mean ± σ):     548.0 ms ±   6.9 ms    [User: 2439.8 ms, System: 926.7 ms]
  Range (min … max):   542.4 ms … 555.7 ms    3 runs
```

#### This branch
```bash
Benchmark 1: node --run build:rolldown
  Time (mean ± σ):     537.3 ms ±  12.8 ms    [User: 2450.7 ms, System: 1034.6 ms]
  Range (min … max):   527.7 ms … 551.9 ms    3 runs
```




<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
