### PR TITLE
perf(rolldown): reduce allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,15 +1347,6 @@ dependencies = [
 
 [[package]]
 name = "json-escape-simd"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1f7d5786a4cb0f4e0f862b562a0e085b5bfa23a4f0dc05e7b823ed4e4d791f"
-dependencies = [
- "anyhow",
-]
-
-[[package]]
-name = "json-escape-simd"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3c2a6c0b4b5637c41719973ef40c6a1cf564f9db6958350de6193fbee9c23f5"
@@ -2288,7 +2279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bd56ed0ec53da593c43d9ea65ced157fe319e454888eb65b239a275e3696499"
 dependencies = [
  "base64-simd",
- "json-escape-simd 3.0.1",
+ "json-escape-simd",
  "napi",
  "napi-build",
  "napi-derive",
@@ -2776,7 +2767,7 @@ dependencies = [
  "insta",
  "itertools",
  "itoa",
- "json-escape-simd 1.1.0",
+ "json-escape-simd",
  "memchr",
  "notify",
  "oxc",
@@ -2808,6 +2799,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "simdutf8",
  "string_wizard",
  "sugar_path",
  "testing_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ infer = "0.19.0"
 insta = "1.43.1"
 itertools = "0.14.0"
 itoa = "1.0.15"
-json-escape-simd = "1.1"
+json-escape-simd = "3"
 json-strip-comments = "3"
 jsonschema = { version = "0.33.0", default-features = false }
 memchr = "2.7.4"

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -62,6 +62,7 @@ rolldown_watcher = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true }
+simdutf8 = { workspace = true }
 string_wizard = { workspace = true }
 sugar_path = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }

--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -98,7 +98,7 @@ pub fn render_cjs<'code>(
 
 // Make sure the imports generate stmts keep live bindings.
 fn render_cjs_chunk_imports(ctx: &GenerateContext<'_>) -> String {
-  let mut s = String::new();
+  let mut s = String::with_capacity(128);
 
   // render imports from other chunks
   ctx.chunk.imports_from_other_chunks.iter().for_each(|(exporter_id, items)| {

--- a/crates/rolldown/src/ecmascript/format/utils/mod.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/mod.rs
@@ -25,7 +25,7 @@ pub fn render_factory_parameters(
 pub fn render_chunk_external_imports<'a>(
   ctx: &'a GenerateContext<'_>,
 ) -> (String, Vec<&'a ExternalModule>) {
-  let mut import_code = String::new();
+  let mut import_code = String::with_capacity(128);
 
   let externals = ctx
     .chunk
@@ -99,7 +99,7 @@ pub fn render_modules_with_peek_runtime_module_at_first<'a>(
 }
 
 pub fn render_chunk_directives<'a, T: Iterator<Item = &'a &'a str>>(directives: T) -> String {
-  let mut ret = String::new();
+  let mut ret = String::with_capacity(128);
   for d in directives {
     ret.push_str(d);
     if (d).ends_with(';') {

--- a/crates/rolldown/src/ecmascript/format/utils/namespace.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/namespace.rs
@@ -38,7 +38,7 @@ pub fn generate_namespace_definition(
   delimiter: &str,
 ) -> (String, String) {
   let parts: Vec<&str> = name.split('.').collect();
-  let mut stmts = String::new();
+  let mut stmts = String::with_capacity(128);
   let mut namespace = String::from(global);
   let global_len = global.len();
 

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -318,7 +318,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     if !should_hoist {
       return None;
     }
-    let mut ret = vec![];
+    let mut ret = Vec::with_capacity(decl.declarations.len() * 2);
     let exprs = decl.declarations.iter_mut().filter_map(|var_decl| {
       ret.extend(var_decl.id.binding_identifiers().iter().map(|item| item.name));
       // Turn `var ... = ...` to `... = ...`

--- a/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
+++ b/crates/rolldown/src/stages/generate_stage/on_demand_wrapping.rs
@@ -149,7 +149,7 @@ impl GenerateStage<'_> {
         root_only.insert(*module_idx);
       }
     }
-    let mut module_groups = vec![];
+    let mut module_groups = Vec::with_capacity(chunk.modules.len());
     let mut module_idx_to_group_idx = FxHashMap::default();
     // higher exec_order usually means module is more closed to entry point
     // lower exec_order means module is more closed to the leaf node of the chunk.

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -98,7 +98,7 @@ pub fn render_chunk_exports(
       if export_items.is_empty() && !matches!(ctx.options.platform, Platform::Node) {
         return None;
       }
-      let mut s = String::new();
+      let mut s = String::with_capacity(128);
       let rendered_items = export_items
         .into_iter()
         .map(|(exported_name, export_ref)| {
@@ -139,7 +139,7 @@ pub fn render_chunk_exports(
       Some(s)
     }
     OutputFormat::Cjs | OutputFormat::Iife | OutputFormat::Umd => {
-      let mut s = String::new();
+      let mut s = String::with_capacity(128);
       match chunk.kind {
         ChunkKind::EntryPoint { module, .. } => {
           let module =

--- a/crates/rolldown/src/utils/transform_source.rs
+++ b/crates/rolldown/src/utils/transform_source.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::mpsc::Sender;
 
 use anyhow::Result;
+use arcstr::ArcStr;
 use rolldown_common::ModuleType;
 use rolldown_common::SourceMapGenMsg;
 use rolldown_common::{
@@ -16,12 +17,12 @@ pub async fn transform_source(
   plugin_driver: &PluginDriver,
   resolved_id: &ResolvedId,
   module_idx: ModuleIdx,
-  source: String,
+  source: ArcStr,
   sourcemap_chain: &mut Vec<SourcemapChainElement>,
   side_effects: &mut Option<HookSideEffects>,
   module_type: &mut ModuleType,
   magic_string_tx: Option<Arc<Sender<SourceMapGenMsg>>>,
-) -> Result<String> {
+) -> Result<ArcStr> {
   plugin_driver
     .transform(
       &resolved_id.id,

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -123,7 +123,7 @@ pub fn update_output_chunk(
 ) -> anyhow::Result<()> {
   let old_chunk = (**chunk).clone();
   *chunk = Arc::new(rolldown_common::OutputChunk {
-    code: js_chunk.code,
+    code: js_chunk.code.into(),
     map: js_chunk.map.map(TryInto::try_into).transpose()?,
     imports: js_chunk.imports.into_iter().map(Into::into).collect(),
     dynamic_imports: js_chunk.dynamic_imports.into_iter().map(Into::into).collect(),

--- a/crates/rolldown_common/src/inner_bundler_options/types/hash_characters.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/hash_characters.rs
@@ -18,7 +18,7 @@ pub enum HashCharacters {
 }
 
 impl HashCharacters {
-  pub fn base(&self) -> u8 {
+  pub const fn base(&self) -> u8 {
     match self {
       HashCharacters::Base64 => 64,
       HashCharacters::Base36 => 36,

--- a/crates/rolldown_common/src/types/hybrid_index_vec.rs
+++ b/crates/rolldown_common/src/types/hybrid_index_vec.rs
@@ -92,4 +92,18 @@ impl<I: Idx, T> HybridIndexVec<I, T> {
       HybridIndexVec::Map(hash_map) => itertools::Either::Right(hash_map.values()),
     }
   }
+
+  pub fn len(&self) -> usize {
+    match self {
+      HybridIndexVec::IndexVec(index_vec) => index_vec.len(),
+      HybridIndexVec::Map(hash_map) => hash_map.len(),
+    }
+  }
+
+  pub fn is_empty(&self) -> bool {
+    match self {
+      HybridIndexVec::IndexVec(index_vec) => index_vec.is_empty(),
+      HybridIndexVec::Map(hash_map) => hash_map.is_empty(),
+    }
+  }
 }

--- a/crates/rolldown_common/src/types/output_chunk.rs
+++ b/crates/rolldown_common/src/types/output_chunk.rs
@@ -24,7 +24,7 @@ pub struct OutputChunk {
   pub imports: Vec<ArcStr>,
   pub dynamic_imports: Vec<ArcStr>,
   // OutputChunk
-  pub code: String,
+  pub code: ArcStr,
   pub map: Option<SourceMap>,
   pub sourcemap_filename: Option<String>,
   pub preliminary_filename: String,

--- a/crates/rolldown_common/src/types/str_or_bytes.rs
+++ b/crates/rolldown_common/src/types/str_or_bytes.rs
@@ -1,9 +1,13 @@
 use std::fmt::Debug;
 
+use arcstr::ArcStr;
+
 #[derive(Clone, Debug)]
 pub enum StrOrBytes {
+  ArcStr(ArcStr),
   Str(String),
-  Bytes(Vec<u8>),
+  // The second field is used to indicate whether the bytes have been validated as utf8
+  Bytes(Vec<u8>, bool),
 }
 
 impl Default for StrOrBytes {
@@ -16,16 +20,20 @@ impl StrOrBytes {
   pub fn try_into_inner_string(self) -> anyhow::Result<String> {
     match self {
       Self::Str(s) => Ok(s),
-      Self::Bytes(_) => Err(anyhow::format_err!("Expected Str, found Bytes")),
+      Self::ArcStr(s) => Ok(s.to_string()),
+      Self::Bytes(..) => Err(anyhow::format_err!("Expected Str, found Bytes")),
     }
   }
 
   pub fn try_into_string(self) -> anyhow::Result<String> {
     match self {
       Self::Str(s) => Ok(s),
-      Self::Bytes(b) => {
-        // validate utf8
-        simdutf8::basic::from_utf8(&b)?;
+      Self::ArcStr(s) => Ok(s.to_string()),
+      Self::Bytes(b, valid) => {
+        if !valid {
+          // validate utf8
+          simdutf8::basic::from_utf8(&b)?;
+        }
         // SAFETY: `b` is valid utf8
         unsafe { Ok(String::from_utf8_unchecked(b)) }
       }
@@ -35,14 +43,24 @@ impl StrOrBytes {
   pub fn as_bytes(&self) -> &[u8] {
     match self {
       Self::Str(s) => s.as_bytes(),
-      Self::Bytes(b) => b.as_slice(),
+      Self::ArcStr(s) => s.as_bytes(),
+      Self::Bytes(b, _) => b.as_slice(),
     }
   }
 
   pub fn try_as_inner_str(&self) -> anyhow::Result<&str> {
     match self {
       Self::Str(s) => Ok(s.as_str()),
-      Self::Bytes(_) => Err(anyhow::format_err!("Expected Str, found Bytes")),
+      Self::ArcStr(s) => Ok(s.as_str()),
+      Self::Bytes(..) => Err(anyhow::format_err!("Expected Str, found Bytes")),
+    }
+  }
+
+  pub fn to_str(&self) -> Option<&str> {
+    match self {
+      Self::Str(s) => Some(s.as_str()),
+      Self::ArcStr(s) => Some(s.as_str()),
+      Self::Bytes(..) => None,
     }
   }
 }
@@ -55,6 +73,6 @@ impl From<String> for StrOrBytes {
 
 impl From<Vec<u8>> for StrOrBytes {
   fn from(b: Vec<u8>) -> Self {
-    Self::Bytes(b)
+    Self::Bytes(b, false)
   }
 }

--- a/crates/rolldown_plugin/src/types/hook_transform_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_transform_args.rs
@@ -3,6 +3,6 @@ use rolldown_common::ModuleType;
 #[derive(Debug)]
 pub struct HookTransformArgs<'a> {
   pub id: &'a str,
-  pub code: &'a String,
+  pub code: &'a str,
   pub module_type: &'a ModuleType,
 }

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -9,10 +9,12 @@ use rolldown_resolver::{ResolveError, Resolver};
 use std::{path::Path, sync::Arc};
 use sugar_path::SugarPath;
 
+#[inline]
 fn is_http_url(s: &str) -> bool {
   s.starts_with("http://") || s.starts_with("https://") || s.starts_with("//")
 }
 
+#[inline]
 pub fn is_data_url(s: &str) -> bool {
   s.trim_start().starts_with("data:")
 }

--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -9,7 +9,7 @@ use rolldown_common::{EmittedAsset, Output};
 use rolldown_plugin::{HookRenderChunkOutput, HookUsage, Plugin};
 use rolldown_utils::{
   dashmap::FxDashMap,
-  hash_placeholder::{find_hash_placeholders, hash_placeholder_left_finder},
+  hash_placeholder::{HASH_PLACEHOLDER_LEFT_FINDER, find_hash_placeholders},
   rustc_hash::FxHashMapExt as _,
   xxhash::xxhash_with_base,
 };
@@ -38,12 +38,12 @@ impl Plugin for ChunkImportMapPlugin {
     _ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookRenderChunkArgs<'_>,
   ) -> rolldown_plugin::HookRenderChunkReturn {
-    let hash_finder = hash_placeholder_left_finder();
     if !self.initialized.swap(true, Ordering::SeqCst) {
       let base = args.options.hash_characters.base();
       let mut used_names = FxHashSet::default();
       for chunk in args.chunks.values() {
-        let hash_placeholders = find_hash_placeholders(&chunk.filename, &hash_finder);
+        let hash_placeholders =
+          find_hash_placeholders(&chunk.filename, &HASH_PLACEHOLDER_LEFT_FINDER);
         if hash_placeholders.is_empty() {
           continue;
         }
@@ -78,7 +78,7 @@ impl Plugin for ChunkImportMapPlugin {
       }
     }
 
-    let mut placeholders = find_hash_placeholders(&args.code, &hash_finder);
+    let mut placeholders = find_hash_placeholders(&args.code, &HASH_PLACEHOLDER_LEFT_FINDER);
     placeholders.retain(|placeholder| self.chunk_import_map.contains_key(placeholder.2));
 
     if placeholders.is_empty() {

--- a/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
@@ -23,7 +23,7 @@ impl Plugin for TestPlugin {
     args: &HookTransformArgs<'_>,
   ) -> HookTransformReturn {
     let mut code = self.0.lock().unwrap();
-    *code = Some(args.code.clone());
+    *code = Some(args.code.to_string());
     Ok(None)
   }
 

--- a/crates/rolldown_plugin_reporter/src/lib.rs
+++ b/crates/rolldown_plugin_reporter/src/lib.rs
@@ -314,7 +314,7 @@ impl Plugin for ReporterPlugin {
         }
         filtered.sort_by(|a, b| a.size.cmp(&b.size));
         for log_entry in filtered {
-          let mut info = String::new();
+          let mut info = String::with_capacity(512);
           let _ = write!(&mut info, "\x1b[2m{out_dir}/\x1b[22m");
 
           let is_asset = !self.is_lib && Path::new(log_entry.name).starts_with(&self.assets_dir);

--- a/crates/rolldown_plugin_transform/src/lib.rs
+++ b/crates/rolldown_plugin_transform/src/lib.rs
@@ -54,7 +54,7 @@ impl Plugin for TransformPlugin {
     if ret.panicked || !ret.errors.is_empty() {
       return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
         ret.errors,
-        &ArcStr::from(args.code.as_str()),
+        &ArcStr::from(args.code),
         &stabilize_id(args.id, ctx.cwd()),
         &Severity::Error,
       )))?;
@@ -67,7 +67,7 @@ impl Plugin for TransformPlugin {
     if !transformer_return.errors.is_empty() {
       return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
         transformer_return.errors,
-        &ArcStr::from(args.code.as_str()),
+        &ArcStr::from(args.code),
         &stabilize_id(args.id, ctx.cwd()),
         &Severity::Error,
       )))?;

--- a/crates/rolldown_plugin_vite_css_post/src/utils.rs
+++ b/crates/rolldown_plugin_vite_css_post/src/utils.rs
@@ -709,7 +709,7 @@ impl ViteCssPostPlugin {
                 width = len.saturating_sub(15 + p1.len())
               )
             })
-            .into_owned();
+            .into();
         }
         *chunk = Arc::new(new_chunk);
       }

--- a/crates/rolldown_plugin_vite_html/src/utils/html_inject.rs
+++ b/crates/rolldown_plugin_vite_html/src/utils/html_inject.rs
@@ -41,29 +41,30 @@ fn serialize_attrs(attrs: Option<&rustc_hash::FxHashMap<&'static str, AttrValue>
   let Some(attrs) = attrs else {
     return String::new();
   };
-  let mut result = String::new();
-  for (key, value) in attrs {
-    match value {
-      AttrValue::String(s) => {
-        // Escape HTML entities in attribute values
-        result.push_str(&rolldown_utils::concat_string!(
-          " ",
-          key,
-          "=\"",
-          s.cow_replace('&', "&amp;")
-            .cow_replace('"', "&quot;")
-            .cow_replace('<', "&lt;")
-            .cow_replace('>', "&gt;"),
-          "\""
-        ));
+  attrs
+    .iter()
+    .map(|(key, value)| {
+      match value {
+        AttrValue::String(s) => {
+          // Escape HTML entities in attribute values
+          rolldown_utils::concat_string!(
+            " ",
+            key,
+            "=\"",
+            s.cow_replace('&', "&amp;")
+              .cow_replace('"', "&quot;")
+              .cow_replace('<', "&lt;")
+              .cow_replace('>', "&gt;"),
+            "\""
+          )
+        }
+        AttrValue::Boolean(true) => {
+          rolldown_utils::concat_string!(" ", key)
+        }
+        AttrValue::Boolean(false) | AttrValue::Undefined => String::new(),
       }
-      AttrValue::Boolean(true) => {
-        result.push_str(&rolldown_utils::concat_string!(" ", key));
-      }
-      AttrValue::Boolean(false) | AttrValue::Undefined => {}
-    }
-  }
-  result
+    })
+    .collect()
 }
 
 /// Serialize a single HTML tag to string

--- a/crates/rolldown_plugin_wasm_helper/src/lib.rs
+++ b/crates/rolldown_plugin_wasm_helper/src/lib.rs
@@ -39,7 +39,7 @@ impl Plugin for WasmHelperPlugin {
 
     if args.id.ends_with(".wasm?init") {
       let file_path = Path::new(&args.id[..args.id.len() - 5]);
-      let source = StrOrBytes::Bytes(fs::read(file_path)?);
+      let source = StrOrBytes::Bytes(fs::read(file_path)?, false);
 
       let referenced_id = ctx
         .emit_file_async(EmittedAsset {

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -22,6 +22,7 @@ use oxc_resolver::{
 #[expect(clippy::struct_field_names)]
 pub struct Resolver<T: FileSystem = OsFileSystem> {
   cwd: PathBuf,
+  fs: T,
   default_resolver: ResolverGeneric<T>,
   // Resolver for `import '...'` and `import(...)`
   import_resolver: ResolverGeneric<T>,
@@ -47,7 +48,7 @@ impl<F: FileSystem> Resolver<F> {
     } else {
       // User have has the responsibility to ensure `path` is real path if needed. We just pass it through.
       let realpath = path.to_path_buf();
-      let json_str = std::fs::read_to_string(path)?;
+      let json_str = self.fs.read_to_string(path)?;
       let oxc_pkg_json = OxcPackageJson::parse(path.to_path_buf(), realpath, &json_str)?;
       let pkg_json = Arc::new(PackageJson::from_oxc_pkg_json(&oxc_pkg_json));
       self.package_json_cache.insert(path.to_path_buf(), Arc::clone(&pkg_json));
@@ -56,7 +57,7 @@ impl<F: FileSystem> Resolver<F> {
   }
 }
 
-impl<F: FileSystem> Resolver<F> {
+impl<F: FileSystem + Clone> Resolver<F> {
   pub fn new(
     fs: F,
     cwd: PathBuf,
@@ -178,7 +179,7 @@ impl<F: FileSystem> Resolver<F> {
     };
 
     let default_resolver =
-      ResolverGeneric::new_with_file_system(fs, resolve_options_with_default_conditions);
+      ResolverGeneric::new_with_file_system(fs.clone(), resolve_options_with_default_conditions);
     let import_resolver =
       default_resolver.clone_with_options(resolve_options_with_import_conditions);
     let require_resolver =
@@ -186,6 +187,7 @@ impl<F: FileSystem> Resolver<F> {
     let css_resolver = default_resolver.clone_with_options(resolve_options_for_css);
     let new_url_resolver = default_resolver.clone_with_options(resolve_options_for_new_url);
     Self {
+      fs,
       cwd,
       default_resolver,
       import_resolver,
@@ -278,7 +280,7 @@ impl<F: FileSystem> Resolver<F> {
       let package_json = info.package_json().map(|p| self.cached_package_json(p));
       let module_def_format = infer_module_def_format(&info);
       ResolveReturn {
-        path: info.full_path().to_str().expect("Should be valid utf8").into(),
+        path: info.full_path().to_string_lossy().into(),
         module_def_format,
         package_json,
       }

--- a/crates/rolldown_testing/src/types/artifacts_snapshot.rs
+++ b/crates/rolldown_testing/src/types/artifacts_snapshot.rs
@@ -180,15 +180,15 @@ impl ArtifactsSnapshot {
               // Skip sourcemap for now
               continue;
             }
+
             match &output_asset.source {
               rolldown_common::StrOrBytes::Str(content) => {
-                let mut asset_child = SnapshotSection::with_title(asset.filename().to_string());
-                asset_child.add_content(&format!("```{file_ext}\n"));
-                asset_child.add_content(content);
-                asset_child.add_content("\n```");
-                assets_section.add_child(asset_child);
+                assets_section.add_child(Self::add_asset_child(asset, file_ext, content));
               }
-              rolldown_common::StrOrBytes::Bytes(bytes) => {
+              rolldown_common::StrOrBytes::ArcStr(content) => {
+                assets_section.add_child(Self::add_asset_child(asset, file_ext, content.as_str()));
+              }
+              rolldown_common::StrOrBytes::Bytes(bytes, _) => {
                 let mut asset_child = SnapshotSection::with_title(asset.filename().to_string());
                 if test_meta.snapshot_bytes {
                   asset_child.add_content(&format!("```{file_ext}\n"));
@@ -247,6 +247,14 @@ impl ArtifactsSnapshot {
       sections.push(sourcemap_section);
     }
     sections
+  }
+
+  fn add_asset_child(asset: &Output, file_ext: &str, content: &str) -> SnapshotSection {
+    let mut asset_child = SnapshotSection::with_title(asset.filename());
+    asset_child.add_content(&format!("```{file_ext}\n"));
+    asset_child.add_content(content);
+    asset_child.add_content("\n```");
+    asset_child
   }
 
   fn create_hmr_error_section(

--- a/crates/rolldown_utils/src/commondir.rs
+++ b/crates/rolldown_utils/src/commondir.rs
@@ -17,7 +17,7 @@ pub fn extract_longest_common_path(path1: &str, path2: &str) -> String {
 
   let mut components1 = path1.components().peekable();
   let mut components2 = path2.components().peekable();
-  let mut common_path = String::new();
+  let mut common_path = String::with_capacity(128);
 
   while let (Some(&comp1), Some(&comp2)) = (components1.peek(), components2.peek()) {
     if comp1 == comp2 {
@@ -29,7 +29,7 @@ pub fn extract_longest_common_path(path1: &str, path2: &str) -> String {
         }
         Component::Normal(s) => {
           common_path.push_str(s.to_str().unwrap_or("")); //Handle the case where the component is not valid utf-8.
-          common_path.push_str(std::path::MAIN_SEPARATOR_STR);
+          common_path.push(std::path::MAIN_SEPARATOR);
         }
       }
 
@@ -40,7 +40,7 @@ pub fn extract_longest_common_path(path1: &str, path2: &str) -> String {
     }
   }
   //Remove the last separator if it exists and the path is not just the root.
-  if common_path.len() > 1 && common_path.ends_with(std::path::MAIN_SEPARATOR_STR) {
+  if common_path.len() > 1 && common_path.ends_with(std::path::MAIN_SEPARATOR) {
     common_path.pop();
   }
   common_path


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Cuts allocations and copies across the pipeline via ArcStr adoption, preallocation, optimized module sorting, and faster sourcemap/hash handling.
> 
> - **Core types/IO**:
>   - Add `StrOrBytes::ArcStr` and mark byte UTF-8 validation; propagate across loader, plugins, and transforms; add helpers (`to_str`, etc.).
>   - Make `HashCharacters::base` const; extend `HybridIndexVec` with `len`/`is_empty`.
>   - Resolver stores `fs`, reads via `FileSystem`, loosens generics, and uses `to_string_lossy`.
> - **Module sorting**:
>   - Introduce `ModuleSortKey` and sort chunks with a single `sort_by_key`, unifying runtime/leaf/normal ordering.
> - **Formatting/Codegen**:
>   - Preallocate strings; refactor ESM/CJS import/export rendering using `Cow` and iterator combinators; reduce intermediate allocations.
> - **Sourcemaps/Assets**:
>   - Parallelize sourcemap path transforms; gate Windows normalization; optimize asset finalization, support `ArcStr` content, and async derive assets.
> - **Hash placeholders**:
>   - Replace ad-hoc finder with static `HASH_PLACEHOLDER_LEFT_FINDER`; update all callers.
> - **Load/Transform pipeline**:
>   - `transform_source`/plugin `transform` now use `ArcStr` and `&str`; fewer clones and copies.
> - **Misc**:
>   - Numerous `with_capacity`/`Vec::with_capacity` and small string/vec optimizations.
>   - Bump `json-escape-simd` to `3.x` and update references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6ab737b6cea3fbde5d232b4d28cd7929a3356e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->