### PR TITLE
refactor(hmr): using __esModule to mark esm module exports

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -1,5 +1,5 @@
 use oxc::{
-  allocator::{Allocator, Box as ArenaBox, Dummy, IntoIn, TakeIn},
+  allocator::{Allocator, Box as ArenaBox, IntoIn, TakeIn},
   ast::{
     NONE,
     ast::{self, ExportDefaultDeclarationKind, Expression, ObjectPropertyKind},
@@ -57,16 +57,16 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         );
         arg_obj_expr.properties.extend(self.exports.drain(..));
         // Add __esModule flag
-        arg_obj_expr.properties.push(ast::ObjectPropertyKind::ObjectProperty(
-          ast::ObjectProperty {
-            key: ast::PropertyKey::StaticIdentifier(
-              self.snippet.id_name("__esModule", SPAN).into_in(self.alloc),
-            ),
-            value: self.snippet.builder.expression_boolean_literal(SPAN, true),
-            ..ast::ObjectProperty::dummy(self.alloc)
-          }
-          .into_in(self.alloc),
-        ));
+        arg_obj_expr.properties.push(
+          self
+            .snippet
+            .object_property_kind_object_property(
+              "__esModule",
+              self.snippet.builder.expression_boolean_literal(SPAN, true),
+              false,
+            )
+            .into_in(self.alloc),
+        );
         ast::Argument::ObjectExpression(arg_obj_expr)
       }
       rolldown_common::ExportsKind::CommonJs => {

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/hmr.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/hmr.rs
@@ -61,16 +61,16 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
           ));
         });
         // Add __esModule flag
-        arg_obj_expr.properties.push(ast::ObjectPropertyKind::ObjectProperty(
-          ast::ObjectProperty {
-            key: ast::PropertyKey::StaticIdentifier(
-              self.snippet.id_name("__esModule", SPAN).into_in(self.alloc),
-            ),
-            value: self.snippet.builder.expression_boolean_literal(SPAN, true),
-            ..ast::ObjectProperty::dummy(self.alloc)
-          }
-          .into_in(self.alloc),
-        ));
+        arg_obj_expr.properties.push(
+          self
+            .snippet
+            .object_property_kind_object_property(
+              "__esModule",
+              self.snippet.builder.expression_boolean_literal(SPAN, true),
+              false,
+            )
+            .into_in(self.alloc),
+        );
         ast::Argument::ObjectExpression(arg_obj_expr)
       }
       rolldown_common::ExportsKind::CommonJs => {

--- a/crates/rolldown/src/runtime/runtime-extra-dev.js
+++ b/crates/rolldown/src/runtime/runtime-extra-dev.js
@@ -88,21 +88,14 @@ class DevRuntime {
     this.moduleHotContextsToBeUpdated.clear()
     // swap new contexts
   }
-  registerModule(id, esmExportGettersOrCjsExports, meta = {}) {
+  registerModule(id, esmExportGettersOrCjsExports) {
     const exports = {};
     Object.keys(esmExportGettersOrCjsExports).forEach((key) => {
       if (Object.prototype.hasOwnProperty.call(esmExportGettersOrCjsExports, key)) {
-        if (meta.cjs) {
-          Object.defineProperty(exports, key, {
-            enumerable: true,
-            get: () => esmExportGettersOrCjsExports[key],
-          });
-        } else {
-          Object.defineProperty(exports, key, {
-            enumerable: true,
-            get: esmExportGettersOrCjsExports[key],
-          });
-        }
+        Object.defineProperty(exports, key, {
+          enumerable: true,
+          get: esmExportGettersOrCjsExports[key],
+        });
       }
     })
     console.debug('Registering module', id, exports);

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -70,6 +70,10 @@ impl LinkingMetadata {
       .map(|name| (name, &self.resolved_exports[name]))
   }
 
+  pub fn canonical_exports_len(&self) -> usize {
+    self.sorted_and_non_ambiguous_resolved_exports.len()
+  }
+
   pub fn is_canonical_exports_empty(&self) -> bool {
     self.sorted_and_non_ambiguous_resolved_exports.is_empty()
   }

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -12,7 +12,7 @@ import assert from "node:assert";
 //#region lib.js
 var require_lib = __commonJS({ "lib.js"(exports, module) {
 	const lib_hot = __rolldown_runtime__.createModuleHotContext("lib.js");
-	__rolldown_runtime__.registerModule("lib.js", module.exports, { cjs: true });
+	__rolldown_runtime__.registerModule("lib.js", module.exports);
 	exports.a = 1;
 } });
 var import_lib = __toESM(require_lib());
@@ -20,7 +20,7 @@ var import_lib = __toESM(require_lib());
 //#endregion
 //#region main.js
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", {});
+__rolldown_runtime__.registerModule("main.js", { __esModule: true });
 assert.strictEqual(import_lib.a, 1);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -20,7 +20,7 @@ var import_lib = __toESM(require_lib());
 //#endregion
 //#region main.js
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { __esModule: true });
+__rolldown_runtime__.registerModule("main.js", { __esModule: () => true });
 assert.strictEqual(import_lib.a, 1);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -20,7 +20,7 @@ var import_cjs = __toESM(require_cjs());
 const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
 __rolldown_runtime__.registerModule("esm.js", {
 	value: () => value,
-	__esModule: true
+	__esModule: () => true
 });
 var esm_exports = {};
 __export(esm_exports, { value: () => value });
@@ -29,7 +29,7 @@ const value = "main";
 //#endregion
 //#region main.js
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { __esModule: true });
+__rolldown_runtime__.registerModule("main.js", { __esModule: () => true });
 console.log(import_cjs, esm_exports);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#region cjs.js
 var require_cjs = __commonJS({ "cjs.js"(exports, module) {
 	const cjs_hot = __rolldown_runtime__.createModuleHotContext("cjs.js");
-	__rolldown_runtime__.registerModule("cjs.js", module.exports, { cjs: true });
+	__rolldown_runtime__.registerModule("cjs.js", module.exports);
 	module.exports.value = "cjs";
 } });
 var import_cjs = __toESM(require_cjs());
@@ -18,7 +18,10 @@ var import_cjs = __toESM(require_cjs());
 //#endregion
 //#region esm.js
 const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
-__rolldown_runtime__.registerModule("esm.js", { value: () => value });
+__rolldown_runtime__.registerModule("esm.js", {
+	value: () => value,
+	__esModule: true
+});
 var esm_exports = {};
 __export(esm_exports, { value: () => value });
 const value = "main";
@@ -26,7 +29,7 @@ const value = "main";
 //#endregion
 //#region main.js
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", {});
+__rolldown_runtime__.registerModule("main.js", { __esModule: true });
 console.log(import_cjs, esm_exports);
 
 //#endregion

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4659,7 +4659,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-BPOQ7Jh-.js
+- main-!~{000}~.js => main-Dy7MvqPh.js
 
 # tests/rolldown/issues/4196
 
@@ -5200,13 +5200,13 @@ expression: output
 
 # tests/rolldown/topics/hmr/mutiply-entires
 
-- entry-!~{000}~.js => entry-cqNUbIkK.js
-- index-!~{001}~.js => index-t76-tv7f.js
-- chunk-!~{002}~.js => chunk-DvBEc7YG.js
+- entry-!~{000}~.js => entry-DT9qLAS4.js
+- index-!~{001}~.js => index-DXGbv_kK.js
+- chunk-!~{002}~.js => chunk-DHqyPXea.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-B1WfpZkd.js
+- main-!~{000}~.js => main-B1deCWUa.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4659,7 +4659,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-Dy7MvqPh.js
+- main-!~{000}~.js => main-0EJMu8Zg.js
 
 # tests/rolldown/issues/4196
 
@@ -5206,7 +5206,7 @@ expression: output
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-B1deCWUa.js
+- main-!~{000}~.js => main-BeFMe4Ep.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Here should follow the babel semantics to mark esm module exports. it will make sure our module exports is compat to other bundlers, eg module federation moduels.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
