### PR TITLE
fix(rolldown_test): refine injection logic

### DIFF
--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -717,7 +717,7 @@ setTimeout(async () => {{
       break;
     }}
   }}
-}}, 10);
+}}, 100);
       ",
         dist_folder.to_str().unwrap().replace('\\', "\\\\") // escape backslashes in Windows paths
       ));

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -706,32 +706,20 @@ import url from 'node:url';
 import path from 'node:path';
 
 const dir = '{}';
-let pollCount = 0;
-const maxPoll = 10;
-const pollInterval = 50;
-
-function tryRunPatches() {{
-  if (typeof globalThis.__rolldown_runtime__ !== 'undefined' || pollCount >= maxPoll) {{
-    clearInterval(timer);
-    (async () => {{
-      for (const patchChunk of globalThis.__testPatches) {{
-        const file = path.join(dir, patchChunk);
-        try {{
-          await import(url.pathToFileURL(file));
-        }} catch (error) {{
-          console.error('Error executing a patch:', error);
-          process.exitCode = 1;
-          break;
-        }}
-      }}
-    }})();
+setTimeout(async () => {{
+  for (const patchChunk of globalThis.__testPatches) {{
+    const file = path.join(dir, patchChunk);
+    try {{
+      await import(url.pathToFileURL(file));
+    }} catch (error) {{
+      console.error('Error executing a patch:', error);
+      process.exitCode = 1;
+      break;
+    }}
   }}
-  pollCount++;
-}}
-
-const timer = setInterval(tryRunPatches, pollInterval);
-  ",
-        dist_folder.to_str().unwrap().replace('\\', "\\\\")
+}}, 10);
+      ",
+        dist_folder.to_str().unwrap().replace('\\', "\\\\") // escape backslashes in Windows paths
       ));
     }
 

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -706,20 +706,32 @@ import url from 'node:url';
 import path from 'node:path';
 
 const dir = '{}';
-setTimeout(async () => {{
-  for (const patchChunk of globalThis.__testPatches) {{
-    const file = path.join(dir, patchChunk);
-    try {{
-      await import(url.pathToFileURL(file));
-    }} catch (error) {{
-      console.error('Error executing a patch:', error);
-      process.exitCode = 1;
-      break;
-    }}
+let pollCount = 0;
+const maxPoll = 10;
+const pollInterval = 50;
+
+function tryRunPatches() {{
+  if (typeof globalThis.__rolldown_runtime__ !== 'undefined' || pollCount >= maxPoll) {{
+    clearInterval(timer);
+    (async () => {{
+      for (const patchChunk of globalThis.__testPatches) {{
+        const file = path.join(dir, patchChunk);
+        try {{
+          await import(url.pathToFileURL(file));
+        }} catch (error) {{
+          console.error('Error executing a patch:', error);
+          process.exitCode = 1;
+          break;
+        }}
+      }}
+    }})();
   }}
-}}, 10);
-      ",
-        dist_folder.to_str().unwrap().replace('\\', "\\\\") // escape backslashes in Windows paths
+  pollCount++;
+}}
+
+const timer = setInterval(tryRunPatches, pollInterval);
+  ",
+        dist_folder.to_str().unwrap().replace('\\', "\\\\")
       ));
     }
 


### PR DESCRIPTION
Injection should poll for `__rolldown_runtime__` before acutally running test. Otherwise, an error will occur in my Linux x64 machine.

```shell
failures:

---- fixture_with_config_tests__rolldown__topics__hmr__dynamic_import__config_json stdout ----
Input: /home/situ/Codes/rolldown/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/_config.json
⬇️⬇️ Failed to execute command  ⬇️⬇️
"node" "--import" "data:text/javascript,globalThis.__testPatches%20%3D%20%5B%22.%2F1754486755140.js%22%5D%3B%0Aimport%20url%20from%20%27node%3Aurl%27%3B%0Aimport%20path%20from%20%27node%3Apath%27%3B%0A%0Aconst%20dir%20%3D%20%27%2Fhome%2Fsitu%2FCodes%2Frolldown%2Fcrates%2Frolldown%2Ftests%2Frolldown%2Ftopics%2Fhmr%2Fdynamic_import%2Fhmr-temp%2Fdist%27%3B%0AsetTimeout%28async%20%28%29%20%3D%3E%20%7B%0A%20%20for%20%28const%20patchChunk%20of%20globalThis.__testPatches%29%20%7B%0A%20%20%20%20const%20file%20%3D%20path.join%28dir%2C%20patchChunk%29%3B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20await%20import%28url.pathToFileURL%28file%29%29%3B%0A%20%20%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20%20%20console.error%28%27Error%20executing%20a%20patch%3A%27%2C%20error%29%3B%0A%20%20%20%20%20%20process.exitCode%20%3D%201%3B%0A%20%20%20%20%20%20break%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%2C%2010%29%3B%0A%20%20%20%20%20%20" "--import" "/home/situ/Codes/rolldown/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/hmr-temp/dist/main.js" "--eval" "\"\"" "--input-type=module"
⬆️⬆️ end  ⬆️⬆️

thread 'fixture_with_config_tests__rolldown__topics__hmr__dynamic_import__config_json' panicked at crates/rolldown_testing/src/integration_test.rs:678:7:
⬇️⬇️ stderr  ⬇️⬇️
Error executing a patch: ReferenceError: __rolldown_runtime__ is not defined
    at file:///home/situ/Codes/rolldown/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/hmr-temp/dist/1754486755140.js:2:31
    at ModuleJob.run (node:internal/modules/esm/module_job:271:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:578:26)
    at async Timeout._onTimeout (data:text/javascript,globalThis.__testPatches%20%3D%20%5B%22.%2F1754486755140.js%22%5D%3B%0Aimport%20url%20from%20%27node%3Aurl%27%3B%0Aimport%20path%20from%20%27node%3Apath%27%3B%0A%0Aconst%20dir%20%3D%20%27%2Fhome%2Fsitu%2FCodes%2Frolldown%2Fcrates%2Frolldown%2Ftests%2Frolldown%2Ftopics%2Fhmr%2Fdynamic_import%2Fhmr-temp%2Fdist%27%3B%0AsetTimeout%28async%20%28%29%20%3D%3E%20%7B%0A%20%20for%20%28const%20patchChunk%20of%20globalThis.__testPatches%29%20%7B%0A%20%20%20%20const%20file%20%3D%20path.join%28dir%2C%20patchChunk%29%3B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20await%20import%28url.pathToFileURL%28file%29%29%3B%0A%20%20%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20%20%20console.error%28%27Error%20executing%20a%20patch%3A%27%2C%20error%29%3B%0A%20%20%20%20%20%20process.exitCode%20%3D%201%3B%0A%20%20%20%20%20%20break%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%2C%2010%29%3B%0A%20%20%20%20%20%20:10:7)

⬇️⬇️ stdout ⬇️⬇️

⬆️⬆️ end  ⬆️⬆️
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- fixture_with_config_tests__rolldown__topics__hmr__generate_patch_error__config_json stdout ----
Input: /home/situ/Codes/rolldown/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/_config.json
⬇️⬇️ Failed to execute command  ⬇️⬇️
"node" "--import" "data:text/javascript,globalThis.__testPatches%20%3D%20%5B%22.%2F1754486755153.js%22%5D%3B%0Aimport%20url%20from%20%27node%3Aurl%27%3B%0Aimport%20path%20from%20%27node%3Apath%27%3B%0A%0Aconst%20dir%20%3D%20%27%2Fhome%2Fsitu%2FCodes%2Frolldown%2Fcrates%2Frolldown%2Ftests%2Frolldown%2Ftopics%2Fhmr%2Fgenerate_patch_error%2Fhmr-temp%2Fdist%27%3B%0AsetTimeout%28async%20%28%29%20%3D%3E%20%7B%0A%20%20for%20%28const%20patchChunk%20of%20globalThis.__testPatches%29%20%7B%0A%20%20%20%20const%20file%20%3D%20path.join%28dir%2C%20patchChunk%29%3B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20await%20import%28url.pathToFileURL%28file%29%29%3B%0A%20%20%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20%20%20console.error%28%27Error%20executing%20a%20patch%3A%27%2C%20error%29%3B%0A%20%20%20%20%20%20process.exitCode%20%3D%201%3B%0A%20%20%20%20%20%20break%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%2C%2010%29%3B%0A%20%20%20%20%20%20" "--import" "/home/situ/Codes/rolldown/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/hmr-temp/dist/main.js" "--eval" "\"\"" "--input-type=module"
⬆️⬆️ end  ⬆️⬆️

thread 'fixture_with_config_tests__rolldown__topics__hmr__generate_patch_error__config_json' panicked at crates/rolldown_testing/src/integration_test.rs:678:7:
⬇️⬇️ stderr  ⬇️⬇️
Error executing a patch: ReferenceError: __rolldown_runtime__ is not defined
    at file:///home/situ/Codes/rolldown/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/hmr-temp/dist/1754486755153.js:2:18
    at ModuleJob.run (node:internal/modules/esm/module_job:271:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:578:26)
    at async Timeout._onTimeout (data:text/javascript,globalThis.__testPatches%20%3D%20%5B%22.%2F1754486755153.js%22%5D%3B%0Aimport%20url%20from%20%27node%3Aurl%27%3B%0Aimport%20path%20from%20%27node%3Apath%27%3B%0A%0Aconst%20dir%20%3D%20%27%2Fhome%2Fsitu%2FCodes%2Frolldown%2Fcrates%2Frolldown%2Ftests%2Frolldown%2Ftopics%2Fhmr%2Fgenerate_patch_error%2Fhmr-temp%2Fdist%27%3B%0AsetTimeout%28async%20%28%29%20%3D%3E%20%7B%0A%20%20for%20%28const%20patchChunk%20of%20globalThis.__testPatches%29%20%7B%0A%20%20%20%20const%20file%20%3D%20path.join%28dir%2C%20patchChunk%29%3B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20await%20import%28url.pathToFileURL%28file%29%29%3B%0A%20%20%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20%20%20console.error%28%27Error%20executing%20a%20patch%3A%27%2C%20error%29%3B%0A%20%20%20%20%20%20process.exitCode%20%3D%201%3B%0A%20%20%20%20%20%20break%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%2C%2010%29%3B%0A%20%20%20%20%20%20:10:7)

⬇️⬇️ stdout ⬇️⬇️
.hmr hello
.app hello

⬆️⬆️ end  ⬆️⬆️


failures:
    fixture_with_config_tests__rolldown__topics__hmr__dynamic_import__config_json
    fixture_with_config_tests__rolldown__topics__hmr__generate_patch_error__config_json

test result: FAILED. 532 passed; 2 failed; 4 ignored; 0 measured; 0 filtered out; finished in 28.07s
```