### PR TITLE
fix(node/options): should validate `transform.jsx` correctly

### DIFF
--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -145,7 +145,15 @@ const TransformOptionsSchema = v.object({
   typescript: v.optional(TypescriptSchema),
   helpers: v.optional(HelpersSchema),
   decorators: v.optional(DecoratorOptionSchema),
-  jsx: v.optional(v.union([v.literal('preserve'), JsxOptionsSchema])),
+  jsx: v.optional(
+    v.union([
+      v.literal(false),
+      v.literal('preserve'),
+      v.literal('react'),
+      v.literal('react-jsx'),
+      JsxOptionsSchema,
+    ]),
+  ),
   target: v.pipe(
     v.optional(v.union([v.string(), v.array(v.string())])),
     v.description('The JavaScript target environment'),


### PR DESCRIPTION
Correct the `valibot` schema for option `jsx` to match the TypeScript type defined at [`transform-options.ts`](https://github.com/ocavue/rolldown/blob/058627d2fe17b2a729ff698a59c255c31df69ee2/packages/rolldown/src/options/transform-options.ts#L119)

Related: https://github.com/rolldown/tsdown/issues/562 