### PR TITLE
fix(cli): `ROLLUP_WATCH` should be set when config is loaded

### DIFF
--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -14,6 +14,11 @@ export async function bundleWithConfig(
   configPath: string,
   cliOptions: NormalizedCliOptions,
 ): Promise<void> {
+  if (cliOptions.watch) {
+    process.env.ROLLUP_WATCH = 'true';
+    process.env.ROLLDOWN_WATCH = 'true';
+  }
+
   const config = await loadConfig(configPath);
 
   if (!config) {
@@ -68,8 +73,6 @@ async function watchInner(
 ) {
   // Only if watch is true in CLI can we use watch mode.
   // We should not make it `await`, as it never ends.
-  process.env.ROLLUP_WATCH = 'true';
-  process.env.ROLLDOWN_WATCH = 'true';
 
   let normalizedConfig = arraify(config).map((option) => {
     return {

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -308,7 +308,9 @@ called output options hook
 `;
 
 exports[`watch cli > should require both ROLLDOWN_WATCH and this.meta.watchMode to be false 1`] = `
-"options called:
+"process.env.ROLLUP_WATCH undefined
+process.env.ROLLDOWN_WATCH undefined
+options called:
 this.meta.watchMode false
 process.env.ROLLUP_WATCH undefined
 process.env.ROLLDOWN_WATCH undefined
@@ -320,7 +322,9 @@ this.meta.watchMode false"
 `;
 
 exports[`watch cli > should require both ROLLDOWN_WATCH and this.meta.watchMode to be true 1`] = `
-"Waiting for changes...
+"process.env.ROLLUP_WATCH true
+process.env.ROLLDOWN_WATCH true
+Waiting for changes...
 options called:
 this.meta.watchMode true
 process.env.ROLLUP_WATCH true

--- a/packages/rolldown/tests/cli/fixtures/watch-mode/rolldown.config.ts
+++ b/packages/rolldown/tests/cli/fixtures/watch-mode/rolldown.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from 'rolldown'
 
+console.log('process.env.ROLLUP_WATCH', process.env.ROLLUP_WATCH)
+console.log('process.env.ROLLDOWN_WATCH', process.env.ROLLDOWN_WATCH)
+
 export default defineConfig({
   input: 'index.ts',
   cwd: import.meta.dirname,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`ROLLUP_WATCH` and `ROLLDOWN_WATCH` should be set before loading the config so that it is set even if it's referenced in the top-level of the config.

refs #3967

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

