### PR TITLE
feat(rolldown_plugin_utils): support `to_output_file_path_in_js`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,7 +2887,9 @@ dependencies = [
 name = "rolldown_plugin_utils"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "cow-utils",
+ "itertools",
  "rolldown_utils",
  "sugar_path",
 ]

--- a/crates/rolldown_plugin_utils/Cargo.toml
+++ b/crates/rolldown_plugin_utils/Cargo.toml
@@ -15,6 +15,8 @@ doctest = false
 workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 cow-utils = { workspace = true }
+itertools = { workspace = true }
 rolldown_utils = { workspace = true }
 sugar_path = { workspace = true }

--- a/crates/rolldown_plugin_utils/src/join_url_segments.rs
+++ b/crates/rolldown_plugin_utils/src/join_url_segments.rs
@@ -1,0 +1,11 @@
+use std::borrow::Cow;
+
+pub fn join_url_segments<'a>(mut a: &'a str, b: &'a str) -> Cow<'a, str> {
+  if a.is_empty() || b.is_empty() {
+    return Cow::Borrowed(if a.is_empty() { b } else { a });
+  }
+  if a.ends_with('/') {
+    a = &a[..a.len() - 1];
+  }
+  Cow::Owned(format!("{a}{}{b}", if b.starts_with('/') { "" } else { "/" }))
+}

--- a/crates/rolldown_plugin_utils/src/lib.rs
+++ b/crates/rolldown_plugin_utils/src/lib.rs
@@ -1,3 +1,7 @@
+mod join_url_segments;
+mod to_output_file_path_in_js;
 mod to_relative_runtime_path;
 
+pub use join_url_segments::join_url_segments;
+pub use to_output_file_path_in_js::to_output_file_path_in_js;
 pub use to_relative_runtime_path::create_to_import_meta_url_based_relative_runtime;

--- a/crates/rolldown_plugin_utils/src/to_output_file_path_in_js.rs
+++ b/crates/rolldown_plugin_utils/src/to_output_file_path_in_js.rs
@@ -1,0 +1,67 @@
+use std::{path::Path, pin::Pin};
+
+use itertools::Either;
+use sugar_path::SugarPath as _;
+
+use crate::join_url_segments;
+
+pub struct RenderBuiltUrlConfig<'a> {
+  pub r#type: &'a str,
+  pub host_id: &'a str,
+  pub host_type: &'a str,
+  pub is_server: bool,
+}
+
+pub struct RenderBuiltUrlRet {
+  relative: Option<bool>,
+  runtime: Option<String>,
+}
+
+pub type RenderBuiltUrl = dyn Fn(
+    &str,
+    &RenderBuiltUrlConfig,
+  ) -> Pin<
+    Box<(dyn Future<Output = anyhow::Result<Option<Either<String, RenderBuiltUrlRet>>>> + Send)>,
+  > + Send
+  + Sync;
+
+pub struct ToOutputFilePathInJSEnv<'a> {
+  pub base: &'a str,
+  pub decoded_base: &'a str,
+  pub render_built_url: Option<&'a RenderBuiltUrl>,
+}
+
+pub async fn to_output_file_path_in_js<'a>(
+  env: ToOutputFilePathInJSEnv<'a>,
+  config: RenderBuiltUrlConfig<'a>,
+  filename: &str,
+  to_relative: Either<impl Fn(&Path, &Path) -> String, impl Fn(&Path, &Path) -> String>,
+) -> anyhow::Result<Either<String, String>> {
+  let mut relative = env.base.is_empty() || env.base.starts_with("./");
+  if let Some(render_built_url) = env.render_built_url {
+    if let Some(result) = render_built_url(filename, &config).await? {
+      match result {
+        Either::Left(result) => return Ok(Either::Left(result)),
+        Either::Right(result) => {
+          if let Some(runtime) = result.runtime {
+            return Ok(Either::Right(runtime));
+          }
+          if let Some(r) = result.relative {
+            relative = r;
+          }
+        }
+      }
+    }
+  }
+  if relative && !config.is_server {
+    return Ok(match to_relative {
+      Either::Left(to_relative) => {
+        Either::Left(to_relative(filename.as_path(), config.host_id.as_path()))
+      }
+      Either::Right(to_relative) => {
+        Either::Right(to_relative(filename.as_path(), config.host_id.as_path()))
+      }
+    });
+  }
+  Ok(Either::Left(join_url_segments(env.decoded_base, filename).into_owned()))
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It's used by `assetPlugin`、`cssPlugin`、`importAnalysisBuildPlugin`、`workerPlugin`.