### PR TITLE
refactor: private fields `wrap_kind` and `original_wrap_kind` and keep them sync

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -87,7 +87,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       .linking_info
       .wrapper_stmt_info
       .is_some_and(|idx| self.ctx.module.stmt_infos[idx].is_included)
-      .then_some(self.ctx.linking_info.wrap_kind);
+      .then_some(self.ctx.linking_info.wrap_kind());
 
     self.ctx.needs_hosted_top_level_binding = matches!(included_wrap_kind, Some(WrapKind::Esm));
 

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -95,7 +95,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       return true;
     };
     let importee_linking_info = &self.ctx.linking_infos[importee.idx];
-    match importee_linking_info.wrap_kind {
+    match importee_linking_info.wrap_kind() {
       WrapKind::None => {
         // Remove this statement by ignoring it
       }
@@ -106,7 +106,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         // ```
         if rec.meta.contains(ImportRecordMeta::SafelyMergeCjsNs)
           // TODO: merge cjs namepspace in module group level
-          && self.ctx.linking_infos[self.ctx.module.idx].wrap_kind.is_none()
+          && self.ctx.linking_infos[self.ctx.module.idx].wrap_kind().is_none()
         {
           let chunk_idx = self.ctx.chunk_id;
           if let Some(symbol_ref_to_be_merged) =
@@ -865,7 +865,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       match &self.ctx.modules[importee_id] {
         Module::Normal(importee) => {
           let importee_linking_info = &self.ctx.linking_infos[importee_id];
-          let new_expr = match importee_linking_info.wrap_kind {
+          let new_expr = match importee_linking_info.wrap_kind() {
             WrapKind::Esm => {
               // Rewrite `import('./foo.mjs')` to `(init_foo(), foo_exports)`
               let importee_linking_info = &self.ctx.linking_infos[importee_id];
@@ -1025,7 +1025,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             match &self.ctx.modules[rec.resolved_module] {
               Module::Normal(importee) => {
                 let importee_linking_info = &self.ctx.linking_infos[importee.idx];
-                if matches!(importee_linking_info.wrap_kind, WrapKind::Esm) {
+                if matches!(importee_linking_info.wrap_kind(), WrapKind::Esm) {
                   let wrapper_ref_name =
                     self.canonical_name_for(importee_linking_info.wrapper_ref.unwrap());
                   program.body.push(self.snippet.call_expr_stmt(wrapper_ref_name));

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -294,7 +294,7 @@ impl GenerateStage<'_> {
         let mut none_wrapped_module_to_wrapped_dependency_length = FxHashMap::default();
         let js_import_order = self.js_import_order(*entry_module, &chunk_module_to_exec_order);
         for idx in js_import_order {
-          match self.link_output.metas[idx].wrap_kind {
+          match self.link_output.metas[idx].original_wrap_kind() {
             WrapKind::None => {
               if !wrapped_modules.is_empty() {
                 none_wrapped_module_to_wrapped_dependency_length.insert(idx, wrapped_modules.len());
@@ -347,7 +347,7 @@ impl GenerateStage<'_> {
           FxHashMap::default();
         let mut remove_map: FxHashMap<ModuleIdx, Vec<ImportRecordIdx>> = FxHashMap::default();
         for (module_idx, (importer_idx, rec_idx)) in module_init_position {
-          match self.link_output.metas[module_idx].wrap_kind {
+          match self.link_output.metas[module_idx].original_wrap_kind() {
             WrapKind::None => {
               if let Some(deps_length) =
                 none_wrapped_module_to_wrapped_dependency_length.get(&module_idx)
@@ -409,7 +409,7 @@ impl GenerateStage<'_> {
         .iter()
         .filter(|item| {
           self.link_output.module_table[item.owner].as_normal().unwrap().is_included()
-            && self.link_output.metas[item.owner].wrap_kind.is_none()
+            && self.link_output.metas[item.owner].wrap_kind().is_none()
         })
         // Determine safely merged cjs ns binding should put in where
         // We should put it in the importRecord which first reference the cjs ns binding.

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -255,7 +255,7 @@ impl GenerateStage<'_> {
           let entry = &self.link_output.module_table[*entry_id].as_normal().unwrap();
           let entry_meta = &self.link_output.metas[entry.idx];
 
-          if !matches!(entry_meta.wrap_kind, WrapKind::Cjs) {
+          if !matches!(entry_meta.wrap_kind(), WrapKind::Cjs) {
             for export_ref in entry_meta
               .resolved_exports
               .values()
@@ -272,7 +272,7 @@ impl GenerateStage<'_> {
             }
           }
 
-          if !matches!(entry_meta.wrap_kind, WrapKind::None) {
+          if !matches!(entry_meta.wrap_kind(), WrapKind::None) {
             depended_symbols
               .insert(entry_meta.wrapper_ref.expect("cjs should be wrapped in esm output"));
           }

--- a/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
@@ -77,7 +77,7 @@ impl GenerateStage<'_> {
         let Some(normal) = self.link_output.module_table[rec.resolved_module].as_normal() else {
           continue;
         };
-        if self.link_output.metas[normal.idx].wrap_kind == WrapKind::Cjs
+        if self.link_output.metas[normal.idx].wrap_kind() == WrapKind::Cjs
           && normal.meta.contains(EcmaViewMeta::ExecutionOrderSensitive)
         {
           bailout_importer = true;
@@ -95,8 +95,8 @@ impl GenerateStage<'_> {
         // If the module is a boundary module, we can't inline it.
         continue;
       }
-      if self.link_output.metas[*module_idx].wrap_kind == WrapKind::Esm {
-        self.link_output.metas[*module_idx].wrap_kind = WrapKind::None;
+      if self.link_output.metas[*module_idx].wrap_kind() == WrapKind::Esm {
+        self.link_output.metas[*module_idx].update_wrap_kind(WrapKind::None);
       }
     }
   }
@@ -139,7 +139,7 @@ impl GenerateStage<'_> {
     for module_idx in &chunk.modules {
       module_to_exec_order
         .insert(*module_idx, self.link_output.module_table[*module_idx].exec_order());
-      if matches!(self.link_output.metas[*module_idx].wrap_kind, WrapKind::Cjs | WrapKind::None) {
+      if matches!(self.link_output.metas[*module_idx].wrap_kind(), WrapKind::Cjs | WrapKind::None) {
         root_only.insert(*module_idx);
       }
     }
@@ -152,7 +152,7 @@ impl GenerateStage<'_> {
       if visited.contains(module_idx) {
         continue;
       }
-      if matches!(self.link_output.metas[*module_idx].wrap_kind, WrapKind::Cjs | WrapKind::None) {
+      if matches!(self.link_output.metas[*module_idx].wrap_kind(), WrapKind::Cjs | WrapKind::None) {
         // If the module is a cjs or none wrapped module, we can't concatenate it.
         let group = ModuleGroup::new(vec![*module_idx], *module_idx);
         module_idx_to_group_idx.insert(*module_idx, module_groups.len());

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -22,7 +22,7 @@ fn init_entry_point_stmt_info(
   let mut referenced_symbols = vec![];
 
   // Include the wrapper if present
-  if !matches!(meta.wrap_kind, WrapKind::None) {
+  if !matches!(meta.wrap_kind(), WrapKind::None) {
     // If a commonjs module becomes an entry point while targeting esm, we need to at least add a `export default require_foo();`
     // statement as some kind of syntax sugar. So users won't need to manually create a proxy file with `export default require('./foo.cjs')` in it.
     referenced_symbols.push((meta.wrapper_ref.unwrap(), false));

--- a/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
+++ b/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
@@ -32,13 +32,13 @@ impl LinkStage<'_> {
           }
           ImportKind::Require => match importee.exports_kind {
             ExportsKind::Esm => {
-              self.metas[importee.idx].wrap_kind = WrapKind::Esm;
+              self.metas[importee.idx].sync_wrap_kind(WrapKind::Esm);
             }
             ExportsKind::CommonJs => {
-              self.metas[importee.idx].wrap_kind = WrapKind::Cjs;
+              self.metas[importee.idx].sync_wrap_kind(WrapKind::Cjs);
             }
             ExportsKind::None => {
-              self.metas[importee.idx].wrap_kind = WrapKind::Cjs;
+              self.metas[importee.idx].sync_wrap_kind(WrapKind::Cjs);
               // SAFETY: If `importee` and `importer` are different, so this is safe. If they are the same, then behaviors are still expected.
               // A module with `ExportsKind::None` that `require` self should be turned into `ExportsKind::CommonJs`.
               unsafe {
@@ -53,13 +53,13 @@ impl LinkStage<'_> {
               // returns a promise, so the imported file must also be wrapped
               match importee.exports_kind {
                 ExportsKind::Esm => {
-                  self.metas[importee.idx].wrap_kind = WrapKind::Esm;
+                  self.metas[importee.idx].sync_wrap_kind(WrapKind::Esm);
                 }
                 ExportsKind::CommonJs => {
-                  self.metas[importee.idx].wrap_kind = WrapKind::Cjs;
+                  self.metas[importee.idx].sync_wrap_kind(WrapKind::Cjs);
                 }
                 ExportsKind::None => {
-                  self.metas[importee.idx].wrap_kind = WrapKind::Cjs;
+                  self.metas[importee.idx].sync_wrap_kind(WrapKind::Cjs);
                   // SAFETY: If `importee` and `importer` are different, so this is safe. If they are the same, then behaviors are still expected.
                   // A module with `ExportsKind::None` that `require` self should be turned into `ExportsKind::CommonJs`.
                   unsafe {
@@ -84,7 +84,7 @@ impl LinkStage<'_> {
       if matches!(importer.exports_kind, ExportsKind::CommonJs)
         && (!is_entry || matches!(self.options.format, OutputFormat::Esm))
       {
-        self.metas[importer.idx].wrap_kind = WrapKind::Cjs;
+        self.metas[importer.idx].sync_wrap_kind(WrapKind::Cjs);
       }
     });
   }

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -267,7 +267,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   // for a es json module it did not needs to be wrapped anyway.
   link_staged.metas[module_idx].wrapper_stmt_info = None;
   link_staged.metas[module_idx].wrapper_ref = None;
-  link_staged.metas[module_idx].wrap_kind = WrapKind::None;
+  link_staged.metas[module_idx].sync_wrap_kind(WrapKind::None);
 
   link_staged.symbols.store_local_db(module_idx, symbol_ref_db);
   true

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -120,8 +120,9 @@ impl<'a> LinkStage<'a> {
         .module_table
         .modules
         .iter()
-        .map(|module| LinkingMetadata {
-          dependencies: module
+        .map(|module| {
+          let mut meta = LinkingMetadata::default();
+          meta.dependencies = module
             .import_records()
             .iter()
             .filter_map(|rec| match rec.kind {
@@ -131,13 +132,13 @@ impl<'a> LinkStage<'a> {
               ImportKind::Require => None,
               _ => Some(rec.resolved_module),
             })
-            .collect(),
-          star_exports_from_external_modules: module.as_normal().map_or(vec![], |inner| {
+            .collect();
+          meta.star_exports_from_external_modules = module.as_normal().map_or(vec![], |inner| {
             inner
               .star_exports_from_external_modules(&scan_stage_output.module_table.modules)
               .collect()
-          }),
-          ..LinkingMetadata::default()
+          });
+          meta
         })
         .collect::<IndexVec<ModuleIdx, _>>(),
       module_table: scan_stage_output.module_table,

--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -103,7 +103,7 @@ impl LinkStage<'_> {
                 match rec.kind {
                   ImportKind::Import => {
                     let is_reexport_all = rec.meta.contains(ImportRecordMeta::IsExportStar);
-                    match importee_linking_info.wrap_kind {
+                    match importee_linking_info.wrap_kind() {
                       WrapKind::None => {
                         // for case:
                         // ```js
@@ -191,7 +191,7 @@ impl LinkStage<'_> {
                       }
                     }
                   }
-                  ImportKind::Require => match importee_linking_info.wrap_kind {
+                  ImportKind::Require => match importee_linking_info.wrap_kind() {
                     WrapKind::None => {}
                     WrapKind::Cjs => {
                       // something like `require_foo()`
@@ -216,7 +216,7 @@ impl LinkStage<'_> {
                   },
                   ImportKind::DynamicImport => {
                     if self.options.inline_dynamic_imports {
-                      match importee_linking_info.wrap_kind {
+                      match importee_linking_info.wrap_kind() {
                         WrapKind::None => {}
                         WrapKind::Cjs => {
                           //  `__toESM(require_foo())`

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -22,7 +22,7 @@ pub fn render_wrapped_entry_chunk(
 ) -> Option<String> {
   if let ChunkKind::EntryPoint { module: entry_id, .. } = ctx.chunk.kind {
     let entry_meta = &ctx.link_output.metas[entry_id];
-    match entry_meta.wrap_kind {
+    match entry_meta.wrap_kind() {
       WrapKind::Esm => {
         let wrapper_ref = entry_meta.wrapper_ref.as_ref().unwrap();
         // init_xxx
@@ -296,7 +296,7 @@ pub fn get_export_items(chunk: &Chunk) -> Vec<(CompactStr, SymbolRef)> {
 pub fn get_chunk_export_names(chunk: &Chunk, graph: &LinkStageOutput) -> Vec<CompactStr> {
   if let ChunkKind::EntryPoint { module: entry_id, .. } = &chunk.kind {
     let entry_meta = &graph.metas[*entry_id];
-    if matches!(entry_meta.wrap_kind, WrapKind::Cjs) {
+    if matches!(entry_meta.wrap_kind(), WrapKind::Cjs) {
       return vec![CompactStr::new("default")];
     }
   }
@@ -308,7 +308,7 @@ pub fn get_chunk_export_names_with_ctx(ctx: &GenerateContext<'_>) -> Vec<Compact
   let GenerateContext { chunk, link_output, render_export_items_index_vec, .. } = ctx;
   if let ChunkKind::EntryPoint { module: entry_id, .. } = &chunk.kind {
     let entry_meta = &link_output.metas[*entry_id];
-    if matches!(entry_meta.wrap_kind, WrapKind::Cjs) {
+    if matches!(entry_meta.wrap_kind(), WrapKind::Cjs) {
       return vec![CompactStr::new("default")];
     }
   }


### PR DESCRIPTION
private two fields and expose a limited function to mutate `wrap_kind` and `original_wrap_kind` so we could make sure they are synced except for some special scenarios. 
For now, they are: 
1. override `wrap_kind` when `strictExecutionOrder` is enabled.
2. update inner module of moduleGroup when concatenateWrappedmodules