### PR TITLE
feat(hmr): handle `import ... from 'external-module'` in rolldown's best

### DIFF
--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -18,7 +18,7 @@ use rolldown_plugin::SharedPluginDriver;
 use rolldown_sourcemap::{Source, SourceJoiner, SourceMapSource};
 use rolldown_utils::{
   concat_string,
-  indexmap::FxIndexSet,
+  indexmap::{FxIndexMap, FxIndexSet},
   rayon::{IntoParallelIterator, ParallelIterator},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -376,6 +376,7 @@ impl HmrManager {
             imports: FxHashSet::default(),
             generated_static_import_infos: FxHashMap::default(),
             re_export_all_dependencies: FxIndexSet::default(),
+            generated_static_import_stmts_from_external: FxIndexMap::default(),
           };
 
           finalizer.visit_program(fields.program);

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
@@ -76,6 +76,7 @@ function text(el, text$1) {
 
 ```js
 //#region hmr.js
+import * as import_node_assert_0 from "node:assert";
 var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = {};
@@ -83,11 +84,10 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
 		init_sub_3();
 		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
-		var import_sub_0 = __rolldown_runtime__.loadExports("sub/index.js");
-		const { assert } = globalThis.__node;
-		assert.strictEqual(import_sub_0.foo, "foo");
-		assert.strictEqual(import_sub_0.bar, "bar");
-		assert.strictEqual(import_sub_0.named, "named");
+		var import_sub_1 = __rolldown_runtime__.loadExports("sub/index.js");
+		import_node_assert_0.default.strictEqual(import_sub_1.foo, "foo");
+		import_node_assert_0.default.strictEqual(import_sub_1.bar, "bar");
+		import_node_assert_0.default.strictEqual(import_sub_1.named, "named");
 		hot_hmr.accept();
 	} finally {}
 }));

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/hmr.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/hmr.hmr-0.js
@@ -1,7 +1,7 @@
 
+import assert from 'node:assert';
 import { foo, bar, named } from './sub/index.js'
 
-const { assert } = globalThis.__node;
 
 assert.strictEqual(foo, 'foo')
 assert.strictEqual(bar, 'bar')

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -676,19 +676,9 @@ impl IntegrationTest {
   fn generate_globals_injection_for_execute_output(
     config_name: Option<&str>,
     patch_chunks: &[String],
-    options: &NormalizedBundlerOptions,
+    _options: &NormalizedBundlerOptions,
   ) -> String {
     let mut stmts = vec![];
-    if options.experimental.hmr.is_some() {
-      stmts.push("import nodeFs from 'node:fs';".to_string());
-      stmts.push("import nodeAssert from 'node:assert';".to_string());
-      stmts.push("import nodePath from 'node:path';".to_string());
-      stmts.push("import nodeUrl from 'node:url';".to_string());
-      stmts.push(
-        "globalThis.__node = { fs: nodeFs, assert: nodeAssert, path: nodePath, url: nodeUrl };"
-          .to_string(),
-      );
-    }
 
     if let Some(config_name) = config_name {
       stmts.push(format!("globalThis.__configName = `{config_name}`;",));


### PR DESCRIPTION
We just simply preserve external imports and let runtime handle them.