### PR TITLE
fix: process CJS tree shaking bailout modules before eliminating unused dynamic entries

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/6513/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/6513/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./entry.js"
+      }
+    ],
+    "format": "cjs"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
@@ -1,0 +1,70 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## chunk.js
+
+```js
+// HIDDEN [rolldown:runtime]
+
+Object.defineProperty(exports, '__commonJS', {
+  enumerable: true,
+  get: function () {
+    return __commonJS;
+  }
+});
+Object.defineProperty(exports, '__esm', {
+  enumerable: true,
+  get: function () {
+    return __esm;
+  }
+});
+Object.defineProperty(exports, '__toESM', {
+  enumerable: true,
+  get: function () {
+    return __toESM;
+  }
+});
+```
+
+## dynamic.js
+
+```js
+const require_chunk = require('./chunk.js');
+
+//#region dynamic.js
+var ddd;
+var init_dynamic = require_chunk.__esm({ "dynamic.js": (() => {
+	ddd = 100;
+}) });
+
+//#endregion
+init_dynamic();
+exports.ddd = ddd;
+```
+
+## main.js
+
+```js
+const require_chunk = require('./chunk.js');
+let node_assert = require("node:assert");
+node_assert = require_chunk.__toESM(node_assert);
+
+//#region lib.js
+var require_lib = /* @__PURE__ */ require_chunk.__commonJS({ "lib.js": ((exports) => {
+	const remoteProvider = async function() {
+		return await Promise.resolve().then(() => require("./dynamic.js"));
+	};
+	exports.defaultProvider = remoteProvider;
+}) });
+
+//#endregion
+//#region entry.js
+var import_lib = /* @__PURE__ */ require_chunk.__toESM(require_lib());
+(async () => {
+	(0, node_assert.default)((await (0, import_lib.defaultProvider)()).ddd === 100);
+})();
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/issues/6513/dynamic.js
+++ b/crates/rolldown/tests/rolldown/issues/6513/dynamic.js
@@ -1,0 +1,1 @@
+export const ddd = 100;

--- a/crates/rolldown/tests/rolldown/issues/6513/entry.js
+++ b/crates/rolldown/tests/rolldown/issues/6513/entry.js
@@ -1,0 +1,8 @@
+import assert from "node:assert";
+import { defaultProvider } from "./lib";
+
+(async () => {
+  const mod = await defaultProvider();
+
+  assert(mod.ddd === 100);
+})();

--- a/crates/rolldown/tests/rolldown/issues/6513/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/6513/lib.js
@@ -1,0 +1,6 @@
+const remoteProvider = async function() {
+  const mod = await import('./dynamic.js');
+  return mod;
+};
+
+exports.defaultProvider = remoteProvider;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4787,6 +4787,12 @@ expression: output
 - entries/main-esm.js => entries/main-esm.js
 - chunks/lazy-esm.js => chunks/lazy-esm.js
 
+# tests/rolldown/issues/6513
+
+- main-!~{000}~.js => main-DJLQ7AhO.js
+- chunk-!~{001}~.js => chunk--zchQUYv.js
+- dynamic-!~{003}~.js => dynamic-C-F4zVAd.js
+
 # tests/rolldown/issues/rolldown_vite_289
 
 - main-!~{000}~.js => main-Bldhf8JA.js


### PR DESCRIPTION
Closed #6513