### PR TITLE
refactor: add MarkModuleLoaded option to resolve module load promise

### DIFF
--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -251,6 +251,7 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
       .make_absolute_externals_relative
       .unwrap_or_default(),
     invalidate_js_side_cache: raw_options.invalidate_js_side_cache,
+    mark_module_loaded: raw_options.mark_module_loaded,
   };
 
   NormalizeOptionsReturn { options: normalized, resolve_options: raw_resolve, warnings }

--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -102,4 +102,7 @@ pub struct BindingInputOptions {
   #[napi(ts_type = "() => void")]
   // TODO: The `FnArgs<()>` is not supported.
   pub invalidate_js_side_cache: Option<JsCallback<FnArgs<(Option<bool>,)>, ()>>,
+  #[debug(skip)]
+  #[napi(ts_type = "(id: string, success: bool) => void")]
+  pub mark_module_loaded: Option<JsCallback<FnArgs<(String, bool)>, ()>>,
 }

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -8,6 +8,7 @@ use types::inject_import::InjectImport;
 use types::invalidate_js_side_cache::InvalidateJsSideCache;
 use types::jsx::Jsx;
 use types::make_absolute_externals_relative::MakeAbsoluteExternalsRelative;
+use types::mark_module_loaded::MarkModuleLoaded;
 use types::minify_options::RawMinifyOptions;
 use types::output_option::{AssetFilenamesOutputOption, GlobalsOutputOption};
 use types::sanitize_filename::SanitizeFilename;
@@ -197,6 +198,12 @@ pub struct BundlerOptions {
     schemars(skip)
   )]
   pub invalidate_js_side_cache: Option<InvalidateJsSideCache>,
+  #[cfg_attr(
+    feature = "deserialize_bundler_options",
+    serde(default, skip_deserializing),
+    schemars(skip)
+  )]
+  pub mark_module_loaded: Option<MarkModuleLoaded>,
 }
 
 impl BundlerOptions {

--- a/crates/rolldown_common/src/inner_bundler_options/types/mark_module_loaded.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/mark_module_loaded.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+use std::{future::Future, pin::Pin};
+
+use derive_more::Debug;
+
+pub type MarkModuleLoadedFn = dyn Fn(&str, bool) -> Pin<Box<(dyn Future<Output = anyhow::Result<()>> + Send + 'static)>>
+  + Send
+  + Sync;
+
+#[derive(Clone, Debug)]
+#[debug("MarkModuleLoadedFn::Fn(...)")]
+pub struct MarkModuleLoaded(Arc<MarkModuleLoadedFn>);
+
+impl MarkModuleLoaded {
+  pub fn new(f: Arc<MarkModuleLoadedFn>) -> Self {
+    Self(f)
+  }
+
+  pub async fn call(&self, module_id: &str, success: bool) -> anyhow::Result<()> {
+    self.0(module_id, success).await
+  }
+}

--- a/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
@@ -13,6 +13,7 @@ pub mod invalidate_js_side_cache;
 pub mod is_external;
 pub mod jsx;
 pub mod make_absolute_externals_relative;
+pub mod mark_module_loaded;
 pub mod minify_options;
 pub mod module_type;
 pub mod normalized_bundler_options;

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -29,7 +29,7 @@ use super::{
 use crate::{
   DeferSyncScanDataOption, EmittedAsset, EsModuleFlag, FilenameTemplate, GlobalsOutputOption,
   HashCharacters, InjectImport, InputItem, InvalidateJsSideCache, MakeAbsoluteExternalsRelative,
-  ModuleType, RollupPreRenderedAsset,
+  MarkModuleLoaded, ModuleType, RollupPreRenderedAsset,
 };
 
 #[allow(clippy::struct_excessive_bools)] // Using raw booleans is more clear in this case
@@ -93,6 +93,7 @@ pub struct NormalizedBundlerOptions {
   pub transform_options: TransformOptions,
   pub make_absolute_externals_relative: MakeAbsoluteExternalsRelative,
   pub invalidate_js_side_cache: Option<InvalidateJsSideCache>,
+  pub mark_module_loaded: Option<MarkModuleLoaded>,
 }
 
 // This is only used for testing
@@ -152,6 +153,7 @@ impl Default for NormalizedBundlerOptions {
       make_absolute_externals_relative: Default::default(),
       jsx: Default::default(),
       invalidate_js_side_cache: Default::default(),
+      mark_module_loaded: Default::default(),
     }
   }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -34,6 +34,7 @@ pub mod bundler_options {
       is_external::IsExternal,
       jsx::{Jsx, NormalizedJsxOptions},
       make_absolute_externals_relative::MakeAbsoluteExternalsRelative,
+      mark_module_loaded::MarkModuleLoaded,
       minify_options::{MinifyOptions, MinifyOptionsObject, RawMinifyOptions},
       module_type::ModuleType,
       normalized_bundler_options::{NormalizedBundlerOptions, SharedNormalizedBundlerOptions},

--- a/crates/rolldown_plugin_isolated_declaration/src/lib.rs
+++ b/crates/rolldown_plugin_isolated_declaration/src/lib.rs
@@ -38,7 +38,7 @@ impl Plugin for IsolatedDeclarationPlugin {
       for specifier in type_import_specifiers {
         let resolved_id = ctx.resolve(&specifier, Some(args.id), None).await??;
         if matches!(resolved_id.external, ResolvedExternal::Bool(false)) {
-          ctx.load(&resolved_id.id, None, None).await?;
+          ctx.load(&resolved_id.id, None).await?;
         }
       }
 

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -96,7 +96,7 @@ export declare class BindingOutputs {
 }
 
 export declare class BindingPluginContext {
-  load(specifier: string, sideEffects: BindingHookSideEffects | undefined, fn: (success: boolean) => void): Promise<void>
+  load(specifier: string, sideEffects: BindingHookSideEffects | undefined): Promise<void>
   resolve(specifier: string, importer?: string | undefined | null, extraOptions?: BindingPluginContextResolveOptions | undefined | null): Promise<BindingPluginContextResolvedId | null>
   emitFile(file: BindingEmittedAsset, assetFilename?: string | undefined | null, fnSanitizedFileName?: string | undefined | null): string
   emitChunk(file: BindingEmittedChunk): string
@@ -428,6 +428,7 @@ export interface BindingInputOptions {
   makeAbsoluteExternalsRelative?: BindingMakeAbsoluteExternalsRelative
   debug?: BindingDebugOptions
   invalidateJsSideCache?: () => void
+  markModuleLoaded?: (id: string, success: bool) => void
 }
 
 export interface BindingIsolatedDeclarationPluginConfig {

--- a/packages/rolldown/src/plugin/plugin-context-data.ts
+++ b/packages/rolldown/src/plugin/plugin-context-data.ts
@@ -9,6 +9,7 @@ export class PluginContextData {
   moduleOptionMap: Map<string, ModuleOptions> = new Map();
   resolveOptionsMap: Map<number, PluginContextResolveOptions> = new Map();
   loadModulePromiseMap: Map<string, Promise<void>> = new Map();
+  loadModulePromiseResolveFnMap: Map<string, () => void> = new Map();
   renderedChunkMeta: RenderedChunkMeta | null = null;
 
   updateModuleOption(id: string, option: ModuleOptions): ModuleOptions {
@@ -99,8 +100,16 @@ export class PluginContextData {
     return this.renderedChunkMeta;
   }
 
+  markModuleLoaded(id: string, _success: boolean): void {
+    // Here the bundler will give an error for it, so here avoid give other error again, it could be is confusing.
+    // TODO: It maybe could be improved in the future.
+    const resolve = this.loadModulePromiseResolveFnMap.get(id);
+    if (resolve) resolve();
+  }
+
   clear(): void {
     this.renderedChunkMeta = null;
     this.loadModulePromiseMap.clear();
+    this.loadModulePromiseResolveFnMap.clear();
   }
 }

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -99,6 +99,9 @@ export function bindingifyInputOptions(
     ),
     debug: inputOptions.debug,
     invalidateJsSideCache: pluginContextData.clear.bind(pluginContextData),
+    markModuleLoaded: pluginContextData.markModuleLoaded.bind(
+      pluginContextData,
+    ),
   };
 }
 

--- a/packages/rolldown/tests/fixtures/plugin/context/load-enter-module-task-module/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/load-enter-module-task-module/_config.ts
@@ -1,0 +1,27 @@
+import { defineTest } from 'rolldown-tests'
+import { expect } from 'vitest'
+import path from 'node:path'
+
+export default defineTest({
+  config: {
+    input: ['main.js', 'foo.js'],
+    plugins: [
+      {
+        name: 'test-plugin-context',
+        async transform(code, id) {
+          if (id.endsWith('main.js')) {
+            const moduleInfo = await this.load({
+              id: path.join(__dirname, 'foo.js'),
+            })
+            expect(moduleInfo.code!.includes('foo')).toBe(true)
+          }
+          if (id.endsWith('foo.js')) {
+            await new Promise((resolve) => {
+              setTimeout(resolve, 10);
+            })
+          }
+        },
+      },
+    ],
+  }
+})

--- a/packages/rolldown/tests/fixtures/plugin/context/load-enter-module-task-module/foo.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/load-enter-module-task-module/foo.js
@@ -1,0 +1,1 @@
+console.log('foo')

--- a/packages/rolldown/tests/fixtures/plugin/context/load-enter-module-task-module/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/load-enter-module-task-module/main.js
@@ -1,0 +1,1 @@
+console.log('main')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
close https://github.com/rolldown/rolldown/issues/4341

The issue happened if the js side load module, but it already enter the module task which not finished. Here maybe couldn't be notify in parallel.

So here add the `MarkModuleLoaded` option to move the related logic to js side, it  could avoid the rust parallel issue.

related: https://github.com/sxzz/rolldown-plugin-dts/actions/runs/14703765236 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
