### PR TITLE
feat: merge same `ImportNamespaceSpecifier`  for external module

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -15,6 +15,7 @@ use rolldown_rstr::{Rstr, ToRstr};
 use rolldown_utils::{
   ecmascript::{is_validate_identifier_name, legitimize_identifier_name},
   index_vec_ext::IndexVecExt,
+  indexmap::FxIndexSet,
   rayon::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator},
 };
 
@@ -178,15 +179,7 @@ impl LinkStage<'_> {
     self.errors.extend(binding_ctx.errors);
     self.warnings.extend(binding_ctx.warnings);
 
-    for symbol_set in binding_ctx.external_import_namespace_merger.values() {
-      let mut peekable = symbol_set.iter();
-      let Some(first) = peekable.next() else {
-        continue;
-      };
-      for symbol in peekable {
-        binding_ctx.symbol_db.link(*first, *symbol);
-      }
-    }
+    self.external_import_namespace_merger = binding_ctx.external_import_namespace_merger;
 
     for (module_idx, map) in &binding_ctx.external_import_binding_merger {
       for (key, symbol_set) in map {
@@ -534,7 +527,7 @@ struct BindImportsAndExportsContext<'a> {
   pub warnings: Vec<BuildDiagnostic>,
   pub external_import_binding_merger:
     FxHashMap<ModuleIdx, FxHashMap<CompactStr, IndexSet<SymbolRef>>>,
-  pub external_import_namespace_merger: FxHashMap<ModuleIdx, IndexSet<SymbolRef>>,
+  pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
   pub side_effects_modules: &'a FxHashSet<ModuleIdx>,
   pub normal_symbol_exports_chain_map: &'a mut FxHashMap<SymbolRef, Vec<SymbolRef>>,
 }

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -6,6 +6,7 @@ use rolldown_common::{
   dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_error::BuildDiagnostic;
+use rolldown_utils::indexmap::FxIndexSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
@@ -41,6 +42,7 @@ pub struct LinkStageOutput {
   pub used_symbol_refs: FxHashSet<SymbolRef>,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, Vec<SymbolRef>>,
+  pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
 }
 
 #[derive(Debug)]
@@ -59,6 +61,7 @@ pub struct LinkStage<'a> {
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, Vec<SymbolRef>>,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
   pub normal_symbol_exports_chain_map: FxHashMap<SymbolRef, Vec<SymbolRef>>,
+  pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
 }
 
 impl<'a> LinkStage<'a> {
@@ -101,6 +104,7 @@ impl<'a> LinkStage<'a> {
       used_symbol_refs: FxHashSet::default(),
       safely_merge_cjs_ns_map: scan_stage_output.safely_merge_cjs_ns_map,
       normal_symbol_exports_chain_map: FxHashMap::default(),
+      external_import_namespace_merger: FxHashMap::default(),
     }
   }
 
@@ -133,6 +137,7 @@ impl<'a> LinkStage<'a> {
       used_symbol_refs: self.used_symbol_refs,
       dynamic_import_exports_usage_map: self.dynamic_import_exports_usage_map,
       safely_merge_cjs_ns_map: self.safely_merge_cjs_ns_map,
+      external_import_namespace_merger: self.external_import_namespace_merger,
     }
   }
 

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
@@ -6,13 +6,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import * as ns$2 from "x";
+import * as ns$1 from "x";
 import { ns } from "x";
 
 
 //#region a.js
 var a_exports = {};
-__export(a_exports, { ns: () => ns$2 });
+__export(a_exports, { ns: () => ns$1 });
 var init_a = __esm({ "a.js"() {} });
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
@@ -1,27 +1,24 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
 ## entry.js
 
 ```js
-import * as ns$3 from "x";
 import * as ns$2 from "x";
-import * as ns$1 from "x";
 import { ns } from "x";
 
 
 //#region a.js
 var a_exports = {};
-__export(a_exports, { ns: () => ns$3 });
+__export(a_exports, { ns: () => ns$2 });
 var init_a = __esm({ "a.js"() {} });
 
 //#endregion
 //#region b.js
 var b_exports = {};
-__export(b_exports, { ns: () => ns$2 });
+__export(b_exports, { ns: () => ns$1 });
 var init_b = __esm({ "b.js"() {} });
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/diff.md
@@ -67,21 +67,19 @@ init_e();
 ```
 ### rolldown
 ```js
-import * as ns$3 from "x";
-import * as ns$2 from "x";
 import * as ns$1 from "x";
 import { ns } from "x";
 
 
 //#region a.js
 var a_exports = {};
-__export(a_exports, { ns: () => ns$3 });
+__export(a_exports, { ns: () => ns$1 });
 var init_a = __esm({ "a.js"() {} });
 
 //#endregion
 //#region b.js
 var b_exports = {};
-__export(b_exports, { ns: () => ns$2 });
+__export(b_exports, { ns: () => ns$1 });
 var init_b = __esm({ "b.js"() {} });
 
 //#endregion
@@ -118,15 +116,13 @@ init_e();
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,42 +1,41 @@
-+import * as ns$3 from "x";
-+import * as ns$2 from "x";
+@@ -1,42 +1,39 @@
 +import * as ns$1 from "x";
 +import {ns} from "x";
  var a_exports = {};
  __export(a_exports, {
 -    ns: () => ns
-+    ns: () => ns$3
++    ns: () => ns$1
  });
 -import * as ns from "x";
  var init_a = __esm({
@@ -135,7 +131,7 @@ init_e();
  var b_exports = {};
  __export(b_exports, {
 -    ns: () => ns2
-+    ns: () => ns$2
++    ns: () => ns$1
  });
 -import * as ns2 from "x";
  var init_b = __esm({

--- a/crates/rolldown/tests/esbuild/default/import_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
@@ -117,7 +116,6 @@ snapshot_kind: text
 ## entry.js
 
 ```js
-import * as ns from "foo";
 import * as ns2 from "foo";
 import def, { a, a2, b } from "foo";
 
@@ -125,7 +123,7 @@ import def, { a, a2, b } from "foo";
 const imp = [import("foo"), function() {
 	return import("foo");
 }];
-console.log(ns, a, b, def, def, ns2, def, a2, b, imp);
+console.log(ns2, a, b, def, def, ns2, def, a2, b, imp);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/import_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
@@ -116,14 +116,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import * as ns2 from "foo";
+import * as ns from "foo";
 import def, { a, a2, b } from "foo";
 
 //#region entry.js
 const imp = [import("foo"), function() {
 	return import("foo");
 }];
-console.log(ns2, a, b, def, def, ns2, def, a2, b, imp);
+console.log(ns, a, b, def, def, ns, def, a2, b, imp);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/import_forms_with_minify_identifiers_and_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/default/import_forms_with_minify_identifiers_and_no_bundle/bypass.md
@@ -23,14 +23,13 @@ console.log(o, r, m, t, f, i, p, s, n, a);
 ### rolldown
 ```js
 import * as ns from "foo";
-import * as ns2 from "foo";
 import def, { a, a2, b } from "foo";
 
 //#region entry.js
 const imp = [import("foo"), function() {
 	return import("foo");
 }];
-console.log(ns, a, b, def, def, ns2, def, a2, b, imp);
+console.log(ns, a, b, def, def, ns, def, a2, b, imp);
 
 //#endregion
 ```
@@ -39,7 +38,7 @@ console.log(ns, a, b, def, def, ns2, def, a2, b, imp);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,11 +1,7 @@
+@@ -1,11 +1,6 @@
 -import "foo";
 -import "foo";
 -import * as o from "foo";
@@ -49,12 +48,11 @@ console.log(ns, a, b, def, def, ns2, def, a2, b, imp);
 -import p, {a2 as s, b as n} from "foo";
 -const a = [import("foo"), function () {
 +import * as ns from "foo";
-+import * as ns2 from "foo";
 +import def, {a, a2, b} from "foo";
 +var imp = [import("foo"), function () {
      return import("foo");
  }];
 -console.log(o, r, m, t, f, i, p, s, n, a);
-+console.log(ns, a, b, def, def, ns2, def, a2, b, imp);
++console.log(ns, a, b, def, def, ns, def, a2, b, imp);
 
 ```

--- a/crates/rolldown/tests/esbuild/default/import_forms_with_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_forms_with_no_bundle/artifacts.snap
@@ -116,14 +116,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import * as ns2 from "foo";
+import * as ns from "foo";
 import def, { a, a2, b } from "foo";
 
 //#region entry.js
 const imp = [import("foo"), function nested() {
 	return import("foo");
 }];
-console.log(ns2, a, b, def, def, ns2, def, a2, b, imp);
+console.log(ns, a, b, def, def, ns, def, a2, b, imp);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/import_forms_with_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_forms_with_no_bundle/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
@@ -117,7 +116,6 @@ snapshot_kind: text
 ## entry.js
 
 ```js
-import * as ns from "foo";
 import * as ns2 from "foo";
 import def, { a, a2, b } from "foo";
 
@@ -125,7 +123,7 @@ import def, { a, a2, b } from "foo";
 const imp = [import("foo"), function nested() {
 	return import("foo");
 }];
-console.log(ns, a, b, def, def, ns2, def, a2, b, imp);
+console.log(ns2, a, b, def, def, ns2, def, a2, b, imp);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/import_forms_with_no_bundle/bypass.md
+++ b/crates/rolldown/tests/esbuild/default/import_forms_with_no_bundle/bypass.md
@@ -23,14 +23,13 @@ console.log(ns, a, c, def, def2, ns2, def3, a2, c3, imp);
 ### rolldown
 ```js
 import * as ns from "foo";
-import * as ns2 from "foo";
 import def, { a, a2, b } from "foo";
 
 //#region entry.js
 const imp = [import("foo"), function nested() {
 	return import("foo");
 }];
-console.log(ns, a, b, def, def, ns2, def, a2, b, imp);
+console.log(ns, a, b, def, def, ns, def, a2, b, imp);
 
 //#endregion
 ```
@@ -39,7 +38,7 @@ console.log(ns, a, b, def, def, ns2, def, a2, b, imp);
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,11 +1,7 @@
+@@ -1,11 +1,6 @@
 -import "foo";
 -import "foo";
  import * as ns from "foo";
@@ -48,12 +47,11 @@ console.log(ns, a, b, def, def, ns2, def, a2, b, imp);
 -import def2, * as ns2 from "foo";
 -import def3, {a2, b as c3} from "foo";
 -const imp = [import("foo"), function nested() {
-+import * as ns2 from "foo";
 +import def, {a, a2, b} from "foo";
 +var imp = [import("foo"), function nested() {
      return import("foo");
  }];
 -console.log(ns, a, c, def, def2, ns2, def3, a2, c3, imp);
-+console.log(ns, a, b, def, def, ns2, def, a2, b, imp);
++console.log(ns, a, b, def, def, ns, def, a2, b, imp);
 
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
@@ -104,12 +104,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## external-def.js
 
 ```js
-import "./external-def2.js";
-
-```
-## external-def2.js
-
-```js
 import * as ns from "external";
 import def from "external";
 
@@ -117,12 +111,10 @@ import def from "external";
 console.log(def, ns.def);
 
 //#endregion
-export { ns };
 ```
 ## external-default.js
 
 ```js
-import { ns } from "./external-def2.js";
 import * as ns from "external";
 import def from "external";
 
@@ -144,12 +136,6 @@ console.log(def, def);
 ## external-ns-def.js
 
 ```js
-import "./external-ns-def2.js";
-
-```
-## external-ns-def2.js
-
-```js
 import * as ns from "external";
 import def from "external";
 
@@ -157,12 +143,10 @@ import def from "external";
 console.log(def, ns, ns.def);
 
 //#endregion
-export { ns };
 ```
 ## external-ns-default.js
 
 ```js
-import { ns } from "./external-ns-def2.js";
 import * as ns from "external";
 import def from "external";
 

--- a/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
@@ -104,6 +104,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## external-def.js
 
 ```js
+import "./external-def2.js";
+
+```
+## external-def2.js
+
+```js
 import * as ns from "external";
 import def from "external";
 
@@ -111,10 +117,12 @@ import def from "external";
 console.log(def, ns.def);
 
 //#endregion
+export { ns };
 ```
 ## external-default.js
 
 ```js
+import { ns } from "./external-def2.js";
 import * as ns from "external";
 import def from "external";
 
@@ -136,6 +144,12 @@ console.log(def, def);
 ## external-ns-def.js
 
 ```js
+import "./external-ns-def2.js";
+
+```
+## external-ns-def2.js
+
+```js
 import * as ns from "external";
 import def from "external";
 
@@ -143,10 +157,12 @@ import def from "external";
 console.log(def, ns, ns.def);
 
 //#endregion
+export { ns };
 ```
 ## external-ns-default.js
 
 ```js
+import { ns } from "./external-ns-def2.js";
 import * as ns from "external";
 import def from "external";
 

--- a/crates/rolldown/tests/rolldown/function/external/export_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/export_external/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
@@ -8,7 +7,6 @@ snapshot_kind: text
 
 ```js
 import * as ext1 from "external";
-import * as ext from "external";
 import { a, a as a$1, a as a1, b, b as b$1, b as b1 } from "external";
 
 //#region foo.js
@@ -17,7 +15,7 @@ console.log(a1$1);
 
 //#endregion
 //#region main.js
-console.log(ext, a1, b1, ext1, a$1, b$1);
+console.log(ext1, a1, b1, ext1, a$1, b$1);
 
 //#endregion
 export { a, b };

--- a/crates/rolldown/tests/rolldown/function/external/import_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/import_external/artifacts.snap
@@ -1,18 +1,16 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
 ## main.js
 
 ```js
-import * as ext$1 from "external";
 import * as ext from "external";
 import { a, b } from "external";
 
 //#region foo.js
-console.log(ext$1, a, b);
+console.log(ext, a, b);
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/issues/4324/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4324/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "external": ["node:http", "node:net"]
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/4324/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4324/artifacts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import * as hello from "node:http";
+import { URL } from "node:net";
+
+//#region file.js
+console.log("file", hello, URL);
+
+//#endregion
+//#region file2.js
+console.log("file", hello, URL);
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/issues/4324/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4324/artifacts.snap
@@ -6,15 +6,16 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import * as hello from "node:http";
+import * as what from "node:http";
+import dh from "node:http";
 import { URL } from "node:net";
 
 //#region file.js
-console.log("file", hello, URL);
+console.log("file", what, URL, dh);
 
 //#endregion
 //#region file2.js
-console.log("file", hello, URL);
+console.log("file", what, URL, dh);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/issues/4324/file.js
+++ b/crates/rolldown/tests/rolldown/issues/4324/file.js
@@ -1,0 +1,4 @@
+import * as what from 'node:http';
+import { URL } from 'node:net';
+
+console.log('file', what, URL);

--- a/crates/rolldown/tests/rolldown/issues/4324/file.js
+++ b/crates/rolldown/tests/rolldown/issues/4324/file.js
@@ -1,4 +1,5 @@
-import * as what from 'node:http';
+import dh, * as what from 'node:http';
 import { URL } from 'node:net';
 
-console.log('file', what, URL);
+console.log('file', what, URL, dh);
+

--- a/crates/rolldown/tests/rolldown/issues/4324/file2.js
+++ b/crates/rolldown/tests/rolldown/issues/4324/file2.js
@@ -1,4 +1,5 @@
-import * as hello from 'node:http';
+import dh, * as hello from 'node:http';
 import { URL as URL2 } from 'node:net';
 
-console.log('file', hello, URL2);
+console.log('file', hello, URL2, dh);
+

--- a/crates/rolldown/tests/rolldown/issues/4324/file2.js
+++ b/crates/rolldown/tests/rolldown/issues/4324/file2.js
@@ -1,0 +1,4 @@
+import * as hello from 'node:http';
+import { URL as URL2 } from 'node:net';
+
+console.log('file', hello, URL2);

--- a/crates/rolldown/tests/rolldown/issues/4324/main.js
+++ b/crates/rolldown/tests/rolldown/issues/4324/main.js
@@ -1,0 +1,2 @@
+import './file.js'
+import './file2.js'

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -843,7 +843,7 @@ expression: output
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
-- entry-!~{000}~.js => entry-BmDksj4Q.js
+- entry-!~{000}~.js => entry-Bgev7Bqj.js
 
 # tests/esbuild/default/external_module_exclusion_package
 
@@ -915,11 +915,11 @@ expression: output
 
 # tests/esbuild/default/import_forms_with_minify_identifiers_and_no_bundle
 
-- entry-!~{000}~.js => entry-qpFBF9v6.js
+- entry-!~{000}~.js => entry-BP3Qc8x8.js
 
 # tests/esbuild/default/import_forms_with_no_bundle
 
-- entry-!~{000}~.js => entry-COyv-4Wz.js
+- entry-!~{000}~.js => entry-ClQqYg4L.js
 
 # tests/esbuild/default/import_fs_browser
 
@@ -1895,18 +1895,20 @@ expression: output
 
 # tests/esbuild/importstar/import_default_namespace_combo_issue446
 
-- external-def-!~{005}~.js => external-def-DMWRNYC1.js
-- external-default-!~{004}~.js => external-default-CeaZt81w.js
+- external-def-!~{005}~.js => external-def-BbZtze6f.js
+- external-default-!~{004}~.js => external-default-BlR6JmYG.js
 - external-default2-!~{000}~.js => external-default2-DUcUjrRi.js
 - external-ns-!~{001}~.js => external-ns-all2LFha.js
-- external-ns-def-!~{003}~.js => external-ns-def-CPrnmGVn.js
-- external-ns-default-!~{002}~.js => external-ns-default-Cbqf8eIs.js
+- external-ns-def-!~{003}~.js => external-ns-def-BG3w8rdv.js
+- external-ns-default-!~{002}~.js => external-ns-default-3z7HkR6q.js
 - internal-def-!~{00b}~.js => internal-def-CRNsLces.js
 - internal-default-!~{00a}~.js => internal-default-Dx0cXe3H.js
 - internal-default2-!~{006}~.js => internal-default2-Br-ACsYq.js
 - internal-ns-!~{007}~.js => internal-ns-a_Hq6o6-.js
 - internal-ns-def-!~{009}~.js => internal-ns-def-BSYbjTZ1.js
 - internal-ns-default-!~{008}~.js => internal-ns-default-BkqjZs1S.js
+- external-def-!~{00g}~.js => external-def-ceM7EDte.js
+- external-ns-def-!~{00e}~.js => external-ns-def-BE4XoJvZ.js
 - internal-!~{00c}~.js => internal-1sX5rN8A.js
 
 # tests/esbuild/importstar/import_export_other_as_namespace_common_js
@@ -4188,7 +4190,7 @@ expression: output
 
 # tests/rolldown/function/external/export_external
 
-- main-!~{000}~.js => main-bboG_iKl.js
+- main-!~{000}~.js => main-5sPV7EtM.js
 
 # tests/rolldown/function/external/implicit_import_external
 
@@ -4196,7 +4198,7 @@ expression: output
 
 # tests/rolldown/function/external/import_external
 
-- main-!~{000}~.js => main-B3SOe15B.js
+- main-!~{000}~.js => main-De65fPUh.js
 
 # tests/rolldown/function/external/keep_import_external_order
 
@@ -4695,6 +4697,10 @@ expression: output
 - main-!~{000}~.js => main-BjZFiMIo.js
 - chunk-!~{001}~.js => chunk-e6zvK7dF.js
 - lib-!~{003}~.js => lib-DXD_OL-7.js
+
+# tests/rolldown/issues/4324
+
+- main-!~{000}~.js => main-BvlzDs6f.js
 
 # tests/rolldown/issues/4390
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -843,7 +843,7 @@ expression: output
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
-- entry-!~{000}~.js => entry-Bgev7Bqj.js
+- entry-!~{000}~.js => entry-C5L-ji0D.js
 
 # tests/esbuild/default/external_module_exclusion_package
 
@@ -915,11 +915,11 @@ expression: output
 
 # tests/esbuild/default/import_forms_with_minify_identifiers_and_no_bundle
 
-- entry-!~{000}~.js => entry-BP3Qc8x8.js
+- entry-!~{000}~.js => entry-ONEZmqML.js
 
 # tests/esbuild/default/import_forms_with_no_bundle
 
-- entry-!~{000}~.js => entry-ClQqYg4L.js
+- entry-!~{000}~.js => entry-CjRqtT4p.js
 
 # tests/esbuild/default/import_fs_browser
 
@@ -1895,20 +1895,18 @@ expression: output
 
 # tests/esbuild/importstar/import_default_namespace_combo_issue446
 
-- external-def-!~{005}~.js => external-def-BbZtze6f.js
-- external-default-!~{004}~.js => external-default-BlR6JmYG.js
+- external-def-!~{005}~.js => external-def-DMWRNYC1.js
+- external-default-!~{004}~.js => external-default-CeaZt81w.js
 - external-default2-!~{000}~.js => external-default2-DUcUjrRi.js
 - external-ns-!~{001}~.js => external-ns-all2LFha.js
-- external-ns-def-!~{003}~.js => external-ns-def-BG3w8rdv.js
-- external-ns-default-!~{002}~.js => external-ns-default-3z7HkR6q.js
+- external-ns-def-!~{003}~.js => external-ns-def-CPrnmGVn.js
+- external-ns-default-!~{002}~.js => external-ns-default-Cbqf8eIs.js
 - internal-def-!~{00b}~.js => internal-def-CRNsLces.js
 - internal-default-!~{00a}~.js => internal-default-Dx0cXe3H.js
 - internal-default2-!~{006}~.js => internal-default2-Br-ACsYq.js
 - internal-ns-!~{007}~.js => internal-ns-a_Hq6o6-.js
 - internal-ns-def-!~{009}~.js => internal-ns-def-BSYbjTZ1.js
 - internal-ns-default-!~{008}~.js => internal-ns-default-BkqjZs1S.js
-- external-def-!~{00g}~.js => external-def-ceM7EDte.js
-- external-ns-def-!~{00e}~.js => external-ns-def-BE4XoJvZ.js
 - internal-!~{00c}~.js => internal-1sX5rN8A.js
 
 # tests/esbuild/importstar/import_export_other_as_namespace_common_js
@@ -4700,7 +4698,7 @@ expression: output
 
 # tests/rolldown/issues/4324
 
-- main-!~{000}~.js => main-BvlzDs6f.js
+- main-!~{000}~.js => main-DulOdpdR.js
 
 # tests/rolldown/issues/4390
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Closed https://github.com/rolldown/rolldown/issues/4324
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate namespace imports when bundling external modules, ensuring each external module is only imported once as a namespace.

- **Tests**
  - Added new test cases to verify correct handling of namespace imports for external modules, including scenarios with multiple imports from the same external source.

- **Chores**
  - Updated test configurations to mark certain modules as external dependencies and clarify execution expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->