### PR TITLE
fix(rolldown): run DCE on chunk when `minify: dce-only`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/minify_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/minify_assets.rs
@@ -39,13 +39,15 @@ impl GenerateStage<'_> {
             };
 
             // TODO: Do we need to ensure `asset.filename` to be absolute path?
-            let (minified_content, new_map) = EcmaCompiler::minify(
+            let (minified_content, new_map) = EcmaCompiler::dce_or_minify(
               asset.content.try_as_inner_str()?,
               options.format.source_type().with_jsx(true),
               asset.map.is_some(),
               &asset.filename,
-              minify_options.to_oxc_minifier_options(options),
+              minify_options.mangle,
               minify_options.compress,
+              minify_options.get_mangle_options(options),
+              minify_options.get_compress_options(options),
               codegen_options,
             );
             asset.content = minified_content.into();

--- a/packages/rolldown/tests/fixtures/tree-shake/on-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/on-chunk/_config.ts
@@ -1,0 +1,32 @@
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown'
+import { defineTest } from 'rolldown-tests'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    treeshake: {
+      moduleSideEffects: false,
+    },
+    output: {
+      minify: 'dce-only'
+    },
+    plugins: [
+      {
+        name: 'foo',
+        renderChunk(code) {
+          return code.replace('FOO', 'true');
+        },
+      }
+    ]
+  },
+  afterTest: (output) => {
+    output.output
+    .filter(({ type }) => type === 'chunk')
+    .forEach((chunk) => {
+      let code = (chunk as RolldownOutputChunk).code
+      expect(code).not.includes('FOO')
+      expect(code).not.includes('true')
+      expect(code).includes('console.log("foo")')
+    })
+  },
+})

--- a/packages/rolldown/tests/fixtures/tree-shake/on-chunk/main.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/on-chunk/main.js
@@ -1,0 +1,1 @@
+FOO && (function () { console.log('foo') }());


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/13176

`minify_options` are unpacked and passed to `dce_or_minify` because we can't import `rolldown_common` in `rolldown_ecmascript`, it would introduce cyclic import.