### PR TITLE
refactor!: remove deprecated top-level `define` and `inject` options

### DIFF
--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -10,8 +10,6 @@ const INVALID_LOG_POSITION = 'INVALID_LOG_POSITION',
   MULTIPLY_NOTIFY_OPTION = 'MULTIPLY_NOTIFY_OPTION',
   PARSE_ERROR = 'PARSE_ERROR',
   NO_FS_IN_BROWSER = 'NO_FS_IN_BROWSER',
-  DEPRECATED_DEFINE = 'DEPRECATED_DEFINE',
-  DEPRECATED_INJECT = 'DEPRECATED_INJECT',
   DEPRECATED_PROFILER_NAMES = 'DEPRECATED_PROFILER_NAMES',
   DEPRECATED_KEEP_NAMES = 'DEPRECATED_KEEP_NAMES',
   DEPRECATED_DROP_LABELS = 'DEPRECATED_DROP_LABELS';
@@ -66,24 +64,6 @@ export function logNoFileSystemInBrowser(method: string): RollupLog {
     code: NO_FS_IN_BROWSER,
     message:
       `Cannot access the file system (via "${method}") when using the browser build of Rolldown.`,
-  };
-}
-
-export function logDeprecatedDefine(): RollupLog {
-  return {
-    code: DEPRECATED_DEFINE,
-    message: `${
-      styleText(['yellow', 'bold'], '⚠ Deprecation Warning:')
-    } The top-level "define" option is deprecated. Use "transform.define" instead.`,
-  };
-}
-
-export function logDeprecatedInject(): RollupLog {
-  return {
-    code: DEPRECATED_INJECT,
-    message: `${
-      styleText(['yellow', 'bold'], '⚠ Deprecation Warning:')
-    } The top-level "inject" option is deprecated. Use "transform.inject" instead.`,
   };
 }
 

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -316,22 +316,6 @@ export interface InputOptions {
     nativeMagicString?: boolean;
   };
   /**
-   * Replace global variables or [property accessors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors) with the provided values.
-   *
-   * @deprecated Use `transform.define` instead. This top-level option will be removed in a future release.
-   *
-   * See `transform.define` for detailed documentation and examples.
-   */
-  define?: Record<string, string>;
-  /**
-   * Inject import statements on demand.
-   *
-   * @deprecated Use `transform.inject` instead. This top-level option will be removed in a future release.
-   *
-   * See `transform.inject` for detailed documentation and examples.
-   */
-  inject?: Record<string, string | [string, string]>;
-  /**
    * Whether to add readable names to internal variables for profiling purposes.
    *
    * When enabled, generated code will use descriptive variable names that correspond

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -31,7 +31,10 @@ import { bindingifyPlugin } from '../plugin/bindingify-plugin';
 import { PluginContextData } from '../plugin/plugin-context-data';
 import { arraify } from './misc';
 import { normalizedStringOrRegex } from './normalize-string-or-regex';
-import { normalizeTransformOptions } from './normalize-transform-options';
+import {
+  type NormalizedTransformOptions,
+  normalizeTransformOptions,
+} from './normalize-transform-options';
 
 export function bindingifyInputOptions(
   rawPlugins: RolldownPlugin[],
@@ -249,7 +252,7 @@ function bindingifyResolve(
 }
 
 function bindingifyInject(
-  inject: InputOptions['inject'],
+  inject: NormalizedTransformOptions['inject'],
 ): BindingInputOptions['inject'] {
   if (inject) {
     return Object.entries(inject).map(

--- a/packages/rolldown/src/utils/normalize-transform-options.ts
+++ b/packages/rolldown/src/utils/normalize-transform-options.ts
@@ -1,14 +1,10 @@
 import type { TransformOptions as OxcTransformOptions } from '../binding.cjs';
 import type { LogHandler } from '../log/log-handler';
 import { LOG_LEVEL_WARN } from '../log/logging';
-import {
-  logDeprecatedDefine,
-  logDeprecatedDropLabels,
-  logDeprecatedInject,
-} from '../log/logs';
+import { logDeprecatedDropLabels } from '../log/logs';
 import type { InputOptions } from '../options/input-options';
 
-interface NormalizedTransformOptions {
+export interface NormalizedTransformOptions {
   define: Array<[string, string]> | undefined;
   inject: Record<string, string | [string, string]> | undefined;
   dropLabels: string[] | undefined;
@@ -26,25 +22,10 @@ export function normalizeTransformOptions(
 ): NormalizedTransformOptions {
   const transform = inputOptions.transform;
 
-  // Extract define - prefer transform.define over top-level define
-  let define: Array<[string, string]> | undefined;
-  if (transform?.define) {
-    define = Object.entries(transform.define);
-  } else if (inputOptions.define) {
-    // Warn about deprecated top-level define
-    onLog(LOG_LEVEL_WARN, logDeprecatedDefine());
-    define = Object.entries(inputOptions.define);
-  }
-
-  // Extract inject - prefer transform.inject over top-level inject
-  let inject: Record<string, string | [string, string]> | undefined;
-  if (transform?.inject) {
-    inject = transform.inject;
-  } else if (inputOptions.inject) {
-    // Warn about deprecated top-level inject
-    onLog(LOG_LEVEL_WARN, logDeprecatedInject());
-    inject = inputOptions.inject;
-  }
+  const define = transform?.define
+    ? Object.entries(transform.define)
+    : undefined;
+  const inject = transform?.inject;
 
   // Extract dropLabels - prefer transform.dropLabels over top-level dropLabels
   let dropLabels: string[] | undefined;

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -196,12 +196,18 @@ const TransformOptionsSchema = v.object({
     v.optional(v.union([v.string(), v.array(v.string())])),
     v.description('The JavaScript target environment'),
   ),
-  define: v.optional(v.record(v.string(), v.string())),
-  inject: v.optional(
-    v.record(
-      v.string(),
-      v.union([v.string(), v.tuple([v.string(), v.string()])]),
+  define: v.pipe(
+    v.optional(v.record(v.string(), v.string())),
+    v.description('Define global variables'),
+  ),
+  inject: v.pipe(
+    v.optional(
+      v.record(
+        v.string(),
+        v.union([v.string(), v.tuple([v.string(), v.string()])]),
+      ),
     ),
+    v.description('Inject import statements on demand'),
   ),
   dropLabels: v.pipe(
     v.optional(v.array(v.string())),
@@ -552,16 +558,6 @@ const InputOptionsSchema = v.strictObject({
       nativeMagicString: v.optional(v.boolean()),
     }),
   ),
-  define: v.pipe(
-    v.optional(v.record(v.string(), v.string())),
-    v.description('Define global variables'),
-  ),
-  inject: v.optional(
-    v.record(
-      v.string(),
-      v.union([v.string(), v.tuple([v.string(), v.string()])]),
-    ),
-  ),
   profilerNames: v.optional(v.boolean()),
   transform: v.optional(TransformOptionsSchema),
   watch: v.optional(v.union([WatchOptionsSchema, v.literal(false)])),
@@ -609,10 +605,6 @@ const InputCliOverrideSchema = v.strictObject({
     v.description(
       'Comma-separated list of module ids to exclude from the bundle `<module-id>,...`',
     ),
-  ),
-  inject: v.pipe(
-    v.optional(v.record(v.string(), v.string())),
-    v.description('Inject import statements on demand'),
   ),
   treeshake: v.pipe(
     v.optional(v.boolean()),

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -44,7 +44,6 @@ OPTIONS
   --css-entry-file-names <css-entry-file-names>Name pattern for emitted css entry chunks.
   --cwd <cwd>                 Current working directory.
   --debug.session-id <debug.session-id>Used to name the build.
-  --define <define>           Define global variables.
   --drop-labels <drop-labels> Remove labeled statements with these label names.
   --entry-file-names <name>   Name pattern for emitted entry chunks.
   --environment <environment> Pass additional settings to the config file via process.ENV.
@@ -56,7 +55,6 @@ OPTIONS
   --generated-code.profiler-names Whether to add readable names to internal variables for profiling purposes.
   --generated-code.symbols    Whether to use Symbol.toStringTag for namespace objects.
   --hash-characters <hash-characters>Use the specified character set for file hashes.
-  --inject <inject>           Inject import statements on demand.
   --inline-dynamic-imports    Inline dynamic imports.
   --input <input>             Entry file.
   --intro <intro>             Code to insert the top of the bundled file (inside the wrapper function).
@@ -88,10 +86,10 @@ OPTIONS
   --transform.assumptions.set-public-class-fields .
   --transform.decorators.emit-decorator-metadata .
   --transform.decorators.legacy .
-  --transform.define <transform.define>.
+  --transform.define <transform.define>Define global variables.
   --transform.drop-labels <transform.drop-labels>Remove labeled statements with these label names.
   --transform.helpers.mode <transform.helpers.mode>.
-  --transform.inject <transform.inject>.
+  --transform.inject <transform.inject>Inject import statements on demand.
   --transform.jsx <transform.jsx>.
   --transform.target <transform.target>The JavaScript target environment.
   --transform.typescript.allow-declare-fields .

--- a/packages/rolldown/tests/fixtures/function/define/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/define/_config.ts
@@ -4,8 +4,10 @@ import { expect } from 'vitest';
 
 export default defineTest({
   config: {
-    define: {
-      'process.env.NODE_ENV': '"production"',
+    transform: {
+      define: {
+        'process.env.NODE_ENV': '"production"',
+      },
     },
     external: ['node:assert'],
   },

--- a/packages/rolldown/tests/fixtures/function/inject/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/inject/_config.ts
@@ -4,16 +4,18 @@ import { expect } from 'vitest';
 
 export default defineTest({
   config: {
-    inject: {
-      // import { Promise } from './promise-shim'
-      Promise: ['./promise-shim', 'Promise'],
-      // import { Promise as P } from './promise-shim'
-      P: ['./promise-shim', 'Promise'],
-      // import $ from 'jquery'
-      $: './jquery',
-      // import * as fs from 'node:fs'
-      fs: ['./node-fs', '*'],
-      'Object.assign': './object-assign-shim',
+    transform: {
+      inject: {
+        // import { Promise } from './promise-shim'
+        Promise: ['./promise-shim', 'Promise'],
+        // import { Promise as P } from './promise-shim'
+        P: ['./promise-shim', 'Promise'],
+        // import $ from 'jquery'
+        $: './jquery',
+        // import * as fs from 'node:fs'
+        fs: ['./node-fs', '*'],
+        'Object.assign': './object-assign-shim',
+      },
     },
     external: ['node:assert'],
   },


### PR DESCRIPTION
These two options were deprecated around a month ago (#6544) since 1.0.0-beta.44.