### PR TITLE
feat(rolldown): oxc_resolver v9.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5c7d43ec2c0dcd506adb52f94cc2903e754f413cb548c4733b03c3103eb908"
+checksum = "32ae4ba32ec42720e4106991fa940bdca8a7ade4c1c00c053c116c7ee7459c87"
 dependencies = [
  "cfg-if",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ oxc_transform_napi = { version = "0.68.1" }
 # Versions must be relaxed for usage in oxc.
 # Please update with `cargo update oxc_resolver oxc_sourcemap oxc_index`
 oxc_index = { version = "3", features = ["rayon", "serde"] } # https://github.com/oxc-project/oxc-index-vec
-oxc_resolver = { version = "8", features = ["package_json_raw_json_api"] } # https://github.com/oxc-project/oxc-resolver
+oxc_resolver = { version = "9", features = ["package_json_raw_json_api"] } # https://github.com/oxc-project/oxc-resolver
 oxc_sourcemap = { version = "3" } # https://github.com/oxc-project/oxc-sourcemap
 
 [profile.release]

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -112,6 +112,7 @@ impl<F: FileSystem + Default> Resolver<F> {
       fully_specified: false,
       main_fields,
       main_files: raw_resolve.main_files.unwrap_or_else(|| vec!["index".to_string()]),
+      modules: vec!["node_modules".into()],
       resolve_to_context: false,
       prefer_relative: false,
       prefer_absolute: false,


### PR DESCRIPTION
I removed the `modules` option in a previous version, it's now restored.
