### PR TITLE
refactor(rolldown_plugin): support napi plugin context

### DIFF
--- a/crates/rolldown_plugin/src/plugin_context/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_context/mod.rs
@@ -1,7 +1,7 @@
-mod native_context;
+mod native_plugin_context;
 mod plugin_context;
 mod transform_plugin_context;
 
-pub use native_context::PluginContextImpl;
+pub use native_plugin_context::NativePluginContextImpl;
 pub use plugin_context::PluginContext;
 pub use transform_plugin_context::{SharedTransformPluginContext, TransformPluginContext};

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct PluginContextImpl {
+pub struct NativePluginContextImpl {
   pub(crate) skipped_resolve_calls: Vec<Arc<HookResolveIdSkipped>>,
   pub(crate) plugin_idx: PluginIdx,
   pub(crate) resolver: Arc<Resolver>,
@@ -36,7 +36,7 @@ pub struct PluginContextImpl {
   pub(crate) tx: Arc<Mutex<Option<tokio::sync::mpsc::Sender<ModuleLoaderMsg>>>>,
 }
 
-impl PluginContextImpl {
+impl NativePluginContextImpl {
   pub async fn load(
     &self,
     specifier: &str,

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
@@ -1,18 +1,24 @@
 use std::{
-  ops::Deref,
+  path::PathBuf,
   sync::{Arc, Weak},
 };
 
+use arcstr::ArcStr;
 use derive_more::Debug;
-use rolldown_common::NormalizedBundlerOptions;
-use rolldown_resolver::Resolver;
+use rolldown_common::{ResolvedId, side_effects::HookSideEffects};
 
-use crate::types::hook_resolve_id_skipped::HookResolveIdSkipped;
+use crate::{PluginContextResolveOptions, types::hook_resolve_id_skipped::HookResolveIdSkipped};
 
-use super::PluginContextImpl;
+use super::NativePluginContextImpl;
+
+#[derive(Debug)]
+pub struct NapiPluginContextImpl;
 
 #[derive(Debug, Clone)]
-pub struct PluginContext(std::sync::Arc<PluginContextImpl>);
+pub enum PluginContext {
+  Napi(Arc<NapiPluginContextImpl>),
+  Native(Arc<NativePluginContextImpl>),
+}
 
 impl PluginContext {
   #[must_use]
@@ -20,38 +26,139 @@ impl PluginContext {
     &self,
     skipped_resolve_calls: Vec<Arc<HookResolveIdSkipped>>,
   ) -> Self {
-    Self(Arc::new(PluginContextImpl {
-      skipped_resolve_calls,
-      plugin_idx: self.plugin_idx,
-      plugin_driver: Weak::clone(&self.plugin_driver),
-      resolver: Arc::clone(&self.resolver),
-      file_emitter: Arc::clone(&self.file_emitter),
-      options: Arc::clone(&self.options),
-      watch_files: Arc::clone(&self.watch_files),
-      modules: Arc::clone(&self.modules),
-      tx: Arc::clone(&self.tx),
-    }))
+    match self {
+      PluginContext::Napi(_) => self.clone(),
+      PluginContext::Native(ctx) => Self::Native(Arc::new(NativePluginContextImpl {
+        skipped_resolve_calls,
+        plugin_idx: ctx.plugin_idx,
+        plugin_driver: Weak::clone(&ctx.plugin_driver),
+        resolver: Arc::clone(&ctx.resolver),
+        file_emitter: Arc::clone(&ctx.file_emitter),
+        options: Arc::clone(&ctx.options),
+        watch_files: Arc::clone(&ctx.watch_files),
+        modules: Arc::clone(&ctx.modules),
+        tx: Arc::clone(&ctx.tx),
+      })),
+    }
   }
 
-  pub fn options(&self) -> &NormalizedBundlerOptions {
-    &self.options
+  pub async fn load(
+    &self,
+    specifier: &str,
+    side_effects: Option<HookSideEffects>,
+  ) -> anyhow::Result<()> {
+    match self {
+      PluginContext::Napi(_) => unimplemented!("Can't call `load` on PluginContext::Napi"),
+      PluginContext::Native(ctx) => ctx.load(specifier, side_effects).await,
+    }
   }
 
-  pub fn resolver(&self) -> &Resolver {
-    &self.resolver
+  pub async fn resolve(
+    &self,
+    specifier: &str,
+    importer: Option<&str>,
+    extra_options: Option<PluginContextResolveOptions>,
+  ) -> anyhow::Result<Result<ResolvedId, rolldown_resolver::ResolveError>> {
+    match self {
+      PluginContext::Napi(_) => unimplemented!("Can't call `resolve` on PluginContext::Napi"),
+      PluginContext::Native(ctx) => ctx.resolve(specifier, importer, extra_options).await,
+    }
   }
-}
 
-impl Deref for PluginContext {
-  type Target = PluginContextImpl;
-
-  fn deref(&self) -> &Self::Target {
-    &self.0
+  pub async fn emit_chunk(&self, chunk: rolldown_common::EmittedChunk) -> anyhow::Result<ArcStr> {
+    match self {
+      PluginContext::Napi(_) => unimplemented!("Can't call `emit_chunk` on PluginContext::Napi"),
+      PluginContext::Native(ctx) => ctx.emit_chunk(chunk).await,
+    }
   }
-}
 
-impl From<PluginContextImpl> for PluginContext {
-  fn from(ctx: PluginContextImpl) -> Self {
-    Self(Arc::new(ctx))
+  pub fn emit_file(
+    &self,
+    file: rolldown_common::EmittedAsset,
+    fn_asset_filename: Option<String>,
+    fn_sanitized_file_name: Option<String>,
+  ) -> ArcStr {
+    match self {
+      PluginContext::Napi(_) => unimplemented!("Can't call `emit_file` on PluginContext::Napi"),
+      PluginContext::Native(ctx) => ctx.emit_file(file, fn_asset_filename, fn_sanitized_file_name),
+    }
+  }
+
+  pub async fn emit_file_async(
+    &self,
+    file: rolldown_common::EmittedAsset,
+  ) -> anyhow::Result<ArcStr> {
+    match self {
+      PluginContext::Napi(_) => {
+        unimplemented!("Can't call `emit_file_async` on PluginContext::Napi")
+      }
+      PluginContext::Native(ctx) => ctx.emit_file_async(file).await,
+    }
+  }
+
+  pub fn get_file_name(&self, reference_id: &str) -> anyhow::Result<ArcStr> {
+    match self {
+      PluginContext::Napi(_) => {
+        unimplemented!("Can't call `get_file_name` on PluginContext::Napi")
+      }
+      PluginContext::Native(ctx) => ctx.get_file_name(reference_id),
+    }
+  }
+
+  pub fn get_module_info(&self, module_id: &str) -> Option<Arc<rolldown_common::ModuleInfo>> {
+    match self {
+      PluginContext::Napi(_) => {
+        unimplemented!("Can't call `get_module_info` on PluginContext::Napi")
+      }
+      PluginContext::Native(ctx) => ctx.get_module_info(module_id),
+    }
+  }
+
+  pub fn get_module_ids(&self) -> Vec<String> {
+    match self {
+      PluginContext::Napi(_) => {
+        unimplemented!("Can't call `get_module_ids` on PluginContext::Napi")
+      }
+      PluginContext::Native(ctx) => ctx.get_module_ids(),
+    }
+  }
+
+  pub fn cwd(&self) -> &PathBuf {
+    match self {
+      PluginContext::Napi(_) => unimplemented!("Can't call `cwd` on PluginContext::Napi"),
+      PluginContext::Native(ctx) => ctx.cwd(),
+    }
+  }
+
+  pub fn add_watch_file(&self, file: &str) {
+    match self {
+      PluginContext::Napi(_) => {
+        unimplemented!("Can't call `add_watch_file` on PluginContext::Napi")
+      }
+      PluginContext::Native(ctx) => ctx.add_watch_file(file),
+    }
+  }
+
+  pub fn options(&self) -> &rolldown_common::NormalizedBundlerOptions {
+    match self {
+      PluginContext::Napi(_) => unimplemented!("Can't call `options` on PluginContext::Napi"),
+      PluginContext::Native(ctx) => &ctx.options,
+    }
+  }
+
+  pub fn resolver(&self) -> &rolldown_resolver::Resolver {
+    match self {
+      PluginContext::Napi(_) => unimplemented!("Can't call `resolver` on PluginContext::Napi"),
+      PluginContext::Native(ctx) => &ctx.resolver,
+    }
+  }
+
+  pub fn file_emitter(&self) -> &rolldown_common::SharedFileEmitter {
+    match self {
+      PluginContext::Napi(_) => {
+        unimplemented!("Can't call `file_emitter` on PluginContext::Napi")
+      }
+      PluginContext::Native(ctx) => &ctx.file_emitter,
+    }
   }
 }

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -17,7 +17,7 @@ use tokio::sync::Mutex;
 use crate::{
   __inner::SharedPluginable,
   HookUsage, PluginContext, PluginHookMeta, PluginOrder,
-  plugin_context::PluginContextImpl,
+  plugin_context::NativePluginContextImpl,
   type_aliases::{IndexPluginContext, IndexPluginable},
   types::plugin_idx::PluginIdx,
 };
@@ -59,20 +59,17 @@ impl PluginDriver {
       plugins.into_iter().for_each(|plugin| {
         let plugin_idx = index_plugins.push(Arc::clone(&plugin));
         plugin_usage_vec.push(plugin.call_hook_usage());
-        index_contexts.push(
-          PluginContextImpl {
-            skipped_resolve_calls: vec![],
-            plugin_idx,
-            plugin_driver: Weak::clone(plugin_driver),
-            resolver: Arc::clone(resolver),
-            file_emitter: Arc::clone(file_emitter),
-            modules: Arc::clone(&modules),
-            options: Arc::clone(options),
-            watch_files: Arc::clone(&watch_files),
-            tx: Arc::clone(&tx),
-          }
-          .into(),
-        );
+        index_contexts.push(PluginContext::Native(Arc::new(NativePluginContextImpl {
+          skipped_resolve_calls: vec![],
+          plugin_idx,
+          plugin_driver: Weak::clone(plugin_driver),
+          resolver: Arc::clone(resolver),
+          file_emitter: Arc::clone(file_emitter),
+          modules: Arc::clone(&modules),
+          options: Arc::clone(options),
+          watch_files: Arc::clone(&watch_files),
+          tx: Arc::clone(&tx),
+        })));
       });
 
       Self {

--- a/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
@@ -196,7 +196,7 @@ impl PluginDriver {
         .call_generate_bundle(ctx, &mut args)
         .instrument(debug_span!("generate_bundle_hook", plugin_name = plugin.call_name().as_ref()))
         .await?;
-      ctx.file_emitter.add_additional_files(bundle, warnings);
+      ctx.file_emitter().add_additional_files(bundle, warnings);
     }
     Ok(())
   }
@@ -215,7 +215,7 @@ impl PluginDriver {
         .call_write_bundle(ctx, &mut args)
         .instrument(debug_span!("write_bundle_hook", plugin_name = plugin.call_name().as_ref()))
         .await?;
-      ctx.file_emitter.add_additional_files(bundle, warnings);
+      ctx.file_emitter().add_additional_files(bundle, warnings);
     }
     Ok(())
   }


### PR DESCRIPTION
### Description

Related to #4397 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated plugin context handling to use an enum with distinct variants for native and Napi plugin contexts.
  - Introduced clear separation of behavior for different plugin context types, with unimplemented methods for the Napi variant.
  - Renamed internal plugin context implementations for clarity.
  - Adjusted how file emitters are accessed within plugin context methods.

No changes to end-user functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->