### PR TITLE
feat(rolldown): `oxc_resolver` v8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0647cd92993b4dd3ee821beb5483d08f041ac312e3b186b38d167a65347488ab"
+checksum = "fe5c7d43ec2c0dcd506adb52f94cc2903e754f413cb548c4733b03c3103eb908"
 dependencies = [
  "cfg-if",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ oxc_transform_napi = { version = "0.67.0" }
 # Versions must be relaxed for usage in oxc.
 # Please update with `cargo update oxc_resolver oxc_sourcemap oxc_index`
 oxc_index = { version = "3", features = ["rayon", "serde"] } # https://github.com/oxc-project/oxc-index-vec
-oxc_resolver = { version = "7", features = ["package_json_raw_json_api"] } # https://github.com/oxc-project/oxc-resolver
+oxc_resolver = { version = "8", features = ["package_json_raw_json_api"] } # https://github.com/oxc-project/oxc-resolver
 oxc_sourcemap = { version = "3" } # https://github.com/oxc-project/oxc-sourcemap
 
 [profile.release]

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_resolve_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_resolve_options.rs
@@ -36,7 +36,6 @@ impl From<BindingResolveOptions> for rolldown::ResolveOptions {
       }),
       main_fields: value.main_fields,
       main_files: value.main_files,
-      modules: value.modules,
       symlinks: value.symlinks,
       tsconfig_filename: value.tsconfig_filename,
     }

--- a/crates/rolldown_common/src/inner_bundler_options/types/resolve_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/resolve_options.rs
@@ -20,7 +20,6 @@ pub struct ResolveOptions {
   pub extension_alias: Option<Vec<(String, Vec<String>)>>,
   pub main_fields: Option<Vec<String>>,
   pub main_files: Option<Vec<String>>,
-  pub modules: Option<Vec<String>>,
   pub symlinks: Option<bool>,
   pub tsconfig_filename: Option<String>,
 }

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -100,7 +100,6 @@ impl<F: FileSystem + Default> Resolver<F> {
       imports_fields: vec![vec!["imports".to_string()]],
       alias_fields,
       condition_names: default_conditions,
-      description_files: vec!["package.json".to_string()],
       enforce_extension: EnforceExtension::Auto,
       exports_fields: raw_resolve
         .exports_fields
@@ -113,7 +112,6 @@ impl<F: FileSystem + Default> Resolver<F> {
       fully_specified: false,
       main_fields,
       main_files: raw_resolve.main_files.unwrap_or_else(|| vec!["index".to_string()]),
-      modules: raw_resolve.modules.unwrap_or_else(|| vec!["node_modules".to_string()]),
       resolve_to_context: false,
       prefer_relative: false,
       prefer_absolute: false,

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1180,15 +1180,6 @@
             "type": "string"
           }
         },
-        "modules": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
         "symlinks": {
           "type": [
             "boolean",


### PR DESCRIPTION
Fixed a case where a path did not return a package.json.

Removed the `modules` and `description_files` option, because the only options are `node_modules` and `package.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the "modules" field from resolve options across the application, including configuration files and schema definitions.
- **Chores**
  - Updated the version of an internal dependency to improve compatibility and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->