### PR TITLE
refactor!: remove deprecated top-level `keepNames` option

### DIFF
--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -10,7 +10,6 @@ const INVALID_LOG_POSITION = 'INVALID_LOG_POSITION',
   MULTIPLY_NOTIFY_OPTION = 'MULTIPLY_NOTIFY_OPTION',
   PARSE_ERROR = 'PARSE_ERROR',
   NO_FS_IN_BROWSER = 'NO_FS_IN_BROWSER',
-  DEPRECATED_KEEP_NAMES = 'DEPRECATED_KEEP_NAMES',
   DEPRECATED_DROP_LABELS = 'DEPRECATED_DROP_LABELS';
 
 export function logParseError(message: string): RollupLog {
@@ -63,14 +62,6 @@ export function logNoFileSystemInBrowser(method: string): RollupLog {
     code: NO_FS_IN_BROWSER,
     message:
       `Cannot access the file system (via "${method}") when using the browser build of Rolldown.`,
-  };
-}
-
-export function logDeprecatedKeepNames(): RollupLog {
-  return {
-    code: DEPRECATED_KEEP_NAMES,
-    message:
-      'The top-level "keepNames" option is deprecated. Use "output.keepNames" instead.',
   };
 }
 

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -342,14 +342,6 @@ export interface InputOptions {
    * See `transform.dropLabels` for detailed documentation and examples.
    */
   dropLabels?: string[];
-  /**
-   * Keep function and class names after bundling.
-   *
-   * @deprecated Use `output.keepNames` instead. This top-level option will be removed in a future release.
-   *
-   * See `output.keepNames` for detailed documentation.
-   */
-  keepNames?: boolean;
   checks?: ChecksOptions;
   makeAbsoluteExternalsRelative?: MakeAbsoluteExternalsRelative;
   debug?: {

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -15,8 +15,7 @@ import type {
 import { BuiltinPlugin } from '../builtin-plugin/utils';
 import { bindingifyBuiltInPlugin } from '../builtin-plugin/utils';
 import type { LogHandler } from '../log/log-handler';
-import { LOG_LEVEL_WARN, type LogLevelOption } from '../log/logging';
-import { logDeprecatedKeepNames } from '../log/logs';
+import type { LogLevelOption } from '../log/logging';
 import type {
   AttachDebugOptions,
   HmrOptions,
@@ -70,16 +69,6 @@ export function bindingifyInputOptions(
   // Normalize transform options to extract define, inject, and oxc transform options
   const normalizedTransform = normalizeTransformOptions(inputOptions, onLog);
 
-  // Normalize keepNames - prefer output.keepNames over top-level keepNames
-  let keepNames: boolean | undefined;
-  if (outputOptions.keepNames !== undefined) {
-    keepNames = outputOptions.keepNames;
-  } else if (inputOptions.keepNames !== undefined) {
-    // Warn about deprecated top-level keepNames
-    onLog(LOG_LEVEL_WARN, logDeprecatedKeepNames());
-    keepNames = inputOptions.keepNames;
-  }
-
   return {
     input: bindingifyInput(inputOptions.input),
     plugins,
@@ -103,7 +92,7 @@ export function bindingifyInputOptions(
     transform: normalizedTransform.oxcTransformOptions,
     watch: bindingifyWatch(inputOptions.watch),
     dropLabels: normalizedTransform.dropLabels,
-    keepNames,
+    keepNames: outputOptions.keepNames,
     checks: inputOptions.checks,
     deferSyncScanData: () => {
       let ret: BindingDeferSyncScanData[] = [];

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -565,10 +565,6 @@ const InputOptionsSchema = v.strictObject({
     v.description('Remove labeled statements with these label names'),
   ),
   checks: v.optional(ChecksOptionsSchema),
-  keepNames: v.pipe(
-    v.optional(v.boolean()),
-    v.description('Keep function/class name'),
-  ),
   debug: v.pipe(
     v.optional(v.object({
       sessionId: v.pipe(

--- a/packages/rolldown/tests/fixtures/misc/keep-names/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/keep-names/basic/_config.ts
@@ -2,8 +2,10 @@ import { defineTest } from 'rolldown-tests';
 
 export default defineTest({
   config: {
-    keepNames: true,
     external: ['node:assert'],
+    output: {
+      keepNames: true,
+    },
   },
   afterTest: async () => {
     await import('./assert.mjs');


### PR DESCRIPTION
This option was deprecated around a month ago (#6556) since 1.0.0-beta.44.