### PR TITLE
feat(debug): add `StmtSideEffect` to record the specific reason why a stmt has side effect

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -56,7 +56,8 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
         self.options.transform_options.is_jsx_preserve(),
         self.options,
       )
-      .detect_side_effect_of_stmt(stmt);
+      .detect_side_effect_of_stmt(stmt)
+      .has_side_effect();
 
       #[cfg(debug_assertions)]
       {

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/stmt_side_effect.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/stmt_side_effect.rs
@@ -1,0 +1,19 @@
+#[derive(Debug)]
+pub enum StmtSideEffect {
+  None,
+  // TODO(hyf0): This should be removed in the future.
+  Unknown,
+}
+
+impl StmtSideEffect {
+  pub fn has_side_effect(&self) -> bool {
+    !matches!(self, StmtSideEffect::None)
+  }
+}
+
+// TODO(hyf0): should be removed once we give every side effect a specific reason
+impl From<bool> for StmtSideEffect {
+  fn from(value: bool) -> Self {
+    if value { Self::Unknown } else { StmtSideEffect::None }
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- The change is limited in the `side_effect_detector` folder to reduce changes.

- I'm invesgating https://github.com/rolldown/rolldown/issues/3981, one factor about the big size is the side effect inconsistency between module level and stmt level.

- We need this to achieve the similar features like https://parceljs.org/blog/v2/#scope-hoisting-diagnostics

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
