### PR TITLE
refactor(rolldown_plugin_build_import_analysis): align the logic with `rolldown-vite`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,8 +2738,8 @@ dependencies = [
  "arcstr",
  "oxc",
  "rolldown_common",
+ "rolldown_ecmascript_utils",
  "rolldown_plugin",
- "rustc-hash",
 ]
 
 [[package]]

--- a/crates/rolldown_plugin_build_import_analysis/Cargo.toml
+++ b/crates/rolldown_plugin_build_import_analysis/Cargo.toml
@@ -18,5 +18,5 @@ workspace = true
 arcstr = { workspace = true }
 oxc = { workspace = true }
 rolldown_common = { workspace = true }
+rolldown_ecmascript_utils = { workspace = true }
 rolldown_plugin = { workspace = true }
-rustc-hash = { workspace = true }

--- a/crates/rolldown_plugin_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_build_import_analysis/src/ast_visit.rs
@@ -1,227 +1,60 @@
-use oxc::ast::ast::{
-  Argument, BindingPattern, BindingPatternKind, CallExpression, Expression, ImportOrExportKind,
-  PropertyKey, Statement, StaticMemberExpression, VariableDeclaration, VariableDeclarationKind,
+use oxc::{
+  allocator::CloneIn as _,
+  ast::{
+    NONE,
+    ast::{BindingPatternKind, Expression, ImportOrExportKind, Statement, VariableDeclaration},
+  },
+  ast_visit::{VisitMut, walk_mut},
+  semantic::ScopeFlags,
+  span::SPAN,
 };
-use oxc::ast::{AstBuilder, NONE};
-use oxc::ast_visit::{VisitMut, walk_mut};
-use oxc::semantic::ScopeFlags;
-use oxc::span::{Atom, SPAN};
-use rustc_hash::FxHashMap;
+use rolldown_ecmascript_utils::AstSnippet;
 
-use crate::PRELOAD_HELPER_ID;
-
-use super::ast_utils::{construct_snippet_for_expression, construct_snippet_from_await_decl};
+use super::PRELOAD_HELPER_ID;
 
 const PRELOAD_METHOD: &str = "__vitePreload";
 
-/// First element is the import specifier, second element is `decls` or `props` of expr
-#[derive(Debug)]
-enum ImportPattern<'a> {
-  /// const {foo} = await import('foo')
-  Decl(Atom<'a>, Vec<Atom<'a>>),
-}
-
 #[allow(clippy::struct_excessive_bools)]
 pub struct BuildImportAnalysisVisitor<'a> {
-  builder: AstBuilder<'a>,
-  need_prepend_helper: bool,
-  insert_preload: bool,
-  scope_stack: Vec<ScopeFlags>,
-  has_inserted_helper: bool,
+  pub snippet: AstSnippet<'a>,
+  pub scope_stack: Vec<ScopeFlags>,
+  pub insert_preload: bool,
+  pub has_inserted_helper: bool,
+  pub need_prepend_helper: bool,
   pub render_built_url: bool,
   pub is_relative_base: bool,
-}
-
-impl<'a> BuildImportAnalysisVisitor<'a> {
-  pub fn new(
-    builder: AstBuilder<'a>,
-    insert_preload: bool,
-    render_built_url: bool,
-    is_relative_base: bool,
-  ) -> Self {
-    Self {
-      builder,
-      need_prepend_helper: false,
-      insert_preload,
-      scope_stack: vec![],
-      has_inserted_helper: false,
-      render_built_url,
-      is_relative_base,
-    }
-  }
-
-  fn is_top_level(&self) -> bool {
-    self.scope_stack.last().is_some_and(|flags| flags.contains(ScopeFlags::Top))
-  }
-
-  /// ```js
-  /// (await import('foo')).foo
-  /// ```
-  fn rewrite_paren_member_expr(&mut self, member_expr: &mut StaticMemberExpression<'a>) {
-    let Expression::ParenthesizedExpression(ref mut paren) = member_expr.object else {
-      return;
-    };
-    let Expression::AwaitExpression(ref mut expr) = paren.expression else {
-      return;
-    };
-    let Expression::ImportExpression(ref import_expr) = expr.argument else { return };
-
-    let source = match &import_expr.source {
-      Expression::StringLiteral(lit) => lit.value,
-      Expression::TemplateLiteral(lit) if lit.quasis.len() == 1 && lit.expressions.is_empty() => {
-        let Some(first) = lit.quasis.first() else {
-          return;
-        };
-        first.value.cooked.unwrap_or(first.value.raw)
-      }
-      _ => return,
-    };
-
-    let property = member_expr.property.name;
-
-    let vite_preload_call = construct_snippet_for_expression(
-      self.builder,
-      source,
-      &[property],
-      self.is_relative_base || self.render_built_url,
-    );
-    expr.argument = vite_preload_call;
-    self.need_prepend_helper = true;
-  }
-
-  /// ```js
-  /// import('foo').then(({foo})=>{})
-  /// ```
-  fn rewrite_import_expr(&mut self, expr: &mut CallExpression<'a>) {
-    let Expression::StaticMemberExpression(ref mut callee) = expr.callee else {
-      return;
-    };
-    let Expression::ImportExpression(ref import_expr) = callee.object else {
-      return;
-    };
-    let source = match &import_expr.source {
-      Expression::StringLiteral(lit) => lit.value,
-      Expression::TemplateLiteral(lit) if lit.quasis.len() == 1 && lit.expressions.is_empty() => {
-        let Some(first) = lit.quasis.first() else { return };
-        first.value.cooked.unwrap_or(first.value.raw)
-      }
-      _ => return,
-    };
-    if callee.property.name != "then" {
-      return;
-    }
-    let [Argument::ArrowFunctionExpression(arrow_expr)] = expr.arguments.as_slice() else {
-      return;
-    };
-    let Some(first_param) = arrow_expr.params.items.first() else {
-      return;
-    };
-
-    let BindingPatternKind::ObjectPattern(ref pat) = first_param.pattern.kind else {
-      return;
-    };
-
-    let decls = pat
-      .properties
-      .iter()
-      .filter_map(|prop| match &prop.key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name),
-        _ => None,
-      })
-      .collect::<Vec<_>>();
-
-    let vite_preload_call = construct_snippet_for_expression(
-      self.builder,
-      source,
-      &decls,
-      self.render_built_url || self.is_relative_base,
-    );
-    callee.object = vite_preload_call;
-    self.need_prepend_helper = true;
-  }
 }
 
 impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
   fn visit_program(&mut self, it: &mut oxc::ast::ast::Program<'a>) {
     walk_mut::walk_program(self, it);
     if self.need_prepend_helper && self.insert_preload && !self.has_inserted_helper {
-      let helper_stmt = Statement::from(self.builder.module_declaration_import_declaration(
+      it.body.push(Statement::from(self.snippet.builder.module_declaration_import_declaration(
         SPAN,
-        Some(self.builder.vec1(self.builder.import_declaration_specifier_import_specifier(
-          SPAN,
-          self.builder.module_export_name_identifier_name(SPAN, PRELOAD_METHOD),
-          self.builder.binding_identifier(SPAN, PRELOAD_METHOD),
-          ImportOrExportKind::Value,
-        ))),
-        self.builder.string_literal(SPAN, PRELOAD_HELPER_ID, None),
+        Some(self.snippet.builder.vec1(
+          self.snippet.builder.import_declaration_specifier_import_specifier(
+            SPAN,
+            self.snippet.builder.module_export_name_identifier_name(SPAN, PRELOAD_METHOD),
+            self.snippet.id(PRELOAD_METHOD, SPAN),
+            ImportOrExportKind::Value,
+          ),
+        )),
+        self.snippet.builder.string_literal(SPAN, PRELOAD_HELPER_ID, None),
         None,
         NONE,
         ImportOrExportKind::Value,
-      ));
-      it.body.push(helper_stmt);
+      )));
     }
   }
 
-  fn visit_variable_declaration(&mut self, decl: &mut VariableDeclaration<'a>) {
-    walk_mut::walk_variable_declaration(self, decl);
-    let mut declarators_map = decl
-      .declarations
-      .iter_mut()
-      .enumerate()
-      .filter_map(|(i, decl)| {
-        let Some(Expression::AwaitExpression(ref mut init)) = decl.init else {
-          return None;
-        };
-        let Expression::ImportExpression(ref mut import) = init.argument else {
-          return None;
-        };
-        let BindingPattern { kind, .. } = &decl.id;
-        let BindingPatternKind::ObjectPattern(kind) = kind else {
-          return None;
-        };
-        let source = match &import.source {
-          Expression::StringLiteral(lit) => lit.value,
-          Expression::TemplateLiteral(lit)
-            if lit.quasis.len() == 1 && lit.expressions.is_empty() =>
-          {
-            let first = lit.quasis.first()?;
-            first.value.cooked.unwrap_or(first.value.raw)
-          }
-          _ => return None,
-        };
-        // TODO: `const {a: {c: {d: f}}} = await import('./lib.js')`
-        // for now, only support `const {a} = await import('./lib.js')`
-        let decls = kind
-          .properties
-          .iter()
-          .filter_map(|prop| match &prop.key {
-            PropertyKey::StaticIdentifier(id) => Some(id.name),
-            _ => None,
-          })
-          .collect::<Vec<_>>();
-        Some((i, (ImportPattern::Decl(source, decls), decl.kind)))
-      })
-      .collect::<FxHashMap<usize, (ImportPattern<'a>, VariableDeclarationKind)>>();
-    if declarators_map.is_empty() {
-      return;
+  fn visit_expression(&mut self, expr: &mut Expression<'a>) {
+    walk_mut::walk_expression(self, expr);
+    match expr {
+      Expression::CallExpression(expr) => self.rewrite_import_expr(expr),
+      Expression::StaticMemberExpression(expr) => self.rewrite_member_expr(expr),
+      _ => return,
     }
-    for (i, d) in decl.declarations.iter_mut().enumerate() {
-      if let Some((pattern, kind)) = declarators_map.remove(&i) {
-        match pattern {
-          ImportPattern::Decl(source, decls) => {
-            self.need_prepend_helper = true;
-            let mut declarator = construct_snippet_from_await_decl(
-              self.builder,
-              source,
-              &decls,
-              kind,
-              self.render_built_url || self.is_relative_base,
-            );
-            std::mem::swap(d, &mut declarator);
-          }
-        }
-      }
-    }
+    self.need_prepend_helper = true;
   }
 
   fn visit_variable_declarator(&mut self, it: &mut oxc::ast::ast::VariableDeclarator<'a>) {
@@ -234,12 +67,30 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
     walk_mut::walk_variable_declarator(self, it);
   }
 
-  fn visit_expression(&mut self, expr: &mut Expression<'a>) {
-    walk_mut::walk_expression(self, expr);
-    match expr {
-      Expression::StaticMemberExpression(expr) => self.rewrite_paren_member_expr(expr),
-      Expression::CallExpression(expr) => self.rewrite_import_expr(expr),
-      _ => {}
+  /// transform `const {foo} = await import('foo')`
+  /// to `const {foo} = await __vitePreload(async () => { let foo; return {foo} = await import('foo'); }, ...)`
+  fn visit_variable_declaration(&mut self, decl: &mut VariableDeclaration<'a>) {
+    walk_mut::walk_variable_declaration(self, decl);
+    for decl in &mut decl.declarations {
+      if matches!(decl.id.kind, BindingPatternKind::ObjectPattern(_))
+        && matches!(
+          &decl.init,
+          Some(Expression::AwaitExpression(expr)) if matches!(expr.argument, Expression::ImportExpression(_))
+        )
+      {
+        decl.init = Some(self.snippet.builder.expression_await(
+          SPAN,
+          self.construct_vite_preload_call(
+            self.snippet.builder.binding_pattern(
+              decl.id.kind.clone_in(self.snippet.alloc()),
+              NONE,
+              false,
+            ),
+            decl.init.take().unwrap(),
+          ),
+        ));
+        self.need_prepend_helper = true;
+      }
     }
   }
 

--- a/crates/rolldown_plugin_build_import_analysis/src/lib.rs
+++ b/crates/rolldown_plugin_build_import_analysis/src/lib.rs
@@ -4,10 +4,9 @@ mod ast_visit;
 use std::borrow::Cow;
 
 use arcstr::ArcStr;
-use oxc::ast::AstBuilder;
 use oxc::ast_visit::VisitMut;
-use oxc::codegen::{self, Codegen, CodegenOptions, Gen};
 use rolldown_common::side_effects::HookSideEffects;
+use rolldown_ecmascript_utils::AstSnippet;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
   HookResolveIdReturn, HookTransformAstArgs, HookTransformAstReturn, HookUsage, Plugin,
@@ -61,7 +60,7 @@ impl Plugin for BuildImportAnalysisPlugin {
     }
     let mut ast = args.ast;
     ast.program.with_mut(|fields| {
-      let builder = AstBuilder::new(fields.allocator);
+      let builder = AstSnippet::new(fields.allocator);
       let mut visitor = BuildImportAnalysisVisitor::new(
         builder,
         self.insert_preload,
@@ -70,10 +69,6 @@ impl Plugin for BuildImportAnalysisPlugin {
       );
       visitor.visit_program(fields.program);
     });
-
-    let mut codegen =
-      Codegen::new().with_options(CodegenOptions { comments: false, ..CodegenOptions::default() });
-    ast.program().r#gen(&mut codegen, codegen::Context::default());
     Ok(ast)
   }
 

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/_config.ts
@@ -1,0 +1,41 @@
+import { expect } from 'vitest'
+import { defineTest } from 'rolldown-tests'
+import { buildImportAnalysisPlugin } from 'rolldown/experimental'
+
+export default defineTest({
+  skipComposingJsPlugin: true,
+  config: {
+    input: './main.js',
+    plugins: [
+      {
+        // insert some dummy runtime flag to assert the runtime behavior
+        name: 'insert_dummy_flag',
+        transform(code) {
+          let runtimeCode = `const __VITE_IS_MODERN__ = false;`
+          return {
+            code: runtimeCode + code,
+          }
+        },
+      },
+      buildImportAnalysisPlugin({
+        preloadCode: `
+export const __vitePreload = (v) => {
+  return v()
+};
+`,
+        insertPreload: true,
+        optimizeModulePreloadRelativePaths: false,
+        renderBuiltUrl: true,
+        isRelativeBase: false,
+      }),
+    ],
+  },
+  async afterTest(output) {
+    await import('./assert.mjs')
+    output.output.forEach((item) => {
+      if (item.type === 'chunk' && item.name === 'main') {
+        expect(item.code).to.includes('import.meta.url')
+      }
+    })
+  },
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/assert.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert'
+import { c, d } from './dist/main'
+
+assert.strictEqual(c, 0)
+assert.strictEqual(c, d)

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/lib.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/lib.js
@@ -1,0 +1,1 @@
+export const a = { b: [0], d: 0 }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/main.js
@@ -1,0 +1,3 @@
+const { a: { b: [c], d } } = await import('./lib.js')
+
+export { c, d }


### PR DESCRIPTION
Related to #3983

- Refactored the code to align the logic with `rolldown-vite`
- Support complex assignment syntax like `const { a: { b: c, d: [e] } } = await import('./lib.js');`