### PR TITLE
feat(rolldown_plugin_utils): add `to_string_literal`

### DIFF
--- a/crates/rolldown_plugin_utils/src/lib.rs
+++ b/crates/rolldown_plugin_utils/src/lib.rs
@@ -14,6 +14,7 @@ mod render_asset_url_in_js;
 mod strip_bom;
 mod to_output_file_path;
 mod to_relative_runtime_path;
+mod to_string_literal;
 
 pub mod constants;
 pub mod css;
@@ -37,3 +38,4 @@ pub use to_output_file_path::{
   AssetUrlResult, RenderBuiltUrl, RenderBuiltUrlConfig, RenderBuiltUrlRet, ToOutputFilePathEnv,
 };
 pub use to_relative_runtime_path::create_to_import_meta_url_based_relative_runtime;
+pub use to_string_literal::to_string_literal;

--- a/crates/rolldown_plugin_utils/src/to_string_literal.rs
+++ b/crates/rolldown_plugin_utils/src/to_string_literal.rs
@@ -1,0 +1,33 @@
+pub fn to_string_literal(input: &str) -> String {
+  // this is just a rough estimate of the number of characters that requires escaping
+  const ADDITIONAL: usize = 4;
+
+  let mut output = String::with_capacity(input.len() + 2 + 1 + ADDITIONAL);
+  output.push('"');
+  for c in input.chars() {
+    match c {
+      '\n' => {
+        output.push('\\');
+        output.push('n');
+      }
+      '\r' => {
+        output.push('\\');
+        output.push('r');
+      }
+      '\\' | '"' => {
+        output.push('\\');
+        output.push(c);
+      }
+      _ => output.push(c),
+    }
+  }
+  output.push('"');
+  output
+}
+
+#[test]
+fn test() {
+  assert_eq!(to_string_literal("foo"), r#""foo""#);
+  assert_eq!(to_string_literal(r#"foo"\n\rbar"#), r#""foo\"\\n\\rbar""#);
+  assert_eq!(to_string_literal(r"foo\bar"), r#""foo\\bar""#);
+}


### PR DESCRIPTION
Added `to_string_literal` function that is similar to what `JSON.string(str)`.