### PR TITLE
chore: bump rolldown-ariadne

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
  "oxc-miette-derive",
  "textwrap",
  "thiserror 2.0.12",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2500,11 +2500,11 @@ dependencies = [
 
 [[package]]
 name = "rolldown-ariadne"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dfc1754b008b592c36747e857cd46972e82f5c35250857b544924c0918285c4"
+checksum = "324d1b9754f0cb535f4032a6a654d3a56047a500f557c16060f12f70b0089c57"
 dependencies = [
- "unicode-width 0.1.14",
+ "unicode-width",
  "yansi",
 ]
 
@@ -3446,7 +3446,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3706,12 +3706,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ rolldown_workspace = { version = "0.1.0", path = "./crates/rolldown_workspace" }
 anyhow = "1.0.98"
 append-only-vec = "0.1.7"
 arcstr = { version = "1.2.0", default-features = false }
-ariadne = { package = "rolldown-ariadne", version = "0.5.1" }
+ariadne = { package = "rolldown-ariadne", version = "0.5.2" }
 async-channel = "2.3.1"
 async-scoped = "0.9.0"
 async-trait = "0.1.88"


### PR DESCRIPTION
1. 0.5.2 rebase some changes from upstream from https://github.com/zesterer/ariadne/tree/74c2a7f8881e95629f9fb8d70140c133972d81d3