### PR TITLE
feat(types): expose `ChunkingContext` type

### DIFF
--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -35,6 +35,7 @@ import type {
 import type {
   AddonFunction,
   ChunkFileNamesFunction,
+  ChunkingContext,
   GlobalsFunction,
   MinifyOptions,
   ModuleFormat,
@@ -106,6 +107,7 @@ export type {
   AsyncPluginHooks,
   BuildOptions,
   ChunkFileNamesFunction,
+  ChunkingContext,
   ConfigExport,
   CustomPluginOptions,
   DefineParallelPluginResult,

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -1,6 +1,5 @@
 import type { BindingMinifyOptions, PreRenderedChunk } from '../binding';
 import type { RolldownOutputPluginOption } from '../plugin';
-import type { ChunkingContext } from '../types/chunking-context';
 import type {
   SourcemapIgnoreListOption,
   SourcemapPathTransformOption,
@@ -34,6 +33,10 @@ export type AssetFileNamesFunction = (chunkInfo: PreRenderedAsset) => string;
 export type GlobalsFunction = (name: string) => string;
 
 export type MinifyOptions = BindingMinifyOptions;
+
+export interface ChunkingContext {
+  getModuleInfo(moduleId: string): ModuleInfo | null;
+}
 
 export interface OutputOptions {
   dir?: string;

--- a/packages/rolldown/src/types/chunking-context.ts
+++ b/packages/rolldown/src/types/chunking-context.ts
@@ -2,7 +2,7 @@ import type { BindingChunkingContext } from '../binding';
 import { transformModuleInfo } from '../utils/transform-module-info';
 import type { ModuleInfo } from './module-info';
 
-export class ChunkingContext {
+export class ChunkingContextImpl {
   constructor(private context: BindingChunkingContext) {}
   getModuleInfo(moduleId: string): ModuleInfo | null {
     const bindingInfo = this.context.getModuleInfo(moduleId);

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -1,6 +1,6 @@
 import type { BindingOutputOptions } from '../binding';
 import type { OutputOptions } from '../options/output-options';
-import { ChunkingContext } from '../types/chunking-context';
+import { ChunkingContextImpl } from '../types/chunking-context';
 import type { SourcemapIgnoreListOption } from '../types/misc';
 import { transformAssetSource } from './asset-source';
 import { unimplemented } from './misc';
@@ -202,7 +202,7 @@ function bindingifyAdvancedChunks(
       return {
         ...restGroup,
         name: typeof name === 'function'
-          ? (id, ctx) => name(id, new ChunkingContext(ctx))
+          ? (id, ctx) => name(id, new ChunkingContextImpl(ctx))
           : name,
       };
     }),


### PR DESCRIPTION
so that users can define the function outside the options object more easily.