### PR TITLE
feat(watch): support result.close at error event

### DIFF
--- a/crates/rolldown/src/watch/event.rs
+++ b/crates/rolldown/src/watch/event.rs
@@ -41,7 +41,7 @@ pub enum BundleEvent {
   BundleStart,
   BundleEnd(BundleEndEventData),
   End,
-  Error(OutputsDiagnostics),
+  Error(BundleErrorEventData),
 }
 
 impl Display for BundleEvent {
@@ -65,5 +65,16 @@ pub struct BundleEndEventData {
 impl Debug for BundleEndEventData {
   fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
     write!(f, "BundleEndEventData {{ output: {}, duration: {} }}", self.output, self.duration)
+  }
+}
+
+pub struct BundleErrorEventData {
+  pub error: OutputsDiagnostics,
+  pub result: Arc<Mutex<Bundler>>,
+}
+
+impl Debug for BundleErrorEventData {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    write!(f, "BundleEndEventData {{ errors: {:?} }}", self.error)
   }
 }

--- a/packages/rolldown/src/api/watch/watch-emitter.ts
+++ b/packages/rolldown/src/api/watch/watch-emitter.ts
@@ -24,8 +24,8 @@ export type RolldownWatcherEvent =
   | { code: 'END' }
   | {
     code: 'ERROR';
-    error:
-      Error; /* the error is not compilable with rollup * /  /**  result: RollupBuild | null **/
+    error: Error; /* the error is not compilable with rollup */
+    result: RolldownWatchBuild;
   };
 
 export class WatcherEmitter {
@@ -105,10 +105,11 @@ export class WatcherEmitter {
                 break;
 
               case 'ERROR':
-                const errors = event.errors();
+                const data = event.bundleErrorData();
                 await listener({
                   code: 'ERROR',
-                  error: normalizeErrors(errors),
+                  error: normalizeErrors(data.error),
+                  result: data.result,
                 });
                 break;
 

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -9,6 +9,11 @@ export declare class BindingBundleEndEventData {
   get result(): Bundler
 }
 
+export declare class BindingBundleErrorEventData {
+  get result(): Bundler
+  get error(): Array<Error | BindingError>
+}
+
 export declare class BindingCallableBuiltinPlugin {
   constructor(plugin: BindingBuiltinPlugin)
   resolveId(id: string, importer?: string | undefined | null, options?: BindingHookJsResolveIdOptions | undefined | null): Promise<BindingHookJsResolveIdOutput | null>
@@ -150,7 +155,7 @@ export declare class BindingWatcherEvent {
   watchChangeData(): BindingWatcherChangeData
   bundleEndData(): BindingBundleEndEventData
   bundleEventKind(): string
-  errors(): Array<Error | BindingError>
+  bundleErrorData(): BindingBundleErrorEventData
 }
 
 export declare class Bundler {

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -375,6 +375,7 @@ if (!nativeBinding) {
 }
 
 module.exports.BindingBundleEndEventData = nativeBinding.BindingBundleEndEventData
+module.exports.BindingBundleErrorEventData = nativeBinding.BindingBundleErrorEventData
 module.exports.BindingCallableBuiltinPlugin = nativeBinding.BindingCallableBuiltinPlugin
 module.exports.BindingError = nativeBinding.BindingError
 module.exports.BindingModuleInfo = nativeBinding.BindingModuleInfo

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -61,6 +61,7 @@ const {
   },
 })
 export const BindingBundleEndEventData = __napiModule.exports.BindingBundleEndEventData
+export const BindingBundleErrorEventData = __napiModule.exports.BindingBundleErrorEventData
 export const BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
 export const BindingError = __napiModule.exports.BindingError
 export const BindingModuleInfo = __napiModule.exports.BindingModuleInfo

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -86,6 +86,7 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
 })
 
 module.exports.BindingBundleEndEventData = __napiModule.exports.BindingBundleEndEventData
+module.exports.BindingBundleErrorEventData = __napiModule.exports.BindingBundleErrorEventData
 module.exports.BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
 module.exports.BindingError = __napiModule.exports.BindingError
 module.exports.BindingModuleInfo = __napiModule.exports.BindingModuleInfo


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
related https://github.com/rolldown/rolldown/pull/4423
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Error events now provide additional context, including both error details and the current bundler state.
  - The error event payload includes a new object with error diagnostics and a build result for enhanced debugging and handling.

- **Bug Fixes**
  - Improved error event structure ensures more consistent and informative error reporting during watch operations.

- **Tests**
  - Added a new test to verify correct behavior when handling and closing after ERROR events during watch mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->