### PR TITLE
refactor(rust): introduce `PluginDriverFactory` to manage creation of `PluginDriver`

### DIFF
--- a/crates/rolldown/src/bundler/impl_bundler_getter.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_getter.rs
@@ -2,7 +2,7 @@ use super::Bundler;
 use crate::SharedOptions;
 use arcstr::ArcStr;
 use rolldown_utils::dashmap::FxDashSet;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 impl Bundler {
   pub fn options(&self) -> &SharedOptions {
@@ -14,6 +14,12 @@ impl Bundler {
   }
 
   pub fn watch_files(&self) -> &Arc<FxDashSet<ArcStr>> {
-    &self.bundle_factory.plugin_driver.watch_files
+    static EMPTY_SET: LazyLock<Arc<FxDashSet<ArcStr>>> =
+      LazyLock::new(|| Arc::new(FxDashSet::default()));
+    if let Some(last_bundle_context) = &self.last_bundle_context {
+      &last_bundle_context.plugin_driver.watch_files
+    } else {
+      &EMPTY_SET
+    }
   }
 }

--- a/crates/rolldown/src/bundler/impl_bundler_hmr.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_hmr.rs
@@ -12,11 +12,17 @@ impl Bundler {
     clients: &[ClientHmrInput<'_>],
     next_hmr_patch_id: Arc<AtomicU32>,
   ) -> BuildResult<Vec<ClientHmrUpdate>> {
+    let Some(plugin_driver) = self.last_bundle_context.as_ref().map(|ctx| &ctx.plugin_driver)
+    else {
+      return Err(anyhow::format_err!(
+        "HMR requires to run at least one bundle before invalidation"
+      ))?;
+    };
     let mut hmr_stage = HmrStage::new(HmrStageInput {
       fs: self.bundle_factory.fs.clone(),
       options: Arc::clone(&self.bundle_factory.options),
       resolver: Arc::clone(&self.bundle_factory.resolver),
-      plugin_driver: Arc::clone(&self.bundle_factory.plugin_driver),
+      plugin_driver: Arc::clone(plugin_driver),
       cache: &mut self.cache,
       next_hmr_patch_id,
     });
@@ -31,11 +37,17 @@ impl Bundler {
     executed_modules: &FxHashSet<String>,
     next_hmr_patch_id: Arc<AtomicU32>,
   ) -> BuildResult<HmrUpdate> {
+    let Some(plugin_driver) = self.last_bundle_context.as_ref().map(|ctx| &ctx.plugin_driver)
+    else {
+      return Err(anyhow::format_err!(
+        "HMR requires to run at least one bundle before invalidation"
+      ))?;
+    };
     let mut hmr_stage = HmrStage::new(HmrStageInput {
       fs: self.bundle_factory.fs.clone(),
       options: Arc::clone(&self.bundle_factory.options),
       resolver: Arc::clone(&self.bundle_factory.resolver),
-      plugin_driver: Arc::clone(&self.bundle_factory.plugin_driver),
+      plugin_driver: Arc::clone(plugin_driver),
       cache: &mut self.cache,
       next_hmr_patch_id,
     });

--- a/crates/rolldown/src/bundler_builder.rs
+++ b/crates/rolldown/src/bundler_builder.rs
@@ -11,7 +11,7 @@ pub struct BundlerBuilder {
 
 impl BundlerBuilder {
   pub fn build(self) -> BuildResult<Bundler> {
-    Bundler::with_builder_options(self.options, self.plugins, None, true)
+    Bundler::with_plugins(self.options, self.plugins)
   }
 
   #[must_use]

--- a/crates/rolldown/src/dev/building_task.rs
+++ b/crates/rolldown/src/dev/building_task.rs
@@ -63,11 +63,14 @@ impl BundlingTask {
     {
       let bundler = self.bundler.lock().await;
       for changed_file in self.input.changed_files() {
-        bundler
-          .plugin_driver
-          // FIXME: use proper WatcherChangeKind for created/removed files.
-          .watch_change(changed_file.to_str().unwrap(), WatcherChangeKind::Update)
-          .await?;
+        if let Some(plugin_driver) =
+          bundler.last_bundle_context.as_ref().map(|ctx| &ctx.plugin_driver)
+        {
+          plugin_driver
+            // FIXME: use proper WatcherChangeKind for created/removed files.
+            .watch_change(changed_file.to_str().unwrap(), WatcherChangeKind::Update)
+            .await?;
+        }
       }
     }
 

--- a/crates/rolldown/src/stages/generate_stage/advanced_chunks.rs
+++ b/crates/rolldown/src/stages/generate_stage/advanced_chunks.rs
@@ -125,7 +125,7 @@ impl GenerateStage<'_> {
           }
         }
 
-        let ctx = ChunkingContext::new(Arc::clone(&self.plugin_driver.modules));
+        let ctx = ChunkingContext::new(Arc::clone(&self.plugin_driver.module_infos));
 
         let Some(group_name) = match_group.name.value(&ctx, &normal_module.id).await? else {
           // Group which doesn't have a name will be ignored.

--- a/crates/rolldown_plugin/src/lib.rs
+++ b/crates/rolldown_plugin/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::{
   plugin_context::{
     PluginContext, SharedNativePluginContext, SharedTransformPluginContext, TransformPluginContext,
   },
-  plugin_driver::{PluginDriver, SharedPluginDriver},
+  plugin_driver::{PluginDriver, PluginDriverFactory, SharedPluginDriver},
   pluginable::Pluginable,
   types::custom_field::CustomField,
   types::hook_addon_args::HookAddonArgs,

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
@@ -43,7 +43,7 @@ impl PluginContext {
   }
 
   #[must_use]
-  pub fn new_shared_with_skipped_resolve_calls(
+  pub fn fork_with_skipped_resolve_calls(
     &self,
     skipped_resolve_calls: Vec<Arc<HookResolveIdSkipped>>,
   ) -> Self {
@@ -59,7 +59,7 @@ impl PluginContext {
         file_emitter: Arc::clone(&ctx.file_emitter),
         options: Arc::clone(&ctx.options),
         watch_files: Arc::clone(&ctx.watch_files),
-        modules: Arc::clone(&ctx.modules),
+        module_infos: Arc::clone(&ctx.module_infos),
         tx: Arc::clone(&ctx.tx),
         session: ctx.session.clone(),
         build_span: Arc::clone(&ctx.build_span),

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -85,10 +85,7 @@ impl PluginDriver {
             &skipped_resolve_calls.map_or_else(
               || ctx.clone(),
               |skipped_resolve_calls| {
-                PluginContext::new_shared_with_skipped_resolve_calls(
-                  ctx,
-                  skipped_resolve_calls.clone(),
-                )
+                PluginContext::fork_with_skipped_resolve_calls(ctx, skipped_resolve_calls.clone())
               },
             ),
             args,
@@ -156,10 +153,7 @@ impl PluginDriver {
           &skipped_resolve_calls.map_or_else(
             || ctx.clone(),
             |skipped_resolve_calls| {
-              PluginContext::new_shared_with_skipped_resolve_calls(
-                ctx,
-                skipped_resolve_calls.clone(),
-              )
+              PluginContext::fork_with_skipped_resolve_calls(ctx, skipped_resolve_calls.clone())
             },
           ),
           args,

--- a/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
@@ -1,0 +1,81 @@
+use std::sync::{Arc, Weak};
+
+use dashmap::DashMap;
+use oxc_index::IndexVec;
+use rolldown_common::{SharedFileEmitter, SharedModuleInfoDashMap, SharedNormalizedBundlerOptions};
+use rolldown_resolver::Resolver;
+use rolldown_utils::dashmap::FxDashSet;
+
+use crate::{
+  __inner::SharedPluginable,
+  PluginContext,
+  plugin_context::{NativePluginContextImpl, PluginContextMeta},
+  plugin_driver::{ContextLoadCompletionManager, hook_orders::PluginHookOrders},
+  type_aliases::{IndexPluginContext, IndexPluginable},
+};
+
+pub struct PluginDriverFactory {
+  plugins: Vec<SharedPluginable>,
+  resolver: Arc<Resolver>,
+}
+
+impl PluginDriverFactory {
+  pub fn new(plugins: Vec<SharedPluginable>, resolver: &Arc<Resolver>) -> Self {
+    Self { plugins, resolver: Arc::clone(resolver) }
+  }
+
+  pub fn create_plugin_driver(
+    &self,
+    file_emitter: &SharedFileEmitter,
+    options: &SharedNormalizedBundlerOptions,
+    session: &rolldown_debug::Session,
+    initial_build_span: &Arc<tracing::Span>,
+    module_infos: SharedModuleInfoDashMap,
+  ) -> Arc<crate::plugin_driver::PluginDriver> {
+    let watch_files = Arc::new(FxDashSet::default());
+    let meta = Arc::new(PluginContextMeta::default());
+    let tx = Arc::new(tokio::sync::Mutex::new(None));
+    let mut plugin_usage_vec = IndexVec::new();
+
+    // Clone the Arc to share across contexts
+    let build_span_arc = Arc::clone(initial_build_span);
+
+    Arc::new_cyclic(|plugin_driver| {
+      let mut index_plugins = IndexPluginable::with_capacity(self.plugins.len());
+      let mut index_contexts = IndexPluginContext::with_capacity(self.plugins.len());
+
+      self.plugins.iter().for_each(|plugin| {
+        let plugin_idx = index_plugins.push(Arc::clone(plugin));
+        plugin_usage_vec.push(plugin.call_hook_usage());
+        index_contexts.push(PluginContext::Native(Arc::new(NativePluginContextImpl {
+          plugin_name: plugin.call_name(),
+          skipped_resolve_calls: vec![],
+          plugin_idx,
+          plugin_driver: Weak::clone(plugin_driver),
+          meta: Arc::clone(&meta),
+          resolver: Arc::clone(&self.resolver),
+          file_emitter: Arc::clone(file_emitter),
+          module_infos: Arc::clone(&module_infos),
+          options: Arc::clone(options),
+          watch_files: Arc::clone(&watch_files),
+          tx: Arc::clone(&tx),
+          session: session.clone(),
+          build_span: Arc::clone(&build_span_arc),
+        })));
+      });
+
+      crate::plugin_driver::PluginDriver {
+        hook_orders: PluginHookOrders::new(&index_plugins, &plugin_usage_vec),
+        plugins: index_plugins,
+        contexts: index_contexts,
+        file_emitter: Arc::clone(file_emitter),
+        watch_files,
+        module_infos,
+        transform_dependencies: Arc::new(DashMap::default()),
+        context_load_completion_manager: ContextLoadCompletionManager::default(),
+        tx,
+        options: Arc::clone(options),
+      }
+    })
+  }
+}


### PR DESCRIPTION
Follow-up of https://github.com/rolldown/rolldown/pull/6883. We will use `PluginDriverFactory` to manage bundler level and bundle level data separately.

With this PR, we're finally able to find and solve potential issues like https://github.com/rolldown/rolldown/pull/6891/files#r2507078414. The new design might encounter many issues, but that's expected. These issues are caused because we don't treat bundler and build/bundle level data properly. It also makes complicated features like `incremental build/hmr/watch mode` vulnerable.