### PR TITLE
chore: use jsonc schema for knip config

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "$schema": "https://unpkg.com/knip@5/schema-jsonc.json",
   "ignoreBinaries": ["only-allow"],
   "ignoreWorkspaces": ["examples/**"], // no rolldown plugin yet
   "workspaces": {


### PR DESCRIPTION
The jsonc schema has `"allowTrailingCommas": true` and would suppress the trailing comma warnings in vscode.
https://github.com/webpro-nl/knip/blob/cbfb9c3b1c6fd4f77b5e5f0987e0f027ee609feb/packages/knip/schema-jsonc.json#L10
