### PR TITLE
fix: don't mangle variable names when `minify: 'dce-only'` is used

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/minify_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/minify_assets.rs
@@ -1,6 +1,6 @@
 use oxc::{
   codegen::{self, CodegenOptions, CommentOptions},
-  minifier::MinifierOptions,
+  minifier::{CompressOptions, MinifierOptions},
 };
 use rolldown_common::{LegalComments, MinifyOptions, NormalizedBundlerOptions};
 use rolldown_ecmascript::EcmaCompiler;
@@ -19,7 +19,9 @@ impl GenerateStage<'_> {
   ) -> BuildResult<()> {
     let (compress, minify_option) = match &options.minify {
       MinifyOptions::Disabled => return Ok(()),
-      MinifyOptions::DeadCodeEliminationOnly => (false, &MinifierOptions::default()),
+      MinifyOptions::DeadCodeEliminationOnly => {
+        (false, &MinifierOptions { mangle: None, compress: Some(CompressOptions::default()) })
+      }
       MinifyOptions::Enabled(options) => (true, options),
     };
     let remove_whitespace = compress;

--- a/packages/rolldown/tests/fixtures/output/minify/dce-only/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/minify/dce-only/_config.ts
@@ -9,6 +9,7 @@ export default defineTest({
   },
   afterTest: (output) => {
     const code = output.output[0].code;
+    expect(code).toContain('varNameIsNotMangled')
     expect(code).toContain('legal comment is kept');
     expect(code).toContain('annotation comment is kept');
   },

--- a/packages/rolldown/tests/fixtures/output/minify/dce-only/main.js
+++ b/packages/rolldown/tests/fixtures/output/minify/dce-only/main.js
@@ -1,3 +1,8 @@
 /*! legal comment is kept */
 
 import(/* @vite-ignore annotation comment is kept */ 'node:module')
+
+export function foo() {
+  const varNameIsNotMangled = window.something
+  return varNameIsNotMangled + varNameIsNotMangled
+}


### PR DESCRIPTION
fixes this test failure:
https://github.com/rolldown/rolldown/actions/runs/17101976025/job/48500741336#step:6:360

refs #5804