### PR TITLE
test(dev): invalidate call with multiple parent when some parents are not executed

### DIFF
--- a/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/dev.config.mjs
+++ b/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'node',
+  build: {
+    input: 'src/main.js',
+    experimental: {
+      hmr: {
+        new: true,
+      },
+    },
+    platform: 'node',
+    treeshake: false,
+  },
+});

--- a/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/package.json
+++ b/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "invalidation-multiple-parent",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/child.hmr-1.js
+++ b/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/child.hmr-1.js
@@ -1,0 +1,7 @@
+if (import.meta.hot) {
+  import.meta.hot.accept((_newExports) => {
+    import.meta.hot.invalidate();
+  });
+}
+
+export const value = 'child-updated';

--- a/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/child.js
+++ b/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/child.js
@@ -1,0 +1,7 @@
+if (import.meta.hot) {
+  import.meta.hot.accept((_newExports) => {
+    import.meta.hot.invalidate();
+  });
+}
+
+export const value = 'child';

--- a/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/main.js
+++ b/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/main.js
@@ -1,0 +1,13 @@
+function load(id) {
+  if (id === 'parent1') {
+    return import('./parent1.js');
+  }
+  if (id === 'parent2') {
+    return import('./parent2.js');
+  }
+  throw new Error(`Unknown module: ${id}`);
+}
+
+load('parent1');
+
+globalThis.records = [];

--- a/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/parent1.js
+++ b/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/parent1.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+import { value } from './child';
+
+assert(['child', 'child-updated'].includes(value));
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/parent2-child.js
+++ b/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/parent2-child.js
@@ -1,0 +1,1 @@
+export const value = 'parent2-child';

--- a/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/parent2.js
+++ b/packages/test-dev-server/tests/fixtures/invalidation-multiple-parent/src/parent2.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert';
+import { value } from './child';
+import { value as parent2ChildValue } from './parent2-child';
+
+assert(['child', 'child-updated'].includes(value));
+assert.strictEqual(parent2ChildValue, 'parent2-child');
+nodeFs.writeFileSync('./ok-1', '');
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,6 +502,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/test-dev-server/tests/fixtures/invalidation-multiple-parent:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
   packages/test-dev-server/tests/fixtures/multiple-edits:
     devDependencies:
       '@rolldown/test-dev-server':


### PR DESCRIPTION
When there's a module graph like:
```mermaid
graph TD
  main["main (loaded)"] -. dynamic .-> parent1["parent1 (loaded)"]
  main -. dynamic .-> parent2
  parent1 --> child["child (loaded)"]
  parent2 --> child
  parent2 --> parent2-child
```
calling `invalidate` at child.js causes a broken behavior.
When `invalidate` is called, both `parent1` and `parent2` are re-executed, but because `parent2` was never executed, the value of `parent2-child` is not stored in the runtime and causes `loadExports` to return `{}`.
https://github.com/rolldown/rolldown/blob/c8448395d666ff705889451f032db660b3613610/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js#L68-L69

Ideally, we should only re-execute `parent1`. But we can also fix this by correctly executing `parent2`.
