### PR TITLE
chore: change stackblitz URL to auto fork one

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Reproduction link or steps
       description: |
-        - Use [stackblitz](https://stackblitz.com/github/rolldown/rolldown-starter-stackblitz) to create a minimal reproduction and share the link.
+        - Use [stackblitz](https://stackblitz.com/fork/github/rolldown/rolldown-starter-stackblitz) to create a minimal reproduction and share the link.
         - Or provide a minimal repository on GitHub that can reproduce the issue. You could use [this template](https://github.com/rolldown/rolldown-starter-stackblitz).
       placeholder: Reproduction link or steps
     validations:

--- a/.github/workflows/automation-labeled.yml
+++ b/.github/workflows/automation-labeled.yml
@@ -48,7 +48,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.issue.number }}
-          body: 'Thanks for reporting this issue! To help us investigate and resolve it more efficiently, could you provide a minimal reproduction? You can either create a [StackBlitz project](https://stackblitz.com/github/rolldown/rolldown-starter-stackblitz?file=README.md) or a GitHub repository demonstrating the problem. This will make it easier for us to debug and find a solution. Thanks!'
+          body: 'Thanks for reporting this issue! To help us investigate and resolve it more efficiently, could you provide a minimal reproduction? You can either create a [StackBlitz project](https://stackblitz.com/fork/github/rolldown/rolldown-starter-stackblitz?file=README.md) or a GitHub repository demonstrating the problem. This will make it easier for us to debug and find a solution. Thanks!'
           reactions-edit-mode: 'replace'
           edit-mode: replace
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 <div align="center">
 
-[![rolldown-starter-stackblitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/rolldown/rolldown-starter-stackblitz)
+[![rolldown-starter-stackblitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/rolldown/rolldown-starter-stackblitz)
 
 </div>
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Replaced https://stackblitz.com/github/rolldown/rolldown-starter-stackblitz with https://stackblitz.com/fork/github/rolldown/rolldown-starter-stackblitz.

The new URL will fork the project automatically. The old URL didn't do that and saving a change triggered forking it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
