### PR TITLE
fix: inline only self referenced json module properties

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -136,6 +136,7 @@ pub async fn create_ecma_view(
     constant_export_map,
     depended_runtime_helper: Box::default(),
     import_attribute_map,
+    json_module_none_self_reference_included_symbol: None,
   };
 
   let ecma_related = EcmaRelated { ast, symbols, dynamic_import_rec_exports_usage };

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -293,6 +293,10 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         program.body.splice(0..0, declaration_of_module_namespace_object);
       }
     }
+
+    if self.json_module_inlined_prop.is_some() {
+      program.body.drain_filter(|item| matches!(item, ast::Statement::EmptyStatement(_)));
+    }
   }
 
   fn visit_binding_identifier(&mut self, ident: &mut ast::BindingIdentifier<'ast>) {
@@ -313,6 +317,8 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
   }
 
   fn visit_statement(&mut self, it: &mut ast::Statement<'ast>) {
+    _ = self.try_inline_json_module_prop(it);
+
     if !self.ctx.options.drop_labels.is_empty() {
       if let ast::Statement::LabeledStatement(stmt) = it {
         if self.ctx.options.drop_labels.contains(stmt.label.name.as_str()) {

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -151,6 +151,7 @@ impl RuntimeModuleTask {
         constant_export_map: FxHashMap::default(),
         depended_runtime_helper: Box::default(),
         import_attribute_map: FxHashMap::default(),
+        json_module_none_self_reference_included_symbol: None,
       },
       css_view: None,
       asset_view: None,

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -30,6 +30,12 @@ bitflags::bitflags! {
         /// 1. https://github.com/rolldown/rolldown/blob/8bc7dca5a09047b6b494e3fa7b6b7564aa465372/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs?plain=1#L122-L134
         /// 2. https://github.com/rolldown/rolldown/blob/8bc7dca5a09047b6b494e3fa7b6b7564aa465372/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs?plain=1#L188-L197
         const ReExportDynamicExports = 1 << 2;
+        /// After transforming a JSON module to an ESM module, a default export is created that
+        /// references all top-level properties of the JSON object. This flag tracks whether a
+        /// property is being referenced by the export default object itself (self-reference).
+        /// If a top-level property is only referenced by the export default object and not by
+        /// any outer modules, it can be safely inlined in the final output.
+        const JsonDefaultExportSelfReference = 1 << 3;
     }
 }
 
@@ -51,6 +57,7 @@ struct Context<'a> {
   bailout_cjs_tree_shaking_modules: FxHashSet<ModuleIdx>,
   may_partial_namespace: bool,
   module_namespace_included_reason: &'a mut IndexVec<ModuleIdx, ModuleNamespaceIncludedReason>,
+  json_module_none_self_reference_included_symbol: FxHashMap<ModuleIdx, FxHashSet<SymbolRef>>,
 }
 
 impl LinkStage<'_> {
@@ -88,6 +95,7 @@ impl LinkStage<'_> {
       may_partial_namespace: false,
       module_namespace_included_reason: &mut module_namespace_included_reason,
       inline_const_smart: self.options.optimization.is_inline_const_smart_mode(),
+      json_module_none_self_reference_included_symbol: FxHashMap::default(),
     };
 
     let (user_defined_entries, mut dynamic_entries): (Vec<_>, Vec<_>) =
@@ -163,6 +171,12 @@ impl LinkStage<'_> {
         .for_each(|local| {
           include_symbol(context, local.symbol_ref, SymbolIncludeReason::Normal);
         });
+    }
+
+    // Setting the json module none self reference included symbol map
+    for (mi, set) in std::mem::take(&mut context.json_module_none_self_reference_included_symbol) {
+      let module = self.module_table[mi].as_normal_mut().expect("should be a normal module");
+      _ = module.ecma_view.json_module_none_self_reference_included_symbol.insert(Box::new(set));
     }
 
     // mark those dynamic import records as dead, in case we could eliminate them later in ast
@@ -401,6 +415,7 @@ impl LinkStage<'_> {
       may_partial_namespace: false,
       module_namespace_included_reason,
       inline_const_smart: self.options.optimization.is_inline_const_smart_mode(),
+      json_module_none_self_reference_included_symbol: FxHashMap::default(),
     };
 
     for helper in depended_runtime_helper {
@@ -508,11 +523,11 @@ fn include_module(ctx: &mut Context, module: &NormalModule) {
   }
 }
 
-fn include_symbol(ctx: &mut Context, symbol_ref: SymbolRef, include_kind: SymbolIncludeReason) {
+fn include_symbol(ctx: &mut Context, symbol_ref: SymbolRef, include_reason: SymbolIncludeReason) {
   let mut canonical_ref = ctx.symbols.canonical_ref_for(symbol_ref);
 
   if let Some(v) = ctx.constant_symbol_map.get(&canonical_ref)
-    && !include_kind.contains(SymbolIncludeReason::EntryExport)
+    && !include_reason.contains(SymbolIncludeReason::EntryExport)
     && !ctx.inline_const_smart
     && !v.commonjs_export
   {
@@ -567,10 +582,10 @@ fn include_symbol(ctx: &mut Context, symbol_ref: SymbolRef, include_kind: Symbol
   }
 
   if canonical_ref.symbol.is_module_namespace() {
-    if include_kind.intersects(SymbolIncludeReason::Normal | SymbolIncludeReason::EntryExport) {
+    if include_reason.intersects(SymbolIncludeReason::Normal | SymbolIncludeReason::EntryExport) {
       ctx.module_namespace_included_reason[canonical_ref.owner]
         .insert(ModuleNamespaceIncludedReason::Unknown);
-    } else if include_kind.contains(SymbolIncludeReason::ReExportDynamicExports) {
+    } else if include_reason.contains(SymbolIncludeReason::ReExportDynamicExports) {
       ctx.module_namespace_included_reason[canonical_ref.owner]
         .insert(ModuleNamespaceIncludedReason::ReExportExternalModule);
     }
@@ -579,6 +594,15 @@ fn include_symbol(ctx: &mut Context, symbol_ref: SymbolRef, include_kind: Symbol
   ctx.used_symbol_refs.insert(canonical_ref);
 
   if let Module::Normal(module) = &ctx.modules[canonical_ref.owner] {
+    if !include_reason.contains(SymbolIncludeReason::JsonDefaultExportSelfReference)
+      && module.module_type == ModuleType::Json
+    {
+      ctx
+        .json_module_none_self_reference_included_symbol
+        .entry(module.idx)
+        .or_default()
+        .insert(canonical_ref);
+    }
     include_module(ctx, module);
     module.stmt_infos.declared_stmts_by_symbol(&canonical_ref).iter().copied().for_each(
       |stmt_info_id| {
@@ -639,11 +663,19 @@ fn include_statement(ctx: &mut Context, module: &NormalModule, stmt_info_id: Stm
       ctx.bailout_cjs_tree_shaking_modules.insert(module_idx);
     }
   });
-  let include_kind = if stmt_info.meta.contains(StmtInfoMeta::ReExportDynamicExports) {
+  let mut include_kind = if stmt_info.meta.contains(StmtInfoMeta::ReExportDynamicExports) {
     SymbolIncludeReason::ReExportDynamicExports
   } else {
     SymbolIncludeReason::Normal
   };
+
+  let is_json_module = module.module_type == ModuleType::Json;
+
+  // For a transformed json module
+  if is_json_module && !stmt_info.referenced_symbols.is_empty() {
+    include_kind |= SymbolIncludeReason::JsonDefaultExportSelfReference;
+  }
+
   stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
     if let Some(member_expr_resolution) = match reference_ref {
       SymbolOrMemberExprRef::Symbol(_) => None,

--- a/crates/rolldown/tests/esbuild/default/metafile_import_with_type_json/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/metafile_import_with_type_json/artifacts.snap
@@ -7,8 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region data.json
-var some = "data";
-var data_default = { some };
+var data_default = { some: "data" };
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/loader/loader_bundle_with_import_attributes/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_bundle_with_import_attributes/artifacts.snap
@@ -7,8 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region data.json
-var works = true;
-var data_default = { works };
+var data_default = { works: true };
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_application_json/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_application_json/artifacts.snap
@@ -11,8 +11,7 @@ var json___31_32_33__default = "123";
 
 //#endregion
 //#region <data:application/json;base64,eyJ3b3JrcyI6dHJ1ZX0=>
-var works$1 = true;
-var json_base64_eyJ3b3JrcyI6dHJ1ZX0__default = { works: works$1 };
+var json_base64_eyJ3b3JrcyI6dHJ1ZX0__default = { works: true };
 
 //#endregion
 //#region <data:application/json;charset=UTF-8,%31%32%33>
@@ -20,8 +19,7 @@ var json_charset_UTF_8__31_32_33_default = 123;
 
 //#endregion
 //#region <data:application/json;charset=UTF-8;base64,eyJ3b3JrcyI6dHJ1ZX0=>
-var works = true;
-var json_charset_UTF_8_base64_eyJ3b3JrcyI6dHJ1ZX0__default = { works };
+var json_charset_UTF_8_base64_eyJ3b3JrcyI6dHJ1ZX0__default = { works: true };
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/loader/loader_json_common_js_and_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_common_js_and_es6/artifacts.snap
@@ -8,11 +8,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region y.json
-var y1 = true;
-var y2 = false;
 var y_default = {
-	y1,
-	y2
+	y1: true,
+	y2: false
 };
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
@@ -16,8 +16,7 @@ var test2_exports = /* @__PURE__ */ __export({
 	default: () => test2_default,
 	"invalid-identifier": () => invalid_identifier
 });
-var invalid_identifier = true;
-var test2_default = { "invalid-identifier": invalid_identifier };
+var test2_default = { "invalid-identifier": true };
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/loader/loader_json_prototype/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_prototype/artifacts.snap
@@ -7,7 +7,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region data.json
-var __proto__ = { "foo": "bar" };
 var data_default = {
 	"": "The property below should be converted to a computed property:",
 	["__proto__"]: __proto__

--- a/crates/rolldown/tests/esbuild/loader/loader_json_shared_with_multiple_entries_issue413/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_shared_with_multiple_entries_issue413/artifacts.snap
@@ -29,8 +29,7 @@ console.log("b:", data_default);
 
 ```js
 //#region data.json
-var test = 123;
-var data_default = { test };
+var data_default = { test: 123 };
 
 //#endregion
 export { data_default };

--- a/crates/rolldown/tests/rolldown/function/module_types/json/object_with_reserved_key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/module_types/json/object_with_reserved_key/artifacts.snap
@@ -9,8 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 //#region foo.json
-var _null = null;
-var foo_default = { "null": _null };
+var foo_default = { "null": null };
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/topics/json/preserved_key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/json/preserved_key/artifacts.snap
@@ -9,19 +9,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "assert";
 
 //#region a.json
-var _eval = true;
-var _arguments = false;
-var valid = true;
-var _let = true;
 var __let = "result";
-var _globalThis = false;
 var a_default = {
-	"eval": _eval,
-	"arguments": _arguments,
-	valid,
-	"let": _let,
+	"eval": true,
+	"arguments": false,
+	valid: true,
+	"let": true,
 	"_let": __let,
-	"globalThis": _globalThis
+	"globalThis": false
 };
 
 //#endregion
@@ -34,6 +29,7 @@ assert.deepStrictEqual(a_default, {
 	_let: "result",
 	globalThis: false
 });
+assert.strictEqual(__let, "result");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/json/preserved_key/main.js
+++ b/crates/rolldown/tests/rolldown/topics/json/preserved_key/main.js
@@ -1,12 +1,13 @@
-import assert from 'assert'
-import mod from './a.json'
-
+import assert from "assert";
+import mod, { _let } from "./a.json";
 
 assert.deepStrictEqual(mod, {
   eval: true,
   arguments: false,
   valid: true,
   let: true,
-  _let: 'result',
+  _let: "result",
   globalThis: false,
-})
+});
+
+assert.strictEqual(_let, "result");

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -1257,7 +1257,7 @@ expression: output
 
 # tests/esbuild/default/metafile_import_with_type_json
 
-- entry-!~{000}~.js => entry-FOYNJ7A8.js
+- entry-!~{000}~.js => entry-hKBp-jZT.js
 
 # tests/esbuild/default/metafile_no_bundle
 
@@ -2203,7 +2203,7 @@ expression: output
 
 # tests/esbuild/loader/loader_bundle_with_import_attributes
 
-- entry-!~{000}~.js => entry-D2KuEVij.js
+- entry-!~{000}~.js => entry-DGh9-jdq.js
 
 # tests/esbuild/loader/loader_bundle_with_type_json_only_default_export
 
@@ -2235,7 +2235,7 @@ expression: output
 
 # tests/esbuild/loader/loader_data_url_application_json
 
-- entry-!~{000}~.js => entry-CYTXagqf.js
+- entry-!~{000}~.js => entry-DxkwWC22.js
 
 # tests/esbuild/loader/loader_data_url_base64_invalid_utf8
 
@@ -2364,11 +2364,11 @@ expression: output
 
 # tests/esbuild/loader/loader_json_common_js_and_es6
 
-- entry-!~{000}~.js => entry-rPcexRV8.js
+- entry-!~{000}~.js => entry-DQtjCY_d.js
 
 # tests/esbuild/loader/loader_json_invalid_identifier_es6
 
-- entry-!~{000}~.js => entry-u_TCkpaS.js
+- entry-!~{000}~.js => entry-CMMWNBUK.js
 
 # tests/esbuild/loader/loader_json_no_bundle
 
@@ -2392,13 +2392,13 @@ expression: output
 
 # tests/esbuild/loader/loader_json_prototype
 
-- entry-!~{000}~.js => entry-DEuj-ZaU.js
+- entry-!~{000}~.js => entry-ErGDKV_-.js
 
 # tests/esbuild/loader/loader_json_shared_with_multiple_entries_issue413
 
-- a-!~{000}~.js => a-Bidc285K.js
-- b-!~{001}~.js => b-_hCXwXWb.js
-- data-!~{002}~.js => data-BMjU8Z7E.js
+- a-!~{000}~.js => a-C98attye.js
+- b-!~{001}~.js => b-Ce4gepAP.js
+- data-!~{002}~.js => data-BohhjThX.js
 
 # tests/esbuild/loader/loader_text_common_js_and_es6
 
@@ -4395,7 +4395,7 @@ expression: output
 
 # tests/rolldown/function/module_types/json/object_with_reserved_key
 
-- main-!~{000}~.js => main-DSa1gaE0.js
+- main-!~{000}~.js => main-DuL9VPap.js
 
 # tests/rolldown/function/module_types/jsx
 
@@ -5621,7 +5621,7 @@ expression: output
 
 # tests/rolldown/topics/json/preserved_key
 
-- main-!~{000}~.js => main-OvdenNcV.js
+- main-!~{000}~.js => main-DtytjKtK.js
 
 # tests/rolldown/topics/keep_names/declaration
 

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -112,6 +112,8 @@ pub struct EcmaView {
   pub hmr_info: HmrInfo,
   pub constant_export_map: FxHashMap<SymbolId, ConstExportMeta>,
   pub import_attribute_map: FxHashMap<ImportRecordIdx, ImportAttribute>,
+  /// Use `Box` since it is rarely used also it could reduce the size of `EcmaView`, .
+  pub json_module_none_self_reference_included_symbol: Option<Box<FxHashSet<SymbolRef>>>,
 }
 
 bitflags! {


### PR DESCRIPTION
This pr aligns with the esbuild json top-level property inlining.e.g.
**esbuild**
https://hyrious.me/esbuild-repl/?version=0.23.0&b=e%00entry.js%00import+json+from+%27.%2Fa.json%27%3B%0A%2F%2F+import+%7B+Entity%2C+PrimaryKey+%7D+from+%27%40mikro-orm%2Flibsql%27%3B%0Aconsole.log%28a%29%0A%2F%2F+%40Entity%28%29%0Aclass+Message+%7B%0A++%2F%2F+%40PrimaryKey%28%29%0A++id%3B%0A%0A++constructor%28id%29+%7B%0A++++this.id+%3D+id%3B%0A++%7D%0A%0A++toString%28%29+%7B%0A++++return+this.id.toString%28%29%3B%0A++%7D%0A%7D%0A%0Aconst+y+%3D+new+Message%281%29%3B%0Aconsole.log%28y.toString%28%29%29%3B%0Aconsole.log%28json.Message+%2B+y.toString%28%29%29%3B%0A&b=%00a.json%00%7B%0A++%22Message%22%3A+1%2C%0A++%22a%22%3A+2000%0A%7D%0A&o=%7B%0A++treeShaking%3A+true%2C%0A++external%3A+%5B%22c%22%2C+%22a%22%2C+%22b%22%5D%2C%0A%22bundle%22%3A+true%2C%0Aformat%3A+%22esm%22%0A%7D

**latest rolldown**


https://repl.rolldown.rs/#eNptUstOwzAQ/JWVL02hdVPgFFRUCXFCiAqOlIObOMHg2MF22kZR/h0775bevNmZ2dnZlChGQYmYiOgRG+3eAgVDPUOhK9NMKgPfWgqIlUxhghcEu3JyvxWLBbSAEp6EYaaYwUaxlKjimRZQtZR1yn6UnEuVLjjb6V/uuKEUWnKKuUw8Mq211o2GZ6uQE63hhWpNEgrlVgA4wCDuQAAsskru4dSMykMjlceiacMAMF9MYxbBqkECVA3cyHejmEi8HqmoyZXoCHgAdLSaWY+BwuoJeujseUsHGu9TjPjnPZcd7ha7hnOozZ2iwK5CqxlSkvNIHgS2AjFLRme60Dk5mCkyGxu8tbDXzDDrob9IR5/AsFWjFPzjrFxE7f70WKtHNCY57yjIOs14njDxKIUhTFA1cnqhc+L0CogG5yfP/JG7PJv04/ZEwaaXoUdjPX3Y060eOuKnDc66aP7MbnJbNdPqM29RG/wWBbCcNZ+IK2583693RJXV2VvCEvvYn++oIfjuFlV/lCET4Q==

This optimization could somehow reduce the naming conflication and output size.

Closed https://github.com/rolldown/rolldown/issues/6097