### PR TITLE
fix(types): omit `sourcemap` property from `MinifyOptions` correctly

### DIFF
--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -39,7 +39,7 @@ export type GlobalsFunction = (name: string) => string;
 
 export type MinifyOptions = Omit<
   BindingMinifyOptions,
-  'module' | 'codegen' | 'sorucemap'
+  'module' | 'codegen' | 'sourcemap'
 >;
 
 export interface ChunkingContext {


### PR DESCRIPTION
There was a typo.