### PR TITLE
fix(plugin/vite-resolve): resolve glob side effects field correctly

### DIFF
--- a/crates/rolldown_common/src/types/package_json.rs
+++ b/crates/rolldown_common/src/types/package_json.rs
@@ -40,6 +40,7 @@ impl PackageJson {
     self.r#type.as_deref()
   }
 
+  /// * `module_path`: relative path to the module from `package.json` path
   pub fn check_side_effects_for(&self, module_path: &str) -> Option<bool> {
     let side_effects = self.side_effects.as_ref()?;
     // Is it necessary to convert module_path to relative path?

--- a/crates/rolldown_plugin_vite_resolve/src/resolver.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/resolver.rs
@@ -293,10 +293,14 @@ impl Resolver {
         let side_effects = result
           .package_json()
           .and_then(|pkg_json| {
+            // the glob expr is based on parent path of package.json, which is package path
+            // so we should use the relative path of the module to package path
+            let module_path_relative_to_package =
+              raw_path.as_path().relative(pkg_json.path.parent()?);
             self
               .package_json_cache
               .cached_package_json_side_effects(pkg_json)
-              .check_side_effects_for(&raw_path)
+              .check_side_effects_for(module_path_relative_to_package.to_str()?)
           })
           .map(
             |side_effects| {


### PR DESCRIPTION
`pkgJson.check_side_effects_for` should receive a relative path.

refs https://github.com/vitejs/rolldown-vite/issues/283
