### PR TITLE
chore: remove `preinstall` script

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -71,8 +71,7 @@
     "build-browser:debug": "cross-env BROWSER_PKG=1 pnpm run --sequential \"/^build-(binding|binding:wasi|node)$/\"",
     "build-browser:release": "cross-env BROWSER_PKG=1 pnpm run --sequential \"/^build-(binding|binding:wasi:release|node)$/\"",
     "# Scrips for docs #": "_",
-    "extract-options-doc": "typedoc",
-    "preinstall": "npx only-allow pnpm"
+    "extract-options-doc": "typedoc"
   },
   "napi": {
     "binaryName": "rolldown-binding",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Remove the `preinstall` script in the rolldown package, otherwise, the following warning message will appear when using pnpm to install rolldown, and relevant configuration is required.

![image](https://github.com/user-attachments/assets/64cec598-f180-47dc-8993-ce0dc1ae5d9a)

In fact, this script has no logical modification, it is only used to verify the package management tool during development, so I think it can be removed. The corresponding script can be included in the package.json file in the project root directory.