### PR TITLE
fix: better `NoEntryPoint` error message

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -660,7 +660,7 @@ impl ModuleLoader {
     entry_points.extend(extra_entry_points);
 
     if entry_points.is_empty() && self.is_full_scan {
-      Err(anyhow::anyhow!("You must supply options.input to rolldown"))?;
+      Err(BuildDiagnostic::invalid_option(rolldown_error::InvalidOptionType::NoEntryPoint))?;
     }
 
     self.cache.importers = self.intermediate_normal_modules.importers;

--- a/crates/rolldown_error/src/events/invalid_option.rs
+++ b/crates/rolldown_error/src/events/invalid_option.rs
@@ -6,6 +6,7 @@ pub enum InvalidOptionType {
   UnsupportedCodeSplittingFormat(String),
   InvalidOutputFile,
   InvalidOutputDirOption,
+  NoEntryPoint,
 }
 
 #[derive(Debug)]
@@ -20,11 +21,12 @@ impl BuildEvent for InvalidOption {
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {
     match &self.invalid_option_type {
-      InvalidOptionType::UnsupportedCodeSplittingFormat(format) => {
-        format!("Invalid value \"{format}\" for option \"output.format\" - UMD and IIFE are not supported for code splitting. You may set `output.inlineDynamicImports` to `true` when using dynamic imports.")
-      }
-      InvalidOptionType::InvalidOutputFile => "Invalid value for option \"output.file\" - When building multiple chunks, the \"output.dir\" option must be used, not \"output.file\". You may set `output.inlineDynamicImports` to `true` when using dynamic imports.".to_string(),
-      InvalidOptionType::InvalidOutputDirOption => "Invalid value for option \"output.dir\" - you must set either \"output.file\" for a single-file build or \"output.dir\" when generating multiple chunks.".to_string()
+        InvalidOptionType::UnsupportedCodeSplittingFormat(format) => {
+            format!("Invalid value \"{format}\" for option \"output.format\" - UMD and IIFE are not supported for code splitting. You may set `output.inlineDynamicImports` to `true` when using dynamic imports.")
+          }
+        InvalidOptionType::InvalidOutputFile => "Invalid value for option \"output.file\" - When building multiple chunks, the \"output.dir\" option must be used, not \"output.file\". You may set `output.inlineDynamicImports` to `true` when using dynamic imports.".to_string(),
+        InvalidOptionType::InvalidOutputDirOption => "Invalid value for option \"output.dir\" - you must set either \"output.file\" for a single-file build or \"output.dir\" when generating multiple chunks.".to_string(),
+        InvalidOptionType::NoEntryPoint =>"You must supply `options.input` to rolldown, you should at least provide one entrypoint via `options.input` or `this.emitFile({type: 'chunk', ...})` (https://rollupjs.org/plugin-development/#this-emitfile)".to_string(),
     }
   }
 }


### PR DESCRIPTION
Since the error is caused by incorrect configuration, which should not be unhandled.

![image](https://github.com/user-attachments/assets/764d63f9-9ce2-46de-9fe9-050b254dac05)
