### PR TITLE
refactor(crates/rolldown): migrate from #[allow] to #[expect] attributes

### DIFF
--- a/crates/rolldown/src/asset/asset_generator.rs
+++ b/crates/rolldown/src/asset/asset_generator.rs
@@ -8,7 +8,7 @@ use rolldown_std_utils::OptionExt;
 pub struct AssetGenerator;
 
 impl Generator for AssetGenerator {
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   async fn instantiate_chunk(ctx: &mut GenerateContext<'_>) -> Result<BuildResult<GenerateOutput>> {
     let asset_modules = ctx
       .chunk

--- a/crates/rolldown/src/ast_scanner/cjs_ast_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/cjs_ast_analyzer.rs
@@ -20,7 +20,7 @@ pub enum CommonJsAstType {
 }
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   pub fn cjs_ast_analyzer(&mut self, ty: &CjsGlobalAssignmentType) -> Option<CommonJsAstType> {
     match ty {
       CjsGlobalAssignmentType::ModuleExportsAssignment => {

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -396,7 +396,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   /// visit `Class` of declaration
-  #[allow(clippy::unused_self)]
+  #[expect(clippy::unused_self)]
   pub fn get_class_id(&self, class: &ast::Class<'ast>) -> Option<SymbolId> {
     let id = class.id.as_ref()?;
     let symbol_id = *id.symbol_id.get().unpack_ref();

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -151,7 +151,7 @@ pub struct AstScanner<'me, 'ast> {
 }
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
-  #[allow(clippy::too_many_arguments)]
+  #[expect(clippy::too_many_arguments)]
   pub fn new(
     idx: ModuleIdx,
     scoping: Scoping,

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -460,7 +460,7 @@ impl<'a> SideEffectDetector<'a> {
     }
   }
 
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   fn detect_side_effect_of_expr(&self, expr: &Expression) -> SideEffectDetail {
     match expr {
       Expression::BooleanLiteral(_)
@@ -872,7 +872,7 @@ impl<'a> SideEffectDetector<'a> {
     detail
   }
 
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   pub fn detect_side_effect_of_stmt(&self, stmt: &ast::Statement) -> SideEffectDetail {
     use oxc::ast::ast::Statement;
     match stmt {

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/utils.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/utils.rs
@@ -38,7 +38,7 @@ fn merged_known_primitive_types(
   PrimitiveType::Mixed
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub fn known_primitive_type(scope: &AstScopes, expr: &Expression) -> PrimitiveType {
   match expr {
     Expression::NullLiteral(_) => PrimitiveType::Null,

--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -215,7 +215,7 @@ impl Bundler {
     Ok(output)
   }
 
-  #[allow(clippy::missing_transmute_annotations, clippy::needless_pass_by_ref_mut)]
+  #[expect(clippy::missing_transmute_annotations, clippy::needless_pass_by_ref_mut)]
   async fn bundle_up(
     &mut self,
     scan_stage_output: NormalizedScanStageOutput,
@@ -427,7 +427,7 @@ impl Drop for CacheGuard<'_> {
 }
 
 fn _test_bundler() {
-  #[allow(clippy::needless_pass_by_value)]
+  #[expect(clippy::needless_pass_by_value)]
   fn assert_send(_foo: impl Send) {}
   let mut bundler = Bundler::new(BundlerOptions::default());
   let write_fut = bundler.write();

--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -34,7 +34,7 @@ impl ChunkGraph {
     }
   }
 
-  #[allow(unused)]
+  #[expect(unused)]
   pub fn sorted_chunks(&self) -> impl Iterator<Item = &Chunk> {
     self.sorted_chunk_idx_vec.iter().map(move |&id| &self.chunk_table.chunks[id])
   }

--- a/crates/rolldown/src/css/css_generator.rs
+++ b/crates/rolldown/src/css/css_generator.rs
@@ -9,7 +9,7 @@ use string_wizard::SourceMapOptions;
 pub struct CssGenerator;
 
 impl Generator for CssGenerator {
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   async fn instantiate_chunk(ctx: &mut GenerateContext<'_>) -> Result<BuildResult<GenerateOutput>> {
     let mut ordered_css_modules = ctx
       .chunk

--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -43,7 +43,7 @@ impl RenderedModuleSource {
 pub struct EcmaGenerator;
 
 impl Generator for EcmaGenerator {
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   async fn instantiate_chunk(ctx: &mut GenerateContext<'_>) -> Result<BuildResult<GenerateOutput>> {
     let mut rendered_modules = FxHashMap::default();
     let module_id_to_codegen_ret = std::mem::take(&mut ctx.module_id_to_codegen_ret);

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -21,7 +21,7 @@ pub struct CreateEcmaViewReturn {
   pub raw_import_records: IndexVec<ImportRecordIdx, RawImportRecord>,
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub async fn create_ecma_view(
   ctx: &mut CreateModuleContext<'_>,
   args: CreateModuleViewArgs,

--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -14,7 +14,7 @@ use rolldown_utils::concat_string;
 
 use super::utils::{render_chunk_directives, render_modules_with_peek_runtime_module_at_first};
 
-#[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
+#[expect(clippy::too_many_lines, clippy::needless_pass_by_value)]
 pub fn render_cjs<'code>(
   ctx: &GenerateContext<'_>,
   addon_render_context: AddonRenderContext<'code>,

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -16,7 +16,7 @@ use crate::{
 
 use super::utils::render_chunk_directives;
 
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 pub fn render_esm<'code>(
   ctx: &GenerateContext<'_>,
   addon_render_context: AddonRenderContext<'code>,
@@ -91,7 +91,7 @@ pub fn render_esm<'code>(
   source_joiner
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn render_chunk_content<'code>(
   ctx: &GenerateContext<'_>,
   module_sources: &'code [RenderedModuleSource],

--- a/crates/rolldown/src/ecmascript/format/umd.rs
+++ b/crates/rolldown/src/ecmascript/format/umd.rs
@@ -22,7 +22,7 @@ use super::utils::{
   render_factory_parameters, render_modules_with_peek_runtime_module_at_first,
 };
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub async fn render_umd<'code>(
   ctx: &GenerateContext<'_>,
   addon_render_context: AddonRenderContext<'code>,

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -81,7 +81,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
     self.state = pre;
   }
 
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   fn visit_program(&mut self, program: &mut ast::Program<'ast>) {
     // Drop the hashbang since we already store them in ast_scan phase and
     // we don't want oxc to generate hashbang statement and directives in module level since we already handle

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -717,7 +717,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     ))
   }
 
-  #[allow(clippy::too_many_lines, clippy::collapsible_else_if)]
+  #[expect(clippy::too_many_lines, clippy::collapsible_else_if)]
   fn try_rewrite_global_require_call(
     &self,
     call_expr: &mut ast::CallExpression<'ast>,
@@ -854,7 +854,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     None
   }
 
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   fn try_rewrite_inline_dynamic_import_expr(
     &self,
     import_expr: &ImportExpression<'ast>,
@@ -999,7 +999,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     None
   }
 
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   fn remove_unused_top_level_stmt(&mut self, program: &mut ast::Program<'ast>) -> usize {
     let mut last_import_stmt_idx = None;
 

--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -13,7 +13,7 @@ use crate::ecmascript::ecma_module_view_factory::normalize_side_effects;
 
 use super::task_context::TaskContext;
 
-#[allow(clippy::rc_buffer)]
+#[expect(clippy::rc_buffer)]
 pub struct ExternalModuleTask {
   ctx: Arc<TaskContext>,
   module_idx: ModuleIdx,
@@ -22,7 +22,7 @@ pub struct ExternalModuleTask {
   // The module is asserted to be this specific module type.
 }
 
-#[allow(clippy::rc_buffer)]
+#[expect(clippy::rc_buffer)]
 impl ExternalModuleTask {
   pub fn new(
     ctx: Arc<TaskContext>,

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -200,7 +200,7 @@ impl<'a> ModuleLoader<'a> {
     })
   }
 
-  #[allow(clippy::rc_buffer)]
+  #[expect(clippy::rc_buffer)]
   fn try_spawn_new_task(
     &mut self,
     resolved_id: ResolvedId,
@@ -245,7 +245,7 @@ impl<'a> ModuleLoader<'a> {
     idx
   }
 
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   #[tracing::instrument(level = "debug", skip_all)]
   pub async fn fetch_modules(
     &mut self,

--- a/crates/rolldown/src/module_loader/resolve_utils.rs
+++ b/crates/rolldown/src/module_loader/resolve_utils.rs
@@ -47,7 +47,7 @@ pub async fn resolve_id(
   .await
 }
 
-#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+#[expect(clippy::too_many_lines, clippy::too_many_arguments)]
 pub async fn resolve_dependencies(
   self_resolved_id: &ResolvedId,
   options: &SharedOptions,

--- a/crates/rolldown/src/stages/generate_stage/advanced_chunks.rs
+++ b/crates/rolldown/src/stages/generate_stage/advanced_chunks.rs
@@ -31,14 +31,14 @@ oxc_index::define_index_type! {
 }
 
 impl ModuleGroup {
-  #[allow(clippy::cast_precision_loss)] // We consider `usize` to `f64` is safe here
+  #[expect(clippy::cast_precision_loss)] // We consider `usize` to `f64` is safe here
   pub fn add_module(&mut self, module_idx: ModuleIdx, module_table: &ModuleTable) {
     if self.modules.insert(module_idx) {
       self.sizes += module_table[module_idx].size() as f64;
     }
   }
 
-  #[allow(clippy::cast_precision_loss)] // We consider `usize` to `f64` is safe here
+  #[expect(clippy::cast_precision_loss)] // We consider `usize` to `f64` is safe here
   pub fn remove_module(&mut self, module_idx: ModuleIdx, module_table: &ModuleTable) {
     if self.modules.remove(&module_idx) {
       self.sizes -= module_table[module_idx].size() as f64;
@@ -48,7 +48,7 @@ impl ModuleGroup {
 }
 
 impl GenerateStage<'_> {
-  #[allow(
+  #[expect(
     clippy::too_many_lines,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -40,7 +40,7 @@ enum CombineChunkRet {
 pub type IndexSplittingInfo = IndexVec<ModuleIdx, SplittingInfo>;
 
 impl GenerateStage<'_> {
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   #[tracing::instrument(level = "debug", skip_all)]
   pub async fn generate_chunks(&mut self) -> BuildResult<ChunkGraph> {
     let entries_len: u32 =
@@ -246,7 +246,7 @@ impl GenerateStage<'_> {
     Ok(chunk_graph)
   }
 
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   pub fn ensure_lazy_module_initialization_order(&self, chunk_graph: &mut ChunkGraph) {
     if self.options.experimental.strict_execution_order.unwrap_or_default() {
       // If `strict_execution_order` is enabled, the lazy module initialization order is already

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -31,7 +31,7 @@ type IndexImportsFromOtherChunks =
   IndexVec<ChunkIdx, FxHashMap<ChunkIdx, Vec<CrossChunkImportItem>>>;
 
 impl GenerateStage<'_> {
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   #[tracing::instrument(level = "debug", skip_all)]
   pub fn compute_cross_chunk_links(&mut self, chunk_graph: &mut ChunkGraph) {
     let mut index_chunk_depended_symbols: IndexChunkDependedSymbols =
@@ -144,7 +144,7 @@ impl GenerateStage<'_> {
 
   /// - Assign each symbol to the chunk it belongs to
   /// - Collect all referenced symbols and consider them potential imports
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   fn collect_depended_symbols(
     &mut self,
     chunk_graph: &ChunkGraph,
@@ -322,7 +322,7 @@ impl GenerateStage<'_> {
 
   /// - Filter out depended symbols to come from other chunks
   /// - Mark exports of importee chunks
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   fn compute_chunk_imports(
     &self,
     chunk_graph: &ChunkGraph,
@@ -353,7 +353,7 @@ impl GenerateStage<'_> {
             is_dynamic_imported
               || !matches!(normalized_entry_signatures, PreserveEntrySignatures::False)
           };
-          #[allow(clippy::nonminimal_bool)]
+          #[expect(clippy::nonminimal_bool)]
           if needs_export_entry_signatures {
             // If the entry point is external, we don't need to compute exports.
             let meta = &self.link_output.metas[module_idx];

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -63,7 +63,7 @@ impl<'a> GenerateStage<'a> {
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   pub async fn generate(&mut self) -> BuildResult<BundleOutput> {
     self.plugin_driver.render_start(self.options).await?;
 
@@ -237,7 +237,7 @@ impl<'a> GenerateStage<'a> {
   /// Notices:
   /// - Should generate filenames that are stable cross builds and os.
   #[tracing::instrument(level = "debug", skip_all)]
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   async fn generate_chunk_name_and_preliminary_filenames(
     &self,
     chunk_graph: &mut ChunkGraph,

--- a/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
@@ -48,7 +48,7 @@ impl GenerateStage<'_> {
   /// - A commonjs module, a commonjs module can't not be safely eager eval.
   /// - A es module required by other module
   /// - All reachable modules of a boundary module in current chunk.
-  #[allow(unused)]
+  #[expect(unused)]
   fn inline_entry_chunk_wrapping(&mut self, chunk: &Chunk) {
     // All modules in entry chunk must be reachable from a entry module.
     let mut boundary_module = chunk
@@ -101,7 +101,6 @@ impl GenerateStage<'_> {
     }
   }
 
-  #[allow(unused)]
   fn expand_boundary(
     &self,
     boundary_modules: &mut FxHashSet<ModuleIdx>,

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -33,7 +33,7 @@ use crate::{
 use super::GenerateStage;
 
 impl GenerateStage<'_> {
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   pub async fn render_chunk_to_assets(
     &mut self,
     chunk_graph: &ChunkGraph,
@@ -260,7 +260,7 @@ impl GenerateStage<'_> {
           .map(|&module_idx| match self.link_output.module_table[module_idx].as_normal() {
             Some(module) => {
               let ast = self.link_output.ast_table[module.idx].as_ref().expect("should have ast");
-              #[allow(clippy::bool_to_int_with_if)]
+              #[expect(clippy::bool_to_int_with_if)]
               let initial_indent = if matches!(
                 self.link_output.metas[module_idx].concatenated_wrapped_module_kind,
                 ConcatenateWrappedModuleKind::None

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -587,7 +587,7 @@ struct BindImportsAndExportsContext<'a> {
 }
 
 impl BindImportsAndExportsContext<'_> {
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   fn match_imports_with_exports(&mut self, module_id: ModuleIdx) {
     let Module::Normal(module) = &self.index_modules[module_id] else {
       return;
@@ -793,7 +793,7 @@ impl BindImportsAndExportsContext<'_> {
     }
   }
 
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   fn match_import_with_export(
     &mut self,
     index_modules: &IndexModules,

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -102,7 +102,7 @@ fn update_module_default_export_info(
   module.stmt_infos.declare_symbol_for_stmt(idx, TaggedSymbolRef::Normal(default_symbol_ref));
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 /// return true if the json is a ObjectExpression
 fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -> bool {
   let module = &mut link_staged.module_table[module_idx];
@@ -206,7 +206,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   let original_symbol_ref_db = std::mem::take(link_staged.symbols.local_db_mut(module_idx));
   let (_, facade_scope) = original_symbol_ref_db.ast_scopes.into_inner();
   // recreate semantic data
-  #[allow(clippy::cast_possible_truncation)]
+  #[expect(clippy::cast_possible_truncation)]
   let scoping = ecma_ast.make_symbol_table_and_scope_tree_with_semantic_builder(
     SemanticBuilder::new().with_scope_tree_child_ids(true).with_stats(Stats {
       nodes: declaration_binding_names.len().next_power_of_two() as u32,

--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -28,7 +28,7 @@ struct DeferUpdateInfo {
   record_meta_pairs: Vec<(ImportRecordIdx, ImportRecordMeta)>,
 }
 impl LinkStage<'_> {
-  #[allow(clippy::collapsible_if, clippy::too_many_lines)]
+  #[expect(clippy::collapsible_if, clippy::too_many_lines)]
   #[tracing::instrument(level = "debug", skip_all)]
   pub(super) fn reference_needed_symbols(&mut self) {
     // Since each module only access its own symbol ref db, we use zip rather than a Mutex to

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -54,7 +54,7 @@ struct Context<'a> {
 }
 
 impl LinkStage<'_> {
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   #[tracing::instrument(level = "debug", skip_all)]
   pub fn include_statements(&mut self) {
     let mut is_included_vec: IndexVec<ModuleIdx, IndexVec<StmtInfoIdx, bool>> = self
@@ -194,7 +194,7 @@ impl LinkStage<'_> {
           }
           let any_included =
             stmt_info_idxs.iter().any(|stmt_info_idx| is_included_vec[module.idx][*stmt_info_idx]);
-          #[allow(clippy::cast_possible_truncation)]
+          #[expect(clippy::cast_possible_truncation)]
           // It is alright, since the `RuntimeHelper` is a bitmask and the index is guaranteed to be less than 32.
           normalized_runtime_helper
             .set(RuntimeHelper::from_bits(1 << index as u32).unwrap(), any_included);

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -8,7 +8,7 @@ use rolldown_common::{
 use rolldown_utils::ecmascript::legitimize_identifier_name;
 use rustc_hash::FxHashMap;
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn deconflict_chunk_symbols(
   chunk: &mut Chunk,

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -31,7 +31,7 @@ use crate::{
   utils::process_code_and_sourcemap::process_code_and_sourcemap,
 };
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[tracing::instrument(level = "debug", skip_all)]
 pub async fn finalize_assets(
   chunk_graph: &ChunkGraph,

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -82,7 +82,7 @@ pub fn render_wrapped_entry_chunk(
   }
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub fn render_chunk_exports(
   ctx: &GenerateContext<'_>,
   export_mode: Option<&OutputExports>,

--- a/crates/rolldown/src/utils/normalize_transform_options.rs
+++ b/crates/rolldown/src/utils/normalize_transform_options.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use oxc::transformer::ESTarget;
 use rolldown_common::{BundlerTransformOptions, Either, JsxOptions, JsxPreset, TransformOptions};
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub fn normalize_transform_options_with_tsconfig(
   mut transform_options: BundlerTransformOptions,
   tsconfig: Option<Arc<rolldown_resolver::TsConfig>>,

--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -94,7 +94,7 @@ fn verify_raw_options(raw_options: &crate::BundlerOptions) -> Vec<BuildDiagnosti
   warnings
 }
 
-#[allow(clippy::too_many_lines)] // This function is long, but it's mostly just mapping values
+#[expect(clippy::too_many_lines)] // This function is long, but it's mostly just mapping values
 pub fn prepare_build_context(mut raw_options: crate::BundlerOptions) -> PrepareBuildContext {
   let warnings = verify_raw_options(&raw_options);
 

--- a/crates/rolldown/src/utils/process_code_and_sourcemap.rs
+++ b/crates/rolldown/src/utils/process_code_and_sourcemap.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use super::uuid::uuid_v4_string_from_u128;
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub async fn process_code_and_sourcemap(
   options: &NormalizedBundlerOptions,
   code: &mut String,
@@ -36,7 +36,7 @@ pub async fn process_code_and_sourcemap(
     let mut x_google_ignore_list = vec![];
     for (index, source) in map.get_sources().enumerate() {
       if source_map_ignore_list.call(source, map_path.to_string_lossy().as_ref()).await? {
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         x_google_ignore_list.push(index as u32);
       }
     }

--- a/crates/rolldown/src/watch/emitter.rs
+++ b/crates/rolldown/src/watch/emitter.rs
@@ -17,7 +17,7 @@ impl WatcherEmitter {
     Self { tx: Arc::new(tx), rx: Arc::new(Mutex::new(rx)) }
   }
 
-  #[allow(clippy::needless_pass_by_value)]
+  #[expect(clippy::needless_pass_by_value)]
   pub fn emit(&self, event: WatcherEvent) -> Result<()> {
     self.tx.send(event)?;
     Ok(())

--- a/crates/rolldown/src/watch/watcher.rs
+++ b/crates/rolldown/src/watch/watcher.rs
@@ -48,7 +48,7 @@ pub struct WatcherImpl {
 }
 
 impl WatcherImpl {
-  #[allow(clippy::needless_pass_by_value)]
+  #[expect(clippy::needless_pass_by_value)]
   pub fn new(
     bundlers: Vec<Arc<Mutex<Bundler>>>,
     notify_option: Option<NotifyOption>,

--- a/crates/rolldown/src/watch/watcher_task.rs
+++ b/crates/rolldown/src/watch/watcher_task.rs
@@ -90,7 +90,7 @@ impl WatcherTask {
             .join(bundler.options.file.as_ref().unwrap_or(&bundler.options.out_dir))
             .to_string_lossy()
             .to_string(),
-          #[allow(clippy::cast_possible_truncation)]
+          #[expect(clippy::cast_possible_truncation)]
           duration: start_time.elapsed().as_millis() as u32,
           result: Arc::clone(&self.bundler),
         })))?;

--- a/crates/rolldown/tests/integration_esbuild.rs
+++ b/crates/rolldown/tests/integration_esbuild.rs
@@ -1,11 +1,11 @@
-#![allow(clippy::ignore_without_reason)]
+#![expect(clippy::ignore_without_reason)]
 
 use std::path::PathBuf;
 
 use rolldown_testing::fixture::Fixture;
 use testing_macros::fixture;
 
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 #[fixture("./tests/esbuild/**/_config.json")]
 fn test(path: PathBuf) {
   Fixture::new(path.parent().unwrap()).run_integration_test();

--- a/crates/rolldown/tests/integration_rolldown.rs
+++ b/crates/rolldown/tests/integration_rolldown.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::ignore_without_reason)]
+#![expect(clippy::ignore_without_reason)]
 use std::fmt::Write as _;
 use std::path::{Component, PathBuf};
 
@@ -13,7 +13,7 @@ use testing_macros::fixture;
 
 mod rolldown;
 
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 #[fixture("./tests/rolldown/**/_config.json")]
 fn fixture_with_config(config_path: PathBuf) {
   Fixture::new(config_path.parent().unwrap()).run_integration_test();

--- a/crates/rolldown/tests/integration_rollup.rs
+++ b/crates/rolldown/tests/integration_rollup.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use rolldown_testing::fixture::Fixture;
 use testing_macros::fixture;
 
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 #[fixture("./tests/rollup/**/_config.json")]
 fn test(path: PathBuf) {
   Fixture::new(path.parent().unwrap()).run_integration_test();


### PR DESCRIPTION
## Summary
Migrate from `#[allow]` to `#[expect]` attributes in the rolldown crate.

## Changes
- Updated 41 files in crates/rolldown
- Replaced all `#[allow(...)]` attributes with `#[expect(...)]`

🤖 Generated with [Claude Code](https://claude.ai/code)