### PR TITLE
fix(dev): call `watchChange` hook

### DIFF
--- a/packages/test-dev-server/tests/fixtures/edit/dev.config.mjs
+++ b/packages/test-dev-server/tests/fixtures/edit/dev.config.mjs
@@ -1,5 +1,7 @@
 import { defineDevConfig } from '@rolldown/test-dev-server';
 
+let lastWatchChangeResult = '';
+
 export default defineDevConfig({
   platform: 'node',
   build: {
@@ -9,5 +11,21 @@ export default defineDevConfig({
     },
     platform: 'node',
     treeshake: false,
+    plugins: [
+      {
+        name: 'watch-change-result',
+        watchChange(_id, _kind) {
+          lastWatchChangeResult = `called`;
+        },
+        transform(code, id) {
+          if (id.endsWith('foo.js')) {
+            return code.replace(
+              '__WATCH_CHANGE_RESULT__',
+              JSON.stringify('-' + lastWatchChangeResult),
+            );
+          }
+        },
+      },
+    ],
   },
 });

--- a/packages/test-dev-server/tests/fixtures/edit/src/foo.hmr-1.js
+++ b/packages/test-dev-server/tests/fixtures/edit/src/foo.hmr-1.js
@@ -1,1 +1,1 @@
-export let value = 'edited-foo';
+export let value = 'edited-foo' + __WATCH_CHANGE_RESULT__;

--- a/packages/test-dev-server/tests/fixtures/edit/src/foo.js
+++ b/packages/test-dev-server/tests/fixtures/edit/src/foo.js
@@ -1,1 +1,1 @@
-export let value = 'foo';
+export let value = 'foo' + __WATCH_CHANGE_RESULT__;

--- a/packages/test-dev-server/tests/fixtures/edit/src/main.js
+++ b/packages/test-dev-server/tests/fixtures/edit/src/main.js
@@ -4,7 +4,7 @@ export { value as fooValue } from './foo';
 
 if (import.meta.hot) {
   import.meta.hot.accept((newExports) => {
-    assert.equal(newExports.fooValue, 'edited-foo');
+    assert.equal(newExports.fooValue, 'edited-foo-called');
     nodeFs.writeFileSync('./ok-0', '');
   });
 }


### PR DESCRIPTION
fixes #6323

This PR calls the `watchChange` hook always with `WatcherChangeKind::Update` event. We need to implement the event merging to support the other event kinds.
