### PR TITLE
chore: use `debug=line-tables-only` for profile.dev and profile.test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,14 +210,12 @@ oxc_resolver_napi = { version = "11.5.0", default-features = false, features = [
 oxc_sourcemap = "4" # https://github.com/oxc-project/oxc-sourcemap
 
 [profile.dev]
-# Disabling debug info speeds up local and CI builds,
-# and we don't rely on it for debugging that much.
-debug = 1
+# Minimal debug info to speed up local and CI builds.
+debug = "line-tables-only"
 
 [profile.test]
-# Disabling debug info speeds up local and CI builds,
-# and we don't rely on it for debugging that much.
-debug = 1
+# Minimal debug info to speed up local and CI builds.
+debug = "line-tables-only"
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,12 +212,12 @@ oxc_sourcemap = "4" # https://github.com/oxc-project/oxc-sourcemap
 [profile.dev]
 # Disabling debug info speeds up local and CI builds,
 # and we don't rely on it for debugging that much.
-debug = false
+debug = 1
 
 [profile.test]
 # Disabling debug info speeds up local and CI builds,
 # and we don't rely on it for debugging that much.
-debug = false
+debug = 1
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
A trade of between DX and Ci speed