### PR TITLE
feat(test): decorator and deconflict_exported_names

### DIFF
--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -120,6 +120,14 @@ describe('cli options for bundling', () => {
       expect(error.message).matchSnapshot()
     }
   })
+  
+
+  it('should handle nested options (from flat to deep cli options)', async () => {
+    const cwd = cliFixturesDir('cli-option-short-boolean')
+    const status = await $({ cwd })`rolldown index.ts -d dist --transform.decorators.legacy`
+    expect(status.exitCode).toBe(0)
+    expect(cleanStdout(status.stdout)).toMatchSnapshot()
+  })
 })
 
 describe('config', () => {

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -6,11 +6,32 @@ import nodePath from 'node:path'
 main()
 
 function main() {
-  const testConfigPaths = import.meta.glob<TestConfig>(
+  const fixtureTestConfigPaths = import.meta.glob<TestConfig>(
     './fixtures/**/_config.ts',
     { import: 'default', eager: true },
-  )
-  for (const [testConfigPath, testConfig] of Object.entries(testConfigPaths)) {
+  );
+  
+  const pluginTestConfigPaths = import.meta.glob<TestConfig>(
+    './fixtures/plugin/**/_config.ts',
+    { import: 'default', eager: true },
+  );
+  
+  const onlyFixtureTest = Object.entries(fixtureTestConfigPaths).filter(
+    ([_, testConfig]) => testConfig.only,
+  );
+  
+  const onlyPluginTest = Object.entries(pluginTestConfigPaths).filter(
+    ([_, testConfig]) => testConfig.only,
+  );
+  
+  let fixtureTests = Object.entries(fixtureTestConfigPaths);
+  let pluginTests = Object.entries(pluginTestConfigPaths);
+  if (onlyFixtureTest.length + onlyPluginTest.length > 0) {
+    fixtureTests = onlyFixtureTest;
+    pluginTests = onlyPluginTest;
+  }
+
+  for (const [testConfigPath, testConfig] of fixtureTests) {
     const dirPath = nodePath.dirname(testConfigPath)
     const testName = dirPath.replace('./fixtures/', '')
 
@@ -38,13 +59,8 @@ function main() {
     })
   }
 
-  const pluginTestConfigPaths = import.meta.glob<TestConfig>(
-    './fixtures/plugin/**/_config.ts',
-    { import: 'default', eager: true },
-  )
-  for (const [testConfigPath, testConfig] of Object.entries(
-    pluginTestConfigPaths,
-  )) {
+
+  for (const [testConfigPath, testConfig] of pluginTests) {
     const dirPath = nodePath.dirname(testConfigPath)
     const testName = dirPath.replace('./fixtures/', '')
 

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest'
+import { expect, test } from 'vitest'
 import type { TestConfig } from './src/types'
 import { InputOptions, OutputOptions, rolldown } from 'rolldown'
 import nodePath from 'node:path'

--- a/packages/rolldown/tests/fixtures/misc/keep-names/aliased_class/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/keep-names/aliased_class/_config.ts
@@ -2,13 +2,10 @@ import { defineTest } from 'rolldown-tests'
 
 export default defineTest({
   config: {
-    input: 'main.ts',
     keepNames: true,
-    resolve: {
-      tsconfigFilename: 'tsconfig.json',
-    },
+    external: ['node:assert'],
   },
-  async afterTest(_output) {
+  afterTest: async () => {
     await import('./assert.mjs')
   },
 })

--- a/packages/rolldown/tests/fixtures/misc/keep-names/aliased_class/assert.mjs
+++ b/packages/rolldown/tests/fixtures/misc/keep-names/aliased_class/assert.mjs
@@ -1,0 +1,6 @@
+import {Test, _Test} from './dist/main'
+import assert from 'assert'
+
+
+assert.strictEqual(Test.name, "Test")
+assert.strictEqual(_Test.name, "Test")

--- a/packages/rolldown/tests/fixtures/misc/keep-names/aliased_class/main.js
+++ b/packages/rolldown/tests/fixtures/misc/keep-names/aliased_class/main.js
@@ -1,0 +1,9 @@
+var _Test;
+let Test = _Test = class Test {
+
+};
+
+export {
+  Test,
+  _Test,
+};

--- a/packages/rolldown/tests/fixtures/transform/decorator-linking-rename-reference/_config.ts
+++ b/packages/rolldown/tests/fixtures/transform/decorator-linking-rename-reference/_config.ts
@@ -6,11 +6,7 @@ export default defineTest({
     resolve: {
       tsconfigFilename: 'tsconfig.json',
     },
-    transform: {
-      typescript: {
-        onlyRemoveTypeImports: true,
-      },
-    },
+    keepNames: true,
   },
   async afterTest(_output) {
     await import('./assert.mjs')

--- a/packages/rolldown/tests/fixtures/transform/decorator-linking-rename-reference/_config.ts
+++ b/packages/rolldown/tests/fixtures/transform/decorator-linking-rename-reference/_config.ts
@@ -1,0 +1,18 @@
+import { defineTest } from 'rolldown-tests'
+
+export default defineTest({
+  config: {
+    input: 'main.ts',
+    resolve: {
+      tsconfigFilename: 'tsconfig.json',
+    },
+    transform: {
+      typescript: {
+        onlyRemoveTypeImports: true,
+      },
+    },
+  },
+  async afterTest(_output) {
+    await import('./assert.mjs')
+  },
+})

--- a/packages/rolldown/tests/fixtures/transform/decorator-linking-rename-reference/assert.mjs
+++ b/packages/rolldown/tests/fixtures/transform/decorator-linking-rename-reference/assert.mjs
@@ -1,0 +1,5 @@
+// @ts-nocheck
+import assert from 'node:assert'
+import { staticName } from './dist/main'
+
+assert.strictEqual(staticName, "MyClass")

--- a/packages/rolldown/tests/fixtures/transform/decorator-linking-rename-reference/main.ts
+++ b/packages/rolldown/tests/fixtures/transform/decorator-linking-rename-reference/main.ts
@@ -1,0 +1,10 @@
+function MyDecorator(): ClassDecorator {
+  return (_target) => {}
+}
+
+@MyDecorator()
+class MyClass { 
+  static myStaticName = MyClass.name;
+}
+
+export const staticName = MyClass.myStaticName;

--- a/packages/rolldown/tests/fixtures/transform/decorator-linking-rename-reference/tsconfig.json
+++ b/packages/rolldown/tests/fixtures/transform/decorator-linking-rename-reference/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+		"experimentalDecorators": true,
+		"emitDecoratorMetadata": true,
+  },
+  "extends": "../../../../tsconfig.json"
+}

--- a/packages/rolldown/tests/fixtures/transform/decorator-linking-rename/_config.ts
+++ b/packages/rolldown/tests/fixtures/transform/decorator-linking-rename/_config.ts
@@ -1,0 +1,18 @@
+import { defineTest } from 'rolldown-tests'
+
+export default defineTest({
+  config: {
+    input: 'main.ts',
+    resolve: {
+      tsconfigFilename: 'tsconfig.json',
+    },
+    transform: {
+      typescript: {
+        onlyRemoveTypeImports: true,
+      },
+    },
+  },
+  async afterTest(_output) {
+    await import('./assert.mjs')
+  },
+})

--- a/packages/rolldown/tests/fixtures/transform/decorator-linking-rename/assert.mjs
+++ b/packages/rolldown/tests/fixtures/transform/decorator-linking-rename/assert.mjs
@@ -1,0 +1,5 @@
+// @ts-nocheck
+import assert from 'node:assert'
+import { myName } from './dist/main'
+
+assert.strictEqual(myName, 'MyClass', 'Should return the correct name for MyClass after renaming')

--- a/packages/rolldown/tests/fixtures/transform/decorator-linking-rename/main.ts
+++ b/packages/rolldown/tests/fixtures/transform/decorator-linking-rename/main.ts
@@ -1,0 +1,10 @@
+function MyDecorator(): ClassDecorator {
+  return (target) => {}
+}
+
+@MyDecorator()
+class MyClass { 
+  myName = MyClass.name;
+}
+
+export const myName = new MyClass().myName;

--- a/packages/rolldown/tests/fixtures/transform/decorator-linking-rename/tsconfig.json
+++ b/packages/rolldown/tests/fixtures/transform/decorator-linking-rename/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+		"experimentalDecorators": true,
+		"emitDecoratorMetadata": true,
+  },
+  "extends": "../../../../tsconfig.json"
+}

--- a/packages/rolldown/tests/src/types.ts
+++ b/packages/rolldown/tests/src/types.ts
@@ -3,6 +3,7 @@ import type { RolldownOptions, RolldownOutput } from 'rolldown'
 export type TestKind = 'default' | 'compose-js-plugin'
 export interface TestConfig {
   skip?: boolean
+  only?: boolean
   skipComposingJsPlugin?: boolean
   config?: RolldownOptions
   beforeTest?: (testKind: TestKind) => Promise<void> | void


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


deconflict_exported_names or rename_non_root_symbol does not work with decorators as the introduce the var Class = _Class = class Class however this is being transformed into var Class = _Class = class Class$1 without setting name correctly. Ie executing console.log(Class.name) the output yields two different results console.log(Class.name) => "Class" and console.log(Class$1.name) => "Class$1" .