### PR TITLE
ci: disable publish to nightly

### DIFF
--- a/.github/workflows/publish-to-npm-for-nightly-canary.yml
+++ b/.github/workflows/publish-to-npm-for-nightly-canary.yml
@@ -5,9 +5,10 @@ permissions: {}
 on:
   # Manually released. This will publish under the canary npm tag.
   workflow_dispatch:
+  # Publish to nightly is disabled, favor pkg.pr.new.
   # Every day at midnight. This will publish under the nightly npm tag.
-  schedule:
-    - cron: '0 0 * * *'
+  # schedule:
+# - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -6,16 +6,13 @@
 2. "Run workflow" with `1.0.0-beta.x` (without leading `v`).
 3. Wait for https://github.com/rolldown/rolldown/actions/workflows/publish-to-npm.yml to finish.
 
-## Canary / Nightly
+## Canary
 
 1. Visit https://github.com/rolldown/rolldown/actions/workflows/publish-to-npm-for-nightly-canary.yml
 2. "Run workflow"
 
-If you trigger the workflow manually, it will publish the latest commit to the canary tag.
+Latest Canary versions are https://www.npmjs.com/package/rolldown/v/canary
 
-If the workflow is triggered by a schedule, it will publish the latest commit to the nightly tag.
+## pkg.pr.new
 
-Latest Canary and Nightly versions are
-
-- https://www.npmjs.com/package/rolldown/v/nightly
-- https://www.npmjs.com/package/rolldown/v/canary
+https://pkg.pr.new/~/rolldown/rolldown


### PR DESCRIPTION
Given that

* we have `pkg.pr.new`
* we intend to release more often
* nightly versions are hard to use, we need to take a look at what commits are in the nightly