### PR TITLE
fix: esm export * from 'externalized-dep' generates unnecessary code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,6 +2599,7 @@ dependencies = [
  "anyhow",
  "append-only-vec",
  "arcstr",
+ "bitflags 2.9.1",
  "commondir",
  "css-module-lexer",
  "dunce",

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -22,6 +22,7 @@ serde = ["dep:serde", "oxc_index/serde"]
 anyhow = { workspace = true }
 append-only-vec = { workspace = true }
 arcstr = { workspace = true }
+bitflags = { workspace = true }
 commondir = { workspace = true }
 css-module-lexer = { workspace = true }
 dunce = { workspace = true }

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -51,13 +51,15 @@ pub fn render_esm<'code>(
 
   if let Some(entry_module) = ctx.chunk.entry_module(&ctx.link_output.module_table) {
     if matches!(entry_module.exports_kind, ExportsKind::Esm) {
-      entry_module
-        .star_export_module_ids()
+      ctx
+        .chunk
+        .entry_level_external_module_idx
+        .iter()
+        .copied()
         .filter_map(|importee| {
           let importee = &ctx.link_output.module_table[importee];
           importee.as_external().map(|m| m.get_import_path(ctx.chunk))
         })
-        .dedup()
         .for_each(|ext_name| {
           source_joiner.append_source(concat_string!("export * from \"", ext_name, "\"\n"));
         });

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -322,6 +322,11 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         OutputFormat::Esm => {
           let stmts = export_all_externals_rec_ids.iter().copied().flat_map(|idx| {
             let rec = &self.ctx.module.import_records[idx];
+            if rec.meta.contains(ImportRecordMeta::EntryLevelExternal)
+              && !self.ctx.linking_info.module_namespace_real_included
+            {
+              return vec![];
+            }
             // importee_exports
             let importee_namespace_name = self.canonical_name_for(rec.namespace_ref);
             let m = self.ctx.modules.get(rec.resolved_module);

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -1,5 +1,5 @@
 use rolldown_common::{
-  EntryPoint, ExportsKind, ModuleIdx, OutputFormat, PreserveEntrySignatures,
+  EntryPoint, ExportsKind, ImportRecordMeta, ModuleIdx, OutputFormat, PreserveEntrySignatures,
   SharedNormalizedBundlerOptions, StmtInfo, StmtInfoMeta, TaggedSymbolRef, WrapKind,
   dynamic_import_usage::DynamicImportExportsUsage,
 };
@@ -103,7 +103,11 @@ impl LinkStage<'_> {
             match self.options.format {
               OutputFormat::Esm => {
                 meta.star_exports_from_external_modules.iter().copied().for_each(|rec_idx| {
-                  referenced_symbols.push(ecma_module.import_records[rec_idx].namespace_ref.into());
+                  let rec = &ecma_module.import_records[rec_idx];
+                  if rec.meta.contains(ImportRecordMeta::EntryLevelExternal) {
+                    return;
+                  }
+                  referenced_symbols.push(rec.namespace_ref.into());
                   declared_symbols.push(TaggedSymbolRef::Normal(
                     ecma_module.import_records[rec_idx].namespace_ref,
                   ));

--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -46,7 +46,6 @@ impl LinkStage<'_> {
           unsafe { &mut *(addr_of!(importer.depended_runtime_helper).cast_mut()) };
         let importer_side_effect = unsafe { &mut *(addr_of!(importer.side_effects).cast_mut()) };
         let mut symbols_to_be_declared = vec![];
-
         stmt_infos.infos.iter_mut_enumerated().for_each(|(stmt_info_idx, stmt_info)| {
           if stmt_info.meta.contains(StmtInfoMeta::HasDummyRecord) {
             depended_runtime_helper_map[RuntimeHelper::Require.bits().trailing_zeros() as usize]
@@ -125,6 +124,7 @@ impl LinkStage<'_> {
                           if meta.has_dynamic_exports {
                             *importer_side_effect = DeterminedSideEffects::Analyzed(true);
                             stmt_info.side_effect = true.into();
+                            stmt_info.meta.insert(StmtInfoMeta::ReExportDynamicExports);
                             depended_runtime_helper_map
                               [RuntimeHelper::ReExport.bits().trailing_zeros() as usize]
                               .push(stmt_info_idx);
@@ -191,6 +191,7 @@ impl LinkStage<'_> {
                           depended_runtime_helper_map
                             [RuntimeHelper::ReExport.bits().trailing_zeros() as usize]
                             .push(stmt_info_idx);
+                          stmt_info.meta.insert(StmtInfoMeta::ReExportDynamicExports);
                           stmt_info.referenced_symbols.push(importer.namespace_object_ref.into());
                           stmt_info.referenced_symbols.push(importee.namespace_object_ref.into());
                         }

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -69,6 +69,7 @@ pub struct LinkingMetadata {
   /// also need to link the exported facade symbol.
   pub included_commonjs_export_symbol: FxHashSet<SymbolRef>,
   pub depended_runtime_helper: RuntimeHelper,
+  pub module_namespace_real_included: bool,
 }
 
 impl LinkingMetadata {

--- a/crates/rolldown/tests/rolldown/issues/4472/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4472/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "external": ["ext-index", "ext-file", "ext-folder"]
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/4472/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4472/artifacts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+export * from "ext-index"
+
+export * from "ext-file"
+
+export * from "ext-folder"
+
+// HIDDEN [rolldown:runtime]
+//#region file.js
+var file_exports = {};
+__export(file_exports, { file: () => file });
+const file = {};
+
+//#endregion
+//#region folder.js
+var folder_exports = {};
+__export(folder_exports, { folder: () => folder });
+const folder = {};
+
+//#endregion
+//#region main.js
+var main_exports = {};
+__export(main_exports, {
+	file: () => file,
+	folder: () => folder,
+	index: () => index
+});
+const index = {};
+
+//#endregion
+export { file, folder, index };
+```

--- a/crates/rolldown/tests/rolldown/issues/4472/file.js
+++ b/crates/rolldown/tests/rolldown/issues/4472/file.js
@@ -1,0 +1,3 @@
+export * from 'ext-file';
+
+export const file = {};

--- a/crates/rolldown/tests/rolldown/issues/4472/folder.js
+++ b/crates/rolldown/tests/rolldown/issues/4472/folder.js
@@ -1,0 +1,3 @@
+export * from 'ext-folder';
+
+export const folder = {};

--- a/crates/rolldown/tests/rolldown/issues/4472/main.js
+++ b/crates/rolldown/tests/rolldown/issues/4472/main.js
@@ -1,0 +1,6 @@
+export * from 'ext-index';
+
+export * from './file';
+export * from './folder';
+
+export const index = {};

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/_config.json
@@ -7,5 +7,6 @@
       }
     ],
     "external": ["node:fs"]
-  }
+  },
+  "expectExecuted": false
 }

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4767,6 +4767,10 @@ expression: output
 
 - main-!~{000}~.js => main-BidJk8ta.js
 
+# tests/rolldown/issues/4472
+
+- main-!~{000}~.js => main-CcP89K74.js
+
 # tests/rolldown/issues/4491
 
 - main-!~{000}~.js => main-BOUZhfES.js

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -71,6 +71,8 @@ pub struct Chunk {
   pub chunk_reason_type: Box<ChunkReasonType>,
   pub preserve_entry_signature: Option<PreserveEntrySignatures>,
   pub depended_runtime_helper: RuntimeHelper,
+  /// related to [`crate::types::import_record::ImportRecordMeta::EntryLevelExternal`]
+  pub entry_level_external_module_idx: Vec<ModuleIdx>,
 }
 
 impl Chunk {

--- a/crates/rolldown_common/src/types/import_record.rs
+++ b/crates/rolldown_common/src/types/import_record.rs
@@ -53,6 +53,9 @@ bitflags::bitflags! {
     /// Mark namespace of a record could be merged safely
     const SafelyMergeCjsNs = 1 << 9;
     const JsonModule = 1 << 10;
+    /// If a record is a re-export-all from an external module, and that re-export-all chain continues uninterrupted to the entry point,
+    /// we can reuse the original re-export-all declaration instead of generating complex interoperability code.
+    const EntryLevelExternal = 1 << 11;
 
     const TopLevelPureDynamicImport = Self::IsTopLevel.bits() | Self::PureDynamicImport.bits();
   }

--- a/crates/rolldown_common/src/types/stmt_info.rs
+++ b/crates/rolldown_common/src/types/stmt_info.rs
@@ -108,6 +108,7 @@ bitflags! {
         const ClassExpr = 1 << 3;
         /// If this statement needs to reference `__require` runtime
         const HasDummyRecord = 1 << 4;
+        const ReExportDynamicExports = 1 << 5;
         const KeepNamesType = StmtInfoMeta::FnDecl.bits() | StmtInfoMeta::ClassDecl.bits() | StmtInfoMeta::FnExpr.bits() | StmtInfoMeta::ClassExpr.bits();
     }
 }


### PR DESCRIPTION
<img width="1226" height="1279" alt="image" src="https://github.com/user-attachments/assets/479df9d0-fe71-4798-ba21-6fc513a4c0b1" />

Closed #4472


1. Added hoistable entryLevelExternal definition https://github.com/rolldown/rolldown/blob/41f49be7dc5946f7cb584f4b041ecb76dc620527/crates/rolldown_common/src/types/import_record.rs?plain=1#L56-L57
2. Record the module namespace included reason, it is used to rewind in some special scenarios (e.g. the module namespace is only included due to `reexport` ofan  external module)
