### PR TITLE
perf: reduce runtime symbol memory usage and hashtable lookup

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -2,7 +2,8 @@ use arcstr::ArcStr;
 use itertools::Itertools;
 use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
-  Chunk, ChunkIdx, ChunkModulesOrderBy, ChunkTable, EcmaViewMeta, ModuleIdx, SymbolRef,
+  Chunk, ChunkIdx, ChunkModulesOrderBy, ChunkTable, EcmaViewMeta, ModuleIdx, RuntimeHelper,
+  SymbolRef,
 };
 use rustc_hash::FxHashMap;
 
@@ -43,9 +44,15 @@ impl ChunkGraph {
     idx
   }
 
-  pub fn add_module_to_chunk(&mut self, module_idx: ModuleIdx, chunk_idx: ChunkIdx) {
+  pub fn add_module_to_chunk(
+    &mut self,
+    module_idx: ModuleIdx,
+    chunk_idx: ChunkIdx,
+    depended_runtime_helper: RuntimeHelper,
+  ) {
     self.chunk_table.chunks[chunk_idx].modules.push(module_idx);
     self.module_to_chunk[module_idx] = Some(chunk_idx);
+    self.chunk_table.chunks[chunk_idx].depended_runtime_helper.insert(depended_runtime_helper);
   }
 
   pub fn sort_chunk_modules(&mut self, link_output: &LinkStageOutput, options: &SharedOptions) {

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -133,6 +133,7 @@ pub async fn create_ecma_view(
     directive_range,
     dummy_record_set,
     constant_export_map,
+    depended_runtime_helper: Box::default(),
   };
 
   let ecma_related = EcmaRelated { ast, symbols, dynamic_import_rec_exports_usage };

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -152,6 +152,7 @@ impl RuntimeModuleTask {
         directive_range: vec![],
         dummy_record_set,
         constant_export_map: FxHashMap::default(),
+        depended_runtime_helper: Box::default(),
       },
       css_view: None,
       asset_view: None,

--- a/crates/rolldown/src/stages/generate_stage/advanced_chunks.rs
+++ b/crates/rolldown/src/stages/generate_stage/advanced_chunks.rs
@@ -195,7 +195,11 @@ impl GenerateStage<'_> {
         group.remove_module(runtime_module_idx, &self.link_output.module_table);
       });
       chunk_graph.chunk_table[chunk_idx].bits.union(&index_splitting_info[runtime_module_idx].bits);
-      chunk_graph.add_module_to_chunk(runtime_module_idx, chunk_idx);
+      chunk_graph.add_module_to_chunk(
+        runtime_module_idx,
+        chunk_idx,
+        self.link_output.metas[runtime_module_idx].depended_runtime_helper,
+      );
       module_to_assigned[runtime_module_idx] = true;
     }
 
@@ -327,7 +331,11 @@ impl GenerateStage<'_> {
           group.remove_module(module_idx, &self.link_output.module_table);
         });
         chunk_graph.chunk_table[chunk_idx].bits.union(&index_splitting_info[module_idx].bits);
-        chunk_graph.add_module_to_chunk(module_idx, chunk_idx);
+        chunk_graph.add_module_to_chunk(
+          module_idx,
+          chunk_idx,
+          self.link_output.metas[module_idx].depended_runtime_helper,
+        );
         module_to_assigned[module_idx] = true;
       });
     }

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -9,7 +9,7 @@ use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
   ChunkIdx, ChunkKind, ChunkMeta, CrossChunkImportItem, EntryPointKind, ExportsKind, ImportKind,
   ImportRecordMeta, Module, ModuleIdx, NamedImport, OutputFormat, PreserveEntrySignatures,
-  SymbolRef, WrapKind,
+  RUNTIME_HELPER_NAMES, SymbolRef, WrapKind,
 };
 use rolldown_rstr::{Rstr, ToRstr};
 use rolldown_utils::concat_string;
@@ -284,6 +284,14 @@ impl GenerateStage<'_> {
             depended_symbols.insert(entry.namespace_object_ref);
           }
         }
+
+        // Depending runtime helpers
+        for helper in chunk.depended_runtime_helper {
+          let index = helper.bits().trailing_zeros() as usize;
+          let name = RUNTIME_HELPER_NAMES[index];
+          depended_symbols.insert(self.link_output.runtime.resolve_symbol(name));
+        }
+
         chunk_id_to_symbols_vec.push((chunk_id, symbol_needs_to_assign));
       },
     );

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -90,7 +90,7 @@ impl LinkStage<'_> {
         // real statement to construct the Module Namespace Object and assign it to a variable.
         // This is only a concept of esm, so no need to care about this in commonjs.
         if matches!(ecma_module.exports_kind, ExportsKind::Esm) {
-          let meta = &self.metas[ecma_module.idx];
+          let meta = &mut self.metas[ecma_module.idx];
           let mut referenced_symbols = vec![];
           let mut declared_symbols = vec![];
           if !meta.is_canonical_exports_empty() {

--- a/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
+++ b/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
@@ -6,6 +6,9 @@ use super::LinkStage;
 impl LinkStage<'_> {
   pub(super) fn patch_module_dependencies(&mut self) {
     self.metas.par_iter_mut_enumerated().for_each(|(module_idx, meta)| {
+      if !meta.depended_runtime_helper.is_empty() {
+        meta.dependencies.insert(self.runtime.id());
+      }
       // Symbols from runtime are referenced by bundler not import statements.
       meta.referenced_symbols_by_entry_point_chunk.iter().for_each(
         |(symbol_ref, _came_from_cjs)| {

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -1,7 +1,7 @@
 use oxc_index::IndexVec;
 use rolldown_common::{
   EntryPointKind, ImportRecordIdx, MemberExprRefResolutionMap, ModuleIdx, ResolvedExport,
-  StmtInfoIdx, SymbolRef, WrapKind, dynamic_import_usage::DynamicImportExportsUsage,
+  RuntimeHelper, StmtInfoIdx, SymbolRef, WrapKind, dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_rstr::Rstr;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
@@ -68,6 +68,7 @@ pub struct LinkingMetadata {
   /// tree shaking, when one symbol was linked it may not only link the namespace ref symbol, and
   /// also need to link the exported facade symbol.
   pub included_commonjs_export_symbol: FxHashSet<SymbolRef>,
+  pub depended_runtime_helper: RuntimeHelper,
 }
 
 impl LinkingMetadata {

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -5,8 +5,8 @@ use std::{
 
 use crate::{
   ChunkIdx, ChunkKind, FilenameTemplate, ModuleIdx, ModuleTable, NamedImport, NormalModule,
-  NormalizedBundlerOptions, PreserveEntrySignatures, RollupPreRenderedChunk, SymbolRef,
-  chunk::types::chunk_reason_type::ChunkReasonType,
+  NormalizedBundlerOptions, PreserveEntrySignatures, RollupPreRenderedChunk, RuntimeHelper,
+  SymbolRef, chunk::types::chunk_reason_type::ChunkReasonType,
 };
 pub mod chunk_table;
 pub mod types;
@@ -70,6 +70,7 @@ pub struct Chunk {
   pub create_reasons: Vec<String>,
   pub chunk_reason_type: Box<ChunkReasonType>,
   pub preserve_entry_signature: Option<PreserveEntrySignatures>,
+  pub depended_runtime_helper: RuntimeHelper,
 }
 
 impl Chunk {

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -1,4 +1,4 @@
-use crate::ConstExportMeta;
+use crate::{ConstExportMeta, RUNTIME_HELPER_NAMES, StmtInfoIdx};
 use arcstr::ArcStr;
 use bitflags::bitflags;
 use oxc::{semantic::SymbolId, span::Span};
@@ -97,6 +97,7 @@ pub struct EcmaView {
   /// `Span` of `new URL('path', import.meta.url)` -> `ImportRecordIdx`
   pub new_url_references: FxHashMap<Span, ImportRecordIdx>,
   pub this_expr_replace_map: FxHashMap<Span, ThisExprReplaceKind>,
+  pub depended_runtime_helper: Box<[Vec<StmtInfoIdx>; RUNTIME_HELPER_NAMES.len()]>,
 
   pub hmr_hot_ref: Option<SymbolRef>,
   pub hmr_info: HmrInfo,

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -153,6 +153,7 @@ pub use crate::{
   types::rollup_pre_rendered_asset::RollupPreRenderedAsset,
   types::rollup_pre_rendered_chunk::RollupPreRenderedChunk,
   types::rollup_rendered_chunk::RollupRenderedChunk,
+  types::runtime_helper::{RUNTIME_HELPER_NAMES, RuntimeHelper},
   types::scan_mode::ScanMode,
   types::side_effects,
   types::source_mutation::SourceMutation,

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -42,6 +42,7 @@ pub mod resolved_request_info;
 pub mod rollup_pre_rendered_asset;
 pub mod rollup_pre_rendered_chunk;
 pub mod rollup_rendered_chunk;
+pub mod runtime_helper;
 pub mod scan_mode;
 pub mod side_effects;
 pub mod source_mutation;

--- a/crates/rolldown_common/src/types/runtime_helper.rs
+++ b/crates/rolldown_common/src/types/runtime_helper.rs
@@ -1,0 +1,52 @@
+use bitflags::bitflags;
+
+bitflags! {
+    /// Represents individual utility functions and variables exported from a JavaScript module.
+    /// Each flag corresponds to a distinct export.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+    pub struct RuntimeHelper: u32 { // Using u64 to accommodate a larger number of flags
+        const Create = 1 << 0;
+        const DefProp = 1 << 1;
+        const Name = 1 << 2;
+        const GetOwnPropDesc = 1 << 3;
+        const GetOwnPropNames = 1 << 4;
+        const GetProtoOf = 1 << 5;
+        const HasOwnProp = 1 << 6;
+        const Esm = 1 << 7;
+        const EsmMin = 1 << 8;
+        const CommonJs = 1 << 9;
+        const CommonJsMin = 1 << 10;
+        const Export = 1 << 11;
+        const CopyProps = 1 << 12;
+        const ReExport = 1 << 13;
+        const ToEsm = 1 << 14;
+        const ToCommonJs = 1 << 15;
+        const ToBinaryNode = 1 << 16;
+        const ToBinary = 1 << 17;
+        const ToDynamicImportEsm = 1 << 18;
+        const Require = 1 << 19;
+    }
+}
+
+pub const RUNTIME_HELPER_NAMES: [&str; 20] = [
+  "__create",
+  "__defProp",
+  "__name",
+  "__getOwnPropDesc",
+  "__getOwnPropNames",
+  "__getProtoOf",
+  "__hasOwnProp",
+  "__esm",
+  "__esmMin",
+  "__commonJS",
+  "__commonJSMin",
+  "__export",
+  "__copyProps",
+  "__reExport",
+  "__toESM",
+  "__toCommonJS",
+  "__toBinaryNode",
+  "__toBinary",
+  "__toDynamicImportESM",
+  "__require",
+];


### PR DESCRIPTION
# Benefit
1. Before, each runtime symbol needed 8 bytes, now it only needs 4 bytes(Now we only need to store the StmtInfoIdx)
2. Less hashtable lookup(especially when `strictExecutionOrder` is enabled), before referencing each runtime symbol we need to lookup the real `SymbolRef` according to the `name`, now in the whole linking phase, we just store the `RuntimeHelperKind` and lookup them only once finally.
3. It is more convenient to reference runtime symbol at the chunk level after the linking phase, I will explain more details in the next pr, but even without this benefit, the perf is still good enough.