### PR TITLE
refactor(rust): remove unused import star and default flags from `ImportRecordMeta`

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -458,9 +458,6 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       record_id,
       span_imported,
     };
-    if name_import.imported.is_default() {
-      self.result.import_records[record_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
-    }
     self.result.named_exports.insert(
       export_name.into(),
       LocalExport { referenced: generated_imported_as_ref, span: name_import.span_imported },
@@ -486,7 +483,6 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       record_id,
     };
 
-    self.result.import_records[record_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_STAR);
     self.result.named_exports.insert(
       export_name.into(),
       LocalExport { referenced: generated_imported_as_ref, span: name_import.span_imported },
@@ -632,18 +628,13 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         let sym = spec.local.expect_symbol_id();
         let imported = spec.imported.name();
         self.add_named_import(sym, imported.as_str(), rec_id, spec.imported.span());
-        if imported == "default" {
-          self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
-        }
       }
       ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
         self.add_named_import(spec.local.expect_symbol_id(), "default", rec_id, spec.span);
-        self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_DEFAULT);
       }
       ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
         let symbol_id = spec.local.expect_symbol_id();
         self.add_star_import(symbol_id, rec_id, spec.span);
-        self.result.import_records[rec_id].meta.insert(ImportRecordMeta::CONTAINS_IMPORT_STAR);
       }
     });
   }

--- a/crates/rolldown_common/src/types/import_record.rs
+++ b/crates/rolldown_common/src/types/import_record.rs
@@ -27,26 +27,22 @@ pub struct ImportRecordStateResolved {
 bitflags::bitflags! {
   #[derive(Debug, Clone, Copy)]
   pub struct ImportRecordMeta: u16 {
-    /// If it is `import * as ns from '...'` or `export * as ns from '...'`
-    const CONTAINS_IMPORT_STAR = 1;
-    /// If it is `import def from '...'`, `import { default as def }`, `export { default as def }` or `export { default } from '...'`
-    const CONTAINS_IMPORT_DEFAULT = 1 << 1;
     /// If it is `import {} from '...'` or `import '...'`
-    const IS_PLAIN_IMPORT = 1 << 2;
+    const IS_PLAIN_IMPORT = 1;
     /// the import is inserted during ast transformation, can't get source slice from the original source file
-    const IS_UNSPANNED_IMPORT = 1 << 3;
+    const IS_UNSPANNED_IMPORT = 1 << 1;
     /// `export * from 'mod'` only
-    const IS_EXPORT_STAR = 1 << 4;
+    const IS_EXPORT_STAR = 1 << 2;
     ///  Tell the finalizer to use the runtime "__require()" instead of "require()"
-    const CALL_RUNTIME_REQUIRE = 1 << 5;
+    const CALL_RUNTIME_REQUIRE = 1 << 3;
     ///  `require('mod')` is used to load the module only
-    const IS_REQUIRE_UNUSED = 1 << 6;
+    const IS_REQUIRE_UNUSED = 1 << 4;
     /// If the import is a dummy import, it should be ignored during linking, e.g.
     /// `require` ExpressionIdentifier should be considering as a import record,
     /// but it did not import any module.
-    const IS_DUMMY = 1 << 7;
+    const IS_DUMMY = 1 << 5;
     /// if the import record is in a try-catch block
-    const IN_TRY_CATCH_BLOCK = 1 << 8;
+    const IN_TRY_CATCH_BLOCK = 1 << 6;
     /// Whether it is a pure dynamic import, aka a dynamic import only reference a module without using
     /// its exports e.g.
     /// ```js
@@ -54,11 +50,11 @@ bitflags::bitflags! {
     /// import('mod').then(mod => {});
     /// const a = await import('mod'); // the a is never be referenced
     /// ```
-    const PURE_DYNAMIC_IMPORT = 1 << 9;
+    const PURE_DYNAMIC_IMPORT = 1 << 7;
     /// Whether it is a pure dynamic import referenced a side effect free module
-    const DEAD_DYNAMIC_IMPORT = 1 << 10;
+    const DEAD_DYNAMIC_IMPORT = 1 << 8;
     /// Whether the import is a top level import
-    const IS_TOP_LEVEL = 1 << 11;
+    const IS_TOP_LEVEL = 1 << 9;
     const TOP_LEVEL_PURE_DYNAMIC_IMPORT = Self::IS_TOP_LEVEL.bits() | Self::PURE_DYNAMIC_IMPORT.bits();
   }
 }

--- a/crates/rolldown_common/src/types/named_import.rs
+++ b/crates/rolldown_common/src/types/named_import.rs
@@ -35,10 +35,6 @@ impl Specifier {
   pub fn is_star(&self) -> bool {
     matches!(self, Self::Star)
   }
-
-  pub fn is_default(&self) -> bool {
-    matches!(self, Self::Literal(atom) if atom.as_str() == "default")
-  }
 }
 
 impl Display for Specifier {


### PR DESCRIPTION
### Description

It seems these are no longer in use. Should we consider removing the related logic?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed internal metadata flags related to default and star imports from import records.
  - Adjusted internal flag definitions for import records to streamline bit assignments.
  - Removed a method for identifying default import specifiers. 

No changes to user-facing features or exported APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->