### PR TITLE
fix: keep top level variables for non-esm format when minify is enabled

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/minify_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/minify_assets.rs
@@ -41,6 +41,7 @@ impl GenerateStage<'_> {
             // TODO: Do we need to ensure `asset.filename` to be absolute path?
             let (minified_content, new_map) = EcmaCompiler::minify(
               asset.content.try_as_inner_str()?,
+              options.format.source_type().with_jsx(true),
               asset.map.is_some(),
               &asset.filename,
               minify_options.to_oxc_minifier_options(options),

--- a/crates/rolldown/tests/rolldown/function/format/iife/iife_with_name_with_minify/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/iife_with_name_with_minify/artifacts.snap
@@ -6,5 +6,5 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-(function(exports){let t=1;return exports.value=t,exports})({});
+var module=function(exports){let t=1;return exports.value=t,exports}({});
 ```

--- a/crates/rolldown/tests/rolldown/function/minify/exports/_config.json
+++ b/crates/rolldown/tests/rolldown/function/minify/exports/_config.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "minify": true,
+    "format": "esm"
+  },
+  "snapshot": false,
+  "configVariants": [
+    {
+      "configName": "cjs",
+      "format": "cjs"
+    },
+    {
+      "configName": "umd",
+      "format": "umd",
+      "name": "lib"
+    },
+    {
+      "configName": "iife",
+      "format": "iife",
+      "name": "lib"
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/minify/exports/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/minify/exports/_test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+
+switch (globalThis.__testName) {
+  case undefined:
+  case 'Extended Test: (minify_internal_exports: true': {
+    const { foo } = await import('./dist/main.js')
+    assert.strictEqual(foo, 'foo')
+    break
+  }
+  case 'cjs': {
+    const libModCjs = require('./dist/main.js')
+    assert.strictEqual(libModCjs.foo, 'foo')
+    break
+  }
+  case 'umd': {
+    await import('./dist/main.js')
+    assert(!!globalThis.lib)
+    assert.strictEqual(globalThis.lib.foo, 'foo')
+    break
+  }
+  case 'iife': {
+    const iifeContent = fs.readFileSync(
+      path.resolve(import.meta.dirname, './dist/main.js'),
+      'utf-8'
+    )
+    ;(0, eval)(iifeContent)
+    assert(!!globalThis.lib)
+    assert.strictEqual(globalThis.lib.foo, 'foo')
+    break
+  }
+  default: {
+    throw new Error(`Unknown test name: ${globalThis.__testName}`)
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/minify/exports/main.js
+++ b/crates/rolldown/tests/rolldown/function/minify/exports/main.js
@@ -1,0 +1,1 @@
+export const foo = 'foo'

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4392,6 +4392,10 @@ expression: output
 - main-!~{000}~.js => main-CG4zlDFv.js
 - main-CG4zlDFv.js.map
 
+# tests/rolldown/function/minify/exports
+
+- main-!~{000}~.js => main-D2tiPUbr.js
+
 # tests/rolldown/function/minify/inject_node_env
 
 - main-!~{000}~.js => main-CihG9yyg.js

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_format.rs
@@ -1,3 +1,4 @@
+use oxc::span::SourceType;
 #[cfg(feature = "deserialize_bundler_options")]
 use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
@@ -28,6 +29,14 @@ impl OutputFormat {
   /// Since we have different implementation for `IIFE` and extra implementation of `UMD` omit them as well
   pub fn should_call_runtime_require(&self) -> bool {
     !matches!(self, Self::Cjs | Self::Umd | Self::Iife)
+  }
+
+  #[inline]
+  pub fn source_type(&self) -> SourceType {
+    match self {
+      Self::Esm => SourceType::mjs(),
+      Self::Cjs | Self::Iife | Self::Umd => SourceType::cjs(),
+    }
   }
 }
 

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -102,6 +102,7 @@ impl EcmaCompiler {
 
   pub fn minify(
     source_text: &str,
+    source_type: SourceType,
     enable_sourcemap: bool,
     filename: &str,
     minifier_options: MinifierOptions,
@@ -109,8 +110,7 @@ impl EcmaCompiler {
     codegen_options: CodegenOptions,
   ) -> (String, Option<SourceMap>) {
     let allocator = Allocator::default();
-    let program =
-      Parser::new(&allocator, source_text, SourceType::default().with_jsx(true)).parse().program;
+    let program = Parser::new(&allocator, source_text, source_type).parse().program;
     let program = allocator.alloc(program);
     let ret = Self::minify_impl(minifier_options, run_compress, &allocator, program);
     let ret = Codegen::new()


### PR DESCRIPTION
Top level variables were removed even for non-esm format when minify is enabled.