### PR TITLE
fix: avoid `define` deprecation warning when loading a config file

### DIFF
--- a/packages/rolldown/src/utils/load-config.ts
+++ b/packages/rolldown/src/utils/load-config.ts
@@ -20,12 +20,14 @@ async function bundleTsConfig(
     resolve: {
       mainFields: ['main'],
     },
-    define: {
-      __dirname: dirnameVarName,
-      __filename: filenameVarName,
-      'import.meta.url': importMetaUrlVarName,
-      'import.meta.dirname': dirnameVarName,
-      'import.meta.filename': filenameVarName,
+    transform: {
+      define: {
+        __dirname: dirnameVarName,
+        __filename: filenameVarName,
+        'import.meta.url': importMetaUrlVarName,
+        'import.meta.dirname': dirnameVarName,
+        'import.meta.filename': filenameVarName,
+      },
     },
     treeshake: false,
     external: [/^[\w@][^:]/], // external bare imports


### PR DESCRIPTION
The config loader was using the top-level `define`, so the warning was emitted if a config is used even if it was not used inside the user config.