### PR TITLE
chore(vscode): remove `code-spell-checker` extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "editorconfig.editorconfig",
-    "streetsidesoftware.code-spell-checker",
     "rust-lang.rust-analyzer",
     "dprint.dprint"
   ]


### PR DESCRIPTION
We no longer use `cspell`.