### PR TITLE
fix: use canonical runtime time for `__name`

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -240,7 +240,11 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
     // TODO: perf it
     for (stmt_index, original_name, new_name) in self.ctx.keep_name_statement_to_insert.iter().rev()
     {
-      it.insert(*stmt_index, self.snippet.keep_name_call_expr_stmt(original_name, new_name));
+      let finalized_name = self.snippet.atom(self.canonical_name_for_runtime("__name"));
+      it.insert(
+        *stmt_index,
+        self.snippet.keep_name_call_expr_stmt(original_name, new_name, finalized_name.as_str()),
+      );
     }
     self.ctx.cur_stmt_index = previous_stmt_index;
     self.ctx.keep_name_statement_to_insert = previous_keep_name_statement;

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1246,7 +1246,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     }
     let (original_name, _) = self.get_conflicted_info(id.as_ref()?)?;
     let original_name: Rstr = original_name.into();
-    Some(self.snippet.static_block_keep_name_helper(&original_name))
+    let canonical_name = self.snippet.atom(self.canonical_name_for_runtime("__name"));
+    Some(self.snippet.static_block_keep_name_helper(&original_name, canonical_name.as_str()))
   }
 
   fn try_rewrite_import_expression(&self, node: &mut ast::Expression<'ast>) -> bool {

--- a/crates/rolldown/tests/rolldown/issues/5139/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/5139/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "keepNames": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/5139/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/5139/_test.mjs
@@ -1,0 +1,14 @@
+import {Foo, Bar, baz, b, bar, foo } from './dist/main.js'
+import assert from 'node:assert'
+
+
+assert.equal(Foo.name, 'Foo');
+assert.equal(Bar.name, 'Foo');
+
+assert.equal(baz.name, 'baz');
+assert.equal(b.name, 'baz');
+
+assert.equal(foo.name, 'foo');
+assert.equal(bar.name, 'foo');
+
+

--- a/crates/rolldown/tests/rolldown/issues/5139/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5139/artifacts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+
+//#region foo.js
+var Foo = class {};
+function foo() {}
+const baz = function() {};
+function __name() {}
+__name();
+
+//#endregion
+//#region main.js
+var Foo$1 = class {
+	static {
+		__name$1(this, "Foo");
+	}
+};
+function foo$1() {}
+__name$1(foo$1, "foo");
+const baz$1 = function() {};
+__name$1(baz$1, "baz");
+
+//#endregion
+export { Foo as Bar, Foo$1 as Foo, baz as b, foo as bar, baz$1 as baz, foo$1 as foo };
+```

--- a/crates/rolldown/tests/rolldown/issues/5139/foo.js
+++ b/crates/rolldown/tests/rolldown/issues/5139/foo.js
@@ -1,0 +1,10 @@
+export class Foo {}
+export function foo() {}
+
+export const baz = function() {
+
+}
+
+function __name() {}
+// rolldown to deconflict `__name` function
+__name();

--- a/crates/rolldown/tests/rolldown/issues/5139/main.js
+++ b/crates/rolldown/tests/rolldown/issues/5139/main.js
@@ -1,0 +1,7 @@
+import { Foo as Bar, foo as bar, baz as b } from "./foo.js";
+
+export class Foo {}
+export function foo() {}
+export const baz = function() {};
+
+export { Bar, bar, b };

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4737,6 +4737,10 @@ expression: output
 
 - main-!~{000}~.js => main-BQQtZSou.js
 
+# tests/rolldown/issues/5139
+
+- main-!~{000}~.js => main-_kxx8NhO.js
+
 # tests/rolldown/misc/ambiguous_star_export
 
 - main-!~{000}~.js => main-Brk4weCb.js

--- a/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
@@ -752,12 +752,13 @@ impl<'ast> AstSnippet<'ast> {
     &self,
     original_name: PassedStr,
     new_name: PassedStr,
+    canonical_runtime_name: PassedStr<'ast>,
   ) -> Statement<'ast> {
     self.builder.statement_expression(
       SPAN,
       self.builder.expression_call(
         SPAN,
-        self.builder.expression_identifier(SPAN, "__name"),
+        self.builder.expression_identifier(SPAN, canonical_runtime_name),
         NONE,
         {
           let mut items = self.builder.vec_with_capacity(2);
@@ -775,14 +776,18 @@ impl<'ast> AstSnippet<'ast> {
     )
   }
 
-  pub fn static_block_keep_name_helper(&self, name: PassedStr) -> ClassElement<'ast> {
+  pub fn static_block_keep_name_helper(
+    &self,
+    name: PassedStr,
+    canonical_runtime_name: PassedStr<'ast>,
+  ) -> ClassElement<'ast> {
     self.builder.class_element_static_block(
       SPAN,
       self.builder.vec1(self.builder.statement_expression(
         SPAN,
         self.builder.expression_call(
           SPAN,
-          self.builder.expression_identifier(SPAN, "__name"),
+          self.builder.expression_identifier(SPAN, canonical_runtime_name),
           NONE,
           {
             let mut items = self.builder.vec_with_capacity(2);


### PR DESCRIPTION
closed #5139