### PR TITLE
docs(guide/plugin-development): fix typo in examples

### DIFF
--- a/docs/guide/plugin-development.md
+++ b/docs/guide/plugin-development.md
@@ -19,7 +19,7 @@ export default function myPlugin() {
         // early return
         return
       }
-      // preform actual transform
+      // perform actual transform
       return transformedCode
     },
   }
@@ -41,7 +41,7 @@ export default function myPlugin() {
         id: /\.data$/
       },
       handler (code) {
-        // preform actual transform
+        // perform actual transform
         return transformedCode
       },
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Small typo `preform` -> `perform`
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
