### PR TITLE
refactor: use `sort_unstable_by_key` for simple property access

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -55,7 +55,7 @@ impl ChunkGraph {
         options.experimental.chunk_modules_order.unwrap_or_default(),
         ChunkModulesOrderBy::ExecOrder
       ) {
-        chunk.modules.sort_by_cached_key(|idx| link_output.module_table[*idx].exec_order());
+        chunk.modules.sort_unstable_by_key(|idx| link_output.module_table[*idx].exec_order());
         return;
       }
 
@@ -78,9 +78,9 @@ impl ChunkGraph {
           rest.push(module_idx);
         }
       }
-      side_effects_free_leaf_modules.sort_by_cached_key(|idx| link_output.module_table[*idx].id());
-      rest.sort_by_cached_key(|idx| link_output.module_table[*idx].exec_order());
-      runtime_related.sort_by_cached_key(|idx| link_output.module_table[*idx].exec_order());
+      side_effects_free_leaf_modules.sort_by_key(|idx| link_output.module_table[*idx].id());
+      rest.sort_unstable_by_key(|idx| link_output.module_table[*idx].exec_order());
+      runtime_related.sort_unstable_by_key(|idx| link_output.module_table[*idx].exec_order());
 
       chunk.modules = runtime_related
         .into_iter()

--- a/crates/rolldown_common/src/module/mod.rs
+++ b/crates/rolldown_common/src/module/mod.rs
@@ -23,6 +23,7 @@ impl Module {
     }
   }
 
+  #[inline]
   pub fn exec_order(&self) -> u32 {
     match self {
       Module::Normal(v) => v.exec_order,


### PR DESCRIPTION
https://github.com/rolldown/rolldown/pull/5227#discussion_r2196441732