### PR TITLE
feat: add compare_contents_for_polling option to dev watcher

### DIFF
--- a/crates/rolldown/src/dev/dev_engine.rs
+++ b/crates/rolldown/src/dev/dev_engine.rs
@@ -52,6 +52,7 @@ impl DevEngine {
     let watcher_config = WatcherConfig {
       poll_interval: ctx.options.poll_interval,
       debounce_delay: ctx.options.debounce_duration,
+      compare_contents_for_polling: ctx.options.compare_contents_for_polling,
     };
 
     let watcher = {

--- a/crates/rolldown/src/dev/dev_options.rs
+++ b/crates/rolldown/src/dev/dev_options.rs
@@ -15,6 +15,8 @@ pub struct DevWatchOptions {
   pub use_debounce: Option<bool>,
   /// Debounce duration in milliseconds (only used when use_debounce is true)
   pub debounce_duration: Option<u64>,
+  /// Whether to compare file contents for poll-based watchers (only used when use_polling is true)
+  pub compare_contents_for_polling: Option<bool>,
 }
 
 #[derive(Default)]
@@ -25,6 +27,7 @@ pub struct DevOptions {
   pub watch: Option<DevWatchOptions>,
 }
 
+#[expect(clippy::struct_excessive_bools)]
 pub struct NormalizedDevOptions {
   pub on_hmr_updates: Option<OnHmrUpdatesCallback>,
   pub eager_rebuild: bool,
@@ -32,6 +35,7 @@ pub struct NormalizedDevOptions {
   pub poll_interval: u64,
   pub use_debounce: bool,
   pub debounce_duration: u64,
+  pub compare_contents_for_polling: bool,
 }
 
 pub fn normalize_dev_options(options: DevOptions) -> NormalizedDevOptions {
@@ -43,5 +47,6 @@ pub fn normalize_dev_options(options: DevOptions) -> NormalizedDevOptions {
     poll_interval: watch_options.poll_interval.unwrap_or(100),
     use_debounce: watch_options.use_debounce.unwrap_or(true),
     debounce_duration: watch_options.debounce_duration.unwrap_or(10),
+    compare_contents_for_polling: watch_options.compare_contents_for_polling.unwrap_or(false),
   }
 }

--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -36,6 +36,8 @@ impl BindingDevEngine {
     let poll_interval = watch_options.and_then(|watch| watch.poll_interval);
     let use_debounce = watch_options.and_then(|watch| watch.use_debounce);
     let debounce_duration = watch_options.and_then(|watch| watch.debounce_duration);
+    let compare_contents_for_polling =
+      watch_options.and_then(|watch| watch.compare_contents_for_polling);
 
     // If callback is provided, wrap it to convert Vec<HmrUpdate> to Vec<BindingHmrUpdate>
     let on_hmr_updates = on_hmr_updates_callback.map(|js_callback| {
@@ -53,12 +55,14 @@ impl BindingDevEngine {
       || poll_interval.is_some()
       || use_debounce.is_some()
       || debounce_duration.is_some()
+      || compare_contents_for_polling.is_some()
     {
       Some(rolldown::dev::dev_options::DevWatchOptions {
         use_polling,
         poll_interval: poll_interval.map(u64::from),
         use_debounce,
         debounce_duration: debounce_duration.map(u64::from),
+        compare_contents_for_polling,
       })
     } else {
       None

--- a/crates/rolldown_binding/src/binding_dev_options.rs
+++ b/crates/rolldown_binding/src/binding_dev_options.rs
@@ -9,6 +9,7 @@ pub struct BindingDevWatchOptions {
   pub poll_interval: Option<u32>,
   pub use_debounce: Option<bool>,
   pub debounce_duration: Option<u32>,
+  pub compare_contents_for_polling: Option<bool>,
 }
 
 #[napi(object, object_to_js = false)]

--- a/crates/rolldown_watcher/src/watcher_config.rs
+++ b/crates/rolldown_watcher/src/watcher_config.rs
@@ -13,6 +13,13 @@ pub struct WatcherConfig {
   ///
   /// ⚠️Only take effect for poll-based watchers.
   pub poll_interval: u64,
+
+  /// Whether to compare file contents for poll-based watchers.
+  /// When enabled, poll watchers will check file contents to determine if they actually changed.
+  /// Default to false.
+  ///
+  /// ⚠️Only take effect for poll-based watchers.
+  pub compare_contents_for_polling: bool,
 }
 
 impl Default for WatcherConfig {
@@ -21,6 +28,7 @@ impl Default for WatcherConfig {
       debounce_delay: 10,
       // Chokidar's default poll interval is 100ms
       poll_interval: 100,
+      compare_contents_for_polling: false,
     }
   }
 }
@@ -37,6 +45,6 @@ impl WatcherConfig {
   pub fn to_notify_config(&self) -> notify::Config {
     notify::Config::default()
       .with_poll_interval(self.poll_interval_duration())
-      .with_compare_contents(false)
+      .with_compare_contents(self.compare_contents_for_polling)
   }
 }

--- a/packages/rolldown/src/api/dev/dev-engine.ts
+++ b/packages/rolldown/src/api/dev/dev-engine.ts
@@ -28,6 +28,7 @@ export class DevEngine {
         pollInterval: devOptions.watch.pollInterval,
         useDebounce: devOptions.watch.useDebounce,
         debounceDuration: devOptions.watch.debounceDuration,
+        compareContentsForPolling: devOptions.watch.compareContentsForPolling,
       },
     };
 

--- a/packages/rolldown/src/api/dev/dev-options.ts
+++ b/packages/rolldown/src/api/dev/dev-options.ts
@@ -21,6 +21,12 @@ export interface DevWatchOptions {
    * @default 10
    */
   debounceDuration?: number;
+  /**
+   * Whether to compare file contents for poll-based watchers (only used when usePolling is true).
+   * When enabled, poll watchers will check file contents to determine if they actually changed.
+   * @default false
+   */
+  compareContentsForPolling?: boolean;
 }
 
 export interface DevOptions {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1583,6 +1583,7 @@ export interface BindingDevWatchOptions {
   pollInterval?: number
   useDebounce?: boolean
   debounceDuration?: number
+  compareContentsForPolling?: boolean
 }
 
 export interface BindingDynamicImportVarsPluginConfig {


### PR DESCRIPTION
Adds support for compare_contents option in poll-based watchers to
enable content comparison for better change detection.

Changes:
- Add compare_contents_for_polling field to WatcherConfig (defaults to false)
- Expose option through DevWatchOptions in both Rust and TypeScript APIs
- Update NAPI binding to pass option from TS to Rust
- Auto-generated binding.d.ts now includes the new option