### PR TITLE
refactor(hmr): using esm module namespace to store it's exports

### DIFF
--- a/crates/rolldown/src/runtime/runtime-extra-dev.js
+++ b/crates/rolldown/src/runtime/runtime-extra-dev.js
@@ -111,9 +111,9 @@ class DevRuntime {
   createCjsInitializer = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports)
   // @ts-expect-error it exists
   __toESM = __toESM;
-  // @ts-expect-error it exits
+  // @ts-expect-error it exists
   __toCommonJS = __toCommonJS
-  // @ts-expect-error it exits
+  // @ts-expect-error it exists
   __export = __export
 } 
 

--- a/crates/rolldown/src/runtime/runtime-extra-dev.js
+++ b/crates/rolldown/src/runtime/runtime-extra-dev.js
@@ -88,26 +88,10 @@ class DevRuntime {
     this.moduleHotContextsToBeUpdated.clear()
     // swap new contexts
   }
-  registerModule(id, esmExportGettersOrCjsExports) {
-    const exports = {};
-    Object.keys(esmExportGettersOrCjsExports).forEach((key) => {
-      if (Object.prototype.hasOwnProperty.call(esmExportGettersOrCjsExports, key)) {
-        Object.defineProperty(exports, key, {
-          enumerable: true,
-          get: esmExportGettersOrCjsExports[key],
-        });
-      }
-    })
+  registerModule(id, exports) {
     console.debug('Registering module', id, exports);
-    if (this.modules[id]) {
-      this.modules[id] = {
-        exports,
-      }
-    } else {
-      // If the module is not in the cache, we need to register it.
-      this.modules[id] = {
-        exports,
-      };
+    this.modules[id] = {
+      exports,
     }
   }
 
@@ -127,6 +111,10 @@ class DevRuntime {
   createCjsInitializer = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports)
   // @ts-expect-error it exists
   __toESM = __toESM;
+  // @ts-expect-error it exits
+  __toCommonJS = __toCommonJS
+  // @ts-expect-error it exits
+  __export = __export
 } 
 
 globalThis.__rolldown_runtime__ = DevRuntime.getInstance();

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -70,10 +70,6 @@ impl LinkingMetadata {
       .map(|name| (name, &self.resolved_exports[name]))
   }
 
-  pub fn canonical_exports_len(&self) -> usize {
-    self.sorted_and_non_ambiguous_resolved_exports.len()
-  }
-
   pub fn is_canonical_exports_empty(&self) -> bool {
     self.sorted_and_non_ambiguous_resolved_exports.is_empty()
   }

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -18,9 +18,15 @@ var require_lib = __commonJS({ "lib.js"(exports, module) {
 
 //#endregion
 //#region main.js
+var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+<<<<<<< HEAD
 __rolldown_runtime__.registerModule("main.js", { __esModule: () => true });
 var import_lib = __toESM(require_lib());
+=======
+__rolldown_runtime__.__toCommonJS(main_exports);
+__rolldown_runtime__.registerModule("main.js", main_exports);
+>>>>>>> dce44170c (refactor(hmr): using esm module namespace to store it's exports)
 assert.strictEqual(import_lib.a, 1);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -20,13 +20,9 @@ var require_lib = __commonJS({ "lib.js"(exports, module) {
 //#region main.js
 var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-<<<<<<< HEAD
-__rolldown_runtime__.registerModule("main.js", { __esModule: () => true });
-var import_lib = __toESM(require_lib());
-=======
 __rolldown_runtime__.__toCommonJS(main_exports);
 __rolldown_runtime__.registerModule("main.js", main_exports);
->>>>>>> dce44170c (refactor(hmr): using esm module namespace to store it's exports)
+var import_lib = __toESM(require_lib());
 assert.strictEqual(import_lib.a, 1);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -16,20 +16,24 @@ var require_cjs = __commonJS({ "cjs.js"(exports, module) {
 
 //#endregion
 //#region esm.js
-const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
-__rolldown_runtime__.registerModule("esm.js", {
-	value: () => value,
-	__esModule: () => true
-});
 var esm_exports = {};
 __export(esm_exports, { value: () => value });
+const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
+__rolldown_runtime__.__toCommonJS(esm_exports);
+__rolldown_runtime__.registerModule("esm.js", esm_exports);
 const value = "main";
 
 //#endregion
 //#region main.js
+var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+<<<<<<< HEAD
 __rolldown_runtime__.registerModule("main.js", { __esModule: () => true });
 var import_cjs = __toESM(require_cjs());
+=======
+__rolldown_runtime__.__toCommonJS(main_exports);
+__rolldown_runtime__.registerModule("main.js", main_exports);
+>>>>>>> dce44170c (refactor(hmr): using esm module namespace to store it's exports)
 console.log(import_cjs, esm_exports);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -27,13 +27,9 @@ const value = "main";
 //#region main.js
 var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-<<<<<<< HEAD
-__rolldown_runtime__.registerModule("main.js", { __esModule: () => true });
-var import_cjs = __toESM(require_cjs());
-=======
 __rolldown_runtime__.__toCommonJS(main_exports);
 __rolldown_runtime__.registerModule("main.js", main_exports);
->>>>>>> dce44170c (refactor(hmr): using esm module namespace to store it's exports)
+var import_cjs = __toESM(require_cjs());
 console.log(import_cjs, esm_exports);
 
 //#endregion

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4659,11 +4659,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-<<<<<<< HEAD
-- main-!~{000}~.js => main-DHp4Ws7A.js
-=======
-- main-!~{000}~.js => main-C8CEOJZX.js
->>>>>>> dce44170c (refactor(hmr): using esm module namespace to store it's exports)
+- main-!~{000}~.js => main-Dyyx3o7E.js
 
 # tests/rolldown/issues/4196
 
@@ -5208,23 +5204,13 @@ expression: output
 
 # tests/rolldown/topics/hmr/mutiply-entires
 
-<<<<<<< HEAD
-- entry-!~{000}~.js => entry-D3qdtA0j.js
-- index-!~{001}~.js => index-Bbp4lvLR.js
-- chunk-!~{002}~.js => chunk-DnGosdBm.js
-
-# tests/rolldown/topics/hmr/register_exports
-
-- main-!~{000}~.js => main-BdEZr9rY.js
-=======
 - entry-!~{000}~.js => entry-CBZpKmcs.js
 - index-!~{001}~.js => index-Bx6GS1WH.js
 - chunk-!~{002}~.js => chunk-DCxEFtjL.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-BSpSms2Z.js
->>>>>>> dce44170c (refactor(hmr): using esm module namespace to store it's exports)
+- main-!~{000}~.js => main-CkJjwhFU.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4659,7 +4659,11 @@ expression: output
 
 # tests/rolldown/issues/4129
 
+<<<<<<< HEAD
 - main-!~{000}~.js => main-DHp4Ws7A.js
+=======
+- main-!~{000}~.js => main-C8CEOJZX.js
+>>>>>>> dce44170c (refactor(hmr): using esm module namespace to store it's exports)
 
 # tests/rolldown/issues/4196
 
@@ -5204,6 +5208,7 @@ expression: output
 
 # tests/rolldown/topics/hmr/mutiply-entires
 
+<<<<<<< HEAD
 - entry-!~{000}~.js => entry-D3qdtA0j.js
 - index-!~{001}~.js => index-Bbp4lvLR.js
 - chunk-!~{002}~.js => chunk-DnGosdBm.js
@@ -5211,6 +5216,15 @@ expression: output
 # tests/rolldown/topics/hmr/register_exports
 
 - main-!~{000}~.js => main-BdEZr9rY.js
+=======
+- entry-!~{000}~.js => entry-CBZpKmcs.js
+- index-!~{001}~.js => index-Bx6GS1WH.js
+- chunk-!~{002}~.js => chunk-DCxEFtjL.js
+
+# tests/rolldown/topics/hmr/register_exports
+
+- main-!~{000}~.js => main-BSpSms2Z.js
+>>>>>>> dce44170c (refactor(hmr): using esm module namespace to store it's exports)
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The previous implementation has a problem for cjs. 

```.js 
__rolldown_runtime__.registerModule("cjs.js", module.exports);
exports.a = 1
function b() {
   exports.b = 1
}
```
The runtime using `Object.keys(esmExportGettersOrCjsExports)` can't get it's real exports.

The pr fixed it directly using `exports` at runtime. To compat it with esm, using esm namespace object is suitable.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
