### PR TITLE
refactor: make `ecma_related` in `NormalModuleTaskResult` non-optional

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -336,10 +336,7 @@ impl<'a> ModuleLoader<'a> {
             warnings,
           } = *task_result;
           all_warnings.extend(warnings);
-          let mut dynamic_import_rec_exports_usage = ecma_related
-            .as_mut()
-            .map(|item| std::mem::take(&mut item.dynamic_import_rec_exports_usage))
-            .unwrap_or_default();
+          let dynamic_import_rec_exports_usage = &mut ecma_related.dynamic_import_rec_exports_usage;
 
           let mut import_records: IndexVec<ImportRecordIdx, rolldown_common::ResolvedImportRecord> =
             IndexVec::with_capacity(raw_import_records.len());
@@ -409,10 +406,9 @@ impl<'a> ModuleLoader<'a> {
           module.set_import_records(import_records);
 
           let module_idx = module.idx();
-          if let Some(EcmaRelated { ast, symbols, .. }) = ecma_related {
-            *self.intermediate_normal_modules.index_ecma_ast.get_mut(module_idx) = Some(ast);
-            self.symbol_ref_db.store_local_db(module_idx, symbols);
-          }
+          let EcmaRelated { ast, symbols, .. } = ecma_related;
+          *self.intermediate_normal_modules.index_ecma_ast.get_mut(module_idx) = Some(ast);
+          self.symbol_ref_db.store_local_db(module_idx, symbols);
 
           if user_defined_entry_ids.contains(&module_idx) {
             module.as_normal_mut().expect("should be normal module ").is_user_defined_entry = true;

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -212,7 +212,7 @@ impl ModuleTask {
 
     let result = ModuleLoaderMsg::NormalModuleDone(Box::new(NormalModuleTaskResult {
       module: module.into(),
-      ecma_related: Some(ecma_related),
+      ecma_related,
       resolved_deps,
       raw_import_records,
       warnings,

--- a/crates/rolldown_common/src/module_loader/task_result.rs
+++ b/crates/rolldown_common/src/module_loader/task_result.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashMap;
 
 pub struct NormalModuleTaskResult {
   pub module: Module,
-  pub ecma_related: Option<EcmaRelated>,
+  pub ecma_related: EcmaRelated,
   pub resolved_deps: IndexVec<ImportRecordIdx, ResolvedId>,
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
   pub warnings: Vec<BuildDiagnostic>,


### PR DESCRIPTION
Related to #5946