### PR TITLE
chore: add back bench-par

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -19,11 +19,8 @@
     "packages/bench": {
       "entry": [
         "vue-entry.js",
-        "src/parallel-babel-plugin/impl.ts", // imported from src/parallel-babel-plugin/index.ts
       ],
-      "babel": {
-        "config": "src/parallel-babel-plugin/impl.ts",
-      },
+      "ignoreDependencies": ["@babel/@preset-.+"],
     },
     "packages/rolldown": {
       "entry": [

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -17,7 +17,13 @@
       ],
     },
     "packages/bench": {
-      "entry": ["vue-entry.js"],
+      "entry": [
+        "vue-entry.js",
+        "src/parallel-babel-plugin/impl.ts", // imported from src/parallel-babel-plugin/index.ts
+      ],
+      "babel": {
+        "config": "src/parallel-babel-plugin/impl.ts"
+      }
     },
     "packages/rolldown": {
       "entry": [

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -22,8 +22,8 @@
         "src/parallel-babel-plugin/impl.ts", // imported from src/parallel-babel-plugin/index.ts
       ],
       "babel": {
-        "config": "src/parallel-babel-plugin/impl.ts"
-      }
+        "config": "src/parallel-babel-plugin/impl.ts",
+      },
     },
     "packages/rolldown": {
       "entry": [

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -20,7 +20,7 @@
       "entry": [
         "vue-entry.js",
       ],
-      "ignoreDependencies": ["@babel/@preset-.+"],
+      "ignoreDependencies": ["@babel/preset-.+"],
     },
     "packages/rolldown": {
       "entry": [

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "bench": "oxnode ./benches/compare.js",
-    "bench-ci": "oxnode ./benches/ci.js"
+    "bench-ci": "oxnode ./benches/ci.js",
+    "bench-par": "oxnode ./benches/par.js"
   },
   "dependencies": {
     "react": "^19.0.0",
@@ -14,6 +15,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",
+    "@babel/preset-env": "^7.24.7",
+    "@babel/preset-typescript": "^7.24.7",
     "@oxc-node/cli": "catalog:",
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-node-resolve": "^16.0.0",

--- a/packages/bench/src/parallel-babel-plugin/impl.ts
+++ b/packages/bench/src/parallel-babel-plugin/impl.ts
@@ -63,4 +63,5 @@ const impl: ParallelPluginImplementation = defineParallelPluginImplementation(
   },
 );
 
+/** @public referenced by ./index.ts */
 export default impl;

--- a/packages/bench/src/parallel-babel-plugin/impl.ts
+++ b/packages/bench/src/parallel-babel-plugin/impl.ts
@@ -1,6 +1,10 @@
 import babel from '@babel/core';
 import nodePath from 'node:path';
 import type { Plugin } from 'rolldown';
+import {
+  defineParallelPluginImplementation,
+  type ParallelPluginImplementation,
+} from 'rolldown/parallelPlugin';
 
 export const babelPlugin = (): Plugin => {
   const partialConfig = babel.loadPartialConfig({
@@ -52,3 +56,12 @@ export const babelPlugin = (): Plugin => {
     },
   };
 };
+
+
+const impl: ParallelPluginImplementation = defineParallelPluginImplementation(
+  (_options, _context) => {
+    return babelPlugin();
+  },
+);
+
+export default impl;

--- a/packages/bench/src/parallel-babel-plugin/impl.ts
+++ b/packages/bench/src/parallel-babel-plugin/impl.ts
@@ -57,7 +57,6 @@ export const babelPlugin = (): Plugin => {
   };
 };
 
-
 const impl: ParallelPluginImplementation = defineParallelPluginImplementation(
   (_options, _context) => {
     return babelPlugin();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,12 @@ importers:
       '@babel/core':
         specifier: ^7.24.7
         version: 7.27.1
+      '@babel/preset-env':
+        specifier: ^7.24.7
+        version: 7.27.2(@babel/core@7.27.1)
+      '@babel/preset-typescript':
+        specifier: ^7.24.7
+        version: 7.27.1(@babel/core@7.27.1)
       '@oxc-node/cli':
         specifier: 'catalog:'
         version: 0.0.27


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds back bench-par command in `packages/bench` that was removed in #4715.
It doesn't work anyway because parallel plugins are not working right now. But I guess it's fine to keep it. (or we can remove it completely if that's better)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
