### PR TITLE
chore(rust/test): sensible heading level for build snapshot of config variant

### DIFF
--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/artifacts.snap
@@ -33,13 +33,11 @@ const b = "a";
 export { a, b };
 ```
 
----
+# Variant: no-profiler-names: [profiler_names: false]
 
-Variant: no-profiler-names: [profiler_names: false]
+## Assets
 
-# Assets
-
-## a.js
+### a.js
 
 ```js
 import { a } from "./common.js";
@@ -47,7 +45,7 @@ import { a } from "./common.js";
 export { a };
 ```
 
-## b.js
+### b.js
 
 ```js
 import { b } from "./common.js";
@@ -55,7 +53,7 @@ import { b } from "./common.js";
 export { b };
 ```
 
-## common.js
+### common.js
 
 ```js
 //#region a.js

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/basic_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/basic_cjs/artifacts.snap
@@ -48,13 +48,11 @@ export { require_a, require_b };
 export { __commonJS };
 ```
 
----
+# Variant: no-profiler-names: [profiler_names: false]
 
-Variant: no-profiler-names: [profiler_names: false]
+## Assets
 
-# Assets
-
-## a.js
+### a.js
 
 ```js
 import { require_a } from "./common.js";
@@ -63,7 +61,7 @@ export default require_a();
 
 ```
 
-## b.js
+### b.js
 
 ```js
 import { require_b } from "./common.js";
@@ -72,7 +70,7 @@ export default require_b();
 
 ```
 
-## common.js
+### common.js
 
 ```js
 import { __commonJSMin } from "./rolldown-runtime.js";
@@ -92,7 +90,7 @@ var require_b = /* @__PURE__ */ __commonJSMin(((exports) => {
 export { require_a, require_b };
 ```
 
-## rolldown-runtime.js
+### rolldown-runtime.js
 
 ```js
 // HIDDEN [rolldown:runtime]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_basic/artifacts.snap
@@ -22,13 +22,11 @@ var init_main = __esm({"main.js": (() => {
 init_main();
 ```
 
----
+# Variant: [profiler_names: false]
 
-Variant: [profiler_names: false]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 // HIDDEN [rolldown:runtime]
@@ -47,13 +45,11 @@ var init_main = __esmMin((() => {
 init_main();
 ```
 
----
+# Variant: [pife_for_module_wrappers: false]
 
-Variant: [pife_for_module_wrappers: false]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 // HIDDEN [rolldown:runtime]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/concatenate_wrapped_modules/artifacts.snap
@@ -41,13 +41,11 @@ var init_main = __esm({ "main.js": (() => {
 init_main();
 ```
 
----
+# Variant: [on_demand_wrapping: true]
 
-Variant: [on_demand_wrapping: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import assert from "node:assert";

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain/artifacts.snap
@@ -22,13 +22,11 @@ nodeAssert.equal(value, "foo");
 //#endregion
 ```
 
----
+# Variant: [strict_execution_order: true]
 
-Variant: [strict_execution_order: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import nodeAssert from "node:assert";

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
@@ -22,13 +22,11 @@ nodeAssert.equal(value$1, "foo");
 //#endregion
 ```
 
----
+# Variant: [strict_execution_order: true]
 
-Variant: [strict_execution_order: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import nodeAssert from "node:assert";
@@ -83,13 +81,11 @@ var init_main = __esm({ "main.js": (() => {
 init_main();
 ```
 
----
+# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
 
-Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import nodeAssert from "node:assert";

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
@@ -22,13 +22,11 @@ nodeAssert.equal(value$1, "foo");
 //#endregion
 ```
 
----
+# Variant: [strict_execution_order: true]
 
-Variant: [strict_execution_order: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import nodeAssert from "node:assert";

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4782/artifacts.snap
@@ -32,13 +32,11 @@ var init_main = __esm({ "main.js": (() => {
 init_main();
 ```
 
----
+# Variant: [on_demand_wrapping: true]
 
-Variant: [on_demand_wrapping: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 // HIDDEN [rolldown:runtime]

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
@@ -30,13 +30,11 @@ init_main();
 export { dep_default as dep };
 ```
 
----
+# Variant: [on_demand_wrapping: true]
 
-Variant: [on_demand_wrapping: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import nodeAssert from "node:assert";

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/remove_unused_no_side_effect_module/artifacts.snap
@@ -14,13 +14,11 @@ nodeAssert.equal(globalThis.value, void 0, "Unused no side effect module should 
 //#endregion
 ```
 
----
+# Variant: [strict_execution_order: true]
 
-Variant: [strict_execution_order: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import nodeAssert from "node:assert";

--- a/crates/rolldown/tests/rolldown/function/extend/entry-wrapped-cjs-default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/entry-wrapped-cjs-default/artifacts.snap
@@ -17,13 +17,11 @@ export default require_main();
 
 ```
 
----
+# Variant: [format: Cjs]
 
-Variant: [format: Cjs]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 // HIDDEN [rolldown:runtime]
@@ -38,13 +36,11 @@ module.exports = require_main();
 
 ```
 
----
+# Variant: [extend: true] [format: Iife] [name: "module"]
 
-Variant: [extend: true] [format: Iife] [name: "module"]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 this.module = (function() {
@@ -62,13 +58,11 @@ return require_main();
 })();
 ```
 
----
+# Variant: [extend: true] [format: Umd] [name: "module"]
 
-Variant: [extend: true] [format: Umd] [name: "module"]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 (function(global, factory) {

--- a/crates/rolldown/tests/rolldown/function/extend/entry-wrapped-cjs-named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/entry-wrapped-cjs-named/artifacts.snap
@@ -17,13 +17,11 @@ export default require_main();
 
 ```
 
----
+# Variant: [exports: Named] [format: Cjs]
 
-Variant: [exports: Named] [format: Cjs]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 // HIDDEN [rolldown:runtime]
@@ -42,13 +40,11 @@ Object.defineProperty(exports, 'default', {
 });
 ```
 
----
+# Variant: [exports: Named] [extend: true] [format: Iife] [name: "module"]
 
-Variant: [exports: Named] [extend: true] [format: Iife] [name: "module"]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 (function(exports) {
@@ -70,13 +66,11 @@ Object.defineProperty(exports, 'default', {
 })(this.module = this.module || {});
 ```
 
----
+# Variant: [exports: Named] [extend: true] [format: Umd] [name: "module"]
 
-Variant: [exports: Named] [extend: true] [format: Umd] [name: "module"]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 (function(global, factory) {

--- a/crates/rolldown/tests/rolldown/issues/2859/1/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2859/1/artifacts.snap
@@ -32,13 +32,11 @@ import("./lib.js").then((exports) => assert.deepStrictEqual({ ...exports }, {
 export {  };
 ```
 
----
+# Variant: [format: Cjs]
 
-Variant: [format: Cjs]
+## Assets
 
-# Assets
-
-## lib.js
+### lib.js
 
 ```js
 
@@ -59,7 +57,7 @@ exports.default = lib_default;
 exports.foo = foo;
 ```
 
-## main.js
+### main.js
 
 ```js
 // HIDDEN [rolldown:runtime]

--- a/crates/rolldown/tests/rolldown/issues/2859/2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2859/2/artifacts.snap
@@ -23,22 +23,20 @@ import("./main.js").then((exports) => assert.deepStrictEqual({ ...exports }, {
 export { bar, main_default as default, foo };
 ```
 
----
+# Variant: [format: Cjs]
 
-Variant: [format: Cjs]
+## warnings
 
-# warnings
-
-## MIXED_EXPORT
+### MIXED_EXPORT
 
 ```text
 [MIXED_EXPORT] Warning: Entry module "main" is using named (including "bar", "default", "foo") and default exports together. Consumers of your bundle will have to use `main.js.default` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.
 
 ```
 
-# Assets
+## Assets
 
-## main.js
+### main.js
 
 ```js
 Object.defineProperty(exports, '__esModule', { value: true });

--- a/crates/rolldown/tests/rolldown/issues/3456/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3456/artifacts.snap
@@ -11,13 +11,11 @@ import { "\n\"\\'" as test } from "external";
 export { test as "\n\"\\'" };
 ```
 
----
+# Variant: [format: Cjs]
 
-Variant: [format: Cjs]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 // HIDDEN [rolldown:runtime]

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -71,13 +71,11 @@ var import_node_mode_by_cjs_extension = /* @__PURE__ */ __toESM(require_node_mod
 //#endregion
 ```
 
----
+# Variant: [format: Cjs]
 
-Variant: [format: Cjs]
+## Assets
 
-# Assets
-
-## chunk.js
+### chunk.js
 
 ```js
 // HIDDEN [rolldown:runtime]
@@ -102,7 +100,7 @@ Object.defineProperty(exports, '__toESM', {
 });
 ```
 
-## lib.js
+### lib.js
 
 ```js
 const require_chunk = require('./chunk.js');
@@ -122,7 +120,7 @@ Object.defineProperty(exports, 'default', {
 });
 ```
 
-## main.js
+### main.js
 
 ```js
 const require_chunk = require('./chunk.js');
@@ -168,13 +166,11 @@ var import_node_mode_by_cjs_extension = /* @__PURE__ */ require_chunk.__toESM(re
 //#endregion
 ```
 
----
+# Variant: [inline_dynamic_imports: true]
 
-Variant: [inline_dynamic_imports: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import nodeAssert from "node:assert";

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -37,13 +37,11 @@ var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs());
 //#endregion
 ```
 
----
+# Variant: [on_demand_wrapping: true] [strict_execution_order: true]
 
-Variant: [on_demand_wrapping: true] [strict_execution_order: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import assert from "node:assert";

--- a/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/basic/artifacts.snap
@@ -30,13 +30,11 @@ const unused = value;
 export { unused, value };
 ```
 
----
+# Variant: [preserve_entry_signatures: Strict]
 
-Variant: [preserve_entry_signatures: Strict]
+## Assets
 
-# Assets
-
-## dynamic.js
+### dynamic.js
 
 ```js
 import { value } from "./lib.js";
@@ -47,7 +45,7 @@ console.log(`shared: `, value);
 //#endregion
 ```
 
-## lib.js
+### lib.js
 
 ```js
 //#region lib.js
@@ -57,7 +55,7 @@ const value = 100;
 export { value };
 ```
 
-## main.js
+### main.js
 
 ```js
 import { value } from "./lib.js";
@@ -71,13 +69,11 @@ const unused = value;
 export { unused };
 ```
 
----
+# Variant: [preserve_entry_signatures: False]
 
-Variant: [preserve_entry_signatures: False]
+## Assets
 
-# Assets
-
-## dynamic.js
+### dynamic.js
 
 ```js
 import { value } from "./main.js";
@@ -88,7 +84,7 @@ console.log(`shared: `, value);
 //#endregion
 ```
 
-## main.js
+### main.js
 
 ```js
 //#region lib.js

--- a/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/top_level_var/issue_5884/artifacts.snap
@@ -22,13 +22,11 @@ var Example = class Example {
 //#endregion
 ```
 
----
+# Variant: [top_level_var: true]
 
-Variant: [top_level_var: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import assert from "node:assert";

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/issue_6246/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/issue_6246/artifacts.snap
@@ -29,13 +29,11 @@ assert.strictEqual(mutable_let, "mutable_let1");
 //#endregion
 ```
 
----
+# Variant: [inline_const: Config(InlineConstConfig { mode: None, pass: 2 })]
 
-Variant: [inline_const: Config(InlineConstConfig { mode: None, pass: 2 })]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import assert from "node:assert";

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass/artifacts.snap
@@ -33,13 +33,11 @@ demo();
 
 ```
 
----
+# Variant: inlineConstPass2: [inline_const: Config(InlineConstConfig { mode: None, pass: 2 })]
 
-Variant: inlineConstPass2: [inline_const: Config(InlineConstConfig { mode: None, pass: 2 })]
+## Assets
 
-# Assets
-
-## pagea.js
+### pagea.js
 
 ```js
 function demo() {}
@@ -47,7 +45,7 @@ demo();
 
 ```
 
-## pageb.js
+### pageb.js
 
 ```js
 function demo() {}

--- a/crates/rolldown/tests/rolldown/topics/generated_code/symbols/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/symbols/artifacts.snap
@@ -15,13 +15,11 @@ const a = 1;
 exports.a = a;
 ```
 
----
+# Variant: [format: Esm]
 
-Variant: [format: Esm]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 //#region main.js
@@ -31,22 +29,20 @@ const a = 1;
 export { a };
 ```
 
----
+# Variant: [format: Iife]
 
-Variant: [format: Iife]
+## warnings
 
-# warnings
-
-## MISSING_NAME_OPTION_FOR_IIFE_EXPORT
+### MISSING_NAME_OPTION_FOR_IIFE_EXPORT
 
 ```text
 [MISSING_NAME_OPTION_FOR_IIFE_EXPORT] Warning: If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.
 
 ```
 
-# Assets
+## Assets
 
-## main.js
+### main.js
 
 ```js
 (function(exports) {

--- a/crates/rolldown/tests/rolldown/topics/tla/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/basic/artifacts.snap
@@ -13,13 +13,11 @@ const foo = await Promise.resolve("foo");
 export { foo };
 ```
 
----
+# Variant: [strict_execution_order: true]
 
-Variant: [strict_execution_order: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 // HIDDEN [rolldown:runtime]

--- a/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/inside_try_block/artifacts.snap
@@ -16,13 +16,11 @@ try {
 export { foo };
 ```
 
----
+# Variant: [strict_execution_order: true]
 
-Variant: [strict_execution_order: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 // HIDDEN [rolldown:runtime]

--- a/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/transitive_dep/artifacts.snap
@@ -17,13 +17,11 @@ const value = value$1 + "+lib";
 export { value };
 ```
 
----
+# Variant: [strict_execution_order: true]
 
-Variant: [strict_execution_order: true]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 // HIDDEN [rolldown:runtime]

--- a/crates/rolldown/tests/rollup/relative-external/artifacts.snap
+++ b/crates/rolldown/tests/rollup/relative-external/artifacts.snap
@@ -10,26 +10,22 @@ import "./external";
 
 ```
 
----
+# Variant: [entry_filenames: "[name].js"]
 
-Variant: [entry_filenames: "[name].js"]
+## Assets
 
-# Assets
-
-## main.js
+### main.js
 
 ```js
 import "./external";
 
 ```
 
----
+# Variant: [entry_filenames: "chunk/[name].js"]
 
-Variant: [entry_filenames: "chunk/[name].js"]
+## Assets
 
-# Assets
-
-## chunk/main.js
+### chunk/main.js
 
 ```js
 import "../external";

--- a/crates/rolldown_testing/src/types/snapshot_section.rs
+++ b/crates/rolldown_testing/src/types/snapshot_section.rs
@@ -22,6 +22,10 @@ impl SnapshotSection {
     Self { title: Some(title.into()), content: String::new(), children: Vec::new() }
   }
 
+  pub fn add_title(&mut self, title: impl Into<String>) {
+    self.title = Some(title.into());
+  }
+
   pub fn add_content(&mut self, content: &str) {
     self.content.push_str(content);
   }


### PR DESCRIPTION
<img width="1254" height="728" alt="image" src="https://github.com/user-attachments/assets/184b71c2-1489-4f87-8986-20e962078fe6" />

- Organize the content in reasonable scope
- This also gives better experiences when reviewing the snapshot in some markdown friendly ide. Especially when you are checking the differences between different config variants.