### PR TITLE
docs: fix default debounce duration in DevWatchOptions JSDoc

### DIFF
--- a/packages/rolldown/src/api/dev/dev-options.ts
+++ b/packages/rolldown/src/api/dev/dev-options.ts
@@ -18,7 +18,7 @@ export interface DevWatchOptions {
   useDebounce?: boolean;
   /**
    * Debounce duration in milliseconds (only used when useDebounce is true).
-   * @default 100
+   * @default 10
    */
   debounceDuration?: number;
 }


### PR DESCRIPTION
Correct the default debounce duration from 100ms to 10ms in the
TypeScript interface documentation to match the actual default
value used in the Rust implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>