### PR TITLE
feat: use same option object reference

### DIFF
--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -35,6 +35,7 @@ import type {
 import type {
   AddonFunction,
   ChunkFileNamesFunction,
+  ChunkingContext,
   GlobalsFunction,
   MinifyOptions,
   ModuleFormat,
@@ -106,6 +107,7 @@ export type {
   AsyncPluginHooks,
   BuildOptions,
   ChunkFileNamesFunction,
+  ChunkingContext,
   ConfigExport,
   CustomPluginOptions,
   DefineParallelPluginResult,

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -1,6 +1,5 @@
 import type { BindingMinifyOptions, PreRenderedChunk } from '../binding';
 import type { RolldownOutputPluginOption } from '../plugin';
-import type { ChunkingContext } from '../types/chunking-context';
 import type {
   SourcemapIgnoreListOption,
   SourcemapPathTransformOption,
@@ -34,6 +33,10 @@ export type AssetFileNamesFunction = (chunkInfo: PreRenderedAsset) => string;
 export type GlobalsFunction = (name: string) => string;
 
 export type MinifyOptions = BindingMinifyOptions;
+
+export interface ChunkingContext {
+  getModuleInfo(moduleId: string): ModuleInfo | null;
+}
 
 export interface OutputOptions {
   dir?: string;

--- a/packages/rolldown/src/parallel-plugin-worker.ts
+++ b/packages/rolldown/src/parallel-plugin-worker.ts
@@ -27,7 +27,7 @@ const { registryId, pluginInfos, threadNumber } = workerData as WorkerData;
             {} as InputOptions,
             {} as OutputOptions,
             // TODO need to find a way to share pluginContextData
-            new PluginContextData(),
+            new PluginContextData(() => {}, {} as OutputOptions, []),
             [],
             () => {},
             'info' as const,

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -7,7 +7,6 @@ import { normalizeHook } from '../utils/normalize-hook';
 
 import path from 'node:path';
 import { SYMBOL_FOR_RESOLVE_CALLER_THAT_SKIP_SELF } from '../constants/plugin-context';
-import { NormalizedInputOptionsImpl } from '../options/normalized-input-options';
 import {
   bindingifySourcemap,
   type ExistingRawSourceMap,
@@ -61,7 +60,7 @@ export function bindingifyBuildStart(
           args.logLevel,
           args.watchMode,
         ),
-        new NormalizedInputOptionsImpl(opts, args.onLog),
+        args.pluginContextData.getInputOptions(opts),
       );
     },
     meta: bindingifyPluginHookMeta(meta),

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -1,6 +1,4 @@
 import type { BindingHookFilter, BindingPluginOptions } from '../binding';
-import { NormalizedInputOptionsImpl } from '../options/normalized-input-options';
-import { NormalizedOutputOptionsImpl } from '../options/normalized-output-options';
 import { bindingifySourcemap } from '../types/sourcemap';
 import { normalizeErrors } from '../utils/error';
 import { normalizeHook } from '../utils/normalize-hook';
@@ -39,12 +37,8 @@ export function bindingifyRenderStart(
           args.logLevel,
           args.watchMode,
         ),
-        new NormalizedOutputOptionsImpl(
-          opts,
-          args.outputOptions,
-          args.normalizedOutputPlugins,
-        ),
-        new NormalizedInputOptionsImpl(opts, args.onLog),
+        args.pluginContextData.getOutputOptions(opts),
+        args.pluginContextData.getInputOptions(opts),
       );
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -87,11 +81,7 @@ export function bindingifyRenderChunk(
         ),
         code,
         transformRenderedChunk(chunk),
-        new NormalizedOutputOptionsImpl(
-          opts,
-          args.outputOptions,
-          args.normalizedOutputPlugins,
-        ),
+        args.pluginContextData.getOutputOptions(opts),
         args.pluginContextData.getRenderChunkMeta()!,
       );
 
@@ -200,11 +190,7 @@ export function bindingifyGenerateBundle(
       const output = transformToOutputBundle(context, bundle, changed);
       await handler.call(
         context,
-        new NormalizedOutputOptionsImpl(
-          opts,
-          args.outputOptions,
-          args.normalizedOutputPlugins,
-        ),
+        args.pluginContextData.getOutputOptions(opts),
         output,
         isWrite,
       );
@@ -241,11 +227,7 @@ export function bindingifyWriteBundle(
       const output = transformToOutputBundle(context, bundle, changed);
       await handler.call(
         context,
-        new NormalizedOutputOptionsImpl(
-          opts,
-          args.outputOptions,
-          args.normalizedOutputPlugins,
-        ),
+        args.pluginContextData.getOutputOptions(opts),
         output,
       );
       return collectChangedBundle(changed, output);

--- a/packages/rolldown/src/types/chunking-context.ts
+++ b/packages/rolldown/src/types/chunking-context.ts
@@ -2,7 +2,7 @@ import type { BindingChunkingContext } from '../binding';
 import { transformModuleInfo } from '../utils/transform-module-info';
 import type { ModuleInfo } from './module-info';
 
-export class ChunkingContext {
+export class ChunkingContextImpl {
   constructor(private context: BindingChunkingContext) {}
   getModuleInfo(moduleId: string): ModuleInfo | null {
     const bindingInfo = this.context.getModuleInfo(moduleId);

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -36,7 +36,11 @@ export function bindingifyInputOptions(
   logLevel: LogLevelOption,
   watchMode: boolean,
 ): BindingInputOptions {
-  const pluginContextData = new PluginContextData();
+  const pluginContextData = new PluginContextData(
+    onLog,
+    outputOptions,
+    normalizedOutputPlugins,
+  );
 
   const plugins = rawPlugins.map((plugin) => {
     if ('_parallel' in plugin) {

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -1,6 +1,6 @@
 import type { BindingOutputOptions } from '../binding';
 import type { OutputOptions } from '../options/output-options';
-import { ChunkingContext } from '../types/chunking-context';
+import { ChunkingContextImpl } from '../types/chunking-context';
 import type { SourcemapIgnoreListOption } from '../types/misc';
 import { transformAssetSource } from './asset-source';
 import { unimplemented } from './misc';
@@ -202,7 +202,7 @@ function bindingifyAdvancedChunks(
       return {
         ...restGroup,
         name: typeof name === 'function'
-          ? (id, ctx) => name(id, new ChunkingContext(ctx))
+          ? (id, ctx) => name(id, new ChunkingContextImpl(ctx))
           : name,
       };
     }),

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import type { TestConfig } from './src/types'
-import { InputOptions, OutputOptions, rolldown } from 'rolldown'
+import { InputOptions, rolldown } from 'rolldown'
 import nodePath from 'node:path'
 
 main()
@@ -81,17 +81,19 @@ function main() {
 }
 
 async function compileFixture(fixturePath: string, config: TestConfig) {
-  if (Array.isArray(config.config?.output)) {
-    throw new Error(
-      'The multiply output configure is not support at test runner',
-    )
-  }
-  let outputOptions = config.config?.output ?? {}
   const inputOptions: InputOptions = {
     input: 'main.js',
     cwd: fixturePath,
     ...config.config,
   }
   const build = await rolldown(inputOptions)
-  return await build.write(outputOptions as OutputOptions)
+  if (Array.isArray(config.config?.output)) {
+    const outputs = []
+    for (const output of config.config.output) {
+      outputs.push(await build.write(output))
+    }
+    return outputs
+  }
+  const outputOptions = config.config?.output ?? {}
+  return await build.write(outputOptions)
 }

--- a/packages/rolldown/tests/fixtures/plugin/render-start/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/render-start/_config.ts
@@ -1,11 +1,14 @@
 import { expect, vi } from 'vitest'
 import path from 'node:path'
 import { defineTest } from 'rolldown-tests'
+import type { NormalizedInputOptions } from 'rolldown'
 
 const entry = path.join(__dirname, './main.js')
 const entryFileNames = '[name]-render-start.js'
 
 const renderStartFn = vi.fn()
+
+let buildStartInputOptions: NormalizedInputOptions
 
 export default defineTest({
   config: {
@@ -20,8 +23,16 @@ export default defineTest({
           renderStartFn()
           expect(inputOptions.input).toStrictEqual([entry])
           expect(outputOptions.entryFileNames).toBe(entryFileNames)
+          // ensure same reference
+          expect(inputOptions).toBe(buildStartInputOptions)
         },
       },
+      {
+        name: 'test-plugin-save-build-start-input-options',
+        buildStart: (inputOptions) => {
+          buildStartInputOptions = inputOptions
+        },
+      }
     ],
   },
   afterTest: () => {

--- a/packages/rolldown/tests/fixtures/plugin/write-bundle-multiple/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/write-bundle-multiple/_config.ts
@@ -1,0 +1,35 @@
+import path from 'node:path'
+
+import { expect } from 'vitest'
+import { defineTest } from 'rolldown-tests'
+import type { InternalModuleFormat, NormalizedOutputOptions } from 'rolldown'
+
+const entry = path.join(__dirname, './main.js')
+
+let generateBundleOutputOptions: Partial<Record<InternalModuleFormat, NormalizedOutputOptions>> = {}
+
+export default defineTest({
+  config: {
+    input: entry,
+    plugins: [
+      {
+        name: 'test-plugin',
+        writeBundle: async (options) => {
+          expect(generateBundleOutputOptions[options.format]).not.toBeUndefined()
+          // ensure same reference
+          expect(options).toBe(generateBundleOutputOptions[options.format])
+        },
+      },
+      {
+        name: 'test-plugin-save-generate-bundle-output-options',
+        generateBundle: async (options) => {
+          generateBundleOutputOptions[options.format] = options
+        },
+      }
+    ],
+    output: [
+      { format: 'es' },
+      { format: 'cjs' }
+    ]
+  },
+})

--- a/packages/rolldown/tests/fixtures/plugin/write-bundle-multiple/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/write-bundle-multiple/main.js
@@ -1,0 +1,1 @@
+console.log()

--- a/packages/rolldown/tests/src/index.ts
+++ b/packages/rolldown/tests/src/index.ts
@@ -1,5 +1,8 @@
-import type { TestConfig } from './types'
+import type { OutputOptions } from 'rolldown'
+import type { TestConfig, WithoutValue } from './types'
 
-export function defineTest(testConfig: TestConfig): TestConfig {
+export function defineTest<OutputOpts extends WithoutValue | undefined | OutputOptions | OutputOptions[]>(
+  testConfig: TestConfig<OutputOpts>
+): TestConfig<OutputOpts> {
   return testConfig
 }

--- a/packages/rolldown/tests/src/types.ts
+++ b/packages/rolldown/tests/src/types.ts
@@ -1,12 +1,25 @@
-import type { RolldownOptions, RolldownOutput } from 'rolldown'
+import type { OutputOptions, RolldownOptions, RolldownOutput } from 'rolldown'
 
 export type TestKind = 'default' | 'compose-js-plugin'
-export interface TestConfig {
+
+export type WithoutValue = 0
+type OutputOptsToOutputInner<OutputOpts extends undefined | OutputOptions | OutputOptions[]> =
+  OutputOpts extends OutputOptions[]
+    ? OutputOpts extends undefined | OutputOptions
+      ? RolldownOutput[] | RolldownOutput
+      : RolldownOutput[]
+    : RolldownOutput
+type OutputOptsToOutput<OutputOpts extends WithoutValue | undefined | OutputOptions | OutputOptions[]> =
+  [WithoutValue] extends [OutputOpts]
+    ? RolldownOutput
+    : OutputOptsToOutputInner<Exclude<OutputOpts, WithoutValue>>
+
+export interface TestConfig<OutputOpts extends WithoutValue | undefined | OutputOptions | OutputOptions[] = undefined | OutputOptions | OutputOptions[]> {
   skip?: boolean
   skipComposingJsPlugin?: boolean
-  config?: RolldownOptions
+  config?: RolldownOptions & { output?: OutputOpts }
   beforeTest?: (testKind: TestKind) => Promise<void> | void
-  afterTest?: (output: RolldownOutput) => Promise<void> | void
+  afterTest?: (output: OutputOptsToOutput<OutputOpts>) => Promise<void> | void
   catchError?: (err: unknown) => Promise<void> | void
 }
 


### PR DESCRIPTION
Use the same option object reference so that plugins can store information for each output.
```ts
const data = new WeakMap<NormalizedOutputOptions, Something>()
const foo = {
  name: 'foo',
  renderChunk(code, chunk, opts) { data.set(opts, something) },
  generateBundle(opts) { console.log(data.get(opts)) }
}
```
