### PR TITLE
fix(cli): remove unnecessary `await`

### DIFF
--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -87,7 +87,7 @@ async function watchInner(
       }),
     };
   });
-  const watcher = await rolldownWatch(normalizedConfig);
+  const watcher = rolldownWatch(normalizedConfig);
 
   onExit((code: number | null | undefined) => {
     Promise.resolve(watcher.close()).finally(() => {


### PR DESCRIPTION
Remove `await` as `rolldownWatch()` only return `RolldownWatcher` except a `Promise`.