### PR TITLE
fix(rolldown_plugin_build_import_analysis): avoid `default` keyword error

### DIFF
--- a/crates/rolldown_plugin_build_import_analysis/src/ast_utils.rs
+++ b/crates/rolldown_plugin_build_import_analysis/src/ast_utils.rs
@@ -49,9 +49,10 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
     }
     if matches!(await_expr,  Expression::AwaitExpression(expr) if matches!(expr.argument, Expression::ImportExpression(_)))
     {
-      let property = match member_expr.property.name.as_str() {
-        "default" => self.snippet.atom("__vite_default__"),
-        _ => member_expr.property.name,
+      let (key, value) = match member_expr.property.name.as_str() {
+        // avoid `default` keyword error
+        key @ "default" => (key, "__vite_default__"),
+        _ => (member_expr.property.name.as_str(), member_expr.property.name.as_str()),
       };
       *await_expr = Expression::AwaitExpression(self.snippet.builder.alloc_await_expression(
         SPAN,
@@ -61,10 +62,10 @@ impl<'a> BuildImportAnalysisVisitor<'a> {
               SPAN,
               self.snippet.builder.vec1(self.snippet.builder.binding_property(
                 SPAN,
-                self.snippet.builder.property_key_static_identifier(SPAN, property),
+                self.snippet.builder.property_key_static_identifier(SPAN, key),
                 self.snippet.builder.binding_pattern(
                   BindingPatternKind::BindingIdentifier(
-                    self.snippet.builder.alloc_binding_identifier(SPAN, property),
+                    self.snippet.builder.alloc_binding_identifier(SPAN, value),
                   ),
                   NONE,
                   false,

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/lib.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/lib.js
@@ -1,1 +1,2 @@
 export const foo = 100
+export default foo

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/basic/main.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 
 const { foo } = await import('./lib.js')
-const a = (await import('./lib.js')).foo
+const a = (await import('./lib.js')).default
 const b = (await (() => import('./lib.js'))()).foo
 const c = await import('./lib.js').then((c) => c.foo)
 import('./lib.js').then(({ foo }) => {


### PR DESCRIPTION
Should be `const { default: __vite_default__ } = ` instead of `const { __vite_default__ } = `