### PR TITLE
chore: inject test variant name to rust unit test script

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/allow_different_variant_unit_test/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/allow_different_variant_unit_test/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "treeshake": false
+  },
+  "configVariants": [
+    {
+      "configName": "enable-treeshake",
+      "treeshake": true
+    }
+  ],
+  "snapshot": false
+}

--- a/crates/rolldown/tests/rolldown/topics/allow_different_variant_unit_test/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/allow_different_variant_unit_test/_test.mjs
@@ -1,0 +1,12 @@
+import * as fs from 'node:fs'
+import path from 'node:path'
+import assert from 'node:assert'
+
+
+const file = fs.readFileSync(path.resolve(import.meta.dirname, "./dist/main.js"), "utf-8")
+
+if (globalThis.__testName === 'enable-treeshake') {
+  assert.ok(!file.includes('test'))
+} else {
+  assert.ok(file.includes('test'))
+}

--- a/crates/rolldown/tests/rolldown/topics/allow_different_variant_unit_test/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/allow_different_variant_unit_test/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+function test() {}
+
+//#endregion
+```
+---
+
+Variant: enable-treeshake
+
+# Assets
+
+## main.js
+
+```js
+
+```

--- a/crates/rolldown/tests/rolldown/topics/allow_different_variant_unit_test/main.js
+++ b/crates/rolldown/tests/rolldown/topics/allow_different_variant_unit_test/main.js
@@ -1,0 +1,4 @@
+function test() {
+
+}
+

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5066,6 +5066,10 @@ expression: output
 - main1-DuhB17iW.js.map
 - shared-Bisfm5lw.js.map
 
+# tests/rolldown/topics/allow_different_variant_unit_test
+
+- main-!~{000}~.js => main-BFTacv6h.js
+
 # tests/rolldown/topics/bundler_esm_cjs_tests/0
 
 - entry-!~{000}~.js => entry-BM0IqEBl.js

--- a/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
@@ -138,7 +138,7 @@ impl TreeshakeOptions {
 
   pub fn into_normalized_options(self) -> NormalizedTreeshakeOptions {
     match self {
-      TreeshakeOptions::Boolean(true) => NormalizedTreeshakeOptions::default(),
+      TreeshakeOptions::Boolean(true) => InnerOptions::default().into(),
       TreeshakeOptions::Boolean(false) => NormalizedTreeshakeOptions::new(None),
       TreeshakeOptions::Option(inner_options) => inner_options.into(),
     }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1289,6 +1289,12 @@
             "null"
           ]
         },
+        "configName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "exports": {
           "anyOf": [
             {
@@ -1321,6 +1327,16 @@
           "anyOf": [
             {
               "$ref": "#/$defs/PreserveEntrySignatures"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "treeshake": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TreeshakeOptions"
             },
             {
               "type": "null"

--- a/crates/rolldown_testing/src/fixture.rs
+++ b/crates/rolldown_testing/src/fixture.rs
@@ -41,7 +41,7 @@ impl Fixture {
     let configs = std::iter::once(NamedBundlerOptions { options: options.clone(), name: None })
       .chain(config_variants.into_iter().map(|variant| NamedBundlerOptions {
         options: variant.apply(&options),
-        name: Some(variant.to_string()),
+        name: Some(variant.config_name.clone().unwrap_or(variant.to_string())),
       }))
       .collect::<Vec<_>>();
 

--- a/crates/rolldown_testing_config/src/lib.rs
+++ b/crates/rolldown_testing_config/src/lib.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 
-use rolldown_common::{BundlerOptions, OutputExports, OutputFormat, PreserveEntrySignatures};
+use rolldown_common::{
+  BundlerOptions, OutputExports, OutputFormat, PreserveEntrySignatures, TreeshakeOptions,
+};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -10,11 +12,13 @@ pub struct ConfigVariant {
   pub format: Option<OutputFormat>,
   pub extend: Option<bool>,
   pub name: Option<String>,
+  pub config_name: Option<String>,
   pub exports: Option<OutputExports>,
   pub strict_execution_order: Option<bool>,
   pub entry_filenames: Option<String>,
   pub inline_dynamic_imports: Option<bool>,
   pub preserve_entry_signatures: Option<PreserveEntrySignatures>,
+  pub treeshake: Option<TreeshakeOptions>,
 }
 
 impl ConfigVariant {
@@ -45,6 +49,9 @@ impl ConfigVariant {
     if let Some(preserve_entry_signatures) = &self.preserve_entry_signatures {
       config.preserve_entry_signatures = Some(*preserve_entry_signatures);
     }
+    if let Some(treeshake) = &self.treeshake {
+      config.treeshake = treeshake.clone();
+    }
     config
   }
 }
@@ -72,6 +79,9 @@ impl Display for ConfigVariant {
     }
     if let Some(preserve_entry_signatures) = &self.preserve_entry_signatures {
       fields.push(format!("preserve_entry_signatures: {preserve_entry_signatures:?}"));
+    }
+    if let Some(treeshake) = &self.treeshake {
+      fields.push(format!("treeshake: {treeshake:?}"));
     }
     fields.sort();
     if fields.is_empty() { write!(f, "()") } else { write!(f, "({})", fields.join(", ")) }


### PR DESCRIPTION
Allow writing different unit test logic according to different config variant.
Usually, the unit test logic is pretty small, it is verbose to create multiple `_test.${name}.mjs`.