### PR TITLE
test(rust): automatically run extented test for `minify_internal_exports: true`

### DIFF
--- a/crates/rolldown/tests/rolldown/function/minify_internal_exports/basic/_config.json
+++ b/crates/rolldown/tests/rolldown/function/minify_internal_exports/basic/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [{
+      "name": "main",
+      "import": "./main.js"
+    }, {
+      "name": "main2",
+      "import": "./main2.js"
+    }],
+    "minifyInternalExports": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/minify_internal_exports/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/minify_internal_exports/basic/artifacts.snap
@@ -1,0 +1,36 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## internal.js
+
+```js
+//#region internal.js
+const internal = "internal";
+
+//#endregion
+export { internal as b };
+```
+## main.js
+
+```js
+import { b as internal } from "./internal.js";
+
+//#region main.js
+const main = internal;
+
+//#endregion
+export { main };
+```
+## main2.js
+
+```js
+import { b as internal } from "./internal.js";
+
+//#region main2.js
+const main2 = internal;
+
+//#endregion
+export { main2 };
+```

--- a/crates/rolldown/tests/rolldown/function/minify_internal_exports/basic/internal.js
+++ b/crates/rolldown/tests/rolldown/function/minify_internal_exports/basic/internal.js
@@ -1,0 +1,1 @@
+export const internal = 'internal'

--- a/crates/rolldown/tests/rolldown/function/minify_internal_exports/basic/main.js
+++ b/crates/rolldown/tests/rolldown/function/minify_internal_exports/basic/main.js
@@ -1,0 +1,3 @@
+import { internal } from './internal'
+
+export const main = internal

--- a/crates/rolldown/tests/rolldown/function/minify_internal_exports/basic/main2.js
+++ b/crates/rolldown/tests/rolldown/function/minify_internal_exports/basic/main2.js
@@ -1,0 +1,3 @@
+import { internal } from './internal'
+
+export const main2 = internal

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4386,6 +4386,12 @@ expression: output
 
 - main-!~{000}~.js => main-CihG9yyg.js
 
+# tests/rolldown/function/minify_internal_exports/basic
+
+- main-!~{000}~.js => main-Dlg1NF9r.js
+- main2-!~{001}~.js => main2-CEYgtBPX.js
+- internal-!~{002}~.js => internal-DjTmYc72.js
+
 # tests/rolldown/function/module_types/asset
 
 - main-!~{000}~.js => main-BYCQS-ki.js

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -122,4 +122,5 @@ pub struct BindingOutputOptions<'env> {
   pub virtual_dirname: Option<String>,
   pub preserve_modules_root: Option<String>,
   pub top_level_var: Option<bool>,
+  pub minify_internal_exports: Option<bool>,
 }

--- a/crates/rolldown_binding/src/types/binding_normalized_options.rs
+++ b/crates/rolldown_binding/src/types/binding_normalized_options.rs
@@ -267,4 +267,9 @@ impl BindingNormalizedOptions {
   pub fn top_level_var(&self) -> bool {
     self.inner.top_level_var
   }
+
+  #[napi(getter)]
+  pub fn minify_internal_exports(&self) -> bool {
+    self.inner.minify_internal_exports
+  }
 }

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -468,7 +468,7 @@ pub fn normalize_binding_options(
       .transpose()?,
     optimization: input_options.optimization.map(OptimizationOption::from),
     top_level_var: output_options.top_level_var,
-    minify_internal_exports: Some(false),
+    minify_internal_exports: output_options.minify_internal_exports,
   };
 
   #[cfg(not(target_family = "wasm"))]

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -61,6 +61,9 @@
       "description": "Controls whether snapshots should be generated",
       "type": "boolean",
       "default": true
+    },
+    "extendedTests": {
+      "$ref": "#/$defs/ExtendedTests"
     }
   },
   "additionalProperties": false,
@@ -1354,6 +1357,29 @@
               "type": "null"
             }
           ]
+        },
+        "minifyInternalExports": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "_snapshot": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedTests": {
+      "type": "object",
+      "properties": {
+        "minifyInternalExports": {
+          "description": "Run the test case with `minifyInternalExports` enabled in addition to the default config.",
+          "type": "boolean",
+          "default": true
         }
       },
       "additionalProperties": false

--- a/crates/rolldown_testing_config/src/lib.rs
+++ b/crates/rolldown_testing_config/src/lib.rs
@@ -19,6 +19,11 @@ pub struct ConfigVariant {
   pub inline_dynamic_imports: Option<bool>,
   pub preserve_entry_signatures: Option<PreserveEntrySignatures>,
   pub treeshake: Option<TreeshakeOptions>,
+  pub minify_internal_exports: Option<bool>,
+  // --- non-bundler options are start with `_`
+  // Whether to include the output in the snapshot for this config variant.
+  #[serde(rename = "_snapshot")]
+  pub snapshot: Option<bool>,
 }
 
 impl ConfigVariant {
@@ -51,6 +56,9 @@ impl ConfigVariant {
     }
     if let Some(treeshake) = &self.treeshake {
       config.treeshake = treeshake.clone();
+    }
+    if let Some(minify_internal_exports) = &self.minify_internal_exports {
+      config.minify_internal_exports = Some(*minify_internal_exports);
     }
     config
   }
@@ -135,6 +143,8 @@ pub struct TestMeta {
   /// Controls whether snapshots should be generated
   #[serde(default = "true_by_default")]
   pub snapshot: bool,
+  #[serde(default)]
+  pub extended_tests: ExtendedTests,
 }
 
 impl Default for TestMeta {
@@ -145,4 +155,19 @@ impl Default for TestMeta {
 
 fn true_by_default() -> bool {
   true
+}
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[allow(clippy::struct_excessive_bools, clippy::pub_underscore_fields)]
+pub struct ExtendedTests {
+  /// Run the test case with `minifyInternalExports` enabled in addition to the default config.
+  #[serde(default = "true_by_default")]
+  pub minify_internal_exports: bool,
+}
+
+impl Default for ExtendedTests {
+  fn default() -> Self {
+    serde_json::from_str("{}").unwrap()
+  }
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1138,6 +1138,7 @@ export declare class BindingNormalizedOptions {
   get preserveModulesRoot(): string | undefined
   get virtualDirname(): string
   get topLevelVar(): boolean
+  get minifyInternalExports(): boolean
 }
 
 export declare class BindingOutputAsset {
@@ -1667,6 +1668,7 @@ export interface BindingOutputOptions {
   virtualDirname?: string
   preserveModulesRoot?: string
   topLevelVar?: boolean
+  minifyInternalExports?: boolean
 }
 
 export interface BindingOxcRuntimePluginConfig {

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -51,6 +51,7 @@ export interface NormalizedOutputOptions {
   virtualDirname: string;
   preserveModulesRoot?: string;
   topLevelVar?: boolean;
+  minifyInternalExports?: boolean;
 }
 
 // TODO: I guess we make these getters enumerable so it act more like a plain object
@@ -195,6 +196,10 @@ export class NormalizedOutputOptionsImpl implements NormalizedOutputOptions {
 
   get topLevelVar(): boolean {
     return this.inner.topLevelVar ?? false;
+  }
+
+  get minifyInternalExports(): boolean {
+    return this.inner.minifyInternalExports ?? false;
   }
 }
 

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -319,6 +319,13 @@ export interface OutputOptions {
   virtualDirname?: string;
   preserveModulesRoot?: string;
   topLevelVar?: boolean;
+  /**
+   * - Type: `boolean`
+   * - Default: `false`
+   *
+   * Whether to minify internal exports.
+   */
+  minifyInternalExports?: boolean;
 }
 
 interface OverwriteOutputOptionsForCli {

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -82,6 +82,7 @@ export function bindingifyOutputOptions(
     legalComments,
     preserveModulesRoot,
     topLevelVar,
+    minifyInternalExports: outputOptions.minifyInternalExports,
   };
 }
 

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -741,6 +741,10 @@ const OutputOptionsSchema = v.strictObject({
     v.description('Put preserved modules under this path at root level'),
   ),
   virtualDirname: v.optional(v.string()),
+  minifyInternalExports: v.pipe(
+    v.optional(v.boolean()),
+    v.description('Minify internal exports'),
+  ),
 });
 
 const getAddonDescription = (

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -57,6 +57,7 @@ OPTIONS
   --legal-comments <legal-comments>Control comments in the output.
   --log-level <log-level>     Log level (silent, info, debug, warn).
   --make-absolute-externals-relative Prevent normalization of external imports.
+  --minify-internal-exports   Minify internal exports.
   --module-types <types>      Module types for customized extensions.
   --no-external-live-bindings Disable external live bindings.
   --no-preserve-entry-signatures Avoid facade chunks for entry points.

--- a/packages/rolldown/tests/fixtures/verify-options/_config.ts
+++ b/packages/rolldown/tests/fixtures/verify-options/_config.ts
@@ -44,6 +44,7 @@ export default defineTest({
       preserveModules: true,
       preserveModulesRoot: "src",
       virtualDirname: "virtual",
+      minifyInternalExports: true,
     },
     plugins: [
       {
@@ -107,6 +108,7 @@ export default defineTest({
       expect(option.preserveModules).toBe(true)
       expect(option.preserveModulesRoot).toStrictEqual(path.join(__dirname, "src"))
       expect(option.virtualDirname).toBe('virtual')
+      expect(option.minifyInternalExports).toBe(true)
     })
   },
 })


### PR DESCRIPTION
- Closes https://github.com/rolldown/rolldown/issues/4785.

When `minify_internal_exports` gets stablized in the future, we might remove this or change it to test `minify_internal_exports: false` automatically.