### PR TITLE
test: cjs module lexer for named import external with cjs format

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "format": "cjs",
+    "external": ["external"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport/_test.mjs
@@ -1,0 +1,10 @@
+const require = (await import('node:module')).createRequire(import.meta.url);
+const fs = require('node:fs');
+const assert = require('node:assert');
+const path = require('node:path');
+const { parse } = require('cjs-module-lexer');
+
+const parsed = parse(fs.readFileSync(path.resolve(import.meta.dirname, 'dist/main.js'), 'utf8'));
+assert.deepStrictEqual(parsed, {
+  exports: ['readFileSync'], reexports: ['external']
+})

--- a/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport/artifacts.snap
@@ -1,0 +1,21 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+let external = require("external");
+external = __toESM(external);
+
+exports.readFileSync = external.readFileSync;
+Object.keys(external).forEach(function (k) {
+  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
+    enumerable: true,
+    get: function () { return external[k]; }
+  });
+});
+
+```

--- a/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport/main.js
+++ b/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport/main.js
@@ -1,0 +1,7 @@
+import { readFileSync } from 'external'
+
+export * from 'external'
+
+export {
+  readFileSync
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5390,6 +5390,10 @@ expression: output
 
 - main-!~{000}~.js => main-B89Pmjkg.js
 
+# tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport
+
+- main-!~{000}~.js => main-BTFDcswM.js
+
 # tests/rolldown/topics/css/align_vite
 
 - main-!~{000}~.js => main-X654ryY_.js


### PR DESCRIPTION
A follow-up of https://github.com/rolldown/rolldown/pull/5966j, if you use convert 
```js
let external = require("external");
external = __toESM(external);
```

to 
```js
let external = __toESM(require('external'));
```
The test would fail.