### PR TITLE
docs: add sitemap

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -199,6 +199,9 @@ export default defineConfig({
     'Fast Rust-based bundler for JavaScript with Rollup-compatible API',
   lastUpdated: true,
   cleanUrls: true,
+  sitemap: {
+    hostname: 'https://rolldown.rs',
+  },
   head: [
     [
       'link',


### PR DESCRIPTION
Adds sitemap Rolldown docs. 

Helps search engines, like Google, crawl and index Rolldown content more efficiently