### PR TITLE
feat: add proper close method to DevEngine for resource cleanup

### DIFF
--- a/crates/rolldown/examples/dev.rs
+++ b/crates/rolldown/examples/dev.rs
@@ -4,8 +4,6 @@ use rolldown::dev::DevOptions;
 use rolldown::{BundlerBuilder, BundlerOptions, DevEngine, ExperimentalOptions};
 use sugar_path::SugarPath;
 
-// RD_LOG=rolldown::dev=trace cargo run --example dev
-
 #[expect(clippy::print_stdout)]
 #[tokio::main]
 async fn main() {
@@ -27,6 +25,20 @@ async fn main() {
     },
   )
   .unwrap();
+
+  println!("Starting DevEngine...");
   dev_engine.run().await.unwrap();
-  dev_engine.wait_for_close().await;
+
+  // Demonstrate the close method: run for 10 seconds then close
+  println!("DevEngine running, will close automatically after 10 seconds...");
+
+  // Wait for 10 seconds
+  tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+
+  println!("10 seconds elapsed, closing DevEngine...");
+
+  // Call the close method to clean up resources
+  dev_engine.close().await.unwrap();
+
+  println!("DevEngine closed successfully!");
 }

--- a/crates/rolldown/src/dev/watcher_event_service.rs
+++ b/crates/rolldown/src/dev/watcher_event_service.rs
@@ -9,6 +9,7 @@ use crate::dev::{
 
 pub enum WatcherEventServiceMsg {
   FileChange(FileChangeResult),
+  Close,
 }
 
 pub type WatcherEventServiceTx = UnboundedSender<WatcherEventServiceMsg>;
@@ -29,6 +30,10 @@ impl WatcherEventService {
 
   pub fn create_event_handler(&self) -> WatcherEventHandler {
     WatcherEventHandler { service_tx: self.tx.clone() }
+  }
+
+  pub fn tx(&self) -> &WatcherEventServiceTx {
+    &self.tx
   }
 
   pub async fn run(mut self) {
@@ -71,6 +76,9 @@ impl WatcherEventService {
             eprintln!("notify error: {e:?}");
           }
         },
+        WatcherEventServiceMsg::Close => {
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
Implement comprehensive cleanup functionality for DevEngine:
- Add atomic boolean to track closed state and prevent double-close
- Introduce Close message to WatcherEventService for graceful shutdown
- Store service sender tx for proper channel closure
- Unwatch all files using batch operations
- Wait for service termination with timeout protection
- Update dev.rs example to demonstrate close method usage

The close method ensures all resources are properly cleaned up:
watchers, services, file tracking, and background tasks.