### PR TITLE
refactor!: remove deprecated top-level `dropLabels` option

### DIFF
--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -1,5 +1,4 @@
 import { getCodeFrame } from '../utils/code-frame';
-import { styleText } from '../utils/style-text';
 import { locate } from './locate-character';
 import type { RollupLog } from './logging';
 
@@ -9,8 +8,7 @@ const INVALID_LOG_POSITION = 'INVALID_LOG_POSITION',
   CYCLE_LOADING = 'CYCLE_LOADING',
   MULTIPLY_NOTIFY_OPTION = 'MULTIPLY_NOTIFY_OPTION',
   PARSE_ERROR = 'PARSE_ERROR',
-  NO_FS_IN_BROWSER = 'NO_FS_IN_BROWSER',
-  DEPRECATED_DROP_LABELS = 'DEPRECATED_DROP_LABELS';
+  NO_FS_IN_BROWSER = 'NO_FS_IN_BROWSER';
 
 export function logParseError(message: string): RollupLog {
   return {
@@ -62,15 +60,6 @@ export function logNoFileSystemInBrowser(method: string): RollupLog {
     code: NO_FS_IN_BROWSER,
     message:
       `Cannot access the file system (via "${method}") when using the browser build of Rolldown.`,
-  };
-}
-
-export function logDeprecatedDropLabels(): RollupLog {
-  return {
-    code: DEPRECATED_DROP_LABELS,
-    message: `${
-      styleText(['yellow', 'bold'], '⚠ Deprecation Warning:')
-    } The top-level "dropLabels" option is deprecated. Use "transform.dropLabels" instead.`,
   };
 }
 

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -334,14 +334,6 @@ export interface InputOptions {
    */
   transform?: TransformOptions;
   watch?: WatcherOptions | false;
-  /**
-   * Remove labeled statements with these label names.
-   *
-   * @deprecated Use `transform.dropLabels` instead. This top-level option will be removed in a future release.
-   *
-   * See `transform.dropLabels` for detailed documentation and examples.
-   */
-  dropLabels?: string[];
   checks?: ChecksOptions;
   makeAbsoluteExternalsRelative?: MakeAbsoluteExternalsRelative;
   debug?: {

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -67,7 +67,7 @@ export function bindingifyInputOptions(
   });
 
   // Normalize transform options to extract define, inject, and oxc transform options
-  const normalizedTransform = normalizeTransformOptions(inputOptions, onLog);
+  const normalizedTransform = normalizeTransformOptions(inputOptions);
 
   return {
     input: bindingifyInput(inputOptions.input),

--- a/packages/rolldown/src/utils/normalize-transform-options.ts
+++ b/packages/rolldown/src/utils/normalize-transform-options.ts
@@ -1,7 +1,4 @@
 import type { TransformOptions as OxcTransformOptions } from '../binding.cjs';
-import type { LogHandler } from '../log/log-handler';
-import { LOG_LEVEL_WARN } from '../log/logging';
-import { logDeprecatedDropLabels } from '../log/logs';
 import type { InputOptions } from '../options/input-options';
 
 export interface NormalizedTransformOptions {
@@ -18,7 +15,6 @@ export interface NormalizedTransformOptions {
  */
 export function normalizeTransformOptions(
   inputOptions: InputOptions,
-  onLog: LogHandler,
 ): NormalizedTransformOptions {
   const transform = inputOptions.transform;
 
@@ -26,16 +22,7 @@ export function normalizeTransformOptions(
     ? Object.entries(transform.define)
     : undefined;
   const inject = transform?.inject;
-
-  // Extract dropLabels - prefer transform.dropLabels over top-level dropLabels
-  let dropLabels: string[] | undefined;
-  if (transform?.dropLabels) {
-    dropLabels = transform.dropLabels;
-  } else if (inputOptions.dropLabels) {
-    // Warn about deprecated top-level dropLabels
-    onLog(LOG_LEVEL_WARN, logDeprecatedDropLabels());
-    dropLabels = inputOptions.dropLabels;
-  }
+  const dropLabels = transform?.dropLabels;
 
   // Extract OXC transform options (excluding define, inject, and dropLabels)
   let oxcTransformOptions: OxcTransformOptions | undefined;

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -560,10 +560,6 @@ const InputOptionsSchema = v.strictObject({
   ),
   transform: v.optional(TransformOptionsSchema),
   watch: v.optional(v.union([WatchOptionsSchema, v.literal(false)])),
-  dropLabels: v.pipe(
-    v.optional(v.array(v.string())),
-    v.description('Remove labeled statements with these label names'),
-  ),
   checks: v.optional(ChecksOptionsSchema),
   debug: v.pipe(
     v.optional(v.object({

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -44,7 +44,6 @@ OPTIONS
   --css-entry-file-names <css-entry-file-names>Name pattern for emitted css entry chunks.
   --cwd <cwd>                 Current working directory.
   --debug.session-id <debug.session-id>Used to name the build.
-  --drop-labels <drop-labels> Remove labeled statements with these label names.
   --entry-file-names <name>   Name pattern for emitted entry chunks.
   --environment <environment> Pass additional settings to the config file via process.ENV.
   --es-module                 Always generate \`__esModule\` marks in non-ESM formats, defaults to \`if-default-prop\` (use \`--no-esModule\` to always disable).

--- a/packages/rolldown/tests/fixtures/misc/drop-labels/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/drop-labels/basic/_config.ts
@@ -3,7 +3,9 @@ import { expect } from 'vitest';
 
 export default defineTest({
   config: {
-    dropLabels: ['DROP'],
+    transform: {
+      dropLabels: ['DROP'],
+    },
   },
   afterTest: (output) => {
     expect(output.output[0].code).not.toContain('DROP');


### PR DESCRIPTION
This option was deprecated around a month ago (#6557) since 1.0.0-beta.44.

close #6545
