### PR TITLE
perf: enable Wasm 128bit SIMD Extension

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -47,4 +47,11 @@ rustflags = ["--cfg", "tracing_unstable"]
 rustflags = ["--cfg", "tracing_unstable"]
 
 [target.wasm32-wasip1-threads]
-rustflags = ["-C", "target-feature=+simd128", "--cfg", "tokio_unstable", "--cfg", "tracing_unstable"]
+rustflags = [
+  "-C",
+  "target-feature=+simd128",
+  "--cfg",
+  "tokio_unstable",
+  "--cfg",
+  "tracing_unstable",
+]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -47,4 +47,4 @@ rustflags = ["--cfg", "tracing_unstable"]
 rustflags = ["--cfg", "tracing_unstable"]
 
 [target.wasm32-wasip1-threads]
-rustflags = ["--cfg", "tokio_unstable", "--cfg", "tracing_unstable"]
+rustflags = ["-C", "target-feature=+simd128", "--cfg", "tokio_unstable", "--cfg", "tracing_unstable"]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds `-C target-feature=+simd128` flag for wasm compilation. This may improve perf in browsers.

The [Wasm 128bit SIMD Extension](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) is [supported by Chrome 91+, Firefox 89+, Safari 16.4+, Node 16.4+](https://webassembly.org/features/#:~:text=1.0.24-,Fixed%2Dwidth%20SIMD,-91). This should be supported widely enough.

The wasm build would probably no longer work on machines without 128 SIMD support. But I'm not sure if those are common. At least, I tested with iPad mini 5 and Pixel 6a and both supports it. If needed, we can use [`wasm-feature-detect`](https://github.com/GoogleChromeLabs/wasm-feature-detect) to fallback to a non-simd build.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
