### PR TITLE
refactor(crates/rolldown_binding): migrate from #[allow] to #[expect] attributes

### DIFF
--- a/crates/rolldown_binding/src/binding_bundler_impl.rs
+++ b/crates/rolldown_binding/src/binding_bundler_impl.rs
@@ -109,7 +109,7 @@ impl BindingBundlerImpl {
       move |env, outputs| {
         let chunk_size = outputs.chunk_len();
         // 16mb per chunk, it's just a hint, so it doesn't need to be accurate
-        #[allow(clippy::cast_possible_wrap)]
+        #[expect(clippy::cast_possible_wrap)]
         let memory_consumption = chunk_size as i64 * 1024 * 1024 * 16;
         memory_adjustment.fetch_add(memory_consumption, Ordering::Relaxed);
         env.adjust_external_memory(memory_consumption)?;
@@ -185,7 +185,7 @@ impl BindingBundlerImpl {
 }
 
 impl BindingBundlerImpl {
-  #[allow(clippy::significant_drop_tightening)]
+  #[expect(clippy::significant_drop_tightening)]
   pub async fn scan_impl(&self) -> napi::Result<BindingOutputs> {
     let mut bundler_core = self.inner.lock().await;
     let output = Self::handle_result(bundler_core.scan(vec![]).await, bundler_core.options());
@@ -204,7 +204,7 @@ impl BindingBundlerImpl {
     Ok(vec![].into())
   }
 
-  #[allow(clippy::significant_drop_tightening)]
+  #[expect(clippy::significant_drop_tightening)]
   pub async fn write_impl(bundler: Arc<Mutex<NativeBundler>>) -> napi::Result<BindingOutputs> {
     let mut bundler_core = bundler.lock().await;
 
@@ -220,7 +220,7 @@ impl BindingBundlerImpl {
     Ok(outputs.assets.into())
   }
 
-  #[allow(clippy::significant_drop_tightening)]
+  #[expect(clippy::significant_drop_tightening)]
   pub async fn generate_impl(&self) -> napi::Result<BindingOutputs> {
     let mut bundler_core = self.inner.lock().await;
 
@@ -236,7 +236,7 @@ impl BindingBundlerImpl {
     Ok(bundle_output.assets.into())
   }
 
-  #[allow(clippy::significant_drop_tightening)]
+  #[expect(clippy::significant_drop_tightening)]
   pub async fn close_impl(&self) -> napi::Result<()> {
     let mut bundler_core = self.inner.lock().await;
 

--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -1,7 +1,7 @@
 // Allow type complexity rule, because NAPI-RS requires the direct types to generate the TypeScript definitions.
-#![allow(clippy::type_complexity)]
+#![expect(clippy::type_complexity)]
 // Due to the bound of NAPI-RS, we need to use `String` though we only need `&str`.
-#![allow(clippy::needless_pass_by_value)]
+#![expect(clippy::needless_pass_by_value)]
 // Most of transmute are just change the lifetime `'a` to `'static`., the annotation, e.g.
 //
 // BindingTransformPluginContext::new(unsafe {
@@ -11,7 +11,7 @@
 //   >(ctx)
 // }),
 // Looks redundant
-#![allow(clippy::missing_transmute_annotations)]
+#![expect(clippy::missing_transmute_annotations)]
 
 #[cfg(all(target_family = "wasm", tokio_unstable))]
 use std::sync::{

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -41,7 +41,7 @@ use super::{
   types::binding_builtin_plugin_name::BindingBuiltinPluginName,
 };
 
-#[allow(clippy::pub_underscore_fields)]
+#[expect(clippy::pub_underscore_fields)]
 #[napi(object)]
 pub struct BindingBuiltinPlugin<'a> {
   #[napi(js_name = "__name")]
@@ -61,7 +61,7 @@ impl std::fmt::Debug for BindingBuiltinPlugin<'_> {
 impl TryFrom<BindingBuiltinPlugin<'_>> for Arc<dyn Pluginable> {
   type Error = napi::Error;
 
-  #[allow(clippy::too_many_lines)]
+  #[expect(clippy::too_many_lines)]
   fn try_from(plugin: BindingBuiltinPlugin) -> Result<Self, Self::Error> {
     Ok(match plugin.__name {
       BindingBuiltinPluginName::Alias => {

--- a/crates/rolldown_binding/src/options/plugin/config/binding_build_import_analysis_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_build_import_analysis_plugin_config.rs
@@ -2,7 +2,7 @@ use rolldown_plugin_build_import_analysis::BuildImportAnalysisPlugin;
 
 #[napi_derive::napi(object)]
 #[derive(Debug, Default)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct BindingBuildImportAnalysisPluginConfig {
   pub preload_code: String,
   pub insert_preload: bool,

--- a/crates/rolldown_binding/src/options/plugin/config/binding_reporter_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_reporter_plugin_config.rs
@@ -2,7 +2,7 @@ use rolldown_plugin_reporter::ReporterPlugin;
 
 #[napi_derive::napi(object)]
 #[derive(Debug, Default)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct BindingReporterPluginConfig {
   pub is_tty: bool,
   pub is_lib: bool,

--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_resolve_plugin_config.rs
@@ -137,7 +137,7 @@ impl From<BindingViteResolvePluginConfig> for ViteResolveOptions {
 
 #[napi_derive::napi(object)]
 #[derive(Debug)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct BindingViteResolvePluginResolveOptions {
   pub is_build: bool,
   pub is_production: bool,

--- a/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
@@ -74,7 +74,7 @@ pub struct BindingModules {
   pub keys: Vec<String>,
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 impl From<&rolldown_common::Modules> for BindingModules {
   fn from(modules: &rolldown_common::Modules) -> Self {
     let values = modules.values.iter().map(|x| BindingRenderedModule::new(Arc::clone(x))).collect();

--- a/crates/rolldown_binding/src/types/js_callback.rs
+++ b/crates/rolldown_binding/src/types/js_callback.rs
@@ -114,7 +114,7 @@ where
   Ret: 'static + Send + FromNapiValue,
   napi::Either<napi::Either<Promise<Ret>, Ret>, UnknownReturnValue>: FromNapiValue,
 {
-  #[allow(clippy::manual_async_fn)]
+  #[expect(clippy::manual_async_fn)]
   fn await_call(&self, args: Args) -> impl Future<Output = Result<Ret, napi::Error>> + Send {
     async move {
       match self.call_async(args).await? {

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -116,7 +116,7 @@ fn normalize_globals_option(
   })
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub fn normalize_binding_options(
   input_options: crate::options::BindingInputOptions,
   output_options: crate::options::BindingOutputOptions,

--- a/crates/rolldown_binding/src/watcher.rs
+++ b/crates/rolldown_binding/src/watcher.rs
@@ -19,7 +19,7 @@ pub struct BindingNotifyOption {
 }
 
 impl From<BindingNotifyOption> for rolldown_common::NotifyOption {
-  #[allow(clippy::cast_lossless)]
+  #[expect(clippy::cast_lossless)]
   fn from(value: BindingNotifyOption) -> Self {
     Self {
       poll_interval: value.poll_interval.map(|m| Duration::from_millis(m as u64)),


### PR DESCRIPTION
## Summary
Migrate from `#[allow]` to `#[expect]` attributes in the rolldown_binding crate.

## Changes
- Updated 10 files in crates/rolldown_binding
- Replaced all `#[allow(...)]` attributes with `#[expect(...)]`

🤖 Generated with [Claude Code](https://claude.ai/code)