### PR TITLE
test: enable expectExecuted in HMR tests

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/_config.json
@@ -3,7 +3,5 @@
     "experimental": {
       "hmr": {}
     }
-  },
-  // Runtime currently relies on browser environment's `WebSocket`
-  "expectExecuted": false
+  }
 }

--- a/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
@@ -31,7 +31,7 @@ const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.__toCommonJS(main_exports);
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 console.log(foo$1, foo);
-main_hot.accept();
+main_hot.accept(() => {});
 
 //#endregion
 ```
@@ -50,7 +50,7 @@ var init_main_0 = __rolldown_runtime__.createEsmInitializer(function() {
 		var import_foo_0 = __rolldown_runtime__.loadExports("foo.mjs");
 		var import_foo_1 = __rolldown_runtime__.loadExports("foo/index.mjs");
 		console.log(import_foo_0.foo, import_foo_1.foo);
-		hot_main.accept();
+		hot_main.accept(() => {});
 	} finally {}
 });
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/main.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/main.hmr-0.js
@@ -3,4 +3,4 @@ import * as dir from './foo/index.mjs'
 
 console.log(file.foo, dir.foo)
 
-import.meta.hot.accept()
+import.meta.hot.accept(() => {})

--- a/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/main.js
@@ -3,4 +3,4 @@ import * as dir from './foo/index.mjs'
 
 console.log(file.foo, dir.foo)
 
-import.meta.hot.accept()
+import.meta.hot.accept(() => {})

--- a/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/_config.json
@@ -13,7 +13,5 @@
     "experimental": {
       "hmr": {}
     }
-  },
-  // Runtime currently relies on browser environment's `WebSocket`
-  "expectExecuted": false
+  }
 }

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/_config.json
@@ -3,7 +3,5 @@
     "experimental": {
       "hmr": {}
     }
-  },
-  // Runtime currently relies on browser environment's `WebSocket`
-  "expectExecuted": false
+  }
 }

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5367,7 +5367,7 @@ expression: output
 
 # tests/rolldown/topics/hmr/deconflict_import_bindings
 
-- main-!~{000}~.js => main-CsVwbL6p.js
+- main-!~{000}~.js => main-evpwWx4a.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 


### PR DESCRIPTION
Enabled `expectExecuted` in HMR tests. It currently only runs the initial bundle.