### PR TITLE
feat(hmr): introduce `rolldown_plugin_hmr` to inject runtime code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,6 +2493,7 @@ dependencies = [
  "rolldown_loader_utils",
  "rolldown_plugin",
  "rolldown_plugin_data_uri",
+ "rolldown_plugin_hmr",
  "rolldown_resolver",
  "rolldown_rstr",
  "rolldown_sourcemap",
@@ -2783,6 +2784,15 @@ dependencies = [
  "rolldown_plugin",
  "rolldown_utils",
  "sugar_path",
+]
+
+[[package]]
+name = "rolldown_plugin_hmr"
+version = "0.1.0"
+dependencies = [
+ "arcstr",
+ "oxc",
+ "rolldown_plugin",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ rolldown_plugin_asset_import_meta_url = { version = "0.1.0", path = "./crates/ro
 rolldown_plugin_build_import_analysis = { version = "0.1.0", path = "./crates/rolldown_plugin_build_import_analysis" }
 rolldown_plugin_data_uri = { version = "0.1.0", path = "./crates/rolldown_plugin_data_uri" }
 rolldown_plugin_dynamic_import_vars = { version = "0.0.1", path = "./crates/rolldown_plugin_dynamic_import_vars" }
+rolldown_plugin_hmr = { version = "0.1.0", path = "./crates/rolldown_plugin_hmr" }
 rolldown_plugin_import_glob = { version = "0.1.0", path = "./crates/rolldown_plugin_import_glob" }
 rolldown_plugin_isolated_declaration = { version = "0.1.0", path = "./crates/rolldown_plugin_isolated_declaration" }
 rolldown_plugin_json = { version = "0.1.0", path = "./crates/rolldown_plugin_json" }

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -43,6 +43,7 @@ rolldown_fs = { workspace = true, features = ["os"] }
 rolldown_loader_utils = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_plugin_data_uri = { workspace = true }
+rolldown_plugin_hmr = { workspace = true }
 rolldown_resolver = { workspace = true }
 rolldown_rstr = { workspace = true }
 rolldown_sourcemap = { workspace = true }

--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -47,7 +47,8 @@ impl BundlerBuilder {
 
     let file_emitter = Arc::new(FileEmitter::new(Arc::clone(&options)));
 
-    apply_inner_plugins(&mut self.plugins);
+    apply_inner_plugins(&options, &mut self.plugins);
+
     Bundler {
       closed: false,
       plugin_driver: PluginDriver::new_shared(self.plugins, &resolver, &file_emitter, &options),

--- a/crates/rolldown/src/utils/apply_inner_plugins.rs
+++ b/crates/rolldown/src/utils/apply_inner_plugins.rs
@@ -1,10 +1,28 @@
 use std::sync::Arc;
 
+use rolldown_common::NormalizedBundlerOptions;
 use rolldown_plugin::__inner::SharedPluginable;
 
-/// Some builtin features of rolldown is implemented via plugins. However, though these features
-/// are implemented via plugins, users could not feel the existence of these plugins. And to do so,
-/// we need to apply these plugins after user's plugins to control the final order of plugins.
-pub fn apply_inner_plugins(user_plugins: &mut Vec<SharedPluginable>) {
+/// Some builtin features of rolldown is implemented via builtin plugins. However, though these
+/// features are implemented via plugins, users could not feel the existence of these plugins. And
+/// to do so, we need to be careful about the order of plugins.
+/// - These plugins should be always prepended to user's plugins, so they be decided whether to be
+///   push forward or back via `PluginHookMeta`.
+/// - Order of plugins theselves don't decide the final execution order of hooks.
+/// - Control the order of plugins via `PluginHookMeta` mechanism.
+pub fn apply_inner_plugins(
+  options: &NormalizedBundlerOptions,
+  user_plugins: &mut Vec<SharedPluginable>,
+) {
+  let mut before_user_plugins: Vec<SharedPluginable> = vec![];
+
+  if options.experimental.hmr.is_some() {
+    before_user_plugins.push(Arc::new(rolldown_plugin_hmr::HmrPlugin));
+  }
+
+  if !before_user_plugins.is_empty() {
+    user_plugins.splice(0..0, before_user_plugins);
+  }
+
   user_plugins.push(Arc::new(rolldown_plugin_data_uri::DataUriPlugin::default()));
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
@@ -9,6 +9,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 import nodeAssert from "node:assert";
 
 
+//#region rolldown:hmr
+var rolldown_hmr_exports = {};
+const rolldown_hmr_hot = __rolldown_runtime__.createModuleHotContext("rolldown:hmr");
+__rolldown_runtime__.registerModule("rolldown:hmr", { exports: rolldown_hmr_exports });
+var init_rolldown_hmr = __esm({ "rolldown:hmr"() {
+	globalThis.__rolldown_hmr__ ??= true;
+} });
+
+//#endregion
 //#region foo.cjs
 var require_foo = __commonJS({ "foo.cjs"(exports, module) {
 	const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.cjs");
@@ -23,6 +32,7 @@ const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 var import_foo;
 var init_main = __esm({ "main.js"() {
+	init_rolldown_hmr();
 	import_foo = __toESM(require_foo());
 	nodeAssert.strictEqual(import_foo.value, "foo");
 } });

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -9,6 +9,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 
+//#region rolldown:hmr
+var rolldown_hmr_exports = {};
+const rolldown_hmr_hot = __rolldown_runtime__.createModuleHotContext("rolldown:hmr");
+__rolldown_runtime__.registerModule("rolldown:hmr", { exports: rolldown_hmr_exports });
+globalThis.__rolldown_hmr__ ??= true;
+
+//#endregion
 //#region lib.js
 var require_lib = __commonJS({ "lib.js"(exports, module) {
 	const lib_hot = __rolldown_runtime__.createModuleHotContext("lib.js");

--- a/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
@@ -7,6 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 
+//#region rolldown:hmr
+var rolldown_hmr_exports = {};
+const rolldown_hmr_hot = __rolldown_runtime__.createModuleHotContext("rolldown:hmr");
+__rolldown_runtime__.registerModule("rolldown:hmr", { exports: rolldown_hmr_exports });
+globalThis.__rolldown_hmr__ ??= true;
+
+//#endregion
 //#region foo.mjs
 var foo_exports = {};
 __export(foo_exports, { foo: () => foo$1 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -7,6 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 
+//#region rolldown:hmr
+var rolldown_hmr_exports = {};
+const rolldown_hmr_hot = __rolldown_runtime__.createModuleHotContext("rolldown:hmr");
+__rolldown_runtime__.registerModule("rolldown:hmr", { exports: rolldown_hmr_exports });
+globalThis.__rolldown_hmr__ ??= true;
+
+//#endregion
 //#region hmr.js
 var hmr_exports = {};
 __export(hmr_exports, { foo: () => foo });

--- a/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
@@ -3,19 +3,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## chunk.js
-
-```js
-
-```
 ## entry.js
 
 ```js
-import "./chunk.js";
+import "./rolldown_hmr.js";
 
 //#region entry.js
+var entry_exports = {};
 const entry_hot = __rolldown_runtime__.createModuleHotContext("entry.js");
-__rolldown_runtime__.registerModule("entry.js", {});
+__rolldown_runtime__.registerModule("entry.js", { exports: entry_exports });
 console.log("entry");
 
 //#endregion
@@ -23,12 +19,25 @@ console.log("entry");
 ## index.js
 
 ```js
-import "./chunk.js";
+import "./rolldown_hmr.js";
 
 //#region index.js
+var mutiply_entires_exports = {};
 const mutiply_entires_hot = __rolldown_runtime__.createModuleHotContext("index.js");
-__rolldown_runtime__.registerModule("index.js", {});
+__rolldown_runtime__.registerModule("index.js", { exports: mutiply_entires_exports });
 console.log("index");
+
+//#endregion
+```
+## rolldown_hmr.js
+
+```js
+
+//#region rolldown:hmr
+var rolldown_hmr_exports = {};
+const rolldown_hmr_hot = __rolldown_runtime__.createModuleHotContext("rolldown:hmr");
+__rolldown_runtime__.registerModule("rolldown:hmr", { exports: rolldown_hmr_exports });
+globalThis.__rolldown_hmr__ ??= true;
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
@@ -7,6 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 
+//#region rolldown:hmr
+var rolldown_hmr_exports = {};
+const rolldown_hmr_hot = __rolldown_runtime__.createModuleHotContext("rolldown:hmr");
+__rolldown_runtime__.registerModule("rolldown:hmr", { exports: rolldown_hmr_exports });
+globalThis.__rolldown_hmr__ ??= true;
+
+//#endregion
 //#region hmr.js
 var hmr_exports = {};
 __export(hmr_exports, { foo: () => foo });

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -7,6 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 
+//#region rolldown:hmr
+var rolldown_hmr_exports = {};
+const rolldown_hmr_hot = __rolldown_runtime__.createModuleHotContext("rolldown:hmr");
+__rolldown_runtime__.registerModule("rolldown:hmr", { exports: rolldown_hmr_exports });
+globalThis.__rolldown_hmr__ ??= true;
+
+//#endregion
 //#region cjs.js
 var require_cjs = __commonJS({ "cjs.js"(exports, module) {
 	const cjs_hot = __rolldown_runtime__.createModuleHotContext("cjs.js");

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4063,7 +4063,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-C5VeU61G.js
+- main-!~{000}~.js => main-L8npGjuE.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4697,7 +4697,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-ystnxVR1.js
+- main-!~{000}~.js => main-Chr1AQp_.js
 
 # tests/rolldown/issues/4196
 
@@ -5398,25 +5398,25 @@ expression: output
 
 # tests/rolldown/topics/hmr/deconflict_import_bindings
 
-- main-!~{000}~.js => main-C5k9LH1Q.js
+- main-!~{000}~.js => main-DdLP8xDV.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-DVf294w-.js
+- main-!~{000}~.js => main-CkHgmXvL.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-o8SXFCw-.js
-- index-!~{001}~.js => index-D-irBaZm.js
-- chunk-!~{002}~.js => chunk-GhOtMXFi.js
+- entry-!~{000}~.js => entry-BubHRJWf.js
+- index-!~{001}~.js => index-89Yy2ssk.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-C2EcaPRD.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-DuGcRdKw.js
+- main-!~{000}~.js => main-HE2p_U6w.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-CRYNMszA.js
+- main-!~{000}~.js => main-BSEulp2i.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 

--- a/crates/rolldown_plugin_hmr/Cargo.toml
+++ b/crates/rolldown_plugin_hmr/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rolldown_plugin_hmr"
+version = "0.1.0"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+arcstr = { workspace = true }
+oxc = { workspace = true }
+rolldown_plugin = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rolldown_plugin_hmr/src/hmr_plugin.rs
+++ b/crates/rolldown_plugin_hmr/src/hmr_plugin.rs
@@ -1,0 +1,83 @@
+use oxc::{
+  ast::{AstBuilder, NONE, ast},
+  span::SPAN,
+};
+use rolldown_plugin::{HookLoadOutput, HookResolveIdOutput, HookUsage, Plugin};
+
+use crate::HMR_RUNTIME_MODULE_SPECIFIER;
+
+#[derive(Debug)]
+pub struct HmrPlugin;
+
+impl Plugin for HmrPlugin {
+  fn name(&self) -> std::borrow::Cow<'static, str> {
+    "builtin:hmr".into()
+  }
+
+  fn register_hook_usage(&self) -> rolldown_plugin::HookUsage {
+    HookUsage::TransformAst | HookUsage::ResolveId | HookUsage::Load
+  }
+
+  async fn resolve_id(
+    &self,
+    _ctx: &rolldown_plugin::PluginContext,
+    args: &rolldown_plugin::HookResolveIdArgs<'_>,
+  ) -> rolldown_plugin::HookResolveIdReturn {
+    if args.specifier == HMR_RUNTIME_MODULE_SPECIFIER {
+      return Ok(Some(HookResolveIdOutput { id: args.specifier.into(), ..Default::default() }));
+    }
+
+    Ok(None)
+  }
+
+  fn resolve_id_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Some(rolldown_plugin::PluginHookMeta { order: Some(rolldown_plugin::PluginOrder::Pre) })
+  }
+
+  async fn load(
+    &self,
+    _ctx: &rolldown_plugin::PluginContext,
+    args: &rolldown_plugin::HookLoadArgs<'_>,
+  ) -> rolldown_plugin::HookLoadReturn {
+    if args.id == HMR_RUNTIME_MODULE_SPECIFIER {
+      let runtime_source = arcstr::literal!(include_str!("./runtime/index.js"));
+      return Ok(Some(HookLoadOutput { code: runtime_source, ..Default::default() }));
+    }
+
+    Ok(None)
+  }
+
+  fn load_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Some(rolldown_plugin::PluginHookMeta { order: Some(rolldown_plugin::PluginOrder::Pre) })
+  }
+
+  async fn transform_ast(
+    &self,
+    _ctx: &rolldown_plugin::PluginContext,
+    mut args: rolldown_plugin::HookTransformAstArgs<'_>,
+  ) -> rolldown_plugin::HookTransformAstReturn {
+    if args.is_user_defined_entry {
+      // Inject `import 'rolldown:hmr';` to all user defined entry points to ensure the HMR runtime is loaded.
+      args.ast.program.with_mut(|fields| {
+        let ast_builder = AstBuilder::new(fields.allocator);
+
+        // `import 'rolldown:hmr';`
+        let import_stmt = ast::Statement::ImportDeclaration(ast_builder.alloc_import_declaration(
+          SPAN,
+          None,
+          ast_builder.string_literal(SPAN, HMR_RUNTIME_MODULE_SPECIFIER, None),
+          None,
+          NONE,
+          ast::ImportOrExportKind::Value,
+        ));
+        fields.program.body.insert(0, import_stmt);
+      });
+    }
+
+    Ok(args.ast)
+  }
+
+  fn transform_ast_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Some(rolldown_plugin::PluginHookMeta { order: Some(rolldown_plugin::PluginOrder::Pre) })
+  }
+}

--- a/crates/rolldown_plugin_hmr/src/lib.rs
+++ b/crates/rolldown_plugin_hmr/src/lib.rs
@@ -1,0 +1,5 @@
+mod hmr_plugin;
+
+pub use hmr_plugin::HmrPlugin;
+
+pub static HMR_RUNTIME_MODULE_SPECIFIER: &str = "rolldown:hmr";

--- a/crates/rolldown_plugin_hmr/src/runtime/index.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/index.js
@@ -1,0 +1,3 @@
+// @ts-check
+
+(/** @type {any} */ (globalThis)).__rolldown_hmr__ ??= true;


### PR DESCRIPTION
- `rolldown:hmr` is treated as a normal module. Users can't observe it via plugin hooks, because we process it in advance in `rolldown_plugin_hmr`.
- I'm also using `rolldown:hmr` as a case to explore what's the proper way to handle runtime module.