### PR TITLE
feat: show owner module id for "canonical name not found for" errors

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -50,7 +50,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   }
 
   pub fn canonical_name_for(&self, symbol: SymbolRef) -> &'me Rstr {
-    self.ctx.symbol_db.canonical_name_for(symbol, self.ctx.canonical_names)
+    self.ctx.symbol_db.canonical_name_for(symbol, self.ctx.canonical_names).unwrap_or_else(|| {
+      panic!(
+        "canonical name not found for {symbol:?}, original_name: {:?} in module {:?}",
+        symbol.name(self.ctx.symbol_db),
+        self.ctx.modules.get(symbol.owner).map_or("unknown", |module| module.id())
+      );
+    })
   }
 
   pub fn canonical_name_for_runtime(&self, name: &str) -> &Rstr {

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -210,14 +210,9 @@ impl SymbolRefDb {
     &self,
     refer: SymbolRef,
     canonical_names: &'name FxHashMap<SymbolRef, Rstr>,
-  ) -> &'name Rstr {
+  ) -> Option<&'name Rstr> {
     let canonical_ref = self.canonical_ref_for(refer);
-    canonical_names.get(&canonical_ref).unwrap_or_else(|| {
-      panic!(
-        "canonical name not found for {canonical_ref:?}, original_name: {:?}",
-        refer.name(self)
-      );
-    })
+    canonical_names.get(&canonical_ref)
   }
 
   pub fn get(&self, refer: SymbolRef) -> &SymbolRefDataClassic {


### PR DESCRIPTION
Improved the error message for "canonical name not found for" errors so that it's easier to find out the cause.