### PR TITLE
refactor: hide namespace statement index knowledge inside StmtInfos

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -167,12 +167,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     let result = ScanResult {
       named_imports: FxIndexMap::default(),
       named_exports: FxHashMap::default(),
-      stmt_infos: {
-        let mut stmt_infos = StmtInfos::default();
-        // The first `StmtInfo` is used to represent the statement that declares and constructs Module Namespace Object
-        stmt_infos.push(StmtInfo::default());
-        stmt_infos
-      },
+      stmt_infos: StmtInfos::new(),
       import_records: IndexVec::new(),
       default_export_ref,
       namespace_object_ref,

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -9,7 +9,7 @@ use oxc::{
   semantic::ScopeFlags,
   span::{SPAN, Span},
 };
-use rolldown_common::{ExportsKind, StmtInfoIdx, SymbolRef, ThisExprReplaceKind, WrapKind};
+use rolldown_common::{ExportsKind, SymbolRef, ThisExprReplaceKind, WrapKind};
 use rolldown_ecmascript_utils::{ExpressionExt, JsxExt};
 
 use crate::hmr::utils::HmrAstBuilder;
@@ -41,7 +41,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
     // init namespace_alias_symbol_id
 
     let is_namespace_referenced = matches!(self.ctx.module.exports_kind, ExportsKind::Esm)
-      && self.ctx.module.stmt_infos[StmtInfoIdx::new(0)].is_included;
+      && self.ctx.module.stmt_infos.get_namespace_stmt_info().is_included;
 
     let last_import_stmt_idx = self.remove_unused_top_level_stmt(program);
 

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -69,7 +69,6 @@ pub struct EcmaView {
   pub namespace_object_ref: SymbolRef,
   pub named_imports: FxIndexMap<SymbolRef, NamedImport>,
   pub named_exports: FxHashMap<Rstr, LocalExport>,
-  /// `stmt_infos[0]` represents the namespace binding statement
   pub stmt_infos: StmtInfos,
   pub import_records: IndexVec<ImportRecordIdx, ResolvedImportRecord>,
   /// The key is the `Span` of `ImportDeclaration`, `ImportExpression`, `ExportNamedDeclaration`, `ExportAllDeclaration`


### PR DESCRIPTION
Moved codes that interacted with namespace statement index inside StmtInfos where possible.
This should make it possible to read the code in more places without thinking about the fact that the first index is a namespace statement.
