### PR TITLE
refactor!: only call `closeBundle` hook when bundling actually happens

### DIFF
--- a/crates/rolldown_binding/src/binding_bundler_impl.rs
+++ b/crates/rolldown_binding/src/binding_bundler_impl.rs
@@ -144,7 +144,7 @@ impl BindingBundlerImpl {
   #[napi(getter)]
   #[tracing::instrument(level = "debug", skip_all)]
   pub fn get_closed(&self) -> napi::Result<bool> {
-    napi::bindgen_prelude::block_on(async { self.get_closed_impl().await })
+    Ok(napi::bindgen_prelude::block_on(async { self.inner.lock().await.closed }))
   }
 
   #[napi]
@@ -246,13 +246,6 @@ impl BindingBundlerImpl {
 
   pub fn into_inner(self) -> Arc<Mutex<NativeBundler>> {
     self.inner
-  }
-
-  #[allow(clippy::significant_drop_tightening)]
-  pub async fn get_closed_impl(&self) -> napi::Result<bool> {
-    let bundler_core = self.inner.lock().await;
-
-    Ok(bundler_core.closed)
   }
 
   fn handle_errors(

--- a/packages/rolldown/src/utils/create-bundler-option.ts
+++ b/packages/rolldown/src/utils/create-bundler-option.ts
@@ -22,7 +22,6 @@ export async function createBundlerOptions(
   inputOptions: InputOptions,
   outputOptions: OutputOptions,
   watchMode: boolean,
-  isClose?: boolean,
 ): Promise<BundlerOptionWithStopWorker> {
   const inputPlugins = await normalizePluginOption(inputOptions.plugins);
   const outputPlugins = await normalizePluginOption(outputOptions.plugins);
@@ -35,16 +34,14 @@ export async function createBundlerOptions(
     watchMode,
   );
 
-  if (!isClose) {
-    // The `outputOptions` hook is called with the input plugins and the output plugins
-    outputOptions = PluginDriver.callOutputOptionsHook(
-      [...inputPlugins, ...outputPlugins],
-      outputOptions,
-      onLog,
-      logLevel,
-      watchMode,
-    );
-  }
+  // The `outputOptions` hook is called with the input plugins and the output plugins
+  outputOptions = PluginDriver.callOutputOptionsHook(
+    [...inputPlugins, ...outputPlugins],
+    outputOptions,
+    onLog,
+    logLevel,
+    watchMode,
+  );
 
   const normalizedOutputPlugins = await normalizePluginOption(
     outputOptions.plugins,

--- a/packages/rolldown/src/utils/create-bundler.ts
+++ b/packages/rolldown/src/utils/create-bundler.ts
@@ -14,13 +14,11 @@ export async function createBundlerImpl(
   bundler: BindingBundler,
   inputOptions: InputOptions,
   outputOptions: OutputOptions,
-  isClose?: boolean,
 ): Promise<BundlerImplWithStopWorker> {
   const option = await createBundlerOptions(
     inputOptions,
     outputOptions,
     false,
-    isClose,
   );
 
   if (asyncRuntimeShutdown) {

--- a/packages/rolldown/tests/build-api/build-api.test.ts
+++ b/packages/rolldown/tests/build-api/build-api.test.ts
@@ -1,36 +1,38 @@
-import { test, expect } from 'vitest'
-import { rolldown } from 'rolldown'
-import path from 'node:path'
+import path from 'node:path';
+import { rolldown } from 'rolldown';
+import { expect, test } from 'vitest';
 
 test('rolldown write twice', async () => {
   const bundle = await rolldown({
     input: './main.js',
     cwd: import.meta.dirname,
-  })
+  });
   const esmOutput = await bundle.write({
     format: 'esm',
     entryFileNames: 'main.mjs',
-  })
-  expect(await bundle.watchFiles).toStrictEqual([path.join(import.meta.dirname, 'main.js')])
-  expect(esmOutput.output[0].fileName).toBe('main.mjs')
-  expect(esmOutput.output[0].code).toBeDefined()
+  });
+  expect(await bundle.watchFiles).toStrictEqual([
+    path.join(import.meta.dirname, 'main.js'),
+  ]);
+  expect(esmOutput.output[0].fileName).toBe('main.mjs');
+  expect(esmOutput.output[0].code).toBeDefined();
 
   const output = await bundle.write({
     format: 'iife',
     entryFileNames: 'main.js',
-  })
-  expect(output.output[0].fileName).toBe('main.js')
-  expect(output.output[0].code.includes('(function() {')).toBe(true)
-})
+  });
+  expect(output.output[0].fileName).toBe('main.js');
+  expect(output.output[0].code.includes('(function() {')).toBe(true);
+});
 
 test('rolldown concurrent write', async () => {
   const bundle = await rolldown({
     input: ['./main.js'],
     cwd: import.meta.dirname,
-  })
-  await write()
+  });
+  await write();
   // Execute twice
-  await write()
+  await write();
 
   async function write() {
     await Promise.all([
@@ -40,16 +42,81 @@ test('rolldown concurrent write', async () => {
         dir: './dist',
         entryFileNames: 'main.cjs',
       }),
-    ])
+    ]);
   }
-})
+});
 
 test('should support `Symbol.asyncDispose` of the rolldown bundle and set closed state to true', async () => {
   const bundle = await rolldown({
     input: ['./main.js'],
     cwd: import.meta.dirname,
-  })
+  });
+  await bundle.generate();
+  await bundle[Symbol.asyncDispose]();
+  expect(bundle.closed).toBe(true);
+});
 
-  await bundle[Symbol.asyncDispose]()
-  expect(bundle.closed).toBe(true)
-})
+test('passes errors from closeBundle hook', async () => {
+  let handledError = false;
+  try {
+    const bundle = await rolldown({
+      input: './main.js',
+      cwd: import.meta.dirname,
+      plugins: [
+        {
+          name: 'test',
+          closeBundle() {
+            this.error('close bundle error');
+          },
+        },
+      ],
+    });
+    await bundle.generate();
+    await bundle.close();
+  } catch (error: any) {
+    expect(error.message).toBe('close bundle error');
+    handledError = true;
+  } finally {
+    expect(handledError).toBeTruthy();
+  }
+});
+
+test('supports closeBundle hook', async () => {
+  let closeBundleCalls = 0;
+  try {
+    const bundle = await rolldown({
+      input: './main.js',
+      cwd: import.meta.dirname,
+      plugins: [
+        {
+          name: 'test',
+          closeBundle() {
+            closeBundleCalls++;
+          },
+        },
+      ],
+    });
+    await bundle.generate();
+    await bundle.close();
+  } finally {
+    expect(closeBundleCalls).toBe(1);
+  }
+});
+
+test('closeBundle hook is not called if closed directly', async () => {
+  await expect(async () => {
+    const bundle = await rolldown({
+      input: './main.js',
+      cwd: import.meta.dirname,
+      plugins: [
+        {
+          name: 'test',
+          closeBundle() {
+            this.error('close bundle error');
+          },
+        },
+      ],
+    });
+    await bundle.close();
+  }).not.toThrow()
+});

--- a/packages/rolldown/tests/build-api/build-api.test.ts
+++ b/packages/rolldown/tests/build-api/build-api.test.ts
@@ -104,7 +104,7 @@ test('supports closeBundle hook', async () => {
 });
 
 test('closeBundle hook is not called if closed directly', async () => {
-  await expect(async () => {
+  const task = async () => {
     const bundle = await rolldown({
       input: './main.js',
       cwd: import.meta.dirname,
@@ -118,5 +118,6 @@ test('closeBundle hook is not called if closed directly', async () => {
       ],
     });
     await bundle.close();
-  }).not.toThrow()
+  };
+  await expect(task()).resolves.not.toThrow()
 });

--- a/packages/rolldown/tests/error/error.test.ts
+++ b/packages/rolldown/tests/error/error.test.ts
@@ -93,6 +93,7 @@ describe('Plugin closeBundle hook', async () => {
         },
       ],
     })
+    await build.generate()
     await build.close()
     expect(closeBundleFn).toHaveBeenCalledTimes(1)
   })

--- a/packages/rollup-tests/src/ignored-tests.js
+++ b/packages/rollup-tests/src/ignored-tests.js
@@ -1,4 +1,9 @@
 const ignoreTests = [
+  // Integrate the test suite into Rolldown
+  // https://github.com/rolldown/rolldown/pull/5715
+  "rollup@hooks@passes errors from closeBundle hook",
+  "rollup@hooks@supports closeBundle hook",
+
   'rollup@function@bundle-facade-order: respects the order of entry points when there are additional facades for chunks', // https://github.com/rolldown/rolldown/issues/1842#issuecomment-2296345255
 
   // Ignore skipIfWindows test avoid test status error

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,9 +1,9 @@
 {
   "failed": 0,
   "skipFailed": 2,
-  "ignored": 15,
+  "ignored": 17,
   "ignored(unsupported features)": 394,
   "ignored(treeshaking)": 282,
   "ignored(behavior passed, snapshot different)": 124,
-  "passed": 731
+  "passed": 729
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -2,8 +2,8 @@
 |----| ---- |
 | failed | 0 |
 | skipFailed | 2 |
-| ignored | 15 |
+| ignored | 17 |
 | ignored(unsupported features) | 394 |
 | ignored(treeshaking) | 282 |
 | ignored(behavior passed, snapshot different) | 124 |
-| passed | 731 |
+| passed | 729 |


### PR DESCRIPTION
By default, `closed` is set to true. This is a difference from Rollup, because in Rolldown, `rolldown.rolldown` will not execute any build logic by default, and it will only initialize the bundler when `generate` or `write` is called.

### Why do this?

In Rollup, `rollup.rollup` runs a full build flow, triggering build hooks and caching results, so a bundler instance is always available to be closed later. In contrast, `rolldown.rolldown` only returns a JS-side object without initializing a Rust-side bundler. The bundler is only created when `generate` or `write` is called, which means no build hooks are triggered beforehand.

#### The previous logic had two issues I think:
1. It always created a new bundler just to call close, rather than closing the existing instance.
2. If no instance existed, it would still create one solely to trigger the `closeBundle` hook — but since no build hooks had been run, this was effectively meaningless.

This difference in architecture between Rollup and Rolldown means that blindly emulating Rollup’s behavior here was misleading. The original code’s sole purpose of triggering `closeBundle` without a preceding build doesn’t align with how Rolldown’s lifecycle works.