### PR TITLE
chore: adding rustfmt components for `repo-validation`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           tools: just
           cache-key: debug-build
-          components: clippy
+          components: clippy rustfmt
 
       - run: just lint-rust
 


### PR DESCRIPTION
required by https://github.com/rolldown/rolldown/pull/6052