### PR TITLE
refactor(rolldown_debug,rolldown_tracing): remove `EnvFilter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,8 +783,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf04c5ec15464ace8355a7b440a33aece288993475556d461154d7a62ad9947c"
 dependencies = [
  "bit-set",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,8 +772,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
  "bit-set",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1029,8 +1029,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1183,7 +1183,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -1305,7 +1305,7 @@ dependencies = [
  "percent-encoding",
  "referencing",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "serde",
  "serde_json",
  "uuid-simd",
@@ -1414,15 +1414,6 @@ dependencies = [
  "rolldown_workspace",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2564,17 +2555,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2585,14 +2567,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3778,8 +3754,6 @@ checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
- "valuable",
- "valuable-serde",
 ]
 
 [[package]]
@@ -3788,21 +3762,15 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
- "matchers",
  "nu-ansi-term",
- "once_cell",
- "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
- "valuable",
- "valuable-serde",
 ]
 
 [[package]]
@@ -3934,16 +3902,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "valuable-serde"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee0548edecd1b907be7e67789923b7d02275b9ba4a33ebc33300e2c947a8cb1"
-dependencies = [
- "serde",
- "valuable",
-]
 
 [[package]]
 name = "version_check"

--- a/crates/rolldown_debug/Cargo.toml
+++ b/crates/rolldown_debug/Cargo.toml
@@ -20,4 +20,4 @@ rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json"] }
+tracing-subscriber = { workspace = true, default-features = false, features = ["std", "fmt", "json"] }

--- a/crates/rolldown_debug/src/lib.rs
+++ b/crates/rolldown_debug/src/lib.rs
@@ -9,6 +9,6 @@ mod utils;
 pub use rolldown_debug_action as action;
 
 pub use {
-  init_tracing::{DebugTracer, Session, init_devtool_tracing},
+  init_tracing::{DebugTracer, Session},
   utils::{generate_build_id, generate_session_id},
 };

--- a/crates/rolldown_tracing/Cargo.toml
+++ b/crates/rolldown_tracing/Cargo.toml
@@ -21,4 +21,4 @@ test = false
 [dependencies]
 tracing = { workspace = true, features = ["valuable"] }
 tracing-chrome = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter", "json", "valuable"] }
+tracing-subscriber = { workspace = true, default-features = false, features = ["std"] }

--- a/crates/rolldown_tracing/src/lib.rs
+++ b/crates/rolldown_tracing/src/lib.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 /// Some guidelines for tracing:
 /// - Using `RD_LOG=trace` to enable tracing or other values for more specific tracing.
 ///   - See  https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax for more syntax details.
@@ -6,13 +5,15 @@ use std::any::Any;
 /// - Using `RD_LOG=trace RD_LOG_OUTPUT=chrome-json` to collect tracing events into a json file.
 ///   - Using `RD_LOG_OUTPUT_STYLE=async` to record traces as a group of asynchronous operations.
 use std::sync::atomic::AtomicBool;
+use std::{any::Any, str::FromStr};
 
 use tracing_chrome::ChromeLayerBuilder;
 use tracing_chrome::TraceStyle;
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::fmt;
-use tracing_subscriber::fmt::format::FmtSpan;
-use tracing_subscriber::prelude::*;
+use tracing_subscriber::{
+  filter::Targets,
+  fmt::{self, format::FmtSpan},
+  prelude::*,
+};
 
 static LOG_ENV_NAME: &str = "RD_LOG";
 static LOG_OUTPUT_ENV_NAME: &str = "RD_LOG_OUTPUT";
@@ -20,17 +21,15 @@ static LOG_OUTPUT_ENV_NAME: &str = "RD_LOG_OUTPUT";
 static IS_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
-  if std::env::var(LOG_ENV_NAME).is_err() {
+  let Ok(env_var) = std::env::var(LOG_ENV_NAME) else {
     // tracing will slow down the bundling process, so we only enable it when `LOG` is set.
     return None;
-  }
+  };
   if IS_INITIALIZED.swap(true, std::sync::atomic::Ordering::SeqCst) {
     return None;
   }
 
   let output_mode = std::env::var(LOG_OUTPUT_ENV_NAME).unwrap_or_else(|_| "stdout".to_string());
-
-  let env_filter = EnvFilter::from_env(LOG_ENV_NAME);
 
   match output_mode.as_str() {
     "chrome-json" | "chrome-json-threaded" => {
@@ -38,7 +37,10 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
         if output_mode == "chrome-json" { TraceStyle::Async } else { TraceStyle::Threaded };
       let (chrome_layer, guard) =
         ChromeLayerBuilder::new().trace_style(trace_style).include_args(true).build();
-      tracing_subscriber::registry().with(env_filter).with(chrome_layer).init();
+      tracing_subscriber::registry()
+        .with(Targets::from_str(&env_var).unwrap())
+        .with(chrome_layer)
+        .init();
       Some(Box::new(guard))
     }
     "json" => {
@@ -48,7 +50,7 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
     }
     _ => {
       tracing_subscriber::registry()
-        .with(env_filter)
+        .with(Targets::from_str(&env_var).unwrap())
         .with(fmt::layer().pretty().with_span_events(FmtSpan::CLOSE | FmtSpan::ENTER))
         .init();
       tracing::debug!("Tracing initialized");


### PR DESCRIPTION
`EnvFilter` (enabled through the `env-filter` feature flag) includes an outdated regex engine, which increases the binary size by a significant amount.

With the change in this PR, binary size is decreased from 15375248  to
14862624. i.e. 15.37mb - 14.86mb = 0.51mb.

### Testing

I tested

* `RD_LOG=debug`
* `RD_LOG='oxc_resolver'`
* `debug: true` in rolldown config, observed correct output in the `.rolldown/0000000000000/` directory. 