### PR TITLE
fix(node): allow `transform.jsx: 'preserve'` by options validator

### DIFF
--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -158,7 +158,7 @@ const TransformOptionsSchema = v.object({
   typescript: v.optional(TypescriptSchema),
   helpers: v.optional(HelpersSchema),
   decorators: v.optional(DecoratorOptionSchema),
-  jsx: v.optional(JsxOptionsSchema),
+  jsx: v.optional(v.union([v.literal('preserve'), JsxOptionsSchema])),
   target: v.pipe(
     v.optional(v.union([v.string(), v.array(v.string())])),
     v.description('The JavaScript target environment'),

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -82,13 +82,7 @@ OPTIONS
   --transform.decorators.emit-decorator-metadata .
   --transform.decorators.legacy .
   --transform.helpers.mode <transform.helpers.mode>.
-  --transform.jsx.development Development specific information.
-  --transform.jsx.import-source <transform.jsx.import-source>Import the factory of element and fragment if mode is classic.
-  --transform.jsx.pragma <transform.jsx.pragma>Jsx element transformation.
-  --transform.jsx.pragma-flag <transform.jsx.pragma-flag>Jsx fragment transformation.
-  --transform.jsx.refresh     Enable react fast refresh.
-  --transform.jsx.runtime <transform.jsx.runtime>Which runtime to use.
-  --transform.jsx.throw-if-namespace <transform.jsx.throw-if-namespace>Toggles whether to throw an error when a tag name uses an XML namespace.
+  --transform.jsx <transform.jsx>.
   --transform.target <transform.target>The JavaScript target environment.
   --transform.typescript.allow-declare-fields .
   --transform.typescript.allow-namespaces .


### PR DESCRIPTION
This is allowed by the types, but was not allowed by the validator.