### PR TITLE
feat(dev): return whether the build is already scheduled from `scheduleBuildIfStale` method

### DIFF
--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -104,9 +104,7 @@ impl BindingDevEngine {
   #[napi]
   pub async fn schedule_build_if_stale(&self) -> Option<ScheduledBuild> {
     let result = self.inner.schedule_build_if_stale().await.expect("Should handle this error");
-    result.and_then(|(future, already_scheduled)| {
-      (!already_scheduled).then(|| ScheduledBuild { future })
-    })
+    result.map(|(future, already_scheduled)| ScheduledBuild { future, already_scheduled })
   }
 
   #[napi]
@@ -124,6 +122,7 @@ impl BindingDevEngine {
 #[napi]
 pub struct ScheduledBuild {
   future: BuildProcessFuture,
+  already_scheduled: bool,
 }
 
 #[napi]
@@ -132,5 +131,10 @@ impl ScheduledBuild {
   pub async fn wait(&self) -> napi::Result<()> {
     self.future.clone().await;
     Ok(())
+  }
+
+  #[napi]
+  pub fn already_scheduled(&self) -> bool {
+    self.already_scheduled
   }
 }

--- a/packages/rolldown/src/api/dev/dev-engine.ts
+++ b/packages/rolldown/src/api/dev/dev-engine.ts
@@ -68,14 +68,16 @@ export class DevEngine {
   /**
    * Returns true if a new build is scheduled.
    */
-  async scheduleBuildIfStale(): Promise<boolean> {
+  async scheduleBuildIfStale(): Promise<
+    'scheduled' | 'alreadyScheduled' | undefined
+  > {
     const scheduled = await this.#inner.scheduleBuildIfStale();
     if (scheduled) {
       // don't wait here as we want to return the result without waiting the actual build
       scheduled.wait().catch(() => {});
-      return true;
+      return scheduled.alreadyScheduled() ? 'alreadyScheduled' : 'scheduled';
     }
-    return false;
+    return undefined;
   }
 
   async invalidate(

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1444,6 +1444,7 @@ export declare class ParallelJsPluginRegistry {
 
 export declare class ScheduledBuild {
   wait(): Promise<void>
+  alreadyScheduled(): boolean
 }
 
 export declare class TraceSubscriberGuard {


### PR DESCRIPTION
refs #6087
refs https://github.com/vitejs/rolldown-vite/pull/401