### PR TITLE
chore(infra): clean up `dist` before building `rolldown`

### DIFF
--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -74,6 +74,10 @@ if (isBrowserPkg) {
 }
 
 (async () => {
+  // clean up unused files that may be left from previous builds
+  fs.rmSync(outputDir, { recursive: true, force: true });
+  fs.mkdirSync(outputDir, { recursive: true });
+
   for (const config of configs) {
     await build(config);
   }


### PR DESCRIPTION
Leftovers `xx-xxx.d.ts` in `dist` from last build break this command and cause `just build` failed.

https://github.com/rolldown/rolldown/blob/1cea807f7d42f2327663d5c344d5ddc7aee4979a/packages/rolldown/package.json#L111