### PR TITLE
fix: merge `typescript.onlyRemoveTypeImports` correctly

### DIFF
--- a/crates/rolldown/src/utils/normalize_transform_options.rs
+++ b/crates/rolldown/src/utils/normalize_transform_options.rs
@@ -93,30 +93,31 @@ pub fn normalize_transform_options_with_tsconfig(
     // | true                 | remove                 | -                    | -                     |
     // | true                 | preserve, error        | true                 | true                  |
     let mut typescript = transform_options.typescript.unwrap_or_default();
-    typescript.only_remove_type_imports = if compiler_options.verbatim_module_syntax.is_some() {
-      compiler_options.verbatim_module_syntax
-    } else if compiler_options.preserve_value_imports.is_some()
-      || compiler_options.imports_not_used_as_values.is_some()
-    {
-      let preserve_value_imports = compiler_options.preserve_value_imports.unwrap_or(false);
-      let imports_not_used_as_values =
-        compiler_options.imports_not_used_as_values.as_deref().unwrap_or("remove");
-      if !preserve_value_imports && imports_not_used_as_values == "remove" {
-        Some(true)
-      } else if preserve_value_imports
-        && (imports_not_used_as_values == "preserve" || imports_not_used_as_values == "error")
+    if typescript.only_remove_type_imports.is_none() {
+      if compiler_options.verbatim_module_syntax.is_some() {
+        typescript.only_remove_type_imports = compiler_options.verbatim_module_syntax;
+      } else if compiler_options.preserve_value_imports.is_some()
+        || compiler_options.imports_not_used_as_values.is_some()
       {
-        Some(false)
-      } else {
-        // warnings.push(
-        //   `preserveValueImports=${preserveValueImports} + importsNotUsedAsValues=${importsNotUsedAsValues} is not supported by oxc.` +
-        //     'Please migrate to the new verbatimModuleSyntax option.',
-        // )
-        Some(false)
+        let preserve_value_imports = compiler_options.preserve_value_imports.unwrap_or(false);
+        let imports_not_used_as_values =
+          compiler_options.imports_not_used_as_values.as_deref().unwrap_or("remove");
+        typescript.only_remove_type_imports =
+          if !preserve_value_imports && imports_not_used_as_values == "remove" {
+            Some(true)
+          } else if preserve_value_imports
+            && (imports_not_used_as_values == "preserve" || imports_not_used_as_values == "error")
+          {
+            Some(false)
+          } else {
+            // warnings.push(
+            //   `preserveValueImports=${preserveValueImports} + importsNotUsedAsValues=${importsNotUsedAsValues} is not supported by oxc.` +
+            //     'Please migrate to the new verbatimModuleSyntax option.',
+            // )
+            Some(false)
+          };
       }
-    } else {
-      Some(false)
-    };
+    }
 
     let disable_use_define_for_class_fields =
       !compiler_options.use_define_for_class_fields.unwrap_or_else(|| {

--- a/crates/rolldown_plugin_transform/src/utils.rs
+++ b/crates/rolldown_plugin_transform/src/utils.rs
@@ -199,30 +199,32 @@ impl TransformPlugin {
         // | true                 | remove                 | -                    | -                     |
         // | true                 | preserve, error        | true                 | true                  |
         let mut typescript = transform_options.typescript.unwrap_or_default();
-        typescript.only_remove_type_imports = if compiler_options.verbatim_module_syntax.is_some() {
-          compiler_options.verbatim_module_syntax
-        } else if compiler_options.preserve_value_imports.is_some()
-          || compiler_options.imports_not_used_as_values.is_some()
-        {
-          let preserve_value_imports = compiler_options.preserve_value_imports.unwrap_or(false);
-          let imports_not_used_as_values =
-            compiler_options.imports_not_used_as_values.as_deref().unwrap_or("remove");
-          if !preserve_value_imports && imports_not_used_as_values == "remove" {
-            Some(true)
-          } else if preserve_value_imports
-            && (imports_not_used_as_values == "preserve" || imports_not_used_as_values == "error")
+        if typescript.only_remove_type_imports.is_none() {
+          if compiler_options.verbatim_module_syntax.is_some() {
+            typescript.only_remove_type_imports = compiler_options.verbatim_module_syntax;
+          } else if compiler_options.preserve_value_imports.is_some()
+            || compiler_options.imports_not_used_as_values.is_some()
           {
-            Some(false)
-          } else {
-            // warnings.push(
-            //   `preserveValueImports=${preserveValueImports} + importsNotUsedAsValues=${importsNotUsedAsValues} is not supported by oxc.` +
-            //     'Please migrate to the new verbatimModuleSyntax option.',
-            // )
-            Some(false)
+            let preserve_value_imports = compiler_options.preserve_value_imports.unwrap_or(false);
+            let imports_not_used_as_values =
+              compiler_options.imports_not_used_as_values.as_deref().unwrap_or("remove");
+            typescript.only_remove_type_imports = if !preserve_value_imports
+              && imports_not_used_as_values == "remove"
+            {
+              Some(true)
+            } else if preserve_value_imports
+              && (imports_not_used_as_values == "preserve" || imports_not_used_as_values == "error")
+            {
+              Some(false)
+            } else {
+              // warnings.push(
+              //   `preserveValueImports=${preserveValueImports} + importsNotUsedAsValues=${importsNotUsedAsValues} is not supported by oxc.` +
+              //     'Please migrate to the new verbatimModuleSyntax option.',
+              // )
+              Some(false)
+            };
           }
-        } else {
-          Some(false)
-        };
+        }
 
         let disable_use_define_for_class_fields = !compiler_options
           .use_define_for_class_fields

--- a/packages/rolldown/tests/fixtures/transform/only-remove-type-imports/_config.ts
+++ b/packages/rolldown/tests/fixtures/transform/only-remove-type-imports/_config.ts
@@ -5,6 +5,7 @@ import { getOutputChunk } from 'rolldown-tests/utils'
 export default defineTest({
   config: {
     input: 'main.ts',
+    tsconfig: 'tsconfig.json',
     transform: {
       typescript: {
         onlyRemoveTypeImports: true,

--- a/packages/rolldown/tests/fixtures/transform/only-remove-type-imports/tsconfig.json
+++ b/packages/rolldown/tests/fixtures/transform/only-remove-type-imports/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "verbatimModuleSyntax": false
+  },
+  "extends": "../../../../tsconfig.json"
+}


### PR DESCRIPTION
closes #5954

Waiting for confirmation on https://github.com/vitejs/rolldown-vite/pull/394