### PR TITLE
build(rolldown): support to build `rolldown` with `.wasm` binding

### DIFF
--- a/justfile
+++ b/justfile
@@ -157,26 +157,30 @@ build: build-pluginutils build-rolldown
 build-glue:
   pnpm run --filter rolldown build-js-glue
 
-# Build `rolldown` located in `packages/rolldown` itself and its binding.
+# Build `rolldown` located in `packages/rolldown` itself and its `.node` binding.
 build-rolldown: build-pluginutils
   pnpm run --filter rolldown build-native:debug
 
-# Build `rolldown` located in `packages/rolldown` itself and its binding in release mode.
+# Build `rolldown` located in `packages/rolldown` itself and its `.wasm` binding for WASI.
+build-rolldown-wasi: build-pluginutils
+  pnpm run --filter rolldown build-wasi:debug
+
+# Build `rolldown` located in `packages/rolldown` itself and its `.node` binding in release mode.
 build-rolldown-release: build-pluginutils
   pnpm run --filter rolldown build-native:release
 
-# Build `rolldown` located in `packages/rolldown` itself and its binding in profile mode.
+# Build `rolldown` located in `packages/rolldown` itself and its `.node` binding in profile mode.
 build-rolldown-profile:
   pnpm run --filter rolldown build-native:profile
 
 build-rolldown-memory-profile:
   pnpm run --filter rolldown build-native:memory-profile
 
-# Build `@rolldown/browser` located in `packages/browser` itself and its binding.
+# Build `@rolldown/browser` located in `packages/browser` itself and its `.wasm` binding.
 build-browser: build-pluginutils
   pnpm run --filter "@rolldown/browser" build:debug
 
-# Build `@rolldown/browser` located in `packages/browser` itself and its binding in release mode.
+# Build `@rolldown/browser` located in `packages/browser` itself and its `.wasm` binding in release mode.
 build-browser-release: build-pluginutils
   pnpm run --filter "@rolldown/browser" build:release
 

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -92,6 +92,8 @@
     "build-native:release": "pnpm run --sequential '/^build-(binding:release|js-glue)$/'",
     "build-native:profile": "pnpm run build-binding:profile && pnpm run build-js-glue",
     "build-native:memory-profile": "pnpm run build-binding:profile --features default_global_allocator && pnpm run build-js-glue",
+    "build-wasi:debug": "TARGET='rolldown-wasi' pnpm run --sequential '/^build-(binding|binding:wasi|node)$/'",
+    "build-wasi:release": "TARGET='rolldown-wasi' pnpm run --sequential '/^build-(binding|binding:wasi:release|node)$/'",
     "build-browser-pkg:debug": "TARGET='browser' pnpm run --sequential '/^build-(binding|binding:wasi|node)$/'",
     "build-browser-pkg:release": "TARGET='browser' pnpm run --sequential '/^build-(binding|binding:wasi:release|node)$/'",
     "# Scrips for docs #": "_",


### PR DESCRIPTION
`just build-rolldown-wasi`​ for building `rolldown`​ package with wasi binding.