### PR TITLE
chore: Revert "refactor: simplify module_namespace construction (#5939)"

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -328,76 +328,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
   #[expect(clippy::too_many_lines)]
   fn generate_declaration_of_module_namespace_object(&self) -> Vec<ast::Statement<'ast>> {
-    let module_namespace_included_reason = self.ctx.linking_info.module_namespace_included_reason;
-    let is_namespace_referenced = matches!(self.ctx.module.exports_kind, ExportsKind::Esm)
-      && if module_namespace_included_reason.contains(ModuleNamespaceIncludedReason::Unknown) {
-        true
-      } else if module_namespace_included_reason
-        .contains(ModuleNamespaceIncludedReason::ReExportExternalModule)
-      {
-        // If the module namespace is only used to reexport external module,
-        // then we need to ensure if it is still has dynamic exports after flatten entry level
-        // external module, see `find_entry_level_external_module`
-        self.ctx.linking_info.has_dynamic_exports
-      } else {
-        false
-      };
-
-    if !is_namespace_referenced {
-      return vec![];
-    }
-
     let binding_name_for_namespace_object_ref =
       self.canonical_name_for(self.ctx.module.namespace_object_ref);
+    // construct `var [binding_name_for_namespace_object_ref] = {}`
+    let decl_stmt = self.snippet.var_decl_stmt(
+      binding_name_for_namespace_object_ref,
+      ast::Expression::ObjectExpression(ArenaBox::new_in(
+        ObjectExpression::dummy(self.alloc),
+        self.alloc,
+      )),
+    );
 
-    // construct `{ prop_name: () => returned, ... }`
-    let mut arg_obj_expr = ast::ObjectExpression::dummy(self.alloc);
-
-    arg_obj_expr.properties.extend(self.ctx.linking_info.canonical_exports(false).map(
-      |(export, resolved_export)| {
-        // prop_name: () => returned
-        let prop_name = export;
-        let returned = self.finalized_expr_for_symbol_ref(resolved_export.symbol_ref, false, false);
-        ast::ObjectPropertyKind::ObjectProperty(
-          ast::ObjectProperty {
-            key: if is_validate_identifier_name(prop_name) {
-              ast::PropertyKey::StaticIdentifier(
-                self.snippet.id_name(prop_name, SPAN).into_in(self.alloc),
-              )
-            } else {
-              ast::PropertyKey::StringLiteral(self.snippet.alloc_string_literal(prop_name, SPAN))
-            },
-            value: self.snippet.only_return_arrow_expr(returned),
-            ..ast::ObjectProperty::dummy(self.alloc)
-          }
-          .into_in(self.alloc),
-        )
-      },
-    ));
-
-    // if there is no export, we should generate `var ns = {}` instead of `var ns = __export({}, {})`
-    // else construct `__export(ns_name, { prop_name: () => returned, ... })`
-    let module_namespace_rhs = if arg_obj_expr.properties.is_empty() {
-      Expression::ObjectExpression(self.builder().alloc(arg_obj_expr))
-    } else {
-      self.snippet.builder.expression_call(
-        SPAN,
-        self.finalized_expr_for_runtime_symbol("__export"),
-        NONE,
-        self.snippet.builder.vec_from_array([
-          ast::Argument::from(ast::Expression::ObjectExpression(ArenaBox::new_in(
-            ObjectExpression::dummy(self.alloc),
-            self.alloc,
-          ))),
-          ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.alloc)),
-        ]),
-        false,
-      )
-    };
-
-    // construct `var [binding_name_for_namespace_object_ref] = __export(...)`
-    let decl_stmt =
-      self.snippet.var_decl_stmt(binding_name_for_namespace_object_ref, module_namespace_rhs);
+    let has_exports = self.ctx.linking_info.canonical_exports(false).next().is_some();
 
     let export_all_externals_rec_ids = &self.ctx.linking_info.star_exports_from_external_modules;
 
@@ -470,7 +412,50 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       }
     }
 
-    let mut ret = vec![decl_stmt];
+    if !has_exports {
+      let mut ret = vec![decl_stmt];
+      ret.extend(re_export_external_stmts.unwrap_or_default());
+      return ret;
+    }
+
+    // construct `{ prop_name: () => returned, ... }`
+    let mut arg_obj_expr = ast::ObjectExpression::dummy(self.alloc);
+
+    arg_obj_expr.properties.extend(self.ctx.linking_info.canonical_exports(false).map(
+      |(export, resolved_export)| {
+        // prop_name: () => returned
+        let prop_name = export;
+        let returned = self.finalized_expr_for_symbol_ref(resolved_export.symbol_ref, false, false);
+        ast::ObjectPropertyKind::ObjectProperty(
+          ast::ObjectProperty {
+            key: if is_validate_identifier_name(prop_name) {
+              ast::PropertyKey::StaticIdentifier(
+                self.snippet.id_name(prop_name, SPAN).into_in(self.alloc),
+              )
+            } else {
+              ast::PropertyKey::StringLiteral(self.snippet.alloc_string_literal(prop_name, SPAN))
+            },
+            value: self.snippet.only_return_arrow_expr(returned),
+            ..ast::ObjectProperty::dummy(self.alloc)
+          }
+          .into_in(self.alloc),
+        )
+      },
+    ));
+
+    // construct `__export(ns_name, { prop_name: () => returned, ... })`
+    let export_call_expr = self.snippet.builder.expression_call(
+      SPAN,
+      self.finalized_expr_for_runtime_symbol("__export"),
+      NONE,
+      self.snippet.builder.vec_from_array([
+        ast::Argument::from(self.snippet.id_ref_expr(binding_name_for_namespace_object_ref, SPAN)),
+        ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.alloc)),
+      ]),
+      false,
+    );
+    let export_call_stmt = self.snippet.builder.statement_expression(SPAN, export_call_expr);
+    let mut ret = vec![decl_stmt, export_call_stmt];
     ret.extend(re_export_external_stmts.unwrap_or_default());
 
     ret

--- a/crates/rolldown/src/runtime/runtime-base.js
+++ b/crates/rolldown/src/runtime/runtime-base.js
@@ -17,7 +17,6 @@ export var __commonJSMin = (cb, mod) => () => (mod || cb((mod = { exports: {} })
 export var __export = (target, all) => {
   for (var name in all)
     __defProp(target, name, { get: all[name], enumerable: true })
-  return target;
 }
 export var __copyProps = (to, from, except, desc) => {
   if (from && typeof from === 'object' || typeof from === 'function')

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index-module.js
-var index_module_exports = __export({}, { foo: () => foo });
+var index_module_exports = {};
+__export(index_module_exports, { foo: () => foo });
 var foo;
 var init_index_module = __esm({ "node_modules/demo-pkg/index-module.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index-module.js
-var index_module_exports = __export({}, { foo: () => foo });
+var index_module_exports = {};
+__export(index_module_exports, { foo: () => foo });
 var foo;
 var init_index_module = __esm({ "node_modules/demo-pkg/index-module.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index.js
-var demo_pkg_exports = __export({}, { foo: () => foo });
+var demo_pkg_exports = {};
+__export(demo_pkg_exports, { foo: () => foo });
 var foo;
 var init_demo_pkg = __esm({ "node_modules/demo-pkg/index.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index.js
-var demo_pkg_exports = __export({}, { foo: () => foo });
+var demo_pkg_exports = {};
+__export(demo_pkg_exports, { foo: () => foo });
 const foo = 123;
 console.log("hello");
 

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
@@ -18,7 +18,8 @@ var init_lib = __esm({ "lib.js": (() => {
 
 //#endregion
 //#region cjs.js
-var cjs_exports = __export({}, { default: () => cjs_default });
+var cjs_exports = {};
+__export(cjs_exports, { default: () => cjs_default });
 var cjs_default;
 var init_cjs = __esm({ "cjs.js": (() => {
 	init_lib();

--- a/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, { foo: () => foo$1 });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo$1 });
 function foo$1() {
 	return "foo";
 }
@@ -18,7 +19,8 @@ var init_foo = __esm({ "foo.js": (() => {}) });
 
 //#endregion
 //#region bar.js
-var bar_exports = __export({}, { bar: () => bar$1 });
+var bar_exports = {};
+__export(bar_exports, { bar: () => bar$1 });
 function bar$1() {
 	return "bar";
 }

--- a/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
@@ -15,7 +15,8 @@ var init_a = __esm({ "a.js": (() => {
 
 //#endregion
 //#region b.js
-var b_exports = __export({}, { xyz: () => xyz });
+var b_exports = {};
+__export(b_exports, { xyz: () => xyz });
 var xyz;
 var init_b = __esm({ "b.js": (() => {
 	xyz = null;
@@ -23,7 +24,8 @@ var init_b = __esm({ "b.js": (() => {
 
 //#endregion
 //#region commonjs.js
-var commonjs_exports = __export({}, {
+var commonjs_exports = {};
+__export(commonjs_exports, {
 	C: () => Class,
 	Class: () => Class,
 	Fn: () => Fn,
@@ -48,7 +50,8 @@ var init_commonjs = __esm({ "commonjs.js": (() => {
 
 //#endregion
 //#region c.js
-var c_exports = __export({}, { default: () => c_default });
+var c_exports = {};
+__export(c_exports, { default: () => c_default });
 var c_default;
 var init_c = __esm({ "c.js": (() => {
 	c_default = class {};
@@ -56,7 +59,8 @@ var init_c = __esm({ "c.js": (() => {
 
 //#endregion
 //#region d.js
-var d_exports = __export({}, { default: () => Foo });
+var d_exports = {};
+__export(d_exports, { default: () => Foo });
 var Foo;
 var init_d = __esm({ "d.js": (() => {
 	Foo = class {};
@@ -65,13 +69,15 @@ var init_d = __esm({ "d.js": (() => {
 
 //#endregion
 //#region e.js
-var e_exports = __export({}, { default: () => e_default });
+var e_exports = {};
+__export(e_exports, { default: () => e_default });
 function e_default() {}
 var init_e = __esm({ "e.js": (() => {}) });
 
 //#endregion
 //#region f.js
-var f_exports = __export({}, { default: () => foo$1 });
+var f_exports = {};
+__export(f_exports, { default: () => foo$1 });
 function foo$1() {}
 var init_f = __esm({ "f.js": (() => {
 	foo$1.prop = 123;
@@ -79,13 +85,15 @@ var init_f = __esm({ "f.js": (() => {
 
 //#endregion
 //#region g.js
-var g_exports = __export({}, { default: () => g_default });
+var g_exports = {};
+__export(g_exports, { default: () => g_default });
 async function g_default() {}
 var init_g = __esm({ "g.js": (() => {}) });
 
 //#endregion
 //#region h.js
-var h_exports = __export({}, { default: () => foo });
+var h_exports = {};
+__export(h_exports, { default: () => foo });
 async function foo() {}
 var init_h = __esm({ "h.js": (() => {
 	foo.prop = 123;

--- a/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
@@ -12,7 +12,8 @@ const abc = void 0;
 
 //#endregion
 //#region b.js
-var b_exports = __export({}, { xyz: () => xyz });
+var b_exports = {};
+__export(b_exports, { xyz: () => xyz });
 const xyz = null;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
@@ -24,7 +24,8 @@ const abc = void 0;
 
 //#endregion
 //#region b.js
-var b_exports = __export({}, { xyz: () => xyz });
+var b_exports = {};
+__export(b_exports, { xyz: () => xyz });
 const xyz = null;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
@@ -33,7 +33,8 @@ export { b_default as default };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region b.js
-var b_exports = __export({}, { default: () => b_default });
+var b_exports = {};
+__export(b_exports, { default: () => b_default });
 function b_default() {}
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
@@ -11,12 +11,14 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region foo/test.js
-var test_exports = __export({}, { foo: () => foo });
+var test_exports = {};
+__export(test_exports, { foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports$1 = __export({}, { bar: () => bar });
+var test_exports$1 = {};
+__export(test_exports$1, { bar: () => bar });
 let bar = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
@@ -11,22 +11,26 @@ import { ns } from "x";
 
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = __export({}, { ns: () => ns$1 });
+var a_exports = {};
+__export(a_exports, { ns: () => ns$1 });
 var init_a = __esm({ "a.js": (() => {}) });
 
 //#endregion
 //#region b.js
-var b_exports = __export({}, { ns: () => ns$1 });
+var b_exports = {};
+__export(b_exports, { ns: () => ns$1 });
 var init_b = __esm({ "b.js": (() => {}) });
 
 //#endregion
 //#region c.js
-var c_exports = __export({}, { ns: () => ns$1 });
+var c_exports = {};
+__export(c_exports, { ns: () => ns$1 });
 var init_c = __esm({ "c.js": (() => {}) });
 
 //#endregion
 //#region d.js
-var d_exports = __export({}, { ns: () => ns });
+var d_exports = {};
+__export(d_exports, { ns: () => ns });
 var init_d = __esm({ "d.js": (() => {}) });
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/forbid_string_export_names_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/forbid_string_export_names_bundle/artifacts.snap
@@ -16,7 +16,8 @@ let nested$1 = 2;
 
 //#endregion
 //#region nested.js
-var nested_exports = __export({}, {
+var nested_exports = {};
+__export(nested_exports, {
 	"nested name": () => nested,
 	"very nested name": () => nested$1
 });

--- a/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = __export({}, { esm_foo_: () => esm_foo_ });
+var esm_exports = {};
+__export(esm_exports, { esm_foo_: () => esm_foo_ });
 var esm_foo_;
 var init_esm = __esm({ "esm.js": (() => {
 	esm_foo_ = "foo";

--- a/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
@@ -9,12 +9,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region foo/test.js
-var test_exports = __export({}, { foo: () => foo });
+var test_exports = {};
+__export(test_exports, { foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports$1 = __export({}, { bar: () => bar });
+var test_exports$1 = {};
+__export(test_exports$1, { bar: () => bar });
 let bar = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
@@ -9,7 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
-var entry_exports = __export({}, { foo: () => foo });
+var entry_exports = {};
+__export(entry_exports, { foo: () => foo });
 const foo = 123;
 console.log(entry_exports);
 

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
@@ -9,7 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
-var entry_exports = __export({}, { foo: () => foo });
+var entry_exports = {};
+__export(entry_exports, { foo: () => foo });
 var foo;
 var init_entry = __esm({ "entry.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
@@ -9,7 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
-var entry_exports = __export({}, {
+var entry_exports = {};
+__export(entry_exports, {
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region entry.js
-var entry_exports = __export({}, {
+var entry_exports = {};
+__export(entry_exports, {
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
@@ -231,7 +231,8 @@ console.log(internal_default, internal_exports);
 ```js
 // HIDDEN [rolldown:runtime]
 //#region internal.js
-var internal_exports = __export({}, { default: () => internal_default });
+var internal_exports = {};
+__export(internal_exports, { default: () => internal_default });
 var internal_default = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region entry.js
-var entry_exports = __export({}, {
+var entry_exports = {};
+__export(entry_exports, {
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, { foo: () => foo });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo });
 var foo;
 var init_foo = __esm({ "foo.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, { foo: () => foo$1 });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, { foo: () => foo$1 });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, { foo: () => foo$1 });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
@@ -14,7 +14,8 @@ const foo$1 = 123;
 
 //#endregion
 //#region bar.js
-var bar_exports = __export({}, { foo: () => foo$1 });
+var bar_exports = {};
+__export(bar_exports, { foo: () => foo$1 });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
@@ -18,7 +18,8 @@ const z = 4;
 
 //#endregion
 //#region common.js
-var common_exports = __export({}, {
+var common_exports = {};
+__export(common_exports, {
 	x: () => x,
 	z: () => z
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
@@ -10,12 +10,14 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region bar.js
-var bar_exports = __export({}, { bar: () => bar });
+var bar_exports = {};
+__export(bar_exports, { bar: () => bar });
 const bar = 123;
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({}, { bar_ns: () => bar_exports });
+var foo_exports = {};
+__export(foo_exports, { bar_ns: () => bar_exports });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
@@ -12,7 +12,8 @@ const foo = () => "hi there";
 
 //#endregion
 //#region folders/index.js
-var folders_exports = __export({}, { foo: () => foo });
+var folders_exports = {};
+__export(folders_exports, { foo: () => foo });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
@@ -24,7 +24,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, { x: () => x });
+var foo_exports = {};
+__export(foo_exports, { x: () => x });
 const x = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
@@ -28,7 +28,8 @@ const x = 123;
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({}, { x: () => x });
+var foo_exports = {};
+__export(foo_exports, { x: () => x });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
@@ -24,7 +24,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region bar.js
-var bar_exports = __export({}, { x: () => x });
+var bar_exports = {};
+__export(bar_exports, { x: () => x });
 const x = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, {
+var foo_exports = {};
+__export(foo_exports, {
 	foo: () => foo,
 	ns: () => foo_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, {
+var foo_exports = {};
+__export(foo_exports, {
 	foo: () => foo,
 	ns: () => foo_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_and_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_and_common_js/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = __export({}, { foo: () => foo });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo });
 var foo;
 var init_foo = __esm({ "foo.ts": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = __export({}, { foo: () => foo });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo });
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = __export({}, { foo: () => foo });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo });
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = __export({}, { foo: () => foo });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo });
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
@@ -12,7 +12,8 @@ const foo = 123;
 
 //#endregion
 //#region bar.ts
-var bar_exports = __export({}, { foo: () => foo });
+var bar_exports = {};
+__export(bar_exports, { foo: () => foo });
 
 //#endregion
 //#region entry.ts

--- a/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
@@ -12,7 +12,8 @@ var invalid_identifier$1 = true;
 
 //#endregion
 //#region test2.json
-var test2_exports = __export({}, {
+var test2_exports = {};
+__export(test2_exports, {
 	default: () => test2_default,
 	"invalid-identifier": () => invalid_identifier
 });

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.browser.js
-var module_browser_exports = __export({}, { default: () => module_browser_default });
+var module_browser_exports = {};
+__export(module_browser_exports, { default: () => module_browser_default });
 var module_browser_default;
 var init_module_browser = __esm({ "node_modules/demo-pkg/module.browser.js": (() => {
 	module_browser_default = "browser module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({}, { default: () => module_default });
+var module_exports = {};
+__export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main/artifacts.snap
@@ -10,7 +10,8 @@ import assert, { deepEqual } from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({}, { default: () => module_default });
+var module_exports = {};
+__export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({}, { default: () => module_default });
+var module_exports = {};
+__export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({}, { default: () => module_default });
+var module_exports = {};
+__export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({}, { default: () => module_default });
+var module_exports = {};
+__export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_require_only/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_require_only/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({}, { default: () => module_default });
+var module_exports = {};
+__export(module_exports, { default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
@@ -16,7 +16,8 @@ export { foo };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = __export({}, { foo: () => foo });
+var a_exports = {};
+__export(a_exports, { foo: () => foo });
 var foo;
 var init_a = __esm({ "a.js": (() => {
 	;

--- a/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
@@ -8,12 +8,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.ts
-var a_exports = __export({}, { foo: () => foo$3 });
+var a_exports = {};
+__export(a_exports, { foo: () => foo$3 });
 let foo$3 = 123;
 
 //#endregion
 //#region b.ts
-var b_exports = __export({}, { foo: () => foo$2 });
+var b_exports = {};
+__export(b_exports, { foo: () => foo$2 });
 let foo$2 = 123;
 
 //#endregion
@@ -22,7 +24,8 @@ var Test = void 0;
 
 //#endregion
 //#region c.ts
-var c_exports = __export({}, {
+var c_exports = {};
+__export(c_exports, {
 	Test: () => Test,
 	foo: () => foo$1
 });
@@ -30,7 +33,8 @@ let foo$1 = 123;
 
 //#endregion
 //#region d.ts
-var d_exports = __export({}, {
+var d_exports = {};
+__export(d_exports, {
 	Test: () => Test,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
@@ -12,7 +12,8 @@ var nope = void 0;
 
 //#endregion
 //#region foo.ts
-var foo_exports = __export({}, { nope: () => nope });
+var foo_exports = {};
+__export(foo_exports, { nope: () => nope });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region import.ts
-var import_exports = __export({}, { value: () => value });
+var import_exports = {};
+__export(import_exports, { value: () => value });
 let value = 123;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = __export({}, {
+var esm_exports = {};
+__export(esm_exports, {
 	default: () => esm_default_fn,
 	esm_named_class: () => esm_named_class,
 	esm_named_fn: () => esm_named_fn,

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = __export({}, { default: () => esm_default });
+var esm_exports = {};
+__export(esm_exports, { default: () => esm_default });
 var esm_default;
 var init_esm = __esm({ "esm.js": (() => {
 	esm_default = "esm";

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = __export({}, { default: () => esm_default });
+var esm_exports = {};
+__export(esm_exports, { default: () => esm_default });
 var esm_default;
 var init_esm = __esm({ "esm.js": (() => {
 	esm_default = "esm";

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region json.js
-var json_exports = __export({}, { default: () => json_default });
+var json_exports = {};
+__export(json_exports, { default: () => json_default });
 var json_default;
 var init_json = __esm({ "json.js": (() => {
 	json_default = JSON.parse("[1, 2, 3]");

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
@@ -14,7 +14,8 @@ var require_react = /* @__PURE__ */ __commonJS({ "react.js": ((exports, module) 
 
 //#endregion
 //#region lib.js
-var lib_exports = __export({}, { default: () => toArray$1 });
+var lib_exports = {};
+__export(lib_exports, { default: () => toArray$1 });
 function toArray$1(children) {
 	import_react$1.default.Children.forEach(children, function(child) {});
 	return ret;

--- a/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
@@ -20,7 +20,8 @@ const value = 1;
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({}, {
+var foo_exports = {};
+__export(foo_exports, {
 	bar: () => import_commonjs$1.bar,
 	value: () => value
 });

--- a/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = __export({}, { a: () => a$1 });
+var esm_exports = {};
+__export(esm_exports, { a: () => a$1 });
 var a$1;
 var init_esm = __esm({ "esm.js": (() => {
 	a$1 = 100;

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, { foo: () => foo });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo });
 const foo = 1;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
@@ -40,7 +40,8 @@ require("node:assert");
 const require_chunk = require('./chunk.js');
 
 //#region esm.js
-var esm_exports = require_chunk.__export({}, { share: () => share });
+var esm_exports = {};
+require_chunk.__export(esm_exports, { share: () => share });
 function share() {
 	return 1;
 }

--- a/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region lib.prod.js
-var lib_prod_exports = __export({}, { default: () => lib_prod_default });
+var lib_prod_exports = {};
+__export(lib_prod_exports, { default: () => lib_prod_default });
 var lib_prod_default;
 var init_lib_prod = __esm({ "lib.prod.js": (() => {
 	lib_prod_default = "prod";

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
@@ -17,12 +17,14 @@ export { lib_npm_a_exports as libA, lib_npm_b_exports as libB, lib_ui_exports as
 import { __export } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-npm-a/index.js
-var lib_npm_a_exports = __export({}, { default: () => lib_npm_a_default });
+var lib_npm_a_exports = {};
+__export(lib_npm_a_exports, { default: () => lib_npm_a_default });
 var lib_npm_a_default = "npm-a";
 
 //#endregion
 //#region node_modules/lib-npm-b/index.js
-var lib_npm_b_exports = __export({}, { default: () => lib_npm_b_default });
+var lib_npm_b_exports = {};
+__export(lib_npm_b_exports, { default: () => lib_npm_b_default });
 var lib_npm_b_default = "npm-b";
 
 //#endregion
@@ -38,7 +40,6 @@ var __export = (target, all) => {
 		get: all[name],
 		enumerable: true
 	});
-	return target;
 };
 
 //#endregion
@@ -50,7 +51,8 @@ export { __export };
 import { __export } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-ui/index.js
-var lib_ui_exports = __export({}, { default: () => lib_ui_default });
+var lib_ui_exports = {};
+__export(lib_ui_exports, { default: () => lib_ui_default });
 var lib_ui_default = "ui";
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/export_mode/cjs/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/cjs/default/artifacts.snap
@@ -9,7 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region mod.js
-var default_exports = __export({}, { default: () => example });
+var default_exports = {};
+__export(default_exports, { default: () => example });
 function example() {
 	return "default";
 }

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/default/artifacts.snap
@@ -11,7 +11,8 @@ var module = (function() {
 // HIDDEN [rolldown:runtime]
 
 //#region mod.js
-var default_exports = __export({}, {
+var default_exports = {};
+__export(default_exports, {
 	add: () => add,
 	subtract: () => subtract
 });

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
@@ -12,7 +12,8 @@ Object.defineProperty(exports, '__esModule', { value: true });
 // HIDDEN [rolldown:runtime]
 
 //#region mod.js
-var named_exports = __export({}, {
+var named_exports = {};
+__export(named_exports, {
 	add: () => add,
 	subtract: () => subtract
 });

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
@@ -19,7 +19,8 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region esm.js
-var esm_exports = __export({}, { value: () => value });
+var esm_exports = {};
+__export(esm_exports, { value: () => value });
 var value;
 var init_esm = __esm({ "esm.js": (() => {
 	value = 1;

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
@@ -18,7 +18,8 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region esm.js
-var esm_exports = __export({}, { value: () => value });
+var esm_exports = {};
+__export(esm_exports, { value: () => value });
 var value;
 var init_esm = __esm({ "esm.js": (() => {
 	value = 1;

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
@@ -21,7 +21,8 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region esm.js
-var esm_exports = __export({}, { value: () => value });
+var esm_exports = {};
+__export(esm_exports, { value: () => value });
 var value;
 var init_esm = __esm({ "esm.js": (() => {
 	value = 1;

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -10,7 +10,8 @@ import { __esm, __export } from "./rolldown-runtime.js";
 import { init_second, value } from "./second.js";
 
 //#region first.js
-var first_exports = __export({}, { value: () => value$1 });
+var first_exports = {};
+__export(first_exports, { value: () => value$1 });
 var value$1;
 var init_first = __esm({ "first.js": (() => {
 	init_second();
@@ -50,7 +51,8 @@ import { __esm, __export } from "./rolldown-runtime.js";
 import { init_first, value } from "./first.js";
 
 //#region second.js
-var second_exports = __export({}, { value: () => value$1 });
+var second_exports = {};
+__export(second_exports, { value: () => value$1 });
 var value$1;
 var init_second = __esm({ "second.js": (() => {
 	init_first();

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = __export({}, { constant: () => constant });
+var lib_exports = {};
+__export(lib_exports, { constant: () => constant });
 var constant;
 var init_lib = __esm({ "lib.js": (() => {
 	constant = 1;
@@ -49,7 +50,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = __export({}, { constant: () => constant });
+var lib_exports = {};
+__export(lib_exports, { constant: () => constant });
 var constant;
 var init_lib = __esm({ "lib.js": (() => {
 	constant = 1;

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
@@ -10,7 +10,8 @@ import nodeAssert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib-impl.js
-var lib_impl_exports = __export({}, { foo: () => foo });
+var lib_impl_exports = {};
+__export(lib_impl_exports, { foo: () => foo });
 function foo() {
 	return fn();
 }

--- a/crates/rolldown/tests/rolldown/misc/invalid_ident_repr/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/invalid_ident_repr/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region 1aaa.js
-var _1aaa_exports = __export({}, { default: () => _1aaa_default });
+var _1aaa_exports = {};
+__export(_1aaa_exports, { default: () => _1aaa_default });
 const a = "shared.js";
 var _1aaa_default = a;
 

--- a/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = __export({}, { abc: () => abc });
+var a_exports = {};
+__export(a_exports, { abc: () => abc });
 const abc = void 0;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, {
+var foo_exports = {};
+__export(foo_exports, {
 	a: () => a,
 	a1: () => a1,
 	a2: () => a2,

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/artifacts.snap
@@ -10,7 +10,8 @@ export * from "node:fs"
 
 // HIDDEN [rolldown:runtime]
 //#region main.js
-var main_exports = __export({}, { main: () => main });
+var main_exports = {};
+__export(main_exports, { main: () => main });
 import * as import_node_fs from "node:fs";
 __reExport(main_exports, import_node_fs);
 var main;

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
@@ -9,7 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region main.js
-var main_exports = __export({}, { main: () => main });
+var main_exports = {};
+__export(main_exports, { main: () => main });
 __reExport(main_exports, require("node:fs"));
 var main;
 var init_main = __esm({ "main.js": (() => {

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, { default: () => foo$1 });
+var foo_exports = {};
+__export(foo_exports, { default: () => foo$1 });
 function foo$1(a$1$1) {
 	assert.equal(a$1$1, a$1$1);
 	assert.equal(a$1, 1);

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({}, { foo: () => foo$1 });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo$1 });
 function foo$1(a$1$1) {
 	console.log(a$1$1, a$1);
 }

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept-outside-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept-outside-circular/artifacts.snap
@@ -11,21 +11,24 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = __export({}, { c: () => c });
+var c_exports = {};
+__export(c_exports, { c: () => c });
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
 
 //#endregion
 //#region b.js
-var b_exports = __export({}, { b: () => b });
+var b_exports = {};
+__export(b_exports, { b: () => b });
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = __export({}, { a: () => a });
+var a_exports = {};
+__export(a_exports, { a: () => a });
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
@@ -11,7 +11,8 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region child.js
-var child_exports = __export({}, { foo: () => foo });
+var child_exports = {};
+__export(child_exports, { foo: () => foo });
 const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
 __rolldown_runtime__.registerModule("child.js", { exports: child_exports });
 const foo = 0;

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -31,7 +31,8 @@ export default require_exist_dep_cjs();
 import { __export } from "./chunk.js";
 
 //#region exist-dep-esm.js
-var exist_dep_esm_exports = __export({}, { value: () => value });
+var exist_dep_esm_exports = {};
+__export(exist_dep_esm_exports, { value: () => value });
 const exist_dep_esm_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
 __rolldown_runtime__.registerModule("exist-dep-esm.js", { exports: exist_dep_esm_exports });
 const value = "exist-esm";
@@ -46,7 +47,8 @@ import { __export, __reExport, __toCommonJS, __toDynamicImportESM, __toESM } fro
 
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = __export({}, { foo: () => foo });
+var hmr_exports = {};
+__export(hmr_exports, { foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 async function foo() {

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
@@ -9,7 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region sub/foo.js
-var foo_exports = __export({}, {
+var foo_exports = {};
+__export(foo_exports, {
 	foo: () => foo,
 	named: () => named$2
 });
@@ -20,7 +21,8 @@ const named$2 = "foo";
 
 //#endregion
 //#region sub/bar.js
-var bar_exports = __export({}, {
+var bar_exports = {};
+__export(bar_exports, {
 	bar: () => bar,
 	named: () => named$1
 });
@@ -31,14 +33,16 @@ const named$1 = "bar";
 
 //#endregion
 //#region sub/named.js
-var named_exports = __export({}, { named: () => named });
+var named_exports = {};
+__export(named_exports, { named: () => named });
 const named_hot = __rolldown_runtime__.createModuleHotContext("sub/named.js");
 __rolldown_runtime__.registerModule("sub/named.js", { exports: named_exports });
 const named = "named";
 
 //#endregion
 //#region sub/index.js
-var sub_exports = __export({}, {
+var sub_exports = {};
+__export(sub_exports, {
 	bar: () => bar,
 	foo: () => foo,
 	named: () => named

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -9,7 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = __export({}, { foo: () => foo });
+var hmr_exports = {};
+__export(hmr_exports, { foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
@@ -11,7 +11,8 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region self_accept.js
-var self_accept_exports = __export({}, { foo: () => foo$1 });
+var self_accept_exports = {};
+__export(self_accept_exports, { foo: () => foo$1 });
 const self_accept_hot = __rolldown_runtime__.createModuleHotContext("self_accept.js");
 __rolldown_runtime__.registerModule("self_accept.js", { exports: self_accept_exports });
 const foo$1 = "foo";
@@ -21,7 +22,8 @@ self_accept_hot.accept((mod) => {
 
 //#endregion
 //#region single_accept/child.js
-var child_exports$1 = __export({}, { count: () => count$2 });
+var child_exports$1 = {};
+__export(child_exports$1, { count: () => count$2 });
 const child_hot$1 = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
 __rolldown_runtime__.registerModule("single_accept/child.js", { exports: child_exports$1 });
 const count$2 = 0;
@@ -48,7 +50,8 @@ process.on("beforeExit", (code) => {
 
 //#endregion
 //#region array_accept/child.js
-var child_exports = __export({}, { count: () => count });
+var child_exports = {};
+__export(child_exports, { count: () => count });
 const child_hot = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
 __rolldown_runtime__.registerModule("array_accept/child.js", { exports: child_exports });
 const count = 0;
@@ -75,7 +78,8 @@ process.on("beforeExit", (code) => {
 
 //#endregion
 //#region optional_chaining.js
-var optional_chaining_exports = __export({}, { foo: () => foo });
+var optional_chaining_exports = {};
+__export(optional_chaining_exports, { foo: () => foo });
 const optional_chaining_hot = __rolldown_runtime__.createModuleHotContext("optional_chaining.js");
 __rolldown_runtime__.registerModule("optional_chaining.js", { exports: optional_chaining_exports });
 const foo = "foo";

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
@@ -9,28 +9,32 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region common.js
-var common_exports = __export({}, { prefix: () => prefix });
+var common_exports = {};
+__export(common_exports, { prefix: () => prefix });
 const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
 __rolldown_runtime__.registerModule("common.js", { exports: common_exports });
 const prefix = "prefix:";
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({}, { foo: () => foo });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
 
 //#endregion
 //#region bar.js
-var bar_exports = __export({}, { bar: () => bar });
+var bar_exports = {};
+__export(bar_exports, { bar: () => bar });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
 
 //#endregion
 //#region messenger.js
-var messenger_exports = __export({}, {
+var messenger_exports = {};
+__export(messenger_exports, {
 	msg: () => msg,
 	sayMessage: () => sayMessage
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
@@ -9,28 +9,32 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region common.js
-var common_exports = __export({}, { prefix: () => prefix });
+var common_exports = {};
+__export(common_exports, { prefix: () => prefix });
 const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
 __rolldown_runtime__.registerModule("common.js", { exports: common_exports });
 const prefix = "prefix:";
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({}, { foo: () => foo });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
 
 //#endregion
 //#region bar.js
-var bar_exports = __export({}, { bar: () => bar });
+var bar_exports = {};
+__export(bar_exports, { bar: () => bar });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
 
 //#endregion
 //#region messenger.js
-var messenger_exports = __export({}, {
+var messenger_exports = {};
+__export(messenger_exports, {
 	msg: () => msg,
 	sayMessage: () => sayMessage
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -10,7 +10,8 @@ import { __export } from "./chunk.js";
 import { trim } from "./string.js";
 
 //#region bar.js
-var bar_exports = __export({}, { default: () => bar_default });
+var bar_exports = {};
+__export(bar_exports, { default: () => bar_default });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 function bar_default() {
@@ -33,7 +34,8 @@ import { __export } from "./chunk.js";
 import { trim, unused } from "./string.js";
 
 //#region utils/index.js
-var utils_exports = __export({}, {
+var utils_exports = {};
+__export(utils_exports, {
 	trim: () => trim,
 	unused: () => unused
 });
@@ -42,7 +44,8 @@ __rolldown_runtime__.registerModule("utils/index.js", { exports: utils_exports }
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({}, { default: () => foo_default });
+var foo_exports = {};
+__export(foo_exports, { default: () => foo_default });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 function foo_default() {
@@ -75,7 +78,8 @@ const routes = {
 import { __export } from "./chunk.js";
 
 //#region utils/string.js
-var string_exports = __export({}, {
+var string_exports = {};
+__export(string_exports, {
 	trim: () => trim,
 	unused: () => unused
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/no-accept-outside-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/no-accept-outside-circular/artifacts.snap
@@ -11,21 +11,24 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = __export({}, { c: () => c });
+var c_exports = {};
+__export(c_exports, { c: () => c });
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
 
 //#endregion
 //#region b.js
-var b_exports = __export({}, { b: () => b });
+var b_exports = {};
+__export(b_exports, { b: () => b });
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = __export({}, { a: () => a });
+var a_exports = {};
+__export(a_exports, { a: () => a });
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };

--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
@@ -9,7 +9,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = __export({}, { foo: () => foo });
+var hmr_exports = {};
+__export(hmr_exports, { foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -18,7 +18,8 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 //#endregion
 //#region esm.js
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
-var esm_exports = __export({}, { value: () => value });
+var esm_exports = {};
+__export(esm_exports, { value: () => value });
 const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
 __rolldown_runtime__.registerModule("esm.js", { exports: esm_exports });
 const value = "main";

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -100,7 +100,8 @@ assert.strictEqual(requiredUmdLib.foo, "foo");
 
 //#endregion
 //#region cases/manual_reexport/lib.js
-var lib_exports = __export({}, {
+var lib_exports = {};
+__export(lib_exports, {
 	Globals: () => Globals,
 	value: () => value
 });
@@ -112,7 +113,8 @@ const value = "lib";
 
 //#endregion
 //#region cases/manual_reexport/barrel.js
-var barrel_exports = __export({}, {
+var barrel_exports = {};
+__export(barrel_exports, {
 	Globals: () => Globals,
 	value: () => value
 });
@@ -131,7 +133,8 @@ assert.strictEqual(Globals, Object);
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo.mjs
-var foo_exports = __export({}, { foo: () => foo$1 });
+var foo_exports = {};
+__export(foo_exports, { foo: () => foo$1 });
 init_trigger_dep();
 const foo_hot$1 = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo.mjs");
 __rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo.mjs", { exports: foo_exports });
@@ -139,7 +142,8 @@ const foo$1 = "foo";
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo/index.mjs
-var foo_exports$1 = __export({}, { foo: () => foo });
+var foo_exports$1 = {};
+__export(foo_exports$1, { foo: () => foo });
 init_trigger_dep();
 const foo_hot = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo/index.mjs");
 __rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo/index.mjs", { exports: foo_exports$1 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
@@ -11,7 +11,8 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = __export({}, { c: () => c });
+var c_exports = {};
+__export(c_exports, { c: () => c });
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
@@ -22,14 +23,16 @@ c_hot.accept((nextExports) => {
 
 //#endregion
 //#region b.js
-var b_exports = __export({}, { b: () => b });
+var b_exports = {};
+__export(b_exports, { b: () => b });
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = __export({}, { a: () => a });
+var a_exports = {};
+__export(a_exports, { a: () => a });
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -20,7 +20,8 @@ var require_dep_cjs = /* @__PURE__ */ __commonJS({ "modules/dep-cjs.js": ((expor
 //#endregion
 //#region modules/dep-esm.js
 var import_dep_cjs = /* @__PURE__ */ __toESM(require_dep_cjs());
-var dep_esm_exports = __export({}, { value: () => value$1 });
+var dep_esm_exports = {};
+__export(dep_esm_exports, { value: () => value$1 });
 const dep_esm_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm.js");
 __rolldown_runtime__.registerModule("modules/dep-esm.js", { exports: dep_esm_exports });
 const value$1 = "esm";
@@ -36,7 +37,8 @@ var require_dep_cjs_default = /* @__PURE__ */ __commonJS({ "modules/dep-cjs-defa
 //#endregion
 //#region modules/dep-esm-default.js
 var import_dep_cjs_default = /* @__PURE__ */ __toESM(require_dep_cjs_default());
-var dep_esm_default_exports = __export({}, { default: () => dep_esm_default_default });
+var dep_esm_default_exports = {};
+__export(dep_esm_default_exports, { default: () => dep_esm_default_default });
 const dep_esm_default_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-default.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-default.js", { exports: dep_esm_default_exports });
 var dep_esm_default_default = "esm-default";
@@ -52,7 +54,8 @@ var require_dep_cjs_named = /* @__PURE__ */ __commonJS({ "modules/dep-cjs-named.
 //#endregion
 //#region modules/dep-esm-named.js
 var import_dep_cjs_named = /* @__PURE__ */ __toESM(require_dep_cjs_named());
-var dep_esm_named_exports = __export({}, { named: () => named });
+var dep_esm_named_exports = {};
+__export(dep_esm_named_exports, { named: () => named });
 const dep_esm_named_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-named.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-named.js", { exports: dep_esm_named_exports });
 const named = "esm-named";
@@ -68,7 +71,8 @@ var require_dep_cjs_namespace = /* @__PURE__ */ __commonJS({ "modules/dep-cjs-na
 //#endregion
 //#region modules/dep-esm-namespace.js
 var import_dep_cjs_namespace = /* @__PURE__ */ __toESM(require_dep_cjs_namespace());
-var dep_esm_namespace_exports = __export({}, { value: () => value });
+var dep_esm_namespace_exports = {};
+__export(dep_esm_namespace_exports, { value: () => value });
 const dep_esm_namespace_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-namespace.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-namespace.js", { exports: dep_esm_namespace_exports });
 const value = "esm-namespace";

--- a/crates/rolldown/tests/rolldown/topics/keep_names/declaration2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/declaration2/artifacts.snap
@@ -10,7 +10,8 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = __export({}, {
+var a_exports = {};
+__export(a_exports, {
 	delay: () => delay$1,
 	random64: () => random64$1
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region main.js
-var main_exports = __export({}, {
+var main_exports = {};
+__export(main_exports, {
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
@@ -24,7 +24,8 @@ export { main_default as default, foo };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region main.js
-var main_exports = __export({}, {
+var main_exports = {};
+__export(main_exports, {
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
@@ -10,7 +10,8 @@ Object.defineProperty(exports, '__esModule', { value: true });
 // HIDDEN [rolldown:runtime]
 
 //#region main.js
-var main_exports = __export({}, {
+var main_exports = {};
+__export(main_exports, {
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/tla/inline_dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/inline_dynamic_import/artifacts.snap
@@ -8,7 +8,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region c.js
-var c_exports = __export({}, { default: () => c_default });
+var c_exports = {};
+__export(c_exports, { default: () => c_default });
 var _default, c_default;
 var init_c = __esm({ "c.js": (() => {
 	_default = { aaa: { bbb: [
@@ -33,7 +34,8 @@ var init_b = __esm({ "b.js": (async () => {
 
 //#endregion
 //#region a.js
-var a_exports = __export({}, { buildDevConfig: () => buildDevConfig });
+var a_exports = {};
+__export(a_exports, { buildDevConfig: () => buildDevConfig });
 var buildDevConfig;
 var init_a = __esm({ "a.js": (async () => {
 	await init_b();

--- a/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
@@ -12,7 +12,8 @@ const foo = 1;
 
 //#endregion
 //#region export-star.js
-var export_star_exports = __export({}, { foo: () => foo });
+var export_star_exports = {};
+__export(export_star_exports, { foo: () => foo });
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format/artifacts.snap
@@ -19,7 +19,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js
-var lib_exports = __export({}, { default: () => lib_default });
+var lib_exports = {};
+__export(lib_exports, { default: () => lib_default });
 var lib_default;
 var init_lib = __esm({ "lib.js": (() => {
 	lib_default = 2;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -268,7 +268,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main
 
-- src_entry-!~{000}~.js => src_entry-Af_lq6If.js
+- src_entry-!~{000}~.js => src_entry-CnvGSiyh.js
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_module
 
@@ -284,7 +284,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main
 
-- src_entry-!~{000}~.js => src_entry-CMW0qt-Q.js
+- src_entry-!~{000}~.js => src_entry-Dmc_zJYq.js
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_module
 
@@ -337,7 +337,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6
 
-- src_entry-!~{000}~.js => src_entry-Bs7G5Nxu.js
+- src_entry-!~{000}~.js => src_entry-BD4eU270.js
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js
 
@@ -353,7 +353,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6
 
-- src_entry-!~{000}~.js => src_entry-hTrnOJMe.js
+- src_entry-!~{000}~.js => src_entry-BUnoAT0b.js
 
 # tests/esbuild/dce/package_json_side_effects_false_no_warning_in_node_modules_issue999
 
@@ -479,7 +479,7 @@ expression: output
 
 # tests/esbuild/dce/tree_shaking_in_esm_wrapper
 
-- entry-!~{000}~.js => entry-DajY2rdw.js
+- entry-!~{000}~.js => entry-D0OaAbwh.js
 
 # tests/esbuild/dce/tree_shaking_js_with_associated_css
 
@@ -609,7 +609,7 @@ expression: output
 
 # tests/esbuild/default/common_js_from_es6
 
-- entry-!~{000}~.js => entry-Ba3xsEEm.js
+- entry-!~{000}~.js => entry-CokA6VYr.js
 
 # tests/esbuild/default/conditional_import
 
@@ -718,24 +718,24 @@ expression: output
 
 # tests/esbuild/default/export_forms_common_js
 
-- entry-!~{000}~.js => entry-cFoC7tfg.js
+- entry-!~{000}~.js => entry-MhOZTeoD.js
 
 # tests/esbuild/default/export_forms_es6
 
-- entry-!~{000}~.js => entry-YZfsURb_.js
+- entry-!~{000}~.js => entry-CNJxOU5W.js
 
 # tests/esbuild/default/export_forms_iife
 
-- entry-!~{000}~.js => entry-CjcCpsoz.js
+- entry-!~{000}~.js => entry-4De0duF1.js
 
 # tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle
 
-- a-!~{000}~.js => a-BE-gzQBI.js
-- b-!~{001}~.js => b-WMiLdmia.js
+- a-!~{000}~.js => a-C-ZyFH0D.js
+- b-!~{001}~.js => b-qhjqeTzO.js
 - c-!~{002}~.js => c-DbAYnqxj.js
 - d-!~{003}~.js => d-erhulghW.js
 - e-!~{004}~.js => e-BluWtRWc.js
-- b-!~{005}~.js => b-D66qAEzf.js
+- b-!~{005}~.js => b-AmO3MwuF.js
 
 # tests/esbuild/default/export_fs_browser
 
@@ -767,11 +767,11 @@ expression: output
 
 # tests/esbuild/default/exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-D8GQVj9x.js
+- entry-!~{000}~.js => entry-qnruVGtF.js
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
-- entry-!~{000}~.js => entry-BALq-a5y.js
+- entry-!~{000}~.js => entry-Bd5t1CLY.js
 
 # tests/esbuild/default/external_module_exclusion_package
 
@@ -799,7 +799,7 @@ expression: output
 
 # tests/esbuild/default/forbid_string_export_names_bundle
 
-- entry-!~{000}~.js => entry-D2Y_2cR3.js
+- entry-!~{000}~.js => entry-DZBxtX9-.js
 
 # tests/esbuild/default/forbid_string_export_names_no_bundle
 
@@ -1148,9 +1148,9 @@ expression: output
 
 # tests/esbuild/default/mangle_props_import_export_bundled
 
-- entry-cjs-!~{001}~.js => entry-cjs-B9tvMAxC.js
-- entry-esm-!~{000}~.js => entry-esm-BwTgsiQ9.js
-- cjs-!~{002}~.js => cjs-2TSG2Ccw.js
+- entry-cjs-!~{001}~.js => entry-cjs-RzygboMK.js
+- entry-esm-!~{000}~.js => entry-esm-DaCME5Qz.js
+- cjs-!~{002}~.js => cjs-bi-rzMdU.js
 
 # tests/esbuild/default/mangle_props_jsx_preserve
 
@@ -1303,7 +1303,7 @@ expression: output
 
 # tests/esbuild/default/minified_exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-hwF73UjS.js
+- entry-!~{000}~.js => entry-DykaIxN4.js
 
 # tests/esbuild/default/minified_jsx_preserve_with_object_spread
 
@@ -1762,19 +1762,19 @@ expression: output
 
 # tests/esbuild/importstar/export_self_and_import_self_common_js
 
-- entry-!~{000}~.js => entry-7bhij10E.js
+- entry-!~{000}~.js => entry-DmPUDDjT.js
 
 # tests/esbuild/importstar/export_self_and_require_self_common_js
 
-- entry-!~{000}~.js => entry-mljvlA-L.js
+- entry-!~{000}~.js => entry-DCkgMRMK.js
 
 # tests/esbuild/importstar/export_self_as_namespace_common_js
 
-- entry-!~{000}~.js => entry--3pHyhhm.js
+- entry-!~{000}~.js => entry-e1Et3AnI.js
 
 # tests/esbuild/importstar/export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-Bjlj8Ca_.js
+- entry-!~{000}~.js => entry-CrFSqNU8.js
 
 # tests/esbuild/importstar/export_self_common_js
 
@@ -1808,13 +1808,13 @@ expression: output
 - external-ns-!~{001}~.js => external-ns-all2LFha.js
 - external-ns-def-!~{003}~.js => external-ns-def-CPrnmGVn.js
 - external-ns-default-!~{002}~.js => external-ns-default-Cbqf8eIs.js
-- internal-def-!~{00b}~.js => internal-def-BUT8UPRw.js
-- internal-default-!~{00a}~.js => internal-default-BD6Tniz_.js
-- internal-default2-!~{006}~.js => internal-default2-C-XyoOuz.js
-- internal-ns-!~{007}~.js => internal-ns-Do8K9u_T.js
-- internal-ns-def-!~{009}~.js => internal-ns-def-jxkvoauO.js
-- internal-ns-default-!~{008}~.js => internal-ns-default-B5Go_JFE.js
-- internal-!~{00c}~.js => internal-qqDZhrpX.js
+- internal-def-!~{00b}~.js => internal-def-CRNsLces.js
+- internal-default-!~{00a}~.js => internal-default-Dx0cXe3H.js
+- internal-default2-!~{006}~.js => internal-default2-Br-ACsYq.js
+- internal-ns-!~{007}~.js => internal-ns-a_Hq6o6-.js
+- internal-ns-def-!~{009}~.js => internal-ns-def-BSYbjTZ1.js
+- internal-ns-default-!~{008}~.js => internal-ns-default-BkqjZs1S.js
+- internal-!~{00c}~.js => internal-1sX5rN8A.js
 
 # tests/esbuild/importstar/import_export_other_as_namespace_common_js
 
@@ -1822,7 +1822,7 @@ expression: output
 
 # tests/esbuild/importstar/import_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-Bjlj8Ca_.js
+- entry-!~{000}~.js => entry-CrFSqNU8.js
 
 # tests/esbuild/importstar/import_export_star_ambiguous_warning
 
@@ -1854,11 +1854,11 @@ expression: output
 
 # tests/esbuild/importstar/import_star_and_common_js
 
-- entry-!~{000}~.js => entry-Ctl7N1SH.js
+- entry-!~{000}~.js => entry-DmuTEWK8.js
 
 # tests/esbuild/importstar/import_star_capture
 
-- entry-!~{000}~.js => entry-B0bwKOLu.js
+- entry-!~{000}~.js => entry-DRZgLsj7.js
 
 # tests/esbuild/importstar/import_star_common_js_capture
 
@@ -1874,7 +1874,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_import_star_capture
 
-- entry-!~{000}~.js => entry-B0bwKOLu.js
+- entry-!~{000}~.js => entry-DRZgLsj7.js
 
 # tests/esbuild/importstar/import_star_export_import_star_no_capture
 
@@ -1886,7 +1886,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_as_capture
 
-- entry-!~{000}~.js => entry-B0bwKOLu.js
+- entry-!~{000}~.js => entry-DRZgLsj7.js
 
 # tests/esbuild/importstar/import_star_export_star_as_no_capture
 
@@ -1898,7 +1898,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_capture
 
-- entry-!~{000}~.js => entry-g9cKH1n-.js
+- entry-!~{000}~.js => entry-DaFT1upj.js
 
 # tests/esbuild/importstar/import_star_export_star_no_capture
 
@@ -1906,7 +1906,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_omit_ambiguous
 
-- entry-!~{000}~.js => entry-DEmuPo-9.js
+- entry-!~{000}~.js => entry-gyjSeV8R.js
 
 # tests/esbuild/importstar/import_star_export_star_unused
 
@@ -1942,7 +1942,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_of_export_star_as
 
-- entry-!~{000}~.js => entry-BKzT1Dou.js
+- entry-!~{000}~.js => entry-BbcqPKpk.js
 
 # tests/esbuild/importstar/import_star_unused
 
@@ -1950,7 +1950,7 @@ expression: output
 
 # tests/esbuild/importstar/issue176
 
-- entry-!~{000}~.js => entry-Bl99I4rM.js
+- entry-!~{000}~.js => entry-Bpek_SCa.js
 
 # tests/esbuild/importstar/namespace_import_missing_common_js
 
@@ -1958,11 +1958,11 @@ expression: output
 
 # tests/esbuild/importstar/namespace_import_missing_es6
 
-- entry-!~{000}~.js => entry-fVovZZVU.js
+- entry-!~{000}~.js => entry-wg_v8cH5.js
 
 # tests/esbuild/importstar/namespace_import_re_export_star_missing_es6
 
-- entry-!~{000}~.js => entry-ZtO5roFc.js
+- entry-!~{000}~.js => entry-Cx3-VPSK.js
 
 # tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6
 
@@ -1986,7 +1986,7 @@ expression: output
 
 # tests/esbuild/importstar/re_export_namespace_import_missing_es6
 
-- entry-!~{000}~.js => entry-3A06COpI.js
+- entry-!~{000}~.js => entry-Cm_DwAz2.js
 
 # tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6
 
@@ -1994,11 +1994,11 @@ expression: output
 
 # tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-mk1pkhsX.js
+- entry-!~{000}~.js => entry-BvbMMCKs.js
 
 # tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-mk1pkhsX.js
+- entry-!~{000}~.js => entry-BvbMMCKs.js
 
 # tests/esbuild/importstar/re_export_star_as_common_js_no_bundle
 
@@ -2070,11 +2070,11 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_and_common_js
 
-- entry-!~{000}~.js => entry-CggfpCY4.js
+- entry-!~{000}~.js => entry-B48ekpxm.js
 
 # tests/esbuild/importstar_ts/ts_import_star_capture
 
-- entry-!~{000}~.js => entry-CqlPOHNS.js
+- entry-!~{000}~.js => entry-C7aMyrUT.js
 
 # tests/esbuild/importstar_ts/ts_import_star_common_js_capture
 
@@ -2090,7 +2090,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture
 
-- entry-!~{000}~.js => entry-CqlPOHNS.js
+- entry-!~{000}~.js => entry-C7aMyrUT.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_import_star_no_capture
 
@@ -2102,7 +2102,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture
 
-- entry-!~{000}~.js => entry-CqlPOHNS.js
+- entry-!~{000}~.js => entry-C7aMyrUT.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_as_no_capture
 
@@ -2114,7 +2114,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_capture
 
-- entry-!~{000}~.js => entry-ChOZ7-6h.js
+- entry-!~{000}~.js => entry-B3EWy3I-.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_no_capture
 
@@ -2368,7 +2368,7 @@ expression: output
 
 # tests/esbuild/loader/loader_json_invalid_identifier_es6
 
-- entry-!~{000}~.js => entry-DTAPEHJC.js
+- entry-!~{000}~.js => entry-Bzc21GuB.js
 
 # tests/esbuild/loader/loader_json_no_bundle
 
@@ -2882,27 +2882,27 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser
 
-- entry-!~{000}~.js => entry-DdsNFwAt.js
+- entry-!~{000}~.js => entry-Bm_48Jpl.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main
 
-- entry-!~{000}~.js => entry-CkGa_xX-.js
+- entry-!~{000}~.js => entry-BKFrzYbS.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main
 
-- entry-!~{000}~.js => entry-4-Zn-orq.js
+- entry-!~{000}~.js => entry-C_ut64Dl.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main
 
-- entry-!~{000}~.js => entry-D_PosRIZ.js
+- entry-!~{000}~.js => entry-CapQN31r.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file
 
-- entry-!~{000}~.js => entry-uscDF-Pu.js
+- entry-!~{000}~.js => entry-F89RrY3v.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files
 
-- entry-!~{000}~.js => entry-CmTD2_iD.js
+- entry-!~{000}~.js => entry-Dg0EAXUU.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_only
 
@@ -2910,7 +2910,7 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_require_only
 
-- entry-!~{000}~.js => entry-1aFdCpGL.js
+- entry-!~{000}~.js => entry-CXeqxZ95.js
 
 # tests/esbuild/packagejson/package_json_exports_alternatives
 
@@ -3160,9 +3160,9 @@ expression: output
 
 # tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617
 
-- a-!~{000}~.js => a-yLQmP1-U.js
-- b-!~{001}~.js => b-DGWJEOZI.js
-- a-!~{002}~.js => a-CgjyfL-4.js
+- a-!~{000}~.js => a-Bc5-IKbc.js
+- b-!~{001}~.js => b-D6zj-uGY.js
+- a-!~{002}~.js => a-BXF1mP2E.js
 
 # tests/esbuild/splitting/splitting_minify_identifiers_crash_issue437
 
@@ -3219,7 +3219,7 @@ expression: output
 
 # tests/esbuild/ts/export_type_issue379
 
-- entry-!~{000}~.js => entry-D_7KTYja.js
+- entry-!~{000}~.js => entry-r0kTubL9.js
 
 # tests/esbuild/ts/this_inside_function_ts
 
@@ -3373,7 +3373,7 @@ expression: output
 
 # tests/esbuild/ts/ts_export_missing_es6
 
-- entry-!~{000}~.js => entry-B1s1BRz2.js
+- entry-!~{000}~.js => entry-CaFGqRrE.js
 
 # tests/esbuild/ts/ts_export_namespace
 
@@ -3409,7 +3409,7 @@ expression: output
 
 # tests/esbuild/ts/ts_import_equals_undefined_import
 
-- entry-!~{000}~.js => entry-BLXQMzn-.js
+- entry-!~{000}~.js => entry-ClvLtF_A.js
 
 # tests/esbuild/ts/ts_import_missing_unused_es6
 
@@ -3529,7 +3529,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/basic_commonjs
 
-- main-!~{000}~.js => main-C53gUSEP.js
+- main-!~{000}~.js => main-CKHZsNj3.js
 
 # tests/rolldown/cjs_compat/cjs_entry
 
@@ -3547,15 +3547,15 @@ expression: output
 
 # tests/rolldown/cjs_compat/esm_require_esm
 
-- main-!~{000}~.js => main-CNDbLB73.js
+- main-!~{000}~.js => main-BNBxS7Hg.js
 
 # tests/rolldown/cjs_compat/esm_require_esm_unused
 
-- main-!~{000}~.js => main-DndPqx_2.js
+- main-!~{000}~.js => main-DEAFC77U.js
 
 # tests/rolldown/cjs_compat/exoprt_star_of_cjs
 
-- main-!~{000}~.js => main-CRbY0cJI.js
+- main-!~{000}~.js => main-BUm7A9yW.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
 
@@ -3567,11 +3567,11 @@ expression: output
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
 
-- main-!~{000}~.js => main-CjVET2bl.js
+- main-!~{000}~.js => main-CwG5_1gm.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
 
-- main-!~{000}~.js => main-DfpxV_OP.js
+- main-!~{000}~.js => main-CY_waB3R.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
 
@@ -3608,7 +3608,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout
 
-- main-!~{000}~.js => main-JEoMii-E.js
+- main-!~{000}~.js => main-Q6Enn7wZ.js
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout2
 
@@ -3624,7 +3624,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_2
 
-- main-!~{000}~.js => main-WVsMybHe.js
+- main-!~{000}~.js => main-BcHPfiQE.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize
 
@@ -3642,7 +3642,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/reexport_commonjs
 
-- main-!~{000}~.js => main-BitJ5lY6.js
+- main-!~{000}~.js => main-CEL0Hc_a.js
 
 # tests/rolldown/cjs_compat/reexports_from_cjs
 
@@ -3664,7 +3664,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/require_call_expr_unused
 
-- main-!~{000}~.js => main-CySsmIJk.js
+- main-!~{000}~.js => main-DS1l5coy.js
 
 # tests/rolldown/cjs_compat/unnecessary_compat_default_property_access
 
@@ -3679,9 +3679,9 @@ expression: output
 
 # tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file
 
-- main-!~{000}~.js => main-D-WweD7J.js
-- foo-!~{001}~.js => foo-CcVy2lFy.js
-- foo-!~{003}~.js => foo-qzSCeWc6.js
+- main-!~{000}~.js => main-DrZnh7hA.js
+- foo-!~{001}~.js => foo-B90YrT8O.js
+- foo-!~{003}~.js => foo-CdZSNn-S.js
 
 # tests/rolldown/code_splitting/ensure_safe_identifier
 
@@ -3703,9 +3703,9 @@ expression: output
 
 # tests/rolldown/code_splitting/format_cjs_with_esm_require_esm
 
-- main1-!~{000}~.js => main1-BEQSXsJx.js
-- main2-!~{001}~.js => main2-CrBBGTk2.js
-- chunk-!~{002}~.js => chunk-0Q102Th_.js
+- main1-!~{000}~.js => main1-ClScYW9f.js
+- main2-!~{001}~.js => main2-BfMFBQXc.js
+- chunk-!~{002}~.js => chunk-BMlwYAFk.js
 
 # tests/rolldown/code_splitting/format_cjs_with_module_cjs
 
@@ -3729,7 +3729,7 @@ expression: output
 
 # tests/rolldown/dce/conditional_exports
 
-- main-!~{000}~.js => main-BTDoqxtJ.js
+- main-!~{000}~.js => main-BpAmeYQA.js
 
 # tests/rolldown/dce/defined_expr_in_paren_expr
 
@@ -3830,10 +3830,10 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/split_node_modules
 
-- main-!~{000}~.js => main-BR1W8jDW.js
-- other-libs-!~{005}~.js => other-libs-D9rdy0dK.js
-- rolldown-runtime-!~{001}~.js => rolldown-runtime-CRsg5ciU.js
-- ui-!~{003}~.js => ui-TMnRAtXp.js
+- main-!~{000}~.js => main-CKBEWSQT.js
+- other-libs-!~{005}~.js => other-libs-aMYKRBbT.js
+- rolldown-runtime-!~{001}~.js => rolldown-runtime-BFxWfBIB.js
+- ui-!~{003}~.js => ui-BOaO4aOi.js
 
 # tests/rolldown/function/context/defined
 
@@ -3965,7 +3965,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-ZJ9nRyO5.js
+- main-!~{000}~.js => main-BRl9l4uJ.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4035,7 +4035,7 @@ expression: output
 
 # tests/rolldown/function/export_mode/cjs/default
 
-- main-!~{000}~.js => main-BPtzCLR-.js
+- main-!~{000}~.js => main-Cm3GgXVs.js
 
 # tests/rolldown/function/export_mode/cjs/named
 
@@ -4047,11 +4047,11 @@ expression: output
 
 # tests/rolldown/function/export_mode/iife/default
 
-- main-!~{000}~.js => main-DBy53FuP.js
+- main-!~{000}~.js => main-Czy5HG6o.js
 
 # tests/rolldown/function/export_mode/iife/named
 
-- main-!~{000}~.js => main-BgbQKeAc.js
+- main-!~{000}~.js => main-B6pAK4Aj.js
 
 # tests/rolldown/function/export_mode/umd/auto/none
 
@@ -4265,15 +4265,15 @@ expression: output
 
 # tests/rolldown/function/inline_dynamic_imports/cjs
 
-- main-!~{000}~.js => main-CZcHVBHq.js
+- main-!~{000}~.js => main-lwGAEuFX.js
 
 # tests/rolldown/function/inline_dynamic_imports/esm
 
-- main-!~{000}~.js => main-aV8Jbtxq.js
+- main-!~{000}~.js => main-DHUJRmGm.js
 
 # tests/rolldown/function/inline_dynamic_imports/iife
 
-- main-!~{000}~.js => main-Dfi4DVIj.js
+- main-!~{000}~.js => main-BnGtBBQb.js
 
 # tests/rolldown/function/intro/cjs
 
@@ -4623,10 +4623,10 @@ expression: output
 
 # tests/rolldown/issues/3650
 
-- main-!~{000}~.js => main-FUIHUjoF.js
-- first-!~{005}~.js => first-D0NQl5n2.js
-- rolldown-runtime-!~{001}~.js => rolldown-runtime-BotFMl-M.js
-- second-!~{003}~.js => second-C0DELlBi.js
+- main-!~{000}~.js => main-B-7EuN8u.js
+- first-!~{005}~.js => first-By7s9ezu.js
+- rolldown-runtime-!~{001}~.js => rolldown-runtime-BvgZlyOU.js
+- second-!~{003}~.js => second-BvWtJ7WD.js
 
 # tests/rolldown/issues/3746/a
 
@@ -4648,7 +4648,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-BGNEBivx.js
+- main-!~{000}~.js => main-GYiaesa8.js
 
 # tests/rolldown/issues/4196
 
@@ -4686,7 +4686,7 @@ expression: output
 
 # tests/rolldown/issues/4472
 
-- main-!~{000}~.js => main-B7eiCkAF.js
+- main-!~{000}~.js => main-B0axk7Uw.js
 
 # tests/rolldown/issues/4491
 
@@ -4730,10 +4730,10 @@ expression: output
 
 # tests/rolldown/issues/5387
 
-- main-!~{000}~.js => main-Dn1LUzZM.js
-- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-CioeDuEE.js
-- liblib/index-!~{005}~.js => liblib/index-C229nT2_.js
-- liblib/lib-!~{003}~.js => liblib/lib-5gcjR3za.js
+- main-!~{000}~.js => main-BF_p7yIv.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-li4Svopq.js
+- liblib/index-!~{005}~.js => liblib/index-CrkltzeF.js
+- liblib/lib-!~{003}~.js => liblib/lib-CEDze9up.js
 
 # tests/rolldown/issues/5531
 
@@ -4755,11 +4755,11 @@ expression: output
 
 # tests/rolldown/issues/5870
 
-- main-!~{000}~.js => main-Bhhy81Lu.js
+- main-!~{000}~.js => main-XvrnrFAA.js
 
 # tests/rolldown/issues/rolldown_vite_289
 
-- main-!~{000}~.js => main-CG2Uqr20.js
+- main-!~{000}~.js => main-bGTkbLZB.js
 
 # tests/rolldown/misc/ambiguous_star_export
 
@@ -4831,7 +4831,7 @@ expression: output
 
 # tests/rolldown/misc/invalid_ident_repr
 
-- main-!~{000}~.js => main-Dc2gjAIi.js
+- main-!~{000}~.js => main-C4WRfKZ2.js
 
 # tests/rolldown/misc/merge_external_import
 
@@ -4950,9 +4950,9 @@ expression: output
 
 # tests/rolldown/misc/reexport_star
 
-- entry-!~{001}~.js => entry-D4RpWrJC.js
-- main-!~{000}~.js => main-Y9fa6KSZ.js
-- a-!~{002}~.js => a-DQbpgPRb.js
+- entry-!~{001}~.js => entry-9pAfnsAm.js
+- main-!~{000}~.js => main-64pdxdCn.js
+- a-!~{002}~.js => a-DNkyR4qI.js
 
 # tests/rolldown/misc/reexport_star_from_local_named_export
 
@@ -4992,8 +4992,8 @@ expression: output
 
 # tests/rolldown/misc/wrapped_esm
 
-- main-!~{000}~.js => main-BZ0CUDLB.js
-- main-BZ0CUDLB.js.map
+- main-!~{000}~.js => main-56AOIbNp.js
+- main-56AOIbNp.js.map
 
 # tests/rolldown/optimization/inline_const/5197
 
@@ -5090,11 +5090,11 @@ expression: output
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry
 
-- entry-!~{000}~.js => entry-ChrN9O-S.js
+- entry-!~{000}~.js => entry-BW4t5NUS.js
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs
 
-- entry-!~{000}~.js => entry-D6h1ylyP.js
+- entry-!~{000}~.js => entry-BP4bvwb-.js
 
 # tests/rolldown/sourcemap/css_sourcemap_reference
 
@@ -5147,15 +5147,15 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/12
 
-- entry-!~{000}~.js => entry-C9H9T8DL.js
-- foo-!~{003}~.js => foo--8KZCZM2.js
-- foo-!~{001}~.js => foo-BQD1oJEU.js
+- entry-!~{000}~.js => entry-Bkz5zR5y.js
+- foo-!~{001}~.js => foo-B5buwoml.js
+- foo-!~{003}~.js => foo-DVrMr8-1.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/13
 
-- entry-!~{000}~.js => entry-KYCZ_w3s.js
-- foo-!~{003}~.js => foo--8KZCZM2.js
-- foo-!~{001}~.js => foo-BQD1oJEU.js
+- entry-!~{000}~.js => entry-DqrV-noK.js
+- foo-!~{001}~.js => foo-B5buwoml.js
+- foo-!~{003}~.js => foo-DVrMr8-1.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/14
 
@@ -5175,11 +5175,11 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/18
 
-- entry-!~{000}~.js => entry-Br1FLFwc.js
+- entry-!~{000}~.js => entry-ShzHe5oD.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/19
 
-- entry-!~{000}~.js => entry-CPR7XO8V.js
+- entry-!~{000}~.js => entry-BAOwXqXy.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/2
 
@@ -5187,27 +5187,27 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/20
 
-- entry-!~{000}~.js => entry-Dg3vhAf4.js
+- entry-!~{000}~.js => entry-D2_7JUng.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/21
 
-- entry-!~{000}~.js => entry-B9Te-0jw.js
+- entry-!~{000}~.js => entry-BUI3CA7X.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/22
 
-- entry-!~{000}~.js => entry-DHnyo1Tu.js
+- entry-!~{000}~.js => entry-BKfUW5Tm.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/23
 
-- entry-!~{000}~.js => entry-D6gnzNSz.js
+- entry-!~{000}~.js => entry-DDe2XBQ2.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/24
 
-- entry-!~{000}~.js => entry-DQeU5-PZ.js
+- entry-!~{000}~.js => entry-C5_mIfc-.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/25
 
-- entry-!~{000}~.js => entry-D_EHnwZQ.js
+- entry-!~{000}~.js => entry-dsJDbanh.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/26
 
@@ -5281,7 +5281,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/41
 
-- entry-!~{000}~.js => entry-Cf1CybZR.js
+- entry-!~{000}~.js => entry-C5yBdK2g.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/42
 
@@ -5289,7 +5289,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/43
 
-- entry-!~{000}~.js => entry-C-UiNEe1.js
+- entry-!~{000}~.js => entry-COAHiUqm.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/44
 
@@ -5297,15 +5297,15 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/45
 
-- entry-!~{000}~.js => entry-BQjGohj2.js
+- entry-!~{000}~.js => entry-CFhCCS_K.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/46
 
-- entry-!~{000}~.js => entry-BTLYPluH.js
+- entry-!~{000}~.js => entry-DqAzscfO.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/47
 
-- entry-!~{000}~.js => entry-DGw5MmhI.js
+- entry-!~{000}~.js => entry-CBVq1aah.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/48
 
@@ -5381,7 +5381,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/7
 
-- entry-!~{000}~.js => entry-vw8auHMs.js
+- entry-!~{000}~.js => entry-CZz9Tf7-.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/8
 
@@ -5389,7 +5389,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/9
 
-- entry-!~{000}~.js => entry-BmudLtRY.js
+- entry-!~{000}~.js => entry-OEtcTgKT.js
 
 # tests/rolldown/topics/chunk_modules_order/basic
 
@@ -5478,90 +5478,90 @@ expression: output
 
 # tests/rolldown/topics/deconflict/wrapped_esm_default_function
 
-- main-!~{000}~.js => main-CFaBwEh6.js
-- main-CFaBwEh6.js.map
+- main-!~{000}~.js => main-CS1VGtNM.js
+- main-CS1VGtNM.js.map
 
 # tests/rolldown/topics/deconflict/wrapped_esm_export_named_function
 
-- main-!~{000}~.js => main-CsezXmEV.js
-- main-CsezXmEV.js.map
+- main-!~{000}~.js => main-X0JfucbC.js
+- main-X0JfucbC.js.map
 
 # tests/rolldown/topics/hmr/accept-outside-circular
 
-- main-!~{000}~.js => main-MmQjTxTb.js
+- main-!~{000}~.js => main-Cg5h6ch6.js
 
 # tests/rolldown/topics/hmr/change_accept
 
-- main-!~{000}~.js => main-DbsKdEI0.js
+- main-!~{000}~.js => main-CjLhLu5f.js
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-aTt2MS1v.js
-- chunk-!~{001}~.js => chunk-CydLoWfU.js
-- exist-dep-cjs-!~{003}~.js => exist-dep-cjs-BhBb1QWf.js
-- exist-dep-esm-!~{005}~.js => exist-dep-esm-AWCHhAPu.js
+- main-!~{000}~.js => main-D_Qah7KK.js
+- chunk-!~{001}~.js => chunk-EJRfyxWL.js
+- exist-dep-cjs-!~{003}~.js => exist-dep-cjs-CMMhV_IP.js
+- exist-dep-esm-!~{005}~.js => exist-dep-esm-DS9du_-x.js
 
 # tests/rolldown/topics/hmr/export_star
 
-- main-!~{000}~.js => main-OYVmIKr5.js
+- main-!~{000}~.js => main-iugOMOus.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-BWgxzmAI.js
+- main-!~{000}~.js => main-Abs8vRWN.js
 
 # tests/rolldown/topics/hmr/import_meta_hot_accept
 
-- main-!~{000}~.js => main-Ds7JFVzo.js
+- main-!~{000}~.js => main-DQ9Ayfx4.js
 
 # tests/rolldown/topics/hmr/issue_5149
 
-- main-!~{000}~.js => main-RVLuvVa1.js
+- main-!~{000}~.js => main-2i-rnA2D.js
 
 # tests/rolldown/topics/hmr/issue_5150
 
-- main-!~{000}~.js => main-B1Igwawb.js
+- main-!~{000}~.js => main-CzhdaBZW.js
 
 # tests/rolldown/topics/hmr/issue_5159
 
-- main-!~{000}~.js => main-BC3cpZ7Y.js
-- bar-!~{005}~.js => bar-iAXtQ1fc.js
-- chunk-!~{001}~.js => chunk-R1zqOBtV.js
-- foo-!~{007}~.js => foo-D7rvMW16.js
-- string-!~{003}~.js => string-sezsvxwQ.js
+- main-!~{000}~.js => main-Bg3Yer-O.js
+- bar-!~{005}~.js => bar-BisjqNeR.js
+- chunk-!~{001}~.js => chunk--KgZXUQQ.js
+- foo-!~{007}~.js => foo-OmnQYi5B.js
+- string-!~{003}~.js => string-CMcoXSG2.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-dCJ1qa4A.js
-- index-!~{001}~.js => index-Dk5l8ViI.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-BnqhA0kl.js
+- entry-!~{000}~.js => entry-1MwsmcRP.js
+- index-!~{001}~.js => index-DRnPso5Y.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-h3ThDu7r.js
 
 # tests/rolldown/topics/hmr/no-accept-outside-circular
 
-- main-!~{000}~.js => main-BTIiTfoy.js
+- main-!~{000}~.js => main-DQro9Nzn.js
 
 # tests/rolldown/topics/hmr/no_boundary_reload
 
-- main-!~{000}~.js => main-Cmjtt2_G.js
+- main-!~{000}~.js => main-DgJD8HMG.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-B33IQqx6.js
+- main-!~{000}~.js => main-CJPqt-_s.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-B427GPjo.js
+- main-!~{000}~.js => main-Dw3g15p1.js
 
 # tests/rolldown/topics/hmr/runtime_correctness
 
-- main-!~{000}~.js => main-COx3ujK0.js
+- main-!~{000}~.js => main-DkhPloRE.js
 
 # tests/rolldown/topics/hmr/self-accept-within-circular
 
-- main-!~{000}~.js => main-DKqcKUKd.js
+- main-!~{000}~.js => main-CpNkBBH9.js
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-L8Ful77Y.js
+- main-!~{000}~.js => main-DeyM9iQ0.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 
@@ -5574,7 +5574,7 @@ expression: output
 
 # tests/rolldown/topics/keep_names/declaration2
 
-- main-!~{000}~.js => main-pzNhgBbv.js
+- main-!~{000}~.js => main-CsBPgQXn.js
 
 # tests/rolldown/topics/keep_names/expression
 
@@ -5713,17 +5713,17 @@ expression: output
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped
 
-- main-!~{000}~.js => main-C8ZBUgzL.js
+- main-!~{000}~.js => main-BvFRRf7Y.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries
 
-- entry-!~{000}~.js => entry-B1pu1NoH.js
-- entry2-!~{001}~.js => entry2-7EqT_Ayt.js
-- main-!~{002}~.js => main-hsL8k8GW.js
+- entry-!~{000}~.js => entry-D_XoBjPI.js
+- entry2-!~{001}~.js => entry2-CkINfvDH.js
+- main-!~{002}~.js => main-C7UG2YkQ.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs
 
-- main-!~{000}~.js => main-Bht9jruf.js
+- main-!~{000}~.js => main-Bvm3ovl0.js
 
 # tests/rolldown/topics/tla/basic
 
@@ -5731,7 +5731,7 @@ expression: output
 
 # tests/rolldown/topics/tla/inline_dynamic_import
 
-- main-!~{000}~.js => main-DCCcI82r.js
+- main-!~{000}~.js => main-B8Iec8--.js
 
 # tests/rolldown/topics/tla/inside_try_block
 
@@ -5759,7 +5759,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/commonjs
 
-- main-!~{000}~.js => main-Bq4Rk5cj.js
+- main-!~{000}~.js => main-DDXCupjO.js
 
 # tests/rolldown/tree_shaking/commonjs_5546
 
@@ -5767,7 +5767,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/commonjs_inline_const
 
-- main-!~{000}~.js => main-CwRd7dMj.js
+- main-!~{000}~.js => main-CjSU2_dP.js
 
 # tests/rolldown/tree_shaking/commonjs_mixed
 
@@ -5833,7 +5833,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/export_star
 
-- main-!~{000}~.js => main--xUG-M4U.js
+- main-!~{000}~.js => main-PPodLJ5E.js
 
 # tests/rolldown/tree_shaking/export_star2
 
@@ -5954,7 +5954,7 @@ expression: output
 
 # tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format
 
-- main-!~{000}~.js => main-MuyidogI.js
+- main-!~{000}~.js => main-D2nEHzob.js
 
 # tests/rolldown/warnings/minified-with-eval
 


### PR DESCRIPTION
This reverts commit 7866a608a635069982c7d128de33de23c8083c18.
Since the `rolldown-plugin-dts` relys on the pattern to generate `d.ts`

```js
const module_ns = {}
__export({}, {...})
```

See log https://github.com/rolldown/rolldown/actions/runs/17603918809/job/50010934316