### PR TITLE
feat: take node esm spec into account for dynamic imports in cjs modules that satisfy nodejs

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -153,7 +153,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               self.snippet.builder.vec(),
               false,
             ),
-            self.ctx.module.should_consider_node_esm_spec(),
+            self.ctx.module.should_consider_node_esm_spec_for_static_import(),
           ),
         );
         return false;
@@ -914,7 +914,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                     self.snippet.builder.atom(to_esm_fn_name.as_str()),
                   ),
                   self.snippet.call_expr_expr(importee_wrapper_ref_name),
-                  self.ctx.module.should_consider_node_esm_spec(),
+                  self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
                 ),
               ))
             }
@@ -961,7 +961,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               self.finalized_expr_for_runtime_symbol("__toDynamicImportESM");
 
             let mut arguments = self.snippet.builder.vec();
-            if self.ctx.module.should_consider_node_esm_spec() {
+            if self.ctx.module.should_consider_node_esm_spec_for_dynamic_import() {
               arguments.push(ast::Argument::from(self.snippet.builder.expression_numeric_literal(
                 SPAN,
                 1.0,
@@ -1105,7 +1105,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                                 false,
                               ),
                             ),
-                            self.ctx.module.should_consider_node_esm_spec(),
+                            self.ctx.module.should_consider_node_esm_spec_for_static_import(),
                           ),
                         ),
                       }
@@ -1274,7 +1274,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               self.finalized_expr_for_runtime_symbol("__toDynamicImportESM");
 
             let mut arguments = self.snippet.builder.vec();
-            if self.ctx.module.should_consider_node_esm_spec() {
+            if self.ctx.module.should_consider_node_esm_spec_for_dynamic_import() {
               arguments.push(ast::Argument::from(self.snippet.builder.expression_numeric_literal(
                 SPAN,
                 1.0,

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 
-export { __commonJS, __toDynamicImportESM };
+export { __commonJS, __toDynamicImportESM, __toESM };
 ```
 ## lib.js
 
@@ -27,27 +27,44 @@ export default require_lib();
 ## main.js
 
 ```js
-import { __toDynamicImportESM } from "./chunk.js";
+import { __commonJS, __toDynamicImportESM, __toESM } from "./chunk.js";
 import nodeAssert from "node:assert";
 
 //#region non-node-mode.js
-async function main$1() {
+async function main$2() {
 	const exports = await import("./lib.js").then(__toDynamicImportESM());
 	nodeAssert.deepEqual(Object.keys(exports).sort(), ["parse"]);
 	nodeAssert.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
 	nodeAssert.strictEqual(exports.default, void 0, "Target has __esModule, so no auto-generated default export");
 }
-main$1();
+main$2();
 
 //#endregion
 //#region node-mode-by-mjs-extension.mjs
-async function main() {
+async function main$1() {
 	const exports = await import("./lib.js").then(__toDynamicImportESM(1));
 	nodeAssert.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
 	nodeAssert.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
 	nodeAssert.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
-main();
+main$1();
+
+//#endregion
+//#region node-mode-by-cjs-extension.cjs
+var require_node_mode_by_cjs_extension = __commonJS({ "node-mode-by-cjs-extension.cjs"(exports, module) {
+	async function main() {
+		const exports = await import("./lib.js").then(__toDynamicImportESM(1));
+		nodeAssert.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
+		nodeAssert.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
+		nodeAssert.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
+	}
+	main();
+	module.exports = {};
+} });
+
+//#endregion
+//#region main.js
+var import_node_mode_by_cjs_extension = __toESM(require_node_mode_by_cjs_extension());
 
 //#endregion
 ```
@@ -107,23 +124,40 @@ const require_chunk = require('./chunk.js');
 const node_assert = require_chunk.__toESM(require("node:assert"));
 
 //#region non-node-mode.js
-async function main$1() {
+async function main$2() {
 	const exports$1 = await Promise.resolve().then(() => require_chunk.__toDynamicImportESM()(require("./lib.js")));
 	node_assert.default.deepEqual(Object.keys(exports$1).sort(), ["parse"]);
 	node_assert.default.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 	node_assert.default.strictEqual(exports$1.default, void 0, "Target has __esModule, so no auto-generated default export");
 }
-main$1();
+main$2();
 
 //#endregion
 //#region node-mode-by-mjs-extension.mjs
-async function main() {
+async function main$1() {
 	const exports$1 = await Promise.resolve().then(() => require_chunk.__toDynamicImportESM(1)(require("./lib.js")));
 	node_assert.default.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
 	node_assert.default.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 	node_assert.default.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
-main();
+main$1();
+
+//#endregion
+//#region node-mode-by-cjs-extension.cjs
+var require_node_mode_by_cjs_extension = require_chunk.__commonJS({ "node-mode-by-cjs-extension.cjs"(exports, module) {
+	async function main() {
+		const exports$1 = await Promise.resolve().then(() => require_chunk.__toDynamicImportESM(1)(require("./lib.js")));
+		node_assert.default.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
+		node_assert.default.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
+		node_assert.default.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
+	}
+	main();
+	module.exports = {};
+} });
+
+//#endregion
+//#region main.js
+var import_node_mode_by_cjs_extension = require_chunk.__toESM(require_node_mode_by_cjs_extension());
 
 //#endregion
 ```
@@ -147,23 +181,40 @@ var require_lib = __commonJS({ "lib.js"(exports) {
 
 //#endregion
 //#region non-node-mode.js
-async function main$1() {
+async function main$2() {
 	const exports$1 = await Promise.resolve().then(() => __toESM(require_lib()));
 	nodeAssert.deepEqual(Object.keys(exports$1).sort(), ["parse"]);
 	nodeAssert.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 	nodeAssert.strictEqual(exports$1.default, void 0, "Target has __esModule, so no auto-generated default export");
 }
-main$1();
+main$2();
 
 //#endregion
 //#region node-mode-by-mjs-extension.mjs
-async function main() {
+async function main$1() {
 	const exports$1 = await Promise.resolve().then(() => __toESM(require_lib(), 1));
 	nodeAssert.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
 	nodeAssert.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 	nodeAssert.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
-main();
+main$1();
+
+//#endregion
+//#region node-mode-by-cjs-extension.cjs
+var require_node_mode_by_cjs_extension = __commonJS({ "node-mode-by-cjs-extension.cjs"(exports, module) {
+	async function main() {
+		const exports$1 = await Promise.resolve().then(() => __toESM(require_lib(), 1));
+		nodeAssert.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
+		nodeAssert.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
+		nodeAssert.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
+	}
+	main();
+	module.exports = {};
+} });
+
+//#endregion
+//#region main.js
+var import_node_mode_by_cjs_extension = __toESM(require_node_mode_by_cjs_extension());
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/issues/4289/main.js
+++ b/crates/rolldown/tests/rolldown/issues/4289/main.js
@@ -1,2 +1,3 @@
 import './non-node-mode'
 import './node-mode-by-mjs-extension.mjs'
+import './node-mode-by-cjs-extension.cjs'

--- a/crates/rolldown/tests/rolldown/issues/4289/node-mode-by-cjs-extension.cjs
+++ b/crates/rolldown/tests/rolldown/issues/4289/node-mode-by-cjs-extension.cjs
@@ -1,0 +1,13 @@
+import nodeAssert from 'node:assert';
+
+async function main() {
+  const exports = await import('./lib.js');
+
+  nodeAssert.deepEqual(Object.keys(exports).sort(), ['default', 'parse']);
+  nodeAssert.strictEqual(exports.parse, 'parse', 'Expected export exists and is correct');
+  nodeAssert.strictEqual(exports.default.parse, 'parse', 'Target has __esModule, but this file triggered node compat mode');
+}
+
+main()
+
+module.exports = {}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4686,9 +4686,9 @@ expression: output
 
 # tests/rolldown/issues/4289
 
-- main-!~{000}~.js => main-BRpkZFvs.js
-- chunk-!~{001}~.js => chunk-BAbtX2hM.js
-- lib-!~{003}~.js => lib-DsLjAtIi.js
+- main-!~{000}~.js => main-BjZFiMIo.js
+- chunk-!~{001}~.js => chunk-e6zvK7dF.js
+- lib-!~{003}~.js => lib-DXD_OL-7.js
 
 # tests/rolldown/issues/4390
 

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -200,8 +200,15 @@ impl NormalModule {
   // - `package.json` has `"type": "module"`
   // , we need to consider to stimulate the Node.js ESM behavior for maximum compatibility.
   #[inline]
-  pub fn should_consider_node_esm_spec(&self) -> bool {
+  pub fn should_consider_node_esm_spec_for_static_import(&self) -> bool {
     self.ecma_view.def_format.is_esm()
+  }
+
+  #[inline]
+  pub fn should_consider_node_esm_spec_for_dynamic_import(&self) -> bool {
+    // Dynamic imports in cjs must be written targeting node platform.
+    // So we always consider Node.js ESM spec for dynamic imports in cjs modules, even if modules aren't explicitly marked as cjs.
+    self.ecma_view.def_format.is_esm() || self.ecma_view.def_format.is_commonjs()
   }
 
   pub fn render(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Related to #4289.

@sapphi-red pointed out that dynamic imports in cjs is a thing that's quite specfic to nodejs. So to improve compatibilities of `import('some-cjs-module.js')`, now rolldown always considers node esm spec for dynamic imports in cjs modules.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
