### PR TITLE
fix(rollup-tests): update ignored tests for `option.context`

### DIFF
--- a/packages/rollup-tests/src/failed-tests.json
+++ b/packages/rollup-tests/src/failed-tests.json
@@ -1,4 +1,3 @@
 [
-  "rollup@function@es5-class-called-without-new: does not swallow type errors when running constructor functions without \"new\"",
-  "rollup@function@options-in-renderstart: makes input and output options available in renderStart"
+  "rollup@function@es5-class-called-without-new: does not swallow type errors when running constructor functions without \"new\""
 ]

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -123,6 +123,10 @@
  - rollup@function@adds-timings-to-bundle-when-codesplitting: Adds timing information to bundle when bundling with perf=true
  - rollup@function@adds-timings-to-bundle: Adds timing information to bundle when bundling with perf=true
 
+### The `input.context` is not fully supported
+
+ - rollup@function@options-in-renderstart: makes input and output options available in renderStart
+
 ### `output.dynamicImportInCjs` is not supported
  - rollup@function@dynamic-import-this-function: uses correct "this" in dynamic imports when not using arrow functions
  - rollup@function@dynamic-import-this-arrow: uses correct "this" in dynamic imports when using arrow functions

--- a/packages/rollup-tests/src/ignored-tests.js
+++ b/packages/rollup-tests/src/ignored-tests.js
@@ -22,8 +22,6 @@ const ignoreTests = [
 
   "rollup@function@generate-bundle-mutation: handles adding or deleting symbols in generateBundle", // rolldown outputs a warning when assigning to bundle[foo]
   "rollup@form@logical-expression@simplify-non-boolean: simplifies logical expressions that resolve statically to non-boolean values", // Oxc DCE is sub-optimal.
-
-  "rollup@function@options-in-renderstart: makes input and output options available in renderStart", // The test is no longer exist on Rollup side.
 ]
 
 module.exports = {

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,8 +1,8 @@
 {
   "failed": 0,
   "skipFailed": 1,
-  "ignored": 16,
-  "ignored(unsupported features)": 393,
+  "ignored": 15,
+  "ignored(unsupported features)": 394,
   "ignored(treeshaking)": 282,
   "ignored(behavior passed, snapshot different)": 124,
   "passed": 732

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -2,8 +2,8 @@
 |----| ---- |
 | failed | 0 |
 | skipFailed | 1 |
-| ignored | 16 |
-| ignored(unsupported features) | 393 |
+| ignored | 15 |
+| ignored(unsupported features) | 394 |
 | ignored(treeshaking) | 282 |
 | ignored(behavior passed, snapshot different) | 124 |
 | passed | 732 |


### PR DESCRIPTION
The test still exists in Rollup tests. I accidentally overlooked the existence of this test. Sorry for my mistake.

https://github.com/rolldown/rolldown/pull/5663/files#diff-99e8d6ce47a816a57479146171fce2fc6085c40db1d1dc3498ed5e98ac7ee2deR26