### PR TITLE
feat: support `chunkModulesOrder` 

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -1,7 +1,12 @@
 use arcstr::ArcStr;
+use itertools::Itertools;
 use oxc_index::{IndexVec, index_vec};
-use rolldown_common::{Chunk, ChunkIdx, ChunkTable, ModuleIdx, SymbolRef};
+use rolldown_common::{
+  Chunk, ChunkIdx, ChunkModulesOrderBy, ChunkTable, EcmaViewMeta, ModuleIdx, SymbolRef,
+};
 use rustc_hash::FxHashMap;
+
+use crate::{SharedOptions, stages::link_stage::LinkStageOutput};
 
 #[derive(Debug)]
 pub struct ChunkGraph {
@@ -41,5 +46,46 @@ impl ChunkGraph {
   pub fn add_module_to_chunk(&mut self, module_idx: ModuleIdx, chunk_idx: ChunkIdx) {
     self.chunk_table.chunks[chunk_idx].modules.push(module_idx);
     self.module_to_chunk[module_idx] = Some(chunk_idx);
+  }
+
+  pub fn sort_chunk_modules(&mut self, link_output: &LinkStageOutput, options: &SharedOptions) {
+    // Sort modules in each chunk by execution order
+    self.chunk_table.iter_mut().for_each(|chunk| {
+      if matches!(
+        options.experimental.chunk_modules_order.unwrap_or_default(),
+        ChunkModulesOrderBy::ExecOrder
+      ) {
+        chunk.modules.sort_by_cached_key(|idx| link_output.module_table[*idx].exec_order());
+        return;
+      }
+
+      // group those leaf module that has no side effects together.
+      let mut side_effects_free_leaf_modules = vec![];
+      let mut rest = vec![];
+      let mut runtime_related = vec![];
+      for &module_idx in &chunk.modules {
+        let module = &link_output.module_table[module_idx];
+        if module.id().starts_with("rolldown:") {
+          runtime_related.push(module_idx);
+          continue;
+        }
+        if let Some(normal) = module.as_normal()
+          && normal.import_records.is_empty()
+          && !normal.meta.contains(EcmaViewMeta::HAS_ANALYZED_SIDE_EFFECT)
+        {
+          side_effects_free_leaf_modules.push(module_idx);
+        } else {
+          rest.push(module_idx);
+        }
+      }
+      side_effects_free_leaf_modules.sort_by_cached_key(|idx| link_output.module_table[*idx].id());
+      rest.sort_by_cached_key(|idx| link_output.module_table[*idx].exec_order());
+      runtime_related.sort_by_cached_key(|idx| link_output.module_table[*idx].exec_order());
+
+      chunk.modules = runtime_related
+        .into_iter()
+        .chain(side_effects_free_leaf_modules.into_iter().chain(rest))
+        .collect_vec();
+    });
   }
 }

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -155,12 +155,7 @@ impl GenerateStage<'_> {
       }
     }
 
-    // Sort modules in each chunk by execution order
-    chunk_graph.chunk_table.iter_mut().for_each(|chunk| {
-      chunk
-        .modules
-        .sort_unstable_by_key(|module_id| self.link_output.module_table[*module_id].exec_order());
-    });
+    chunk_graph.sort_chunk_modules(self.link_output, self.options);
 
     chunk_graph
       .chunk_table

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "chunkModulesOrder": "moduleId"
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/_test.mjs
@@ -1,0 +1,2 @@
+import assert from "node:assert"
+

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/a.js
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/a.js
@@ -1,0 +1,1 @@
+export const a = 'a'

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/artifacts.snap
@@ -1,0 +1,25 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region a.js
+const a = "a";
+
+//#endregion
+//#region b.js
+const b = "b";
+
+//#endregion
+//#region c.js
+const c = "c";
+
+//#endregion
+//#region main.js
+console.log(a, b, c);
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/b.js
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/c.js
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/c.js
@@ -1,0 +1,1 @@
+export const c = 'c'

--- a/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/main.js
+++ b/crates/rolldown/tests/rolldown/topics/chunk_modules_order/basic/main.js
@@ -1,0 +1,6 @@
+import {c} from './c'
+import {b} from './b'
+import {a} from './a'
+
+console.log(a, b, c)
+

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5350,6 +5350,10 @@ expression: output
 
 - entry-!~{000}~.js => entry-OEtcTgKT.js
 
+# tests/rolldown/topics/chunk_modules_order/basic
+
+- main-!~{000}~.js => main-CR3sFzVE.js
+
 # tests/rolldown/topics/cjs_module_lexer_compat/export_star_from_external
 
 - main-!~{000}~.js => main-mcqoN11I.js

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -7,6 +7,7 @@ pub struct BindingExperimentalOptions {
   pub resolve_new_url_to_asset: Option<bool>,
   pub hmr: Option<BindingExperimentalHmrOptions>,
   pub attach_debug_info: Option<BindingAttachDebugInfo>,
+  pub chunk_modules_order: Option<BindingChunkModuleOrderBy>,
 }
 
 impl From<BindingExperimentalOptions> for rolldown_common::ExperimentalOptions {
@@ -20,6 +21,7 @@ impl From<BindingExperimentalOptions> for rolldown_common::ExperimentalOptions {
       incremental_build: None,
       hmr: value.hmr.map(Into::into),
       attach_debug_info: value.attach_debug_info.map(Into::into),
+      chunk_modules_order: value.chunk_modules_order.map(Into::into),
     }
   }
 }
@@ -52,6 +54,22 @@ impl From<BindingAttachDebugInfo> for rolldown_common::AttachDebugInfo {
       BindingAttachDebugInfo::None => rolldown_common::AttachDebugInfo::None,
       BindingAttachDebugInfo::Simple => rolldown_common::AttachDebugInfo::Simple,
       BindingAttachDebugInfo::Full => rolldown_common::AttachDebugInfo::Full,
+    }
+  }
+}
+
+#[derive(Debug)]
+#[napi_derive::napi]
+pub enum BindingChunkModuleOrderBy {
+  ModuleId,
+  ExecOrder,
+}
+
+impl From<BindingChunkModuleOrderBy> for rolldown_common::ChunkModulesOrderBy {
+  fn from(value: BindingChunkModuleOrderBy) -> Self {
+    match value {
+      BindingChunkModuleOrderBy::ModuleId => rolldown_common::ChunkModulesOrderBy::ModuleId,
+      BindingChunkModuleOrderBy::ExecOrder => rolldown_common::ChunkModulesOrderBy::ExecOrder,
     }
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/chunk_modules_order.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/chunk_modules_order.rs
@@ -1,0 +1,16 @@
+#[cfg(feature = "deserialize_bundler_options")]
+use schemars::JsonSchema;
+#[cfg(feature = "deserialize_bundler_options")]
+use serde::Deserialize;
+
+#[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
+  serde(rename_all = "camelCase", deny_unknown_fields)
+)]
+pub enum ChunkModulesOrderBy {
+  #[default]
+  ExecOrder,
+  ModuleId,
+}

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use crate::ROLLDOWN_IGNORE;
 
 use super::attach_debug_info::AttachDebugInfo;
+use super::chunk_modules_order::ChunkModulesOrderBy;
 use super::hmr_options::HmrOptions;
 
 #[derive(Debug, Default, Clone)]
@@ -22,6 +23,7 @@ pub struct ExperimentalOptions {
   pub incremental_build: Option<bool>,
   pub hmr: Option<HmrOptions>,
   pub attach_debug_info: Option<AttachDebugInfo>,
+  pub chunk_modules_order: Option<ChunkModulesOrderBy>,
 }
 
 impl ExperimentalOptions {

--- a/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod advanced_chunks_options;
 pub mod attach_debug_info;
+pub mod chunk_modules_order;
 pub mod debug_options;
 pub mod defer_sync_scan_data_option;
 pub mod es_module_flag;

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -23,6 +23,7 @@ pub mod bundler_options {
         AdvancedChunksOptions, ChunkingContext, MatchGroup, MatchGroupName, MatchGroupTest,
       },
       attach_debug_info::AttachDebugInfo,
+      chunk_modules_order::ChunkModulesOrderBy,
       debug_options::DebugOptions,
       defer_sync_scan_data_option::DeferSyncScanDataOption,
       es_module_flag::EsModuleFlag,

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -841,6 +841,16 @@
               "type": "null"
             }
           ]
+        },
+        "chunkModulesOrder": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ChunkModulesOrderBy"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -881,6 +891,13 @@
         "none",
         "simple",
         "full"
+      ]
+    },
+    "ChunkModulesOrderBy": {
+      "type": "string",
+      "enum": [
+        "execOrder",
+        "moduleId"
       ]
     },
     "RawMinifyOptions": {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1330,6 +1330,11 @@ export interface BindingChecksOptions {
   configurationFieldConflict?: boolean
 }
 
+export declare enum BindingChunkModuleOrderBy {
+  ModuleId = 0,
+  ExecOrder = 1
+}
+
 export interface BindingDebugOptions {
   sessionId?: string
 }
@@ -1374,6 +1379,7 @@ export interface BindingExperimentalOptions {
   resolveNewUrlToAsset?: boolean
   hmr?: BindingExperimentalHmrOptions
   attachDebugInfo?: BindingAttachDebugInfo
+  chunkModulesOrder?: BindingChunkModuleOrderBy
 }
 
 export interface BindingFilterToken {

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -376,7 +376,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Severity, ParseResult, ExportExportNameKind, ExportImportNameKind, ExportLocalNameKind, ImportNameKind, parseAsync, parseSync, rawTransferSupported, ResolverFactory, EnforceExtension, ModuleType, sync, HelperMode, isolatedDeclaration, moduleRunnerTransform, transform, BindingBundleEndEventData, BindingBundleErrorEventData, BindingBundler, BindingBundlerImpl, BindingCallableBuiltinPlugin, BindingChunkingContext, BindingError, BindingHmrOutput, BindingModuleInfo, BindingNormalizedOptions, BindingOutputAsset, BindingOutputChunk, BindingOutputs, BindingPluginContext, BindingRenderedChunk, BindingRenderedChunkMeta, BindingRenderedModule, BindingTransformPluginContext, BindingWatcher, BindingWatcherChangeData, BindingWatcherEvent, ParallelJsPluginRegistry, BindingAttachDebugInfo, BindingBuiltinPluginName, BindingJsx, BindingLogLevel, BindingPluginOrder, FilterTokenKind, registerPlugins, shutdownAsyncRuntime, startAsyncRuntime } = nativeBinding
+const { Severity, ParseResult, ExportExportNameKind, ExportImportNameKind, ExportLocalNameKind, ImportNameKind, parseAsync, parseSync, rawTransferSupported, ResolverFactory, EnforceExtension, ModuleType, sync, HelperMode, isolatedDeclaration, moduleRunnerTransform, transform, BindingBundleEndEventData, BindingBundleErrorEventData, BindingBundler, BindingBundlerImpl, BindingCallableBuiltinPlugin, BindingChunkingContext, BindingError, BindingHmrOutput, BindingModuleInfo, BindingNormalizedOptions, BindingOutputAsset, BindingOutputChunk, BindingOutputs, BindingPluginContext, BindingRenderedChunk, BindingRenderedChunkMeta, BindingRenderedModule, BindingTransformPluginContext, BindingWatcher, BindingWatcherChangeData, BindingWatcherEvent, ParallelJsPluginRegistry, BindingAttachDebugInfo, BindingBuiltinPluginName, BindingChunkModuleOrderBy, BindingJsx, BindingLogLevel, BindingPluginOrder, FilterTokenKind, registerPlugins, shutdownAsyncRuntime, startAsyncRuntime } = nativeBinding
 export { Severity }
 export { ParseResult }
 export { ExportExportNameKind }
@@ -418,6 +418,7 @@ export { BindingWatcherEvent }
 export { ParallelJsPluginRegistry }
 export { BindingAttachDebugInfo }
 export { BindingBuiltinPluginName }
+export { BindingChunkModuleOrderBy }
 export { BindingJsx }
 export { BindingLogLevel }
 export { BindingPluginOrder }

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -74,6 +74,8 @@ export type OptimizationOptions = {
 
 export type AttachDebugOptions = 'none' | 'simple' | 'full';
 
+type ChunkModulesOrder = 'exec-order' | 'module-id';
+
 interface RollupJsxOptions {
   mode?: 'classic' | 'automatic' | 'preserve';
   factory?: string;
@@ -141,6 +143,18 @@ export interface InputOptions {
     viteMode?: boolean;
     resolveNewUrlToAsset?: boolean;
     hmr?: HmrOptions;
+    /**
+     * Control which order should use when rendering modules in chunk
+     *
+     * - Type: `'exec-order' | 'module-id'
+     * - Default: `'exec-order'`
+     *
+     * - `exec-order`: Almost equivalent to the topological order of the module graph, but specially handling when module graph has cycle.
+     * - `module-id`: This is more friendly for gzip compression, especially for some javascript static asset lib (e.g. icon library)
+     * > [!NOTE]
+     * > Try to sort the modules by their module id if possible(Since rolldown scope hoist all modules in the chunk, we only try to sort those modules by module id if we could ensure runtime behavior is correct after sorting).
+     */
+    chunkModulesOrder?: ChunkModulesOrder;
     /**
      * Attach debug information to the output bundle.
      *

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -102,6 +102,7 @@ export const BindingWatcherEvent = __napiModule.exports.BindingWatcherEvent
 export const ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
 export const BindingAttachDebugInfo = __napiModule.exports.BindingAttachDebugInfo
 export const BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName
+export const BindingChunkModuleOrderBy = __napiModule.exports.BindingChunkModuleOrderBy
 export const BindingJsx = __napiModule.exports.BindingJsx
 export const BindingLogLevel = __napiModule.exports.BindingLogLevel
 export const BindingPluginOrder = __napiModule.exports.BindingPluginOrder

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -149,6 +149,7 @@ module.exports.BindingWatcherEvent = __napiModule.exports.BindingWatcherEvent
 module.exports.ParallelJsPluginRegistry = __napiModule.exports.ParallelJsPluginRegistry
 module.exports.BindingAttachDebugInfo = __napiModule.exports.BindingAttachDebugInfo
 module.exports.BindingBuiltinPluginName = __napiModule.exports.BindingBuiltinPluginName
+module.exports.BindingChunkModuleOrderBy = __napiModule.exports.BindingChunkModuleOrderBy
 module.exports.BindingJsx = __napiModule.exports.BindingJsx
 module.exports.BindingLogLevel = __napiModule.exports.BindingLogLevel
 module.exports.BindingPluginOrder = __napiModule.exports.BindingPluginOrder

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -1,5 +1,6 @@
 import {
   BindingAttachDebugInfo,
+  BindingChunkModuleOrderBy,
   BindingJsx,
   BindingLogLevel,
 } from '../binding';
@@ -86,16 +87,7 @@ export function bindingifyInputOptions(
       ? Object.entries(inputOptions.define)
       : undefined,
     inject: bindingifyInject(inputOptions.inject),
-    experimental: {
-      strictExecutionOrder: inputOptions.experimental?.strictExecutionOrder,
-      disableLiveBindings: inputOptions.experimental?.disableLiveBindings,
-      viteMode: inputOptions.experimental?.viteMode,
-      resolveNewUrlToAsset: inputOptions.experimental?.resolveNewUrlToAsset,
-      hmr: bindingifyHmr(inputOptions.experimental?.hmr),
-      attachDebugInfo: bindingifyAttachDebugInfo(
-        inputOptions.experimental?.attachDebugInfo,
-      ),
-    },
+    experimental: bindingifyExperimental(inputOptions.experimental),
     profilerNames: inputOptions?.profilerNames,
     jsx,
     transform,
@@ -176,6 +168,37 @@ function bindingifyExternal(
       });
     };
   }
+}
+
+function bindingifyExperimental(
+  experimental: InputOptions['experimental'],
+): BindingInputOptions['experimental'] {
+  let chunkModulesOrder = BindingChunkModuleOrderBy.ExecOrder;
+  if (experimental?.chunkModulesOrder) {
+    switch (experimental.chunkModulesOrder) {
+      case 'exec-order':
+        chunkModulesOrder = BindingChunkModuleOrderBy.ExecOrder;
+        break;
+      case 'module-id':
+        chunkModulesOrder = BindingChunkModuleOrderBy.ModuleId;
+        break;
+      default:
+        throw new Error(
+          `Unexpected chunkModulesOrder: ${experimental.chunkModulesOrder}`,
+        );
+    }
+  }
+  return {
+    strictExecutionOrder: experimental?.strictExecutionOrder,
+    disableLiveBindings: experimental?.disableLiveBindings,
+    viteMode: experimental?.viteMode,
+    resolveNewUrlToAsset: experimental?.resolveNewUrlToAsset,
+    hmr: bindingifyHmr(experimental?.hmr),
+    attachDebugInfo: bindingifyAttachDebugInfo(
+      experimental?.attachDebugInfo,
+    ),
+    chunkModulesOrder,
+  };
 }
 
 function bindingifyResolve(

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -404,6 +404,10 @@ const InputOptionsSchema = v.strictObject({
         v.literal('simple'),
         v.literal('full'),
       ])),
+      chunkModulesOrder: v.optional(v.union([
+        v.literal('module-id'),
+        v.literal('exec-order'),
+      ])),
     }),
   ),
   define: v.pipe(


### PR DESCRIPTION
opt-in support sort chunk modules by their moduleId, only if
- All those modules are leaf module (without any dependency)
- Those modules should not have side effects

I have tried other ways: 
- construct a matrix that could `O(1)` search if  module `a` is a descendant of module `b` but the time complexity is `O(n ^ 3)` and `O(n ^2)` space complexity, `n` is the count of module in module graph , one case would be: 
`a` -> `b` -> `c` -> .....  -> `n`, they you need to calc descendant of `n`, `n-1` ... `a`, that simply equals to `1 + 2 + 3 + 4 + ... + n`, this is only for one entry if it is a fully connected module then the overall complexity would be `O(n ^3)`, But since we would bailout for circular reference, a more proper estimitate would be `O(n ^2)` which is still not scale, the worse thing is this sometimes leads a none total order sorting, so I came up such a simple strategy, but it is good enoguh for now.