### PR TITLE
fix: allow keeping whitespace while enabling minify

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/minify_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/minify_assets.rs
@@ -18,14 +18,15 @@ impl GenerateStage<'_> {
     options: &NormalizedBundlerOptions,
     assets: &mut AssetVec,
   ) -> BuildResult<()> {
-    let (compress, minify_option) = match &options.minify {
+    let (compress, minify_option, remove_whitespace) = match &options.minify {
       MinifyOptions::Disabled => return Ok(()),
-      MinifyOptions::DeadCodeEliminationOnly => {
-        (false, &MinifierOptions { mangle: None, compress: Some(CompressOptions::default()) })
-      }
-      MinifyOptions::Enabled(options) => (true, options),
+      MinifyOptions::DeadCodeEliminationOnly => (
+        false,
+        &MinifierOptions { mangle: None, compress: Some(CompressOptions::default()) },
+        false,
+      ),
+      MinifyOptions::Enabled((options, remove_whitespace)) => (true, options, *remove_whitespace),
     };
-    let remove_whitespace = compress;
     let allocator_pool = AllocatorPool::new(rayon::current_num_threads());
     assets.par_iter_mut().try_for_each(|asset| -> anyhow::Result<()> {
       if test_d_ts_pattern(&asset.filename) {

--- a/crates/rolldown_binding/src/utils/minify_options_conversion.rs
+++ b/crates/rolldown_binding/src/utils/minify_options_conversion.rs
@@ -37,3 +37,9 @@ pub fn compress_options_to_napi_compress_options(
     },
   }
 }
+
+pub fn codegen_options_to_napi_codegen_options(
+  remove_whitespace: bool,
+) -> oxc_minify_napi::CodegenOptions {
+  oxc_minify_napi::CodegenOptions { remove_whitespace: Some(remove_whitespace) }
+}

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -333,10 +333,15 @@ pub fn normalize_binding_options(
             Err(napi::Error::new(napi::Status::InvalidArg, "Invalid minify option"))
           }
         }
-        napi::bindgen_prelude::Either3::C(opts) => Ok(RawMinifyOptions::Object(
+        napi::bindgen_prelude::Either3::C(opts) => Ok(RawMinifyOptions::Object((
           oxc::minifier::MinifierOptions::try_from(&opts)
             .map_err(|_| napi::Error::new(napi::Status::InvalidArg, "Invalid minify option"))?,
-        )),
+          match &opts.codegen {
+            None => true,
+            Some(Either::A(bool)) => *bool,
+            Some(Either::B(codegen_opts)) => codegen_opts.remove_whitespace.unwrap_or(true),
+          },
+        ))),
       })
       .transpose()?,
     extend: output_options.extend,

--- a/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 pub enum RawMinifyOptions {
   Bool(bool),
   DeadCodeEliminationOnly,
-  Object(oxc::minifier::MinifierOptions),
+  Object((oxc::minifier::MinifierOptions, bool)),
 }
 
 impl RawMinifyOptions {
@@ -44,10 +44,10 @@ impl RawMinifyOptions {
             treeshake: TreeShakeOptions::from(&options.treeshake),
             ..CompressOptions::smallest()
           };
-          MinifyOptions::Enabled(oxc::minifier::MinifierOptions {
-            mangle: Some(mangle),
-            compress: Some(compress),
-          })
+          MinifyOptions::Enabled((
+            oxc::minifier::MinifierOptions { mangle: Some(mangle), compress: Some(compress) },
+            true,
+          ))
         } else {
           MinifyOptions::Disabled
         }
@@ -76,7 +76,7 @@ pub enum MinifyOptions {
   Disabled,
   DeadCodeEliminationOnly,
   /// Setting all values to false in `MinifyOptionsObject` means DCE only.
-  Enabled(oxc::minifier::MinifierOptions),
+  Enabled((oxc::minifier::MinifierOptions, bool)),
 }
 
 impl MinifyOptions {

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -39,7 +39,7 @@ export type GlobalsFunction = (name: string) => string;
 
 export type MinifyOptions = Omit<
   BindingMinifyOptions,
-  'module' | 'codegen' | 'sourcemap'
+  'module' | 'sourcemap'
 >;
 
 export interface ChunkingContext {

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -328,9 +328,14 @@ const MangleOptionsSchema = v.strictObject({
   debug: v.optional(v.boolean()),
 });
 
+const CodegenOptionsSchema = v.strictObject({
+  removeWhitespace: v.optional(v.boolean()),
+});
+
 const MinifyOptionsSchema = v.strictObject({
   compress: v.optional(v.union([v.boolean(), CompressOptionsSchema])),
   mangle: v.optional(v.union([v.boolean(), MangleOptionsSchema])),
+  codegen: v.optional(v.union([v.boolean(), CodegenOptionsSchema])),
 });
 
 const ResolveOptionsSchema = v.strictObject({


### PR DESCRIPTION
`output: { minify: { codegen: false } }` was no longer possible to specify. This PR fixes that.

requires https://github.com/oxc-project/oxc/pull/13288
