### PR TITLE
perf(common): add ArcStr variant to StrOrBytes to reduce clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,7 +3136,6 @@ dependencies = [
 name = "rolldown_plugin_isolated_declaration"
 version = "0.1.0"
 dependencies = [
- "arcstr",
  "oxc",
  "rolldown_common",
  "rolldown_error",
@@ -3251,7 +3250,6 @@ name = "rolldown_plugin_transform"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arcstr",
  "itertools",
  "memchr",
  "oxc",

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -279,6 +279,20 @@ impl ModuleTask {
           &self.ctx.plugin_driver,
           &self.resolved_id,
           self.module_idx,
+          source.into(),
+          sourcemap_chain,
+          hook_side_effects,
+          &mut module_type,
+          magic_string_tx,
+        )
+        .await?;
+        StrOrBytes::ArcStr(source)
+      }
+      StrOrBytes::ArcStr(source) => {
+        let source = transform_source(
+          &self.ctx.plugin_driver,
+          &self.resolved_id,
+          self.module_idx,
           source,
           sourcemap_chain,
           hook_side_effects,
@@ -286,9 +300,9 @@ impl ModuleTask {
           magic_string_tx,
         )
         .await?;
-        source.into()
+        StrOrBytes::ArcStr(source)
       }
-      StrOrBytes::Bytes(_) => source,
+      StrOrBytes::Bytes(..) => source,
     };
     if let ModuleType::Custom(_) = module_type {
       // TODO: should provide some diagnostics for user how they should handle the module type.

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -46,9 +46,14 @@ impl PreProcessEcmaAst {
       semantic_ret.errors.into_iter().partition(|w| w.severity == OxcSeverity::Error);
 
     let warnings = if errors.is_empty() {
-      BuildDiagnostic::from_oxc_diagnostics(warnings, &source, path, &Severity::Warning)
+      BuildDiagnostic::from_oxc_diagnostics(warnings, source.clone(), path, &Severity::Warning)
     } else {
-      return Err(BuildDiagnostic::from_oxc_diagnostics(errors, &source, path, &Severity::Error))?;
+      return Err(BuildDiagnostic::from_oxc_diagnostics(
+        errors,
+        source.clone(),
+        path,
+        &Severity::Error,
+      ))?;
     };
 
     self.stats = semantic_ret.semantic.stats();
@@ -85,7 +90,7 @@ impl PreProcessEcmaAst {
             .collect_vec();
           return Err(BuildDiagnostic::from_oxc_diagnostics(
             errors,
-            &source,
+            source,
             path,
             &Severity::Error,
           ));

--- a/crates/rolldown/src/utils/transform_source.rs
+++ b/crates/rolldown/src/utils/transform_source.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::mpsc::Sender;
 
 use anyhow::Result;
+use arcstr::ArcStr;
 use rolldown_common::ModuleType;
 use rolldown_common::SourceMapGenMsg;
 use rolldown_common::{
@@ -16,12 +17,12 @@ pub async fn transform_source(
   plugin_driver: &PluginDriver,
   resolved_id: &ResolvedId,
   module_idx: ModuleIdx,
-  source: String,
+  source: ArcStr,
   sourcemap_chain: &mut Vec<SourcemapChainElement>,
   side_effects: &mut Option<HookSideEffects>,
   module_type: &mut ModuleType,
   magic_string_tx: Option<Arc<Sender<SourceMapGenMsg>>>,
-) -> Result<String> {
+) -> Result<ArcStr> {
   plugin_driver
     .transform(
       &resolved_id.id,

--- a/crates/rolldown_common/src/types/str_or_bytes.rs
+++ b/crates/rolldown_common/src/types/str_or_bytes.rs
@@ -1,9 +1,13 @@
 use std::fmt::Debug;
 
+use arcstr::ArcStr;
+
 #[derive(Clone, Debug)]
 pub enum StrOrBytes {
+  ArcStr(ArcStr),
   Str(String),
-  Bytes(Vec<u8>),
+  // The second field is used to indicate whether the bytes have been validated as utf8
+  Bytes(Vec<u8>, bool),
 }
 
 impl Default for StrOrBytes {
@@ -16,16 +20,20 @@ impl StrOrBytes {
   pub fn try_into_inner_string(self) -> anyhow::Result<String> {
     match self {
       Self::Str(s) => Ok(s),
-      Self::Bytes(_) => Err(anyhow::format_err!("Expected Str, found Bytes")),
+      Self::ArcStr(s) => Ok(s.to_string()),
+      Self::Bytes(..) => Err(anyhow::format_err!("Expected Str, found Bytes")),
     }
   }
 
   pub fn try_into_string(self) -> anyhow::Result<String> {
     match self {
       Self::Str(s) => Ok(s),
-      Self::Bytes(b) => {
-        // validate utf8
-        simdutf8::basic::from_utf8(&b)?;
+      Self::ArcStr(s) => Ok(s.to_string()),
+      Self::Bytes(b, valid) => {
+        if !valid {
+          // validate utf8
+          simdutf8::basic::from_utf8(&b)?;
+        }
         // SAFETY: `b` is valid utf8
         unsafe { Ok(String::from_utf8_unchecked(b)) }
       }
@@ -35,14 +43,24 @@ impl StrOrBytes {
   pub fn as_bytes(&self) -> &[u8] {
     match self {
       Self::Str(s) => s.as_bytes(),
-      Self::Bytes(b) => b.as_slice(),
+      Self::ArcStr(s) => s.as_bytes(),
+      Self::Bytes(b, _) => b.as_slice(),
     }
   }
 
   pub fn try_as_inner_str(&self) -> anyhow::Result<&str> {
     match self {
       Self::Str(s) => Ok(s.as_str()),
-      Self::Bytes(_) => Err(anyhow::format_err!("Expected Str, found Bytes")),
+      Self::ArcStr(s) => Ok(s.as_str()),
+      Self::Bytes(..) => Err(anyhow::format_err!("Expected Str, found Bytes")),
+    }
+  }
+
+  pub fn to_str(&self) -> Option<&str> {
+    match self {
+      Self::Str(s) => Some(s.as_str()),
+      Self::ArcStr(s) => Some(s.as_str()),
+      Self::Bytes(..) => None,
     }
   }
 }
@@ -55,6 +73,6 @@ impl From<String> for StrOrBytes {
 
 impl From<Vec<u8>> for StrOrBytes {
   fn from(b: Vec<u8>) -> Self {
-    Self::Bytes(b)
+    Self::Bytes(b, false)
   }
 }

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -32,7 +32,7 @@ impl EcmaCompiler {
         if ret.panicked || !ret.errors.is_empty() {
           Err(BuildDiagnostic::from_oxc_diagnostics(
             ret.errors,
-            &source.clone(),
+            source.clone(),
             filename,
             &Severity::Error,
           ))
@@ -70,7 +70,7 @@ impl EcmaCompiler {
           }
           Err(errors) => Err(BuildDiagnostic::from_oxc_diagnostics(
             errors,
-            &source.clone(),
+            source.clone(),
             filename,
             &Severity::Error,
           )),

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -220,7 +220,7 @@ impl BuildDiagnostic {
 
   pub fn from_oxc_diagnostics<T>(
     diagnostics: T,
-    source: &ArcStr,
+    source: ArcStr,
     path: &str,
     severity: &Severity,
   ) -> Vec<Self>

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -9,6 +9,7 @@ use crate::{
   },
 };
 use anyhow::{Context, Result};
+use arcstr::ArcStr;
 use rolldown_common::{
   ModuleInfo, ModuleType, NormalModule, PluginIdx, SharedNormalizedBundlerOptions,
   SourcemapChainElement, SourcemapHires, side_effects::HookSideEffects,
@@ -219,12 +220,12 @@ impl PluginDriver {
     &self,
     id: &str,
     module_idx: rolldown_common::ModuleIdx,
-    original_code: String,
+    original_code: ArcStr,
     sourcemap_chain: &mut Vec<SourcemapChainElement>,
     side_effects: &mut Option<HookSideEffects>,
     module_type: &mut ModuleType,
     magic_string_tx: Option<Arc<std::sync::mpsc::Sender<rolldown_common::SourceMapGenMsg>>>,
-  ) -> Result<String> {
+  ) -> Result<ArcStr> {
     let mut code = original_code;
     let mut original_sourcemap_chain = std::mem::take(sourcemap_chain);
     let mut plugin_sourcemap_chain = UniqueArc::new(original_sourcemap_chain);
@@ -236,7 +237,7 @@ impl PluginDriver {
       trace_action!(action::HookTransformCallStart {
         action: "HookTransformCallStart",
         module_id: id.to_string(),
-        content: code.clone(),
+        content: code.to_string(),
         plugin_name: plugin.call_name().to_string(),
         plugin_id: plugin_idx.raw(),
         call_id: call_id.clone().unwrap_or_default(),
@@ -266,7 +267,7 @@ impl PluginDriver {
           *side_effects = Some(v);
         }
         if let Some(v) = r.code {
-          code = v;
+          code = v.into();
           trace_action!(action::HookTransformCallEnd {
             action: "HookTransformCallEnd",
             module_id: id.to_string(),

--- a/crates/rolldown_plugin/src/types/hook_transform_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_transform_args.rs
@@ -3,6 +3,6 @@ use rolldown_common::ModuleType;
 #[derive(Debug)]
 pub struct HookTransformArgs<'a> {
   pub id: &'a str,
-  pub code: &'a String,
+  pub code: &'a str,
   pub module_type: &'a ModuleType,
 }

--- a/crates/rolldown_plugin_isolated_declaration/Cargo.toml
+++ b/crates/rolldown_plugin_isolated_declaration/Cargo.toml
@@ -16,7 +16,6 @@ doctest = false
 workspace = true
 
 [dependencies]
-arcstr = { workspace = true }
 oxc = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_error = { workspace = true }

--- a/crates/rolldown_plugin_isolated_declaration/src/lib.rs
+++ b/crates/rolldown_plugin_isolated_declaration/src/lib.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, path::Path};
 
-use arcstr::ArcStr;
 use oxc::{
   allocator::IntoIn,
   ast_visit::VisitMut,
@@ -56,7 +55,7 @@ impl Plugin for IsolatedDeclarationPlugin {
       if !ret.errors.is_empty() {
         return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
           ret.errors,
-          &ArcStr::from(ret.program.source_text),
+          ret.program.source_text.into(),
           &stabilize_id(args.id, ctx.cwd()),
           &Severity::Error,
         )))?;

--- a/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
@@ -23,7 +23,7 @@ impl Plugin for TestPlugin {
     args: &HookTransformArgs<'_>,
   ) -> HookTransformReturn {
     let mut code = self.0.lock().unwrap();
-    *code = Some(args.code.clone());
+    *code = Some(args.code.to_string());
     Ok(None)
   }
 

--- a/crates/rolldown_plugin_transform/Cargo.toml
+++ b/crates/rolldown_plugin_transform/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-arcstr = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
 oxc = { workspace = true }

--- a/crates/rolldown_plugin_transform/src/lib.rs
+++ b/crates/rolldown_plugin_transform/src/lib.rs
@@ -3,7 +3,6 @@ mod utils;
 use std::borrow::Cow;
 use std::path::Path;
 
-use arcstr::ArcStr;
 use oxc::codegen::{Codegen, CodegenOptions, CodegenReturn, CommentOptions};
 use oxc::parser::Parser;
 use oxc::semantic::SemanticBuilder;
@@ -54,7 +53,7 @@ impl Plugin for TransformPlugin {
     if ret.panicked || !ret.errors.is_empty() {
       return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
         ret.errors,
-        &ArcStr::from(args.code.as_str()),
+        args.code.into(),
         &stabilize_id(args.id, ctx.cwd()),
         &Severity::Error,
       )))?;
@@ -67,7 +66,7 @@ impl Plugin for TransformPlugin {
     if !transformer_return.errors.is_empty() {
       return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
         transformer_return.errors,
-        &ArcStr::from(args.code.as_str()),
+        args.code.into(),
         &stabilize_id(args.id, ctx.cwd()),
         &Severity::Error,
       )))?;

--- a/crates/rolldown_plugin_wasm_helper/src/lib.rs
+++ b/crates/rolldown_plugin_wasm_helper/src/lib.rs
@@ -39,7 +39,7 @@ impl Plugin for WasmHelperPlugin {
 
     if args.id.ends_with(".wasm?init") {
       let file_path = Path::new(&args.id[..args.id.len() - 5]);
-      let source = StrOrBytes::Bytes(fs::read(file_path)?);
+      let source = StrOrBytes::Bytes(fs::read(file_path)?, false);
 
       let referenced_id = ctx
         .emit_file_async(EmittedAsset {

--- a/crates/rolldown_testing/src/types/artifacts_snapshot.rs
+++ b/crates/rolldown_testing/src/types/artifacts_snapshot.rs
@@ -188,7 +188,14 @@ impl ArtifactsSnapshot {
                 asset_child.add_content("\n```");
                 assets_section.add_child(asset_child);
               }
-              rolldown_common::StrOrBytes::Bytes(bytes) => {
+              rolldown_common::StrOrBytes::ArcStr(content) => {
+                let mut asset_child = SnapshotSection::with_title(asset.filename().to_string());
+                asset_child.add_content(&format!("```{file_ext}\n"));
+                asset_child.add_content(content);
+                asset_child.add_content("\n```");
+                assets_section.add_child(asset_child);
+              }
+              rolldown_common::StrOrBytes::Bytes(bytes, _) => {
                 let mut asset_child = SnapshotSection::with_title(asset.filename().to_string());
                 if test_meta.snapshot_bytes {
                   asset_child.add_content(&format!("```{file_ext}\n"));


### PR DESCRIPTION
perf(common): add ArcStr variant to StrOrBytes to reduce clones

- Add StrOrBytes::ArcStr variant using arcstr crate for cheap cloning
- Add UTF-8 validation flag to Bytes variant to avoid redundant checks
- Add to_str() method for convenient string access
- Update try_into_string() to handle validated bytes more efficiently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

perf(rolldown): adapt codebase to StrOrBytes ArcStr variant

- Update load_source to use ArcStr for plugin-provided code
- Mark bytes from string conversion as UTF-8 validated (true flag)
- Mark bytes from disk reads as unvalidated (false flag)
- Update all match patterns for Bytes variant to handle validation flag
- Update binding layer to handle ArcStr variant
- Change BindingAssetSource from Buffer to Uint8Array

This commit adapts all usages of StrOrBytes to work with the new ArcStr
variant and UTF-8 validation flag introduced in the previous commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>