### PR TITLE
fix(plugin/vite-resolve): optional peer dep id parse error

### DIFF
--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -379,7 +379,7 @@ impl Plugin for ViteResolvePlugin {
     }
 
     if args.id.starts_with(OPTIONAL_PEER_DEP_ID) {
-      let [_, peer_dep, parent_dep, _] = args.id.splitn(4, ":").collect::<Vec<&str>>()[..] else {
+      let [_, peer_dep, parent_dep] = args.id.splitn(3, ":").collect::<Vec<&str>>()[..] else {
         unreachable!()
       };
 


### PR DESCRIPTION
Follow-up to #4980.
It seems the new tests in Vite repo caught a bug.
