### PR TITLE
chore(lint): `oxlint --type-aware`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,12 @@ jobs:
 
       - uses: oxc-project/setup-node@fdbf0dfd334c4e6d56ceeb77d91c76339c2a0885 # v1.0.4
 
+      - name: Build @rolldown/pluginutils
+        run: pnpm --filter '@rolldown/pluginutils' build
+
+      - name: Build rolldown
+        run: pnpm run --filter 'rolldown' build-node
+
       - name: Lint Code
         run: pnpm lint-code
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -39,7 +39,10 @@
         "argsIgnorePattern": "^_"
       }
     ],
-    "unicorn/prefer-node-protocol": "error"
+    "unicorn/prefer-node-protocol": "error",
+    "typescript/no-base-to-string": "allow",
+    "typescript/no-floating-promises": "allow",
+    "typescript/restrict-template-expressions": "allow"
   },
   "overrides": [
     {

--- a/docs/data-loading/options-doc.data.ts
+++ b/docs/data-loading/options-doc.data.ts
@@ -18,13 +18,13 @@ interface Input {
   };
   children?: Input[];
   type?: {
-    type?: (string & 'reflection') | 'array';
+    type?: 'reflection' | 'array';
     declaration?: {
       children?: Input[];
     };
     target?: number;
     elementType?: {
-      type?: (string & 'reflection') | 'array';
+      type?: 'reflection' | 'array';
       declaration?: Input;
     };
   };

--- a/examples/chunk-import-map/rolldown.config.js
+++ b/examples/chunk-import-map/rolldown.config.js
@@ -47,7 +47,7 @@ export default defineConfig({
 
             html = html.replace(
               /<script\s+type="importmap"[^>]*>[\s\S]*?<\/script>/i,
-              `<script type="importmap">${importMap}</script>`,
+              `<script type="importmap">${importMap.toString()}</script>`,
             );
 
             let oldImportMap = importMap;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": "^20.19.0 || >=22.12.0"
   },
   "scripts": {
-    "lint-code": "oxlint -c .oxlintrc.json --ignore-path=.oxlintignore --deny-warnings",
+    "lint-code": "oxlint -c .oxlintrc.json --ignore-path=.oxlintignore --deny-warnings --type-aware",
     "lint-knip": "knip",
     "fmt": "dprint fmt",
     "build": "echo \"Use just build\"",
@@ -32,7 +32,8 @@
     "husky": "^9.1.7",
     "knip": "^5.61.3",
     "lint-staged": "^16.1.2",
-    "oxlint": "^1.6.0",
+    "oxlint": "^1.23.0",
+    "oxlint-tsgolint": "0.2.0",
     "remove-unused-vars": "^0.0.8",
     "rolldown": "workspace:*",
     "typescript": "catalog:"

--- a/packages/bench/src/types.d.ts
+++ b/packages/bench/src/types.d.ts
@@ -1,8 +1,19 @@
 import type { BuildOptions } from 'esbuild';
-import type { RolldownOptions } from 'rolldown';
-import type { RollupOptions } from 'rollup';
+import type { OutputOptions, RolldownOptions } from 'rolldown';
+import type {
+  OutputOptions as RollupOutputOptions,
+  RollupOptions,
+} from 'rollup';
 
 type BundlerName = 'rolldown' | 'rollup' | 'esbuild';
+
+type RolldownOptionsWithSingleOutput = Omit<RolldownOptions, 'output'> & {
+  output?: RolldownOutputOptions;
+};
+
+type RollupOptionsWithSingleOutput = Omit<RollupOptions, 'output'> & {
+  output?: RollupOutputOptions;
+};
 
 export interface BenchSuite {
   derived?: {
@@ -16,9 +27,9 @@ export interface BenchSuite {
   // Multiple rolldown options will result in multiple runs with different options.
   // This is useful for benchmarking different options with the same input in rolldown.
   rolldownOptions?:
-    | RolldownOptions
-    | { name: string; options: RolldownOptions }[];
-  rollupOptions?: RollupOptions;
+    | RolldownOptionsWithSingleOutput
+    | { name: string; options: RolldownOptionsWithSingleOutput }[];
+  rollupOptions?: RollupOptionsWithSingleOutput;
   esbuildOptions?: BuildOptions;
 }
 
@@ -26,5 +37,5 @@ export interface RolldownBenchSuite {
   suiteName: string;
   title: string;
   inputs: string[];
-  options?: RolldownOptions;
+  options?: RolldownOptionsWithSingleOutput;
 }

--- a/packages/pluginutils/tsconfig.json
+++ b/packages/pluginutils/tsconfig.json
@@ -9,7 +9,7 @@
     "module": "ESNext", /* Specify what module code is generated. */
     "rootDir": "./src", /* Specify the root folder within your source files. */
     "declaration": true, /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    "outDir": "./dist/esm", /* Specify an output folder for all emitted files. */
+    "outDir": "./dist", /* Specify an output folder for all emitted files. */
     "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -345,7 +345,10 @@ function generateRuntimeTypes() {
 }
 
 function getTsconfigCompilerOptionsForFile(file: string) {
-  const tsconfigPath = ts.findConfigFile(file, ts.sys.fileExists);
+  const tsconfigPath = ts.findConfigFile(
+    file,
+    (path) => ts.sys.fileExists(path),
+  );
   let compilerOptions = ts.getDefaultCompilerOptions();
   if (tsconfigPath) {
     const parsedConfig = ts.getParsedCommandLineOfConfigFile(

--- a/packages/rolldown/src/api/dev/index.ts
+++ b/packages/rolldown/src/api/dev/index.ts
@@ -1,3 +1,4 @@
 import { DevEngine } from './dev-engine';
 
-export var dev: typeof DevEngine.create = DevEngine.create;
+export const dev: typeof DevEngine.create = (...args) =>
+  DevEngine.create(...args);

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -25,7 +25,7 @@ export async function bundleWithConfig(
   const config = await loadConfig(configPath);
 
   if (!config) {
-    logger.error(`No configuration found at ${config}`);
+    logger.error(`No configuration found at ${configPath}`);
     process.exit(1);
   }
 

--- a/packages/rolldown/src/log/locate-character/index.d.ts
+++ b/packages/rolldown/src/log/locate-character/index.d.ts
@@ -1,15 +1,15 @@
 export function getLocator(
   source: string,
-  options?: Options | undefined,
+  options?: Options,
 ): (
   search: string | number,
-  index?: number | undefined,
+  index?: number,
 ) => Location | undefined;
 
 export function locate(
   source: string,
   search: string | number,
-  options?: Options | undefined,
+  options?: Options,
 ): Location | undefined;
 export type Location = Location_1;
 interface Options {

--- a/packages/rolldown/src/parse-ast-index.ts
+++ b/packages/rolldown/src/parse-ast-index.ts
@@ -54,7 +54,7 @@ const defaultParserOptions: ParserOptions = {
 
 export function parseAst(
   sourceText: string,
-  options?: ParserOptions | undefined | null,
+  options?: ParserOptions | null,
   filename?: string,
 ): Program {
   let ast = parseSync(filename ?? 'file.js', sourceText, {
@@ -69,7 +69,7 @@ export function parseAst(
 
 export async function parseAstAsync(
   sourceText: string,
-  options?: ParserOptions | undefined | null,
+  options?: ParserOptions | null,
   filename?: string,
 ): Promise<Program> {
   return wrap(

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -121,7 +121,7 @@ export function bindingifyAugmentChunkHash(
 
   return {
     plugin: async (ctx, chunk) => {
-      return await handler.call(
+      return handler.call(
         new PluginContextImpl(
           args.outputOptions,
           ctx,

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -69,7 +69,7 @@ export interface PluginContext extends MinimalPluginContext {
         PartialNull<ModuleOptions>
       >,
   ): Promise<ModuleInfo>;
-  parse(input: string, options?: ParserOptions | undefined | null): Program;
+  parse(input: string, options?: ParserOptions | null): Program;
   resolve(
     source: string,
     importer?: string,
@@ -238,7 +238,7 @@ export class PluginContextImpl extends MinimalPluginContextImpl {
 
   public parse(
     input: string,
-    options?: ParserOptions | undefined | null,
+    options?: ParserOptions | null,
   ): Program {
     return parseAst(input, options);
   }

--- a/packages/rolldown/src/utils/load-config.ts
+++ b/packages/rolldown/src/utils/load-config.ts
@@ -112,7 +112,7 @@ function isFilePathESM(filePath: string): boolean {
   }
 }
 
-function findNearestPackageData(basedir: string): any | null {
+function findNearestPackageData(basedir: string): any {
   while (basedir) {
     const pkgPath = path.join(basedir, 'package.json');
     if (tryStatSync(pkgPath)?.isFile()) {

--- a/packages/rolldown/src/utils/normalize-string-or-regex.ts
+++ b/packages/rolldown/src/utils/normalize-string-or-regex.ts
@@ -20,7 +20,7 @@ export function normalizedStringOrRegex<
 
 // For https://github.com/microsoft/TypeScript/issues/17002
 function isReadonlyArray<T extends unknown[] | readonly unknown[]>(
-  input: T | unknown,
+  input: unknown,
 ): input is T {
   return Array.isArray(input);
 }

--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -103,7 +103,7 @@ export function getLocation(source: string, search: string | number) {
 export async function waitUtil(expectFn: () => void) {
   for (let tries = 0; tries < 20; tries++) {
     try {
-      await expectFn()
+      expectFn()
       return
     } catch {}
     await sleep(50)

--- a/packages/test-dev-server/src/utils/decode-client-message.ts
+++ b/packages/test-dev-server/src/utils/decode-client-message.ts
@@ -2,8 +2,18 @@ import { RawData } from 'ws';
 
 import { ClientMessage } from '../types/client-message';
 
+function rawDataToString(data: Buffer | ArrayBuffer | Buffer[]): string {
+  if (Buffer.isBuffer(data)) {
+    return data.toString('utf8');
+  }
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString('utf8');
+  }
+  return Buffer.from(data).toString('utf8');
+}
+
 export function decodeClientMessage(data: RawData): ClientMessage {
-  const stringified = data.toString();
+  const stringified = rawDataToString(data);
   const decoded = JSON.parse(stringified) as ClientMessage;
   switch (decoded.type) {
     case 'hmr:invalidate':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,8 +282,11 @@ importers:
         specifier: ^16.1.2
         version: 16.2.4
       oxlint:
-        specifier: ^1.6.0
-        version: 1.23.0
+        specifier: ^1.23.0
+        version: 1.23.0(oxlint-tsgolint@0.2.0)
+      oxlint-tsgolint:
+        specifier: 0.2.0
+        version: 0.2.0
       remove-unused-vars:
         specifier: ^0.0.8
         version: 0.0.8
@@ -2675,6 +2678,36 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxlint-tsgolint/darwin-arm64@0.2.0':
+    resolution: {integrity: sha512-ayJO9SmiJ15oV3+svIw8bqun0ySdjiD7L+ddwNB4vOAgUX/rdX1KTBnDb/ZEk6MOFBnFgbbiEiLRJLlGtuFYVQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.2.0':
+    resolution: {integrity: sha512-iCrcjkqqyy3zq+yXOmNsjt/DiSU4u9yJ00hEr4oGSrrk7V0ju6eqrmsh8VGS74YLY3MCskTjeTyVDRR7huc3WQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.2.0':
+    resolution: {integrity: sha512-Kne4mrJGCZ0O+/ukcvWftCmDAEFUpMQ4q4wZdWVlnmNdTbtICIay3ofk/rzX0QoZmEZh0jy/G7p+5P0t9Bg5Sg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.2.0':
+    resolution: {integrity: sha512-DKGFSR71fnExWpJXvN32SqWuEcT1XXeI1CKpO63jgXTAUpVl9H/BXG3+gNptSoZqzqeFTj8jOgiaX6VkOABqGA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.2.0':
+    resolution: {integrity: sha512-Grbkva1YH0eTRtv3MkVTFAycVwQSytcl8N52zNs1YresWwOlnNvNZ5EeLIaQaudcxwsbpZWR2Bdsfa467zDJTw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.2.0':
+    resolution: {integrity: sha512-asfPqgu7r1H8NmBNxfMpZER6WvrUTH8BDMPIcChBhrUjuSmt4UMyiyul3CEPZLPQcPlaWCeGnConTu3BabK4Fw==}
+    cpu: [x64]
+    os: [win32]
+
   '@oxlint/darwin-arm64@1.23.0':
     resolution: {integrity: sha512-sbxoftgEMKmZQO7O4wHR9Rs7MfiHa2UH2x4QJDoc4LXqSCsI4lUIJbFQ05vX+zOUbt7CQMPdxEzExd4DqeKY2w==}
     cpu: [arm64]
@@ -4694,6 +4727,10 @@ packages:
   oxc-transform@0.95.0:
     resolution: {integrity: sha512-SmS5aThb5K0SoUZgzGbikNBjrGHfOY4X5TEqBlaZb1uy5YgXbUSbpakpZJ13yW36LNqy8Im5+y+sIk5dlzpZ/w==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxlint-tsgolint@0.2.0:
+    resolution: {integrity: sha512-37Hy+FT1sz8hHUo31JIgFDA8NcFndexrg5okutWRPXNejJwB9hKN+pyInaQQIv4XDsgNcQsSR2VJoq99eaGk9g==}
+    hasBin: true
 
   oxlint@1.23.0:
     resolution: {integrity: sha512-cLVdSE7Bza8npm+PffU0oufs15+M5uSMbQn0k2fJCayWU0xqQ3dyA3w9tEk8lgNOk1j1VJEdYctz64Vik8VG1w==}
@@ -7434,6 +7471,24 @@ snapshots:
   '@oxc-transform/binding-win32-x64-msvc@0.95.0':
     optional: true
 
+  '@oxlint-tsgolint/darwin-arm64@0.2.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.2.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.2.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.2.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.2.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.2.0':
+    optional: true
+
   '@oxlint/darwin-arm64@1.23.0':
     optional: true
 
@@ -9605,7 +9660,16 @@ snapshots:
       '@oxc-transform/binding-win32-arm64-msvc': 0.95.0
       '@oxc-transform/binding-win32-x64-msvc': 0.95.0
 
-  oxlint@1.23.0:
+  oxlint-tsgolint@0.2.0:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.2.0
+      '@oxlint-tsgolint/darwin-x64': 0.2.0
+      '@oxlint-tsgolint/linux-arm64': 0.2.0
+      '@oxlint-tsgolint/linux-x64': 0.2.0
+      '@oxlint-tsgolint/win32-arm64': 0.2.0
+      '@oxlint-tsgolint/win32-x64': 0.2.0
+
+  oxlint@1.23.0(oxlint-tsgolint@0.2.0):
     optionalDependencies:
       '@oxlint/darwin-arm64': 1.23.0
       '@oxlint/darwin-x64': 1.23.0
@@ -9615,6 +9679,7 @@ snapshots:
       '@oxlint/linux-x64-musl': 1.23.0
       '@oxlint/win32-arm64': 1.23.0
       '@oxlint/win32-x64': 1.23.0
+      oxlint-tsgolint: 0.2.0
 
   p-defer@1.0.0: {}
 


### PR DESCRIPTION
To enable type aware linting:

1. `pnpm add -w -D oxlint-tsgolint`
2. add `--type-aware` to cli
3. enable the rules

```
    "typescript/no-floating-promises": "error",
    "typescript/no-misused-promises": "error"
```

(or in cli `-D typescript/no-floating-promises -D typescript/no-misused-promises`)

<img width="1768" height="1704" alt="image" src="https://github.com/user-attachments/assets/8392a24f-8029-4f41-abd7-14d400de3cfb" />
