### PR TITLE
feat(strictExecutionOrder): no need to generate plain chunk imports for addressing side effects

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -396,8 +396,15 @@ impl GenerateStage<'_> {
             .iter_enumerated()
             .filter(|(id, _)| *id != chunk_id)
             .filter(|(_, importee_chunk)| {
-              importee_chunk.bits.has_bit(*importer_chunk_bit)
-                && importee_chunk.has_side_effect(self.link_output.runtime.id())
+              if self.options.experimental.is_strict_execution_order_enabled() {
+                // With strict_execution_order/wrapping, modules aren't executed in loading but on-demand.
+                // So we don't need to do plain imports to address the side effects. It would be ensured
+                // by those `init_xxx()` calls.
+                false
+              } else {
+                importee_chunk.bits.has_bit(*importer_chunk_bit)
+                  && importee_chunk.has_side_effect(self.link_output.runtime.id())
+              }
             })
             .for_each(|(importee_chunk_id, _)| {
               index_cross_chunk_imports[chunk_id].insert(importee_chunk_id);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "external": ["node:assert"],
+    "experimental": {
+      "strictExecutionOrder": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
@@ -1,0 +1,79 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## chunk.js
+
+```js
+
+export { __esm };
+```
+## common.js
+
+```js
+import { __esm } from "./chunk.js";
+
+//#region common.js
+function foo() {
+	globalThis.value = typeof globalThis.value === "number" ? globalThis.value + 1 : 0;
+}
+var common, _;
+var init_common = __esm({ "common.js"() {
+	common = "common";
+	_ = /* @__PURE__ */ foo();
+} });
+
+//#endregion
+export { _, common, init_common };
+```
+## main.js
+
+```js
+import { __esm } from "./chunk.js";
+
+//#region main.js
+var init_main = __esm({ async "main.js"() {
+	await import("./page-a.js").then(console.log);
+	await import("./page-b.js").then(console.log);
+} });
+
+//#endregion
+await init_main();
+```
+## page-a.js
+
+```js
+import { __esm } from "./chunk.js";
+import { _, common, init_common } from "./common.js";
+import nodeAssert from "node:assert";
+
+//#region page-a.js
+function render() {
+	console.log(common, _);
+}
+var init_page_a = __esm({ "page-a.js"() {
+	init_common();
+	nodeAssert.strictEqual(globalThis.value, 0);
+} });
+
+//#endregion
+init_page_a();
+export { render };
+```
+## page-b.js
+
+```js
+import { __esm } from "./chunk.js";
+import nodeAssert from "node:assert";
+
+//#region page-b.js
+function render() {}
+var init_page_b = __esm({ "page-b.js"() {
+	nodeAssert.strictEqual(globalThis.value, 0);
+} });
+
+//#endregion
+init_page_b();
+export { render };
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/common.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/common.js
@@ -1,0 +1,7 @@
+export const common = "common"
+
+function foo() {
+  globalThis.value = typeof globalThis.value === 'number' ? globalThis.value + 1 : 0
+}
+
+export const _ =/*#__PURE__*/ foo()

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/main.js
@@ -1,0 +1,2 @@
+await import('./page-a').then(console.log)
+await import('./page-b').then(console.log)

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/page-a.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/page-a.js
@@ -1,0 +1,8 @@
+import nodeAssert from 'node:assert'
+import { common, _ } from './common.js'
+
+nodeAssert.strictEqual(globalThis.value, 0)
+
+export function render() {
+  console.log(common, _)
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/page-b.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/page-b.js
@@ -1,0 +1,6 @@
+import nodeAssert from 'node:assert'
+import'./common.js'
+
+nodeAssert.strictEqual(globalThis.value, 0)
+
+export function render() {}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4071,6 +4071,14 @@ expression: output
 
 - main-!~{000}~.js => main-DVzdOrRP.js
 
+# tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports
+
+- main-!~{000}~.js => main-BtaVe3-D.js
+- chunk-!~{001}~.js => chunk--BJLk7li.js
+- common-!~{003}~.js => common-C4wqcyCT.js
+- page-a-!~{005}~.js => page-a-BF05FZf6.js
+- page-b-!~{007}~.js => page-b-BsmTzYKQ.js
+
 # tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax
 
 - main-!~{000}~.js => main-BbzIdLSS.js


### PR DESCRIPTION
Part of https://github.com/rolldown/rolldown/issues/4812. `strictExecutionOrder: true` make it easy to assume doing plain import on chunk doesn't have side effect. @sapphi-red cc