### PR TITLE
chore(rust): make `cargo publish --workspace` work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "string_wizard"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "insta",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ rolldown_tracing = { version = "0.1.0", path = "crates/rolldown_tracing" }
 rolldown_utils = { version = "0.1.0", path = "crates/rolldown_utils" }
 rolldown_watcher = { version = "0.1.0", path = "crates/rolldown_watcher" }
 rolldown_workspace = { version = "0.1.0", path = "crates/rolldown_workspace" }
-string_wizard = { version = "0.0.26", path = "crates/string_wizard", features = ["serde"] }
+string_wizard = { version = "0.0.27", path = "crates/string_wizard", features = ["serde"] }
 
 #
 anyhow = "1.0.98"

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bench"
 version = "0.1.0"
-publish = true
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 edition.workspace = true

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Fast JavaScript bundler in Rust, designed for the future of Vite"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -73,7 +74,7 @@ xxhash-rust = { workspace = true, features = ["xxh3"] }
 [dev-dependencies]
 glob = { workspace = true }
 insta = { workspace = true }
-rolldown_testing = { workspace = true }
+rolldown_testing = { path = "../rolldown_testing" }
 rolldown_workspace = { workspace = true }
 sugar_path = { workspace = true }
 testing_macros = { workspace = true }

--- a/crates/rolldown_debug/Cargo.toml
+++ b/crates/rolldown_debug/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Debugging utilities for Rolldown"
 
 [lints]
 workspace = true

--- a/crates/rolldown_debug_action/Cargo.toml
+++ b/crates/rolldown_debug_action/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Debug action handlers for Rolldown"
 
 [lints]
 workspace = true

--- a/crates/rolldown_ecmascript/Cargo.toml
+++ b/crates/rolldown_ecmascript/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rolldown_ecmascript"
 version = "0.1.0"
 publish = true
+description = "ECMAScript AST and parsing utilities for Rolldown"
 
 edition.workspace = true
 homepage.workspace = true

--- a/crates/rolldown_ecmascript_utils/Cargo.toml
+++ b/crates/rolldown_ecmascript_utils/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Helper utilities for ECMAScript processing"
 
 [lints]
 workspace = true

--- a/crates/rolldown_filter_analyzer/Cargo.toml
+++ b/crates/rolldown_filter_analyzer/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Analyzer for filter patterns in Rolldown"
 
 [lints]
 workspace = true

--- a/crates/rolldown_fs/Cargo.toml
+++ b/crates/rolldown_fs/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Filesystem abstraction layer for Rolldown"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin/Cargo.toml
+++ b/crates/rolldown_plugin/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Plugin interface for Rolldown bundler"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_alias/Cargo.toml
+++ b/crates/rolldown_plugin_alias/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for module path aliasing"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_asset/Cargo.toml
+++ b/crates/rolldown_plugin_asset/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for asset handling"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_asset_import_meta_url/Cargo.toml
+++ b/crates/rolldown_plugin_asset_import_meta_url/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for import.meta.url asset handling"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_build_import_analysis/Cargo.toml
+++ b/crates/rolldown_plugin_build_import_analysis/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for build import analysis"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_chunk_import_map/Cargo.toml
+++ b/crates/rolldown_plugin_chunk_import_map/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 publish = true
+description = "Rolldown plugin for chunk import mapping"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_data_uri/Cargo.toml
+++ b/crates/rolldown_plugin_data_uri/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 publish = true
+description = "Rolldown plugin for data URI handling"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_dynamic_import_vars/Cargo.toml
+++ b/crates/rolldown_plugin_dynamic_import_vars/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for dynamic import with template literals"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_esm_external_require/Cargo.toml
+++ b/crates/rolldown_plugin_esm_external_require/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for ESM external require handling"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_hmr/Cargo.toml
+++ b/crates/rolldown_plugin_hmr/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for Hot Module Replacement (HMR)"
 
 [dependencies]
 arcstr = { workspace = true }

--- a/crates/rolldown_plugin_import_glob/Cargo.toml
+++ b/crates/rolldown_plugin_import_glob/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for glob imports"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_isolated_declaration/Cargo.toml
+++ b/crates/rolldown_plugin_isolated_declaration/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for TypeScript isolated declarations"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -25,5 +26,5 @@ rolldown_utils = { workspace = true }
 sugar_path = { workspace = true }
 
 [dev-dependencies]
-rolldown_testing = { workspace = true }
+rolldown_testing = { path = '../rolldown_testing' }
 testing_macros = { workspace = true }

--- a/crates/rolldown_plugin_json/Cargo.toml
+++ b/crates/rolldown_plugin_json/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for JSON file imports"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_load_fallback/Cargo.toml
+++ b/crates/rolldown_plugin_load_fallback/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for load fallback handling"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_manifest/Cargo.toml
+++ b/crates/rolldown_plugin_manifest/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for build manifest generation"
 
 [lints]
 workspace = true

--- a/crates/rolldown_plugin_module_preload_polyfill/Cargo.toml
+++ b/crates/rolldown_plugin_module_preload_polyfill/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for module preload polyfill"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_oxc_runtime/Cargo.toml
+++ b/crates/rolldown_plugin_oxc_runtime/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for OXC runtime helpers"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_react_refresh_wrapper/Cargo.toml
+++ b/crates/rolldown_plugin_react_refresh_wrapper/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for React Refresh wrapper"
 
 [lints]
 workspace = true

--- a/crates/rolldown_plugin_replace/Cargo.toml
+++ b/crates/rolldown_plugin_replace/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for string replacement"
 
 [lints]
 workspace = true
@@ -23,5 +24,5 @@ string_wizard = { workspace = true }
 
 [dev-dependencies]
 rolldown = { workspace = true }
-rolldown_testing = { workspace = true }
+rolldown_testing = { path = '../rolldown_testing' }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "rt-multi-thread"] }

--- a/crates/rolldown_plugin_reporter/Cargo.toml
+++ b/crates/rolldown_plugin_reporter/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for build reporting"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_transform/Cargo.toml
+++ b/crates/rolldown_plugin_transform/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for code transformation"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_utils/Cargo.toml
+++ b/crates/rolldown_plugin_utils/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Shared utilities for Rolldown plugins"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_vite_css/Cargo.toml
+++ b/crates/rolldown_plugin_vite_css/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for Vite CSS handling"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_vite_css_post/Cargo.toml
+++ b/crates/rolldown_plugin_vite_css_post/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for Vite CSS post-processing"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_vite_html/Cargo.toml
+++ b/crates/rolldown_plugin_vite_html/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for Vite HTML handling"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_vite_resolve/Cargo.toml
+++ b/crates/rolldown_plugin_vite_resolve/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 publish = true
+description = "Rolldown plugin for Vite module resolution"
 
 [lib]
 doctest = false

--- a/crates/rolldown_plugin_wasm_fallback/Cargo.toml
+++ b/crates/rolldown_plugin_wasm_fallback/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for WebAssembly fallback handling"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_wasm_helper/Cargo.toml
+++ b/crates/rolldown_plugin_wasm_helper/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for WebAssembly helper generation"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_plugin_web_worker_post/Cargo.toml
+++ b/crates/rolldown_plugin_web_worker_post/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Rolldown plugin for Web Worker post-processing"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_sourcemap/Cargo.toml
+++ b/crates/rolldown_sourcemap/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rolldown_sourcemap"
 version = "0.1.0"
 publish = true
+description = "Source map generation and manipulation for Rolldown"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_std_utils/Cargo.toml
+++ b/crates/rolldown_std_utils/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Standard library utilities for Rolldown"
 
 [lib]
 doctest = false

--- a/crates/rolldown_testing_config/Cargo.toml
+++ b/crates/rolldown_testing_config/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish = true
+publish = false
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rolldown_utils"
 version = "0.1.0"
 publish = true
+description = "General-purpose utilities for Rolldown"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/rolldown_watcher/Cargo.toml
+++ b/crates/rolldown_watcher/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "File watching implementation for Rolldown"
 
 [dependencies]
 rolldown-notify = { workspace = true }

--- a/crates/rolldown_workspace/Cargo.toml
+++ b/crates/rolldown_workspace/Cargo.toml
@@ -6,6 +6,7 @@ homepage.workspace = true
 license.workspace = true
 publish = true
 repository.workspace = true
+description = "Workspace management utilities for Rolldown"
 
 [lib]
 doctest = false

--- a/crates/string_wizard/Cargo.toml
+++ b/crates/string_wizard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "string_wizard"
-version = "0.0.26"
+version = "0.0.27"
 edition = "2021"
 license = "MIT"
 publish = true


### PR DESCRIPTION
closes #3227

`rolldown_testing` is changed to depend on path because of cyclic dependency with `rolldown`.

https://crates.io/crates/rolldown is released on top of this branch.

Published crates: 

```
rolldown_std_utils
rolldown_utils
rolldown_error
rolldown_ecmascript
rolldown_sourcemap
string_wizard
rolldown_common
rolldown_debug_action
rolldown_debug
rolldown_ecmascript_utils
rolldown_fs
rolldown_resolver
rolldown_plugin
rolldown_plugin_chunk_import_map
rolldown_plugin_data_uri
rolldown_plugin_hmr
rolldown_plugin_oxc_runtime
rolldown_tracing
rolldown_watcher
rolldown_workspace
rolldown
rolldown_plugin_alias
rolldown_plugin_utils
rolldown_plugin_asset
rolldown_plugin_asset_import_meta_url
rolldown_plugin_build_import_analysis
rolldown_plugin_dynamic_import_vars
rolldown_plugin_esm_external_require
rolldown_plugin_import_glob
rolldown_plugin_isolated_declaration
rolldown_plugin_json
rolldown_plugin_load_fallback
rolldown_plugin_manifest
rolldown_plugin_module_preload_polyfill
rolldown_plugin_react_refresh_wrapper
rolldown_plugin_replace
rolldown_plugin_reporter
rolldown_plugin_transform
rolldown_plugin_vite_css
rolldown_plugin_vite_resolve
rolldown_plugin_wasm_fallback
rolldown_plugin_wasm_helper
rolldown_plugin_web_worker_post
rolldown_filter_analyzer
rolldown_plugin_vite_css_post
rolldown_plugin_vite_html
```