### PR TITLE
feat(rolldown): bump `oxc_resolver` to v7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "6.0.2"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7597d578eb373705e141e9f04cc7be5d3f4e11ab87966ab6cc0a18892c5b13b3"
+checksum = "0647cd92993b4dd3ee821beb5483d08f041ac312e3b186b38d167a65347488ab"
 dependencies = [
  "cfg-if",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ oxc_transform_napi = { version = "0.67.0" }
 # Versions must be relaxed for usage in oxc.
 # Please update with `cargo update oxc_resolver oxc_sourcemap oxc_index`
 oxc_index = { version = "3", features = ["rayon", "serde"] } # https://github.com/oxc-project/oxc-index-vec
-oxc_resolver = { version = "6", features = ["package_json_raw_json_api"] } # https://github.com/oxc-project/oxc-resolver
+oxc_resolver = { version = "7", features = ["package_json_raw_json_api"] } # https://github.com/oxc-project/oxc-resolver
 oxc_sourcemap = { version = "3" } # https://github.com/oxc-project/oxc-sourcemap
 
 [profile.release]


### PR DESCRIPTION
Fixes

* https://github.com/oxc-project/oxc-resolver/issues/396

Relates

* https://github.com/vitejs/rolldown-vite/issues/100

