### PR TITLE
feat!: enable `output.minifyInternalExports` for `format: 'es'` or `minify: true`

### DIFF
--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -3,8 +3,8 @@ use std::{borrow::Cow, path::Path, sync::Arc};
 use oxc::transformer_plugins::InjectGlobalVariablesConfig;
 use rolldown_common::{
   AttachDebugInfo, GlobalsOutputOption, InjectImport, LegalComments, MinifyOptions, ModuleType,
-  NormalizedBundlerOptions, OutputFormat, Platform, PreserveEntrySignatures, TreeshakeOptions,
-  normalize_optimization_option,
+  NormalizedBundlerOptions, OutputFormat, Platform, PreserveEntrySignatures, RawMinifyOptions,
+  TreeshakeOptions, normalize_optimization_option,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult, InvalidOptionType};
 use rolldown_fs::{OsFileSystem, OxcResolverFileSystem as _};
@@ -342,7 +342,10 @@ pub fn prepare_build_context(
     debug: raw_options.debug.is_some(),
     optimization: normalize_optimization_option(raw_options.optimization, platform),
     top_level_var: raw_options.top_level_var.unwrap_or(false),
-    minify_internal_exports: raw_options.minify_internal_exports.unwrap_or(false),
+    minify_internal_exports: raw_options.minify_internal_exports.unwrap_or(
+      matches!(format, OutputFormat::Esm)
+        || matches!(raw_minify, RawMinifyOptions::Bool(true) | RawMinifyOptions::Object(_)),
+    ),
     clean_dir: raw_options.clean_dir.unwrap_or(false),
     context: raw_options.context.unwrap_or_default(),
     tsconfig,

--- a/crates/rolldown/tests/esbuild/dce/dce_var_exports/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/dce_var_exports/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { __commonJS } from "./chunk.js";
+import { t as __commonJS } from "./chunk.js";
 
 //#region a.js
 var require_a = /* @__PURE__ */ __commonJS({ "a.js": ((exports, module) => {
@@ -22,7 +22,7 @@ export default require_a();
 ## b.js
 
 ```js
-import { __commonJS } from "./chunk.js";
+import { t as __commonJS } from "./chunk.js";
 
 //#region b.js
 var require_b = /* @__PURE__ */ __commonJS({ "b.js": ((exports, module) => {
@@ -38,7 +38,7 @@ export default require_b();
 ## c.js
 
 ```js
-import { __commonJS } from "./chunk.js";
+import { t as __commonJS } from "./chunk.js";
 
 //#region c.js
 var require_c = /* @__PURE__ */ __commonJS({ "c.js": ((exports) => {
@@ -55,5 +55,5 @@ export default require_c();
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __commonJS };
+export { __commonJS as t };
 ```

--- a/crates/rolldown/tests/esbuild/default/conditional_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/conditional_import/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { __toDynamicImportESM } from "./chunk.js";
+import { n as __toDynamicImportESM } from "./chunk.js";
 
 //#region a.js
 x ? import("a") : y ? import("./import.js").then(__toDynamicImportESM()) : import("c");
@@ -17,7 +17,7 @@ x ? import("a") : y ? import("./import.js").then(__toDynamicImportESM()) : impor
 ## b.js
 
 ```js
-import { __toDynamicImportESM } from "./chunk.js";
+import { n as __toDynamicImportESM } from "./chunk.js";
 
 //#region b.js
 x ? y ? import("a") : import("./import.js").then(__toDynamicImportESM()) : import(c);
@@ -29,13 +29,13 @@ x ? y ? import("a") : import("./import.js").then(__toDynamicImportESM()) : impor
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __commonJS, __toDynamicImportESM };
+export { __toDynamicImportESM as n, __commonJS as t };
 ```
 
 ## import.js
 
 ```js
-import { __commonJS } from "./chunk.js";
+import { t as __commonJS } from "./chunk.js";
 
 //#region import.js
 var require_import = /* @__PURE__ */ __commonJS({ "import.js": ((exports) => {

--- a/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { b_exports } from "./b2.js";
+import { n as b_exports } from "./b2.js";
 
 //#region a.js
 var a_default = 123;
@@ -25,7 +25,7 @@ export { Class, Class as Cls, Class2 as Cls2, Func2 as Fn2, Func, constName, a_d
 ## b.js
 
 ```js
-import { b_default } from "./b2.js";
+import { t as b_default } from "./b2.js";
 
 export { b_default as default };
 ```
@@ -39,7 +39,7 @@ var b_exports = /* @__PURE__ */ __export({ default: () => b_default });
 function b_default() {}
 
 //#endregion
-export { b_default, b_exports };
+export { b_exports as n, b_default as t };
 ```
 
 ## c.js

--- a/crates/rolldown/tests/esbuild/default/import_missing_neither_es6_nor_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_missing_neither_es6_nor_common_js/artifacts.snap
@@ -47,7 +47,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## bare.js
 
 ```js
-import { init_foo } from "./foo.js";
+import { r as init_foo } from "./foo.js";
 
 //#region bare.js
 init_foo();
@@ -70,13 +70,13 @@ var init_foo = __esm({ "foo.js": (() => {
 }) });
 
 //#endregion
-export { __toCommonJS, default$1 as default, foo_exports, init_foo, x, y };
+export { y as a, x as i, foo_exports as n, __toCommonJS as o, init_foo as r, default$1 as t };
 ```
 
 ## foo2.js
 
 ```js
-import { init_foo } from "./foo.js";
+import { r as init_foo } from "./foo.js";
 
 init_foo();
 ```
@@ -93,7 +93,7 @@ console.log(import("./foo2.js"));
 ## named.js
 
 ```js
-import default$1, { init_foo, x, y } from "./foo.js";
+import { a as y, i as x, r as init_foo, t as default$1 } from "./foo.js";
 
 //#region named.js
 init_foo();
@@ -105,7 +105,7 @@ console.log(default$1(x, y));
 ## require.js
 
 ```js
-import { __toCommonJS, foo_exports, init_foo } from "./foo.js";
+import { n as foo_exports, o as __toCommonJS, r as init_foo } from "./foo.js";
 
 //#region require.js
 console.log((init_foo(), __toCommonJS(foo_exports)));
@@ -116,7 +116,7 @@ console.log((init_foo(), __toCommonJS(foo_exports)));
 ## star-capture.js
 
 ```js
-import { foo_exports, init_foo } from "./foo.js";
+import { n as foo_exports, r as init_foo } from "./foo.js";
 
 //#region star-capture.js
 init_foo();
@@ -128,7 +128,7 @@ console.log(foo_exports);
 ## star.js
 
 ```js
-import { init_foo } from "./foo.js";
+import { r as init_foo } from "./foo.js";
 
 //#region star.js
 init_foo();

--- a/crates/rolldown/tests/esbuild/default/indirect_require_message/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/indirect_require_message/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## array.js
 
 ```js
-import { __require } from "./chunk.js";
+import { t as __require } from "./chunk.js";
 
 //#region array.js
 __require;
@@ -17,7 +17,7 @@ __require;
 ## assign.js
 
 ```js
-import { __require } from "./chunk.js";
+import { t as __require } from "./chunk.js";
 
 //#region assign.js
 require = x;
@@ -29,13 +29,13 @@ require = x;
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __require };
+export { __require as t };
 ```
 
 ## dot.js
 
 ```js
-import { __require } from "./chunk.js";
+import { t as __require } from "./chunk.js";
 
 //#region dot.js
 __require.cache;
@@ -46,7 +46,7 @@ __require.cache;
 ## ident.js
 
 ```js
-import { __require } from "./chunk.js";
+import { t as __require } from "./chunk.js";
 
 //#region ident.js
 __require;
@@ -57,7 +57,7 @@ __require;
 ## index.js
 
 ```js
-import { __require } from "./chunk.js";
+import { t as __require } from "./chunk.js";
 
 //#region index.js
 __require[cache];

--- a/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
@@ -21,13 +21,13 @@ var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports) => {
 }) });
 
 //#endregion
-export { __commonJS, __toCommonJS, __toESM, esm_exports, esm_foo_, init_esm, require_cjs };
+export { __commonJS as a, init_esm as i, esm_exports as n, __toCommonJS as o, esm_foo_ as r, __toESM as s, require_cjs as t };
 ```
 
 ## entry-cjs.js
 
 ```js
-import { __commonJS, __toCommonJS, esm_exports, init_esm, require_cjs } from "./cjs.js";
+import { a as __commonJS, i as init_esm, n as esm_exports, o as __toCommonJS, t as require_cjs } from "./cjs.js";
 
 //#region entry-cjs.js
 var require_entry_cjs = /* @__PURE__ */ __commonJS({ "entry-cjs.js": ((exports) => {
@@ -44,7 +44,7 @@ export default require_entry_cjs();
 ## entry-esm.js
 
 ```js
-import { __toESM, esm_foo_, init_esm, require_cjs } from "./cjs.js";
+import { i as init_esm, r as esm_foo_, s as __toESM, t as require_cjs } from "./cjs.js";
 
 //#region entry-esm.js
 init_esm();

--- a/crates/rolldown/tests/esbuild/default/many_entry_points/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/many_entry_points/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## e00.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e00.js
 console.log(shared_default);
@@ -17,7 +17,7 @@ console.log(shared_default);
 ## e01.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e01.js
 console.log(shared_default);
@@ -28,7 +28,7 @@ console.log(shared_default);
 ## e02.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e02.js
 console.log(shared_default);
@@ -39,7 +39,7 @@ console.log(shared_default);
 ## e03.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e03.js
 console.log(shared_default);
@@ -50,7 +50,7 @@ console.log(shared_default);
 ## e04.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e04.js
 console.log(shared_default);
@@ -61,7 +61,7 @@ console.log(shared_default);
 ## e05.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e05.js
 console.log(shared_default);
@@ -72,7 +72,7 @@ console.log(shared_default);
 ## e06.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e06.js
 console.log(shared_default);
@@ -83,7 +83,7 @@ console.log(shared_default);
 ## e07.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e07.js
 console.log(shared_default);
@@ -94,7 +94,7 @@ console.log(shared_default);
 ## e08.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e08.js
 console.log(shared_default);
@@ -105,7 +105,7 @@ console.log(shared_default);
 ## e09.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e09.js
 console.log(shared_default);
@@ -116,7 +116,7 @@ console.log(shared_default);
 ## e10.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e10.js
 console.log(shared_default);
@@ -127,7 +127,7 @@ console.log(shared_default);
 ## e11.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e11.js
 console.log(shared_default);
@@ -138,7 +138,7 @@ console.log(shared_default);
 ## e12.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e12.js
 console.log(shared_default);
@@ -149,7 +149,7 @@ console.log(shared_default);
 ## e13.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e13.js
 console.log(shared_default);
@@ -160,7 +160,7 @@ console.log(shared_default);
 ## e14.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e14.js
 console.log(shared_default);
@@ -171,7 +171,7 @@ console.log(shared_default);
 ## e15.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e15.js
 console.log(shared_default);
@@ -182,7 +182,7 @@ console.log(shared_default);
 ## e16.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e16.js
 console.log(shared_default);
@@ -193,7 +193,7 @@ console.log(shared_default);
 ## e17.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e17.js
 console.log(shared_default);
@@ -204,7 +204,7 @@ console.log(shared_default);
 ## e18.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e18.js
 console.log(shared_default);
@@ -215,7 +215,7 @@ console.log(shared_default);
 ## e19.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e19.js
 console.log(shared_default);
@@ -226,7 +226,7 @@ console.log(shared_default);
 ## e20.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e20.js
 console.log(shared_default);
@@ -237,7 +237,7 @@ console.log(shared_default);
 ## e21.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e21.js
 console.log(shared_default);
@@ -248,7 +248,7 @@ console.log(shared_default);
 ## e22.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e22.js
 console.log(shared_default);
@@ -259,7 +259,7 @@ console.log(shared_default);
 ## e23.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e23.js
 console.log(shared_default);
@@ -270,7 +270,7 @@ console.log(shared_default);
 ## e24.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e24.js
 console.log(shared_default);
@@ -281,7 +281,7 @@ console.log(shared_default);
 ## e25.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e25.js
 console.log(shared_default);
@@ -292,7 +292,7 @@ console.log(shared_default);
 ## e26.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e26.js
 console.log(shared_default);
@@ -303,7 +303,7 @@ console.log(shared_default);
 ## e27.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e27.js
 console.log(shared_default);
@@ -314,7 +314,7 @@ console.log(shared_default);
 ## e28.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e28.js
 console.log(shared_default);
@@ -325,7 +325,7 @@ console.log(shared_default);
 ## e29.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e29.js
 console.log(shared_default);
@@ -336,7 +336,7 @@ console.log(shared_default);
 ## e30.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e30.js
 console.log(shared_default);
@@ -347,7 +347,7 @@ console.log(shared_default);
 ## e31.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e31.js
 console.log(shared_default);
@@ -358,7 +358,7 @@ console.log(shared_default);
 ## e32.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e32.js
 console.log(shared_default);
@@ -369,7 +369,7 @@ console.log(shared_default);
 ## e33.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e33.js
 console.log(shared_default);
@@ -380,7 +380,7 @@ console.log(shared_default);
 ## e34.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e34.js
 console.log(shared_default);
@@ -391,7 +391,7 @@ console.log(shared_default);
 ## e35.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e35.js
 console.log(shared_default);
@@ -402,7 +402,7 @@ console.log(shared_default);
 ## e36.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e36.js
 console.log(shared_default);
@@ -413,7 +413,7 @@ console.log(shared_default);
 ## e37.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e37.js
 console.log(shared_default);
@@ -424,7 +424,7 @@ console.log(shared_default);
 ## e38.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e38.js
 console.log(shared_default);
@@ -435,7 +435,7 @@ console.log(shared_default);
 ## e39.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region e39.js
 console.log(shared_default);
@@ -450,5 +450,5 @@ console.log(shared_default);
 var shared_default = 123;
 
 //#endregion
-export { shared_default };
+export { shared_default as t };
 ```

--- a/crates/rolldown/tests/esbuild/default/metafile_various_cases/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/metafile_various_cases/artifacts.snap
@@ -59,7 +59,7 @@ copy;
 var default$1 = void 0;
 
 //#endregion
-export { default$1 as default, file_default };
+export { file_default as n, default$1 as t };
 ```
 
 ## dynamic.js
@@ -75,7 +75,7 @@ export { dynamic_default as default };
 ## entry.js
 
 ```js
-import default$1, { file_default } from "./copy.js";
+import { n as file_default, t as default$1 } from "./copy.js";
 import a from "extern-esm";
 
 // HIDDEN [rolldown:runtime]

--- a/crates/rolldown/tests/esbuild/default/multiple_entry_points_same_name_collision/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/multiple_entry_points_same_name_collision/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a_entry.js
 
 ```js
-import { foo } from "./common.js";
+import { t as foo } from "./common.js";
 
 //#region a/entry.js
 console.log(foo);
@@ -17,7 +17,7 @@ console.log(foo);
 ## b_entry.js
 
 ```js
-import { foo } from "./common.js";
+import { t as foo } from "./common.js";
 
 //#region b/entry.js
 console.log(foo);
@@ -32,5 +32,5 @@ console.log(foo);
 let foo = 123;
 
 //#endregion
-export { foo };
+export { foo as t };
 ```

--- a/crates/rolldown/tests/esbuild/default/no_warn_common_js_exports_in_esm_pass_through/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/no_warn_common_js_exports_in_esm_pass_through/artifacts.snap
@@ -55,7 +55,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __commonJS };
+export { __commonJS as t };
 ```
 
 ## cjs-in-esm.js
@@ -73,7 +73,7 @@ export { foo };
 ## import-in-cjs.js
 
 ```js
-import { __commonJS } from "./chunk.js";
+import { t as __commonJS } from "./chunk.js";
 import { foo } from "bar";
 
 //#region import-in-cjs.js
@@ -90,7 +90,7 @@ export default require_import_in_cjs();
 ## no-warnings-here.js
 
 ```js
-import { __commonJS } from "./chunk.js";
+import { t as __commonJS } from "./chunk.js";
 
 //#region no-warnings-here.js
 var require_no_warnings_here = /* @__PURE__ */ __commonJS({ "no-warnings-here.js": ((exports, module) => {

--- a/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
@@ -183,7 +183,7 @@ console.log(def, ns);
 ## internal-def.js
 
 ```js
-import { internal_default } from "./internal.js";
+import { t as internal_default } from "./internal.js";
 
 //#region internal-def.js
 console.log(internal_default, void 0);
@@ -194,7 +194,7 @@ console.log(internal_default, void 0);
 ## internal-default.js
 
 ```js
-import { internal_default } from "./internal.js";
+import { t as internal_default } from "./internal.js";
 
 //#region internal-default.js
 console.log(internal_default, internal_default);
@@ -205,7 +205,7 @@ console.log(internal_default, internal_default);
 ## internal-default2.js
 
 ```js
-import { internal_default } from "./internal.js";
+import { t as internal_default } from "./internal.js";
 
 //#region internal-default2.js
 console.log(internal_default, internal_default);
@@ -216,7 +216,7 @@ console.log(internal_default, internal_default);
 ## internal-ns-def.js
 
 ```js
-import { internal_default, internal_exports } from "./internal.js";
+import { n as internal_exports, t as internal_default } from "./internal.js";
 
 //#region internal-ns-def.js
 console.log(internal_default, internal_exports, void 0);
@@ -227,7 +227,7 @@ console.log(internal_default, internal_exports, void 0);
 ## internal-ns-default.js
 
 ```js
-import { internal_default, internal_exports } from "./internal.js";
+import { n as internal_exports, t as internal_default } from "./internal.js";
 
 //#region internal-ns-default.js
 console.log(internal_default, internal_exports, internal_default);
@@ -238,7 +238,7 @@ console.log(internal_default, internal_exports, internal_default);
 ## internal-ns.js
 
 ```js
-import { internal_default, internal_exports } from "./internal.js";
+import { n as internal_exports, t as internal_default } from "./internal.js";
 
 //#region internal-ns.js
 console.log(internal_default, internal_exports);
@@ -255,5 +255,5 @@ var internal_exports = /* @__PURE__ */ __export({ default: () => internal_defaul
 var internal_default = 123;
 
 //#endregion
-export { internal_default, internal_exports };
+export { internal_exports as n, internal_default as t };
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_empty_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_empty_file/artifacts.snap
@@ -65,13 +65,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 var require_empty = /* @__PURE__ */ __commonJS({ "empty.cjs": (() => {}) });
 
 //#endregion
-export { __toESM, require_empty };
+export { __toESM as n, require_empty as t };
 ```
 
 ## entry-default.js
 
 ```js
-import { __toESM, require_empty } from "./empty.js";
+import { n as __toESM, t as require_empty } from "./empty.js";
 
 //#region entry-default.js
 var import_empty = /* @__PURE__ */ __toESM(require_empty());
@@ -83,7 +83,7 @@ console.log(void 0, void 0, import_empty.default);
 ## entry-nope.js
 
 ```js
-import { __toESM, require_empty } from "./empty.js";
+import { n as __toESM, t as require_empty } from "./empty.js";
 
 //#region entry-nope.js
 var import_empty = /* @__PURE__ */ __toESM(require_empty());

--- a/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_side_effect_free_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_namespace_undefined_property_side_effect_free_file/artifacts.snap
@@ -60,7 +60,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry-default.js
 
 ```js
-import { __toESM, require_no_side_effects } from "./no-side-effects.js";
+import { n as __toESM, t as require_no_side_effects } from "./no-side-effects.js";
 
 //#region entry-default.js
 var import_no_side_effects = /* @__PURE__ */ __toESM(require_no_side_effects());
@@ -72,7 +72,7 @@ console.log(void 0, void 0, import_no_side_effects.default);
 ## entry-nope.js
 
 ```js
-import { __toESM, require_no_side_effects } from "./no-side-effects.js";
+import { n as __toESM, t as require_no_side_effects } from "./no-side-effects.js";
 
 //#region entry-nope.js
 var import_no_side_effects = /* @__PURE__ */ __toESM(require_no_side_effects());
@@ -91,5 +91,5 @@ var require_no_side_effects = /* @__PURE__ */ __commonJS({ "foo/no-side-effects.
 }) });
 
 //#endregion
-export { __toESM, require_no_side_effects };
+export { __toESM as n, require_no_side_effects as t };
 ```

--- a/crates/rolldown/tests/esbuild/loader/loader_json_shared_with_multiple_entries_issue413/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_shared_with_multiple_entries_issue413/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { data_default } from "./data.js";
+import { t as data_default } from "./data.js";
 
 //#region a.js
 console.log("a:", data_default);
@@ -17,7 +17,7 @@ console.log("a:", data_default);
 ## b.js
 
 ```js
-import { data_default } from "./data.js";
+import { t as data_default } from "./data.js";
 
 //#region b.js
 console.log("b:", data_default);
@@ -32,5 +32,5 @@ console.log("b:", data_default);
 var data_default = { test: 123 };
 
 //#endregion
-export { data_default };
+export { data_default as t };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_assign_to_local/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_assign_to_local/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { foo, setFoo } from "./shared.js";
+import { n as setFoo, t as foo } from "./shared.js";
 
 //#region a.js
 setFoo(123);
@@ -18,7 +18,7 @@ console.log(foo);
 ## b.js
 
 ```js
-import { foo } from "./shared.js";
+import { t as foo } from "./shared.js";
 
 //#region b.js
 console.log(foo);
@@ -36,5 +36,5 @@ function setFoo(value) {
 }
 
 //#endregion
-export { foo, setFoo };
+export { setFoo as n, foo as t };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_circular_reference_issue251/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_circular_reference_issue251/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { p, q } from "./a2.js";
+import { n as q, t as p } from "./a2.js";
 
 export { p, q };
 ```
@@ -22,13 +22,13 @@ var q = 6;
 var p = 5;
 
 //#endregion
-export { p, q };
+export { q as n, p as t };
 ```
 
 ## b.js
 
 ```js
-import { p, q } from "./a2.js";
+import { n as q, t as p } from "./a2.js";
 
 export { p, q };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { setValue } from "./shared.js";
+import { t as setValue } from "./shared.js";
 
 //#region a.js
 setValue(123);
@@ -37,5 +37,5 @@ function setValue(next) {
 sideEffects(getValue);
 
 //#endregion
-export { setValue };
+export { setValue as t };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies_recursive/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies_recursive/artifacts.snap
@@ -22,7 +22,7 @@ import "./z.js";
 
 ```js
 import "./x.js";
-import { setY2, setZ2 } from "./z.js";
+import { n as setY2, t as setZ2 } from "./z.js";
 
 //#region c.js
 setY2();
@@ -38,13 +38,13 @@ setZ2();
 function setX(v) {}
 
 //#endregion
-export { setX };
+export { setX as t };
 ```
 
 ## z.js
 
 ```js
-import { setX } from "./x.js";
+import { t as setX } from "./x.js";
 
 //#region y.js
 function setY(v) {}
@@ -59,5 +59,5 @@ function setZ2(v) {
 }
 
 //#endregion
-export { setY2, setZ2 };
+export { setY2 as n, setZ2 as t };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import { __toDynamicImportESM, __toESM, require_foo } from "./foo.js";
+import { n as __toDynamicImportESM, r as __toESM, t as require_foo } from "./foo.js";
 
 //#region entry.js
 var import_foo = /* @__PURE__ */ __toESM(require_foo());
@@ -25,13 +25,13 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {
 }) });
 
 //#endregion
-export { __toDynamicImportESM, __toESM, require_foo };
+export { __toDynamicImportESM as n, __toESM as r, require_foo as t };
 ```
 
 ## foo2.js
 
 ```js
-import { require_foo } from "./foo.js";
+import { t as require_foo } from "./foo.js";
 
 export default require_foo();
 

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import { bar } from "./foo2.js";
+import { t as bar } from "./foo2.js";
 
 //#region entry.js
 import("./foo.js").then(({ bar: b }) => console.log(bar, b));
@@ -17,7 +17,7 @@ import("./foo.js").then(({ bar: b }) => console.log(bar, b));
 ## foo.js
 
 ```js
-import { bar } from "./foo2.js";
+import { t as bar } from "./foo2.js";
 
 export { bar };
 ```
@@ -29,5 +29,5 @@ export { bar };
 let bar = 123;
 
 //#endregion
-export { bar };
+export { bar as t };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_common_js_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_common_js_into_es6/artifacts.snap
@@ -7,13 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __commonJS, __toDynamicImportESM };
+export { __toDynamicImportESM as n, __commonJS as t };
 ```
 
 ## entry.js
 
 ```js
-import { __toDynamicImportESM } from "./chunk.js";
+import { n as __toDynamicImportESM } from "./chunk.js";
 
 //#region entry.js
 import("./foo.js").then(__toDynamicImportESM()).then(({ default: { bar } }) => console.log(bar));
@@ -24,7 +24,7 @@ import("./foo.js").then(__toDynamicImportESM()).then(({ default: { bar } }) => c
 ## foo.js
 
 ```js
-import { __commonJS } from "./chunk.js";
+import { t as __commonJS } from "./chunk.js";
 
 //#region foo.js
 var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports) => {

--- a/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { foo, init_a } from "./a2.js";
+import { n as foo, r as init_a } from "./a2.js";
 
 init_a();
 export { foo };
@@ -24,13 +24,13 @@ var init_a = __esm({ "a.js": (() => {
 }) });
 
 //#endregion
-export { __toCommonJS, a_exports, foo, init_a };
+export { __toCommonJS as i, foo as n, init_a as r, a_exports as t };
 ```
 
 ## b.js
 
 ```js
-import { __toCommonJS, a_exports, init_a } from "./a2.js";
+import { i as __toCommonJS, r as init_a, t as a_exports } from "./a2.js";
 
 //#region b.js
 let bar = (init_a(), __toCommonJS(a_exports));

--- a/crates/rolldown/tests/esbuild/splitting/splitting_minify_identifiers_crash_issue437/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_minify_identifiers_crash_issue437/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { foo } from "./shared.js";
+import { t as foo } from "./shared.js";
 
 //#region a.js
 console.log(foo);
@@ -17,7 +17,7 @@ console.log(foo);
 ## b.js
 
 ```js
-import { foo } from "./shared.js";
+import { t as foo } from "./shared.js";
 
 //#region b.js
 console.log(foo);
@@ -39,5 +39,5 @@ import "./shared.js";
 function foo(bar) {}
 
 //#endregion
-export { foo };
+export { foo as t };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_missing_lazy_export/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_missing_lazy_export/artifacts.snap
@@ -34,7 +34,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { foo } from "./common.js";
+import { n as foo } from "./common.js";
 
 //#region a.js
 console.log(foo());
@@ -45,7 +45,7 @@ console.log(foo());
 ## b.js
 
 ```js
-import { bar } from "./common.js";
+import { t as bar } from "./common.js";
 
 //#region b.js
 console.log(bar());
@@ -69,5 +69,5 @@ function bar() {
 }
 
 //#endregion
-export { bar, foo };
+export { foo as n, bar as t };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_nested_directories/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_nested_directories/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## pageA_page.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region pageA/page.js
 console.log(shared_default);
@@ -17,7 +17,7 @@ console.log(shared_default);
 ## pageB_page.js
 
 ```js
-import { shared_default } from "./shared.js";
+import { t as shared_default } from "./shared.js";
 
 //#region pageB/page.js
 console.log(-shared_default);
@@ -32,5 +32,5 @@ console.log(-shared_default);
 var shared_default = 123;
 
 //#endregion
-export { shared_default };
+export { shared_default as t };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_re_export_issue273/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_re_export_issue273/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { a } from "./a2.js";
+import { t as a } from "./a2.js";
 
 export { a };
 ```
@@ -18,13 +18,13 @@ export { a };
 const a = 1;
 
 //#endregion
-export { a };
+export { a as t };
 ```
 
 ## b.js
 
 ```js
-import { a } from "./a2.js";
+import { t as a } from "./a2.js";
 
 export { a };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_shared_common_js_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_shared_common_js_into_es6/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { require_shared } from "./shared.js";
+import { t as require_shared } from "./shared.js";
 
 //#region a.js
 const { foo } = require_shared();
@@ -18,7 +18,7 @@ console.log(foo);
 ## b.js
 
 ```js
-import { require_shared } from "./shared.js";
+import { t as require_shared } from "./shared.js";
 
 //#region b.js
 const { foo } = require_shared();
@@ -37,5 +37,5 @@ var require_shared = /* @__PURE__ */ __commonJS({ "shared.js": ((exports) => {
 }) });
 
 //#endregion
-export { require_shared };
+export { require_shared as t };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_shared_es6_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_shared_es6_into_es6/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { foo } from "./shared.js";
+import { t as foo } from "./shared.js";
 
 //#region a.js
 console.log(foo);
@@ -17,7 +17,7 @@ console.log(foo);
 ## b.js
 
 ```js
-import { foo } from "./shared.js";
+import { t as foo } from "./shared.js";
 
 //#region b.js
 console.log(foo);
@@ -32,5 +32,5 @@ console.log(foo);
 let foo = 123;
 
 //#endregion
-export { foo };
+export { foo as t };
 ```

--- a/crates/rolldown/tests/esbuild/splitting/splitting_side_effects_without_dependencies/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_side_effects_without_dependencies/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { a } from "./shared.js";
+import { t as a } from "./shared.js";
 
 //#region a.js
 console.log(a);
@@ -17,7 +17,7 @@ console.log(a);
 ## b.js
 
 ```js
-import { b } from "./shared.js";
+import { n as b } from "./shared.js";
 
 //#region b.js
 console.log(b);
@@ -34,5 +34,5 @@ let b = 2;
 console.log("side effect");
 
 //#endregion
-export { a, b };
+export { b as n, a as t };
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/dynamic_cjs_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/dynamic_cjs_entry/artifacts.snap
@@ -7,13 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __commonJS, __toDynamicImportESM };
+export { __toDynamicImportESM as n, __commonJS as t };
 ```
 
 ## cjs.js
 
 ```js
-import { __commonJS } from "./chunk.js";
+import { t as __commonJS } from "./chunk.js";
 
 //#region cjs.js
 var require_cjs = /* @__PURE__ */ __commonJS({ "cjs.js": ((exports, module) => {
@@ -28,7 +28,7 @@ export default require_cjs();
 ## main.js
 
 ```js
-import { __toDynamicImportESM } from "./chunk.js";
+import { n as __toDynamicImportESM } from "./chunk.js";
 
 //#region main.js
 var main_default = import("./cjs.js").then(__toDynamicImportESM());

--- a/crates/rolldown/tests/rolldown/cjs_compat/multiple_circle_cjs_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/multiple_circle_cjs_entries/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { require_a } from "./a2.js";
+import { t as require_a } from "./a2.js";
 
 export default require_a();
 
@@ -30,13 +30,13 @@ var require_a = /* @__PURE__ */ __commonJS({ "a.js": ((exports, module) => {
 }) });
 
 //#endregion
-export { require_a, require_b };
+export { require_b as n, require_a as t };
 ```
 
 ## b.js
 
 ```js
-import { require_b } from "./a2.js";
+import { n as require_b } from "./a2.js";
 
 export default require_b();
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/node_module_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/node_module_commonjs/artifacts.snap
@@ -13,13 +13,13 @@ var require_commonjs = /* @__PURE__ */ __commonJS({ "commonjs.js": ((exports, mo
 }) });
 
 //#endregion
-export { __reExport, __toESM, require_commonjs };
+export { __reExport as n, __toESM as r, require_commonjs as t };
 ```
 
 ## entry.js
 
 ```js
-import { __toESM, require_commonjs } from "./commonjs.js";
+import { r as __toESM, t as require_commonjs } from "./commonjs.js";
 
 //#region entry.js
 var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs(), 1);
@@ -31,7 +31,7 @@ console.log(import_commonjs.default);
 ## main.js
 
 ```js
-import { __reExport, __toESM, require_commonjs } from "./commonjs.js";
+import { n as __reExport, r as __toESM, t as require_commonjs } from "./commonjs.js";
 
 //#region star-export.js
 var star_export_exports = {};

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize_chunk_split/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize_chunk_split/artifacts.snap
@@ -20,13 +20,13 @@ function test() {
 }
 
 //#endregion
-export { __toESM, require_cjs, test };
+export { require_cjs as n, __toESM as r, test as t };
 ```
 
 ## entry.js
 
 ```js
-import { test } from "./a.js";
+import { t as test } from "./a.js";
 
 //#region entry.js
 const entry = test();
@@ -38,7 +38,7 @@ export { entry };
 ## main.js
 
 ```js
-import { __toESM, require_cjs, test } from "./a.js";
+import { n as require_cjs, r as __toESM, t as test } from "./a.js";
 
 //#region b.js
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
@@ -12,13 +12,13 @@ var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
 const foo = 1;
 
 //#endregion
-export { foo, foo_exports };
+export { foo_exports as n, foo as t };
 ```
 
 ## foo2.js
 
 ```js
-import { foo } from "./foo.js";
+import { t as foo } from "./foo.js";
 
 export { foo };
 ```
@@ -26,7 +26,7 @@ export { foo };
 ## main.js
 
 ```js
-import { foo_exports } from "./foo.js";
+import { n as foo_exports } from "./foo.js";
 
 //#region main.js
 import("./foo2.js").then(console.log);
@@ -37,6 +37,6 @@ console.log(foo_exports);
 
 # Output Stats
 
-- foo.js, is_entry false, is_dynamic_entry false, exports ["foo", "foo_exports"]
+- foo.js, is_entry false, is_dynamic_entry false, exports ["n", "t"]
 - foo2.js, is_entry false, is_dynamic_entry true, exports ["foo"]
 - main.js, is_entry true, is_dynamic_entry false, exports []

--- a/crates/rolldown/tests/rolldown/code_splitting/import_export_unicode/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/import_export_unicode/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## foo.js
 
 ```js
-import { devil } from "./foo2.js";
+import { t as devil } from "./foo2.js";
 
 export { devil as "😈" };
 ```
@@ -18,13 +18,13 @@ export { devil as "😈" };
 const devil = "devil";
 
 //#endregion
-export { devil };
+export { devil as t };
 ```
 
 ## main.js
 
 ```js
-import { devil } from "./foo2.js";
+import { t as devil } from "./foo2.js";
 
 //#region main.js
 const moduleFoo = import("./foo.js");

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
@@ -6,8 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { share_default } from "./share2.js";
-import { share_default as share_default$1 } from "./share4.js";
+import { t as share_default } from "./share2.js";
+import { t as share_default$1 } from "./share4.js";
 
 //#region main.js
 console.log(share_default, share_default$1);
@@ -20,7 +20,7 @@ import("./share3.js").then(console.log);
 ## share.js
 
 ```js
-import { share_default } from "./share2.js";
+import { t as share_default } from "./share2.js";
 
 export { share_default as default };
 ```
@@ -32,13 +32,13 @@ export { share_default as default };
 var share_default = "shared";
 
 //#endregion
-export { share_default };
+export { share_default as t };
 ```
 
 ## share3.js
 
 ```js
-import { share_default } from "./share4.js";
+import { t as share_default } from "./share4.js";
 
 export { share_default as default };
 ```
@@ -50,5 +50,5 @@ export { share_default as default };
 var share_default = {};
 
 //#endregion
-export { share_default };
+export { share_default as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { a } from "./common.js";
+import { n as a } from "./common.js";
 
 export { a };
 ```
@@ -14,7 +14,7 @@ export { a };
 ## b.js
 
 ```js
-import { b } from "./common.js";
+import { t as b } from "./common.js";
 
 export { b };
 ```
@@ -30,7 +30,7 @@ const a = "a";
 const b = "a";
 
 //#endregion
-export { a, b };
+export { a as n, b as t };
 ```
 
 # Variant: no-profiler-names: [profiler_names: false]
@@ -40,7 +40,7 @@ export { a, b };
 ### a.js
 
 ```js
-import { a } from "./common.js";
+import { n as a } from "./common.js";
 
 export { a };
 ```
@@ -48,7 +48,7 @@ export { a };
 ### b.js
 
 ```js
-import { b } from "./common.js";
+import { t as b } from "./common.js";
 
 export { b };
 ```
@@ -64,5 +64,5 @@ const a = "a";
 const b = "a";
 
 //#endregion
-export { a, b };
+export { a as n, b as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/basic_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/basic_cjs/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { require_a } from "./common.js";
+import { n as require_a } from "./common.js";
 
 export default require_a();
 
@@ -15,7 +15,7 @@ export default require_a();
 ## b.js
 
 ```js
-import { require_b } from "./common.js";
+import { t as require_b } from "./common.js";
 
 export default require_b();
 
@@ -24,7 +24,7 @@ export default require_b();
 ## common.js
 
 ```js
-import { __commonJS } from "./rolldown-runtime.js";
+import { t as __commonJS } from "./rolldown-runtime.js";
 
 //#region a.cjs
 var require_a = /* @__PURE__ */ __commonJS({ "a.cjs": ((exports) => {
@@ -38,14 +38,14 @@ var require_b = /* @__PURE__ */ __commonJS({ "b.cjs": ((exports) => {
 }) });
 
 //#endregion
-export { require_a, require_b };
+export { require_a as n, require_b as t };
 ```
 
 ## rolldown-runtime.js
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __commonJS };
+export { __commonJS as t };
 ```
 
 # Variant: no-profiler-names: [profiler_names: false]
@@ -55,7 +55,7 @@ export { __commonJS };
 ### a.js
 
 ```js
-import { require_a } from "./common.js";
+import { n as require_a } from "./common.js";
 
 export default require_a();
 
@@ -64,7 +64,7 @@ export default require_a();
 ### b.js
 
 ```js
-import { require_b } from "./common.js";
+import { t as require_b } from "./common.js";
 
 export default require_b();
 
@@ -73,7 +73,7 @@ export default require_b();
 ### common.js
 
 ```js
-import { __commonJSMin } from "./rolldown-runtime.js";
+import { t as __commonJSMin } from "./rolldown-runtime.js";
 
 //#region a.cjs
 var require_a = /* @__PURE__ */ __commonJSMin(((exports) => {
@@ -87,12 +87,12 @@ var require_b = /* @__PURE__ */ __commonJSMin(((exports) => {
 }));
 
 //#endregion
-export { require_a, require_b };
+export { require_a as n, require_b as t };
 ```
 
 ### rolldown-runtime.js
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __commonJSMin };
+export { __commonJSMin as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/artifacts.snap
@@ -6,8 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { __esm } from "./rolldown-runtime.js";
-import { foo, init_foo } from "./vendor.js";
+import { t as __esm } from "./rolldown-runtime.js";
+import { n as init_foo, t as foo } from "./vendor.js";
 import nodeAssert from "node:assert";
 
 //#region main.js
@@ -24,13 +24,13 @@ init_main();
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __esm };
+export { __esm as t };
 ```
 
 ## vendor.js
 
 ```js
-import { __esm } from "./rolldown-runtime.js";
+import { t as __esm } from "./rolldown-runtime.js";
 
 //#region bar.js
 var bar;
@@ -47,5 +47,5 @@ var init_foo = __esm({ "foo.js": (() => {
 }) });
 
 //#endregion
-export { foo, init_foo };
+export { init_foo as n, foo as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/issue_2617/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/issue_2617/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { lib_default } from "./splited_lib.js";
+import { t as lib_default } from "./splited_lib.js";
 
 //#region main.js
 console.log("lib", lib_default);
@@ -21,5 +21,5 @@ console.log("lib", lib_default);
 var lib_default = "hello, world";
 
 //#endregion
-export { lib_default };
+export { lib_default as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
@@ -6,8 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { lib_ui_exports } from "./ui.js";
-import { lib_npm_a_exports, lib_npm_b_exports } from "./other-libs.js";
+import { t as lib_ui_exports } from "./ui.js";
+import { n as lib_npm_a_exports, t as lib_npm_b_exports } from "./other-libs.js";
 
 export { lib_npm_a_exports as libA, lib_npm_b_exports as libB, lib_ui_exports as ui };
 ```
@@ -15,7 +15,7 @@ export { lib_npm_a_exports as libA, lib_npm_b_exports as libB, lib_ui_exports as
 ## other-libs.js
 
 ```js
-import { __export } from "./rolldown-runtime.js";
+import { t as __export } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-npm-a/index.js
 var lib_npm_a_exports = /* @__PURE__ */ __export({ default: () => lib_npm_a_default });
@@ -27,7 +27,7 @@ var lib_npm_b_exports = /* @__PURE__ */ __export({ default: () => lib_npm_b_defa
 var lib_npm_b_default = "npm-b";
 
 //#endregion
-export { lib_npm_a_exports, lib_npm_b_exports };
+export { lib_npm_a_exports as n, lib_npm_b_exports as t };
 ```
 
 ## rolldown-runtime.js
@@ -45,18 +45,18 @@ var __export = (all) => {
 };
 
 //#endregion
-export { __export };
+export { __export as t };
 ```
 
 ## ui.js
 
 ```js
-import { __export } from "./rolldown-runtime.js";
+import { t as __export } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-ui/index.js
 var lib_ui_exports = /* @__PURE__ */ __export({ default: () => lib_ui_default });
 var lib_ui_default = "ui";
 
 //#endregion
-export { lib_ui_exports };
+export { lib_ui_exports as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/dir/should_generate_correct_relative_import_path/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/dir/should_generate_correct_relative_import_path/artifacts.snap
@@ -20,13 +20,13 @@ export { value };
 const value = "shared";
 
 //#endregion
-export { value };
+export { value as t };
 ```
 
 ## ./entries/a.mjs
 
 ```js
-import { value } from "../chunks/shared.mjs";
+import { t as value } from "../chunks/shared.mjs";
 
 //#region a.js
 const asyncValue = import("../chunks/async.mjs");
@@ -38,7 +38,7 @@ export { asyncValue, value };
 ## ./entries/b.mjs
 
 ```js
-import { value } from "../chunks/shared.mjs";
+import { t as value } from "../chunks/shared.mjs";
 
 //#region b.js
 const asyncValue = import("../chunks/async.mjs");

--- a/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_correct_relative_import_path/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_correct_relative_import_path/artifacts.snap
@@ -20,13 +20,13 @@ export { value };
 const value = "shared";
 
 //#endregion
-export { value };
+export { value as t };
 ```
 
 ## ./entries/a.mjs
 
 ```js
-import { value } from "../chunks/shared.mjs";
+import { t as value } from "../chunks/shared.mjs";
 
 //#region a.js
 const asyncValue = import("../chunks/async.mjs");
@@ -38,7 +38,7 @@ export { asyncValue, value };
 ## ./entries/b.mjs
 
 ```js
-import { value } from "../chunks/shared.mjs";
+import { t as value } from "../chunks/shared.mjs";
 
 //#region b.js
 const asyncValue = import("../chunks/async.mjs");

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/ensure_lazy_module_eval/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/ensure_lazy_module_eval/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { require_dynamic } from "./dynamic2.js";
+import { t as require_dynamic } from "./dynamic2.js";
 
 export default require_dynamic();
 
@@ -23,13 +23,13 @@ var require_dynamic = /* @__PURE__ */ __commonJS({ "dynamic.js": ((exports, modu
 }) });
 
 //#endregion
-export { __toESM, require_dynamic };
+export { __toESM as n, require_dynamic as t };
 ```
 
 ## main.js
 
 ```js
-import { __toESM, require_dynamic } from "./dynamic2.js";
+import { n as __toESM, t as require_dynamic } from "./dynamic2.js";
 import { strictEqual } from "node:assert";
 
 //#region sideeffects.js

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lazy-chunk.js
 
 ```js
-import { foo } from "./user-lib.js";
+import { t as foo } from "./user-lib.js";
 
 //#region lazy-chunk.js
 foo();
@@ -17,7 +17,7 @@ foo();
 ## main.js
 
 ```js
-import { foo } from "./user-lib.js";
+import { t as foo } from "./user-lib.js";
 
 //#region polyfill.js
 Object.somePolyfilledFunction = () => {};
@@ -39,5 +39,5 @@ async function foo() {
 }
 
 //#endregion
-export { foo };
+export { foo as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/strict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/strict/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lazy-chunk.js
 
 ```js
-import { __esm, foo, init_user_lib } from "./user-lib.js";
+import { n as init_user_lib, r as __esm, t as foo } from "./user-lib.js";
 
 //#region lazy-chunk.js
 var init_lazy_chunk = __esm({ "lazy-chunk.js": (() => {
@@ -21,7 +21,7 @@ init_lazy_chunk();
 ## main.js
 
 ```js
-import { __esm, foo, init_user_lib } from "./user-lib.js";
+import { n as init_user_lib, r as __esm, t as foo } from "./user-lib.js";
 
 //#region polyfill.js
 var init_polyfill = __esm({ "polyfill.js": (() => {
@@ -53,5 +53,5 @@ var init_user_lib = __esm({ "user-lib.js": (() => {
 }) });
 
 //#endregion
-export { __esm, foo, init_user_lib };
+export { init_user_lib as n, __esm as r, foo as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/strict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/strict/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry1.js
 
 ```js
-import { __esm, init_run_dep } from "./run-dep.js";
+import { n as __esm, t as init_run_dep } from "./run-dep.js";
 
 //#region init-dep-1.js
 var init_init_dep_1 = __esm({ "init-dep-1.js": (() => {
@@ -27,7 +27,7 @@ init_entry1();
 ## entry2.js
 
 ```js
-import { __esm, init_run_dep } from "./run-dep.js";
+import { n as __esm, t as init_run_dep } from "./run-dep.js";
 
 //#region init-dep-2.js
 var init_init_dep_2 = __esm({ "init-dep-2.js": (() => {
@@ -55,5 +55,5 @@ var init_run_dep = __esm({ "run-dep.js": (() => {
 }) });
 
 //#endregion
-export { __esm, init_run_dep };
+export { __esm as n, init_run_dep as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { __esm, init_read, read } from "./read.js";
+import { n as read, r as __esm, t as init_read } from "./read.js";
 
 //#region dynamic.js
 var init_dynamic = __esm({ "dynamic.js": (() => {
@@ -21,7 +21,7 @@ init_dynamic();
 ## main.js
 
 ```js
-import { __esm, init_read, read } from "./read.js";
+import { n as read, r as __esm, t as init_read } from "./read.js";
 import nodeAssert from "node:assert";
 
 //#region setup.js
@@ -62,5 +62,5 @@ var init_read = __esm({ "read.js": (() => {
 }) });
 
 //#endregion
-export { __esm, init_read, read };
+export { read as n, __esm as r, init_read as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
@@ -40,22 +40,23 @@ export { dep_default as dep };
 import nodeAssert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
+//#region dep.js
 function foo() {
 	globalThis.value = 1;
 }
-
 var dep_default;
-var init_main = __esm({"main.js": (() => {
-//#region dep.js
+var init_dep = __esm({ "dep.js": (() => {
 	dep_default = /* @__PURE__ */ foo();
+}) });
 
 //#endregion
 //#region main.js
+var init_main = __esm({ "main.js": (() => {
+	init_dep();
 	nodeAssert.strictEqual(globalThis.value, 1);
+}) });
 
 //#endregion
-})});
-
 init_main();
 export { dep_default as dep };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/artifacts.snap
@@ -6,8 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { __esm } from "./rolldown-runtime.js";
-import { init_foo } from "./test.js";
+import { t as __esm } from "./rolldown-runtime.js";
+import { t as init_foo } from "./test.js";
 
 
 var init_main = __esm({"main.js": (() => {
@@ -28,13 +28,13 @@ init_main();
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __esm };
+export { __esm as t };
 ```
 
 ## test.js
 
 ```js
-import { __esm } from "./rolldown-runtime.js";
+import { t as __esm } from "./rolldown-runtime.js";
 import assert from "node:assert";
 
 //#region foo_inner.js
@@ -51,5 +51,5 @@ var init_foo = __esm({ "foo.js": (() => {
 }) });
 
 //#endregion
-export { init_foo };
+export { init_foo as t };
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { require_dynamic } from "./dynamic2.js";
+import { t as require_dynamic } from "./dynamic2.js";
 
 export default require_dynamic();
 
@@ -23,13 +23,13 @@ var require_dynamic = /* @__PURE__ */ __commonJS({ "dynamic.js": ((exports, modu
 }) });
 
 //#endregion
-export { __esm, __toESM, require_dynamic };
+export { __esm as n, __toESM as r, require_dynamic as t };
 ```
 
 ## main.js
 
 ```js
-import { __esm, __toESM, require_dynamic } from "./dynamic2.js";
+import { n as __esm, r as __toESM, t as require_dynamic } from "./dynamic2.js";
 import { strictEqual } from "node:assert";
 
 function foo() {

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports/artifacts.snap
@@ -7,13 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __esm };
+export { __esm as t };
 ```
 
 ## common.js
 
 ```js
-import { __esm } from "./chunk.js";
+import { t as __esm } from "./chunk.js";
 
 //#region common.js
 function foo() {
@@ -26,13 +26,13 @@ var init_common = __esm({ "common.js": (() => {
 }) });
 
 //#endregion
-export { _, common, init_common };
+export { common as n, init_common as r, _ as t };
 ```
 
 ## main.js
 
 ```js
-import { __esm } from "./chunk.js";
+import { t as __esm } from "./chunk.js";
 
 //#region main.js
 var init_main = __esm({ "main.js": (async () => {
@@ -47,8 +47,8 @@ await init_main();
 ## page-a.js
 
 ```js
-import { __esm } from "./chunk.js";
-import { _, common, init_common } from "./common.js";
+import { t as __esm } from "./chunk.js";
+import { n as common, r as init_common, t as _ } from "./common.js";
 import nodeAssert from "node:assert";
 
 //#region page-a.js
@@ -68,7 +68,7 @@ export { render };
 ## page-b.js
 
 ```js
-import { __esm } from "./chunk.js";
+import { t as __esm } from "./chunk.js";
 import nodeAssert from "node:assert";
 
 //#region page-b.js

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## indirect.js
 
 ```js
-import { read } from "./indirect2.js";
+import { t as read } from "./indirect2.js";
 
 export { read };
 ```
@@ -16,13 +16,13 @@ export { read };
 ```js
 import { read } from "node:fs";
 
-export { read };
+export { read as t };
 ```
 
 ## main.js
 
 ```js
-import { read } from "./indirect2.js";
+import { t as read } from "./indirect2.js";
 
 //#region read.js
 console.log(1);

--- a/crates/rolldown/tests/rolldown/function/external/splitting_with_external_module/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_with_external_module/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import { value } from "./share.js";
+import { t as value } from "./share.js";
 import assert from "node:assert";
 
 //#region entry.js
@@ -18,7 +18,7 @@ assert.equal(value, 1);
 ## main.js
 
 ```js
-import { value } from "./share.js";
+import { t as value } from "./share.js";
 import assert from "node:assert";
 
 //#region main.js
@@ -34,5 +34,5 @@ assert(value === 1);
 const value = 1;
 
 //#endregion
-export { value };
+export { value as t };
 ```

--- a/crates/rolldown/tests/rolldown/issues/1722/1/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/1722/1/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## foo.js
 
 ```js
-import { import_sub, main } from "./main2.js";
+import { n as main, t as import_sub } from "./main2.js";
 
 var sub = import_sub.sub;
 export { main, sub };
@@ -15,7 +15,7 @@ export { main, sub };
 ## main.js
 
 ```js
-import { import_sub, main } from "./main2.js";
+import { n as main, t as import_sub } from "./main2.js";
 
 var sub = import_sub.sub;
 export { main, sub };
@@ -36,5 +36,5 @@ var import_sub = /* @__PURE__ */ __toESM(require_sub());
 const main = "main";
 
 //#endregion
-export { import_sub, main };
+export { main as n, import_sub as t };
 ```

--- a/crates/rolldown/tests/rolldown/issues/1722/2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/1722/2/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry1.js
 
 ```js
-import { import_foo } from "./main.js";
+import { t as import_foo } from "./main.js";
 
 var foo = import_foo.foo;
 export { foo };
@@ -15,7 +15,7 @@ export { foo };
 ## entry2.js
 
 ```js
-import { import_foo } from "./main.js";
+import { t as import_foo } from "./main.js";
 
 var foo = import_foo.foo;
 export { foo };
@@ -35,5 +35,5 @@ var require_foo = /* @__PURE__ */ __commonJS({ "foo.js": ((exports, module) => {
 var import_foo = /* @__PURE__ */ __toESM(require_foo());
 
 //#endregion
-export { import_foo };
+export { import_foo as t };
 ```

--- a/crates/rolldown/tests/rolldown/issues/2038/a/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2038/a/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { result } from "./b2.js";
+import { t as result } from "./b2.js";
 
 //#region a.js
 var a_default = result();
@@ -18,7 +18,7 @@ export { a_default as default };
 ## b.js
 
 ```js
-import { result } from "./b2.js";
+import { t as result } from "./b2.js";
 
 export { result };
 ```
@@ -32,7 +32,7 @@ function result() {
 }
 
 //#endregion
-export { result };
+export { result as t };
 ```
 
 ## main.js

--- a/crates/rolldown/tests/rolldown/issues/2038/b/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2038/b/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { import_c } from "./b.js";
+import { t as import_c } from "./b.js";
 
 //#region a.js
 let a = import_c.test;
@@ -30,13 +30,13 @@ var require_c = /* @__PURE__ */ __commonJS({ "c.js": ((exports) => {
 var import_c = /* @__PURE__ */ __toESM(require_c());
 
 //#endregion
-export { import_c };
+export { import_c as t };
 ```
 
 ## b2.js
 
 ```js
-import { import_c } from "./b.js";
+import { t as import_c } from "./b.js";
 
 var test = import_c.test;
 export { test };

--- a/crates/rolldown/tests/rolldown/issues/2085/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2085/artifacts.snap
@@ -19,13 +19,13 @@ var require_b = /* @__PURE__ */ __commonJS({ "b.js": ((exports) => {
 var import_b = /* @__PURE__ */ __toESM(require_b());
 
 //#endregion
-export { import_b };
+export { import_b as t };
 ```
 
 ## a2.js
 
 ```js
-import { import_b } from "./a.js";
+import { t as import_b } from "./a.js";
 
 var b_default = import_b._default;
 export { b_default as default };
@@ -34,7 +34,7 @@ export { b_default as default };
 ## c.js
 
 ```js
-import { import_b } from "./a.js";
+import { t as import_b } from "./a.js";
 
 //#region c.js
 function c_default(tag, options) {

--- a/crates/rolldown/tests/rolldown/issues/3438/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3438/artifacts.snap
@@ -6,9 +6,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { clear } from "./repro12.js";
-import { clear as clear$1, clear$1 as clear$1$1 } from "./repro22.js";
-import { clear as clear$2, clear$1 as clear$1$2, clear$2 as clear$2$1 } from "./repro32.js";
+import { t as clear } from "./repro12.js";
+import { n as clear$1$1, t as clear$1 } from "./repro22.js";
+import { n as clear$1$2, r as clear$2$1, t as clear$2 } from "./repro32.js";
 
 //#region main.js
 var main_default = [
@@ -30,7 +30,7 @@ export { main_default as default };
 ## repro1.js
 
 ```js
-import { clear } from "./repro12.js";
+import { t as clear } from "./repro12.js";
 
 export { clear };
 ```
@@ -42,13 +42,13 @@ export { clear };
 const clear = "repro1_clear";
 
 //#endregion
-export { clear };
+export { clear as t };
 ```
 
 ## repro2.js
 
 ```js
-import { clear, clear$1 } from "./repro22.js";
+import { n as clear$1, t as clear } from "./repro22.js";
 
 export { clear, clear$1 };
 ```
@@ -61,13 +61,13 @@ const clear$1 = "repro2_clear$1";
 const clear = "repro2_clear";
 
 //#endregion
-export { clear, clear$1 };
+export { clear$1 as n, clear as t };
 ```
 
 ## repro3.js
 
 ```js
-import { clear, clear$1, clear$2 } from "./repro32.js";
+import { n as clear$1, r as clear$2, t as clear } from "./repro32.js";
 
 export { clear, clear$1, clear$2 };
 ```
@@ -81,5 +81,5 @@ const clear$1 = "repro3_clear$1";
 const clear = "repro3_clear";
 
 //#endregion
-export { clear, clear$1, clear$2 };
+export { clear$1 as n, clear$2 as r, clear as t };
 ```

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -21,8 +21,8 @@ To fix:
 ## first.js
 
 ```js
-import { __esm, __export } from "./rolldown-runtime.js";
-import { init_second, value } from "./second.js";
+import { n as __export, t as __esm } from "./rolldown-runtime.js";
+import { r as value, t as init_second } from "./second.js";
 
 //#region first.js
 var first_exports = /* @__PURE__ */ __export({ value: () => value$1 });
@@ -33,15 +33,15 @@ var init_first = __esm({ "first.js": (() => {
 }) });
 
 //#endregion
-export { first_exports, init_first, value$1 as value };
+export { init_first as n, value$1 as r, first_exports as t };
 ```
 
 ## main.js
 
 ```js
-import { __esm } from "./rolldown-runtime.js";
-import { init_second, second_exports } from "./second.js";
-import { first_exports, init_first } from "./first.js";
+import { t as __esm } from "./rolldown-runtime.js";
+import { n as second_exports, t as init_second } from "./second.js";
+import { n as init_first, t as first_exports } from "./first.js";
 
 //#region main.js
 var init_main = __esm({ "main.js": (() => {
@@ -58,14 +58,14 @@ init_main();
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __esm, __export };
+export { __export as n, __esm as t };
 ```
 
 ## second.js
 
 ```js
-import { __esm, __export } from "./rolldown-runtime.js";
-import { init_first, value } from "./first.js";
+import { n as __export, t as __esm } from "./rolldown-runtime.js";
+import { n as init_first, r as value } from "./first.js";
 
 //#region second.js
 var second_exports = /* @__PURE__ */ __export({ value: () => value$1 });
@@ -76,5 +76,5 @@ var init_second = __esm({ "second.js": (() => {
 }) });
 
 //#endregion
-export { init_second, second_exports, value$1 as value };
+export { second_exports as n, value$1 as r, init_second as t };
 ```

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -7,13 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __commonJS, __toDynamicImportESM, __toESM };
+export { __toDynamicImportESM as n, __toESM as r, __commonJS as t };
 ```
 
 ## lib.js
 
 ```js
-import { __commonJS } from "./chunk.js";
+import { t as __commonJS } from "./chunk.js";
 
 //#region lib.js
 var require_lib = /* @__PURE__ */ __commonJS({ "lib.js": ((exports) => {
@@ -29,7 +29,7 @@ export default require_lib();
 ## main.js
 
 ```js
-import { __commonJS, __toDynamicImportESM, __toESM } from "./chunk.js";
+import { n as __toDynamicImportESM, r as __toESM, t as __commonJS } from "./chunk.js";
 import nodeAssert from "node:assert";
 
 //#region non-node-mode.js

--- a/crates/rolldown/tests/rolldown/issues/4895/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4895/artifacts.snap
@@ -16,13 +16,13 @@ import("./dynamic.js");
 const unused = 42;
 
 //#endregion
-export { shared, unused };
+export { shared as t, unused };
 ```
 
 ## dynamic.js
 
 ```js
-import { shared } from "./allow-extension.js";
+import { t as shared } from "./allow-extension.js";
 
 //#region allow-extension/dynamic.js
 console.log(shared);
@@ -33,7 +33,7 @@ console.log(shared);
 ## dynamic2.js
 
 ```js
-import { shared } from "./false.js";
+import { t as shared } from "./false.js";
 
 //#region false/dynamic.js
 console.log(shared);
@@ -44,7 +44,7 @@ console.log(shared);
 ## dynamic3.js
 
 ```js
-import { shared } from "./lib.js";
+import { t as shared } from "./lib.js";
 
 //#region not-specified/dynamic.js
 console.log(shared);
@@ -55,7 +55,7 @@ console.log(shared);
 ## dynamic4.js
 
 ```js
-import { shared } from "./lib2.js";
+import { t as shared } from "./lib2.js";
 
 //#region strict/dynamic.js
 console.log(shared);
@@ -75,7 +75,7 @@ console.log(shared);
 import("./dynamic2.js");
 
 //#endregion
-export { shared };
+export { shared as t };
 ```
 
 ## lib.js
@@ -85,7 +85,7 @@ export { shared };
 const shared = "shared";
 
 //#endregion
-export { shared };
+export { shared as t };
 ```
 
 ## lib2.js
@@ -95,7 +95,7 @@ export { shared };
 const shared = "shared";
 
 //#endregion
-export { shared };
+export { shared as t };
 ```
 
 ## main.js
@@ -107,7 +107,7 @@ export { shared };
 ## not-specified.js
 
 ```js
-import { shared } from "./lib.js";
+import { t as shared } from "./lib.js";
 
 //#region not-specified/main.js
 console.log(shared);
@@ -121,7 +121,7 @@ export { unused };
 ## strict.js
 
 ```js
-import { shared } from "./lib2.js";
+import { t as shared } from "./lib2.js";
 
 //#region strict/main.js
 console.log(shared);

--- a/crates/rolldown/tests/rolldown/issues/6593/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6593/artifacts.snap
@@ -7,13 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __commonJS, __toDynamicImportESM };
+export { __toDynamicImportESM as n, __commonJS as t };
 ```
 
 ## lib.js
 
 ```js
-import { __commonJS } from "./chunk.js";
+import { t as __commonJS } from "./chunk.js";
 
 //#region plugin.js
 var require_plugin = /* @__PURE__ */ __commonJS({ "plugin.js": ((exports) => {
@@ -40,7 +40,7 @@ export default require_lib();
 ## main.js
 
 ```js
-import { __toDynamicImportESM } from "./chunk.js";
+import { n as __toDynamicImportESM } from "./chunk.js";
 import assert from "node:assert";
 
 //#region entry.js

--- a/crates/rolldown/tests/rolldown/misc/chunk_level_directives/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/chunk_level_directives/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 "use entry2";
 
 
-import { a } from "./shared.js";
+import { t as a } from "./shared.js";
 
 //#region entry2.js
 console.log(`a: `, a);
@@ -23,7 +23,7 @@ console.log(`a: `, a);
 "use entry";
 
 
-import { a } from "./shared.js";
+import { t as a } from "./shared.js";
 
 //#region entry1.js
 console.log(`a: `, a);
@@ -38,5 +38,5 @@ console.log(`a: `, a);
 const a = "shared.js";
 
 //#endregion
-export { a };
+export { a as t };
 ```

--- a/crates/rolldown/tests/rolldown/misc/cjs_entry_as_dependency/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/cjs_entry_as_dependency/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { __commonJS, __toESM, require_main2 } from "./main22.js";
+import { n as __commonJS, r as __toESM, t as require_main2 } from "./main22.js";
 
 //#region main.js
 var require_main = /* @__PURE__ */ __commonJS({ "main.js": ((exports, module) => {
@@ -22,7 +22,7 @@ export default require_main();
 ## main2.js
 
 ```js
-import { require_main2 } from "./main22.js";
+import { t as require_main2 } from "./main22.js";
 
 export default require_main2();
 
@@ -38,5 +38,5 @@ var require_main2 = /* @__PURE__ */ __commonJS({ "main2.js": ((exports, module) 
 }) });
 
 //#endregion
-export { __commonJS, __toESM, require_main2 };
+export { __commonJS as n, __toESM as r, require_main2 as t };
 ```

--- a/crates/rolldown/tests/rolldown/misc/duplicate_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/duplicate_entries/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { main_default } from "./main3.js";
+import { t as main_default } from "./main3.js";
 
 export { main_default as default };
 ```
@@ -14,7 +14,7 @@ export { main_default as default };
 ## main2.js
 
 ```js
-import { main_default } from "./main3.js";
+import { t as main_default } from "./main3.js";
 
 export { main_default as default };
 ```
@@ -26,5 +26,5 @@ export { main_default as default };
 var main_default = {};
 
 //#endregion
-export { main_default };
+export { main_default as t };
 ```

--- a/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/basic/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { value } from "./main.js";
+import { t as value } from "./main.js";
 
 //#region dynamic.js
 console.log(`shared: `, value);
@@ -27,7 +27,7 @@ console.log(`shared: `, value);
 const unused = value;
 
 //#endregion
-export { unused, value };
+export { value as t, unused };
 ```
 
 # Variant: [preserve_entry_signatures: Strict]
@@ -37,7 +37,7 @@ export { unused, value };
 ### dynamic.js
 
 ```js
-import { value } from "./lib.js";
+import { t as value } from "./lib.js";
 
 //#region dynamic.js
 console.log(`shared: `, value);
@@ -52,13 +52,13 @@ console.log(`shared: `, value);
 const value = 100;
 
 //#endregion
-export { value };
+export { value as t };
 ```
 
 ### main.js
 
 ```js
-import { value } from "./lib.js";
+import { t as value } from "./lib.js";
 
 //#region main.js
 import("./dynamic.js");
@@ -76,7 +76,7 @@ export { unused };
 ### dynamic.js
 
 ```js
-import { value } from "./main.js";
+import { t as value } from "./main.js";
 
 //#region dynamic.js
 console.log(`shared: `, value);
@@ -96,5 +96,5 @@ import("./dynamic.js");
 console.log(`shared: `, value);
 
 //#endregion
-export { value };
+export { value as t };
 ```

--- a/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/exports-only/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/exports-only/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { value } from "./main.js";
+import { t as value } from "./main.js";
 
 //#region dynamic.js
 console.log(`shared: `, value);
@@ -17,7 +17,7 @@ console.log(`shared: `, value);
 ## dynamic2.js
 
 ```js
-import { value } from "./lib2.js";
+import { t as value } from "./lib2.js";
 
 //#region dynamic2.js
 console.log(`shared: `, value);
@@ -32,7 +32,7 @@ console.log(`shared: `, value);
 const value = "lib2";
 
 //#endregion
-export { value };
+export { value as t };
 ```
 
 ## main.js
@@ -47,13 +47,13 @@ import("./dynamic.js");
 console.log(`shared: `, value);
 
 //#endregion
-export { value };
+export { value as t };
 ```
 
 ## main2.js
 
 ```js
-import { value } from "./lib2.js";
+import { t as value } from "./lib2.js";
 
 //#region main2.js
 import("./dynamic2.js");

--- a/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/issue-4873-2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/issue-4873-2/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## bar.js
 
 ```js
-import { n } from "./shared.js";
+import { t as n } from "./shared.js";
 
 //#region bar.js
 console.log("bar" + n);
@@ -19,7 +19,7 @@ export { msg };
 ## foo.js
 
 ```js
-import { n } from "./shared.js";
+import { t as n } from "./shared.js";
 
 //#region foo.js
 console.log("foo" + n);
@@ -55,5 +55,5 @@ import(`https://localhost`).catch((mod) => {
 const n = 1;
 
 //#endregion
-export { n };
+export { n as t };
 ```

--- a/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/issue-4880/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/issue-4880/artifacts.snap
@@ -30,8 +30,9 @@ export { foo_default as default };
 ## foo2.js
 
 ```js
-import { foo2_default } from "./foo22.js";
+import { t as foo2_default } from "./foo22.js";
 
+export { foo2_default as default };
 ```
 
 ## foo22.js
@@ -41,13 +42,13 @@ import { foo2_default } from "./foo22.js";
 var foo2_default = "foo2";
 
 //#endregion
-export { foo2_default };
+export { foo2_default as t };
 ```
 
 ## main.js
 
 ```js
-import { foo2_default } from "./foo22.js";
+import { t as foo2_default } from "./foo22.js";
 import assert from "node:assert";
 
 //#region main.js

--- a/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/issue_5026/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_entry_signature/issue_5026/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-import { createRouter } from "./router.js";
+import { t as createRouter } from "./router.js";
 
 //#region main.js
 await createRouter(() => import("./page.js")).isReady;
@@ -18,7 +18,7 @@ globalThis.result.push("ready");
 ## page.js
 
 ```js
-import { foo } from "./router.js";
+import { n as foo } from "./router.js";
 
 //#region page.mjs
 globalThis.result = [foo];
@@ -41,5 +41,5 @@ const createRouter = (page) => {
 const foo = "foo";
 
 //#endregion
-export { createRouter, foo };
+export { foo as n, createRouter as t };
 ```

--- a/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
@@ -12,13 +12,13 @@ var a_exports = /* @__PURE__ */ __export({ abc: () => abc });
 const abc = void 0;
 
 //#endregion
-export { a_exports };
+export { a_exports as t };
 ```
 
 ## entry.js
 
 ```js
-import { a_exports } from "./a.js";
+import { t as a_exports } from "./a.js";
 
 export { a_exports as a };
 ```
@@ -26,7 +26,7 @@ export { a_exports as a };
 ## main.js
 
 ```js
-import { a_exports } from "./a.js";
+import { t as a_exports } from "./a.js";
 
 export { a_exports as a };
 ```

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/5197/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/5197/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## bar.js
 
 ```js
-import { bar_default } from "./bar2.js";
+import { t as bar_default } from "./bar2.js";
 
 export { bar_default as default };
 ```
@@ -18,13 +18,13 @@ export { bar_default as default };
 var bar_default = "bar";
 
 //#endregion
-export { bar_default };
+export { bar_default as t };
 ```
 
 ## main.js
 
 ```js
-import { bar_default } from "./bar2.js";
+import { t as bar_default } from "./bar2.js";
 import assert from "node:assert";
 
 //#region main.js

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass/artifacts.snap
@@ -7,14 +7,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 const derived = false;
-export { derived };
+export { derived as t };
 
 ```
 
 ## pagea.js
 
 ```js
-import { derived } from "./foo.js";
+import { t as derived } from "./foo.js";
 function demo() {
 	if (derived) console.log("page-a");
 }
@@ -25,7 +25,7 @@ demo();
 ## pageb.js
 
 ```js
-import { derived } from "./foo.js";
+import { t as derived } from "./foo.js";
 function demo() {
 	if (derived) console.log("page-a");
 }

--- a/crates/rolldown/tests/rolldown/optimization/pife_for_module_wrappers/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/pife_for_module_wrappers/basic/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { a } from "./common.js";
+import { n as a } from "./common.js";
 
 export { a };
 ```
@@ -14,7 +14,7 @@ export { a };
 ## b.js
 
 ```js
-import { b } from "./common.js";
+import { t as b } from "./common.js";
 
 export { b };
 ```
@@ -30,5 +30,5 @@ const a = "a";
 const b = "a";
 
 //#endregion
-export { a, b };
+export { a as n, b as t };
 ```

--- a/crates/rolldown/tests/rolldown/optimization/pife_for_module_wrappers/disabled/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/pife_for_module_wrappers/disabled/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { a } from "./common.js";
+import { n as a } from "./common.js";
 
 export { a };
 ```
@@ -14,7 +14,7 @@ export { a };
 ## b.js
 
 ```js
-import { b } from "./common.js";
+import { t as b } from "./common.js";
 
 export { b };
 ```
@@ -30,5 +30,5 @@ const a = "a";
 const b = "a";
 
 //#endregion
-export { a, b };
+export { a as n, b as t };
 ```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/issue_5737/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/issue_5737/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import { foo as foo$1 } from "./foo.js";
+import { t as foo$1 } from "./foo.js";
 import assert from "node:assert";
 
 //#region main.js
@@ -20,7 +20,7 @@ export { foo };
 ## entry2.js
 
 ```js
-import { foo } from "./foo.js";
+import { t as foo } from "./foo.js";
 
 export { foo };
 ```
@@ -32,5 +32,5 @@ export { foo };
 const foo = 0;
 
 //#endregion
-export { foo };
+export { foo as t };
 ```

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -7,13 +7,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __commonJS, __export, __reExport, __toCommonJS, __toDynamicImportESM, __toESM };
+export { __toDynamicImportESM as a, __toCommonJS as i, __export as n, __toESM as o, __reExport as r, __commonJS as t };
 ```
 
 ## exist-dep-cjs.js
 
 ```js
-import { __commonJS } from "./chunk.js";
+import { t as __commonJS } from "./chunk.js";
 
 //#region exist-dep-cjs.js
 var require_exist_dep_cjs = /* @__PURE__ */ __commonJS({ "exist-dep-cjs.js": ((exports, module) => {
@@ -30,7 +30,7 @@ export default require_exist_dep_cjs();
 ## exist-dep-esm.js
 
 ```js
-import { __export } from "./chunk.js";
+import { n as __export } from "./chunk.js";
 
 //#region exist-dep-esm.js
 var exist_dep_esm_exports = /* @__PURE__ */ __export({ value: () => value });
@@ -45,7 +45,7 @@ export { value };
 ## main.js
 
 ```js
-import { __export, __reExport, __toCommonJS, __toDynamicImportESM, __toESM } from "./chunk.js";
+import { a as __toDynamicImportESM, i as __toCommonJS, n as __export, o as __toESM, r as __reExport } from "./chunk.js";
 
 // HIDDEN [rolldown:hmr]
 //#region hmr.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -6,8 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## bar.js
 
 ```js
-import { __export } from "./chunk.js";
-import { trim } from "./string.js";
+import { t as __export } from "./chunk.js";
+import { t as trim } from "./string.js";
 
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __export({ default: () => bar_default });
@@ -25,14 +25,14 @@ export { bar_default as default };
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __export, __reExport, __toCommonJS, __toDynamicImportESM, __toESM };
+export { __toESM as a, __toDynamicImportESM as i, __reExport as n, __toCommonJS as r, __export as t };
 ```
 
 ## foo.js
 
 ```js
-import { __export } from "./chunk.js";
-import { trim, unused } from "./string.js";
+import { t as __export } from "./chunk.js";
+import { n as unused, t as trim } from "./string.js";
 
 //#region utils/index.js
 var utils_exports = /* @__PURE__ */ __export({
@@ -58,7 +58,7 @@ export { foo_default as default };
 ## main.js
 
 ```js
-import { __export, __reExport, __toCommonJS, __toDynamicImportESM, __toESM } from "./chunk.js";
+import { a as __toESM, i as __toDynamicImportESM, n as __reExport, r as __toCommonJS, t as __export } from "./chunk.js";
 
 // HIDDEN [rolldown:hmr]
 //#region main.js
@@ -76,7 +76,7 @@ const routes = {
 ## string.js
 
 ```js
-import { __export } from "./chunk.js";
+import { t as __export } from "./chunk.js";
 
 //#region utils/string.js
 var string_exports = /* @__PURE__ */ __export({
@@ -93,5 +93,5 @@ function unused() {
 }
 
 //#endregion
-export { trim, unused };
+export { unused as n, trim as t };
 ```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## async-entry.js
 
 ```js
-import { count, inc, reset } from "./shared.js";
+import { n as inc, r as reset, t as count } from "./shared.js";
 import assert from "node:assert";
 
 //#region async-entry.js
@@ -26,7 +26,7 @@ assert.strictEqual(count, count);
 ## main.js
 
 ```js
-import { count, inc, reset } from "./shared.js";
+import { n as inc, r as reset, t as count } from "./shared.js";
 
 //#region main.js
 import("./async-entry.js");
@@ -48,5 +48,5 @@ function inc() {
 }
 
 //#endregion
-export { count, inc, reset };
+export { inc as n, reset as r, count as t };
 ```

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import { foo, main_default } from "./main.js";
+import { n as main_default, t as foo } from "./main.js";
 
 export { main_default as default, foo };
 ```
@@ -14,7 +14,7 @@ export { main_default as default, foo };
 ## entry2.js
 
 ```js
-import { foo, main_default } from "./main.js";
+import { n as main_default, t as foo } from "./main.js";
 
 export { main_default as default, foo };
 ```
@@ -27,5 +27,5 @@ const foo = "foo";
 var main_default = "main";
 
 //#endregion
-export { foo, main_default };
+export { main_default as n, foo as t };
 ```

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import { foo, init_main, main_default } from "./main.js";
+import { n as init_main, r as main_default, t as foo } from "./main.js";
 
 init_main();
 export { main_default as default, foo };
@@ -15,7 +15,7 @@ export { main_default as default, foo };
 ## entry2.js
 
 ```js
-import { foo, init_main, main_default } from "./main.js";
+import { n as init_main, r as main_default, t as foo } from "./main.js";
 
 init_main();
 export { main_default as default, foo };
@@ -38,5 +38,5 @@ var init_main = __esm({ "main.js": (() => {
 }) });
 
 //#endregion
-export { foo, init_main, main_default };
+export { init_main as n, main_default as r, foo as t };
 ```

--- a/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/no_side_effects/artifacts.snap
@@ -15,7 +15,7 @@ Object.defineProperty(classLike.prototype, "sideEffect", { get() {
 } });
 
 //#endregion
-export { classLike };
+export { classLike as t };
 ```
 
 ## entry.js
@@ -32,7 +32,7 @@ console.log("Hello");
 ## entry2.js
 
 ```js
-import { classLike } from "./classLike.js";
+import { t as classLike } from "./classLike.js";
 
 //#region entry2.js
 new classLike();

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
@@ -21,7 +21,7 @@ To fix:
 ## main.js
 
 ```js
-import { sharedValue } from "./vendor.js";
+import { t as sharedValue } from "./vendor.js";
 
 //#region main.js
 console.log("Main entry with shared:", sharedValue);
@@ -40,5 +40,5 @@ export { mainFunc };
 const sharedValue = "shared module value";
 
 //#endregion
-export { sharedValue };
+export { sharedValue as t };
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -126,10 +126,10 @@ expression: output
 
 # tests/esbuild/dce/dce_var_exports
 
-- a-!~{000}~.js => a-DZ21-EUO.js
-- b-!~{001}~.js => b-BedDZ-6S.js
-- c-!~{002}~.js => c-CVJ_R0c_.js
-- chunk-!~{003}~.js => chunk-Cd1td6rr.js
+- a-!~{000}~.js => a-osmoRuTO.js
+- b-!~{001}~.js => b-CuTAYxAZ.js
+- c-!~{002}~.js => c-BS4znS2K.js
+- chunk-!~{003}~.js => chunk-C0-B2heE.js
 
 # tests/esbuild/dce/dead_code_following_jump
 
@@ -613,10 +613,10 @@ expression: output
 
 # tests/esbuild/default/conditional_import
 
-- a-!~{000}~.js => a-CBOlm51R.js
-- b-!~{001}~.js => b-Ds_KXn4m.js
-- chunk-!~{002}~.js => chunk-FGKrBk_Z.js
-- import-!~{004}~.js => import-DZhQBNpt.js
+- a-!~{000}~.js => a-fW3-K_11.js
+- b-!~{001}~.js => b-D4eD8e3J.js
+- chunk-!~{002}~.js => chunk-B_FYKD9-.js
+- import-!~{004}~.js => import-DegZZScx.js
 
 # tests/esbuild/default/conditional_require
 
@@ -730,12 +730,12 @@ expression: output
 
 # tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle
 
-- a-!~{000}~.js => a-CCLkgzBI.js
-- b-!~{001}~.js => b-CfYqhmnk.js
+- a-!~{000}~.js => a-4rD4mxul.js
+- b-!~{001}~.js => b-DTbQBCNu.js
 - c-!~{002}~.js => c-DbAYnqxj.js
 - d-!~{003}~.js => d-erhulghW.js
 - e-!~{004}~.js => e-BluWtRWc.js
-- b-!~{005}~.js => b-BiAqcQ2h.js
+- b-!~{005}~.js => b-BPPiAsRK.js
 
 # tests/esbuild/default/export_fs_browser
 
@@ -883,14 +883,14 @@ expression: output
 
 # tests/esbuild/default/import_missing_neither_es6_nor_common_js
 
-- bare-!~{003}~.js => bare-DvPu9kSD.js
-- import-!~{005}~.js => import-DVnLWQFA.js
-- named-!~{000}~.js => named-CuY0P-le.js
-- require-!~{004}~.js => require-D5AK_2L5.js
-- star-capture-!~{002}~.js => star-capture-CFIoY2vh.js
-- star-!~{001}~.js => star-gVCMSDUp.js
-- foo-!~{006}~.js => foo-ARGE8_vk.js
-- foo-!~{008}~.js => foo-CswbBjht.js
+- bare-!~{003}~.js => bare-BaeMO7qL.js
+- import-!~{005}~.js => import-CmbBkEu4.js
+- named-!~{000}~.js => named-BTLusJnP.js
+- require-!~{004}~.js => require-CMa5gyQH.js
+- star-!~{001}~.js => star-CCdHwztu.js
+- star-capture-!~{002}~.js => star-capture-CM7MEfH3.js
+- foo-!~{008}~.js => foo-ChBTjzWU.js
+- foo-!~{006}~.js => foo-DmS_v9vB.js
 
 # tests/esbuild/default/import_namespace_this_value
 
@@ -917,12 +917,12 @@ expression: output
 
 # tests/esbuild/default/indirect_require_message
 
-- array-!~{000}~.js => array-CSx0pvTG.js
-- assign-!~{001}~.js => assign-Dd64WgR8.js
-- dot-!~{002}~.js => dot-BY8H7C6Q.js
-- ident-!~{003}~.js => ident-BUKwP9uX.js
-- index-!~{004}~.js => index-_bx5qC1i.js
-- chunk-!~{005}~.js => chunk-C--e1a9N.js
+- array-!~{000}~.js => array-BpeofdYH.js
+- assign-!~{001}~.js => assign-B15cS0L2.js
+- dot-!~{002}~.js => dot-3avhlUvM.js
+- ident-!~{003}~.js => ident-Cuf3oj35.js
+- index-!~{004}~.js => index-DM96mymD.js
+- chunk-!~{005}~.js => chunk-kMfLYBFW.js
 
 # tests/esbuild/default/inject
 
@@ -1148,9 +1148,9 @@ expression: output
 
 # tests/esbuild/default/mangle_props_import_export_bundled
 
-- entry-cjs-!~{001}~.js => entry-cjs-D6HglLGC.js
-- entry-esm-!~{000}~.js => entry-esm-30aofPQG.js
-- cjs-!~{002}~.js => cjs-DrCCHDdE.js
+- entry-cjs-!~{001}~.js => entry-cjs-DbYcM7E9.js
+- entry-esm-!~{000}~.js => entry-esm-ChVVtXCL.js
+- cjs-!~{002}~.js => cjs-CtZabevd.js
 
 # tests/esbuild/default/mangle_props_jsx_preserve
 
@@ -1213,47 +1213,47 @@ expression: output
 
 # tests/esbuild/default/many_entry_points
 
-- e00-!~{000}~.js => e00-gAOeZP6L.js
-- e01-!~{001}~.js => e01-BcovJOqp.js
-- e02-!~{002}~.js => e02-Cc8a6aiE.js
-- e03-!~{003}~.js => e03-DFkB81gC.js
-- e04-!~{004}~.js => e04-DqSWMMCy.js
-- e05-!~{005}~.js => e05-CmWoijrL.js
-- e06-!~{006}~.js => e06-hpItZbpa.js
-- e07-!~{007}~.js => e07-BwY82uh_.js
-- e08-!~{008}~.js => e08-BKbCispT.js
-- e09-!~{009}~.js => e09-BK8TaOTl.js
-- e10-!~{00a}~.js => e10-_qSRWxVi.js
-- e11-!~{00b}~.js => e11-Dbbp_BF4.js
-- e12-!~{00c}~.js => e12-ClSNDFG7.js
-- e13-!~{00d}~.js => e13-Dm8dOZTc.js
-- e14-!~{00e}~.js => e14-B4CuLFAb.js
-- e15-!~{00f}~.js => e15-BnimKBsZ.js
-- e16-!~{00g}~.js => e16-CWdpwcEx.js
-- e17-!~{00h}~.js => e17-B5r90YHu.js
-- e18-!~{00i}~.js => e18-B3n6FuSG.js
-- e19-!~{00j}~.js => e19-BaB2PcNI.js
-- e20-!~{00k}~.js => e20-DF02r1GA.js
-- e21-!~{00l}~.js => e21-BR5jrxbU.js
-- e22-!~{00m}~.js => e22-DuNDN3ZH.js
-- e23-!~{00n}~.js => e23-BCILa8IR.js
-- e24-!~{00o}~.js => e24-DBZ7m0UI.js
-- e25-!~{00p}~.js => e25-D0QkldZR.js
-- e26-!~{00q}~.js => e26-Cyl4jlIO.js
-- e27-!~{00r}~.js => e27-B4qF2NaP.js
-- e28-!~{00s}~.js => e28-D7KMpkZ1.js
-- e29-!~{00t}~.js => e29-DTcr-FMM.js
-- e30-!~{00u}~.js => e30-DvLyKCqR.js
-- e31-!~{00v}~.js => e31-Cli2YPT6.js
-- e32-!~{00w}~.js => e32-CipkkSpA.js
-- e33-!~{00x}~.js => e33-DfgxXfzO.js
-- e34-!~{00y}~.js => e34-Cm2Z6RrK.js
-- e35-!~{00z}~.js => e35-Bgm2DQsF.js
-- e36-!~{00A}~.js => e36-_0OICvX4.js
-- e37-!~{00B}~.js => e37-CvL2yk7i.js
-- e38-!~{00C}~.js => e38-ZYiJAqnQ.js
-- e39-!~{00D}~.js => e39-Dk1DxEsl.js
-- shared-!~{00E}~.js => shared-BMXNdK6P.js
+- e00-!~{000}~.js => e00-Bh3jD6D5.js
+- e01-!~{001}~.js => e01-B-fEWK0a.js
+- e02-!~{002}~.js => e02-h6PzX0JX.js
+- e03-!~{003}~.js => e03-DZdeGN29.js
+- e04-!~{004}~.js => e04-fGaE3utZ.js
+- e05-!~{005}~.js => e05-BXSpEKdX.js
+- e06-!~{006}~.js => e06-B-FMyuQ7.js
+- e07-!~{007}~.js => e07-D9WZ74h5.js
+- e08-!~{008}~.js => e08-RUVE3mal.js
+- e09-!~{009}~.js => e09-BJoLWOpV.js
+- e10-!~{00a}~.js => e10-DK4xEnkU.js
+- e11-!~{00b}~.js => e11-DkXV9x5v.js
+- e12-!~{00c}~.js => e12-BtZVFjsf.js
+- e13-!~{00d}~.js => e13-k-zNkq9v.js
+- e14-!~{00e}~.js => e14-BOs-RPeG.js
+- e15-!~{00f}~.js => e15-CGTbhfsb.js
+- e16-!~{00g}~.js => e16-_3L330tm.js
+- e17-!~{00h}~.js => e17-CKfa-7Rp.js
+- e18-!~{00i}~.js => e18-BsaUJLHY.js
+- e19-!~{00j}~.js => e19-A7vq5xzB.js
+- e20-!~{00k}~.js => e20-BNkMCXVO.js
+- e21-!~{00l}~.js => e21-lNxpYfzG.js
+- e22-!~{00m}~.js => e22-CSsuJ4dF.js
+- e23-!~{00n}~.js => e23-BkMbcZIL.js
+- e24-!~{00o}~.js => e24-B5ZM7W-v.js
+- e25-!~{00p}~.js => e25-uQ0VP7tZ.js
+- e26-!~{00q}~.js => e26-C_ZcCnFN.js
+- e27-!~{00r}~.js => e27-BMgdzWKB.js
+- e28-!~{00s}~.js => e28-5eKm-6ty.js
+- e29-!~{00t}~.js => e29-bEHli_eq.js
+- e30-!~{00u}~.js => e30-CLz8Job6.js
+- e31-!~{00v}~.js => e31-8HiX25Of.js
+- e32-!~{00w}~.js => e32-JDcZVodU.js
+- e33-!~{00x}~.js => e33-D5Xjzq-d.js
+- e34-!~{00y}~.js => e34-Bdgp2l4T.js
+- e35-!~{00z}~.js => e35-BdC7Gu3_.js
+- e36-!~{00A}~.js => e36-H56Wxz2B.js
+- e37-!~{00B}~.js => e37-COYcZbXZ.js
+- e38-!~{00C}~.js => e38-Xkp7cF2B.js
+- e39-!~{00D}~.js => e39-Bbp2lC5b.js
+- shared-!~{00E}~.js => shared-Ierq1zHq.js
 
 # tests/esbuild/default/metafile_import_with_type_json
 
@@ -1267,9 +1267,9 @@ expression: output
 
 # tests/esbuild/default/metafile_various_cases
 
-- entry-!~{001}~.js => entry-BcAi7lcc.js
-- entry-!~{000}~.js => entry-Cf-vh7HI.js
-- copy-!~{002}~.js => copy-B06R0MNC.js
+- entry-!~{001}~.js => entry-C8lVrsYF.js
+- entry-!~{000}~.js => entry-DHmkoikt.js
+- copy-!~{002}~.js => copy-DDA5F9k1.js
 - dynamic-!~{005}~.js => dynamic-BHpZ7YgO.js
 - assets/file-C2vEMN7j.file
 - entry2.css
@@ -1324,9 +1324,9 @@ expression: output
 
 # tests/esbuild/default/multiple_entry_points_same_name_collision
 
-- a_entry-!~{000}~.js => a_entry-CbhRNmnT.js
-- b_entry-!~{001}~.js => b_entry-DXCzTyEt.js
-- common-!~{002}~.js => common-C8inFso3.js
+- a_entry-!~{000}~.js => a_entry-CshRVoo_.js
+- b_entry-!~{001}~.js => b_entry-W6qCoDuV.js
+- common-!~{002}~.js => common-XBPnqvOH.js
 
 # tests/esbuild/default/named_function_expression_argument_collision
 
@@ -1359,9 +1359,9 @@ expression: output
 # tests/esbuild/default/no_warn_common_js_exports_in_esm_pass_through
 
 - cjs-in-esm-!~{000}~.js => cjs-in-esm-CAiwlB1I.js
-- import-in-cjs-!~{001}~.js => import-in-cjs-BGH20Hau.js
-- no-warnings-here-!~{002}~.js => no-warnings-here-D60BzOc6.js
-- chunk-!~{003}~.js => chunk-Cd1td6rr.js
+- import-in-cjs-!~{001}~.js => import-in-cjs-CCFgCIwd.js
+- no-warnings-here-!~{002}~.js => no-warnings-here-BdsdDGCO.js
+- chunk-!~{003}~.js => chunk-C0-B2heE.js
 
 # tests/esbuild/default/node_annotation_false_positive_issue3544
 
@@ -1808,13 +1808,13 @@ expression: output
 - external-ns-!~{001}~.js => external-ns-all2LFha.js
 - external-ns-def-!~{003}~.js => external-ns-def-CPrnmGVn.js
 - external-ns-default-!~{002}~.js => external-ns-default-Cbqf8eIs.js
-- internal-def-!~{00b}~.js => internal-def-C1dYR6OX.js
-- internal-default-!~{00a}~.js => internal-default-DHVmIuVq.js
-- internal-default2-!~{006}~.js => internal-default2-Ci1cyXOL.js
-- internal-ns-def-!~{009}~.js => internal-ns-def-CIi59e0J.js
-- internal-ns-default-!~{008}~.js => internal-ns-default-qzsc-H6r.js
-- internal-ns-!~{007}~.js => internal-ns-nrzgvc6S.js
-- internal-!~{00c}~.js => internal-BgvGs5hJ.js
+- internal-def-!~{00b}~.js => internal-def-DSKRE1Kz.js
+- internal-default-!~{00a}~.js => internal-default-AMDI_efR.js
+- internal-default2-!~{006}~.js => internal-default2-B76WG0Xl.js
+- internal-ns-!~{007}~.js => internal-ns-DTFN4H_P.js
+- internal-ns-def-!~{009}~.js => internal-ns-def-iMJvhQ5D.js
+- internal-ns-default-!~{008}~.js => internal-ns-default-C9TNFr22.js
+- internal-!~{00c}~.js => internal-BBmdECkB.js
 
 # tests/esbuild/importstar/import_export_other_as_namespace_common_js
 
@@ -1830,15 +1830,15 @@ expression: output
 
 # tests/esbuild/importstar/import_namespace_undefined_property_empty_file
 
-- entry-default-!~{001}~.js => entry-default-DFTphgwS.js
-- entry-nope-!~{000}~.js => entry-nope-BYcUifvH.js
-- empty-!~{002}~.js => empty-UknkEYWX.js
+- entry-default-!~{001}~.js => entry-default-BCPQc9yz.js
+- entry-nope-!~{000}~.js => entry-nope-B2O1cSbI.js
+- empty-!~{002}~.js => empty-BZrJlLb3.js
 
 # tests/esbuild/importstar/import_namespace_undefined_property_side_effect_free_file
 
-- entry-default-!~{001}~.js => entry-default-DjU1N2NO.js
-- entry-nope-!~{000}~.js => entry-nope-qZifJH1X.js
-- no-side-effects-!~{002}~.js => no-side-effects-63P-MoQR.js
+- entry-default-!~{001}~.js => entry-default-Bxa2rT38.js
+- entry-nope-!~{000}~.js => entry-nope-C4h5DXFk.js
+- no-side-effects-!~{002}~.js => no-side-effects-DlI-6Dr4.js
 
 # tests/esbuild/importstar/import_of_export_star
 
@@ -2396,9 +2396,9 @@ expression: output
 
 # tests/esbuild/loader/loader_json_shared_with_multiple_entries_issue413
 
-- a-!~{000}~.js => a-C98attye.js
-- b-!~{001}~.js => b-Ce4gepAP.js
-- data-!~{002}~.js => data-BohhjThX.js
+- a-!~{000}~.js => a-8WJPwNdw.js
+- b-!~{001}~.js => b-CV5tiItg.js
+- data-!~{002}~.js => data-CXT8ghb6.js
 
 # tests/esbuild/loader/loader_text_common_js_and_es6
 
@@ -3086,9 +3086,9 @@ expression: output
 
 # tests/esbuild/splitting/splitting_assign_to_local
 
-- a-!~{000}~.js => a-DruZRuJd.js
-- b-!~{001}~.js => b-BA8e7wiH.js
-- shared-!~{002}~.js => shared-BdLebkjJ.js
+- a-!~{000}~.js => a-jcxof_Cn.js
+- b-!~{001}~.js => b-B68nVIM5.js
+- shared-!~{002}~.js => shared-Bo6rznne.js
 
 # tests/esbuild/splitting/splitting_chunk_path_dir_placeholder_implicit_outbase
 
@@ -3097,23 +3097,23 @@ expression: output
 
 # tests/esbuild/splitting/splitting_circular_reference_issue251
 
-- a-!~{000}~.js => a-C4DLlseJ.js
-- b-!~{001}~.js => b-D4Hlz7A9.js
-- a-!~{002}~.js => a-DoX8QhAD.js
+- a-!~{000}~.js => a-DKUNht4j.js
+- b-!~{001}~.js => b-Odxw2-T8.js
+- a-!~{002}~.js => a-CJ1eEqwW.js
 
 # tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies
 
-- a-!~{000}~.js => a-BWw_QdQB.js
-- b-!~{001}~.js => b-CCDB5ylF.js
-- shared-!~{002}~.js => shared-Cr4uy-E2.js
+- a-!~{000}~.js => a-D6HjgzrT.js
+- b-!~{001}~.js => b-Da2jBPdE.js
+- shared-!~{002}~.js => shared-St-ofABg.js
 
 # tests/esbuild/splitting/splitting_cross_chunk_assignment_dependencies_recursive
 
-- a-!~{000}~.js => a-DX3Ku8uZ.js
-- b-!~{001}~.js => b-PrB6LDJC.js
-- c-!~{002}~.js => c-HaBYwsma.js
-- x-!~{003}~.js => x-KEV6KpMQ.js
-- z-!~{005}~.js => z-B2Db3a-x.js
+- a-!~{000}~.js => a-BI32jRzY.js
+- b-!~{001}~.js => b-D4fEGXw_.js
+- c-!~{002}~.js => c-DkgSDygv.js
+- x-!~{003}~.js => x-Rk4avc83.js
+- z-!~{005}~.js => z-BEo77qFZ.js
 
 # tests/esbuild/splitting/splitting_duplicate_chunk_collision
 
@@ -3126,21 +3126,21 @@ expression: output
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6
 
-- entry-!~{000}~.js => entry-B4NP_gHl.js
-- foo-!~{003}~.js => foo-BG8ps5AG.js
-- foo-!~{001}~.js => foo-BzLyFbvP.js
+- entry-!~{000}~.js => entry-BITI4AbM.js
+- foo-!~{003}~.js => foo-BBrODgjp.js
+- foo-!~{001}~.js => foo-C5SEgfqp.js
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6
 
-- entry-!~{000}~.js => entry-kWDxdhi1.js
-- foo-!~{001}~.js => foo-DMIuwKJr.js
-- foo-!~{003}~.js => foo-DmjM5Tf3.js
+- entry-!~{000}~.js => entry-YAj9uLot.js
+- foo-!~{003}~.js => foo-BhBlqXAO.js
+- foo-!~{001}~.js => foo-pP5LxmSk.js
 
 # tests/esbuild/splitting/splitting_dynamic_common_js_into_es6
 
-- entry-!~{000}~.js => entry-CBGU6wmY.js
-- chunk-!~{001}~.js => chunk-BAbtX2hM.js
-- foo-!~{003}~.js => foo-CFCQwcNi.js
+- entry-!~{000}~.js => entry-BganFbRV.js
+- chunk-!~{001}~.js => chunk-H6kpAueX.js
+- foo-!~{003}~.js => foo-DnaPIY7E.js
 
 # tests/esbuild/splitting/splitting_dynamic_es6_into_es6
 
@@ -3160,28 +3160,28 @@ expression: output
 
 # tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617
 
-- a-!~{000}~.js => a-B9GwE8N7.js
-- b-!~{001}~.js => b-BHMIWFdM.js
-- a-!~{002}~.js => a-pKIN51wc.js
+- a-!~{000}~.js => a-BS66Zg3t.js
+- b-!~{001}~.js => b-Dj0xFRQB.js
+- a-!~{002}~.js => a-Kw6qRqbm.js
 
 # tests/esbuild/splitting/splitting_minify_identifiers_crash_issue437
 
-- a-!~{000}~.js => a-DRGgySQt.js
-- b-!~{001}~.js => b-6X6q96nq.js
-- c-!~{002}~.js => c-CD_L4K1e.js
-- shared-!~{003}~.js => shared-Be1gVcD8.js
+- a-!~{000}~.js => a-Cigw7zh5.js
+- b-!~{001}~.js => b-BxVWDg0_.js
+- c-!~{002}~.js => c-l2s_7_sR.js
+- shared-!~{003}~.js => shared--UPBFTGo.js
 
 # tests/esbuild/splitting/splitting_missing_lazy_export
 
-- a-!~{000}~.js => a-DikyWjhc.js
-- b-!~{001}~.js => b-CFyQFpF4.js
-- common-!~{002}~.js => common-DVJ1iagZ.js
+- a-!~{000}~.js => a-fzAtWTYJ.js
+- b-!~{001}~.js => b-HNqljLjd.js
+- common-!~{002}~.js => common-BmPOYD1U.js
 
 # tests/esbuild/splitting/splitting_nested_directories
 
-- pageA_page-!~{000}~.js => pageA_page-D2K8YWtH.js
-- pageB_page-!~{001}~.js => pageB_page-CT805g7h.js
-- shared-!~{002}~.js => shared-_fC__ZEZ.js
+- pageA_page-!~{000}~.js => pageA_page-DC8ZZJ5m.js
+- pageB_page-!~{001}~.js => pageB_page-bdrIE0xl.js
+- shared-!~{002}~.js => shared-DBQ2cghv.js
 
 # tests/esbuild/splitting/splitting_public_path_entry_name
 
@@ -3190,27 +3190,27 @@ expression: output
 
 # tests/esbuild/splitting/splitting_re_export_issue273
 
-- a-!~{000}~.js => a-DIprqnlp.js
-- b-!~{001}~.js => b-FeJN0Vfk.js
-- a-!~{002}~.js => a-BfyPmfHN.js
+- a-!~{000}~.js => a-BrOuVO1R.js
+- b-!~{001}~.js => b-DzQ04KD5.js
+- a-!~{002}~.js => a-FkXGUaJG.js
 
 # tests/esbuild/splitting/splitting_shared_common_js_into_es6
 
-- a-!~{000}~.js => a-D5K4K-Bq.js
-- b-!~{001}~.js => b-B6tXc_qo.js
-- shared-!~{002}~.js => shared-BY-6kLNH.js
+- a-!~{000}~.js => a-BgphDTL_.js
+- b-!~{001}~.js => b-Bfogou0r.js
+- shared-!~{002}~.js => shared-D5_ALIBC.js
 
 # tests/esbuild/splitting/splitting_shared_es6_into_es6
 
-- a-!~{000}~.js => a-CcsfHATw.js
-- b-!~{001}~.js => b-D3eDmqeg.js
-- shared-!~{002}~.js => shared-DOfp1hIa.js
+- a-!~{000}~.js => a-DR5KzZut.js
+- b-!~{001}~.js => b-B8HH4r7G.js
+- shared-!~{002}~.js => shared-BH-0_VrB.js
 
 # tests/esbuild/splitting/splitting_side_effects_without_dependencies
 
-- a-!~{000}~.js => a-B-DOA30C.js
-- b-!~{001}~.js => b-BS0tgQsd.js
-- shared-!~{002}~.js => shared-D_ZRu1qf.js
+- a-!~{000}~.js => a-CsoN44c5.js
+- b-!~{001}~.js => b-DQeFI33w.js
+- shared-!~{002}~.js => shared-CH_twume.js
 
 # tests/esbuild/ts/enum_rules_from_type_script_5_0
 
@@ -3537,9 +3537,9 @@ expression: output
 
 # tests/rolldown/cjs_compat/dynamic_cjs_entry
 
-- main-!~{000}~.js => main-C0xjA_OO.js
-- chunk-!~{001}~.js => chunk-BAbtX2hM.js
-- cjs-!~{003}~.js => cjs-cdc7-g1D.js
+- main-!~{000}~.js => main-CdvEHXPs.js
+- chunk-!~{001}~.js => chunk-H6kpAueX.js
+- cjs-!~{003}~.js => cjs-DI4nUf34.js
 
 # tests/rolldown/cjs_compat/esm_require_cjs
 
@@ -3596,15 +3596,15 @@ expression: output
 
 # tests/rolldown/cjs_compat/multiple_circle_cjs_entries
 
-- a-!~{000}~.js => a-DegDNUVi.js
-- b-!~{001}~.js => b-CUzUcCP8.js
-- a-!~{002}~.js => a-CxvNQFUn.js
+- a-!~{000}~.js => a-Ceri791x.js
+- b-!~{001}~.js => b-CECX4VF9.js
+- a-!~{002}~.js => a-Dr7MewNh.js
 
 # tests/rolldown/cjs_compat/node_module_commonjs
 
-- entry-!~{001}~.js => entry-DYoANFCP.js
-- main-!~{000}~.js => main-BeFLkVNa.js
-- commonjs-!~{002}~.js => commonjs-CVCO1Kcl.js
+- entry-!~{001}~.js => entry-BqX5UmXU.js
+- main-!~{000}~.js => main-o7vWrc9f.js
+- commonjs-!~{002}~.js => commonjs-w7mTz9d9.js
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout
 
@@ -3632,9 +3632,9 @@ expression: output
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize_chunk_split
 
-- entry-!~{000}~.js => entry-CTOg42pm.js
-- main-!~{001}~.js => main-Bk1zrpEd.js
-- a-!~{002}~.js => a-Ibxf60pv.js
+- entry-!~{000}~.js => entry-BIPYXcTF.js
+- main-!~{001}~.js => main-BCT6wsUq.js
+- a-!~{002}~.js => a-BamTTcZb.js
 
 # tests/rolldown/cjs_compat/react-like
 
@@ -3679,9 +3679,9 @@ expression: output
 
 # tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file
 
-- main-!~{000}~.js => main-Bh3wu1El.js
-- foo-!~{003}~.js => foo-BFa84b2T.js
-- foo-!~{001}~.js => foo-BNFXuCA7.js
+- main-!~{000}~.js => main-B2XHtYkw.js
+- foo-!~{003}~.js => foo-BRLq0tsP.js
+- foo-!~{001}~.js => foo-BUUTsJII.js
 
 # tests/rolldown/code_splitting/ensure_safe_identifier
 
@@ -3715,17 +3715,17 @@ expression: output
 
 # tests/rolldown/code_splitting/import_export_unicode
 
-- main-!~{000}~.js => main-Cj8a6zp1.js
-- foo-!~{003}~.js => foo-CFXmcieM.js
-- foo-!~{001}~.js => foo-CHbSR4SS.js
+- main-!~{000}~.js => main-loo5zflG.js
+- foo-!~{001}~.js => foo-lkM6U-gR.js
+- foo-!~{003}~.js => foo-wNcveKNc.js
 
 # tests/rolldown/code_splitting/issue_2786
 
-- main-!~{000}~.js => main-B7jq-oW0.js
-- share-!~{005}~.js => share-0pk_LKAe.js
-- share-!~{007}~.js => share-BHp_w4um.js
-- share-!~{003}~.js => share-Dt2p-BNK.js
-- share-!~{001}~.js => share-DyQhD9RN.js
+- main-!~{000}~.js => main-alh1ZCTp.js
+- share-!~{007}~.js => share-BBxc668T.js
+- share-!~{003}~.js => share-BL2-D2da.js
+- share-!~{005}~.js => share-BdOG78KB.js
+- share-!~{001}~.js => share-CkZh55oA.js
 
 # tests/rolldown/dce/conditional_exports
 
@@ -3745,27 +3745,27 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/basic
 
-- a-!~{000}~.js => a-CcaBLJp5.js
-- b-!~{001}~.js => b-aQ857t6g.js
-- common-!~{002}~.js => common-DfGFFFKe.js
+- a-!~{000}~.js => a-BlI4VyMA.js
+- b-!~{001}~.js => b-BEAVLJSl.js
+- common-!~{002}~.js => common-CyjycInd.js
 
 # tests/rolldown/function/advanced_chunks/basic_cjs
 
-- a-!~{000}~.js => a-DHyuTKbK.js
-- b-!~{001}~.js => b-DkXOkVzH.js
-- common-!~{004}~.js => common-Dr1Ioixn.js
-- rolldown-runtime-!~{002}~.js => rolldown-runtime-ClQUeAEL.js
+- a-!~{000}~.js => a-Y-cabb6Q.js
+- b-!~{001}~.js => b-CNnnPYV6.js
+- common-!~{004}~.js => common-B4-w0jQK.js
+- rolldown-runtime-!~{002}~.js => rolldown-runtime-_Q6n9rjR.js
 
 # tests/rolldown/function/advanced_chunks/include_dependencies_recursively
 
-- main-!~{000}~.js => main-DJCMxexC.js
-- rolldown-runtime-!~{001}~.js => rolldown-runtime-BjtMze0h.js
-- vendor-!~{003}~.js => vendor-CC54ps3e.js
+- main-!~{000}~.js => main-qO9AWp7E.js
+- rolldown-runtime-!~{001}~.js => rolldown-runtime-JPYs5Gv-.js
+- vendor-!~{003}~.js => vendor-CMMksvBg.js
 
 # tests/rolldown/function/advanced_chunks/issue_2617
 
-- main-!~{000}~.js => main-Y4jDuhbs.js
-- splited_lib-!~{001}~.js => splited_lib-D9Ok3EWH.js
+- main-!~{000}~.js => main-CXYuKywD.js
+- splited_lib-!~{001}~.js => splited_lib-DirPE8LP.js
 
 # tests/rolldown/function/advanced_chunks/max_module_size
 
@@ -3830,10 +3830,10 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/split_node_modules
 
-- main-!~{000}~.js => main-aXwtU-I-.js
-- other-libs-!~{005}~.js => other-libs-Bb5eXrIp.js
-- rolldown-runtime-!~{001}~.js => rolldown-runtime-BjHBHhXT.js
-- ui-!~{003}~.js => ui-Bf0tm2vu.js
+- main-!~{000}~.js => main-CHl1dlHT.js
+- other-libs-!~{005}~.js => other-libs-fWd5HzzI.js
+- rolldown-runtime-!~{001}~.js => rolldown-runtime-DeTcrHyD.js
+- ui-!~{003}~.js => ui-Bb4v178j.js
 
 # tests/rolldown/function/context/defined
 
@@ -3923,21 +3923,21 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/ensure_lazy_module_eval
 
-- dynamic-!~{001}~.js => dynamic-BpUjAus5.js
-- main-!~{000}~.js => main-CdwVgZap.js
-- dynamic-!~{002}~.js => dynamic-CcRE_i8T.js
+- dynamic-!~{001}~.js => dynamic-CRZYgHAN.js
+- main-!~{000}~.js => main-DmKEx_LM.js
+- dynamic-!~{002}~.js => dynamic-GJWltGV0.js
 
 # tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict
 
-- main-!~{000}~.js => main-C9tRYJu-.js
-- lazy-chunk-!~{003}~.js => lazy-chunk-Ba8grf6d.js
-- user-lib-!~{001}~.js => user-lib-DIIJoimA.js
+- main-!~{000}~.js => main-DTP0Jpuk.js
+- lazy-chunk-!~{003}~.js => lazy-chunk-wEI66Qdo.js
+- user-lib-!~{001}~.js => user-lib-CFm6ADhP.js
 
 # tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/strict
 
-- main-!~{000}~.js => main-DIo8mJ2A.js
-- lazy-chunk-!~{003}~.js => lazy-chunk-lJR8kQgM.js
-- user-lib-!~{001}~.js => user-lib-C7vJyfGy.js
+- main-!~{000}~.js => main-CsvSGTed.js
+- lazy-chunk-!~{003}~.js => lazy-chunk-BIeHMuOX.js
+- user-lib-!~{001}~.js => user-lib-D0Xwm_YL.js
 
 # tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/non_strict
 
@@ -3947,9 +3947,9 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_399/strict
 
-- entry1-!~{000}~.js => entry1-C3lC3z0t.js
-- entry2-!~{001}~.js => entry2-BT1bfS2b.js
-- run-dep-!~{002}~.js => run-dep-D52ukhFK.js
+- entry1-!~{000}~.js => entry1-2JDDv_er.js
+- entry2-!~{001}~.js => entry2-Dpc2Yq7h.js
+- run-dep-!~{002}~.js => run-dep-BBw76gd9.js
 
 # tests/rolldown/function/experimental/strict_execution_order/exports_chain
 
@@ -3969,9 +3969,9 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
-- main-!~{000}~.js => main-9wQB0zfq.js
-- dynamic-!~{003}~.js => dynamic-C_U1TnUi.js
-- read-!~{001}~.js => read-hbL_w2sJ.js
+- main-!~{000}~.js => main-Dx0srSBy.js
+- dynamic-!~{003}~.js => dynamic-DKnGVp75.js
+- read-!~{001}~.js => read-CuokAFSd.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4782
 
@@ -3983,9 +3983,9 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_5303
 
-- main-!~{000}~.js => main-C3O574d7.js
-- rolldown-runtime-!~{001}~.js => rolldown-runtime-BjtMze0h.js
-- test-!~{003}~.js => test-DWjb2zYB.js
+- main-!~{000}~.js => main-BOlzDzRZ.js
+- rolldown-runtime-!~{001}~.js => rolldown-runtime-JPYs5Gv-.js
+- test-!~{003}~.js => test---FAGLz5.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_5922
 
@@ -3993,9 +3993,9 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/on_demand_wrapping
 
-- dynamic-!~{001}~.js => dynamic-BhqYqd04.js
-- main-!~{000}~.js => main-CJX4hrCK.js
-- dynamic-!~{002}~.js => dynamic-DKjUd_a-.js
+- dynamic-!~{001}~.js => dynamic-BtRcEWSp.js
+- main-!~{000}~.js => main-CsU_n4to.js
+- dynamic-!~{002}~.js => dynamic-Bzy_jMqy.js
 
 # tests/rolldown/function/experimental/strict_execution_order/react-like
 
@@ -4007,11 +4007,11 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/strip_plain_chunk_imports
 
-- main-!~{000}~.js => main-BLgaWtQc.js
-- chunk-!~{001}~.js => chunk--BJLk7li.js
-- common-!~{003}~.js => common-CNFKf5QD.js
-- page-a-!~{005}~.js => page-a-BDsi0RXF.js
-- page-b-!~{007}~.js => page-b-BzrE3mdB.js
+- main-!~{000}~.js => main-CjR03IhZ.js
+- chunk-!~{001}~.js => chunk-BzGhuYON.js
+- common-!~{003}~.js => common-CgySzaYJ.js
+- page-a-!~{005}~.js => page-a-BpiFrewp.js
+- page-b-!~{007}~.js => page-b-K0P5SDYC.js
 
 # tests/rolldown/function/experimental/strict_execution_order/top_level_await_syntax
 
@@ -4147,15 +4147,15 @@ expression: output
 
 # tests/rolldown/function/external/splitting_indirect_external_symbol
 
-- main-!~{000}~.js => main-Bu4yWRJV.js
-- indirect-!~{003}~.js => indirect-C8E1UGaS.js
-- indirect-!~{001}~.js => indirect-CtAS5Xvj.js
+- main-!~{000}~.js => main-BZ9es64I.js
+- indirect-!~{003}~.js => indirect-CCaFuyCY.js
+- indirect-!~{001}~.js => indirect-DrGj9Oik.js
 
 # tests/rolldown/function/external/splitting_with_external_module
 
-- entry-!~{001}~.js => entry-ALg0Esei.js
-- main-!~{000}~.js => main-tYnvYV-F.js
-- share-!~{002}~.js => share-CSalUTYT.js
+- entry-!~{001}~.js => entry-DoHEy-3L.js
+- main-!~{000}~.js => main-2hMoMwh5.js
+- share-!~{002}~.js => share-b1qaxmrB.js
 
 # tests/rolldown/function/external_live_bindings
 
@@ -4511,15 +4511,15 @@ expression: output
 
 # tests/rolldown/issues/1722/1
 
-- foo-!~{001}~.js => foo-CE9L34Ig.js
-- main-!~{000}~.js => main-VN4l1Mc7.js
-- main-!~{002}~.js => main-DCB5E4gj.js
+- foo-!~{001}~.js => foo-BU306j3E.js
+- main-!~{000}~.js => main-CsAO_EbA.js
+- main-!~{002}~.js => main-DzaLUq5X.js
 
 # tests/rolldown/issues/1722/2
 
-- entry1-!~{000}~.js => entry1-CX4X3DE_.js
-- entry2-!~{001}~.js => entry2-Dx6uwqg9.js
-- main-!~{002}~.js => main-wXV9uFs4.js
+- entry1-!~{000}~.js => entry1-Dd9z8ALk.js
+- entry2-!~{001}~.js => entry2-Do_bZ0Av.js
+- main-!~{002}~.js => main-Bq6mK70N.js
 
 # tests/rolldown/issues/1769
 
@@ -4527,24 +4527,24 @@ expression: output
 
 # tests/rolldown/issues/2038/a
 
-- main-!~{000}~.js => main-DBS60Fu-.js
-- a-!~{005}~.js => a-BBwr7Dw-.js
-- b-!~{001}~.js => b-BxSxOS8X.js
-- b-!~{003}~.js => b-BzcTnVvR.js
+- main-!~{000}~.js => main-BgnQsxXI.js
+- a-!~{005}~.js => a-CqCpq_Rh.js
+- b-!~{001}~.js => b-BtrqQb1d.js
+- b-!~{003}~.js => b-C61cu37f.js
 
 # tests/rolldown/issues/2038/b
 
-- main-!~{000}~.js => main-8TDrZ36r.js
-- a-!~{005}~.js => a-BX3GMvZS.js
-- b-!~{003}~.js => b-Br839cxA.js
-- b-!~{001}~.js => b-CrP06tRo.js
+- main-!~{000}~.js => main-BqrcfBzj.js
+- a-!~{005}~.js => a-D94CCT5r.js
+- b-!~{001}~.js => b-COAS-Frn.js
+- b-!~{003}~.js => b-CXCZ7xEB.js
 
 # tests/rolldown/issues/2085
 
-- main-!~{000}~.js => main-DUFtYYTo.js
-- a-!~{003}~.js => a-ChWPLiB9.js
-- a-!~{001}~.js => a-fRuc763U.js
-- c-!~{005}~.js => c-DYKCx0d_.js
+- main-!~{000}~.js => main-DfXu4SgJ.js
+- a-!~{001}~.js => a-CnhP6OE1.js
+- a-!~{003}~.js => a-DUrWTeyr.js
+- c-!~{005}~.js => c-BlnahMqm.js
 
 # tests/rolldown/issues/2300
 
@@ -4610,13 +4610,13 @@ expression: output
 
 # tests/rolldown/issues/3438
 
-- main-!~{000}~.js => main-DT8feizy.js
-- repro1-!~{003}~.js => repro1-C2egieRJ.js
-- repro1-!~{001}~.js => repro1-DpFyQUSD.js
-- repro2-!~{005}~.js => repro2-2ZzljHIE.js
-- repro2-!~{007}~.js => repro2-NY6EXoxf.js
-- repro3-!~{009}~.js => repro3-BuKsv5jH.js
-- repro3-!~{00b}~.js => repro3-DZYQEA0N.js
+- main-!~{000}~.js => main-Cjgl__GU.js
+- repro1-!~{003}~.js => repro1-Bk4VJTxt.js
+- repro1-!~{001}~.js => repro1-C8ZGrNz2.js
+- repro2-!~{007}~.js => repro2-DV6zg7do.js
+- repro2-!~{005}~.js => repro2-Da24K2hB.js
+- repro3-!~{009}~.js => repro3-B5AQg-Rz.js
+- repro3-!~{00b}~.js => repro3-DhMBk37L.js
 
 # tests/rolldown/issues/3456
 
@@ -4628,10 +4628,10 @@ expression: output
 
 # tests/rolldown/issues/3650
 
-- main-!~{000}~.js => main-wM0ExBa-.js
-- first-!~{005}~.js => first-DkeNlDhv.js
-- rolldown-runtime-!~{001}~.js => rolldown-runtime-Czh5gyOq.js
-- second-!~{003}~.js => second-D44Eph83.js
+- main-!~{000}~.js => main-CrEDmU34.js
+- first-!~{005}~.js => first-BAFVxk4Q.js
+- rolldown-runtime-!~{001}~.js => rolldown-runtime-BWwZaUdI.js
+- second-!~{003}~.js => second-DgmlASz2.js
 
 # tests/rolldown/issues/3746/a
 
@@ -4665,9 +4665,9 @@ expression: output
 
 # tests/rolldown/issues/4289
 
-- main-!~{000}~.js => main-BLiNqcSr.js
-- chunk-!~{001}~.js => chunk-e6zvK7dF.js
-- lib-!~{003}~.js => lib-gFGHPkDo.js
+- main-!~{000}~.js => main-B6Xu685v.js
+- chunk-!~{001}~.js => chunk-BrqVeARn.js
+- lib-!~{003}~.js => lib-D8Z4IETS.js
 
 # tests/rolldown/issues/4324
 
@@ -4795,9 +4795,9 @@ expression: output
 
 # tests/rolldown/issues/6593
 
-- main-!~{000}~.js => main-JSinLx_b.js
-- chunk-!~{001}~.js => chunk-BAbtX2hM.js
-- lib-!~{003}~.js => lib-DwB2ouhb.js
+- main-!~{000}~.js => main-C51avVP1.js
+- chunk-!~{001}~.js => chunk-H6kpAueX.js
+- lib-!~{003}~.js => lib-mlnvUzca.js
 
 # tests/rolldown/issues/rolldown_vite_289
 
@@ -4843,15 +4843,15 @@ expression: output
 
 # tests/rolldown/misc/chunk_level_directives
 
-- entry2-!~{001}~.js => entry2-DV0JmFuv.js
-- main-!~{000}~.js => main-BizQVnNB.js
-- shared-!~{002}~.js => shared-BIEIToZA.js
+- entry2-!~{001}~.js => entry2-D1s0QnHI.js
+- main-!~{000}~.js => main-BHPAQRgL.js
+- shared-!~{002}~.js => shared-y1NHBW2S.js
 
 # tests/rolldown/misc/cjs_entry_as_dependency
 
-- main-!~{000}~.js => main-Css4G-UB.js
-- main2-!~{001}~.js => main2-ILuIavua.js
-- main2-!~{002}~.js => main2-BJUOpbWL.js
+- main-!~{000}~.js => main-DBrz6oBu.js
+- main2-!~{001}~.js => main2-DMLyoaqt.js
+- main2-!~{002}~.js => main2-D40U7gCj.js
 
 # tests/rolldown/misc/common_js_min
 
@@ -4859,9 +4859,9 @@ expression: output
 
 # tests/rolldown/misc/duplicate_entries
 
-- main-!~{000}~.js => main-DenVDVqc.js
-- main2-!~{001}~.js => main2-DbrHOFgk.js
-- main-!~{002}~.js => main-BPORSC20.js
+- main-!~{000}~.js => main-CaQmUqti.js
+- main2-!~{001}~.js => main2-BnOgs1uk.js
+- main-!~{002}~.js => main-yibLZAlH.js
 
 # tests/rolldown/misc/footer/cjs
 
@@ -4894,16 +4894,16 @@ expression: output
 
 # tests/rolldown/misc/preserve_entry_signature/basic
 
-- main-!~{000}~.js => main-BprC3gAF.js
-- dynamic-!~{001}~.js => dynamic-D3xOeHId.js
+- main-!~{000}~.js => main-B1bwHaXY.js
+- dynamic-!~{001}~.js => dynamic-mm1bPaiu.js
 
 # tests/rolldown/misc/preserve_entry_signature/exports-only
 
-- main-!~{000}~.js => main-DIX5ZFCW.js
-- main2-!~{001}~.js => main2-CP6yUZAb.js
-- dynamic-!~{004}~.js => dynamic-DBHbx_t1.js
-- dynamic2-!~{006}~.js => dynamic2-DBL8pqW5.js
-- lib2-!~{002}~.js => lib2-B8LDz-cx.js
+- main-!~{000}~.js => main-Drk3C-0X.js
+- main2-!~{001}~.js => main2-i31PlmLG.js
+- dynamic-!~{004}~.js => dynamic-DWrmw2ff.js
+- dynamic2-!~{006}~.js => dynamic2-CGCRc5uw.js
+- lib2-!~{002}~.js => lib2-BUvq8Iix.js
 
 # tests/rolldown/misc/preserve_entry_signature/issue-4873
 
@@ -4912,24 +4912,24 @@ expression: output
 
 # tests/rolldown/misc/preserve_entry_signature/issue-4873-2
 
-- main-!~{000}~.js => main-BHTncKiU.js
-- bar-!~{003}~.js => bar-D0DzI928.js
-- foo-!~{005}~.js => foo-UM55xbSc.js
-- shared-!~{001}~.js => shared-ahT7H2GG.js
+- main-!~{000}~.js => main-kAPCLMH2.js
+- bar-!~{003}~.js => bar-DQ7memHS.js
+- foo-!~{005}~.js => foo-Cr4EDIP_.js
+- shared-!~{001}~.js => shared-MfrkefLk.js
 
 # tests/rolldown/misc/preserve_entry_signature/issue-4880
 
 - dynamic-!~{003}~.js => dynamic-BuO4HKk2.js
 - foo-!~{001}~.js => foo-Cz3zB3do.js
-- foo2-!~{002}~.js => foo2-Bv-MyeCj.js
-- main-!~{000}~.js => main-n0johxfQ.js
-- foo2-!~{004}~.js => foo2-DI34K6gG.js
+- foo2-!~{002}~.js => foo2-DnbetzBn.js
+- main-!~{000}~.js => main-B0YiAGyE.js
+- foo2-!~{004}~.js => foo2-CnPhrzGD.js
 
 # tests/rolldown/misc/preserve_entry_signature/issue_5026
 
-- main-!~{000}~.js => main-D-LkFY0e.js
-- page-!~{003}~.js => page-C5ekNCHn.js
-- router-!~{001}~.js => router-DhxpoWNN.js
+- main-!~{000}~.js => main-pD6JfqAk.js
+- page-!~{003}~.js => page-BPHhiowU.js
+- router-!~{001}~.js => router-B3yyvNXp.js
 
 # tests/rolldown/misc/preserve_modules/directives
 
@@ -4996,9 +4996,9 @@ expression: output
 
 # tests/rolldown/misc/reexport_star
 
-- entry-!~{001}~.js => entry-BQhXSQ7k.js
-- main-!~{000}~.js => main-DCKAGXaA.js
-- a-!~{002}~.js => a-BikrYMBH.js
+- entry-!~{001}~.js => entry-D7P0Gnnp.js
+- main-!~{000}~.js => main-0jtQhAoJ.js
+- a-!~{002}~.js => a-BbCBe7zL.js
 
 # tests/rolldown/misc/reexport_star_from_local_named_export
 
@@ -5043,9 +5043,9 @@ expression: output
 
 # tests/rolldown/optimization/inline_const/5197
 
-- main-!~{000}~.js => main-C1_Ucsch.js
-- bar-!~{003}~.js => bar-BTstUsfv.js
-- bar-!~{001}~.js => bar-BpbuVh-Q.js
+- main-!~{000}~.js => main-DlSsvnGL.js
+- bar-!~{001}~.js => bar-BrfnPKgg.js
+- bar-!~{003}~.js => bar-Dl9ffZcq.js
 
 # tests/rolldown/optimization/inline_const/6101
 
@@ -5074,9 +5074,9 @@ expression: output
 
 # tests/rolldown/optimization/inline_const/multi_pass
 
-- pagea-!~{000}~.js => pagea-WAYx4GdC.js
-- pageb-!~{001}~.js => pageb-oR5IZai9.js
-- foo-!~{002}~.js => foo-834KDxQ3.js
+- pagea-!~{000}~.js => pagea-BMjIpLFS.js
+- pageb-!~{001}~.js => pageb-BPz-jE-d.js
+- foo-!~{002}~.js => foo-3tP7DyUD.js
 
 # tests/rolldown/optimization/inline_const/ns_chain
 
@@ -5101,15 +5101,15 @@ expression: output
 
 # tests/rolldown/optimization/pife_for_module_wrappers/basic
 
-- a-!~{000}~.js => a-CcaBLJp5.js
-- b-!~{001}~.js => b-aQ857t6g.js
-- common-!~{002}~.js => common-DfGFFFKe.js
+- a-!~{000}~.js => a-BlI4VyMA.js
+- b-!~{001}~.js => b-BEAVLJSl.js
+- common-!~{002}~.js => common-CyjycInd.js
 
 # tests/rolldown/optimization/pife_for_module_wrappers/disabled
 
-- a-!~{000}~.js => a-CcaBLJp5.js
-- b-!~{001}~.js => b-aQ857t6g.js
-- common-!~{002}~.js => common-DfGFFFKe.js
+- a-!~{000}~.js => a-BlI4VyMA.js
+- b-!~{001}~.js => b-BEAVLJSl.js
+- common-!~{002}~.js => common-CyjycInd.js
 
 # tests/rolldown/resolve/add_module_condition_by_default
 
@@ -5210,15 +5210,15 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/12
 
-- entry-!~{000}~.js => entry-C_ltREyT.js
-- foo-!~{003}~.js => foo-D6UQdwbh.js
-- foo-!~{001}~.js => foo-D8wN_Ff_.js
+- entry-!~{000}~.js => entry-BHqIgIzC.js
+- foo-!~{001}~.js => foo-BrnToA7q.js
+- foo-!~{003}~.js => foo-CnrVv6N3.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/13
 
-- entry-!~{000}~.js => entry-CZ589tB0.js
-- foo-!~{003}~.js => foo-D6UQdwbh.js
-- foo-!~{001}~.js => foo-D8wN_Ff_.js
+- entry-!~{000}~.js => entry-CqgHQZ1C.js
+- foo-!~{001}~.js => foo-BrnToA7q.js
+- foo-!~{003}~.js => foo-CnrVv6N3.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/14
 
@@ -5535,9 +5535,9 @@ expression: output
 
 # tests/rolldown/topics/deconflict/issue_5737
 
-- entry-!~{000}~.js => entry-BwPByaap.js
-- entry2-!~{001}~.js => entry2-TnfF1t67.js
-- foo-!~{002}~.js => foo-CNqygoys.js
+- entry-!~{000}~.js => entry-C5JzlZ9O.js
+- entry2-!~{001}~.js => entry2-Hb7mqraD.js
+- foo-!~{002}~.js => foo-Bd0y3rit.js
 
 # tests/rolldown/topics/deconflict/issue_6227
 
@@ -5567,10 +5567,10 @@ expression: output
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-BTGtcTqI.js
-- chunk-!~{001}~.js => chunk-DNTYBYor.js
-- exist-dep-cjs-!~{003}~.js => exist-dep-cjs-BjEGgMv1.js
-- exist-dep-esm-!~{005}~.js => exist-dep-esm-Bz8YTEOv.js
+- main-!~{000}~.js => main-CIxCLaSW.js
+- chunk-!~{001}~.js => chunk-Duw_ny98.js
+- exist-dep-cjs-!~{003}~.js => exist-dep-cjs-Co1YuoOW.js
+- exist-dep-esm-!~{005}~.js => exist-dep-esm-C0RIFthk.js
 
 # tests/rolldown/topics/hmr/export_star
 
@@ -5594,11 +5594,11 @@ expression: output
 
 # tests/rolldown/topics/hmr/issue_5159
 
-- main-!~{000}~.js => main-BHfmFUKQ.js
-- bar-!~{005}~.js => bar-Bz70XMyB.js
-- chunk-!~{001}~.js => chunk-DlkQDk1t.js
-- foo-!~{007}~.js => foo-arEyVQ6_.js
-- string-!~{003}~.js => string-DVOdt709.js
+- main-!~{000}~.js => main-DHqC4v3y.js
+- bar-!~{005}~.js => bar-BGDA9DW5.js
+- chunk-!~{001}~.js => chunk-B1qYHasC.js
+- foo-!~{007}~.js => foo-CKg-ex8y.js
+- string-!~{003}~.js => string-DjRCTkj8.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
@@ -5720,9 +5720,9 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/named_exports_in_common_chunks
 
-- main-!~{000}~.js => main-B26G8hK4.js
-- async-entry-!~{003}~.js => async-entry-BOkRvE3G.js
-- shared-!~{001}~.js => shared-Bd9QGsb8.js
+- main-!~{000}~.js => main-gOSUDD_4.js
+- async-entry-!~{003}~.js => async-entry-CTnpuzS1.js
+- shared-!~{001}~.js => shared-Br_j6oXj.js
 
 # tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs
 
@@ -5776,9 +5776,9 @@ expression: output
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries
 
-- entry-!~{000}~.js => entry-69BujILk.js
-- entry2-!~{001}~.js => entry2-C-QsPaCl.js
-- main-!~{002}~.js => main-8bOaTE0y.js
+- entry-!~{000}~.js => entry--3VwUqRZ.js
+- entry2-!~{001}~.js => entry2-l2vVxF13.js
+- main-!~{002}~.js => main-CwTwUdfG.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs
 
@@ -5792,9 +5792,9 @@ expression: output
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries
 
-- entry-!~{000}~.js => entry-DoVaNndD.js
-- entry2-!~{001}~.js => entry2-SojYqu40.js
-- main-!~{002}~.js => main-BvD5LE2A.js
+- entry-!~{000}~.js => entry-BJBYAYD0.js
+- entry2-!~{001}~.js => entry2-CpLr47NW.js
+- main-!~{002}~.js => main-Bx-C7Edo.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs
 
@@ -5957,9 +5957,9 @@ expression: output
 
 # tests/rolldown/tree_shaking/no_side_effects
 
-- entry-!~{000}~.js => entry-DKLXbdZt.js
-- entry2-!~{001}~.js => entry2-n-AAi8Vc.js
-- classLike-!~{002}~.js => classLike-ByuPzZA8.js
+- entry-!~{000}~.js => entry-B7GK0Aud.js
+- entry2-!~{001}~.js => entry2-79CVyqpW.js
+- classLike-!~{002}~.js => classLike-CaEEY6YG.js
 
 # tests/rolldown/tree_shaking/property_read_side_effects
 
@@ -6027,8 +6027,8 @@ expression: output
 
 # tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures
 
-- main-!~{000}~.js => main-BTBGFOb0.js
-- vendor-!~{001}~.js => vendor-CKG4H9Kv.js
+- main-!~{000}~.js => main-2W-NqMTU.js
+- vendor-!~{001}~.js => vendor-D8jcB6MY.js
 
 # tests/rolldown/warnings/invalid_option/invalid_context_entity
 

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -444,7 +444,7 @@ export interface OutputOptions {
   topLevelVar?: boolean;
   /**
    * - Type: `boolean`
-   * - Default: `false`
+   * - Default: `true` for format `es` or if `output.minify` is `true` or object, `false` otherwise
    *
    * Whether to minify internal exports.
    */

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/restore-query-extension/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/restore-query-extension/index.ts.snap
@@ -1,8 +1,8 @@
-import { a_exports, name as name$1 } from "./a2.js";
-import { b_exports, name as name$2 } from "./b2.js";
-import { modules_exports, name as name$3 } from "./modules2.js";
-import { a_default } from "./a4.js";
-import { b_default } from "./b4.js";
+import { n as name$1, t as a_exports } from "./a2.js";
+import { n as name$2, t as b_exports } from "./b2.js";
+import { n as modules_exports, r as name$3 } from "./modules2.js";
+import { t as a_default } from "./a4.js";
+import { t as b_default } from "./b4.js";
 
 //#region ../fixtures/a/index.ts
 const basic = {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
@@ -1,8 +1,8 @@
-import { a_exports, name as name$1 } from "./a2.js";
-import { b_exports, name as name$2 } from "./b2.js";
-import { modules_exports, name as name$3 } from "./modules2.js";
-import { a_default } from "./a4.js";
-import { b_default } from "./b4.js";
+import { n as name$1, t as a_exports } from "./a2.js";
+import { n as name$2, t as b_exports } from "./b2.js";
+import { n as modules_exports, r as name$3 } from "./modules2.js";
+import { t as a_default } from "./a4.js";
+import { t as b_default } from "./b4.js";
 
 //#region ../fixtures/a/index.ts
 const basic = {

--- a/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/virtual/virtual-module-as-chunk/_config.ts
@@ -28,7 +28,7 @@ export default defineTest({
         expect(getOutputChunkNames(output)).toStrictEqual([
       'entry.js',
       'main.js',
-      '_module-iGCt1YOi.js',
+      '_module-C0Fm2lP_.js',
     ])
   },
 })

--- a/packages/rolldown/tests/fixtures/output/hash-filenames/normal/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/hash-filenames/normal/_config.ts
@@ -55,11 +55,11 @@ export default defineTest({
           expect(chunk.preliminaryFileName).toMatchInlineSnapshot(
             `"main-!~{000}~.js"`,
           )
-          expect(chunk.fileName).toMatchInlineSnapshot(`"main-Cq0S4hCi.js"`)
+          expect(chunk.fileName).toMatchInlineSnapshot(`"main-BKJjLIpN.js"`)
           expect(chunk.imports).toMatchInlineSnapshot(
             `
             [
-              "shared-C2o4kkYX.js",
+              "shared-4ttuH-iD.js",
             ]
           `,
           )
@@ -73,11 +73,11 @@ export default defineTest({
           break
 
         case path.join(__dirname, 'entry.js'):
-          expect(chunk.fileName).toMatchInlineSnapshot(`"entry-DHkmI37_.js"`)
+          expect(chunk.fileName).toMatchInlineSnapshot(`"entry--UVBFch3.js"`)
           expect(chunk.imports).toMatchInlineSnapshot(
             `
             [
-              "shared-C2o4kkYX.js",
+              "shared-4ttuH-iD.js",
             ]
           `,
           )

--- a/packages/rolldown/tests/fixtures/output/minify/exclude-dts/snap/main-CVjRSRz3.js.snap
+++ b/packages/rolldown/tests/fixtures/output/minify/exclude-dts/snap/main-CVjRSRz3.js.snap
@@ -1,0 +1,1 @@
+function e(){return 1}export{e as t};

--- a/packages/rolldown/tests/fixtures/output/minify/exclude-dts/snap/main-CbI6foa0.js.snap
+++ b/packages/rolldown/tests/fixtures/output/minify/exclude-dts/snap/main-CbI6foa0.js.snap
@@ -1,1 +1,0 @@
-function e(){return 1}export{e as hello};

--- a/packages/rolldown/tests/fixtures/output/minify/exclude-dts/snap/main-CiI4PTwY.js.snap
+++ b/packages/rolldown/tests/fixtures/output/minify/exclude-dts/snap/main-CiI4PTwY.js.snap
@@ -1,1 +1,0 @@
-function e(){return 1}export{e as hello};

--- a/packages/rolldown/tests/fixtures/output/minify/exclude-dts/snap/main.d.ts.snap
+++ b/packages/rolldown/tests/fixtures/output/minify/exclude-dts/snap/main.d.ts.snap
@@ -1,3 +1,3 @@
-import { hello } from "./main-CiI4PTwY.js";
+import { t as hello } from "./main-CVjRSRz3.js";
 
 export { hello };

--- a/packages/rolldown/tests/fixtures/output/minify/exclude-dts/snap/main.js.snap
+++ b/packages/rolldown/tests/fixtures/output/minify/exclude-dts/snap/main.js.snap
@@ -1,1 +1,1 @@
-import{hello as e}from"./main-CiI4PTwY.js";export{e as hello};
+import{t as e}from"./main-CVjRSRz3.js";export{e as hello};


### PR DESCRIPTION
close #5216

I chose a slightly different default value because Rolldown does not support `format: 'system'` and `output.compat`.
