### PR TITLE
refactor(rolldown_utils): simplify `block_on_spawn_all`

### DIFF
--- a/crates/rolldown_utils/src/futures.rs
+++ b/crates/rolldown_utils/src/futures.rs
@@ -2,7 +2,6 @@ use futures::Future;
 
 /// `async` here is only used to satisfy the wasm shim version of `block_on_spawn_all`.
 /// This function allow you to spawn non-static futures in parallel and wait for all of them to finish.
-#[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::unused_async)]
 pub async fn block_on_spawn_all<Iter, Out>(iter: Iter) -> Vec<Out>
 where
@@ -10,12 +9,20 @@ where
   Out: Send + 'static,
   Iter::Item: Future<Output = Out> + Send,
 {
-  use async_scoped::TokioScope;
-  let (_ret, collections) =
-    async_scoped::Scope::scope_and_block(|scope: &mut TokioScope<'_, _>| {
-      iter.into_iter().for_each(|fut| scope.spawn(fut));
-    });
-  collections.into_iter().map(Result::unwrap).collect()
+  #[cfg(target_arch = "wasm32")]
+  {
+    use futures::future::join_all;
+    join_all(iter).await
+  }
+  #[cfg(not(target_arch = "wasm32"))]
+  {
+    use async_scoped::TokioScope;
+    let (_ret, collections) =
+      async_scoped::Scope::scope_and_block(|scope: &mut TokioScope<'_, _>| {
+        iter.into_iter().for_each(|fut| scope.spawn(fut));
+      });
+    collections.into_iter().map(Result::unwrap).collect()
+  }
 }
 
 async fn _test_block_on_spawn_all_non_static_future() {
@@ -24,18 +31,6 @@ async fn _test_block_on_spawn_all_non_static_future() {
     words.push_str("hello");
   };
   let _ = block_on_spawn_all(std::iter::once(non_static_future)).await;
-}
-
-#[cfg(target_arch = "wasm32")]
-pub async fn block_on_spawn_all<Iter, Out>(iter: Iter) -> Vec<Out>
-where
-  Iter: Iterator,
-  Out: Send + 'static,
-  Iter::Item: Future<Output = Out> + Send,
-{
-  use futures::future::join_all;
-  let outs = join_all(iter).await;
-  outs
 }
 
 pub fn block_on<F: Future>(f: F) -> F::Output {


### PR DESCRIPTION
Simplify the function declarations of `block_on_spawn_all` under different `cfg` conditions.