### PR TITLE
chore: always build `@rolldown/pluginutils` before build rolldown

### DIFF
--- a/justfile
+++ b/justfile
@@ -124,7 +124,7 @@ fix-repo:
     just fmt-repo
 
 # Support `just build [native|browser] [debug|release]`
-build target="native" mode="debug":
+build target="native" mode="debug": build-pluginutils
     pnpm run --filter rolldown build-{{ target }}:{{ mode }}
 
 _build-native-debug:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
