### PR TITLE
chore: fix typos

### DIFF
--- a/crates/rolldown/src/watch/watcher.rs
+++ b/crates/rolldown/src/watch/watcher.rs
@@ -121,7 +121,7 @@ impl WatcherImpl {
     }
 
     self.invalidating.store(true, Ordering::Relaxed);
-    self.exec_tx.send(ExecChannelMsg::Exec).expect("send watcher exec cannel message error");
+    self.exec_tx.send(ExecChannelMsg::Exec).expect("send watcher exec channel message error");
   }
 
   #[tracing::instrument(level = "debug", skip_all)]

--- a/crates/rolldown_common/src/types/entry_point.rs
+++ b/crates/rolldown_common/src/types/entry_point.rs
@@ -19,7 +19,7 @@ pub struct EntryPoint {
 pub enum EntryPointKind {
   UserDefined = 0,
   DynamicImport = 1,
-  /// The extra varant [EntryPointKind::EmittedUserDefined] is only used to sort the entry points, it is equal to [EntryPointKind::UserDefined] in terms of functionality.
+  /// The extra variant [EntryPointKind::EmittedUserDefined] is only used to sort the entry points, it is equal to [EntryPointKind::UserDefined] in terms of functionality.
   EmittedUserDefined = 2,
 }
 


### PR DESCRIPTION
The typos CI started to fail after https://github.com/rolldown/rolldown/pull/6380