### PR TITLE
chore(infra): add knip to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,9 @@ jobs:
       - name: Lint Code
         run: pnpm lint-code
 
+      - name: Lint exports & dependencies
+        run: pnpm lint-knip
+
       - name: Validate workspace package
         run: node scripts/misc/published-package-check.mjs
 

--- a/justfile
+++ b/justfile
@@ -110,6 +110,9 @@ lint-rust:
 lint-node:
     pnpm lint-code
 
+lint-knip:
+    pnpm lint-knip
+
 lint-repo:
     typos
     cargo ls-lint

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -34,6 +34,7 @@
         "src/browser.js",
         "src/cli/index.ts",
         "src/log/locate-character/index.d.ts",
+        "src/parallel-plugin-worker.ts",
         "src/rolldown-binding.wasi-browser.js",
         "src/{wasi,webcontainer}-*.*",
       ],
@@ -48,6 +49,7 @@
         "buble",
         "pathe",
       ],
+      "ignoreUnresolved": ["#parallel-plugin-worker"], // target file is unavailable before build
     },
     "packages/rolldown/npm/wasm32-wasi": {
       "ignoreDependencies": ["@napi-rs/wasm-runtime"],

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "ignoreBinaries": ["only-allow", "typos"],
+  "ignoreBinaries": ["only-allow"],
   "ignoreWorkspaces": ["examples/**"], // no rolldown plugin yet
   "workspaces": {
     ".": {
@@ -46,6 +46,7 @@
         "@oxc-project/runtime",
         "@rollup/plugin-json",
         "buble",
+        "pathe",
       ],
     },
     "packages/rolldown/npm/wasm32-wasi": {

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -70,7 +70,7 @@ export type HmrOptions = boolean | {
 
 export type AttachDebugOptions = 'none' | 'simple' | 'full';
 
-export interface RollupJsxOptions {
+interface RollupJsxOptions {
   mode?: 'classic' | 'automatic' | 'preserve';
   factory?: string;
   fragment?: string;


### PR DESCRIPTION
Now that we've mostly established the `package.json` dependency exceptions in `knip.jsonc` we can consider adding knip to CI, so here's that.