### PR TITLE
chore: remove minification warning for prod

### DIFF
--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -1,4 +1,3 @@
-import colors from 'ansis';
 import type { RollupLog } from '../types/misc';
 import { getCodeFrame } from '../utils/code-frame';
 import { locate } from './locate-character';
@@ -8,7 +7,6 @@ const INVALID_LOG_POSITION = 'INVALID_LOG_POSITION',
   INPUT_HOOK_IN_OUTPUT_PLUGIN = 'INPUT_HOOK_IN_OUTPUT_PLUGIN',
   CYCLE_LOADING = 'CYCLE_LOADING',
   MULTIPLY_NOTIFY_OPTION = 'MULTIPLY_NOTIFY_OPTION',
-  MINIFY_WARNING = 'MINIFY_WARNING',
   PARSE_ERROR = 'PARSE_ERROR';
 
 export function logParseError(message: string): RollupLog {

--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -18,15 +18,6 @@ export function logParseError(message: string): RollupLog {
   };
 }
 
-export function logMinifyWarning(): RollupLog {
-  return {
-    code: MINIFY_WARNING,
-    message: colors.yellow(
-      'The built-in minifier is still under development. Setting "minify: true" is not recommended for production use.',
-    ),
-  };
-}
-
 export function logInvalidLogPosition(pluginName: string): RollupLog {
   return {
     code: INVALID_LOG_POSITION,

--- a/packages/rolldown/src/utils/create-bundler-option.ts
+++ b/packages/rolldown/src/utils/create-bundler-option.ts
@@ -1,7 +1,6 @@
 import { BindingBundlerOptions } from '../binding';
 import { getLogger, getOnLog } from '../log/logger';
-import { LOG_LEVEL_INFO, LOG_LEVEL_WARN } from '../log/logging';
-import { logMinifyWarning } from '../log/logs';
+import { LOG_LEVEL_INFO } from '../log/logging';
 import type { InputOptions } from '../options/input-options';
 import type { OutputOptions } from '../options/output-options';
 import { PluginDriver } from '../plugin/plugin-driver';
@@ -45,10 +44,6 @@ export async function createBundlerOptions(
       logLevel,
       watchMode,
     );
-  }
-
-  if (outputOptions.minify === true) {
-    onLog(LOG_LEVEL_WARN, logMinifyWarning());
   }
 
   const normalizedOutputPlugins = await normalizePluginOption(

--- a/packages/rolldown/tests/fixtures/tree-shake/minify/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/minify/_config.ts
@@ -2,25 +2,13 @@ import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
 import { defineTest } from 'rolldown-tests'
 import { expect, vi } from 'vitest'
 
-const onLogFn = vi.fn()
-
 export default defineTest({
   config: {
     output: {
       minify: true,
-    },
-    onLog(level, log) {
-      expect(level).toBe('warn')
-      expect(log.code).toBe('MINIFY_WARNING')
-      expect(log.message).toContain(
-        'Setting "minify: true" is not recommended for production use.',
-      )
-      onLogFn()
-    },
+    }
   },
   afterTest: (output) => {
-    expect(onLogFn).toHaveBeenCalledTimes(1)
-
     output.output
       .filter(({ type }) => type === 'chunk')
       .forEach((chunk) => {


### PR DESCRIPTION
After talking with @yyx990803 earlier today, the warning that appears when using `oxc-minify` during build is no longer necessary and can be removed.