### PR TITLE
fix: Panic with "jsx": "preserve" when rewrite a `memberExpression`

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/6036/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/6036/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "transform": {
+      "jsx": "preserve"
+    },
+    "input": [
+      {
+        "name": "main",
+        "import": "./index.ts"
+      }
+    ]
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/6036/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6036/artifacts.snap
@@ -1,0 +1,26 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+//#region react.ts
+var require_react = /* @__PURE__ */ __commonJS({ "react.ts": ((exports, module) => {
+	module.exports = {};
+}) });
+
+//#endregion
+//#region component/hello.tsx
+var import_react = /* @__PURE__ */ __toESM(require_react());
+function Hello() {
+	return <import_react.default.Fragment>
+      <h1>Hello</h1>
+    </import_react.default.Fragment>;
+}
+
+//#endregion
+export { Hello };
+```

--- a/crates/rolldown/tests/rolldown/issues/6036/component/hello.tsx
+++ b/crates/rolldown/tests/rolldown/issues/6036/component/hello.tsx
@@ -1,0 +1,9 @@
+import React from '../react.ts';
+
+export function Hello() {
+  return (
+    <React.Fragment>
+      <h1>Hello</h1>
+    </React.Fragment>
+  );
+}

--- a/crates/rolldown/tests/rolldown/issues/6036/index.ts
+++ b/crates/rolldown/tests/rolldown/issues/6036/index.ts
@@ -1,0 +1,1 @@
+export * from './component/hello';

--- a/crates/rolldown/tests/rolldown/issues/6036/react.ts
+++ b/crates/rolldown/tests/rolldown/issues/6036/react.ts
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4761,6 +4761,10 @@ expression: output
 
 - main-!~{000}~.js => main-DgJmHtwB.js
 
+# tests/rolldown/issues/6036
+
+- main-!~{000}~.js => main-QBmbik0c.js
+
 # tests/rolldown/issues/rolldown_vite_289
 
 - main-!~{000}~.js => main-Bldhf8JA.js

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/jsx.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/jsx.rs
@@ -1,17 +1,27 @@
 use oxc::allocator::Box;
-use oxc::ast::ast::{IdentifierReference, JSXMemberExpressionObject};
+use oxc::ast::ast::{
+  Expression, JSXMemberExpression, JSXMemberExpressionObject, StaticMemberExpression,
+};
 
 pub trait JsxExt<'ast> {
-  fn rewrite_ident_reference(&mut self, ident_ref: Box<'ast, IdentifierReference<'ast>>);
+  type AstKind;
+  fn rewrite_ident_reference(&mut self, ident_ref: JSXMemberExpressionObject<'ast>);
+  fn from_ast(
+    member_expr: Self::AstKind,
+    allocator: &'ast oxc::allocator::Allocator,
+  ) -> Option<Self>
+  where
+    Self: Sized;
 }
 
 impl<'ast> JsxExt<'ast> for JSXMemberExpressionObject<'ast> {
-  fn rewrite_ident_reference(&mut self, ident_ref: Box<'ast, IdentifierReference<'ast>>) {
+  type AstKind = Expression<'ast>;
+  fn rewrite_ident_reference(&mut self, ident_ref: JSXMemberExpressionObject<'ast>) {
     let mut object = self;
     loop {
       match object {
-        JSXMemberExpressionObject::IdentifierReference(ident) => {
-          *ident = ident_ref;
+        JSXMemberExpressionObject::IdentifierReference(_ident) => {
+          *object = ident_ref;
           break;
         }
         JSXMemberExpressionObject::MemberExpression(member_expr) => {
@@ -20,5 +30,46 @@ impl<'ast> JsxExt<'ast> for JSXMemberExpressionObject<'ast> {
         JSXMemberExpressionObject::ThisExpression(_) => break,
       }
     }
+  }
+
+  fn from_ast(
+    member_expr: Expression<'ast>,
+    allocator: &'ast oxc::allocator::Allocator,
+  ) -> Option<Self> {
+    match member_expr {
+      Expression::Identifier(ident) => Some(JSXMemberExpressionObject::IdentifierReference(ident)),
+      Expression::StaticMemberExpression(member_expr) => {
+        Some(JSXMemberExpressionObject::MemberExpression(Box::new_in(
+          JSXMemberExpression::from_ast(member_expr.unbox(), allocator)?,
+          allocator,
+        )))
+      }
+      Expression::ThisExpression(expr) => Some(JSXMemberExpressionObject::ThisExpression(expr)),
+      _ => None,
+    }
+  }
+}
+
+impl<'ast> JsxExt<'ast> for JSXMemberExpression<'ast> {
+  type AstKind = StaticMemberExpression<'ast>;
+  fn rewrite_ident_reference(&mut self, _ident_ref: JSXMemberExpressionObject<'ast>) {
+    todo!()
+  }
+
+  fn from_ast(
+    member_expr: StaticMemberExpression<'ast>,
+    allocator: &'ast oxc::allocator::Allocator,
+  ) -> Option<Self>
+  where
+    Self: Sized,
+  {
+    Some(JSXMemberExpression {
+      span: member_expr.span,
+      object: JSXMemberExpressionObject::from_ast(member_expr.object, allocator)?,
+      property: oxc::ast::ast::JSXIdentifier {
+        span: member_expr.span,
+        name: member_expr.property.name,
+      },
+    })
   }
 }


### PR DESCRIPTION
This pr only ensures bundle `jsx`​ successfully when it meets `MemberExpression` rewrite, the rest part I will do in another pr after `StaticCommonjsPropAccess` optimization, which will rewrite commonjs prop access like, 

```js
var import_react = /* @__PURE__ */ __toESM(require_react());
const import_react_default = import_react.default.
function Hello() {
	return <import_react_default.Fragment>
      <h1>Hello</h1>
    </import_react_default.Fragment>;
}

```

After the optimization, we could just capitalize the binding if it is used as `JSXElement`

Almost fixed #6036()， since the issue only required build without panic