### PR TITLE
perf(rolldown_plugin_reporter): gzip size computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1379,6 +1380,15 @@ dependencies = [
  "bitflags 2.9.1",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3046,6 +3056,7 @@ dependencies = [
  "flate2",
  "itoa",
  "num-format",
+ "rayon",
  "rolldown_common",
  "rolldown_plugin",
  "sugar_path",
@@ -4341,3 +4352,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ dashmap = "6.1.0"
 derive_more = { version = "2.0.1", features = ["debug"] }
 dunce = "1.0.5" # Normalize Windows paths to the most compatible format, avoiding UNC where possible
 fast-glob = "1.0.0"
-flate2 = "1.1.1"
+flate2 = { version = "1.1.1", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
 futures = "0.3.31"
 glob = "0.3.2"

--- a/crates/rolldown_plugin_reporter/Cargo.toml
+++ b/crates/rolldown_plugin_reporter/Cargo.toml
@@ -19,6 +19,7 @@ cow-utils = { workspace = true }
 flate2 = { workspace = true }
 itoa = { workspace = true }
 num-format = { workspace = true }
+rayon = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
 sugar_path = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -91,6 +91,7 @@ allow = [
   "MIT-0",
   "CC0-1.0",
   "BSD-2-Clause",
+  "Zlib",
   # "Apache-2.0 WITH LLVM-exception",
 ]
 # Lint level for licenses considered copyleft


### PR DESCRIPTION
> [!note]
> - bench case: **apps/10000** 20000+ modules.
> - configuration: advanced-chunks + disabled minify


# Before
I noticed that the gzip size computation costs a lot of time in rolldown-vite, in my local computer, it takes 158ms to compute gzip size(total building time takes about 750ms)
<img width="2514" height="1316" alt="image" src="https://github.com/user-attachments/assets/4d315d60-20f6-4fd4-a384-193c8b53c957" />

```bash
rolldown-vite v7.0.12 building for production...
✓ 20014 modules transformed.
vite-dist/index.html                               0.62 kB │ gzip:   0.34 kB
vite-dist/assets/rolldown-runtime-DWGyDpL3.js      1.12 kB │ gzip:   0.55 kB
vite-dist/assets/react-jrohfdTy.js               207.41 kB │ gzip:  54.06 kB
vite-dist/assets/index-BROXgPrc.js             3,901.62 kB │ gzip: 323.08 kB
vite-dist/assets/other-libs-BVAwKXhJ.js        6,680.16 kB │ gzip: 938.17 kB
✓ built in 755ms
```



# After
<img width="2514" height="1316" alt="image" src="https://github.com/user-attachments/assets/429300ce-d604-4d6e-9616-87d4231a7f5f" />

```bash
rolldown-vite v7.0.12 building for production...
✓ 20014 modules transformed.
vite-dist/index.html                               0.62 kB │ gzip:   0.34 kB
vite-dist/assets/rolldown-runtime-DWGyDpL3.js      1.12 kB │ gzip:   0.56 kB
vite-dist/assets/react-jrohfdTy.js               207.41 kB │ gzip:  54.25 kB
vite-dist/assets/index-BUf1zkMf.js             3,901.62 kB │ gzip: 323.61 kB
vite-dist/assets/other-libs-BVAwKXhJ.js        6,680.16 kB │ gzip: 938.11 kB
✓ built in 648ms
```
The size after gzip is almost identical; it should be alright to have a little difference since it's just a gzip size used for reference.