### PR TITLE
refactor: use pascal case when naming bitflags field

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -77,7 +77,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
       self.visit_statement(stmt);
       if self.current_stmt_info.side_effect.contains(SideEffectDetail::Unknown) {
-        self.result.ecma_view_meta.insert(EcmaViewMeta::HAS_ANALYZED_SIDE_EFFECT);
+        self.result.ecma_view_meta.insert(EcmaViewMeta::HasAnalyzedSideEffect);
       }
       self.result.stmt_infos.add_stmt_info(std::mem::take(&mut self.current_stmt_info));
     }
@@ -86,7 +86,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     self.result.directive_range = program.directives.iter().map(GetSpan::span).collect();
     self.result.dynamic_import_rec_exports_usage =
       std::mem::take(&mut self.dynamic_import_usage_info.dynamic_import_exports_usage);
-    if self.result.ecma_view_meta.contains(EcmaViewMeta::EVAL) {
+    if self.result.ecma_view_meta.contains(EcmaViewMeta::Eval) {
       // if there exists `eval` in current module, assume all dynamic import are completely used;
       for usage in self.result.dynamic_import_rec_exports_usage.values_mut() {
         *usage = DynamicImportExportsUsage::Complete;
@@ -449,7 +449,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       if ident_ref.name == "eval" {
         // TODO: esbuild track has_eval for each scope, this could reduce bailout range, and may
         // improve treeshaking performance. https://github.com/evanw/esbuild/blob/360d47230813e67d0312ad754cad2b6ee09b151b/internal/js_ast/js_ast.go#L1288-L1291
-        self.result.ecma_view_meta.insert(EcmaViewMeta::EVAL);
+        self.result.ecma_view_meta.insert(EcmaViewMeta::Eval);
         self.result.warnings.push(
           BuildDiagnostic::eval(self.id.to_string(), self.source.clone(), ident_ref.span)
             .with_severity_warning(),

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -447,10 +447,10 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
 
     let ref_flags = symbol_ref.flags_mut(&mut self.result.symbol_ref_db);
     if is_const {
-      ref_flags.insert(SymbolRefFlags::IS_CONST);
+      ref_flags.insert(SymbolRefFlags::IsConst);
     }
     if !is_reassigned {
-      ref_flags.insert(SymbolRefFlags::IS_NOT_REASSIGNED);
+      ref_flags.insert(SymbolRefFlags::IsNotReassigned);
     }
 
     self.result.named_exports.insert(
@@ -462,7 +462,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   fn add_local_default_export(&mut self, local: SymbolId, span: Span) {
     // The default symbol ref never get reassigned.
     let symbol_ref: SymbolRef = (self.idx, local).into();
-    symbol_ref.flags_mut(&mut self.result.symbol_ref_db).insert(SymbolRefFlags::IS_NOT_REASSIGNED);
+    symbol_ref.flags_mut(&mut self.result.symbol_ref_db).insert(SymbolRefFlags::IsNotReassigned);
 
     self.result.named_exports.insert(
       "default".into(),
@@ -584,7 +584,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     } else {
       // export * from '...'
       self.result.import_records[id].meta.insert(ImportRecordMeta::IS_EXPORT_STAR);
-      self.result.ecma_view_meta.insert(EcmaViewMeta::HAS_STAR_EXPORT);
+      self.result.ecma_view_meta.insert(EcmaViewMeta::HasStarExport);
     }
     self.result.imports.insert(decl.span, id);
   }

--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -78,7 +78,7 @@ impl ChunkGraph {
         }
         if let Some(normal) = module.as_normal()
           && normal.import_records.is_empty()
-          && !normal.meta.contains(EcmaViewMeta::HAS_ANALYZED_SIDE_EFFECT)
+          && !normal.meta.contains(EcmaViewMeta::HasAnalyzedSideEffect)
         {
           side_effects_free_leaf_modules.push(module_idx);
         } else {

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -114,9 +114,9 @@ pub async fn create_ecma_view(
     side_effects,
     meta: {
       let mut meta = ecma_view_meta;
-      meta.set(EcmaViewMeta::HAS_LAZY_EXPORT, has_lazy_export);
+      meta.set(EcmaViewMeta::HasLazyExport, has_lazy_export);
       meta.set(
-        EcmaViewMeta::SAFELY_TREESHAKE_COMMONJS,
+        EcmaViewMeta::SafelyTreeshakeCommonjs,
         ast_usage.contains(EcmaModuleAstUsage::AllStaticExportPropertyAccess)
           && !ast_usage.contains(EcmaModuleAstUsage::UnknownExportsRead),
       );

--- a/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
@@ -69,7 +69,7 @@ impl GenerateStage<'_> {
           continue;
         };
         if self.link_output.metas[normal.idx].wrap_kind == WrapKind::Cjs
-          && normal.meta.contains(EcmaViewMeta::HAS_ANALYZED_SIDE_EFFECT)
+          && normal.meta.contains(EcmaViewMeta::HasAnalyzedSideEffect)
         {
           bailout_importer = true;
         }

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -171,7 +171,7 @@ impl LinkStage<'_> {
       .filter_map(|(m, meta)| m.as_normal_mut().map(|m| (m, meta)))
       .for_each(|(module, meta)| {
         let idx = module.idx;
-        module.meta.set(EcmaViewMeta::INCLUDED, is_module_included_vec[idx]);
+        module.meta.set(EcmaViewMeta::Included, is_module_included_vec[idx]);
         is_included_vec[module.idx].iter_enumerated().for_each(|(stmt_info_id, is_included)| {
           module.stmt_infos.get_mut(stmt_info_id).is_included = *is_included;
         });
@@ -410,7 +410,7 @@ impl LinkStage<'_> {
 
     let module =
       self.module_table[self.runtime.id()].as_normal_mut().expect("should be a normal module");
-    module.meta.set(EcmaViewMeta::INCLUDED, true);
+    module.meta.set(EcmaViewMeta::Included, true);
 
     for (stmt_idx, included) in is_stmt_included_vec[self.runtime.id()].iter_enumerated() {
       module.stmt_infos.get_mut(stmt_idx).is_included = *included;
@@ -439,7 +439,7 @@ fn include_module(ctx: &mut Context, module: &NormalModule) {
       let bail_eval = module.meta.has_eval()
         && !stmt_info.declared_symbols.is_empty()
         && stmt_info_id.index() != 0;
-      let has_side_effects = if module.meta.contains(EcmaViewMeta::SAFELY_TREESHAKE_COMMONJS)
+      let has_side_effects = if module.meta.contains(EcmaViewMeta::SafelyTreeshakeCommonjs)
         && ctx.options.treeshake.commonjs()
       {
         stmt_info.side_effect.contains(SideEffectDetail::Unknown)

--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -37,7 +37,7 @@ fn wrap_module_recursively(ctx: &mut Context, target: ModuleIdx) {
   // Check if the module really needs to be wrapped
   if ctx.on_demand_wrapping
     && matches!(module.exports_kind, ExportsKind::Esm | ExportsKind::None)
-    && !module.meta.contains(EcmaViewMeta::HAS_ANALYZED_SIDE_EFFECT)
+    && !module.meta.contains(EcmaViewMeta::HasAnalyzedSideEffect)
     && module.import_records.is_empty()
   {
     return;

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -16,12 +16,12 @@ use crate::{
 bitflags! {
     #[derive(Debug, Default, Clone, Copy)]
     pub struct EcmaViewMeta: u8 {
-        const EVAL = 1;
-        const INCLUDED = 1 << 1;
-        const HAS_LAZY_EXPORT = 1 << 2;
-        const HAS_STAR_EXPORT = 1 << 3;
-        const SAFELY_TREESHAKE_COMMONJS = 1 << 4;
-        const HAS_ANALYZED_SIDE_EFFECT = 1 << 5;
+        const Eval = 1;
+        const Included = 1 << 1;
+        const HasLazyExport = 1 << 2;
+        const HasStarExport = 1 << 3;
+        const SafelyTreeshakeCommonjs = 1 << 4;
+        const HasAnalyzedSideEffect = 1 << 5;
     }
 }
 
@@ -43,19 +43,19 @@ pub fn generate_replace_this_expr_map(
 impl EcmaViewMeta {
   #[inline]
   pub fn has_eval(&self) -> bool {
-    self.contains(Self::EVAL)
+    self.contains(Self::Eval)
   }
   #[inline]
   pub fn is_included(&self) -> bool {
-    self.contains(Self::INCLUDED)
+    self.contains(Self::Included)
   }
   #[inline]
   pub fn has_lazy_export(&self) -> bool {
-    self.contains(Self::HAS_LAZY_EXPORT)
+    self.contains(Self::HasLazyExport)
   }
   #[inline]
   pub fn has_star_export(&self) -> bool {
-    self.contains(Self::HAS_STAR_EXPORT)
+    self.contains(Self::HasStarExport)
   }
 }
 

--- a/crates/rolldown_common/src/types/symbol_ref.rs
+++ b/crates/rolldown_common/src/types/symbol_ref.rs
@@ -41,14 +41,14 @@ impl SymbolRef {
   pub fn is_declared_by_const(&self, db: &SymbolRefDb) -> Option<bool> {
     let flags = self.flags(db)?;
     // Not having this flag means we don't know if it's declared by `const` instead of it's not declared by `const`.
-    flags.contains(SymbolRefFlags::IS_CONST).then_some(true)
+    flags.contains(SymbolRefFlags::IsConst).then_some(true)
   }
 
   /// `None` means we don't know if it gets reassigned.
   pub fn is_not_reassigned(&self, db: &SymbolRefDb) -> Option<bool> {
     let flags = self.flags(db)?;
     // Not having this flag means we don't know
-    flags.contains(SymbolRefFlags::IS_NOT_REASSIGNED).then_some(true)
+    flags.contains(SymbolRefFlags::IsNotReassigned).then_some(true)
   }
 
   pub fn is_declared_in_root_scope(&self, db: &SymbolRefDb) -> bool {

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -25,9 +25,9 @@ pub struct SymbolRefDataClassic {
 bitflags::bitflags! {
   #[derive(Debug, Default, Clone, Copy)]
   pub struct SymbolRefFlags: u8 {
-    const IS_NOT_REASSIGNED = 1;
+    const IsNotReassigned = 1;
     /// If this symbol is declared by `const`. Eg. `const a = 1;`
-    const IS_CONST = 1 << 1;
+    const IsConst = 1 << 1;
   }
 }
 


### PR DESCRIPTION
Most of `bitflags` already use **Pascal** case, this pr unifies all naming style