### PR TITLE
refactor(hmr): use `rolldown:hmr` to load hmr runtime code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ version = "0.1.0"
 dependencies = [
  "arcstr",
  "oxc",
+ "rolldown_common",
  "rolldown_plugin",
 ]
 

--- a/crates/rolldown/src/module_finalizers/hmr.rs
+++ b/crates/rolldown/src/module_finalizers/hmr.rs
@@ -12,7 +12,9 @@ use super::ScopeHoistingFinalizer;
 impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
   pub fn generate_hmr_header(&self) -> Vec<ast::Statement<'ast>> {
     let mut ret = vec![];
-    if !self.ctx.options.is_hmr_enabled() {
+    if !self.ctx.options.is_hmr_enabled()
+      || self.ctx.module.id.as_ref() == rolldown_plugin_hmr::HMR_RUNTIME_MODULE_SPECIFIER
+    {
       return ret;
     }
 

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -70,29 +70,7 @@ impl RuntimeModuleTask {
 
   #[expect(clippy::too_many_lines)]
   async fn run_inner(&self) -> BuildResult<()> {
-    let source = if let Some(hmr_options) = &self.ctx.options.experimental.hmr {
-      let mut runtime_source = String::new();
-      match self.ctx.options.platform {
-        Platform::Node => {
-          runtime_source.push_str("import { WebSocket } from 'ws';\n");
-        }
-        Platform::Browser | Platform::Neutral => {
-          // Browser platform should use the native WebSocket and neutral platform doesn't have any assumptions.
-        }
-      }
-      runtime_source.push_str(&get_runtime_js());
-      runtime_source.push_str(include_str!("../runtime/runtime-extra-dev-common.js"));
-      if let Some(implement) = hmr_options.implement.as_deref() {
-        runtime_source.push_str(implement);
-      } else {
-        let content = include_str!("../runtime/runtime-extra-dev-default.js");
-        let host = hmr_options.host.as_deref().unwrap_or("localhost");
-        let port = hmr_options.port.unwrap_or(3000);
-        let addr = format!("{host}:{port}");
-        runtime_source.push_str(&content.replace("$ADDR", &addr));
-      }
-      ArcStr::from(runtime_source)
-    } else if self.ctx.options.is_esm_format_with_node_platform() {
+    let source = if self.ctx.options.is_esm_format_with_node_platform() {
       get_runtime_js_with_node_platform().into()
     } else {
       get_runtime_js().into()

--- a/crates/rolldown/src/runtime/runtime-base.js
+++ b/crates/rolldown/src/runtime/runtime-base.js
@@ -14,7 +14,7 @@ var __commonJS = (cb, mod) => function () {
   return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports
 }
 var __commonJSMin = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports)
-var __export = (target, all) => {
+export var __export = (target, all) => {
   for (var name in all)
     __defProp(target, name, { get: all[name], enumerable: true })
 }
@@ -31,7 +31,7 @@ var __reExport = (target, mod, secondTarget) => (
   __copyProps(target, mod, 'default'),
   secondTarget && __copyProps(secondTarget, mod, 'default')
 )
-var __toESM = (mod, isNodeMode, target) => (
+export var __toESM = (mod, isNodeMode, target) => (
   target = mod != null ? __create(__getProtoOf(mod)) : {},
   __copyProps(
     isNodeMode || !mod || !mod.__esModule
@@ -39,7 +39,7 @@ var __toESM = (mod, isNodeMode, target) => (
       : target,
     mod)
 )
-var __toCommonJS = mod => __copyProps(__defProp({}, '__esModule', { value: true }), mod)
+export var __toCommonJS = mod => __copyProps(__defProp({}, '__esModule', { value: true }), mod)
 export var __toBinaryNode = base64 => new Uint8Array(Buffer.from(base64, 'base64'))
 export var __toBinary = /* @__PURE__ */ (() => {
   var table = new Uint8Array(128)

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
@@ -20,12 +20,12 @@ var require_foo = __commonJS({ "foo.cjs"(exports, module) {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
-var import_foo;
+var import_foo, main_hot;
 var init_main = __esm({ "main.js"() {
 	init_rolldown_hmr();
 	import_foo = __toESM(require_foo());
+	main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+	__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 	nodeAssert.strictEqual(import_foo.value, "foo");
 } });
 

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -20,9 +20,9 @@ var require_lib = __commonJS({ "lib.js"(exports, module) {
 //#endregion
 //#region main.js
 var main_exports = {};
+var import_lib = __toESM(require_lib());
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
-var import_lib = __toESM(require_lib());
 assert.strictEqual(import_lib.a, 1);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -26,9 +26,9 @@ const value = "main";
 //#endregion
 //#region main.js
 var main_exports = {};
+var import_cjs = __toESM(require_cjs());
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
-var import_cjs = __toESM(require_cjs());
 console.log(import_cjs, esm_exports);
 
 //#endregion

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4063,7 +4063,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-L8npGjuE.js
+- main-!~{000}~.js => main-DH8KC_uI.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4697,7 +4697,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-Chr1AQp_.js
+- main-!~{000}~.js => main-LdORHUUL.js
 
 # tests/rolldown/issues/4196
 
@@ -5398,25 +5398,25 @@ expression: output
 
 # tests/rolldown/topics/hmr/deconflict_import_bindings
 
-- main-!~{000}~.js => main-DdLP8xDV.js
+- main-!~{000}~.js => main-BgBqOpSC.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-CkHgmXvL.js
+- main-!~{000}~.js => main-DdmvPD9K.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-BubHRJWf.js
-- index-!~{001}~.js => index-89Yy2ssk.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-C2EcaPRD.js
+- entry-!~{000}~.js => entry-wnlB7yV5.js
+- index-!~{001}~.js => index-e-WKZ_Sd.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-C0lG6dx-.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-HE2p_U6w.js
+- main-!~{000}~.js => main-CtghUp8F.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-BSEulp2i.js
+- main-!~{000}~.js => main-B7w8STyO.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 

--- a/crates/rolldown_plugin_hmr/Cargo.toml
+++ b/crates/rolldown_plugin_hmr/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 arcstr = { workspace = true }
 oxc = { workspace = true }
+rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
 
 [lints]

--- a/crates/rolldown_plugin_hmr/src/hmr_plugin.rs
+++ b/crates/rolldown_plugin_hmr/src/hmr_plugin.rs
@@ -1,7 +1,9 @@
+use arcstr::ArcStr;
 use oxc::{
   ast::{AstBuilder, NONE, ast},
   span::SPAN,
 };
+use rolldown_common::{Platform, ResolvedExternal};
 use rolldown_plugin::{HookLoadOutput, HookResolveIdOutput, HookUsage, Plugin};
 
 use crate::HMR_RUNTIME_MODULE_SPECIFIER;
@@ -26,6 +28,14 @@ impl Plugin for HmrPlugin {
     if args.specifier == HMR_RUNTIME_MODULE_SPECIFIER {
       return Ok(Some(HookResolveIdOutput { id: args.specifier.into(), ..Default::default() }));
     }
+    if args.specifier == "ws" {
+      // FIXME(hyf0): As the dependency of `rolldown:hmr`, `ws` has a advanced execution timing than `rolldown:hmr`, which cause a runtime error.
+      return Ok(Some(HookResolveIdOutput {
+        id: args.specifier.into(),
+        external: Some(ResolvedExternal::Bool(true)),
+        ..Default::default()
+      }));
+    }
 
     Ok(None)
   }
@@ -36,11 +46,37 @@ impl Plugin for HmrPlugin {
 
   async fn load(
     &self,
-    _ctx: &rolldown_plugin::PluginContext,
+    ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookLoadArgs<'_>,
   ) -> rolldown_plugin::HookLoadReturn {
     if args.id == HMR_RUNTIME_MODULE_SPECIFIER {
-      let runtime_source = arcstr::literal!(include_str!("./runtime/index.js"));
+      let mut runtime_source = String::new();
+      let bundler_options = ctx.options();
+
+      if let Some(hmr_options) = &bundler_options.experimental.hmr {
+        match bundler_options.platform {
+          Platform::Node => {
+            runtime_source.push_str("import { WebSocket } from 'ws';\n");
+          }
+          Platform::Browser | Platform::Neutral => {
+            // Browser platform should use the native WebSocket and neutral platform doesn't have any assumptions.
+          }
+        }
+
+        runtime_source.push_str(include_str!("./runtime/runtime-extra-dev-common.js"));
+
+        if let Some(implement) = hmr_options.implement.as_deref() {
+          runtime_source.push_str(implement);
+        } else {
+          let content = include_str!("./runtime/runtime-extra-dev-default.js");
+          let host = hmr_options.host.as_deref().unwrap_or("localhost");
+          let port = hmr_options.port.unwrap_or(3000);
+          let addr = format!("{host}:{port}");
+          runtime_source.push_str(&content.replace("$ADDR", &addr));
+        }
+      }
+
+      let runtime_source = ArcStr::from(runtime_source);
       return Ok(Some(HookLoadOutput { code: runtime_source, ..Default::default() }));
     }
 

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
@@ -1,30 +1,31 @@
 // @ts-check
+// @ts-expect-error
+import { __export, __toCommonJS, __toESM } from 'rolldown:runtime';
 
 // oxlint-disable-next-line no-unused-vars
-class DevRuntime {
+export class DevRuntime {
   /**
    * @type {Record<string, { exports: any }>}
    */
-  modules = {}
+  modules = {};
   /**
    * @param {string} _moduleId
    */
   createModuleHotContext(_moduleId) {
-    throw new Error('createModuleHotContext should be implemented')
+    throw new Error('createModuleHotContext should be implemented');
   }
   /**
-   *
    * @param {string[]} _boundaries
    */
   applyUpdates(_boundaries) {
-    throw new Error('applyUpdates should be implemented')
+    throw new Error('applyUpdates should be implemented');
   }
   /**
    * @param {string} id
    * @param {{ exports: any }} module
    */
   registerModule(id, module) {
-    this.modules[id] = module
+    this.modules[id] = module;
   }
   /**
    * @param {string} id
@@ -45,21 +46,20 @@ class DevRuntime {
    * @type {<T>(fn: any, res: T) => () => T}
    * @internal
    */
-  createEsmInitializer = (fn, res) => () => (fn && (res = fn(fn = 0)), res)
+  createEsmInitializer = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
   /**
    * __commonJSMin
    *
    * @type {<T extends { exports: any }>(cb: any, mod: { exports: any }) => () => T}
    * @internal
    */
-  createCjsInitializer = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports)
+  createCjsInitializer =
+    (cb, mod) =>
+    () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
   /** @internal */
-  // @ts-expect-error it exists
   __toESM = __toESM;
   /** @internal */
-  // @ts-expect-error it exists
-  __toCommonJS = __toCommonJS
+  __toCommonJS = __toCommonJS;
   /** @internal */
-  // @ts-expect-error it exists
-  __export = __export
+  __export = __export;
 }

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
@@ -4,9 +4,8 @@ class ModuleHotContext {
   /**
    * @type {{ deps: [string], fn: (moduleExports: Record<string, any>[]) => void }[]}
    */
-  acceptCallbacks = []
+  acceptCallbacks = [];
   /**
-   *
    * @param {string} moduleId
    * @param {DevRuntime} devRuntime
    */
@@ -31,7 +30,7 @@ class ModuleHotContext {
       this.acceptCallbacks.push({
         deps: [acceptingPath],
         fn: cb,
-      })
+      });
     } else {
       throw new Error('Invalid arguments for `import.meta.hot.accept`');
     }
@@ -42,11 +41,11 @@ class DefaultDevRuntime extends DevRuntime {
   /**
    * @type {Map<string, ModuleHotContext>}
    */
-  moduleHotContexts = new Map()
+  moduleHotContexts = new Map();
   /**
    * @type {Map<string, ModuleHotContext>}
    */
-  moduleHotContextsToBeUpdated = new Map()
+  moduleHotContextsToBeUpdated = new Map();
   /**
    * @override
    * @param {string} moduleId
@@ -72,27 +71,28 @@ class DefaultDevRuntime extends DevRuntime {
         const acceptCallbacks = hotContext.acceptCallbacks;
         acceptCallbacks.filter((cb) => {
           cb.fn(this.modules[moduleId].exports);
-        })
+        });
       }
     }
     this.moduleHotContextsToBeUpdated.forEach((hotContext, moduleId) => {
       this.moduleHotContexts.set(moduleId, hotContext);
-    })
-    this.moduleHotContextsToBeUpdated.clear()
+    });
+    this.moduleHotContextsToBeUpdated.clear();
     // swap new contexts
   }
 }
 
-;(/** @type {any} */ (globalThis)).__rolldown_runtime__ ??= new DefaultDevRuntime();
+(/** @type {any} */ (globalThis)).__rolldown_runtime__ ??=
+  new DefaultDevRuntime();
 
 /** @param {string} url */
 function loadScript(url) {
   var script = document.createElement('script');
   script.src = url;
   script.type = 'module';
-  script.onerror = function () {
+  script.onerror = function() {
     console.error('Failed to load script: ' + url);
-  }
+  };
   document.body.appendChild(script);
 }
 
@@ -100,19 +100,19 @@ console.debug('HMR runtime loaded', '$ADDR');
 const addr = new URL('ws://$ADDR');
 addr.searchParams.set('from', 'hmr-runtime');
 
-const socket = new WebSocket(addr)
+const socket = new WebSocket(addr);
 
 /** @param {MessageEvent} event */
-socket.onmessage = function (event) {
-  const data = JSON.parse(event.data)
+socket.onmessage = function(event) {
+  const data = JSON.parse(event.data);
   console.debug('Received message:', data);
   if (data.type === 'update') {
-    if(typeof process === 'object') {
-      import(data.path)
+    if (typeof process === 'object') {
+      import(data.path);
       console.debug(`[hmr]: Importing HMR patch: ${data.path}`);
     } else {
       console.debug(`[hmr]: Loading HMR patch: ${data.path}`);
-      loadScript(data.url)
+      loadScript(data.url);
     }
   }
-}
+};

--- a/crates/rolldown_testing/src/hmr-runtime.js
+++ b/crates/rolldown_testing/src/hmr-runtime.js
@@ -1,6 +1,6 @@
-// @ts-check
+// @ts-nocheck FIXME(hyf0): Enable type check
 
-/// <reference path="../../../crates/rolldown/src/runtime/runtime-extra-dev-common.js" />
+/// <reference path="../../../crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js" />
 
 class TestDevRuntime extends DevRuntime {
   /**

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -300,7 +300,7 @@ function copy() {
 function generateRuntimeTypes() {
   const inputFile = nodePath.resolve(
     __dirname,
-    '../../crates/rolldown/src/runtime/runtime-extra-dev-common.js',
+    '../../crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js',
   );
   const outputFile = nodePath.resolve(
     outputDir,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,6 +579,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/test-dev-server/tests/tmp/fixtures/basic:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../../..
+
   packages/testing: {}
 
   packages/vite-tests:


### PR DESCRIPTION
I'll remove other hmr-related hard-code in the next PR.