### PR TITLE
chore: fix warnings reported by `just lint`

### DIFF
--- a/crates/bench/benches/bundle.rs
+++ b/crates/bench/benches/bundle.rs
@@ -6,16 +6,13 @@ use rolldown_common::BundlerOptions;
 use rolldown_testing::bundler_options_presets::{multi_duplicated_symbol, rome_ts, threejs};
 
 fn items() -> Vec<(&'static str, BundlerOptions)> {
-  let mut result = vec![
+  vec![
     ("threejs", threejs()),
     ("rome_ts", rome_ts()),
     ("multi-duplicated-top-level-symbol", multi_duplicated_symbol()),
-  ];
-  #[cfg(not(feature = "codspeed"))]
-  {
-    result.push(("threejs10x", rolldown_testing::bundler_options_presets::threejs10x()));
-  }
-  result
+    #[cfg(not(feature = "codspeed"))]
+    ("threejs10x", rolldown_testing::bundler_options_presets::threejs10x()),
+  ]
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/crates/bench/benches/scan.rs
+++ b/crates/bench/benches/scan.rs
@@ -5,12 +5,12 @@ use rolldown_common::BundlerOptions;
 use rolldown_testing::bundler_options_presets::{rome_ts, threejs};
 
 fn items() -> Vec<(&'static str, BundlerOptions)> {
-  let mut result = vec![("threejs", threejs()), ("rome_ts", rome_ts())];
-  #[cfg(not(feature = "codspeed"))]
-  {
-    result.push(("threejs10x", rolldown_testing::bundler_options_presets::threejs10x()));
-  }
-  result
+  vec![
+    ("threejs", threejs()),
+    ("rome_ts", rome_ts()),
+    #[cfg(not(feature = "codspeed"))]
+    ("threejs10x", rolldown_testing::bundler_options_presets::threejs10x()),
+  ]
 }
 
 fn criterion_benchmark(c: &mut Criterion) {


### PR DESCRIPTION
```bash
warning: variable does not need to be mutable
 --> crates\bench\benches\scan.rs:8:7
  |
8 |   let mut result = vec![("threejs", threejs()), ("rome_ts", rome_ts())];
  |       ----^^^^^^
  |       |
  |       help: remove this `mut`
  |
  = note: `#[warn(unused_mut)]` on by default

warning: variable does not need to be mutable
 --> crates\bench\benches\bundle.rs:9:7
  |
9 |   let mut result = vec![
  |       ----^^^^^^
  |       |
  |       help: remove this `mut`
  |
  = note: `#[warn(unused_mut)]` on by default
```
