### PR TITLE
feat(rolldown): oxc v0.97.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "oxc"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2de9d29ee93972a681161c620c428c87adc2137d8bdd0c010eb076251e8c474"
+checksum = "ba56f4785aa7c8075ac45235af88329d2168eafcd812548c509421d19f3f8e43"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1816,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ef2dba21be1ce515378b2b7143eaa2a912f9e6ffe162ae20639d56f53d60e3"
+checksum = "9500e5c4bf57e65f931518201a55658fa639a2b923e01a6467c82e18ef9dfdc2"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -1831,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad9195311a1961bb6ef1de0ce6a52147bccea50b5a40423b7b44e8448ed4fc"
+checksum = "73849bfea33c22b17c365cc032dc31132d1314a9afd54b9db7285d2660143ea3"
 dependencies = [
  "bitflags 2.10.0",
  "oxc_allocator",
@@ -1848,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f03da6fac191c0817a32ae1a7dde27fd27d98732c61fcaeb55a99a4d543ba49"
+checksum = "bc1b9a1ee12c5369a515460e7e4b2066e4b6249a1469394aa93dd0aa7f940387"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1860,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42fcdb162d247a0e9c1aa985b388f000eba19fb1ee1845b2ec0ddc595f95131"
+checksum = "5aafd28e1091e4ac2e257b7ee2da3e2368b5d10115b5c91553cfe13d8838b497"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1872,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388f6e0dd1a825de3a11d94af540726539cccd428651fee3bab841da196549d4"
+checksum = "e9ffc821c265cc43b38fd0bec67f01e22e95ccfb597fd7384b4d6479894cf39e"
 dependencies = [
  "bitflags 2.10.0",
  "itertools",
@@ -1886,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c9a53ca79c87846e4f2b4f3df514b0b2bf910a1ba76a9e8cb742570b8b47ce"
+checksum = "6ec5fe3835930195cd5a3362aa9559370ed8ce1aaf8f65d992dbb999075a6a68"
 dependencies = [
  "bitflags 2.10.0",
  "cow-utils",
@@ -1907,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_compat"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271a875e3e9e1f6d259c99e0557fcc83d96b025ddfca40e215d6bbb58bae9d45"
+checksum = "b73638911c4624a0f4fbbde909adc6ba4c0f3ed0666b8df349b15e04b5d12a0c"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1920,18 +1920,18 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f5171d7b8bc907a1b29e557d14f8478509a2154272d56db9ee8aed6bfe8dec"
+checksum = "0f6fb764c02ba8fd4b5a63fe35ec0d96b326a8a5a5ddd4251baea1d2b0c4f777"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef2bf6a713fd27bc65812d695bdfde3f8fcef735f00b861258518346642721b"
+checksum = "6fd4d6311ab059f5a70bcb2ec03c156086242f4f5a8ed44fb59c6e4d1c89d98f"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1940,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f908100cb2759dd2f42ca33d95ea158b8d78e2591b577757729fc9a4a4c63bc3"
+checksum = "7371190f03d3de13c8c5123cb0aba670690b22fde2e068ee385caacd9e5b1e0f"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5644d3399116ff3f0cfb81f9a790c4b8173b504ed52274ecc757b57f30098ad1"
+checksum = "5e9149fe7697266369e9fa081970c13165a78e6c600ff95fb99202dacc518199"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1977,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a7b1c97cb29091217c319843518202aaade72978eca5ef8bb374e8c78d3ae3"
+checksum = "7056d5f8dca0c235c0d0f65bb2535939b0b0001ab42316eeb71cddbcb1f49fe4"
 dependencies = [
  "bitflags 2.10.0",
  "oxc_allocator",
@@ -1994,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3695e3b0694093d24f0f7c8b77dc36b1a4b55020bf52166271010c8095bba5"
+checksum = "a87f6565b64cacbecebe68996f2bf15877058fd792fdf09bb6ad778ea1ab2fa6"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2011,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d4f7493209202a6d2824a1d18a3bced22c7e6a32b9b0f41d718dc090fa4dc"
+checksum = "aba67ad01f927ba0bb33c9f907ae388920cae4e3404b265164b01d1471396c89"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_minify_napi"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9004a0c99d2183f7034826147c739e7cc77539cb3335148bd85ff1943e4bf338"
+checksum = "a179fc8ea999bcda69986f57eaabb5ab664577e463faf1ca6ec3258d0f406c47"
 dependencies = [
  "napi",
  "napi-build",
@@ -2056,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_napi"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6e28e16dc42fcf697d521c3255db4849d101483023cc3610e47bf34eadab8d"
+checksum = "8a7dd3332729c1c8ac066e1d289743b748ad7f3a8c526578ea207691a2ee4c79"
 dependencies = [
  "napi",
  "napi-build",
@@ -2072,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e080498b7a4456a63111f9c65b4dd1b98147955347854b809b6ad4cc5d6a0c0a"
+checksum = "324174a2bc9857a6ad9bc62f6b99889416c6ff133d65af67d875ba83103013a3"
 dependencies = [
  "bitflags 2.10.0",
  "cow-utils",
@@ -2095,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser_napi"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bcc99d098732dd900208c8b00640cf76bbcdfa8bc113bb023b028acefc66f8"
+checksum = "5c032d046de9f77fb3499ef7fd4ed0b6e10893e1395da667e85e7bcb83ec278d"
 dependencies = [
  "napi",
  "napi-build",
@@ -2111,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb87ab0b072e1e97d8101cb1678204bc3873d84f13255ae5aa088f1b85f7a8e1"
+checksum = "1896674a4e31a5332c7b57326c6327336a4848c1dc7d274658c3c86ad2be4100"
 dependencies = [
  "bitflags 2.10.0",
  "oxc_allocator",
@@ -2165,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56958658ca1f9f5f050dc4317821255d2ca132763b6fbee9227e45ef79ed173"
+checksum = "5c89cb4832fc494cd784154deaae4cbf1e8cd81a3f522c9046f18b516089dcf4"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2203,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41422232cfd9915d31dbb76ba2e5ae212884cad232e37203bdcb15bd1466951d"
+checksum = "b01d164645225a9e927de494609b1d981f0a828e4456e0caad097541ff9b81b5"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -2217,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea81736f2343df141c7d8de78a91d155be4f712dfa6cd1bdd9a8b4f0676f01f"
+checksum = "67543e785d7f4506ac4e95c90d7a6562be5a0c1e37e446a9d6fe6dd94d971f9e"
 dependencies = [
  "bitflags 2.10.0",
  "cow-utils",
@@ -2238,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transform_napi"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42feae105b89bcda4f025715bb722052aab4d7b62a04b50d29b5565d2f1a6afa"
+checksum = "5acddbfa0f9570a4a6c31a01a15ab2c5945e6391a255179100b96f9d974709f2"
 dependencies = [
  "napi",
  "napi-build",
@@ -2253,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6aee257a9750a3beeb8124f1fffcc3a5c2623ac2e36e851fbab8da339e9263"
+checksum = "40c7e4a23b87895f1c144eae7f818edfc82573539ea4d9ba92bd1e64662d1d52"
 dependencies = [
  "base64",
  "compact_str",
@@ -2283,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38addf2f866a14a53c3e937b248429f717546da230be59f35664ecfc3a6aea07"
+checksum = "75c0a692d3224b5dc87fea2b69505486e2079f9a013307416ad9d51e9db2244a"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2305,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcbcda1412b43a921856314e2984cb9282f0d23c1439ae21bd5879110e01681"
+checksum = "bbf212ba99e891138336305be01047e9406bc0898671bf41c13a6fc075a4aa38"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,13 +215,13 @@ napi-build = { version = "2.2.2" }
 napi-derive = { version = "3.0.0", default-features = false, features = ["type-def"] }
 
 # oxc crates with the same version
-oxc = { version = "0.96.0", features = ["ast_visit", "transformer", "minifier", "mangler", "semantic", "codegen", "serialize", "isolated_declarations", "regular_expression", "cfg"] }
-oxc_allocator = { version = "0.96.0", features = ["pool"] }
-oxc_ecmascript = { version = "0.96.0" }
-oxc_minify_napi = { version = "0.96.0" }
-oxc_parser_napi = { version = "0.96.0" }
-oxc_transform_napi = { version = "0.96.0" }
-oxc_traverse = { version = "0.96.0" }
+oxc = { version = "0.97.0", features = ["ast_visit", "transformer", "minifier", "mangler", "semantic", "codegen", "serialize", "isolated_declarations", "regular_expression", "cfg"] }
+oxc_allocator = { version = "0.97.0", features = ["pool"] }
+oxc_ecmascript = { version = "0.97.0" }
+oxc_minify_napi = { version = "0.97.0" }
+oxc_parser_napi = { version = "0.97.0" }
+oxc_transform_napi = { version = "0.97.0" }
+oxc_traverse = { version = "0.97.0" }
 
 # oxc crates in their own repos
 # Versions must be relaxed for usage in oxc.

--- a/crates/rolldown/tests/esbuild/default/require_bad_extension/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/require_bad_extension/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Errors
 
@@ -14,7 +13,7 @@ snapshot_kind: text
    │     │ 
    │     ╰─ 
    │ 
-   │ Help: Try insert a semicolon here
+   │ Help: Try inserting a semicolon here
 ───╯
 
 ```

--- a/crates/rolldown/tests/esbuild/loader/with_type_json_override_loader/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/with_type_json_override_loader/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Errors
 
@@ -14,7 +13,7 @@ snapshot_kind: text
    │                        │ 
    │                        ╰─ 
    │ 
-   │ Help: Try insert a semicolon here
+   │ Help: Try inserting a semicolon here
 ───╯
 
 ```

--- a/crates/rolldown/tests/esbuild/lower/lower_using/_config.json
+++ b/crates/rolldown/tests/esbuild/lower/lower_using/_config.json
@@ -15,5 +15,7 @@
       }
     ]
   },
-  "expectExecuted": false
+  "expectExecuted": false,
+  "_comment": "expectError is true because of https://github.com/evanw/esbuild/issues/4323",
+  "expectError": true
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_using/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_using/artifacts.snap
@@ -1,64 +1,124 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# Assets
+# Errors
 
-## entry.js
+## PARSE_ERROR
 
-```js
-//#region entry.js
-using a = b;
-await using c = d;
-if (nested) {
-	using x = 1;
-	await using y = 2;
-}
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:14:11 ]
+    │
+ 14 │        case 0: using c = d
+    │                ─────┬─────  
+    │                     ╰─────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
 
-//#endregion
 ```
 
-## loops.js
+## PARSE_ERROR
 
-```js
-//#region loops.js
-for (using a of b) c(() => a);
-for (await using d of e) f(() => d);
-for await (using g of h) i(() => g);
-for await (await using j of k) l(() => j);
-if (nested) {
-	for (using a of b) c(() => a);
-	for (await using d of e) f(() => d);
-	for await (using g of h) i(() => g);
-	for await (await using j of k) l(() => j);
-}
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:15:12 ]
+    │
+ 15 │        default: using e = f
+    │                 ─────┬─────  
+    │                      ╰─────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
 
-//#endregion
 ```
 
-## switch.js
+## PARSE_ERROR
 
-```js
-//#region switch.js
-using x = y;
-switch (foo) {
-	case 0: using c = d;
-	default: using e = f;
-}
-switch (foo) {
-	case 0: await using c = d;
-	default: using e = f;
-}
-async function foo() {
-	using x$1 = y;
-	switch (foo) {
-		case 0: using c = d;
-		default: using e = f;
-	}
-	switch (foo) {
-		case 0: await using c = d;
-		default: using e = f;
-	}
-}
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:18:11 ]
+    │
+ 18 │        case 0: await using c = d
+    │                ────────┬────────  
+    │                        ╰────────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
 
-//#endregion
+```
+
+## PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:19:12 ]
+    │
+ 19 │        default: using e = f
+    │                 ─────┬─────  
+    │                      ╰─────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
+
+```
+
+## PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+   ╭─[ switch.js:3:10 ]
+   │
+ 3 │     case 0: using c = d
+   │             ─────┬─────  
+   │                  ╰─────── 
+   │ 
+   │ Help: Wrap this declaration in a block statement
+───╯
+
+```
+
+## PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+   ╭─[ switch.js:4:11 ]
+   │
+ 4 │     default: using e = f
+   │              ─────┬─────  
+   │                   ╰─────── 
+   │ 
+   │ Help: Wrap this declaration in a block statement
+───╯
+
+```
+
+## PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+   ╭─[ switch.js:7:10 ]
+   │
+ 7 │     case 0: await using c = d
+   │             ────────┬────────  
+   │                     ╰────────── 
+   │ 
+   │ Help: Wrap this declaration in a block statement
+───╯
+
+```
+
+## PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+   ╭─[ switch.js:8:11 ]
+   │
+ 8 │     default: using e = f
+   │              ─────┬─────  
+   │                   ╰─────── 
+   │ 
+   │ Help: Wrap this declaration in a block statement
+───╯
+
 ```

--- a/crates/rolldown/tests/esbuild/lower/lower_using_unsupported_async/_config.json
+++ b/crates/rolldown/tests/esbuild/lower/lower_using_unsupported_async/_config.json
@@ -15,5 +15,7 @@
       }
     ]
   },
-  "expectExecuted": false
+  "expectExecuted": false,
+  "_comment": "expectError is true because of https://github.com/evanw/esbuild/issues/4323",
+  "expectError": true
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_using_unsupported_async/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_using_unsupported_async/artifacts.snap
@@ -1,44 +1,94 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# Assets
+# Errors
 
-## entry.js
+## PARSE_ERROR
 
-```js
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:10:11 ]
+    │
+ 10 │        case 0: using c = d
+    │                ─────┬─────  
+    │                     ╰─────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
 
 ```
 
-## loops.js
+## PARSE_ERROR
 
-```js
-//#region loops.js
-for (using a of b) c(() => a);
-if (nested) for (using a of b) c(() => a);
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:11:12 ]
+    │
+ 11 │        default: using e = f
+    │                 ─────┬─────  
+    │                      ╰─────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
 
-//#endregion
 ```
 
-## switch.js
+## PARSE_ERROR
 
-```js
-//#region switch.js
-using x = y;
-switch (foo) {
-	case 0: using c = d;
-	default: using e = f;
-}
-async function foo() {
-	using x$1 = y;
-	switch (foo) {
-		case 0: using c = d;
-		default: using e = f;
-	}
-	switch (foo) {
-		case 0: await using c = d;
-		default: using e = f;
-	}
-}
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:14:11 ]
+    │
+ 14 │        case 0: await using c = d
+    │                ────────┬────────  
+    │                        ╰────────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
 
-//#endregion
+```
+
+## PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:15:12 ]
+    │
+ 15 │        default: using e = f
+    │                 ─────┬─────  
+    │                      ╰─────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
+
+```
+
+## PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+   ╭─[ switch.js:3:10 ]
+   │
+ 3 │     case 0: using c = d
+   │             ─────┬─────  
+   │                  ╰─────── 
+   │ 
+   │ Help: Wrap this declaration in a block statement
+───╯
+
+```
+
+## PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+   ╭─[ switch.js:4:11 ]
+   │
+ 4 │     default: using e = f
+   │              ─────┬─────  
+   │                   ╰─────── 
+   │ 
+   │ Help: Wrap this declaration in a block statement
+───╯
+
 ```

--- a/crates/rolldown/tests/esbuild/lower/lower_using_unsupported_using_and_async/_config.json
+++ b/crates/rolldown/tests/esbuild/lower/lower_using_unsupported_using_and_async/_config.json
@@ -15,5 +15,7 @@
       }
     ]
   },
-  "expectExecuted": false
+  "expectExecuted": false,
+  "_comment": "expectError is true because of https://github.com/evanw/esbuild/issues/4323",
+  "expectError": true
 }

--- a/crates/rolldown/tests/esbuild/lower/lower_using_unsupported_using_and_async/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/lower/lower_using_unsupported_using_and_async/artifacts.snap
@@ -1,44 +1,94 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
 ---
-# Assets
+# Errors
 
-## entry.js
+## PARSE_ERROR
 
-```js
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:10:11 ]
+    │
+ 10 │        case 0: using c = d
+    │                ─────┬─────  
+    │                     ╰─────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
 
 ```
 
-## loops.js
+## PARSE_ERROR
 
-```js
-//#region loops.js
-for (using a of b) c(() => a);
-if (nested) for (using a of b) c(() => a);
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:11:12 ]
+    │
+ 11 │        default: using e = f
+    │                 ─────┬─────  
+    │                      ╰─────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
 
-//#endregion
 ```
 
-## switch.js
+## PARSE_ERROR
 
-```js
-//#region switch.js
-using x = y;
-switch (foo) {
-	case 0: using c = d;
-	default: using e = f;
-}
-async function foo() {
-	using x$1 = y;
-	switch (foo) {
-		case 0: using c = d;
-		default: using e = f;
-	}
-	switch (foo) {
-		case 0: await using c = d;
-		default: using e = f;
-	}
-}
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:14:11 ]
+    │
+ 14 │        case 0: await using c = d
+    │                ────────┬────────  
+    │                        ╰────────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
 
-//#endregion
+```
+
+## PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+    ╭─[ switch.js:15:12 ]
+    │
+ 15 │        default: using e = f
+    │                 ─────┬─────  
+    │                      ╰─────── 
+    │ 
+    │ Help: Wrap this declaration in a block statement
+────╯
+
+```
+
+## PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+   ╭─[ switch.js:3:10 ]
+   │
+ 3 │     case 0: using c = d
+   │             ─────┬─────  
+   │                  ╰─────── 
+   │ 
+   │ Help: Wrap this declaration in a block statement
+───╯
+
+```
+
+## PARSE_ERROR
+
+```text
+[PARSE_ERROR] Error: Using declaration cannot appear in the bare case statement.
+   ╭─[ switch.js:4:11 ]
+   │
+ 4 │     default: using e = f
+   │              ─────┬─────  
+   │                   ╰─────── 
+   │ 
+   │ Help: Wrap this declaration in a block statement
+───╯
+
 ```

--- a/crates/rolldown/tests/esbuild/ts/enum_rules_from_type_script_5_0/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/enum_rules_from_type_script_5_0/artifacts.snap
@@ -60,12 +60,12 @@ var Foo = /* @__PURE__ */ function(Foo$1) {
 	Foo$1["X21"] = "Infinity";
 	Foo$1["X22"] = "-Infinity";
 	Foo$1["X23"] = "0";
-	Foo$1["X24"] = "ABxC";
+	Foo$1["X24"] = "A0BxC-31246D";
 	Foo$1[Foo$1["X25"] = 321] = "X25";
 	Foo$1[Foo$1["X26"] = 123] = "X26";
 	Foo$1["X27"] = "123x";
 	Foo$1["X28"] = "x123";
-	Foo$1["X29"] = "a";
+	Foo$1["X29"] = "a123b";
 	Foo$1[Foo$1["X30"] = Foo$1.X0] = "X30";
 	Foo$1[Foo$1["X31"] = Foo$1.X0 + "x"] = "X31";
 	Foo$1[Foo$1["X32"] = "x" + Foo$1.X0] = "X32";
@@ -73,7 +73,7 @@ var Foo = /* @__PURE__ */ function(Foo$1) {
 	Foo$1["X34"] = "x";
 	Foo$1["X35"] = "xy";
 	Foo$1["X36"] = "yx";
-	Foo$1["X37"] = "ax";
+	Foo$1["X37"] = "axb";
 	Foo$1[Foo$1["X38"] = Foo$1["X1"]] = "X38";
 	Foo$1[Foo$1["X39"] = Foo$1["X1"] + "y"] = "X39";
 	Foo$1[Foo$1["X40"] = "y" + Foo$1["X1"]] = "X40";

--- a/crates/rolldown/tests/esbuild/ts/ts_import_in_node_modules_name_collision_with_css/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_in_node_modules_name_collision_with_css/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │     │ 
    │     ╰─ 
    │ 
-   │ Help: Try insert a semicolon here
+   │ Help: Try inserting a semicolon here
 ───╯
 
 ```
@@ -28,7 +28,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │     │ 
    │     ╰─ 
    │ 
-   │ Help: Try insert a semicolon here
+   │ Help: Try inserting a semicolon here
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/errors/parse_error/jsx/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/parse_error/jsx/artifacts.snap
@@ -6,12 +6,16 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## PARSE_ERROR
 
 ```text
-[PARSE_ERROR] Error: Expected `,` but found `class`
+[PARSE_ERROR] Error: Expected `,` or `)` but found `class`
    ╭─[ main.jsx:8:8 ]
    │
+ 4 │   return (
+   │          ┬  
+   │          ╰── Opened here
+   │ 
  8 │     <a class="the">
    │        ──┬──  
-   │          ╰──── `,` expected
+   │          ╰──── `,` or `)` expected
 ───╯
 
 ```
@@ -20,15 +24,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```text
 [PARSE_ERROR] Error: Expected corresponding JSX closing tag for 'b'.
-   ╭─[ main.jsx:5:6 ]
+   ╭─[ main.jsx:7:7 ]
    │
  5 │     <b>
    │      ┬  
-   │      ╰── 
+   │      ╰── Opened here
    │ 
  7 │     </a>
    │       ┬  
-   │       ╰── 
+   │       ╰── Expected `</b>`
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/errors/parse_error/normal/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/parse_error/normal/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Errors
 
@@ -14,7 +13,7 @@ snapshot_kind: text
    │     │ 
    │     ╰─ 
    │ 
-   │ Help: Try insert a semicolon here
+   │ Help: Try inserting a semicolon here
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/hmr/recover_from_intial_build_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/recover_from_intial_build_error/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        │ 
    │        ╰─ 
    │ 
-   │ Help: Try insert a semicolon here
+   │ Help: Try inserting a semicolon here
 ───╯
 
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -2704,12 +2704,6 @@ expression: output
 
 - entry-!~{000}~.js => entry-CMXZovLt.js
 
-# tests/esbuild/lower/lower_using
-
-- entry-!~{000}~.js => entry-B3IANQX3.js
-- loops-!~{001}~.js => loops-jV2n8FiX.js
-- switch-!~{002}~.js => switch-BASDpxdg.js
-
 # tests/esbuild/lower/lower_using_hoisting
 
 - hoist-directive-!~{001}~.js => hoist-directive-aLVAy9nS.js
@@ -2735,18 +2729,6 @@ expression: output
 # tests/esbuild/lower/lower_using_inside_ts_namespace
 
 - entry-!~{000}~.js => entry-WEiDann8.js
-
-# tests/esbuild/lower/lower_using_unsupported_async
-
-- entry-!~{000}~.js => entry-CMXZovLt.js
-- loops-!~{001}~.js => loops-CgXuEPfh.js
-- switch-!~{002}~.js => switch-Co85tZ-f.js
-
-# tests/esbuild/lower/lower_using_unsupported_using_and_async
-
-- entry-!~{000}~.js => entry-CMXZovLt.js
-- loops-!~{001}~.js => loops-CgXuEPfh.js
-- switch-!~{002}~.js => switch-Co85tZ-f.js
 
 # tests/esbuild/lower/static_class_block_es2021
 
@@ -3212,7 +3194,7 @@ expression: output
 # tests/esbuild/ts/enum_rules_from_type_script_5_0
 
 - not-supported-!~{001}~.js => not-supported-BslC2gdM.js
-- supported-!~{000}~.js => supported-B0txwxjS.js
+- supported-!~{000}~.js => supported-gWLBl1oC.js
 
 # tests/esbuild/ts/export_type_issue379
 

--- a/crates/rolldown_binding/src/utils/minify_options_conversion.rs
+++ b/crates/rolldown_binding/src/utils/minify_options_conversion.rs
@@ -39,6 +39,8 @@ pub fn compress_options_to_napi_compress_options(
     join_vars: Some(compress.join_vars),
     sequences: Some(compress.sequences),
     max_iterations: compress.max_iterations,
+    // available in the root treeshake options
+    treeshake: None,
   }
 }
 

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -74,6 +74,8 @@ export interface CompressOptions {
   dropLabels?: Array<string>
   /** Limit the maximum number of iterations for debugging purpose. */
   maxIterations?: number
+  /** Treeshake options. */
+  treeshake?: TreeShakeOptions
 }
 
 export interface CompressOptionsKeepNames {
@@ -131,7 +133,7 @@ export interface MangleOptionsKeepNames {
 export declare function minify(filename: string, sourceText: string, options?: MinifyOptions | undefined | null): MinifyResult
 
 export interface MinifyOptions {
-  /** Use when minifying an ES6 module. */
+  /** Use when minifying an ES module. */
   module?: boolean
   compress?: boolean | CompressOptions
   mangle?: boolean | MangleOptions
@@ -143,6 +145,40 @@ export interface MinifyResult {
   code: string
   map?: SourceMap
   errors: Array<OxcError>
+}
+
+export interface TreeShakeOptions {
+  /**
+   * Whether to respect the pure annotations.
+   *
+   * Pure annotations are comments that mark an expression as pure.
+   * For example: @__PURE__ or #__NO_SIDE_EFFECTS__.
+   *
+   * @default true
+   */
+  annotations?: boolean
+  /**
+   * Whether to treat this function call as pure.
+   *
+   * This function is called for normal function calls, new calls, and
+   * tagged template calls.
+   */
+  manualPureFunctions?: Array<string>
+  /**
+   * Whether property read accesses have side effects.
+   *
+   * @default 'always'
+   */
+  propertyReadSideEffects?: boolean | 'always'
+  /**
+   * Whether accessing a global variable has side effects.
+   *
+   * Accessing a non-existing global variable will throw an error.
+   * Global variable may be a getter that has side effects.
+   *
+   * @default true
+   */
+  unknownGlobalSideEffects?: boolean
 }
 export interface Comment {
   type: 'Line' | 'Block'
@@ -865,7 +901,7 @@ export interface JsxOptions {
   /**
    * Enables `@babel/plugin-transform-react-pure-annotations`.
    *
-   * It will mark top-level React method calls as pure for tree shaking.
+   * It will mark JSX elements and top-level React method calls as pure for tree shaking.
    *
    * @see {@link https://babeljs.io/docs/en/babel-plugin-transform-react-pure-annotations}
    *


### PR DESCRIPTION
The 3 changed files are waiting for upstream:

* https://github.com/evanw/esbuild/issues/4323

Handing the rest of the API changes to @sapphi-red 

```
error[E0063]: missing field `treeshake` in initializer of `oxc_minify_napi::CompressOptions`
  --> crates/rolldown_binding/src/utils/minify_options_conversion.rs:22:3
   |
22 |   oxc_minify_napi::CompressOptions {
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `treeshake`
```