### PR TITLE
test(rolldown): add basic test for asset plugin

### DIFF
--- a/packages/rolldown/tests/fixtures/builtin-plugin/asset/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/asset/basic/_config.ts
@@ -1,0 +1,17 @@
+import { assetPlugin } from 'rolldown/experimental'
+import { defineTest } from 'rolldown-tests'
+import { expect } from 'vitest'
+import path from 'path'
+
+export default defineTest({
+  config: {
+    plugins: [
+      assetPlugin({}),
+    ],
+  },
+  async afterTest(output) {
+    await expect(output.output[0].code).toMatchFileSnapshot(
+      path.resolve(import.meta.dirname, 'main.js.snap')
+    )
+  },
+})

--- a/packages/rolldown/tests/fixtures/builtin-plugin/asset/basic/foo.txt
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/asset/basic/foo.txt
@@ -1,0 +1,1 @@
+Hello world

--- a/packages/rolldown/tests/fixtures/builtin-plugin/asset/basic/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/asset/basic/main.js
@@ -1,0 +1,5 @@
+import foo from './foo.txt';
+import fooRaw from './foo.txt?raw';
+
+console.log(foo);
+console.log(fooRaw);

--- a/packages/rolldown/tests/fixtures/builtin-plugin/asset/basic/main.js.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/asset/basic/main.js.snap
@@ -1,0 +1,13 @@
+//#region foo.txt
+var foo_default = "data:text/plain;charset=utf-8,Hello world";
+
+//#endregion
+//#region foo.txt?raw
+var foo_default$1 = "Hello world";
+
+//#endregion
+//#region main.js
+console.log(foo_default);
+console.log(foo_default$1);
+
+//#endregion


### PR DESCRIPTION
Add basic test for rolldown_plugin_asset, also for the fix #5749
