### PR TITLE
refactor: pass the while CodegenOptions to `EcmaCompiler::minify`

### DIFF
--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -100,7 +100,6 @@ impl EcmaCompiler {
       .build(ast.program())
   }
 
-  #[allow(clippy::needless_pass_by_value)] // hyf0: Seems a bug of clippy. `codegen_options` is indeed used as value.
   pub fn minify(
     source_text: &str,
     enable_sourcemap: bool,
@@ -108,7 +107,6 @@ impl EcmaCompiler {
     minifier_options: MinifierOptions,
     run_compress: bool,
     codegen_options: CodegenOptions,
-    print_legal_comments: bool,
   ) -> (String, Option<SourceMap>) {
     let allocator = Allocator::default();
     let program =
@@ -117,12 +115,6 @@ impl EcmaCompiler {
     let ret = Self::minify_impl(minifier_options, run_compress, &allocator, program);
     let ret = Codegen::new()
       .with_options(CodegenOptions {
-        comments: CommentOptions {
-          annotation: false,
-          jsdoc: false,
-          normal: false,
-          legal: if print_legal_comments { LegalComment::Inline } else { LegalComment::None },
-        },
         source_map_path: enable_sourcemap.then(|| PathBuf::from(filename)),
         ..codegen_options
       })


### PR DESCRIPTION
This PR is a pure refactor and should not change any behavior.
I changed the code to set all `CodegenOptions` in a single place so that it's easier to understand the final value of the option.
