### PR TITLE
refactor: align parameter name for `treeshake.moduleSideEffects`

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
@@ -22,7 +22,7 @@ pub type BindingModuleSideEffects = Either4<
 #[derive(Debug)]
 pub struct BindingTreeshake {
   #[napi(
-    ts_type = "boolean | ReadonlyArray<string> | BindingModuleSideEffectsRule[] | ((id: string, is_external: boolean) => boolean | undefined)"
+    ts_type = "boolean | ReadonlyArray<string> | BindingModuleSideEffectsRule[] | ((id: string, external: boolean) => boolean | undefined)"
   )]
   #[debug("ModuleSideEffects(...)")]
   pub module_side_effects: BindingModuleSideEffects,

--- a/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
@@ -78,7 +78,7 @@ pub enum ModuleSideEffects {
 
 type ModuleSideEffectsFn = dyn Fn(
     &str, // id
-    bool, // is_resolved
+    bool, // external
   ) -> Pin<Box<(dyn Future<Output = anyhow::Result<Option<bool>>> + Send + 'static)>>
   + Send
   + Sync

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1931,7 +1931,7 @@ export interface BindingTransformPluginConfig {
 }
 
 export interface BindingTreeshake {
-  moduleSideEffects: boolean | ReadonlyArray<string> | BindingModuleSideEffectsRule[] | ((id: string, is_external: boolean) => boolean | undefined)
+  moduleSideEffects: boolean | ReadonlyArray<string> | BindingModuleSideEffectsRule[] | ((id: string, external: boolean) => boolean | undefined)
   annotations?: boolean
   manualPureFunctions?: ReadonlyArray<string>
   unknownGlobalSideEffects?: boolean

--- a/packages/rolldown/src/types/module-side-effects.ts
+++ b/packages/rolldown/src/types/module-side-effects.ts
@@ -8,7 +8,7 @@ type ModuleSideEffectsOption =
   | boolean
   | readonly string[]
   | ModuleSideEffectsRule[]
-  | ((id: string, isResolved: boolean) => boolean | undefined)
+  | ((id: string, external: boolean) => boolean | undefined)
   | 'no-external';
 
 export type TreeshakingOptions = {


### PR DESCRIPTION
Simply aligned the parameter name for `treeshake.moduleSideEffects` to use `external`.