### PR TITLE
refactor: remove `stmt_info_idx` in StmtInfo

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -79,7 +79,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     );
     // Custom visit
     for (idx, stmt) in program.body.iter().enumerate() {
-      self.current_stmt_info.stmt_idx = Some(idx.into());
+      self.current_stmt_idx = Some(idx.into());
       self.current_stmt_info.side_effect = SideEffectDetector::new(
         &self.result.symbol_ref_db.ast_scopes,
         self.immutable_ctx.flat_options,
@@ -493,10 +493,10 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
 
         if self.traverse_state.contains(TraverseState::RootSymbolReferenceStmtInfoId) {
           // Since `0` is always namespace object stmt info
-          self.result.stmt_infos.reference_stmt_for_symbol_id(
-            self.current_stmt_info.stmt_idx.unwrap() + 1,
-            root_symbol_id,
-          );
+          self
+            .result
+            .stmt_infos
+            .reference_stmt_for_symbol_id(self.current_stmt_idx.unwrap() + 1, root_symbol_id);
         }
 
         self.check_import_assign(ident_ref, root_symbol_id.symbol);

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1041,7 +1041,6 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // skip first statement info to make sure `program.body` has same index as `stmt_infos`
     old_body.into_iter().enumerate().zip(self.ctx.module.stmt_infos.iter().skip(1)).for_each(
       |((_top_stmt_idx, mut top_stmt), stmt_info)| {
-        debug_assert!(matches!(stmt_info.stmt_idx, Some(_top_stmt_idx)));
         if !stmt_info.is_included {
           return;
         }

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -69,7 +69,6 @@ impl LinkStage<'_> {
         // tree-shaking process.
         linking_info.shimmed_missing_exports.iter().for_each(|(_name, symbol_ref)| {
           let stmt_info = StmtInfo {
-            stmt_idx: None,
             declared_symbols: vec![TaggedSymbolRef::Normal(*symbol_ref)],
             referenced_symbols: vec![],
             side_effect: false.into(),
@@ -120,7 +119,6 @@ impl LinkStage<'_> {
           // Corresponding AST for this statement will be created by the finalizer.
           declared_symbols.push(TaggedSymbolRef::Normal(ecma_module.namespace_object_ref));
           let namespace_stmt_info = StmtInfo {
-            stmt_idx: None,
             declared_symbols,
             referenced_symbols,
             side_effect: false.into(),

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -231,14 +231,13 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   let stmt_info = module.stmt_infos.drain(1.into()..);
   let mut all_declared_symbols =
     stmt_info.flat_map(|info| info.referenced_symbols).collect::<Vec<_>>();
-  for (i, (local, (exported, _))) in declaration_binding_names.iter().enumerate() {
+  for (local, (exported, _)) in &declaration_binding_names {
     let symbol_id =
       symbol_ref_db.scoping().get_root_binding(local.as_str()).expect("should have binding");
     let symbol_ref: SymbolRef = (module_idx, symbol_id).into();
     all_declared_symbols.push(SymbolOrMemberExprRef::from(symbol_ref));
-    let stmt_info = StmtInfo::default()
-      .with_stmt_idx(i)
-      .with_declared_symbols(vec![TaggedSymbolRef::Normal(symbol_ref)]);
+    let stmt_info =
+      StmtInfo::default().with_declared_symbols(vec![TaggedSymbolRef::Normal(symbol_ref)]);
     module.stmt_infos.add_stmt_info(stmt_info);
     module.named_exports.insert(
       exported.clone(),
@@ -247,7 +246,6 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   }
   // declare default export statement
   let stmt_info = StmtInfo::default()
-    .with_stmt_idx(declaration_binding_names.len())
     .with_declared_symbols(vec![TaggedSymbolRef::Normal(default_export_ref)])
     .with_referenced_symbols(all_declared_symbols.clone());
 

--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -220,7 +220,6 @@ pub fn create_wrapper(
         .create_facade_root_symbol_ref(module.idx, &format!("require_{}", &module.repr_name));
 
       let stmt_info = StmtInfo {
-        stmt_idx: None,
         declared_symbols: vec![TaggedSymbolRef::Normal(wrapper_ref)],
         referenced_symbols: vec![if options.profiler_names {
           runtime.resolve_symbol("__commonJS").into()
@@ -253,7 +252,6 @@ pub fn create_wrapper(
         symbols.create_facade_root_symbol_ref(module.idx, &format!("init_{}", &module.repr_name));
 
       let stmt_info = StmtInfo {
-        stmt_idx: None,
         declared_symbols: vec![TaggedSymbolRef::Normal(wrapper_ref)],
         referenced_symbols: vec![if options.profiler_names {
           runtime.resolve_symbol("__esm").into()

--- a/crates/rolldown_common/src/types/stmt_info.rs
+++ b/crates/rolldown_common/src/types/stmt_info.rs
@@ -132,12 +132,6 @@ bitflags! {
 
 #[derive(Default, Debug, Clone)]
 pub struct StmtInfo {
-  /// The index of this statement in the module body.
-  ///
-  /// We will create some facade statements while bundling, and the facade statements
-  /// don't have a corresponding statement in the original module body, which means
-  /// `stmt_idx` will be `None`.
-  pub stmt_idx: Option<StmtInfoIdx>,
   // currently, we only store top level symbols
   pub declared_symbols: Vec<TaggedSymbolRef>,
   // We will add symbols of other modules to `referenced_symbols`, so we need `SymbolRef`
@@ -157,7 +151,7 @@ pub struct StmtInfo {
 #[cfg(target_pointer_width = "64")]
 const _: () = {
   #[cfg(not(debug_assertions))]
-  assert!(size_of::<StmtInfo>() == 88usize);
+  assert!(size_of::<StmtInfo>() == 80usize);
 };
 
 impl StmtInfo {
@@ -168,12 +162,6 @@ impl StmtInfo {
       #[cfg(debug_assertions)]
       source: self.debug_label.clone().unwrap_or_else(|| "<Noop>".into()),
     }
-  }
-
-  #[must_use]
-  pub fn with_stmt_idx(mut self, stmt_idx: usize) -> Self {
-    self.stmt_idx = Some(stmt_idx.into());
-    self
   }
 
   #[must_use]


### PR DESCRIPTION
The `StmtInfoIdx`​ is only used in `scan`​ phase, we could record the current `idx` for each top level `StmtInfo` instead of use another field in `StmtInfo` to record it.
Removing `StmtInfoIdx`​ could reduce the memory usage of `StmtInfo`​ , which was created a lot during bundling.