### PR TITLE
fix: indirect requiring external module  is not wrapped by `__toESM` in cjs format

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/5044/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/5044/_config.json
@@ -2,7 +2,7 @@
   "config": {
     "preserveModules": true,
     "external": ["preact"],
-    "format": "cjs",
+    "format": "cjs"
   },
   "expectExecuted": false
 }

--- a/crates/rolldown/tests/rolldown/issues/5044/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5044/artifacts.snap
@@ -20,15 +20,17 @@ const preact = require_rolldown_runtime.__toESM(require("preact"));
 ## lib.js
 
 ```js
+const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
 require('./cube.js');
-const preact = require("preact");
+const preact = require_rolldown_runtime.__toESM(require("preact"));
 
 ```
 ## main.js
 
 ```js
+const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
 require('./lib.js');
-const preact = require("preact");
+const preact = require_rolldown_runtime.__toESM(require("preact"));
 
 Object.defineProperty(exports, 'createContext', {
   enumerable: true,

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4775,10 +4775,10 @@ expression: output
 
 # tests/rolldown/issues/5044
 
-- main-!~{000}~.js => main-D8gvDh02.js
+- main-!~{000}~.js => main-pxuuBVD-.js
 - _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-mwmJao_F.js
 - cube-!~{003}~.js => cube-BCmsXstN.js
-- lib-!~{005}~.js => lib-BPbv7Y41.js
+- lib-!~{005}~.js => lib-BYAeIlLm.js
 
 # tests/rolldown/issues/5139
 

--- a/examples/basic-vue/index.js
+++ b/examples/basic-vue/index.js
@@ -1,3 +1,3 @@
-import { createApp } from 'vue';
+import { createApp } from 'react';
 
 export default createApp({});


### PR DESCRIPTION
Closed https://github.com/rolldown/rolldown/issues/5044