### PR TITLE
fix(node): allow `output.topLevelVar` by options validator

### DIFF
--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -792,6 +792,10 @@ const OutputOptionsSchema = v.strictObject({
     v.optional(v.boolean()),
     v.description('Minify internal exports'),
   ),
+  topLevelVar: v.pipe(
+    v.optional(v.boolean()),
+    v.description('Rewrite top-level declarations to use `var`.'),
+  ),
 });
 
 const getAddonDescription = (

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -74,6 +74,7 @@ OPTIONS
   --shim-missing-exports      Create shim variables for missing exports.
   --sourcemap-base-url <sourcemap-base-url>Base URL used to prefix sourcemap paths.
   --sourcemap-debug-ids       Inject sourcemap debug IDs.
+  --top-level-var             Rewrite top-level declarations to use \`var\`.
   --transform.assumptions.ignore-function-length .
   --transform.assumptions.no-document-all .
   --transform.assumptions.object-rest-no-symbols .


### PR DESCRIPTION
This is allowed by the types, but was not allowed by the validator.

refs https://github.com/rolldown/rolldown/pull/5188