### PR TITLE
refactor: remove `@rolldown-ignore` ignore comment support

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -202,7 +202,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
   fn visit_import_expression(&mut self, expr: &ast::ImportExpression<'ast>) {
     // If a `ImportExpression` is ignored by `/* @vite-ignore */` comment, we should not treat it as a dynamic import
-    let should_ignore = self.is_ignored_by_comment(expr);
+    let should_ignore = self.is_imoprt_expr_ignored_by_comment(expr);
     if !should_ignore && let Some(request) = expr.source.as_static_module_request() {
       let import_rec_idx =
         self.add_import_record(request.as_str(), ImportKind::DynamicImport, expr.source.span(), {

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -130,7 +130,6 @@ pub struct AstScannerImmutableCtx<'me, 'ast> {
   id: &'me ModuleId,
   comments: &'me oxc::allocator::Vec<'me, Comment>,
   options: &'me SharedOptions,
-  ignore_comment: &'static str,
   flat_options: FlatOptions,
   allocator: &'ast oxc::allocator::Allocator,
 }
@@ -225,7 +224,6 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         id: file_path,
         comments,
         options,
-        ignore_comment: options.experimental.get_ignore_comment(),
         flat_options,
       },
       current_stmt_info: StmtInfo::default(),
@@ -1038,7 +1036,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     self.result.constant_export_map.insert(symbol_id, value);
   }
 
-  fn is_ignored_by_comment(&mut self, expr: &ImportExpression<'ast>) -> bool {
+  fn is_imoprt_expr_ignored_by_comment(&mut self, expr: &ImportExpression<'ast>) -> bool {
     let mut should_ignore = false;
     while self.current_comment_idx < self.immutable_ctx.comments.len() {
       let comment = &self.immutable_ctx.comments[self.current_comment_idx];

--- a/crates/rolldown/src/ast_scanner/new_url.rs
+++ b/crates/rolldown/src/ast_scanner/new_url.rs
@@ -35,10 +35,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     let has_leading_ignore_comment = get_leading_comment(
       self.immutable_ctx.comments,
       first_arg_string_literal.span,
-      Some(|comment: &Comment| {
-        let original_source = &self.immutable_ctx.source.as_str()[comment.content_span()];
-        original_source.contains(self.immutable_ctx.ignore_comment)
-      }),
+      Some(|comment: &Comment| comment.is_vite()),
     )
     .is_some();
     if has_leading_ignore_comment {

--- a/crates/rolldown/tests/rolldown/topics/new_url/opt-out/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/new_url/opt-out/artifacts.snap
@@ -7,7 +7,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region main.js
-new URL("path-should-not-exists", import.meta.url);
+new URL(
+	/* @vite-ignore */
+	"path-should-not-exists",
+	import.meta.url
+);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/new_url/opt-out/main.js
+++ b/crates/rolldown/tests/rolldown/topics/new_url/opt-out/main.js
@@ -1,1 +1,1 @@
-new URL(/* @rolldown-ignore */ 'path-should-not-exists', import.meta.url);
+new URL(/* @vite-ignore */ 'path-should-not-exists', import.meta.url);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5705,7 +5705,7 @@ expression: output
 
 # tests/rolldown/topics/new_url/opt-out
 
-- main-!~{000}~.js => main-BbJnFXzt.js
+- main-!~{000}~.js => main-C-kiE7Dg.js
 
 # tests/rolldown/topics/new_url/opt_out_vite_mode
 

--- a/crates/rolldown_common/src/ecmascript/comment_annotation.rs
+++ b/crates/rolldown_common/src/ecmascript/comment_annotation.rs
@@ -1,7 +1,5 @@
 use oxc::{ast::Comment, span::Span};
 
-pub static ROLLDOWN_IGNORE: &str = "@rolldown-ignore";
-
 /// Get the leading comment of a node when condition is satisfy
 pub fn get_leading_comment<'a, 'ast: 'a, F: Fn(&Comment) -> bool>(
   comments: &'a oxc::allocator::Vec<'ast, Comment>,
@@ -10,8 +8,5 @@ pub fn get_leading_comment<'a, 'ast: 'a, F: Fn(&Comment) -> bool>(
 ) -> Option<&'a Comment> {
   let i = comments.binary_search_by(|c| c.attached_to.cmp(&node_span.start)).ok()?;
   let comment = comments.get(i)?;
-  match predicate {
-    Some(predicate) if predicate(comment) => Some(comment),
-    _ => None,
-  }
+  predicate.and_then(|func| func(comment).then_some(comment))
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -3,7 +3,6 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::Deserialize;
 
-use crate::ROLLDOWN_IGNORE;
 use crate::inner_bundler_options::types::chunk_import_map::ChunkImportMap;
 
 use super::attach_debug_info::AttachDebugInfo;
@@ -65,11 +64,6 @@ impl ExperimentalOptions {
 
   pub fn is_on_demand_wrapping_enabled(&self) -> bool {
     self.on_demand_wrapping.unwrap_or(false)
-  }
-
-  #[inline]
-  pub fn get_ignore_comment(&self) -> &'static str {
-    if self.vite_mode.unwrap_or_default() { "@vite-ignore" } else { ROLLDOWN_IGNORE }
   }
 
   pub fn is_resolve_new_url_to_asset_enabled(&self) -> bool {

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -99,7 +99,7 @@ pub use crate::{
     css_view::{CssAssetNameReplacer, CssRenderer, CssView},
   },
   ecmascript::{
-    comment_annotation::{ROLLDOWN_IGNORE, get_leading_comment},
+    comment_annotation::get_leading_comment,
     dynamic_import_usage,
     ecma_asset_meta::EcmaAssetMeta,
     ecma_view::{


### PR DESCRIPTION
I don't mark it as breaking change, since I don't find anyone relys on this feature https://github.com/search?q=rolldown-ignore&type=code