### PR TITLE
refactor(rolldown): add `const RUNTIME_MODULE_ID: ModuleId`

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -8,7 +8,7 @@ use oxc::{
   span::{GetSpan, Span},
 };
 use rolldown_common::{
-  EcmaModuleAstUsage, ImportKind, ImportRecordMeta, RUNTIME_MODULE_ID, StmtInfoMeta,
+  EcmaModuleAstUsage, ImportKind, ImportRecordMeta, RUNTIME_MODULE_KEY, StmtInfoMeta,
   ThisExprReplaceKind, dynamic_import_usage::DynamicImportExportsUsage,
   generate_replace_this_expr_map,
 };
@@ -320,7 +320,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
               _ => false,
             };
             // should not replace require in `runtime` code
-            if is_dummy_record && self.id.as_ref() != RUNTIME_MODULE_ID {
+            if is_dummy_record && self.id.as_ref() != RUNTIME_MODULE_KEY {
               let import_rec_idx = self.add_import_record(
                 "",
                 ImportKind::Require,

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -17,7 +17,7 @@ use rolldown_common::{
   DUMMY_MODULE_IDX, EcmaRelated, EntryPoint, EntryPointKind, ExternalModule,
   ExternalModuleTaskResult, HybridIndexVec, ImportKind, ImportRecordIdx, ImportRecordMeta,
   ImporterRecord, Module, ModuleId, ModuleIdx, ModuleLoaderMsg, ModuleType, NormalModuleTaskResult,
-  RUNTIME_MODULE_ID, ResolvedId, RuntimeModuleBrief, RuntimeModuleTaskResult, StmtInfoIdx,
+  RUNTIME_MODULE_KEY, ResolvedId, RuntimeModuleBrief, RuntimeModuleTaskResult, StmtInfoIdx,
   SymbolRefDb, SymbolRefDbForModule,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult};
@@ -155,7 +155,7 @@ impl ModuleLoader {
       IntermediateNormalModules::new(is_full_scan, std::mem::take(&mut cache.importers));
     let runtime_id = intermediate_normal_modules.alloc_ecma_module_idx();
 
-    let remaining = if cache.module_id_to_idx.contains_key(RUNTIME_MODULE_ID) {
+    let remaining = if cache.module_id_to_idx.contains_key(RUNTIME_MODULE_KEY) {
       // the first alloc just want to allocate the runtime module id
       intermediate_normal_modules.reset_ecma_module_idx();
       0
@@ -163,7 +163,7 @@ impl ModuleLoader {
       let task = RuntimeModuleTask::new(runtime_id, tx.clone(), Arc::clone(&options));
 
       tokio::spawn(async { task.run() });
-      cache.module_id_to_idx.insert(RUNTIME_MODULE_ID.into(), VisitState::Seen(runtime_id));
+      cache.module_id_to_idx.insert(RUNTIME_MODULE_KEY.into(), VisitState::Seen(runtime_id));
       1
     };
 

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -16,7 +16,7 @@ use sugar_path::SugarPath;
 
 use rolldown_common::{
   ImportKind, ImportRecordIdx, ImportRecordMeta, ModuleDefFormat, ModuleId, ModuleIdx, ModuleInfo,
-  ModuleLoaderMsg, ModuleType, NormalModule, NormalModuleTaskResult, RUNTIME_MODULE_ID,
+  ModuleLoaderMsg, ModuleType, NormalModule, NormalModuleTaskResult, RUNTIME_MODULE_KEY,
   RawImportRecord, ResolvedId, StrOrBytes,
 };
 use rolldown_error::{
@@ -307,7 +307,7 @@ impl ModuleTask {
     kind: ImportKind,
   ) -> anyhow::Result<Result<ResolvedId, ResolveError>> {
     // Check runtime module
-    if specifier == RUNTIME_MODULE_ID {
+    if specifier == RUNTIME_MODULE_KEY {
       return Ok(Ok(ResolvedId {
         id: specifier.into(),
         ignored: false,

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -3,11 +3,11 @@ use oxc::ast_visit::VisitMut;
 use oxc::span::SourceType;
 use oxc_index::IndexVec;
 use rolldown_common::{
-  EcmaView, EcmaViewMeta, ExportsKind, ModuleDefFormat, ModuleId, ModuleIdx, ModuleType,
-  NormalModule, side_effects::DeterminedSideEffects,
+  EcmaView, EcmaViewMeta, ExportsKind, ModuleDefFormat, ModuleIdx, ModuleType, NormalModule,
+  side_effects::DeterminedSideEffects,
 };
 use rolldown_common::{
-  ModuleLoaderMsg, Platform, RUNTIME_MODULE_ID, ResolvedId, RuntimeModuleBrief,
+  ModuleLoaderMsg, Platform, RUNTIME_MODULE_ID, RUNTIME_MODULE_KEY, ResolvedId, RuntimeModuleBrief,
   RuntimeModuleTaskResult, SharedNormalizedBundlerOptions,
 };
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
@@ -84,7 +84,7 @@ impl RuntimeModuleTask {
       ))
     };
 
-    let (ast, scan_result) = self.make_ecma_ast(RUNTIME_MODULE_ID, &source)?;
+    let (ast, scan_result) = self.make_ecma_ast(RUNTIME_MODULE_KEY, &source)?;
 
     let ScanResult {
       named_imports,
@@ -105,10 +105,10 @@ impl RuntimeModuleTask {
     let module = NormalModule {
       idx: self.module_idx,
       repr_name: "rolldown_runtime".to_string(),
-      stable_id: RUNTIME_MODULE_ID.to_string(),
-      id: ModuleId::new(RUNTIME_MODULE_ID),
+      stable_id: RUNTIME_MODULE_KEY.to_string(),
+      id: RUNTIME_MODULE_ID,
 
-      debug_id: RUNTIME_MODULE_ID.to_string(),
+      debug_id: RUNTIME_MODULE_KEY.to_string(),
       exec_order: u32::MAX,
       is_user_defined_entry: false,
       module_type: ModuleType::Js,
@@ -191,7 +191,7 @@ impl RuntimeModuleTask {
     });
 
     let scoping = ast.make_scoping();
-    let facade_path = ModuleId::new(RUNTIME_MODULE_ID);
+    let facade_path = RUNTIME_MODULE_ID;
     let scanner = AstScanner::new(
       self.module_idx,
       scoping,

--- a/crates/rolldown/src/utils/parse_to_ecma_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ecma_ast.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use arcstr::ArcStr;
 use oxc::{semantic::Scoping, span::SourceType as OxcSourceType};
-use rolldown_common::{ModuleType, NormalizedBundlerOptions, RUNTIME_MODULE_ID, StrOrBytes};
+use rolldown_common::{ModuleType, NormalizedBundlerOptions, RUNTIME_MODULE_KEY, StrOrBytes};
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_loader_utils::{binary_to_esm, text_to_string_literal};
@@ -133,7 +133,7 @@ fn pre_process_source(
     ModuleType::Binary => {
       let source = source.into_bytes();
       let encoded = rolldown_utils::base64::to_standard_base64(source);
-      binary_to_esm(&encoded, options.platform, RUNTIME_MODULE_ID)
+      binary_to_esm(&encoded, options.platform, RUNTIME_MODULE_KEY)
     }
     ModuleType::Empty => String::new(),
     ModuleType::Custom(custom_type) => {

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -96,7 +96,7 @@ pub use crate::{
   },
   module_loader::{
     AddEntryModuleMsg, ModuleLoaderMsg,
-    runtime_module_brief::{RUNTIME_MODULE_ID, RuntimeModuleBrief},
+    runtime_module_brief::{RUNTIME_MODULE_ID, RUNTIME_MODULE_KEY, RuntimeModuleBrief},
     runtime_task_result::RuntimeModuleTaskResult,
     task_result::{EcmaRelated, ExternalModuleTaskResult, NormalModuleTaskResult},
   },

--- a/crates/rolldown_common/src/module_loader/runtime_module_brief.rs
+++ b/crates/rolldown_common/src/module_loader/runtime_module_brief.rs
@@ -1,6 +1,10 @@
-use crate::{AstScopes, ModuleIdx, SymbolRef};
 use oxc::{semantic::SymbolId, span::CompactStr as CompactString};
 use rustc_hash::FxHashMap;
+
+use crate::{AstScopes, ModuleId, ModuleIdx, SymbolRef};
+
+pub const RUNTIME_MODULE_KEY: &str = "rolldown:runtime";
+pub const RUNTIME_MODULE_ID: ModuleId = ModuleId::new_arc_str(arcstr::literal!(RUNTIME_MODULE_KEY));
 
 #[derive(Debug, Clone)]
 pub struct RuntimeModuleBrief {
@@ -35,5 +39,3 @@ impl RuntimeModuleBrief {
     Self { id: ModuleIdx::new(0), name_to_symbol: FxHashMap::default() }
   }
 }
-
-pub static RUNTIME_MODULE_ID: &str = "rolldown:runtime";

--- a/crates/rolldown_common/src/types/module_id.rs
+++ b/crates/rolldown_common/src/types/module_id.rs
@@ -14,8 +14,14 @@ pub struct ModuleId {
 }
 
 impl ModuleId {
+  #[inline]
   pub fn new(value: impl Into<ArcStr>) -> Self {
-    Self { resource_id: value.into() }
+    Self::new_arc_str(value.into())
+  }
+
+  #[inline]
+  pub const fn new_arc_str(resource_id: ArcStr) -> Self {
+    Self { resource_id }
   }
 
   pub fn resource_id(&self) -> &ArcStr {


### PR DESCRIPTION
This PR adds

```rust
pub const RUNTIME_MODULE_KEY: &str = "rolldown:runtime";
pub const RUNTIME_MODULE_ID: ModuleId = ModuleId::new_arc_str(arcstr::literal!(RUNTIME_MODULE_KEY));
```

It's good practice to constify these things instead of creating them on the fly.