### PR TITLE
fix: respect package.json type field in plugin-resolved modules

### DIFF
--- a/packages/rolldown/tests/fixtures/issues/6398/.gitignore
+++ b/packages/rolldown/tests/fixtures/issues/6398/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/rolldown/tests/fixtures/issues/6398/_config.ts
+++ b/packages/rolldown/tests/fixtures/issues/6398/_config.ts
@@ -1,0 +1,19 @@
+import { defineTest } from 'rolldown-tests'
+
+export default defineTest({
+  config: {
+    external: ['node:assert'],
+    plugins: [{
+      name: 'test',
+      async resolveId(specifier, importer, extraArgs) {
+        if (specifier === 'dep') {
+          return await this.resolve(specifier, importer)
+        }
+      }
+    }]
+  },
+  async afterTest() {
+     // @ts-ignore
+     await import('./dist/main')
+  },
+})

--- a/packages/rolldown/tests/fixtures/issues/6398/main.js
+++ b/packages/rolldown/tests/fixtures/issues/6398/main.js
@@ -1,0 +1,7 @@
+import nodeAssert from 'node:assert'
+import { cjsDepStar } from 'dep'
+
+// If `lib/lib.js` is marked as `package.json#type: "module"` by rolldown,
+// then `cjsDepStar.default` should point to `cjsDepStar` itself
+nodeAssert.equal(cjsDepStar.value, 'cjs-dep')
+nodeAssert.equal(cjsDepStar.default.value, 'cjs-dep')

--- a/packages/rolldown/tests/fixtures/issues/6398/node_modules/dep/cjs-dep.cjs
+++ b/packages/rolldown/tests/fixtures/issues/6398/node_modules/dep/cjs-dep.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  value: 'cjs-dep'
+}

--- a/packages/rolldown/tests/fixtures/issues/6398/node_modules/dep/lib.js
+++ b/packages/rolldown/tests/fixtures/issues/6398/node_modules/dep/lib.js
@@ -1,0 +1,2 @@
+import * as cjsDepStar from './cjs-dep.cjs'
+export { cjsDepStar }

--- a/packages/rolldown/tests/fixtures/issues/6398/node_modules/dep/package.json
+++ b/packages/rolldown/tests/fixtures/issues/6398/node_modules/dep/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "exports": "./lib.js"
+}


### PR DESCRIPTION
partially fixes, #6398

When plugins resolve module IDs, ModuleDefFormat now checks both file extensions and package.json "type" field, matching the behavior of the internal resolver. This ensures consistent module format determination regardless of resolution path.

Changes:
- Add infer_module_def_format() helper in resolve_id_with_plugins.rs
- Update resolve_dynamic_import and resolve_id hooks to use helper
- Add test case with ESM package resolved via internal resolver