### PR TITLE
test: copy rollup preserveEntrySignature override-via-plugin test

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -334,7 +334,7 @@ impl GenerateStage<'_> {
         match finalized_preserve_entry_signatures {
           PreserveEntrySignatures::AllowExtension
           | PreserveEntrySignatures::Strict
-          | PreserveEntrySignatures::False => Some(self.options.preserve_entry_signatures),
+          | PreserveEntrySignatures::False => Some(finalized_preserve_entry_signatures),
           PreserveEntrySignatures::ExportsOnly => {
             let meta = &self.link_output.metas[module.idx];
             if meta.sorted_and_non_ambiguous_resolved_exports.is_empty() {

--- a/crates/rolldown/tests/rolldown/issues/4895/allow-extension/dynamic.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/allow-extension/dynamic.js
@@ -1,0 +1,2 @@
+import { shared } from './lib.js';
+console.log(shared);

--- a/crates/rolldown/tests/rolldown/issues/4895/allow-extension/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/allow-extension/lib.js
@@ -1,0 +1,1 @@
+export const shared = 'shared';

--- a/crates/rolldown/tests/rolldown/issues/4895/allow-extension/main.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/allow-extension/main.js
@@ -1,0 +1,4 @@
+import { shared } from './lib.js';
+console.log(shared);
+import('./dynamic.js');
+export const unused = 42;

--- a/crates/rolldown/tests/rolldown/issues/4895/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4895/artifacts.snap
@@ -1,0 +1,123 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## allow-extension.js
+
+```js
+//#region allow-extension/lib.js
+const shared = "shared";
+
+//#endregion
+//#region allow-extension/main.js
+console.log(shared);
+import("./dynamic.js");
+const unused = 42;
+
+//#endregion
+export { shared, unused };
+```
+## dynamic.js
+
+```js
+import { shared } from "./allow-extension.js";
+
+//#region allow-extension/dynamic.js
+console.log(shared);
+
+//#endregion
+```
+## dynamic2.js
+
+```js
+import { shared } from "./false.js";
+
+//#region false/dynamic.js
+console.log(shared);
+
+//#endregion
+```
+## dynamic3.js
+
+```js
+import { shared } from "./lib.js";
+
+//#region not-specified/dynamic.js
+console.log(shared);
+
+//#endregion
+```
+## dynamic4.js
+
+```js
+import { shared } from "./lib2.js";
+
+//#region strict/dynamic.js
+console.log(shared);
+
+//#endregion
+```
+## false.js
+
+```js
+//#region false/lib.js
+const shared = "shared";
+
+//#endregion
+//#region false/main.js
+console.log(shared);
+import("./dynamic2.js");
+
+//#endregion
+export { shared };
+```
+## lib.js
+
+```js
+//#region not-specified/lib.js
+const shared = "shared";
+
+//#endregion
+export { shared };
+```
+## lib2.js
+
+```js
+//#region strict/lib.js
+const shared = "shared";
+
+//#endregion
+export { shared };
+```
+## main.js
+
+```js
+
+```
+## not-specified.js
+
+```js
+import { shared } from "./lib.js";
+
+//#region not-specified/main.js
+console.log(shared);
+import("./dynamic3.js");
+const unused = 42;
+
+//#endregion
+export { unused };
+```
+## strict.js
+
+```js
+import { shared } from "./lib2.js";
+
+//#region strict/main.js
+console.log(shared);
+import("./dynamic4.js");
+const unused = 42;
+
+//#endregion
+export { unused };
+```

--- a/crates/rolldown/tests/rolldown/issues/4895/false/dynamic.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/false/dynamic.js
@@ -1,0 +1,2 @@
+import { shared } from './lib.js';
+console.log(shared);

--- a/crates/rolldown/tests/rolldown/issues/4895/false/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/false/lib.js
@@ -1,0 +1,1 @@
+export const shared = 'shared';

--- a/crates/rolldown/tests/rolldown/issues/4895/false/main.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/false/main.js
@@ -1,0 +1,4 @@
+import { shared } from './lib.js';
+console.log(shared);
+import('./dynamic.js');
+export const unused = 42;

--- a/crates/rolldown/tests/rolldown/issues/4895/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/4895/mod.rs
@@ -1,0 +1,70 @@
+use std::{borrow::Cow, sync::Arc};
+
+use rolldown::{BundlerOptions, PreserveEntrySignatures};
+use rolldown_common::EmittedChunk;
+use rolldown_plugin::{HookUsage, Plugin, PluginContext};
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+
+#[derive(Debug)]
+struct Test;
+
+impl Plugin for Test {
+  fn name(&self) -> Cow<'static, str> {
+    "test".into()
+  }
+
+  async fn build_start(
+    &self,
+    ctx: &PluginContext,
+    _args: &rolldown_plugin::HookBuildStartArgs<'_>,
+  ) -> Result<(), anyhow::Error> {
+    ctx
+      .emit_chunk(EmittedChunk {
+        id: "./strict/main.js".into(),
+        name: Some("strict".into()),
+        preserve_entry_signatures: Some(PreserveEntrySignatures::Strict),
+        ..Default::default()
+      })
+      .await?;
+    ctx
+      .emit_chunk(EmittedChunk {
+        id: "./not-specified/main.js".into(),
+        name: Some("not-specified".into()),
+        ..Default::default()
+      })
+      .await?;
+    ctx
+      .emit_chunk(EmittedChunk {
+        id: "./allow-extension/main.js".into(),
+        name: Some("allow-extension".into()),
+        preserve_entry_signatures: Some(PreserveEntrySignatures::AllowExtension),
+        ..Default::default()
+      })
+      .await?;
+    ctx
+      .emit_chunk(EmittedChunk {
+        id: "./false/main.js".into(),
+        name: Some("false".into()),
+        preserve_entry_signatures: Some(PreserveEntrySignatures::False),
+        ..Default::default()
+      })
+      .await?;
+    Ok(())
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::BuildStart
+  }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_rewrite_dynamic_imports_that_import_external_modules() {
+  let cwd = abs_file_dir!();
+
+  IntegrationTest::new(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions { cwd: Some(cwd), input: None, ..Default::default() },
+      vec![Arc::new(Test)],
+    )
+    .await;
+}

--- a/crates/rolldown/tests/rolldown/issues/4895/not-specified/dynamic.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/not-specified/dynamic.js
@@ -1,0 +1,2 @@
+import { shared } from './lib.js';
+console.log(shared);

--- a/crates/rolldown/tests/rolldown/issues/4895/not-specified/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/not-specified/lib.js
@@ -1,0 +1,1 @@
+export const shared = 'shared';

--- a/crates/rolldown/tests/rolldown/issues/4895/not-specified/main.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/not-specified/main.js
@@ -1,0 +1,4 @@
+import { shared } from './lib.js';
+console.log(shared);
+import('./dynamic.js');
+export const unused = 42;

--- a/crates/rolldown/tests/rolldown/issues/4895/strict/dynamic.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/strict/dynamic.js
@@ -1,0 +1,2 @@
+import { shared } from './lib.js';
+console.log(shared);

--- a/crates/rolldown/tests/rolldown/issues/4895/strict/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/strict/lib.js
@@ -1,0 +1,1 @@
+export const shared = 'shared';

--- a/crates/rolldown/tests/rolldown/issues/4895/strict/main.js
+++ b/crates/rolldown/tests/rolldown/issues/4895/strict/main.js
@@ -1,0 +1,4 @@
+import { shared } from './lib.js';
+console.log(shared);
+import('./dynamic.js');
+export const unused = 42;

--- a/crates/rolldown/tests/rolldown/issues/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/mod.rs
@@ -1,2 +1,4 @@
 #[path = "./1733/mod.rs"]
 mod _1733;
+#[path = "./4895/mod.rs"]
+mod _4895;


### PR DESCRIPTION
copy from https://github.com/rollup/rollup/blob/061a0387c8654222620f602471d66afd3c582048/test/chunking-form/samples/preserve-entry-signatures/override-via-plugin/_config.js#L1-L36