### PR TITLE
perf(rolldown): upgrade sugar_path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,9 +3869,12 @@ dependencies = [
 
 [[package]]
 name = "sugar_path"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8230d5b8a65a6d4d4a7e5ee8dbdd9312ba447a8b8329689a390a0945d69b57ce"
+checksum = "48abcb2199ce37819c20dc7a72dc09e3263a00e598ff5089fe5fda92e0f63c37"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "supports-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ serde_json = "1.0.140"
 simdutf8 = "0.1.5"
 smallvec = "1.15.0"
 string_cache = "0.9.0"
-sugar_path = { version = "1.2.0", features = ["cached_current_dir"] }
+sugar_path = { version = "1.2.1", features = ["cached_current_dir"] }
 terminal_size = "0.4.2"
 testing_macros = "1.0.0"
 tokio = { version = "1.45.0", default-features = false }


### PR DESCRIPTION
Reduce memory allocation in the sugar_path

<img width="1954" height="1502" alt="CleanShot 2025-10-21 at 09 43 43@2x" src="https://github.com/user-attachments/assets/04ae52c5-1dac-4d2d-bc46-f7e27023303c" />
