### PR TITLE
perf(string_wizard): reduce allocation

### DIFF
--- a/crates/rolldown/src/css/css_generator.rs
+++ b/crates/rolldown/src/css/css_generator.rs
@@ -35,7 +35,7 @@ impl Generator for CssGenerator {
 
     for module in &ordered_css_modules {
       let css_view = module.css_view.as_ref().unwrap();
-      let mut magic_string = string_wizard::MagicString::new(&css_view.source);
+      let mut magic_string = string_wizard::MagicString::new(css_view.source.as_str());
       for mutation in &css_view.mutations {
         mutation.apply(&mut magic_string);
       }

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -212,7 +212,7 @@ impl NormalModule {
         );
         if !self.ecma_view.mutations.is_empty() {
           let original_code: Arc<str> = render_output.code.into();
-          let mut magic_string = string_wizard::MagicString::new(&*original_code);
+          let mut magic_string = string_wizard::MagicString::new(&original_code);
           for mutation in &self.ecma_view.mutations {
             mutation.apply(&mut magic_string);
           }

--- a/crates/string_wizard/src/chunk.rs
+++ b/crates/string_wizard/src/chunk.rs
@@ -84,10 +84,7 @@ impl<'str> Chunk<'str> {
     new_chunk
   }
 
-  pub fn fragments(
-    &'str self,
-    original_source: &'str CowStr<'str>,
-  ) -> impl Iterator<Item = &'str str> {
+  pub fn fragments(&'str self, original_source: &'str str) -> impl Iterator<Item = &'str str> {
     let intro_iter = self.intro.iter().map(|frag| frag.as_ref());
     let source_frag = self
       .edited_content

--- a/crates/string_wizard/src/joiner.rs
+++ b/crates/string_wizard/src/joiner.rs
@@ -1,4 +1,4 @@
-use crate::{CowStr, MagicString};
+use crate::MagicString;
 
 pub struct JoinerOptions {
   pub separator: Option<String>,
@@ -25,7 +25,7 @@ impl<'s> Joiner<'s> {
     self
   }
 
-  pub fn append_raw(&mut self, raw: impl Into<CowStr<'s>>) -> &mut Self {
+  pub fn append_raw(&mut self, raw: &'s str) -> &mut Self {
     self.sources.push(MagicString::new(raw));
     self
   }

--- a/crates/string_wizard/src/magic_string/indent.rs
+++ b/crates/string_wizard/src/magic_string/indent.rs
@@ -63,7 +63,7 @@ impl MagicString<'_> {
   fn guessed_indentor(&mut self) -> &str {
     let guessed_indentor = self
       .guessed_indentor
-      .get_or_init(|| guess_indentor(&self.source).unwrap_or_else(|| "\t".to_string()));
+      .get_or_init(|| guess_indentor(self.source).unwrap_or_else(|| "\t".to_string()));
     guessed_indentor
   }
 
@@ -120,7 +120,7 @@ impl MagicString<'_> {
         let mut line_starts = vec![];
         char_index = chunk.start();
         let chunk_end = chunk.end();
-        for char in chunk.span.text(&self.source).chars() {
+        for char in chunk.span.text(self.source).chars() {
           debug_assert!(self.source.is_char_boundary(char_index));
           if !exclude_set.contains(char_index) {
             if char == '\n' {

--- a/crates/string_wizard/src/magic_string/mod.rs
+++ b/crates/string_wizard/src/magic_string/mod.rs
@@ -28,7 +28,7 @@ pub struct MagicString<'s> {
   filename: Option<String>,
   intro: VecDeque<CowStr<'s>>,
   outro: VecDeque<CowStr<'s>>,
-  source: CowStr<'s>,
+  source: &'s str,
   chunks: IndexChunks<'s>,
   first_chunk_idx: ChunkIdx,
   last_chunk_idx: ChunkIdx,
@@ -41,12 +41,11 @@ pub struct MagicString<'s> {
 }
 
 impl<'text> MagicString<'text> {
-  pub fn new(source: impl Into<CowStr<'text>>) -> Self {
+  pub fn new(source: &'text str) -> Self {
     Self::with_options(source, Default::default())
   }
 
-  pub fn with_options(source: impl Into<CowStr<'text>>, options: MagicStringOptions) -> Self {
-    let source: CowStr = source.into();
+  pub fn with_options(source: &'text str, options: MagicStringOptions) -> Self {
     let source_len = source.len();
     let initial_chunk = Chunk::new(Span(0, source_len));
     let mut chunks = IndexChunks::with_capacity(1);
@@ -111,7 +110,7 @@ impl<'text> MagicString<'text> {
   pub(crate) fn fragments(&'text self) -> impl Iterator<Item = &'text str> {
     let intro = self.intro.iter().map(|s| s.as_ref());
     let outro = self.outro.iter().map(|s| s.as_ref());
-    let chunks = self.iter_chunks().flat_map(|c| c.fragments(&self.source));
+    let chunks = self.iter_chunks().flat_map(|c| c.fragments(self.source));
     intro.chain(chunks).chain(outro)
   }
 

--- a/crates/string_wizard/src/magic_string/replace.rs
+++ b/crates/string_wizard/src/magic_string/replace.rs
@@ -34,8 +34,7 @@ impl<'text> MagicString<'text> {
     options: ReplaceOptions,
   ) -> &mut Self {
     let to: CowStr<'text> = to.into();
-    let source = self.source.clone();
-    for (match_start, part) in source.match_indices(from).take(options.count) {
+    for (match_start, part) in self.source.match_indices(from).take(options.count) {
       let end = match_start + part.len();
       self.update_with(
         match_start,

--- a/crates/string_wizard/src/magic_string/replace.rs
+++ b/crates/string_wizard/src/magic_string/replace.rs
@@ -34,22 +34,16 @@ impl<'text> MagicString<'text> {
     options: ReplaceOptions,
   ) -> &mut Self {
     let to: CowStr<'text> = to.into();
-    // PERF(hyf0): Unnecessary `collect` due to borrow checker limitation.
-    let matches = self
-      .source
-      .match_indices(from)
-      .take(options.count)
-      .map(|(match_start, part)| (match_start, match_start + part.len()))
-      .collect::<Box<[_]>>();
-
-    matches.iter().for_each(|(start, end)| {
+    let source = self.source.clone();
+    for (match_start, part) in source.match_indices(from).take(options.count) {
+      let end = match_start + part.len();
       self.update_with(
-        *start,
-        *end,
+        match_start,
+        end,
         to.clone(),
         UpdateOptions { overwrite: true, keep_original: options.store_original_in_sourcemap },
       );
-    });
+    }
 
     self
   }

--- a/crates/string_wizard/src/magic_string/source_map.rs
+++ b/crates/string_wizard/src/magic_string/source_map.rs
@@ -27,31 +27,25 @@ impl MagicString<'_> {
   pub fn source_map(&self, opts: SourceMapOptions) -> oxc_sourcemap::SourceMap {
     let mut source_builder = SourcemapBuilder::new(opts.hires);
 
-    source_builder.set_source_and_content(&opts.source, &self.source);
+    source_builder.set_source_and_content(&opts.source, self.source);
 
-    let locator = Locator::new(&self.source);
+    let locator = Locator::new(self.source);
 
     self.intro.iter().for_each(|frag| {
       source_builder.advance(frag);
     });
 
     let utf16_index_map =
-      precompute_utf16_index_map(&self.source, self.iter_chunks().map(|chunk| chunk.start()));
+      precompute_utf16_index_map(self.source, self.iter_chunks().map(|chunk| chunk.start()));
 
     self.iter_chunks().for_each(|chunk| {
       chunk.intro.iter().for_each(|frag| {
         source_builder.advance(frag);
       });
       let name =
-        (chunk.keep_in_mappings && chunk.is_edited()).then(|| chunk.span.text(&self.source));
+        (chunk.keep_in_mappings && chunk.is_edited()).then(|| chunk.span.text(self.source));
 
-      source_builder.add_chunk(
-        chunk,
-        utf16_index_map[&chunk.start()],
-        &locator,
-        &self.source,
-        name,
-      );
+      source_builder.add_chunk(chunk, utf16_index_map[&chunk.start()], &locator, self.source, name);
 
       chunk.outro.iter().for_each(|frag| {
         source_builder.advance(frag);


### PR DESCRIPTION
Refactor `MagicString { source: Cow<str> }` to `MagicString { source: &str }` to prevent potential heap allocation.

~I added `self.source.clone()`.~ Here are the types of `source` in `MagicString` throughout the entire project, summarized by Claude Code:

| File                                                           | Source Type          | Ownership | Performance Impact                |
  |----------------------------------------------------------------|----------------------|-----------|-----------------------------------|
  | Production Code                                                |                      |           |                                   |
  | rolldown_common/src/module/normal_module.rs                    | &*Arc<str>           | Borrowed  | ✅ Clone is cheap (reference copy) |
  | rolldown_plugin/src/plugin_driver/build_hooks.rs               | &str (original_code) | Borrowed  | ✅ Clone is cheap (reference copy) |
  | rolldown_plugin/src/plugin_context/transform_plugin_context.rs | ArcStr.as_str()      | Borrowed  | ✅ Clone is cheap (reference copy) |
  | rolldown/src/css/css_generator.rs                              | &ArcStr              | Borrowed  | ✅ Clone is cheap (reference copy) |
  | rolldown_plugin_replace/src/plugin.rs (transform)              | &String              | Borrowed  | ✅ Clone is cheap (reference copy) |
  | rolldown_plugin_replace/src/plugin.rs (render_chunk)           | &String              | Borrowed  | ✅ Clone is cheap (reference copy) |
  | Test Code                                                      |                      |           |                                   |
  | All test files                                                 | &str literals        | Borrowed  | ✅ Clone is cheap (reference copy) |