### PR TITLE
fix(node): add `type` property to `RenderedChunk`

### DIFF
--- a/packages/rolldown/src/types/rolldown-output.ts
+++ b/packages/rolldown/src/types/rolldown-output.ts
@@ -33,6 +33,7 @@ export interface RenderedModule {
 }
 
 export interface RenderedChunk extends Omit<BindingRenderedChunk, 'modules'> {
+  type: 'chunk';
   modules: {
     [id: string]: RenderedModule;
   };

--- a/packages/rolldown/src/utils/transform-rendered-chunk.ts
+++ b/packages/rolldown/src/utils/transform-rendered-chunk.ts
@@ -7,6 +7,7 @@ export function transformRenderedChunk(
 ): RenderedChunk {
   let modules: null | RenderedChunk['modules'] = null;
   return {
+    type: 'chunk',
     get name() {
       return chunk.name;
     },

--- a/packages/rolldown/tests/fixtures/plugin/render-chunk/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/render-chunk/basic/_config.ts
@@ -21,6 +21,7 @@ export default defineTest({
           testChunk(meta.chunks['main.js'])
 
           function testChunk(chunk: RenderedChunk) {
+            expect(chunk.type).toBe('chunk')
             expect(chunk.name).toBe('main')
             expect(chunk.fileName).toBe('main.js')
             expect(chunk.isEntry).toBe(true)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR adds the missing `type` property to `RenderedChunk` that exists in rollup.
https://github.com/rollup/rollup/blob/7536ffb3149ad4aa7cda4e7ef343e5376e2392e1/src/rollup/types.d.ts#L933

reported at https://github.com/vuejs/vitepress/pull/4747#issuecomment-2879996354

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
