### PR TITLE
feat(rollup-test): log error when `pringStatus`

### DIFF
--- a/packages/rollup-tests/src/intercept/check.js
+++ b/packages/rollup-tests/src/intercept/check.js
@@ -3,7 +3,7 @@ const expectedStatus = require('../status.json');
 const alreadyFailedTests = new Set(loadFailedTests())
 
 /**
- * @type {Set<string>}
+ * @type {Set<{name: string, err: Error | undefined}>}
  */
 const failedTests = new Set()
 
@@ -42,15 +42,20 @@ afterEach(function updateStatus() {
   if (state === 'failed') {
     console.error(this.currentTest.err)
     status.failed += 1
-    failedTests.add(calcTestId(this.currentTest))
+    failedTests.add({ name: calcTestId(this.currentTest), err: this.currentTest.err })
   } else if (state === 'passed') {
     status.passed += 1
   }
 })
 
 after(function printStatus() {
-  const sorted = [...failedTests].sort()
-  console.log('failures', JSON.stringify(sorted, null, 2))
+  const sorted = [...failedTests].sort((a, b) => a.name.localeCompare(b.name))
+  sorted.forEach(failure => {
+    console.log(failure.name)
+    console.error(failure.err)
+    console.log("\n")
+  })
+  console.log('failures', JSON.stringify(sorted.map(v => v.name), null, 2))
   console.table(status)
   if (status.failed > 0) {
     // enforce exit process to avoid rust process is not exit.


### PR DESCRIPTION
Print error after tests are all completed for better dev experience, if there is any error, to avoid searching for error in the extensive terminal output.

For example

```shell
rollup@function@sourcemap-base-url-invalid: throws for invalid sourcemapBaseUrl
AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:

{
  code: 'GenericFailure',
  message: 'Invalid value for `sourcemapBaseUrl` option, should be a valid URL: example.com'
}

should loosely deep-equal

{
  code: 'INVALID_OPTION',
  message: 'Invalid value for option "output.sourcemapBaseUrl" - must be a valid URL, received "example.com".',
  url: 'https://rollupjs.org/configuration-options/#output-sourcemapbaseurl'
}
    at compareError (test/utils.js:69:9)
    at /home/situ/Codes/rolldown/packages/rollup-tests/test/function/index.js:135:10 {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: '{\n' +
    '  "code": "GenericFailure"\n' +
    '  "message": "Invalid value for `sourcemapBaseUrl` option, should be a valid URL: example.com"\n' +
    '}',
  expected: '{\n' +
    '  "code": "INVALID_OPTION"\n' +
    '  "message": "Invalid value for option \\"output.sourcemapBaseUrl\\" - must be a valid URL, received \\"example.com\\"."\n' +
    '  "url": "https://rollupjs.org/configuration-options/#output-sourcemapbaseurl"\n' +
    '}',
  operator: 'deepEqual'
}


rollup@sourcemaps@sourcemap-base-url-without-trailing-slash: add a trailing slash automatically if it is missing@generates es
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
actual expected

'//#end sourcegMappingURL=https://example.com/a/bundle.es.js.map'

    at Object.test (/home/situ/Codes/rolldown/rollup/test/sourcemaps/samples/sourcemap-base-url-without-trailing-slash/_config.js:12:10)
    at generateAndTestBundle (test/sourcemaps/index.js:69:15)
    at Context.<anonymous> (test/sourcemaps/index.js:44:7) {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: '//#endregion',
  expected: '//# sourceMappingURL=https://example.com/a/bundle.es.js.map',
  operator: 'strictEqual'
}


rollup@sourcemaps@sourcemap-base-url: adds a sourcemap base url@generates es
AssertionError [ERR_ASSERTION]: '//#endregion' == '//# sourceMappingURL=https://example.com/a/bundle.es.js.map'
    at Object.test (/home/situ/Codes/rolldown/rollup/test/sourcemaps/samples/sourcemap-base-url/_config.js:13:10)
    at generateAndTestBundle (test/sourcemaps/index.js:69:15)
    at Context.<anonymous> (test/sourcemaps/index.js:44:7) {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: '//#endregion',
  expected: '//# sourceMappingURL=https://example.com/a/bundle.es.js.map',
  operator: '=='
}


failures [
  "rollup@function@sourcemap-base-url-invalid: throws for invalid sourcemapBaseUrl",
  "rollup@sourcemaps@sourcemap-base-url-without-trailing-slash: add a trailing slash automatically if it is missing@generates es",
  "rollup@sourcemaps@sourcemap-base-url: adds a sourcemap base url@generates es"
]
┌──────────────────────────────────────────────┬────────┐
│ (index)                                      │ Values │
├──────────────────────────────────────────────┼────────┤
│ failed                                       │ 3      │
│ skipFailed                                   │ 2      │
│ ignored                                      │ 17     │
│ ignored(unsupported features)                │ 390    │
│ ignored(treeshaking)                         │ 282    │
│ ignored(behavior passed, snapshot different) │ 124    │
│ passed                                       │ 730    │
└──────────────────────────────────────────────┴────────┘
```