### PR TITLE
feat(watcher): support result.close at bundle end event

### DIFF
--- a/crates/rolldown/src/watch/event.rs
+++ b/crates/rolldown/src/watch/event.rs
@@ -1,8 +1,14 @@
-use std::fmt::Display;
+use std::{
+  fmt::{Debug, Display},
+  sync::Arc,
+};
 
 use arcstr::ArcStr;
 
 use rolldown_common::{OutputsDiagnostics, WatcherChangeKind};
+use tokio::sync::Mutex;
+
+use crate::Bundler;
 
 #[derive(Debug)]
 pub enum WatcherEvent {
@@ -50,8 +56,14 @@ impl Display for BundleEvent {
   }
 }
 
-#[derive(Debug)]
 pub struct BundleEndEventData {
   pub output: String,
   pub duration: u32,
+  pub result: Arc<Mutex<Bundler>>,
+}
+
+impl Debug for BundleEndEventData {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    write!(f, "BundleEndEventData {{ output: {}, duration: {} }}", self.output, self.duration)
+  }
 }

--- a/crates/rolldown/src/watch/watcher_task.rs
+++ b/crates/rolldown/src/watch/watcher_task.rs
@@ -91,6 +91,7 @@ impl WatcherTask {
             .to_string(),
           #[allow(clippy::cast_possible_truncation)]
           duration: start_time.elapsed().as_millis() as u32,
+          result: Arc::clone(&self.bundler),
         })))?;
       }
       Err(errs) => {

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -64,6 +64,10 @@ impl Bundler {
     })
   }
 
+  pub fn new_with_bundler(inner: Arc<Mutex<NativeBundler>>) -> Self {
+    Self { inner }
+  }
+
   #[napi]
   #[tracing::instrument(level = "debug", skip_all)]
   pub async fn write(&self) -> napi::Result<BindingOutputs> {

--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -103,6 +103,6 @@ pub struct BindingInputOptions {
   // TODO: The `FnArgs<()>` is not supported.
   pub invalidate_js_side_cache: Option<JsCallback<FnArgs<(Option<bool>,)>, ()>>,
   #[debug(skip)]
-  #[napi(ts_type = "(id: string, success: bool) => void")]
+  #[napi(ts_type = "(id: string, success: boolean) => void")]
   pub mark_module_loaded: Option<JsCallback<FnArgs<(String, bool)>, ()>>,
 }

--- a/packages/rolldown/src/api/watch/watch-emitter.ts
+++ b/packages/rolldown/src/api/watch/watch-emitter.ts
@@ -1,10 +1,13 @@
-import { BindingWatcherEvent } from '../../binding';
+import { BindingWatcherEvent, Bundler } from '../../binding';
 import type { MaybePromise } from '../../types/utils';
 import { normalizeErrors } from '../../utils/error';
 
 export type WatcherEvent = 'close' | 'event' | 'restart' | 'change';
 
 export type ChangeEvent = 'create' | 'update' | 'delete';
+
+// TODO: find a way use `RolldownBuild` instead of `Bundler`.
+export type RolldownWatchBuild = Bundler;
 
 export type RolldownWatcherEvent =
   | { code: 'START' }
@@ -16,7 +19,7 @@ export type RolldownWatcherEvent =
     duration: number;
     // input?: InputOption
     output: readonly string[];
-    // result: RollupBuild
+    result: RolldownWatchBuild;
   }
   | { code: 'END' }
   | {
@@ -92,11 +95,12 @@ export class WatcherEmitter {
             const code = event.bundleEventKind();
             switch (code) {
               case 'BUNDLE_END':
-                const { duration, output } = event.bundleEndData();
+                const { duration, output, result } = event.bundleEndData();
                 await listener({
                   code: 'BUNDLE_END',
                   duration,
                   output: [output], // rolldown doesn't support arraying configure output
+                  result,
                 });
                 break;
 

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -6,6 +6,7 @@ export type BindingStringOrRegex = string | RegExp
 export declare class BindingBundleEndEventData {
   output: string
   duration: number
+  get result(): Bundler
 }
 
 export declare class BindingCallableBuiltinPlugin {
@@ -436,7 +437,7 @@ export interface BindingInputOptions {
   makeAbsoluteExternalsRelative?: BindingMakeAbsoluteExternalsRelative
   debug?: BindingDebugOptions
   invalidateJsSideCache?: () => void
-  markModuleLoaded?: (id: string, success: bool) => void
+  markModuleLoaded?: (id: string, success: boolean) => void
 }
 
 export interface BindingIsolatedDeclarationPluginConfig {

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -185,6 +185,31 @@ test.sequential('watch event off', async () => {
   await watcher.close()
 })
 
+test.sequential('watch BUNDLE_END event result.close() + closeBundle', async () => {
+  const { input, outputDir } = await createTestInputAndOutput('watch-event-close-closeBundle')
+  const closeBundleFn = vi.fn()
+  const watcher = watch({
+    input,
+    output: { dir: outputDir },
+    plugins: [
+      {
+        name: 'test',
+        closeBundle: closeBundleFn
+      }
+    ]
+  })
+  watcher.on('event', async (event) => {
+    if (event.code === 'BUNDLE_END') {
+      await event.result.close()
+    }
+  })
+  await waitBuildFinished(watcher)
+
+  expect(closeBundleFn).toBeCalledTimes(1)
+
+  await watcher.close()
+})
+
 test.sequential('watch BUNDLE_END event output + "file" option', async () => {
   const { input, output } = await createTestInputAndOutput('watch-event')
   const watcher = watch({


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
close https://github.com/rolldown/rolldown/issues/4380
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new property to the bundle end event, allowing access to the build result directly from the event object.
  - Exposed a getter for the build result in event data, enabling further actions such as closing the result.
- **Bug Fixes**
  - Corrected TypeScript type annotations from non-standard `bool` to standard `boolean` for callback parameters.
- **Tests**
  - Introduced a new test to verify that closing the build result triggers the appropriate plugin lifecycle hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->