### PR TITLE
fix: imported namespace is missing after external import namespace merging

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -140,8 +140,16 @@ impl GenerateStage<'_> {
           continue;
         }
         group.sort_unstable_by_key(|item| self.link_output.module_table[item.owner].exec_order());
-        for symbol in &group[1..] {
-          self.link_output.symbol_db.link(**symbol, *group[0]);
+        let Some(idx) =
+          group.iter().position(|item| self.link_output.used_symbol_refs.contains(item))
+        else {
+          continue;
+        };
+        // In the extreme case, idx would eq to group.len() - 1, which means the first symbol is the only one that is used.
+        // `idx + 1` would eq to len of the group, the iteration is still safe,
+        // https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=38bb53e79b4f7aaa73ef9d6b4cfb3cc2
+        for symbol in &group[idx + 1..] {
+          self.link_output.symbol_db.link(**symbol, *group[idx]);
         }
       }
     }

--- a/crates/rolldown/tests/rolldown/issues/4993/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4993/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "external": ["rollup"]
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/4993/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4993/artifacts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import * as Rollup from "rollup";
+
+export { Rollup };
+```

--- a/crates/rolldown/tests/rolldown/issues/4993/main.js
+++ b/crates/rolldown/tests/rolldown/issues/4993/main.js
@@ -1,0 +1,4 @@
+import * as Rollup from 'rollup'
+import {} from './pluginContainer.js'
+
+export { Rollup }

--- a/crates/rolldown/tests/rolldown/issues/4993/pluginContainer.js
+++ b/crates/rolldown/tests/rolldown/issues/4993/pluginContainer.js
@@ -1,0 +1,2 @@
+import * as rollup0 from 'rollup'
+export var PluginContext = [() => rollup0]

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4733,6 +4733,10 @@ expression: output
 
 - main-!~{000}~.js => main-D_pxn1_z.js
 
+# tests/rolldown/issues/4993
+
+- main-!~{000}~.js => main-BQQtZSou.js
+
 # tests/rolldown/misc/ambiguous_star_export
 
 - main-!~{000}~.js => main-Brk4weCb.js


### PR DESCRIPTION
Closed #4993