### PR TITLE
refactor(rolldown_plugin_asset): improve `resolve_id` hook logic

### DIFF
--- a/crates/rolldown_plugin_asset/src/lib.rs
+++ b/crates/rolldown_plugin_asset/src/lib.rs
@@ -31,15 +31,9 @@ impl Plugin for AssetPlugin {
     if self.is_not_valid_assets(ctx.cwd(), args.specifier) {
       return Ok(None);
     }
-
-    if check_public_file(clean_url(args.specifier), self.public_dir.as_deref()).is_some() {
-      return Ok(Some(rolldown_plugin::HookResolveIdOutput {
-        id: args.specifier.into(),
-        ..Default::default()
-      }));
-    }
-
-    Ok(None)
+    Ok(check_public_file(clean_url(args.specifier), self.public_dir.as_deref()).map(|_| {
+      rolldown_plugin::HookResolveIdOutput { id: args.specifier.into(), ..Default::default() }
+    }))
   }
 
   async fn load(


### PR DESCRIPTION
### Description

The `is_assets_include` logic will be used later, so it has been extracted into a separate function.