### PR TITLE
chore(test): avoid invalid code on windows

### DIFF
--- a/crates/rolldown_std_utils/src/path_ext.rs
+++ b/crates/rolldown_std_utils/src/path_ext.rs
@@ -77,7 +77,9 @@ fn test_representative_file_name() {
   let path = cwd.join("vue").join("mod.ts");
   assert_eq!(path.representative_file_name(false), "vue");
 
-  let path = cwd.join("src").join("vue.js");
   #[cfg(not(target_os = "windows"))]
-  assert_eq!(path.representative_file_name(true), "./project/src/vue");
+  {
+    let path = cwd.join("src").join("vue.js");
+    assert_eq!(path.representative_file_name(true), "./project/src/vue");
+  }
 }

--- a/crates/rolldown_utils/src/commondir.rs
+++ b/crates/rolldown_utils/src/commondir.rs
@@ -52,18 +52,17 @@ mod tests {
 
   #[test]
   fn test_extract_longest_common_path() {
-    let path1 = "/home/user/documents/report.txt";
-    let path2 = "/home/user/pictures/image.jpg";
-    let path3 = "/home/user/documents/presentation.pdf";
-    let path4 = "/home/user";
-    let path5 = "/home/user/documents";
-    let path6 = "/usr/local/bin";
-    let path7 = "/usr/local";
-    let path8 = "/";
-    let path9 = "/";
-
     #[cfg(not(windows))]
     {
+      let path1 = "/home/user/documents/report.txt";
+      let path2 = "/home/user/pictures/image.jpg";
+      let path3 = "/home/user/documents/presentation.pdf";
+      let path4 = "/home/user";
+      let path5 = "/home/user/documents";
+      let path6 = "/usr/local/bin";
+      let path7 = "/usr/local";
+      let path8 = "/";
+      let path9 = "/";
       assert_eq!(extract_longest_common_path(path1, path2), "/home/user");
       assert_eq!(extract_longest_common_path(path1, path3), "/home/user/documents");
       assert_eq!(extract_longest_common_path(path4, path5), "/home/user");


### PR DESCRIPTION
### Description

```bash
[<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
](error: unused variable: `path`
  --> crates\rolldown_std_utils\src\path_ext.rs:80:7
   |
80 |   let path = cwd.join("src").join("vue.js");
   |       ^^^^ help: if this is intentional, prefix it with an underscore: `_path`
   |
   = note: `-D unused-variables` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_variables)]`)
```