### PR TITLE
feat: improve error message for `unresolved_import` when platform is `neutral`

### DIFF
--- a/crates/rolldown/src/module_loader/resolve_utils.rs
+++ b/crates/rolldown/src/module_loader/resolve_utils.rs
@@ -113,6 +113,9 @@ pub async fn resolve_dependencies(
                   None,
                 ));
               } else {
+                let help = matches!(options.platform, rolldown_common::Platform::Neutral).then(|| {
+                  r#"The "main" field here was ignored. Main fields must be configured explicitly when using the "neutral" platform."#.to_string()
+                });
                 warnings.push(
                   BuildDiagnostic::resolve_error(
                     source.clone(),
@@ -124,7 +127,7 @@ pub async fn resolve_dependencies(
                     },
                     "Module not found, treating it as an external dependency".into(),
                     EventKind::UnresolvedImport,
-                    None,
+                    help,
                   )
                   .with_severity_warning(),
                 );

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_neutral_no_default_main_fields/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_neutral_no_default_main_fields/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # warnings
 
@@ -13,6 +12,8 @@ snapshot_kind: text
  1 │ import fn from 'demo-pkg'
    │                ─────┬────  
    │                     ╰────── Module not found, treating it as an external dependency
+   │ 
+   │ Help: The "main" field here was ignored. Main fields must be configured explicitly when using the "neutral" platform.
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/resolve/natural_platform_without_mainfields/_config.json
+++ b/crates/rolldown/tests/rolldown/resolve/natural_platform_without_mainfields/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "platform": "neutral"
+  }
+}

--- a/crates/rolldown/tests/rolldown/resolve/natural_platform_without_mainfields/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/natural_platform_without_mainfields/artifacts.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Warning: Could not resolve 'foo' in main.js
+   ╭─[ main.js:1:19 ]
+   │
+ 1 │ import { a } from "foo";
+   │                   ──┬──  
+   │                     ╰──── Module not found, treating it as an external dependency
+   │ 
+   │ Help: The "main" field here was ignored. Main fields must be configured explicitly when using the "neutral" platform.
+───╯
+
+```
+# Assets
+
+## main.js
+
+```js
+import { a } from "foo";
+import assert from "node:assert";
+
+//#region main.js
+assert.strictEqual(a, 1e3);
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/resolve/natural_platform_without_mainfields/main.js
+++ b/crates/rolldown/tests/rolldown/resolve/natural_platform_without_mainfields/main.js
@@ -1,0 +1,6 @@
+import { a } from "foo";
+import assert from 'node:assert'
+
+
+assert.strictEqual(a, 1000)
+

--- a/crates/rolldown/tests/rolldown/resolve/natural_platform_without_mainfields/node_modules/foo/lib/index.js
+++ b/crates/rolldown/tests/rolldown/resolve/natural_platform_without_mainfields/node_modules/foo/lib/index.js
@@ -1,0 +1,1 @@
+export const a = 1000;

--- a/crates/rolldown/tests/rolldown/resolve/natural_platform_without_mainfields/node_modules/foo/package.json
+++ b/crates/rolldown/tests/rolldown/resolve/natural_platform_without_mainfields/node_modules/foo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "foo",
+  "main": "lib/index.js"
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5119,6 +5119,10 @@ expression: output
 
 - main-!~{000}~.js => main-tpAxLMZ5.js
 
+# tests/rolldown/resolve/natural_platform_without_mainfields
+
+- main-!~{000}~.js => main-1wxvB78i.js
+
 # tests/rolldown/resolve/ts_config_merge_decorator_metadata
 
 - main-!~{000}~.js => main-C1cURgQH.js


### PR DESCRIPTION
related to https://github.com/rolldown/rolldown/issues/5695