### PR TITLE
fix: generate valid identifier for export names with `minifyInternalExports`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -607,7 +607,6 @@ fn generate_minified_names(mut value: u32) -> String {
     buffer.push(byte);
     value /= REST_BASE;
   }
-  buffer.reverse();
   // SAFETY: `buffer` is base64 characters, it is valid utf8 characters
   unsafe { String::from_utf8_unchecked(buffer) }
 }


### PR DESCRIPTION
This reverse is not needed.