### PR TITLE
docs: check for document existence

### DIFF
--- a/docs/.vitepress/theme/components/RolldownVideoModal.vue
+++ b/docs/.vitepress/theme/components/RolldownVideoModal.vue
@@ -10,9 +10,12 @@ const isModalVisible = ref(false);
 
 // Scroll lock
 watch(isModalVisible, (value) => {
-  value
-    ? (document.documentElement.style.overflow = 'hidden')
-    : (document.documentElement.style.overflow = 'auto');
+  if(typeof document === 'undefined') {
+    return
+  }
+
+  const newOverflowValue = value ? 'hidden' : 'auto';
+  document.documentElement.style.overflow = newOverflowValue;
 },
   { immediate: true }
 );


### PR DESCRIPTION
Removes a doc build-time error where `document` is undefined (as the scrol llock watcher is triggered during SSR)