### PR TITLE
chore: bundle `valibot`

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -63,10 +63,8 @@
   "dependencies": {
     "@napi-rs/wasm-runtime": "^0.2.8",
     "@oxc-project/types": "0.67.0",
-    "@valibot/to-json-schema": "1.0.0",
     "ansis": "^3.17.0",
-    "pathe": "^2.0.3",
-    "valibot": "1.0.0"
+    "pathe": "^2.0.3"
   },
   "peerDependencies": {
     "@oxc-project/runtime": "0.67.0"

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -105,8 +105,6 @@ function withShared(
       /rolldown-binding\..*\.wasm/,
       /@rolldown\/binding-.*/,
       /\.\/rolldown-binding\.wasi\.cjs/,
-      // some dependencies, e.g. zod, cannot be inlined because their types
-      // are used in public APIs
       ...Object.keys(pkgJson.dependencies ?? {}),
     ],
     define: {

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -105,9 +105,7 @@
   },
   "dependencies": {
     "@oxc-project/types": "0.67.0",
-    "@valibot/to-json-schema": "1.0.0",
-    "ansis": "^3.17.0",
-    "valibot": "1.0.0"
+    "ansis": "^3.17.0"
   },
   "peerDependencies": {
     "@oxc-project/runtime": "0.67.0"
@@ -124,6 +122,7 @@
     "@rolldown/testing": "workspace:*",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash-es": "^4.17.12",
+    "@valibot/to-json-schema": "1.0.0",
     "consola": "^3.4.2",
     "emnapi": "^1.2.0",
     "execa": "^9.2.0",
@@ -142,7 +141,8 @@
     "type-fest": "^4.20.0",
     "typedoc": "^0.28.0",
     "typescript": "^5.7.3",
-    "unbuild": "^3.0.0"
+    "unbuild": "^3.0.0",
+    "valibot": "1.0.0"
   },
   "optionalDependencies": {
     "@rolldown/binding-darwin-arm64": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,18 +263,12 @@ importers:
       '@oxc-project/types':
         specifier: 0.67.0
         version: 0.67.0
-      '@valibot/to-json-schema':
-        specifier: 1.0.0
-        version: 1.0.0(valibot@1.0.0(typescript@5.8.3))
       ansis:
         specifier: ^3.17.0
         version: 3.17.0
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
-      valibot:
-        specifier: 1.0.0
-        version: 1.0.0(typescript@5.8.3)
 
   packages/debug: {}
 
@@ -286,15 +280,9 @@ importers:
       '@oxc-project/types':
         specifier: 0.67.0
         version: 0.67.0
-      '@valibot/to-json-schema':
-        specifier: 1.0.0
-        version: 1.0.0(valibot@1.0.0(typescript@5.8.3))
       ansis:
         specifier: ^3.17.0
         version: 3.17.0
-      valibot:
-        specifier: 1.0.0
-        version: 1.0.0(typescript@5.8.3)
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.0.0-alpha.77
@@ -314,6 +302,9 @@ importers:
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
+      '@valibot/to-json-schema':
+        specifier: 1.0.0
+        version: 1.0.0(valibot@1.0.0(typescript@5.8.3))
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -371,6 +362,9 @@ importers:
       unbuild:
         specifier: ^3.0.0
         version: 3.5.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+      valibot:
+        specifier: 1.0.0
+        version: 1.0.0(typescript@5.8.3)
     optionalDependencies:
       '@rolldown/binding-darwin-arm64':
         specifier: workspace:*


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Valibot is a library with quite a lot of surface area (2MB)

However, it is excellent for treeshaking and bundling - so this PR bundles `valibot`.

This makes its size on disk for rolldown go from 2MB -> 33kB~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependencies by removing unused packages from the browser package and shifting certain dependencies in the rolldown package to development-only status. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->