### PR TITLE
fix: align resolve extension order with esbuild

### DIFF
--- a/crates/rolldown/tests/esbuild/ts/ts_import_in_node_modules_name_collision_with_css/_config.json
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_in_node_modules_name_collision_with_css/_config.json
@@ -6,5 +6,7 @@
         "import": "entry.ts"
       }
     ]
-  }
+  },
+  // hyf0: To pass this test, we need to finsih the builtin css support and add `.css` to the default resolve extensions.
+  "expectError": true
 }

--- a/crates/rolldown/tests/esbuild/ts/ts_import_in_node_modules_name_collision_with_css/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_in_node_modules_name_collision_with_css/artifacts.snap
@@ -1,34 +1,33 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# Assets
+# Errors
 
-## entry.css
+## PARSE_ERROR
 
-```css
-.js_ts_css {}
-.ts_css {}
+```text
+[PARSE_ERROR] Error: Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[ node_modules/pkg/js_ts.ts:1:5 ]
+   │
+ 1 │ TEST FAILED
+   │     │ 
+   │     ╰─ 
+   │ 
+   │ Help: Try insert a semicolon here
+───╯
 
 ```
-## entry.js
+## PARSE_ERROR
 
-```js
-//#region node_modules/pkg/js_ts_css.js
-function js_ts_css_default() {}
+```text
+[PARSE_ERROR] Error: Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[ node_modules/pkg/js_ts_css.ts:1:5 ]
+   │
+ 1 │ TEST FAILED
+   │     │ 
+   │     ╰─ 
+   │ 
+   │ Help: Try insert a semicolon here
+───╯
 
-//#endregion
-//#region node_modules/pkg/ts_css.ts
-function ts_css_default() {}
-
-//#endregion
-//#region node_modules/pkg/js_ts.js
-function js_ts_default() {}
-
-//#endregion
-//#region node_modules/pkg/index.ts
-js_ts_css_default();
-ts_css_default();
-js_ts_default();
-
-//#endregion
 ```

--- a/crates/rolldown/tests/esbuild/ts/ts_import_in_node_modules_name_collision_with_css/diff.md
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_in_node_modules_name_collision_with_css/diff.md
@@ -2,6 +2,44 @@
 1. rolldown don't insert debug comments in css
 2. sub optimal
 # Diff
+## /out.js
+### esbuild
+```js
+// node_modules/pkg/js_ts_css.js
+function js_ts_css_default() {
+}
+
+// node_modules/pkg/ts_css.ts
+function ts_css_default() {
+}
+
+// node_modules/pkg/js_ts.js
+function js_ts_default() {
+}
+
+// node_modules/pkg/index.ts
+js_ts_css_default();
+ts_css_default();
+js_ts_default();
+```
+### rolldown
+```js
+
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	
+@@ -1,6 +0,0 @@
+-function js_ts_css_default() {}
+-function ts_css_default() {}
+-function js_ts_default() {}
+-js_ts_css_default();
+-ts_css_default();
+-js_ts_default();
+
+```
 ## /out.css
 ### esbuild
 ```js
@@ -15,16 +53,14 @@
 ```
 ### rolldown
 ```js
-.js_ts_css {}
-.ts_css {}
 
 ```
 ### diff
 ```diff
 ===================================================================
 --- esbuild	/out.css
-+++ rolldown	entry.css
-@@ -1,7 +1,2 @@
++++ rolldown	
+@@ -1,7 +0,0 @@
 -/* node_modules/pkg/js_ts_css.css */
 -.js_ts_css {
 -}
@@ -33,7 +69,5 @@
 -.ts_css {
 -}
 \ No newline at end of file
-+.js_ts_css {}
-+.ts_css {}
 
 ```

--- a/crates/rolldown/tests/esbuild/ts/ts_prefer_js_over_ts_inside_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_prefer_js_over_ts_inside_node_modules/artifacts.snap
@@ -6,12 +6,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## src_main.js
 
 ```js
-//#region src/relative/path.js
-console.log("FAILURE");
+//#region src/relative/path.ts
+console.log("success");
 
 //#endregion
-//#region node_modules/package/path.js
-console.log("success");
+//#region node_modules/package/path.ts
+console.log("FAILURE");
 
 //#endregion
 //#region src/relative2/path.js

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3540,11 +3540,6 @@ expression: output
 
 - entry-!~{000}~.js => entry-Bk58htPI.js
 
-# tests/esbuild/ts/ts_import_in_node_modules_name_collision_with_css
-
-- entry-!~{000}~.js => entry-BdivPvW6.js
-- entry.css
-
 # tests/esbuild/ts/ts_import_missing_unused_es6
 
 - entry-!~{000}~.js => entry-CMXZovLt.js
@@ -3630,7 +3625,7 @@ expression: output
 
 # tests/esbuild/ts/ts_prefer_js_over_ts_inside_node_modules
 
-- src_main-!~{000}~.js => src_main-DnMCSLLi.js
+- src_main-!~{000}~.js => src_main-DZCcAwNA.js
 
 # tests/esbuild/ts/ts_print_non_finite_number_inside_with
 

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -107,7 +107,7 @@ impl<F: FileSystem + Default> Resolver<F> {
         .unwrap_or_else(|| vec![vec!["exports".to_string()]]),
       extension_alias,
       extensions: raw_resolve.extensions.unwrap_or_else(|| {
-        [".jsx", ".js", ".ts", ".tsx", ".json"].into_iter().map(str::to_string).collect()
+        [".tsx", ".ts", ".jsx", ".js", ".json"].into_iter().map(str::to_string).collect()
       }),
       fallback: vec![],
       fully_specified: false,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://esbuild.github.io/api/#resolve-extensions:~:text=The%20full%20order%20of%20implicit%20file%20extensions%20in%20esbuild%20can%20be%20customized%20using%20the%20resolve%20extensions%20setting%2C%20which%20defaults%20to

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
