### PR TITLE
fix(rust/dev): `ensure_latest_bundle_output` shouldn't loop infinitely

### DIFF
--- a/crates/rolldown/src/dev/type_aliases.rs
+++ b/crates/rolldown/src/dev/type_aliases.rs
@@ -4,12 +4,10 @@ use tokio::sync::{
   oneshot,
 };
 
-use super::{
-  dev_context::BundlingFuture,
-  types::{
-    coordinator_msg::CoordinatorMsg, coordinator_state_snapshot::CoordinatorStateSnapshot,
-    schedule_build_return::ScheduleBuildReturn,
-  },
+use super::types::{
+  coordinator_msg::CoordinatorMsg, coordinator_state_snapshot::CoordinatorStateSnapshot,
+  ensure_latest_bundle_output_return::EnsureLatestBundleOutputReturn,
+  schedule_build_return::ScheduleBuildReturn,
 };
 
 // GetBuildStatus message
@@ -24,5 +22,7 @@ pub type ScheduleBuildIfStaleReceiver = oneshot::Receiver<BuildResult<Option<Sch
 pub type CoordinatorSender = UnboundedSender<CoordinatorMsg>;
 pub type CoordinatorReceiver = UnboundedReceiver<CoordinatorMsg>;
 
-pub type EnsureLatestBundleOutputSender = oneshot::Sender<BuildResult<Option<BundlingFuture>>>;
-pub type EnsureLatestBundleOutputReceiver = oneshot::Receiver<BuildResult<Option<BundlingFuture>>>;
+pub type EnsureLatestBundleOutputSender =
+  oneshot::Sender<BuildResult<Option<EnsureLatestBundleOutputReturn>>>;
+pub type EnsureLatestBundleOutputReceiver =
+  oneshot::Receiver<BuildResult<Option<EnsureLatestBundleOutputReturn>>>;

--- a/crates/rolldown/src/dev/types/ensure_latest_bundle_output_return.rs
+++ b/crates/rolldown/src/dev/types/ensure_latest_bundle_output_return.rs
@@ -1,0 +1,9 @@
+use crate::dev::dev_context::BundlingFuture;
+
+/// Return value for `ensure_latest_bundle_output` containing the bundling future to await
+#[derive(Debug, Clone)]
+pub struct EnsureLatestBundleOutputReturn {
+  /// The bundling task future to wait for
+  pub future: BundlingFuture,
+  pub is_ensure_latest_bundle_output_future: bool,
+}

--- a/crates/rolldown/src/dev/types/mod.rs
+++ b/crates/rolldown/src/dev/types/mod.rs
@@ -2,5 +2,6 @@ pub mod client_session;
 pub mod coordinator_msg;
 pub mod coordinator_state;
 pub mod coordinator_state_snapshot;
+pub mod ensure_latest_bundle_output_return;
 pub mod schedule_build_return;
 pub mod task_input;


### PR DESCRIPTION
- Fixes https://github.com/rolldown/rolldown/pull/6968#discussion_r2519116057
- `recover_from_intial_build_error`​ triggers this error but because we don't panic, so it doesn't failed until this PR.