### PR TITLE
refactor(rust): explicitly ensure printing annotation comments

### DIFF
--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -102,6 +102,9 @@ impl EcmaCompiler {
         comments: is_print_full_comments,
         source_map_path: options.sourcemap.then(|| PathBuf::from(options.filename)),
         legal_comments,
+        // This option will be configurable when we begin to support `ignore-annotations`
+        // https://esbuild.github.io/api/#ignore-annotations
+        annotation_comments: true,
         ..CodegenOptions::default()
       })
       .build(ast.program())


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Referring to esbuild:

- Annotation comments has its own control option. It's not related to `legalComments` option.
- Since we don't support [`ignoreAnnotations`](https://esbuild.github.io/api/#ignore-annotations) option, we just simply print annotation comments always.

https://hyrious.me/esbuild-repl/?version=0.25.4&b=e%00entry.js%00%2F*+comments1+*%2F%0A%2F*+comments2+*%2F%0Afoo%3Bbar%3B%0A%0A%2F%2F%21+Legal+comments1%0A%2F*%21+Legal+comments2+*%2F%0Afoo%3Bbar%3B%0A%0A%2F*+comments+*%2F+foo%28a%2C+b%29%3B%0A%0Alet+pureExpression+%3D+%2F*+%40__PURE__+*%2F+inPureFunction%28%29%3B&o=--legal-comments%3Dnone

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
