### PR TITLE
fix(strict_execution_order): wrapped module should be included on demand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ redundant_pub_crate = "warn"
 significant_drop_in_scrutinee = "warn"
 unused_peekable = "warn"
 
+# Rewriting `unwrap_or` to `map_or` requires to annotate type explicitly which is cumbersome
+map_unwrap_or = "allow"
+
 [workspace.dependencies]
 criterion2 = { version = "3.0.0", default-features = false }
 css-module-lexer = "0.0.15"

--- a/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
+++ b/crates/rolldown/src/module_finalizers/scope_hoisting/mod.rs
@@ -620,7 +620,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   ) -> Option<Expression<'ast>> {
     match member_expr {
       MemberExpression::ComputedMemberExpression(inner_expr) => {
-        if let Some((object_ref, props)) =
+        if let Some((object_ref, props, ..)) =
           self.ctx.linking_info.resolved_member_expr_refs.get(&inner_expr.span)
         {
           match object_ref {
@@ -640,7 +640,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       }
       MemberExpression::StaticMemberExpression(inner_expr) => {
         match self.ctx.linking_info.resolved_member_expr_refs.get(&inner_expr.span) {
-          Some((object_ref, props)) => {
+          Some((object_ref, props, ..)) => {
             match object_ref {
               Some(object_ref) => {
                 let object_ref_expr = self.finalized_expr_for_symbol_ref(*object_ref, false, None);

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -58,6 +58,7 @@ pub struct LinkStage<'a> {
   pub used_symbol_refs: FxHashSet<SymbolRef>,
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, Vec<SymbolRef>>,
   pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
+  pub normal_symbol_exports_chain_map: FxHashMap<SymbolRef, Vec<SymbolRef>>,
 }
 
 impl<'a> LinkStage<'a> {
@@ -99,6 +100,7 @@ impl<'a> LinkStage<'a> {
       options,
       used_symbol_refs: FxHashSet::default(),
       safely_merge_cjs_ns_map: scan_stage_output.safely_merge_cjs_ns_map,
+      normal_symbol_exports_chain_map: FxHashMap::default(),
     }
   }
 

--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -196,7 +196,7 @@ pub fn create_wrapper(
         } else {
           runtime.resolve_symbol("__esmMin").into()
         }],
-        side_effect: false,
+        side_effect: true,
         is_included: false,
         import_records: Vec::new(),
         #[cfg(debug_assertions)]

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -1,8 +1,7 @@
-use oxc::span::{CompactStr, Span};
 use oxc_index::IndexVec;
 use rolldown_common::{
-  EntryPointKind, ImportRecordIdx, ModuleIdx, ResolvedExport, StmtInfoIdx, SymbolRef, WrapKind,
-  dynamic_import_usage::DynamicImportExportsUsage,
+  EntryPointKind, ImportRecordIdx, MemberExprRefResolutionMap, ModuleIdx, ResolvedExport,
+  StmtInfoIdx, SymbolRef, WrapKind, dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_rstr::Rstr;
 use rolldown_utils::indexmap::FxIndexSet;
@@ -56,7 +55,7 @@ pub struct LinkingMetadata {
   /// The dependencies of the module. It means if you want include this module, you need to include these dependencies too.
   pub dependencies: FxIndexSet<ModuleIdx>,
   // `None` the member expression resolve to a ambiguous export.
-  pub resolved_member_expr_refs: FxHashMap<Span, (Option<SymbolRef>, Vec<CompactStr>)>,
+  pub resolved_member_expr_refs: MemberExprRefResolutionMap,
   pub star_exports_from_external_modules: Vec<ImportRecordIdx>,
   pub safe_cjs_to_eliminate_interop_default: bool,
   pub is_tla_or_contains_tla_dependency: bool,

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/artifacts.snap
@@ -22,7 +22,6 @@ init_index_module();
 
 //#endregion
 //#region src/entry.js
-init_index_module();
 console.log("unused import");
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/diff.md
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/diff.md
@@ -44,7 +44,6 @@ init_index_module();
 
 //#endregion
 //#region src/entry.js
-init_index_module();
 console.log("unused import");
 
 //#endregion
@@ -54,7 +53,7 @@ console.log("unused import");
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	src_entry.js
-@@ -1,14 +1,14 @@
+@@ -1,14 +1,13 @@
 -var index_main_exports = {};
 -__export(index_main_exports, {
 +var index_module_exports = {};
@@ -73,7 +72,6 @@ console.log("unused import");
  });
 -init_index_main();
 -init_index_main();
-+init_index_module();
 +init_index_module();
  console.log("unused import");
 

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
@@ -19,7 +19,6 @@ var init_demo_pkg = __esm({ "node_modules/demo-pkg/index.js"() {
 //#endregion
 //#region src/entry.js
 init_demo_pkg();
-init_demo_pkg();
 console.log("unused import");
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/bypass.md
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/bypass.md
@@ -36,7 +36,6 @@ var init_demo_pkg = __esm({ "node_modules/demo-pkg/index.js"() {
 //#endregion
 //#region src/entry.js
 init_demo_pkg();
-init_demo_pkg();
 console.log("unused import");
 
 //#endregion
@@ -46,7 +45,7 @@ console.log("unused import");
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	src_entry.js
-@@ -3,11 +3,12 @@
+@@ -3,9 +3,9 @@
      foo: () => foo
  });
  var foo;
@@ -57,8 +56,5 @@ console.log("unused import");
          console.log("hello");
      }
  });
- init_demo_pkg();
-+init_demo_pkg();
- console.log("unused import");
 
 ```

--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
@@ -11,21 +10,21 @@ snapshot_kind: text
 const node_assert = __toESM(require("node:assert"));
 
 //#region foo/test.js
-var test_exports$1 = {};
-__export(test_exports$1, { foo: () => foo });
+var test_exports = {};
+__export(test_exports, { foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports = {};
-__export(test_exports, { bar: () => bar });
+var test_exports$1 = {};
+__export(test_exports$1, { bar: () => bar });
 let bar = 123;
 
 //#endregion
 //#region entry.js
 console.log(exports, module.exports);
-node_assert.default.deepEqual(test_exports$1, { foo: 123 });
-node_assert.default.deepEqual(test_exports, { bar: 123 });
+node_assert.default.deepEqual(test_exports, { foo: 123 });
+node_assert.default.deepEqual(test_exports$1, { bar: 123 });
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/bypass.md
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/bypass.md
@@ -27,21 +27,21 @@ console.log(exports, module.exports, test_exports, test_exports2);
 const node_assert = __toESM(require("node:assert"));
 
 //#region foo/test.js
-var test_exports$1 = {};
-__export(test_exports$1, { foo: () => foo });
+var test_exports = {};
+__export(test_exports, { foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports = {};
-__export(test_exports, { bar: () => bar });
+var test_exports$1 = {};
+__export(test_exports$1, { bar: () => bar });
 let bar = 123;
 
 //#endregion
 //#region entry.js
 console.log(exports, module.exports);
-node_assert.default.deepEqual(test_exports$1, { foo: 123 });
-node_assert.default.deepEqual(test_exports, { bar: 123 });
+node_assert.default.deepEqual(test_exports, { foo: 123 });
+node_assert.default.deepEqual(test_exports$1, { bar: 123 });
 
 //#endregion
 ```
@@ -51,27 +51,25 @@ node_assert.default.deepEqual(test_exports, { bar: 123 });
 --- esbuild	/out.js
 +++ rolldown	entry.js
 @@ -1,11 +1,18 @@
--var test_exports = {};
--__export(test_exports, {
 +var node_assert = __toESM(require("node:assert"));
-+var test_exports$1 = {};
-+__export(test_exports$1, {
+ var test_exports = {};
+ __export(test_exports, {
      foo: () => foo
  });
  var foo = 123;
 -var test_exports2 = {};
 -__export(test_exports2, {
-+var test_exports = {};
-+__export(test_exports, {
++var test_exports$1 = {};
++__export(test_exports$1, {
      bar: () => bar
  });
  var bar = 123;
 -console.log(exports, module.exports, test_exports, test_exports2);
 +console.log(exports, module.exports);
-+node_assert.default.deepEqual(test_exports$1, {
++node_assert.default.deepEqual(test_exports, {
 +    foo: 123
 +});
-+node_assert.default.deepEqual(test_exports, {
++node_assert.default.deepEqual(test_exports$1, {
 +    bar: 123
 +});
 

--- a/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
@@ -9,19 +9,19 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 
 //#region foo/test.js
-var test_exports$1 = {};
-__export(test_exports$1, { foo: () => foo });
+var test_exports = {};
+__export(test_exports, { foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports = {};
-__export(test_exports, { bar: () => bar });
+var test_exports$1 = {};
+__export(test_exports$1, { bar: () => bar });
 let bar = 123;
 
 //#endregion
 //#region entry.js
-console.log(exports, module.exports, test_exports$1, test_exports);
+console.log(exports, module.exports, test_exports, test_exports$1);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/bypass.md
+++ b/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/bypass.md
@@ -27,19 +27,19 @@ console.log(exports, module.exports, o, r);
 
 
 //#region foo/test.js
-var test_exports$1 = {};
-__export(test_exports$1, { foo: () => foo });
+var test_exports = {};
+__export(test_exports, { foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports = {};
-__export(test_exports, { bar: () => bar });
+var test_exports$1 = {};
+__export(test_exports$1, { bar: () => bar });
 let bar = 123;
 
 //#endregion
 //#region entry.js
-console.log(exports, module.exports, test_exports$1, test_exports);
+console.log(exports, module.exports, test_exports, test_exports$1);
 
 //#endregion
 ```
@@ -52,8 +52,8 @@ console.log(exports, module.exports, test_exports$1, test_exports);
 -var o = {};
 -p(o, {
 -    foo: () => l
-+var test_exports$1 = {};
-+__export(test_exports$1, {
++var test_exports = {};
++__export(test_exports, {
 +    foo: () => foo
  });
 -var l = 123;
@@ -61,13 +61,13 @@ console.log(exports, module.exports, test_exports$1, test_exports);
 -p(r, {
 -    bar: () => m
 +var foo = 123;
-+var test_exports = {};
-+__export(test_exports, {
++var test_exports$1 = {};
++__export(test_exports$1, {
 +    bar: () => bar
  });
 -var m = 123;
 -console.log(exports, module.exports, o, r);
 +var bar = 123;
-+console.log(exports, module.exports, test_exports$1, test_exports);
++console.log(exports, module.exports, test_exports, test_exports$1);
 
 ```

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
@@ -7,10 +7,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 
-//#region something.js
-var init_something = __esm({ "something.js"() {} });
-
-//#endregion
 //#region c.js
 var require_c = __commonJS({ "c.js"() {
 	await 0;
@@ -28,7 +24,6 @@ var init_b = __esm({ async "b.js"() {
 //#region a.js
 var a_exports = {};
 var init_a = __esm({ async "a.js"() {
-	await init_something();
 	await init_b();
 } });
 

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/artifacts.snap
@@ -29,9 +29,7 @@ var init_b = __esm({ "b.js"() {} });
 //#endregion
 //#region a.js
 var a_exports = {};
-var init_a = __esm({ "a.js"() {
-	init_b();
-} });
+var init_a = __esm({ "a.js"() {} });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/bypass.md
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/bypass.md
@@ -61,9 +61,7 @@ var init_b = __esm({ "b.js"() {} });
 //#endregion
 //#region a.js
 var a_exports = {};
-var init_a = __esm({ "a.js"() {
-	init_b();
-} });
+var init_a = __esm({ "a.js"() {} });
 
 //#endregion
 //#region entry.js
@@ -84,7 +82,7 @@ return require_entry();
 ===================================================================
 --- esbuild	/out.js
 +++ rolldown	entry.js
-@@ -1,31 +1,24 @@
+@@ -1,31 +1,22 @@
 -(() => {
 -    var c_exports = {};
 -    var init_c = __esm({
@@ -104,9 +102,10 @@ return require_entry();
      });
      var a_exports = {};
      var init_a = __esm({
-         "a.js"() {
-             init_b();
-         }
+-        "a.js"() {
+-            init_b();
+-        }
++        "a.js"() {}
      });
 -    var entry_exports = {};
 -    var init_entry = __esm({

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_index_no_ext/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_index_no_ext/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 //#region src/demo-pkg/no-ext-browser/index.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region src/demo-pkg/no-ext/index.js
@@ -17,14 +17,14 @@ let node = "node";
 
 //#endregion
 //#region src/demo-pkg/ext-browser/index.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
 assert.equal(node, "node");
-assert.equal(browser, "browser");
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
+assert.equal(browser$1, "browser");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_index_no_ext/bypass.md
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_index_no_ext/bypass.md
@@ -24,7 +24,7 @@ console.log(browser2);
 import assert from "node:assert";
 
 //#region src/demo-pkg/no-ext-browser/index.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region src/demo-pkg/no-ext/index.js
@@ -32,14 +32,14 @@ let node = "node";
 
 //#endregion
 //#region src/demo-pkg/ext-browser/index.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
 assert.equal(node, "node");
-assert.equal(browser, "browser");
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
+assert.equal(browser$1, "browser");
 
 //#endregion
 ```
@@ -49,15 +49,14 @@ assert.equal(browser, "browser");
 --- esbuild	/Users/user/project/out.js
 +++ rolldown	entry.js
 @@ -1,7 +1,4 @@
--var browser = "browser";
-+var browser$1 = "browser";
+ var browser = "browser";
  var node = "node";
 -var browser2 = "browser";
 -console.log(browser);
 -console.log(node);
 -console.log(browser2);
 -console.log(browser2);
-+var browser = "browser";
-+console.log(browser$1, node, browser, browser);
++var browser$1 = "browser";
++console.log(browser, node, browser$1, browser$1);
 
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_no_ext/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_no_ext/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 //#region src/demo-pkg/no-ext-browser.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region src/demo-pkg/no-ext.js
@@ -17,14 +17,14 @@ let node = "node";
 
 //#endregion
 //#region src/demo-pkg/ext-browser.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
 assert.equal(node, "node");
-assert.equal(browser, "browser");
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
+assert.equal(browser$1, "browser");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_no_ext/bypass.md
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_no_ext/bypass.md
@@ -25,7 +25,7 @@ console.log(browser2);
 import assert from "node:assert";
 
 //#region src/demo-pkg/no-ext-browser.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region src/demo-pkg/no-ext.js
@@ -33,14 +33,14 @@ let node = "node";
 
 //#endregion
 //#region src/demo-pkg/ext-browser.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
 assert.equal(node, "node");
-assert.equal(browser, "browser");
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
+assert.equal(browser$1, "browser");
 
 //#endregion
 ```
@@ -50,15 +50,14 @@ assert.equal(browser, "browser");
 --- esbuild	/Users/user/project/out.js
 +++ rolldown	entry.js
 @@ -1,7 +1,4 @@
--var browser = "browser";
-+var browser$1 = "browser";
+ var browser = "browser";
  var node = "node";
 -var browser2 = "browser";
 -console.log(browser);
 -console.log(node);
 -console.log(browser2);
 -console.log(browser2);
-+var browser = "browser";
-+console.log(browser$1, node, browser, browser);
++var browser$1 = "browser";
++console.log(browser, node, browser$1, browser$1);
 
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_index_no_ext/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_index_no_ext/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 //#region node_modules/demo-pkg/no-ext-browser/index.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region node_modules/demo-pkg/no-ext/index.js
@@ -17,14 +17,14 @@ let node = "node";
 
 //#endregion
 //#region node_modules/demo-pkg/ext-browser/index.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
 assert.equal(node, "node");
-assert.equal(browser, "browser");
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
+assert.equal(browser$1, "browser");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_index_no_ext/bypass.md
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_index_no_ext/bypass.md
@@ -24,7 +24,7 @@ console.log(browser2);
 import assert from "node:assert";
 
 //#region node_modules/demo-pkg/no-ext-browser/index.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region node_modules/demo-pkg/no-ext/index.js
@@ -32,14 +32,14 @@ let node = "node";
 
 //#endregion
 //#region node_modules/demo-pkg/ext-browser/index.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
 assert.equal(node, "node");
-assert.equal(browser, "browser");
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
+assert.equal(browser$1, "browser");
 
 //#endregion
 ```
@@ -49,15 +49,14 @@ assert.equal(browser, "browser");
 --- esbuild	/Users/user/project/out.js
 +++ rolldown	entry.js
 @@ -1,7 +1,4 @@
--var browser = "browser";
-+var browser$1 = "browser";
+ var browser = "browser";
  var node = "node";
 -var browser2 = "browser";
 -console.log(browser);
 -console.log(node);
 -console.log(browser2);
 -console.log(browser2);
-+var browser = "browser";
-+console.log(browser$1, node, browser, browser);
++var browser$1 = "browser";
++console.log(browser, node, browser$1, browser$1);
 
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_no_ext/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_no_ext/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 //#region node_modules/demo-pkg/no-ext-browser.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region node_modules/demo-pkg/no-ext.js
@@ -17,14 +17,14 @@ let node = "node";
 
 //#endregion
 //#region node_modules/demo-pkg/ext-browser.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
 assert.equal(node, "node");
-assert.equal(browser, "browser");
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
+assert.equal(browser$1, "browser");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_no_ext/bypass.md
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_no_ext/bypass.md
@@ -24,7 +24,7 @@ console.log(browser2);
 import assert from "node:assert";
 
 //#region node_modules/demo-pkg/no-ext-browser.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region node_modules/demo-pkg/no-ext.js
@@ -32,14 +32,14 @@ let node = "node";
 
 //#endregion
 //#region node_modules/demo-pkg/ext-browser.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
 assert.equal(node, "node");
-assert.equal(browser, "browser");
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
+assert.equal(browser$1, "browser");
 
 //#endregion
 ```
@@ -49,15 +49,14 @@ assert.equal(browser, "browser");
 --- esbuild	/Users/user/project/out.js
 +++ rolldown	entry.js
 @@ -1,7 +1,4 @@
--var browser = "browser";
-+var browser$1 = "browser";
+ var browser = "browser";
  var node = "node";
 -var browser2 = "browser";
 -console.log(browser);
 -console.log(node);
 -console.log(browser2);
 -console.log(browser2);
-+var browser = "browser";
-+console.log(browser$1, node, browser, browser);
++var browser$1 = "browser";
++console.log(browser, node, browser$1, browser$1);
 
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge/artifacts.snap
@@ -15,7 +15,7 @@ var require_cjs = __commonJS({ "cjs.js"(exports, module) {
 //#endregion
 //#region a.js
 var import_cjs$2 = __toESM(require_cjs());
-function test$1() {
+function test() {
 	return import_cjs$2.default;
 }
 
@@ -23,15 +23,15 @@ function test$1() {
 //#region b.js
 var import_cjs = __toESM(require_cjs());
 var import_cjs$1 = __toESM(require_cjs());
-function test() {
+function test$1() {
 	console.log(import_cjs$1.default);
 	return import_cjs.default;
 }
 
 //#endregion
 //#region main.js
-const aa = test$1();
-const bb = test();
+const aa = test();
+const bb = test$1();
 
 //#endregion
 export { aa, bb };

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize/artifacts.snap
@@ -24,21 +24,21 @@ var require_util = __commonJS({ "util.js"(exports, module) {
 //#region a.js
 var import_cjs = __toESM(require_cjs());
 var import_util = __toESM(require_util());
-function test$1() {
+function test() {
 	(0, import_util.default)();
 	return import_cjs.default;
 }
 
 //#endregion
 //#region b.js
-function test() {
+function test$1() {
 	return import_cjs.default;
 }
-var b_default = test;
+var b_default = test$1;
 
 //#endregion
 //#region main.js
-const aa = test$1();
+const aa = test();
 const bb = b_default();
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/issue_2617/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/issue_2617/artifacts.snap
@@ -29,14 +29,9 @@ export { __esm };
 ```js
 import { __esm } from "./rolldown-runtime.js";
 
-//#region shaked.js
-var init_shaked = __esm({ "shaked.js"() {} });
-
-//#endregion
 //#region lib.js
 var lib_default;
 var init_lib = __esm({ "lib.js"() {
-	init_shaked();
 	lib_default = "hello, world";
 } });
 

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
@@ -7,15 +7,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import { __esm } from "./rolldown-runtime.js";
-import { init_lib_ui, lib_ui_exports } from "./ui.js";
-import { init_lib_npm_a, init_lib_npm_b, lib_npm_a_exports, lib_npm_b_exports } from "./other-libs.js";
+import { lib_ui_exports } from "./ui.js";
+import { lib_npm_a_exports, lib_npm_b_exports } from "./other-libs.js";
 
 //#region main.js
-var init_main = __esm({ "main.js"() {
-	init_lib_ui();
-	init_lib_npm_a();
-	init_lib_npm_b();
-} });
+var init_main = __esm({ "main.js"() {} });
 
 //#endregion
 init_main();
@@ -44,7 +40,7 @@ var init_lib_npm_b = __esm({ "node_modules/lib-npm-b/index.js"() {
 } });
 
 //#endregion
-export { init_lib_npm_a, init_lib_npm_b, lib_npm_a_exports, lib_npm_b_exports };
+export { lib_npm_a_exports, lib_npm_b_exports };
 ```
 ## rolldown-runtime.js
 
@@ -79,5 +75,5 @@ var init_lib_ui = __esm({ "node_modules/lib-ui/index.js"() {
 } });
 
 //#endregion
-export { init_lib_ui, lib_ui_exports };
+export { lib_ui_exports };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "external": ["node:assert"]
+  },
+  "configVariants": [{
+    "strictExecutionOrder": true
+  }]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
@@ -1,0 +1,71 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import nodeAssert from "node:assert";
+
+//#region dep.js
+const value$1 = "";
+
+//#endregion
+//#region lib-foo.js
+const value = "foo" + value$1;
+
+//#endregion
+//#region main.js
+nodeAssert.equal(value, "foo");
+
+//#endregion
+```
+---
+
+Variant: (strict_execution_order: true)
+
+# Assets
+
+## main.js
+
+```js
+import nodeAssert from "node:assert";
+
+
+//#region dep.js
+var value$1;
+var init_dep = __esm({ "dep.js"() {
+	value$1 = "";
+} });
+
+//#endregion
+//#region lib-foo.js
+var value;
+var init_lib_foo = __esm({ "lib-foo.js"() {
+	init_dep();
+	value = "foo" + value$1;
+} });
+
+//#endregion
+//#region proxy-foo.js
+var init_proxy_foo = __esm({ "proxy-foo.js"() {
+	init_lib_foo();
+} });
+
+//#endregion
+//#region proxy.js
+var init_proxy = __esm({ "proxy.js"() {
+	init_proxy_foo();
+} });
+
+//#endregion
+//#region main.js
+var init_main = __esm({ "main.js"() {
+	init_proxy();
+	nodeAssert.equal(value, "foo");
+} });
+
+//#endregion
+init_main();
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/dep.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/dep.js
@@ -1,0 +1,1 @@
+export const value = ''

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/lib-bar.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/lib-bar.js
@@ -1,0 +1,3 @@
+import { value as v } from './dep'
+
+export const value = 'bar' + v

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/lib-foo.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/lib-foo.js
@@ -1,0 +1,3 @@
+import { value as v } from './dep'
+
+export const value = 'foo' + v

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/main.js
@@ -1,0 +1,4 @@
+import nodeAssert from 'node:assert'
+import { foo } from './proxy'
+
+nodeAssert.equal(foo, 'foo')

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/package.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/proxy-bar.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/proxy-bar.js
@@ -1,0 +1,3 @@
+import { value as bar } from './lib-bar'
+
+export { bar }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/proxy-foo.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/proxy-foo.js
@@ -1,0 +1,3 @@
+import { value as foo } from './lib-foo'
+
+export { foo }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/proxy.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/proxy.js
@@ -1,0 +1,4 @@
+import { foo } from './proxy-foo'
+import { bar } from './proxy-bar'
+
+export { foo, bar }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "external": ["node:assert"]
+  },
+  "configVariants": [{
+    "strictExecutionOrder": true
+  }]
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
@@ -1,0 +1,71 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import nodeAssert from "node:assert";
+
+//#region dep.js
+const value = "";
+
+//#endregion
+//#region lib-foo.js
+const value$1 = "foo" + value;
+
+//#endregion
+//#region main.js
+nodeAssert.equal(value$1, "foo");
+
+//#endregion
+```
+---
+
+Variant: (strict_execution_order: true)
+
+# Assets
+
+## main.js
+
+```js
+import nodeAssert from "node:assert";
+
+
+//#region dep.js
+var value$1;
+var init_dep = __esm({ "dep.js"() {
+	value$1 = "";
+} });
+
+//#endregion
+//#region lib-foo.js
+var value;
+var init_lib_foo = __esm({ "lib-foo.js"() {
+	init_dep();
+	value = "foo" + value$1;
+} });
+
+//#endregion
+//#region proxy-foo.js
+var init_proxy_foo = __esm({ "proxy-foo.js"() {
+	init_lib_foo();
+} });
+
+//#endregion
+//#region proxy.js
+var init_proxy = __esm({ "proxy.js"() {
+	init_proxy_foo();
+} });
+
+//#endregion
+//#region main.js
+var init_main = __esm({ "main.js"() {
+	init_proxy();
+	nodeAssert.equal(value, "foo");
+} });
+
+//#endregion
+init_main();
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/dep.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/dep.js
@@ -1,0 +1,1 @@
+export const value = ''

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/lib-bar.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/lib-bar.js
@@ -1,0 +1,3 @@
+import { value as v } from './dep'
+
+export const value = 'bar' + v

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/lib-foo.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/lib-foo.js
@@ -1,0 +1,3 @@
+import { value as v } from './dep'
+
+export const value = 'foo' + v

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/main.js
@@ -1,0 +1,4 @@
+import nodeAssert from 'node:assert'
+import * as star from './proxy'
+
+nodeAssert.equal(star.foo, 'foo')

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/package.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/proxy-bar.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/proxy-bar.js
@@ -1,0 +1,3 @@
+import { value as bar } from './lib-bar'
+
+export { bar }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/proxy-foo.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/proxy-foo.js
@@ -1,0 +1,3 @@
+import { value as foo } from './lib-foo'
+
+export { foo }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/proxy.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/proxy.js
@@ -1,0 +1,4 @@
+import { foo } from './proxy-foo'
+import { bar } from './proxy-bar'
+
+export { foo, bar }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
@@ -25,13 +25,8 @@ Variant: (strict_execution_order: true)
 import nodeAssert from "node:assert";
 
 
-//#region no_side_effect.js
-var init_no_side_effect = __esm({ "no_side_effect.js"() {} });
-
-//#endregion
 //#region main.js
 var init_main = __esm({ "main.js"() {
-	init_no_side_effect();
 	nodeAssert.equal(globalThis.value, void 0, "Unused no side effect module should be removed");
 } });
 

--- a/crates/rolldown/tests/rolldown/function/shim_missing_exports/basic_wrapped_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/shim_missing_exports/basic_wrapped_esm/artifacts.snap
@@ -17,7 +17,6 @@ var init_foo = __esm({ "foo.js"() {
 //#endregion
 //#region main.js
 init_foo();
-init_foo();
 
 //#endregion
 export { missing };

--- a/crates/rolldown/tests/rolldown/misc/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/basic/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
@@ -10,13 +9,13 @@ snapshot_kind: text
 import assert from "node:assert";
 
 //#region shared.js
-const a$1 = "shared.js";
+const a = "shared.js";
 
 //#endregion
 //#region main.js
-const a = "index.js";
-assert.equal(a, "index.js");
-assert.equal(a$1, "shared.js");
+const a$1 = "index.js";
+assert.equal(a$1, "index.js");
+assert.equal(a, "shared.js");
 
 //#endregion
 //# sourceMappingURL=main.js.map
@@ -27,20 +26,20 @@ assert.equal(a$1, "shared.js");
 ```
 - ../shared.js
 (0:0) "const " --> (3:0) "const "
-(0:6) "a = " --> (3:6) "a$1 = "
-(0:10) "'shared.js'\n" --> (3:12) "\"shared.js\";\n"
+(0:6) "a = " --> (3:6) "a = "
+(0:10) "'shared.js'\n" --> (3:10) "\"shared.js\";\n"
 - ../main.js
 (2:0) "const " --> (7:0) "const "
-(2:6) "a = " --> (7:6) "a = "
-(2:10) "'index.js'\n" --> (7:10) "\"index.js\";\n"
+(2:6) "a = " --> (7:6) "a$1 = "
+(2:10) "'index.js'\n" --> (7:12) "\"index.js\";\n"
 (3:0) "assert." --> (8:0) "assert."
 (3:7) "equal(" --> (8:7) "equal("
-(3:13) "a, " --> (8:13) "a, "
-(3:16) "'index.js')" --> (8:16) "\"index.js\")"
-(3:27) "\n" --> (8:27) ";\n"
+(3:13) "a, " --> (8:13) "a$1, "
+(3:16) "'index.js')" --> (8:18) "\"index.js\")"
+(3:27) "\n" --> (8:29) ";\n"
 (4:0) "assert." --> (9:0) "assert."
 (4:7) "equal(" --> (9:7) "equal("
-(4:13) "a2, " --> (9:13) "a$1, "
-(4:17) "'shared.js')" --> (9:18) "\"shared.js\")"
-(4:29) "\n" --> (9:30) ";\n"
+(4:13) "a2, " --> (9:13) "a, "
+(4:17) "'shared.js')" --> (9:16) "\"shared.js\")"
+(4:29) "\n" --> (9:28) ";\n"
 ```

--- a/crates/rolldown/tests/rolldown/misc/basic_re_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/basic_re_export/artifacts.snap
@@ -9,13 +9,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 //#region a.js
-const a$1 = "a.js";
+const a = "a.js";
 
 //#endregion
 //#region main.js
-const a = "index.js";
-assert.equal(a, "index.js");
-assert.equal(a$1, "a.js");
+const a$1 = "index.js";
+assert.equal(a$1, "index.js");
+assert.equal(a, "a.js");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/basic/artifacts.snap
@@ -9,13 +9,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "assert";
 
 //#region a.js
-const a$1 = "a.js";
+const a = "a.js";
 
 //#endregion
 //#region main.js
-const a = "main.js";
-assert.equal(a, "main.js");
-assert.equal(a$1, "a.js");
+const a$1 = "main.js";
+assert.equal(a$1, "main.js");
+assert.equal(a, "a.js");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/basic_scoped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/basic_scoped/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
@@ -10,16 +9,16 @@ snapshot_kind: text
 import assert from "assert";
 
 //#region a.js
-const a$1 = "a.js";
+const a = "a.js";
 
 //#endregion
 //#region main.js
-const a = "main.js";
+const a$1 = "main.js";
 function foo(a$1$1) {
 	return [
 		a$1$1,
-		a,
-		a$1
+		a$1,
+		a
 	];
 }
 assert.deepEqual(foo("foo"), [
@@ -37,12 +36,12 @@ assert.deepEqual(foo("foo"), [
 ```
 - ../a.js
 (0:0) "const " --> (3:0) "const "
-(0:6) "a = " --> (3:6) "a$1 = "
-(0:10) "'a.js'\n" --> (3:12) "\"a.js\";\n"
+(0:6) "a = " --> (3:6) "a = "
+(0:10) "'a.js'\n" --> (3:10) "\"a.js\";\n"
 - ../main.js
 (2:0) "const " --> (7:0) "const "
-(2:6) "a = " --> (7:6) "a = "
-(2:10) "'main.js'\n" --> (7:10) "\"main.js\";\n"
+(2:6) "a = " --> (7:6) "a$1 = "
+(2:10) "'main.js'\n" --> (7:12) "\"main.js\";\n"
 (5:0) "function " --> (8:0) "function "
 (5:9) "foo(" --> (8:9) "foo("
 (5:13) "a$1) " --> (8:13) "a$1$1) "
@@ -50,8 +49,8 @@ assert.deepEqual(foo("foo"), [
 (6:2) "return " --> (9:0) "\treturn "
 (6:9) "[" --> (9:8) "[\n"
 (6:10) "a$1, " --> (10:2) "a$1$1,\n"
-(6:15) "a, " --> (11:2) "a,\n"
-(6:18) "aJs]" --> (12:2) "a$1\n"
+(6:15) "a, " --> (11:2) "a$1,\n"
+(6:18) "aJs]" --> (12:2) "a\n"
 (6:22) "\n" --> (13:1) "];\n"
 (7:1) "\n" --> (14:0) "}\n"
 (9:0) "assert." --> (15:0) "assert."

--- a/crates/rolldown/tests/rolldown/topics/deconflict/issue_364/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/issue_364/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
@@ -10,15 +9,15 @@ snapshot_kind: text
 import assert from "node:assert";
 
 //#region shared.js
-const a$2 = "shared.js";
+const a = "shared.js";
 
 //#endregion
 //#region main.js
-const a = "a";
-const a$1 = "a$1";
-assert.equal(a$2, "shared.js");
-assert.equal(a, "a");
-assert.equal(a$1, "a$1");
+const a$1 = "a";
+const a$1$1 = "a$1";
+assert.equal(a, "shared.js");
+assert.equal(a$1, "a");
+assert.equal(a$1$1, "a$1");
 
 //#endregion
 //# sourceMappingURL=main.js.map
@@ -29,28 +28,28 @@ assert.equal(a$1, "a$1");
 ```
 - ../shared.js
 (0:0) "const " --> (3:0) "const "
-(0:6) "a = " --> (3:6) "a$2 = "
-(0:10) "'shared.js'\n" --> (3:12) "\"shared.js\";\n"
+(0:6) "a = " --> (3:6) "a = "
+(0:10) "'shared.js'\n" --> (3:10) "\"shared.js\";\n"
 - ../main.js
 (2:0) "const " --> (7:0) "const "
-(2:6) "a = " --> (7:6) "a = "
-(2:10) "'a'\n" --> (7:10) "\"a\";\n"
+(2:6) "a = " --> (7:6) "a$1 = "
+(2:10) "'a'\n" --> (7:12) "\"a\";\n"
 (3:0) "const " --> (8:0) "const "
-(3:6) "a$1 = " --> (8:6) "a$1 = "
-(3:12) "'a$1'\n" --> (8:12) "\"a$1\";\n"
+(3:6) "a$1 = " --> (8:6) "a$1$1 = "
+(3:12) "'a$1'\n" --> (8:14) "\"a$1\";\n"
 (5:0) "assert." --> (9:0) "assert."
 (5:7) "equal(" --> (9:7) "equal("
-(5:13) "a2, " --> (9:13) "a$2, "
-(5:17) "'shared.js')" --> (9:18) "\"shared.js\")"
-(5:29) "\n" --> (9:30) ";\n"
+(5:13) "a2, " --> (9:13) "a, "
+(5:17) "'shared.js')" --> (9:16) "\"shared.js\")"
+(5:29) "\n" --> (9:28) ";\n"
 (6:0) "assert." --> (10:0) "assert."
 (6:7) "equal(" --> (10:7) "equal("
-(6:13) "a, " --> (10:13) "a, "
-(6:16) "'a')" --> (10:16) "\"a\")"
-(6:20) "\n" --> (10:20) ";\n"
+(6:13) "a, " --> (10:13) "a$1, "
+(6:16) "'a')" --> (10:18) "\"a\")"
+(6:20) "\n" --> (10:22) ";\n"
 (7:0) "assert." --> (11:0) "assert."
 (7:7) "equal(" --> (11:7) "equal("
-(7:13) "a$1, " --> (11:13) "a$1, "
-(7:18) "'a$1')" --> (11:18) "\"a$1\")"
-(7:24) "\n" --> (11:24) ";\n"
+(7:13) "a$1, " --> (11:13) "a$1$1, "
+(7:18) "'a$1')" --> (11:20) "\"a$1\")"
+(7:24) "\n" --> (11:26) ";\n"
 ```

--- a/crates/rolldown/tests/rolldown/topics/keep_names/declaration/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/declaration/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
@@ -11,25 +10,24 @@ import assert from "node:assert";
 
 
 //#region a.js
-function test$1() {}
-__name(test$1, "test");
+function test() {}
 function a() {}
-var Foo$1 = class {
+var Foo = class {};
+
+//#endregion
+//#region main.js
+test();
+a();
+const test$1 = 10;
+var Foo$1 = class extends Foo {
 	static {
 		__name(this, "Foo");
 	}
 };
-
-//#endregion
-//#region main.js
-test$1();
-a();
-const test = 10;
-var Foo = class extends Foo$1 {};
-console.log(`test: `, test);
-assert.strictEqual(Foo.name, "Foo");
+console.log(`test: `, test$1);
 assert.strictEqual(Foo$1.name, "Foo");
-assert.strictEqual(test$1.name, "test");
+assert.strictEqual(Foo.name, "Foo");
+assert.strictEqual(test.name, "test");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -324,7 +324,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main
 
-- src_entry-!~{000}~.js => src_entry-BC8s_e1d.js
+- src_entry-!~{000}~.js => src_entry-B4a2G_J4.js
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_module
 
@@ -393,7 +393,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6
 
-- src_entry-!~{000}~.js => src_entry-By34m57k.js
+- src_entry-!~{000}~.js => src_entry-CQtz_ZD8.js
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js
 
@@ -838,7 +838,7 @@ expression: output
 
 # tests/esbuild/default/exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-B0-3jBbo.js
+- entry-!~{000}~.js => entry-BDqZoHuB.js
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
@@ -1379,7 +1379,7 @@ expression: output
 
 # tests/esbuild/default/minified_exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-DtfKiS88.js
+- entry-!~{000}~.js => entry-DykaIxN4.js
 
 # tests/esbuild/default/minified_jsx_preserve_with_object_spread
 
@@ -1697,11 +1697,11 @@ expression: output
 
 # tests/esbuild/default/top_level_await_forbidden_require
 
-- entry-!~{000}~.js => entry-tJ3W5hbA.js
+- entry-!~{000}~.js => entry-Bx8ByEeH.js
 
 # tests/esbuild/default/top_level_await_forbidden_require_dead_branch
 
-- entry-!~{000}~.js => entry-DabYB3n1.js
+- entry-!~{000}~.js => entry-CjA06sAA.js
 
 # tests/esbuild/default/top_level_await_iife_dead_branch
 
@@ -2902,7 +2902,7 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_browser_index_no_ext
 
-- entry-!~{000}~.js => entry-DEzgRw24.js
+- entry-!~{000}~.js => entry-Dv39UzBV.js
 
 # tests/esbuild/packagejson/package_json_browser_issue2002_a
 
@@ -2950,15 +2950,15 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_browser_no_ext
 
-- entry-!~{000}~.js => entry-CDa22rfJ.js
+- entry-!~{000}~.js => entry-De-e1yQ-.js
 
 # tests/esbuild/packagejson/package_json_browser_node_modules_index_no_ext
 
-- entry-!~{000}~.js => entry-qYvU3w5L.js
+- entry-!~{000}~.js => entry-BL0xYy0_.js
 
 # tests/esbuild/packagejson/package_json_browser_node_modules_no_ext
 
-- entry-!~{000}~.js => entry-BwGK4wwh.js
+- entry-!~{000}~.js => entry-DofpIrhO.js
 
 # tests/esbuild/packagejson/package_json_browser_over_main_node
 
@@ -3738,11 +3738,11 @@ expression: output
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge
 
-- main-!~{000}~.js => main-7Uqf_bwy.js
+- main-!~{000}~.js => main-mbEkR_Bu.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize
 
-- main-!~{000}~.js => main-CnFkSBwz.js
+- main-!~{000}~.js => main-B3J4C0DR.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize_chunk_split
 
@@ -3858,9 +3858,9 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/issue_2617
 
-- main-!~{000}~.js => main-IhJhtX9Y.js
+- main-!~{000}~.js => main-CgB9jNWY.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BjtMze0h.js
-- splited_lib-!~{003}~.js => splited_lib-BgXOTk10.js
+- splited_lib-!~{003}~.js => splited_lib-A55JX3bb.js
 
 # tests/rolldown/function/advanced_chunks/max_module_size
 
@@ -3936,10 +3936,10 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/split_node_modules
 
-- main-!~{000}~.js => main-CgintLkr.js
-- other-libs-!~{005}~.js => other-libs-9w3pul5i.js
+- main-!~{000}~.js => main-BjmQ9ujI.js
+- other-libs-!~{005}~.js => other-libs-Bo0B-gKW.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BvgZlyOU.js
-- ui-!~{003}~.js => ui-17vXJ9Bu.js
+- ui-!~{003}~.js => ui-CMSLr63w.js
 
 # tests/rolldown/function/define/node_env
 
@@ -4030,6 +4030,14 @@ expression: output
 - entry1-!~{000}~.js => entry1-GhJFkkfA.js
 - entry2-!~{001}~.js => entry2-D5YLwzdZ.js
 - run-dep-!~{002}~.js => run-dep-IkByYhJ_.js
+
+# tests/rolldown/function/experimental/strict_execution_order/exports_chain
+
+- main-!~{000}~.js => main-DLGWTVDF.js
+
+# tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns
+
+- main-!~{000}~.js => main-CuDlvFzB.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4367,8 +4375,8 @@ expression: output
 
 # tests/rolldown/function/minify/basic
 
-- main-!~{000}~.js => main-iuKz2ghl.js
-- main-iuKz2ghl.js.map
+- main-!~{000}~.js => main-CG4zlDFv.js
+- main-CG4zlDFv.js.map
 
 # tests/rolldown/function/minify/inject_node_env
 
@@ -4518,7 +4526,7 @@ expression: output
 
 # tests/rolldown/function/shim_missing_exports/basic_wrapped_esm
 
-- main-!~{000}~.js => main-BBAfU8Lx.js
+- main-!~{000}~.js => main-D_J4eDe5.js
 
 # tests/rolldown/function/shim_missing_exports/shake_unused_shimmed_exports
 
@@ -4746,12 +4754,12 @@ expression: output
 
 # tests/rolldown/misc/basic
 
-- main-!~{000}~.js => main-iuKz2ghl.js
-- main-iuKz2ghl.js.map
+- main-!~{000}~.js => main-CG4zlDFv.js
+- main-CG4zlDFv.js.map
 
 # tests/rolldown/misc/basic_re_export
 
-- main-!~{000}~.js => main-CpnSvEoA.js
+- main-!~{000}~.js => main-BPXamdUM.js
 
 # tests/rolldown/misc/chunk_level_directives
 
@@ -5225,12 +5233,12 @@ expression: output
 
 # tests/rolldown/topics/deconflict/basic
 
-- main-!~{000}~.js => main-BDoDIaEP.js
+- main-!~{000}~.js => main-TNiGXLU8.js
 
 # tests/rolldown/topics/deconflict/basic_scoped
 
-- main-!~{000}~.js => main-DSjWo8hf.js
-- main-DSjWo8hf.js.map
+- main-!~{000}~.js => main-QTbkFQwx.js
+- main-QTbkFQwx.js.map
 
 # tests/rolldown/topics/deconflict/complex_params_patterns
 
@@ -5262,8 +5270,8 @@ expression: output
 
 # tests/rolldown/topics/deconflict/issue_364
 
-- main-!~{000}~.js => main-Dhg00Vwi.js
-- main-Dhg00Vwi.js.map
+- main-!~{000}~.js => main-C3PfjjVO.js
+- main-C3PfjjVO.js.map
 
 # tests/rolldown/topics/deconflict/wrapped_esm_default_function
 
@@ -5296,7 +5304,7 @@ expression: output
 
 # tests/rolldown/topics/keep_names/declaration
 
-- main-!~{000}~.js => main-D-HGS_0P.js
+- main-!~{000}~.js => main-zKjYwJAp.js
 
 # tests/rolldown/topics/keep_names/declaration2
 

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -101,6 +101,7 @@ pub use crate::{
     runtime_task_result::RuntimeModuleTaskResult,
     task_result::{EcmaRelated, ExternalModuleTaskResult, NormalModuleTaskResult},
   },
+  type_aliases::MemberExprRefResolutionMap,
   types::asset::Asset,
   types::asset_idx::AssetIdx,
   types::asset_meta::InstantiationKind,

--- a/crates/rolldown_common/src/type_aliases.rs
+++ b/crates/rolldown_common/src/type_aliases.rs
@@ -1,5 +1,10 @@
+use oxc::span::{CompactStr, Span};
 use oxc_index::IndexVec;
+use rustc_hash::FxHashMap;
 
-use crate::{Chunk, ChunkIdx};
+use crate::{Chunk, ChunkIdx, SymbolRef};
 
 pub type IndexChunks = IndexVec<ChunkIdx, Chunk>;
+
+pub type MemberExprRefResolutionMap =
+  FxHashMap<Span, (Option<SymbolRef>, Vec<CompactStr>, Vec<SymbolRef>)>;

--- a/crates/rolldown_common/src/types/member_expr_ref.rs
+++ b/crates/rolldown_common/src/types/member_expr_ref.rs
@@ -1,7 +1,6 @@
 use oxc::span::{CompactStr, Span};
-use rustc_hash::FxHashMap;
 
-use crate::SymbolRef;
+use crate::{SymbolRef, type_aliases::MemberExprRefResolutionMap};
 
 /// For member expression, e.g. `foo_ns.bar_ns.c`
 /// - `object_ref` is the `SymbolRef` that represents `foo_ns`
@@ -25,9 +24,9 @@ impl MemberExprRef {
   #[allow(clippy::manual_map)]
   pub fn resolved_symbol_ref(
     &self,
-    resolved_map: &FxHashMap<Span, (Option<SymbolRef>, Vec<CompactStr>)>,
+    resolved_map: &MemberExprRefResolutionMap,
   ) -> Option<SymbolRef> {
-    if let Some((resolved, _)) = resolved_map.get(&self.span) {
+    if let Some((resolved, ..)) = resolved_map.get(&self.span) {
       // This member expression resolve to a ambiguous export if `resolved` equals to `None`, which means it actually resolve to nothing.
       // It would be rewrite to `undefined` in the final code.
       resolved.map(|sym_ref| sym_ref)

--- a/packages/rollup-tests/src/ignored-passed-snapshot-different-tests.js
+++ b/packages/rollup-tests/src/ignored-passed-snapshot-different-tests.js
@@ -130,5 +130,7 @@ module.exports = [
     "rollup@function@preload-loading-module: waits for pre-loaded modules that are currently loading",
     // passed, the rolldown using `__name` to keep the original name
     "rollup@form@assignment-to-exports-class-declaration: does not rewrite class expression IDs@generates es",
-    "rollup@form@simplify-expression-annotations: keeps correct annotations when simplifying expressinos"
+    "rollup@form@simplify-expression-annotations: keeps correct annotations when simplifying expressinos",
+    // hyf0: We can align the deconflict logic with rollup, but it requires unnecessary logic and doesn't have payoff.
+  "rollup@form@deconflict-module-priority: prioritizes entry modules over dependencies when deconflicting",
 ]

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -4,6 +4,6 @@
   "ignored": 13,
   "ignored(unsupported features)": 407,
   "ignored(treeshaking)": 287,
-  "ignored(behavior passed, snapshot different)": 122,
-  "passed": 718
+  "ignored(behavior passed, snapshot different)": 123,
+  "passed": 717
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -5,5 +5,5 @@
 | ignored | 13 |
 | ignored(unsupported features) | 407 |
 | ignored(treeshaking) | 287 |
-| ignored(behavior passed, snapshot different) | 122 |
-| passed | 718 |
+| ignored(behavior passed, snapshot different) | 123 |
+| passed | 717 |


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes the size problem of enabling `strictExecutionOrder` at https://github.com/rolldown/rolldown/issues/3981.

---

Fixes https://github.com/rolldown/rolldown/issues/3981.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
