### PR TITLE
fix(hmr): ensure correct runtime behavior for `export * from ...`

### DIFF
--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -349,6 +349,7 @@ impl HmrManager {
           dependencies: FxIndexSet::default(),
           imports: FxHashSet::default(),
           generated_static_import_infos: FxHashMap::default(),
+          re_export_all_dependencies: FxIndexSet::default(),
         };
 
         finalizer.visit_program(fields.program);

--- a/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/deconflict_import_bindings/artifacts.snap
@@ -164,6 +164,8 @@ var init_rolldown_hmr_3 = __rolldown_runtime__.createEsmInitializer((function() 
 			__export = import_rolldown_runtime_0.__export;
 			/** @internal */
 			__toDynamicImportESM = import_rolldown_runtime_0.__toDynamicImportESM;
+			/** @internal */
+			__reExport = import_rolldown_runtime_0.__reExport;
 		}
 		class TestDevRuntime extends DevRuntime {
 			/**
@@ -222,6 +224,7 @@ var init_rolldown_runtime_4 = __rolldown_runtime__.createEsmInitializer((functio
 			}
 			return to;
 		};
+		var __reExport = (target, mod, secondTarget) => (__copyProps(target, mod, "default"), secondTarget && __copyProps(secondTarget, mod, "default"));
 		var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
 			value: mod,
 			enumerable: true

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __commonJS, __export, __toCommonJS, __toDynamicImportESM, __toESM };
+export { __commonJS, __export, __reExport, __toCommonJS, __toDynamicImportESM, __toESM };
 ```
 ## exist-dep-cjs.js
 
@@ -43,7 +43,7 @@ export { value };
 ## main.js
 
 ```js
-import { __export, __toCommonJS, __toDynamicImportESM, __toESM } from "./chunk.js";
+import { __export, __reExport, __toCommonJS, __toDynamicImportESM, __toESM } from "./chunk.js";
 
 // HIDDEN [rolldown:hmr]
 //#region hmr.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
@@ -10,25 +10,42 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region sub/foo.js
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo });
+__export(foo_exports, {
+	foo: () => foo,
+	named: () => named$2
+});
 const foo_hot = __rolldown_runtime__.createModuleHotContext("sub/foo.js");
 __rolldown_runtime__.registerModule("sub/foo.js", { exports: foo_exports });
 const foo = "foo";
+const named$2 = "foo";
 
 //#endregion
 //#region sub/bar.js
 var bar_exports = {};
-__export(bar_exports, { bar: () => bar });
+__export(bar_exports, {
+	bar: () => bar,
+	named: () => named$1
+});
 const bar_hot = __rolldown_runtime__.createModuleHotContext("sub/bar.js");
 __rolldown_runtime__.registerModule("sub/bar.js", { exports: bar_exports });
-const bar = "bars";
+const bar = "bar";
+const named$1 = "bar";
+
+//#endregion
+//#region sub/named.js
+var named_exports = {};
+__export(named_exports, { named: () => named });
+const named_hot = __rolldown_runtime__.createModuleHotContext("sub/named.js");
+__rolldown_runtime__.registerModule("sub/named.js", { exports: named_exports });
+const named = "named";
 
 //#endregion
 //#region sub/index.js
 var sub_exports = {};
 __export(sub_exports, {
 	bar: () => bar,
-	foo: () => foo
+	foo: () => foo,
+	named: () => named
 });
 const sub_hot = __rolldown_runtime__.createModuleHotContext("sub/index.js");
 __rolldown_runtime__.registerModule("sub/index.js", { exports: sub_exports });
@@ -77,10 +94,14 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 var init_bar_1 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var ns_bar = {};
-		__rolldown_runtime__.__export(ns_bar, { bar: () => bar });
+		__rolldown_runtime__.__export(ns_bar, {
+			bar: () => bar,
+			named: () => named
+		});
 		__rolldown_runtime__.registerModule("sub/bar.js", { exports: ns_bar });
 		const hot_bar = __rolldown_runtime__.createModuleHotContext("sub/bar.js");
-		const bar = "bars";
+		const bar = "bar";
+		const named = "bar";
 	} finally {}
 }));
 
@@ -89,10 +110,14 @@ var init_bar_1 = __rolldown_runtime__.createEsmInitializer((function() {
 var init_foo_2 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var ns_foo = {};
-		__rolldown_runtime__.__export(ns_foo, { foo: () => foo });
+		__rolldown_runtime__.__export(ns_foo, {
+			foo: () => foo,
+			named: () => named
+		});
 		__rolldown_runtime__.registerModule("sub/foo.js", { exports: ns_foo });
 		const hot_foo = __rolldown_runtime__.createModuleHotContext("sub/foo.js");
 		const foo = "foo";
+		const named = "foo";
 	} finally {}
 }));
 
@@ -101,13 +126,29 @@ var init_foo_2 = __rolldown_runtime__.createEsmInitializer((function() {
 var init_sub_3 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var ns_sub = {};
-		__rolldown_runtime__.__export(ns_sub, {});
+		__rolldown_runtime__.__export(ns_sub, { named: () => import_named_2.named });
 		__rolldown_runtime__.registerModule("sub/index.js", { exports: ns_sub });
 		init_foo_2();
 		init_bar_1();
+		init_named_4();
 		const hot_sub = __rolldown_runtime__.createModuleHotContext("sub/index.js");
 		var import_foo_0 = __rolldown_runtime__.loadExports("sub/foo.js");
+		__rolldown_runtime__.__reExport(ns_sub, import_foo_0);
 		var import_bar_1 = __rolldown_runtime__.loadExports("sub/bar.js");
+		__rolldown_runtime__.__reExport(ns_sub, import_bar_1);
+		var import_named_2 = __rolldown_runtime__.loadExports("sub/named.js");
+	} finally {}
+}));
+
+//#endregion
+//#region sub/named.js
+var init_named_4 = __rolldown_runtime__.createEsmInitializer((function() {
+	try {
+		var ns_named = {};
+		__rolldown_runtime__.__export(ns_named, { named: () => named });
+		__rolldown_runtime__.registerModule("sub/named.js", { exports: ns_named });
+		const hot_named = __rolldown_runtime__.createModuleHotContext("sub/named.js");
+		const named = "named";
 	} finally {}
 }));
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/sub/bar.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/sub/bar.js
@@ -1,1 +1,2 @@
-export const bar = 'bars'
+export const bar = 'bar'
+export const named = 'bar'

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/sub/foo.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/sub/foo.js
@@ -1,1 +1,2 @@
 export const foo = 'foo'
+export const named = 'foo'

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/sub/index.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/sub/index.js
@@ -1,2 +1,3 @@
 export * from './foo.js'
 export * from './bar.js'
+export { named } from './named.js'

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/sub/named.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/sub/named.js
@@ -1,0 +1,1 @@
+export const named = 'named'

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -25,7 +25,7 @@ export { bar_default as default };
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __export, __toCommonJS, __toDynamicImportESM, __toESM };
+export { __export, __reExport, __toCommonJS, __toDynamicImportESM, __toESM };
 ```
 ## foo.js
 
@@ -58,7 +58,7 @@ export { foo_default as default };
 ## main.js
 
 ```js
-import { __export, __toCommonJS, __toDynamicImportESM, __toESM } from "./chunk.js";
+import { __export, __reExport, __toCommonJS, __toDynamicImportESM, __toESM } from "./chunk.js";
 
 // HIDDEN [rolldown:hmr]
 //#region main.js

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4060,7 +4060,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-Bb3AbQtA.js
+- main-!~{000}~.js => main-BCExEOOM.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4731,7 +4731,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-9pXZqgmo.js
+- main-!~{000}~.js => main-DyaaPSCy.js
 
 # tests/rolldown/issues/4196
 
@@ -5501,56 +5501,56 @@ expression: output
 
 # tests/rolldown/topics/hmr/deconflict_import_bindings
 
-- main-!~{000}~.js => main-Bu6m5KuF.js
+- main-!~{000}~.js => main-BbSj2Nfk.js
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-M8OQV59d.js
-- chunk-!~{001}~.js => chunk-8OODDWbD.js
-- exist-dep-cjs-!~{003}~.js => exist-dep-cjs-i5QXDAv6.js
-- exist-dep-esm-!~{005}~.js => exist-dep-esm-CbY1ke2_.js
+- main-!~{000}~.js => main-IRg-BogZ.js
+- chunk-!~{001}~.js => chunk-EJRfyxWL.js
+- exist-dep-cjs-!~{003}~.js => exist-dep-cjs-CMMhV_IP.js
+- exist-dep-esm-!~{005}~.js => exist-dep-esm-DS9du_-x.js
 
 # tests/rolldown/topics/hmr/export_star
 
-- main-!~{000}~.js => main-CK22Dsp5.js
+- main-!~{000}~.js => main-CNc4zq-d.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-Cm3C6mQH.js
+- main-!~{000}~.js => main-a2sWK8wq.js
 
 # tests/rolldown/topics/hmr/issue_5149
 
-- main-!~{000}~.js => main-C4vaaWcq.js
+- main-!~{000}~.js => main-ChDG295G.js
 
 # tests/rolldown/topics/hmr/issue_5150
 
-- main-!~{000}~.js => main-DqRBvpQT.js
+- main-!~{000}~.js => main-DRU4Jo0i.js
 
 # tests/rolldown/topics/hmr/issue_5159
 
-- main-!~{000}~.js => main-K2kWHB-A.js
-- bar-!~{005}~.js => bar-9GyTK8RJ.js
-- chunk-!~{001}~.js => chunk-H37MHKgK.js
-- foo-!~{007}~.js => foo-DWqUFXTX.js
-- string-!~{003}~.js => string-CVda_J7-.js
+- main-!~{000}~.js => main-BHAurs1l.js
+- bar-!~{005}~.js => bar-BisjqNeR.js
+- chunk-!~{001}~.js => chunk--KgZXUQQ.js
+- foo-!~{007}~.js => foo-OmnQYi5B.js
+- string-!~{003}~.js => string-CMcoXSG2.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-BPZIs1mk.js
-- index-!~{001}~.js => index-BL3zgd2U.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-gxTUiBAp.js
+- entry-!~{000}~.js => entry-DuzgHSBP.js
+- index-!~{001}~.js => index-gHbaN3vx.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-HfwL1-NX.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-C2h-3mJ8.js
+- main-!~{000}~.js => main-C9O2twdF.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-Brsmj5f_.js
+- main-!~{000}~.js => main-NuVSIYM-.js
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-DApPzWAG.js
+- main-!~{000}~.js => main-BBufK_wo.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
@@ -1,6 +1,7 @@
 // @ts-check
 import {
   __export,
+  __reExport,
   __toCommonJS,
   __toDynamicImportESM,
   __toESM,
@@ -89,4 +90,6 @@ export class DevRuntime {
   __export = __export;
   /** @internal */
   __toDynamicImportESM = __toDynamicImportESM;
+  /** @internal */
+  __reExport = __reExport;
 }


### PR DESCRIPTION
Fixes https://github.com/rolldown/rolldown/issues/5532.