### PR TITLE
fix: should not panic when meet a syntax error in watch mode.

### DIFF
--- a/crates/rolldown/examples/watch.rs
+++ b/crates/rolldown/examples/watch.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use rolldown::{Bundler, BundlerOptions, ExperimentalOptions, InputItem, ResolveOptions, Watcher};
-use rolldown_workspace::root_dir;
+use rolldown::{Bundler, BundlerOptions, ExperimentalOptions, Watcher};
+use sugar_path::SugarPath;
 use tokio::sync::Mutex;
 
 // cargo run --example watch
@@ -9,20 +9,9 @@ use tokio::sync::Mutex;
 #[tokio::main]
 async fn main() {
   let bundler = Bundler::new(BundlerOptions {
-    input: Some(vec![InputItem {
-      name: Some("rome-ts".to_string()),
-      import: root_dir().join("tmp/bench/rome/src/entry.ts").to_str().unwrap().to_string(),
-    }]),
-    cwd: Some(root_dir().join("tmp/bench/rome")),
+    input: Some(vec!["./entry.js".to_string().into()]),
+    cwd: Some(rolldown_workspace::crate_dir("rolldown").join("./examples/basic").normalize()),
 
-    // --- Required specific options for Rome
-    shim_missing_exports: Some(true), // Need this due rome is not written with `isolatedModules: true`
-    resolve: Some(ResolveOptions {
-      tsconfig_filename: Some(
-        root_dir().join("tmp/bench/rome/src/tsconfig.json").to_str().unwrap().to_string(),
-      ),
-      ..Default::default()
-    }),
     experimental: Some(ExperimentalOptions { incremental_build: Some(true), ..Default::default() }),
     ..Default::default()
   });


### PR DESCRIPTION
I thought using a **mutable reference** may be better than returning the `cache` struct, so that we don't need to worry about forgetting to reassign `cache` in the future.

realted to https://github.com/rolldown/rolldown/pull/4898