### PR TITLE
fix: track spans in member expression properties for accurate sourcemaps

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -418,7 +418,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
               }
               None => match self.try_extract_parent_static_member_expr_chain(1) {
                 Some((_span, prop)) => {
-                  self.self_used_cjs_named_exports.insert(prop[0].as_str().into());
+                  self.self_used_cjs_named_exports.insert(prop[0].0.clone());
                 }
                 _ => {
                   self.result.ast_usage.insert(EcmaModuleAstUsage::UnknownExportsRead);

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -841,13 +841,13 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   pub fn add_member_expr_reference(
     &mut self,
     object_ref: SymbolRef,
-    props: Vec<CompactStr>,
+    prop_and_span_list: Vec<(CompactStr, Span)>,
     span: Span,
   ) {
     self
       .current_stmt_info
       .referenced_symbols
-      .push(MemberExprRef::new(object_ref, props, span).into());
+      .push(MemberExprRef::new(object_ref, prop_and_span_list, span).into());
   }
 
   fn is_root_symbol(&self, symbol_id: SymbolId) -> bool {
@@ -891,19 +891,19 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   pub fn try_extract_parent_static_member_expr_chain(
     &self,
     max_len: usize,
-  ) -> Option<(Span, Vec<CompactStr>)> {
+  ) -> Option<(Span, Vec<(CompactStr, Span)>)> {
     let mut span = SPAN;
     let mut props = vec![];
     for ancestor_ast in self.visit_path.iter().rev().take(max_len) {
       match ancestor_ast {
         AstKind::StaticMemberExpression(expr) => {
           span = ancestor_ast.span();
-          props.push(expr.property.name.as_str().into());
+          props.push((expr.property.name.as_str().into(), expr.property.span()));
         }
         AstKind::ComputedMemberExpression(expr) => {
           if let Some(name) = expr.static_property_name() {
             span = ancestor_ast.span();
-            props.push(name.into());
+            props.push((name.into(), expr.expression.span()));
           } else {
             break;
           }

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -634,7 +634,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     match self.ctx.linking_info.resolved_member_expr_refs.get(&span) {
       Some(MemberExprRefResolution {
         resolved: object_ref,
-        props,
+        prop_and_related_span_list: props,
         target_commonjs_exported_symbol: target_commonjs_exported_symbol_meta,
         ..
       }) => object_ref

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_6099/_config.json
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_6099/_config.json
@@ -1,0 +1,4 @@
+{
+  "visualizeSourcemap": true,
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_6099/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_6099/artifacts.snap
@@ -1,0 +1,60 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+//#region cjs.js
+var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports) => {
+	exports.version = "1.0.0";
+	Object.defineProperty(exports, "version", { get() {
+		throw new Error("see stacktrace");
+	} });
+}) });
+
+//#endregion
+//#region main.js
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
+const foo = import_cjs.version.startsWith("1");
+console.log(foo);
+
+//#endregion
+//# sourceMappingURL=main.js.map
+```
+
+# Sourcemap Visualizer
+
+```
+- ../cjs.js
+(0:0) "exports." --> (28:0) "\texports."
+(0:8) "version = " --> (28:9) "version = "
+(0:18) "\"1.0.0\"\n" --> (28:19) "\"1.0.0\";\n"
+(1:0) "Object." --> (29:0) "\tObject."
+(1:7) "defineProperty(" --> (29:8) "defineProperty("
+(1:22) "exports, " --> (29:23) "exports, "
+(1:31) "'version', " --> (29:32) "\"version\", "
+(1:42) "{\n" --> (29:43) "{ "
+(2:2) "get() " --> (29:45) "get() "
+(2:8) "{\n" --> (29:51) "{\n"
+(3:4) "throw " --> (30:0) "\t\tthrow "
+(3:10) "new " --> (30:8) "new "
+(3:14) "Error(" --> (30:12) "Error("
+(3:20) "'see stacktrace')" --> (30:18) "\"see stacktrace\")"
+(3:37) "\n" --> (30:35) ";\n"
+(5:1) ")" --> (31:4) ")"
+(5:2) "\n" --> (31:5) ";\n"
+- ../main.js
+(2:0) "const " --> (37:0) "const "
+(2:6) "foo = mod." --> (37:6) "foo = import_cjs."
+(2:16) "version." --> (37:23) "version."
+(2:24) "startsWith(" --> (37:31) "startsWith("
+(2:35) "\"1\")" --> (37:42) "\"1\")"
+(2:39) "\n" --> (37:46) ";\n"
+(3:0) "console." --> (38:0) "console."
+(3:8) "log(" --> (38:8) "log("
+(3:12) "foo)" --> (38:12) "foo)"
+(3:16) "\n" --> (38:16) ";\n"
+```

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_6099/cjs.js
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_6099/cjs.js
@@ -1,0 +1,6 @@
+exports.version = "1.0.0"
+Object.defineProperty(exports, 'version', {
+  get() {
+    throw new Error('see stacktrace')
+  }
+})

--- a/crates/rolldown/tests/rolldown/sourcemap/issue_6099/main.js
+++ b/crates/rolldown/tests/rolldown/sourcemap/issue_6099/main.js
@@ -1,0 +1,5 @@
+import mod from './cjs.js'
+
+const foo = mod.version.startsWith("1")
+console.log(foo)
+

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5112,6 +5112,11 @@ expression: output
 - assets/main.js => assets/main.js
 - assets/main.js.map
 
+# tests/rolldown/sourcemap/issue_6099
+
+- main-!~{000}~.js => main-CJ_LmJ_O.js
+- main-CJ_LmJ_O.js.map
+
 # tests/rolldown/sourcemap/live_binding
 
 - main1-!~{000}~.js => main1-DuhB17iW.js

--- a/crates/rolldown_common/src/types/member_expr_ref.rs
+++ b/crates/rolldown_common/src/types/member_expr_ref.rs
@@ -8,7 +8,7 @@ use crate::{MemberExprRefResolution, SymbolRef, type_aliases::MemberExprRefResol
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MemberExprRef {
   pub object_ref: SymbolRef,
-  pub props: Vec<CompactStr>,
+  pub prop_and_span_list: Vec<(CompactStr, Span)>,
   /// Span of the whole member expression
   /// FIXME: use `AstNodeId` to identify the MemberExpr instead of `Span`
   /// related discussion: https://github.com/rolldown/rolldown/pull/1818#discussion_r1699374441
@@ -16,8 +16,12 @@ pub struct MemberExprRef {
 }
 
 impl MemberExprRef {
-  pub fn new(object_ref: SymbolRef, props: Vec<CompactStr>, span: Span) -> Self {
-    Self { object_ref, props, span }
+  pub fn new(
+    object_ref: SymbolRef,
+    prop_and_span_list: Vec<(CompactStr, Span)>,
+    span: Span,
+  ) -> Self {
+    Self { object_ref, prop_and_span_list, span }
   }
 
   /// This method is tricky, use it with care.

--- a/crates/rolldown_common/src/types/member_expr_ref_resolution.rs
+++ b/crates/rolldown_common/src/types/member_expr_ref_resolution.rs
@@ -1,4 +1,4 @@
-use oxc::span::CompactStr;
+use oxc::span::{CompactStr, Span};
 
 use crate::SymbolRef;
 
@@ -11,8 +11,8 @@ pub struct MemberExprRefResolution {
   /// console.log(ns.nonExistExport)
   /// ```
   pub resolved: Option<SymbolRef>,
-  /// Used to store "foo", "bar" for `ns.foo.bar`.
-  pub props: Vec<CompactStr>,
+  /// Used to store "foo", "bar" for `ns.foo.bar` and their related span.
+  pub prop_and_related_span_list: Vec<(CompactStr, Span)>,
   /// If you want to include the `resolved` symbol, these are depended symbols that need to be included together to ensure correct runtime behaviors.
   pub depended_refs: Vec<SymbolRef>,
   /// The barrel exports from commonjs is different from es module.

--- a/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
@@ -60,23 +60,23 @@ impl<'ast> AstSnippet<'ast> {
   pub fn member_expr_or_ident_ref(
     &self,
     object: ast::Expression<'ast>,
-    names: &[CompactStr],
+    name_and_span_list: &[(CompactStr, Span)],
     span: Span,
   ) -> ast::Expression<'ast> {
     let mut cur = object;
-    for name in names {
+    for (name, related_span) in name_and_span_list {
       cur = if identifier::is_identifier_name(name) {
         ast::Expression::from(self.builder.member_expression_static(
           SPAN,
           cur,
-          self.id_name(name, SPAN),
+          self.id_name(name, *related_span),
           false,
         ))
       } else {
         ast::Expression::from(self.builder.member_expression_computed(
           SPAN,
           cur,
-          self.builder.expression_string_literal(SPAN, self.builder.atom(name), None),
+          self.builder.expression_string_literal(*related_span, self.builder.atom(name), None),
           false,
         ))
       };
@@ -89,13 +89,13 @@ impl<'ast> AstSnippet<'ast> {
   #[inline]
   pub fn member_expr_with_void_zero_object(
     &self,
-    names: &[CompactStr],
+    name_and_span_list: &[(CompactStr, Span)],
     span: Span,
   ) -> ast::Expression<'ast> {
-    if names.is_empty() {
+    if name_and_span_list.is_empty() {
       self.void_zero()
     } else {
-      self.member_expr_or_ident_ref(self.void_zero(), &names[1..], span)
+      self.member_expr_or_ident_ref(self.void_zero(), &name_and_span_list[1..], span)
     }
   }
 


### PR DESCRIPTION
Closed #6099

The issue was already solved by #6091. This pr adds a test case for the sourcemapping generation