### PR TITLE
fix: `asset` ModuleType not available in TypeScript package

### DIFF
--- a/crates/rolldown_common/src/inner_bundler_options/types/module_type.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/module_type.rs
@@ -40,6 +40,8 @@ impl ModuleType {
       "dataurl" => Ok(Self::Dataurl),
       "binary" => Ok(Self::Binary),
       "empty" => Ok(Self::Empty),
+      "css" => Ok(Self::Css),
+      "asset" => Ok(Self::Asset),
       _ => Err(anyhow::format_err!("Unknown module type: {s}")),
     }
   }
@@ -58,6 +60,8 @@ impl ModuleType {
       "dataurl" => Self::Dataurl,
       "binary" => Self::Binary,
       "empty" => Self::Empty,
+      "css" => Self::Css,
+      "asset" => Self::Asset,
       _ => Self::Custom(s.as_ref().to_string()),
     }
   }

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -49,6 +49,7 @@ export type ModuleTypes = Record<
   | 'binary'
   | 'empty'
   | 'css'
+  | 'asset'
 >;
 
 export interface JsxOptions {

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -49,6 +49,7 @@ const ExternalSchema = v.union([
 const ModuleTypesSchema = v.record(
   v.string(),
   v.union([
+    v.literal('asset'),
     v.literal('base64'),
     v.literal('binary'),
     v.literal('css'),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes https://github.com/rolldown/rolldown/issues/4363

The Rust `ModuleType` enum and it's `impl`s were slightly misaligned, so fixed those as well.


### Context
I'm trying to migrate to `tsdown`, but need the custom loader support https://github.com/rolldown/tsdown/issues/162