### PR TITLE
fix: reserve exported symbols of HMR modules during symbol de-conflict

### DIFF
--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -133,6 +133,15 @@ pub fn deconflict_chunk_symbols(
     .for_each(|module| {
       if let Some(hmr_hot_ref) = module.hmr_hot_ref {
         renamer.add_symbol_in_root_scope(hmr_hot_ref);
+        
+        // make sure every *exported* symbol gets a canonical name. Without this, HMR-specific code paths
+        // that access those exports can panic.
+        link_output
+          .metas[module.idx]
+          .canonical_exports(false)
+          .for_each(|(_export_name, resolved_export)| {
+            renamer.add_symbol_in_root_scope(resolved_export.symbol_ref);
+          });
       }
 
       module

--- a/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "hmr": {}
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/artifacts.snap
@@ -1,0 +1,85 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## bar.js
+
+```js
+import { __export } from "./chunk.js";
+import { trim } from "./string.js";
+
+//#region bar.js
+var bar_exports = {};
+__export(bar_exports, { default: () => bar });
+const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
+__rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
+function bar() {
+	return trim("bar");
+}
+
+//#endregion
+export { bar as default };
+```
+## chunk.js
+
+```js
+
+export { __export, __toCommonJS, __toDynamicImportESM, __toESM };
+```
+## foo.js
+
+```js
+import { __export } from "./chunk.js";
+import { trim } from "./string.js";
+
+//#region foo.js
+var foo_exports = {};
+__export(foo_exports, { default: () => foo });
+const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
+__rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
+function foo() {
+	return trim("foo");
+}
+
+//#endregion
+export { foo as default };
+```
+## main.js
+
+```js
+import { __export, __toCommonJS, __toDynamicImportESM, __toESM } from "./chunk.js";
+
+// HIDDEN [rolldown:hmr]
+//#region main.js
+var main_exports = {};
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const templates = {
+	foo: () => import("./foo.js"),
+	bar: () => import("./bar.js")
+};
+console.log(templates);
+
+//#endregion
+```
+## string.js
+
+```js
+import { __export } from "./chunk.js";
+
+//#region utils/string.js
+var string_exports = {};
+__export(string_exports, {
+	trim: () => trim,
+	unused: () => unused
+});
+const string_hot = __rolldown_runtime__.createModuleHotContext("utils/string.js");
+__rolldown_runtime__.registerModule("utils/string.js", { exports: string_exports });
+function trim(s) {
+	return s.trim();
+}
+
+//#endregion
+export { trim };
+```

--- a/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/bar.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/bar.js
@@ -1,0 +1,5 @@
+import { trim } from './utils/index.js'; // import via barrel file
+
+export default function bar() {
+  return trim('bar');
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/foo.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/foo.js
@@ -1,0 +1,5 @@
+import { trim } from './utils/string.js'; // import directly
+
+export default function foo() {
+  return trim('foo');
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/main.js
@@ -1,0 +1,6 @@
+const templates = {
+  foo: () => import('./foo.js'), // two separate dynamic imports (causing separate chunks)
+  bar: () => import('./bar.js'), 
+};
+
+console.log(templates);

--- a/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/utils/index.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/utils/index.js
@@ -1,0 +1,1 @@
+export * from './string.js';

--- a/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/utils/string.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/unused-in-chunk/utils/string.js
@@ -1,0 +1,7 @@
+export function trim(s) {
+  return s.trim();
+}
+
+export function unused() {
+  return 'unused';
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/unused-export-barrel-hmr-issue5235/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/unused-export-barrel-hmr-issue5235/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./entry.js"
+      }
+    ],
+    "experimental": {
+      "hmr": {}
+    },
+    "treeshake": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/unused-export-barrel-hmr-issue5235/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/unused-export-barrel-hmr-issue5235/artifacts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+
+// HIDDEN [rolldown:hmr]
+//#region foo.js
+var foo_exports = {};
+__export(foo_exports, {
+	foo: () => foo,
+	unused: () => unused
+});
+const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
+__rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
+function foo() {
+	return "foo";
+}
+
+//#endregion
+//#region entry.js
+var entry_exports = {};
+const entry_hot = __rolldown_runtime__.createModuleHotContext("entry.js");
+__rolldown_runtime__.registerModule("entry.js", { exports: entry_exports });
+console.log(foo);
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/tree_shaking/unused-export-barrel-hmr-issue5235/barrel.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/unused-export-barrel-hmr-issue5235/barrel.js
@@ -1,0 +1,1 @@
+export * from './foo'

--- a/crates/rolldown/tests/rolldown/tree_shaking/unused-export-barrel-hmr-issue5235/entry.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/unused-export-barrel-hmr-issue5235/entry.js
@@ -1,0 +1,2 @@
+import { foo } from "./barrel";
+console.log(foo);

--- a/crates/rolldown/tests/rolldown/tree_shaking/unused-export-barrel-hmr-issue5235/foo.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/unused-export-barrel-hmr-issue5235/foo.js
@@ -1,0 +1,7 @@
+export function foo() {
+  return 'foo';
+}
+
+export function unused() {
+  return 'unused';
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3852,6 +3852,14 @@ expression: output
 - share-!~{003}~.js => share-Dt2p-BNK.js
 - share-!~{001}~.js => share-DyQhD9RN.js
 
+# tests/rolldown/code_splitting/unused-in-chunk
+
+- main-!~{000}~.js => main-6lSCOZM6.js
+- bar-!~{005}~.js => bar-BtEqOTAV.js
+- chunk-!~{001}~.js => chunk-H37MHKgK.js
+- foo-!~{007}~.js => foo-RyfnpTYd.js
+- string-!~{003}~.js => string-DcHNXTtJ.js
+
 # tests/rolldown/dce/conditional_exports
 
 - main-!~{000}~.js => main-C_Ssu_r3.js
@@ -5765,6 +5773,10 @@ expression: output
 # tests/rolldown/tree_shaking/side_effect_free_dynamic_importee
 
 - main-!~{000}~.js => main-vb0jrLmM.js
+
+# tests/rolldown/tree_shaking/unused-export-barrel-hmr-issue5235
+
+- main-!~{000}~.js => main-BW7EcPO7.js
 
 # tests/rolldown/tree_shaking/unused_dynamic_imported_chunk
 

--- a/packages/rolldown/tests/fixtures/tree-shake/unused-export-barrel-hmr-issue5235/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/unused-export-barrel-hmr-issue5235/_config.ts
@@ -1,0 +1,18 @@
+import { defineTest } from "rolldown-tests";
+import { expect } from "vitest";
+
+export default defineTest({
+  config: {
+    input: {
+      main: "./entry.js",
+    },
+    experimental: {
+      hmr: true,
+    },
+    treeshake: true,
+  },
+  afterTest: (output) => {
+    expect(output.output[0].code).toContain(`return "foo";`);
+    expect(output.output[0].code).not.toContain(`return "unused";`);
+  },
+});

--- a/packages/rolldown/tests/fixtures/tree-shake/unused-export-barrel-hmr-issue5235/barrel.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/unused-export-barrel-hmr-issue5235/barrel.js
@@ -1,0 +1,1 @@
+export * from './foo'

--- a/packages/rolldown/tests/fixtures/tree-shake/unused-export-barrel-hmr-issue5235/entry.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/unused-export-barrel-hmr-issue5235/entry.js
@@ -1,0 +1,2 @@
+import { foo } from "./barrel";
+console.log(foo);

--- a/packages/rolldown/tests/fixtures/tree-shake/unused-export-barrel-hmr-issue5235/foo.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/unused-export-barrel-hmr-issue5235/foo.js
@@ -1,0 +1,7 @@
+export function foo() {
+  return 'foo';
+}
+
+export function unused() {
+  return 'unused';
+}


### PR DESCRIPTION
~~Fixes #5235~~ (already fixed by https://github.com/rolldown/rolldown/pull/5311)
Fixes #5259 

Make sure every *exported* symbol gets a canonical name. Without this, HMR-specific code paths that access those exports can panic.
