### PR TITLE
feat(experimental): introduce `freeExternalMemory` to free external memory immediately

### DIFF
--- a/crates/rolldown_binding/src/types/binding_output_asset.rs
+++ b/crates/rolldown_binding/src/types/binding_output_asset.rs
@@ -6,43 +6,56 @@ use crate::options::plugin::types::binding_asset_source::BindingAssetSource;
 
 #[napi]
 pub struct BindingOutputAsset {
-  inner: Arc<rolldown_common::OutputAsset>,
+  inner: Option<Arc<rolldown_common::OutputAsset>>,
 }
 
 #[napi]
 impl BindingOutputAsset {
   pub fn new(inner: Arc<rolldown_common::OutputAsset>) -> Self {
-    Self { inner }
+    Self { inner: Some(inner) }
+  }
+
+  fn try_get_inner(&self) -> napi::Result<&Arc<rolldown_common::OutputAsset>> {
+    self.inner.as_ref().ok_or_else(|| {
+      napi::Error::from_reason(
+        "BindingOutputAsset has been freed. Cannot access properties after calling __free__()",
+      )
+    })
+  }
+
+  #[napi(enumerable = false)]
+  pub fn drop_inner(&mut self) -> bool {
+    self.inner.take().is_some()
   }
 
   #[napi(getter)]
-  pub fn file_name(&self) -> &str {
-    &self.inner.filename
+  pub fn file_name(&self) -> napi::Result<&str> {
+    Ok(&self.try_get_inner()?.filename)
   }
 
   #[napi(getter)]
-  pub fn original_file_name(&self) -> Option<&str> {
-    self.inner.original_file_names.first().map(AsRef::as_ref)
+  pub fn original_file_name(&self) -> napi::Result<Option<&str>> {
+    Ok(self.try_get_inner()?.original_file_names.first().map(AsRef::as_ref))
   }
 
   #[napi(getter)]
-  pub fn original_file_names(&self) -> Vec<&str> {
-    self.inner.original_file_names.iter().map(AsRef::as_ref).collect()
+  pub fn original_file_names(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.original_file_names.iter().map(AsRef::as_ref).collect())
   }
 
   #[napi(getter)]
-  pub fn source(&self) -> BindingAssetSource {
-    self.inner.source.clone().into()
+  pub fn source(&self) -> napi::Result<BindingAssetSource> {
+    Ok(self.try_get_inner()?.source.clone().into())
   }
 
   #[napi(getter)]
-  pub fn name(&self) -> Option<&str> {
-    self.inner.names.first().map(AsRef::as_ref)
+  pub fn name(&self) -> napi::Result<Option<&str>> {
+    Ok(self.try_get_inner()?.names.first().map(AsRef::as_ref))
   }
 
   #[napi(getter)]
-  pub fn names(&self) -> Vec<&str> {
-    self.inner.names.iter().map(AsRef::as_ref).collect()
+  pub fn names(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.names.iter().map(AsRef::as_ref).collect())
   }
 }
 

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -13,86 +13,99 @@ use super::{
 
 #[napi]
 pub struct BindingOutputChunk {
-  inner: Arc<rolldown_common::OutputChunk>,
+  inner: Option<Arc<rolldown_common::OutputChunk>>,
 }
 
 #[napi]
 impl BindingOutputChunk {
   pub fn new(inner: Arc<rolldown_common::OutputChunk>) -> Self {
-    Self { inner }
+    Self { inner: Some(inner) }
+  }
+
+  fn try_get_inner(&self) -> napi::Result<&Arc<rolldown_common::OutputChunk>> {
+    self.inner.as_ref().ok_or_else(|| {
+      napi::Error::from_reason(
+        "BindingOutputChunk has been freed. Cannot access properties after calling __free__()",
+      )
+    })
+  }
+
+  #[napi(enumerable = false)]
+  pub fn drop_inner(&mut self) -> bool {
+    self.inner.take().is_some()
   }
 
   #[napi(getter)]
-  pub fn is_entry(&self) -> bool {
-    self.inner.is_entry
+  pub fn is_entry(&self) -> napi::Result<bool> {
+    Ok(self.try_get_inner()?.is_entry)
   }
 
   #[napi(getter)]
-  pub fn is_dynamic_entry(&self) -> bool {
-    self.inner.is_dynamic_entry
+  pub fn is_dynamic_entry(&self) -> napi::Result<bool> {
+    Ok(self.try_get_inner()?.is_dynamic_entry)
   }
 
   #[napi(getter)]
-  pub fn facade_module_id(&self) -> Option<&str> {
-    self.inner.facade_module_id.as_deref()
+  pub fn facade_module_id(&self) -> napi::Result<Option<&str>> {
+    Ok(self.try_get_inner()?.facade_module_id.as_deref())
   }
 
   #[napi(getter)]
-  pub fn module_ids(&self) -> Vec<&str> {
-    self.inner.module_ids.iter().map(AsRef::as_ref).collect()
+  pub fn module_ids(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.module_ids.iter().map(AsRef::as_ref).collect())
   }
 
   #[napi(getter)]
-  pub fn exports(&self) -> Vec<&str> {
-    self.inner.exports.iter().map(AsRef::as_ref).collect()
+  pub fn exports(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.exports.iter().map(AsRef::as_ref).collect())
   }
 
   // RenderedChunk
   #[napi(getter)]
-  pub fn file_name(&self) -> &str {
-    &self.inner.filename
+  pub fn file_name(&self) -> napi::Result<&str> {
+    Ok(&self.try_get_inner()?.filename)
   }
 
   #[napi(getter)]
-  pub fn modules(&self) -> BindingModules {
-    (&self.inner.modules).into()
+  pub fn modules(&self) -> napi::Result<BindingModules> {
+    Ok((&self.try_get_inner()?.modules).into())
   }
 
   #[napi(getter)]
-  pub fn imports(&self) -> Vec<&str> {
-    self.inner.imports.iter().map(AsRef::as_ref).collect()
+  pub fn imports(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.imports.iter().map(AsRef::as_ref).collect())
   }
 
   #[napi(getter)]
-  pub fn dynamic_imports(&self) -> Vec<&str> {
-    self.inner.dynamic_imports.iter().map(AsRef::as_ref).collect()
+  pub fn dynamic_imports(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.dynamic_imports.iter().map(AsRef::as_ref).collect())
   }
 
   // OutputChunk
   #[napi(getter)]
-  pub fn code(&self) -> &str {
-    &self.inner.code
+  pub fn code(&self) -> napi::Result<&str> {
+    Ok(&self.try_get_inner()?.code)
   }
 
   #[napi(getter)]
   // TODO: claude code - Cannot change to Option<&str>: performs JSON serialization via to_json_string()
   pub fn map(&self) -> napi::Result<Option<String>> {
-    Ok(self.inner.map.as_ref().map(SourceMap::to_json_string))
+    Ok(self.try_get_inner()?.map.as_ref().map(SourceMap::to_json_string))
   }
 
   #[napi(getter)]
-  pub fn sourcemap_file_name(&self) -> Option<&str> {
-    self.inner.sourcemap_filename.as_deref()
+  pub fn sourcemap_file_name(&self) -> napi::Result<Option<&str>> {
+    Ok(self.try_get_inner()?.sourcemap_filename.as_deref())
   }
 
   #[napi(getter)]
-  pub fn preliminary_file_name(&self) -> &str {
-    &self.inner.preliminary_filename
+  pub fn preliminary_file_name(&self) -> napi::Result<&str> {
+    Ok(&self.try_get_inner()?.preliminary_filename)
   }
 
   #[napi(getter)]
-  pub fn name(&self) -> &str {
-    &self.inner.name
+  pub fn name(&self) -> napi::Result<&str> {
+    Ok(&self.try_get_inner()?.name)
   }
 }
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -39,6 +39,7 @@
         "src/parallel-plugin-worker.ts",
         "src/rolldown-binding.wasi-browser.js",
         "src/{wasi,webcontainer}-*.*",
+        "src/api/experimental.ts",
       ],
       "ignore": [
         "src/binding.js",

--- a/packages/rolldown/src/api/experimental.ts
+++ b/packages/rolldown/src/api/experimental.ts
@@ -2,6 +2,8 @@ import type { InputOptions } from '../options/input-options';
 import { PluginDriver } from '../plugin/plugin-driver';
 import { RolldownBuild } from './rolldown/rolldown-build';
 
+export { freeExternalMemory } from '../types/external-memory-handle';
+
 /**
  * This is an experimental API. It's behavior may change in the future.
  *

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1396,6 +1396,7 @@ export declare class BindingNormalizedOptions {
 }
 
 export declare class BindingOutputAsset {
+  dropInner(): boolean
   get fileName(): string
   get originalFileName(): string | null
   get originalFileNames(): Array<string>
@@ -1405,6 +1406,7 @@ export declare class BindingOutputAsset {
 }
 
 export declare class BindingOutputChunk {
+  dropInner(): boolean
   get isEntry(): boolean
   get isDynamicEntry(): boolean
   get facadeModuleId(): string | null

--- a/packages/rolldown/src/types/external-memory-handle.ts
+++ b/packages/rolldown/src/types/external-memory-handle.ts
@@ -1,0 +1,45 @@
+// - `unique symbol` can't be used in computed properties with `isolatedDeclarations: true`
+// - https://github.com/microsoft/typescript/issues/61892
+export const symbolForExternalMemoryHandle =
+  '__rolldown_external_memory_handle__' as const;
+
+/**
+ * Interface for objects that hold external memory that can be explicitly freed.
+ */
+export interface ExternalMemoryHandle {
+  /**
+   * Frees the external memory held by this object.
+   * @returns `true` if memory was successfully freed, `false` if it was already freed.
+   * @internal
+   */
+  [symbolForExternalMemoryHandle]: () => boolean;
+}
+
+/**
+ * Frees the external memory held by the given handle.
+ *
+ * This is useful when you want to manually release memory held by Rust objects
+ * (like `OutputChunk` or `OutputAsset`) before they are garbage collected.
+ *
+ * @param handle - The object with external memory to free
+ * @returns `true` if memory was successfully freed, `false` if it was already freed
+ *
+ * @example
+ * ```typescript
+ * import { freeExternalMemory } from 'rolldown/experimental';
+ *
+ * const output = await bundle.generate();
+ * const chunk = output.output[0];
+ *
+ * // Use the chunk...
+ *
+ * // Manually free the memory
+ * const freed = freeExternalMemory(chunk); // true
+ * const alreadyFreed = freeExternalMemory(chunk); // false
+ *
+ * // Accessing chunk properties after freeing will throw an error
+ * ```
+ */
+export function freeExternalMemory(handle: ExternalMemoryHandle): boolean {
+  return handle[symbolForExternalMemoryHandle]();
+}

--- a/packages/rolldown/src/types/rolldown-output-impl.ts
+++ b/packages/rolldown/src/types/rolldown-output-impl.ts
@@ -1,12 +1,26 @@
 import type { BindingOutputs } from '../binding';
 import { transformToRollupOutput } from '../utils/transform-to-rollup-output';
+import type { ExternalMemoryHandle } from './external-memory-handle';
 import type { RolldownOutput } from './rolldown-output';
 
-export class RolldownOutputImpl implements RolldownOutput {
+export class RolldownOutputImpl
+  implements RolldownOutput, ExternalMemoryHandle
+{
   constructor(private bindingOutputs: BindingOutputs) {
   }
 
   get output(): RolldownOutput['output'] {
     return transformToRollupOutput(this.bindingOutputs).output;
+  }
+
+  __rolldown_external_memory_handle__(): boolean {
+    let allFreed = true;
+    for (const chunk of this.bindingOutputs.chunks) {
+      allFreed = chunk.dropInner() && allFreed;
+    }
+    for (const asset of this.bindingOutputs.assets) {
+      allFreed = asset.dropInner() && allFreed;
+    }
+    return allFreed;
   }
 }

--- a/packages/rolldown/src/types/rolldown-output.ts
+++ b/packages/rolldown/src/types/rolldown-output.ts
@@ -1,7 +1,8 @@
 import type { BindingRenderedChunk } from '../binding';
 import type { AssetSource } from '../utils/asset-source';
+import type { ExternalMemoryHandle } from './external-memory-handle';
 
-export interface OutputAsset {
+export interface OutputAsset extends ExternalMemoryHandle {
   type: 'asset';
   fileName: string;
   /** @deprecated Use "originalFileNames" instead. */
@@ -48,7 +49,7 @@ export interface RenderedChunk extends Omit<BindingRenderedChunk, 'modules'> {
   dynamicImports: Array<string>;
 }
 
-export interface OutputChunk {
+export interface OutputChunk extends ExternalMemoryHandle {
   type: 'chunk';
   code: string;
   name: string;

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -7,6 +7,7 @@ import type {
   JsOutputChunk,
 } from '../binding';
 import type { PluginContext } from '../plugin/plugin-context';
+import { symbolForExternalMemoryHandle } from '../types/external-memory-handle';
 import type { OutputBundle } from '../types/output-bundle';
 import type {
   OutputAsset,
@@ -71,6 +72,9 @@ function transformToRollupOutputChunk(
     },
     sourcemapFileName: bindingChunk.sourcemapFileName || null,
     preliminaryFileName: bindingChunk.preliminaryFileName,
+    [symbolForExternalMemoryHandle]: () => {
+      return bindingChunk.dropInner();
+    },
   } as OutputChunk;
   const cache: Record<string | symbol, any> = {};
   return new Proxy(chunk, {
@@ -159,6 +163,9 @@ function transformToRollupOutputAsset(
     },
     name: bindingAsset.name ?? undefined,
     names: bindingAsset.names,
+    [symbolForExternalMemoryHandle]: () => {
+      return bindingAsset.dropInner();
+    },
   } as OutputAsset;
   const cache: Record<string | symbol, any> = {};
   return new Proxy(asset, {
@@ -169,6 +176,10 @@ function transformToRollupOutputAsset(
       const value = target[p as keyof OutputAsset];
       cache[p] = value;
       return value;
+    },
+    has(target, p): boolean {
+      if (p in cache) return true;
+      return p in target;
     },
   });
 }


### PR DESCRIPTION
Part of #6346.

```typescript
import { freeExternalMemory } from 'rolldown/experimental';

const output = await bundle.generate();

freeExternalMemory(output)
```

- Accessing chunk properties after freeing will throw an error