### PR TITLE
chore(rust): fixes for `cargo publish --dry-run --workspace`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_dynamic_import_vars"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "arcstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,7 @@ map_unwrap_or = "allow"
 collapsible_if = "allow"
 
 [workspace.dependencies]
-criterion2 = { version = "3.0.0", default-features = false }
-css-module-lexer = "0.0.15"
+# publish = true
 rolldown = { version = "0.1.0", path = "./crates/rolldown" }
 rolldown_binding_watcher = { version = "0.1.0", path = "./crates/rolldown_binding_watcher" }
 rolldown_common = { version = "0.1.0", path = "./crates/rolldown_common" }
@@ -96,7 +95,7 @@ rolldown_plugin_asset_import_meta_url = { version = "0.1.0", path = "./crates/ro
 rolldown_plugin_build_import_analysis = { version = "0.1.0", path = "./crates/rolldown_plugin_build_import_analysis" }
 rolldown_plugin_chunk_import_map = { version = "0.1.0", path = "./crates/rolldown_plugin_chunk_import_map" }
 rolldown_plugin_data_uri = { version = "0.1.0", path = "./crates/rolldown_plugin_data_uri" }
-rolldown_plugin_dynamic_import_vars = { version = "0.0.1", path = "./crates/rolldown_plugin_dynamic_import_vars" }
+rolldown_plugin_dynamic_import_vars = { version = "0.1.0", path = "./crates/rolldown_plugin_dynamic_import_vars" }
 rolldown_plugin_esm_external_require = { version = "0.1.0", path = "./crates/rolldown_plugin_esm_external_require" }
 rolldown_plugin_hmr = { version = "0.1.0", path = "./crates/rolldown_plugin_hmr" }
 rolldown_plugin_import_glob = { version = "0.1.0", path = "./crates/rolldown_plugin_import_glob" }
@@ -124,7 +123,9 @@ rolldown_tracing = { version = "0.1.0", path = "./crates/rolldown_tracing" }
 rolldown_utils = { version = "0.1.0", path = "./crates/rolldown_utils" }
 rolldown_watcher = { version = "0.1.0", path = "./crates/rolldown_watcher" }
 rolldown_workspace = { version = "0.1.0", path = "./crates/rolldown_workspace" }
+string_wizard = { version = "0.0.26", path = "./crates/string_wizard", features = ["serde"] }
 
+#
 anyhow = "1.0.98"
 append-only-vec = "0.1.7"
 arcstr = { version = "1.2.0", default-features = false }
@@ -138,6 +139,8 @@ bitflags = "2.9.1"
 blake3 = "1.8.2"
 commondir = "1.0.0"
 cow-utils = "0.1.3"
+criterion2 = { version = "3.0.0", default-features = false }
+css-module-lexer = "0.0.15"
 dashmap = "6.1.0"
 derive_more = { version = "2.0.1", features = ["debug"] }
 dunce = "1.0.5" # Normalize Windows paths to the most compatible format, avoiding UNC where possible
@@ -177,7 +180,6 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 simdutf8 = "0.1.5"
 smallvec = "1.15.0"
-string_wizard = { path = "./crates/string_wizard", features = ["serde"] }
 sugar_path = { version = "1.2.0", features = ["cached_current_dir"] }
 terminal_size = "0.4.2"
 testing_macros = "1.0.0"

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bench"
 version = "0.1.0"
+publish = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 edition.workspace = true

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rolldown_binding"
 version = "0.1.0"
+publish = true
 
 edition.workspace = true
 homepage.workspace = true

--- a/crates/rolldown_binding_watcher/Cargo.toml
+++ b/crates/rolldown_binding_watcher/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rolldown_binding_watcher"
 version = "0.1.0"
+publish = true
 
 edition.workspace = true
 homepage.workspace = true

--- a/crates/rolldown_common/Cargo.toml
+++ b/crates/rolldown_common/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rolldown_common"
 version = "0.1.0"
+publish = true
 description = "This crate is mostly for sharing code between rolldwon crates."
 
 edition.workspace = true

--- a/crates/rolldown_debug/Cargo.toml
+++ b/crates/rolldown_debug/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lints]

--- a/crates/rolldown_debug_action/Cargo.toml
+++ b/crates/rolldown_debug_action/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lints]

--- a/crates/rolldown_ecmascript/Cargo.toml
+++ b/crates/rolldown_ecmascript/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rolldown_ecmascript"
 version = "0.1.0"
+publish = true
 
 edition.workspace = true
 homepage.workspace = true

--- a/crates/rolldown_ecmascript_utils/Cargo.toml
+++ b/crates/rolldown_ecmascript_utils/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lints]

--- a/crates/rolldown_error/Cargo.toml
+++ b/crates/rolldown_error/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rolldown_error"
 version = "0.1.0"
+publish = true
 description = "rolldown_error"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_filter_analyzer/Cargo.toml
+++ b/crates/rolldown_filter_analyzer/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lints]

--- a/crates/rolldown_fs/Cargo.toml
+++ b/crates/rolldown_fs/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_alias/Cargo.toml
+++ b/crates/rolldown_plugin_alias/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_asset/Cargo.toml
+++ b/crates/rolldown_plugin_asset/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_asset_import_meta_url/Cargo.toml
+++ b/crates/rolldown_plugin_asset_import_meta_url/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_build_import_analysis/Cargo.toml
+++ b/crates/rolldown_plugin_build_import_analysis/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_chunk_import_map/Cargo.toml
+++ b/crates/rolldown_plugin_chunk_import_map/Cargo.toml
@@ -3,6 +3,7 @@ name = "rolldown_plugin_chunk_import_map"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+publish = true
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_data_uri/Cargo.toml
+++ b/crates/rolldown_plugin_data_uri/Cargo.toml
@@ -3,6 +3,7 @@ name = "rolldown_plugin_data_uri"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+publish = true
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_dynamic_import_vars/Cargo.toml
+++ b/crates/rolldown_plugin_dynamic_import_vars/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "rolldown_plugin_dynamic_import_vars"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_esm_external_require/Cargo.toml
+++ b/crates/rolldown_plugin_esm_external_require/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_hmr/Cargo.toml
+++ b/crates/rolldown_plugin_hmr/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/rolldown_plugin_import_glob/Cargo.toml
+++ b/crates/rolldown_plugin_import_glob/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_isolated_declaration/Cargo.toml
+++ b/crates/rolldown_plugin_isolated_declaration/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_json/Cargo.toml
+++ b/crates/rolldown_plugin_json/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_load_fallback/Cargo.toml
+++ b/crates/rolldown_plugin_load_fallback/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_manifest/Cargo.toml
+++ b/crates/rolldown_plugin_manifest/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lints]

--- a/crates/rolldown_plugin_module_preload_polyfill/Cargo.toml
+++ b/crates/rolldown_plugin_module_preload_polyfill/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_oxc_runtime/Cargo.toml
+++ b/crates/rolldown_plugin_oxc_runtime/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lib]

--- a/crates/rolldown_plugin_react_refresh_wrapper/Cargo.toml
+++ b/crates/rolldown_plugin_react_refresh_wrapper/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lints]

--- a/crates/rolldown_plugin_replace/Cargo.toml
+++ b/crates/rolldown_plugin_replace/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lints]
@@ -16,7 +17,7 @@ doctest = false
 oxc = { workspace = true }
 regex = { workspace = true }
 regress = { workspace = true }
-rolldown_plugin = { path = "../rolldown_plugin" }
+rolldown_plugin = { workspace = true }
 rustc-hash = { workspace = true }
 string_wizard = { workspace = true }
 

--- a/crates/rolldown_plugin_reporter/Cargo.toml
+++ b/crates/rolldown_plugin_reporter/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_transform/Cargo.toml
+++ b/crates/rolldown_plugin_transform/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_utils/Cargo.toml
+++ b/crates/rolldown_plugin_utils/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_vite_css/Cargo.toml
+++ b/crates/rolldown_plugin_vite_css/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lib]

--- a/crates/rolldown_plugin_vite_css_post/Cargo.toml
+++ b/crates/rolldown_plugin_vite_css_post/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lib]

--- a/crates/rolldown_plugin_vite_resolve/Cargo.toml
+++ b/crates/rolldown_plugin_vite_resolve/Cargo.toml
@@ -3,6 +3,7 @@ name = "rolldown_plugin_vite_resolve"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+publish = true
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_wasm_fallback/Cargo.toml
+++ b/crates/rolldown_plugin_wasm_fallback/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_wasm_helper/Cargo.toml
+++ b/crates/rolldown_plugin_wasm_helper/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_plugin_web_worker_post/Cargo.toml
+++ b/crates/rolldown_plugin_web_worker_post/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_resolver/Cargo.toml
+++ b/crates/rolldown_resolver/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rolldown_resolver"
 version = "0.1.0"
+publish = true
 description = "rolldown_resolver"
 
 edition.workspace = true

--- a/crates/rolldown_sourcemap/Cargo.toml
+++ b/crates/rolldown_sourcemap/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rolldown_sourcemap"
 version = "0.1.0"
+publish = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_std_utils/Cargo.toml
+++ b/crates/rolldown_std_utils/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lib]

--- a/crates/rolldown_testing/Cargo.toml
+++ b/crates/rolldown_testing/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rolldown_testing"
 version = "0.1.0"
+publish = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 edition.workspace = true

--- a/crates/rolldown_testing_config/Cargo.toml
+++ b/crates/rolldown_testing_config/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_tracing/Cargo.toml
+++ b/crates/rolldown_tracing/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rolldown_tracing"
 version = "0.1.0"
+publish = true
 description = "rolldown_tracing"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rolldown_utils"
 version = "0.1.0"
+publish = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_watcher/Cargo.toml
+++ b/crates/rolldown_watcher/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/rolldown_workspace/Cargo.toml
+++ b/crates/rolldown_workspace/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = true
 repository.workspace = true
 
 [lib]

--- a/crates/string_wizard/Cargo.toml
+++ b/crates/string_wizard/Cargo.toml
@@ -3,6 +3,7 @@ name = "string_wizard"
 version = "0.0.26"
 edition = "2021"
 license = "MIT"
+publish = true
 description = "manipulate string like a wizard"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
part of #3227