### PR TITLE
refactor(rust): filter out devtools specific events for normal tracing

### DIFF
--- a/crates/rolldown_debug/src/debug_formatter.rs
+++ b/crates/rolldown_debug/src/debug_formatter.rs
@@ -221,7 +221,7 @@ pub struct ActionMetaExtractor {
 
 impl tracing::field::Visit for ActionMetaExtractor {
   fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-    if field.name() == "meta" {
+    if field.name() == "devtoolsAction" {
       self.meta = Some(serde_json::from_str(value).unwrap());
     }
   }

--- a/crates/rolldown_debug/src/trace_action_macro.rs
+++ b/crates/rolldown_debug/src/trace_action_macro.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! trace_action {
   ($expr:expr) => {
-    tracing::trace!(meta = serde_json::to_string(&$expr).unwrap());
+    tracing::trace!(devtoolsAction = serde_json::to_string(&$expr).unwrap());
   };
 }
 


### PR DESCRIPTION
- I'm investigating https://github.com/rolldown/rolldown/pull/6936#discussion_r2513930579. I find I have to use tracing to inspect the behavior, so I turn to solve some issues related to tracing.
- Previously, we use `trace` level to infer the event is a devtools-specific event, while this allows us to freely write tracing code with any level now. @IWANABETHATGUY cc