### PR TITLE
fix: remove unused module namespace object exporting 

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -418,22 +418,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   }
 
   fn generate_declaration_of_module_namespace_object(&self) -> Vec<ast::Statement<'ast>> {
-    let module_namespace_included_reason = self.ctx.linking_info.module_namespace_included_reason;
-    let is_namespace_referenced = matches!(self.ctx.module.exports_kind, ExportsKind::Esm)
-      && if module_namespace_included_reason.contains(ModuleNamespaceIncludedReason::Unknown) {
-        true
-      } else if module_namespace_included_reason
-        .contains(ModuleNamespaceIncludedReason::ReExportExternalModule)
-      {
-        // If the module namespace is only used to reexport external module,
-        // then we need to ensure if it is still has dynamic exports after flatten entry level
-        // external module, see `find_entry_level_external_module`
-        self.ctx.linking_info.has_dynamic_exports
-      } else {
-        false
-      };
-
-    if !is_namespace_referenced {
+    if !self.module_namespace_included {
       return vec![];
     }
 

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -494,7 +494,9 @@ impl GenerateStage<'_> {
           let entry_module = &self.link_output.metas[entry_module_idx];
           entry_module.canonical_exports(false).for_each(|(name, export)| {
             let export_ref = self.link_output.symbol_db.canonical_ref_for(export.symbol_ref);
-            if !exported_chunk_symbols.contains_key(&export.symbol_ref) {
+            if !exported_chunk_symbols.contains_key(&export.symbol_ref)
+              || !self.link_output.used_symbol_refs.contains(&export.symbol_ref)
+            {
               // Rolldown supports tree-shaking on dynamic entries, so not all exports are used.
               return;
             }
@@ -543,6 +545,9 @@ impl GenerateStage<'_> {
           Reverse::<u32>(self.link_output.module_table[symbol_ref.owner].exec_order())
         })
       {
+        if !self.link_output.used_symbol_refs.contains(chunk_export) {
+          continue;
+        }
         let original_name: CompactStr = match predefined_names.as_slice() {
           [] => CompactStr::new(chunk_export.name(&self.link_output.symbol_db)),
           lst => {

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -75,6 +75,8 @@ impl<'a> GenerateStage<'a> {
       validate_options_for_multi_chunk_output(self.options)?;
     }
 
+    self.finalized_module_namespace_ref_usage();
+
     self.compute_cross_chunk_links(&mut chunk_graph);
 
     self.ensure_lazy_module_initialization_order(&mut chunk_graph);

--- a/crates/rolldown/tests/rolldown/issues/6992/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/6992/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "external": ["@sentry/node"],
+    "preserveModules": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
@@ -1,0 +1,34 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## _virtual/rolldown_runtime.js
+
+```js
+// HIDDEN [rolldown:runtime]
+export { __reExport };
+```
+
+## main.js
+
+```js
+import { __reExport } from "./_virtual/rolldown_runtime.js";
+import "./server/index.js";
+
+export * from "@sentry/node"
+
+//#region main.js
+var main_exports = {};
+
+//#endregion
+```
+
+## server/index.js
+
+```js
+import { __reExport } from "../_virtual/rolldown_runtime.js";
+
+export * from "@sentry/node"
+
+```

--- a/crates/rolldown/tests/rolldown/issues/6992/main.js
+++ b/crates/rolldown/tests/rolldown/issues/6992/main.js
@@ -1,0 +1,1 @@
+export * from './server';

--- a/crates/rolldown/tests/rolldown/issues/6992/server/index.js
+++ b/crates/rolldown/tests/rolldown/issues/6992/server/index.js
@@ -1,0 +1,3 @@
+// This breaks it!!!
+export * from "@sentry/node";
+

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_4818/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_4818/artifacts.snap
@@ -15,7 +15,8 @@ var foo_exports = /* @__PURE__ */ __export({
 });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.json");
 __rolldown_runtime__.registerModule("foo.json", { exports: foo_exports });
-var foo_default = { foo: "__EXP__" };
+var foo = "__EXP__";
+var foo_default = { foo };
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4844,6 +4844,12 @@ expression: output
 - main-!~{000}~.js => main-uyjEQE00.js
 - lib-!~{001}~.js => lib-CTg-KV6l.js
 
+# tests/rolldown/issues/6992
+
+- main-!~{000}~.js => main-D2QP9LbS.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-CRC6Pc46.js
+- server/index-!~{003}~.js => server/index-ChpZggGM.js
+
 # tests/rolldown/issues/duplicate_default_export
 
 - main-!~{000}~.js => main-BvtLtePT.js
@@ -5672,7 +5678,7 @@ expression: output
 
 # tests/rolldown/topics/hmr/issue_4818
 
-- main-!~{000}~.js => main-CX-_NZJb.js
+- main-!~{000}~.js => main-CpnnrpTq.js
 
 # tests/rolldown/topics/hmr/issue_5149
 


### PR DESCRIPTION
**Isuses**
- Before, when hmr is enabled, every `module_namespace`​ export object is generated but some of them are not included in `used_symbol_refs`​.
- Before, some module namespace object is not generated but included in `used_symbol_refs`. (e.g. indirect external module reexport)export * from "@sentry/node"
￼


This pr syncs `module_namespace` usage before code generation(both module level and chunk level), so that we could use `used_symbol_ref` to determine if a module namespace ref is used or not.

Closed #6992