### PR TITLE
fix(rolldown): sync scoping properly in pre_process_ecma_ast

### DIFF
--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -1,10 +1,11 @@
 use std::path::Path;
 
 use itertools::Itertools;
+use oxc::ast::ast::Program;
 use oxc::ast_visit::VisitMut;
 use oxc::diagnostics::Severity as OxcSeverity;
 use oxc::minifier::{CompressOptions, Compressor, TreeShakeOptions};
-use oxc::semantic::{SemanticBuilder, Stats};
+use oxc::semantic::{Scoping, SemanticBuilder, Stats};
 use oxc::transformer::Transformer;
 use oxc::transformer_plugins::{
   InjectGlobalVariables, ReplaceGlobalDefines, ReplaceGlobalDefinesConfig,
@@ -21,9 +22,6 @@ use super::tweak_ast_for_scanning::PreProcessor;
 
 #[derive(Default)]
 pub struct PreProcessEcmaAst {
-  /// Only recreate semantic data if ast is changed.
-  ast_changed: bool,
-
   /// Semantic statistics.
   stats: Stats,
 }
@@ -39,13 +37,14 @@ impl PreProcessEcmaAst {
     has_lazy_export: bool,
   ) -> BuildResult<ParseToEcmaAstResult> {
     let source = ast.source().clone();
-    // Build initial semantic data and check for semantic errors.
-    let semantic_ret = ast.program.with_mut(|WithMutFields { program, .. }| {
-      SemanticBuilder::new().with_check_syntax_error(true).build(program)
+    // Step 1: Build initial semantic data and check for semantic errors.
+    let semantic_ret = ast.program.with_dependent(|_owner, dep| {
+      SemanticBuilder::new().with_check_syntax_error(true).build(&dep.program)
     });
 
     let (errors, warnings): (Vec<_>, Vec<_>) =
       semantic_ret.errors.into_iter().partition(|w| w.severity == OxcSeverity::Error);
+
     let warnings = if errors.is_empty() {
       BuildDiagnostic::from_oxc_diagnostics(warnings, &source, path, &Severity::Warning)
     } else {
@@ -53,100 +52,101 @@ impl PreProcessEcmaAst {
     };
 
     self.stats = semantic_ret.semantic.stats();
-    let scoping = semantic_ret.semantic.into_scoping();
+    let mut scoping = Some(semantic_ret.semantic.into_scoping());
 
-    let mut scoping = ast.program.with_mut(|fields| {
-      let WithMutFields { allocator, program, .. } = fields;
-      // Use built-in define plugin.
-      if let Some(replace_global_define_config) = replace_global_define_config {
+    // Step 2: Run define plugin.
+    if let Some(replace_global_define_config) = replace_global_define_config {
+      ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
         let ret = ReplaceGlobalDefines::new(allocator, replace_global_define_config.clone())
-          .build(scoping, program);
-        self.ast_changed = true;
-        ret.scoping
-      } else {
-        scoping
-      }
-    });
-    // Transform TypeScript and jsx.
+          .build(scoping.take().unwrap(), program);
+        if !ret.changed {
+          scoping = Some(ret.scoping);
+        }
+      });
+    }
+
+    // Step 3: Transform TypeScript and jsx.
     // Note: Currently, oxc_transform supports es syntax up to ES2024 (unicode-sets-regex).
     if !matches!(parsed_type, OxcParseType::Js)
       || bundle_options.transform_options.env.regexp.set_notation
     {
-      let ret = ast.program.with_mut(|fields| {
+      ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
         let transform_options = &bundle_options.transform_options;
-
-        Transformer::new(fields.allocator, Path::new(path), transform_options)
-          .build_with_scoping(scoping, fields.program)
-      });
-
-      // TODO: emit diagnostic, aiming to pass more tests,
-      // we ignore warning for now
-      let errors = ret
-        .errors
-        .into_iter()
-        .filter(|item| matches!(item.severity, OxcSeverity::Error))
-        .collect_vec();
-      if !errors.is_empty() {
-        Err(BuildDiagnostic::from_oxc_diagnostics(errors, &source, path, &Severity::Error))?;
-      }
-
-      scoping = ret.scoping;
-      self.ast_changed = true;
+        let scoping = self.recreate_scoping(&mut scoping, program, false);
+        let ret = Transformer::new(allocator, Path::new(path), transform_options)
+          .build_with_scoping(scoping, program);
+        // TODO: emit diagnostic, aiming to pass more tests,
+        // we ignore warning for now
+        if ret.errors.iter().any(|error| error.severity == OxcSeverity::Error) {
+          let errors = ret
+            .errors
+            .into_iter()
+            .filter(|item| matches!(item.severity, OxcSeverity::Error))
+            .collect_vec();
+          return Err(BuildDiagnostic::from_oxc_diagnostics(
+            errors,
+            &source,
+            path,
+            &Severity::Error,
+          ));
+        }
+        Ok(())
+      })?;
     }
 
-    ast.program.with_mut(|fields| {
-      let WithMutFields { allocator, program, .. } = fields;
+    // Step 4: Run inject plugin.
+    if !bundle_options.inject.is_empty() {
+      ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
+        let new_scoping = self.recreate_scoping(&mut scoping, program, false);
+        let inject_config = bundle_options.oxc_inject_global_variables_config.clone();
+        let ret = InjectGlobalVariables::new(allocator, inject_config).build(new_scoping, program);
+        if !ret.changed {
+          scoping = Some(ret.scoping);
+        }
+      });
+    }
 
-      if !bundle_options.inject.is_empty() {
-        // if the define replace something, we need to recreate the semantic data.
-        // to correct the `root_unresolved_references`
-        // https://github.com/oxc-project/oxc/blob/0136431b31a1d4cc20147eb085d9314b224cc092/crates/oxc_transformer/src/plugins/inject_global_variables.rs#L184-L184
-        // TODO: real ast_changed hint
-        let semantic_ret = SemanticBuilder::new().with_stats(self.stats).build(program);
-        scoping = semantic_ret.semantic.into_scoping();
-        let ret = InjectGlobalVariables::new(
-          allocator,
-          bundle_options.oxc_inject_global_variables_config.clone(),
-        )
-        .build(scoping, program);
-        scoping = ret.scoping;
-        self.ast_changed = true;
-      }
-
-      // avoid DCE for lazy export
-      if bundle_options.treeshake.is_some() && !has_lazy_export {
-        // Perform dead code elimination.
+    // Step 5: Run DCE.
+    // Avoid DCE for lazy export.
+    if bundle_options.treeshake.is_some() && !has_lazy_export {
+      ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
+        let scoping = self.recreate_scoping(&mut scoping, program, false);
         // NOTE: `CompressOptions::dead_code_elimination` will remove `ParenthesizedExpression`s from the AST.
         let options = CompressOptions {
           treeshake: TreeShakeOptions::from(&bundle_options.treeshake),
           ..CompressOptions::dce()
         };
-        let compressor = Compressor::new(allocator);
-        if self.ast_changed {
-          let semantic_ret = SemanticBuilder::new().with_stats(self.stats).build(program);
-          scoping = semantic_ret.semantic.into_scoping();
-        }
-        compressor.dead_code_elimination_with_scoping(program, scoping, options);
-      }
-    });
+        Compressor::new(allocator).dead_code_elimination_with_scoping(program, scoping, options);
+      });
+    }
 
-    ast.program.with_mut(|fields| {
-      let mut pre_processor = PreProcessor::new(fields.allocator, bundle_options.keep_names);
-      pre_processor.visit_program(fields.program);
-    });
-
-    // NOTE: Recreate semantic data because AST is changed in the transformations above.
-    let scoping = ast.program.with_dependent(|_owner, dep| {
-      SemanticBuilder::new()
-        // Required by `module.scope.get_child_ids` in `crates/rolldown/src/utils/renamer.rs`.
-        .with_scope_tree_child_ids(true)
-        // Preallocate memory for the underlying data structures.
-        .with_stats(self.stats)
-        .build(&dep.program)
-        .semantic
-        .into_scoping()
+    // Step 6: Modify AST for Rolldown.
+    let scoping = ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
+      let mut pre_processor = PreProcessor::new(allocator, bundle_options.keep_names);
+      pre_processor.visit_program(program);
+      self.recreate_scoping(&mut None, program, true)
     });
 
     Ok(ParseToEcmaAstResult { ast, scoping, has_lazy_export, warnings })
+  }
+
+  fn recreate_scoping(
+    &mut self,
+    scoping: &mut Option<Scoping>,
+    program: &Program<'_>,
+    with_scope_tree_child_ids: bool,
+  ) -> Scoping {
+    if let Some(scoping) = scoping.take() {
+      return scoping;
+    }
+    let ret = SemanticBuilder::new()
+      // Required by `module.scope.get_child_ids` in `crates/rolldown/src/utils/renamer.rs`.
+      .with_scope_tree_child_ids(with_scope_tree_child_ids)
+      // Preallocate memory for the underlying data structures.
+      .with_stats(self.stats)
+      .build(program)
+      .semantic;
+    self.stats = ret.stats();
+    ret.into_scoping()
   }
 }

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_446/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_446/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "transform": {
+      "target": "es2018"
+    },
+    "define": {
+      "import.meta.env.VITE_AUTH_URL": "foo"
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_446/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_446/artifacts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+var _window$settings;
+const foo = "foo";
+const authURL = foo !== null && foo !== void 0 ? foo : (_window$settings = window.settings) === null || _window$settings === void 0 ? void 0 : _window$settings.authURL;
+
+//#endregion
+export { authURL };
+```

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_446/main.js
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_446/main.js
@@ -1,0 +1,3 @@
+const foo = "foo";
+
+export const authURL = import.meta.env.VITE_AUTH_URL ?? window.settings?.authURL;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4797,6 +4797,10 @@ expression: output
 
 - main-!~{000}~.js => main-Bldhf8JA.js
 
+# tests/rolldown/issues/rolldown_vite_446
+
+- main-!~{000}~.js => main-h6-DlyQZ.js
+
 # tests/rolldown/misc/ambiguous_star_export
 
 - main-!~{000}~.js => main-Brk4weCb.js


### PR DESCRIPTION
We need to recreate scoping after each transformation step because none of the steps syncs scoping at present, which is a huge waste that we should fix later in the future.

But in the interim, `define` and `inject` plugins now return a `changed` flag for whether AST has been changed, which is used to skip recreating scoping.
Previously it was recreating semantic even if `define` plugin didn't change anything.
And define plugin is always provided by the value `process.env.NODE_ENV: development`.

This gives us a 5 - 10% performance improvement.

I took the opportunity to refactor the code to make it more consistent.

Fixes https://github.com/vitejs/rolldown-vite/issues/446