### PR TITLE
feat(plugin/vite-resolve): port changes after Vite 6

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -164,6 +164,7 @@ pub struct BindingViteResolvePluginConfig {
   pub resolve_options: BindingViteResolvePluginResolveOptions,
   pub environment_consumer: String,
   pub environment_name: String,
+  pub builtins: Vec<BindingStringOrRegex>,
   #[napi(ts_type = "true | string[]")]
   pub external: napi::Either<BindingTrueValue, Vec<String>>,
   #[napi(ts_type = "true | Array<string | RegExp>")]
@@ -178,8 +179,6 @@ pub struct BindingViteResolvePluginConfig {
   #[debug("{}", if finalize_bare_specifier.is_some() { "Some(<finalize_other_specifiers>)" } else { "None" })]
   #[napi(ts_type = "(resolvedId: string, rawId: string) => VoidNullable<string>")]
   pub finalize_other_specifiers: Option<JsCallback<FnArgs<(String, String)>, Option<String>>>,
-
-  pub runtime: String,
 }
 
 impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
@@ -199,6 +198,7 @@ impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
       resolve_options: value.resolve_options.into(),
       environment_consumer: value.environment_consumer,
       environment_name: value.environment_name,
+      builtins: bindingify_string_or_regex_array(value.builtins),
       external,
       no_external,
       dedupe: value.dedupe,
@@ -233,8 +233,6 @@ impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
           })
         },
       ),
-
-      runtime: value.runtime,
     }
   }
 }

--- a/crates/rolldown_plugin_vite_resolve/src/builtin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/builtin.rs
@@ -1,0 +1,45 @@
+use oxc_resolver::NODEJS_BUILTINS;
+use rolldown_utils::{js_regex::HybridRegex, pattern_filter::StringOrRegex};
+use rustc_hash::FxHashSet;
+
+const NODE_BUILTIN_NAMESPACE: &str = "node:";
+const NPM_BUILTIN_NAMESPACE: &str = "npm:";
+const BUN_BUILTIN_NAMESPACE: &str = "bun:";
+
+#[derive(Debug)]
+pub struct BuiltinChecker {
+  builtin_strings: FxHashSet<String>,
+  builtin_regexes: Vec<HybridRegex>,
+}
+
+impl BuiltinChecker {
+  pub fn new(builtins: Vec<StringOrRegex>) -> Self {
+    let mut builtin_strings = FxHashSet::default();
+    let mut builtin_regexes = Vec::new();
+    for builtin in builtins {
+      match builtin {
+        StringOrRegex::String(s) => {
+          builtin_strings.insert(s);
+        }
+        StringOrRegex::Regex(regex) => {
+          builtin_regexes.push(regex);
+        }
+      }
+    }
+    Self { builtin_strings, builtin_regexes }
+  }
+
+  pub fn is_builtin(&self, id: &str) -> bool {
+    if self.builtin_strings.contains(id) {
+      return true;
+    }
+    self.builtin_regexes.iter().any(|regex| regex.matches(id))
+  }
+}
+
+pub fn is_node_like_builtin(id: &str) -> bool {
+  id.starts_with(NPM_BUILTIN_NAMESPACE)
+    || id.starts_with(BUN_BUILTIN_NAMESPACE)
+    || id.starts_with(NODE_BUILTIN_NAMESPACE)
+    || NODEJS_BUILTINS.contains(&id)
+}

--- a/crates/rolldown_plugin_vite_resolve/src/external.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/external.rs
@@ -5,7 +5,10 @@ use rolldown_utils::{dashmap::FxDashMap, pattern_filter::StringOrRegex};
 use rustc_hash::FxHashSet;
 
 use crate::{
-  builtin::BuiltinChecker, resolver::Resolver, utils::{can_externalize_file, get_npm_package_name, is_bare_import, is_in_node_modules}, utils_filter::UtilsFilter
+  builtin::BuiltinChecker,
+  resolver::Resolver,
+  utils::{can_externalize_file, get_npm_package_name, is_bare_import, is_in_node_modules},
+  utils_filter::UtilsFilter,
 };
 
 #[derive(Debug, Clone)]

--- a/crates/rolldown_plugin_vite_resolve/src/external.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/external.rs
@@ -5,11 +5,7 @@ use rolldown_utils::{dashmap::FxDashMap, pattern_filter::StringOrRegex};
 use rustc_hash::FxHashSet;
 
 use crate::{
-  resolver::Resolver,
-  utils::{
-    can_externalize_file, get_npm_package_name, is_bare_import, is_builtin, is_in_node_modules,
-  },
-  utils_filter::UtilsFilter,
+  builtin::BuiltinChecker, resolver::Resolver, utils::{can_externalize_file, get_npm_package_name, is_bare_import, is_in_node_modules}, utils_filter::UtilsFilter
 };
 
 #[derive(Debug, Clone)]
@@ -75,14 +71,18 @@ pub struct ExternalDeciderOptions {
 #[derive(Debug)]
 pub struct ExternalDecider {
   options: ExternalDeciderOptions,
-  runtime: String,
   resolver: Arc<Resolver>,
+  builtin_checker: Arc<BuiltinChecker>,
   processed_ids: FxDashMap<String, bool>,
 }
 
 impl ExternalDecider {
-  pub fn new(options: ExternalDeciderOptions, runtime: String, resolver: Arc<Resolver>) -> Self {
-    Self { options, runtime, resolver, processed_ids: DashMap::default() }
+  pub fn new(
+    options: ExternalDeciderOptions,
+    resolver: Arc<Resolver>,
+    builtin_checker: Arc<BuiltinChecker>,
+  ) -> Self {
+    Self { options, resolver, builtin_checker, processed_ids: DashMap::default() }
   }
 
   pub fn is_external(&self, id: &str, importer: Option<&str>) -> bool {
@@ -92,7 +92,8 @@ impl ExternalDecider {
 
     let mut is_external = false;
     if !id.starts_with('.') && !Path::new(id).is_absolute() {
-      is_external = is_builtin(id, &self.runtime) || self.is_configured_as_external(id, importer);
+      is_external =
+        self.builtin_checker.is_builtin(id) || self.is_configured_as_external(id, importer);
     }
     self.processed_ids.insert(id.to_owned(), is_external);
 

--- a/crates/rolldown_plugin_vite_resolve/src/lib.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/lib.rs
@@ -1,3 +1,4 @@
+mod builtin;
 mod callable_plugin;
 mod external;
 mod file_url;

--- a/crates/rolldown_plugin_vite_resolve/src/package_json_cache.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/package_json_cache.rs
@@ -40,8 +40,9 @@ impl PackageJsonCache {
           let Ok(package_json_string) = fs::read_to_string(&oxc_pkg_json.realpath) else {
             return Default::default();
           };
+          let package_json_string = package_json_string.trim_start_matches("\u{feff}"); // strip bom
           let Ok(package_json) =
-            serde_json::from_str::<PackageJsonWithPeerDependenciesRaw>(&package_json_string)
+            serde_json::from_str::<PackageJsonWithPeerDependenciesRaw>(package_json_string)
           else {
             return Default::default();
           };

--- a/crates/rolldown_plugin_vite_resolve/src/resolver.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/resolver.rs
@@ -266,8 +266,7 @@ impl Resolver {
     match result {
       Ok(result) => {
         let raw_path = result.full_path().to_str().unwrap().to_string();
-        let path = raw_path.strip_prefix("\\\\?\\").unwrap_or(&raw_path);
-        let path = normalize_path(path);
+        let path = normalize_path(&raw_path);
 
         let side_effects = result
           .package_json()

--- a/crates/rolldown_plugin_vite_resolve/src/resolver.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/resolver.rs
@@ -30,7 +30,7 @@ pub struct BaseOptions<'a> {
   pub preserve_symlinks: bool,
 }
 
-const ADDITIONAL_OPTIONS_FIELD_COUNT: u8 = 3;
+const ADDITIONAL_OPTIONS_FIELD_COUNT: u8 = 2;
 const RESOLVER_COUNT: u8 = 2_u8.pow(ADDITIONAL_OPTIONS_FIELD_COUNT as u32);
 
 const DEV_PROD_CONDITION: &str = "development|production";
@@ -39,16 +39,15 @@ const DEV_PROD_CONDITION: &str = "development|production";
 pub struct AdditionalOptions {
   is_require: bool,
   prefer_relative: bool,
-  is_from_ts_importer: bool,
 }
 
 impl AdditionalOptions {
-  pub fn new(is_require: bool, prefer_relative: bool, is_from_ts_importer: bool) -> Self {
-    Self { is_require, prefer_relative, is_from_ts_importer }
+  pub fn new(is_require: bool, prefer_relative: bool) -> Self {
+    Self { is_require, prefer_relative }
   }
 
   fn as_bools(&self) -> [bool; ADDITIONAL_OPTIONS_FIELD_COUNT as usize] {
-    [self.is_require, self.prefer_relative, self.is_from_ts_importer]
+    [self.is_require, self.prefer_relative]
   }
 
   fn as_u8(&self) -> u8 {
@@ -58,7 +57,7 @@ impl AdditionalOptions {
 
 impl From<[bool; RESOLVER_COUNT as usize]> for AdditionalOptions {
   fn from(value: [bool; RESOLVER_COUNT as usize]) -> Self {
-    Self { is_require: value[0], prefer_relative: value[1], is_from_ts_importer: value[2] }
+    Self { is_require: value[0], prefer_relative: value[1] }
   }
 }
 
@@ -101,7 +100,7 @@ impl Resolvers {
     let external_resolver = Resolver::new(
       base_resolver.clone_with_options(get_resolve_options(
         &BaseOptions { is_production: false, conditions: external_conditions, ..*base_options },
-        AdditionalOptions { is_from_ts_importer: false, is_require: false, prefer_relative: false },
+        AdditionalOptions { is_require: false, prefer_relative: false },
       )),
       Arc::clone(&package_json_cache),
       runtime,
@@ -143,16 +142,12 @@ fn get_resolve_options(
     },
     condition_names: get_conditions(base_options, &additional_options),
     extensions,
-    extension_alias: if additional_options.is_from_ts_importer {
-      vec![
-        (".js".to_string(), vec![".ts".to_string(), ".tsx".to_string(), ".js".to_string()]),
-        (".jsx".to_string(), vec![".ts".to_string(), ".tsx".to_string(), ".jsx".to_string()]),
-        (".mjs".to_string(), vec![".mts".to_string(), ".mjs".to_string()]),
-        (".cjs".to_string(), vec![".cts".to_string(), ".cjs".to_string()]),
-      ]
-    } else {
-      vec![]
-    },
+    extension_alias: vec![
+      (".js".to_string(), vec![".ts".to_string(), ".tsx".to_string(), ".js".to_string()]),
+      (".jsx".to_string(), vec![".ts".to_string(), ".tsx".to_string(), ".jsx".to_string()]),
+      (".mjs".to_string(), vec![".mts".to_string(), ".mjs".to_string()]),
+      (".cjs".to_string(), vec![".cts".to_string(), ".cjs".to_string()]),
+    ],
     main_fields,
     main_files: if !base_options.try_index {
       vec![]

--- a/crates/rolldown_plugin_vite_resolve/src/utils.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/utils.rs
@@ -1,14 +1,9 @@
 use std::borrow::Cow;
 
 use cow_utils::CowUtils;
-use oxc_resolver::NODEJS_BUILTINS;
 
 pub const BROWSER_EXTERNAL_ID: &str = "__vite-browser-external";
 pub const OPTIONAL_PEER_DEP_ID: &str = "__vite-optional-peer-dep";
-
-const NODE_BUILTIN_NAMESPACE: &str = "node:";
-const NPM_BUILTIN_NAMESPACE: &str = "npm:";
-const BUN_BUILTIN_NAMESPACE: &str = "bun:";
 
 pub fn clean_url(url: &str) -> &str {
   url.find(['?', '#']).map(|pos| (&url[..pos])).unwrap_or(url)
@@ -32,20 +27,6 @@ pub fn is_deep_import(id: &str) -> bool {
   } else {
     id[1..].contains('/')
   }
-}
-
-pub fn is_builtin(id: &str, runtime: &str) -> bool {
-  if runtime == "deno" && id.starts_with(NPM_BUILTIN_NAMESPACE) {
-    return true;
-  }
-  if runtime == "bun" && id.starts_with(BUN_BUILTIN_NAMESPACE) {
-    return true;
-  }
-  is_node_builtin(id)
-}
-
-fn is_node_builtin(id: &str) -> bool {
-  id.starts_with(NODE_BUILTIN_NAMESPACE) || NODEJS_BUILTINS.contains(&id)
 }
 
 pub fn get_extension(id: &str) -> &str {

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -9,12 +9,13 @@ use std::{
 
 use crate::{
   CallablePlugin, ResolveOptionsExternal,
+  builtin::{BuiltinChecker, is_node_like_builtin},
   external::{self, ExternalDecider, ExternalDeciderOptions},
   file_url::file_url_str_to_path_and_postfix,
   resolver::{self, AdditionalOptions, Resolvers},
   utils::{
-    BROWSER_EXTERNAL_ID, OPTIONAL_PEER_DEP_ID, clean_url, is_bare_import, is_builtin,
-    is_in_node_modules, is_windows_drive_path, normalize_path,
+    BROWSER_EXTERNAL_ID, OPTIONAL_PEER_DEP_ID, clean_url, is_bare_import, is_in_node_modules,
+    is_windows_drive_path, normalize_path,
   },
 };
 use anyhow::anyhow;
@@ -25,6 +26,7 @@ use rolldown_plugin::{
   HookResolveIdOutput, HookResolveIdReturn, HookUsage, Plugin, PluginContext,
   typedmap::TypedMapKey,
 };
+use rolldown_utils::pattern_filter::StringOrRegex;
 use rustc_hash::FxHashSet;
 use sugar_path::SugarPath;
 
@@ -35,6 +37,7 @@ pub struct ViteResolveOptions {
   pub resolve_options: ViteResolveResolveOptions,
   pub environment_consumer: String,
   pub environment_name: String,
+  pub builtins: Vec<StringOrRegex>,
   pub external: external::ResolveOptionsExternal,
   pub no_external: external::ResolveOptionsNoExternal,
   pub dedupe: Vec<String>,
@@ -42,8 +45,6 @@ pub struct ViteResolveOptions {
   pub finalize_bare_specifier: Option<Arc<FinalizeBareSpecifierCallback>>,
   #[debug(skip)]
   pub finalize_other_specifiers: Option<Arc<FinalizeOtherSpecifiersCallback>>,
-
-  pub runtime: String,
 }
 pub type FinalizeBareSpecifierCallback = dyn (Fn(
     &str,
@@ -96,10 +97,9 @@ pub struct ViteResolvePlugin {
   #[debug(skip)]
   finalize_other_specifiers: Option<Arc<FinalizeOtherSpecifiersCallback>>,
 
-  runtime: String,
-
   resolvers: Resolvers,
   external_decider: ExternalDecider,
+  builtin_checker: Arc<BuiltinChecker>,
 }
 
 impl ViteResolvePlugin {
@@ -115,10 +115,11 @@ impl ViteResolvePlugin {
       root: &options.resolve_options.root,
       preserve_symlinks: options.resolve_options.preserve_symlinks,
     };
+    let builtin_checker = Arc::new(BuiltinChecker::new(options.builtins));
     let resolvers = Resolvers::new(
       &base_options,
       &options.resolve_options.external_conditions,
-      options.runtime.clone(),
+      Arc::clone(&builtin_checker),
     );
     let no_external = Arc::new(options.no_external);
     let dedupe = Arc::new(options.dedupe.into_iter().collect());
@@ -131,7 +132,6 @@ impl ViteResolvePlugin {
       environment_name: options.environment_name,
       finalize_bare_specifier: options.finalize_bare_specifier,
       finalize_other_specifiers: options.finalize_other_specifiers,
-      runtime: options.runtime.clone(),
       external_decider: ExternalDecider::new(
         ExternalDeciderOptions {
           external: options.external,
@@ -139,9 +139,10 @@ impl ViteResolvePlugin {
           dedupe,
           is_build: options.resolve_options.is_build,
         },
-        options.runtime,
         resolvers.get_for_external(),
+        Arc::clone(&builtin_checker),
       ),
+      builtin_checker,
 
       resolvers,
       resolve_options: options.resolve_options,
@@ -233,51 +234,78 @@ impl ViteResolvePlugin {
         return Ok(Some(result));
       }
 
-      if is_builtin(args.specifier, &self.runtime) {
-        if self.environment_consumer == "server" {
-          if self.no_external.is_true()
-              // if both noExternal and external are true, noExternal will take the higher priority and bundle it.
-              // only if the id is explicitly listed in external, we will externalize it and skip this error.
-              &&(matches!(self.external, ResolveOptionsExternal::True)
-              || !self.external.is_external_explicitly(args.specifier))
-          {
-            let mut message = format!("Cannot bundle Node.js built-in \"{}\"", args.specifier);
-            if let Some(importer) = args.importer {
-              let current_dir =
-                env::current_dir().unwrap_or(PathBuf::from(&self.resolve_options.root));
-              message.push_str(&format!(
-                " imported from \"{}\"",
-                Path::new(importer).relative(current_dir).to_string_lossy()
-              ));
-            }
-            message.push_str(&format!(
-              ". Consider disabling environments.{}.noExternal or remove the built-in dependency.",
-              self.environment_name
-            ));
-            return Err(anyhow!(message));
-          }
-
-          return Ok(Some(HookResolveIdOutput {
-            id: args.specifier.into(),
-            external: Some(true.into()),
-            side_effects: Some(HookSideEffects::False),
-            ..Default::default()
-          }));
-        } else {
-          if !self.resolve_options.as_src {
-            // TODO(sapphi-red): debug log
-          } else if self.resolve_options.is_production {
-            // TODO(sapphi-red): warn log
-          }
-          return Ok(Some(HookResolveIdOutput {
-            id: if self.resolve_options.is_production {
-              arcstr::literal!(BROWSER_EXTERNAL_ID)
-            } else {
-              format!("{BROWSER_EXTERNAL_ID}:{}", args.specifier).into()
-            },
-            ..Default::default()
-          }));
+      // built-ins
+      // externalize if building for a server environment, otherwise redirect to an empty module
+      if self.environment_consumer == "server" && self.builtin_checker.is_builtin(args.specifier) {
+        return Ok(Some(HookResolveIdOutput {
+          id: args.specifier.into(),
+          external: Some(true.into()),
+          side_effects: Some(HookSideEffects::False),
+          ..Default::default()
+        }));
+      } else if self.environment_consumer == "server" && is_node_like_builtin(args.specifier) {
+        if !(matches!(self.external, ResolveOptionsExternal::True)
+          || self.external.is_external_explicitly(args.specifier))
+        {
+          // TODO(sapphi-red): warn log
+          // let mut message =
+          //   format!("Automatically externalized node built-in module \"{}\"", &args.specifier);
+          // if let Some(importer) = args.importer {
+          //   let current_dir =
+          //     env::current_dir().unwrap_or(PathBuf::from(&self.resolve_options.root));
+          //   message.push_str(&format!(
+          //     " imported from \"{}\"",
+          //     Path::new(importer).relative(current_dir).to_string_lossy()
+          //   ));
+          // }
+          // message.push_str(&format!(
+          //   ". Consider adding it to environments.{}.external if it is intended.",
+          //   self.environment_name
+          // ));
         }
+
+        return Ok(Some(HookResolveIdOutput {
+          id: args.specifier.into(),
+          external: Some(true.into()),
+          side_effects: Some(HookSideEffects::False),
+          ..Default::default()
+        }));
+      } else if self.environment_consumer == "client" && is_node_like_builtin(args.specifier) {
+        if self.no_external.is_true()
+            // if both noExternal and external are true, noExternal will take the higher priority and bundle it.
+            // only if the id is explicitly listed in external, we will externalize it and skip this error.
+            &&(matches!(self.external, ResolveOptionsExternal::True)
+            || !self.external.is_external_explicitly(args.specifier))
+        {
+          let mut message = format!("Cannot bundle Node.js built-in \"{}\"", args.specifier);
+          if let Some(importer) = args.importer {
+            let current_dir =
+              env::current_dir().unwrap_or(PathBuf::from(&self.resolve_options.root));
+            message.push_str(&format!(
+              " imported from \"{}\"",
+              Path::new(importer).relative(current_dir).to_string_lossy()
+            ));
+          }
+          message.push_str(&format!(
+            ". Consider disabling environments.{}.noExternal or remove the built-in dependency.",
+            self.environment_name
+          ));
+          return Err(anyhow!(message));
+        }
+
+        if !self.resolve_options.as_src {
+          // TODO(sapphi-red): debug log
+        } else if self.resolve_options.is_production {
+          // TODO(sapphi-red): warn log
+        }
+        return Ok(Some(HookResolveIdOutput {
+          id: if self.resolve_options.is_production {
+            arcstr::literal!(BROWSER_EXTERNAL_ID)
+          } else {
+            format!("{BROWSER_EXTERNAL_ID}:{}", args.specifier).into()
+          },
+          ..Default::default()
+        }));
       }
     }
 

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::{
   CallablePlugin, ResolveOptionsExternal,
   external::{self, ExternalDecider, ExternalDeciderOptions},
-  file_url::file_url_str_to_path,
+  file_url::file_url_str_to_path_and_postfix,
   resolver::{self, AdditionalOptions, Resolvers},
   utils::{
     BROWSER_EXTERNAL_ID, OPTIONAL_PEER_DEP_ID, clean_url, is_bare_import, is_builtin,
@@ -184,8 +184,8 @@ impl ViteResolvePlugin {
 
     // file url as path
     if args.specifier.starts_with("file://") {
-      let path = file_url_str_to_path(args.specifier)?;
-      let mut res = normalize_path(&path).into_owned();
+      let (path, postfix) = file_url_str_to_path_and_postfix(args.specifier)?;
+      let mut res = normalize_path(&path).into_owned() + &postfix;
       if let Some(finalize_other_specifiers) = &self.finalize_other_specifiers {
         if let Some(finalized) = finalize_other_specifiers(&res, args.specifier).await? {
           res = finalized;

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -29,7 +29,6 @@ use rustc_hash::FxHashSet;
 use sugar_path::SugarPath;
 
 const FS_PREFIX: &str = "/@fs/";
-const TS_EXTENSIONS: &[&str] = &[".ts", ".mts", ".cts", ".tsx"];
 
 #[derive(Debug)]
 pub struct ViteResolveOptions {
@@ -211,7 +210,6 @@ impl ViteResolvePlugin {
     let additional_options = AdditionalOptions::new(
       self.resolve_options.is_require.unwrap_or(args.kind == ImportKind::Require),
       self.resolve_options.prefer_relative || args.importer.is_some_and(|i| i.ends_with(".html")),
-      is_from_ts_importer(args.importer),
     );
     let resolver = self.resolvers.get(additional_options);
 
@@ -487,28 +485,6 @@ fn is_external_url(id: &str) -> bool {
       let protocol = &id[0..double_slash_pos];
       protocol.strip_suffix(':').map(|p| p.bytes().all(|c| c.is_ascii_alphabetic())).is_some()
     }
-  } else {
-    false
-  }
-}
-
-fn is_from_ts_importer(importer: Option<&str>) -> bool {
-  if let Some(importer) = importer {
-    // TODO(sapphi-red): support depScan, moduleMeta
-    // https://github.com/vitejs/vite/blob/58f1df3288b0f9584bb413dd34b8d65671258f6f/packages/vite/src/node/plugins/resolve.ts#L240-L248
-    has_suffix(importer, TS_EXTENSIONS)
-  } else {
-    false
-  }
-}
-
-fn has_suffix(s: &str, suffix: &[&str]) -> bool {
-  if suffix.iter().any(|suffix| s.ends_with(suffix)) {
-    return true;
-  }
-
-  if let Some((s, _)) = s.split_once('?') {
-    suffix.iter().any(|suffix| s.ends_with(suffix))
   } else {
     false
   }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -733,12 +733,12 @@ export interface BindingViteResolvePluginConfig {
   resolveOptions: BindingViteResolvePluginResolveOptions
   environmentConsumer: string
   environmentName: string
+  builtins: Array<BindingStringOrRegex>
   external: true | string[]
   noExternal: true | Array<string | RegExp>
   dedupe: Array<string>
   finalizeBareSpecifier?: (resolvedId: string, rawId: string, importer: string | null | undefined) => VoidNullable<string>
   finalizeOtherSpecifiers?: (resolvedId: string, rawId: string) => VoidNullable<string>
-  runtime: string
 }
 
 export interface BindingViteResolvePluginResolveOptions {

--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -73,16 +73,9 @@ export function buildImportAnalysisPlugin(
 }
 
 export function viteResolvePlugin(
-  config: Omit<BindingViteResolvePluginConfig, 'runtime'>,
+  config: BindingViteResolvePluginConfig,
 ): BuiltinPlugin {
-  const builtinPlugin = new BuiltinPlugin('builtin:vite-resolve', {
-    ...config,
-    runtime: process.versions.deno
-      ? 'deno'
-      : process.versions.bun
-      ? 'bun'
-      : 'node',
-  });
+  const builtinPlugin = new BuiltinPlugin('builtin:vite-resolve', config);
   return makeBuiltinPluginCallable(builtinPlugin);
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Ported changes from the following PRs:

- https://github.com/vitejs/vite/pull/18889
- https://github.com/vitejs/vite/pull/19300
- https://github.com/vitejs/vite/pull/18584, https://github.com/vitejs/vite/pull/19312

and some minor changes.

With this PR and #4270, the tests in Vite repo should now pass with native resolve plugin.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
