### PR TITLE
feat(experimental): introduce `freeExternalMemory` to free external memory immediately

### DIFF
--- a/crates/rolldown_binding/src/types/binding_output_asset.rs
+++ b/crates/rolldown_binding/src/types/binding_output_asset.rs
@@ -6,43 +6,56 @@ use crate::options::plugin::types::binding_asset_source::BindingAssetSource;
 
 #[napi]
 pub struct BindingOutputAsset {
-  inner: Arc<rolldown_common::OutputAsset>,
+  inner: Option<Arc<rolldown_common::OutputAsset>>,
 }
 
 #[napi]
 impl BindingOutputAsset {
   pub fn new(inner: Arc<rolldown_common::OutputAsset>) -> Self {
-    Self { inner }
+    Self { inner: Some(inner) }
+  }
+
+  fn try_get_inner(&self) -> napi::Result<&Arc<rolldown_common::OutputAsset>> {
+    self.inner.as_ref().ok_or_else(|| {
+      napi::Error::from_reason(
+        "Memory has been freed by `freeExternalMemory()`. Cannot access properties. To prevent this, use `freeExternalMemory(handle, true)` with `keepDataAlive`.",
+      )
+    })
+  }
+
+  #[napi(enumerable = false)]
+  pub fn drop_inner(&mut self) -> bool {
+    self.inner.take().is_some()
   }
 
   #[napi(getter)]
-  pub fn file_name(&self) -> &str {
-    &self.inner.filename
+  pub fn file_name(&self) -> napi::Result<&str> {
+    Ok(&self.try_get_inner()?.filename)
   }
 
   #[napi(getter)]
-  pub fn original_file_name(&self) -> Option<&str> {
-    self.inner.original_file_names.first().map(AsRef::as_ref)
+  pub fn original_file_name(&self) -> napi::Result<Option<&str>> {
+    Ok(self.try_get_inner()?.original_file_names.first().map(AsRef::as_ref))
   }
 
   #[napi(getter)]
-  pub fn original_file_names(&self) -> Vec<&str> {
-    self.inner.original_file_names.iter().map(AsRef::as_ref).collect()
+  pub fn original_file_names(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.original_file_names.iter().map(AsRef::as_ref).collect())
   }
 
   #[napi(getter)]
-  pub fn source(&self) -> BindingAssetSource {
-    self.inner.source.clone().into()
+  pub fn source(&self) -> napi::Result<BindingAssetSource> {
+    Ok(self.try_get_inner()?.source.clone().into())
   }
 
   #[napi(getter)]
-  pub fn name(&self) -> Option<&str> {
-    self.inner.names.first().map(AsRef::as_ref)
+  pub fn name(&self) -> napi::Result<Option<&str>> {
+    Ok(self.try_get_inner()?.names.first().map(AsRef::as_ref))
   }
 
   #[napi(getter)]
-  pub fn names(&self) -> Vec<&str> {
-    self.inner.names.iter().map(AsRef::as_ref).collect()
+  pub fn names(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.names.iter().map(AsRef::as_ref).collect())
   }
 }
 

--- a/crates/rolldown_binding/src/types/binding_output_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_output_chunk.rs
@@ -13,86 +13,99 @@ use super::{
 
 #[napi]
 pub struct BindingOutputChunk {
-  inner: Arc<rolldown_common::OutputChunk>,
+  inner: Option<Arc<rolldown_common::OutputChunk>>,
 }
 
 #[napi]
 impl BindingOutputChunk {
   pub fn new(inner: Arc<rolldown_common::OutputChunk>) -> Self {
-    Self { inner }
+    Self { inner: Some(inner) }
+  }
+
+  fn try_get_inner(&self) -> napi::Result<&Arc<rolldown_common::OutputChunk>> {
+    self.inner.as_ref().ok_or_else(|| {
+      napi::Error::from_reason(
+        "Memory has been freed by `freeExternalMemory()`. Cannot access properties. To prevent this, use `freeExternalMemory(handle, true)` with `keepDataAlive`.",
+      )
+    })
+  }
+
+  #[napi(enumerable = false)]
+  pub fn drop_inner(&mut self) -> bool {
+    self.inner.take().is_some()
   }
 
   #[napi(getter)]
-  pub fn is_entry(&self) -> bool {
-    self.inner.is_entry
+  pub fn is_entry(&self) -> napi::Result<bool> {
+    Ok(self.try_get_inner()?.is_entry)
   }
 
   #[napi(getter)]
-  pub fn is_dynamic_entry(&self) -> bool {
-    self.inner.is_dynamic_entry
+  pub fn is_dynamic_entry(&self) -> napi::Result<bool> {
+    Ok(self.try_get_inner()?.is_dynamic_entry)
   }
 
   #[napi(getter)]
-  pub fn facade_module_id(&self) -> Option<&str> {
-    self.inner.facade_module_id.as_deref()
+  pub fn facade_module_id(&self) -> napi::Result<Option<&str>> {
+    Ok(self.try_get_inner()?.facade_module_id.as_deref())
   }
 
   #[napi(getter)]
-  pub fn module_ids(&self) -> Vec<&str> {
-    self.inner.module_ids.iter().map(AsRef::as_ref).collect()
+  pub fn module_ids(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.module_ids.iter().map(AsRef::as_ref).collect())
   }
 
   #[napi(getter)]
-  pub fn exports(&self) -> Vec<&str> {
-    self.inner.exports.iter().map(AsRef::as_ref).collect()
+  pub fn exports(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.exports.iter().map(AsRef::as_ref).collect())
   }
 
   // RenderedChunk
   #[napi(getter)]
-  pub fn file_name(&self) -> &str {
-    &self.inner.filename
+  pub fn file_name(&self) -> napi::Result<&str> {
+    Ok(&self.try_get_inner()?.filename)
   }
 
   #[napi(getter)]
-  pub fn modules(&self) -> BindingModules {
-    (&self.inner.modules).into()
+  pub fn modules(&self) -> napi::Result<BindingModules> {
+    Ok((&self.try_get_inner()?.modules).into())
   }
 
   #[napi(getter)]
-  pub fn imports(&self) -> Vec<&str> {
-    self.inner.imports.iter().map(AsRef::as_ref).collect()
+  pub fn imports(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.imports.iter().map(AsRef::as_ref).collect())
   }
 
   #[napi(getter)]
-  pub fn dynamic_imports(&self) -> Vec<&str> {
-    self.inner.dynamic_imports.iter().map(AsRef::as_ref).collect()
+  pub fn dynamic_imports(&self) -> napi::Result<Vec<&str>> {
+    Ok(self.try_get_inner()?.dynamic_imports.iter().map(AsRef::as_ref).collect())
   }
 
   // OutputChunk
   #[napi(getter)]
-  pub fn code(&self) -> &str {
-    &self.inner.code
+  pub fn code(&self) -> napi::Result<&str> {
+    Ok(&self.try_get_inner()?.code)
   }
 
   #[napi(getter)]
   // TODO: claude code - Cannot change to Option<&str>: performs JSON serialization via to_json_string()
   pub fn map(&self) -> napi::Result<Option<String>> {
-    Ok(self.inner.map.as_ref().map(SourceMap::to_json_string))
+    Ok(self.try_get_inner()?.map.as_ref().map(SourceMap::to_json_string))
   }
 
   #[napi(getter)]
-  pub fn sourcemap_file_name(&self) -> Option<&str> {
-    self.inner.sourcemap_filename.as_deref()
+  pub fn sourcemap_file_name(&self) -> napi::Result<Option<&str>> {
+    Ok(self.try_get_inner()?.sourcemap_filename.as_deref())
   }
 
   #[napi(getter)]
-  pub fn preliminary_file_name(&self) -> &str {
-    &self.inner.preliminary_filename
+  pub fn preliminary_file_name(&self) -> napi::Result<&str> {
+    Ok(&self.try_get_inner()?.preliminary_filename)
   }
 
   #[napi(getter)]
-  pub fn name(&self) -> &str {
-    &self.inner.name
+  pub fn name(&self) -> napi::Result<&str> {
+    Ok(&self.try_get_inner()?.name)
   }
 }
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -39,6 +39,7 @@
         "src/parallel-plugin-worker.ts",
         "src/rolldown-binding.wasi-browser.js",
         "src/{wasi,webcontainer}-*.*",
+        "src/api/experimental.ts",
       ],
       "ignore": [
         "src/binding.js",

--- a/packages/pluginutils/tsconfig.json
+++ b/packages/pluginutils/tsconfig.json
@@ -14,6 +14,8 @@
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     "isolatedDeclarations": true,
+    // This is for `rolldown` which uses decorators. This is a limitation of oxnode, which should infer tsconfig.json respecting project.
+    "experimentalDecorators": true,
 
     /* Type Checking */
     "strict": true, /* Enable all strict type-checking options. */

--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -152,6 +152,10 @@ function withShared(
     },
     transform: {
       target: 'node22',
+      decorator: {
+        // Legacy decorators are required for the @lazy and @nonEnumerable decorators
+        legacy: true,
+      },
       define: {
         'import.meta.browserBuild': String(isBrowserBuild),
       },

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -85,7 +85,7 @@
     "build-binding:wasi": "pnpm build-binding --target wasm32-wasip1-threads",
     "build-binding:wasi:release": "pnpm build-binding --profile release-wasi --target wasm32-wasip1-threads",
     "# Scrips for node #": "_",
-    "build-node": "tsx -C dev ./build.ts",
+    "build-node": "oxnode -C dev ./build.ts",
     "build-types-check": "tsc -p ./tsconfig.check.json",
     "build-js-glue": "pnpm run --sequential '/^build-(node|types-check)$/'",
     "build-native:debug": "pnpm run --sequential '/^build-(binding|js-glue)$/'",
@@ -134,7 +134,6 @@
   "devDependencies": {
     "@napi-rs/cli": "catalog:",
     "@napi-rs/wasm-runtime": "catalog:",
-    "@oxc-node/cli": "catalog:",
     "@rollup/plugin-json": "catalog:",
     "buble": "catalog:",
     "consola": "catalog:",
@@ -148,7 +147,7 @@
     "rollup": "catalog:",
     "signal-exit": "catalog:",
     "source-map": "catalog:",
-    "tsx": "catalog:",
+    "@oxc-node/cli": "catalog:",
     "typescript": "catalog:",
     "valibot": "catalog:"
   },

--- a/packages/rolldown/src/api/experimental.ts
+++ b/packages/rolldown/src/api/experimental.ts
@@ -2,6 +2,8 @@ import type { InputOptions } from '../options/input-options';
 import { PluginDriver } from '../plugin/plugin-driver';
 import { RolldownBuild } from './rolldown/rolldown-build';
 
+export { freeExternalMemory } from '../types/external-memory-handle';
+
 /**
  * This is an experimental API. It's behavior may change in the future.
  *

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -91,6 +91,9 @@ export class RolldownBuild {
     return new RolldownOutputImpl(unwrapBindingResult(output));
   }
 
+  /**
+   * Close the build and free resources.
+   */
   async close(): Promise<void> {
     if (this.#bundlerImpl) {
       await this.#bundlerImpl.stopWorkers?.();

--- a/packages/rolldown/src/binding.d.ts
+++ b/packages/rolldown/src/binding.d.ts
@@ -1396,6 +1396,7 @@ export declare class BindingNormalizedOptions {
 }
 
 export declare class BindingOutputAsset {
+  dropInner(): boolean
   get fileName(): string
   get originalFileName(): string | null
   get originalFileNames(): Array<string>
@@ -1405,6 +1406,7 @@ export declare class BindingOutputAsset {
 }
 
 export declare class BindingOutputChunk {
+  dropInner(): boolean
   get isEntry(): boolean
   get isDynamicEntry(): boolean
   get facadeModuleId(): string | null

--- a/packages/rolldown/src/decorators/lazy.ts
+++ b/packages/rolldown/src/decorators/lazy.ts
@@ -1,0 +1,51 @@
+const LAZY_FIELDS_KEY = Symbol('__lazy_fields__');
+const LAZY_CACHE_PREFIX = '__cached_';
+
+/**
+ * Legacy decorator that makes a getter lazy-evaluated and cached.
+ * Also auto-registers the field for batch prefetching.
+ *
+ * @example
+ * ```typescript
+ * class MyClass {
+ *   @lazy
+ *   get expensiveValue() {
+ *     return someExpensiveComputation();
+ *   }
+ * }
+ * ```
+ */
+export function lazy(
+  target: any,
+  propertyKey: string,
+  descriptor: PropertyDescriptor,
+): PropertyDescriptor {
+  // Ensure the class constructor has a lazy fields registry
+  if (!target.constructor[LAZY_FIELDS_KEY]) {
+    target.constructor[LAZY_FIELDS_KEY] = new Set<string>();
+  }
+  target.constructor[LAZY_FIELDS_KEY].add(propertyKey);
+
+  // eslint-disable-next-line typescript-eslint/unbound-method
+  const originalGetter = descriptor.get!;
+  const cacheKey = LAZY_CACHE_PREFIX + propertyKey;
+
+  descriptor.get = function(this: any) {
+    if (!(cacheKey in this)) {
+      this[cacheKey] = originalGetter.call(this);
+    }
+    return this[cacheKey];
+  };
+
+  return descriptor;
+}
+
+/**
+ * Get all lazy field names from a class instance.
+ *
+ * @param instance - Instance to inspect
+ * @returns Set of lazy property names
+ */
+export function getLazyFields(instance: any): Set<string> {
+  return instance.constructor[LAZY_FIELDS_KEY] || new Set();
+}

--- a/packages/rolldown/src/decorators/non-enumerable.ts
+++ b/packages/rolldown/src/decorators/non-enumerable.ts
@@ -1,0 +1,22 @@
+/**
+ * Decorator that makes a property or method non-enumerable.
+ * This hides the property from enumeration (e.g., Object.keys(), for...in loops).
+ *
+ * @example
+ * ```typescript
+ * class MyClass {
+ *   @nonEnumerable
+ *   hiddenMethod() {
+ *     return 'This method will not show up in Object.keys()';
+ *   }
+ * }
+ * ```
+ */
+export function nonEnumerable(
+  target: any,
+  propertyKey: string,
+  descriptor: PropertyDescriptor,
+): PropertyDescriptor {
+  descriptor.enumerable = false;
+  return descriptor;
+}

--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -1,7 +1,7 @@
 export { dev } from './api/dev';
 export { DevEngine } from './api/dev/dev-engine';
 export type { DevOptions, DevWatchOptions } from './api/dev/dev-options';
-export { scan } from './api/experimental';
+export { freeExternalMemory, scan } from './api/experimental';
 export {
   BindingRebuildStrategy,
   isolatedDeclaration,

--- a/packages/rolldown/src/types/external-memory-handle.ts
+++ b/packages/rolldown/src/types/external-memory-handle.ts
@@ -1,0 +1,57 @@
+// - `unique symbol` can't be used in computed properties with `isolatedDeclarations: true`
+// - https://github.com/microsoft/typescript/issues/61892
+const symbolForExternalMemoryHandle =
+  '__rolldown_external_memory_handle__' as const;
+
+/**
+ * Interface for objects that hold external memory that can be explicitly freed.
+ */
+export interface ExternalMemoryHandle {
+  /**
+   * Frees the external memory held by this object.
+   * @param keepDataAlive - If true, evaluates all lazy fields before freeing memory.
+   *   This will take time but prevents errors when accessing properties after freeing.
+   * @returns `true` if memory was successfully freed, `false` if it was already freed.
+   * @internal
+   */
+  [symbolForExternalMemoryHandle]: (keepDataAlive?: boolean) => boolean;
+}
+
+/**
+ * Frees the external memory held by the given handle.
+ *
+ * This is useful when you want to manually release memory held by Rust objects
+ * (like `OutputChunk` or `OutputAsset`) before they are garbage collected.
+ *
+ * @param handle - The object with external memory to free
+ * @param keepDataAlive - If true, evaluates all lazy fields before freeing memory (default: false).
+ *   This will take time to copy data from Rust to JavaScript, but prevents errors
+ *   when accessing properties after the memory is freed.
+ * @returns `true` if memory was successfully freed, `false` if it was already freed
+ *
+ * @example
+ * ```typescript
+ * import { freeExternalMemory } from 'rolldown/experimental';
+ *
+ * const output = await bundle.generate();
+ * const chunk = output.output[0];
+ *
+ * // Use the chunk...
+ *
+ * // Manually free the memory (fast, but accessing properties after will throw)
+ * const freed = freeExternalMemory(chunk); // true
+ * const alreadyFreed = freeExternalMemory(chunk); // false
+ *
+ * // Keep data alive before freeing (slower, but data remains accessible)
+ * freeExternalMemory(chunk, true); // Evaluates all lazy fields first
+ * console.log(chunk.code); // OK - data was copied to JavaScript before freeing
+ *
+ * // Without keepDataAlive, accessing chunk properties after freeing will throw an error
+ * ```
+ */
+export function freeExternalMemory(
+  handle: ExternalMemoryHandle,
+  keepDataAlive = false,
+): boolean {
+  return handle[symbolForExternalMemoryHandle](keepDataAlive);
+}

--- a/packages/rolldown/src/types/output-asset-impl.ts
+++ b/packages/rolldown/src/types/output-asset-impl.ts
@@ -1,0 +1,58 @@
+import type { BindingOutputAsset } from '../binding';
+import { getLazyFields, lazy } from '../decorators/lazy';
+import { nonEnumerable } from '../decorators/non-enumerable';
+import type { AssetSource } from '../utils/asset-source';
+import { transformAssetSource } from '../utils/asset-source';
+import type { OutputAsset } from './rolldown-output';
+
+export class OutputAssetImpl implements OutputAsset {
+  readonly type = 'asset' as const;
+
+  constructor(private bindingAsset: BindingOutputAsset) {
+  }
+
+  @lazy
+  get fileName(): string {
+    return this.bindingAsset.fileName;
+  }
+
+  @lazy
+  get originalFileName(): string | null {
+    return this.bindingAsset.originalFileName || null;
+  }
+
+  @lazy
+  get originalFileNames(): string[] {
+    return this.bindingAsset.originalFileNames;
+  }
+
+  @lazy
+  get name(): string | undefined {
+    return this.bindingAsset.name ?? undefined;
+  }
+
+  @lazy
+  get names(): string[] {
+    return this.bindingAsset.names;
+  }
+
+  @lazy
+  get source(): AssetSource {
+    return transformAssetSource(this.bindingAsset.source);
+  }
+
+  @nonEnumerable
+  __rolldown_external_memory_handle__(keepDataAlive?: boolean): boolean {
+    if (keepDataAlive) {
+      this.#evaluateAllLazyFields();
+    }
+    return this.bindingAsset.dropInner();
+  }
+
+  #evaluateAllLazyFields(): void {
+    for (const field of getLazyFields(this)) {
+      // Accessing the property triggers lazy evaluation via the @lazy decorator.
+      const _value = (this as any)[field];
+    }
+  }
+}

--- a/packages/rolldown/src/types/output-chunk-impl.ts
+++ b/packages/rolldown/src/types/output-chunk-impl.ts
@@ -1,0 +1,100 @@
+import type { BindingOutputChunk } from '../binding';
+import { getLazyFields, lazy } from '../decorators/lazy';
+import { nonEnumerable } from '../decorators/non-enumerable';
+import { transformChunkModules } from '../utils/transform-rendered-chunk';
+import { transformToRollupSourceMap } from '../utils/transform-to-rollup-output';
+import type { OutputChunk, RenderedModule, SourceMap } from './rolldown-output';
+
+export class OutputChunkImpl implements OutputChunk {
+  readonly type = 'chunk' as const;
+
+  constructor(private bindingChunk: BindingOutputChunk) {
+  }
+
+  @lazy
+  get fileName(): string {
+    return this.bindingChunk.fileName;
+  }
+
+  @lazy
+  get name(): string {
+    return this.bindingChunk.name;
+  }
+
+  @lazy
+  get exports(): string[] {
+    return this.bindingChunk.exports;
+  }
+
+  @lazy
+  get isEntry(): boolean {
+    return this.bindingChunk.isEntry;
+  }
+
+  @lazy
+  get facadeModuleId(): string | null {
+    return this.bindingChunk.facadeModuleId || null;
+  }
+
+  @lazy
+  get isDynamicEntry(): boolean {
+    return this.bindingChunk.isDynamicEntry;
+  }
+
+  @lazy
+  get sourcemapFileName(): string | null {
+    return this.bindingChunk.sourcemapFileName || null;
+  }
+
+  @lazy
+  get preliminaryFileName(): string {
+    return this.bindingChunk.preliminaryFileName;
+  }
+
+  @lazy
+  get code(): string {
+    return this.bindingChunk.code;
+  }
+
+  @lazy
+  get modules(): { [id: string]: RenderedModule } {
+    return transformChunkModules(this.bindingChunk.modules);
+  }
+
+  @lazy
+  get imports(): string[] {
+    return this.bindingChunk.imports;
+  }
+
+  @lazy
+  get dynamicImports(): string[] {
+    return this.bindingChunk.dynamicImports;
+  }
+
+  @lazy
+  get moduleIds(): string[] {
+    return this.bindingChunk.moduleIds;
+  }
+
+  @lazy
+  get map(): SourceMap | null {
+    return this.bindingChunk.map
+      ? transformToRollupSourceMap(this.bindingChunk.map)
+      : null;
+  }
+
+  @nonEnumerable
+  __rolldown_external_memory_handle__(keepDataAlive?: boolean): boolean {
+    if (keepDataAlive) {
+      this.#evaluateAllLazyFields();
+    }
+    return this.bindingChunk.dropInner();
+  }
+
+  #evaluateAllLazyFields(): void {
+    for (const field of getLazyFields(this)) {
+      // Accessing the property triggers lazy evaluation via the @lazy decorator.
+      const _value = (this as any)[field];
+    }
+  }
+}

--- a/packages/rolldown/src/types/rolldown-output-impl.ts
+++ b/packages/rolldown/src/types/rolldown-output-impl.ts
@@ -1,12 +1,29 @@
 import type { BindingOutputs } from '../binding';
+import { lazy } from '../decorators/lazy';
+import { nonEnumerable } from '../decorators/non-enumerable';
 import { transformToRollupOutput } from '../utils/transform-to-rollup-output';
+import type { ExternalMemoryHandle } from './external-memory-handle';
 import type { RolldownOutput } from './rolldown-output';
 
-export class RolldownOutputImpl implements RolldownOutput {
+export class RolldownOutputImpl
+  implements RolldownOutput, ExternalMemoryHandle
+{
   constructor(private bindingOutputs: BindingOutputs) {
   }
 
+  @lazy
   get output(): RolldownOutput['output'] {
     return transformToRollupOutput(this.bindingOutputs).output;
+  }
+
+  @nonEnumerable
+  __rolldown_external_memory_handle__(keepDataAlive?: boolean): boolean {
+    let allFreed = true;
+    const outputs = this.output;
+    for (const item of outputs) {
+      allFreed = allFreed &&
+        item.__rolldown_external_memory_handle__(keepDataAlive);
+    }
+    return allFreed;
   }
 }

--- a/packages/rolldown/src/types/rolldown-output.ts
+++ b/packages/rolldown/src/types/rolldown-output.ts
@@ -1,7 +1,8 @@
 import type { BindingRenderedChunk } from '../binding';
 import type { AssetSource } from '../utils/asset-source';
+import type { ExternalMemoryHandle } from './external-memory-handle';
 
-export interface OutputAsset {
+export interface OutputAsset extends ExternalMemoryHandle {
   type: 'asset';
   fileName: string;
   /** @deprecated Use "originalFileNames" instead. */
@@ -48,7 +49,7 @@ export interface RenderedChunk extends Omit<BindingRenderedChunk, 'modules'> {
   dynamicImports: Array<string>;
 }
 
-export interface OutputChunk {
+export interface OutputChunk extends ExternalMemoryHandle {
   type: 'chunk';
   code: string;
   name: string;
@@ -68,6 +69,6 @@ export interface OutputChunk {
   preliminaryFileName: string;
 }
 
-export interface RolldownOutput {
+export interface RolldownOutput extends ExternalMemoryHandle {
   output: [OutputChunk, ...(OutputChunk | OutputAsset)[]];
 }

--- a/packages/rolldown/tests/fixtures/topics/free-external-memory/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/free-external-memory/_config.ts
@@ -1,0 +1,48 @@
+import { defineTest } from 'rolldown-tests'
+import { freeExternalMemory } from 'rolldown/experimental'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'test-emit-asset',
+        buildStart() {
+          // Emit an asset to ensure we have both chunks and assets for type testing
+          this.emitFile({
+            type: 'asset',
+            name: 'test.txt',
+            source: 'test content for type checking',
+          })
+        },
+      },
+    ],
+  },
+  afterTest(output) {
+    // This test primarily ensures TypeScript type correctness in main.ts
+    // The actual runtime behavior is tested in object-properties test
+    // Here we just verify the API works at runtime as well
+
+    // Test 1: Can call freeExternalMemory on RolldownOutput
+    const result1 = freeExternalMemory(output)
+    expect(typeof result1).toBe('boolean')
+
+    // Test 2: Can call freeExternalMemory on OutputChunk
+    const chunk = output.output.find((item) => item.type === 'chunk')
+    expect(chunk).toBeDefined()
+    if (chunk) {
+      const result2 = freeExternalMemory(chunk)
+      expect(typeof result2).toBe('boolean')
+      // After freeing, accessing properties should throw
+      expect(() => chunk.name).toThrow()
+    }
+
+    // Test 3: Can call freeExternalMemory on OutputAsset
+    const asset = output.output.find((item) => item.type === 'asset')
+    expect(asset).toBeDefined()
+    if (asset) {
+      const result3 = freeExternalMemory(asset)
+      expect(typeof result3).toBe('boolean')
+    }
+  },
+})

--- a/packages/rolldown/tests/fixtures/topics/free-external-memory/main.ts
+++ b/packages/rolldown/tests/fixtures/topics/free-external-memory/main.ts
@@ -1,0 +1,22 @@
+// Test if `freeExternalMemory` could be called satisfying the type requirements
+
+import { rolldown } from 'rolldown'
+import { freeExternalMemory } from 'rolldown/experimental'
+
+async function testFreeExternalMemory() {
+  const build = await rolldown({
+    input: './main.ts',
+  })
+
+  const bundle = await build.generate()
+  
+
+  function _usage() {
+    freeExternalMemory(bundle)
+    for (const item of bundle.output) {
+      freeExternalMemory(item)
+    }
+  }
+}
+
+export default testFreeExternalMemory

--- a/packages/rolldown/tests/fixtures/topics/rollup-compat/object-properties/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/rollup-compat/object-properties/_config.ts
@@ -1,0 +1,80 @@
+import { defineTest } from 'rolldown-tests'
+import { getOutputAsset, getOutputChunk } from 'rolldown-tests/utils'
+import { expect } from 'vitest'
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'test-emit-asset',
+        buildStart() {
+          // Emit an asset to ensure we have both chunks and assets to test
+          this.emitFile({
+            type: 'asset',
+            name: 'test-asset.txt',
+            source: 'test content',
+          })
+        },
+      },
+    ],
+  },
+  afterTest(output) {
+    // Test 1: OutputChunk instances should have non-enumerable __rolldown_external_memory_handle__
+    const chunks = getOutputChunk(output)
+    expect(chunks.length).toBeGreaterThan(0)
+
+    for (const chunk of chunks) {
+      // Verify the method exists and is callable
+      expect(typeof chunk.__rolldown_external_memory_handle__).toBe('function')
+
+      // Verify it's not enumerable (doesn't appear in Object.keys)
+      expect(Object.keys(chunk)).not.toContain('__rolldown_external_memory_handle__')
+
+      // Verify the property descriptor shows enumerable: false
+      // The method is on the prototype, so we need to check the prototype chain
+      const descriptor = Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(chunk),
+        '__rolldown_external_memory_handle__',
+      )
+      expect(descriptor).toBeDefined()
+      expect(descriptor?.enumerable).toBe(false)
+    }
+
+    // Test 2: OutputAsset instances should have non-enumerable __rolldown_external_memory_handle__
+    const assets = getOutputAsset(output)
+    expect(assets.length).toBeGreaterThan(0)
+
+    for (const asset of assets) {
+      // Verify the method exists and is callable
+      expect(typeof asset.__rolldown_external_memory_handle__).toBe('function')
+
+      // Verify it's not enumerable (doesn't appear in Object.keys)
+      expect(Object.keys(asset)).not.toContain('__rolldown_external_memory_handle__')
+
+      // Verify the property descriptor shows enumerable: false
+      // The method is on the prototype, so we need to check the prototype chain
+      const descriptor = Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(asset),
+        '__rolldown_external_memory_handle__',
+      )
+      expect(descriptor).toBeDefined()
+      expect(descriptor?.enumerable).toBe(false)
+    }
+
+    // Test 3: RolldownOutput instance should have non-enumerable __rolldown_external_memory_handle__
+    // Verify the method exists and is callable
+    expect(typeof output.__rolldown_external_memory_handle__).toBe('function')
+
+    // Verify it's not enumerable (doesn't appear in Object.keys)
+    expect(Object.keys(output)).not.toContain('__rolldown_external_memory_handle__')
+
+    // Verify the property descriptor shows enumerable: false
+    // The method is on the prototype, so we need to check the prototype chain
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(output),
+      '__rolldown_external_memory_handle__',
+    )
+    expect(descriptor).toBeDefined()
+    expect(descriptor?.enumerable).toBe(false)
+  },
+})

--- a/packages/rolldown/tests/fixtures/topics/rollup-compat/object-properties/main.js
+++ b/packages/rolldown/tests/fixtures/topics/rollup-compat/object-properties/main.js
@@ -1,0 +1,1 @@
+export const answer = 42;

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -17,6 +17,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "isolatedModules": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "experimentalDecorators": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,7 +208,7 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     tsx:
-      specifier: ^4.19.4
+      specifier: ^4.20.6
       version: 4.20.6
     typescript:
       specifier: ^5.8.3
@@ -570,9 +570,6 @@ importers:
       source-map:
         specifier: 'catalog:'
         version: 0.7.6
-      tsx:
-        specifier: 'catalog:'
-        version: 4.20.6
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,6 @@ catalog:
   'rolldown-plugin-dts': '^0.17.0'
   'tsdown': '0.15.10'
   'typescript': '^5.8.3'
-  'tsx': '^4.19.4'
   'vitest': '^4.0.1'
   'vite': '^7.0.0'
   '@types/node': '24.9.1'
@@ -110,3 +109,4 @@ catalog:
   'estree-toolkit': '^1.7.8'
   'web-tree-sitter': '^0.25.0'
   'valibot': '1.1.0'
+  'tsx': '^4.20.6'


### PR DESCRIPTION
This PR consolidates https://github.com/rolldown/rolldown/pull/6707 and https://github.com/rolldown/rolldown/pull/6696. Part of #6346.

```typescript
import { freeExternalMemory } from 'rolldown/experimental';

const bundle = await build.generate();

freeExternalMemory(bundle)

bundle.output // error
```


```typescript
import { freeExternalMemory } from 'rolldown/experimental';

const bundle = await build.generate();

freeExternalMemory(bundle, /*keepDataAlive:*/ true)

bundle.output // no error
```
