### PR TITLE
feat: expose `sourcemapBaseUrl` from NormalizedOutputOptions

### DIFF
--- a/crates/rolldown_binding/src/types/binding_normalized_options.rs
+++ b/crates/rolldown_binding/src/types/binding_normalized_options.rs
@@ -165,6 +165,11 @@ impl BindingNormalizedOptions {
   }
 
   #[napi(getter)]
+  pub fn sourcemap_base_url(&self) -> Option<String> {
+    self.inner.sourcemap_base_url.clone()
+  }
+
+  #[napi(getter)]
   pub fn banner(&self) -> Either<Option<String>, Undefined> {
     match &self.inner.banner {
       Some(rolldown::AddonOutputOption::String(inner)) => Either::A(inner.clone()),

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1203,6 +1203,7 @@ export declare class BindingNormalizedOptions {
   get esModule(): boolean | 'if-default-prop'
   get inlineDynamicImports(): boolean
   get sourcemap(): boolean | 'inline' | 'hidden'
+  get sourcemapBaseUrl(): string | null
   get banner(): string | undefined | null | undefined
   get footer(): string | undefined | null | undefined
   get intro(): string | undefined | null | undefined

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -28,6 +28,7 @@ export interface NormalizedOutputOptions {
   format: InternalModuleFormat;
   exports: NonNullable<OutputOptions['exports']>;
   sourcemap: boolean | 'inline' | 'hidden';
+  sourcemapBaseUrl: string | undefined;
   cssEntryFileNames: string | ChunkFileNamesFunction;
   cssChunkFileNames: string | ChunkFileNamesFunction;
   inlineDynamicImports: boolean;
@@ -88,6 +89,10 @@ export class NormalizedOutputOptionsImpl implements NormalizedOutputOptions {
 
   get sourcemap(): boolean | 'inline' | 'hidden' {
     return this.inner.sourcemap;
+  }
+
+  get sourcemapBaseUrl(): string | undefined {
+    return this.inner.sourcemapBaseUrl ?? undefined;
   }
 
   get cssEntryFileNames(): string | ChunkFileNamesFunction {


### PR DESCRIPTION
Follow up to #5413.

Exposed `sourcemapBaseUrl` from `NormalizedOutputOptions`.