### PR TITLE
feat: move filter related utils to `@rolldown/pluginutils`

### DIFF
--- a/.github/workflows/benchmark-node.yml
+++ b/.github/workflows/benchmark-node.yml
@@ -68,7 +68,9 @@ jobs:
         run: just setup-bench
 
       - name: Build packages
-        run: just build native release
+        run: |
+          pnpm --filter '@rolldown/pluginutils' build
+          just build native release
 
       - name: Run benchmarks
         run: pnpm --filter bench run bench-ci

--- a/.github/workflows/reusable-browser-test.yml
+++ b/.github/workflows/reusable-browser-test.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Build Browser Rolldown
         run: just build browser release
 
+      - name: Build `@rolldown/pluginutils`
+        run: pnpm --filter '@rolldown/pluginutils' build
+
       - name: Build Node Packages
         run: pnpm --filter rolldown build-node
 

--- a/.github/workflows/reusable-browser-test.yml
+++ b/.github/workflows/reusable-browser-test.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Add WASI target
         run: rustup target add wasm32-wasip1-threads
 
-      - name: Build Browser Rolldown
-        run: just build browser release
-
       - name: Build `@rolldown/pluginutils`
         run: pnpm --filter '@rolldown/pluginutils' build
+
+      - name: Build Browser Rolldown
+        run: just build browser release
 
       - name: Build Node Packages
         run: pnpm --filter rolldown build-node

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Setup Node For Development
         uses: ./.github/actions/setup-node
 
+      - name: Build `@rolldown/pluginutils`
+        run: pnpm --filter '@rolldown/pluginutils' build
+
       - name: Build Native Rolldown
         run: just build native
 

--- a/packages/pluginutils/build.mjs
+++ b/packages/pluginutils/build.mjs
@@ -9,6 +9,7 @@ const args = ['run', 'build:all']; // Replace with any arguments for the command
 
 spawnSync(command, args, {
   stdio: ['pipe', process.stdout, process.stderr],
+  shell: true,
 });
 
 fs.writeFileSync(

--- a/packages/pluginutils/build.mjs
+++ b/packages/pluginutils/build.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 fs.rmSync('dist', { recursive: true, force: true });
 

--- a/packages/pluginutils/build.mjs
+++ b/packages/pluginutils/build.mjs
@@ -13,7 +13,7 @@ spawnSync(command, args, {
 });
 
 fs.writeFileSync(
-  path.resolve(import.meta.dirname, 'dist/cjs/package.json'),
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'dist/cjs/package.json'),
   `{
   "type": "commonjs"
 }`,

--- a/packages/pluginutils/build.mjs
+++ b/packages/pluginutils/build.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 fs.rmSync('dist', { recursive: true, force: true });
 
@@ -11,7 +12,7 @@ spawnSync(command, args, {
 });
 
 fs.writeFileSync(
-  'dist/cjs/package.json',
+  path.resolve(import.meta.dirname, 'dist/cjs/package.json'),
   `{
   "type": "commonjs"
 }`,

--- a/packages/pluginutils/build.mjs
+++ b/packages/pluginutils/build.mjs
@@ -1,0 +1,18 @@
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+
+fs.rmSync('dist', { recursive: true, force: true });
+
+const command = 'npm'; // Replace with the command you want to execute
+const args = ['run', 'build:all']; // Replace with any arguments for the command
+
+spawnSync(command, args, {
+  stdio: ['pipe', process.stdout, process.stderr],
+});
+
+fs.writeFileSync(
+  'dist/cjs/package.json',
+  `{
+  "type": "commonjs"
+}`,
+);

--- a/packages/pluginutils/build.mjs
+++ b/packages/pluginutils/build.mjs
@@ -13,7 +13,10 @@ spawnSync(command, args, {
 });
 
 fs.writeFileSync(
-  path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'dist/cjs/package.json'),
+  path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'dist/cjs/package.json',
+  ),
   `{
   "type": "commonjs"
 }`,

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@rolldown/pluginutils",
+  "version": "1.0.0-beta.8",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rolldown/rolldown.git",
+    "directory": "packages/pluginutils"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -26,8 +26,8 @@
     "rimraf": "^5.0.0"
   },
   "scripts": {
-    "build": "rimraf dist && npm run build:esm && npm run build:cjs && npm run tweak-cjs-type",
-    "tweak-cjs-type": "echo \"{\\\"type\\\": \\\"commonjs\\\"}\" > dist/cjs/package.json",
+    "build": "node build.mjs",
+    "build:all": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc -p ./tsconfig.esm.json",
     "build:cjs": "tsc -p ./tsconfig.cjs.json",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -26,7 +26,8 @@
     "rimraf": "^5.0.0"
   },
   "scripts": {
-    "build": "rimraf dist && npm run build:esm && npm run build:cjs",
+    "build": "rimraf dist && npm run build:esm && npm run build:cjs && npm run tweak-cjs-type",
+    "tweak-cjs-type": "echo \"{\\\"type\\\": \\\"commonjs\\\"}\" > dist/cjs/package.json",
     "build:esm": "tsc -p ./tsconfig.esm.json",
     "build:cjs": "tsc -p ./tsconfig.cjs.json",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rolldown/pluginutils",
   "version": "1.0.0-beta.8",
+  "private": true,
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -13,15 +13,21 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/cjs/index.d.ts"
     }
   },
   "files": [
     "dist"
   ],
+  "devDependencies": {
+    "rimraf": "^5.0.0"
+  },
   "scripts": {
-    "build": "tsc -b",
+    "build": "rimraf dist && npm run build:esm && npm run build:cjs",
+    "build:esm": "tsc -p ./tsconfig.esm.json",
+    "build:cjs": "tsc -p ./tsconfig.cjs.json",
     "test": "echo \"Error: no test specified\" && exit 1"
   }
 }

--- a/packages/pluginutils/src/index.ts
+++ b/packages/pluginutils/src/index.ts
@@ -1,0 +1,130 @@
+type StringOrRegExp = string | RegExp;
+
+// Inline this type to avoid import it from `rolldown`.
+// The only downside is we need to keep it in sync with `rolldown` manually, 
+// it is alright since it is pretty stable now. 
+type PluginModuleType = "js" | "jsx" | "ts" | "tsx" | "json" | "text" | "base64" | "dataurl" | "binary" | "empty" | (string & {});
+
+export type FilterExpressionKind = FilterExpression['kind'];
+
+export type FilterExpression =
+  | And
+  | Or
+  | Not
+  | Id
+  | ModuleType
+  | Code
+  | Include
+  | Exclude;
+
+export type TopLevelFilterExpression = Include | Exclude;
+
+export class And {
+  kind: 'and';
+  args: FilterExpression[];
+  constructor(...args: FilterExpression[]) {
+    if (args.length === 0) {
+      throw new Error('`And` expects at least one operand');
+    }
+    this.args = args;
+    this.kind = 'and';
+  }
+}
+class Or {
+  kind: 'or';
+  args: FilterExpression[];
+  constructor(...args: FilterExpression[]) {
+    if (args.length === 0) {
+      throw new Error('`Or` expects at least one operand');
+    }
+    this.args = args;
+    this.kind = 'or';
+  }
+}
+
+class Not {
+  kind: 'not';
+  expr: FilterExpression;
+  constructor(expr: FilterExpression) {
+    this.expr = expr;
+    this.kind = 'not';
+  }
+}
+
+class Id {
+  kind: 'id';
+  pattern: StringOrRegExp;
+  constructor(pattern: StringOrRegExp) {
+    this.pattern = pattern;
+    this.kind = 'id';
+  }
+}
+
+class ModuleType {
+  kind: 'moduleType';
+  pattern: PluginModuleType;
+  constructor(pattern: PluginModuleType) {
+    this.pattern = pattern;
+    this.kind = 'moduleType';
+  }
+}
+
+class Code {
+  kind: 'code';
+  pattern: StringOrRegExp;
+  constructor(expr: StringOrRegExp) {
+    this.pattern = expr;
+    this.kind = 'code';
+  }
+}
+
+class Include {
+  kind: 'include';
+  expr: FilterExpression;
+  constructor(expr: FilterExpression) {
+    this.expr = expr;
+    this.kind = 'include';
+  }
+}
+
+class Exclude {
+  kind: 'exclude';
+  expr: FilterExpression;
+  constructor(expr: FilterExpression) {
+    this.expr = expr;
+    this.kind = 'exclude';
+  }
+}
+
+export function and(...args: FilterExpression[]): And {
+  return new And(...args);
+}
+
+export function or(...args: FilterExpression[]): Or {
+  return new Or(...args);
+}
+
+export function not(expr: FilterExpression): Not {
+  return new Not(expr);
+}
+
+export function id(pattern: StringOrRegExp): Id {
+  return new Id(pattern);
+}
+
+export function moduleType(pattern: PluginModuleType): ModuleType {
+  return new ModuleType(pattern);
+}
+
+export function code(pattern: StringOrRegExp): Code {
+  return new Code(pattern);
+}
+
+export function include(expr: FilterExpression): Include {
+  return new Include(expr);
+}
+
+export function exclude(expr: FilterExpression): Exclude {
+  return new Exclude(expr);
+}
+

--- a/packages/pluginutils/src/index.ts
+++ b/packages/pluginutils/src/index.ts
@@ -1,9 +1,20 @@
 type StringOrRegExp = string | RegExp;
 
 // Inline this type to avoid import it from `rolldown`.
-// The only downside is we need to keep it in sync with `rolldown` manually, 
-// it is alright since it is pretty stable now. 
-type PluginModuleType = "js" | "jsx" | "ts" | "tsx" | "json" | "text" | "base64" | "dataurl" | "binary" | "empty" | (string & {});
+// The only downside is we need to keep it in sync with `rolldown` manually,
+// it is alright since it is pretty stable now.
+type PluginModuleType =
+  | 'js'
+  | 'jsx'
+  | 'ts'
+  | 'tsx'
+  | 'json'
+  | 'text'
+  | 'base64'
+  | 'dataurl'
+  | 'binary'
+  | 'empty'
+  | (string & {});
 
 export type FilterExpressionKind = FilterExpression['kind'];
 
@@ -127,4 +138,3 @@ export function include(expr: FilterExpression): Include {
 export function exclude(expr: FilterExpression): Exclude {
   return new Exclude(expr);
 }
-

--- a/packages/pluginutils/tsconfig.base.json
+++ b/packages/pluginutils/tsconfig.base.json
@@ -7,7 +7,7 @@
     "moduleResolution": "node", /* Specify module resolution strategy. */
     /* Modules */
     "module": "ESNext", /* Specify what module code is generated. */
-    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src", /* Specify the root folder within your source files. */
     "declaration": true, /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     "outDir": "./dist/esm", /* Specify an output folder for all emitted files. */
     "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
@@ -16,8 +16,7 @@
 
     /* Type Checking */
     "strict": true, /* Enable all strict type-checking options. */
-    "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": ["src"]
-
 }

--- a/packages/pluginutils/tsconfig.base.json
+++ b/packages/pluginutils/tsconfig.base.json
@@ -9,7 +9,7 @@
     "module": "ESNext", /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     "declaration": true, /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    "outDir": "./dist", /* Specify an output folder for all emitted files. */
+    "outDir": "./dist/esm", /* Specify an output folder for all emitted files. */
     "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */

--- a/packages/pluginutils/tsconfig.cjs.json
+++ b/packages/pluginutils/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs", /* Specify what module code is generated. */
+    "outDir": "./dist/cjs", /* Specify an output folder for all emitted files. */
+  }
+}

--- a/packages/pluginutils/tsconfig.cjs.json
+++ b/packages/pluginutils/tsconfig.cjs.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "commonjs", /* Specify what module code is generated. */
-    "outDir": "./dist/cjs", /* Specify an output folder for all emitted files. */
+    "outDir": "./dist/cjs" /* Specify an output folder for all emitted files. */
   }
 }

--- a/packages/pluginutils/tsconfig.esm.json
+++ b/packages/pluginutils/tsconfig.esm.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "ESNext", /* Specify what module code is generated. */
-    "outDir": "./dist/esm", /* Specify an output folder for all emitted files. */
+    "outDir": "./dist/esm" /* Specify an output folder for all emitted files. */
   }
 }
-

--- a/packages/pluginutils/tsconfig.esm.json
+++ b/packages/pluginutils/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext", /* Specify what module code is generated. */
+    "outDir": "./dist/esm", /* Specify an output folder for all emitted files. */
+  }
+}
+

--- a/packages/pluginutils/tsconfig.json
+++ b/packages/pluginutils/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "incremental": false, /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+
+    /* Language and Environment */
+    "target": "ESNext", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "moduleResolution": "node", /* Specify module resolution strategy. */
+    /* Modules */
+    "module": "ESNext", /* Specify what module code is generated. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+    "declaration": true, /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "outDir": "./dist", /* Specify an output folder for all emitted files. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true, /* Enable all strict type-checking options. */
+    "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+  },
+  "include": ["src"]
+
+}

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -105,7 +105,8 @@
   },
   "dependencies": {
     "@oxc-project/types": "catalog:",
-    "ansis": "^3.17.0"
+    "ansis": "^3.17.0",
+    "@rolldown/pluginutils": "workspace:*"
   },
   "peerDependencies": {
     "@oxc-project/runtime": "catalog:"

--- a/packages/rolldown/src/filter-index.ts
+++ b/packages/rolldown/src/filter-index.ts
@@ -1,127 +1,16 @@
-import type { ModuleType as PluginModuleType } from './plugin';
-import type { StringOrRegExp } from './types/utils';
-
-export type FilterExpressionKind = FilterExpression['kind'];
-
-export type FilterExpression =
-  | And
-  | Or
-  | Not
-  | Id
-  | ModuleType
-  | Code
-  | Include
-  | Exclude;
-
-export type TopLevelFilterExpression = Include | Exclude;
-
-export class And {
-  kind: 'and';
-  args: FilterExpression[];
-  constructor(...args: FilterExpression[]) {
-    if (args.length === 0) {
-      throw new Error('`And` expects at least one operand');
-    }
-    this.args = args;
-    this.kind = 'and';
-  }
-}
-class Or {
-  kind: 'or';
-  args: FilterExpression[];
-  constructor(...args: FilterExpression[]) {
-    if (args.length === 0) {
-      throw new Error('`Or` expects at least one operand');
-    }
-    this.args = args;
-    this.kind = 'or';
-  }
-}
-
-class Not {
-  kind: 'not';
-  expr: FilterExpression;
-  constructor(expr: FilterExpression) {
-    this.expr = expr;
-    this.kind = 'not';
-  }
-}
-
-class Id {
-  kind: 'id';
-  pattern: StringOrRegExp;
-  constructor(pattern: StringOrRegExp) {
-    this.pattern = pattern;
-    this.kind = 'id';
-  }
-}
-
-class ModuleType {
-  kind: 'moduleType';
-  pattern: PluginModuleType;
-  constructor(pattern: PluginModuleType) {
-    this.pattern = pattern;
-    this.kind = 'moduleType';
-  }
-}
-
-class Code {
-  kind: 'code';
-  pattern: StringOrRegExp;
-  constructor(expr: StringOrRegExp) {
-    this.pattern = expr;
-    this.kind = 'code';
-  }
-}
-
-class Include {
-  kind: 'include';
-  expr: FilterExpression;
-  constructor(expr: FilterExpression) {
-    this.expr = expr;
-    this.kind = 'include';
-  }
-}
-
-class Exclude {
-  kind: 'exclude';
-  expr: FilterExpression;
-  constructor(expr: FilterExpression) {
-    this.expr = expr;
-    this.kind = 'exclude';
-  }
-}
-
-export function and(...args: FilterExpression[]): And {
-  return new And(...args);
-}
-
-export function or(...args: FilterExpression[]): Or {
-  return new Or(...args);
-}
-
-export function not(expr: FilterExpression): Not {
-  return new Not(expr);
-}
-
-export function id(pattern: StringOrRegExp): Id {
-  return new Id(pattern);
-}
-
-export function moduleType(pattern: PluginModuleType): ModuleType {
-  return new ModuleType(pattern);
-}
-
-export function code(pattern: StringOrRegExp): Code {
-  return new Code(pattern);
-}
-
-export function include(expr: FilterExpression): Include {
-  return new Include(expr);
-}
-
-export function exclude(expr: FilterExpression): Exclude {
-  return new Exclude(expr);
-}
-
-export { withFilter } from './plugin';
+export {
+  and,
+  or,
+  not,
+  id,
+  moduleType,
+  code,
+  exclude,
+  include,
+} from "@rolldown/pluginutils";
+export { withFilter } from "./plugin";
+export type {
+  FilterExpression,
+  FilterExpressionKind,
+  TopLevelFilterExpression,
+} from "@rolldown/pluginutils";

--- a/packages/rolldown/src/filter-index.ts
+++ b/packages/rolldown/src/filter-index.ts
@@ -9,8 +9,3 @@ export {
   include,
 } from "@rolldown/pluginutils";
 export { withFilter } from "./plugin";
-export type {
-  FilterExpression,
-  FilterExpressionKind,
-  TopLevelFilterExpression,
-} from "@rolldown/pluginutils";

--- a/packages/rolldown/src/filter-index.ts
+++ b/packages/rolldown/src/filter-index.ts
@@ -1,11 +1,11 @@
 export {
   and,
-  or,
-  not,
-  id,
-  moduleType,
   code,
   exclude,
+  id,
   include,
-} from "@rolldown/pluginutils";
-export { withFilter } from "./plugin";
+  moduleType,
+  not,
+  or,
+} from '@rolldown/pluginutils';
+export { withFilter } from './plugin';

--- a/packages/rolldown/src/plugin/bindingify-hook-filter.ts
+++ b/packages/rolldown/src/plugin/bindingify-hook-filter.ts
@@ -1,7 +1,7 @@
-import * as R from 'remeda';
-import type { BindingFilterToken, BindingHookFilter } from '../binding.d';
 import type { FilterExpression } from '@rolldown/pluginutils';
 import * as filter from '@rolldown/pluginutils';
+import * as R from 'remeda';
+import type { BindingFilterToken, BindingHookFilter } from '../binding.d';
 import type { StringOrRegExp } from '../types/utils';
 import { arraify } from '../utils/misc';
 import type { HookFilterExtension } from '.';

--- a/packages/rolldown/src/plugin/bindingify-hook-filter.ts
+++ b/packages/rolldown/src/plugin/bindingify-hook-filter.ts
@@ -1,7 +1,7 @@
 import * as R from 'remeda';
 import type { BindingFilterToken, BindingHookFilter } from '../binding.d';
-import type { FilterExpression } from '../filter-index';
-import * as filter from '../filter-index';
+import type { FilterExpression } from '@rolldown/pluginutils';
+import * as filter from '@rolldown/pluginutils';
 import type { StringOrRegExp } from '../types/utils';
 import { arraify } from '../utils/misc';
 import type { HookFilterExtension } from '.';

--- a/packages/rolldown/src/plugin/hook-filter.ts
+++ b/packages/rolldown/src/plugin/hook-filter.ts
@@ -1,4 +1,4 @@
-import type { TopLevelFilterExpression } from '../filter-index';
+import type { TopLevelFilterExpression } from '@rolldown/pluginutils';
 import type { ModuleType } from '../index';
 import type { MaybeArray } from '../types/utils';
 import type { StringOrRegExp } from '../types/utils';

--- a/packages/rolldown/tsconfig.check.json
+++ b/packages/rolldown/tsconfig.check.json
@@ -3,8 +3,8 @@
   // https://github.com/vitejs/vite/blob/1465b2064ee23ac5df5414b13355a394ccd931af/packages/vite/tsconfig.check.json
   "compilerOptions": {
     "target": "ES2020",
-    "moduleResolution": "node16",
-    "module": "node16",
+    "moduleResolution": "bundler",
+    "module": "ESNext",
     "lib": ["ES2020", "ESNext.Disposable"], // ES2020 is very conservative check for client types, could be bumped if needed
     "types": ["node"], // Avoid checking unrelated node_modules types
     "noEmit": true,

--- a/packages/test-dev-server/tests/fixtures.test.ts
+++ b/packages/test-dev-server/tests/fixtures.test.ts
@@ -35,7 +35,7 @@ function main() {
       projectName,
     );
     copyProjectToTmp(projectName);
-    await execa('pnpm install', {
+    await execa('pnpm install --no-frozen-lockfile', {
       cwd: tmpProjectPath,
       shell: true,
       stdio: 'inherit',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,8 +293,8 @@ importers:
   packages/pluginutils:
     devDependencies:
       rimraf:
-        specifier: ^6.0.1
-        version: 6.0.1
+        specifier: ^5.0.0
+        version: 5.0.10
 
   packages/rolldown:
     dependencies:
@@ -6093,6 +6093,10 @@ packages:
     resolution: {integrity: sha512-bYBjgxmkvTAfgIYy328fmkwhp39v8lwVgWhhrzxPV3yHtcSqyYKe9/XOhvW48UFjATg3VuJbpsp5822ACNvkmw==}
     engines: {node: '>= 0.10'}
     deprecated: Use String.prototype.padEnd() instead
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
 
   rimraf@6.0.1:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
@@ -12413,6 +12417,10 @@ snapshots:
   rfdc@1.4.1: {}
 
   right-pad@1.0.1: {}
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.4.5
 
   rimraf@6.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,7 +290,11 @@ importers:
 
   packages/debug: {}
 
-  packages/pluginutils: {}
+  packages/pluginutils:
+    devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
 
   packages/rolldown:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,8 @@ importers:
 
   packages/debug: {}
 
+  packages/pluginutils: {}
+
   packages/rolldown:
     dependencies:
       '@oxc-project/runtime':
@@ -298,6 +300,9 @@ importers:
       '@oxc-project/types':
         specifier: 'catalog:'
         version: 0.68.1
+      '@rolldown/pluginutils':
+        specifier: workspace:*
+        version: link:../pluginutils
       ansis:
         specifier: ^3.17.0
         version: 3.17.0
@@ -568,12 +573,6 @@ importers:
       '@rolldown/test-dev-server':
         specifier: workspace:*
         version: link:../../..
-
-  packages/test-dev-server/tests/tmp/fixtures/basic:
-    devDependencies:
-      '@rolldown/test-dev-server':
-        specifier: workspace:*
-        version: link:../../../..
 
   packages/testing: {}
 
@@ -6089,7 +6088,7 @@ packages:
   right-pad@1.0.1:
     resolution: {integrity: sha512-bYBjgxmkvTAfgIYy328fmkwhp39v8lwVgWhhrzxPV3yHtcSqyYKe9/XOhvW48UFjATg3VuJbpsp5822ACNvkmw==}
     engines: {node: '>= 0.10'}
-    deprecated: Please use String.prototype.padEnd() over this package.
+    deprecated: Use String.prototype.padEnd() instead
 
   rimraf@6.0.1:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new utility package for building composable filter expressions, providing flexible filtering options for plugins.

- **Refactor**
  - Updated internal code to use the new utility package for filter expressions, replacing previous local implementations.

- **Chores**
  - Added configuration files and scripts to support building and publishing the new utility package.
  - Updated dependencies and TypeScript settings for improved module compatibility.
  - Enhanced CI workflow to build the new utility package during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->