### PR TITLE
fix: support passing all js primitive value for `replacePlugin` 

### DIFF
--- a/packages/rolldown/src/builtin-plugin/replace-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/replace-plugin.ts
@@ -1,5 +1,5 @@
 import type { BindingReplacePluginConfig } from '../binding';
-
+import { logger } from '../cli/logger';
 import { BuiltinPlugin } from './utils';
 
 /**
@@ -28,10 +28,22 @@ export function replacePlugin(
   values: BindingReplacePluginConfig['values'] = {},
   options: Omit<BindingReplacePluginConfig, 'values'> = {},
 ): BuiltinPlugin {
+  let hasNonStringValues = false;
+
   // Convert all values to string during runtime
   Object.keys(values).forEach(key => {
-    values[key] = values[key].toString();
+    const value = values[key];
+    if (typeof value !== 'string') {
+      hasNonStringValues = true;
+      values[key] = String(value);
+    }
   });
+
+  if (hasNonStringValues) {
+    logger.warn(
+      'Some values provided to `replacePlugin` are not strings. They will be converted to strings, but for better performance consider converting them manually.',
+    );
+  }
 
   return new BuiltinPlugin('builtin:replace', { ...options, values });
 }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/replace/issue-5817/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/replace/issue-5817/_config.ts
@@ -7,11 +7,35 @@ export default defineTest({
     plugins: [
       replacePlugin({
         // @ts-ignore
-        __rolldown: 1
+        __rolldown_number: 42,
+        // @ts-ignore
+        __rolldown_string: JSON.stringify('hello world'),
+        // @ts-ignore
+        __rolldown_boolean_true: true,
+        // @ts-ignore
+        __rolldown_boolean_false: false,
+        // @ts-ignore
+        __rolldown_null: null,
+        // @ts-ignore
+        __rolldown_undefined: undefined,
+        // @ts-ignore
+        __rolldown_bigint: 123n,
       }),
     ],
   },
   afterTest(output) {
-    expect(output.output[0].code).toContain(`console.log(1)`)
- }
+    const code = output.output[0].code;
+    expect(code).toMatchInlineSnapshot(`
+      "//#region main.js
+      console.log(42);
+      console.log("hello world");
+      console.log(true);
+      console.log(false);
+      console.log(null);
+      console.log(void 0);
+      console.log(123);
+
+      //#endregion"
+    `)
+  }
 })

--- a/packages/rolldown/tests/fixtures/builtin-plugin/replace/issue-5817/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/replace/issue-5817/main.js
@@ -1,3 +1,9 @@
-console.log(__rolldown)
+console.log(__rolldown_number)
+console.log(__rolldown_string)
+console.log(__rolldown_boolean_true)
+console.log(__rolldown_boolean_false)
+console.log(__rolldown_null)
+console.log(__rolldown_undefined)
+console.log(__rolldown_bigint)
 
 


### PR DESCRIPTION
close #6122