### PR TITLE
feat: handle errors from `BundlerBuilder#build`

### DIFF
--- a/crates/bench/benches/scan.rs
+++ b/crates/bench/benches/scan.rs
@@ -22,7 +22,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     .for_each(|item| {
       group.bench_function(format!("scan@{}", item.name), move |b| {
         b.to_async(tokio::runtime::Runtime::new().unwrap()).iter(|| async {
-          let mut rolldown_bundler = rolldown::Bundler::new(item.options.clone());
+          let mut rolldown_bundler =
+            rolldown::Bundler::new(item.options.clone()).expect("Failed to create bundler");
           let _output = rolldown_bundler.scan(vec![]).await.expect("should not failed in scan");
         });
       });

--- a/crates/rolldown/examples/basic.rs
+++ b/crates/rolldown/examples/basic.rs
@@ -15,7 +15,8 @@ async fn main() {
     cwd: Some(workspace::crate_dir("rolldown").join("./examples/basic").normalize()),
     sourcemap: Some(SourceMapType::File),
     ..Default::default()
-  });
+  })
+  .expect("Failed to create bundler");
 
   let _result = bundler.write().await.unwrap();
 }

--- a/crates/rolldown/examples/build_bench_rome_ts.rs
+++ b/crates/rolldown/examples/build_bench_rome_ts.rs
@@ -18,7 +18,8 @@ async fn main() {
     shim_missing_exports: Some(true), // Need this due rome is not written with `isolatedModules: true`
     tsconfig: Some(root.join("tmp/bench/rome/src/tsconfig.json").to_str().unwrap().to_string()),
     ..Default::default()
-  });
+  })
+  .expect("Failed to create bundler");
 
   let _result = bundler.write().await.unwrap();
 }

--- a/crates/rolldown/examples/build_bench_threejs10x.rs
+++ b/crates/rolldown/examples/build_bench_threejs10x.rs
@@ -16,7 +16,8 @@ async fn main() {
     cwd: Some(project_root.join("examples")),
     sourcemap: Some(SourceMapType::File),
     ..Default::default()
-  });
+  })
+  .expect("Failed to create bundler");
 
   let _result = bundler.write().await.unwrap();
 }

--- a/crates/rolldown/examples/watch.rs
+++ b/crates/rolldown/examples/watch.rs
@@ -14,7 +14,8 @@ async fn main() {
 
     experimental: Some(ExperimentalOptions { incremental_build: Some(true), ..Default::default() }),
     ..Default::default()
-  });
+  })
+  .expect("Failed to create bundler");
   let watcher = Watcher::new(vec![Arc::new(Mutex::new(bundler))], None).unwrap();
   watcher.start().await;
 }

--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -45,11 +45,14 @@ pub struct Bundler {
 }
 
 impl Bundler {
-  pub fn new(options: BundlerOptions) -> Self {
+  pub fn new(options: BundlerOptions) -> BuildResult<Self> {
     BundlerBuilder::default().with_options(options).build()
   }
 
-  pub fn with_plugins(options: BundlerOptions, plugins: Vec<SharedPluginable>) -> Self {
+  pub fn with_plugins(
+    options: BundlerOptions,
+    plugins: Vec<SharedPluginable>,
+  ) -> BuildResult<Self> {
     BundlerBuilder::default().with_options(options).with_plugins(plugins).build()
   }
 }
@@ -436,10 +439,10 @@ impl Drop for CacheGuard<'_> {
 
 fn _test_bundler() {
   fn assert_send(_foo: impl Send) {}
-  let mut bundler = Bundler::new(BundlerOptions::default());
+  let mut bundler = Bundler::new(BundlerOptions::default()).expect("Failed to create bundler");
   let write_fut = bundler.write();
   assert_send(write_fut);
-  let mut bundler = Bundler::new(BundlerOptions::default());
+  let mut bundler = Bundler::new(BundlerOptions::default()).expect("Failed to create bundler");
   let generate_fut = bundler.generate();
   assert_send(generate_fut);
 }

--- a/crates/rolldown/src/dev/dev_engine.rs
+++ b/crates/rolldown/src/dev/dev_engine.rs
@@ -35,7 +35,7 @@ pub struct DevEngine {
 
 impl DevEngine {
   pub fn new(bundler_builder: BundlerBuilder, options: DevOptions) -> BuildResult<Self> {
-    Self::with_bundler(Arc::new(Mutex::new(bundler_builder.build())), options)
+    Self::with_bundler(Arc::new(Mutex::new(bundler_builder.build()?)), options)
   }
 
   pub fn with_bundler(bundler: Arc<Mutex<Bundler>>, options: DevOptions) -> BuildResult<Self> {

--- a/crates/rolldown_binding/src/binding_bundler_impl.rs
+++ b/crates/rolldown_binding/src/binding_bundler_impl.rs
@@ -85,8 +85,19 @@ impl BindingBundlerImpl {
       .with_session(session)
       .with_disable_tracing_setup(true);
 
+    // TODO: improve the following error message
+    let bundler = bundler_builder.build().map_err(|err| {
+      napi::Error::new(
+        napi::Status::GenericFailure,
+        format!(
+          "Failed to create bundler:\n{}",
+          err.iter().map(|e| e.to_diagnostic().to_string()).collect::<Vec<_>>().join("\n")
+        ),
+      )
+    })?;
+
     Ok(Self {
-      inner: Arc::new(Mutex::new(bundler_builder.build())),
+      inner: Arc::new(Mutex::new(bundler)),
       memory_adjustment: Arc::new(AtomicI64::new(0)),
     })
   }

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -58,7 +58,7 @@ impl IntegrationTest {
   pub async fn bundle(&self, mut options: BundlerOptions) -> BuildResult<BundleOutput> {
     self.apply_test_defaults(&mut options);
 
-    let mut bundler = Bundler::new(options);
+    let mut bundler = Bundler::new(options)?;
 
     if self.test_meta.write_to_disk {
       if bundler.options().out_dir.as_path().is_dir() {
@@ -123,7 +123,8 @@ impl IntegrationTest {
         named_options.options.dir.as_ref().map_or("dist", |v| v)
       );
 
-      let mut bundler = Bundler::with_plugins(named_options.options, plugins.clone());
+      let mut bundler = Bundler::with_plugins(named_options.options, plugins.clone())
+        .expect("Failed to create bundler");
 
       let debug_title = named_options.description.clone().unwrap_or_else(String::new);
 

--- a/crates/rolldown_testing/src/utils.rs
+++ b/crates/rolldown_testing/src/utils.rs
@@ -9,7 +9,7 @@ pub fn assert_bundled(options: BundlerOptions) {
     .build()
     .expect("Failed building the Runtime")
     .block_on(async move {
-      let mut bundler = rolldown::Bundler::new(options);
+      let mut bundler = rolldown::Bundler::new(options).expect("Failed to create bundler");
       bundler.generate().await
     });
   assert!(result.is_ok(), "Failed to bundle.");


### PR DESCRIPTION
In `BundlerBuilder#build`, some option-related errors or other issues cannot be represented as warnings, so we need to provide proper error handling for build failures.