### PR TITLE
chore: add `node:` prefix to `module` in runtime.js

### DIFF
--- a/crates/rolldown/src/runtime/runtime-head-node.js
+++ b/crates/rolldown/src/runtime/runtime-head-node.js
@@ -1,1 +1,1 @@
-import { createRequire } from 'module';
+import { createRequire } from 'node:module';

--- a/crates/rolldown/tests/rolldown/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
 ## main.js
 
 ```js
-import { createRequire } from "module";
+import { createRequire } from "node:module";
 import * as fs from "fs";
 import * as nodeFs from "node:fs";
 

--- a/crates/rolldown/tests/rolldown/function/resolve/alias_to_node_builtin_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/resolve/alias_to_node_builtin_module/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
 ## main.js
 
 ```js
-import { createRequire } from "module";
+import { createRequire } from "node:module";
 
 
 //#region main.js

--- a/crates/rolldown/tests/rolldown/issues/2685/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2685/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
 ## main.js
 
 ```js
-import { createRequire } from "module";
+import { createRequire } from "node:module";
 
 //#region rolldown:runtime
 var __require = /* @__PURE__ */ createRequire(import.meta.url);

--- a/crates/rolldown/tests/rolldown/issues/3395/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3395/artifacts.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
 ## main.js
 
 ```js
-import { createRequire } from "module";
+import { createRequire } from "node:module";
 
 
 //#region main.js

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4456,11 +4456,11 @@ expression: output
 
 # tests/rolldown/function/platform/node/should_not_throw_warnings_for_import_builtin_modules/basic
 
-- main-!~{000}~.js => main-C19_NGhs.js
+- main-!~{000}~.js => main-BJ5nqhB1.js
 
 # tests/rolldown/function/resolve/alias_to_node_builtin_module
 
-- main-!~{000}~.js => main-B0DHcS_I.js
+- main-!~{000}~.js => main-DVLqSnT5.js
 
 # tests/rolldown/function/resolve/browser_filed_false
 
@@ -4565,7 +4565,7 @@ expression: output
 
 # tests/rolldown/issues/2685
 
-- main-!~{000}~.js => main-DVonihTt.js
+- main-!~{000}~.js => main-DuvcNmGS.js
 
 # tests/rolldown/issues/2833
 
@@ -4606,7 +4606,7 @@ expression: output
 
 # tests/rolldown/issues/3395
 
-- main-!~{000}~.js => main-BIyVlF5M.js
+- main-!~{000}~.js => main-HNTwtrHw.js
 
 # tests/rolldown/issues/3437
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Closed #4451
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
