### PR TITLE
feat(debug): attach both `session_id` and `build_id` to debug events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,6 +2552,7 @@ dependencies = [
  "oxc_transform_napi",
  "rolldown",
  "rolldown_common",
+ "rolldown_debug",
  "rolldown_error",
  "rolldown_plugin",
  "rolldown_plugin_alias",

--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -19,19 +19,17 @@ use crate::{
 pub struct BundlerBuilder {
   options: BundlerOptions,
   plugins: Vec<SharedPluginable>,
+  session_id: Option<Arc<str>>,
 }
 
 impl BundlerBuilder {
   pub fn build(mut self) -> Bundler {
-    let mut session_id: Arc<str> = std::time::SystemTime::now()
-      .duration_since(std::time::UNIX_EPOCH)
-      .expect("Time went backwards")
-      .as_millis()
-      .to_string()
-      .into();
-
     let mut debug_tracer = None;
+
+    let mut session_id = self.session_id.unwrap_or_else(|| Arc::from("unknown_session"));
+
     if let Some(debug_options) = &self.options.debug {
+      // TODO(hyf0): session_id shouldn't be set by user, it should be generated internally to ensure the uniqueness.
       if let Some(id) = &debug_options.session_id {
         session_id = id.to_string().into();
       }
@@ -73,6 +71,7 @@ impl BundlerBuilder {
       hmr_manager: None,
       session_span,
       _debug_tracer: debug_tracer,
+      build_count: 0,
     }
   }
 
@@ -163,6 +162,12 @@ impl BundlerBuilder {
   #[must_use]
   pub fn with_plugins(mut self, plugins: Vec<SharedPluginable>) -> Self {
     self.plugins = plugins;
+    self
+  }
+
+  #[must_use]
+  pub fn with_session_id(mut self, session_id: Arc<str>) -> Self {
+    self.session_id = Some(session_id);
     self
   }
 }

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -30,6 +30,7 @@ oxc_resolver_napi = { workspace = true }
 oxc_transform_napi = { workspace = true }
 rolldown = { workspace = true }
 rolldown_common = { workspace = true }
+rolldown_debug = { workspace = true }
 rolldown_error = { workspace = true, features = ["napi"] }
 rolldown_plugin = { workspace = true }
 rolldown_plugin_alias = { workspace = true }

--- a/crates/rolldown_binding/src/binding_bundler.rs
+++ b/crates/rolldown_binding/src/binding_bundler.rs
@@ -5,27 +5,18 @@ use napi_derive::napi;
 
 use crate::binding_bundler_impl::{BindingBundlerImpl, BindingBundlerOptions};
 
-#[expect(unused)]
 #[napi]
 pub struct BindingBundler {
   session_id: Arc<str>,
-  session_span: tracing::Span,
 }
 
 #[napi]
 impl BindingBundler {
   #[napi(constructor)]
   pub fn new() -> napi::Result<Self> {
-    let session_id: Arc<str> = std::time::SystemTime::now()
-      .duration_since(std::time::UNIX_EPOCH)
-      .expect("Time went backwards")
-      .as_millis()
-      .to_string()
-      .into();
+    let session_id = rolldown_debug::generate_session_id();
 
-    let session_span = tracing::trace_span!("Session", session_id = &*session_id);
-
-    Ok(Self { session_id, session_span })
+    Ok(Self { session_id })
   }
 
   #[napi]
@@ -35,6 +26,6 @@ impl BindingBundler {
     env: Env,
     options: BindingBundlerOptions,
   ) -> napi::Result<BindingBundlerImpl> {
-    BindingBundlerImpl::new(env, options)
+    BindingBundlerImpl::new(env, options, Arc::clone(&self.session_id))
   }
 }

--- a/crates/rolldown_binding/src/watcher.rs
+++ b/crates/rolldown_binding/src/watcher.rs
@@ -45,7 +45,10 @@ impl BindingWatcher {
   ) -> napi::Result<Self> {
     let bundlers = options
       .into_iter()
-      .map(|option| BindingBundlerImpl::new(env, option).map(BindingBundlerImpl::into_inner))
+      .map(|option| {
+        // TODO(hyf0): support emit debug data for builtin watch
+        BindingBundlerImpl::new(env, option, Arc::from("0000")).map(BindingBundlerImpl::into_inner)
+      })
       .collect::<Result<Vec<_>, _>>()?;
 
     Ok(Self { inner: rolldown::Watcher::new(bundlers, notify_option.map(Into::into))? })

--- a/crates/rolldown_debug/src/debug_data_propagate_layer.rs
+++ b/crates/rolldown_debug/src/debug_data_propagate_layer.rs
@@ -107,6 +107,7 @@ const CONTEXT_PREFIX: &str = "CONTEXT_";
 const CONTEXT_PREFIX_LEN: usize = CONTEXT_PREFIX.len();
 impl tracing::field::Visit for ContextDataFinder {
   fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+    // Only record context data that starts with `CONTEXT_`.
     if field.name().starts_with(CONTEXT_PREFIX) {
       let key = &field.name()[CONTEXT_PREFIX_LEN..];
       let value = value.to_string();

--- a/crates/rolldown_debug/src/lib.rs
+++ b/crates/rolldown_debug/src/lib.rs
@@ -4,7 +4,11 @@ mod init_tracing;
 mod static_data;
 mod trace_action_macro;
 mod type_alias;
+mod utils;
 
 pub use rolldown_debug_action as action;
 
-pub use init_tracing::{DebugTracer, init_devtool_tracing};
+pub use {
+  init_tracing::{DebugTracer, init_devtool_tracing},
+  utils::{generate_build_id, generate_session_id},
+};

--- a/crates/rolldown_debug/src/utils.rs
+++ b/crates/rolldown_debug/src/utils.rs
@@ -1,0 +1,17 @@
+use std::sync::{Arc, atomic::AtomicU32};
+
+static SESSION_ID_SEED: AtomicU32 = AtomicU32::new(0);
+
+pub fn generate_build_id(build_count: u32) -> Arc<str> {
+  format!("bid_{build_count}").into()
+}
+
+pub fn generate_session_id() -> Arc<str> {
+  let timestamp = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .expect("Time went backwards")
+    .as_millis()
+    .to_string();
+  let seed = SESSION_ID_SEED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+  format!("sid_{timestamp}_{seed}").into()
+}

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1093,7 +1093,6 @@ export declare class BindingBundler {
 }
 
 export declare class BindingBundlerImpl {
-  constructor(option: BindingBundlerOptions)
   write(): Promise<BindingOutputs>
   generate(): Promise<BindingOutputs>
   scan(): Promise<BindingOutputs>


### PR DESCRIPTION
To clarify:
- `session` means a period  that matchs  `RolldownBuild`'s lifetime. Every `rolldown(..)` creates a new `session id`.
- `build_id` will be created for every `RolldownBuild#write` or ``RolldownBuild#generate`
- `build_id` always belong to some session.
- `watch` doesn't support debug mode so far.

For https://github.com/rolldown/rolldown/issues/4134,

Rolldown is gonna emits a `meta.json` for each session/`.rolldown/[session_id]`. FYI @antfu.

---

the output now looks like

```
{"timestamp":1750197631355,"session_id":"sid_1750197631338_0","action":"BuildStart","build_id":"bid_1750197631354_0"}
{"timestamp":1750197631355,"session_id":"sid_1750197631338_0","action":"BuildStart","build_id":"bid_1750197631354_0"}
{"timestamp":1750197631356,"session_id":"sid_1750197631338_0","action":"HookResolveIdCallStart","importer":null,"module_request":"./index.ts","import_kind":"import-statement","plugin_name":"builtin:oxc-runtime","plugin_index":0,"trigger":"${hook_resolve_id_trigger}","call_id":"./index.ts_1750197631356","build_id":"bid_1750197631354_0"}
{"timestamp":1750197631356,"session_id":"sid_1750197631338_0","action":"HookResolveIdCallEnd","resolved_id":null,"is_external":null,"plugin_name":"builtin:oxc-runtime","plugin_index":0,"trigger":"${hook_resolve_id_trigger}","call_id":"./index.ts_1750197631356","build_id":"bid_1750197631354_0"}
{"timestamp":1750197631357,"session_id":"sid_1750197631338_0","action":"HookResolveIdCallStart","importer":null,"module_request":"./index.ts","import_kind":"import-statement","plugin_name":"builtin:data-uri","plugin_index":1,"trigger":"${hook_resolve_id_trigger}","call_id":"./index.ts_1750197631357","build_id":"bid_1750197631354_0"}
{"timestamp":1750197631357,"session_id":"sid_1750197631338_0","action":"HookResolveIdCallEnd","resolved_id":null,"is_external":null,"plugin_name":"builtin:data-uri","plugin_index":1,"trigger":"${hook_resolve_id_trigger}","call_id":"./index.ts_1750197631357","build_id":"bid_1750197631354_0"}
```