### PR TITLE
chore: remove unnecessary `skipComposingJsPlugin`

### DIFF
--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/_config.ts
@@ -3,7 +3,6 @@ import { defineTest } from 'rolldown-tests'
 import { buildImportAnalysisPlugin } from 'rolldown/experimental'
 
 export default defineTest({
-  skipComposingJsPlugin: true,
   config: {
     input: './main.js',
     plugins: [

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/check-helper-inserted/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/check-helper-inserted/_config.ts
@@ -2,7 +2,6 @@ import { defineTest } from 'rolldown-tests'
 import { buildImportAnalysisPlugin } from 'rolldown/experimental'
 
 export default defineTest({
-  skipComposingJsPlugin: true,
   config: {
     input: './main.js',
     plugins: [

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/complex-syntax/_config.ts
@@ -3,7 +3,6 @@ import { defineTest } from 'rolldown-tests'
 import { buildImportAnalysisPlugin } from 'rolldown/experimental'
 
 export default defineTest({
-  skipComposingJsPlugin: true,
   config: {
     input: './main.js',
     plugins: [

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/render-built-url/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/render-built-url/_config.ts
@@ -3,7 +3,6 @@ import { defineTest } from 'rolldown-tests'
 import { buildImportAnalysisPlugin } from 'rolldown/experimental'
 
 export default defineTest({
-  skipComposingJsPlugin: true,
   config: {
     input: './main.js',
     plugins: [

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-chunk/_config.ts
@@ -8,7 +8,6 @@ const emittedChunkPreliminaryFilenames: string[] = [],
   emittedChunkFilenames: string[] = []
 
 export default defineTest({
-  skipComposingJsPlugin: true,
   config: {
     output: {
       entryFileNames: '[name].[hash].js',

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file/_config.ts
@@ -10,7 +10,6 @@ let referenceId: string
 const ORIGINAL_FILE_NAME = 'original.txt'
 
 export default defineTest({
-  skipComposingJsPlugin: true,
   config: {
     output: {
       assetFileNames: '[name]-[hash].[ext]',

--- a/packages/rolldown/tests/fixtures/plugin/output-plugins/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/output-plugins/_config.ts
@@ -7,7 +7,6 @@ const renderStartFn = vi.fn()
 const onLogFn = vi.fn()
 
 export default defineTest({
-  skipComposingJsPlugin: true, // Here mutate the test config at non-skipComposingJsPlugin test will be next skipComposingJsPlugin test failed.
   config: {
     output: {
       plugins: [

--- a/packages/rolldown/tests/fixtures/plugin/plugin-order/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/plugin-order/_config.ts
@@ -70,7 +70,6 @@ export default defineTest({
       },
     ],
   },
-  skipComposingJsPlugin: true,
   afterTest: () => {
     for (const hook of hooks) {
       expect(calledHooks[hook]).toStrictEqual([

--- a/packages/rolldown/tests/fixtures/plugin/render-chunk/filter/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/render-chunk/filter/_config.ts
@@ -4,7 +4,6 @@ import { defineTest } from 'rolldown-tests'
 const renderChunkFn = vi.fn()
 
 export default defineTest({
-  skipComposingJsPlugin: true,
   config: {
     plugins: [
       {

--- a/packages/rolldown/tests/fixtures/plugin/resolve-id/filter/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/resolve-id/filter/_config.ts
@@ -4,8 +4,6 @@ import { expect, vi } from 'vitest'
 const resolveIdFn = vi.fn()
 
 export default defineTest({
-  beforeTest() {},
-  skipComposingJsPlugin: true,
   config: {
     input: './main.js',
     plugins: [

--- a/packages/rolldown/tests/fixtures/plugin/transform/filter/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/filter/_config.ts
@@ -6,7 +6,6 @@ const transformFn2 = vi.fn()
 const transformFn3 = vi.fn()
 
 export default defineTest({
-  skipComposingJsPlugin: true,
   config: {
     plugins: [
       {

--- a/packages/rolldown/tests/fixtures/plugin/transform/with-filter-nested/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/with-filter-nested/_config.ts
@@ -37,7 +37,6 @@ const nestedPlugin: RolldownPluginOption = [
 ];
 
 export default defineTest({
-	skipComposingJsPlugin: true,
 	config: {
 		// Without this override, the transform function will be called 9 times
 		plugins: [

--- a/packages/rolldown/tests/fixtures/plugin/transform/with-filter/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/with-filter/_config.ts
@@ -7,7 +7,6 @@ const transformFn2 = vi.fn();
 const transformFn3 = vi.fn();
 
 export default defineTest({
-	skipComposingJsPlugin: true,
 	config: {
 		plugins: [
 			withFilter(

--- a/packages/rolldown/tests/fixtures/plugin/transform/without-sourcemap/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/without-sourcemap/_config.ts
@@ -8,7 +8,6 @@ import {
 import { SourceMapConsumer } from 'source-map'
 
 export default defineTest({
-  skipComposingJsPlugin: true,
   config: {
     plugins: [
       {

--- a/packages/rolldown/tests/src/types.ts
+++ b/packages/rolldown/tests/src/types.ts
@@ -14,7 +14,6 @@ type OutputOptsToOutput<OutputOpts extends WithoutValue | undefined | OutputOpti
 
 export interface TestConfig<OutputOpts extends WithoutValue | undefined | OutputOptions | OutputOptions[] = undefined | OutputOptions | OutputOptions[]> {
   skip?: boolean
-  skipComposingJsPlugin?: boolean
   config?: RolldownOptions & { output?: OutputOpts }
   beforeTest?: () => Promise<void> | void
   afterTest?: (output: OutputOptsToOutput<OutputOpts>) => Promise<void> | void


### PR DESCRIPTION
Could you search the codebase with `skipComposingJsPlugin` and remove them?

_Originally posted by @hyf0 in https://github.com/rolldown/rolldown/pull/5122#pullrequestreview-2973432683_
            