### PR TITLE
refactor(rust): follow the `coderabbitai`'s suggestions

### DIFF
--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -316,7 +316,7 @@ impl Plugin for ViteResolvePlugin {
 
     let base_dir = args
       .importer
-      .map(|i| Path::new(i).parent().map(|i| i.to_str().unwrap()).unwrap_or(i))
+      .map(|i| Path::new(i).parent().and_then(|p| p.to_str()).unwrap_or(i))
       .unwrap_or(&self.resolve_options.root);
     let resolved = resolver.normalize_oxc_resolver_result(
       args.importer,
@@ -387,6 +387,7 @@ impl Plugin for ViteResolvePlugin {
         let [_, peer_dep, parent_dep, _] = args.id.splitn(4, ":").collect::<Vec<&str>>()[..] else {
           unreachable!()
         };
+
         return Ok(Some(HookLoadOutput {
           code: get_development_optional_peer_dep_module_code(peer_dep, parent_dep),
           ..Default::default()


### PR DESCRIPTION
### Description

See https://github.com/rolldown/rolldown/pull/4403#pullrequestreview-2813327013

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of plugin context to reuse a single instance, enhancing efficiency and maintainability.
  - Updated logic for determining base directories during import resolution for safer and more idiomatic behavior.

- **Style**
  - Minor formatting improvements for code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->