### PR TITLE
feat(assetFileNames): support `name` and `originalFileName`

### DIFF
--- a/crates/rolldown_binding/src/options/binding_output_options/binding_pre_rendered_asset.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_pre_rendered_asset.rs
@@ -5,7 +5,9 @@ use crate::options::plugin::types::binding_asset_source::BindingAssetSource;
 #[napi_derive::napi(object)]
 #[derive(Default, Debug)]
 pub struct BindingPreRenderedAsset {
+  pub name: Option<String>,
   pub names: Vec<String>,
+  pub original_file_name: Option<String>,
   pub original_file_names: Vec<String>,
   pub source: BindingAssetSource,
 }
@@ -13,7 +15,9 @@ pub struct BindingPreRenderedAsset {
 impl From<rolldown_common::RollupPreRenderedAsset> for BindingPreRenderedAsset {
   fn from(value: rolldown_common::RollupPreRenderedAsset) -> Self {
     Self {
+      name: value.names.first().map(ArcStr::to_string),
       names: value.names.iter().map(ArcStr::to_string).collect(),
+      original_file_name: value.original_file_names.first().map(ArcStr::to_string),
       original_file_names: value.original_file_names.iter().map(ArcStr::to_string).collect(),
       source: value.source.into(),
     }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1853,7 +1853,9 @@ export interface BindingPluginWithIndex {
 }
 
 export interface BindingPreRenderedAsset {
+  name?: string
   names: Array<string>
+  originalFileName?: string
   originalFileNames: Array<string>
   source: BindingAssetSource
 }

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -22,10 +22,12 @@ export type AddonFunction = (chunk: RenderedChunk) => string | Promise<string>;
 export type ChunkFileNamesFunction = (chunkInfo: PreRenderedChunk) => string;
 
 export interface PreRenderedAsset {
+  type: 'asset';
+  name?: string;
   names: string[];
+  originalFileName?: string;
   originalFileNames: string[];
   source: string | Uint8Array;
-  type: 'asset';
 }
 
 export type AssetFileNamesFunction = (chunkInfo: PreRenderedAsset) => string;

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -32,7 +32,7 @@ export interface EmittedAsset {
   type: 'asset';
   name?: string;
   fileName?: string;
-  originalFileName?: string | null;
+  originalFileName?: string;
   source: AssetSource;
 }
 
@@ -226,10 +226,12 @@ export class PluginContextImpl extends MinimalPluginContextImpl {
   private getAssetFileNames(file: EmittedAsset): string | undefined {
     if (typeof this.outputOptions.assetFileNames === 'function') {
       return this.outputOptions.assetFileNames({
+        type: 'asset',
+        name: file.name,
         names: file.name ? [file.name] : [],
+        originalFileName: file.originalFileName,
         originalFileNames: file.originalFileName ? [file.originalFileName] : [],
         source: file.source,
-        type: 'asset',
       });
     }
   }

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -161,7 +161,9 @@ function bindingifyAssetFilenames(
   if (typeof assetFileNames === 'function') {
     return (asset) => {
       return assetFileNames({
+        name: asset.name,
         names: asset.names,
+        originalFileName: asset.originalFileName,
         originalFileNames: asset.originalFileNames,
         source: transformAssetSource(asset.source),
         type: 'asset',

--- a/packages/rolldown/tests/fixtures/output/asset-filenames/function/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/asset-filenames/function/_config.ts
@@ -1,11 +1,13 @@
+import { expect } from 'vitest'
 import { defineTest } from 'rolldown-tests'
 import { getOutputAssetNames } from 'rolldown-tests/utils'
-import { expect } from 'vitest'
 
 export default defineTest({
   config: {
     output: {
       assetFileNames: (asset) => {
+        expect(asset).toHaveProperty('name')
+        expect(asset).toHaveProperty('originalFileName')
         if (
           typeof asset.source === 'string' &&
           asset.source === 'emitted' &&


### PR DESCRIPTION
See https://github.com/vitejs/vite-ecosystem-ci/actions/runs/16640378447/job/47089473662

Many parts of the ecosystem are currently breaking because of this. Although Rollup has marked these features as deprecated, they haven’t been fully removed yet. To ensure a smoother migration experience and maintain ecosystem compatibility, we will continue to support them for now.