### PR TITLE
feat: add `this.fs` support

### DIFF
--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -66,6 +66,12 @@ import type {
   TransformResult,
 } from './plugin';
 import type {
+  BufferEncoding,
+  RolldownDirectoryEntry,
+  RolldownFileStats,
+  RolldownFsModule,
+} from './plugin/fs';
+import type {
   GeneralHookFilter,
   HookFilter,
   ModuleTypeFilter,
@@ -106,6 +112,7 @@ export const VERSION: string = version;
 export type {
   AddonFunction,
   AsyncPluginHooks,
+  BufferEncoding,
   BuildOptions,
   ChunkFileNamesFunction,
   ChunkingContext,
@@ -161,6 +168,9 @@ export type {
   ResolveIdExtraOptions,
   ResolveIdResult,
   RolldownBuild,
+  RolldownDirectoryEntry,
+  RolldownFileStats,
+  RolldownFsModule,
   RolldownOptions,
   RolldownOutput,
   RolldownPlugin,

--- a/packages/rolldown/src/plugin/fs.ts
+++ b/packages/rolldown/src/plugin/fs.ts
@@ -1,0 +1,112 @@
+import fsp from 'node:fs/promises';
+
+export interface RolldownFsModule {
+  appendFile(
+    path: string,
+    data: string | Uint8Array,
+    options?: {
+      encoding?: BufferEncoding | null;
+      mode?: string | number;
+      flag?: string | number;
+    },
+  ): Promise<void>;
+
+  copyFile(
+    source: string,
+    destination: string,
+    mode?: string | number,
+  ): Promise<void>;
+
+  mkdir(
+    path: string,
+    options?: { recursive?: boolean; mode?: string | number },
+  ): Promise<void>;
+
+  mkdtemp(prefix: string): Promise<string>;
+
+  readdir(path: string, options?: { withFileTypes?: false }): Promise<string[]>;
+  readdir(
+    path: string,
+    options?: { withFileTypes: true },
+  ): Promise<RolldownDirectoryEntry[]>;
+
+  readFile(
+    path: string,
+    options?: { encoding?: null; flag?: string | number; signal?: AbortSignal },
+  ): Promise<Uint8Array>;
+  readFile(
+    path: string,
+    options?: {
+      encoding: BufferEncoding;
+      flag?: string | number;
+      signal?: AbortSignal;
+    },
+  ): Promise<string>;
+
+  realpath(path: string): Promise<string>;
+
+  rename(oldPath: string, newPath: string): Promise<void>;
+
+  rmdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+
+  stat(path: string): Promise<RolldownFileStats>;
+
+  lstat(path: string): Promise<RolldownFileStats>;
+
+  unlink(path: string): Promise<void>;
+
+  writeFile(
+    path: string,
+    data: string | Uint8Array,
+    options?: {
+      encoding?: BufferEncoding | null;
+      mode?: string | number;
+      flag?: string | number;
+    },
+  ): Promise<void>;
+}
+
+export type BufferEncoding =
+  | 'ascii'
+  | 'utf8'
+  | 'utf16le'
+  | 'ucs2'
+  | 'base64'
+  | 'base64url'
+  | 'latin1'
+  | 'binary'
+  | 'hex';
+
+export interface RolldownDirectoryEntry {
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+  name: string;
+}
+
+export interface RolldownFileStats {
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+  size: number;
+  mtime: Date;
+  ctime: Date;
+  atime: Date;
+  birthtime: Date;
+}
+
+export const fsModule: RolldownFsModule = {
+  appendFile: fsp.appendFile,
+  copyFile: fsp.copyFile,
+  mkdir: fsp.mkdir as RolldownFsModule['mkdir'],
+  mkdtemp: fsp.mkdtemp,
+  readdir: fsp.readdir,
+  readFile: fsp.readFile as RolldownFsModule['readFile'],
+  realpath: fsp.realpath,
+  rename: fsp.rename,
+  rmdir: fsp.rmdir,
+  stat: fsp.stat,
+  lstat: fsp.lstat,
+  unlink: fsp.unlink,
+  writeFile: fsp.writeFile,
+};

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -19,6 +19,7 @@ import type { PartialNull } from '../types/utils';
 import { type AssetSource, bindingAssetSource } from '../utils/asset-source';
 import { bindingifyPreserveEntrySignatures } from '../utils/bindingify-input-options';
 import { unimplemented, unreachable } from '../utils/misc';
+import { fsModule, type RolldownFsModule } from './fs';
 import type {
   CustomPluginOptions,
   ModuleOptions,
@@ -55,6 +56,7 @@ export interface PluginContextResolveOptions {
 export type GetModuleInfo = (moduleId: string) => ModuleInfo | null;
 
 export interface PluginContext extends MinimalPluginContext {
+  fs: RolldownFsModule;
   emitFile(file: EmittedFile): string;
   getFileName(referenceId: string): string;
   getModuleIds(): IterableIterator<string>;
@@ -76,6 +78,7 @@ export interface PluginContext extends MinimalPluginContext {
 }
 
 export class PluginContextImpl extends MinimalPluginContextImpl {
+  fs: RolldownFsModule = fsModule;
   getModuleInfo: GetModuleInfo;
   constructor(
     private outputOptions: OutputOptions,

--- a/packages/rolldown/tests/fixtures/plugin/context/fs/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/fs/_config.ts
@@ -1,0 +1,24 @@
+import { defineTest } from 'rolldown-tests'
+import { expect, vi } from 'vitest'
+
+const fn = vi.fn()
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'test-plugin-context',
+        async load(id) {
+          if (id.endsWith('main.js')) {
+            fn()
+            const stat = await this.fs.stat(id)
+            expect(stat.isFile()).toBe(true)
+          }
+        },
+      },
+    ],
+  },
+  afterTest: () => {
+    expect(fn).toHaveBeenCalledTimes(1)
+  },
+})

--- a/packages/rolldown/tests/fixtures/plugin/context/fs/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/fs/main.js
@@ -1,0 +1,1 @@
+console.log('main')


### PR DESCRIPTION
Adds `this.fs` support which was added to rollup in https://github.com/rollup/rollup/pull/5944.

Note that while https://github.com/rollup/rollup/pull/5944 adds `options.fs`, this PR does not add that feature.
