### PR TITLE
refactor: introduce `BindingResult` to pass errors from rust to js

### DIFF
--- a/crates/rolldown_binding/src/binding_bundler_impl.rs
+++ b/crates/rolldown_binding/src/binding_bundler_impl.rs
@@ -8,7 +8,10 @@ use crate::worker_manager::WorkerManager;
 use crate::{
   options::{BindingInputOptions, BindingOutputOptions},
   parallel_js_plugin_registry::ParallelJsPluginRegistry,
-  types::binding_outputs::BindingOutputs,
+  types::{
+    binding_outputs::{BindingOutputs, to_binding_error},
+    error::{BindingError, BindingErrors, BindingResult},
+  },
   utils::{handle_result, normalize_binding_options::normalize_binding_options},
 };
 use napi::{
@@ -103,7 +106,10 @@ impl BindingBundlerImpl {
 
   #[napi]
   #[tracing::instrument(level = "debug", skip_all)]
-  pub fn write<'env>(&self, env: &'env Env) -> napi::Result<PromiseRaw<'env, BindingOutputs>> {
+  pub fn write<'env>(
+    &self,
+    env: &'env Env,
+  ) -> napi::Result<PromiseRaw<'env, BindingResult<BindingOutputs>>> {
     let inner = Arc::clone(&self.inner);
     let memory_adjustment = Arc::clone(&self.memory_adjustment);
 
@@ -113,12 +119,14 @@ impl BindingBundlerImpl {
         Ok(outputs)
       },
       move |env, outputs| {
-        let chunk_size = outputs.chunk_len();
-        // 16mb per chunk, it's just a hint, so it doesn't need to be accurate
-        #[expect(clippy::cast_possible_wrap)]
-        let memory_consumption = chunk_size as i64 * 1024 * 1024 * 16;
-        memory_adjustment.fetch_add(memory_consumption, Ordering::Relaxed);
-        env.adjust_external_memory(memory_consumption)?;
+        if let napi::Either::B(ref binding_outputs) = outputs {
+          let chunk_size = binding_outputs.chunk_len();
+          // 16mb per chunk, it's just a hint, so it doesn't need to be accurate
+          #[expect(clippy::cast_possible_wrap)]
+          let memory_consumption = chunk_size as i64 * 1024 * 1024 * 16;
+          memory_adjustment.fetch_add(memory_consumption, Ordering::Relaxed);
+          env.adjust_external_memory(memory_consumption)?;
+        }
         Ok(outputs)
       },
     )
@@ -126,13 +134,13 @@ impl BindingBundlerImpl {
 
   #[napi]
   #[tracing::instrument(level = "debug", skip_all)]
-  pub async fn generate(&self) -> napi::Result<BindingOutputs> {
+  pub async fn generate(&self) -> napi::Result<BindingResult<BindingOutputs>> {
     self.generate_impl().await
   }
 
   #[napi]
   #[tracing::instrument(level = "debug", skip_all)]
-  pub async fn scan(&self) -> napi::Result<BindingOutputs> {
+  pub async fn scan(&self) -> napi::Result<BindingResult<BindingOutputs>> {
     self.scan_impl().await
   }
 
@@ -158,7 +166,7 @@ impl BindingBundlerImpl {
 
 impl BindingBundlerImpl {
   #[expect(clippy::significant_drop_tightening)]
-  pub async fn scan_impl(&self) -> napi::Result<BindingOutputs> {
+  pub async fn scan_impl(&self) -> napi::Result<BindingResult<BindingOutputs>> {
     let mut bundler_core = self.inner.lock().await;
     let output =
       Self::handle_result(bundler_core.scan(ScanMode::Full).await, bundler_core.options());
@@ -166,47 +174,66 @@ impl BindingBundlerImpl {
     match output {
       Ok(output) => {
         if let Err(err) = Self::handle_warnings(output.warnings, bundler_core.options()).await {
-          return Ok(Self::handle_errors(vec![err.into()], bundler_core.options()));
+          let error = to_binding_error(&err.into(), bundler_core.options().cwd.clone());
+          return Ok(napi::Either::A(BindingErrors::new(vec![error])));
         }
       }
-      Err(outputs) => {
-        return Ok(outputs);
+      Err(errors) => {
+        return Ok(napi::Either::A(BindingErrors::new(errors)));
       }
     }
 
-    Ok(vec![].into())
+    Ok(napi::Either::B(vec![].into()))
   }
 
   #[expect(clippy::significant_drop_tightening)]
-  pub async fn write_impl(bundler: Arc<Mutex<NativeBundler>>) -> napi::Result<BindingOutputs> {
+  pub async fn write_impl(
+    bundler: Arc<Mutex<NativeBundler>>,
+  ) -> napi::Result<BindingResult<BindingOutputs>> {
     let mut bundler_core = bundler.lock().await;
 
     let outputs = match bundler_core.write().await {
       Ok(outputs) => outputs,
-      Err(errs) => return Ok(Self::handle_errors(errs.into_vec(), bundler_core.options())),
+      Err(errs) => {
+        let errors: Vec<BindingError> = errs
+          .into_vec()
+          .iter()
+          .map(|diagnostic| to_binding_error(diagnostic, bundler_core.options().cwd.clone()))
+          .collect();
+        return Ok(napi::Either::A(BindingErrors::new(errors)));
+      }
     };
 
     if let Err(err) = Self::handle_warnings(outputs.warnings, bundler_core.options()).await {
-      return Ok(Self::handle_errors(vec![err.into()], bundler_core.options()));
+      let error = to_binding_error(&err.into(), bundler_core.options().cwd.clone());
+      return Ok(napi::Either::A(BindingErrors::new(vec![error])));
     }
 
-    Ok(outputs.assets.into())
+    Ok(napi::Either::B(outputs.assets.into()))
   }
 
   #[expect(clippy::significant_drop_tightening)]
-  pub async fn generate_impl(&self) -> napi::Result<BindingOutputs> {
+  pub async fn generate_impl(&self) -> napi::Result<BindingResult<BindingOutputs>> {
     let mut bundler_core = self.inner.lock().await;
 
     let bundle_output = match bundler_core.generate().await {
       Ok(output) => output,
-      Err(errs) => return Ok(Self::handle_errors(errs.into_vec(), bundler_core.options())),
+      Err(errs) => {
+        let errors: Vec<BindingError> = errs
+          .into_vec()
+          .iter()
+          .map(|diagnostic| to_binding_error(diagnostic, bundler_core.options().cwd.clone()))
+          .collect();
+        return Ok(napi::Either::A(BindingErrors::new(errors)));
+      }
     };
 
     if let Err(err) = Self::handle_warnings(bundle_output.warnings, bundler_core.options()).await {
-      return Ok(Self::handle_errors(vec![err.into()], bundler_core.options()));
+      let error = to_binding_error(&err.into(), bundler_core.options().cwd.clone());
+      return Ok(napi::Either::A(BindingErrors::new(vec![error])));
     }
 
-    Ok(bundle_output.assets.into())
+    Ok(napi::Either::B(bundle_output.assets.into()))
   }
 
   #[expect(clippy::significant_drop_tightening)]
@@ -222,18 +249,16 @@ impl BindingBundlerImpl {
     self.inner
   }
 
-  fn handle_errors(
-    errs: Vec<BuildDiagnostic>,
-    options: &NormalizedBundlerOptions,
-  ) -> BindingOutputs {
-    BindingOutputs::from_errors(errs, options.cwd.clone())
-  }
-
   fn handle_result<T>(
     result: BuildResult<T>,
     options: &NormalizedBundlerOptions,
-  ) -> Result<T, BindingOutputs> {
-    result.map_err(|e| Self::handle_errors(e.into_vec(), options))
+  ) -> Result<T, Vec<crate::types::error::BindingError>> {
+    result.map_err(|e| {
+      e.into_vec()
+        .iter()
+        .map(|diagnostic| to_binding_error(diagnostic, options.cwd.clone()))
+        .collect()
+    })
   }
 
   async fn handle_warnings(

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -8,7 +8,7 @@ use crate::types::{
   binding_normalized_options::BindingNormalizedOptions,
   binding_outputs::{BindingOutputs, JsChangedOutputs},
   binding_rendered_chunk::BindingRenderedChunk,
-  error::BindingError,
+  error::{BindingError, BindingResult},
   js_callback::MaybeAsyncJsCallback,
 };
 
@@ -139,22 +139,22 @@ pub struct BindingPluginOptions {
   pub render_error_meta: Option<BindingPluginHookMeta>,
 
   #[napi(
-    ts_type = "(ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<JsChangedOutputs>>"
+    ts_type = "(ctx: BindingPluginContext, bundle: BindingErrorsOr<BindingOutputs>, isWrite: boolean, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<JsChangedOutputs>>"
   )]
   pub generate_bundle: Option<
     MaybeAsyncJsCallback<
-      FnArgs<(BindingPluginContext, BindingOutputs, bool, BindingNormalizedOptions)>,
+      FnArgs<(BindingPluginContext, BindingResult<BindingOutputs>, bool, BindingNormalizedOptions)>,
       JsChangedOutputs,
     >,
   >,
   pub generate_bundle_meta: Option<BindingPluginHookMeta>,
 
   #[napi(
-    ts_type = "(ctx: BindingPluginContext, bundle: BindingOutputs, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<JsChangedOutputs>>"
+    ts_type = "(ctx: BindingPluginContext, bundle: BindingErrorsOr<BindingOutputs>, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<JsChangedOutputs>>"
   )]
   pub write_bundle: Option<
     MaybeAsyncJsCallback<
-      FnArgs<(BindingPluginContext, BindingOutputs, BindingNormalizedOptions)>,
+      FnArgs<(BindingPluginContext, BindingResult<BindingOutputs>, BindingNormalizedOptions)>,
       JsChangedOutputs,
     >,
   >,

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -1,7 +1,7 @@
 use crate::types::{
   binding_module_info::BindingModuleInfo,
   binding_normalized_options::BindingNormalizedOptions,
-  binding_outputs::{JsChangedOutputs, to_js_diagnostic},
+  binding_outputs::{JsChangedOutputs, to_binding_error},
   binding_rendered_chunk::BindingRenderedChunk,
   js_callback::MaybeAsyncJsCallbackExt,
 };
@@ -255,7 +255,7 @@ impl Plugin for JsPlugin {
             args
               .errors
               .iter()
-              .map(|diagnostic| to_js_diagnostic(diagnostic, args.cwd.clone()))
+              .map(|diagnostic| to_binding_error(diagnostic, args.cwd.clone()))
               .collect()
           }),
         )
@@ -454,7 +454,7 @@ impl Plugin for JsPlugin {
           args
             .errors
             .iter()
-            .map(|diagnostic| to_js_diagnostic(diagnostic, args.cwd.clone()))
+            .map(|diagnostic| to_binding_error(diagnostic, args.cwd.clone()))
             .collect(),
         )
           .into(),
@@ -479,7 +479,7 @@ impl Plugin for JsPlugin {
         .await_call(
           (
             ctx.clone().into(),
-            args.bundle.clone().into(),
+            napi::Either::B(args.bundle.clone().into()),
             args.is_write,
             BindingNormalizedOptions::new(Arc::clone(args.options)),
           )
@@ -506,7 +506,7 @@ impl Plugin for JsPlugin {
         .await_call(
           (
             ctx.clone().into(),
-            args.bundle.clone().into(),
+            napi::Either::B(args.bundle.clone().into()),
             BindingNormalizedOptions::new(Arc::clone(args.options)),
           )
             .into(),

--- a/crates/rolldown_binding/src/types/binding_hmr_output.rs
+++ b/crates/rolldown_binding/src/types/binding_hmr_output.rs
@@ -1,7 +1,7 @@
 use napi_derive::napi;
 use rolldown_error::BuildDiagnostic;
 
-use crate::types::{binding_outputs::to_js_diagnostic, error::BindingError};
+use crate::types::{binding_outputs::to_binding_error, error::BindingError};
 
 #[napi]
 #[derive(Debug)]
@@ -29,7 +29,7 @@ impl BindingHmrOutput {
     if let Some(rolldown_common::OutputsDiagnostics { diagnostics, cwd }) = self.errors.as_ref() {
       return diagnostics
         .iter()
-        .map(|diagnostic| to_js_diagnostic(diagnostic, cwd.clone()))
+        .map(|diagnostic| to_binding_error(diagnostic, cwd.clone()))
         .collect();
     }
     vec![]
@@ -127,7 +127,7 @@ pub enum BindingGenerateHmrPatchReturn {
 impl BindingGenerateHmrPatchReturn {
   pub fn from_errors(diagnostics: Vec<BuildDiagnostic>, cwd: std::path::PathBuf) -> Self {
     Self::Error(
-      diagnostics.iter().map(|diagnostic| to_js_diagnostic(diagnostic, cwd.clone())).collect(),
+      diagnostics.iter().map(|diagnostic| to_binding_error(diagnostic, cwd.clone())).collect(),
     )
   }
 }

--- a/crates/rolldown_binding/src/types/binding_watcher_event.rs
+++ b/crates/rolldown_binding/src/types/binding_watcher_event.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use napi::tokio::sync::Mutex;
 use napi_derive::napi;
 
-use super::{binding_outputs::to_js_diagnostic, error::BindingError};
+use super::{binding_outputs::to_binding_error, error::BindingError};
 use rolldown::{BundleEvent, Bundler, WatcherEvent};
 
 #[napi]
@@ -66,7 +66,7 @@ impl BindingWatcherEvent {
           .error
           .diagnostics
           .iter()
-          .map(|diagnostic| to_js_diagnostic(diagnostic, data.error.cwd.clone()))
+          .map(|diagnostic| to_binding_error(diagnostic, data.error.cwd.clone()))
           .collect(),
         result: Arc::clone(&data.result),
       },

--- a/crates/rolldown_binding/src/types/error/mod.rs
+++ b/crates/rolldown_binding/src/types/error/mod.rs
@@ -1,5 +1,6 @@
 pub mod native_error;
 
+use napi::Either;
 pub use native_error::NativeError;
 
 #[napi_derive::napi(discriminant = "type", object_from_js = false)]
@@ -7,3 +8,17 @@ pub enum BindingError {
   JsError(napi::JsError),
   NativeError(NativeError),
 }
+
+#[napi_derive::napi(object, object_from_js = false)]
+pub struct BindingErrors {
+  pub errors: Vec<BindingError>,
+  pub is_binding_errors: bool,
+}
+
+impl BindingErrors {
+  pub fn new(errors: Vec<BindingError>) -> Self {
+    Self { errors, is_binding_errors: true }
+  }
+}
+
+pub type BindingResult<T> = Either<BindingErrors, T>;

--- a/justfile
+++ b/justfile
@@ -164,6 +164,10 @@ build-rolldown-debug:
 build-glue:
   pnpm run --filter rolldown build-js-glue
 
+# Only build `.node` binding located in `packages/rolldown`.
+build-rolldown-binding:
+  pnpm run --filter rolldown build-binding
+
 # Build `rolldown` located in `packages/rolldown` itself and its `.node` binding.
 build-rolldown: build-pluginutils
   pnpm run --filter rolldown build-native:debug

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -126,7 +126,7 @@
         "asyncInit": true
       }
     },
-    "dtsHeader": "type MaybePromise<T> = T | Promise<T>\ntype Nullable<T> = T | null | undefined\ntype VoidNullable<T = void> = T | null | undefined | void\nexport type BindingStringOrRegex = string | RegExp\n\n"
+    "dtsHeader": "type MaybePromise<T> = T | Promise<T>\ntype Nullable<T> = T | null | undefined\ntype VoidNullable<T = void> = T | null | undefined | void\nexport type BindingStringOrRegex = string | RegExp\ntype BindingResult<T> = { errors: BindingError[], isBindingErrors: boolean } | T\n\n"
   },
   "dependencies": {
     "@oxc-project/types": "catalog:",

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -9,8 +9,8 @@ import type { OutputOptions } from '../../options/output-options';
 import type { HasProperty, TypeAssert } from '../../types/assert';
 import type { RolldownOutput } from '../../types/rolldown-output';
 import { createBundlerOptions } from '../../utils/create-bundler-option';
+import { unwrapBindingResult } from '../../utils/error';
 import {
-  handleOutputErrors,
   transformToRollupOutput,
 } from '../../utils/transform-to-rollup-output';
 import { validateOption } from '../../utils/validator';
@@ -76,21 +76,21 @@ export class RolldownBuild {
   async scan(): Promise<void> {
     const { impl } = await this.#getBundlerWithStopWorker({});
     const output = await impl.scan();
-    return handleOutputErrors(output);
+    unwrapBindingResult(output);
   }
 
   async generate(outputOptions: OutputOptions = {}): Promise<RolldownOutput> {
     validateOption('output', outputOptions);
     const { impl } = await this.#getBundlerWithStopWorker(outputOptions);
     const output = await impl.generate();
-    return transformToRollupOutput(output);
+    return transformToRollupOutput(unwrapBindingResult(output));
   }
 
   async write(outputOptions: OutputOptions = {}): Promise<RolldownOutput> {
     validateOption('output', outputOptions);
     const { impl } = await this.#getBundlerWithStopWorker(outputOptions);
     const output = await impl.write();
-    return transformToRollupOutput(output);
+    return transformToRollupOutput(unwrapBindingResult(output));
   }
 
   async close(): Promise<void> {

--- a/packages/rolldown/src/api/watch/watch-emitter.ts
+++ b/packages/rolldown/src/api/watch/watch-emitter.ts
@@ -3,7 +3,7 @@ import {
   type BindingWatcherEvent,
 } from '../../binding';
 import type { MaybePromise } from '../../types/utils';
-import { aggregateBindingErrorsIntoError } from '../../utils/error';
+import { aggregateBindingErrorsIntoJsError } from '../../utils/error';
 
 type WatcherEvent = 'close' | 'event' | 'restart' | 'change';
 
@@ -117,7 +117,7 @@ export class WatcherEmitter {
                 const data = event.bundleErrorData();
                 await listener({
                   code: 'ERROR',
-                  error: aggregateBindingErrorsIntoError(data.error),
+                  error: aggregateBindingErrorsIntoJsError(data.error),
                   result: data.result,
                 });
                 break;

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -2,6 +2,7 @@ type MaybePromise<T> = T | Promise<T>
 type Nullable<T> = T | null | undefined
 type VoidNullable<T = void> = T | null | undefined | void
 export type BindingStringOrRegex = string | RegExp
+type BindingResult<T> = { errors: BindingError[], isBindingErrors: boolean } | T
 
 export interface CodegenOptions {
   /**
@@ -1278,9 +1279,9 @@ export declare class BindingBundler {
 }
 
 export declare class BindingBundlerImpl {
-  write(): Promise<BindingOutputs>
-  generate(): Promise<BindingOutputs>
-  scan(): Promise<BindingOutputs>
+  write(): Promise<BindingResult<BindingOutputs>>
+  generate(): Promise<BindingResult<BindingOutputs>>
+  scan(): Promise<BindingResult<BindingOutputs>>
   close(): Promise<void>
   get closed(): boolean
   getWatchFiles(): Promise<Array<string>>
@@ -1416,7 +1417,6 @@ export declare class BindingOutputChunk {
 export declare class BindingOutputs {
   get chunks(): Array<BindingOutputChunk>
   get assets(): Array<BindingOutputAsset>
-  get errors(): Array<BindingError>
 }
 
 export declare class BindingPluginContext {
@@ -1655,6 +1655,11 @@ export interface BindingEmittedChunk {
 export type BindingError =
   | { type: 'JsError', field0: Error }
   | { type: 'NativeError', field0: NativeError }
+
+export interface BindingErrors {
+  errors: Array<BindingError>
+  isBindingErrors: boolean
+}
 
 export interface BindingEsmExternalRequirePluginConfig {
   external: Array<BindingStringOrRegex>
@@ -2030,9 +2035,9 @@ export interface BindingPluginOptions {
   renderStartMeta?: BindingPluginHookMeta
   renderError?: (ctx: BindingPluginContext, error: BindingError[]) => void
   renderErrorMeta?: BindingPluginHookMeta
-  generateBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, isWrite: boolean, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<JsChangedOutputs>>
+  generateBundle?: (ctx: BindingPluginContext, bundle: BindingErrorsOr<BindingOutputs>, isWrite: boolean, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<JsChangedOutputs>>
   generateBundleMeta?: BindingPluginHookMeta
-  writeBundle?: (ctx: BindingPluginContext, bundle: BindingOutputs, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<JsChangedOutputs>>
+  writeBundle?: (ctx: BindingPluginContext, bundle: BindingErrorsOr<BindingOutputs>, opts: BindingNormalizedOptions) => MaybePromise<VoidNullable<JsChangedOutputs>>
   writeBundleMeta?: BindingPluginHookMeta
   closeBundle?: (ctx: BindingPluginContext) => MaybePromise<VoidNullable>
   closeBundleMeta?: BindingPluginHookMeta

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -10,7 +10,7 @@ import {
   bindingifySourcemap,
   type ExistingRawSourceMap,
 } from '../types/sourcemap';
-import { aggregateBindingErrorsIntoError } from '../utils/error';
+import { aggregateBindingErrorsIntoJsError } from '../utils/error';
 import { transformModuleInfo } from '../utils/transform-module-info';
 import {
   isEmptySourcemapFiled,
@@ -78,7 +78,7 @@ export function bindingifyBuildEnd(
           args.logLevel,
           args.watchMode,
         ),
-        err ? aggregateBindingErrorsIntoError(err) : undefined,
+        err ? aggregateBindingErrorsIntoJsError(err) : undefined,
       );
     },
     meta: bindingifyPluginHookMeta(meta),

--- a/packages/rolldown/src/plugin/bindingify-output-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-output-hooks.ts
@@ -1,6 +1,9 @@
 import type { BindingHookFilter, BindingPluginOptions } from '../binding';
 import { bindingifySourcemap } from '../types/sourcemap';
-import { aggregateBindingErrorsIntoError } from '../utils/error';
+import {
+  aggregateBindingErrorsIntoJsError,
+  unwrapBindingResult,
+} from '../utils/error';
 import { normalizeHook } from '../utils/normalize-hook';
 import { transformRenderedChunk } from '../utils/transform-rendered-chunk';
 import {
@@ -156,7 +159,7 @@ export function bindingifyRenderError(
           args.logLevel,
           args.watchMode,
         ),
-        aggregateBindingErrorsIntoError(err),
+        aggregateBindingErrorsIntoJsError(err),
       );
     },
     meta: bindingifyPluginHookMeta(meta),
@@ -187,7 +190,11 @@ export function bindingifyGenerateBundle(
         args.logLevel,
         args.watchMode,
       );
-      const output = transformToOutputBundle(context, bundle, changed);
+      const output = transformToOutputBundle(
+        context,
+        unwrapBindingResult(bundle),
+        changed,
+      );
       await handler.call(
         context,
         args.pluginContextData.getOutputOptions(opts),
@@ -224,7 +231,11 @@ export function bindingifyWriteBundle(
         args.logLevel,
         args.watchMode,
       );
-      const output = transformToOutputBundle(context, bundle, changed);
+      const output = transformToOutputBundle(
+        context,
+        unwrapBindingResult(bundle),
+        changed,
+      );
       await handler.call(
         context,
         args.pluginContextData.getOutputOptions(opts),

--- a/packages/rolldown/src/utils/error.ts
+++ b/packages/rolldown/src/utils/error.ts
@@ -1,5 +1,18 @@
-import { type BindingError } from '../binding';
+import { type BindingError, type BindingResult } from '../binding';
 import type { RollupError } from '../log/logging';
+
+export function unwrapBindingResult<T>(
+  container: BindingResult<T>,
+): T {
+  if (
+    typeof container === 'object' && container !== null &&
+    'isBindingErrors' in container &&
+    container.isBindingErrors
+  ) {
+    throw aggregateBindingErrorsIntoJsError(container.errors);
+  }
+  return container as T;
+}
 
 function normalizeBindingError(e: BindingError): Error {
   return e.type === 'JsError'
@@ -11,7 +24,7 @@ function normalizeBindingError(e: BindingError): Error {
     });
 }
 
-export function aggregateBindingErrorsIntoError(
+export function aggregateBindingErrorsIntoJsError(
   rawErrors: BindingError[],
 ): Error {
   const errors = rawErrors.map(normalizeBindingError);

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -20,7 +20,6 @@ import {
   bindingAssetSource,
   transformAssetSource,
 } from './asset-source';
-import { aggregateBindingErrorsIntoError } from './error';
 import { transformChunkModules } from './transform-rendered-chunk';
 
 function transformToRollupSourceMap(map: string): SourceMap {
@@ -133,7 +132,6 @@ export function transformToRollupOutput(
   output: BindingOutputs,
   changed?: ChangedOutputs,
 ): RolldownOutput {
-  handleOutputErrors(output);
   const { chunks, assets } = output;
   return {
     output: [
@@ -141,13 +139,6 @@ export function transformToRollupOutput(
       ...assets.map((asset) => transformToRollupOutputAsset(asset, changed)),
     ],
   } as RolldownOutput;
-}
-
-export function handleOutputErrors(output: BindingOutputs): void {
-  const rawErrors = output.errors;
-  if (rawErrors.length > 0) {
-    throw aggregateBindingErrorsIntoError(rawErrors);
-  }
 }
 
 export function transformToOutputBundle(


### PR DESCRIPTION
Issues of previous error mechanism:

- `BindingOutputs#errors` always got consumed in the js side. It adds unnecessary lazy overhead.
- `BindingOutputs#errors` doesn't force develpoers to handle errors.
- `BindingOutputs#errors` get handled repeatly due to each function doesn't know about whether its caller handles the error or not.

---

This PR introduces `BindingResult` as a unify way, not just for passing `BindingOutput`​, to handle errors passed from rust to js.

- Errors are forced to handle if you want to use the value
- Errors are designed to only need to be handled once.

Related might still need to polished, but I want to set a correct direction first.