### PR TITLE
chore(build.ts): separate import type

### DIFF
--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -6,7 +6,8 @@ import { dts } from 'rolldown-plugin-dts';
 import * as ts from 'typescript';
 
 import { CopyAddonPlugin } from './copy-addon-plugin';
-import { build, BuildOptions, type Plugin } from './src/index';
+import type { Plugin } from './src/index';
+import { build, BuildOptions } from './src/index';
 import { styleText } from './src/utils/style-text';
 
 const __dirname = nodePath.join(fileURLToPath(import.meta.url), '..');


### PR DESCRIPTION
I think it is always better to separate type-only imports. 