### PR TITLE
refactor: include DevRuntime base class even if custom HMR implementation is passed

### DIFF
--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -81,10 +81,11 @@ impl RuntimeModuleTask {
         }
       }
       runtime_source.push_str(&get_runtime_js());
+      runtime_source.push_str(include_str!("../runtime/runtime-extra-dev-common.js"));
       if let Some(implement) = hmr_options.implement.as_deref() {
         runtime_source.push_str(implement);
       } else {
-        let content = include_str!("../runtime/runtime-extra-dev.js");
+        let content = include_str!("../runtime/runtime-extra-dev-default.js");
         let host = hmr_options.host.as_deref().unwrap_or("localhost");
         let port = hmr_options.port.unwrap_or(3000);
         let addr = format!("{host}:{port}");

--- a/crates/rolldown/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown/src/runtime/runtime-extra-dev-common.js
@@ -1,0 +1,66 @@
+// @ts-check
+
+// oxlint-disable-next-line no-unused-vars
+class DevRuntime {
+  /**
+   * @type {Record<string, { exports: any }>}
+   */
+  modules = {}
+  /**
+   * @param {string} _moduleId
+   */
+  createModuleHotContext(_moduleId) {
+    throw new Error('createModuleHotContext should be implemented')
+  }
+  /**
+   *
+   * @param {string[]} _boundaries
+   */
+  applyUpdates(_boundaries) {
+    throw new Error('applyUpdates should be implemented')
+  }
+  /**
+   * @param {string} id
+   * @param {{ exports: any }} module
+   */
+  registerModule(id, module) {
+    console.debug('Registering module', id, module);
+    this.modules[id] = module
+  }
+  /**
+   * @param {string} id
+   */
+  loadExports(id) {
+    const module = this.modules[id];
+    if (module) {
+      return module.exports;
+    } else {
+      console.warn(`Module ${id} not found`);
+      return {};
+    }
+  }
+
+  /**
+   * __esmMin
+   *
+   * @type {<T>(fn: any, res: T) => () => T}
+   * @internal
+   */
+  createEsmInitializer = (fn, res) => () => (fn && (res = fn(fn = 0)), res)
+  /**
+   * __commonJSMin
+   *
+   * @type {<T extends { exports: any }>(cb: any, mod: { exports: any }) => () => T}
+   * @internal
+   */
+  createCjsInitializer = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports)
+  /** @internal */
+  // @ts-expect-error it exists
+  __toESM = __toESM;
+  /** @internal */
+  // @ts-expect-error it exists
+  __toCommonJS = __toCommonJS
+  /** @internal */
+  // @ts-expect-error it exists
+  __export = __export
+}

--- a/crates/rolldown/src/runtime/runtime-extra-dev-default.js
+++ b/crates/rolldown/src/runtime/runtime-extra-dev-default.js
@@ -38,15 +38,7 @@ class ModuleHotContext {
   }
 }
 
-class DevRuntime {
-  /**
-   * @type {Map<string, Set<(...args: any[]) => void>>}
-   */
-  acceptPathToCallers = new Map()
-  /**
-   * @type {Record<string, { exports: any }>}
-   */
-  modules = {}
+class DefaultDevRuntime extends DevRuntime {
   /**
    * @type {Map<string, ModuleHotContext>}
    */
@@ -56,21 +48,7 @@ class DevRuntime {
    */
   moduleHotContextsToBeUpdated = new Map()
   /**
-   *
-   * @returns {DevRuntime}
-   */
-  static getInstance() {
-    /**
-     * @type {DevRuntime | undefined}
-     */
-    let instance = globalThis.__rolldown_runtime__;
-    if (!instance) {
-      instance = new DevRuntime();
-      globalThis.__rolldown_runtime__ = instance;
-    }
-    return instance
-  }
-  /**
+   * @override
    * @param {string} moduleId
    */
   createModuleHotContext(moduleId) {
@@ -83,7 +61,7 @@ class DevRuntime {
     return hotContext;
   }
   /**
-   *
+   * @override
    * @param {string[]} boundaries
    */
   applyUpdates(boundaries) {
@@ -103,53 +81,9 @@ class DevRuntime {
     this.moduleHotContextsToBeUpdated.clear()
     // swap new contexts
   }
-  /**
-   * @param {string} id
-   * @param {{ exports: any }} module
-   */
-  registerModule(id, module) {
-    console.debug('Registering module', id, module);
-    this.modules[id] = module
-  }
-  /**
-   * @param {string} id
-   */
-  loadExports(id) {
-    const module = this.modules[id];
-    if (module) {
-      return module.exports;
-    } else {
-      console.warn(`Module ${id} not found`);
-      return {};
-    }
-  }
-
-  /**
-   * __esmMin
-   *
-   * @type {<T>(fn: any, res: T) => () => T}
-   * @internal
-   */
-  createEsmInitializer = (fn, res) => () => (fn && (res = fn(fn = 0)), res)
-  /**
-   * __commonJSMin
-   *
-   * @type {<T extends { exports: any }>(cb: any, mod: { exports: any }) => () => T}
-   * @internal
-   */
-  createCjsInitializer = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports)
-  /** @internal */
-  // @ts-expect-error it exists
-  __toESM = __toESM;
-  /** @internal */
-  // @ts-expect-error it exists
-  __toCommonJS = __toCommonJS
-  /** @internal */
-  // @ts-expect-error it exists
-  __export = __export
 }
 
-globalThis.__rolldown_runtime__ = DevRuntime.getInstance();
+;(/** @type {any} */ (globalThis)).__rolldown_runtime__ ??= new DefaultDevRuntime();
 
 /** @param {string} url */
 function loadScript(url) {

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4063,7 +4063,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-BZtAq6v5.js
+- main-!~{000}~.js => main-BHjcQpjN.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4697,7 +4697,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-BO-541NT.js
+- main-!~{000}~.js => main-ChUrgBBM.js
 
 # tests/rolldown/issues/4196
 
@@ -5371,17 +5371,17 @@ expression: output
 
 # tests/rolldown/topics/hmr/deconflict_import_bindings
 
-- main-!~{000}~.js => main-BQu-dzW2.js
+- main-!~{000}~.js => main-Bsw305ma.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-q35uSqQd.js
-- index-!~{001}~.js => index-DnJyT3wj.js
-- chunk-!~{002}~.js => chunk-DWFXkX0J.js
+- entry-!~{000}~.js => entry-CBzHZYBI.js
+- index-!~{001}~.js => index-D1GGCNxh.js
+- chunk-!~{002}~.js => chunk-CUsgavGH.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-D3RiDSio.js
+- main-!~{000}~.js => main-B4-Shbiz.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -297,7 +297,7 @@ function copy() {
 function generateRuntimeTypes() {
   const inputFile = nodePath.resolve(
     __dirname,
-    '../../crates/rolldown/src/runtime/runtime-extra-dev.js',
+    '../../crates/rolldown/src/runtime/runtime-extra-dev-common.js',
   );
   const outputFile = nodePath.resolve(
     outputDir,


### PR DESCRIPTION
Split the HMR runtime into two parts and inject the commonly needed part even if the custom implementation is used.