### PR TITLE
ci: remove `needs-triage` label when issues get assigned

### DIFF
--- a/.github/workflows/automate-jobs.yml
+++ b/.github/workflows/automate-jobs.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           actions: 'remove-labels'
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.pull_request.number || github.event.issue.number }}
           labels: 'needs-triage'
 
   approval-if-self-assigned:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
