### PR TITLE
refactor(rolldown): remove unnecessary comments

### DIFF
--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -72,9 +72,6 @@ async function watchInner(
   config: ConfigExport,
   cliOptions: NormalizedCliOptions,
 ) {
-  // Only if watch is true in CLI can we use watch mode.
-  // We should not make it `await`, as it never ends.
-
   let normalizedConfig = arraify(config).map((option) => {
     return {
       ...option,


### PR DESCRIPTION
Remove these comments since original code commented is no longer existed and may mislead others in the future.

Reference: https://github.com/rolldown/rolldown/pull/2413/files#diff-c78b17f497f595892f9851b63e71507f2c158dab2f3dd89ec38459f103e77898R57-R62