### PR TITLE
fix(rolldown_plugin_transform): resolve tsconfig from absolute path

### DIFF
--- a/crates/rolldown_plugin_transform/src/utils.rs
+++ b/crates/rolldown_plugin_transform/src/utils.rs
@@ -119,7 +119,7 @@ impl TransformPlugin {
     }
 
     if source_type.is_typescript() {
-      let path = Path::new(id).parent().and_then(find_tsconfig_json_for_file);
+      let path = Path::new(cwd).join(id).parent().and_then(find_tsconfig_json_for_file);
       let tsconfig = path.map(|path| ctx.resolver().resolve_tsconfig(&path)).transpose()?;
 
       if let Some(tsconfig) = tsconfig {


### PR DESCRIPTION
closes #6164, https://github.com/vitejs/rolldown-vite/issues/424