### PR TITLE
feat(binding): always use the same `BindingBundler` to create `BindingBundlerImpl` for the same `RolldownBuild`

### DIFF
--- a/crates/rolldown_binding/src/binding_bundler.rs
+++ b/crates/rolldown_binding/src/binding_bundler.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use napi::Env;
+use napi_derive::napi;
+
+use crate::binding_bundler_impl::{BindingBundlerImpl, BindingBundlerOptions};
+
+#[expect(unused)]
+#[napi]
+pub struct BindingBundler {
+  session_id: Arc<str>,
+  session_span: tracing::Span,
+}
+
+#[napi]
+impl BindingBundler {
+  #[napi(constructor)]
+  pub fn new() -> napi::Result<Self> {
+    let session_id: Arc<str> = std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .expect("Time went backwards")
+      .as_millis()
+      .to_string()
+      .into();
+
+    let session_span = tracing::trace_span!("Session", session_id = &*session_id);
+
+    Ok(Self { session_id, session_span })
+  }
+
+  #[napi]
+  #[cfg_attr(target_family = "wasm", allow(unused))]
+  pub fn create_impl(
+    &self,
+    env: Env,
+    options: BindingBundlerOptions,
+  ) -> napi::Result<BindingBundlerImpl> {
+    BindingBundlerImpl::new(env, options)
+  }
+}

--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -27,6 +27,7 @@ pub mod utils;
 pub use oxc_parser_napi;
 pub use oxc_resolver_napi;
 pub use oxc_transform_napi;
+pub mod binding_bundler;
 mod generated;
 pub mod watcher;
 pub mod worker_manager;

--- a/packages/rolldown/src/api/experimental.ts
+++ b/packages/rolldown/src/api/experimental.ts
@@ -1,6 +1,7 @@
+import { BindingBundler } from '../binding';
 import type { InputOptions } from '../options/input-options';
 import { PluginDriver } from '../plugin/plugin-driver';
-import { createBundler } from '../utils/create-bundler';
+import { createBundlerImpl } from '../utils/create-bundler';
 import { handleOutputErrors } from '../utils/transform-to-rollup-output';
 
 /**
@@ -10,7 +11,11 @@ import { handleOutputErrors } from '../utils/transform-to-rollup-output';
  */
 export const experimental_scan = async (input: InputOptions): Promise<void> => {
   const inputOptions = await PluginDriver.callOptionsHook(input);
-  const { bundler, stopWorkers } = await createBundler(inputOptions, {});
+  const { impl: bundler, stopWorkers } = await createBundlerImpl(
+    new BindingBundler(),
+    inputOptions,
+    {},
+  );
   const output = await bundler.scan();
   handleOutputErrors(output);
   await stopWorkers?.();

--- a/packages/rolldown/src/api/watch/watch-emitter.ts
+++ b/packages/rolldown/src/api/watch/watch-emitter.ts
@@ -1,4 +1,7 @@
-import { BindingBundlerImpl, BindingWatcherEvent } from '../../binding';
+import {
+  type BindingBundlerImpl,
+  type BindingWatcherEvent,
+} from '../../binding';
 import type { MaybePromise } from '../../types/utils';
 import { normalizeErrors } from '../../utils/error';
 

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1087,6 +1087,11 @@ export declare class BindingBundleErrorEventData {
   get error(): Array<Error | BindingError>
 }
 
+export declare class BindingBundler {
+  constructor()
+  createImpl(options: BindingBundlerOptions): BindingBundlerImpl
+}
+
 export declare class BindingBundlerImpl {
   constructor(option: BindingBundlerOptions)
   write(): Promise<BindingOutputs>

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -376,7 +376,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Severity, ParseResult, ExportExportNameKind, ExportImportNameKind, ExportLocalNameKind, getBufferOffset, ImportNameKind, parseAsync, parseAsyncRaw, parseSync, parseSyncRaw, rawTransferSupported, ResolverFactory, EnforceExtension, ModuleType, sync, HelperMode, isolatedDeclaration, moduleRunnerTransform, transform, BindingBundleEndEventData, BindingBundleErrorEventData, BindingBundlerImpl, BindingCallableBuiltinPlugin, BindingError, BindingHmrOutput, BindingModuleInfo, BindingNormalizedOptions, BindingOutputAsset, BindingOutputChunk, BindingOutputs, BindingPluginContext, BindingRenderedChunk, BindingRenderedChunkMeta, BindingRenderedModule, BindingTransformPluginContext, BindingWatcher, BindingWatcherChangeData, BindingWatcherEvent, ParallelJsPluginRegistry, BindingAttachDebugInfo, BindingBuiltinPluginName, BindingHookSideEffects, BindingJsx, BindingLogLevel, BindingPluginOrder, FilterTokenKind, registerPlugins, shutdownAsyncRuntime, startAsyncRuntime } = nativeBinding
+const { Severity, ParseResult, ExportExportNameKind, ExportImportNameKind, ExportLocalNameKind, getBufferOffset, ImportNameKind, parseAsync, parseAsyncRaw, parseSync, parseSyncRaw, rawTransferSupported, ResolverFactory, EnforceExtension, ModuleType, sync, HelperMode, isolatedDeclaration, moduleRunnerTransform, transform, BindingBundleEndEventData, BindingBundleErrorEventData, BindingBundler, BindingBundlerImpl, BindingCallableBuiltinPlugin, BindingError, BindingHmrOutput, BindingModuleInfo, BindingNormalizedOptions, BindingOutputAsset, BindingOutputChunk, BindingOutputs, BindingPluginContext, BindingRenderedChunk, BindingRenderedChunkMeta, BindingRenderedModule, BindingTransformPluginContext, BindingWatcher, BindingWatcherChangeData, BindingWatcherEvent, ParallelJsPluginRegistry, BindingAttachDebugInfo, BindingBuiltinPluginName, BindingHookSideEffects, BindingJsx, BindingLogLevel, BindingPluginOrder, FilterTokenKind, registerPlugins, shutdownAsyncRuntime, startAsyncRuntime } = nativeBinding
 export { Severity }
 export { ParseResult }
 export { ExportExportNameKind }
@@ -399,6 +399,7 @@ export { moduleRunnerTransform }
 export { transform }
 export { BindingBundleEndEventData }
 export { BindingBundleErrorEventData }
+export { BindingBundler }
 export { BindingBundlerImpl }
 export { BindingCallableBuiltinPlugin }
 export { BindingError }

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -83,6 +83,7 @@ export const moduleRunnerTransform = __napiModule.exports.moduleRunnerTransform
 export const transform = __napiModule.exports.transform
 export const BindingBundleEndEventData = __napiModule.exports.BindingBundleEndEventData
 export const BindingBundleErrorEventData = __napiModule.exports.BindingBundleErrorEventData
+export const BindingBundler = __napiModule.exports.BindingBundler
 export const BindingBundlerImpl = __napiModule.exports.BindingBundlerImpl
 export const BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
 export const BindingError = __napiModule.exports.BindingError

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -107,6 +107,7 @@ module.exports.moduleRunnerTransform = __napiModule.exports.moduleRunnerTransfor
 module.exports.transform = __napiModule.exports.transform
 module.exports.BindingBundleEndEventData = __napiModule.exports.BindingBundleEndEventData
 module.exports.BindingBundleErrorEventData = __napiModule.exports.BindingBundleErrorEventData
+module.exports.BindingBundler = __napiModule.exports.BindingBundler
 module.exports.BindingBundlerImpl = __napiModule.exports.BindingBundlerImpl
 module.exports.BindingCallableBuiltinPlugin = __napiModule.exports.BindingCallableBuiltinPlugin
 module.exports.BindingError = __napiModule.exports.BindingError

--- a/packages/rolldown/src/utils/create-bundler.ts
+++ b/packages/rolldown/src/utils/create-bundler.ts
@@ -1,5 +1,6 @@
 import {
-  BindingBundlerImpl,
+  type BindingBundler,
+  type BindingBundlerImpl,
   shutdownAsyncRuntime,
   startAsyncRuntime,
 } from '../binding';
@@ -9,11 +10,12 @@ import { createBundlerOptions } from './create-bundler-option';
 
 let asyncRuntimeShutdown = false;
 
-export async function createBundler(
+export async function createBundlerImpl(
+  bundler: BindingBundler,
   inputOptions: InputOptions,
   outputOptions: OutputOptions,
   isClose?: boolean,
-): Promise<BundlerWithStopWorker> {
+): Promise<BundlerImplWithStopWorker> {
   const option = await createBundlerOptions(
     inputOptions,
     outputOptions,
@@ -27,7 +29,7 @@ export async function createBundler(
 
   try {
     return {
-      bundler: new BindingBundlerImpl(option.bundlerOptions),
+      impl: bundler.createImpl(option.bundlerOptions),
       stopWorkers: option.stopWorkers,
       shutdown: () => {
         shutdownAsyncRuntime();
@@ -40,8 +42,8 @@ export async function createBundler(
   }
 }
 
-export interface BundlerWithStopWorker {
-  bundler: BindingBundlerImpl;
+export interface BundlerImplWithStopWorker {
+  impl: BindingBundlerImpl;
   stopWorkers?: () => Promise<void>;
   shutdown: () => void;
 }


### PR DESCRIPTION
Part of #4134.

This PR makes `builds` triggered by the same `RolldownBuild` always belong to the same `session/bundler`