### PR TITLE
fix(watch): allow call `result.close` multiply times

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -87,6 +87,12 @@ impl Bundler {
     Ok(())
   }
 
+  // The rollup always crate a new build at watch mode, it cloud be call multiply times.
+  // Here only reset the closed flag to make it possible to call again.
+  pub fn reset_closed(&mut self) {
+    self.closed = false;
+  }
+
   #[tracing::instrument(target = "devtool", level = "debug", skip_all)]
   pub async fn scan(&mut self, changed_ids: Vec<ArcStr>) -> BuildResult<NormalizedScanStageOutput> {
     trace_action!(action::BuildStart { action: "BuildStart" });

--- a/crates/rolldown/src/watch/watcher_task.rs
+++ b/crates/rolldown/src/watch/watcher_task.rs
@@ -55,6 +55,7 @@ impl WatcherTask {
 
     self.emitter.emit(WatcherEvent::Event(BundleEvent::BundleStart))?;
 
+    bundler.reset_closed();
     bundler.plugin_driver.clear();
 
     let result = {

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -207,6 +207,11 @@ test.sequential('watch BUNDLE_END event result.close() + closeBundle', async () 
 
   expect(closeBundleFn).toBeCalledTimes(1)
 
+  // The `result.close` could be call multiply times.
+  fs.writeFileSync(input, 'console.log(3)')
+  await waitBuildFinished(watcher)
+  expect(closeBundleFn).toBeCalledTimes(2)
+
   await watcher.close()
 })
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for reusing the bundler in watch mode, enabling multiple build cycles without recreating the instance.

- **Tests**
  - Enhanced watch mode tests to verify correct behavior when closing and rebuilding multiple times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->