### PR TITLE
ci: fix `remove-needs-triage-when-assigned` job

### DIFF
--- a/.github/workflows/automate-jobs.yml
+++ b/.github/workflows/automate-jobs.yml
@@ -13,6 +13,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/rolldown/rolldown/issues/4287.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
