### PR TITLE
refactor: rename `is_module_facade()` to `is_entry_point()` for clarity

### DIFF
--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -58,7 +58,7 @@ pub fn render_cjs<'code>(
         ctx.options.es_module,
         has_default_export,
         &ctx.options.generated_code,
-        ctx.chunk.is_module_facade(),
+        ctx.chunk.is_entry_point(),
       ) {
         source_joiner.append_source(marker);
       }

--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -131,7 +131,7 @@ pub async fn render_iife<'code>(
       ctx.options.es_module,
       has_default_export,
       &ctx.options.generated_code,
-      ctx.chunk.is_module_facade(),
+      ctx.chunk.is_entry_point(),
     ) {
       source_joiner.append_source(marker);
     }

--- a/crates/rolldown/src/ecmascript/format/umd.rs
+++ b/crates/rolldown/src/ecmascript/format/umd.rs
@@ -98,7 +98,7 @@ pub async fn render_umd<'code>(
       ctx.options.es_module,
       has_default_export,
       &ctx.options.generated_code,
-      ctx.chunk.is_module_facade(),
+      ctx.chunk.is_entry_point(),
     ) {
       source_joiner.append_source(marker.to_string());
     }

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -332,10 +332,10 @@ impl Chunk {
     matches!(&self.kind, ChunkKind::EntryPoint { meta, .. } if meta.contains(ChunkMeta::DynamicImported))
   }
 
-  /// Check if this chunk is a module facade (represents a specific module).
-  /// Module facades are entry point chunks (user-defined or dynamic), not common chunks.
-  /// This is used to determine if Symbol.toStringTag should be added when generatedCode.symbols is true.
-  pub fn is_module_facade(&self) -> bool {
+  /// Returns true if this chunk is an entry point.
+  /// Entry points include both user-defined entries and dynamically imported modules.
+  /// When `generatedCode.symbols` is enabled, entry point chunks get `Symbol.toStringTag` defined.
+  pub fn is_entry_point(&self) -> bool {
     matches!(&self.kind, ChunkKind::EntryPoint { .. })
   }
 }


### PR DESCRIPTION
from https://github.com/rolldown/rolldown/pull/6784#discussion_r2519107024