### PR TITLE
fix: undefined `process.versions` for browser build

### DIFF
--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -205,7 +205,7 @@ function bindingifyResolve(
   resolve: InputOptions['resolve'],
 ): BindingInputOptions['resolve'] {
   // process is undefined for browser build
-  const yarnPnp = typeof process === 'object' && !!process.versions.pnp;
+  const yarnPnp = typeof process === 'object' && !!process.versions?.pnp;
   if (resolve) {
     const { alias, extensionAlias, ...rest } = resolve;
     return {


### PR DESCRIPTION
In Nuxt 4 (only dev mode)
<img width="582" height="240" alt="image" src="https://github.com/user-attachments/assets/c57ebea9-aa6a-4498-ae1e-e48b1672cbf4" />
