### PR TITLE
feat(crates/rolldown_watcher): introduce `PathsMut` to batch watch/unwatch behaviors

### DIFF
--- a/crates/rolldown/examples/dev.rs
+++ b/crates/rolldown/examples/dev.rs
@@ -27,6 +27,6 @@ async fn main() {
     },
   )
   .unwrap();
-  dev_engine.run().await;
+  dev_engine.run().await.unwrap();
   dev_engine.wait_for_close().await;
 }

--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -74,7 +74,7 @@ impl BindingDevEngine {
 
   #[napi]
   pub async fn run(&self) -> napi::Result<()> {
-    self.inner.run().await;
+    self.inner.run().await.map_err(|_e| napi::Error::from_reason("Failed to run dev engine"))?;
     Ok(())
   }
 

--- a/crates/rolldown_watcher/src/lib.rs
+++ b/crates/rolldown_watcher/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod event;
 mod event_handler;
+mod paths_mut;
 mod recommended_watcher;
 mod utils;
 mod watcher;
@@ -26,6 +27,7 @@ pub use debounced_recommended_watcher::DebouncedRecommendedWatcher;
 
 pub use crate::{event::EventResult as FileChangeResult, event_handler::EventHandler};
 pub use notify::RecursiveMode;
+pub use paths_mut::PathsMut;
 pub use recommended_watcher::RecommendedWatcher;
 pub use watcher_config::WatcherConfig;
 pub use {watcher::Watcher, watcher_ext::WatcherExt};

--- a/crates/rolldown_watcher/src/paths_mut.rs
+++ b/crates/rolldown_watcher/src/paths_mut.rs
@@ -1,0 +1,44 @@
+use std::path::Path;
+
+use notify::RecursiveMode;
+use rolldown_error::BuildResult;
+
+/// A trait for batch manipulation of watched paths.
+///
+/// This provides better performance than multiple individual calls to `watch` and `unwatch`
+/// when you need to add or remove many paths at once.
+pub trait PathsMut {
+  /// Add a path to be watched with the specified recursive mode.
+  ///
+  /// # Arguments
+  ///
+  /// * `path` - The path to watch
+  /// * `recursive_mode` - Whether to watch the path recursively or not
+  ///
+  /// # Returns
+  ///
+  /// A BuildResult indicating success or failure
+  fn add(&mut self, path: &Path, recursive_mode: RecursiveMode) -> BuildResult<()>;
+
+  /// Remove a path from being watched.
+  ///
+  /// # Arguments
+  ///
+  /// * `path` - The path to stop watching
+  ///
+  /// # Returns
+  ///
+  /// A BuildResult indicating success or failure
+  fn remove(&mut self, path: &Path) -> BuildResult<()>;
+
+  /// Commit all the accumulated add/remove operations.
+  ///
+  /// Some implementations may apply changes immediately in `add`/`remove`,
+  /// in which case this is a no-op. Others may batch all operations
+  /// and apply them only when `commit` is called.
+  ///
+  /// # Returns
+  ///
+  /// A BuildResult indicating success or failure
+  fn commit(self: Box<Self>) -> BuildResult<()>;
+}

--- a/crates/rolldown_watcher/src/watcher.rs
+++ b/crates/rolldown_watcher/src/watcher.rs
@@ -2,7 +2,7 @@ use notify::RecursiveMode;
 use rolldown_error::BuildResult;
 use std::path::Path;
 
-use crate::{EventHandler, WatcherConfig};
+use crate::{EventHandler, PathsMut, WatcherConfig};
 
 pub trait Watcher {
   fn new<F: EventHandler>(event_handler: F) -> BuildResult<Self>
@@ -22,4 +22,33 @@ pub trait Watcher {
   /// Returns an error in the case that `path` has not been watched or if removing the watch
   /// fails.
   fn unwatch(&mut self, path: &Path) -> BuildResult<()>;
+
+  /// Returns a mutable interface to the watched paths for batch operations.
+  ///
+  /// This provides better performance than multiple calls to `watch` and `unwatch`
+  /// if you want to add/remove many paths at once.
+  ///
+  /// # Returns
+  ///
+  /// A boxed trait object that allows batch manipulation of watched paths.
+  fn paths_mut<'me>(&'me mut self) -> Box<dyn PathsMut + 'me> {
+    struct DefaultPathsMut<'a, T: ?Sized>(&'a mut T);
+
+    impl<T: Watcher + ?Sized> PathsMut for DefaultPathsMut<'_, T> {
+      fn add(&mut self, path: &Path, recursive_mode: RecursiveMode) -> BuildResult<()> {
+        self.0.watch(path, recursive_mode)
+      }
+
+      fn remove(&mut self, path: &Path) -> BuildResult<()> {
+        self.0.unwatch(path)
+      }
+
+      fn commit(self: Box<Self>) -> BuildResult<()> {
+        // No-op - changes are applied immediately
+        Ok(())
+      }
+    }
+
+    Box::new(DefaultPathsMut(self))
+  }
 }


### PR DESCRIPTION
Ref: https://github.com/notify-rs/notify/issues/710