### PR TITLE
refactor: remove unnecessaey lazy data passing for `BindingOutputs`

### DIFF
--- a/crates/rolldown_binding/src/binding_bundler_impl.rs
+++ b/crates/rolldown_binding/src/binding_bundler_impl.rs
@@ -120,7 +120,7 @@ impl BindingBundlerImpl {
       },
       move |env, outputs| {
         if let napi::Either::B(ref binding_outputs) = outputs {
-          let chunk_size = binding_outputs.chunk_len();
+          let chunk_size = binding_outputs.chunks.len();
           // 16mb per chunk, it's just a hint, so it doesn't need to be accurate
           #[expect(clippy::cast_possible_wrap)]
           let memory_consumption = chunk_size as i64 * 1024 * 1024 * 16;

--- a/crates/rolldown_binding/src/types/binding_outputs.rs
+++ b/crates/rolldown_binding/src/types/binding_outputs.rs
@@ -13,28 +13,10 @@ use napi_derive::napi;
 use rolldown_error::{BuildDiagnostic, DiagnosticOptions};
 use rustc_hash::FxBuildHasher;
 
-// The `BindingOutputs` take the data to js side, the rust side will not use it anymore.
-#[napi]
+#[napi(object, object_from_js = false)]
 pub struct BindingOutputs {
-  chunks: Vec<BindingOutputChunk>,
-  assets: Vec<BindingOutputAsset>,
-}
-
-#[napi]
-impl BindingOutputs {
-  pub(crate) fn chunk_len(&self) -> usize {
-    self.chunks.len()
-  }
-
-  #[napi(getter)]
-  pub fn chunks(&mut self) -> Vec<BindingOutputChunk> {
-    std::mem::take(&mut self.chunks)
-  }
-
-  #[napi(getter)]
-  pub fn assets(&mut self) -> Vec<BindingOutputAsset> {
-    std::mem::take(&mut self.assets)
-  }
+  pub chunks: Vec<BindingOutputChunk>,
+  pub assets: Vec<BindingOutputAsset>,
 }
 
 impl From<Vec<rolldown_common::Output>> for BindingOutputs {

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1421,11 +1421,6 @@ export declare class BindingOutputChunk {
   get name(): string
 }
 
-export declare class BindingOutputs {
-  get chunks(): Array<BindingOutputChunk>
-  get assets(): Array<BindingOutputAsset>
-}
-
 export declare class BindingPluginContext {
   load(specifier: string, sideEffects: boolean | 'no-treeshake' | undefined, packageJsonPath?: string): Promise<void>
   resolve(specifier: string, importer?: string | undefined | null, extraOptions?: BindingPluginContextResolveOptions | undefined | null): Promise<BindingPluginContextResolvedId | null>
@@ -1999,6 +1994,11 @@ export interface BindingOutputOptions {
   topLevelVar?: boolean
   minifyInternalExports?: boolean
   cleanDir?: boolean
+}
+
+export interface BindingOutputs {
+  chunks: Array<BindingOutputChunk>
+  assets: Array<BindingOutputAsset>
 }
 
 export interface BindingPluginContextResolvedId {

--- a/packages/rolldown/src/binding.js
+++ b/packages/rolldown/src/binding.js
@@ -575,7 +575,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { minify, Severity, ParseResult, ExportExportNameKind, ExportImportNameKind, ExportLocalNameKind, ImportNameKind, parseAsync, parseSync, rawTransferSupported, ResolverFactory, EnforceExtension, ModuleType, sync, HelperMode, isolatedDeclaration, moduleRunnerTransform, transform, transformAsync, BindingBundleEndEventData, BindingBundleErrorEventData, BindingBundler, BindingBundlerImpl, BindingCallableBuiltinPlugin, BindingChunkingContext, BindingDevEngine, BindingMagicString, BindingModuleInfo, BindingNormalizedOptions, BindingOutputAsset, BindingOutputChunk, BindingOutputs, BindingPluginContext, BindingRenderedChunk, BindingRenderedChunkMeta, BindingRenderedModule, BindingTransformPluginContext, BindingUrlResolver, BindingWatcher, BindingWatcherChangeData, BindingWatcherEvent, ParallelJsPluginRegistry, ScheduledBuild, TraceSubscriberGuard, BindingAttachDebugInfo, BindingBuiltinPluginName, BindingChunkModuleOrderBy, BindingLogLevel, BindingPluginOrder, BindingPropertyReadSideEffects, BindingPropertyWriteSideEffects, BindingRebuildStrategy, createTokioRuntime, FilterTokenKind, initTraceSubscriber, registerPlugins, shutdownAsyncRuntime, startAsyncRuntime } = nativeBinding
+const { minify, Severity, ParseResult, ExportExportNameKind, ExportImportNameKind, ExportLocalNameKind, ImportNameKind, parseAsync, parseSync, rawTransferSupported, ResolverFactory, EnforceExtension, ModuleType, sync, HelperMode, isolatedDeclaration, moduleRunnerTransform, transform, transformAsync, BindingBundleEndEventData, BindingBundleErrorEventData, BindingBundler, BindingBundlerImpl, BindingCallableBuiltinPlugin, BindingChunkingContext, BindingDevEngine, BindingMagicString, BindingModuleInfo, BindingNormalizedOptions, BindingOutputAsset, BindingOutputChunk, BindingPluginContext, BindingRenderedChunk, BindingRenderedChunkMeta, BindingRenderedModule, BindingTransformPluginContext, BindingUrlResolver, BindingWatcher, BindingWatcherChangeData, BindingWatcherEvent, ParallelJsPluginRegistry, ScheduledBuild, TraceSubscriberGuard, BindingAttachDebugInfo, BindingBuiltinPluginName, BindingChunkModuleOrderBy, BindingLogLevel, BindingPluginOrder, BindingPropertyReadSideEffects, BindingPropertyWriteSideEffects, BindingRebuildStrategy, createTokioRuntime, FilterTokenKind, initTraceSubscriber, registerPlugins, shutdownAsyncRuntime, startAsyncRuntime } = nativeBinding
 export { minify }
 export { Severity }
 export { ParseResult }
@@ -607,7 +607,6 @@ export { BindingModuleInfo }
 export { BindingNormalizedOptions }
 export { BindingOutputAsset }
 export { BindingOutputChunk }
-export { BindingOutputs }
 export { BindingPluginContext }
 export { BindingRenderedChunk }
 export { BindingRenderedChunkMeta }

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -94,7 +94,6 @@ export const BindingModuleInfo = __napiModule.exports.BindingModuleInfo
 export const BindingNormalizedOptions = __napiModule.exports.BindingNormalizedOptions
 export const BindingOutputAsset = __napiModule.exports.BindingOutputAsset
 export const BindingOutputChunk = __napiModule.exports.BindingOutputChunk
-export const BindingOutputs = __napiModule.exports.BindingOutputs
 export const BindingPluginContext = __napiModule.exports.BindingPluginContext
 export const BindingRenderedChunk = __napiModule.exports.BindingRenderedChunk
 export const BindingRenderedChunkMeta = __napiModule.exports.BindingRenderedChunkMeta

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -139,7 +139,6 @@ module.exports.BindingModuleInfo = __napiModule.exports.BindingModuleInfo
 module.exports.BindingNormalizedOptions = __napiModule.exports.BindingNormalizedOptions
 module.exports.BindingOutputAsset = __napiModule.exports.BindingOutputAsset
 module.exports.BindingOutputChunk = __napiModule.exports.BindingOutputChunk
-module.exports.BindingOutputs = __napiModule.exports.BindingOutputs
 module.exports.BindingPluginContext = __napiModule.exports.BindingPluginContext
 module.exports.BindingRenderedChunk = __napiModule.exports.BindingRenderedChunk
 module.exports.BindingRenderedChunkMeta = __napiModule.exports.BindingRenderedChunkMeta


### PR DESCRIPTION
https://github.com/rolldown/rolldown/blob/a53d4418cab2293168f6545e1060dac58fdf55fb/packages/rolldown/src/utils/transform-to-rollup-output.ts#L135

get called all the time