### PR TITLE
fix: cjs namespace property optimization access should only apply to ns_alias prop `default`

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -265,9 +265,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         .is_some_and(|resolved_module| {
           self.ctx.linking_infos[*resolved_module].safe_cjs_to_eliminate_interop_default
         });
+
       expr = if is_safe_cjs_to_eliminate_interop_default
         && original_reference_id
           .is_some_and(|item| self.interested_namespace_alias_ref_id.contains(&item))
+        && ns_alias.property_name.as_str() == "default"
       {
         expr
       } else {

--- a/crates/rolldown/tests/rolldown/cjs_compat/react-like/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/react-like/artifacts.snap
@@ -14,6 +14,7 @@ var require_react = __commonJS({ "react.js"(exports) {
 	exports.createReactElement = function() {
 		return "div";
 	};
+	exports.version = 1;
 } });
 
 //#endregion
@@ -23,9 +24,17 @@ var require_commonjs = __commonJS({ "commonjs.js"(exports, module) {
 } });
 
 //#endregion
+//#region commonjs2.js
+var require_commonjs2 = __commonJS({ "commonjs2.js"(exports, module) {
+	module.exports = require_react();
+} });
+
+//#endregion
 //#region main.js
 var import_commonjs = __toESM(require_commonjs());
+var import_commonjs2 = __toESM(require_commonjs2());
 assert.equal(import_commonjs.createReactElement(), "div");
+assert.equal(import_commonjs2.version.toString(), "1");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/react-like/commonjs2.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/react-like/commonjs2.js
@@ -1,0 +1,1 @@
+module.exports = require('./react.js');

--- a/crates/rolldown/tests/rolldown/cjs_compat/react-like/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/react-like/main.js
@@ -1,5 +1,7 @@
-import React from './commonjs.js'
-import assert from 'node:assert'
+import React from "./commonjs.js";
+import { version } from "./commonjs2.js";
 
+import assert from "node:assert";
 
-assert.equal(React.createReactElement(), 'div')
+assert.equal(React.createReactElement(), "div");
+assert.equal(version.toString(), '1');

--- a/crates/rolldown/tests/rolldown/cjs_compat/react-like/react.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/react-like/react.js
@@ -1,3 +1,6 @@
 exports.createReactElement = function () {
 	return "div";
 };
+
+
+exports.version = 1;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3759,7 +3759,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/react-like
 
-- main-!~{000}~.js => main-CI7vFg_S.js
+- main-!~{000}~.js => main-8zELAbr8.js
 
 # tests/rolldown/cjs_compat/reexport_commonjs
 


### PR DESCRIPTION
related to https://github.com/vitejs/rolldown-vite/issues/220