### PR TITLE
feat: add validation warning for advanced chunks options without groups

### DIFF
--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -38,6 +38,41 @@ fn verify_raw_options(raw_options: &crate::BundlerOptions) -> Vec<BuildDiagnosti
     _ => {}
   }
 
+  if let Some(advanced_chunks) = &raw_options.advanced_chunks {
+    let has_groups = advanced_chunks.groups.as_ref().is_some_and(|groups| !groups.is_empty());
+
+    if !has_groups {
+      let mut specified_options = Vec::new();
+      if advanced_chunks.min_share_count.is_some() {
+        specified_options.push("minShareCount".to_string());
+      }
+      if advanced_chunks.min_size.is_some() {
+        specified_options.push("minSize".to_string());
+      }
+      if advanced_chunks.max_size.is_some() {
+        specified_options.push("maxSize".to_string());
+      }
+      if advanced_chunks.min_module_size.is_some() {
+        specified_options.push("minModuleSize".to_string());
+      }
+      if advanced_chunks.max_module_size.is_some() {
+        specified_options.push("maxModuleSize".to_string());
+      }
+      if advanced_chunks.include_dependencies_recursively.is_some() {
+        specified_options.push("includeDependenciesRecursively".to_string());
+      }
+
+      if !specified_options.is_empty() {
+        warnings.push(
+          BuildDiagnostic::invalid_option(InvalidOptionType::AdvancedChunksWithoutGroups(
+            specified_options,
+          ))
+          .with_severity_warning(),
+        );
+      }
+    }
+  }
+
   warnings
 }
 

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/advanced_chunks_without_groups/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/advanced_chunks_without_groups/_config.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.js"
+      }
+    ],
+    "advancedChunks": {
+      "minShareCount": 2,
+      "minSize": 1000,
+      "maxSize": 5000,
+      "includeDependenciesRecursively": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/advanced_chunks_without_groups/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/advanced_chunks_without_groups/artifacts.snap
@@ -1,0 +1,21 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## INVALID_OPTION
+
+```text
+[INVALID_OPTION] Warning: Advanced chunks options (minShareCount, minSize, maxSize, includeDependenciesRecursively) specified without groups. These options have no effect without groups - you should either add groups to use advanced chunking or remove these options.
+
+```
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+console.log("hello from main");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/advanced_chunks_without_groups/main.js
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/advanced_chunks_without_groups/main.js
@@ -1,0 +1,1 @@
+console.log('hello from main')

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5726,6 +5726,10 @@ expression: output
 
 - main-!~{000}~.js => main-Fv4vYntb.js
 
+# tests/rolldown/warnings/invalid_option/advanced_chunks_without_groups
+
+- main-!~{000}~.js => main-B7ZfmDK1.js
+
 # tests/rolldown/warnings/invalid_option/invalid_output_dir_option
 
 - main.js => main.js

--- a/crates/rolldown_error/src/events/invalid_option.rs
+++ b/crates/rolldown_error/src/events/invalid_option.rs
@@ -8,6 +8,7 @@ pub enum InvalidOptionType {
   InvalidOutputFile,
   InvalidOutputDirOption,
   NoEntryPoint,
+  AdvancedChunksWithoutGroups(Vec<String>),
 }
 
 #[derive(Debug)]
@@ -31,6 +32,10 @@ impl BuildEvent for InvalidOption {
         InvalidOptionType::InvalidOutputFile => "Invalid value for option \"output.file\" - When building multiple chunks, the \"output.dir\" option must be used, not \"output.file\". You may set `output.inlineDynamicImports` to `true` when using dynamic imports.".to_string(),
         InvalidOptionType::InvalidOutputDirOption => "Invalid value for option \"output.dir\" - you must set either \"output.file\" for a single-file build or \"output.dir\" when generating multiple chunks.".to_string(),
         InvalidOptionType::NoEntryPoint =>"You must supply `options.input` to rolldown, you should at least provide one entrypoint via `options.input` or `this.emitFile({type: 'chunk', ...})` (https://rollupjs.org/plugin-development/#this-emitfile)".to_string(),
+        InvalidOptionType::AdvancedChunksWithoutGroups(options) => {
+          let options_list = options.join(", ");
+          format!("Advanced chunks options ({options_list}) specified without groups. These options have no effect without groups - you should either add groups to use advanced chunking or remove these options.")
+        }
     }
   }
 }


### PR DESCRIPTION
Added a warning if advanced chunks options are specified without groups.

close #4932 