### PR TITLE
fix: __toESM function breaking ES module imports

### DIFF
--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_assert = __toESM(require("node:assert"));
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
 
 //#region foo/test.js
 var test_exports = {};

--- a/crates/rolldown/tests/esbuild/default/import_fs_node_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_fs_node_common_js/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const fs = __toESM(require("fs"));
+let fs = require("fs");
+fs = __toESM(fs);
 
 //#region entry.js
 console.log(fs, fs.readFileSync, fs.default);

--- a/crates/rolldown/tests/esbuild/default/import_namespace_this_value/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_namespace_this_value/artifacts.snap
@@ -45,7 +45,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 const require_chunk = require('./chunk.js');
-const external = require_chunk.__toESM(require("external"));
+let external = require("external");
+external = require_chunk.__toESM(external);
 
 //#region a.js
 console.log(external[foo](), new external[foo]());
@@ -56,7 +57,8 @@ console.log(external[foo](), new external[foo]());
 
 ```js
 const require_chunk = require('./chunk.js');
-const external = require_chunk.__toESM(require("external"));
+let external = require("external");
+external = require_chunk.__toESM(external);
 
 //#region b.js
 console.log(external.foo(), new external.foo());
@@ -67,7 +69,8 @@ console.log(external.foo(), new external.foo());
 
 ```js
 const require_chunk = require('./chunk.js');
-const external = require_chunk.__toESM(require("external"));
+let external = require("external");
+external = require_chunk.__toESM(external);
 
 //#region c.js
 console.log((0, external.default)(), (0, external.foo)());

--- a/crates/rolldown/tests/esbuild/default/inject/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/inject/artifacts.snap
@@ -7,8 +7,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const external_pkg = __toESM(require("external-pkg"));
-const external_pkg2 = __toESM(require("external-pkg2"));
+let external_pkg = require("external-pkg");
+external_pkg = __toESM(external_pkg);
+let external_pkg2 = require("external-pkg2");
+external_pkg2 = __toESM(external_pkg2);
 
 //#region replacement.js
 let replace = { test() {} };

--- a/crates/rolldown/tests/esbuild/default/quoted_property/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/quoted_property/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const ext = __toESM(require("ext"));
+let ext = require("ext");
+ext = __toESM(ext);
 
 //#region entry.js
 console.log(ext.mustBeUnquoted, ext["mustBeQuoted"]);

--- a/crates/rolldown/tests/esbuild/default/quoted_property_mangle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/quoted_property_mangle/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const ext = __toESM(require("ext"));
+let ext = require("ext");
+ext = __toESM(ext);
 
 //#region entry.js
 console.log(ext.mustBeUnquoted, ext["mustBeUnquoted2"]);

--- a/crates/rolldown/tests/esbuild/default/re_export_default_external_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/re_export_default_external_common_js/artifacts.snap
@@ -7,8 +7,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const foo = __toESM(require("foo"));
-const bar = __toESM(require("bar"));
+let foo = require("foo");
+foo = __toESM(foo);
+let bar = require("bar");
+bar = __toESM(bar);
 
 Object.defineProperty(exports, 'bar', {
   enumerable: true,

--- a/crates/rolldown/tests/esbuild/default/re_export_default_no_bundle_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/re_export_default_no_bundle_common_js/artifacts.snap
@@ -7,8 +7,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const foo = __toESM(require("./foo"));
-const bar = __toESM(require("./bar"));
+let foo = require("./foo");
+foo = __toESM(foo);
+let bar = require("./bar");
+bar = __toESM(bar);
 
 Object.defineProperty(exports, 'bar', {
   enumerable: true,

--- a/crates/rolldown/tests/esbuild/default/string_export_names_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/string_export_names_common_js/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const foo = __toESM(require("./foo"));
+let foo = require("./foo");
+foo = __toESM(foo);
 
 Object.defineProperty(exports, 'all the stuff', {
   enumerable: true,

--- a/crates/rolldown/tests/esbuild/default/to_esm_wrapper_omission/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/to_esm_wrapper_omission/artifacts.snap
@@ -142,14 +142,22 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 require("a_nowrap");
-const b_nowrap = __toESM(require("b_nowrap"));
-const d_WRAP = __toESM(require("d_WRAP"));
-const e_WRAP = __toESM(require("e_WRAP"));
-const f_WRAP = __toESM(require("f_WRAP"));
-const g_WRAP = __toESM(require("g_WRAP"));
-const h_WRAP = __toESM(require("h_WRAP"));
-const i_WRAP = __toESM(require("i_WRAP"));
-const j_WRAP = __toESM(require("j_WRAP"));
+let b_nowrap = require("b_nowrap");
+b_nowrap = __toESM(b_nowrap);
+let d_WRAP = require("d_WRAP");
+d_WRAP = __toESM(d_WRAP);
+let e_WRAP = require("e_WRAP");
+e_WRAP = __toESM(e_WRAP);
+let f_WRAP = require("f_WRAP");
+f_WRAP = __toESM(f_WRAP);
+let g_WRAP = require("g_WRAP");
+g_WRAP = __toESM(g_WRAP);
+let h_WRAP = require("h_WRAP");
+h_WRAP = __toESM(h_WRAP);
+let i_WRAP = require("i_WRAP");
+i_WRAP = __toESM(i_WRAP);
+let j_WRAP = require("j_WRAP");
+j_WRAP = __toESM(j_WRAP);
 
 //#region entry.js
 (0, b_nowrap.b)();

--- a/crates/rolldown/tests/esbuild/default/warn_common_js_exports_in_esm_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/warn_common_js_exports_in_esm_bundle/artifacts.snap
@@ -52,7 +52,8 @@ exports.foo = foo;
 
 ```js
 // HIDDEN [rolldown:runtime]
-const bar = __toESM(require("bar"));
+let bar = require("bar");
+bar = __toESM(bar);
 
 //#region import-in-cjs.js
 exports.foo = bar.foo;

--- a/crates/rolldown/tests/esbuild/default/warn_common_js_exports_in_esm_convert/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/warn_common_js_exports_in_esm_convert/artifacts.snap
@@ -90,7 +90,8 @@ exports.foo = foo;
 
 ```js
 // HIDDEN [rolldown:runtime]
-const bar = __toESM(require("bar"));
+let bar = require("bar");
+bar = __toESM(bar);
 
 //#region import-in-cjs.js
 exports.foo = bar.foo;

--- a/crates/rolldown/tests/esbuild/importstar/import_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_self_common_js/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_assert = __toESM(require("node:assert"));
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
 
 //#region entry.js
 var require_entry = /* @__PURE__ */ __commonJS({ "entry.js": ((exports) => {

--- a/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_common_js_no_capture/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_assert = __toESM(require("node:assert"));
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
 
 //#region foo.js
 var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/artifacts.snap
@@ -21,7 +21,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const foo = __toESM(require("foo"));
+let foo = require("foo");
+foo = __toESM(foo);
 
 Object.defineProperty(exports, 'out', {
   enumerable: true,

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_common_js/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const foo = __toESM(require("foo"));
+let foo = require("foo");
+foo = __toESM(foo);
 
 Object.defineProperty(exports, 'out', {
   enumerable: true,

--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_module_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_module_cjs/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 const require_share$1 = require('./share.js');
-const node_assert = require_share$1.__toESM(require("node:assert"));
+let node_assert = require("node:assert");
+node_assert = require_share$1.__toESM(node_assert);
 
 //#region main1.js
 var import_share = /* @__PURE__ */ require_share$1.__toESM(require_share$1.require_share());
@@ -19,7 +20,8 @@ node_assert.default.equal((0, import_share.share)(), 1);
 
 ```js
 const require_share$1 = require('./share.js');
-const node_assert = require_share$1.__toESM(require("node:assert"));
+let node_assert = require("node:assert");
+node_assert = require_share$1.__toESM(node_assert);
 
 //#region main2.js
 var import_share = /* @__PURE__ */ require_share$1.__toESM(require_share$1.require_share());

--- a/crates/rolldown/tests/rolldown/function/external_live_bindings/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external_live_bindings/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_fs = __toESM(require("node:fs"));
+let node_fs = require("node:fs");
+node_fs = __toESM(node_fs);
 
 //#region main.js
 const nonExternal = "nonExternal";

--- a/crates/rolldown/tests/rolldown/issues/2859/1/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2859/1/artifacts.snap
@@ -60,7 +60,8 @@ exports.foo = foo;
 
 ```js
 // HIDDEN [rolldown:runtime]
-const assert = __toESM(require("assert"));
+let assert = require("assert");
+assert = __toESM(assert);
 
 //#region main.js
 Promise.resolve().then(() => require("./lib.js")).then((exports$1) => assert.default.deepStrictEqual({ ...exports$1 }, {

--- a/crates/rolldown/tests/rolldown/issues/2859/2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2859/2/artifacts.snap
@@ -41,7 +41,8 @@ Variant: [format: Cjs]
 ```js
 Object.defineProperty(exports, '__esModule', { value: true });
 // HIDDEN [rolldown:runtime]
-const assert = __toESM(require("assert"));
+let assert = require("assert");
+assert = __toESM(assert);
 
 //#region main.js
 const foo = "foo";

--- a/crates/rolldown/tests/rolldown/issues/2903/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2903/artifacts.snap
@@ -19,7 +19,8 @@ Object.defineProperty(exports, '__toESM', {
 
 ```js
 const require_chunk = require('./chunk.js');
-const node_path = require_chunk.__toESM(require("node:path"));
+let node_path = require("node:path");
+node_path = require_chunk.__toESM(node_path);
 
 //#region main.js
 var main_default = node_path.default.join;
@@ -31,7 +32,8 @@ module.exports = main_default;
 
 ```js
 const require_chunk = require('./chunk.js');
-const node_fs = require_chunk.__toESM(require("node:fs"));
+let node_fs = require("node:fs");
+node_fs = require_chunk.__toESM(node_fs);
 
 //#region main2.js
 var main2_default = node_fs.default.existsSync;

--- a/crates/rolldown/tests/rolldown/issues/2903_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2903_2/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_path = __toESM(require("node:path"));
+let node_path = require("node:path");
+node_path = __toESM(node_path);
 
 module.exports = node_path.default;
 ```

--- a/crates/rolldown/tests/rolldown/issues/2903_3/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2903_3/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_path = __toESM(require("node:path"));
+let node_path = require("node:path");
+node_path = __toESM(node_path);
 
 module.exports = node_path.default;
 ```

--- a/crates/rolldown/tests/rolldown/issues/3456/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3456/artifacts.snap
@@ -20,7 +20,8 @@ Variant: [format: Cjs]
 
 ```js
 // HIDDEN [rolldown:runtime]
-const external = __toESM(require("external"));
+let external = require("external");
+external = __toESM(external);
 
 exports["\n\"\\'"] = external["\n\"\\'"];
 ```

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -121,7 +121,8 @@ Object.defineProperty(exports, 'default', {
 
 ```js
 const require_chunk = require('./chunk.js');
-const node_assert = require_chunk.__toESM(require("node:assert"));
+let node_assert = require("node:assert");
+node_assert = require_chunk.__toESM(node_assert);
 
 //#region non-node-mode.js
 async function main$2() {

--- a/crates/rolldown/tests/rolldown/issues/4406/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4406/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const zod = __toESM(require("zod"));
+let zod = require("zod");
+zod = __toESM(zod);
 
 //#region main.js
 console.log(zod.z);

--- a/crates/rolldown/tests/rolldown/issues/4585/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4585/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_process = __toESM(require("node:process"));
+let node_process = require("node:process");
+node_process = __toESM(node_process);
 
 //#region lib.js
 var VFile = class {

--- a/crates/rolldown/tests/rolldown/issues/5044/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5044/artifacts.snap
@@ -14,7 +14,8 @@ exports.__toESM = __toESM;
 
 ```js
 const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
-const preact = require_rolldown_runtime.__toESM(require("preact"));
+let preact = require("preact");
+preact = require_rolldown_runtime.__toESM(preact);
 
 ```
 ## lib.js
@@ -22,7 +23,8 @@ const preact = require_rolldown_runtime.__toESM(require("preact"));
 ```js
 const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
 require('./cube.js');
-const preact = require_rolldown_runtime.__toESM(require("preact"));
+let preact = require("preact");
+preact = require_rolldown_runtime.__toESM(preact);
 
 ```
 ## main.js
@@ -30,7 +32,8 @@ const preact = require_rolldown_runtime.__toESM(require("preact"));
 ```js
 const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
 require('./lib.js');
-const preact = require_rolldown_runtime.__toESM(require("preact"));
+let preact = require("preact");
+preact = require_rolldown_runtime.__toESM(preact);
 
 Object.defineProperty(exports, 'createContext', {
   enumerable: true,

--- a/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_assert = __toESM(require("node:assert"));
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
 
 //#region cjs.js
 var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {

--- a/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_assert = __toESM(require("node:assert"));
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
 
 //#region main.js
 node_assert.default.equal(require("url").pathToFileURL(__filename), require("url").pathToFileURL(__filename).href);
@@ -22,16 +23,16 @@ node_assert.default.equal(__filename, __filename);
 
 ```
 - ../main.js
-(2:0) "assert." --> (26:0) "node_assert.default."
-(2:7) "equal(" --> (26:20) "equal("
-(2:13) "require(" --> (26:26) "require("
-(2:21) "\"url\")." --> (26:34) "\"url\")."
-(2:28) "pathToFileURL(" --> (26:41) "pathToFileURL("
-(2:42) "__filename), import.meta.url)\n" --> (26:55) "__filename), require(\"url\").pathToFileURL(__filename).href);\n"
-(3:0) "assert." --> (27:0) "node_assert.default."
-(3:7) "equal(" --> (27:20) "equal("
-(3:13) "__dirname, import.meta.dirname)\n" --> (27:26) "__dirname, __dirname);\n"
-(4:0) "assert." --> (28:0) "node_assert.default."
-(4:7) "equal(" --> (28:20) "equal("
-(4:13) "__filename, import.meta.filename)\n" --> (28:26) "__filename, __filename);\n"
+(2:0) "assert." --> (27:0) "node_assert.default."
+(2:7) "equal(" --> (27:20) "equal("
+(2:13) "require(" --> (27:26) "require("
+(2:21) "\"url\")." --> (27:34) "\"url\")."
+(2:28) "pathToFileURL(" --> (27:41) "pathToFileURL("
+(2:42) "__filename), import.meta.url)\n" --> (27:55) "__filename), require(\"url\").pathToFileURL(__filename).href);\n"
+(3:0) "assert." --> (28:0) "node_assert.default."
+(3:7) "equal(" --> (28:20) "equal("
+(3:13) "__dirname, import.meta.dirname)\n" --> (28:26) "__dirname, __dirname);\n"
+(4:0) "assert." --> (29:0) "node_assert.default."
+(4:7) "equal(" --> (29:20) "equal("
+(4:13) "__filename, import.meta.filename)\n" --> (29:26) "__filename, __filename);\n"
 ```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_binding_in_common_chunks_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_binding_in_common_chunks_cjs/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_assert = __toESM(require("node:assert"));
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
 
 //#region shared.js
 let count = 0;

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_expr_in_common_chunks_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_expr_in_common_chunks_cjs/artifacts.snap
@@ -7,7 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_assert = __toESM(require("node:assert"));
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
 
 //#region shared.js
 let count = 0;

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 const require_shared = require('./shared.js');
-const node_assert = __toESM(require("node:assert"));
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
 
 //#region async-entry.js
 require_shared.reset();

--- a/crates/rolldown/tests/rolldown/topics/npm_packages/util_deprecate/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/npm_packages/util_deprecate/artifacts.snap
@@ -7,8 +7,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-const node_assert = __toESM(require("node:assert"));
-const node_util = __toESM(require("node:util"));
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+let node_util = require("node:util");
+node_util = __toESM(node_util);
 
 //#region ../../../../../../../node_modules/.pnpm/util-deprecate@1.0.2/node_modules/util-deprecate/node.js
 var require_node = /* @__PURE__ */ __commonJS({ "../../../../../../../node_modules/.pnpm/util-deprecate@1.0.2/node_modules/util-deprecate/node.js": ((exports, module) => {

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -767,7 +767,7 @@ expression: output
 
 # tests/esbuild/default/exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-BDqZoHuB.js
+- entry-!~{000}~.js => entry-qnruVGtF.js
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
@@ -855,7 +855,7 @@ expression: output
 
 # tests/esbuild/default/import_fs_node_common_js
 
-- entry-!~{000}~.js => entry-Dmuxt_j1.js
+- entry-!~{000}~.js => entry-BCRNF7T8.js
 
 # tests/esbuild/default/import_fs_node_es6
 
@@ -894,9 +894,9 @@ expression: output
 
 # tests/esbuild/default/import_namespace_this_value
 
-- a-!~{000}~.js => a-B1cvmcuX.js
-- b-!~{001}~.js => b-CkqRS8ig.js
-- c-!~{002}~.js => c-CJvcE3N8.js
+- a-!~{000}~.js => a-qMv73Kfc.js
+- b-!~{001}~.js => b-CcbPKzHl.js
+- c-!~{002}~.js => c-BFDrVi90.js
 - chunk-!~{003}~.js => chunk-6KP7ZeDK.js
 
 # tests/esbuild/default/import_re_export_es6_issue149
@@ -926,7 +926,7 @@ expression: output
 
 # tests/esbuild/default/inject
 
-- entry-!~{000}~.js => entry-miuSu9xu.js
+- entry-!~{000}~.js => entry-CMsYa2Ai.js
 
 # tests/esbuild/default/inject_assign
 
@@ -1408,11 +1408,11 @@ expression: output
 
 # tests/esbuild/default/quoted_property
 
-- entry-!~{000}~.js => entry-mwKP_aWt.js
+- entry-!~{000}~.js => entry-Wud7xSO6.js
 
 # tests/esbuild/default/quoted_property_mangle
 
-- entry-!~{000}~.js => entry-BsCw9WtW.js
+- entry-!~{000}~.js => entry-DsU6w4eo.js
 
 # tests/esbuild/default/re_export_common_js_as_es6
 
@@ -1420,7 +1420,7 @@ expression: output
 
 # tests/esbuild/default/re_export_default_external_common_js
 
-- entry-!~{000}~.js => entry-GdMMYtHQ.js
+- entry-!~{000}~.js => entry-CHTq3Iyt.js
 
 # tests/esbuild/default/re_export_default_external_es6
 
@@ -1436,7 +1436,7 @@ expression: output
 
 # tests/esbuild/default/re_export_default_no_bundle_common_js
 
-- entry-!~{000}~.js => entry-BbjQblto.js
+- entry-!~{000}~.js => entry-D2mgJMBQ.js
 
 # tests/esbuild/default/re_export_default_no_bundle_es6
 
@@ -1564,7 +1564,7 @@ expression: output
 
 # tests/esbuild/default/string_export_names_common_js
 
-- entry-!~{000}~.js => entry-Bp59z7QV.js
+- entry-!~{000}~.js => entry-DTYeg8yc.js
 
 # tests/esbuild/default/string_export_names_iife
 
@@ -1588,7 +1588,7 @@ expression: output
 
 # tests/esbuild/default/to_esm_wrapper_omission
 
-- entry-!~{000}~.js => entry-ChRk-zlm.js
+- entry-!~{000}~.js => entry-UF0FcqKy.js
 
 # tests/esbuild/default/top_level_await_allowed_import_with_splitting
 
@@ -1702,14 +1702,14 @@ expression: output
 # tests/esbuild/default/warn_common_js_exports_in_esm_bundle
 
 - cjs-in-esm-!~{000}~.js => cjs-in-esm-plvIZEyb.js
-- import-in-cjs-!~{001}~.js => import-in-cjs-BSJuYoUc.js
+- import-in-cjs-!~{001}~.js => import-in-cjs-Dfaom-sA.js
 - no-warnings-here-!~{002}~.js => no-warnings-here-BnKOXmVw.js
 
 # tests/esbuild/default/warn_common_js_exports_in_esm_convert
 
 - cjs-in-esm-!~{000}~.js => cjs-in-esm-plvIZEyb.js
 - cjs-in-esm2-!~{001}~.js => cjs-in-esm2-DFD0Tg0r.js
-- import-in-cjs-!~{002}~.js => import-in-cjs-DGQPE4IN.js
+- import-in-cjs-!~{002}~.js => import-in-cjs-B1s24v9X.js
 - no-warnings-here-!~{003}~.js => no-warnings-here-83rFFOtF.js
 
 # tests/esbuild/glob/glob_basic_no_bundle
@@ -1850,7 +1850,7 @@ expression: output
 
 # tests/esbuild/importstar/import_self_common_js
 
-- entry-!~{000}~.js => entry-KZe9a68l.js
+- entry-!~{000}~.js => entry-DVOKK1ys.js
 
 # tests/esbuild/importstar/import_star_and_common_js
 
@@ -1866,7 +1866,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_common_js_no_capture
 
-- entry-!~{000}~.js => entry-DuKfWEiV.js
+- entry-!~{000}~.js => entry-CGjXGPIu.js
 
 # tests/esbuild/importstar/import_star_common_js_unused
 
@@ -2002,7 +2002,7 @@ expression: output
 
 # tests/esbuild/importstar/re_export_star_as_common_js_no_bundle
 
-- entry-!~{000}~.js => entry-DtvfImrs.js
+- entry-!~{000}~.js => entry-DNMfojOP.js
 
 # tests/esbuild/importstar/re_export_star_as_es6_no_bundle
 
@@ -2010,7 +2010,7 @@ expression: output
 
 # tests/esbuild/importstar/re_export_star_as_external_common_js
 
-- entry-!~{000}~.js => entry-DtvfImrs.js
+- entry-!~{000}~.js => entry-DNMfojOP.js
 
 # tests/esbuild/importstar/re_export_star_as_external_es6
 
@@ -3709,8 +3709,8 @@ expression: output
 
 # tests/rolldown/code_splitting/format_cjs_with_module_cjs
 
-- main1-!~{000}~.js => main1-B_0DLyIh.js
-- main2-!~{001}~.js => main2-DtJzZDgV.js
+- main1-!~{000}~.js => main1-CygNWizv.js
+- main2-!~{001}~.js => main2-BUcRTHXC.js
 - share-!~{002}~.js => share-C5QPUyyJ.js
 
 # tests/rolldown/code_splitting/import_export_unicode
@@ -4155,7 +4155,7 @@ expression: output
 
 # tests/rolldown/function/external_live_bindings
 
-- main-!~{000}~.js => main-C4bNRZan.js
+- main-!~{000}~.js => main-LEyzep5p.js
 
 # tests/rolldown/function/file/css
 
@@ -4564,17 +4564,17 @@ expression: output
 
 # tests/rolldown/issues/2903
 
-- main-!~{000}~.js => main-BFUzfqGd.js
-- main2-!~{001}~.js => main2-BJTI1hj4.js
+- main-!~{000}~.js => main-C7JuFxfV.js
+- main2-!~{001}~.js => main2-fjX7Knug.js
 - chunk-!~{002}~.js => chunk-CfyQ4nhY.js
 
 # tests/rolldown/issues/2903_2
 
-- main-!~{000}~.js => main-Msh9siPa.js
+- main-!~{000}~.js => main-CdJqsvgU.js
 
 # tests/rolldown/issues/2903_3
 
-- main-!~{000}~.js => main-Msh9siPa.js
+- main-!~{000}~.js => main-CdJqsvgU.js
 
 # tests/rolldown/issues/2903_4
 
@@ -4666,7 +4666,7 @@ expression: output
 
 # tests/rolldown/issues/4406
 
-- main-!~{000}~.js => main-BWZDWune.js
+- main-!~{000}~.js => main-BwJAASiK.js
 
 # tests/rolldown/issues/4443
 
@@ -4686,7 +4686,7 @@ expression: output
 
 # tests/rolldown/issues/4585
 
-- main-!~{000}~.js => main-CGW9A3zc.js
+- main-!~{000}~.js => main-DA4Ptp8j.js
 
 # tests/rolldown/issues/4780
 
@@ -4703,10 +4703,10 @@ expression: output
 
 # tests/rolldown/issues/5044
 
-- main-!~{000}~.js => main-pxuuBVD-.js
+- main-!~{000}~.js => main-OKtGn7An.js
 - _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-mwmJao_F.js
-- cube-!~{003}~.js => cube-BCmsXstN.js
-- lib-!~{005}~.js => lib-BYAeIlLm.js
+- cube-!~{003}~.js => cube-BXW_EK5r.js
+- lib-!~{005}~.js => lib-BHNBR_-C.js
 
 # tests/rolldown/issues/5139
 
@@ -4980,7 +4980,7 @@ expression: output
 
 # tests/rolldown/misc/use_strict/no_use_strict_with_non_strict_cjs_in_cjs_format
 
-- main-!~{000}~.js => main-DTso9GhH.js
+- main-!~{000}~.js => main-sg0L_mHr.js
 
 # tests/rolldown/misc/wrapped_esm
 
@@ -5548,8 +5548,8 @@ expression: output
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 
-- main-!~{000}~.js => main-DYMHAJIA.js
-- main-DYMHAJIA.js.map
+- main-!~{000}~.js => main-DuxQNW7D.js
+- main-DuxQNW7D.js.map
 
 # tests/rolldown/topics/keep_names/declaration
 
@@ -5573,7 +5573,7 @@ expression: output
 
 # tests/rolldown/topics/keep_names/issue_5525
 
-- entry-!~{000}~.js => entry-D8KRfvnx.js
+- entry-!~{000}~.js => entry-vroonOwj.js
 - entry2-!~{001}~.js => entry2-CA0mV8Xo.js
 - foo-!~{002}~.js => foo-DKOGr9By.js
 
@@ -5592,8 +5592,8 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/default_export_binding_in_common_chunks_cjs
 
-- main-!~{000}~.js => main-LUYnBTMi.js
-- async-entry-!~{001}~.js => async-entry-DKKrYZuD.js
+- main-!~{000}~.js => main-CeIEHOld.js
+- async-entry-!~{001}~.js => async-entry-CYLC0Ajr.js
 
 # tests/rolldown/topics/live_bindings/default_export_decl
 
@@ -5615,8 +5615,8 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/default_export_expr_in_common_chunks_cjs
 
-- main-!~{000}~.js => main-9uy801aV.js
-- async-entry-!~{001}~.js => async-entry-D6foZElf.js
+- main-!~{000}~.js => main-ab8umXFV.js
+- async-entry-!~{001}~.js => async-entry-BG8MStYS.js
 
 # tests/rolldown/topics/live_bindings/named_exports
 
@@ -5634,8 +5634,8 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs
 
-- main-!~{000}~.js => main-IMNdm2ip.js
-- async-entry-!~{003}~.js => async-entry-DXj3pnzb.js
+- main-!~{000}~.js => main-CIDwKN8k.js
+- async-entry-!~{003}~.js => async-entry-DVNSNS7v.js
 - shared-!~{001}~.js => shared-DlT5txJr.js
 
 # tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs
@@ -5672,7 +5672,7 @@ expression: output
 
 # tests/rolldown/topics/npm_packages/util_deprecate
 
-- main-!~{000}~.js => main-CsGMnTIT.js
+- main-!~{000}~.js => main-BBYHgJpL.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export
 


### PR DESCRIPTION
Closed #5934

es-module-lexer only recognize specific pattern to collect exports binding,  see https://github.com/edison1105/rolldownToESM/blob/ce20866468677b1ac17946b6f8be9c00bf99827f/bug-repro.cjs?plain=1#L27-L46 as an example, 
when the module is imported via `import()` 
`cjs-module-lexer` can't recognize pattern like: 
```js
const __mock_library = __toESM(require("./mock-library.cjs"));
```
And assume it is dynamic, so that `foo` is not reexported, but it could recognize pattern like: 
```js
const __mock_library = require("./mock-library.cjs");

exports.bar = function bar() {}

Object.keys(__mock_library).forEach(function (k) {
  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
    enumerable: true,
    get: function () { return __mock_library[k]; }
  });

  // still not working, due to __toESM processed properties as a getter function
  // exports[k] = __mock_library[k]
});


```

After doing some investigation, I found that it also could recognize pattern like: 
```js
let __mock_library = require("./mock-library.cjs");
__mock_library = __toESM(__mock_library);
// ... snip
```

So I changed the importing `external` module code to make sure we have better compatibility with `cjs-module-lexer`
