### PR TITLE
feat: link to docs for commonjs prefer_builtin_feature diagnostic

### DIFF
--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -66,20 +66,29 @@ impl BundlerBuilder {
       // key is the name property of the plugin
       // the first element of value is the npm package name of the plugin
       // the second element of value is the preferred builtin feature, `None` if the feature is not configured
-      ("inject", ("@rollup/plugin-inject", Some("inject"))),
-      ("node-resolve", (" @rollup/plugin-node-resolve", None)),
-      ("commonjs", ("@rollup/plugin-commonjs", None)),
-      ("json", ("@rollup/plugin-json", None)),
+      // the third element of value is an additional message to show
+      ("inject", ("@rollup/plugin-inject", Some("inject"), None)),
+      ("node-resolve", ("@rollup/plugin-node-resolve", None, None)),
+      (
+        "commonjs",
+        (
+          "@rollup/plugin-commonjs",
+          None,
+          Some(" Check https://rolldown.rs/in-depth/bundling-cjs for more details."),
+        ),
+      ),
+      ("json", ("@rollup/plugin-json", None, None)),
     ]);
     for plugin in plugins {
       let name = plugin.call_name();
-      let Some((package_name, feature)) = map.get(name.as_ref()) else {
+      let Some((package_name, feature, additional_message)) = map.get(name.as_ref()) else {
         continue;
       };
       warning.push(
         BuildDiagnostic::prefer_builtin_feature(
           feature.map(String::from),
           (*package_name).to_string(),
+          *additional_message,
         )
         .with_severity_warning(),
       );

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -302,8 +302,12 @@ impl BuildDiagnostic {
     Self::new_inner(AssignToImport { filename, source, span, name })
   }
 
-  pub fn prefer_builtin_feature(builtin_feature: Option<String>, plugin_name: String) -> Self {
-    Self::new_inner(PreferBuiltinFeature { builtin_feature, plugin_name })
+  pub fn prefer_builtin_feature(
+    builtin_feature: Option<String>,
+    plugin_name: String,
+    additional_message: Option<&'static str>,
+  ) -> Self {
+    Self::new_inner(PreferBuiltinFeature { builtin_feature, plugin_name, additional_message })
   }
 
   #[expect(clippy::cast_possible_truncation)]

--- a/crates/rolldown_error/src/build_diagnostic/events/prefer_builtin_feature.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/prefer_builtin_feature.rs
@@ -6,6 +6,7 @@ pub struct PreferBuiltinFeature {
   /// If it is none, it means there is no options to turn the feature off.
   pub builtin_feature: Option<String>,
   pub plugin_name: String,
+  pub additional_message: Option<&'static str>,
 }
 
 impl BuildEvent for PreferBuiltinFeature {
@@ -16,13 +17,15 @@ impl BuildEvent for PreferBuiltinFeature {
   fn message(&self, _opts: &DiagnosticOptions) -> String {
     if let Some(feature) = &self.builtin_feature {
       format!(
-        "Rolldown supports `{feature}` natively, please refer https://rolldown.rs/apis/config-options for more details, this is performant than passing `{}` to plugins option.",
-        self.plugin_name
+        "Rolldown supports `{feature}` natively, please refer https://rolldown.rs/apis/config-options for more details, this is performant than passing `{}` to plugins option.{}",
+        self.plugin_name,
+        self.additional_message.unwrap_or_default()
       )
     } else {
       format!(
-        "The functionality provided by `{}` is already covered natively, maybe you could remove the plugin from your configuration",
-        self.plugin_name
+        "The functionality provided by `{}` is already covered natively, maybe you could remove the plugin from your configuration.{}",
+        self.plugin_name,
+        self.additional_message.unwrap_or_default()
       )
     }
   }

--- a/packages/rolldown/tests/fixtures/plugin/prefer-builtin-feature/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/prefer-builtin-feature/_config.ts
@@ -20,7 +20,7 @@ export default defineTest({
   afterTest() {
     expect(warnings).toMatchInlineSnapshot(`
 			[
-			  "[PREFER_BUILTIN_FEATURE] Warning: The functionality provided by \`@rollup/plugin-json\` is already covered natively, maybe you could remove the plugin from your configuration
+			  "[PREFER_BUILTIN_FEATURE] Warning: The functionality provided by \`@rollup/plugin-json\` is already covered natively, maybe you could remove the plugin from your configuration.
 			  │ 
 			  │ Help: This diagnostic may be false positive, you could turn it off via \`checks.preferBuiltinFeature\`
 			",


### PR DESCRIPTION
Added a link to docs so that people migrating to the built-in commonjs handling from the commonjs plugin can find the docs.