### PR TITLE
fix(scanner): identify `module.exports.__esModule = true`

### DIFF
--- a/crates/rolldown/src/ast_scanner/cjs_ast_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/cjs_ast_analyzer.rs
@@ -47,7 +47,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
           let parent_parent_kind = self.visit_path.get(cursor - 1)?;
           match parent_parent_kind {
             parent_parent_kind if parent_parent_kind.is_member_expression_kind() => {
-              let parent_parent = kind.as_member_expression_kind().unwrap();
+              let parent_parent = parent_parent_kind.as_member_expression_kind().unwrap();
               self.check_assignment_target_property(&parent_parent, cursor - 1)
             }
             AstKind::Argument(arg) => self.check_object_define_property(arg, cursor - 1),


### PR DESCRIPTION
Fix what I think is a bug in the scanner.

Prior to #5069 this code was:

```rs
match parent_parent_kind {
    AstKind::MemberExpression(parent_parent) => {
        self.check_assignment_target_property(parent_parent, cursor - 1)
    }
}
```

#5069 [changed it](https://github.com/rolldown/rolldown/pull/5069/files#diff-75d46c668c6a1268220bfc745c56ee8fbd1652c0ae6fefef4d7fc77725de8462L38-R42) to:

```rs
match parent_parent_kind {
    parent_parent_kind if parent_parent_kind.is_member_expression_kind() => {
        let parent_parent = kind.as_member_expression_kind().unwrap();
        //                  ^^^^
        self.check_assignment_target_property(&parent_parent, cursor - 1)
    }
}
```

I believe this change introduced a bug - `kind` is the `AstKind` of the *parent* of `module`, which is `module.exports`. But what we want to check here is the *grandparent* - to see if it's `module.exports.__esModule`. Consequently I'd expect that `module.exports.__esModule = true` is not being correctly identified.

However, I'm not familiar with Rolldown, and this PR change makes no difference to test results. So could someone else please check my logic?

(came across this while preparing a PR to update to latest Oxc, which touches the same code)