### PR TITLE
feat(dev): introduce `DevEngine` to support build for devlopement scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,6 +1601,19 @@ dependencies = [
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375bd3a138be7bfeff3480e4a623df4cbfb55b79df617c055cd810ba466fa078"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
 ]
 
 [[package]]
@@ -2667,6 +2689,7 @@ dependencies = [
  "rolldown_testing",
  "rolldown_tracing",
  "rolldown_utils",
+ "rolldown_watcher",
  "rolldown_workspace",
  "rustc-hash",
  "serde",
@@ -3319,6 +3342,15 @@ dependencies = [
  "tokio",
  "uuid",
  "xxhash-rust",
+]
+
+[[package]]
+name = "rolldown_watcher"
+version = "0.1.0"
+dependencies = [
+ "notify",
+ "notify-debouncer-full",
+ "rolldown_error",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ rolldown_testing = { version = "0.1.0", path = "./crates/rolldown_testing" }
 rolldown_testing_config = { version = "0.1.0", path = "./crates/rolldown_testing_config" }
 rolldown_tracing = { version = "0.1.0", path = "./crates/rolldown_tracing" }
 rolldown_utils = { version = "0.1.0", path = "./crates/rolldown_utils" }
+rolldown_watcher = { version = "0.1.0", path = "./crates/rolldown_watcher" }
 rolldown_workspace = { version = "0.1.0", path = "./crates/rolldown_workspace" }
 
 anyhow = "1.0.98"
@@ -155,6 +156,7 @@ mimalloc-safe = "0.1.52"
 mime = "0.3.17"
 nom = "8.0.0"
 notify = "8.1.0"
+notify-debouncer-full = "0.6.0"
 num-bigint = "0.4.6"
 num-format = "0.4"
 owo-colors = "4.2.2"

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -52,6 +52,7 @@ rolldown_sourcemap = { workspace = true }
 rolldown_std_utils = { workspace = true }
 rolldown_tracing = { workspace = true }
 rolldown_utils = { workspace = true }
+rolldown_watcher = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rolldown/examples/dev.rs
+++ b/crates/rolldown/examples/dev.rs
@@ -1,0 +1,18 @@
+use rolldown::{BundlerBuilder, BundlerOptions, DevEngine, ExperimentalOptions};
+use sugar_path::SugarPath;
+
+// RD_LOG=rolldown::dev=trace cargo run --example dev
+
+#[tokio::main]
+async fn main() {
+  let bundler_builder = BundlerBuilder::default().with_options(BundlerOptions {
+    input: Some(vec!["./entry.js".to_string().into()]),
+    cwd: Some(rolldown_workspace::crate_dir("rolldown").join("./examples/basic").normalize()),
+
+    experimental: Some(ExperimentalOptions { incremental_build: Some(true), ..Default::default() }),
+    ..Default::default()
+  });
+  let mut dev_engine = DevEngine::<rolldown_watcher::NotifyWatcher>::new(bundler_builder).unwrap();
+  dev_engine.run().await;
+  dev_engine.wait_for_close().await;
+}

--- a/crates/rolldown/src/dev/build_driver.rs
+++ b/crates/rolldown/src/dev/build_driver.rs
@@ -1,0 +1,71 @@
+use std::{mem, ops::Deref, path::PathBuf, sync::Arc};
+
+use futures::FutureExt;
+
+use tokio::sync::Mutex;
+
+use crate::{
+  Bundler, BundlerBuilder,
+  dev::{
+    bundling_task::BundlingTask,
+    dev_context::{BuildProcessFuture, DevContext, PinBoxSendStaticFuture, SharedDevContext},
+  },
+};
+
+pub type SharedBuildDriver = Arc<BuildDriver>;
+
+pub struct BuildDriver {
+  pub bundler: Arc<Mutex<Bundler>>,
+  pub ctx: SharedDevContext,
+}
+
+impl BuildDriver {
+  pub fn new(bundler_builder: BundlerBuilder) -> Self {
+    let bundler = Arc::new(Mutex::new(bundler_builder.build()));
+    let ctx = Arc::new(DevContext::default());
+
+    Self { bundler, ctx }
+  }
+
+  pub async fn schedule_build(&self, changed_paths: Vec<PathBuf>) -> Option<BuildProcessFuture> {
+    let mut build_status = self.ctx.status.lock().await;
+    if build_status.is_in_building || build_status.is_in_debouncing {
+      tracing::trace!(
+        "Bailout due to is_in_building({}) or is_in_debouncing({}) with changed files: {:#?}",
+        build_status.is_in_building,
+        build_status.is_in_debouncing,
+        build_status.changed_files,
+      );
+      build_status.changed_files.extend(changed_paths);
+      return None;
+    }
+
+    let mut batched_changed_files = mem::take(&mut build_status.changed_files);
+    batched_changed_files.extend(changed_paths);
+
+    let bundling_task = BundlingTask {
+      bundler: Arc::clone(&self.bundler),
+      changed_files: batched_changed_files,
+      dev_data: Arc::clone(&self.ctx),
+      ensure_latest_build: true,
+    };
+
+    let bundling_future = (Box::pin(bundling_task.exec()) as PinBoxSendStaticFuture).shared();
+    tokio::spawn(bundling_future.clone());
+
+    tracing::trace!("BuildStatus is in debouncing");
+    build_status.is_in_debouncing = true;
+    build_status.future = bundling_future.clone();
+    drop(build_status);
+
+    Some(bundling_future)
+  }
+}
+
+impl Deref for BuildDriver {
+  type Target = DevContext;
+
+  fn deref(&self) -> &Self::Target {
+    &self.ctx
+  }
+}

--- a/crates/rolldown/src/dev/bundling_task.rs
+++ b/crates/rolldown/src/dev/bundling_task.rs
@@ -1,0 +1,80 @@
+use std::{mem, path::PathBuf, sync::Arc, time::Duration};
+
+use indexmap::IndexSet;
+use rolldown_error::BuildResult;
+use tokio::sync::Mutex;
+
+use crate::{Bundler, dev::dev_context::SharedDevContext};
+
+pub struct BundlingTask {
+  pub bundler: Arc<Mutex<Bundler>>,
+  // Empty changed files mean full build instead of incremental build
+  pub changed_files: IndexSet<PathBuf>,
+  pub dev_data: SharedDevContext,
+  pub ensure_latest_build: bool,
+}
+
+impl BundlingTask {
+  pub async fn exec(mut self) {
+    let build_delay = 0;
+
+    let mut build_status = if build_delay > 0 {
+      loop {
+        tokio::time::sleep(Duration::from_millis(build_delay)).await;
+        let mut build_status = self.dev_data.status.lock().await;
+        if build_status.changed_files.is_empty() {
+          break build_status;
+        }
+        self.changed_files.append(&mut build_status.changed_files);
+      }
+    } else {
+      self.dev_data.status.lock().await
+    };
+
+    tracing::trace!("`BuildStatus` is in building with changed files: {:#?}", self.changed_files);
+    build_status.is_in_building = true;
+    build_status.is_in_debouncing = false;
+
+    drop(build_status);
+
+    self.build().await;
+  }
+
+  async fn build(self) {
+    let build_result = self.build_inner().await;
+
+    match build_result {
+      Ok(()) => {}
+      Err(_) => {
+        let mut build_status = self.dev_data.status.lock().await;
+        build_status.is_in_building = false;
+      }
+    }
+  }
+
+  async fn build_inner(&self) -> BuildResult<()> {
+    let mut bundler = self.bundler.lock().await;
+    let changed_files = self.changed_files.iter().map(|p| p.to_string_lossy().into()).collect();
+    let scan_output = bundler.scan(changed_files).await?;
+    let _bundle_output = bundler.bundle_write(scan_output).await?;
+
+    let mut build_status = loop {
+      let mut build_status = self.dev_data.status.lock().await;
+      if !self.ensure_latest_build || build_status.changed_files.is_empty() {
+        build_status.is_in_building = false;
+        break build_status;
+      }
+      let changed_files = mem::take(&mut build_status.changed_files);
+      drop(build_status);
+      let changed_files = changed_files.iter().map(|p| p.to_string_lossy().into()).collect();
+      let scan_output = bundler.scan(changed_files).await?;
+      let _bundle_output = bundler.bundle_write(scan_output).await?;
+    };
+    tracing::trace!(
+      "`BuildStatus` finished building with changed files: {:#?}",
+      self.changed_files
+    );
+    build_status.is_in_building = false;
+    Ok(())
+  }
+}

--- a/crates/rolldown/src/dev/dev_context.rs
+++ b/crates/rolldown/src/dev/dev_context.rs
@@ -1,0 +1,57 @@
+use std::{future::Future, path::PathBuf, pin::Pin, sync::Arc};
+
+use futures::{
+  FutureExt,
+  future::{self, Shared},
+};
+use indexmap::IndexSet;
+use tokio::sync::Mutex;
+
+pub type SharedDevContext = Arc<DevContext>;
+
+pub type PinBoxSendStaticFuture<T = ()> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
+pub type BuildProcessFuture = Shared<PinBoxSendStaticFuture<()>>;
+
+pub struct BuildStatus {
+  pub is_in_building: bool,
+  pub is_in_debouncing: bool,
+  pub changed_files: IndexSet<PathBuf>,
+  pub future: BuildProcessFuture,
+}
+impl BuildStatus {
+  pub fn is_in_process(&self) -> bool {
+    self.is_in_building || self.is_in_debouncing
+  }
+}
+
+pub struct DevContext {
+  pub status: Mutex<BuildStatus>,
+}
+
+impl DevContext {
+  pub async fn wait_for_current_build_finish(&self) -> () {
+    let build_status = self.status.lock().await;
+    if !build_status.is_in_process() {
+      return;
+    }
+    let build_process_future = build_status.future.clone();
+    // Note: Inside `build_process_future`, it requires to lock `BuildStatus` to modify the status.
+    // So, we need to drop the lock before we await `build_process_future`, otherwise we might get a deadlock.
+    drop(build_status);
+    build_process_future.await;
+  }
+}
+
+impl Default for DevContext {
+  fn default() -> Self {
+    let future = Box::pin(future::ready(())) as PinBoxSendStaticFuture;
+    Self {
+      status: Mutex::new(BuildStatus {
+        is_in_building: false,
+        is_in_debouncing: false,
+        future: future.shared(),
+        changed_files: IndexSet::new(),
+      }),
+    }
+  }
+}

--- a/crates/rolldown/src/dev/dev_engine.rs
+++ b/crates/rolldown/src/dev/dev_engine.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use arcstr::ArcStr;
+use futures::{FutureExt, future::Shared};
+use rolldown_error::BuildResult;
+use rolldown_utils::dashmap::FxDashSet;
+use rolldown_watcher::Watcher;
+use sugar_path::SugarPath;
+use tokio::sync::Mutex;
+
+use crate::{
+  BundlerBuilder,
+  dev::{
+    build_driver::{BuildDriver, SharedBuildDriver},
+    dev_context::PinBoxSendStaticFuture,
+    watcher_event_service::WatcherEventService,
+  },
+};
+
+pub struct DevEngine<W: Watcher + Send + 'static> {
+  build_driver: SharedBuildDriver,
+  watcher: Mutex<W>,
+  watched_files: FxDashSet<ArcStr>,
+  watcher_service: Option<WatcherEventService>,
+  watcher_service_handle: Option<Shared<PinBoxSendStaticFuture<()>>>,
+}
+
+impl<W: Watcher + Send + 'static> DevEngine<W> {
+  pub fn new(bundler_builder: BundlerBuilder) -> BuildResult<Self> {
+    let build_driver = Arc::new(BuildDriver::new(bundler_builder));
+
+    let watcher_event_service = WatcherEventService::new(Arc::clone(&build_driver));
+    let watcher = W::new(watcher_event_service.create_event_handler())?;
+
+    Ok(Self {
+      build_driver,
+      watcher: Mutex::new(watcher),
+      watched_files: FxDashSet::default(),
+      watcher_service: Some(watcher_event_service),
+      watcher_service_handle: None,
+    })
+  }
+
+  pub async fn run(&mut self) {
+    if let Some(build_process_future) = self.build_driver.schedule_build(vec![]).await {
+      build_process_future.await;
+    } else {
+      self.build_driver.wait_for_current_build_finish().await;
+    }
+
+    if let Some(watcher_service) = self.watcher_service.take() {
+      let watcher_service_handle = tokio::spawn(watcher_service.run());
+      let watcher_service_handle = Box::pin(async move {
+        watcher_service_handle.await.expect("How we handle this error?");
+      }) as PinBoxSendStaticFuture;
+      self.watcher_service_handle = Some(watcher_service_handle.shared());
+    }
+
+    let bundler = self.build_driver.bundler.lock().await;
+    // hyf0 TODO: `get_watch_files` is not a proper API to tell which files should be watched.
+    let watch_files = bundler.get_watch_files();
+
+    let mut watcher = self.watcher.lock().await;
+    // let mut watched_paths = watcher.paths_mut();
+    for watch_file in watch_files.iter() {
+      let watch_file = &*watch_file;
+      if self.watched_files.contains(watch_file) {
+        continue;
+      }
+      self.watched_files.insert(watch_file.clone());
+      watcher.watch(watch_file.as_path(), notify::RecursiveMode::NonRecursive).unwrap();
+    }
+  }
+
+  pub async fn wait_for_close(&self) {
+    if let Some(watcher_service_handle) = self.watcher_service_handle.clone() {
+      watcher_service_handle.await;
+    }
+  }
+}

--- a/crates/rolldown/src/dev/mod.rs
+++ b/crates/rolldown/src/dev/mod.rs
@@ -1,0 +1,6 @@
+pub mod build_driver;
+pub mod bundling_task;
+pub mod dev_context;
+pub mod dev_engine;
+pub mod watcher_event_handler;
+pub mod watcher_event_service;

--- a/crates/rolldown/src/dev/watcher_event_handler.rs
+++ b/crates/rolldown/src/dev/watcher_event_handler.rs
@@ -1,0 +1,14 @@
+use rolldown_watcher::EventHandler;
+
+use crate::dev::watcher_event_service::{WatcherEventServiceMsg, WatcherEventServiceTx};
+
+pub struct WatcherEventHandler {
+  pub service_tx: WatcherEventServiceTx,
+}
+impl EventHandler for WatcherEventHandler {
+  fn handle_event(&mut self, event: rolldown_watcher::FileChangeResult) {
+    if self.service_tx.send(WatcherEventServiceMsg::FileChange(event)).is_err() {
+      // TODO: handle send failed
+    }
+  }
+}

--- a/crates/rolldown/src/dev/watcher_event_service.rs
+++ b/crates/rolldown/src/dev/watcher_event_service.rs
@@ -1,0 +1,56 @@
+use rolldown_watcher::FileChangeResult;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+use crate::dev::{build_driver::SharedBuildDriver, watcher_event_handler::WatcherEventHandler};
+
+pub enum WatcherEventServiceMsg {
+  FileChange(FileChangeResult),
+}
+
+pub type WatcherEventServiceTx = UnboundedSender<WatcherEventServiceMsg>;
+pub type WatcherEventServiceRx = UnboundedReceiver<WatcherEventServiceMsg>;
+
+pub struct WatcherEventService {
+  pub ctx: SharedBuildDriver,
+  pub rx: WatcherEventServiceRx,
+  pub tx: WatcherEventServiceTx,
+}
+
+impl WatcherEventService {
+  pub fn new(ctx: SharedBuildDriver) -> Self {
+    let (tx, rx) = unbounded_channel::<WatcherEventServiceMsg>();
+    Self { ctx, rx, tx }
+  }
+
+  pub fn create_event_handler(&self) -> WatcherEventHandler {
+    WatcherEventHandler { service_tx: self.tx.clone() }
+  }
+
+  pub async fn run(mut self) {
+    while let Some(msg) = {
+      tracing::trace!("`BuildService` is waiting for messages.");
+      self.rx.recv().await
+    } {
+      match msg {
+        WatcherEventServiceMsg::FileChange(file_change_result) => match file_change_result {
+          Ok(batched_events) => {
+            let changed_files = batched_events
+              .into_iter()
+              .flat_map(|batched_event| match &batched_event.kind {
+                notify::EventKind::Modify(_modify_kind) => batched_event.event.paths,
+                _ => {
+                  vec![]
+                }
+              })
+              .collect::<Vec<_>>();
+
+            self.ctx.schedule_build(changed_files).await;
+          }
+          Err(e) => {
+            eprintln!("notify error: {e:?}");
+          }
+        },
+      }
+    }
+  }
+}

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -4,6 +4,7 @@ mod bundler;
 mod bundler_builder;
 mod chunk_graph;
 mod css;
+mod dev;
 mod ecmascript;
 mod hmr;
 mod module_finalizers;
@@ -25,6 +26,7 @@ pub(crate) type SharedOptions = SharedNormalizedBundlerOptions;
 pub use crate::{
   bundler::Bundler,
   bundler_builder::BundlerBuilder,
+  dev::dev_engine::DevEngine,
   types::bundle_output::BundleOutput,
   watch::event::{BundleEvent, WatcherEvent},
   watcher::Watcher,

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -706,6 +706,7 @@ impl<'a> ModuleLoader<'a> {
       // if it is in incremental mode, we skip the runtime module, since it is always there
       // so use a dummy runtime_brief as a placeholder
       runtime: if self.is_full_scan {
+        tracing::debug!("changed_resolved_ids: {changed_resolved_ids:#?}");
         runtime_brief.expect("Failed to find runtime module. This should not happen")
       } else {
         RuntimeModuleBrief::dummy()

--- a/crates/rolldown_watcher/Cargo.toml
+++ b/crates/rolldown_watcher/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rolldown_watcher"
+version = "0.1.0"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+notify = { workspace = true }
+notify-debouncer-full = { workspace = true }
+rolldown_error = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rolldown_watcher/src/lib.rs
+++ b/crates/rolldown_watcher/src/lib.rs
@@ -1,0 +1,10 @@
+//! This crate provides a customized watcher functionalities for `rolldown`.
+//! Notify is a low-level library. It's not easy to use it directly.
+
+mod notify_watcher;
+mod watcher;
+
+pub use notify_debouncer_full::{
+  DebounceEventHandler as EventHandler, DebounceEventResult as FileChangeResult,
+};
+pub use {notify_watcher::NotifyWatcher, watcher::Watcher};

--- a/crates/rolldown_watcher/src/notify_watcher.rs
+++ b/crates/rolldown_watcher/src/notify_watcher.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use notify::RecommendedWatcher;
+use notify_debouncer_full::{DebounceEventHandler, Debouncer, RecommendedCache, new_debouncer};
+use rolldown_error::{BuildResult, ResultExt};
+
+use crate::Watcher;
+
+pub type NotifyWatcher = Debouncer<RecommendedWatcher, RecommendedCache>;
+
+impl Watcher for NotifyWatcher {
+  fn new<F: DebounceEventHandler>(event_handler: F) -> BuildResult<Self>
+  where
+    Self: Sized,
+  {
+    Ok(new_debouncer(Duration::from_millis(10), None, event_handler).map_err_to_unhandleable()?)
+  }
+
+  fn watch(
+    &mut self,
+    path: &std::path::Path,
+    recursive_mode: notify::RecursiveMode,
+  ) -> BuildResult<()> {
+    NotifyWatcher::watch(self, path, recursive_mode).map_err_to_unhandleable()?;
+
+    Ok(())
+  }
+
+  fn unwatch(&mut self, path: &std::path::Path) -> BuildResult<()> {
+    NotifyWatcher::unwatch(self, path).map_err_to_unhandleable()?;
+
+    Ok(())
+  }
+}

--- a/crates/rolldown_watcher/src/watcher.rs
+++ b/crates/rolldown_watcher/src/watcher.rs
@@ -1,0 +1,20 @@
+use notify::RecursiveMode;
+use notify_debouncer_full::DebounceEventHandler;
+use rolldown_error::BuildResult;
+use std::path::Path;
+
+pub trait Watcher {
+  fn new<F: DebounceEventHandler>(event_handler: F) -> BuildResult<Self>
+  where
+    Self: Sized;
+
+  fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> BuildResult<()>;
+
+  /// Stop watching a path.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error in the case that `path` has not been watched or if removing the watch
+  /// fails.
+  fn unwatch(&mut self, path: &Path) -> BuildResult<()>;
+}


### PR DESCRIPTION

## High-Level Architecture

```mermaid
graph TB
    subgraph "External"
        FS[File System]
        BB[BundlerBuilder]
        B[Bundler]
    end
    
    subgraph "Dev Module Core"
        DE[DevEngine&lt;W&gt;]
        BD[BuildDriver]
        DC[DevContext]
        BT[BundlingTask]
    end
    
    subgraph "File Watching System"
        W[Watcher&lt;W&gt;]
        WEH[WatcherEventHandler]
        WES[WatcherEventService]
    end
    
    subgraph "Shared State"
        BS[BuildStatus]
        ASDD[ArcSharedDevData]
    end
    
    BB --> DE
    DE --> BD
    DE --> WES
    DE --> W
    BD --> DC
    BD --> BT
    BD --> B
    BT --> B
    BT --> DC
    DC --> BS
    W --> WEH
    WEH --> WES
    WES --> BD
    FS --> W
    DC -.-> ASDD
```

## Usage Example

```rust
use rolldown::dev::DevEngine;
use rolldown_watcher::NotifyWatcher;

// Create dev engine with specific watcher implementation
let mut dev_engine = DevEngine::<NotifyWatcher>::new(bundler_builder)?;

// Start the development server
dev_engine.run().await;

// Wait for graceful shutdown
dev_engine.wait_for_close().await;
```