### PR TITLE
feat(dev): return `RolldownOutput` instead of `BindingOutputs` from `onOutput`

### DIFF
--- a/packages/rolldown/src/api/dev/dev-engine.ts
+++ b/packages/rolldown/src/api/dev/dev-engine.ts
@@ -10,6 +10,7 @@ import type { OutputOptions } from '../../options/output-options';
 import { PluginDriver } from '../../plugin/plugin-driver';
 import { createBundlerOptions } from '../../utils/create-bundler-option';
 import { normalizeBindingResult } from '../../utils/error';
+import { transformToRollupOutput } from '../../utils/transform-to-rollup-output';
 import type { DevOptions } from './dev-options';
 
 export class DevEngine {
@@ -50,7 +51,12 @@ export class DevEngine {
     const userOnOutput = devOptions.onOutput;
     const bindingOnOutput: BindingDevOptions['onOutput'] = userOnOutput
       ? function(rawResult) {
-        userOnOutput(normalizeBindingResult(rawResult));
+        const result = normalizeBindingResult(rawResult);
+        if (result instanceof Error) {
+          userOnOutput(result);
+          return;
+        }
+        userOnOutput(transformToRollupOutput(result));
       }
       : undefined;
 

--- a/packages/rolldown/src/api/dev/dev-options.ts
+++ b/packages/rolldown/src/api/dev/dev-options.ts
@@ -1,4 +1,5 @@
-import type { BindingClientHmrUpdate, BindingOutputs } from '../../binding';
+import type { BindingClientHmrUpdate } from '../../binding';
+import type { RolldownOutput } from '../../types/rolldown-output';
 
 type DevOnHmrUpdates = (
   result: Error | {
@@ -8,7 +9,7 @@ type DevOnHmrUpdates = (
 ) => void | Promise<void>;
 
 type DevOnOutput = (
-  result: Error | BindingOutputs,
+  result: Error | RolldownOutput,
 ) => void | Promise<void>;
 
 export interface DevWatchOptions {


### PR DESCRIPTION
Just to make it a bit easier to work with.