### PR TITLE
refactor: use `rolldown_utils::futures::block_on` for `WatcherImpl#start`

### DIFF
--- a/crates/rolldown/src/watch/watcher.rs
+++ b/crates/rolldown/src/watch/watcher.rs
@@ -201,16 +201,8 @@ impl WatcherImpl {
         }
       }
     };
-    #[cfg(target_family = "wasm")]
-    {
-      futures::executor::block_on(future);
-    }
-    #[cfg(not(target_family = "wasm"))]
-    {
-      tokio::task::block_in_place(move || {
-        tokio::runtime::Handle::current().block_on(future);
-      });
-    }
+
+    rolldown_utils::futures::block_on(future);
   }
 }
 


### PR DESCRIPTION
Related to https://github.com/rolldown/rolldown/pull/5007

I wrapped the relevant logic in a `block_on` function.