### PR TITLE
feat(rolldown_plugin_chunk_import_map): implement initial `render_chunk` logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,6 +2593,7 @@ dependencies = [
  "rolldown_error",
  "rolldown_fs",
  "rolldown_plugin",
+ "rolldown_plugin_chunk_import_map",
  "rolldown_plugin_data_uri",
  "rolldown_plugin_hmr",
  "rolldown_resolver",
@@ -2858,7 +2859,11 @@ dependencies = [
 name = "rolldown_plugin_chunk_import_map"
 version = "0.1.0"
 dependencies = [
+ "arcstr",
  "rolldown_plugin",
+ "rolldown_utils",
+ "rustc-hash",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ rolldown_plugin_alias = { version = "0.1.0", path = "./crates/rolldown_plugin_al
 rolldown_plugin_asset = { version = "0.1.0", path = "./crates/rolldown_plugin_asset" }
 rolldown_plugin_asset_import_meta_url = { version = "0.1.0", path = "./crates/rolldown_plugin_asset_import_meta_url" }
 rolldown_plugin_build_import_analysis = { version = "0.1.0", path = "./crates/rolldown_plugin_build_import_analysis" }
+rolldown_plugin_chunk_import_map = { version = "0.1.0", path = "./crates/rolldown_plugin_chunk_import_map" }
 rolldown_plugin_data_uri = { version = "0.1.0", path = "./crates/rolldown_plugin_data_uri" }
 rolldown_plugin_dynamic_import_vars = { version = "0.0.1", path = "./crates/rolldown_plugin_dynamic_import_vars" }
 rolldown_plugin_hmr = { version = "0.1.0", path = "./crates/rolldown_plugin_hmr" }

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -42,6 +42,7 @@ rolldown_ecmascript_utils = { workspace = true }
 rolldown_error = { workspace = true }
 rolldown_fs = { workspace = true, features = ["os"] }
 rolldown_plugin = { workspace = true }
+rolldown_plugin_chunk_import_map = { workspace = true }
 rolldown_plugin_data_uri = { workspace = true }
 rolldown_plugin_hmr = { workspace = true }
 rolldown_resolver = { workspace = true }

--- a/crates/rolldown/src/utils/apply_inner_plugins.rs
+++ b/crates/rolldown/src/utils/apply_inner_plugins.rs
@@ -20,6 +20,11 @@ pub fn apply_inner_plugins(
     before_user_plugins.push(Arc::new(rolldown_plugin_hmr::HmrPlugin));
   }
 
+  if options.experimental.is_chunk_import_map_enabled() {
+    before_user_plugins
+      .push(Arc::new(rolldown_plugin_chunk_import_map::ChunkImportMapPlugin::default()));
+  }
+
   if !before_user_plugins.is_empty() {
     user_plugins.splice(0..0, before_user_plugins);
   }

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -8,6 +8,7 @@ pub struct BindingExperimentalOptions {
   pub hmr: Option<BindingExperimentalHmrOptions>,
   pub attach_debug_info: Option<BindingAttachDebugInfo>,
   pub chunk_modules_order: Option<BindingChunkModuleOrderBy>,
+  pub chunk_import_map: Option<bool>,
   pub on_demand_wrapping: Option<bool>,
   pub incremental_build: Option<bool>,
 }
@@ -23,6 +24,7 @@ impl From<BindingExperimentalOptions> for rolldown_common::ExperimentalOptions {
       hmr: value.hmr.map(Into::into),
       attach_debug_info: value.attach_debug_info.map(Into::into),
       chunk_modules_order: value.chunk_modules_order.map(Into::into),
+      chunk_import_map: value.chunk_import_map,
       on_demand_wrapping: value.on_demand_wrapping,
     }
   }

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -24,6 +24,7 @@ pub struct ExperimentalOptions {
   pub hmr: Option<HmrOptions>,
   pub attach_debug_info: Option<AttachDebugInfo>,
   pub chunk_modules_order: Option<ChunkModulesOrderBy>,
+  pub chunk_import_map: Option<bool>,
   pub on_demand_wrapping: Option<bool>,
 }
 
@@ -60,5 +61,9 @@ impl ExperimentalOptions {
 
   pub fn is_attach_debug_info_full(&self) -> bool {
     self.attach_debug_info.is_some_and(|info| info.is_full())
+  }
+
+  pub fn is_chunk_import_map_enabled(&self) -> bool {
+    self.chunk_import_map.unwrap_or(false)
   }
 }

--- a/crates/rolldown_plugin_chunk_import_map/Cargo.toml
+++ b/crates/rolldown_plugin_chunk_import_map/Cargo.toml
@@ -8,4 +8,8 @@ license = "MIT"
 doctest = false
 
 [dependencies]
+arcstr = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_utils = { workspace = true }
+rustc-hash = { workspace = true }
+xxhash-rust = { workspace = true, features = ["xxh3"] }

--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -1,9 +1,24 @@
-use std::borrow::Cow;
+use std::{
+  borrow::Cow,
+  hash::Hash,
+  sync::atomic::{AtomicBool, Ordering},
+};
 
-use rolldown_plugin::{HookUsage, Plugin};
+use arcstr::ArcStr;
+use rolldown_plugin::{HookRenderChunkOutput, HookUsage, Plugin};
+use rolldown_utils::{
+  dashmap::FxDashMap,
+  hash_placeholder::{find_hash_placeholders, hash_placeholder_left_finder},
+  xxhash::xxhash_with_base,
+};
+use rustc_hash::FxHashSet;
+use xxhash_rust::xxh3::Xxh3;
 
 #[derive(Debug, Default)]
-pub struct ChunkImportMapPlugin;
+pub struct ChunkImportMapPlugin {
+  initialized: AtomicBool,
+  chunk_import_map: FxDashMap<ArcStr, String>,
+}
 
 impl Plugin for ChunkImportMapPlugin {
   fn name(&self) -> Cow<'static, str> {
@@ -11,6 +26,85 @@ impl Plugin for ChunkImportMapPlugin {
   }
 
   fn register_hook_usage(&self) -> HookUsage {
-    HookUsage::empty()
+    HookUsage::RenderChunk | HookUsage::GenerateBundle
+  }
+
+  async fn render_chunk(
+    &self,
+    _ctx: &rolldown_plugin::PluginContext,
+    args: &rolldown_plugin::HookRenderChunkArgs<'_>,
+  ) -> rolldown_plugin::HookRenderChunkReturn {
+    let hash_finder = hash_placeholder_left_finder();
+    if !self.initialized.swap(true, Ordering::SeqCst) {
+      let base = args.options.hash_characters.base();
+      let mut used_names = FxHashSet::default();
+      for chunk in args.chunks.values() {
+        let hash_placeholders = find_hash_placeholders(&chunk.filename, &hash_finder);
+        if hash_placeholders.is_empty() {
+          continue;
+        }
+        let hasher = match &chunk.facade_module_id {
+          Some(module_id) => {
+            let mut hasher = Xxh3::with_seed(0);
+            module_id.resource_id().as_str().hash(&mut hasher);
+            hasher
+          }
+          None => {
+            // Fallback logic for common chunk
+            let mut hasher = Xxh3::with_seed(1);
+            if used_names.contains(&chunk.name) {
+              // Reduce the impact factor
+              let Some(module_id) = chunk.module_ids.iter().min() else { continue };
+              module_id.resource_id().as_str().hash(&mut hasher);
+            } else {
+              used_names.insert(chunk.name.clone());
+              chunk.name.hash(&mut hasher);
+            }
+            hasher
+          }
+        };
+        let hash = xxhash_with_base(&hasher.digest128().to_le_bytes(), base);
+        let mut chunk_id = chunk.filename.to_string();
+        for (start, end, placeholder) in hash_placeholders {
+          let hash = hash[..end - start].to_string();
+          unsafe { chunk_id.as_bytes_mut()[start..end].copy_from_slice(hash.as_bytes()) };
+          self.chunk_import_map.insert(placeholder.into(), hash);
+        }
+        self.chunk_import_map.insert(chunk.filename.clone(), chunk_id);
+      }
+    }
+
+    let mut placeholders = find_hash_placeholders(&args.code, &hash_finder);
+    placeholders.retain(|placeholder| self.chunk_import_map.contains_key(placeholder.2));
+
+    if placeholders.is_empty() {
+      return Ok(None);
+    }
+
+    let mut code = args.code.clone();
+    for (start, end, placeholder) in placeholders {
+      let hash = self.chunk_import_map.get(placeholder).expect("hash placeholder must exist");
+      debug_assert_eq!(hash.len(), end - start, "hash length doesn't match placeholder size");
+      unsafe {
+        code.as_bytes_mut()[start..end].copy_from_slice(hash.as_bytes());
+      }
+    }
+    Ok(Some(HookRenderChunkOutput { code, map: None }))
+  }
+
+  fn render_chunk_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Some(rolldown_plugin::PluginHookMeta { order: Some(rolldown_plugin::PluginOrder::Post) })
+  }
+
+  async fn generate_bundle(
+    &self,
+    _ctx: &rolldown_plugin::PluginContext,
+    _args: &mut rolldown_plugin::HookGenerateBundleArgs<'_>,
+  ) -> rolldown_plugin::HookNoopReturn {
+    Ok(())
+  }
+
+  fn generate_bundle_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Some(rolldown_plugin::PluginHookMeta { order: Some(rolldown_plugin::PluginOrder::Pre) })
   }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -852,6 +852,12 @@
             }
           ]
         },
+        "chunkImportMap": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "onDemandWrapping": {
           "type": [
             "boolean",

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1466,6 +1466,7 @@ export interface BindingExperimentalOptions {
   hmr?: BindingExperimentalHmrOptions
   attachDebugInfo?: BindingAttachDebugInfo
   chunkModulesOrder?: BindingChunkModuleOrderBy
+  chunkImportMap?: boolean
   onDemandWrapping?: boolean
   incrementalBuild?: boolean
 }

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -169,6 +169,7 @@ export interface InputOptions {
      * > You shouldn't use `full` in the production build.
      */
     attachDebugInfo?: AttachDebugOptions;
+    chunkImportMap?: boolean;
     onDemandWrapping?: boolean;
     /**
      * Required to be used with `watch` mode.

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -198,6 +198,7 @@ function bindingifyExperimental(
       experimental?.attachDebugInfo,
     ),
     chunkModulesOrder,
+    chunkImportMap: experimental?.chunkImportMap,
     onDemandWrapping: experimental?.onDemandWrapping,
     incrementalBuild: experimental?.incrementalBuild,
   };

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -410,6 +410,7 @@ const InputOptionsSchema = v.strictObject({
         v.literal('module-id'),
         v.literal('exec-order'),
       ])),
+      chunkImportMap: v.optional(v.boolean()),
     }),
   ),
   define: v.pipe(


### PR DESCRIPTION
Related to #5025

The changes will be split into smaller PRs and merged incrementally, with test cases added in the final step.