### PR TITLE
fix(dev/watch): debounce duration should default to 10

### DIFF
--- a/crates/rolldown/src/dev/dev_options.rs
+++ b/crates/rolldown/src/dev/dev_options.rs
@@ -42,6 +42,6 @@ pub fn normalize_dev_options(options: DevOptions) -> NormalizedDevOptions {
     use_polling: watch_options.use_polling.unwrap_or(false),
     poll_interval: watch_options.poll_interval.unwrap_or(100),
     use_debounce: watch_options.use_debounce.unwrap_or(true),
-    debounce_duration: watch_options.debounce_duration.unwrap_or(100),
+    debounce_duration: watch_options.debounce_duration.unwrap_or(10),
   }
 }


### PR DESCRIPTION
Probably the reason of hmr tests being flaky. Anyway, we now have #6077 to explicit configurate watcher for CI>