### PR TITLE
refactor(node): implement a new `Bundler` that satisfy the usage of `RolldownBuild`

### DIFF
--- a/crates/rolldown/src/build/build_context.rs
+++ b/crates/rolldown/src/build/build_context.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use rolldown_common::SharedNormalizedBundlerOptions;
+use rolldown_plugin::SharedPluginDriver;
+
+/// Used to store context information during the build process.
+#[derive(Clone)]
+pub struct BuildContext {
+  pub(crate) options: SharedNormalizedBundlerOptions,
+  pub(crate) plugin_driver: SharedPluginDriver,
+}
+
+impl BuildContext {
+  /// Get the bundler options used in this build context.
+  pub fn options(&self) -> &SharedNormalizedBundlerOptions {
+    &self.options
+  }
+
+  /// Get the watch files collected during this build context.
+  pub fn watch_files(&self) -> &Arc<rolldown_utils::dashmap::FxDashSet<arcstr::ArcStr>> {
+    &self.plugin_driver.watch_files
+  }
+
+  pub fn plugin_driver(&self) -> &SharedPluginDriver {
+    &self.plugin_driver
+  }
+}

--- a/crates/rolldown/src/build/build_factory.rs
+++ b/crates/rolldown/src/build/build_factory.rs
@@ -1,0 +1,170 @@
+use std::{any::Any, sync::Arc};
+
+use rolldown_common::{BundlerOptions, FileEmitter, NormalizedBundlerOptions, SharedFileEmitter};
+use rolldown_error::{BuildDiagnostic, BuildResult, EventKindSwitcher};
+use rolldown_fs::OsFileSystem;
+use rolldown_plugin::{__inner::SharedPluginable, PluginDriver, SharedPluginDriver};
+use rustc_hash::FxHashMap;
+
+use crate::{
+  Build,
+  types::scan_stage_cache::ScanStageCache,
+  utils::{
+    apply_inner_plugins::apply_inner_plugins,
+    prepare_build_context::{PrepareBuildContext, prepare_build_context},
+  },
+};
+
+use super::super::{SharedOptions, SharedResolver};
+
+#[derive(Debug, Default)]
+pub struct BuildFactoryOptions {
+  pub bundler_options: BundlerOptions,
+  pub plugins: Vec<SharedPluginable>,
+  pub session: Option<rolldown_debug::Session>,
+  pub disable_tracing_setup: bool,
+}
+
+pub struct BuildFactory {
+  pub fs: OsFileSystem,
+  pub options: SharedOptions,
+  pub resolver: SharedResolver,
+  pub file_emitter: SharedFileEmitter,
+  pub plugin_driver: SharedPluginDriver,
+  /// Warnings collected during build factory creation
+  pub session: rolldown_debug::Session,
+  pub(crate) _log_guard: Option<Box<dyn Any + Send>>,
+}
+
+impl BuildFactory {
+  pub fn new(mut opts: BuildFactoryOptions) -> BuildResult<(Self, Vec<BuildDiagnostic>)> {
+    let session = opts.session.unwrap_or_else(rolldown_debug::Session::dummy);
+
+    let maybe_guard =
+      if opts.disable_tracing_setup { None } else { rolldown_tracing::try_init_tracing() };
+
+    let PrepareBuildContext { fs, resolver, options, mut warnings } =
+      prepare_build_context(opts.bundler_options)?;
+
+    Self::check_prefer_builtin_feature(opts.plugins.as_slice(), &options, &mut warnings);
+
+    apply_inner_plugins(&options, &mut opts.plugins);
+
+    let file_emitter = Arc::new(FileEmitter::new(Arc::clone(&options)));
+
+    // FIXME: shouldn't crate build span here, but for satisfying the previous code
+    let build_id = rolldown_debug::generate_build_id(0);
+    let build_span = Arc::new(tracing::info_span!(
+      parent: &session.span,
+      "build",
+      CONTEXT_build_id = build_id.as_ref()
+    ));
+
+    Ok((
+      Self {
+        plugin_driver: PluginDriver::new_shared(
+          opts.plugins,
+          &resolver,
+          &file_emitter,
+          &options,
+          &session,
+          &build_span,
+        ),
+        file_emitter,
+        resolver,
+        options,
+        fs,
+        _log_guard: maybe_guard,
+        session,
+      },
+      warnings,
+    ))
+  }
+
+  pub fn create_build(&mut self) -> Build {
+    Build {
+      fs: self.fs.clone(),
+      options: Arc::clone(&self.options),
+      resolver: Arc::clone(&self.resolver),
+      file_emitter: Arc::clone(&self.file_emitter),
+      plugin_driver: Arc::clone(&self.plugin_driver),
+      warnings: Vec::new(),
+      session: self.session.clone(),
+      cache: ScanStageCache::default(),
+    }
+  }
+
+  fn check_prefer_builtin_feature(
+    plugins: &[SharedPluginable],
+    options: &NormalizedBundlerOptions,
+    warning: &mut Vec<BuildDiagnostic>,
+  ) {
+    if !options.checks.contains(EventKindSwitcher::PreferBuiltinFeature) {
+      return;
+    }
+    let map = FxHashMap::from_iter([
+      // key is the name property of the plugin
+      // the first element of value is the npm package name of the plugin
+      // the second element of value is the preferred builtin feature, `None` if the feature is not configured
+      // the third element of value is an additional message to show
+      ("inject", ("@rollup/plugin-inject", Some("inject"), None)),
+      ("node-resolve", ("@rollup/plugin-node-resolve", None, None)),
+      (
+        "commonjs",
+        (
+          "@rollup/plugin-commonjs",
+          None,
+          Some(" Check https://rolldown.rs/in-depth/bundling-cjs for more details."),
+        ),
+      ),
+      ("json", ("@rollup/plugin-json", None, None)),
+    ]);
+    for plugin in plugins {
+      let name = plugin.call_name();
+      let Some((package_name, feature, additional_message)) = map.get(name.as_ref()) else {
+        continue;
+      };
+      warning.push(
+        BuildDiagnostic::prefer_builtin_feature(
+          feature.map(String::from),
+          (*package_name).to_string(),
+          *additional_message,
+        )
+        .with_severity_warning(),
+      );
+    }
+  }
+}
+
+// impl BundlerBuilder {
+
+//   #[must_use]
+//   pub fn with_options(mut self, options: BundlerOptions) -> Self {
+//     self.options = options;
+//     self
+//   }
+
+//   #[must_use]
+//   pub fn with_plugins(mut self, plugins: Vec<SharedPluginable>) -> Self {
+//     self.plugins = plugins;
+//     self
+//   }
+
+//   #[must_use]
+//   pub fn with_build_count(mut self, build_count: u32) -> Self {
+//     self.build_count = build_count;
+//     self
+//   }
+
+//   #[must_use]
+//   pub fn with_session(mut self, session: rolldown_debug::Session) -> Self {
+//     self.session = Some(session);
+//     self
+//   }
+
+//   #[must_use]
+//   pub fn with_disable_tracing_setup(mut self, disable: bool) -> Self {
+//     self.disable_tracing_setup = disable;
+//     self
+//   }
+// }

--- a/crates/rolldown/src/build/mod.rs
+++ b/crates/rolldown/src/build/mod.rs
@@ -1,0 +1,3 @@
+pub mod build;
+pub mod build_context;
+pub mod build_factory;

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -1,5 +1,6 @@
 mod asset;
 mod ast_scanner;
+mod build;
 mod bundler;
 mod bundler_builder;
 mod chunk_graph;
@@ -24,6 +25,11 @@ pub(crate) type SharedResolver = Arc<Resolver<OsFileSystem>>;
 pub(crate) type SharedOptions = SharedNormalizedBundlerOptions;
 
 pub use crate::{
+  build::{
+    build::Build,
+    build_context::BuildContext,
+    build_factory::{BuildFactory, BuildFactoryOptions},
+  },
   bundler::Bundler,
   bundler_builder::BundlerBuilder,
   dev::dev_engine::DevEngine,

--- a/crates/rolldown_binding/src/binding_bundler.rs
+++ b/crates/rolldown_binding/src/binding_bundler.rs
@@ -1,47 +1,228 @@
-use std::sync::Arc;
+// TODO: add reasons about why creating `BindingBundler` instead of reusing `Bundler` of `rolldown` crate.
 
+use crate::{
+  binding_bundler_impl::BindingBundlerOptions,
+  bundler::Bundler,
+  types::{
+    binding_outputs::{BindingOutputs, to_binding_error},
+    error::{BindingError, BindingErrors, BindingResult},
+  },
+  utils::{
+    handle_result, handle_warnings,
+    normalize_binding_options::{NormalizeBindingOptionsReturn, normalize_binding_options},
+  },
+};
+use napi::{Env, bindgen_prelude::PromiseRaw};
 use napi_derive::napi;
-
-use crate::binding_bundler_impl::{BindingBundlerImpl, BindingBundlerOptions};
+use rolldown::BuildContext;
+use std::sync::Arc;
 
 #[napi]
 pub struct BindingBundler {
-  // Every `.write(..)/.generate(..)` will create a new `BindingBundlerImpl`, we use this field to track the build count.
-  build_count: u32,
-  session_id: Arc<str>,
-  debug_tracer: Option<rolldown_debug::DebugTracer>,
-  session: rolldown_debug::Session,
+  inner: Bundler,
+  last_build_context: Option<BuildContext>,
 }
 
 #[napi]
 impl BindingBundler {
   #[napi(constructor)]
   pub fn new() -> napi::Result<Self> {
-    let session_id = rolldown_debug::generate_session_id();
-    Ok(Self {
-      session_id,
-      build_count: 0,
-      debug_tracer: None,
-      session: rolldown_debug::Session::dummy(),
-    })
+    let inner = Bundler::new();
+    Ok(Self { inner, last_build_context: None })
   }
 
   #[napi]
-  #[cfg_attr(target_family = "wasm", allow(unused))]
-  pub fn create_impl(
+  pub fn generate<'env>(
     &mut self,
-    options: BindingBundlerOptions,
-  ) -> napi::Result<BindingBundlerImpl> {
-    if self.debug_tracer.is_none() && options.input_options.debug.is_some() {
-      self.debug_tracer = Some(rolldown_debug::DebugTracer::init(Arc::clone(&self.session_id)));
-      // Caveat: `Span` must be created after initialization of `DebugTracer`, we need it to inject data to the tracking system.
-      let session_span =
-        tracing::debug_span!("session", CONTEXT_session_id = self.session_id.as_ref());
-      // Update the `session` with the actual session span
-      self.session = rolldown_debug::Session::new(Arc::clone(&self.session_id), session_span);
+    env: &'env Env,
+    options: BindingBundlerOptions<'env>,
+  ) -> napi::Result<PromiseRaw<'env, BindingResult<BindingOutputs>>> {
+    let normalized = Self::normalize_binding_options(options)?;
+    let maybe_build = self.inner.create_build(normalized.bundler_options, normalized.plugins);
+    if let Ok((build, _)) = &maybe_build {
+      // Extract build context before consuming the build
+      self.last_build_context = Some(build.context());
     }
 
-    self.build_count += 1;
-    BindingBundlerImpl::new(options, self.session.clone(), self.build_count)
+    let fut = async move {
+      // TODO: we probably advance error handling here instead of waiting for an async call
+      let (build, mut warnings_for_creating_build) = maybe_build.map_err(|err| {
+        napi::Error::new(
+          napi::Status::GenericFailure,
+          err.iter().map(|e| e.to_diagnostic().to_string()).collect::<Vec<_>>().join("\n"),
+        )
+      })?;
+      let cwd = build.options().cwd.clone();
+      let options = Arc::clone(build.options());
+      let bundle_output = match build.generate().await {
+        Ok(output) => output,
+        Err(errs) => {
+          let errors: Vec<BindingError> = errs
+            .into_vec()
+            .iter()
+            .map(|diagnostic| to_binding_error(diagnostic, cwd.clone()))
+            .collect();
+          return Ok(napi::Either::A(BindingErrors::new(errors)));
+        }
+      };
+
+      warnings_for_creating_build.extend(bundle_output.warnings);
+
+      if let Err(err) = handle_warnings(warnings_for_creating_build, &options).await {
+        let error = to_binding_error(&err.into(), cwd.clone());
+        return Ok(napi::Either::A(BindingErrors::new(vec![error])));
+      }
+
+      Ok(napi::Either::B(bundle_output.assets.into()))
+    };
+    env.spawn_future(fut)
+  }
+
+  #[napi]
+  pub fn write<'env>(
+    &mut self,
+    env: &'env Env,
+    options: BindingBundlerOptions<'env>,
+  ) -> napi::Result<PromiseRaw<'env, BindingResult<BindingOutputs>>> {
+    let normalized = Self::normalize_binding_options(options)?;
+    let maybe_build = self.inner.create_build(normalized.bundler_options, normalized.plugins);
+    if let Ok((build, _)) = &maybe_build {
+      // Extract build context before consuming the build
+      self.last_build_context = Some(build.context());
+    }
+
+    let fut = async move {
+      let (build, mut warnings_for_creating_build) = maybe_build.map_err(|err| {
+        napi::Error::new(
+          napi::Status::GenericFailure,
+          err.iter().map(|e| e.to_diagnostic().to_string()).collect::<Vec<_>>().join("\n"),
+        )
+      })?;
+      let cwd = build.options().cwd.clone();
+      let options = Arc::clone(build.options());
+      let bundle_output = match build.write().await {
+        Ok(output) => output,
+        Err(errs) => {
+          let errors: Vec<BindingError> = errs
+            .into_vec()
+            .iter()
+            .map(|diagnostic| to_binding_error(diagnostic, cwd.clone()))
+            .collect();
+          return Ok(napi::Either::A(BindingErrors::new(errors)));
+        }
+      };
+
+      warnings_for_creating_build.extend(bundle_output.warnings);
+
+      if let Err(err) = handle_warnings(warnings_for_creating_build, &options).await {
+        let error = to_binding_error(&err.into(), cwd.clone());
+        return Ok(napi::Either::A(BindingErrors::new(vec![error])));
+      }
+
+      Ok(napi::Either::B(bundle_output.assets.into()))
+    };
+    env.spawn_future(fut)
+  }
+
+  #[napi]
+  pub fn scan<'env>(
+    &mut self,
+    env: &'env Env,
+    options: BindingBundlerOptions<'env>,
+  ) -> napi::Result<PromiseRaw<'env, BindingResult<BindingOutputs>>> {
+    let normalized = Self::normalize_binding_options(options)?;
+    let maybe_build = self.inner.create_build(normalized.bundler_options, normalized.plugins);
+    if let Ok((build, _)) = &maybe_build {
+      // Extract build context before consuming the build
+      self.last_build_context = Some(build.context());
+    }
+
+    let fut = async move {
+      let (build, _warnings_for_creating_build) = maybe_build.map_err(|err| {
+        napi::Error::new(
+          napi::Status::GenericFailure,
+          err.iter().map(|e| e.to_diagnostic().to_string()).collect::<Vec<_>>().join("\n"),
+        )
+      })?;
+      let cwd = build.options().cwd.clone();
+      match build.scan().await {
+        Ok(()) => {
+          // scan() returns no useful output, just return empty
+          Ok(napi::Either::B(vec![].into()))
+        }
+        Err(errs) => {
+          let errors: Vec<BindingError> = errs
+            .into_vec()
+            .iter()
+            .map(|diagnostic| to_binding_error(diagnostic, cwd.clone()))
+            .collect();
+          Ok(napi::Either::A(BindingErrors::new(errors)))
+        }
+      }
+    };
+    env.spawn_future(fut)
+  }
+
+  #[napi]
+  // - `Bundler::close()/inner.close()` requires acquiring `&mut self`
+  // - Acquiring `&mut self` in async napi `fn` is unsafe, so we must use a sync `fn` here.
+  // - But `Bundler::close()/inner.close()` contains async cleanup operations, so we have await its returned future
+  // in another async context instead of directly calling `close().await`.
+  // - This also affects how the code is written in `Bundler::close()/inner.close()`, see the implementation there for more details.
+  pub fn close<'env>(&mut self, env: &'env Env) -> napi::Result<PromiseRaw<'env, ()>> {
+    let cleanup_fut = self.inner.close();
+    env.spawn_future(async move {
+      let res = cleanup_fut.await;
+      handle_result(res)?;
+      Ok(())
+    })
+  }
+
+  #[napi(getter)]
+  pub fn closed(&self) -> bool {
+    self.inner.closed()
+  }
+
+  #[napi]
+  pub fn get_watch_files(&self) -> Vec<String> {
+    self
+      .last_build_context
+      .as_ref()
+      .map(|context| context.watch_files().iter().map(|s| s.to_string()).collect())
+      .unwrap_or_default()
+  }
+}
+
+impl BindingBundler {
+  fn normalize_binding_options(
+    option: BindingBundlerOptions,
+  ) -> napi::Result<NormalizeBindingOptionsReturn> {
+    let BindingBundlerOptions { input_options, output_options, parallel_plugins_registry } = option;
+
+    #[cfg(not(target_family = "wasm"))]
+    let worker_count =
+      parallel_plugins_registry.as_ref().map(|registry| registry.worker_count).unwrap_or_default();
+    #[cfg(not(target_family = "wasm"))]
+    let parallel_plugins_map =
+      parallel_plugins_registry.map(|registry| registry.take_plugin_values());
+
+    #[cfg(not(target_family = "wasm"))]
+    let worker_manager = if worker_count > 0 {
+      use crate::worker_manager::WorkerManager;
+      Some(WorkerManager::new(worker_count))
+    } else {
+      None
+    };
+
+    let ret = normalize_binding_options(
+      input_options,
+      output_options,
+      #[cfg(not(target_family = "wasm"))]
+      parallel_plugins_map,
+      #[cfg(not(target_family = "wasm"))]
+      worker_manager,
+    )?;
+
+    Ok(ret)
   }
 }

--- a/crates/rolldown_binding/src/bundler.rs
+++ b/crates/rolldown_binding/src/bundler.rs
@@ -1,0 +1,90 @@
+// TODO: add reasons about why we creating another `Bundler` instead of reusing `Bundler` of `rolldown` crate.
+
+use rolldown::{Build, BuildContext, BuildFactory, BuildFactoryOptions, BundlerOptions};
+use rolldown_error::BuildResult;
+use rolldown_plugin::__inner::SharedPluginable;
+use std::sync::Arc;
+
+pub struct Bundler {
+  session_id: Arc<str>,
+  debug_tracer: Option<rolldown_debug::DebugTracer>,
+  session: rolldown_debug::Session,
+  closed: bool,
+  last_build_context: Option<BuildContext>,
+}
+
+impl Bundler {
+  pub fn new() -> Self {
+    let session_id = rolldown_debug::generate_session_id();
+    Self {
+      session_id,
+      debug_tracer: None,
+      session: rolldown_debug::Session::dummy(),
+      closed: false,
+      last_build_context: None,
+    }
+  }
+
+  pub fn create_build(
+    &mut self,
+    bundler_options: BundlerOptions,
+    plugins: Vec<SharedPluginable>,
+  ) -> BuildResult<(Build, Vec<rolldown_error::BuildDiagnostic>)> {
+    if self.closed {
+      return Err(
+        anyhow::anyhow!(
+          "Bundle is already closed, no more calls to 'generate' or 'write' are allowed."
+        )
+        .into(),
+      );
+    }
+    self.enable_debug_tracing_if_needed(&bundler_options);
+
+    let (mut build_factory, warnings) = BuildFactory::new(BuildFactoryOptions {
+      bundler_options,
+      plugins,
+      session: Some(self.session.clone()),
+      disable_tracing_setup: true,
+    })?;
+
+    let build = build_factory.create_build();
+
+    self.last_build_context = Some(build.context());
+
+    Ok((build, warnings))
+  }
+
+  #[must_use = "Future must be awaited to do the actual cleanup work"]
+  pub fn close(&mut self) -> impl Future<Output = anyhow::Result<()>> + Send + 'static {
+    let is_closed = self.closed;
+    let last_build_context = self.last_build_context.clone();
+    if !is_closed {
+      self.closed = true;
+    }
+    // - The code is written in a non-intuitive way to satisfy the rustc and the upper usage of `BindingBundler#close`.
+    // - We need the future to be `Send + 'static` for napi-rs, so we can't use `async fn` directly here.
+    // - Read `BindingBundler#close` in `crates/rolldown_binding/src/binding_bundler.rs` for more details.
+    async move {
+      if let Some(context) = last_build_context {
+        let plugin_driver = context.plugin_driver();
+        plugin_driver.close_bundle().await?;
+      }
+      Ok(())
+    }
+  }
+
+  pub fn closed(&self) -> bool {
+    self.closed
+  }
+
+  fn enable_debug_tracing_if_needed(&mut self, options: &BundlerOptions) {
+    if self.debug_tracer.is_none() && options.debug.is_some() {
+      self.debug_tracer = Some(rolldown_debug::DebugTracer::init(Arc::clone(&self.session_id)));
+      // Caveat: `Span` must be created after initialization of `DebugTracer`, we need it to inject data to the tracking system.
+      let session_span =
+        tracing::debug_span!("session", CONTEXT_session_id = self.session_id.as_ref());
+      // Update the `session` with the actual session span
+      self.session = rolldown_debug::Session::new(Arc::clone(&self.session_id), session_span);
+    }
+  }
+}

--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -33,6 +33,7 @@ pub mod binding_bundler;
 pub mod binding_bundler_impl;
 pub mod binding_dev_engine;
 pub mod binding_dev_options;
+pub mod bundler;
 mod generated;
 pub mod options;
 pub mod parallel_js_plugin_registry;

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1300,7 +1300,12 @@ export declare class BindingBundleErrorEventData {
 
 export declare class BindingBundler {
   constructor()
-  createImpl(options: BindingBundlerOptions): BindingBundlerImpl
+  generate(options: BindingBundlerOptions): Promise<BindingResult<BindingOutputs>>
+  write(options: BindingBundlerOptions): Promise<BindingResult<BindingOutputs>>
+  scan(options: BindingBundlerOptions): Promise<BindingResult<BindingOutputs>>
+  close(): Promise<undefined>
+  get closed(): boolean
+  getWatchFiles(): Array<string>
 }
 
 export declare class BindingBundlerImpl {

--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -159,18 +159,18 @@ async function bundleInner(
   for (const config of configList) {
     const outputList = arraify(config.output || {});
     const build = await rolldown({ ...config, ...cliOptions.input });
-    for (const output of outputList) {
-      // run multiply instance at sequential
-      try {
+    try {
+      for (const output of outputList) {
+        // run multiply instance at sequential
         result.push(
           await build.write({
             ...output,
             ...cliOptions.output,
           }),
         );
-      } finally {
-        await build.close();
       }
+    } finally {
+      await build.close();
     }
   }
 

--- a/packages/rolldown/tests/error/error.test.ts
+++ b/packages/rolldown/tests/error/error.test.ts
@@ -107,8 +107,12 @@ describe('Plugin closeBundle hook', async () => {
       await build.close();
       await build.write();
     } catch (error: any) {
-      expect(error.message).toMatch(
-        `Rolldown internal error: Bundle is already closed, no more calls to 'generate' or 'write' are allowed.`,
+      expect(error.message).toMatchInlineSnapshot(
+        `
+        "[UNHANDLEABLE_ERROR] Error: Something went wrong inside rolldown, please report this problem at https://github.com/rolldown/rolldown/issues.
+        Bundle is already closed, no more calls to 'generate' or 'write' are allowed.
+        "
+      `,
       );
     }
   });


### PR DESCRIPTION
This's a transitive refactor and still some things need to be done in later PRs. So

- watch mode is not affected because I isolated changes and only affect the `RolldownBuild` logic.
- dev mode is not affected too.
- `Bundler` in `crates/rolldown` is not touched to avoid too much changes.
- This PR doesn't seperate the bundler/build level data, but it's a preparation for that purpose.  


---

This PR introduces a `Build`​ concept to represent the process of doing a build. Having this abstraction allows us to implement different bundler for different usages.

In the previous code, `RolldownBuild`​ create a `Bundler`​  underlying for each `generate/write`​ call. Without mentioning potential errors, this abstraction is already wrong and give us buggy mental model when working aounrd these code.

With this PR, `RolldownBuild`​ create only a `Bundler`​, but multiple `builds`​ underlying for each `generate/write`​ call. This gives us a correct mental model when working with code under `rolldown`​ without needing to considering about the usage of `RolldownBuild`​.