### PR TITLE
build(rolldown): refactor `build.ts` to prepare to support build `rolldown` package with wasi binding

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -50,9 +50,9 @@
   },
   "scripts": {
     "build": "pnpm run build:debug",
-    "build:debug": "pnpm run --filter rolldown build-browser:debug",
-    "build:release": "pnpm run --filter rolldown build-browser:release",
-    "build-node": "BROWSER_PKG=1 pnpm run --filter rolldown build-node",
+    "build:debug": "pnpm run --filter rolldown build-browser-pkg:debug",
+    "build:release": "pnpm run --filter rolldown build-browser-pkg:release",
+    "build-node": "TARGET='browser' pnpm run --filter rolldown build-node",
     "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -92,8 +92,8 @@
     "build-native:release": "pnpm run --sequential '/^build-(binding:release|js-glue)$/'",
     "build-native:profile": "pnpm run build-binding:profile && pnpm run build-js-glue",
     "build-native:memory-profile": "pnpm run build-binding:profile --features default_global_allocator && pnpm run build-js-glue",
-    "build-browser:debug": "BROWSER_PKG=1 pnpm run --sequential '/^build-(binding|binding:wasi|node)$/'",
-    "build-browser:release": "BROWSER_PKG=1 pnpm run --sequential '/^build-(binding|binding:wasi:release|node)$/'",
+    "build-browser-pkg:debug": "TARGET='browser' pnpm run --sequential '/^build-(binding|binding:wasi|node)$/'",
+    "build-browser-pkg:release": "TARGET='browser' pnpm run --sequential '/^build-(binding|binding:wasi:release|node)$/'",
     "# Scrips for docs #": "_",
     "extract-options-doc": "typedoc",
     "prepublishOnly": "napi pre-publish -t npm --no-gh-release"


### PR DESCRIPTION
We need to distinguish concepts here:
- browser means `@rolldown/browser` package
- rolldown means `rolldown` package that uses native binding
- rolldown-wasi measn `rolldown` package that uses `.wasm` binding under the hood.
- browser and rolldown-wasi have similar output but they're different things.