### PR TITLE
fix(node): call options hook for experimental_scan

### DIFF
--- a/packages/rolldown/src/api/experimental.ts
+++ b/packages/rolldown/src/api/experimental.ts
@@ -1,4 +1,5 @@
 import type { InputOptions } from '../options/input-options';
+import { PluginDriver } from '../plugin/plugin-driver';
 import { createBundler } from '../utils/create-bundler';
 import { handleOutputErrors } from '../utils/transform-to-rollup-output';
 
@@ -8,7 +9,8 @@ import { handleOutputErrors } from '../utils/transform-to-rollup-output';
  * Calling this API will only execute the scan stage of rolldown.
  */
 export const experimental_scan = async (input: InputOptions): Promise<void> => {
-  const { bundler, stopWorkers } = await createBundler(input, {});
+  const inputOptions = await PluginDriver.callOptionsHook(input);
+  const { bundler, stopWorkers } = await createBundler(inputOptions, {});
   const output = await bundler.scan();
   handleOutputErrors(output);
   await stopWorkers?.();

--- a/packages/rolldown/tests/scan.test.ts
+++ b/packages/rolldown/tests/scan.test.ts
@@ -1,0 +1,26 @@
+import { test, expect, describe } from 'vitest'
+import { scan } from 'rolldown/experimental'
+
+describe('experimental_scan', () => {
+  test('call options hook', async () => {
+    expect.assertions(1)
+
+    await scan({
+      input: 'virtual',
+      plugins: [
+        {
+          name: 'test',
+          options(opts) {
+            expect(opts).toBeTruthy()
+          },
+          resolveId(id) {
+            if (id === 'virtual') return '\0' + id
+          },
+          load(id) {
+            if (id === '\0virtual') return ''
+          }
+        }
+      ]
+    })
+  })
+})


### PR DESCRIPTION
Call `options` hook for exprimental_scan to be consistent.