### PR TITLE
feat: support function config with custom CLI arguments

### DIFF
--- a/packages/rolldown/src/cli/index.ts
+++ b/packages/rolldown/src/cli/index.ts
@@ -6,10 +6,10 @@ import { showHelp } from './commands/help';
 import { logger } from './logger';
 
 async function main() {
-  const cliOptions = parseCliArguments();
+  const { rawArgs, ...cliOptions } = parseCliArguments();
 
   if (cliOptions.config || cliOptions.config === '') {
-    await bundleWithConfig(cliOptions.config, cliOptions);
+    await bundleWithConfig(cliOptions.config, cliOptions, rawArgs);
     return;
   }
 

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -95,6 +95,7 @@ import type { ModuleInfo } from './types/module-info';
 import type { TreeshakingOptions } from './types/module-side-effects';
 import type { OutputBundle } from './types/output-bundle';
 import type { RolldownOptions } from './types/rolldown-options';
+import type { RolldownOptionsFunction } from './types/rolldown-options-function';
 import type {
   OutputAsset,
   OutputChunk,
@@ -173,6 +174,7 @@ export type {
   RolldownFileStats,
   RolldownFsModule,
   RolldownOptions,
+  RolldownOptionsFunction,
   RolldownOutput,
   RolldownPlugin,
   RolldownPluginOption,

--- a/packages/rolldown/src/types/config-export.ts
+++ b/packages/rolldown/src/types/config-export.ts
@@ -1,6 +1,10 @@
 import type { RolldownOptions } from './rolldown-options';
+import type { RolldownOptionsFunction } from './rolldown-options-function';
 
 /**
  * Type for `default export` of `rolldown.config.js` file.
  */
-export type ConfigExport = RolldownOptions | RolldownOptions[];
+export type ConfigExport =
+  | RolldownOptions
+  | RolldownOptions[]
+  | RolldownOptionsFunction;

--- a/packages/rolldown/src/types/rolldown-options-function.ts
+++ b/packages/rolldown/src/types/rolldown-options-function.ts
@@ -1,0 +1,6 @@
+import type { RolldownOptions } from './rolldown-options';
+import type { MaybePromise } from './utils';
+
+export type RolldownOptionsFunction = (
+  commandLineArguments: Record<string, any>,
+) => MaybePromise<RolldownOptions | RolldownOptions[]>;

--- a/packages/rolldown/src/utils/define-config.ts
+++ b/packages/rolldown/src/utils/define-config.ts
@@ -1,8 +1,12 @@
 import type { ConfigExport } from '../types/config-export';
 import type { RolldownOptions } from '../types/rolldown-options';
+import type { RolldownOptionsFunction } from '../types/rolldown-options-function';
 
 export function defineConfig(config: RolldownOptions): RolldownOptions;
 export function defineConfig(config: RolldownOptions[]): RolldownOptions[];
+export function defineConfig(
+  config: RolldownOptionsFunction,
+): RolldownOptionsFunction;
 export function defineConfig(config: ConfigExport): ConfigExport;
 export function defineConfig(config: ConfigExport): ConfigExport {
   return config;

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -312,6 +312,13 @@ exports[`config > should resolve rolldown.config.cjs 1`] = `
 "
 `;
 
+exports[`config > should support custom cli arguments 1`] = `
+"Option \`customArg\` is unrecognized. We will ignore this option.
+<DIR>/index.js  chunk │ size: 0.14 kB
+
+"
+`;
+
 exports[`watch cli > should allow multiply output + call options hook once + call outputOptions hook 1`] = `
 "called options hook
 called output options hook

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -214,6 +214,18 @@ describe('config', () => {
     expect(cleanStdout(status.stdout)).toMatchSnapshot()
   })
 
+
+  it('should support custom cli arguments', async () => {
+    const cwd = cliFixturesDir('cli-with-custom-args')
+
+    const status = await $({
+      cwd,
+    })`rolldown -c rolldown.config.js --customArg=customValue`
+    expect(status.exitCode).toBe(0)
+    expect(cleanStdout(status.stdout)).toMatchSnapshot()
+  })
+
+
   it('should allow multiply output + call options hook once  + call outputOptions hook', async () => {
     const cwd = cliFixturesDir('config-multiply-output-with-options-hooks')
     const status = await $({

--- a/packages/rolldown/tests/cli/fixtures/cli-with-custom-args/index.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-with-custom-args/index.js
@@ -1,0 +1,1 @@
+export default 'hello, world!'

--- a/packages/rolldown/tests/cli/fixtures/cli-with-custom-args/rolldown.config.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-with-custom-args/rolldown.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'rolldown'
+import assert from 'node:assert'
+
+export default defineConfig((args) => {
+  assert.strictEqual(args.customArg, 'customValue')
+  return {
+    input: './index.js'
+  }
+})

--- a/packages/rolldown/tests/rollup-compat.test-d.ts
+++ b/packages/rolldown/tests/rollup-compat.test-d.ts
@@ -37,11 +37,11 @@ describe('plugin type compatibility', () => {
     expectTypeOf(plugin).toEqualTypeOf<RolldownRawPlugin | { name: string }>()
 
     const buildS = undefined
-    // @ts-expect-error -- only known properties should be allowed
     defineConfig({
       plugins: [
         {
           name: 'test',
+          // @ts-expect-error -- only known properties should be allowed
           buildS
           //    ^ input suggestion should work here
         }


### PR DESCRIPTION
Closed #6067

## Screenshot
<img width="1000" height="150" alt="image" src="https://github.com/user-attachments/assets/d99eaae3-dfd0-44ca-9106-3ee74e7daffc" />

similar with https://rollupjs.org/command-line-interface/#configuration-files:~:text=command%20line%20options%20if%20you%20prefix%20them%20with%20config%3A, 

**Limitation compared to Rollup**
- Because we use node builtin `parseArgs` util to parse cli args, it only supports `k=v` pattern when parsing the unknown pair  of args, e.g.
```bash
rolldown -c rolldown.cofnig.js --foo bar
```
it would only return `{config: 'rolldown.config.js', foo: undefined}`

you should use 
```bash
rolldown -c rolldown.cofnig.js --foo=bar
```
instead