### PR TITLE
fix: use kqueue for file watch on mac

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,8 +157,8 @@ memchr = "2.7.4"
 mimalloc-safe = "0.1.52"
 mime = "0.3.17"
 nom = "8.0.0"
-notify = { version = "8.1.0", git = "https://github.com/sapphi-red/notify", rev = "refs/heads/fix/debounce-events" }
-notify-debouncer-full = { version = "0.6.0", git = "https://github.com/sapphi-red/notify", rev = "refs/heads/fix/debounce-events" }
+notify = { version = "8.1.0", default-features = false, features = ["macos_kqueue"], git = "https://github.com/sapphi-red/notify", rev = "refs/heads/fix/debounce-events" }
+notify-debouncer-full = { version = "0.6.0", default-features = false, features = ["macos_kqueue"], git = "https://github.com/sapphi-red/notify", rev = "refs/heads/fix/debounce-events" }
 num-bigint = "0.4.6"
 num-format = "0.4"
 owo-colors = "4.2.2"


### PR DESCRIPTION
- notify's fsevents support doesn't work for me when there's a lot of files. I confirmed that the watcher loop was working fine, but not sure about the cause.
- notify's kqueue support works for me even with a lot of files
- It seems [kqueue matches the purpose for us](https://watchexec.github.io/docs/macos-fsevents.html). That said, it uses [more file descriptors and may cause "too many open files" error](https://github.com/watchexec/watchexec/issues/268)