### PR TITLE
test: add class like cases for empty function optimizations

### DIFF
--- a/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/class_like/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/class_like/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "minify": "dceOnly"
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/class_like/a.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/class_like/a.js
@@ -1,0 +1,9 @@
+export let result = 0
+export function classLike() {}
+
+Object.defineProperty(classLike.prototype, 'sideEffect', {
+  get() {
+    result++
+    return 0
+  }
+})

--- a/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/class_like/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/class_like/artifacts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+let result = 0;
+function classLike() {}
+Object.defineProperty(classLike.prototype, "sideEffect", { get() {
+	result++;
+	return 0;
+} });
+function main_default() {
+	new classLike();
+	assert.equal(result, 1);
+}
+export { main_default as default };
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/class_like/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_empty_function_call/class_like/main.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert';
+import { result, classLike } from './a.js';
+
+export default function () {
+  new classLike();
+  assert.equal(result, 1);
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects/artifacts.snap
@@ -3,9 +3,25 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
+## classLike.js
+
+```js
+//#region classLike.js
+/* @__NO_SIDE_EFFECTS__ */
+function classLike() {}
+Object.defineProperty(classLike.prototype, "sideEffect", { get() {
+	console.log("this side effect may not need to be preserved? See https://github.com/javascript-compiler-hints/compiler-notations-spec/issues/8");
+	return 0;
+} });
+
+//#endregion
+export { classLike };
+```
 ## entry.js
 
 ```js
+import "./classLike.js";
+
 //#region main.js
 console.log("Hello");
 
@@ -14,5 +30,10 @@ console.log("Hello");
 ## entry2.js
 
 ```js
+import { classLike } from "./classLike.js";
 
+//#region entry2.js
+new classLike();
+
+//#endregion
 ```

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects/classLike.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects/classLike.js
@@ -1,0 +1,9 @@
+/* #__NO_SIDE_EFFECTS__ */
+export function classLike() {}
+
+Object.defineProperty(classLike.prototype, 'sideEffect', {
+  get() {
+    console.log('this side effect may not need to be preserved? See https://github.com/javascript-compiler-hints/compiler-notations-spec/issues/8')
+    return 0
+  }
+})

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects/entry2.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects/entry2.js
@@ -1,6 +1,7 @@
 import { defineComponent } from './hello.js'
 import noop from './lib.js'
-
- defineComponent({})
+import { classLike } from './classLike.js'
 
 noop({})
+defineComponent({})
+new classLike()

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects/main.js
@@ -1,4 +1,4 @@
 import './hello.js';
+import './classLike.js';
 
 console.log('Hello');
-

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5049,6 +5049,10 @@ expression: output
 - main-!~{000}~.js => main-BbnV7Uu1.js
 - b-!~{001}~.js => b-BTVziTgp.js
 
+# tests/rolldown/optimization/inline_empty_function_call/class_like
+
+- main-!~{000}~.js => main-CyCzjYr_.js
+
 # tests/rolldown/optimization/pife_for_module_wrappers/basic
 
 - a-!~{000}~.js => a-CcaBLJp5.js
@@ -5903,8 +5907,9 @@ expression: output
 
 # tests/rolldown/tree_shaking/no_side_effects
 
-- entry-!~{000}~.js => entry-CglVlrGN.js
-- entry2-!~{001}~.js => entry2-BfeMxN5u.js
+- entry-!~{000}~.js => entry-DKLXbdZt.js
+- entry2-!~{001}~.js => entry2-n-AAi8Vc.js
+- classLike-!~{002}~.js => classLike-ByuPzZA8.js
 
 # tests/rolldown/tree_shaking/property_read_side_effects
 


### PR DESCRIPTION
Added tests for cases like
```js
export function classLike() {}

Object.defineProperty(classLike.prototype, 'sideEffect', {
  get() {
    result++
    return 0
  }
})
```

`new classLike()` calls should not be removed. But when it's annotated with `#__NO_SIDE_EFFECTS__`, some tools remove it (currently Rolldown doesn't). I think the current behavior is fine for now as the behavior is not aligned among tools (https://github.com/javascript-compiler-hints/compiler-notations-spec/issues/8).

A real world case is https://github.com/d3/d3-color/blob/71c7f100f9fa85a1c70fcbaeb5f803ee8db5620d/src/color.js#L3
