### PR TITLE
feat(node): automatically clean up external memory when calling `close`

### DIFF
--- a/packages/pluginutils/tsconfig.json
+++ b/packages/pluginutils/tsconfig.json
@@ -14,6 +14,8 @@
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     "isolatedDeclarations": true,
+    // This is for `rolldown` which uses decorators. This is a limitation of oxnode, which should infer tsconfig.json respecting project.
+    "experimentalDecorators": true,
 
     /* Type Checking */
     "strict": true, /* Enable all strict type-checking options. */

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -152,6 +152,9 @@ function withShared(
     },
     transform: {
       target: 'node22',
+      decorator: {
+        legacy: true,
+      },
       define: {
         'import.meta.browserBuild': String(isBrowserBuild),
       },

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -85,7 +85,7 @@
     "build-binding:wasi": "pnpm build-binding --target wasm32-wasip1-threads",
     "build-binding:wasi:release": "pnpm build-binding --profile release-wasi --target wasm32-wasip1-threads",
     "# Scrips for node #": "_",
-    "build-node": "tsx -C dev ./build.ts",
+    "build-node": "oxnode -C dev ./build.ts",
     "build-types-check": "tsc -p ./tsconfig.check.json",
     "build-js-glue": "pnpm run --sequential '/^build-(node|types-check)$/'",
     "build-native:debug": "pnpm run --sequential '/^build-(binding|js-glue)$/'",
@@ -134,7 +134,6 @@
   "devDependencies": {
     "@napi-rs/cli": "catalog:",
     "@napi-rs/wasm-runtime": "catalog:",
-    "@oxc-node/cli": "catalog:",
     "@rollup/plugin-json": "catalog:",
     "buble": "catalog:",
     "consola": "catalog:",
@@ -148,7 +147,7 @@
     "rollup": "catalog:",
     "signal-exit": "catalog:",
     "source-map": "catalog:",
-    "tsx": "catalog:",
+    "@oxc-node/cli": "catalog:",
     "typescript": "catalog:",
     "valibot": "catalog:"
   },

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -7,6 +7,10 @@ import {
 import type { InputOptions } from '../../options/input-options';
 import type { OutputOptions } from '../../options/output-options';
 import type { HasProperty, TypeAssert } from '../../types/assert';
+import {
+  type ExternalMemoryHandle,
+  freeExternalMemory,
+} from '../../types/external-memory-handle';
 import type { RolldownOutput } from '../../types/rolldown-output';
 import { RolldownOutputImpl } from '../../types/rolldown-output-impl';
 import { createBundlerOptions } from '../../utils/create-bundler-option';
@@ -22,10 +26,13 @@ interface BundlerImplWithStopWorker {
 // @ts-expect-error TS2540: the polyfill of `asyncDispose`.
 Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose');
 
+const IS_WEAKREF_SUPPORTED = typeof WeakRef !== 'undefined';
+
 export class RolldownBuild {
   #inputOptions: InputOptions;
   #bundler: BindingBundler;
   #bundlerImpl?: BundlerImplWithStopWorker;
+  #externalMemoryHandles: WeakRef<ExternalMemoryHandle>[] = [];
 
   static asyncRuntimeShutdown = false;
 
@@ -80,23 +87,47 @@ export class RolldownBuild {
   async generate(outputOptions: OutputOptions = {}): Promise<RolldownOutput> {
     validateOption('output', outputOptions);
     const { impl } = await this.#getBundlerWithStopWorker(outputOptions);
-    const output = await impl.generate();
-    return new RolldownOutputImpl(unwrapBindingResult(output));
+    const outputResult = await impl.generate();
+    const output = new RolldownOutputImpl(unwrapBindingResult(outputResult));
+    this.#storeToExternalMemoryHandle(output);
+    return output;
   }
 
   async write(outputOptions: OutputOptions = {}): Promise<RolldownOutput> {
     validateOption('output', outputOptions);
     const { impl } = await this.#getBundlerWithStopWorker(outputOptions);
-    const output = await impl.write();
-    return new RolldownOutputImpl(unwrapBindingResult(output));
+    const outputResult = await impl.write();
+    const output = new RolldownOutputImpl(unwrapBindingResult(outputResult));
+    this.#storeToExternalMemoryHandle(output);
+    return output;
   }
 
-  async close(): Promise<void> {
+  /**
+   * Close the build and free resources eagerly.
+   *
+   * By default, Rolldown will move data of external memory to Node.js heap before freeing the external memory. This allows users to still access the data after closing the build. However, this may lead to increased memory usage in Node.js heap and potential performance overhead due to data copying.
+   *
+   * If you don't need to access the data after closing the build, you can set `keepDataAlive` to `false` to free the external memory directly without moving data to Node.js heap.
+   *
+   * **Note:** Automatic cleanup of external memory handles only works in environments that support `WeakRef` (Node.js 14.6+ and modern browsers). In environments without WeakRef support, you can only rely on the garbage collector or manually free them by calling `freeExternalMemory()` from `rolldown/experimental`.
+   *
+   * @param keepDataAlive - Whether to keep data alive in Node.js heap after closing the build. Default is `true`.
+   */
+  async close(keepDataAlive = true): Promise<void> {
     if (this.#bundlerImpl) {
       await this.#bundlerImpl.stopWorkers?.();
       await this.#bundlerImpl.impl.close();
       this.#bundlerImpl.shutdown();
       this.#bundlerImpl = void 0;
+    }
+    if (this.#externalMemoryHandles.length > 0) {
+      for (const ref of this.#externalMemoryHandles) {
+        const handle = ref.deref();
+        if (handle) {
+          freeExternalMemory(handle, keepDataAlive);
+        }
+      }
+      this.#externalMemoryHandles = [];
     }
   }
 
@@ -109,6 +140,13 @@ export class RolldownBuild {
   // Converting it to a synchronous API might cause a deadlock if the user calls `write` and `watchFiles` simultaneously.
   get watchFiles(): Promise<string[]> {
     return this.#bundlerImpl?.impl.getWatchFiles() ?? Promise.resolve([]);
+  }
+
+  #storeToExternalMemoryHandle(handle: ExternalMemoryHandle) {
+    // This is a best-effort attempt to help free external memory. If `WeakRef` is not available, we just skip it.
+    if (IS_WEAKREF_SUPPORTED) {
+      this.#externalMemoryHandles.push(new WeakRef(handle));
+    }
   }
 }
 

--- a/packages/rolldown/src/decorators/lazy.ts
+++ b/packages/rolldown/src/decorators/lazy.ts
@@ -1,0 +1,51 @@
+const LAZY_FIELDS_KEY = Symbol('__lazy_fields__');
+const LAZY_CACHE_PREFIX = '__cached_';
+
+/**
+ * Legacy decorator that makes a getter lazy-evaluated and cached.
+ * Also auto-registers the field for batch prefetching.
+ *
+ * @example
+ * ```typescript
+ * class MyClass {
+ *   @lazy
+ *   get expensiveValue() {
+ *     return someExpensiveComputation();
+ *   }
+ * }
+ * ```
+ */
+export function lazy(
+  target: any,
+  propertyKey: string,
+  descriptor: PropertyDescriptor,
+): PropertyDescriptor {
+  // Ensure the class constructor has a lazy fields registry
+  if (!target.constructor[LAZY_FIELDS_KEY]) {
+    target.constructor[LAZY_FIELDS_KEY] = new Set<string>();
+  }
+  target.constructor[LAZY_FIELDS_KEY].add(propertyKey);
+
+  // eslint-disable-next-line typescript-eslint/unbound-method
+  const originalGetter = descriptor.get!;
+  const cacheKey = LAZY_CACHE_PREFIX + propertyKey;
+
+  descriptor.get = function(this: any) {
+    if (!(cacheKey in this)) {
+      this[cacheKey] = originalGetter.call(this);
+    }
+    return this[cacheKey];
+  };
+
+  return descriptor;
+}
+
+/**
+ * Get all lazy field names from a class instance.
+ *
+ * @param instance - Instance to inspect
+ * @returns Set of lazy property names
+ */
+export function getLazyFields(instance: any): Set<string> {
+  return instance.constructor[LAZY_FIELDS_KEY] || new Set();
+}

--- a/packages/rolldown/src/decorators/non-enumerable.ts
+++ b/packages/rolldown/src/decorators/non-enumerable.ts
@@ -1,0 +1,22 @@
+/**
+ * Decorator that makes a property or method non-enumerable.
+ * This hides the property from enumeration (e.g., Object.keys(), for...in loops).
+ *
+ * @example
+ * ```typescript
+ * class MyClass {
+ *   @nonEnumerable
+ *   hiddenMethod() {
+ *     return 'This method will not show up in Object.keys()';
+ *   }
+ * }
+ * ```
+ */
+export function nonEnumerable(
+  target: any,
+  propertyKey: string,
+  descriptor: PropertyDescriptor,
+): PropertyDescriptor {
+  descriptor.enumerable = false;
+  return descriptor;
+}

--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -1,7 +1,7 @@
 export { dev } from './api/dev';
 export { DevEngine } from './api/dev/dev-engine';
 export type { DevOptions, DevWatchOptions } from './api/dev/dev-options';
-export { scan } from './api/experimental';
+export { freeExternalMemory, scan } from './api/experimental';
 export {
   BindingRebuildStrategy,
   isolatedDeclaration,

--- a/packages/rolldown/src/types/external-memory-handle.ts
+++ b/packages/rolldown/src/types/external-memory-handle.ts
@@ -1,6 +1,6 @@
 // - `unique symbol` can't be used in computed properties with `isolatedDeclarations: true`
 // - https://github.com/microsoft/typescript/issues/61892
-export const symbolForExternalMemoryHandle =
+const symbolForExternalMemoryHandle =
   '__rolldown_external_memory_handle__' as const;
 
 /**
@@ -9,10 +9,12 @@ export const symbolForExternalMemoryHandle =
 export interface ExternalMemoryHandle {
   /**
    * Frees the external memory held by this object.
+   * @param keepDataAlive - If true, evaluates all lazy fields before freeing memory.
+   *   This will take time but prevents errors when accessing properties after freeing.
    * @returns `true` if memory was successfully freed, `false` if it was already freed.
    * @internal
    */
-  [symbolForExternalMemoryHandle]: () => boolean;
+  [symbolForExternalMemoryHandle]: (keepDataAlive?: boolean) => boolean;
 }
 
 /**
@@ -22,6 +24,9 @@ export interface ExternalMemoryHandle {
  * (like `OutputChunk` or `OutputAsset`) before they are garbage collected.
  *
  * @param handle - The object with external memory to free
+ * @param keepDataAlive - If true, evaluates all lazy fields before freeing memory (default: false).
+ *   This will take time to copy data from Rust to JavaScript, but prevents errors
+ *   when accessing properties after the memory is freed.
  * @returns `true` if memory was successfully freed, `false` if it was already freed
  *
  * @example
@@ -33,13 +38,20 @@ export interface ExternalMemoryHandle {
  *
  * // Use the chunk...
  *
- * // Manually free the memory
+ * // Manually free the memory (fast, but accessing properties after will throw)
  * const freed = freeExternalMemory(chunk); // true
  * const alreadyFreed = freeExternalMemory(chunk); // false
  *
- * // Accessing chunk properties after freeing will throw an error
+ * // Keep data alive before freeing (slower, but data remains accessible)
+ * freeExternalMemory(chunk, true); // Evaluates all lazy fields first
+ * console.log(chunk.code); // OK - data was copied to JavaScript before freeing
+ *
+ * // Without keepDataAlive, accessing chunk properties after freeing will throw an error
  * ```
  */
-export function freeExternalMemory(handle: ExternalMemoryHandle): boolean {
-  return handle[symbolForExternalMemoryHandle]();
+export function freeExternalMemory(
+  handle: ExternalMemoryHandle,
+  keepDataAlive = false,
+): boolean {
+  return handle[symbolForExternalMemoryHandle](keepDataAlive);
 }

--- a/packages/rolldown/src/types/output-asset-impl.ts
+++ b/packages/rolldown/src/types/output-asset-impl.ts
@@ -1,0 +1,57 @@
+import type { BindingOutputAsset } from '../binding';
+import { getLazyFields, lazy } from '../decorators/lazy';
+import { nonEnumerable } from '../decorators/non-enumerable';
+import type { AssetSource } from '../utils/asset-source';
+import { transformAssetSource } from '../utils/asset-source';
+import type { OutputAsset } from './rolldown-output';
+
+export class OutputAssetImpl implements OutputAsset {
+  readonly type = 'asset' as const;
+
+  constructor(private bindingAsset: BindingOutputAsset) {
+  }
+
+  @lazy
+  get fileName(): string {
+    return this.bindingAsset.fileName;
+  }
+
+  @lazy
+  get originalFileName(): string | null {
+    return this.bindingAsset.originalFileName || null;
+  }
+
+  @lazy
+  get originalFileNames(): string[] {
+    return this.bindingAsset.originalFileNames;
+  }
+
+  @lazy
+  get name(): string | undefined {
+    return this.bindingAsset.name ?? undefined;
+  }
+
+  @lazy
+  get names(): string[] {
+    return this.bindingAsset.names;
+  }
+
+  @lazy
+  get source(): AssetSource {
+    return transformAssetSource(this.bindingAsset.source);
+  }
+
+  @nonEnumerable
+  __rolldown_external_memory_handle__(keepDataAlive?: boolean): boolean {
+    if (keepDataAlive) {
+      this.#evaluateAllLazyFields();
+    }
+    return this.bindingAsset.dropInner();
+  }
+
+  #evaluateAllLazyFields(): void {
+    for (const field of getLazyFields(this)) {
+      void (this as any)[field];
+    }
+  }
+}

--- a/packages/rolldown/src/types/output-chunk-impl.ts
+++ b/packages/rolldown/src/types/output-chunk-impl.ts
@@ -1,0 +1,99 @@
+import type { BindingOutputChunk } from '../binding';
+import { getLazyFields, lazy } from '../decorators/lazy';
+import { nonEnumerable } from '../decorators/non-enumerable';
+import { transformChunkModules } from '../utils/transform-rendered-chunk';
+import { transformToRollupSourceMap } from '../utils/transform-to-rollup-output';
+import type { OutputChunk, RenderedModule, SourceMap } from './rolldown-output';
+
+export class OutputChunkImpl implements OutputChunk {
+  readonly type = 'chunk' as const;
+
+  constructor(private bindingChunk: BindingOutputChunk) {
+  }
+
+  @lazy
+  get fileName(): string {
+    return this.bindingChunk.fileName;
+  }
+
+  @lazy
+  get name(): string {
+    return this.bindingChunk.name;
+  }
+
+  @lazy
+  get exports(): string[] {
+    return this.bindingChunk.exports;
+  }
+
+  @lazy
+  get isEntry(): boolean {
+    return this.bindingChunk.isEntry;
+  }
+
+  @lazy
+  get facadeModuleId(): string | null {
+    return this.bindingChunk.facadeModuleId || null;
+  }
+
+  @lazy
+  get isDynamicEntry(): boolean {
+    return this.bindingChunk.isDynamicEntry;
+  }
+
+  @lazy
+  get sourcemapFileName(): string | null {
+    return this.bindingChunk.sourcemapFileName || null;
+  }
+
+  @lazy
+  get preliminaryFileName(): string {
+    return this.bindingChunk.preliminaryFileName;
+  }
+
+  @lazy
+  get code(): string {
+    return this.bindingChunk.code;
+  }
+
+  @lazy
+  get modules(): { [id: string]: RenderedModule } {
+    return transformChunkModules(this.bindingChunk.modules);
+  }
+
+  @lazy
+  get imports(): string[] {
+    return this.bindingChunk.imports;
+  }
+
+  @lazy
+  get dynamicImports(): string[] {
+    return this.bindingChunk.dynamicImports;
+  }
+
+  @lazy
+  get moduleIds(): string[] {
+    return this.bindingChunk.moduleIds;
+  }
+
+  @lazy
+  get map(): SourceMap | null {
+    return this.bindingChunk.map
+      ? transformToRollupSourceMap(this.bindingChunk.map)
+      : null;
+  }
+
+  @nonEnumerable
+  __rolldown_external_memory_handle__(keepDataAlive?: boolean): boolean {
+    if (keepDataAlive) {
+      this.#evaluateAllLazyFields();
+    }
+    return this.bindingChunk.dropInner();
+  }
+
+  #evaluateAllLazyFields(): void {
+    for (const field of getLazyFields(this)) {
+      void (this as any)[field];
+    }
+  }
+}

--- a/packages/rolldown/src/types/rolldown-output-impl.ts
+++ b/packages/rolldown/src/types/rolldown-output-impl.ts
@@ -1,4 +1,6 @@
 import type { BindingOutputs } from '../binding';
+import { lazy } from '../decorators/lazy';
+import { nonEnumerable } from '../decorators/non-enumerable';
 import { transformToRollupOutput } from '../utils/transform-to-rollup-output';
 import type { ExternalMemoryHandle } from './external-memory-handle';
 import type { RolldownOutput } from './rolldown-output';
@@ -9,17 +11,20 @@ export class RolldownOutputImpl
   constructor(private bindingOutputs: BindingOutputs) {
   }
 
+  @lazy
   get output(): RolldownOutput['output'] {
     return transformToRollupOutput(this.bindingOutputs).output;
   }
 
-  __rolldown_external_memory_handle__(): boolean {
+  @nonEnumerable
+  __rolldown_external_memory_handle__(keepDataAlive?: boolean): boolean {
     let allFreed = true;
-    for (const chunk of this.bindingOutputs.chunks) {
-      allFreed = chunk.dropInner() && allFreed;
-    }
-    for (const asset of this.bindingOutputs.assets) {
-      allFreed = asset.dropInner() && allFreed;
+    // Get the output array which contains OutputChunkImpl and OutputAssetImpl instances
+    const outputs = this.output;
+    for (const item of outputs) {
+      // Call each item's __rolldown_external_memory_handle__ to ensure all lazy fields are evaluated when needed
+      allFreed = item.__rolldown_external_memory_handle__(keepDataAlive) &&
+        allFreed;
     }
     return allFreed;
   }

--- a/packages/rolldown/src/types/rolldown-output.ts
+++ b/packages/rolldown/src/types/rolldown-output.ts
@@ -69,6 +69,6 @@ export interface OutputChunk extends ExternalMemoryHandle {
   preliminaryFileName: string;
 }
 
-export interface RolldownOutput {
+export interface RolldownOutput extends ExternalMemoryHandle {
   output: [OutputChunk, ...(OutputChunk | OutputAsset)[]];
 }

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -7,8 +7,9 @@ import type {
   JsOutputChunk,
 } from '../binding';
 import type { PluginContext } from '../plugin/plugin-context';
-import { symbolForExternalMemoryHandle } from '../types/external-memory-handle';
+import { OutputAssetImpl } from '../types/output-asset-impl';
 import type { OutputBundle } from '../types/output-bundle';
+import { OutputChunkImpl } from '../types/output-chunk-impl';
 import type {
   OutputAsset,
   OutputChunk,
@@ -23,7 +24,7 @@ import {
 } from './asset-source';
 import { transformChunkModules } from './transform-rendered-chunk';
 
-function transformToRollupSourceMap(map: string): SourceMap {
+export function transformToRollupSourceMap(map: string): SourceMap {
   const parsed: Omit<SourceMap, 'toString' | 'toUrl'> = JSON.parse(map);
   const obj: SourceMap = {
     ...parsed,
@@ -42,55 +43,7 @@ function transformToRollupSourceMap(map: string): SourceMap {
 function transformToRollupOutputChunk(
   bindingChunk: BindingOutputChunk,
 ): OutputChunk {
-  const chunk = {
-    type: 'chunk',
-    get code() {
-      return bindingChunk.code;
-    },
-    fileName: bindingChunk.fileName,
-    name: bindingChunk.name,
-    get modules() {
-      return transformChunkModules(bindingChunk.modules);
-    },
-    get imports() {
-      return bindingChunk.imports;
-    },
-    get dynamicImports() {
-      return bindingChunk.dynamicImports;
-    },
-    exports: bindingChunk.exports,
-    isEntry: bindingChunk.isEntry,
-    facadeModuleId: bindingChunk.facadeModuleId || null,
-    isDynamicEntry: bindingChunk.isDynamicEntry,
-    get moduleIds() {
-      return bindingChunk.moduleIds;
-    },
-    get map() {
-      return bindingChunk.map
-        ? transformToRollupSourceMap(bindingChunk.map)
-        : null;
-    },
-    sourcemapFileName: bindingChunk.sourcemapFileName || null,
-    preliminaryFileName: bindingChunk.preliminaryFileName,
-    [symbolForExternalMemoryHandle]: () => {
-      return bindingChunk.dropInner();
-    },
-  } as OutputChunk;
-  const cache: Record<string | symbol, any> = {};
-  return new Proxy(chunk, {
-    get(target, p) {
-      if (p in cache) {
-        return cache[p];
-      }
-      const value = target[p as keyof OutputChunk];
-      cache[p] = value;
-      return value;
-    },
-    has(target, p): boolean {
-      if (p in cache) return true;
-      return p in target;
-    },
-  });
+  return new OutputChunkImpl(bindingChunk);
 }
 
 function transformToMutableRollupOutputChunk(
@@ -153,35 +106,7 @@ function transformToMutableRollupOutputChunk(
 function transformToRollupOutputAsset(
   bindingAsset: BindingOutputAsset,
 ): OutputAsset {
-  const asset = {
-    type: 'asset',
-    fileName: bindingAsset.fileName,
-    originalFileName: bindingAsset.originalFileName || null,
-    originalFileNames: bindingAsset.originalFileNames,
-    get source(): AssetSource {
-      return transformAssetSource(bindingAsset.source);
-    },
-    name: bindingAsset.name ?? undefined,
-    names: bindingAsset.names,
-    [symbolForExternalMemoryHandle]: () => {
-      return bindingAsset.dropInner();
-    },
-  } as OutputAsset;
-  const cache: Record<string | symbol, any> = {};
-  return new Proxy(asset, {
-    get(target, p) {
-      if (p in cache) {
-        return cache[p];
-      }
-      const value = target[p as keyof OutputAsset];
-      cache[p] = value;
-      return value;
-    },
-    has(target, p): boolean {
-      if (p in cache) return true;
-      return p in target;
-    },
-  });
+  return new OutputAssetImpl(bindingAsset);
 }
 
 function transformToMutableRollupOutputAsset(

--- a/packages/rolldown/tests/fixtures/topics/free-external-memory/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/free-external-memory/_config.ts
@@ -1,0 +1,46 @@
+import { defineTest } from 'rolldown-tests'
+import { freeExternalMemory } from 'rolldown/experimental'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'test-emit-asset',
+        buildStart() {
+          // Emit an asset to ensure we have both chunks and assets for type testing
+          this.emitFile({
+            type: 'asset',
+            name: 'test.txt',
+            source: 'test content for type checking',
+          })
+        },
+      },
+    ],
+  },
+  afterTest(output) {
+    // This test primarily ensures TypeScript type correctness in main.ts
+    // The actual runtime behavior is tested in object-properties test
+    // Here we just verify the API works at runtime as well
+
+    // Test 1: Can call freeExternalMemory on RolldownOutput
+    const result1 = freeExternalMemory(output)
+    expect(typeof result1).toBe('boolean')
+
+    // Test 2: Can call freeExternalMemory on OutputChunk
+    const chunk = output.output.find((item) => item.type === 'chunk')
+    expect(chunk).toBeDefined()
+    if (chunk) {
+      const result2 = freeExternalMemory(chunk)
+      expect(typeof result2).toBe('boolean')
+    }
+
+    // Test 3: Can call freeExternalMemory on OutputAsset
+    const asset = output.output.find((item) => item.type === 'asset')
+    expect(asset).toBeDefined()
+    if (asset) {
+      const result3 = freeExternalMemory(asset)
+      expect(typeof result3).toBe('boolean')
+    }
+  },
+})

--- a/packages/rolldown/tests/fixtures/topics/free-external-memory/main.ts
+++ b/packages/rolldown/tests/fixtures/topics/free-external-memory/main.ts
@@ -1,0 +1,22 @@
+// Test if `freeExternalMemory` could be called satisfying the type requirements
+
+import { rolldown } from 'rolldown'
+import { freeExternalMemory } from 'rolldown/experimental'
+
+async function testFreeExternalMemory() {
+  const build = await rolldown({
+    input: './main.ts',
+  })
+
+  const bundle = await build.generate()
+  
+
+  function _usage() {
+    freeExternalMemory(bundle)
+    for (const item of bundle.output) {
+      freeExternalMemory(item)
+    }
+  }
+}
+
+export default testFreeExternalMemory

--- a/packages/rolldown/tests/fixtures/topics/rollup-compat/object-properties/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/rollup-compat/object-properties/_config.ts
@@ -1,0 +1,80 @@
+import { defineTest } from 'rolldown-tests'
+import { getOutputAsset, getOutputChunk } from 'rolldown-tests/utils'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'test-emit-asset',
+        buildStart() {
+          // Emit an asset to ensure we have both chunks and assets to test
+          this.emitFile({
+            type: 'asset',
+            name: 'test-asset.txt',
+            source: 'test content',
+          })
+        },
+      },
+    ],
+  },
+  afterTest(output) {
+    // Test 1: OutputChunk instances should have non-enumerable __rolldown_external_memory_handle__
+    const chunks = getOutputChunk(output)
+    expect(chunks.length).toBeGreaterThan(0)
+
+    for (const chunk of chunks) {
+      // Verify the method exists and is callable
+      expect(typeof chunk.__rolldown_external_memory_handle__).toBe('function')
+
+      // Verify it's not enumerable (doesn't appear in Object.keys)
+      expect(Object.keys(chunk)).not.toContain('__rolldown_external_memory_handle__')
+
+      // Verify the property descriptor shows enumerable: false
+      // The method is on the prototype, so we need to check the prototype chain
+      const descriptor = Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(chunk),
+        '__rolldown_external_memory_handle__',
+      )
+      expect(descriptor).toBeDefined()
+      expect(descriptor?.enumerable).toBe(false)
+    }
+
+    // Test 2: OutputAsset instances should have non-enumerable __rolldown_external_memory_handle__
+    const assets = getOutputAsset(output)
+    expect(assets.length).toBeGreaterThan(0)
+
+    for (const asset of assets) {
+      // Verify the method exists and is callable
+      expect(typeof asset.__rolldown_external_memory_handle__).toBe('function')
+
+      // Verify it's not enumerable (doesn't appear in Object.keys)
+      expect(Object.keys(asset)).not.toContain('__rolldown_external_memory_handle__')
+
+      // Verify the property descriptor shows enumerable: false
+      // The method is on the prototype, so we need to check the prototype chain
+      const descriptor = Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(asset),
+        '__rolldown_external_memory_handle__',
+      )
+      expect(descriptor).toBeDefined()
+      expect(descriptor?.enumerable).toBe(false)
+    }
+
+    // Test 3: RolldownOutput instance should have non-enumerable __rolldown_external_memory_handle__
+    // Verify the method exists and is callable
+    expect(typeof output.__rolldown_external_memory_handle__).toBe('function')
+
+    // Verify it's not enumerable (doesn't appear in Object.keys)
+    expect(Object.keys(output)).not.toContain('__rolldown_external_memory_handle__')
+
+    // Verify the property descriptor shows enumerable: false
+    // The method is on the prototype, so we need to check the prototype chain
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(output),
+      '__rolldown_external_memory_handle__',
+    )
+    expect(descriptor).toBeDefined()
+    expect(descriptor?.enumerable).toBe(false)
+  },
+})

--- a/packages/rolldown/tests/fixtures/topics/rollup-compat/object-properties/main.js
+++ b/packages/rolldown/tests/fixtures/topics/rollup-compat/object-properties/main.js
@@ -1,0 +1,1 @@
+export const answer = 42;

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -17,6 +17,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "experimentalDecorators": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,7 +208,7 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     tsx:
-      specifier: ^4.19.4
+      specifier: ^4.20.6
       version: 4.20.6
     typescript:
       specifier: ^5.8.3
@@ -576,9 +576,6 @@ importers:
       source-map:
         specifier: 'catalog:'
         version: 0.7.6
-      tsx:
-        specifier: 'catalog:'
-        version: 4.20.6
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,6 @@ catalog:
   'rolldown-plugin-dts': '^0.17.0'
   'tsdown': '0.15.10'
   'typescript': '^5.8.3'
-  'tsx': '^4.19.4'
   'vitest': '^4.0.1'
   'vite': '^7.0.0'
   '@types/node': '24.9.1'
@@ -110,3 +109,4 @@ catalog:
   'estree-toolkit': '^1.7.8'
   'web-tree-sitter': '^0.25.0'
   'valibot': '1.1.0'
+  'tsx': '^4.20.6'


### PR DESCRIPTION
- Part of #6346
- https://github.com/nodejs/node/issues/60424

Explanation:

- When calling `close`, Objects that impments `ExternalMemoryHandle` would be cleaned up automatically from `RolldownBuild#externalMemoryHandles`.
- We use `WeakRef` to store objects, so it won't be an issue to that rolldown itself prevents objects from being GCed by nodejs
- Active lts node version all support `WeakRef`
- Legacy decorator is inroduced to collect lazy fields automatically. (We could switch to stage3 decorator once oxc supports it)
- We'll eagerly evaluate lazy fields when cleaning up to avoid errors when users try to access objects after cleaning. (This is enabled by default, becuase that's how people's mental model thinks. Our tests is also written in this way)