### PR TITLE
refactor(rust/binding): rename `BindingError` to `NativeError`

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -6,8 +6,9 @@ use std::fmt::Debug;
 use crate::types::{
   binding_module_info::BindingModuleInfo,
   binding_normalized_options::BindingNormalizedOptions,
-  binding_outputs::{BindingError, BindingOutputs, JsChangedOutputs},
+  binding_outputs::{BindingOutputs, JsChangedOutputs},
   binding_rendered_chunk::BindingRenderedChunk,
+  error::native_error::NativeError,
   js_callback::MaybeAsyncJsCallback,
 };
 
@@ -96,11 +97,11 @@ pub struct BindingPluginOptions {
   pub module_parsed_meta: Option<BindingPluginHookMeta>,
 
   #[napi(
-    ts_type = "(ctx: BindingPluginContext, error?: (Error | BindingError)[]) => MaybePromise<VoidNullable>"
+    ts_type = "(ctx: BindingPluginContext, error?: (Error | NativeError)[]) => MaybePromise<VoidNullable>"
   )]
   pub build_end: Option<
     MaybeAsyncJsCallback<
-      FnArgs<(BindingPluginContext, Option<Vec<napi::Either<napi::JsError, BindingError>>>)>,
+      FnArgs<(BindingPluginContext, Option<Vec<napi::Either<napi::JsError, NativeError>>>)>,
     >,
   >,
   pub build_end_meta: Option<BindingPluginHookMeta>,
@@ -136,10 +137,10 @@ pub struct BindingPluginOptions {
     Option<MaybeAsyncJsCallback<FnArgs<(BindingPluginContext, BindingNormalizedOptions)>>>,
   pub render_start_meta: Option<BindingPluginHookMeta>,
 
-  #[napi(ts_type = "(ctx: BindingPluginContext, error: (Error | BindingError)[]) => void")]
+  #[napi(ts_type = "(ctx: BindingPluginContext, error: (Error | NativeError)[]) => void")]
   pub render_error: Option<
     MaybeAsyncJsCallback<
-      FnArgs<(BindingPluginContext, Vec<napi::Either<napi::JsError, BindingError>>)>,
+      FnArgs<(BindingPluginContext, Vec<napi::Either<napi::JsError, NativeError>>)>,
     >,
   >,
   pub render_error_meta: Option<BindingPluginHookMeta>,

--- a/crates/rolldown_binding/src/types/binding_hmr_output.rs
+++ b/crates/rolldown_binding/src/types/binding_hmr_output.rs
@@ -1,7 +1,7 @@
 use napi_derive::napi;
 use rolldown_error::BuildDiagnostic;
 
-use crate::types::binding_outputs::{BindingError, to_js_diagnostic};
+use crate::types::{binding_outputs::to_js_diagnostic, error::native_error::NativeError};
 
 #[napi]
 #[derive(Debug)]
@@ -25,7 +25,7 @@ impl BindingHmrOutput {
   }
 
   #[napi(getter)]
-  pub fn errors(&mut self) -> Vec<napi::Either<napi::JsError, BindingError>> {
+  pub fn errors(&mut self) -> Vec<napi::Either<napi::JsError, NativeError>> {
     if let Some(rolldown_common::OutputsDiagnostics { diagnostics, cwd }) = self.errors.as_ref() {
       return diagnostics
         .iter()
@@ -121,7 +121,7 @@ impl From<rolldown_common::ClientHmrUpdate> for BindingClientHmrUpdate {
 #[napi(discriminant = "type", object_from_js = false)]
 pub enum BindingGenerateHmrPatchReturn {
   Ok(Vec<BindingHmrUpdate>),
-  Error(Vec<napi::Either<napi::JsError, BindingError>>),
+  Error(Vec<napi::Either<napi::JsError, NativeError>>),
 }
 
 impl BindingGenerateHmrPatchReturn {

--- a/crates/rolldown_binding/src/types/binding_watcher_event.rs
+++ b/crates/rolldown_binding/src/types/binding_watcher_event.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use napi::tokio::sync::Mutex;
 use napi_derive::napi;
 
-use super::binding_outputs::{BindingError, to_js_diagnostic};
+use super::{binding_outputs::to_js_diagnostic, error::native_error::NativeError};
 use rolldown::{BundleEvent, Bundler, WatcherEvent};
 
 #[napi]
@@ -100,7 +100,7 @@ impl BindingBundleEndEventData {
 
 #[napi]
 pub struct BindingBundleErrorEventData {
-  error: Vec<napi::Either<napi::JsError, BindingError>>,
+  error: Vec<napi::Either<napi::JsError, NativeError>>,
   result: Arc<Mutex<Bundler>>,
 }
 
@@ -112,7 +112,7 @@ impl BindingBundleErrorEventData {
   }
 
   #[napi(getter)]
-  pub fn error(&mut self) -> Vec<napi::Either<napi::JsError, BindingError>> {
+  pub fn error(&mut self) -> Vec<napi::Either<napi::JsError, NativeError>> {
     std::mem::take(&mut self.error)
   }
 }

--- a/crates/rolldown_binding/src/types/error/mod.rs
+++ b/crates/rolldown_binding/src/types/error/mod.rs
@@ -1,0 +1,1 @@
+pub mod native_error;

--- a/crates/rolldown_binding/src/types/error/native_error.rs
+++ b/crates/rolldown_binding/src/types/error/native_error.rs
@@ -1,0 +1,7 @@
+/// Error emitted from native side, it only contains kind and message, no stack trace.
+// TODO: hyf0 do we want to rust stack trace?
+#[napi_derive::napi(object)]
+pub struct NativeError {
+  pub kind: String,
+  pub message: String,
+}

--- a/crates/rolldown_binding/src/types/mod.rs
+++ b/crates/rolldown_binding/src/types/mod.rs
@@ -15,6 +15,7 @@ pub mod binding_sourcemap;
 pub mod binding_string_or_regex;
 pub mod binding_watcher_event;
 pub mod defer_sync_scan_data;
+pub mod error;
 pub mod js_callback;
 pub mod js_regex;
 pub mod preserve_entry_signatures;

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1269,7 +1269,7 @@ export declare class BindingBundleEndEventData {
 
 export declare class BindingBundleErrorEventData {
   get result(): BindingBundlerImpl
-  get error(): Array<Error | BindingError>
+  get error(): Array<Error | NativeError>
 }
 
 export declare class BindingBundler {
@@ -1317,7 +1317,7 @@ export declare class BindingDevEngine {
 
 export declare class BindingHmrOutput {
   get patch(): BindingHmrUpdate | null
-  get errors(): Array<Error | BindingError>
+  get errors(): Array<Error | NativeError>
 }
 
 export declare class BindingMagicString {
@@ -1416,7 +1416,7 @@ export declare class BindingOutputChunk {
 export declare class BindingOutputs {
   get chunks(): Array<BindingOutputChunk>
   get assets(): Array<BindingOutputAsset>
-  get errors(): Array<Error | BindingError>
+  get errors(): Array<Error | NativeError>
 }
 
 export declare class BindingPluginContext {
@@ -1651,11 +1651,6 @@ export interface BindingEmittedChunk {
   preserveEntrySignatures?: BindingPreserveEntrySignatures
 }
 
-export interface BindingError {
-  kind: string
-  message: string
-}
-
 export interface BindingEsmExternalRequirePluginConfig {
   external: Array<BindingStringOrRegex>
   skipDuplicateCheck?: boolean
@@ -1693,7 +1688,7 @@ export interface BindingGeneratedCodeOptions {
 
 export type BindingGenerateHmrPatchReturn =
   | { type: 'Ok', field0: Array<BindingHmrUpdate> }
-  | { type: 'Error', field0: Array<Error | BindingError> }
+  | { type: 'Error', field0: Array<Error | NativeError> }
 
 export interface BindingHmrBoundaryOutput {
   boundary: string
@@ -2019,7 +2014,7 @@ export interface BindingPluginOptions {
   transformFilter?: BindingHookFilter
   moduleParsed?: (ctx: BindingPluginContext, module: BindingModuleInfo) => MaybePromise<VoidNullable>
   moduleParsedMeta?: BindingPluginHookMeta
-  buildEnd?: (ctx: BindingPluginContext, error?: (Error | BindingError)[]) => MaybePromise<VoidNullable>
+  buildEnd?: (ctx: BindingPluginContext, error?: (Error | NativeError)[]) => MaybePromise<VoidNullable>
   buildEndMeta?: BindingPluginHookMeta
   renderChunk?: (ctx: BindingPluginContext, code: string, chunk: BindingRenderedChunk, opts: BindingNormalizedOptions, meta: BindingRenderedChunkMeta) => MaybePromise<VoidNullable<BindingHookRenderChunkOutput>>
   renderChunkMeta?: BindingPluginHookMeta
@@ -2028,7 +2023,7 @@ export interface BindingPluginOptions {
   augmentChunkHashMeta?: BindingPluginHookMeta
   renderStart?: (ctx: BindingPluginContext, opts: BindingNormalizedOptions) => void
   renderStartMeta?: BindingPluginHookMeta
-  renderError?: (ctx: BindingPluginContext, error: (Error | BindingError)[]) => void
+  renderError?: (ctx: BindingPluginContext, error: (Error | NativeError)[]) => void
   renderErrorMeta?: BindingPluginHookMeta
   generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<JsChangedOutputs>>
   generateBundleMeta?: BindingPluginHookMeta
@@ -2260,6 +2255,12 @@ export interface JsOutputChunk {
   map?: BindingSourcemap
   sourcemapFilename?: string
   preliminaryFilename: string
+}
+
+/** Error emitted from native side, it only contains kind and message, no stack trace. */
+export interface NativeError {
+  kind: string
+  message: string
 }
 
 export interface PreRenderedChunk {

--- a/packages/rolldown/src/utils/error.ts
+++ b/packages/rolldown/src/utils/error.ts
@@ -1,7 +1,7 @@
-import { type BindingError } from '../binding';
+import { type NativeError } from '../binding';
 import type { RollupError } from '../log/logging';
 
-export function normalizeErrors(rawErrors: (BindingError | Error)[]): Error {
+export function normalizeErrors(rawErrors: (NativeError | Error)[]): Error {
   const errors = rawErrors.map((e) =>
     e instanceof Error
       ? e


### PR DESCRIPTION
- `NativeError` is a more accurate name.
- `BindingError` concept would be used for covering `NativeError` and `JsError` in concept.

Context:

- I'm developing exposing error from dev engine and found it's a little chaotic to understand how the rust error are passed to js side.