### PR TITLE
refactor(normal_module): refactor ESM namespace generation

### DIFF
--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -363,7 +363,7 @@ pub enum EsmNamespaceKind {
 }
 
 impl EsmNamespaceKind {
-  pub fn debug_label(&self) -> &'static str {
+  pub fn debug_label(self) -> &'static str {
     match self {
       EsmNamespaceKind::Default => "esm_namespace_ref_derived_from_module_exports",
       EsmNamespaceKind::NodeMode => "esm_namespace_ref_derived_from_module_exports node",

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -258,6 +258,31 @@ impl NormalModule {
     self.ecma_view.meta.is_included()
   }
 
+  pub fn generate_esm_namespace_in_cjs_internal(
+    &mut self,
+    symbol_db: &mut SymbolRefDb,
+    runtime_module: &RuntimeModuleBrief,
+    wrap_ref: SymbolRef,
+    kind: EsmNamespaceKind,
+  ) -> Option<EsmNamespaceInCjs> {
+    let esm_namespace_ref = symbol_db.create_facade_root_symbol_ref(
+      self.idx,
+      &concat_string!("import_", legitimize_identifier_name(&self.repr_name)),
+    );
+
+    let stmt_info_idx = self.stmt_infos.add_stmt_info(StmtInfo {
+      stmt_idx: None,
+      declared_symbols: vec![esm_namespace_ref],
+      referenced_symbols: vec![wrap_ref.into(), runtime_module.resolve_symbol("__toESM").into()],
+      force_tree_shaking: true,
+      #[cfg(debug_assertions)]
+      debug_label: Some(kind.debug_label().to_string()),
+      ..Default::default()
+    });
+
+    Some(EsmNamespaceInCjs { namespace_ref: esm_namespace_ref, stmt_info_idx })
+  }
+
   /// Generates
   /// ```js
   /// var import_xxx = __toESM(require_xxx());
@@ -271,25 +296,12 @@ impl NormalModule {
     if self.esm_namespace_in_cjs.is_some() {
       return;
     }
-    let esm_namespace_ref_derived_from_module_exports = symbol_db.create_facade_root_symbol_ref(
-      self.idx,
-      &concat_string!("import_", legitimize_identifier_name(&self.repr_name)),
+    self.esm_namespace_in_cjs = self.generate_esm_namespace_in_cjs_internal(
+      symbol_db,
+      runtime_module,
+      wrap_ref,
+      EsmNamespaceKind::Default,
     );
-
-    let stmt_info_idx = self.stmt_infos.add_stmt_info(StmtInfo {
-      stmt_idx: None,
-      declared_symbols: vec![esm_namespace_ref_derived_from_module_exports],
-      referenced_symbols: vec![wrap_ref.into(), runtime_module.resolve_symbol("__toESM").into()],
-      force_tree_shaking: true,
-      #[cfg(debug_assertions)]
-      debug_label: Some("esm_namespace_ref_derived_from_module_exports".to_string()),
-      ..Default::default()
-    });
-
-    self.esm_namespace_in_cjs = Some(EsmNamespaceInCjs {
-      namespace_ref: esm_namespace_ref_derived_from_module_exports,
-      stmt_info_idx,
-    });
   }
 
   /// Generates
@@ -305,25 +317,12 @@ impl NormalModule {
     if self.esm_namespace_in_cjs_node_mode.is_some() {
       return;
     }
-    let esm_namespace_ref_derived_from_module_exports = symbol_db.create_facade_root_symbol_ref(
-      self.idx,
-      &concat_string!("import_", legitimize_identifier_name(&self.repr_name)),
+    self.esm_namespace_in_cjs_node_mode = self.generate_esm_namespace_in_cjs_internal(
+      symbol_db,
+      runtime_module,
+      wrap_ref,
+      EsmNamespaceKind::NodeMode,
     );
-
-    let stmt_info_idx = self.stmt_infos.add_stmt_info(StmtInfo {
-      stmt_idx: None,
-      declared_symbols: vec![esm_namespace_ref_derived_from_module_exports],
-      referenced_symbols: vec![wrap_ref.into(), runtime_module.resolve_symbol("__toESM").into()],
-      #[cfg(debug_assertions)]
-      debug_label: Some("esm_namespace_ref_derived_from_module_exports node".to_string()),
-      force_tree_shaking: true,
-      ..Default::default()
-    });
-
-    self.esm_namespace_in_cjs_node_mode = Some(EsmNamespaceInCjs {
-      namespace_ref: esm_namespace_ref_derived_from_module_exports,
-      stmt_info_idx,
-    });
   }
 
   #[expect(clippy::cast_precision_loss)]
@@ -355,4 +354,19 @@ impl DerefMut for NormalModule {
 
 pub enum ModuleRenderArgs<'any> {
   Ecma { ast: &'any EcmaAst },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum EsmNamespaceKind {
+  Default,
+  NodeMode,
+}
+
+impl EsmNamespaceKind {
+  pub fn debug_label(&self) -> &'static str {
+    match self {
+      EsmNamespaceKind::Default => "esm_namespace_ref_derived_from_module_exports",
+      EsmNamespaceKind::NodeMode => "esm_namespace_ref_derived_from_module_exports node",
+    }
+  }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Refactor `generate_esm_namespace_in_cjs_stmt` and `generate_esm_namespace_in_cjs_node_mode_stmt`

- Introduces `EsmNamespaceKind` enum to replace magic strings for debug labels, improving type safety and maintainability
- Extracts common logic into the private helper `generate_esm_namespace_in_cjs_internal` to reduce code duplication