### PR TITLE
refactor(rust): align `resolve_id_check_external` with `rollup`

### DIFF
--- a/crates/rolldown/src/module_loader/resolve_utils.rs
+++ b/crates/rolldown/src/module_loader/resolve_utils.rs
@@ -16,6 +16,7 @@ use rolldown_common::{
 use rolldown_error::{BuildDiagnostic, BuildResult, DiagnosableArcstr, EventKind};
 
 use crate::{SharedOptions, SharedResolver};
+
 #[tracing::instrument(skip_all, fields(CONTEXT_hook_resolve_id_trigger = "automatic"))]
 pub(crate) async fn resolve_id(
   bundle_options: &SharedOptions,

--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -181,7 +181,7 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
     raw_options.cwd.unwrap_or_else(|| std::env::current_dir().expect("Failed to get current dir"));
   let normalized = NormalizedBundlerOptions {
     input: raw_options.input.unwrap_or_default(),
-    external: raw_options.external,
+    external: raw_options.external.unwrap_or_default(),
     treeshake: raw_options.treeshake.into_normalized_options(),
     platform,
     name: raw_options.name,

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -38,7 +38,7 @@ pub struct NormalizedBundlerOptions {
   // --- Input
   pub input: Vec<InputItem>,
   pub cwd: PathBuf,
-  pub external: Option<IsExternal>,
+  pub external: IsExternal,
   /// corresponding to `false | NormalizedTreeshakeOption`
   pub treeshake: NormalizedTreeshakeOptions,
   pub platform: Platform,

--- a/crates/rolldown_common/src/types/resolved_request_info.rs
+++ b/crates/rolldown_common/src/types/resolved_request_info.rs
@@ -33,7 +33,7 @@ impl From<bool> for ResolvedExternal {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct ResolvedId {
   pub id: ArcStr,
   // https://github.com/defunctzombie/package-browser-field-spec/blob/8c4869f6a5cb0de26d208de804ad0a62473f5a03/README.md?plain=1#L62-L77

--- a/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use arcstr::ArcStr;
 use rolldown_common::{
-  ImportKind, MakeAbsoluteExternalsRelative, ModuleDefFormat, ResolvedExternal, ResolvedId,
+  ImportKind, MakeAbsoluteExternalsRelative, ResolvedExternal, ResolvedId,
   SharedNormalizedBundlerOptions,
 };
 use rolldown_resolver::{ResolveError, Resolver};
@@ -19,7 +19,7 @@ use super::resolve_id_with_plugins::is_data_url;
 pub async fn resolve_id_check_external(
   resolver: &Resolver,
   plugin_driver: &PluginDriver,
-  request: &str,
+  specifier: &str,
   importer: Option<&str>,
   is_entry: bool,
   import_kind: ImportKind,
@@ -29,16 +29,14 @@ pub async fn resolve_id_check_external(
   bundle_options: &SharedNormalizedBundlerOptions,
 ) -> anyhow::Result<Result<ResolvedId, ResolveError>> {
   // Check external with unresolved path
-  if let Some(resolve_id) =
-    check_external_with_request(request, importer, bundle_options, false).await?
-  {
-    return Ok(Ok(resolve_id));
+  if bundle_options.external.call(specifier, importer, false).await? {
+    return Ok(Ok(resolve_external(bundle_options, specifier, importer, true).await?.unwrap()));
   }
 
   let resolved_id = resolve_id_with_plugins(
     resolver,
     plugin_driver,
-    request,
+    specifier,
     importer,
     is_entry,
     import_kind,
@@ -50,56 +48,45 @@ pub async fn resolve_id_check_external(
 
   match resolved_id {
     Ok(mut resolved_id) => {
-      if matches!(resolved_id.external, ResolvedExternal::Bool(false)) {
-        // Check external with resolved path
-        if let Some(is_external) = bundle_options.external.as_ref() {
-          resolved_id.external = is_external(resolved_id.id.as_str(), importer, true).await?.into();
-        }
+      if matches!(resolved_id.normalize_external_id, Some(true)) {
+        return Ok(Ok(
+          resolve_external(bundle_options, &resolved_id.id, importer, true).await?.unwrap(),
+        ));
       }
-
-      match resolved_id.external {
-        ResolvedExternal::Bool(true) => {
+      let external = match resolved_id.external {
+        ResolvedExternal::Bool(false) => {
+          let specifier = resolved_id.id.as_str();
+          bundle_options.external.call(specifier, importer, true).await?.into()
+        }
+        _ => resolved_id.external,
+      };
+      resolved_id.external = match external {
+        ResolvedExternal::Bool(false) => ResolvedExternal::Bool(false),
+        ResolvedExternal::Relative => ResolvedExternal::Bool(true),
+        _ => {
           if !is_absolute(resolved_id.id.as_str())
-            || is_not_absolute_external(
-              resolved_id.id.as_str(),
-              request,
-              &bundle_options.make_absolute_externals_relative,
-            )
+            || (matches!(external, ResolvedExternal::Bool(true))
+              && is_not_absolute_external(
+                resolved_id.id.as_str(),
+                specifier,
+                &bundle_options.make_absolute_externals_relative,
+              ))
           {
-            resolved_id.external = true.into();
+            ResolvedExternal::Bool(true)
           } else {
-            resolved_id.external = ResolvedExternal::Absolute;
-          }
-
-          if matches!(resolved_id.normalize_external_id, Some(true))
-            && bundle_options.make_absolute_externals_relative.is_enabled()
-          {
-            resolved_id.id =
-              normalize_relative_external_id(&resolved_id.id, importer, &bundle_options.cwd);
+            ResolvedExternal::Absolute
           }
         }
-        ResolvedExternal::Absolute => {
-          if is_absolute(resolved_id.id.as_str()) {
-            resolved_id.external = ResolvedExternal::Absolute;
-          } else {
-            resolved_id.external = true.into();
-          }
-        }
-        ResolvedExternal::Relative => {
-          resolved_id.external = true.into();
-        }
-        ResolvedExternal::Bool(false) => {}
-      }
-
+      };
       Ok(Ok(resolved_id))
     }
     Err(e) => {
       if let ResolveError::NotFound(_) = &e {
         // If module can't resolve, check external with unresolved path with `isResolved: true`
-        if let Some(resolve_id) =
-          check_external_with_request(request, importer, bundle_options, true).await?
+        if let Some(resolved_id) =
+          resolve_external(bundle_options, specifier, importer, false).await?
         {
-          return Ok(Ok(resolve_id));
+          return Ok(Ok(resolved_id));
         }
       }
       Ok(Err(e))
@@ -107,68 +94,54 @@ pub async fn resolve_id_check_external(
   }
 }
 
-async fn check_external_with_request(
-  request: &str,
+async fn resolve_external(
+  options: &SharedNormalizedBundlerOptions,
+  specifier: &str,
   importer: Option<&str>,
-  bundle_options: &SharedNormalizedBundlerOptions,
-  is_resolved: bool,
+  is_external: bool,
 ) -> anyhow::Result<Option<ResolvedId>> {
-  // ref https://github.com/rollup/rollup/blob/master/src/ModuleLoader.ts#L555
-  if let Some(is_external) = bundle_options.external.as_ref() {
-    let id = if bundle_options.make_absolute_externals_relative.is_enabled() {
-      normalize_relative_external_id(request, importer, &bundle_options.cwd)
-    } else {
-      request.into()
-    };
-    let raw_request = if is_resolved { &id } else { request };
-    if is_external(raw_request, importer, is_resolved).await? {
-      let external =
-        if is_not_absolute_external(&id, request, &bundle_options.make_absolute_externals_relative)
-        {
-          true.into()
-        } else {
-          ResolvedExternal::Absolute
-        };
-      return Ok(Some(ResolvedId {
-        id,
-        ignored: false,
-        module_def_format: ModuleDefFormat::Unknown,
-        external,
-        normalize_external_id: None,
-        package_json: None,
-        side_effects: None,
-        is_external_without_side_effects: false,
-      }));
-    }
+  let id = if options.make_absolute_externals_relative.is_enabled() {
+    normalize_relative_external_id(&options.cwd, specifier, importer)
+  } else {
+    specifier.into()
+  };
+
+  if !is_external && !options.external.call(&id, importer, true).await? {
+    return Ok(None);
   }
-  Ok(None)
+
+  let external =
+    if is_not_absolute_external(&id, specifier, &options.make_absolute_externals_relative) {
+      ResolvedExternal::Bool(true)
+    } else {
+      ResolvedExternal::Absolute
+    };
+
+  Ok(Some(ResolvedId { id, external, ..Default::default() }))
 }
 
 fn is_not_absolute_external(
   id: &str,
-  source: &str,
+  specifier: &str,
   make_absolute_externals_relative: &MakeAbsoluteExternalsRelative,
 ) -> bool {
-  matches!(make_absolute_externals_relative, MakeAbsoluteExternalsRelative::Bool(true))
-    || (matches!(make_absolute_externals_relative, MakeAbsoluteExternalsRelative::IfRelativeSource)
-      && is_relative(source))
-    || !is_absolute(id)
+  match make_absolute_externals_relative {
+    MakeAbsoluteExternalsRelative::Bool(true) => true,
+    MakeAbsoluteExternalsRelative::IfRelativeSource if is_relative(specifier) => true,
+    _ => !is_absolute(id),
+  }
 }
 
-fn normalize_relative_external_id(source: &str, importer: Option<&str>, root: &Path) -> ArcStr {
-  if is_relative(source) {
-    if let Some(importer) = importer {
-      if is_data_url(importer) {
-        source.into()
-      } else {
-        Path::new(importer).join("..").join(source).normalize().to_string_lossy().into()
-      }
-    } else {
-      root.join(source).normalize().to_string_lossy().into()
-    }
-  } else {
-    source.into()
+fn normalize_relative_external_id(cwd: &Path, specifier: &str, importer: Option<&str>) -> ArcStr {
+  if !is_relative(specifier) || importer.is_some_and(is_data_url) {
+    return specifier.into();
   }
+  let path = if let Some(importer) = importer {
+    Path::new(importer).join("..").join(specifier)
+  } else {
+    cwd.join(specifier)
+  };
+  path.normalize().to_string_lossy().into()
 }
 
 #[inline]

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -147,10 +147,7 @@ export function bindingifyResolveId(
         };
       }
       if (typeof ret === 'string') {
-        return {
-          id: ret,
-          normalizeExternalId: true,
-        };
+        return { id: ret, normalizeExternalId: false };
       }
 
       // Make sure the `moduleSideEffects` is update to date

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -344,6 +344,9 @@ const InputOptionsSchema = v.strictObject({
   input: v.optional(InputOptionSchema),
   plugins: v.optional(v.custom<RolldownPluginOption>(() => true)),
   external: v.optional(ExternalSchema),
+  makeAbsoluteExternalsRelative: v.optional(
+    v.union([v.boolean(), v.literal('ifRelativeSource')]),
+  ),
   resolve: v.optional(ResolveOptionsSchema),
   cwd: v.pipe(
     v.optional(v.string()),
@@ -450,6 +453,10 @@ const InputCliOverrideSchema = v.strictObject({
   treeshake: v.pipe(
     v.optional(v.boolean()),
     v.description('enable treeshaking'),
+  ),
+  makeAbsoluteExternalsRelative: v.pipe(
+    v.optional(v.boolean()),
+    v.description('Prevent normalization of external imports'),
   ),
   jsx: v.pipe(
     v.optional(

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -56,6 +56,7 @@ OPTIONS
   --keep-names                Keep function/class name.
   --legal-comments <legal-comments>Control comments in the output.
   --log-level <log-level>     Log level (silent, info, debug, warn).
+  --make-absolute-externals-relative Prevent normalization of external imports.
   --module-types <types>      Module types for customized extensions.
   --no-external-live-bindings Disable external live bindings.
   --no-treeshake              Disable treeshaking.

--- a/packages/rolldown/tests/fixtures/plugin/resolve-id/return-string-with-external/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-id/return-string-with-external/_config.ts
@@ -1,0 +1,24 @@
+import path from 'node:path'
+import { expect } from 'vitest'
+import { defineTest } from 'rolldown-tests'
+
+const entry = path.join(__dirname, './main.js')
+
+export default defineTest({
+  config: {
+    input: entry,
+    external: /\.\/bar.js/,
+    plugins: [{
+      name: 'test',
+      resolveId(source) {
+        if (source === './foo') {
+          return './bar.js';
+        }
+      },
+      buildEnd() {
+        const target = [...this.getModuleIds()].find((v) => v === './bar.js');
+        expect(target).toBeDefined()
+      },
+    }],
+  }
+})

--- a/packages/rolldown/tests/fixtures/plugin/resolve-id/return-string-with-external/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-id/return-string-with-external/main.js
@@ -1,0 +1,2 @@
+import { a } from './foo'
+console.log(a)


### PR DESCRIPTION
### Description

Related to #4634

I realigned the `external` resolution logic and addressed several edge cases to ensure consistency.