### PR TITLE
chore(infra): make script `lint-repo` work on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint-code": "oxlint -c .oxlintrc.json --ignore-path=.oxlintignore --deny-warnings",
     "lint-spell": "cspell \"**\" --no-progress  --gitignore",
-    "lint-repo": "pnpm run --stream --color \"/^fmt|lint-spell$/\"",
+    "lint-repo": "pnpm run --stream --color '/^fmt|lint-spell$/'",
     "fmt": "dprint fmt",
     "build": "echo \"Use just build\"",
     "build:release": "echo \"Use just build native release\"",


### PR DESCRIPTION
### Description

```bash
> monorepo@ lint-repo D:\shulaoda\rolldown
> pnpm run --stream --color "/^fmt|lint-spell$/"

 ELIFECYCLE  Command failed.
error: Recipe `lint-repo` failed on line 111 with exit code 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the formatting of the linting script in the configuration to improve shell compatibility. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->