### PR TITLE
perf: make js plugin tracing more accurate

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -228,8 +228,7 @@ impl Plugin for JsPlugin {
     _normal_module: &NormalModule,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.module_parsed {
-      cb.await_call((ctx.clone().into(), BindingModuleInfo::new(module_info)).into())
-        .await?;
+      cb.await_call((ctx.clone().into(), BindingModuleInfo::new(module_info)).into()).await?;
     }
     Ok(())
   }
@@ -409,10 +408,9 @@ impl Plugin for JsPlugin {
     chunk: Arc<rolldown_common::RollupRenderedChunk>,
   ) -> rolldown_plugin::HookAugmentChunkHashReturn {
     match &self.augment_chunk_hash {
-      Some(cb) => Ok(
-        cb.await_call((ctx.clone().into(), BindingRenderedChunk::new(chunk)).into())
-          .await?,
-      ),
+      Some(cb) => {
+        Ok(cb.await_call((ctx.clone().into(), BindingRenderedChunk::new(chunk)).into()).await?)
+      }
       _ => Ok(None),
     }
   }
@@ -503,8 +501,7 @@ impl Plugin for JsPlugin {
     ctx: &rolldown_plugin::PluginContext,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.close_bundle {
-      cb.await_call(FnArgs { data: (ctx.clone().into(),) })
-        .await?;
+      cb.await_call(FnArgs { data: (ctx.clone().into(),) }).await?;
     }
     Ok(())
   }
@@ -520,8 +517,7 @@ impl Plugin for JsPlugin {
     event: rolldown_common::WatcherChangeKind,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.watch_change {
-      cb.await_call((ctx.clone().into(), path.to_string(), event.to_string()).into())
-        .await?;
+      cb.await_call((ctx.clone().into(), path.to_string(), event.to_string()).into()).await?;
     }
     Ok(())
   }
@@ -535,8 +531,7 @@ impl Plugin for JsPlugin {
     ctx: &rolldown_plugin::PluginContext,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.close_watcher {
-      cb.await_call(FnArgs { data: (ctx.clone().into(),) })
-        .await?;
+      cb.await_call(FnArgs { data: (ctx.clone().into(),) }).await?;
     }
     Ok(())
   }

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -13,6 +13,7 @@ use rolldown_common::NormalModule;
 use rolldown_plugin::{__inner::SharedPluginable, HookUsage, Plugin, typedmap::TypedMapKey};
 use rolldown_utils::pattern_filter::{self};
 use std::{borrow::Cow, ops::Deref, path::Path, sync::Arc};
+use tracing::{Instrument, debug_span};
 
 use super::{
   BindingPluginOptions,
@@ -227,7 +228,8 @@ impl Plugin for JsPlugin {
     _normal_module: &NormalModule,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.module_parsed {
-      cb.await_call((ctx.clone().into(), BindingModuleInfo::new(module_info)).into()).await?;
+      cb.await_call((ctx.clone().into(), BindingModuleInfo::new(module_info)).into())
+        .await?;
     }
     Ok(())
   }
@@ -407,9 +409,10 @@ impl Plugin for JsPlugin {
     chunk: Arc<rolldown_common::RollupRenderedChunk>,
   ) -> rolldown_plugin::HookAugmentChunkHashReturn {
     match &self.augment_chunk_hash {
-      Some(cb) => {
-        Ok(cb.await_call((ctx.clone().into(), BindingRenderedChunk::new(chunk)).into()).await?)
-      }
+      Some(cb) => Ok(
+        cb.await_call((ctx.clone().into(), BindingRenderedChunk::new(chunk)).into())
+          .await?,
+      ),
       _ => Ok(None),
     }
   }
@@ -500,7 +503,8 @@ impl Plugin for JsPlugin {
     ctx: &rolldown_plugin::PluginContext,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.close_bundle {
-      cb.await_call(FnArgs { data: (ctx.clone().into(),) }).await?;
+      cb.await_call(FnArgs { data: (ctx.clone().into(),) })
+        .await?;
     }
     Ok(())
   }
@@ -516,7 +520,8 @@ impl Plugin for JsPlugin {
     event: rolldown_common::WatcherChangeKind,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.watch_change {
-      cb.await_call((ctx.clone().into(), path.to_string(), event.to_string()).into()).await?;
+      cb.await_call((ctx.clone().into(), path.to_string(), event.to_string()).into())
+        .await?;
     }
     Ok(())
   }
@@ -530,7 +535,8 @@ impl Plugin for JsPlugin {
     ctx: &rolldown_plugin::PluginContext,
   ) -> rolldown_plugin::HookNoopReturn {
     if let Some(cb) = &self.close_watcher {
-      cb.await_call(FnArgs { data: (ctx.clone().into(),) }).await?;
+      cb.await_call(FnArgs { data: (ctx.clone().into(),) })
+        .await?;
     }
     Ok(())
   }

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -13,7 +13,6 @@ use rolldown_common::NormalModule;
 use rolldown_plugin::{__inner::SharedPluginable, HookUsage, Plugin, typedmap::TypedMapKey};
 use rolldown_utils::pattern_filter::{self};
 use std::{borrow::Cow, ops::Deref, path::Path, sync::Arc};
-use tracing::{Instrument, debug_span};
 
 use super::{
   BindingPluginOptions,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Temp drop tracing span for native builtin plugin 
Case 10000

## Before 
trace-json: 1.3GB
![image](https://github.com/user-attachments/assets/4e470920-849f-4f95-a3a9-730353566f56)

## After 
trace-json: 600MB
![image](https://github.com/user-attachments/assets/5a149a77-6edf-4223-9874-9f167ee4046b)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
