### PR TITLE
fix(rolldown_binding): use `Weak<OutputChunk>` to prevent memory leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1596,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,7 +1625,7 @@ dependencies = [
  "napi-build",
  "napi-sys",
  "nohash-hasher",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "tokio",
@@ -1919,7 +1941,7 @@ dependencies = [
  "bincode 2.0.1",
  "flate2",
  "nom",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -1963,7 +1985,7 @@ dependencies = [
  "hashbrown 0.16.0",
  "oxc_data_structures",
  "oxc_estree",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
@@ -2020,7 +2042,7 @@ dependencies = [
  "oxc_index",
  "oxc_syntax",
  "petgraph",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -2042,7 +2064,7 @@ dependencies = [
  "oxc_sourcemap",
  "oxc_span",
  "oxc_syntax",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -2054,7 +2076,7 @@ dependencies = [
  "cow-utils",
  "oxc-browserslist",
  "oxc_syntax",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
@@ -2128,7 +2150,7 @@ dependencies = [
  "oxc_ecmascript",
  "oxc_span",
  "oxc_syntax",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -2144,7 +2166,7 @@ dependencies = [
  "oxc_index",
  "oxc_semantic",
  "oxc_span",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -2168,7 +2190,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "oxc_traverse",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -2226,7 +2248,7 @@ dependencies = [
  "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "seq-macro",
 ]
 
@@ -2243,7 +2265,7 @@ dependencies = [
  "oxc_ast_macros",
  "oxc_estree",
  "oxc_napi",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -2258,7 +2280,7 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_span",
  "phf 0.13.1",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "unicode-id-start",
 ]
 
@@ -2275,7 +2297,7 @@ dependencies = [
  "once_cell",
  "papaya",
  "pnp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "simdutf8",
@@ -2316,7 +2338,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "phf 0.13.1",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "self_cell",
 ]
 
@@ -2331,7 +2353,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
 ]
@@ -2367,7 +2389,7 @@ dependencies = [
  "oxc_index",
  "oxc_span",
  "phf 0.13.1",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "unicode-id-start",
 ]
@@ -2384,7 +2406,7 @@ dependencies = [
  "oxc",
  "oxc_napi",
  "oxc_sourcemap",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -2411,7 +2433,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "oxc_traverse",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sha1",
@@ -2436,7 +2458,7 @@ dependencies = [
  "oxc_syntax",
  "oxc_transformer",
  "oxc_traverse",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -2454,7 +2476,7 @@ dependencies = [
  "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -2646,7 +2668,7 @@ dependencies = [
  "miniz_oxide",
  "pathdiff",
  "radix_trie",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -2862,6 +2884,7 @@ dependencies = [
  "commondir",
  "css-module-lexer",
  "derive_more",
+ "dhat",
  "dunce",
  "futures",
  "glob",
@@ -2897,7 +2920,7 @@ dependencies = [
  "rolldown_utils",
  "rolldown_watcher",
  "rolldown_workspace",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "string_wizard",
@@ -2970,7 +2993,7 @@ dependencies = [
  "rolldown_sourcemap",
  "rolldown_tracing",
  "rolldown_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "string_wizard",
  "tracing",
  "url",
@@ -3008,7 +3031,7 @@ dependencies = [
  "rolldown_sourcemap",
  "rolldown_std_utils",
  "rolldown_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "schemars",
  "serde",
  "serde_json",
@@ -3025,7 +3048,7 @@ dependencies = [
  "blake3",
  "dashmap",
  "rolldown_debug_action",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "tracing",
@@ -3075,7 +3098,7 @@ dependencies = [
  "rolldown-ariadne",
  "rolldown_utils",
  "ropey",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "sugar_path",
 ]
 
@@ -3113,7 +3136,7 @@ dependencies = [
  "rolldown_resolver",
  "rolldown_sourcemap",
  "rolldown_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "string_wizard",
@@ -3172,7 +3195,7 @@ dependencies = [
  "rolldown_common",
  "rolldown_plugin",
  "rolldown_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde_json",
  "xxhash-rust",
 ]
@@ -3212,7 +3235,7 @@ dependencies = [
  "rolldown_common",
  "rolldown_plugin",
  "rolldown_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -3287,7 +3310,7 @@ dependencies = [
  "rolldown_common",
  "rolldown_plugin",
  "rolldown_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
 ]
@@ -3333,7 +3356,7 @@ dependencies = [
  "rolldown",
  "rolldown_plugin",
  "rolldown_testing",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "string_wizard",
  "tokio",
 ]
@@ -3383,7 +3406,7 @@ dependencies = [
  "rolldown_common",
  "rolldown_plugin",
  "rolldown_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde_json",
  "sugar_path",
 ]
@@ -3399,7 +3422,7 @@ dependencies = [
  "rolldown_plugin_utils",
  "rolldown_sourcemap",
  "rolldown_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde_json",
 ]
 
@@ -3417,7 +3440,7 @@ dependencies = [
  "rolldown_plugin",
  "rolldown_plugin_utils",
  "rolldown_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde_json",
  "string_wizard",
  "sugar_path",
@@ -3450,7 +3473,7 @@ dependencies = [
  "rolldown_plugin",
  "rolldown_plugin_utils",
  "rolldown_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sugar_path",
@@ -3508,7 +3531,7 @@ dependencies = [
  "oxc",
  "oxc_sourcemap",
  "rolldown_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -3535,7 +3558,7 @@ dependencies = [
  "rolldown_sourcemap",
  "rolldown_testing_config",
  "rolldown_workspace",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "schemars",
  "serde_json",
  "sugar_path",
@@ -3590,7 +3613,7 @@ dependencies = [
  "regex",
  "regress",
  "rolldown_std_utils",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde_json",
  "simdutf8",
  "sugar_path",
@@ -3627,6 +3650,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3905,7 +3934,7 @@ dependencies = [
  "memchr",
  "oxc_index",
  "oxc_sourcemap",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
@@ -4033,6 +4062,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,10 +236,10 @@ debug = "line-tables-only"
 
 [profile.release]
 codegen-units = 1
-debug = false # Set to `true` for debug information
-lto = "fat"
+debug = true # Set to `true` for debug information
+lto = "thin"
 opt-level = 3
-strip = "symbols" # Set to `false` for debug information
+strip = false # "symbols" # Set to `false` for debug information
 
 [profile.release-debug]
 debug = true

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -27,6 +27,7 @@ bitflags = { workspace = true }
 commondir = { workspace = true }
 css-module-lexer = { workspace = true }
 derive_more = { workspace = true }
+dhat = "0.3.3"
 dunce = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -51,6 +51,8 @@ impl BundlerBuilder {
       cache: ScanStageCache::default(),
       session,
       build_count: self.build_count,
+      assets: vec![],
+      // profiler: Some(dhat::Profiler::new_heap()),
     })
   }
 

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -1,3 +1,6 @@
+// #[global_allocator]
+// static ALLOC: dhat::Alloc = dhat::Alloc;
+
 mod asset;
 mod ast_scanner;
 mod bundler;

--- a/crates/rolldown_binding/src/binding_bundler_impl.rs
+++ b/crates/rolldown_binding/src/binding_bundler_impl.rs
@@ -174,7 +174,7 @@ impl BindingBundlerImpl {
       }
     }
 
-    Ok(vec![].into())
+    Ok(BindingOutputs::default())
   }
 
   #[expect(clippy::significant_drop_tightening)]
@@ -190,7 +190,7 @@ impl BindingBundlerImpl {
       return Ok(Self::handle_errors(vec![err.into()], bundler_core.options()));
     }
 
-    Ok(outputs.assets.into())
+    Ok(BindingOutputs::from(&outputs.assets))
   }
 
   #[expect(clippy::significant_drop_tightening)]
@@ -206,7 +206,7 @@ impl BindingBundlerImpl {
       return Ok(Self::handle_errors(vec![err.into()], bundler_core.options()));
     }
 
-    Ok(bundle_output.assets.into())
+    Ok(BindingOutputs::from(&bundle_output.assets))
   }
 
   #[expect(clippy::significant_drop_tightening)]

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -1,7 +1,7 @@
 use crate::types::{
   binding_module_info::BindingModuleInfo,
   binding_normalized_options::BindingNormalizedOptions,
-  binding_outputs::{JsChangedOutputs, to_js_diagnostic},
+  binding_outputs::{BindingOutputs, JsChangedOutputs, to_js_diagnostic},
   binding_rendered_chunk::BindingRenderedChunk,
   js_callback::MaybeAsyncJsCallbackExt,
 };
@@ -479,7 +479,7 @@ impl Plugin for JsPlugin {
         .await_call(
           (
             ctx.clone().into(),
-            args.bundle.clone().into(),
+            BindingOutputs::from(&args.bundle.clone()),
             args.is_write,
             BindingNormalizedOptions::new(Arc::clone(args.options)),
           )
@@ -506,7 +506,7 @@ impl Plugin for JsPlugin {
         .await_call(
           (
             ctx.clone().into(),
-            args.bundle.clone().into(),
+            BindingOutputs::from(&args.bundle.clone()),
             BindingNormalizedOptions::new(Arc::clone(args.options)),
           )
             .into(),

--- a/crates/rolldown_binding/src/types/binding_output_asset.rs
+++ b/crates/rolldown_binding/src/types/binding_output_asset.rs
@@ -1,48 +1,53 @@
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use napi_derive::napi;
+use rolldown_common::OutputAsset;
 
 use crate::options::plugin::types::binding_asset_source::BindingAssetSource;
 
 #[napi]
 pub struct BindingOutputAsset {
-  inner: Arc<rolldown_common::OutputAsset>,
+  inner: Weak<OutputAsset>,
 }
 
 #[napi]
 impl BindingOutputAsset {
-  pub fn new(inner: Arc<rolldown_common::OutputAsset>) -> Self {
+  pub fn new(inner: Weak<OutputAsset>) -> Self {
     Self { inner }
+  }
+
+  fn inner(&self) -> Arc<OutputAsset> {
+    self.inner.upgrade().unwrap()
   }
 
   #[napi(getter)]
   pub fn file_name(&self) -> String {
-    self.inner.filename.to_string()
+    self.inner().filename.to_string()
   }
 
   #[napi(getter)]
   pub fn original_file_name(&self) -> Option<String> {
-    self.inner.original_file_names.first().cloned()
+    self.inner().original_file_names.first().cloned()
   }
 
   #[napi(getter)]
   pub fn original_file_names(&self) -> Vec<String> {
-    self.inner.original_file_names.clone()
+    self.inner().original_file_names.clone()
   }
 
   #[napi(getter)]
   pub fn source(&self) -> BindingAssetSource {
-    self.inner.source.clone().into()
+    self.inner().source.clone().into()
   }
 
   #[napi(getter)]
   pub fn name(&self) -> Option<String> {
-    self.inner.names.first().cloned()
+    self.inner().names.first().cloned()
   }
 
   #[napi(getter)]
   pub fn names(&self) -> Vec<String> {
-    self.inner.names.clone()
+    self.inner().names.clone()
   }
 }
 

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -1,7 +1,11 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+  collections::HashMap,
+  sync::{Arc, Weak},
+};
 
 use arcstr::ArcStr;
 use napi_derive::napi;
+use rolldown_common::OutputChunk;
 use rolldown_sourcemap::SourceMap;
 use rustc_hash::FxBuildHasher;
 
@@ -14,85 +18,89 @@ use super::{
 
 #[napi]
 pub struct BindingOutputChunk {
-  inner: Arc<rolldown_common::OutputChunk>,
+  inner: Weak<OutputChunk>,
 }
 
 #[napi]
 impl BindingOutputChunk {
-  pub fn new(inner: Arc<rolldown_common::OutputChunk>) -> Self {
+  pub fn new(inner: Weak<OutputChunk>) -> Self {
     Self { inner }
+  }
+
+  fn inner(&self) -> Arc<OutputChunk> {
+    self.inner.upgrade().unwrap()
   }
 
   #[napi(getter)]
   pub fn is_entry(&self) -> bool {
-    self.inner.is_entry
+    self.inner().is_entry
   }
 
   #[napi(getter)]
   pub fn is_dynamic_entry(&self) -> bool {
-    self.inner.is_dynamic_entry
+    self.inner().is_dynamic_entry
   }
 
   #[napi(getter)]
   pub fn facade_module_id(&self) -> Option<String> {
-    self.inner.facade_module_id.as_ref().map(|x| x.to_string())
+    self.inner().facade_module_id.as_ref().map(|x| x.to_string())
   }
 
   #[napi(getter)]
   pub fn module_ids(&self) -> Vec<String> {
-    self.inner.module_ids.iter().map(|x| x.to_string()).collect()
+    self.inner().module_ids.iter().map(|x| x.to_string()).collect()
   }
 
   #[napi(getter)]
   pub fn exports(&self) -> Vec<String> {
-    self.inner.exports.iter().map(ToString::to_string).collect()
+    self.inner().exports.iter().map(ToString::to_string).collect()
   }
 
   // RenderedChunk
   #[napi(getter)]
   pub fn file_name(&self) -> String {
-    self.inner.filename.to_string()
+    self.inner().filename.to_string()
   }
 
   #[napi(getter)]
   pub fn modules(&self) -> BindingModules {
-    (&self.inner.modules).into()
+    (&self.inner().modules).into()
   }
 
   #[napi(getter)]
   pub fn imports(&self) -> Vec<String> {
-    self.inner.imports.iter().map(ArcStr::to_string).collect()
+    self.inner().imports.iter().map(ArcStr::to_string).collect()
   }
 
   #[napi(getter)]
   pub fn dynamic_imports(&self) -> Vec<String> {
-    self.inner.dynamic_imports.iter().map(ArcStr::to_string).collect()
+    self.inner().dynamic_imports.iter().map(ArcStr::to_string).collect()
   }
 
   // OutputChunk
   #[napi(getter)]
   pub fn code(&self) -> String {
-    self.inner.code.clone()
+    self.inner().code.clone()
   }
 
   #[napi(getter)]
   pub fn map(&self) -> napi::Result<Option<String>> {
-    Ok(self.inner.map.as_ref().map(SourceMap::to_json_string))
+    Ok(self.inner().map.as_ref().map(SourceMap::to_json_string))
   }
 
   #[napi(getter)]
   pub fn sourcemap_file_name(&self) -> Option<String> {
-    self.inner.sourcemap_filename.clone()
+    self.inner().sourcemap_filename.clone()
   }
 
   #[napi(getter)]
   pub fn preliminary_file_name(&self) -> String {
-    self.inner.preliminary_filename.to_string()
+    self.inner().preliminary_filename.to_string()
   }
 
   #[napi(getter)]
   pub fn name(&self) -> String {
-    self.inner.name.to_string()
+    self.inner().name.to_string()
   }
 }
 
@@ -118,11 +126,11 @@ pub struct JsOutputChunk {
 }
 
 pub fn update_output_chunk(
-  chunk: &mut Arc<rolldown_common::OutputChunk>,
+  chunk: &mut Arc<OutputChunk>,
   js_chunk: JsOutputChunk,
 ) -> anyhow::Result<()> {
   let old_chunk = (**chunk).clone();
-  *chunk = Arc::new(rolldown_common::OutputChunk {
+  *chunk = Arc::new(OutputChunk {
     code: js_chunk.code,
     map: js_chunk.map.map(TryInto::try_into).transpose()?,
     imports: js_chunk.imports.into_iter().map(Into::into).collect(),

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -14,6 +14,7 @@ use rustc_hash::FxBuildHasher;
 
 // The `BindingOutputs` take the data to js side, the rust side will not use it anymore.
 #[napi]
+#[derive(Default)]
 pub struct BindingOutputs {
   chunks: Vec<BindingOutputChunk>,
   assets: Vec<BindingOutputAsset>,
@@ -53,16 +54,16 @@ impl BindingOutputs {
   }
 }
 
-impl From<Vec<rolldown_common::Output>> for BindingOutputs {
-  fn from(outputs: Vec<rolldown_common::Output>) -> Self {
+impl From<&Vec<rolldown_common::Output>> for BindingOutputs {
+  fn from(outputs: &Vec<rolldown_common::Output>) -> Self {
     let mut chunks = vec![];
     let mut assets = vec![];
-    outputs.into_iter().for_each(|o| match o {
+    outputs.iter().for_each(|o| match o {
       rolldown_common::Output::Chunk(chunk) => {
-        chunks.push(BindingOutputChunk::new(chunk));
+        chunks.push(BindingOutputChunk::new(Arc::downgrade(&chunk)));
       }
       rolldown_common::Output::Asset(asset) => {
-        assets.push(BindingOutputAsset::new(asset));
+        assets.push(BindingOutputAsset::new(Arc::downgrade(&asset)));
       }
     });
     Self { chunks, assets, error: None }


### PR DESCRIPTION
may fix #6121

The js side should not own the Arc.