### PR TITLE
fix: incorrect module execution order with sideeffectful CJS module

### DIFF
--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -1,9 +1,10 @@
 use rolldown_common::{
-  ChunkIdx, ConstExportMeta, IndexModules, ModuleIdx, NormalModule, RuntimeModuleBrief,
-  SharedFileEmitter, SymbolRef, SymbolRefDb,
+  ChunkIdx, ConstExportMeta, ImportRecordIdx, IndexModules, ModuleIdx, NormalModule,
+  RuntimeModuleBrief, SharedFileEmitter, SymbolRef, SymbolRefDb,
 };
 
 use oxc::span::CompactStr;
+use rolldown_utils::indexmap::FxIndexMap;
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -30,4 +31,5 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub constant_value_map: &'me FxHashMap<SymbolRef, ConstExportMeta>,
   pub needs_hosted_top_level_binding: bool,
   pub module_namespace_included: bool,
+  pub transferred_import_record: FxIndexMap<ImportRecordIdx, String>,
 }

--- a/crates/rolldown/src/utils/mod.rs
+++ b/crates/rolldown/src/utils/mod.rs
@@ -27,11 +27,11 @@ use rustc_hash::FxHashSet;
 use super::module_finalizers::{ScopeHoistingFinalizer, ScopeHoistingFinalizerContext};
 
 #[tracing::instrument(level = "trace", skip_all)]
-pub fn finalize_normal_module(
-  ctx: ScopeHoistingFinalizerContext<'_>,
-  ast: &mut EcmaAst,
-  ast_scope: &AstScopes,
-) {
+pub fn finalize_normal_module<'me>(
+  ctx: ScopeHoistingFinalizerContext<'me>,
+  ast: &'me mut EcmaAst,
+  ast_scope: &'me AstScopes,
+) -> ScopeHoistingFinalizerContext<'me> {
   ast.program.with_mut(|fields| {
     let (oxc_program, alloc) = (fields.program, fields.allocator);
     let mut finalizer = ScopeHoistingFinalizer {
@@ -47,5 +47,6 @@ pub fn finalize_normal_module(
     };
     finalizer.visit_program(oxc_program);
     oxc_program.comments = finalizer.comments.take_in(alloc);
-  });
+    finalizer.ctx
+  })
 }

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/artifacts.snap
@@ -19,10 +19,10 @@ var init_index_module = __esm({ "node_modules/demo-pkg/index-module.js": (() => 
 //#endregion
 //#region src/require-demo-pkg.js
 init_index_module();
+init_index_module();
 
 //#endregion
 //#region src/entry.js
-init_index_module();
 console.log("unused import");
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/mix-cjs-esm/artifacts.snap
@@ -51,13 +51,10 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region esm-import-cjs-require.js
+var import_esm_import_cjs_export = /* @__PURE__ */ __toESM(require_esm_import_cjs_export());
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 require_foo();
 assert.equal(import_cjs.a, void 0);
-
-//#endregion
-//#region main.js
-var import_esm_import_cjs_export = /* @__PURE__ */ __toESM(require_esm_import_cjs_export());
 
 //#endregion
 //# sourceMappingURL=main.js.map
@@ -79,9 +76,5 @@ var import_esm_import_cjs_export = /* @__PURE__ */ __toESM(require_esm_import_cj
 (0:7) "exports = " --> (48:8) "exports = "
 (0:17) "1;" --> (48:18) "1;\n"
 - ../esm-import-cjs-require.js
-(3:0) "assert." --> (55:0) "assert."
-(3:7) "equal(" --> (55:7) "equal("
-(3:13) "a, " --> (55:13) "import_cjs.a, "
-(3:16) "undefined)" --> (55:27) "void 0)"
-(3:26) "\n" --> (55:34) ";\n"
+(3:0) "assert.equal(a, undefined)\n" --> (56:0) "assert.equal(import_cjs.a, void 0);\n"
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_none_default_ns_property_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_none_default_ns_property_name/artifacts.snap
@@ -19,11 +19,11 @@ var require_commonjs = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports) =>
 
 //#endregion
 //#region refactor.mjs
+var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 var refactor_default = (a) => a;
 
 //#endregion
 //#region main.js
-var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 import_commonjs.ObjectElement.refract = refactor_default(import_commonjs.ObjectElement);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge/artifacts.snap
@@ -14,13 +14,13 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region a.js
-var import_cjs$2 = /* @__PURE__ */ __toESM(require_cjs());
 function test() {
 	return import_cjs$2.default;
 }
 
 //#endregion
 //#region b.js
+var import_cjs$2 = /* @__PURE__ */ __toESM(require_cjs());
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 var import_cjs$1 = /* @__PURE__ */ __toESM(require_cjs());
 function test$1() {

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize/artifacts.snap
@@ -22,8 +22,6 @@ var require_util = /* @__PURE__ */ __commonJS({ "util.js": ((exports, module) =>
 
 //#endregion
 //#region a.js
-var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
-var import_util = /* @__PURE__ */ __toESM(require_util());
 function test() {
 	(0, import_util.default)();
 	return import_cjs.default;
@@ -31,6 +29,8 @@ function test() {
 
 //#endregion
 //#region b.js
+var import_util = /* @__PURE__ */ __toESM(require_util());
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 function test$1() {
 	return import_cjs.default;
 }

--- a/crates/rolldown/tests/rolldown/issues/4782/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/4782/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "experimental": {}
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/4782/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4782/artifacts.snap
@@ -1,0 +1,40 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## lib.js
+
+```js
+// HIDDEN [rolldown:runtime]
+//#region leaflet.js
+var require_leaflet = /* @__PURE__ */ __commonJS({ "leaflet.js": ((exports, module) => {
+	(function(global$1, factory) {
+		typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global$1 = typeof globalThis !== "undefined" ? globalThis : global$1 || self, factory(global$1.leaflet = {}));
+	})(exports, function(exports$1) {
+		exports$1.foo = "foo";
+		global.L = exports$1;
+	});
+}) });
+
+//#endregion
+//#region leaflet-toolbar.js
+var import_leaflet = /* @__PURE__ */ __toESM(require_leaflet());
+(function(t) {
+	t.L.Toolbar = L.foo;
+})(global);
+
+//#endregion
+//#region lib.js
+console.log("hello", !!L);
+
+//#endregion
+```
+## main.js
+
+```js
+//#region main.js
+import("./lib.js");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/issues/4782/leaflet-toolbar.js
+++ b/crates/rolldown/tests/rolldown/issues/4782/leaflet-toolbar.js
@@ -1,0 +1,4 @@
+!(function (t) {
+  'use strict';
+  t.L.Toolbar = L.foo;
+})(global);

--- a/crates/rolldown/tests/rolldown/issues/4782/leaflet.js
+++ b/crates/rolldown/tests/rolldown/issues/4782/leaflet.js
@@ -1,0 +1,14 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined'
+    ? factory(exports)
+    : typeof define === 'function' && define.amd
+    ? define(['exports'], factory)
+    : ((global =
+        typeof globalThis !== 'undefined' ? globalThis : global || self),
+      factory((global.leaflet = {})));
+})(this, function (exports) {
+  'use strict';
+
+  exports.foo = 'foo';
+  global.L = exports;
+});

--- a/crates/rolldown/tests/rolldown/issues/4782/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/4782/lib.js
@@ -1,0 +1,3 @@
+import './leaflet.js';
+import './leaflet-toolbar.js';
+console.log('hello', !!L);

--- a/crates/rolldown/tests/rolldown/issues/4782/main.js
+++ b/crates/rolldown/tests/rolldown/issues/4782/main.js
@@ -1,0 +1,1 @@
+import('./lib.js')

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -17,6 +17,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region esm.js
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 var esm_exports = {};
 __export(esm_exports, { value: () => value });
 const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
@@ -26,7 +27,6 @@ const value = "main";
 //#endregion
 //#region main.js
 var main_exports = {};
-var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 console.log(import_cjs, esm_exports);

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -17,6 +17,7 @@ var require_exist_dep_cjs = /* @__PURE__ */ __commonJS({ "exist-dep-cjs.js": ((e
 
 //#endregion
 //#region exist-dep-esm.js
+var import_exist_dep_cjs = /* @__PURE__ */ __toESM(require_exist_dep_cjs());
 var exist_dep_esm_exports = {};
 __export(exist_dep_esm_exports, { value: () => value });
 const exist_dep_esm_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
@@ -26,7 +27,6 @@ const value = "exist-esm";
 //#endregion
 //#region hmr.js
 var hmr_exports = {};
-var import_exist_dep_cjs = /* @__PURE__ */ __toESM(require_exist_dep_cjs());
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 hmr_hot.accept((mod) => {

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs/artifacts.snap
@@ -28,6 +28,8 @@ var require_cjs$2 = /* @__PURE__ */ __commonJS({ "src/export_star_from_cjs/cjs.j
 
 //#endregion
 //#region src/export_star_from_cjs/index.js
+var import_basic_ref_with_named_default = /* @__PURE__ */ __toESM(require_basic_ref_with_named_default());
+var import_basic_ns = /* @__PURE__ */ __toESM(require_basic_ns());
 var export_star_from_cjs_exports = {};
 __reExport(export_star_from_cjs_exports, /* @__PURE__ */ __toESM(require_cjs$2()));
 
@@ -67,8 +69,6 @@ var require_indirect_common_js = /* @__PURE__ */ __commonJS({ "src/indirect_comm
 
 //#endregion
 //#region main.js
-var import_basic_ns = /* @__PURE__ */ __toESM(require_basic_ns());
-var import_basic_ref_with_named_default = /* @__PURE__ */ __toESM(require_basic_ref_with_named_default());
 var import_indirect_common_js = /* @__PURE__ */ __toESM(require_indirect_common_js());
 assert.equal(import_basic_ns.a, "basic-a");
 assert.equal(import_basic_ref_with_named_default.a, "basic-ref-with-named-default-a");

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -336,7 +336,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main
 
-- src_entry-!~{000}~.js => src_entry-C2peZyuC.js
+- src_entry-!~{000}~.js => src_entry-Dmc_zJYq.js
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_module
 
@@ -3716,8 +3716,8 @@ expression: output
 
 # tests/rolldown/cjs_compat/mix-cjs-esm
 
-- main-!~{000}~.js => main-DjRkGoWy.js
-- main-DjRkGoWy.js.map
+- main-!~{000}~.js => main-BHvrdxT6.js
+- main-BHvrdxT6.js.map
 
 # tests/rolldown/cjs_compat/multiple_circle_cjs_entries
 
@@ -3741,11 +3741,11 @@ expression: output
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_none_default_ns_property_name
 
-- main-!~{000}~.js => main-wIDV8rsX.js
+- main-!~{000}~.js => main-CMeZ36WU.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge
 
-- main-!~{000}~.js => main-BywzsmJB.js
+- main-!~{000}~.js => main-UzXWIcz5.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_2
 
@@ -3753,7 +3753,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize
 
-- main-!~{000}~.js => main-D8jvRMNG.js
+- main-!~{000}~.js => main-ogn2r6Dl.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize_chunk_split
 
@@ -4791,6 +4791,11 @@ expression: output
 
 - main-!~{000}~.js => main-D_pxn1_z.js
 
+# tests/rolldown/issues/4782
+
+- main-!~{000}~.js => main-W30fkYCW.js
+- lib-!~{001}~.js => lib-DIxPYki1.js
+
 # tests/rolldown/issues/4993
 
 - main-!~{000}~.js => main-BQQtZSou.js
@@ -5558,7 +5563,7 @@ expression: output
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-CNKiZVCL.js
+- main-!~{000}~.js => main-CisBJ67Z.js
 
 # tests/rolldown/topics/hmr/runtime_correctness
 
@@ -5566,7 +5571,7 @@ expression: output
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-BN-YXISS.js
+- main-!~{000}~.js => main-CGlDmDpv.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 
@@ -5764,7 +5769,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/commonjs
 
-- main-!~{000}~.js => main-DDdJExEQ.js
+- main-!~{000}~.js => main-DDXCupjO.js
 
 # tests/rolldown/tree_shaking/commonjs_5546
 

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -4,9 +4,9 @@ use std::{
 };
 
 use crate::{
-  ChunkIdx, ChunkKind, FilenameTemplate, ModuleIdx, ModuleTable, NamedImport, NormalModule,
-  NormalizedBundlerOptions, PreserveEntrySignatures, RollupPreRenderedChunk, RuntimeHelper,
-  SymbolRef, chunk::types::chunk_reason_type::ChunkReasonType,
+  ChunkIdx, ChunkKind, FilenameTemplate, ImportRecordIdx, ModuleIdx, ModuleTable, NamedImport,
+  NormalModule, NormalizedBundlerOptions, PreserveEntrySignatures, RollupPreRenderedChunk,
+  RuntimeHelper, SymbolRef, chunk::types::chunk_reason_type::ChunkReasonType,
 };
 pub mod chunk_table;
 pub mod types;
@@ -73,6 +73,9 @@ pub struct Chunk {
   pub depended_runtime_helper: RuntimeHelper,
   /// related to [`crate::types::import_record::ImportRecordMeta::EntryLevelExternal`]
   pub entry_level_external_module_idx: Vec<ModuleIdx>,
+  pub insert_map: FxHashMap<ModuleIdx, Vec<(ModuleIdx, ImportRecordIdx)>>,
+  pub remove_map: FxHashMap<ModuleIdx, Vec<ImportRecordIdx>>,
+  pub transformed_parts_rendered: FxIndexMap<(ModuleIdx, ImportRecordIdx), String>,
 }
 
 impl Chunk {

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -138,3 +138,14 @@ impl SourceMutation for ImportMetaRolldownAssetReplacer {
       .replace_all("import.meta.__ROLLDOWN_ASSET_FILENAME", format!("\"{}\"", self.asset_filename));
   }
 }
+
+#[derive(Debug, Default)]
+pub struct PrependRenderedImport {
+  pub intro: String,
+}
+
+impl SourceMutation for PrependRenderedImport {
+  fn apply(&self, magic_string: &mut string_wizard::MagicString<'_>) {
+    magic_string.prepend(self.intro.clone());
+  }
+}

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -89,7 +89,7 @@ pub use crate::{
     ecma_asset_meta::EcmaAssetMeta,
     ecma_view::{
       EcmaModuleAstUsage, EcmaView, EcmaViewMeta, ImportMetaRolldownAssetReplacer,
-      ThisExprReplaceKind, generate_replace_this_expr_map,
+      PrependRenderedImport, ThisExprReplaceKind, generate_replace_this_expr_map,
     },
     module_idx::ModuleIdx,
     node_builtin_modules::is_existing_node_builtin_modules,

--- a/crates/rolldown_common/src/types/import_kind.rs
+++ b/crates/rolldown_common/src/types/import_kind.rs
@@ -18,10 +18,11 @@ pub enum ImportKind {
 }
 
 impl ImportKind {
+  #[inline]
   pub fn is_static(&self) -> bool {
     matches!(self, Self::Import | Self::Require | Self::AtImport | Self::UrlImport | Self::NewUrl)
   }
-
+  #[inline]
   pub fn is_dynamic(&self) -> bool {
     matches!(self, Self::DynamicImport)
   }


### PR DESCRIPTION
Closed https://github.com/rolldown/rolldown/issues/4782
1. Add basic ability to transfer parts of the code in one module to another module if they are in the same chunk.
2. Add a new process to ensure put lazy module(wrapped) is first initialization to the correct position.