### PR TITLE
feat: support plugin context meta for native plugins

### DIFF
--- a/crates/rolldown_plugin/src/plugin_context/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_context/mod.rs
@@ -1,7 +1,9 @@
 mod native_plugin_context;
 mod plugin_context;
+mod plugin_context_meta;
 mod transform_plugin_context;
 
 pub use native_plugin_context::{NativePluginContextImpl, SharedNativePluginContext};
 pub use plugin_context::PluginContext;
+pub use plugin_context_meta::PluginContextMeta;
 pub use transform_plugin_context::{SharedTransformPluginContext, TransformPluginContext};

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -16,6 +16,7 @@ use tokio::sync::Mutex;
 
 use crate::{
   PluginDriver,
+  plugin_context::PluginContextMeta,
   types::{
     hook_resolve_id_skipped::HookResolveIdSkipped,
     plugin_context_resolve_options::PluginContextResolveOptions, plugin_idx::PluginIdx,
@@ -30,6 +31,7 @@ pub struct NativePluginContextImpl {
   pub(crate) skipped_resolve_calls: Vec<Arc<HookResolveIdSkipped>>,
   pub(crate) plugin_idx: PluginIdx,
   pub(crate) resolver: Arc<Resolver>,
+  pub(crate) meta: Arc<PluginContextMeta>,
   pub(crate) plugin_driver: Weak<PluginDriver>,
   pub(crate) file_emitter: SharedFileEmitter,
   pub(crate) options: SharedNormalizedBundlerOptions,

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
@@ -7,7 +7,10 @@ use arcstr::ArcStr;
 use derive_more::Debug;
 use rolldown_common::{Log, ResolvedId, side_effects::HookSideEffects};
 
-use crate::{PluginContextResolveOptions, types::hook_resolve_id_skipped::HookResolveIdSkipped};
+use crate::{
+  PluginContextResolveOptions, plugin_context::PluginContextMeta,
+  types::hook_resolve_id_skipped::HookResolveIdSkipped,
+};
 
 use super::NativePluginContextImpl;
 
@@ -37,6 +40,7 @@ impl PluginContext {
         skipped_resolve_calls,
         plugin_idx: ctx.plugin_idx,
         plugin_driver: Weak::clone(&ctx.plugin_driver),
+        meta: Arc::clone(&ctx.meta),
         resolver: Arc::clone(&ctx.resolver),
         file_emitter: Arc::clone(&ctx.file_emitter),
         options: Arc::clone(&ctx.options),
@@ -141,6 +145,13 @@ impl PluginContext {
         unimplemented!("Can't call `add_watch_file` on PluginContext::Napi")
       }
       PluginContext::Native(ctx) => ctx.add_watch_file(file),
+    }
+  }
+
+  pub fn meta(&self) -> &PluginContextMeta {
+    match self {
+      PluginContext::Napi(_) => unimplemented!("Can't call `meta` on PluginContext::Napi"),
+      PluginContext::Native(ctx) => &ctx.meta,
     }
   }
 

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context_meta.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context_meta.rs
@@ -1,0 +1,21 @@
+use std::{
+  any::{Any, TypeId},
+  sync::Arc,
+};
+
+use rolldown_utils::dashmap::FxDashMap;
+
+#[derive(Debug, Default)]
+pub struct PluginContextMeta {
+  inner: FxDashMap<TypeId, Arc<dyn Any + Send + Sync>>,
+}
+
+impl PluginContextMeta {
+  pub fn insert<T: Any + Send + Sync>(&self, value: Arc<T>) {
+    self.inner.insert(TypeId::of::<T>(), value);
+  }
+
+  pub fn get<T: Any + Send + Sync>(&self) -> Option<Arc<T>> {
+    self.inner.get(&TypeId::of::<T>()).and_then(|v| v.clone().downcast::<T>().ok())
+  }
+}

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -23,7 +23,7 @@ use tokio::sync::Mutex;
 use crate::{
   __inner::SharedPluginable,
   PluginContext,
-  plugin_context::NativePluginContextImpl,
+  plugin_context::{NativePluginContextImpl, PluginContextMeta},
   plugin_driver::hook_orders::PluginHookOrders,
   type_aliases::{IndexPluginContext, IndexPluginable},
   types::plugin_idx::PluginIdx,
@@ -51,6 +51,7 @@ impl PluginDriver {
   ) -> SharedPluginDriver {
     let watch_files = Arc::new(DashSet::default());
     let modules = Arc::new(DashMap::default());
+    let meta = Arc::new(PluginContextMeta::default());
     let tx = Arc::new(Mutex::new(None));
     let mut plugin_usage_vec = IndexVec::new();
 
@@ -65,6 +66,7 @@ impl PluginDriver {
           skipped_resolve_calls: vec![],
           plugin_idx,
           plugin_driver: Weak::clone(plugin_driver),
+          meta: Arc::clone(&meta),
           resolver: Arc::clone(resolver),
           file_emitter: Arc::clone(file_emitter),
           modules: Arc::clone(&modules),


### PR DESCRIPTION
To enable native plugins to share data with each other, plugin context meta provides a mechanism for inter-plugin communication.