### PR TITLE
perf(rolldown_utils): only allocate HASH_PLACEHOLDER_LEFT once

### DIFF
--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -9,7 +9,7 @@ use rolldown_common::{EmittedAsset, Output};
 use rolldown_plugin::{HookRenderChunkOutput, HookUsage, Plugin};
 use rolldown_utils::{
   dashmap::FxDashMap,
-  hash_placeholder::{find_hash_placeholders, hash_placeholder_left_finder},
+  hash_placeholder::{HASH_PLACEHOLDER_LEFT_FINDER, find_hash_placeholders},
   rustc_hash::FxHashMapExt as _,
   xxhash::xxhash_with_base,
 };
@@ -38,12 +38,12 @@ impl Plugin for ChunkImportMapPlugin {
     _ctx: &rolldown_plugin::PluginContext,
     args: &rolldown_plugin::HookRenderChunkArgs<'_>,
   ) -> rolldown_plugin::HookRenderChunkReturn {
-    let hash_finder = hash_placeholder_left_finder();
     if !self.initialized.swap(true, Ordering::SeqCst) {
       let base = args.options.hash_characters.base();
       let mut used_names = FxHashSet::default();
       for chunk in args.chunks.values() {
-        let hash_placeholders = find_hash_placeholders(&chunk.filename, &hash_finder);
+        let hash_placeholders =
+          find_hash_placeholders(&chunk.filename, &HASH_PLACEHOLDER_LEFT_FINDER);
         if hash_placeholders.is_empty() {
           continue;
         }
@@ -78,7 +78,7 @@ impl Plugin for ChunkImportMapPlugin {
       }
     }
 
-    let mut placeholders = find_hash_placeholders(&args.code, &hash_finder);
+    let mut placeholders = find_hash_placeholders(&args.code, &HASH_PLACEHOLDER_LEFT_FINDER);
     placeholders.retain(|placeholder| self.chunk_import_map.contains_key(placeholder.2));
 
     if placeholders.is_empty() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use a single static `HASH_PLACEHOLDER_LEFT_FINDER` instead of constructing a new `Finder` per call; update all usages and simplify related code paths.
> 
> - **rolldown_utils**:
>   - Introduce static `HASH_PLACEHOLDER_LEFT_FINDER` (`LazyLock<Finder<'static>>`) and remove `hash_placeholder_left_finder()`.
>   - Update `find_hash_placeholders`, `replace_placeholder_with_hash`, and tests to use the static finder.
> - **rolldown (finalize_chunks)**:
>   - Switch to `HASH_PLACEHOLDER_LEFT_FINDER` for extracting/replacing placeholders.
>   - Minor refactor: replace match on `StrOrBytes` with `if let` for string cases.
> - **plugin (chunk_import_map)**:
>   - Use `HASH_PLACEHOLDER_LEFT_FINDER` for filename/code placeholder detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65c17285d874e662de679b0728df233afd3c01be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<img width="1758" height="1834" alt="CleanShot 2025-10-17 at 15 44 22@2x" src="https://github.com/user-attachments/assets/e2a38bdb-f126-491c-86f7-2af46068fa31" />
