### PR TITLE
refactor!: remove deprecated top-level `profilerNames` option

### DIFF
--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -10,7 +10,6 @@ const INVALID_LOG_POSITION = 'INVALID_LOG_POSITION',
   MULTIPLY_NOTIFY_OPTION = 'MULTIPLY_NOTIFY_OPTION',
   PARSE_ERROR = 'PARSE_ERROR',
   NO_FS_IN_BROWSER = 'NO_FS_IN_BROWSER',
-  DEPRECATED_PROFILER_NAMES = 'DEPRECATED_PROFILER_NAMES',
   DEPRECATED_KEEP_NAMES = 'DEPRECATED_KEEP_NAMES',
   DEPRECATED_DROP_LABELS = 'DEPRECATED_DROP_LABELS';
 
@@ -64,14 +63,6 @@ export function logNoFileSystemInBrowser(method: string): RollupLog {
     code: NO_FS_IN_BROWSER,
     message:
       `Cannot access the file system (via "${method}") when using the browser build of Rolldown.`,
-  };
-}
-
-export function logDeprecatedProfilerNames(): RollupLog {
-  return {
-    code: DEPRECATED_PROFILER_NAMES,
-    message:
-      'The top-level "profilerNames" option is deprecated. Use "output.generatedCode.profilerNames" instead.',
   };
 }
 

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -316,17 +316,6 @@ export interface InputOptions {
     nativeMagicString?: boolean;
   };
   /**
-   * Whether to add readable names to internal variables for profiling purposes.
-   *
-   * When enabled, generated code will use descriptive variable names that correspond
-   * to the original module names, making it easier to profile and debug the bundled code.
-   *
-   * @default true when minification is disabled, false when minification is enabled
-   *
-   * @deprecated Use `output.generatedCode.profilerNames` instead. This top-level option will be removed in a future release.
-   */
-  profilerNames?: boolean;
-  /**
    * Configure how the code is transformed. This process happens after the `transform` hook.
    *
    * To transpile [legacy decorators](https://github.com/tc39/proposal-decorators/tree/4ac0f4cd31bd0f2e8170cb4c5136e51671e46c8d), you could use
@@ -402,7 +391,6 @@ export type InputCliOptions =
     | 'onLog'
     | 'resolve'
     | 'experimental'
-    | 'profilerNames'
     | 'watch'
   >
   & OverwriteInputOptionsForCli;

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -16,10 +16,7 @@ import { BuiltinPlugin } from '../builtin-plugin/utils';
 import { bindingifyBuiltInPlugin } from '../builtin-plugin/utils';
 import type { LogHandler } from '../log/log-handler';
 import { LOG_LEVEL_WARN, type LogLevelOption } from '../log/logging';
-import {
-  logDeprecatedKeepNames,
-  logDeprecatedProfilerNames,
-} from '../log/logs';
+import { logDeprecatedKeepNames } from '../log/logs';
 import type {
   AttachDebugOptions,
   HmrOptions,
@@ -73,16 +70,6 @@ export function bindingifyInputOptions(
   // Normalize transform options to extract define, inject, and oxc transform options
   const normalizedTransform = normalizeTransformOptions(inputOptions, onLog);
 
-  // Normalize profilerNames - prefer output.generatedCode.profilerNames over top-level profilerNames
-  let profilerNames: boolean | undefined;
-  if (outputOptions.generatedCode?.profilerNames !== undefined) {
-    profilerNames = outputOptions.generatedCode.profilerNames;
-  } else if (inputOptions.profilerNames !== undefined) {
-    // Warn about deprecated top-level profilerNames
-    onLog(LOG_LEVEL_WARN, logDeprecatedProfilerNames());
-    profilerNames = inputOptions.profilerNames;
-  }
-
   // Normalize keepNames - prefer output.keepNames over top-level keepNames
   let keepNames: boolean | undefined;
   if (outputOptions.keepNames !== undefined) {
@@ -112,7 +99,7 @@ export function bindingifyInputOptions(
     define: normalizedTransform.define,
     inject: bindingifyInject(normalizedTransform.inject),
     experimental: bindingifyExperimental(inputOptions.experimental),
-    profilerNames,
+    profilerNames: outputOptions.generatedCode?.profilerNames,
     transform: normalizedTransform.oxcTransformOptions,
     watch: bindingifyWatch(inputOptions.watch),
     dropLabels: normalizedTransform.dropLabels,

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -558,7 +558,6 @@ const InputOptionsSchema = v.strictObject({
       nativeMagicString: v.optional(v.boolean()),
     }),
   ),
-  profilerNames: v.optional(v.boolean()),
   transform: v.optional(TransformOptionsSchema),
   watch: v.optional(v.union([WatchOptionsSchema, v.literal(false)])),
   dropLabels: v.pipe(
@@ -635,7 +634,6 @@ const InputCliOptionsSchema = v.omit(
     'onLog',
     'resolve',
     'experimental',
-    'profilerNames',
     'watch',
   ],
 );


### PR DESCRIPTION
This option was deprecated around a month ago (#6555) since 1.0.0-beta.44.