### PR TITLE
fix(rolldown_plugin_asset): should directly stringify raw content

### DIFF
--- a/crates/rolldown_plugin_asset/src/lib.rs
+++ b/crates/rolldown_plugin_asset/src/lib.rs
@@ -84,8 +84,8 @@ impl Plugin for AssetPlugin {
 
       ctx.add_watch_file(&path);
 
-      let file = serde_json::from_str::<Value>(&std::fs::read_to_string(path.as_ref())?)?;
-      let code = arcstr::format!("export default {}", serde_json::to_string(&file)?);
+      let content = std::fs::read_to_string(path.as_ref())?;
+      let code = arcstr::format!("export default {}", serde_json::to_string(&content)?);
       return Ok(Some(rolldown_plugin::HookLoadOutput {
         code,
         module_type: Some(ModuleType::Js),


### PR DESCRIPTION
Reference: Asset plugin in Vite just directly read content and then `JSON.stringify()` it. There is no extra `JSON.parse()` phase.

https://github.com/vitejs/vite/blob/86d2e8be50be535494734f9f5f5236c61626b308/packages/vite/src/node/plugins/asset.ts#L178-L185

### What happened

Parsing a content that is not a valid JSON string will cause error. For example if we import text file with content `png` and use `assetPlugin` in rolldown config.

```js
import text from './example.txt?raw';
```

```js
import { defineConfig } from 'rolldown';
import { assetPlugin } from 'rolldown/experimental';

export default defineConfig({
  input: './index.js',
  plugins: [
    assetPlugin({}),
  ],
});
```

Will yield

```shell
 ERROR  Build failed with 1 error:                                                                                                                                                  

[UNLOADABLE_DEPENDENCY] Error: Could not load example.txt?raw
   ╭─[ index.js:2:18 ]
   │
 2 │ import text from './example.txt?raw';
   │                  ─────────┬─────────  
   │                           ╰─────────── caused by plugin builtin:asset
───╯


    at normalizeErrors (/home/situ/Codes/rolldown/packages/rolldown/dist/shared/src-Bj9wacS6.mjs:2270:18)
    at handleOutputErrors (/home/situ/Codes/rolldown/packages/rolldown/dist/shared/src-Bj9wacS6.mjs:3006:34)
    at transformToRollupOutput (/home/situ/Codes/rolldown/packages/rolldown/dist/shared/src-Bj9wacS6.mjs:3000:2)
    at RolldownBuild.write (/home/situ/Codes/rolldown/packages/rolldown/dist/shared/src-Bj9wacS6.mjs:4207:10)
    at async bundleInner (/home/situ/Codes/rolldown/packages/rolldown/dist/cli.mjs:1598:16)
    at async bundleWithConfig (/home/situ/Codes/rolldown/packages/rolldown/dist/cli.mjs:1510:7)
    at async main (/home/situ/Codes/rolldown/packages/rolldown/dist/cli.mjs:1748:3)
```
