### PR TITLE
perf(rolldown): reduce unnecessary Vec allocate

### DIFF
--- a/crates/rolldown/src/utils/process_code_and_sourcemap.rs
+++ b/crates/rolldown/src/utils/process_code_and_sourcemap.rs
@@ -26,24 +26,21 @@ pub async fn process_code_and_sourcemap(
   let map_filename = format!("{filename}.map");
   let map_path = file_dir.join(&map_filename);
 
-  let paths =
-    map.get_sources().map(|source| source.as_path().relative(file_dir)).collect::<Vec<_>>();
-  // Here not normalize the windows path, the rollup `sourcemap_path_transform` ctx.options need to original path.
-  let sources = paths.iter().map(|x| x.to_string_lossy()).collect::<Vec<_>>();
-  map.set_sources(sources.iter().map(std::convert::AsRef::as_ref).collect::<Vec<_>>());
-
   if let Some(source_map_ignore_list) = &options.sourcemap_ignore_list {
     let mut x_google_ignore_list = vec![];
     for (index, source) in map.get_sources().enumerate() {
+      let source = source.as_path().relative(file_dir);
       let should_ignore = match source_map_ignore_list {
         rolldown_common::SourceMapIgnoreList::Boolean(_)
         | rolldown_common::SourceMapIgnoreList::StringOrRegex(_) => {
           // Fast path: no async overhead for static values (boolean/string/regex)
-          source_map_ignore_list.exec_static(source)
+          source_map_ignore_list.exec_static(source.to_string_lossy().as_ref())
         }
         rolldown_common::SourceMapIgnoreList::Fn(_) => {
           // Slow path: async function call only when needed
-          source_map_ignore_list.exec_dynamic(source, map_path.to_string_lossy().as_ref()).await?
+          source_map_ignore_list
+            .exec_dynamic(source.to_string_lossy().as_ref(), map_path.to_string_lossy().as_ref())
+            .await?
         }
       };
 
@@ -60,7 +57,9 @@ pub async fn process_code_and_sourcemap(
   if let Some(sourcemap_path_transform) = &options.sourcemap_path_transform {
     let map_path = map_path.to_string_lossy();
     let sources = try_join_all(map.get_sources().map(async |source| {
-      let source = sourcemap_path_transform.call(source, map_path.as_ref()).await?;
+      let source = source.as_path().relative(file_dir);
+      let source =
+        sourcemap_path_transform.call(source.to_string_lossy().as_ref(), map_path.as_ref()).await?;
       #[cfg(windows)]
       {
         // Normalize the windows path.
@@ -76,8 +75,18 @@ pub async fn process_code_and_sourcemap(
     map.set_sources(sources);
   } else if cfg!(windows) {
     // Normalize the windows path at final.
-    let sources = map.get_sources().map(|x| x.to_slash_lossy().to_string()).collect::<Vec<_>>();
+    let sources = map
+      .get_sources()
+      .map(|x| x.as_path().relative(file_dir).to_slash_lossy().to_string())
+      .collect::<Vec<_>>();
     map.set_sources(sources);
+  } else {
+    map.set_sources(
+      map
+        .get_sources()
+        .map(|x| x.as_path().relative(file_dir).to_string_lossy().into_owned())
+        .collect::<Vec<_>>(),
+    );
   }
 
   if options.sourcemap_debug_ids && options.sourcemap.is_some() {


### PR DESCRIPTION
If there is `sourcemap_ignore_list` or `sourcemap_path_transform`, skip the `paths` and `sources` allocation.