### PR TITLE
ci: skip `@rolldown/browser` build if no node related changes detected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
   build-browser:
     name: Build `@rolldown/browser`
     needs: [changes]
+    if: ${{ needs.changes.outputs.node-changes == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Follow up to #6155