### PR TITLE
test(dev): add rebuild after HMR case

### DIFF
--- a/packages/test-dev-server/tests/fixtures/edit-rebuild/dev.config.mjs
+++ b/packages/test-dev-server/tests/fixtures/edit-rebuild/dev.config.mjs
@@ -1,0 +1,15 @@
+import { defineDevConfig } from '@rolldown/test-dev-server';
+
+export default defineDevConfig({
+  platform: 'node',
+  build: {
+    input: 'src/main.js',
+    experimental: {
+      hmr: {
+        new: true,
+      },
+    },
+    platform: 'node',
+    treeshake: false,
+  },
+});

--- a/packages/test-dev-server/tests/fixtures/edit-rebuild/package.json
+++ b/packages/test-dev-server/tests/fixtures/edit-rebuild/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "edit",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "serve"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@rolldown/test-dev-server": "workspace:*"
+  }
+}

--- a/packages/test-dev-server/tests/fixtures/edit-rebuild/src/foo.hmr-1.js
+++ b/packages/test-dev-server/tests/fixtures/edit-rebuild/src/foo.hmr-1.js
@@ -1,0 +1,6 @@
+import nodeFs from 'node:fs';
+
+export let value = 'edited-foo';
+
+import.meta.hot.accept();
+nodeFs.writeFileSync('./ok-0', '');

--- a/packages/test-dev-server/tests/fixtures/edit-rebuild/src/foo.js
+++ b/packages/test-dev-server/tests/fixtures/edit-rebuild/src/foo.js
@@ -1,0 +1,3 @@
+export let value = 'foo';
+
+import.meta.hot.accept();

--- a/packages/test-dev-server/tests/fixtures/edit-rebuild/src/main.hmr-2.js
+++ b/packages/test-dev-server/tests/fixtures/edit-rebuild/src/main.hmr-2.js
@@ -1,0 +1,7 @@
+// @restart
+import assert from 'node:assert';
+import nodeFs from 'node:fs';
+import { value as fooValue } from './foo';
+
+assert.strictEqual(fooValue, 'edited-foo');
+nodeFs.writeFileSync('./ok-1', '');

--- a/packages/test-dev-server/tests/fixtures/edit-rebuild/src/main.js
+++ b/packages/test-dev-server/tests/fixtures/edit-rebuild/src/main.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { value as fooValue } from './foo';
+
+assert.strictEqual(fooValue, 'foo');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,12 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/test-dev-server/tests/fixtures/edit-rebuild:
+    devDependencies:
+      '@rolldown/test-dev-server':
+        specifier: workspace:*
+        version: link:../../..
+
   packages/test-dev-server/tests/fixtures/invalidation:
     devDependencies:
       '@rolldown/test-dev-server':


### PR DESCRIPTION
Added a test for the following case.

1. HMR update
2. Rebuild

I expect this test to pass. I expect this line to write out a new `dist/main.js`, but it doesn't seem to.
https://github.com/rolldown/rolldown/blob/b66b25028eec6c061cd324cf1c91aab9e1810d2c/packages/test-dev-server/src/dev-server.ts#L151
