### PR TITLE
fix: handle error when creating output chunk directories

### DIFF
--- a/crates/rolldown/src/bundler.rs
+++ b/crates/rolldown/src/bundler.rs
@@ -237,7 +237,10 @@ impl Bundler {
       let dest = dist_dir.join(chunk.filename());
       if let Some(p) = dest.parent() {
         if !self.fs.exists(p) {
-          self.fs.create_dir_all(p).unwrap();
+          self.fs.create_dir_all(p).map_err(|err| {
+            anyhow::anyhow!("Could not create directory for output chunks: {}", p.display())
+              .context(err)
+          })?;
         }
       }
       self.fs.write(&dest, chunk.content_as_bytes()).map_err(|err| {


### PR DESCRIPTION
fixes https://github.com/vitejs/rolldown-vite/issues/495