### PR TITLE
perf: change `profile.dev.debug` to improve rust compile times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,3 +217,6 @@ debug = false # Set to `true` for debug information
 lto = "fat"
 opt-level = 3
 strip = "symbols" # Set to `false` for debug information
+
+[profile.dev]
+debug = "line-tables-only"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. reference blog: https://kobzol.github.io/rust/rustc/2025/05/20/disable-debuginfo-to-improve-rust-compile-times.html
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
