### PR TITLE
test(vite-tests): fix rolldown overrides

### DIFF
--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -52,7 +52,7 @@ printTitle('# Updating pnpm-workspace.yaml to link to local rolldown...');
 const pnpmWorkspace = path.resolve(REPO_PATH, 'pnpm-workspace.yaml');
 const pnpmWorkspaceYaml = fs.readFileSync(pnpmWorkspace, 'utf-8');
 const newPnpmWorkspaceYaml = pnpmWorkspaceYaml.replace(
-  /overrides:\n/,
+  /overrides:\n\s*rolldown:\s*\$rolldown\n/,
   `overrides:\n${OVERRIDES.join('\n')}\n`
 );
 fs.writeFileSync(pnpmWorkspace, newPnpmWorkspaceYaml, 'utf-8');


### PR DESCRIPTION
Vite's repo now has `rolldown: $rolldown` in `pnpm-workspace.yaml` and vite-tests failed because of that.
