### PR TITLE
perf(rolldown_plugin_alias): avoid unnecessary `to_string` allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,6 +2640,7 @@ dependencies = [
 name = "rolldown_plugin_alias"
 version = "0.1.0"
 dependencies = [
+ "cow-utils",
  "rolldown_plugin",
  "rolldown_utils",
 ]

--- a/crates/rolldown_plugin_alias/Cargo.toml
+++ b/crates/rolldown_plugin_alias/Cargo.toml
@@ -15,5 +15,6 @@ doctest = false
 workspace = true
 
 [dependencies]
+cow-utils = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_utils = { workspace = true }

--- a/crates/rolldown_plugin_alias/src/lib.rs
+++ b/crates/rolldown_plugin_alias/src/lib.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use cow_utils::CowUtils;
 use rolldown_plugin::{
   HookResolveIdOutput, HookUsage, Plugin, PluginContext, PluginContextResolveOptions,
 };
@@ -33,14 +34,14 @@ impl Plugin for AliasPlugin {
     let matched_entry = self.entries.iter().find(|alias| matches(&alias.find, importee));
 
     let Some(matched_entry) = matched_entry else { return Ok(None) };
-    let update_id = match &matched_entry.find {
-      StringOrRegex::String(find) => importee.replace(find, &matched_entry.replacement),
+    let specifier = match &matched_entry.find {
+      StringOrRegex::String(find) => importee.cow_replace(find, &matched_entry.replacement),
       StringOrRegex::Regex(find) => find.replace_all(importee, &matched_entry.replacement),
     };
 
     let resolved_id = ctx
       .resolve(
-        &update_id,
+        &specifier,
         args.importer,
         Some(PluginContextResolveOptions {
           skip_self: true,

--- a/crates/rolldown_utils/src/js_regex.rs
+++ b/crates/rolldown_utils/src/js_regex.rs
@@ -38,19 +38,19 @@ impl HybridRegex {
     }
   }
 
-  pub fn replace_all(&self, haystack: &str, replacement: &str) -> String {
+  pub fn replace_all<'a>(&self, haystack: &'a str, replacement: &str) -> Cow<'a, str> {
     match self {
-      HybridRegex::Optimize(r) => r.replace_all(haystack, replacement).to_string(),
-      HybridRegex::Ecma(reg) => regress_regexp_replace_all(reg, haystack, replacement).to_string(),
+      HybridRegex::Optimize(r) => r.replace_all(haystack, replacement),
+      HybridRegex::Ecma(reg) => regress_regexp_replace_all(reg, haystack, replacement),
     }
   }
 }
 
-fn regress_regexp_replace_all<'a>(
+fn regress_regexp_replace_all<'h>(
   reg: &regress::Regex,
-  haystack: &'a str,
+  haystack: &'h str,
   replacement: &str,
-) -> Cow<'a, str> {
+) -> Cow<'h, str> {
   let iter = reg.find_iter(haystack);
   let mut iter = iter.peekable();
   if iter.peek().is_none() {


### PR DESCRIPTION
### Description

Related to #3968

Currently, `HybridRegex::replace_all` is only used in `rolldown_plugin_alias`.
