### PR TITLE
fix(hmr): boundary and accept_via was reversed

### DIFF
--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -373,7 +373,7 @@ impl HmrManager {
     }
 
     hmr_prerequisites.boundaries.iter().for_each(|boundary| {
-      let init_fn_name = &module_idx_to_init_fn_name[&boundary.boundary];
+      let init_fn_name = &module_idx_to_init_fn_name[&boundary.accepted_via];
       source_joiner.append_source(format!("{init_fn_name}()"));
     });
 
@@ -383,8 +383,9 @@ impl HmrManager {
         .boundaries
         .iter()
         .map(|boundary| {
-          let module = &self.module_table().modules[boundary.boundary];
-          format!("'{}'", module.stable_id())
+          let boundary_mod = &self.module_table().modules[boundary.boundary];
+          let accepted_via = &self.module_table().modules[boundary.accepted_via];
+          format!("['{}', '{}']", boundary_mod.stable_id(), accepted_via.stable_id())
         })
         .collect::<Vec<_>>()
         .join(",")
@@ -484,7 +485,7 @@ impl HmrManager {
 
       if importer.can_accept_hmr_dependency_for(&module.id) {
         modules_to_be_updated.insert(module_idx);
-        hmr_boundaries.insert(HmrBoundary { boundary: module_idx, accepted_via: importer_idx });
+        hmr_boundaries.insert(HmrBoundary { boundary: importer_idx, accepted_via: module_idx });
         continue;
       }
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
@@ -65,14 +65,14 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_parent_0()
-__rolldown_runtime__.applyUpdates(['parent.js']);
+__rolldown_runtime__.applyUpdates([['main.js', 'parent.js']]);
 ```
 ## Meta
 
 - update type: patch
 ### Hmr Boundaries
 
-- boundary: parent.js, accepted_via: main.js
+- boundary: main.js, accepted_via: parent.js
 # HMR Step 1
 
 ## Code
@@ -91,11 +91,11 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_child_0()
-__rolldown_runtime__.applyUpdates(['child.js']);
+__rolldown_runtime__.applyUpdates([['parent.js', 'child.js']]);
 ```
 ## Meta
 
 - update type: patch
 ### Hmr Boundaries
 
-- boundary: child.js, accepted_via: parent.js
+- boundary: parent.js, accepted_via: child.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -124,7 +124,7 @@ var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_hmr_0()
-__rolldown_runtime__.applyUpdates(['hmr.js']);
+__rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 ```
 ## Meta
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
@@ -93,7 +93,7 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_hmr_0()
-__rolldown_runtime__.applyUpdates(['hmr.js']);
+__rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 ```
 ## Meta
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -88,7 +88,7 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_hmr_0()
-__rolldown_runtime__.applyUpdates(['hmr.js']);
+__rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 ```
 ## Meta
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
@@ -106,7 +106,7 @@ var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_self_accept_0()
-__rolldown_runtime__.applyUpdates(['self_accept.js']);
+__rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
 ```
 ## Meta
 
@@ -136,7 +136,7 @@ var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_self_accept_0()
-__rolldown_runtime__.applyUpdates(['self_accept.js']);
+__rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
 ```
 ## Meta
 
@@ -162,14 +162,14 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_child_0()
-__rolldown_runtime__.applyUpdates(['single_accept/child.js']);
+__rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/child.js']]);
 ```
 ## Meta
 
 - update type: patch
 ### Hmr Boundaries
 
-- boundary: single_accept/child.js, accepted_via: single_accept/parent.js
+- boundary: single_accept/parent.js, accepted_via: single_accept/child.js
 # HMR Step 3
 
 ## Code
@@ -188,14 +188,14 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_child_0()
-__rolldown_runtime__.applyUpdates(['single_accept/child.js']);
+__rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/child.js']]);
 ```
 ## Meta
 
 - update type: patch
 ### Hmr Boundaries
 
-- boundary: single_accept/child.js, accepted_via: single_accept/parent.js
+- boundary: single_accept/parent.js, accepted_via: single_accept/child.js
 # HMR Step 4
 
 ## Code
@@ -214,14 +214,14 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_child_0()
-__rolldown_runtime__.applyUpdates(['array_accept/child.js']);
+__rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/child.js']]);
 ```
 ## Meta
 
 - update type: patch
 ### Hmr Boundaries
 
-- boundary: array_accept/child.js, accepted_via: array_accept/parent.js
+- boundary: array_accept/parent.js, accepted_via: array_accept/child.js
 # HMR Step 5
 
 ## Code
@@ -240,11 +240,11 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_child_0()
-__rolldown_runtime__.applyUpdates(['array_accept/child.js']);
+__rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/child.js']]);
 ```
 ## Meta
 
 - update type: patch
 ### Hmr Boundaries
 
-- boundary: array_accept/child.js, accepted_via: array_accept/parent.js
+- boundary: array_accept/parent.js, accepted_via: array_accept/child.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
@@ -119,7 +119,7 @@ var init_messenger_1 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_messenger_1()
-__rolldown_runtime__.applyUpdates(['messenger.js']);
+__rolldown_runtime__.applyUpdates([['messenger.js', 'messenger.js']]);
 ```
 ## Meta
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
@@ -148,7 +148,7 @@ var init_messenger_3 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_messenger_3()
-__rolldown_runtime__.applyUpdates(['messenger.js']);
+__rolldown_runtime__.applyUpdates([['messenger.js', 'messenger.js']]);
 ```
 ## Meta
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -403,7 +403,7 @@ var init_trigger_dep_11 = __rolldown_runtime__.createEsmInitializer((function() 
 
 //#endregion
 init_main_10()
-__rolldown_runtime__.applyUpdates(['main.js']);
+__rolldown_runtime__.applyUpdates([['main.js', 'main.js']]);
 ```
 ## Meta
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -171,7 +171,7 @@ var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_hmr_0()
-__rolldown_runtime__.applyUpdates(['hmr.js']);
+__rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 ```
 ## Meta
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3957,7 +3957,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-C58YIQ2g.js
+- main-!~{000}~.js => main-BRl9l4uJ.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4632,7 +4632,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-COdRlg2M.js
+- main-!~{000}~.js => main-GYiaesa8.js
 
 # tests/rolldown/issues/4196
 
@@ -5441,38 +5441,38 @@ expression: output
 
 # tests/rolldown/topics/hmr/change_accept
 
-- main-!~{000}~.js => main-BeoRVPT1.js
+- main-!~{000}~.js => main-CjLhLu5f.js
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-SUY2JqE0.js
+- main-!~{000}~.js => main-D_Qah7KK.js
 - chunk-!~{001}~.js => chunk-EJRfyxWL.js
 - exist-dep-cjs-!~{003}~.js => exist-dep-cjs-CMMhV_IP.js
 - exist-dep-esm-!~{005}~.js => exist-dep-esm-DS9du_-x.js
 
 # tests/rolldown/topics/hmr/export_star
 
-- main-!~{000}~.js => main-nUx8D7Mq.js
+- main-!~{000}~.js => main-iugOMOus.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-DfQ-oF6b.js
+- main-!~{000}~.js => main-Abs8vRWN.js
 
 # tests/rolldown/topics/hmr/import_meta_hot_accept
 
-- main-!~{000}~.js => main-B9No_UzW.js
+- main-!~{000}~.js => main-BJBQmZJO.js
 
 # tests/rolldown/topics/hmr/issue_5149
 
-- main-!~{000}~.js => main-DXr2occU.js
+- main-!~{000}~.js => main-2i-rnA2D.js
 
 # tests/rolldown/topics/hmr/issue_5150
 
-- main-!~{000}~.js => main-CffKaaPN.js
+- main-!~{000}~.js => main-CzhdaBZW.js
 
 # tests/rolldown/topics/hmr/issue_5159
 
-- main-!~{000}~.js => main-B3Z2wnq1.js
+- main-!~{000}~.js => main-Bg3Yer-O.js
 - bar-!~{005}~.js => bar-BisjqNeR.js
 - chunk-!~{001}~.js => chunk--KgZXUQQ.js
 - foo-!~{007}~.js => foo-OmnQYi5B.js
@@ -5480,29 +5480,29 @@ expression: output
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-XlK4V1mL.js
-- index-!~{001}~.js => index-DoQln8uI.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-CYgFQx_h.js
+- entry-!~{000}~.js => entry-1MwsmcRP.js
+- index-!~{001}~.js => index-DRnPso5Y.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-h3ThDu7r.js
 
 # tests/rolldown/topics/hmr/no_boundary_reload
 
-- main-!~{000}~.js => main-C27nGp8p.js
+- main-!~{000}~.js => main-DgJD8HMG.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-BCMx9M5R.js
+- main-!~{000}~.js => main-CJPqt-_s.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-SP8xxwvb.js
+- main-!~{000}~.js => main-Dw3g15p1.js
 
 # tests/rolldown/topics/hmr/runtime_correctness
 
-- main-!~{000}~.js => main-D_0ECsNY.js
+- main-!~{000}~.js => main-DkhPloRE.js
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-BMZkyjvb.js
+- main-!~{000}~.js => main-DeyM9iQ0.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
@@ -69,11 +69,11 @@ class DefaultDevRuntime extends DevRuntime {
   }
   /**
    * @override
-   * @param {string[]} boundaries
+   * @param {[string, string][]} boundaries
    */
   applyUpdates(boundaries) {
     // trigger callbacks of accept() correctly
-    for (let moduleId of boundaries) {
+    for (let [moduleId, acceptedVia] of boundaries) {
       const hotContext = this.moduleHotContexts.get(moduleId);
       if (hotContext) {
         const acceptCallbacks = hotContext.acceptCallbacks;

--- a/crates/rolldown_testing/src/hmr-runtime.js
+++ b/crates/rolldown_testing/src/hmr-runtime.js
@@ -34,23 +34,24 @@ class TestDevRuntime extends DevRuntime {
   }
   /**
    * @override
-   * @param {string[]} boundaries
+   * @param {[string, string][]} boundaries
    */
   applyUpdates(boundaries) {
-    for (const moduleId of boundaries) {
-      for (const ctx of this.contexts.values()) {
-        for (const { deps, cb } of ctx.callbacks) {
-          if (Array.isArray(deps)) {
-            if (deps.includes(moduleId)) {
-              const mods = deps.map((id) =>
-                id === moduleId ? this.loadExports(moduleId) : undefined
-              );
-              cb(mods);
-            }
-          } else {
-            if (deps === moduleId) {
-              cb(this.loadExports(moduleId));
-            }
+    for (const [boundary, acceptedVia] of boundaries) {
+      const ctx = this.contexts.get(boundary);
+      if (!ctx) continue;
+
+      for (const { deps, cb } of ctx.callbacks) {
+        if (Array.isArray(deps)) {
+          if (deps.includes(acceptedVia)) {
+            const mods = deps.map((id) =>
+              id === acceptedVia ? this.loadExports(acceptedVia) : undefined
+            );
+            cb(mods);
+          }
+        } else {
+          if (deps === acceptedVia) {
+            cb(this.loadExports(acceptedVia));
           }
         }
       }


### PR DESCRIPTION
Follow-up to #5822.

Sorry, I was wrong about https://github.com/rolldown/rolldown/pull/5822/files#r2291320036. 
The code there was correct. To correct my comment, accepted_via is the module that is re-executed (re-imported). boundary is the module that declared the boundary.
