### PR TITLE
feat(pluginutils): add `suffixRegex` & support multiple string

### DIFF
--- a/packages/pluginutils/README.md
+++ b/packages/pluginutils/README.md
@@ -17,6 +17,7 @@ import {
   exactRegex,
   makeIdFiltersToMatchWithQuery,
   prefixRegex,
+  suffixRegex,
 } from '@rolldown/pluginutils';
 
 // Match exactly 'foo.js'
@@ -24,6 +25,9 @@ const filter = exactRegex('foo.js');
 
 // Match any id starting with 'lib/'
 const prefix = prefixRegex('lib/');
+
+// Match any id ending with 'foo'
+const suffix = suffixRegex('foo');
 
 // Match ids with query params (e.g. 'foo.js?bar')
 const idFilters = makeIdFiltersToMatchWithQuery(['**/*.js', /\.ts$/]);
@@ -70,8 +74,9 @@ const myPlugin = {
 
 ### Simple Filters
 
-- `exactRegex(str: string, flags?: string): RegExp` — Matches the exact string.
-- `prefixRegex(str: string, flags?: string): RegExp` — Matches values with the given prefix.
+- `exactRegex(str: string | string[], flags?: string): RegExp` — Matches the exact string.
+- `prefixRegex(str: string | string[], flags?: string): RegExp` — Matches values with the given prefix.
+- `suffixRegex(str: string | string[], flags?: string): RegExp` — Matches values with the given suffix.
 - `makeIdFiltersToMatchWithQuery(input: string | RegExp | (string | RegExp)[]): string | RegExp | (string | RegExp)[]` — Adapts filters to match ids with query params.
 
 ### Composable Filters

--- a/packages/pluginutils/src/simple-filters.test.ts
+++ b/packages/pluginutils/src/simple-filters.test.ts
@@ -17,6 +17,16 @@ describe('exactRegex', () => {
     expect(regex.test('afoo')).toBe(false);
   });
 
+  test('supports without flag parameter with empty string', () => {
+    const regex = exactRegex('');
+    expect(regex).toStrictEqual(/^(?!)$/);
+
+    expect(regex.test('')).toBe(false);
+    expect(regex.test('foo')).toBe(false);
+    expect(regex.test('fooa')).toBe(false);
+    expect(regex.test('afoo')).toBe(false);
+  });
+
   test('supports with array input without flag parameter', () => {
     const regex = exactRegex(['foo', 'bar']);
     expect(regex).toStrictEqual(/^(?:foo|bar)$/);
@@ -24,6 +34,16 @@ describe('exactRegex', () => {
     expect(regex.test('foo')).toBe(true);
     expect(regex.test('bar')).toBe(true);
     expect(regex.test('baz')).toBe(false);
+  });
+
+  test('supports with empty array input without flag parameter', () => {
+    const regex = exactRegex(['']);
+    expect(regex).toStrictEqual(/^(?!)$/);
+
+    expect(regex.test('')).toBe(false);
+    expect(regex.test('foo')).toBe(false);
+    expect(regex.test('fooa')).toBe(false);
+    expect(regex.test('afoo')).toBe(false);
   });
 
   test('supports with flag parameter', () => {

--- a/packages/pluginutils/src/simple-filters.test.ts
+++ b/packages/pluginutils/src/simple-filters.test.ts
@@ -17,7 +17,7 @@ describe('exactRegex', () => {
     expect(regex.test('afoo')).toBe(false);
   });
 
-  test('supports with array input without flag paramenter', () => {
+  test('supports with array input without flag parameter', () => {
     const regex = exactRegex(['foo', 'bar']);
     expect(regex).toStrictEqual(/^(?:foo|bar)$/);
 

--- a/packages/pluginutils/src/simple-filters.test.ts
+++ b/packages/pluginutils/src/simple-filters.test.ts
@@ -4,6 +4,7 @@ import {
   exactRegex,
   makeIdFiltersToMatchWithQuery,
   prefixRegex,
+  suffixRegex,
 } from './simple-filters.js';
 
 describe('exactRegex', () => {
@@ -16,6 +17,15 @@ describe('exactRegex', () => {
     expect(regex.test('afoo')).toBe(false);
   });
 
+  test('supports with array input without flag paramenter', () => {
+    const regex = exactRegex(['foo', 'bar']);
+    expect(regex).toStrictEqual(/^(?:foo|bar)$/);
+
+    expect(regex.test('foo')).toBe(true);
+    expect(regex.test('bar')).toBe(true);
+    expect(regex.test('baz')).toBe(false);
+  });
+
   test('supports with flag parameter', () => {
     const regex = exactRegex('foo', 'i');
     expect(regex).toStrictEqual(/^foo$/i);
@@ -26,6 +36,17 @@ describe('exactRegex', () => {
     expect(regex.test('aFoo')).toBe(false);
   });
 
+  test('supports with array input with flag parameter', () => {
+    const regex = exactRegex(['foo', 'bar'], 'i');
+    expect(regex).toStrictEqual(/^(?:foo|bar)$/i);
+
+    expect(regex.test('foo')).toBe(true);
+    expect(regex.test('bar')).toBe(true);
+    expect(regex.test('baz')).toBe(false);
+    expect(regex.test('Foo')).toBe(true);
+    expect(regex.test('Bar')).toBe(true);
+  });
+
   test('escapes special characters for Regex', () => {
     const regex = exactRegex('foo(bar)');
     expect(regex).toStrictEqual(/^foo\(bar\)$/);
@@ -34,6 +55,16 @@ describe('exactRegex', () => {
     expect(regex.test('foo(bar\\)')).toBe(false);
     expect(regex.test('foo(bar)a')).toBe(false);
     expect(regex.test('afoo(bar)')).toBe(false);
+  });
+
+  test('escape special characters for array input', () => {
+    const regex = exactRegex(['foo(bar)', 'baz']);
+    expect(regex).toStrictEqual(/^(?:foo\(bar\)|baz)$/);
+
+    expect(regex.test('foo(bar)')).toBe(true);
+    expect(regex.test('baz')).toBe(true);
+    expect(regex.test('foo(baz)')).toBe(false);
+    expect(regex.test('baz(foo)')).toBe(false);
   });
 });
 
@@ -47,6 +78,15 @@ describe('prefixRegex', () => {
     expect(regex.test('afoo')).toBe(false);
   });
 
+  test('supports with array input without flag parameter', () => {
+    const regex = prefixRegex(['foo', 'bar']);
+    expect(regex).toStrictEqual(/^(?:foo|bar)/);
+
+    expect(regex.test('foo')).toBe(true);
+    expect(regex.test('bar')).toBe(true);
+    expect(regex.test('baz')).toBe(false);
+  });
+
   test('supports with flag parameter', () => {
     const regex = prefixRegex('foo', 'i');
     expect(regex).toStrictEqual(/^foo/i);
@@ -57,6 +97,17 @@ describe('prefixRegex', () => {
     expect(regex.test('aFoo')).toBe(false);
   });
 
+  test('supports with array input with flag parameter', () => {
+    const regex = prefixRegex(['foo', 'bar'], 'i');
+    expect(regex).toStrictEqual(/^(?:foo|bar)/i);
+
+    expect(regex.test('foo')).toBe(true);
+    expect(regex.test('bar')).toBe(true);
+    expect(regex.test('baz')).toBe(false);
+    expect(regex.test('Foo')).toBe(true);
+    expect(regex.test('Bar')).toBe(true);
+  });
+
   test('escapes special characters for Regex', () => {
     const regex = prefixRegex('foo(bar)');
     expect(regex).toStrictEqual(/^foo\(bar\)/);
@@ -65,6 +116,77 @@ describe('prefixRegex', () => {
     expect(regex.test('foo(bar\\)')).toBe(false);
     expect(regex.test('foo(bar)a')).toBe(true);
     expect(regex.test('afoo(bar)')).toBe(false);
+  });
+
+  test('escape special characters for array input', () => {
+    const regex = prefixRegex(['foo(bar)', 'baz']);
+    expect(regex).toStrictEqual(/^(?:foo\(bar\)|baz)/);
+
+    expect(regex.test('foo(bar)')).toBe(true);
+    expect(regex.test('baz')).toBe(true);
+    expect(regex.test('foo(baz)')).toBe(false);
+    expect(regex.test('baz(foo)')).toBe(true);
+  });
+});
+
+describe('suffixRegex', () => {
+  test('supports without flag parameter', () => {
+    const regex = suffixRegex('foo');
+    expect(regex).toStrictEqual(/foo$/);
+
+    expect(regex.test('foo')).toBe(true);
+    expect(regex.test('fooa')).toBe(false);
+    expect(regex.test('afoo')).toBe(true);
+  });
+
+  test('supports with array input without flag parameter', () => {
+    const regex = suffixRegex(['foo', 'bar']);
+    expect(regex).toStrictEqual(/(?:foo|bar)$/);
+
+    expect(regex.test('foo')).toBe(true);
+    expect(regex.test('bar')).toBe(true);
+    expect(regex.test('baz')).toBe(false);
+  });
+
+  test('supports with flag parameter', () => {
+    const regex = suffixRegex('foo', 'i');
+    expect(regex).toStrictEqual(/foo$/i);
+
+    expect(regex.test('foo')).toBe(true);
+    expect(regex.test('Foo')).toBe(true);
+    expect(regex.test('Fooa')).toBe(false);
+    expect(regex.test('aFoo')).toBe(true);
+  });
+
+  test('supports with array input with flag parameter', () => {
+    const regex = suffixRegex(['foo', 'bar'], 'i');
+    expect(regex).toStrictEqual(/(?:foo|bar)$/i);
+
+    expect(regex.test('foo')).toBe(true);
+    expect(regex.test('bar')).toBe(true);
+    expect(regex.test('baz')).toBe(false);
+    expect(regex.test('Foo')).toBe(true);
+    expect(regex.test('Bar')).toBe(true);
+  });
+
+  test('escapes special characters for Regex', () => {
+    const regex = suffixRegex('foo(bar)');
+    expect(regex).toStrictEqual(/foo\(bar\)$/);
+
+    expect(regex.test('foo(bar)')).toBe(true);
+    expect(regex.test('foo(bar\\)')).toBe(false);
+    expect(regex.test('foo(bar)a')).toBe(false);
+    expect(regex.test('afoo(bar)')).toBe(true);
+  });
+
+  test('escape special characters for array input', () => {
+    const regex = suffixRegex(['foo(bar)', 'baz']);
+    expect(regex).toStrictEqual(/(?:foo\(bar\)|baz)$/);
+
+    expect(regex.test('foo(bar)')).toBe(true);
+    expect(regex.test('baz')).toBe(true);
+    expect(regex.test('foo(baz)')).toBe(false);
+    expect(regex.test('baz(foo)')).toBe(false);
   });
 });
 

--- a/packages/pluginutils/src/simple-filters.ts
+++ b/packages/pluginutils/src/simple-filters.ts
@@ -80,7 +80,7 @@ function combineMultipleStrings(
   if (Array.isArray(str)) {
     const escapeStr = str.map(escapeRegex).join('|');
     if (escapeStr && str.length > 1) {
-      return `${escapeRegex('(?:')}${escapeStr}${escapeRegex(')')}`;
+      return `(?:${escapeStr})`;
     }
     return escapeStr;
   }

--- a/packages/pluginutils/src/simple-filters.ts
+++ b/packages/pluginutils/src/simple-filters.ts
@@ -18,8 +18,8 @@
  * }
  * ```
  */
-export function exactRegex(str: string, flags?: string): RegExp {
-  return new RegExp(`^${escapeRegex(str)}$`, flags);
+export function exactRegex(str: string | string[], flags?: string): RegExp {
+  return new RegExp(`^${combineMultipleStrings(str)}$`, flags);
 }
 
 /**
@@ -42,13 +42,49 @@ export function exactRegex(str: string, flags?: string): RegExp {
  * }
  * ```
  */
-export function prefixRegex(str: string, flags?: string): RegExp {
-  return new RegExp(`^${escapeRegex(str)}`, flags);
+export function prefixRegex(str: string | string[], flags?: string): RegExp {
+  return new RegExp(`^${combineMultipleStrings(str)}`, flags);
+}
+
+/**
+ * Constructs a RegExp that matches a value that has the specified suffix.
+ *
+ * This is useful for plugin hook filters.
+ *
+ * @param str the string to match.
+ * @param flags flags for the RegExp.
+ *
+ * @example
+ * ```ts
+ * import { suffixRegex } from '@rolldown/pluginutils';
+ * const plugin = {
+ *   name: 'plugin',
+ *   resolveId: {
+ *     filter: { id: suffixRegex('.vue') },
+ *     handler(id) {} // will only be called for IDs ending with `.vue`
+ *   }
+ * }
+ * ```
+ */
+export function suffixRegex(str: string | string[], flags?: string): RegExp {
+  return new RegExp(`${combineMultipleStrings(str)}$`, flags);
 }
 
 const escapeRegexRE = /[-/\\^$*+?.()|[\]{}]/g;
 function escapeRegex(str: string): string {
   return str.replace(escapeRegexRE, '\\$&');
+}
+function combineMultipleStrings(
+  str: string | string[],
+): string {
+  if (Array.isArray(str)) {
+    const escapeStr = str.map(escapeRegex).join('|');
+    if (escapeStr && str.length > 1) {
+      return `${escapeRegex('(?:')}(${escapeStr})${escapeRegex(')')}`;
+    }
+    return escapeStr;
+  }
+  return escapeRegex(str);
 }
 
 type WidenString<T> = T extends string ? string : T;

--- a/packages/pluginutils/src/simple-filters.ts
+++ b/packages/pluginutils/src/simple-filters.ts
@@ -77,14 +77,15 @@ function escapeRegex(str: string): string {
 function combineMultipleStrings(
   str: string | string[],
 ): string {
-  if (Array.isArray(str)) {
-    const escapeStr = str.map(escapeRegex).join('|');
-    if (escapeStr && str.length > 1) {
-      return `(?:${escapeStr})`;
-    }
-    return escapeStr;
+  str = Array.isArray(str) ? str : [str];
+  if (str.filter(Boolean).length === 0) {
+    return '(?!)'; // matches nothing
   }
-  return escapeRegex(str);
+  const escapeStr = str.map(escapeRegex).join('|');
+  if (escapeStr && str.length > 1) {
+    return `(?:${escapeStr})`;
+  }
+  return escapeStr;
 }
 
 type WidenString<T> = T extends string ? string : T;

--- a/packages/pluginutils/src/simple-filters.ts
+++ b/packages/pluginutils/src/simple-filters.ts
@@ -80,7 +80,7 @@ function combineMultipleStrings(
   if (Array.isArray(str)) {
     const escapeStr = str.map(escapeRegex).join('|');
     if (escapeStr && str.length > 1) {
-      return `${escapeRegex('(?:')}(${escapeStr})${escapeRegex(')')}`;
+      return `${escapeRegex('(?:')}${escapeStr}${escapeRegex(')')}`;
     }
     return escapeStr;
   }


### PR DESCRIPTION
Added `suffixRegex` function to facilitate plugins to filter files with specific suffixes.

The first parameter of `prefixRegex`/`suffixRegex`/`exactRegex` functions is expanded to support string arrays, making it easier to combine multiple conditions.