### PR TITLE
fix: returning result of this.resolve in resolveDynamicImport hook impacts bundle size

### DIFF
--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -43,12 +43,18 @@ pub async fn resolve_id_with_plugins(
       )
       .await?
     {
+      let package_json = r.package_json_path.as_ref().and_then(|p| {
+        let v = resolver.package_json_cache().get(&PathBuf::from(&p))?;
+        let package_json = v.clone();
+        Some(package_json)
+      });
       return Ok(Ok(ResolvedId {
         module_def_format: ModuleDefFormat::from_path(r.id.as_str()),
         id: r.id,
         external: r.external.unwrap_or_default(),
         normalize_external_id: r.normalize_external_id,
         side_effects: r.side_effects,
+        package_json,
         ..Default::default()
       }));
     }

--- a/packages/rolldown/src/plugin/bindingify-build-hooks.ts
+++ b/packages/rolldown/src/plugin/bindingify-build-hooks.ts
@@ -198,6 +198,7 @@ export function bindingifyResolveDynamicImport(
       const result: BindingHookResolveIdOutput = {
         id: ret.id,
         external: ret.external,
+        packageJsonPath: ret.packageJsonPath,
       };
 
       if (ret.moduleSideEffects !== null) {

--- a/packages/rolldown/tests/fixtures/resolve/issue-5846-2/_config.ts
+++ b/packages/rolldown/tests/fixtures/resolve/issue-5846-2/_config.ts
@@ -1,0 +1,32 @@
+import { defineTest } from "rolldown-tests";
+import path from "node:path";
+import { expect } from "vitest";
+const entry = path.join(__dirname, "./main.ts");
+
+export default defineTest({
+	config: {
+		input: entry,
+		plugins: [
+			{
+				name: "test",
+				async resolveDynamicImport(source, importer) {
+					if (!importer) {
+						return;
+					}
+					const resolved = await this.resolve(source, importer, {
+						skipSelf: true,
+					});
+
+					// Comment out this line to "fix" tree-shaking.
+					return resolved;
+				},
+			},
+		],
+	},
+	afterTest(output) {
+		for (const chunk of output.output) {
+			if (chunk.type !== "chunk") continue;
+			expect(chunk.code).not.toContain(`sideEffects`);
+		}
+	},
+});

--- a/packages/rolldown/tests/fixtures/resolve/issue-5846-2/main.ts
+++ b/packages/rolldown/tests/fixtures/resolve/issue-5846-2/main.ts
@@ -1,0 +1,3 @@
+import('./side-effects.ts')
+
+console.log('main')

--- a/packages/rolldown/tests/fixtures/resolve/issue-5846-2/package.json
+++ b/packages/rolldown/tests/fixtures/resolve/issue-5846-2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "5846-2",
+  "sideEffects": false
+}

--- a/packages/rolldown/tests/fixtures/resolve/issue-5846-2/side-effects.ts
+++ b/packages/rolldown/tests/fixtures/resolve/issue-5846-2/side-effects.ts
@@ -1,0 +1,1 @@
+console.log('sideEffects')


### PR DESCRIPTION
Same with #5851, but for `resolveDynamicImport` hook.