### PR TITLE
chore(ci): rework CD workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,44 @@
+name: Prepare Release
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0 # for changelog
+          persist-credentials: true # for create-pull-request
+
+      - uses: taiki-e/install-action@735e5933943122c5ac182670a935f54a949265c1 # v2.52.4
+        with:
+          tool: just
+
+      - uses: ./.github/actions/setup-node
+
+      - run: just bump-packages ${VERSION}
+        env:
+          VERSION: ${{ inputs.version }}
+
+      - run: just changelog
+
+      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          commit-message: 'release: v${{ inputs.version }}'
+          branch: release-v${{ inputs.version }}
+          branch-suffix: timestamp
+          base: main
+          title: 'release: v${{ inputs.version }}'
+          assignees: Boshen

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -4,27 +4,54 @@ permissions: {}
 
 on:
   push:
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+    branches:
+      - main
+    paths:
+      - packages/rolldown/package.json
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check:
+    name: Check version
+    runs-on: ubuntu-latest
+    outputs:
+      version_changed: ${{ steps.version.outputs.changed }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
+
+      - name: Check version changes
+        uses: EndBug/version-check@36ff30f37c7deabe56a30caa043d127be658c425 # v2.1.5
+        id: version
+        with:
+          static-checking: localIsNew
+          file-url: https://unpkg.com/rolldown@latest/package.json
+          file-name: packages/rolldown/package.json
+
+      - name: Print version
+        if: steps.version.outputs.changed == 'true'
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          echo "Version change found! New version: ${NEW_VERSION}"
+
   build:
+    needs: check
+    if: needs.check.outputs.version_changed == 'true'
     name: Build bindings and node packages
     uses: ./.github/workflows/reusable-release-build.yml
 
   publish:
+    needs: build
     if: github.repository == 'rolldown/rolldown'
     name: Publish npm Packages
     runs-on: ubuntu-latest
     permissions:
       contents: write # for softprops/action-gh-release@v1
       id-token: write # for `npm publish --provenance`
-    needs:
-      - build
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
 
@@ -94,3 +121,11 @@ jobs:
           NPM_TOKEN: ${{ secrets.ROLLDOWN_NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        with:
+          draft: false
+          tag_name: v${{ needs.check.outputs.version }} # tags the current commit
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true


### PR DESCRIPTION
This PR changes CD workflow from "triggered by tag" to "triggered by version change".

1. Maintainer use the GitHub UI - Actions - Prepare Release - input version
2. "Prepare Release" workflow creates a PR, with versions and changelogs submitted
3. Once the PR is merged, it triggers build and npm publish
4. Once published, it creates a GitHub Release and tags the commit

This removes all human interaction while creating a release, 
and also fixes mismatch between published commit and tagged commit.

I will remove https://rolldown.rs/contrib-guide/release and add a `MAINTENANCE.md` for this after we complete a successful release.