### PR TITLE
refactor(dev): use dynamic dispatch watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,7 +2800,6 @@ dependencies = [
  "rolldown_sourcemap",
  "rolldown_tracing",
  "rolldown_utils",
- "rolldown_watcher",
  "rustc-hash",
  "tracing",
  "url",

--- a/crates/rolldown/examples/dev.rs
+++ b/crates/rolldown/examples/dev.rs
@@ -16,7 +16,7 @@ async fn main() {
     experimental: Some(ExperimentalOptions { incremental_build: Some(true), ..Default::default() }),
     ..Default::default()
   });
-  let dev_engine = DevEngine::<rolldown_watcher::NotifyWatcher>::new(
+  let dev_engine = DevEngine::new(
     bundler_builder,
     DevOptions {
       eager_rebuild: Some(false),

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -59,7 +59,6 @@ rolldown_plugin_web_worker_post = { workspace = true }
 rolldown_sourcemap = { workspace = true }
 rolldown_tracing = { workspace = true }
 rolldown_utils = { workspace = true }
-rolldown_watcher = { workspace = true }
 rustc-hash = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -1,18 +1,16 @@
 use napi_derive::napi;
 use std::sync::Arc;
 
-use napi::{Env, threadsafe_function::ThreadsafeFunctionCallMode};
-use rolldown_watcher::NotifyWatcher;
-
 use crate::binding_bundler_impl::{BindingBundlerImpl, BindingBundlerOptions};
 use crate::binding_dev_options::BindingDevOptions;
 use crate::types::binding_hmr_output::BindingHmrUpdate;
 use crate::types::js_callback::JsCallback;
 use napi::bindgen_prelude::FnArgs;
+use napi::{Env, threadsafe_function::ThreadsafeFunctionCallMode};
 
 #[napi]
 pub struct BindingDevEngine {
-  inner: rolldown::DevEngine<NotifyWatcher>,
+  inner: rolldown::DevEngine,
   _session_id: Arc<str>,
   _session: rolldown_debug::Session,
   #[allow(dead_code)]

--- a/crates/rolldown_watcher/src/lib.rs
+++ b/crates/rolldown_watcher/src/lib.rs
@@ -5,7 +5,10 @@ mod event;
 mod event_handler;
 mod notify_watcher;
 mod watcher;
+mod watcher_ext;
 
 pub use crate::{event::EventResult as FileChangeResult, event_handler::EventHandler};
 pub use notify::RecursiveMode;
-pub use {notify_watcher::NotifyWatcher, watcher::Watcher};
+pub use {notify_watcher::NotifyWatcher, watcher::Watcher, watcher_ext::WatcherExt};
+
+pub type DynWatcher = Box<dyn Watcher + Send + 'static>;

--- a/crates/rolldown_watcher/src/watcher_ext.rs
+++ b/crates/rolldown_watcher/src/watcher_ext.rs
@@ -1,0 +1,14 @@
+use crate::{DynWatcher, Watcher};
+
+pub trait WatcherExt {
+  fn into_dyn_watcher(self) -> DynWatcher;
+}
+
+impl<T> WatcherExt for T
+where
+  T: Watcher + Send + 'static,
+{
+  fn into_dyn_watcher(self) -> DynWatcher {
+    Box::new(self)
+  }
+}


### PR DESCRIPTION
To make CI stable, https://github.com/rolldown/rolldown/pull/5979  switched to `PollWatcher`.

`PollWatcher` isn't an ideal watcher for every platform. We need the dynamic dispatch watcher to allow to change watcher based on variables dynamically.