### PR TITLE
feat: add array support for `treeshake.moduleSideEffects` option

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
@@ -26,6 +26,7 @@ pub struct BindingTreeshake {
   #[debug("ModuleSideEffects(...)")]
   pub module_side_effects: BindingModuleSideEffects,
   pub annotations: Option<bool>,
+  #[napi(ts_type = "ReadonlyArray<string>")]
   pub manual_pure_functions: Option<Vec<String>>,
   pub unknown_global_side_effects: Option<bool>,
   pub commonjs: Option<bool>,

--- a/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
@@ -68,6 +68,8 @@ impl Default for TreeshakeOptions {
 pub enum ModuleSideEffects {
   #[debug("ModuleSideEffectsRules({_0:?})")]
   ModuleSideEffectsRules(Vec<ModuleSideEffectsRule>),
+  #[debug("IdSet({_0:?})")]
+  IdSet(FxHashSet<String>),
   #[debug("Boolean({_0})")]
   Boolean(bool),
   #[debug("Function")]
@@ -114,6 +116,7 @@ impl ModuleSideEffects {
         // analyze side effects from source code
         None
       }
+      ModuleSideEffects::IdSet(set) => Some(set.contains(path)),
       ModuleSideEffects::Boolean(false) => Some(false),
       ModuleSideEffects::Boolean(true) => None,
       ModuleSideEffects::Function(_) => unreachable!(),

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1931,7 +1931,7 @@ export interface BindingTransformPluginConfig {
 }
 
 export interface BindingTreeshake {
-  moduleSideEffects: boolean | BindingModuleSideEffectsRule[] | ((id: string, is_external: boolean) => boolean | undefined)
+  moduleSideEffects: boolean | ReadonlyArray<string> | BindingModuleSideEffectsRule[] | ((id: string, is_external: boolean) => boolean | undefined)
   annotations?: boolean
   manualPureFunctions?: ReadonlyArray<string>
   unknownGlobalSideEffects?: boolean

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1933,7 +1933,7 @@ export interface BindingTransformPluginConfig {
 export interface BindingTreeshake {
   moduleSideEffects: boolean | BindingModuleSideEffectsRule[] | ((id: string, is_external: boolean) => boolean | undefined)
   annotations?: boolean
-  manualPureFunctions?: Array<string>
+  manualPureFunctions?: ReadonlyArray<string>
   unknownGlobalSideEffects?: boolean
   commonjs?: boolean
 }

--- a/packages/rolldown/src/types/module-side-effects.ts
+++ b/packages/rolldown/src/types/module-side-effects.ts
@@ -10,12 +10,10 @@ type ModuleSideEffectsOption =
   | ((id: string, isResolved: boolean) => boolean | undefined)
   | 'no-external';
 
-export type TreeshakingOptions =
-  | {
-    moduleSideEffects?: ModuleSideEffectsOption;
-    annotations?: boolean;
-    manualPureFunctions?: string[];
-    unknownGlobalSideEffects?: boolean;
-    commonjs?: boolean;
-  }
-  | boolean;
+export type TreeshakingOptions = {
+  moduleSideEffects?: ModuleSideEffectsOption;
+  annotations?: boolean;
+  manualPureFunctions?: readonly string[];
+  unknownGlobalSideEffects?: boolean;
+  commonjs?: boolean;
+};

--- a/packages/rolldown/src/types/module-side-effects.ts
+++ b/packages/rolldown/src/types/module-side-effects.ts
@@ -6,6 +6,7 @@ interface ModuleSideEffectsRule {
 
 type ModuleSideEffectsOption =
   | boolean
+  | readonly string[]
   | ModuleSideEffectsRule[]
   | ((id: string, isResolved: boolean) => boolean | undefined)
   | 'no-external';

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -263,7 +263,6 @@
 ### The `output.treeshake.moduleSideEffect` is not compatible with rollup
  - rollup@function@module-side-effects@transform: handles setting moduleSideEffects in the transform hook
  - rollup@function@module-side-effects@load: handles setting moduleSideEffects in the load hook
- - rollup@function@module-side-effects@array: supports setting module side effects via an array
  - rollup@function@module-side-effects@resolve-id-external: does not include modules without used exports if moduleSideEffect is false
  - rollup@function@module-side-effects@resolve-id: does not include modules without used exports if moduleSideEffect is false
 

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -2,8 +2,8 @@
   "failed": 0,
   "skipFailed": 1,
   "ignored": 15,
-  "ignored(unsupported features)": 398,
+  "ignored(unsupported features)": 397,
   "ignored(treeshaking)": 282,
   "ignored(behavior passed, snapshot different)": 124,
-  "passed": 728
+  "passed": 729
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -3,7 +3,7 @@
 | failed | 0 |
 | skipFailed | 1 |
 | ignored | 15 |
-| ignored(unsupported features) | 398 |
+| ignored(unsupported features) | 397 |
 | ignored(treeshaking) | 282 |
 | ignored(behavior passed, snapshot different) | 124 |
-| passed | 728 |
+| passed | 729 |


### PR DESCRIPTION
Added array support for `treeshake.moduleSideEffects` option, which is supported by Rollup.
https://github.com/rollup/rollup/blob/e4082a84063490503a6ee3b4ac74b45be745f111/src/rollup/types.d.ts#L653
