### PR TITLE
ci: extend Vite tests timeout

### DIFF
--- a/.github/workflows/vite-tests.yml
+++ b/.github/workflows/vite-tests.yml
@@ -34,7 +34,7 @@ jobs:
         target: [ubuntu-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.target }}
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Extended timeout for Vite tests because it now somehow takes longer time.
https://github.com/rolldown/rolldown/actions/runs/15524426663/job/43701998156

For example, node tests now takes 12 minutes. It used to take 7 minutes.
https://github.com/rolldown/rolldown/actions/runs/15481108836/job/43586989916
https://github.com/rolldown/rolldown/actions/runs/15521558045/job/43695430919
