### PR TITLE
docs: add redirect for old plugin development page link

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -6,6 +6,10 @@ ignore = "git diff --quiet 'HEAD^' HEAD ./docs ./packages/rolldown"
 from = "/about/"
 to = "/guide/"
 
+[[redirects]]
+from = "/guide/plugin-development"
+to = "/plugins/"
+
 # https://github.com/okineadev/vitepress-plugin-llms#netlify
 [[redirects]]
 from = "/*.txt"


### PR DESCRIPTION
Makes sure that previous links like https://rolldown.rs/guide/plugin-development#plugin-hook-filters do not break 