### PR TITLE
fix: take `resolve.modules` into account

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_resolve_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_resolve_options.rs
@@ -36,6 +36,7 @@ impl From<BindingResolveOptions> for rolldown::ResolveOptions {
       extension_alias: value.extension_alias.map(|alias| {
         alias.into_iter().map(|item| (item.target, item.replacements)).collect::<Vec<_>>()
       }),
+      modules: value.modules,
       main_fields: value.main_fields,
       main_files: value.main_files,
       symlinks: value.symlinks,

--- a/crates/rolldown_common/src/inner_bundler_options/types/resolve_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/resolve_options.rs
@@ -20,6 +20,7 @@ pub struct ResolveOptions {
   pub extension_alias: Option<Vec<(String, Vec<String>)>>,
   pub main_fields: Option<Vec<String>>,
   pub main_files: Option<Vec<String>>,
+  pub modules: Option<Vec<String>>,
   pub symlinks: Option<bool>,
   pub yarn_pnp: Option<bool>,
 }

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -147,7 +147,7 @@ impl<F: FileSystem> Resolver<F> {
       fully_specified: false,
       main_fields,
       main_files: raw_resolve.main_files.unwrap_or_else(|| vec!["index".to_string()]),
-      modules: vec!["node_modules".into()],
+      modules: raw_resolve.modules.unwrap_or_else(|| vec!["node_modules".into()]),
       resolve_to_context: false,
       prefer_relative: false,
       prefer_absolute: false,

--- a/packages/rolldown/tests/fixtures/resolve/custom-modules/_config.ts
+++ b/packages/rolldown/tests/fixtures/resolve/custom-modules/_config.ts
@@ -1,0 +1,9 @@
+import { defineTest } from 'rolldown-tests'
+
+export default defineTest({
+  config: {
+    resolve: {
+      modules: ['custom-node-modules'],
+    },
+  },
+})

--- a/packages/rolldown/tests/fixtures/resolve/custom-modules/custom-node-modules/foo/index.js
+++ b/packages/rolldown/tests/fixtures/resolve/custom-modules/custom-node-modules/foo/index.js
@@ -1,0 +1,1 @@
+export default 'foo'

--- a/packages/rolldown/tests/fixtures/resolve/custom-modules/custom-node-modules/foo/package.json
+++ b/packages/rolldown/tests/fixtures/resolve/custom-modules/custom-node-modules/foo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/packages/rolldown/tests/fixtures/resolve/custom-modules/main.js
+++ b/packages/rolldown/tests/fixtures/resolve/custom-modules/main.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert'
+import foo from 'foo'
+
+assert.strictEqual(foo, 'foo')


### PR DESCRIPTION
## Summary

When `resolve.modules` is configured via the JavaScript API, it never reaches the native resolver. This causes module resolution to fall back to the default `["node_modules"]` path set inside oxc-resolver, even when custom module directories are explicitly specified.

## Root Cause

The `BindingResolveOptions` struct in `crates/rolldown_binding/src/options/binding_input_options/binding_resolve_options.rs` includes a `modules` field but fails to forward it in the `From<BindingResolveOptions> for rolldown::ResolveOptions` implementation. All other resolve options (alias, alias_fields, condition_names, etc.) are properly forwarded—`modules` was simply omitted.

## Changes

Added the missing `modules` field assignment in the conversion:

```rust
impl From<BindingResolveOptions> for rolldown::ResolveOptions {
  fn from(value: BindingResolveOptions) -> Self {
    Self {
      // ... other fields
      modules: value.modules,  // ← Added
      // ... remaining fields
    }
  }
}
```

## Questions

1. Was the omission of `modules` intentional? If so, what was the reasoning?
2. I believe this is the only place that needs to change to fix the issue, but I'm not 100% certain—could there be other spots in the binding layer that need updating?

## Reference

- [Rolldown Module Resolution Documentation](https://rolldown.rs/guide/features#module-resolution)
