### PR TITLE
chore: force ignore files when `typos` lint-stage

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "*.@(js|ts|tsx)": [
       "pnpm lint-code -- --fix"
     ],
-    "*": "typos"
+    "*": "typos --force-exclude"
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
ref: https://github.com/crate-ci/typos/issues/1110
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
