### PR TITLE
feat: concatenateWrappedModule

### DIFF
--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -1,6 +1,6 @@
 use rolldown_common::{
   ChunkIdx, ConstExportMeta, ImportRecordIdx, IndexModules, ModuleIdx, NormalModule,
-  RuntimeModuleBrief, SharedFileEmitter, SymbolRef, SymbolRefDb,
+  RenderedConcatenatedModuleParts, RuntimeModuleBrief, SharedFileEmitter, SymbolRef, SymbolRefDb,
 };
 
 use oxc::span::CompactStr;
@@ -32,4 +32,5 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub needs_hosted_top_level_binding: bool,
   pub module_namespace_included: bool,
   pub transferred_import_record: FxIndexMap<ImportRecordIdx, String>,
+  pub rendered_concatenated_wrapped_module_parts: RenderedConcatenatedModuleParts,
 }

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -1,10 +1,11 @@
+use itertools::Itertools;
 use oxc::allocator::FromIn;
-use oxc::span::Atom;
+use oxc::span::{Atom, CompactStr};
 use oxc::{
   allocator::{self, IntoIn, TakeIn},
   ast::{
     NONE,
-    ast::{self, BindingPatternKind, Expression, SimpleAssignmentTarget},
+    ast::{self, BindingPatternKind, Expression, SimpleAssignmentTarget, Statement},
     match_member_expression,
   },
   ast_visit::{VisitMut, walk_mut},
@@ -12,8 +13,10 @@ use oxc::{
   span::{SPAN, Span},
 };
 use rolldown_common::{
-  ExportsKind, ModuleNamespaceIncludedReason, SymbolRef, ThisExprReplaceKind, WrapKind,
+  ConcatenateWrappedModuleKind, ExportsKind, ModuleNamespaceIncludedReason, SymbolRef,
+  ThisExprReplaceKind, WrapKind,
 };
+use rolldown_ecmascript::ToSourceString;
 use rolldown_ecmascript_utils::{ExpressionExt, JsxExt};
 
 use crate::hmr::utils::HmrAstBuilder;
@@ -154,14 +157,10 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         ));
       }
       Some(WrapKind::Esm) => {
-        use ast::Statement;
-        let wrap_ref_name = self.canonical_name_for(self.ctx.linking_info.wrapper_ref.unwrap());
-        let esm_ref = if self.ctx.options.profiler_names {
-          self.canonical_ref_for_runtime("__esm")
-        } else {
-          self.canonical_ref_for_runtime("__esmMin")
-        };
-        let esm_ref_expr = self.finalized_expr_for_symbol_ref(esm_ref, false, false);
+        let is_concatenated_wrapped_module = !matches!(
+          self.ctx.linking_info.concatenated_wrapped_module_kind,
+          ConcatenateWrappedModuleKind::None
+        );
         let old_body = program.body.take_in(self.alloc);
 
         let mut fn_stmts = allocator::Vec::new_in(self.alloc);
@@ -184,9 +183,25 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
               stmts_inside_closure.push(stmt);
             }
           });
-        program.body.extend(declaration_of_module_namespace_object);
-        program.body.extend(fn_stmts);
-        if !self.top_level_var_bindings.is_empty() {
+
+        if is_concatenated_wrapped_module {
+          self.ctx.rendered_concatenated_wrapped_module_parts.hoisted_functions_or_module_ns_decl =
+            declaration_of_module_namespace_object
+              .iter()
+              .chain(fn_stmts.iter())
+              .map(rolldown_ecmascript::ToSourceString::to_source_string)
+              .collect_vec();
+          self.ctx.rendered_concatenated_wrapped_module_parts.hoisted_vars = self
+            .top_level_var_bindings
+            .iter()
+            .map(|var_name| CompactStr::new(var_name))
+            .collect_vec();
+        } else {
+          program.body.extend(declaration_of_module_namespace_object);
+          program.body.extend(fn_stmts);
+        }
+
+        if !is_concatenated_wrapped_module && !self.top_level_var_bindings.is_empty() {
           let builder = self.builder();
           let decorations = self.top_level_var_bindings.iter().map(|var_name| {
             builder.variable_declarator(
@@ -210,6 +225,36 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
             false,
           )));
         }
+
+        // The wrapping would happen during the chunk codegen phase
+        if matches!(
+          self.ctx.linking_info.concatenated_wrapped_module_kind,
+          ConcatenateWrappedModuleKind::Inner
+        ) {
+          program.body.extend(stmts_inside_closure);
+          return;
+        }
+
+        let esm_ref = if self.ctx.options.profiler_names {
+          self.canonical_ref_for_runtime("__esm")
+        } else {
+          self.canonical_ref_for_runtime("__esmMin")
+        };
+        let esm_ref_expr = self.finalized_expr_for_symbol_ref(esm_ref, false, false);
+        let wrap_ref_name = self.canonical_name_for(self.ctx.linking_info.wrapper_ref.unwrap());
+
+        if matches!(
+          self.ctx.linking_info.concatenated_wrapped_module_kind,
+          ConcatenateWrappedModuleKind::Root
+        ) {
+          self.ctx.rendered_concatenated_wrapped_module_parts.rendered_esm_runtime_expr =
+            Some(self.builder().expression_statement(SPAN, esm_ref_expr).to_source_string());
+          self.ctx.rendered_concatenated_wrapped_module_parts.wrap_ref_name =
+            Some(wrap_ref_name.clone());
+          program.body.extend(stmts_inside_closure);
+          return;
+        }
+
         program.body.push(self.snippet.esm_wrapper_stmt(
           wrap_ref_name,
           esm_ref_expr,

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -11,8 +11,9 @@ use rolldown_std_utils::OptionExt;
 use rustc_hash::FxHashMap;
 
 use rolldown_common::{
-  ChunkIdx, ChunkKind, CssAssetNameReplacer, ImportMetaRolldownAssetReplacer, ImportRecordIdx,
-  Module, ModuleIdx, PreliminaryFilename, PrependRenderedImport, RollupPreRenderedAsset,
+  ChunkIdx, ChunkKind, ConcatenateWrappedModuleKind, CssAssetNameReplacer,
+  ImportMetaRolldownAssetReplacer, ImportRecordIdx, Module, ModuleIdx, PreliminaryFilename,
+  PrependRenderedImport, RenderedConcatenatedModuleParts, RollupPreRenderedAsset,
 };
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_std_utils::{PathBufExt, PathExt, representative_file_name_for_preserve_modules};
@@ -64,6 +65,7 @@ impl<'a> GenerateStage<'a> {
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
+  #[allow(clippy::too_many_lines)]
   pub async fn generate(&mut self) -> BuildResult<BundleOutput> {
     self.plugin_driver.render_start(self.options).await?;
 
@@ -160,9 +162,19 @@ impl<'a> GenerateStage<'a> {
               idxs.into_iter().map(|idx| (idx, String::new())).collect::<FxIndexMap<_, _>>()
             })
             .unwrap_or_default(),
+          rendered_concatenated_wrapped_module_parts: RenderedConcatenatedModuleParts::default(),
         };
         let ctx = finalize_normal_module(ctx, ast, ast_scope);
-        (!ctx.transferred_import_record.is_empty()).then_some((idx, ctx.transferred_import_record))
+        (!ctx.transferred_import_record.is_empty()
+          || !matches!(
+            ctx.linking_info.concatenated_wrapped_module_kind,
+            ConcatenateWrappedModuleKind::None
+          ))
+        .then_some((
+          idx,
+          ctx.transferred_import_record,
+          ctx.rendered_concatenated_wrapped_module_parts,
+        ))
       })
       .collect::<Vec<_>>();
 
@@ -173,13 +185,28 @@ impl<'a> GenerateStage<'a> {
   fn apply_transfer_parts_mutation(
     &mut self,
     chunk_graph: &mut ChunkGraph,
-    transfer_parts_rendered_maps: Vec<(ModuleIdx, FxIndexMap<ImportRecordIdx, String>)>,
+    transfer_parts_rendered_maps: Vec<(
+      ModuleIdx,
+      FxIndexMap<ImportRecordIdx, String>,
+      RenderedConcatenatedModuleParts,
+    )>,
   ) {
     let mut normalized_transfer_parts_rendered_maps = FxHashMap::default();
-    for (idx, transferred_import_record) in transfer_parts_rendered_maps {
+    for (idx, transferred_import_record, rendered_concatenated_module_parts) in
+      transfer_parts_rendered_maps
+    {
       for (rec_idx, rendered_string) in transferred_import_record {
         normalized_transfer_parts_rendered_maps.insert((idx, rec_idx), rendered_string);
       }
+      let chunk_idx = chunk_graph.module_to_chunk[idx].expect("should have chunk idx");
+      let chunk = &mut chunk_graph.chunk_table[chunk_idx];
+      chunk
+        .module_idx_to_render_concatenated_module
+        .insert(idx, rendered_concatenated_module_parts);
+    }
+
+    if normalized_transfer_parts_rendered_maps.is_empty() {
+      return;
     }
     for chunk in chunk_graph.chunk_table.iter_mut() {
       for (module_idx, recs) in &chunk.insert_map {

--- a/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
@@ -1,24 +1,32 @@
 use std::collections::VecDeque;
 
-use rolldown_common::{Chunk, ChunkKind, EcmaViewMeta, ImportKind, ModuleIdx, WrapKind};
-use rustc_hash::FxHashSet;
+use rolldown_common::{
+  Chunk, ChunkKind, ConcatenateWrappedModuleKind, EcmaViewMeta, ImportKind, ModuleGroup, ModuleIdx,
+  WrapKind,
+};
+use rolldown_utils::rustc_hash::FxHashMapExt;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::chunk_graph::ChunkGraph;
 
 use super::GenerateStage;
 
 impl GenerateStage<'_> {
-  #[allow(clippy::too_many_lines)]
   #[tracing::instrument(level = "debug", skip_all)]
   pub fn on_demand_wrapping(&mut self, chunk_graph: &mut ChunkGraph) {
     // Currently, hmr is strongly rely on wrapping function to update module exports
-    if !self.options.experimental.is_on_demand_wrapping_enabled() || self.options.is_hmr_enabled() {
+    if !self.options.experimental.strict_execution_order.unwrap_or_default()
+      || !self.options.experimental.is_on_demand_wrapping_enabled()
+      || self.options.is_hmr_enabled()
+    {
       // If strict execution order is not enabled, we don't need to do on-demand wrapping.
       return;
     }
     for chunk in chunk_graph.chunk_table.iter_mut() {
       if matches!(chunk.kind, ChunkKind::EntryPoint { .. }) {
-        self.inline_entry_chunk_wrapping(chunk);
+        // self.inline_entry_chunk_wrapping(chunk);
+        self.concatenate_wrapping_modules(chunk);
+        // Needs to investigate how to merge these two optimization
       }
     }
   }
@@ -40,6 +48,7 @@ impl GenerateStage<'_> {
   /// - A commonjs module, a commonjs module can't not be safely eager eval.
   /// - A es module required by other module
   /// - All reachable modules of a boundary module in current chunk.
+  #[allow(unused)]
   fn inline_entry_chunk_wrapping(&mut self, chunk: &Chunk) {
     // All modules in entry chunk must be reachable from a entry module.
     let mut boundary_module = chunk
@@ -92,6 +101,7 @@ impl GenerateStage<'_> {
     }
   }
 
+  #[allow(unused)]
   fn expand_boundary(
     &self,
     boundary_modules: &mut FxHashSet<ModuleIdx>,
@@ -115,5 +125,111 @@ impl GenerateStage<'_> {
       }
     }
     *boundary_modules = visited;
+  }
+
+  fn concatenate_wrapping_modules(&mut self, chunk: &mut Chunk) {
+    // Those modules could only be a group root.
+    let mut root_only = chunk
+      .exports_to_other_chunks
+      .keys()
+      .map(|symbol| symbol.owner)
+      .collect::<FxHashSet<ModuleIdx>>();
+
+    let mut module_to_exec_order = FxHashMap::with_capacity(chunk.modules.len());
+    for module_idx in &chunk.modules {
+      module_to_exec_order
+        .insert(*module_idx, self.link_output.module_table[*module_idx].exec_order());
+      if matches!(self.link_output.metas[*module_idx].wrap_kind, WrapKind::Cjs | WrapKind::None) {
+        root_only.insert(*module_idx);
+      }
+    }
+    let mut module_groups = vec![];
+    let mut module_idx_to_group_idx = FxHashMap::default();
+    // higher exec_order usually means module is more closed to entry point
+    // lower exec_order means module is more closed to the leaf node of the chunk.
+    let mut visited = FxHashSet::default();
+    for module_idx in chunk.modules.iter().rev() {
+      if visited.contains(module_idx) {
+        continue;
+      }
+      if matches!(self.link_output.metas[*module_idx].wrap_kind, WrapKind::Cjs | WrapKind::None) {
+        // If the module is a cjs or none wrapped module, we can't concatenate it.
+        let group = ModuleGroup::new(vec![*module_idx], *module_idx);
+        module_idx_to_group_idx.insert(*module_idx, module_groups.len());
+        module_groups.push(group);
+        continue;
+      }
+
+      let mut group =
+        self.expand_module_group(&module_to_exec_order, &root_only, &mut visited, *module_idx);
+      let len = group.modules.len();
+
+      for idx in &group.modules {
+        if *idx != group.entry {
+          self.link_output.metas[*idx].concatenated_wrapped_module_kind =
+            ConcatenateWrappedModuleKind::Inner;
+        } else if len != 1 {
+          self.link_output.metas[*idx].concatenated_wrapped_module_kind =
+            ConcatenateWrappedModuleKind::Root;
+        }
+        module_idx_to_group_idx.insert(*idx, module_groups.len());
+      }
+      group.modules.sort_by_cached_key(|item| module_to_exec_order[item]);
+
+      module_groups.push(group);
+    }
+    module_groups.sort_by_cached_key(|group| module_to_exec_order[&group.entry]);
+    chunk.module_idx_to_group_idx = module_idx_to_group_idx;
+    chunk.module_groups = module_groups;
+  }
+
+  fn expand_module_group(
+    &self,
+    module_to_exec_order: &FxHashMap<ModuleIdx, u32>,
+    root_only: &FxHashSet<ModuleIdx>,
+    visited: &mut FxHashSet<ModuleIdx>,
+    entry: ModuleIdx,
+  ) -> ModuleGroup {
+    // This function is used to expand module group, so that we can concatenate
+    // all modules in the group.
+    let mut q = VecDeque::from_iter([entry]);
+    let mut groups = FxHashSet::default();
+    while let Some(module_idx) = q.pop_front() {
+      if !visited.insert(module_idx) {
+        continue;
+      }
+      groups.insert(module_idx);
+      for dep in self.link_output.metas[module_idx]
+        .dependencies
+        .iter()
+        .filter(|idx| module_to_exec_order.contains_key(idx) && !root_only.contains(idx))
+      {
+        q.push_back(*dep);
+      }
+    }
+
+    let mut prune_set = FxHashSet::default();
+    for module_idx in &groups {
+      let Some(module) = self.link_output.module_table[*module_idx].as_normal() else {
+        continue;
+      };
+      module
+        .importers_idx
+        .iter()
+        .filter(|importer_idx| {
+          // If the importer is not in the group, we can prune it.
+          !groups.contains(importer_idx) && module_to_exec_order.contains_key(importer_idx)
+        })
+        .for_each(|importer_idx| {
+          prune_set.insert(*importer_idx);
+        });
+    }
+
+    for module_idx in prune_set {
+      groups.remove(&module_idx);
+      visited.remove(&module_idx);
+    }
+
+    ModuleGroup { modules: groups.into_iter().collect(), entry }
   }
 }

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -1,9 +1,9 @@
 use oxc::span::CompactStr;
 use oxc_index::IndexVec;
 use rolldown_common::{
-  EntryPointKind, ImportRecordIdx, MemberExprRefResolutionMap, ModuleIdx,
-  ModuleNamespaceIncludedReason, ResolvedExport, RuntimeHelper, StmtInfoIdx, SymbolRef, WrapKind,
-  dynamic_import_usage::DynamicImportExportsUsage,
+  ConcatenateWrappedModuleKind, EntryPointKind, ImportRecordIdx, MemberExprRefResolutionMap,
+  ModuleIdx, ModuleNamespaceIncludedReason, ResolvedExport, RuntimeHelper, StmtInfoIdx, SymbolRef,
+  WrapKind, dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -61,6 +61,7 @@ pub struct LinkingMetadata {
   pub resolved_member_expr_refs: MemberExprRefResolutionMap,
   pub star_exports_from_external_modules: Vec<ImportRecordIdx>,
   pub is_tla_or_contains_tla_dependency: bool,
+  pub concatenated_wrapped_module_kind: ConcatenateWrappedModuleKind,
   /// Used to to track a facade binding referenced cjs module
   /// included reexport symbol from commonjs module
   pub named_import_to_cjs_module: FxHashMap<SymbolRef, ModuleIdx>,

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/_config.json
@@ -8,6 +8,5 @@
     {
       "onDemandWrapping": true
     }
-  ],
-  "expectExecuted": false
+  ]
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
@@ -1,0 +1,77 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+// HIDDEN [rolldown:runtime]
+//#region setup.js
+var init_setup = __esm({ "setup.js": (() => {
+	globalThis.globalValue = "foo";
+}) });
+
+//#endregion
+//#region foo_inner.js
+var foo_inner_default;
+var init_foo_inner = __esm({ "foo_inner.js": (() => {
+	foo_inner_default = { foo: /* @__PURE__ */ (() => globalValue)() };
+}) });
+
+//#endregion
+//#region foo.js
+var init_foo = __esm({ "foo.js": (() => {
+	init_foo_inner();
+	assert.strictEqual(foo_inner_default.foo, "foo");
+}) });
+
+//#endregion
+//#region main.js
+var init_main = __esm({ "main.js": (() => {
+	init_setup();
+	init_foo();
+	init_foo_inner();
+	assert.equal(foo_inner_default.foo, "foo");
+}) });
+
+//#endregion
+init_main();
+```
+---
+
+Variant: [on_demand_wrapping: true]
+
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+// HIDDEN [rolldown:runtime]
+
+var foo_inner_default;
+var init_main = __esm({"main.js": () => {
+//#region setup.js
+globalThis.globalValue = "foo";
+
+//#endregion
+//#region foo_inner.js
+foo_inner_default = { foo: /* @__PURE__ */ (() => globalValue)() };
+
+//#endregion
+//#region foo.js
+assert.strictEqual(foo_inner_default.foo, "foo");
+
+//#endregion
+//#region main.js
+assert.equal(foo_inner_default.foo, "foo");
+
+//#endregion
+}});
+
+init_main();
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/foo.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/foo.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert'
+import inner from './foo_inner.js';
+
+assert.strictEqual(inner.foo, 'foo');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/foo_inner.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/foo_inner.js
@@ -1,0 +1,3 @@
+export default {
+  foo: /* #__PURE__ */ (() => globalValue)(),
+};

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/main.js
@@ -1,0 +1,6 @@
+import assert from 'node:assert'
+import './setup.js';
+import './foo.js';
+import v from './foo_inner.js'
+assert.equal(v.foo, 'foo');
+

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/setup.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/setup.js
@@ -1,0 +1,1 @@
+globalThis.globalValue = 'foo';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
@@ -97,12 +97,18 @@ import nodeAssert from "node:assert";
 const value$1 = "";
 
 //#endregion
+
+var value;
+var init_main = __esm({"main.js": () => {
 //#region lib-foo.js
-const value = "foo" + value$1;
+value = "foo" + value$1;
 
 //#endregion
 //#region main.js
 nodeAssert.equal(value, "foo");
 
 //#endregion
+}});
+
+init_main();
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
@@ -49,19 +49,18 @@ var require_dep_a = /* @__PURE__ */ __commonJS({ "dep-a.js": ((exports, module) 
 }) });
 
 //#endregion
+
+var import_dep_a;
+var init_main = __esm({"main.js": () => {
 //#region dep-b.js
-var init_dep_b = __esm({ "dep-b.js": (() => {
-	sideEffect.touched = true;
-}) });
+sideEffect.touched = true;
 
 //#endregion
 //#region main.js
-var import_dep_a;
-var init_main = __esm({ "main.js": (() => {
-	import_dep_a = /* @__PURE__ */ __toESM(require_dep_a());
-	init_dep_b();
-}) });
+import_dep_a = /* @__PURE__ */ __toESM(require_dep_a());
 
 //#endregion
+}});
+
 init_main();
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
@@ -41,20 +41,22 @@ Variant: [on_demand_wrapping: true]
 import nodeAssert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
-//#region dep.js
 function foo() {
 	globalThis.value = 1;
 }
+
 var dep_default;
-var init_dep = __esm({ "dep.js": (() => {
-	dep_default = /* @__PURE__ */ foo();
-}) });
+var init_main = __esm({"main.js": () => {
+//#region dep.js
+dep_default = /* @__PURE__ */ foo();
 
 //#endregion
 //#region main.js
-init_dep();
 nodeAssert.strictEqual(globalThis.value, 1);
 
 //#endregion
+}});
+
+init_main();
 export { dep_default as dep };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/artifacts.snap
@@ -9,6 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 import { __esm } from "./rolldown-runtime.js";
 import { init_foo } from "./test.js";
 
+
+var init_main = __esm({"main.js": () => {
 //#region setup.js
 globalThis.globalValue = "foo";
 
@@ -17,6 +19,9 @@ globalThis.globalValue = "foo";
 init_foo();
 
 //#endregion
+}});
+
+init_main();
 ```
 ## rolldown-runtime.js
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/_config.json
@@ -14,5 +14,6 @@
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     }
-  }
+  },
+  "expectExecuted": false
 }

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/artifacts.snap
@@ -30,31 +30,27 @@ export { __esm, __toESM, require_dynamic };
 import { __esm, __toESM, require_dynamic } from "./dynamic2.js";
 import { strictEqual } from "node:assert";
 
-//#region sideeffects.js
-var init_sideeffects = __esm({ "sideeffects.js": (() => {
-	globalThis.a = 2;
-}) });
-
-//#endregion
-//#region esm.js
-var import_dynamic, a;
-var init_esm = __esm({ "esm.js": (() => {
-	import_dynamic = /* @__PURE__ */ __toESM(require_dynamic());
-	init_sideeffects();
-	a = globalThis.a;
-	strictEqual(a, 2);
-}) });
-
-//#endregion
-//#region cjs.js
-init_esm();
 function foo() {
 	return 100;
 }
+
+var import_dynamic, a;
+var init_main = __esm({"main.js": () => {
+//#region sideeffects.js
+globalThis.a = 2;
+
+//#endregion
+//#region esm.js
+import_dynamic = /* @__PURE__ */ __toESM(require_dynamic());
+a = globalThis.a;
+strictEqual(a, 2);
 
 //#endregion
 //#region main.js
 console.log(`mod.foo: `, foo);
 
 //#endregion
+}});
+
+init_main();
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4030,6 +4030,10 @@ expression: output
 
 - main-!~{000}~.js => main-iGXOFHWU.js
 
+# tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules
+
+- main-!~{000}~.js => main-DZgJ4wKa.js
+
 # tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict
 
 - main-!~{000}~.js => main-C9tRYJu-.js
@@ -4086,14 +4090,14 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_5303
 
-- main-!~{000}~.js => main-DO3NAFWR.js
+- main-!~{000}~.js => main-DIm8iZ1a.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BjtMze0h.js
 - test-!~{003}~.js => test-DWjb2zYB.js
 
 # tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping
 
 - dynamic-!~{001}~.js => dynamic-BhqYqd04.js
-- main-!~{000}~.js => main-BiFMWJtk.js
+- main-!~{000}~.js => main-CloeuwD0.js
 - dynamic-!~{002}~.js => dynamic-DKjUd_a-.js
 
 # tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -5,8 +5,9 @@ use std::{
 
 use crate::{
   ChunkIdx, ChunkKind, FilenameTemplate, ImportRecordIdx, ModuleIdx, ModuleTable, NamedImport,
-  NormalModule, NormalizedBundlerOptions, PreserveEntrySignatures, RollupPreRenderedChunk,
-  RuntimeHelper, SymbolRef, chunk::types::chunk_reason_type::ChunkReasonType,
+  NormalModule, NormalizedBundlerOptions, PreserveEntrySignatures, RenderedConcatenatedModuleParts,
+  RollupPreRenderedChunk, RuntimeHelper, SymbolRef,
+  chunk::types::{chunk_reason_type::ChunkReasonType, module_group::ModuleGroup},
 };
 pub mod chunk_table;
 pub mod types;
@@ -76,6 +77,10 @@ pub struct Chunk {
   pub insert_map: FxHashMap<ModuleIdx, Vec<(ModuleIdx, ImportRecordIdx)>>,
   pub remove_map: FxHashMap<ModuleIdx, Vec<ImportRecordIdx>>,
   pub transformed_parts_rendered: FxIndexMap<(ModuleIdx, ImportRecordIdx), String>,
+  pub module_groups: Vec<ModuleGroup>,
+  pub module_idx_to_group_idx: FxHashMap<ModuleIdx, usize>,
+  pub module_idx_to_render_concatenated_module:
+    FxHashMap<ModuleIdx, RenderedConcatenatedModuleParts>,
 }
 
 impl Chunk {

--- a/crates/rolldown_common/src/chunk/types/mod.rs
+++ b/crates/rolldown_common/src/chunk/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod chunk_reason_type;
 pub mod cross_chunk_import_item;
+pub mod module_group;
 pub mod preliminary_filename;
 
 pub struct AddonRenderContext<'code> {

--- a/crates/rolldown_common/src/chunk/types/module_group.rs
+++ b/crates/rolldown_common/src/chunk/types/module_group.rs
@@ -1,0 +1,29 @@
+use crate::ModuleIdx;
+#[cfg(debug_assertions)]
+use crate::ModuleTable;
+
+#[derive(Debug, Clone)]
+pub struct ModuleGroup {
+  pub modules: Vec<ModuleIdx>,
+  // TODO: maybe we could remove this since the entry module of a module group
+  // should always be the last module after the module group sorted by execution order.
+  pub entry: ModuleIdx,
+}
+
+impl ModuleGroup {
+  pub fn new(modules: Vec<ModuleIdx>, entry: ModuleIdx) -> Self {
+    Self { modules, entry }
+  }
+
+  #[cfg(debug_assertions)]
+  #[track_caller]
+  #[allow(clippy::print_stdout)]
+  pub fn debug_module_group(&self, module_table: &ModuleTable) {
+    let caller = std::panic::Location::caller();
+    println!("[{}:{}] Debugging module group:", caller.file(), caller.line());
+    for module_idx in &self.modules {
+      let module = &module_table[*module_idx];
+      println!("{}", &module.stable_id());
+    }
+  }
+}

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -76,7 +76,8 @@ pub use crate::{
     chunk_table::ChunkTable,
     types::{
       AddonRenderContext, chunk_reason_type::ChunkReasonType,
-      cross_chunk_import_item::CrossChunkImportItem, preliminary_filename::PreliminaryFilename,
+      cross_chunk_import_item::CrossChunkImportItem, module_group::ModuleGroup,
+      preliminary_filename::PreliminaryFilename,
     },
   },
   css::{
@@ -119,6 +120,9 @@ pub use crate::{
   types::bundler_file_system::BundlerFileSystem,
   types::chunk_idx::ChunkIdx,
   types::chunk_kind::ChunkKind,
+  types::concatenate_wrapped_module::{
+    ConcatenateWrappedModuleKind, RenderedConcatenatedModuleParts,
+  },
   types::constant_value::{ConstExportMeta, ConstantValue},
   types::deconflict::ModuleScopeSymbolIdMap,
   types::defer_sync_scan_data::DeferSyncScanData,

--- a/crates/rolldown_common/src/types/concatenate_wrapped_module.rs
+++ b/crates/rolldown_common/src/types/concatenate_wrapped_module.rs
@@ -1,0 +1,23 @@
+use oxc::span::CompactStr;
+
+/// We only concatenate wrapped modules when `WrapKind` is `Esm`
+#[derive(Debug, Clone, Copy, Default)]
+pub enum ConcatenateWrappedModuleKind {
+  /// The len of module group of the module should be greater equal than 2
+  /// The module is the root of the module group
+  Root,
+  /// Just a normal esm wrapped module  
+  #[default]
+  None,
+  /// The len of module group of the module should be greater equal than 2
+  /// The module is the inner module of the module group
+  Inner,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RenderedConcatenatedModuleParts {
+  pub hoisted_vars: Vec<CompactStr>,
+  pub hoisted_functions_or_module_ns_decl: Vec<String>,
+  pub wrap_ref_name: Option<CompactStr>,
+  pub rendered_esm_runtime_expr: Option<String>,
+}

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -5,6 +5,7 @@ pub mod ast_scopes;
 pub mod bundler_file_system;
 pub mod chunk_idx;
 pub mod chunk_kind;
+pub mod concatenate_wrapped_module;
 pub mod constant_value;
 pub mod deconflict;
 pub mod defer_sync_scan_data;


### PR DESCRIPTION
The basic idea is try to find those single-entry isolated subgraphs that wrapKind is `esm` .
The definition of an ESM single-entry isolated subgraph: 
All inner module of the moduleGroup can only be reachable in the graph from the root of the module group.