### PR TITLE
fix: handle error when creating output chunk directories

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -166,7 +166,9 @@ impl Bundle {
       let dest = dist_dir.join(chunk.filename());
       if let Some(p) = dest.parent() {
         if !self.fs.exists(p) {
-          self.fs.create_dir_all(p).unwrap();
+          self.fs.create_dir_all(p).with_context(|| {
+            format!("Could not create directory for output chunks: {}", p.display())
+          })?;
         }
       }
       self


### PR DESCRIPTION
It seems #6870 was reverted by #6877. Maybe we should check if there aren't other changes that got lost.