### PR TITLE
fix(rolldown_plugin_build_import_analysis): align pure dynamic import handling with rolldown-vite

### DIFF
--- a/crates/rolldown_plugin_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_build_import_analysis/src/ast_utils.rs
@@ -7,6 +7,7 @@ use oxc::{
       FormalParameterKind, Statement, StaticMemberExpression, VariableDeclarationKind,
     },
   },
+  ast_visit::walk_mut::walk_arguments,
   semantic::ScopeFlags,
   span::SPAN,
 };
@@ -41,7 +42,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
 
   /// transform `(await import('foo')).foo`
   /// to `(await __vitePreload(async () => { let foo; return {foo} = await import('foo'); },...))).foo`
-  pub fn rewrite_member_expr(&mut self, member_expr: &mut StaticMemberExpression<'a>) {
+  pub fn rewrite_member_expr(&self, member_expr: &mut StaticMemberExpression<'a>) -> bool {
     let mut await_expr = &mut member_expr.object;
     while let Expression::ParenthesizedExpression(member_expr) = await_expr {
       await_expr = &mut member_expr.expression;
@@ -79,32 +80,44 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
           await_expr.take_in(self.snippet.alloc()),
         ),
       ));
-      self.need_prepend_helper = true;
+      return true;
     }
+    false
   }
 
   /// transform `import('foo').then(({foo})=>{})`
   /// to `__vitePreload(async () => { let foo; return {foo} = await import('foo'); },...).then(({foo})=>{})`
-  pub fn rewrite_import_expr(&mut self, expr: &mut CallExpression<'a>) {
+  pub fn rewrite_call_expr(&mut self, expr: &mut CallExpression<'a>) -> bool {
     let Expression::StaticMemberExpression(ref mut callee) = expr.callee else {
-      return;
+      return false;
     };
     if callee.property.name != "then"
       || expr.arguments.is_empty()
       || !matches!(callee.object, Expression::ImportExpression(_))
     {
-      return;
+      return false;
     }
     let arg = match &expr.arguments[0] {
       Argument::ArrowFunctionExpression(expr) if !expr.params.is_empty() => &expr.params.items[0],
       Argument::FunctionExpression(expr) if !expr.params.is_empty() => &expr.params.items[0],
-      _ => return,
+      _ => return false,
     };
     callee.object = self.construct_vite_preload_call(
       arg.pattern.clone_in(self.snippet.alloc()),
       self.snippet.builder.expression_await(SPAN, callee.object.take_in(self.snippet.alloc())),
     );
-    self.need_prepend_helper = true;
+    walk_arguments(self, &mut expr.arguments);
+    true
+  }
+
+  /// transform `import('foo')`
+  /// to `__vitePreload(() =>import('foo'),...)`
+  pub fn rewrite_import_expr(&self, expr: &mut Expression<'a>) -> bool {
+    let Expression::ImportExpression(_) = expr else { return false };
+    *expr = self.vite_preload_call(Argument::from(
+      self.snippet.only_return_arrow_expr(expr.take_in(self.snippet.alloc())),
+    ));
+    true
   }
 
   pub fn construct_vite_preload_call(
@@ -112,6 +125,49 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
     binding_pat: BindingPattern<'a>,
     await_expr: Expression<'a>,
   ) -> Expression<'a> {
+    let argument = Argument::from(Expression::ArrowFunctionExpression(
+      self.snippet.builder.alloc_arrow_function_expression(
+        SPAN,
+        false,
+        true,
+        NONE,
+        self.snippet.builder.formal_parameters(
+          SPAN,
+          FormalParameterKind::Signature,
+          self.snippet.builder.vec(),
+          NONE,
+        ),
+        NONE,
+        self.snippet.builder.function_body(SPAN, self.snippet.builder.vec(), {
+          let mut statements = self.snippet.builder.vec_with_capacity(2);
+          statements.push(Statement::from(Declaration::VariableDeclaration(
+            self.snippet.builder.alloc_variable_declaration(
+              SPAN,
+              VariableDeclarationKind::Const,
+              self.snippet.builder.vec1(self.snippet.builder.variable_declarator(
+                SPAN,
+                VariableDeclarationKind::Const,
+                binding_pat.clone_in(self.snippet.alloc()),
+                Some(await_expr),
+                false,
+              )),
+              false,
+            ),
+          )));
+          statements.push(Statement::ReturnStatement(
+            self
+              .snippet
+              .builder
+              .alloc_return_statement(SPAN, Some(binding_pat.into_expression(&self.snippet))),
+          ));
+          statements
+        }),
+      ),
+    ));
+    self.vite_preload_call(argument)
+  }
+
+  pub fn vite_preload_call(&self, argument: Argument<'a>) -> Expression<'a> {
     self.snippet.builder.expression_call(
       SPAN,
       self.snippet.id_ref_expr("__vitePreload", SPAN),
@@ -120,45 +176,7 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
         let append_import_meta_url = self.render_built_url || self.is_relative_base;
         let capacity = if append_import_meta_url { 3 } else { 2 };
         let mut items = self.snippet.builder.vec_with_capacity(capacity);
-        items.push(Argument::from(Expression::ArrowFunctionExpression(
-          self.snippet.builder.alloc_arrow_function_expression(
-            SPAN,
-            false,
-            true,
-            NONE,
-            self.snippet.builder.formal_parameters(
-              SPAN,
-              FormalParameterKind::Signature,
-              self.snippet.builder.vec(),
-              NONE,
-            ),
-            NONE,
-            self.snippet.builder.function_body(SPAN, self.snippet.builder.vec(), {
-              let mut statements = self.snippet.builder.vec_with_capacity(2);
-              statements.push(Statement::from(Declaration::VariableDeclaration(
-                self.snippet.builder.alloc_variable_declaration(
-                  SPAN,
-                  VariableDeclarationKind::Const,
-                  self.snippet.builder.vec1(self.snippet.builder.variable_declarator(
-                    SPAN,
-                    VariableDeclarationKind::Const,
-                    binding_pat.clone_in(self.snippet.alloc()),
-                    Some(await_expr),
-                    false,
-                  )),
-                  false,
-                ),
-              )));
-              statements.push(Statement::ReturnStatement(
-                self
-                  .snippet
-                  .builder
-                  .alloc_return_statement(SPAN, Some(binding_pat.into_expression(&self.snippet))),
-              ));
-              statements
-            }),
-          ),
-        )));
+        items.push(argument);
         items.push(Argument::from(self.snippet.builder.expression_conditional(
           SPAN,
           self.snippet.id_ref_expr(IS_MODERN_FLAG, SPAN),

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/_config.ts
@@ -1,6 +1,6 @@
-import { buildImportAnalysisPlugin } from 'rolldown/experimental'
-import { defineTest } from 'rolldown-tests'
 import { expect } from 'vitest'
+import { defineTest } from 'rolldown-tests'
+import { buildImportAnalysisPlugin } from 'rolldown/experimental'
 
 export default defineTest({
   skipComposingJsPlugin: true,
@@ -10,22 +10,15 @@ export default defineTest({
       {
         // insert some dummy runtime flag to assert the runtime behavior
         name: 'insert_dummy_flag',
-        transform(code, id) {
-          let runtimeCode = `
-const __VITE_IS_MODERN__ = false;
-
-`
+        transform(code) {
+          let runtimeCode = `const __VITE_IS_MODERN__ = false;`
           return {
             code: runtimeCode + code,
           }
         },
       },
       buildImportAnalysisPlugin({
-        preloadCode: `
-export const __vitePreload = (v) => {
-  return v()
-};
-`,
+        preloadCode: `export const __vitePreload = (v) => { return v() };`,
         insertPreload: true,
         optimizeModulePreloadRelativePaths: false,
         renderBuiltUrl: false,

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/a.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/a.js
@@ -1,1 +1,0 @@
-export const a = 1

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/assert.mjs
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import assert from 'node:assert'
-import { foo, b } from './dist/main'
+import { foo, a, b } from './dist/main'
 
+assert.strictEqual(a, b)
+assert.strictEqual(foo, a)
 assert.strictEqual(foo, 100)
-assert.strictEqual(b, 2)

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/b.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/b.js
@@ -1,1 +1,0 @@
-export const b = 2

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/main.js
@@ -1,8 +1,10 @@
 import assert from 'node:assert'
+
 const { foo } = await import('./lib.js')
-const b = (await import('./b.js')).b
-import('./a.js').then(({ a }) => {
-  assert.strictEqual(a, 1)
+const a = (await import('./lib.js')).foo
+const b = (await (() => import('./lib.js'))()).foo
+import('./lib.js').then(({ foo }) => {
+  assert.strictEqual(foo , a)
 })
 
-export { foo, b }
+export { foo, a, b }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/check-helper-inserted/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/check-helper-inserted/_config.ts
@@ -1,6 +1,5 @@
-import { buildImportAnalysisPlugin } from 'rolldown/experimental'
 import { defineTest } from 'rolldown-tests'
-import { expect } from 'vitest'
+import { buildImportAnalysisPlugin } from 'rolldown/experimental'
 
 export default defineTest({
   skipComposingJsPlugin: true,
@@ -8,24 +7,16 @@ export default defineTest({
     input: './main.js',
     plugins: [
       {
-        // insert some dummy runtime flag to assert the runtime behavior
         name: 'insert_dummy_flag',
-        transform(code, id) {
-          let runtimeCode = `
-const __VITE_IS_MODERN__ = false;
-
-`
+        transform(code) {
+          let runtimeCode = `const __VITE_IS_MODERN__ = false;`
           return {
             code: runtimeCode + code,
           }
         },
       },
       buildImportAnalysisPlugin({
-        preloadCode: `
-export const __vitePreload = (v) => {
-  return v()
-};
-`,
+        preloadCode: `export const __vitePreload = (v) => { return v() };`,
         insertPreload: true,
         optimizeModulePreloadRelativePaths: false,
         renderBuiltUrl: false,
@@ -33,14 +24,7 @@ export const __vitePreload = (v) => {
       }),
     ],
   },
-  async afterTest(output) {
+  async afterTest() {
     await import('./assert.mjs')
-    output.output.forEach((item) => {
-      if (item.type === 'chunk') {
-        Object.keys(item.modules).forEach((key) => {
-          expect(key).not.contains('vite')
-        })
-      }
-    })
   },
 })

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/check-helper-inserted/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/check-helper-inserted/main.js
@@ -1,6 +1,1 @@
-const __vitePreload = (v) => {
-  return v()
-}
-const { foo } = await import('./lib.js')
-
-export { foo }
+export const { foo } = await import('./lib.js')

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/_config.ts
@@ -18,11 +18,7 @@ export default defineTest({
         },
       },
       buildImportAnalysisPlugin({
-        preloadCode: `
-export const __vitePreload = (v) => {
-  return v()
-};
-`,
+        preloadCode: `export const __vitePreload = (v) => { return v() };`,
         insertPreload: true,
         optimizeModulePreloadRelativePaths: false,
         renderBuiltUrl: true,

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/render-built-url/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/render-built-url/_config.ts
@@ -1,6 +1,6 @@
-import { buildImportAnalysisPlugin } from 'rolldown/experimental'
-import { defineTest } from 'rolldown-tests'
 import { expect } from 'vitest'
+import { defineTest } from 'rolldown-tests'
+import { buildImportAnalysisPlugin } from 'rolldown/experimental'
 
 export default defineTest({
   skipComposingJsPlugin: true,
@@ -10,22 +10,15 @@ export default defineTest({
       {
         // insert some dummy runtime flag to assert the runtime behavior
         name: 'insert_dummy_flag',
-        transform(code, id) {
-          let runtimeCode = `
-const __VITE_IS_MODERN__ = false;
-
-`
+        transform(code) {
+          let runtimeCode = `const __VITE_IS_MODERN__ = false;`
           return {
             code: runtimeCode + code,
           }
         },
       },
       buildImportAnalysisPlugin({
-        preloadCode: `
-export const __vitePreload = (v) => {
-  return v()
-};
-`,
+        preloadCode: `export const __vitePreload = (v) => { return v() };`,
         insertPreload: true,
         optimizeModulePreloadRelativePaths: false,
         renderBuiltUrl: true,


### PR DESCRIPTION
closes https://github.com/vitejs/rolldown-vite/issues/189, https://github.com/vitejs/rolldown-vite/issues/255

Related to https://github.com/vitejs/rolldown-vite/issues/213