### PR TITLE
feat: rolldown_filter_analyzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,11 +2585,8 @@ dependencies = [
 name = "rolldown_filter_analyzer"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "arcstr",
  "oxc",
  "rolldown_ecmascript",
- "rolldown_error",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rolldown_filter_analyzer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arcstr",
+ "oxc",
+ "rolldown_ecmascript",
+ "rolldown_error",
+]
+
+[[package]]
 name = "rolldown_fs"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ quote = "1"
 syn = { version = "2", default-features = false }
 
 # oxc crates with the same version
-oxc = { version = "0.64.0", features = ["ast_visit", "transformer", "minifier", "mangler", "semantic", "codegen", "serialize", "isolated_declarations", "regular_expression"] }
+oxc = { version = "0.64.0", features = ["ast_visit", "transformer", "minifier", "mangler", "semantic", "codegen", "serialize", "isolated_declarations", "regular_expression", "cfg"] }
 oxc_parser_napi = { version = "0.64.0" }
 oxc_transform_napi = { version = "0.64.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,6 @@ oxc = { version = "0.65.0", features = ["ast_visit", "transformer", "minifier", 
 oxc_parser_napi = { version = "0.65.0" }
 oxc_transform_napi = { version = "0.65.0" }
 
-
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.
 # Please update with `cargo update oxc_resolver oxc_sourcemap oxc_index`

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -614,7 +614,7 @@ mod test {
   fn get_statements_side_effect(code: &str) -> bool {
     let source_type = SourceType::tsx();
     let ast = EcmaCompiler::parse("<Noop>", code, source_type).unwrap();
-    let semantic = EcmaAst::make_semantic(ast.program());
+    let semantic = EcmaAst::make_semantic(ast.program(), false);
     let scoping = semantic.into_scoping();
     let ast_scopes = AstScopes::new(scoping);
 

--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -186,7 +186,7 @@ impl HmrManager {
       let ast = &mut self.input.index_ecma_ast[ecma_ast_idx].0;
 
       ast.program.with_mut(|fields| {
-        let scoping = EcmaAst::make_semantic(fields.program).into_scoping();
+        let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
         let mut finalizer = HmrAstFinalizer {
           modules,
           alloc: fields.allocator,

--- a/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
@@ -10,13 +10,19 @@ impl EcmaAst {
     self.program().is_empty()
   }
 
-  pub fn make_semantic<'ast>(program: &'ast Program<'ast>) -> Semantic<'ast> {
-    let semantic = SemanticBuilder::new().with_scope_tree_child_ids(true).build(program).semantic;
+  pub fn make_semantic<'ast>(program: &'ast Program<'ast>, with_cfg: bool) -> Semantic<'ast> {
+    let semantic = SemanticBuilder::new()
+      .with_scope_tree_child_ids(true)
+      .with_cfg(with_cfg)
+      .build(program)
+      .semantic;
     semantic
   }
 
   pub fn make_scoping(&self) -> Scoping {
-    self.program.with_dependent(|_owner, dep| Self::make_semantic(&dep.program).into_scoping())
+    self.program.with_dependent(|_owner, dep| {
+      Self::make_semantic(&dep.program, /*with_cfg*/ false).into_scoping()
+    })
   }
 
   pub fn make_symbol_table_and_scope_tree_with_semantic_builder<'a>(

--- a/crates/rolldown_filter_analyzer/Cargo.toml
+++ b/crates/rolldown_filter_analyzer/Cargo.toml
@@ -7,10 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow         = { workspace = true }
-arcstr         = { workspace = true }
-oxc            = { workspace = true }
-rolldown_error = { workspace = true }
+oxc = { workspace = true }
 rolldown_ecmascript = { workspace = true }
 
 [lints]

--- a/crates/rolldown_filter_analyzer/Cargo.toml
+++ b/crates/rolldown_filter_analyzer/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rolldown_filter_analyzer"
+version = "0.1.0"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow         = { workspace = true }
+arcstr         = { workspace = true }
+oxc            = { workspace = true }
+rolldown_error = { workspace = true }
+rolldown_ecmascript = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rolldown_filter_analyzer/src/lib.rs
+++ b/crates/rolldown_filter_analyzer/src/lib.rs
@@ -1,0 +1,98 @@
+use oxc::ast::AstKind;
+use oxc::ast::ast::{Expression, Program};
+use oxc::ast_visit::Visit;
+use oxc::cfg::graph::adj::NodeIndex;
+use oxc::cfg::graph::visit::{Control, DfsEvent, EdgeRef};
+use oxc::cfg::visit::set_depth_first_search;
+use oxc::cfg::{EdgeType, InstructionKind};
+use oxc::semantic::Semantic;
+use oxc::span::SourceType;
+use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
+
+#[cfg(test)]
+mod test;
+pub fn filterable(source: &str) -> bool {
+  let ast = EcmaCompiler::parse("<Noop>", source, SourceType::mjs()).unwrap();
+  let semantic = EcmaAst::make_semantic(ast.program(), true);
+  let mut analyzer = FilterableAnalyzer::new(&semantic);
+  analyzer.visit_program(&ast.program());
+  analyzer.ret
+}
+
+struct FilterableAnalyzer<'b, 'a: 'b> {
+  ast_ext: &'b Semantic<'a>,
+  ret: bool,
+}
+
+impl<'b, 'a> FilterableAnalyzer<'b, 'a> {
+  pub fn new(ast_ext: &'b Semantic<'a>) -> Self {
+    Self { ast_ext, ret: false }
+  }
+}
+
+impl<'b, 'a> Visit<'a> for FilterableAnalyzer<'b, 'a> {
+  fn visit_program(&mut self, _it: &Program<'a>) {
+    let Some(cfg) = self.ast_ext.cfg() else {
+      return;
+    };
+    let g = cfg.graph();
+    let mut function_index = None;
+    let mut caller_index = NodeIndex::from(0);
+    let ret = set_depth_first_search(g, Some(NodeIndex::from(1)), |e| {
+      match e {
+        DfsEvent::Discover(n, _) => Control::<bool>::Continue,
+        DfsEvent::TreeEdge(s, e) => {
+          if function_index.is_some() {
+            for b in cfg.basic_block(e).instructions() {
+              if matches!(b.kind, InstructionKind::Unreachable) {
+                return Control::Prune;
+              }
+              if matches!(b.kind, InstructionKind::ImplicitReturn) {
+                return Control::Break(true);
+              }
+              let node = b.node_id.map(|id| self.ast_ext.nodes().get_node(id).kind());
+              match node {
+                Some(AstKind::ReturnStatement(stmt)) => match stmt.argument {
+                  // `return undefined;`
+                  Some(Expression::Identifier(ref id)) if id.name == "undefined" => {
+                    return Control::Break(true);
+                  }
+                  // `return;`
+                  None => {
+                    return Control::Break(true);
+                  }
+                  _ => {
+                    return Control::Prune;
+                  }
+                },
+                Some(AstKind::IfStatement(_) | AstKind::BlockStatement(_)) => {
+                  continue;
+                }
+                Some(_) => {
+                  if matches!(b.kind, InstructionKind::Condition) {
+                    continue;
+                  }
+                  return Control::Prune;
+                }
+                None => {
+                  return Control::Continue;
+                }
+              }
+            }
+          } else {
+            for e in g.edges_connecting(s, e) {
+              if matches!(g.edge_weight(e.id()), Some(EdgeType::NewFunction)) {
+                function_index = Some(e.target());
+                caller_index = s;
+              }
+            }
+          }
+          Control::Continue
+        }
+        DfsEvent::BackEdge(..) | DfsEvent::CrossForwardEdge(..) => Control::Continue,
+        DfsEvent::Finish(s, _) => Control::Continue,
+      }
+    });
+    self.ret = ret.break_value().unwrap_or_default();
+  }
+}

--- a/crates/rolldown_filter_analyzer/src/test.rs
+++ b/crates/rolldown_filter_analyzer/src/test.rs
@@ -1,50 +1,40 @@
 use crate::filterable;
 
 #[test]
-fn unfilterable_case() {
-  assert_eq!(
-    filterable(
-      r#"
+fn not_filterable_case() {
+  assert!(!filterable(
+    r"
 function test() {
       throw new Error(
       )
 }
-  "#,
-    ),
-    false
-  );
+  ",
+  ),);
 
-  assert_eq!(
-    filterable(
-      r#"
+  assert!(!filterable(
+    r"
 function test() {
   if (a) {
     call();
   }
   call();
 }
-  "#,
-    ),
-    false
-  );
+  ",
+  ),);
 
-  assert_eq!(
-    filterable(
-      r#"
+  assert!(!filterable(
+    r"
 function test() {
   if (a) {
     call();
   }
   throw new Error();
 }
-  "#,
-    ),
-    false
-  );
+  ",
+  ),);
 
-  assert_eq!(
-    filterable(
-      r#"
+  assert!(!filterable(
+    r#"
 function test() {
   if (a) {
     call();
@@ -54,17 +44,14 @@ function test() {
   };
 }
   "#,
-    ),
-    false
-  );
+  ),);
 }
 
 #[test]
 fn filterable_case() {
   // Different return case
-  assert_eq!(
-    filterable(
-      r#"
+  assert!(filterable(
+    r"
 function test() {
   if (a) {
     return;
@@ -72,43 +59,34 @@ function test() {
   call();
 }
 
-  "#,
-    ),
-    true
-  );
+  ",
+  ),);
 
-  assert_eq!(
-    filterable(
-      r#"
+  assert!(filterable(
+    r"
 function test() {
   if (a) {
     return undefined;
   }
   call();
 }
-  "#,
-    ),
-    true
-  );
+  ",
+  ));
 
   // implicit return at the end of function
-  assert_eq!(
-    filterable(
-      r#"
+  assert!(filterable(
+    r"
 function test() {
   if (a) {
     call();
   }
 }
 
-  "#,
-    ),
-    true
-  );
+  ",
+  ),);
 
-  assert_eq!(
-    filterable(
-      r#"
+  assert!(filterable(
+    r"
 function test() {
   if (a) {
     return;
@@ -118,8 +96,6 @@ function test() {
     call();
   }
 }
-  "#,
-    ),
-    true
-  );
+  ",
+  ),);
 }

--- a/crates/rolldown_filter_analyzer/src/test.rs
+++ b/crates/rolldown_filter_analyzer/src/test.rs
@@ -1,0 +1,125 @@
+use crate::filterable;
+
+#[test]
+fn unfilterable_case() {
+  assert_eq!(
+    filterable(
+      r#"
+function test() {
+      throw new Error(
+      )
+}
+  "#,
+    ),
+    false
+  );
+
+  assert_eq!(
+    filterable(
+      r#"
+function test() {
+  if (a) {
+    call();
+  }
+  call();
+}
+  "#,
+    ),
+    false
+  );
+
+  assert_eq!(
+    filterable(
+      r#"
+function test() {
+  if (a) {
+    call();
+  }
+  throw new Error();
+}
+  "#,
+    ),
+    false
+  );
+
+  assert_eq!(
+    filterable(
+      r#"
+function test() {
+  if (a) {
+    call();
+  }
+  return {
+    code: "test"
+  };
+}
+  "#,
+    ),
+    false
+  );
+}
+
+#[test]
+fn filterable_case() {
+  // Different return case
+  assert_eq!(
+    filterable(
+      r#"
+function test() {
+  if (a) {
+    return;
+  }
+  call();
+}
+
+  "#,
+    ),
+    true
+  );
+
+  assert_eq!(
+    filterable(
+      r#"
+function test() {
+  if (a) {
+    return undefined;
+  }
+  call();
+}
+  "#,
+    ),
+    true
+  );
+
+  // implicit return at the end of function
+  assert_eq!(
+    filterable(
+      r#"
+function test() {
+  if (a) {
+    call();
+  }
+}
+
+  "#,
+    ),
+    true
+  );
+
+  assert_eq!(
+    filterable(
+      r#"
+function test() {
+  if (a) {
+    return;
+  }
+
+  if (b) {
+    call();
+  }
+}
+  "#,
+    ),
+    true
+  );
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. The new crate is used to detect if a plugin hook has a potential opportunity to use `filter` to improve performance, the basic idea is pretty straightforward: Whether there exists a path that reaches a statement that returns undefined without encountering any sideeffects statement, if exists we assume the plugin could be filtered with `filter` attribute 
2. Will add js part in next pr.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
