### PR TITLE
feat: add validation for `preserveEntrySignatures` with `includeDependenciesRecursively` option

### DIFF
--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, path::Path, sync::Arc};
 use oxc::transformer_plugins::InjectGlobalVariablesConfig;
 use rolldown_common::{
   AttachDebugInfo, GlobalsOutputOption, InjectImport, LegalComments, MinifyOptions, ModuleType,
-  NormalizedBundlerOptions, OutputFormat, Platform, TreeshakeOptions,
+  NormalizedBundlerOptions, OutputFormat, Platform, PreserveEntrySignatures, TreeshakeOptions,
   normalize_optimization_option,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult, InvalidOptionType};
@@ -23,8 +23,9 @@ pub struct PrepareBuildContext {
   pub warnings: Vec<BuildDiagnostic>,
 }
 
-fn verify_raw_options(raw_options: &crate::BundlerOptions) -> Vec<BuildDiagnostic> {
+fn verify_raw_options(raw_options: &crate::BundlerOptions) -> BuildResult<Vec<BuildDiagnostic>> {
   let mut warnings: Vec<BuildDiagnostic> = Vec::new();
+  let mut errors: Vec<BuildDiagnostic> = Vec::new();
 
   if raw_options.dir.is_some() && raw_options.file.is_some() {
     warnings.push(
@@ -89,19 +90,49 @@ fn verify_raw_options(raw_options: &crate::BundlerOptions) -> Vec<BuildDiagnosti
         );
       }
     }
+
+    // Check if `advancedChunks.include_dependencies_recursively` conflict with `preserveEntrySignatures`
+    if matches!(advanced_chunks.include_dependencies_recursively, Some(false)) {
+      if let Some(preserve_signatures) = &raw_options.preserve_entry_signatures {
+        if matches!(
+          preserve_signatures,
+          PreserveEntrySignatures::Strict | PreserveEntrySignatures::ExportsOnly
+        ) {
+          errors.push(BuildDiagnostic::invalid_option(
+            InvalidOptionType::IncludeDependenciesRecursivelyWithConflictPreserveEntrySignatures(
+              preserve_signatures.to_string(),
+            ),
+          ));
+        }
+      }
+    }
   }
 
-  warnings
+  if errors.is_empty() { Ok(warnings) } else { Err(errors.into()) }
 }
 
 #[expect(clippy::too_many_lines)] // This function is long, but it's mostly just mapping values
 pub fn prepare_build_context(
   mut raw_options: crate::BundlerOptions,
 ) -> BuildResult<PrepareBuildContext> {
-  let mut warnings = verify_raw_options(&raw_options);
+  let mut warnings = verify_raw_options(&raw_options)?;
 
   let format = raw_options.format.unwrap_or(crate::OutputFormat::Esm);
-  let preserve_entry_signatures = raw_options.preserve_entry_signatures.unwrap_or_default();
+
+  let preserve_entry_signatures = if let Some(advanced_chunks) = &raw_options.advanced_chunks
+    && matches!(advanced_chunks.include_dependencies_recursively, Some(false))
+    && raw_options.preserve_entry_signatures.is_none()
+  {
+    warnings.push(
+      BuildDiagnostic::invalid_option(
+        InvalidOptionType::IncludeDependenciesRecursivelyWithImplicitPreserveEntrySignatures,
+      )
+      .with_severity_warning(),
+    );
+    PreserveEntrySignatures::AllowExtension
+  } else {
+    raw_options.preserve_entry_signatures.unwrap_or_default()
+  };
 
   let platform = raw_options.platform.unwrap_or(match format {
     OutputFormat::Cjs => Platform::Node,

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.js"
+      }
+    ],
+    "preserveEntrySignatures": "strict",
+    "advancedChunks": {
+      "includeDependenciesRecursively": false
+    }
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/artifacts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## INVALID_OPTION
+
+```text
+[INVALID_OPTION] Error: Invalid option combination detected:
+
+- advancedChunks.includeDependenciesRecursively = false
+- preserveEntrySignatures = "strict"
+
+To fix:
+
+- Set `preserveEntrySignatures` either to false or 'allow-extension'
+
+```

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/lib.js
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/lib.js
@@ -1,0 +1,5 @@
+export const value = 'library value';
+
+export function helper() {
+  return 'helper function';
+}

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/main.js
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/main.js
@@ -1,0 +1,7 @@
+import { value } from './lib.js';
+
+console.log('Main entry:', value);
+
+export function main() {
+  return 'main function';
+}

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -1,6 +1,21 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
+# warnings
+
+## INVALID_OPTION
+
+```text
+[INVALID_OPTION] Warning: `preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown
+
+- `advancedChunks.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+
+To fix:
+
+- Set `preserveEntrySignatures` either to `false` or 'allow-extension' in your config
+
+```
+
 # Assets
 
 ## first.js

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/_config.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.js"
+      }
+    ],
+    "advancedChunks": {
+      "includeDependenciesRecursively": false,
+      "groups": [
+        {
+          "name": "vendor",
+          "test": "shared"
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## INVALID_OPTION
+
+```text
+[INVALID_OPTION] Warning: `preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown
+
+- `advancedChunks.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+
+To fix:
+
+- Set `preserveEntrySignatures` either to `false` or 'allow-extension' in your config
+
+```
+
+# Assets
+
+## main.js
+
+```js
+import { sharedValue } from "./vendor.js";
+
+//#region main.js
+console.log("Main entry with shared:", sharedValue);
+function mainFunc() {
+	return "main function";
+}
+
+//#endregion
+export { mainFunc };
+```
+
+## vendor.js
+
+```js
+//#region shared.js
+const sharedValue = "shared module value";
+
+//#endregion
+export { sharedValue };
+```

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/main.js
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/main.js
@@ -1,0 +1,7 @@
+import { sharedValue } from './shared.js';
+
+console.log('Main entry with shared:', sharedValue);
+
+export function mainFunc() {
+  return 'main function';
+}

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/shared.js
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/shared.js
@@ -1,0 +1,5 @@
+export const sharedValue = 'shared module value';
+
+export function sharedHelper() {
+  return 'shared helper';
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -6000,6 +6000,11 @@ expression: output
 
 - main-!~{000}~.js => main-B7ZfmDK1.js
 
+# tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures
+
+- main-!~{000}~.js => main-BTBGFOb0.js
+- vendor-!~{001}~.js => vendor-CKG4H9Kv.js
+
 # tests/rolldown/warnings/invalid_option/invalid_context_entity
 
 - main-!~{000}~.js => main-DJPe_EHd.js

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_option/preserve_entry_signatures.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_option/preserve_entry_signatures.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter};
+
 #[cfg(feature = "deserialize_bundler_options")]
 use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
@@ -24,5 +26,17 @@ impl PreserveEntrySignatures {
   #[must_use]
   pub fn is_allow_extension(&self) -> bool {
     matches!(self, Self::AllowExtension)
+  }
+}
+
+impl Display for PreserveEntrySignatures {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    let s = match self {
+      Self::AllowExtension => "allow-extension",
+      Self::Strict => "strict",
+      Self::ExportsOnly => "exports-only",
+      Self::False => "false",
+    };
+    write!(f, "{s}")
   }
 }

--- a/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
@@ -10,6 +10,8 @@ pub enum InvalidOptionType {
   NoEntryPoint,
   AdvancedChunksWithoutGroups(Vec<String>),
   InvalidContext(String),
+  IncludeDependenciesRecursivelyWithConflictPreserveEntrySignatures(String),
+  IncludeDependenciesRecursivelyWithImplicitPreserveEntrySignatures,
 }
 
 #[derive(Debug)]
@@ -39,6 +41,29 @@ impl BuildEvent for InvalidOption {
         }
         InvalidOptionType::InvalidContext(options) => {
             format!("\"{options}\" is an illegitimate identifier for option \"context\". You may use a legitimate context identifier instead.")
+        }
+        InvalidOptionType::IncludeDependenciesRecursivelyWithConflictPreserveEntrySignatures(value) => {
+          [
+            "Invalid option combination detected:",
+            "",
+            "- advancedChunks.includeDependenciesRecursively = false",
+            &format!("- preserveEntrySignatures = \"{value}\""),
+            "",
+            "To fix:",
+            "",
+            "- Set `preserveEntrySignatures` either to false or 'allow-extension'",
+          ].join("\n")
+        }
+        InvalidOptionType::IncludeDependenciesRecursivelyWithImplicitPreserveEntrySignatures => {
+          [
+            "`preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown",
+            "",
+            "- `advancedChunks.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'",
+            "",
+            "To fix:",
+            "",
+            "- Set `preserveEntrySignatures` either to `false` or 'allow-extension' in your config",
+          ].join("\n")
         }
     }
   }

--- a/docs/guide/in-depth/advanced-chunks.md
+++ b/docs/guide/in-depth/advanced-chunks.md
@@ -352,7 +352,7 @@ If you don't want this behavior, you could use [`advancedChunks.includeDependenc
 
 :::warning Caveats
 
-With `includeDependenciesRecursively: false`, depended modules of a group might be left in the entry chunks. It's invalid to export non-entry module from an entry chunk. To avoid this, we strongly recommend to set:
+With `includeDependenciesRecursively: false`, depended modules of a group might be left in the entry chunks. It's invalid to export non-entry module from an entry chunk. To avoid this, Rolldown will implicitly set `preserveEntrySignatures: 'allow-extension'` if you didn't set it explicitly.
 
 - [`InputOptions.preserveEntrySignatures: false | 'allow-extension'`](/reference/config-options#preserveentrysignatures)
 


### PR DESCRIPTION
Closes #6449

Two varificationd:

When `includeDependenciesRecursively` is set to false:

- if `preserveEntrySignatures` is unset, we will set it `allow-extension` with warning.
- if `preserveEntrySignatures` is set to `strcit` etc, we will throw an error to interrupt the build.