### PR TITLE
feat(rolldown): oxc_resolver v11.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1261,7 +1261,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1612,7 +1612,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2127,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "11.13.1"
+version = "11.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab3f270c313ac7f814ce73a64f4bdf36a183dcae4593b2f96c6e6afea8c99d0"
+checksum = "0f1af25f894076eedc44509ad0cc33afb829aa06ec3f23e395f47bcbc1c6e964"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -2152,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver_napi"
-version = "11.13.1"
+version = "11.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c779320dd5440f02a4a185dd6da6b02616775d6a07e1f6ebee724379d07f6e22"
+checksum = "915f8f50b9ce98bec9755d51025d43ecdcad3b36a1c956032aba5b926ac96271"
 dependencies = [
  "fancy-regex",
  "napi",
@@ -3523,7 +3523,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3585,7 +3585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4310,7 +4310,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/rolldown_fs/src/file_system.rs
+++ b/crates/rolldown_fs/src/file_system.rs
@@ -26,11 +26,6 @@ pub trait FileSystem: Send + Sync + OxcResolverFileSystem {
   /// * See [std::path::Path::exists]
   fn exists(&self, path: &Path) -> bool;
 
-  /// # Errors
-  ///
-  /// * See [std::fs::read]
-  fn read(&self, path: &Path) -> io::Result<Vec<u8>>;
-
   /// Returns a vector of absolute paths to the directory entries.
   ///
   /// Here we don't return [`std::fs::ReadDir`] because

--- a/crates/rolldown_fs/src/memory.rs
+++ b/crates/rolldown_fs/src/memory.rs
@@ -76,16 +76,6 @@ impl FileSystem for MemoryFileSystem {
     self.fs.exists(path.to_string_lossy().as_ref()).is_ok()
   }
 
-  fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
-    let mut buf = Vec::new();
-    self
-      .fs
-      .open_file(&path.to_string_lossy())
-      .map_err(|err| io::Error::new(io::ErrorKind::NotFound, err))?
-      .read_to_end(&mut buf)?;
-    Ok(buf)
-  }
-
   fn read_dir(&self, path: &Path) -> io::Result<Vec<PathBuf>> {
     let path_str = path.to_string_lossy();
     let entries = self
@@ -112,6 +102,16 @@ impl FileSystem for MemoryFileSystem {
 impl OxcResolverFileSystem for MemoryFileSystem {
   fn new(_yarn_pnp: bool) -> Self {
     Self::default()
+  }
+
+  fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    self
+      .fs
+      .open_file(&path.to_string_lossy())
+      .map_err(|err| io::Error::new(io::ErrorKind::NotFound, err))?
+      .read_to_end(&mut buf)?;
+    Ok(buf)
   }
 
   fn read_to_string(&self, path: &Path) -> io::Result<String> {

--- a/crates/rolldown_fs/src/os.rs
+++ b/crates/rolldown_fs/src/os.rs
@@ -35,10 +35,6 @@ impl FileSystem for OsFileSystem {
     path.exists()
   }
 
-  fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
-    std::fs::read(path)
-  }
-
   fn read_dir(&self, path: &Path) -> io::Result<Vec<PathBuf>> {
     let entries = std::fs::read_dir(path)?;
     let mut paths = Vec::new();
@@ -57,6 +53,10 @@ impl FileSystem for OsFileSystem {
 impl OxcResolverFileSystem for OsFileSystem {
   fn new(yarn_pnp: bool) -> Self {
     Self(Arc::new(FileSystemOs::new(yarn_pnp)))
+  }
+
+  fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
+    self.0.read(path)
   }
 
   fn read_to_string(&self, path: &Path) -> io::Result<String> {

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -48,8 +48,8 @@ impl<F: FileSystem> Resolver<F> {
     } else {
       // User have has the responsibility to ensure `path` is real path if needed. We just pass it through.
       let realpath = path.to_path_buf();
-      let json_str = self.fs.read_to_string(path)?;
-      let oxc_pkg_json = OxcPackageJson::parse(&self.fs, path.to_path_buf(), realpath, json_str)?;
+      let json_bytes = self.fs.read(path)?;
+      let oxc_pkg_json = OxcPackageJson::parse(&self.fs, path.to_path_buf(), realpath, json_bytes)?;
       let pkg_json = Arc::new(PackageJson::from_oxc_pkg_json(&oxc_pkg_json));
       self.package_json_cache.insert(path.to_path_buf(), Arc::clone(&pkg_json));
       Ok(pkg_json)


### PR DESCRIPTION
fixes #6949
closes https://github.com/rolldown/rolldown/pull/6957
* Fixes files appear to be missing on linux