### PR TITLE
refactor: remove unused `force_tree_shaking` in `stmt_info`

### DIFF
--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -55,7 +55,6 @@ impl LinkStage<'_> {
             #[cfg(debug_assertions)]
             debug_label: None,
             meta: StmtInfoMeta::default(),
-            ..Default::default()
           };
           ecma_module.stmt_infos.add_stmt_info(stmt_info);
         });
@@ -100,7 +99,6 @@ impl LinkStage<'_> {
             #[cfg(debug_assertions)]
             debug_label: None,
             meta: StmtInfoMeta::default(),
-            ..Default::default()
           };
           ecma_module.stmt_infos.replace_namespace_stmt_info(namespace_stmt_info);
         }

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -136,16 +136,8 @@ fn include_module(ctx: &mut Context, module: &NormalModule) {
   } else {
     // Skip the first statement, which is the namespace object. It should be included only if it is used no matter
     // tree shaking is enabled or not.
-    module.stmt_infos.iter_enumerated().skip(1).for_each(|(stmt_info_id, stmt_info)| {
-      if stmt_info.force_tree_shaking {
-        if stmt_info.side_effect {
-          // If `force_tree_shaking` is true, the statement should be included either by itself due to having side effects
-          // or by other statements referencing it.
-          include_statement(ctx, module, stmt_info_id);
-        }
-      } else {
-        include_statement(ctx, module, stmt_info_id);
-      }
+    module.stmt_infos.iter_enumerated().skip(1).for_each(|(stmt_info_id, _)| {
+      include_statement(ctx, module, stmt_info_id);
     });
   }
 

--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -169,7 +169,6 @@ pub fn create_wrapper(
         #[cfg(debug_assertions)]
         debug_label: None,
         meta: StmtInfoMeta::default(),
-        ..Default::default()
       };
 
       linking_info.wrapper_stmt_info = Some(module.stmt_infos.add_stmt_info(stmt_info));
@@ -201,7 +200,6 @@ pub fn create_wrapper(
         #[cfg(debug_assertions)]
         debug_label: None,
         meta: StmtInfoMeta::default(),
-        ..Default::default()
       };
 
       linking_info.wrapper_stmt_info = Some(module.stmt_infos.add_stmt_info(stmt_info));

--- a/crates/rolldown_common/src/types/stmt_info.rs
+++ b/crates/rolldown_common/src/types/stmt_info.rs
@@ -101,7 +101,6 @@ pub struct StmtInfo {
   #[cfg(debug_assertions)]
   pub debug_label: Option<String>,
   pub meta: StmtInfoMeta,
-  pub force_tree_shaking: bool,
 }
 
 #[cfg(target_pointer_width = "64")]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. As you can see it always assigned to `false`, so just keep the then branch is enough
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
