### PR TITLE
fix(plugins): wrap replacePlugin with makeBuiltinPluginCallable

### DIFF
--- a/packages/rolldown/src/builtin-plugin/replace-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/replace-plugin.ts
@@ -1,5 +1,5 @@
 import type { BindingReplacePluginConfig } from '../binding.cjs';
-import { BuiltinPlugin } from './utils';
+import { BuiltinPlugin, makeBuiltinPluginCallable } from './utils';
 
 /**
  * Replaces targeted strings in files while bundling.
@@ -35,5 +35,7 @@ export function replacePlugin(
     }
   });
 
-  return new BuiltinPlugin('builtin:replace', { ...options, values });
+  return makeBuiltinPluginCallable(
+    new BuiltinPlugin('builtin:replace', { ...options, values }),
+  );
 }


### PR DESCRIPTION
fix https://github.com/vitejs/rolldown-vite/issues/473
fix https://github.com/nuxt/nuxt/issues/33602

This PR makes the replace plugin callable from rolldown vite