### PR TITLE
perf(hmr): remove no-op `runtime.__toCommonJS` call

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -46,15 +46,6 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
           ret.extend(self.generate_declaration_of_module_namespace_object(
             &binding_name_for_namespace_object_ref,
           ));
-          // Add __esModule flag
-          ret.push(self.snippet.builder.statement_expression(
-            SPAN,
-            self.snippet.call_expr_with_arg_expr(
-              self.snippet.id_ref_expr("__rolldown_runtime__.__toCommonJS", SPAN),
-              self.snippet.id_ref_expr(&binding_name_for_namespace_object_ref, SPAN),
-              false,
-            ),
-          ));
 
           // { exports: namespace }
           ast::Argument::ObjectExpression(self.snippet.builder.alloc_object_expression(

--- a/crates/rolldown/src/module_finalizers/hmr.rs
+++ b/crates/rolldown/src/module_finalizers/hmr.rs
@@ -36,16 +36,6 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
         let binding_name_for_namespace_object_ref =
           self.canonical_name_for(self.ctx.module.namespace_object_ref);
 
-        // Add __esModule flag
-        ret.push(self.snippet.builder.statement_expression(
-          SPAN,
-          self.snippet.call_expr_with_arg_expr(
-            self.snippet.id_ref_expr("__rolldown_runtime__.__toCommonJS", SPAN),
-            self.snippet.id_ref_expr(binding_name_for_namespace_object_ref.as_str(), SPAN),
-            false,
-          ),
-        ));
-
         // { exports: namespace }
         ast::Argument::ObjectExpression(self.snippet.builder.alloc_object_expression(
           SPAN,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
@@ -20,7 +20,6 @@ var require_foo = __commonJS({ "foo.cjs"(exports, module) {
 //#region main.js
 var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.__toCommonJS(main_exports);
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 var import_foo;
 var init_main = __esm({ "main.js"() {

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -20,7 +20,6 @@ var require_lib = __commonJS({ "lib.js"(exports, module) {
 //#region main.js
 var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.__toCommonJS(main_exports);
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 var import_lib = __toESM(require_lib());
 assert.strictEqual(import_lib.a, 1);

--- a/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
@@ -11,7 +11,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 var foo_exports = {};
 __export(foo_exports, { foo: () => foo$1 });
 const foo_hot$1 = __rolldown_runtime__.createModuleHotContext("foo.mjs");
-__rolldown_runtime__.__toCommonJS(foo_exports);
 __rolldown_runtime__.registerModule("foo.mjs", { exports: foo_exports });
 const foo$1 = "foo";
 
@@ -20,7 +19,6 @@ const foo$1 = "foo";
 var foo_exports$1 = {};
 __export(foo_exports$1, { foo: () => foo });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo/index.mjs");
-__rolldown_runtime__.__toCommonJS(foo_exports$1);
 __rolldown_runtime__.registerModule("foo/index.mjs", { exports: foo_exports$1 });
 const foo = "foo";
 
@@ -28,7 +26,6 @@ const foo = "foo";
 //#region main.js
 var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.__toCommonJS(main_exports);
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 console.log(foo$1, foo);
 main_hot.accept(() => {});
@@ -44,7 +41,6 @@ var init_main_0 = __rolldown_runtime__.createEsmInitializer(function() {
 	try {
 		var ns_main = {};
 		__rolldown_runtime__.__export(ns_main, {});
-		__rolldown_runtime__.__toCommonJS(ns_main);
 		__rolldown_runtime__.registerModule("main.js", { exports: ns_main });
 		const hot_main = __rolldown_runtime__.createModuleHotContext("main.js");
 		var import_foo_0 = __rolldown_runtime__.loadExports("foo.mjs");

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -11,7 +11,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 var hmr_exports = {};
 __export(hmr_exports, { foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
-__rolldown_runtime__.__toCommonJS(hmr_exports);
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";
 text$1(".hmr", foo);
@@ -26,7 +25,6 @@ hmr_hot.accept((mod) => {
 //#region sub.js
 var sub_exports = {};
 const sub_hot = __rolldown_runtime__.createModuleHotContext("sub.js");
-__rolldown_runtime__.__toCommonJS(sub_exports);
 __rolldown_runtime__.registerModule("sub.js", { exports: sub_exports });
 text(".app", "hello");
 function text(el, text$2) {
@@ -37,7 +35,6 @@ function text(el, text$2) {
 //#region main.js
 var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.__toCommonJS(main_exports);
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 
 //#endregion
@@ -74,7 +71,6 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer(function() {
 	try {
 		var ns_hmr = {};
 		__rolldown_runtime__.__export(ns_hmr, { foo: () => foo });
-		__rolldown_runtime__.__toCommonJS(ns_hmr);
 		__rolldown_runtime__.registerModule("hmr.js", { exports: ns_hmr });
 		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
 		const foo = "hello";

--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
@@ -11,7 +11,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 var hmr_exports = {};
 __export(hmr_exports, { foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
-__rolldown_runtime__.__toCommonJS(hmr_exports);
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";
 hmr_hot.accept(() => {});
@@ -20,7 +19,6 @@ hmr_hot.accept(() => {});
 //#region main.js
 var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.__toCommonJS(main_exports);
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -19,7 +19,6 @@ var require_cjs = __commonJS({ "cjs.js"(exports, module) {
 var esm_exports = {};
 __export(esm_exports, { value: () => value });
 const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
-__rolldown_runtime__.__toCommonJS(esm_exports);
 __rolldown_runtime__.registerModule("esm.js", { exports: esm_exports });
 const value = "main";
 
@@ -27,7 +26,6 @@ const value = "main";
 //#region main.js
 var main_exports = {};
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.__toCommonJS(main_exports);
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 var import_cjs = __toESM(require_cjs());
 console.log(import_cjs, esm_exports);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4055,7 +4055,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-OC0Dohxp.js
+- main-!~{000}~.js => main-CDYdy_N3.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4689,7 +4689,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-BtKssRCj.js
+- main-!~{000}~.js => main-f9-6DsUZ.js
 
 # tests/rolldown/issues/4196
 
@@ -5382,11 +5382,11 @@ expression: output
 
 # tests/rolldown/topics/hmr/deconflict_import_bindings
 
-- main-!~{000}~.js => main-BwDR2gBS.js
+- main-!~{000}~.js => main-CIiI-ZVS.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-CbHBADwK.js
+- main-!~{000}~.js => main-BkkUJ-tm.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
@@ -5396,11 +5396,11 @@ expression: output
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-CArqQ-kU.js
+- main-!~{000}~.js => main-BFLlT2IV.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-BKyTMtgE.js
+- main-!~{000}~.js => main-CNQj63F-.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 


### PR DESCRIPTION
`__rolldown_runtime__.__toCommonJS(namespace);` was generated in the HMR code. But this call is no-op (the return value is not used).

```js
var __toCommonJS = mod => __copyProps(__defProp({}, '__esModule', { value: true }), mod)
var __copyProps = (to, from, except, desc) => {
  if (from && typeof from === 'object' || typeof from === 'function')
    for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
      key = keys[i]
      if (!__hasOwnProp.call(to, key) && key !== except)
        __defProp(to, key, { get: (k => from[k]).bind(null, key), enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable })
    }
  return to
}
var __defProp = Object.defineProperty
```

Also this call is slow because it copies all properties.

This seems to be added by https://github.com/rolldown/rolldown/pull/4461 but I'm not sure why this was added.
