### PR TITLE
refactor: get normalized options via binding

### DIFF
--- a/crates/rolldown_binding/src/types/binding_normalized_options.rs
+++ b/crates/rolldown_binding/src/types/binding_normalized_options.rs
@@ -247,4 +247,19 @@ impl BindingNormalizedOptions {
   pub fn legal_comments(&self) -> String {
     self.inner.legal_comments.to_string()
   }
+
+  #[napi(getter)]
+  pub fn preserve_modules(&self) -> bool {
+    self.inner.preserve_modules
+  }
+
+  #[napi(getter, ts_return_type = "string | undefined")]
+  pub fn preserve_modules_root(&self) -> Option<String> {
+    self.inner.preserve_modules_root.clone()
+  }
+
+  #[napi(getter)]
+  pub fn virtual_dirname(&self) -> String {
+    self.inner.virtual_dirname.clone()
+  }
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1146,6 +1146,9 @@ export declare class BindingNormalizedOptions {
   get minify(): false | BindingMinifyOptions
   get polyfillRequire(): boolean
   get legalComments(): 'none' | 'inline'
+  get preserveModules(): boolean
+  get preserveModulesRoot(): string | undefined
+  get virtualDirname(): string
 }
 
 export declare class BindingOutputAsset {

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -181,15 +181,15 @@ export class NormalizedOutputOptionsImpl implements NormalizedOutputOptions {
   }
 
   get preserveModules(): boolean {
-    return this.outputOptions.preserveModules || false;
+    return this.inner.preserveModules;
   }
 
   get preserveModulesRoot(): string | undefined {
-    return this.outputOptions.preserveModulesRoot;
+    return this.inner.preserveModulesRoot;
   }
 
   get virtualDirname(): string {
-    return this.outputOptions.virtualDirname || '_virtual';
+    return this.inner.virtualDirname;
   }
 }
 


### PR DESCRIPTION
The fix in [pr](https://github.com/rolldown/rolldown/pull/4879/files) could return the correct result, but it differs from other options. This PR aligns with the same style of returning a normalized option via binding.