### PR TITLE
perf(rolldown_sourcemap): disable rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3131,7 +3131,6 @@ dependencies = [
  "memchr",
  "oxc",
  "oxc_sourcemap",
- "rolldown_utils",
  "rustc-hash",
 ]
 

--- a/crates/rolldown_sourcemap/Cargo.toml
+++ b/crates/rolldown_sourcemap/Cargo.toml
@@ -19,8 +19,7 @@ doctest = false
 [dependencies]
 memchr = { workspace = true }
 oxc = { workspace = true }
-oxc_sourcemap = { workspace = true, features = ["rayon"] }
-rolldown_utils = { workspace = true }
+oxc_sourcemap = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -2,7 +2,6 @@ mod source;
 mod source_joiner;
 
 use oxc_sourcemap::Token;
-use rolldown_utils::rayon::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::FxHashMap;
 
 pub use oxc_sourcemap::SourceMapBuilder;
@@ -18,7 +17,7 @@ pub fn collapse_sourcemaps(mut sourcemap_chain: Vec<&SourceMap>) -> SourceMap {
   let first_map = sourcemap_chain.first().expect("sourcemap_chain should not be empty");
 
   let sourcemap_and_lookup_table = sourcemap_chain
-    .par_iter()
+    .iter()
     .map(|sourcemap| (sourcemap, sourcemap.generate_lookup_table()))
     .collect::<Vec<_>>();
 
@@ -31,7 +30,7 @@ pub fn collapse_sourcemaps(mut sourcemap_chain: Vec<&SourceMap>) -> SourceMap {
     FxHashMap::from_iter(first_map.get_sources().enumerate().map(|(i, source)| (source, i as u32)));
 
   let tokens = source_view_tokens
-    .par_iter()
+    .iter()
     .filter_map(|token| {
       let original_token = sourcemap_and_lookup_table.iter().rev().try_fold(
         *token,


### PR DESCRIPTION
Sourcemap processing should be kept on its own thread because there are other threads processing the same thing, spawning threads is expensive.

<img width="1746" height="382" alt="image" src="https://github.com/user-attachments/assets/814662db-6eee-41ec-b1f4-0041eef0c6f8" />

