### PR TITLE
perf: skip empty write bundle hook with `hook_usage` meta

### DIFF
--- a/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
@@ -207,10 +207,12 @@ impl PluginDriver {
     opts: &SharedNormalizedBundlerOptions,
     warnings: &mut Vec<BuildDiagnostic>,
   ) -> HookNoopReturn {
-    for (_, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_write_bundle_meta)
+    for (plugin_idx, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_write_bundle_meta)
     {
+      if !self.plugin_usage_vec[plugin_idx].contains(HookUsage::WriteBundle) {
+        continue;
+      }
       let mut args = crate::HookWriteBundleArgs { bundle, options: opts };
-
       plugin
         .call_write_bundle(ctx, &mut args)
         .instrument(debug_span!("write_bundle_hook", plugin_name = plugin.call_name().as_ref()))

--- a/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/output_hooks.rs
@@ -207,7 +207,8 @@ impl PluginDriver {
     opts: &SharedNormalizedBundlerOptions,
     warnings: &mut Vec<BuildDiagnostic>,
   ) -> HookNoopReturn {
-    for (plugin_idx, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_write_bundle_meta)
+    for (plugin_idx, plugin, ctx) in
+      self.iter_plugin_with_context_by_order(&self.order_by_write_bundle_meta)
     {
       if !self.plugin_usage_vec[plugin_idx].contains(HookUsage::WriteBundle) {
         continue;


### PR DESCRIPTION
write bundle hook was missing `hook_usage` meta check. This PR adds that.

refs #4187
