### PR TITLE
feat(hmr): return `undefined` from `generateHmrPatch` when there is no patch

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -284,7 +284,10 @@ impl Bundler {
     &self.plugin_driver.watch_files
   }
 
-  pub async fn generate_hmr_patch(&mut self, changed_files: Vec<String>) -> BuildResult<Option<HmrOutput>> {
+  pub async fn generate_hmr_patch(
+    &mut self,
+    changed_files: Vec<String>,
+  ) -> BuildResult<Option<HmrOutput>> {
     self.hmr_manager.as_mut().expect("HMR manager is not initialized").hmr(changed_files).await
   }
 

--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -284,7 +284,7 @@ impl Bundler {
     &self.plugin_driver.watch_files
   }
 
-  pub async fn generate_hmr_patch(&mut self, changed_files: Vec<String>) -> BuildResult<HmrOutput> {
+  pub async fn generate_hmr_patch(&mut self, changed_files: Vec<String>) -> BuildResult<Option<HmrOutput>> {
     self.hmr_manager.as_mut().expect("HMR manager is not initialized").hmr(changed_files).await
   }
 

--- a/crates/rolldown_binding/src/types/binding_hmr_output.rs
+++ b/crates/rolldown_binding/src/types/binding_hmr_output.rs
@@ -40,6 +40,12 @@ impl From<rolldown_common::HmrOutput> for BindingHmrOutput {
   }
 }
 
+impl From<Option<rolldown_common::HmrOutput>> for BindingHmrOutput {
+  fn from(value: Option<rolldown_common::HmrOutput>) -> Self {
+    Self { patch: value.map(Into::into), errors: None }
+  }
+}
+
 #[napi_derive::napi(object)]
 #[derive(Debug)]
 pub struct BindingHmrOutputPatch {

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -169,18 +169,20 @@ impl IntegrationTest {
             let hmr_output = bundler.generate_hmr_patch(changed_files).await;
             match hmr_output {
               Ok(output) => {
-                let snapshot_content =
-                  Self::render_hmr_output_to_string(step, &output, vec![], &cwd);
-                collect_snapshot(snapshot_content);
+                if let Some(output) = output {
+                  let snapshot_content =
+                    Self::render_hmr_output_to_string(step, &output, vec![], &cwd);
+                  collect_snapshot(snapshot_content);
 
-                if execute_output {
-                  assert!(
-                    !output.full_reload,
-                    "execute_output should be false when full reload happens"
-                  );
-                  let output_path = format!("{}/{}", &output_dir, &output.filename);
-                  fs::write(&output_path, output.code).unwrap();
-                  patch_chunks.push(format!("./{}", output.filename));
+                  if execute_output {
+                    assert!(
+                      !output.full_reload,
+                      "execute_output should be false when full reload happens"
+                    );
+                    let output_path = format!("{}/{}", &output_dir, &output.filename);
+                    fs::write(&output_path, output.code).unwrap();
+                    patch_chunks.push(format!("./{}", output.filename));
+                  }
                 }
               }
               Err(errs) => {

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -80,7 +80,7 @@ export class RolldownBuild {
 
   async generateHmrPatch(
     changedFiles: string[],
-  ): Promise<BindingHmrOutputPatch> {
+  ): Promise<BindingHmrOutputPatch | undefined> {
     const output = await this.#bundlerImpl!.impl.generateHmrPatch(
       changedFiles,
     );
@@ -95,7 +95,7 @@ export class RolldownBuild {
       file,
       firstInvalidatedBy,
     );
-    return transformHmrPatchOutput(output);
+    return transformHmrPatchOutput(output)!;
   }
 
   // TODO(underfin)

--- a/packages/rolldown/src/utils/transform-hmr-patch-output.ts
+++ b/packages/rolldown/src/utils/transform-hmr-patch-output.ts
@@ -3,10 +3,10 @@ import { normalizeErrors } from './error';
 
 export function transformHmrPatchOutput(
   output: BindingHmrOutput,
-): BindingHmrOutputPatch {
+): BindingHmrOutputPatch | undefined {
   handleHmrPatchOutputErrors(output);
   const { patch } = output;
-  return patch!;
+  return patch ?? undefined;
 }
 
 function handleHmrPatchOutputErrors(output: BindingHmrOutput): void {


### PR DESCRIPTION
so that I can handle this condition more properly.
https://github.com/vitejs/rolldown-vite/blob/502c04e24af11b85ff96f09a901cf19487b12287/packages/vite/src/node/server/environments/fullBundleEnvironment.ts#L359-L363
