### PR TITLE
chore: Align status notice in readme with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 > 🚧 **Beta Software**
 >
-> Rolldown is currently in beta status. While it can already handle most production use cases, there may still be bugs and rough edges. Most notably, the built-in minification feature is still in early work-in-progress status.
+> Rolldown is currently in beta status. While it can already handle most production use cases, there may still be bugs and rough edges. Most notably, the built-in minification feature is still in alpha status.
 
 # Rolldown
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@
 
 </div>
 
-> 🚧 **Work in Progress**
+> 🚧 **Beta Software**
 >
-> Rolldown is currently in active development and not usable for production yet.
+> Rolldown is currently in beta status. While it can already handle most production use cases, there may still be bugs and rough edges. Most notably, the built-in minification feature is still in early work-in-progress status.
 
 # Rolldown
 


### PR DESCRIPTION
The notice in the docs [was updated ~6 months ago](https://github.com/rolldown/rolldown/commit/3ab6ab49e6ece9770174b1f93408bd1ddcae4a2a#diff-049d400b4837940fc4fd4519150b7867f092f8569718b4dfedb356713a29d3a2), but [the identical message in the readme](https://github.com/rolldown/rolldown/blob/44c6f6d75e155e631f83713d2ca6a6945797749a/README.md?plain=1#L39-L41) wasn't updated at the same time (was added ~1 year ago). Felt like an oversight to me, but might be mistaken 🙂