### PR TITLE
feat(on_demand_wrapping): don't wrap modules that don't rely on others and have side effect

### DIFF
--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -25,6 +25,16 @@ fn wrap_module_recursively(ctx: &mut Context, target: ModuleIdx) {
   }
   ctx.visited_modules[target] = true;
 
+  // Check if the module really needs to be wrapped
+  match module.exports_kind {
+    ExportsKind::Esm | ExportsKind::None => {
+      if !module.side_effects.has_side_effects() && module.import_records.is_empty() {
+        return;
+      }
+    }
+    ExportsKind::CommonJs => {}
+  }
+
   if matches!(ctx.linking_infos[target].wrap_kind, WrapKind::None) {
     ctx.linking_infos[target].wrap_kind = match module.exports_kind {
       ExportsKind::Esm | ExportsKind::None => WrapKind::Esm,

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
@@ -10,11 +10,8 @@ import assert from "node:assert";
 
 
 //#region lib.js
-var keep1, keep2;
-var init_lib = __esm({ "lib.js"() {
-	keep1 = () => "keep1";
-	keep2 = () => "keep2";
-} });
+let keep1 = () => "keep1";
+let keep2 = () => "keep2";
 
 //#endregion
 //#region cjs.js
@@ -22,13 +19,11 @@ var cjs_exports = {};
 __export(cjs_exports, { default: () => cjs_default });
 var cjs_default;
 var init_cjs = __esm({ "cjs.js"() {
-	init_lib();
 	cjs_default = keep2();
 } });
 
 //#endregion
 //#region entry.js
-init_lib();
 assert.equal(keep1(), "keep1");
 assert.deepEqual((init_cjs(), __toCommonJS(cjs_exports)), { default: "keep2" });
 

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/diff.md
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/diff.md
@@ -1,0 +1,85 @@
+# Diff
+## /out.js
+### esbuild
+```js
+// lib.js
+var keep1, keep2;
+var init_lib = __esm({
+  "lib.js"() {
+    keep1 = () => "keep1";
+    keep2 = () => "keep2";
+  }
+});
+
+// cjs.js
+var cjs_exports = {};
+__export(cjs_exports, {
+  default: () => cjs_default
+});
+var cjs_default;
+var init_cjs = __esm({
+  "cjs.js"() {
+    init_lib();
+    cjs_default = keep2();
+  }
+});
+
+// entry.js
+init_lib();
+console.log(keep1(), (init_cjs(), __toCommonJS(cjs_exports)));
+```
+### rolldown
+```js
+import assert from "node:assert";
+
+
+//#region lib.js
+let keep1 = () => "keep1";
+let keep2 = () => "keep2";
+
+//#endregion
+//#region cjs.js
+var cjs_exports = {};
+__export(cjs_exports, { default: () => cjs_default });
+var cjs_default;
+var init_cjs = __esm({ "cjs.js"() {
+	cjs_default = keep2();
+} });
+
+//#endregion
+//#region entry.js
+assert.equal(keep1(), "keep1");
+assert.deepEqual((init_cjs(), __toCommonJS(cjs_exports)), { default: "keep2" });
+
+//#endregion
+```
+### diff
+```diff
+===================================================================
+--- esbuild	/out.js
++++ rolldown	entry.js
+@@ -1,20 +1,13 @@
+-var keep1, keep2;
+-var init_lib = __esm({
+-    "lib.js"() {
+-        keep1 = () => "keep1";
+-        keep2 = () => "keep2";
+-    }
+-});
++var keep1 = () => "keep1";
++var keep2 = () => "keep2";
+ var cjs_exports = {};
+ __export(cjs_exports, {
+     default: () => cjs_default
+ });
+ var cjs_default;
+ var init_cjs = __esm({
+     "cjs.js"() {
+-        init_lib();
+         cjs_default = keep2();
+     }
+ });
+-init_lib();
+ console.log(keep1(), (init_cjs(), __toCommonJS(cjs_exports)));
+
+```

--- a/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
@@ -8,19 +8,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 
 //#region a.js
-var abc;
-var init_a = __esm({ "a.js"() {
-	abc = void 0;
-} });
+const abc = void 0;
 
 //#endregion
 //#region b.js
 var b_exports = {};
 __export(b_exports, { xyz: () => xyz });
-var xyz;
-var init_b = __esm({ "b.js"() {
-	xyz = null;
-} });
+const xyz = null;
 
 //#endregion
 //#region commonjs.js
@@ -39,8 +33,6 @@ __export(commonjs_exports, {
 function Fn() {}
 var commonjs_default, v, l, c, Class;
 var init_commonjs = __esm({ "commonjs.js"() {
-	init_a();
-	init_b();
 	commonjs_default = 123;
 	v = 234;
 	l = 234;

--- a/crates/rolldown/tests/esbuild/default/export_forms_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/default/export_forms_common_js/diff.md
@@ -143,19 +143,13 @@ init_h();
 ```js
 
 //#region a.js
-var abc;
-var init_a = __esm({ "a.js"() {
-	abc = void 0;
-} });
+const abc = void 0;
 
 //#endregion
 //#region b.js
 var b_exports = {};
 __export(b_exports, { xyz: () => xyz });
-var xyz;
-var init_b = __esm({ "b.js"() {
-	xyz = null;
-} });
+const xyz = null;
 
 //#endregion
 //#region commonjs.js
@@ -174,8 +168,6 @@ __export(commonjs_exports, {
 function Fn() {}
 var commonjs_default, v, l, c, Class;
 var init_commonjs = __esm({ "commonjs.js"() {
-	init_a();
-	init_b();
 	commonjs_default = 123;
 	v = 234;
 	l = 234;
@@ -251,7 +243,41 @@ init_h();
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -69,14 +69,14 @@
+@@ -1,20 +1,10 @@
+-var abc;
+-var init_a = __esm({
+-    "a.js"() {
+-        abc = void 0;
+-    }
+-});
++var abc = void 0;
+ var b_exports = {};
+ __export(b_exports, {
+     xyz: () => xyz
+ });
+-var xyz;
+-var init_b = __esm({
+-    "b.js"() {
+-        xyz = null;
+-    }
+-});
++var xyz = null;
+ var commonjs_exports = {};
+ __export(commonjs_exports, {
+     C: () => Class,
+     Class: () => Class,
+@@ -29,10 +19,8 @@
+ function Fn() {}
+ var commonjs_default, v, l, c, Class;
+ var init_commonjs = __esm({
+     "commonjs.js"() {
+-        init_a();
+-        init_b();
+         commonjs_default = 123;
+         v = 234;
+         l = 234;
+         c = 234;
+@@ -69,14 +57,14 @@
      "e.js"() {}
  });
  var f_exports = {};
@@ -269,7 +295,7 @@ init_h();
  });
  var g_exports = {};
  __export(g_exports, {
-@@ -87,14 +87,14 @@
+@@ -87,14 +75,14 @@
      "g.js"() {}
  });
  var h_exports = {};

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
@@ -7,10 +7,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 
-//#region something.js
-var init_something = __esm({ "something.js"() {} });
-
-//#endregion
 //#region c.js
 var require_c = __commonJS({ "c.js"() {
 	await 0;
@@ -28,7 +24,6 @@ var init_b = __esm({ async "b.js"() {
 //#region a.js
 var a_exports = {};
 var init_a = __esm({ async "a.js"() {
-	await init_something();
 	await init_b();
 } });
 

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/artifacts.snap
@@ -6,43 +6,27 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { a, init_a } from "./common.js";
+import { a } from "./common.js";
 
-init_a();
 export { a };
 ```
 ## b.js
 
 ```js
-import { b, init_b } from "./common.js";
+import { b } from "./common.js";
 
-init_b();
 export { b };
 ```
 ## common.js
 
 ```js
-import { __esm } from "./rolldown-runtime.js";
-
 //#region a.js
-var a;
-var init_a = __esm({ "a.js"() {
-	a = "a";
-} });
+const a = "a";
 
 //#endregion
 //#region b.js
-var b;
-var init_b = __esm({ "b.js"() {
-	b = "a";
-} });
+const b = "a";
 
 //#endregion
-export { a, b, init_a, init_b };
-```
-## rolldown-runtime.js
-
-```js
-
-export { __esm };
+export { a, b };
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/issue_2617/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/issue_2617/artifacts.snap
@@ -29,14 +29,9 @@ export { __esm };
 ```js
 import { __esm } from "./rolldown-runtime.js";
 
-//#region shaked.js
-var init_shaked = __esm({ "shaked.js"() {} });
-
-//#endregion
 //#region lib.js
 var lib_default;
 var init_lib = __esm({ "lib.js"() {
-	init_shaked();
 	lib_default = "hello, world";
 } });
 

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
@@ -7,15 +7,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import { __esm } from "./rolldown-runtime.js";
-import { init_lib_ui, lib_ui_exports } from "./ui.js";
-import { init_lib_npm_a, init_lib_npm_b, lib_npm_a_exports, lib_npm_b_exports } from "./other-libs.js";
+import { lib_ui_exports } from "./ui.js";
+import { lib_npm_a_exports, lib_npm_b_exports } from "./other-libs.js";
 
 //#region main.js
-var init_main = __esm({ "main.js"() {
-	init_lib_ui();
-	init_lib_npm_a();
-	init_lib_npm_b();
-} });
+var init_main = __esm({ "main.js"() {} });
 
 //#endregion
 init_main();
@@ -24,27 +20,21 @@ export { lib_npm_a_exports as libA, lib_npm_b_exports as libB, lib_ui_exports as
 ## other-libs.js
 
 ```js
-import { __esm, __export } from "./rolldown-runtime.js";
+import { __export } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-npm-a/index.js
 var lib_npm_a_exports = {};
 __export(lib_npm_a_exports, { default: () => lib_npm_a_default });
-var lib_npm_a_default;
-var init_lib_npm_a = __esm({ "node_modules/lib-npm-a/index.js"() {
-	lib_npm_a_default = "npm-a";
-} });
+var lib_npm_a_default = "npm-a";
 
 //#endregion
 //#region node_modules/lib-npm-b/index.js
 var lib_npm_b_exports = {};
 __export(lib_npm_b_exports, { default: () => lib_npm_b_default });
-var lib_npm_b_default;
-var init_lib_npm_b = __esm({ "node_modules/lib-npm-b/index.js"() {
-	lib_npm_b_default = "npm-b";
-} });
+var lib_npm_b_default = "npm-b";
 
 //#endregion
-export { init_lib_npm_a, init_lib_npm_b, lib_npm_a_exports, lib_npm_b_exports };
+export { lib_npm_a_exports, lib_npm_b_exports };
 ```
 ## rolldown-runtime.js
 
@@ -68,16 +58,13 @@ export { __esm, __export };
 ## ui.js
 
 ```js
-import { __esm, __export } from "./rolldown-runtime.js";
+import { __export } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-ui/index.js
 var lib_ui_exports = {};
 __export(lib_ui_exports, { default: () => lib_ui_default });
-var lib_ui_default;
-var init_lib_ui = __esm({ "node_modules/lib-ui/index.js"() {
-	lib_ui_default = "ui";
-} });
+var lib_ui_default = "ui";
 
 //#endregion
-export { init_lib_ui, lib_ui_exports };
+export { lib_ui_exports };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
@@ -25,13 +25,8 @@ Variant: (strict_execution_order: true)
 import nodeAssert from "node:assert";
 
 
-//#region no_side_effect.js
-var init_no_side_effect = __esm({ "no_side_effect.js"() {} });
-
-//#endregion
 //#region main.js
 var init_main = __esm({ "main.js"() {
-	init_no_side_effect();
 	nodeAssert.equal(globalThis.value, void 0, "Unused no side effect module should be removed");
 } });
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
@@ -6,5 +6,5 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-var e=(e,t)=>()=>(e&&(t=e(e=0)),t);async function t(){console.log(`foo`)}var n=e(()=>{}),r=e(async()=>{await n(),await t()});await r();
+var e=(e,t)=>()=>(e&&(t=e(e=0)),t);async function t(){console.log(`foo`)}var n=e(async()=>{await t()});await n();
 ```

--- a/crates/rolldown/tests/rolldown/issues/3437/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3437/artifacts.snap
@@ -25,8 +25,6 @@ export { __esm };
 ## square.js
 
 ```js
-import { __esm } from "./rolldown-runtime.js";
-
 //#region square.json
 var hello = "world";
 var square_default = { hello };

--- a/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/24/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/24/artifacts.snap
@@ -8,18 +8,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 
 //#region bar.js
-var baz;
-var init_bar = __esm({ "bar.js"() {
-	baz = 123;
-} });
+let baz = 123;
 
 //#endregion
 //#region foo.js
 var foo_exports = {};
 __export(foo_exports, { baz: () => baz });
-var init_foo = __esm({ "foo.js"() {
-	init_bar();
-} });
+var init_foo = __esm({ "foo.js"() {} });
 
 //#endregion
 //#region entry.js
@@ -40,18 +35,13 @@ Variant: (format: Cjs)
 
 
 //#region bar.js
-var baz;
-var init_bar = __esm({ "bar.js"() {
-	baz = 123;
-} });
+let baz = 123;
 
 //#endregion
 //#region foo.js
 var foo_exports = {};
 __export(foo_exports, { baz: () => baz });
-var init_foo = __esm({ "foo.js"() {
-	init_bar();
-} });
+var init_foo = __esm({ "foo.js"() {} });
 
 //#endregion
 //#region entry.js
@@ -74,18 +64,13 @@ Variant: (format: Iife)
 
 
 //#region bar.js
-var baz;
-var init_bar = __esm({ "bar.js"() {
-	baz = 123;
-} });
+let baz = 123;
 
 //#endregion
 //#region foo.js
 var foo_exports = {};
 __export(foo_exports, { baz: () => baz });
-var init_foo = __esm({ "foo.js"() {
-	init_bar();
-} });
+var init_foo = __esm({ "foo.js"() {} });
 
 //#endregion
 //#region entry.js
@@ -112,18 +97,13 @@ Variant: (format: Umd)
 
 
 //#region bar.js
-var baz;
-var init_bar = __esm({ "bar.js"() {
-	baz = 123;
-} });
+let baz = 123;
 
 //#endregion
 //#region foo.js
 var foo_exports = {};
 __export(foo_exports, { baz: () => baz });
-var init_foo = __esm({ "foo.js"() {
-	init_bar();
-} });
+var init_foo = __esm({ "foo.js"() {} });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/25/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/bundler_esm_cjs_tests/25/artifacts.snap
@@ -8,18 +8,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 
 //#region bar.js
-var baz;
-var init_bar = __esm({ "bar.js"() {
-	baz = 123;
-} });
+let baz = 123;
 
 //#endregion
 //#region foo.js
 var foo_exports = {};
 __export(foo_exports, { baz: () => baz });
-var init_foo = __esm({ "foo.js"() {
-	init_bar();
-} });
+var init_foo = __esm({ "foo.js"() {} });
 
 //#endregion
 //#region entry.js
@@ -40,18 +35,13 @@ Variant: (format: Cjs)
 
 
 //#region bar.js
-var baz;
-var init_bar = __esm({ "bar.js"() {
-	baz = 123;
-} });
+let baz = 123;
 
 //#endregion
 //#region foo.js
 var foo_exports = {};
 __export(foo_exports, { baz: () => baz });
-var init_foo = __esm({ "foo.js"() {
-	init_bar();
-} });
+var init_foo = __esm({ "foo.js"() {} });
 
 //#endregion
 //#region entry.js
@@ -74,18 +64,13 @@ Variant: (format: Iife)
 
 
 //#region bar.js
-var baz;
-var init_bar = __esm({ "bar.js"() {
-	baz = 123;
-} });
+let baz = 123;
 
 //#endregion
 //#region foo.js
 var foo_exports = {};
 __export(foo_exports, { baz: () => baz });
-var init_foo = __esm({ "foo.js"() {
-	init_bar();
-} });
+var init_foo = __esm({ "foo.js"() {} });
 
 //#endregion
 //#region entry.js
@@ -112,18 +97,13 @@ Variant: (format: Umd)
 
 
 //#region bar.js
-var baz;
-var init_bar = __esm({ "bar.js"() {
-	baz = 123;
-} });
+let baz = 123;
 
 //#endregion
 //#region foo.js
 var foo_exports = {};
 __export(foo_exports, { baz: () => baz });
-var init_foo = __esm({ "foo.js"() {
-	init_bar();
-} });
+var init_foo = __esm({ "foo.js"() {} });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -535,7 +535,7 @@ expression: output
 
 # tests/esbuild/dce/tree_shaking_in_esm_wrapper
 
-- entry-!~{000}~.js => entry-B-uR5lyc.js
+- entry-!~{000}~.js => entry-Dpt3CcKB.js
 
 # tests/esbuild/dce/tree_shaking_js_with_associated_css
 
@@ -789,7 +789,7 @@ expression: output
 
 # tests/esbuild/default/export_forms_common_js
 
-- entry-!~{000}~.js => entry-BC6ZIWDt.js
+- entry-!~{000}~.js => entry-B3QIko0i.js
 
 # tests/esbuild/default/export_forms_es6
 
@@ -1697,7 +1697,7 @@ expression: output
 
 # tests/esbuild/default/top_level_await_forbidden_require
 
-- entry-!~{000}~.js => entry-tJ3W5hbA.js
+- entry-!~{000}~.js => entry-Bx8ByEeH.js
 
 # tests/esbuild/default/top_level_await_forbidden_require_dead_branch
 
@@ -3851,16 +3851,15 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/basic
 
-- a-!~{000}~.js => a-Duokw3jp.js
-- b-!~{001}~.js => b-GanGBqOK.js
-- common-!~{004}~.js => common-CHGMauua.js
-- rolldown-runtime-!~{002}~.js => rolldown-runtime-F0QY5PnL.js
+- a-!~{000}~.js => a-CcaBLJp5.js
+- b-!~{001}~.js => b-aQ857t6g.js
+- common-!~{002}~.js => common-DfGFFFKe.js
 
 # tests/rolldown/function/advanced_chunks/issue_2617
 
-- main-!~{000}~.js => main-IhJhtX9Y.js
+- main-!~{000}~.js => main-CgB9jNWY.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BjtMze0h.js
-- splited_lib-!~{003}~.js => splited_lib-BgXOTk10.js
+- splited_lib-!~{003}~.js => splited_lib-A55JX3bb.js
 
 # tests/rolldown/function/advanced_chunks/max_module_size
 
@@ -3936,10 +3935,10 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/split_node_modules
 
-- main-!~{000}~.js => main-CgintLkr.js
-- other-libs-!~{005}~.js => other-libs-9w3pul5i.js
+- main-!~{000}~.js => main-C5l1SOxR.js
+- other-libs-!~{005}~.js => other-libs-DDYt6ifN.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BvgZlyOU.js
-- ui-!~{003}~.js => ui-17vXJ9Bu.js
+- ui-!~{003}~.js => ui-Bub0P6Va.js
 
 # tests/rolldown/function/define/node_env
 
@@ -4041,7 +4040,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify
 
-- main-!~{000}~.js => main-Buo6YqrV.js
+- main-!~{000}~.js => main-C4BCfZuJ.js
 
 # tests/rolldown/function/export_mode/cjs/auto/default
 
@@ -4634,9 +4633,9 @@ expression: output
 
 # tests/rolldown/issues/3437
 
-- main-!~{000}~.js => main-Ds1QWccq.js
+- main-!~{000}~.js => main-CYMnVwR9.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BjtMze0h.js
-- square-!~{003}~.js => square-yFcIWcT3.js
+- square-!~{003}~.js => square-DKKPtQr6.js
 
 # tests/rolldown/issues/3438
 
@@ -5000,11 +4999,11 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/24
 
-- entry-!~{000}~.js => entry-BIe4XfGi.js
+- entry-!~{000}~.js => entry-BoIys9GA.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/25
 
-- entry-!~{000}~.js => entry-BJlV_0iA.js
+- entry-!~{000}~.js => entry-D1c0Z96Y.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/26
 

--- a/scripts/snap-diff/stats/stats.md
+++ b/scripts/snap-diff/stats/stats.md
@@ -1,16 +1,16 @@
 # Compatibility metric
 - total: 784
-- passed: 566
-- passed ratio: 72.19%
+- passed: 565
+- passed ratio: 72.07%
 # Compatibility metric without not supported case
 - total: 721
-- passed: 566
-- passed ratio: 78.50%
+- passed: 565
+- passed ratio: 78.36%
 # Compatibility metric details
 ## dce
 - total: 113
-- passed: 93
-- passed ratio: 82.30%
+- passed: 92
+- passed ratio: 81.42%
 ## default
 - total: 254
 - passed: 187

--- a/scripts/snap-diff/summary/dce.md
+++ b/scripts/snap-diff/summary/dce.md
@@ -29,6 +29,8 @@
   diff
 ## [remove_unused_no_side_effects_tagged_templates](../../../crates/rolldown/tests/esbuild/dce/remove_unused_no_side_effects_tagged_templates/diff.md)
   diff
+## [tree_shaking_in_esm_wrapper](../../../crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/diff.md)
+  diff
 ## [tree_shaking_lowered_class_static_field](../../../crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field/diff.md)
   diff
 ## [tree_shaking_lowered_class_static_field_assignment](../../../crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field_assignment/diff.md)
@@ -80,7 +82,6 @@
 ## [tree_shaking_class_property](../../../crates/rolldown/tests/esbuild/dce/tree_shaking_class_property)
 ## [tree_shaking_class_static_property](../../../crates/rolldown/tests/esbuild/dce/tree_shaking_class_static_property)
 ## [tree_shaking_import_identifier](../../../crates/rolldown/tests/esbuild/dce/tree_shaking_import_identifier)
-## [tree_shaking_in_esm_wrapper](../../../crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper)
 ## [tree_shaking_object_property](../../../crates/rolldown/tests/esbuild/dce/tree_shaking_object_property)
 # Bypassed Cases
 ## [const_value_inlining_bundle](../../../crates/rolldown/tests/esbuild/dce/const_value_inlining_bundle/bypass.md)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Part of https://github.com/rolldown/rolldown/issues/3410, https://github.com/rolldown/rolldown/issues/3981.

---

It turns out if a module doesn't have side effect and doesn't rely on other modules(in other words, not resiponsible for initlizing other modules), it could be safely not wrapped.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
