### PR TITLE
perf(rolldown): take advantage of tokio blocking threads

### DIFF
--- a/crates/bench/benches/scan.rs
+++ b/crates/bench/benches/scan.rs
@@ -21,7 +21,14 @@ fn criterion_benchmark(c: &mut Criterion) {
     .flat_map(|(name, options)| derive_benchmark_items(&derive_options, name, options.clone()))
     .for_each(|item| {
       group.bench_function(format!("scan@{}", item.name), move |b| {
-        b.to_async(tokio::runtime::Runtime::new().unwrap()).iter(|| async {
+        b.to_async(
+          tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(32)
+            .build()
+            .unwrap(),
+        )
+        .iter(|| async {
           let mut rolldown_bundler =
             rolldown::Bundler::new(item.options.clone()).expect("Failed to create bundler");
           let _output =

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -232,7 +232,7 @@ impl ModuleTask {
     let result = load_source(
       &self.ctx.plugin_driver,
       &self.resolved_id,
-      &self.ctx.fs,
+      self.ctx.fs.clone(),
       sourcemap_chain,
       hook_side_effects,
       &self.ctx.options,

--- a/crates/rolldown_testing/src/utils.rs
+++ b/crates/rolldown_testing/src/utils.rs
@@ -1,19 +1,6 @@
 use std::{borrow::Cow, sync::LazyLock};
 
 use regex::Regex;
-use rolldown_common::BundlerOptions;
-
-pub fn assert_bundled(options: BundlerOptions) {
-  let result = tokio::runtime::Builder::new_multi_thread()
-    .enable_all()
-    .build()
-    .expect("Failed building the Runtime")
-    .block_on(async move {
-      let mut bundler = rolldown::Bundler::new(options).expect("Failed to create bundler");
-      bundler.generate().await
-    });
-  assert!(result.is_ok(), "Failed to bundle.");
-}
 
 #[macro_export]
 /// `std::file!` alternative that returns an absolute path.


### PR DESCRIPTION
closes https://github.com/rolldown/rolldown/issues/3754

Benchmark in apps/10000:

### `1.0.0-beta.38`

```
❯ hyperfine --warmup 3 --runs 10 --command-name "rolldown-latest" "../../node_modules/.bin/rolldown build --config rolldown.config.mjs"
Benchmark 1: rolldown-latest
  Time (mean ± σ):     553.6 ms ±  21.4 ms    [User: 1107.1 ms, System: 2948.2 ms]
  Range (min … max):   518.7 ms … 579.5 ms    10 runs
```

### `current`

```
❯ hyperfine --warmup 3 --runs 10 --command-name "rolldown-latest" "../../node_modules/.bin/rolldown build --config rolldown.config.mjs"
Benchmark 1: rolldown-latest
  Time (mean ± σ):     458.1 ms ±   6.5 ms    [User: 1052.2 ms, System: 1092.4 ms]
  Range (min … max):   447.5 ms … 468.8 ms    10 runs
```

I don't know why `codspeed` crashes, I added a feature for `codspeed` so that under `codspeed` it doesn't use `spawn_blocking`.