### PR TITLE
refactor(rust): isolate mutations on assets data

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -226,6 +226,7 @@ impl Generator for EcmaGenerator {
           debug_id: 0,
           imports: vec![],
           dynamic_imports: vec![],
+          sourcemap_filename: None,
         }),
         augment_chunk_hash: None,
         file_dir: file_dir.to_path_buf(),

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -3,10 +3,15 @@ use std::{hash::Hash, mem};
 use arcstr::ArcStr;
 use itertools::Itertools;
 use oxc_index::{IndexVec, index_vec};
-use rolldown_common::{HashCharacters, InsChunkIdx, InstantiationKind, StrOrBytes};
+use rolldown_common::{
+  Asset, HashCharacters, InsChunkIdx, InstantiationKind, NormalizedBundlerOptions, SourceMapType,
+  StrOrBytes,
+};
+use rolldown_error::BuildResult;
 #[cfg(not(target_family = "wasm"))]
 use rolldown_utils::rayon::IndexedParallelIterator;
 use rolldown_utils::{
+  concat_string,
   hash_placeholder::{
     extract_hash_placeholders, hash_placeholder_left_finder, replace_placeholder_with_hash,
   },
@@ -21,19 +26,21 @@ use xxhash_rust::xxh3::Xxh3;
 
 use crate::{
   chunk_graph::ChunkGraph,
-  stages::link_stage::LinkStageOutput,
+  stages::{generate_stage::GenerateStage, link_stage::LinkStageOutput},
   type_alias::{AssetVec, IndexChunkToInstances, IndexInstantiatedChunks},
+  utils::process_code_and_sourcemap::process_code_and_sourcemap,
 };
 
 #[allow(clippy::too_many_lines)]
 #[tracing::instrument(level = "debug", skip_all)]
-pub fn finalize_assets(
+pub async fn finalize_assets(
   chunk_graph: &ChunkGraph,
   link_output: &LinkStageOutput,
   index_instantiated_chunks: IndexInstantiatedChunks,
   index_chunk_to_instances: &IndexChunkToInstances,
   hash_characters: HashCharacters,
-) -> AssetVec {
+  options: &NormalizedBundlerOptions,
+) -> BuildResult<AssetVec> {
   let finder = hash_placeholder_left_finder();
 
   let ins_chunk_idx_by_placeholder = index_instantiated_chunks
@@ -184,7 +191,93 @@ pub fn finalize_assets(
     }
   });
 
-  assets
+  GenerateStage::minify_assets(options, &mut assets)?;
+
+  // apply sourcemap related logic
+
+  let mut derived_assets = vec![];
+
+  for asset in &mut assets {
+    match &mut asset.meta {
+      InstantiationKind::Ecma(ecma_meta) => {
+        let asset_code = mem::take(&mut asset.content);
+        let mut code = asset_code.try_into_string()?;
+        if let Some(map) = asset.map.as_mut() {
+          if let Some(sourcemap_asset) = process_code_and_sourcemap(
+            options,
+            &mut code,
+            map,
+            &asset.file_dir,
+            asset.filename.as_str(),
+            ecma_meta.debug_id,
+            /*is_css*/ false,
+          )
+          .await?
+          {
+            derived_assets.push(Asset {
+              originate_from: asset.originate_from,
+              content: sourcemap_asset.source,
+              filename: sourcemap_asset.filename.clone(),
+              map: None,
+              meta: InstantiationKind::Sourcemap(Box::new(rolldown_common::SourcemapAssetMeta {
+                names: sourcemap_asset.names,
+                original_file_names: sourcemap_asset.original_file_names,
+              })),
+              augment_chunk_hash: None,
+              // FIXME:
+              file_dir: asset.file_dir.clone(),
+              preliminary_filename: asset.preliminary_filename.clone(),
+            });
+          }
+        }
+
+        let sourcemap_filename = if matches!(options.sourcemap, Some(SourceMapType::Inline) | None)
+        {
+          None
+        } else {
+          Some(concat_string!(asset.filename, ".map"))
+        };
+        ecma_meta.sourcemap_filename = sourcemap_filename;
+        asset.content = code.into();
+      }
+      InstantiationKind::Css(css_meta) => {
+        let asset_code = mem::take(&mut asset.content);
+        let mut code = asset_code.try_into_string()?;
+        if let Some(map) = asset.map.as_mut() {
+          if let Some(sourcemap_asset) = process_code_and_sourcemap(
+            options,
+            &mut code,
+            map,
+            &asset.file_dir,
+            asset.filename.as_str(),
+            css_meta.debug_id,
+            /*is_css*/ true,
+          )
+          .await?
+          {
+            derived_assets.push(Asset {
+              originate_from: asset.originate_from,
+              content: sourcemap_asset.source,
+              filename: sourcemap_asset.filename.clone(),
+              map: None,
+              meta: InstantiationKind::None,
+              augment_chunk_hash: None,
+              // FIXME:
+              file_dir: asset.file_dir.clone(),
+              preliminary_filename: asset.preliminary_filename.clone(),
+            });
+          }
+        }
+
+        asset.content = code.into();
+      }
+      InstantiationKind::None | InstantiationKind::Sourcemap(_) => {}
+    }
+  }
+
+  assets.extend(derived_assets);
+
+  Ok(assets)
 }
 
 fn collect_transitive_dependencies(

--- a/crates/rolldown/src/utils/process_code_and_sourcemap.rs
+++ b/crates/rolldown/src/utils/process_code_and_sourcemap.rs
@@ -1,18 +1,16 @@
 use std::path::Path;
 
 use oxc::ast::CommentKind;
-use rolldown_common::{OutputAsset, SourceMapType};
+use rolldown_common::{NormalizedBundlerOptions, OutputAsset, SourceMapType};
 use rolldown_error::BuildResult;
 use rolldown_sourcemap::SourceMap;
 use sugar_path::SugarPath;
-
-use crate::SharedOptions;
 
 use super::uuid::uuid_v4_string_from_u128;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn process_code_and_sourcemap(
-  options: &SharedOptions,
+  options: &NormalizedBundlerOptions,
   code: &mut String,
   map: &mut SourceMap,
   file_dir: &Path,

--- a/crates/rolldown_common/src/ecmascript/ecma_asset_meta.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_asset_meta.rs
@@ -12,4 +12,5 @@ pub struct EcmaAssetMeta {
   // The updated fields of rendered_chunk after the final render
   pub imports: Vec<ArcStr>,
   pub dynamic_imports: Vec<ArcStr>,
+  pub sourcemap_filename: Option<String>,
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
@@ -7,7 +7,7 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::Deserialize;
 
-use crate::{OutputFormat, SharedNormalizedBundlerOptions};
+use crate::{NormalizedBundlerOptions, OutputFormat};
 
 #[derive(Debug, Clone)]
 #[cfg_attr(
@@ -88,7 +88,7 @@ pub struct MinifyOptionsObject {
 impl MinifyOptionsObject {
   pub fn to_oxc_minifier_options(
     &self,
-    option: &SharedNormalizedBundlerOptions,
+    option: &NormalizedBundlerOptions,
   ) -> oxc::minifier::MinifierOptions {
     let keep_names = option.keep_names;
     oxc::minifier::MinifierOptions {

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -106,7 +106,7 @@ pub use crate::{
   },
   type_aliases::{MemberExprRefResolutionMap, SharedModuleInfoDashMap},
   types::asset::Asset,
-  types::asset_meta::InstantiationKind,
+  types::asset_meta::{InstantiationKind, SourcemapAssetMeta},
   types::ast_scope_idx::AstScopeIdx,
   types::ast_scopes::AstScopes,
   types::bundler_file_system::BundlerFileSystem,

--- a/crates/rolldown_common/src/types/asset_meta.rs
+++ b/crates/rolldown_common/src/types/asset_meta.rs
@@ -5,6 +5,7 @@ use crate::{EcmaAssetMeta, css::css_asset_meta::CssAssetMeta};
 pub enum InstantiationKind {
   Ecma(Box<EcmaAssetMeta>),
   Css(Box<CssAssetMeta>),
+  Sourcemap(Box<SourcemapAssetMeta>),
   // Using Variant `None` instead of `Option<AssetMeta>` to make it friendly to use pattern matching.
   None,
 }
@@ -19,4 +20,10 @@ impl From<CssAssetMeta> for InstantiationKind {
   fn from(rendered_chunk: CssAssetMeta) -> Self {
     InstantiationKind::Css(Box::new(rendered_chunk))
   }
+}
+
+#[derive(Debug)]
+pub struct SourcemapAssetMeta {
+  pub names: Vec<String>,
+  pub original_file_names: Vec<String>,
 }


### PR DESCRIPTION
This PR contains two purposes:

1. The oringal code will mutate the `asset.content` during transforming `Asset` to `Output`. It's not an ideal logic, we want this step to be pure converting option without any mutation.
2. Due to `1.`, the asset data we emitted to devtool are not the final data. This causes some inconsistency, which we don't want this to happen.