### PR TITLE
feat(pluginutils): add `makeIdFiltersToMatchWithQuery` function

### DIFF
--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -27,9 +27,11 @@
     "build:all": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc -p ./tsconfig.esm.json",
     "build:cjs": "tsc -p ./tsconfig.cjs.json",
-    "test": "vitest"
+    "test": "vitest --typecheck"
   },
   "devDependencies": {
+    "@types/picomatch": "^4.0.0",
+    "picomatch": "^4.0.2",
     "vitest": "^3.0.1"
   }
 }

--- a/packages/pluginutils/src/simple-filters.test-d.ts
+++ b/packages/pluginutils/src/simple-filters.test-d.ts
@@ -1,0 +1,61 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import { makeIdFiltersToMatchWithQuery } from './simple-filters';
+
+describe('makeIdFiltersToMatchWithQuery', () => {
+  test('single string input', () => {
+    const input = 'foo';
+    expectTypeOf(makeIdFiltersToMatchWithQuery(input)).toEqualTypeOf<string>();
+
+    // string literal should return normal string
+    expectTypeOf(makeIdFiltersToMatchWithQuery('foo')).not.toEqualTypeOf<
+      'foo'
+    >();
+    expectTypeOf(makeIdFiltersToMatchWithQuery('foo')).toEqualTypeOf<string>();
+  });
+
+  test('single regex input', () => {
+    expectTypeOf(makeIdFiltersToMatchWithQuery(/foo/)).toEqualTypeOf<RegExp>();
+  });
+
+  test('single string or regex input', () => {
+    const input = 'foo' as string | RegExp;
+    expectTypeOf(makeIdFiltersToMatchWithQuery(input)).toEqualTypeOf<
+      string | RegExp
+    >();
+  });
+
+  test('array string input', () => {
+    const input = ['foo'];
+    expectTypeOf(makeIdFiltersToMatchWithQuery(input)).toEqualTypeOf<
+      string[]
+    >();
+
+    // string literal should return normal string
+    expectTypeOf(makeIdFiltersToMatchWithQuery(['foo'])).not.toEqualTypeOf<
+      'foo'[]
+    >();
+    expectTypeOf(makeIdFiltersToMatchWithQuery(['foo'])).toEqualTypeOf<
+      string[]
+    >();
+  });
+
+  test('array regex input', () => {
+    expectTypeOf(makeIdFiltersToMatchWithQuery([/foo/])).toEqualTypeOf<
+      RegExp[]
+    >();
+  });
+
+  test('array string or regex input', () => {
+    const input = ['foo'] as (string | RegExp)[];
+    expectTypeOf(makeIdFiltersToMatchWithQuery(input)).toEqualTypeOf<
+      (string | RegExp)[]
+    >();
+  });
+
+  test('mixed input', () => {
+    const input = ['foo', /bar/] as (string | RegExp)[] | string | RegExp;
+    expectTypeOf(makeIdFiltersToMatchWithQuery(input)).toEqualTypeOf<
+      (string | RegExp)[] | string | RegExp
+    >();
+  });
+});

--- a/packages/pluginutils/src/simple-filters.test.ts
+++ b/packages/pluginutils/src/simple-filters.test.ts
@@ -93,7 +93,7 @@ describe('makeIdFiltersToMatchWithQuery', () => {
     const input = /\/foo\//;
     const output = makeIdFiltersToMatchWithQuery(input);
 
-    const matcher = path => output.test(path);
+    const matcher = (path: string) => output.test(path);
     expectWithAnyQuery(matcher, '/foo/bar.js', true);
     expectWithAnyQuery(matcher, '/bar/bar.ts', false);
   });
@@ -102,7 +102,7 @@ describe('makeIdFiltersToMatchWithQuery', () => {
     const input = /\/foo\/.*\.js$/;
     const output = makeIdFiltersToMatchWithQuery(input);
 
-    const matcher = path => output.test(path);
+    const matcher = (path: string) => output.test(path);
     expectWithAnyQuery(matcher, '/foo/bar.js', true);
     expectWithAnyQuery(matcher, '/foo/bar.ts', false);
   });
@@ -111,7 +111,7 @@ describe('makeIdFiltersToMatchWithQuery', () => {
     const input = /\/foo\/[^/]*(\/src|\/dist\/[^/]*\.js$|$)/;
     const output = makeIdFiltersToMatchWithQuery(input);
 
-    const matcher = path => output.test(path);
+    const matcher = (path: string) => output.test(path);
     expectWithAnyQuery(matcher, '/foo/bar/src/foo', true);
     expectWithAnyQuery(matcher, '/foo/bar/dist/foo.js', true);
     expectWithAnyQuery(matcher, '/foo/bar/dist/foo.ts', false);
@@ -123,7 +123,7 @@ describe('makeIdFiltersToMatchWithQuery', () => {
     const input = /\/foo\/\$.*\.js$/;
     const output = makeIdFiltersToMatchWithQuery(input);
 
-    const matcher = path => output.test(path);
+    const matcher = (path: string) => output.test(path);
     expectWithAnyQuery(matcher, '/foo/$bar.js', true);
     expectWithAnyQuery(matcher, '/foo/$bar.ts', false);
   });

--- a/packages/pluginutils/src/simple-filters.ts
+++ b/packages/pluginutils/src/simple-filters.ts
@@ -47,25 +47,25 @@ export function makeIdFiltersToMatchWithQuery(
   input: string | RegExp | readonly (string | RegExp)[],
 ): string | RegExp | (string | RegExp)[] {
   if (!Array.isArray(input)) {
-    return makeIdFilterToMatchWithQueries(
+    return makeIdFilterToMatchWithQuery(
       // Array.isArray cannot narrow the type
       // https://github.com/microsoft/TypeScript/issues/17002
       input as Exclude<typeof input, readonly unknown[]>,
     );
   }
-  return input.map((i) => makeIdFilterToMatchWithQueries(i));
+  return input.map((i) => makeIdFilterToMatchWithQuery(i));
 }
 
-function makeIdFilterToMatchWithQueries(
+function makeIdFilterToMatchWithQuery(
   input: string | RegExp,
 ): string | RegExp {
   if (typeof input === 'string') {
     return `${input}{?*,}`;
   }
-  return makeRegexIdFilterToMatchWithQueries(input);
+  return makeRegexIdFilterToMatchWithQuery(input);
 }
 
-function makeRegexIdFilterToMatchWithQueries(input: RegExp) {
+function makeRegexIdFilterToMatchWithQuery(input: RegExp) {
   return new RegExp(
     // replace `$` with `(?:\?.*)?$` (ignore `\$`)
     input.source.replace(/(?<!\\)\$/g, '(?:\\?.*)?$'),

--- a/packages/pluginutils/src/simple-filters.ts
+++ b/packages/pluginutils/src/simple-filters.ts
@@ -26,3 +26,49 @@ const escapeRegexRE = /[-/\\^$*+?.()|[\]{}]/g;
 function escapeRegex(str: string): string {
   return str.replace(escapeRegexRE, '\\$&');
 }
+
+type WidenString<T> = T extends string ? string : T;
+
+/**
+ * Converts a id filter to match with an id with a query.
+ *
+ * @param input the id filters to convert.
+ */
+export function makeIdFiltersToMatchWithQuery<T extends string | RegExp>(
+  input: T,
+): WidenString<T>;
+export function makeIdFiltersToMatchWithQuery<T extends string | RegExp>(
+  input: readonly T[],
+): WidenString<T>[];
+export function makeIdFiltersToMatchWithQuery(
+  input: string | RegExp | readonly (string | RegExp)[],
+): string | RegExp | (string | RegExp)[];
+export function makeIdFiltersToMatchWithQuery(
+  input: string | RegExp | readonly (string | RegExp)[],
+): string | RegExp | (string | RegExp)[] {
+  if (!Array.isArray(input)) {
+    return makeIdFilterToMatchWithQueries(
+      // Array.isArray cannot narrow the type
+      // https://github.com/microsoft/TypeScript/issues/17002
+      input as Exclude<typeof input, readonly unknown[]>,
+    );
+  }
+  return input.map((i) => makeIdFilterToMatchWithQueries(i));
+}
+
+function makeIdFilterToMatchWithQueries(
+  input: string | RegExp,
+): string | RegExp {
+  if (typeof input === 'string') {
+    return `${input}{?*,}`;
+  }
+  return makeRegexIdFilterToMatchWithQueries(input);
+}
+
+function makeRegexIdFilterToMatchWithQueries(input: RegExp) {
+  return new RegExp(
+    // replace `$` with `(?:\?.*)?$` (ignore `\$`)
+    input.source.replace(/(?<!\\)\$/g, '(?:\\?.*)?$'),
+    input.flags,
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,12 @@ importers:
 
   packages/pluginutils:
     devDependencies:
+      '@types/picomatch':
+        specifier: ^4.0.0
+        version: 4.0.0
+      picomatch:
+        specifier: ^4.0.2
+        version: 4.0.2
       vitest:
         specifier: ^3.0.1
         version: 3.0.9(@types/debug@4.1.12)(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
@@ -3600,6 +3606,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/picomatch@4.0.0':
+    resolution: {integrity: sha512-J1Bng+wlyEERWSgJQU1Pi0HObCLVcr994xT/M+1wcl/yNRTGBupsCxthgkdYG+GCOMaQH7iSVUY3LJVBBqG7MQ==}
 
   '@types/react-dom@19.0.4':
     resolution: {integrity: sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==}
@@ -9649,6 +9658,8 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/picomatch@4.0.0': {}
 
   '@types/react-dom@19.0.4(@types/react@19.0.12)':
     dependencies:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds `makeIdFiltersToMatchWithQuery` function to `@rolldown/pluginutils`.

This function is useful for codes like:
```js
const cleanId = cleanUrl(id)
if (filter(id) || filter(filepath)) {
  // process
}
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
