### PR TITLE
fix: missing_export warning should not be an hard error

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -711,12 +711,14 @@ impl BindImportsAndExportsContext<'_> {
             named_import.imported.to_string(),
             named_import.span_imported,
           );
-          if let Some(importee) = importee.as_normal() {
-            if matches!(importee.module_type, ModuleType::Ts | ModuleType::Tsx) {
-              diagnostic = diagnostic.with_severity_warning();
-            }
+          if let Some(importee) = importee.as_normal()
+            && matches!(importee.module_type, ModuleType::Ts | ModuleType::Tsx)
+          {
+            diagnostic = diagnostic.with_severity_warning();
+            self.warnings.push(diagnostic);
+          } else {
+            self.errors.push(diagnostic);
           }
-          self.errors.push(diagnostic);
         }
       }
     }

--- a/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/_config.json
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/_config.json
@@ -7,6 +7,5 @@
       }
     ]
   },
-  "expectExecuted": false,
-  "expectError": true
+  "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# Errors
+# warnings
 
 ## MISSING_EXPORT
 
@@ -26,4 +26,104 @@ source: crates/rolldown_testing/src/integration_test.rs
    │           ╰──── Missing export
 ───╯
 
+```
+# Assets
+
+## entry.js
+
+```js
+//#region keep/declare-class.ts
+let bar = 123;
+
+//#endregion
+//#region keep/declare-let.ts
+let bar$1 = 123;
+
+//#endregion
+//#region keep/interface-merged.ts
+var foo$3 = class foo$3 {
+	static x = new foo$3();
+};
+var interface_merged_default = foo$3;
+let bar$2 = 123;
+
+//#endregion
+//#region keep/interface-nested.ts
+var interface_nested_default = foo;
+let bar$3 = 123;
+
+//#endregion
+//#region keep/type-nested.ts
+var type_nested_default = foo;
+let bar$4 = 123;
+
+//#endregion
+//#region keep/value-namespace.ts
+let foo$2;
+(function(_foo) {
+	_foo.num = 0;
+})(foo$2 || (foo$2 = {}));
+var value_namespace_default = foo$2;
+let bar$5 = 123;
+
+//#endregion
+//#region keep/value-namespace-merged.ts
+let foo$1;
+(function(_foo) {
+	_foo.num = 0;
+})(foo$1 || (foo$1 = {}));
+var value_namespace_merged_default = foo$1;
+let bar$6 = 123;
+
+//#endregion
+//#region remove/interface.ts
+let bar$7 = 123;
+
+//#endregion
+//#region remove/interface-exported.ts
+let bar$8 = 123;
+
+//#endregion
+//#region remove/type.ts
+let bar$9 = 123;
+
+//#endregion
+//#region remove/type-exported.ts
+let bar$10 = 123;
+
+//#endregion
+//#region remove/type-only-namespace.ts
+let bar$11 = 123;
+
+//#endregion
+//#region remove/type-only-namespace-exported.ts
+let bar$12 = 123;
+
+//#endregion
+//#region entry.ts
+var entry_default = [
+	dc_def,
+	bar,
+	dl_def,
+	bar$1,
+	interface_merged_default,
+	bar$2,
+	interface_nested_default,
+	bar$3,
+	type_nested_default,
+	bar$4,
+	value_namespace_default,
+	bar$5,
+	value_namespace_merged_default,
+	bar$6,
+	bar$7,
+	bar$8,
+	bar$9,
+	bar$10,
+	bar$11,
+	bar$12
+];
+
+//#endregion
+export { entry_default as default };
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3484,6 +3484,10 @@ expression: output
 
 - entry-!~{000}~.js => entry-B7hHkHEF.js
 
+# tests/esbuild/ts/ts_export_default_type_issue316
+
+- entry-!~{000}~.js => entry-ezzTSP9M.js
+
 # tests/esbuild/ts/ts_export_equals
 
 - a-!~{000}~.js => a-B_RtVVxo.js


### PR DESCRIPTION
#4147 changed the severity but it was still pushed to `self.errors` instead of `self.warnings`.