### PR TITLE
test: skip paths function test

### DIFF
--- a/packages/rolldown/tests/fixtures/output/paths/function/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/paths/function/_config.ts
@@ -1,13 +1,14 @@
-import { defineTest } from 'rolldown-tests'
-import { expect } from 'vitest'
+import { defineTest } from "rolldown-tests";
+import { expect } from "vitest";
 
 export default defineTest({
+  skip: true,
   config: {
-    external: ['d3', 'd4'],
+    external: ["d3", "d4"],
     output: {
       paths: (id) => {
-        if (id === 'd3') {
-          return 'https://cdn.jsdelivr.net/npm/d3@7.8.5/dist/d3.min.js';
+        if (id === "d3") {
+          return "https://cdn.jsdelivr.net/npm/d3@7.8.5/dist/d3.min.js";
         }
         return id;
       },
@@ -22,7 +23,6 @@ export default defineTest({
       console.log(a, b);
 
       //#endregion"
-    `)
-
+    `);
   },
-})
+});


### PR DESCRIPTION
Related to https://github.com/rolldown/rolldown/issues/6737, since the test failed too frequently, disable for now.  
Note: I can't reproduce it locally.