### PR TITLE
chore(deps): upgrade napi to remove linker args that skip missing symbols

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,31 +7,30 @@ ck = "check --workspace --all-features --all-targets --locked"
 ls-lint = "run --bin ls-lint"
 run-fixture = "run --bin run-fixture"
 
-[target.'cfg(target_vendor = "apple")']
-rustflags = [
-  "-C",
-  "link-args=-Wl,-undefined,dynamic_lookup,-no_fixup_chains",
-]
-
-# To be able to run unit tests on Linux, support compilation to 'x86_64-unknown-linux-gnu'.
-# pthread_key_create() destructors and segfault after a DSO unloading https://sourceware.org/bugzilla/show_bug.cgi?id=21031
-[target.'cfg(all(target_os = "linux", target_env = "gnu"))']
-rustflags = [
-  "-C",
-  "link-args=-Wl,--warn-unresolved-symbols",
-  "-C",
-  "link-args=-Wl,-z,nodelete",
-]
-
-# To be able to run unit tests on Windows, support compilation to 'x86_64-pc-windows-msvc'.
-[target.'cfg(target_env = "msvc")']
-rustflags = ["-C", "link-args=/FORCE"]
-
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.i686-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.'cfg(target_os = "windows")']
+rustflags = [
+  # Disables linking against the default Universal C Runtime (libucrt.lib). This prevents conflicts if another CRT library is linked manually.
+  "-C",
+  "link-args=/NODEFAULTLIB:libucrt.lib",
+  # Manually adds ucrt.lib (the Universal CRT) as a default library to link against, replacing the one you just excluded above.
+  # This ensures consistent linking when multiple CRTs might be available.
+  "-C",
+  "link-args=/DEFAULTLIB:ucrt.lib",
+]
+
+# LLD linker is currently broken for us, opt out.
+# https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/#what-s-in-1-90-0-stable
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "linker-features=-lld"]
 
 [target.wasm32-wasip1-threads]
 rustflags = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,9 +1376,9 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
  "windows-link",
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a1135cfe16ca43ac82ac05858554fc39c037d8e4592f2b4a83d7ef8e822f43"
+checksum = "5d00c1a7ffcf62e0889630f122f8920383f5a9ce4b54377b05c2833fb6123857"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -1517,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.2.4"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae82775d1b06f3f07efd0666e59bbc175da8383bc372051031d7a447e94fbea"
+checksum = "68064c4cf827376751236ee6785e0e38a6461f83a7a7f227c89f6256f3e96cc2"
 
 [[package]]
 name = "napi-derive"
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed8f0e23a62a3ce0fbb6527cdc056e9282ddd9916b068c46f8923e18eed5ee6"
+checksum = "6f200fd782433de18d46d496223be780837b2f3772e5816f4425e0520bff26c2"
 dependencies = [
  "libloading",
 ]


### PR DESCRIPTION
Remove all the confusing linker args that were used to bypass missing napi symbols during `cargo test`s.