### PR TITLE
feat(rolldown_plugin_react_refresh_wrapper): make the plugin callable

### DIFF
--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -133,5 +133,9 @@ export function reactRefreshWrapperPlugin(
     config.include = normalizedStringOrRegex(config.include);
     config.exclude = normalizedStringOrRegex(config.exclude);
   }
-  return new BuiltinPlugin('builtin:react-refresh-wrapper', config);
+  const builtinPlugin = new BuiltinPlugin(
+    'builtin:react-refresh-wrapper',
+    config,
+  );
+  return makeBuiltinPluginCallable(builtinPlugin);
 }


### PR DESCRIPTION
So that I can simplify the react plugin a bit.