### PR TITLE
feat: support variadic args for `or` and `and` filter expr

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/types/binding_filter_expression.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_filter_expression.rs
@@ -1,16 +1,84 @@
-use derive_more::Debug;
-
 use itertools::Itertools;
+use napi::{
+  bindgen_prelude::{Either3, FromNapiValue},
+  sys,
+};
 use napi_derive::napi;
-use rolldown_utils::filter_expression::Token;
+use rolldown_utils::{
+  filter_expression::Token, js_regex::HybridRegex, pattern_filter::StringOrRegex,
+};
 
-use super::binding_js_or_regex::BindingStringOrRegex;
+use super::binding_js_or_regex::JsRegExp;
+
+#[derive(Debug, Clone)]
+pub enum BindingFilterTokenPayloadInner {
+  StringOrRegex(StringOrRegex),
+  Number(u32),
+}
+impl BindingFilterTokenPayloadInner {
+  pub fn expect_string(self) -> String {
+    match self {
+      BindingFilterTokenPayloadInner::StringOrRegex(inner) => inner.expect_string(),
+      BindingFilterTokenPayloadInner::Number(_) => unreachable!(),
+    }
+  }
+
+  pub fn expect_string_or_regex(self) -> StringOrRegex {
+    match self {
+      BindingFilterTokenPayloadInner::StringOrRegex(inner) => inner,
+      BindingFilterTokenPayloadInner::Number(_) => unreachable!(),
+    }
+  }
+
+  pub fn expect_number(self) -> u32 {
+    match self {
+      BindingFilterTokenPayloadInner::StringOrRegex(_) => unreachable!(),
+      BindingFilterTokenPayloadInner::Number(v) => v,
+    }
+  }
+
+  pub fn expect_regex(self) -> HybridRegex {
+    match self {
+      BindingFilterTokenPayloadInner::StringOrRegex(inner) => inner.expect_regex(),
+      BindingFilterTokenPayloadInner::Number(_) => unreachable!(),
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct BindingFilterTokenPayload(BindingFilterTokenPayloadInner);
+
+impl BindingFilterTokenPayload {
+  pub fn into_inner(self) -> BindingFilterTokenPayloadInner {
+    self.0
+  }
+}
+
+impl FromNapiValue for BindingFilterTokenPayload {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+    unsafe {
+      let value = Either3::<String, JsRegExp, u32>::from_napi_value(env, napi_val)?;
+      let value = match value {
+        Either3::A(inner) => {
+          BindingFilterTokenPayloadInner::StringOrRegex(StringOrRegex::String(inner))
+        }
+        Either3::B(inner) => {
+          let reg = HybridRegex::with_flags(&inner.source, &inner.flags)?;
+          BindingFilterTokenPayloadInner::StringOrRegex(StringOrRegex::Regex(reg))
+        }
+        Either3::C(inner) => BindingFilterTokenPayloadInner::Number(inner),
+      };
+      Ok(Self(value))
+    }
+  }
+}
 
 #[napi(object, object_to_js = false)]
 #[derive(Debug, Clone)]
 pub struct BindingFilterToken {
   pub kind: FilterTokenKind,
-  pub value: Option<BindingStringOrRegex>,
+  #[napi(ts_type = "BindingStringOrRegex | number")]
+  pub payload: Option<BindingFilterTokenPayload>,
 }
 
 #[napi(string_enum)]
@@ -29,19 +97,28 @@ pub enum FilterTokenKind {
 impl From<BindingFilterToken> for Token {
   fn from(value: BindingFilterToken) -> Self {
     match value.kind {
-      FilterTokenKind::Id => Token::Id(value.value.expect("Id should have payload").inner()),
-      FilterTokenKind::Code => Token::Code(value.value.expect("Code should have payload").inner()),
-      FilterTokenKind::ModuleType => Token::ModuleType(
-        value.value.expect("ModuleType should have payload").inner().expect_string(),
+      FilterTokenKind::Id => Token::Id(
+        value.payload.expect("Id should have payload").into_inner().expect_string_or_regex(),
       ),
-      FilterTokenKind::And => Token::And,
-      FilterTokenKind::Or => Token::Or,
+      FilterTokenKind::Code => Token::Code(
+        value.payload.expect("Code should have payload").into_inner().expect_string_or_regex(),
+      ),
+      FilterTokenKind::ModuleType => Token::ModuleType(
+        value.payload.expect("ModuleType should have payload").into_inner().expect_string(),
+      ),
+      FilterTokenKind::And => {
+        Token::And(value.payload.expect("And should have payload").into_inner().expect_number())
+      }
+      FilterTokenKind::Or => {
+        Token::Or(value.payload.expect("`Or` should have payload").into_inner().expect_number())
+      }
       FilterTokenKind::Not => Token::Not,
       FilterTokenKind::Include => Token::Include,
       FilterTokenKind::Exclude => Token::Exclude,
     }
   }
 }
+
 pub fn normalized_tokens(tokens: Vec<BindingFilterToken>) -> Vec<Token> {
   tokens.into_iter().map(Token::from).collect_vec()
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -311,7 +311,7 @@ export interface BindingExperimentalOptions {
 
 export interface BindingFilterToken {
   kind: FilterTokenKind
-  value?: BindingStringOrRegex
+  payload?: BindingStringOrRegex | number
 }
 
 export interface BindingGlobImportPluginConfig {

--- a/packages/rolldown/src/filter-index.ts
+++ b/packages/rolldown/src/filter-index.ts
@@ -17,21 +17,23 @@ export type TopLevelFilterExpression = Include | Exclude;
 
 export class And {
   kind: 'and';
-  left: FilterExpression;
-  right: FilterExpression;
-  constructor(left: FilterExpression, right: FilterExpression) {
-    this.left = left;
-    this.right = right;
+  args: FilterExpression[];
+  constructor(...args: FilterExpression[]) {
+    if (args.length === 0) {
+      throw new Error('`And` expects at least one operand');
+    }
+    this.args = args;
     this.kind = 'and';
   }
 }
 class Or {
   kind: 'or';
-  left: FilterExpression;
-  right: FilterExpression;
-  constructor(left: FilterExpression, right: FilterExpression) {
-    this.left = left;
-    this.right = right;
+  args: FilterExpression[];
+  constructor(...args: FilterExpression[]) {
+    if (args.length === 0) {
+      throw new Error('`Or` expects at least one operand');
+    }
+    this.args = args;
     this.kind = 'or';
   }
 }
@@ -90,39 +92,36 @@ class Exclude {
   }
 }
 
-export function and(left: FilterExpression, right: FilterExpression): And {
-  return { kind: 'and', left, right };
+export function and(...args: FilterExpression[]): And {
+  return new And(...args);
 }
 
-export function or(left: FilterExpression, right: FilterExpression): Or {
-  return { kind: 'or', left, right };
+export function or(...args: FilterExpression[]): Or {
+  return new Or(...args);
 }
 
 export function not(expr: FilterExpression): Not {
-  return { kind: 'not', expr };
+  return new Not(expr);
 }
 
 export function id(pattern: StringOrRegExp): Id {
-  return {
-    kind: 'id',
-    pattern,
-  };
+  return new Id(pattern);
 }
 
 export function moduleType(pattern: PluginModuleType): ModuleType {
-  return { kind: 'moduleType', pattern };
+  return new ModuleType(pattern);
 }
 
 export function code(pattern: StringOrRegExp): Code {
-  return { kind: 'code', pattern };
+  return new Code(pattern);
 }
 
 export function include(expr: FilterExpression): Include {
-  return { kind: 'include', expr };
+  return new Include(expr);
 }
 
 export function exclude(expr: FilterExpression): Exclude {
-  return { kind: 'exclude', expr };
+  return new Exclude(expr);
 }
 
 export { withFilter } from './plugin';


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. This should also improve the performance of interpreting the filterExpr, since now `Or` and `And` filterExpr are more cache-friendly.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded filter expression logic to support combining multiple conditions with "and"/"or" (n-ary logic), allowing more flexible and powerful filtering.
  - Filter tokens now support both string/regex and numeric payloads for greater versatility.

- **Refactor**
  - Updated filter expression and token structures to use arrays for "and"/"or" operations instead of only two operands.
  - Renamed and unified token property from "value" to "payload" to accommodate new types.
  - Adjusted related APIs and helper functions to support the new filter expression model.
  - Converted exported filter factory functions to return class instances instead of plain objects.
  - Simplified filter expression evaluation and parsing to align with n-ary logic changes.
  - Removed unused helper function for joining filter expressions with "or".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->