### PR TITLE
fix(hmr): should not panic for editing modules that contain `import(..)`

### DIFF
--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -195,6 +195,14 @@ impl HmrManager {
     // due to architecture limitation.
     modules_to_invalidate.extend(affected_modules.clone());
 
+    tracing::debug!(
+      target: "hmr",
+      "modules_to_invalidate` {:?}",
+      modules_to_invalidate.iter()
+        .map(|module_idx| self.module_db.modules[*module_idx].stable_id())
+        .collect::<Vec<_>>(),
+    );
+
     let module_infos_to_be_updated = modules_to_invalidate
       .iter()
       .map(|module_idx| {

--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -139,6 +139,8 @@ impl HmrManager {
     let mut hmr_boundaries = FxIndexSet::default();
     let mut need_to_full_reload = false;
     let mut full_reload_reason = None;
+
+    // We're checking if this change could be handled by hmr. If so, we need to find the HMR boundaries.
     while let Some(changed_module_idx) = changed_modules.pop() {
       if need_to_full_reload {
         break;
@@ -172,6 +174,11 @@ impl HmrManager {
       hmr_boundaries.extend(boundaries);
     }
 
+    // The HMR process will execute the code starting from the HMR boundaries. The HMR process expects all dependencies
+    // of the HMR boundaries to be re-executed. We collect them here to include them in the HMR output.
+    affected_modules
+      .extend(Self::collect_affected_modules_from_boundaries(&self.module_db, &hmr_boundaries));
+
     if need_to_full_reload {
       return Ok(HmrOutput {
         full_reload_reason,
@@ -191,9 +198,17 @@ impl HmrManager {
 
     let mut modules_to_invalidate = changed_modules.clone();
     // FIXME(hyf0): In general, only modules got edited need to be invalidated, because we need to refetch their latest content.
-    // For those modules that are not edited, we should be able to reuse their AST. But currently we don't have a good way to do that
-    // due to architecture limitation.
+    // For those modules that are not edited but affected, we should be able to reuse their previous AST instead of going through the whole
+    // module loading process again. But currently we don't have a good way to do that due to architecture limitation.
     modules_to_invalidate.extend(affected_modules.clone());
+
+    // FIXME: It's expected that `rolldown:runtime` appears in the `affected_modules`. But the module loader can't handle it properly, it'll
+    // report an error that disk doesn't exist file called `rolldown:runtime`.
+    self.module_db.iter().find_map(|m| (m.id() == "rolldown:runtime").then_some(m.idx())).inspect(
+      |runtime_idx| {
+        modules_to_invalidate.shift_remove(runtime_idx);
+      },
+    );
 
     tracing::debug!(
       target: "hmr",
@@ -451,5 +466,39 @@ impl HmrManager {
     }
 
     false
+  }
+
+  fn collect_affected_modules_from_boundaries(
+    modules: &ModuleTable,
+    hmr_boundaries: &FxIndexSet<HmrBoundary>,
+  ) -> impl IntoIterator<Item = ModuleIdx> {
+    fn collect_dependencies(
+      modules: &ModuleTable,
+      module_idx: ModuleIdx,
+      visited: &mut FxHashSet<ModuleIdx>,
+    ) {
+      if visited.contains(&module_idx) {
+        return;
+      }
+      visited.insert(module_idx);
+
+      let module = &modules[module_idx];
+      match module {
+        Module::Normal(normal_module) => {
+          normal_module.import_records.iter().for_each(|import_record| {
+            collect_dependencies(modules, import_record.resolved_module, visited);
+          });
+        }
+        Module::External(_external_module) => {
+          // No need to deal with external modules in HMR.
+        }
+      }
+    }
+    let mut visited = FxHashSet::default();
+    hmr_boundaries.iter().for_each(|boundary| {
+      collect_dependencies(modules, boundary.boundary, &mut visited);
+    });
+
+    visited
   }
 }

--- a/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
@@ -43,11 +43,182 @@ var init_main_0 = __rolldown_runtime__.createEsmInitializer(function() {
 		var ns_main = {};
 		__rolldown_runtime__.__export(ns_main, {});
 		__rolldown_runtime__.registerModule("main.js", { exports: ns_main });
+		init_foo_2();
+		init_foo_3();
 		const hot_main = __rolldown_runtime__.createModuleHotContext("main.js");
 		var import_foo_0 = __rolldown_runtime__.loadExports("foo.mjs");
 		var import_foo_1 = __rolldown_runtime__.loadExports("foo/index.mjs");
 		console.log(import_foo_0.foo, import_foo_1.foo);
 		hot_main.accept(() => {});
+	} finally {}
+});
+
+var init_rolldown_runtime_1 = __rolldown_runtime__.createEsmInitializer(function() {
+	try {
+		var ns_rolldown_runtime = {};
+		__rolldown_runtime__.__export(ns_rolldown_runtime, {});
+		__rolldown_runtime__.registerModule("rolldown:runtime", { exports: ns_rolldown_runtime });
+		const hot_rolldown_runtime = __rolldown_runtime__.createModuleHotContext("rolldown:runtime");
+		var __create = Object.create;
+		var __defProp = Object.defineProperty;
+		var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+		var __getOwnPropNames = Object.getOwnPropertyNames;
+		var __getProtoOf = Object.getPrototypeOf;
+		var __hasOwnProp = Object.prototype.hasOwnProperty;
+		var __export = (target, all) => {
+			for (var name in all) __defProp(target, name, {
+				get: all[name],
+				enumerable: true
+			});
+		};
+		var __copyProps = (to, from, except, desc) => {
+			if (from && typeof from === "object" || typeof from === "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
+				key = keys[i];
+				if (!__hasOwnProp.call(to, key) && key !== except) __defProp(to, key, {
+					get: ((k) => from[k]).bind(null, key),
+					enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+				});
+			}
+			return to;
+		};
+		var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
+			value: mod,
+			enumerable: true
+		}) : target, mod));
+		var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+		var __toDynamicImportESM = (isNodeMode) => (mod) => __toESM(mod.default, isNodeMode);
+	} finally {}
+});
+
+var init_foo_2 = __rolldown_runtime__.createEsmInitializer(function() {
+	try {
+		var ns_foo = {};
+		__rolldown_runtime__.__export(ns_foo, { foo: () => foo });
+		__rolldown_runtime__.registerModule("foo.mjs", { exports: ns_foo });
+		const hot_foo = __rolldown_runtime__.createModuleHotContext("foo.mjs");
+		const foo = "foo";
+	} finally {}
+});
+
+var init_foo_3 = __rolldown_runtime__.createEsmInitializer(function() {
+	try {
+		var ns_foo = {};
+		__rolldown_runtime__.__export(ns_foo, { foo: () => foo });
+		__rolldown_runtime__.registerModule("foo/index.mjs", { exports: ns_foo });
+		const hot_foo = __rolldown_runtime__.createModuleHotContext("foo/index.mjs");
+		const foo = "foo";
+	} finally {}
+});
+
+var init_rolldown_hmr_4 = __rolldown_runtime__.createEsmInitializer(function() {
+	try {
+		var ns_rolldown_hmr = {};
+		__rolldown_runtime__.__export(ns_rolldown_hmr, { DevRuntime: () => DevRuntime });
+		__rolldown_runtime__.registerModule("rolldown:hmr", { exports: ns_rolldown_hmr });
+		init_rolldown_runtime_1();
+		const hot_rolldown_hmr = __rolldown_runtime__.createModuleHotContext("rolldown:hmr");
+		var import_rolldown_runtime_0 = __rolldown_runtime__.loadExports("rolldown:runtime");
+		class Module {
+			/**
+			* @type {any}
+			*/
+			exports = null;
+			/**
+			* @type {string}
+			*/
+			id;
+			/**
+			* @param {string} id
+			*/
+			constructor(id) {
+				this.id = id;
+			}
+		}
+		class DevRuntime {
+			/**
+			* @type {Record<string, Module>}
+			*/
+			modules = {};
+			/**
+			* @param {string} _moduleId
+			*/
+			createModuleHotContext(_moduleId) {
+				throw new Error("createModuleHotContext should be implemented");
+			}
+			/**
+			* @param {string[]} _boundaries
+			*/
+			applyUpdates(_boundaries) {
+				throw new Error("applyUpdates should be implemented");
+			}
+			/**
+			* @param {string} id
+			* @param {{ exports: any }} meta
+			*/
+			registerModule(id, meta) {
+				const module = new Module(id);
+				module.exports = meta.exports;
+				this.modules[id] = module;
+			}
+			/**
+			* @param {string} id
+			*/
+			loadExports(id) {
+				const module = this.modules[id];
+				if (module) {
+					return module.exports;
+				} else {
+					console.warn(`Module ${id} not found`);
+					return {};
+				}
+			}
+			/**
+			* __esmMin
+			*
+			* @type {<T>(fn: any, res: T) => () => T}
+			* @internal
+			*/
+			createEsmInitializer = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
+			/**
+			* __commonJSMin
+			*
+			* @type {<T extends { exports: any }>(cb: any, mod: { exports: any }) => () => T}
+			* @internal
+			*/
+			createCjsInitializer = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+			/** @internal */
+			__toESM = import_rolldown_runtime_0.__toESM;
+			/** @internal */
+			__toCommonJS = import_rolldown_runtime_0.__toCommonJS;
+			/** @internal */
+			__export = import_rolldown_runtime_0.__export;
+			/** @internal */
+			__toDynamicImportESM = import_rolldown_runtime_0.__toDynamicImportESM;
+		}
+		class TestDevRuntime extends DevRuntime {
+			/**
+			* @override
+			* @param {string} _moduleId
+			*/
+			createModuleHotContext(_moduleId) {
+				return { accept() {} };
+			}
+			/**
+			* @override
+			* @param {string[]} _boundaries
+			*/
+			applyUpdates(_boundaries) {}
+		}
+		globalThis.__rolldown_runtime__ ??= new TestDevRuntime();
+		/** @type {string[]} */
+		const testPatches = globalThis.__testPatches;
+		if (testPatches) {
+			setTimeout(async () => {
+				for (const patchChunk of testPatches) {
+					await import(patchChunk);
+				}
+			}, 0);
+		}
 	} finally {}
 });
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -3,15 +3,58 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
+## chunk.js
+
+```js
+
+export { __commonJS, __export, __toCommonJS, __toDynamicImportESM, __toESM };
+```
+## exist-dep-cjs.js
+
+```js
+import { __commonJS } from "./chunk.js";
+
+//#region exist-dep-cjs.js
+var require_exist_dep_cjs = __commonJS({ "exist-dep-cjs.js"(exports, module) {
+	const exist_dep_cjs_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-cjs.js");
+	__rolldown_runtime__.registerModule("exist-dep-cjs.js", module);
+	exports.value = "exist-cjs";
+} });
+
+//#endregion
+export default require_exist_dep_cjs();
+
+```
+## exist-dep-esm.js
+
+```js
+import { __export } from "./chunk.js";
+
+//#region exist-dep-esm.js
+var exist_dep_esm_exports = {};
+__export(exist_dep_esm_exports, { value: () => value });
+const exist_dep_esm_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
+__rolldown_runtime__.registerModule("exist-dep-esm.js", { exports: exist_dep_esm_exports });
+const value = "exist-esm";
+
+//#endregion
+export { value };
+```
 ## main.js
 
 ```js
+import { __export, __toCommonJS, __toDynamicImportESM, __toESM } from "./chunk.js";
 
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
 var hmr_exports = {};
+__export(hmr_exports, { foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+async function foo() {
+	await import("./exist-dep-cjs.js").then(__toDynamicImportESM()).then(console.log);
+	await import("./exist-dep-esm.js").then(console.log);
+}
 hmr_hot.accept((mod) => {
 	if (mod) {
 		console.log(".hmr", mod.foo);
@@ -34,12 +77,19 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 var init_hmr_0 = __rolldown_runtime__.createEsmInitializer(function() {
 	try {
 		var ns_hmr = {};
-		__rolldown_runtime__.__export(ns_hmr, { bar: () => bar });
+		__rolldown_runtime__.__export(ns_hmr, {
+			foo: () => foo,
+			bar: () => bar
+		});
 		__rolldown_runtime__.registerModule("hmr.js", { exports: ns_hmr });
 		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
+		async function foo() {
+			await (require_exist_dep_cjs_2(), Promise.resolve().then(() => __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports("exist-dep-cjs.js")))).then(console.log);
+			await (init_exist_dep_esm_1(), Promise.resolve().then(() => __rolldown_runtime__.loadExports("exist-dep-esm.js"))).then(console.log);
+		}
 		async function bar() {
-			await (require_new_dep_cjs_1(), Promise.resolve().then(() => __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports("new-dep-cjs.js")))).then(console.log);
-			await (init_new_dep_esm_2(), Promise.resolve().then(() => __rolldown_runtime__.loadExports("new-dep-esm.js"))).then(console.log);
+			await (require_new_dep_cjs_3(), Promise.resolve().then(() => __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports("new-dep-cjs.js")))).then(console.log);
+			await (init_new_dep_esm_4(), Promise.resolve().then(() => __rolldown_runtime__.loadExports("new-dep-esm.js"))).then(console.log);
 		}
 		hot_hmr.accept((mod) => {
 			if (mod) {
@@ -49,7 +99,25 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer(function() {
 	} finally {}
 });
 
-var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer(function(module, exports) {
+var init_exist_dep_esm_1 = __rolldown_runtime__.createEsmInitializer(function() {
+	try {
+		var ns_exist_dep_esm = {};
+		__rolldown_runtime__.__export(ns_exist_dep_esm, { value: () => value });
+		__rolldown_runtime__.registerModule("exist-dep-esm.js", { exports: ns_exist_dep_esm });
+		const hot_exist_dep_esm = __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
+		const value = "exist-esm";
+	} finally {}
+});
+
+var require_exist_dep_cjs_2 = __rolldown_runtime__.createCjsInitializer(function(module, exports) {
+	try {
+		__rolldown_runtime__.registerModule("exist-dep-cjs.js", module);
+		const hot_exist_dep_cjs = __rolldown_runtime__.createModuleHotContext("exist-dep-cjs.js");
+		exports.value = "exist-cjs";
+	} finally {}
+});
+
+var require_new_dep_cjs_3 = __rolldown_runtime__.createCjsInitializer(function(module, exports) {
 	try {
 		__rolldown_runtime__.registerModule("new-dep-cjs.js", module);
 		const hot_new_dep_cjs = __rolldown_runtime__.createModuleHotContext("new-dep-cjs.js");
@@ -57,7 +125,7 @@ var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer(function(m
 	} finally {}
 });
 
-var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer(function() {
+var init_new_dep_esm_4 = __rolldown_runtime__.createEsmInitializer(function() {
 	try {
 		var ns_new_dep_esm = {};
 		__rolldown_runtime__.__export(ns_new_dep_esm, { value: () => value });

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/hmr.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/hmr.hmr-0.js
@@ -1,8 +1,7 @@
-// FIXME(hyf0): panic
-// export async function foo() {
-//   await import('./exist-dep-cjs').then(console.log)
-//   await import('./exist-dep-esm').then(console.log)
-// }
+export async function foo() {
+  await import('./exist-dep-cjs').then(console.log)
+  await import('./exist-dep-esm').then(console.log)
+}
 
 export async function bar() {
   await import('./new-dep-cjs.js').then(console.log)

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/hmr.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/hmr.js
@@ -1,8 +1,7 @@
-// FIXME(hyf0): panic
-// export async function foo() {
-//   await import('./exist-dep-cjs').then(console.log)
-//   await import('./exist-dep-esm').then(console.log)
-// }
+export async function foo() {
+  await import('./exist-dep-cjs').then(console.log)
+  await import('./exist-dep-esm').then(console.log)
+}
 
 import.meta.hot.accept((mod) => {
   if (mod) {

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -53,8 +53,10 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer(function() {
 		var ns_hmr = {};
 		__rolldown_runtime__.__export(ns_hmr, {});
 		__rolldown_runtime__.registerModule("hmr.js", { exports: ns_hmr });
-		require_new_dep_cjs_1();
-		init_new_dep_esm_2();
+		require_exist_dep_cjs_2();
+		init_exist_dep_esm_1();
+		require_new_dep_cjs_3();
+		init_new_dep_esm_4();
 		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
 		var import_exist_dep_cjs_0 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("exist-dep-cjs.js"));
 		var import_exist_dep_esm_1 = __rolldown_runtime__.loadExports("exist-dep-esm.js");
@@ -68,7 +70,25 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer(function() {
 	} finally {}
 });
 
-var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer(function(module, exports) {
+var init_exist_dep_esm_1 = __rolldown_runtime__.createEsmInitializer(function() {
+	try {
+		var ns_exist_dep_esm = {};
+		__rolldown_runtime__.__export(ns_exist_dep_esm, { value: () => value });
+		__rolldown_runtime__.registerModule("exist-dep-esm.js", { exports: ns_exist_dep_esm });
+		const hot_exist_dep_esm = __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
+		const value = "exist-esm";
+	} finally {}
+});
+
+var require_exist_dep_cjs_2 = __rolldown_runtime__.createCjsInitializer(function(module, exports) {
+	try {
+		__rolldown_runtime__.registerModule("exist-dep-cjs.js", module);
+		const hot_exist_dep_cjs = __rolldown_runtime__.createModuleHotContext("exist-dep-cjs.js");
+		exports.value = "exist-cjs";
+	} finally {}
+});
+
+var require_new_dep_cjs_3 = __rolldown_runtime__.createCjsInitializer(function(module, exports) {
 	try {
 		__rolldown_runtime__.registerModule("new-dep-cjs.js", module);
 		const hot_new_dep_cjs = __rolldown_runtime__.createModuleHotContext("new-dep-cjs.js");
@@ -76,7 +96,7 @@ var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer(function(m
 	} finally {}
 });
 
-var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer(function() {
+var init_new_dep_esm_4 = __rolldown_runtime__.createEsmInitializer(function() {
 	try {
 		var ns_new_dep_esm = {};
 		__rolldown_runtime__.__export(ns_new_dep_esm, { value: () => value });

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5467,7 +5467,10 @@ expression: output
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-BQUKp0js.js
+- main-!~{000}~.js => main-CaCo5ESO.js
+- chunk-!~{001}~.js => chunk-8OODDWbD.js
+- exist-dep-cjs-!~{003}~.js => exist-dep-cjs-73N58i3V.js
+- exist-dep-esm-!~{005}~.js => exist-dep-esm-CbY1ke2_.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 


### PR DESCRIPTION
Run

```
RD_LOG=hmr=trace RUST_BACKTRACE=FULL cargo test -p rolldown -- fixture_with_config_tests__rolldown__topics__hmr__dynamic_import__config_json --nocapture
```

Closes https://github.com/rolldown/rolldown/issues/5249
Closes https://github.com/rolldown/rolldown/pull/5248