### PR TITLE
chore(rolldown_binding): remove unused `BindingModulePreloadPolyfillPluginConfig`

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -1,7 +1,10 @@
-use derive_more::Debug;
+use std::sync::Arc;
+
 use napi::JsUnknown;
 use napi::bindgen_prelude::FromNapiValue;
 use napi_derive::napi;
+use rustc_hash::FxHashSet;
+
 use rolldown_plugin::__inner::Pluginable;
 use rolldown_plugin_alias::AliasPlugin;
 use rolldown_plugin_asset::AssetPlugin;
@@ -22,23 +25,20 @@ use rolldown_plugin_vite_resolve::ViteResolvePlugin;
 use rolldown_plugin_wasm_fallback::WasmFallbackPlugin;
 use rolldown_plugin_wasm_helper::WasmHelperPlugin;
 use rolldown_plugin_web_worker_post::WebWorkerPostPlugin;
-use rustc_hash::FxHashSet;
-use std::sync::Arc;
 
-use super::config::BindingAliasPluginConfig;
-use super::config::BindingAssetPluginConfig;
-use super::config::BindingBuildImportAnalysisPluginConfig;
-use super::config::BindingDynamicImportVarsPluginConfig;
-use super::config::BindingImportGlobPluginConfig;
-use super::config::BindingIsolatedDeclarationPluginConfig;
-use super::config::BindingJsonPluginConfig;
-use super::config::BindingManifestPluginConfig;
-use super::config::BindingReplacePluginConfig;
-use super::config::BindingReporterPluginConfig;
-use super::config::BindingTransformPluginConfig;
-use super::config::BindingViteResolvePluginConfig;
-use super::types::binding_builtin_plugin_name::BindingBuiltinPluginName;
-use super::types::binding_module_federation_plugin_option::BindingModuleFederationPluginOption;
+use super::{
+  config::{
+    BindingAliasPluginConfig, BindingAssetPluginConfig, BindingBuildImportAnalysisPluginConfig,
+    BindingDynamicImportVarsPluginConfig, BindingImportGlobPluginConfig,
+    BindingIsolatedDeclarationPluginConfig, BindingJsonPluginConfig, BindingManifestPluginConfig,
+    BindingReplacePluginConfig, BindingReporterPluginConfig, BindingTransformPluginConfig,
+    BindingViteResolvePluginConfig,
+  },
+  types::{
+    binding_builtin_plugin_name::BindingBuiltinPluginName,
+    binding_module_federation_plugin_option::BindingModuleFederationPluginOption,
+  },
+};
 
 #[allow(clippy::pub_underscore_fields)]
 #[napi(object)]
@@ -55,12 +55,6 @@ impl std::fmt::Debug for BindingBuiltinPlugin {
       .field("options", &"<JsUnknown>")
       .finish()
   }
-}
-
-#[napi_derive::napi(object)]
-#[derive(Debug, Default)]
-pub struct BindingModulePreloadPolyfillPluginConfig {
-  pub skip: Option<bool>,
 }
 
 impl TryFrom<BindingBuiltinPlugin> for Arc<dyn Pluginable> {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -564,10 +564,6 @@ export interface BindingModuleFederationPluginOption {
   getPublicPath?: string
 }
 
-export interface BindingModulePreloadPolyfillPluginConfig {
-  skip?: boolean
-}
-
 export interface BindingModules {
   values: Array<BindingRenderedModule>
   keys: Array<string>

--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -9,7 +9,6 @@ import type {
   BindingManifestPluginConfig,
   BindingMfManifest,
   BindingModuleFederationPluginOption,
-  BindingModulePreloadPolyfillPluginConfig,
   BindingRemote,
   BindingReporterPluginConfig,
   BindingViteResolvePluginConfig,
@@ -24,10 +23,8 @@ export class BuiltinPlugin {
   ) {}
 }
 
-export function modulePreloadPolyfillPlugin(
-  config?: BindingModulePreloadPolyfillPluginConfig,
-): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:module-preload-polyfill', config);
+export function modulePreloadPolyfillPlugin(): BuiltinPlugin {
+  return new BuiltinPlugin('builtin:module-preload-polyfill');
 }
 
 export function dynamicImportVarsPlugin(


### PR DESCRIPTION
### Description

closes #4577