### PR TITLE
refactor(incremental): use `clone_in_with_semantic_ids` for program cloning

### DIFF
--- a/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
@@ -50,7 +50,7 @@ impl EcmaAst {
         allocator: Allocator::with_capacity(self.allocator().used_bytes()),
       },
       |owner| {
-        let program = self.program().clone_in(&owner.allocator);
+        let program = self.program().clone_in_with_semantic_ids(&owner.allocator);
         ProgramCellDependent { program }
       },
     );


### PR DESCRIPTION
Using `clone_in` will lose semantic information, which causes issues during the module finalizers phase.