### PR TITLE
test(dev): apply HMR edits on Windows

### DIFF
--- a/packages/test-dev-server/tests/fixtures.test.ts
+++ b/packages/test-dev-server/tests/fixtures.test.ts
@@ -202,7 +202,8 @@ async function collectHmrEditFiles(
   projectPath: string,
 ) {
   const hmrEditFiles = await glob(
-    nodePath.join(projectPath, '/src/**/*.hmr-*.*'),
+    glob.convertPathToPattern(nodePath.join(projectPath, './src')) +
+      '/**/*.hmr-*.*',
     {
       ignore: ['**/node_modules/**', '**/dist/**'],
       absolute: true,


### PR DESCRIPTION
`hmrEditFiles` was an empty array on Windows. So no edit was applied in the tests.