### PR TITLE
feat(testing): add extended test coverage for minifier feature

### DIFF
--- a/crates/rolldown/tests/rolldown/extended_tests/minify_test/_config.json
+++ b/crates/rolldown/tests/rolldown/extended_tests/minify_test/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "entry.js"
+      }
+    ]
+  },
+  "extendedTests": {
+    "minify": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/extended_tests/minify_test/entry.js
+++ b/crates/rolldown/tests/rolldown/extended_tests/minify_test/entry.js
@@ -1,0 +1,11 @@
+function unusedFunction() {
+  console.log('this should be removed by minifier');
+  return 'unused';
+}
+
+function keepThis() {
+  const message = 'Hello, World!';
+  return message;
+}
+
+export { keepThis };

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1529,6 +1529,12 @@
             }
           ]
         },
+        "minify": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "minifyInternalExports": {
           "type": [
             "boolean",
@@ -1592,6 +1598,11 @@
           "description": "Run the test case with `minifyInternalExports` enabled in addition to the default config.",
           "type": "boolean",
           "default": true
+        },
+        "minify": {
+          "description": "Run the test case with `minify` enabled in addition to the default config.",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/crates/rolldown_testing/src/fixture.rs
+++ b/crates/rolldown_testing/src/fixture.rs
@@ -84,5 +84,13 @@ impl Fixture {
         ..Default::default()
       });
     }
+    if meta.extended_tests.minify && options.minify.is_none() {
+      config_variants.push(ConfigVariant {
+        config_name: Some("extended-minify".to_string()),
+        minify: Some(true),
+        snapshot: Some(false),
+        ..Default::default()
+      });
+    }
   }
 }

--- a/crates/rolldown_testing_config/src/config_variant.rs
+++ b/crates/rolldown_testing_config/src/config_variant.rs
@@ -19,6 +19,7 @@ pub struct ConfigVariant {
   pub inline_dynamic_imports: Option<bool>,
   pub preserve_entry_signatures: Option<PreserveEntrySignatures>,
   pub treeshake: Option<TreeshakeOptions>,
+  pub minify: Option<bool>,
   pub minify_internal_exports: Option<bool>,
   pub on_demand_wrapping: Option<bool>,
   pub profiler_names: Option<bool>,
@@ -64,6 +65,9 @@ impl ConfigVariant {
     }
     if let Some(treeshake) = &self.treeshake {
       config.treeshake = treeshake.clone();
+    }
+    if let Some(minify) = &self.minify {
+      config.minify = Some(rolldown_common::RawMinifyOptions::Bool(*minify));
     }
     if let Some(minify_internal_exports) = &self.minify_internal_exports {
       config.minify_internal_exports = Some(*minify_internal_exports);
@@ -122,6 +126,9 @@ impl ConfigVariant {
     }
     if let Some(treeshake) = &self.treeshake {
       fields.push(format!("treeshake: {treeshake:?}"));
+    }
+    if let Some(minify) = &self.minify {
+      fields.push(format!("minify: {minify:?}"));
     }
     if let Some(on_demand_wrapping) = &self.on_demand_wrapping {
       fields.push(format!("on_demand_wrapping: {on_demand_wrapping:?}"));

--- a/crates/rolldown_testing_config/src/extended_tests.rs
+++ b/crates/rolldown_testing_config/src/extended_tests.rs
@@ -9,6 +9,9 @@ pub struct ExtendedTests {
   /// Run the test case with `minifyInternalExports` enabled in addition to the default config.
   #[serde(default = "true_by_default")]
   pub minify_internal_exports: bool,
+  /// Run the test case with `minify` enabled in addition to the default config.
+  #[serde(default)]
+  pub minify: bool,
 }
 
 impl Default for ExtendedTests {


### PR DESCRIPTION
Adds support for running tests with minification enabled as an extended test variant. This improves test coverage by automatically testing code with minifier enabled.

- Add minify field to ExtendedTests struct
- Add minify support to ConfigVariant
- Update fixture.rs to apply minify extended test when enabled
- Add example test case for extended minify testing

Closes #6026