### PR TITLE
chore: use `lto: thin` in profile mode for better profiling experience.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,8 +244,9 @@ debug = true
 inherits = "release"
 
 [profile.profile]
-debug = true
+debug = "line-tables-only"
 strip = false
+lto = "thin"
 inherits = "release"
 
 [profile.release-wasi]


### PR DESCRIPTION
<img width="1681" height="296" alt="image" src="https://github.com/user-attachments/assets/4cf47982-03c3-470b-b4d8-0ff0ede29da9" />

According to my experiment, `thin` is only a little smaller than `fat`, and for an incremental release rebuild, 
`lto: fat` cost about 2min30s, but `lto: thin` only took 1min31s, that's 40% compile time improvement. It is fine to keep  `lto: fat` in release mode, since it has theoretically better performance and smaller binary size, but we don't need it in `profile` mode, which may run multiple times in short term.