### PR TITLE
fix(hmr): `import.meta.hot.accept` in patch file should work

### DIFF
--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -176,6 +176,14 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     node.body.push(ast::Statement::VariableDeclaration(var_decl));
   }
 
+  fn enter_call_expression(
+    &mut self,
+    node: &mut ast::CallExpression<'ast>,
+    _ctx: &mut oxc_traverse::TraverseCtx<'ast, ()>,
+  ) {
+    self.rewrite_hot_accept_call_deps(node);
+  }
+
   fn exit_expression(
     &mut self,
     node: &mut oxc::ast::ast::Expression<'ast>,
@@ -213,14 +221,6 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
     self.try_rewrite_dynamic_import(node);
     self.try_rewrite_require(node, ctx);
     self.rewrite_import_meta_hot(node);
-  }
-
-  fn exit_call_expression(
-    &mut self,
-    node: &mut ast::CallExpression<'ast>,
-    _ctx: &mut oxc_traverse::TraverseCtx<'ast, ()>,
-  ) {
-    self.rewrite_hot_accept_call_deps(node);
   }
 }
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "hmr": {}
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
@@ -1,0 +1,101 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+// HIDDEN [rolldown:runtime]
+// HIDDEN [rolldown:hmr]
+//#region child.js
+var child_exports = {};
+__export(child_exports, { foo: () => foo });
+const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
+__rolldown_runtime__.registerModule("child.js", { exports: child_exports });
+const foo = 0;
+
+//#endregion
+//#region parent.js
+var parent_exports = {};
+const parent_hot = __rolldown_runtime__.createModuleHotContext("parent.js");
+__rolldown_runtime__.registerModule("parent.js", { exports: parent_exports });
+parent_hot.accept("child.js", () => {
+	globalThis.oldAcceptWasCalled = true;
+});
+process.on("beforeExit", (code) => {
+	if (code !== 0) return;
+	assert(!globalThis.oldAcceptWasCalled);
+});
+
+//#endregion
+//#region main.js
+var main_exports = {};
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+main_hot.accept("parent.js", () => {});
+
+//#endregion
+```
+# HMR Step 0
+
+## Code
+
+```js
+//#region parent.js
+import * as import_node_assert_00 from "node:assert";
+var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
+	try {
+		var __rolldown_exports__ = {};
+		__rolldown_runtime__.__export(__rolldown_exports__, {});
+		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
+		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
+		var import_child_01 = __rolldown_runtime__.loadExports("child.js");
+		hot_parent.accept("child.js", () => {
+			globalThis.newAcceptWasCalled = true;
+		});
+		process.on("beforeExit", (code) => {
+			if (code !== 0) return;
+			import_node_assert_00.default(globalThis.newAcceptWasCalled);
+		});
+	} finally {}
+}));
+
+//#endregion
+init_parent_0()
+__rolldown_runtime__.applyUpdates(['parent.js']);
+```
+## Meta
+
+- update type: patch
+### Hmr Boundaries
+
+- boundary: parent.js, accepted_via: main.js
+# HMR Step 1
+
+## Code
+
+```js
+//#region child.js
+var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
+	try {
+		var __rolldown_exports__ = {};
+		__rolldown_runtime__.__export(__rolldown_exports__, { foo: () => foo });
+		__rolldown_runtime__.registerModule("child.js", { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext("child.js");
+		const foo = 1;
+	} finally {}
+}));
+
+//#endregion
+init_child_0()
+__rolldown_runtime__.applyUpdates(['child.js']);
+```
+## Meta
+
+- update type: patch
+### Hmr Boundaries
+
+- boundary: child.js, accepted_via: parent.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/child.hmr-1.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/child.hmr-1.js
@@ -1,0 +1,1 @@
+export const foo = 1

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/child.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/child.js
@@ -1,0 +1,1 @@
+export const foo = 0

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/main.js
@@ -1,0 +1,3 @@
+import './parent.js'
+
+import.meta.hot.accept('./parent.js', () => {})

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/parent.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/parent.hmr-0.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert'
+import './child.js'
+
+import.meta.hot.accept('./child.js', () => {
+  globalThis.newAcceptWasCalled = true
+})
+
+process.on('beforeExit', (code) => {
+  if (code !== 0) return
+  assert(globalThis.newAcceptWasCalled)
+})

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/parent.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/parent.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert'
+import './child.js'
+
+import.meta.hot.accept('./child.js', () => {
+  globalThis.oldAcceptWasCalled = true
+})
+
+process.on('beforeExit', (code) => {
+  if (code !== 0) return
+  assert(!globalThis.oldAcceptWasCalled)
+})

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5439,6 +5439,10 @@ expression: output
 - main-!~{000}~.js => main-X0JfucbC.js
 - main-X0JfucbC.js.map
 
+# tests/rolldown/topics/hmr/change_accept
+
+- main-!~{000}~.js => main-BeoRVPT1.js
+
 # tests/rolldown/topics/hmr/dynamic_import
 
 - main-!~{000}~.js => main-SUY2JqE0.js


### PR DESCRIPTION
Aligned the implementation with
https://github.com/rolldown/rolldown/blob/d5d5bfcd0bc9fe8366ea8aa51a7404f9c37288c6/crates/rolldown/src/module_finalizers/impl_visit_mut.rs#L352-L364
to make `import.meta.hot.accept` in patch files work.
