### PR TITLE
refactor(rolldown_plugin): expose `SharedNativePluginContext` for `BindingPluginContext`

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
@@ -1,6 +1,6 @@
 use napi_derive::napi;
 
-use rolldown_plugin::PluginContext;
+use rolldown_plugin::{PluginContext, SharedNativePluginContext};
 
 use super::types::{
   binding_emitted_asset::BindingEmittedAsset, binding_emitted_chunk::BindingEmittedChunk,
@@ -13,7 +13,7 @@ use crate::{types::binding_module_info::BindingModuleInfo, utils::napi_error};
 
 #[napi]
 pub struct BindingPluginContext {
-  inner: PluginContext,
+  inner: SharedNativePluginContext,
 }
 
 #[napi]
@@ -93,8 +93,11 @@ impl BindingPluginContext {
 }
 
 impl From<PluginContext> for BindingPluginContext {
-  fn from(inner: PluginContext) -> Self {
-    Self { inner }
+  fn from(ctx: PluginContext) -> Self {
+    match ctx {
+      PluginContext::Napi(_) => unreachable!("Js plugins don't have PluginContext::Napi"),
+      PluginContext::Native(inner) => Self { inner },
+    }
   }
 }
 #[napi(object)]

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -22,7 +22,9 @@ pub use crate::{
     HookRenderChunkReturn, HookResolveIdReturn, HookTransformAstReturn, HookTransformReturn,
     Plugin,
   },
-  plugin_context::{PluginContext, SharedTransformPluginContext, TransformPluginContext},
+  plugin_context::{
+    PluginContext, SharedNativePluginContext, SharedTransformPluginContext, TransformPluginContext,
+  },
   plugin_driver::{PluginDriver, SharedPluginDriver},
   types::custom_field::CustomField,
   types::hook_addon_args::HookAddonArgs,

--- a/crates/rolldown_plugin/src/plugin_context/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_context/mod.rs
@@ -2,6 +2,6 @@ mod native_plugin_context;
 mod plugin_context;
 mod transform_plugin_context;
 
-pub use native_plugin_context::NativePluginContextImpl;
+pub use native_plugin_context::{NativePluginContextImpl, SharedNativePluginContext};
 pub use plugin_context::PluginContext;
 pub use transform_plugin_context::{SharedTransformPluginContext, TransformPluginContext};

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -23,6 +23,8 @@ use crate::{
   utils::resolve_id_check_external::resolve_id_check_external,
 };
 
+pub type SharedNativePluginContext = Arc<NativePluginContextImpl>;
+
 #[derive(Debug)]
 pub struct NativePluginContextImpl {
   pub(crate) skipped_resolve_calls: Vec<Arc<HookResolveIdSkipped>>,


### PR DESCRIPTION
### Description

Related to #4397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new type alias for shared plugin context, enabling easier handling of thread-safe plugin contexts.
  - Made the shared plugin context type publicly accessible for plugin development.

- **Refactor**
  - Updated internal structures to use the new shared plugin context type, improving consistency and future extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->