### PR TITLE
fix: should not generate `init_mod` when record is a ExportAllDeclaration and importee is a inner concatenate module

### DIFF
--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/_config.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "experimental": {
+      "strictExecutionOrder": true
+    }
+  },
+  "configVariants": [
+    {
+      "onDemandWrapping": true
+    }
+  ],
+  "snapshot": false
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/heavy/index.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/heavy/index.js
@@ -1,0 +1,1 @@
+export * from './m01.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/heavy/m01.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/heavy/m01.js
@@ -1,0 +1,2 @@
+globalThis.foo = 'foo';
+export const H01 = true;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5922/main.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert'
+import * as ns from './heavy/index';
+assert.strictEqual(ns.H01, true);
+assert.strictEqual(globalThis.foo, 'foo');

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3983,6 +3983,10 @@ expression: output
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BjtMze0h.js
 - test-!~{003}~.js => test-DWjb2zYB.js
 
+# tests/rolldown/function/experimental/strict_execution_order/issue_5922
+
+- main-!~{000}~.js => main-DhT6Z56b.js
+
 # tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping
 
 - dynamic-!~{001}~.js => dynamic-BhqYqd04.js


### PR DESCRIPTION
related to #5922

This is an issue I found when I investigated #5922