### PR TITLE
fix: try 5954

### DIFF
--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -11,7 +11,7 @@ use oxc::transformer_plugins::{
 };
 
 use rolldown_common::NormalizedBundlerOptions;
-use rolldown_ecmascript::{EcmaAst, WithMutFields};
+use rolldown_ecmascript::{EcmaAst, ToSourceString, WithMutFields};
 use rolldown_error::{BuildDiagnostic, BuildResult, Severity};
 
 use crate::types::oxc_parse_type::OxcParseType;
@@ -68,6 +68,7 @@ impl PreProcessEcmaAst {
         scoping
       }
     });
+
     // Transform TypeScript and jsx.
     // Note: Currently, oxc_transform supports es syntax up to ES2024 (unicode-sets-regex).
     if !matches!(parsed_type, OxcParseType::Js)
@@ -75,6 +76,7 @@ impl PreProcessEcmaAst {
     {
       let ret = ast.program.with_mut(|fields| {
         let transform_options = &bundle_options.transform_options;
+        dbg!(&transform_options.typescript.only_remove_type_imports);
 
         Transformer::new(fields.allocator, Path::new(path), transform_options)
           .build_with_scoping(scoping, fields.program)

--- a/examples/basic-vue/index.js
+++ b/examples/basic-vue/index.js
@@ -1,3 +1,0 @@
-import { createApp } from 'vue';
-
-export default createApp({});

--- a/examples/basic-vue/index.ts
+++ b/examples/basic-vue/index.ts
@@ -1,1 +1,2 @@
 import { type T01 } from '@shared/types'
+

--- a/examples/basic-vue/index.ts
+++ b/examples/basic-vue/index.ts
@@ -1,2 +1,1 @@
-import { type T01 } from '@shared/types'
-
+import { type T01 } from '@shared/types';

--- a/examples/basic-vue/main.ts
+++ b/examples/basic-vue/main.ts
@@ -1,1 +1,1 @@
-import { type T01 } from '@shared/types'
+import { type T01 } from '@shared/types';

--- a/examples/basic-vue/rolldown.config.js
+++ b/examples/basic-vue/rolldown.config.js
@@ -4,7 +4,7 @@ export default defineConfig({
   input: './index.ts',
   transform: {
     typescript: {
-      onlyRemoveTypeImports: true
-    }
-  }
+      onlyRemoveTypeImports: true,
+    },
+  },
 });

--- a/examples/basic-vue/rolldown.config.js
+++ b/examples/basic-vue/rolldown.config.js
@@ -1,5 +1,10 @@
 import { defineConfig } from 'rolldown';
 
 export default defineConfig({
-  input: './index.js',
+  input: './index.ts',
+  transform: {
+    typescript: {
+      onlyRemoveTypeImports: true
+    }
+  }
 });

--- a/examples/basic-vue/tsconfig.json
+++ b/examples/basic-vue/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Bundler",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "useDefineForClassFields": true,
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": [
+        "./src/*"
+      ],
+      "@shared": [
+        "./src/lib/index.ts"
+      ],
+      "@shared/types": [
+        "./src/lib/types/index.ts"
+      ],
+      "@utils/*": [
+        "./src/lib/utils/*"
+      ]
+    }
+  },
+  "include": [
+    "./**/*.ts"
+  ]
+}


### PR DESCRIPTION
First run `just build` to build the binding.

# Without `tsconfig`
When you customize `transform.typescript.onlyRemoveTypeImports`, it works as expected.
See the `dbg!` print result
# With `tsconfig: "./tsconfig.json"`
1. The default value of `onlyRemoveTypeImports`  become `true`
2. When you customize `transform.typescript.onlyRemoveTypeImports`, the result did not change

>   * When a tsconfig path is specified, the module resolver will respect `compilerOptions.paths` from the specified `tsconfig.json`,
>  * and the tsconfig options will be merged with the top-level `transform` options, with the `transform` options taking precedence.

According to the documentation, whena  user tries to customize `onlyRemoveTypeImports`, it should overridethe  related value in `tsconfig.json`