### PR TITLE
refactor(rust): replace unwrap with expect for better error handling in message sending

### DIFF
--- a/crates/rolldown/src/dev/building_task.rs
+++ b/crates/rolldown/src/dev/building_task.rs
@@ -112,11 +112,9 @@ impl BundlingTask {
     build_state.has_stale_build_output = !self.rebuild;
     drop(build_state);
 
-    if self.dev_context.build_channel_tx.send(BuildMessage::BuildFinish).is_err() {
-      tracing::error!("Failed to send build finish message to build channel");
-      // Notice: Send error will only happen when the channel is closed. It might be closed by an error or what.
-      // Handling this error is helpful to that situation.
-    }
+    self.dev_context.build_channel_tx.send(BuildMessage::BuildFinish).expect(
+      "Build service channel closed while sending BuildFinish - build service terminated unexpectedly"
+    );
   }
 
   async fn run_inner(&mut self) -> BuildResult<()> {

--- a/crates/rolldown/src/dev/watcher_event_handler.rs
+++ b/crates/rolldown/src/dev/watcher_event_handler.rs
@@ -7,8 +7,8 @@ pub struct WatcherEventHandler {
 }
 impl EventHandler for WatcherEventHandler {
   fn handle_event(&mut self, event: rolldown_watcher::FileChangeResult) {
-    if self.service_tx.send(BuildMessage::WatchEvent(event)).is_err() {
-      // TODO: handle send failed
-    }
+    self.service_tx.send(BuildMessage::WatchEvent(event)).expect(
+      "Build service channel closed while sending file change event - build service terminated unexpectedly"
+    );
   }
 }

--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -41,7 +41,7 @@ impl ExternalModuleTask {
         .tx
         .send(ModuleLoaderMsg::BuildErrors(errs.into_vec().into_boxed_slice()))
         .await
-        .expect("Send should not fail");
+        .expect("ModuleLoader: failed to send external module build errors - main thread terminated while processing errors");
     }
   }
 
@@ -98,8 +98,9 @@ impl ExternalModuleTask {
       side_effects: external_module_side_effects,
       need_renormalize_render_path,
     }));
-    // If the main thread is dead, nothing we can do to handle these send failures.
-    let _ = self.ctx.tx.send(msg).await;
+    self.ctx.tx.send(msg).await.expect(
+      "ModuleLoader channel closed while sending external module completion - main thread terminated unexpectedly"
+    );
     Ok(())
   }
 }

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -614,7 +614,9 @@ impl<'a> ModuleLoader<'a> {
       return Err(errors.into());
     }
     if let Some(tx) = self.magic_string_tx.as_ref() {
-      tx.send(SourceMapGenMsg::Terminate).unwrap();
+      tx.send(SourceMapGenMsg::Terminate).expect(
+        "SourceMapGen: failed to send Terminate message - sourcemap worker thread died unexpectedly"
+      );
     }
 
     // defer sync user modified data in js side

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -83,7 +83,7 @@ impl ModuleTask {
         .tx
         .send(ModuleLoaderMsg::BuildErrors(errs.into_vec().into_boxed_slice()))
         .await
-        .expect("Send should not fail");
+        .expect("ModuleLoader: failed to send build errors - main thread terminated while processing module errors");
     }
   }
 
@@ -225,8 +225,9 @@ impl ModuleTask {
       warnings,
     }));
 
-    // If the main thread is dead, nothing we can do to handle these send failures.
-    let _ = self.ctx.tx.send(result).await;
+    self.ctx.tx.send(result).await.expect(
+      "ModuleLoader channel closed while sending module completion - main thread terminated unexpectedly"
+    );
 
     Ok(())
   }

--- a/crates/rolldown/src/watch/emitter.rs
+++ b/crates/rolldown/src/watch/emitter.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -18,7 +18,10 @@ impl WatcherEmitter {
   }
 
   pub fn emit(&self, event: WatcherEvent) -> Result<()> {
-    self.tx.send(event)?;
+    self
+      .tx
+      .send(event)
+      .context("WatcherEmitter: failed to emit event - receiver was dropped prematurely")?;
     Ok(())
   }
 }

--- a/crates/rolldown/src/watch/watcher.rs
+++ b/crates/rolldown/src/watch/watcher.rs
@@ -1,4 +1,5 @@
 use crate::watch::event::{BundleEvent, WatcherChangeData, WatcherEvent};
+use anyhow::Context;
 use arcstr::ArcStr;
 #[cfg(not(target_family = "wasm"))]
 use notify::Watcher as _;
@@ -73,7 +74,9 @@ impl WatcherImpl {
     let notify_watcher = Arc::new(Mutex::new(RecommendedWatcher::new(
       move |res| {
         if let Err(e) = tx.send(WatcherChannelMsg::NotifyEvent(res)) {
-          eprintln!("send watch event error {e:?}");
+          eprintln!(
+            "Watcher: failed to send file change notification - channel closed while processing file system event: {e:?}"
+          );
         }
       },
       watch_option,
@@ -121,7 +124,9 @@ impl WatcherImpl {
     }
 
     self.invalidating.store(true, Ordering::Relaxed);
-    self.exec_tx.send(ExecChannelMsg::Exec).expect("send watcher exec channel message error");
+    self.exec_tx.send(ExecChannelMsg::Exec).expect(
+      "Watcher: failed to send Exec message - watcher event loop terminated while scheduling rebuild"
+    );
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
@@ -148,8 +153,13 @@ impl WatcherImpl {
   #[tracing::instrument(level = "debug", skip_all)]
   pub async fn close(&self) -> anyhow::Result<()> {
     // close channel
-    self.tx.send(WatcherChannelMsg::Close)?;
-    self.exec_tx.send(ExecChannelMsg::Close)?;
+    self
+      .tx
+      .send(WatcherChannelMsg::Close)
+      .context("Watcher: failed to send Close message - watcher event loop already terminated")?;
+    self.exec_tx.send(ExecChannelMsg::Close).context(
+      "Watcher: failed to send Close message to exec channel - watcher execution loop already terminated"
+    )?;
     // stop watching files
     // TODO the notify watcher should be dropped, because the stop method is private
     let inner = self.notify_watcher.lock().await;

--- a/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
@@ -39,6 +39,8 @@ impl BindingTransformPluginContext {
     let internal_magic_string = std::mem::take(&mut magic_string.inner);
 
     // If the the message is not send to main thread correctly, we should panic immediately.
-    self.inner.send_magic_string(internal_magic_string).unwrap()
+    self.inner.send_magic_string(internal_magic_string).expect(
+      "TransformPluginContext: failed to send MagicString to sourcemap worker - sourcemap generation thread terminated unexpectedly during transform"
+    )
   }
 }

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -92,7 +92,8 @@ impl FileEmitter {
       "The `PluginContext.emitFile` with `type: 'chunk'` only work at `buildStart/resolveId/load/transform/moduleParsed` hooks.",
     )?
     .send(ModuleLoaderMsg::AddEntryModule(Box::new(AddEntryModuleMsg { chunk: Arc::clone(&chunk), reference_id: reference_id.clone(), preserve_entry_signatures: chunk.preserve_entry_signatures })))
-    .await?;
+    .await
+    .context("FileEmitter: failed to send AddEntryModule message - module loader shut down during file emission")?;
     self.chunks.insert(reference_id.clone(), chunk);
     Ok(reference_id)
   }

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -61,7 +61,8 @@ impl NativePluginContextImpl {
         module_def_format,
         ..Default::default()
       })))
-      .await?;
+      .await
+      .context("PluginContext: failed to send FetchModule message - module loader shut down during plugin execution")?;
     let plugin_driver = self
       .plugin_driver
       .upgrade()


### PR DESCRIPTION
Some users reported error of `Error: channel closed`​, which lacks useful information to investigate.