### PR TITLE
fix: inlining constants in CJS by optimization.inlineConst incorrectly inlines non-constant values if the value is assigned more than once

### DIFF
--- a/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
@@ -11,6 +11,27 @@ use crate::ast_scanner::IdentifierReferenceKind;
 
 use super::AstScanner;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CommonjsExportSymbolUsage {
+  pub read: u32,
+  pub write: u32,
+  pub bailout: bool,
+}
+
+impl CommonjsExportSymbolUsage {
+  /// A commonjs export symbol could only be removed if both of these conditions are met:
+  /// 1. It is never read locally.
+  /// 2. It is only be written once in top level.
+  /// 3. It should be analyzable. Which means the `bailout` flag is false.
+  pub fn can_be_removed(&self) -> bool {
+    !self.bailout && self.read == 0 && self.write == 1
+  }
+
+  pub fn can_be_inlined(&self) -> bool {
+    !self.bailout && self.write == 1
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CommonJsAstType {
   /// We don't need extra `module.exports` related type for now.

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/6101/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/6101/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "optimization": {
+      "inlineConst": true
+    }
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/6101/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/6101/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+//#region react.js
+var require_react = /* @__PURE__ */ __commonJS({ "react.js": ((exports) => {
+	exports.version = "1.0.0";
+	Object.defineProperty(exports, "version", { get() {
+		throw new Error();
+	} });
+}) });
+
+//#endregion
+//#region main.js
+var import_react = /* @__PURE__ */ __toESM(require_react());
+console.log(import_react.version);
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/6101/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/6101/main.js
@@ -1,0 +1,3 @@
+import react from "./react.js";
+
+console.log(react.version);

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/6101/react.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/6101/react.js
@@ -1,0 +1,6 @@
+exports.version = "1.0.0";
+Object.defineProperty(exports, "version", {
+	get() {
+		throw new Error();
+	},
+});

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5017,9 +5017,13 @@ expression: output
 - bar-!~{003}~.js => bar-BTstUsfv.js
 - bar-!~{001}~.js => bar-BpbuVh-Q.js
 
+# tests/rolldown/optimization/inline_const/6101
+
+- main-!~{000}~.js => main-C1zSqdVO.js
+
 # tests/rolldown/optimization/inline_const/basic
 
-- main-!~{000}~.js => main-BHmOf_A8.js
+- main-!~{000}~.js => main-CarfS3Qb.js
 
 # tests/rolldown/optimization/inline_const/issue_4786
 

--- a/justfile
+++ b/justfile
@@ -129,10 +129,15 @@ fix-repo:
 lint: lint-rust lint-node lint-repo
 
 # Linting formatting, syntax and linting issues for Rust files.
-lint-rust:
+lint-rust: clippy
   cargo fmt --all --check
   cargo check --workspace --all-features --all-targets --locked
+
+# For the most of the time, code is automatically formatted on save in the editor.
+# Also, clippy already cover compiler error.
+clippy:
   cargo clippy --workspace --all-targets -- --deny warnings
+
 
 lint-node:
   pnpm lint-code


### PR DESCRIPTION
closed #6101