### PR TITLE
feat(dev): ignore self imports when computing update for invalidate

### DIFF
--- a/crates/rolldown/src/hmr/hmr_manager.rs
+++ b/crates/rolldown/src/hmr/hmr_manager.rs
@@ -139,7 +139,8 @@ impl HmrManager {
     //
     // We can safely batch these importers into one update, because we know no file edits have occurred and the HMR boundary relationships
     // remain unchanged.
-    let stale_modules = caller.importers_idx.clone();
+    let mut stale_modules = caller.importers_idx.clone();
+    stale_modules.swap_remove(&caller.idx); // ignore self-imports
     let ret =
       self.compute_hmr_update(&stale_modules, &FxIndexSet::default(), first_invalidated_by).await?;
     // ret.is_self_accepting = true; // (hyf0) TODO: what's this for?

--- a/packages/test-dev-server/tests/fixtures/invalidation/src/child2.hmr-3.js
+++ b/packages/test-dev-server/tests/fixtures/invalidation/src/child2.hmr-3.js
@@ -1,0 +1,10 @@
+import * as mod from './child2';
+
+if (import.meta.hot) {
+  import.meta.hot.accept((_newExports) => {
+    globalThis.records.push(Object.keys(mod));
+    import.meta.hot.invalidate();
+  });
+}
+
+export const value2 = 'child2-updated';

--- a/packages/test-dev-server/tests/fixtures/invalidation/src/child2.js
+++ b/packages/test-dev-server/tests/fixtures/invalidation/src/child2.js
@@ -1,0 +1,10 @@
+import * as mod from './child2';
+
+if (import.meta.hot) {
+  import.meta.hot.accept((_newExports) => {
+    globalThis.records.push(Object.keys(mod));
+    import.meta.hot.invalidate();
+  });
+}
+
+export const value2 = 'child2';

--- a/packages/test-dev-server/tests/fixtures/invalidation/src/parent.js
+++ b/packages/test-dev-server/tests/fixtures/invalidation/src/parent.js
@@ -1,12 +1,20 @@
 import assert from 'node:assert';
 import nodeFs from 'node:fs';
 import { value } from './child';
+import { value2 } from './child2';
 
 if (import.meta.hot) {
   import.meta.hot.accept();
 }
 
-if (value === 'child-handleable') {
+if (value2 === 'child2-updated') {
+  assert.deepStrictEqual(globalThis.records, [
+    'child-handleable',
+    'child-unhandleable',
+    ['value2'],
+  ]);
+  nodeFs.writeFileSync('./ok-2', '');
+} else if (value === 'child-handleable') {
   throw new Error(
     "This change should be handled by child itself. It shouldn't propagate to parent.",
   );


### PR DESCRIPTION
The self imports should be ignored when computing update for invalidate call because we already know that the module cannot self accept.

The react refresh wrapper plugin injects a self import.
https://github.com/rolldown/rolldown/blob/9883b9bf1e1b8c74e3c9f438af9fa7109e29b6ea/crates/rolldown_plugin_react_refresh_wrapper/src/lib.rs#L60