### PR TITLE
chore(rolldown): `oxc-sourcemap` v3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6665c417b2aa1c426a7b142bcc0d2f47d9fee9e6f88610f054cfa7ce6623001e"
+checksum = "9cd7bb37974a2684a080d05b9c28460e1610c5ac5ef13f481a45179f458239cb"
 dependencies = [
  "base64-simd",
  "cfg-if",

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -362,7 +362,7 @@ impl PluginDriver {
       }
       // If sourcemap hasn't `sourcesContent`, using original code to fill it.
       if map.get_source_content(0).is_none_or(str::is_empty) {
-        map.set_source_contents(vec![original_code]);
+        map.set_source_contents(vec![Some(original_code)]);
       }
       Some(map)
     } else if let Some(code) = code {

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -67,7 +67,7 @@ pub fn collapse_sourcemaps(mut sourcemap_chain: Vec<&SourceMap>) -> SourceMap {
     first_map.get_names().map(Into::into).collect::<Vec<_>>(),
     None,
     first_map.get_sources().map(Into::into).collect::<Vec<_>>(),
-    first_map.get_source_contents().map(|x| x.map(Into::into).collect::<Vec<_>>()),
+    first_map.get_source_contents().map(|x| x.map(Into::into)).collect::<Vec<_>>(),
     tokens,
     None,
   )


### PR DESCRIPTION
closes #4327
