### PR TITLE
fix: __name lacks require('./chunk-containing-runtime') when format: 'cjs' + keepNames: true

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -256,14 +256,15 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
     // TODO: perf it
     for (stmt_index, original_name, new_name) in self.ctx.keep_name_statement_to_insert.iter().rev()
     {
-      let finalized_name = self.snippet.atom(self.canonical_name_for_runtime("__name"));
+      let name_ref = self.canonical_ref_for_runtime("__name");
+      let finalized_callee = self.finalized_expr_for_symbol_ref(name_ref, false, false);
       let target =
         self.snippet.builder.expression_identifier(SPAN, self.snippet.builder.atom(new_name));
       it.insert(
         *stmt_index,
         self.snippet.builder.statement_expression(
           SPAN,
-          self.snippet.keep_name_call_expr(original_name, target, finalized_name, false),
+          self.snippet.keep_name_call_expr(original_name, target, finalized_callee, false),
         ),
       );
     }
@@ -525,9 +526,10 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
               {
                 let fn_expr = init.take_in(self.alloc);
 
-                let finalized_name = self.snippet.atom(self.canonical_name_for_runtime("__name"));
+                let name_ref = self.canonical_ref_for_runtime("__name");
+                let finalized_callee = self.finalized_expr_for_symbol_ref(name_ref, false, false);
                 *init =
-                  self.snippet.keep_name_call_expr(&original_name, fn_expr, finalized_name, true);
+                  self.snippet.keep_name_call_expr(&original_name, fn_expr, finalized_callee, true);
               }
             }
             _ => {}

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1251,8 +1251,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     }
     let (original_name, _) = self.get_conflicted_info(id.as_ref()?)?;
     let original_name: Rstr = original_name.into();
-    let canonical_name = self.snippet.atom(self.canonical_name_for_runtime("__name"));
-    Some(self.snippet.static_block_keep_name_helper(&original_name, canonical_name.as_str()))
+
+    let name_ref = self.canonical_ref_for_runtime("__name");
+    let finalized_callee = self.finalized_expr_for_symbol_ref(name_ref, false, false);
+    Some(self.snippet.static_block_keep_name_helper(&original_name, finalized_callee))
   }
 
   fn try_rewrite_import_expression(&self, node: &mut ast::Expression<'ast>) -> bool {

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_5525/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_5525/_config.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "./entry.js"
+      },
+      {
+        "name": "entry2",
+        "import": "./entry2.js"
+      }
+    ],
+    "keepNames": true,
+    "format": "cjs"
+  },
+  "snapshot": false
+}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_5525/entry.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_5525/entry.js
@@ -1,0 +1,23 @@
+import {
+	Foo as Bar,
+	VarKlass as VarKlass2,
+	FunctionDeclaration as FunctionDeclaration2,
+	VarFunction as VarFunction2,
+	VarKlass,
+} from "./foo.js";
+import assert from "node:assert";
+
+assert.strictEqual(Bar.name, "Foo");
+assert.strictEqual(VarKlass2.name, "VarKlass");
+assert.strictEqual(FunctionDeclaration2.name, "FunctionDeclaration");
+assert.strictEqual(VarFunction2.name, "VarFunction");
+
+class Foo {}
+export const VarKlass = class {};
+export function FunctionDeclaration() {}
+export const VarFunction = function () {};
+
+assert.strictEqual(Foo.name, "Foo");
+assert.strictEqual(VarKlass.name, "VarKlass");
+assert.strictEqual(FunctionDeclaration.name, "FunctionDeclaration");
+assert.strictEqual(VarFunction.name, "VarFunction");

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_5525/entry2.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_5525/entry2.js
@@ -1,0 +1,7 @@
+import { Foo as Bar } from './foo.js'
+
+export class Foo {
+
+}
+
+export { Bar }

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_5525/foo.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_5525/foo.js
@@ -1,0 +1,5 @@
+export class Foo {}
+export const VarKlass = class {}
+export function FunctionDeclaration() {} 
+export const VarFunction = function() {}
+

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5561,6 +5561,12 @@ expression: output
 
 - decorator-!~{000}~.js => decorator-CvurVfst.js
 
+# tests/rolldown/topics/keep_names/issue_5525
+
+- entry-!~{000}~.js => entry-BCzFFI04.js
+- entry2-!~{001}~.js => entry2-CA0mV8Xo.js
+- foo-!~{002}~.js => foo-DKOGr9By.js
+
 # tests/rolldown/topics/live_bindings/default_export_binding
 
 - main-!~{000}~.js => main-DPODtWAZ.js

--- a/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
@@ -744,12 +744,12 @@ impl<'ast> AstSnippet<'ast> {
     &self,
     original_name: PassedStr,
     target: Expression<'ast>,
-    canonical_runtime_name: Atom<'ast>,
+    callee: Expression<'ast>,
     pure: bool,
   ) -> Expression<'ast> {
     self.builder.expression_call_with_pure(
       SPAN,
-      self.builder.expression_identifier(SPAN, canonical_runtime_name),
+      callee,
       NONE,
       {
         let mut items = self.builder.vec_with_capacity(2);
@@ -767,7 +767,7 @@ impl<'ast> AstSnippet<'ast> {
   pub fn static_block_keep_name_helper(
     &self,
     name: PassedStr,
-    canonical_runtime_name: PassedStr<'ast>,
+    callee: Expression<'ast>,
   ) -> ClassElement<'ast> {
     self.builder.class_element_static_block(
       SPAN,
@@ -775,7 +775,7 @@ impl<'ast> AstSnippet<'ast> {
         SPAN,
         self.builder.expression_call(
           SPAN,
-          self.builder.expression_identifier(SPAN, canonical_runtime_name),
+          callee,
           NONE,
           {
             let mut items = self.builder.vec_with_capacity(2);


### PR DESCRIPTION
closed #5525