### PR TITLE
refactor(rust/dev): replace `CoordinatorMsg::HasLatestBuildOutput` with `GetStatus`

### DIFF
--- a/crates/rolldown/src/dev/type_aliases.rs
+++ b/crates/rolldown/src/dev/type_aliases.rs
@@ -17,10 +17,6 @@ pub type GetStatusReceiver = oneshot::Receiver<CoordinatorStatus>;
 pub type ScheduleBuildSender = oneshot::Sender<BuildResult<Option<(BundlingFuture, bool)>>>;
 pub type ScheduleBuildReceiver = oneshot::Receiver<BuildResult<Option<(BundlingFuture, bool)>>>;
 
-// HasLatestBuildOutput message
-pub type HasLatestBuildOutputSender = oneshot::Sender<bool>;
-pub type HasLatestBuildOutputReceiver = oneshot::Receiver<bool>;
-
 // Coordinator channel
 pub type CoordinatorSender = UnboundedSender<CoordinatorMsg>;
 pub type CoordinatorReceiver = UnboundedReceiver<CoordinatorMsg>;

--- a/crates/rolldown/src/dev/types/coordinator_msg.rs
+++ b/crates/rolldown/src/dev/types/coordinator_msg.rs
@@ -1,18 +1,16 @@
 use rolldown_error::BuildResult;
 use rolldown_fs_watcher::FileChangeResult;
 
-use crate::dev::type_aliases::{GetStatusSender, HasLatestBuildOutputSender, ScheduleBuildSender};
+use crate::dev::type_aliases::{GetStatusSender, ScheduleBuildSender};
 
 /// Messages sent to the BundleCoordinator
 pub enum CoordinatorMsg {
   /// File system change event from watcher
   WatchEvent(FileChangeResult),
   /// Build task completed
-  BuildCompleted { result: BuildResult<()>, task_required_rebuild: bool },
+  BundleCompleted { result: BuildResult<()>, has_generated_bundle_output: bool },
   /// Request to schedule a build if stale
   ScheduleBuild { reply: ScheduleBuildSender },
-  /// Check if we have latest build output
-  HasLatestBuildOutput { reply: HasLatestBuildOutputSender },
   /// Get current build status (atomic operation)
   GetStatus { reply: GetStatusSender },
   /// Close the coordinator

--- a/crates/rolldown/src/dev/types/coordinator_status.rs
+++ b/crates/rolldown/src/dev/types/coordinator_status.rs
@@ -3,10 +3,8 @@ use crate::dev::{dev_context::BundlingFuture, types::initial_build_state::Initia
 /// Response containing current coordinator status
 #[derive(Debug, Clone)]
 pub struct CoordinatorStatus {
-  /// The current build future if a build is running
-  pub current_build_future: Option<BundlingFuture>,
-  /// Whether the build output is stale
+  // `None` if no build is running
+  pub running_future: Option<BundlingFuture>,
   pub has_stale_output: bool,
-  /// The state of the initial build
   pub initial_build_state: InitialBuildState,
 }

--- a/crates/rolldown_binding/src/binding_dev_engine.rs
+++ b/crates/rolldown_binding/src/binding_dev_engine.rs
@@ -152,13 +152,17 @@ impl BindingDevEngine {
   }
 
   #[napi]
-  pub async fn has_latest_build_output(&self) -> bool {
-    self.inner.has_latest_build_output().await
+  pub async fn has_latest_build_output(&self) -> napi::Result<bool> {
+    self
+      .inner
+      .has_latest_bundle_output()
+      .await
+      .map_err(|_e| napi::Error::from_reason("Failed to check latest build output"))
   }
 
   #[napi]
   pub async fn ensure_latest_build_output(&self) -> napi::Result<()> {
-    self.inner.ensure_latest_build_output().await.expect("Should handle this error");
+    self.inner.ensure_latest_bundle_output().await.expect("Should handle this error");
     Ok(())
   }
 

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -215,7 +215,7 @@ impl IntegrationTest {
 
         // Optionally wait for async builds to complete
         if self.test_meta.dev.ensure_latest_build_output_for_each_step {
-          dev_engine.ensure_latest_build_output().await.unwrap();
+          dev_engine.ensure_latest_bundle_output().await.unwrap();
         }
       }
       drop(dev_engine);


### PR DESCRIPTION
- behaviors
    - `CoordinatorMsg::HasLatestBuildOutput` is replaced with `GetStatus`​ message.
- styles
    - A lot naming changes about replace `build `​with `bundle`​. I isolated these changes in rust. After we make things more stable, I will change the naming of TS API interface `DevEngine`​ .