### PR TITLE
refactor(rust): update display string for `UrlImport` to `url-token`

### DIFF
--- a/crates/rolldown_common/src/types/import_kind.rs
+++ b/crates/rolldown_common/src/types/import_kind.rs
@@ -47,7 +47,7 @@ impl Display for ImportKind {
       Self::Require => write!(f, "require-call"),
       // TODO(hyf0): check if this literal is the same as esbuild's
       Self::AtImport => write!(f, "import-rule"),
-      ImportKind::UrlImport => write!(f, "url-import"),
+      ImportKind::UrlImport => write!(f, "url-token"),
       ImportKind::NewUrl => write!(f, "new-url"),
       ImportKind::HotAccept => write!(f, "hot-accept"),
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Align with existing ImportKind with esbuild. For rolldown-only's, we don't need to align with esbuild.

https://github.com/evanw/esbuild/blob/d34e79e2a998c21bb71d57b92b0017ca11756912/internal/ast/ast.go#L56-L57C11

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
