### PR TITLE
fix: use transform.target as default for minify target when `minify: { compress: true }`

### DIFF
--- a/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
@@ -12,7 +12,14 @@ use serde::Deserialize;
 pub enum RawMinifyOptions {
   Bool(bool),
   DeadCodeEliminationOnly,
-  Object((oxc::minifier::MinifierOptions, bool)),
+  Object(RawMinifyOptionsDetailed),
+}
+
+#[derive(Debug, Clone)]
+pub struct RawMinifyOptionsDetailed {
+  pub options: oxc::minifier::MinifierOptions,
+  pub default_target: bool,
+  pub remove_whitespace: bool,
 }
 
 impl RawMinifyOptions {
@@ -53,7 +60,16 @@ impl RawMinifyOptions {
         }
       }
       RawMinifyOptions::DeadCodeEliminationOnly => MinifyOptions::DeadCodeEliminationOnly,
-      RawMinifyOptions::Object(value) => MinifyOptions::Enabled(value),
+      RawMinifyOptions::Object(value) => MinifyOptions::Enabled((
+        {
+          let mut opts = value.options;
+          if value.default_target {
+            opts.compress.get_or_insert_default().target = options.transform_options.target.clone();
+          }
+          opts
+        },
+        value.remove_whitespace,
+      )),
     }
     //
   }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -47,7 +47,7 @@ pub mod bundler_options {
       legal_comments::LegalComments,
       log_level::LogLevel,
       make_absolute_externals_relative::MakeAbsoluteExternalsRelative,
-      minify_options::{MinifyOptions, RawMinifyOptions},
+      minify_options::{MinifyOptions, RawMinifyOptions, RawMinifyOptionsDetailed},
       module_type::ModuleType,
       normalized_bundler_options::{NormalizedBundlerOptions, SharedNormalizedBundlerOptions},
       on_log::{Log, LogWithoutPlugin, OnLog},

--- a/packages/rolldown/tests/fixtures/output/minify/respect-target/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/minify/respect-target/_config.ts
@@ -9,7 +9,8 @@ export default defineTest({
     },
     output: [
       { minify: true },
-      { minify: 'dce-only' }
+      { minify: 'dce-only' },
+      { minify: { compress: true } }
     ],
   },
   afterTest: async (outputs) => {

--- a/packages/rolldown/tests/fixtures/output/minify/respect-target/snap-2/main.js.snap
+++ b/packages/rolldown/tests/fixtures/output/minify/respect-target/snap-2/main.js.snap
@@ -1,0 +1,1 @@
+function hello(e){console.log(e==null?void 0:e.name)}export{hello};


### PR DESCRIPTION
use transform.target as default for minify target when `minify: { compress: true }` and `minify: { compress: {/* target not specified */} }`.

refs https://github.com/rolldown/rolldown/pull/6402, https://github.com/vitejs/rolldown-vite/issues/440
