### PR TITLE
feat(plugin/transform): allow readonly array for options

### DIFF
--- a/packages/rolldown/src/builtin-plugin/transform-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/transform-plugin.ts
@@ -3,7 +3,7 @@ import { BuiltinPlugin } from './constructors';
 import { BindingTransformPluginConfig } from '../binding';
 import { normalizedStringOrRegex } from '../utils/normalize-string-or-regex';
 
-type TransformPattern = string | RegExp | (RegExp | string)[];
+type TransformPattern = string | RegExp | readonly (RegExp | string)[];
 
 // A temp config type for giving better user experience
 export type TransformPluginConfig =

--- a/packages/rolldown/src/utils/normalize-string-or-regex.ts
+++ b/packages/rolldown/src/utils/normalize-string-or-regex.ts
@@ -4,14 +4,23 @@ import type { BindingStringOrRegex } from '../binding';
  * Normalize single or multiple string or regex patterns to an array of BindingStringOrRegex
  * convert a type that is dx friendly to a type that is friendly for binding usage
  */
-export function normalizedStringOrRegex(
-  pattern?: Array<string | RegExp> | (string | RegExp),
-): BindingStringOrRegex[] | undefined {
+export function normalizedStringOrRegex<
+  T extends Array<BindingStringOrRegex> | ReadonlyArray<BindingStringOrRegex>,
+>(
+  pattern?: T | BindingStringOrRegex,
+): T | undefined {
   if (!pattern) {
     return undefined;
   }
-  if (!Array.isArray(pattern)) {
-    pattern = [pattern];
+  if (!isReadonlyArray(pattern)) {
+    return [pattern] as T;
   }
-  return pattern;
+  return pattern as T;
+}
+
+// For https://github.com/microsoft/TypeScript/issues/17002
+function isReadonlyArray<T extends unknown[] | readonly unknown[]>(
+  input: T | unknown,
+): input is T {
+  return Array.isArray(input);
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

So that I can remove these `@ts-expect-error`s:
https://github.com/vitejs/rolldown-vite/pull/136/files#diff-5d977ec5bf5e8f4a2e6feefaa99f53724925500426005ec1368b177a02f6c210R147

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
