### PR TITLE
chore(examples/par-plugin): correct tsconfig `extends` path

### DIFF
--- a/examples/par-plugin/tsconfig.json
+++ b/examples/par-plugin/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "../../tsconfig.pure-js.json",
+  "extends": "../../tsconfig.json",
   "include": ["./**/*.js", "./**/*.mjs", "./**/*.cjs", "./**/*.d.ts"]
 }


### PR DESCRIPTION
### Description

The path `../../tsconfig.pure-js.json` is invalid because the file does not exist.