### PR TITLE
feat(builtin-plugin): support `bindingifyViteHtmlPlugin`

### DIFF
--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -10,7 +10,6 @@ import type {
   BindingReactRefreshWrapperPluginConfig,
   BindingReporterPluginConfig,
   BindingViteCssPostPluginConfig,
-  BindingViteHtmlPluginConfig,
   BindingViteResolvePluginConfig,
   BindingWasmHelperPluginConfig,
 } from '../binding.cjs';
@@ -139,12 +138,6 @@ export function viteCSSPostPlugin(
   config?: BindingViteCssPostPluginConfig,
 ): BuiltinPlugin {
   return new BuiltinPlugin('builtin:vite-css-post', config);
-}
-
-export function viteHtmlPlugin(
-  config?: BindingViteHtmlPluginConfig,
-): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:vite-html', config);
 }
 
 export function htmlInlineProxyPlugin(): BuiltinPlugin {

--- a/packages/rolldown/src/builtin-plugin/utils.ts
+++ b/packages/rolldown/src/builtin-plugin/utils.ts
@@ -2,8 +2,24 @@ import {
   type BindingBuiltinPlugin,
   type BindingBuiltinPluginName,
   BindingCallableBuiltinPlugin,
+  type BindingOutputChunk,
+  type BindingOutputs,
 } from '../binding.cjs';
+import type { LogHandler } from '../log/log-handler';
+import type { LogLevelOption } from '../log/logging';
 import { error, logPluginError } from '../log/logs';
+import {
+  type MinimalPluginContext,
+  MinimalPluginContextImpl,
+} from '../plugin/minimal-plugin-context';
+import {
+  transformToOutputBundle,
+  transformToRollupOutputChunk,
+} from '../utils/transform-to-rollup-output';
+import type {
+  IndexHtmlTransformContext,
+  ViteHtmlPluginOptions,
+} from './vite-html-plugin';
 
 type BindingCallableBuiltinPluginLike = {
   [K in keyof BindingCallableBuiltinPlugin]: BindingCallableBuiltinPlugin[K];
@@ -58,6 +74,74 @@ export function makeBuiltinPluginCallable(
 export function bindingifyBuiltInPlugin(
   plugin: BuiltinPlugin,
 ): BindingBuiltinPlugin {
+  return {
+    __name: plugin.name,
+    options: plugin._options,
+  };
+}
+
+export function bindingifyViteHtmlPlugin(
+  plugin: BuiltinPlugin,
+  onLog: LogHandler,
+  logLevel: LogLevelOption,
+  watchMode: boolean,
+): BindingBuiltinPlugin {
+  const { preHooks, normalHooks, postHooks, applyHtmlTransforms, ...options } =
+    plugin
+      ._options as ViteHtmlPluginOptions;
+  if (preHooks.length + normalHooks.length + postHooks.length > 0) {
+    return {
+      __name: plugin.name,
+      options: {
+        ...options,
+        transformIndexHtml: async (
+          html: string,
+          path: string,
+          filename: string,
+          output?: BindingOutputs,
+          chunk?: BindingOutputChunk,
+          hook: 'transform' | 'generateBundle' = 'transform',
+        ): Promise<string> => {
+          const pluginContext = new MinimalPluginContextImpl(
+            onLog,
+            logLevel,
+            plugin.name,
+            watchMode,
+            'transformIndexHtml',
+          ) as MinimalPluginContext;
+
+          const context: IndexHtmlTransformContext = {
+            path,
+            filename,
+            bundle: output
+              ? transformToOutputBundle(pluginContext, output, {
+                updated: new Set(),
+                deleted: new Set(),
+              })
+              : undefined,
+            chunk: chunk ? transformToRollupOutputChunk(chunk) : undefined,
+          };
+
+          switch (hook) {
+            case 'transform':
+              return await applyHtmlTransforms(
+                html,
+                preHooks,
+                pluginContext,
+                context,
+              );
+            case 'generateBundle':
+              return await applyHtmlTransforms(
+                html,
+                [...normalHooks, ...postHooks],
+                pluginContext,
+                context,
+              );
+          }
+        },
+      },
+    };
+  }
   return {
     __name: plugin.name,
     options: plugin._options,

--- a/packages/rolldown/src/builtin-plugin/vite-html-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/vite-html-plugin.ts
@@ -1,0 +1,63 @@
+import type { BindingViteHtmlPluginConfig } from '../binding.cjs';
+import type { MinimalPluginContext } from '../plugin/minimal-plugin-context';
+import type { OutputBundle } from '../types/output-bundle';
+import type { OutputChunk } from '../types/rolldown-output';
+import { BuiltinPlugin } from './utils';
+
+interface HtmlTagDescriptor {
+  tag: string;
+  /**
+   * attribute values will be escaped automatically if needed
+   */
+  attrs?: Record<string, string | boolean | undefined>;
+  children?: string | HtmlTagDescriptor[];
+  /**
+   * default: 'head-prepend'
+   */
+  injectTo?: 'head' | 'body' | 'head-prepend' | 'body-prepend';
+}
+
+type IndexHtmlTransformResult =
+  | string
+  | HtmlTagDescriptor[]
+  | {
+    html: string;
+    tags: HtmlTagDescriptor[];
+  };
+
+type IndexHtmlTransformHook = (
+  this: MinimalPluginContext,
+  html: string,
+  ctx: IndexHtmlTransformContext,
+) => IndexHtmlTransformResult | void | Promise<IndexHtmlTransformResult | void>;
+
+export interface IndexHtmlTransformContext {
+  /**
+   * public path when served
+   */
+  path: string;
+  /**
+   * filename on disk
+   */
+  filename: string;
+  bundle?: OutputBundle;
+  chunk?: OutputChunk;
+}
+
+export interface ViteHtmlPluginOptions extends BindingViteHtmlPluginConfig {
+  preHooks: IndexHtmlTransformHook[];
+  normalHooks: IndexHtmlTransformHook[];
+  postHooks: IndexHtmlTransformHook[];
+  applyHtmlTransforms: (
+    html: string,
+    hooks: IndexHtmlTransformHook[],
+    pluginContext: MinimalPluginContext,
+    ctx: IndexHtmlTransformContext,
+  ) => Promise<string>;
+}
+
+export function viteHtmlPlugin(
+  config?: ViteHtmlPluginOptions,
+): BuiltinPlugin {
+  return new BuiltinPlugin('builtin:vite-html', config);
+}

--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -38,7 +38,6 @@ export {
   reactRefreshWrapperPlugin,
   reporterPlugin,
   viteCSSPostPlugin,
-  viteHtmlPlugin,
   viteResolvePlugin,
   wasmFallbackPlugin,
   wasmHelperPlugin,
@@ -49,3 +48,7 @@ export { aliasPlugin } from './builtin-plugin/alias-plugin';
 export { assetPlugin } from './builtin-plugin/asset-plugin';
 export { transformPlugin } from './builtin-plugin/transform-plugin';
 export { viteCSSPlugin } from './builtin-plugin/vite-css-plugin';
+export {
+  viteHtmlPlugin,
+  type ViteHtmlPluginOptions,
+} from './builtin-plugin/vite-html-plugin';

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -1,5 +1,4 @@
 import './setup';
-import { version } from '../package.json';
 import { build, type BuildOptions } from './api/build';
 import { rolldown } from './api/rolldown';
 import type { RolldownBuild } from './api/rolldown/rolldown-build';
@@ -109,9 +108,9 @@ import type {
 import type { ExistingRawSourceMap, SourceMapInput } from './types/sourcemap';
 import type { PartialNull } from './types/utils';
 import { defineConfig } from './utils/define-config';
+import { VERSION } from './version';
 
-export { build, defineConfig, rolldown, watch };
-export const VERSION: string = version;
+export { build, defineConfig, rolldown, VERSION, watch };
 export { BindingMagicString } from './binding.cjs';
 export type {
   AddonFunction,

--- a/packages/rolldown/src/log/logger.ts
+++ b/packages/rolldown/src/log/logger.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
-import { VERSION } from '..';
 import type { InputOptions } from '../options/input-options';
 import type { Plugin } from '../plugin';
 import { getSortedPlugins } from '../plugin/plugin-driver';
+import { VERSION } from '../version';
 import {
   type LoggingFunction,
   type LogHandler,

--- a/packages/rolldown/src/plugin/minimal-plugin-context.ts
+++ b/packages/rolldown/src/plugin/minimal-plugin-context.ts
@@ -1,4 +1,3 @@
-import { VERSION } from '..';
 import {
   getLogHandler,
   type LoggingFunction,
@@ -14,6 +13,7 @@ import {
 } from '../log/logging';
 import { error, logPluginError } from '../log/logs';
 import type { Extends, TypeAssert } from '../types/assert';
+import { VERSION } from '../version';
 
 export interface PluginContextMeta {
   rollupVersion: string;

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -12,7 +12,10 @@ import type {
   BindingInjectImportNamespace,
   BindingInputOptions,
 } from '../binding.cjs';
-import { BuiltinPlugin } from '../builtin-plugin/utils';
+import {
+  bindingifyViteHtmlPlugin,
+  BuiltinPlugin,
+} from '../builtin-plugin/utils';
 import { bindingifyBuiltInPlugin } from '../builtin-plugin/utils';
 import type { LogHandler } from '../log/log-handler';
 import type { LogLevelOption } from '../log/logging';
@@ -52,7 +55,10 @@ export function bindingifyInputOptions(
       return undefined;
     }
     if (plugin instanceof BuiltinPlugin) {
-      return bindingifyBuiltInPlugin(plugin as BuiltinPlugin);
+      if (plugin.name === 'builtin:vite-html') {
+        return bindingifyViteHtmlPlugin(plugin, onLog, logLevel, watchMode);
+      }
+      return bindingifyBuiltInPlugin(plugin);
     }
     return bindingifyPlugin(
       plugin,

--- a/packages/rolldown/src/utils/transform-to-rollup-output.ts
+++ b/packages/rolldown/src/utils/transform-to-rollup-output.ts
@@ -6,7 +6,7 @@ import type {
   JsOutputAsset,
   JsOutputChunk,
 } from '../binding.cjs';
-import type { PluginContext } from '../plugin/plugin-context';
+import type { MinimalPluginContext } from '../plugin/minimal-plugin-context';
 import { OutputAssetImpl } from '../types/output-asset-impl';
 import type { OutputBundle } from '../types/output-bundle';
 import { OutputChunkImpl } from '../types/output-chunk-impl';
@@ -40,7 +40,7 @@ export function transformToRollupSourceMap(map: string): SourceMap {
   return obj;
 }
 
-function transformToRollupOutputChunk(
+export function transformToRollupOutputChunk(
   bindingChunk: BindingOutputChunk,
 ): OutputChunk {
   return new OutputChunkImpl(bindingChunk);
@@ -171,7 +171,7 @@ function transformToMutableRollupOutput(
 }
 
 export function transformToOutputBundle(
-  context: PluginContext,
+  context: MinimalPluginContext,
   output: BindingOutputs,
   changed: ChangedOutputs,
 ): OutputBundle {

--- a/packages/rolldown/src/version.ts
+++ b/packages/rolldown/src/version.ts
@@ -1,0 +1,3 @@
+import { version } from '../package.json';
+
+export const VERSION: string = version;


### PR DESCRIPTION
Preparation for implementing the `transformIndexHtml` hook in the native HTML plugin.