### PR TITLE
chore: target node v24

### DIFF
--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -159,7 +159,7 @@ function withShared(
       ],
     },
     transform: {
-      target: 'node22',
+      target: 'node24',
       decorator: {
         // Legacy decorators are required for the @lazyProp decorator
         legacy: true,


### PR DESCRIPTION
should we target node v22 or we can move to node v24 ? 