### PR TITLE
feat: improve error message for `this.resolve` and `this.load`

### DIFF
--- a/crates/rolldown_binding/src/utils/napi_error.rs
+++ b/crates/rolldown_binding/src/utils/napi_error.rs
@@ -1,11 +1,17 @@
-use std::fmt::Debug;
-
-pub fn resolve_error(specifier: &str, err: impl Debug) -> napi::Error {
-  napi::Error::from_reason(format!(
-    "Errored while resolving {specifier:?} in `this.resolve`. Got {err:?}."
-  ))
+pub fn resolve_error(specifier: &str, err: anyhow::Error) -> napi::Error {
+  let mut new_err =
+    napi::Error::from_reason(format!("Errored while resolving {specifier:?} in `this.resolve`."));
+  if let Ok(cause) = err.downcast::<napi::Error>() {
+    new_err.set_cause(cause);
+  }
+  new_err
 }
 
-pub fn load_error(specifier: &str, err: impl Debug) -> napi::Error {
-  napi::Error::from_reason(format!("Errored while load {specifier:?} in `this.load`. Got {err:?}."))
+pub fn load_error(specifier: &str, err: anyhow::Error) -> napi::Error {
+  let mut new_err =
+    napi::Error::from_reason(format!("Errored while load {specifier:?} in `this.load`."));
+  if let Ok(cause) = err.downcast::<napi::Error>() {
+    new_err.set_cause(cause);
+  }
+  new_err
 }

--- a/crates/rolldown_binding/src/utils/napi_error.rs
+++ b/crates/rolldown_binding/src/utils/napi_error.rs
@@ -1,17 +1,25 @@
 pub fn resolve_error(specifier: &str, err: anyhow::Error) -> napi::Error {
-  let mut new_err =
-    napi::Error::from_reason(format!("Errored while resolving {specifier:?} in `this.resolve`."));
-  if let Ok(cause) = err.downcast::<napi::Error>() {
-    new_err.set_cause(cause);
+  if err.downcast_ref::<napi::Error>().is_some() {
+    let mut new_err =
+      napi::Error::from_reason(format!("Errored while resolving {specifier:?} in `this.resolve`."));
+    new_err.set_cause(err.downcast::<napi::Error>().unwrap());
+    new_err
+  } else {
+    napi::Error::from_reason(format!(
+      "Errored while resolving {specifier:?} in `this.resolve`. Got {err:?}."
+    ))
   }
-  new_err
 }
 
 pub fn load_error(specifier: &str, err: anyhow::Error) -> napi::Error {
-  let mut new_err =
-    napi::Error::from_reason(format!("Errored while load {specifier:?} in `this.load`."));
-  if let Ok(cause) = err.downcast::<napi::Error>() {
-    new_err.set_cause(cause);
+  if err.downcast_ref::<napi::Error>().is_some() {
+    let mut new_err =
+      napi::Error::from_reason(format!("Errored while load {specifier:?} in `this.load`."));
+    new_err.set_cause(err.downcast::<napi::Error>().unwrap());
+    new_err
+  } else {
+    napi::Error::from_reason(format!(
+      "Errored while load {specifier:?} in `this.load`. Got {err:?}."
+    ))
   }
-  new_err
 }

--- a/packages/rolldown/src/utils/error.ts
+++ b/packages/rolldown/src/utils/error.ts
@@ -73,6 +73,15 @@ function getErrorMessage(e: RollupError): string {
   if (e.stack) {
     s = joinNewLine(s, e.stack.replace(message, ''));
   }
+  if (e.cause) {
+    s = joinNewLine(s, 'Caused by:');
+    s = joinNewLine(
+      s,
+      getErrorMessage(e.cause as any).split('\n').map(line => '  ' + line).join(
+        '\n',
+      ),
+    );
+  }
   return s;
 }
 

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve-error-cause/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve-error-cause/_config.ts
@@ -1,0 +1,33 @@
+import { defineTest } from 'rolldown-tests'
+import { expect, vi } from 'vitest'
+
+const fn = vi.fn()
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'test-plugin-context',
+        async buildStart(this) {
+          await this.resolve('./sub.js', undefined, { skipSelf: false })
+          fn()
+        },
+        async resolveId(id) {
+          if (id === './sub.js') {
+            throw new Error('my error')
+          }
+          return null
+        },
+      },
+    ],
+  },
+  afterTest: () => {
+    expect(fn).not.toHaveBeenCalled()
+  },
+  catchError(err: any) {
+    expect(err).toBeInstanceOf(Error)
+    expect(err.message).toContain('Errored while resolving "./sub.js" in `this.resolve`.')
+    expect(err.message).toContain('Caused by:')
+    expect(err.message).toContain('Error: my error')
+  },
+})

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve/_config.ts
@@ -10,7 +10,7 @@ export default defineTest({
       {
         name: 'test-plugin-context',
         async buildStart(this) {
-          const ret = await this.resolve('./sub.js', undefined, { skipSelf: false })
+          const ret = await this.resolve('./main.js')
           if (!ret) {
             throw new Error('resolve failed')
           }
@@ -18,12 +18,6 @@ export default defineTest({
           expect(external).toBe(false)
           expect(id).toEqual(nodePath.join(import.meta.dirname, 'main.js'))
           fn()
-        },
-        async resolveId(id) {
-          if (id === './sub.js') {
-            throw new Error('my error')
-          }
-          return null
         },
       },
     ],

--- a/packages/rolldown/tests/fixtures/plugin/context/resolve/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/resolve/_config.ts
@@ -10,7 +10,7 @@ export default defineTest({
       {
         name: 'test-plugin-context',
         async buildStart(this) {
-          const ret = await this.resolve('./main.js')
+          const ret = await this.resolve('./sub.js', undefined, { skipSelf: false })
           if (!ret) {
             throw new Error('resolve failed')
           }
@@ -18,6 +18,12 @@ export default defineTest({
           expect(external).toBe(false)
           expect(id).toEqual(nodePath.join(import.meta.dirname, 'main.js'))
           fn()
+        },
+        async resolveId(id) {
+          if (id === './sub.js') {
+            throw new Error('my error')
+          }
+          return null
         },
       },
     ],


### PR DESCRIPTION
Made the `this.resolve` / `this.load` error message to contain the original stacktrace.

**Old Error**:
```
[plugin test-plugin-context]
Error: Errored while resolving "./sub.js" in `this.resolve`. Got GenericFailure, Error: my error.
```

**New Error**:
```
[plugin test-plugin-context]
Error: Errored while resolving "./sub.js" in `this.resolve`.
Caused by:
  [plugin test-plugin-context]
  Error: my error
      at PluginContextImpl.resolveId (/home/green/workspace/rolldown/packages/rolldown/tests/fixtures/plugin/context/resolve/_config.ts:24:19)
      at plugin (/home/green/workspace/rolldown/packages/rolldown/dist/shared/src-_iWIzySM.mjs:2706:30)
      at plugin.<computed> (/home/green/workspace/rolldown/packages/rolldown/dist/shared/src-_iWIzySM.mjs:3404:18)
```

Related error: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/16718227301/job/47316318655#step:7:1580

depends on https://github.com/napi-rs/napi-rs/pull/2829
