### PR TITLE
chore: remove long-commented-out code

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -297,11 +297,6 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
           ))?;
         }
       }
-      // if !scanned_top_level_symbols.is_empty() {
-      //   return Err(anyhow::format_err!(
-      //     "Some top-level symbols are scanned by the scanner but not declared in the top-level scope: {scanned_top_level_symbols:?}",
-      //   ));
-      // }
     }
     self.result.ast_usage = self.ast_usage;
     Ok(self.result)
@@ -682,7 +677,6 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         match &decl.declaration {
           ast::ExportDefaultDeclarationKind::ClassDeclaration(class) => {
             self.visit_class(class);
-            // walk::walk_declaration(self, &ast::Declaration::ClassDeclaration(func));
           }
           _ => {}
         }

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -223,7 +223,6 @@ fn json_object_expr_to_esm(
     }),
   );
 
-  // let default_symbol_ref = module.default_export_ref;
   // update semantic data of module
   let root_scope_id = scoping.root_scope_id();
   let mut symbol_ref_db = SymbolRefDbForModule::new(scoping, module_idx, root_scope_id);

--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -38,17 +38,10 @@ impl GenerateContext<'_> {
     canonical_names: &FxHashMap<SymbolRef, Rstr>,
   ) -> String {
     let symbol_db = &self.link_output.symbol_db;
-    // let belong_to_chunk_idx =
-    // if !symbol_ref.is_declared_in_root_scope(self.ctx.symbol_db) {
-    //   // No fancy things on none root scope symbols
-    //   return self.snippet.id_ref_expr(self.canonical_name_for(symbol_ref), SPAN);
-    // }
     let canonical_ref = symbol_db.canonical_ref_for(symbol_ref);
     let canonical_symbol = symbol_db.get(canonical_ref);
     let namespace_alias = &canonical_symbol.namespace_alias;
     if let Some(_ns_alias) = namespace_alias {
-      // canonical_ref = ns_alias.namespace_ref;
-      // canonical_symbol = symbol_db.get(canonical_ref);
       // Not sure if we need to handle this case
       unreachable!("You run into a bug, please report it");
     }

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -131,7 +131,6 @@ impl<'name> Renamer<'name> {
       map: &ModuleScopeSymbolIdMap<'_>,
     ) {
       let bindings = map.get(&module.idx).map(|vec| &vec[scope_id]).unwrap();
-      // let mut bindings = ast_scope.scoping().get_bindings(scope_id).iter().collect::<Vec<_>>();
       let mut used_canonical_names_for_this_scope = FxHashMap::with_capacity(bindings.len());
 
       bindings.iter().for_each(|&(symbol_id, binding_name)| {

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -143,27 +143,6 @@ impl NormalModule {
     }
   }
 
-  // // https://tc39.es/ecma262/#sec-getexportednames
-  // pub fn get_exported_names<'module>(
-  //   &'module self,
-  //   export_star_set: &mut FxHashSet<NormalModuleId>,
-  //   ret: &mut FxHashSet<&'module Rstr>,
-  //   modules: &'module IndexVec<NormalModuleId, NormalModule>,
-  // ) {
-  //   if export_star_set.contains(&self.id) {
-  //     // noop
-  //   } else {
-  //     export_star_set.insert(self.id);
-  //     ret.extend(self.named_exports.keys().filter(|name| name.as_str() != "default"));
-  //     self.star_export_modules().for_each(|importee_id| match importee_id {
-  //       ModuleId::Normal(importee_id) => {
-  //         modules[importee_id].get_exported_names(export_star_set, ret, modules)
-  //       }
-  //       ModuleId::External(_) => {}
-  //     });
-  //   }
-  // }
-
   pub fn ecma_ast_idx(&self) -> EcmaAstIdx {
     self.ecma_view.ecma_ast_idx.expect("ecma_ast_idx should be set in this stage")
   }

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -24,36 +24,6 @@ use tracing::{Instrument, debug_span};
 impl PluginDriver {
   #[tracing::instrument(level = "trace", skip_all)]
   pub async fn build_start(&self, opts: &SharedNormalizedBundlerOptions) -> HookNoopReturn {
-    // let ret = {
-    //   #[cfg(not(target_arch = "wasm32"))]
-    //   {
-    //     block_on_spawn_all(
-    //       self
-    //         .iter_plugin_with_context_by_order(&self.order_by_build_start_meta)
-    //         .map(|(_, plugin, ctx)| plugin.call_build_start(ctx)),
-    //     )
-    //     .await
-    //   }
-    //   #[cfg(target_arch = "wasm32")]
-    //   {
-    //     // FIXME(hyf0): This is a workaround for wasm32 target, it's wired that
-    //     // `block_on_spawn_all(self.plugins.iter().map(|(plugin, ctx)| plugin.build_start(ctx))).await;` will emit compile errors like
-    //     // `implementation of `std::marker::Send` is not general enough`. It seems to be the problem related to HRTB, async and iterator.
-    //     // I guess we need some rust experts here.
-    //     let mut futures = vec![];
-    //     for (_, plugin, ctx) in
-    //       self.iter_plugin_with_context_by_order(&self.order_by_build_start_meta)
-    //     {
-    //       futures.push(plugin.call_build_start(ctx));
-    //     }
-    //     block_on_spawn_all(futures.into_iter()).await
-    //   }
-    // };
-
-    // for r in ret {
-    //   r?;
-    // }
-
     for (plugin_idx, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_build_start_meta)
     {

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -268,10 +268,6 @@ impl IntegrationTest {
       options.input = Some(vec![default_test_input_item()]);
     }
 
-    // if options.cwd.is_none() {
-    //   options.cwd = Some(fixture_path.to_path_buf());
-    // }
-
     let output_ext = "js";
 
     if options.entry_filenames.is_none() {

--- a/crates/rolldown_utils/src/rayon.rs
+++ b/crates/rolldown_utils/src/rayon.rs
@@ -88,6 +88,5 @@ fn _usages() {
   demo.iter_mut().par_bridge().for_each(|_| {});
   demo.clone().into_iter().par_bridge().for_each(|_| {});
   demo.par_iter().for_each(|_| {});
-  // demo.par_iter_mut().for_each(|_| {});
   demo.clone().into_par_iter().for_each(|_| {});
 }


### PR DESCRIPTION
These code blocks have been commented out for over six months to a year and  are no longer in use. Removing them helps prevent unnecessary code bloat and keeps the codebase clean.