### PR TITLE
feat(rolldown): oxc v0.80.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "shlex",
 ]
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29180405ab3b37bb020246ea66bf8ae233708766fd59581ae929feaef10ce91"
+checksum = "35584c5fcba8059780748866387fb97c5a203bcfc563fc3d0790af406727a117"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1355,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -1458,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.1.3"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afaf586c21f260e9dc327ae3585fc6efcbb24a416d5151da38bbd35a1f2663c8"
+checksum = "3f995fe29e20a4d5bf5af93d3c8384fd53772bbbc1bf3b03e38dce2b1b0425e3"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -1482,9 +1482,9 @@ checksum = "dcae8ad5609d14afb3a3b91dee88c757016261b151e9dcecabf1b2a31a6cab14"
 
 [[package]]
 name = "napi-derive"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e61844e0c0bb81e711f2084abe7cff187b03ca21ff8b000cb59bbda61e15a9"
+checksum = "7e6d190d5e09d449b2b38127cdcdb7aed860599e492a15c73f977d5d87df69a5"
 dependencies = [
  "convert_case",
  "ctor",
@@ -1496,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ab19e9b98efb13895f492a2e367ca50c955ac3c4723613af73fdda4011afcc"
+checksum = "15158ced16693eaa0c709e4c9768ca08eb56325691e68510db8440d27ccd41d1"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1728,9 +1728,9 @@ checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "oxc"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103305034c9bcdd1cf8514fae2581cff754330fba3fd7b00eb989cf59d34b67"
+checksum = "8af9eb06845613ecab92d0c08bba1e05d3226152e3e07d1793ad3aa228a3f05e"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1752,11 +1752,12 @@ dependencies = [
 
 [[package]]
 name = "oxc-browserslist"
-version = "2.0.12"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05d19022f54d3e0b8b1679c80f02d140e95e4308385eb247ba3168c299c81bb"
+checksum = "b94a2f0da0105f3a813eeb6b182a791b2dc491f494432e1953fd8e72c1f3887d"
 dependencies = [
  "bincode 2.0.1",
+ "flate2",
  "nom",
  "rustc-hash",
  "serde",
@@ -1792,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0648465317fe75292f9c4bcd66f072b84a3c5da423e2afc526c4ffa0c2dcbe"
+checksum = "0b1301e61c53d6f0a252a0e9f6495b112f403e6fcee7f7040055a77682e68768"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -1807,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c6726eb07082e19cbd9207299b981d96a91b24b1e9fac50ef83abf6957c103"
+checksum = "670cf83ede2349153ffcd30105aa42aa34de493919a2dea628cfbfada8461b97"
 dependencies = [
  "bitflags 2.9.1",
  "oxc_allocator",
@@ -1823,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22a1455097feb967e5fe9e8423ad6b54f879c0bf2f19790004a51d780b6de42"
+checksum = "79a8d5845a8fce343729abff7c46bfe839a6a763c2ec805dcfb85c83fd15a8b5"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1835,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5525d0a6f41d8562b0eba5b2fd86eb10b545a0670f06895d6e2ee29a426c3a"
+checksum = "bd499527d053a9932b0263fdb93dd5f8b2b319e039b16dcefe35c41d12a6aa2d"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1848,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc0cdee51de4ca60d35886bfef14dbf66517dcdb30c0ccc6bcddf2f1d6b8ee"
+checksum = "24790a46aeee018020ba6c3d9f78c61cf7ce1b8c448ef41c1c40e7b207a52d0a"
 dependencies = [
  "bitflags 2.9.1",
  "itertools",
@@ -1863,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde7a3dd1d2de014fd2d527a9e851b0ea5cd2c6a222c55db76e0778921ff55e0"
+checksum = "50768c311d0db5641da3708d0b6c9c63edb6841f19b722f98ae4c1a9e811238c"
 dependencies = [
  "bitflags 2.9.1",
  "cow-utils",
@@ -1884,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8bfe5529c2e92d065de962990f094db40b7073a25256fbf1cf2393f885c53f"
+checksum = "15f63e3fbabe99f18ad51db5d68d5dc5c407d038f67e4faf3ca9a4a3e6836122"
 dependencies = [
  "ropey",
  "rustversion",
@@ -1894,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf81eb976b8573dd6df3a205c09a053368dec82aa02b3a26ef87b1c8a281b4e"
+checksum = "395715864b505c0f1ac61fd5fd9dad03b85529323be5c69143c28d10c10a87e3"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1905,12 +1906,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f477b1e3169c1262a5e6cd8750bb068a372d92aaa897767716326d5982b382a4"
+checksum = "420a96025457985ecb7bc537d80a1760d0326b4faa627f3362f1203cc802993e"
 dependencies = [
+ "cow-utils",
  "num-bigint",
  "num-traits",
+ "oxc_allocator",
  "oxc_ast",
  "oxc_span",
  "oxc_syntax",
@@ -1918,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021de9011a2cbed28c6f3bf508cedcf9ae6f706c3ec44f4ec6b0444e510a5cd6"
+checksum = "a75a6aca8a627435939ab1b216b3013fcd6797915faa220566978179b11315b2"
 dependencies = [
  "itoa",
  "oxc_data_structures",
@@ -1939,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b922c2df7df06c908274f3f1588fba934ab1646bf544d5b5a1f3f0cb9f75cb"
+checksum = "295a7f60bf86ac9fbec977f6c8a9df87d6a4e1dfc431f3666cf9e63aaef03569"
 dependencies = [
  "bitflags 2.9.1",
  "oxc_allocator",
@@ -1956,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b85dd5fd3166477dfc14edf32b6bc2afd76924402458431834702f41e8f699"
+checksum = "c7c508130d7f24fac09a3f06804de663611501b615437ccaa96299de59d4ffa1"
 dependencies = [
  "fixedbitset",
  "itertools",
@@ -1973,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13127a076342affc6c0a1865edaf245156bc874c8f63168201d6c4acb7c0e692"
+checksum = "2ce962ad9e418a3fe53d247e64a63e66e65bed7f8e4fef5fe296cbb4b86aecaf"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -1994,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0caa91afa1e83da64aef224e62e5a63f6da5b5bf889ec041f984579d3c20bc"
+checksum = "2ce37cbfab9687bf8f12f569f8dcd434e755cfc64dfd2f37afd3a52a17453bfa"
 dependencies = [
  "napi",
  "napi-build",
@@ -2010,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da1b5f1855784705ba07fdaac9f608820d90c2b8939feb62bf289fe98c10ce7"
+checksum = "e3795e25917b06c517761baa5fea9fe2ce1f67180608945375d67f605b4f7980"
 dependencies = [
  "bitflags 2.9.1",
  "cow-utils",
@@ -2033,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb60fc02849374102672e02cd43ee4f65bdb64ccd36d35311a5044cd0d86430"
+checksum = "7932d89acd52a1d1f2951a900ab9c58974bf12de1813b4cb3c7d37b694abebd9"
 dependencies = [
  "napi",
  "napi-build",
@@ -2049,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6326ce81b7010b863310f81d0e6aa64a463bb090294f25ee41d65d1d44fe05"
+checksum = "d5649b52cca897621f4f403c6d92bddb45fade8da0f01e68e3b88240d232fda7"
 dependencies = [
  "bitflags 2.9.1",
  "oxc_allocator",
@@ -2099,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80120323d4254d11f18b3be215b1ea05994f77ebfd116671ee0445521337c154"
+checksum = "76d661bed7b8349ca63e8100a983ee1a3d059f51a345db0b90c49ef3a05bf5ef"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2121,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "4.0.3"
+version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0618099929dae38d4473066a5bb59e27e91c46db747d3671dca382c92e0264"
+checksum = "1d6057a9bbd4a84bb4146539123642ee66e0f5ac700b0fcddd193cabcb2e0460"
 dependencies = [
  "base64-simd",
  "napi",
@@ -2136,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fcbae2eb648351603dee42a56f19a6f9900e55f189dd9fe6373c786eb079d8"
+checksum = "96fd662d7483121c8acee269f0ec52759fc506e7c92d52453f716d4ab4b25f2b"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2150,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d64b6aa7f4f2d49ce1c2b109a0964196c4045b66692ec6c64b04f21d0639a7"
+checksum = "74e67afd539df6cb1f8de52e3df056b745c4f91b5e5ce59c3b2c398bd5ec54b8"
 dependencies = [
  "bitflags 2.9.1",
  "cow-utils",
@@ -2172,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e8958be5d270cab3f290e4bff2baedc5dfec693e07dab7db621d76041927e"
+checksum = "369aa9b39f1b5e4a74cb10410b248230310d8e8a56651a9983ea57f3e295ed8b"
 dependencies = [
  "napi",
  "napi-build",
@@ -2187,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d6ff78c0dbca0623a66ed1734677daa2d752eb448a695744eff3f65f2ef6a1"
+checksum = "61ca579f8743df79a79f1333026f101e154c880f180e09e1cb10365a6108516b"
 dependencies = [
  "base64",
  "compact_str",
@@ -2218,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec278199b99a42bffb32c6a78f4c997b197abe5effe75ad1e1203ba443947bf1"
+checksum = "7065149e5c14f7e111c105396b7f553f58037b41369c814745c6e8a6edcff421"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2240,9 +2243,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6912a7af91bbd721afe6065bb25560b38975a88d5be7c06b6940ec506d2bb81b"
+checksum = "e42142999fc22b26b58a3bd79151e77fe8f0f47448694b5c7bde1c087243b98d"
 dependencies = [
  "itoa",
  "oxc_allocator",
@@ -3421,9 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3687,9 +3690,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "io-uring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,14 +197,14 @@ napi-build = { version = "2.2.2" }
 napi-derive = { version = "3.0.0", default-features = false, features = ["type-def"] }
 
 # oxc crates with the same version
-oxc = { version = "0.79.0", features = ["ast_visit", "transformer", "minifier", "mangler", "semantic", "codegen", "serialize", "isolated_declarations", "regular_expression", "cfg"] }
-oxc_ecmascript = { version = "0.79.0" }
-oxc_parser_napi = { version = "0.79.0" }
-oxc_transform_napi = { version = "0.79.0" }
+oxc = { version = "0.80.0", features = ["ast_visit", "transformer", "minifier", "mangler", "semantic", "codegen", "serialize", "isolated_declarations", "regular_expression", "cfg"] }
+oxc_ecmascript = { version = "0.80.0" }
+oxc_parser_napi = { version = "0.80.0" }
+oxc_transform_napi = { version = "0.80.0" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.
-# Please update with `cargo update oxc_resolver oxc_resolver_napi oxc_sourcemap oxc_index`
+# Please update with `cargo update oxc_resolver oxc_resolver_napi oxc_sourcemap oxc_index oxc-browserslist`
 oxc_index = { version = "3", features = ["rayon", "serde"] } # https://github.com/oxc-project/oxc-index-vec
 oxc_resolver = { version = "11.5.0", features = ["package_json_raw_json_api", "yarn_pnp"] } # https://github.com/oxc-project/oxc-resolver
 oxc_resolver_napi = { version = "11.5.0", default-features = false, features = ["yarn_pnp"] }

--- a/crates/rolldown/tests/esbuild/dce/dce_of_decorators/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/dce_of_decorators/artifacts.snap
@@ -16,8 +16,14 @@ const fn = () => {
 var Field = class {
 	@fn field;
 };
+var Method = class {
+	@fn method() {}
+};
 var StaticField = class {
 	@fn static field;
+};
+var StaticMethod = class {
+	@fn static method() {}
 };
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/dce/dce_of_experimental_decorators/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/dce_of_experimental_decorators/artifacts.snap
@@ -16,8 +16,14 @@ const fn = () => {
 var Field = class {
 	@fn field;
 };
+var Method = class {
+	@fn method() {}
+};
 var StaticField = class {
 	@fn static field;
+};
+var StaticMethod = class {
+	@fn static method() {}
 };
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/dce/dce_of_symbol_instances/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/dce_of_symbol_instances/artifacts.snap
@@ -7,17 +7,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region class.js
-var Keep1 = class {
-	*[Symbol.iterator]() {}
-	[keep];
-};
-var Keep2 = class {
-	[keep];
-	*[Symbol.iterator]() {}
-};
-var Keep3 = class {
-	*[Symbol.wtf]() {}
-};
+Symbol.iterator, keep;
+keep, Symbol.iterator;
+Symbol.wtf;
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field/artifacts.snap
@@ -7,11 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var KeepMe1 = class {
-	static x = "x";
-	static y = sideEffects();
-	static z = "z";
-};
+sideEffects();
 var KeepMe2 = class {
 	static x = "x";
 	static y = "y";

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field_assignment/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field_assignment/artifacts.snap
@@ -7,11 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.ts
-var KeepMe2 = class {
-	static x = "x";
-	static y = sideEffects();
-	static z = "z";
-};
+sideEffects();
 var KeepMe3 = class {
 	static x = "x";
 	static y = "y";

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field_minified/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_lowered_class_static_field_minified/artifacts.snap
@@ -7,11 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-var KeepMe1 = class {
-	static x = "x";
-	static y = sideEffects();
-	static z = "z";
-};
+sideEffects();
 var KeepMe2 = class {
 	static x = "x";
 	static y = "y";

--- a/crates/rolldown/tests/esbuild/default/hashbang_banner_use_strict_order/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/hashbang_banner_use_strict_order/artifacts.snap
@@ -8,9 +8,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 #! in file
 #! from banner
-'use strict';
-
-
 (function() {
 
 

--- a/crates/rolldown/tests/esbuild/default/import_inside_try/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_inside_try/artifacts.snap
@@ -33,10 +33,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
-let x;
 try {
-	x = import("nope1");
-	x = await import("nope2");
+	import("nope1");
+	await import("nope2");
 } catch {}
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/mangle_quoted_props/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/mangle_quoted_props/artifacts.snap
@@ -13,9 +13,7 @@ foo(x ? "_keepThisProperty" : "_keepThisPropertyToo");
 x[foo("_keepThisProperty")];
 x?.[foo("_keepThisProperty")];
 foo("_keepThisProperty");
-(class {
-	[foo("_keepThisProperty")] = x;
-});
+foo("_keepThisProperty");
 var { [foo("_keepThisProperty")]: x } = y;
 foo("_keepThisProperty") in x;
 
@@ -34,9 +32,7 @@ x?.[y ? z : "_mangleThis"];
 x[y, "_mangleThis"];
 x?.[y, "_mangleThis"];
 y;
-(class {
-	[(y, "_mangleThis")] = x;
-});
+y, "_mangleThis";
 var { "_mangleThis": x } = y;
 var { ["_mangleThis"]: x } = y;
 var { [(z, "_mangleThis")]: x } = y;

--- a/crates/rolldown/tests/esbuild/default/mangle_quoted_props_minify_syntax/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/mangle_quoted_props_minify_syntax/artifacts.snap
@@ -13,9 +13,7 @@ foo(x ? "_keepThisProperty" : "_keepThisPropertyToo");
 x[foo("_keepThisProperty")];
 x?.[foo("_keepThisProperty")];
 foo("_keepThisProperty");
-(class {
-	[foo("_keepThisProperty")] = x;
-});
+foo("_keepThisProperty");
 var { [foo("_keepThisProperty")]: x } = y;
 foo("_keepThisProperty") in x;
 
@@ -34,9 +32,7 @@ x?.[y ? z : "_mangleThis"];
 x[y, "_mangleThis"];
 x?.[y, "_mangleThis"];
 y;
-(class {
-	[(y, "_mangleThis")] = x;
-});
+y, "_mangleThis";
 var { "_mangleThis": x } = y;
 var { ["_mangleThis"]: x } = y;
 var { [(z, "_mangleThis")]: x } = y;

--- a/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_cjs_issue2264/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_cjs_issue2264/artifacts.snap
@@ -6,9 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-'use strict';
-
-
 
 //#region entry.js
 let a = 1;

--- a/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_esm_issue2264/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_esm_issue2264/artifacts.snap
@@ -6,8 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-
-
 //#region entry.js
 let a = 1;
 

--- a/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_iife_issue2264/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_iife_issue2264/artifacts.snap
@@ -14,9 +14,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-'use strict';
-
-
 (function(exports) {
 
 

--- a/crates/rolldown/tests/esbuild/lower/java_script_auto_accessor_es2021/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/java_script_auto_accessor_es2021/artifacts.snap
@@ -7,14 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region js-define.js
-var Foo = class {
-	accessor one = 1;
-	accessor #two = 2;
-	accessor [three()] = 3;
-	static accessor four = 4;
-	static accessor #five = 5;
-	static accessor [six()] = 6;
-};
+three(), six();
 
 //#endregion
 ```
@@ -22,30 +15,9 @@ var Foo = class {
 
 ```js
 //#region ts-assign/ts-assign.ts
-var Foo = class {
-	accessor one = 1;
-	accessor #two = 2;
-	accessor [three()] = 3;
-	static accessor four = 4;
-	static accessor #five = 5;
-	static accessor [six()] = 6;
-};
-var Normal = class {
-	accessor a = b;
-	c = d;
-};
-var Private = class {
-	accessor #a = b;
-	c = d;
-};
-var StaticNormal = class {
-	static accessor a = b;
-	static c = d;
-};
-var StaticPrivate = class {
-	static accessor #a = b;
-	static c = d;
-};
+three(), six();
+b, d;
+b, d;
 
 //#endregion
 ```
@@ -53,30 +25,9 @@ var StaticPrivate = class {
 
 ```js
 //#region ts-define/ts-define.ts
-var Foo = class {
-	accessor one = 1;
-	accessor #two = 2;
-	accessor [three()] = 3;
-	static accessor four = 4;
-	static accessor #five = 5;
-	static accessor [six()] = 6;
-};
-var Normal = class {
-	accessor a = b;
-	c = d;
-};
-var Private = class {
-	accessor #a = b;
-	c = d;
-};
-var StaticNormal = class {
-	static accessor a = b;
-	static c = d;
-};
-var StaticPrivate = class {
-	static accessor #a = b;
-	static c = d;
-};
+three(), six();
+b, d;
+b, d;
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/lower/java_script_auto_accessor_es2022/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/java_script_auto_accessor_es2022/artifacts.snap
@@ -7,14 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region js-define.js
-var Foo = class {
-	accessor one = 1;
-	accessor #two = 2;
-	accessor [three()] = 3;
-	static accessor four = 4;
-	static accessor #five = 5;
-	static accessor [six()] = 6;
-};
+three(), six();
 
 //#endregion
 ```
@@ -22,30 +15,9 @@ var Foo = class {
 
 ```js
 //#region ts-assign/ts-assign.ts
-var Foo = class {
-	accessor one = 1;
-	accessor #two = 2;
-	accessor [three()] = 3;
-	static accessor four = 4;
-	static accessor #five = 5;
-	static accessor [six()] = 6;
-};
-var Normal = class {
-	accessor a = b;
-	c = d;
-};
-var Private = class {
-	accessor #a = b;
-	c = d;
-};
-var StaticNormal = class {
-	static accessor a = b;
-	static c = d;
-};
-var StaticPrivate = class {
-	static accessor #a = b;
-	static c = d;
-};
+three(), six();
+b, d;
+b, d;
 
 //#endregion
 ```
@@ -53,30 +25,9 @@ var StaticPrivate = class {
 
 ```js
 //#region ts-define/ts-define.ts
-var Foo = class {
-	accessor one = 1;
-	accessor #two = 2;
-	accessor [three()] = 3;
-	static accessor four = 4;
-	static accessor #five = 5;
-	static accessor [six()] = 6;
-};
-var Normal = class {
-	accessor a = b;
-	c = d;
-};
-var Private = class {
-	accessor #a = b;
-	c = d;
-};
-var StaticNormal = class {
-	static accessor a = b;
-	static c = d;
-};
-var StaticPrivate = class {
-	static accessor #a = b;
-	static c = d;
-};
+three(), six();
+b, d;
+b, d;
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/lower/java_script_auto_accessor_es_next/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/java_script_auto_accessor_es_next/artifacts.snap
@@ -7,14 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region js-define.js
-var Foo = class {
-	accessor one = 1;
-	accessor #two = 2;
-	accessor [three()] = 3;
-	static accessor four = 4;
-	static accessor #five = 5;
-	static accessor [six()] = 6;
-};
+three(), six();
 
 //#endregion
 ```
@@ -22,30 +15,9 @@ var Foo = class {
 
 ```js
 //#region ts-assign/ts-assign.ts
-var Foo = class {
-	accessor one = 1;
-	accessor #two = 2;
-	accessor [three()] = 3;
-	static accessor four = 4;
-	static accessor #five = 5;
-	static accessor [six()] = 6;
-};
-var Normal = class {
-	accessor a = b;
-	c = d;
-};
-var Private = class {
-	accessor #a = b;
-	c = d;
-};
-var StaticNormal = class {
-	static accessor a = b;
-	static c = d;
-};
-var StaticPrivate = class {
-	static accessor #a = b;
-	static c = d;
-};
+three(), six();
+b, d;
+b, d;
 
 //#endregion
 ```
@@ -53,30 +25,9 @@ var StaticPrivate = class {
 
 ```js
 //#region ts-define/ts-define.ts
-var Foo = class {
-	accessor one = 1;
-	accessor #two = 2;
-	accessor [three()] = 3;
-	static accessor four = 4;
-	static accessor #five = 5;
-	static accessor [six()] = 6;
-};
-var Normal = class {
-	accessor a = b;
-	c = d;
-};
-var Private = class {
-	accessor #a = b;
-	c = d;
-};
-var StaticNormal = class {
-	static accessor a = b;
-	static c = d;
-};
-var StaticPrivate = class {
-	static accessor #a = b;
-	static c = d;
-};
+three(), six();
+b, d;
+b, d;
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/lower/lower_async_generator/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_generator/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
 function _usingCtx() {
 	var r = "function" == typeof SuppressedError ? SuppressedError : function(r$1, e$1) {
 		var n$1 = Error();

--- a/crates/rolldown/tests/esbuild/lower/lower_async_generator_no_await/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_generator_no_await/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
 function _usingCtx() {
 	var r = "function" == typeof SuppressedError ? SuppressedError : function(r$1, e$1) {
 		var n$1 = Error();

--- a/crates/rolldown/tests/esbuild/lower/lower_async_super_es2016_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_super_es2016_no_bundle/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
+Base;
+Base;
 for (let i = 0; i < 3; i++) objs.push({
 	__proto__: { foo() {
 		return i;

--- a/crates/rolldown/tests/esbuild/lower/lower_async_super_es2017_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_async_super_es2017_no_bundle/artifacts.snap
@@ -7,6 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region entry.js
+Base;
+Base;
 for (let i = 0; i < 3; i++) objs.push({
 	__proto__: { foo() {
 		return i;

--- a/crates/rolldown/tests/esbuild/lower/lower_nested_function_direct_eval/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_nested_function_direct_eval/artifacts.snap
@@ -114,8 +114,6 @@ if (foo) eval("");
 ## 5.js
 
 ```js
-
-
 //#region 5.js
 if (foo) {}
 
@@ -124,8 +122,6 @@ if (foo) {}
 ## 6.js
 
 ```js
-
-
 //#region 6.js
 if (foo) eval("");
 
@@ -134,8 +130,6 @@ if (foo) eval("");
 ## 7.js
 
 ```js
-
-
 //#region 7.js
 if (foo) {
 	if (bar) eval("");
@@ -146,8 +140,6 @@ if (foo) {
 ## 8.js
 
 ```js
-
-
 //#region 8.js
 if (foo) eval("");
 

--- a/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493/artifacts.snap
@@ -6,32 +6,32 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/checkPrivateRedeclaration.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/checkPrivateRedeclaration.js
 function _checkPrivateRedeclaration(e, t) {
 	if (t.has(e)) throw new TypeError("Cannot initialize the same private elements twice on an object");
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldInitSpec.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldInitSpec.js
 function _classPrivateFieldInitSpec(e, t, a) {
 	_checkPrivateRedeclaration(e, t), t.set(e, a);
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/assertClassBrand.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/assertClassBrand.js
 function _assertClassBrand(e, t, n) {
 	if ("function" == typeof e ? e === t : e.has(t)) return arguments.length < 3 ? t : n;
 	throw new TypeError("Private element is not present on this object");
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldGet2.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldGet2.js
 function _classPrivateFieldGet2(s, a) {
 	return s.get(_assertClassBrand(s, a));
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldSet2.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/classPrivateFieldSet2.js
 function _classPrivateFieldSet2(s, a, r) {
 	return s.set(_assertClassBrand(s, a), r), r;
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2016_no_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2016_no_bundle/_config.json
@@ -6,5 +6,6 @@
         "import": "entry.js"
       }
     ]
-  }
+  },
+  "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2016_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2016_no_bundle/artifacts.snap
@@ -6,5 +6,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
+Base;
+Base;
 
+//#endregion
 ```

--- a/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2021_no_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2021_no_bundle/_config.json
@@ -6,5 +6,6 @@
         "import": "entry.js"
       }
     ]
-  }
+  },
+  "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2021_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_async_super_es2021_no_bundle/artifacts.snap
@@ -6,5 +6,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
+Base;
+Base;
 
+//#endregion
 ```

--- a/crates/rolldown/tests/esbuild/lower/lower_static_super_es2016_no_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_super_es2016_no_bundle/_config.json
@@ -6,5 +6,6 @@
         "import": "entry.js"
       }
     ]
-  }
+  },
+  "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_static_super_es2016_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_super_es2016_no_bundle/artifacts.snap
@@ -6,5 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
+Base;
 
+//#endregion
 ```

--- a/crates/rolldown/tests/esbuild/lower/lower_static_super_es2021_no_bundle/_config.json
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_super_es2021_no_bundle/_config.json
@@ -6,5 +6,6 @@
         "import": "entry.js"
       }
     ]
-  }
+  },
+  "expectExecuted": false
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_static_super_es2021_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_static_super_es2021_no_bundle/artifacts.snap
@@ -6,5 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+//#region entry.js
+Base;
 
+//#endregion
 ```

--- a/crates/rolldown/tests/esbuild/lower/lower_using_hoisting/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_using_hoisting/artifacts.snap
@@ -273,8 +273,6 @@ d;
 ## hoist-use-strict.js
 
 ```js
-
-
 //#region hoist-use-strict.js
 b;
 

--- a/crates/rolldown/tests/esbuild/lower/lower_using_inside_ts_namespace/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_using_inside_ts_namespace/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/usingCtx.js
 function _usingCtx() {
 	var r = "function" == typeof SuppressedError ? SuppressedError : function(r$1, e$1) {
 		var n$1 = Error();

--- a/crates/rolldown/tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies_recursive/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies_recursive/artifacts.snap
@@ -41,13 +41,8 @@ setZ2();
 
 ```js
 //#region x.js
-let _x;
-function setX(v) {
-	_x = v;
-}
-function setX2(v) {
-	_x = v;
-}
+function setX(v) {}
+function setX2(v) {}
 
 //#endregion
 export { setX, setX2 };
@@ -58,24 +53,16 @@ export { setX, setX2 };
 import { setX } from "./x.js";
 
 //#region y.js
-let _y;
-function setY(v) {
-	_y = v;
-}
+function setY(v) {}
 function setY2(v) {
 	setX(v);
-	_y = v;
 }
 
 //#endregion
 //#region z.js
-let _z;
-function setZ(v) {
-	_z = v;
-}
+function setZ(v) {}
 function setZ2(v) {
 	setY(v);
-	_z = v;
 }
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/ts/ts_minify_enum_property_names/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_minify_enum_property_names/artifacts.snap
@@ -32,15 +32,7 @@ var SameFileBad = /* @__PURE__ */ function(SameFileBad$1) {
 	SameFileBad$1["PROTOTYPE"] = "prototype";
 	return SameFileBad$1;
 }(SameFileBad || {});
-var Foo = class {
-	[100] = 100;
-	"200" = 200;
-	["300"] = 300;
-	[SameFileGood.STR] = SameFileGood.STR;
-	[SameFileGood.NUM] = SameFileGood.NUM;
-	[CrossFileGood.STR] = CrossFileGood.STR;
-	[CrossFileGood.NUM] = CrossFileGood.NUM;
-};
+SameFileGood.STR, SameFileGood.NUM, CrossFileGood.STR, CrossFileGood.NUM;
 shouldNotBeComputed(class {
 	[100] = 100;
 	"200" = 200;

--- a/crates/rolldown/tests/rolldown/misc/use_strict/esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/esm/artifacts.snap
@@ -6,8 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-
-
 //#region main.js
 const a = 1;
 console.log(a);

--- a/crates/rolldown/tests/rolldown/resolve/ts_config_merge_decorator_metadata/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/ts_config_merge_decorator_metadata/artifacts.snap
@@ -6,13 +6,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/decorateMetadata.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/decorateMetadata.js
 function __decorateMetadata(k, v) {
 	if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/decorate.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/decorate.js
 function __decorate(decorators, target, key, desc) {
 	var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
 	if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);

--- a/crates/rolldown/tests/rolldown/resolve/ts_config_option_merge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/ts_config_option_merge/artifacts.snap
@@ -14,7 +14,7 @@ function add(a, b) {
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/decorateParam.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/decorateParam.js
 function __decorateParam(paramIndex, decorator) {
 	return function(target, key) {
 		decorator(target, key, paramIndex);
@@ -22,7 +22,7 @@ function __decorateParam(paramIndex, decorator) {
 }
 
 //#endregion
-//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.79.0/node_modules/@oxc-project/runtime/src/helpers/esm/decorate.js
+//#region ../../../../../../node_modules/.pnpm/@oxc-project+runtime@0.80.0/node_modules/@oxc-project/runtime/src/helpers/esm/decorate.js
 function __decorate(decorators, target, key, desc) {
 	var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
 	if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);

--- a/crates/rolldown/tests/rollup/simplify-with-destructuring/artifacts.snap
+++ b/crates/rolldown/tests/rollup/simplify-with-destructuring/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
@@ -13,7 +12,7 @@ import assert from "assert";
 let foo, unused;
 ({foo} = { foo: "bar" });
 assert.strictEqual(foo, "bar");
-const assign = () => unused = {foo} = { foo: "baz" };
+const assign = () => ({foo} = { foo: "baz" });
 assign();
 assert.strictEqual(foo, "baz");
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -72,7 +72,7 @@ expression: output
 
 # tests/esbuild/dce/dce_of_decorators
 
-- keep-these-!~{000}~.js => keep-these-BTQt1pSZ.js
+- keep-these-!~{000}~.js => keep-these-BwHnIShJ.js
 
 # tests/esbuild/dce/dce_of_destructuring
 
@@ -80,7 +80,7 @@ expression: output
 
 # tests/esbuild/dce/dce_of_experimental_decorators
 
-- keep-these-!~{000}~.js => keep-these-BzLjhcsl.js
+- keep-these-!~{000}~.js => keep-these-BkGMHk-b.js
 
 # tests/esbuild/dce/dce_of_expr_after_keep_names_issue3195
 
@@ -93,7 +93,7 @@ expression: output
 
 # tests/esbuild/dce/dce_of_symbol_instances
 
-- class-!~{000}~.js => class-DWGoxy-2.js
+- class-!~{000}~.js => class-DtODMnQf.js
 - object-!~{001}~.js => object-c5hjUGWk.js
 
 # tests/esbuild/dce/dce_of_using_declarations
@@ -568,15 +568,15 @@ expression: output
 
 # tests/esbuild/dce/tree_shaking_lowered_class_static_field
 
-- entry-!~{000}~.js => entry-R0_l7mIp.js
+- entry-!~{000}~.js => entry-BKWHQYWZ.js
 
 # tests/esbuild/dce/tree_shaking_lowered_class_static_field_assignment
 
-- entry-!~{000}~.js => entry-DpT2y-ga.js
+- entry-!~{000}~.js => entry-hobWokOE.js
 
 # tests/esbuild/dce/tree_shaking_lowered_class_static_field_minified
 
-- entry-!~{000}~.js => entry-R0_l7mIp.js
+- entry-!~{000}~.js => entry-BKWHQYWZ.js
 
 # tests/esbuild/dce/tree_shaking_no_bundle_cjs
 
@@ -883,7 +883,7 @@ expression: output
 
 # tests/esbuild/default/hashbang_banner_use_strict_order
 
-- entry-!~{000}~.js => entry-CzOxBtMM.js
+- entry-!~{000}~.js => entry-6U8T8zUM.js
 
 # tests/esbuild/default/hashbang_bundle
 
@@ -931,7 +931,7 @@ expression: output
 
 # tests/esbuild/default/import_inside_try
 
-- entry-!~{000}~.js => entry-Q8-v3YeB.js
+- entry-!~{000}~.js => entry-CKshUZ1O.js
 
 # tests/esbuild/default/import_meta_common_js
 
@@ -1276,13 +1276,13 @@ expression: output
 
 # tests/esbuild/default/mangle_quoted_props
 
-- keep-!~{000}~.js => keep-CiXfrWY8.js
-- mangle-!~{001}~.js => mangle-Ci8hf8cj.js
+- keep-!~{000}~.js => keep-BFTfjx2d.js
+- mangle-!~{001}~.js => mangle-BHEB-c2o.js
 
 # tests/esbuild/default/mangle_quoted_props_minify_syntax
 
-- keep-!~{000}~.js => keep-CiXfrWY8.js
-- mangle-!~{001}~.js => mangle-Ci8hf8cj.js
+- keep-!~{000}~.js => keep-BFTfjx2d.js
+- mangle-!~{001}~.js => mangle-BHEB-c2o.js
 
 # tests/esbuild/default/many_entry_points
 
@@ -1750,15 +1750,15 @@ expression: output
 
 # tests/esbuild/default/use_strict_directive_bundle_cjs_issue2264
 
-- entry-!~{000}~.js => entry-wRKbsRr5.js
+- entry-!~{000}~.js => entry-Bvo4BYro.js
 
 # tests/esbuild/default/use_strict_directive_bundle_esm_issue2264
 
-- entry-!~{000}~.js => entry-hXtm27Ye.js
+- entry-!~{000}~.js => entry-DK-XPZv9.js
 
 # tests/esbuild/default/use_strict_directive_bundle_iife_issue2264
 
-- entry-!~{000}~.js => entry-OsJbWXS_.js
+- entry-!~{000}~.js => entry-BFZLtvQZ.js
 
 # tests/esbuild/default/use_strict_directive_bundle_issue1837
 
@@ -2515,21 +2515,21 @@ expression: output
 
 # tests/esbuild/lower/java_script_auto_accessor_es2021
 
-- js-define-!~{000}~.js => js-define-rulW5vLg.js
-- ts-assign_ts-assign-!~{002}~.js => ts-assign_ts-assign-KGDqwMwc.js
-- ts-define_ts-define-!~{001}~.js => ts-define_ts-define-BbdVpmn3.js
+- js-define-!~{000}~.js => js-define-rG1Qxxq0.js
+- ts-assign_ts-assign-!~{002}~.js => ts-assign_ts-assign-DIcQFw_e.js
+- ts-define_ts-define-!~{001}~.js => ts-define_ts-define-Ct5vKSQL.js
 
 # tests/esbuild/lower/java_script_auto_accessor_es2022
 
-- js-define-!~{000}~.js => js-define-rulW5vLg.js
-- ts-assign_ts-assign-!~{002}~.js => ts-assign_ts-assign-KGDqwMwc.js
-- ts-define_ts-define-!~{001}~.js => ts-define_ts-define-BbdVpmn3.js
+- js-define-!~{000}~.js => js-define-rG1Qxxq0.js
+- ts-assign_ts-assign-!~{002}~.js => ts-assign_ts-assign-DIcQFw_e.js
+- ts-define_ts-define-!~{001}~.js => ts-define_ts-define-Ct5vKSQL.js
 
 # tests/esbuild/lower/java_script_auto_accessor_es_next
 
-- js-define-!~{000}~.js => js-define-rulW5vLg.js
-- ts-assign_ts-assign-!~{002}~.js => ts-assign_ts-assign-KGDqwMwc.js
-- ts-define_ts-define-!~{001}~.js => ts-define_ts-define-BbdVpmn3.js
+- js-define-!~{000}~.js => js-define-rG1Qxxq0.js
+- ts-assign_ts-assign-!~{002}~.js => ts-assign_ts-assign-DIcQFw_e.js
+- ts-define_ts-define-!~{001}~.js => ts-define_ts-define-Ct5vKSQL.js
 
 # tests/esbuild/lower/java_script_decorators_bundle_issue3768
 
@@ -2572,19 +2572,19 @@ expression: output
 
 # tests/esbuild/lower/lower_async_generator
 
-- entry-!~{000}~.js => entry-BYJ_Kg6M.js
+- entry-!~{000}~.js => entry-g--LCELz.js
 
 # tests/esbuild/lower/lower_async_generator_no_await
 
-- entry-!~{000}~.js => entry-BYJ_Kg6M.js
+- entry-!~{000}~.js => entry-g--LCELz.js
 
 # tests/esbuild/lower/lower_async_super_es2016_no_bundle
 
-- entry-!~{000}~.js => entry-OUiITk6I.js
+- entry-!~{000}~.js => entry-BiSop-aA.js
 
 # tests/esbuild/lower/lower_async_super_es2017_no_bundle
 
-- entry-!~{000}~.js => entry-OUiITk6I.js
+- entry-!~{000}~.js => entry-BiSop-aA.js
 
 # tests/esbuild/lower/lower_async_this2016_common_js
 
@@ -2636,14 +2636,14 @@ expression: output
 - 2-!~{001}~.js => 2-B5-vDtKB.js
 - 3-!~{002}~.js => 3-CLLzrSuj.js
 - 4-!~{003}~.js => 4-BQEU1B8F.js
-- 5-!~{004}~.js => 5-COWf4txy.js
-- 6-!~{005}~.js => 6-BnBULIrm.js
-- 7-!~{006}~.js => 7-DuljJypV.js
-- 8-!~{007}~.js => 8-BUfHBQdk.js
+- 5-!~{004}~.js => 5-TxPJUhc1.js
+- 6-!~{005}~.js => 6-JwcW2KXv.js
+- 7-!~{006}~.js => 7-9wpZ-A4q.js
+- 8-!~{007}~.js => 8-my4xG5vP.js
 
 # tests/esbuild/lower/lower_nullish_coalescing_assignment_issue1493
 
-- entry-!~{000}~.js => entry-D0RdrMpN.js
+- entry-!~{000}~.js => entry-Cn_lWxiM.js
 
 # tests/esbuild/lower/lower_object_spread_no_bundle
 
@@ -2779,19 +2779,19 @@ expression: output
 
 # tests/esbuild/lower/lower_static_async_super_es2016_no_bundle
 
-- entry-!~{000}~.js => entry-CMXZovLt.js
+- entry-!~{000}~.js => entry-DKDXmOsS.js
 
 # tests/esbuild/lower/lower_static_async_super_es2021_no_bundle
 
-- entry-!~{000}~.js => entry-CMXZovLt.js
+- entry-!~{000}~.js => entry-DKDXmOsS.js
 
 # tests/esbuild/lower/lower_static_super_es2016_no_bundle
 
-- entry-!~{000}~.js => entry-CMXZovLt.js
+- entry-!~{000}~.js => entry-C2q4soOY.js
 
 # tests/esbuild/lower/lower_static_super_es2021_no_bundle
 
-- entry-!~{000}~.js => entry-CMXZovLt.js
+- entry-!~{000}~.js => entry-C2q4soOY.js
 
 # tests/esbuild/lower/lower_strict_mode_syntax
 
@@ -2827,11 +2827,11 @@ expression: output
 - hoist-export-local-indirect-!~{007}~.js => hoist-export-local-indirect-HSZBlKOb.js
 - hoist-export-star-!~{003}~.js => hoist-export-star-jYddb4P1.js
 - hoist-import-!~{002}~.js => hoist-import-BLaUL1j7.js
-- hoist-use-strict-!~{000}~.js => hoist-use-strict-pw49g_7u.js
+- hoist-use-strict-!~{000}~.js => hoist-use-strict-BpJDaqMA.js
 
 # tests/esbuild/lower/lower_using_inside_ts_namespace
 
-- entry-!~{000}~.js => entry-2iwBuLfY.js
+- entry-!~{000}~.js => entry-CsueQAgy.js
 
 # tests/esbuild/lower/lower_using_unsupported_async
 
@@ -3206,11 +3206,11 @@ expression: output
 
 # tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies_recursive
 
-- a-!~{000}~.js => a-DNmRKShH.js
-- b-!~{001}~.js => b-z3u_Fak2.js
-- c-!~{002}~.js => c-By2OI2eN.js
-- x-!~{003}~.js => x-CkvKqwKd.js
-- z-!~{005}~.js => z-KhZa7vL0.js
+- a-!~{000}~.js => a-B6CDTJan.js
+- b-!~{001}~.js => b-BeLJzcJx.js
+- c-!~{002}~.js => c-DIqLKrYX.js
+- x-!~{003}~.js => x-BhbOquNH.js
+- z-!~{005}~.js => z-BXIfo6kz.js
 
 # tests/esbuild/splitting/splitting_duplicate_chunk_collision
 
@@ -3575,7 +3575,7 @@ expression: output
 
 # tests/esbuild/ts/ts_minify_enum_property_names
 
-- entry-!~{000}~.js => entry-BUKrAnqi.js
+- entry-!~{000}~.js => entry-XMvhL2CK.js
 
 # tests/esbuild/ts/ts_minify_namespace
 
@@ -5030,7 +5030,7 @@ expression: output
 
 # tests/rolldown/misc/use_strict/esm
 
-- main-!~{000}~.js => main-m-GG56UQ.js
+- main-!~{000}~.js => main-C9hoGOiU.js
 
 # tests/rolldown/misc/use_strict/ignore_treeshaked_modules
 
@@ -5094,11 +5094,11 @@ expression: output
 
 # tests/rolldown/resolve/ts_config_merge_decorator_metadata
 
-- main-!~{000}~.js => main-MF3I2Zgo.js
+- main-!~{000}~.js => main-BHBoWkld.js
 
 # tests/rolldown/resolve/ts_config_option_merge
 
-- main-!~{000}~.js => main-BYlE1psn.js
+- main-!~{000}~.js => main-CGeWpKLm.js
 
 # tests/rolldown/resolve/wildcard_alias
 
@@ -5967,6 +5967,6 @@ expression: output
 
 # tests/rollup/simplify-with-destructuring
 
-- main-!~{000}~.js => main-3MCZbPq8.js
+- main-!~{000}~.js => main-Dwl1cMos.js
 
 ```

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_pattern_ext.rs
@@ -57,9 +57,14 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
       // Turn `var { a, b = 2 } = ...` to `{a, b = 2} = ...`
       BindingPatternKind::ObjectPattern(obj_pat) => {
         let mut obj_target = ObjectAssignmentTarget {
-          rest: obj_pat.rest.take().map(|rest| AssignmentTargetRest {
-            span: rest.span,
-            target: rest.unbox().argument.into_assignment_target(alloc),
+          rest: obj_pat.rest.take().map(|rest| {
+            Box::new_in(
+              AssignmentTargetRest {
+                span: rest.span,
+                target: rest.unbox().argument.into_assignment_target(alloc),
+              },
+              alloc,
+            )
           }),
           ..ObjectAssignmentTarget::dummy(alloc)
         };
@@ -72,9 +77,14 @@ impl<'ast> BindingPatternExt<'ast> for BindingPattern<'ast> {
       BindingPatternKind::ArrayPattern(arr_pat) => {
         let mut arr_target = ArrayAssignmentTarget {
           span: arr_pat.span,
-          rest: arr_pat.rest.take().map(|rest| AssignmentTargetRest {
-            span: rest.span,
-            target: rest.unbox().argument.into_assignment_target(alloc),
+          rest: arr_pat.rest.take().map(|rest| {
+            Box::new_in(
+              AssignmentTargetRest {
+                span: rest.span,
+                target: rest.unbox().argument.into_assignment_target(alloc),
+              },
+              alloc,
+            )
           }),
           elements: oxc::allocator::Vec::with_capacity_in(arr_pat.elements.len(), alloc),
         };

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_property_ext.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/binding_property_ext.rs
@@ -1,5 +1,5 @@
 use oxc::{
-  allocator::{Allocator, Dummy as _, IntoIn as _, TakeIn},
+  allocator::{Allocator, Box, Dummy as _, IntoIn as _, TakeIn},
   ast::ast::{
     ArrayAssignmentTarget, AssignmentTargetMaybeDefault, AssignmentTargetProperty,
     AssignmentTargetPropertyIdentifier, AssignmentTargetPropertyProperty, AssignmentTargetRest,
@@ -103,9 +103,14 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
               ArrayAssignmentTarget {
                 elements,
                 span: arr_pat.span,
-                rest: arr_pat.rest.map(|rest| AssignmentTargetRest {
-                  span: rest.span,
-                  target: rest.unbox().argument.into_assignment_target(alloc),
+                rest: arr_pat.rest.map(|rest| {
+                  Box::new_in(
+                    AssignmentTargetRest {
+                      span: rest.span,
+                      target: rest.unbox().argument.into_assignment_target(alloc),
+                    },
+                    alloc,
+                  )
                 }),
               }
               .into_in(alloc),
@@ -130,9 +135,14 @@ impl<'ast> BindingPropertyExt<'ast> for BindingProperty<'ast> {
               ObjectAssignmentTarget {
                 properties,
                 span: obj_pat.span,
-                rest: obj_pat.rest.map(|rest| AssignmentTargetRest {
-                  span: rest.span,
-                  target: rest.unbox().argument.into_assignment_target(alloc),
+                rest: obj_pat.rest.map(|rest| {
+                  Box::new_in(
+                    AssignmentTargetRest {
+                      span: rest.span,
+                      target: rest.unbox().argument.into_assignment_target(alloc),
+                    },
+                    alloc,
+                  )
                 }),
               }
               .into_in(alloc),

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -302,8 +302,8 @@ impl PluginDriver {
     if let Some(mut map) = map {
       // If sourcemap  hasn't `sources`, using original id to fill it.
       let source = map.get_source(0);
-      if source.is_none_or(str::is_empty)
-        || (map.get_sources().count() == 1 && (source != Some(id)))
+      if source.is_none_or(|s| s.is_empty())
+        || (map.get_sources().count() == 1 && (source.map(AsRef::as_ref) != Some(id)))
       {
         map.set_sources(vec![id]);
       }

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -86,9 +86,9 @@ pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
 
   SourceMap::new(
     None,
-    first_map.get_names().map(Into::into).collect::<Vec<_>>(),
+    first_map.get_names().map(Arc::clone).collect::<Vec<_>>(),
     None,
-    first_map.get_sources().map(Into::into).collect::<Vec<_>>(),
+    first_map.get_sources().map(Arc::clone).collect::<Vec<_>>(),
     first_map.get_source_contents().map(|x| x.map(Arc::clone)).collect::<Vec<_>>(),
     tokens,
     None,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,20 +19,20 @@ catalogs:
       specifier: ^0.0.30
       version: 0.0.30
     '@oxc-project/runtime':
-      specifier: '=0.79.0'
-      version: 0.79.0
+      specifier: '=0.80.0'
+      version: 0.80.0
     '@oxc-project/types':
-      specifier: '=0.79.0'
-      version: 0.79.0
+      specifier: '=0.80.0'
+      version: 0.80.0
     fast-glob:
       specifier: ^3.3.3
       version: 3.3.3
     oxc-parser:
-      specifier: '=0.79.0'
-      version: 0.79.0
+      specifier: '=0.80.0'
+      version: 0.80.0
     oxc-transform:
-      specifier: '=0.79.0'
-      version: 0.79.0
+      specifier: '=0.80.0'
+      version: 0.80.0
     rolldown-plugin-dts:
       specifier: ^0.14.0
       version: 0.14.2
@@ -55,7 +55,7 @@ importers:
         version: 0.0.30
       '@oxc-project/runtime':
         specifier: 'catalog:'
-        version: 0.79.0
+        version: 0.80.0
       '@types/node':
         specifier: 24.1.0
         version: 24.1.0
@@ -172,7 +172,7 @@ importers:
         version: link:../../packages/rolldown
       unplugin-isolated-decl:
         specifier: ^0.8.1
-        version: 0.8.3(oxc-transform@0.79.0)(rollup@4.45.1)(typescript@5.8.3)
+        version: 0.8.3(oxc-transform@0.80.0)(rollup@4.45.1)(typescript@5.8.3)
 
   examples/par-plugin:
     devDependencies:
@@ -264,7 +264,7 @@ importers:
         version: 1.0.0
       '@oxc-project/runtime':
         specifier: 'catalog:'
-        version: 0.79.0
+        version: 0.80.0
 
   packages/debug:
     devDependencies:
@@ -291,10 +291,10 @@ importers:
     dependencies:
       '@oxc-project/runtime':
         specifier: 'catalog:'
-        version: 0.79.0
+        version: 0.80.0
       '@oxc-project/types':
         specifier: 'catalog:'
-        version: 0.79.0
+        version: 0.80.0
       '@rolldown/pluginutils':
         specifier: workspace:*
         version: link:../pluginutils
@@ -337,7 +337,7 @@ importers:
         version: 11.0.3
       oxc-parser:
         specifier: 'catalog:'
-        version: 0.79.0
+        version: 0.80.0
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
@@ -410,7 +410,7 @@ importers:
         version: 11.7.1
       oxc-transform:
         specifier: 'catalog:'
-        version: 0.79.0
+        version: 0.80.0
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -2084,8 +2084,8 @@ packages:
   '@oxc-node/core@0.0.30':
     resolution: {integrity: sha512-lZeV5b9gtqnKr9YxDoYLglt2d9Hq39r4K4XRDRLPd1UTjNXkSUVRpiFDweB/emhIt03EZzwgoh9RxFwpMTWVCg==}
 
-  '@oxc-parser/binding-android-arm64@0.79.0':
-    resolution: {integrity: sha512-uTQQHt0ggQkxtkLnxNl5hKzQTps22JMPrA3eDX3uPQJ1c8/rkJUsgjH+F2Nf3CtfdWqxJXc3WdcZYYzvhgTZ6A==}
+  '@oxc-parser/binding-android-arm64@0.80.0':
+    resolution: {integrity: sha512-H0S4QTRFhct1uO1ZOnzGQAoHSJVHCyZa+oivovHkbqA0z271ppRkXmJuLfjW+9CBW0577JNAhjTflKUDpCO4lg==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [android]
@@ -2095,8 +2095,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-arm64@0.79.0':
-    resolution: {integrity: sha512-WaXZfJWtLuBuR8x3LfP7g2pfLtMFL5X5fw6z4d8IhDbEdPHJdgBbOcln202LxyLv0ujfmBFZez9mT0tVR/CTTA==}
+  '@oxc-parser/binding-darwin-arm64@0.80.0':
+    resolution: {integrity: sha512-cVGI6NeGs1u1Ev8yO7I+zXPQuduCwwhYXd/K64uygx+OFp7fC7zSIlkGpoxFRUuSxqyipC813foAfUOwM1Y0PA==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -2106,26 +2106,26 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.79.0':
-    resolution: {integrity: sha512-56xiOoFh9vxMczpb82SYSbFtUmNesZoG5MDDluKd5c64l+8/jJWnWsVfcjPFVEZTgEUYH39fQMqFGTWVvjmhrA==}
+  '@oxc-parser/binding-darwin-x64@0.80.0':
+    resolution: {integrity: sha512-h7wRo10ywI2vLz9VljFeIaUh9u7l2l3kvF6FAteY3cPqbCA6JYUZGJaykhMqTxJoG6wrzf35sMA2ubvq67iAMA==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-freebsd-x64@0.79.0':
-    resolution: {integrity: sha512-DeWlp3OHHfeUOpy4FB6PPAWYonawSdIUVQueDFJ8WZPfMWSsZEhEHL6eAL7mizTJH5QI4FtUQc7FBjrhcFCP2Q==}
+  '@oxc-parser/binding-freebsd-x64@0.80.0':
+    resolution: {integrity: sha512-KcJ+8w/wVwd/XfDmgA9QZJAWML3vPu2O2Y8XRkf3U9VsN5n8cZ5PXMbH4NBSb3O7ctdDSvwnnuApLOz3sTHsUw==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.79.0':
-    resolution: {integrity: sha512-2RQ2nZ1sp07lKl3ToI9DQaL+Kc1w2Ga+b4vFO87pTzeTbOCiLcS92FYtPA0nO3HX5+M+FMdCdZJOVRTDwNHhsw==}
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.80.0':
+    resolution: {integrity: sha512-5OCRxV5fX5RkVqsag55m4EFeudSZ0nSMYXgdtfR/5JZSiYmIYyPycafNNa52liqC2gx27vzrDRE4FdlG+5fhww==}
     engines: {node: '>=20.0.0'}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.79.0':
-    resolution: {integrity: sha512-/zDggeVxxgXY7dibkm8oUchSpYaZiBh+LPudavlVD6GBFOVzbFDoZMEq+dAFsZNMul/IFQ8nncUhr7bLmFunNg==}
+  '@oxc-parser/binding-linux-arm-musleabihf@0.80.0':
+    resolution: {integrity: sha512-kMa2PeA2GHMhvV617WdFzDAWCo2A00knPEe6rxFUO/Gr8TTLv1/LlEY6UqGseWrRfkkhFiAO496nRPW/6B5DCg==}
     engines: {node: '>=20.0.0'}
     cpu: [arm]
     os: [linux]
@@ -2135,8 +2135,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.79.0':
-    resolution: {integrity: sha512-fHXDm/jWzdIpE4qAX8p1x2/sk3Sw13yWWXdgevEcD6VPZTsice15n+q8xYVJCgzX7eZllBiCg9VlC9P4knLejw==}
+  '@oxc-parser/binding-linux-arm64-gnu@0.80.0':
+    resolution: {integrity: sha512-y2NEhbFfKPdOkf3ZR/3xwJFJVji6IKxwXKHUN4bEdqpcO0tkXSCiP0MzTxjEY6ql2/MXdkqK0Ym92dYsRsgsyg==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -2146,20 +2146,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.79.0':
-    resolution: {integrity: sha512-uM1G4if/SM891mmErfDjf2dGmBaaK50VntNfw8FIrpx/QzWh3yGq5toAYFKxYXfT30WPYrDpeCejaTumMzcf6w==}
+  '@oxc-parser/binding-linux-arm64-musl@0.80.0':
+    resolution: {integrity: sha512-j3tKausSXwHS/Ej6ct2dmKJtw0UIME2XJmj6QfPT6LyUSNTndj4yXRXuMSrCOrX9/0qH9GhmqeL9ouU27dQRFw==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.79.0':
-    resolution: {integrity: sha512-KLDpBwsmwRh6XovD+WUF6imkkiFVwPVcjype9k6yIiiPWirHU9JztYfA912Iz+AsEgF/OP+CGY+NsWzkdC4+jQ==}
+  '@oxc-parser/binding-linux-riscv64-gnu@0.80.0':
+    resolution: {integrity: sha512-h+uPvyTcpTFd946fGPU57sZeec2qHPUYQRZeXHB2uuZjps+9pxQ5zIz0EBM/JgBtnwdtoR93RAu1YNAVbqY5Zw==}
     engines: {node: '>=20.0.0'}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.79.0':
-    resolution: {integrity: sha512-CzOSo7h7mXtMkHn+FsKfkwck76eu1NwYQF/TmkCnZ0aJ7HlbTosgmbrmxWo9v0Ios0EXQFvbu89J73dKARmEwg==}
+  '@oxc-parser/binding-linux-s390x-gnu@0.80.0':
+    resolution: {integrity: sha512-+u74hV+WwCPL4UBNOJaIGRozTCfZ7pM5JCEe8zAlMkKexftUzbtvW02314bVD9bqoRAL3Gg6jcZrjNjwDX2FwQ==}
     engines: {node: '>=20.0.0'}
     cpu: [s390x]
     os: [linux]
@@ -2169,8 +2169,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.79.0':
-    resolution: {integrity: sha512-hDDFAI+u1p9Co1c4VMTz9dG7DvBjkTwuYfYkjJfp7JJjGZVq8uwobl6dNRtfqStF6HE6k71LCyN747DeJ82RHQ==}
+  '@oxc-parser/binding-linux-x64-gnu@0.80.0':
+    resolution: {integrity: sha512-N9UGnWVWMlOJH+6550tqyBxd9qkMd0f4m+YRA0gly6efJTuLbPQpjkJm7pJbMu+GULcvSJ/Y0bkMAIQTtwP0vQ==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
@@ -2180,14 +2180,14 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-x64-musl@0.79.0':
-    resolution: {integrity: sha512-+75nxVLKs2X3YXvZUFLz8YIaI8bA4vBt+RptXxbh8suMZzwDzdNiZ0qoxNJh38fFkg6K1HTKSnN52IGBVrJGpg==}
+  '@oxc-parser/binding-linux-x64-musl@0.80.0':
+    resolution: {integrity: sha512-l2N/GlFEri27QBMi0e53V/SlpQotIvHbz+rZZG/EO+vn58ZEr0eTG+PjJoOY/T8+TQb8nrCtRe4S/zNDpV6zSQ==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-parser/binding-wasm32-wasi@0.79.0':
-    resolution: {integrity: sha512-ewzIevW8DIQKOZ9MCVCIEaiz1xXDK0Q+qIUMbUkB7WtZkHkYc3YAccX0Ydxsw+0TuGuKDV2QXOSFa3Cqj+BzXw==}
+  '@oxc-parser/binding-wasm32-wasi@0.80.0':
+    resolution: {integrity: sha512-5iEwQqMXU1HiRlWuD3f+8N2O3qWhS+nOFEAWgE3sjMUnTtILPJETYhaGBPqqPWg1iRO3+hE1lEBCdI91GS1CUQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
@@ -2196,8 +2196,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.79.0':
-    resolution: {integrity: sha512-EE9L1CLL4/dfa12ES+q3LNQPphxA2dWLt8MRblevtchqxkZ9vcFWjwSTo2zu+vO4WKAI2exFYGjVi9G5nzEHDQ==}
+  '@oxc-parser/binding-win32-arm64-msvc@0.80.0':
+    resolution: {integrity: sha512-HedSH/Db7OFR2SugTbuawaV1vjgUjCXzxPquow/1FLtpRT2wASbMaRRbyD/h2n4DJ8V2zGqnV8Q+vic+VNvnKg==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -2207,8 +2207,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-x64-msvc@0.79.0':
-    resolution: {integrity: sha512-nmjzBDXPJ/t2igY00XZDBvxMg/qSfVSpV43nNMsu5JIczPauuKcjGXJXLgFu3LWBLd/4c6ebQkgSV+tBBgl7xw==}
+  '@oxc-parser/binding-win32-x64-msvc@0.80.0':
+    resolution: {integrity: sha512-SSiM0m7jG5yxVf0ivy1rF8OuTJo8ITgp1ccp2aqPZG6Qyl5QiVpf8HI1X5AvPFxts2B4Bv8U3Dip+FobqBkwcw==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [win32]
@@ -2217,8 +2217,8 @@ packages:
     resolution: {integrity: sha512-jOU7sDFMyq5ShGJC21UobalVzqcdtWGfySVp8ELvKoVLzMpLHb4kv1bs9VKxaP8XC7Z9hlAXwEKVhCTN+j21aQ==}
     engines: {node: '>=6.9.0'}
 
-  '@oxc-project/runtime@0.79.0':
-    resolution: {integrity: sha512-Eva2WW6DT+saZSpQzHwGA60MHoGPufSLPnj6aybLJRIyu8nZdpVpEf/1hwXPbCPPdzOt6334IQnph4H8E8NmOA==}
+  '@oxc-project/runtime@0.80.0':
+    resolution: {integrity: sha512-3rzy1bJAZ4s7zV9TKT60x119RwJDCDqEtCwK/Zc2qlm7wGhiIUxLLYUhE/mN91yB0u1kxm5sh4NjU12sPqQTpg==}
     engines: {node: '>=6.9.0'}
 
   '@oxc-project/types@0.37.0':
@@ -2227,8 +2227,8 @@ packages:
   '@oxc-project/types@0.78.0':
     resolution: {integrity: sha512-8FvExh0WRWN1FoSTjah1xa9RlavZcJQ8/yxRbZ7ElmSa2Ij5f5Em7MvRbSthE6FbwC6Wh8iAw0Gpna7QdoqLGg==}
 
-  '@oxc-project/types@0.79.0':
-    resolution: {integrity: sha512-brkIAdIaum1Vdh+mCs82ySgAMxI30sxWkfo8Lm2dRblryiPQs29l1fF9L7uwNT6jZ4ycMa3eeT36ppWh5htykA==}
+  '@oxc-project/types@0.80.0':
+    resolution: {integrity: sha512-xxHQm8wfCv2e8EmtaDwpMeAHOWqgQDAYg+BJouLXSQt5oTKu9TIXrgNMGSrM2fLvKmECsRd9uUFAAD+hPyootA==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.6.0':
     resolution: {integrity: sha512-UJTf5uZs919qavt9Btvbzkr3eaUu4d+FXBri8AB2BtOezriaTTUvArab2K9fdACQ4yFggTD5ews1l19V/6SW2Q==}
@@ -2325,91 +2325,91 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-transform/binding-android-arm64@0.79.0':
-    resolution: {integrity: sha512-2l6Xd4YaonqaCz3GD4JVeDRrqu+go2N5Y1epQpkhJh/6gDfC8kk2BoqAbdIGWAik8i2JBtoiR6MK2oNg1ek5Lg==}
+  '@oxc-transform/binding-android-arm64@0.80.0':
+    resolution: {integrity: sha512-HAK6zIUOteptOsSRqoGu41cez7kj/OPJqBGdgdP6FFh2RFcRfh0vqefjgF69af7TjzsRxVF8itiWvFsJHrIFoA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [android]
 
-  '@oxc-transform/binding-darwin-arm64@0.79.0':
-    resolution: {integrity: sha512-dH76DT0b+EeIbKL2CApVlJcnBEBr+c289aaukPshtVARm6zRqiCyEXoZDnx5l2AFqpjdvSxI7BdfilNxeNDRhg==}
+  '@oxc-transform/binding-darwin-arm64@0.80.0':
+    resolution: {integrity: sha512-sVcK4tjXbCfexlhquKVcwoKQrekQWDzRXtDwOWxm3CV1k5qGUm/rl5RAQLnXYtZVgu0U2dGEct9tNms+dzbACA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-transform/binding-darwin-x64@0.79.0':
-    resolution: {integrity: sha512-ceCwYNsNeq+86MMiP2UFomwqc+xejhh+/1i3NhXchdEu+WWPeYJvERkMv0wVkraMWunj13pq0nzJemO6xDbECQ==}
+  '@oxc-transform/binding-darwin-x64@0.80.0':
+    resolution: {integrity: sha512-MWmDTJszdO3X2LvbvIZocdfJnb/wjr3zhU99IlruwxsFfVNHbl03091bXi1ABsV5dyU+47V/A5jG3xOtg5X0vQ==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-transform/binding-freebsd-x64@0.79.0':
-    resolution: {integrity: sha512-hTdZkm0Hqvufp39njXoIHJeNLusmfXMEsi3xsh3aM/mwafkvpGkVIMXBnrhrPv9yexhPLd5o30qQjGWq7YbIDQ==}
+  '@oxc-transform/binding-freebsd-x64@0.80.0':
+    resolution: {integrity: sha512-fKuwj/iBfjfGePjcR9+j2TQ/7RlrUIT4ir/OAcHWYJ/kvxp4XY/juKYXo4lks/MW/dwe+UR1Lp6xiCQBuxpyIg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-transform/binding-linux-arm-gnueabihf@0.79.0':
-    resolution: {integrity: sha512-tO4symA9Qy11CPNIoVqX+n5CMtibJZUtbIo5+HEy/Qg0JLYsuf3vGkG7u+vSlUSbjHukfC597kfVTNTHXoSLEg==}
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.80.0':
+    resolution: {integrity: sha512-R0QdfKiV+ZFiM28UnyylOEtTBFjAb4XuHvQltUSUpylXXIbGd+0Z1WF5lY3Z776Vy00HWhYj/Vo03rhvjdVDTA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-transform/binding-linux-arm-musleabihf@0.79.0':
-    resolution: {integrity: sha512-Q76cWXG46PxoNFZOZfEM5+BzO3xU/8GgDTScZzhynbFBcAC/nF/dhADhSAmckM93xLm10W2Ysp3/5MIYIG4Tpg==}
+  '@oxc-transform/binding-linux-arm-musleabihf@0.80.0':
+    resolution: {integrity: sha512-hIfp4LwyQMRhsY9ptx4UleffoY9wZofTmnHFhZTMdb/hoE97Vuqw7Ub2cLcWMu0FYHIX8zXCMd1CJjs2MV1X3w==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-transform/binding-linux-arm64-gnu@0.79.0':
-    resolution: {integrity: sha512-oXIKO8Uz5EmlvOeQgBMIepUXGJ25T7hmH0CeIGXqb0H+lyapqKESg9qF8Is9g9Nbg2+4E2tpERItrD0j/chlKQ==}
+  '@oxc-transform/binding-linux-arm64-gnu@0.80.0':
+    resolution: {integrity: sha512-mOYGji1m55BD2vV5m1qnrXbdqyPp/AU9p1Rn+0hM2zkE3pVkETCPvLevSvt4rHQZBZFIWeRGo47QNsNQyaZBsg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-transform/binding-linux-arm64-musl@0.79.0':
-    resolution: {integrity: sha512-wkFXyEChJPtpd4sMbgnitEb4XNgKgWzIvbohqpf2xZgNLzFyYPRCsxVhIawy1TAdWLmYEOC6qkeixJJJOi1fNw==}
+  '@oxc-transform/binding-linux-arm64-musl@0.80.0':
+    resolution: {integrity: sha512-kBBCQwr1GCkr/b0iXH+ijsg+CSPCAMSV2tu4LmG2PFaxBnZilMYfUyWHCAiskbbUADikecUfwX6hHIaQoMaixg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-transform/binding-linux-riscv64-gnu@0.79.0':
-    resolution: {integrity: sha512-j5DuPin/XEBDp1ylyBDxReAZmQMFcNei3u+Sj8ECI/gZIXjyvyUkV59wymcg2cA9mnYKUaIkQ5yR1TO1HBCNUA==}
+  '@oxc-transform/binding-linux-riscv64-gnu@0.80.0':
+    resolution: {integrity: sha512-8CGJhHoD2Ttw8HtCNd/IWnGtL0Nsn448L2hZJtbDDGVUZUF4bbZFdXPnRt0QrEbupywoH6InN6q2imLous6xnw==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxc-transform/binding-linux-s390x-gnu@0.79.0':
-    resolution: {integrity: sha512-HhviUAVUUVi/eSyJFZLEB/6bwpdTV/d/UZzga25HZb1XS0iCJ8w2c6lkxDrUep6l4kXXeJm7Lv5oOIZXH6tp0A==}
+  '@oxc-transform/binding-linux-s390x-gnu@0.80.0':
+    resolution: {integrity: sha512-V/Lb6m5loWzvdB/qo6eYvVXidQku/PA706JbeE/PPCup8At+BwOXnZjktv7LDxrpuqnO32tZDHUUc9Y3bzOEBw==}
     engines: {node: '>=14.0.0'}
     cpu: [s390x]
     os: [linux]
 
-  '@oxc-transform/binding-linux-x64-gnu@0.79.0':
-    resolution: {integrity: sha512-jDlgmkY3m/JmQYqmJiAXnA5dXJGRcoGWM7pLmEB4990wFJyagnqcbp3fraueLaNsjtZQaJl81uaimlsfMlSvtw==}
+  '@oxc-transform/binding-linux-x64-gnu@0.80.0':
+    resolution: {integrity: sha512-03hHW04MQNb+ak27xo79nUkMjVu6146TNgeSapcDRATH4R0YMmXB2oPQK1K2nuBJzVZjBjH7Bus/I7tR3JasAg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-transform/binding-linux-x64-musl@0.79.0':
-    resolution: {integrity: sha512-V1G1UGHmBKexgsbDspU4LCYL9cFuxKNtNwWob/2gvrC2wSeQfRr/69Dzd6N9bZdwbHtXiM7wzQTacsKWgh8aBg==}
+  '@oxc-transform/binding-linux-x64-musl@0.80.0':
+    resolution: {integrity: sha512-BkXniuuHpo9cR2S3JDKIvmUrNvmm335owGW4rfp07HjVUsbq9e7bSnvOnyA3gXGdrPR2IgCWGi5nnXk2NN5Q0A==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-transform/binding-wasm32-wasi@0.79.0':
-    resolution: {integrity: sha512-loAZbwF8Xwj2O1I/zTL5C2mjh0OUgoaX/KVT9GifQXONM0Hdct3PAc4RUQouBk+8m8gWfoI5nlDSNIqABaiK3A==}
+  '@oxc-transform/binding-wasm32-wasi@0.80.0':
+    resolution: {integrity: sha512-jfRRXLtfSgTeJXBHj6qb+HHUd6hmYcyUNMBcTY8/k+JVsx0ThfrmCIufNlSJTt1zB+ugnMVMuQGeB0oF+aa86w==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@oxc-transform/binding-win32-arm64-msvc@0.79.0':
-    resolution: {integrity: sha512-nZBHaJ5uXMGsB90p7yk+mPMt8l7Uftw94nzvtQutOavuuGEuEJS/V32X2Tp4kvyCZPuRIpLxLTEI5zPtn1xAHg==}
+  '@oxc-transform/binding-win32-arm64-msvc@0.80.0':
+    resolution: {integrity: sha512-bofcVhlAV1AKzbE0TgDH+h813pbwWwwRhN6tv/hD4qEuWh/qEjv8Xb3Ar15xfBfyLI53FoJascuaJAFzX+IN9A==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-transform/binding-win32-x64-msvc@0.79.0':
-    resolution: {integrity: sha512-TaJlPnU/jDV9TkIj7yGMj2+RVUOY5D+VuCvxNDpVTF4M3x4KB3KG10X6wffUrk/8S+kdG4uPqUPc7QGHwrIAHg==}
+  '@oxc-transform/binding-win32-x64-msvc@0.80.0':
+    resolution: {integrity: sha512-MT6hQo9Kw/VuQUfX0fc0OpUdZesQruT0UNY9hxIcqcli7pbxMrvFBjkXo7oUb2151s/n+F4fyQOWvaR6zwxtDA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [win32]
@@ -4472,15 +4472,15 @@ packages:
   oxc-parser@0.37.0:
     resolution: {integrity: sha512-s5GDqjuFI0R3iEYvrQ0YOxBAOi601wCNAUodco8aA7D7qJu6pRb32qmqi5rhzJM4si3M5XQSr5CSDBhdGJl3Ig==}
 
-  oxc-parser@0.79.0:
-    resolution: {integrity: sha512-m8/kZXhPk9AFutl6CsdAn7wKg+ZrxcamEl0koen6aoq4dLkVHfozxHJAk+r++D78XGWj4X02P3GreK/GqwsdVg==}
+  oxc-parser@0.80.0:
+    resolution: {integrity: sha512-lTEUQs+WBOXPUzMR/tWY4yT9D7xXwnENtRR7Epw/QcuYpV4fRveEA+zq8IGUwyyuWecl8jHrddCCuadw+kZOSA==}
     engines: {node: '>=20.0.0'}
 
   oxc-resolver@11.6.0:
     resolution: {integrity: sha512-Yj3Wy+zLljtFL8ByKOljaPhiXjJWVe875p5MHaT5VAHoEmzeg1BuswM8s/E7ErpJ3s0fsXJfUYJE4v1bl7N65g==}
 
-  oxc-transform@0.79.0:
-    resolution: {integrity: sha512-BcNQOv8efvK/ZfoGwj9J2vO4o5GS03WPSuek40CQHi/0XXpmec3M5fuLK+Rfu0ny/w6f2UhosZYNCOHMORMlsg==}
+  oxc-transform@0.80.0:
+    resolution: {integrity: sha512-hWusSpynsn4MZP1KJa7e254xyVmowTUshvttpk7JfTt055YEJ+ad6memMJ9GJqPeeyydfnwwKkLy6eiwDn12xA==}
     engines: {node: '>=14.0.0'}
 
   oxlint@1.7.0:
@@ -7170,61 +7170,61 @@ snapshots:
       '@oxc-node/core-win32-ia32-msvc': 0.0.30
       '@oxc-node/core-win32-x64-msvc': 0.0.30
 
-  '@oxc-parser/binding-android-arm64@0.79.0':
+  '@oxc-parser/binding-android-arm64@0.80.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.37.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.79.0':
+  '@oxc-parser/binding-darwin-arm64@0.80.0':
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.37.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.79.0':
+  '@oxc-parser/binding-darwin-x64@0.80.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.79.0':
+  '@oxc-parser/binding-freebsd-x64@0.80.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.79.0':
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.80.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.79.0':
+  '@oxc-parser/binding-linux-arm-musleabihf@0.80.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.37.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.79.0':
+  '@oxc-parser/binding-linux-arm64-gnu@0.80.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-musl@0.37.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-musl@0.79.0':
+  '@oxc-parser/binding-linux-arm64-musl@0.80.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.79.0':
+  '@oxc-parser/binding-linux-riscv64-gnu@0.80.0':
     optional: true
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.79.0':
+  '@oxc-parser/binding-linux-s390x-gnu@0.80.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.37.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-gnu@0.79.0':
+  '@oxc-parser/binding-linux-x64-gnu@0.80.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.37.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-musl@0.79.0':
+  '@oxc-parser/binding-linux-x64-musl@0.80.0':
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.79.0':
+  '@oxc-parser/binding-wasm32-wasi@0.80.0':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.1
     optional: true
@@ -7232,24 +7232,24 @@ snapshots:
   '@oxc-parser/binding-win32-arm64-msvc@0.37.0':
     optional: true
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.79.0':
+  '@oxc-parser/binding-win32-arm64-msvc@0.80.0':
     optional: true
 
   '@oxc-parser/binding-win32-x64-msvc@0.37.0':
     optional: true
 
-  '@oxc-parser/binding-win32-x64-msvc@0.79.0':
+  '@oxc-parser/binding-win32-x64-msvc@0.80.0':
     optional: true
 
   '@oxc-project/runtime@0.78.0': {}
 
-  '@oxc-project/runtime@0.79.0': {}
+  '@oxc-project/runtime@0.80.0': {}
 
   '@oxc-project/types@0.37.0': {}
 
   '@oxc-project/types@0.78.0': {}
 
-  '@oxc-project/types@0.79.0': {}
+  '@oxc-project/types@0.80.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.6.0':
     optional: true
@@ -7310,51 +7310,51 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.6.0':
     optional: true
 
-  '@oxc-transform/binding-android-arm64@0.79.0':
+  '@oxc-transform/binding-android-arm64@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-darwin-arm64@0.79.0':
+  '@oxc-transform/binding-darwin-arm64@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-darwin-x64@0.79.0':
+  '@oxc-transform/binding-darwin-x64@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-freebsd-x64@0.79.0':
+  '@oxc-transform/binding-freebsd-x64@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm-gnueabihf@0.79.0':
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm-musleabihf@0.79.0':
+  '@oxc-transform/binding-linux-arm-musleabihf@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm64-gnu@0.79.0':
+  '@oxc-transform/binding-linux-arm64-gnu@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-linux-arm64-musl@0.79.0':
+  '@oxc-transform/binding-linux-arm64-musl@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-linux-riscv64-gnu@0.79.0':
+  '@oxc-transform/binding-linux-riscv64-gnu@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-linux-s390x-gnu@0.79.0':
+  '@oxc-transform/binding-linux-s390x-gnu@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-linux-x64-gnu@0.79.0':
+  '@oxc-transform/binding-linux-x64-gnu@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-linux-x64-musl@0.79.0':
+  '@oxc-transform/binding-linux-x64-musl@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-wasm32-wasi@0.79.0':
+  '@oxc-transform/binding-wasm32-wasi@0.80.0':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.1
     optional: true
 
-  '@oxc-transform/binding-win32-arm64-msvc@0.79.0':
+  '@oxc-transform/binding-win32-arm64-msvc@0.80.0':
     optional: true
 
-  '@oxc-transform/binding-win32-x64-msvc@0.79.0':
+  '@oxc-transform/binding-win32-x64-msvc@0.80.0':
     optional: true
 
   '@oxlint/darwin-arm64@1.7.0':
@@ -9543,25 +9543,25 @@ snapshots:
       '@oxc-parser/binding-win32-arm64-msvc': 0.37.0
       '@oxc-parser/binding-win32-x64-msvc': 0.37.0
 
-  oxc-parser@0.79.0:
+  oxc-parser@0.80.0:
     dependencies:
-      '@oxc-project/types': 0.79.0
+      '@oxc-project/types': 0.80.0
     optionalDependencies:
-      '@oxc-parser/binding-android-arm64': 0.79.0
-      '@oxc-parser/binding-darwin-arm64': 0.79.0
-      '@oxc-parser/binding-darwin-x64': 0.79.0
-      '@oxc-parser/binding-freebsd-x64': 0.79.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.79.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.79.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.79.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.79.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.79.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.79.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.79.0
-      '@oxc-parser/binding-linux-x64-musl': 0.79.0
-      '@oxc-parser/binding-wasm32-wasi': 0.79.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.79.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.79.0
+      '@oxc-parser/binding-android-arm64': 0.80.0
+      '@oxc-parser/binding-darwin-arm64': 0.80.0
+      '@oxc-parser/binding-darwin-x64': 0.80.0
+      '@oxc-parser/binding-freebsd-x64': 0.80.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.80.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.80.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.80.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.80.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.80.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.80.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.80.0
+      '@oxc-parser/binding-linux-x64-musl': 0.80.0
+      '@oxc-parser/binding-wasm32-wasi': 0.80.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.80.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.80.0
 
   oxc-resolver@11.6.0:
     dependencies:
@@ -9587,23 +9587,23 @@ snapshots:
       '@oxc-resolver/binding-win32-ia32-msvc': 11.6.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.6.0
 
-  oxc-transform@0.79.0:
+  oxc-transform@0.80.0:
     optionalDependencies:
-      '@oxc-transform/binding-android-arm64': 0.79.0
-      '@oxc-transform/binding-darwin-arm64': 0.79.0
-      '@oxc-transform/binding-darwin-x64': 0.79.0
-      '@oxc-transform/binding-freebsd-x64': 0.79.0
-      '@oxc-transform/binding-linux-arm-gnueabihf': 0.79.0
-      '@oxc-transform/binding-linux-arm-musleabihf': 0.79.0
-      '@oxc-transform/binding-linux-arm64-gnu': 0.79.0
-      '@oxc-transform/binding-linux-arm64-musl': 0.79.0
-      '@oxc-transform/binding-linux-riscv64-gnu': 0.79.0
-      '@oxc-transform/binding-linux-s390x-gnu': 0.79.0
-      '@oxc-transform/binding-linux-x64-gnu': 0.79.0
-      '@oxc-transform/binding-linux-x64-musl': 0.79.0
-      '@oxc-transform/binding-wasm32-wasi': 0.79.0
-      '@oxc-transform/binding-win32-arm64-msvc': 0.79.0
-      '@oxc-transform/binding-win32-x64-msvc': 0.79.0
+      '@oxc-transform/binding-android-arm64': 0.80.0
+      '@oxc-transform/binding-darwin-arm64': 0.80.0
+      '@oxc-transform/binding-darwin-x64': 0.80.0
+      '@oxc-transform/binding-freebsd-x64': 0.80.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.80.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.80.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.80.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.80.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.80.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.80.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.80.0
+      '@oxc-transform/binding-linux-x64-musl': 0.80.0
+      '@oxc-transform/binding-wasm32-wasi': 0.80.0
+      '@oxc-transform/binding-win32-arm64-msvc': 0.80.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.80.0
 
   oxlint@1.7.0:
     optionalDependencies:
@@ -10433,7 +10433,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-isolated-decl@0.8.3(oxc-transform@0.79.0)(rollup@4.45.1)(typescript@5.8.3):
+  unplugin-isolated-decl@0.8.3(oxc-transform@0.80.0)(rollup@4.45.1)(typescript@5.8.3):
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.45.1)
       debug: 4.4.1(supports-color@8.1.1)
@@ -10441,7 +10441,7 @@ snapshots:
       oxc-parser: 0.37.0
       unplugin: 1.16.1
     optionalDependencies:
-      oxc-transform: 0.79.0
+      oxc-transform: 0.80.0
       typescript: 5.8.3
     transitivePeerDependencies:
       - rollup

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalog:
   'rolldown-plugin-dts': '^0.14.0'
   'tsdown': '0.13.0'
   # oxc
-  '@oxc-project/runtime': '=0.79.0'
-  '@oxc-project/types': '=0.79.0'
-  'oxc-parser': '=0.79.0'
-  'oxc-transform': '=0.79.0'
+  '@oxc-project/runtime': '=0.80.0'
+  '@oxc-project/types': '=0.80.0'
+  'oxc-parser': '=0.80.0'
+  'oxc-transform': '=0.80.0'


### PR DESCRIPTION
More minifier changes:

* Remove unnecessary 'use strict' directive  
* Inline small constant values 
* Remove unused class expression 