### PR TITLE
refactor: share `FlatOptions` in whole build session

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -45,8 +45,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
 use sugar_path::SugarPath;
 
-use self::side_effect_detector::ScannerFlatOptions;
 use crate::SharedOptions;
+use crate::ast_scanner::side_effect_detector::FlatOptions;
 
 // TODO: Not sure if this necessary to match the module request.
 // If we found it cause high false positive, we could add a extra step to match it package name as
@@ -143,7 +143,7 @@ pub struct AstScanner<'me, 'ast> {
   dynamic_import_usage_info: DynamicImportUsageInfo,
   ignore_comment: &'static str,
   // Cached flag fields from options to avoid repeated function calls
-  flags: ScannerFlatOptions,
+  flat_options: FlatOptions,
   /// "top level" `this` AstNode range in source code
   top_level_this_expr_set: FxHashSet<Span>,
   /// A flag to resolve `this` appear with propertyKey in class
@@ -166,7 +166,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     comments: &'me oxc::allocator::Vec<'me, Comment>,
     options: &'me SharedOptions,
     allocator: &'ast oxc::allocator::Allocator,
-    flags: ScannerFlatOptions,
+    flat_options: FlatOptions,
   ) -> Self {
     let root_scope_id = scoping.root_scope_id();
     let mut symbol_ref_db = SymbolRefDbForModule::new(scoping, idx, root_scope_id);
@@ -227,7 +227,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       cur_class_decl: None,
       visit_path: vec![],
       ignore_comment: options.experimental.get_ignore_comment(),
-      flags,
+      flat_options,
       options,
       scope_stack: vec![],
       dynamic_import_usage_info: DynamicImportUsageInfo::default(),

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -32,7 +32,9 @@ bitflags! {
 
 bitflags! {
   #[derive(Debug, Clone, Copy)]
-  pub struct ScannerFlatOptions: u16 {
+  /// A flat options struct to avoid passing `&SharedNormalizedBundlerOptions` everywhere.
+  /// which also make accessing frequently used options faster.
+  pub struct FlatOptions: u16 {
     const IgnoreAnnotations = 1 << 0;
     const JsxPreserve = 1 << 1;
     const IsManualPureFunctionsEmpty = 1 << 2;
@@ -60,7 +62,7 @@ bitflags! {
   }
 }
 
-impl ScannerFlatOptions {
+impl FlatOptions {
   pub fn from_shared_options(options: &SharedNormalizedBundlerOptions) -> Self {
     let mut flags = Self::empty();
     flags.set(Self::IgnoreAnnotations, !options.treeshake.annotations());
@@ -152,13 +154,13 @@ mod utils;
 pub struct SideEffectDetector<'a> {
   pub scope: &'a AstScopes,
   options: &'a SharedNormalizedBundlerOptions,
-  flags: ScannerFlatOptions,
+  flags: FlatOptions,
 }
 
 impl<'a> SideEffectDetector<'a> {
   pub fn new(
     scope: &'a AstScopes,
-    flags: ScannerFlatOptions,
+    flags: FlatOptions,
     options: &'a SharedNormalizedBundlerOptions,
   ) -> Self {
     Self { scope, options, flags }
@@ -1070,7 +1072,7 @@ mod test {
   use rolldown_common::{AstScopes, NormalizedBundlerOptions, SideEffectDetail};
   use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
 
-  use super::{ScannerFlatOptions, SideEffectDetector};
+  use super::{FlatOptions, SideEffectDetector};
 
   fn get_statements_side_effect(code: &str) -> bool {
     let source_type = SourceType::tsx();
@@ -1080,7 +1082,7 @@ mod test {
     let ast_scopes = AstScopes::new(scoping);
 
     let options = Arc::new(NormalizedBundlerOptions::default());
-    let flags = ScannerFlatOptions::from_shared_options(&options);
+    let flags = FlatOptions::from_shared_options(&options);
     ast.program().body.iter().any(|stmt| {
       SideEffectDetector::new(&ast_scopes, flags, &options)
         .detect_side_effect_of_stmt(stmt)
@@ -1096,7 +1098,7 @@ mod test {
     let ast_scopes = AstScopes::new(scoping);
 
     let options = Arc::new(NormalizedBundlerOptions::default());
-    let flags = ScannerFlatOptions::from_shared_options(&options);
+    let flags = FlatOptions::from_shared_options(&options);
     ast
       .program()
       .body

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -10,7 +10,7 @@ use rolldown_utils::{ecmascript::legitimize_identifier_name, indexmap::FxIndexSe
 use sugar_path::SugarPath;
 
 use crate::{
-  ast_scanner::{AstScanner, ScanResult, side_effect_detector::ScannerFlatOptions},
+  ast_scanner::{AstScanner, ScanResult},
   types::module_factory::{CreateModuleContext, CreateModuleViewArgs},
   utils::parse_to_ecma_ast::{ParseToEcmaAstResult, parse_to_ecma_ast},
 };
@@ -37,7 +37,6 @@ pub async fn create_ecma_view(
   let repr_name = module_id.as_path().representative_file_name();
   let repr_name = legitimize_identifier_name(&repr_name);
 
-  let flags = ScannerFlatOptions::from_shared_options(ctx.options);
   let scanner = AstScanner::new(
     ctx.module_index,
     scoping,
@@ -48,7 +47,7 @@ pub async fn create_ecma_view(
     ast.comments(),
     ctx.options,
     ast.allocator(),
-    flags,
+    ctx.flat_options,
   );
 
   let ScanResult {

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -15,6 +15,7 @@ use rolldown_error::{
 use rolldown_std_utils::PathExt;
 use rolldown_utils::{ecmascript::legitimize_identifier_name, indexmap::FxIndexSet};
 
+use crate::ast_scanner::side_effect_detector::FlatOptions;
 use crate::{
   asset::create_asset_view,
   css::create_css_view,
@@ -45,6 +46,7 @@ pub struct ModuleTask {
   is_user_defined_entry: bool,
   /// The module is asserted to be this specific module type.
   asserted_module_type: Option<ModuleType>,
+  flat_options: FlatOptions,
 }
 
 impl ModuleTask {
@@ -55,6 +57,7 @@ impl ModuleTask {
     owner: Option<ModuleTaskOwner>,
     is_user_defined_entry: bool,
     assert_module_type: Option<ModuleType>,
+    flat_options: FlatOptions,
   ) -> Self {
     Self {
       ctx,
@@ -63,6 +66,7 @@ impl ModuleTask {
       owner,
       is_user_defined_entry,
       asserted_module_type: assert_module_type,
+      flat_options,
     }
   }
 
@@ -141,6 +145,7 @@ impl ModuleTask {
         module_type: module_type.clone(),
         replace_global_define_config: self.ctx.meta.replace_global_define_config.clone(),
         is_user_defined_entry: self.is_user_defined_entry,
+        flat_options: self.flat_options,
       },
       CreateModuleViewArgs { source, sourcemap_chain, hook_side_effects },
     )

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -20,6 +20,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
   SharedOptions,
+  ast_scanner::side_effect_detector::FlatOptions,
   type_alias::IndexEcmaAst,
   types::linking_metadata::{LinkingMetadata, LinkingMetadataVec},
 };
@@ -80,6 +81,8 @@ pub struct LinkStage<'a> {
   pub overrode_preserve_entry_signature_map: FxHashMap<ModuleIdx, PreserveEntrySignatures>,
   pub entry_point_to_reference_ids: FxHashMap<EntryPoint, Vec<ArcStr>>,
   pub global_constant_symbol_map: FxHashMap<SymbolRef, ConstExportMeta>,
+  #[expect(dead_code)]
+  pub flat_options: FlatOptions,
 }
 
 impl<'a> LinkStage<'a> {
@@ -159,6 +162,7 @@ impl<'a> LinkStage<'a> {
       overrode_preserve_entry_signature_map: scan_stage_output
         .overrode_preserve_entry_signature_map,
       entry_point_to_reference_ids: scan_stage_output.entry_point_to_reference_ids,
+      flat_options: scan_stage_output.flat_options,
     }
   }
 

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -18,6 +18,7 @@ use rustc_hash::FxHashMap;
 
 use crate::{
   SharedOptions, SharedResolver,
+  ast_scanner::side_effect_detector::FlatOptions,
   module_loader::{ModuleLoader, module_loader::ModuleLoaderOutput},
   type_alias::IndexEcmaAst,
   types::scan_stage_cache::ScanStageCache,
@@ -78,6 +79,7 @@ pub struct NormalizedScanStageOutput {
   // TODO: merge the preserve_entry_signatures_map in incremental build
   pub overrode_preserve_entry_signature_map: FxHashMap<ModuleIdx, PreserveEntrySignatures>,
   pub entry_point_to_reference_ids: FxHashMap<EntryPoint, Vec<ArcStr>>,
+  pub flat_options: FlatOptions,
 }
 
 impl NormalizedScanStageOutput {
@@ -105,6 +107,7 @@ impl NormalizedScanStageOutput {
       safely_merge_cjs_ns_map: self.safely_merge_cjs_ns_map.clone(),
       overrode_preserve_entry_signature_map: self.overrode_preserve_entry_signature_map.clone(),
       entry_point_to_reference_ids: self.entry_point_to_reference_ids.clone(),
+      flat_options: self.flat_options,
     }
   }
 }
@@ -128,6 +131,7 @@ impl From<ScanStageOutput> for NormalizedScanStageOutput {
       safely_merge_cjs_ns_map: value.safely_merge_cjs_ns_map,
       overrode_preserve_entry_signature_map: value.overrode_preserve_entry_signature_map,
       entry_point_to_reference_ids: value.entry_point_to_reference_ids,
+      flat_options: value.flat_options,
     }
   }
 }
@@ -144,6 +148,7 @@ pub struct ScanStageOutput {
   pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, Vec<SymbolRef>>,
   pub overrode_preserve_entry_signature_map: FxHashMap<ModuleIdx, PreserveEntrySignatures>,
   pub entry_point_to_reference_ids: FxHashMap<EntryPoint, Vec<ArcStr>>,
+  pub flat_options: FlatOptions,
 }
 
 impl ScanStage {
@@ -204,6 +209,7 @@ impl ScanStage {
       safely_merge_cjs_ns_map,
       overrode_preserve_entry_signature_map,
       entry_point_to_reference_ids,
+      flat_options,
     } = module_loader_output;
 
     self.plugin_driver.file_emitter.set_context_load_modules_tx(None).await;
@@ -221,6 +227,7 @@ impl ScanStage {
       safely_merge_cjs_ns_map,
       overrode_preserve_entry_signature_map,
       entry_point_to_reference_ids,
+      flat_options,
     })
   }
 
@@ -271,6 +278,7 @@ impl From<ModuleLoaderOutput> for ScanStageOutput {
       safely_merge_cjs_ns_map,
       overrode_preserve_entry_signature_map,
       entry_point_to_reference_ids,
+      flat_options,
     } = module_loader_output;
     ScanStageOutput {
       entry_points,
@@ -283,6 +291,7 @@ impl From<ModuleLoaderOutput> for ScanStageOutput {
       safely_merge_cjs_ns_map,
       overrode_preserve_entry_signature_map,
       entry_point_to_reference_ids,
+      flat_options,
     }
   }
 }

--- a/crates/rolldown/src/types/module_factory.rs
+++ b/crates/rolldown/src/types/module_factory.rs
@@ -6,7 +6,7 @@ use rolldown_error::BuildDiagnostic;
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_sourcemap::SourceMap;
 
-use crate::SharedOptions;
+use crate::{SharedOptions, ast_scanner::side_effect_detector::FlatOptions};
 
 pub struct CreateModuleContext<'a> {
   pub stable_id: &'a str,
@@ -18,6 +18,7 @@ pub struct CreateModuleContext<'a> {
   pub warnings: &'a mut Vec<BuildDiagnostic>,
   pub replace_global_define_config: Option<ReplaceGlobalDefinesConfig>,
   pub is_user_defined_entry: bool,
+  pub flat_options: FlatOptions,
 }
 
 pub struct CreateModuleViewArgs {

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -140,6 +140,7 @@ impl ScanStageCache {
       dynamic_import_exports_usage_map: cache.dynamic_import_exports_usage_map.clone(),
       overrode_preserve_entry_signature_map: cache.overrode_preserve_entry_signature_map.clone(),
       entry_point_to_reference_ids: cache.entry_point_to_reference_ids.clone(),
+      flat_options: cache.flat_options,
     }
   }
 }


### PR DESCRIPTION
### TL;DR

Refactored `ScannerFlatOptions` to `FlatOptions` and improved its propagation throughout the codebase.

### What changed?

- Renamed `ScannerFlatOptions` to `FlatOptions` to better reflect its purpose
- Added documentation to clarify that `FlatOptions` is used to avoid passing `&SharedNormalizedBundlerOptions` everywhere and to make accessing frequently used options faster
- Modified the `AstScanner` to use `flat_options` instead of `flags`
- Updated the module loader to create and propagate `flat_options` to various tasks
- Ensured `flat_options` is passed through the scan stage output to the link stage
- Updated all references to use the renamed struct

### How to test?

- Run the existing test suite to ensure all functionality works as expected
- Verify that all modules using the options still behave correctly
- Check that performance is maintained or improved with the refactored approach

### Why make this change?

This change improves code organization and readability by:
1. Using a more appropriate name for the options struct
2. Ensuring consistent propagation of options throughout the codebase
3. Making the purpose of the struct clearer with added documentation
4. Reducing redundant option resolution by passing the flat options structure through the build pipeline

The refactoring should make the codebase more maintainable while potentially improving performance by avoiding repeated function calls to access options.