### PR TITLE
chore(just): Skip corepack if not available

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ setup:
   cargo install cargo-binstall
   cargo binstall cargo-insta cargo-deny cargo-shear typos-cli -y
   # Node.js related setup
-  corepack enable
+  (! which corepack) || corepack enable
   pnpm install
   just setup-submodule
   just setup-bench

--- a/justfile
+++ b/justfile
@@ -12,11 +12,21 @@ setup:
   cargo install cargo-binstall
   cargo binstall cargo-insta cargo-deny cargo-shear typos-cli -y
   # Node.js related setup
-  (! which corepack) || corepack enable
+  just _maybe-corepack
   pnpm install
   just setup-submodule
   just setup-bench
   @echo "✅✅✅ Setup complete!"
+
+[private]
+[unix]
+_maybe-corepack:
+  @command -v corepack >/dev/null 2>&1 && corepack enable || echo "corepack not found, skipping corepack enable"
+
+[private]
+[windows]
+_maybe-corepack:
+  @if (Get-Command corepack -ErrorAction SilentlyContinue) { corepack enable } else { Write-Host "corepack not found, skipping corepack enable" }
 
 setup-submodule:
   git submodule update --init


### PR DESCRIPTION


<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

The contribution docs are written as if corepack is not mandatory, but
eventually I get told to run `just setup` which does kinda mandate it.
Let's just skip it if it's not there, I already set up pnpm and node up
via volta and it works fine.