### PR TITLE
refactor(debug): use `serde_json` to emit strcutural logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,12 +2425,12 @@ dependencies = [
  "rolldown_workspace",
  "rustc-hash",
  "serde",
+ "serde_json",
  "string_wizard",
  "sugar_path",
  "testing_macros",
  "tokio",
  "tracing",
- "valuable",
  "xxhash-rust",
 ]
 
@@ -2539,7 +2539,6 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "ts-rs",
- "valuable",
 ]
 
 [[package]]
@@ -2630,12 +2629,12 @@ dependencies = [
  "rolldown_utils",
  "rustc-hash",
  "serde",
+ "serde_json",
  "string_wizard",
  "sugar_path",
  "tokio",
  "tracing",
  "typedmap",
- "valuable",
 ]
 
 [[package]]
@@ -3616,20 +3615,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-dependencies = [
- "valuable-derive",
-]
-
-[[package]]
-name = "valuable-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a32a9bcc0f6c6ccfd5b27bcf298c58e753bcc9eeff268157a303393183a6d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "valuable-serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ string_wizard = { path = "./crates/string_wizard", features = ["serde"] }
 sugar_path = { version = "1.2.0", features = ["cached_current_dir"] }
 testing_macros = "1.0.0"
 tokio = { version = "1.38.0", default-features = false }
-tracing = { version = "0.1.41", features = ["valuable"] }
+tracing = { version = "0.1.41" }
 tracing-chrome = "0.7.2"
 tracing-serde = "0.2.0"
 tracing-subscriber = { version = "0.3.18", default-features = false }
@@ -180,7 +180,6 @@ ts-rs = "10.1"
 typedmap = "0.6.0"
 url = "2.5.4"
 urlencoding = "2.1.3"
-valuable = "0.1.1"
 vfs = "0.12.0"
 xxhash-rust = "0.8.10"
 

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -50,11 +50,11 @@ rolldown_tracing = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
+serde_json = { workspace = true }
 string_wizard = { workspace = true }
 sugar_path = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing = { workspace = true }
-valuable = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]
@@ -67,4 +67,5 @@ testing_macros = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "rt-multi-thread"] }
 
 [package.metadata.cargo-shear]
-ignored = ["serde"]
+# `serde_json` is used in `trace_action` macro.
+ignored = ["serde", "serde_json"]

--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -23,7 +23,6 @@ use rolldown_plugin::{
 };
 use rolldown_utils::dashmap::FxDashSet;
 use std::{any::Any, sync::Arc};
-use valuable::Valuable;
 
 pub struct Bundler {
   pub closed: bool,

--- a/crates/rolldown_debug/Cargo.toml
+++ b/crates/rolldown_debug/Cargo.toml
@@ -12,9 +12,9 @@ rolldown_debug_action = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
-tracing = { workspace = true, features = ["valuable"] }
+tracing = { workspace = true }
 tracing-serde = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json", "valuable"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json"] }
 
 [lints]
 workspace = true

--- a/crates/rolldown_debug/src/debug_formatter.rs
+++ b/crates/rolldown_debug/src/debug_formatter.rs
@@ -29,71 +29,106 @@ where
     _writer: Writer<'_>,
     event: &Event<'_>,
   ) -> std::fmt::Result {
-    let meta = event.metadata();
-    let session_id = if let Some(scope) = ctx.event_scope() {
-      let mut spans = scope.from_root();
-      loop {
-        if let Some(span) = spans.next() {
-          if let Some(build_id) = span.extensions().get::<SessionId>() {
-            break Some(build_id.clone());
+    let mut action_meta_extractor = ActionMetaExtractor::default();
+    event.record(&mut action_meta_extractor);
+    let action_meta = action_meta_extractor.meta;
+
+    if let Some(action_meta) = action_meta {
+      // This branch means this event is not only for normal tracing, but also for devtool tracing.
+      let meta = event.metadata();
+      let session_id = if let Some(scope) = ctx.event_scope() {
+        let mut spans = scope.from_root();
+        loop {
+          if let Some(span) = spans.next() {
+            if let Some(build_id) = span.extensions().get::<SessionId>() {
+              break Some(build_id.clone());
+            }
+          } else {
+            break None;
           }
-        } else {
-          break None;
         }
+      } else {
+        None
+      };
+
+      let session_id = session_id.as_ref().map_or(DEFAULT_SESSION_ID, |s| &s.0);
+
+      std::fs::create_dir_all(format!(".rolldown/{session_id}")).ok();
+
+      let log_filename: Arc<str> = format!(".rolldown/{session_id}/logs.json").into();
+
+      if !OPENED_FILE_HANDLES.contains_key(&log_filename) {
+        let file = OpenOptions::new()
+          .create(true)
+          .append(true)
+          .open(log_filename.as_ref())
+          .map_err(|_| std::fmt::Error)?;
+        // Ensure for each file, we only have one unique file handle to prevent multiple writes.
+        OPENED_FILE_HANDLES.insert(Arc::clone(&log_filename), file);
       }
+
+      OPENED_FILES_BY_SESSION
+        .entry(session_id.to_string())
+        .or_default()
+        .insert(Arc::clone(&log_filename));
+
+      let mut file = OPENED_FILE_HANDLES
+        .get_mut(&log_filename)
+        .unwrap_or_else(|| panic!("{log_filename} not found"));
+      let mut file = file.value_mut();
+
+      let mut visit = || {
+        let mut serializer = serde_json::Serializer::new(&mut file);
+        let mut serializer = serializer.serialize_map(None)?;
+
+        serializer.serialize_entry("timestamp", &current_utc_timestamp_ms())?;
+        serializer.serialize_entry("level", &meta.level().as_serde())?;
+        serializer.serialize_entry("session_id", session_id)?;
+        serializer.serialize_value(&action_meta)?;
+        let serde_json::Value::Object(action_meta) = &action_meta else {
+          unreachable!("action_meta should always be an object");
+        };
+
+        for (key, value) in action_meta {
+          serializer.serialize_entry(key, value)?;
+        }
+
+        // TODO(hyf0): we don't care about other fields for now.
+        // let mut visitor = tracing_serde::SerdeMapVisitor::new(serializer);
+        // event.record(&mut visitor);
+        // serializer = visitor.take_serializer()?;
+
+        serializer.end()
+      };
+
+      visit().map_err(|_| std::fmt::Error)?;
+      writeln!(file).map_err(|_| std::fmt::Error)?;
+      file.flush().map_err(|_| std::fmt::Error)?;
+      Ok(())
     } else {
-      None
-    };
-
-    let session_id = session_id.as_ref().map_or(DEFAULT_SESSION_ID, |s| &s.0);
-
-    std::fs::create_dir_all(format!(".rolldown/{session_id}")).ok();
-
-    let log_filename: Arc<str> = format!(".rolldown/{session_id}/logs.json").into();
-
-    if !OPENED_FILE_HANDLES.contains_key(&log_filename) {
-      let file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(log_filename.as_ref())
-        .map_err(|_| std::fmt::Error)?;
-      // Ensure for each file, we only have one unique file handle to prevent multiple writes.
-      OPENED_FILE_HANDLES.insert(Arc::clone(&log_filename), file);
+      // This branch means this event for normal tracing.
+      Ok(())
     }
-
-    OPENED_FILES_BY_SESSION
-      .entry(session_id.to_string())
-      .or_default()
-      .insert(Arc::clone(&log_filename));
-
-    let mut file = OPENED_FILE_HANDLES
-      .get_mut(&log_filename)
-      .unwrap_or_else(|| panic!("{log_filename} not found"));
-    let mut file = file.value_mut();
-
-    let mut visit = || {
-      let mut serializer = serde_json::Serializer::new(&mut file);
-      let mut serializer = serializer.serialize_map(None)?;
-
-      serializer.serialize_entry("timestamp", &current_utc_timestamp_ms())?;
-      serializer.serialize_entry("level", &meta.level().as_serde())?;
-      serializer.serialize_entry("session_id", session_id)?;
-
-      let mut visitor = tracing_serde::SerdeMapVisitor::new(serializer);
-      event.record(&mut visitor);
-
-      serializer = visitor.take_serializer()?;
-
-      serializer.end()
-    };
-
-    visit().map_err(|_| std::fmt::Error)?;
-    writeln!(file).map_err(|_| std::fmt::Error)?;
-    file.flush().map_err(|_| std::fmt::Error)?;
-    Ok(())
   }
 }
 
 fn current_utc_timestamp_ms() -> u128 {
   SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis()
+}
+
+#[derive(Default)]
+pub struct ActionMetaExtractor {
+  pub meta: Option<serde_json::Value>,
+}
+
+impl tracing::field::Visit for ActionMetaExtractor {
+  fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+    if field.name() == "meta" {
+      self.meta = Some(serde_json::from_str(value).unwrap());
+    }
+  }
+
+  fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {
+    // `EventMetaExtractor` doesn't care about debug values.
+  }
 }

--- a/crates/rolldown_debug/src/trace_action_macro.rs
+++ b/crates/rolldown_debug/src/trace_action_macro.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! trace_action {
   ($expr:expr) => {
-    tracing::trace!(meta = $expr.as_value());
+    tracing::trace!(meta = serde_json::to_string(&$expr).unwrap());
   };
 }

--- a/crates/rolldown_debug_action/Cargo.toml
+++ b/crates/rolldown_debug_action/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 ts-rs = { workspace = true }
-valuable = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/rolldown_debug_action/src/definitions/build_end.rs
+++ b/crates/rolldown_debug_action/src/definitions/build_end.rs
@@ -1,4 +1,4 @@
-#[derive(valuable::Valuable, ts_rs::TS, serde::Serialize)]
+#[derive(ts_rs::TS, serde::Serialize)]
 #[ts(export)]
 pub struct BuildEnd {
   #[ts(type = "'BuildEnd'")]

--- a/crates/rolldown_debug_action/src/definitions/build_start.rs
+++ b/crates/rolldown_debug_action/src/definitions/build_start.rs
@@ -1,4 +1,4 @@
-#[derive(valuable::Valuable, ts_rs::TS, serde::Serialize)]
+#[derive(ts_rs::TS, serde::Serialize)]
 #[ts(export)]
 pub struct BuildStart {
   #[ts(type = "'BuildStart'")]

--- a/crates/rolldown_debug_action/src/definitions/hook_load_call_end.rs
+++ b/crates/rolldown_debug_action/src/definitions/hook_load_call_end.rs
@@ -1,4 +1,4 @@
-#[derive(valuable::Valuable, ts_rs::TS, serde::Serialize)]
+#[derive(ts_rs::TS, serde::Serialize)]
 #[ts(export)]
 pub struct HookLoadCallEnd {
   #[ts(type = "'HookLoadCallEnd'")]

--- a/crates/rolldown_debug_action/src/definitions/hook_load_call_start.rs
+++ b/crates/rolldown_debug_action/src/definitions/hook_load_call_start.rs
@@ -1,4 +1,4 @@
-#[derive(valuable::Valuable, ts_rs::TS, serde::Serialize)]
+#[derive(ts_rs::TS, serde::Serialize)]
 #[ts(export)]
 pub struct HookLoadCallStart {
   #[ts(type = "'HookLoadCallStart'")]

--- a/crates/rolldown_debug_action/src/definitions/hook_resolve_id_call_end.rs
+++ b/crates/rolldown_debug_action/src/definitions/hook_resolve_id_call_end.rs
@@ -1,4 +1,4 @@
-#[derive(valuable::Valuable, ts_rs::TS, serde::Serialize)]
+#[derive(ts_rs::TS, serde::Serialize)]
 #[ts(export)]
 pub struct HookResolveIdCallEnd {
   #[ts(type = "'HookResolveIdCallEnd'")]

--- a/crates/rolldown_debug_action/src/definitions/hook_resolve_id_call_start.rs
+++ b/crates/rolldown_debug_action/src/definitions/hook_resolve_id_call_start.rs
@@ -1,4 +1,4 @@
-#[derive(valuable::Valuable, ts_rs::TS, serde::Serialize)]
+#[derive(ts_rs::TS, serde::Serialize)]
 #[ts(export)]
 pub struct HookResolveIdCallStart {
   #[ts(type = "'HookResolveIdCallStart'")]

--- a/crates/rolldown_debug_action/src/definitions/hook_transform_call_end.rs
+++ b/crates/rolldown_debug_action/src/definitions/hook_transform_call_end.rs
@@ -1,4 +1,4 @@
-#[derive(valuable::Valuable, ts_rs::TS, serde::Serialize)]
+#[derive(ts_rs::TS, serde::Serialize)]
 #[ts(export)]
 pub struct HookTransformCallEnd {
   #[ts(type = "'HookTransformCallEnd'")]

--- a/crates/rolldown_debug_action/src/definitions/hook_transform_call_start.rs
+++ b/crates/rolldown_debug_action/src/definitions/hook_transform_call_start.rs
@@ -1,4 +1,4 @@
-#[derive(valuable::Valuable, ts_rs::TS, serde::Serialize)]
+#[derive(ts_rs::TS, serde::Serialize)]
 #[ts(export)]
 pub struct HookTransformCallStart {
   #[ts(type = "'HookTransformCallStart'")]

--- a/crates/rolldown_debug_action/src/definitions/mod.rs
+++ b/crates/rolldown_debug_action/src/definitions/mod.rs
@@ -7,7 +7,7 @@ pub mod hook_resolve_id_call_start;
 pub mod hook_transform_call_end;
 pub mod hook_transform_call_start;
 
-#[derive(valuable::Valuable, ts_rs::TS, serde::Serialize)]
+#[derive(ts_rs::TS, serde::Serialize)]
 #[ts(export)]
 #[serde(untagged)]
 pub enum Meta {

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -35,12 +35,13 @@ rolldown_sourcemap = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
+serde_json = { workspace = true }
 string_wizard = { workspace = true }
 sugar_path = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true, features = ["valuable"] }
 typedmap = { workspace = true, features = ["dashmap"] }
-valuable = { workspace = true }
 
 [package.metadata.cargo-shear]
-ignored = ["serde"]
+# `serde_json` is used in `trace_action` macro.
+ignored = ["serde", "serde_json"]

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -20,7 +20,6 @@ use rolldown_sourcemap::SourceMap;
 use rolldown_utils::unique_arc::UniqueArc;
 use string_wizard::{MagicString, SourceMapOptions};
 use tracing::{Instrument, debug_span};
-use valuable::Valuable;
 
 impl PluginDriver {
   #[tracing::instrument(level = "trace", skip_all)]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Using `serde_json` gives more flexibility to manapulate data. It's very useful to inject some global data to logs, while `Valueable` is immutable.
- `Valueable` is not a active-maintained crate. https://github.com/tokio-rs/valuable/issues


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
