### PR TITLE
refactor(rolldown_binding): move and split `binding_js_or_regex`

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
@@ -7,8 +7,8 @@ use rolldown::{InnerOptions, ModuleSideEffects, ModuleSideEffectsRule};
 use rolldown_utils::js_regex::HybridRegex;
 
 use crate::{
-  options::plugin::types::binding_js_or_regex::JsRegExp,
   types::js_callback::{JsCallback, JsCallbackExt},
+  types::js_regex::JsRegExp,
 };
 
 pub type BindingModuleSideEffects = Either3<

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_watch_option.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_watch_option.rs
@@ -1,4 +1,4 @@
-use crate::options::plugin::types::binding_js_or_regex::{
+use crate::types::binding_string_or_regex::{
   BindingStringOrRegex, bindingify_string_or_regex_array,
 };
 

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_advanced_chunks_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_advanced_chunks_options.rs
@@ -1,4 +1,4 @@
-use crate::options::plugin::types::binding_js_or_regex::BindingStringOrRegex;
+use crate::types::binding_string_or_regex::BindingStringOrRegex;
 
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Debug)]

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -33,13 +33,16 @@ use rustc_hash::{FxBuildHasher, FxHashSet};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::types::binding_builtin_plugin_name::BindingBuiltinPluginName;
-use super::types::binding_js_or_regex::{BindingStringOrRegex, bindingify_string_or_regex_array};
-use super::types::binding_limited_boolean::BindingTrueValue;
-use super::types::binding_module_federation_plugin_option::BindingModuleFederationPluginOption;
+use crate::types::binding_string_or_regex::{
+  BindingStringOrRegex, bindingify_string_or_regex_array,
+};
 use crate::types::js_callback::{
   JsCallback, JsCallbackExt, MaybeAsyncJsCallback, MaybeAsyncJsCallbackExt,
 };
+
+use super::types::binding_builtin_plugin_name::BindingBuiltinPluginName;
+use super::types::binding_limited_boolean::BindingTrueValue;
+use super::types::binding_module_federation_plugin_option::BindingModuleFederationPluginOption;
 
 #[allow(clippy::pub_underscore_fields)]
 #[napi(object)]

--- a/crates/rolldown_binding/src/options/plugin/types/binding_filter_expression.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_filter_expression.rs
@@ -7,7 +7,7 @@ use rolldown_utils::{
   filter_expression::Token, js_regex::HybridRegex, pattern_filter::StringOrRegex,
 };
 
-use super::binding_js_or_regex::JsRegExp;
+use crate::types::js_regex::JsRegExp;
 
 #[derive(Debug, Clone)]
 pub enum BindingFilterTokenPayloadInner {

--- a/crates/rolldown_binding/src/options/plugin/types/mod.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/mod.rs
@@ -10,7 +10,6 @@ pub mod binding_hook_resolve_id_extra_args;
 pub mod binding_hook_resolve_id_output;
 pub mod binding_hook_side_effects;
 pub mod binding_hook_transform_output;
-pub mod binding_js_or_regex;
 pub mod binding_limited_boolean;
 pub mod binding_module_federation_plugin_option;
 pub mod binding_module_type;

--- a/crates/rolldown_binding/src/types/binding_string_or_regex.rs
+++ b/crates/rolldown_binding/src/types/binding_string_or_regex.rs
@@ -1,58 +1,11 @@
 use std::fmt::Debug;
 
-use napi::{
-  Either, Env, Error, JsObject, JsUnknown, NapiValue, Status,
-  bindgen_prelude::{FromNapiValue, Function, TypeName, ValidateNapiValue},
-  sys,
-};
+use napi::{Either, bindgen_prelude::FromNapiValue, sys};
 
 use rolldown_utils::js_regex::HybridRegex;
 use rolldown_utils::pattern_filter::StringOrRegex;
 
-#[derive(Debug, Default, Clone)]
-pub struct JsRegExp {
-  pub source: String,
-  pub flags: String,
-}
-
-impl ValidateNapiValue for JsRegExp {}
-
-impl TypeName for JsRegExp {
-  fn type_name() -> &'static str {
-    "RegExp"
-  }
-
-  fn value_type() -> napi::ValueType {
-    napi::ValueType::Object
-  }
-}
-
-impl FromNapiValue for JsRegExp {
-  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
-    let js_object = unsafe { JsObject::from_raw_unchecked(env, napi_val) };
-
-    let env = Env::from(env);
-    let global = env.get_global()?;
-    let regexp_constructor = global.get_named_property::<Function<JsUnknown, ()>>("RegExp")?;
-
-    if js_object.instanceof(regexp_constructor)? {
-      let source = js_object.get_named_property::<String>("source")?;
-      let flags = js_object.get_named_property::<String>("flags")?;
-
-      Ok(JsRegExp { source, flags })
-    } else {
-      Err(Error::new(Status::ObjectExpected, "Expect a RegExp object"))
-    }
-  }
-}
-
-impl TryFrom<JsRegExp> for HybridRegex {
-  type Error = anyhow::Error;
-
-  fn try_from(value: JsRegExp) -> Result<Self, Self::Error> {
-    HybridRegex::with_flags(&value.source, &value.flags)
-  }
-}
+use super::js_regex::JsRegExp;
 
 #[derive(Debug, Clone)]
 pub struct BindingStringOrRegex(StringOrRegex);

--- a/crates/rolldown_binding/src/types/js_regex.rs
+++ b/crates/rolldown_binding/src/types/js_regex.rs
@@ -1,0 +1,54 @@
+use std::fmt::Debug;
+
+use napi::{
+  Env, Error, JsObject, JsUnknown, NapiValue, Status,
+  bindgen_prelude::{FromNapiValue, Function, TypeName, ValidateNapiValue},
+  sys,
+};
+
+use rolldown_utils::js_regex::HybridRegex;
+
+#[derive(Debug, Default, Clone)]
+pub struct JsRegExp {
+  pub source: String,
+  pub flags: String,
+}
+
+impl ValidateNapiValue for JsRegExp {}
+
+impl TypeName for JsRegExp {
+  fn type_name() -> &'static str {
+    "RegExp"
+  }
+
+  fn value_type() -> napi::ValueType {
+    napi::ValueType::Object
+  }
+}
+
+impl FromNapiValue for JsRegExp {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+    let js_object = unsafe { JsObject::from_raw_unchecked(env, napi_val) };
+
+    let env = Env::from(env);
+    let global = env.get_global()?;
+    let regexp_constructor = global.get_named_property::<Function<JsUnknown, ()>>("RegExp")?;
+
+    if js_object.instanceof(regexp_constructor)? {
+      let source = js_object.get_named_property::<String>("source")?;
+      let flags = js_object.get_named_property::<String>("flags")?;
+
+      Ok(JsRegExp { source, flags })
+    } else {
+      Err(Error::new(Status::ObjectExpected, "Expect a RegExp object"))
+    }
+  }
+}
+
+impl TryFrom<JsRegExp> for HybridRegex {
+  type Error = anyhow::Error;
+
+  fn try_from(value: JsRegExp) -> Result<Self, Self::Error> {
+    HybridRegex::with_flags(&value.source, &value.flags)
+  }
+}

--- a/crates/rolldown_binding/src/types/mod.rs
+++ b/crates/rolldown_binding/src/types/mod.rs
@@ -12,6 +12,8 @@ pub mod binding_rendered_module;
 pub mod binding_resolve_alias_item;
 pub mod binding_resolve_extension_alias;
 pub mod binding_sourcemap;
+pub mod binding_string_or_regex;
 pub mod binding_watcher_event;
 pub mod defer_sync_scan_data;
 pub mod js_callback;
+pub mod js_regex;


### PR DESCRIPTION
### Description

Related to #4577