### PR TITLE
feat: mark all `toESM` as pure

### DIFF
--- a/crates/rolldown/tests/esbuild/dce/import_re_export_of_namespace_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/import_re_export_of_namespace_import/artifacts.snap
@@ -16,7 +16,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "node_modules/pkg/foo.js": ((expo
 
 //#endregion
 //#region node_modules/pkg/index.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js/artifacts.snap
@@ -15,7 +15,7 @@ var require_demo_pkg = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/index
 
 //#endregion
 //#region src/entry.js
-var import_demo_pkg = __toESM(require_demo_pkg());
+var import_demo_pkg = /* @__PURE__ */ __toESM(require_demo_pkg());
 console.log(import_demo_pkg.foo);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js/artifacts.snap
@@ -17,7 +17,7 @@ var require_demo_pkg = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/index
 
 //#endregion
 //#region src/entry.js
-var import_demo_pkg = __toESM(require_demo_pkg());
+var import_demo_pkg = /* @__PURE__ */ __toESM(require_demo_pkg());
 assert.deepEqual(import_demo_pkg, {
 	default: { foo: 123 },
 	foo: 123

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_true_keep_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_true_keep_common_js/artifacts.snap
@@ -14,7 +14,7 @@ var require_demo_pkg = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/index
 
 //#endregion
 //#region src/entry.js
-var import_demo_pkg = __toESM(require_demo_pkg());
+var import_demo_pkg = /* @__PURE__ */ __toESM(require_demo_pkg());
 console.log("unused import");
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/dot_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/dot_import/artifacts.snap
@@ -16,7 +16,7 @@ var require_dot_import = /* @__PURE__ */ __commonJS({ "index.js": ((exports) => 
 
 //#endregion
 //#region entry.js
-var import_dot_import = __toESM(require_dot_import());
+var import_dot_import = /* @__PURE__ */ __toESM(require_dot_import());
 assert.equal(import_dot_import.x, 123);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/dynamic_import_with_template_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/dynamic_import_with_template_iife/artifacts.snap
@@ -14,8 +14,8 @@ var require_b = /* @__PURE__ */ __commonJS({ "b.js": ((exports) => {
 
 //#endregion
 //#region a.js
-Promise.resolve().then(() => __toESM(require_b())).then((ns) => console.log(ns));
-Promise.resolve().then(() => __toESM(require_b())).then((ns) => console.log(ns));
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_b())).then((ns) => console.log(ns));
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_b())).then((ns) => console.log(ns));
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/es6_from_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/es6_from_common_js/artifacts.snap
@@ -26,8 +26,8 @@ var require_bar = /* @__PURE__ */ __commonJS({ "bar.js": ((exports) => {
 
 //#endregion
 //#region entry.js
-var import_foo = __toESM(require_foo());
-var import_bar = __toESM(require_bar());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
+var import_bar = /* @__PURE__ */ __toESM(require_bar());
 assert.equal((0, import_foo.foo)(), "foo");
 assert.equal((0, import_bar.bar)(), "bar");
 

--- a/crates/rolldown/tests/esbuild/default/import_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_missing_common_js/artifacts.snap
@@ -14,7 +14,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region entry.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 console.log((0, import_foo.default)(import_foo.x, import_foo.y));
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/jsx_automatic_imports_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/jsx_automatic_imports_common_js/artifacts.snap
@@ -24,7 +24,7 @@ var require_custom_react = /* @__PURE__ */ __commonJS({ "custom-react.js": ((exp
 
 //#endregion
 //#region entry.jsx
-var import_custom_react = __toESM(require_custom_react());
+var import_custom_react = /* @__PURE__ */ __toESM(require_custom_react());
 console.log(/* @__PURE__ */ jsx("div", { jsx: import_custom_react.jsx }), /* @__PURE__ */ jsx(Fragment, { children: /* @__PURE__ */ jsx(import_custom_react.Fragment, {}) }));
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/jsx_imports_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/jsx_imports_common_js/artifacts.snap
@@ -14,7 +14,7 @@ var require_custom_react = /* @__PURE__ */ __commonJS({ "custom-react.js": ((exp
 
 //#endregion
 //#region entry.jsx
-var import_custom_react = __toESM(require_custom_react());
+var import_custom_react = /* @__PURE__ */ __toESM(require_custom_react());
 console.log(/* @__PURE__ */ (0, import_custom_react.elem)("div", null), /* @__PURE__ */ (0, import_custom_react.elem)(import_custom_react.frag, null, "fragment"));
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
@@ -47,8 +47,8 @@ import { __toESM, esm_foo_, init_esm, require_cjs } from "./cjs.js";
 
 //#region entry-esm.js
 init_esm();
-var import_cjs = __toESM(require_cjs());
-var import_cjs$1 = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
+var import_cjs$1 = /* @__PURE__ */ __toESM(require_cjs());
 let bar_ = [
 	esm_foo_,
 	import_cjs.cjs_foo_,

--- a/crates/rolldown/tests/esbuild/default/nested_es6_from_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/nested_es6_from_common_js/artifacts.snap
@@ -18,7 +18,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region entry.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 assert.equal((0, import_foo.fn)(), 123);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/node_modules/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/node_modules/artifacts.snap
@@ -16,7 +16,7 @@ var require_demo_pkg = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/index
 
 //#endregion
 //#region src/entry.js
-var import_demo_pkg = __toESM(require_demo_pkg());
+var import_demo_pkg = /* @__PURE__ */ __toESM(require_demo_pkg());
 console.log((0, import_demo_pkg.default)());
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/re_export_common_js_as_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/re_export_common_js_as_es6/artifacts.snap
@@ -14,7 +14,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region entry.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 
 //#endregion
 var bar = import_foo.bar;

--- a/crates/rolldown/tests/esbuild/default/top_level_await_allowed_import_without_splitting/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_allowed_import_without_splitting/artifacts.snap
@@ -17,7 +17,7 @@ var require_c = /* @__PURE__ */ __commonJS({ "c.js": (() => {
 var b_exports = {};
 var import_c;
 var init_b = __esm({ "b.js": (async () => {
-	import_c = __toESM(require_c());
+	import_c = /* @__PURE__ */ __toESM(require_c());
 }) });
 
 //#endregion
@@ -32,8 +32,8 @@ var init_a = __esm({ "a.js": (async () => {
 var require_entry = /* @__PURE__ */ __commonJS({ "entry.js": (() => {
 	init_a().then(() => a_exports);
 	init_b().then(() => b_exports);
-	Promise.resolve().then(() => __toESM(require_c()));
-	Promise.resolve().then(() => __toESM(require_entry()));
+	Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_c()));
+	Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_entry()));
 	await 0;
 }) });
 

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
@@ -17,7 +17,7 @@ var require_c = /* @__PURE__ */ __commonJS({ "c.js": (() => {
 var b_exports = {};
 var import_c;
 var init_b = __esm({ "b.js": (async () => {
-	import_c = __toESM(require_c());
+	import_c = /* @__PURE__ */ __toESM(require_c());
 }) });
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/artifacts.snap
@@ -15,7 +15,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region entry.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 
 //#endregion
 Object.defineProperty(exports, 'ns', {

--- a/crates/rolldown/tests/esbuild/importstar/export_other_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_common_js/artifacts.snap
@@ -15,7 +15,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region entry.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 
 //#endregion
 Object.defineProperty(exports, 'bar', {

--- a/crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/artifacts.snap
@@ -15,7 +15,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region bar.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 
 //#endregion
 Object.defineProperty(exports, 'y', {

--- a/crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/artifacts.snap
@@ -15,7 +15,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region entry.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 
 //#endregion
 Object.defineProperty(exports, 'ns', {

--- a/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_empty_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_empty_file/artifacts.snap
@@ -69,7 +69,7 @@ export { __toESM, require_empty };
 import { __toESM, require_empty } from "./empty.js";
 
 //#region entry-default.js
-var import_empty = __toESM(require_empty());
+var import_empty = /* @__PURE__ */ __toESM(require_empty());
 console.log(void 0, void 0, import_empty.default);
 
 //#endregion
@@ -80,7 +80,7 @@ console.log(void 0, void 0, import_empty.default);
 import { __toESM, require_empty } from "./empty.js";
 
 //#region entry-nope.js
-var import_empty = __toESM(require_empty());
+var import_empty = /* @__PURE__ */ __toESM(require_empty());
 console.log(void 0, void 0, import_empty.nope);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_side_effect_free_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_side_effect_free_file/artifacts.snap
@@ -59,7 +59,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import { __toESM, require_no_side_effects } from "./no-side-effects.js";
 
 //#region entry-default.js
-var import_no_side_effects = __toESM(require_no_side_effects());
+var import_no_side_effects = /* @__PURE__ */ __toESM(require_no_side_effects());
 console.log(void 0, void 0, import_no_side_effects.default);
 
 //#endregion
@@ -70,7 +70,7 @@ console.log(void 0, void 0, import_no_side_effects.default);
 import { __toESM, require_no_side_effects } from "./no-side-effects.js";
 
 //#region entry-nope.js
-var import_no_side_effects = __toESM(require_no_side_effects());
+var import_no_side_effects = /* @__PURE__ */ __toESM(require_no_side_effects());
 console.log(void 0, void 0, import_no_side_effects.nope);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_self_common_js/artifacts.snap
@@ -11,7 +11,7 @@ const node_assert = __toESM(require("node:assert"));
 
 //#region entry.js
 var require_entry = /* @__PURE__ */ __commonJS({ "entry.js": ((exports) => {
-	var import_entry = __toESM(require_entry());
+	var import_entry = /* @__PURE__ */ __toESM(require_entry());
 	exports.foo = 123;
 	node_assert.default.equal(import_entry.foo, void 0);
 }) });

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_capture/artifacts.snap
@@ -16,7 +16,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region entry.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 let foo = 234;
 assert.deepEqual(import_foo, {
 	default: { foo: 123 },

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/artifacts.snap
@@ -16,7 +16,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region entry.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 let foo = 234;
 node_assert.default.equal(import_foo.foo, 123);
 node_assert.default.equal(import_foo.foo, 123);

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_common_js/artifacts.snap
@@ -16,7 +16,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region entry.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 assert.deepEqual(import_foo, {
 	default: { x: 123 },
 	x: 123

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_unused_missing_common_js/artifacts.snap
@@ -16,7 +16,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region entry.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 assert.equal(import_foo.foo, void 0);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_common_js_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_common_js_capture/artifacts.snap
@@ -14,7 +14,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.ts": ((exports) => {
 
 //#endregion
 //#region entry.ts
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 let foo = 234;
 console.log(import_foo, import_foo.foo, foo);
 

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_common_js_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_common_js_no_capture/artifacts.snap
@@ -14,7 +14,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.ts": ((exports) => {
 
 //#endregion
 //#region entry.ts
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 let foo = 234;
 console.log(import_foo.foo, import_foo.foo, foo);
 

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_bad_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_bad_main/artifacts.snap
@@ -18,7 +18,7 @@ var require_demo_pkg = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/index
 
 //#endregion
 //#region src/entry.js
-var import_demo_pkg = __toESM(require_demo_pkg());
+var import_demo_pkg = /* @__PURE__ */ __toESM(require_demo_pkg());
 assert.equal((0, import_demo_pkg.default)(), 123);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_disabled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_disabled/artifacts.snap
@@ -23,7 +23,7 @@ var require_demo_pkg = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/index
 
 //#endregion
 //#region src/entry.js
-var import_demo_pkg = __toESM(require_demo_pkg());
+var import_demo_pkg = /* @__PURE__ */ __toESM(require_demo_pkg());
 assert.equal((0, import_demo_pkg.default)(), 234);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_to_module/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_to_module/artifacts.snap
@@ -27,7 +27,7 @@ var require_demo_pkg = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/index
 
 //#endregion
 //#region src/entry.js
-var import_demo_pkg = __toESM(require_demo_pkg());
+var import_demo_pkg = /* @__PURE__ */ __toESM(require_demo_pkg());
 assert.equal((0, import_demo_pkg.default)(), 123);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_to_relative/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_module_to_relative/artifacts.snap
@@ -27,7 +27,7 @@ var require_demo_pkg = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/index
 
 //#endregion
 //#region src/entry.js
-var import_demo_pkg = __toESM(require_demo_pkg());
+var import_demo_pkg = /* @__PURE__ */ __toESM(require_demo_pkg());
 assert.equal((0, import_demo_pkg.default)(), 123);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_native_module_disabled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_native_module_disabled/artifacts.snap
@@ -21,7 +21,7 @@ var require_demo_pkg = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/index
 
 //#endregion
 //#region src/entry.js
-var import_demo_pkg = __toESM(require_demo_pkg());
+var import_demo_pkg = /* @__PURE__ */ __toESM(require_demo_pkg());
 console.log((0, import_demo_pkg.default)());
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_disabled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_disabled/artifacts.snap
@@ -23,7 +23,7 @@ var require_main = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/main.js":
 
 //#endregion
 //#region src/entry.js
-var import_main = __toESM(require_main());
+var import_main = /* @__PURE__ */ __toESM(require_main());
 assert.deepEqual((0, import_main.default)(), {});
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_module/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_module/artifacts.snap
@@ -25,7 +25,7 @@ var require_main = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/main.js":
 
 //#endregion
 //#region src/entry.js
-var import_main = __toESM(require_main());
+var import_main = /* @__PURE__ */ __toESM(require_main());
 assert.deepEqual((0, import_main.default)(), ["main", "util-browser"]);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_relative/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_map_relative_to_relative/artifacts.snap
@@ -25,7 +25,7 @@ var require_main_browser = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/m
 
 //#endregion
 //#region src/entry.js
-var import_main_browser = __toESM(require_main_browser());
+var import_main_browser = /* @__PURE__ */ __toESM(require_main_browser());
 assert.deepEqual((0, import_main_browser.default)(), ["main-browser", "util-browser"]);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_over_main_node/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_over_main_node/artifacts.snap
@@ -18,7 +18,7 @@ var require_main = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/main.js":
 
 //#endregion
 //#region src/entry.js
-var import_main = __toESM(require_main());
+var import_main = /* @__PURE__ */ __toESM(require_main());
 assert.equal((0, import_main.default)(), 123);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_over_module_browser/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_over_module_browser/artifacts.snap
@@ -18,7 +18,7 @@ var require_main_browser = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/m
 
 //#endregion
 //#region src/entry.js
-var import_main_browser = __toESM(require_main_browser());
+var import_main_browser = /* @__PURE__ */ __toESM(require_main_browser());
 assert.equal((0, import_main_browser.default)(), 123);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_string/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_string/artifacts.snap
@@ -18,7 +18,7 @@ var require_browser = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/browse
 
 //#endregion
 //#region src/entry.js
-var import_browser = __toESM(require_browser());
+var import_browser = /* @__PURE__ */ __toESM(require_browser());
 assert.equal((0, import_browser.default)(), 123);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_with_main_node/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_with_main_node/artifacts.snap
@@ -18,7 +18,7 @@ var require_main = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/main.js":
 
 //#endregion
 //#region src/entry.js
-var import_main = __toESM(require_main());
+var import_main = /* @__PURE__ */ __toESM(require_main());
 assert.equal((0, import_main.default)(), 123);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_main/artifacts.snap
@@ -18,7 +18,7 @@ var require_custom_main = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/cu
 
 //#endregion
 //#region src/entry.js
-var import_custom_main = __toESM(require_custom_main());
+var import_custom_main = /* @__PURE__ */ __toESM(require_custom_main());
 assert.equal((0, import_custom_main.default)(), 123);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_main_fields_a/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_main_fields_a/artifacts.snap
@@ -16,7 +16,7 @@ var require_a = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/a.js": ((exp
 
 //#endregion
 //#region src/entry.js
-var import_a = __toESM(require_a());
+var import_a = /* @__PURE__ */ __toESM(require_a());
 assert.equal(import_a.default, "a");
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_neutral_explicit_main_fields/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_neutral_explicit_main_fields/artifacts.snap
@@ -18,7 +18,7 @@ var require_main = /* @__PURE__ */ __commonJS({ "node_modules/demo-pkg/main.js":
 
 //#endregion
 //#region src/entry.js
-var import_main = __toESM(require_main());
+var import_main = /* @__PURE__ */ __toESM(require_main());
 assert.equal((0, import_main.default)(), 123);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import { __toDynamicImportESM, __toESM, require_foo } from "./foo.js";
 
 //#region entry.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 import("./foo2.js").then(__toDynamicImportESM()).then(({ default: { bar: b } }) => console.log(import_foo.bar, b));
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/ts/ts_export_equals/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_equals/artifacts.snap
@@ -15,7 +15,7 @@ var require_b = /* @__PURE__ */ __commonJS({ "b.ts": ((exports, module) => {
 
 //#endregion
 //#region a.ts
-var import_b = __toESM(require_b());
+var import_b = /* @__PURE__ */ __toESM(require_b());
 console.log(import_b.default);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
@@ -37,7 +37,7 @@ var require_commonjs$1 = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports, 
 
 //#endregion
 //#region main.js
-var import_commonjs = __toESM(require_commonjs$1());
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs$1());
 init_esm();
 console.log(import_commonjs.default, esm_default_fn, esm_named_var, esm_named_fn, esm_named_class);
 const require_commonjs = () => {};

--- a/crates/rolldown/tests/rolldown/cjs_compat/exoprt_star_of_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/exoprt_star_of_cjs/artifacts.snap
@@ -15,7 +15,7 @@ var require_c = /* @__PURE__ */ __commonJS({ "c.js": ((exports) => {
 //#endregion
 //#region b.js
 var b_exports = {};
-__reExport(b_exports, __toESM(require_c()));
+__reExport(b_exports, /* @__PURE__ */ __toESM(require_c()));
 
 //#endregion
 //#region a.js

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as/artifacts.snap
@@ -16,7 +16,7 @@ var require_commonjs = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports) =>
 
 //#endregion
 //#region main.js
-var import_commonjs = __toESM(require_commonjs());
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 assert.deepEqual(import_commonjs, {
 	default: { a: 1 },
 	a: 1

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import/artifacts.snap
@@ -16,7 +16,7 @@ var require_commonjs = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports) =>
 
 //#endregion
 //#region main.js
-var import_commonjs = __toESM(require_commonjs());
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 assert.equal(import_commonjs.a, 1);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import/artifacts.snap
@@ -17,7 +17,7 @@ var require_commonjs = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports) =>
 //#endregion
 //#region proxy.js
 var proxy_exports = {};
-__reExport(proxy_exports, __toESM(require_commonjs()));
+__reExport(proxy_exports, /* @__PURE__ */ __toESM(require_commonjs()));
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import/artifacts.snap
@@ -23,8 +23,8 @@ var require_commonjs2 = /* @__PURE__ */ __commonJS({ "commonjs2.js": ((exports) 
 //#endregion
 //#region proxy.js
 var proxy_exports = {};
-__reExport(proxy_exports, __toESM(require_commonjs()));
-__reExport(proxy_exports, __toESM(require_commonjs2()));
+__reExport(proxy_exports, /* @__PURE__ */ __toESM(require_commonjs()));
+__reExport(proxy_exports, /* @__PURE__ */ __toESM(require_commonjs2()));
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default/artifacts.snap
@@ -14,7 +14,7 @@ var require_commonjs = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports, mo
 
 //#endregion
 //#region main.js
-var import_commonjs = __toESM(require_commonjs());
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 
 //#endregion
 var commonjs_default = import_commonjs.default;

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport/artifacts.snap
@@ -14,7 +14,7 @@ var require_commonjs = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports) =>
 
 //#endregion
 //#region main.js
-var import_commonjs = __toESM(require_commonjs());
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 
 //#endregion
 var a = import_commonjs.a;

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_the_same_cjs_twice/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_the_same_cjs_twice/artifacts.snap
@@ -14,8 +14,8 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region main.js
-var import_cjs = __toESM(require_cjs());
-var import_cjs$1 = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
+var import_cjs$1 = /* @__PURE__ */ __toESM(require_cjs());
 
 //#endregion
 var a = import_cjs.a;

--- a/crates/rolldown/tests/rolldown/cjs_compat/issue_3364/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/issue_3364/artifacts.snap
@@ -30,7 +30,7 @@ var require_commonjs = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports, mo
 
 //#endregion
 //#region main.js
-var import_commonjs = __toESM(require_commonjs());
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 assert.equal(import_commonjs.default.call({}, 1, 2), 3);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
@@ -51,13 +51,13 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region esm-import-cjs-require.js
-var import_cjs = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 require_foo();
 assert.equal(import_cjs.a, void 0);
 
 //#endregion
 //#region main.js
-var import_esm_import_cjs_export = __toESM(require_esm_import_cjs_export());
+var import_esm_import_cjs_export = /* @__PURE__ */ __toESM(require_esm_import_cjs_export());
 
 //#endregion
 //# sourceMappingURL=main.js.map

--- a/crates/rolldown/tests/rolldown/cjs_compat/multiple_circle_cjs_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/multiple_circle_cjs_entries/artifacts.snap
@@ -17,14 +17,14 @@ export default require_a();
 // HIDDEN [rolldown:runtime]
 //#region b.js
 var require_b = /* @__PURE__ */ __commonJS({ "b.js": ((exports, module) => {
-	var import_a = __toESM(require_a());
+	var import_a = /* @__PURE__ */ __toESM(require_a());
 	module.exports = "b";
 }) });
 
 //#endregion
 //#region a.js
 var require_a = /* @__PURE__ */ __commonJS({ "a.js": ((exports, module) => {
-	var import_b = __toESM(require_b());
+	var import_b = /* @__PURE__ */ __toESM(require_b());
 	module.exports = "a";
 }) });
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/node_module_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/node_module_commonjs/artifacts.snap
@@ -21,7 +21,7 @@ export { __reExport, __toESM, require_commonjs };
 import { __toESM, require_commonjs } from "./commonjs.js";
 
 //#region entry.js
-var import_commonjs = __toESM(require_commonjs(), 1);
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs(), 1);
 console.log(import_commonjs.default);
 
 //#endregion
@@ -33,11 +33,11 @@ import { __reExport, __toESM, require_commonjs } from "./commonjs.js";
 
 //#region star-export.js
 var star_export_exports = {};
-__reExport(star_export_exports, __toESM(require_commonjs(), 1));
+__reExport(star_export_exports, /* @__PURE__ */ __toESM(require_commonjs(), 1));
 
 //#endregion
 //#region main.mjs
-var import_commonjs = __toESM(require_commonjs(), 1);
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs(), 1);
 console.log(import_commonjs.default, star_export_exports);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
@@ -31,7 +31,7 @@ var require_commonjs = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports) =>
 
 //#endregion
 //#region main.js
-var import_commonjs = __toESM(require_commonjs());
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 assert.deepEqual(import_commonjs.default.slice(1), [2, 3], "should import JSON file as expected");
 assert.equal(import_commonjs.foo, 1);
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout2/artifacts.snap
@@ -19,7 +19,7 @@ var require_commonjs = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports, mo
 
 //#endregion
 //#region main.js
-var import_commonjs = __toESM(require_commonjs());
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 assert.equal(import_commonjs.default.foo, 1);
 assert.equal(import_commonjs.default.bar, 2);
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_none_default_ns_property_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_none_default_ns_property_name/artifacts.snap
@@ -23,7 +23,7 @@ var refactor_default = (a) => a;
 
 //#endregion
 //#region main.js
-var import_commonjs = __toESM(require_commonjs());
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 import_commonjs.ObjectElement.refract = refactor_default(import_commonjs.ObjectElement);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge/artifacts.snap
@@ -14,15 +14,15 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region a.js
-var import_cjs$2 = __toESM(require_cjs());
+var import_cjs$2 = /* @__PURE__ */ __toESM(require_cjs());
 function test() {
 	return import_cjs$2.default;
 }
 
 //#endregion
 //#region b.js
-var import_cjs = __toESM(require_cjs());
-var import_cjs$1 = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
+var import_cjs$1 = /* @__PURE__ */ __toESM(require_cjs());
 function test$1() {
 	console.log(import_cjs$1.default);
 	return import_cjs.default;

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
@@ -22,7 +22,7 @@ function toArray$1(children) {
 }
 var import_react$1;
 var init_lib = __esm({ "lib.js": (() => {
-	import_react$1 = __toESM(require_react());
+	import_react$1 = /* @__PURE__ */ __toESM(require_react());
 }) });
 
 //#endregion
@@ -34,8 +34,8 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region main.js
-var import_react = __toESM(require_react());
-var import_cjs = __toESM(require_cjs());
+var import_react = /* @__PURE__ */ __toESM(require_react());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 console.log("r", import_react, Typography, import_cjs.default);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize/artifacts.snap
@@ -22,8 +22,8 @@ var require_util = /* @__PURE__ */ __commonJS({ "util.js": ((exports, module) =>
 
 //#endregion
 //#region a.js
-var import_cjs = __toESM(require_cjs());
-var import_util = __toESM(require_util());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
+var import_util = /* @__PURE__ */ __toESM(require_util());
 function test() {
 	(0, import_util.default)();
 	return import_cjs.default;

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize_chunk_split/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize_chunk_split/artifacts.snap
@@ -14,7 +14,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region a.js
-var import_cjs = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 function test() {
 	return import_cjs.default;
 }
@@ -39,7 +39,7 @@ export { entry };
 import { __toESM, require_cjs, test } from "./a.js";
 
 //#region b.js
-var import_cjs = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 function test$1() {
 	return import_cjs.default;
 }

--- a/crates/rolldown/tests/rolldown/cjs_compat/react-like/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/react-like/artifacts.snap
@@ -31,8 +31,8 @@ var require_commonjs2 = /* @__PURE__ */ __commonJS({ "commonjs2.js": ((exports, 
 
 //#endregion
 //#region main.js
-var import_commonjs = __toESM(require_commonjs());
-var import_commonjs2 = __toESM(require_commonjs2());
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
+var import_commonjs2 = /* @__PURE__ */ __toESM(require_commonjs2());
 assert.equal(import_commonjs.createReactElement(), "div");
 assert.equal(import_commonjs.version.toString(), "1");
 assert.equal(import_commonjs2.version.toString(), "1");

--- a/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
@@ -25,12 +25,12 @@ __export(foo_exports, {
 	bar: () => import_commonjs$1.bar,
 	value: () => value
 });
-__reExport(foo_exports, __toESM(require_commonjs()));
-var import_commonjs$1 = __toESM(require_commonjs());
+__reExport(foo_exports, /* @__PURE__ */ __toESM(require_commonjs()));
+var import_commonjs$1 = /* @__PURE__ */ __toESM(require_commonjs());
 
 //#endregion
 //#region main.js
-var import_commonjs = __toESM(require_commonjs());
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 assert.equal(import_commonjs$1.bar, 1);
 assert.equal(value, 1);
 assert.equal(foo_exports.foo, void 0);

--- a/crates/rolldown/tests/rolldown/cjs_compat/reexports_from_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/reexports_from_cjs/artifacts.snap
@@ -17,8 +17,8 @@ var require_commonjs = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports, mo
 //#endregion
 //#region reexports.mjs
 var reexports_exports = {};
-var import_commonjs = __toESM(require_commonjs(), 1);
-__reExport(reexports_exports, __toESM(require_commonjs(), 1));
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs(), 1);
+__reExport(reexports_exports, /* @__PURE__ */ __toESM(require_commonjs(), 1));
 assert.equal(import_commonjs.bar, 1);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/unnecessary_compat_default_property_access/artifacts.snap
@@ -43,11 +43,11 @@ var require_commonjs_without_module_exports = /* @__PURE__ */ __commonJS({ "comm
 
 //#endregion
 //#region main.js
-var import_cjs_esmodule_flag1 = __toESM(require_cjs_esmodule_flag1());
-var import_cjs_esmodule_flag2 = __toESM(require_cjs_esmodule_flag2());
-var import_cjs_esmodule_flag3 = __toESM(require_cjs_esmodule_flag3());
-var import_cjs_esmodule_flag4 = __toESM(require_cjs_esmodule_flag4());
-var import_commonjs_without_module_exports = __toESM(require_commonjs_without_module_exports());
+var import_cjs_esmodule_flag1 = /* @__PURE__ */ __toESM(require_cjs_esmodule_flag1());
+var import_cjs_esmodule_flag2 = /* @__PURE__ */ __toESM(require_cjs_esmodule_flag2());
+var import_cjs_esmodule_flag3 = /* @__PURE__ */ __toESM(require_cjs_esmodule_flag3());
+var import_cjs_esmodule_flag4 = /* @__PURE__ */ __toESM(require_cjs_esmodule_flag4());
+var import_commonjs_without_module_exports = /* @__PURE__ */ __toESM(require_commonjs_without_module_exports());
 console.log(import_cjs_esmodule_flag1.default, import_cjs_esmodule_flag2.default, import_cjs_esmodule_flag3.default, import_cjs_esmodule_flag4.default, import_commonjs_without_module_exports.default);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_module_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_module_cjs/artifacts.snap
@@ -10,7 +10,7 @@ const require_share$1 = require('./share.js');
 const node_assert = require_share$1.__toESM(require("node:assert"));
 
 //#region main1.js
-var import_share = require_share$1.__toESM(require_share$1.require_share());
+var import_share = /* @__PURE__ */ require_share$1.__toESM(require_share$1.require_share());
 node_assert.default.equal((0, import_share.share)(), 1);
 
 //#endregion
@@ -22,7 +22,7 @@ const require_share$1 = require('./share.js');
 const node_assert = require_share$1.__toESM(require("node:assert"));
 
 //#region main2.js
-var import_share = require_share$1.__toESM(require_share$1.require_share());
+var import_share = /* @__PURE__ */ require_share$1.__toESM(require_share$1.require_share());
 node_assert.default.equal((0, import_share.share)(), 1);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
@@ -23,7 +23,7 @@ var require_lib = /* @__PURE__ */ __commonJS({ "lib.js": ((exports, module) => {
 
 //#endregion
 //#region main.js
-var import_lib = __toESM(require_lib());
+var import_lib = /* @__PURE__ */ __toESM(require_lib());
 
 //#endregion
 var lib = import_lib.default;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
@@ -23,7 +23,7 @@ var main_exports = {};
 var import_foo, main_hot;
 var init_main = __esm({ "main.js": (() => {
 	init_rolldown_hmr();
-	import_foo = __toESM(require_foo());
+	import_foo = /* @__PURE__ */ __toESM(require_foo());
 	main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 	__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 	nodeAssert.strictEqual(import_foo.value, "foo");

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
@@ -24,7 +24,7 @@ var init_dep_b = __esm({ "dep-b.js": (() => {
 //#region main.js
 var import_dep_a;
 var init_main = __esm({ "main.js": (() => {
-	import_dep_a = __toESM(require_dep_a());
+	import_dep_a = /* @__PURE__ */ __toESM(require_dep_a());
 	init_dep_b();
 }) });
 
@@ -58,7 +58,7 @@ var init_dep_b = __esm({ "dep-b.js": (() => {
 //#region main.js
 var import_dep_a;
 var init_main = __esm({ "main.js": (() => {
-	import_dep_a = __toESM(require_dep_a());
+	import_dep_a = /* @__PURE__ */ __toESM(require_dep_a());
 	init_dep_b();
 }) });
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/artifacts.snap
@@ -39,7 +39,7 @@ var init_sideeffects = __esm({ "sideeffects.js": (() => {
 //#region esm.js
 var import_dynamic, a;
 var init_esm = __esm({ "esm.js": (() => {
-	import_dynamic = __toESM(require_dynamic());
+	import_dynamic = /* @__PURE__ */ __toESM(require_dynamic());
 	init_sideeffects();
 	a = globalThis.a;
 	strictEqual(a, 2);

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
@@ -28,8 +28,8 @@ var init_esm = __esm({ "esm.js": (() => {
 
 //#endregion
 //#region main.js
-Promise.resolve().then(() => __toESM(require_foo()));
-Promise.resolve().then(() => __toESM(require_cjs()));
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_foo()));
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs()));
 Promise.resolve().then(() => (init_esm(), esm_exports));
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
@@ -27,8 +27,8 @@ var init_esm = __esm({ "esm.js": (() => {
 
 //#endregion
 //#region main.js
-Promise.resolve().then(() => __toESM(require_foo()));
-Promise.resolve().then(() => __toESM(require_cjs()));
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_foo()));
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs()));
 Promise.resolve().then(() => (init_esm(), esm_exports));
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
@@ -30,8 +30,8 @@ var init_esm = __esm({ "esm.js": (() => {
 
 //#endregion
 //#region main.js
-Promise.resolve().then(() => __toESM(require_foo()));
-Promise.resolve().then(() => __toESM(require_cjs()));
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_foo()));
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs()));
 Promise.resolve().then(() => (init_esm(), esm_exports));
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/module_types/json/correct_semantic_of_import_and_require/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/json/correct_semantic_of_import_and_require/artifacts.snap
@@ -16,7 +16,7 @@ var require_codes = /* @__PURE__ */ __commonJS({ "codes.json": ((exports, module
 
 //#endregion
 //#region main.js
-var import_codes = __toESM(require_codes());
+var import_codes = /* @__PURE__ */ __toESM(require_codes());
 const codes2 = require_codes();
 assert.strictEqual(import_codes.default, codes2);
 

--- a/crates/rolldown/tests/rolldown/issues/1722/1/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/1722/1/artifacts.snap
@@ -30,7 +30,7 @@ var require_sub = /* @__PURE__ */ __commonJS({ "sub.cjs": ((exports, module) => 
 
 //#endregion
 //#region main.js
-var import_sub = __toESM(require_sub());
+var import_sub = /* @__PURE__ */ __toESM(require_sub());
 const main = "main";
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/1722/2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/1722/2/artifacts.snap
@@ -30,7 +30,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports, module) => {
 
 //#endregion
 //#region main.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 
 //#endregion
 export { import_foo };

--- a/crates/rolldown/tests/rolldown/issues/2038/b/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2038/b/artifacts.snap
@@ -26,7 +26,7 @@ var require_c = /* @__PURE__ */ __commonJS({ "c.js": ((exports) => {
 
 //#endregion
 //#region b.js
-var import_c = __toESM(require_c());
+var import_c = /* @__PURE__ */ __toESM(require_c());
 
 //#endregion
 export { import_c };

--- a/crates/rolldown/tests/rolldown/issues/2085/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2085/artifacts.snap
@@ -16,7 +16,7 @@ var require_b = /* @__PURE__ */ __commonJS({ "b.js": ((exports) => {
 
 //#endregion
 //#region a.js
-var import_b = __toESM(require_b());
+var import_b = /* @__PURE__ */ __toESM(require_b());
 
 //#endregion
 export { import_b };

--- a/crates/rolldown/tests/rolldown/issues/2903_4/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2903_4/artifacts.snap
@@ -33,7 +33,7 @@ var require_cjs_dep = /* @__PURE__ */ require_chunk.__commonJS({ "cjs-dep.js": (
 
 //#endregion
 //#region main.js
-var import_cjs_dep = require_chunk.__toESM(require_cjs_dep());
+var import_cjs_dep = /* @__PURE__ */ require_chunk.__toESM(require_cjs_dep());
 
 //#endregion
 ```
@@ -49,7 +49,7 @@ var require_cjs_dep2 = /* @__PURE__ */ require_chunk.__commonJS({ "cjs-dep2.js":
 
 //#endregion
 //#region main2.js
-var import_cjs_dep2 = require_chunk.__toESM(require_cjs_dep2());
+var import_cjs_dep2 = /* @__PURE__ */ require_chunk.__toESM(require_cjs_dep2());
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/issues/3367/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3367/artifacts.snap
@@ -14,7 +14,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports, module) => {
 
 //#endregion
 //#region main.mjs
-var import_foo = __toESM(require_foo(), 1);
+var import_foo = /* @__PURE__ */ __toESM(require_foo(), 1);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/issues/3529/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3529/artifacts.snap
@@ -28,8 +28,8 @@ var require_a = /* @__PURE__ */ __commonJS({ "a.cjs": ((exports, module) => {
 
 //#endregion
 //#region main.mjs
-var import_a = __toESM(require_a(), 1);
-var import_b = __toESM(require_b(), 1);
+var import_a = /* @__PURE__ */ __toESM(require_a(), 1);
+var import_b = /* @__PURE__ */ __toESM(require_b(), 1);
 console.log({
 	a: import_a.default,
 	b: import_b.default

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -20,7 +20,7 @@ var require_lib = /* @__PURE__ */ __commonJS({ "lib.js": ((exports, module) => {
 //#endregion
 //#region main.js
 var main_exports = {};
-var import_lib = __toESM(require_lib());
+var import_lib = /* @__PURE__ */ __toESM(require_lib());
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 assert.strictEqual(import_lib.a, 1);

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -64,7 +64,7 @@ var require_node_mode_by_cjs_extension = /* @__PURE__ */ __commonJS({ "node-mode
 
 //#endregion
 //#region main.js
-var import_node_mode_by_cjs_extension = __toESM(require_node_mode_by_cjs_extension());
+var import_node_mode_by_cjs_extension = /* @__PURE__ */ __toESM(require_node_mode_by_cjs_extension());
 
 //#endregion
 ```
@@ -157,7 +157,7 @@ var require_node_mode_by_cjs_extension = /* @__PURE__ */ require_chunk.__commonJ
 
 //#endregion
 //#region main.js
-var import_node_mode_by_cjs_extension = require_chunk.__toESM(require_node_mode_by_cjs_extension());
+var import_node_mode_by_cjs_extension = /* @__PURE__ */ require_chunk.__toESM(require_node_mode_by_cjs_extension());
 
 //#endregion
 ```
@@ -182,7 +182,7 @@ var require_lib = /* @__PURE__ */ __commonJS({ "lib.js": ((exports) => {
 //#endregion
 //#region non-node-mode.js
 async function main$2() {
-	const exports$1 = await Promise.resolve().then(() => __toESM(require_lib()));
+	const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_lib()));
 	nodeAssert.deepEqual(Object.keys(exports$1).sort(), ["parse"]);
 	nodeAssert.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 	nodeAssert.strictEqual(exports$1.default, void 0, "Target has __esModule, so no auto-generated default export");
@@ -192,7 +192,7 @@ main$2();
 //#endregion
 //#region node-mode-by-mjs-extension.mjs
 async function main$1() {
-	const exports$1 = await Promise.resolve().then(() => __toESM(require_lib(), 1));
+	const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_lib(), 1));
 	nodeAssert.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
 	nodeAssert.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 	nodeAssert.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
@@ -203,7 +203,7 @@ main$1();
 //#region node-mode-by-cjs-extension.cjs
 var require_node_mode_by_cjs_extension = /* @__PURE__ */ __commonJS({ "node-mode-by-cjs-extension.cjs": ((exports, module) => {
 	async function main() {
-		const exports$1 = await Promise.resolve().then(() => __toESM(require_lib(), 1));
+		const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_lib(), 1));
 		nodeAssert.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
 		nodeAssert.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 		nodeAssert.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
@@ -214,7 +214,7 @@ var require_node_mode_by_cjs_extension = /* @__PURE__ */ __commonJS({ "node-mode
 
 //#endregion
 //#region main.js
-var import_node_mode_by_cjs_extension = __toESM(require_node_mode_by_cjs_extension());
+var import_node_mode_by_cjs_extension = /* @__PURE__ */ __toESM(require_node_mode_by_cjs_extension());
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/issues/4443/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4443/artifacts.snap
@@ -17,7 +17,7 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 
 //#endregion
 //#region main.js
-var import_foo = __toESM(require_foo());
+var import_foo = /* @__PURE__ */ __toESM(require_foo());
 assert.strictEqual(globalThis.value, "foo", "globalThis.value should be \"foo\"");
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/5209/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5209/artifacts.snap
@@ -19,7 +19,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports) => {
 
 //#endregion
 //#region main.js
-var import_cjs = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 var accepts = typeof import_cjs.default === "function" ? import_cjs.default : import_cjs.default.default;
 assert.strictEqual(accepts(), 123);
 

--- a/crates/rolldown/tests/rolldown/misc/cjs_entry_as_dependency/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/cjs_entry_as_dependency/artifacts.snap
@@ -10,7 +10,7 @@ import { __commonJS, __toESM, require_main2 } from "./main22.js";
 
 //#region main.js
 var require_main = /* @__PURE__ */ __commonJS({ "main.js": ((exports, module) => {
-	var import_main2 = __toESM(require_main2());
+	var import_main2 = /* @__PURE__ */ __toESM(require_main2());
 	module.exports = import_main2.default;
 }) });
 

--- a/crates/rolldown/tests/rolldown/misc/use_strict/allow_parse_non_strict_code_in_cjs_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/allow_parse_non_strict_code_in_cjs_format/artifacts.snap
@@ -16,7 +16,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region main.js
-var import_cjs = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 (0, node_assert.default)(typeof import_cjs.default === "function");
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/misc/use_strict/emit_use_strict_with_strict_cjs_in_cjs_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/emit_use_strict_with_strict_cjs_in_cjs_format/artifacts.snap
@@ -16,7 +16,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region main.js
-var import_cjs = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 console.log(import_cjs.default);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/artifacts.snap
@@ -17,7 +17,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region main.js
-var import_cjs = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 node_assert.default.deepEqual(import_cjs.default, { default: {} });
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/attach_correct_package_json/artifacts.snap
@@ -20,7 +20,7 @@ var require_demo_lib = /* @__PURE__ */ __commonJS({ "node_modules/demo-lib/index
 
 //#endregion
 //#region node_modules/demo-lib/nested-lib/index.js
-var import_demo_lib = __toESM(require_demo_lib(), 1);
+var import_demo_lib = /* @__PURE__ */ __toESM(require_demo_lib(), 1);
 const value = import_demo_lib.default.value;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -26,7 +26,7 @@ const value = "main";
 //#endregion
 //#region main.js
 var main_exports = {};
-var import_cjs = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 console.log(import_cjs, esm_exports);

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -26,7 +26,7 @@ const value = "exist-esm";
 //#endregion
 //#region hmr.js
 var hmr_exports = {};
-var import_exist_dep_cjs = __toESM(require_exist_dep_cjs());
+var import_exist_dep_cjs = /* @__PURE__ */ __toESM(require_exist_dep_cjs());
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 hmr_hot.accept((mod) => {

--- a/crates/rolldown/tests/rolldown/topics/keep_names/if_stmt/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/if_stmt/artifacts.snap
@@ -29,7 +29,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region main.js
-var import_cjs = __toESM(require_cjs());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 assert.strictEqual(import_cjs.Router.name, "Router");
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs/artifacts.snap
@@ -29,7 +29,7 @@ var require_cjs$2 = /* @__PURE__ */ __commonJS({ "src/export_star_from_cjs/cjs.j
 //#endregion
 //#region src/export_star_from_cjs/index.js
 var export_star_from_cjs_exports = {};
-__reExport(export_star_from_cjs_exports, __toESM(require_cjs$2()));
+__reExport(export_star_from_cjs_exports, /* @__PURE__ */ __toESM(require_cjs$2()));
 
 //#endregion
 //#region src/nested_export_star_from_cjs/cjs.js
@@ -40,7 +40,7 @@ var require_cjs$1 = /* @__PURE__ */ __commonJS({ "src/nested_export_star_from_cj
 //#endregion
 //#region src/nested_export_star_from_cjs/reexport.js
 var reexport_exports = {};
-__reExport(reexport_exports, __toESM(require_cjs$1()));
+__reExport(reexport_exports, /* @__PURE__ */ __toESM(require_cjs$1()));
 
 //#endregion
 //#region src/named_import_export_star_from_cjs/cjs.js
@@ -51,7 +51,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "src/named_import_export_star_fro
 //#endregion
 //#region src/named_import_export_star_from_cjs/index.js
 var named_import_export_star_from_cjs_exports = {};
-__reExport(named_import_export_star_from_cjs_exports, __toESM(require_cjs()));
+__reExport(named_import_export_star_from_cjs_exports, /* @__PURE__ */ __toESM(require_cjs()));
 
 //#endregion
 //#region src/indirect_common_js/lib.js
@@ -67,9 +67,9 @@ var require_indirect_common_js = /* @__PURE__ */ __commonJS({ "src/indirect_comm
 
 //#endregion
 //#region main.js
-var import_basic_ns = __toESM(require_basic_ns());
-var import_basic_ref_with_named_default = __toESM(require_basic_ref_with_named_default());
-var import_indirect_common_js = __toESM(require_indirect_common_js());
+var import_basic_ns = /* @__PURE__ */ __toESM(require_basic_ns());
+var import_basic_ref_with_named_default = /* @__PURE__ */ __toESM(require_basic_ref_with_named_default());
+var import_indirect_common_js = /* @__PURE__ */ __toESM(require_indirect_common_js());
 assert.equal(import_basic_ns.a, "basic-a");
 assert.equal(import_basic_ref_with_named_default.a, "basic-ref-with-named-default-a");
 assert.equal(export_star_from_cjs_exports.a, "export-star-from-cjs-a");

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -153,7 +153,7 @@ expression: output
 
 # tests/esbuild/dce/import_re_export_of_namespace_import
 
-- entry-!~{000}~.js => entry-4Ic4Tz4J.js
+- entry-!~{000}~.js => entry-CG9XlZin.js
 
 # tests/esbuild/dce/inline_empty_function_calls
 
@@ -393,7 +393,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js
 
-- src_entry-!~{000}~.js => src_entry-DFh6JGgi.js
+- src_entry-!~{000}~.js => src_entry-CZY8yMHF.js
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_named_import_es6
 
@@ -401,7 +401,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_star_import_common_js
 
-- src_entry-!~{000}~.js => src_entry-SVN0GD8R.js
+- src_entry-!~{000}~.js => src_entry-BrwKoVwI.js
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6
 
@@ -450,7 +450,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_true_keep_common_js
 
-- src_entry-!~{000}~.js => src_entry-DWWb1ypL.js
+- src_entry-!~{000}~.js => src_entry-QVqUVjui.js
 
 # tests/esbuild/dce/package_json_side_effects_true_keep_es6
 
@@ -744,7 +744,7 @@ expression: output
 
 # tests/esbuild/default/dot_import
 
-- entry-!~{000}~.js => entry-SkuIW7VC.js
+- entry-!~{000}~.js => entry-T7GriVg-.js
 
 # tests/esbuild/default/duplicate_entry_point
 
@@ -762,7 +762,7 @@ expression: output
 
 # tests/esbuild/default/dynamic_import_with_template_iife
 
-- a-!~{000}~.js => a-D2bPpB0T.js
+- a-!~{000}~.js => a-0DjJ_4ow.js
 
 # tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910
 
@@ -778,7 +778,7 @@ expression: output
 
 # tests/esbuild/default/es6_from_common_js
 
-- entry-!~{000}~.js => entry-B132jQUw.js
+- entry-!~{000}~.js => entry-CPQkjOWP.js
 
 # tests/esbuild/default/export_chain
 
@@ -947,7 +947,7 @@ expression: output
 
 # tests/esbuild/default/import_missing_common_js
 
-- entry-!~{000}~.js => entry-BNN5vIRK.js
+- entry-!~{000}~.js => entry-KjRmAL1p.js
 
 # tests/esbuild/default/import_missing_neither_es6_nor_common_js
 
@@ -1046,7 +1046,7 @@ expression: output
 
 # tests/esbuild/default/jsx_automatic_imports_common_js
 
-- entry-!~{000}~.js => entry-CwitGDcS.js
+- entry-!~{000}~.js => entry-BDRt6dFa.js
 
 # tests/esbuild/default/jsx_automatic_imports_es6
 
@@ -1064,7 +1064,7 @@ expression: output
 
 # tests/esbuild/default/jsx_imports_common_js
 
-- entry-!~{000}~.js => entry-BETulTdN.js
+- entry-!~{000}~.js => entry-DIDVo2S0.js
 
 # tests/esbuild/default/jsx_imports_es6
 
@@ -1222,7 +1222,7 @@ expression: output
 # tests/esbuild/default/mangle_props_import_export_bundled
 
 - entry-cjs-!~{001}~.js => entry-cjs-RzygboMK.js
-- entry-esm-!~{000}~.js => entry-esm-BNgjnrfm.js
+- entry-esm-!~{000}~.js => entry-esm-DaCME5Qz.js
 - cjs-!~{002}~.js => cjs-bi-rzMdU.js
 
 # tests/esbuild/default/mangle_props_jsx_preserve
@@ -1415,7 +1415,7 @@ expression: output
 
 # tests/esbuild/default/nested_es6_from_common_js
 
-- entry-!~{000}~.js => entry-Byk9H_ZZ.js
+- entry-!~{000}~.js => entry-DHVCEljP.js
 
 # tests/esbuild/default/nested_require_without_call
 
@@ -1446,7 +1446,7 @@ expression: output
 
 # tests/esbuild/default/node_modules
 
-- src_entry_js-!~{000}~.js => src_entry_js-zNVm_8TY.js
+- src_entry_js-!~{000}~.js => src_entry_js-Bd9bawSd.js
 
 # tests/esbuild/default/non_determinism_issue2537
 
@@ -1493,7 +1493,7 @@ expression: output
 
 # tests/esbuild/default/re_export_common_js_as_es6
 
-- entry-!~{000}~.js => entry-C_8pBtq5.js
+- entry-!~{000}~.js => entry-ClN5Jv5a.js
 
 # tests/esbuild/default/re_export_default_external_common_js
 
@@ -1678,7 +1678,7 @@ expression: output
 
 # tests/esbuild/default/top_level_await_allowed_import_without_splitting
 
-- entry-!~{000}~.js => entry-BMx3059D.js
+- entry-!~{000}~.js => entry-BxOTk1MC.js
 
 # tests/esbuild/default/top_level_await_cjs_dead_branch
 
@@ -1694,7 +1694,7 @@ expression: output
 
 # tests/esbuild/default/top_level_await_forbidden_require
 
-- entry-!~{000}~.js => entry-CDgttm4L.js
+- entry-!~{000}~.js => entry-2Z80prCa.js
 
 # tests/esbuild/default/top_level_await_forbidden_require_dead_branch
 
@@ -1839,15 +1839,15 @@ expression: output
 
 # tests/esbuild/importstar/export_other_as_namespace_common_js
 
-- entry-!~{000}~.js => entry-1OWtKSka.js
+- entry-!~{000}~.js => entry-LrwB20XW.js
 
 # tests/esbuild/importstar/export_other_common_js
 
-- entry-!~{000}~.js => entry-C9BiFd4n.js
+- entry-!~{000}~.js => entry-B8363NMa.js
 
 # tests/esbuild/importstar/export_other_nested_common_js
 
-- entry-!~{000}~.js => entry-DBtxtvV8.js
+- entry-!~{000}~.js => entry-udQrMJcp.js
 
 # tests/esbuild/importstar/export_self_and_import_self_common_js
 
@@ -1907,7 +1907,7 @@ expression: output
 
 # tests/esbuild/importstar/import_export_other_as_namespace_common_js
 
-- entry-!~{000}~.js => entry-1OWtKSka.js
+- entry-!~{000}~.js => entry-LrwB20XW.js
 
 # tests/esbuild/importstar/import_export_self_as_namespace_es6
 
@@ -1919,14 +1919,14 @@ expression: output
 
 # tests/esbuild/importstar/import_namespace_undefined_property_empty_file
 
-- entry-default-!~{001}~.js => entry-default-DLsIPqmK.js
-- entry-nope-!~{000}~.js => entry-nope-CsFKxap8.js
+- entry-default-!~{001}~.js => entry-default-DFTphgwS.js
+- entry-nope-!~{000}~.js => entry-nope-BYcUifvH.js
 - empty-!~{002}~.js => empty-UknkEYWX.js
 
 # tests/esbuild/importstar/import_namespace_undefined_property_side_effect_free_file
 
-- entry-default-!~{001}~.js => entry-default-BGaHgSme.js
-- entry-nope-!~{000}~.js => entry-nope-ckWYLkuy.js
+- entry-default-!~{001}~.js => entry-default-DjU1N2NO.js
+- entry-nope-!~{000}~.js => entry-nope-qZifJH1X.js
 - no-side-effects-!~{002}~.js => no-side-effects-63P-MoQR.js
 
 # tests/esbuild/importstar/import_of_export_star
@@ -1939,7 +1939,7 @@ expression: output
 
 # tests/esbuild/importstar/import_self_common_js
 
-- entry-!~{000}~.js => entry-BcjKOxtP.js
+- entry-!~{000}~.js => entry-KZe9a68l.js
 
 # tests/esbuild/importstar/import_star_and_common_js
 
@@ -1951,11 +1951,11 @@ expression: output
 
 # tests/esbuild/importstar/import_star_common_js_capture
 
-- entry-!~{000}~.js => entry-D9rFZzdz.js
+- entry-!~{000}~.js => entry-BWKdH30k.js
 
 # tests/esbuild/importstar/import_star_common_js_no_capture
 
-- entry-!~{000}~.js => entry-CsSHJ8_w.js
+- entry-!~{000}~.js => entry-DuKfWEiV.js
 
 # tests/esbuild/importstar/import_star_common_js_unused
 
@@ -2043,7 +2043,7 @@ expression: output
 
 # tests/esbuild/importstar/namespace_import_missing_common_js
 
-- entry-!~{000}~.js => entry-BU7jRa-I.js
+- entry-!~{000}~.js => entry-O0_SShc4.js
 
 # tests/esbuild/importstar/namespace_import_missing_es6
 
@@ -2059,7 +2059,7 @@ expression: output
 
 # tests/esbuild/importstar/namespace_import_unused_missing_common_js
 
-- entry-!~{000}~.js => entry-B4nRjWjT.js
+- entry-!~{000}~.js => entry-Czu09kou.js
 
 # tests/esbuild/importstar/namespace_import_unused_missing_es6
 
@@ -2167,11 +2167,11 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_common_js_capture
 
-- entry-!~{000}~.js => entry-TGGaT4fd.js
+- entry-!~{000}~.js => entry-DRSuRDK7.js
 
 # tests/esbuild/importstar_ts/ts_import_star_common_js_no_capture
 
-- entry-!~{000}~.js => entry-CHqUk9jZ.js
+- entry-!~{000}~.js => entry-BZ59Mr1i.js
 
 # tests/esbuild/importstar_ts/ts_import_star_common_js_unused
 
@@ -2891,7 +2891,7 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_bad_main
 
-- entry-!~{000}~.js => entry-CvdtIgVg.js
+- entry-!~{000}~.js => entry-DW4Py3J6.js
 
 # tests/esbuild/packagejson/package_json_browser_index_no_ext
 
@@ -2915,31 +2915,31 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_browser_map_module_disabled
 
-- entry-!~{000}~.js => entry-COkMzv14.js
+- entry-!~{000}~.js => entry-DR1oPSOn.js
 
 # tests/esbuild/packagejson/package_json_browser_map_module_to_module
 
-- entry-!~{000}~.js => entry-pWLkr4-Z.js
+- entry-!~{000}~.js => entry-bV61_tkf.js
 
 # tests/esbuild/packagejson/package_json_browser_map_module_to_relative
 
-- entry-!~{000}~.js => entry-CsdU7kfO.js
+- entry-!~{000}~.js => entry-CCv0filu.js
 
 # tests/esbuild/packagejson/package_json_browser_map_native_module_disabled
 
-- entry-!~{000}~.js => entry-DNsFbqfz.js
+- entry-!~{000}~.js => entry-44qZln_d.js
 
 # tests/esbuild/packagejson/package_json_browser_map_relative_disabled
 
-- entry-!~{000}~.js => entry-B5vh4rZz.js
+- entry-!~{000}~.js => entry-Ba6NmiOf.js
 
 # tests/esbuild/packagejson/package_json_browser_map_relative_to_module
 
-- entry-!~{000}~.js => entry-DAF94WjR.js
+- entry-!~{000}~.js => entry-rPDqjeW4.js
 
 # tests/esbuild/packagejson/package_json_browser_map_relative_to_relative
 
-- entry-!~{000}~.js => entry-BJulC19P.js
+- entry-!~{000}~.js => entry-C9F62ENf.js
 
 # tests/esbuild/packagejson/package_json_browser_no_ext
 
@@ -2955,19 +2955,19 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_browser_over_main_node
 
-- entry-!~{000}~.js => entry-C987utpc.js
+- entry-!~{000}~.js => entry-DCgvYOBn.js
 
 # tests/esbuild/packagejson/package_json_browser_over_module_browser
 
-- entry-!~{000}~.js => entry-BM1XHiNN.js
+- entry-!~{000}~.js => entry-BQUsPzDP.js
 
 # tests/esbuild/packagejson/package_json_browser_string
 
-- entry-!~{000}~.js => entry-dQ8E3QTo.js
+- entry-!~{000}~.js => entry-CfSfp2VD.js
 
 # tests/esbuild/packagejson/package_json_browser_with_main_node
 
-- entry-!~{000}~.js => entry-C987utpc.js
+- entry-!~{000}~.js => entry-DCgvYOBn.js
 
 # tests/esbuild/packagejson/package_json_browser_with_module_browser
 
@@ -3127,11 +3127,11 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_main
 
-- entry-!~{000}~.js => entry-DLzYqPXl.js
+- entry-!~{000}~.js => entry-CsQEOeEd.js
 
 # tests/esbuild/packagejson/package_json_main_fields_a
 
-- entry-!~{000}~.js => entry-7_nUaLFD.js
+- entry-!~{000}~.js => entry-BP5db-nm.js
 
 # tests/esbuild/packagejson/package_json_main_fields_b
 
@@ -3155,7 +3155,7 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_neutral_explicit_main_fields
 
-- entry-!~{000}~.js => entry-C987utpc.js
+- entry-!~{000}~.js => entry-DCgvYOBn.js
 
 # tests/esbuild/packagejson/package_json_neutral_no_default_main_fields
 
@@ -3223,7 +3223,7 @@ expression: output
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6
 
-- entry-!~{000}~.js => entry-DRll7FCd.js
+- entry-!~{000}~.js => entry-B4NP_gHl.js
 - foo-!~{003}~.js => foo-BG8ps5AG.js
 - foo-!~{001}~.js => foo-BzLyFbvP.js
 
@@ -3486,7 +3486,7 @@ expression: output
 
 # tests/esbuild/ts/ts_export_equals
 
-- a-!~{000}~.js => a-CkEuL0zn.js
+- a-!~{000}~.js => a-B_RtVVxo.js
 
 # tests/esbuild/ts/ts_export_missing_es6
 
@@ -3650,7 +3650,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/basic_commonjs
 
-- main-!~{000}~.js => main-C44muzSk.js
+- main-!~{000}~.js => main-CKHZsNj3.js
 
 # tests/rolldown/cjs_compat/cjs_entry
 
@@ -3676,98 +3676,98 @@ expression: output
 
 # tests/rolldown/cjs_compat/exoprt_star_of_cjs
 
-- main-!~{000}~.js => main-BiOAamgQ.js
+- main-!~{000}~.js => main-BUm7A9yW.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
 
-- main-!~{000}~.js => main-D1VuDi0m.js
+- main-!~{000}~.js => main-Bb7S9_y8.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_named_import
 
-- main-!~{000}~.js => main-BG5gWvMt.js
+- main-!~{000}~.js => main-DIbjKQVU.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
 
-- main-!~{000}~.js => main-V5ySc9KU.js
+- main-!~{000}~.js => main-CwG5_1gm.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
 
-- main-!~{000}~.js => main-DcES9h-8.js
+- main-!~{000}~.js => main-C4OWpIxJ.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
 
-- main-!~{000}~.js => main-ByOcwQeO.js
+- main-!~{000}~.js => main-DFqmbkAW.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_named_reexport
 
-- main-!~{000}~.js => main-BBSvXo-g.js
+- main-!~{000}~.js => main-Bk2UjXHx.js
 
 # tests/rolldown/cjs_compat/import_the_same_cjs_twice
 
-- main-!~{000}~.js => main-BWHnBTgX.js
+- main-!~{000}~.js => main-DuFkSZrL.js
 
 # tests/rolldown/cjs_compat/issue_3364
 
-- main-!~{000}~.js => main-B4Dma7zO.js
+- main-!~{000}~.js => main-Ct3OcTlI.js
 
 # tests/rolldown/cjs_compat/mix-cjs-esm
 
-- main-!~{000}~.js => main-B7uUTQ6D.js
-- main-B7uUTQ6D.js.map
+- main-!~{000}~.js => main-DjRkGoWy.js
+- main-DjRkGoWy.js.map
 
 # tests/rolldown/cjs_compat/multiple_circle_cjs_entries
 
-- a-!~{000}~.js => a-DxQeZu4k.js
-- b-!~{001}~.js => b-BPYjMK0J.js
-- a-!~{002}~.js => a-DdujXtGd.js
+- a-!~{000}~.js => a-DegDNUVi.js
+- b-!~{001}~.js => b-CUzUcCP8.js
+- a-!~{002}~.js => a-CxvNQFUn.js
 
 # tests/rolldown/cjs_compat/node_module_commonjs
 
-- entry-!~{001}~.js => entry-hIJVkSdX.js
-- main-!~{000}~.js => main-W048Jvsy.js
+- entry-!~{001}~.js => entry-DYoANFCP.js
+- main-!~{000}~.js => main-BeFLkVNa.js
 - commonjs-!~{002}~.js => commonjs-CVCO1Kcl.js
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout
 
-- main-!~{000}~.js => main-DR-QyFwx.js
+- main-!~{000}~.js => main-Q6Enn7wZ.js
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout2
 
-- main-!~{000}~.js => main-auEwY1sO.js
+- main-!~{000}~.js => main-BDnVomKU.js
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_none_default_ns_property_name
 
-- main-!~{000}~.js => main-DbhebxFp.js
+- main-!~{000}~.js => main-wIDV8rsX.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge
 
-- main-!~{000}~.js => main-j21Ljcj3.js
+- main-!~{000}~.js => main-BywzsmJB.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_2
 
-- main-!~{000}~.js => main-jDC8-GlG.js
+- main-!~{000}~.js => main-BcHPfiQE.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize
 
-- main-!~{000}~.js => main-DjwlIAn3.js
+- main-!~{000}~.js => main-D8jvRMNG.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize_chunk_split
 
-- entry-!~{000}~.js => entry-_G5eJ6yr.js
-- main-!~{001}~.js => main-GBZMbCFs.js
-- a-!~{002}~.js => a-KaKo8WLp.js
+- entry-!~{000}~.js => entry-CTOg42pm.js
+- main-!~{001}~.js => main-Bk1zrpEd.js
+- a-!~{002}~.js => a-Ibxf60pv.js
 
 # tests/rolldown/cjs_compat/react-like
 
-- main-!~{000}~.js => main-OEquFgkk.js
+- main-!~{000}~.js => main-CeQXbZor.js
 
 # tests/rolldown/cjs_compat/reexport_commonjs
 
-- main-!~{000}~.js => main-B0mgrW0Z.js
+- main-!~{000}~.js => main-CEL0Hc_a.js
 
 # tests/rolldown/cjs_compat/reexports_from_cjs
 
-- main-!~{000}~.js => main-COiAj5uR.js
+- main-!~{000}~.js => main-CgP31t9f.js
 
 # tests/rolldown/cjs_compat/require/create_require
 
@@ -3789,7 +3789,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/unnecessary_compat_default_property_access
 
-- main-!~{000}~.js => main-DG3V3cdD.js
+- main-!~{000}~.js => main-Dr60rKiv.js
 
 # tests/rolldown/code_splitting/basic
 
@@ -3830,8 +3830,8 @@ expression: output
 
 # tests/rolldown/code_splitting/format_cjs_with_module_cjs
 
-- main1-!~{000}~.js => main1-DmwaDy6x.js
-- main2-!~{001}~.js => main2-C8_Gna3u.js
+- main1-!~{000}~.js => main1-B_0DLyIh.js
+- main2-!~{001}~.js => main2-DtJzZDgV.js
 - share-!~{002}~.js => share-C5QPUyyJ.js
 
 # tests/rolldown/code_splitting/import_export_unicode
@@ -3850,7 +3850,7 @@ expression: output
 
 # tests/rolldown/dce/conditional_exports
 
-- main-!~{000}~.js => main-Bq8iIdoV.js
+- main-!~{000}~.js => main-BpAmeYQA.js
 
 # tests/rolldown/dce/defined_expr_in_paren_expr
 
@@ -4056,7 +4056,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-BglwVSaL.js
+- main-!~{000}~.js => main-Bb3AbQtA.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4066,7 +4066,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4782
 
-- main-!~{000}~.js => main-FCiKqvpr.js
+- main-!~{000}~.js => main-DjOBEwin.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4920
 
@@ -4075,7 +4075,7 @@ expression: output
 # tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping
 
 - dynamic-!~{001}~.js => dynamic-BhqYqd04.js
-- main-!~{000}~.js => main-CM2MCy3D.js
+- main-!~{000}~.js => main-BiFMWJtk.js
 - dynamic-!~{002}~.js => dynamic-DKjUd_a-.js
 
 # tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module
@@ -4342,15 +4342,15 @@ expression: output
 
 # tests/rolldown/function/inline_dynamic_imports/cjs
 
-- main-!~{000}~.js => main-BblsJzTO.js
+- main-!~{000}~.js => main-lwGAEuFX.js
 
 # tests/rolldown/function/inline_dynamic_imports/esm
 
-- main-!~{000}~.js => main-aDyKY62q.js
+- main-!~{000}~.js => main-DHUJRmGm.js
 
 # tests/rolldown/function/inline_dynamic_imports/iife
 
-- main-!~{000}~.js => main-CmJzEAKp.js
+- main-!~{000}~.js => main-BnGtBBQb.js
 
 # tests/rolldown/function/intro/cjs
 
@@ -4451,7 +4451,7 @@ expression: output
 
 # tests/rolldown/function/module_types/json/correct_semantic_of_import_and_require
 
-- main-!~{000}~.js => main-BQD3pEdF.js
+- main-!~{000}~.js => main-DPQGtCiB.js
 
 # tests/rolldown/function/module_types/json/customize
 
@@ -4583,15 +4583,15 @@ expression: output
 
 # tests/rolldown/issues/1722/1
 
-- foo-!~{001}~.js => foo-Cty7Z7B7.js
-- main-!~{000}~.js => main-DAnns7UH.js
-- main-!~{002}~.js => main-D1eDqEHW.js
+- foo-!~{001}~.js => foo-CE9L34Ig.js
+- main-!~{000}~.js => main-VN4l1Mc7.js
+- main-!~{002}~.js => main-DCB5E4gj.js
 
 # tests/rolldown/issues/1722/2
 
-- entry1-!~{000}~.js => entry1-CFijSH3t.js
-- entry2-!~{001}~.js => entry2-Uz2U8Cqx.js
-- main-!~{002}~.js => main-Vxvk6OkC.js
+- entry1-!~{000}~.js => entry1-CX4X3DE_.js
+- entry2-!~{001}~.js => entry2-Dx6uwqg9.js
+- main-!~{002}~.js => main-wXV9uFs4.js
 
 # tests/rolldown/issues/1769
 
@@ -4606,17 +4606,17 @@ expression: output
 
 # tests/rolldown/issues/2038/b
 
-- main-!~{000}~.js => main-DENdtMun.js
-- a-!~{005}~.js => a-CBmYUEnH.js
-- b-!~{001}~.js => b-B8gQMyU7.js
-- b-!~{003}~.js => b-C9B4M5Vd.js
+- main-!~{000}~.js => main-8TDrZ36r.js
+- a-!~{005}~.js => a-BX3GMvZS.js
+- b-!~{003}~.js => b-Br839cxA.js
+- b-!~{001}~.js => b-CrP06tRo.js
 
 # tests/rolldown/issues/2085
 
-- main-!~{000}~.js => main-Daa-AcNN.js
-- a-!~{003}~.js => a-D4-JS4z4.js
-- a-!~{001}~.js => a-qcF8lAct.js
-- c-!~{005}~.js => c-BfjdMQAf.js
+- main-!~{000}~.js => main-DUFtYYTo.js
+- a-!~{003}~.js => a-ChWPLiB9.js
+- a-!~{001}~.js => a-fRuc763U.js
+- c-!~{005}~.js => c-DYKCx0d_.js
 
 # tests/rolldown/issues/2300
 
@@ -4659,13 +4659,13 @@ expression: output
 
 # tests/rolldown/issues/2903_4
 
-- main-!~{000}~.js => main-C-EywvON.js
-- main2-!~{001}~.js => main2-pD_68URn.js
+- main-!~{000}~.js => main-z1PaPiH8.js
+- main2-!~{001}~.js => main2-onjTZtFY.js
 - chunk-!~{002}~.js => chunk-Dqp1o9pS.js
 
 # tests/rolldown/issues/3367
 
-- main-!~{000}~.js => main-DpQl-SAu.js
+- main-!~{000}~.js => main-DD7krNgO.js
 
 # tests/rolldown/issues/3395
 
@@ -4692,7 +4692,7 @@ expression: output
 
 # tests/rolldown/issues/3529
 
-- main-!~{000}~.js => main-BvVrzCHu.js
+- main-!~{000}~.js => main-CWUfj7oR.js
 
 # tests/rolldown/issues/3650
 
@@ -4721,7 +4721,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-BwDA8ojz.js
+- main-!~{000}~.js => main-9pXZqgmo.js
 
 # tests/rolldown/issues/4196
 
@@ -4733,7 +4733,7 @@ expression: output
 
 # tests/rolldown/issues/4289
 
-- main-!~{000}~.js => main-DPwCg8yL.js
+- main-!~{000}~.js => main-BLiNqcSr.js
 - chunk-!~{001}~.js => chunk-e6zvK7dF.js
 - lib-!~{003}~.js => lib-gFGHPkDo.js
 
@@ -4751,7 +4751,7 @@ expression: output
 
 # tests/rolldown/issues/4443
 
-- main-!~{000}~.js => main-XxkwPNmk.js
+- main-!~{000}~.js => main-CKCW296L.js
 
 # tests/rolldown/issues/4459
 
@@ -4786,7 +4786,7 @@ expression: output
 
 # tests/rolldown/issues/5209
 
-- main-!~{000}~.js => main-D57U5is_.js
+- main-!~{000}~.js => main-Lm27rt-w.js
 
 # tests/rolldown/issues/5242
 
@@ -4794,9 +4794,9 @@ expression: output
 
 # tests/rolldown/issues/5387
 
-- main-!~{000}~.js => main-5m6MN1Zx.js
+- main-!~{000}~.js => main-BF_p7yIv.js
 - _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-li4Svopq.js
-- liblib/index-!~{005}~.js => liblib/index-CW9qBxqo.js
+- liblib/index-!~{005}~.js => liblib/index-CrkltzeF.js
 - liblib/lib-!~{003}~.js => liblib/lib-CEDze9up.js
 
 # tests/rolldown/issues/rolldown_vite_289
@@ -4845,13 +4845,13 @@ expression: output
 
 # tests/rolldown/misc/cjs_entry_as_dependency
 
-- main-!~{000}~.js => main-DYXBPIr4.js
+- main-!~{000}~.js => main-Css4G-UB.js
 - main2-!~{001}~.js => main2-ILuIavua.js
 - main2-!~{002}~.js => main2-BJUOpbWL.js
 
 # tests/rolldown/misc/common_js_min
 
-- main-!~{000}~.js => main-CZgAKdoZ.js
+- main-!~{000}~.js => main-DXiWDywg.js
 
 # tests/rolldown/misc/duplicate_entries
 
@@ -5008,11 +5008,11 @@ expression: output
 
 # tests/rolldown/misc/use_strict/allow_parse_non_strict_code_in_cjs_format
 
-- main-!~{000}~.js => main-BATYa3YS.js
+- main-!~{000}~.js => main-RPEfhAxM.js
 
 # tests/rolldown/misc/use_strict/emit_use_strict_with_strict_cjs_in_cjs_format
 
-- main-!~{000}~.js => main-uRgPvwuD.js
+- main-!~{000}~.js => main-Cnui6OE6.js
 
 # tests/rolldown/misc/use_strict/empty_file
 
@@ -5028,7 +5028,7 @@ expression: output
 
 # tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format
 
-- main-!~{000}~.js => main-BfpSuvqh.js
+- main-!~{000}~.js => main-DTso9GhH.js
 
 # tests/rolldown/misc/wrapped_esm
 
@@ -5043,7 +5043,7 @@ expression: output
 
 # tests/rolldown/optimization/inline_const/basic
 
-- main-!~{000}~.js => main-Drk3_wdb.js
+- main-!~{000}~.js => main-CTfw_pO5.js
 
 # tests/rolldown/optimization/inline_const/issue_4786
 
@@ -5072,7 +5072,7 @@ expression: output
 
 # tests/rolldown/resolve/attach_correct_package_json
 
-- main-!~{000}~.js => main-BpB2vQ4T.js
+- main-!~{000}~.js => main-Dhp9LlkD.js
 
 # tests/rolldown/resolve/hash_tag_as_dir_name
 
@@ -5148,11 +5148,11 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/10
 
-- entry-!~{000}~.js => entry-CCKt5xMk.js
+- entry-!~{000}~.js => entry-26UPr7_O.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/11
 
-- entry-!~{000}~.js => entry-CRAzAtTt.js
+- entry-!~{000}~.js => entry-BNO5dN8x.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/12
 
@@ -5220,19 +5220,19 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/26
 
-- entry-!~{000}~.js => entry-BgJA83xf.js
+- entry-!~{000}~.js => entry-YhskOOIV.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/27
 
-- entry-!~{000}~.js => entry-dpL7w8Ri.js
+- entry-!~{000}~.js => entry-DQ2RHmhl.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/28
 
-- entry-!~{000}~.js => entry-DUd_rD_C.js
+- entry-!~{000}~.js => entry-DaE4gwtn.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/29
 
-- entry-!~{000}~.js => entry-CGVhKAlu.js
+- entry-!~{000}~.js => entry-CUfNTV0P.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/3
 
@@ -5240,11 +5240,11 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/30
 
-- entry-!~{000}~.js => entry-5G_QuLxx.js
+- entry-!~{000}~.js => entry-CraO3cd5.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/31
 
-- entry-!~{000}~.js => entry-BrQ8OmcR.js
+- entry-!~{000}~.js => entry-DDbTKVEb.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/32
 
@@ -5258,31 +5258,31 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/34
 
-- entry-!~{000}~.js => entry-Bfcxd1jd.js
+- entry-!~{000}~.js => entry-CrGCgbLz.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/35
 
-- entry-!~{000}~.js => entry-syrDCBWD.js
+- entry-!~{000}~.js => entry-9UU-Kzep.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/36
 
-- entry-!~{000}~.js => entry-pNdsZlhy.js
+- entry-!~{000}~.js => entry-dxSP21ek.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/37
 
-- entry-!~{000}~.js => entry-f6Nwd_AR.js
+- entry-!~{000}~.js => entry-B2QKTeQL.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/38
 
-- entry-!~{000}~.js => entry-8wSvixzu.js
+- entry-!~{000}~.js => entry-BaQTlj-U.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/39
 
-- entry-!~{000}~.js => entry-GAAlyZ5L.js
+- entry-!~{000}~.js => entry--Z4Op6xH.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/4
 
-- entry-!~{000}~.js => entry-DU_TZR8-.js
+- entry-!~{000}~.js => entry-tg2AqB6K.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/40
 
@@ -5318,55 +5318,55 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/48
 
-- entry-!~{000}~.js => entry-B13k6LkU.js
+- entry-!~{000}~.js => entry-BdwSh2Rc.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/49
 
-- entry-!~{000}~.js => entry-D7nYDngT.js
+- entry-!~{000}~.js => entry-Cj3CIl5Q.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/5
 
-- entry-!~{000}~.js => entry-DTrMsMU8.js
+- entry-!~{000}~.js => entry-CVFHwAj2.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/50
 
-- entry-!~{000}~.js => entry-Dqh2OQ_Z.js
+- entry-!~{000}~.js => entry-Dz3SztY3.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/51
 
-- entry-!~{000}~.js => entry-BNR88U8i.js
+- entry-!~{000}~.js => entry-DiIjWGAb.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/52
 
-- entry-!~{000}~.js => entry-RQG_wqNN.js
+- entry-!~{000}~.js => entry-BTvSOuH6.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/53
 
-- entry-!~{000}~.js => entry-Den7ZiaM.js
+- entry-!~{000}~.js => entry-DYh_0JQW.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/54
 
-- entry-!~{000}~.js => entry-Dm3VZEHW.js
+- entry-!~{000}~.js => entry-9zCllm_2.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/55
 
-- entry-!~{000}~.js => entry-BHVY7BiK.js
+- entry-!~{000}~.js => entry-DAH7G26N.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/56
 
-- entry-!~{000}~.js => entry-dgl3gF_E.js
+- entry-!~{000}~.js => entry-bfnTS2N8.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/57
 
-- entry-!~{000}~.js => entry-CYVqOpOF.js
+- entry-!~{000}~.js => entry-Dr76jvGJ.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/58
 
-- entry-!~{000}~.js => entry-BBH0q5B-.js
+- entry-!~{000}~.js => entry-Do5drIB3.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/59
 
-- entry-!~{000}~.js => entry-BuB5rjIF.js
+- entry-!~{000}~.js => entry-By83Uu9z.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/6
 
@@ -5374,19 +5374,19 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/60
 
-- entry-!~{000}~.js => entry-Bv9MfVEQ.js
+- entry-!~{000}~.js => entry-DRG3KI37.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/61
 
-- entry-!~{000}~.js => entry-Ht-07s0P.js
+- entry-!~{000}~.js => entry-Dp7pOuop.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/62
 
-- entry-!~{000}~.js => entry-DFKG9zPs.js
+- entry-!~{000}~.js => entry-q5j-DIrn.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/63
 
-- entry-!~{000}~.js => entry-CvrL4Q6a.js
+- entry-!~{000}~.js => entry-BkzYmh56.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/7
 
@@ -5516,11 +5516,11 @@ expression: output
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-EWN_FgZi.js
+- main-!~{000}~.js => main-Brsmj5f_.js
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-5EopgXYY.js
+- main-!~{000}~.js => main-DApPzWAG.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 
@@ -5541,7 +5541,7 @@ expression: output
 
 # tests/rolldown/topics/keep_names/if_stmt
 
-- main-!~{000}~.js => main-CBzSvjoE.js
+- main-!~{000}~.js => main-BdR-uMgI.js
 
 # tests/rolldown/topics/keep_names/issue_5294
 
@@ -5712,7 +5712,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/commonjs
 
-- main-!~{000}~.js => main-BBut9FG8.js
+- main-!~{000}~.js => main-DDdJExEQ.js
 
 # tests/rolldown/tree_shaking/commonjs_mixed
 

--- a/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
@@ -649,12 +649,13 @@ impl<'ast> AstSnippet<'ast> {
     } else {
       self.builder.vec1(Argument::from(expr))
     };
-    ast::Expression::CallExpression(self.builder.alloc_call_expression(
+    ast::Expression::CallExpression(self.builder.alloc_call_expression_with_pure(
       SPAN,
       to_esm_fn_expr,
       NONE,
       args,
       false,
+      true,
     ))
   }
 


### PR DESCRIPTION
follow-up of https://github.com/rolldown/rolldown/pull/5419, 
Here is an example I found in `react-router-dom` example. After bundle, we will generate the following code: 

``` js

// write or paste code here

var require_dist = /* @__PURE__ */ __commonJSMin((exports) => {
	Object.defineProperty(exports, "__esModule", { value: true });
});

//#endregion
//#region node_modules/.pnpm/react-router@7.6.2_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/react-router/dist/development/chunk-NL6KNZEE.mjs

var import_dist = _toESM(require_dist(), 1);

```
**the import_dist** is not used anywhere
As we already know, `__toESM` onlyaddsg some interop prop on the exported object, if the require is not used,  adding those interop props is redundant, so we could mark the `__toESM` as pure, this could somehow reduce the output size.
