### PR TITLE
fix: error instead of panic if `sourcemapBaseUrl` is an invalid URL

### DIFF
--- a/crates/rolldown_binding/src/types/binding_normalized_options.rs
+++ b/crates/rolldown_binding/src/types/binding_normalized_options.rs
@@ -165,6 +165,11 @@ impl BindingNormalizedOptions {
   }
 
   #[napi(getter)]
+  pub fn sourcemap_base_url(&self) -> Option<String> {
+    self.inner.sourcemap_base_url.clone()
+  }
+
+  #[napi(getter)]
   pub fn banner(&self) -> Either<Option<String>, Undefined> {
     match &self.inner.banner {
       Some(rolldown::AddonOutputOption::String(inner)) => Either::A(inner.clone()),

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -335,15 +335,24 @@ pub fn normalize_binding_options(
     footer: normalize_addon_option(output_options.footer),
     intro: normalize_addon_option(output_options.intro),
     outro: normalize_addon_option(output_options.outro),
-    sourcemap_base_url: output_options.sourcemap_base_url.map(|maybe_url| {
-      if let Ok(mut url) = Url::parse(&maybe_url) {
-        if !url.path().ends_with('/') {
-          url.set_path(&rolldown_utils::concat_string!(url.path(), "/"));
+    sourcemap_base_url: output_options
+      .sourcemap_base_url
+      .map(|maybe_url| {
+        if let Ok(mut url) = Url::parse(&maybe_url) {
+          if !url.path().ends_with('/') {
+            url.set_path(&rolldown_utils::concat_string!(url.path(), "/"));
+          }
+          Ok(url.to_string())
+        } else {
+          Err(napi::Error::new(
+            napi::Status::GenericFailure,
+            format!(
+              "Invalid value for `sourcemapBaseUrl` option, should be a valid URL: {maybe_url}"
+            ),
+          ))
         }
-        return url.to_string();
-      }
-      panic!("Invalid sourcemapBaseUrl: {maybe_url}");
-    }),
+      })
+      .transpose()?,
     sourcemap_ignore_list,
     sourcemap_path_transform,
     sourcemap_debug_ids: output_options.sourcemap_debug_ids,

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1203,6 +1203,7 @@ export declare class BindingNormalizedOptions {
   get esModule(): boolean | 'if-default-prop'
   get inlineDynamicImports(): boolean
   get sourcemap(): boolean | 'inline' | 'hidden'
+  get sourcemapBaseUrl(): string | null
   get banner(): string | undefined | null | undefined
   get footer(): string | undefined | null | undefined
   get intro(): string | undefined | null | undefined

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -28,6 +28,7 @@ export interface NormalizedOutputOptions {
   format: InternalModuleFormat;
   exports: NonNullable<OutputOptions['exports']>;
   sourcemap: boolean | 'inline' | 'hidden';
+  sourcemapBaseUrl: string | undefined;
   cssEntryFileNames: string | ChunkFileNamesFunction;
   cssChunkFileNames: string | ChunkFileNamesFunction;
   inlineDynamicImports: boolean;
@@ -88,6 +89,10 @@ export class NormalizedOutputOptionsImpl implements NormalizedOutputOptions {
 
   get sourcemap(): boolean | 'inline' | 'hidden' {
     return this.inner.sourcemap;
+  }
+
+  get sourcemapBaseUrl(): string | undefined {
+    return this.inner.sourcemapBaseUrl ?? undefined;
   }
 
   get cssEntryFileNames(): string | ChunkFileNamesFunction {


### PR DESCRIPTION
Follow up to #5413