### PR TITLE
feat(debug): distinguish if `resolve_id` hook is called automatically or manually

### DIFF
--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -294,6 +294,7 @@ impl ModuleTask {
     Ok((source, module_type))
   }
 
+  #[tracing::instrument(skip_all, fields(CONTEXT_hook_resolve_id_trigger = "automatic"))]
   pub(crate) async fn resolve_id(
     bundle_options: &SharedOptions,
     resolver: &SharedResolver,

--- a/crates/rolldown_debug/src/lib.rs
+++ b/crates/rolldown_debug/src/lib.rs
@@ -3,6 +3,7 @@ mod debug_formatter;
 mod init_tracing;
 mod static_data;
 mod trace_action_macro;
+mod type_alias;
 
 pub use rolldown_debug_action as action;
 

--- a/crates/rolldown_debug/src/type_alias.rs
+++ b/crates/rolldown_debug/src/type_alias.rs
@@ -1,0 +1,3 @@
+use rustc_hash::FxHashMap;
+
+pub type ContextDataMap = FxHashMap<&'static str, String>;

--- a/crates/rolldown_debug_action/src/definitions/hook_resolve_id_call_end.rs
+++ b/crates/rolldown_debug_action/src/definitions/hook_resolve_id_call_end.rs
@@ -9,4 +9,6 @@ pub struct HookResolveIdCallEnd {
   pub plugin_name: String,
   /// The index of the plugin in the plugin list. It's unique to each plugin.
   pub plugin_index: u32,
+  #[ts(type = "'automatic' | 'manual")]
+  pub trigger: &'static str,
 }

--- a/crates/rolldown_debug_action/src/definitions/hook_resolve_id_call_start.rs
+++ b/crates/rolldown_debug_action/src/definitions/hook_resolve_id_call_start.rs
@@ -9,4 +9,6 @@ pub struct HookResolveIdCallStart {
   pub plugin_name: String,
   /// The index of the plugin in the plugin list. It's unique to each plugin.
   pub plugin_index: u32,
+  #[ts(type = "'automatic' | 'manual")]
+  pub trigger: &'static str,
 }

--- a/crates/rolldown_plugin/src/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context.rs
@@ -134,6 +134,7 @@ impl PluginContextImpl {
     Ok(())
   }
 
+  #[tracing::instrument(skip_all, fields(CONTEXT_hook_resolve_id_trigger = "manual"))]
   pub async fn resolve(
     &self,
     specifier: &str,

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -108,7 +108,8 @@ impl PluginDriver {
         module_request: args.specifier.to_string(),
         import_kind: args.kind.to_string(),
         plugin_name: plugin.call_name().to_string(),
-        plugin_index: plugin_idx.raw()
+        plugin_index: plugin_idx.raw(),
+        trigger: "${hook_resolve_id_trigger}",
       });
       if let Some(r) = plugin
         .call_resolve_id(
@@ -132,6 +133,7 @@ impl PluginDriver {
           is_external: r.external.map(|v| v.is_external()),
           plugin_name: plugin.call_name().to_string(),
           plugin_index: plugin_idx.raw(),
+          trigger: "${hook_resolve_id_trigger}",
         });
         return Ok(Some(r));
       }
@@ -141,6 +143,7 @@ impl PluginDriver {
         is_external: None,
         plugin_name: plugin.call_name().to_string(),
         plugin_index: plugin_idx.raw(),
+        trigger: "${hook_resolve_id_trigger}",
       });
     }
     Ok(None)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It took me a day to explore data injection in https://github.com/rolldown/rolldown/pull/4256.

This PR also introduce a way to inject contextual data to event.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
