### PR TITLE
refactor(hmr): replace `HmrOutput` with `HmrUpdate`

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 
 use arcstr::ArcStr;
 use rolldown_common::{
-  GetLocalDbMut, HmrOutput, Module, NormalizedBundlerOptions, ScanMode, SharedFileEmitter,
+  GetLocalDbMut, HmrUpdate, Module, NormalizedBundlerOptions, ScanMode, SharedFileEmitter,
   SymbolRefDb,
 };
 use rolldown_debug::{action, trace_action, trace_action_enabled};
@@ -286,7 +286,7 @@ impl Bundler {
   pub async fn generate_hmr_patch(
     &mut self,
     changed_files: Vec<String>,
-  ) -> BuildResult<Option<HmrOutput>> {
+  ) -> BuildResult<Option<HmrUpdate>> {
     let mut updates = self
       .hmr_manager
       .as_mut()
@@ -302,7 +302,7 @@ impl Bundler {
     &mut self,
     caller: String,
     first_invalidated_by: Option<String>,
-  ) -> BuildResult<HmrOutput> {
+  ) -> BuildResult<HmrUpdate> {
     self
       .hmr_manager
       .as_mut()

--- a/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
@@ -237,10 +237,7 @@ __rolldown_runtime__.applyUpdates(['main.js']);
 ```
 ## Meta
 
-- full_reload: false
-- first_invalidated_by: None
-- is_self_accepting: false
-- full_reload_reason: None
+- update type: patch
 ### Hmr Boundaries
 
 - boundary: main.js, accepted_via: main.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -150,10 +150,7 @@ __rolldown_runtime__.applyUpdates(['hmr.js']);
 ```
 ## Meta
 
-- full_reload: false
-- first_invalidated_by: None
-- is_self_accepting: false
-- full_reload_reason: None
+- update type: patch
 ### Hmr Boundaries
 
 - boundary: hmr.js, accepted_via: hmr.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -60,11 +60,7 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 
 ## Meta
 
-- full_reload: false
-- first_invalidated_by: None
-- is_self_accepting: false
-- full_reload_reason: None
-### Hmr Boundaries
+- update type: noop
 # HMR Step 1
 
 ## Code
@@ -96,10 +92,7 @@ __rolldown_runtime__.applyUpdates(['hmr.js']);
 ```
 ## Meta
 
-- full_reload: false
-- first_invalidated_by: None
-- is_self_accepting: false
-- full_reload_reason: None
+- update type: patch
 ### Hmr Boundaries
 
 - boundary: hmr.js, accepted_via: hmr.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
@@ -154,10 +154,7 @@ __rolldown_runtime__.applyUpdates(['messenger.js']);
 ```
 ## Meta
 
-- full_reload: false
-- first_invalidated_by: None
-- is_self_accepting: false
-- full_reload_reason: None
+- update type: patch
 ### Hmr Boundaries
 
 - boundary: messenger.js, accepted_via: messenger.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -121,10 +121,7 @@ __rolldown_runtime__.applyUpdates(['hmr.js']);
 ```
 ## Meta
 
-- full_reload: false
-- first_invalidated_by: None
-- is_self_accepting: false
-- full_reload_reason: None
+- update type: patch
 ### Hmr Boundaries
 
 - boundary: hmr.js, accepted_via: hmr.js

--- a/crates/rolldown_binding/src/binding_bundler_impl.rs
+++ b/crates/rolldown_binding/src/binding_bundler_impl.rs
@@ -5,7 +5,10 @@ use crate::worker_manager::WorkerManager;
 use crate::{
   options::{BindingInputOptions, BindingOutputOptions},
   parallel_js_plugin_registry::ParallelJsPluginRegistry,
-  types::{binding_hmr_output::BindingHmrOutput, binding_outputs::BindingOutputs},
+  types::{
+    binding_hmr_output::{BindingHmrOutput, BindingHmrUpdate},
+    binding_outputs::BindingOutputs,
+  },
   utils::{
     handle_result, normalize_binding_options::normalize_binding_options,
     try_init_custom_trace_subscriber,
@@ -121,7 +124,7 @@ impl BindingBundlerImpl {
     let mut bundler_core = self.inner.lock().await;
     let result = bundler_core.generate_hmr_patch(changed_files).await;
     match result {
-      Ok(output) => Ok(output.into()),
+      Ok(output) => Ok(BindingHmrOutput::new(output.map(BindingHmrUpdate::from), None)),
       Err(errs) => {
         Ok(BindingHmrOutput::from_errors(errs.into_vec(), bundler_core.options().cwd.clone()))
       }
@@ -137,7 +140,7 @@ impl BindingBundlerImpl {
     let mut bundler_core = self.inner.lock().await;
     let result = bundler_core.hmr_invalidate(caller, first_invalidated_by).await;
     match result {
-      Ok(output) => Ok(output.into()),
+      Ok(output) => Ok(BindingHmrOutput::new(Some(output.into()), None)),
       Err(errs) => {
         Ok(BindingHmrOutput::from_errors(errs.into_vec(), bundler_core.options().cwd.clone()))
       }

--- a/crates/rolldown_common/src/hmr/hmr_output.rs
+++ b/crates/rolldown_common/src/hmr/hmr_output.rs
@@ -1,16 +1,27 @@
 use arcstr::ArcStr;
 
-#[derive(Default)]
-pub struct HmrOutput {
+#[derive(Debug)]
+pub struct HmrPatch {
   pub code: String,
   pub filename: String,
   pub sourcemap: Option<String>,
   pub sourcemap_filename: Option<String>,
   pub hmr_boundaries: Vec<HmrBoundaryOutput>,
-  pub full_reload: bool,
-  pub first_invalidated_by: Option<String>,
-  pub is_self_accepting: bool,            // only for hmr invalidate
-  pub full_reload_reason: Option<String>, // only for hmr invalidate
+}
+
+pub enum HmrUpdate {
+  Patch(HmrPatch),
+  FullReload {
+    reason: String,
+  },
+  /// For the hmr request, there're no actual actions that need to be done.
+  Noop,
+}
+
+impl HmrUpdate {
+  pub fn is_full_reload(&self) -> bool {
+    matches!(self, Self::FullReload { .. })
+  }
 }
 
 #[derive(Debug)]

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -97,7 +97,7 @@ pub use crate::{
   file_emitter::{EmittedAsset, EmittedChunk, EmittedChunkInfo, FileEmitter, SharedFileEmitter},
   hmr::{
     hmr_boundary::HmrBoundary,
-    hmr_output::{HmrBoundaryOutput, HmrOutput},
+    hmr_output::{HmrBoundaryOutput, HmrPatch, HmrUpdate},
   },
   module::{
     Module,

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -4,7 +4,7 @@ import {
 } from '../../utils/create-bundler';
 import { transformToRollupOutput } from '../../utils/transform-to-rollup-output';
 
-import type { BindingHmrOutputPatch } from '../../binding';
+import type { BindingHmrUpdate } from '../../binding';
 import { BindingBundler } from '../../binding';
 import type { InputOptions } from '../../options/input-options';
 import type { OutputOptions } from '../../options/output-options';
@@ -80,7 +80,7 @@ export class RolldownBuild {
 
   async generateHmrPatch(
     changedFiles: string[],
-  ): Promise<BindingHmrOutputPatch | undefined> {
+  ): Promise<BindingHmrUpdate | undefined> {
     const output = await this.#bundlerImpl!.impl.generateHmrPatch(
       changedFiles,
     );
@@ -90,7 +90,7 @@ export class RolldownBuild {
   async hmrInvalidate(
     file: string,
     firstInvalidatedBy?: string,
-  ): Promise<BindingHmrOutputPatch> {
+  ): Promise<BindingHmrUpdate> {
     const output = await this.#bundlerImpl!.impl.hmrInvalidate(
       file,
       firstInvalidatedBy,

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1175,7 +1175,7 @@ export declare class BindingError {
 }
 
 export declare class BindingHmrOutput {
-  get patch(): BindingHmrOutputPatch | null
+  get patch(): BindingHmrUpdate | null
   get errors(): Array<Error | BindingError>
 }
 
@@ -1489,17 +1489,10 @@ export interface BindingHmrBoundaryOutput {
   acceptedVia: string
 }
 
-export interface BindingHmrOutputPatch {
-  code: string
-  filename: string
-  sourcemap?: string
-  sourcemapFilename?: string
-  hmrBoundaries: Array<BindingHmrBoundaryOutput>
-  fullReload: boolean
-  firstInvalidatedBy?: string
-  isSelfAccepting: boolean
-  fullReloadReason?: string
-}
+export type BindingHmrUpdate =
+  | { type: 'Patch', code: string, filename: string, sourcemap?: string, sourcemapFilename?: string, hmrBoundaries: Array<BindingHmrBoundaryOutput> }
+  | { type: 'FullReload', reason?: string }
+  | { type: 'Noop' }
 
 export interface BindingHookFilter {
   value?: Array<Array<BindingFilterToken>>

--- a/packages/rolldown/src/utils/transform-hmr-patch-output.ts
+++ b/packages/rolldown/src/utils/transform-hmr-patch-output.ts
@@ -1,9 +1,9 @@
-import type { BindingHmrOutput, BindingHmrOutputPatch } from '../binding';
+import type { BindingHmrOutput, BindingHmrUpdate } from '../binding';
 import { normalizeErrors } from './error';
 
 export function transformHmrPatchOutput(
   output: BindingHmrOutput,
-): BindingHmrOutputPatch | undefined {
+): BindingHmrUpdate | undefined {
   handleHmrPatchOutputErrors(output);
   const { patch } = output;
   return patch ?? undefined;

--- a/packages/test-dev-server/src/dev-server.ts
+++ b/packages/test-dev-server/src/dev-server.ts
@@ -129,6 +129,9 @@ export class DevServer {
   sendUpdateToClient(
     output: Awaited<ReturnType<rolldown.RolldownBuild['hmrInvalidate']>>,
   ): void {
+    if (output.type !== 'Patch') {
+      return;
+    }
     if (this.hasLiveConnections && output.code) {
       console.log('Patching...');
       const path = `${seed}.js`;


### PR DESCRIPTION
- Use `enum` to reduce complexity caused by combine non-related data together