### PR TITLE
perf(hmr): remove `console.debug` in `runtime.registerModule`

### DIFF
--- a/crates/rolldown/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown/src/runtime/runtime-extra-dev-common.js
@@ -24,7 +24,6 @@ class DevRuntime {
    * @param {{ exports: any }} module
    */
   registerModule(id, module) {
-    console.debug('Registering module', id, module);
     this.modules[id] = module
   }
   /**

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4055,7 +4055,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-CDYdy_N3.js
+- main-!~{000}~.js => main-C5VeU61G.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4689,7 +4689,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-f9-6DsUZ.js
+- main-!~{000}~.js => main-ystnxVR1.js
 
 # tests/rolldown/issues/4196
 
@@ -5382,25 +5382,25 @@ expression: output
 
 # tests/rolldown/topics/hmr/deconflict_import_bindings
 
-- main-!~{000}~.js => main-CIiI-ZVS.js
+- main-!~{000}~.js => main-C5k9LH1Q.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-BkkUJ-tm.js
+- main-!~{000}~.js => main-DVf294w-.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-BEsI0-Z_.js
-- index-!~{001}~.js => index-CgLD4SE9.js
-- chunk-!~{002}~.js => chunk-DTr7MmcB.js
+- entry-!~{000}~.js => entry-o8SXFCw-.js
+- index-!~{001}~.js => index-D-irBaZm.js
+- chunk-!~{002}~.js => chunk-GhOtMXFi.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-BFLlT2IV.js
+- main-!~{000}~.js => main-DuGcRdKw.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-CNQj63F-.js
+- main-!~{000}~.js => main-CRYNMszA.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 


### PR DESCRIPTION
`runtime.registerModule` is a hot path and `console.debug` is slow even if we filter it out in dev tools.
