### PR TITLE
feat(dev): manage cache by `DevEngine`

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -388,6 +388,14 @@ impl Bundler {
       });
     }
   }
+
+  pub fn take_cache(&mut self) -> ScanStageCache {
+    std::mem::take(&mut self.cache)
+  }
+
+  pub fn set_cache(&mut self, cache: ScanStageCache) {
+    self.cache = cache;
+  }
 }
 
 struct CacheGuard<'a> {

--- a/crates/rolldown/src/dev/build_driver.rs
+++ b/crates/rolldown/src/dev/build_driver.rs
@@ -57,6 +57,7 @@ impl BuildDriver {
         require_full_rebuild: build_state.require_full_rebuild,
         dev_data: Arc::clone(&self.ctx),
         ensure_latest_build: true,
+        cache: build_state.cache.take(),
       };
 
       let bundling_future = (Box::pin(bundling_task.exec()) as PinBoxSendStaticFuture).shared();

--- a/crates/rolldown/src/dev/build_state_machine/mod.rs
+++ b/crates/rolldown/src/dev/build_state_machine/mod.rs
@@ -2,7 +2,7 @@ pub mod build_state;
 use build_state::{BuildBuildingState, BuildDelayingState, BuildState};
 use rolldown_error::BuildResult;
 
-use crate::dev::dev_context::BuildProcessFuture;
+use crate::{dev::dev_context::BuildProcessFuture, types::scan_stage_cache::ScanStageCache};
 use indexmap::IndexSet;
 use std::path::PathBuf;
 use tracing;
@@ -11,12 +11,18 @@ use tracing;
 pub struct BuildStateMachine<State = BuildState> {
   pub changed_files: IndexSet<PathBuf>,
   pub require_full_rebuild: bool,
+  pub cache: Option<ScanStageCache>,
   pub state: State,
 }
 
 impl BuildStateMachine<BuildState> {
   pub fn new() -> Self {
-    Self { changed_files: IndexSet::new(), require_full_rebuild: true, state: BuildState::Idle }
+    Self {
+      changed_files: IndexSet::new(),
+      require_full_rebuild: true,
+      state: BuildState::Idle,
+      cache: None,
+    }
   }
 
   pub fn is_busy(&self) -> bool {


### PR DESCRIPTION
Current implementation is just to make new api work. It'll get polished once the new api get stablized.