### PR TITLE
feat: make RolldownBuild.watchFiles to async

### DIFF
--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -98,13 +98,11 @@ impl Bundler {
     napi::bindgen_prelude::block_on(async { self.get_closed_impl().await })
   }
 
-  #[napi(getter)]
+  #[napi]
   #[tracing::instrument(level = "debug", skip_all)]
-  pub fn get_watch_files(&self) -> napi::Result<Vec<String>> {
-    napi::bindgen_prelude::block_on(async {
-      let bundler_core = self.inner.lock().await;
-      Ok(bundler_core.get_watch_files().iter().map(|s| s.to_string()).collect())
-    })
+  pub async fn get_watch_files(&self) -> napi::Result<Vec<String>> {
+    let bundler_core = self.inner.lock().await;
+    Ok(bundler_core.get_watch_files().iter().map(|s| s.to_string()).collect())
   }
 
   #[napi]

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -83,8 +83,11 @@ export class RolldownBuild {
     return this.#bundler?.bundler.hmrInvalidate(file, firstInvalidatedBy);
   }
 
-  get watchFiles(): string[] {
-    return this.#bundler?.bundler.watchFiles ?? [];
+  // TODO(underfin)
+  // The `watchFiles` return is a promise but rollup not.
+  // Making it to sync api maybe cause dead lock if the user call `write` and `watchFiles` at the same time.
+  get watchFiles(): Promise<string[]> {
+    return this.#bundler?.bundler.getWatchFiles() ?? Promise.resolve([]);
   }
 }
 

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -84,8 +84,8 @@ export class RolldownBuild {
   }
 
   // TODO(underfin)
-  // The `watchFiles` return is a promise but rollup not.
-  // Making it to sync api maybe cause dead lock if the user call `write` and `watchFiles` at the same time.
+  // The `watchFiles` method returns a promise, but Rollup does not.
+  // Converting it to a synchronous API might cause a deadlock if the user calls `write` and `watchFiles` simultaneously.
   get watchFiles(): Promise<string[]> {
     return this.#bundler?.bundler.getWatchFiles() ?? Promise.resolve([]);
   }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -165,7 +165,7 @@ export declare class Bundler {
   scan(): Promise<BindingOutputs>
   close(): Promise<void>
   get closed(): boolean
-  get watchFiles(): Array<string>
+  getWatchFiles(): Promise<Array<string>>
   generateHmrPatch(changedFiles: Array<string>): Promise<BindingHmrOutput>
   hmrInvalidate(file: string, firstInvalidatedBy?: string | undefined | null): Promise<BindingHmrOutput>
 }

--- a/packages/rolldown/tests/build-api/build-api.test.ts
+++ b/packages/rolldown/tests/build-api/build-api.test.ts
@@ -11,7 +11,7 @@ test('rolldown write twice', async () => {
     format: 'esm',
     entryFileNames: 'main.mjs',
   })
-  expect(bundle.watchFiles).toStrictEqual([path.join(import.meta.dirname, 'main.js')])
+  expect(await bundle.watchFiles).toStrictEqual([path.join(import.meta.dirname, 'main.js')])
   expect(esmOutput.output[0].fileName).toBe('main.mjs')
   expect(esmOutput.output[0].code).toBeDefined()
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Making it to sync api maybe cause dead lock if the user call `write` and `watchFiles` at the same time, so here using async for it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
