### PR TITLE
feat: add `optimization.pifeForModuleWrappers` option

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -30,6 +30,7 @@ pub struct HmrAstFinalizer<'me, 'ast> {
   pub modules: &'me IndexModules,
   pub module: &'me NormalModule,
   pub affected_module_idx_to_init_fn_name: &'me FxHashMap<ModuleIdx, String>,
+  pub use_pife_for_module_wrappers: bool,
   //Internal state
   pub import_binding: FxHashMap<SymbolId, String>,
   pub exports: oxc::allocator::Vec<'ast, ObjectPropertyKind<'ast>>,
@@ -408,7 +409,7 @@ impl<'ast> VisitMut<'ast> for HmrAstFinalizer<'_, 'ast> {
       )),
     );
     // mark the callback as PIFE because the callback is executed when this chunk is loaded
-    user_code_wrapper.pife = true;
+    user_code_wrapper.pife = self.use_pife_for_module_wrappers;
 
     let initializer_call = if self.module.exports_kind.is_commonjs() {
       // __rolldown__runtime.createCjsInitializer((function (module, exports) { [user code] }))

--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -310,6 +310,8 @@ impl HmrManager {
       };
 
       let enable_sourcemap = self.options.sourcemap.is_some() && !affected_module.is_virtual();
+      let use_pife_for_module_wrappers =
+        self.options.optimization.is_pife_for_module_wrappers_enabled();
       let modules = &self.input.module_db.modules;
       let ast = self.input.index_ecma_ast[affected_module_idx]
         .as_mut()
@@ -327,6 +329,7 @@ impl HmrManager {
           module: affected_module,
           exports: oxc::allocator::Vec::new_in(fields.allocator),
           affected_module_idx_to_init_fn_name: &module_idx_to_init_fn_name,
+          use_pife_for_module_wrappers,
           dependencies: FxIndexSet::default(),
           imports: FxHashSet::default(),
         };

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -193,6 +193,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           esm_ref_expr,
           stmts_inside_closure,
           self.ctx.options.profiler_names,
+          self.ctx.options.optimization.is_pife_for_module_wrappers_enabled(),
           &self.ctx.module.stable_id,
           self.ctx.linking_info.is_tla_or_contains_tla_dependency,
         ));

--- a/crates/rolldown/src/utils/normalize_options.rs
+++ b/crates/rolldown/src/utils/normalize_options.rs
@@ -4,6 +4,7 @@ use oxc::transformer_plugins::InjectGlobalVariablesConfig;
 use rolldown_common::{
   AttachDebugInfo, GlobalsOutputOption, InjectImport, LegalComments, MinifyOptions, ModuleType,
   NormalizedBundlerOptions, OutputFormat, Platform, PreserveEntrySignatures, TreeshakeOptions,
+  normalize_optimization_option,
 };
 use rolldown_error::{BuildDiagnostic, InvalidOptionType};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -296,7 +297,7 @@ pub fn normalize_options(mut raw_options: crate::BundlerOptions) -> NormalizeOpt
     cwd,
     preserve_entry_signatures,
     debug: raw_options.debug.is_some(),
-    optimization: raw_options.optimization.unwrap_or_default(),
+    optimization: normalize_optimization_option(raw_options.optimization, platform),
     top_level_var: raw_options.top_level_var.unwrap_or(false),
     minify_internal_exports: raw_options.minify_internal_exports.unwrap_or(false),
   };

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_optimization.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_optimization.rs
@@ -6,6 +6,6 @@ pub struct BindingOptimization {
 
 impl From<BindingOptimization> for rolldown_common::OptimizationOption {
   fn from(value: BindingOptimization) -> Self {
-    Self { inline_const: value.inline_const }
+    Self { inline_const: value.inline_const, pife_for_module_wrappers: None /* TODO */ }
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/optimization.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/optimization.rs
@@ -3,6 +3,8 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::Deserialize;
 
+use crate::Platform;
+
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
@@ -25,11 +27,33 @@ pub struct OptimizationOption {
   /// export const long_string = 'this is a very long string that will be inlined everywhere';
   /// ```
   pub inline_const: Option<bool>,
+  /// Use PIFE patterns for module wrappers so that JS engines can compile the functions eagerly.
+  /// This improves the initial execution performance.
+  /// See <https://v8.dev/blog/preparser#pife> for more details about the optimization.
+  pub pife_for_module_wrappers: Option<bool>,
 }
 
 impl OptimizationOption {
   #[inline]
   pub fn is_inline_const_enabled(&self) -> bool {
     self.inline_const.unwrap_or(false)
+  }
+
+  #[inline]
+  pub fn is_pife_for_module_wrappers_enabled(&self) -> bool {
+    self.pife_for_module_wrappers.unwrap_or(false)
+  }
+}
+
+pub fn normalize_optimization_option(
+  option: Option<OptimizationOption>,
+  platform: Platform,
+) -> OptimizationOption {
+  let option = option.unwrap_or_default();
+  OptimizationOption {
+    inline_const: option.inline_const,
+    pife_for_module_wrappers: Some(
+      option.pife_for_module_wrappers.unwrap_or(!matches!(platform, Platform::Neutral)),
+    ),
   }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -44,7 +44,7 @@ pub mod bundler_options {
       module_type::ModuleType,
       normalized_bundler_options::{NormalizedBundlerOptions, SharedNormalizedBundlerOptions},
       on_log::{Log, OnLog},
-      optimization::OptimizationOption,
+      optimization::{OptimizationOption, normalize_optimization_option},
       output_exports::OutputExports,
       output_format::OutputFormat,
       output_option::{

--- a/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
@@ -352,12 +352,14 @@ impl<'ast> AstSnippet<'ast> {
   /// ```js
   /// var init_foo = __esm((() => { ... }));
   /// ```
+  #[expect(clippy::too_many_arguments)]
   pub fn esm_wrapper_stmt(
     &self,
     binding_name: PassedStr,
     esm_fn_expr: ast::Expression<'ast>,
     statements: allocator::Vec<'ast, Statement<'ast>>,
     profiler_names: bool,
+    use_pife: bool,
     stable_id: &str,
     is_async: bool,
   ) -> ast::Statement<'ast> {
@@ -378,7 +380,7 @@ impl<'ast> AstSnippet<'ast> {
     // and the statically imported modules are evaluated in the initial load
     let mut arrow_expr =
       self.builder.alloc_arrow_function_expression(SPAN, false, is_async, NONE, params, NONE, body);
-    arrow_expr.pife = true;
+    arrow_expr.pife = use_pife;
 
     if profiler_names {
       let obj_expr = self.builder.alloc_object_expression(

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1370,6 +1370,13 @@
             "boolean",
             "null"
           ]
+        },
+        "pifeForModuleWrappers": {
+          "description": "Use PIFE patterns for module wrappers so that JS engines can compile the functions eagerly.\nThis improves the initial execution performance.\nSee <https://v8.dev/blog/preparser#pife> for more details about the optimization.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Added `optimization.pifeForModuleWrappers` option on rust side, which is `true` by default for `platform: 'browser'` and `platform: 'node'`.

refs: https://github.com/rolldown/rolldown/pull/5427#issuecomment-3114202714
