### PR TITLE
fix: use patched notify for better file change event debouncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,8 +801,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "file-id"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Ffix%2Fdebounce-events#453ac66e12af730162a51b2fa458a4f54400a5fa"
 dependencies = [
  "windows-sys 0.60.2",
 ]
@@ -1593,8 +1592,7 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 [[package]]
 name = "notify"
 version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Ffix%2Fdebounce-events#453ac66e12af730162a51b2fa458a4f54400a5fa"
 dependencies = [
  "bitflags 2.9.4",
  "fsevent-sys",
@@ -1611,8 +1609,7 @@ dependencies = [
 [[package]]
 name = "notify-debouncer-full"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375bd3a138be7bfeff3480e4a623df4cbfb55b79df617c055cd810ba466fa078"
+source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Ffix%2Fdebounce-events#453ac66e12af730162a51b2fa458a4f54400a5fa"
 dependencies = [
  "file-id",
  "log",
@@ -1624,8 +1621,7 @@ dependencies = [
 [[package]]
 name = "notify-types"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Ffix%2Fdebounce-events#453ac66e12af730162a51b2fa458a4f54400a5fa"
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,8 +157,8 @@ memchr = "2.7.4"
 mimalloc-safe = "0.1.52"
 mime = "0.3.17"
 nom = "8.0.0"
-notify = "8.1.0"
-notify-debouncer-full = "0.6.0"
+notify = { version = "8.1.0", git = "https://github.com/sapphi-red/notify", rev = "refs/heads/fix/debounce-events" }
+notify-debouncer-full = { version = "0.6.0", git = "https://github.com/sapphi-red/notify", rev = "refs/heads/fix/debounce-events" }
 num-bigint = "0.4.6"
 num-format = "0.4"
 owo-colors = "4.2.2"


### PR DESCRIPTION
Temporary switch to my fork with a patch (https://github.com/notify-rs/notify/pull/711) until the PR is merged.