### PR TITLE
fix(hmr): rewrite import.meta.hot

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -79,6 +79,7 @@ pub struct ScanResult {
   pub new_url_references: FxHashMap<Span, ImportRecordIdx>,
   pub this_expr_replace_map: FxHashMap<Span, ThisExprReplaceKind>,
   pub hmr_info: HmrInfo,
+  pub hmr_hot_ref: Option<SymbolRef>,
 }
 
 pub struct AstScanner<'me, 'ast> {
@@ -134,6 +135,10 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     let name = concat_string!(legitimized_repr_name, "_exports");
     let namespace_object_ref = symbol_ref_db.create_facade_root_symbol_ref(&name);
 
+    let hmr_hot_ref = options.experimental.hmr.as_ref().map(|_| {
+      symbol_ref_db.create_facade_root_symbol_ref(&concat_string!(legitimized_repr_name, "_hot"))
+    });
+
     let result = ScanResult {
       named_imports: FxIndexMap::default(),
       named_exports: FxHashMap::default(),
@@ -160,6 +165,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       new_url_references: FxHashMap::default(),
       this_expr_replace_map: FxHashMap::default(),
       hmr_info: HmrInfo::default(),
+      hmr_hot_ref,
     };
 
     Self {

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -69,6 +69,7 @@ pub async fn create_ecma_view(
     new_url_references: new_url_imports,
     this_expr_replace_map,
     hmr_info,
+    hmr_hot_ref,
   } = scanner.scan(ast.program())?;
 
   if !errors.is_empty() {
@@ -122,6 +123,7 @@ pub async fn create_ecma_view(
     esm_namespace_in_cjs: None,
     esm_namespace_in_cjs_node_mode: None,
     hmr_info,
+    hmr_hot_ref,
   };
 
   let ecma_related = EcmaRelated { ast, symbols, dynamic_import_rec_exports_usage };

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/hmr.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/hmr.rs
@@ -123,15 +123,23 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
   }
 
   pub fn generate_stmt_of_init_module_hot_context(&self) -> ast::Statement<'ast> {
+    let hot_name = self.canonical_name_for(self.ctx.module.ecma_view.hmr_hot_ref.unwrap());
     // import.meta.hot = __rolldown_runtime__.createModuleHotContext(moduleId);
     let stmt = quote_stmt(
       self.alloc,
       &format!(
-        "import.meta.hot = __rolldown_runtime__.createModuleHotContext({:?});",
-        self.ctx.module.stable_id
+        "const {} = __rolldown_runtime__.createModuleHotContext({:?});",
+        hot_name, self.ctx.module.stable_id
       ),
     );
     stmt
+  }
+
+  pub fn rewrite_import_meta_hot(&self, expr: &mut ast::Expression<'ast>) {
+    if expr.is_import_meta_hot() {
+      let hot_name = self.canonical_name_for(self.ctx.module.ecma_view.hmr_hot_ref.unwrap());
+      *expr = self.snippet.id_ref_expr(hot_name, SPAN);
+    }
   }
 
   pub fn rewrite_hot_accept_call_deps(&self, call_expr: &mut ast::CallExpression<'ast>) {

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/impl_visit_mut.rs
@@ -314,6 +314,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         }
       }
     }
+    self.rewrite_import_meta_hot(expr);
 
     walk_mut::walk_expression(self, expr);
   }

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -149,6 +149,7 @@ impl RuntimeModuleTask {
         esm_namespace_in_cjs: None,
         esm_namespace_in_cjs_node_mode: None,
         hmr_info: scan_result.hmr_info,
+        hmr_hot_ref: None,
       },
       css_view: None,
       asset_view: None,

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -126,6 +126,10 @@ pub fn deconflict_chunk_symbols(
     .rev()
     .filter_map(|id| link_output.module_table.modules[id].as_normal())
     .for_each(|module| {
+      if let Some(hmr_hot_ref) = module.hmr_hot_ref {
+        renamer.add_symbol_in_root_scope(hmr_hot_ref);
+      }
+
       module
         .stmt_infos
         .iter()

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 
 //#region lib.js
 var require_lib = __commonJS({ "lib.js"(exports, module) {
-	import.meta.hot = __rolldown_runtime__.createModuleHotContext("lib.js");
+	const lib_hot = __rolldown_runtime__.createModuleHotContext("lib.js");
 	__rolldown_runtime__.registerModule("lib.js", module.exports, { cjs: true });
 	exports.a = 1;
 } });
@@ -19,7 +19,7 @@ var import_lib = __toESM(require_lib());
 
 //#endregion
 //#region main.js
-import.meta.hot = __rolldown_runtime__.createModuleHotContext("main.js");
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", {});
 assert.strictEqual(import_lib.a, 1);
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 //#region cjs.js
 var require_cjs = __commonJS({ "cjs.js"(exports, module) {
-	import.meta.hot = __rolldown_runtime__.createModuleHotContext("cjs.js");
+	const cjs_hot = __rolldown_runtime__.createModuleHotContext("cjs.js");
 	__rolldown_runtime__.registerModule("cjs.js", module.exports, { cjs: true });
 	module.exports.value = "cjs";
 } });
@@ -17,7 +17,7 @@ var import_cjs = __toESM(require_cjs());
 
 //#endregion
 //#region esm.js
-import.meta.hot = __rolldown_runtime__.createModuleHotContext("esm.js");
+const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
 __rolldown_runtime__.registerModule("esm.js", { value: () => value });
 var esm_exports = {};
 __export(esm_exports, { value: () => value });
@@ -25,7 +25,7 @@ const value = "main";
 
 //#endregion
 //#region main.js
-import.meta.hot = __rolldown_runtime__.createModuleHotContext("main.js");
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", {});
 console.log(import_cjs, esm_exports);
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4659,7 +4659,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-Bl27OrDc.js
+- main-!~{000}~.js => main-DFoYJjFt.js
 
 # tests/rolldown/issues/4196
 
@@ -5192,7 +5192,7 @@ expression: output
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-DTHexXOW.js
+- main-!~{000}~.js => main-D3FcQdsf.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -102,6 +102,7 @@ pub struct EcmaView {
   /// - Only exist when this module is a cjs module and get imported by static `import` statement.
   pub esm_namespace_in_cjs_node_mode: Option<EsmNamespaceInCjs>,
 
+  pub hmr_hot_ref: Option<SymbolRef>,
   pub hmr_info: HmrInfo,
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `import.meta.hot.invalidate` is execute at hmr, The original `import.meta.hot` is dependent on the module execute order, it will break at `import.meta.hot.invalidate`.

``` .js
import.meta.hot.accept(() => {
    // Trigger HMR in importers
    import.meta.hot.invalidate()
})
```

So the pr intend to fix it.
- Init chunk, create a hot symbol to deconflict.
- hmr chunk create a name `${reprname}_hot`.
``` .js
const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
main_hot.accept(() => {
    // Trigger HMR in importers
    main_hot.invalidate()
})
```
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
