### PR TITLE
feat: add `export`s to `rolldown:runtime`

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -209,6 +209,70 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
 
     vec![decl_stmt, export_call_stmt]
   }
+
+  // Rewrite `import(...)` to sensible form.
+  fn try_rewrite_dynamic_import(&self, it: &mut ast::Expression<'ast>) {
+    let ast::Expression::ImportExpression(import_expr) = it else {
+      return;
+    };
+
+    let Some(rec_idx) = self.module.imports.get(&import_expr.span) else {
+      return;
+    };
+
+    let importee_idx = &self.module.import_records[*rec_idx].resolved_module;
+
+    let Module::Normal(importee) = &self.modules[*importee_idx] else {
+      // Not a normal module, skip
+      return;
+    };
+    // FIXME: consider about CommonJS interop
+    // let is_importee_cjs = importee.exports_kind == rolldown_common::ExportsKind::CommonJs;
+
+    // Turn `import('./foo.js')` into `(init_foo(), Promise.resolve().then(() => __rolldown_runtime__.loadExports('./foo.js')))`
+
+    let init_fn_name = &self.affected_module_idx_to_init_fn_name[importee_idx];
+
+    // init_foo()
+    let init_fn_call = self.snippet.builder.alloc_call_expression(
+      SPAN,
+      self.snippet.id_ref_expr(init_fn_name, SPAN),
+      NONE,
+      self.snippet.builder.vec(),
+      false,
+    );
+
+    // __rolldown_runtime__.loadExports('./foo.js')
+    let load_exports_call_expr =
+      ast::Expression::CallExpression(self.snippet.builder.alloc_call_expression(
+        SPAN,
+        self.snippet.id_ref_expr("__rolldown_runtime__.loadExports", SPAN),
+        NONE,
+        self.snippet.builder.vec1(ast::Argument::StringLiteral(
+          self.snippet.builder.alloc_string_literal(
+            SPAN,
+            self.snippet.builder.atom(&importee.stable_id),
+            None,
+          ),
+        )),
+        false,
+      ));
+
+    // Promise.resolve().then(() => __rolldown_runtime__.loadExports('./foo.js'))
+    let promise_resolve_then_load_exports =
+      self.snippet.promise_resolve_then_call_expr(load_exports_call_expr);
+
+    // (init_foo(), Promise.resolve().then(() => __rolldown_runtime__.loadExports('./foo.js')))
+    let ret_expr =
+      ast::Expression::SequenceExpression(self.snippet.builder.alloc_sequence_expression(
+        SPAN,
+        self.snippet.builder.vec_from_array([
+          ast::Expression::CallExpression(init_fn_call),
+          promise_resolve_then_load_exports,
+        ]),
+      ));
+    *it = ret_expr;
+  }
 }
 
 impl<'ast> VisitMut<'ast> for HmrAstFinalizer<'_, 'ast> {
@@ -536,18 +600,6 @@ impl<'ast> VisitMut<'ast> for HmrAstFinalizer<'_, 'ast> {
     // console.log(foo);
     // ```
 
-    // For `import()` statements
-    // Transform
-    // ```js
-    // const foo = await import('./foo.js');
-    // console.log(foo);
-    // ```
-    // to
-    // ```js
-    // const foo = await Promise.resolve(__rolldown_runtime__.loadExports('./foo.js'));
-    // console.log(foo);
-    // ```
-
     walk_mut::walk_statement(self, node);
   }
 
@@ -563,6 +615,8 @@ impl<'ast> VisitMut<'ast> for HmrAstFinalizer<'_, 'ast> {
         }
       }
     }
+
+    self.try_rewrite_dynamic_import(it);
 
     self.rewrite_import_meta_hot(it);
 

--- a/crates/rolldown/src/runtime/index.js
+++ b/crates/rolldown/src/runtime/index.js
@@ -1,27 +1,27 @@
 // Port from https://github.com/evanw/esbuild/blob/main/internal/runtime/runtime.go
-var __create = Object.create
-var __defProp = Object.defineProperty
-var __name = (target, value) => __defProp(target, "name", { value, configurable: true });
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor // Note: can return "undefined" due to a Safari bug
-var __getOwnPropNames = Object.getOwnPropertyNames
-var __getProtoOf = Object.getPrototypeOf
-var __hasOwnProp = Object.prototype.hasOwnProperty
+export var __create = Object.create
+export var __defProp = Object.defineProperty
+export var __name = (target, value) => __defProp(target, "name", { value, configurable: true });
+export var __getOwnPropDesc = Object.getOwnPropertyDescriptor // Note: can return "undefined" due to a Safari bug
+export var __getOwnPropNames = Object.getOwnPropertyNames
+export var __getProtoOf = Object.getPrototypeOf
+export var __hasOwnProp = Object.prototype.hasOwnProperty
 // This is for lazily-initialized ESM code. This has two implementations, a
 // compact one for minified code and a verbose one that generates friendly
 // names in V8's profiler and in stack traces.
-var __esm = (fn, res) => function () {
+export var __esm = (fn, res) => function () {
   return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res
 }
-var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res)
+export var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res)
 // Wraps a CommonJS closure and returns a require() function. This has two
 // implementations, a compact one for minified code and a verbose one that
 // generates friendly names in V8's profiler and in stack traces.
-var __commonJS = (cb, mod) => function () {
+export var __commonJS = (cb, mod) => function () {
   return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports
 }
-var __commonJSMin = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports)
+export var __commonJSMin = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports)
 // Used to implement ESM exports both for "require()" and "import * as"
-var __export = (target, all) => {
+export var __export = (target, all) => {
   for (var name in all)
     __defProp(target, name, { get: all[name], enumerable: true })
 }
@@ -31,7 +31,7 @@ var __export = (target, all) => {
 // shim to fall back to "globalThis.require" even if it's defined later
 // (including property accesses such as "require.resolve") so we need to
 // use a proxy (issue #1614).
-var __require = /* @__PURE__ */ (x =>
+export var __require = /* @__PURE__ */ (x =>
   typeof require !== 'undefined' ? require :
     typeof Proxy !== 'undefined' ? new Proxy(x, {
       get: (a, b) => (typeof require !== 'undefined' ? require : a)[b]
@@ -55,7 +55,7 @@ var __copyProps = (to, from, except, desc) => {
 // current module is an entry point and the target format is CommonJS, we
 // also copy the properties to "module.exports" in addition to our module's
 // internal ESM export object.
-var __reExport = (target, mod, secondTarget) => (
+export var __reExport = (target, mod, secondTarget) => (
   __copyProps(target, mod, 'default'),
   secondTarget && __copyProps(secondTarget, mod, 'default')
 )
@@ -64,7 +64,7 @@ var __reExport = (target, mod, secondTarget) => (
 // ".mjs" file, package.json has "type: module", or the "__esModule" export
 // in the CommonJS file is falsy or missing), the "default" property is
 // overridden to point to the original CommonJS exports object instead.
-var __toESM = (mod, isNodeMode, target) => (
+export var __toESM = (mod, isNodeMode, target) => (
   target = mod != null ? __create(__getProtoOf(mod)) : {},
   __copyProps(
     // If the importer is in node compatibility mode or this is not an ESM
@@ -80,7 +80,7 @@ var __toESM = (mod, isNodeMode, target) => (
 // Converts the module from ESM to CommonJS. This clones the input module
 // object with the addition of a non-enumerable "__esModule" property set
 // to "true", which overwrites any existing export named "__esModule".
-var __toCommonJS = mod => __copyProps(__defProp({}, '__esModule', { value: true }), mod)
+export var __toCommonJS = mod => __copyProps(__defProp({}, '__esModule', { value: true }), mod)
 
 // This is for the "binary" loader (custom code is ~2x faster than "atob")
 export var __toBinaryNode = base64 => new Uint8Array(Buffer.from(base64, 'base64'))

--- a/crates/rolldown/src/runtime/runtime-base.js
+++ b/crates/rolldown/src/runtime/runtime-base.js
@@ -1,16 +1,16 @@
 
-var __create = Object.create
-var __defProp = Object.defineProperty
-var __name = (target, value) => __defProp(target, "name", { value, configurable: true });
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor
-var __getOwnPropNames = Object.getOwnPropertyNames
-var __getProtoOf = Object.getPrototypeOf
-var __hasOwnProp = Object.prototype.hasOwnProperty
-var __esm = (fn, res) => function () {
+export var __create = Object.create
+export var __defProp = Object.defineProperty
+export var __name = (target, value) => __defProp(target, "name", { value, configurable: true });
+export var __getOwnPropDesc = Object.getOwnPropertyDescriptor
+export var __getOwnPropNames = Object.getOwnPropertyNames
+export var __getProtoOf = Object.getPrototypeOf
+export var __hasOwnProp = Object.prototype.hasOwnProperty
+export var __esm = (fn, res) => function () {
   return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res
 }
-var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res)
-var __commonJS = (cb, mod) => function () {
+export var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res)
+export var __commonJS = (cb, mod) => function () {
   return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports
 }
 var __commonJSMin = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports)
@@ -18,7 +18,7 @@ export var __export = (target, all) => {
   for (var name in all)
     __defProp(target, name, { get: all[name], enumerable: true })
 }
-var __copyProps = (to, from, except, desc) => {
+export var __copyProps = (to, from, except, desc) => {
   if (from && typeof from === 'object' || typeof from === 'function')
     for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
       key = keys[i]
@@ -27,7 +27,7 @@ var __copyProps = (to, from, except, desc) => {
     }
   return to
 }
-var __reExport = (target, mod, secondTarget) => (
+export var __reExport = (target, mod, secondTarget) => (
   __copyProps(target, mod, 'default'),
   secondTarget && __copyProps(secondTarget, mod, 'default')
 )

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "hmr": {}
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -1,0 +1,69 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+
+// HIDDEN [rolldown:hmr]
+//#region hmr.js
+var hmr_exports = {};
+const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
+__rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+hmr_hot.accept((mod) => {
+	if (mod) console.log(".hmr", mod.foo);
+});
+
+//#endregion
+//#region main.js
+var main_exports = {};
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+
+//#endregion
+```
+# HMR Step 0
+
+## Code
+
+```js
+var init_hmr_0 = __rolldown_runtime__.createEsmInitializer(function() {
+	try {
+		var ns_hmr = {};
+		__rolldown_runtime__.__export(ns_hmr, { foo: () => foo });
+		__rolldown_runtime__.registerModule("hmr.js", { exports: ns_hmr });
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
+		hot_hmr.accept((mod) => {
+			if (mod) console.log(".hmr", mod.foo);
+		});
+		async function foo() {
+			const mod = await (init_new_dep_1(), Promise.resolve().then(() => __rolldown_runtime__.loadExports("new-dep.js")));
+			console.log(mod.value);
+		}
+	} finally {}
+});
+
+var init_new_dep_1 = __rolldown_runtime__.createEsmInitializer(function() {
+	try {
+		var ns_new_dep = {};
+		__rolldown_runtime__.__export(ns_new_dep, { value: () => value });
+		__rolldown_runtime__.registerModule("new-dep.js", { exports: ns_new_dep });
+		const hot_new_dep = __rolldown_runtime__.createModuleHotContext("new-dep.js");
+		const value = "hello";
+	} finally {}
+});
+
+init_hmr_0()
+__rolldown_runtime__.applyUpdates(['hmr.js']);
+```
+## Meta
+
+- full_reload: false
+- first_invalidated_by: None
+- is_self_accepting: false
+- full_reload_reason: None
+### Hmr Boundaries
+
+- boundary: hmr.js, accepted_via: hmr.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/hmr.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/hmr.hmr-0.js
@@ -1,0 +1,9 @@
+import.meta.hot.accept((mod) => {
+  if (mod) {
+    console.log('.hmr', mod.foo)
+  }
+})
+export async function foo() {
+  const mod = await import('./new-dep.js')
+  console.log(mod.value)
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/hmr.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/hmr.js
@@ -1,0 +1,5 @@
+import.meta.hot.accept((mod) => {
+  if (mod) {
+    console.log('.hmr', mod.foo)
+  }
+})

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/main.js
@@ -1,0 +1,1 @@
+import './hmr.js'

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/new-dep.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/new-dep.js
@@ -1,0 +1,1 @@
+export const value = 'hello'

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5435,6 +5435,10 @@ expression: output
 
 - main-!~{000}~.js => main-BgBqOpSC.js
 
+# tests/rolldown/topics/hmr/dynamic_import
+
+- main-!~{000}~.js => main-D5MSSgFu.js
+
 # tests/rolldown/topics/hmr/generate_patch_error
 
 - main-!~{000}~.js => main-DdmvPD9K.js


### PR DESCRIPTION
Notes:
- The original runtime code had `export`s. They are removed by accident.
- `rolldown:hmr` is a normal module now, it can only interact with `rolldown:runtime` via the esm `import/export` mechanism.