### PR TITLE
fix: 5802

### DIFF
--- a/packages/rolldown/src/builtin-plugin/alias-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/alias-plugin.ts
@@ -11,5 +11,5 @@ type AliasPluginConfig = {
 };
 
 export function aliasPlugin(config: AliasPluginConfig): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:alias', config);
+  return BuiltinPlugin.getInstance('builtin:alias', config);
 }

--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -20,7 +20,7 @@ import { BuiltinPlugin, makeBuiltinPluginCallable } from './utils';
 export function modulePreloadPolyfillPlugin(
   config?: BindingModulePreloadPolyfillPluginConfig,
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:module-preload-polyfill', config);
+  return BuiltinPlugin.getInstance('builtin:module-preload-polyfill', config);
 }
 
 type DynamicImportVarsPluginConfig =
@@ -40,84 +40,87 @@ export function dynamicImportVarsPlugin(
     config.include = normalizedStringOrRegex(config.include);
     config.exclude = normalizedStringOrRegex(config.exclude);
   }
-  return new BuiltinPlugin('builtin:dynamic-import-vars', config);
+  return BuiltinPlugin.getInstance('builtin:dynamic-import-vars', config);
 }
 
 export function importGlobPlugin(
   config?: BindingImportGlobPluginConfig,
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:import-glob', config);
+  return BuiltinPlugin.getInstance('builtin:import-glob', config);
 }
 
 export function reporterPlugin(
   config?: BindingReporterPluginConfig,
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:reporter', config);
+  return BuiltinPlugin.getInstance('builtin:reporter', config);
 }
 
 export function manifestPlugin(
   config?: BindingManifestPluginConfig,
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:manifest', config);
+  return BuiltinPlugin.getInstance('builtin:manifest', config);
 }
 
 export function wasmHelperPlugin(
   config?: BindingWasmHelperPluginConfig,
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:wasm-helper', config);
+  return BuiltinPlugin.getInstance('builtin:wasm-helper', config);
 }
 
 export function wasmFallbackPlugin(): BuiltinPlugin {
-  const builtinPlugin = new BuiltinPlugin('builtin:wasm-fallback');
+  const builtinPlugin = BuiltinPlugin.getInstance('builtin:wasm-fallback');
   return makeBuiltinPluginCallable(builtinPlugin);
 }
 
 export function loadFallbackPlugin(): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:load-fallback');
+  return BuiltinPlugin.getInstance('builtin:load-fallback');
 }
 
 export function jsonPlugin(config?: BindingJsonPluginConfig): BuiltinPlugin {
-  const builtinPlugin = new BuiltinPlugin('builtin:json', config);
+  const builtinPlugin = BuiltinPlugin.getInstance('builtin:json', config);
   return makeBuiltinPluginCallable(builtinPlugin);
 }
 
 export function buildImportAnalysisPlugin(
   config: BindingBuildImportAnalysisPluginConfig,
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:build-import-analysis', config);
+  return BuiltinPlugin.getInstance('builtin:build-import-analysis', config);
 }
 
 export function viteResolvePlugin(
   config: BindingViteResolvePluginConfig,
 ): BuiltinPlugin {
-  const builtinPlugin = new BuiltinPlugin('builtin:vite-resolve', config);
+  const builtinPlugin = BuiltinPlugin.getInstance(
+    'builtin:vite-resolve',
+    config,
+  );
   return makeBuiltinPluginCallable(builtinPlugin);
 }
 
 export function isolatedDeclarationPlugin(
   config?: BindingIsolatedDeclarationPluginConfig,
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:isolated-declaration', config);
+  return BuiltinPlugin.getInstance('builtin:isolated-declaration', config);
 }
 
 export function assetPlugin(
   config?: BindingAssetPluginConfig,
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:asset', config);
+  return BuiltinPlugin.getInstance('builtin:asset', config);
 }
 
 export function webWorkerPostPlugin(): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:web-worker-post');
+  return BuiltinPlugin.getInstance('builtin:web-worker-post');
 }
 
 export function oxcRuntimePlugin(
   config?: BindingOxcRuntimePluginConfig,
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:oxc-runtime', config);
+  return BuiltinPlugin.getInstance('builtin:oxc-runtime', config);
 }
 
 export function esmExternalRequirePlugin(
   config?: BindingEsmExternalRequirePluginConfig,
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:esm-external-require', config);
+  return BuiltinPlugin.getInstance('builtin:esm-external-require', config);
 }

--- a/packages/rolldown/src/builtin-plugin/replace-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/replace-plugin.ts
@@ -28,5 +28,5 @@ export function replacePlugin(
   values: BindingReplacePluginConfig['values'] = {},
   options: Omit<BindingReplacePluginConfig, 'values'> = {},
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:replace', { ...options, values });
+  return BuiltinPlugin.getInstance('builtin:replace', { ...options, values });
 }

--- a/packages/rolldown/src/builtin-plugin/transform-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/transform-plugin.ts
@@ -28,5 +28,5 @@ export function transformPlugin(config?: TransformPluginConfig): BuiltinPlugin {
       jsxRefreshExclude: normalizedStringOrRegex(config.jsxRefreshExclude),
     };
   }
-  return new BuiltinPlugin('builtin:transform', config);
+  return BuiltinPlugin.getInstance('builtin:transform', config);
 }

--- a/packages/rolldown/src/builtin-plugin/utils.ts
+++ b/packages/rolldown/src/builtin-plugin/utils.ts
@@ -9,12 +9,32 @@ type BindingCallableBuiltinPluginLike = {
   [K in keyof BindingCallableBuiltinPlugin]: BindingCallableBuiltinPlugin[K];
 };
 
+const CLASS_SYMBOL = Symbol.for('BuiltinPlugin');
+
+// Our cli use `.mjs`, but the configuration maybe use `.cjs` entry(if use require to load builtin plugins or use cts configuration).
+// Use this pattern to ensure the whole process use same `BuiltinPlugin` class.
 export class BuiltinPlugin {
-  constructor(
+  // Make constructor private to enforce singleton pattern
+  //
+  private constructor(
     public name: BindingBuiltinPluginName,
     // NOTE: has `_` to avoid conflict with `options` hook
     public _options?: unknown,
-  ) {}
+  ) {
+  }
+
+  static getInstance(
+    name: BindingBuiltinPluginName,
+    _options?: unknown,
+  ): BuiltinPlugin {
+    // @ts-ignore
+    if (!globalThis[CLASS_SYMBOL]) {
+      // @ts-ignore
+      globalThis[CLASS_SYMBOL] = BuiltinPlugin;
+    }
+    // @ts-ignore
+    return new globalThis[CLASS_SYMBOL](name, _options);
+  }
 }
 
 export function makeBuiltinPluginCallable(


### PR DESCRIPTION
### TL;DR

Implemented a singleton pattern for `BuiltinPlugin` class to ensure consistent instances across different module systems.

### What changed?

- Modified the `BuiltinPlugin` class to use a singleton pattern with a private constructor
- Added a static `getInstance()` method that replaces direct instantiation
- Introduced a global symbol `Symbol.for('BuiltinPlugin')` to store the class reference
- Updated all plugin factory functions to use `BuiltinPlugin.getInstance()` instead of `new BuiltinPlugin()`

### How to test?

1. Verify that all built-in plugins work correctly in both ESM and CommonJS environments
2. Test with mixed module systems (e.g., `.mjs` and `.cjs` files in the same project)
3. Ensure plugins maintain consistent behavior across different import methods

### Why make this change?

This change addresses potential issues when using different module systems in the same process. Since the CLI uses `.mjs` but configurations might use `.cjs` (via `require` or TypeScript CTS files), we need to ensure the same `BuiltinPlugin` class is used throughout the application. The singleton pattern guarantees consistent plugin instances regardless of how they're imported or which module system is used.