### PR TITLE
test(rolldown): should await for `toMatchFileSnapshot`

### DIFF
--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/restore-query-extension/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/restore-query-extension/_config.ts
@@ -22,19 +22,19 @@ export default defineTest({
     ],
   },
   async afterTest(output: RolldownOutput) {
-    output.output.forEach((chunk) => {
+    for (const chunk of output.output) {
       if (chunk.type === 'chunk') {
         if (chunk.name?.startsWith('index_js')) {
-          expect(chunk.code).toMatchFileSnapshot(
+          await expect(chunk.code).toMatchFileSnapshot(
             path.resolve(import.meta.dirname, 'dir/index.js.snap'),
           )
         } else if (chunk.name?.startsWith('b_js')) {
-          expect(chunk.code).toMatchFileSnapshot(
+          await expect(chunk.code).toMatchFileSnapshot(
             path.resolve(import.meta.dirname, 'dir/b.js.snap'),
           )
         }
       }
-    })
+    }
     await import('./assert.mjs')
   },
 })

--- a/packages/rolldown/tests/fixtures/output/minify/exclude-dts/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/minify/exclude-dts/_config.ts
@@ -20,17 +20,16 @@ export default defineTest({
       },
     ],
   },
-  afterTest: (output) => {
+  afterTest: async (output) => {
     for (const o of output.output) {
       if (o.type !== "chunk") {
-        expect(o.source).toMatchFileSnapshot(
+        await expect(o.source).toMatchFileSnapshot(
           path.resolve(import.meta.dirname, 'snap', `${o.fileName}.snap`),
         );
       } else {
-        expect(o.code).toMatchFileSnapshot(
+        await expect(o.code).toMatchFileSnapshot(
           path.resolve(import.meta.dirname, 'snap',`${o.fileName}.snap`),
         );
-
       }
     }
   },


### PR DESCRIPTION
Fix this since I saw a warning from my terminal.

```shell
Promise returned by `expect(actual).toMatchFileSnapshot(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
```