### PR TITLE
refactor(rust/dev): unwrap `Result<_>` from the return type of `BundleCoordinator::schedule_build_if_stale`

### DIFF
--- a/crates/rolldown/src/dev/dev_engine.rs
+++ b/crates/rolldown/src/dev/dev_engine.rs
@@ -234,7 +234,7 @@ impl DevEngine {
       let received = reply_receiver
         .await
         .map_err_to_unhandleable()
-        .context("DevEngine: coordinator closed before responding to EnsureLatestBundleOutput")??;
+        .context("DevEngine: coordinator closed before responding to EnsureLatestBundleOutput")?;
 
       // Wait for the build if one is running or was scheduled
       if let Some(ret) = received {
@@ -327,7 +327,7 @@ impl DevEngine {
     let _ = self.coordinator_sender.send(CoordinatorMsg::ScheduleBuildIfStale { reply: reply_tx });
 
     // Wait for the build that was triggered by the file change
-    if let Ok(Ok(Some(ret))) = reply_rx.await {
+    if let Ok(Some(ret)) = reply_rx.await {
       ret.future.await;
     }
   }

--- a/crates/rolldown/src/dev/type_aliases.rs
+++ b/crates/rolldown/src/dev/type_aliases.rs
@@ -1,4 +1,3 @@
-use rolldown_error::BuildResult;
 use tokio::sync::{
   mpsc::{UnboundedReceiver, UnboundedSender},
   oneshot,
@@ -15,14 +14,13 @@ pub type GetStateSender = oneshot::Sender<CoordinatorStateSnapshot>;
 pub type GetStateReceiver = oneshot::Receiver<CoordinatorStateSnapshot>;
 
 // ScheduleBuild message
-pub type ScheduleBuildIfStaleSender = oneshot::Sender<BuildResult<Option<ScheduleBuildReturn>>>;
-pub type ScheduleBuildIfStaleReceiver = oneshot::Receiver<BuildResult<Option<ScheduleBuildReturn>>>;
+pub type ScheduleBuildIfStaleSender = oneshot::Sender<Option<ScheduleBuildReturn>>;
+pub type ScheduleBuildIfStaleReceiver = oneshot::Receiver<Option<ScheduleBuildReturn>>;
 
 // Coordinator channel
 pub type CoordinatorSender = UnboundedSender<CoordinatorMsg>;
 pub type CoordinatorReceiver = UnboundedReceiver<CoordinatorMsg>;
 
-pub type EnsureLatestBundleOutputSender =
-  oneshot::Sender<BuildResult<Option<EnsureLatestBundleOutputReturn>>>;
+pub type EnsureLatestBundleOutputSender = oneshot::Sender<Option<EnsureLatestBundleOutputReturn>>;
 pub type EnsureLatestBundleOutputReceiver =
-  oneshot::Receiver<BuildResult<Option<EnsureLatestBundleOutputReturn>>>;
+  oneshot::Receiver<Option<EnsureLatestBundleOutputReturn>>;


### PR DESCRIPTION
https://github.com/rolldown/rolldown/pull/6974#discussion_r2520771183