### PR TITLE
refactor(rust/dev): remove unnecessary bundler cache management of dev engine

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -221,14 +221,6 @@ impl Bundler {
       .await
   }
 
-  pub(crate) fn take_cache(&mut self) -> ScanStageCache {
-    std::mem::take(&mut self.cache)
-  }
-
-  pub(crate) fn set_cache(&mut self, cache: ScanStageCache) {
-    self.cache = cache;
-  }
-
   pub(crate) async fn bundle_write(
     &mut self,
     scan_stage_output: NormalizedScanStageOutput,

--- a/crates/rolldown/src/dev/build_driver.rs
+++ b/crates/rolldown/src/dev/build_driver.rs
@@ -74,7 +74,6 @@ impl BuildDriver {
         input: task_input,
         bundler: Arc::clone(&self.bundler),
         dev_context: Arc::clone(&self.ctx),
-        bundler_cache: build_state.cache.take(),
         next_hmr_patch_id: Arc::clone(&self.next_hmr_patch_id),
       };
 
@@ -137,18 +136,17 @@ impl BuildDriver {
   ) -> BuildResult<Vec<ClientHmrUpdate>> {
     let mut updates = Vec::new();
     for client in self.ctx.clients.iter() {
-      let mut build_state = loop {
+      loop {
         let build_state = self.ctx.state.lock().await;
         if let Some(building_future) = build_state.is_busy_then_future().cloned() {
           drop(build_state);
           building_future.await;
         } else {
-          break build_state;
+          break;
         }
-      };
+      }
 
       let mut bundler = self.bundler.lock().await;
-      bundler.set_cache(build_state.cache.take().expect("Should never be none here"));
       let update = bundler
         .compute_update_for_calling_invalidate(
           caller.clone(),
@@ -158,7 +156,6 @@ impl BuildDriver {
           Arc::clone(&self.next_hmr_patch_id),
         )
         .await?;
-      build_state.cache = Some(bundler.take_cache());
       updates.push(ClientHmrUpdate { client_id: client.key().to_string(), update });
     }
 

--- a/crates/rolldown/src/dev/build_state_machine/mod.rs
+++ b/crates/rolldown/src/dev/build_state_machine/mod.rs
@@ -4,28 +4,19 @@ use std::collections::VecDeque;
 use build_state::{BuildBuildingState, BuildDelayingState, BuildState};
 use rolldown_error::BuildResult;
 
-use crate::{
-  dev::{dev_context::BuildProcessFuture, types::task_input::TaskInput},
-  types::scan_stage_cache::ScanStageCache,
-};
+use crate::dev::{dev_context::BuildProcessFuture, types::task_input::TaskInput};
 use tracing;
 
 #[derive(Debug)]
 pub struct BuildStateMachine<State = BuildState> {
   pub queued_tasks: VecDeque<TaskInput>,
   pub has_stale_build_output: bool,
-  pub cache: Option<ScanStageCache>,
   pub state: State,
 }
 
 impl BuildStateMachine<BuildState> {
   pub fn new() -> Self {
-    Self {
-      queued_tasks: VecDeque::new(),
-      state: BuildState::Idle,
-      cache: None,
-      has_stale_build_output: false,
-    }
+    Self { queued_tasks: VecDeque::new(), state: BuildState::Idle, has_stale_build_output: false }
   }
 
   pub fn is_busy(&self) -> bool {


### PR DESCRIPTION
HMR stage now uses the cache inside of the bundler itself. There's no need to pass cache around.