### PR TITLE
fix: use correct `FileTemplate` when enable `preserve_modules`

### DIFF
--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -117,7 +117,9 @@ impl Chunk {
     options: &NormalizedBundlerOptions,
     rollup_pre_rendered_chunk: &RollupPreRenderedChunk,
   ) -> anyhow::Result<FilenameTemplate> {
+    // https://github.com/rollup/rollup/blob/061a0387c8654222620f602471d66afd3c582048/src/Chunk.ts?plain=1#L526-L529
     let ret = if matches!(self.kind, ChunkKind::EntryPoint { is_user_defined, .. } if is_user_defined)
+      || options.preserve_modules
     {
       options.entry_filenames.call(rollup_pre_rendered_chunk).await?
     } else {

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/_config.ts
@@ -12,15 +12,15 @@ export default defineTest({
   afterTest: (output) => {
     expect(output.output[0].fileName).toMatchInlineSnapshot(`"main.js"`);
     expect(output.output[0].code).toMatchInlineSnapshot(`
-      "import { a } from "./src/index-DGfmz2Yl.js";
-      import { lib } from "./lib-i3NB89bx.js";
+      "import { a } from "./src/index.js";
+      import { lib } from "./lib.js";
 
       //#region main.js
       console.log(lib, a);
 
       //#endregion"
     `);
-    expect(output.output[1].fileName).toMatchInlineSnapshot(`"lib-i3NB89bx.js"`);
+    expect(output.output[1].fileName).toMatchInlineSnapshot(`"lib.js"`);
     expect((output.output[1] as OutputChunk).code).toMatchInlineSnapshot(`
       "//#region lib.js
       const lib = "lib";
@@ -28,7 +28,7 @@ export default defineTest({
       //#endregion
       export { lib };"
     `)
-    expect(output.output[2].fileName).toMatchInlineSnapshot(`"src/index-DGfmz2Yl.js"`);
+    expect(output.output[2].fileName).toMatchInlineSnapshot(`"src/index.js"`);
     expect((output.output[2] as OutputChunk).code).toMatchInlineSnapshot(`
       "//#region src/index.js
       const a = 100;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
ref https://github.com/rollup/rollup/blob/061a0387c8654222620f602471d66afd3c582048/src/Chunk.ts?plain=1#L526-L529
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
