### PR TITLE
fix(strictExecutionOrder): ensure initialization chain of entry exports

### DIFF
--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -77,7 +77,14 @@ impl LinkStage<'_> {
         };
         let meta = &self.metas[entry.id];
         meta.referenced_symbols_by_entry_point_chunk.iter().for_each(|symbol_ref| {
-          include_symbol(context, *symbol_ref);
+          if let Module::Normal(module) = &context.modules[symbol_ref.owner] {
+            module.stmt_infos.declared_stmts_by_symbol(symbol_ref).iter().copied().for_each(
+              |stmt_info_id| {
+                include_statement(context, module, stmt_info_id);
+              },
+            );
+            include_symbol(context, *symbol_ref);
+          }
         });
         include_module(context, module);
       });
@@ -113,7 +120,14 @@ impl LinkStage<'_> {
       };
       let meta = &self.metas[entry.id];
       meta.referenced_symbols_by_entry_point_chunk.iter().for_each(|symbol_ref| {
-        include_symbol(context, *symbol_ref);
+        if let Module::Normal(module) = &context.modules[symbol_ref.owner] {
+          module.stmt_infos.declared_stmts_by_symbol(symbol_ref).iter().copied().for_each(
+            |stmt_info_id| {
+              include_statement(context, module, stmt_info_id);
+            },
+          );
+          include_symbol(context, *symbol_ref);
+        }
       });
       include_module(context, module);
       true

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
@@ -7,11 +7,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 import { __esm } from "./rolldown-runtime.js";
-import { lib_ui_exports } from "./ui.js";
-import { lib_npm_a_exports, lib_npm_b_exports } from "./other-libs.js";
+import { init_lib_ui, lib_ui_exports } from "./ui.js";
+import { init_lib_npm_a, init_lib_npm_b, lib_npm_a_exports, lib_npm_b_exports } from "./other-libs.js";
 
 //#region main.js
-var init_main = __esm({ "main.js"() {} });
+var init_main = __esm({ "main.js"() {
+	init_lib_ui();
+	init_lib_npm_a();
+	init_lib_npm_b();
+} });
 
 //#endregion
 init_main();
@@ -40,7 +44,7 @@ var init_lib_npm_b = __esm({ "node_modules/lib-npm-b/index.js"() {
 } });
 
 //#endregion
-export { lib_npm_a_exports, lib_npm_b_exports };
+export { init_lib_npm_a, init_lib_npm_b, lib_npm_a_exports, lib_npm_b_exports };
 ```
 ## rolldown-runtime.js
 
@@ -75,5 +79,5 @@ var init_lib_ui = __esm({ "node_modules/lib-ui/index.js"() {
 } });
 
 //#endregion
-export { lib_ui_exports };
+export { init_lib_ui, lib_ui_exports };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "strictExecutionOrder": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import nodeAssert from "node:assert";
+
+
+//#region dep.js
+function foo() {
+	globalThis.value = 1;
+}
+var dep_default;
+var init_dep = __esm({ "dep.js"() {
+	dep_default = /* @__PURE__ */ foo();
+} });
+
+//#endregion
+//#region main.js
+var init_main = __esm({ "main.js"() {
+	init_dep();
+	nodeAssert.strictEqual(globalThis.value, 1);
+} });
+
+//#endregion
+init_main();
+export { dep_default as dep };
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/dep.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/dep.js
@@ -1,0 +1,5 @@
+function foo() {
+  globalThis.value = 1
+}
+
+export default /*#__PURE__*/ foo()

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/main.js
@@ -1,0 +1,7 @@
+import nodeAssert from "node:assert"
+
+import dep from "./dep.js"
+
+nodeAssert.strictEqual(globalThis.value, 1)
+
+export { dep }

--- a/crates/rolldown/tests/rolldown/function/shim_missing_exports/basic_wrapped_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/shim_missing_exports/basic_wrapped_esm/artifacts.snap
@@ -17,6 +17,7 @@ var init_foo = __esm({ "foo.js"() {
 //#endregion
 //#region main.js
 init_foo();
+init_foo();
 
 //#endregion
 export { missing };

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3949,10 +3949,10 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/split_node_modules
 
-- main-!~{000}~.js => main-BjmQ9ujI.js
-- other-libs-!~{005}~.js => other-libs-Bo0B-gKW.js
+- main-!~{000}~.js => main-CgintLkr.js
+- other-libs-!~{005}~.js => other-libs-9w3pul5i.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BvgZlyOU.js
-- ui-!~{003}~.js => ui-CMSLr63w.js
+- ui-!~{003}~.js => ui-17vXJ9Bu.js
 
 # tests/rolldown/function/define/node_env
 
@@ -4070,6 +4070,10 @@ expression: output
 - main-!~{000}~.js => main-BB2kLC1L.js
 - dynamic-!~{003}~.js => dynamic-DSCFIWqq.js
 - read-!~{001}~.js => read-C1QSWzqi.js
+
+# tests/rolldown/function/experimental/strict_execution_order/issue_4920
+
+- main-!~{000}~.js => main-Cdv0wJBe.js
 
 # tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module
 
@@ -4522,7 +4526,7 @@ expression: output
 
 # tests/rolldown/function/shim_missing_exports/basic_wrapped_esm
 
-- main-!~{000}~.js => main-D_J4eDe5.js
+- main-!~{000}~.js => main-BBAfU8Lx.js
 
 # tests/rolldown/function/shim_missing_exports/shake_unused_shimmed_exports
 


### PR DESCRIPTION
Fixes https://github.com/rolldown/rolldown/issues/4920.