### PR TITLE
perf(rolldown): reduce size of `ModuleLoaderMsg` from 1472 to 24 bytes

### DIFF
--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -40,7 +40,7 @@ impl ExternalModuleTask {
       self
         .ctx
         .tx
-        .send(ModuleLoaderMsg::BuildErrors(errs.into_vec()))
+        .send(ModuleLoaderMsg::BuildErrors(errs.into_vec().into_boxed_slice()))
         .await
         .expect("Send should not fail");
     }
@@ -91,14 +91,14 @@ impl ExternalModuleTask {
       resolved_id.id.clone()
     };
     let legitimized_identifier_name = legitimize_identifier_name(&identifier_name);
-    let msg = ModuleLoaderMsg::ExternalModuleDone(ExternalModuleTaskResult {
+    let msg = ModuleLoaderMsg::ExternalModuleDone(Box::new(ExternalModuleTaskResult {
       idx: self.module_idx,
       id: resolved_id.id.clone(),
       name: file_name,
       identifier_name: legitimized_identifier_name.into(),
       side_effects: external_module_side_effects,
       need_renormalize_render_path,
-    });
+    }));
     // If the main thread is dead, nothing we can do to handle these send failures.
     let _ = self.ctx.tx.send(msg).await;
     Ok(())

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -310,7 +310,7 @@ impl ModuleLoader {
             resolved_deps,
             raw_import_records,
             warnings,
-          } = task_result;
+          } = *task_result;
           all_warnings.extend(warnings);
           let mut dynamic_import_rec_exports_usage = ecma_related
             .as_mut()
@@ -396,7 +396,7 @@ impl ModuleLoader {
             identifier_name,
             side_effects,
             need_renormalize_render_path,
-          } = task_result;
+          } = *task_result;
 
           self.symbol_ref_db.store_local_db(
             task_result.idx,
@@ -424,7 +424,7 @@ impl ModuleLoader {
             ast,
             raw_import_records,
             resolved_deps,
-          } = task_result;
+          } = *task_result;
           let mut import_records = IndexVec::with_capacity(raw_import_records.len());
 
           for (raw_rec, info) in raw_import_records.into_iter().zip(resolved_deps) {
@@ -474,7 +474,13 @@ impl ModuleLoader {
           self.remaining -= 1;
         }
         ModuleLoaderMsg::FetchModule(resolve_id) => {
-          self.try_spawn_new_task(resolve_id, None, false, None, Arc::clone(&user_defined_entries));
+          self.try_spawn_new_task(
+            *resolve_id,
+            None,
+            false,
+            None,
+            Arc::clone(&user_defined_entries),
+          );
         }
         ModuleLoaderMsg::AddEntryModule(msg) => {
           let data = msg.chunk;

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -89,7 +89,7 @@ impl ModuleTask {
       self
         .ctx
         .tx
-        .send(ModuleLoaderMsg::BuildErrors(errs.into_vec()))
+        .send(ModuleLoaderMsg::BuildErrors(errs.into_vec().into_boxed_slice()))
         .await
         .expect("Send should not fail");
     }
@@ -225,13 +225,13 @@ impl ModuleTask {
     self.ctx.plugin_driver.module_parsed(Arc::clone(&module_info), &module).await?;
     self.ctx.plugin_driver.mark_context_load_modules_loaded(&module.id, true).await?;
 
-    let result = ModuleLoaderMsg::NormalModuleDone(NormalModuleTaskResult {
+    let result = ModuleLoaderMsg::NormalModuleDone(Box::new(NormalModuleTaskResult {
       module: module.into(),
       ecma_related: Some(ecma_related),
       resolved_deps,
       raw_import_records,
       warnings,
-    });
+    }));
 
     // If the main thread is dead, nothing we can do to handle these send failures.
     let _ = self.ctx.tx.send(result).await;

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -40,7 +40,7 @@ impl RuntimeModuleTask {
     if let Err(errs) = self.run_inner() {
       self
         .tx
-        .try_send(ModuleLoaderMsg::BuildErrors(errs.into_vec()))
+        .try_send(ModuleLoaderMsg::BuildErrors(errs.into_vec().into_boxed_slice()))
         .expect("Send should not fail");
     }
   }
@@ -164,14 +164,14 @@ impl RuntimeModuleTask {
       .collect();
 
     let runtime = RuntimeModuleBrief::new(self.module_idx, &symbol_ref_db.ast_scopes);
-    let result = ModuleLoaderMsg::RuntimeNormalModuleDone(RuntimeModuleTaskResult {
+    let result = ModuleLoaderMsg::RuntimeNormalModuleDone(Box::new(RuntimeModuleTaskResult {
       ast,
       module,
       runtime,
       resolved_deps,
       raw_import_records,
       local_symbol_ref_db: symbol_ref_db,
-    });
+    }));
 
     // If the main thread is dead, nothing we can do to handle these send failures.
     let _ = self.tx.try_send(result);

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -91,7 +91,7 @@ impl FileEmitter {
     .context(
       "The `PluginContext.emitFile` with `type: 'chunk'` only work at `buildStart/resolveId/load/transform/moduleParsed` hooks.",
     )?
-    .send(ModuleLoaderMsg::AddEntryModule(AddEntryModuleMsg { chunk: Arc::clone(&chunk), reference_id: reference_id.clone() }))
+    .send(ModuleLoaderMsg::AddEntryModule(Box::new(AddEntryModuleMsg { chunk: Arc::clone(&chunk), reference_id: reference_id.clone() })))
     .await?;
     self.chunks.insert(reference_id.clone(), chunk);
     Ok(reference_id)

--- a/crates/rolldown_common/src/module_loader/mod.rs
+++ b/crates/rolldown_common/src/module_loader/mod.rs
@@ -12,12 +12,12 @@ pub mod runtime_task_result;
 pub mod task_result;
 
 pub enum ModuleLoaderMsg {
-  NormalModuleDone(NormalModuleTaskResult),
-  ExternalModuleDone(ExternalModuleTaskResult),
-  RuntimeNormalModuleDone(RuntimeModuleTaskResult),
-  FetchModule(ResolvedId),
-  AddEntryModule(AddEntryModuleMsg),
-  BuildErrors(Vec<BuildDiagnostic>),
+  NormalModuleDone(Box<NormalModuleTaskResult>),
+  ExternalModuleDone(Box<ExternalModuleTaskResult>),
+  RuntimeNormalModuleDone(Box<RuntimeModuleTaskResult>),
+  FetchModule(Box<ResolvedId>),
+  AddEntryModule(Box<AddEntryModuleMsg>),
+  BuildErrors(Box<[BuildDiagnostic]>),
 }
 
 pub struct AddEntryModuleMsg {

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -50,7 +50,7 @@ impl NativePluginContextImpl {
       guard.context("The `PluginContext.load` only work at `resolveId/load/transform/moduleParsed` hooks. If you using it at resolveId hook, please make sure it could not load the entry module.")?
     };
     sender
-      .send(ModuleLoaderMsg::FetchModule(ResolvedId {
+      .send(ModuleLoaderMsg::FetchModule(Box::new(ResolvedId {
         id: specifier.into(),
         ignored: false,
         module_def_format: ModuleDefFormat::Unknown,
@@ -59,7 +59,7 @@ impl NativePluginContextImpl {
         package_json: None,
         side_effects,
         is_external_without_side_effects: false,
-      }))
+      })))
       .await?;
     Ok(())
   }


### PR DESCRIPTION
Allocating 1472 bytes for every task is a bit too much ...