### PR TITLE
refactor: deconflict asset file names

### DIFF
--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -11,7 +11,7 @@ use arcstr::ArcStr;
 use rolldown_rstr::Rstr;
 use rolldown_std_utils::PathExt;
 use rolldown_utils::{
-  BitSet, hash_placeholder::HashPlaceholderGenerator, indexmap::FxIndexMap,
+  BitSet, dashmap::FxDashMap, hash_placeholder::HashPlaceholderGenerator, indexmap::FxIndexMap,
   make_unique_name::make_unique_name,
 };
 use rustc_hash::FxHashMap;
@@ -142,7 +142,7 @@ impl Chunk {
     rollup_pre_rendered_chunk: &RollupPreRenderedChunk,
     chunk_name: &ArcStr,
     hash_placeholder_generator: &mut HashPlaceholderGenerator,
-    used_name_counts: &mut FxHashMap<ArcStr, u32>,
+    used_name_counts: &FxDashMap<ArcStr, u32>,
   ) -> anyhow::Result<PreliminaryFilename> {
     if let Some(file) = &options.file {
       let basename = PathBuf::from(file)
@@ -188,7 +188,7 @@ impl Chunk {
     rollup_pre_rendered_chunk: &RollupPreRenderedChunk,
     chunk_name: &ArcStr,
     hash_placeholder_generator: &mut HashPlaceholderGenerator,
-    used_name_counts: &mut FxHashMap<ArcStr, u32>,
+    used_name_counts: &FxDashMap<ArcStr, u32>,
   ) -> anyhow::Result<PreliminaryFilename> {
     if let Some(file) = &options.file {
       let mut file = PathBuf::from(file);

--- a/crates/rolldown_utils/src/make_unique_name.rs
+++ b/crates/rolldown_utils/src/make_unique_name.rs
@@ -1,13 +1,12 @@
-use std::{collections::hash_map::Entry, ffi::OsStr};
+use std::ffi::OsStr;
 
 use arcstr::ArcStr;
-use rustc_hash::FxHashMap;
+use dashmap::Entry;
 use sugar_path::SugarPath;
 
-use crate::concat_string;
+use crate::{concat_string, dashmap::FxDashMap};
 
-#[allow(clippy::implicit_hasher)]
-pub fn make_unique_name(name: &ArcStr, used_name_counts: &mut FxHashMap<ArcStr, u32>) -> ArcStr {
+pub fn make_unique_name(name: &ArcStr, used_name_counts: &FxDashMap<ArcStr, u32>) -> ArcStr {
   let mut candidate = name.clone();
   let extension = name
     .as_path()
@@ -44,29 +43,29 @@ mod tests {
 
   #[test]
   fn test() {
-    let mut used_name_counts = FxHashMap::default();
+    let used_name_counts = FxDashMap::default();
 
-    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &mut used_name_counts);
+    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &used_name_counts);
     assert_eq!(unique_name.as_str(), "foo.js");
 
-    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &mut used_name_counts);
+    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &used_name_counts);
     assert_eq!(unique_name.as_str(), "foo2.js");
 
-    let unique_name = make_unique_name(&ArcStr::from("foo2.js"), &mut used_name_counts);
+    let unique_name = make_unique_name(&ArcStr::from("foo2.js"), &used_name_counts);
     assert_eq!(unique_name.as_str(), "foo22.js");
   }
 
   #[test]
   fn test2() {
-    let mut used_name_counts = FxHashMap::default();
+    let used_name_counts = FxDashMap::default();
 
-    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &mut used_name_counts);
+    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &used_name_counts);
     assert_eq!(unique_name.as_str(), "foo.js");
 
-    let unique_name = make_unique_name(&ArcStr::from("foo2.js"), &mut used_name_counts);
+    let unique_name = make_unique_name(&ArcStr::from("foo2.js"), &used_name_counts);
     assert_eq!(unique_name.as_str(), "foo2.js");
 
-    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &mut used_name_counts);
+    let unique_name = make_unique_name(&ArcStr::from("foo.js"), &used_name_counts);
     assert_eq!(unique_name.as_str(), "foo3.js");
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
using `make_unique_name` to deconflict asset file names.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
