### PR TITLE
fix(clean-dir): advance clean outdir to allow `generateBundle` outputs

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -227,8 +227,6 @@ impl Bundler {
     &mut self,
     scan_stage_output: NormalizedScanStageOutput,
   ) -> BuildResult<BundleOutput> {
-    let mut output = self.bundle_up(scan_stage_output, /* is_write */ true).await?;
-
     let dist_dir = self.options.cwd.join(&self.options.out_dir);
 
     if self.options.clean_dir && self.options.dir.is_some() {
@@ -237,6 +235,8 @@ impl Bundler {
           .context(err)
       })?;
     }
+
+    let mut output = self.bundle_up(scan_stage_output, /* is_write */ true).await?;
 
     self.fs.create_dir_all(&dist_dir).map_err(|err| {
       anyhow::anyhow!("Could not create directory for output chunks: {}", dist_dir.display())

--- a/packages/rolldown/tests/behaviors/clean-dir.test.ts
+++ b/packages/rolldown/tests/behaviors/clean-dir.test.ts
@@ -83,12 +83,18 @@ test('clean outdir hooks', async () => {
     input,
     cwd: root,
   });
+  
   await bundler.write({
     dir: outdir,
     entryFileNames: 'index.js',
     cleanDir: true,
   });
-  expect(existsSync(join(outdir, generateBundleFile))).toBe(false);
+
+  expect(existsSync(join(outdir, generateBundleFile))).toBe(true);
+  expect(readFileSync(join(outdir, generateBundleFile), 'utf-8')).toBe(
+    generateBundleContent,
+  );
+
   expect(existsSync(join(outdir, writeBundleFile))).toBe(true);
   expect(readFileSync(join(outdir, writeBundleFile), 'utf-8')).toBe(
     writeBundleContent,

--- a/packages/rolldown/tests/behaviors/clean-dir.test.ts
+++ b/packages/rolldown/tests/behaviors/clean-dir.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { rolldown } from 'rolldown';
 import { expect, test } from 'vitest';
@@ -6,17 +6,21 @@ import { expect, test } from 'vitest';
 const root = import.meta.dirname
 
 test('clean out dir', async () => {
+  const outdir = join(root, 'dist/clean-dir')
+  if (existsSync(outdir)) rmSync(outdir, { recursive: true })
+  
   const bundler = await rolldown({ input: 'index.ts', cwd: root })
-  const outdir = 'dist'
   await bundler.write({ dir: outdir, entryFileNames: 'index1.js', cleanDir: true })
-  expect(existsSync(join(root, 'dist/index1.js'))).toBe(true)
+  expect(existsSync(join(outdir, 'index1.js'))).toBe(true)
 
   await bundler.write({ dir: outdir, entryFileNames: 'index2.js', cleanDir: false })
-  expect(existsSync(join(root, 'dist/index1.js'))).toBe(true)
-  expect(existsSync(join(root, 'dist/index2.js'))).toBe(true)
+  expect(existsSync(join(outdir, 'index1.js'))).toBe(true)
+  expect(existsSync(join(outdir, 'index2.js'))).toBe(true)
 
   await bundler.write({ dir: outdir, entryFileNames: 'index3.js', cleanDir: true })
-  expect(existsSync(join(root, 'dist/index1.js'))).toBe(false)
-  expect(existsSync(join(root, 'dist/index2.js'))).toBe(false)
-  expect(existsSync(join(root, 'dist/index3.js'))).toBe(true)
+  expect(existsSync(join(outdir, 'index1.js'))).toBe(false)
+  expect(existsSync(join(outdir, 'index2.js'))).toBe(false)
+  expect(existsSync(join(outdir, 'index3.js'))).toBe(true)
+
+  rmSync(outdir, { recursive: true })
 })

--- a/packages/rolldown/tests/behaviors/clean-dir.test.ts
+++ b/packages/rolldown/tests/behaviors/clean-dir.test.ts
@@ -1,26 +1,98 @@
-import { existsSync, rmSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
-import { rolldown } from 'rolldown';
+import { rolldown, RolldownPlugin } from 'rolldown';
 import { expect, test } from 'vitest';
 
-const root = import.meta.dirname
+const root = import.meta.dirname;
+const input = join(root, 'index.ts');
 
-test('clean out dir', async () => {
-  const outdir = join(root, 'dist/clean-dir')
-  if (existsSync(outdir)) rmSync(outdir, { recursive: true })
-  
-  const bundler = await rolldown({ input: 'index.ts', cwd: root })
-  await bundler.write({ dir: outdir, entryFileNames: 'index1.js', cleanDir: true })
-  expect(existsSync(join(outdir, 'index1.js'))).toBe(true)
+test('clean outdir', async () => {
+  const outdir = join(root, 'dist/clean-dir');
+  if (existsSync(outdir)) rmSync(outdir, { recursive: true });
 
-  await bundler.write({ dir: outdir, entryFileNames: 'index2.js', cleanDir: false })
-  expect(existsSync(join(outdir, 'index1.js'))).toBe(true)
-  expect(existsSync(join(outdir, 'index2.js'))).toBe(true)
+  const bundler = await rolldown({ input, cwd: root });
+  await bundler.write({
+    dir: outdir,
+    entryFileNames: 'index1.js',
+    cleanDir: true,
+  });
+  expect(existsSync(join(outdir, 'index1.js'))).toBe(true);
 
-  await bundler.write({ dir: outdir, entryFileNames: 'index3.js', cleanDir: true })
-  expect(existsSync(join(outdir, 'index1.js'))).toBe(false)
-  expect(existsSync(join(outdir, 'index2.js'))).toBe(false)
-  expect(existsSync(join(outdir, 'index3.js'))).toBe(true)
+  await bundler.write({
+    dir: outdir,
+    entryFileNames: 'index2.js',
+    cleanDir: false,
+  });
+  expect(existsSync(join(outdir, 'index1.js'))).toBe(true);
+  expect(existsSync(join(outdir, 'index2.js'))).toBe(true);
 
-  rmSync(outdir, { recursive: true })
-})
+  await bundler.write({
+    dir: outdir,
+    entryFileNames: 'index3.js',
+    cleanDir: true,
+  });
+  expect(existsSync(join(outdir, 'index1.js'))).toBe(false);
+  expect(existsSync(join(outdir, 'index2.js'))).toBe(false);
+  expect(existsSync(join(outdir, 'index3.js'))).toBe(true);
+
+  rmSync(outdir, { recursive: true });
+});
+
+// When cleanDir is true, and there are file output in
+// the `generateBundle` hook, the file should not be cleaned.
+test('clean outdir hooks', async () => {
+  const generateBundleFile = 'generate-bundle.md';
+  const generateBundleContent = 'Generate bundle output.';
+
+  const writeBundleFile = 'write-bundle.md';
+  const writeBundleContent = 'Write bundle output.';
+
+  function examplePlugin(): RolldownPlugin {
+    return {
+      name: 'example-plugin',
+      generateBundle(outputOptions) {
+        const outputDir = outputOptions.dir;
+        if (!outputDir) throw new Error('cannot get outdir in plugin');
+        mkdirSync(outputDir, { recursive: true });
+        writeFileSync(
+          join(outputDir, generateBundleFile),
+          generateBundleContent,
+        );
+      },
+      writeBundle(outputOptions) {
+        const outputDir = outputOptions.dir;
+        if (!outputDir) throw new Error('cannot get outdir in plugin');
+        mkdirSync(outputDir, { recursive: true });
+        writeFileSync(join(outputDir, writeBundleFile), writeBundleContent);
+      },
+    };
+  }
+
+  const outdir = join(root, 'dist/clean-dir-hooks');
+  if (existsSync(outdir)) rmSync(outdir, { recursive: true });
+  expect(existsSync(outdir)).toBe(false);
+
+  const bundler = await rolldown({
+    plugins: [examplePlugin()],
+    input,
+    cwd: root,
+  });
+  await bundler.write({
+    dir: outdir,
+    entryFileNames: 'index.js',
+    cleanDir: true,
+  });
+  expect(existsSync(join(outdir, generateBundleFile))).toBe(false);
+  expect(existsSync(join(outdir, writeBundleFile))).toBe(true);
+  expect(readFileSync(join(outdir, writeBundleFile), 'utf-8')).toBe(
+    writeBundleContent,
+  );
+
+  rmSync(outdir, { recursive: true });
+});

--- a/packages/rolldown/tests/behaviors/index.ts
+++ b/packages/rolldown/tests/behaviors/index.ts
@@ -1,3 +1,3 @@
 export function placeholder(...values: number[]) {
-  return values.reduce((acc, cur) => acc + cur, 0)
+  return values.reduce((acc, cur) => acc + cur, 0);
 }

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
-import { test } from 'vitest'
-import { rolldown } from 'rolldown'
 import type { InputOptions } from 'rolldown'
+import { rolldown } from 'rolldown'
+import { test } from 'vitest'
 import type { TestConfig } from './src/types'
 
 main()
@@ -36,7 +36,7 @@ function main() {
       } catch (err) {
         throw new Error(`Failed in ${testConfigPath}`, { cause: err })
       }
-    })
+    }, 30_000) // Specify a longer timeout than default 20_000ms.
   }
 }
 

--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -36,7 +36,7 @@ function main() {
       } catch (err) {
         throw new Error(`Failed in ${testConfigPath}`, { cause: err })
       }
-    }, 30_000) // Specify a longer timeout than default 20_000ms.
+    }, 60_000) // Specify a longer timeout than default 20_000ms.
   }
 }
 


### PR DESCRIPTION
See: https://github.com/rolldown/rolldown/pull/6486#issuecomment-3421660516

Advance the "clean dir" code before the `bundle_up` is called inside the `bundle_write` function: `fn generate_bundle` is called in `fn bundle_up`, and the "clean dir" code is advanced before the call of `fn bundle_up` in `fn bundle_write`.

- [x] Fix the source code and pass all current tests.
- [x] Create new behavior tests about the `generateBundle` and `writeBundle` hook.

I also fix another bug about testing timeout configuration, which prevents the previous random failure when testing spent more time than the default 20s (20_000ms).