### PR TITLE
chore(rollup-tests): skip occasionally failing test case

### DIFF
--- a/packages/rollup-tests/src/failed-tests.json
+++ b/packages/rollup-tests/src/failed-tests.json
@@ -1,3 +1,4 @@
 [
+  "rollup@function@emit-file@no-input: It is not necessary to provide an input if a dynamic entry is emitted",
   "rollup@function@es5-class-called-without-new: does not swallow type errors when running constructor functions without \"new\""
 ]

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,9 +1,9 @@
 {
   "failed": 0,
-  "skipFailed": 1,
+  "skipFailed": 2,
   "ignored": 15,
   "ignored(unsupported features)": 394,
   "ignored(treeshaking)": 282,
   "ignored(behavior passed, snapshot different)": 124,
-  "passed": 732
+  "passed": 731
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -1,9 +1,9 @@
 |  | number |
 |----| ---- |
 | failed | 0 |
-| skipFailed | 1 |
+| skipFailed | 2 |
 | ignored | 15 |
 | ignored(unsupported features) | 394 |
 | ignored(treeshaking) | 282 |
 | ignored(behavior passed, snapshot different) | 124 |
-| passed | 732 |
+| passed | 731 |


### PR DESCRIPTION
This test case occasionally fails on CI, so it is temporarily skipped. 

I suspect the cause is a data race between synchronous and asynchronous operations: on the NAPI side, `block_on` runs in NAPI’s async environment, while the `emitFile` logic inside Rolldown runs in Tokio’s async environment. This issue may be more likely to reproduce on lower-end machines.