### PR TITLE
feat(hmr): automatically disable treeshaking in hmr

### DIFF
--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, path::Path};
 use oxc::transformer_plugins::InjectGlobalVariablesConfig;
 use rolldown_common::{
   AttachDebugInfo, GlobalsOutputOption, InjectImport, LegalComments, MinifyOptions, ModuleType,
-  NormalizedBundlerOptions, OutputFormat, Platform, PreserveEntrySignatures,
+  NormalizedBundlerOptions, OutputFormat, Platform, PreserveEntrySignatures, TreeshakeOptions,
 };
 use rolldown_error::{BuildDiagnostic, InvalidOptionType};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -232,10 +232,17 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
   );
   let cwd =
     raw_options.cwd.unwrap_or_else(|| std::env::current_dir().expect("Failed to get current dir"));
+
+  let mut raw_treeshake = raw_options.treeshake;
+  if experimental.hmr.is_some() {
+    // HMR requires treeshaking to be disabled
+    raw_treeshake = TreeshakeOptions::Boolean(false);
+  }
+
   let normalized = NormalizedBundlerOptions {
     input: raw_options.input.unwrap_or_default(),
     external: raw_options.external.unwrap_or_default(),
-    treeshake: raw_options.treeshake.into_normalized_options(),
+    treeshake: raw_treeshake.into_normalized_options(),
     platform,
     name: raw_options.name,
     entry_filenames: raw_options.entry_filenames.unwrap_or_else(|| "[name].js".to_string().into()),

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -13,7 +13,9 @@ var hmr_exports = {};
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 hmr_hot.accept((mod) => {
-	if (mod) console.log(".hmr", mod.foo);
+	if (mod) {
+		console.log(".hmr", mod.foo);
+	}
 });
 
 //#endregion
@@ -40,7 +42,9 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer(function() {
 			await (init_new_dep_esm_2(), Promise.resolve().then(() => __rolldown_runtime__.loadExports("new-dep-esm.js"))).then(console.log);
 		}
 		hot_hmr.accept((mod) => {
-			if (mod) console.log(".hmr", mod.foo);
+			if (mod) {
+				console.log(".hmr", mod.foo);
+			}
 		});
 	} finally {}
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -19,7 +19,9 @@ function text$1(el, text$2) {
 	console.log(el, text$2);
 }
 hmr_hot.accept((mod) => {
-	if (mod) console.log(".hmr", mod.foo);
+	if (mod) {
+		console.log(".hmr", mod.foo);
+	}
 });
 
 //#endregion
@@ -80,7 +82,9 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer(function() {
 			console.log(el, text);
 		}
 		hot_hmr.accept((mod) => {
-			if (mod) console.log(".hmr", mod.foo);
+			if (mod) {
+				console.log(".hmr", mod.foo);
+			}
 		});
 	} finally {}
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -8,12 +8,31 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 
 // HIDDEN [rolldown:hmr]
+//#region exist-dep-cjs.js
+var require_exist_dep_cjs = __commonJS({ "exist-dep-cjs.js"(exports, module) {
+	const exist_dep_cjs_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-cjs.js");
+	__rolldown_runtime__.registerModule("exist-dep-cjs.js", module);
+	exports.value = "exist-cjs";
+} });
+
+//#endregion
+//#region exist-dep-esm.js
+var exist_dep_esm_exports = {};
+__export(exist_dep_esm_exports, { value: () => value });
+const exist_dep_esm_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
+__rolldown_runtime__.registerModule("exist-dep-esm.js", { exports: exist_dep_esm_exports });
+const value = "exist-esm";
+
+//#endregion
 //#region hmr.js
 var hmr_exports = {};
+var import_exist_dep_cjs = __toESM(require_exist_dep_cjs());
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 hmr_hot.accept((mod) => {
-	if (mod) console.log(".hmr", mod.foo);
+	if (mod) {
+		console.log(".hmr", mod.foo);
+	}
 });
 
 //#endregion
@@ -42,7 +61,9 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer(function() {
 		var import_new_dep_cjs_2 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("new-dep-cjs.js"));
 		var import_new_dep_esm_3 = __rolldown_runtime__.loadExports("new-dep-esm.js");
 		hot_hmr.accept((mod) => {
-			if (mod) console.log(".hmr", mod.foo);
+			if (mod) {
+				console.log(".hmr", mod.foo);
+			}
 		});
 	} finally {}
 });

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4067,7 +4067,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-DtFrwtjK.js
+- main-!~{000}~.js => main-CULnuoFt.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4729,7 +4729,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-B4CPmt68.js
+- main-!~{000}~.js => main-BNy7N6Sl.js
 
 # tests/rolldown/issues/4196
 
@@ -5459,21 +5459,21 @@ expression: output
 
 # tests/rolldown/topics/hmr/deconflict_import_bindings
 
-- main-!~{000}~.js => main-BiBPf_z-.js
+- main-!~{000}~.js => main-pyxBy6AY.js
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-duM8i50F.js
+- main-!~{000}~.js => main-ZYAOt5V0.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-B3SOMwoL.js
+- main-!~{000}~.js => main-DRztFpwI.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-D_g6k6lb.js
-- index-!~{001}~.js => index-CI0-AnWJ.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-DdRdQYHl.js
+- entry-!~{000}~.js => entry-I3ZJmPFx.js
+- index-!~{001}~.js => index-DaBxWGNZ.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-BCfnkUfE.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
@@ -5481,11 +5481,11 @@ expression: output
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-RmX4Jh6e.js
+- main-!~{000}~.js => main-Bck2In-l.js
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-duM8i50F.js
+- main-!~{000}~.js => main-kUOU8gjL.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 


### PR DESCRIPTION
There're some partial optimizations (like dce) we could do in hmr. 

However, it's expected to disable treeshaking in hmr and let's ensure this behavior.