### PR TITLE
refactor: processing external module in tokio thread instead of main thread

### DIFF
--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -1,0 +1,106 @@
+use std::{path::Path, sync::Arc};
+
+use arcstr::ArcStr;
+use rolldown_common::{
+  ExternalModuleTaskResult, ModuleId, ModuleIdx, ModuleInfo, ModuleLoaderMsg, ResolvedExternal,
+  ResolvedId,
+};
+use rolldown_error::BuildResult;
+use rolldown_utils::{ecmascript::legitimize_identifier_name, indexmap::FxIndexSet};
+use sugar_path::SugarPath;
+
+use crate::ecmascript::ecma_module_view_factory::normalize_side_effects;
+
+use super::task_context::TaskContext;
+
+#[allow(clippy::rc_buffer)]
+pub struct ExternalModuleTask {
+  ctx: Arc<TaskContext>,
+  module_idx: ModuleIdx,
+  resolved_id: ResolvedId,
+  user_defined_entries: Arc<Vec<(Option<ArcStr>, ResolvedId)>>,
+  /// The module is asserted to be this specific module type.
+  build_span: tracing::Span,
+}
+
+#[allow(clippy::rc_buffer)]
+impl ExternalModuleTask {
+  pub fn new(
+    ctx: Arc<TaskContext>,
+    idx: ModuleIdx,
+    resolved_id: ResolvedId,
+    build_span: tracing::Span,
+    user_defined_entries: Arc<Vec<(Option<ArcStr>, ResolvedId)>>,
+  ) -> Self {
+    Self { ctx, module_idx: idx, resolved_id, build_span, user_defined_entries }
+  }
+  #[tracing::instrument(name="ExternalModuleTask::run", parent = &self.build_span, level = "trace", skip_all, fields(module_id = ?self.resolved_id.id))]
+  pub async fn run(self) {
+    if let Err(errs) = self.run_inner().await {
+      self
+        .ctx
+        .tx
+        .send(ModuleLoaderMsg::BuildErrors(errs.into_vec()))
+        .await
+        .expect("Send should not fail");
+    }
+  }
+
+  async fn run_inner(&self) -> BuildResult<()> {
+    let resolved_id = &self.resolved_id;
+    let external_module_side_effects =
+      normalize_side_effects(&self.ctx.options, resolved_id, None, None, resolved_id.side_effects)
+        .await?;
+    let id = ModuleId::new(&resolved_id.id);
+    self.ctx.plugin_driver.set_module_info(
+      &id.clone(),
+      Arc::new(ModuleInfo {
+        code: None,
+        id,
+        is_entry: false,
+        importers: FxIndexSet::default(),
+        dynamic_importers: FxIndexSet::default(),
+        imported_ids: FxIndexSet::default(),
+        dynamically_imported_ids: FxIndexSet::default(),
+        exports: vec![],
+      }),
+    );
+
+    let need_renormalize_render_path = !matches!(resolved_id.external, ResolvedExternal::Absolute)
+      && Path::new(resolved_id.id.as_str()).is_absolute();
+
+    let file_name = if need_renormalize_render_path {
+      let entries_common_dir = commondir::CommonDir::try_new(
+        self.user_defined_entries.iter().map(|(_, resolved_id)| resolved_id.id.as_str()),
+      )
+      .expect("should have common dir for entries");
+      let relative_path =
+        Path::new(resolved_id.id.as_str()).relative(entries_common_dir.common_root());
+      relative_path.to_slash_lossy().into()
+    } else {
+      resolved_id.id.clone()
+    };
+
+    let identifier_name = if need_renormalize_render_path {
+      Path::new(resolved_id.id.as_str())
+        .relative(&self.ctx.options.cwd)
+        .normalize()
+        .to_slash_lossy()
+        .into()
+    } else {
+      resolved_id.id.clone()
+    };
+    let legitimized_identifier_name = legitimize_identifier_name(&identifier_name);
+    let msg = ModuleLoaderMsg::ExternalModuleDone(ExternalModuleTaskResult {
+      idx: self.module_idx,
+      id: resolved_id.id.clone(),
+      name: file_name,
+      identifier_name: legitimized_identifier_name.into(),
+      side_effects: external_module_side_effects,
+      need_renormalize_render_path,
+    });
+    // If the main thread is dead, nothing we can do to handle these send failures.
+    let _ = self.ctx.tx.send(msg).await;
+    Ok(())
+  }
+}

--- a/crates/rolldown/src/module_loader/mod.rs
+++ b/crates/rolldown/src/module_loader/mod.rs
@@ -3,3 +3,4 @@ pub mod module_task;
 mod runtime_module_task;
 pub mod task_context;
 pub use module_loader::ModuleLoader;
+pub mod external_module_task;

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -95,7 +95,7 @@ pub use crate::{
     AddEntryModuleMsg, ModuleLoaderMsg,
     runtime_module_brief::{RUNTIME_MODULE_ID, RuntimeModuleBrief},
     runtime_task_result::RuntimeModuleTaskResult,
-    task_result::{EcmaRelated, NormalModuleTaskResult},
+    task_result::{EcmaRelated, ExternalModuleTaskResult, NormalModuleTaskResult},
   },
   types::asset::Asset,
   types::asset_idx::AssetIdx,

--- a/crates/rolldown_common/src/module_loader/mod.rs
+++ b/crates/rolldown_common/src/module_loader/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use arcstr::ArcStr;
 use rolldown_error::BuildDiagnostic;
 use runtime_task_result::RuntimeModuleTaskResult;
-use task_result::NormalModuleTaskResult;
+use task_result::{ExternalModuleTaskResult, NormalModuleTaskResult};
 
 use crate::{EmittedChunk, ResolvedId};
 
@@ -13,6 +13,7 @@ pub mod task_result;
 
 pub enum ModuleLoaderMsg {
   NormalModuleDone(NormalModuleTaskResult),
+  ExternalModuleDone(ExternalModuleTaskResult),
   RuntimeNormalModuleDone(RuntimeModuleTaskResult),
   FetchModule(ResolvedId),
   AddEntryModule(AddEntryModuleMsg),

--- a/crates/rolldown_common/src/module_loader/task_result.rs
+++ b/crates/rolldown_common/src/module_loader/task_result.rs
@@ -1,7 +1,8 @@
 use crate::{
-  ImportRecordIdx, Module, RawImportRecord, ResolvedId, SymbolRefDbForModule,
-  dynamic_import_usage::DynamicImportExportsUsage,
+  ImportRecordIdx, Module, ModuleIdx, RawImportRecord, ResolvedId, SymbolRefDbForModule,
+  dynamic_import_usage::DynamicImportExportsUsage, side_effects::DeterminedSideEffects,
 };
+use arcstr::ArcStr;
 use oxc_index::IndexVec;
 use rolldown_ecmascript::EcmaAst;
 use rolldown_error::BuildDiagnostic;
@@ -13,6 +14,15 @@ pub struct NormalModuleTaskResult {
   pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
   pub warnings: Vec<BuildDiagnostic>,
+}
+
+pub struct ExternalModuleTaskResult {
+  pub idx: ModuleIdx,
+  pub id: ArcStr,
+  pub name: ArcStr,
+  pub identifier_name: ArcStr,
+  pub side_effects: DeterminedSideEffects,
+  pub need_renormalize_render_path: bool,
 }
 
 pub struct EcmaRelated {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
#### Context
1. https://github.com/rolldown/rolldown/pull/4305 breaks the wasi build, 
![image](https://github.com/user-attachments/assets/0974e239-fe9a-493e-befa-907f0687f53f)
I guess it is due to the fact that I changed `try_spawn_task` to `async`,whichs is requir.d,
Because `moduleSideEffects` maybe a `jsFunction` call, so it needs to be converted to async, since async is contagious, the caller also needs to be converted to `async`.

Now this pr tries to solve this problem without converting `try_spawn_task` to async, which moves `externalModuole` processing to another tokio thread. 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
