### PR TITLE
test(hmr): support to run mutiple test fixtures

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -83,5 +83,8 @@
     "packages/test-dev-server/tests/fixtures/basic": {
       "entry": ["dev.config.mjs", "src/*.js"], // no @rolldown/test-dev-server plugin
     },
+    "packages/test-dev-server/tests/fixtures/basic2": {
+      "entry": ["dev.config.mjs", "src/*.js"], // no @rolldown/test-dev-server plugin
+    },
   },
 }

--- a/packages/test-dev-server/tests/fixtures/basic2/dev.config.mjs
+++ b/packages/test-dev-server/tests/fixtures/basic2/dev.config.mjs
@@ -1,0 +1,12 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  build: {
+    input: 'src/main.js',
+    experimental: {
+      hmr: true,
+    },
+    platform: 'node',
+    treeshake: false,
+  },
+});

--- a/packages/test-dev-server/tests/fixtures/basic2/package.json
+++ b/packages/test-dev-server/tests/fixtures/basic2/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "basic-hmr",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/fixtures/basic2/src/hmr-boundary.hmr-1.js
+++ b/packages/test-dev-server/tests/fixtures/basic2/src/hmr-boundary.hmr-1.js
@@ -1,0 +1,7 @@
+import { value as depValue } from './new-dep';
+export const value = depValue;
+
+import.meta.hot.accept((newExports) => {
+  globalThis.hmrChange(newExports);
+});
+console.log('HMR boundary file changed');

--- a/packages/test-dev-server/tests/fixtures/basic2/src/hmr-boundary.js
+++ b/packages/test-dev-server/tests/fixtures/basic2/src/hmr-boundary.js
@@ -1,0 +1,5 @@
+export const value = 1;
+
+import.meta.hot.accept((newExports) => {
+  globalThis.hmrChange(newExports);
+});

--- a/packages/test-dev-server/tests/fixtures/basic2/src/main.js
+++ b/packages/test-dev-server/tests/fixtures/basic2/src/main.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert';
+import nodeFs from 'node:fs';
+import { value } from './hmr-boundary';
+
+assert.equal(value, 1);
+
+globalThis.hmrChange = async (exports) => {
+  console.log('HMR change detected');
+  if (exports.value === 2) {
+    nodeFs.writeFileSync('./ok-1', '');
+  }
+  process.exit(0);
+};

--- a/packages/test-dev-server/tests/fixtures/basic2/src/new-dep.js
+++ b/packages/test-dev-server/tests/fixtures/basic2/src/new-dep.js
@@ -1,0 +1,1 @@
+export const value = 2;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,6 +535,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/test-dev-server/tests/fixtures/basic2:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
   packages/testing: {}
 
   packages/vite-tests:


### PR DESCRIPTION
- `basic2` would be replaced to meaningful tests in later PRs.
- We now use it to ensure hmr test infra could run mutiple test cases.