### PR TITLE
refactor: normalized common filter to filter expr

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -250,6 +250,15 @@ impl BindingPluginOptions {
       filter_expr_kinds.push((FilterExprCacheKey::Transform, filter_kind));
     }
 
+    if let Some(filter) = self.render_chunk_filter.as_ref().and_then(|item| item.custom.as_ref()) {
+      let filter_kind = filter
+        .clone()
+        .into_iter()
+        .map(|tokens| filter_expression::parse(normalized_tokens(tokens)))
+        .collect_vec();
+      filter_expr_kinds.push((FilterExprCacheKey::RenderChunk, filter_kind));
+    }
+
     filter_expr_kinds
   }
 }

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_filter.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_filter.rs
@@ -27,4 +27,5 @@ pub struct BindingTransformHookFilter {
 #[derive(Default, Clone, Debug)]
 pub struct BindingRenderChunkHookFilter {
   pub code: Option<BindingGeneralHookFilter>,
+  pub custom: Option<Vec<Vec<BindingFilterToken>>>,
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -674,6 +674,7 @@ export interface BindingRemote {
 
 export interface BindingRenderChunkHookFilter {
   code?: BindingGeneralHookFilter
+  custom?: Array<Array<BindingFilterToken>>
 }
 
 export interface BindingReplacePluginConfig {

--- a/packages/rolldown/src/plugin/bindingify-hook-filter.ts
+++ b/packages/rolldown/src/plugin/bindingify-hook-filter.ts
@@ -1,3 +1,4 @@
+import * as R from 'remeda';
 import type {
   BindingFilterToken,
   BindingGeneralHookFilter,
@@ -5,26 +6,135 @@ import type {
   BindingTransformHookFilter,
 } from '../binding.d';
 import type { FilterExpression } from '../filter-expression-index';
+import * as filter from '../filter-expression-index';
 import { arraify } from '../utils/misc';
-import type { HookFilterExtension, ModuleType } from '.';
+import type { HookFilterExtension } from '.';
 import type { GeneralHookFilter } from './hook-filter';
+
+// Convert `exclude` and `include` to tokens of FilterExpr
+// Array of `BindingFilterToken` will be converted to `FilterExpr` finally,
+// use `generalHookFilterToFilterExprs` instead of `generalHookFilterToFilterArrayOfArrayBindingFilterToken` would be concise
+function generalHookFilterMatcherToFilterExprs(
+  matcher: GeneralHookFilter,
+  stringKind: 'code' | 'id',
+): filter.TopLevelFilterExpression[] | undefined {
+  if (typeof matcher === 'string' || matcher instanceof RegExp) {
+    return [filter.include(filter.id(matcher))];
+  }
+  if (Array.isArray(matcher)) {
+    return matcher.map((m) => filter.include(filter.id(m)));
+  }
+  if (matcher.custom) {
+    return matcher.custom;
+  }
+  let ret: filter.TopLevelFilterExpression[] = [];
+  let isCode = stringKind === 'code';
+  if (matcher.exclude) {
+    ret.push(
+      ...arraify(matcher.exclude).map((m) =>
+        filter.exclude(isCode ? filter.code(m) : filter.id(m))
+      ),
+    );
+  }
+  if (matcher.include) {
+    ret.push(
+      ...arraify(matcher.include).map((m) =>
+        filter.include(isCode ? filter.code(m) : filter.id(m))
+      ),
+    );
+  }
+  return ret;
+}
+
+// TODO: support variadic `or` and `and`
+function transformFilterMatcherToFilterExprs(
+  filterOption: HookFilterExtension<'transform'>['filter'],
+): filter.TopLevelFilterExpression[] | undefined {
+  if (!filterOption) {
+    return undefined;
+  }
+  const { id, code, moduleType, custom } = filterOption;
+
+  if (custom) {
+    return custom;
+  }
+  let ret: filter.TopLevelFilterExpression[] = [];
+  let idIncludes: filter.TopLevelFilterExpression[] = [];
+  let idExcludes: filter.TopLevelFilterExpression[] = [];
+  let codeIncludes: filter.TopLevelFilterExpression[] = [];
+  let codeExcludes: filter.TopLevelFilterExpression[] = [];
+  if (id) {
+    [idIncludes, idExcludes] = R.partition(
+      generalHookFilterMatcherToFilterExprs(id, 'id') ?? [],
+      (m) => m.kind === 'include',
+    );
+  }
+  if (code) {
+    [codeIncludes, codeExcludes] = R.partition(
+      generalHookFilterMatcherToFilterExprs(code, 'code') ?? [],
+      (m) => m.kind === 'include',
+    );
+  }
+  ret.push(...idExcludes);
+  ret.push(...codeExcludes);
+
+  let cursor: filter.FilterExpression | undefined;
+  if (moduleType) {
+    let moduleTypes = Array.isArray(moduleType)
+      ? moduleType
+      : moduleType.include ?? [];
+    cursor = joinFilterExprsWithOr(
+      moduleTypes.map((m) => filter.moduleType(m)),
+    );
+  }
+  if (idIncludes.length) {
+    let joinedOrExpr = joinFilterExprsWithOr(idIncludes.map(item => item.expr));
+    if (!cursor) {
+      cursor = joinedOrExpr;
+    } else {
+      cursor = filter.and(cursor, joinedOrExpr);
+    }
+  }
+
+  if (codeIncludes.length) {
+    let joinedOrExpr = joinFilterExprsWithOr(
+      codeIncludes.map(item => item.expr),
+    );
+    if (!cursor) {
+      cursor = joinedOrExpr;
+    } else {
+      cursor = filter.and(cursor, joinedOrExpr);
+    }
+  }
+  if (cursor) {
+    ret.push(filter.include(cursor));
+  }
+  return ret;
+}
+
+// This is temp function, it is no more used when we support variadic `or` and `and`
+// Convert List of `TopLevelFilterExpression` to a `FilterExpression`
+// if the length is one then return the first element
+// or recursively join the elements with `or`
+function joinFilterExprsWithOr(
+  filterExprs: FilterExpression[],
+): FilterExpression {
+  if (filterExprs.length === 1) {
+    return filterExprs[0];
+  }
+  return filter.or(filterExprs[0], joinFilterExprsWithOr(filterExprs.slice(1)));
+}
 
 export function bindingifyGeneralHookFilter(
   matcher: GeneralHookFilter,
+  stringKind: 'code' | 'id',
 ): BindingGeneralHookFilter {
-  if (typeof matcher === 'string' || matcher instanceof RegExp) {
-    return { include: [matcher] };
-  }
-  if (Array.isArray(matcher)) {
-    return { include: matcher };
-  }
+  let filterExprs = generalHookFilterMatcherToFilterExprs(matcher, stringKind);
   let custom: BindingFilterToken[][] = [];
-  if (matcher.custom) {
-    custom = matcher.custom.map(bindingifyFilterExpr);
+  if (filterExprs) {
+    custom = filterExprs.map(bindingifyFilterExpr);
   }
   return {
-    include: matcher.include ? arraify(matcher.include) : undefined,
-    exclude: matcher.exclude ? arraify(matcher.exclude) : undefined,
     custom: custom.length > 0 ? custom : undefined,
   };
 }
@@ -87,7 +197,7 @@ export function bindingifyResolveIdFilter(
   filterOption?: HookFilterExtension<'resolveId'>['filter'],
 ): BindingGeneralHookFilter | undefined {
   return filterOption?.id
-    ? bindingifyGeneralHookFilter(filterOption.id)
+    ? bindingifyGeneralHookFilter(filterOption.id, 'id')
     : undefined;
 }
 
@@ -95,7 +205,7 @@ export function bindingifyLoadFilter(
   filterOption?: HookFilterExtension<'load'>['filter'],
 ): BindingGeneralHookFilter | undefined {
   return filterOption?.id
-    ? bindingifyGeneralHookFilter(filterOption.id)
+    ? bindingifyGeneralHookFilter(filterOption.id, 'id')
     : undefined;
 }
 
@@ -105,24 +215,14 @@ export function bindingifyTransformFilter(
   if (!filterOption) {
     return undefined;
   }
-  const { id, code, moduleType, custom } = filterOption;
 
-  let moduleTypeRet: ModuleType[] | undefined;
-  if (moduleType) {
-    if (Array.isArray(moduleType)) {
-      moduleTypeRet = moduleType;
-    } else {
-      moduleTypeRet = moduleType.include;
-    }
-  }
+  let custom = transformFilterMatcherToFilterExprs(filterOption);
+
   let ret: BindingFilterToken[][] = [];
   if (custom) {
     ret = custom.map(bindingifyFilterExpr);
   }
   return {
-    id: id ? bindingifyGeneralHookFilter(id) : undefined,
-    code: code ? bindingifyGeneralHookFilter(code) : undefined,
-    moduleType: moduleTypeRet,
     custom: ret.length > 0 ? ret : undefined,
   };
 }
@@ -134,7 +234,9 @@ export function bindingifyRenderChunkFilter(
     const { code } = filterOption;
 
     return {
-      code: code ? bindingifyGeneralHookFilter(code) : undefined,
+      custom: code
+        ? bindingifyGeneralHookFilter(code, 'code').custom
+        : undefined,
     };
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. This pr only preservesthe  `custom` field for each BindingHookFilter, this is preparation for removing all filter-related util function so that we could only maintain `filterExprInterpreter`
