### PR TITLE
refactor: move FlatOptions to rolldown_common

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -29,11 +29,11 @@ use oxc::{
 use oxc_index::IndexVec;
 use rolldown_common::dynamic_import_usage::{DynamicImportExportsUsage, DynamicImportUsageInfo};
 use rolldown_common::{
-  ConstExportMeta, ConstantValue, EcmaModuleAstUsage, EcmaViewMeta, ExportsKind, HmrInfo,
-  ImportAttribute, ImportKind, ImportRecordIdx, ImportRecordMeta, LocalExport, MemberExprRef,
-  ModuleDefFormat, ModuleId, ModuleIdx, NamedImport, RawImportRecord, SideEffectDetail, Specifier,
-  StmtInfo, StmtInfoMeta, StmtInfos, SymbolRef, SymbolRefDbForModule, SymbolRefFlags,
-  TaggedSymbolRef, ThisExprReplaceKind, generate_replace_this_expr_map,
+  ConstExportMeta, ConstantValue, EcmaModuleAstUsage, EcmaViewMeta, ExportsKind, FlatOptions,
+  HmrInfo, ImportAttribute, ImportKind, ImportRecordIdx, ImportRecordMeta, LocalExport,
+  MemberExprRef, ModuleDefFormat, ModuleId, ModuleIdx, NamedImport, RawImportRecord,
+  SideEffectDetail, Specifier, StmtInfo, StmtInfoMeta, StmtInfos, SymbolRef, SymbolRefDbForModule,
+  SymbolRefFlags, TaggedSymbolRef, ThisExprReplaceKind, generate_replace_this_expr_map,
 };
 use rolldown_ecmascript_utils::{BindingIdentifierExt, BindingPatternExt, FunctionExt};
 use rolldown_error::{BuildDiagnostic, BuildResult, CjsExportSpan};
@@ -46,7 +46,6 @@ use std::borrow::Cow;
 use sugar_path::SugarPath;
 
 use crate::SharedOptions;
-use crate::ast_scanner::side_effect_detector::FlatOptions;
 
 // TODO: Not sure if this necessary to match the module request.
 // If we found it cause high false positive, we could add a extra step to match it package name as

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -9,7 +9,7 @@ use oxc_index::IndexVec;
 use rolldown_common::dynamic_import_usage::DynamicImportExportsUsage;
 use rolldown_common::side_effects::{DeterminedSideEffects, HookSideEffects};
 use rolldown_common::{
-  EcmaRelated, EntryPoint, EntryPointKind, ExternalModule, ExternalModuleTaskResult,
+  EcmaRelated, EntryPoint, EntryPointKind, ExternalModule, ExternalModuleTaskResult, FlatOptions,
   HybridIndexVec, ImportKind, ImportRecordMeta, ImporterRecord, Module, ModuleId, ModuleIdx,
   ModuleLoaderMsg, ModuleType, NormalModuleTaskResult, PreserveEntrySignatures, RUNTIME_MODULE_KEY,
   ResolvedId, RuntimeModuleBrief, RuntimeModuleTaskResult, ScanMode, SymbolRef, SymbolRefDb,
@@ -25,7 +25,6 @@ use rolldown_utils::rustc_hash::FxHashSetExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::Instrument;
 
-use crate::ast_scanner::side_effect_detector::FlatOptions;
 use crate::ecmascript::ecma_module_view_factory::normalize_side_effects;
 use crate::module_loader::task_context::TaskContext;
 use crate::stages::scan_stage::resolve_user_defined_entries;

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use sugar_path::SugarPath;
 
 use rolldown_common::{
-  ImportKind, ModuleId, ModuleIdx, ModuleInfo, ModuleLoaderMsg, ModuleType, NormalModule,
-  NormalModuleTaskResult, ResolvedId, StrOrBytes,
+  FlatOptions, ImportKind, ModuleId, ModuleIdx, ModuleInfo, ModuleLoaderMsg, ModuleType,
+  NormalModule, NormalModuleTaskResult, ResolvedId, StrOrBytes,
 };
 use rolldown_error::{
   BuildDiagnostic, BuildResult, UnloadableDependencyContext, downcast_napi_error_diagnostics,
@@ -15,7 +15,6 @@ use rolldown_error::{
 use rolldown_std_utils::PathExt;
 use rolldown_utils::{ecmascript::legitimize_identifier_name, indexmap::FxIndexSet};
 
-use crate::ast_scanner::side_effect_detector::FlatOptions;
 use crate::{
   asset::create_asset_view,
   css::create_css_view,

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -5,7 +5,7 @@ use oxc::ast_visit::VisitMut;
 use oxc::span::SourceType;
 use oxc_index::IndexVec;
 use rolldown_common::{
-  EcmaView, ExportsKind, ModuleDefFormat, ModuleIdx, ModuleType, NormalModule,
+  EcmaView, ExportsKind, FlatOptions, ModuleDefFormat, ModuleIdx, ModuleType, NormalModule,
   side_effects::DeterminedSideEffects,
 };
 use rolldown_common::{
@@ -19,7 +19,7 @@ use rolldown_utils::indexmap::FxIndexSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-  ast_scanner::{AstScanner, ScanResult, side_effect_detector::FlatOptions},
+  ast_scanner::{AstScanner, ScanResult},
   utils::tweak_ast_for_scanning::PreProcessor,
 };
 

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -11,8 +11,9 @@ use oxc::{
   semantic::ScopeFlags,
 };
 use rolldown_common::{
-  AstScopes, ConstExportMeta, EcmaViewMeta, GetLocalDb, ModuleIdx, SharedNormalizedBundlerOptions,
-  SideEffectDetail, StmtInfoIdx, SymbolRef, SymbolRefDb, SymbolRefFlags,
+  AstScopes, ConstExportMeta, EcmaViewMeta, FlatOptions, GetLocalDb, ModuleIdx,
+  SharedNormalizedBundlerOptions, SideEffectDetail, StmtInfoIdx, SymbolRef, SymbolRefDb,
+  SymbolRefFlags,
 };
 use rolldown_ecmascript_utils::{ExpressionExt, is_top_level};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -20,7 +21,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{
   ast_scanner::{
     const_eval::{ConstEvalCtx, try_extract_const_literal},
-    side_effect_detector::{FlatOptions, SideEffectDetector},
+    side_effect_detector::SideEffectDetector,
   },
   module_finalizers::TraverseState,
 };

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -4,7 +4,7 @@ use oxc_index::IndexVec;
 #[cfg(debug_assertions)]
 use rolldown_common::common_debug_symbol_ref;
 use rolldown_common::{
-  ConstExportMeta, EntryPoint, EntryPointKind, ImportKind, ModuleIdx, ModuleTable,
+  ConstExportMeta, EntryPoint, EntryPointKind, FlatOptions, ImportKind, ModuleIdx, ModuleTable,
   PreserveEntrySignatures, RuntimeModuleBrief, SymbolRef, SymbolRefDb,
   dynamic_import_usage::DynamicImportExportsUsage,
 };
@@ -20,7 +20,6 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
   SharedOptions,
-  ast_scanner::side_effect_detector::FlatOptions,
   type_alias::IndexEcmaAst,
   types::linking_metadata::{LinkingMetadata, LinkingMetadataVec},
 };

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -6,8 +6,8 @@ use oxc_index::IndexVec;
 #[cfg(not(target_os = "macos"))]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rolldown_common::{
-  EntryPoint, HybridIndexVec, Module, ModuleIdx, ModuleTable, PreserveEntrySignatures, ResolvedId,
-  RuntimeModuleBrief, ScanMode, SymbolRef, SymbolRefDb,
+  EntryPoint, FlatOptions, HybridIndexVec, Module, ModuleIdx, ModuleTable, PreserveEntrySignatures,
+  ResolvedId, RuntimeModuleBrief, ScanMode, SymbolRef, SymbolRefDb,
   dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_ecmascript::EcmaAst;
@@ -18,7 +18,6 @@ use rustc_hash::FxHashMap;
 
 use crate::{
   SharedOptions, SharedResolver,
-  ast_scanner::side_effect_detector::FlatOptions,
   module_loader::{ModuleLoader, module_loader::ModuleLoaderOutput},
   type_alias::IndexEcmaAst,
   types::scan_stage_cache::ScanStageCache,

--- a/crates/rolldown/src/types/module_factory.rs
+++ b/crates/rolldown/src/types/module_factory.rs
@@ -1,12 +1,12 @@
 use oxc::transformer_plugins::ReplaceGlobalDefinesConfig;
 use rolldown_common::{
-  ModuleIdx, ModuleType, ResolvedId, StrOrBytes, side_effects::HookSideEffects,
+  FlatOptions, ModuleIdx, ModuleType, ResolvedId, StrOrBytes, side_effects::HookSideEffects,
 };
 use rolldown_error::BuildDiagnostic;
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_sourcemap::SourceMap;
 
-use crate::{SharedOptions, ast_scanner::side_effect_detector::FlatOptions};
+use crate::SharedOptions;
 
 pub struct CreateModuleContext<'a> {
   pub stable_id: &'a str,

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -142,6 +142,7 @@ pub use crate::{
   types::entry_point::{EntryPoint, EntryPointKind},
   types::exports_kind::ExportsKind,
   types::external_module_idx::ExternalModuleIdx,
+  types::flat_options::FlatOptions,
   types::hmr_info::HmrInfo,
   types::hybrid_index_vec::HybridIndexVec,
   types::import_attribute::ImportAttribute,

--- a/crates/rolldown_common/src/types/flat_options.rs
+++ b/crates/rolldown_common/src/types/flat_options.rs
@@ -1,0 +1,120 @@
+use crate::bundler_options::SharedNormalizedBundlerOptions;
+use bitflags::bitflags;
+
+bitflags! {
+  #[derive(Debug, Clone, Copy)]
+  /// A flat options struct to avoid passing `&SharedNormalizedBundlerOptions` everywhere.
+  /// which also make accessing frequently used options faster.
+  pub struct FlatOptions: u16 {
+    const IgnoreAnnotations = 1 << 0;
+    const JsxPreserve = 1 << 1;
+    const IsManualPureFunctionsEmpty = 1 << 2;
+    /// If the flag is set, it means the `treeshake.property_read_side_effects` is `Always`.
+    /// Otherwise, it is `False`.
+    const PropertyReadSideEffects = 1 << 3;
+    /// If the flag is set, it means the `treeshake.property_write_side_effects` is `Always`.
+    /// Otherwise, it is `False`.
+    const PropertyWriteSideEffects = 1 << 4;
+    /// If set, ESM import/export syntax should be preserved in the output.
+    /// Usage: `!self.options.format.keep_esm_import_export_syntax()`
+    const KeepEsmImportExportSyntax = 1 << 5;
+    /// If set, the format should call runtime require function.
+    /// Usage: `self.options.format.should_call_runtime_require()`
+    const ShouldCallRuntimeRequire = 1 << 6;
+    /// If set, polyfill require for ESM format when targeting Node platform.
+    /// Usage: `self.options.polyfill_require_for_esm_format_with_node_platform()`
+    const PolyfillRequireForEsmFormatWithNodePlatform = 1 << 7;
+    /// If set, new URL() calls with string literal and import.meta.url should be resolved to assets.
+    /// Usage: `self.options.experimental.is_resolve_new_url_to_asset_enabled()`
+    const ResolveNewUrlToAssetEnabled = 1 << 8;
+    /// If set, inline const optimization is enabled.
+    /// Usage: `self.options.optimization.is_inline_const_enabled()`
+    const InlineConstEnabled = 1 << 9;
+  }
+}
+
+impl FlatOptions {
+  pub fn from_shared_options(options: &SharedNormalizedBundlerOptions) -> Self {
+    let mut flags = Self::empty();
+    flags.set(Self::IgnoreAnnotations, !options.treeshake.annotations());
+    flags.set(Self::JsxPreserve, options.transform_options.is_jsx_preserve());
+    flags
+      .set(Self::IsManualPureFunctionsEmpty, options.treeshake.manual_pure_functions().is_none());
+    flags.set(
+      Self::PropertyReadSideEffects,
+      matches!(
+        options.treeshake.property_read_side_effects(),
+        crate::bundler_options::PropertyReadSideEffects::Always
+      ),
+    );
+    flags.set(
+      Self::PropertyWriteSideEffects,
+      matches!(
+        options.treeshake.property_write_side_effects(),
+        crate::bundler_options::PropertyWriteSideEffects::Always
+      ),
+    );
+    flags.set(Self::KeepEsmImportExportSyntax, options.format.keep_esm_import_export_syntax());
+    flags.set(Self::ShouldCallRuntimeRequire, options.format.should_call_runtime_require());
+    flags.set(
+      Self::PolyfillRequireForEsmFormatWithNodePlatform,
+      options.polyfill_require_for_esm_format_with_node_platform(),
+    );
+    flags.set(
+      Self::ResolveNewUrlToAssetEnabled,
+      options.experimental.is_resolve_new_url_to_asset_enabled(),
+    );
+    flags.set(Self::InlineConstEnabled, options.optimization.is_inline_const_enabled());
+    flags
+  }
+
+  #[inline]
+  pub fn ignore_annotations(self) -> bool {
+    self.contains(Self::IgnoreAnnotations)
+  }
+
+  #[inline]
+  pub fn jsx_preserve(self) -> bool {
+    self.contains(Self::JsxPreserve)
+  }
+
+  #[inline]
+  pub fn is_manual_pure_functions_empty(self) -> bool {
+    self.contains(Self::IsManualPureFunctionsEmpty)
+  }
+
+  #[inline]
+  pub fn property_read_side_effects(self) -> bool {
+    self.contains(Self::PropertyReadSideEffects)
+  }
+
+  #[inline]
+  pub fn property_write_side_effects(self) -> bool {
+    self.contains(Self::PropertyWriteSideEffects)
+  }
+
+  #[inline]
+  pub fn keep_esm_import_export_syntax(self) -> bool {
+    self.contains(Self::KeepEsmImportExportSyntax)
+  }
+
+  #[inline]
+  pub fn should_call_runtime_require(self) -> bool {
+    self.contains(Self::ShouldCallRuntimeRequire)
+  }
+
+  #[inline]
+  pub fn polyfill_require_for_esm_format_with_node_platform(self) -> bool {
+    self.contains(Self::PolyfillRequireForEsmFormatWithNodePlatform)
+  }
+
+  #[inline]
+  pub fn resolve_new_url_to_asset_enabled(self) -> bool {
+    self.contains(Self::ResolveNewUrlToAssetEnabled)
+  }
+
+  #[inline]
+  pub fn inline_const_enabled(self) -> bool {
+    self.contains(Self::InlineConstEnabled)
+  }
+}

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -11,6 +11,7 @@ pub mod defer_sync_scan_data;
 pub mod entry_point;
 pub mod exports_kind;
 pub mod external_module_idx;
+pub mod flat_options;
 pub mod hmr_info;
 pub mod hybrid_index_vec;
 pub mod import_attribute;


### PR DESCRIPTION
Since `FlatOptions`​ are used in the most of stage of bundling move it to `rolldown_common`​ should be more proper.