### PR TITLE
fix(hmr): reexport named declaration

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -1,17 +1,19 @@
 use oxc::{
   allocator::{Allocator, Box as ArenaBox, Dummy, IntoIn, TakeIn},
-  ast::NONE,
-  ast::ast::{self, ExportDefaultDeclarationKind},
+  ast::{
+    NONE,
+    ast::{self, ExportDefaultDeclarationKind, Expression, ObjectPropertyKind},
+  },
   ast_visit::{VisitMut, walk_mut},
   semantic::{Scoping, SymbolId},
-  span::{Atom, SPAN},
+  span::SPAN,
 };
 
 use rolldown_common::{IndexModules, Module, ModuleIdx, NormalModule};
 use rolldown_ecmascript_utils::{
-  AstSnippet, BindingIdentifierExt, BindingPatternExt, ExpressionExt, quote_stmt, quote_stmts,
+  AstSnippet, BindingIdentifierExt, ExpressionExt, quote_stmt, quote_stmts,
 };
-use rolldown_utils::{ecmascript::is_validate_identifier_name, indexmap::FxIndexSet};
+use rolldown_utils::indexmap::FxIndexSet;
 use rustc_hash::FxHashMap;
 
 pub struct HmrAstFinalizer<'me, 'ast> {
@@ -24,12 +26,12 @@ pub struct HmrAstFinalizer<'me, 'ast> {
   pub affected_module_idx_to_init_fn_name: &'me FxHashMap<ModuleIdx, String>,
   //Internal state
   pub import_binding: FxHashMap<SymbolId, String>,
-  pub exports: FxHashMap<Atom<'ast>, Atom<'ast>>,
+  pub exports: oxc::allocator::Vec<'ast, ObjectPropertyKind<'ast>>,
   pub dependencies: FxIndexSet<ModuleIdx>,
 }
 
 impl<'ast> HmrAstFinalizer<'_, 'ast> {
-  pub fn generate_hmr_header(&self) -> Vec<ast::Statement<'ast>> {
+  pub fn generate_hmr_header(&mut self) -> Vec<ast::Statement<'ast>> {
     let mut ret = vec![];
 
     // `import.meta.hot = __rolldown_runtime__.createModuleHotContext(moduleId);`
@@ -52,36 +54,17 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     stmt
   }
 
-  pub fn generate_runtime_module_register_for_hmr(&self) -> Vec<ast::Statement<'ast>> {
+  pub fn generate_runtime_module_register_for_hmr(&mut self) -> Vec<ast::Statement<'ast>> {
     let mut ret = vec![];
 
     let module_exports = match self.module.exports_kind {
       rolldown_common::ExportsKind::Esm => {
         // TODO: Still we could reuse use module namespace def
 
-        // Empty object `{}`
-        let mut arg_obj_expr =
-          self.snippet.builder.alloc_object_expression(SPAN, self.snippet.builder.vec());
-
-        self.exports.iter().for_each(|(exported, local_name)| {
-          // prop_name: () => returned
-          let prop_name = exported;
-          let returned = self.snippet.id_ref_expr(local_name, SPAN);
-          arg_obj_expr.properties.push(ast::ObjectPropertyKind::ObjectProperty(
-            ast::ObjectProperty {
-              key: if is_validate_identifier_name(prop_name) {
-                ast::PropertyKey::StaticIdentifier(
-                  self.snippet.id_name(prop_name, SPAN).into_in(self.alloc),
-                )
-              } else {
-                ast::PropertyKey::StringLiteral(self.snippet.alloc_string_literal(prop_name, SPAN))
-              },
-              value: self.snippet.only_return_arrow_expr(returned),
-              ..ast::ObjectProperty::dummy(self.alloc)
-            }
-            .into_in(self.alloc),
-          ));
-        });
+        let arg_obj_expr = self.snippet.builder.alloc_object_expression(
+          SPAN,
+          self.snippet.builder.vec_from_iter(self.exports.drain(..)),
+        );
         ast::Argument::ObjectExpression(arg_obj_expr)
       }
       rolldown_common::ExportsKind::CommonJs => {
@@ -333,40 +316,107 @@ impl<'ast> VisitMut<'ast> for HmrAstFinalizer<'_, 'ast> {
         }
         ast::ModuleDeclaration::ExportNamedDeclaration(decl) => {
           if let Some(_source) = &decl.source {
-            // TODO: support reexport
             // export {} from '...'
-            decl.specifiers.iter().for_each(|spec| {
-              self.exports.insert(spec.exported.name(), spec.local.name());
-            });
+            let rec_id = self.module.imports[&decl.span];
+            let rec = &self.module.import_records[rec_id];
+            self.dependencies.insert(rec.resolved_module);
+            match &self.modules[rec.resolved_module] {
+              Module::Normal(importee) => {
+                self.dependencies.insert(rec.resolved_module);
+                let id = &importee.stable_id;
+                let binding_name = format!("import_{}", importee.repr_name);
+                let stmt = quote_stmt(
+                  self.alloc,
+                  format!("const {binding_name} = __rolldown_runtime__.loadExports({id:?});",)
+                    .as_str(),
+                );
+                self.exports.extend(decl.specifiers.iter().map(|specifier| {
+                  self.snippet.object_property_kind_object_property(
+                    &specifier.exported.name(),
+                    match &specifier.local {
+                      ast::ModuleExportName::IdentifierName(ident) => {
+                        Expression::StaticMemberExpression(
+                          self.snippet.builder.alloc_static_member_expression(
+                            SPAN,
+                            self.snippet.id_ref_expr(&binding_name, SPAN),
+                            self.snippet.builder.identifier_name(SPAN, ident.name.as_str()),
+                            false,
+                          ),
+                        )
+                      }
+                      ast::ModuleExportName::StringLiteral(str) => {
+                        Expression::ComputedMemberExpression(
+                          self.snippet.builder.alloc_computed_member_expression(
+                            SPAN,
+                            self.snippet.id_ref_expr(&binding_name, SPAN),
+                            self.snippet.builder.expression_string_literal(
+                              SPAN, str.value.as_str(), None
+                            ),
+                            false,
+                          ),
+                        )
+                      }
+                      ast::ModuleExportName::IdentifierReference(_) => {
+                        unreachable!(
+                          "ModuleExportName IdentifierReference is invalid in ExportNamedDeclaration with source"
+                        )
+                      }
+                    },
+                    matches!(specifier.exported, ast::ModuleExportName::StringLiteral(_))
+                  )
+                }));
+
+                *node = stmt;
+              }
+              Module::External(_importee) => {
+                todo!("handle external module");
+              }
+            }
           } else if let Some(decl) = &mut decl.declaration {
             match decl {
               ast::Declaration::VariableDeclaration(var_decl) => {
                 // export var foo = 1
                 // export var { foo, bar } = { foo: 1, bar: 2 }
-                var_decl.declarations.iter().for_each(|decl| {
-                  decl.id.binding_identifiers().into_iter().for_each(|id| {
-                    self.exports.insert(id.name, id.name);
-                  });
-                });
+                self.exports.extend(var_decl.declarations.iter().filter_map(|decl| {
+                  decl.id.get_identifier_name().map(|ident| {
+                    self.snippet.object_property_kind_object_property(
+                      ident.as_str(),
+                      self.snippet.id_ref_expr(ident.as_str(), SPAN),
+                      false,
+                    )
+                  })
+                }));
               }
               ast::Declaration::FunctionDeclaration(fn_decl) => {
                 // export function foo() {}
-                let id = fn_decl.id.as_ref().unwrap();
-                self.exports.insert(id.name, id.name);
+                let id = fn_decl.id.as_ref().unwrap().name.as_str();
+                self.exports.push(self.snippet.object_property_kind_object_property(
+                  id,
+                  self.snippet.id_ref_expr(id, SPAN),
+                  false,
+                ));
               }
               ast::Declaration::ClassDeclaration(cls_decl) => {
                 // export class Foo {}
-                let id = cls_decl.id.as_ref().unwrap();
-                self.exports.insert(id.name, id.name);
+                let id = cls_decl.id.as_ref().unwrap().name.as_str();
+                self.exports.push(self.snippet.object_property_kind_object_property(
+                  id,
+                  self.snippet.id_ref_expr(id, SPAN),
+                  false,
+                ));
               }
               _ => unreachable!("doesn't support ts now"),
             }
             *node = ast::Statement::from(decl.take_in(self.alloc));
           } else {
             // export { foo, bar as bar2 }
-            decl.specifiers.iter().for_each(|spec| {
-              self.exports.insert(spec.exported.name(), spec.local.name());
-            });
+            self.exports.extend(decl.specifiers.iter().map(|specifier| {
+              self.snippet.object_property_kind_object_property(
+                &specifier.exported.name(),
+                self.snippet.id_ref_expr(&specifier.local.name(), SPAN),
+                matches!(specifier.exported, ast::ModuleExportName::StringLiteral(_)),
+              )
+            }));
             *node =
               ast::Statement::EmptyStatement(self.snippet.builder.alloc_empty_statement(SPAN));
           }
@@ -374,10 +424,18 @@ impl<'ast> VisitMut<'ast> for HmrAstFinalizer<'_, 'ast> {
         ast::ModuleDeclaration::ExportDefaultDeclaration(decl) => match &mut decl.declaration {
           ast::ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
             if let Some(id) = &function.id {
-              self.exports.insert("default".into(), id.name);
+              self.exports.push(self.snippet.object_property_kind_object_property(
+                "default",
+                self.snippet.id_ref_expr(&id.name, SPAN),
+                false,
+              ));
             } else {
               function.id = Some(self.snippet.id("__rolldown_default__", SPAN));
-              self.exports.insert("default".into(), "__rolldown_default__".into());
+              self.exports.push(self.snippet.object_property_kind_object_property(
+                "default",
+                self.snippet.id_ref_expr("__rolldown_default__", SPAN),
+                false,
+              ));
             }
             *node = ast::Statement::FunctionDeclaration(ArenaBox::new_in(
               function.as_mut().take_in(self.alloc),
@@ -386,10 +444,18 @@ impl<'ast> VisitMut<'ast> for HmrAstFinalizer<'_, 'ast> {
           }
           ast::ExportDefaultDeclarationKind::ClassDeclaration(class) => {
             if let Some(id) = &class.id {
-              self.exports.insert("default".into(), id.name);
+              self.exports.push(self.snippet.object_property_kind_object_property(
+                "default",
+                self.snippet.id_ref_expr(&id.name, SPAN),
+                false,
+              ));
             } else {
               class.id = Some(self.snippet.id("__rolldown_default__", SPAN));
-              self.exports.insert("default".into(), "__rolldown_default__".into());
+              self.exports.push(self.snippet.object_property_kind_object_property(
+                "default",
+                self.snippet.id_ref_expr("__rolldown_default__", SPAN),
+                false,
+              ));
             }
             *node = ast::Statement::ClassDeclaration(ArenaBox::new_in(
               class.as_mut().take_in(self.alloc),
@@ -400,7 +466,11 @@ impl<'ast> VisitMut<'ast> for HmrAstFinalizer<'_, 'ast> {
             let expr = expr.to_expression_mut();
             // Transform `export default [expression]` => `var __rolldown_default__ = [expression]`
             *node = self.snippet.var_decl_stmt("__rolldown_default__", expr.take_in(self.alloc));
-            self.exports.insert("default".into(), "__rolldown_default__".into());
+            self.exports.push(self.snippet.object_property_kind_object_property(
+              "default",
+              self.snippet.id_ref_expr("__rolldown_default__", SPAN),
+              false,
+            ));
           }
           unhandled_kind => {
             unreachable!("Unexpected export default declaration kind: {unhandled_kind:#?}");

--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -195,7 +195,7 @@ impl HmrManager {
           scoping: &scoping,
           import_binding: FxHashMap::default(),
           module: affected_module,
-          exports: FxHashMap::default(),
+          exports: oxc::allocator::Vec::new_in(fields.allocator),
           affected_module_idx_to_init_fn_name: &module_idx_to_init_fn_name,
           dependencies: FxIndexSet::default(),
         };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

``` .js
export { foo } from './foo.js'
```
support this case.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
