### PR TITLE
refactor!: move preserveEntrySignatures from output to input options

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -14,6 +14,7 @@ use binding_debug_options::BindingDebugOptions;
 use binding_defer_sync_scan_data::BindingDeferSyncScanDataOption;
 use binding_make_absolute_externals_relative::BindingMakeAbsoluteExternalsRelative;
 use derive_more::Debug;
+use napi::Either;
 use napi::bindgen_prelude::FnArgs;
 use napi_derive::napi;
 use rustc_hash::FxBuildHasher;
@@ -106,4 +107,6 @@ pub struct BindingInputOptions<'env> {
   #[debug(skip)]
   #[napi(ts_type = "(id: string, success: boolean) => void")]
   pub mark_module_loaded: Option<JsCallback<FnArgs<(String, bool)>, ()>>,
+  #[napi(ts_type = "'strict' | 'allow-extension' | 'exports-only' | false")]
+  pub preserve_entry_signatures: Option<Either<String, bool>>,
 }

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -121,6 +121,4 @@ pub struct BindingOutputOptions<'env> {
   pub preserve_modules: Option<bool>,
   pub virtual_dirname: Option<String>,
   pub preserve_modules_root: Option<String>,
-  #[napi(ts_type = "'strict' | 'allow-extension' | 'exports-only' | false")]
-  pub preserve_entry_signatures: Option<Either<String, bool>>,
 }

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -443,7 +443,7 @@ pub fn normalize_binding_options(
     preserve_modules: output_options.preserve_modules,
     virtual_dirname: output_options.virtual_dirname,
     preserve_modules_root: output_options.preserve_modules_root,
-    preserve_entry_signatures: output_options
+    preserve_entry_signatures: input_options
       .preserve_entry_signatures
       .map(|v| match v {
         Either::A(str) => match str.as_str() {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1526,6 +1526,7 @@ export interface BindingInputOptions {
   debug?: BindingDebugOptions
   invalidateJsSideCache?: () => void
   markModuleLoaded?: (id: string, success: boolean) => void
+  preserveEntrySignatures?: 'strict' | 'allow-extension' | 'exports-only' | false
 }
 
 export interface BindingIsolatedDeclarationPluginConfig {
@@ -1670,7 +1671,6 @@ export interface BindingOutputOptions {
   preserveModules?: boolean
   virtualDirname?: string
   preserveModulesRoot?: string
-  preserveEntrySignatures?: 'strict' | 'allow-extension' | 'exports-only' | false
 }
 
 export interface BindingOxcRuntimePluginConfig {

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -228,6 +228,11 @@ export interface InputOptions {
   debug?: {
     sessionId?: string;
   };
+  preserveEntrySignatures?:
+    | false
+    | 'strict'
+    | 'allow-extension'
+    | 'exports-only';
 }
 
 interface OverwriteInputOptionsForCli {

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -182,11 +182,6 @@ export interface OutputOptions {
   preserveModules?: boolean;
   virtualDirname?: string;
   preserveModulesRoot?: string;
-  preserveEntrySignatures?:
-    | false
-    | 'strict'
-    | 'allow-extension'
-    | 'exports-only';
 }
 
 interface OverwriteOutputOptionsForCli {

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -106,6 +106,7 @@ export function bindingifyInputOptions(
     markModuleLoaded: pluginContextData.markModuleLoaded.bind(
       pluginContextData,
     ),
+    preserveEntrySignatures: inputOptions.preserveEntrySignatures,
   };
 }
 

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -35,7 +35,6 @@ export function bindingifyOutputOptions(
     virtualDirname,
     legalComments,
     preserveModulesRoot,
-    preserveEntrySignatures,
   } = outputOptions;
 
   return {
@@ -74,7 +73,6 @@ export function bindingifyOutputOptions(
     virtualDirname,
     legalComments,
     preserveModulesRoot,
-    preserveEntrySignatures,
   };
 }
 

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -433,6 +433,14 @@ const InputOptionsSchema = v.strictObject({
       'Enable debug mode. Emit debug information to disk. This might slow down the build process significantly.',
     ),
   ),
+  preserveEntrySignatures: v.pipe(
+    v.optional(v.union([
+      v.literal('strict'),
+      v.literal('allow-extension'),
+      v.literal('exports-only'),
+      v.literal(false),
+    ])),
+  ),
 });
 
 const InputCliOverrideSchema = v.strictObject({
@@ -468,6 +476,12 @@ const InputCliOverrideSchema = v.strictObject({
       ]),
     ),
     v.description('Jsx options preset'),
+  ),
+  preserveEntrySignatures: v.pipe(
+    v.optional(v.union([
+      v.literal(false),
+    ])),
+    v.description('Avoid facade chunks for entry points'),
   ),
 });
 
@@ -700,14 +714,6 @@ const OutputOptionsSchema = v.strictObject({
     v.optional(v.string()),
     v.description('Put preserved modules under this path at root level'),
   ),
-  preserveEntrySignatures: v.pipe(
-    v.optional(v.union([
-      v.literal('strict'),
-      v.literal('allow-extension'),
-      v.literal('exports-only'),
-      v.literal(false),
-    ])),
-  ),
   virtualDirname: v.optional(v.string()),
 });
 
@@ -795,12 +801,6 @@ const OutputCliOverrideSchema = v.strictObject({
   minify: v.pipe(
     v.optional(v.boolean()),
     v.description('Minify the bundled file'),
-  ),
-  preserveEntrySignatures: v.pipe(
-    v.optional(v.union([
-      v.literal(false),
-    ])),
-    v.description('Avoid facade chunks for entry points'),
   ),
 });
 


### PR DESCRIPTION
see https://rollupjs.org/configuration-options/#preserveentrysignatures