### PR TITLE
fix(watch-cli): call result.close at bundle end or error

### DIFF
--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -101,7 +101,7 @@ async function watchInner(
       changedFile.push(id);
     }
   });
-  watcher.on('event', (event) => {
+  watcher.on('event', async (event) => {
     switch (event.code) {
       case 'BUNDLE_START':
         if (changedFile.length > 0) {
@@ -115,6 +115,7 @@ async function watchInner(
         break;
 
       case 'BUNDLE_END':
+        await event.result.close();
         logger.success(
           `Rebuilt ${colors.bold(relativeId(event.output[0]))} in ${
             colors.bold(ms(event.duration))
@@ -123,6 +124,7 @@ async function watchInner(
         break;
 
       case 'ERROR':
+        await event.result.close();
         logger.error(event.error);
         break;
 

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -325,7 +325,8 @@ onLog called:
 this.meta.watchMode false
 (test plugin) trigger onLog
 buildStart called:
-this.meta.watchMode false"
+this.meta.watchMode false
+closeBundle called:"
 `;
 
 exports[`watch cli > should require both ROLLDOWN_WATCH and this.meta.watchMode to be true 1`] = `
@@ -340,5 +341,6 @@ onLog called:
 this.meta.watchMode true
 (test plugin) trigger onLog
 buildStart called:
-this.meta.watchMode true"
+this.meta.watchMode true
+closeBundle called:"
 `;

--- a/packages/rolldown/tests/cli/fixtures/watch-mode/rolldown.config.ts
+++ b/packages/rolldown/tests/cli/fixtures/watch-mode/rolldown.config.ts
@@ -24,7 +24,9 @@ export default defineConfig({
       buildStart() {
         console.log('buildStart called:')
         console.log('this.meta.watchMode', this.meta.watchMode)
-
+      },
+      closeBundle() {
+        console.log('closeBundle called:')
         process.exit(0)
       },
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
close https://github.com/rolldown/rolldown/issues/4394
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource management in watch mode to ensure proper asynchronous cleanup after bundling or errors.
- **Tests**
  - Updated test plugin behavior to terminate the process during the correct lifecycle phase, enhancing test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->