### PR TITLE
chore(test/dev): collect multiple build outputs for each step

### DIFF
--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1686,6 +1686,11 @@
               "type": "null"
             }
           ]
+        },
+        "ensureLatestBuildOutputForEachStep": {
+          "description": "If `true`, the test will call `ensure_latest_build_output()` after each HMR step to wait for async builds.\nThis allows capturing all build outputs triggered by each step.\nDefault is `false` for backwards compatibility and performance.",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/crates/rolldown_testing/src/types/dev_artifacts_snapshot.rs
+++ b/crates/rolldown_testing/src/types/dev_artifacts_snapshot.rs
@@ -19,7 +19,7 @@ impl DevArtifactsSnapshot {
   pub fn render(self, test_meta: &TestMeta) -> String {
     let mut root_section = SnapshotSection::root();
 
-    for mut build_round in self.builds {
+    for build_round in self.builds {
       if !build_round.overwritten_test_meta_snapshot {
         continue;
       }
@@ -51,12 +51,12 @@ impl DevArtifactsSnapshot {
       }
 
       // Render `# HMR Steps N`
-      for (step, hmr_result) in build_round.hmr_updates_by_steps.into_iter().enumerate() {
+      for (step_index, step_output) in build_round.hmr_steps.into_iter().enumerate() {
         let hmr_sections = Self::create_hmr_step_sections(
           test_meta,
-          step,
-          hmr_result,
-          &mut build_round.rebuild_results,
+          step_index,
+          step_output.hmr_updates,
+          step_output.build_outputs,
           cwd,
         );
         build_round_sections.extend(hmr_sections);
@@ -91,7 +91,7 @@ impl DevArtifactsSnapshot {
     test_meta: &TestMeta,
     step: usize,
     hmr_result: BuildResult<(Vec<rolldown_common::ClientHmrUpdate>, Vec<String>)>,
-    rebuild_results: &mut Vec<BuildResult<BundleOutput>>,
+    mut build_outputs: Vec<BuildResult<BundleOutput>>,
     cwd: &Path,
   ) -> Vec<SnapshotSection> {
     match hmr_result {
@@ -103,7 +103,7 @@ impl DevArtifactsSnapshot {
             step,
             &hmr_update.update,
             vec![],
-            rebuild_results,
+            &mut build_outputs,
             cwd,
           )
         })

--- a/crates/rolldown_testing/src/types/dev_round_output.rs
+++ b/crates/rolldown_testing/src/types/dev_round_output.rs
@@ -3,9 +3,11 @@ use std::path::PathBuf;
 use rolldown::BundleOutput;
 use rolldown_error::BuildResult;
 
+use super::HmrStepOutput;
+
 /// After support config variants, a test case might run the bundler multiple times with different configs.
 /// For each run, we call it a "build round" or "dev round".
-/// For HMR/dev mode, a dev round contains the initial build plus rebuilds triggered by file changes.
+/// For HMR/dev mode, a dev round contains the initial build plus HMR steps triggered by file changes.
 /// This struct contains all the information we want to snapshot for a dev round with HMR.
 #[derive(Default)]
 pub struct DevRoundOutput {
@@ -13,6 +15,7 @@ pub struct DevRoundOutput {
   pub cwd: Option<PathBuf>,
   pub debug_title: Option<String>,
   pub initial_output: Option<BuildResult<BundleOutput>>,
-  pub rebuild_results: Vec<BuildResult<BundleOutput>>,
-  pub hmr_updates_by_steps: Vec<BuildResult<(Vec<rolldown_common::ClientHmrUpdate>, Vec<String>)>>,
+  /// HMR steps: each step contains HMR updates and any build outputs triggered by that step.
+  /// Each step corresponds to one file change event applied during testing.
+  pub hmr_steps: Vec<HmrStepOutput>,
 }

--- a/crates/rolldown_testing/src/types/hmr_step_output.rs
+++ b/crates/rolldown_testing/src/types/hmr_step_output.rs
@@ -1,0 +1,15 @@
+use rolldown::BundleOutput;
+use rolldown_error::BuildResult;
+
+/// Represents the outputs from a single HMR step.
+/// A step consists of file changes that trigger HMR updates and potentially build outputs.
+pub struct HmrStepOutput {
+  /// The HMR updates generated for this step.
+  /// Contains updates for all clients (Vec<ClientHmrUpdate>) and the changed files.
+  pub hmr_updates: BuildResult<(Vec<rolldown_common::ClientHmrUpdate>, Vec<String>)>,
+  /// Build outputs triggered by this HMR step.
+  /// Can be empty (pure HMR patch with no rebuild),
+  /// one (typical full-reload scenario),
+  /// or multiple (if multiple rebuilds are triggered).
+  pub build_outputs: Vec<BuildResult<BundleOutput>>,
+}

--- a/crates/rolldown_testing/src/types/mod.rs
+++ b/crates/rolldown_testing/src/types/mod.rs
@@ -2,10 +2,12 @@ mod build_artifacts_snapshot;
 mod build_round_output;
 mod dev_artifacts_snapshot;
 mod dev_round_output;
+mod hmr_step_output;
 mod snapshot_section;
 
 pub use build_artifacts_snapshot::BuildArtifactsSnapshot;
 pub use build_round_output::BuildRoundOutput;
 pub use dev_artifacts_snapshot::DevArtifactsSnapshot;
 pub use dev_round_output::DevRoundOutput;
+pub use hmr_step_output::HmrStepOutput;
 pub use snapshot_section::SnapshotSection;

--- a/crates/rolldown_testing_config/src/dev_test_meta.rs
+++ b/crates/rolldown_testing_config/src/dev_test_meta.rs
@@ -7,6 +7,11 @@ use serde::Deserialize;
 pub struct DevTestMeta {
   #[serde(default)]
   pub config: Option<DevOptions>,
+  #[serde(default)]
+  /// If `true`, the test will call `ensure_latest_build_output()` after each HMR step to wait for async builds.
+  /// This allows capturing all build outputs triggered by each step.
+  /// Default is `false` for backwards compatibility and performance.
+  pub ensure_latest_build_output_for_each_step: bool,
 }
 
 impl Default for DevTestMeta {


### PR DESCRIPTION
- For #6567, `dev`​ mode need to test all possible situations, so we try collect all output from each step.
- `DevTestMeta#ensureLatestBuildOutputForEachStep`​ is also supported for testing related situations.