### PR TITLE
chore(rolldown_plugin_asset): remove unnecessary comments

### DIFF
--- a/crates/rolldown_plugin_asset/src/lib.rs
+++ b/crates/rolldown_plugin_asset/src/lib.rs
@@ -93,15 +93,6 @@ impl Plugin for AssetPlugin {
       &id,
     )?;
 
-    // TODO(shulaoda): align below logic
-    // Inherit HMR timestamp if this asset was invalidated
-    // if (!url.startsWith('data:') && this.environment.mode === 'dev') {
-    //   const mod = this.environment.moduleGraph.getModuleById(id)
-    //   if (mod && mod.lastHMRTimestamp > 0) {
-    //     url = injectQuery(url, `t=${mod.lastHMRTimestamp}`)
-    //   }
-    // }
-
     let url = rolldown_plugin_utils::encode_uri_path(url);
     let code = arcstr::format!("export default {}", serde_json::to_string(&Value::String(url))?);
     Ok(Some(rolldown_plugin::HookLoadOutput {


### PR DESCRIPTION
We currently do not support the logic of `dev` environment, so this `todo` is unnecessary.