### PR TITLE
fix(rolldown_plugin_build_import_analysis): preload helper is imported even if it’s not needed

### DIFF
--- a/crates/rolldown_plugin_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_build_import_analysis/src/ast_visit.rs
@@ -53,9 +53,8 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
       match expr {
         Expression::CallExpression(expr) => self.rewrite_import_expr(expr),
         Expression::StaticMemberExpression(expr) => self.rewrite_member_expr(expr),
-        _ => return,
+        _ => {}
       }
-      self.need_prepend_helper = true;
     }
   }
 


### PR DESCRIPTION
closes https://github.com/vitejs/rolldown-vite/issues/254