### PR TITLE
fix: TypeError when loading CJS files after bundling mixed CJS+TS project 

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -164,7 +164,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           self.canonical_ref_for_runtime("__commonJSMin")
         };
 
-        let commonjs_ref_expr = self.finalized_expr_for_symbol_ref(commonjs_ref, false, false);
+        let (commonjs_ref_expr, _) = self.finalized_expr_for_symbol_ref(commonjs_ref, false, false);
 
         let mut stmts_inside_closure = allocator::Vec::new_in(self.alloc);
         stmts_inside_closure.append(&mut program.body);
@@ -262,7 +262,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         } else {
           self.canonical_ref_for_runtime("__esmMin")
         };
-        let esm_ref_expr = self.finalized_expr_for_symbol_ref(esm_ref, false, false);
+        let (esm_ref_expr, _) = self.finalized_expr_for_symbol_ref(esm_ref, false, false);
         let wrap_ref_name = self.canonical_name_for(self.ctx.linking_info.wrapper_ref.unwrap());
 
         if matches!(
@@ -355,7 +355,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
     // TODO: perf it
     for (stmt_index, original_name, new_name) in self.keep_name_statement_to_insert.iter().rev() {
       let name_ref = self.canonical_ref_for_runtime("__name");
-      let finalized_callee = self.finalized_expr_for_symbol_ref(name_ref, false, false);
+      let (finalized_callee, _) = self.finalized_expr_for_symbol_ref(name_ref, false, false);
       let target =
         self.snippet.builder.expression_identifier(SPAN, self.snippet.builder.atom(new_name));
       it.insert(
@@ -661,7 +661,8 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
                 let fn_expr = init.take_in(self.alloc);
 
                 let name_ref = self.canonical_ref_for_runtime("__name");
-                let finalized_callee = self.finalized_expr_for_symbol_ref(name_ref, false, false);
+                let (finalized_callee, _) =
+                  self.finalized_expr_for_symbol_ref(name_ref, false, false);
                 *init =
                   self.snippet.keep_name_call_expr(&original_name, fn_expr, finalized_callee, true);
               }

--- a/crates/rolldown/src/module_finalizers/rename.rs
+++ b/crates/rolldown/src/module_finalizers/rename.rs
@@ -21,7 +21,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
     let symbol_id = self.scope.symbol_id_for(reference_id)?;
 
     let symbol_ref: SymbolRef = (self.ctx.id, symbol_id).into();
-    let mut expr = self.finalized_expr_for_symbol_ref(symbol_ref, is_callee, false);
+    let (mut expr, _) = self.finalized_expr_for_symbol_ref(symbol_ref, is_callee, false);
 
     // See https://github.com/oxc-project/oxc/issues/4606
 

--- a/crates/rolldown/tests/rolldown/issues/5930/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/5930/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "format": "cjs"
+  },
+  "configVariants": [
+    {
+      "preserveModules": true
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/issues/5930/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5930/artifacts.snap
@@ -1,0 +1,115 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+
+//#region lib.js
+var require_lib = /* @__PURE__ */ __commonJS({ "lib.js": ((exports, module) => {
+	module.exports = {};
+}) });
+
+//#endregion
+//#region rule.js
+var require_rule = /* @__PURE__ */ __commonJS({ "rule.js": ((exports, module) => {
+	const mod$1 = require_lib();
+	module.exports = {
+		meta: 4 + String(mod$1).length,
+		create: function() {
+			console.log("loaded rule");
+		}
+	};
+}) });
+
+//#endregion
+//#region main.js
+var import_rule = /* @__PURE__ */ __toESM(require_rule());
+const plugin = { mod: import_rule.default };
+node_assert.default.strictEqual(plugin.mod.meta, 19);
+var main_default = plugin;
+
+//#endregion
+module.exports = main_default;
+```
+
+# Variant: [preserve_modules: true]
+
+## Assets
+
+### _virtual/rolldown_runtime.js
+
+```js
+// HIDDEN [rolldown:runtime]
+
+exports.__commonJS = __commonJS;
+exports.__toESM = __toESM;
+```
+
+### lib.js
+
+```js
+const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
+
+//#region lib.js
+var require_lib = /* @__PURE__ */ require_rolldown_runtime.__commonJS({ "lib.js": ((exports, module) => {
+	module.exports = {};
+}) });
+
+//#endregion
+Object.defineProperty(exports, 'default', {
+  enumerable: true,
+  get: function () {
+    return require_lib();
+  }
+});
+```
+
+### main.js
+
+```js
+const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
+const require_rule$1 = require('./rule.js');
+let node_assert = require("node:assert");
+node_assert = require_rolldown_runtime.__toESM(node_assert);
+
+//#region main.js
+var import_rule = /* @__PURE__ */ require_rolldown_runtime.__toESM(require_rule$1.default);
+const plugin = { mod: import_rule.default };
+node_assert.default.strictEqual(plugin.mod.meta, 19);
+var main_default = plugin;
+
+//#endregion
+module.exports = main_default;
+```
+
+### rule.js
+
+```js
+const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
+const require_lib$1 = require('./lib.js');
+
+//#region rule.js
+var require_rule = /* @__PURE__ */ require_rolldown_runtime.__commonJS({ "rule.js": ((exports, module) => {
+	const mod = require_lib$1.default;
+	module.exports = {
+		meta: 4 + String(mod).length,
+		create: function() {
+			console.log("loaded rule");
+		}
+	};
+}) });
+
+//#endregion
+Object.defineProperty(exports, 'default', {
+  enumerable: true,
+  get: function () {
+    return require_rule();
+  }
+});
+```

--- a/crates/rolldown/tests/rolldown/issues/5930/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/5930/lib.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/crates/rolldown/tests/rolldown/issues/5930/main.js
+++ b/crates/rolldown/tests/rolldown/issues/5930/main.js
@@ -1,0 +1,8 @@
+import mod from "./rule";
+import assert from "node:assert";
+
+const plugin = {
+  mod,
+};
+assert.strictEqual(plugin.mod.meta, 19);
+export default plugin;

--- a/crates/rolldown/tests/rolldown/issues/5930/rule.js
+++ b/crates/rolldown/tests/rolldown/issues/5930/rule.js
@@ -1,0 +1,9 @@
+const mod = require("./lib");
+
+module.exports = {
+  // [Object object]
+  meta: "rule".length + String(mod).length,
+  create: function () {
+    console.log("loaded rule");
+  },
+};

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4766,6 +4766,10 @@ expression: output
 
 - main-!~{000}~.js => main-DgJmHtwB.js
 
+# tests/rolldown/issues/5930
+
+- main-!~{000}~.js => main-CG_fOlqG.js
+
 # tests/rolldown/issues/6036
 
 - main-!~{000}~.js => main-QBmbik0c.js

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1637,6 +1637,12 @@
             "null"
           ]
         },
+        "preserveModules": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "_snapshot": {
           "description": "Whether to include the output in the snapshot for this config variant.",
           "type": [

--- a/crates/rolldown_testing_config/src/config_variant.rs
+++ b/crates/rolldown_testing_config/src/config_variant.rs
@@ -26,6 +26,7 @@ pub struct ConfigVariant {
   #[serde(deserialize_with = "deserialize_inline_const", default)]
   pub inline_const: Option<InlineConstOption>,
   pub top_level_var: Option<bool>,
+  pub preserve_modules: Option<bool>,
   // --- non-bundler options are start with `_`
   /// Whether to include the output in the snapshot for this config variant.
   #[serde(rename = "_snapshot")]
@@ -79,6 +80,9 @@ impl ConfigVariant {
     }
     if let Some(top_level_var) = &self.top_level_var {
       config.top_level_var = Some(*top_level_var);
+    }
+    if let Some(preserve_modules) = &self.preserve_modules {
+      config.preserve_modules = Some(*preserve_modules);
     }
 
     if let Some(pife_for_module_wrappers) = &self.pife_for_module_wrappers {
@@ -137,6 +141,9 @@ impl ConfigVariant {
     }
     if let Some(top_level_var) = &self.top_level_var {
       fields.push(format!("top_level_var: {top_level_var:?}"));
+    }
+    if let Some(preserve_modules) = &self.preserve_modules {
+      fields.push(format!("preserve_modules: {preserve_modules:?}"));
     }
     if let Some(inline_const) = &self.inline_const {
       fields.push(format!("inline_const: {inline_const:?}"));


### PR DESCRIPTION
closed #5930

Current issue: 
https://repl.rolldown.rs/#eNplUctOwzAQ/JWVT6mIXHHEqEeOiANHzMFNNsGVY6d+FKQq/87aTlFET/a+Zmdmr2xg4sompS0/hfy1TPyFLeso0tPsfITJ9TB4N4FkfO+TQcmepV2LKgSkZ61b16OoqdIkbedsiDCbNGoLB7hKCxmwlXahem3lIXrdxZdzUqaprZx6+IRRtfD4tKNO/CnrehxUMjdAyhNVZCL6hEvLjD5uxKxR1UJ4xJxXmJCZ5P2MhrKizdQtrGOVfnbgAB7PSXtssg2ELVnmJe09cta438PH2/GEXQRXns+inBQJ8qm6yA3aMX7BA7yTAXZsCGq3JskggM6jiihgSLaL2llodhWdSkTM0VrjRiJknOqxhwqbaQEsq8VFojOmd9+W09Sgx63a+0oV/s/vstWlOKcobhQG5ydFoWTdKUhWGAPMHummF3wttgQB+TaFEPFhC7G55NuQrhDZ8gst29p6

The binding finalization only considers when the required CJS module is in a common chunk, 
so it always converts 
```
const mod = require('./lib')
```
to 
```js
const mod = require_rule$1.require_rule()
```

This did not consider if the wrap_ref is exported via entry cjs module, which may generate 
```
Object.defineProperty(exports, 'default', {
  enumerable: true,
  get: function () {
    return require_rule();
  }
});
```

this pr fixed this scenario.