### PR TITLE
feat(rust): skip transform hook for modules starts with `rolldown:`

### DIFF
--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -255,6 +255,7 @@ impl ModuleTask {
       module_type = asserted.clone();
     }
     let source = match source {
+      _ if self.resolved_id.id.starts_with("rolldown:") => source,
       StrOrBytes::Str(source) => {
         // Run plugin transform.
         let source = transform_source(


### PR DESCRIPTION
Discussed at https://github.com/rolldown/rolldown/pull/5159#issuecomment-3035306968.

On reflection, I think it's better to not allow it in the first place. Considering possible `rolldown:oxc-runtime` in the future, it's not a good idea to let users modify internal modules' code. @sapphi-red cc

However, if we do require this in the future, we could rethink this decision.