### PR TITLE
fix(debug): `build_id` doesn't increase

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -57,7 +57,7 @@ impl Bundler {
 impl Bundler {
   #[tracing::instrument(level = "debug", skip_all, parent = &self.session_span)]
   pub async fn write(&mut self) -> BuildResult<BundleOutput> {
-    let build_count = self.inc_build_count();
+    let build_count = self.build_count;
     async {
       trace_action!(action::BuildStart { action: "BuildStart" });
       let scan_stage_output = self.scan(vec![]).await?;
@@ -75,7 +75,7 @@ impl Bundler {
 
   #[tracing::instrument(level = "debug", skip_all, parent = &self.session_span)]
   pub async fn generate(&mut self) -> BuildResult<BundleOutput> {
-    let build_count = self.inc_build_count();
+    let build_count = self.build_count;
     async {
       trace_action!(action::BuildStart { action: "BuildStart" });
       let scan_stage_output = self.scan(vec![]).await?;
@@ -349,12 +349,6 @@ impl Bundler {
         .collect();
       trace_action!(action::ModuleGraphReady { action: "ModuleGraphReady", modules });
     }
-  }
-
-  fn inc_build_count(&mut self) -> u32 {
-    let count = self.build_count;
-    self.build_count += 1;
-    count
   }
 }
 

--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -20,6 +20,7 @@ pub struct BundlerBuilder {
   options: BundlerOptions,
   plugins: Vec<SharedPluginable>,
   session_id: Option<Arc<str>>,
+  build_count: u32,
 }
 
 impl BundlerBuilder {
@@ -71,7 +72,7 @@ impl BundlerBuilder {
       hmr_manager: None,
       session_span,
       _debug_tracer: debug_tracer,
-      build_count: 0,
+      build_count: self.build_count,
     }
   }
 
@@ -168,6 +169,12 @@ impl BundlerBuilder {
   #[must_use]
   pub fn with_session_id(mut self, session_id: Arc<str>) -> Self {
     self.session_id = Some(session_id);
+    self
+  }
+
+  #[must_use]
+  pub fn with_build_count(mut self, build_count: u32) -> Self {
+    self.build_count = build_count;
     self
   }
 }

--- a/crates/rolldown_binding/src/binding_bundler.rs
+++ b/crates/rolldown_binding/src/binding_bundler.rs
@@ -8,6 +8,8 @@ use crate::binding_bundler_impl::{BindingBundlerImpl, BindingBundlerOptions};
 #[napi]
 pub struct BindingBundler {
   session_id: Arc<str>,
+  // Every `.write(..)/.generate(..)` will create a new `BindingBundlerImpl`, we use this field to track the build count.
+  build_count: u32,
 }
 
 #[napi]
@@ -15,17 +17,19 @@ impl BindingBundler {
   #[napi(constructor)]
   pub fn new() -> napi::Result<Self> {
     let session_id = rolldown_debug::generate_session_id();
+    let build_count = 0;
 
-    Ok(Self { session_id })
+    Ok(Self { session_id, build_count })
   }
 
   #[napi]
   #[cfg_attr(target_family = "wasm", allow(unused))]
   pub fn create_impl(
-    &self,
+    &mut self,
     env: Env,
     options: BindingBundlerOptions,
   ) -> napi::Result<BindingBundlerImpl> {
-    BindingBundlerImpl::new(env, options, Arc::clone(&self.session_id))
+    self.build_count += 1;
+    BindingBundlerImpl::new(env, options, Arc::clone(&self.session_id), self.build_count)
   }
 }

--- a/crates/rolldown_binding/src/binding_bundler_impl.rs
+++ b/crates/rolldown_binding/src/binding_bundler_impl.rs
@@ -33,7 +33,12 @@ pub struct BindingBundlerImpl {
 #[napi]
 impl BindingBundlerImpl {
   #[cfg_attr(target_family = "wasm", allow(unused))]
-  pub fn new(env: Env, option: BindingBundlerOptions, session_id: Arc<str>) -> napi::Result<Self> {
+  pub fn new(
+    env: Env,
+    option: BindingBundlerOptions,
+    session_id: Arc<str>,
+    build_count: u32,
+  ) -> napi::Result<Self> {
     try_init_custom_trace_subscriber(env);
 
     let BindingBundlerOptions { input_options, output_options, parallel_plugins_registry } = option;
@@ -61,7 +66,8 @@ impl BindingBundlerImpl {
     let bundler_builder = BundlerBuilder::default()
       .with_options(ret.bundler_options)
       .with_plugins(ret.plugins)
-      .with_session_id(session_id);
+      .with_session_id(session_id)
+      .with_build_count(build_count);
 
     Ok(Self { inner: Arc::new(Mutex::new(bundler_builder.build())) })
   }

--- a/crates/rolldown_binding/src/watcher.rs
+++ b/crates/rolldown_binding/src/watcher.rs
@@ -47,7 +47,8 @@ impl BindingWatcher {
       .into_iter()
       .map(|option| {
         // TODO(hyf0): support emit debug data for builtin watch
-        BindingBundlerImpl::new(env, option, Arc::from("0000")).map(BindingBundlerImpl::into_inner)
+        BindingBundlerImpl::new(env, option, Arc::from("0000"), 0)
+          .map(BindingBundlerImpl::into_inner)
       })
       .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/rolldown_debug/src/utils.rs
+++ b/crates/rolldown_debug/src/utils.rs
@@ -1,9 +1,12 @@
 use std::sync::{Arc, atomic::AtomicU32};
 
 static SESSION_ID_SEED: AtomicU32 = AtomicU32::new(0);
+static BUILD_ID_SEED: AtomicU32 = AtomicU32::new(0);
 
 pub fn generate_build_id(build_count: u32) -> Arc<str> {
-  format!("bid_{build_count}").into()
+  let seed = BUILD_ID_SEED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+  format!("bid_{seed}_count_{build_count}").into()
 }
 
 pub fn generate_session_id() -> Arc<str> {
@@ -13,5 +16,5 @@ pub fn generate_session_id() -> Arc<str> {
     .as_millis()
     .to_string();
   let seed = SESSION_ID_SEED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-  format!("sid_{timestamp}_{seed}").into()
+  format!("sid_{seed}_{timestamp}").into()
 }


### PR DESCRIPTION
Afterthought:

For this case, current archtecture makes the rust rolldown more like a part of the `rolldown` in nodejs instead of a standalone crate.