### PR TITLE
perf: use `IndexBitSet<Idx>` instead of `IndexVec<Idx, bool>`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/advanced_chunks.rs
+++ b/crates/rolldown/src/stages/generate_stage/advanced_chunks.rs
@@ -6,6 +6,7 @@ use rolldown_common::{
   Chunk, ChunkKind, ChunkingContext, MatchGroupTest, Module, ModuleIdx, ModuleTable,
 };
 use rolldown_error::BuildResult;
+use rolldown_utils::index_bitset::IndexBitSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{chunk_graph::ChunkGraph, types::linking_metadata::LinkingMetadataVec};
@@ -57,7 +58,7 @@ impl GenerateStage<'_> {
   pub async fn apply_advanced_chunks(
     &self,
     index_splitting_info: &IndexSplittingInfo,
-    module_to_assigned: &mut IndexVec<ModuleIdx, bool>,
+    module_to_assigned: &mut IndexBitSet::<ModuleIdx>,
     chunk_graph: &mut ChunkGraph,
     input_base: &ArcStr,
   ) -> BuildResult<()> {
@@ -84,7 +85,7 @@ impl GenerateStage<'_> {
         continue;
       }
 
-      if module_to_assigned[normal_module.idx] {
+      if module_to_assigned.has_bit(normal_module.idx) {
         continue;
       }
 
@@ -196,7 +197,7 @@ impl GenerateStage<'_> {
       });
       chunk_graph.chunk_table[chunk_idx].bits.union(&index_splitting_info[runtime_module_idx].bits);
       chunk_graph.add_module_to_chunk(runtime_module_idx, chunk_idx);
-      module_to_assigned[runtime_module_idx] = true;
+      module_to_assigned.set_bit(runtime_module_idx);
     }
 
     while let Some(this_module_group) = module_groups.pop() {
@@ -328,7 +329,7 @@ impl GenerateStage<'_> {
         });
         chunk_graph.chunk_table[chunk_idx].bits.union(&index_splitting_info[module_idx].bits);
         chunk_graph.add_module_to_chunk(module_idx, chunk_idx);
-        module_to_assigned[module_idx] = true;
+        module_to_assigned.set_bit(module_idx);
       });
     }
     Ok(())

--- a/crates/rolldown/src/stages/generate_stage/advanced_chunks.rs
+++ b/crates/rolldown/src/stages/generate_stage/advanced_chunks.rs
@@ -58,7 +58,7 @@ impl GenerateStage<'_> {
   pub async fn apply_advanced_chunks(
     &self,
     index_splitting_info: &IndexSplittingInfo,
-    module_to_assigned: &mut IndexBitSet::<ModuleIdx>,
+    module_to_assigned: &mut IndexBitSet<ModuleIdx>,
     chunk_graph: &mut ChunkGraph,
     input_base: &ArcStr,
   ) -> BuildResult<()> {

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -34,7 +34,7 @@ impl LinkStage<'_> {
       let default_symbol_ref = module.default_export_ref;
       let is_json = matches!(module.module_type, ModuleType::Json);
       if !is_json || module.exports_kind == ExportsKind::CommonJs {
-        update_module_default_export_info(module, default_symbol_ref, 1.into());
+        update_module_default_export_info(module, default_symbol_ref, 1u32.into());
       }
       module_idx_to_exports_kind.push((module.ecma_ast_idx(), module.exports_kind, is_json));
 
@@ -71,7 +71,7 @@ impl LinkStage<'_> {
         // if json is not a ObjectExpression, we will fallback to normal esm lazy export transform
         let module = &mut self.module_table[module_idx];
         let module = module.as_normal_mut().unwrap();
-        update_module_default_export_info(module, module.default_export_ref, 1.into());
+        update_module_default_export_info(module, module.default_export_ref, 1u32.into());
       }
 
       // shadowing the previous mutable ref, to avoid reference mutable ref twice at the same time.
@@ -236,7 +236,7 @@ fn json_object_expr_to_esm(
   // update module stmts info
   // clear stmt info, since we need to split `ObjectExpression` into multiple decl, the original stmt info is invalid.
   // preserve the first one, which is `NamespaceRef`
-  let stmt_info = module.stmt_infos.drain(1.into()..);
+  let stmt_info = module.stmt_infos.drain(1u32.into()..);
   let mut all_declared_symbols =
     stmt_info.flat_map(|info| info.referenced_symbols).collect::<Vec<_>>();
   for (i, (local, exported, _)) in declaration_binding_names.iter().enumerate() {

--- a/crates/rolldown_common/src/ecmascript/module_idx.rs
+++ b/crates/rolldown_common/src/ecmascript/module_idx.rs
@@ -1,4 +1,5 @@
 oxc_index::define_index_type! {
     #[derive(Default)]
     pub struct ModuleIdx = u32;
+    IMPL_RAW_CONVERSIONS = true;
 }

--- a/crates/rolldown_common/src/types/stmt_info.rs
+++ b/crates/rolldown_common/src/types/stmt_info.rs
@@ -72,6 +72,7 @@ impl std::ops::DerefMut for StmtInfos {
 oxc_index::define_index_type! {
   #[derive(Default)]
   pub struct StmtInfoIdx = u32;
+  IMPL_RAW_CONVERSIONS = true;
 }
 
 bitflags! {

--- a/crates/rolldown_utils/src/bitset.rs
+++ b/crates/rolldown_utils/src/bitset.rs
@@ -69,7 +69,7 @@ impl Debug for BitSet {
 
 pub struct BitSetIter<'a> {
   bitset: &'a BitSet,
-  curr: u32
+  curr: u32,
 }
 
 impl<'a> BitSetIter<'a> {
@@ -91,7 +91,6 @@ impl Iterator for BitSetIter<'_> {
     Some(val)
   }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/rolldown_utils/src/bitset.rs
+++ b/crates/rolldown_utils/src/bitset.rs
@@ -3,11 +3,12 @@ use std::fmt::{Debug, Display};
 #[derive(Clone, PartialEq, Eq, Default, Hash, PartialOrd, Ord)]
 pub struct BitSet {
   entries: Vec<u8>,
+  length: u32,
 }
 
 impl BitSet {
   pub fn new(max_bit_count: u32) -> Self {
-    Self { entries: vec![0; max_bit_count.div_ceil(8) as usize] }
+    Self { entries: vec![0; max_bit_count.div_ceil(8) as usize], length: max_bit_count }
   }
 
   pub fn has_bit(&self, bit: u32) -> bool {
@@ -20,6 +21,11 @@ impl BitSet {
 
   pub fn is_empty(&self) -> bool {
     self.entries.iter().all(|&e| e == 0)
+  }
+
+  #[expect(clippy::iter_without_into_iter)]
+  pub fn iter(&self) -> BitSetIter {
+    BitSetIter::new(self)
   }
 
   pub fn union(&mut self, other: &Self) {
@@ -60,6 +66,32 @@ impl Debug for BitSet {
     f.debug_tuple("BitSet").field(&self.to_string()).finish()
   }
 }
+
+pub struct BitSetIter<'a> {
+  bitset: &'a BitSet,
+  curr: u32
+}
+
+impl<'a> BitSetIter<'a> {
+  fn new(bitset: &'a BitSet) -> Self {
+    Self { bitset, curr: 0 }
+  }
+}
+
+impl Iterator for BitSetIter<'_> {
+  type Item = bool;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    if self.curr >= self.bitset.length {
+      return None;
+    }
+
+    let val = self.bitset.has_bit(self.curr);
+    self.curr += 1;
+    Some(val)
+  }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/crates/rolldown_utils/src/index_bitset.rs
+++ b/crates/rolldown_utils/src/index_bitset.rs
@@ -3,7 +3,7 @@ use std::{fmt, marker::PhantomData};
 
 use oxc_index::{Idx, IndexVec};
 
-use crate::{bitset::BitSetIter, BitSet};
+use crate::{BitSet, bitset::BitSetIter};
 
 type Enumerated<Iter, I, T> = iter::Map<iter::Enumerate<Iter>, fn((usize, T)) -> (I, T)>;
 

--- a/crates/rolldown_utils/src/index_bitset.rs
+++ b/crates/rolldown_utils/src/index_bitset.rs
@@ -1,0 +1,69 @@
+use core::iter;
+use std::{fmt, marker::PhantomData};
+
+use oxc_index::{Idx, IndexVec};
+
+use crate::{bitset::BitSetIter, BitSet};
+
+type Enumerated<Iter, I, T> = iter::Map<iter::Enumerate<Iter>, fn((usize, T)) -> (I, T)>;
+
+#[derive(Clone, PartialEq, Eq, Default, Hash, PartialOrd, Ord)]
+pub struct IndexBitSet<I: Idx + Into<u32>> {
+  raw: BitSet,
+  _marker: PhantomData<fn(&I)>,
+}
+
+impl<I: Idx + Into<u32>> fmt::Display for IndexBitSet<I> {
+  fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Display::fmt(&self.raw, fmt)
+  }
+}
+
+impl<I: Idx + Into<u32>> fmt::Debug for IndexBitSet<I> {
+  fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Debug::fmt(&self.raw, fmt)
+  }
+}
+
+impl<I: Idx + Into<u32>> IndexBitSet<I> {
+  #[inline]
+  pub fn new(max_bit_count: u32) -> Self {
+    Self { raw: BitSet::new(max_bit_count), _marker: PhantomData }
+  }
+
+  #[inline]
+  pub fn has_bit(&self, bit: I) -> bool {
+    self.raw.has_bit(bit.into())
+  }
+
+  #[inline]
+  pub fn set_bit(&mut self, bit: I) {
+    self.raw.set_bit(bit.into());
+  }
+
+  #[inline]
+  pub fn is_empty(&self) -> bool {
+    self.raw.is_empty()
+  }
+
+  #[expect(clippy::iter_without_into_iter)]
+  #[inline]
+  pub fn iter(&self) -> BitSetIter {
+    self.raw.iter()
+  }
+
+  #[inline]
+  pub fn iter_enumerated(&self) -> Enumerated<BitSetIter, I, bool> {
+    self.raw.iter().enumerate().map(|(i, t)| (I::from_usize(i), t))
+  }
+
+  #[inline]
+  pub fn union(&mut self, other: &Self) {
+    self.raw.union(&other.raw);
+  }
+
+  #[inline]
+  pub fn index_of_one(&self) -> IndexVec<I, u32> {
+    self.raw.index_of_one().into()
+  }
+}

--- a/crates/rolldown_utils/src/lib.rs
+++ b/crates/rolldown_utils/src/lib.rs
@@ -21,6 +21,7 @@ pub mod commondir;
 pub mod concat_string;
 pub mod filter_expression;
 pub mod hash_placeholder;
+pub mod index_bitset;
 pub mod index_vec_ext;
 pub mod js_regex;
 pub mod make_unique_name;


### PR DESCRIPTION
Implemented `IndexBitSet<Idx>` and replaced all `IndexVec<Idx, bool>` with that. This should reduce the memory usage a bit in theory.