### PR TITLE
chore: bump rolldown-ariadne

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "rolldown-ariadne"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324d1b9754f0cb535f4032a6a654d3a56047a500f557c16060f12f70b0089c57"
+checksum = "77dff57c9de498bb1eb5b1ce682c2e3a0ae956b266fa0933c3e151b87b078967"
 dependencies = [
  "unicode-width",
  "yansi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ rolldown_workspace = { version = "0.1.0", path = "./crates/rolldown_workspace" }
 anyhow = "1.0.98"
 append-only-vec = "0.1.7"
 arcstr = { version = "1.2.0", default-features = false }
-ariadne = { package = "rolldown-ariadne", version = "0.5.2" }
+ariadne = { package = "rolldown-ariadne", version = "0.5.3" }
 async-channel = "2.3.1"
 async-scoped = "0.9.0"
 async-trait = "0.1.88"

--- a/crates/rolldown/tests/rolldown/resolve/matched_alias_not_found/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/matched_alias_not_found/artifacts.snap
@@ -7,5 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```text
 [RESOLVE_ERROR] Error: Could not resolve 'react/jsx-runtime' in main.jsx
+  │ 
+  │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/config-options#resolve-alias for more details
 
 ```

--- a/packages/rolldown/tests/fixtures/plugin/prefer-builtin-feature/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/prefer-builtin-feature/_config.ts
@@ -18,9 +18,17 @@ export default defineTest({
 		},
 	},
 	afterTest() {
-		expect(warnings).toEqual([
-			`[PREFER_BUILTIN_FEATURE] Warning: The functionality provided by \`@rollup/plugin-json\` is already covered natively, maybe you could remove the plugin from your configuration\n`,
-      `[PREFER_BUILTIN_FEATURE] Warning: Rolldown supports \`inject\` natively, please refer https://rolldown.rs/reference/config-options for more details, this is performant than passing \`@rollup/plugin-inject\` to plugins option.\n`
-		]);
+		expect(warnings).toMatchInlineSnapshot(`
+			[
+			  "[PREFER_BUILTIN_FEATURE] Warning: The functionality provided by \`@rollup/plugin-json\` is already covered natively, maybe you could remove the plugin from your configuration
+			  │ 
+			  │ Help: This diagnostic may be false positive, you could turn it off via \`checks.preferBuiltinFeature\`
+			",
+			  "[PREFER_BUILTIN_FEATURE] Warning: Rolldown supports \`inject\` natively, please refer https://rolldown.rs/reference/config-options for more details, this is performant than passing \`@rollup/plugin-inject\` to plugins option.
+			  │ 
+			  │ Help: This diagnostic may be false positive, you could turn it off via \`checks.preferBuiltinFeature\`
+			",
+			]
+		`);
 	},
 });


### PR DESCRIPTION
Support rendering help and note without any labels.

see test case in https://github.com/rolldown/ariadne/pull/11/files