### PR TITLE
feat: include plugin name in the message of UNHANDLEABLE_ERRORs that happened in plugins

### DIFF
--- a/crates/rolldown_binding/src/binding_bundler_impl.rs
+++ b/crates/rolldown_binding/src/binding_bundler_impl.rs
@@ -286,6 +286,7 @@ impl BindingBundlerImpl {
               message: warning
                 .to_diagnostic_with(&DiagnosticOptions { cwd: options.cwd.clone() })
                 .to_color_string(),
+              plugin: None,
             },
           )
           .await;

--- a/crates/rolldown_binding/src/types/binding_log.rs
+++ b/crates/rolldown_binding/src/types/binding_log.rs
@@ -6,10 +6,17 @@ pub struct BindingLog {
   pub id: Option<String>,
   pub code: Option<String>,
   pub exporter: Option<String>,
+  pub plugin: Option<String>,
 }
 
 impl From<rolldown_common::Log> for BindingLog {
   fn from(value: rolldown_common::Log) -> Self {
-    Self { code: value.code, message: value.message, id: value.id, exporter: value.exporter }
+    Self {
+      code: value.code,
+      message: value.message,
+      id: value.id,
+      exporter: value.exporter,
+      plugin: value.plugin,
+    }
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/on_log.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/on_log.rs
@@ -29,4 +29,25 @@ pub struct Log {
   pub id: Option<String>,
   pub code: Option<String>,
   pub exporter: Option<String>,
+  pub plugin: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct LogWithoutPlugin {
+  pub message: String,
+  pub id: Option<String>,
+  pub code: Option<String>,
+  pub exporter: Option<String>,
+}
+
+impl LogWithoutPlugin {
+  pub fn into_log(self, plugin_name: Option<String>) -> Log {
+    Log {
+      message: self.message,
+      id: self.id,
+      code: self.code,
+      exporter: self.exporter,
+      plugin: plugin_name,
+    }
+  }
 }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -46,7 +46,7 @@ pub mod bundler_options {
       minify_options::{MinifyOptions, MinifyOptionsObject, RawMinifyOptions},
       module_type::ModuleType,
       normalized_bundler_options::{NormalizedBundlerOptions, SharedNormalizedBundlerOptions},
-      on_log::{Log, OnLog},
+      on_log::{Log, LogWithoutPlugin, OnLog},
       optimization::{OptimizationOption, normalize_optimization_option},
       output_exports::OutputExports,
       output_format::OutputFormat,

--- a/crates/rolldown_error/src/events/unhandleable_error.rs
+++ b/crates/rolldown_error/src/events/unhandleable_error.rs
@@ -1,3 +1,5 @@
+use std::{borrow::Cow, fmt::Display};
+
 use crate::{DiagnosticOptions, EventKind};
 
 use super::BuildEvent;
@@ -19,9 +21,34 @@ impl BuildEvent for UnhandleableError {
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {
+    if let Some(inner_err) = self.0.downcast_ref::<CausedPlugin>() {
+      let source = self.0.source().expect("Error with CausedPlugin should have a source");
+      return format!(
+        "Something went wrong inside native plugin `{}`. Please report this problem at https://github.com/rolldown/rolldown/issues.\n{}",
+        inner_err.plugin, source
+      );
+    }
+
     format!(
       "Something went wrong inside rolldown, please report this problem at https://github.com/rolldown/rolldown/issues.\n{}",
       self.0
     )
+  }
+}
+
+#[derive(Debug)]
+pub struct CausedPlugin {
+  pub plugin: Cow<'static, str>,
+}
+
+impl CausedPlugin {
+  pub fn new(plugin: Cow<'static, str>) -> Self {
+    Self { plugin }
+  }
+}
+
+impl Display for CausedPlugin {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "caused by plugin `{}`", self.plugin)
   }
 }

--- a/crates/rolldown_error/src/lib.rs
+++ b/crates/rolldown_error/src/lib.rs
@@ -17,6 +17,7 @@ pub use crate::{
   events::ambiguous_external_namespace::AmbiguousExternalNamespaceModule,
   events::commonjs_variable_in_esm::CjsExportSpan,
   events::invalid_option::InvalidOptionType,
+  events::unhandleable_error::CausedPlugin,
   events::unloadable_dependency::UnloadableDependencyContext,
   generated::event_kind_switcher::EventKindSwitcher,
   locator::line_column_to_byte_offset,

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -7,7 +7,7 @@ mod type_aliases;
 mod types;
 mod utils;
 
-pub use rolldown_common::Log;
+pub use rolldown_common::{Log, LogWithoutPlugin};
 pub use typedmap;
 
 /// Only for usage by the rolldown's crate. Do not use this directly.

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
@@ -5,7 +5,7 @@ use std::{
 
 use arcstr::ArcStr;
 use derive_more::Debug;
-use rolldown_common::{Log, ResolvedId, side_effects::HookSideEffects};
+use rolldown_common::{LogWithoutPlugin, ResolvedId, side_effects::HookSideEffects};
 
 use crate::{
   PluginContextResolveOptions, plugin_context::PluginContextMeta,
@@ -37,6 +37,7 @@ impl PluginContext {
     match self {
       PluginContext::Napi(_) => self.clone(),
       PluginContext::Native(ctx) => Self::Native(Arc::new(NativePluginContextImpl {
+        plugin_name: ctx.plugin_name.clone(),
         skipped_resolve_calls,
         plugin_idx: ctx.plugin_idx,
         plugin_driver: Weak::clone(&ctx.plugin_driver),
@@ -179,7 +180,7 @@ impl PluginContext {
   }
 
   #[inline]
-  pub fn info(&self, log: Log) {
+  pub fn info(&self, log: LogWithoutPlugin) {
     match self {
       PluginContext::Napi(_) => {
         unimplemented!("Can't call `info` on PluginContext::Napi")
@@ -189,7 +190,7 @@ impl PluginContext {
   }
 
   #[inline]
-  pub fn warn(&self, log: Log) {
+  pub fn warn(&self, log: LogWithoutPlugin) {
     match self {
       PluginContext::Napi(_) => {
         unimplemented!("Can't call `warn` on PluginContext::Napi")
@@ -199,7 +200,7 @@ impl PluginContext {
   }
 
   #[inline]
-  pub fn debug(&self, log: Log) {
+  pub fn debug(&self, log: LogWithoutPlugin) {
     match self {
       PluginContext::Napi(_) => {
         unimplemented!("Can't call `debug` on PluginContext::Napi")

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -63,6 +63,7 @@ impl PluginDriver {
         let plugin_idx = index_plugins.push(Arc::clone(&plugin));
         plugin_usage_vec.push(plugin.call_hook_usage());
         index_contexts.push(PluginContext::Native(Arc::new(NativePluginContextImpl {
+          plugin_name: plugin.call_name(),
           skipped_resolve_calls: vec![],
           plugin_idx,
           plugin_driver: Weak::clone(plugin_driver),

--- a/crates/rolldown_plugin/src/plugin_driver/watch_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/watch_hooks.rs
@@ -1,12 +1,17 @@
 use crate::HookNoopReturn;
 use crate::PluginDriver;
+use anyhow::Context;
 use rolldown_common::WatcherChangeKind;
+use rolldown_error::CausedPlugin;
 
 impl PluginDriver {
   pub async fn watch_change(&self, path: &str, event: WatcherChangeKind) -> HookNoopReturn {
     for (_, plugin, ctx) in self.iter_plugin_with_context_by_order(&self.order_by_watch_change_meta)
     {
-      plugin.call_watch_change(ctx, path, event).await?;
+      plugin
+        .call_watch_change(ctx, path, event)
+        .await
+        .with_context(|| CausedPlugin::new(plugin.call_name()))?;
     }
     Ok(())
   }
@@ -15,7 +20,10 @@ impl PluginDriver {
     for (_, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_close_watcher_meta)
     {
-      plugin.call_close_watcher(ctx).await?;
+      plugin
+        .call_close_watcher(ctx)
+        .await
+        .with_context(|| CausedPlugin::new(plugin.call_name()))?;
     }
     Ok(())
   }

--- a/crates/rolldown_plugin_alias/src/lib.rs
+++ b/crates/rolldown_plugin_alias/src/lib.rs
@@ -67,7 +67,12 @@ impl Plugin for AliasPlugin {
           let message = format!(
             "rewrote {importee} to {specifier} but was not an absolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path."
           );
-          ctx.warn(rolldown_plugin::Log { message, code: None, id: None, exporter: None });
+          ctx.warn(rolldown_plugin::LogWithoutPlugin {
+            message,
+            code: None,
+            id: None,
+            exporter: None,
+          });
         }
         HookResolveIdOutput::from_id(specifier)
       }

--- a/crates/rolldown_plugin_utils/src/file_to_url.rs
+++ b/crates/rolldown_plugin_utils/src/file_to_url.rs
@@ -138,7 +138,7 @@ impl FileToUrlEnv<'_> {
 
   fn asset_to_data_url(&self, path: &Path, content: &[u8]) -> anyhow::Result<String> {
     if self.is_lib && content.starts_with(GIT_LFS_PREFIX) {
-      self.ctx.warn(rolldown_plugin::Log {
+      self.ctx.warn(rolldown_plugin::LogWithoutPlugin {
         message: format!("Inlined file {} was not downloaded via Git LFS", path.display()),
         ..Default::default()
       });

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -188,7 +188,7 @@ impl ViteResolvePlugin {
     if let Some(on_warn) = &self.on_warn {
       on_warn(message).await
     } else {
-      ctx.warn(rolldown_common::Log { message, id: None, code: None, exporter: None });
+      ctx.warn(rolldown_common::LogWithoutPlugin { message, id: None, code: None, exporter: None });
       Ok(())
     }
   }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1664,6 +1664,7 @@ export interface BindingLog {
   id?: string
   code?: string
   exporter?: string
+  plugin?: string
 }
 
 export declare enum BindingLogLevel {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/alias/should-not-match/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/alias/should-not-match/_config.ts
@@ -18,6 +18,7 @@ export default defineTest({
       expect(log.message).toContain(
         "Could not resolve 'rolldownlib.js' in main.js",
       )
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },

--- a/packages/rolldown/tests/fixtures/builtin-plugin/isolated-declaration/error/main.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/isolated-declaration/error/main.ts.snap
@@ -1,6 +1,6 @@
 Error: Build failed with 1 error:
 
-[UNHANDLEABLE_ERROR] Error: Something went wrong inside rolldown, please report this problem at https://github.com/rolldown/rolldown/issues.
+[UNHANDLEABLE_ERROR] Error: Something went wrong inside native plugin `builtin:isolated-declaration`. Please report this problem at https://github.com/rolldown/rolldown/issues.
 
 [builtin:isolated-declaration] Error: TS9007: Function must have an explicit return type annotation with --isolatedDeclarations.
    ╭─[ main.ts:3:17 ]

--- a/packages/rolldown/tests/fixtures/builtin-plugin/transform/main.js.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/transform/main.js.snap
@@ -1,6 +1,6 @@
 Error: Build failed with 1 error:
 
-[UNHANDLEABLE_ERROR] Error: Something went wrong inside rolldown, please report this problem at https://github.com/rolldown/rolldown/issues.
+[UNHANDLEABLE_ERROR] Error: Something went wrong inside native plugin `builtin:transform`. Please report this problem at https://github.com/rolldown/rolldown/issues.
 
 [builtin:transform] Error: Namespace tags are not supported by default. React's JSX doesn't support namespace tags. You can set `throwIfNamespace: false` to bypass this warning.
    ╭─[ jsx.abc:1:19 ]

--- a/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-false/_config.ts
@@ -14,6 +14,7 @@ export default defineTest({
     onLog(level, log) {
       expect(level).toBe('warn')
       expect(log.code).toBe('MISSING_NAME_OPTION_FOR_IIFE_EXPORT')
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },

--- a/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-true/_config.ts
@@ -14,6 +14,7 @@ export default defineTest({
     onLog(level, log) {
       expect(level).toBe('warn')
       expect(log.code).toBe('MISSING_NAME_OPTION_FOR_IIFE_EXPORT')
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },

--- a/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/cycle-load-error/_config.ts
@@ -19,6 +19,7 @@ export default defineTest({
       expect(log.message).toContain(
         'cycle loading at test-plugin-context plugin',
       )
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },

--- a/packages/rolldown/tests/fixtures/plugin/output-plugins/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/output-plugins/_config.ts
@@ -27,6 +27,7 @@ export default defineTest({
     onLog(level, log) {
       expect(level).toBe('warn')
       expect(log.code).toBe('INPUT_HOOK_IN_OUTPUT_PLUGIN')
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },

--- a/packages/rolldown/tests/fixtures/tree-shake/unused-external-import-stmt/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/unused-external-import-stmt/_config.ts
@@ -16,6 +16,7 @@ export default defineTest({
       expect(log.message).toContain(
         "Could not resolve 'unused-external-module' in main.js",
       )
+      expect(log.plugin).toBeUndefined()
       onLogFn()
     },
   },


### PR DESCRIPTION
Added the plugin name to the error message.

**before**
```
[UNHANDLEABLE_ERROR] Error: Something went wrong inside rolldown, please report this problem at https://github.com/rolldown/rolldown/issues.
test error
```
**after**
```
[UNHANDLEABLE_ERROR] Error: Something went wrong inside native plugin `rolldown:vite-resolve`. Please report this problem at https://github.com/rolldown/rolldown/issues.
test error
```

