### PR TITLE
chore(rolldown): add aliases for renamed vite plugins

### DIFF
--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -44,6 +44,17 @@ export {
   viteWebWorkerPostPlugin,
 } from './builtin-plugin/constructors';
 
+export {
+  /**
+   * @deprecated Use `viteDynamicImportVarsPlugin` instead.
+   */
+  viteDynamicImportVarsPlugin as dynamicImportVarsPlugin,
+  /**
+   * @deprecated Use `viteImportGlobPlugin` instead.
+   */
+  viteImportGlobPlugin as importGlobPlugin,
+} from './builtin-plugin/constructors';
+
 export { viteAliasPlugin } from './builtin-plugin/alias-plugin';
 export { viteAssetPlugin } from './builtin-plugin/asset-plugin';
 export { viteTransformPlugin } from './builtin-plugin/transform-plugin';

--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -46,11 +46,11 @@ export {
 
 export {
   /**
-   * @deprecated Use `viteDynamicImportVarsPlugin` instead.
+   * Alias of `viteDynamicImportVarsPlugin`. Note that this plugin is only intended to be used by Vite.
    */
   viteDynamicImportVarsPlugin as dynamicImportVarsPlugin,
   /**
-   * @deprecated Use `viteImportGlobPlugin` instead.
+   * Alias of `viteImportGlobPlugin`. Note that this plugin is only intended to be used by Vite.
    */
   viteImportGlobPlugin as importGlobPlugin,
 } from './builtin-plugin/constructors';


### PR DESCRIPTION
Related to #7042

I noticed that some users, including `tsdown`, rely on the Vite-specific plugins `importGlobPlugin` and `dynamicImportVarsPlugin`. This caused issues when I tried to upgrade `rolldown-vite`, so I’m keeping these aliases for now to preserve compatibility.