### PR TITLE
refactor(rust): rename `BuildFactory/Build` to `BundleFactory/Bundle`

### DIFF
--- a/crates/rolldown/src/build/mod.rs
+++ b/crates/rolldown/src/build/mod.rs
@@ -1,3 +1,0 @@
-pub mod build;
-pub mod build_context;
-pub mod build_factory;

--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -1,4 +1,4 @@
-use crate::build::build_context::BuildContext;
+use crate::bundle::bundle_context::BundleContext;
 
 use super::super::{
   SharedOptions, SharedResolver,
@@ -21,7 +21,7 @@ use rolldown_plugin::{HookBuildEndArgs, HookRenderErrorArgs, SharedPluginDriver}
 use rolldown_utils::dashmap::FxDashSet;
 use std::sync::Arc;
 
-pub struct Build {
+pub struct Bundle {
   pub(crate) fs: OsFileSystem,
   pub(crate) options: SharedOptions,
   pub(crate) resolver: SharedResolver,
@@ -32,7 +32,7 @@ pub struct Build {
   pub(crate) session: rolldown_debug::Session,
 }
 
-impl Build {
+impl Bundle {
   #[tracing::instrument(level = "debug", skip_all, parent = &self.session.span)]
   /// This method intentionally get the ownership of `self` to show that the method cannot be called multiple times.
   pub async fn write(mut self) -> BuildResult<BundleOutput> {
@@ -130,8 +130,8 @@ impl Build {
     &self.plugin_driver.watch_files
   }
 
-  pub fn context(&self) -> BuildContext {
-    BuildContext {
+  pub fn context(&self) -> BundleContext {
+    BundleContext {
       options: Arc::clone(&self.options),
       plugin_driver: Arc::clone(&self.plugin_driver),
     }

--- a/crates/rolldown/src/bundle/bundle_context.rs
+++ b/crates/rolldown/src/bundle/bundle_context.rs
@@ -3,20 +3,20 @@ use std::sync::Arc;
 use rolldown_common::SharedNormalizedBundlerOptions;
 use rolldown_plugin::SharedPluginDriver;
 
-/// Used to store context information during the build process.
+/// Used to store context information during the bundling process.
 #[derive(Clone)]
-pub struct BuildContext {
+pub struct BundleContext {
   pub(crate) options: SharedNormalizedBundlerOptions,
   pub(crate) plugin_driver: SharedPluginDriver,
 }
 
-impl BuildContext {
-  /// Get the bundler options used in this build context.
+impl BundleContext {
+  /// Get the bundler options used in this bundle context.
   pub fn options(&self) -> &SharedNormalizedBundlerOptions {
     &self.options
   }
 
-  /// Get the watch files collected during this build context.
+  /// Get the watch files collected during this bundle context.
   pub fn watch_files(&self) -> &Arc<rolldown_utils::dashmap::FxDashSet<arcstr::ArcStr>> {
     &self.plugin_driver.watch_files
   }

--- a/crates/rolldown/src/bundle/bundle_factory.rs
+++ b/crates/rolldown/src/bundle/bundle_factory.rs
@@ -7,7 +7,7 @@ use rolldown_plugin::{__inner::SharedPluginable, PluginDriver, SharedPluginDrive
 use rustc_hash::FxHashMap;
 
 use crate::{
-  Build,
+  Bundle,
   types::scan_stage_cache::ScanStageCache,
   utils::{
     apply_inner_plugins::apply_inner_plugins,
@@ -18,28 +18,28 @@ use crate::{
 use super::super::{SharedOptions, SharedResolver};
 
 #[derive(Debug, Default)]
-pub struct BuildFactoryOptions {
+pub struct BundleFactoryOptions {
   pub bundler_options: BundlerOptions,
   pub plugins: Vec<SharedPluginable>,
   pub session: Option<rolldown_debug::Session>,
   pub disable_tracing_setup: bool,
 }
 
-pub struct BuildFactory {
+pub struct BundleFactory {
   pub fs: OsFileSystem,
   pub options: SharedOptions,
   pub resolver: SharedResolver,
   pub file_emitter: SharedFileEmitter,
   pub plugin_driver: SharedPluginDriver,
-  /// Warnings collected during build factory creation.
-  /// These warnings are transferred to the first created `Build` via `create_build()` or `create_incremental_build()`.
+  /// Warnings collected during bundle factory creation.
+  /// These warnings are transferred to the first created `Bundle` via `create_bundle()` or `create_incremental_bundle()`.
   pub warnings: Vec<BuildDiagnostic>,
   pub session: rolldown_debug::Session,
   pub(crate) _log_guard: Option<Box<dyn Any + Send>>,
 }
 
-impl BuildFactory {
-  pub fn new(mut opts: BuildFactoryOptions) -> BuildResult<Self> {
+impl BundleFactory {
+  pub fn new(mut opts: BundleFactoryOptions) -> BuildResult<Self> {
     let session = opts.session.unwrap_or_else(rolldown_debug::Session::dummy);
 
     let maybe_guard =
@@ -81,8 +81,8 @@ impl BuildFactory {
     })
   }
 
-  pub fn create_build(&mut self) -> Build {
-    Build {
+  pub fn create_bundle(&mut self) -> Bundle {
+    Bundle {
       fs: self.fs.clone(),
       options: Arc::clone(&self.options),
       resolver: Arc::clone(&self.resolver),
@@ -94,8 +94,8 @@ impl BuildFactory {
     }
   }
 
-  pub fn create_incremental_build(&mut self, cache: ScanStageCache) -> Build {
-    Build {
+  pub fn create_incremental_bundle(&mut self, cache: ScanStageCache) -> Bundle {
+    Bundle {
       fs: self.fs.clone(),
       options: Arc::clone(&self.options),
       resolver: Arc::clone(&self.resolver),

--- a/crates/rolldown/src/bundle/mod.rs
+++ b/crates/rolldown/src/bundle/mod.rs
@@ -1,0 +1,3 @@
+pub mod bundle;
+pub mod bundle_context;
+pub mod bundle_factory;

--- a/crates/rolldown/src/bundler/impl_bundler_build.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_build.rs
@@ -8,23 +8,23 @@ impl Bundler {
   #[tracing::instrument(level = "debug", skip_all, parent = &self.session.span)]
   pub async fn write(&mut self) -> BuildResult<BundleOutput> {
     self.create_error_if_closed()?;
-    let build = self.build_factory.create_build();
-    build.write().await
+    let bundle = self.bundle_factory.create_bundle();
+    bundle.write().await
   }
 
   #[tracing::instrument(level = "debug", skip_all, parent = &self.session.span)]
   pub async fn generate(&mut self) -> BuildResult<BundleOutput> {
     self.create_error_if_closed()?;
-    let build = self.build_factory.create_build();
-    build.generate().await
+    let bundle = self.bundle_factory.create_bundle();
+    bundle.generate().await
   }
 
   #[tracing::instrument(target = "devtool", level = "debug", skip_all)]
   #[cfg(feature = "experimental")]
   pub async fn scan(&mut self) -> BuildResult<()> {
     self.create_error_if_closed()?;
-    let build = self.build_factory.create_build();
-    build.scan().await?;
+    let bundle = self.bundle_factory.create_bundle();
+    bundle.scan().await?;
 
     Ok(())
   }

--- a/crates/rolldown/src/bundler/impl_bundler_getter.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_getter.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 impl Bundler {
   pub fn options(&self) -> &SharedOptions {
-    &self.build_factory.options
+    &self.bundle_factory.options
   }
 
   pub fn closed(&self) -> bool {
@@ -14,6 +14,6 @@ impl Bundler {
   }
 
   pub fn watch_files(&self) -> &Arc<FxDashSet<ArcStr>> {
-    &self.build_factory.plugin_driver.watch_files
+    &self.bundle_factory.plugin_driver.watch_files
   }
 }

--- a/crates/rolldown/src/bundler/impl_bundler_hmr.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_hmr.rs
@@ -13,10 +13,10 @@ impl Bundler {
     next_hmr_patch_id: Arc<AtomicU32>,
   ) -> BuildResult<Vec<ClientHmrUpdate>> {
     let mut hmr_stage = HmrStage::new(HmrStageInput {
-      fs: self.build_factory.fs.clone(),
-      options: Arc::clone(&self.build_factory.options),
-      resolver: Arc::clone(&self.build_factory.resolver),
-      plugin_driver: Arc::clone(&self.build_factory.plugin_driver),
+      fs: self.bundle_factory.fs.clone(),
+      options: Arc::clone(&self.bundle_factory.options),
+      resolver: Arc::clone(&self.bundle_factory.resolver),
+      plugin_driver: Arc::clone(&self.bundle_factory.plugin_driver),
       cache: &mut self.cache,
       next_hmr_patch_id,
     });
@@ -32,10 +32,10 @@ impl Bundler {
     next_hmr_patch_id: Arc<AtomicU32>,
   ) -> BuildResult<HmrUpdate> {
     let mut hmr_stage = HmrStage::new(HmrStageInput {
-      fs: self.build_factory.fs.clone(),
-      options: Arc::clone(&self.build_factory.options),
-      resolver: Arc::clone(&self.build_factory.resolver),
-      plugin_driver: Arc::clone(&self.build_factory.plugin_driver),
+      fs: self.bundle_factory.fs.clone(),
+      options: Arc::clone(&self.bundle_factory.options),
+      resolver: Arc::clone(&self.bundle_factory.resolver),
+      plugin_driver: Arc::clone(&self.bundle_factory.plugin_driver),
       cache: &mut self.cache,
       next_hmr_patch_id,
     });

--- a/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
@@ -1,19 +1,19 @@
 use super::Bundler;
-use crate::{Build, types::bundle_output::BundleOutput};
+use crate::{Bundle, types::bundle_output::BundleOutput};
 use arcstr::ArcStr;
 use rolldown_common::ScanMode;
 use rolldown_error::BuildResult;
 use std::mem;
 
 impl Bundler {
-  pub(crate) async fn with_incremental_build<T>(
+  pub(crate) async fn with_incremental_bundle<T>(
     &mut self,
-    with_fn: impl AsyncFnOnce(&mut Build) -> BuildResult<T>,
+    with_fn: impl AsyncFnOnce(&mut Bundle) -> BuildResult<T>,
   ) -> BuildResult<T> {
     let cache = mem::take(&mut self.cache);
-    let mut build = self.build_factory.create_incremental_build(cache);
-    let ret = with_fn(&mut build).await?;
-    self.cache = build.cache;
+    let mut bundle = self.bundle_factory.create_incremental_bundle(cache);
+    let ret = with_fn(&mut bundle).await?;
+    self.cache = bundle.cache;
     Ok(ret)
   }
 
@@ -21,28 +21,28 @@ impl Bundler {
     &mut self,
     scan_mode: ScanMode<ArcStr>,
   ) -> BuildResult<BundleOutput> {
-    self.incremental_build(true, scan_mode).await
+    self.incremental_bundle(true, scan_mode).await
   }
 
   pub(crate) async fn incremental_generate(
     &mut self,
     scan_mode: ScanMode<ArcStr>,
   ) -> BuildResult<BundleOutput> {
-    self.incremental_build(false, scan_mode).await
+    self.incremental_bundle(false, scan_mode).await
   }
 
-  async fn incremental_build(
+  async fn incremental_bundle(
     &mut self,
     is_write: bool,
     scan_mode: ScanMode<ArcStr>,
   ) -> BuildResult<BundleOutput> {
     self
-      .with_incremental_build(async |build| {
-        let middle_output = build.scan_modules(scan_mode).await?;
+      .with_incremental_bundle(async |bundle| {
+        let middle_output = bundle.scan_modules(scan_mode).await?;
         if is_write {
-          build.bundle_write(middle_output).await
+          bundle.bundle_write(middle_output).await
         } else {
-          build.bundle_generate(middle_output).await
+          bundle.bundle_generate(middle_output).await
         }
       })
       .await

--- a/crates/rolldown/src/lib.rs
+++ b/crates/rolldown/src/lib.rs
@@ -1,6 +1,6 @@
 mod asset;
 mod ast_scanner;
-mod build;
+mod bundle;
 mod bundler;
 mod bundler_builder;
 mod chunk_graph;
@@ -25,10 +25,10 @@ pub(crate) type SharedResolver = Arc<Resolver<OsFileSystem>>;
 pub(crate) type SharedOptions = SharedNormalizedBundlerOptions;
 
 pub use crate::{
-  build::{
-    build::Build,
-    build_context::BuildContext,
-    build_factory::{BuildFactory, BuildFactoryOptions},
+  bundle::{
+    bundle::Bundle,
+    bundle_context::BundleContext,
+    bundle_factory::{BundleFactory, BundleFactoryOptions},
   },
   bundler::Bundler,
   bundler_builder::BundlerBuilder,

--- a/crates/rolldown/src/watch/watcher_task.rs
+++ b/crates/rolldown/src/watch/watcher_task.rs
@@ -68,20 +68,20 @@ impl WatcherTask {
 
       // https://github.com/rollup/rollup/blob/ecff5325941ec36599f9967731ed6871186a72ee/src/watch/watch.ts#L206
       bundler
-        .with_incremental_build(async |build| {
-          let middle_output_result = build.scan_modules(scan_mode).await;
-          let watched_files = Arc::clone(build.get_watch_files());
+        .with_incremental_bundle(async |bundle| {
+          let middle_output_result = bundle.scan_modules(scan_mode).await;
+          let watched_files = Arc::clone(bundle.get_watch_files());
           // Watch no matter scan success or failed, so we might have a chance to recover from errors.
-          self.watch_files(&watched_files, &build.options).await?;
+          self.watch_files(&watched_files, &bundle.options).await?;
           let middle_output = middle_output_result?;
 
-          if build.options.watch.skip_write {
+          if bundle.options.watch.skip_write {
             Ok(())
           } else {
-            let output_result = build.bundle_write(middle_output).await;
+            let output_result = bundle.bundle_write(middle_output).await;
             // avoid watching scan stage files twice // TODO: hyf0: A bad code smell here.
             watched_files.clear();
-            self.watch_files(&watched_files, &build.options).await?;
+            self.watch_files(&watched_files, &bundle.options).await?;
             output_result.map(|_| ())
           }
         })


### PR DESCRIPTION
I noticed this while I was working around the code. Rollup has the concept of `build`​ stage/phase. Rolldown followed this abstraction subconsciously.

The previous lifecycle of `Build`​ includes `build`​ + `generate`​ stages, which is improper, so we use `bundle`​ as the concept of finishing the process that starts from `build`​ and end with `generate`​.