### PR TITLE
test(strict_execution_order): unused side effect module should be removed

### DIFF
--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "external": ["node:assert"]
+  },
+  "configVariants": [{
+    "strictExecutionOrder": true
+  }]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import nodeAssert from "node:assert";
+
+//#region main.js
+nodeAssert.equal(globalThis.value, void 0, "Unused no side effect module should be removed");
+
+//#endregion
+```
+---
+
+Variant: (strict_execution_order: true)
+
+# Assets
+
+## main.js
+
+```js
+import nodeAssert from "node:assert";
+
+
+//#region no_side_effect.js
+var init_no_side_effect = __esm({ "no_side_effect.js"() {} });
+
+//#endregion
+//#region main.js
+var init_main = __esm({ "main.js"() {
+	nodeAssert.equal(globalThis.value, void 0, "Unused no side effect module should be removed");
+} });
+
+//#endregion
+init_main();
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/main.js
@@ -1,0 +1,4 @@
+import nodeAssert from 'node:assert'
+import './no_side_effect'
+
+nodeAssert.equal(globalThis.value, undefined, 'Unused no side effect module should be removed')

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/no_side_effect.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/no_side_effect.js
@@ -1,0 +1,7 @@
+// This file is intentionally marked as no side effect to check if rolldown will remove unused no-side-effect modules.
+
+function foo() {
+  globalThis.value = 'called'
+}
+
+/*#__PURE__*/ foo()

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4031,6 +4031,10 @@ expression: output
 - entry2-!~{001}~.js => entry2-D5YLwzdZ.js
 - run-dep-!~{002}~.js => run-dep-IkByYhJ_.js
 
+# tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module
+
+- main-!~{000}~.js => main-DVzdOrRP.js
+
 # tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax
 
 - main-!~{000}~.js => main-BbzIdLSS.js


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds a test case to show how rolldown behave when importing a no-side-effect module with `strict_exeuciton_order: true`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
