### PR TITLE
refactor: enable `isolatedModules` & `verbatimModuleSyntax`

### DIFF
--- a/packages/rolldown/src/api/build.ts
+++ b/packages/rolldown/src/api/build.ts
@@ -1,5 +1,5 @@
-import { InputOptions } from '../options/input-options';
-import { OutputOptions } from '../options/output-options';
+import type { InputOptions } from '../options/input-options';
+import type { OutputOptions } from '../options/output-options';
 import type { RolldownOutput } from '../types/rolldown-output';
 import { rolldown } from './rolldown';
 

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -1,10 +1,10 @@
 import {
-  BundlerWithStopWorker,
+  type BundlerWithStopWorker,
   createBundler,
 } from '../../utils/create-bundler';
 import { transformToRollupOutput } from '../../utils/transform-to-rollup-output';
 
-import { BindingHmrOutput } from '../../binding';
+import type { BindingHmrOutput } from '../../binding';
 import type { InputOptions } from '../../options/input-options';
 import type { OutputOptions } from '../../options/output-options';
 import type { HasProperty, TypeAssert } from '../../types/assert';

--- a/packages/rolldown/src/api/watch/index.ts
+++ b/packages/rolldown/src/api/watch/index.ts
@@ -1,5 +1,5 @@
 import type { WatchOptions } from '../../options/watch-options';
-import { RolldownWatcher, WatcherEmitter } from './watch-emitter';
+import { type RolldownWatcher, WatcherEmitter } from './watch-emitter';
 import { createWatcher } from './watcher';
 
 // Compat to `rollup.watch`

--- a/packages/rolldown/src/api/watch/watch-emitter.ts
+++ b/packages/rolldown/src/api/watch/watch-emitter.ts
@@ -1,5 +1,5 @@
 import { BindingWatcherEvent } from '../../binding';
-import { MaybePromise } from '../../types/utils';
+import type { MaybePromise } from '../../types/utils';
 import { normalizeErrors } from '../../utils/error';
 
 export type WatcherEvent = 'close' | 'event' | 'restart' | 'change';

--- a/packages/rolldown/src/api/watch/watcher.ts
+++ b/packages/rolldown/src/api/watch/watcher.ts
@@ -1,10 +1,10 @@
 import { BindingWatcher, shutdownAsyncRuntime } from '../../binding';
 import { LOG_LEVEL_WARN } from '../../log/logging';
 import { logMultiplyNotifyOption } from '../../log/logs';
-import { WatchOptions } from '../../options/watch-options';
+import type { WatchOptions } from '../../options/watch-options';
 import { PluginDriver } from '../../plugin/plugin-driver';
 import {
-  BundlerOptionWithStopWorker,
+  type BundlerOptionWithStopWorker,
   createBundlerOptions,
 } from '../../utils/create-bundler-option';
 import { arraify } from '../../utils/misc';

--- a/packages/rolldown/src/builtin-plugin/replace-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/replace-plugin.ts
@@ -1,4 +1,4 @@
-import { BindingReplacePluginConfig } from '../binding';
+import type { BindingReplacePluginConfig } from '../binding';
 
 import { BuiltinPlugin } from './constructors';
 

--- a/packages/rolldown/src/builtin-plugin/transform-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/transform-plugin.ts
@@ -1,6 +1,6 @@
 import { BuiltinPlugin } from './constructors';
 
-import { BindingTransformPluginConfig } from '../binding';
+import type { BindingTransformPluginConfig } from '../binding';
 import { normalizedStringOrRegex } from '../utils/normalize-string-or-regex';
 
 type TransformPattern = string | RegExp | readonly (RegExp | string)[];

--- a/packages/rolldown/src/builtin-plugin/utils.ts
+++ b/packages/rolldown/src/builtin-plugin/utils.ts
@@ -1,4 +1,7 @@
-import { BindingBuiltinPlugin, BindingCallableBuiltinPlugin } from '../binding';
+import {
+  type BindingBuiltinPlugin,
+  BindingCallableBuiltinPlugin,
+} from '../binding';
 
 import { BuiltinPlugin } from './constructors';
 

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -6,7 +6,7 @@ import type { ConfigExport, RolldownOutput } from '../..';
 import { rolldown } from '../../api/rolldown';
 import { watch as rolldownWatch } from '../../api/watch';
 import { arraify } from '../../utils/misc';
-import { NormalizedCliOptions } from '../arguments/normalize';
+import type { NormalizedCliOptions } from '../arguments/normalize';
 import { loadConfig } from '../load-config';
 import { logger } from '../logger';
 

--- a/packages/rolldown/src/constants/plugin.ts
+++ b/packages/rolldown/src/constants/plugin.ts
@@ -1,4 +1,4 @@
-import { Plugin } from '../plugin';
+import type { Plugin } from '../plugin';
 
 export const ENUMERATED_INPUT_PLUGIN_HOOK_NAMES = [
   'options',

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -3,26 +3,36 @@ import { build, type BuildOptions } from './api/build';
 import { rolldown } from './api/rolldown';
 import { RolldownBuild } from './api/rolldown/rolldown-build';
 import { watch } from './api/watch';
-import { RolldownWatcher } from './api/watch/watch-emitter';
-import { PreRenderedChunk } from './binding';
-import type { LogOrStringHandler } from './log/logging';
+import type { RolldownWatcher } from './api/watch/watch-emitter';
+import type { PreRenderedChunk } from './binding';
+import type {
+  LogLevel,
+  LogLevelOption,
+  LogOrStringHandler,
+  RollupLog,
+  RollupLogWithString,
+} from './log/logging';
 import type {
   ExternalOption,
   InputOption,
   InputOptions,
   JsxOptions,
 } from './options/input-options';
-import { NormalizedInputOptions } from './options/normalized-input-options';
-import {
+import type { NormalizedInputOptions } from './options/normalized-input-options';
+import type {
   InternalModuleFormat,
   NormalizedOutputOptions,
 } from './options/normalized-output-options';
 import type {
+  AddonFunction,
+  ChunkFileNamesFunction,
+  GlobalsFunction,
+  MinifyOptions,
   ModuleFormat,
   OutputOptions,
   PreRenderedAsset,
 } from './options/output-options';
-import { WatchOptions } from './options/watch-options';
+import type { WatchOptions } from './options/watch-options';
 import type {
   AsyncPluginHooks,
   CustomPluginOptions,
@@ -44,29 +54,36 @@ import type {
   SourceDescription,
   TransformResult,
 } from './plugin';
-export { withFilter } from './plugin';
+import { withFilter } from './plugin';
 import type {
   HookFilter,
   ModuleTypeFilter,
   StringFilter,
 } from './plugin/hook-filter';
-import {
+import type {
   MinimalPluginContext,
   PluginContextMeta,
 } from './plugin/minimal-plugin-context';
-import { DefineParallelPluginResult } from './plugin/parallel-plugin';
-import {
+import type { DefineParallelPluginResult } from './plugin/parallel-plugin';
+import type {
   EmittedAsset,
   EmittedFile,
   GetModuleInfo,
   PluginContext,
 } from './plugin/plugin-context';
-import { TransformPluginContext } from './plugin/transform-plugin-context';
-import { ConfigExport } from './types/config-export';
-import { ModuleInfo } from './types/module-info';
-import { OutputBundle } from './types/output-bundle';
+import type { TransformPluginContext } from './plugin/transform-plugin-context';
+import type { ConfigExport } from './types/config-export';
+import type {
+  LoggingFunction,
+  RollupError,
+  SourcemapIgnoreListOption,
+  WarningHandlerWithDefault,
+} from './types/misc';
+import type { ModuleInfo } from './types/module-info';
+import type { TreeshakingOptions } from './types/module-side-effects';
+import type { OutputBundle } from './types/output-bundle';
 import type { RolldownOptions } from './types/rolldown-options';
-import {
+import type {
   OutputAsset,
   OutputChunk,
   RenderedChunk,
@@ -74,16 +91,18 @@ import {
   RolldownOutput,
   SourceMap,
 } from './types/rolldown-output';
-import { ExistingRawSourceMap, SourceMapInput } from './types/sourcemap';
-import { PartialNull } from './types/utils';
+import type { ExistingRawSourceMap, SourceMapInput } from './types/sourcemap';
+import type { PartialNull } from './types/utils';
 import { defineConfig } from './utils/define-config';
 
-export { build, defineConfig, rolldown, watch };
+export { build, defineConfig, rolldown, watch, withFilter };
 export const VERSION: string = version;
 
 export type {
+  AddonFunction,
   AsyncPluginHooks,
   BuildOptions,
+  ChunkFileNamesFunction,
   ConfigExport,
   CustomPluginOptions,
   DefineParallelPluginResult,
@@ -93,6 +112,7 @@ export type {
   ExternalOption,
   FunctionPluginHooks,
   GetModuleInfo,
+  GlobalsFunction,
   HookFilter,
   HookFilterExtension,
   ImportKind,
@@ -101,7 +121,11 @@ export type {
   InternalModuleFormat,
   JsxOptions,
   LoadResult,
+  LoggingFunction,
+  LogLevel,
+  LogLevelOption,
   LogOrStringHandler,
+  MinifyOptions,
   MinimalPluginContext,
   ModuleFormat,
   ModuleInfo,
@@ -134,19 +158,17 @@ export type {
   RolldownPlugin,
   RolldownPluginOption,
   RolldownWatcher,
+  RollupError,
+  RollupLog,
+  RollupLogWithString,
   SourceDescription,
   SourceMap,
+  SourcemapIgnoreListOption,
   SourceMapInput,
   StringFilter,
   TransformPluginContext,
   TransformResult,
+  TreeshakingOptions,
+  WarningHandlerWithDefault,
   WatchOptions,
 };
-
-export type {
-  LoggingFunction,
-  LogLevel,
-  RollupError,
-  RollupLog,
-  WarningHandlerWithDefault,
-} from './types/misc';

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -1,4 +1,4 @@
-import { TransformOptions } from '../binding';
+import type { TransformOptions } from '../binding';
 import type {
   LogLevel,
   LogLevelOption,

--- a/packages/rolldown/src/options/normalized-input-options.ts
+++ b/packages/rolldown/src/options/normalized-input-options.ts
@@ -1,4 +1,4 @@
-import { InputOptions } from '..';
+import type { InputOptions } from '..';
 import { BindingNormalizedOptions } from '../binding';
 import type { LogHandler } from '../types/misc';
 

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -1,4 +1,4 @@
-import { RolldownPlugin } from '..';
+import type { RolldownPlugin } from '..';
 import type {
   BindingMinifyOptions,
   BindingNormalizedOptions,

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -1,10 +1,10 @@
-import type { PreRenderedChunk } from '../binding';
-import { RolldownOutputPluginOption } from '../plugin';
-import {
+import type { BindingMinifyOptions, PreRenderedChunk } from '../binding';
+import type { RolldownOutputPluginOption } from '../plugin';
+import type {
   SourcemapIgnoreListOption,
   SourcemapPathTransformOption,
 } from '../types/misc';
-import { RenderedChunk } from '../types/rolldown-output';
+import type { RenderedChunk } from '../types/rolldown-output';
 import type { StringOrRegExp } from '../types/utils';
 
 export type ModuleFormat =
@@ -20,12 +20,6 @@ export type ModuleFormat =
 export type AddonFunction = (chunk: RenderedChunk) => string | Promise<string>;
 
 export type ChunkFileNamesFunction = (chunkInfo: PreRenderedChunk) => string;
-
-export interface MinifyOptions {
-  mangle: boolean;
-  compress: boolean;
-  removeWhitespace: boolean;
-}
 
 export interface PreRenderedAsset {
   names: string[];
@@ -51,6 +45,8 @@ export type ESTarget =
   | 'es2023'
   | 'es2024'
   | 'esnext';
+
+export type MinifyOptions = BindingMinifyOptions;
 
 export interface OutputOptions {
   dir?: string;

--- a/packages/rolldown/src/options/watch-options.ts
+++ b/packages/rolldown/src/options/watch-options.ts
@@ -1,5 +1,5 @@
-import { InputOptions } from '../options/input-options';
-import { OutputOptions } from '../options/output-options';
+import type { InputOptions } from '../options/input-options';
+import type { OutputOptions } from '../options/output-options';
 
 export interface WatchOptions extends InputOptions {
   output?: OutputOptions | OutputOptions[];

--- a/packages/rolldown/src/parse-ast-index.ts
+++ b/packages/rolldown/src/parse-ast-index.ts
@@ -1,4 +1,4 @@
-import { Program } from '@oxc-project/types';
+import type { Program } from '@oxc-project/types';
 import { parseAsync, parseSync } from './binding';
 import type { ParseResult, ParserOptions } from './binding';
 import { locate } from './log/locate-character';

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -9,7 +9,10 @@ import { normalizeHook } from '../utils/normalize-hook';
 import path from 'node:path';
 import { SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF } from '../constants/plugin-context';
 import { NormalizedInputOptionsImpl } from '../options/normalized-input-options';
-import { bindingifySourcemap, ExistingRawSourceMap } from '../types/sourcemap';
+import {
+  bindingifySourcemap,
+  type ExistingRawSourceMap,
+} from '../types/sourcemap';
 import { normalizeErrors } from '../utils/error';
 import { transformModuleInfo } from '../utils/transform-module-info';
 import { bindingifySideEffects } from '../utils/transform-side-effects';
@@ -25,7 +28,7 @@ import {
 import type { BindingifyPluginArgs } from './bindingify-plugin';
 import {
   bindingifyPluginHookMeta,
-  PluginHookWithBindingExt,
+  type PluginHookWithBindingExt,
 } from './bindingify-plugin-hook-meta';
 import type {
   PluginHooks,
@@ -34,7 +37,7 @@ import type {
 } from './index';
 import {
   PluginContextImpl,
-  PrivatePluginContextResolveOptions,
+  type PrivatePluginContextResolveOptions,
 } from './plugin-context';
 import { TransformPluginContextImpl } from './transform-plugin-context';
 

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -6,14 +6,14 @@ import { normalizeErrors } from '../utils/error';
 import { normalizeHook } from '../utils/normalize-hook';
 import { transformRenderedChunk } from '../utils/transform-rendered-chunk';
 import {
-  ChangedOutputs,
+  type ChangedOutputs,
   collectChangedBundle,
   transformToOutputBundle,
 } from '../utils/transform-to-rollup-output';
 import type { BindingifyPluginArgs } from './bindingify-plugin';
 import {
   bindingifyPluginHookMeta,
-  PluginHookWithBindingExt,
+  type PluginHookWithBindingExt,
 } from './bindingify-plugin-hook-meta';
 import { PluginContextImpl } from './plugin-context';
 

--- a/packages/rolldown/src/plugin/bindingify-plugin-hook-meta.ts
+++ b/packages/rolldown/src/plugin/bindingify-plugin-hook-meta.ts
@@ -1,5 +1,5 @@
-import { BindingPluginHookMeta, BindingPluginOrder } from '../binding';
-import { ObjectHookMeta, PluginOrder } from '.';
+import { type BindingPluginHookMeta, BindingPluginOrder } from '../binding';
+import type { ObjectHookMeta, PluginOrder } from '.';
 
 export function bindingifyPluginHookMeta(
   options: ObjectHookMeta,

--- a/packages/rolldown/src/plugin/bindingify-watch-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-watch-hooks.ts
@@ -1,9 +1,9 @@
 import type { BindingPluginOptions } from '../binding';
 import { normalizeHook } from '../utils/normalize-hook';
-import { BindingifyPluginArgs } from './bindingify-plugin';
+import type { BindingifyPluginArgs } from './bindingify-plugin';
 import {
   bindingifyPluginHookMeta,
-  PluginHookWithBindingExt,
+  type PluginHookWithBindingExt,
 } from './bindingify-plugin-hook-meta';
 import type { ChangeEvent } from './index';
 import { PluginContextImpl } from './plugin-context';

--- a/packages/rolldown/src/plugin/generated/hook-usage.ts
+++ b/packages/rolldown/src/plugin/generated/hook-usage.ts
@@ -41,7 +41,7 @@ export class HookUsage {
   }
 }
 
-import { Plugin } from '../..';
+import type { Plugin } from '../..';
 export function extractHookUsage(plugin: Plugin): HookUsage {
   let hookUsage = new HookUsage();
 

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -13,7 +13,7 @@ import type { NormalizedOutputOptions } from '../options/normalized-output-optio
 import type { RollupLog } from '../types/misc';
 import type { ModuleInfo } from '../types/module-info';
 import type { OutputBundle } from '../types/output-bundle';
-import { RenderedChunk } from '../types/rolldown-output';
+import type { RenderedChunk } from '../types/rolldown-output';
 import type { SourceMapInput } from '../types/sourcemap';
 import type {
   MakeAsync,

--- a/packages/rolldown/src/plugin/plugin-context-data.ts
+++ b/packages/rolldown/src/plugin/plugin-context-data.ts
@@ -1,9 +1,9 @@
-import { ModuleOptions } from '..';
+import type { ModuleOptions } from '..';
 import { BindingPluginContext } from '../binding';
 import type { ModuleInfo } from '../types/module-info';
 import { transformModuleInfo } from '../utils/transform-module-info';
-import { RenderedChunkMeta } from '.';
-import { PluginContextResolveOptions } from './plugin-context';
+import type { RenderedChunkMeta } from '.';
+import type { PluginContextResolveOptions } from './plugin-context';
 
 export class PluginContextData {
   moduleOptionMap: Map<string, ModuleOptions> = new Map();

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -1,19 +1,19 @@
-import { Program } from '@oxc-project/types';
+import type { Program } from '@oxc-project/types';
 import type { BindingPluginContext, ParserOptions } from '../binding';
 import { SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF } from '../constants/plugin-context';
 import { LOG_LEVEL_WARN } from '../log/logging';
 import { logCycleLoading } from '../log/logs';
-import { OutputOptions } from '../options/output-options';
+import type { OutputOptions } from '../options/output-options';
 import { parseAst } from '../parse-ast-index';
 import {
-  MinimalPluginContext,
+  type MinimalPluginContext,
   MinimalPluginContextImpl,
 } from '../plugin/minimal-plugin-context';
 import type { Extends, TypeAssert } from '../types/assert';
 import type { LogHandler, LogLevelOption } from '../types/misc';
-import { ModuleInfo } from '../types/module-info';
-import { PartialNull } from '../types/utils';
-import { AssetSource, bindingAssetSource } from '../utils/asset-source';
+import type { ModuleInfo } from '../types/module-info';
+import type { PartialNull } from '../types/utils';
+import { type AssetSource, bindingAssetSource } from '../utils/asset-source';
 import { unimplemented, unreachable } from '../utils/misc';
 import { bindingifySideEffects } from '../utils/transform-side-effects';
 import type {

--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -1,11 +1,11 @@
-import { InputOptions, OutputOptions, RolldownPlugin } from '..';
+import type { InputOptions, OutputOptions, RolldownPlugin } from '..';
 import { BuiltinPlugin } from '../builtin-plugin/constructors';
 import { getLogger, getOnLog } from '../log/logger';
 import { LOG_LEVEL_INFO, type LogLevelOption } from '../log/logging';
 import type { LogHandler } from '../types/misc';
 import { normalizeHook } from '../utils/normalize-hook';
 import { normalizePluginOption } from '../utils/normalize-plugin-option';
-import { Plugin } from './';
+import type { Plugin } from './';
 import { MinimalPluginContextImpl } from './minimal-plugin-context';
 
 export class PluginDriver {

--- a/packages/rolldown/src/plugin/transform-plugin-context.ts
+++ b/packages/rolldown/src/plugin/transform-plugin-context.ts
@@ -4,7 +4,7 @@ import type {
 } from '../binding';
 import { normalizeLog } from '../log/log-handler';
 import { augmentCodeLocation, error, logPluginError } from '../log/logs';
-import { OutputOptions } from '../options/output-options';
+import type { OutputOptions } from '../options/output-options';
 import type { Extends, TypeAssert } from '../types/assert';
 import type {
   LoggingFunctionWithPosition,
@@ -12,7 +12,7 @@ import type {
   LogLevelOption,
   RollupError,
 } from '../types/misc';
-import { SourceMap } from '../types/rolldown-output';
+import type { SourceMap } from '../types/rolldown-output';
 import type { Plugin } from './index';
 import { type PluginContext, PluginContextImpl } from './plugin-context';
 import { PluginContextData } from './plugin-context-data';

--- a/packages/rolldown/src/plugin/with-filter.ts
+++ b/packages/rolldown/src/plugin/with-filter.ts
@@ -1,5 +1,5 @@
-import { HookFilterExtension, Plugin, RolldownPluginOption } from '..';
-import { StringOrRegExp } from '../types/utils';
+import type { HookFilterExtension, Plugin, RolldownPluginOption } from '..';
+import type { StringOrRegExp } from '../types/utils';
 import { arraify, isPromiseLike } from '../utils/misc';
 
 type OverrideFilterObject = {

--- a/packages/rolldown/src/types/module-info.ts
+++ b/packages/rolldown/src/types/module-info.ts
@@ -1,4 +1,4 @@
-import { ModuleOptions } from '..';
+import type { ModuleOptions } from '..';
 
 export interface ModuleInfo extends ModuleOptions {
   /**

--- a/packages/rolldown/src/types/rolldown-output.ts
+++ b/packages/rolldown/src/types/rolldown-output.ts
@@ -1,5 +1,5 @@
 import type { BindingRenderedChunk } from '../binding';
-import { AssetSource } from '../utils/asset-source';
+import type { AssetSource } from '../utils/asset-source';
 
 export interface OutputAsset {
   type: 'asset';

--- a/packages/rolldown/src/types/sourcemap.ts
+++ b/packages/rolldown/src/types/sourcemap.ts
@@ -1,4 +1,4 @@
-import { BindingSourcemap } from '../binding';
+import type { BindingSourcemap } from '../binding';
 import type { SourceMap } from './rolldown-output';
 
 export interface ExistingRawSourceMap {

--- a/packages/rolldown/src/utils/asset-source.ts
+++ b/packages/rolldown/src/utils/asset-source.ts
@@ -1,4 +1,4 @@
-import { BindingAssetSource } from '../binding';
+import type { BindingAssetSource } from '../binding';
 
 export type AssetSource = string | Uint8Array;
 

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -8,13 +8,13 @@ import type {
 } from '../binding';
 import { BuiltinPlugin } from '../builtin-plugin/constructors';
 import { bindingifyBuiltInPlugin } from '../builtin-plugin/utils';
-import { LogLevelOption } from '../log/logging';
+import type { LogLevelOption } from '../log/logging';
 import type { HmrOptions, InputOptions } from '../options/input-options';
 import type { OutputOptions } from '../options/output-options';
 import type { RolldownPlugin } from '../plugin';
 import { bindingifyPlugin } from '../plugin/bindingify-plugin';
 import { PluginContextData } from '../plugin/plugin-context-data';
-import { LogHandler } from '../types/misc';
+import type { LogHandler } from '../types/misc';
 import { arraify } from './misc';
 import { normalizedStringOrRegex } from './normalize-string-or-regex';
 import { bindingifySideEffects } from './transform-side-effects';

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -1,6 +1,6 @@
 import type { BindingOutputOptions } from '../binding';
 import type { OutputOptions } from '../options/output-options';
-import { SourcemapIgnoreListOption } from '../types/misc';
+import type { SourcemapIgnoreListOption } from '../types/misc';
 import { transformAssetSource } from './asset-source';
 import { unimplemented } from './misc';
 import { transformRenderedChunk } from './transform-rendered-chunk';

--- a/packages/rolldown/src/utils/compose-js-plugins.ts
+++ b/packages/rolldown/src/utils/compose-js-plugins.ts
@@ -1,20 +1,20 @@
 import * as R from 'remeda';
-import { TupleToUnion } from 'type-fest';
+import type { TupleToUnion } from 'type-fest';
 import { BuiltinPlugin } from '../builtin-plugin/constructors';
-import { PluginHookNames } from '../constants/plugin';
+import type { PluginHookNames } from '../constants/plugin';
 import { SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF } from '../constants/plugin-context';
-import {
+import type {
   ModuleSideEffects,
   Plugin,
   PrivateResolveIdExtraOptions,
   RolldownPlugin,
 } from '../plugin';
-import {
+import type {
   PluginContext,
   PrivatePluginContextResolveOptions,
 } from '../plugin/plugin-context';
-import { TransformPluginContext } from '../plugin/transform-plugin-context';
-import { AssertNever } from '../types/assert';
+import type { TransformPluginContext } from '../plugin/transform-plugin-context';
+import type { AssertNever } from '../types/assert';
 import { isNullish } from './misc';
 import { normalizeHook } from './normalize-hook';
 import { isPluginHookName } from './plugin';

--- a/packages/rolldown/src/utils/create-bundler-option.ts
+++ b/packages/rolldown/src/utils/create-bundler-option.ts
@@ -1,11 +1,11 @@
-import { BindingBundlerOptions } from '../binding';
+import type { BindingBundlerOptions } from '../binding';
 import { getLogger, getOnLog } from '../log/logger';
 import { LOG_LEVEL_INFO } from '../log/logging';
 import type { InputOptions } from '../options/input-options';
 import type { OutputOptions } from '../options/output-options';
 import { PluginDriver } from '../plugin/plugin-driver';
 import { getObjectPlugins } from '../plugin/plugin-driver';
-import { LogHandler } from '../types/misc';
+import type { LogHandler } from '../types/misc';
 import { bindingifyInputOptions } from './bindingify-input-options';
 import { bindingifyOutputOptions } from './bindingify-output-options';
 import { composeJsPlugins } from './compose-js-plugins';

--- a/packages/rolldown/src/utils/error.ts
+++ b/packages/rolldown/src/utils/error.ts
@@ -1,5 +1,5 @@
 import { BindingError } from '../binding';
-import { RollupError } from '../types/misc';
+import type { RollupError } from '../types/misc';
 
 export function normalizeErrors(rawErrors: (BindingError | Error)[]): Error {
   const errors = rawErrors.map((e) =>

--- a/packages/rolldown/src/utils/normalize-hook.ts
+++ b/packages/rolldown/src/utils/normalize-hook.ts
@@ -1,5 +1,5 @@
 import type { ObjectHook, ObjectHookMeta } from '../plugin';
-import { AnyFn } from '../types/utils';
+import type { AnyFn } from '../types/utils';
 import { unreachable } from './misc';
 
 export function normalizeHook<Hook extends ObjectHook<AnyFn | string>>(

--- a/packages/rolldown/src/utils/normalize-plugin-option.ts
+++ b/packages/rolldown/src/utils/normalize-plugin-option.ts
@@ -5,7 +5,7 @@ import { logInputHookInOutputPlugin } from '../log/logs';
 import type { InputOptions } from '../options/input-options';
 import type { OutputOptions } from '../options/output-options';
 import type { RolldownOutputPlugin, RolldownPlugin } from '../plugin';
-import { LogHandler } from '../types/misc';
+import type { LogHandler } from '../types/misc';
 import { asyncFlatten } from './async-flatten';
 
 export const normalizePluginOption: {

--- a/packages/rolldown/src/utils/plugin/index.ts
+++ b/packages/rolldown/src/utils/plugin/index.ts
@@ -1,6 +1,6 @@
 import {
   ENUMERATED_PLUGIN_HOOK_NAMES,
-  PluginHookNames,
+  type PluginHookNames,
 } from '../../constants/plugin';
 
 export const isPluginHookName: (

--- a/packages/rolldown/src/utils/transform-module-info.ts
+++ b/packages/rolldown/src/utils/transform-module-info.ts
@@ -1,4 +1,4 @@
-import { ModuleOptions } from '..';
+import type { ModuleOptions } from '..';
 import type { BindingModuleInfo } from '../binding';
 import type { ModuleInfo } from '../types/module-info';
 import { unsupported } from './misc';

--- a/packages/rolldown/src/utils/transform-rendered-chunk.ts
+++ b/packages/rolldown/src/utils/transform-rendered-chunk.ts
@@ -1,5 +1,5 @@
-import { BindingRenderedChunk } from '../binding';
-import { RenderedChunk } from '../types/rolldown-output';
+import type { BindingRenderedChunk } from '../binding';
+import type { RenderedChunk } from '../types/rolldown-output';
 import { transformToRenderedModule } from './transform-rendered-module';
 
 export function transformRenderedChunk(

--- a/packages/rolldown/src/utils/transform-rendered-module.ts
+++ b/packages/rolldown/src/utils/transform-rendered-module.ts
@@ -1,5 +1,5 @@
-import { BindingRenderedModule } from '../binding';
-import { RenderedModule } from '../types/rolldown-output';
+import type { BindingRenderedModule } from '../binding';
+import type { RenderedModule } from '../types/rolldown-output';
 
 export function transformToRenderedModule(
   bindingRenderedModule: BindingRenderedModule,

--- a/packages/rolldown/src/utils/transform-side-effects.ts
+++ b/packages/rolldown/src/utils/transform-side-effects.ts
@@ -1,5 +1,5 @@
 import { BindingHookSideEffects } from '../binding';
-import { ModuleSideEffects } from '../plugin';
+import type { ModuleSideEffects } from '../plugin';
 
 export function bindingifySideEffects(
   sideEffects?: ModuleSideEffects,

--- a/packages/rolldown/src/utils/transform-sourcemap.ts
+++ b/packages/rolldown/src/utils/transform-sourcemap.ts
@@ -1,4 +1,4 @@
-import { type ExistingRawSourceMap, SourceMapInput } from '../types/sourcemap';
+import type { ExistingRawSourceMap, SourceMapInput } from '../types/sourcemap';
 
 export function isEmptySourcemapFiled(
   array: undefined | (string | null)[],

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -15,7 +15,7 @@ import type {
 } from '../types/rolldown-output';
 import { bindingifySourcemap } from '../types/sourcemap';
 import {
-  AssetSource,
+  type AssetSource,
   bindingAssetSource,
   transformAssetSource,
 } from './asset-source';

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -2,7 +2,7 @@ import { toJsonSchema } from '@valibot/to-json-schema';
 import colors from 'ansis';
 import * as v from 'valibot';
 import type { PreRenderedChunk } from '../binding';
-import { PreRenderedAsset } from '../options/output-options';
+import type { PreRenderedAsset } from '../options/output-options';
 import type {
   RolldownOutputPluginOption,
   RolldownPluginOption,

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -15,6 +15,8 @@
     "outDir": "./dist/types",
     "resolveJsonModule": true,
     "noEmit": false,
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
   }
 }

--- a/tasks/generator/src/generators/hook_usage.rs
+++ b/tasks/generator/src/generators/hook_usage.rs
@@ -101,7 +101,7 @@ fn generate_hook_usage_ts() -> String {
     }}
   }}
 
-import {{ Plugin }} from '../..';
+import type {{ Plugin }} from '../..';
 export function extractHookUsage(plugin: Plugin): HookUsage {{
   let hookUsage = new HookUsage();
   {union_hook_usage_list}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- enable `isolatedModules` & `verbatimModuleSyntax` for stricter checking.
- fix `MinifyOptions` with optional (referenced from binding)
- Expose more types (tsdown could be need them)
