### PR TITLE
refactor: reuse previous facade scoping when generate lazy_exports

### DIFF
--- a/crates/rolldown_common/src/types/ast_scopes.rs
+++ b/crates/rolldown_common/src/types/ast_scopes.rs
@@ -53,6 +53,10 @@ impl AstScopes {
     self.scoping = scoping;
   }
 
+  pub fn set_facade_scope(&mut self, facade_scoping: FacadeScoping) {
+    self.facade_scoping = facade_scoping;
+  }
+
   pub fn is_unresolved(&self, reference_id: ReferenceId) -> bool {
     self.scoping.get_reference(reference_id).symbol_id().is_none()
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
1. Reuse facade_scoping so that we don't need to recreate each facade symbols, which make it less error-prune
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
