### PR TITLE
revert: "fix: replace_plugin does not work as expected with .ts config (#5920)"

### DIFF
--- a/packages/rolldown/src/builtin-plugin/alias-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/alias-plugin.ts
@@ -1,4 +1,4 @@
-import { BuiltinPlugin, createBuiltinPlugin } from './utils';
+import { BuiltinPlugin } from './utils';
 
 type AliasPluginAlias = {
   find: string | RegExp;
@@ -11,5 +11,5 @@ type AliasPluginConfig = {
 };
 
 export function aliasPlugin(config: AliasPluginConfig): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:alias', config);
+  return new BuiltinPlugin('builtin:alias', config);
 }

--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -15,16 +15,12 @@ import type {
 } from '../binding';
 import type { StringOrRegExp } from '../types/utils';
 import { normalizedStringOrRegex } from '../utils/normalize-string-or-regex';
-import {
-  BuiltinPlugin,
-  createBuiltinPlugin,
-  makeBuiltinPluginCallable,
-} from './utils';
+import { BuiltinPlugin, makeBuiltinPluginCallable } from './utils';
 
 export function modulePreloadPolyfillPlugin(
   config?: BindingModulePreloadPolyfillPluginConfig,
 ): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:module-preload-polyfill', config);
+  return new BuiltinPlugin('builtin:module-preload-polyfill', config);
 }
 
 type DynamicImportVarsPluginConfig =
@@ -44,84 +40,84 @@ export function dynamicImportVarsPlugin(
     config.include = normalizedStringOrRegex(config.include);
     config.exclude = normalizedStringOrRegex(config.exclude);
   }
-  return createBuiltinPlugin('builtin:dynamic-import-vars', config);
+  return new BuiltinPlugin('builtin:dynamic-import-vars', config);
 }
 
 export function importGlobPlugin(
   config?: BindingImportGlobPluginConfig,
 ): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:import-glob', config);
+  return new BuiltinPlugin('builtin:import-glob', config);
 }
 
 export function reporterPlugin(
   config?: BindingReporterPluginConfig,
 ): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:reporter', config);
+  return new BuiltinPlugin('builtin:reporter', config);
 }
 
 export function manifestPlugin(
   config?: BindingManifestPluginConfig,
 ): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:manifest', config);
+  return new BuiltinPlugin('builtin:manifest', config);
 }
 
 export function wasmHelperPlugin(
   config?: BindingWasmHelperPluginConfig,
 ): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:wasm-helper', config);
+  return new BuiltinPlugin('builtin:wasm-helper', config);
 }
 
 export function wasmFallbackPlugin(): BuiltinPlugin {
-  const builtinPlugin = createBuiltinPlugin('builtin:wasm-fallback');
+  const builtinPlugin = new BuiltinPlugin('builtin:wasm-fallback');
   return makeBuiltinPluginCallable(builtinPlugin);
 }
 
 export function loadFallbackPlugin(): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:load-fallback');
+  return new BuiltinPlugin('builtin:load-fallback');
 }
 
 export function jsonPlugin(config?: BindingJsonPluginConfig): BuiltinPlugin {
-  const builtinPlugin = createBuiltinPlugin('builtin:json', config);
+  const builtinPlugin = new BuiltinPlugin('builtin:json', config);
   return makeBuiltinPluginCallable(builtinPlugin);
 }
 
 export function buildImportAnalysisPlugin(
   config: BindingBuildImportAnalysisPluginConfig,
 ): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:build-import-analysis', config);
+  return new BuiltinPlugin('builtin:build-import-analysis', config);
 }
 
 export function viteResolvePlugin(
   config: BindingViteResolvePluginConfig,
 ): BuiltinPlugin {
-  const builtinPlugin = createBuiltinPlugin('builtin:vite-resolve', config);
+  const builtinPlugin = new BuiltinPlugin('builtin:vite-resolve', config);
   return makeBuiltinPluginCallable(builtinPlugin);
 }
 
 export function isolatedDeclarationPlugin(
   config?: BindingIsolatedDeclarationPluginConfig,
 ): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:isolated-declaration', config);
+  return new BuiltinPlugin('builtin:isolated-declaration', config);
 }
 
 export function assetPlugin(
   config?: BindingAssetPluginConfig,
 ): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:asset', config);
+  return new BuiltinPlugin('builtin:asset', config);
 }
 
 export function webWorkerPostPlugin(): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:web-worker-post');
+  return new BuiltinPlugin('builtin:web-worker-post');
 }
 
 export function oxcRuntimePlugin(
   config?: BindingOxcRuntimePluginConfig,
 ): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:oxc-runtime', config);
+  return new BuiltinPlugin('builtin:oxc-runtime', config);
 }
 
 export function esmExternalRequirePlugin(
   config?: BindingEsmExternalRequirePluginConfig,
 ): BuiltinPlugin {
-  return createBuiltinPlugin('builtin:esm-external-require', config);
+  return new BuiltinPlugin('builtin:esm-external-require', config);
 }

--- a/packages/rolldown/src/builtin-plugin/replace-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/replace-plugin.ts
@@ -1,6 +1,6 @@
 import type { BindingReplacePluginConfig } from '../binding';
 
-import { BuiltinPlugin, createBuiltinPlugin } from './utils';
+import { BuiltinPlugin } from './utils';
 
 /**
  * Replaces targeted strings in files while bundling.
@@ -33,5 +33,5 @@ export function replacePlugin(
     values[key] = values[key].toString();
   });
 
-  return createBuiltinPlugin('builtin:replace', { ...options, values });
+  return new BuiltinPlugin('builtin:replace', { ...options, values });
 }

--- a/packages/rolldown/src/builtin-plugin/transform-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/transform-plugin.ts
@@ -1,4 +1,4 @@
-import { BuiltinPlugin, createBuiltinPlugin } from './utils';
+import { BuiltinPlugin } from './utils';
 
 import type { BindingTransformPluginConfig } from '../binding';
 import { normalizedStringOrRegex } from '../utils/normalize-string-or-regex';
@@ -28,5 +28,5 @@ export function transformPlugin(config?: TransformPluginConfig): BuiltinPlugin {
       jsxRefreshExclude: normalizedStringOrRegex(config.jsxRefreshExclude),
     };
   }
-  return createBuiltinPlugin('builtin:transform', config);
+  return new BuiltinPlugin('builtin:transform', config);
 }

--- a/packages/rolldown/src/builtin-plugin/utils.ts
+++ b/packages/rolldown/src/builtin-plugin/utils.ts
@@ -9,8 +9,6 @@ type BindingCallableBuiltinPluginLike = {
   [K in keyof BindingCallableBuiltinPlugin]: BindingCallableBuiltinPlugin[K];
 };
 
-const BuiltinClassSymbol: symbol = Symbol.for('__RolldownBuiltinPlugin__');
-
 // eslint-disable @typescript-eslint/no-unsafe-declaration-merging
 export class BuiltinPlugin {
   constructor(
@@ -18,23 +16,7 @@ export class BuiltinPlugin {
     // NOTE: has `_` to avoid conflict with `options` hook
     public _options?: unknown,
   ) {
-    this[BuiltinClassSymbol] = true;
   }
-}
-
-export function isBuiltinPlugin(obj: any): obj is BuiltinPlugin {
-  return obj && obj[BuiltinClassSymbol] === true;
-}
-
-export interface BuiltinPlugin {
-  [BuiltinClassSymbol]: boolean;
-}
-
-export function createBuiltinPlugin(
-  name: BindingBuiltinPluginName,
-  options?: unknown,
-): BuiltinPlugin {
-  return new BuiltinPlugin(name, options);
 }
 
 export function makeBuiltinPluginCallable(

--- a/packages/rolldown/src/plugin/plugin-driver.ts
+++ b/packages/rolldown/src/plugin/plugin-driver.ts
@@ -1,5 +1,5 @@
 import type { InputOptions, OutputOptions, RolldownPlugin } from '..';
-import { isBuiltinPlugin } from '../builtin-plugin/utils';
+import { BuiltinPlugin } from '../builtin-plugin/utils';
 import type { LogHandler } from '../log/log-handler';
 import { getLogger, getOnLog } from '../log/logger';
 import { LOG_LEVEL_INFO, type LogLevelOption } from '../log/logging';
@@ -90,7 +90,7 @@ export function getObjectPlugins(plugins: RolldownPlugin[]): Plugin[] {
     if ('_parallel' in plugin) {
       return undefined;
     }
-    if (isBuiltinPlugin(plugin)) {
+    if (plugin instanceof BuiltinPlugin) {
       return undefined;
     }
     return plugin;

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -13,7 +13,7 @@ import type {
   BindingInjectImportNamespace,
   BindingInputOptions,
 } from '../binding';
-import { BuiltinPlugin, isBuiltinPlugin } from '../builtin-plugin/utils';
+import { BuiltinPlugin } from '../builtin-plugin/utils';
 import { bindingifyBuiltInPlugin } from '../builtin-plugin/utils';
 import type { LogHandler } from '../log/log-handler';
 import { LOG_LEVEL_WARN, type LogLevelOption } from '../log/logging';
@@ -49,7 +49,7 @@ export function bindingifyInputOptions(
     if ('_parallel' in plugin) {
       return undefined;
     }
-    if (isBuiltinPlugin(plugin)) {
+    if (plugin instanceof BuiltinPlugin) {
       return bindingifyBuiltInPlugin(plugin as BuiltinPlugin);
     }
     return bindingifyPlugin(

--- a/packages/rolldown/src/utils/normalize-plugin-option.ts
+++ b/packages/rolldown/src/utils/normalize-plugin-option.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { oxcRuntimePlugin } from '../builtin-plugin/constructors';
-import { BuiltinPlugin, isBuiltinPlugin } from '../builtin-plugin/utils';
+import { BuiltinPlugin } from '../builtin-plugin/utils';
 import { ENUMERATED_INPUT_PLUGIN_HOOK_NAMES } from '../constants/plugin';
 import type { LogHandler } from '../log/log-handler';
 import { LOG_LEVEL_WARN } from '../log/logging';
@@ -41,7 +41,7 @@ export function normalizePlugins<T extends RolldownPlugin>(
     if ('_parallel' in plugin) {
       continue;
     }
-    if (isBuiltinPlugin(plugin)) {
+    if (plugin instanceof BuiltinPlugin) {
       continue;
     }
     if (!plugin.name) {


### PR DESCRIPTION
> Now that https://github.com/rolldown/rolldown/issues/5941 is resolved we don't have any dual publishing hazard > problems anymore. Can https://github.com/rolldown/rolldown/pull/5920 then be reverted or is it good to keep anyway?

Closed #6073