### PR TITLE
build: provide `"type": "module"` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "monorepo",
   "description": "Rollup in Rust",
+  "type": "module",
   "private": true,
   "packageManager": "pnpm@10.12.1",
   "engines": {


### PR DESCRIPTION
Actually I think `"type": "module"` syntax detection is required for performance issue. Node.js doc says, "Syntax detection should have no performance impact on CommonJS modules, but it incurs a slight performance penalty for ES modules; add `"type": "module"` to the nearest parent `package.json` file to eliminate the performance cost."  That is why I think may be we may add this here.

https://nodejs.org/en/blog/release/v20.19.0#module-syntax-detection-is-now-enabled-by-default