### PR TITLE
fix(rolldown_plugin_transform): use `or` instead of `xor` for `transformOptions.lang`

### DIFF
--- a/crates/rolldown_plugin_transform/src/utils.rs
+++ b/crates/rolldown_plugin_transform/src/utils.rs
@@ -69,7 +69,7 @@ impl TransformPlugin {
     let source_type = if is_jsx_refresh_lang {
       SourceType::mjs()
     } else {
-      match self.transform_options.lang.as_deref().xor(ext) {
+      match self.transform_options.lang.as_deref().or(ext) {
         Some("js" | "cjs" | "mjs") => SourceType::mjs(),
         Some("jsx") => SourceType::jsx(),
         Some("ts" | "cts" | "mts") => SourceType::ts(),


### PR DESCRIPTION
### Description

This is a mistake.