### PR TITLE
refactor(rolldown_plugin_chunk_import_map): clarify import map paths and output filename

### DIFF
--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -111,13 +111,16 @@ impl Plugin for ChunkImportMapPlugin {
     for output in args.bundle.iter() {
       let Output::Chunk(chunk) = output else { continue };
       if let Some(v) = self.chunk_import_map.get(chunk.preliminary_filename.as_str()) {
-        chunk_import_map.insert(v.to_string(), chunk.filename.to_string());
+        chunk_import_map.insert(
+          rolldown_utils::concat_string!("./", v.as_str()),
+          rolldown_utils::concat_string!("./", chunk.filename),
+        );
       }
     }
 
     ctx
       .emit_file_async(EmittedAsset {
-        file_name: Some(arcstr::literal!(".importmap.json")),
+        file_name: Some(arcstr::literal!(".chunk-import-map.json")),
         source: (serde_json::to_string_pretty(&chunk_import_map)?).into(),
         ..Default::default()
       })


### PR DESCRIPTION
The default URL base is `"./"`, but we may consider exposing it as a configurable option for users in the future. Additionally, the output filename has been changed to `.chunk-import-map.json` to avoid confusion with the standard import map format, as the file does not follow the `{ "imports": { ... } }` structure.