### PR TITLE
fix(vite-tests): avoid crash when `packageJson.pnpm` is undefined

### DIFF
--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -44,6 +44,9 @@ await runCmdAndPipe(
 printTitle('# Updating package.json to link to local rolldown...');
 const packageJsonPath = path.resolve(REPO_PATH, 'package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+if (packageJson.pnpm === undefined) {
+  packageJson.pnpm = { overrides: {} }
+}
 for (const [name, value] of Object.entries(OVERRIDES)) {
   packageJson.pnpm.overrides[name] = value;
 }


### PR DESCRIPTION
See https://github.com/rolldown/rolldown/actions/runs/15874869223/job/44759946994