### PR TITLE
fix: do not normalize iife global names

### DIFF
--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -37,7 +37,7 @@ use crate::{
 use rolldown_common::{AddonRenderContext, ExternalModule, OutputExports};
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_sourcemap::SourceJoiner;
-use rolldown_utils::{concat_string, ecmascript::legitimize_identifier_name};
+use rolldown_utils::concat_string;
 
 use super::utils::{
   render_chunk_directives, render_chunk_external_imports, render_factory_parameters,
@@ -188,7 +188,7 @@ async fn render_iife_factory_arguments(
   for external in externals {
     let global = globals.call(external.id.as_str()).await;
     let target = match &global {
-      Some(global_name) => legitimize_identifier_name(global_name).to_string(),
+      Some(global_name) => global_name.to_string(),
       None => {
         warnings.push(
           BuildDiagnostic::missing_global_name(


### PR DESCRIPTION
Previously global names would be normalized before being rendered in IIFE arguments, this does not align with Rollup behaviour.

Example config
```js
export default {
  output: {
    inlineDynamicImports: true,
    format: "iife",
    globals: (id) => "foo.bar.baz",
  },
  external: "bar"
};
```

<details>
<summary>Before</summary>

```js
(function(bar) {

//#region rolldown:runtime
var __create = Object.create;
var __defProp = Object.defineProperty;
var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
var __getOwnPropNames = Object.getOwnPropertyNames;
var __getProtoOf = Object.getPrototypeOf;
var __hasOwnProp = Object.prototype.hasOwnProperty;
var __copyProps = (to, from, except, desc) => {
	if (from && typeof from === "object" || typeof from === "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
		key = keys[i];
		if (!__hasOwnProp.call(to, key) && key !== except) __defProp(to, key, {
			get: ((k) => from[k]).bind(null, key),
			enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
		});
	}
	return to;
};
var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
	value: mod,
	enumerable: true
}) : target, mod));

//#endregion
bar = __toESM(bar);

//#region index.ts
console.log(bar.foo);

//#endregion
})(foo_bar_baz);
```
</details>

<details>
<summary>After</summary>

```js
(function(bar) {

//#region rolldown:runtime
var __create = Object.create;
var __defProp = Object.defineProperty;
var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
var __getOwnPropNames = Object.getOwnPropertyNames;
var __getProtoOf = Object.getPrototypeOf;
var __hasOwnProp = Object.prototype.hasOwnProperty;
var __copyProps = (to, from, except, desc) => {
	if (from && typeof from === "object" || typeof from === "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
		key = keys[i];
		if (!__hasOwnProp.call(to, key) && key !== except) __defProp(to, key, {
			get: ((k) => from[k]).bind(null, key),
			enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
		});
	}
	return to;
};
var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
	value: mod,
	enumerable: true
}) : target, mod));

//#endregion
bar = __toESM(bar);

//#region test/index.js
console.log(bar.foo);

//#endregion
})(foo.bar.baz);
```
</details>