### PR TITLE
perf(cli): advance `createTokioRuntime`

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -33,6 +33,7 @@
     "packages/rolldown": {
       "entry": [
         "src/browser.js",
+        "src/cli/setup-index.ts",
         "src/cli/index.ts",
         "src/log/locate-character/index.d.ts",
         "src/parallel-plugin-worker.ts",

--- a/packages/rolldown/bin/cli.mjs
+++ b/packages/rolldown/bin/cli.mjs
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
+import '../dist/cli-setup.mjs';
 import '../dist/cli.mjs';

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -117,6 +117,7 @@ function withShared(
       'experimental-index': './src/experimental-index',
       ...!isBrowserBuild
         ? {
+          'cli-setup': './src/cli/setup-index',
           cli: './src/cli/index',
           config: './src/config',
           'parallel-plugin': './src/parallel-plugin',

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -6,7 +6,6 @@ import { version } from '../../../package.json';
 import type { RolldownOptions, RolldownOutput } from '../..';
 import { rolldown } from '../../api/rolldown';
 import { watch as rolldownWatch } from '../../api/watch';
-import { createTokioRuntime } from '../../binding';
 import { getClearScreenFunction } from '../../utils/clear-screen';
 import { loadConfig } from '../../utils/load-config';
 import { arraify } from '../../utils/misc';
@@ -37,10 +36,8 @@ export async function bundleWithConfig(
 
   // TODO: Could add more validation/diagnostics here to emit a nice error message
   if (cliOptions.watch) {
-    createTokioRuntime(32);
     await watchInner(resolvedConfig, cliOptions);
   } else {
-    createTokioRuntime(4);
     await bundleInner(resolvedConfig, cliOptions);
   }
 }

--- a/packages/rolldown/src/cli/setup-index.ts
+++ b/packages/rolldown/src/cli/setup-index.ts
@@ -1,0 +1,21 @@
+// Initialize Tokio runtime as early as possible to avoid wasting time on imports
+
+import { createTokioRuntime } from '../binding';
+
+let isWatchMode = false;
+
+// Check for --watch or -w flag directly in process.argv. This is a bit hacky but good enough.
+for (let i = 0; i < process.argv.length; i++) {
+  const arg = process.argv[i];
+  if (arg === '--watch' || arg === '-w') {
+    isWatchMode = true;
+    break;
+  }
+}
+
+if (isWatchMode) {
+  // Due to implementation of watch, if we don't use this much of threads, it'll hang.
+  createTokioRuntime(32);
+} else {
+  createTokioRuntime(4);
+}


### PR DESCRIPTION
This slighly reduce the boostrap time mentioned https://github.com/rolldown/rolldown/issues/6616.