### PR TITLE
fix(rust): crashes with object containing `shorthand` to `NaN`

### DIFF
--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -340,14 +340,17 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
   fn visit_object_property(&mut self, prop: &mut ast::ObjectProperty<'ast>) {
     // Ensure `{ a }` would be rewritten to `{ a: a$1 }` instead of `{ a$1 }`
     if prop.shorthand {
-      let ast::Expression::Identifier(id_ref) = &mut prop.value else {
-        unreachable!("Shorthand property value should be an identifier")
-      };
-      if let Some(expr) = self.generate_finalized_expr_for_reference(id_ref, false) {
-        prop.value = expr;
-        prop.shorthand = false;
-      } else {
-        id_ref.reference_id.get_mut().take();
+      // Issue: <https://github.com/rolldown/rolldown/issues/4196>
+      if let ast::Expression::Identifier(id_ref) = &mut prop.value {
+        match self.generate_finalized_expr_for_reference(id_ref, false) {
+          Some(expr) => {
+            prop.value = expr;
+            prop.shorthand = false;
+          }
+          None => {
+            id_ref.reference_id.get_mut().take();
+          }
+        }
       }
     }
 

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -340,7 +340,6 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
   fn visit_object_property(&mut self, prop: &mut ast::ObjectProperty<'ast>) {
     // Ensure `{ a }` would be rewritten to `{ a: a$1 }` instead of `{ a$1 }`
     if prop.shorthand {
-      // Issue: <https://github.com/rolldown/rolldown/issues/4196>
       if let ast::Expression::Identifier(id_ref) = &mut prop.value {
         match self.generate_finalized_expr_for_reference(id_ref, false) {
           Some(expr) => {

--- a/crates/rolldown/tests/rolldown/issues/4196/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4196/_config.json
@@ -1,0 +1,3 @@
+{
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/4196/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4196/artifacts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+let a = 1;
+console.log(a);
+function main_default() {
+	const a$1 = 2;
+	console.log({
+		a: a$1,
+		NaN: NaN
+	});
+}
+
+//#endregion
+export { main_default as default };
+```

--- a/crates/rolldown/tests/rolldown/issues/4196/main.js
+++ b/crates/rolldown/tests/rolldown/issues/4196/main.js
@@ -1,0 +1,6 @@
+let a = 1
+console.log(a)
+export default function() {
+  const a = 2;
+  console.log({ a, NaN })
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4666,6 +4666,10 @@ expression: output
 
 - main-!~{000}~.js => main-Bl27OrDc.js
 
+# tests/rolldown/issues/4196
+
+- main-!~{000}~.js => main-Ck3tZAk1.js
+
 # tests/rolldown/misc/ambiguous_star_export
 
 - main-!~{000}~.js => main-Brk4weCb.js


### PR DESCRIPTION
### Description

Closes #4196

Related to #4123 