### PR TITLE
fix: useless __export helper usage

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -380,7 +380,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     let module_namespace_rhs = if arg_obj_expr.properties.is_empty() {
       Expression::ObjectExpression(self.builder().alloc(arg_obj_expr))
     } else {
-      self.snippet.builder.expression_call(
+      self.snippet.builder.expression_call_with_pure(
         SPAN,
         self.finalized_expr_for_runtime_symbol("__export"),
         NONE,
@@ -389,6 +389,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           .builder
           .vec_from_array([ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.alloc))]),
         false,
+        true,
       )
     };
 

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index-module.js
-var index_module_exports = __export({ foo: () => foo });
+var index_module_exports = /* @__PURE__ */ __export({ foo: () => foo });
 var foo;
 var init_index_module = __esm({ "node_modules/demo-pkg/index-module.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index-module.js
-var index_module_exports = __export({ foo: () => foo });
+var index_module_exports = /* @__PURE__ */ __export({ foo: () => foo });
 var foo;
 var init_index_module = __esm({ "node_modules/demo-pkg/index-module.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index.js
-var demo_pkg_exports = __export({ foo: () => foo });
+var demo_pkg_exports = /* @__PURE__ */ __export({ foo: () => foo });
 var foo;
 var init_demo_pkg = __esm({ "node_modules/demo-pkg/index.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index.js
-var demo_pkg_exports = __export({ foo: () => foo });
+var demo_pkg_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const foo = 123;
 console.log("hello");
 

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
@@ -18,7 +18,7 @@ var init_lib = __esm({ "lib.js": (() => {
 
 //#endregion
 //#region cjs.js
-var cjs_exports = __export({ default: () => cjs_default });
+var cjs_exports = /* @__PURE__ */ __export({ default: () => cjs_default });
 var cjs_default;
 var init_cjs = __esm({ "cjs.js": (() => {
 	init_lib();

--- a/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
 function foo$1() {
 	return "foo";
 }
@@ -18,7 +18,7 @@ var init_foo = __esm({ "foo.js": (() => {}) });
 
 //#endregion
 //#region bar.js
-var bar_exports = __export({ bar: () => bar$1 });
+var bar_exports = /* @__PURE__ */ __export({ bar: () => bar$1 });
 function bar$1() {
 	return "bar";
 }

--- a/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
@@ -15,7 +15,7 @@ var init_a = __esm({ "a.js": (() => {
 
 //#endregion
 //#region b.js
-var b_exports = __export({ xyz: () => xyz });
+var b_exports = /* @__PURE__ */ __export({ xyz: () => xyz });
 var xyz;
 var init_b = __esm({ "b.js": (() => {
 	xyz = null;
@@ -23,7 +23,7 @@ var init_b = __esm({ "b.js": (() => {
 
 //#endregion
 //#region commonjs.js
-var commonjs_exports = __export({
+var commonjs_exports = /* @__PURE__ */ __export({
 	C: () => Class,
 	Class: () => Class,
 	Fn: () => Fn,
@@ -48,7 +48,7 @@ var init_commonjs = __esm({ "commonjs.js": (() => {
 
 //#endregion
 //#region c.js
-var c_exports = __export({ default: () => c_default });
+var c_exports = /* @__PURE__ */ __export({ default: () => c_default });
 var c_default;
 var init_c = __esm({ "c.js": (() => {
 	c_default = class {};
@@ -56,7 +56,7 @@ var init_c = __esm({ "c.js": (() => {
 
 //#endregion
 //#region d.js
-var d_exports = __export({ default: () => Foo });
+var d_exports = /* @__PURE__ */ __export({ default: () => Foo });
 var Foo;
 var init_d = __esm({ "d.js": (() => {
 	Foo = class {};
@@ -65,13 +65,13 @@ var init_d = __esm({ "d.js": (() => {
 
 //#endregion
 //#region e.js
-var e_exports = __export({ default: () => e_default });
+var e_exports = /* @__PURE__ */ __export({ default: () => e_default });
 function e_default() {}
 var init_e = __esm({ "e.js": (() => {}) });
 
 //#endregion
 //#region f.js
-var f_exports = __export({ default: () => foo$1 });
+var f_exports = /* @__PURE__ */ __export({ default: () => foo$1 });
 function foo$1() {}
 var init_f = __esm({ "f.js": (() => {
 	foo$1.prop = 123;
@@ -79,13 +79,13 @@ var init_f = __esm({ "f.js": (() => {
 
 //#endregion
 //#region g.js
-var g_exports = __export({ default: () => g_default });
+var g_exports = /* @__PURE__ */ __export({ default: () => g_default });
 async function g_default() {}
 var init_g = __esm({ "g.js": (() => {}) });
 
 //#endregion
 //#region h.js
-var h_exports = __export({ default: () => foo });
+var h_exports = /* @__PURE__ */ __export({ default: () => foo });
 async function foo() {}
 var init_h = __esm({ "h.js": (() => {
 	foo.prop = 123;

--- a/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
@@ -12,7 +12,7 @@ const abc = void 0;
 
 //#endregion
 //#region b.js
-var b_exports = __export({ xyz: () => xyz });
+var b_exports = /* @__PURE__ */ __export({ xyz: () => xyz });
 const xyz = null;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
@@ -24,7 +24,7 @@ const abc = void 0;
 
 //#endregion
 //#region b.js
-var b_exports = __export({ xyz: () => xyz });
+var b_exports = /* @__PURE__ */ __export({ xyz: () => xyz });
 const xyz = null;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
@@ -33,7 +33,7 @@ export { b_default as default };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region b.js
-var b_exports = __export({ default: () => b_default });
+var b_exports = /* @__PURE__ */ __export({ default: () => b_default });
 function b_default() {}
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
@@ -11,12 +11,12 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region foo/test.js
-var test_exports = __export({ foo: () => foo });
+var test_exports = /* @__PURE__ */ __export({ foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports$1 = __export({ bar: () => bar });
+var test_exports$1 = /* @__PURE__ */ __export({ bar: () => bar });
 let bar = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
@@ -11,22 +11,22 @@ import { ns } from "x";
 
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = __export({ ns: () => ns$1 });
+var a_exports = /* @__PURE__ */ __export({ ns: () => ns$1 });
 var init_a = __esm({ "a.js": (() => {}) });
 
 //#endregion
 //#region b.js
-var b_exports = __export({ ns: () => ns$1 });
+var b_exports = /* @__PURE__ */ __export({ ns: () => ns$1 });
 var init_b = __esm({ "b.js": (() => {}) });
 
 //#endregion
 //#region c.js
-var c_exports = __export({ ns: () => ns$1 });
+var c_exports = /* @__PURE__ */ __export({ ns: () => ns$1 });
 var init_c = __esm({ "c.js": (() => {}) });
 
 //#endregion
 //#region d.js
-var d_exports = __export({ ns: () => ns });
+var d_exports = /* @__PURE__ */ __export({ ns: () => ns });
 var init_d = __esm({ "d.js": (() => {}) });
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/forbid_string_export_names_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/forbid_string_export_names_bundle/artifacts.snap
@@ -16,7 +16,7 @@ let nested$1 = 2;
 
 //#endregion
 //#region nested.js
-var nested_exports = __export({
+var nested_exports = /* @__PURE__ */ __export({
 	"nested name": () => nested,
 	"very nested name": () => nested$1
 });

--- a/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = __export({ esm_foo_: () => esm_foo_ });
+var esm_exports = /* @__PURE__ */ __export({ esm_foo_: () => esm_foo_ });
 var esm_foo_;
 var init_esm = __esm({ "esm.js": (() => {
 	esm_foo_ = "foo";

--- a/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
@@ -9,12 +9,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region foo/test.js
-var test_exports = __export({ foo: () => foo });
+var test_exports = /* @__PURE__ */ __export({ foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports$1 = __export({ bar: () => bar });
+var test_exports$1 = /* @__PURE__ */ __export({ bar: () => bar });
 let bar = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
-var entry_exports = __export({ foo: () => foo });
+var entry_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const foo = 123;
 console.log(entry_exports);
 

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
-var entry_exports = __export({ foo: () => foo });
+var entry_exports = /* @__PURE__ */ __export({ foo: () => foo });
 var foo;
 var init_entry = __esm({ "entry.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
-var entry_exports = __export({
+var entry_exports = /* @__PURE__ */ __export({
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region entry.js
-var entry_exports = __export({
+var entry_exports = /* @__PURE__ */ __export({
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
@@ -231,7 +231,7 @@ console.log(internal_default, internal_exports);
 ```js
 // HIDDEN [rolldown:runtime]
 //#region internal.js
-var internal_exports = __export({ default: () => internal_default });
+var internal_exports = /* @__PURE__ */ __export({ default: () => internal_default });
 var internal_default = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region entry.js
-var entry_exports = __export({
+var entry_exports = /* @__PURE__ */ __export({
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
 var foo;
 var init_foo = __esm({ "foo.js": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
@@ -14,7 +14,7 @@ const foo$1 = 123;
 
 //#endregion
 //#region bar.js
-var bar_exports = __export({ foo: () => foo$1 });
+var bar_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
@@ -18,7 +18,7 @@ const z = 4;
 
 //#endregion
 //#region common.js
-var common_exports = __export({
+var common_exports = /* @__PURE__ */ __export({
 	x: () => x,
 	z: () => z
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
@@ -10,12 +10,12 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region bar.js
-var bar_exports = __export({ bar: () => bar });
+var bar_exports = /* @__PURE__ */ __export({ bar: () => bar });
 const bar = 123;
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({ bar_ns: () => bar_exports });
+var foo_exports = /* @__PURE__ */ __export({ bar_ns: () => bar_exports });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
@@ -12,7 +12,7 @@ const foo = () => "hi there";
 
 //#endregion
 //#region folders/index.js
-var folders_exports = __export({ foo: () => foo });
+var folders_exports = /* @__PURE__ */ __export({ foo: () => foo });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
@@ -24,7 +24,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({ x: () => x });
+var foo_exports = /* @__PURE__ */ __export({ x: () => x });
 const x = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
@@ -28,7 +28,7 @@ const x = 123;
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({ x: () => x });
+var foo_exports = /* @__PURE__ */ __export({ x: () => x });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
@@ -24,7 +24,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region bar.js
-var bar_exports = __export({ x: () => x });
+var bar_exports = /* @__PURE__ */ __export({ x: () => x });
 const x = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({
+var foo_exports = /* @__PURE__ */ __export({
 	foo: () => foo,
 	ns: () => foo_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({
+var foo_exports = /* @__PURE__ */ __export({
 	foo: () => foo,
 	ns: () => foo_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_and_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_and_common_js/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
 var foo;
 var init_foo = __esm({ "foo.ts": (() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
@@ -12,7 +12,7 @@ const foo = 123;
 
 //#endregion
 //#region bar.ts
-var bar_exports = __export({ foo: () => foo });
+var bar_exports = /* @__PURE__ */ __export({ foo: () => foo });
 
 //#endregion
 //#region entry.ts

--- a/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
@@ -12,7 +12,7 @@ var invalid_identifier$1 = true;
 
 //#endregion
 //#region test2.json
-var test2_exports = __export({
+var test2_exports = /* @__PURE__ */ __export({
 	default: () => test2_default,
 	"invalid-identifier": () => invalid_identifier
 });

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.browser.js
-var module_browser_exports = __export({ default: () => module_browser_default });
+var module_browser_exports = /* @__PURE__ */ __export({ default: () => module_browser_default });
 var module_browser_default;
 var init_module_browser = __esm({ "node_modules/demo-pkg/module.browser.js": (() => {
 	module_browser_default = "browser module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main/artifacts.snap
@@ -10,7 +10,7 @@ import assert, { deepEqual } from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_require_only/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_require_only/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
 var module_default;
 var init_module = __esm({ "node_modules/demo-pkg/module.js": (() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
@@ -16,7 +16,7 @@ export { foo };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = __export({ foo: () => foo });
+var a_exports = /* @__PURE__ */ __export({ foo: () => foo });
 var foo;
 var init_a = __esm({ "a.js": (() => {
 	;

--- a/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
@@ -8,12 +8,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.ts
-var a_exports = __export({ foo: () => foo$3 });
+var a_exports = /* @__PURE__ */ __export({ foo: () => foo$3 });
 let foo$3 = 123;
 
 //#endregion
 //#region b.ts
-var b_exports = __export({ foo: () => foo$2 });
+var b_exports = /* @__PURE__ */ __export({ foo: () => foo$2 });
 let foo$2 = 123;
 
 //#endregion
@@ -22,7 +22,7 @@ var Test = void 0;
 
 //#endregion
 //#region c.ts
-var c_exports = __export({
+var c_exports = /* @__PURE__ */ __export({
 	Test: () => Test,
 	foo: () => foo$1
 });
@@ -30,7 +30,7 @@ let foo$1 = 123;
 
 //#endregion
 //#region d.ts
-var d_exports = __export({
+var d_exports = /* @__PURE__ */ __export({
 	Test: () => Test,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
@@ -12,7 +12,7 @@ var nope = void 0;
 
 //#endregion
 //#region foo.ts
-var foo_exports = __export({ nope: () => nope });
+var foo_exports = /* @__PURE__ */ __export({ nope: () => nope });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region import.ts
-var import_exports = __export({ value: () => value });
+var import_exports = /* @__PURE__ */ __export({ value: () => value });
 let value = 123;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = __export({
+var esm_exports = /* @__PURE__ */ __export({
 	default: () => esm_default_fn,
 	esm_named_class: () => esm_named_class,
 	esm_named_fn: () => esm_named_fn,

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = __export({ default: () => esm_default });
+var esm_exports = /* @__PURE__ */ __export({ default: () => esm_default });
 var esm_default;
 var init_esm = __esm({ "esm.js": (() => {
 	esm_default = "esm";

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = __export({ default: () => esm_default });
+var esm_exports = /* @__PURE__ */ __export({ default: () => esm_default });
 var esm_default;
 var init_esm = __esm({ "esm.js": (() => {
 	esm_default = "esm";

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region json.js
-var json_exports = __export({ default: () => json_default });
+var json_exports = /* @__PURE__ */ __export({ default: () => json_default });
 var json_default;
 var init_json = __esm({ "json.js": (() => {
 	json_default = JSON.parse("[1, 2, 3]");

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
@@ -14,7 +14,7 @@ var require_react = /* @__PURE__ */ __commonJS({ "react.js": ((exports, module) 
 
 //#endregion
 //#region lib.js
-var lib_exports = __export({ default: () => toArray$1 });
+var lib_exports = /* @__PURE__ */ __export({ default: () => toArray$1 });
 function toArray$1(children) {
 	import_react$1.default.Children.forEach(children, function(child) {});
 	return ret;

--- a/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
@@ -20,7 +20,7 @@ const value = 1;
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({
+var foo_exports = /* @__PURE__ */ __export({
 	bar: () => import_commonjs$1.bar,
 	value: () => value
 });

--- a/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = __export({ a: () => a$1 });
+var esm_exports = /* @__PURE__ */ __export({ a: () => a$1 });
 var a$1;
 var init_esm = __esm({ "esm.js": (() => {
 	a$1 = 100;

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const foo = 1;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
@@ -40,7 +40,7 @@ require("node:assert");
 const require_chunk = require('./chunk.js');
 
 //#region esm.js
-var esm_exports = require_chunk.__export({ share: () => share });
+var esm_exports = /* @__PURE__ */ require_chunk.__export({ share: () => share });
 function share() {
 	return 1;
 }

--- a/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region lib.prod.js
-var lib_prod_exports = __export({ default: () => lib_prod_default });
+var lib_prod_exports = /* @__PURE__ */ __export({ default: () => lib_prod_default });
 var lib_prod_default;
 var init_lib_prod = __esm({ "lib.prod.js": (() => {
 	lib_prod_default = "prod";

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
@@ -17,12 +17,12 @@ export { lib_npm_a_exports as libA, lib_npm_b_exports as libB, lib_ui_exports as
 import { __export } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-npm-a/index.js
-var lib_npm_a_exports = __export({ default: () => lib_npm_a_default });
+var lib_npm_a_exports = /* @__PURE__ */ __export({ default: () => lib_npm_a_default });
 var lib_npm_a_default = "npm-a";
 
 //#endregion
 //#region node_modules/lib-npm-b/index.js
-var lib_npm_b_exports = __export({ default: () => lib_npm_b_default });
+var lib_npm_b_exports = /* @__PURE__ */ __export({ default: () => lib_npm_b_default });
 var lib_npm_b_default = "npm-b";
 
 //#endregion
@@ -51,7 +51,7 @@ export { __export };
 import { __export } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-ui/index.js
-var lib_ui_exports = __export({ default: () => lib_ui_default });
+var lib_ui_exports = /* @__PURE__ */ __export({ default: () => lib_ui_default });
 var lib_ui_default = "ui";
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/export_mode/cjs/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/cjs/default/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region mod.js
-var default_exports = __export({ default: () => example });
+var default_exports = /* @__PURE__ */ __export({ default: () => example });
 function example() {
 	return "default";
 }

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/default/artifacts.snap
@@ -11,7 +11,7 @@ var module = (function() {
 // HIDDEN [rolldown:runtime]
 
 //#region mod.js
-var default_exports = __export({
+var default_exports = /* @__PURE__ */ __export({
 	add: () => add,
 	subtract: () => subtract
 });

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
@@ -12,7 +12,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 // HIDDEN [rolldown:runtime]
 
 //#region mod.js
-var named_exports = __export({
+var named_exports = /* @__PURE__ */ __export({
 	add: () => add,
 	subtract: () => subtract
 });

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
@@ -19,7 +19,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region esm.js
-var esm_exports = __export({ value: () => value });
+var esm_exports = /* @__PURE__ */ __export({ value: () => value });
 var value;
 var init_esm = __esm({ "esm.js": (() => {
 	value = 1;

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
@@ -18,7 +18,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region esm.js
-var esm_exports = __export({ value: () => value });
+var esm_exports = /* @__PURE__ */ __export({ value: () => value });
 var value;
 var init_esm = __esm({ "esm.js": (() => {
 	value = 1;

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
@@ -21,7 +21,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 
 //#endregion
 //#region esm.js
-var esm_exports = __export({ value: () => value });
+var esm_exports = /* @__PURE__ */ __export({ value: () => value });
 var value;
 var init_esm = __esm({ "esm.js": (() => {
 	value = 1;

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -10,7 +10,7 @@ import { __esm, __export } from "./rolldown-runtime.js";
 import { init_second, value } from "./second.js";
 
 //#region first.js
-var first_exports = __export({ value: () => value$1 });
+var first_exports = /* @__PURE__ */ __export({ value: () => value$1 });
 var value$1;
 var init_first = __esm({ "first.js": (() => {
 	init_second();
@@ -50,7 +50,7 @@ import { __esm, __export } from "./rolldown-runtime.js";
 import { init_first, value } from "./first.js";
 
 //#region second.js
-var second_exports = __export({ value: () => value$1 });
+var second_exports = /* @__PURE__ */ __export({ value: () => value$1 });
 var value$1;
 var init_second = __esm({ "second.js": (() => {
 	init_first();

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = __export({ constant: () => constant });
+var lib_exports = /* @__PURE__ */ __export({ constant: () => constant });
 var constant;
 var init_lib = __esm({ "lib.js": (() => {
 	constant = 1;
@@ -49,7 +49,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = __export({ constant: () => constant });
+var lib_exports = /* @__PURE__ */ __export({ constant: () => constant });
 var constant;
 var init_lib = __esm({ "lib.js": (() => {
 	constant = 1;

--- a/crates/rolldown/tests/rolldown/issues/5923/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/5923/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "external": ["external"],
+    "minify": "dceOnly"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/5923/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5923/artifacts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+export * from "external";
+Object.defineProperty;
+Object.getOwnPropertyDescriptor;
+Object.getOwnPropertyNames;
+Object.prototype.hasOwnProperty;
+let foo;
+export { foo };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/5923/dep.js
+++ b/crates/rolldown/tests/rolldown/issues/5923/dep.js
@@ -1,0 +1,1 @@
+export * from 'external'

--- a/crates/rolldown/tests/rolldown/issues/5923/main.js
+++ b/crates/rolldown/tests/rolldown/issues/5923/main.js
@@ -1,0 +1,3 @@
+export let foo
+export * from './dep.js'
+

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
@@ -10,7 +10,7 @@ import nodeAssert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib-impl.js
-var lib_impl_exports = __export({ foo: () => foo });
+var lib_impl_exports = /* @__PURE__ */ __export({ foo: () => foo });
 function foo() {
 	return fn();
 }

--- a/crates/rolldown/tests/rolldown/misc/invalid_ident_repr/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/invalid_ident_repr/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region 1aaa.js
-var _1aaa_exports = __export({ default: () => _1aaa_default });
+var _1aaa_exports = /* @__PURE__ */ __export({ default: () => _1aaa_default });
 const a = "shared.js";
 var _1aaa_default = a;
 

--- a/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = __export({ abc: () => abc });
+var a_exports = /* @__PURE__ */ __export({ abc: () => abc });
 const abc = void 0;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({
+var foo_exports = /* @__PURE__ */ __export({
 	a: () => a,
 	a1: () => a1,
 	a2: () => a2,

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/artifacts.snap
@@ -10,7 +10,7 @@ export * from "node:fs"
 
 // HIDDEN [rolldown:runtime]
 //#region main.js
-var main_exports = __export({ main: () => main });
+var main_exports = /* @__PURE__ */ __export({ main: () => main });
 import * as import_node_fs from "node:fs";
 __reExport(main_exports, import_node_fs);
 var main;

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region main.js
-var main_exports = __export({ main: () => main });
+var main_exports = /* @__PURE__ */ __export({ main: () => main });
 __reExport(main_exports, require("node:fs"));
 var main;
 var init_main = __esm({ "main.js": (() => {

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({ default: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __export({ default: () => foo$1 });
 function foo$1(a$1$1) {
 	assert.equal(a$1$1, a$1$1);
 	assert.equal(a$1, 1);

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = __export({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
 function foo$1(a$1$1) {
 	console.log(a$1$1, a$1);
 }

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept-outside-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept-outside-circular/artifacts.snap
@@ -11,21 +11,21 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = __export({ c: () => c });
+var c_exports = /* @__PURE__ */ __export({ c: () => c });
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
 
 //#endregion
 //#region b.js
-var b_exports = __export({ b: () => b });
+var b_exports = /* @__PURE__ */ __export({ b: () => b });
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = __export({ a: () => a });
+var a_exports = /* @__PURE__ */ __export({ a: () => a });
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region child.js
-var child_exports = __export({ foo: () => foo });
+var child_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
 __rolldown_runtime__.registerModule("child.js", { exports: child_exports });
 const foo = 0;

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -31,7 +31,7 @@ export default require_exist_dep_cjs();
 import { __export } from "./chunk.js";
 
 //#region exist-dep-esm.js
-var exist_dep_esm_exports = __export({ value: () => value });
+var exist_dep_esm_exports = /* @__PURE__ */ __export({ value: () => value });
 const exist_dep_esm_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
 __rolldown_runtime__.registerModule("exist-dep-esm.js", { exports: exist_dep_esm_exports });
 const value = "exist-esm";
@@ -46,7 +46,7 @@ import { __export, __reExport, __toCommonJS, __toDynamicImportESM, __toESM } fro
 
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = __export({ foo: () => foo });
+var hmr_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 async function foo() {

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region sub/foo.js
-var foo_exports = __export({
+var foo_exports = /* @__PURE__ */ __export({
 	foo: () => foo,
 	named: () => named$2
 });
@@ -20,7 +20,7 @@ const named$2 = "foo";
 
 //#endregion
 //#region sub/bar.js
-var bar_exports = __export({
+var bar_exports = /* @__PURE__ */ __export({
 	bar: () => bar,
 	named: () => named$1
 });
@@ -31,14 +31,14 @@ const named$1 = "bar";
 
 //#endregion
 //#region sub/named.js
-var named_exports = __export({ named: () => named });
+var named_exports = /* @__PURE__ */ __export({ named: () => named });
 const named_hot = __rolldown_runtime__.createModuleHotContext("sub/named.js");
 __rolldown_runtime__.registerModule("sub/named.js", { exports: named_exports });
 const named = "named";
 
 //#endregion
 //#region sub/index.js
-var sub_exports = __export({
+var sub_exports = /* @__PURE__ */ __export({
 	bar: () => bar,
 	foo: () => foo,
 	named: () => named

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = __export({ foo: () => foo });
+var hmr_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region self_accept.js
-var self_accept_exports = __export({ foo: () => foo$1 });
+var self_accept_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
 const self_accept_hot = __rolldown_runtime__.createModuleHotContext("self_accept.js");
 __rolldown_runtime__.registerModule("self_accept.js", { exports: self_accept_exports });
 const foo$1 = "foo";
@@ -21,7 +21,7 @@ self_accept_hot.accept((mod) => {
 
 //#endregion
 //#region single_accept/child.js
-var child_exports$1 = __export({ count: () => count$2 });
+var child_exports$1 = /* @__PURE__ */ __export({ count: () => count$2 });
 const child_hot$1 = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
 __rolldown_runtime__.registerModule("single_accept/child.js", { exports: child_exports$1 });
 const count$2 = 0;
@@ -48,7 +48,7 @@ process.on("beforeExit", (code) => {
 
 //#endregion
 //#region array_accept/child.js
-var child_exports = __export({ count: () => count });
+var child_exports = /* @__PURE__ */ __export({ count: () => count });
 const child_hot = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
 __rolldown_runtime__.registerModule("array_accept/child.js", { exports: child_exports });
 const count = 0;
@@ -75,7 +75,7 @@ process.on("beforeExit", (code) => {
 
 //#endregion
 //#region optional_chaining.js
-var optional_chaining_exports = __export({ foo: () => foo });
+var optional_chaining_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const optional_chaining_hot = __rolldown_runtime__.createModuleHotContext("optional_chaining.js");
 __rolldown_runtime__.registerModule("optional_chaining.js", { exports: optional_chaining_exports });
 const foo = "foo";

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
@@ -9,28 +9,28 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region common.js
-var common_exports = __export({ prefix: () => prefix });
+var common_exports = /* @__PURE__ */ __export({ prefix: () => prefix });
 const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
 __rolldown_runtime__.registerModule("common.js", { exports: common_exports });
 const prefix = "prefix:";
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
 
 //#endregion
 //#region bar.js
-var bar_exports = __export({ bar: () => bar });
+var bar_exports = /* @__PURE__ */ __export({ bar: () => bar });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
 
 //#endregion
 //#region messenger.js
-var messenger_exports = __export({
+var messenger_exports = /* @__PURE__ */ __export({
 	msg: () => msg,
 	sayMessage: () => sayMessage
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
@@ -9,28 +9,28 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region common.js
-var common_exports = __export({ prefix: () => prefix });
+var common_exports = /* @__PURE__ */ __export({ prefix: () => prefix });
 const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
 __rolldown_runtime__.registerModule("common.js", { exports: common_exports });
 const prefix = "prefix:";
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
 
 //#endregion
 //#region bar.js
-var bar_exports = __export({ bar: () => bar });
+var bar_exports = /* @__PURE__ */ __export({ bar: () => bar });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
 
 //#endregion
 //#region messenger.js
-var messenger_exports = __export({
+var messenger_exports = /* @__PURE__ */ __export({
 	msg: () => msg,
 	sayMessage: () => sayMessage
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -10,7 +10,7 @@ import { __export } from "./chunk.js";
 import { trim } from "./string.js";
 
 //#region bar.js
-var bar_exports = __export({ default: () => bar_default });
+var bar_exports = /* @__PURE__ */ __export({ default: () => bar_default });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 function bar_default() {
@@ -33,7 +33,7 @@ import { __export } from "./chunk.js";
 import { trim, unused } from "./string.js";
 
 //#region utils/index.js
-var utils_exports = __export({
+var utils_exports = /* @__PURE__ */ __export({
 	trim: () => trim,
 	unused: () => unused
 });
@@ -42,7 +42,7 @@ __rolldown_runtime__.registerModule("utils/index.js", { exports: utils_exports }
 
 //#endregion
 //#region foo.js
-var foo_exports = __export({ default: () => foo_default });
+var foo_exports = /* @__PURE__ */ __export({ default: () => foo_default });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 function foo_default() {
@@ -75,7 +75,7 @@ const routes = {
 import { __export } from "./chunk.js";
 
 //#region utils/string.js
-var string_exports = __export({
+var string_exports = /* @__PURE__ */ __export({
 	trim: () => trim,
 	unused: () => unused
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/no-accept-outside-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/no-accept-outside-circular/artifacts.snap
@@ -11,21 +11,21 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = __export({ c: () => c });
+var c_exports = /* @__PURE__ */ __export({ c: () => c });
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
 
 //#endregion
 //#region b.js
-var b_exports = __export({ b: () => b });
+var b_exports = /* @__PURE__ */ __export({ b: () => b });
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = __export({ a: () => a });
+var a_exports = /* @__PURE__ */ __export({ a: () => a });
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };

--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = __export({ foo: () => foo });
+var hmr_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -18,7 +18,7 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
 //#endregion
 //#region esm.js
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
-var esm_exports = __export({ value: () => value });
+var esm_exports = /* @__PURE__ */ __export({ value: () => value });
 const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
 __rolldown_runtime__.registerModule("esm.js", { exports: esm_exports });
 const value = "main";

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -100,7 +100,7 @@ assert.strictEqual(requiredUmdLib.foo, "foo");
 
 //#endregion
 //#region cases/manual_reexport/lib.js
-var lib_exports = __export({
+var lib_exports = /* @__PURE__ */ __export({
 	Globals: () => Globals,
 	value: () => value
 });
@@ -112,7 +112,7 @@ const value = "lib";
 
 //#endregion
 //#region cases/manual_reexport/barrel.js
-var barrel_exports = __export({
+var barrel_exports = /* @__PURE__ */ __export({
 	Globals: () => Globals,
 	value: () => value
 });
@@ -131,7 +131,7 @@ assert.strictEqual(Globals, Object);
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo.mjs
-var foo_exports = __export({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
 init_trigger_dep();
 const foo_hot$1 = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo.mjs");
 __rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo.mjs", { exports: foo_exports });
@@ -139,7 +139,7 @@ const foo$1 = "foo";
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo/index.mjs
-var foo_exports$1 = __export({ foo: () => foo });
+var foo_exports$1 = /* @__PURE__ */ __export({ foo: () => foo });
 init_trigger_dep();
 const foo_hot = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo/index.mjs");
 __rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo/index.mjs", { exports: foo_exports$1 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = __export({ c: () => c });
+var c_exports = /* @__PURE__ */ __export({ c: () => c });
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
@@ -22,14 +22,14 @@ c_hot.accept((nextExports) => {
 
 //#endregion
 //#region b.js
-var b_exports = __export({ b: () => b });
+var b_exports = /* @__PURE__ */ __export({ b: () => b });
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = __export({ a: () => a });
+var a_exports = /* @__PURE__ */ __export({ a: () => a });
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -20,7 +20,7 @@ var require_dep_cjs = /* @__PURE__ */ __commonJS({ "modules/dep-cjs.js": ((expor
 //#endregion
 //#region modules/dep-esm.js
 var import_dep_cjs = /* @__PURE__ */ __toESM(require_dep_cjs());
-var dep_esm_exports = __export({ value: () => value$1 });
+var dep_esm_exports = /* @__PURE__ */ __export({ value: () => value$1 });
 const dep_esm_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm.js");
 __rolldown_runtime__.registerModule("modules/dep-esm.js", { exports: dep_esm_exports });
 const value$1 = "esm";
@@ -36,7 +36,7 @@ var require_dep_cjs_default = /* @__PURE__ */ __commonJS({ "modules/dep-cjs-defa
 //#endregion
 //#region modules/dep-esm-default.js
 var import_dep_cjs_default = /* @__PURE__ */ __toESM(require_dep_cjs_default());
-var dep_esm_default_exports = __export({ default: () => dep_esm_default_default });
+var dep_esm_default_exports = /* @__PURE__ */ __export({ default: () => dep_esm_default_default });
 const dep_esm_default_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-default.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-default.js", { exports: dep_esm_default_exports });
 var dep_esm_default_default = "esm-default";
@@ -52,7 +52,7 @@ var require_dep_cjs_named = /* @__PURE__ */ __commonJS({ "modules/dep-cjs-named.
 //#endregion
 //#region modules/dep-esm-named.js
 var import_dep_cjs_named = /* @__PURE__ */ __toESM(require_dep_cjs_named());
-var dep_esm_named_exports = __export({ named: () => named });
+var dep_esm_named_exports = /* @__PURE__ */ __export({ named: () => named });
 const dep_esm_named_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-named.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-named.js", { exports: dep_esm_named_exports });
 const named = "esm-named";
@@ -68,7 +68,7 @@ var require_dep_cjs_namespace = /* @__PURE__ */ __commonJS({ "modules/dep-cjs-na
 //#endregion
 //#region modules/dep-esm-namespace.js
 var import_dep_cjs_namespace = /* @__PURE__ */ __toESM(require_dep_cjs_namespace());
-var dep_esm_namespace_exports = __export({ value: () => value });
+var dep_esm_namespace_exports = /* @__PURE__ */ __export({ value: () => value });
 const dep_esm_namespace_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-namespace.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-namespace.js", { exports: dep_esm_namespace_exports });
 const value = "esm-namespace";

--- a/crates/rolldown/tests/rolldown/topics/keep_names/declaration2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/declaration2/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = __export({
+var a_exports = /* @__PURE__ */ __export({
 	delay: () => delay$1,
 	random64: () => random64$1
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region main.js
-var main_exports = __export({
+var main_exports = /* @__PURE__ */ __export({
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
@@ -24,7 +24,7 @@ export { main_default as default, foo };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region main.js
-var main_exports = __export({
+var main_exports = /* @__PURE__ */ __export({
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
@@ -10,7 +10,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 // HIDDEN [rolldown:runtime]
 
 //#region main.js
-var main_exports = __export({
+var main_exports = /* @__PURE__ */ __export({
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/tla/inline_dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/inline_dynamic_import/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region c.js
-var c_exports = __export({ default: () => c_default });
+var c_exports = /* @__PURE__ */ __export({ default: () => c_default });
 var _default, c_default;
 var init_c = __esm({ "c.js": (() => {
 	_default = { aaa: { bbb: [
@@ -33,7 +33,7 @@ var init_b = __esm({ "b.js": (async () => {
 
 //#endregion
 //#region a.js
-var a_exports = __export({ buildDevConfig: () => buildDevConfig });
+var a_exports = /* @__PURE__ */ __export({ buildDevConfig: () => buildDevConfig });
 var buildDevConfig;
 var init_a = __esm({ "a.js": (async () => {
 	await init_b();

--- a/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
@@ -12,7 +12,7 @@ const foo = 1;
 
 //#endregion
 //#region export-star.js
-var export_star_exports = __export({ foo: () => foo });
+var export_star_exports = /* @__PURE__ */ __export({ foo: () => foo });
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format/artifacts.snap
@@ -19,7 +19,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js
-var lib_exports = __export({ default: () => lib_default });
+var lib_exports = /* @__PURE__ */ __export({ default: () => lib_default });
 var lib_default;
 var init_lib = __esm({ "lib.js": (() => {
 	lib_default = 2;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -268,7 +268,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_main
 
-- src_entry-!~{000}~.js => src_entry-Biwgb54B.js
+- src_entry-!~{000}~.js => src_entry-CEzKWI0f.js
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_main_implicit_module
 
@@ -284,7 +284,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_main
 
-- src_entry-!~{000}~.js => src_entry-BVzn7Bih.js
+- src_entry-!~{000}~.js => src_entry-Bw-ouNrt.js
 
 # tests/esbuild/dce/package_json_side_effects_array_keep_module_implicit_module
 
@@ -337,7 +337,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6
 
-- src_entry-!~{000}~.js => src_entry-Bg51fX9c.js
+- src_entry-!~{000}~.js => src_entry-CPU2qgfH.js
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js
 
@@ -353,7 +353,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6
 
-- src_entry-!~{000}~.js => src_entry-_8n9Gg9b.js
+- src_entry-!~{000}~.js => src_entry-B1tpCItc.js
 
 # tests/esbuild/dce/package_json_side_effects_false_no_warning_in_node_modules_issue999
 
@@ -479,7 +479,7 @@ expression: output
 
 # tests/esbuild/dce/tree_shaking_in_esm_wrapper
 
-- entry-!~{000}~.js => entry-Ch5Z_C5n.js
+- entry-!~{000}~.js => entry-Bh0SBS6V.js
 
 # tests/esbuild/dce/tree_shaking_js_with_associated_css
 
@@ -609,7 +609,7 @@ expression: output
 
 # tests/esbuild/default/common_js_from_es6
 
-- entry-!~{000}~.js => entry-_Qm1Sgig.js
+- entry-!~{000}~.js => entry-IN8wLYVt.js
 
 # tests/esbuild/default/conditional_import
 
@@ -718,24 +718,24 @@ expression: output
 
 # tests/esbuild/default/export_forms_common_js
 
-- entry-!~{000}~.js => entry-Cc14oagr.js
+- entry-!~{000}~.js => entry-Cjg-R_al.js
 
 # tests/esbuild/default/export_forms_es6
 
-- entry-!~{000}~.js => entry-DayGGSFD.js
+- entry-!~{000}~.js => entry-BeM-awMj.js
 
 # tests/esbuild/default/export_forms_iife
 
-- entry-!~{000}~.js => entry-Bdnwpg2R.js
+- entry-!~{000}~.js => entry-BoA_Bz4x.js
 
 # tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle
 
-- a-!~{000}~.js => a-DdIa7K-V.js
-- b-!~{001}~.js => b-BgmrRy4H.js
+- a-!~{000}~.js => a-CCLkgzBI.js
+- b-!~{001}~.js => b-CfYqhmnk.js
 - c-!~{002}~.js => c-DbAYnqxj.js
 - d-!~{003}~.js => d-erhulghW.js
 - e-!~{004}~.js => e-BluWtRWc.js
-- b-!~{005}~.js => b-Bac6rVcX.js
+- b-!~{005}~.js => b-BiAqcQ2h.js
 
 # tests/esbuild/default/export_fs_browser
 
@@ -767,11 +767,11 @@ expression: output
 
 # tests/esbuild/default/exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-4Yy9KgCs.js
+- entry-!~{000}~.js => entry-Bh_mT5--.js
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
-- entry-!~{000}~.js => entry-r88d_BX_.js
+- entry-!~{000}~.js => entry-CiqIcGjY.js
 
 # tests/esbuild/default/external_module_exclusion_package
 
@@ -799,7 +799,7 @@ expression: output
 
 # tests/esbuild/default/forbid_string_export_names_bundle
 
-- entry-!~{000}~.js => entry-Ba685RuS.js
+- entry-!~{000}~.js => entry-CD8wldMK.js
 
 # tests/esbuild/default/forbid_string_export_names_no_bundle
 
@@ -1148,9 +1148,9 @@ expression: output
 
 # tests/esbuild/default/mangle_props_import_export_bundled
 
-- entry-cjs-!~{001}~.js => entry-cjs-qwEKIqFz.js
-- entry-esm-!~{000}~.js => entry-esm-D1abGL0i.js
-- cjs-!~{002}~.js => cjs-cvdrm0sT.js
+- entry-cjs-!~{001}~.js => entry-cjs-D6HglLGC.js
+- entry-esm-!~{000}~.js => entry-esm-30aofPQG.js
+- cjs-!~{002}~.js => cjs-DrCCHDdE.js
 
 # tests/esbuild/default/mangle_props_jsx_preserve
 
@@ -1303,7 +1303,7 @@ expression: output
 
 # tests/esbuild/default/minified_exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-C1j_QgfI.js
+- entry-!~{000}~.js => entry-DAahXalj.js
 
 # tests/esbuild/default/minified_jsx_preserve_with_object_spread
 
@@ -1762,19 +1762,19 @@ expression: output
 
 # tests/esbuild/importstar/export_self_and_import_self_common_js
 
-- entry-!~{000}~.js => entry-Df6PbQiR.js
+- entry-!~{000}~.js => entry-BXU-CvFX.js
 
 # tests/esbuild/importstar/export_self_and_require_self_common_js
 
-- entry-!~{000}~.js => entry-D9UjBAad.js
+- entry-!~{000}~.js => entry-CbXriUjv.js
 
 # tests/esbuild/importstar/export_self_as_namespace_common_js
 
-- entry-!~{000}~.js => entry-Bno3TDqw.js
+- entry-!~{000}~.js => entry-CqgwbM7x.js
 
 # tests/esbuild/importstar/export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-DkNRVnGH.js
+- entry-!~{000}~.js => entry-BjuprFH4.js
 
 # tests/esbuild/importstar/export_self_common_js
 
@@ -1808,13 +1808,13 @@ expression: output
 - external-ns-!~{001}~.js => external-ns-all2LFha.js
 - external-ns-def-!~{003}~.js => external-ns-def-CPrnmGVn.js
 - external-ns-default-!~{002}~.js => external-ns-default-Cbqf8eIs.js
-- internal-def-!~{00b}~.js => internal-def-D6qFot6Z.js
-- internal-default-!~{00a}~.js => internal-default-Dvw9i2jP.js
-- internal-default2-!~{006}~.js => internal-default2-C4y52FIj.js
-- internal-ns-def-!~{009}~.js => internal-ns-def-BJfruA94.js
-- internal-ns-default-!~{008}~.js => internal-ns-default-DR81cm7V.js
-- internal-ns-!~{007}~.js => internal-ns-xQOY01s7.js
-- internal-!~{00c}~.js => internal-BKiSDmWN.js
+- internal-def-!~{00b}~.js => internal-def-C1dYR6OX.js
+- internal-default-!~{00a}~.js => internal-default-DHVmIuVq.js
+- internal-default2-!~{006}~.js => internal-default2-Ci1cyXOL.js
+- internal-ns-def-!~{009}~.js => internal-ns-def-CIi59e0J.js
+- internal-ns-default-!~{008}~.js => internal-ns-default-qzsc-H6r.js
+- internal-ns-!~{007}~.js => internal-ns-nrzgvc6S.js
+- internal-!~{00c}~.js => internal-BgvGs5hJ.js
 
 # tests/esbuild/importstar/import_export_other_as_namespace_common_js
 
@@ -1822,7 +1822,7 @@ expression: output
 
 # tests/esbuild/importstar/import_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-DkNRVnGH.js
+- entry-!~{000}~.js => entry-BjuprFH4.js
 
 # tests/esbuild/importstar/import_export_star_ambiguous_warning
 
@@ -1854,11 +1854,11 @@ expression: output
 
 # tests/esbuild/importstar/import_star_and_common_js
 
-- entry-!~{000}~.js => entry-CXrtuzyh.js
+- entry-!~{000}~.js => entry-BdAfbRqL.js
 
 # tests/esbuild/importstar/import_star_capture
 
-- entry-!~{000}~.js => entry-VUr8y8P7.js
+- entry-!~{000}~.js => entry-_hDqUGXo.js
 
 # tests/esbuild/importstar/import_star_common_js_capture
 
@@ -1874,7 +1874,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_import_star_capture
 
-- entry-!~{000}~.js => entry-VUr8y8P7.js
+- entry-!~{000}~.js => entry-_hDqUGXo.js
 
 # tests/esbuild/importstar/import_star_export_import_star_no_capture
 
@@ -1886,7 +1886,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_as_capture
 
-- entry-!~{000}~.js => entry-VUr8y8P7.js
+- entry-!~{000}~.js => entry-_hDqUGXo.js
 
 # tests/esbuild/importstar/import_star_export_star_as_no_capture
 
@@ -1898,7 +1898,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_capture
 
-- entry-!~{000}~.js => entry-DAjDO2yg.js
+- entry-!~{000}~.js => entry-CHrbBx1A.js
 
 # tests/esbuild/importstar/import_star_export_star_no_capture
 
@@ -1906,7 +1906,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_omit_ambiguous
 
-- entry-!~{000}~.js => entry-n_Rt-Wwa.js
+- entry-!~{000}~.js => entry-Bnf3CkQy.js
 
 # tests/esbuild/importstar/import_star_export_star_unused
 
@@ -1942,7 +1942,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_of_export_star_as
 
-- entry-!~{000}~.js => entry-Dtim_c16.js
+- entry-!~{000}~.js => entry-BlKWwTFz.js
 
 # tests/esbuild/importstar/import_star_unused
 
@@ -1950,7 +1950,7 @@ expression: output
 
 # tests/esbuild/importstar/issue176
 
-- entry-!~{000}~.js => entry-Z5jFUXBf.js
+- entry-!~{000}~.js => entry-CjdfFNLl.js
 
 # tests/esbuild/importstar/namespace_import_missing_common_js
 
@@ -1958,11 +1958,11 @@ expression: output
 
 # tests/esbuild/importstar/namespace_import_missing_es6
 
-- entry-!~{000}~.js => entry-CcCtNz9R.js
+- entry-!~{000}~.js => entry-CBJDv8Qi.js
 
 # tests/esbuild/importstar/namespace_import_re_export_star_missing_es6
 
-- entry-!~{000}~.js => entry-C435rsHL.js
+- entry-!~{000}~.js => entry-CsYg5oXs.js
 
 # tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6
 
@@ -1986,7 +1986,7 @@ expression: output
 
 # tests/esbuild/importstar/re_export_namespace_import_missing_es6
 
-- entry-!~{000}~.js => entry-BrB38k73.js
+- entry-!~{000}~.js => entry-D0HzRlDE.js
 
 # tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6
 
@@ -1994,11 +1994,11 @@ expression: output
 
 # tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-2teKaFI_.js
+- entry-!~{000}~.js => entry-DKqYdbJV.js
 
 # tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-2teKaFI_.js
+- entry-!~{000}~.js => entry-DKqYdbJV.js
 
 # tests/esbuild/importstar/re_export_star_as_common_js_no_bundle
 
@@ -2070,11 +2070,11 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_and_common_js
 
-- entry-!~{000}~.js => entry-DihndQL7.js
+- entry-!~{000}~.js => entry-sBQq59-L.js
 
 # tests/esbuild/importstar_ts/ts_import_star_capture
 
-- entry-!~{000}~.js => entry-Du5EsJhu.js
+- entry-!~{000}~.js => entry-Cl5Vkmqy.js
 
 # tests/esbuild/importstar_ts/ts_import_star_common_js_capture
 
@@ -2090,7 +2090,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture
 
-- entry-!~{000}~.js => entry-Du5EsJhu.js
+- entry-!~{000}~.js => entry-Cl5Vkmqy.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_import_star_no_capture
 
@@ -2102,7 +2102,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture
 
-- entry-!~{000}~.js => entry-Du5EsJhu.js
+- entry-!~{000}~.js => entry-Cl5Vkmqy.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_as_no_capture
 
@@ -2114,7 +2114,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_capture
 
-- entry-!~{000}~.js => entry-lE32ZYXe.js
+- entry-!~{000}~.js => entry-CaSEsR28.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_no_capture
 
@@ -2368,7 +2368,7 @@ expression: output
 
 # tests/esbuild/loader/loader_json_invalid_identifier_es6
 
-- entry-!~{000}~.js => entry-76Dcw4f0.js
+- entry-!~{000}~.js => entry-u_TCkpaS.js
 
 # tests/esbuild/loader/loader_json_no_bundle
 
@@ -2882,27 +2882,27 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser
 
-- entry-!~{000}~.js => entry-J9YPH-8s.js
+- entry-!~{000}~.js => entry-DogXmJmV.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main
 
-- entry-!~{000}~.js => entry-DYc5YvpD.js
+- entry-!~{000}~.js => entry-D99qNyJV.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main
 
-- entry-!~{000}~.js => entry-C5w2T6aE.js
+- entry-!~{000}~.js => entry-BNWUb0X9.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main
 
-- entry-!~{000}~.js => entry-D6VqqiBX.js
+- entry-!~{000}~.js => entry-BExISjX_.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file
 
-- entry-!~{000}~.js => entry-C-3Cffxq.js
+- entry-!~{000}~.js => entry-DLhTMHwQ.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files
 
-- entry-!~{000}~.js => entry-B7XRV-iE.js
+- entry-!~{000}~.js => entry-LkyB3fD_.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_only
 
@@ -2910,7 +2910,7 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_require_only
 
-- entry-!~{000}~.js => entry-jOmuMTwQ.js
+- entry-!~{000}~.js => entry-Dvtev-pA.js
 
 # tests/esbuild/packagejson/package_json_exports_alternatives
 
@@ -3160,9 +3160,9 @@ expression: output
 
 # tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617
 
-- a-!~{000}~.js => a-D-xQQWxE.js
-- b-!~{001}~.js => b-Cxue9W_B.js
-- a-!~{002}~.js => a-CccJr8tQ.js
+- a-!~{000}~.js => a-B9GwE8N7.js
+- b-!~{001}~.js => b-BHMIWFdM.js
+- a-!~{002}~.js => a-pKIN51wc.js
 
 # tests/esbuild/splitting/splitting_minify_identifiers_crash_issue437
 
@@ -3219,7 +3219,7 @@ expression: output
 
 # tests/esbuild/ts/export_type_issue379
 
-- entry-!~{000}~.js => entry-BPSBkCDH.js
+- entry-!~{000}~.js => entry-BBYP0tLb.js
 
 # tests/esbuild/ts/this_inside_function_ts
 
@@ -3373,7 +3373,7 @@ expression: output
 
 # tests/esbuild/ts/ts_export_missing_es6
 
-- entry-!~{000}~.js => entry-09b_LUP2.js
+- entry-!~{000}~.js => entry-B57sPqkR.js
 
 # tests/esbuild/ts/ts_export_namespace
 
@@ -3409,7 +3409,7 @@ expression: output
 
 # tests/esbuild/ts/ts_import_equals_undefined_import
 
-- entry-!~{000}~.js => entry-DfzI7ukJ.js
+- entry-!~{000}~.js => entry--I4RUSxy.js
 
 # tests/esbuild/ts/ts_import_missing_unused_es6
 
@@ -3529,7 +3529,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/basic_commonjs
 
-- main-!~{000}~.js => main-ZAOrHxCO.js
+- main-!~{000}~.js => main-B3DA0eHd.js
 
 # tests/rolldown/cjs_compat/cjs_entry
 
@@ -3547,11 +3547,11 @@ expression: output
 
 # tests/rolldown/cjs_compat/esm_require_esm
 
-- main-!~{000}~.js => main-CQ-YEDNY.js
+- main-!~{000}~.js => main-BW8EXkqu.js
 
 # tests/rolldown/cjs_compat/esm_require_esm_unused
 
-- main-!~{000}~.js => main-1rr5PQn6.js
+- main-!~{000}~.js => main-3ctdt5dx.js
 
 # tests/rolldown/cjs_compat/exoprt_star_of_cjs
 
@@ -3608,7 +3608,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout
 
-- main-!~{000}~.js => main-B-0t9dC5.js
+- main-!~{000}~.js => main-KgWL-VeZ.js
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout2
 
@@ -3624,7 +3624,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_2
 
-- main-!~{000}~.js => main-BPEEeSnZ.js
+- main-!~{000}~.js => main-BCBPebdk.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize
 
@@ -3642,7 +3642,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/reexport_commonjs
 
-- main-!~{000}~.js => main-Dc0aPQlr.js
+- main-!~{000}~.js => main-BDK85hSM.js
 
 # tests/rolldown/cjs_compat/reexports_from_cjs
 
@@ -3664,7 +3664,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/require_call_expr_unused
 
-- main-!~{000}~.js => main-703RZrFB.js
+- main-!~{000}~.js => main-B6W2-z2V.js
 
 # tests/rolldown/cjs_compat/unnecessary_compat_default_property_access
 
@@ -3679,9 +3679,9 @@ expression: output
 
 # tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file
 
-- main-!~{000}~.js => main-BUFrpW9Y.js
-- foo-!~{001}~.js => foo-Cxw82iPH.js
-- foo-!~{003}~.js => foo-DgyqTdlt.js
+- main-!~{000}~.js => main-Bh3wu1El.js
+- foo-!~{003}~.js => foo-BFa84b2T.js
+- foo-!~{001}~.js => foo-BNFXuCA7.js
 
 # tests/rolldown/code_splitting/ensure_safe_identifier
 
@@ -3704,7 +3704,7 @@ expression: output
 # tests/rolldown/code_splitting/format_cjs_with_esm_require_esm
 
 - main1-!~{000}~.js => main1-Bc4ggQKQ.js
-- main2-!~{001}~.js => main2-DM5RLY0k.js
+- main2-!~{001}~.js => main2-CMxXCXyG.js
 - chunk-!~{002}~.js => chunk-DF4tzTM3.js
 
 # tests/rolldown/code_splitting/format_cjs_with_module_cjs
@@ -3729,7 +3729,7 @@ expression: output
 
 # tests/rolldown/dce/conditional_exports
 
-- main-!~{000}~.js => main-Dy392c9y.js
+- main-!~{000}~.js => main-C_ykWGwH.js
 
 # tests/rolldown/dce/defined_expr_in_paren_expr
 
@@ -3830,10 +3830,10 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/split_node_modules
 
-- main-!~{000}~.js => main-Ctm_x4Ek.js
-- other-libs-!~{005}~.js => other-libs-BdmYiJt_.js
+- main-!~{000}~.js => main-aXwtU-I-.js
+- other-libs-!~{005}~.js => other-libs-Bb5eXrIp.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BjHBHhXT.js
-- ui-!~{003}~.js => ui-CSTCN2Vb.js
+- ui-!~{003}~.js => ui-Bf0tm2vu.js
 
 # tests/rolldown/function/context/defined
 
@@ -3965,7 +3965,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-BGzbxmYX.js
+- main-!~{000}~.js => main-DuE427jl.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4035,7 +4035,7 @@ expression: output
 
 # tests/rolldown/function/export_mode/cjs/default
 
-- main-!~{000}~.js => main-CgXEmowS.js
+- main-!~{000}~.js => main-DcU6NuQI.js
 
 # tests/rolldown/function/export_mode/cjs/named
 
@@ -4047,11 +4047,11 @@ expression: output
 
 # tests/rolldown/function/export_mode/iife/default
 
-- main-!~{000}~.js => main-CCbYYn2i.js
+- main-!~{000}~.js => main-CIGIL4Cn.js
 
 # tests/rolldown/function/export_mode/iife/named
 
-- main-!~{000}~.js => main-DNIzrg4L.js
+- main-!~{000}~.js => main-DJKY92-1.js
 
 # tests/rolldown/function/export_mode/umd/auto/none
 
@@ -4265,15 +4265,15 @@ expression: output
 
 # tests/rolldown/function/inline_dynamic_imports/cjs
 
-- main-!~{000}~.js => main-BLU4az0x.js
+- main-!~{000}~.js => main-D-mRkfFo.js
 
 # tests/rolldown/function/inline_dynamic_imports/esm
 
-- main-!~{000}~.js => main-C_6_o5s_.js
+- main-!~{000}~.js => main-CShVuTUP.js
 
 # tests/rolldown/function/inline_dynamic_imports/iife
 
-- main-!~{000}~.js => main-DmibGmq5.js
+- main-!~{000}~.js => main-BCBDWXHd.js
 
 # tests/rolldown/function/intro/cjs
 
@@ -4623,10 +4623,10 @@ expression: output
 
 # tests/rolldown/issues/3650
 
-- main-!~{000}~.js => main-CNfqSJvQ.js
-- first-!~{005}~.js => first-dH-SJVGL.js
+- main-!~{000}~.js => main-wM0ExBa-.js
+- first-!~{005}~.js => first-DkeNlDhv.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-Czh5gyOq.js
-- second-!~{003}~.js => second-DcOieJYm.js
+- second-!~{003}~.js => second-D44Eph83.js
 
 # tests/rolldown/issues/3746/a
 
@@ -4648,7 +4648,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-kqhYXZ73.js
+- main-!~{000}~.js => main-8paqTwQ3.js
 
 # tests/rolldown/issues/4196
 
@@ -4755,11 +4755,15 @@ expression: output
 
 # tests/rolldown/issues/5870
 
-- main-!~{000}~.js => main-DpHdvOC_.js
+- main-!~{000}~.js => main-RTlOtn4-.js
+
+# tests/rolldown/issues/5923
+
+- main-!~{000}~.js => main-DgJmHtwB.js
 
 # tests/rolldown/issues/rolldown_vite_289
 
-- main-!~{000}~.js => main-BQVOIIRp.js
+- main-!~{000}~.js => main-Bldhf8JA.js
 
 # tests/rolldown/misc/ambiguous_star_export
 
@@ -4831,7 +4835,7 @@ expression: output
 
 # tests/rolldown/misc/invalid_ident_repr
 
-- main-!~{000}~.js => main-CCn2s5l7.js
+- main-!~{000}~.js => main-CW2mE44C.js
 
 # tests/rolldown/misc/merge_external_import
 
@@ -4950,9 +4954,9 @@ expression: output
 
 # tests/rolldown/misc/reexport_star
 
-- entry-!~{001}~.js => entry-CQ3P4yX9.js
-- main-!~{000}~.js => main-yPapkCtB.js
-- a-!~{002}~.js => a-DBw9R85P.js
+- entry-!~{001}~.js => entry-BQhXSQ7k.js
+- main-!~{000}~.js => main-DCKAGXaA.js
+- a-!~{002}~.js => a-BikrYMBH.js
 
 # tests/rolldown/misc/reexport_star_from_local_named_export
 
@@ -4992,8 +4996,8 @@ expression: output
 
 # tests/rolldown/misc/wrapped_esm
 
-- main-!~{000}~.js => main-CRWxNdQs.js
-- main-CRWxNdQs.js.map
+- main-!~{000}~.js => main-D4QvxGXc.js
+- main-D4QvxGXc.js.map
 
 # tests/rolldown/optimization/inline_const/5197
 
@@ -5090,11 +5094,11 @@ expression: output
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry
 
-- entry-!~{000}~.js => entry-RkGIJBmQ.js
+- entry-!~{000}~.js => entry-BTfWKMP6.js
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs
 
-- entry-!~{000}~.js => entry-C2z5N-mK.js
+- entry-!~{000}~.js => entry-BlQk7pLl.js
 
 # tests/rolldown/sourcemap/css_sourcemap_reference
 
@@ -5147,15 +5151,15 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/12
 
-- entry-!~{000}~.js => entry-DL64exNB.js
-- foo-!~{003}~.js => foo-Dkt_SCGT.js
-- foo-!~{001}~.js => foo-kAxgQP-y.js
+- entry-!~{000}~.js => entry-C_ltREyT.js
+- foo-!~{003}~.js => foo-D6UQdwbh.js
+- foo-!~{001}~.js => foo-D8wN_Ff_.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/13
 
-- entry-!~{000}~.js => entry-D-Us-y9Y.js
-- foo-!~{003}~.js => foo-Dkt_SCGT.js
-- foo-!~{001}~.js => foo-kAxgQP-y.js
+- entry-!~{000}~.js => entry-CZ589tB0.js
+- foo-!~{003}~.js => foo-D6UQdwbh.js
+- foo-!~{001}~.js => foo-D8wN_Ff_.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/14
 
@@ -5175,11 +5179,11 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/18
 
-- entry-!~{000}~.js => entry-CdIksLYW.js
+- entry-!~{000}~.js => entry-C2GEQhQn.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/19
 
-- entry-!~{000}~.js => entry-C_yFdCg6.js
+- entry-!~{000}~.js => entry-BpyofWHE.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/2
 
@@ -5187,27 +5191,27 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/20
 
-- entry-!~{000}~.js => entry-D2s1KPDY.js
+- entry-!~{000}~.js => entry-D4yNC4xV.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/21
 
-- entry-!~{000}~.js => entry-DXIr15V3.js
+- entry-!~{000}~.js => entry-BO767DKO.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/22
 
-- entry-!~{000}~.js => entry-DFuGINdK.js
+- entry-!~{000}~.js => entry-D4Q8M9Xd.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/23
 
-- entry-!~{000}~.js => entry-kqfDV4GG.js
+- entry-!~{000}~.js => entry-u9g4xLUi.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/24
 
-- entry-!~{000}~.js => entry-DRzUTC9W.js
+- entry-!~{000}~.js => entry-CsRkNRXa.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/25
 
-- entry-!~{000}~.js => entry-BtI7K_G-.js
+- entry-!~{000}~.js => entry-DzNXKRGr.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/26
 
@@ -5281,7 +5285,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/41
 
-- entry-!~{000}~.js => entry-Cwr2Y78C.js
+- entry-!~{000}~.js => entry-CZYQVjz6.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/42
 
@@ -5289,7 +5293,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/43
 
-- entry-!~{000}~.js => entry-BuG09Ee_.js
+- entry-!~{000}~.js => entry-BAAz53Xw.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/44
 
@@ -5297,15 +5301,15 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/45
 
-- entry-!~{000}~.js => entry-C3CmoNjW.js
+- entry-!~{000}~.js => entry-Dibx0lfj.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/46
 
-- entry-!~{000}~.js => entry-DJktq6lt.js
+- entry-!~{000}~.js => entry-Dl_-cBjN.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/47
 
-- entry-!~{000}~.js => entry-TZy3LrQI.js
+- entry-!~{000}~.js => entry-BURAqFI0.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/48
 
@@ -5381,7 +5385,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/7
 
-- entry-!~{000}~.js => entry-6Xo6AB0Y.js
+- entry-!~{000}~.js => entry-CNc9LSlK.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/8
 
@@ -5389,7 +5393,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/9
 
-- entry-!~{000}~.js => entry-BljtslFW.js
+- entry-!~{000}~.js => entry-otT1GsY_.js
 
 # tests/rolldown/topics/chunk_modules_order/basic
 
@@ -5478,90 +5482,90 @@ expression: output
 
 # tests/rolldown/topics/deconflict/wrapped_esm_default_function
 
-- main-!~{000}~.js => main-BJztRJka.js
-- main-BJztRJka.js.map
+- main-!~{000}~.js => main-DozknKTF.js
+- main-DozknKTF.js.map
 
 # tests/rolldown/topics/deconflict/wrapped_esm_export_named_function
 
-- main-!~{000}~.js => main-C9tEB531.js
-- main-C9tEB531.js.map
+- main-!~{000}~.js => main-CzUffRKc.js
+- main-CzUffRKc.js.map
 
 # tests/rolldown/topics/hmr/accept-outside-circular
 
-- main-!~{000}~.js => main-C4_HK0BM.js
+- main-!~{000}~.js => main-EkO3z54D.js
 
 # tests/rolldown/topics/hmr/change_accept
 
-- main-!~{000}~.js => main-DwvRKiBP.js
+- main-!~{000}~.js => main-C7hV0jup.js
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-C9cxbImV.js
+- main-!~{000}~.js => main-DAbcTv6s.js
 - chunk-!~{001}~.js => chunk-DNTYBYor.js
 - exist-dep-cjs-!~{003}~.js => exist-dep-cjs-BjEGgMv1.js
-- exist-dep-esm-!~{005}~.js => exist-dep-esm-m-fUSw9r.js
+- exist-dep-esm-!~{005}~.js => exist-dep-esm-Bz8YTEOv.js
 
 # tests/rolldown/topics/hmr/export_star
 
-- main-!~{000}~.js => main-D8NGspIA.js
+- main-!~{000}~.js => main-CBtuVZ5J.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-r_uFwTr3.js
+- main-!~{000}~.js => main-Dy4Q3F5t.js
 
 # tests/rolldown/topics/hmr/import_meta_hot_accept
 
-- main-!~{000}~.js => main-B5bOoDRD.js
+- main-!~{000}~.js => main-CnQMc0MA.js
 
 # tests/rolldown/topics/hmr/issue_5149
 
-- main-!~{000}~.js => main-BthopV6e.js
+- main-!~{000}~.js => main-Pfg3mek1.js
 
 # tests/rolldown/topics/hmr/issue_5150
 
-- main-!~{000}~.js => main-BIzw3npf.js
+- main-!~{000}~.js => main-Bj1XTdMl.js
 
 # tests/rolldown/topics/hmr/issue_5159
 
-- main-!~{000}~.js => main-BQi0A8i7.js
-- bar-!~{005}~.js => bar-fSOAjohH.js
+- main-!~{000}~.js => main-DHzPyjb2.js
+- bar-!~{005}~.js => bar-Bz70XMyB.js
 - chunk-!~{001}~.js => chunk-DlkQDk1t.js
-- foo-!~{007}~.js => foo-JVHVr0iM.js
-- string-!~{003}~.js => string-Bi84wAtb.js
+- foo-!~{007}~.js => foo-arEyVQ6_.js
+- string-!~{003}~.js => string-DVOdt709.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-DUQx3S65.js
-- index-!~{001}~.js => index-RK3cjCaD.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-B7xs0Iig.js
+- entry-!~{000}~.js => entry-FDUjbOTW.js
+- index-!~{001}~.js => index-CMqusyYg.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-BNBOgN3E.js
 
 # tests/rolldown/topics/hmr/no-accept-outside-circular
 
-- main-!~{000}~.js => main-BCVoBJJV.js
+- main-!~{000}~.js => main-Df8Ue2i-.js
 
 # tests/rolldown/topics/hmr/no_boundary_reload
 
-- main-!~{000}~.js => main-9hVtFjVx.js
+- main-!~{000}~.js => main-DB49UK5h.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-D3rbnnBk.js
+- main-!~{000}~.js => main-DEwqFvrO.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-BUgw21N9.js
+- main-!~{000}~.js => main-CtfW1sbk.js
 
 # tests/rolldown/topics/hmr/runtime_correctness
 
-- main-!~{000}~.js => main-Bm4AYHgK.js
+- main-!~{000}~.js => main-DyvmFUow.js
 
 # tests/rolldown/topics/hmr/self-accept-within-circular
 
-- main-!~{000}~.js => main-CvNTOkNf.js
+- main-!~{000}~.js => main-Dn9JKZHk.js
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-DrxKyuqJ.js
+- main-!~{000}~.js => main-WR9NPIFB.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 
@@ -5578,7 +5582,7 @@ expression: output
 
 # tests/rolldown/topics/keep_names/declaration2
 
-- main-!~{000}~.js => main-CDKRehwQ.js
+- main-!~{000}~.js => main-Dv6b7EVo.js
 
 # tests/rolldown/topics/keep_names/expression
 
@@ -5717,17 +5721,17 @@ expression: output
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped
 
-- main-!~{000}~.js => main-OdODt6d9.js
+- main-!~{000}~.js => main-Cg0PGwQu.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries
 
-- entry-!~{000}~.js => entry-DpewEy5z.js
-- entry2-!~{001}~.js => entry2-kGd2vgu3.js
-- main-!~{002}~.js => main-B8zPyoIA.js
+- entry-!~{000}~.js => entry-DoVaNndD.js
+- entry2-!~{001}~.js => entry2-SojYqu40.js
+- main-!~{002}~.js => main-BvD5LE2A.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs
 
-- main-!~{000}~.js => main-GCf73MFm.js
+- main-!~{000}~.js => main-DwoXuw2_.js
 
 # tests/rolldown/topics/tla/basic
 
@@ -5735,7 +5739,7 @@ expression: output
 
 # tests/rolldown/topics/tla/inline_dynamic_import
 
-- main-!~{000}~.js => main-CbFYlHLJ.js
+- main-!~{000}~.js => main-II5eFd1E.js
 
 # tests/rolldown/topics/tla/inside_try_block
 
@@ -5837,7 +5841,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/export_star
 
-- main-!~{000}~.js => main-rE1MiGjh.js
+- main-!~{000}~.js => main-DwLqlujD.js
 
 # tests/rolldown/tree_shaking/export_star2
 
@@ -5958,7 +5962,7 @@ expression: output
 
 # tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format
 
-- main-!~{000}~.js => main-mKnVbNV-.js
+- main-!~{000}~.js => main-dBcUUTZg.js
 
 # tests/rolldown/warnings/minified-with-eval
 


### PR DESCRIPTION
related https://github.com/rolldown/rolldown/issues/5923

With `@__PURE__` annotation, when `xxx_exports` is unused `__export` could be removed by minifier.