### PR TITLE
feat:  treeshake.propertyReadSideEffects

### DIFF
--- a/crates/rolldown/src/ast_scanner/const_eval.rs
+++ b/crates/rolldown/src/ast_scanner/const_eval.rs
@@ -1,6 +1,5 @@
 use oxc::{
   ast::ast::Expression,
-  minifier::PropertyReadSideEffects,
   semantic::{IsGlobalReference, ReferenceId, Scoping, SymbolId},
 };
 use oxc_ecmascript::{
@@ -57,7 +56,7 @@ impl<'ast> MayHaveSideEffectsContext<'ast> for ConstEvalCtx<'_, 'ast> {
   }
 
   fn property_read_side_effects(&self) -> oxc::minifier::PropertyReadSideEffects {
-    PropertyReadSideEffects::All
+    oxc::minifier::PropertyReadSideEffects::All
   }
 
   fn unknown_global_side_effects(&self) -> bool {

--- a/crates/rolldown/src/ast_scanner/const_eval.rs
+++ b/crates/rolldown/src/ast_scanner/const_eval.rs
@@ -1,5 +1,6 @@
 use oxc::{
   ast::ast::Expression,
+  minifier::PropertyReadSideEffects,
   semantic::{IsGlobalReference, ReferenceId, Scoping, SymbolId},
 };
 use oxc_ecmascript::{
@@ -56,7 +57,7 @@ impl<'ast> MayHaveSideEffectsContext<'ast> for ConstEvalCtx<'_, 'ast> {
   }
 
   fn property_read_side_effects(&self) -> oxc::minifier::PropertyReadSideEffects {
-    oxc::minifier::PropertyReadSideEffects::All
+    PropertyReadSideEffects::All
   }
 
   fn unknown_global_side_effects(&self) -> bool {

--- a/crates/rolldown/tests/rolldown/tree_shaking/property_read_side_effects/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/property_read_side_effects/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "treeshake": {
+      "propertyReadSideEffects": "false"
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/property_read_side_effects/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/property_read_side_effects/artifacts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region constants.js
+const API_ENDPOINTS = {
+	USERS: "/api/users",
+	POSTS: "/api/posts"
+};
+const someObject = {
+	a: 1,
+	b: 2,
+	c: 3,
+	d: 4,
+	e: 5,
+	nested: { deep: "value" }
+};
+
+//#endregion
+//#region main.js
+API_ENDPOINTS[unknown];
+const { d } = console.log("side effect") || someObject;
+const { e } = (() => {
+	console.log("effect");
+	return someObject;
+})();
+var main_default = {};
+
+//#endregion
+export { main_default as default };
+```

--- a/crates/rolldown/tests/rolldown/tree_shaking/property_read_side_effects/constants.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/property_read_side_effects/constants.js
@@ -1,0 +1,15 @@
+export const API_ENDPOINTS = {
+    USERS: '/api/users',
+    POSTS: '/api/posts'
+}
+
+export const someObject = {
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4,
+    e: 5,
+    nested: {
+        deep: 'value'
+    }
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/property_read_side_effects/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/property_read_side_effects/main.js
@@ -4,7 +4,7 @@ API_ENDPOINTS.USERS // Should be tree-shaken when propertyReadSideEffects: false
 API_ENDPOINTS['POSTS'] // Should be tree-shaken when propertyReadSideEffects: false
 
 function test() {}
-API_ENDPOINTS[unknown] // Should be tree-shaken when propertyReadSideEffects: false
+API_ENDPOINTS[unknown] // Should not be tree-shaken when propertyReadSideEffects: false
 API_ENDPOINTS[test] // Should be tree-shaken when propertyReadSideEffects: false
 
 // Object destructuring tests

--- a/crates/rolldown/tests/rolldown/tree_shaking/property_read_side_effects/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/property_read_side_effects/main.js
@@ -1,0 +1,19 @@
+import { API_ENDPOINTS, someObject } from './constants.js'
+
+API_ENDPOINTS.USERS // Should be tree-shaken when propertyReadSideEffects: false
+API_ENDPOINTS['POSTS'] // Should be tree-shaken when propertyReadSideEffects: false
+
+function test() {}
+API_ENDPOINTS[unknown] // Should be tree-shaken when propertyReadSideEffects: false
+API_ENDPOINTS[test] // Should be tree-shaken when propertyReadSideEffects: false
+
+// Object destructuring tests
+const { a, b } = someObject // Should be tree-shaken when propertyReadSideEffects: false
+const { c: renamed } = someObject // Should be tree-shaken when propertyReadSideEffects: false
+const { nested: { deep } } = someObject // Should be tree-shaken when propertyReadSideEffects: false
+
+// These should remain since they have actual side effects in the initializer
+const { d } = console.log('side effect') || someObject // Should NOT be tree-shaken - has side effect
+const { e } = (() => { console.log('effect'); return someObject })() // Should NOT be tree-shaken
+
+export default {}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5855,6 +5855,10 @@ expression: output
 - main-!~{000}~.js => main-BnY28741.js
 - main-BnY28741.js.map
 
+# tests/rolldown/tree_shaking/property_read_side_effects
+
+- main-!~{000}~.js => main-Djw0f4KQ.js
+
 # tests/rolldown/tree_shaking/pure_annotation
 
 - main-!~{000}~.js => main-CPLcFEro.js

--- a/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
@@ -8,6 +8,17 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::{Deserialize, Deserializer};
 
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(
+  feature = "deserialize_bundler_options",
+  derive(Deserialize, JsonSchema),
+  serde(rename_all = "camelCase")
+)]
+pub enum PropertyReadSideEffects {
+  Always,
+  False,
+}
+
 #[derive(Debug, Clone)]
 #[cfg_attr(
   feature = "deserialize_bundler_options",
@@ -49,6 +60,14 @@ impl NormalizedTreeshakeOptions {
 
   pub fn commonjs(&self) -> bool {
     self.as_ref().and_then(|item| item.commonjs).unwrap_or(false)
+  }
+  /// By default we assume property reads have side effects
+  #[inline]
+  pub fn property_read_side_effects(&self) -> PropertyReadSideEffects {
+    self
+      .as_ref()
+      .and_then(|opt| opt.property_read_side_effects)
+      .unwrap_or(PropertyReadSideEffects::Always)
   }
 
   // TODO: optimize this
@@ -165,6 +184,7 @@ pub struct InnerOptions {
   pub manual_pure_functions: Option<FxHashSet<String>>,
   pub unknown_global_side_effects: Option<bool>,
   pub commonjs: Option<bool>,
+  pub property_read_side_effects: Option<PropertyReadSideEffects>,
 }
 
 impl Default for InnerOptions {
@@ -175,6 +195,7 @@ impl Default for InnerOptions {
       manual_pure_functions: None,
       unknown_global_side_effects: None,
       commonjs: None,
+      property_read_side_effects: None,
     }
   }
 }
@@ -199,7 +220,10 @@ impl From<&NormalizedTreeshakeOptions> for oxc::minifier::TreeShakeOptions {
       manual_pure_functions: value
         .manual_pure_functions()
         .map_or(default.manual_pure_functions, |set| set.iter().cloned().collect::<Vec<_>>()),
-      property_read_side_effects: default.property_read_side_effects,
+      property_read_side_effects: match value.property_read_side_effects() {
+        PropertyReadSideEffects::Always => oxc::minifier::PropertyReadSideEffects::All,
+        PropertyReadSideEffects::False => oxc::minifier::PropertyReadSideEffects::None,
+      },
       unknown_global_side_effects: value.unknown_global_side_effects(),
     }
   }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -74,7 +74,10 @@ pub mod bundler_options {
         TransformOptions as BundlerTransformOptions, TypeScriptOptions,
       },
       transform_options::{JsxPreset, TransformOptions},
-      treeshake::{InnerOptions, ModuleSideEffects, ModuleSideEffectsRule, PropertyReadSideEffects, TreeshakeOptions},
+      treeshake::{
+        InnerOptions, ModuleSideEffects, ModuleSideEffectsRule, PropertyReadSideEffects,
+        TreeshakeOptions,
+      },
       watch_option::{NotifyOption, OnInvalidate, WatchOption},
     },
   };

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -74,7 +74,7 @@ pub mod bundler_options {
         TransformOptions as BundlerTransformOptions, TypeScriptOptions,
       },
       transform_options::{JsxPreset, TransformOptions},
-      treeshake::{InnerOptions, ModuleSideEffects, ModuleSideEffectsRule, TreeshakeOptions},
+      treeshake::{InnerOptions, ModuleSideEffects, ModuleSideEffectsRule, PropertyReadSideEffects, TreeshakeOptions},
       watch_option::{NotifyOption, OnInvalidate, WatchOption},
     },
   };

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -798,9 +798,26 @@
             "boolean",
             "null"
           ]
+        },
+        "propertyReadSideEffects": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PropertyReadSideEffects"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
+    },
+    "PropertyReadSideEffects": {
+      "type": "string",
+      "enum": [
+        "always",
+        "false"
+      ]
     },
     "ExperimentalOptions": {
       "type": "object",

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -2009,6 +2009,11 @@ export type BindingPreserveEntrySignatures =
   | { type: 'Bool', field0: boolean }
   | { type: 'String', field0: string }
 
+export declare enum BindingPropertyReadSideEffects {
+  Always = 0,
+  False = 1
+}
+
 export interface BindingRenderBuiltUrlConfig {
   ssr: boolean
   type: 'asset' | 'public'
@@ -2080,6 +2085,7 @@ export interface BindingTreeshake {
   manualPureFunctions?: ReadonlyArray<string>
   unknownGlobalSideEffects?: boolean
   commonjs?: boolean
+  propertyReadSideEffects?: false | 'always'
 }
 
 export interface BindingVitePluginCustom {

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -508,7 +508,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { minify, Severity, ParseResult, ExportExportNameKind, ExportImportNameKind, ExportLocalNameKind, ImportNameKind, parseAsync, parseSync, rawTransferSupported, ResolverFactory, EnforceExtension, ModuleType, sync, HelperMode, isolatedDeclaration, moduleRunnerTransform, transform, BindingBundleEndEventData, BindingBundleErrorEventData, BindingBundler, BindingBundlerImpl, BindingCallableBuiltinPlugin, BindingChunkingContext, BindingDevEngine, BindingHmrOutput, BindingModuleInfo, BindingNormalizedOptions, BindingOutputAsset, BindingOutputChunk, BindingOutputs, BindingPluginContext, BindingRenderedChunk, BindingRenderedChunkMeta, BindingRenderedModule, BindingTransformPluginContext, BindingWatcher, BindingWatcherChangeData, BindingWatcherEvent, ParallelJsPluginRegistry, TraceSubscriberGuard, BindingAttachDebugInfo, BindingBuiltinPluginName, BindingChunkModuleOrderBy, BindingJsx, BindingLogLevel, BindingPluginOrder, FilterTokenKind, initTraceSubscriber, registerPlugins, shutdownAsyncRuntime, startAsyncRuntime, JsWatcher } = nativeBinding
+const { minify, Severity, ParseResult, ExportExportNameKind, ExportImportNameKind, ExportLocalNameKind, ImportNameKind, parseAsync, parseSync, rawTransferSupported, ResolverFactory, EnforceExtension, ModuleType, sync, HelperMode, isolatedDeclaration, moduleRunnerTransform, transform, BindingBundleEndEventData, BindingBundleErrorEventData, BindingBundler, BindingBundlerImpl, BindingCallableBuiltinPlugin, BindingChunkingContext, BindingDevEngine, BindingHmrOutput, BindingModuleInfo, BindingNormalizedOptions, BindingOutputAsset, BindingOutputChunk, BindingOutputs, BindingPluginContext, BindingRenderedChunk, BindingRenderedChunkMeta, BindingRenderedModule, BindingTransformPluginContext, BindingWatcher, BindingWatcherChangeData, BindingWatcherEvent, ParallelJsPluginRegistry, TraceSubscriberGuard, BindingAttachDebugInfo, BindingBuiltinPluginName, BindingChunkModuleOrderBy, BindingJsx, BindingLogLevel, BindingPluginOrder, BindingPropertyReadSideEffects, FilterTokenKind, initTraceSubscriber, registerPlugins, shutdownAsyncRuntime, startAsyncRuntime, JsWatcher } = nativeBinding
 export { minify }
 export { Severity }
 export { ParseResult }
@@ -556,6 +556,7 @@ export { BindingChunkModuleOrderBy }
 export { BindingJsx }
 export { BindingLogLevel }
 export { BindingPluginOrder }
+export { BindingPropertyReadSideEffects }
 export { FilterTokenKind }
 export { initTraceSubscriber }
 export { registerPlugins }

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -110,6 +110,7 @@ export const BindingChunkModuleOrderBy = __napiModule.exports.BindingChunkModule
 export const BindingJsx = __napiModule.exports.BindingJsx
 export const BindingLogLevel = __napiModule.exports.BindingLogLevel
 export const BindingPluginOrder = __napiModule.exports.BindingPluginOrder
+export const BindingPropertyReadSideEffects = __napiModule.exports.BindingPropertyReadSideEffects
 export const FilterTokenKind = __napiModule.exports.FilterTokenKind
 export const initTraceSubscriber = __napiModule.exports.initTraceSubscriber
 export const registerPlugins = __napiModule.exports.registerPlugins

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -155,6 +155,7 @@ module.exports.BindingChunkModuleOrderBy = __napiModule.exports.BindingChunkModu
 module.exports.BindingJsx = __napiModule.exports.BindingJsx
 module.exports.BindingLogLevel = __napiModule.exports.BindingLogLevel
 module.exports.BindingPluginOrder = __napiModule.exports.BindingPluginOrder
+module.exports.BindingPropertyReadSideEffects = __napiModule.exports.BindingPropertyReadSideEffects
 module.exports.FilterTokenKind = __napiModule.exports.FilterTokenKind
 module.exports.initTraceSubscriber = __napiModule.exports.initTraceSubscriber
 module.exports.registerPlugins = __napiModule.exports.registerPlugins

--- a/packages/rolldown/src/types/module-side-effects.ts
+++ b/packages/rolldown/src/types/module-side-effects.ts
@@ -17,5 +17,5 @@ export type TreeshakingOptions = {
   manualPureFunctions?: readonly string[];
   unknownGlobalSideEffects?: boolean;
   commonjs?: boolean;
-  propertyReadSideEffects?: boolean | 'always';
+  propertyReadSideEffects?: false | 'always';
 };

--- a/packages/rolldown/src/types/module-side-effects.ts
+++ b/packages/rolldown/src/types/module-side-effects.ts
@@ -17,4 +17,5 @@ export type TreeshakingOptions = {
   manualPureFunctions?: readonly string[];
   unknownGlobalSideEffects?: boolean;
   commonjs?: boolean;
+  propertyReadSideEffects?: boolean | 'always';
 };

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -322,6 +322,9 @@ const TreeshakingOptionsSchema = v.union([
     manualPureFunctions: v.optional(v.array(v.string())),
     unknownGlobalSideEffects: v.optional(v.boolean()),
     commonjs: v.optional(v.boolean()),
+    propertyReadSideEffects: v.optional(
+      v.union([v.literal(false), v.literal('always')]),
+    ),
   }),
 ]);
 


### PR DESCRIPTION
related to #5872

1. Now only `'always'` and `false` of `treeshake.propertyReadSideEffects` are supported
2. `true` required to analyse the internal object, which we don't have the ability yet.