### PR TITLE
feat: add warning and conversion for `import.meta` for non-`esm` output format

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -257,6 +257,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
           let static_name = member_expr.static_property_name().unwrap_or(Atom::from(""));
           static_name == "url" || static_name == "dirname" || static_name == "filename"
         })
+        // Here we need to set it to `false` to emit warnings when leaving `import.meta` alone along with the logic `not` head of this.
         .unwrap_or(false)
         && !self.options.format.keep_esm_import_export_syntax()
         && it.meta.name == "import"

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -1,5 +1,3 @@
-use oxc::ast::ast::MetaProperty;
-use oxc::span::Atom;
 use oxc::{
   ast::{
     AstKind,
@@ -249,12 +247,12 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     walk::walk_new_expression(self, it);
   }
 
-  fn visit_meta_property(&mut self, it: &MetaProperty<'ast>) {
+  fn visit_meta_property(&mut self, it: &ast::MetaProperty<'ast>) {
     if let Some(parent) = self.visit_path.last() {
       if !parent
         .as_member_expression_kind()
         .map(|member_expr| {
-          let static_name = member_expr.static_property_name().unwrap_or(Atom::from(""));
+          let static_name = member_expr.static_property_name().unwrap_or(ast::Atom::from(""));
           static_name == "url" || static_name == "dirname" || static_name == "filename"
         })
         // Here we need to set it to `false` to emit warnings when leaving `import.meta` alone along with the logic `not` head of this.

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -297,6 +297,14 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           }
         }
       }
+      ast::Expression::MetaProperty(meta) => {
+        if meta.meta.name == "import"
+          && meta.property.name == "meta"
+          && !self.ctx.options.format.keep_esm_import_export_syntax()
+        {
+          *expr = self.snippet.builder.expression_object(SPAN, self.snippet.builder.vec());
+        }
+      }
       _ => {
         if let Some(new_expr) =
           expr.as_member_expression().and_then(|expr| self.try_rewrite_member_expr(expr))

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -502,19 +502,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             self.snippet.builder.alloc_identifier_reference(SPAN, name),
           ));
         }
-        _ if property_name.starts_with("ROLLUP_FILE_URL_") => {
-          return self.rewrite_rollup_file_url(property_name);
-        }
-        _ => {
-          return self
-            .ctx
-            .options
-            .format
-            .keep_esm_import_export_syntax()
-            .not()
-            .then_some(self.snippet.builder.expression_object(SPAN, self.snippet.builder.vec()));
-        }
+        _ => {}
       }
+      return self.rewrite_rollup_file_url(property_name);
     }
     None
   }

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -17,7 +17,6 @@ use rolldown_common::{
 use rolldown_ecmascript_utils::{
   AstSnippet, BindingPatternExt, CallExpressionExt, ExpressionExt, StatementExt,
 };
-use std::ops::Not;
 
 mod finalizer_context;
 mod impl_visit_mut;

--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -99,27 +99,6 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
     }
   }
 
-  // replace all `import.meta.*` with `undefined` for none `esm` format
-  // note: Any definition more specific than `import.meta.*` will be replace first
-  if !matches!(format, OutputFormat::Esm) {
-    match raw_define.entry("import.meta.*".to_string()) {
-      indexmap::map::Entry::Occupied(_occupied_entry) => {}
-      indexmap::map::Entry::Vacant(vacant_entry) => {
-        vacant_entry.insert("undefined".to_string());
-        // comment out when https://github.com/rolldown/rolldown/issues/3301 is finished
-        raw_define
-          .entry("import.meta.url".to_string())
-          .or_insert_with(|| "import.meta.url".to_string());
-        raw_define
-          .entry("import.meta.dirname".to_string())
-          .or_insert_with(|| "import.meta.dirname".to_string());
-        raw_define
-          .entry("import.meta.filename".to_string())
-          .or_insert_with(|| "import.meta.filename".to_string());
-      }
-    }
-  }
-
   let define = raw_define.into_iter().collect();
 
   // Take out resolve options

--- a/crates/rolldown/tests/esbuild/default/import_meta_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_meta_common_js/artifacts.snap
@@ -1,7 +1,20 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
+# warnings
+
+## EMPTY_IMPORT_META
+
+```text
+[EMPTY_IMPORT_META] Warning: `import.meta` is unavailable with the "cjs" output format and will be empty.
+   ╭─[ entry.js:1:30 ]
+   │
+ 1 │ console.log(import.meta.url, import.meta.path)
+   │                              ─────┬─────  
+   │                                   ╰─────── Avoid using `import.meta` in this context, or set the output format to `esm` instead.
+───╯
+
+```
 # Assets
 
 ## entry.js
@@ -9,7 +22,7 @@ snapshot_kind: text
 ```js
 
 //#region entry.js
-console.log(require("url").pathToFileURL(__filename).href, void 0);
+console.log(require("url").pathToFileURL(__filename).href, {});
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/import_meta_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_meta_common_js/artifacts.snap
@@ -6,12 +6,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## EMPTY_IMPORT_META
 
 ```text
-[EMPTY_IMPORT_META] Warning: `import.meta` is unavailable with the "cjs" output format and will be empty.
+[EMPTY_IMPORT_META] Warning: `import.meta` is not available with the `cjs` output format and will be empty.
    ╭─[ entry.js:1:30 ]
    │
  1 │ console.log(import.meta.url, import.meta.path)
    │                              ─────┬─────  
-   │                                   ╰─────── Avoid using `import.meta` in this context, or set the output format to `esm` instead.
+   │                                   ╰─────── You need to set the output format to `esm` for `import.meta` to work correctly.
 ───╯
 
 ```
@@ -22,7 +22,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 
 //#region entry.js
-console.log(require("url").pathToFileURL(__filename).href, {});
+console.log(require("url").pathToFileURL(__filename).href, {}.path);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/import_meta_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/default/import_meta_common_js/diff.md
@@ -13,7 +13,7 @@ console.log(import_meta.url, import_meta.path);
 ```js
 
 //#region entry.js
-console.log(require("url").pathToFileURL(__filename).href, void 0);
+console.log(require("url").pathToFileURL(__filename).href, {});
 
 //#endregion
 ```
@@ -25,6 +25,6 @@ console.log(require("url").pathToFileURL(__filename).href, void 0);
 @@ -1,2 +1,1 @@
 -var import_meta = {};
 -console.log(import_meta.url, import_meta.path);
-+console.log(require("url").pathToFileURL(__filename).href, void 0);
++console.log(require("url").pathToFileURL(__filename).href, {});
 
 ```

--- a/crates/rolldown/tests/esbuild/default/import_meta_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/default/import_meta_common_js/diff.md
@@ -13,7 +13,7 @@ console.log(import_meta.url, import_meta.path);
 ```js
 
 //#region entry.js
-console.log(require("url").pathToFileURL(__filename).href, {}.path);
+console.log(require("url").pathToFileURL(__filename).href, ({}).path);
 
 //#endregion
 ```
@@ -25,6 +25,6 @@ console.log(require("url").pathToFileURL(__filename).href, {}.path);
 @@ -1,2 +1,1 @@
 -var import_meta = {};
 -console.log(import_meta.url, import_meta.path);
-+console.log(require("url").pathToFileURL(__filename).href, {}.path);
++console.log(require("url").pathToFileURL(__filename).href, ({}).path);
 
 ```

--- a/crates/rolldown/tests/esbuild/default/import_meta_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/default/import_meta_common_js/diff.md
@@ -13,7 +13,7 @@ console.log(import_meta.url, import_meta.path);
 ```js
 
 //#region entry.js
-console.log(require("url").pathToFileURL(__filename).href, {});
+console.log(require("url").pathToFileURL(__filename).href, {}.path);
 
 //#endregion
 ```
@@ -25,6 +25,6 @@ console.log(require("url").pathToFileURL(__filename).href, {});
 @@ -1,2 +1,1 @@
 -var import_meta = {};
 -console.log(import_meta.url, import_meta.path);
-+console.log(require("url").pathToFileURL(__filename).href, {});
++console.log(require("url").pathToFileURL(__filename).href, {}.path);
 
 ```

--- a/crates/rolldown/tests/esbuild/default/import_meta_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/default/import_meta_common_js/diff.md
@@ -13,7 +13,7 @@ console.log(import_meta.url, import_meta.path);
 ```js
 
 //#region entry.js
-console.log(require("url").pathToFileURL(__filename).href, ({}).path);
+console.log(require("url").pathToFileURL(__filename).href, {}.path);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/warnings/empty_import_meta/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/empty_import_meta/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/rolldown/warnings/empty_import_meta/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/empty_import_meta/artifacts.snap
@@ -1,0 +1,43 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## EMPTY_IMPORT_META
+
+```text
+[EMPTY_IMPORT_META] Warning: `import.meta` is unavailable with the "cjs" output format and will be empty.
+   ╭─[ main.js:1:13 ]
+   │
+ 1 │ console.log(import.meta.hello);
+   │             ─────┬─────  
+   │                  ╰─────── Avoid using `import.meta` in this context, or set the output format to `esm` instead.
+───╯
+
+```
+## EMPTY_IMPORT_META
+
+```text
+[EMPTY_IMPORT_META] Warning: `import.meta` is unavailable with the "cjs" output format and will be empty.
+   ╭─[ main.js:4:13 ]
+   │
+ 4 │ console.log(import.meta);
+   │             ─────┬─────  
+   │                  ╰─────── Avoid using `import.meta` in this context, or set the output format to `esm` instead.
+───╯
+
+```
+# Assets
+
+## main.js
+
+```js
+
+//#region main.js
+console.log({});
+console.log(__filename);
+console.log(require("url").pathToFileURL(__filename).href);
+console.log({});
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/warnings/empty_import_meta/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/empty_import_meta/artifacts.snap
@@ -6,24 +6,24 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## EMPTY_IMPORT_META
 
 ```text
-[EMPTY_IMPORT_META] Warning: `import.meta` is unavailable with the "cjs" output format and will be empty.
+[EMPTY_IMPORT_META] Warning: `import.meta` is not available with the `cjs` output format and will be empty.
    ╭─[ main.js:1:13 ]
    │
  1 │ console.log(import.meta.hello);
    │             ─────┬─────  
-   │                  ╰─────── Avoid using `import.meta` in this context, or set the output format to `esm` instead.
+   │                  ╰─────── You need to set the output format to `esm` for `import.meta` to work correctly.
 ───╯
 
 ```
 ## EMPTY_IMPORT_META
 
 ```text
-[EMPTY_IMPORT_META] Warning: `import.meta` is unavailable with the "cjs" output format and will be empty.
+[EMPTY_IMPORT_META] Warning: `import.meta` is not available with the `cjs` output format and will be empty.
    ╭─[ main.js:4:13 ]
    │
  4 │ console.log(import.meta);
    │             ─────┬─────  
-   │                  ╰─────── Avoid using `import.meta` in this context, or set the output format to `esm` instead.
+   │                  ╰─────── You need to set the output format to `esm` for `import.meta` to work correctly.
 ───╯
 
 ```
@@ -34,7 +34,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 
 //#region main.js
-console.log({});
+console.log({}.hello);
 console.log(__filename);
 console.log(require("url").pathToFileURL(__filename).href);
 console.log({});

--- a/crates/rolldown/tests/rolldown/warnings/empty_import_meta/main.js
+++ b/crates/rolldown/tests/rolldown/warnings/empty_import_meta/main.js
@@ -1,0 +1,4 @@
+console.log(import.meta.hello);
+console.log(import.meta.filename);
+console.log(import.meta.url);
+console.log(import.meta);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -935,7 +935,7 @@ expression: output
 
 # tests/esbuild/default/import_meta_common_js
 
-- entry-!~{000}~.js => entry-6049eP6E.js
+- entry-!~{000}~.js => entry-Cjrrr93N.js
 
 # tests/esbuild/default/import_meta_es6
 
@@ -5835,7 +5835,7 @@ expression: output
 
 # tests/rolldown/warnings/empty_import_meta
 
-- main-!~{000}~.js => main-DHuQYeLR.js
+- main-!~{000}~.js => main-DfcONHmG.js
 
 # tests/rolldown/warnings/eval
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -935,7 +935,7 @@ expression: output
 
 # tests/esbuild/default/import_meta_common_js
 
-- entry-!~{000}~.js => entry-BmVN66cq.js
+- entry-!~{000}~.js => entry-6049eP6E.js
 
 # tests/esbuild/default/import_meta_es6
 
@@ -5832,6 +5832,10 @@ expression: output
 # tests/rolldown/warnings/configuration_field_conflict
 
 - main-!~{000}~.js => main-5X8T5evH.js
+
+# tests/rolldown/warnings/empty_import_meta
+
+- main-!~{000}~.js => main-DHuQYeLR.js
 
 # tests/rolldown/warnings/eval
 

--- a/crates/rolldown_binding/src/generated/binding_checks_options.rs
+++ b/crates/rolldown_binding/src/generated/binding_checks_options.rs
@@ -14,6 +14,7 @@ pub struct BindingChecksOptions {
   pub filename_conflict: Option<bool>,
   pub common_js_variable_in_esm: Option<bool>,
   pub import_is_undefined: Option<bool>,
+  pub empty_import_meta: Option<bool>,
   pub configuration_field_conflict: Option<bool>,
 }
 impl From<BindingChecksOptions> for rolldown_common::ChecksOptions {
@@ -29,6 +30,7 @@ impl From<BindingChecksOptions> for rolldown_common::ChecksOptions {
       filename_conflict: value.filename_conflict,
       common_js_variable_in_esm: value.common_js_variable_in_esm,
       import_is_undefined: value.import_is_undefined,
+      empty_import_meta: value.empty_import_meta,
       configuration_field_conflict: value.configuration_field_conflict,
     }
   }

--- a/crates/rolldown_common/src/generated/checks_options.rs
+++ b/crates/rolldown_common/src/generated/checks_options.rs
@@ -22,6 +22,7 @@ pub struct ChecksOptions {
   pub filename_conflict: Option<bool>,
   pub common_js_variable_in_esm: Option<bool>,
   pub import_is_undefined: Option<bool>,
+  pub empty_import_meta: Option<bool>,
   pub configuration_field_conflict: Option<bool>,
 }
 impl From<ChecksOptions> for rolldown_error::EventKindSwitcher {
@@ -60,6 +61,10 @@ impl From<ChecksOptions> for rolldown_error::EventKindSwitcher {
     flag.set(
       rolldown_error::EventKindSwitcher::ImportIsUndefined,
       value.import_is_undefined.unwrap_or(true),
+    );
+    flag.set(
+      rolldown_error::EventKindSwitcher::EmptyImportMeta,
+      value.empty_import_meta.unwrap_or(true),
     );
     flag.set(
       rolldown_error::EventKindSwitcher::ConfigurationFieldConflict,

--- a/crates/rolldown_error/src/build_error/error_constructors.rs
+++ b/crates/rolldown_error/src/build_error/error_constructors.rs
@@ -192,6 +192,15 @@ impl BuildDiagnostic {
     Self::new_inner(UnsupportedFeature { filename, source, span, error_message })
   }
 
+  pub fn empty_import_meta(filename: String, source: ArcStr, span: Span, format: ArcStr) -> Self {
+    Self::new_inner(crate::events::empty_import_meta::EmptyImportMeta {
+      filename,
+      source,
+      span,
+      format,
+    })
+  }
+
   // --- Rolldown related
 
   pub fn oxc_parse_error(

--- a/crates/rolldown_error/src/event_kind.rs
+++ b/crates/rolldown_error/src/event_kind.rs
@@ -29,18 +29,19 @@ pub enum EventKind {
   ExportUndefinedVariableError = 17,
   ImportIsUndefined = 18,
   UnsupportedFeatureError = 19,
+  EmptyImportMeta = 20,
 
   // --- These kinds are rolldown specific
-  JsonParseError = 20,
-  IllegalReassignmentError = 21,
-  InvalidDefineConfigError = 22,
-  ResolveError = 23,
-  UnhandleableError = 24,
-  UnloadableDependencyError = 25,
+  JsonParseError = 21,
+  IllegalReassignmentError = 22,
+  InvalidDefineConfigError = 23,
+  ResolveError = 24,
+  UnhandleableError = 25,
+  UnloadableDependencyError = 26,
 
-  IoError = 26,
-  NapiError = 27,
-  ConfigurationFieldConflict = 28,
+  IoError = 27,
+  NapiError = 28,
+  ConfigurationFieldConflict = 29,
 }
 
 impl Display for EventKind {
@@ -71,6 +72,7 @@ impl Display for EventKind {
       EventKind::ExportUndefinedVariableError => write!(f, "EXPORT_UNDEFINED_VARIABLE"),
       EventKind::ImportIsUndefined => write!(f, "IMPORT_IS_UNDEFINED"),
       EventKind::UnsupportedFeatureError => write!(f, "UNSUPPORTED_FEATURE"),
+      EventKind::EmptyImportMeta => write!(f, "EMPTY_IMPORT_META"),
 
       // --- Rolldown specific
       EventKind::JsonParseError => write!(f, "JSON_PARSE"),

--- a/crates/rolldown_error/src/events/empty_import_meta.rs
+++ b/crates/rolldown_error/src/events/empty_import_meta.rs
@@ -1,0 +1,48 @@
+use crate::DiagnosticOptions;
+use crate::diagnostic::Diagnostic;
+use crate::events::BuildEvent;
+use arcstr::ArcStr;
+use oxc::span::Span;
+
+#[derive(Debug)]
+pub struct EmptyImportMeta {
+  pub filename: String,
+  pub source: ArcStr,
+  pub span: Span,
+  pub format: ArcStr,
+}
+
+impl BuildEvent for EmptyImportMeta {
+  fn kind(&self) -> crate::event_kind::EventKind {
+    crate::event_kind::EventKind::EmptyImportMeta
+  }
+
+  fn id(&self) -> Option<String> {
+    Some(self.filename.clone())
+  }
+
+  fn message(&self, _opts: &DiagnosticOptions) -> String {
+    format!(
+      "`import.meta` is unavailable with the `{}` output format and will be empty.",
+      self.format
+    )
+  }
+
+  fn on_diagnostic(&self, diagnostic: &mut Diagnostic, opts: &DiagnosticOptions) {
+    let filename = opts.stabilize_path(&self.filename);
+    let file_id = diagnostic.add_file(filename, self.source.clone());
+
+    diagnostic.title = format!(
+      "`import.meta` is unavailable with the \"{}\" output format and will be empty.",
+      self.format
+    );
+
+    diagnostic.add_label(
+      &file_id,
+      self.span.start..self.span.end,
+      String::from(
+        "Avoid using `import.meta` in this context, or set the output format to `esm` instead.",
+      ),
+    );
+  }
+}

--- a/crates/rolldown_error/src/events/empty_import_meta.rs
+++ b/crates/rolldown_error/src/events/empty_import_meta.rs
@@ -23,7 +23,7 @@ impl BuildEvent for EmptyImportMeta {
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {
     format!(
-      "`import.meta` is unavailable with the `{}` output format and will be empty.",
+      "`import.meta` is not available with the `{}` output format and will be empty.",
       self.format
     )
   }
@@ -33,7 +33,7 @@ impl BuildEvent for EmptyImportMeta {
     let file_id = diagnostic.add_file(filename, self.source.clone());
 
     diagnostic.title = format!(
-      "`import.meta` is unavailable with the \"{}\" output format and will be empty.",
+      "`import.meta` is not available with the `{}` output format and will be empty.",
       self.format
     );
 
@@ -41,7 +41,7 @@ impl BuildEvent for EmptyImportMeta {
       &file_id,
       self.span.start..self.span.end,
       String::from(
-        "Avoid using `import.meta` in this context, or set the output format to `esm` instead.",
+        "You need to set the output format to `esm` for `import.meta` to work correctly.",
       ),
     );
   }

--- a/crates/rolldown_error/src/events/mod.rs
+++ b/crates/rolldown_error/src/events/mod.rs
@@ -12,6 +12,7 @@ pub mod assign_to_import;
 pub mod circular_dependency;
 pub mod commonjs_variable_in_esm;
 pub mod configuration_field_conflict;
+pub mod empty_import_meta;
 pub mod eval;
 pub mod export_undefined_variable;
 pub mod external_entry;

--- a/crates/rolldown_error/src/generated/event_kind_switcher.rs
+++ b/crates/rolldown_error/src/generated/event_kind_switcher.rs
@@ -25,14 +25,15 @@ bitflags! {
     const ExportUndefinedVariableError = 1 << 17;
     const ImportIsUndefined = 1 << 18;
     const UnsupportedFeatureError = 1 << 19;
-    const JsonParseError = 1 << 20;
-    const IllegalReassignmentError = 1 << 21;
-    const InvalidDefineConfigError = 1 << 22;
-    const ResolveError = 1 << 23;
-    const UnhandleableError = 1 << 24;
-    const UnloadableDependencyError = 1 << 25;
-    const IoError = 1 << 26;
-    const NapiError = 1 << 27;
-    const ConfigurationFieldConflict = 1 << 28;
+    const EmptyImportMeta = 1 << 20;
+    const JsonParseError = 1 << 21;
+    const IllegalReassignmentError = 1 << 22;
+    const InvalidDefineConfigError = 1 << 23;
+    const ResolveError = 1 << 24;
+    const UnhandleableError = 1 << 25;
+    const UnloadableDependencyError = 1 << 26;
+    const IoError = 1 << 27;
+    const NapiError = 1 << 28;
+    const ConfigurationFieldConflict = 1 << 29;
   }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1214,6 +1214,12 @@
             "null"
           ]
         },
+        "emptyImportMeta": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "configurationFieldConflict": {
           "type": [
             "boolean",

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1413,6 +1413,7 @@ export interface BindingChecksOptions {
   filenameConflict?: boolean
   commonJsVariableInEsm?: boolean
   importIsUndefined?: boolean
+  emptyImportMeta?: boolean
   configurationFieldConflict?: boolean
 }
 

--- a/packages/rolldown/src/options/generated/checks-options.ts
+++ b/packages/rolldown/src/options/generated/checks-options.ts
@@ -63,6 +63,12 @@ export interface ChecksOptions {
   importIsUndefined?: boolean;
 
   /**
+   * Whether to emit warning when detecting empty import meta
+   * @default true
+   */
+  emptyImportMeta?: boolean;
+
+  /**
    * Whether to emit warning when detecting configuration field conflict
    * @default true
    */

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -257,6 +257,12 @@ const ChecksOptionsSchema = v.strictObject({
       'Whether to emit warning when detecting import is undefined',
     ),
   ),
+  emptyImportMeta: v.pipe(
+    v.optional(v.boolean()),
+    v.description(
+      'Whether to emit warning when detecting empty import meta',
+    ),
+  ),
   configurationFieldConflict: v.pipe(
     v.optional(v.boolean()),
     v.description(

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -27,6 +27,7 @@ OPTIONS
   --checks.circular-dependency Whether to emit warning when detecting circular dependency.
   --checks.common-js-variable-in-esm Whether to emit warning when detecting common js variable in esm.
   --checks.configuration-field-conflict Whether to emit warning when detecting configuration field conflict.
+  --checks.empty-import-meta  Whether to emit warning when detecting empty import meta.
   --checks.eval               Whether to emit warning when detecting eval.
   --checks.filename-conflict  Whether to emit warning when detecting filename conflict.
   --checks.import-is-undefined Whether to emit warning when detecting import is undefined.


### PR DESCRIPTION
resolves #5343.
It appears that code already exists for normalizing options regarding the correction of `import.meta`. However, we need to detect it during pre-processing of the AST, so let's implement it later via `Visit`.