### PR TITLE
chore: enable compare_contents_for_polling and update poll interval for CI test-dev-server

### DIFF
--- a/packages/test-dev-server/src/utils/get-dev-watch-options-for-ci.ts
+++ b/packages/test-dev-server/src/utils/get-dev-watch-options-for-ci.ts
@@ -3,8 +3,9 @@ import { DevWatchOptions } from 'rolldown/experimental';
 export function getDevWatchOptionsForCi(): DevWatchOptions {
   return {
     usePolling: true,
-    pollInterval: 25,
+    pollInterval: 40,
     useDebounce: true,
     debounceDuration: 200,
+    compareContentsForPolling: true,
   };
 }


### PR DESCRIPTION
Optimizes CI file watching by enabling content comparison and adjusting timing:
- Enable compareContentsForPolling: true for more reliable change detection
- Increase pollInterval from 25ms to 40ms to reduce CPU usage while maintaining responsiveness