### PR TITLE
fix: `chunk.name` is not sanitized when the chunk is a common chunk

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -203,9 +203,11 @@ impl<'a> GenerateStage<'a> {
               let (chunk_name, absolute_chunk_file_name) =
                 representative_file_name_for_preserve_modules(module_id.as_path());
 
-              let sanitized_filename =
+              let sanitized_absolute_filename =
                 sanitize_filename.call(absolute_chunk_file_name.as_ref()).await?;
-              (ArcStr::from(chunk_name), sanitized_filename)
+
+              let sanitized_chunk_name = sanitize_filename.call(&chunk_name).await?;
+              (sanitized_chunk_name, sanitized_absolute_filename)
             } else if is_user_defined {
               // try extract meaningful input name from path
               if let Some(file_stem) = module.id().as_path().file_stem().and_then(|f| f.to_str()) {
@@ -233,7 +235,7 @@ impl<'a> GenerateStage<'a> {
               let module_id = module.id();
               let name = module_id.as_path().representative_file_name();
               let sanitized_filename = sanitize_filename.call(&name).await?;
-              Ok((ArcStr::from(name), sanitized_filename))
+              Ok((sanitized_filename.clone(), sanitized_filename))
             } else {
               let name = arcstr::literal!("chunk");
               Ok((name.clone(), name))

--- a/packages/rolldown/tests/fixtures/misc/issues/4709/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/issues/4709/_config.ts
@@ -1,0 +1,31 @@
+import { defineTest } from "rolldown-tests";
+import { expect } from "vitest";
+
+export default defineTest({
+	config: {
+		input: ["./main.js"],
+		output: {
+			dir: "./dist",
+		},
+		plugins: [
+			{
+				name: "emit",
+				resolveId(id) {
+					if (id[0] === "\0") {
+						return id;
+					}
+				},
+				load(id) {
+					if (id[0] === "\0") {
+						return `console.log('virtual')`;
+					}
+				},
+				renderChunk(_code, chunk) {
+					if (chunk.name.includes("virtual")) {
+						expect(JSON.stringify(chunk.name)).toBe("\"_virtual\"");
+					}
+				},
+			},
+		],
+	},
+});

--- a/packages/rolldown/tests/fixtures/misc/issues/4709/bar.js
+++ b/packages/rolldown/tests/fixtures/misc/issues/4709/bar.js
@@ -1,0 +1,2 @@
+import "\0virtual";
+console.log("bar");

--- a/packages/rolldown/tests/fixtures/misc/issues/4709/foo.js
+++ b/packages/rolldown/tests/fixtures/misc/issues/4709/foo.js
@@ -1,0 +1,2 @@
+import "\0virtual";
+console.log("foo");

--- a/packages/rolldown/tests/fixtures/misc/issues/4709/main.js
+++ b/packages/rolldown/tests/fixtures/misc/issues/4709/main.js
@@ -1,0 +1,2 @@
+import('./foo.js')
+import('./bar.js')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Closed #4709
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
