### PR TITLE
refactor: rename `cross_module_inline_const` to `cross_module_optimization`

### DIFF
--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -28,7 +28,7 @@ impl CrossModuleInlineConstCtx {
 }
 
 impl LinkStage<'_> {
-  pub(super) fn cross_module_inline_const(&mut self) {
+  pub(super) fn cross_module_optimization(&mut self) {
     let inline_const_pass = self.options.optimization.inline_const_pass();
     if inline_const_pass < 2 {
       return;

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -29,7 +29,7 @@ use super::scan_stage::NormalizedScanStageOutput;
 mod bind_imports_and_exports;
 mod compute_tla;
 mod create_exports_for_ecma_modules;
-mod cross_module_inline_const;
+mod cross_module_optimization;
 mod determine_module_exports_kind;
 mod generate_lazy_export;
 mod patch_module_dependencies;
@@ -173,7 +173,7 @@ impl<'a> LinkStage<'a> {
     self.bind_imports_and_exports();
     self.create_exports_for_ecma_modules();
     self.reference_needed_symbols();
-    self.cross_module_inline_const();
+    self.cross_module_optimization();
     self.include_statements();
     self.patch_module_dependencies();
 


### PR DESCRIPTION
now, not only `inlineConst` may require an extra AST visit, but also 
- https://github.com/rolldown/rolldown/issues/3234, 
- https://github.com/rolldown/rolldown/issues/3403#issuecomment-2955476250 
required an extra pass to update cross module info