### PR TITLE
fix: handle error in `generateHmrPatch`

### DIFF
--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -106,13 +106,18 @@ impl Bundler {
   }
 
   #[napi]
-  pub async fn generate_hmr_patch(&self, changed_files: Vec<String>) -> BindingHmrOutput {
+  pub async fn generate_hmr_patch(
+    &self,
+    changed_files: Vec<String>,
+  ) -> napi::Result<BindingHmrOutput> {
     let mut bundler_core = self.inner.lock().await;
-    bundler_core
-      .generate_hmr_patch(changed_files)
-      .await
-      .expect("Failed to generate HMR patch")
-      .into()
+    let result = bundler_core.generate_hmr_patch(changed_files).await;
+    match result {
+      Ok(output) => Ok(output.into()),
+      Err(errs) => {
+        Ok(BindingHmrOutput::from_errors(errs.into_vec(), bundler_core.options().cwd.clone()))
+      }
+    }
   }
 
   #[napi]

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -4,11 +4,12 @@ import {
 } from '../../utils/create-bundler';
 import { transformToRollupOutput } from '../../utils/transform-to-rollup-output';
 
-import type { BindingHmrOutput } from '../../binding';
+import type { BindingHmrOutput, BindingHmrOutputPatch } from '../../binding';
 import type { InputOptions } from '../../options/input-options';
 import type { OutputOptions } from '../../options/output-options';
 import type { HasProperty, TypeAssert } from '../../types/assert';
 import type { RolldownOutput } from '../../types/rolldown-output';
+import { transformHmrPatchOutput } from '../../utils/transform-hmr-patch-output';
 import { validateOption } from '../../utils/validator';
 
 // @ts-expect-error TS2540: the polyfill of `asyncDispose`.
@@ -72,8 +73,9 @@ export class RolldownBuild {
 
   async generateHmrPatch(
     changedFiles: string[],
-  ): Promise<BindingHmrOutput | undefined> {
-    return this.#bundler?.bundler.generateHmrPatch(changedFiles);
+  ): Promise<BindingHmrOutputPatch | undefined> {
+    const output = await this.#bundler!.bundler.generateHmrPatch(changedFiles);
+    return transformHmrPatchOutput(output);
   }
 
   async hmrInvalidate(

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1099,6 +1099,11 @@ export declare class BindingError {
   message: string
 }
 
+export declare class BindingHmrOutput {
+  get patch(): BindingHmrOutputPatch | null
+  get errors(): Array<Error | BindingError>
+}
+
 export declare class BindingModuleInfo {
   id: string
   importers: Array<string>
@@ -1392,7 +1397,7 @@ export interface BindingHmrBoundaryOutput {
   acceptedVia: string
 }
 
-export interface BindingHmrOutput {
+export interface BindingHmrOutputPatch {
   code: string
   filename: string
   sourcemap?: string

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -399,6 +399,7 @@ module.exports.BindingBundleEndEventData = nativeBinding.BindingBundleEndEventDa
 module.exports.BindingBundleErrorEventData = nativeBinding.BindingBundleErrorEventData
 module.exports.BindingCallableBuiltinPlugin = nativeBinding.BindingCallableBuiltinPlugin
 module.exports.BindingError = nativeBinding.BindingError
+module.exports.BindingHmrOutput = nativeBinding.BindingHmrOutput
 module.exports.BindingModuleInfo = nativeBinding.BindingModuleInfo
 module.exports.BindingNormalizedOptions = nativeBinding.BindingNormalizedOptions
 module.exports.BindingOutputAsset = nativeBinding.BindingOutputAsset

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -85,6 +85,7 @@ export const BindingBundleEndEventData = __napiModule.exports.BindingBundleEndEv
 export const BindingBundleErrorEventData = __napiModule.exports.BindingBundleErrorEventData
 export const BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
 export const BindingError = __napiModule.exports.BindingError
+export const BindingHmrOutput = __napiModule.exports.BindingHmrOutput
 export const BindingModuleInfo = __napiModule.exports.BindingModuleInfo
 export const BindingNormalizedOptions = __napiModule.exports.BindingNormalizedOptions
 export const BindingOutputAsset = __napiModule.exports.BindingOutputAsset

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -109,6 +109,7 @@ module.exports.BindingBundleEndEventData = __napiModule.exports.BindingBundleEnd
 module.exports.BindingBundleErrorEventData = __napiModule.exports.BindingBundleErrorEventData
 module.exports.BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
 module.exports.BindingError = __napiModule.exports.BindingError
+module.exports.BindingHmrOutput = __napiModule.exports.BindingHmrOutput
 module.exports.BindingModuleInfo = __napiModule.exports.BindingModuleInfo
 module.exports.BindingNormalizedOptions = __napiModule.exports.BindingNormalizedOptions
 module.exports.BindingOutputAsset = __napiModule.exports.BindingOutputAsset

--- a/packages/rolldown/src/utils/transform-hmr-patch-output.ts
+++ b/packages/rolldown/src/utils/transform-hmr-patch-output.ts
@@ -1,0 +1,17 @@
+import type { BindingHmrOutput, BindingHmrOutputPatch } from '../binding';
+import { normalizeErrors } from './error';
+
+export function transformHmrPatchOutput(
+  output: BindingHmrOutput,
+): BindingHmrOutputPatch {
+  handleHmrPatchOutputErrors(output);
+  const { patch } = output;
+  return patch!;
+}
+
+function handleHmrPatchOutputErrors(output: BindingHmrOutput): void {
+  const rawErrors = output.errors;
+  if (rawErrors.length > 0) {
+    throw normalizeErrors(rawErrors);
+  }
+}


### PR DESCRIPTION
Handled error in `generateHmrPatch` so that it doesn't crash when saving a file with syntax errors.