### PR TITLE
chore(ci): pin oxc versions; run rust CI when pnpm-lock.yaml changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
-              - 'deny.toml'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
               - '.gitattributes'
             node-changes:
               - *rust-changes
@@ -51,8 +52,6 @@ jobs:
               - 'examples/**'
               - 'scripts/**'
               - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
             pluginutils-changes:
               - 'packages/pluginutils/**'
               - 'package.json'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,9 +193,9 @@ napi-derive = { version = "3.0.0-beta.1", default-features = false, features = [
 
 # oxc crates with the same version
 
-oxc = { version = "0.72.1", features = ["ast_visit", "transformer", "minifier", "mangler", "semantic", "codegen", "serialize", "isolated_declarations", "regular_expression", "cfg"] }
-oxc_parser_napi = { version = "0.72.1" }
-oxc_transform_napi = { version = "0.72.1" }
+oxc = { version = "=0.72.2", features = ["ast_visit", "transformer", "minifier", "mangler", "semantic", "codegen", "serialize", "isolated_declarations", "regular_expression", "cfg"] }
+oxc_parser_napi = { version = "=0.72.2" }
+oxc_transform_napi = { version = "=0.72.2" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,16 +13,16 @@ catalogs:
       specifier: ^0.0.27
       version: 0.0.27
     '@oxc-project/runtime':
-      specifier: 0.72.2
+      specifier: '=0.72.2'
       version: 0.72.2
     '@oxc-project/types':
-      specifier: 0.72.2
+      specifier: '=0.72.2'
       version: 0.72.2
     oxc-parser:
-      specifier: 0.72.2
+      specifier: '=0.72.2'
       version: 0.72.2
     oxc-transform:
-      specifier: 0.72.2
+      specifier: '=0.72.2'
       version: 0.72.2
     rolldown-plugin-dts:
       specifier: ^0.13.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,9 +18,9 @@ shellEmulator: true
 catalog:
   '@oxc-node/cli': '^0.0.27'
   '@oxc-node/core': '^0.0.27'
-  '@oxc-project/runtime': '0.72.2'
-  '@oxc-project/types': '0.72.2'
-  'oxc-parser': '0.72.2'
-  'oxc-transform': '0.72.2'
+  '@oxc-project/runtime': '=0.72.2'
+  '@oxc-project/types': '=0.72.2'
+  'oxc-parser': '=0.72.2'
+  'oxc-transform': '=0.72.2'
   'tsdown': '0.12.6'
   'rolldown-plugin-dts': '^0.13.6'


### PR DESCRIPTION
pin oxc versions so that renovate lock file maintainance won't auto change them.

