### PR TITLE
feat(hmr): handle import.meta.hot.invalidate

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -254,11 +254,19 @@ impl Bundler {
   }
 
   pub async fn generate_hmr_patch(&mut self, changed_files: Vec<String>) -> BuildResult<HmrOutput> {
+    self.hmr_manager.as_mut().expect("HMR manager is not initialized").hmr(changed_files).await
+  }
+
+  pub async fn hmr_invalidate(
+    &mut self,
+    file: String,
+    first_invalidated_by: Option<String>,
+  ) -> BuildResult<HmrOutput> {
     self
       .hmr_manager
       .as_mut()
       .expect("HMR manager is not initialized")
-      .generate_hmr_patch(changed_files)
+      .hmr_invalidate(file, first_invalidated_by)
       .await
   }
 

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -125,6 +125,20 @@ impl Bundler {
       .expect("Failed to generate HMR patch")
       .into()
   }
+
+  #[napi]
+  pub async fn hmr_invalidate(
+    &self,
+    file: String,
+    first_invalidated_by: Option<String>,
+  ) -> BindingHmrOutput {
+    let mut bundler_core = self.inner.lock().await;
+    bundler_core
+      .hmr_invalidate(file, first_invalidated_by)
+      .await
+      .expect("Failed to call hmr_invalidate")
+      .into()
+  }
 }
 
 impl Bundler {

--- a/crates/rolldown_binding/src/types/binding_hmr_output.rs
+++ b/crates/rolldown_binding/src/types/binding_hmr_output.rs
@@ -4,6 +4,9 @@ pub struct BindingHmrOutput {
   pub patch: String,
   pub hmr_boundaries: Vec<BindingHmrBoundaryOutput>,
   pub full_reload: bool,
+  pub first_invalidated_by: Option<String>,
+  pub is_self_accepting: bool,
+  pub full_reload_reason: Option<String>,
 }
 
 impl From<rolldown_common::HmrOutput> for BindingHmrOutput {
@@ -12,6 +15,9 @@ impl From<rolldown_common::HmrOutput> for BindingHmrOutput {
       patch: value.patch,
       hmr_boundaries: value.hmr_boundaries.into_iter().map(Into::into).collect(),
       full_reload: value.full_reload,
+      first_invalidated_by: value.first_invalidated_by,
+      is_self_accepting: value.is_self_accepting,
+      full_reload_reason: value.full_reload_reason,
     }
   }
 }

--- a/crates/rolldown_common/src/hmr/hmr_output.rs
+++ b/crates/rolldown_common/src/hmr/hmr_output.rs
@@ -5,6 +5,9 @@ pub struct HmrOutput {
   pub patch: String,
   pub hmr_boundaries: Vec<HmrBoundaryOutput>,
   pub full_reload: bool,
+  pub first_invalidated_by: Option<String>,
+  pub is_self_accepting: bool,            // only for hmr invalidate
+  pub full_reload_reason: Option<String>, // only for hmr invalidate
 }
 
 #[derive(Debug)]

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -76,6 +76,13 @@ export class RolldownBuild {
     return this.#bundler?.bundler.generateHmrPatch(changedFiles);
   }
 
+  async hmrInvalidate(
+    file: string,
+    firstInvalidatedBy?: string,
+  ): Promise<BindingHmrOutput | undefined> {
+    return this.#bundler?.bundler.hmrInvalidate(file, firstInvalidatedBy);
+  }
+
   get watchFiles(): string[] {
     return this.#bundler?.bundler.watchFiles ?? [];
   }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -161,6 +161,7 @@ export declare class Bundler {
   get closed(): boolean
   get watchFiles(): Array<string>
   generateHmrPatch(changedFiles: Array<string>): Promise<BindingHmrOutput>
+  hmrInvalidate(file: string, firstInvalidatedBy?: string | undefined | null): Promise<BindingHmrOutput>
 }
 
 export declare class ParallelJsPluginRegistry {
@@ -328,6 +329,9 @@ export interface BindingHmrOutput {
   patch: string
   hmrBoundaries: Array<BindingHmrBoundaryOutput>
   fullReload: boolean
+  firstInvalidatedBy?: string
+  isSelfAccepting: boolean
+  fullReloadReason?: string
 }
 
 export interface BindingHookJsLoadOutput {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The vite hmr has hmr `invalidate` feature, it is mark the self accpeting hmr module can't process update, using the API to the update needs to be forcefully propagated to importers. ref https://vite.dev/guide/api-hmr#hot-invalidate-message-string.
``` .js
import.meta.hot.accept(() => {
    // Trigger HMR in importers
    import.meta.hot.invalidate()
})
```

## The vite implement.

- the self accepting module change, the hmr boundary is the module
- hmr runtime to execute `import.meta.hot.accept` callback, so the ` import.meta.hot.invalidate` is called, and then the API will be send a msg `vite:invalidate` to the server. The reason is the client hasn't module graph.
- the server using   the importer of  invalidate module to propagateUpdate


The rolldown esm hmr is follow the vite implement. The rolldown-vite receiver `vite:invalidate` was msg will call `rolldownBuild.hmrInvalidate` to execute rolldown internal propagateUpdate.


related [rolldown-vite commit](https://github.com/vitejs/rolldown-vite/pull/107/commits/e44af732d77a772f02dbbe9374aeb973d5098544)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
