### PR TITLE
fix: `options.jsx` is ignored when `options.transform` is set

### DIFF
--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -7,7 +7,8 @@ const INVALID_LOG_POSITION = 'INVALID_LOG_POSITION',
   INPUT_HOOK_IN_OUTPUT_PLUGIN = 'INPUT_HOOK_IN_OUTPUT_PLUGIN',
   CYCLE_LOADING = 'CYCLE_LOADING',
   MULTIPLY_NOTIFY_OPTION = 'MULTIPLY_NOTIFY_OPTION',
-  PARSE_ERROR = 'PARSE_ERROR';
+  PARSE_ERROR = 'PARSE_ERROR',
+  DUPLICATE_JSX_CONFIG = 'DUPLICATE_JSX_CONFIG';
 
 export function logParseError(message: string): RollupLog {
   return {
@@ -51,6 +52,14 @@ export function logMultiplyNotifyOption(): RollupLog {
     code: MULTIPLY_NOTIFY_OPTION,
     message:
       `Found multiply notify option at watch options, using first one to start notify watcher.`,
+  };
+}
+
+export function logDuplicateJsxConfig(): RollupLog {
+  return {
+    code: DUPLICATE_JSX_CONFIG,
+    message:
+      'Both `options.jsx` and `options.transform.jsx` are set so `options.jsx` is ignored',
   };
 }
 

--- a/packages/rolldown/tests/fixtures/jsx/duplicate-with-transform/_config.ts
+++ b/packages/rolldown/tests/fixtures/jsx/duplicate-with-transform/_config.ts
@@ -1,0 +1,26 @@
+import { expect, vi } from 'vitest'
+import { defineTest } from 'rolldown-tests'
+import { getOutputChunk } from 'rolldown-tests/utils'
+
+const fn = vi.fn()
+export default defineTest({
+  config: {
+    input: 'main.jsx',
+    jsx: {
+      mode: 'classic',
+      factory: 'h',
+      fragment: 'h.f',
+    },
+    transform: {
+      jsx: 'preserve'
+    },
+    onwarn(warning) {
+      fn()
+      expect(warning.code).toBe('DUPLICATE_JSX_CONFIG')
+    }
+  },
+  afterTest(output) {
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(getOutputChunk(output)[0].code).contain('<><div /></>')
+  },
+})

--- a/packages/rolldown/tests/fixtures/jsx/duplicate-with-transform/main.jsx
+++ b/packages/rolldown/tests/fixtures/jsx/duplicate-with-transform/main.jsx
@@ -1,0 +1,5 @@
+const Component = () => {
+    return <><div /></>
+};
+
+export { Component };


### PR DESCRIPTION
closes #5136