### PR TITLE
feat: pass plugin name to log

### DIFF
--- a/crates/rolldown_binding/src/binding_bundler_impl.rs
+++ b/crates/rolldown_binding/src/binding_bundler_impl.rs
@@ -286,6 +286,7 @@ impl BindingBundlerImpl {
               message: warning
                 .to_diagnostic_with(&DiagnosticOptions { cwd: options.cwd.clone() })
                 .to_color_string(),
+              plugin: None,
             },
           )
           .await;

--- a/crates/rolldown_binding/src/types/binding_log.rs
+++ b/crates/rolldown_binding/src/types/binding_log.rs
@@ -6,10 +6,17 @@ pub struct BindingLog {
   pub id: Option<String>,
   pub code: Option<String>,
   pub exporter: Option<String>,
+  pub plugin: Option<String>,
 }
 
 impl From<rolldown_common::Log> for BindingLog {
   fn from(value: rolldown_common::Log) -> Self {
-    Self { code: value.code, message: value.message, id: value.id, exporter: value.exporter }
+    Self {
+      code: value.code,
+      message: value.message,
+      id: value.id,
+      exporter: value.exporter,
+      plugin: value.plugin,
+    }
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/on_log.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/on_log.rs
@@ -29,4 +29,25 @@ pub struct Log {
   pub id: Option<String>,
   pub code: Option<String>,
   pub exporter: Option<String>,
+  pub plugin: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct LogWithoutPlugin {
+  pub message: String,
+  pub id: Option<String>,
+  pub code: Option<String>,
+  pub exporter: Option<String>,
+}
+
+impl LogWithoutPlugin {
+  pub fn into_log(self, plugin_name: Option<String>) -> Log {
+    Log {
+      message: self.message,
+      id: self.id,
+      code: self.code,
+      exporter: self.exporter,
+      plugin: plugin_name,
+    }
+  }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -46,7 +46,7 @@ pub mod bundler_options {
       minify_options::{MinifyOptions, MinifyOptionsObject, RawMinifyOptions},
       module_type::ModuleType,
       normalized_bundler_options::{NormalizedBundlerOptions, SharedNormalizedBundlerOptions},
-      on_log::{Log, OnLog},
+      on_log::{Log, LogWithoutPlugin, OnLog},
       optimization::{OptimizationOption, normalize_optimization_option},
       output_exports::OutputExports,
       output_format::OutputFormat,

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -7,7 +7,7 @@ mod type_aliases;
 mod types;
 mod utils;
 
-pub use rolldown_common::Log;
+pub use rolldown_common::{Log, LogWithoutPlugin};
 pub use typedmap;
 
 /// Only for usage by the rolldown's crate. Do not use this directly.

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
@@ -5,7 +5,7 @@ use std::{
 
 use arcstr::ArcStr;
 use derive_more::Debug;
-use rolldown_common::{Log, ResolvedId, side_effects::HookSideEffects};
+use rolldown_common::{LogWithoutPlugin, ResolvedId, side_effects::HookSideEffects};
 
 use crate::{
   PluginContextResolveOptions, plugin_context::PluginContextMeta,
@@ -37,6 +37,7 @@ impl PluginContext {
     match self {
       PluginContext::Napi(_) => self.clone(),
       PluginContext::Native(ctx) => Self::Native(Arc::new(NativePluginContextImpl {
+        plugin_name: ctx.plugin_name.clone(),
         skipped_resolve_calls,
         plugin_idx: ctx.plugin_idx,
         plugin_driver: Weak::clone(&ctx.plugin_driver),
@@ -179,7 +180,7 @@ impl PluginContext {
   }
 
   #[inline]
-  pub fn info(&self, log: Log) {
+  pub fn info(&self, log: LogWithoutPlugin) {
     match self {
       PluginContext::Napi(_) => {
         unimplemented!("Can't call `info` on PluginContext::Napi")
@@ -189,7 +190,7 @@ impl PluginContext {
   }
 
   #[inline]
-  pub fn warn(&self, log: Log) {
+  pub fn warn(&self, log: LogWithoutPlugin) {
     match self {
       PluginContext::Napi(_) => {
         unimplemented!("Can't call `warn` on PluginContext::Napi")
@@ -199,7 +200,7 @@ impl PluginContext {
   }
 
   #[inline]
-  pub fn debug(&self, log: Log) {
+  pub fn debug(&self, log: LogWithoutPlugin) {
     match self {
       PluginContext::Napi(_) => {
         unimplemented!("Can't call `debug` on PluginContext::Napi")

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -63,6 +63,7 @@ impl PluginDriver {
         let plugin_idx = index_plugins.push(Arc::clone(&plugin));
         plugin_usage_vec.push(plugin.call_hook_usage());
         index_contexts.push(PluginContext::Native(Arc::new(NativePluginContextImpl {
+          plugin_name: plugin.call_name(),
           skipped_resolve_calls: vec![],
           plugin_idx,
           plugin_driver: Weak::clone(plugin_driver),

--- a/crates/rolldown_plugin_alias/src/lib.rs
+++ b/crates/rolldown_plugin_alias/src/lib.rs
@@ -67,7 +67,12 @@ impl Plugin for AliasPlugin {
           let message = format!(
             "rewrote {importee} to {specifier} but was not an absolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path."
           );
-          ctx.warn(rolldown_plugin::Log { message, code: None, id: None, exporter: None });
+          ctx.warn(rolldown_plugin::LogWithoutPlugin {
+            message,
+            code: None,
+            id: None,
+            exporter: None,
+          });
         }
         HookResolveIdOutput::from_id(specifier)
       }

--- a/crates/rolldown_plugin_utils/src/file_to_url.rs
+++ b/crates/rolldown_plugin_utils/src/file_to_url.rs
@@ -138,7 +138,7 @@ impl FileToUrlEnv<'_> {
 
   fn asset_to_data_url(&self, path: &Path, content: &[u8]) -> anyhow::Result<String> {
     if self.is_lib && content.starts_with(GIT_LFS_PREFIX) {
-      self.ctx.warn(rolldown_plugin::Log {
+      self.ctx.warn(rolldown_plugin::LogWithoutPlugin {
         message: format!("Inlined file {} was not downloaded via Git LFS", path.display()),
         ..Default::default()
       });

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -188,7 +188,7 @@ impl ViteResolvePlugin {
     if let Some(on_warn) = &self.on_warn {
       on_warn(message).await
     } else {
-      ctx.warn(rolldown_common::Log { message, id: None, code: None, exporter: None });
+      ctx.warn(rolldown_common::LogWithoutPlugin { message, id: None, code: None, exporter: None });
       Ok(())
     }
   }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1664,6 +1664,7 @@ export interface BindingLog {
   id?: string
   code?: string
   exporter?: string
+  plugin?: string
 }
 
 export declare enum BindingLogLevel {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/should-not-match/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/should-not-match/_config.ts
@@ -18,6 +18,7 @@ export default defineTest({
       expect(log.message).toContain(
         "Could not resolve 'rolldownlib.js' in main.js",
       )
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },

--- a/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-false/_config.ts
@@ -14,6 +14,7 @@ export default defineTest({
     onLog(level, log) {
       expect(level).toBe('warn')
       expect(log.code).toBe('MISSING_NAME_OPTION_FOR_IIFE_EXPORT')
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },

--- a/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-true/_config.ts
@@ -14,6 +14,7 @@ export default defineTest({
     onLog(level, log) {
       expect(level).toBe('warn')
       expect(log.code).toBe('MISSING_NAME_OPTION_FOR_IIFE_EXPORT')
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },

--- a/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
@@ -19,6 +19,7 @@ export default defineTest({
       expect(log.message).toContain(
         'cycle loading at test-plugin-context plugin',
       )
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },

--- a/packages/rolldown/tests/fixtures/plugin/output-plugins/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/output-plugins/_config.ts
@@ -27,6 +27,7 @@ export default defineTest({
     onLog(level, log) {
       expect(level).toBe('warn')
       expect(log.code).toBe('INPUT_HOOK_IN_OUTPUT_PLUGIN')
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },

--- a/packages/rolldown/tests/fixtures/tree-shake/unused-external-import-stmt/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/unused-external-import-stmt/_config.ts
@@ -16,6 +16,7 @@ export default defineTest({
       expect(log.message).toContain(
         "Could not resolve 'unused-external-module' in main.js",
       )
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },


### PR DESCRIPTION
Add `plugin` field to `Log`. It is assigned by PluginContext. The `plugin` field is passed to the JS side as `plugin` property.