### PR TITLE
feat: mark `__export` runtime helper as pure

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -444,7 +444,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     ));
 
     // construct `__export(ns_name, { prop_name: () => returned, ... })`
-    let export_call_expr = self.snippet.builder.expression_call(
+    let export_call_expr = self.snippet.builder.expression_call_with_pure(
       SPAN,
       self.finalized_expr_for_runtime_symbol("__export"),
       NONE,
@@ -453,6 +453,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.alloc)),
       ]),
       false,
+      true,
     );
     let export_call_stmt = self.snippet.builder.statement_expression(SPAN, export_call_expr);
     let mut ret = vec![decl_stmt, export_call_stmt];

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index-module.js
 var index_module_exports = {};
-__export(index_module_exports, { foo: () => foo });
+/* @__PURE__ */ __export(index_module_exports, { foo: () => foo });
 var foo;
 var init_index_module = __esm({ "node_modules/demo-pkg/index-module.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index-module.js
 var index_module_exports = {};
-__export(index_module_exports, { foo: () => foo });
+/* @__PURE__ */ __export(index_module_exports, { foo: () => foo });
 var foo;
 var init_index_module = __esm({ "node_modules/demo-pkg/index-module.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index.js
 var demo_pkg_exports = {};
-__export(demo_pkg_exports, { foo: () => foo });
+/* @__PURE__ */ __export(demo_pkg_exports, { foo: () => foo });
 var foo;
 var init_demo_pkg = __esm({ "node_modules/demo-pkg/index.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index.js
 var demo_pkg_exports = {};
-__export(demo_pkg_exports, { foo: () => foo });
+/* @__PURE__ */ __export(demo_pkg_exports, { foo: () => foo });
 const foo = 123;
 console.log("hello");
 

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
@@ -19,7 +19,7 @@ var init_lib = __esm({ "lib.js": (() => {
 //#endregion
 //#region cjs.js
 var cjs_exports = {};
-__export(cjs_exports, { default: () => cjs_default });
+/* @__PURE__ */ __export(cjs_exports, { default: () => cjs_default });
 var cjs_default;
 var init_cjs = __esm({ "cjs.js": (() => {
 	init_lib();

--- a/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo$1 });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo$1 });
 function foo$1() {
 	return "foo";
 }
@@ -20,7 +20,7 @@ var init_foo = __esm({ "foo.js": (() => {}) });
 //#endregion
 //#region bar.js
 var bar_exports = {};
-__export(bar_exports, { bar: () => bar$1 });
+/* @__PURE__ */ __export(bar_exports, { bar: () => bar$1 });
 function bar$1() {
 	return "bar";
 }

--- a/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
@@ -16,7 +16,7 @@ var init_a = __esm({ "a.js": (() => {
 //#endregion
 //#region b.js
 var b_exports = {};
-__export(b_exports, { xyz: () => xyz });
+/* @__PURE__ */ __export(b_exports, { xyz: () => xyz });
 var xyz;
 var init_b = __esm({ "b.js": (() => {
 	xyz = null;
@@ -25,7 +25,7 @@ var init_b = __esm({ "b.js": (() => {
 //#endregion
 //#region commonjs.js
 var commonjs_exports = {};
-__export(commonjs_exports, {
+/* @__PURE__ */ __export(commonjs_exports, {
 	C: () => Class,
 	Class: () => Class,
 	Fn: () => Fn,
@@ -51,7 +51,7 @@ var init_commonjs = __esm({ "commonjs.js": (() => {
 //#endregion
 //#region c.js
 var c_exports = {};
-__export(c_exports, { default: () => c_default });
+/* @__PURE__ */ __export(c_exports, { default: () => c_default });
 var c_default;
 var init_c = __esm({ "c.js": (() => {
 	c_default = class {};
@@ -60,7 +60,7 @@ var init_c = __esm({ "c.js": (() => {
 //#endregion
 //#region d.js
 var d_exports = {};
-__export(d_exports, { default: () => Foo });
+/* @__PURE__ */ __export(d_exports, { default: () => Foo });
 var Foo;
 var init_d = __esm({ "d.js": (() => {
 	Foo = class {};
@@ -70,14 +70,14 @@ var init_d = __esm({ "d.js": (() => {
 //#endregion
 //#region e.js
 var e_exports = {};
-__export(e_exports, { default: () => e_default });
+/* @__PURE__ */ __export(e_exports, { default: () => e_default });
 function e_default() {}
 var init_e = __esm({ "e.js": (() => {}) });
 
 //#endregion
 //#region f.js
 var f_exports = {};
-__export(f_exports, { default: () => foo$1 });
+/* @__PURE__ */ __export(f_exports, { default: () => foo$1 });
 function foo$1() {}
 var init_f = __esm({ "f.js": (() => {
 	foo$1.prop = 123;
@@ -86,14 +86,14 @@ var init_f = __esm({ "f.js": (() => {
 //#endregion
 //#region g.js
 var g_exports = {};
-__export(g_exports, { default: () => g_default });
+/* @__PURE__ */ __export(g_exports, { default: () => g_default });
 async function g_default() {}
 var init_g = __esm({ "g.js": (() => {}) });
 
 //#endregion
 //#region h.js
 var h_exports = {};
-__export(h_exports, { default: () => foo });
+/* @__PURE__ */ __export(h_exports, { default: () => foo });
 async function foo() {}
 var init_h = __esm({ "h.js": (() => {
 	foo.prop = 123;

--- a/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
@@ -13,7 +13,7 @@ const abc = void 0;
 //#endregion
 //#region b.js
 var b_exports = {};
-__export(b_exports, { xyz: () => xyz });
+/* @__PURE__ */ __export(b_exports, { xyz: () => xyz });
 const xyz = null;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
@@ -25,7 +25,7 @@ const abc = void 0;
 //#endregion
 //#region b.js
 var b_exports = {};
-__export(b_exports, { xyz: () => xyz });
+/* @__PURE__ */ __export(b_exports, { xyz: () => xyz });
 const xyz = null;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
@@ -34,7 +34,7 @@ export { b_default as default };
 // HIDDEN [rolldown:runtime]
 //#region b.js
 var b_exports = {};
-__export(b_exports, { default: () => b_default });
+/* @__PURE__ */ __export(b_exports, { default: () => b_default });
 function b_default() {}
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
@@ -11,13 +11,13 @@ const node_assert = __toESM(require("node:assert"));
 
 //#region foo/test.js
 var test_exports = {};
-__export(test_exports, { foo: () => foo });
+/* @__PURE__ */ __export(test_exports, { foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
 var test_exports$1 = {};
-__export(test_exports$1, { bar: () => bar });
+/* @__PURE__ */ __export(test_exports$1, { bar: () => bar });
 let bar = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
@@ -12,25 +12,25 @@ import { ns } from "x";
 // HIDDEN [rolldown:runtime]
 //#region a.js
 var a_exports = {};
-__export(a_exports, { ns: () => ns$1 });
+/* @__PURE__ */ __export(a_exports, { ns: () => ns$1 });
 var init_a = __esm({ "a.js": (() => {}) });
 
 //#endregion
 //#region b.js
 var b_exports = {};
-__export(b_exports, { ns: () => ns$1 });
+/* @__PURE__ */ __export(b_exports, { ns: () => ns$1 });
 var init_b = __esm({ "b.js": (() => {}) });
 
 //#endregion
 //#region c.js
 var c_exports = {};
-__export(c_exports, { ns: () => ns$1 });
+/* @__PURE__ */ __export(c_exports, { ns: () => ns$1 });
 var init_c = __esm({ "c.js": (() => {}) });
 
 //#endregion
 //#region d.js
 var d_exports = {};
-__export(d_exports, { ns: () => ns });
+/* @__PURE__ */ __export(d_exports, { ns: () => ns });
 var init_d = __esm({ "d.js": (() => {}) });
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/forbid_string_export_names_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/forbid_string_export_names_bundle/artifacts.snap
@@ -17,7 +17,7 @@ let nested$1 = 2;
 //#endregion
 //#region nested.js
 var nested_exports = {};
-__export(nested_exports, {
+/* @__PURE__ */ __export(nested_exports, {
 	"nested name": () => nested,
 	"very nested name": () => nested$1
 });

--- a/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region esm.js
 var esm_exports = {};
-__export(esm_exports, { esm_foo_: () => esm_foo_ });
+/* @__PURE__ */ __export(esm_exports, { esm_foo_: () => esm_foo_ });
 var esm_foo_;
 var init_esm = __esm({ "esm.js": (() => {
 	esm_foo_ = "foo";

--- a/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
@@ -10,13 +10,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 //#region foo/test.js
 var test_exports = {};
-__export(test_exports, { foo: () => foo });
+/* @__PURE__ */ __export(test_exports, { foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
 var test_exports$1 = {};
-__export(test_exports$1, { bar: () => bar });
+/* @__PURE__ */ __export(test_exports$1, { bar: () => bar });
 let bar = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 //#region entry.js
 var entry_exports = {};
-__export(entry_exports, { foo: () => foo });
+/* @__PURE__ */ __export(entry_exports, { foo: () => foo });
 const foo = 123;
 console.log(entry_exports);
 

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 //#region entry.js
 var entry_exports = {};
-__export(entry_exports, { foo: () => foo });
+/* @__PURE__ */ __export(entry_exports, { foo: () => foo });
 var foo;
 var init_entry = __esm({ "entry.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 //#region entry.js
 var entry_exports = {};
-__export(entry_exports, {
+/* @__PURE__ */ __export(entry_exports, {
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region entry.js
 var entry_exports = {};
-__export(entry_exports, {
+/* @__PURE__ */ __export(entry_exports, {
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
@@ -232,7 +232,7 @@ console.log(internal_default, internal_exports);
 // HIDDEN [rolldown:runtime]
 //#region internal.js
 var internal_exports = {};
-__export(internal_exports, { default: () => internal_default });
+/* @__PURE__ */ __export(internal_exports, { default: () => internal_default });
 var internal_default = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region entry.js
 var entry_exports = {};
-__export(entry_exports, {
+/* @__PURE__ */ __export(entry_exports, {
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo });
 var foo;
 var init_foo = __esm({ "foo.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo$1 });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo$1 });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo$1 });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
@@ -15,7 +15,7 @@ const foo$1 = 123;
 //#endregion
 //#region bar.js
 var bar_exports = {};
-__export(bar_exports, { foo: () => foo$1 });
+/* @__PURE__ */ __export(bar_exports, { foo: () => foo$1 });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
@@ -19,7 +19,7 @@ const z = 4;
 //#endregion
 //#region common.js
 var common_exports = {};
-__export(common_exports, {
+/* @__PURE__ */ __export(common_exports, {
 	x: () => x,
 	z: () => z
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
@@ -11,13 +11,13 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region bar.js
 var bar_exports = {};
-__export(bar_exports, { bar: () => bar });
+/* @__PURE__ */ __export(bar_exports, { bar: () => bar });
 const bar = 123;
 
 //#endregion
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { bar_ns: () => bar_exports });
+/* @__PURE__ */ __export(foo_exports, { bar_ns: () => bar_exports });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
@@ -13,7 +13,7 @@ const foo = () => "hi there";
 //#endregion
 //#region folders/index.js
 var folders_exports = {};
-__export(folders_exports, { foo: () => foo });
+/* @__PURE__ */ __export(folders_exports, { foo: () => foo });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
@@ -25,7 +25,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { x: () => x });
+/* @__PURE__ */ __export(foo_exports, { x: () => x });
 const x = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
@@ -29,7 +29,7 @@ const x = 123;
 //#endregion
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { x: () => x });
+/* @__PURE__ */ __export(foo_exports, { x: () => x });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
@@ -25,7 +25,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region bar.js
 var bar_exports = {};
-__export(bar_exports, { x: () => x });
+/* @__PURE__ */ __export(bar_exports, { x: () => x });
 const x = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, {
+/* @__PURE__ */ __export(foo_exports, {
 	foo: () => foo,
 	ns: () => foo_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, {
+/* @__PURE__ */ __export(foo_exports, {
 	foo: () => foo,
 	ns: () => foo_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_and_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_and_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo });
 var foo;
 var init_foo = __esm({ "foo.ts": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo$1 });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo$1 });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo$1 });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
@@ -13,7 +13,7 @@ const foo$1 = 123;
 //#endregion
 //#region bar.ts
 var bar_exports = {};
-__export(bar_exports, { foo: () => foo$1 });
+/* @__PURE__ */ __export(bar_exports, { foo: () => foo$1 });
 
 //#endregion
 //#region entry.ts

--- a/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
@@ -13,7 +13,7 @@ var invalid_identifier$1 = true;
 //#endregion
 //#region test2.json
 var test2_exports = {};
-__export(test2_exports, {
+/* @__PURE__ */ __export(test2_exports, {
 	default: () => test2_default,
 	"invalid-identifier": () => invalid_identifier
 });

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.browser.js
 var module_browser_exports = {};
-__export(module_browser_exports, { default: () => module_browser_default });
+/* @__PURE__ */ __export(module_browser_exports, { default: () => module_browser_default });
 var module_browser_default;
 var init_module_browser = __esm({ "node_modules/demo-pkg/module.browser.js": (() => {
 	module_browser_default = "browser module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
 var module_exports = {};
-__export(module_exports, { default: () => module_default });
+/* @__PURE__ */ __export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main/artifacts.snap
@@ -11,7 +11,7 @@ import assert, { deepEqual } from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
 var module_exports = {};
-__export(module_exports, { default: () => module_default });
+/* @__PURE__ */ __export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
 var module_exports = {};
-__export(module_exports, { default: () => module_default });
+/* @__PURE__ */ __export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
 var module_exports = {};
-__export(module_exports, { default: () => module_default });
+/* @__PURE__ */ __export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
 var module_exports = {};
-__export(module_exports, { default: () => module_default });
+/* @__PURE__ */ __export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_require_only/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_require_only/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
 var module_exports = {};
-__export(module_exports, { default: () => module_default });
+/* @__PURE__ */ __export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
@@ -17,7 +17,7 @@ export { foo };
 // HIDDEN [rolldown:runtime]
 //#region a.js
 var a_exports = {};
-__export(a_exports, { foo: () => foo });
+/* @__PURE__ */ __export(a_exports, { foo: () => foo });
 var foo;
 var init_a = __esm({ "a.js": (() => {
 	;

--- a/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
@@ -9,13 +9,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region a.ts
 var a_exports = {};
-__export(a_exports, { foo: () => foo$3 });
+/* @__PURE__ */ __export(a_exports, { foo: () => foo$3 });
 let foo$3 = 123;
 
 //#endregion
 //#region b.ts
 var b_exports = {};
-__export(b_exports, { foo: () => foo$2 });
+/* @__PURE__ */ __export(b_exports, { foo: () => foo$2 });
 let foo$2 = 123;
 
 //#endregion
@@ -25,7 +25,7 @@ var Test = void 0;
 //#endregion
 //#region c.ts
 var c_exports = {};
-__export(c_exports, {
+/* @__PURE__ */ __export(c_exports, {
 	Test: () => Test,
 	foo: () => foo$1
 });
@@ -34,7 +34,7 @@ let foo$1 = 123;
 //#endregion
 //#region d.ts
 var d_exports = {};
-__export(d_exports, {
+/* @__PURE__ */ __export(d_exports, {
 	Test: () => Test,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
@@ -13,7 +13,7 @@ var nope = void 0;
 //#endregion
 //#region foo.ts
 var foo_exports = {};
-__export(foo_exports, { nope: () => nope });
+/* @__PURE__ */ __export(foo_exports, { nope: () => nope });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region import.ts
 var import_exports = {};
-__export(import_exports, { value: () => value });
+/* @__PURE__ */ __export(import_exports, { value: () => value });
 let value = 123;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region esm.js
 var esm_exports = {};
-__export(esm_exports, {
+/* @__PURE__ */ __export(esm_exports, {
 	default: () => esm_default_fn,
 	esm_named_class: () => esm_named_class,
 	esm_named_fn: () => esm_named_fn,

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region esm.js
 var esm_exports = {};
-__export(esm_exports, { default: () => esm_default });
+/* @__PURE__ */ __export(esm_exports, { default: () => esm_default });
 var esm_default;
 var init_esm = __esm({ "esm.js": (() => {
 	esm_default = "esm";

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region esm.js
 var esm_exports = {};
-__export(esm_exports, { default: () => esm_default });
+/* @__PURE__ */ __export(esm_exports, { default: () => esm_default });
 var esm_default;
 var init_esm = __esm({ "esm.js": (() => {
 	esm_default = "esm";

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region json.js
 var json_exports = {};
-__export(json_exports, { default: () => json_default });
+/* @__PURE__ */ __export(json_exports, { default: () => json_default });
 var json_default;
 var init_json = __esm({ "json.js": (() => {
 	json_default = JSON.parse("[1, 2, 3]");

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
@@ -15,7 +15,7 @@ var require_react = /* @__PURE__ */ __commonJS({ "react.js": ((exports, module) 
 //#endregion
 //#region lib.js
 var lib_exports = {};
-__export(lib_exports, { default: () => toArray$1 });
+/* @__PURE__ */ __export(lib_exports, { default: () => toArray$1 });
 function toArray$1(children) {
 	import_react$1.default.Children.forEach(children, function(child) {});
 	return ret;

--- a/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
@@ -21,7 +21,7 @@ const value = 1;
 //#endregion
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, {
+/* @__PURE__ */ __export(foo_exports, {
 	bar: () => import_commonjs$1.bar,
 	value: () => value
 });

--- a/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region esm.js
 var esm_exports = {};
-__export(esm_exports, { a: () => a$1 });
+/* @__PURE__ */ __export(esm_exports, { a: () => a$1 });
 var a$1;
 var init_esm = __esm({ "esm.js": (() => {
 	a$1 = 100;

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo });
 const foo = 1;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
@@ -41,7 +41,7 @@ const require_chunk = require('./chunk.js');
 
 //#region esm.js
 var esm_exports = {};
-require_chunk.__export(esm_exports, { share: () => share });
+/* @__PURE__ */ require_chunk.__export(esm_exports, { share: () => share });
 function share() {
 	return 1;
 }

--- a/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region lib.prod.js
 var lib_prod_exports = {};
-__export(lib_prod_exports, { default: () => lib_prod_default });
+/* @__PURE__ */ __export(lib_prod_exports, { default: () => lib_prod_default });
 var lib_prod_default;
 var init_lib_prod = __esm({ "lib.prod.js": (() => {
 	lib_prod_default = "prod";

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
@@ -18,13 +18,13 @@ import { __export } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-npm-a/index.js
 var lib_npm_a_exports = {};
-__export(lib_npm_a_exports, { default: () => lib_npm_a_default });
+/* @__PURE__ */ __export(lib_npm_a_exports, { default: () => lib_npm_a_default });
 var lib_npm_a_default = "npm-a";
 
 //#endregion
 //#region node_modules/lib-npm-b/index.js
 var lib_npm_b_exports = {};
-__export(lib_npm_b_exports, { default: () => lib_npm_b_default });
+/* @__PURE__ */ __export(lib_npm_b_exports, { default: () => lib_npm_b_default });
 var lib_npm_b_default = "npm-b";
 
 //#endregion
@@ -52,7 +52,7 @@ import { __export } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-ui/index.js
 var lib_ui_exports = {};
-__export(lib_ui_exports, { default: () => lib_ui_default });
+/* @__PURE__ */ __export(lib_ui_exports, { default: () => lib_ui_default });
 var lib_ui_default = "ui";
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/export_mode/cjs/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/cjs/default/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 //#region mod.js
 var default_exports = {};
-__export(default_exports, { default: () => example });
+/* @__PURE__ */ __export(default_exports, { default: () => example });
 function example() {
 	return "default";
 }

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/default/artifacts.snap
@@ -12,7 +12,7 @@ var module = (function() {
 
 //#region mod.js
 var default_exports = {};
-__export(default_exports, {
+/* @__PURE__ */ __export(default_exports, {
 	add: () => add,
 	subtract: () => subtract
 });

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
@@ -13,7 +13,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 //#region mod.js
 var named_exports = {};
-__export(named_exports, {
+/* @__PURE__ */ __export(named_exports, {
 	add: () => add,
 	subtract: () => subtract
 });

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
@@ -20,7 +20,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 //#endregion
 //#region esm.js
 var esm_exports = {};
-__export(esm_exports, { value: () => value });
+/* @__PURE__ */ __export(esm_exports, { value: () => value });
 var value;
 var init_esm = __esm({ "esm.js": (() => {
 	value = 1;

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
@@ -19,7 +19,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 //#endregion
 //#region esm.js
 var esm_exports = {};
-__export(esm_exports, { value: () => value });
+/* @__PURE__ */ __export(esm_exports, { value: () => value });
 var value;
 var init_esm = __esm({ "esm.js": (() => {
 	value = 1;

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
@@ -22,7 +22,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 //#endregion
 //#region esm.js
 var esm_exports = {};
-__export(esm_exports, { value: () => value });
+/* @__PURE__ */ __export(esm_exports, { value: () => value });
 var value;
 var init_esm = __esm({ "esm.js": (() => {
 	value = 1;

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -11,7 +11,7 @@ import { init_second, value } from "./second.js";
 
 //#region first.js
 var first_exports = {};
-__export(first_exports, { value: () => value$1 });
+/* @__PURE__ */ __export(first_exports, { value: () => value$1 });
 var value$1;
 var init_first = __esm({ "first.js": (() => {
 	init_second();
@@ -52,7 +52,7 @@ import { init_first, value } from "./first.js";
 
 //#region second.js
 var second_exports = {};
-__export(second_exports, { value: () => value$1 });
+/* @__PURE__ */ __export(second_exports, { value: () => value$1 });
 var value$1;
 var init_second = __esm({ "second.js": (() => {
 	init_first();

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region lib.js
 var lib_exports = {};
-__export(lib_exports, { constant: () => constant });
+/* @__PURE__ */ __export(lib_exports, { constant: () => constant });
 var constant;
 var init_lib = __esm({ "lib.js": (() => {
 	constant = 1;
@@ -51,7 +51,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region lib.js
 var lib_exports = {};
-__export(lib_exports, { constant: () => constant });
+/* @__PURE__ */ __export(lib_exports, { constant: () => constant });
 var constant;
 var init_lib = __esm({ "lib.js": (() => {
 	constant = 1;

--- a/crates/rolldown/tests/rolldown/issues/5923/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/5923/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "external": ["external"],
+    "minify": "dceOnly"
+
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/5923/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5923/artifacts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+export * from "external";
+Object.defineProperty;
+Object.getOwnPropertyDescriptor;
+Object.getOwnPropertyNames;
+Object.prototype.hasOwnProperty;
+let foo;
+export { foo };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/5923/dep.js
+++ b/crates/rolldown/tests/rolldown/issues/5923/dep.js
@@ -1,0 +1,1 @@
+export * from 'external'

--- a/crates/rolldown/tests/rolldown/issues/5923/main.js
+++ b/crates/rolldown/tests/rolldown/issues/5923/main.js
@@ -1,0 +1,2 @@
+export let foo
+export * from './dep.js'

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
@@ -11,7 +11,7 @@ import nodeAssert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region lib-impl.js
 var lib_impl_exports = {};
-__export(lib_impl_exports, { foo: () => foo });
+/* @__PURE__ */ __export(lib_impl_exports, { foo: () => foo });
 function foo() {
 	return fn();
 }

--- a/crates/rolldown/tests/rolldown/misc/invalid_ident_repr/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/invalid_ident_repr/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region 1aaa.js
 var _1aaa_exports = {};
-__export(_1aaa_exports, { default: () => _1aaa_default });
+/* @__PURE__ */ __export(_1aaa_exports, { default: () => _1aaa_default });
 const a$1 = "shared.js";
 var _1aaa_default = a$1;
 

--- a/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region a.js
 var a_exports = {};
-__export(a_exports, { abc: () => abc });
+/* @__PURE__ */ __export(a_exports, { abc: () => abc });
 const abc = void 0;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, {
+/* @__PURE__ */ __export(foo_exports, {
 	a: () => a,
 	a1: () => a1,
 	a2: () => a2,

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/artifacts.snap
@@ -11,7 +11,7 @@ export * from "node:fs"
 // HIDDEN [rolldown:runtime]
 //#region main.js
 var main_exports = {};
-__export(main_exports, { main: () => main });
+/* @__PURE__ */ __export(main_exports, { main: () => main });
 import * as import_node_fs from "node:fs";
 __reExport(main_exports, import_node_fs);
 var main;

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 //#region main.js
 var main_exports = {};
-__export(main_exports, { main: () => main });
+/* @__PURE__ */ __export(main_exports, { main: () => main });
 __reExport(main_exports, require("node:fs"));
 var main;
 var init_main = __esm({ "main.js": (() => {

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { default: () => foo$1 });
+/* @__PURE__ */ __export(foo_exports, { default: () => foo$1 });
 function foo$1(a$1$1) {
 	assert.equal(a$1$1, a$1$1);
 	assert.equal(a$1, 1);

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "assert";
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo$1 });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo$1 });
 function foo$1(a$1$1) {
 	console.log(a$1$1, a$1);
 }

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
@@ -12,7 +12,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region child.js
 var child_exports = {};
-__export(child_exports, { foo: () => foo });
+/* @__PURE__ */ __export(child_exports, { foo: () => foo });
 const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
 __rolldown_runtime__.registerModule("child.js", { exports: child_exports });
 const foo = 0;

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -32,7 +32,7 @@ import { __export } from "./chunk.js";
 
 //#region exist-dep-esm.js
 var exist_dep_esm_exports = {};
-__export(exist_dep_esm_exports, { value: () => value });
+/* @__PURE__ */ __export(exist_dep_esm_exports, { value: () => value });
 const exist_dep_esm_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
 __rolldown_runtime__.registerModule("exist-dep-esm.js", { exports: exist_dep_esm_exports });
 const value = "exist-esm";
@@ -48,7 +48,7 @@ import { __export, __reExport, __toCommonJS, __toDynamicImportESM, __toESM } fro
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
 var hmr_exports = {};
-__export(hmr_exports, { foo: () => foo });
+/* @__PURE__ */ __export(hmr_exports, { foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 async function foo() {

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region sub/foo.js
 var foo_exports = {};
-__export(foo_exports, {
+/* @__PURE__ */ __export(foo_exports, {
 	foo: () => foo,
 	named: () => named$2
 });
@@ -22,7 +22,7 @@ const named$2 = "foo";
 //#endregion
 //#region sub/bar.js
 var bar_exports = {};
-__export(bar_exports, {
+/* @__PURE__ */ __export(bar_exports, {
 	bar: () => bar,
 	named: () => named$1
 });
@@ -34,7 +34,7 @@ const named$1 = "bar";
 //#endregion
 //#region sub/named.js
 var named_exports = {};
-__export(named_exports, { named: () => named });
+/* @__PURE__ */ __export(named_exports, { named: () => named });
 const named_hot = __rolldown_runtime__.createModuleHotContext("sub/named.js");
 __rolldown_runtime__.registerModule("sub/named.js", { exports: named_exports });
 const named = "named";
@@ -42,7 +42,7 @@ const named = "named";
 //#endregion
 //#region sub/index.js
 var sub_exports = {};
-__export(sub_exports, {
+/* @__PURE__ */ __export(sub_exports, {
 	bar: () => bar,
 	foo: () => foo,
 	named: () => named

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
 var hmr_exports = {};
-__export(hmr_exports, { foo: () => foo });
+/* @__PURE__ */ __export(hmr_exports, { foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
@@ -12,7 +12,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region self_accept.js
 var self_accept_exports = {};
-__export(self_accept_exports, { foo: () => foo });
+/* @__PURE__ */ __export(self_accept_exports, { foo: () => foo });
 const self_accept_hot = __rolldown_runtime__.createModuleHotContext("self_accept.js");
 __rolldown_runtime__.registerModule("self_accept.js", { exports: self_accept_exports });
 const foo = "foo";
@@ -23,7 +23,7 @@ self_accept_hot.accept((mod) => {
 //#endregion
 //#region single_accept/child.js
 var child_exports$1 = {};
-__export(child_exports$1, { count: () => count$2 });
+/* @__PURE__ */ __export(child_exports$1, { count: () => count$2 });
 const child_hot$1 = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
 __rolldown_runtime__.registerModule("single_accept/child.js", { exports: child_exports$1 });
 const count$2 = 0;
@@ -51,7 +51,7 @@ process.on("beforeExit", (code) => {
 //#endregion
 //#region array_accept/child.js
 var child_exports = {};
-__export(child_exports, { count: () => count });
+/* @__PURE__ */ __export(child_exports, { count: () => count });
 const child_hot = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
 __rolldown_runtime__.registerModule("array_accept/child.js", { exports: child_exports });
 const count = 0;

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region common.js
 var common_exports = {};
-__export(common_exports, { prefix: () => prefix });
+/* @__PURE__ */ __export(common_exports, { prefix: () => prefix });
 const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
 __rolldown_runtime__.registerModule("common.js", { exports: common_exports });
 const prefix = "prefix:";
@@ -18,7 +18,7 @@ const prefix = "prefix:";
 //#endregion
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
@@ -26,7 +26,7 @@ const foo = prefix + "foo";
 //#endregion
 //#region bar.js
 var bar_exports = {};
-__export(bar_exports, { bar: () => bar });
+/* @__PURE__ */ __export(bar_exports, { bar: () => bar });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
@@ -34,7 +34,7 @@ const bar = prefix + "bar";
 //#endregion
 //#region messenger.js
 var messenger_exports = {};
-__export(messenger_exports, {
+/* @__PURE__ */ __export(messenger_exports, {
 	msg: () => msg,
 	sayMessage: () => sayMessage
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region common.js
 var common_exports = {};
-__export(common_exports, { prefix: () => prefix });
+/* @__PURE__ */ __export(common_exports, { prefix: () => prefix });
 const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
 __rolldown_runtime__.registerModule("common.js", { exports: common_exports });
 const prefix = "prefix:";
@@ -18,7 +18,7 @@ const prefix = "prefix:";
 //#endregion
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
@@ -26,7 +26,7 @@ const foo = prefix + "foo";
 //#endregion
 //#region bar.js
 var bar_exports = {};
-__export(bar_exports, { bar: () => bar });
+/* @__PURE__ */ __export(bar_exports, { bar: () => bar });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
@@ -34,7 +34,7 @@ const bar = prefix + "bar";
 //#endregion
 //#region messenger.js
 var messenger_exports = {};
-__export(messenger_exports, {
+/* @__PURE__ */ __export(messenger_exports, {
 	msg: () => msg,
 	sayMessage: () => sayMessage
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -11,7 +11,7 @@ import { trim } from "./string.js";
 
 //#region bar.js
 var bar_exports = {};
-__export(bar_exports, { default: () => bar_default });
+/* @__PURE__ */ __export(bar_exports, { default: () => bar_default });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 function bar_default() {
@@ -35,7 +35,7 @@ import { trim, unused } from "./string.js";
 
 //#region utils/index.js
 var utils_exports = {};
-__export(utils_exports, {
+/* @__PURE__ */ __export(utils_exports, {
 	trim: () => trim,
 	unused: () => unused
 });
@@ -45,7 +45,7 @@ __rolldown_runtime__.registerModule("utils/index.js", { exports: utils_exports }
 //#endregion
 //#region foo.js
 var foo_exports = {};
-__export(foo_exports, { default: () => foo_default });
+/* @__PURE__ */ __export(foo_exports, { default: () => foo_default });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 function foo_default() {
@@ -79,7 +79,7 @@ import { __export } from "./chunk.js";
 
 //#region utils/string.js
 var string_exports = {};
-__export(string_exports, {
+/* @__PURE__ */ __export(string_exports, {
 	trim: () => trim,
 	unused: () => unused
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
@@ -10,7 +10,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
 var hmr_exports = {};
-__export(hmr_exports, { foo: () => foo });
+/* @__PURE__ */ __export(hmr_exports, { foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -19,7 +19,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 //#region esm.js
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 var esm_exports = {};
-__export(esm_exports, { value: () => value });
+/* @__PURE__ */ __export(esm_exports, { value: () => value });
 const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
 __rolldown_runtime__.registerModule("esm.js", { exports: esm_exports });
 const value = "main";

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -101,7 +101,7 @@ assert.strictEqual(requiredUmdLib.foo, "foo");
 //#endregion
 //#region cases/manual_reexport/lib.js
 var lib_exports = {};
-__export(lib_exports, {
+/* @__PURE__ */ __export(lib_exports, {
 	Globals: () => Globals,
 	value: () => value
 });
@@ -114,7 +114,7 @@ const value = "lib";
 //#endregion
 //#region cases/manual_reexport/barrel.js
 var barrel_exports = {};
-__export(barrel_exports, {
+/* @__PURE__ */ __export(barrel_exports, {
 	Globals: () => Globals,
 	value: () => value
 });
@@ -134,7 +134,7 @@ assert.strictEqual(Globals, Object);
 //#endregion
 //#region cases/deconflict_import_bindings/foo.mjs
 var foo_exports = {};
-__export(foo_exports, { foo: () => foo$1 });
+/* @__PURE__ */ __export(foo_exports, { foo: () => foo$1 });
 init_trigger_dep();
 const foo_hot$1 = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo.mjs");
 __rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo.mjs", { exports: foo_exports });
@@ -143,7 +143,7 @@ const foo$1 = "foo";
 //#endregion
 //#region cases/deconflict_import_bindings/foo/index.mjs
 var foo_exports$1 = {};
-__export(foo_exports$1, { foo: () => foo });
+/* @__PURE__ */ __export(foo_exports$1, { foo: () => foo });
 init_trigger_dep();
 const foo_hot = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo/index.mjs");
 __rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo/index.mjs", { exports: foo_exports$1 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -21,7 +21,7 @@ var require_dep_cjs = /* @__PURE__ */ __commonJS({ "modules/dep-cjs.js": ((expor
 //#region modules/dep-esm.js
 var import_dep_cjs = /* @__PURE__ */ __toESM(require_dep_cjs());
 var dep_esm_exports = {};
-__export(dep_esm_exports, { value: () => value$1 });
+/* @__PURE__ */ __export(dep_esm_exports, { value: () => value$1 });
 const dep_esm_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm.js");
 __rolldown_runtime__.registerModule("modules/dep-esm.js", { exports: dep_esm_exports });
 const value$1 = "esm";
@@ -38,7 +38,7 @@ var require_dep_cjs_default = /* @__PURE__ */ __commonJS({ "modules/dep-cjs-defa
 //#region modules/dep-esm-default.js
 var import_dep_cjs_default = /* @__PURE__ */ __toESM(require_dep_cjs_default());
 var dep_esm_default_exports = {};
-__export(dep_esm_default_exports, { default: () => dep_esm_default_default });
+/* @__PURE__ */ __export(dep_esm_default_exports, { default: () => dep_esm_default_default });
 const dep_esm_default_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-default.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-default.js", { exports: dep_esm_default_exports });
 var dep_esm_default_default = "esm-default";
@@ -55,7 +55,7 @@ var require_dep_cjs_named = /* @__PURE__ */ __commonJS({ "modules/dep-cjs-named.
 //#region modules/dep-esm-named.js
 var import_dep_cjs_named = /* @__PURE__ */ __toESM(require_dep_cjs_named());
 var dep_esm_named_exports = {};
-__export(dep_esm_named_exports, { named: () => named });
+/* @__PURE__ */ __export(dep_esm_named_exports, { named: () => named });
 const dep_esm_named_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-named.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-named.js", { exports: dep_esm_named_exports });
 const named = "esm-named";
@@ -72,7 +72,7 @@ var require_dep_cjs_namespace = /* @__PURE__ */ __commonJS({ "modules/dep-cjs-na
 //#region modules/dep-esm-namespace.js
 var import_dep_cjs_namespace = /* @__PURE__ */ __toESM(require_dep_cjs_namespace());
 var dep_esm_namespace_exports = {};
-__export(dep_esm_namespace_exports, { value: () => value });
+/* @__PURE__ */ __export(dep_esm_namespace_exports, { value: () => value });
 const dep_esm_namespace_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-namespace.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-namespace.js", { exports: dep_esm_namespace_exports });
 const value = "esm-namespace";

--- a/crates/rolldown/tests/rolldown/topics/keep_names/declaration2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/declaration2/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region a.js
 var a_exports = {};
-__export(a_exports, {
+/* @__PURE__ */ __export(a_exports, {
 	delay: () => delay$1,
 	random64: () => random64$1
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region main.js
 var main_exports = {};
-__export(main_exports, {
+/* @__PURE__ */ __export(main_exports, {
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
@@ -25,7 +25,7 @@ export { main_default as default, foo };
 // HIDDEN [rolldown:runtime]
 //#region main.js
 var main_exports = {};
-__export(main_exports, {
+/* @__PURE__ */ __export(main_exports, {
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
@@ -11,7 +11,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 //#region main.js
 var main_exports = {};
-__export(main_exports, {
+/* @__PURE__ */ __export(main_exports, {
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/tla/inline_dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/inline_dynamic_import/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region c.js
 var c_exports = {};
-__export(c_exports, { default: () => c_default });
+/* @__PURE__ */ __export(c_exports, { default: () => c_default });
 var _default, c_default;
 var init_c = __esm({ "c.js": (() => {
 	_default = { aaa: { bbb: [
@@ -35,7 +35,7 @@ var init_b = __esm({ "b.js": (async () => {
 //#endregion
 //#region a.js
 var a_exports = {};
-__export(a_exports, { buildDevConfig: () => buildDevConfig });
+/* @__PURE__ */ __export(a_exports, { buildDevConfig: () => buildDevConfig });
 var buildDevConfig;
 var init_a = __esm({ "a.js": (async () => {
 	await init_b();

--- a/crates/rolldown/tests/rolldown/tree_shaking/advanced_barrel_exports_bailout_dynamic_key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/advanced_barrel_exports_bailout_dynamic_key/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region a.js
 var a_exports = {};
-__export(a_exports, {
+/* @__PURE__ */ __export(a_exports, {
 	a: () => a,
 	b: () => b,
 	c: () => c

--- a/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
@@ -13,7 +13,7 @@ const foo = 1;
 //#endregion
 //#region export-star.js
 var export_star_exports = {};
-__export(export_star_exports, { foo: () => foo });
+/* @__PURE__ */ __export(export_star_exports, { foo: () => foo });
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format/artifacts.snap
@@ -20,7 +20,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 //#region lib.js
 var lib_exports = {};
-__export(lib_exports, { default: () => lib_default });
+/* @__PURE__ */ __export(lib_exports, { default: () => lib_default });
 var lib_default;
 var init_lib = __esm({ "lib.js": (() => {
 	lib_default = 2;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -268,7 +268,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main
 
-- src_entry-!~{000}~.js => src_entry-CnvGSiyh.js
+- src_entry-!~{000}~.js => src_entry-cjqGmDp0.js
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_module
 
@@ -284,7 +284,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main
 
-- src_entry-!~{000}~.js => src_entry-Dmc_zJYq.js
+- src_entry-!~{000}~.js => src_entry-uTUjiT9V.js
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_module
 
@@ -337,7 +337,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6
 
-- src_entry-!~{000}~.js => src_entry-BD4eU270.js
+- src_entry-!~{000}~.js => src_entry-B7HVFbix.js
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js
 
@@ -353,7 +353,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6
 
-- src_entry-!~{000}~.js => src_entry-BUnoAT0b.js
+- src_entry-!~{000}~.js => src_entry-xXSeTa2v.js
 
 # tests/esbuild/dce/package_json_side_effects_false_no_warning_in_node_modules_issue999
 
@@ -479,7 +479,7 @@ expression: output
 
 # tests/esbuild/dce/tree_shaking_in_esm_wrapper
 
-- entry-!~{000}~.js => entry-D0OaAbwh.js
+- entry-!~{000}~.js => entry-tatmwwhe.js
 
 # tests/esbuild/dce/tree_shaking_js_with_associated_css
 
@@ -609,7 +609,7 @@ expression: output
 
 # tests/esbuild/default/common_js_from_es6
 
-- entry-!~{000}~.js => entry-CokA6VYr.js
+- entry-!~{000}~.js => entry-BGzhT1g7.js
 
 # tests/esbuild/default/conditional_import
 
@@ -718,24 +718,24 @@ expression: output
 
 # tests/esbuild/default/export_forms_common_js
 
-- entry-!~{000}~.js => entry-MhOZTeoD.js
+- entry-!~{000}~.js => entry-CSR0axGX.js
 
 # tests/esbuild/default/export_forms_es6
 
-- entry-!~{000}~.js => entry-CNJxOU5W.js
+- entry-!~{000}~.js => entry-D0vprYrI.js
 
 # tests/esbuild/default/export_forms_iife
 
-- entry-!~{000}~.js => entry-4De0duF1.js
+- entry-!~{000}~.js => entry-C95pFibk.js
 
 # tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle
 
-- a-!~{000}~.js => a-C-ZyFH0D.js
-- b-!~{001}~.js => b-qhjqeTzO.js
+- a-!~{000}~.js => a-BfbUYr09.js
+- b-!~{001}~.js => b-8CFZ_hIa.js
 - c-!~{002}~.js => c-DbAYnqxj.js
 - d-!~{003}~.js => d-erhulghW.js
 - e-!~{004}~.js => e-BluWtRWc.js
-- b-!~{005}~.js => b-AmO3MwuF.js
+- b-!~{005}~.js => b-DOHI7awH.js
 
 # tests/esbuild/default/export_fs_browser
 
@@ -767,11 +767,11 @@ expression: output
 
 # tests/esbuild/default/exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-BDqZoHuB.js
+- entry-!~{000}~.js => entry-cHAOcwd8.js
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
-- entry-!~{000}~.js => entry-Bd5t1CLY.js
+- entry-!~{000}~.js => entry-96Z3Vc56.js
 
 # tests/esbuild/default/external_module_exclusion_package
 
@@ -799,7 +799,7 @@ expression: output
 
 # tests/esbuild/default/forbid_string_export_names_bundle
 
-- entry-!~{000}~.js => entry-DZBxtX9-.js
+- entry-!~{000}~.js => entry-BV9UN3Fa.js
 
 # tests/esbuild/default/forbid_string_export_names_no_bundle
 
@@ -1148,9 +1148,9 @@ expression: output
 
 # tests/esbuild/default/mangle_props_import_export_bundled
 
-- entry-cjs-!~{001}~.js => entry-cjs-RzygboMK.js
-- entry-esm-!~{000}~.js => entry-esm-DaCME5Qz.js
-- cjs-!~{002}~.js => cjs-bi-rzMdU.js
+- entry-cjs-!~{001}~.js => entry-cjs-Ch9egv4L.js
+- entry-esm-!~{000}~.js => entry-esm-B6JC73V-.js
+- cjs-!~{002}~.js => cjs-BMrLdftT.js
 
 # tests/esbuild/default/mangle_props_jsx_preserve
 
@@ -1303,7 +1303,7 @@ expression: output
 
 # tests/esbuild/default/minified_exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-DykaIxN4.js
+- entry-!~{000}~.js => entry-eLyLoRcH.js
 
 # tests/esbuild/default/minified_jsx_preserve_with_object_spread
 
@@ -1762,19 +1762,19 @@ expression: output
 
 # tests/esbuild/importstar/export_self_and_import_self_common_js
 
-- entry-!~{000}~.js => entry-DmPUDDjT.js
+- entry-!~{000}~.js => entry-uXTHcYoU.js
 
 # tests/esbuild/importstar/export_self_and_require_self_common_js
 
-- entry-!~{000}~.js => entry-DCkgMRMK.js
+- entry-!~{000}~.js => entry-DOFqyym4.js
 
 # tests/esbuild/importstar/export_self_as_namespace_common_js
 
-- entry-!~{000}~.js => entry-e1Et3AnI.js
+- entry-!~{000}~.js => entry-BZJiL-_2.js
 
 # tests/esbuild/importstar/export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-CrFSqNU8.js
+- entry-!~{000}~.js => entry-ChHBfaou.js
 
 # tests/esbuild/importstar/export_self_common_js
 
@@ -1808,13 +1808,13 @@ expression: output
 - external-ns-!~{001}~.js => external-ns-all2LFha.js
 - external-ns-def-!~{003}~.js => external-ns-def-CPrnmGVn.js
 - external-ns-default-!~{002}~.js => external-ns-default-Cbqf8eIs.js
-- internal-def-!~{00b}~.js => internal-def-CRNsLces.js
-- internal-default-!~{00a}~.js => internal-default-Dx0cXe3H.js
-- internal-default2-!~{006}~.js => internal-default2-Br-ACsYq.js
-- internal-ns-!~{007}~.js => internal-ns-a_Hq6o6-.js
-- internal-ns-def-!~{009}~.js => internal-ns-def-BSYbjTZ1.js
-- internal-ns-default-!~{008}~.js => internal-ns-default-BkqjZs1S.js
-- internal-!~{00c}~.js => internal-1sX5rN8A.js
+- internal-def-!~{00b}~.js => internal-def-E47aU5LL.js
+- internal-default-!~{00a}~.js => internal-default-BCTXhocV.js
+- internal-default2-!~{006}~.js => internal-default2-Bz85OpQf.js
+- internal-ns-!~{007}~.js => internal-ns-BqbLozKx.js
+- internal-ns-def-!~{009}~.js => internal-ns-def-ByZg6JIe.js
+- internal-ns-default-!~{008}~.js => internal-ns-default-K3xqU3GL.js
+- internal-!~{00c}~.js => internal-zvKqBhSs.js
 
 # tests/esbuild/importstar/import_export_other_as_namespace_common_js
 
@@ -1822,7 +1822,7 @@ expression: output
 
 # tests/esbuild/importstar/import_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-CrFSqNU8.js
+- entry-!~{000}~.js => entry-ChHBfaou.js
 
 # tests/esbuild/importstar/import_export_star_ambiguous_warning
 
@@ -1854,11 +1854,11 @@ expression: output
 
 # tests/esbuild/importstar/import_star_and_common_js
 
-- entry-!~{000}~.js => entry-DmuTEWK8.js
+- entry-!~{000}~.js => entry-Br0eywwv.js
 
 # tests/esbuild/importstar/import_star_capture
 
-- entry-!~{000}~.js => entry-DRZgLsj7.js
+- entry-!~{000}~.js => entry-0M6hc_Z7.js
 
 # tests/esbuild/importstar/import_star_common_js_capture
 
@@ -1874,7 +1874,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_import_star_capture
 
-- entry-!~{000}~.js => entry-DRZgLsj7.js
+- entry-!~{000}~.js => entry-0M6hc_Z7.js
 
 # tests/esbuild/importstar/import_star_export_import_star_no_capture
 
@@ -1886,7 +1886,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_as_capture
 
-- entry-!~{000}~.js => entry-DRZgLsj7.js
+- entry-!~{000}~.js => entry-0M6hc_Z7.js
 
 # tests/esbuild/importstar/import_star_export_star_as_no_capture
 
@@ -1898,7 +1898,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_capture
 
-- entry-!~{000}~.js => entry-DaFT1upj.js
+- entry-!~{000}~.js => entry-uBueiUVZ.js
 
 # tests/esbuild/importstar/import_star_export_star_no_capture
 
@@ -1906,7 +1906,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_omit_ambiguous
 
-- entry-!~{000}~.js => entry-gyjSeV8R.js
+- entry-!~{000}~.js => entry-DOGNqqni.js
 
 # tests/esbuild/importstar/import_star_export_star_unused
 
@@ -1942,7 +1942,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_of_export_star_as
 
-- entry-!~{000}~.js => entry-BbcqPKpk.js
+- entry-!~{000}~.js => entry-BhsZlyUH.js
 
 # tests/esbuild/importstar/import_star_unused
 
@@ -1950,7 +1950,7 @@ expression: output
 
 # tests/esbuild/importstar/issue176
 
-- entry-!~{000}~.js => entry-Bpek_SCa.js
+- entry-!~{000}~.js => entry-DRaQNajO.js
 
 # tests/esbuild/importstar/namespace_import_missing_common_js
 
@@ -1958,11 +1958,11 @@ expression: output
 
 # tests/esbuild/importstar/namespace_import_missing_es6
 
-- entry-!~{000}~.js => entry-wg_v8cH5.js
+- entry-!~{000}~.js => entry-CYAGSJzw.js
 
 # tests/esbuild/importstar/namespace_import_re_export_star_missing_es6
 
-- entry-!~{000}~.js => entry-Cx3-VPSK.js
+- entry-!~{000}~.js => entry-DMuBQpsG.js
 
 # tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6
 
@@ -1986,7 +1986,7 @@ expression: output
 
 # tests/esbuild/importstar/re_export_namespace_import_missing_es6
 
-- entry-!~{000}~.js => entry-Cm_DwAz2.js
+- entry-!~{000}~.js => entry-Bsm0fzgE.js
 
 # tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6
 
@@ -1994,11 +1994,11 @@ expression: output
 
 # tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-BvbMMCKs.js
+- entry-!~{000}~.js => entry-B7_r0kV5.js
 
 # tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-BvbMMCKs.js
+- entry-!~{000}~.js => entry-B7_r0kV5.js
 
 # tests/esbuild/importstar/re_export_star_as_common_js_no_bundle
 
@@ -2070,11 +2070,11 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_and_common_js
 
-- entry-!~{000}~.js => entry-B48ekpxm.js
+- entry-!~{000}~.js => entry-B5vkoKHe.js
 
 # tests/esbuild/importstar_ts/ts_import_star_capture
 
-- entry-!~{000}~.js => entry-CKvXp9g-.js
+- entry-!~{000}~.js => entry-COihkT_2.js
 
 # tests/esbuild/importstar_ts/ts_import_star_common_js_capture
 
@@ -2090,7 +2090,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture
 
-- entry-!~{000}~.js => entry-CKvXp9g-.js
+- entry-!~{000}~.js => entry-COihkT_2.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_import_star_no_capture
 
@@ -2102,7 +2102,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture
 
-- entry-!~{000}~.js => entry-CKvXp9g-.js
+- entry-!~{000}~.js => entry-COihkT_2.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_as_no_capture
 
@@ -2114,7 +2114,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_capture
 
-- entry-!~{000}~.js => entry-CTyNlyop.js
+- entry-!~{000}~.js => entry-D67EeGwI.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_no_capture
 
@@ -2368,7 +2368,7 @@ expression: output
 
 # tests/esbuild/loader/loader_json_invalid_identifier_es6
 
-- entry-!~{000}~.js => entry-Bzc21GuB.js
+- entry-!~{000}~.js => entry-0zDZXRgg.js
 
 # tests/esbuild/loader/loader_json_no_bundle
 
@@ -2882,27 +2882,27 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser
 
-- entry-!~{000}~.js => entry-Bm_48Jpl.js
+- entry-!~{000}~.js => entry-DESKzF6k.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main
 
-- entry-!~{000}~.js => entry-BKFrzYbS.js
+- entry-!~{000}~.js => entry-DqJUKVSV.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main
 
-- entry-!~{000}~.js => entry-C_ut64Dl.js
+- entry-!~{000}~.js => entry-DTP6fakJ.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main
 
-- entry-!~{000}~.js => entry-CapQN31r.js
+- entry-!~{000}~.js => entry-CsKZfAxM.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file
 
-- entry-!~{000}~.js => entry-F89RrY3v.js
+- entry-!~{000}~.js => entry-BVeszSJs.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files
 
-- entry-!~{000}~.js => entry-Dg0EAXUU.js
+- entry-!~{000}~.js => entry-C0Qkv3ei.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_only
 
@@ -2910,7 +2910,7 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_require_only
 
-- entry-!~{000}~.js => entry-CXeqxZ95.js
+- entry-!~{000}~.js => entry-B26IfEtY.js
 
 # tests/esbuild/packagejson/package_json_exports_alternatives
 
@@ -3160,9 +3160,9 @@ expression: output
 
 # tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617
 
-- a-!~{000}~.js => a-Bc5-IKbc.js
-- b-!~{001}~.js => b-D6zj-uGY.js
-- a-!~{002}~.js => a-BXF1mP2E.js
+- a-!~{000}~.js => a-yaG3iVZp.js
+- b-!~{001}~.js => b-DJ31Lt-H.js
+- a-!~{002}~.js => a-DZiQE6Mi.js
 
 # tests/esbuild/splitting/splitting_minify_identifiers_crash_issue437
 
@@ -3219,7 +3219,7 @@ expression: output
 
 # tests/esbuild/ts/export_type_issue379
 
-- entry-!~{000}~.js => entry-r0kTubL9.js
+- entry-!~{000}~.js => entry-DJzmos0u.js
 
 # tests/esbuild/ts/this_inside_function_ts
 
@@ -3373,7 +3373,7 @@ expression: output
 
 # tests/esbuild/ts/ts_export_missing_es6
 
-- entry-!~{000}~.js => entry-CaFGqRrE.js
+- entry-!~{000}~.js => entry-YOZBHrIy.js
 
 # tests/esbuild/ts/ts_export_namespace
 
@@ -3409,7 +3409,7 @@ expression: output
 
 # tests/esbuild/ts/ts_import_equals_undefined_import
 
-- entry-!~{000}~.js => entry-Bk58htPI.js
+- entry-!~{000}~.js => entry-BUtldta8.js
 
 # tests/esbuild/ts/ts_import_missing_unused_es6
 
@@ -3529,7 +3529,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/basic_commonjs
 
-- main-!~{000}~.js => main-CKHZsNj3.js
+- main-!~{000}~.js => main-2LaPiFmr.js
 
 # tests/rolldown/cjs_compat/cjs_entry
 
@@ -3547,11 +3547,11 @@ expression: output
 
 # tests/rolldown/cjs_compat/esm_require_esm
 
-- main-!~{000}~.js => main-BNBxS7Hg.js
+- main-!~{000}~.js => main-DEi1Wq7S.js
 
 # tests/rolldown/cjs_compat/esm_require_esm_unused
 
-- main-!~{000}~.js => main-DEAFC77U.js
+- main-!~{000}~.js => main-WR30ECQG.js
 
 # tests/rolldown/cjs_compat/exoprt_star_of_cjs
 
@@ -3608,7 +3608,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout
 
-- main-!~{000}~.js => main-Q6Enn7wZ.js
+- main-!~{000}~.js => main-BmrlcFqf.js
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout2
 
@@ -3624,7 +3624,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_2
 
-- main-!~{000}~.js => main-BcHPfiQE.js
+- main-!~{000}~.js => main-Dn4mZLCY.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize
 
@@ -3642,7 +3642,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/reexport_commonjs
 
-- main-!~{000}~.js => main-CEL0Hc_a.js
+- main-!~{000}~.js => main-x3LGperm.js
 
 # tests/rolldown/cjs_compat/reexports_from_cjs
 
@@ -3664,7 +3664,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/require_call_expr_unused
 
-- main-!~{000}~.js => main-DS1l5coy.js
+- main-!~{000}~.js => main-CovRb10m.js
 
 # tests/rolldown/cjs_compat/unnecessary_compat_default_property_access
 
@@ -3679,9 +3679,9 @@ expression: output
 
 # tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file
 
-- main-!~{000}~.js => main-DrZnh7hA.js
-- foo-!~{001}~.js => foo-B90YrT8O.js
-- foo-!~{003}~.js => foo-CdZSNn-S.js
+- main-!~{000}~.js => main-CztHgk8c.js
+- foo-!~{003}~.js => foo-D_asBBiN.js
+- foo-!~{001}~.js => foo-nnKstpHN.js
 
 # tests/rolldown/code_splitting/ensure_safe_identifier
 
@@ -3704,7 +3704,7 @@ expression: output
 # tests/rolldown/code_splitting/format_cjs_with_esm_require_esm
 
 - main1-!~{000}~.js => main1-ClScYW9f.js
-- main2-!~{001}~.js => main2-BfMFBQXc.js
+- main2-!~{001}~.js => main2-DQkOpmqr.js
 - chunk-!~{002}~.js => chunk-BMlwYAFk.js
 
 # tests/rolldown/code_splitting/format_cjs_with_module_cjs
@@ -3729,7 +3729,7 @@ expression: output
 
 # tests/rolldown/dce/conditional_exports
 
-- main-!~{000}~.js => main-BpAmeYQA.js
+- main-!~{000}~.js => main-HUHa4zCQ.js
 
 # tests/rolldown/dce/defined_expr_in_paren_expr
 
@@ -3826,10 +3826,10 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/split_node_modules
 
-- main-!~{000}~.js => main-CKBEWSQT.js
-- other-libs-!~{005}~.js => other-libs-aMYKRBbT.js
+- main-!~{000}~.js => main-DUPalezm.js
+- other-libs-!~{005}~.js => other-libs-D5UsBL2V.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BFxWfBIB.js
-- ui-!~{003}~.js => ui-BOaO4aOi.js
+- ui-!~{003}~.js => ui-CH62VO-_.js
 
 # tests/rolldown/function/context/defined
 
@@ -3961,7 +3961,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-BRl9l4uJ.js
+- main-!~{000}~.js => main-BPQ3VJOj.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4027,7 +4027,7 @@ expression: output
 
 # tests/rolldown/function/export_mode/cjs/default
 
-- main-!~{000}~.js => main-Cm3GgXVs.js
+- main-!~{000}~.js => main-OJc5x-OW.js
 
 # tests/rolldown/function/export_mode/cjs/named
 
@@ -4039,11 +4039,11 @@ expression: output
 
 # tests/rolldown/function/export_mode/iife/default
 
-- main-!~{000}~.js => main-Czy5HG6o.js
+- main-!~{000}~.js => main-H66zvfFL.js
 
 # tests/rolldown/function/export_mode/iife/named
 
-- main-!~{000}~.js => main-B6pAK4Aj.js
+- main-!~{000}~.js => main-CjZ_sWS2.js
 
 # tests/rolldown/function/export_mode/umd/auto/none
 
@@ -4257,15 +4257,15 @@ expression: output
 
 # tests/rolldown/function/inline_dynamic_imports/cjs
 
-- main-!~{000}~.js => main-lwGAEuFX.js
+- main-!~{000}~.js => main-L4Q7Lglr.js
 
 # tests/rolldown/function/inline_dynamic_imports/esm
 
-- main-!~{000}~.js => main-DHUJRmGm.js
+- main-!~{000}~.js => main-DrsREyYb.js
 
 # tests/rolldown/function/inline_dynamic_imports/iife
 
-- main-!~{000}~.js => main-BnGtBBQb.js
+- main-!~{000}~.js => main-CD-5WfuG.js
 
 # tests/rolldown/function/intro/cjs
 
@@ -4611,10 +4611,10 @@ expression: output
 
 # tests/rolldown/issues/3650
 
-- main-!~{000}~.js => main-B-7EuN8u.js
-- first-!~{005}~.js => first-By7s9ezu.js
+- main-!~{000}~.js => main-9Pvbs0pV.js
+- first-!~{005}~.js => first-CKOitz7P.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BvgZlyOU.js
-- second-!~{003}~.js => second-BvWtJ7WD.js
+- second-!~{003}~.js => second-D8ezD1dX.js
 
 # tests/rolldown/issues/3746/a
 
@@ -4636,7 +4636,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-GYiaesa8.js
+- main-!~{000}~.js => main-CHXQjj4a.js
 
 # tests/rolldown/issues/4196
 
@@ -4743,11 +4743,15 @@ expression: output
 
 # tests/rolldown/issues/5870
 
-- main-!~{000}~.js => main-XvrnrFAA.js
+- main-!~{000}~.js => main-tLFQgLgo.js
+
+# tests/rolldown/issues/5923
+
+- main-!~{000}~.js => main-LKE1DU1c.js
 
 # tests/rolldown/issues/rolldown_vite_289
 
-- main-!~{000}~.js => main-bGTkbLZB.js
+- main-!~{000}~.js => main-FCJEyQ6E.js
 
 # tests/rolldown/misc/ambiguous_star_export
 
@@ -4819,7 +4823,7 @@ expression: output
 
 # tests/rolldown/misc/invalid_ident_repr
 
-- main-!~{000}~.js => main-BlImAHc4.js
+- main-!~{000}~.js => main-J-YbjzNK.js
 
 # tests/rolldown/misc/merge_external_import
 
@@ -4938,9 +4942,9 @@ expression: output
 
 # tests/rolldown/misc/reexport_star
 
-- entry-!~{001}~.js => entry-9pAfnsAm.js
-- main-!~{000}~.js => main-64pdxdCn.js
-- a-!~{002}~.js => a-DNkyR4qI.js
+- entry-!~{001}~.js => entry-DEd1lSyP.js
+- main-!~{000}~.js => main-BRElImyy.js
+- a-!~{002}~.js => a-BnLVDU5Y.js
 
 # tests/rolldown/misc/reexport_star_from_local_named_export
 
@@ -4980,8 +4984,8 @@ expression: output
 
 # tests/rolldown/misc/wrapped_esm
 
-- main-!~{000}~.js => main-56AOIbNp.js
-- main-56AOIbNp.js.map
+- main-!~{000}~.js => main-DSs5lBHS.js
+- main-DSs5lBHS.js.map
 
 # tests/rolldown/optimization/inline_const/5197
 
@@ -5078,11 +5082,11 @@ expression: output
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry
 
-- entry-!~{000}~.js => entry-BW4t5NUS.js
+- entry-!~{000}~.js => entry-8zNJjSm2.js
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs
 
-- entry-!~{000}~.js => entry-BP4bvwb-.js
+- entry-!~{000}~.js => entry-D1Hf8MRm.js
 
 # tests/rolldown/sourcemap/css_sourcemap_reference
 
@@ -5130,15 +5134,15 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/12
 
-- entry-!~{000}~.js => entry-Bkz5zR5y.js
-- foo-!~{001}~.js => foo-B5buwoml.js
-- foo-!~{003}~.js => foo-DVrMr8-1.js
+- entry-!~{000}~.js => entry-CzzK9QVl.js
+- foo-!~{003}~.js => foo-gweZQMIG.js
+- foo-!~{001}~.js => foo-yWLgmmqU.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/13
 
-- entry-!~{000}~.js => entry-DqrV-noK.js
-- foo-!~{001}~.js => foo-B5buwoml.js
-- foo-!~{003}~.js => foo-DVrMr8-1.js
+- entry-!~{000}~.js => entry-DU4Zz0PB.js
+- foo-!~{003}~.js => foo-gweZQMIG.js
+- foo-!~{001}~.js => foo-yWLgmmqU.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/14
 
@@ -5158,11 +5162,11 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/18
 
-- entry-!~{000}~.js => entry-ShzHe5oD.js
+- entry-!~{000}~.js => entry-sVWAftSN.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/19
 
-- entry-!~{000}~.js => entry-BAOwXqXy.js
+- entry-!~{000}~.js => entry-CvomFjP_.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/2
 
@@ -5170,27 +5174,27 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/20
 
-- entry-!~{000}~.js => entry-D2_7JUng.js
+- entry-!~{000}~.js => entry-UhjSG-cI.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/21
 
-- entry-!~{000}~.js => entry-BUI3CA7X.js
+- entry-!~{000}~.js => entry-ksDydCbC.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/22
 
-- entry-!~{000}~.js => entry-BKfUW5Tm.js
+- entry-!~{000}~.js => entry-DSUfoyu7.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/23
 
-- entry-!~{000}~.js => entry-DDe2XBQ2.js
+- entry-!~{000}~.js => entry-CYTChPM9.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/24
 
-- entry-!~{000}~.js => entry-C5_mIfc-.js
+- entry-!~{000}~.js => entry-CYNbADol.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/25
 
-- entry-!~{000}~.js => entry-dsJDbanh.js
+- entry-!~{000}~.js => entry-Dh7tneHv.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/26
 
@@ -5264,7 +5268,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/41
 
-- entry-!~{000}~.js => entry-C5yBdK2g.js
+- entry-!~{000}~.js => entry-CJzgLms6.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/42
 
@@ -5272,7 +5276,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/43
 
-- entry-!~{000}~.js => entry-COAHiUqm.js
+- entry-!~{000}~.js => entry-DpCQhZaO.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/44
 
@@ -5280,15 +5284,15 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/45
 
-- entry-!~{000}~.js => entry-CFhCCS_K.js
+- entry-!~{000}~.js => entry-DakRMx1X.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/46
 
-- entry-!~{000}~.js => entry-DqAzscfO.js
+- entry-!~{000}~.js => entry-u0IbVoQt.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/47
 
-- entry-!~{000}~.js => entry-CBVq1aah.js
+- entry-!~{000}~.js => entry-RTIW7x1H.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/48
 
@@ -5364,7 +5368,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/7
 
-- entry-!~{000}~.js => entry-CZz9Tf7-.js
+- entry-!~{000}~.js => entry-Db5iZ4TU.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/8
 
@@ -5372,7 +5376,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/9
 
-- entry-!~{000}~.js => entry-OEtcTgKT.js
+- entry-!~{000}~.js => entry-Ce516mSM.js
 
 # tests/rolldown/topics/chunk_modules_order/basic
 
@@ -5457,78 +5461,78 @@ expression: output
 
 # tests/rolldown/topics/deconflict/wrapped_esm_default_function
 
-- main-!~{000}~.js => main-CS1VGtNM.js
-- main-CS1VGtNM.js.map
+- main-!~{000}~.js => main-ihqbVKy9.js
+- main-ihqbVKy9.js.map
 
 # tests/rolldown/topics/deconflict/wrapped_esm_export_named_function
 
-- main-!~{000}~.js => main-X0JfucbC.js
-- main-X0JfucbC.js.map
+- main-!~{000}~.js => main-DP0z6PVG.js
+- main-DP0z6PVG.js.map
 
 # tests/rolldown/topics/hmr/change_accept
 
-- main-!~{000}~.js => main-CjLhLu5f.js
+- main-!~{000}~.js => main-C5tMYOST.js
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-D_Qah7KK.js
+- main-!~{000}~.js => main-D5PCLaRj.js
 - chunk-!~{001}~.js => chunk-EJRfyxWL.js
 - exist-dep-cjs-!~{003}~.js => exist-dep-cjs-CMMhV_IP.js
-- exist-dep-esm-!~{005}~.js => exist-dep-esm-DS9du_-x.js
+- exist-dep-esm-!~{005}~.js => exist-dep-esm-Cf-Pfy96.js
 
 # tests/rolldown/topics/hmr/export_star
 
-- main-!~{000}~.js => main-iugOMOus.js
+- main-!~{000}~.js => main-BFWBYhcT.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-Abs8vRWN.js
+- main-!~{000}~.js => main-CLR76aZ5.js
 
 # tests/rolldown/topics/hmr/import_meta_hot_accept
 
-- main-!~{000}~.js => main-BJBQmZJO.js
+- main-!~{000}~.js => main-DcD6wdDT.js
 
 # tests/rolldown/topics/hmr/issue_5149
 
-- main-!~{000}~.js => main-2i-rnA2D.js
+- main-!~{000}~.js => main-D4xjj0hX.js
 
 # tests/rolldown/topics/hmr/issue_5150
 
-- main-!~{000}~.js => main-CzhdaBZW.js
+- main-!~{000}~.js => main-0jcCQ5M2.js
 
 # tests/rolldown/topics/hmr/issue_5159
 
-- main-!~{000}~.js => main-Bg3Yer-O.js
-- bar-!~{005}~.js => bar-BisjqNeR.js
+- main-!~{000}~.js => main-Xp1q3CIk.js
+- bar-!~{005}~.js => bar-DS88iBet.js
 - chunk-!~{001}~.js => chunk--KgZXUQQ.js
-- foo-!~{007}~.js => foo-OmnQYi5B.js
-- string-!~{003}~.js => string-CMcoXSG2.js
+- foo-!~{007}~.js => foo-BDZS08DQ.js
+- string-!~{003}~.js => string-lixhZ52z.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-1MwsmcRP.js
-- index-!~{001}~.js => index-DRnPso5Y.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-h3ThDu7r.js
+- entry-!~{000}~.js => entry-BTdlVDI2.js
+- index-!~{001}~.js => index-Bm6PiAN6.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-DO4_xOHO.js
 
 # tests/rolldown/topics/hmr/no_boundary_reload
 
-- main-!~{000}~.js => main-DgJD8HMG.js
+- main-!~{000}~.js => main-CKG_xWnC.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-CJPqt-_s.js
+- main-!~{000}~.js => main-DoJ8AsVc.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-Dw3g15p1.js
+- main-!~{000}~.js => main-CfrH8T3J.js
 
 # tests/rolldown/topics/hmr/runtime_correctness
 
-- main-!~{000}~.js => main-DkhPloRE.js
+- main-!~{000}~.js => main-DVMf3d2r.js
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-DeyM9iQ0.js
+- main-!~{000}~.js => main-UF6acreS.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 
@@ -5541,7 +5545,7 @@ expression: output
 
 # tests/rolldown/topics/keep_names/declaration2
 
-- main-!~{000}~.js => main-CsBPgQXn.js
+- main-!~{000}~.js => main-BZEBCuc3.js
 
 # tests/rolldown/topics/keep_names/expression
 
@@ -5680,17 +5684,17 @@ expression: output
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped
 
-- main-!~{000}~.js => main-BvFRRf7Y.js
+- main-!~{000}~.js => main-fGpBMaXU.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries
 
-- entry-!~{000}~.js => entry-D_XoBjPI.js
-- entry2-!~{001}~.js => entry2-CkINfvDH.js
-- main-!~{002}~.js => main-C7UG2YkQ.js
+- entry-!~{000}~.js => entry-BGZazGYX.js
+- entry2-!~{001}~.js => entry2-CYsOJVNc.js
+- main-!~{002}~.js => main-BtFAY-0b.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs
 
-- main-!~{000}~.js => main-Bvm3ovl0.js
+- main-!~{000}~.js => main-Cc-NNzai.js
 
 # tests/rolldown/topics/tla/basic
 
@@ -5698,7 +5702,7 @@ expression: output
 
 # tests/rolldown/topics/tla/inline_dynamic_import
 
-- main-!~{000}~.js => main-B8Iec8--.js
+- main-!~{000}~.js => main-DUTD6WNu.js
 
 # tests/rolldown/topics/tla/inside_try_block
 
@@ -5722,7 +5726,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/advanced_barrel_exports_bailout_dynamic_key
 
-- main-!~{000}~.js => main-CYJiKP4y.js
+- main-!~{000}~.js => main-BmRd9baC.js
 
 # tests/rolldown/tree_shaking/commonjs
 
@@ -5796,7 +5800,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/export_star
 
-- main-!~{000}~.js => main-PPodLJ5E.js
+- main-!~{000}~.js => main-esjwKjsC.js
 
 # tests/rolldown/tree_shaking/export_star2
 
@@ -5909,7 +5913,7 @@ expression: output
 
 # tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format
 
-- main-!~{000}~.js => main-D2nEHzob.js
+- main-!~{000}~.js => main-BN0_NXjX.js
 
 # tests/rolldown/warnings/minified-with-eval
 


### PR DESCRIPTION
`__export`​ just like `__esm`​ it only take effects when the export object are used, so mark it as `pure`​ could reduce the output size in some scenario see https://github.com/rolldown/rolldown/issues/5923 as an example