### PR TITLE
feat(rust): use `BundleMode` to handle incremental build exhaustively

### DIFF
--- a/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
@@ -1,17 +1,18 @@
 use super::Bundler;
 use crate::{Bundle, types::bundle_output::BundleOutput};
 use arcstr::ArcStr;
-use rolldown_common::ScanMode;
+use rolldown_common::{BundleMode, ScanMode};
 use rolldown_error::BuildResult;
 use std::mem;
 
 impl Bundler {
-  pub(crate) async fn with_incremental_bundle<T>(
+  pub(crate) async fn with_cached_bundle<T>(
     &mut self,
+    bundle_mode: BundleMode,
     with_fn: impl AsyncFnOnce(&mut Bundle) -> BuildResult<T>,
   ) -> BuildResult<T> {
     let cache = mem::take(&mut self.cache);
-    let mut bundle = self.bundle_factory.create_incremental_bundle(cache);
+    let mut bundle = self.bundle_factory.create_bundle(bundle_mode, Some(cache))?;
     let ret = with_fn(&mut bundle).await?;
     self.cache = bundle.cache;
     Ok(ret)
@@ -36,8 +37,12 @@ impl Bundler {
     is_write: bool,
     scan_mode: ScanMode<ArcStr>,
   ) -> BuildResult<BundleOutput> {
+    let bundle_mode = match scan_mode {
+      ScanMode::Full => BundleMode::IncrementalFullBuild,
+      ScanMode::Partial(_) => BundleMode::IncrementalBuild,
+    };
     self
-      .with_incremental_bundle(async |bundle| {
+      .with_cached_bundle(bundle_mode, async |bundle| {
         let middle_output = bundle.scan_modules(scan_mode).await?;
         if is_write {
           bundle.bundle_write(middle_output).await

--- a/crates/rolldown_binding/src/classic_bundler.rs
+++ b/crates/rolldown_binding/src/classic_bundler.rs
@@ -60,6 +60,7 @@
 /// - The codebase maintains clear separation of concerns, preventing the wrong mental model that caused bugs previously
 /// - Development is more maintainable as changes are made at the appropriate abstraction level
 use rolldown::{Bundle, BundleFactory, BundleFactoryOptions, BundleHandle, BundlerOptions};
+use rolldown_common::BundleMode;
 use rolldown_error::BuildResult;
 use rolldown_plugin::__inner::SharedPluginable;
 use std::sync::Arc;
@@ -101,7 +102,7 @@ impl ClassicBundler {
       disable_tracing_setup: true,
     })?;
 
-    let bundle = bundle_factory.create_bundle();
+    let bundle = bundle_factory.create_bundle(BundleMode::FullBuild, None)?;
 
     self.last_bundle_handle = Some(bundle.context());
 

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -136,6 +136,7 @@ pub use crate::{
   types::asset_meta::{InstantiationKind, SourcemapAssetMeta},
   types::ast_scope_idx::AstScopeIdx,
   types::ast_scopes::AstScopes,
+  types::bundle_mode::BundleMode,
   types::chunk_idx::ChunkIdx,
   types::chunk_kind::ChunkKind,
   types::concatenate_wrapped_module::{

--- a/crates/rolldown_common/src/types/bundle_mode.rs
+++ b/crates/rolldown_common/src/types/bundle_mode.rs
@@ -1,0 +1,20 @@
+#[derive(Debug, Clone, Copy)]
+pub enum BundleMode {
+  // Normal build
+  FullBuild,
+  // A full build with enabling `incremental` option.
+  // Compared to `FullBuild`, `IncrementalFullBuild` needss to store the data into cache for future incremental builds, while `FullBuild` does not care about that.
+  IncrementalFullBuild,
+  // An incremental build only for changed files
+  IncrementalBuild,
+}
+
+impl BundleMode {
+  pub fn is_full_build(&self) -> bool {
+    matches!(self, BundleMode::FullBuild | BundleMode::IncrementalFullBuild)
+  }
+
+  pub fn is_incremental(&self) -> bool {
+    matches!(self, BundleMode::IncrementalFullBuild | BundleMode::IncrementalBuild)
+  }
+}

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -2,6 +2,7 @@ pub mod asset;
 pub mod asset_meta;
 pub mod ast_scope_idx;
 pub mod ast_scopes;
+pub mod bundle_mode;
 pub mod chunk_idx;
 pub mod chunk_kind;
 pub mod concatenate_wrapped_module;


### PR DESCRIPTION
Several reasons I want to introduce `BundleMode`:

## A mental model footgun

`BundleMode` is used to emphasize there are 3 states when we integrate incremental build into rolldown.

For exmaple, for watch mode:

1. if `incremental_build: false`, file changes should result to full rebuild every time
2. if `incremental_build: true`, the first build is not a plain full build, it needs to be done with saving data into cache.
3. if `incremental_build: true`, files changes should result to incremental rebuilds.

The footgun:

https://github.com/rolldown/rolldown/blob/c19666e8309871688d997729d32f49108604249a/crates/rolldown/src/watch/watcher_task.rs#L53-L67

When `incremental_build: false`, the watch mode will use `ScanMode:Full` in order to trigger full build, which seems to satisfy the above `1.`, but it's not!

> 1. if `incremental_build: false`, file changes should result to full rebuild every time

`watch mode` triggers a full build with extra unnecessary overhead of saving cache! And for each file change.

This PR doesn't fix the behavior but make it clear to be recognized. See https://github.com/rolldown/rolldown/pull/6894/files#r2507176596.

## Reduce bug prone patterns:

- https://github.com/rolldown/rolldown/pull/6894/files#r2507167806
- https://github.com/rolldown/rolldown/pull/6894/files#r2507174518

## Misc

Inside of the `Bundle` logic, we're using `ScanMode` + `is_incremental_build_enabled` to achieve the same effect as `BundleMode`. I restrict the refactor area of this PR, so they are not touched.

The previous design for the bundler hides many issues and cause advance features vulnerable. https://github.com/rolldown/rolldown/pull/6891#discussion_r2507078414 probably won't be the last issue.