### PR TITLE
feat(dev): use PathsMut for debounced RecommendedWatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,7 +801,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "file-id"
 version = "0.2.3"
-source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Ffix%2Fdebounce-events#453ac66e12af730162a51b2fa458a4f54400a5fa"
+source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Fpatches#772dce88b7acf4b02a7da02fb409001cff234676"
 dependencies = [
  "windows-sys 0.60.2",
 ]
@@ -1592,7 +1592,7 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 [[package]]
 name = "notify"
 version = "8.2.0"
-source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Ffix%2Fdebounce-events#453ac66e12af730162a51b2fa458a4f54400a5fa"
+source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Fpatches#772dce88b7acf4b02a7da02fb409001cff234676"
 dependencies = [
  "bitflags 2.9.4",
  "fsevent-sys",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "notify-debouncer-full"
 version = "0.6.0"
-source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Ffix%2Fdebounce-events#453ac66e12af730162a51b2fa458a4f54400a5fa"
+source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Fpatches#772dce88b7acf4b02a7da02fb409001cff234676"
 dependencies = [
  "file-id",
  "log",
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "notify-types"
 version = "2.0.0"
-source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Ffix%2Fdebounce-events#453ac66e12af730162a51b2fa458a4f54400a5fa"
+source = "git+https://github.com/sapphi-red/notify?rev=refs%2Fheads%2Fpatches#772dce88b7acf4b02a7da02fb409001cff234676"
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,8 +157,8 @@ memchr = "2.7.4"
 mimalloc-safe = "0.1.52"
 mime = "0.3.17"
 nom = "8.0.0"
-notify = { version = "8.1.0", default-features = false, features = ["macos_kqueue"], git = "https://github.com/sapphi-red/notify", rev = "refs/heads/fix/debounce-events" }
-notify-debouncer-full = { version = "0.6.0", default-features = false, features = ["macos_kqueue"], git = "https://github.com/sapphi-red/notify", rev = "refs/heads/fix/debounce-events" }
+notify = { version = "8.1.0", default-features = false, features = ["macos_kqueue"], git = "https://github.com/sapphi-red/notify", rev = "refs/heads/patches" }
+notify-debouncer-full = { version = "0.6.0", default-features = false, features = ["macos_kqueue"], git = "https://github.com/sapphi-red/notify", rev = "refs/heads/patches" }
 num-bigint = "0.4.6"
 num-format = "0.4"
 owo-colors = "4.2.2"

--- a/crates/rolldown_watcher/src/debounced_recommended_watcher.rs
+++ b/crates/rolldown_watcher/src/debounced_recommended_watcher.rs
@@ -1,4 +1,7 @@
-use crate::{EventHandler, Watcher, WatcherConfig, utils::DebounceEventHandlerAdapter};
+use crate::{
+  EventHandler, Watcher, WatcherConfig,
+  utils::{DebounceEventHandlerAdapter, NotifyPathsMutAdapter},
+};
 use notify::RecommendedWatcher;
 use notify_debouncer_full::{Debouncer, RecommendedCache, new_debouncer_opt};
 use rolldown_error::{BuildResult, ResultExt};
@@ -44,5 +47,10 @@ impl Watcher for DebouncedRecommendedWatcher {
   fn unwatch(&mut self, path: &std::path::Path) -> BuildResult<()> {
     self.0.unwatch(path).map_err_to_unhandleable()?;
     Ok(())
+  }
+
+  fn paths_mut<'me>(&'me mut self) -> Box<dyn crate::PathsMut + 'me> {
+    let paths_mut = self.0.paths_mut();
+    Box::new(NotifyPathsMutAdapter::new(paths_mut))
   }
 }


### PR DESCRIPTION
Similar to #6120, but for the debounced RecommendedWatcher.

Switched to a different branch: https://github.com/sapphi-red/notify/commits/patches/
