### PR TITLE
fix: register trace subscriber

### DIFF
--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -140,7 +140,9 @@ function withShared(
       options.plugins,
     ],
     treeshake: {
-      moduleSideEffects: ['signal-exit'],
+      moduleSideEffects: [
+        { test: /\/signal-exit\//, sideEffects: false },
+      ],
     },
   };
 }


### PR DESCRIPTION
`./setup.ts` was tree shaken completely because of the `treeshake.moduleSideEffects: ['signal-exit']` setting which was added in #6024. This PR removes that. I guess it's not needed, but I'm not sure. How can I test this?

refs #5913, #6024
