### PR TITLE
perf(rolldown): use allocator pool when minifying chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "oxc_index",
  "oxc_traverse",
  "petgraph",
+ "rayon",
  "rolldown_common",
  "rolldown_debug",
  "rolldown_ecmascript",

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -37,6 +37,7 @@ oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }
 oxc_traverse = { workspace = true }
 petgraph = { workspace = true }
+rayon = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_debug = { workspace = true }
 rolldown_ecmascript = { workspace = true }

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -99,7 +99,9 @@ impl EcmaCompiler {
       .build(ast.program())
   }
 
+  #[expect(clippy::too_many_arguments)]
   pub fn dce_or_minify(
+    allocator: &Allocator,
     source_text: &str,
     source_type: SourceType,
     enable_sourcemap: bool,
@@ -108,13 +110,12 @@ impl EcmaCompiler {
     minify_options: MinifierOptions,
     codegen_options: CodegenOptions,
   ) -> (String, Option<SourceMap>) {
-    let allocator = Allocator::default();
-    let mut program = Parser::new(&allocator, source_text, source_type).parse().program;
+    let mut program = Parser::new(allocator, source_text, source_type).parse().program;
     let minifier = Minifier::new(minify_options);
     let ret = if compress {
-      minifier.minify(&allocator, &mut program)
+      minifier.minify(allocator, &mut program)
     } else {
-      minifier.dce(&allocator, &mut program)
+      minifier.dce(allocator, &mut program)
     };
     let ret = Codegen::new()
       .with_options(CodegenOptions {


### PR DESCRIPTION
`AllocatorPool` should reduce peak memory a bit. We are using it in the linter and see no issues so far.