### PR TITLE
feat(types): expose more watcher related types

### DIFF
--- a/packages/rolldown/src/api/watch/watch-emitter.ts
+++ b/packages/rolldown/src/api/watch/watch-emitter.ts
@@ -6,7 +6,7 @@ export type WatcherEvent = 'close' | 'event' | 'restart' | 'change';
 
 export type ChangeEvent = 'create' | 'update' | 'delete';
 
-export type RollupWatcherEvent =
+export type RolldownWatcherEvent =
   | { code: 'START' }
   | {
     code: 'BUNDLE_START'; /* input?: InputOption; output: readonly string[] */
@@ -48,7 +48,7 @@ export class WatcherEmitter {
   ): this;
   on(
     event: 'event',
-    listener: (data: RollupWatcherEvent) => MaybePromise<void>,
+    listener: (data: RolldownWatcherEvent) => MaybePromise<void>,
   ): this;
   on(event: 'restart' | 'close', listener: () => MaybePromise<void>): this;
   on(

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -3,7 +3,10 @@ import { build, type BuildOptions } from './api/build';
 import { rolldown } from './api/rolldown';
 import { RolldownBuild } from './api/rolldown/rolldown-build';
 import { watch } from './api/watch';
-import type { RolldownWatcher } from './api/watch/watch-emitter';
+import type {
+  RolldownWatcher,
+  RolldownWatcherEvent,
+} from './api/watch/watch-emitter';
 import type { PreRenderedChunk } from './binding';
 import type {
   LoggingFunction,
@@ -158,6 +161,7 @@ export type {
   RolldownPlugin,
   RolldownPluginOption,
   RolldownWatcher,
+  RolldownWatcherEvent,
   RollupError,
   RollupLog,
   RollupLogWithString,

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -25,6 +25,7 @@ import type {
   InputOption,
   InputOptions,
   JsxOptions,
+  WatcherOptions,
 } from './options/input-options';
 import type { NormalizedInputOptions } from './options/normalized-input-options';
 import type {
@@ -173,5 +174,6 @@ export type {
   TransformResult,
   TreeshakingOptions,
   WarningHandlerWithDefault,
+  WatcherOptions,
   WatchOptions,
 };

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -61,7 +61,7 @@ export interface JsxOptions {
   development?: boolean;
 }
 
-export interface WatchOptions {
+export interface WatcherOptions {
   skipWrite?: boolean;
   buildDelay?: number;
   notify?: {
@@ -223,7 +223,7 @@ export interface InputOptions {
    */
   jsx?: false | 'react' | 'react-jsx' | 'preserve' | JsxOptions;
   transform?: OxcTransformOption;
-  watch?: WatchOptions | false;
+  watch?: WatcherOptions | false;
   dropLabels?: string[];
   keepNames?: boolean;
   checks?: ChecksOptions;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Expose `RolldownWatcherEvent` and `WatcherOptions`. These are exposed from rollup and Vite uses them.
https://github.com/rollup/rollup/blob/cb8f81530279f1262d692fde2d4cecc758cadd46/src/rollup/types.d.ts#L1059-L1070
https://github.com/rollup/rollup/blob/cb8f81530279f1262d692fde2d4cecc758cadd46/src/rollup/types.d.ts#L1011-L1019

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated type and interface names for consistency with project naming conventions. This includes renaming certain watcher-related types and updating their usage throughout the codebase.
- **Documentation**
  - Newly renamed and additional watcher-related types are now available for external use in the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->