### PR TITLE
feat: warn when assignment to bundle is detected

### DIFF
--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -188,17 +188,18 @@ export function bindingifyGenerateBundle(
         updated: new Set(),
         deleted: new Set(),
       } as ChangedOutputs;
-      const output = transformToOutputBundle(bundle, changed);
+      const context = new PluginContextImpl(
+        args.outputOptions,
+        ctx,
+        args.plugin,
+        args.pluginContextData,
+        args.onLog,
+        args.logLevel,
+        args.watchMode,
+      );
+      const output = transformToOutputBundle(context, bundle, changed);
       await handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
+        context,
         new NormalizedOutputOptionsImpl(
           opts,
           args.outputOptions,
@@ -228,17 +229,18 @@ export function bindingifyWriteBundle(
         updated: new Set(),
         deleted: new Set(),
       } as ChangedOutputs;
-      const output = transformToOutputBundle(bundle, changed);
+      const context = new PluginContextImpl(
+        args.outputOptions,
+        ctx,
+        args.plugin,
+        args.pluginContextData,
+        args.onLog,
+        args.logLevel,
+        args.watchMode,
+      );
+      const output = transformToOutputBundle(context, bundle, changed);
       await handler.call(
-        new PluginContextImpl(
-          args.outputOptions,
-          ctx,
-          args.plugin,
-          args.pluginContextData,
-          args.onLog,
-          args.logLevel,
-          args.watchMode,
-        ),
+        context,
         new NormalizedOutputOptionsImpl(
           opts,
           args.outputOptions,

--- a/packages/rollup-tests/src/ignored-tests.js
+++ b/packages/rollup-tests/src/ignored-tests.js
@@ -6,12 +6,12 @@ const ignoreTests = [
   'rollup@function@preserve-symlink: follows symlinks',
   'rollup@function@symlink: follows symlinks',
   "rollup@form@sourcemaps-inline: correct sourcemaps are written (inline)@generates es",
- 
+
   // The result is not working as expected
   "rollup@function@module-side-effect-reexport: includes side effects of re-exporters unless they have moduleSideEffects: false",// https://github.com/rolldown/rolldown/issues/2864
   "rollup@form@hoisted-vars-in-dead-branches: renders hoisted variables in dead branches", // https://github.com/oxc-project/oxc/issues/7209
   "rollup@function@hoisted-variable-if-else: handles hoisted variables in chained if statements",// https://github.com/oxc-project/oxc/issues/7209
-  "rollup@function@argument-deoptimization@global-calls: tracks argument mutations of calls to globals", // need as esm if module is unknow-format and add `use strcit` to the output, https://github.com/rolldown/rolldown/issues/2394
+  "rollup@function@argument-deoptimization@global-calls: tracks argument mutations of calls to globals", // need as esm if module is unknown-format and add `use strcit` to the output, https://github.com/rolldown/rolldown/issues/2394
 
   // /*@__PURE__*/ related
   "rollup@form@pure-comment-scenarios-complex: correctly handles various advanced pure comment scenarios",// https://github.com/oxc-project/oxc/issues/7501 https://github.com/oxc-project/oxc/issues/7209#issuecomment-2503133537 The `assigned to unreferenced var will be dropped` is a minify featrue
@@ -19,7 +19,9 @@ const ignoreTests = [
 
   "rollup@hooks@assigns chunk IDs before creating outputBundle chunks", // The `renderChunk` is called at parallel, collect chunk info to array is unstable.  https://github.com/rolldown/rolldown/issues/2364
   "rollup@form@non-empty-block-statement: do not remove non an empty block statement@generates es", // https://github.com/rolldown/rolldown/pull/3541#issuecomment-2649731213
-  "rollup@function@es5-class-called-without-new" // rolldown align directive rendering with esbuild
+  "rollup@function@es5-class-called-without-new", // rolldown align directive rendering with esbuild
+
+  "rollup@function@generate-bundle-mutation: handles adding or deleting symbols in generateBundle", // rolldown outputs a warning when assigning to bundle[foo]
 ]
 
 module.exports = {

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,9 +1,9 @@
 {
   "failed": 0,
   "skipFailed": 1,
-  "ignored": 13,
+  "ignored": 14,
   "ignored(unsupported features)": 407,
   "ignored(treeshaking)": 287,
   "ignored(behavior passed, snapshot different)": 123,
-  "passed": 717
+  "passed": 716
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -2,8 +2,8 @@
 |----| ---- |
 | failed | 0 |
 | skipFailed | 1 |
-| ignored | 13 |
+| ignored | 14 |
 | ignored(unsupported features) | 407 |
 | ignored(treeshaking) | 287 |
 | ignored(behavior passed, snapshot different) | 123 |
-| passed | 717 |
+| passed | 716 |


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When `bunde[foo] = something` is executed, show a warning so that users can notice that the plugin is not compatible and the plugin should update the code.

refs https://github.com/vitejs/rolldown-vite/issues/204#issuecomment-2929944348

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
