### PR TITLE
fix(rust/dev): `DevEngine#ensure_latest_bundle_output` should schedule a rebuild task if there're no queued tasks

### DIFF
--- a/crates/rolldown/src/dev/dev_engine.rs
+++ b/crates/rolldown/src/dev/dev_engine.rs
@@ -209,61 +209,34 @@ impl DevEngine {
   pub async fn ensure_latest_bundle_output(&self) -> BuildResult<()> {
     self.create_error_if_closed()?;
 
-    let mut count = 0;
-
+    let mut loop_counter = 0u32;
     loop {
-      count += 1;
-      if count > 1000 {
+      if loop_counter > 1000 {
         eprintln!(
-          "Debug: `ensure_latest_bundle_output` wait for 1000 times build, something might be wrong"
+          "[DevEngine] ensure_latest_bundle_output has looped {loop_counter} times, something might be wrong",
         );
         break;
       }
-
-      // Get current build status from coordinator
-      let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+      let (reply_sender, reply_receiver) = tokio::sync::oneshot::channel();
       self
         .coordinator_sender
-        .send(CoordinatorMsg::GetStatus { reply: reply_tx })
+        .send(CoordinatorMsg::EnsureLatestBundleOutput { reply: reply_sender })
         .map_err_to_unhandleable()
-        .context("DevEngine: failed to send GetStatus to coordinator")?;
-      let status = reply_rx
+        .context("DevEngine: failed to send EnsureLatestBundleOutput to coordinator")?;
+
+      let bundling_future = reply_receiver
         .await
         .map_err_to_unhandleable()
-        .context("DevEngine: coordinator closed before responding to GetStatus")?;
+        .context("DevEngine: coordinator closed before responding to EnsureLatestBundleOutput")??;
 
-      if let Some(building_future) = status.running_future {
-        tracing::trace!("Waiting for current build to finish...; {:?}", status.initial_build_state);
-        building_future.await;
+      // Wait for the build if one is running or was scheduled
+      if let Some(future) = bundling_future {
+        // Either a build is ongoing, or a new build was scheduled - wait for it to complete
+        future.await;
       } else {
-        tracing::trace!("No current build in progress...");
-        if status.has_stale_output {
-          // Need to schedule a build
-          let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-          self
-            .coordinator_sender
-            .send(CoordinatorMsg::ScheduleBuild { reply: reply_tx })
-            .map_err_to_unhandleable()
-            .context("DevEngine: failed to send ScheduleBuild to coordinator")?;
-
-          let schedule_result = reply_rx
-            .await
-            .map_err_to_unhandleable()
-            .context("DevEngine: coordinator closed before responding to ScheduleBuild")??;
-
-          if let Some((building_future, _)) = schedule_result {
-            building_future.await;
-          } else {
-            // No build was scheduled, which means there's no task in queue
-            // Queue the appropriate task based on initial build state
-            // This shouldn't normally happen as coordinator queues initial task
-            break;
-          }
-        } else {
-          // Build output is fresh, we're done
-          break;
-        }
+        break;
       }
+      loop_counter += 1;
     }
 
     Ok(())
@@ -342,7 +315,7 @@ impl DevEngine {
     // Send ScheduleBuild to ensure WatchEvent is processed (FIFO),
     // and get the build future to wait on
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-    let _ = self.coordinator_sender.send(CoordinatorMsg::ScheduleBuild { reply: reply_tx });
+    let _ = self.coordinator_sender.send(CoordinatorMsg::ScheduleBuildIfStale { reply: reply_tx });
 
     // Wait for the build that was triggered by the file change
     if let Ok(Ok(Some((future, _)))) = reply_rx.await {

--- a/crates/rolldown/src/dev/type_aliases.rs
+++ b/crates/rolldown/src/dev/type_aliases.rs
@@ -14,9 +14,13 @@ pub type GetStatusSender = oneshot::Sender<CoordinatorStatus>;
 pub type GetStatusReceiver = oneshot::Receiver<CoordinatorStatus>;
 
 // ScheduleBuild message
-pub type ScheduleBuildSender = oneshot::Sender<BuildResult<Option<(BundlingFuture, bool)>>>;
-pub type ScheduleBuildReceiver = oneshot::Receiver<BuildResult<Option<(BundlingFuture, bool)>>>;
+pub type ScheduleBuildIfStaleSender = oneshot::Sender<BuildResult<Option<(BundlingFuture, bool)>>>;
+pub type ScheduleBuildIfStaleReceiver =
+  oneshot::Receiver<BuildResult<Option<(BundlingFuture, bool)>>>;
 
 // Coordinator channel
 pub type CoordinatorSender = UnboundedSender<CoordinatorMsg>;
 pub type CoordinatorReceiver = UnboundedReceiver<CoordinatorMsg>;
+
+pub type EnsureLatestBundleOutputSender = oneshot::Sender<BuildResult<Option<BundlingFuture>>>;
+pub type EnsureLatestBundleOutputReceiver = oneshot::Receiver<BuildResult<Option<BundlingFuture>>>;

--- a/crates/rolldown/src/dev/types/coordinator_msg.rs
+++ b/crates/rolldown/src/dev/types/coordinator_msg.rs
@@ -1,18 +1,17 @@
 use rolldown_error::BuildResult;
-use rolldown_fs_watcher::FileChangeResult;
+use rolldown_fs_watcher::FsEventResult;
 
-use crate::dev::type_aliases::{GetStatusSender, ScheduleBuildSender};
+use crate::dev::type_aliases::{
+  EnsureLatestBundleOutputSender, GetStatusSender, ScheduleBuildIfStaleSender,
+};
 
 /// Messages sent to the BundleCoordinator
+#[derive(Debug)]
 pub enum CoordinatorMsg {
-  /// File system change event from watcher
-  WatchEvent(FileChangeResult),
-  /// Build task completed
+  WatchEvent(FsEventResult),
   BundleCompleted { result: BuildResult<()>, has_generated_bundle_output: bool },
-  /// Request to schedule a build if stale
-  ScheduleBuild { reply: ScheduleBuildSender },
-  /// Get current build status (atomic operation)
+  ScheduleBuildIfStale { reply: ScheduleBuildIfStaleSender },
   GetStatus { reply: GetStatusSender },
-  /// Close the coordinator
+  EnsureLatestBundleOutput { reply: EnsureLatestBundleOutputSender },
   Close,
 }

--- a/crates/rolldown/src/dev/watcher_event_handler.rs
+++ b/crates/rolldown/src/dev/watcher_event_handler.rs
@@ -6,7 +6,7 @@ pub struct WatcherEventHandler {
   pub coordinator_tx: CoordinatorSender,
 }
 impl FsEventHandler for WatcherEventHandler {
-  fn handle_event(&mut self, event: rolldown_fs_watcher::FileChangeResult) {
+  fn handle_event(&mut self, event: rolldown_fs_watcher::FsEventResult) {
     self.coordinator_tx.send(CoordinatorMsg::WatchEvent(event)).expect(
       "Coordinator channel closed while sending file change event - coordinator terminated unexpectedly"
     );

--- a/crates/rolldown_fs_watcher/src/lib.rs
+++ b/crates/rolldown_fs_watcher/src/lib.rs
@@ -27,7 +27,7 @@ mod debounced_recommended_fs_watcher;
 pub use debounced_recommended_fs_watcher::DebouncedRecommendedFsWatcher;
 
 pub use crate::{
-  fs_event::{FsEvent, FsEventResult as FileChangeResult},
+  fs_event::{FsEvent, FsEventResult},
   fs_event_handler::FsEventHandler,
 };
 pub use fs_watcher::FsWatcher;

--- a/crates/rolldown_tracing/src/lib.rs
+++ b/crates/rolldown_tracing/src/lib.rs
@@ -59,6 +59,17 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
       // See `crates/rolldown_debug`
       unimplemented!()
     }
+    "readable" => {
+      tracing_subscriber::registry()
+        .with(filter_for_removing_devtools_event)
+        .with(Targets::from_str(&env_var).unwrap())
+        .with(
+          fmt::layer().pretty().with_span_events(FmtSpan::NONE).with_level(true).with_target(false),
+        )
+        .init();
+      tracing::debug!("Tracing initialized");
+      None
+    }
     _ => {
       tracing_subscriber::registry()
         .with(filter_for_removing_devtools_event)

--- a/packages/test-dev-server/src/dev-server.ts
+++ b/packages/test-dev-server/src/dev-server.ts
@@ -84,8 +84,9 @@ class DevServer {
     this.#devEngine = devEngine;
     process.stdin.on('data', async data => {
       if (data.toString() === 'r') {
-        if (!await devEngine.hasLatestBuildOutput()) {
-          void devEngine.ensureLatestBuildOutput();
+        const hasLatestOutput = await devEngine.hasLatestBuildOutput();
+        if (!hasLatestOutput) {
+          await devEngine.ensureLatestBuildOutput();
         }
       }
     }).unref();

--- a/packages/test-dev-server/tests/fixtures.test.ts
+++ b/packages/test-dev-server/tests/fixtures.test.ts
@@ -37,7 +37,7 @@ function main() {
     for (const fixtureName of fixtureNames) {
       // Skip if it's not a valid fixture
       if (
-        fixtureName.includes('edit-reload') || !nodeFs.existsSync(
+        !nodeFs.existsSync(
           nodePath.join(fixturesPath, fixtureName, 'package.json'),
         )
       ) {


### PR DESCRIPTION
Fixes [edit-reload test](https://github.com/rolldown/rolldown/pull/6936#discussion_r2513930579). 