### PR TITLE
feat(rolldown_plugin_vite_resolve): align subpath import resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2934,6 +2934,7 @@ dependencies = [
  "anyhow",
  "cow-utils",
  "itertools",
+ "rolldown_plugin",
  "rolldown_utils",
  "sugar_path",
 ]
@@ -2958,6 +2959,7 @@ dependencies = [
  "oxc_resolver",
  "rolldown_common",
  "rolldown_plugin",
+ "rolldown_plugin_utils",
  "rolldown_utils",
  "rustc-hash",
  "serde",

--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
@@ -36,6 +36,12 @@ pub struct BindingViteResolvePluginConfig {
   #[debug("{}", if finalize_bare_specifier.is_some() { "Some(<finalize_other_specifiers>)" } else { "None" })]
   #[napi(ts_type = "(resolvedId: string, rawId: string) => VoidNullable<string>")]
   pub finalize_other_specifiers: Option<JsCallback<FnArgs<(String, String)>, Option<String>>>,
+  #[debug("Some(<resolve_subpath_imports>)")]
+  #[napi(
+    ts_type = "(id: string, importer: string, isRequire: boolean, scan: boolean) => VoidNullable<string>"
+  )]
+  pub resolve_subpath_imports:
+    JsCallback<FnArgs<(String, Option<String>, bool, bool)>, Option<String>>,
 }
 
 impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
@@ -87,6 +93,19 @@ impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
                 .await
                 .map_err(anyhow::Error::from)
             })
+          })
+        },
+      ),
+      resolve_subpath_imports: Arc::new(
+        move |id: &str, importer: Option<&str>, is_require: bool, scan: bool| {
+          let resolve_fn = Arc::clone(&value.resolve_subpath_imports);
+          let id = id.to_owned();
+          let importer = importer.map(std::string::ToString::to_string);
+          Box::pin(async move {
+            resolve_fn
+              .invoke_async((id, importer, is_require, scan).into())
+              .await
+              .map_err(anyhow::Error::from)
           })
         },
       ),

--- a/crates/rolldown_plugin_utils/Cargo.toml
+++ b/crates/rolldown_plugin_utils/Cargo.toml
@@ -18,5 +18,6 @@ workspace = true
 anyhow = { workspace = true }
 cow-utils = { workspace = true }
 itertools = { workspace = true }
+rolldown_plugin = { workspace = true }
 rolldown_utils = { workspace = true }
 sugar_path = { workspace = true }

--- a/crates/rolldown_plugin_utils/src/constants.rs
+++ b/crates/rolldown_plugin_utils/src/constants.rs
@@ -1,0 +1,15 @@
+use rolldown_plugin::typedmap::TypedMapKey;
+
+#[derive(Hash, PartialEq, Eq)]
+pub struct ViteImportGlob;
+pub struct ViteImportGlobValue(bool);
+
+impl ViteImportGlobValue {
+  pub fn is_sub_imports_pattern(&self) -> bool {
+    self.0
+  }
+}
+
+impl TypedMapKey for ViteImportGlob {
+  type Value = ViteImportGlobValue;
+}

--- a/crates/rolldown_plugin_utils/src/lib.rs
+++ b/crates/rolldown_plugin_utils/src/lib.rs
@@ -5,6 +5,8 @@ mod join_url_segments;
 mod to_output_file_path_in_js;
 mod to_relative_runtime_path;
 
+pub mod constants;
+
 pub use check_public_file::check_public_file;
 pub use file_to_url::{FileToUrlEnv, file_to_url};
 pub use find_special_query::find_special_query;

--- a/crates/rolldown_plugin_vite_resolve/Cargo.toml
+++ b/crates/rolldown_plugin_vite_resolve/Cargo.toml
@@ -18,6 +18,7 @@ fast-glob = { workspace = true }
 oxc_resolver = { workspace = true, features = ["package_json_raw_json_api"] }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_plugin_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1917,6 +1917,7 @@ export interface BindingViteResolvePluginConfig {
   dedupe: Array<string>
   finalizeBareSpecifier?: (resolvedId: string, rawId: string, importer: string | null | undefined) => VoidNullable<string>
   finalizeOtherSpecifiers?: (resolvedId: string, rawId: string) => VoidNullable<string>
+  resolveSubpathImports: (id: string, importer: string, isRequire: boolean, scan: boolean) => VoidNullable<string>
 }
 
 export interface BindingViteResolvePluginResolveOptions {


### PR DESCRIPTION
Although `rolldown-vite` aligns partially with the js behavior through the [importGlobSubpathImportsResolvePlugin](https://github.com/vitejs/rolldown-vite/blob/rolldown-vite/packages/vite/src/node/plugins/resolve.ts#L451-L482), its logic is not fully consistent.  Additionally, the `custom` can only be passed between JS plugins or between native plugins — communication between JS and native plugins is not supported.

Therefore, this subpath import resolution logic needs to be moved into the native plugin to ensure correctness and compatibility.