### PR TITLE
fix: remove `signal-exit` to prevent Ctrl+C blocking

### DIFF
--- a/packages/rolldown/src/setup.ts
+++ b/packages/rolldown/src/setup.ts
@@ -1,10 +1,9 @@
 import { isMainThread } from 'node:worker_threads';
-import { onExit } from 'signal-exit';
 import { initTraceSubscriber } from './binding';
 
 if (!import.meta.browserBuild && isMainThread) {
   const subscriberGuard = initTraceSubscriber();
-  onExit(() => {
-    subscriberGuard?.close();
-  });
+  if (subscriberGuard) {
+    process.on('exit', () => subscriberGuard.close());
+  }
 }


### PR DESCRIPTION
closes #6308

`signal-exit` v4.1.0 hijacks the global process signal handling mechanism:
  - Replaces `process.emit` method
  - Replaces `process.reallyExit` method
  - Registers listeners for all signals

### Conflicts with Other Tools

  - `readline.createInterface()` has its own SIGINT handling
  - `tsx` may also have signal handling mechanisms
  - When multiple signal handlers exist, `signal-exit`'s hijacking behavior interferes with normal signal propagation

🤖 From Claude Code