### PR TITLE
perf: reduce wasm release binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,8 @@ debug = true
 inherits = "release"
 
 [profile.release-wasi]
-codegen-units = 16
-debug = 'full'
 inherits = "release"
-lto = "thin"
 opt-level = "s"
-strip = "none"
 
 [workspace.lints.clippy]
 # Guidelines


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR reduces the wasm binary size by tweaking some build options. I guess these were not set to iterate the initial build setup, but we can set it now.

- Original: 9.7MB
- + lto='thin' => lto=true: 8.3MB
- + codegen-units=16 => codegen-units=1: 7.9MB
- + debug='full' => debug=false: 7.9MB
- + strip='none' => strip='symbols': 7.9MB

The `debug` and `strip` did not change the binary size. The output binary did not include debug information, so maybe it is stripped by napi-rs.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
