### PR TITLE
feat: make native json plugin callable

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_side_effects.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_side_effects.rs
@@ -1,4 +1,5 @@
 use napi_derive::napi;
+use rolldown_common::side_effects::HookSideEffects;
 
 #[derive(Debug, PartialEq)]
 #[napi]
@@ -8,12 +9,22 @@ pub enum BindingHookSideEffects {
   NoTreeshake,
 }
 
-impl From<BindingHookSideEffects> for rolldown_common::side_effects::HookSideEffects {
+impl From<BindingHookSideEffects> for HookSideEffects {
   fn from(value: BindingHookSideEffects) -> Self {
     match value {
       BindingHookSideEffects::True => Self::True,
       BindingHookSideEffects::False => Self::False,
       BindingHookSideEffects::NoTreeshake => Self::NoTreeshake,
+    }
+  }
+}
+
+impl From<HookSideEffects> for BindingHookSideEffects {
+  fn from(value: HookSideEffects) -> Self {
+    match value {
+      HookSideEffects::True => Self::True,
+      HookSideEffects::False => Self::False,
+      HookSideEffects::NoTreeshake => Self::NoTreeshake,
     }
   }
 }

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_transform_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_transform_output.rs
@@ -1,4 +1,5 @@
 use rolldown::ModuleType;
+use rolldown_plugin::HookTransformOutput;
 
 use super::binding_hook_side_effects::BindingHookSideEffects;
 use crate::types::binding_sourcemap::BindingSourcemap;
@@ -12,15 +13,26 @@ pub struct BindingHookTransformOutput {
   pub module_type: Option<String>,
 }
 
-impl TryFrom<BindingHookTransformOutput> for rolldown_plugin::HookTransformOutput {
+impl TryFrom<BindingHookTransformOutput> for HookTransformOutput {
   type Error = anyhow::Error;
 
   fn try_from(value: BindingHookTransformOutput) -> Result<Self, Self::Error> {
-    Ok(rolldown_plugin::HookTransformOutput {
+    Ok(Self {
       code: value.code,
       map: value.map.map(TryInto::try_into).transpose()?,
       side_effects: value.side_effects.map(Into::into),
       module_type: value.module_type.map(|ty| ModuleType::from_str_with_fallback(ty.as_str())),
     })
+  }
+}
+
+impl From<HookTransformOutput> for BindingHookTransformOutput {
+  fn from(value: HookTransformOutput) -> Self {
+    Self {
+      code: value.code,
+      map: value.map.map(|v| v.to_json().into()),
+      side_effects: value.side_effects.map(Into::into),
+      module_type: value.module_type.map(|v| v.to_string()),
+    }
   }
 }

--- a/crates/rolldown_binding/src/types/binding_sourcemap.rs
+++ b/crates/rolldown_binding/src/types/binding_sourcemap.rs
@@ -55,3 +55,20 @@ impl TryFrom<BindingJsonSourcemap> for rolldown_sourcemap::SourceMap {
     Ok(map)
   }
 }
+
+impl From<rolldown_sourcemap::JSONSourceMap> for BindingSourcemap {
+  fn from(value: rolldown_sourcemap::JSONSourceMap) -> Self {
+    Self {
+      inner: Either::B(BindingJsonSourcemap {
+        file: value.file,
+        mappings: Some(value.mappings),
+        source_root: value.source_root,
+        sources: Some(value.sources.into_iter().map(Some).collect()),
+        sources_content: value.sources_content,
+        names: Some(value.names),
+        debug_id: value.debug_id,
+        x_google_ignore_list: value.x_google_ignore_list,
+      }),
+    }
+  }
+}

--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -69,7 +69,8 @@ export function loadFallbackPlugin(): BuiltinPlugin {
 }
 
 export function jsonPlugin(config?: BindingJsonPluginConfig): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:json', config);
+  const builtinPlugin = new BuiltinPlugin('builtin:json', config);
+  return makeBuiltinPluginCallable(builtinPlugin);
 }
 
 export function buildImportAnalysisPlugin(


### PR DESCRIPTION
> By the way, are there any native plugins that can be used in dev other than the resolver? If there aren't, I wonder if it's better to disable them in `resolveConfig`.

Currently, we only have three native plugins that are potentially used in the dev environment: `resolver`, `wasmFallback`, and maybe this `json` plugin. The rest aren't callable in dev because they either use the `transform_ast` hook, rely on internal context, or are only used in build environment.

_Originally posted by @shulaoda in https://github.com/vitejs/rolldown-vite/issues/246#issuecomment-2958188784_