### PR TITLE
chore(pluginutils): exclude test files from build

### DIFF
--- a/packages/pluginutils/tsconfig.cjs.json
+++ b/packages/pluginutils/tsconfig.cjs.json
@@ -6,6 +6,6 @@
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.test-d.ts",
+    "**/*.test-d.ts"
   ]
 }

--- a/packages/pluginutils/tsconfig.cjs.json
+++ b/packages/pluginutils/tsconfig.cjs.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "module": "commonjs", /* Specify what module code is generated. */
     "outDir": "./dist/cjs" /* Specify an output folder for all emitted files. */
-  }
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test-d.ts",
+  ]
 }

--- a/packages/pluginutils/tsconfig.esm.json
+++ b/packages/pluginutils/tsconfig.esm.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "module": "ESNext", /* Specify what module code is generated. */
     "outDir": "./dist/esm" /* Specify an output folder for all emitted files. */
-  }
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test-d.ts",
+  ]
 }

--- a/packages/pluginutils/tsconfig.esm.json
+++ b/packages/pluginutils/tsconfig.esm.json
@@ -6,6 +6,6 @@
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.test-d.ts",
+    "**/*.test-d.ts"
   ]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I noticed that the `*.test.ts` and `*.test-d.ts` was included in `dist`. This PR excludes those file from build.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
