### PR TITLE
feat(advancedChunks): only move the captured module itself if `preserveEntrySignatures` is `allow-extension`

### DIFF
--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/_config.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "advancedChunks": {
+      "groups": [
+        {
+          "test": "foo\\.js",
+          "name": "vendor"
+        }
+      ]
+    }
+  },
+  "configVariants": [
+    {
+      "preserveEntrySignatures": "allow-extension"
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
@@ -1,0 +1,101 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { __esm } from "./rolldown-runtime.js";
+import { foo, init_foo } from "./vendor.js";
+import nodeAssert from "node:assert";
+
+//#region main.js
+var init_main = __esm({ "main.js"() {
+	init_foo();
+	nodeAssert.strictEqual(foo, "foo bar");
+} });
+
+//#endregion
+init_main();
+```
+## rolldown-runtime.js
+
+```js
+
+export { __esm };
+```
+## vendor.js
+
+```js
+import { __esm } from "./rolldown-runtime.js";
+
+//#region bar.js
+var bar;
+var init_bar = __esm({ "bar.js"() {
+	bar = "bar";
+} });
+
+//#endregion
+//#region foo.js
+var foo;
+var init_foo = __esm({ "foo.js"() {
+	init_bar();
+	foo = "foo " + bar;
+} });
+
+//#endregion
+export { foo, init_foo };
+```
+---
+
+Variant: (preserve_entry_signatures: AllowExtension)
+
+# Assets
+
+## main.js
+
+```js
+import { __esm } from "./rolldown-runtime.js";
+import { foo, init_foo } from "./vendor.js";
+import nodeAssert from "node:assert";
+
+//#region bar.js
+var bar;
+var init_bar = __esm({ "bar.js"() {
+	bar = "bar";
+} });
+
+//#endregion
+//#region main.js
+var init_main = __esm({ "main.js"() {
+	init_foo();
+	nodeAssert.strictEqual(foo, "foo bar");
+} });
+
+//#endregion
+init_main();
+export { bar, init_bar };
+```
+## rolldown-runtime.js
+
+```js
+
+export { __esm };
+```
+## vendor.js
+
+```js
+import { __esm } from "./rolldown-runtime.js";
+import { bar, init_bar } from "./main.js";
+
+//#region foo.js
+var foo;
+var init_foo = __esm({ "foo.js"() {
+	init_bar();
+	foo = "foo " + bar;
+} });
+
+//#endregion
+export { foo, init_foo };
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/bar.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/bar.js
@@ -1,0 +1,1 @@
+export const bar = 'bar'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/foo.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/foo.js
@@ -1,0 +1,2 @@
+import { bar } from './bar'
+export const foo = 'foo ' + bar

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/main.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/main.js
@@ -1,0 +1,6 @@
+import nodeAssert from 'node:assert';
+import { foo } from './foo'
+
+nodeAssert.strictEqual(foo, 'foo bar');
+
+export {}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3863,6 +3863,12 @@ expression: output
 - common-!~{004}~.js => common-CHGMauua.js
 - rolldown-runtime-!~{002}~.js => rolldown-runtime-F0QY5PnL.js
 
+# tests/rolldown/function/advanced_chunks/include_dependencies_recursively
+
+- main-!~{000}~.js => main-jUCZAWno.js
+- rolldown-runtime-!~{001}~.js => rolldown-runtime-BjtMze0h.js
+- vendor-!~{003}~.js => vendor-DjTUrGY6.js
+
 # tests/rolldown/function/advanced_chunks/issue_2617
 
 - main-!~{000}~.js => main-CgB9jNWY.js

--- a/crates/rolldown_common/src/inner_bundler_options/types/advanced_chunks_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/advanced_chunks_options.rs
@@ -18,7 +18,9 @@ pub struct AdvancedChunksOptions {
   pub max_size: Option<f64>,
   pub min_module_size: Option<f64>,
   pub max_module_size: Option<f64>,
-  // Only for internal use, not intended to be exposed at rolldown's js API
+  /// Whether to include the captured module's dependencies recursively.
+  /// - If `true`, the dependencies would be included this group forcefully unless they are already included in another group.
+  /// - This option would forcefully `true`, if `preserve_entry_signatures` is not `allow-extension`.
   pub include_dependencies_recursively: Option<bool>,
   pub groups: Option<Vec<MatchGroup>>,
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -956,6 +956,7 @@
           "format": "double"
         },
         "includeDependenciesRecursively": {
+          "description": "Whether to include the captured module's dependencies recursively.\n - If `true`, the dependencies would be included this group forcefully unless they are already included in another group.\n - This option would forcefully `true`, if `preserve_entry_signatures` is not `allow-extension`.",
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
You could see the result in the snapshot.

Watch the difference on exports shape of chunk `main.js` and the position of module `bar.js`.