### PR TITLE
feat(types): allow rollup plugin to be assigned to `plugins` option

### DIFF
--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Type Check
         run: pnpm type-check
 
+      - name: Node Type Test
+        run: |
+          pnpm run --filter rolldown-tests test:types
+
       - name: Setup Node20 For Testing
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -337,9 +337,15 @@ export type RolldownPlugin<A = any> =
   | BuiltinPlugin
   | ParallelPlugin;
 export type RolldownPluginOption<A = any> = MaybePromise<
-  NullValue<RolldownPlugin<A>> | false | RolldownPluginOption[]
+  | NullValue<RolldownPlugin<A>>
+  | { name: string } // for rollup plugin compatibility
+  | false
+  | RolldownPluginOption[]
 >;
 export type RolldownOutputPlugin = OutputPlugin | BuiltinPlugin;
 export type RolldownOutputPluginOption = MaybePromise<
-  NullValue<RolldownOutputPlugin> | false | RolldownOutputPluginOption[]
+  | NullValue<RolldownOutputPlugin>
+  | { name: string } // for rollup plugin compatibility
+  | false
+  | RolldownOutputPluginOption[]
 >;

--- a/packages/rolldown/src/utils/normalize-plugin-option.ts
+++ b/packages/rolldown/src/utils/normalize-plugin-option.ts
@@ -9,8 +9,8 @@ import type { RolldownOutputPlugin, RolldownPlugin } from '../plugin';
 import { asyncFlatten } from './async-flatten';
 
 export const normalizePluginOption: {
-  (plugins: InputOptions['plugins']): Promise<RolldownPlugin[]>;
   (plugins: OutputOptions['plugins']): Promise<RolldownOutputPlugin[]>;
+  (plugins: InputOptions['plugins']): Promise<RolldownPlugin[]>;
   (plugins: unknown): Promise<any[]>;
 } = async (plugins: any) => (await asyncFlatten([plugins])).filter(Boolean);
 

--- a/packages/rolldown/tests/package.json
+++ b/packages/rolldown/tests/package.json
@@ -7,6 +7,7 @@
     "test:main": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run --exclude '**/watch.test.ts' --reporter verbose --hideSkippedTests",
     "test:watcher": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run watch.test.ts --reporter verbose --hideSkippedTests",
     "test:stability": "node ./stability/issue-3453/src/build.mjs && node ./stability/issue-3453/verify.mjs",
+    "test:types": "vitest run --typecheck.only --reporter verbose --hideSkippedTests",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/rolldown/tests/rollup-compat.test-d.ts
+++ b/packages/rolldown/tests/rollup-compat.test-d.ts
@@ -1,0 +1,51 @@
+import { test, expectTypeOf, describe } from 'vitest'
+import type { Plugin as RollupPlugin } from 'rollup'
+import { defineConfig, type InputOptions, type OutputOptions, type Plugin as RolldownRawPlugin } from 'rolldown'
+
+describe('plugin type compatibility', () => {
+  type PluginsOption = InputOptions['plugins']
+  type OutputPluginsOption = OutputOptions['plugins']
+
+  test('can assign rollup plugins to `plugins` option', () => {
+    const rollupPluginInstance = undefined as unknown as RollupPlugin
+    expectTypeOf(rollupPluginInstance).toExtend<PluginsOption>()
+
+    // this should not error
+    defineConfig({
+      plugins: [rollupPluginInstance]
+    })
+  })
+
+  test('can assign rollup plugins to `output.plugins` option', () => {
+    const rollupPluginInstance = undefined as unknown as RollupPlugin
+    expectTypeOf(rollupPluginInstance).toExtend<OutputPluginsOption>()
+
+    // this should not error
+    defineConfig({
+      output: {
+        plugins: [rollupPluginInstance]
+      }
+    })
+  })
+
+  test('input suggestions for hooks works', () => {
+    const plugin: PluginsOption = {
+      name: 'test',
+
+      // ^ input suggestion should work here
+    }
+    expectTypeOf(plugin).toEqualTypeOf<RolldownRawPlugin | { name: string }>()
+
+    const buildS = undefined
+    // @ts-expect-error -- only known properties should be allowed
+    defineConfig({
+      plugins: [
+        {
+          name: 'test',
+          buildS
+          //    ^ input suggestion should work here
+        }
+      ]
+    })
+  })
+})

--- a/packages/rolldown/tests/tsconfig.json
+++ b/packages/rolldown/tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
-  "include": ["src/*", "src/**/*", "**/_config.ts", "**/*.test.ts"],
+  "include": ["src/*", "src/**/*", "**/_config.ts", "**/*.test.ts", "**/*.test-d.ts"],
   "compilerOptions": {
     "types": ["node", "vite/client"],
     "rootDir": "./",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently passing a rollup plugin to `plugins` option errors when rollup exists in `node_modules`.
https://stackblitz.com/edit/github-nci4o6nk-ezmf7asi?file=rolldown.config.ts

This PR fixes that error by adding `{ name: string }` to `RolldownPluginOption`.

refs https://github.com/vitejs/rolldown-vite/issues/117


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
