### PR TITLE
fix: when importee is ts or tsx adding potential false positive note for `missing_export` diagnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "rolldown-ariadne"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324d1b9754f0cb535f4032a6a654d3a56047a500f557c16060f12f70b0089c57"
+checksum = "77dff57c9de498bb1eb5b1ce682c2e3a0ae956b266fa0933c3e151b87b078967"
 dependencies = [
  "unicode-width",
  "yansi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ rolldown_workspace = { version = "0.1.0", path = "./crates/rolldown_workspace" }
 anyhow = "1.0.98"
 append-only-vec = "0.1.7"
 arcstr = { version = "1.2.0", default-features = false }
-ariadne = { package = "rolldown-ariadne", version = "0.5.2" }
+ariadne = { package = "rolldown-ariadne", version = "0.5.3" }
 async-channel = "2.3.1"
 async-scoped = "0.9.0"
 async-trait = "0.1.88"

--- a/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
@@ -12,6 +12,9 @@ source: crates/rolldown_testing/src/integration_test.rs
  1 │ import dc_def, { bar as dc } from './keep/declare-class'
    │        ───┬──  
    │           ╰──── Missing export
+   │ 
+   │ Help: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
+   │         exports to appear missing.
 ───╯
 
 ```
@@ -24,6 +27,9 @@ source: crates/rolldown_testing/src/integration_test.rs
  2 │ import dl_def, { bar as dl } from './keep/declare-let'
    │        ───┬──  
    │           ╰──── Missing export
+   │ 
+   │ Help: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
+   │         exports to appear missing.
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/errors/missing_export_ts/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_ts/_config.json
@@ -1,0 +1,3 @@
+{
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/errors/missing_export_ts/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_ts/artifacts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## MISSING_EXPORT
+
+```text
+[MISSING_EXPORT] Warning: "default" is not exported by "foo.ts".
+   ╭─[ main.ts:1:8 ]
+   │
+ 1 │ import dc_def, { bar as dc } from "./foo";
+   │        ───┬──  
+   │           ╰──── Missing export
+   │ 
+   │ Help: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
+   │         exports to appear missing.
+───╯
+
+```
+# Assets
+
+## main.js
+
+```js
+//#region foo.ts
+let bar = 123;
+
+//#endregion
+//#region main.ts
+var main_default = [dc_def, bar];
+
+//#endregion
+export { main_default as default };
+```

--- a/crates/rolldown/tests/rolldown/errors/missing_export_ts/foo.ts
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_ts/foo.ts
@@ -1,0 +1,4 @@
+declare class foo {}
+export default foo
+export let bar = 123
+

--- a/crates/rolldown/tests/rolldown/errors/missing_export_ts/main.ts
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_ts/main.ts
@@ -1,0 +1,3 @@
+import dc_def, { bar as dc } from "./foo";
+
+export default [dc_def, dc];

--- a/crates/rolldown/tests/rolldown/resolve/matched_alias_not_found/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/matched_alias_not_found/artifacts.snap
@@ -7,5 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```text
 [RESOLVE_ERROR] Error: Could not resolve 'react/jsx-runtime' in main.jsx
+  │ 
+  │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/config-options#resolve-alias for more details
 
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3735,6 +3735,10 @@ expression: output
 
 - main-!~{000}~.js => main-B-6QqlpX.js
 
+# tests/rolldown/errors/missing_export_ts
+
+- main-!~{000}~.js => main-BJyCdokI.js
+
 # tests/rolldown/function/advanced_chunks/basic
 
 - a-!~{000}~.js => a-CcaBLJp5.js

--- a/crates/rolldown_error/src/build_error/error_constructors.rs
+++ b/crates/rolldown_error/src/build_error/error_constructors.rs
@@ -111,6 +111,7 @@ impl BuildDiagnostic {
     importer_source: ArcStr,
     imported_specifier: String,
     imported_specifier_span: Span,
+    help: Option<String>,
   ) -> Self {
     Self::new_inner(MissingExport {
       importer,
@@ -119,6 +120,7 @@ impl BuildDiagnostic {
       importer_source,
       imported_specifier,
       imported_specifier_span,
+      help,
     })
   }
 

--- a/crates/rolldown_error/src/events/missing_export.rs
+++ b/crates/rolldown_error/src/events/missing_export.rs
@@ -13,6 +13,7 @@ pub struct MissingExport {
   pub importer_source: ArcStr,
   pub imported_specifier: String,
   pub imported_specifier_span: Span,
+  pub help: Option<String>,
 }
 
 impl BuildEvent for MissingExport {
@@ -40,6 +41,10 @@ impl BuildEvent for MissingExport {
 
     diagnostic.title =
       format!(r#""{}" is not exported by "{}"."#, self.imported_specifier, &self.stable_importee);
+
+    if let Some(help) = &self.help {
+      diagnostic.help = Some(help.clone());
+    }
 
     diagnostic.add_label(
       &file_id,

--- a/examples/basic-vue/main.ts
+++ b/examples/basic-vue/main.ts
@@ -1,0 +1,7 @@
+import type { Foo } from './foo';
+
+class Bar implements Foo {
+  a: string = 'a';
+}
+
+console.log(new Bar());

--- a/packages/rolldown/tests/fixtures/plugin/prefer-builtin-feature/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/prefer-builtin-feature/_config.ts
@@ -18,9 +18,17 @@ export default defineTest({
 		},
 	},
 	afterTest() {
-		expect(warnings).toEqual([
-			`[PREFER_BUILTIN_FEATURE] Warning: The functionality provided by \`@rollup/plugin-json\` is already covered natively, maybe you could remove the plugin from your configuration\n`,
-      `[PREFER_BUILTIN_FEATURE] Warning: Rolldown supports \`inject\` natively, please refer https://rolldown.rs/reference/config-options for more details, this is performant than passing \`@rollup/plugin-inject\` to plugins option.\n`
-		]);
+		expect(warnings).toMatchInlineSnapshot(`
+			[
+			  "[PREFER_BUILTIN_FEATURE] Warning: The functionality provided by \`@rollup/plugin-json\` is already covered natively, maybe you could remove the plugin from your configuration
+			  │ 
+			  │ Help: This diagnostic may be false positive, you could turn it off via \`checks.preferBuiltinFeature\`
+			",
+			  "[PREFER_BUILTIN_FEATURE] Warning: Rolldown supports \`inject\` natively, please refer https://rolldown.rs/reference/config-options for more details, this is performant than passing \`@rollup/plugin-inject\` to plugins option.
+			  │ 
+			  │ Help: This diagnostic may be false positive, you could turn it off via \`checks.preferBuiltinFeature\`
+			",
+			]
+		`);
 	},
 });


### PR DESCRIPTION
Closed #4151