### PR TITLE
fix: ensure `./` prefix for relative imports starting with `.`

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/5557/..y.js
+++ b/crates/rolldown/tests/rolldown/issues/5557/..y.js
@@ -1,0 +1,1 @@
+export default 'y';

--- a/crates/rolldown/tests/rolldown/issues/5557/.x.js
+++ b/crates/rolldown/tests/rolldown/issues/5557/.x.js
@@ -1,0 +1,1 @@
+export default 'x';

--- a/crates/rolldown/tests/rolldown/issues/5557/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/5557/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "preserveModules": true
+  },
+  "snapshot": false
+}

--- a/crates/rolldown/tests/rolldown/issues/5557/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/5557/_test.mjs
@@ -1,0 +1,7 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import assert from 'node:assert'
+
+const bundledFile = fs.readFileSync(path.resolve(import.meta.dirname, 'dist/main.js'))
+assert(bundledFile.includes('./.x.js'))
+assert(bundledFile.includes('./..y.js'))

--- a/crates/rolldown/tests/rolldown/issues/5557/main.js
+++ b/crates/rolldown/tests/rolldown/issues/5557/main.js
@@ -1,0 +1,4 @@
+import x from './.x.js';
+import y from './..y.js';
+
+console.log(x, y);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4830,6 +4830,12 @@ expression: output
 
 - main-!~{000}~.js => main-CHBb07AE.js
 
+# tests/rolldown/issues/5557
+
+- main-!~{000}~.js => main-Bl3y5wUL.js
+- ..y-!~{003}~.js => ..y-jkw_G_n4.js
+- .x-!~{001}~.js => .x-Duu-0G9Y.js
+
 # tests/rolldown/issues/rolldown_vite_289
 
 - main-!~{000}~.js => main-bGTkbLZB.js

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -118,7 +118,7 @@ impl Chunk {
       .as_ref()
       .expect("importee chunk should have absolute_preliminary_filename");
     let import_path = self.relative_path_for(importee_filename.as_path());
-    if import_path.starts_with('.') { import_path } else { format!("./{import_path}") }
+    if import_path.starts_with("../") { import_path } else { format!("./{import_path}") }
   }
 
   pub fn relative_path_for(&self, target: &Path) -> String {


### PR DESCRIPTION
closes #5557