### PR TITLE
fix: allow specifying packageJsonPath in PluginContext.load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,6 +2871,7 @@ dependencies = [
  "rolldown_utils",
  "rustc-hash",
  "string_wizard",
+ "sugar_path",
  "tracing",
  "url",
 ]

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -62,6 +62,7 @@ rolldown_tracing = { workspace = true }
 rolldown_utils = { workspace = true }
 rustc-hash = { workspace = true }
 string_wizard = { workspace = true }
+sugar_path = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -14,7 +14,9 @@ pub use typedmap;
 #[doc(hidden)]
 pub mod __inner {
   pub use super::utils::resolve_id_check_external::resolve_id_check_external;
-  pub use super::utils::resolve_id_with_plugins::resolve_id_with_plugins;
+  pub use super::utils::resolve_id_with_plugins::{
+    infer_module_def_format, resolve_id_with_plugins,
+  };
   pub use crate::pluginable::{Pluginable, SharedPluginable};
 }
 

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
@@ -5,7 +5,9 @@ use std::{
 
 use arcstr::ArcStr;
 use derive_more::Debug;
-use rolldown_common::{LogWithoutPlugin, ResolvedId, side_effects::HookSideEffects};
+use rolldown_common::{
+  LogWithoutPlugin, ModuleDefFormat, ResolvedId, side_effects::HookSideEffects,
+};
 
 use crate::{
   PluginContextResolveOptions, plugin_context::PluginContextMeta,
@@ -67,8 +69,9 @@ impl PluginContext {
     &self,
     specifier: &str,
     side_effects: Option<HookSideEffects>,
+    module_def_format: ModuleDefFormat,
   ) -> anyhow::Result<()> {
-    call_native_only!(self, "load", ctx => ctx.load(specifier, side_effects).await)
+    call_native_only!(self, "load", ctx => ctx.load(specifier, side_effects, module_def_format).await)
   }
 
   pub async fn resolve(

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -19,7 +19,10 @@ pub fn is_data_url(s: &str) -> bool {
 
 /// Infers ModuleDefFormat from file path and optional package.json.
 /// This matches the logic used in the internal resolver's `infer_module_def_format`.
-fn infer_module_def_format(path: &str, package_json: Option<&Arc<PackageJson>>) -> ModuleDefFormat {
+pub fn infer_module_def_format(
+  path: &str,
+  package_json: Option<&Arc<PackageJson>>,
+) -> ModuleDefFormat {
   let fmt = ModuleDefFormat::from_path(path);
 
   // If the extension is specific (.mjs/.cjs/.cts/.mts), use it

--- a/crates/rolldown_plugin_isolated_declaration/src/lib.rs
+++ b/crates/rolldown_plugin_isolated_declaration/src/lib.rs
@@ -41,7 +41,7 @@ impl Plugin for IsolatedDeclarationPlugin {
       for specifier in type_import_specifiers {
         let resolved_id = ctx.resolve(&specifier, Some(args.id), None).await??;
         if matches!(resolved_id.external, ResolvedExternal::Bool(false)) {
-          ctx.load(&resolved_id.id, None).await?;
+          ctx.load(&resolved_id.id, None, resolved_id.module_def_format).await?;
         }
       }
 

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1420,7 +1420,7 @@ export declare class BindingOutputs {
 }
 
 export declare class BindingPluginContext {
-  load(specifier: string, sideEffects: boolean | 'no-treeshake' | undefined): Promise<void>
+  load(specifier: string, sideEffects: boolean | 'no-treeshake' | undefined, packageJsonPath?: string): Promise<void>
   resolve(specifier: string, importer?: string | undefined | null, extraOptions?: BindingPluginContextResolveOptions | undefined | null): Promise<BindingPluginContextResolvedId | null>
   emitFile(file: BindingEmittedAsset, assetFilename?: string | undefined | null, fnSanitizedFileName?: string | undefined | null): string
   emitChunk(file: BindingEmittedChunk): string

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -125,6 +125,7 @@ export class PluginContextImpl extends MinimalPluginContextImpl {
       loadPromise = this.context.load(
         id,
         options.moduleSideEffects ?? undefined,
+        options.packageJsonPath ?? undefined,
       ).catch(() => {
         // avoid reusing the promise if it's an error
         // because the error may happen only in non-supported hooks (e.g. `buildStart` hook)

--- a/packages/rolldown/tests/fixtures/plugin/context/load/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/load/_config.ts
@@ -27,6 +27,10 @@ export default defineTest({
               moduleSideEffects: false,
             })
             expect(moduleInfo.code!.includes('foo')).toBe(true)
+
+            const resolved = await this.resolve('./dir/index.js', id)
+            expect(resolved).toBeDefined()
+            await this.load(resolved!)
           }
           if (id.endsWith('foo.js')) {
             fooHookCalls++
@@ -48,7 +52,8 @@ export default defineTest({
   beforeTest: () => {
     fooHookCalls = 0
   },
-  afterTest: (output) => {
-    expect(output.output[0].code.includes(`console.log`)).toBe(false)
+  afterTest: async (output) => {
+     // @ts-ignore
+     await import('./dist/main')
   },
 })

--- a/packages/rolldown/tests/fixtures/plugin/context/load/dir/cjs.cjs
+++ b/packages/rolldown/tests/fixtures/plugin/context/load/dir/cjs.cjs
@@ -1,0 +1,4 @@
+Object.defineProperties(exports, {
+  __esModule: { value: true }
+});
+module.exports.default = 'default';

--- a/packages/rolldown/tests/fixtures/plugin/context/load/dir/index.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/load/dir/index.js
@@ -1,0 +1,6 @@
+import assert from "node:assert";
+import * as cjs from './cjs.cjs'
+
+// If this file is marked as `package.json#type: "module"` by rolldown,
+// then `cjs.default` should point to `module.exports` of `cjs.cjs`.
+assert.deepStrictEqual(cjs.default, { default: 'default' });

--- a/packages/rolldown/tests/fixtures/plugin/context/load/dir/package.json
+++ b/packages/rolldown/tests/fixtures/plugin/context/load/dir/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/rolldown/tests/fixtures/plugin/context/load/foo.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/load/foo.js
@@ -1,1 +1,1 @@
-console.log('foo')
+globalThis.foo = true

--- a/packages/rolldown/tests/fixtures/plugin/context/load/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/load/main.js
@@ -1,1 +1,5 @@
+import assert from "node:assert";
 import "./foo";
+import "./dir/index.js";
+
+assert.strictEqual(globalThis.foo, undefined);


### PR DESCRIPTION
For codes like below, the moduleDefFormat was not preserved.
```js
const resolved = await this.resolve('./dir/index.js', id)
await this.load(resolved)
```
This PR fixes that by receiving `package_json_path` in `this.load`.

If we receive `module_def_format`, it would make the code more simple. But I guess we don't want to expose that on JS side and keep it an internal thing.

refs #6398
