### PR TITLE
fix(types)!: align `TreeshakingOptions` type with Rollup

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
@@ -26,6 +26,7 @@ pub struct BindingTreeshake {
   #[debug("ModuleSideEffects(...)")]
   pub module_side_effects: BindingModuleSideEffects,
   pub annotations: Option<bool>,
+  #[napi(ts_type = "ReadonlyArray<string>")]
   pub manual_pure_functions: Option<Vec<String>>,
   pub unknown_global_side_effects: Option<bool>,
   pub commonjs: Option<bool>,

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1933,7 +1933,7 @@ export interface BindingTransformPluginConfig {
 export interface BindingTreeshake {
   moduleSideEffects: boolean | BindingModuleSideEffectsRule[] | ((id: string, is_external: boolean) => boolean | undefined)
   annotations?: boolean
-  manualPureFunctions?: Array<string>
+  manualPureFunctions?: ReadonlyArray<string>
   unknownGlobalSideEffects?: boolean
   commonjs?: boolean
 }

--- a/packages/rolldown/src/types/module-side-effects.ts
+++ b/packages/rolldown/src/types/module-side-effects.ts
@@ -10,12 +10,10 @@ type ModuleSideEffectsOption =
   | ((id: string, isResolved: boolean) => boolean | undefined)
   | 'no-external';
 
-export type TreeshakingOptions =
-  | {
-    moduleSideEffects?: ModuleSideEffectsOption;
-    annotations?: boolean;
-    manualPureFunctions?: string[];
-    unknownGlobalSideEffects?: boolean;
-    commonjs?: boolean;
-  }
-  | boolean;
+export type TreeshakingOptions = {
+  moduleSideEffects?: ModuleSideEffectsOption;
+  annotations?: boolean;
+  manualPureFunctions?: readonly string[];
+  unknownGlobalSideEffects?: boolean;
+  commonjs?: boolean;
+};


### PR DESCRIPTION
Aligned the type more to rollup.
https://github.com/rollup/rollup/blob/e4082a84063490503a6ee3b4ac74b45be745f111/src/rollup/types.d.ts#L608-L622
