### PR TITLE
fix(plugin/vite-resolve): normalize leading slash

### DIFF
--- a/crates/rolldown_plugin_vite_resolve/src/utils.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/utils.rs
@@ -69,5 +69,5 @@ pub fn is_in_node_modules(id: &str) -> bool {
 pub fn normalize_leading_slashes(specifier: &str) -> &str {
   let trimmed = specifier.trim_start_matches('/');
   let leading_slashes = specifier.len() - trimmed.len();
-if leading_slashes <= 1 { specifier } else { &specifier[leading_slashes - 1..] }
+  if leading_slashes <= 1 { specifier } else { &specifier[leading_slashes - 1..] }
 }

--- a/crates/rolldown_plugin_vite_resolve/src/utils.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/utils.rs
@@ -69,5 +69,5 @@ pub fn is_in_node_modules(id: &str) -> bool {
 pub fn normalize_leading_slashes(specifier: &str) -> &str {
   let trimmed = specifier.trim_start_matches('/');
   let leading_slashes = specifier.len() - trimmed.len();
-  if leading_slashes == 0 { specifier } else { &specifier[leading_slashes - 1..] }
+if leading_slashes <= 1 { specifier } else { &specifier[leading_slashes - 1..] }
 }

--- a/crates/rolldown_plugin_vite_resolve/src/utils.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/utils.rs
@@ -64,3 +64,10 @@ pub fn can_externalize_file(file_path: &str) -> bool {
 pub fn is_in_node_modules(id: &str) -> bool {
   id.contains("node_modules")
 }
+
+/// path.resolve normalizes the leading slashes to a single slash
+pub fn normalize_leading_slashes(specifier: &str) -> &str {
+  let trimmed = specifier.trim_start_matches('/');
+  let leading_slashes = specifier.len() - trimmed.len();
+  if leading_slashes == 0 { specifier } else { &specifier[leading_slashes - 1..] }
+}

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -8,15 +8,9 @@ use std::{
 };
 
 use crate::{
-  ResolveOptionsExternal,
-  builtin::{BuiltinChecker, is_node_like_builtin},
-  external::{self, ExternalDecider, ExternalDeciderOptions},
-  file_url::file_url_str_to_path_and_postfix,
-  resolver::{self, AdditionalOptions, Resolvers},
-  utils::{
-    BROWSER_EXTERNAL_ID, OPTIONAL_PEER_DEP_ID, is_bare_import, is_in_node_modules,
-    is_windows_drive_path, normalize_path,
-  },
+  builtin::{is_node_like_builtin, BuiltinChecker}, external::{self, ExternalDecider, ExternalDeciderOptions}, file_url::file_url_str_to_path_and_postfix, resolver::{self, AdditionalOptions, Resolvers}, utils::{
+    is_bare_import, is_in_node_modules, is_windows_drive_path, normalize_leading_slashes, normalize_path, BROWSER_EXTERNAL_ID, OPTIONAL_PEER_DEP_ID
+  }, ResolveOptionsExternal
 };
 use anyhow::anyhow;
 use arcstr::ArcStr;
@@ -319,10 +313,11 @@ impl Plugin for ViteResolvePlugin {
       .importer
       .map(|i| Path::new(i).parent().and_then(|p| p.to_str()).unwrap_or(i))
       .unwrap_or(&self.resolve_options.root);
+    let specifier = normalize_leading_slashes(args.specifier);
     let resolved = resolver.normalize_oxc_resolver_result(
       args.importer,
       &self.dedupe,
-      &resolver.resolve_raw(base_dir, args.specifier),
+      &resolver.resolve_raw(base_dir, specifier),
     )?;
     if let Some(mut resolved) = resolved {
       if !scan {

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -206,14 +206,6 @@ impl Plugin for ViteResolvePlugin {
       return Ok(None);
     }
 
-    if is_external_url(args.specifier) {
-      return Ok(Some(HookResolveIdOutput {
-        id: args.specifier.into(),
-        external: Some(true.into()),
-        ..Default::default()
-      }));
-    }
-
     let additional_options = AdditionalOptions::new(
       self.resolve_options.is_require.unwrap_or(args.kind == ImportKind::Require),
       self.resolve_options.prefer_relative || args.importer.is_some_and(|i| i.ends_with(".html")),
@@ -334,6 +326,15 @@ impl Plugin for ViteResolvePlugin {
         }
       }
       return Ok(Some(resolved));
+    }
+
+    // `//something` may resolve to a file so this check should be done after file checks
+    if is_external_url(args.specifier) {
+      return Ok(Some(HookResolveIdOutput {
+        id: args.specifier.into(),
+        external: Some(true.into()),
+        ..Default::default()
+      }));
     }
 
     Ok(None)

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -8,9 +8,15 @@ use std::{
 };
 
 use crate::{
-  builtin::{is_node_like_builtin, BuiltinChecker}, external::{self, ExternalDecider, ExternalDeciderOptions}, file_url::file_url_str_to_path_and_postfix, resolver::{self, AdditionalOptions, Resolvers}, utils::{
-    is_bare_import, is_in_node_modules, is_windows_drive_path, normalize_leading_slashes, normalize_path, BROWSER_EXTERNAL_ID, OPTIONAL_PEER_DEP_ID
-  }, ResolveOptionsExternal
+  ResolveOptionsExternal,
+  builtin::{BuiltinChecker, is_node_like_builtin},
+  external::{self, ExternalDecider, ExternalDeciderOptions},
+  file_url::file_url_str_to_path_and_postfix,
+  resolver::{self, AdditionalOptions, Resolvers},
+  utils::{
+    BROWSER_EXTERNAL_ID, OPTIONAL_PEER_DEP_ID, is_bare_import, is_in_node_modules,
+    is_windows_drive_path, normalize_leading_slashes, normalize_path,
+  },
 };
 use anyhow::anyhow;
 use arcstr::ArcStr;


### PR DESCRIPTION
Resovle ids like `//absolute/path` to align with the Vite's JS resolver.