### PR TITLE
fix(rolldown_plugin_react_refresh_wrapper): avoid using cwd to allow using as a callable plugin

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/config/binding_react_refresh_wrapper_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_react_refresh_wrapper_plugin_config.rs
@@ -6,6 +6,7 @@ use rolldown_plugin_react_refresh_wrapper::ReactRefreshWrapperPluginOptions;
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Debug, Default)]
 pub struct BindingReactRefreshWrapperPluginConfig {
+  pub cwd: String,
   pub include: Option<Vec<BindingStringOrRegex>>,
   pub exclude: Option<Vec<BindingStringOrRegex>>,
   pub jsx_import_source: String,
@@ -15,6 +16,7 @@ pub struct BindingReactRefreshWrapperPluginConfig {
 impl From<BindingReactRefreshWrapperPluginConfig> for ReactRefreshWrapperPluginOptions {
   fn from(value: BindingReactRefreshWrapperPluginConfig) -> Self {
     Self {
+      cwd: value.cwd,
       include: value.include.map(bindingify_string_or_regex_array).unwrap_or_default(),
       exclude: value.exclude.map(bindingify_string_or_regex_array).unwrap_or_default(),
       jsx_import_source: value.jsx_import_source,

--- a/crates/rolldown_plugin_react_refresh_wrapper/src/lib.rs
+++ b/crates/rolldown_plugin_react_refresh_wrapper/src/lib.rs
@@ -17,6 +17,7 @@ const REFRESH_CONTENT: &str = "$RefreshReg$(";
 
 #[derive(Debug)]
 pub struct ReactRefreshWrapperPluginOptions {
+  pub cwd: String,
   pub include: Vec<StringOrRegex>,
   pub exclude: Vec<StringOrRegex>,
   pub jsx_import_source: String,
@@ -25,6 +26,7 @@ pub struct ReactRefreshWrapperPluginOptions {
 
 #[derive(Debug)]
 pub struct ReactRefreshWrapperPlugin {
+  cwd: String,
   include: Vec<StringOrRegex>,
   exclude: Vec<StringOrRegex>,
   jsx_import_runtime: String,
@@ -36,6 +38,7 @@ impl ReactRefreshWrapperPlugin {
   pub fn new(options: ReactRefreshWrapperPluginOptions) -> Self {
     let jsx_import_source = options.jsx_import_source;
     Self {
+      cwd: options.cwd,
       include: options.include,
       exclude: options.exclude,
       jsx_import_dev_runtime: format!("{jsx_import_source}/jsx-dev-runtime"),
@@ -112,11 +115,11 @@ impl Plugin for ReactRefreshWrapperPlugin {
 
   async fn transform(
     &self,
-    ctx: rolldown_plugin::SharedTransformPluginContext,
+    _ctx: rolldown_plugin::SharedTransformPluginContext,
     args: &rolldown_plugin::HookTransformArgs<'_>,
   ) -> rolldown_plugin::HookTransformReturn {
     if matches!(
-      filter(Some(&self.exclude), Some(&self.include), args.id, ctx.cwd().to_str().unwrap()),
+      filter(Some(&self.exclude), Some(&self.include), args.id, &self.cwd),
       FilterResult::Match(false) | FilterResult::NoneMatch(false)
     ) {
       return Ok(None);

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -2070,6 +2070,7 @@ export declare enum BindingPropertyWriteSideEffects {
 }
 
 export interface BindingReactRefreshWrapperPluginConfig {
+  cwd: string
   include?: Array<BindingStringOrRegex>
   exclude?: Array<BindingStringOrRegex>
   jsxImportSource: string


### PR DESCRIPTION
Follow up to #6229