### PR TITLE
perf(rolldown_plugin_json): change `register_hook_usage` to return `HookUsage::Transform`

### DIFF
--- a/crates/rolldown_plugin_json/src/lib.rs
+++ b/crates/rolldown_plugin_json/src/lib.rs
@@ -75,7 +75,6 @@ impl Plugin for JsonPlugin {
   }
 
   fn register_hook_usage(&self) -> rolldown_plugin::HookUsage {
-    // TODO: get hook usage from option
-    HookUsage::all()
+    HookUsage::Transform
   }
 }


### PR DESCRIPTION
### Description

Related to #3968

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal plugin behavior to use only the Transform hook, optimizing how plugins are registered. No visible changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->