### PR TITLE
revert: `test(rust): prevent meaningless snapshot change from bumping oxc runtime versions #5312`

### DIFF
--- a/crates/rolldown/tests/esbuild/lower/lower_async_generator/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_generator/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
 function _usingCtx() {
 	var r = "function" == typeof SuppressedError ? SuppressedError : function(r$1, e$1) {
 		var n$1 = Error();

--- a/crates/rolldown/tests/esbuild/lower/lower_async_generator/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_generator/bypass.md
@@ -283,7 +283,7 @@ async function bar() {
 ```
 ### rolldown
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
 function _usingCtx() {
 	var r = "function" == typeof SuppressedError ? SuppressedError : function(r$1, e$1) {
 		var n$1 = Error();

--- a/crates/rolldown/tests/esbuild/lower/lower_async_generator_no_await/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_generator_no_await/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
 function _usingCtx() {
 	var r = "function" == typeof SuppressedError ? SuppressedError : function(r$1, e$1) {
 		var n$1 = Error();

--- a/crates/rolldown/tests/esbuild/lower/lower_async_generator_no_await/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_generator_no_await/bypass.md
@@ -302,7 +302,7 @@ function bar() {
 ```
 ### rolldown
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
 function _usingCtx() {
 	var r = "function" == typeof SuppressedError ? SuppressedError : function(r$1, e$1) {
 		var n$1 = Error();
@@ -535,7 +535,7 @@ Foo = class {
 -      _promise2 && (yield new __await(_promise2));
 -    }
 -  });
-+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
++//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
 +function _usingCtx() {
 +	var r = "function" == typeof SuppressedError ? SuppressedError : function(r$1, e$1) {
 +		var n$1 = Error();

--- a/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/artifacts.snap
@@ -6,32 +6,32 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/checkPrivateRedeclaration.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/checkPrivateRedeclaration.js
 function _checkPrivateRedeclaration(e, t) {
 	if (t.has(e)) throw new TypeError("Cannot initialize the same private elements twice on an object");
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldInitSpec.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldInitSpec.js
 function _classPrivateFieldInitSpec(e, t, a) {
 	_checkPrivateRedeclaration(e, t), t.set(e, a);
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/assertClassBrand.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/assertClassBrand.js
 function _assertClassBrand(e, t, n) {
 	if ("function" == typeof e ? e === t : e.has(t)) return arguments.length < 3 ? t : n;
 	throw new TypeError("Private element is not present on this object");
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldGet2.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldGet2.js
 function _classPrivateFieldGet2(s, a) {
 	return s.get(_assertClassBrand(s, a));
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldSet2.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldSet2.js
 function _classPrivateFieldSet2(s, a, r) {
 	return s.set(_assertClassBrand(s, a), r), r;
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/diff.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/diff.md
@@ -15,32 +15,32 @@ export {
 ```
 ### rolldown
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/checkPrivateRedeclaration.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/checkPrivateRedeclaration.js
 function _checkPrivateRedeclaration(e, t) {
 	if (t.has(e)) throw new TypeError("Cannot initialize the same private elements twice on an object");
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldInitSpec.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldInitSpec.js
 function _classPrivateFieldInitSpec(e, t, a) {
 	_checkPrivateRedeclaration(e, t), t.set(e, a);
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/assertClassBrand.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/assertClassBrand.js
 function _assertClassBrand(e, t, n) {
 	if ("function" == typeof e ? e === t : e.has(t)) return arguments.length < 3 ? t : n;
 	throw new TypeError("Private element is not present on this object");
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldGet2.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldGet2.js
 function _classPrivateFieldGet2(s, a) {
 	return s.get(_assertClassBrand(s, a));
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldSet2.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldSet2.js
 function _classPrivateFieldSet2(s, a, r) {
 	return s.set(_assertClassBrand(s, a), r), r;
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_using_inside_ts_namespace/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_using_inside_ts_namespace/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
 function _usingCtx() {
 	var r = "function" == typeof SuppressedError ? SuppressedError : function(r$1, e$1) {
 		var n$1 = Error();

--- a/crates/rolldown/tests/esbuild/lower/lower_using_inside_ts_namespace/bypass.md
+++ b/crates/rolldown/tests/esbuild/lower/lower_using_inside_ts_namespace/bypass.md
@@ -20,7 +20,7 @@ var ns;
 ```
 ### rolldown
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
 function _usingCtx() {
 	var r = "function" == typeof SuppressedError ? SuppressedError : function(r$1, e$1) {
 		var n$1 = Error();

--- a/crates/rolldown/tests/rolldown/resolve/ts_config_merge_decorator_metadata/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/ts_config_merge_decorator_metadata/artifacts.snap
@@ -6,13 +6,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/decorateMetadata.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/decorateMetadata.js
 function __decorateMetadata(k, v) {
 	if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/decorate.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/decorate.js
 function __decorate(decorators, target, key, desc) {
 	var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
 	if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);

--- a/crates/rolldown/tests/rolldown/resolve/ts_config_option_merge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/ts_config_option_merge/artifacts.snap
@@ -14,7 +14,7 @@ function add(a, b) {
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/decorateParam.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/decorateParam.js
 function __decorateParam(paramIndex, decorator) {
 	return function(target, key) {
 		decorator(target, key, paramIndex);
@@ -22,7 +22,7 @@ function __decorateParam(paramIndex, decorator) {
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@VERSION/node_modules/@oxc-project/runtime/src/helpers/esm/decorate.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.77.2/node_modules/@oxc-project/runtime/src/helpers/esm/decorate.js
 function __decorate(decorators, target, key, desc) {
 	var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
 	if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4067,7 +4067,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-CULnuoFt.js
+- main-!~{000}~.js => main-Clo-cQzz.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4729,7 +4729,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-BNy7N6Sl.js
+- main-!~{000}~.js => main-mbS9alea.js
 
 # tests/rolldown/issues/4196
 
@@ -5459,33 +5459,33 @@ expression: output
 
 # tests/rolldown/topics/hmr/deconflict_import_bindings
 
-- main-!~{000}~.js => main-pyxBy6AY.js
+- main-!~{000}~.js => main-Bu6m5KuF.js
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-ZYAOt5V0.js
+- main-!~{000}~.js => main-BQUKp0js.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-DRztFpwI.js
+- main-!~{000}~.js => main-Cm3C6mQH.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-I3ZJmPFx.js
-- index-!~{001}~.js => index-DaBxWGNZ.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-BCfnkUfE.js
+- entry-!~{000}~.js => entry-BPZIs1mk.js
+- index-!~{001}~.js => index-BL3zgd2U.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-gxTUiBAp.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-CT-sUQpR.js
+- main-!~{000}~.js => main-C2h-3mJ8.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-Bck2In-l.js
+- main-!~{000}~.js => main-DuNKH6ZV.js
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-kUOU8gjL.js
+- main-!~{000}~.js => main-ChOnEuJG.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
@@ -7,10 +7,28 @@ import {
   // @ts-expect-error
 } from 'rolldown:runtime';
 
+class Module {
+  /**
+   * @type {any}
+   */
+  exports = null;
+  /**
+   * @type {string}
+   */
+  id;
+
+  /**
+   * @param {string} id
+   */
+  constructor(id) {
+    this.id = id;
+  }
+}
+
 // oxlint-disable-next-line no-unused-vars
 export class DevRuntime {
   /**
-   * @type {Record<string, { exports: any }>}
+   * @type {Record<string, Module>}
    */
   modules = {};
   /**
@@ -27,9 +45,11 @@ export class DevRuntime {
   }
   /**
    * @param {string} id
-   * @param {{ exports: any }} module
+   * @param {{ exports: any }} meta
    */
-  registerModule(id, module) {
+  registerModule(id, meta) {
+    const module = new Module(id);
+    module.exports = meta.exports;
     this.modules[id] = module;
   }
   /**

--- a/crates/rolldown_testing/src/utils.rs
+++ b/crates/rolldown_testing/src/utils.rs
@@ -105,12 +105,6 @@ pub(crate) static HMR_RUNTIME_MODULE_OUTPUT_RE: LazyLock<Regex> = LazyLock::new(
     .expect("invalid hmr runtime module output regex")
 });
 
-// Match pattern like `@oxc-project+runtime@0.77.0`
-pub(crate) static OXC_PROJECT_RUNTIME_RE: LazyLock<Regex> = LazyLock::new(|| {
-  Regex::new(r"(@oxc-project\+runtime@\d+\.\d+\.\d+)")
-    .expect("invalid hmr runtime module output regex")
-});
-
 // Some content of snapshot are meaningless, we'd like to remove them to reduce the noise when reviewing snapshots.
 pub fn tweak_snapshot(
   content: &str,
@@ -131,9 +125,6 @@ pub fn tweak_snapshot(
     result =
       HMR_RUNTIME_MODULE_OUTPUT_RE.replace_all(&result, "// HIDDEN [rolldown:hmr]").into_owned();
   }
-
-  // Replace pattern `@oxc-project+runtime@0.77.0` with `@oxc-project+runtime@VERSION` to avoid unnecessary changes in bumping version.
-  result = OXC_PROJECT_RUNTIME_RE.replace_all(&result, "@oxc-project+runtime@VERSION").into_owned();
 
   Cow::Owned(result)
 }


### PR DESCRIPTION
Comments play a part in content hash. We want things related to this to be explicitly.