### PR TITLE
chore(test): add `opposite_minify_internal_exports` and remove `minify_internal_exports` extend test

### DIFF
--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [features]
 default = ["serde"]
 serde = ["dep:serde", "oxc_index/serde"]
+testing = []
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -37,3 +37,6 @@ pub use rolldown_common::bundler_options::*;
 pub use rolldown_resolver::ResolveOptions;
 
 pub use rolldown_plugin as plugin;
+
+#[cfg(feature = "testing")]
+pub use crate::utils::determine_minify_internal_exports_default::determine_minify_internal_exports_default;

--- a/crates/rolldown/src/utils/determine_minify_internal_exports_default.rs
+++ b/crates/rolldown/src/utils/determine_minify_internal_exports_default.rs
@@ -1,0 +1,16 @@
+use rolldown_common::{OutputFormat, RawMinifyOptions};
+
+/// Determines the default value for `minify_internal_exports` based on format and minify settings.
+///
+/// Returns `true` if:
+/// - format is `Esm`, OR
+/// - minify is `Bool(true)` or `Object(_)`
+///
+/// Otherwise returns `false`.
+pub fn determine_minify_internal_exports_default(
+  format: Option<OutputFormat>,
+  minify: &RawMinifyOptions,
+) -> bool {
+  matches!(format, Some(OutputFormat::Esm))
+    || matches!(minify, RawMinifyOptions::Bool(true) | RawMinifyOptions::Object(_))
+}

--- a/crates/rolldown/src/utils/mod.rs
+++ b/crates/rolldown/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod apply_inner_plugins;
 pub mod augment_chunk_hash;
 pub mod chunk;
+pub mod determine_minify_internal_exports_default;
 pub mod fs_utils;
 pub mod load_entry_module;
 pub mod load_source;

--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -3,8 +3,8 @@ use std::{borrow::Cow, path::Path, sync::Arc};
 use oxc::transformer_plugins::InjectGlobalVariablesConfig;
 use rolldown_common::{
   AttachDebugInfo, GlobalsOutputOption, InjectImport, LegalComments, MinifyOptions, ModuleType,
-  NormalizedBundlerOptions, OutputFormat, Platform, PreserveEntrySignatures, RawMinifyOptions,
-  TreeshakeOptions, normalize_optimization_option,
+  NormalizedBundlerOptions, OutputFormat, Platform, PreserveEntrySignatures, TreeshakeOptions,
+  normalize_optimization_option,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult, InvalidOptionType};
 use rolldown_fs::{OsFileSystem, OxcResolverFileSystem as _};
@@ -342,10 +342,12 @@ pub fn prepare_build_context(
     debug: raw_options.debug.is_some(),
     optimization: normalize_optimization_option(raw_options.optimization, platform),
     top_level_var: raw_options.top_level_var.unwrap_or(false),
-    minify_internal_exports: raw_options.minify_internal_exports.unwrap_or(
-      matches!(format, OutputFormat::Esm)
-        || matches!(raw_minify, RawMinifyOptions::Bool(true) | RawMinifyOptions::Object(_)),
-    ),
+    minify_internal_exports: raw_options.minify_internal_exports.unwrap_or_else(|| {
+      crate::utils::determine_minify_internal_exports_default::determine_minify_internal_exports_default(
+        Some(format),
+        &raw_minify,
+      )
+    }),
     clean_dir: raw_options.clean_dir.unwrap_or(false),
     context: raw_options.context.unwrap_or_default(),
     tsconfig,

--- a/crates/rolldown_testing/Cargo.toml
+++ b/crates/rolldown_testing/Cargo.toml
@@ -24,7 +24,7 @@ insta = { workspace = true }
 json-strip-comments = { workspace = true }
 jsonschema = { workspace = true }
 regex = { workspace = true }
-rolldown = { workspace = true }
+rolldown = { workspace = true, features = ["testing"] }
 rolldown_common = { workspace = true }
 rolldown_error = { workspace = true }
 rolldown_sourcemap = { workspace = true }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1652,8 +1652,8 @@
     "ExtendedTests": {
       "type": "object",
       "properties": {
-        "minifyInternalExports": {
-          "description": "Run the test case with `minifyInternalExports` enabled in addition to the default config.",
+        "oppositeMinifyInternalExports": {
+          "description": "Run the test case with the opposite value of `minifyInternalExports` compared to what the default would be.\nIf it's explicitly set in the config, this option has no effect.\nIf the default resolves to `true` (e.g., format: 'es' or minify: true), tests with `false`.\nIf the default resolves to `false` (e.g., format: 'cjs' without minify), tests with `true`.",
           "type": "boolean",
           "default": true
         }

--- a/crates/rolldown_testing/src/fixture.rs
+++ b/crates/rolldown_testing/src/fixture.rs
@@ -76,10 +76,24 @@ impl Fixture {
     options: &BundlerOptions,
     config_variants: &mut Vec<ConfigVariant>,
   ) {
-    if meta.extended_tests.minify_internal_exports && options.minify_internal_exports.is_none() {
+    use rolldown::determine_minify_internal_exports_default;
+    use rolldown_common::RawMinifyOptions;
+
+    if meta.extended_tests.opposite_minify_internal_exports
+      && options.minify_internal_exports.is_none()
+    {
+      // Determine what the default value would be based on format and minify settings
+      let default_value = determine_minify_internal_exports_default(
+        options.format,
+        options.minify.as_ref().unwrap_or(&RawMinifyOptions::Bool(false)),
+      );
+
+      // Test the opposite of the default
+      let test_value = !default_value;
+
       config_variants.push(ConfigVariant {
         config_name: Some("extended-minify-internal-exports".to_string()),
-        minify_internal_exports: Some(true),
+        minify_internal_exports: Some(test_value),
         snapshot: Some(false),
         ..Default::default()
       });

--- a/crates/rolldown_testing_config/src/extended_tests.rs
+++ b/crates/rolldown_testing_config/src/extended_tests.rs
@@ -6,9 +6,12 @@ use crate::utils::true_by_default;
 #[derive(Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExtendedTests {
-  /// Run the test case with `minifyInternalExports` enabled in addition to the default config.
+  /// Run the test case with the opposite value of `minifyInternalExports` compared to what the default would be.
+  /// If it's explicitly set in the config, this option has no effect.
+  /// If the default resolves to `true` (e.g., format: 'es' or minify: true), tests with `false`.
+  /// If the default resolves to `false` (e.g., format: 'cjs' without minify), tests with `true`.
   #[serde(default = "true_by_default")]
-  pub minify_internal_exports: bool,
+  pub opposite_minify_internal_exports: bool,
 }
 
 impl Default for ExtendedTests {


### PR DESCRIPTION
- I removed the previous `minify_internal_exports`​extend test
- New `opposite_minify_internal_exports`​ will now test the opposite behavior `minify_internal_exports`​.
    - If `minify_internal_exports`​ resolve to `false`​, we will test extra times for `true`​ and other way around.