### PR TITLE
fix: keep legal and annotation comments for `minify: 'dce-only'`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/minify_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/minify_assets.rs
@@ -26,8 +26,10 @@ impl GenerateStage<'_> {
               comments: CommentOptions {
                 normal: false,
                 jsdoc: false,
-                annotation: false,
-                legal: if matches!(options.legal_comments, LegalComments::Inline) {
+                annotation: !minify_options.remove_whitespace,
+                legal: if matches!(options.legal_comments, LegalComments::Inline)
+                  || !minify_options.remove_whitespace
+                {
                   codegen::LegalComment::Inline
                 } else {
                   codegen::LegalComment::None

--- a/packages/rolldown/tests/fixtures/output/minify-dce-only/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/minify-dce-only/_config.ts
@@ -1,0 +1,15 @@
+import { defineTest } from "rolldown-tests";
+import { expect } from "vitest";
+
+export default defineTest({
+  config: {
+    output: {
+      minify: 'dce-only',
+    },
+  },
+  afterTest: (output) => {
+    const code = output.output[0].code;
+    expect(code).toContain('legal comment is kept');
+    expect(code).toContain('annotation comment is kept');
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/minify-dce-only/main.js
+++ b/packages/rolldown/tests/fixtures/output/minify-dce-only/main.js
@@ -1,0 +1,3 @@
+/*! legal comment is kept */
+
+import(/* @vite-ignore annotation comment is kept */ 'node:module')


### PR DESCRIPTION
For `minify: 'dce-only'`, legal comments and annotation comments should be kept as that is the behavior in original Vite / esbuild.