### PR TITLE
fix: return `moduleSideEffects` instead of `sideEffects` from callable plugins

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_callable_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_callable_builtin_plugin.rs
@@ -141,7 +141,7 @@ pub struct BindingHookJsResolveIdOutput {
   #[napi(ts_type = "boolean | 'absolute' | 'relative'")]
   pub external: Option<BindingResolvedExternal>,
   #[napi(ts_type = "boolean | 'no-treeshake'")]
-  pub side_effects: Option<BindingHookSideEffects>,
+  pub module_side_effects: Option<BindingHookSideEffects>,
 }
 
 impl From<HookResolveIdOutput> for BindingHookJsResolveIdOutput {
@@ -149,7 +149,7 @@ impl From<HookResolveIdOutput> for BindingHookJsResolveIdOutput {
     Self {
       id: value.id.to_string(),
       external: value.external.map(Into::into),
-      side_effects: value.side_effects.map(Into::into),
+      module_side_effects: value.side_effects.map(Into::into),
     }
   }
 }
@@ -159,7 +159,7 @@ pub struct BindingHookJsLoadOutput {
   pub code: String,
   pub map: Option<String>,
   #[napi(ts_type = "boolean | 'no-treeshake'")]
-  pub side_effects: Option<BindingHookSideEffects>,
+  pub module_side_effects: Option<BindingHookSideEffects>,
 }
 
 impl From<HookLoadOutput> for BindingHookJsLoadOutput {
@@ -167,7 +167,7 @@ impl From<HookLoadOutput> for BindingHookJsLoadOutput {
     Self {
       code: value.code.to_string(),
       map: value.map.map(|map| map.to_json_string()),
-      side_effects: value.side_effects.map(Into::into),
+      module_side_effects: value.side_effects.map(Into::into),
     }
   }
 }

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_load_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_load_output.rs
@@ -8,7 +8,7 @@ use crate::types::binding_sourcemap::BindingSourcemap;
 pub struct BindingHookLoadOutput {
   pub code: String,
   #[napi(ts_type = "boolean | 'no-treeshake'")]
-  pub side_effects: Option<BindingHookSideEffects>,
+  pub module_side_effects: Option<BindingHookSideEffects>,
   pub map: Option<BindingSourcemap>,
   pub module_type: Option<String>,
 }
@@ -20,7 +20,7 @@ impl TryFrom<BindingHookLoadOutput> for rolldown_plugin::HookLoadOutput {
     Ok(rolldown_plugin::HookLoadOutput {
       code: value.code.into(),
       map: value.map.map(TryInto::try_into).transpose()?,
-      side_effects: value.side_effects.map(TryInto::try_into).transpose()?,
+      side_effects: value.module_side_effects.map(TryInto::try_into).transpose()?,
       module_type: value.module_type.map(|ty| ModuleType::from_str_with_fallback(ty.as_str())),
     })
   }

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_output.rs
@@ -10,7 +10,7 @@ pub struct BindingHookResolveIdOutput {
   pub external: Option<BindingResolvedExternal>,
   pub normalize_external_id: Option<bool>,
   #[napi(ts_type = "boolean | 'no-treeshake'")]
-  pub side_effects: Option<BindingHookSideEffects>,
+  pub module_side_effects: Option<BindingHookSideEffects>,
 }
 
 impl TryFrom<BindingHookResolveIdOutput> for rolldown_plugin::HookResolveIdOutput {
@@ -21,7 +21,7 @@ impl TryFrom<BindingHookResolveIdOutput> for rolldown_plugin::HookResolveIdOutpu
       id: value.id.into(),
       external: value.external.map(TryInto::try_into).transpose()?,
       normalize_external_id: value.normalize_external_id,
-      side_effects: value.side_effects.map(TryInto::try_into).transpose()?,
+      side_effects: value.module_side_effects.map(TryInto::try_into).transpose()?,
     })
   }
 }

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_transform_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_transform_output.rs
@@ -8,7 +8,7 @@ use crate::types::binding_sourcemap::BindingSourcemap;
 #[derive(Default, Debug)]
 pub struct BindingHookTransformOutput {
   pub code: Option<String>,
-  pub side_effects: Option<BindingHookSideEffects>,
+  pub module_side_effects: Option<BindingHookSideEffects>,
   pub map: Option<BindingSourcemap>,
   pub module_type: Option<String>,
 }
@@ -20,7 +20,7 @@ impl TryFrom<BindingHookTransformOutput> for HookTransformOutput {
     Ok(Self {
       code: value.code,
       map: value.map.map(TryInto::try_into).transpose()?,
-      side_effects: value.side_effects.map(TryInto::try_into).transpose()?,
+      side_effects: value.module_side_effects.map(TryInto::try_into).transpose()?,
       module_type: value.module_type.map(|ty| ModuleType::from_str_with_fallback(ty.as_str())),
     })
   }
@@ -31,7 +31,7 @@ impl From<HookTransformOutput> for BindingHookTransformOutput {
     Self {
       code: value.code,
       map: value.map.map(|v| v.to_json().into()),
-      side_effects: value.side_effects.map(Into::into),
+      module_side_effects: value.side_effects.map(Into::into),
       module_type: value.module_type.map(|v| v.to_string()),
     }
   }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1404,7 +1404,7 @@ export interface BindingHookFilter {
 export interface BindingHookJsLoadOutput {
   code: string
   map?: string
-  sideEffects?: boolean | 'no-treeshake'
+  moduleSideEffects?: boolean | 'no-treeshake'
 }
 
 export interface BindingHookJsResolveIdOptions {
@@ -1415,12 +1415,12 @@ export interface BindingHookJsResolveIdOptions {
 export interface BindingHookJsResolveIdOutput {
   id: string
   external?: boolean | 'absolute' | 'relative'
-  sideEffects?: boolean | 'no-treeshake'
+  moduleSideEffects?: boolean | 'no-treeshake'
 }
 
 export interface BindingHookLoadOutput {
   code: string
-  sideEffects?: boolean | 'no-treeshake'
+  moduleSideEffects?: boolean | 'no-treeshake'
   map?: BindingSourcemap
   moduleType?: string
 }
@@ -1449,7 +1449,7 @@ export interface BindingHookResolveIdOutput {
   id: string
   external?: BindingResolvedExternal
   normalizeExternalId?: boolean
-  sideEffects?: boolean | 'no-treeshake'
+  moduleSideEffects?: boolean | 'no-treeshake'
 }
 
 export type BindingHookSideEffects =
@@ -1457,7 +1457,7 @@ export type BindingHookSideEffects =
 
 export interface BindingHookTransformOutput {
   code?: string
-  sideEffects?: BindingHookSideEffects
+  moduleSideEffects?: BindingHookSideEffects
   map?: BindingSourcemap
   moduleType?: string
 }

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -147,7 +147,7 @@ export function bindingifyResolveId(
         id: ret.id,
         external: ret.external,
         normalizeExternalId: false,
-        sideEffects: exist.moduleSideEffects ?? undefined,
+        moduleSideEffects: exist.moduleSideEffects ?? undefined,
       };
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -200,7 +200,7 @@ export function bindingifyResolveDynamicImport(
       };
 
       if (ret.moduleSideEffects !== null) {
-        result.sideEffects = ret.moduleSideEffects;
+        result.moduleSideEffects = ret.moduleSideEffects;
       }
 
       args.pluginContextData.updateModuleOption(ret.id, {
@@ -266,7 +266,7 @@ export function bindingifyTransform(
         map: bindingifySourcemap(
           normalizeTransformHookSourcemap(id, code, ret.map),
         ),
-        sideEffects: moduleOption.moduleSideEffects ?? undefined,
+        moduleSideEffects: moduleOption.moduleSideEffects ?? undefined,
         moduleType: ret.moduleType,
       };
     },
@@ -323,7 +323,7 @@ export function bindingifyLoad(
         code: ret.code,
         map: bindingifySourcemap(map),
         moduleType: ret.moduleType,
-        sideEffects: moduleOption.moduleSideEffects ?? undefined,
+        moduleSideEffects: moduleOption.moduleSideEffects ?? undefined,
       };
     },
     meta: bindingifyPluginHookMeta(meta),


### PR DESCRIPTION
`resolveId`, `load`, `transform` hooks should return `moduleSideEffects` property instead of `sideEffects` property.
Callable plugins were returning `sideEffects` property.