### PR TITLE
fix: allow `jsx.pragmaFrag` instead of `jsx.pragmaFlag`

### DIFF
--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -91,7 +91,7 @@ const JsxOptionsSchema = v.strictObject({
     v.optional(v.string()),
     v.description('Jsx element transformation'),
   ),
-  pragmaFlag: v.pipe(
+  pragmaFrag: v.pipe(
     v.optional(
       v.string(),
     ),


### PR DESCRIPTION
There was a typo here.