### PR TITLE
refactor: store ast with same shape as module_table

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -96,7 +96,6 @@ pub async fn create_ecma_view(
   // TODO: Should we check if there are `check_side_effects_for` returns false but there are side effects in the module?
   let ecma_view = EcmaView {
     source: ast.source().clone(),
-    ecma_ast_idx: None,
     named_imports,
     named_exports,
     stmt_infos,

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -121,7 +121,6 @@ impl RuntimeModuleTask {
       module_type,
 
       ecma_view: EcmaView {
-        ecma_ast_idx: None,
         source,
 
         import_records: IndexVec::default(),

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -257,7 +257,7 @@ impl GenerateStage<'_> {
           .par_iter()
           .map(|&module_idx| match self.link_output.module_table[module_idx].as_normal() {
             Some(module) => {
-              let ast = &self.link_output.ast_table[module.ecma_ast_idx()].0;
+              let ast = self.link_output.ast_table[module.idx].as_ref().expect("should have ast");
               module.render(self.options, &ModuleRenderArgs::Ecma { ast })
             }
             _ => None,

--- a/crates/rolldown/src/type_alias.rs
+++ b/crates/rolldown/src/type_alias.rs
@@ -1,9 +1,9 @@
 use oxc_index::IndexVec;
-use rolldown_common::{Asset, ChunkIdx, EcmaAstIdx, InsChunkIdx, InstantiatedChunk, ModuleIdx};
+use rolldown_common::{Asset, ChunkIdx, InsChunkIdx, InstantiatedChunk, ModuleIdx};
 use rolldown_ecmascript::EcmaAst;
 use rolldown_utils::indexmap::FxIndexSet;
 
 pub type IndexChunkToInstances = IndexVec<ChunkIdx, FxIndexSet<InsChunkIdx>>;
 pub type AssetVec = Vec<Asset>;
 pub type IndexInstantiatedChunks = IndexVec<InsChunkIdx, InstantiatedChunk>;
-pub type IndexEcmaAst = IndexVec<EcmaAstIdx, (EcmaAst, ModuleIdx)>;
+pub type IndexEcmaAst = IndexVec<ModuleIdx, Option<EcmaAst>>;

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -58,42 +58,21 @@ impl ScanStageCache {
       }
     }
     // merge module_table, index_ast_scope, index_ecma_ast
-    for (new_idx, mut new_module) in modules {
+    for (new_idx, new_module) in modules {
       let idx = self.module_id_to_idx[new_module.id_clone()].idx();
 
-      let old_module = if new_idx.index() >= cache.module_table.modules.len() {
-        if let Some(module) = new_module.as_normal_mut() {
-          let new_module_idx = ModuleIdx::from_usize(cache.module_table.modules.len());
-          let ecma_ast_idx = module.ecma_ast_idx();
-          let new_ecma_ast_idx = cache
-            .index_ecma_ast
-            .push(std::mem::take(&mut scan_stage_output.index_ecma_ast[ecma_ast_idx]));
-          module.ecma_ast_idx = Some(new_ecma_ast_idx);
+      if new_idx.index() >= cache.module_table.modules.len() {
+        let new_module_idx = ModuleIdx::from_usize(cache.module_table.modules.len());
 
-          cache.symbol_ref_db.store_local_db(
-            new_module_idx,
-            std::mem::take(scan_stage_output.symbol_ref_db.local_db_mut(new_idx)),
-          );
-        }
+        cache.symbol_ref_db.store_local_db(
+          new_module_idx,
+          std::mem::take(scan_stage_output.symbol_ref_db.local_db_mut(new_idx)),
+        );
         cache.module_table.modules.push(new_module);
         continue;
-      } else {
-        std::mem::replace(&mut cache.module_table[idx], new_module)
-      };
-      let Some(new_module) = cache.module_table[idx].as_normal_mut() else {
-        continue;
-      };
-      let old_module = old_module.as_normal().unwrap();
-
-      let new_ecma_ast_idx = new_module.ecma_ast_idx.expect("should have ecma_ast_idx");
-
-      let old_ecma_ast_idx = old_module.ecma_ast_idx.expect("should have ecma_ast_idx");
-
-      new_module.ecma_ast_idx = Some(old_ecma_ast_idx);
-      std::mem::swap(
-        &mut cache.index_ecma_ast[old_ecma_ast_idx],
-        &mut scan_stage_output.index_ecma_ast[new_ecma_ast_idx],
-      );
+      }
+      cache.module_table[idx] = new_module;
+      cache.index_ecma_ast[idx] = scan_stage_output.index_ecma_ast.get_mut(new_idx).take();
       std::mem::swap(
         cache.symbol_ref_db.local_db_mut(idx),
         scan_stage_output.symbol_ref_db.local_db_mut(new_idx),
@@ -138,7 +117,7 @@ impl ScanStageCache {
           .index_ecma_ast
           .raw
           .par_iter()
-          .map(|(ast, module_idx)| (ast.clone_with_another_arena(), *module_idx))
+          .map(|ast| ast.as_ref().map(rolldown_ecmascript::EcmaAst::clone_with_another_arena))
           .collect::<Vec<_>>();
         IndexVec::from_vec(item)
       },

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -8,8 +8,8 @@ use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-  EcmaAstIdx, ExportsKind, HmrInfo, ImportRecordIdx, LocalExport, ModuleDefFormat, ModuleId,
-  ModuleIdx, NamedImport, ResolvedImportRecord, SourceMutation, StmtInfos, SymbolRef,
+  ExportsKind, HmrInfo, ImportRecordIdx, LocalExport, ModuleDefFormat, ModuleId, ModuleIdx,
+  NamedImport, ResolvedImportRecord, SourceMutation, StmtInfos, SymbolRef,
   side_effects::DeterminedSideEffects, types::source_mutation::ArcSourceMutation,
 };
 
@@ -63,7 +63,6 @@ impl EcmaViewMeta {
 pub struct EcmaView {
   pub dummy_record_set: FxHashSet<Span>,
   pub source: ArcStr,
-  pub ecma_ast_idx: Option<EcmaAstIdx>,
   pub def_format: ModuleDefFormat,
   /// Represents [Module Namespace Object](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects)
   pub namespace_object_ref: SymbolRef,

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -117,7 +117,6 @@ pub use crate::{
   types::constant_value::{ConstExportMeta, ConstantValue},
   types::deconflict::ModuleScopeSymbolIdMap,
   types::defer_sync_scan_data::DeferSyncScanData,
-  types::ecma_ast_idx::EcmaAstIdx,
   types::entry_point::{EntryPoint, EntryPointKind},
   types::exports_kind::ExportsKind,
   types::external_module_idx::ExternalModuleIdx,

--- a/crates/rolldown_common/src/module/mod.rs
+++ b/crates/rolldown_common/src/module/mod.rs
@@ -5,9 +5,7 @@ use arcstr::ArcStr;
 use oxc_index::IndexVec;
 use rolldown_std_utils::OptionExt;
 
-use crate::{
-  EcmaAstIdx, ExternalModule, ImportRecordIdx, ModuleIdx, NormalModule, ResolvedImportRecord,
-};
+use crate::{ExternalModule, ImportRecordIdx, ModuleIdx, NormalModule, ResolvedImportRecord};
 
 #[derive(Debug, Clone)]
 pub enum Module {
@@ -119,13 +117,6 @@ impl Module {
         _ => v.ecma_view.import_records = records,
       },
       Module::External(v) => v.import_records = records,
-    }
-  }
-
-  pub fn set_ecma_ast_idx(&mut self, idx: EcmaAstIdx) {
-    match self {
-      Module::Normal(v) => v.ecma_ast_idx = Some(idx),
-      Module::External(_) => panic!("set_ecma_ast_idx should be called on EcmaModule"),
     }
   }
 

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -7,7 +7,7 @@ use crate::{
   LegalComments, ModuleId, ModuleIdx, ModuleInfo, NormalizedBundlerOptions, RawImportRecord,
   ResolvedId, StmtInfo,
 };
-use crate::{EcmaAstIdx, EcmaView, IndexModules, Interop, Module, ModuleType};
+use crate::{EcmaView, IndexModules, Interop, Module, ModuleType};
 use std::ops::{Deref, DerefMut};
 
 use itertools::Itertools;
@@ -141,10 +141,6 @@ impl NormalModule {
     } else {
       ret.extend(self.ecma_view.named_exports.keys().filter(|name| name.as_str() != "default"));
     }
-  }
-
-  pub fn ecma_ast_idx(&self) -> EcmaAstIdx {
-    self.ecma_view.ecma_ast_idx.expect("ecma_ast_idx should be set in this stage")
   }
 
   pub fn star_exports_from_external_modules<'me>(

--- a/crates/rolldown_common/src/types/ecma_ast_idx.rs
+++ b/crates/rolldown_common/src/types/ecma_ast_idx.rs
@@ -1,3 +1,0 @@
-oxc_index::define_index_type! {
-  pub struct EcmaAstIdx = u32;
-}

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -8,7 +8,6 @@ pub mod chunk_kind;
 pub mod constant_value;
 pub mod deconflict;
 pub mod defer_sync_scan_data;
-pub mod ecma_ast_idx;
 pub mod entry_point;
 pub mod exports_kind;
 pub mod external_module_idx;


### PR DESCRIPTION
Since the `ast_vec` is dense in most of the scenarios, store them as `Vec<EcmaAstIdx,EcmaAst>`, will not save too much memory, however, this also increasesthe  complexity of accessing the ast, since you need to get the module first, then get `ecmaAstIdx` , and finally get the ast. For now, you could get `ast` directly with `moduleIdx`