### PR TITLE
fix(rolldown_plugin_transform): skip builtin transform for module id with null byte

### DIFF
--- a/crates/rolldown_plugin_transform/src/utils.rs
+++ b/crates/rolldown_plugin_transform/src/utils.rs
@@ -17,6 +17,8 @@ pub enum JsxRefreshFilter {
 
 impl TransformPlugin {
   pub fn filter(&self, id: &str, cwd: &str, module_type: &Option<ModuleType>) -> bool {
+    // rollup `createFilter` always skips when id includes null byte
+    // https://github.com/rollup/plugins/blob/ad58c8d87c5ab4864e25b5a777290fdf12a3879f/packages/pluginutils/src/createFilter.ts#L51
     if memmem::find(id.as_bytes(), b"\0").is_some() {
       return false;
     }

--- a/crates/rolldown_plugin_transform/src/utils.rs
+++ b/crates/rolldown_plugin_transform/src/utils.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use itertools::Either;
+use memchr::memmem;
 use oxc::{span::SourceType, transformer::TransformOptions};
 use rolldown_common::ModuleType;
 use rolldown_plugin::SharedTransformPluginContext;
@@ -16,6 +17,10 @@ pub enum JsxRefreshFilter {
 
 impl TransformPlugin {
   pub fn filter(&self, id: &str, cwd: &str, module_type: &Option<ModuleType>) -> bool {
+    if memmem::find(id.as_bytes(), b"\0").is_some() {
+      return false;
+    }
+
     if self.include.is_empty() && self.exclude.is_empty() {
       return matches!(module_type, Some(ModuleType::Jsx | ModuleType::Tsx | ModuleType::Ts));
     }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/virtual/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/virtual/_config.ts
@@ -1,0 +1,36 @@
+import { defineTest } from 'rolldown-tests'
+import { transformPlugin } from 'rolldown/experimental'
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    plugins: [
+      transformPlugin(),
+      {
+        name: 'virtual',
+        resolveId(source) {
+          if (source === 'virtual:test.tsx') {
+            return "\0" + source
+          }
+        },
+        load(id) {
+          if (id === "\0virtual:test.tsx") {
+            // this module should be skipped by builtin transform
+            // otherwise this will cause a syntax error
+            // or mysterious tsconfig error
+            // > Tsconfig extends configs circularly: "tsconfig.json" -> "tsconfig.json"
+            return `bad code`;
+          }
+        },
+        transform(code, id) {
+          if (id === "\0virtual:test.tsx") {
+            return `export default "fixed"`;
+          }
+        }
+      },
+    ],
+  },
+  async afterTest() {
+    await import('./assert.mjs')
+  },
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/virtual/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/virtual/assert.mjs
@@ -1,0 +1,4 @@
+import assert from 'node:assert'
+import lib from './dist/main'
+
+assert.strictEqual(lib, "fixed")

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/virtual/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/virtual/main.js
@@ -1,0 +1,2 @@
+import mod from "virtual:test.tsx";
+export default mod


### PR DESCRIPTION
- Related https://github.com/vitejs/rolldown-vite/issues/372

This implements `\0` filtering for builtin transform plugin to align with non-native transform (both oxc and previously with esbuild). This doesn't directly address the case where tsconfig resolution ends up mysterious error `Tsconfig extends configs circularly`.