### PR TITLE
perf: reduce temporary memory usage by avoiding output chunk clone until needed

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{ops::Deref, sync::Arc};
 
 use futures::future::try_join_all;
 use oxc_index::{IndexVec, index_vec};
@@ -88,7 +88,7 @@ impl GenerateStage<'_> {
             )
             .await?
             {
-              output_assets.push(Output::Asset(Box::new(sourcemap_asset)));
+              output_assets.push(Output::Asset(Arc::new(sourcemap_asset)));
             }
           }
 
@@ -98,7 +98,7 @@ impl GenerateStage<'_> {
             } else {
               Some(concat_string!(filename, ".map"))
             };
-          output.push(Output::Chunk(Box::new(OutputChunk {
+          output.push(Output::Chunk(Arc::new(OutputChunk {
             name: rendered_chunk.name.clone(),
             filename: filename.clone(),
             code,
@@ -129,11 +129,11 @@ impl GenerateStage<'_> {
             )
             .await?
             {
-              output_assets.push(Output::Asset(Box::new(sourcemap_asset)));
+              output_assets.push(Output::Asset(Arc::new(sourcemap_asset)));
             }
           }
 
-          output.push(Output::Asset(Box::new(OutputAsset {
+          output.push(Output::Asset(Arc::new(OutputAsset {
             filename: filename.clone(),
             source: code.into(),
             original_file_names: vec![],
@@ -141,7 +141,7 @@ impl GenerateStage<'_> {
           })));
         }
         InstantiationKind::None => {
-          output.push(Output::Asset(Box::new(OutputAsset {
+          output.push(Output::Asset(Arc::new(OutputAsset {
             filename: filename.clone(),
             source: code,
             original_file_names: vec![],

--- a/crates/rolldown_binding/src/types/binding_output_asset.rs
+++ b/crates/rolldown_binding/src/types/binding_output_asset.rs
@@ -1,15 +1,17 @@
+use std::sync::Arc;
+
 use napi_derive::napi;
 
 use crate::options::plugin::types::binding_asset_source::BindingAssetSource;
 
 #[napi]
 pub struct BindingOutputAsset {
-  inner: rolldown_common::OutputAsset,
+  inner: Arc<rolldown_common::OutputAsset>,
 }
 
 #[napi]
 impl BindingOutputAsset {
-  pub fn new(inner: rolldown_common::OutputAsset) -> Self {
+  pub fn new(inner: Arc<rolldown_common::OutputAsset>) -> Self {
     Self { inner }
   }
 

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::{
   binding_output_asset::{BindingOutputAsset, JsOutputAsset},
   binding_output_chunk::{BindingOutputChunk, JsOutputChunk, update_output_chunk},
@@ -48,10 +50,10 @@ impl From<Vec<rolldown_common::Output>> for BindingOutputs {
     let mut assets = vec![];
     outputs.into_iter().for_each(|o| match o {
       rolldown_common::Output::Chunk(chunk) => {
-        chunks.push(BindingOutputChunk::new(*chunk));
+        chunks.push(BindingOutputChunk::new(chunk));
       }
       rolldown_common::Output::Asset(asset) => {
-        assets.push(BindingOutputAsset::new(*asset));
+        assets.push(BindingOutputAsset::new(asset));
       }
     });
     Self { chunks, assets, error: None }
@@ -82,7 +84,7 @@ pub fn update_outputs(
   }
   for asset in changed.assets {
     if let Some(index) = outputs.iter().position(|o| o.filename() == asset.filename) {
-      outputs[index] = rolldown_common::Output::Asset(Box::new(asset.into()));
+      outputs[index] = rolldown_common::Output::Asset(Arc::new(asset.into()));
     }
   }
   for deleted in changed.deleted {

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -226,7 +226,7 @@ impl FileEmitter {
 
       let mut original_file_names = std::mem::take(&mut value.original_file_names);
       original_file_names.sort_unstable();
-      bundle.push(Output::Asset(Box::new(OutputAsset {
+      bundle.push(Output::Asset(Arc::new(OutputAsset {
         filename: value.filename.clone(),
         names,
         original_file_names,

--- a/crates/rolldown_common/src/types/output.rs
+++ b/crates/rolldown_common/src/types/output.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arcstr::ArcStr;
 
 use crate::{OutputChunk, StrOrBytes};
@@ -12,8 +14,8 @@ pub struct OutputAsset {
 
 #[derive(Debug, Clone)]
 pub enum Output {
-  Chunk(Box<OutputChunk>),
-  Asset(Box<OutputAsset>),
+  Chunk(Arc<OutputChunk>),
+  Asset(Arc<OutputAsset>),
 }
 
 impl Output {


### PR DESCRIPTION
These two lines clones the whole bundle output. This is because `args.bundle` is `Vec<Output>` where `Output` is a enum that contains a `Box`.
https://github.com/rolldown/rolldown/blob/35d8e1569d820347646a014fca28ed32457f912c/crates/rolldown_binding/src/options/plugin/js_plugin.rs#L483
https://github.com/rolldown/rolldown/blob/35d8e1569d820347646a014fca28ed32457f912c/crates/rolldown_binding/src/options/plugin/js_plugin.rs#L510

While this `.clone` is inevitable to allow referencing the `bundle` parameter of `generateBundle` hook after the hook has end, the content of `bundle` parameter does not need to have a separate value, because it is readonly (the modification is done via `ChangedOutputs` instead). This PR changes `Box` to `Arc` so that we can share the underlying value.

This PR will have a bigger impact if the output is large. For example, `astro build` with https://github.com/withastro/astro.build used ~8GB of memory previously (if the GC does not run frequently enough). With this PR, it now uses ~3GB.

refs #1082
