### PR TITLE
fix: renamed exports when enabled preserveModules

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -369,10 +369,9 @@ impl GenerateStage<'_> {
     // Generate cross-chunk exports. These must be computed before cross-chunk
     // imports because of export alias renaming, which must consider all export
     // aliases simultaneously to avoid collisions.
-    let mut name_count =
-      FxHashMap::with_capacity(index_chunk_exported_symbols.iter().map(FxHashSet::len).sum());
 
     for (chunk_id, chunk) in chunk_graph.chunk_table.iter_mut_enumerated() {
+      let mut name_count = FxHashMap::with_capacity(index_chunk_exported_symbols[chunk_id].len());
       for chunk_export in index_chunk_exported_symbols[chunk_id]
         .iter()
         .sorted_by_cached_key(|symbol_ref| {

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import { share_default } from "./share2.js";
-import { share_default$1 } from "./share4.js";
+import { share_default as share_default$1 } from "./share4.js";
 
 //#region main.js
 console.log(share_default, share_default$1);
@@ -35,7 +35,7 @@ export { share_default };
 ## share3.js
 
 ```js
-import { share_default$1 as share_default } from "./share4.js";
+import { share_default } from "./share4.js";
 
 export { share_default as default };
 ```
@@ -46,5 +46,5 @@ export { share_default as default };
 var share_default = {};
 
 //#endregion
-export { share_default as share_default$1 };
+export { share_default };
 ```

--- a/crates/rolldown/tests/rolldown/issues/3438/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/3438/_config.json
@@ -1,7 +1,10 @@
 {
   "config": {
     "input": [
-      {"import": "./main.js", "name": "main" }
+      {
+        "import": "./main.js",
+        "name": "main"
+      }
     ]
   }
 }

--- a/crates/rolldown/tests/rolldown/issues/3438/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/3438/_test.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert'
+import main from './dist/main.js'
+
+assert.equal(main[0], 'repro1_clear')
+assert.equal(main[1], 'repro2_clear')
+assert.equal(main[2], 'repro2_clear$1')
+assert.equal(main[3], 'repro3_clear')
+assert.equal(main[4], 'repro3_clear$1')
+assert.equal(main[5], 'repro3_clear$2')

--- a/crates/rolldown/tests/rolldown/issues/3438/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3438/artifacts.snap
@@ -7,8 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import { clear } from "./repro12.js";
-import { clear$1, clear$1$1 } from "./repro22.js";
-import { clear$1$2, clear$2 as clear$2$1, clear$3 as clear$2 } from "./repro32.js";
+import { clear as clear$1, clear$1 as clear$1$1 } from "./repro22.js";
+import { clear as clear$2, clear$1 as clear$1$2, clear$2 as clear$2$1 } from "./repro32.js";
 
 //#region main.js
 var main_default = [
@@ -45,7 +45,7 @@ export { clear };
 ## repro2.js
 
 ```js
-import { clear$1 as clear, clear$1$1 as clear$1 } from "./repro22.js";
+import { clear, clear$1 } from "./repro22.js";
 
 export { clear, clear$1 };
 ```
@@ -57,12 +57,12 @@ const clear$1 = "repro2_clear$1";
 const clear = "repro2_clear";
 
 //#endregion
-export { clear as clear$1, clear$1 as clear$1$1 };
+export { clear, clear$1 };
 ```
 ## repro3.js
 
 ```js
-import { clear$1$2 as clear$1, clear$2, clear$3 as clear } from "./repro32.js";
+import { clear, clear$1, clear$2 } from "./repro32.js";
 
 export { clear, clear$1, clear$2 };
 ```
@@ -75,5 +75,5 @@ const clear$1 = "repro3_clear$1";
 const clear = "repro3_clear";
 
 //#endregion
-export { clear$1 as clear$1$2, clear$2, clear as clear$3 };
+export { clear, clear$1, clear$2 };
 ```

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import { __esm, __export } from "./rolldown-runtime.js";
-import { init_second, value$1 as value } from "./second.js";
+import { init_second, value } from "./second.js";
 
 //#region first.js
 var first_exports = {};
@@ -60,5 +60,5 @@ var init_second = __esm({ "second.js"() {
 } });
 
 //#endregion
-export { init_second, second_exports, value$1 };
+export { init_second, second_exports, value$1 as value };
 ```

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/_config.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entrya",
+        "import": "./entrya.js"
+      },
+      {
+        "name": "entryb",
+        "import": "./entryb.js"
+      }
+    ],
+    "preserveModules": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/a.js
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/a.js
@@ -1,0 +1,1 @@
+export const A = 10

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/artifacts.snap
@@ -1,0 +1,37 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+//#region a.js
+const A = 10;
+
+//#endregion
+export { A };
+```
+## b.js
+
+```js
+//#region b.js
+const A = 10;
+
+//#endregion
+export { A };
+```
+## entrya.js
+
+```js
+import { A } from "./a.js";
+
+export { A };
+```
+## entryb.js
+
+```js
+import { A } from "./b.js";
+
+export { A };
+```

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/b.js
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/b.js
@@ -1,0 +1,1 @@
+export const A = 10

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/entrya.js
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/entrya.js
@@ -1,0 +1,1 @@
+export * from './a.js'

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/entryb.js
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4698/entryb.js
@@ -1,0 +1,1 @@
+export * from './b.js'

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3835,11 +3835,11 @@ expression: output
 
 # tests/rolldown/code_splitting/issue_2786
 
-- main-!~{000}~.js => main-DMfLfpW7.js
-- share-!~{007}~.js => share-C5nb9-cM.js
+- main-!~{000}~.js => main-B7jq-oW0.js
+- share-!~{005}~.js => share-0pk_LKAe.js
+- share-!~{007}~.js => share-BHp_w4um.js
 - share-!~{003}~.js => share-Dt2p-BNK.js
 - share-!~{001}~.js => share-DyQhD9RN.js
-- share-!~{005}~.js => share-rRZDRwa0.js
 
 # tests/rolldown/dce/conditional_exports
 
@@ -4662,13 +4662,13 @@ expression: output
 
 # tests/rolldown/issues/3438
 
-- main-!~{000}~.js => main-DeOwicSS.js
+- main-!~{000}~.js => main-DT8feizy.js
 - repro1-!~{003}~.js => repro1-C2egieRJ.js
 - repro1-!~{001}~.js => repro1-DpFyQUSD.js
-- repro2-!~{007}~.js => repro2-ConQOs64.js
-- repro2-!~{005}~.js => repro2-VC8WBNxQ.js
-- repro3-!~{009}~.js => repro3-Bkc-1-TS.js
-- repro3-!~{00b}~.js => repro3-DTSyGhTl.js
+- repro2-!~{005}~.js => repro2-2ZzljHIE.js
+- repro2-!~{007}~.js => repro2-NY6EXoxf.js
+- repro3-!~{009}~.js => repro3-BuKsv5jH.js
+- repro3-!~{00b}~.js => repro3-DZYQEA0N.js
 
 # tests/rolldown/issues/3456
 
@@ -4680,10 +4680,10 @@ expression: output
 
 # tests/rolldown/issues/3650
 
-- main-!~{000}~.js => main-B9BdFReq.js
-- first-!~{005}~.js => first-BtNyylCt.js
+- main-!~{000}~.js => main-CC6Z5TkW.js
+- first-!~{005}~.js => first-DRp5dWf1.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BvgZlyOU.js
-- second-!~{003}~.js => second-DhdkmuDo.js
+- second-!~{003}~.js => second-BmolHkdL.js
 
 # tests/rolldown/issues/3746/a
 
@@ -4838,6 +4838,13 @@ expression: output
 - dynamic-!~{006}~.js => dynamic-15A52uWR.js
 - dynamic2-!~{002}~.js => dynamic2-RmRtogxQ.js
 - mod-!~{004}~.js => mod-BUtkwoP6.js
+
+# tests/rolldown/misc/preserve_modules/issue_4698
+
+- entrya-!~{000}~.js => entrya-BxVvbd2p.js
+- entryb-!~{001}~.js => entryb-B4vF9Taw.js
+- a-!~{002}~.js => a-C3oW5wmu.js
+- b-!~{004}~.js => b-BZyKveQf.js
 
 # tests/rolldown/misc/preserve_modules/issue_4700
 

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/restore-query-extension/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/restore-query-extension/index.ts.snap
@@ -1,6 +1,6 @@
 import { a_exports, name as name$1 } from "./a2.js";
-import { b_exports, name$1 as name$2 } from "./b2.js";
-import { modules_exports, name$2 as name$3 } from "./modules2.js";
+import { b_exports, name as name$2 } from "./b2.js";
+import { modules_exports, name as name$3 } from "./modules2.js";
 import { a_default } from "./a4.js";
 import { b_default } from "./b4.js";
 

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
@@ -1,6 +1,6 @@
 import { a_exports, name as name$1 } from "./a2.js";
-import { b_exports, name$1 as name$2 } from "./b2.js";
-import { modules_exports, name$2 as name$3 } from "./modules2.js";
+import { b_exports, name as name$2 } from "./b2.js";
+import { modules_exports, name as name$3 } from "./modules2.js";
 import { a_default } from "./a4.js";
 import { b_default } from "./b4.js";
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
- Should deconflict the export symbol name at the single chunk level rather than the whole build level.
- Closed #4698
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
