### PR TITLE
refactor: skip fast in  esm format when transform import.meta

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -248,6 +248,10 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
   }
 
   fn visit_meta_property(&mut self, it: &ast::MetaProperty<'ast>) {
+    if self.options.format.keep_esm_import_export_syntax() {
+      walk::walk_meta_property(self, it);
+      return;
+    }
     if let Some(parent) = self.visit_path.last() {
       if !parent
         .as_member_expression_kind()
@@ -257,7 +261,6 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
         })
         // Here we need to set it to `false` to emit warnings when leaving `import.meta` alone along with the logic `not` head of this.
         .unwrap_or(false)
-        && !self.options.format.keep_esm_import_export_syntax()
         && it.meta.name == "import"
         && it.property.name == "meta"
       {

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -298,9 +298,9 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         }
       }
       ast::Expression::MetaProperty(meta) => {
-        if meta.meta.name == "import"
+        if !self.ctx.options.format.keep_esm_import_export_syntax()
+          && meta.meta.name == "import"
           && meta.property.name == "meta"
-          && !self.ctx.options.format.keep_esm_import_export_syntax()
         {
           *expr = self.snippet.builder.expression_object(SPAN, self.snippet.builder.vec());
         }

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -608,28 +608,24 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         props,
         target_commonjs_exported_symbol: target_commonjs_exported_symbol_meta,
         ..
-      }) => {
-        object_ref
-          .map(|object_ref| {
-            if let Some(export_meta) = target_commonjs_exported_symbol_meta.and_then(
-              |target_commonjs_exported_symbol_meta| {
-                self.ctx.constant_value_map.get(&target_commonjs_exported_symbol_meta.0)
-              },
-            ) {
-              return export_meta.value.to_expression(AstBuilder::new(self.alloc));
-            }
-            let object_ref_expr = self.finalized_expr_for_symbol_ref(
-              object_ref,
-              false,
-              target_commonjs_exported_symbol_meta
-                .is_some_and(|(_symbol, is_exports_default)| !is_exports_default),
-            );
-            self.snippet.member_expr_or_ident_ref(object_ref_expr, props, span)
-          })
-          // .or(None)
-          .or_else(|| Some(self.snippet.member_expr_with_void_zero_object(props, span)))
-        // return Some();
-      }
+      }) => object_ref
+        .map(|object_ref| {
+          if let Some(export_meta) =
+            target_commonjs_exported_symbol_meta.and_then(|target_commonjs_exported_symbol_meta| {
+              self.ctx.constant_value_map.get(&target_commonjs_exported_symbol_meta.0)
+            })
+          {
+            return export_meta.value.to_expression(AstBuilder::new(self.alloc));
+          }
+          let object_ref_expr = self.finalized_expr_for_symbol_ref(
+            object_ref,
+            false,
+            target_commonjs_exported_symbol_meta
+              .is_some_and(|(_symbol, is_exports_default)| !is_exports_default),
+          );
+          self.snippet.member_expr_or_ident_ref(object_ref_expr, props, span)
+        })
+        .or_else(|| Some(self.snippet.member_expr_with_void_zero_object(props, span))),
       _ => {
         let MemberExpression::StaticMemberExpression(static_member_expr) = member_expr else {
           return None;


### PR DESCRIPTION
put trivial branch at first could skip fast in esm format