### PR TITLE
chore(clippy): allow `case_sensitive_file_extension_comparisons`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ unnecessary_safety_comment = "deny"
 # --- pedantic #https://doc.rust-lang.org/clippy/usage.html#clippypedantic
 # To write the best rust code, pedantic group is enabled by default.
 pedantic = { level = "deny", priority = -1 }
+case_sensitive_file_extension_comparisons = "allow"
 
 # Wizards, naming is too hard.
 module_inception = "allow"

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -344,7 +344,6 @@ impl<'a> ModuleLoader<'a> {
           for ((rec_idx, mut raw_rec), resolved_id) in
             raw_import_records.into_iter_enumerated().zip(resolved_deps)
           {
-            #[allow(clippy::case_sensitive_file_extension_comparisons)]
             if self.options.experimental.vite_mode.unwrap_or_default()
               && resolved_id.id.as_str().ends_with(".json")
             {

--- a/crates/rolldown_plugin_json/src/utils.rs
+++ b/crates/rolldown_plugin_json/src/utils.rs
@@ -8,7 +8,6 @@ use serde_json::Value;
 pub const THRESHOLD_SIZE: usize = 10 * 1000;
 
 /// /\.json(?:$|\?)(?!commonjs-(?:proxy|external))/
-#[allow(clippy::case_sensitive_file_extension_comparisons)]
 pub fn is_json_ext(ext: &str) -> bool {
   if ext.ends_with(".json") {
     return true;

--- a/crates/rolldown_plugin_manifest/src/lib.rs
+++ b/crates/rolldown_plugin_manifest/src/lib.rs
@@ -16,7 +16,6 @@ impl Plugin for ManifestPlugin {
     Cow::Borrowed("builtin:manifest")
   }
 
-  #[allow(clippy::case_sensitive_file_extension_comparisons)]
   async fn generate_bundle(
     &self,
     ctx: &PluginContext,

--- a/crates/rolldown_plugin_manifest/src/utils.rs
+++ b/crates/rolldown_plugin_manifest/src/utils.rs
@@ -96,7 +96,6 @@ impl ManifestPlugin {
   }
 }
 
-#[allow(clippy::case_sensitive_file_extension_comparisons)]
 pub fn is_non_js_file(
   file: &str,
   manifest: &std::collections::BTreeMap<String, std::sync::Arc<ManifestChunk>>,

--- a/crates/rolldown_plugin_utils/src/file_to_url.rs
+++ b/crates/rolldown_plugin_utils/src/file_to_url.rs
@@ -102,7 +102,6 @@ impl FileToUrlEnv<'_> {
     Ok(url)
   }
 
-  #[allow(clippy::case_sensitive_file_extension_comparisons)]
   async fn should_inline(
     &self,
     file: &str,

--- a/crates/rolldown_plugin_wasm_fallback/src/lib.rs
+++ b/crates/rolldown_plugin_wasm_fallback/src/lib.rs
@@ -10,7 +10,6 @@ impl Plugin for WasmFallbackPlugin {
     Cow::Borrowed("builtin:wasm-fallback")
   }
 
-  #[allow(clippy::case_sensitive_file_extension_comparisons)]
   async fn load(&self, _ctx: &PluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
     if args.id.ends_with(".wasm") {
       // TODO: Replace the link here after rolldown's document is ready


### PR DESCRIPTION
This rule has not been very useful, so it is temporarily allowed.