### PR TITLE
fix: align behavior when returning `undefined` from `treeshake.moduleSideEffects` function

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -165,14 +165,13 @@ pub async fn normalize_side_effects(
       None => DeterminedSideEffects::NoTreeshake,
       Some(opt) => {
         if opt.module_side_effects.is_fn() {
-          let module_side_effects = opt
+          match opt
             .module_side_effects
             .ffi_resolve(&resolved_id.id, resolved_id.external.is_external())
-            .await?;
-          if module_side_effects.unwrap_or_default() {
-            lazy_check_side_effects(resolved_id, module_type, stmt_infos)
-          } else {
-            DeterminedSideEffects::UserDefined(false)
+            .await?
+          {
+            Some(value) => DeterminedSideEffects::UserDefined(value),
+            None => lazy_check_side_effects(resolved_id, module_type, stmt_infos),
           }
         } else {
           match opt

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -261,8 +261,6 @@
  - rollup@function@unknown-treeshake-preset: throws for unknown presets for the treeshake option
 
 ### The `output.treeshake.moduleSideEffect` is not compatible with rollup
- - rollup@function@module-side-effects@transform: handles setting moduleSideEffects in the transform hook
- - rollup@function@module-side-effects@load: handles setting moduleSideEffects in the load hook
  - rollup@function@module-side-effects@resolve-id-external: does not include modules without used exports if moduleSideEffect is false
  - rollup@function@module-side-effects@resolve-id: does not include modules without used exports if moduleSideEffect is false
 

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -2,8 +2,8 @@
   "failed": 0,
   "skipFailed": 1,
   "ignored": 15,
-  "ignored(unsupported features)": 397,
+  "ignored(unsupported features)": 395,
   "ignored(treeshaking)": 282,
   "ignored(behavior passed, snapshot different)": 124,
-  "passed": 729
+  "passed": 731
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -3,7 +3,7 @@
 | failed | 0 |
 | skipFailed | 1 |
 | ignored | 15 |
-| ignored(unsupported features) | 397 |
+| ignored(unsupported features) | 395 |
 | ignored(treeshaking) | 282 |
 | ignored(behavior passed, snapshot different) | 124 |
-| passed | 729 |
+| passed | 731 |


### PR DESCRIPTION
Aligned the behavior when returning `undefined` from `treeshake.moduleSideEffects` function to Rollup so that the Rollup tests passes.