### PR TITLE
fix(hmr): export full reload info if reach to hmr root

### DIFF
--- a/crates/rolldown_binding/src/types/binding_hmr_output.rs
+++ b/crates/rolldown_binding/src/types/binding_hmr_output.rs
@@ -3,6 +3,7 @@
 pub struct BindingHmrOutput {
   pub patch: String,
   pub hmr_boundaries: Vec<BindingHmrBoundaryOutput>,
+  pub full_reload: bool,
 }
 
 impl From<rolldown_common::HmrOutput> for BindingHmrOutput {
@@ -10,6 +11,7 @@ impl From<rolldown_common::HmrOutput> for BindingHmrOutput {
     Self {
       patch: value.patch,
       hmr_boundaries: value.hmr_boundaries.into_iter().map(Into::into).collect(),
+      full_reload: value.full_reload,
     }
   }
 }

--- a/crates/rolldown_common/src/hmr/hmr_output.rs
+++ b/crates/rolldown_common/src/hmr/hmr_output.rs
@@ -4,6 +4,7 @@ use arcstr::ArcStr;
 pub struct HmrOutput {
   pub patch: String,
   pub hmr_boundaries: Vec<HmrBoundaryOutput>,
+  pub full_reload: bool,
 }
 
 #[derive(Debug)]

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -321,6 +321,7 @@ export interface BindingHmrBoundaryOutput {
 export interface BindingHmrOutput {
   patch: string
   hmrBoundaries: Array<BindingHmrBoundaryOutput>
+  fullReload: boolean
 }
 
 export interface BindingHookJsLoadOutput {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

close https://github.com/rolldown/rolldown/issues/4068.

For the test, tracking at here https://github.com/rolldown/rolldown/issues/4243. I test it at https://github.com/vitejs/rolldown-vite/pull/107/commits/c1edfee1da39b832d226958f347bbdd3a43c4b12
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
