### PR TITLE
fix(ci): fix incorrect tag name for lychee-action

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
 
       - name: Check Links
-        uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c # 2.4.0
+        uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c # v2.4.0
         with:
           # For parameter description, see https://github.com/lycheeverse/lychee#commandline-parameters
           # Accept 429 for now due to GitHub rate limit.


### PR DESCRIPTION
Reported by renovate bot:

Renovate failed to look up the following dependencies:

Could not determine new digest for update (github-tags package lycheeverse/lychee-action)

Files affected:

.github/workflows/link-check.yml

