### PR TITLE
feat: add watcher.off method to remove event listener

### DIFF
--- a/packages/rolldown/src/api/watch/watch-emitter.ts
+++ b/packages/rolldown/src/api/watch/watch-emitter.ts
@@ -64,6 +64,18 @@ export class WatcherEmitter {
     return this;
   }
 
+  off(
+    event: WatcherEvent,
+    listener: (...parameters: any[]) => MaybePromise<void>,
+  ): this {
+    const listeners = this.listeners.get(event);
+    if (listeners) {
+      const index = listeners.indexOf(listener);
+      if (index !== -1) listeners.splice(index, 1);
+    }
+    return this;
+  }
+
   async onEvent(event: BindingWatcherEvent): Promise<void> {
     const listeners = this.listeners.get(event.eventKind() as WatcherEvent);
     if (listeners) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Add `watcher.off` method to `WatcherEmitter`, fixes #4382


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to remove previously registered event listeners for watcher events.

- **Tests**
  - Introduced tests to verify correct addition and removal of event listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->