### PR TITLE
refactor(node): only call `transformToRollupOutput` when needed

### DIFF
--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -8,11 +8,9 @@ import type { InputOptions } from '../../options/input-options';
 import type { OutputOptions } from '../../options/output-options';
 import type { HasProperty, TypeAssert } from '../../types/assert';
 import type { RolldownOutput } from '../../types/rolldown-output';
+import { RolldownOutputImpl } from '../../types/rolldown-output-impl';
 import { createBundlerOptions } from '../../utils/create-bundler-option';
 import { unwrapBindingResult } from '../../utils/error';
-import {
-  transformToRollupOutput,
-} from '../../utils/transform-to-rollup-output';
 import { validateOption } from '../../utils/validator';
 
 interface BundlerImplWithStopWorker {
@@ -83,14 +81,14 @@ export class RolldownBuild {
     validateOption('output', outputOptions);
     const { impl } = await this.#getBundlerWithStopWorker(outputOptions);
     const output = await impl.generate();
-    return transformToRollupOutput(unwrapBindingResult(output));
+    return new RolldownOutputImpl(unwrapBindingResult(output));
   }
 
   async write(outputOptions: OutputOptions = {}): Promise<RolldownOutput> {
     validateOption('output', outputOptions);
     const { impl } = await this.#getBundlerWithStopWorker(outputOptions);
     const output = await impl.write();
-    return transformToRollupOutput(unwrapBindingResult(output));
+    return new RolldownOutputImpl(unwrapBindingResult(output));
   }
 
   async close(): Promise<void> {

--- a/packages/rolldown/src/types/rolldown-output-impl.ts
+++ b/packages/rolldown/src/types/rolldown-output-impl.ts
@@ -1,0 +1,12 @@
+import type { BindingOutputs } from '../binding';
+import { transformToRollupOutput } from '../utils/transform-to-rollup-output';
+import type { RolldownOutput } from './rolldown-output';
+
+export class RolldownOutputImpl implements RolldownOutput {
+  constructor(private bindingOutputs: BindingOutputs) {
+  }
+
+  get output(): RolldownOutput['output'] {
+    return transformToRollupOutput(this.bindingOutputs).output;
+  }
+}


### PR DESCRIPTION
I just found I shouldn't made https://github.com/rolldown/rolldown/pull/6692