### PR TITLE
fix: side effects in this.emitFile({ type: 'chunk' }) is removed when preserveEntrySignatures: false is set

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -400,6 +400,9 @@ impl<'a> ModuleLoader<'a> {
             self.symbol_ref_db.store_local_db(module_idx, symbols);
           }
 
+          if user_defined_entry_ids.contains(&module_idx) {
+            module.as_normal_mut().expect("should be normal module ").is_user_defined_entry = true;
+          }
           *self.intermediate_normal_modules.modules.get_mut(module_idx) = Some(module);
           self.remaining -= 1;
         }
@@ -523,6 +526,9 @@ impl<'a> ModuleLoader<'a> {
           if let Some(preserve_entry_signatures) = data.preserve_entry_signatures {
             overrode_preserve_entry_signature_map.insert(module_idx, preserve_entry_signatures);
           }
+
+          user_defined_entry_ids.insert(module_idx);
+
           let entry = EntryPoint {
             name: data.name.clone(),
             id: module_idx,

--- a/crates/rolldown/tests/rolldown/issues/5011/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5011/artifacts.snap
@@ -1,0 +1,34 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## after-preload-dynamic.js
+
+```js
+import "./after-preload-dynamic2.js";
+
+```
+## after-preload-dynamic2.js
+
+```js
+//#region src/after-preload-dynamic.js
+import("./dynamic-foo.js");
+console.log("after preload dynamic");
+
+//#endregion
+```
+## dynamic-foo.js
+
+```js
+//#region src/dynamic-foo.js
+console.log("dynamic-foo");
+
+//#endregion
+```
+## entry.js
+
+```js
+import "./after-preload-dynamic2.js";
+
+```

--- a/crates/rolldown/tests/rolldown/issues/5011/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/5011/mod.rs
@@ -1,0 +1,57 @@
+use std::{borrow::Cow, sync::Arc};
+
+use rolldown::{BundlerOptions, InputItem, PreserveEntrySignatures};
+use rolldown_common::EmittedChunk;
+use rolldown_plugin::{HookUsage, Plugin };
+use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
+
+#[derive(Debug)]
+struct Test;
+
+impl Plugin for Test {
+  fn name(&self) -> Cow<'static, str> {
+    "test".into()
+  }
+
+  async fn transform(
+    &self,
+    ctx: rolldown_plugin::SharedTransformPluginContext,
+    args: &rolldown_plugin::HookTransformArgs<'_>,
+  ) -> rolldown_plugin::HookTransformReturn {
+    if args.id.ends_with("after-preload-dynamic.js") {
+      ctx
+        .inner
+        .emit_chunk(EmittedChunk {
+          id: "./src/after-preload-dynamic.js".into(),
+          preserve_entry_signatures: None,
+          ..Default::default()
+        })
+        .await?;
+    }
+    Ok(None)
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::Transform
+  }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_rewrite_dynamic_imports_that_import_external_modules() {
+  let cwd = abs_file_dir!();
+
+  IntegrationTest::new(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        cwd: Some(cwd),
+        input: Some(vec![InputItem {
+          name: Some("entry".into()),
+          import: "./src/entry.js".into(),
+        }]),
+        preserve_entry_signatures: Some(PreserveEntrySignatures::False),
+        ..Default::default()
+      },
+      vec![Arc::new(Test)],
+    )
+    .await;
+}

--- a/crates/rolldown/tests/rolldown/issues/5011/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/5011/mod.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, sync::Arc};
 
 use rolldown::{BundlerOptions, InputItem, PreserveEntrySignatures};
 use rolldown_common::EmittedChunk;
-use rolldown_plugin::{HookUsage, Plugin };
+use rolldown_plugin::{HookUsage, Plugin};
 use rolldown_testing::{abs_file_dir, integration_test::IntegrationTest, test_config::TestMeta};
 
 #[derive(Debug)]

--- a/crates/rolldown/tests/rolldown/issues/5011/src/after-preload-dynamic.js
+++ b/crates/rolldown/tests/rolldown/issues/5011/src/after-preload-dynamic.js
@@ -1,0 +1,3 @@
+import("./dynamic-foo");
+
+console.log("after preload dynamic");

--- a/crates/rolldown/tests/rolldown/issues/5011/src/dynamic-foo.js
+++ b/crates/rolldown/tests/rolldown/issues/5011/src/dynamic-foo.js
@@ -1,0 +1,1 @@
+console.log("dynamic-foo");

--- a/crates/rolldown/tests/rolldown/issues/5011/src/entry.js
+++ b/crates/rolldown/tests/rolldown/issues/5011/src/entry.js
@@ -1,0 +1,1 @@
+import './after-preload-dynamic.js';

--- a/crates/rolldown/tests/rolldown/issues/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/mod.rs
@@ -2,3 +2,5 @@
 mod _1733;
 #[path = "./4895/mod.rs"]
 mod _4895;
+#[path = "./5011/mod.rs"]
+mod _5011;


### PR DESCRIPTION
Closed #5011 
The root cause is that we don't mark the entry point generated by `this.emitFile` in `transform` hook related normal module as user define. 