### PR TITLE
feat(rolldown_plugin_chunk_import_map): emit standard import map

### DIFF
--- a/crates/rolldown/src/utils/apply_inner_plugins.rs
+++ b/crates/rolldown/src/utils/apply_inner_plugins.rs
@@ -20,9 +20,11 @@ pub fn apply_inner_plugins(
     before_user_plugins.push(Arc::new(rolldown_plugin_hmr::HmrPlugin));
   }
 
-  if options.experimental.is_chunk_import_map_enabled() {
-    before_user_plugins
-      .push(Arc::new(rolldown_plugin_chunk_import_map::ChunkImportMapPlugin::default()));
+  if let Some(config) = &options.experimental.chunk_import_map {
+    before_user_plugins.push(Arc::new(rolldown_plugin_chunk_import_map::ChunkImportMapPlugin {
+      base_url: config.base_url.clone(),
+      ..Default::default()
+    }));
   }
 
   if !before_user_plugins.is_empty() {

--- a/crates/rolldown_common/src/inner_bundler_options/types/chunk_import_map.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/chunk_import_map.rs
@@ -1,0 +1,14 @@
+#[cfg(feature = "deserialize_bundler_options")]
+use schemars::JsonSchema;
+#[cfg(feature = "deserialize_bundler_options")]
+use serde::Deserialize;
+
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
+  serde(rename_all = "camelCase", deny_unknown_fields)
+)]
+pub struct ChunkImportMap {
+  pub base_url: Option<String>,
+}

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -4,6 +4,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::ROLLDOWN_IGNORE;
+use crate::inner_bundler_options::types::chunk_import_map::ChunkImportMap;
 
 use super::attach_debug_info::AttachDebugInfo;
 use super::chunk_modules_order::ChunkModulesOrderBy;
@@ -47,8 +48,8 @@ pub struct ExperimentalOptions {
   pub incremental_build: Option<bool>,
   pub hmr: Option<HmrOptions>,
   pub attach_debug_info: Option<AttachDebugInfo>,
+  pub chunk_import_map: Option<ChunkImportMap>,
   pub chunk_modules_order: Option<ChunkModulesOrderBy>,
-  pub chunk_import_map: Option<bool>,
   pub on_demand_wrapping: Option<bool>,
   pub transform_hires_sourcemap: Option<SourcemapHires>,
 }
@@ -86,9 +87,5 @@ impl ExperimentalOptions {
 
   pub fn is_attach_debug_info_full(&self) -> bool {
     self.attach_debug_info.is_some_and(|info| info.is_full())
-  }
-
-  pub fn is_chunk_import_map_enabled(&self) -> bool {
-    self.chunk_import_map.unwrap_or(false)
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod advanced_chunks_options;
 pub mod attach_debug_info;
+pub mod chunk_import_map;
 pub mod chunk_modules_order;
 pub mod debug_options;
 pub mod defer_sync_scan_data_option;

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -23,6 +23,7 @@ pub mod bundler_options {
         AdvancedChunksOptions, ChunkingContext, MatchGroup, MatchGroupName, MatchGroupTest,
       },
       attach_debug_info::AttachDebugInfo,
+      chunk_import_map::ChunkImportMap,
       chunk_modules_order::ChunkModulesOrderBy,
       debug_options::DebugOptions,
       defer_sync_scan_data_option::DeferSyncScanDataOption,

--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -122,8 +122,11 @@ impl Plugin for ChunkImportMapPlugin {
 
     ctx
       .emit_file_async(EmittedAsset {
-        file_name: Some(arcstr::literal!(".chunk-import-map.json")),
-        source: (serde_json::to_string_pretty(&chunk_import_map)?).into(),
+        file_name: Some(arcstr::literal!("importmap.json")),
+        source: (serde_json::to_string_pretty(&serde_json::json!({
+            "imports": chunk_import_map
+        }))?)
+        .into(),
         ..Default::default()
       })
       .await?;

--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -18,8 +18,9 @@ use xxhash_rust::xxh3::Xxh3;
 
 #[derive(Debug, Default)]
 pub struct ChunkImportMapPlugin {
-  initialized: AtomicBool,
-  chunk_import_map: FxDashMap<ArcStr, String>,
+  pub base_url: Option<String>,
+  pub initialized: AtomicBool,
+  pub chunk_import_map: FxDashMap<ArcStr, String>,
 }
 
 impl Plugin for ChunkImportMapPlugin {
@@ -107,13 +108,14 @@ impl Plugin for ChunkImportMapPlugin {
       return Ok(());
     }
 
+    let base_url = self.base_url.as_deref().unwrap_or("/");
     let mut chunk_import_map = FxHashMap::with_capacity(self.chunk_import_map.len() / 2);
     for output in args.bundle.iter() {
       let Output::Chunk(chunk) = output else { continue };
       if let Some(v) = self.chunk_import_map.get(chunk.preliminary_filename.as_str()) {
         chunk_import_map.insert(
-          rolldown_utils::concat_string!("./", v.as_str()),
-          rolldown_utils::concat_string!("./", chunk.filename),
+          rolldown_utils::concat_string!(base_url, v.as_str()),
+          rolldown_utils::concat_string!(base_url, chunk.filename),
         );
       }
     }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -842,6 +842,16 @@
             }
           ]
         },
+        "chunkImportMap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ChunkImportMap"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "chunkModulesOrder": {
           "anyOf": [
             {
@@ -850,12 +860,6 @@
             {
               "type": "null"
             }
-          ]
-        },
-        "chunkImportMap": {
-          "type": [
-            "boolean",
-            "null"
           ]
         },
         "onDemandWrapping": {
@@ -914,6 +918,18 @@
         "simple",
         "full"
       ]
+    },
+    "ChunkImportMap": {
+      "type": "object",
+      "properties": {
+        "baseUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "ChunkModulesOrderBy": {
       "type": "string",

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1416,6 +1416,10 @@ export interface BindingChecksOptions {
   configurationFieldConflict?: boolean
 }
 
+export interface BindingChunkImportMap {
+  baseUrl?: string
+}
+
 export declare enum BindingChunkModuleOrderBy {
   ModuleId = 0,
   ExecOrder = 1
@@ -1466,7 +1470,7 @@ export interface BindingExperimentalOptions {
   hmr?: BindingExperimentalHmrOptions
   attachDebugInfo?: BindingAttachDebugInfo
   chunkModulesOrder?: BindingChunkModuleOrderBy
-  chunkImportMap?: boolean
+  chunkImportMap?: boolean | BindingChunkImportMap
   onDemandWrapping?: boolean
   incrementalBuild?: boolean
   transformHiresSourcemap?: boolean | 'boundary'

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -215,7 +215,7 @@ export interface InputOptions {
      * > [!NOTE]
      * > If you want to learn more, you can check out the example here: [examples/chunk-import-map](https://github.com/rolldown/rolldown/tree/main/examples/chunk-import-map)
      */
-    chunkImportMap?: boolean;
+    chunkImportMap?: boolean | { baseUrl?: string };
     onDemandWrapping?: boolean;
     /**
      * Required to be used with `watch` mode.

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -410,7 +410,12 @@ const InputOptionsSchema = v.strictObject({
         v.literal('module-id'),
         v.literal('exec-order'),
       ])),
-      chunkImportMap: v.optional(v.boolean()),
+      chunkImportMap: v.optional(v.union([
+        v.boolean(),
+        v.object({
+          baseUrl: v.optional(v.string()),
+        }),
+      ])),
     }),
   ),
   define: v.pipe(


### PR DESCRIPTION
Emitting a standard import map structure aligns better with user expectations and reduces cognitive overhead. I'll update the documentation and examples accordingly later.