### PR TITLE
test: should apply `treeshake` when enable preserve-modules

### DIFF
--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/tree-shake/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/tree-shake/_config.ts
@@ -1,0 +1,13 @@
+import { defineTest } from 'rolldown-tests'
+
+
+export default defineTest({
+  config: {
+    output: {
+      preserveModules: true
+    }
+  },
+  afterTest: async (output) => {
+    await import('./_test.mjs')
+  },
+})

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/tree-shake/_test.mjs
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/tree-shake/_test.mjs
@@ -1,0 +1,7 @@
+import lib from './dist/main.js'
+import assert from 'node:assert'
+
+
+assert.strictEqual(lib.lib, 'lib')
+assert.strictEqual(lib.a, undefined)
+

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/tree-shake/lib.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/tree-shake/lib.js
@@ -1,0 +1,2 @@
+export const lib = 'lib'
+export const a = 'a'

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/tree-shake/main.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/tree-shake/main.js
@@ -1,0 +1,7 @@
+import * as lib from './lib'
+
+
+export default {
+  lib: lib.lib,
+}
+


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
