### PR TITLE
chore!: expose `withFilter` function via `rolldown/filter` instead of `rolldown`

### DIFF
--- a/packages/rolldown/src/filter-expression-index.ts
+++ b/packages/rolldown/src/filter-expression-index.ts
@@ -124,3 +124,5 @@ export function include(expr: FilterExpression): Include {
 export function exclude(expr: FilterExpression): Exclude {
   return { kind: 'exclude', expr };
 }
+
+export { withFilter } from './plugin';

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -59,7 +59,6 @@ import type {
   SourceDescription,
   TransformResult,
 } from './plugin';
-import { withFilter } from './plugin';
 import type {
   GeneralHookFilter,
   HookFilter,
@@ -95,7 +94,7 @@ import type { ExistingRawSourceMap, SourceMapInput } from './types/sourcemap';
 import type { PartialNull } from './types/utils';
 import { defineConfig } from './utils/define-config';
 
-export { build, defineConfig, rolldown, watch, withFilter };
+export { build, defineConfig, rolldown, watch };
 export const VERSION: string = version;
 
 export type {

--- a/packages/rolldown/tests/fixtures/plugin/transform/with-filter-nested/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/with-filter-nested/_config.ts
@@ -1,4 +1,5 @@
-import { RolldownPluginOption, withFilter } from "rolldown";
+import { RolldownPluginOption } from "rolldown";
+import {withFilter} from 'rolldown/filter';
 import { defineTest } from "rolldown-tests";
 import { expect, vi } from "vitest";
 

--- a/packages/rolldown/tests/fixtures/plugin/transform/with-filter/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/with-filter/_config.ts
@@ -1,4 +1,4 @@
-import { withFilter } from "rolldown";
+import { withFilter } from "rolldown/filter";
 import { defineTest } from "rolldown-tests";
 import { expect, vi } from "vitest";
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
