### PR TITLE
fix(hmr): register cjs module exports

### DIFF
--- a/crates/rolldown/src/runtime/runtime-extra-dev.js
+++ b/crates/rolldown/src/runtime/runtime-extra-dev.js
@@ -88,11 +88,9 @@ class DevRuntime {
     this.moduleHotContextsToBeUpdated.clear()
     // swap new contexts
   }
-  registerModule(id, exports) {
-    console.debug('Registering module', id, exports);
-    this.modules[id] = {
-      exports,
-    }
+  registerModule(id, module) {
+    console.debug('Registering module', id, module);
+    this.modules[id] = module
   }
 
   loadExports(id) {

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -12,7 +12,7 @@ import assert from "node:assert";
 //#region lib.js
 var require_lib = __commonJS({ "lib.js"(exports, module) {
 	const lib_hot = __rolldown_runtime__.createModuleHotContext("lib.js");
-	__rolldown_runtime__.registerModule("lib.js", module.exports);
+	__rolldown_runtime__.registerModule("lib.js", module);
 	exports.a = 1;
 } });
 
@@ -21,7 +21,7 @@ var require_lib = __commonJS({ "lib.js"(exports, module) {
 var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.__toCommonJS(main_exports);
-__rolldown_runtime__.registerModule("main.js", main_exports);
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 var import_lib = __toESM(require_lib());
 assert.strictEqual(import_lib.a, 1);
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 //#region cjs.js
 var require_cjs = __commonJS({ "cjs.js"(exports, module) {
 	const cjs_hot = __rolldown_runtime__.createModuleHotContext("cjs.js");
-	__rolldown_runtime__.registerModule("cjs.js", module.exports);
+	__rolldown_runtime__.registerModule("cjs.js", module);
 	module.exports.value = "cjs";
 } });
 
@@ -20,7 +20,7 @@ var esm_exports = {};
 __export(esm_exports, { value: () => value });
 const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
 __rolldown_runtime__.__toCommonJS(esm_exports);
-__rolldown_runtime__.registerModule("esm.js", esm_exports);
+__rolldown_runtime__.registerModule("esm.js", { exports: esm_exports });
 const value = "main";
 
 //#endregion
@@ -28,7 +28,7 @@ const value = "main";
 var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.__toCommonJS(main_exports);
-__rolldown_runtime__.registerModule("main.js", main_exports);
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 var import_cjs = __toESM(require_cjs());
 console.log(import_cjs, esm_exports);
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4659,7 +4659,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-Dyyx3o7E.js
+- main-!~{000}~.js => main-DSnfptiJ.js
 
 # tests/rolldown/issues/4196
 
@@ -5204,13 +5204,13 @@ expression: output
 
 # tests/rolldown/topics/hmr/mutiply-entires
 
-- entry-!~{000}~.js => entry-CBZpKmcs.js
-- index-!~{001}~.js => index-Bx6GS1WH.js
-- chunk-!~{002}~.js => chunk-DCxEFtjL.js
+- entry-!~{000}~.js => entry-C-wenldj.js
+- index-!~{001}~.js => index-BDVb_WKl.js
+- chunk-!~{002}~.js => chunk-CW_H0o01.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-CkJjwhFU.js
+- main-!~{000}~.js => main-CMDi0hpF.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

``` .js
rolldown_runtime.registerModule("cjs.js", module.exports);
module.exports = {
  a: 1,
  b: 1,
}
```

Fix the case, using the module object to register.