### PR TITLE
refactor: passing vec length directly

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -1,6 +1,6 @@
 use arcstr::ArcStr;
 use oxc_index::{IndexVec, index_vec};
-use rolldown_common::{Chunk, ChunkIdx, ChunkTable, ModuleIdx, ModuleTable, SymbolRef};
+use rolldown_common::{Chunk, ChunkIdx, ChunkTable, ModuleIdx, SymbolRef};
 use rustc_hash::FxHashMap;
 
 #[derive(Debug)]
@@ -16,10 +16,10 @@ pub struct ChunkGraph {
 }
 
 impl ChunkGraph {
-  pub fn new(module_table: &ModuleTable) -> Self {
+  pub fn new(modules_len: usize) -> Self {
     Self {
       chunk_table: ChunkTable::default(),
-      module_to_chunk: index_vec![None; module_table.modules.len()],
+      module_to_chunk: index_vec![None; modules_len],
       sorted_chunk_idx_vec: Vec::new(),
       entry_module_to_entry_chunk: FxHashMap::default(),
       safely_merge_cjs_ns_map_idx_vec: index_vec![],

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -40,7 +40,7 @@ impl GenerateStage<'_> {
     // If we are in test environment, to make the runtime module always fall into a standalone chunk,
     // we create a facade entry point for it.
 
-    let mut chunk_graph = ChunkGraph::new(&self.link_output.module_table);
+    let mut chunk_graph = ChunkGraph::new(self.link_output.module_table.modules.len());
     chunk_graph.chunk_table.chunks.reserve(self.link_output.entries.len());
 
     let mut index_splitting_info: IndexSplittingInfo = oxc_index::index_vec![SplittingInfo {


### PR DESCRIPTION
Refactor the constructor of ChunkGraph so that it directly accepts the module vector length.