### PR TITLE
fix(rolldown_plugin_transform): don't load tsconfig for files in node_modules

### DIFF
--- a/crates/rolldown_plugin_transform/src/utils.rs
+++ b/crates/rolldown_plugin_transform/src/utils.rs
@@ -243,6 +243,11 @@ impl TransformPlugin {
 }
 
 fn find_tsconfig_json_for_file(path: &Path) -> Option<PathBuf> {
+  // don't load tsconfig for paths in node_modules like esbuild
+  if is_in_node_modules(path) {
+    return None;
+  }
+
   let mut dir = path.to_path_buf();
 
   loop {
@@ -256,6 +261,10 @@ fn find_tsconfig_json_for_file(path: &Path) -> Option<PathBuf> {
   }
 
   None
+}
+
+fn is_in_node_modules(id: &Path) -> bool {
+  id.components().any(|comp| comp.as_os_str() == "node_modules")
 }
 
 fn is_use_define_for_class_fields(target: Option<&str>) -> bool {


### PR DESCRIPTION
`tsconfig.json` should not be loaded for files in `node_modules`.
https://github.com/vitejs/vite/blob/37bdfc18f4c5bed053a38c5d717df33036acdd62/packages/vite/src/node/plugins/esbuild.ts#L127-L128
https://github.com/vitejs/vite/blob/37bdfc18f4c5bed053a38c5d717df33036acdd62/packages/vite/src/node/plugins/esbuild.ts#L495-L504
