### PR TITLE
fix(browser): process is not defined error

### DIFF
--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -204,7 +204,8 @@ function bindingifyExperimental(
 function bindingifyResolve(
   resolve: InputOptions['resolve'],
 ): BindingInputOptions['resolve'] {
-  const yarnPnp = !!process.versions.pnp;
+  // process is undefined for browser build
+  const yarnPnp = typeof process === 'object' && !!process.versions.pnp;
   if (resolve) {
     const { alias, extensionAlias, ...rest } = resolve;
     return {


### PR DESCRIPTION
This error was happening on REPL.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vwxsZCw2fCU7AuL6PlaA/dc227b09-69c9-4200-aab8-2eca9e755789.png)

