### PR TITLE
refactor(debug): remove extra mechanism for passing `session_id` and unnecessary passing of spans

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -134,7 +134,6 @@ impl Bundler {
       Arc::clone(&self.plugin_driver),
       self.fs,
       Arc::clone(&self.resolver),
-      self.session_span.clone(),
     )
     .scan(mode, scan_stage_cache_guard.inner())
     .await
@@ -271,7 +270,6 @@ impl Bundler {
         index_ecma_ast: link_stage_output.ast_table,
         // Don't forget to reset the cache if you want to rebuild the bundle instead hmr.
         cache: std::mem::take(&mut self.cache),
-        session_span: self.session_span.clone(),
       }));
     }
     Ok(output)

--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -35,7 +35,7 @@ impl BundlerBuilder {
       }
       debug_tracer = Some(rolldown_debug::DebugTracer::init(Arc::clone(&session_id)));
     }
-    let session_span = tracing::trace_span!("Session", session_id = &*session_id);
+    let session_span = tracing::trace_span!("Session", CONTEXT_session_id = &*session_id);
 
     let maybe_guard = rolldown_tracing::try_init_tracing();
 

--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -31,7 +31,6 @@ pub struct HmrManagerInput {
   pub plugin_driver: SharedPluginDriver,
   pub index_ecma_ast: IndexEcmaAst,
   pub cache: ScanStageCache,
-  pub session_span: tracing::Span,
 }
 
 pub struct HmrManager {
@@ -209,7 +208,6 @@ impl HmrManager {
       })
       .collect::<Vec<_>>();
 
-    let build_span = self.session_span.clone();
     let mut module_loader = ModuleLoader::new(
       self.fs,
       Arc::clone(&self.options),
@@ -217,7 +215,6 @@ impl HmrManager {
       Arc::clone(&self.plugin_driver),
       &mut self.cache,
       false,
-      build_span,
     )?;
 
     let module_loader_output =

--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -19,8 +19,7 @@ pub struct ExternalModuleTask {
   module_idx: ModuleIdx,
   resolved_id: ResolvedId,
   user_defined_entries: Arc<Vec<(Option<ArcStr>, ResolvedId)>>,
-  /// The module is asserted to be this specific module type.
-  build_span: tracing::Span,
+  // The module is asserted to be this specific module type.
 }
 
 #[allow(clippy::rc_buffer)]
@@ -29,12 +28,11 @@ impl ExternalModuleTask {
     ctx: Arc<TaskContext>,
     idx: ModuleIdx,
     resolved_id: ResolvedId,
-    build_span: tracing::Span,
     user_defined_entries: Arc<Vec<(Option<ArcStr>, ResolvedId)>>,
   ) -> Self {
-    Self { ctx, module_idx: idx, resolved_id, build_span, user_defined_entries }
+    Self { ctx, module_idx: idx, resolved_id, user_defined_entries }
   }
-  #[tracing::instrument(name="ExternalModuleTask::run", parent = &self.build_span, level = "trace", skip_all, fields(module_id = ?self.resolved_id.id))]
+  #[tracing::instrument(name="ExternalModuleTask::run", level = "trace", skip_all, fields(module_id = ?self.resolved_id.id))]
   pub async fn run(self) {
     if let Err(errs) = self.run_inner().await {
       self

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -42,7 +42,6 @@ pub struct ModuleTask {
   is_user_defined_entry: bool,
   /// The module is asserted to be this specific module type.
   asserted_module_type: Option<ModuleType>,
-  build_span: tracing::Span,
 }
 
 impl ModuleTask {
@@ -53,7 +52,6 @@ impl ModuleTask {
     owner: Option<ModuleTaskOwner>,
     is_user_defined_entry: bool,
     assert_module_type: Option<ModuleType>,
-    build_span: tracing::Span,
   ) -> Self {
     Self {
       ctx,
@@ -62,11 +60,10 @@ impl ModuleTask {
       owner,
       is_user_defined_entry,
       asserted_module_type: assert_module_type,
-      build_span,
     }
   }
 
-  #[tracing::instrument(name="NormalModuleTask::run", parent = &self.build_span, level = "trace", skip_all, fields(module_id = ?self.resolved_id.id))]
+  #[tracing::instrument(name="NormalModuleTask::run", level = "trace", skip_all, fields(module_id = ?self.resolved_id.id))]
   pub async fn run(mut self) {
     if let Err(errs) = self.run_inner().await {
       self

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -25,7 +25,6 @@ pub struct ScanStage {
   plugin_driver: SharedPluginDriver,
   fs: OsFileSystem,
   resolver: SharedResolver,
-  build_span: tracing::Span,
 }
 
 #[derive(Debug)]
@@ -106,9 +105,8 @@ impl ScanStage {
     plugin_driver: SharedPluginDriver,
     fs: OsFileSystem,
     resolver: SharedResolver,
-    build_span: tracing::Span,
   ) -> Self {
-    Self { options, plugin_driver, fs, resolver, build_span }
+    Self { options, plugin_driver, fs, resolver }
   }
 
   #[tracing::instrument(target = "devtool", level = "debug", skip_all)]
@@ -124,7 +122,6 @@ impl ScanStage {
       Arc::clone(&self.plugin_driver),
       cache,
       mode.is_full(),
-      self.build_span.clone(),
     )?;
 
     // For `pluginContext.emitFile` with `type: chunk`, support it at buildStart hook.

--- a/crates/rolldown_debug/src/debug_data_propagate_layer.rs
+++ b/crates/rolldown_debug/src/debug_data_propagate_layer.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, sync::Arc};
+use std::ops::Deref;
 
 use tracing::{Subscriber, span::Attributes};
 use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
@@ -9,30 +9,6 @@ use crate::type_alias::ContextDataMap;
 
 pub struct DebugDataPropagateLayer;
 
-struct DebugDataFinder {
-  session_id: Option<Arc<str>>,
-}
-
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct SessionId(pub Arc<str>);
-
-impl tracing::field::Visit for DebugDataFinder {
-  fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-    if field.name() == "session_id" {
-      self.session_id = Some(value.into());
-    }
-  }
-  /// Visit an unsigned 128-bit integer value.
-  fn record_u128(&mut self, field: &tracing::field::Field, value: u128) {
-    if field.name() == "session_id" {
-      self.session_id = Some(value.to_string().into());
-    }
-  }
-  fn record_debug(&mut self, _: &tracing::field::Field, _: &dyn std::fmt::Debug) {
-    // Ignore debug fields
-  }
-}
-
 impl<S> Layer<S> for DebugDataPropagateLayer
 where
   S: Subscriber + for<'a> LookupSpan<'a>,
@@ -42,10 +18,6 @@ where
       return;
     };
 
-    let mut visitor = DebugDataFinder { session_id: None };
-    // First see if the current span has a `buildId` field
-    attrs.record(&mut visitor);
-
     let mut context_data_finder = ContextDataFinder::default();
     attrs.record(&mut context_data_finder);
 
@@ -53,36 +25,6 @@ where
 
     if !context_data_finder.context_data.is_empty() {
       exts.insert(ContextData(context_data_finder.context_data));
-    }
-
-    if let Some(build_id) = visitor.session_id {
-      // If it does, it means this span is the root build span. Let's store the `buildId` into the extensions.
-      exts.insert(SessionId(build_id));
-    } else {
-      // If not, we need to propagate the `buildId` from the parent span.
-      let mut next_parent_ref = span_ref.parent();
-      let mut ancestors = vec![];
-      let build_id = loop {
-        // Find the first ancestor that has a `buildId` field
-        if let Some(parent_ref) = next_parent_ref {
-          if let Some(build_id) = parent_ref.extensions().get::<SessionId>() {
-            break Some(build_id.clone());
-          }
-          next_parent_ref = parent_ref.parent();
-          ancestors.push(parent_ref);
-        } else {
-          break None;
-        }
-      };
-
-      if let Some(build_id) = build_id {
-        // If we found a `buildId` in the parent span, we need to propagate it to the current span.
-        exts.insert(build_id.clone());
-        // And also propagate it to all the ancestors we visited.
-        for ancestor in ancestors {
-          ancestor.extensions_mut().insert(build_id.clone());
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
- Nothing changes.
- `session_id` is now also passed around via context-inject mechanism.
- Just realize no need to manually pass spans around. They're already connected to each other in an implicit way.