### PR TITLE
feat(dev): default to not eager rebuild

### DIFF
--- a/crates/rolldown/examples/dev.rs
+++ b/crates/rolldown/examples/dev.rs
@@ -13,9 +13,11 @@ async fn main() {
     experimental: Some(ExperimentalOptions { incremental_build: Some(true), ..Default::default() }),
     ..Default::default()
   });
-  let dev_engine =
-    DevEngine::<rolldown_watcher::NotifyWatcher>::new(bundler_builder, DevOptions::default())
-      .unwrap();
+  let dev_engine = DevEngine::<rolldown_watcher::NotifyWatcher>::new(
+    bundler_builder,
+    DevOptions { eager_rebuild: Some(true), ..Default::default() },
+  )
+  .unwrap();
   dev_engine.run().await;
   dev_engine.wait_for_close().await;
 }

--- a/crates/rolldown/src/dev/build_state_machine/mod.rs
+++ b/crates/rolldown/src/dev/build_state_machine/mod.rs
@@ -5,14 +5,20 @@ use rolldown_error::BuildResult;
 use crate::dev::dev_context::BuildProcessFuture;
 use indexmap::IndexSet;
 use std::path::PathBuf;
+use tracing;
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct BuildStateMachine<State = BuildState> {
   pub changed_files: IndexSet<PathBuf>,
+  pub require_full_rebuild: bool,
   pub state: State,
 }
 
 impl BuildStateMachine<BuildState> {
+  pub fn new() -> Self {
+    Self { changed_files: IndexSet::new(), require_full_rebuild: true, state: BuildState::Idle }
+  }
+
   pub fn is_busy(&self) -> bool {
     matches!(self.state, BuildState::Building { .. } | BuildState::Delaying { .. })
   }
@@ -34,29 +40,38 @@ impl BuildStateMachine<BuildState> {
   }
 
   pub fn try_to_delaying(&mut self, future: BuildProcessFuture) -> BuildResult<()> {
+    tracing::trace!("Attempting to transition to Delaying state");
+    self.require_full_rebuild = false;
     match &self.state {
       BuildState::Idle => {
+        tracing::info!("State transition: Idle -> Delaying");
         self.state = BuildState::Delaying(BuildDelayingState { future });
         Ok(())
       }
       BuildState::Building(_) => {
+        tracing::error!("Illegal state switching to `Delaying` state from `Building`");
         Err(anyhow::format_err!("Illegal state switching to `Delaying` state from `Building`."))?
       }
       BuildState::Delaying(_) => {
+        tracing::error!("Illegal state switching to `Delaying` state from `Delaying`");
         Err(anyhow::format_err!("Illegal state switching to `Delaying` state from `Delaying`."))?
       }
     }
   }
 
   pub fn try_to_building(&mut self) -> BuildResult<()> {
+    tracing::trace!("Attempting to transition to Building state");
     match &self.state {
       BuildState::Idle => {
+        tracing::error!("Illegal state switching to `Building` state from `Idle`");
         Err(anyhow::format_err!("Illegal state switching to `Building` state from `Idle`."))?
       }
       BuildState::Building(_) => {
+        tracing::error!("Illegal state switching to `Building` state from `Building`");
         Err(anyhow::format_err!("Illegal state switching to `Building` state from `Building`."))?
       }
       BuildState::Delaying(inner) => {
+        tracing::info!("State transition: Delaying -> Building");
         let future = inner.future.clone();
         self.state = BuildState::Building(BuildBuildingState { future });
         Ok(())
@@ -65,14 +80,18 @@ impl BuildStateMachine<BuildState> {
   }
 
   pub fn try_to_idle(&mut self) -> BuildResult<()> {
+    tracing::trace!("Attempting to transition to Idle state");
     match &self.state {
       BuildState::Idle => {
+        tracing::error!("Illegal state switching to `Idle` state from `Idle`");
         Err(anyhow::format_err!("Illegal state switching to `Idle` state from `Idle`."))?
       }
       BuildState::Delaying(_) => {
+        tracing::error!("Illegal state switching to `Idle` state from `Delaying`");
         Err(anyhow::format_err!("Illegal state switching to `Idle` state from `Delaying`."))?
       }
       BuildState::Building(_) => {
+        tracing::info!("State transition: Building -> Idle");
         self.state = BuildState::Idle;
         Ok(())
       }

--- a/crates/rolldown/src/dev/dev_context.rs
+++ b/crates/rolldown/src/dev/dev_context.rs
@@ -3,7 +3,7 @@ use std::{future::Future, pin::Pin, sync::Arc};
 use futures::future::Shared;
 use tokio::sync::Mutex;
 
-use crate::dev::build_state_machine::BuildStateMachine;
+use crate::dev::{NormalizedDevOptions, build_state_machine::BuildStateMachine};
 
 pub type SharedDevContext = Arc<DevContext>;
 
@@ -11,23 +11,18 @@ pub type PinBoxSendStaticFuture<T = ()> = Pin<Box<dyn Future<Output = T> + Send 
 pub type BuildProcessFuture = Shared<PinBoxSendStaticFuture<()>>;
 
 pub struct DevContext {
-  pub status: Mutex<BuildStateMachine>,
+  pub state: Mutex<BuildStateMachine>,
+  pub options: NormalizedDevOptions,
 }
 
 impl DevContext {
   pub async fn ensure_current_build_finish(&self) -> () {
-    let build_status = self.status.lock().await;
-    if let Some(build_process_future) = build_status.is_busy_then_future().cloned() {
+    let build_state = self.state.lock().await;
+    if let Some(build_process_future) = build_state.is_busy_then_future().cloned() {
       // Note: Inside `build_process_future`, it requires to lock `BuildStatus` to modify the status.
       // So, we need to drop the lock before we await `build_process_future`, otherwise we might get a deadlock.
-      drop(build_status);
+      drop(build_state);
       build_process_future.await;
     }
-  }
-}
-
-impl Default for DevContext {
-  fn default() -> Self {
-    Self { status: Mutex::new(BuildStateMachine::default()) }
   }
 }

--- a/crates/rolldown/src/dev/dev_options.rs
+++ b/crates/rolldown/src/dev/dev_options.rs
@@ -3,15 +3,23 @@ use std::sync::Arc;
 
 pub type OnHmrUpdatesCallback = Arc<dyn Fn(Vec<HmrUpdate>) + Send + Sync>;
 
+pub type SharedNormalizedDevOptions = Arc<NormalizedDevOptions>;
+
 #[derive(Default)]
 pub struct DevOptions {
   pub on_hmr_updates: Option<OnHmrUpdatesCallback>,
+  /// If `true`, A rebuild will be always issued when a file changes.
+  pub eager_rebuild: Option<bool>,
 }
 
 pub struct NormalizedDevOptions {
   pub on_hmr_updates: Option<OnHmrUpdatesCallback>,
+  pub eager_rebuild: bool,
 }
 
 pub fn normalize_dev_options(options: DevOptions) -> NormalizedDevOptions {
-  NormalizedDevOptions { on_hmr_updates: options.on_hmr_updates }
+  NormalizedDevOptions {
+    on_hmr_updates: options.on_hmr_updates,
+    eager_rebuild: options.eager_rebuild.unwrap_or_default(),
+  }
 }


### PR DESCRIPTION
Eager rebuild might cause inconsist module graph/state between rolldown and browser. It will cause generating wrong hmr updates for the client.

Currently, I'm thinking the process would be:
After the initial build, 
- For each file change, we won't trigger rebuild
- For each file change, we will generate hmr updates and invoke `onHmrUpdates` callback.
- `DevServer` will trigger the rebuild in proper timings like user reloads the page to make sure user could access latest content.

Above are the situations. There'll be some smarter actions to be done for improving UX. Like if the hmr updates result to full reload, we'll trigger a rebuild immediately instead of waiting for being called by `DevServer`.