### PR TITLE
perf: optimize sourcemap ignore list with fast path for static `string | RegExp` 

### DIFF
--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -14,6 +14,7 @@ use binding_pre_rendered_chunk::PreRenderedChunk;
 use super::plugin::BindingPluginOrParallelJsPluginPlaceholder;
 use crate::types::{
   binding_rendered_chunk::BindingRenderedChunk,
+  binding_string_or_regex::BindingStringOrRegex,
   js_callback::{JsCallback, MaybeAsyncJsCallback},
 };
 
@@ -25,6 +26,8 @@ pub type AssetFileNamesOutputOption =
 pub type GlobalsOutputOption =
   Either<FxHashMap<String, String>, JsCallback<FnArgs<(String,)>, String>>;
 pub type SanitizeFileName = Either<bool, JsCallback<FnArgs<(String,)>, String>>;
+pub type SourcemapIgnoreListOutputOption =
+  Either3<bool, BindingStringOrRegex, JsCallback<FnArgs<(String, String)>, bool>>;
 
 #[napi(object, object_to_js = false)]
 #[derive(Debug)]
@@ -99,8 +102,10 @@ pub struct BindingOutputOptions<'env> {
   pub sourcemap: Option<String>,
   pub sourcemap_base_url: Option<String>,
   #[debug(skip)]
-  #[napi(ts_type = "(source: string, sourcemapPath: string) => boolean")]
-  pub sourcemap_ignore_list: Option<JsCallback<FnArgs<(String, String)>, bool>>,
+  #[napi(
+    ts_type = "boolean | string | RegExp | ((source: string, sourcemapPath: string) => boolean)"
+  )]
+  pub sourcemap_ignore_list: Option<SourcemapIgnoreListOutputOption>,
   pub sourcemap_debug_ids: Option<bool>,
   #[debug(skip)]
   #[napi(ts_type = "(source: string, sourcemapPath: string) => string")]

--- a/crates/rolldown_common/src/inner_bundler_options/types/sourcemap_ignore_list.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/sourcemap_ignore_list.rs
@@ -2,21 +2,52 @@ use std::sync::Arc;
 use std::{future::Future, pin::Pin};
 
 use derive_more::Debug;
+use rolldown_utils::pattern_filter::StringOrRegex;
 
 pub type SourceMapIgnoreListFn = dyn Fn(&str, &str) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send + 'static>>
   + Send
   + Sync;
 
 #[derive(Clone, Debug)]
-#[debug("SourceMapIgnoreList::Fn(...)")]
-pub struct SourceMapIgnoreList(Arc<SourceMapIgnoreListFn>);
+pub enum SourceMapIgnoreList {
+  Boolean(bool),
+  StringOrRegex(StringOrRegex),
+  #[debug("SourceMapIgnoreList::Fn(...)")]
+  Fn(Arc<SourceMapIgnoreListFn>),
+}
 
 impl SourceMapIgnoreList {
   pub fn new(f: Arc<SourceMapIgnoreListFn>) -> Self {
-    Self(f)
+    Self::Fn(f)
   }
 
-  pub async fn call(&self, source: &str, sourcemap_path: &str) -> anyhow::Result<bool> {
-    self.0(source, sourcemap_path).await
+  pub fn from_bool(value: bool) -> Self {
+    Self::Boolean(value)
+  }
+
+  pub fn from_string_or_regex(pattern: StringOrRegex) -> Self {
+    Self::StringOrRegex(pattern)
+  }
+
+  pub fn exec_static(&self, source: &str) -> bool {
+    match self {
+      Self::Boolean(value) => *value,
+      Self::StringOrRegex(pattern) => match pattern {
+        StringOrRegex::String(s) => source.contains(s),
+        StringOrRegex::Regex(r) => r.matches(source),
+      },
+      Self::Fn(_) => {
+        unreachable!("exec_static should only be called for `Boolean` or `StringOrRegex` variants")
+      }
+    }
+  }
+
+  pub async fn exec_dynamic(&self, source: &str, sourcemap_path: &str) -> anyhow::Result<bool> {
+    match self {
+      Self::Boolean(_) | Self::StringOrRegex(_) => {
+        unreachable!("exec_dynamic should only be called for Fn variant")
+      }
+      Self::Fn(f) => f(source, sourcemap_path).await,
+    }
   }
 }

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1946,7 +1946,7 @@ export interface BindingOutputOptions {
   plugins: (BindingBuiltinPlugin | BindingPluginOptions | undefined)[]
   sourcemap?: 'file' | 'inline' | 'hidden'
   sourcemapBaseUrl?: string
-  sourcemapIgnoreList?: (source: string, sourcemapPath: string) => boolean
+  sourcemapIgnoreList?: boolean | string | RegExp | ((source: string, sourcemapPath: string) => boolean)
   sourcemapDebugIds?: boolean
   sourcemapPathTransform?: (source: string, sourcemapPath: string) => string
   minify?: boolean | 'dce-only' | MinifyOptions

--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -4,7 +4,7 @@ import type {
   SourcemapIgnoreListOption,
   SourcemapPathTransformOption,
 } from '../types/misc';
-import { bindingifySourcemapIgnoreList } from '../utils/bindingify-output-options';
+import type { StringOrRegExp } from '../types/utils';
 import type {
   AddonFunction,
   AssetFileNamesFunction,
@@ -40,7 +40,11 @@ export interface NormalizedOutputOptions {
   globals: Record<string, string> | GlobalsFunction;
   hashCharacters: 'base64' | 'base36' | 'hex';
   sourcemapDebugIds: boolean;
-  sourcemapIgnoreList: SourcemapIgnoreListOption;
+  sourcemapIgnoreList:
+    | boolean
+    | SourcemapIgnoreListOption
+    | StringOrRegExp
+    | undefined;
   sourcemapPathTransform: SourcemapPathTransformOption | undefined;
   minify: false | MinifyOptions | 'dce-only';
   legalComments: 'none' | 'inline';
@@ -159,10 +163,13 @@ export class NormalizedOutputOptionsImpl implements NormalizedOutputOptions {
     return this.inner.sourcemapDebugIds;
   }
 
-  get sourcemapIgnoreList(): SourcemapIgnoreListOption {
-    return bindingifySourcemapIgnoreList(
-      this.outputOptions.sourcemapIgnoreList,
-    );
+  get sourcemapIgnoreList():
+    | boolean
+    | SourcemapIgnoreListOption
+    | StringOrRegExp
+    | undefined
+  {
+    return this.outputOptions.sourcemapIgnoreList;
   }
 
   get sourcemapPathTransform(): SourcemapPathTransformOption | undefined {

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -64,7 +64,7 @@ export interface OutputOptions {
   sourcemap?: boolean | 'inline' | 'hidden';
   sourcemapBaseUrl?: string;
   sourcemapDebugIds?: boolean;
-  sourcemapIgnoreList?: boolean | SourcemapIgnoreListOption;
+  sourcemapIgnoreList?: boolean | SourcemapIgnoreListOption | StringOrRegExp;
   sourcemapPathTransform?: SourcemapPathTransformOption;
   banner?: string | AddonFunction;
   footer?: string | AddonFunction;

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -1,7 +1,6 @@
 import type { BindingOutputOptions } from '../binding';
 import type { OutputOptions } from '../options/output-options';
 import { ChunkingContextImpl } from '../types/chunking-context';
-import type { SourcemapIgnoreListOption } from '../types/misc';
 import { transformAssetSource } from './asset-source';
 import { unimplemented } from './misc';
 import { transformRenderedChunk } from './transform-rendered-chunk';
@@ -56,7 +55,7 @@ export function bindingifyOutputOptions(
     sourcemap: bindingifySourcemap(sourcemap),
     sourcemapBaseUrl,
     sourcemapDebugIds,
-    sourcemapIgnoreList: bindingifySourcemapIgnoreList(sourcemapIgnoreList),
+    sourcemapIgnoreList: sourcemapIgnoreList ?? /node_modules/,
     sourcemapPathTransform,
     banner: bindingifyAddon(banner),
     footer: bindingifyAddon(footer),
@@ -142,17 +141,6 @@ function bindingifySourcemap(
     default:
       throw new Error(`unknown sourcemap: ${sourcemap}`);
   }
-}
-
-export function bindingifySourcemapIgnoreList(
-  sourcemapIgnoreList: OutputOptions['sourcemapIgnoreList'],
-): SourcemapIgnoreListOption {
-  return typeof sourcemapIgnoreList === 'function'
-    ? sourcemapIgnoreList
-    : sourcemapIgnoreList === false
-    ? () => false
-    : (relativeSourcePath: string, _sourcemapPath: string) =>
-      relativeSourcePath.includes('node_modules');
 }
 
 function bindingifyAssetFilenames(

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -769,7 +769,11 @@ const OutputOptionsSchema = v.strictObject({
     v.description('Inject sourcemap debug IDs'),
   ),
   sourcemapIgnoreList: v.optional(
-    v.union([v.boolean(), v.custom<SourcemapIgnoreListOption>(() => true)]),
+    v.union([
+      v.boolean(),
+      v.custom<SourcemapIgnoreListOption>(() => true),
+      StringOrRegExpSchema,
+    ]),
   ),
   sourcemapPathTransform: v.optional(
     v.custom<SourcemapPathTransformOption>(() => true),


### PR DESCRIPTION
## Linux 
>    OS: Linux 6.9 Pop!_OS 22.04 LTS
>    CPU: (32) x64 AMD Ryzen 9 5950X 16-Core Processor
>    Memory: 37.53 GB / 62.67 GB

<img width="1779" height="353" alt="image" src="https://github.com/user-attachments/assets/8bd46cb6-1bd5-485a-9d6b-a1c543cada07" />


Adding a static `string | RegExp` value for options `output.sourcemapIgnoreList` which reduces a lot of unnecessary rust -> js function call, so that performance got improved when `sourcemap` is enabled.