### PR TITLE
refactor(rust/binding): use `&str` or `JsString` to avoid unnecessary clone

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools;
+use napi::Env;
 use napi_derive::napi;
 use sugar_path::SugarPath;
 
@@ -60,33 +62,45 @@ impl BindingPluginContext {
       .ok();
 
     Ok(ret.map(|info| BindingPluginContextResolvedId {
+      // TODO: should use `&str` instead. (claude code) Attempt failed due to NAPI object field must be String type
       id: info.id.to_string(),
       external: info.external.into(),
       module_side_effects: info.side_effects.map(Into::into),
+      // TODO: should use `&str` instead. (claude code) Attempt failed due to PathBuf conversion requires to_string_lossy()
       package_json_path:
         info.package_json.map(|item| item.realpath().to_string_lossy().to_string()),
     }))
   }
 
   #[napi]
-  pub fn emit_file(
+  pub fn emit_file<'env>(
     &self,
+    env: &'env Env,
     file: BindingEmittedAsset,
     asset_filename: Option<String>,
     fn_sanitized_file_name: Option<String>,
-  ) -> String {
-    self.inner.emit_file(file.into(), asset_filename, fn_sanitized_file_name).to_string()
+  ) -> napi::Result<napi::JsString<'env>> {
+    env.create_string(self.inner.emit_file(file.into(), asset_filename, fn_sanitized_file_name))
   }
 
   #[napi]
-  pub fn emit_chunk(&self, file: BindingEmittedChunk) -> anyhow::Result<String> {
-    napi::bindgen_prelude::block_on(self.inner.emit_chunk(file.try_into()?))
-      .map(|id| id.to_string())
+  pub fn emit_chunk<'env>(
+    &self,
+    env: &'env Env,
+    file: BindingEmittedChunk,
+  ) -> napi::Result<napi::JsString<'env>> {
+    let arc_str = napi::bindgen_prelude::block_on(self.inner.emit_chunk(file.try_into()?))?;
+    env.create_string(arc_str)
   }
 
   #[napi]
-  pub fn get_file_name(&self, reference_id: String) -> anyhow::Result<String> {
-    self.inner.get_file_name(reference_id.as_str()).map(|id| id.to_string())
+  pub fn get_file_name<'env>(
+    &self,
+    env: &'env Env,
+    reference_id: String,
+  ) -> napi::Result<napi::JsString<'env>> {
+    let arc_str = self.inner.get_file_name(reference_id.as_str())?;
+    env.create_string(arc_str)
   }
 
   #[napi]
@@ -95,8 +109,8 @@ impl BindingPluginContext {
   }
 
   #[napi]
-  pub fn get_module_ids(&self) -> Vec<String> {
-    self.inner.get_module_ids()
+  pub fn get_module_ids<'env>(&self, env: &'env Env) -> napi::Result<Vec<napi::JsString<'env>>> {
+    self.inner.get_module_ids().iter().map(|id| env.create_string(id)).try_collect()
   }
 
   #[napi]

--- a/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
@@ -17,7 +17,7 @@ impl BindingTransformPluginContext {
   }
 
   #[napi]
-  // TODO: claude code - Cannot change to &str: performs JSON serialization to generate new String
+  // TODO: should use `&str` instead. (claude code) Attempt failed due to performs JSON serialization to generate new String
   pub fn get_combined_sourcemap(&self) -> String {
     self.inner.get_combined_sourcemap().to_json_string()
   }

--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -102,7 +102,7 @@ impl BindingMagicString<'_> {
   }
 
   #[napi]
-  // TODO: claude code - Cannot change to &str: generates new String from MagicString internal representation
+  // TODO: should use `&str` instead. (claude code) Attempt failed due to generates new String from MagicString internal representation
   pub fn to_string(&self) -> String {
     self.inner.to_string()
   }

--- a/crates/rolldown_binding/src/types/binding_normalized_options.rs
+++ b/crates/rolldown_binding/src/types/binding_normalized_options.rs
@@ -77,41 +77,41 @@ impl BindingNormalizedOptions {
   // Some options can be set to `None`, and these values are converted to `null` in JavaScript.
   // To distinguish them from regular None values, `undefined` is used to represent unsupported functions
   #[napi(getter)]
-  pub fn css_entry_filenames(&self) -> Either<String, Undefined> {
+  pub fn css_entry_filenames(&self) -> Either<&str, Undefined> {
     match &self.inner.css_entry_filenames {
-      rolldown::ChunkFilenamesOutputOption::String(inner) => Either::A(inner.clone()),
+      rolldown::ChunkFilenamesOutputOption::String(inner) => Either::A(inner),
       rolldown::ChunkFilenamesOutputOption::Fn(_) => Either::B(()),
     }
   }
 
   #[napi(getter)]
-  pub fn css_chunk_filenames(&self) -> Either<String, Undefined> {
+  pub fn css_chunk_filenames(&self) -> Either<&str, Undefined> {
     match &self.inner.css_chunk_filenames {
-      rolldown::ChunkFilenamesOutputOption::String(inner) => Either::A(inner.clone()),
+      rolldown::ChunkFilenamesOutputOption::String(inner) => Either::A(inner),
       rolldown::ChunkFilenamesOutputOption::Fn(_) => Either::B(()),
     }
   }
 
   #[napi(getter)]
-  pub fn entry_filenames(&self) -> Either<String, Undefined> {
+  pub fn entry_filenames(&self) -> Either<&str, Undefined> {
     match &self.inner.entry_filenames {
-      rolldown::ChunkFilenamesOutputOption::String(inner) => Either::A(inner.clone()),
+      rolldown::ChunkFilenamesOutputOption::String(inner) => Either::A(inner),
       rolldown::ChunkFilenamesOutputOption::Fn(_) => Either::B(()),
     }
   }
 
   #[napi(getter)]
-  pub fn chunk_filenames(&self) -> Either<String, Undefined> {
+  pub fn chunk_filenames(&self) -> Either<&str, Undefined> {
     match &self.inner.chunk_filenames {
-      rolldown::ChunkFilenamesOutputOption::String(inner) => Either::A(inner.clone()),
+      rolldown::ChunkFilenamesOutputOption::String(inner) => Either::A(inner),
       rolldown::ChunkFilenamesOutputOption::Fn(_) => Either::B(()),
     }
   }
 
   #[napi(getter)]
-  pub fn asset_filenames(&self) -> Either<String, Undefined> {
+  pub fn asset_filenames(&self) -> Either<&str, Undefined> {
     match &self.inner.asset_filenames {
-      rolldown::AssetFilenamesOutputOption::String(inner) => Either::A(inner.clone()),
+      rolldown::AssetFilenamesOutputOption::String(inner) => Either::A(inner),
       rolldown::AssetFilenamesOutputOption::Fn(_) => Either::B(()),
     }
   }
@@ -147,11 +147,11 @@ impl BindingNormalizedOptions {
   }
 
   #[napi(getter, ts_return_type = "boolean | 'if-default-prop'")]
-  pub fn es_module(&self) -> Either<bool, String> {
+  pub fn es_module(&self) -> Either<bool, &'static str> {
     match self.inner.es_module {
       rolldown::EsModuleFlag::Always => Either::A(true),
       rolldown::EsModuleFlag::Never => Either::A(false),
-      rolldown::EsModuleFlag::IfDefaultProp => Either::B("if-default-prop".to_string()),
+      rolldown::EsModuleFlag::IfDefaultProp => Either::B("if-default-prop"),
     }
   }
 
@@ -161,51 +161,51 @@ impl BindingNormalizedOptions {
   }
 
   #[napi(getter, ts_return_type = "boolean | 'inline' | 'hidden'")]
-  pub fn sourcemap(&self) -> Either<bool, String> {
+  pub fn sourcemap(&self) -> Either<bool, &'static str> {
     match self.inner.sourcemap {
       Some(rolldown::SourceMapType::File) => Either::A(true),
-      Some(rolldown::SourceMapType::Hidden) => Either::B("hidden".to_string()),
-      Some(rolldown::SourceMapType::Inline) => Either::B("inline".to_string()),
+      Some(rolldown::SourceMapType::Hidden) => Either::B("hidden"),
+      Some(rolldown::SourceMapType::Inline) => Either::B("inline"),
       None => Either::A(false),
     }
   }
 
   #[napi(getter)]
-  pub fn sourcemap_base_url(&self) -> Option<String> {
-    self.inner.sourcemap_base_url.clone()
+  pub fn sourcemap_base_url(&self) -> Option<&str> {
+    self.inner.sourcemap_base_url.as_deref()
   }
 
   #[napi(getter)]
-  pub fn banner(&self) -> Either<Option<String>, Undefined> {
+  pub fn banner(&self) -> Either<Option<&str>, Undefined> {
     match &self.inner.banner {
-      Some(rolldown::AddonOutputOption::String(inner)) => Either::A(inner.clone()),
+      Some(rolldown::AddonOutputOption::String(inner)) => Either::A(inner.as_deref()),
       Some(rolldown::AddonOutputOption::Fn(_)) => Either::B(()),
       None => Either::A(None),
     }
   }
 
   #[napi(getter)]
-  pub fn footer(&self) -> Either<Option<String>, Undefined> {
+  pub fn footer(&self) -> Either<Option<&str>, Undefined> {
     match &self.inner.footer {
-      Some(rolldown::AddonOutputOption::String(inner)) => Either::A(inner.clone()),
+      Some(rolldown::AddonOutputOption::String(inner)) => Either::A(inner.as_deref()),
       Some(rolldown::AddonOutputOption::Fn(_)) => Either::B(()),
       None => Either::A(None),
     }
   }
 
   #[napi(getter)]
-  pub fn intro(&self) -> Either<Option<String>, Undefined> {
+  pub fn intro(&self) -> Either<Option<&str>, Undefined> {
     match &self.inner.intro {
-      Some(rolldown::AddonOutputOption::String(inner)) => Either::A(inner.clone()),
+      Some(rolldown::AddonOutputOption::String(inner)) => Either::A(inner.as_deref()),
       Some(rolldown::AddonOutputOption::Fn(_)) => Either::B(()),
       None => Either::A(None),
     }
   }
 
   #[napi(getter)]
-  pub fn outro(&self) -> Either<Option<String>, Undefined> {
+  pub fn outro(&self) -> Either<Option<&str>, Undefined> {
     match &self.inner.outro {
-      Some(rolldown::AddonOutputOption::String(inner)) => Either::A(inner.clone()),
+      Some(rolldown::AddonOutputOption::String(inner)) => Either::A(inner.as_deref()),
       Some(rolldown::AddonOutputOption::Fn(_)) => Either::B(()),
       None => Either::A(None),
     }
@@ -249,10 +249,10 @@ impl BindingNormalizedOptions {
   }
 
   #[napi(getter, ts_return_type = "false | 'dce-only' | MinifyOptions")]
-  pub fn minify(&self) -> Either3<bool, String, oxc_minify_napi::MinifyOptions> {
+  pub fn minify(&self) -> Either3<bool, &'static str, oxc_minify_napi::MinifyOptions> {
     match &self.inner.minify {
       MinifyOptions::Disabled => Either3::A(false),
-      MinifyOptions::DeadCodeEliminationOnly => Either3::B("dce-only".to_string()),
+      MinifyOptions::DeadCodeEliminationOnly => Either3::B("dce-only"),
       MinifyOptions::Enabled((minify_options, remove_whitespace)) => {
         Either3::C(oxc_minify_napi::MinifyOptions {
           compress: minify_options
@@ -284,8 +284,8 @@ impl BindingNormalizedOptions {
   }
 
   #[napi(getter, ts_return_type = "string | undefined")]
-  pub fn preserve_modules_root(&self) -> Option<String> {
-    self.inner.preserve_modules_root.clone()
+  pub fn preserve_modules_root(&self) -> Option<&str> {
+    self.inner.preserve_modules_root.as_deref()
   }
 
   #[napi(getter)]
@@ -304,13 +304,12 @@ impl BindingNormalizedOptions {
   }
 
   #[napi(getter)]
-  // TODO: claude code - Cannot change to &str: returns computed literal "void 0" or clones String field based on condition
-  pub fn context(&self) -> String {
+  pub fn context(&self) -> &str {
     // https://github.com/rolldown/rolldown/issues/5671
     if self.inner.context.is_empty() {
-      return "void 0".into();
+      return "void 0";
     }
 
-    self.inner.context.clone()
+    &self.inner.context
   }
 }

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -155,8 +155,8 @@ impl NativePluginContextImpl {
     self.modules.get(module_id).map(|v| Arc::<rolldown_common::ModuleInfo>::clone(v.value()))
   }
 
-  pub fn get_module_ids(&self) -> Vec<String> {
-    self.modules.iter().map(|v| v.key().to_string()).collect()
+  pub fn get_module_ids(&self) -> Vec<ArcStr> {
+    self.modules.iter().map(|v| v.key().clone()).collect()
   }
 
   pub fn cwd(&self) -> &PathBuf {

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
@@ -111,7 +111,7 @@ impl PluginContext {
     call_native_only!(self, "get_module_info", ctx => ctx.get_module_info(module_id))
   }
 
-  pub fn get_module_ids(&self) -> Vec<String> {
+  pub fn get_module_ids(&self) -> Vec<ArcStr> {
     call_native_only!(self, "get_module_ids", ctx => ctx.get_module_ids())
   }
 


### PR DESCRIPTION
There are places which are indeed improper to use `&str`​. Thoese todos will be removed after investigation.