### PR TITLE
chore(infra): remove comments related to `cspell`

### DIFF
--- a/.github/workflows/metric.yml
+++ b/.github/workflows/metric.yml
@@ -36,7 +36,6 @@ jobs:
           echo $COMPILE_TIME
           echo "COMPILE_TIME=$COMPILE_TIME" >> $GITHUB_OUTPUT
 
-          # cspell:disable-next-line
           BINARY_SIZE=$(ls -l ./target/release/librolldown_binding.so | awk '{print $5}')
           echo $BINARY_SIZE
           echo "BINARY_SIZE=$BINARY_SIZE" >> $GITHUB_OUTPUT

--- a/crates/rolldown/src/stages/generate_stage/minify_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/minify_assets.rs
@@ -57,7 +57,6 @@ fn test_d_ts_pattern(input: &str) -> bool {
   input.ends_with(".d.ts") || input.ends_with(".d.cts") || input.ends_with(".d.mts")
 }
 
-// @cspell:ignore ctsx, mtsx
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -1,6 +1,5 @@
 use std::cmp::Reverse;
 
-// cSpell:ignore idxs
 use itertools::Itertools;
 use oxc_index::IndexVec;
 use petgraph::prelude::DiGraphMap;

--- a/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_await_destruct/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/dynamic_import_await_destruct/main.js
@@ -1,6 +1,5 @@
 // copy some tests from https://github.com/parcel-bundler/parcel/pull/5367/files
 // license: https://github.com/parcel-bundler/parcel/blob/a53f8f3ba1025c7ea8653e9719e0a61ef9717079/LICENSE
-// @cSpell: disable
 // the usage should be merged, rest of the exported symbol should be tree-shaken
 const {foo: x, thing: a} = await import("./lib.js")
 console.log(x);

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -1,4 +1,3 @@
-// @Cspell:ignore tokenss
 use itertools::Itertools;
 use napi::bindgen_prelude::{Either, FnArgs};
 use rolldown_utils::filter_expression::{self, FilterExprKind};

--- a/crates/rolldown_error/src/locator.rs
+++ b/crates/rolldown_error/src/locator.rs
@@ -28,7 +28,6 @@ mod test_locator {
   #[test]
   fn line_column_to_byte_offset() {
     use super::ByteLocator;
-    // cspell:ignore ncghi
     let source = "abc\ndef\ncghi";
     assert_eq!(ByteLocator::new(source).byte_offset(0, 0), 0);
     assert_eq!(ByteLocator::new(source).byte_offset(1, 0), 4);

--- a/crates/rolldown_plugin_json/src/utils.rs
+++ b/crates/rolldown_plugin_json/src/utils.rs
@@ -1,4 +1,3 @@
-// cSpell:disable
 use std::fmt::Write as _;
 
 use rolldown_utils::concat_string;

--- a/crates/rolldown_utils/src/global_reference.rs
+++ b/crates/rolldown_utils/src/global_reference.rs
@@ -1,4 +1,3 @@
-// cSpell:disable
 use oxc::span::Atom;
 
 static GLOBAL_IDENT: phf::Set<&str> = phf::phf_set![

--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -1,4 +1,3 @@
-// @cSpell:ignore subcase
 use memchr::memmem;
 use std::{borrow::Cow, path::Path};
 
@@ -380,7 +379,6 @@ filter: {:?}, id: {id}",
         cases: vec![
           ("import.meta", FilterResult::Match(true)),
           ("import_meta", FilterResult::Match(false)),
-          // cspell:ignore importmeta
           ("importmeta", FilterResult::NoneMatch(false)),
         ],
       },

--- a/crates/string_wizard/tests/magic_string.rs
+++ b/crates/string_wizard/tests/magic_string.rs
@@ -1,4 +1,3 @@
-// cSpell:disable
 use std::borrow::Cow;
 
 use string_wizard::IndentOptions;

--- a/crates/string_wizard/tests/magic_string_source_map.rs
+++ b/crates/string_wizard/tests/magic_string_source_map.rs
@@ -1,5 +1,4 @@
 use oxc_sourcemap::SourcemapVisualizer;
-// cSpell:disable
 use string_wizard::{Hires, MagicString, ReplaceOptions, SourceMapOptions, UpdateOptions};
 
 #[test]

--- a/packages/pluginutils/src/composable-filters.test.ts
+++ b/packages/pluginutils/src/composable-filters.test.ts
@@ -1,4 +1,3 @@
-// cSpell:ignore fooa, afoo
 import { describe, expect, test } from 'vitest';
 import {
   and,

--- a/packages/pluginutils/src/simple-filters.test.ts
+++ b/packages/pluginutils/src/simple-filters.test.ts
@@ -1,4 +1,3 @@
-// cSpell:ignore fooa, afoo
 import picomatch from 'picomatch';
 import { describe, expect, test } from 'vitest';
 import {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/should-not-match/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/should-not-match/_config.ts
@@ -21,7 +21,6 @@ export default defineTest({
       onLogFn()
     },
   },
-  // cspell:ignore rolldownlib
   async afterTest() {
     expect(onLogFn).toHaveBeenCalledTimes(1)
 

--- a/packages/rolldown/tests/fixtures/misc/virtual/virtual-dirname/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/virtual/virtual-dirname/_config.ts
@@ -26,8 +26,7 @@ export default defineTest({
       virtualDirname: 'custom-virtual',
     }
   },
-  // cSpell:disable
-  afterTest(output) {
+    afterTest(output) {
     if (process.platform !== 'win32') {
       expect(getOutputChunkNames(output)).toStrictEqual([
         'main.js',

--- a/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
@@ -25,8 +25,7 @@ export default defineTest({
     ],
   },
   afterTest(output) {
-    // cSpell:disable
-    expect(getOutputChunkNames(output)).toStrictEqual([
+        expect(getOutputChunkNames(output)).toStrictEqual([
       'entry.js',
       'main.js',
       '_module-iGCt1YOi.js',

--- a/packages/rolldown/tests/fixtures/output/hash-filenames/normal/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/hash-filenames/normal/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { defineTest } from 'rolldown-tests'
 import { expect } from 'vitest'
 import { getOutputChunk } from 'rolldown-tests/utils'

--- a/packages/rolldown/tests/fixtures/output/sanitize-filename/false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sanitize-filename/false/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { defineTest } from 'rolldown-tests'
 import { getOutputFileNames } from 'rolldown-tests/utils'
 import { expect } from 'vitest'

--- a/packages/rolldown/tests/fixtures/output/sanitize-filename/function/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sanitize-filename/function/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { defineTest } from 'rolldown-tests'
 import { getOutputFileNames } from 'rolldown-tests/utils'
 import { expect } from 'vitest'

--- a/packages/rolldown/tests/fixtures/output/sanitize-filename/true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sanitize-filename/true/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { defineTest } from 'rolldown-tests'
 import { getOutputFileNames } from 'rolldown-tests/utils'
 import { expect } from 'vitest'

--- a/packages/rolldown/tests/fixtures/output/sourcemap/false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap/false/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { expect } from 'vitest'
 import { getOutputFileNames } from 'rolldown-tests/utils'
 import { defineTest } from 'rolldown-tests'

--- a/packages/rolldown/tests/fixtures/output/sourcemap/hidden/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap/hidden/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { expect } from 'vitest'
 import { getOutputFileNames } from 'rolldown-tests/utils'
 import { defineTest } from 'rolldown-tests'

--- a/packages/rolldown/tests/fixtures/output/sourcemap/inline/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap/inline/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { expect } from 'vitest'
 import { getOutputFileNames } from 'rolldown-tests/utils'
 import { defineTest } from 'rolldown-tests'

--- a/packages/rolldown/tests/fixtures/output/sourcemap/methods/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap/methods/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { expect } from 'vitest'
 import { defineTest } from 'rolldown-tests'
 

--- a/packages/rolldown/tests/fixtures/output/sourcemap/true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap/true/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { expect } from 'vitest'
 import { getOutputFileNames } from 'rolldown-tests/utils'
 import { defineTest } from 'rolldown-tests'

--- a/packages/rolldown/tests/fixtures/plugin/augment-chunk-hash/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/augment-chunk-hash/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { expect, vi } from 'vitest'
 import { defineTest } from 'rolldown-tests'
 import { getOutputChunk } from 'rolldown-tests/utils'

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-chunk/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { defineTest } from 'rolldown-tests'
 import { expect } from 'vitest'
 

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { defineTest } from 'rolldown-tests'
 import { getOutputAsset } from 'rolldown-tests/utils'
 import { expect } from 'vitest'

--- a/packages/rolldown/tests/fixtures/plugin/transform/soucemap-with-multiple-sources/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/soucemap-with-multiple-sources/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { expect } from 'vitest'
 import { defineTest } from 'rolldown-tests'
 import {

--- a/packages/rolldown/tests/fixtures/plugin/transform/without-sourcemap/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/without-sourcemap/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { expect } from 'vitest'
 import { defineTest } from 'rolldown-tests'
 import {

--- a/packages/rolldown/tests/fixtures/topics/virtual-module/virtual-entry/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/virtual-module/virtual-entry/_config.ts
@@ -1,4 +1,3 @@
-// cSpell:disable
 import { defineTest } from 'rolldown-tests'
 import { expect } from 'vitest'
 

--- a/packages/rollup-tests/src/ignored-passed-snapshot-different-tests.js
+++ b/packages/rollup-tests/src/ignored-passed-snapshot-different-tests.js
@@ -1,4 +1,3 @@
-// cSpell:disable
 module.exports = [
     // Passed, but the output snapshot is different from rollup
     "rollup@form@make-absolute-externals-relative@make-relative-false: does not normalize external paths when set to false",

--- a/packages/rollup-tests/src/ignored-tests.js
+++ b/packages/rollup-tests/src/ignored-tests.js
@@ -1,4 +1,3 @@
-// cSpell:disable
 const ignoreTests = [
   'rollup@function@bundle-facade-order: respects the order of entry points when there are additional facades for chunks', // https://github.com/rolldown/rolldown/issues/1842#issuecomment-2296345255
 

--- a/packages/rollup-tests/src/ignored-treeshaking-tests.js
+++ b/packages/rollup-tests/src/ignored-treeshaking-tests.js
@@ -1,4 +1,3 @@
-// cSpell:disable
 const ignoreTests = [
   // The treeshaking is not compatible with rollup
   "rollup@form@conditional-put-parens-around-sequence: put parens around sequences if conditional simplified (#1311)",

--- a/scripts/ci/publish-rolldown-to-npm.js
+++ b/scripts/ci/publish-rolldown-to-npm.js
@@ -58,7 +58,6 @@ async function publish(version, tag) {
 // --- main
 
 assertRunningScriptFromRepoRoot();
-// // cspell:ignore nothrow
 $.nothrow = true;
 $.verbose = true;
 

--- a/scripts/snap-diff/index.ts
+++ b/scripts/snap-diff/index.ts
@@ -1,4 +1,3 @@
-// cSpell:ignore packagejson
 import { run } from './runner';
 
 const args = process.argv.slice(2);


### PR DESCRIPTION
`cspell` is no longer in use.