### PR TITLE
test: add "non used export" hmr test

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "experimental": {
+      "hmr": {}
+    },
+    "treeshake": false // NOTE: tree shaking is not supported for HMR now
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
@@ -1,0 +1,27 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+
+//#region hmr.js
+var hmr_exports = {};
+__export(hmr_exports, { foo: () => foo });
+const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
+__rolldown_runtime__.__toCommonJS(hmr_exports);
+__rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+const foo = "hello";
+hmr_hot.accept(() => {});
+
+//#endregion
+//#region main.js
+var main_exports = {};
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.__toCommonJS(main_exports);
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/hmr.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/hmr.js
@@ -1,0 +1,3 @@
+export const foo = 'hello'
+
+import.meta.hot.accept(() => {})

--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/main.js
@@ -1,0 +1,1 @@
+import './hmr.js'

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5383,6 +5383,10 @@ expression: output
 - index-!~{001}~.js => index-D1GGCNxh.js
 - chunk-!~{002}~.js => chunk-CUsgavGH.js
 
+# tests/rolldown/topics/hmr/non_used_export
+
+- main-!~{000}~.js => main-YzWYwFZO.js
+
 # tests/rolldown/topics/hmr/register_exports
 
 - main-!~{000}~.js => main-B4-Shbiz.js


### PR DESCRIPTION
~~probably related to #4898,~~ found while trying https://github.com/rolldown/rolldown/pull/4898#discussion_r2137869683

This test fails only when tree shaking is enabled. Enabling tree shaking with HMR is not supported and is disabled now. So I decided not to try fixing it and only keep the tests for now.
