### PR TITLE
fix(hmr): avoid panic after syntax error

### DIFF
--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -209,16 +209,15 @@ impl HmrManager {
       })
       .collect::<Vec<_>>();
 
-    let mut scan_stage_cache = std::mem::take(&mut self.cache);
-
+    let build_span = self.session_span.clone();
     let mut module_loader = ModuleLoader::new(
       self.fs,
       Arc::clone(&self.options),
       Arc::clone(&self.resolver),
       Arc::clone(&self.plugin_driver),
-      &mut scan_stage_cache,
+      &mut self.cache,
       false,
-      self.session_span.clone(),
+      build_span,
     )?;
 
     let module_loader_output =
@@ -228,8 +227,6 @@ impl HmrManager {
     // `self.cache`, but rustc is not smart enough to infer actually we don't touch it in `drop`
     // implementation, so we need to manually drop it.
     drop(module_loader);
-
-    self.cache = scan_stage_cache;
 
     tracing::debug!(
       target: "hmr",

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/_config.json
@@ -1,0 +1,9 @@
+{
+  "config": {
+    "experimental": {
+      "hmr": {}
+    }
+  },
+  // Runtime currently relies on browser environment's `WebSocket`
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -1,0 +1,102 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+
+//#region hmr.js
+var hmr_exports = {};
+__export(hmr_exports, { foo: () => foo });
+const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
+__rolldown_runtime__.__toCommonJS(hmr_exports);
+__rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+const foo = "hello";
+text$1(".hmr", foo);
+function text$1(el, text$2) {
+	document.querySelector(el).textContent = text$2;
+}
+hmr_hot.accept((mod) => {
+	if (mod) text$1(".hmr", mod.foo);
+});
+
+//#endregion
+//#region sub.js
+var sub_exports = {};
+const sub_hot = __rolldown_runtime__.createModuleHotContext("sub.js");
+__rolldown_runtime__.__toCommonJS(sub_exports);
+__rolldown_runtime__.registerModule("sub.js", { exports: sub_exports });
+text(".app", "hello");
+function text(el, text$2) {
+	document.querySelector(el).textContent = text$2;
+}
+
+//#endregion
+//#region main.js
+var main_exports = {};
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.__toCommonJS(main_exports);
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+
+//#endregion
+```
+# HMR Step 0
+## Errors
+
+### PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Unterminated string
+   ╭─[ hmr.js:1:20 ]
+   │
+ 1 │ export const foo = 'hello
+   │                    ───┬───  
+   │                       ╰───── 
+───╯
+
+```
+
+## Meta
+
+- full_reload: false
+- first_invalidated_by: None
+- is_self_accepting: false
+- full_reload_reason: None
+### Hmr Boundaries
+# HMR Step 1
+
+## Code
+
+```js
+var init_hmr_0 = __rolldown_runtime__.createEsmInitializer(function() {
+	try {
+		var ns_hmr = {};
+		__rolldown_runtime__.__export(ns_hmr, { foo: () => foo });
+		__rolldown_runtime__.__toCommonJS(ns_hmr);
+		__rolldown_runtime__.registerModule("hmr.js", { exports: ns_hmr });
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
+		const foo = "hello";
+		text(".hmr", foo);
+		function text(el, text) {
+			document.querySelector(el).textContent = text;
+		}
+		hot_hmr.accept((mod) => {
+			if (mod) text(".hmr", mod.foo);
+		});
+	} finally {}
+});
+
+init_hmr_0()
+__rolldown_runtime__.applyUpdates(['hmr.js']);
+```
+## Meta
+
+- full_reload: false
+- first_invalidated_by: None
+- is_self_accepting: false
+- full_reload_reason: None
+### Hmr Boundaries
+
+- boundary: hmr.js, accepted_via: hmr.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/hmr.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/hmr.hmr-0.js
@@ -1,0 +1,13 @@
+export const foo = 'hello
+
+text('.hmr', foo)
+
+function text(el, text) {
+  document.querySelector(el).textContent = text
+}
+
+import.meta.hot.accept((mod) => {
+  if (mod) {
+    text('.hmr', mod.foo)
+  }
+})

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/hmr.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/hmr.hmr-1.js
@@ -1,0 +1,13 @@
+export const foo = 'hello'
+
+text('.hmr', foo)
+
+function text(el, text) {
+  document.querySelector(el).textContent = text
+}
+
+import.meta.hot.accept((mod) => {
+  if (mod) {
+    text('.hmr', mod.foo)
+  }
+})

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/hmr.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/hmr.js
@@ -1,0 +1,13 @@
+export const foo = 'hello'
+
+text('.hmr', foo)
+
+function text(el, text) {
+  document.querySelector(el).textContent = text
+}
+
+import.meta.hot.accept((mod) => {
+  if (mod) {
+    text('.hmr', mod.foo)
+  }
+})

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/main.js
@@ -1,0 +1,1 @@
+import './sub.js'

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/sub.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/sub.js
@@ -1,0 +1,7 @@
+import './hmr.js'
+
+text('.app', 'hello')
+
+function text(el, text) {
+  document.querySelector(el).textContent = text
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5373,6 +5373,10 @@ expression: output
 
 - main-!~{000}~.js => main-Bsw305ma.js
 
+# tests/rolldown/topics/hmr/generate_patch_error
+
+- main-!~{000}~.js => main-dX635G9E.js
+
 # tests/rolldown/topics/hmr/mutiply_entires
 
 - entry-!~{000}~.js => entry-CBzHZYBI.js


### PR DESCRIPTION
Fixes the panic that happens after generating a HMR patch after syntax error.