### PR TITLE
fix: returning result of this.resolve in resolveId hook impacts bundle size

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
@@ -48,10 +48,12 @@ impl BindingPluginContext {
       .await
       .map_err(|program_err| napi_error::resolve_error(&specifier, program_err))?
       .ok();
+
     Ok(ret.map(|info| BindingPluginContextResolvedId {
       id: info.id.to_string(),
       external: info.external.into(),
       module_side_effects: info.side_effects.map(Into::into),
+      package_json_path: info.package_json.map(|item| item.realpath.to_string_lossy().to_string()),
     }))
   }
 
@@ -103,6 +105,7 @@ impl From<PluginContext> for BindingPluginContext {
 #[napi(object)]
 pub struct BindingPluginContextResolvedId {
   pub id: String,
+  pub package_json_path: Option<String>,
   #[napi(ts_type = "boolean | 'absolute' | 'relative'")]
   pub external: BindingResolvedExternal,
   #[napi(ts_type = "boolean | 'no-treeshake'")]

--- a/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_output.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_hook_resolve_id_output.rs
@@ -11,6 +11,10 @@ pub struct BindingHookResolveIdOutput {
   pub normalize_external_id: Option<bool>,
   #[napi(ts_type = "boolean | 'no-treeshake'")]
   pub module_side_effects: Option<BindingHookSideEffects>,
+  /// @internal Used to store package json path resolved by oxc resolver,
+  /// we could get the related package json object via the path string.
+  #[napi(ts_type = "string | null")]
+  pub package_json_path: Option<String>,
 }
 
 impl TryFrom<BindingHookResolveIdOutput> for rolldown_plugin::HookResolveIdOutput {
@@ -22,6 +26,7 @@ impl TryFrom<BindingHookResolveIdOutput> for rolldown_plugin::HookResolveIdOutpu
       external: value.external.map(TryInto::try_into).transpose()?,
       normalize_external_id: value.normalize_external_id,
       side_effects: value.module_side_effects.map(TryInto::try_into).transpose()?,
+      package_json_path: value.package_json_path,
     })
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -9,7 +9,7 @@ use types::legal_comments::LegalComments;
 use types::log_level::LogLevel;
 use types::make_absolute_externals_relative::MakeAbsoluteExternalsRelative;
 use types::mark_module_loaded::MarkModuleLoaded;
-use types::minify_options::{RawMinifyOptions, SimpleMinifyOptions};
+use types::minify_options::RawMinifyOptions;
 use types::on_log::OnLog;
 use types::optimization::OptimizationOption;
 use types::output_option::{
@@ -25,6 +25,8 @@ use serde::{Deserialize, Deserializer};
 #[cfg(feature = "deserialize_bundler_options")]
 use serde_json::Value;
 use types::experimental_options::ExperimentalOptions;
+#[cfg(feature = "deserialize_bundler_options")]
+use types::minify_options::SimpleMinifyOptions;
 
 use self::types::treeshake::TreeshakeOptions;
 use self::types::{

--- a/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
@@ -95,6 +95,7 @@ impl MinifyOptions {
   derive(Deserialize, JsonSchema),
   serde(rename_all = "camelCase", deny_unknown_fields, untagged)
 )]
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SimpleMinifyOptions {
   Boolean(bool),

--- a/crates/rolldown_plugin/src/types/hook_resolve_id_output.rs
+++ b/crates/rolldown_plugin/src/types/hook_resolve_id_output.rs
@@ -7,6 +7,7 @@ pub struct HookResolveIdOutput {
   pub external: Option<ResolvedExternal>,
   pub normalize_external_id: Option<bool>,
   pub side_effects: Option<HookSideEffects>,
+  pub package_json_path: Option<String>,
 }
 
 impl HookResolveIdOutput {
@@ -20,6 +21,7 @@ impl HookResolveIdOutput {
       external: Some(resolved_id.external),
       side_effects: resolved_id.side_effects,
       normalize_external_id: None,
+      package_json_path: resolved_id.package_json.map(|p| p.realpath.to_string_lossy().to_string()),
     }
   }
 }

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -4,7 +4,10 @@ use crate::{
 };
 use rolldown_common::{ImportKind, ModuleDefFormat, ResolvedId, is_existing_node_builtin_modules};
 use rolldown_resolver::{ResolveError, Resolver};
-use std::{path::Path, sync::Arc};
+use std::{
+  path::{Path, PathBuf},
+  sync::Arc,
+};
 
 fn is_http_url(s: &str) -> bool {
   s.starts_with("http://") || s.starts_with("https://") || s.starts_with("//")
@@ -64,12 +67,18 @@ pub async fn resolve_id_with_plugins(
     )
     .await?
   {
+    let package_json = r.package_json_path.as_ref().and_then(|p| {
+      let v = resolver.package_json_cache().get(&PathBuf::from(&p))?;
+      let package_json = v.clone();
+      Some(package_json)
+    });
     return Ok(Ok(ResolvedId {
       module_def_format: ModuleDefFormat::from_path(r.id.as_str()),
       id: r.id,
       external: r.external.unwrap_or_default(),
       normalize_external_id: r.normalize_external_id,
       side_effects: r.side_effects,
+      package_json,
       ..Default::default()
     }));
   }

--- a/crates/rolldown_plugin_oxc_runtime/src/lib.rs
+++ b/crates/rolldown_plugin_oxc_runtime/src/lib.rs
@@ -31,12 +31,7 @@ impl Plugin for OxcRuntimePlugin {
         )
         .await??;
 
-      return Ok(Some(rolldown_plugin::HookResolveIdOutput {
-        id: resolved_id.id,
-        external: Some(resolved_id.external),
-        side_effects: resolved_id.side_effects,
-        normalize_external_id: resolved_id.normalize_external_id,
-      }));
+      return Ok(Some(rolldown_plugin::HookResolveIdOutput::from_resolved_id(resolved_id)));
     }
 
     Ok(None)

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -34,6 +34,13 @@ pub struct Resolver<T: FileSystem = OsFileSystem> {
 }
 
 impl<F: FileSystem> Resolver<F> {
+  #[inline]
+  pub fn package_json_cache(&self) -> &FxDashMap<PathBuf, Arc<PackageJson>> {
+    &self.package_json_cache
+  }
+}
+
+impl<F: FileSystem> Resolver<F> {
   #[allow(clippy::too_many_lines)]
   pub fn new(raw_resolve: ResolveOptions, platform: Platform, cwd: PathBuf, fs: F) -> Self {
     let mut default_conditions = vec!["default".to_string()];

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1678,6 +1678,11 @@ export interface BindingHookResolveIdOutput {
   external?: BindingResolvedExternal
   normalizeExternalId?: boolean
   moduleSideEffects?: boolean | 'no-treeshake'
+  /**
+   * @internal Used to store package json path resolved by oxc resolver,
+   * we could get the related package json object via the path string.
+   */
+  packageJsonPath?: string | null
 }
 
 export type BindingHookSideEffects =
@@ -1887,6 +1892,7 @@ export interface BindingOxcRuntimePluginConfig {
 
 export interface BindingPluginContextResolvedId {
   id: string
+  packageJsonPath?: string
   external: boolean | 'absolute' | 'relative'
   moduleSideEffects?: boolean | 'no-treeshake'
 }

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -148,6 +148,7 @@ export function bindingifyResolveId(
         external: ret.external,
         normalizeExternalId: false,
         moduleSideEffects: exist.moduleSideEffects ?? undefined,
+        packageJsonPath: ret.packageJsonPath,
       };
     },
     meta: bindingifyPluginHookMeta(meta),

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -58,6 +58,7 @@ export interface ModuleOptions {
   // flag used to check if user directly modified the `ModuleInfo`
   // this is used to sync state between rust and js
   invalidate?: boolean;
+  packageJsonPath?: string;
 }
 
 export interface ResolvedId extends ModuleOptions {

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -191,6 +191,7 @@ export class PluginContextImpl extends MinimalPluginContextImpl {
       ...info,
       moduleSideEffects: info.moduleSideEffects ?? res.moduleSideEffects ??
         null,
+      packageJsonPath: res.packageJsonPath,
     };
   }
 

--- a/packages/rolldown/tests/fixtures/resolve/issue-5846/_config.ts
+++ b/packages/rolldown/tests/fixtures/resolve/issue-5846/_config.ts
@@ -1,0 +1,30 @@
+import { defineTest } from "rolldown-tests";
+import path from "node:path";
+import { expect } from "vitest";
+const entry = path.join(__dirname, "./main.ts");
+
+export default defineTest({
+	config: {
+		input: entry,
+		plugins: [
+			{
+				name: "test",
+				async resolveId(source, importer, options) {
+					if (!importer) {
+						return;
+					}
+					const resolved = await this.resolve(source, importer, {
+						...options,
+						skipSelf: true,
+					});
+
+					// Comment out this line to "fix" tree-shaking.
+					return resolved;
+				},
+			},
+		],
+	},
+	afterTest(output) {
+		expect(output.output[0].code).not.toContain(`sideEffects`);
+	},
+});

--- a/packages/rolldown/tests/fixtures/resolve/issue-5846/main.ts
+++ b/packages/rolldown/tests/fixtures/resolve/issue-5846/main.ts
@@ -1,0 +1,3 @@
+import './side-effects.ts'
+
+console.log('main')

--- a/packages/rolldown/tests/fixtures/resolve/issue-5846/package.json
+++ b/packages/rolldown/tests/fixtures/resolve/issue-5846/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "5846",
+  "sideEffects": false
+}

--- a/packages/rolldown/tests/fixtures/resolve/issue-5846/side-effects.ts
+++ b/packages/rolldown/tests/fixtures/resolve/issue-5846/side-effects.ts
@@ -1,0 +1,1 @@
+console.log('sideEffects')


### PR DESCRIPTION
Closed #5846
Currently, the packageJson info is lost after using `this.resolve`, this pr stores the `packageJsonPath` and resets it into `ResolveId` after normalized resolve info returned by hook.