### PR TITLE
feat: better error message for `manualChunks`

### DIFF
--- a/packages/rolldown/src/cli/arguments/index.ts
+++ b/packages/rolldown/src/cli/arguments/index.ts
@@ -27,7 +27,9 @@ export const options: {
     description: string;
   };
 } = Object.fromEntries(
-  Object.entries(flattenedSchema).map(([key, schema]) => {
+  Object.entries(flattenedSchema).filter(([_key, schema]) =>
+    getSchemaType(schema) !== 'never'
+  ).map(([key, schema]) => {
     const config = Object.getOwnPropertyDescriptor(alias, key)?.value as
       | OptionConfig
       | undefined;

--- a/packages/rolldown/src/cli/arguments/utils.ts
+++ b/packages/rolldown/src/cli/arguments/utils.ts
@@ -1,6 +1,12 @@
 import type { Schema } from '../../types/schema';
 
-type SchemaType = 'string' | 'boolean' | 'object' | 'number' | 'array' | 'never';
+type SchemaType =
+  | 'string'
+  | 'boolean'
+  | 'object'
+  | 'number'
+  | 'array'
+  | 'never';
 
 const priority: SchemaType[] = [
   'object',

--- a/packages/rolldown/src/cli/arguments/utils.ts
+++ b/packages/rolldown/src/cli/arguments/utils.ts
@@ -1,6 +1,6 @@
 import type { Schema } from '../../types/schema';
 
-type SchemaType = 'string' | 'boolean' | 'object' | 'number' | 'array';
+type SchemaType = 'string' | 'boolean' | 'object' | 'number' | 'array' | 'never';
 
 const priority: SchemaType[] = [
   'object',
@@ -32,7 +32,7 @@ export function getSchemaType(schema: Schema): SchemaType {
     return typeof schema.const as SchemaType;
   }
 
-  return 'object';
+  return 'never';
 }
 
 export function flattenSchema(

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -865,5 +865,8 @@ export function getOutputCliKeys(): string[] {
 }
 
 export function getJsonSchema(): ObjectSchema {
-  return toJsonSchema(CliOptionsSchema) as ObjectSchema;
+  // errorMode: 'ignore' is set to ignore `never` schema
+  // there's no way to surpress the error one-by-one
+  // https://github.com/fabian-hiller/valibot/issues/1062
+  return toJsonSchema(CliOptionsSchema, { errorMode: 'ignore' }) as ObjectSchema;
 }

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -865,10 +865,10 @@ export function getOutputCliKeys(): string[] {
 }
 
 export function getJsonSchema(): ObjectSchema {
-  // errorMode: 'ignore' is set to ignore `never` schema
-  // there's no way to surpress the error one-by-one
-  // https://github.com/fabian-hiller/valibot/issues/1062
   return toJsonSchema(CliOptionsSchema, {
+    // errorMode: 'ignore' is set to ignore `never` schema
+    // there's no way to suppress the error one-by-one
+    // https://github.com/fabian-hiller/valibot/issues/1062
     errorMode: 'ignore',
   }) as ObjectSchema;
 }

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -643,6 +643,9 @@ const OutputOptionsSchema = v.strictObject({
     v.optional(v.boolean()),
     v.description('Inline dynamic imports'),
   ),
+  manualChunks: v.optional(
+    v.never('manualChunks is not supported. Please use advancedChunks instead'),
+  ),
   advancedChunks: v.optional(AdvancedChunksSchema),
   comments: v.pipe(
     v.optional(v.union([v.literal('none'), v.literal('preserve-legal')])),

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -868,5 +868,7 @@ export function getJsonSchema(): ObjectSchema {
   // errorMode: 'ignore' is set to ignore `never` schema
   // there's no way to surpress the error one-by-one
   // https://github.com/fabian-hiller/valibot/issues/1062
-  return toJsonSchema(CliOptionsSchema, { errorMode: 'ignore' }) as ObjectSchema;
+  return toJsonSchema(CliOptionsSchema, {
+    errorMode: 'ignore',
+  }) as ObjectSchema;
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR makes the following error message to be output if `ouput.manualChunks` was specified.

> manualChunks is not supported. Please use advancedChunks instead

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
