### PR TITLE
refactor(crates/rolldown_common): migrate from #[allow] to #[expect] attributes

### DIFF
--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -88,7 +88,6 @@ pub struct Chunk {
 }
 
 impl Chunk {
-  #[allow(clippy::too_many_arguments)]
   pub fn new(
     name: Option<ArcStr>,
     file_name: Option<ArcStr>,

--- a/crates/rolldown_common/src/chunk/types/module_group.rs
+++ b/crates/rolldown_common/src/chunk/types/module_group.rs
@@ -17,7 +17,7 @@ impl ModuleGroup {
 
   #[cfg(debug_assertions)]
   #[track_caller]
-  #[allow(clippy::print_stdout)]
+  #[expect(clippy::print_stdout)]
   pub fn debug_module_group(&self, module_table: &ModuleTable) {
     let caller = std::panic::Location::caller();
     println!("[{}:{}] Debugging module group:", caller.file(), caller.line());

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -36,7 +36,7 @@ pub enum ThisExprReplaceKind {
 }
 
 #[inline]
-#[allow(clippy::implicit_hasher)]
+#[expect(clippy::implicit_hasher)]
 pub fn generate_replace_this_expr_map(
   set: &FxHashSet<Span>,
   kind: ThisExprReplaceKind,

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -52,7 +52,6 @@ pub struct FileEmitter {
   files: FxDashMap<ArcStr, OutputAsset>,
   chunks: FxDashMap<ArcStr, Arc<EmittedChunk>>,
   base_reference_id: AtomicUsize,
-  #[allow(dead_code)]
   options: Arc<NormalizedBundlerOptions>,
   /// Mark the files that have been emitted to bundle.
   emitted_files: FxDashSet<ArcStr>,

--- a/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
@@ -95,7 +95,7 @@ impl MinifyOptions {
   derive(Deserialize, JsonSchema),
   serde(rename_all = "camelCase", deny_unknown_fields, untagged)
 )]
-#[allow(dead_code)]
+#[cfg_attr(not(feature = "deserialize_bundler_options"), expect(dead_code))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SimpleMinifyOptions {
   Boolean(bool),

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -33,7 +33,7 @@ use crate::{
   TransformOptions,
 };
 
-#[allow(clippy::struct_excessive_bools)] // Using raw booleans is more clear in this case
+#[expect(clippy::struct_excessive_bools)] // Using raw booleans is more clear in this case
 #[derive(Debug)]
 pub struct NormalizedBundlerOptions {
   // --- Input
@@ -110,7 +110,7 @@ pub struct NormalizedBundlerOptions {
 
 // This is only used for testing
 impl Default for NormalizedBundlerOptions {
-  #[allow(clippy::default_trait_access)]
+  #[expect(clippy::default_trait_access)]
   fn default() -> Self {
     Self {
       input: Default::default(),

--- a/crates/rolldown_common/src/types/ast_scopes.rs
+++ b/crates/rolldown_common/src/types/ast_scopes.rs
@@ -69,7 +69,7 @@ impl AstScopes {
     self.scoping.get_resolved_references(symbol_id)
   }
 
-  #[allow(clippy::cast_possible_truncation)]
+  #[expect(clippy::cast_possible_truncation)]
   pub fn create_facade_root_symbol_ref(&mut self, name: &str) -> SymbolId {
     assert!(
       self.facade_scoping.next_symbol_id > self.facade_scoping.minimum_symbol_id.index() as u32,


### PR DESCRIPTION
## Summary
Migrate from `#[allow]` to `#[expect]` attributes in the rolldown_common crate.

## Changes
- Updated 7 files in crates/rolldown_common
- Replaced all `#[allow(...)]` attributes with `#[expect(...)]`

🤖 Generated with [Claude Code](https://claude.ai/code)