### PR TITLE
fix(hmr): rewrite `this` to `exports` for cjs modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2614,6 +2614,7 @@ dependencies = [
  "oxc",
  "oxc_ecmascript",
  "oxc_index",
+ "oxc_traverse",
  "petgraph",
  "rolldown_common",
  "rolldown_debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,7 @@ oxc = { version = "0.80.0", features = ["ast_visit", "transformer", "minifier", 
 oxc_ecmascript = { version = "0.80.0" }
 oxc_parser_napi = { version = "0.80.0" }
 oxc_transform_napi = { version = "0.80.0" }
+oxc_traverse = { version = "0.80.0" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -35,6 +35,7 @@ notify = { workspace = true }
 oxc = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }
+oxc_traverse = { workspace = true }
 petgraph = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_debug = { workspace = true }

--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -6,6 +6,7 @@ use std::{
 
 use arcstr::ArcStr;
 use oxc::ast_visit::VisitMut;
+use oxc_traverse::traverse_mut;
 use rolldown_common::{
   EcmaModuleAstUsage, HmrBoundary, HmrBoundaryOutput, HmrPatch, HmrUpdate, Module, ModuleIdx,
   ModuleTable,
@@ -364,6 +365,7 @@ impl HmrManager {
 
         ast.program.with_mut(|fields| {
           let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
+
           let mut finalizer = HmrAstFinalizer {
             modules,
             alloc: fields.allocator,
@@ -384,6 +386,11 @@ impl HmrManager {
             named_exports: FxHashMap::default(),
           };
 
+          let scoping = EcmaAst::make_semantic(fields.program, /*with_cfg*/ false).into_scoping();
+
+          traverse_mut(&mut finalizer, fields.allocator, fields.program, scoping, ());
+
+          // TODO: hyf0 removes `VisitMut`, uses `Traverse` instead.
           finalizer.visit_program(fields.program);
         });
 

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -1,0 +1,39 @@
+use oxc::ast::ast;
+use oxc_traverse::Traverse;
+use rolldown_ecmascript_utils::quote_expr;
+
+use crate::hmr::hmr_ast_finalizer::HmrAstFinalizer;
+
+impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
+  fn exit_expression(
+    &mut self,
+    node: &mut oxc::ast::ast::Expression<'ast>,
+    ctx: &mut oxc_traverse::TraverseCtx<'ast, ()>,
+  ) {
+    if ctx.is_current_scope_valid_for_tla() && matches!(node, ast::Expression::ThisExpression(_)) {
+      // Rewrite this to `undefined` or `exports`
+      if self.module.exports_kind.is_commonjs() {
+        // Rewrite this to `exports`
+        *node = quote_expr(self.alloc, "exports");
+      } else {
+        // Rewrite this to `undefined`
+        *node = quote_expr(self.alloc, "void 0");
+      }
+    }
+  }
+}
+
+trait TraverseCtxExt<'ast> {
+  fn is_current_scope_valid_for_tla(&self) -> bool;
+}
+
+impl<'ast> TraverseCtxExt<'ast> for oxc_traverse::TraverseCtx<'ast, ()> {
+  fn is_current_scope_valid_for_tla(&self) -> bool {
+    // self.scope_stack.iter().rev().all(|flag| flag.is_block() || flag.is_top())
+    let scoping = self.scoping();
+    scoping
+      .scope_ancestors(self.current_scope_id())
+      .map(|scope_id| scoping.scope_flags(scope_id))
+      .all(|scope_flags| scope_flags.is_block() || scope_flags.is_top())
+  }
+}

--- a/crates/rolldown/src/hmr/mod.rs
+++ b/crates/rolldown/src/hmr/mod.rs
@@ -1,3 +1,4 @@
 pub mod hmr_ast_finalizer;
 pub mod hmr_manager;
+pub mod impl_traverse_for_hmr_ast_finalizer;
 pub mod utils;

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -10,10 +10,10 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
-//#region cases/require/cjs-lib.js
-var require_cjs_lib = /* @__PURE__ */ __commonJS({ "cases/require/cjs-lib.js": ((exports, module) => {
-	const cjs_lib_hot = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib.js");
-	__rolldown_runtime__.registerModule("cases/require/cjs-lib.js", module);
+//#region cases/require/cjs-lib-reassign-module-exports.js
+var require_cjs_lib_reassign_module_exports = /* @__PURE__ */ __commonJS({ "cases/require/cjs-lib-reassign-module-exports.js": ((exports, module) => {
+	const cjs_lib_reassign_module_exports_hot = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib-reassign-module-exports.js");
+	__rolldown_runtime__.registerModule("cases/require/cjs-lib-reassign-module-exports.js", module);
 	module.exports = function() {
 		return "exports";
 	};
@@ -21,13 +21,32 @@ var require_cjs_lib = /* @__PURE__ */ __commonJS({ "cases/require/cjs-lib.js": (
 }) });
 
 //#endregion
+//#region cases/require/cjs-lib.js
+var require_cjs_lib = /* @__PURE__ */ __commonJS({ "cases/require/cjs-lib.js": ((exports, module) => {
+	const cjs_lib_hot = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib.js");
+	__rolldown_runtime__.registerModule("cases/require/cjs-lib.js", module);
+	exports.foo = "foo";
+	exports.bar = "bar";
+	var Noop = class {
+		static {
+			this.baz = "bar";
+		}
+	};
+	console.log(Noop);
+}) });
+
+//#endregion
 //#region cases/require/index.js
 var require_exports = {};
 const require_hot = __rolldown_runtime__.createModuleHotContext("cases/require/index.js");
 __rolldown_runtime__.registerModule("cases/require/index.js", { exports: require_exports });
-const requiredCjsLib = require_cjs_lib();
-assert.strictEqual(requiredCjsLib(), "exports");
-assert.strictEqual(requiredCjsLib.foo, "foo");
+const requiredCjsLibReassignModuleExports = require_cjs_lib_reassign_module_exports();
+assert.strictEqual(requiredCjsLibReassignModuleExports(), "exports");
+assert.strictEqual(requiredCjsLibReassignModuleExports.foo, "foo");
+const requireCjsLib = require_cjs_lib();
+assert.strictEqual(requireCjsLib.foo, "foo");
+assert.strictEqual(requireCjsLib.bar, "bar");
+assert.strictEqual(requireCjsLib.baz, undefined);
 
 //#endregion
 //#region cases/manual_reexport/lib.js
@@ -123,11 +142,11 @@ var init_lib_2 = __rolldown_runtime__.createEsmInitializer((function() {
 }));
 
 //#endregion
-//#region cases/require/cjs-lib.js
-var require_cjs_lib_3 = __rolldown_runtime__.createCjsInitializer((function(exports, module) {
+//#region cases/require/cjs-lib-reassign-module-exports.js
+var require_cjs_lib_reassign_module_exports_3 = __rolldown_runtime__.createCjsInitializer((function(exports, module) {
 	try {
-		__rolldown_runtime__.registerModule("cases/require/cjs-lib.js", module);
-		const hot_cjs_lib = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib.js");
+		__rolldown_runtime__.registerModule("cases/require/cjs-lib-reassign-module-exports.js", module);
+		const hot_cjs_lib_reassign_module_exports = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib-reassign-module-exports.js");
 		module.exports = function() {
 			return "exports";
 		};
@@ -136,32 +155,53 @@ var require_cjs_lib_3 = __rolldown_runtime__.createCjsInitializer((function(expo
 }));
 
 //#endregion
+//#region cases/require/cjs-lib.js
+var require_cjs_lib_4 = __rolldown_runtime__.createCjsInitializer((function(exports, module) {
+	try {
+		__rolldown_runtime__.registerModule("cases/require/cjs-lib.js", module);
+		const hot_cjs_lib = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib.js");
+		exports.foo = "foo";
+		exports.bar = "bar";
+		class Noop {
+			static {
+				this.baz = "bar";
+			}
+		}
+		console.log(Noop);
+	} finally {}
+}));
+
+//#endregion
 //#region cases/require/index.js
-import * as import_node_assert_4 from "node:assert";
-var init_require_4 = __rolldown_runtime__.createEsmInitializer((function() {
+import * as import_node_assert_5 from "node:assert";
+var init_require_5 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = {};
 		__rolldown_runtime__.__export(__rolldown_exports__, {});
 		__rolldown_runtime__.registerModule("cases/require/index.js", { exports: __rolldown_exports__ });
 		const hot_require = __rolldown_runtime__.createModuleHotContext("cases/require/index.js");
-		const requiredCjsLib = (require_cjs_lib_3(), __rolldown_runtime__.loadExports("cases/require/cjs-lib.js"));
-		import_node_assert_4.default.strictEqual(requiredCjsLib(), "exports");
-		import_node_assert_4.default.strictEqual(requiredCjsLib.foo, "foo");
+		const requiredCjsLibReassignModuleExports = (require_cjs_lib_reassign_module_exports_3(), __rolldown_runtime__.loadExports("cases/require/cjs-lib-reassign-module-exports.js"));
+		import_node_assert_5.default.strictEqual(requiredCjsLibReassignModuleExports(), "exports");
+		import_node_assert_5.default.strictEqual(requiredCjsLibReassignModuleExports.foo, "foo");
+		const requireCjsLib = (require_cjs_lib_4(), __rolldown_runtime__.loadExports("cases/require/cjs-lib.js"));
+		import_node_assert_5.default.strictEqual(requireCjsLib.foo, "foo");
+		import_node_assert_5.default.strictEqual(requireCjsLib.bar, "bar");
+		import_node_assert_5.default.strictEqual(requireCjsLib.baz, undefined);
 	} finally {}
 }));
 
 //#endregion
 //#region main.js
-var init_main_5 = __rolldown_runtime__.createEsmInitializer((function() {
+var init_main_6 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = {};
 		__rolldown_runtime__.__export(__rolldown_exports__, {});
 		__rolldown_runtime__.registerModule("main.js", { exports: __rolldown_exports__ });
-		init_require_4();
+		init_require_5();
 		init_manual_reexport_1();
 		const hot_main = __rolldown_runtime__.createModuleHotContext("main.js");
-		var import_require_5 = __rolldown_runtime__.loadExports("cases/require/index.js");
-		var import_manual_reexport_5 = __rolldown_runtime__.loadExports("cases/manual_reexport/index.js");
+		var import_require_6 = __rolldown_runtime__.loadExports("cases/require/index.js");
+		var import_manual_reexport_6 = __rolldown_runtime__.loadExports("cases/manual_reexport/index.js");
 		if (hot_main) {
 			hot_main.accept();
 		}
@@ -171,7 +211,7 @@ var init_main_5 = __rolldown_runtime__.createEsmInitializer((function() {
 //#endregion
 // HIDDEN [rolldown:hmr]
 // HIDDEN [rolldown:runtime]
-init_main_5()
+init_main_6()
 __rolldown_runtime__.applyUpdates(['main.js']);
 ```
 ## Meta

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/cases/require/cjs-lib-reassign-module-exports.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/cases/require/cjs-lib-reassign-module-exports.js
@@ -1,0 +1,5 @@
+module.exports = function () {
+  return 'exports'
+}
+module.exports.foo = 'foo'
+

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/cases/require/cjs-lib.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/cases/require/cjs-lib.js
@@ -1,4 +1,10 @@
-module.exports = function () {
-  return 'exports'
+exports.foo  = 'foo'
+this.bar = 'bar'
+
+class Noop {
+  static {
+    this.baz = 'bar'
+  }
 }
-module.exports.foo = 'foo'
+
+console.log(Noop)

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/cases/require/index.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/cases/require/index.js
@@ -1,5 +1,11 @@
 import assert from 'node:assert'
 
-const requiredCjsLib = require('./cjs-lib')
-assert.strictEqual(requiredCjsLib(), 'exports')
-assert.strictEqual(requiredCjsLib.foo, 'foo')
+const requiredCjsLibReassignModuleExports = require('./cjs-lib-reassign-module-exports')
+assert.strictEqual(requiredCjsLibReassignModuleExports(), 'exports')
+assert.strictEqual(requiredCjsLibReassignModuleExports.foo, 'foo')
+
+const requireCjsLib = require('./cjs-lib')
+
+assert.strictEqual(requireCjsLib.foo, 'foo')
+assert.strictEqual(requireCjsLib.bar, 'bar')
+assert.strictEqual(requireCjsLib.baz, undefined)

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5554,7 +5554,7 @@ expression: output
 
 # tests/rolldown/topics/hmr/runtime_correctness
 
-- main-!~{000}~.js => main-CXMG7Ve0.js
+- main-!~{000}~.js => main-DvmEVIze.js
 
 # tests/rolldown/topics/hmr/static_import
 


### PR DESCRIPTION
- Fixes https://github.com/rolldown/rolldown/issues/5616
- Closes https://github.com/rolldown/rolldown/pull/5615