### PR TITLE
refactor(rust): make `Log#code` an `Option`

### DIFF
--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/info_warn_debug/mod.rs
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/info_warn_debug/mod.rs
@@ -20,9 +20,9 @@ impl Plugin for TestPlugin {
     ctx: &PluginContext,
     _args: &rolldown_plugin::HookBuildStartArgs<'_>,
   ) -> rolldown_plugin::HookNoopReturn {
-    ctx.info(Log { code: String::new(), message: "info".to_owned(), id: None, exporter: None });
-    ctx.warn(Log { code: String::new(), message: "warn".to_owned(), id: None, exporter: None });
-    ctx.debug(Log { code: String::new(), message: "debug".to_owned(), id: None, exporter: None });
+    ctx.info(Log { message: "info".to_owned(), code: None, id: None, exporter: None });
+    ctx.warn(Log { message: "warn".to_owned(), code: None, id: None, exporter: None });
+    ctx.debug(Log { message: "debug".to_owned(), code: None, id: None, exporter: None });
     Ok(())
   }
 

--- a/crates/rolldown_binding/src/binding_bundler_impl.rs
+++ b/crates/rolldown_binding/src/binding_bundler_impl.rs
@@ -242,7 +242,7 @@ impl BindingBundlerImpl {
             rolldown::Log {
               id: warning.id(),
               exporter: warning.exporter(),
-              code: warning.kind().to_string(),
+              code: Some(warning.kind().to_string()),
               message: warning
                 .to_diagnostic_with(&DiagnosticOptions { cwd: options.cwd.clone() })
                 .to_color_string(),

--- a/crates/rolldown_binding/src/types/binding_log.rs
+++ b/crates/rolldown_binding/src/types/binding_log.rs
@@ -2,9 +2,9 @@ use napi_derive::napi;
 
 #[napi(object)]
 pub struct BindingLog {
-  pub code: String,
   pub message: String,
   pub id: Option<String>,
+  pub code: Option<String>,
   pub exporter: Option<String>,
 }
 

--- a/crates/rolldown_common/src/inner_bundler_options/types/on_log.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/on_log.rs
@@ -25,8 +25,8 @@ impl OnLog {
 
 #[derive(Debug, Default)]
 pub struct Log {
-  pub code: String,
   pub message: String,
   pub id: Option<String>,
+  pub code: Option<String>,
   pub exporter: Option<String>,
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1656,9 +1656,9 @@ export declare enum BindingJsx {
 }
 
 export interface BindingLog {
-  code: string
   message: string
   id?: string
+  code?: string
   exporter?: string
 }
 


### PR DESCRIPTION
The `code` field in the `RollupLog` type is optional, as it may be used by native plugins later.