### PR TITLE
fix(rolldown_plugin_vite_resolve): align bare import logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,7 +3059,6 @@ dependencies = [
  "anyhow",
  "arcstr",
  "cow-utils",
- "dashmap",
  "derive_more",
  "fast-glob",
  "oxc_resolver",

--- a/crates/rolldown_plugin_vite_resolve/Cargo.toml
+++ b/crates/rolldown_plugin_vite_resolve/Cargo.toml
@@ -12,7 +12,6 @@ anyhow = { workspace = true }
 # NOTE: IDNA support is turned off: https://docs.rs/crate/idna_adapter/latest#:~:text=Turning%20off%20IDNA%20support
 arcstr = { workspace = true }
 cow-utils = { workspace = true }
-dashmap = { workspace = true }
 derive_more = { workspace = true }
 fast-glob = { workspace = true }
 oxc_resolver = { workspace = true, features = ["package_json_raw_json_api"] }

--- a/crates/rolldown_plugin_vite_resolve/src/external.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/external.rs
@@ -1,15 +1,6 @@
-use std::{path::Path, sync::Arc};
+use rolldown_utils::pattern_filter::StringOrRegex;
 
-use dashmap::DashMap;
-use rolldown_utils::{dashmap::FxDashMap, pattern_filter::StringOrRegex};
-use rustc_hash::FxHashSet;
-
-use crate::{
-  builtin::BuiltinChecker,
-  resolver::Resolver,
-  utils::{can_externalize_file, get_npm_package_name, is_bare_import, is_in_node_modules},
-  utils_filter::UtilsFilter,
-};
+use crate::utils_filter::UtilsFilter;
 
 #[derive(Debug, Clone)]
 pub enum ResolveOptionsExternal {
@@ -61,97 +52,4 @@ enum ResolveOptionsNoExternalInner {
   True,
   Vec(UtilsFilter),
   Empty,
-}
-
-#[derive(Debug)]
-pub struct ExternalDeciderOptions {
-  pub external: ResolveOptionsExternal,
-  pub no_external: Arc<ResolveOptionsNoExternal>,
-  pub dedupe: Arc<FxHashSet<String>>,
-  pub is_build: bool,
-}
-
-#[derive(Debug)]
-pub struct ExternalDecider {
-  options: ExternalDeciderOptions,
-  resolver: Arc<Resolver>,
-  builtin_checker: Arc<BuiltinChecker>,
-  processed_ids: FxDashMap<String, bool>,
-}
-
-impl ExternalDecider {
-  pub fn new(
-    options: ExternalDeciderOptions,
-    resolver: Arc<Resolver>,
-    builtin_checker: Arc<BuiltinChecker>,
-  ) -> Self {
-    Self { options, resolver, builtin_checker, processed_ids: DashMap::default() }
-  }
-
-  pub fn is_external(&self, id: &str, importer: Option<&str>) -> bool {
-    if let Some(cached) = self.processed_ids.get(id) {
-      return *cached;
-    }
-
-    let mut is_external = false;
-    if !id.starts_with('.') && !Path::new(id).is_absolute() {
-      is_external =
-        self.builtin_checker.is_builtin(id) || self.is_configured_as_external(id, importer);
-    }
-    self.processed_ids.insert(id.to_owned(), is_external);
-
-    is_external
-  }
-
-  fn is_configured_as_external(&self, id: &str, importer: Option<&str>) -> bool {
-    if self.options.external.is_external_explicitly(id) {
-      return true;
-    }
-    let pkg_name = get_npm_package_name(id);
-    let pkg_name = match pkg_name {
-      Some(pkg_name) => pkg_name,
-      None => return self.is_externalizable(id, importer, false),
-    };
-    if self.options.external.is_external_explicitly(pkg_name) {
-      return self.is_externalizable(id, importer, true);
-    }
-    if self.options.no_external.is_no_external(pkg_name) {
-      return false;
-    }
-    self.is_externalizable(
-      id,
-      importer,
-      matches!(self.options.external, ResolveOptionsExternal::True),
-    )
-  }
-
-  fn is_externalizable(
-    &self,
-    id: &str,
-    importer: Option<&str>,
-    configured_as_external: bool,
-  ) -> bool {
-    if !is_bare_import(id) || id.contains('\0') {
-      return false;
-    }
-
-    // Skip passing importer in build to avoid externalizing non-hoisted dependencies
-    // unresolvable from root (which would be unresolvable from output bundles also)
-    let importer = if self.options.is_build { None } else { importer };
-
-    let result = self.resolver.resolve_bare_import(id, importer, false, &self.options.dedupe);
-    match result {
-      Ok(result) => {
-        let resolved = match result {
-          Some(result) => result,
-          _ => return false,
-        };
-        if !configured_as_external && !is_in_node_modules(&resolved.id) {
-          return false;
-        }
-        can_externalize_file(&resolved.id)
-      }
-      _ => false,
-    }
-  }
 }

--- a/crates/rolldown_plugin_vite_resolve/src/utils.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/utils.rs
@@ -14,21 +14,6 @@ pub fn is_bare_import(id: &str) -> bool {
   id.starts_with(|c| is_regex_w_character_class(c) || c == '@') && !id.contains("://")
 }
 
-// check for deep import, e.g. "my-lib/foo"
-// deepImportRE.test(id)
-pub fn is_deep_import(id: &str) -> bool {
-  if id.starts_with('@') {
-    let split: Vec<&str> = id.splitn(3, '/').collect();
-    split.len() == 3 && split[0].len() >= 2 && !split[1].is_empty()
-  } else {
-    id[1..].contains('/')
-  }
-}
-
-pub fn get_extension(id: &str) -> &str {
-  id.rsplit_once('.').map_or("", |(_, ext)| ext)
-}
-
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape#w
 fn is_regex_w_character_class(c: char) -> bool {
   c.is_ascii_alphanumeric() || c == '_'
@@ -54,15 +39,6 @@ pub fn get_npm_package_name(id: &str) -> Option<&str> {
   } else {
     id.split('/').next()
   }
-}
-
-pub fn can_externalize_file(file_path: &str) -> bool {
-  let ext = get_extension(file_path);
-  ext.is_empty() || ext == "js" || ext == "mjs" || ext == "cjs"
-}
-
-pub fn is_in_node_modules(id: &str) -> bool {
-  id.contains("node_modules")
 }
 
 /// path.resolve normalizes the leading slashes to a single slash

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1868,7 +1868,7 @@ export interface BindingViteResolvePluginConfig {
   external: true | string[]
   noExternal: true | Array<string | RegExp>
   dedupe: Array<string>
-  finalizeBareSpecifier?: (resolvedId: string, rawId: string, importer: string | null | undefined) => VoidNullable<string>
+  finalizeBareSpecifier?: (id: string, importer: string | undefined, scan: boolean) => MaybePromise<BindingHookResolveIdOutput | undefined>
   finalizeOtherSpecifiers?: (resolvedId: string, rawId: string) => VoidNullable<string>
   resolveSubpathImports: (id: string, importer: string, isRequire: boolean, scan: boolean) => VoidNullable<string>
 }

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -133,7 +133,7 @@ export function bindingifyResolveId(
         };
       }
       if (typeof ret === 'string') {
-        return { id: ret, normalizeExternalId: false };
+        return { id: ret };
       }
 
       // Make sure the `moduleSideEffects` is update to date
@@ -146,7 +146,6 @@ export function bindingifyResolveId(
       return {
         id: ret.id,
         external: ret.external,
-        normalizeExternalId: false,
         moduleSideEffects: exist.moduleSideEffects ?? undefined,
       };
     },


### PR DESCRIPTION
closes https://github.com/vitejs/rolldown-vite/issues/288

Since I'm not very familiar with the related logic, I provided a quick workaround. We don't necessarily have to merge it — it's just to help you understand where the issue lies. @sapphi-red cc

The root cause is that we didn't align with the logic in [resolve.ts](https://github.com/vitejs/rolldown-vite/blob/3042f71bb849d05b976b8a7b342803053d5de1c7/packages/vite/src/node/plugins/resolve.ts#L645-L683). Specifically, we're missing the `tryResolveBrowserMapping` and `tryNodeResolve` logic. In this issue, it hits the `tryNodeResolve` branch, which leads to the problem.

The integration of rolldown-vite is as follows:
```js
async finalizeBareSpecifier(id, importer, scan) {
  const environment = getEnv()
  const external =
    options.externalize &&
    options.isBuild &&
    partialEnv.config.consumer === 'server' &&
    shouldExternalize(getEnv(), id, importer)

  const depsOptimizer =
    resolveOptions.optimizeDeps && environment.mode === 'dev'
      ? environment.depsOptimizer
      : undefined

  let res: string | PartialResolvedId | undefined
  if (
    !external &&
    options.asSrc &&
    depsOptimizer &&
    !scan &&
    (res = await tryOptimizedResolve(
      depsOptimizer,
      id,
      importer,
      options.preserveSymlinks,
      options.packageCache,
    ))
  ) {
    return res
  }

  if (
    options.mainFields.includes('browser') &&
    (res = tryResolveBrowserMapping(
      id,
      importer,
      options,
      false,
      external,
    ))
  ) {
    return res
  }

  if (
    (res = tryNodeResolve(
      id,
      importer,
      options,
      depsOptimizer,
      external,
    ))
  ) {
    return res
  }
}
```