### PR TITLE
chore(infra): remove `skipWindows`

### DIFF
--- a/crates/rolldown/tests/integration_rolldown.rs
+++ b/crates/rolldown/tests/integration_rolldown.rs
@@ -39,10 +39,6 @@ async fn filename_with_hash() {
     let TestConfig { config: mut options, meta, config_variants: _not_supported } =
       read_test_config(config_path);
 
-    if meta.skip_windows && cfg!(target_os = "windows") {
-      return;
-    }
-
     if options.cwd.is_none() {
       options.cwd = Some(fixture_path.to_path_buf());
     }

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4706/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4706/_config.json
@@ -8,6 +8,5 @@
     ],
     "preserveModules": true
   },
-  "expectExecuted": false,
-  "skipWindows": true
+  "expectExecuted": false
 }

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -208,7 +208,7 @@ impl Chunk {
       let p = p.relative(self.input_base.as_str());
       Cow::Owned(p.to_slash_lossy().to_string())
     } else {
-      Cow::Owned(PathBuf::from(&options.virtual_dirname).join(p).to_string_lossy().to_string())
+      Cow::Owned(PathBuf::from(&options.virtual_dirname).join(p).to_slash_lossy().to_string())
     }
   }
 

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -37,11 +37,6 @@
       "default": true,
       "type": "boolean"
     },
-    "skipWindows": {
-      "description": "Sometimes, it is cumbersome to handle some windows-specific path issue in tests. Usually it is related tests of `preserve_modules`.We can't just replace all `\\\\` into '/', in path, because the Windows format path will also affect the hash, which leads `filename_with_hash.rs` tests failed.",
-      "default": false,
-      "type": "boolean"
-    },
     "snapshotBytes": {
       "description": "If `true`, bytes source will be snapshot.",
       "default": false,

--- a/crates/rolldown_testing/src/fixture.rs
+++ b/crates/rolldown_testing/src/fixture.rs
@@ -32,10 +32,6 @@ impl Fixture {
     let TestConfig { config: mut options, meta, config_variants } =
       read_test_config(&self.config_path);
 
-    if meta.skip_windows && cfg!(target_os = "windows") {
-      return;
-    }
-
     if options.cwd.is_none() {
       options.cwd = Some(self.fixture_path.clone());
     }

--- a/crates/rolldown_testing_config/src/lib.rs
+++ b/crates/rolldown_testing_config/src/lib.rs
@@ -108,11 +108,6 @@ pub struct TestMeta {
   /// If `true`, the bundle will be called with `write()` instead of `generate()`.
   #[serde(default = "true_by_default")]
   pub write_to_disk: bool,
-  /// Sometimes, it is cumbersome to handle some windows-specific path issue in tests.
-  /// Usually it is related tests of `preserve_modules`.We can't just replace all `\\` into '/',
-  /// in path, because the Windows format path will also affect the hash, which leads `filename_with_hash.rs` tests failed.
-  #[serde(default = "false_by_default")]
-  pub skip_windows: bool,
 }
 
 impl Default for TestMeta {
@@ -123,8 +118,4 @@ impl Default for TestMeta {
 
 fn true_by_default() -> bool {
   true
-}
-
-fn false_by_default() -> bool {
-  false
 }


### PR DESCRIPTION
### Description

The `skipWindows` prevents snapshot updates on Windows, which can lead to CI failures due to outdated snapshots.