### PR TITLE
refactor(rust): remove special fields of `Asset`

### DIFF
--- a/crates/rolldown/src/asset/asset_generator.rs
+++ b/crates/rolldown/src/asset/asset_generator.rs
@@ -24,16 +24,13 @@ impl Generator for AssetGenerator {
       let asset_view = asset_module.asset_view.unpack_ref();
       let preliminary_filename =
         ctx.chunk.asset_preliminary_filenames.get(&asset_module.idx).unpack();
-      let file_path =
-        ctx.options.cwd.as_path().join(&ctx.options.out_dir).join(preliminary_filename.as_str());
-      let file_dir = file_path.parent().expect("chunk file name should have a parent");
+
       instantiated_chunks.push(InstantiatedChunk {
         originate_from: ctx.chunk_idx,
         content: StrOrBytes::Bytes(asset_view.source.to_vec()),
         map: None,
         kind: InstantiationKind::None,
         augment_chunk_hash: None,
-        file_dir: file_dir.to_path_buf(),
         preliminary_filename: preliminary_filename.clone(),
       });
     }

--- a/crates/rolldown/src/css/css_generator.rs
+++ b/crates/rolldown/src/css/css_generator.rs
@@ -76,6 +76,12 @@ impl Generator for CssGenerator {
         .expect("should have preliminary_filename")
         .clone(),
       debug_id: 0,
+      file_dir: file_dir.to_path_buf(),
+      preliminary_filename: ctx
+        .chunk
+        .css_preliminary_filename
+        .clone()
+        .expect("should have preliminary filename"),
     };
 
     Ok(Ok(GenerateOutput {
@@ -85,7 +91,6 @@ impl Generator for CssGenerator {
         map,
         kind: InstantiationKind::from(css_asset_meta),
         augment_chunk_hash: None,
-        file_dir: file_dir.to_path_buf(),
         preliminary_filename: ctx
           .chunk
           .css_preliminary_filename

--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -226,15 +226,20 @@ impl Generator for EcmaGenerator {
           debug_id: 0,
           imports: vec![],
           dynamic_imports: vec![],
+          file_dir: file_dir.to_path_buf(),
           sourcemap_filename: None,
+          preliminary_filename: ctx
+            .chunk
+            .preliminary_filename
+            .clone()
+            .expect("should have preliminary filename"),
         }),
-        augment_chunk_hash: None,
-        file_dir: file_dir.to_path_buf(),
         preliminary_filename: ctx
           .chunk
           .preliminary_filename
           .clone()
           .expect("should have preliminary filename"),
+        augment_chunk_hash: None,
       }],
       warnings: std::mem::take(&mut ctx.warnings),
     }))

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -63,10 +63,7 @@ impl GenerateStage<'_> {
 
     let mut output = Vec::with_capacity(assets.len());
     let mut output_assets: Vec<Output> = vec![];
-    for Asset {
-      map, meta: rendered_chunk, content: code, preliminary_filename, filename, ..
-    } in assets
-    {
+    for Asset { map, meta: rendered_chunk, content: code, filename, .. } in assets {
       match rendered_chunk {
         InstantiationKind::Ecma(ecma_meta) => {
           let code = code.try_into_string()?;
@@ -85,7 +82,7 @@ impl GenerateStage<'_> {
             dynamic_imports: ecma_meta.dynamic_imports,
             map,
             sourcemap_filename: ecma_meta.sourcemap_filename,
-            preliminary_filename: preliminary_filename.to_string(),
+            preliminary_filename: ecma_meta.preliminary_filename.to_string(),
           })));
         }
         InstantiationKind::Css(_css_meta) => {

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -209,7 +209,7 @@ pub async fn finalize_assets(
             options,
             &mut code,
             map,
-            &asset.file_dir,
+            &ecma_meta.file_dir,
             asset.filename.as_str(),
             ecma_meta.debug_id,
             /*is_css*/ false,
@@ -225,10 +225,6 @@ pub async fn finalize_assets(
                 names: sourcemap_asset.names,
                 original_file_names: sourcemap_asset.original_file_names,
               })),
-              augment_chunk_hash: None,
-              // FIXME:
-              file_dir: asset.file_dir.clone(),
-              preliminary_filename: asset.preliminary_filename.clone(),
             });
           }
         }
@@ -250,7 +246,7 @@ pub async fn finalize_assets(
             options,
             &mut code,
             map,
-            &asset.file_dir,
+            &css_meta.file_dir,
             asset.filename.as_str(),
             css_meta.debug_id,
             /*is_css*/ true,
@@ -263,10 +259,6 @@ pub async fn finalize_assets(
               filename: sourcemap_asset.filename.clone(),
               map: None,
               meta: InstantiationKind::None,
-              augment_chunk_hash: None,
-              // FIXME:
-              file_dir: asset.file_dir.clone(),
-              preliminary_filename: asset.preliminary_filename.clone(),
             });
           }
         }

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -167,8 +167,10 @@ pub async fn finalize_assets(
     assets.iter().map(|ins_chunk| ins_chunk.filename.clone()).collect::<Vec<_>>().into();
 
   assets.par_iter_mut().for_each(|ins_chunk| {
-    if let InstantiationKind::Ecma(ecma_meta) = &mut ins_chunk.meta {
-      let chunk = &chunk_graph.chunk_table[ins_chunk.originate_from];
+    if let (InstantiationKind::Ecma(ecma_meta), Some(originate_from)) =
+      (&mut ins_chunk.meta, ins_chunk.originate_from)
+    {
+      let chunk = &chunk_graph.chunk_table[originate_from];
       ecma_meta.imports = chunk
         .cross_chunk_imports
         .iter()
@@ -215,7 +217,7 @@ pub async fn finalize_assets(
           .await?
           {
             derived_assets.push(Asset {
-              originate_from: asset.originate_from,
+              originate_from: None,
               content: sourcemap_asset.source,
               filename: sourcemap_asset.filename.clone(),
               map: None,
@@ -256,7 +258,7 @@ pub async fn finalize_assets(
           .await?
           {
             derived_assets.push(Asset {
-              originate_from: asset.originate_from,
+              originate_from: None,
               content: sourcemap_asset.source,
               filename: sourcemap_asset.filename.clone(),
               map: None,

--- a/crates/rolldown_common/src/css/css_asset_meta.rs
+++ b/crates/rolldown_common/src/css/css_asset_meta.rs
@@ -1,7 +1,13 @@
+use std::path::PathBuf;
+
 use arcstr::ArcStr;
+
+use crate::PreliminaryFilename;
 
 #[derive(Debug)]
 pub struct CssAssetMeta {
   pub filename: ArcStr,
   pub debug_id: u128,
+  pub file_dir: PathBuf,
+  pub preliminary_filename: PreliminaryFilename,
 }

--- a/crates/rolldown_common/src/ecmascript/ecma_asset_meta.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_asset_meta.rs
@@ -1,8 +1,8 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use arcstr::ArcStr;
 
-use crate::RollupRenderedChunk;
+use crate::{PreliminaryFilename, RollupRenderedChunk};
 
 #[derive(Debug)]
 
@@ -13,4 +13,6 @@ pub struct EcmaAssetMeta {
   pub imports: Vec<ArcStr>,
   pub dynamic_imports: Vec<ArcStr>,
   pub sourcemap_filename: Option<String>,
+  pub file_dir: PathBuf,
+  pub preliminary_filename: PreliminaryFilename,
 }

--- a/crates/rolldown_common/src/types/asset.rs
+++ b/crates/rolldown_common/src/types/asset.rs
@@ -8,7 +8,14 @@ use crate::{ChunkIdx, InstantiationKind, PreliminaryFilename, StrOrBytes};
 #[derive(Debug)]
 /// Assets is final output of the bundling process. Inputs -> Modules -> Chunks -> Assets
 pub struct Asset {
-  pub originate_from: ChunkIdx,
+  /// This field indicates the chunk that this asset originates from.
+  /// A chunk might produce multiple assets, for example, a chunk contains [index.js, index.css, icon.png],
+  /// it will produce 3 assets: index.js, index.css, icon.png.
+  /// We think these 3 assets originate from that chunk.
+  ///
+  /// Assets could also be produced without chunks, for example, derived sourcemap files or user-emitted assets.
+  /// In this case, `originate_from` is `None`.
+  pub originate_from: Option<ChunkIdx>,
   pub content: StrOrBytes,
   pub map: Option<SourceMap>,
   pub meta: InstantiationKind,

--- a/crates/rolldown_common/src/types/asset.rs
+++ b/crates/rolldown_common/src/types/asset.rs
@@ -1,9 +1,7 @@
-use std::path::PathBuf;
-
 use arcstr::ArcStr;
 use rolldown_sourcemap::SourceMap;
 
-use crate::{ChunkIdx, InstantiationKind, PreliminaryFilename, StrOrBytes};
+use crate::{ChunkIdx, InstantiationKind, StrOrBytes};
 
 #[derive(Debug)]
 /// Assets is final output of the bundling process. Inputs -> Modules -> Chunks -> Assets
@@ -19,8 +17,5 @@ pub struct Asset {
   pub content: StrOrBytes,
   pub map: Option<SourceMap>,
   pub meta: InstantiationKind,
-  pub augment_chunk_hash: Option<String>,
-  pub file_dir: PathBuf,
-  pub preliminary_filename: PreliminaryFilename,
   pub filename: ArcStr,
 }

--- a/crates/rolldown_common/src/types/instantiated_chunk.rs
+++ b/crates/rolldown_common/src/types/instantiated_chunk.rs
@@ -21,7 +21,7 @@ pub struct InstantiatedChunk {
 impl InstantiatedChunk {
   pub fn finalize(self, filename: ArcStr) -> Asset {
     Asset {
-      originate_from: self.originate_from,
+      originate_from: Some(self.originate_from),
       content: self.content,
       map: self.map,
       meta: self.kind,

--- a/crates/rolldown_common/src/types/instantiated_chunk.rs
+++ b/crates/rolldown_common/src/types/instantiated_chunk.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use arcstr::ArcStr;
 use rolldown_sourcemap::SourceMap;
 
@@ -14,7 +12,6 @@ pub struct InstantiatedChunk {
   pub map: Option<SourceMap>,
   pub kind: InstantiationKind,
   pub augment_chunk_hash: Option<String>,
-  pub file_dir: PathBuf,
   pub preliminary_filename: PreliminaryFilename,
 }
 
@@ -25,9 +22,6 @@ impl InstantiatedChunk {
       content: self.content,
       map: self.map,
       meta: self.kind,
-      augment_chunk_hash: self.augment_chunk_hash,
-      file_dir: self.file_dir,
-      preliminary_filename: self.preliminary_filename,
       filename,
     }
   }


### PR DESCRIPTION
`Asset` should be a generic struct, domain-specific fields should be isolated to `meta`.