### PR TITLE
chore: ensure all diagnostics in self.errors have Severity::Error

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -17,7 +17,7 @@ use rolldown_common::{
   SymbolRefDb,
 };
 use rolldown_debug::{action, trace_action, trace_action_enabled};
-use rolldown_error::{BuildDiagnostic, BuildResult};
+use rolldown_error::{BuildDiagnostic, BuildResult, Severity};
 use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_plugin::{
   __inner::SharedPluginable, HookBuildEndArgs, HookRenderErrorArgs, SharedPluginDriver,
@@ -139,6 +139,7 @@ impl Bundler {
     {
       Ok(v) => v,
       Err(errs) => {
+        debug_assert!(errs.iter().all(|e| e.severity() == Severity::Error));
         self
           .plugin_driver
           .build_end(Some(&HookBuildEndArgs { errors: &errs, cwd: &self.options.cwd }))
@@ -237,6 +238,7 @@ impl Bundler {
         .await; // Notice we don't use `?` to break the control flow here.
 
     if let Err(errors) = &bundle_output {
+      debug_assert!(errors.iter().all(|e| e.severity() == Severity::Error));
       self
         .plugin_driver
         .render_error(&HookRenderErrorArgs { errors, cwd: &self.options.cwd })

--- a/crates/rolldown_error/src/build_error/mod.rs
+++ b/crates/rolldown_error/src/build_error/mod.rs
@@ -78,6 +78,10 @@ impl BuildDiagnostic {
     self.inner.exporter()
   }
 
+  pub fn severity(&self) -> Severity {
+    self.severity
+  }
+
   // --- private
 
   fn new_inner(inner: impl Into<Box<dyn BuildEvent>>) -> Self {

--- a/crates/rolldown_error/src/build_error/severity.rs
+++ b/crates/rolldown_error/src/build_error/severity.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
   Error,
   Warning,


### PR DESCRIPTION
I'm not sure if this is the best way to ensure this. Maybe `self.errors.push` should have a check.
