### PR TITLE
fix: handle error in `hmrInvalidate`

### DIFF
--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -125,13 +125,15 @@ impl Bundler {
     &self,
     file: String,
     first_invalidated_by: Option<String>,
-  ) -> BindingHmrOutput {
+  ) -> napi::Result<BindingHmrOutput> {
     let mut bundler_core = self.inner.lock().await;
-    bundler_core
-      .hmr_invalidate(file, first_invalidated_by)
-      .await
-      .expect("Failed to call hmr_invalidate")
-      .into()
+    let result = bundler_core.hmr_invalidate(file, first_invalidated_by).await;
+    match result {
+      Ok(output) => Ok(output.into()),
+      Err(errs) => {
+        Ok(BindingHmrOutput::from_errors(errs.into_vec(), bundler_core.options().cwd.clone()))
+      }
+    }
   }
 }
 

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -4,7 +4,7 @@ import {
 } from '../../utils/create-bundler';
 import { transformToRollupOutput } from '../../utils/transform-to-rollup-output';
 
-import type { BindingHmrOutput, BindingHmrOutputPatch } from '../../binding';
+import type { BindingHmrOutputPatch } from '../../binding';
 import type { InputOptions } from '../../options/input-options';
 import type { OutputOptions } from '../../options/output-options';
 import type { HasProperty, TypeAssert } from '../../types/assert';
@@ -81,8 +81,12 @@ export class RolldownBuild {
   async hmrInvalidate(
     file: string,
     firstInvalidatedBy?: string,
-  ): Promise<BindingHmrOutput | undefined> {
-    return this.#bundler?.bundler.hmrInvalidate(file, firstInvalidatedBy);
+  ): Promise<BindingHmrOutputPatch | undefined> {
+    const output = await this.#bundler!.bundler.hmrInvalidate(
+      file,
+      firstInvalidatedBy,
+    );
+    return transformHmrPatchOutput(output);
   }
 
   // TODO(underfin)


### PR DESCRIPTION
Same with #4837 but for `hmrInvalidate`.