### PR TITLE
feat(rolldown_plugin_utils): extract `check_public_file` from `rolldown_plugin_asset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2700,6 +2700,7 @@ dependencies = [
  "cow-utils",
  "rolldown_common",
  "rolldown_plugin",
+ "rolldown_plugin_utils",
  "rolldown_utils",
  "serde_json",
  "sugar_path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ rolldown_plugin_oxc_runtime = { version = "0.1.0", path = "./crates/rolldown_plu
 rolldown_plugin_replace = { version = "0.1.0", path = "./crates/rolldown_plugin_replace" }
 rolldown_plugin_reporter = { version = "0.1.0", path = "./crates/rolldown_plugin_reporter" }
 rolldown_plugin_transform = { version = "0.1.0", path = "./crates/rolldown_plugin_transform" }
+rolldown_plugin_utils = { version = "0.1.0", path = "./crates/rolldown_plugin_utils" }
 rolldown_plugin_vite_resolve = { version = "0.1.0", path = "./crates/rolldown_plugin_vite_resolve" }
 rolldown_plugin_wasm_fallback = { version = "0.1.0", path = "./crates/rolldown_plugin_wasm_fallback" }
 rolldown_plugin_wasm_helper = { version = "0.1.0", path = "./crates/rolldown_plugin_wasm_helper" }

--- a/crates/rolldown_plugin_asset/Cargo.toml
+++ b/crates/rolldown_plugin_asset/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = { workspace = true }
 cow-utils = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_plugin_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 serde_json = { workspace = true }
 sugar_path = { workspace = true }

--- a/crates/rolldown_plugin_asset/src/lib.rs
+++ b/crates/rolldown_plugin_asset/src/lib.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 
 use rolldown_common::ModuleType;
 use rolldown_plugin::{HookUsage, Plugin};
+use rolldown_plugin_utils::check_public_file;
 use rolldown_utils::{
   pattern_filter::StringOrRegex, percent_encoding::encode_as_percent_escaped, url::clean_url,
 };
@@ -31,7 +32,7 @@ impl Plugin for AssetPlugin {
       return Ok(None);
     }
 
-    if self.check_public_file(clean_url(args.specifier)).is_some() {
+    if check_public_file(clean_url(args.specifier), self.public_dir.as_deref()).is_some() {
       return Ok(Some(rolldown_plugin::HookResolveIdOutput {
         id: args.specifier.into(),
         ..Default::default()
@@ -48,7 +49,7 @@ impl Plugin for AssetPlugin {
   ) -> rolldown_plugin::HookLoadReturn {
     if args.id.starts_with('\0') || utils::find_query_param(args.id, b"raw").is_some() {
       let cleaned_id = clean_url(args.id);
-      let file = match self.check_public_file(cleaned_id) {
+      let file = match check_public_file(cleaned_id, self.public_dir.as_deref()) {
         Some(f) => Cow::Owned(f.to_string_lossy().into_owned()),
         None => Cow::Borrowed(cleaned_id),
       };

--- a/crates/rolldown_plugin_utils/src/check_public_file.rs
+++ b/crates/rolldown_plugin_utils/src/check_public_file.rs
@@ -1,0 +1,16 @@
+use std::path::{Path, PathBuf};
+
+use sugar_path::SugarPath as _;
+
+pub fn check_public_file(id: &str, public_dir: Option<&str>) -> Option<PathBuf> {
+  if id.is_empty() || id.as_bytes()[0] != b'/' {
+    return None;
+  }
+  if let Some(dir) = public_dir {
+    let file = Path::new(dir).join(&id[1..]).normalize();
+    if file.starts_with(dir) && file.exists() {
+      return Some(file);
+    }
+  }
+  None
+}

--- a/crates/rolldown_plugin_utils/src/lib.rs
+++ b/crates/rolldown_plugin_utils/src/lib.rs
@@ -1,7 +1,9 @@
+mod check_public_file;
 mod join_url_segments;
 mod to_output_file_path_in_js;
 mod to_relative_runtime_path;
 
+pub use check_public_file::check_public_file;
 pub use join_url_segments::join_url_segments;
 pub use to_output_file_path_in_js::to_output_file_path_in_js;
 pub use to_relative_runtime_path::create_to_import_meta_url_based_relative_runtime;


### PR DESCRIPTION
### Description

It's used by `assetPlugin`、`cssPlugin`、`htmlPlugin`、`importAnalysisPlugin`.