### PR TITLE
perf: reduce memory usage when calc none wrapped modules implicit dependency

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -263,7 +263,7 @@ impl GenerateStage<'_> {
           return;
         };
         // After modules in chunk is sorted, it is always sorted by execution order whatever the
-        // `chunk_modules_order` is `exec_order` or `module_id`.Because for `module_id` we only sort
+        // `chunk_modules_order` is `exec_order` or `module_id`. Because for `module_id` we only sort
         // by `module_id` for side effects free leaf modules, those should always execute first and
         // has no wrapping.
         let mut wrapped_modules = vec![];

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -263,7 +263,7 @@ impl GenerateStage<'_> {
           return;
         };
         // After modules in chunk is sorted, it is always sorted by execution order whatever the
-        // `chunk_modules_order` is `exec_order` or `module_id`, because for `module_id` we only sort
+        // `chunk_modules_order` is `exec_order` or `module_id`.Because for `module_id` we only sort
         // by `module_id` for side effects free leaf modules, those should always execute first and
         // has no wrapping.
         let mut wrapped_modules = vec![];
@@ -363,6 +363,8 @@ impl GenerateStage<'_> {
       });
   }
 
+  /// Only considering module eager initlization order, both `require()` and `import()` are lazy
+  /// initialization.
   fn js_import_order(
     &self,
     entry: ModuleIdx,

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -363,7 +363,7 @@ impl GenerateStage<'_> {
       });
   }
 
-  /// Only considering module eager initlization order, both `require()` and `import()` are lazy
+  /// Only considering module eager initialization order, both `require()` and `import()` are lazy
   /// initialization.
   fn js_import_order(
     &self,

--- a/crates/rolldown/tests/rolldown/issues/5531/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/5531/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "experimental": {}
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/5531/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5531/artifacts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+// HIDDEN [rolldown:runtime]
+//#region leaflet.js
+var require_leaflet = /* @__PURE__ */ __commonJS({ "leaflet.js": ((exports, module) => {
+	(function(global$1, factory) {
+		typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global$1 = typeof globalThis !== "undefined" ? globalThis : global$1 || self, factory(global$1.leaflet = {}));
+	})(exports, function(exports$1) {
+		exports$1.foo = "foo";
+		global.L = exports$1;
+	});
+}) });
+
+//#endregion
+//#region leaflet-toolbar.js
+var require_leaflet_toolbar = /* @__PURE__ */ __commonJS({ "leaflet-toolbar.js": ((exports, module) => {
+	global.bar = global.L.foo;
+	module.exports = bar;
+}) });
+
+//#endregion
+//#region lib.js
+var import_leaflet = /* @__PURE__ */ __toESM(require_leaflet());
+require_leaflet_toolbar();
+
+//#endregion
+//#region main.js
+assert.equal(bar, "foo");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/issues/5531/leaflet-toolbar.js
+++ b/crates/rolldown/tests/rolldown/issues/5531/leaflet-toolbar.js
@@ -1,0 +1,2 @@
+global.bar = global.L.foo;
+module.exports = bar;

--- a/crates/rolldown/tests/rolldown/issues/5531/leaflet.js
+++ b/crates/rolldown/tests/rolldown/issues/5531/leaflet.js
@@ -1,0 +1,14 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined'
+    ? factory(exports)
+    : typeof define === 'function' && define.amd
+    ? define(['exports'], factory)
+    : ((global =
+        typeof globalThis !== 'undefined' ? globalThis : global || self),
+      factory((global.leaflet = {})));
+})(this, function (exports) {
+  'use strict';
+
+  exports.foo = 'foo';
+  global.L = exports;
+});

--- a/crates/rolldown/tests/rolldown/issues/5531/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/5531/lib.js
@@ -1,0 +1,1 @@
+require('./leaflet-toolbar.js')

--- a/crates/rolldown/tests/rolldown/issues/5531/main.js
+++ b/crates/rolldown/tests/rolldown/issues/5531/main.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert'
+import './leaflet.js';
+import './lib.js';
+
+assert.equal(bar, 'foo');
+
+

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4826,6 +4826,10 @@ expression: output
 - liblib/index-!~{005}~.js => liblib/index-CrkltzeF.js
 - liblib/lib-!~{003}~.js => liblib/lib-CEDze9up.js
 
+# tests/rolldown/issues/5531
+
+- main-!~{000}~.js => main-CHBb07AE.js
+
 # tests/rolldown/issues/rolldown_vite_289
 
 - main-!~{000}~.js => main-bGTkbLZB.js


### PR DESCRIPTION
Avoid allocating the same parts of the `wrapped_modules`