### PR TITLE
fix(rolldown_plugin_json): avoid generating named exports for `eval` and `arguments`

### DIFF
--- a/crates/rolldown_plugin_utils/src/data_to_esm.rs
+++ b/crates/rolldown_plugin_utils/src/data_to_esm.rs
@@ -66,9 +66,9 @@ mod test {
 
   #[test]
   fn to_esm_named_exports_forbidden_ident() {
-    let data = serde_json::json!({"true": true, "\\\"\n": 1234});
+    let data = serde_json::json!({"true": true, "\\\"\n": 1234, "eval": 0, "arguments": 0});
     assert_eq!(
-      "export default {\n  \"true\": true,\n  \"\\\\\\\"\\n\": 1234\n};",
+      "export default {\n  \"true\": true,\n  \"\\\\\\\"\\n\": 1234,\n  \"eval\": 0,\n  \"arguments\": 0\n};",
       data_to_esm(&data, true)
     );
   }

--- a/crates/rolldown_utils/src/ecmascript.rs
+++ b/crates/rolldown_utils/src/ecmascript.rs
@@ -12,16 +12,17 @@ pub fn is_validate_identifier_name(name: &str) -> bool {
 }
 
 #[inline]
+pub fn is_validate_assignee_identifier_name(name: &str) -> bool {
+  identifier::is_identifier_name(name) && none_preserved_keyword_or_global_object_ext(name)
+}
+
+#[inline]
 /// extra branches are used to avoid SyntaxError in strict mode
 /// ```bash
 /// SyntaxError: Unexpected eval or arguments in strict mode
 /// ```
 pub fn none_preserved_keyword_or_global_object_ext(name: &str) -> bool {
   !keyword::is_reserved_keyword_or_global_object(name) && name != "arguments" && name != "eval"
-}
-
-pub fn is_validate_assignee_identifier_name(name: &str) -> bool {
-  identifier::is_identifier_name(name) && !keyword::is_reserved_keyword_or_global_object(name)
 }
 
 pub fn legitimize_json_local_binding_name(


### PR DESCRIPTION
fixes https://github.com/vitejs/rolldown-vite/issues/436
refs #6140