### PR TITLE
feat: improve `MISSING_EXPORT` warning to suggest `type` modifier

### DIFF
--- a/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
@@ -13,8 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ───┬──  
    │           ╰──── Missing export
    │ 
-   │ Note: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
-   │         exports to appear missing.
+   │ Note: If you meant to import a type rather than a value, make sure to add the `type` modifier (e.g. `import { type Foo } from './keep/declare-class'`).
 ───╯
 
 ```
@@ -28,8 +27,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ───┬──  
    │           ╰──── Missing export
    │ 
-   │ Note: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
-   │         exports to appear missing.
+   │ Note: If you meant to import a type rather than a value, make sure to add the `type` modifier (e.g. `import { type Foo } from './keep/declare-let'`).
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/_config.json
@@ -1,0 +1,3 @@
+{
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/artifacts.snap
@@ -1,0 +1,40 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## MISSING_EXPORT
+
+```text
+[MISSING_EXPORT] Warning: "Bar" is not exported by "bar.ts".
+   ╭─[ main.ts:3:10 ]
+   │
+ 3 │ import { Bar } from './bar.ts'
+   │          ─┬─  
+   │           ╰─── Missing export
+   │ 
+   │ Note: If you meant to import a type rather than a value, make sure to add the `type` modifier (e.g. `import { type Foo } from './bar.ts'`).
+───╯
+
+```
+## MISSING_EXPORT
+
+```text
+[MISSING_EXPORT] Warning: "Foo" is not exported by "foo.ts".
+   ╭─[ main.ts:1:10 ]
+   │
+ 1 │ export { Foo } from './foo.ts'
+   │          ─┬─  
+   │           ╰─── Missing export
+   │ 
+   │ Note: If you meant to import a type rather than a value, make sure to add the `type` modifier (e.g. `import { type Foo } from './foo.ts'`).
+───╯
+
+```
+# Assets
+
+## main.js
+
+```js
+export { Bar, Foo };
+```

--- a/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/bar.ts
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/bar.ts
@@ -1,0 +1,1 @@
+export type Bar = 'bar'

--- a/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/foo.ts
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/foo.ts
@@ -1,0 +1,1 @@
+export type Foo = 'foo'

--- a/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/main.ts
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_reexport_type/main.ts
@@ -1,0 +1,4 @@
+export { Foo } from './foo.ts'
+
+import { Bar } from './bar.ts'
+export { Bar }

--- a/crates/rolldown/tests/rolldown/errors/missing_export_ts/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/missing_export_ts/artifacts.snap
@@ -13,8 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ───┬──  
    │           ╰──── Missing export
    │ 
-   │ Note: This diagnostic might be a false positive when importing from TypeScript files. TypeScript type-only exports and imports are stripped during transformation, which may cause actual
-   │         exports to appear missing.
+   │ Note: If you meant to import a type rather than a value, make sure to add the `type` modifier (e.g. `import { type Foo } from './foo'`).
 ───╯
 
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3735,6 +3735,10 @@ expression: output
 
 - main-!~{000}~.js => main-B-6QqlpX.js
 
+# tests/rolldown/errors/missing_export_reexport_type
+
+- main-!~{000}~.js => main-Cwb0sONg.js
+
 # tests/rolldown/errors/missing_export_ts
 
 - main-!~{000}~.js => main-BJyCdokI.js


### PR DESCRIPTION
There are multiple cases that `MISSING_EXPORT` happens even when TypeScript does not output an error.

1. https://github.com/rolldown/rolldown/pull/4144#issuecomment-2811663851
    - This case only happens when the importer and the importee is both TS. This is because we treat `foo` as a "type" rather than a "value" (since we remove `export default foo` completely. If we treat it as a "value", we should keep that).
2. The case written in https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax (`export { A } from './a'`)
    - This case only happens when the importer and the importee is both TS. This is because if `A` is a "value", `A` would exist after transpilation.

Both of these cases can be fixed by adding the `type` modifier. While setting `verbatimModuleSyntax: true` would make TypeScript to error on these cases, it changes some other behaviors, and is not straightforward to turn that on. This PR improves the error message, so that users can know what to do even if they don't enable `verbatimModuleSyntax`.

refs #4147
