### PR TITLE
feat!: allows users to specify filter expressions directly using an array syntax instead of an object with a "custom" key

### DIFF
--- a/packages/rolldown/src/plugin/bindingify-hook-filter.ts
+++ b/packages/rolldown/src/plugin/bindingify-hook-filter.ts
@@ -2,10 +2,10 @@ import * as R from 'remeda';
 import type { BindingFilterToken, BindingHookFilter } from '../binding.d';
 import type { FilterExpression } from '../filter-expression-index';
 import * as filter from '../filter-expression-index';
+import type { StringOrRegExp } from '../types/utils';
 import { arraify } from '../utils/misc';
 import type { HookFilterExtension } from '.';
 import type { GeneralHookFilter } from './hook-filter';
-import type { StringOrRegExp } from '../types/utils';
 
 // Convert `exclude` and `include` to tokens of FilterExpr
 // Array of `BindingFilterToken` will be converted to `FilterExpr` finally,
@@ -49,7 +49,7 @@ function transformFilterMatcherToFilterExprs(
   if (Array.isArray(filterOption)) {
     return filterOption;
   }
-  const { id, code, moduleType} = filterOption;
+  const { id, code, moduleType } = filterOption;
 
   let ret: filter.TopLevelFilterExpression[] = [];
   let idIncludes: filter.TopLevelFilterExpression[] = [];
@@ -120,7 +120,10 @@ function joinFilterExprsWithOr(
   return filter.or(filterExprs[0], joinFilterExprsWithOr(filterExprs.slice(1)));
 }
 
-export function bindingifyGeneralHookFilter<T extends StringOrRegExp, F extends GeneralHookFilter<T>>(
+export function bindingifyGeneralHookFilter<
+  T extends StringOrRegExp,
+  F extends GeneralHookFilter<T>,
+>(
   stringKind: 'code' | 'id',
   pattern: F,
 ): BindingHookFilter | undefined {
@@ -196,10 +199,12 @@ export function bindingifyResolveIdFilter(
   }
   if (Array.isArray(filterOption)) {
     return {
-      value: filterOption.map(bindingifyFilterExpr)
-    }
+      value: filterOption.map(bindingifyFilterExpr),
+    };
   }
-  return filterOption.id ?  bindingifyGeneralHookFilter('id', filterOption.id) : undefined;
+  return filterOption.id
+    ? bindingifyGeneralHookFilter('id', filterOption.id)
+    : undefined;
 }
 
 export function bindingifyLoadFilter(
@@ -210,10 +215,12 @@ export function bindingifyLoadFilter(
   }
   if (Array.isArray(filterOption)) {
     return {
-      value: filterOption.map(bindingifyFilterExpr)
-    }
+      value: filterOption.map(bindingifyFilterExpr),
+    };
   }
-  return filterOption.id ?  bindingifyGeneralHookFilter('id', filterOption.id) : undefined;
+  return filterOption.id
+    ? bindingifyGeneralHookFilter('id', filterOption.id)
+    : undefined;
 }
 
 export function bindingifyTransformFilter(
@@ -223,11 +230,11 @@ export function bindingifyTransformFilter(
     return undefined;
   }
 
-  let custom = transformFilterMatcherToFilterExprs(filterOption);
+  let filterExprs = transformFilterMatcherToFilterExprs(filterOption);
 
   let ret: BindingFilterToken[][] = [];
-  if (custom) {
-    ret = custom.map(bindingifyFilterExpr);
+  if (filterExprs) {
+    ret = filterExprs.map(bindingifyFilterExpr);
   }
   return {
     value: ret.length > 0 ? ret : undefined,
@@ -242,8 +249,10 @@ export function bindingifyRenderChunkFilter(
   }
   if (Array.isArray(filterOption)) {
     return {
-      value: filterOption.map(bindingifyFilterExpr)
-    }
+      value: filterOption.map(bindingifyFilterExpr),
+    };
   }
-  return filterOption.code ?  bindingifyGeneralHookFilter('code', filterOption.code) : undefined;
+  return filterOption.code
+    ? bindingifyGeneralHookFilter('code', filterOption.code)
+    : undefined;
 }

--- a/packages/rolldown/src/plugin/bindingify-hook-filter.ts
+++ b/packages/rolldown/src/plugin/bindingify-hook-filter.ts
@@ -5,12 +5,13 @@ import * as filter from '../filter-expression-index';
 import { arraify } from '../utils/misc';
 import type { HookFilterExtension } from '.';
 import type { GeneralHookFilter } from './hook-filter';
+import type { StringOrRegExp } from '../types/utils';
 
 // Convert `exclude` and `include` to tokens of FilterExpr
 // Array of `BindingFilterToken` will be converted to `FilterExpr` finally,
 // use `generalHookFilterToFilterExprs` instead of `generalHookFilterToFilterArrayOfArrayBindingFilterToken` would be concise
-function generalHookFilterMatcherToFilterExprs(
-  matcher: GeneralHookFilter,
+function generalHookFilterMatcherToFilterExprs<T extends StringOrRegExp>(
+  matcher: GeneralHookFilter<T>,
   stringKind: 'code' | 'id',
 ): filter.TopLevelFilterExpression[] | undefined {
   if (typeof matcher === 'string' || matcher instanceof RegExp) {
@@ -18,9 +19,6 @@ function generalHookFilterMatcherToFilterExprs(
   }
   if (Array.isArray(matcher)) {
     return matcher.map((m) => filter.include(filter.id(m)));
-  }
-  if (matcher.custom) {
-    return matcher.custom;
   }
   let ret: filter.TopLevelFilterExpression[] = [];
   let isCode = stringKind === 'code';
@@ -48,11 +46,11 @@ function transformFilterMatcherToFilterExprs(
   if (!filterOption) {
     return undefined;
   }
-  const { id, code, moduleType, custom } = filterOption;
-
-  if (custom) {
-    return custom;
+  if (Array.isArray(filterOption)) {
+    return filterOption;
   }
+  const { id, code, moduleType} = filterOption;
+
   let ret: filter.TopLevelFilterExpression[] = [];
   let idIncludes: filter.TopLevelFilterExpression[] = [];
   let idExcludes: filter.TopLevelFilterExpression[] = [];
@@ -122,11 +120,11 @@ function joinFilterExprsWithOr(
   return filter.or(filterExprs[0], joinFilterExprsWithOr(filterExprs.slice(1)));
 }
 
-export function bindingifyGeneralHookFilter(
-  matcher: GeneralHookFilter,
+export function bindingifyGeneralHookFilter<T extends StringOrRegExp, F extends GeneralHookFilter<T>>(
   stringKind: 'code' | 'id',
+  pattern: F,
 ): BindingHookFilter | undefined {
-  let filterExprs = generalHookFilterMatcherToFilterExprs(matcher, stringKind);
+  let filterExprs = generalHookFilterMatcherToFilterExprs(pattern, stringKind);
   let ret: BindingFilterToken[][] = [];
   if (filterExprs) {
     ret = filterExprs.map(bindingifyFilterExpr);
@@ -193,17 +191,29 @@ function bindingifyFilterExprImpl(
 export function bindingifyResolveIdFilter(
   filterOption?: HookFilterExtension<'resolveId'>['filter'],
 ): BindingHookFilter | undefined {
-  return filterOption?.id
-    ? bindingifyGeneralHookFilter(filterOption.id, 'id')
-    : undefined;
+  if (!filterOption) {
+    return undefined;
+  }
+  if (Array.isArray(filterOption)) {
+    return {
+      value: filterOption.map(bindingifyFilterExpr)
+    }
+  }
+  return filterOption.id ?  bindingifyGeneralHookFilter('id', filterOption.id) : undefined;
 }
 
 export function bindingifyLoadFilter(
   filterOption?: HookFilterExtension<'load'>['filter'],
 ): BindingHookFilter | undefined {
-  return filterOption?.id
-    ? bindingifyGeneralHookFilter(filterOption.id, 'id')
-    : undefined;
+  if (!filterOption) {
+    return undefined;
+  }
+  if (Array.isArray(filterOption)) {
+    return {
+      value: filterOption.map(bindingifyFilterExpr)
+    }
+  }
+  return filterOption.id ?  bindingifyGeneralHookFilter('id', filterOption.id) : undefined;
 }
 
 export function bindingifyTransformFilter(
@@ -227,9 +237,13 @@ export function bindingifyTransformFilter(
 export function bindingifyRenderChunkFilter(
   filterOption?: HookFilterExtension<'renderChunk'>['filter'],
 ): BindingHookFilter | undefined {
-  if (filterOption) {
-    const { code } = filterOption;
-
-    return code ? bindingifyGeneralHookFilter(code, 'code') : undefined;
+  if (!filterOption) {
+    return undefined;
   }
+  if (Array.isArray(filterOption)) {
+    return {
+      value: filterOption.map(bindingifyFilterExpr)
+    }
+  }
+  return filterOption.code ?  bindingifyGeneralHookFilter('code', filterOption.code) : undefined;
 }

--- a/packages/rolldown/src/plugin/hook-filter.ts
+++ b/packages/rolldown/src/plugin/hook-filter.ts
@@ -52,6 +52,8 @@ export interface HookFilter {
   id?: GeneralHookFilter;
   moduleType?: ModuleTypeFilter;
   code?: GeneralHookFilter;
-};
+}
 
-export type  TUnionWithTopLevelFilterExpressionArray<T> = T | TopLevelFilterExpression[];
+export type TUnionWithTopLevelFilterExpressionArray<T> =
+  | T
+  | TopLevelFilterExpression[];

--- a/packages/rolldown/src/plugin/hook-filter.ts
+++ b/packages/rolldown/src/plugin/hook-filter.ts
@@ -8,7 +8,6 @@ export type GeneralHookFilter<Value = StringOrRegExp> =
   | {
     include?: MaybeArray<Value>;
     exclude?: MaybeArray<Value>;
-    custom?: TopLevelFilterExpression[];
   };
 
 interface FormalModuleTypeFilter {
@@ -53,5 +52,6 @@ export interface HookFilter {
   id?: GeneralHookFilter;
   moduleType?: ModuleTypeFilter;
   code?: GeneralHookFilter;
-  custom?: TopLevelFilterExpression[];
-}
+};
+
+export type  TUnionWithTopLevelFilterExpressionArray<T> = T | TopLevelFilterExpression[];

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -7,6 +7,7 @@ import type { BuiltinPlugin } from '../builtin-plugin/constructors';
 import type { DefinedHookNames } from '../constants/plugin';
 import type { DEFINED_HOOK_NAMES } from '../constants/plugin';
 import type { SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF } from '../constants/plugin-context';
+import type { TopLevelFilterExpression } from '../filter-expression-index';
 import type { LogLevel, RollupLog } from '../log/logging';
 import type { NormalizedInputOptions } from '../options/normalized-input-options';
 import type { NormalizedOutputOptions } from '../options/normalized-output-options';
@@ -20,7 +21,7 @@ import type {
   NullValue,
   PartialNull,
 } from '../types/utils';
-import type { GeneralHookFilter, HookFilter } from './hook-filter';
+import type { GeneralHookFilter, HookFilter, TUnionWithTopLevelFilterExpressionArray } from './hook-filter';
 import type { MinimalPluginContext } from './minimal-plugin-context';
 import type { ParallelPlugin } from './parallel-plugin';
 import type { PluginContext } from './plugin-context';
@@ -271,13 +272,14 @@ export type ParallelPluginHooks = Exclude<
   keyof FunctionPluginHooks | AddonHooks,
   FirstPluginHooks | SequentialPluginHooks
 >;
+
 export type HookFilterExtension<K extends keyof FunctionPluginHooks> = K extends
-  'transform' ? { filter?: HookFilter }
-  : K extends 'load' ? { filter?: Pick<HookFilter, 'id' | 'custom'> }
+  'transform' ? { filter?: TUnionWithTopLevelFilterExpressionArray<HookFilter> }
+  : K extends 'load' ? { filter?: TUnionWithTopLevelFilterExpressionArray<Pick<HookFilter, 'id'>> }
   : K extends 'resolveId' ? {
-      filter?: { id?: GeneralHookFilter<RegExp> } & Pick<HookFilter, 'custom'>;
+      filter?: TUnionWithTopLevelFilterExpressionArray<{ id?: GeneralHookFilter<RegExp> }>;
     }
-  : K extends 'renderChunk' ? { filter?: Pick<HookFilter, 'code'> }
+  : K extends 'renderChunk' ? { filter?: TUnionWithTopLevelFilterExpressionArray<Pick<HookFilter, 'code'>> }
   : {};
 
 export type PluginHooks = {

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -7,7 +7,6 @@ import type { BuiltinPlugin } from '../builtin-plugin/constructors';
 import type { DefinedHookNames } from '../constants/plugin';
 import type { DEFINED_HOOK_NAMES } from '../constants/plugin';
 import type { SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF } from '../constants/plugin-context';
-import type { TopLevelFilterExpression } from '../filter-expression-index';
 import type { LogLevel, RollupLog } from '../log/logging';
 import type { NormalizedInputOptions } from '../options/normalized-input-options';
 import type { NormalizedOutputOptions } from '../options/normalized-output-options';
@@ -21,7 +20,11 @@ import type {
   NullValue,
   PartialNull,
 } from '../types/utils';
-import type { GeneralHookFilter, HookFilter, TUnionWithTopLevelFilterExpressionArray } from './hook-filter';
+import type {
+  GeneralHookFilter,
+  HookFilter,
+  TUnionWithTopLevelFilterExpressionArray,
+} from './hook-filter';
 import type { MinimalPluginContext } from './minimal-plugin-context';
 import type { ParallelPlugin } from './parallel-plugin';
 import type { PluginContext } from './plugin-context';
@@ -275,11 +278,19 @@ export type ParallelPluginHooks = Exclude<
 
 export type HookFilterExtension<K extends keyof FunctionPluginHooks> = K extends
   'transform' ? { filter?: TUnionWithTopLevelFilterExpressionArray<HookFilter> }
-  : K extends 'load' ? { filter?: TUnionWithTopLevelFilterExpressionArray<Pick<HookFilter, 'id'>> }
-  : K extends 'resolveId' ? {
-      filter?: TUnionWithTopLevelFilterExpressionArray<{ id?: GeneralHookFilter<RegExp> }>;
+  : K extends 'load' ? {
+      filter?: TUnionWithTopLevelFilterExpressionArray<Pick<HookFilter, 'id'>>;
     }
-  : K extends 'renderChunk' ? { filter?: TUnionWithTopLevelFilterExpressionArray<Pick<HookFilter, 'code'>> }
+  : K extends 'resolveId' ? {
+      filter?: TUnionWithTopLevelFilterExpressionArray<
+        { id?: GeneralHookFilter<RegExp> }
+      >;
+    }
+  : K extends 'renderChunk' ? {
+      filter?: TUnionWithTopLevelFilterExpressionArray<
+        Pick<HookFilter, 'code'>
+      >;
+    }
   : {};
 
 export type PluginHooks = {

--- a/packages/rolldown/tests/fixtures/tree-shake/filter-expression/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/filter-expression/_config.ts
@@ -12,10 +12,8 @@ export default defineTest({
 					handler() {
 						transformHookFunction();
 					},
-					filter: {
-						custom: [exclude(and(id(/src/), not(code(/import\s+{/))))],
-					},
-				},
+          filter: [exclude(and(id(/src/), not(code(/import\s+{/))))],
+        },
 			},
 		],
 	},


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. This pr changes the shape of the `filter` object
#### Before
```js
filter: {
  transform: [/pattern/],
  // snip...
  custom: [FilterExpr]
}
```

#### After
```js

filter: {
  transform: [/pattern/],
  // snip...
}
// Or
filter: [FilterExpr]
```
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
