### PR TITLE
fix(cli): support nested options in CLI properly

### DIFF
--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -181,6 +181,14 @@ return exports;
 })({}, node_fs);"
 `;
 
+exports[`cli options for bundling > should handle nested options 1`] = `
+"//#region index.js
+var cli_option_nested_default = defined;
+
+//#endregion
+export { cli_option_nested_default as default };"
+`;
+
 exports[`cli options for bundling > should handle pass \`-s\` options 1`] = `
 "<DIR>/index.js.map  asset │ size: 0.20 kB
 <DIR>/index.js      chunk │ size: 0.19 kB

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -116,6 +116,15 @@ describe('cli options for bundling', () => {
     expect(cleanStdout(status.stdout)).toMatchSnapshot();
   });
 
+  it('should handle nested options', async () => {
+    const cwd = cliFixturesDir('cli-option-nested');
+    const status = await $({
+      cwd,
+    })`rolldown index.js --transform.define __DEFINE__=defined`;
+    expect(status.exitCode).toBe(0);
+    expect(cleanStdout(status.stdout)).toMatchSnapshot();
+  });
+
   it('cli default options', async () => {
     const cwd = cliFixturesDir('cli-default-option');
     const status = await $({ cwd })`rolldown -c`;

--- a/packages/rolldown/tests/cli/fixtures/cli-option-nested/index.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-option-nested/index.js
@@ -1,0 +1,1 @@
+export default __DEFINE__;


### PR DESCRIPTION
`--transform.define` was rejected by the following error:
```
Invalid value for option transform.define: Invalid key: Expected never but received "transform.define". You can use rolldown -h to see the help.
```