### PR TITLE
fix(node)!: remove experimental `RolldownBuild#scan`, only expose it from `rolldown/experimental`

### DIFF
--- a/crates/rolldown_binding/src/binding_bundler.rs
+++ b/crates/rolldown_binding/src/binding_bundler.rs
@@ -125,7 +125,7 @@ impl BindingBundler {
     &mut self,
     env: &'env Env,
     options: BindingBundlerOptions<'env>,
-  ) -> napi::Result<PromiseRaw<'env, BindingResult<BindingOutputs>>> {
+  ) -> napi::Result<PromiseRaw<'env, BindingResult<()>>> {
     let normalized = Self::normalize_binding_options(options)?;
     let maybe_bundle = self.inner.create_bundle(normalized.bundler_options, normalized.plugins);
     if let Ok(bundle) = &maybe_bundle {
@@ -144,7 +144,7 @@ impl BindingBundler {
       match bundle.scan().await {
         Ok(()) => {
           // scan() returns no useful output, just return empty
-          Ok(napi::Either::B(vec![].into()))
+          Ok(napi::Either::B(()))
         }
         Err(errs) => {
           let errors: Vec<BindingError> = errs

--- a/packages/rolldown/src/api/experimental.ts
+++ b/packages/rolldown/src/api/experimental.ts
@@ -1,20 +1,72 @@
+import {
+  BindingBundler,
+  shutdownAsyncRuntime,
+  startAsyncRuntime,
+} from '../binding.cjs';
 import type { InputOptions } from '../options/input-options';
 import { PluginDriver } from '../plugin/plugin-driver';
+import { createBundlerOptions } from '../utils/create-bundler-option';
+import { unwrapBindingResult } from '../utils/error';
+import { validateOption } from '../utils/validator';
 import { RolldownBuild } from './rolldown/rolldown-build';
 
 export { freeExternalMemory } from '../types/external-memory-handle';
 
 /**
- * This is an experimental API. It's behavior may change in the future.
+ * This is an experimental API. Its behavior may change in the future.
  *
- * Calling this API will only execute the scan stage of rolldown.
+ * - Calling this API will only execute the `scan/build` stage of rolldown.
+ * - `scan` will clean up all resources automatically, but if you want to ensure timely cleanup, you need to wait for the returned promise to resolve.
+ *
+ * @example To ensure cleanup of resources, use the returned promise to wait for the scan to complete.
+ * ```ts
+ * import { scan } from 'rolldown/api/experimental';
+ *
+ * const cleanupPromise = await scan(...);
+ * await cleanupPromise;
+ * // Now all resources have been cleaned up.
+ * ```
  */
-export const scan = async (input: InputOptions): Promise<void> => {
-  const inputOptions = await PluginDriver.callOptionsHook(input);
-  const build = new RolldownBuild(inputOptions);
-  try {
-    await build.scan();
-  } finally {
-    await build.close();
+export const scan = async (
+  rawInputOptions: InputOptions,
+  rawOutputOptions = {},
+): Promise<Promise<void>> => {
+  validateOption('input', rawInputOptions);
+  validateOption('output', rawOutputOptions);
+
+  const inputOptions = await PluginDriver.callOptionsHook(rawInputOptions);
+
+  const ret = await createBundlerOptions(
+    inputOptions,
+    rawOutputOptions,
+    false,
+  );
+
+  const bundler = new BindingBundler();
+
+  if (RolldownBuild.asyncRuntimeShutdown) {
+    startAsyncRuntime();
   }
+
+  async function cleanup() {
+    await bundler.close();
+    await ret.stopWorkers?.();
+    shutdownAsyncRuntime();
+    RolldownBuild.asyncRuntimeShutdown = true;
+  }
+
+  let cleanupPromise = Promise.resolve();
+
+  try {
+    const result = await bundler.scan(ret.bundlerOptions);
+    unwrapBindingResult(result);
+  } catch (err) {
+    await cleanup();
+    throw err;
+  } finally {
+    cleanupPromise = cleanup();
+  }
+
+  // Instead of blocking here, we return a promise to let the caller decide when to wait for cleanup.
+  return cleanupPromise;
 };

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -31,29 +31,6 @@ export class RolldownBuild {
     return this.#bundler.closed;
   }
 
-  async scan(): Promise<void> {
-    await this.#stopWorkers?.();
-
-    const option = await createBundlerOptions(
-      this.#inputOptions,
-      {},
-      false,
-    );
-
-    if (RolldownBuild.asyncRuntimeShutdown) {
-      startAsyncRuntime();
-    }
-
-    try {
-      this.#stopWorkers = option.stopWorkers;
-      const output = await this.#bundler.scan(option.bundlerOptions);
-      unwrapBindingResult(output);
-    } catch (e) {
-      await option.stopWorkers?.();
-      throw e;
-    }
-  }
-
   async generate(outputOptions: OutputOptions = {}): Promise<RolldownOutput> {
     return this.#build(false, outputOptions);
   }

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1302,7 +1302,7 @@ export declare class BindingBundler {
   constructor()
   generate(options: BindingBundlerOptions): Promise<BindingResult<BindingOutputs>>
   write(options: BindingBundlerOptions): Promise<BindingResult<BindingOutputs>>
-  scan(options: BindingBundlerOptions): Promise<BindingResult<BindingOutputs>>
+  scan(options: BindingBundlerOptions): Promise<BindingResult<undefined>>
   close(): Promise<undefined>
   get closed(): boolean
   getWatchFiles(): Array<string>


### PR DESCRIPTION
`scan`​ is an experimental functionality, we expect to expose it via `rolldown/experimental`​ instead of stable API.

To use `scan`​, users could

```js
import { scan } from 'rolldown/experimental'

await scan(..)
```