### PR TITLE
docs: correct incorrect documentation about the config file

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -207,10 +207,6 @@ export default defineConfig({
 });
 ```
 
-:::warning Specifying config file name
-The default config file used with the `-c` flag is `rolldown.config.js`. If you are using `.ts` or `.mjs` extensions, make sure to specify the full filename with e.g. `rolldown -c rolldown.config.ts`.
-:::
-
 ### Multiple builds in the same config
 
 You can also specify multiple configurations as an array, and Rolldown will bundle them in parallel.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -147,7 +147,7 @@ $ npm run build
 
 ## Using the Config File
 
-When more options are needed, it is recommended to use a config file for more flexibility. Let's create the following config file:
+When more options are needed, it is recommended to use a config file for more flexibility. A config file can be written in `.js`, `.mjs`, or `.ts` formats. Let's create the following config file:
 
 ```js [rolldown.config.js]
 import { defineConfig } from 'rolldown';
@@ -177,34 +177,6 @@ Next, in the npm script, we can instruct Rolldown to use the config file with th
     "rolldown": "^1.0.0-beta.1"
   }
 }
-```
-
-### TypeScript config file
-
-TypeScript config file is also supported out of the box:
-
-```json{5} [package.json]
-{
-  "name": "my-rolldown-project",
-  "type": "module",
-  "scripts": {
-    "build": "rolldown -c rolldown.config.ts"
-  },
-  "devDependencies": {
-    "rolldown": "^1.0.0-beta.1"
-  }
-}
-```
-
-```js [rolldown.config.ts]
-import { defineConfig } from 'rolldown';
-
-export default defineConfig({
-  input: 'src/main.js',
-  output: {
-    file: 'bundle.js',
-  },
-});
 ```
 
 ### Multiple builds in the same config

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -147,7 +147,7 @@ $ npm run build
 
 ## Using the Config File
 
-When more options are needed, it is recommended to use a config file for more flexibility. A config file can be written in `.js`, `.mjs`, or `.ts` formats. Let's create the following config file:
+When more options are needed, it is recommended to use a config file for more flexibility. A config file can be written in `.js`, `.cjs`, `.mjs`, `.ts`, `.mts`, or `.cts` formats. Let's create the following config file:
 
 ```js [rolldown.config.js]
 import { defineConfig } from 'rolldown';


### PR DESCRIPTION
This PR corrects misleading information in the existing documentation regarding the `rolldown -c` command.

Contrary to what is currently stated in the documentation, the `rolldown -c` command reliably supports the configuration file with the `.js`, `.mjs`, and `.ts` extensions.