### PR TITLE
refactor(rolldown_binding): split `binding_builtin_plugin`

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -22,10 +22,7 @@ use rolldown_plugin_module_preload_polyfill::ModulePreloadPolyfillPlugin;
 use rolldown_plugin_replace::{ReplaceOptions, ReplacePlugin};
 use rolldown_plugin_reporter::ReporterPlugin;
 use rolldown_plugin_transform::TransformPlugin;
-use rolldown_plugin_vite_resolve::{
-  FinalizeBareSpecifierCallback, FinalizeOtherSpecifiersCallback, ViteResolveOptions,
-  ViteResolvePlugin, ViteResolveResolveOptions,
-};
+use rolldown_plugin_vite_resolve::{ViteResolvePlugin, ViteResolveResolveOptions};
 use rolldown_plugin_wasm_fallback::WasmFallbackPlugin;
 use rolldown_plugin_wasm_helper::WasmHelperPlugin;
 use rolldown_plugin_web_worker_post::WebWorkerPostPlugin;
@@ -36,12 +33,10 @@ use std::sync::Arc;
 use crate::types::binding_string_or_regex::{
   BindingStringOrRegex, bindingify_string_or_regex_array,
 };
-use crate::types::js_callback::{
-  JsCallback, JsCallbackExt, MaybeAsyncJsCallback, MaybeAsyncJsCallbackExt,
-};
+use crate::types::js_callback::{MaybeAsyncJsCallback, MaybeAsyncJsCallbackExt};
 
+use super::config::BindingViteResolvePluginConfig;
 use super::types::binding_builtin_plugin_name::BindingBuiltinPluginName;
-use super::types::binding_limited_boolean::BindingTrueValue;
 use super::types::binding_module_federation_plugin_option::BindingModuleFederationPluginOption;
 
 #[allow(clippy::pub_underscore_fields)]
@@ -165,85 +160,6 @@ pub struct BindingBuildImportAnalysisPluginConfig {
   pub optimize_module_preload_relative_paths: bool,
   pub render_built_url: bool,
   pub is_relative_base: bool,
-}
-
-#[napi_derive::napi(object, object_to_js = false)]
-#[derive(Debug)]
-pub struct BindingViteResolvePluginConfig {
-  pub resolve_options: BindingViteResolvePluginResolveOptions,
-  pub environment_consumer: String,
-  pub environment_name: String,
-  pub builtins: Vec<BindingStringOrRegex>,
-  #[napi(ts_type = "true | string[]")]
-  pub external: napi::Either<BindingTrueValue, Vec<String>>,
-  #[napi(ts_type = "true | Array<string | RegExp>")]
-  pub no_external: napi::Either<BindingTrueValue, Vec<BindingStringOrRegex>>,
-  pub dedupe: Vec<String>,
-  #[debug("{}", if finalize_bare_specifier.is_some() { "Some(<finalize_bare_specifier>)" } else { "None" })]
-  #[napi(
-    ts_type = "(resolvedId: string, rawId: string, importer: string | null | undefined) => VoidNullable<string>"
-  )]
-  pub finalize_bare_specifier:
-    Option<JsCallback<FnArgs<(String, String, Option<String>)>, Option<String>>>,
-  #[debug("{}", if finalize_bare_specifier.is_some() { "Some(<finalize_other_specifiers>)" } else { "None" })]
-  #[napi(ts_type = "(resolvedId: string, rawId: string) => VoidNullable<string>")]
-  pub finalize_other_specifiers: Option<JsCallback<FnArgs<(String, String)>, Option<String>>>,
-}
-
-impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
-  fn from(value: BindingViteResolvePluginConfig) -> Self {
-    let external = match value.external {
-      napi::Either::A(_) => rolldown_plugin_vite_resolve::ResolveOptionsExternal::True,
-      napi::Either::B(v) => rolldown_plugin_vite_resolve::ResolveOptionsExternal::Vec(v),
-    };
-    let no_external = match value.no_external {
-      napi::Either::A(_) => rolldown_plugin_vite_resolve::ResolveOptionsNoExternal::new_true(),
-      napi::Either::B(v) => rolldown_plugin_vite_resolve::ResolveOptionsNoExternal::new_vec(
-        bindingify_string_or_regex_array(v),
-      ),
-    };
-
-    Self {
-      resolve_options: value.resolve_options.into(),
-      environment_consumer: value.environment_consumer,
-      environment_name: value.environment_name,
-      builtins: bindingify_string_or_regex_array(value.builtins),
-      external,
-      no_external,
-      dedupe: value.dedupe,
-      finalize_bare_specifier: value.finalize_bare_specifier.map(
-        |finalizer_fn| -> Arc<FinalizeBareSpecifierCallback> {
-          Arc::new(move |resolved_id: &str, raw_id: &str, importer: Option<&str>| {
-            let finalizer_fn = Arc::clone(&finalizer_fn);
-            let resolved_id = resolved_id.to_owned();
-            let raw_id = raw_id.to_owned();
-            let importer = importer.map(ToString::to_string);
-            Box::pin(async move {
-              finalizer_fn
-                .invoke_async((resolved_id, raw_id, importer).into())
-                .await
-                .map_err(anyhow::Error::from)
-            })
-          })
-        },
-      ),
-      finalize_other_specifiers: value.finalize_other_specifiers.map(
-        |finalizer_fn| -> Arc<FinalizeOtherSpecifiersCallback> {
-          Arc::new(move |resolved_id: &str, raw_id: &str| {
-            let finalizer_fn = Arc::clone(&finalizer_fn);
-            let resolved_id = resolved_id.to_owned();
-            let raw_id = raw_id.to_owned();
-            Box::pin(async move {
-              finalizer_fn
-                .invoke_async((resolved_id, raw_id).into())
-                .await
-                .map_err(anyhow::Error::from)
-            })
-          })
-        },
-      ),
-    }
-  }
 }
 
 #[napi_derive::napi(object)]

--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
@@ -1,0 +1,97 @@
+use derive_more::Debug;
+use std::sync::Arc;
+
+use napi::bindgen_prelude::FnArgs;
+use rolldown_plugin_vite_resolve::{
+  FinalizeBareSpecifierCallback, FinalizeOtherSpecifiersCallback, ViteResolveOptions,
+};
+
+use crate::{
+  options::plugin::{
+    binding_builtin_plugin::BindingViteResolvePluginResolveOptions,
+    types::binding_limited_boolean::BindingTrueValue,
+  },
+  types::{
+    binding_string_or_regex::{BindingStringOrRegex, bindingify_string_or_regex_array},
+    js_callback::{JsCallback, JsCallbackExt as _},
+  },
+};
+
+#[napi_derive::napi(object, object_to_js = false)]
+#[derive(Debug)]
+pub struct BindingViteResolvePluginConfig {
+  pub resolve_options: BindingViteResolvePluginResolveOptions,
+  pub environment_consumer: String,
+  pub environment_name: String,
+  pub builtins: Vec<BindingStringOrRegex>,
+  #[napi(ts_type = "true | string[]")]
+  pub external: napi::Either<BindingTrueValue, Vec<String>>,
+  #[napi(ts_type = "true | Array<string | RegExp>")]
+  pub no_external: napi::Either<BindingTrueValue, Vec<BindingStringOrRegex>>,
+  pub dedupe: Vec<String>,
+  #[debug("{}", if finalize_bare_specifier.is_some() { "Some(<finalize_bare_specifier>)" } else { "None" })]
+  #[napi(
+    ts_type = "(resolvedId: string, rawId: string, importer: string | null | undefined) => VoidNullable<string>"
+  )]
+  pub finalize_bare_specifier:
+    Option<JsCallback<FnArgs<(String, String, Option<String>)>, Option<String>>>,
+  #[debug("{}", if finalize_bare_specifier.is_some() { "Some(<finalize_other_specifiers>)" } else { "None" })]
+  #[napi(ts_type = "(resolvedId: string, rawId: string) => VoidNullable<string>")]
+  pub finalize_other_specifiers: Option<JsCallback<FnArgs<(String, String)>, Option<String>>>,
+}
+
+impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
+  fn from(value: BindingViteResolvePluginConfig) -> Self {
+    let external = match value.external {
+      napi::Either::A(_) => rolldown_plugin_vite_resolve::ResolveOptionsExternal::True,
+      napi::Either::B(v) => rolldown_plugin_vite_resolve::ResolveOptionsExternal::Vec(v),
+    };
+    let no_external = match value.no_external {
+      napi::Either::A(_) => rolldown_plugin_vite_resolve::ResolveOptionsNoExternal::new_true(),
+      napi::Either::B(v) => rolldown_plugin_vite_resolve::ResolveOptionsNoExternal::new_vec(
+        bindingify_string_or_regex_array(v),
+      ),
+    };
+
+    Self {
+      resolve_options: value.resolve_options.into(),
+      environment_consumer: value.environment_consumer,
+      environment_name: value.environment_name,
+      builtins: bindingify_string_or_regex_array(value.builtins),
+      external,
+      no_external,
+      dedupe: value.dedupe,
+      finalize_bare_specifier: value.finalize_bare_specifier.map(
+        |finalizer_fn| -> Arc<FinalizeBareSpecifierCallback> {
+          Arc::new(move |resolved_id: &str, raw_id: &str, importer: Option<&str>| {
+            let finalizer_fn = Arc::clone(&finalizer_fn);
+            let resolved_id = resolved_id.to_owned();
+            let raw_id = raw_id.to_owned();
+            let importer = importer.map(ToString::to_string);
+            Box::pin(async move {
+              finalizer_fn
+                .invoke_async((resolved_id, raw_id, importer).into())
+                .await
+                .map_err(anyhow::Error::from)
+            })
+          })
+        },
+      ),
+      finalize_other_specifiers: value.finalize_other_specifiers.map(
+        |finalizer_fn| -> Arc<FinalizeOtherSpecifiersCallback> {
+          Arc::new(move |resolved_id: &str, raw_id: &str| {
+            let finalizer_fn = Arc::clone(&finalizer_fn);
+            let resolved_id = resolved_id.to_owned();
+            let raw_id = raw_id.to_owned();
+            Box::pin(async move {
+              finalizer_fn
+                .invoke_async((resolved_id, raw_id).into())
+                .await
+                .map_err(anyhow::Error::from)
+            })
+          })
+        },
+      ),
+    }
+  }
+}

--- a/crates/rolldown_binding/src/options/plugin/config/mod.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/mod.rs
@@ -1,0 +1,3 @@
+mod binding_vite_resolve_plugin_config;
+
+pub use binding_vite_resolve_plugin_config::BindingViteResolvePluginConfig;

--- a/crates/rolldown_binding/src/options/plugin/mod.rs
+++ b/crates/rolldown_binding/src/options/plugin/mod.rs
@@ -1,14 +1,16 @@
-pub mod binding_plugin_context;
+mod binding_builtin_plugin;
+mod binding_callable_builtin_plugin;
+mod binding_plugin_hook_meta;
 mod binding_plugin_options;
 mod binding_transform_context;
+mod config;
 mod js_plugin;
+
+pub mod binding_plugin_context;
 pub mod types;
 
 pub use binding_plugin_options::*;
 pub use js_plugin::*;
-mod binding_builtin_plugin;
-mod binding_callable_builtin_plugin;
-mod binding_plugin_hook_meta;
 
 #[cfg(not(target_family = "wasm"))]
 mod parallel_js_plugin;


### PR DESCRIPTION
### Description

Related to #4577

If you think this structural arrangement works, I’ll split all the config structs in the next PR.