### PR TITLE
feat(dev): add `skip_write` option

### DIFF
--- a/crates/rolldown/src/dev/dev_options.rs
+++ b/crates/rolldown/src/dev/dev_options.rs
@@ -7,6 +7,8 @@ pub type SharedNormalizedDevOptions = Arc<NormalizedDevOptions>;
 
 #[derive(Default)]
 pub struct DevWatchOptions {
+  /// If `true`, files are not written to disk.
+  pub skip_write: Option<bool>,
   /// If `true`, use polling instead of native file system events for watching
   pub use_polling: Option<bool>,
   /// Poll interval in milliseconds (only used when use_polling is true)
@@ -32,6 +34,7 @@ pub struct DevOptions {
 #[expect(clippy::struct_excessive_bools)]
 pub struct NormalizedDevOptions {
   pub on_hmr_updates: Option<OnHmrUpdatesCallback>,
+  pub skip_write: bool,
   pub eager_rebuild: bool,
   pub use_polling: bool,
   pub poll_interval: u64,
@@ -45,6 +48,7 @@ pub fn normalize_dev_options(options: DevOptions) -> NormalizedDevOptions {
   let watch_options = options.watch.unwrap_or_default();
   NormalizedDevOptions {
     on_hmr_updates: options.on_hmr_updates,
+    skip_write: watch_options.skip_write.unwrap_or_default(),
     eager_rebuild: options.eager_rebuild.unwrap_or_default(),
     use_polling: watch_options.use_polling.unwrap_or(false),
     poll_interval: watch_options.poll_interval.unwrap_or(100),

--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -32,6 +32,7 @@ impl BindingDevEngine {
 
     let on_hmr_updates_callback = dev_options.as_ref().and_then(|opts| opts.on_hmr_updates.clone());
     let watch_options = dev_options.as_ref().and_then(|opts| opts.watch.as_ref());
+    let skip_write = watch_options.and_then(|watch| watch.skip_write);
     let use_polling = watch_options.and_then(|watch| watch.use_polling);
     let poll_interval = watch_options.and_then(|watch| watch.poll_interval);
     let use_debounce = watch_options.and_then(|watch| watch.use_debounce);
@@ -52,7 +53,8 @@ impl BindingDevEngine {
       }) as OnHmrUpdatesCallback
     });
 
-    let dev_watch_options = if use_polling.is_some()
+    let dev_watch_options = if skip_write.is_some()
+      || use_polling.is_some()
       || poll_interval.is_some()
       || use_debounce.is_some()
       || debounce_duration.is_some()
@@ -60,6 +62,7 @@ impl BindingDevEngine {
       || debounce_tick_rate.is_some()
     {
       Some(rolldown::dev::dev_options::DevWatchOptions {
+        skip_write,
         use_polling,
         poll_interval: poll_interval.map(u64::from),
         use_debounce,

--- a/crates/rolldown_binding/src/binding_dev_options.rs
+++ b/crates/rolldown_binding/src/binding_dev_options.rs
@@ -5,6 +5,7 @@ use napi_derive::napi;
 
 #[napi(object, object_to_js = false)]
 pub struct BindingDevWatchOptions {
+  pub skip_write: Option<bool>,
   pub use_polling: Option<bool>,
   pub poll_interval: Option<u32>,
   pub use_debounce: Option<bool>,

--- a/packages/rolldown/src/api/dev/dev-engine.ts
+++ b/packages/rolldown/src/api/dev/dev-engine.ts
@@ -24,6 +24,7 @@ export class DevEngine {
     const bindingDevOptions = {
       onHmrUpdates: devOptions.onHmrUpdates,
       watch: devOptions.watch && {
+        skipWrite: devOptions.watch.skipWrite,
         usePolling: devOptions.watch.usePolling,
         pollInterval: devOptions.watch.pollInterval,
         useDebounce: devOptions.watch.useDebounce,

--- a/packages/rolldown/src/api/dev/dev-options.ts
+++ b/packages/rolldown/src/api/dev/dev-options.ts
@@ -2,6 +2,11 @@ import type { BindingHmrUpdate } from '../../binding';
 
 export interface DevWatchOptions {
   /**
+   * If `true`, files are not written to disk.
+   * @default false
+   */
+  skipWrite?: boolean;
+  /**
    * If `true`, use polling instead of native file system events for watching.
    * @default false
    */

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1580,6 +1580,7 @@ export interface BindingDevOptions {
 }
 
 export interface BindingDevWatchOptions {
+  skipWrite?: boolean
   usePolling?: boolean
   pollInterval?: number
   useDebounce?: boolean


### PR DESCRIPTION
Only added the option, it is still no-op.

I named this `skipWrite` to align with rollup's similar option.
https://rollupjs.org/configuration-options/#watch-skipwrite