### PR TITLE
perf(rolldown_sourcemap): cache source id -> source text mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,6 +3138,7 @@ dependencies = [
  "memchr",
  "oxc",
  "oxc_sourcemap",
+ "rolldown_utils",
  "rustc-hash",
 ]
 

--- a/crates/rolldown_sourcemap/Cargo.toml
+++ b/crates/rolldown_sourcemap/Cargo.toml
@@ -20,6 +20,7 @@ doctest = false
 memchr = { workspace = true }
 oxc = { workspace = true }
 oxc_sourcemap = { workspace = true }
+rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Current approach is hashing the source text for everything token,
cache the mapping to avoid redundant hashes. Hashing large source text
is slow!

