### PR TITLE
feat: support adding note for diagnostic

### DIFF
--- a/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ───┬──  
    │           ╰──── Missing export
    │ 
-   │ Help: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
+   │ Note: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
    │         exports to appear missing.
 ───╯
 
@@ -28,7 +28,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ───┬──  
    │           ╰──── Missing export
    │ 
-   │ Help: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
+   │ Note: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
    │         exports to appear missing.
 ───╯
 

--- a/crates/rolldown/tests/rolldown/errors/missing_export_ts/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_ts/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ───┬──  
    │           ╰──── Missing export
    │ 
-   │ Help: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
+   │ Note: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
    │         exports to appear missing.
 ───╯
 

--- a/crates/rolldown_error/src/build_error/error_constructors.rs
+++ b/crates/rolldown_error/src/build_error/error_constructors.rs
@@ -111,7 +111,7 @@ impl BuildDiagnostic {
     importer_source: ArcStr,
     imported_specifier: String,
     imported_specifier_span: Span,
-    help: Option<String>,
+    note: Option<String>,
   ) -> Self {
     Self::new_inner(MissingExport {
       importer,
@@ -120,7 +120,7 @@ impl BuildDiagnostic {
       importer_source,
       imported_specifier,
       imported_specifier_span,
-      help,
+      note,
     })
   }
 

--- a/crates/rolldown_error/src/diagnostic.rs
+++ b/crates/rolldown_error/src/diagnostic.rs
@@ -53,6 +53,7 @@ pub struct Diagnostic {
   pub(crate) files: FxHashMap</* filename */ DiagnosticFileId, /* file content */ ArcStr>,
   pub(crate) labels: Vec<Label<RolldownLabelSpan>>,
   pub(crate) help: Option<String>,
+  pub(crate) note: Option<String>,
   pub(crate) severity: Severity,
 }
 
@@ -67,6 +68,7 @@ impl Diagnostic {
       files: FxHashMap::default(),
       labels: Vec::default(),
       help: None,
+      note: None,
       severity,
     }
   }
@@ -83,8 +85,15 @@ impl Diagnostic {
     filename
   }
 
+  #[inline]
   pub(crate) fn add_help(&mut self, message: String) -> &mut Self {
     self.help = Some(message);
+    self
+  }
+
+  #[inline]
+  pub(crate) fn add_note(&mut self, message: String) -> &mut Self {
+    self.note = Some(message);
     self
   }
 
@@ -131,6 +140,10 @@ impl Diagnostic {
 
     if let Some(help) = &self.help {
       builder = builder.with_help(help);
+    }
+
+    if let Some(note) = &self.note {
+      builder = builder.with_note(note);
     }
 
     builder = builder.with_message(message);

--- a/crates/rolldown_error/src/events/missing_export.rs
+++ b/crates/rolldown_error/src/events/missing_export.rs
@@ -13,7 +13,7 @@ pub struct MissingExport {
   pub importer_source: ArcStr,
   pub imported_specifier: String,
   pub imported_specifier_span: Span,
-  pub help: Option<String>,
+  pub note: Option<String>,
 }
 
 impl BuildEvent for MissingExport {
@@ -42,8 +42,8 @@ impl BuildEvent for MissingExport {
     diagnostic.title =
       format!(r#""{}" is not exported by "{}"."#, self.imported_specifier, &self.stable_importee);
 
-    if let Some(help) = &self.help {
-      diagnostic.help = Some(help.clone());
+    if let Some(note) = &self.note {
+      diagnostic.add_note(note.clone());
     }
 
     diagnostic.add_label(


### PR DESCRIPTION
# Change "Help" to "Note" for TypeScript missing export diagnostics

This PR changes the classification of the message displayed when a TypeScript export might be missing due to type-only exports being stripped. The message is now presented as a "Note" rather than a "Help" message, which better reflects its informational nature.

The change includes:
- Adding a `note` field to the `Diagnostic` struct
- Adding an `add_note` method to the `Diagnostic` implementation
- Updating the `MissingExport` struct to use `note` instead of `help`
- Modifying the diagnostic output in test snapshots to reflect this change