### PR TITLE
chore(ci): ensure running wasi tests correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,48 @@ jobs:
       os: ${{ matrix.target }}
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}
 
-  browser-test:
+  # Build `rolldown` package with WASI binding.
+  build-rolldown-wasi:
+    name: Build Rolldown with WASI Binding
     needs: changes
+    if: ${{ needs.changes.outputs.node-changes == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
+        with:
+          tools: just
+          cache-key: debug-build-wasi
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Add WASI target
+        run: rustup target add wasm32-wasip1-threads
+
+      - name: Build Rolldown with WASI Binding
+        run: just build-rolldown-wasi
+
+      - name: Upload Rolldown with WASI Binding
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: rolldown-wasi
+          path: |
+            packages/rolldown/dist
+            packages/pluginutils/dist
+          if-no-files-found: error
+
+  wasi-test:
+    needs: [changes, build-rolldown-wasi]
     strategy:
       matrix:
         target: [ubuntu-latest, macos-latest, windows-latest]
-    uses: ./.github/workflows/reusable-browser-test.yml
+    uses: ./.github/workflows/reusable-wasi-test.yml
     with:
       os: ${{ matrix.target }}
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}

--- a/.github/workflows/reusable-wasi-test.yml
+++ b/.github/workflows/reusable-wasi-test.yml
@@ -26,23 +26,14 @@ jobs:
           submodules: true # Pull submodules for additional files
           persist-credentials: false
 
-      - name: Setup Rust
-        uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
-        with:
-          tools: just
-          cache-key: debug-build-wasi
-
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
-      - name: Add WASI target
-        run: rustup target add wasm32-wasip1-threads
-
-      - name: Build Browser Rolldown
-        run: just build-browser
-
-      - name: Build Node Packages
-        run: pnpm --filter rolldown build-node
+      - name: Download Rolldown with WASI Binding
+        uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d # v4.1.5
+        with:
+          name: rolldown-wasi
+          path: ./packages
 
       - name: Build Basic Example
         run: pnpm --filter '@example/*' run --sequential build

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -208,6 +208,12 @@ function patchBindingJs(): Plugin {
       handler(code) {
         return (
           code
+            // Throw error if wasi binding is not available when `NAPI_RS_FORCE_WASI` is truthy. This helps us catch the wasi issue early.
+            // FIXME: hyf0 remove this once napi-rs introduces such behavior.
+            .replace(
+              'nativeBinding = requireNative()',
+              `nativeBinding = process.env.NAPI_RS_FORCE_WASI ? undefined : requireNative()`,
+            )
             // strip off unneeded createRequire in cjs, which breaks mjs
             .replace('const require = createRequire(import.meta.url)', '')
             // inject binding auto download fallback for webcontainer


### PR DESCRIPTION
Previously we run wasi tests with `.node` binding, which is not expected.