### PR TITLE
refactor!: move stable plugins from experimental to `rolldown/plugins`

### DIFF
--- a/docs/builtin-plugins/esm-external-require.md
+++ b/docs/builtin-plugins/esm-external-require.md
@@ -19,7 +19,7 @@ Import and use the plugin from Rolldown's experimental exports:
 
 ```js
 import { defineConfig } from 'rolldown';
-import { esmExternalRequirePlugin } from 'rolldown/experimental';
+import { esmExternalRequirePlugin } from 'rolldown/plugins';
 
 export default defineConfig({
   input: 'src/index.js',

--- a/docs/builtin-plugins/replace.md
+++ b/docs/builtin-plugins/replace.md
@@ -4,11 +4,11 @@ The `replacePlugin` is a built-in Rolldown plugin that replaces the code based o
 
 ## Usage
 
-Import and use the plugin from Rolldown's experimental exports:
+Import and use the plugin from Rolldown's plugins exports:
 
 ```js
 import { defineConfig } from 'rolldown';
-import { replacePlugin } from 'rolldown/experimental';
+import { replacePlugin } from 'rolldown/plugins';
 
 export default defineConfig({
   input: 'src/index.js',

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -116,6 +116,7 @@ function withShared(
   return {
     input: {
       index: './src/index',
+      'plugins-index': './src/plugins-index',
       'experimental-index': './src/experimental-index',
       ...!isBrowserBuild
         ? {

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -58,7 +58,11 @@
       "dev": "./src/parse-ast-index.ts",
       "default": "./dist/parse-ast-index.mjs"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./plugins": {
+      "dev": "./src/plugins-index.ts",
+      "default": "./dist/plugins-index.mjs"
+    }
   },
   "imports": {
     "#parallel-plugin-worker": "./dist/parallel-plugin-worker.mjs"

--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -28,7 +28,6 @@ export { defineParallelPlugin } from './plugin/parallel-plugin';
 export {
   buildImportAnalysisPlugin,
   dynamicImportVarsPlugin,
-  esmExternalRequirePlugin,
   htmlInlineProxyPlugin,
   importGlobPlugin,
   isolatedDeclarationPlugin,
@@ -48,6 +47,5 @@ export {
 
 export { aliasPlugin } from './builtin-plugin/alias-plugin';
 export { assetPlugin } from './builtin-plugin/asset-plugin';
-export { replacePlugin } from './builtin-plugin/replace-plugin';
 export { transformPlugin } from './builtin-plugin/transform-plugin';
 export { viteCSSPlugin } from './builtin-plugin/vite-css-plugin';

--- a/packages/rolldown/src/plugins-index.ts
+++ b/packages/rolldown/src/plugins-index.ts
@@ -1,0 +1,2 @@
+export { esmExternalRequirePlugin } from './builtin-plugin/constructors';
+export { replacePlugin } from './builtin-plugin/replace-plugin';

--- a/packages/rolldown/tests/cli/fixtures/cjs-config-with-replace-plugin/rolldown.config.cjs
+++ b/packages/rolldown/tests/cli/fixtures/cjs-config-with-replace-plugin/rolldown.config.cjs
@@ -1,5 +1,5 @@
 const rolldown = require('rolldown');
-const plugin = require('rolldown/experimental');
+const plugin = require('rolldown/plugins');
 
 module.exports = rolldown.defineConfig({
   input: './index.js',

--- a/packages/rolldown/tests/fixtures/builtin-plugin/replace/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/replace/basic/_config.ts
@@ -1,5 +1,5 @@
 import { defineTest } from 'rolldown-tests';
-import { replacePlugin } from 'rolldown/experimental';
+import { replacePlugin } from 'rolldown/plugins';
 
 export default defineTest({
   config: {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/replace/issue-5817/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/replace/issue-5817/_config.ts
@@ -1,5 +1,5 @@
 import { defineTest } from 'rolldown-tests';
-import { replacePlugin } from 'rolldown/experimental';
+import { replacePlugin } from 'rolldown/plugins';
 import { expect } from 'vitest';
 
 export default defineTest({


### PR DESCRIPTION
closes #5815