### PR TITLE
fix:  cjs treeshaking removes used code

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/6593/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/6593/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./entry.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/6593/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6593/artifacts.snap
@@ -1,0 +1,51 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## chunk.js
+
+```js
+// HIDDEN [rolldown:runtime]
+export { __commonJS, __toDynamicImportESM };
+```
+
+## lib.js
+
+```js
+import { __commonJS } from "./chunk.js";
+
+//#region plugin.js
+var require_plugin = /* @__PURE__ */ __commonJS({ "plugin.js": ((exports) => {
+	Object.defineProperty(exports, "__esModule", { value: true });
+	exports.makePlugin = makePlugin;
+	function makePlugin() {
+		return { name: "plugin" };
+	}
+}) });
+
+//#endregion
+//#region lib.js
+var require_lib = /* @__PURE__ */ __commonJS({ "lib.js": ((exports, module) => {
+	var _pluginFactory = require_plugin();
+	module.exports = _pluginFactory.makePlugin;
+	module.exports.postcss = true;
+}) });
+
+//#endregion
+export default require_lib();
+
+```
+
+## main.js
+
+```js
+import { __toDynamicImportESM } from "./chunk.js";
+import assert from "node:assert";
+
+//#region entry.js
+const mod = await import("./lib.js").then(__toDynamicImportESM());
+assert.strictEqual(mod.default().name, "plugin");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/issues/6593/entry.js
+++ b/crates/rolldown/tests/rolldown/issues/6593/entry.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert'
+const mod = await import('./lib.js');
+
+assert.strictEqual(mod.default().name, 'plugin');

--- a/crates/rolldown/tests/rolldown/issues/6593/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/6593/lib.js
@@ -1,0 +1,5 @@
+var _pluginFactory = require("./plugin.js");
+
+module.exports = _pluginFactory.makePlugin;
+
+module.exports.postcss = true;

--- a/crates/rolldown/tests/rolldown/issues/6593/plugin.js
+++ b/crates/rolldown/tests/rolldown/issues/6593/plugin.js
@@ -1,0 +1,10 @@
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.makePlugin = makePlugin;
+
+function makePlugin() {
+  return {
+    name: "plugin",
+  };
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4793,6 +4793,12 @@ expression: output
 - chunk-!~{001}~.js => chunk--zchQUYv.js
 - dynamic-!~{003}~.js => dynamic-C-F4zVAd.js
 
+# tests/rolldown/issues/6593
+
+- main-!~{000}~.js => main-JSinLx_b.js
+- chunk-!~{001}~.js => chunk-BAbtX2hM.js
+- lib-!~{003}~.js => lib-DwB2ouhb.js
+
 # tests/rolldown/issues/rolldown_vite_289
 
 - main-!~{000}~.js => main-Bldhf8JA.js


### PR DESCRIPTION
Closed #6593

Before we don't consider the CommonJS module bailout and dynamic entry point elimination actually are mutually dependent.