### PR TITLE
refactor(rolldown_plugin_transform): remove unused `runtime_resolve_base` option

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/config/binding_transform_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_transform_plugin_config.rs
@@ -15,7 +15,6 @@ pub struct BindingTransformPluginConfig {
   pub jsx_refresh_exclude: Option<Vec<BindingStringOrRegex>>,
 
   pub is_server_consumer: Option<bool>,
-  pub runtime_resolve_base: Option<String>,
 
   pub jsx_inject: Option<String>,
   pub transform_options: Option<TransformOptions>,

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -2105,7 +2105,6 @@ export interface BindingTransformPluginConfig {
   jsxRefreshInclude?: Array<BindingStringOrRegex>
   jsxRefreshExclude?: Array<BindingStringOrRegex>
   isServerConsumer?: boolean
-  runtimeResolveBase?: string
   jsxInject?: string
   transformOptions?: TransformOptions
 }


### PR DESCRIPTION
`runtime_resolve_base` option is not used and probably won't be used in the future as #6177 landed.