### PR TITLE
refactor(rolldown_plugin_transform): port the rest logic of the `typescript` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "dashmap",
  "derive_more",
  "futures",
+ "itertools",
  "mimalloc-safe",
  "napi",
  "napi-build",

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -21,6 +21,7 @@ async-channel = { workspace = true }
 dashmap = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }
+itertools = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 oxc = { workspace = true }

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -1,8 +1,10 @@
 use derive_more::Debug;
+use napi::Either;
 use napi::JsUnknown;
 use napi::bindgen_prelude::FnArgs;
 use napi::bindgen_prelude::FromNapiValue;
 use napi_derive::napi;
+use oxc_transform_napi::TransformOptions;
 use rolldown_plugin::__inner::Pluginable;
 use rolldown_plugin_alias::{Alias, AliasPlugin};
 use rolldown_plugin_build_import_analysis::BuildImportAnalysisPlugin;
@@ -118,11 +120,18 @@ impl TryFrom<BindingJsonPluginStringify> for JsonPluginStringify {
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct BindingTransformPluginConfig {
   pub include: Option<Vec<BindingStringOrRegex>>,
   pub exclude: Option<Vec<BindingStringOrRegex>>,
+  pub jsx_refresh_include: Option<Vec<BindingStringOrRegex>>,
+  pub jsx_refresh_exclude: Option<Vec<BindingStringOrRegex>>,
+
+  pub is_server_consumer: Option<bool>,
+  pub runtime_resolve_base: Option<String>,
+
   pub jsx_inject: Option<String>,
+  pub transform_options: Option<TransformOptions>,
 }
 
 #[napi_derive::napi(object, object_to_js = false)]
@@ -301,12 +310,86 @@ impl TryFrom<BindingAliasPluginConfig> for AliasPlugin {
 
 impl From<BindingTransformPluginConfig> for TransformPlugin {
   fn from(value: BindingTransformPluginConfig) -> Self {
+    let sourcemap = value.transform_options.as_ref().and_then(|v| v.sourcemap).unwrap_or(true);
+    let transform_options = value.transform_options.map(|v| {
+      let jsx = v.jsx.map(|jsx| match jsx {
+        Either::A(jsx) => itertools::Either::Left(jsx),
+        Either::B(jsx) => {
+          let refresh = jsx.refresh.map(|refresh| match refresh {
+            Either::A(refresh) => itertools::Either::Left(refresh),
+            Either::B(refresh) => {
+              itertools::Either::Right(rolldown_plugin_transform::ReactRefreshOptions {
+                refresh_reg: refresh.refresh_reg,
+                refresh_sig: refresh.refresh_sig,
+                emit_full_signatures: refresh.emit_full_signatures,
+              })
+            }
+          });
+          itertools::Either::Right(rolldown_plugin_transform::JsxOptions {
+            runtime: jsx.runtime,
+            development: jsx.development,
+            throw_if_namespace: jsx.throw_if_namespace,
+            pure: jsx.pure,
+            import_source: jsx.import_source,
+            pragma: jsx.pragma,
+            pragma_frag: jsx.pragma_frag,
+            use_built_ins: jsx.use_built_ins,
+            use_spread: jsx.use_spread,
+            refresh,
+          })
+        }
+      });
+
+      let decorator = v.decorator.map(|decorator| rolldown_plugin_transform::DecoratorOptions {
+        legacy: decorator.legacy,
+        emit_decorator_metadata: decorator.emit_decorator_metadata,
+      });
+
+      let typescript = v.typescript.map(|typescript| {
+        let declaration = typescript.declaration.map(|declaration| {
+          rolldown_plugin_transform::IsolatedDeclarationsOptions {
+            strip_internal: declaration.strip_internal,
+            sourcemap: declaration.sourcemap,
+          }
+        });
+        let rewrite_import_extensions = typescript.rewrite_import_extensions.map(|v| match v {
+          Either::A(v) => itertools::Either::Left(v),
+          Either::B(v) => itertools::Either::Right(v),
+        });
+
+        rolldown_plugin_transform::TypeScriptOptions {
+          declaration,
+          jsx_pragma: typescript.jsx_pragma,
+          jsx_pragma_frag: typescript.jsx_pragma_frag,
+          only_remove_type_imports: typescript.only_remove_type_imports,
+          allow_namespaces: typescript.allow_namespaces,
+          allow_declare_fields: typescript.allow_declare_fields,
+          rewrite_import_extensions,
+        }
+      });
+
+      rolldown_plugin_transform::TransformOptions { lang: v.lang, jsx, decorator, typescript }
+    });
+
     Self {
       include: value.include.map(bindingify_string_or_regex_array).unwrap_or_default(),
       exclude: value.exclude.map(bindingify_string_or_regex_array).unwrap_or_default(),
+      jsx_refresh_include: value
+        .jsx_refresh_include
+        .map(bindingify_string_or_regex_array)
+        .unwrap_or_default(),
+      jsx_refresh_exclude: value
+        .jsx_refresh_exclude
+        .map(bindingify_string_or_regex_array)
+        .unwrap_or_default(),
+
       jsx_inject: value.jsx_inject,
-      // TODO: handle config
-      ..Default::default()
+
+      is_server_consumer: value.is_server_consumer.unwrap_or(true),
+      runtime_resolve_base: value.runtime_resolve_base,
+
+      sourcemap,
+      transform_options: transform_options.unwrap_or_default(),
     }
   }
 }

--- a/crates/rolldown_plugin_transform/src/lib.rs
+++ b/crates/rolldown_plugin_transform/src/lib.rs
@@ -14,7 +14,10 @@ use rolldown_plugin::{
 };
 use rolldown_utils::{clean_url::clean_url, pattern_filter::StringOrRegex};
 
-use types::transform_options::TransformOptions;
+pub use types::{
+  DecoratorOptions, IsolatedDeclarationsOptions, JsxOptions, ReactRefreshOptions, TransformOptions,
+  TypeScriptOptions,
+};
 
 #[derive(Debug, Default)]
 pub struct TransformPlugin {
@@ -25,8 +28,8 @@ pub struct TransformPlugin {
 
   pub jsx_inject: Option<String>,
 
-  pub filename: String,
-  pub environment_consumer: String,
+  pub is_server_consumer: bool,
+  pub runtime_resolve_base: Option<String>,
 
   pub sourcemap: bool,
   pub transform_options: TransformOptions,
@@ -47,7 +50,7 @@ impl Plugin for TransformPlugin {
       let resolved_id = ctx
         .resolve(
           args.specifier,
-          Some(&self.filename),
+          self.runtime_resolve_base.as_deref(),
           Some(PluginContextResolveOptions {
             skip_self: true,
             import_kind: args.kind,
@@ -127,6 +130,10 @@ impl Plugin for TransformPlugin {
   }
 
   fn register_hook_usage(&self) -> HookUsage {
-    HookUsage::ResolveId | HookUsage::Transform
+    if self.runtime_resolve_base.is_some() {
+      HookUsage::ResolveId | HookUsage::Transform
+    } else {
+      HookUsage::Transform
+    }
   }
 }

--- a/crates/rolldown_plugin_transform/src/types/mod.rs
+++ b/crates/rolldown_plugin_transform/src/types/mod.rs
@@ -1,4 +1,11 @@
-pub mod decorator_options;
-pub mod jsx_options;
-pub mod transform_options;
-pub mod typescript_options;
+mod decorator_options;
+mod jsx_options;
+mod transform_options;
+mod typescript_options;
+
+pub use {
+  decorator_options::DecoratorOptions,
+  jsx_options::{JsxOptions, ReactRefreshOptions},
+  transform_options::TransformOptions,
+  typescript_options::{IsolatedDeclarationsOptions, TypeScriptOptions},
+};

--- a/crates/rolldown_plugin_transform/src/utils.rs
+++ b/crates/rolldown_plugin_transform/src/utils.rs
@@ -6,7 +6,7 @@ use rolldown_common::ModuleType;
 use rolldown_plugin::SharedTransformPluginContext;
 use rolldown_utils::{clean_url::clean_url, pattern_filter::filter as pattern_filter};
 
-use crate::{TransformPlugin, types::jsx_options::JsxOptions};
+use crate::{JsxOptions, TransformPlugin};
 
 pub enum JsxRefreshFilter {
   None,
@@ -58,7 +58,7 @@ impl TransformPlugin {
     let is_js_lang = matches!(self.jsx_refresh_filter(id, cwd), JsxRefreshFilter::True)
       && ext.is_some_and(|ext| ["js", "jsx", "ts", "tsx", "mjs"].contains(&ext));
 
-    let is_refresh_disabled = self.environment_consumer == "server"
+    let is_refresh_disabled = self.is_server_consumer
       || matches!(self.jsx_refresh_filter(id, cwd), JsxRefreshFilter::False);
 
     let source_type = if is_js_lang {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -713,7 +713,12 @@ export interface BindingTransformHookFilter {
 export interface BindingTransformPluginConfig {
   include?: Array<BindingStringOrRegex>
   exclude?: Array<BindingStringOrRegex>
+  jsxRefreshInclude?: Array<BindingStringOrRegex>
+  jsxRefreshExclude?: Array<BindingStringOrRegex>
+  isServerConsumer?: boolean
+  runtimeResolveBase?: string
   jsxInject?: string
+  transformOptions?: TransformOptions
 }
 
 export interface BindingTreeshake {


### PR DESCRIPTION
### Description

Related to #3968
