### PR TITLE
chore(infra): add `onlyBuiltDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,13 @@
   "pnpm": {
     "overrides": {
       "vitepress>vite": "npm:rolldown-vite@latest"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "dprint",
+      "esbuild",
+      "tree-sitter"
+    ]
   },
   "lint-staged": {
     "*.@(js|ts|tsx|yml|yaml|md|json|html|toml)": [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Transitive preinstall/postinstall scripts keep showing up in supply-chain attacks. Running them automatically is no longer safe.

ref: https://github.com/orgs/pnpm/discussions/8945