### PR TITLE
perf(rename): reduce some string allocations

### DIFF
--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -153,7 +153,7 @@ impl<'name> Renamer<'name> {
             } else {
               let name = Rstr::from(candidate_name.as_ref());
               used_canonical_names_for_this_scope.insert(name.clone(), 0);
-              slot.insert(Rstr::from(name));
+              slot.insert(name);
               break;
             }
           },

--- a/crates/rolldown_rstr/src/lib.rs
+++ b/crates/rolldown_rstr/src/lib.rs
@@ -2,7 +2,7 @@
 //! - is meant to be a bundler-specialized string type for rolldown.
 //! - to smooth integration with `oxc`'s string types.
 
-use std::{fmt::Display, ops::Deref};
+use std::{borrow::Borrow, fmt::Display, ops::Deref};
 
 /// `OxcStr` is a alias of string type oxc used internally.
 pub type OxcStr = oxc::span::CompactStr;
@@ -62,5 +62,11 @@ impl AsRef<str> for Rstr {
 impl Display for Rstr {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     self.as_str().fmt(f)
+  }
+}
+
+impl Borrow<str> for Rstr {
+  fn borrow(&self) -> &str {
+    self.as_str()
   }
 }


### PR DESCRIPTION
While profiling I noticed some short lived string allocations

<img width="1855" alt="image" src="https://github.com/user-attachments/assets/6f294e7c-3388-42ae-8eaa-f2f52591ee45" />

The best I could do is reduce 1 allocation before testing for collision.