### PR TITLE
refactor(ast_scanner): derive `Debug`, `Clone`, `Copy` for `CjsGlobalAssignmentType`

### DIFF
--- a/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
@@ -45,7 +45,7 @@ pub enum CommonJsAstType {
 }
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
-  pub fn commonjs_export_analyzer(&self, ty: &CjsGlobalAssignmentType) -> Option<CommonJsAstType> {
+  pub fn commonjs_export_analyzer(&self, ty: CjsGlobalAssignmentType) -> Option<CommonJsAstType> {
     let cursor = self.visit_path.len() - 1;
     let parent = self.visit_path.get(cursor)?;
     match parent {
@@ -175,6 +175,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum CjsGlobalAssignmentType {
   ModuleExportsAssignment,
   ExportsAssignment,

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -431,14 +431,13 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         match ident_ref.name.as_str() {
           "module" => {
             self.result.ast_usage.insert(EcmaModuleAstUsage::ModuleRef);
-            let v =
-              self.commonjs_export_analyzer(&CjsGlobalAssignmentType::ModuleExportsAssignment);
+            let v = self.commonjs_export_analyzer(CjsGlobalAssignmentType::ModuleExportsAssignment);
             self.update_ast_usage_for_commonjs_export(v.as_ref());
           }
           "exports" => {
             self.result.ast_usage.insert(EcmaModuleAstUsage::ExportsRef);
             // exports = {} will not change the module.exports object, so we just ignore it;
-            let v = self.commonjs_export_analyzer(&CjsGlobalAssignmentType::ExportsAssignment);
+            let v = self.commonjs_export_analyzer(CjsGlobalAssignmentType::ExportsAssignment);
             self.update_ast_usage_for_commonjs_export(v.as_ref());
             match v {
               // Do nothing since we need to tree shake `exports.<prop>` access


### PR DESCRIPTION
This PR:
 - derives `Debug` for `CjsGlobalAssignmentType` helping for debugging
 - derives `Copy` for `CjsGlobalAssignmentType`, and passes by value to `commonjs_export_analyzer` rather than by reference.

Copy should be cheaper than dereferencing for small enums, since `CjsGlobalAssignmentType` is probably a single byte, copying should will be faster than following a pointer.
