### PR TITLE
test(resolve): module type should be decided by nearest package.json

### DIFF
--- a/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/_config.json
+++ b/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/_config.json
@@ -1,0 +1,4 @@
+{
+  // FIXME: Relies on https://github.com/oxc-project/oxc-resolver/issues/527
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/artifacts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+
+//#region node_modules/demo-lib/index.js
+var require_demo_lib = __commonJS({ "node_modules/demo-lib/index.js"(exports, module) {
+	module.exports = { value: "yes" };
+	Object.defineProperty(module.exports, "__esModule", {
+		value: true,
+		enumerable: false
+	});
+} });
+
+//#endregion
+//#region node_modules/demo-lib/nested-lib/index.js
+var import_demo_lib = __toESM(require_demo_lib());
+const value = import_demo_lib.default.value;
+
+//#endregion
+//#region main.js
+assert.strictEqual(value, "yes");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/main.js
+++ b/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/main.js
@@ -1,0 +1,6 @@
+import assert from 'node:assert'
+import { value } from 'demo-lib'
+
+
+assert.strictEqual(value, 'yes')
+

--- a/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/node_modules/demo-lib/index.js
+++ b/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/node_modules/demo-lib/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+  value: 'yes'
+}
+
+Object.defineProperty(module.exports, '__esModule', {
+  value: true,
+  enumerable: false,
+})

--- a/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/node_modules/demo-lib/nested-lib/index.js
+++ b/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/node_modules/demo-lib/nested-lib/index.js
@@ -1,0 +1,6 @@
+import lib from '../index';
+
+const value = lib.value
+
+export { value }
+

--- a/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/node_modules/demo-lib/nested-lib/package.json
+++ b/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/node_modules/demo-lib/nested-lib/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/node_modules/demo-lib/package.json
+++ b/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/node_modules/demo-lib/package.json
@@ -1,0 +1,3 @@
+{
+  "exports": "./nested-lib/index.js"
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4892,6 +4892,10 @@ expression: output
 
 - main-!~{000}~.js => main-PHNGJQWh.js
 
+# tests/rolldown/resolve/attach_correct_package_json
+
+- main-!~{000}~.js => main-K-HhwO4S.js
+
 # tests/rolldown/resolve/hash_tag_as_dir_name
 
 - main-!~{000}~.js => main-tpAxLMZ5.js


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The test case is reduced from bundling `tslib`.

Bundling the cjs `tslib` will result to invalid output.

The key is https://github.com/oxc-project/oxc-resolver/issues/527.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
