### PR TITLE
feat: add `nativeMagicString` options

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -15,6 +15,7 @@ pub struct BindingExperimentalOptions {
   pub incremental_build: Option<bool>,
   #[napi(ts_type = "boolean | 'boundary'")]
   pub transform_hires_sourcemap: Option<Either<bool, String>>,
+  pub native_magic_string: Option<bool>,
 }
 
 impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOptions {
@@ -52,6 +53,7 @@ impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOption
       } else {
         None
       },
+      native_magic_string: value.native_magic_string,
     })
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/experimental_options.rs
@@ -51,6 +51,7 @@ pub struct ExperimentalOptions {
   pub chunk_modules_order: Option<ChunkModulesOrderBy>,
   pub on_demand_wrapping: Option<bool>,
   pub transform_hires_sourcemap: Option<SourcemapHires>,
+  pub native_magic_string: Option<bool>,
 }
 
 impl ExperimentalOptions {
@@ -81,5 +82,9 @@ impl ExperimentalOptions {
 
   pub fn is_attach_debug_info_full(&self) -> bool {
     self.attach_debug_info.is_some_and(|info| info.is_full())
+  }
+
+  pub fn is_native_magic_string_enabled(&self) -> bool {
+    self.native_magic_string.unwrap_or(false)
   }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -787,6 +787,15 @@
             "type": "string"
           }
         },
+        "modules": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "symlinks": {
           "type": [
             "boolean",
@@ -973,6 +982,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "nativeMagicString": {
+          "type": [
+            "boolean",
+            "null"
           ]
         }
       },

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1681,6 +1681,7 @@ export interface BindingExperimentalOptions {
   onDemandWrapping?: boolean
   incrementalBuild?: boolean
   transformHiresSourcemap?: boolean | 'boundary'
+  nativeMagicString?: boolean
 }
 
 export interface BindingFilterToken {

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -283,6 +283,16 @@ export interface InputOptions {
      */
     incrementalBuild?: boolean;
     transformHiresSourcemap?: boolean | 'boundary';
+    /**
+     * Use native Rust implementation of MagicString for source map generation.
+     *
+     * - Type: `boolean`
+     * - Default: `false`
+     *
+     * When enabled, rolldown will use a native Rust implementation of MagicString
+     * for better performance during source map generation.
+     */
+    nativeMagicString?: boolean;
   };
   /**
    * Replace global variables or [property accessors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors) with the provided values.

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -195,6 +195,7 @@ function bindingifyExperimental(
     chunkImportMap: experimental?.chunkImportMap,
     onDemandWrapping: experimental?.onDemandWrapping,
     incrementalBuild: experimental?.incrementalBuild,
+    nativeMagicString: experimental?.nativeMagicString,
   };
 }
 

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -503,6 +503,7 @@ const InputOptionsSchema = v.strictObject({
           fileName: v.optional(v.string()),
         }),
       ])),
+      nativeMagicString: v.optional(v.boolean()),
     }),
   ),
   define: v.pipe(


### PR DESCRIPTION
This option is used to make https://github.com/rolldown/rolldown/pull/6293 **opt-in**, sometimes on the JS side, users require that the sourcemap generation be **synced**, e.g.
https://github.com/rolldown/rolldown/blob/79fa18fdc978d4babf4c6ec45225b2802e38ddc9/packages/rolldown/src/plugin/transform-plugin-context.ts?plain=1#L80-L82