### PR TITLE
feat(rust)!: merge `target` option into `transform`

### DIFF
--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -4,11 +4,12 @@ use oxc::{
   ast::ast::{self, Expression},
   semantic::{SemanticBuilder, Stats},
   span::SPAN,
+  transformer::ESTarget,
 };
 use rolldown_common::{
-  ESTarget, EcmaAstIdx, EcmaModuleAstUsage, ExportsKind, LocalExport, Module, ModuleIdx,
-  ModuleType, NormalModule, StmtInfo, StmtInfoIdx, SymbolOrMemberExprRef, SymbolRef,
-  SymbolRefDbForModule, WrapKind,
+  EcmaAstIdx, EcmaModuleAstUsage, ExportsKind, LocalExport, Module, ModuleIdx, ModuleType,
+  NormalModule, StmtInfo, StmtInfoIdx, SymbolOrMemberExprRef, SymbolRef, SymbolRefDbForModule,
+  WrapKind,
 };
 use rolldown_ecmascript_utils::AstSnippet;
 use rolldown_rstr::{Rstr, ToRstr};
@@ -164,7 +165,10 @@ fn json_object_expr_to_esm(
               .builder
               .expression_identifier(SPAN, snippet.builder.atom(legitimized_ident.as_str())),
           );
-          if key == "__proto__" && !matches!(link_staged.options.target, ESTarget::Es5) {
+          // TODO(shulaoda): Waiting for oxc transform to support the ES feature `ShorthandProperties`.
+          if key == "__proto__"
+            && !matches!(link_staged.options.transform_options.es_target, ESTarget::ES5)
+          {
             property.computed = true;
           } else if is_legal_ident {
             property.shorthand = is_legal_ident;

--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, path::Path};
 
-use oxc::transformer::{EnvOptions, TransformOptions};
 use oxc::transformer_plugins::InjectGlobalVariablesConfig;
 use rolldown_common::{
   GlobalsOutputOption, InjectImport, LegalComments, MinifyOptions, ModuleType,
@@ -166,18 +165,6 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
         .unwrap_or_default()
     },
   );
-  let target = raw_options.target.unwrap_or_default();
-  let transform_options = raw_options
-    .transform
-    .map(|mut transform_options| {
-      if let Ok(env) = EnvOptions::from_target_list(&target) {
-        transform_options.env = env;
-      }
-      transform_options
-    })
-    .or_else(|| TransformOptions::from_target_list(&target).ok().map(Into::into))
-    .unwrap_or_default();
-
   let cwd =
     raw_options.cwd.unwrap_or_else(|| std::env::current_dir().expect("Failed to get current dir"));
   let normalized = NormalizedBundlerOptions {
@@ -233,11 +220,10 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
     watch: raw_options.watch.unwrap_or_default(),
     legal_comments: raw_options.legal_comments.unwrap_or(LegalComments::Inline),
     drop_labels: FxHashSet::from_iter(raw_options.drop_labels.unwrap_or_default()),
-    target: target.into(),
     keep_names: raw_options.keep_names.unwrap_or_default(),
     polyfill_require: raw_options.polyfill_require.unwrap_or(true),
     defer_sync_scan_data: raw_options.defer_sync_scan_data,
-    transform_options,
+    transform_options: raw_options.transform.unwrap_or_default(),
     make_absolute_externals_relative: raw_options
       .make_absolute_externals_relative
       .unwrap_or_default(),

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -10,7 +10,7 @@ use oxc::transformer_plugins::{
   InjectGlobalVariables, ReplaceGlobalDefines, ReplaceGlobalDefinesConfig,
 };
 
-use rolldown_common::{ESTarget, NormalizedBundlerOptions};
+use rolldown_common::NormalizedBundlerOptions;
 use rolldown_ecmascript::{EcmaAst, WithMutFields};
 use rolldown_error::{BuildDiagnostic, BuildResult, Severity};
 
@@ -69,9 +69,9 @@ impl PreProcessEcmaAst {
       }
     });
     // Transform TypeScript and jsx.
-    // Transform es syntax.
+    // Note: Currently, oxc_transform supports es syntax up to ES2024 (unicode-sets-regex).
     if !matches!(parsed_type, OxcParseType::Js)
-      || !matches!(bundle_options.target, ESTarget::EsNext)
+      || bundle_options.transform_options.env.regexp.set_notation
     {
       let ret = ast.program.with_mut(|fields| {
         let transform_options = &bundle_options.transform_options;

--- a/crates/rolldown/tests/esbuild/default/define_optional_chain_lowered/_config.json
+++ b/crates/rolldown/tests/esbuild/default/define_optional_chain_lowered/_config.json
@@ -9,7 +9,9 @@
     "define": {
       "a.b.c": "1"
     },
-    "target": ["es2019"]
+    "transform": {
+      "target": "es2019"
+    }
   },
   "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/loader/loader_json_prototype_es5/_config.json
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_prototype_es5/_config.json
@@ -6,6 +6,8 @@
         "import": "entry.js"
       }
     ],
-    "target": ["es5"]
+    "transform": {
+      "target": "es5"
+    }
   }
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_export_star_as_name_collision/_config.json
+++ b/crates/rolldown/tests/esbuild/lower/lower_export_star_as_name_collision/_config.json
@@ -6,7 +6,9 @@
         "import": "entry.js"
       }
     ],
-    "target": ["es2019"]
+    "transform": {
+      "target": "es2019"
+    }
   },
   "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/_config.json
+++ b/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/_config.json
@@ -6,6 +6,8 @@
         "import": "entry.js"
       }
     ],
-    "target": ["es2015"]
+    "transform": {
+      "target": "es2015"
+    }
   }
 }

--- a/crates/rolldown/tests/rolldown/function/es-target/_config.json
+++ b/crates/rolldown/tests/rolldown/function/es-target/_config.json
@@ -1,5 +1,7 @@
 {
-    "config": {
-        "target": ["es5"]
+  "config": {
+    "transform": {
+      "target": "es5"
     }
+  }
 }

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -121,7 +121,6 @@ pub struct BindingOutputOptions<'env> {
   pub legal_comments: Option<String>,
   pub polyfill_require: Option<bool>,
   pub preserve_modules: Option<bool>,
-  pub target: Option<Either<String, Vec<String>>>,
   pub virtual_dirname: Option<String>,
   pub preserve_modules_root: Option<String>,
   #[napi(ts_type = "'strict' | 'allow-extension' | 'exports-only' | false")]

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -33,6 +33,7 @@ use self::types::{
   platform::Platform, resolve_options::ResolveOptions, source_map_type::SourceMapType,
   sourcemap_path_transform::SourceMapPathTransform,
 };
+
 use crate::{
   ChecksOptions, ChunkFilenamesOutputOption, ModuleType, SourceMapIgnoreList, TransformOptions,
 };
@@ -179,7 +180,6 @@ pub struct BundlerOptions {
   pub transform: Option<TransformOptions>,
   pub watch: Option<WatchOption>,
   pub legal_comments: Option<LegalComments>,
-  pub target: Option<Vec<String>>,
   pub polyfill_require: Option<bool>,
   #[cfg_attr(
     feature = "deserialize_bundler_options",
@@ -362,7 +362,7 @@ fn deserialize_transform_options<'de, D>(
 where
   D: Deserializer<'de>,
 {
-  use oxc::transformer::{JsxOptions, JsxRuntime};
+  use oxc::transformer::{EnvOptions, JsxOptions, JsxRuntime};
   use serde_json::Value;
 
   use crate::JsxPreset;
@@ -373,6 +373,15 @@ where
       let mut transform_options = TransformOptions::default();
       for (k, v) in obj {
         match k.as_str() {
+          "target" => {
+            let target = v
+              .as_str()
+              .ok_or_else(|| serde::de::Error::custom("transform.target should be a string"))?;
+            transform_options.es_target = std::str::FromStr::from_str(target).map_err(|_| {
+              serde::de::Error::custom("transform.target should be a valid es target")
+            })?;
+            transform_options.env = EnvOptions::from_target(target).unwrap();
+          }
           "jsx" => {
             let jsx = match v {
               Value::String(str) if str == "preserve" => {

--- a/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
@@ -99,7 +99,7 @@ impl MinifyOptionsObject {
         debug: false,
       }),
       compress: Some(CompressOptions {
-        target: option.target.into(),
+        target: option.transform_options.es_target,
         drop_debugger: false,
         drop_console: false,
         keep_names: CompressOptionsKeepNames { function: keep_names, class: keep_names },

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -26,8 +26,8 @@ use super::{
   sourcemap_ignore_list::SourceMapIgnoreList, sourcemap_path_transform::SourceMapPathTransform,
 };
 use crate::{
-  DeferSyncScanDataOption, ESTarget, EmittedAsset, EsModuleFlag, FilenameTemplate,
-  GlobalsOutputOption, HashCharacters, InjectImport, InputItem, InvalidateJsSideCache, LogLevel,
+  DeferSyncScanDataOption, EmittedAsset, EsModuleFlag, FilenameTemplate, GlobalsOutputOption,
+  HashCharacters, InjectImport, InputItem, InvalidateJsSideCache, LogLevel,
   MakeAbsoluteExternalsRelative, MarkModuleLoaded, ModuleType, OnLog, RollupPreRenderedAsset,
   TransformOptions,
 };
@@ -86,7 +86,6 @@ pub struct NormalizedBundlerOptions {
   pub watch: WatchOption,
   pub legal_comments: LegalComments,
   pub drop_labels: FxHashSet<String>,
-  pub target: ESTarget,
   pub polyfill_require: bool,
   pub defer_sync_scan_data: Option<DeferSyncScanDataOption>,
   pub transform_options: TransformOptions,
@@ -151,7 +150,6 @@ impl Default for NormalizedBundlerOptions {
       watch: Default::default(),
       legal_comments: LegalComments::None,
       drop_labels: Default::default(),
-      target: Default::default(),
       polyfill_require: Default::default(),
       defer_sync_scan_data: Default::default(),
       transform_options: Default::default(),

--- a/crates/rolldown_common/src/inner_bundler_options/types/target.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/target.rs
@@ -1,4 +1,4 @@
-use oxc::transformer::ESTarget as OxcEstarget;
+use oxc::transformer::ESTarget as OxcESTarget;
 
 #[cfg(feature = "deserialize_bundler_options")]
 use schemars::JsonSchema;
@@ -7,72 +7,38 @@ use serde::Deserialize;
 
 #[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "deserialize_bundler_options", derive(Deserialize, JsonSchema))]
-#[cfg_attr(feature = "deserialize_bundler_options", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "deserialize_bundler_options", serde(rename_all = "lowercase"))]
 pub enum ESTarget {
-  Es5,
-  Es2015,
-  Es2016,
-  Es2017,
-  Es2018,
-  Es2019,
-  Es2020,
-  Es2021,
-  Es2022,
-  Es2023,
-  Es2024,
+  ES5,
+  ES2015,
+  ES2016,
+  ES2017,
+  ES2018,
+  ES2019,
+  ES2020,
+  ES2021,
+  ES2022,
+  ES2023,
+  ES2024,
   #[default]
-  EsNext,
+  ESNext,
 }
 
-impl From<Vec<String>> for ESTarget {
-  fn from(value: Vec<String>) -> ESTarget {
-    for target in value {
-      if target.len() <= 2 || !target[..2].eq_ignore_ascii_case("es") {
-        continue;
-      }
-
-      let reset = &target[2..];
-
-      if reset.eq_ignore_ascii_case("next") {
-        return Self::EsNext;
-      }
-
-      if let Ok(n) = reset.parse::<usize>() {
-        return match n {
-          5 => ESTarget::Es5,
-          6 | 2015 => ESTarget::Es2015,
-          2016 => ESTarget::Es2016,
-          2017 => ESTarget::Es2017,
-          2018 => ESTarget::Es2018,
-          2019 => ESTarget::Es2019,
-          2020 => ESTarget::Es2020,
-          2021 => ESTarget::Es2021,
-          2022 => ESTarget::Es2022,
-          2023 => ESTarget::Es2023,
-          2024 => ESTarget::Es2024,
-          _ => continue,
-        };
-      }
-    }
-    Self::EsNext
-  }
-}
-
-impl From<ESTarget> for OxcEstarget {
-  fn from(value: ESTarget) -> OxcEstarget {
+impl From<ESTarget> for OxcESTarget {
+  fn from(value: ESTarget) -> OxcESTarget {
     match value {
-      ESTarget::Es5 => OxcEstarget::ES5,
-      ESTarget::Es2015 => OxcEstarget::ES2015,
-      ESTarget::Es2016 => OxcEstarget::ES2016,
-      ESTarget::Es2017 => OxcEstarget::ES2017,
-      ESTarget::Es2018 => OxcEstarget::ES2018,
-      ESTarget::Es2019 => OxcEstarget::ES2019,
-      ESTarget::Es2020 => OxcEstarget::ES2020,
-      ESTarget::Es2021 => OxcEstarget::ES2021,
-      ESTarget::Es2022 => OxcEstarget::ES2022,
-      ESTarget::Es2023 => OxcEstarget::ES2023,
-      ESTarget::Es2024 => OxcEstarget::ES2024,
-      ESTarget::EsNext => OxcEstarget::ESNext,
+      ESTarget::ES5 => OxcESTarget::ES5,
+      ESTarget::ES2015 => OxcESTarget::ES2015,
+      ESTarget::ES2016 => OxcESTarget::ES2016,
+      ESTarget::ES2017 => OxcESTarget::ES2017,
+      ESTarget::ES2018 => OxcESTarget::ES2018,
+      ESTarget::ES2019 => OxcESTarget::ES2019,
+      ESTarget::ES2020 => OxcESTarget::ES2020,
+      ESTarget::ES2021 => OxcESTarget::ES2021,
+      ESTarget::ES2022 => OxcESTarget::ES2022,
+      ESTarget::ES2023 => OxcESTarget::ES2023,
+      ESTarget::ES2024 => OxcESTarget::ES2024,
+      ESTarget::ESNext => OxcESTarget::ESNext,
     }
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/transform_options.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use oxc::transformer::TransformOptions as OxcTransformOptions;
+use oxc::transformer::{ESTarget, TransformOptions as OxcTransformOptions};
 
 #[derive(Debug, Default, Clone)]
 pub enum JsxPreset {
@@ -17,13 +17,14 @@ pub enum JsxPreset {
 
 pub struct TransformOptions {
   inner: OxcTransformOptions,
+  pub es_target: ESTarget,
   pub jsx_preset: JsxPreset,
 }
 
 impl TransformOptions {
   #[inline]
-  pub fn new(options: OxcTransformOptions, jsx_preset: JsxPreset) -> Self {
-    Self { inner: options, jsx_preset }
+  pub fn new(options: OxcTransformOptions, es_target: ESTarget, jsx_preset: JsxPreset) -> Self {
+    Self { inner: options, es_target, jsx_preset }
   }
 
   #[inline]
@@ -34,12 +35,6 @@ impl TransformOptions {
   #[inline]
   pub fn is_jsx_preserve(&self) -> bool {
     matches!(self.jsx_preset, JsxPreset::Preserve)
-  }
-}
-
-impl From<OxcTransformOptions> for TransformOptions {
-  fn from(value: OxcTransformOptions) -> Self {
-    Self { jsx_preset: JsxPreset::Enable, inner: value }
   }
 }
 

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -488,15 +488,6 @@
             "null"
           ]
         },
-        "target": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
         "transform": {
           "type": [
             "object",

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -613,7 +613,6 @@ export interface BindingOutputOptions {
   legalComments?: 'none' | 'inline'
   polyfillRequire?: boolean
   preserveModules?: boolean
-  target?: string | Array<string>
   virtualDirname?: string
   preserveModulesRoot?: string
   preserveEntrySignatures?: 'strict' | 'allow-extension' | 'exports-only' | false

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -14,7 +14,6 @@ import type { ChecksOptions } from './generated/checks-options';
 export type InputOption = string | string[] | Record<string, string>;
 
 // Omit those key that are part of rolldown option
-// Note: `target` should be omit either because it is also used in `minifier`
 type OxcTransformOption = Omit<
   TransformOptions,
   | 'sourceType'
@@ -23,7 +22,6 @@ type OxcTransformOption = Omit<
   | 'sourcemap'
   | 'define'
   | 'inject'
-  | 'target'
 >;
 
 export type ExternalOption =

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -192,7 +192,6 @@ export interface OutputOptions {
   legalComments?: 'none' | 'inline';
   plugins?: RolldownOutputPluginOption;
   polyfillRequire?: boolean;
-  target?: string | string[];
   hoistTransitiveImports?: false;
   preserveModules?: boolean;
   virtualDirname?: string;

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -68,7 +68,6 @@ export function bindingifyOutputOptions(
     inlineDynamicImports: outputOptions.inlineDynamicImports,
     advancedChunks: outputOptions.advancedChunks,
     polyfillRequire: outputOptions.polyfillRequire,
-    target: outputOptions.target,
     sanitizeFileName,
     preserveModules,
     virtualDirname,

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -147,6 +147,10 @@ const TransformOptionsSchema = v.object({
   helpers: v.optional(HelpersSchema),
   decorators: v.optional(DecoratorOptionSchema),
   jsx: v.optional(JsxOptionsSchema),
+  target: v.pipe(
+    v.optional(v.union([v.string(), v.array(v.string())])),
+    v.description('The JavaScript target environment'),
+  ),
 });
 
 const WatchOptionsSchema = v.strictObject({
@@ -564,7 +568,6 @@ const OutputOptionsSchema = v.strictObject({
       }, cjs, and iife)`,
     ),
   ),
-
   sourcemap: v.pipe(
     v.optional(
       v.union([v.boolean(), v.literal('inline'), v.literal('hidden')]),
@@ -642,10 +645,6 @@ const OutputOptionsSchema = v.strictObject({
   polyfillRequire: v.pipe(
     v.optional(v.boolean()),
     v.description('Disable require polyfill injection'),
-  ),
-  target: v.pipe(
-    v.optional(v.union([v.string(), v.array(v.string())])),
-    v.description('The JavaScript target environment'),
   ),
   hoistTransitiveImports: v.optional(
     v.custom<boolean, () => string>((input) => {

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -66,7 +66,6 @@ OPTIONS
   --sanitize-file-name        Sanitize file name.
   --shim-missing-exports      Create shim variables for missing exports.
   --sourcemap-debug-ids       Inject sourcemap debug IDs.
-  --target <target>           The JavaScript target environment.
   --transform.assumptions.ignore-function-length .
   --transform.assumptions.no-document-all .
   --transform.assumptions.object-rest-no-symbols .
@@ -82,6 +81,7 @@ OPTIONS
   --transform.jsx.refresh     Enable react fast refresh.
   --transform.jsx.runtime <transform.jsx.runtime>Which runtime to use.
   --transform.jsx.throw-if-namespace <transform.jsx.throw-if-namespace>Toggles whether to throw an error when a tag name uses an XML namespace.
+  --transform.target <transform.target>The JavaScript target environment.
   --transform.typescript.allow-declare-fields .
   --transform.typescript.allow-namespaces .
   --transform.typescript.declaration.sourcemap .


### PR DESCRIPTION
### Description

We merged `target` into `transform`:
```js
{
  output: {
    target: 'es6'
  }
}
```
to
```js
{
  transform: {
    target: 'es6'
  }
}
```