### PR TITLE
feat: print rolldown version

### DIFF
--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -170,7 +170,7 @@ async function bundleInner(
   const endTime = performance.now();
   const duration = endTime - startTime;
   // If the build time is more than 1s, we should display it in seconds.
-  logger.success(
+  logger.success(`rolldown v${version} Finished in ${colors.green(ms(duration))}`);
     `rollldown v${version} Finished in ${colors.green(ms(duration))}`,
   );
 }

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -170,9 +170,9 @@ async function bundleInner(
   const endTime = performance.now();
   const duration = endTime - startTime;
   // If the build time is more than 1s, we should display it in seconds.
+
   logger.success(`rolldown v${version} Finished in ${colors.green(ms(duration))}`);
-    `rollldown v${version} Finished in ${colors.green(ms(duration))}`,
-  );
+
 }
 
 function printBundleOutputPretty(output: RolldownOutput) {

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -171,8 +171,9 @@ async function bundleInner(
   const duration = endTime - startTime;
   // If the build time is more than 1s, we should display it in seconds.
 
-  logger.success(`rolldown v${version} Finished in ${colors.green(ms(duration))}`);
-
+  logger.success(
+    `rolldown v${version} Finished in ${colors.green(ms(duration))}`,
+  );
 }
 
 function printBundleOutputPretty(output: RolldownOutput) {

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -9,6 +9,7 @@ import { loadConfig } from '../../utils/load-config';
 import { arraify } from '../../utils/misc';
 import type { NormalizedCliOptions } from '../arguments/normalize';
 import { logger } from '../logger';
+import { version } from '../../../package.json';
 
 export async function bundleWithConfig(
   configPath: string,
@@ -169,7 +170,7 @@ async function bundleInner(
   const endTime = performance.now();
   const duration = endTime - startTime;
   // If the build time is more than 1s, we should display it in seconds.
-  logger.success(`Finished in ${colors.green(ms(duration))}`);
+  logger.success(`rollldown v${version} Finished in ${colors.green(ms(duration))}`);
 }
 
 function printBundleOutputPretty(output: RolldownOutput) {

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -2,6 +2,7 @@ import colors from 'ansis';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { onExit } from 'signal-exit';
+import { version } from '../../../package.json';
 import type { ConfigExport, RolldownOutput } from '../..';
 import { rolldown } from '../../api/rolldown';
 import { watch as rolldownWatch } from '../../api/watch';
@@ -9,7 +10,6 @@ import { loadConfig } from '../../utils/load-config';
 import { arraify } from '../../utils/misc';
 import type { NormalizedCliOptions } from '../arguments/normalize';
 import { logger } from '../logger';
-import { version } from '../../../package.json';
 
 export async function bundleWithConfig(
   configPath: string,
@@ -170,7 +170,9 @@ async function bundleInner(
   const endTime = performance.now();
   const duration = endTime - startTime;
   // If the build time is more than 1s, we should display it in seconds.
-  logger.success(`rollldown v${version} Finished in ${colors.green(ms(duration))}`);
+  logger.success(
+    `rollldown v${version} Finished in ${colors.green(ms(duration))}`,
+  );
 }
 
 function printBundleOutputPretty(output: RolldownOutput) {

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -133,7 +133,7 @@ exports[`cli options for bundling > cli default options 1`] = `
 output cli default options {}
 <DIR>/index.js  chunk │ size: 0.13 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`cli options for bundling > should handle \`--input\` and positional args as entries 1`] = `
@@ -198,37 +198,37 @@ exports[`cli options for bundling > should handle pass \`-s\` options 1`] = `
 "<DIR>/index.js.map  asset │ size: 0.21 kB
 <DIR>/index.js      chunk │ size: 0.19 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`cli options for bundling > should handle single array options 1`] = `
 "<DIR>/index.js  chunk │ size: 0.14 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`cli options for bundling > should handle single boolean option 1`] = `
 "<DIR>/index.js  chunk │ size: 0.04 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`cli options for bundling > should handle single boolean short options 1`] = `
 "<DIR>/index.js  chunk │ size: 0.04 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`cli options for bundling > should handle single object options 1`] = `
 "<DIR>/index.js  chunk │ size: 0.27 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`cli options for bundling > should handle single string options 1`] = `
 "<DIR>/index.js  chunk │ size: 0.13 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`cli options for bundling > validate cli options 1`] = `
@@ -240,44 +240,44 @@ Invalid value for option format: Invalid type: Expected ("es" | "cjs" | "esm" | 
 exports[`config > should allow loading cts config 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`config > should allow loading mts config 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`config > should allow loading ts config 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`config > should allow loading ts config from non-working dir 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`config > should allow loading ts config with oxnode 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`config > should allow loading ts config with tsx 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`config > should allow multiply options 1`] = `
 "<DIR>/esm.js  chunk │ size: 0.14 kB
 <DIR>/cjs.js  chunk │ size: 0.14 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`config > should allow multiply output + call options hook once  + call outputOptions hook 1`] = `
@@ -287,26 +287,26 @@ called output options hook
 <DIR>/esm.js  chunk │ size: 0.18 kB
 <DIR>/cjs.js  chunk │ size: 0.17 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`config > should allow multiply output 1`] = `
 "<DIR>/esm.js  chunk │ size: 0.14 kB
 <DIR>/cjs.js  chunk │ size: 0.14 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`config > should bundle in ext-js-syntax-cjs 1`] = `
 "<DIR>/index.js  chunk │ size: 0.13 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`config > should resolve rolldown.config.cjs 1`] = `
 "<DIR>/index.js  chunk │ size: 0.13 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`watch cli > should allow multiply output + call options hook once + call outputOptions hook 1`] = `
@@ -316,7 +316,7 @@ called output options hook
 <DIR>/esm.js  chunk │ size: 0.18 kB
 <DIR>/cjs.js  chunk │ size: 0.17 kB
 
-rolldown v1.0.0-beta.23 "
+"
 `;
 
 exports[`watch cli > should require both ROLLDOWN_WATCH and this.meta.watchMode to be false 1`] = `

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -133,7 +133,7 @@ exports[`cli options for bundling > cli default options 1`] = `
 output cli default options {}
 <DIR>/index.js  chunk │ size: 0.13 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`cli options for bundling > should handle \`--input\` and positional args as entries 1`] = `
@@ -198,37 +198,37 @@ exports[`cli options for bundling > should handle pass \`-s\` options 1`] = `
 "<DIR>/index.js.map  asset │ size: 0.21 kB
 <DIR>/index.js      chunk │ size: 0.19 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`cli options for bundling > should handle single array options 1`] = `
 "<DIR>/index.js  chunk │ size: 0.14 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`cli options for bundling > should handle single boolean option 1`] = `
 "<DIR>/index.js  chunk │ size: 0.04 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`cli options for bundling > should handle single boolean short options 1`] = `
 "<DIR>/index.js  chunk │ size: 0.04 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`cli options for bundling > should handle single object options 1`] = `
 "<DIR>/index.js  chunk │ size: 0.27 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`cli options for bundling > should handle single string options 1`] = `
 "<DIR>/index.js  chunk │ size: 0.13 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`cli options for bundling > validate cli options 1`] = `
@@ -240,44 +240,44 @@ Invalid value for option format: Invalid type: Expected ("es" | "cjs" | "esm" | 
 exports[`config > should allow loading cts config 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`config > should allow loading mts config 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`config > should allow loading ts config 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`config > should allow loading ts config from non-working dir 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`config > should allow loading ts config with oxnode 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`config > should allow loading ts config with tsx 1`] = `
 "<DIR>/index.js  chunk │ size: 0.11 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`config > should allow multiply options 1`] = `
 "<DIR>/esm.js  chunk │ size: 0.14 kB
 <DIR>/cjs.js  chunk │ size: 0.14 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`config > should allow multiply output + call options hook once  + call outputOptions hook 1`] = `
@@ -287,26 +287,26 @@ called output options hook
 <DIR>/esm.js  chunk │ size: 0.18 kB
 <DIR>/cjs.js  chunk │ size: 0.17 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`config > should allow multiply output 1`] = `
 "<DIR>/esm.js  chunk │ size: 0.14 kB
 <DIR>/cjs.js  chunk │ size: 0.14 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`config > should bundle in ext-js-syntax-cjs 1`] = `
 "<DIR>/index.js  chunk │ size: 0.13 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`config > should resolve rolldown.config.cjs 1`] = `
 "<DIR>/index.js  chunk │ size: 0.13 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`watch cli > should allow multiply output + call options hook once + call outputOptions hook 1`] = `
@@ -316,7 +316,7 @@ called output options hook
 <DIR>/esm.js  chunk │ size: 0.18 kB
 <DIR>/cjs.js  chunk │ size: 0.17 kB
 
-"
+rolldown v1.0.0-beta.23 "
 `;
 
 exports[`watch cli > should require both ROLLDOWN_WATCH and this.meta.watchMode to be false 1`] = `

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -12,7 +12,7 @@ function cliFixturesDir(...joined: string[]) {
 // remove `Finished in x ms` since it is not deterministic
 // remove Ansi colors for snapshot testing
 function cleanStdout(stdout: string) {
-  return stripAnsi(stdout).replace(/Finished in \d+(\.\d+)? (s|ms|us|ns)/g, '')
+  return stripAnsi(stdout).replace(/rolldown v(?<version>\S+) Finished in \d+(\.\d+)? (s|ms|us|ns)/g, '')
 }
 
 describe('should not hang after running', () => {


### PR DESCRIPTION
When printing build information, output rolldown versions more friendly.