### PR TITLE
fix: topLevelVar option removes class name, causing a TypeError in static block

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1,4 +1,3 @@
-use oxc::ast::ast::{BindingPatternKind, ClassType};
 use oxc::semantic::ScopeFlags;
 use oxc::{
   allocator::{self, Allocator, Box as ArenaBox, CloneIn, Dummy, IntoIn, TakeIn},
@@ -1197,39 +1196,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             }
           }
           if let Statement::ClassDeclaration(class_decl) = &mut top_stmt {
-            // If it's a class declaration, we need to transform it to a variable declaration whose rhs is a `class {}`
-            let class_name = class_decl.id.take().expect("Class declaration should have an id");
-            let class_id = self.snippet.builder.binding_pattern(
-              BindingPatternKind::BindingIdentifier(self.snippet.builder.alloc(class_name)),
-              NONE,
-              false,
-            );
-            let expr = self.snippet.builder.expression_class(
-              SPAN,
-              ClassType::ClassExpression,
-              class_decl.decorators.take_in(self.alloc),
-              None,
-              class_decl.type_parameters.take(),
-              class_decl.super_class.take(),
-              class_decl.super_type_arguments.take(),
-              class_decl.implements.take_in(self.alloc),
-              class_decl.body.take_in(self.alloc),
-              class_decl.r#abstract,
-              class_decl.declare,
-            );
-            let decl = self.snippet.builder.alloc_variable_declaration(
-              SPAN,
-              VariableDeclarationKind::Var,
-              self.snippet.builder.vec1(self.snippet.builder.variable_declarator(
-                SPAN,
-                VariableDeclarationKind::Var,
-                class_id,
-                Some(expr),
-                false,
-              )),
-              false,
-            );
-            top_stmt = Statement::VariableDeclaration(decl);
+            if let Some(mut decl) = self.get_transformed_class_decl(class_decl) {
+              top_stmt = Statement::from(decl.take_in(self.alloc));
+            }
           }
         }
         program.body.push(top_stmt);

--- a/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+  },
+  "configVariants": [
+    {
+      "topLevelVar": true
+    }
+  ]
+
+}

--- a/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/_test.mjs
+++ b/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/_test.mjs
@@ -1,0 +1,4 @@
+import assert from 'node:assert'
+import fs from 'node:fs/promises'
+const content = await fs.readFile(new URL('dist/main.js', import.meta.url), 'utf8')
+assert(!content.includes('"use strict"'))

--- a/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/artifacts.snap
@@ -1,0 +1,47 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+//#region main.js
+var Example = class Example {
+	static {
+		this.prop = new Example("bar");
+		assert.strictEqual(Example.prop.foo, "bar");
+	}
+	constructor(foo) {
+		this.foo = foo;
+	}
+};
+
+//#endregion
+```
+---
+
+Variant: [top_level_var: true]
+
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+//#region main.js
+var Example = class Example {
+	static {
+		this.prop = new Example("bar");
+		assert.strictEqual(Example.prop.foo, "bar");
+	}
+	constructor(foo) {
+		this.foo = foo;
+	}
+};
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/main.js
+++ b/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/main.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert'
+class Example {
+  static {
+    this.prop = new Example('bar')
+    assert.strictEqual(Example.prop.foo, 'bar')
+  }
+
+  constructor(foo) {
+    this.foo = foo;
+  }
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4954,6 +4954,10 @@ expression: output
 
 - main-!~{000}~.js => main-VI4jzbWN.js
 
+# tests/rolldown/misc/top_level_var/issue_5884
+
+- main-!~{000}~.js => main-DKngZ6kI.js
+
 # tests/rolldown/misc/use_strict/emit_use_strict_with_strict_cjs_in_cjs_format
 
 - main-!~{000}~.js => main-Cnui6OE6.js

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1470,6 +1470,12 @@
             "null"
           ]
         },
+        "topLevelVar": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "_snapshot": {
           "description": "Whether to include the output in the snapshot for this config variant.",
           "type": [

--- a/crates/rolldown_testing_config/src/config_variant.rs
+++ b/crates/rolldown_testing_config/src/config_variant.rs
@@ -23,6 +23,7 @@ pub struct ConfigVariant {
   pub on_demand_wrapping: Option<bool>,
   pub profiler_names: Option<bool>,
   pub pife_for_module_wrappers: Option<bool>,
+  pub top_level_var: Option<bool>,
   // --- non-bundler options are start with `_`
   /// Whether to include the output in the snapshot for this config variant.
   #[serde(rename = "_snapshot")]
@@ -74,6 +75,9 @@ impl ConfigVariant {
     if let Some(profiler_names) = &self.profiler_names {
       config.profiler_names = Some(*profiler_names);
     }
+    if let Some(top_level_var) = &self.top_level_var {
+      config.top_level_var = Some(*top_level_var);
+    }
     if let Some(pife_for_module_wrappers) = &self.pife_for_module_wrappers {
       config.optimization = Some(OptimizationOption {
         pife_for_module_wrappers: Some(*pife_for_module_wrappers),
@@ -120,6 +124,9 @@ impl ConfigVariant {
     }
     if let Some(entry_filenames) = &self.entry_filenames {
       fields.push(format!("entry_filenames: {entry_filenames:?}"));
+    }
+    if let Some(top_level_var) = &self.top_level_var {
+      fields.push(format!("top_level_var: {top_level_var:?}"));
     }
     let mut result = String::new();
     self.config_name.as_ref().inspect(|config_name| {


### PR DESCRIPTION
Closed #5884
### TL;DR

Fix class declarations with static blocks when using `topLevelVar` option.

### What changed?

- Refactored the class declaration transformation logic in `ScopeHoistingFinalizer` by extracting it to a separate method
- Added a test case for class declarations with static blocks when `topLevelVar` is enabled
- Added `topLevelVar` option to the testing configuration schema

### How to test?

Run the new test case in `crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/` which verifies that class declarations with static blocks work correctly when `topLevelVar` is enabled.

### Why make this change?

This PR fixes issue #5884 where class declarations with static blocks were not properly handled when the `topLevelVar` option was enabled. The static initialization blocks in classes need special handling to ensure they work correctly when transformed to variable declarations.