### PR TITLE
test: use `--no-frozen-lockfile` for rolldown-vite tests

### DIFF
--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -51,7 +51,7 @@ fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
 await runCmdAndPipe(
   '# Running `pnpm install`...',
-  ['pnpm', ['install'], { nodeOptions: { cwd: REPO_PATH } }],
+  ['pnpm', ['install', '--no-frozen-lockfile'], { nodeOptions: { cwd: REPO_PATH } }],
 );
 await runCmdAndPipe(
   '# Running `pnpm run build`...',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I forgot that `--frozen-lockfile` is automatically enabled in CI.

refs #4794

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
