### PR TITLE
docs: Remove typo in `output-options`

### DIFF
--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -150,7 +150,7 @@ export interface OutputOptions {
        * - Type: `number`
        * - Default: `0`
        *
-       * Minimum size of the desired chunk. If accumulated size of captured modules is smaller than this value, this group will be ignored.s
+       * Minimum size of the desired chunk. If accumulated size of captured modules is smaller than this value, this group will be ignored.
        */
       minSize?: number;
       /**


### PR DESCRIPTION
There is currently a typo in the `output-options#advancedChunks` documentation. This PR fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in a comment to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->