### PR TITLE
fix(ci): fix double pnpm cache from `setup-node`

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,40 +1,38 @@
-name: 'Setup Node'
-
-description: 'Setup node and pnpm'
+name: Setup node and pnpm
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
-    - name: Install pnpm
-      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
-    - name: Install Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: .node-version
-        cache: 'pnpm'
+        registry-url: 'https://registry.npmjs.org'
+        # see pnpm cache setting below
 
     - name: Get pnpm store directory
+      id: store
       shell: bash
       run: |
-        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-      name: Setup pnpm cache
+    - name: Save and restore pnpm cache on main
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       if: ${{ github.ref_name == 'main' }}
       with:
-        path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        path: ${{ steps.store.outputs.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
 
-    - uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+    - name: Restore pnpm cache on PR
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       if: ${{ github.ref_name != 'main' }}
       with:
-        path: ${{ env.STORE_PATH }}
+        path: ${{ steps.store.outputs.STORE_PATH }}
         key: |
           ${{ runner.os }}-pnpm-store-
 
-    - name: Install dependencies
+    - run: pnpm install --frozen-lockfile
       shell: bash
-      run: pnpm install

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </div>
 
 <div align="center">
-  
+
 [![NPM Unpacked Size (with version)](https://img.shields.io/npm/unpacked-size/rolldown/latest?label=npm)][url-npm]
 [![NPM Unpacked Size darwin-arm64](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-darwin-arm64/latest?label=darwin-arm64)](https://www.npmjs.com/package/@rolldown/binding-darwin-arm64)
 [![NPM Unpacked Size darwin-x64](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-darwin-x64/latest?label=darwin-x64)](https://www.npmjs.com/package/@rolldown/binding-darwin-x64)
@@ -25,18 +25,16 @@
 </div>
 
 <div align="center">
-  
+
 [![pkg.pr.new](https://pkg.pr.new/badge/pkg.pr.new/pkg.pr.new?style=flat&color=000&logoSize=auto)](https://pkg.pr.new/~/rolldown/rolldown)
 
 </div>
 
 <div align="center">
-  
+
 [![rolldown-starter-stackblitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/rolldown/rolldown-starter-stackblitz)
 
 </div>
-
-
 
 > 🚧 **Work in Progress**
 >


### PR DESCRIPTION
    On main:

    ```
    Cache hit for: node-cache-Linux-x64-pnpm-6f4fde5c96eab1b124f5a728264eef66f6857ca9b70c37964f90c94472276289
    Received 209715200 of 245278038 (85.5%), 197.2 MBs/sec
    Received 245278038 of 245278038 (100.0%), 197.2 MBs/sec
    Cache Size: ~234 MB (245278038 B)
    Cache restored successfully
    Cache restored from key: node-cache-Linux-x64-pnpm-6f4fde5c96eab1b124f5a728264eef66f6857ca9b70c37964f90c94472276289

    Run actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
    Cache hit for: Linux-pnpm-store-6f4fde5c96eab1b124f5a728264eef66f6857ca9b70c37964f90c94472276289
    Received 232701618 of 245284530 (94.9%), 221.7 MBs/sec
    Received 245284530 of 245284530 (100.0%), 211.3 MBs/sec
    Cache Size: ~234 MB (245284530 B)
```

Also fixed zizmor reporting https://docs.zizmor.sh/audits/#github-env