### PR TITLE
refactor: move external string/regex matching from JS to Rust

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/mod.rs
@@ -14,6 +14,7 @@ use binding_debug_options::BindingDebugOptions;
 use binding_make_absolute_externals_relative::BindingMakeAbsoluteExternalsRelative;
 use binding_optimization::BindingOptimization;
 use derive_more::Debug;
+use napi::Either;
 use napi::bindgen_prelude::{FnArgs, Promise};
 use napi_derive::napi;
 use rustc_hash::FxBuildHasher;
@@ -27,6 +28,7 @@ use binding_watch_option::BindingWatchOption;
 
 use super::plugin::BindingPluginOrParallelJsPluginPlaceholder;
 use crate::generated::binding_checks_options;
+use crate::types::binding_string_or_regex::BindingStringOrRegex;
 use crate::types::defer_sync_scan_data::BindingDeferSyncScanData;
 use crate::types::preserve_entry_signatures::BindingPreserveEntrySignatures;
 use crate::types::{
@@ -49,9 +51,11 @@ pub struct BindingInputOptions<'env> {
   // experimentalCacheExpiry?: number;
   #[debug(skip)]
   #[napi(
-    ts_type = "undefined | ((source: string, importer: string | undefined, isResolved: boolean) => boolean)"
+    ts_type = "Array<string | RegExp> | ((source: string, importer: string | undefined, isResolved: boolean) => boolean)"
   )]
-  pub external: Option<JsCallback<FnArgs<(String, Option<String>, bool)>, bool>>,
+  pub external: Option<
+    Either<Vec<BindingStringOrRegex>, JsCallback<FnArgs<(String, Option<String>, bool)>, bool>>,
+  >,
   pub input: Vec<BindingInputItem>,
   // makeAbsoluteExternalsRelative?: boolean | 'ifRelativeSource';
   // /** @deprecated Use the "manualChunks" output option instead. */

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -235,7 +235,7 @@ where
   D: Deserializer<'de>,
 {
   let deserialized = Option::<Vec<String>>::deserialize(deserializer)?;
-  Ok(deserialized.map(IsExternal::from_vec))
+  Ok(deserialized.map(IsExternal::from))
 }
 
 #[cfg(feature = "deserialize_bundler_options")]

--- a/crates/rolldown_common/src/inner_bundler_options/types/is_external.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/is_external.rs
@@ -1,58 +1,52 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use derive_more::Debug;
+use rolldown_utils::pattern_filter::StringOrRegex;
 
-type Inner = dyn Fn(
+type IsExternalFn = dyn Fn(
     &str,         // specifier
     Option<&str>, // importer
     bool,         // is_resolved
   ) -> Pin<Box<(dyn Future<Output = anyhow::Result<bool>> + Send + 'static)>>
   + Send
-  + Sync
-  + 'static;
+  + Sync;
 
-#[derive(Clone, Default, Debug)]
-#[debug("IsExternal(...)")]
-pub struct IsExternal(Option<Arc<Inner>>);
+#[derive(Debug, Clone)]
+pub enum IsExternal {
+  #[debug("IsExternal::Fn(..)")]
+  Fn(Option<Arc<IsExternalFn>>),
+  #[debug("IsExternal::StringOrRegex({})", "{0:?}")]
+  StringOrRegex(Vec<StringOrRegex>),
+}
+
+impl Default for IsExternal {
+  fn default() -> Self {
+    IsExternal::Fn(None)
+  }
+}
+
+impl From<Vec<String>> for IsExternal {
+  fn from(value: Vec<String>) -> Self {
+    IsExternal::StringOrRegex(value.into_iter().map(StringOrRegex::String).collect())
+  }
+}
 
 impl IsExternal {
-  pub fn from_closure<F>(f: F) -> Self
-  where
-    F: Fn(
-        &str,         // specifier
-        Option<&str>, // importer
-        bool,         // is_resolved
-      ) -> Pin<Box<(dyn Future<Output = anyhow::Result<bool>> + Send + 'static)>>
-      + Send
-      + Sync
-      + 'static,
-  {
-    Self(Some(Arc::new(f)))
-  }
-
-  pub fn from_vec(value: Vec<String>) -> Self {
-    Self::from_closure(move |source, _, _| {
-      let result = value.iter().any(|item| item == source);
-      Box::pin(async move { Ok(result) })
-    })
-  }
-
   pub async fn call(
     &self,
     specifier: &str,
     importer: Option<&str>,
     is_resolved: bool,
   ) -> anyhow::Result<bool> {
-    Ok(if let Some(is_external) = &self.0 {
-      is_external(specifier, importer, is_resolved).await?
-    } else {
-      false
+    Ok(match self {
+      IsExternal::StringOrRegex(patterns) => patterns.iter().any(|p| match p {
+        StringOrRegex::String(s) => s == specifier,
+        StringOrRegex::Regex(r) => r.matches(specifier),
+      }),
+      IsExternal::Fn(Some(is_external)) => {
+        return is_external(specifier, importer, is_resolved).await;
+      }
+      IsExternal::Fn(None) => false,
     })
-  }
-}
-
-impl From<Vec<String>> for IsExternal {
-  fn from(value: Vec<String>) -> Self {
-    IsExternal::from_vec(value)
   }
 }

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -239,7 +239,7 @@ impl IntegrationTest {
     }
 
     if options.external.is_none() {
-      options.external = Some(IsExternal::from_vec(vec!["node:assert".to_string()]));
+      options.external = Some(IsExternal::from(vec!["node:assert".to_string()]));
     }
 
     if options.input.is_none() {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1759,7 +1759,7 @@ export interface BindingInputItem {
 }
 
 export interface BindingInputOptions {
-  external?: undefined | ((source: string, importer: string | undefined, isResolved: boolean) => boolean)
+  external?: Array<string | RegExp> | ((source: string, importer: string | undefined, isResolved: boolean) => boolean)
   input: Array<BindingInputItem>
   plugins: (BindingBuiltinPlugin | BindingPluginOptions | undefined)[]
   resolve?: BindingResolveOptions

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -163,15 +163,7 @@ function bindingifyExternal(
         return external(id, importer, isResolved) ?? false;
       };
     }
-    const externalArr = arraify(external);
-    return (id, _importer, _isResolved) => {
-      return externalArr.some((pat) => {
-        if (pat instanceof RegExp) {
-          return pat.test(id);
-        }
-        return id === pat;
-      });
-    };
+    return arraify(external);
   }
 }
 


### PR DESCRIPTION
Related to #6027