### PR TITLE
chore(repo): make `pnpm lint-knip` part of `just lint-node`

### DIFF
--- a/justfile
+++ b/justfile
@@ -109,8 +109,6 @@ lint-rust:
 
 lint-node:
     pnpm lint-code
-
-lint-knip:
     pnpm lint-knip
 
 lint-repo:


### PR DESCRIPTION
Since `lint-knip` is a step that blocks CI, we should add it as part of `just roll` so we can check everything before pushing.