### PR TITLE
fix: align sanitize_filename with rollup

### DIFF
--- a/crates/rolldown_utils/src/sanitize_filename.rs
+++ b/crates/rolldown_utils/src/sanitize_filename.rs
@@ -19,7 +19,7 @@ macro_rules! matches_invalid_chars {
           | '?'
           | '['
           | ']'
-          | '@'
+          | '^'
           | '`'
           | '{'
           | '|'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This single character was not aligned.
https://github.com/rollup/rollup/blob/ec5e45af9905e719c5db63f89a05fbfda9cd5c2b/src/utils/sanitizeFileName.ts#L3

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
