### PR TITLE
feat: implement several optimizations options from rollup's `generatedCode`

### DIFF
--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -130,8 +130,11 @@ pub async fn render_iife<'code>(
   }
 
   if named_exports && entry_module.exports_kind.is_esm() {
-    if let Some(marker) = render_namespace_markers(ctx.options.es_module, has_default_export, false)
-    {
+    if let Some(marker) = render_namespace_markers(
+      ctx.options.es_module,
+      has_default_export,
+      ctx.options.optimization.is_symbols_enabled(),
+    ) {
       source_joiner.append_source(marker);
     }
   }

--- a/crates/rolldown/src/ecmascript/format/umd.rs
+++ b/crates/rolldown/src/ecmascript/format/umd.rs
@@ -96,8 +96,11 @@ pub async fn render_umd<'code>(
   }
 
   if named_exports && entry_module.exports_kind.is_esm() {
-    if let Some(marker) = render_namespace_markers(ctx.options.es_module, has_default_export, false)
-    {
+    if let Some(marker) = render_namespace_markers(
+      ctx.options.es_module,
+      has_default_export,
+      ctx.options.optimization.is_symbols_enabled(),
+    ) {
       source_joiner.append_source(marker.to_string());
     }
   }

--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -49,7 +49,11 @@ impl GenerateContext<'_> {
     if let Some(ns_alias) = namespace_alias {
       let canonical_ns_name = &canonical_names[&ns_alias.namespace_ref];
       let property_name = &ns_alias.property_name;
-      return property_access_str(canonical_ns_name, property_name);
+      return property_access_str(
+        canonical_ns_name,
+        property_name,
+        self.options.optimization.is_reserved_names_as_props_enabled(),
+      );
     }
 
     if self.link_output.module_table[canonical_ref.owner].is_external() {
@@ -77,7 +81,11 @@ impl GenerateContext<'_> {
 
           let require_binding = &self.chunk_graph.chunk_table[cur_chunk_idx]
             .require_binding_names_for_other_chunks[&chunk_idx_of_canonical_symbol];
-          rolldown_utils::ecmascript::property_access_str(require_binding, exported_name)
+          property_access_str(
+            require_binding,
+            exported_name,
+            self.options.optimization.is_reserved_names_as_props_enabled(),
+          )
         } else {
           self.canonical_name_for(canonical_names, canonical_ref).to_string()
         }

--- a/crates/rolldown/src/utils/chunk/namespace_marker.rs
+++ b/crates/rolldown/src/utils/chunk/namespace_marker.rs
@@ -17,7 +17,6 @@ pub fn determine_es_module(es_module_flag: EsModuleFlag, has_default_export: boo
 pub fn render_namespace_markers(
   es_module_flag: EsModuleFlag,
   has_default_export: bool,
-  // TODO namespace_to_string_tag
   namespace_to_string_tag: bool,
 ) -> Option<&'static str> {
   let es_module = determine_es_module(es_module_flag, has_default_export);

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -167,7 +167,11 @@ pub fn render_chunk_exports(
                       render_object_define_property(&exported_name, &exported_value)
                     } else {
                       concat_string!(
-                        property_access_str("exports", exported_name.as_str()),
+                        property_access_str(
+                          "exports",
+                          exported_name.as_str(),
+                          ctx.options.optimization.is_reserved_names_as_props_enabled()
+                        ),
                         " = ",
                         exported_value.as_str(),
                         ";"

--- a/crates/rolldown/tests/rolldown/optimization/const_binding/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/const_binding/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "optimization": {
+      "constBindings": false
+    },
+    "external": ["a"],
+    "format": "cjs"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/optimization/const_binding/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/const_binding/artifacts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+var a = __toESM(require("a"));
+
+//#region main.js
+console.log(a.h);
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/optimization/const_binding/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/const_binding/main.js
@@ -1,0 +1,3 @@
+import { h } from 'a'
+
+console.log(h)

--- a/crates/rolldown/tests/rolldown/optimization/reserved_names_as_props/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/reserved_names_as_props/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "optimization": {
+      "reservedNamesAsProps": false
+    },
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/reserved_names_as_props/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/reserved_names_as_props/artifacts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+
+//#region main.js
+const h = 2;
+
+//#endregion
+exports["h"] = h;
+```

--- a/crates/rolldown/tests/rolldown/optimization/reserved_names_as_props/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/reserved_names_as_props/main.js
@@ -1,0 +1,1 @@
+export const h = 2

--- a/crates/rolldown/tests/rolldown/optimization/symbols/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/symbols/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "optimization": {
+      "symbols": true
+    },
+    "format": "iife",
+    "name": "hello",
+    "esModule": "always",
+    "exports": "named"
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/symbols/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/symbols/artifacts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+var hello = (function(exports) {
+
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
+
+//#region main.js
+var main_default = 42;
+const answer = 42;
+
+//#endregion
+exports.answer = answer;
+exports.default = main_default;
+return exports;
+})({});
+```

--- a/crates/rolldown/tests/rolldown/optimization/symbols/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/symbols/main.js
@@ -1,0 +1,2 @@
+export default 42
+export const answer = 42

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5057,6 +5057,10 @@ expression: output
 - main-!~{000}~.js => main-56AOIbNp.js
 - main-56AOIbNp.js.map
 
+# tests/rolldown/optimization/const_binding
+
+- main-!~{000}~.js => main-CkFd55ml.js
+
 # tests/rolldown/optimization/inline_const/5197
 
 - main-!~{000}~.js => main-C1_Ucsch.js
@@ -5091,6 +5095,14 @@ expression: output
 - a-!~{000}~.js => a-CcaBLJp5.js
 - b-!~{001}~.js => b-aQ857t6g.js
 - common-!~{002}~.js => common-DfGFFFKe.js
+
+# tests/rolldown/optimization/reserved_names_as_props
+
+- main-!~{000}~.js => main-CtF-6SX3.js
+
+# tests/rolldown/optimization/symbols
+
+- main-!~{000}~.js => main-DcJ89g6X.js
 
 # tests/rolldown/resolve/add_module_condition_by_default
 

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_optimization.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_optimization.rs
@@ -3,6 +3,9 @@
 pub struct BindingOptimization {
   pub inline_const: Option<bool>,
   pub pife_for_module_wrappers: Option<bool>,
+  pub const_bindings: Option<bool>,
+  pub reserved_names_as_props: Option<bool>,
+  pub symbols: Option<bool>,
 }
 
 impl From<BindingOptimization> for rolldown_common::OptimizationOption {
@@ -10,6 +13,9 @@ impl From<BindingOptimization> for rolldown_common::OptimizationOption {
     Self {
       inline_const: value.inline_const,
       pife_for_module_wrappers: value.pife_for_module_wrappers,
+      const_bindings: value.const_bindings,
+      reserved_names_as_props: value.reserved_names_as_props,
+      symbols: value.symbols,
     }
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/optimization.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/optimization.rs
@@ -31,6 +31,13 @@ pub struct OptimizationOption {
   /// This improves the initial execution performance.
   /// See <https://v8.dev/blog/preparser#pife> for more details about the optimization.
   pub pife_for_module_wrappers: Option<bool>,
+  /// Use `const` instead of `var` for generated variable declarations, including helper functions.
+  /// See <https://rollupjs.org/configuration-options/#output-generatedcode-constbindings>
+  pub const_bindings: Option<bool>,
+  /// See <https://rollupjs.org/configuration-options/#output-generatedcode-reservednamesasprops>
+  pub reserved_names_as_props: Option<bool>,
+  /// See <https://rollupjs.org/configuration-options/#output-generatedcode-symbols>
+  pub symbols: Option<bool>,
 }
 
 impl OptimizationOption {
@@ -42,6 +49,21 @@ impl OptimizationOption {
   #[inline]
   pub fn is_pife_for_module_wrappers_enabled(&self) -> bool {
     self.pife_for_module_wrappers.unwrap_or(false)
+  }
+
+  #[inline]
+  pub fn is_const_bindings_enabled(&self) -> bool {
+    self.const_bindings.unwrap_or(true)
+  }
+
+  #[inline]
+  pub fn is_reserved_names_as_props_enabled(&self) -> bool {
+    self.reserved_names_as_props.unwrap_or(true)
+  }
+
+  #[inline]
+  pub fn is_symbols_enabled(&self) -> bool {
+    self.symbols.unwrap_or(false)
   }
 }
 
@@ -55,5 +77,6 @@ pub fn normalize_optimization_option(
     pife_for_module_wrappers: Some(
       option.pife_for_module_wrappers.unwrap_or(!matches!(platform, Platform::Neutral)),
     ),
+    ..option
   }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1391,6 +1391,27 @@
             "boolean",
             "null"
           ]
+        },
+        "constBindings": {
+          "description": "Use `const` instead of `var` for generated variable declarations, including helper functions.\nSee <https://rollupjs.org/configuration-options/#output-generatedcode-constbindings>",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "reservedNamesAsProps": {
+          "description": "See <https://rollupjs.org/configuration-options/#output-generatedcode-reservednamesasprops>",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "symbols": {
+          "description": "See <https://rollupjs.org/configuration-options/#output-generatedcode-symbols>",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/crates/rolldown_utils/src/ecmascript.rs
+++ b/crates/rolldown_utils/src/ecmascript.rs
@@ -48,8 +48,8 @@ pub fn legitimize_identifier_name(name: &str) -> Cow<'_, str> {
   Cow::Owned(legitimized)
 }
 
-pub fn property_access_str(obj: &str, prop: &str) -> String {
-  if is_validate_identifier_name(prop) {
+pub fn property_access_str(obj: &str, prop: &str, reserved_names_as_props: bool) -> String {
+  if is_validate_identifier_name(prop) && reserved_names_as_props {
     concat_string!(obj, ".", prop)
   } else {
     concat_string!(obj, "[", serde_json::to_string(prop).unwrap(), "]")

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1725,6 +1725,9 @@ export interface BindingNotifyOption {
 export interface BindingOptimization {
   inlineConst?: boolean
   pifeForModuleWrappers?: boolean
+  constBindings?: boolean
+  reservedNamesAsProps?: boolean
+  symbols?: boolean
 }
 
 export interface BindingOutputOptions {

--- a/packages/rolldown/src/cli/arguments/alias.ts
+++ b/packages/rolldown/src/cli/arguments/alias.ts
@@ -16,7 +16,7 @@ export interface OptionConfig {
   reverse?: boolean;
 }
 
-export const alias: Partial<Record<keyof CliOptions, OptionConfig>> = {
+export const alias: Partial<Record<keyof CliOptions | string, OptionConfig>> = {
   config: {
     abbreviation: 'c',
     hint: 'filename',
@@ -81,5 +81,13 @@ export const alias: Partial<Record<keyof CliOptions, OptionConfig>> = {
   },
   moduleTypes: {
     hint: 'types',
+  },
+  'optimization.constBindings': {
+    default: true,
+    reverse: true,
+  },
+  'optimization.reservedNamesAsProps': {
+    default: true,
+    reverse: true,
   },
 };

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -72,6 +72,9 @@ export type HmrOptions = boolean | {
 
 export type OptimizationOptions = {
   inlineConst?: boolean;
+  constBinding?: boolean;
+  reservedNamesAsProps?: boolean;
+  symbols?: boolean;
 };
 
 export type AttachDebugOptions = 'none' | 'simple' | 'full';

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -72,7 +72,7 @@ export type HmrOptions = boolean | {
 
 export type OptimizationOptions = {
   inlineConst?: boolean;
-  constBinding?: boolean;
+  constBindings?: boolean;
   reservedNamesAsProps?: boolean;
   symbols?: boolean;
 };

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -327,19 +327,19 @@ const OptimizationOptionsSchema = v.strictObject({
   ),
   pifeForModuleWrappers: v.pipe(
     v.optional(v.boolean()),
-    v.description('Use PIFE pattern for module wrappers'),
+    v.description('using PIFE pattern for module wrappers'),
   ),
   constBindings: v.pipe(
     v.optional(v.boolean()),
-    v.description('Use `const` bindings for importing modules'),
+    v.description('using `const` bindings for importing modules'),
   ),
   reservedNamesAsProps: v.pipe(
     v.optional(v.boolean()),
-    v.description('Use static property names for reserved names'),
+    v.description('using static property names for reserved names'),
   ),
   symbols: v.pipe(
     v.optional(v.boolean()),
-    v.description('Use symbols for private properties'),
+    v.description('using symbols for private properties'),
   ),
 });
 
@@ -348,13 +348,13 @@ const OptimizationCliOverrideSchema = v.strictObject({
     v.optional(v.union([
       v.literal(false),
     ])),
-    v.description('Use `const` bindings for importing modules'),
+    v.description('using `const` bindings for importing modules'),
   ),
   reservedNamesAsProps: v.pipe(
     v.optional(v.union([
       v.literal(false),
     ])),
-    v.description('Use static property names for reserved names'),
+    v.description('using static property names for reserved names'),
   ),
 });
 

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -329,6 +329,33 @@ const OptimizationOptionsSchema = v.strictObject({
     v.optional(v.boolean()),
     v.description('Use PIFE pattern for module wrappers'),
   ),
+  constBindings: v.pipe(
+    v.optional(v.boolean()),
+    v.description('Use `const` bindings for importing modules'),
+  ),
+  reservedNamesAsProps: v.pipe(
+    v.optional(v.boolean()),
+    v.description('Use static property names for reserved names'),
+  ),
+  symbols: v.pipe(
+    v.optional(v.boolean()),
+    v.description('Use symbols for private properties'),
+  ),
+});
+
+const OptimizationCliOverrideSchema = v.strictObject({
+  constBindings: v.pipe(
+    v.optional(v.union([
+      v.literal(false),
+    ])),
+    v.description('Use `const` bindings for importing modules'),
+  ),
+  reservedNamesAsProps: v.pipe(
+    v.optional(v.union([
+      v.literal(false),
+    ])),
+    v.description('Use static property names for reserved names'),
+  ),
 });
 
 const OnLogSchema = v.pipe(
@@ -540,6 +567,10 @@ const InputCliOverrideSchema = v.strictObject({
     v.optional(v.string()),
     v.description('The entity top-level `this` represents.'),
   ),
+  optimization: v.optional(v.strictObject({
+    ...OptimizationOptionsSchema.entries,
+    ...OptimizationCliOverrideSchema.entries,
+  })),
 });
 
 const InputCliOptionsSchema = v.omit(

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -62,13 +62,13 @@ OPTIONS
   --minify-internal-exports   Minify internal exports.
   --module-types <types>      Module types for customized extensions.
   --no-external-live-bindings Disable external live bindings.
+  --no-optimization.const-bindings Disable using \`const\` bindings for importing modules.
+  --no-optimization.reserved-names-as-props Disable using static property names for reserved names.
   --no-preserve-entry-signatures Avoid facade chunks for entry points.
   --no-treeshake              Disable treeshaking.
-  --optimization.const-bindings Use \`const\` bindings for importing modules.
   --optimization.inline-const Enable crossmodule constant inlining.
-  --optimization.pife-for-module-wrappers Use PIFE pattern for module wrappers.
-  --optimization.reserved-names-as-props Use static property names for reserved names.
-  --optimization.symbols      Use symbols for private properties.
+  --optimization.pife-for-module-wrappers Using PIFE pattern for module wrappers.
+  --optimization.symbols      Using symbols for private properties.
   --outro <outro>             Code to insert the bottom of the bundled file (inside the wrapper function).
   --polyfill-require          Disable require polyfill injection.
   --preserve-modules          Preserve module structure.

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -64,8 +64,11 @@ OPTIONS
   --no-external-live-bindings Disable external live bindings.
   --no-preserve-entry-signatures Avoid facade chunks for entry points.
   --no-treeshake              Disable treeshaking.
+  --optimization.const-bindings Use \`const\` bindings for importing modules.
   --optimization.inline-const Enable crossmodule constant inlining.
   --optimization.pife-for-module-wrappers Use PIFE pattern for module wrappers.
+  --optimization.reserved-names-as-props Use static property names for reserved names.
+  --optimization.symbols      Use symbols for private properties.
   --outro <outro>             Code to insert the bottom of the bundled file (inside the wrapper function).
   --polyfill-require          Disable require polyfill injection.
   --preserve-modules          Preserve module structure.


### PR DESCRIPTION
I think there are some similarities between `optimization` and `generatedCode` that fine-tune the final chunk with the bundler's output code properties, yet do not majorly affect user code. Compared to Rollup's `generatedCode`, Rolldown offers more advanced features, such as inlining constants, while still possibly allowing for small, fine-tuned adjustments, including `constBindings`, `reservedNamesAsProps`, and `symbols`, and it's a slight incremental compat.

Related: #206.

By the way, my semester in 12th grade (gao 3) starts on August 10, which might be my last PR in the summer.