### PR TITLE
chore: add link to rollup docs to "assign to bundle" warning

### DIFF
--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -166,7 +166,7 @@ export function transformToOutputBundle(
       const originalStackTraceLimit = Error.stackTraceLimit;
       Error.stackTraceLimit = 2;
       const message =
-        'This plugin assigns to bundle variable. This is discouraged by Rollup and is not supported by Rolldown. This will be ignored.';
+        'This plugin assigns to bundle variable. This is discouraged by Rollup and is not supported by Rolldown. This will be ignored. https://rollupjs.org/plugin-development/#generatebundle:~:text=DANGER,this.emitFile.';
       const stack = new Error(message).stack ?? message;
       Error.stackTraceLimit = originalStackTraceLimit;
 


### PR DESCRIPTION
The warning didn't describe what the user should do. This PR adds a link to the docs so that the user can know what to do and why they should do it.

refs #4792
