### PR TITLE
fix: use symbol existance to detect if a plugin is BuiltinPlugin

### DIFF
--- a/packages/rolldown/src/builtin-plugin/utils.ts
+++ b/packages/rolldown/src/builtin-plugin/utils.ts
@@ -9,40 +9,32 @@ type BindingCallableBuiltinPluginLike = {
   [K in keyof BindingCallableBuiltinPlugin]: BindingCallableBuiltinPlugin[K];
 };
 
+const BuiltinClassSymbol: symbol = Symbol.for('__RolldownBuiltinPlugin__');
+
+// eslint-disable @typescript-eslint/no-unsafe-declaration-merging
 export class BuiltinPlugin {
   constructor(
     public name: BindingBuiltinPluginName,
     // NOTE: has `_` to avoid conflict with `options` hook
     public _options?: unknown,
-  ) {}
-}
-const CLASS_KEY = Symbol.for('BuiltinPlugin');
-
-// @ts-ignore
-if (!globalThis[CLASS_KEY]) {
-  // @ts-ignore
-  globalThis[CLASS_KEY] = BuiltinPlugin;
+  ) {
+    this[BuiltinClassSymbol] = true;
+  }
 }
 
-// We need to disable global class cache in some scenarios
-// - When we run tests, we need to ensure the globalThis is not polluted between tests or the test will fail(Since the test)
-// - User run rolldown in different worker that may pollute the globalThis just like test scenario
-const disableGlobalClassCache = process.env.ROLLDOWN_TEST === '1' ||
-  process.env.DISABLE_GLOBAL_CLASS_CACHE === '1';
+export function isBuiltinPlugin(obj: any): obj is BuiltinPlugin {
+  return obj && obj[BuiltinClassSymbol] === true;
+}
 
-// Our cli use `cli.mjs` as entry, but the configuration maybe use `cli.cjs` entry(use `require` to load builtin plugins or use `cts` configuration).
-// Use this pattern to ensure the whole process use same `BuiltinPlugin` class.
-// See https://github.com/rolldown/rolldown/blob/1c4a37c1e98f44b0fe5700be5df9e7a871d9df05/packages/rolldown/src/utils/normalize-plugin-option.ts?plain=1#L44.
+export interface BuiltinPlugin {
+  [BuiltinClassSymbol]: boolean;
+}
+
 export function createBuiltinPlugin(
   name: BindingBuiltinPluginName,
   options?: unknown,
 ): BuiltinPlugin {
-  if (disableGlobalClassCache) {
-    return new BuiltinPlugin(name, options);
-  }
-  // @ts-ignore
-  const Cls = globalThis[CLASS_KEY] as typeof BuiltinPlugin;
-  return new Cls(name, options);
+  return new BuiltinPlugin(name, options);
 }
 
 export function makeBuiltinPluginCallable(

--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -1,5 +1,5 @@
 import type { InputOptions, OutputOptions, RolldownPlugin } from '..';
-import { BuiltinPlugin } from '../builtin-plugin/utils';
+import { isBuiltinPlugin } from '../builtin-plugin/utils';
 import type { LogHandler } from '../log/log-handler';
 import { getLogger, getOnLog } from '../log/logger';
 import { LOG_LEVEL_INFO, type LogLevelOption } from '../log/logging';
@@ -90,7 +90,7 @@ export function getObjectPlugins(plugins: RolldownPlugin[]): Plugin[] {
     if ('_parallel' in plugin) {
       return undefined;
     }
-    if (plugin instanceof BuiltinPlugin) {
+    if (isBuiltinPlugin(plugin)) {
       return undefined;
     }
     return plugin;

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -11,7 +11,7 @@ import type {
   BindingInjectImportNamespace,
   BindingInputOptions,
 } from '../binding';
-import { BuiltinPlugin } from '../builtin-plugin/utils';
+import { BuiltinPlugin, isBuiltinPlugin } from '../builtin-plugin/utils';
 import { bindingifyBuiltInPlugin } from '../builtin-plugin/utils';
 import type { LogHandler } from '../log/log-handler';
 import { LOG_LEVEL_WARN, type LogLevelOption } from '../log/logging';
@@ -47,8 +47,8 @@ export function bindingifyInputOptions(
     if ('_parallel' in plugin) {
       return undefined;
     }
-    if (plugin instanceof BuiltinPlugin) {
-      return bindingifyBuiltInPlugin(plugin);
+    if (isBuiltinPlugin(plugin)) {
+      return bindingifyBuiltInPlugin(plugin as BuiltinPlugin);
     }
     return bindingifyPlugin(
       plugin,

--- a/packages/rolldown/src/utils/normalize-plugin-option.ts
+++ b/packages/rolldown/src/utils/normalize-plugin-option.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { oxcRuntimePlugin } from '../builtin-plugin/constructors';
-import { BuiltinPlugin } from '../builtin-plugin/utils';
+import { BuiltinPlugin, isBuiltinPlugin } from '../builtin-plugin/utils';
 import { ENUMERATED_INPUT_PLUGIN_HOOK_NAMES } from '../constants/plugin';
 import type { LogHandler } from '../log/log-handler';
 import { LOG_LEVEL_WARN } from '../log/logging';
@@ -41,7 +41,7 @@ export function normalizePlugins<T extends RolldownPlugin>(
     if ('_parallel' in plugin) {
       continue;
     }
-    if (plugin instanceof BuiltinPlugin) {
+    if (isBuiltinPlugin(plugin)) {
       continue;
     }
     if (!plugin.name) {

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -129,6 +129,14 @@ describe('config', () => {
     expect(status.exitCode).toBe(0)
     expect(cleanStdout(status.stdout)).toMatchSnapshot()
   })
+  it('should bundle in cjs-config-with-replace-plugin', async () => {
+    const cwd = cliFixturesDir('cjs-config-with-replace-plugin')
+    const status = await $({ cwd })`rolldown -c rolldown.config.cjs`
+    expect(status.exitCode).toBe(0)
+    const file = path.resolve(cwd, 'dist/index.js')
+    const content = fs.readFileSync(file, 'utf-8')
+    expect(content).toContain("console.log(1)")
+  })
   it('should not bundle in ext-js-syntax-esm', async () => {
     const cwd = cliFixturesDir('ext-js-syntax-esm')
     try {

--- a/packages/rolldown/tests/cli/fixtures/cjs-config-with-replace-plugin/index.js
+++ b/packages/rolldown/tests/cli/fixtures/cjs-config-with-replace-plugin/index.js
@@ -1,0 +1,1 @@
+console.log(__rolldown)

--- a/packages/rolldown/tests/cli/fixtures/cjs-config-with-replace-plugin/rolldown.config.cjs
+++ b/packages/rolldown/tests/cli/fixtures/cjs-config-with-replace-plugin/rolldown.config.cjs
@@ -1,0 +1,11 @@
+const rolldown = require('rolldown')
+const plugin = require('rolldown/experimental')
+
+module.exports = rolldown.defineConfig({
+  input: './index.js',
+  plugins: [
+    plugin.replacePlugin({
+      '__rolldown': '1'
+    }),
+  ],
+})


### PR DESCRIPTION
Use `Symbol` to avoid dual package hazard, and also we don't need the `globalThisClassCache`, so that vite test will not be affected. 