### PR TITLE
feat: use PIFE for callbacks passed to `__esmMin` wrapper

### DIFF
--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/_config.json
@@ -18,5 +18,11 @@
         }
       ]
     }
-  }
+  },
+  "configVariants": [
+    {
+      "configName": "no-profiler-names",
+      "profilerNames": false
+    }
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/artifacts.snap
@@ -46,3 +46,52 @@ export { a, b, init_a, init_b };
 // HIDDEN [rolldown:runtime]
 export { __esm };
 ```
+---
+
+Variant: no-profiler-names
+
+# Assets
+
+## a.js
+
+```js
+import { a, init_a } from "./common.js";
+
+init_a();
+export { a };
+```
+## b.js
+
+```js
+import { b, init_b } from "./common.js";
+
+init_b();
+export { b };
+```
+## common.js
+
+```js
+import { __esmMin } from "./rolldown-runtime.js";
+
+//#region a.js
+var a;
+var init_a = __esmMin((() => {
+	a = "a";
+}));
+
+//#endregion
+//#region b.js
+var b;
+var init_b = __esmMin((() => {
+	b = "a";
+}));
+
+//#endregion
+export { a, b, init_a, init_b };
+```
+## rolldown-runtime.js
+
+```js
+// HIDDEN [rolldown:runtime]
+export { __esmMin };
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify/artifacts.snap
@@ -6,5 +6,5 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-var e=(e,t)=>()=>(e&&(t=e(e=0)),t);async function t(){console.log(`foo`)}var n=e(()=>{}),r=e(async()=>{await n(),await t()});await r();
+var e=(e,t)=>()=>(e&&(t=e(e=0)),t);async function t(){console.log(`foo`)}var n=e((()=>{})),r=e((async()=>{await n(),await t()}));await r();
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4103,7 +4103,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax_minify
 
-- main-!~{000}~.js => main-Buo6YqrV.js
+- main-!~{000}~.js => main-LH9tIU3F.js
 
 # tests/rolldown/function/export_mode/cjs/auto/default
 

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1465,6 +1465,12 @@
             "null"
           ]
         },
+        "profilerNames": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "_snapshot": {
           "type": [
             "boolean",

--- a/crates/rolldown_testing_config/src/lib.rs
+++ b/crates/rolldown_testing_config/src/lib.rs
@@ -22,6 +22,7 @@ pub struct ConfigVariant {
   pub treeshake: Option<TreeshakeOptions>,
   pub minify_internal_exports: Option<bool>,
   pub on_demand_wrapping: Option<bool>,
+  pub profiler_names: Option<bool>,
   // --- non-bundler options are start with `_`
   // Whether to include the output in the snapshot for this config variant.
   #[serde(rename = "_snapshot")]
@@ -68,6 +69,9 @@ impl ConfigVariant {
         ..config.experimental.unwrap_or_default()
       });
     }
+    if let Some(profiler_names) = &self.profiler_names {
+      config.profiler_names = Some(*profiler_names);
+    }
     config
   }
 }
@@ -101,6 +105,9 @@ impl Display for ConfigVariant {
     }
     if let Some(on_demand_wrapping) = &self.on_demand_wrapping {
       fields.push(format!("on_demand_wrapping: {on_demand_wrapping:?}"));
+    }
+    if let Some(profiler_names) = &self.profiler_names {
+      fields.push(format!("profiler_names: {profiler_names:?}"));
     }
     fields.sort();
     if fields.is_empty() { write!(f, "()") } else { write!(f, "({})", fields.join(", ")) }


### PR DESCRIPTION
This PR changes the generated code to use PIFE for callbacks passed to `__esmMin` wrapper. This improved the start up runtime performance by 2.1x in the case I tested.

I tested this change on https://github.com/rolldown/benchmarks/tree/main/apps/10000 with the following config:
```ts
import { defineConfig } from "vite";

export default defineConfig({
  build: {
    rollupOptions: {
      output: {
        advancedChunks: {
          groups: [
            {
              name: 'some'
            }
          ]
        }
      }
    }
  },
  experimental: {
    enableNativePlugin: true,
  },
  esbuild: false,
});
```
I also updated the HTML to measure the render time.
```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Vite + React</title>
  </head>
  <body>
    <div id="root"></div>
    <script type="module">
      globalThis.start = performance.now()
    </script>
    <script type="module" src="./src/index.jsx"></script>
    <script type="module">
      const end = performance.now()
      console.log('render time:', end - globalThis.start)
    </script>
  </body>
</html>
```

The results were (average of 5 times):

|                            | before | after |
|-------------------| ---------- | ------ |
| dev (no minify, hmr=true) | 295.3 ms | 139.7 ms |
| build (minified) | 190.1 ms | 97.2 ms |

I tested this on Chrome 138.0.7204.101.
Also note that this change increases the output code size slightly:

**Before**: 6,338.19 kB (gzip: 1,871.28 kB)
**After**: 6,376.20 kB (gzip: 1,874.64 kB)

requires https://github.com/oxc-project/oxc/pull/12353

---

**Note: The same optimization can be applied to `__commonJSMin`, `__esm`, `__commonJS`, `createEsmInitializer`.**
