### PR TITLE
perf(rolldown): box `TransformOptions`

### DIFF
--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -295,7 +295,7 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
     keep_names: raw_options.keep_names.unwrap_or_default(),
     polyfill_require: raw_options.polyfill_require.unwrap_or(true),
     defer_sync_scan_data: raw_options.defer_sync_scan_data,
-    transform_options: raw_options.transform.unwrap_or_default(),
+    transform_options: Box::new(raw_options.transform.unwrap_or_default()),
     make_absolute_externals_relative: raw_options
       .make_absolute_externals_relative
       .unwrap_or_default(),

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -89,7 +89,7 @@ pub struct NormalizedBundlerOptions {
   pub drop_labels: FxHashSet<String>,
   pub polyfill_require: bool,
   pub defer_sync_scan_data: Option<DeferSyncScanDataOption>,
-  pub transform_options: TransformOptions,
+  pub transform_options: Box<TransformOptions>,
   pub make_absolute_externals_relative: MakeAbsoluteExternalsRelative,
   pub invalidate_js_side_cache: Option<InvalidateJsSideCache>,
   pub mark_module_loaded: Option<MarkModuleLoaded>,


### PR DESCRIPTION
`TransformOptions` has over 400 bytes, box it so we don't load these 400
bytes when we read the options.