### PR TITLE
chore: deprecate top-level `jsx` option in favor of `transform.jsx`

### DIFF
--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -304,6 +304,11 @@ export interface InputOptions {
   inject?: Record<string, string | [string, string]>;
   profilerNames?: boolean;
   /**
+   * @deprecated Use {@link OxcTransformOption.jsx} instead.
+   *
+   * This top-level `jsx` option will be removed in a future release.
+   * It is only kept for backward compatibility and will be mapped internally to `transform.jsx`.
+   *
    * - `false` disables the JSX parser, resulting in a syntax error if JSX syntax is used.
    * - `"preserve"` disables the JSX transformer, preserving the original JSX syntax in the output.
    * - `"react"` enables the `classic` JSX transformer.


### PR DESCRIPTION
Related to #5782

We are deprecating this option now to raise awareness for users, and it will be completely removed in a future release.