### PR TITLE
refactor(rolldown_binding): split `binding_builtin_plugin`

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -35,6 +35,8 @@ use crate::types::binding_string_or_regex::{
 };
 use crate::types::js_callback::{MaybeAsyncJsCallback, MaybeAsyncJsCallbackExt};
 
+use super::config::BindingImportGlobPluginConfig;
+use super::config::BindingReporterPluginConfig;
 use super::config::BindingViteResolvePluginConfig;
 use super::types::binding_builtin_plugin_name::BindingBuiltinPluginName;
 use super::types::binding_module_federation_plugin_option::BindingModuleFederationPluginOption;
@@ -53,22 +55,6 @@ impl std::fmt::Debug for BindingBuiltinPlugin {
       .field("name", &self.__name)
       .field("options", &"<JsUnknown>")
       .finish()
-  }
-}
-
-#[napi_derive::napi(object)]
-#[derive(Debug, Default)]
-pub struct BindingGlobImportPluginConfig {
-  pub root: Option<String>,
-  pub restore_query_extension: Option<bool>,
-}
-
-impl From<BindingGlobImportPluginConfig> for ImportGlobPluginConfig {
-  fn from(value: BindingGlobImportPluginConfig) -> Self {
-    ImportGlobPluginConfig {
-      root: value.root,
-      restore_query_extension: value.restore_query_extension.unwrap_or_default(),
-    }
   }
 }
 
@@ -414,7 +400,7 @@ impl TryFrom<BindingBuiltinPlugin> for Arc<dyn Pluginable> {
       }
       BindingBuiltinPluginName::ImportGlob => {
         let config = if let Some(options) = plugin.options {
-          BindingGlobImportPluginConfig::from_unknown(options)?.into()
+          BindingImportGlobPluginConfig::from_unknown(options)?.into()
         } else {
           ImportGlobPluginConfig::default()
         };
@@ -463,7 +449,7 @@ impl TryFrom<BindingBuiltinPlugin> for Arc<dyn Pluginable> {
       BindingBuiltinPluginName::ModulePreloadPolyfill => Arc::new(ModulePreloadPolyfillPlugin),
       BindingBuiltinPluginName::Report => {
         let plugin: ReporterPlugin = if let Some(options) = plugin.options {
-          BindingReportPluginConfig::from_unknown(options)?.into()
+          BindingReporterPluginConfig::from_unknown(options)?.into()
         } else {
           return Err(napi::Error::new(
             napi::Status::InvalidArg,
@@ -538,31 +524,6 @@ pub struct BindingReplacePluginConfig {
   pub prevent_assignment: Option<bool>,
   pub object_guards: Option<bool>,
   pub sourcemap: Option<bool>,
-}
-
-#[napi_derive::napi(object)]
-#[derive(Debug, Default)]
-#[allow(clippy::struct_excessive_bools)]
-pub struct BindingReportPluginConfig {
-  pub is_tty: bool,
-  pub is_lib: bool,
-  pub assets_dir: String,
-  pub chunk_limit: u32,
-  pub should_log_info: bool,
-  pub report_compressed_size: bool,
-}
-
-impl From<BindingReportPluginConfig> for ReporterPlugin {
-  fn from(config: BindingReportPluginConfig) -> Self {
-    ReporterPlugin::new(
-      config.is_tty,
-      config.should_log_info,
-      config.chunk_limit as usize,
-      config.report_compressed_size,
-      config.assets_dir,
-      config.is_lib,
-    )
-  }
 }
 
 #[napi_derive::napi(object, object_to_js = false)]

--- a/crates/rolldown_binding/src/options/plugin/config/binding_import_glob_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_import_glob_plugin_config.rs
@@ -1,0 +1,17 @@
+use rolldown_plugin_import_glob::ImportGlobPluginConfig;
+
+#[napi_derive::napi(object)]
+#[derive(Debug, Default)]
+pub struct BindingImportGlobPluginConfig {
+  pub root: Option<String>,
+  pub restore_query_extension: Option<bool>,
+}
+
+impl From<BindingImportGlobPluginConfig> for ImportGlobPluginConfig {
+  fn from(value: BindingImportGlobPluginConfig) -> Self {
+    ImportGlobPluginConfig {
+      root: value.root,
+      restore_query_extension: value.restore_query_extension.unwrap_or_default(),
+    }
+  }
+}

--- a/crates/rolldown_binding/src/options/plugin/config/binding_reporter_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_reporter_plugin_config.rs
@@ -1,0 +1,26 @@
+use rolldown_plugin_reporter::ReporterPlugin;
+
+#[napi_derive::napi(object)]
+#[derive(Debug, Default)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct BindingReporterPluginConfig {
+  pub is_tty: bool,
+  pub is_lib: bool,
+  pub assets_dir: String,
+  pub chunk_limit: u32,
+  pub should_log_info: bool,
+  pub report_compressed_size: bool,
+}
+
+impl From<BindingReporterPluginConfig> for ReporterPlugin {
+  fn from(config: BindingReporterPluginConfig) -> Self {
+    ReporterPlugin::new(
+      config.is_tty,
+      config.should_log_info,
+      config.chunk_limit as usize,
+      config.report_compressed_size,
+      config.assets_dir,
+      config.is_lib,
+    )
+  }
+}

--- a/crates/rolldown_binding/src/options/plugin/config/mod.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/mod.rs
@@ -1,3 +1,7 @@
+mod binding_import_glob_plugin_config;
+mod binding_reporter_plugin_config;
 mod binding_vite_resolve_plugin_config;
 
+pub use binding_import_glob_plugin_config::BindingImportGlobPluginConfig;
+pub use binding_reporter_plugin_config::BindingReporterPluginConfig;
 pub use binding_vite_resolve_plugin_config::BindingViteResolvePluginConfig;

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -348,11 +348,6 @@ export interface BindingFilterToken {
   payload?: BindingStringOrRegex | number | boolean
 }
 
-export interface BindingGlobImportPluginConfig {
-  root?: string
-  restoreQueryExtension?: boolean
-}
-
 export interface BindingHmrBoundaryOutput {
   boundary: string
   acceptedVia: string
@@ -426,6 +421,11 @@ export interface BindingHookTransformOutput {
   sideEffects?: BindingHookSideEffects
   map?: BindingSourcemap
   moduleType?: string
+}
+
+export interface BindingImportGlobPluginConfig {
+  root?: string
+  restoreQueryExtension?: boolean
 }
 
 export interface BindingInjectImportNamed {
@@ -720,7 +720,7 @@ export interface BindingReplacePluginConfig {
   sourcemap?: boolean
 }
 
-export interface BindingReportPluginConfig {
+export interface BindingReporterPluginConfig {
   isTty: boolean
   isLib: boolean
   assetsDir: string

--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -4,7 +4,7 @@ import type {
   BindingBuildImportAnalysisPluginConfig,
   BindingBuiltinPluginName,
   BindingDynamicImportVarsPluginConfig,
-  BindingGlobImportPluginConfig,
+  BindingImportGlobPluginConfig,
   BindingIsolatedDeclarationPluginConfig,
   BindingJsonPluginConfig,
   BindingManifestPluginConfig,
@@ -12,7 +12,7 @@ import type {
   BindingModuleFederationPluginOption,
   BindingModulePreloadPolyfillPluginConfig,
   BindingRemote,
-  BindingReportPluginConfig,
+  BindingReporterPluginConfig,
   BindingViteResolvePluginConfig,
 } from '../binding';
 import { makeBuiltinPluginCallable } from './utils';
@@ -38,13 +38,13 @@ export function dynamicImportVarsPlugin(
 }
 
 export function importGlobPlugin(
-  config?: BindingGlobImportPluginConfig,
+  config?: BindingImportGlobPluginConfig,
 ): BuiltinPlugin {
   return new BuiltinPlugin('builtin:import-glob', config);
 }
 
 export function reportPlugin(
-  config?: BindingReportPluginConfig,
+  config?: BindingReporterPluginConfig,
 ): BuiltinPlugin {
   return new BuiltinPlugin('builtin:report', config);
 }


### PR DESCRIPTION
### Description

Related to #4577

This PR is submitted separately as it corrects the config name.