### PR TITLE
fix(rolldown_plugin_transform): set `typescript.removeClassFieldsWithoutInitializer` for `useDefineForClassFields=false`

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/config/binding_transform_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_transform_plugin_config.rs
@@ -82,6 +82,7 @@ impl From<BindingTransformPluginConfig> for TransformPlugin {
           only_remove_type_imports: typescript.only_remove_type_imports,
           allow_namespaces: typescript.allow_namespaces,
           allow_declare_fields: typescript.allow_declare_fields,
+          remove_class_fields_without_initializer: typescript.remove_class_fields_without_initializer,
           rewrite_import_extensions,
         }
       });

--- a/crates/rolldown_binding/src/options/plugin/config/binding_transform_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_transform_plugin_config.rs
@@ -82,7 +82,8 @@ impl From<BindingTransformPluginConfig> for TransformPlugin {
           only_remove_type_imports: typescript.only_remove_type_imports,
           allow_namespaces: typescript.allow_namespaces,
           allow_declare_fields: typescript.allow_declare_fields,
-          remove_class_fields_without_initializer: typescript.remove_class_fields_without_initializer,
+          remove_class_fields_without_initializer: typescript
+            .remove_class_fields_without_initializer,
           rewrite_import_extensions,
         }
       });

--- a/crates/rolldown_plugin_transform/src/types/typescript_options.rs
+++ b/crates/rolldown_plugin_transform/src/types/typescript_options.rs
@@ -7,6 +7,7 @@ pub struct TypeScriptOptions {
   pub only_remove_type_imports: Option<bool>,
   pub allow_namespaces: Option<bool>,
   pub allow_declare_fields: Option<bool>,
+  pub remove_class_fields_without_initializer: Option<bool>,
   /// Also generate a `.d.ts` declaration file for TypeScript files.
   ///
   /// The source file must be compliant with all
@@ -50,7 +51,9 @@ impl From<TypeScriptOptions> for oxc::transformer::TypeScriptOptions {
         .unwrap_or(ops.only_remove_type_imports),
       allow_namespaces: options.allow_namespaces.unwrap_or(ops.allow_namespaces),
       allow_declare_fields: options.allow_declare_fields.unwrap_or(ops.allow_declare_fields),
-      remove_class_fields_without_initializer: true,
+      remove_class_fields_without_initializer: options
+        .remove_class_fields_without_initializer
+        .unwrap_or(ops.remove_class_fields_without_initializer),
       optimize_const_enums: false,
       rewrite_import_extensions: options.rewrite_import_extensions.and_then(|value| match value {
         Either::Left(v) => {

--- a/crates/rolldown_plugin_transform/src/utils.rs
+++ b/crates/rolldown_plugin_transform/src/utils.rs
@@ -233,7 +233,6 @@ impl TransformPlugin {
         } else {
           Some(false)
         };
-        transform_options.typescript = Some(typescript);
 
         let disable_use_define_for_class_fields = !compiler_options
           .use_define_for_class_fields
@@ -241,6 +240,10 @@ impl TransformPlugin {
 
         let mut assumptions = transform_options.assumptions.unwrap_or_default();
         assumptions.set_public_class_fields = Some(disable_use_define_for_class_fields);
+        typescript.remove_class_fields_without_initializer =
+          Some(disable_use_define_for_class_fields);
+
+        transform_options.typescript = Some(typescript);
         transform_options.assumptions = Some(assumptions);
 
         // set target to es2021 or lower to enable class property transforms


### PR DESCRIPTION
port of https://github.com/vitejs/rolldown-vite/pull/148