### PR TITLE
fix: Panic on reexport external module in  CJS format

### DIFF
--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -130,7 +130,7 @@ fn render_esm_chunk_imports(ctx: &GenerateContext<'_>) -> Option<String> {
   });
   let mut rendered_external_import_namespace_modules = FxHashSet::default();
   // render external imports
-  ctx.chunk.imports_from_external_modules.iter().for_each(|(importee_id, named_imports)| {
+  ctx.chunk.direct_imports_from_external_modules.iter().for_each(|(importee_id, named_imports)| {
     let importee = &ctx.link_output.module_table[*importee_id]
       .as_external()
       .expect("Should be external module here");

--- a/crates/rolldown/src/ecmascript/format/utils/mod.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/mod.rs
@@ -29,7 +29,7 @@ pub fn render_chunk_external_imports<'a>(
 
   let externals = ctx
     .chunk
-    .imports_from_external_modules
+    .direct_imports_from_external_modules
     .iter()
     .filter_map(|(importee_id, _)| {
       let importee = ctx.link_output.module_table[*importee_id]

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -24,13 +24,20 @@ pub fn deconflict_chunk_symbols(
     // deconflict iife introduce symbols by external
     // Also AMD, but we don't support them yet.
     chunk
-      .imports_from_external_modules
+      .direct_imports_from_external_modules
       .iter()
       .filter_map(|(idx, _)| link_output.module_table[*idx].as_external())
       .for_each(|external_module| {
         renamer.add_symbol_in_root_scope(external_module.namespace_ref);
       });
 
+    chunk
+      .import_symbol_from_external_modules
+      .iter()
+      .filter_map(|idx| link_output.module_table[*idx].as_external())
+      .for_each(|external_module| {
+        renamer.add_symbol_in_root_scope(external_module.namespace_ref);
+      });
     match chunk.entry_module_idx() {
       Some(module) => {
         let entry_module =
@@ -106,7 +113,7 @@ pub fn deconflict_chunk_symbols(
     ChunkKind::Common => {}
   }
   if matches!(format, OutputFormat::Esm) {
-    chunk.imports_from_external_modules.iter().for_each(|(module, _)| {
+    chunk.direct_imports_from_external_modules.iter().for_each(|(module, _)| {
       let db = link_output.symbol_db.local_db(*module);
       db.classic_data.iter_enumerated().for_each(|(symbol, _)| {
         let symbol_ref = (*module, symbol).into();

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -178,7 +178,7 @@ pub async fn finalize_assets(
         .map(|importee_asset_idx| index_ins_chunk_to_filename[*importee_asset_idx].clone())
         .chain(
           chunk
-            .imports_from_external_modules
+            .direct_imports_from_external_modules
             .iter()
             .map(|(idx, _)| link_output.module_table[*idx].id().into()),
         )

--- a/crates/rolldown/src/utils/chunk/mod.rs
+++ b/crates/rolldown/src/utils/chunk/mod.rs
@@ -66,7 +66,7 @@ pub fn generate_rendered_chunk(
       })
       .chain(
         chunk
-          .imports_from_external_modules
+          .direct_imports_from_external_modules
           .iter()
           .map(|(idx, _)| link_output.module_table[*idx].id().into()),
       )

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -200,7 +200,7 @@ pub fn render_chunk_exports(
           // First check if any of these external modules have already been imported elsewhere in the chunk
           let mut imported_external_modules: FxHashSet<SymbolRef> = ctx
             .chunk
-            .imports_from_external_modules
+            .direct_imports_from_external_modules
             .iter()
             .map(|(idx, _)| {
               let external = &ctx.link_output.module_table[*idx]

--- a/crates/rolldown/tests/rolldown/issues/4585/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4585/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "external": ["node:process"],
+    "format": "cjs"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/4585/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4585/artifacts.snap
@@ -1,0 +1,25 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+const node_process = __toESM(require("node:process"));
+
+//#region lib.js
+var VFile = class {
+	constructor() {
+		console.log(node_process.default);
+	}
+};
+
+//#endregion
+//#region main.js
+const file = new VFile();
+
+//#endregion
+exports.file = file;
+```

--- a/crates/rolldown/tests/rolldown/issues/4585/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/4585/lib.js
@@ -1,0 +1,9 @@
+import {minproc} from './proc.js'
+
+
+export class VFile {
+  constructor() {
+    console.log(minproc)
+  }
+}
+

--- a/crates/rolldown/tests/rolldown/issues/4585/main.js
+++ b/crates/rolldown/tests/rolldown/issues/4585/main.js
@@ -1,0 +1,3 @@
+import { VFile } from './lib';
+
+export const file = new VFile();

--- a/crates/rolldown/tests/rolldown/issues/4585/proc.js
+++ b/crates/rolldown/tests/rolldown/issues/4585/proc.js
@@ -1,0 +1,1 @@
+export {default as minproc} from 'node:process'

--- a/crates/rolldown/tests/rolldown/issues/5044/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/5044/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "preserveModules": true,
+    "external": ["preact"],
+    "format": "cjs",
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/5044/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5044/artifacts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## _virtual/rolldown_runtime.js
+
+```js
+// HIDDEN [rolldown:runtime]
+
+exports.__toESM = __toESM;
+```
+## cube.js
+
+```js
+const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
+const preact = require_rolldown_runtime.__toESM(require("preact"));
+
+```
+## lib.js
+
+```js
+require('./cube.js');
+const preact = require("preact");
+
+```
+## main.js
+
+```js
+require('./lib.js');
+const preact = require("preact");
+
+Object.defineProperty(exports, 'createContext', {
+  enumerable: true,
+  get: function () {
+    return preact.createContext;
+  }
+});
+```

--- a/crates/rolldown/tests/rolldown/issues/5044/cube.js
+++ b/crates/rolldown/tests/rolldown/issues/5044/cube.js
@@ -1,0 +1,2 @@
+export { createContext } from 'preact';
+export const a = 1000;

--- a/crates/rolldown/tests/rolldown/issues/5044/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/5044/lib.js
@@ -1,0 +1,2 @@
+export { a, createContext } from './cube.js';
+export const b = 1000;

--- a/crates/rolldown/tests/rolldown/issues/5044/main.js
+++ b/crates/rolldown/tests/rolldown/issues/5044/main.js
@@ -1,0 +1,1 @@
+export { createContext } from "./lib";

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4769,6 +4769,10 @@ expression: output
 
 - main-!~{000}~.js => main-BOUZhfES.js
 
+# tests/rolldown/issues/4585
+
+- main-!~{000}~.js => main-CGW9A3zc.js
+
 # tests/rolldown/issues/4780
 
 - main-!~{000}~.js => main-D_pxn1_z.js
@@ -4776,6 +4780,13 @@ expression: output
 # tests/rolldown/issues/4993
 
 - main-!~{000}~.js => main-BQQtZSou.js
+
+# tests/rolldown/issues/5044
+
+- main-!~{000}~.js => main-D8gvDh02.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-mwmJao_F.js
+- cube-!~{003}~.js => cube-BCmsXstN.js
+- lib-!~{005}~.js => lib-BPbv7Y41.js
 
 # tests/rolldown/issues/5139
 

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -15,7 +15,10 @@ use arcstr::ArcStr;
 use rolldown_rstr::Rstr;
 use rolldown_std_utils::PathExt;
 use rolldown_utils::{
-  BitSet, dashmap::FxDashMap, hash_placeholder::HashPlaceholderGenerator, indexmap::FxIndexMap,
+  BitSet,
+  dashmap::FxDashMap,
+  hash_placeholder::HashPlaceholderGenerator,
+  indexmap::{FxIndexMap, FxIndexSet},
   make_unique_name::make_unique_name,
 };
 use rustc_hash::FxHashMap;
@@ -58,7 +61,10 @@ pub struct Chunk {
   pub imports_from_other_chunks: Vec<(ChunkIdx, Vec<CrossChunkImportItem>)>,
   // Only meaningful for cjs format
   pub require_binding_names_for_other_chunks: FxHashMap<ChunkIdx, String>,
-  pub imports_from_external_modules: Vec<(ModuleIdx, Vec<NamedImport>)>,
+  pub direct_imports_from_external_modules: Vec<(ModuleIdx, Vec<NamedImport>)>,
+  /// Used for cjs, umd, iife
+  /// The module directly imported symbol actually came from external modules.
+  pub import_symbol_from_external_modules: FxIndexSet<ModuleIdx>,
   pub exports_to_other_chunks: FxHashMap<SymbolRef, Vec<Rstr>>,
   pub input_base: ArcStr,
   pub create_reasons: Vec<String>,


### PR DESCRIPTION
# Description
Here is a minimum reproduction: 

```js
// main.js
exoprt {createContext} from './lib.js'


// lib.js
export {createContext} from 'preact' // preact is a external module
```
<img width="6120" height="2265" alt="image" src="https://github.com/user-attachments/assets/fe14af2e-5b1b-413b-aa80-d37ec5f5917d" />

after `canonical_ref` the `createContext` imported by `main.js` final pointed the symbol `createContext` exported by external module `preact`, so we need to generate code like:
```js
Object.defineProperty(exports, 'createContext', {
  enumerable: true,
  get: function () {
    return ${external_preact_namespace_deconflicted_name}.createContext;
  }
});

```
When there is only one chunk we could reuse the name(generated by **lib.js**, for now we only record the external module that is directly imported by the module), 
https://github.com/rolldown/rolldown/blob/9b94b6f4dc40fe24371914a09c828aaaecc3a1db/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs?plain=1#L207-L213

But when you enabled `preserveModules` or use `advancedChunks` split the two modules into two chunks, 
`main.js` can't find **deconflicted_name** of `preact`(because it did not directly import `preact`), then it will panic.


1. related #5044
2. related #4585

This pr resovled the panic in both of the two issues above, left adding `__toESM` wrapper to `require('external')` in next pr.