### PR TITLE
chore(examples): add `"type": "module"` in `package.json`

### DIFF
--- a/examples/hmr-raw/package.json
+++ b/examples/hmr-raw/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-hmr",
   "version": "0.0.0",
+  "type": "module",
   "private": true,
   "scripts": {
     "dev": "serve",

--- a/examples/yarn-pnp/package.json
+++ b/examples/yarn-pnp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yarn-pnp",
   "packageManager": "yarn@4.3.1",
-  "type":"module",
+  "type": "module",
   "dependencies": {
     "is-even": "^1.0.0"
   }

--- a/examples/yarn-pnp/package.json
+++ b/examples/yarn-pnp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "yarn-pnp",
   "packageManager": "yarn@4.3.1",
+  "type":"module",
   "dependencies": {
     "is-even": "^1.0.0"
   }

--- a/packages/rollup-tests/package.json
+++ b/packages/rollup-tests/package.json
@@ -1,5 +1,6 @@
 {
   "name": "rollup-tests",
+  "type": "module",
   "private": true,
   "scripts": {
     "test": "ROLLUP_TEST=1 mocha --file ./src/intercept/check.js test/test.js",

--- a/packages/rollup-tests/package.json
+++ b/packages/rollup-tests/package.json
@@ -1,6 +1,5 @@
 {
   "name": "rollup-tests",
-  "type": "module",
   "private": true,
   "scripts": {
     "test": "ROLLUP_TEST=1 mocha --file ./src/intercept/check.js test/test.js",


### PR DESCRIPTION
Thought it is in examples folder, node.js recommends to explicitly mention type: module in package.json. Otherwise it incurs performance cost. (https://nodejs.org/en/blog/release/v20.19.0#module-syntax-detection-is-now-enabled-by-default). That's why I thought may be we can include it.