### PR TITLE
fix: inlineConst inlines a var

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -221,9 +221,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
                 if let Some(value) = self.extract_constant_value_from_expr(Some(&node.right)) {
                   self
-                    .result
-                    .constant_export_map
-                    .insert(exported_symbol.symbol, ConstExportMeta::new(value, true));
+                    .add_constant_symbol(exported_symbol.symbol, ConstExportMeta::new(value, true));
                 }
 
                 self.result.commonjs_exports.insert(
@@ -340,10 +338,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
           // Extract constant value for top-level variable declarations
           if self.is_root_symbol(binding.symbol_id()) {
             if let Some(value) = self.extract_constant_value_from_expr(Some(init)) {
-              self
-                .result
-                .constant_export_map
-                .insert(binding.symbol_id(), ConstExportMeta::new(value, false));
+              self.add_constant_symbol(binding.symbol_id(), ConstExportMeta::new(value, false));
             }
           }
         }
@@ -354,10 +349,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
             if let BindingPatternKind::BindingIdentifier(binding) = &var_decl.id.kind {
               if let Some(init) = &var_decl.init {
                 if let Some(value) = self.extract_constant_value_from_expr(Some(init)) {
-                  self
-                    .result
-                    .constant_export_map
-                    .insert(binding.symbol_id(), ConstExportMeta::new(value, false));
+                  self.add_constant_symbol(binding.symbol_id(), ConstExportMeta::new(value, false));
                 }
               }
             }

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/issue_5902/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/issue_5902/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "optimization": {
+      "inlineConst": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/issue_5902/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/issue_5902/artifacts.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+//#region foo.mjs
+var foo = null;
+function setFoo(_foo) {
+	foo = _foo;
+}
+
+//#endregion
+//#region main.js
+setFoo(20);
+assert.strictEqual(foo, 20);
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/issue_5902/foo.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/issue_5902/foo.mjs
@@ -1,0 +1,4 @@
+export var foo = null;
+export function setFoo(_foo) {
+  foo = _foo;
+}

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/issue_5902/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/issue_5902/main.js
@@ -1,0 +1,6 @@
+import { foo, setFoo } from './foo.mjs'
+import assert from 'node:assert'
+
+
+setFoo(20)
+assert.strictEqual(foo, 20)

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5002,6 +5002,10 @@ expression: output
 
 - main-!~{000}~.js => main-CbeGViBB.js
 
+# tests/rolldown/optimization/inline_const/issue_5902
+
+- main-!~{000}~.js => main-RyfaQvKc.js
+
 # tests/rolldown/optimization/inline_const/ns_chain
 
 - main-!~{000}~.js => main-Brb9u1JP.js

--- a/crates/rolldown_common/src/types/ast_scopes.rs
+++ b/crates/rolldown_common/src/types/ast_scopes.rs
@@ -100,6 +100,11 @@ impl AstScopes {
   }
 
   #[inline]
+  pub fn is_facade_symbol(&self, symbol_id: SymbolId) -> bool {
+    symbol_id.index() >= self.facade_scoping.minimum_symbol_id.index()
+  }
+
+  #[inline]
   pub fn real_symbol_length(&self) -> usize {
     self.scoping.symbols_len()
   }


### PR DESCRIPTION
Now, only `VarDecl` that is not mutated will be added into `constant_symbol_map`
Closed #5902