### PR TITLE
feat(rolldown_binding): add context to errors thrown by plugin hooks

### DIFF
--- a/crates/rolldown_error/src/build_diagnostic/events/plugin_error.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/plugin_error.rs
@@ -21,7 +21,7 @@ impl CausedPlugin {
 
 impl Display for CausedPlugin {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "caused by plugin `{}`", self.name)
+    write!(f, "plugin `{}` threw an error", self.name)
   }
 }
 
@@ -40,7 +40,7 @@ impl BuildEvent for PluginError {
     if self.error.downcast_ref::<BuildDiagnostic>().is_some() {
       String::default()
     } else {
-      self.error.root_cause().to_string()
+      format!("{:?}", self.error)
     }
   }
 


### PR DESCRIPTION
Added `.context` calls and tweaked the stringify code to show more information for errors thrown by plugin hooks.

It looks like this now:
```
[foo] Error: plugin `foo` threw an error

Caused by:
    0: transform hook threw an error for id=D:\documents\GitHub\rolldown\packages\rolldown\src\utils\async-flatten.ts
    1: Failed to convert json sourcemap to struct
    2: Mapping segment had an unsupported size of 0
```

Without this PR, it was like
```
[foo] Error: Mapping segment had an unsupported size of 0
```
