### PR TITLE
chore(repo/ai): add `AGENTS.md` and `CLAUDE.md`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+AGENTS.md @hyf0 @IWANABETHATGUY @shulaoda @sapphi-red
+CLAUDE.md @hyf0 @IWANABETHATGUY @shulaoda @sapphi-red

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Codebase Rules
+
+## NEVER Edit These Files
+
+- `packages/rolldown/src/binding.js` - Auto-generated
+- `packages/rolldown/src/binding.d.ts` - Auto-generated
+- `rollup/*` - Git submodule for test fixtures

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
- `AGENTS.md` is the convention.
- Use method mentioned in https://github.com/anthropics/claude-code/issues/6235#issuecomment-3217884068 to ensure single source of truth.


It's foreseeable that people might argue about the content of `AGENTS.md`. Since there's always way to prompt AI locally like `CLAUDE.local.md`, we're gonna have a simple rule for maintaing `AGENTS.md` and `CLAUDE.md`.

Any change to `AGENTS.md` and `CLAUDE.md` requires @IWANABETHATGUY @shulaoda @sapphi-red @hyf0 all approvals. If anyone doesn't like the change even unreasonablely or no reason, the change won't be accepted.

So, before you make any change to `AGENTS.md`, try to think if the prompt is better for any situation or benefit everyone working the rolldown repo.