### PR TITLE
test(vite-tests): use integration branch for vite compatibility tests

### DIFF
--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -46,7 +46,12 @@ fs.rmSync(REPO_PATH, { recursive: true, force: true });
 
 await runCmdAndPipeOrExit(
   '# Cloning rolldown-vite repo...',
-  ['git', ['clone', 'https://github.com/vitejs/rolldown-vite.git', REPO_PATH]],
+  ['git', ['clone', '--branch', 'integration', 'https://github.com/vitejs/rolldown-vite.git', REPO_PATH]],
+);
+
+await runCmdAndPipeOrExit(
+  '# Rebasing integration onto rolldown-vite...',
+  ['git', ['rebase', 'origin/rolldown-vite'], { nodeOptions: { cwd: REPO_PATH } }],
 );
 
 printTitle('# Updating pnpm-workspace.yaml to link to local rolldown...');


### PR DESCRIPTION
closes #7090

Let's fix the CI issue first, and later we can explore whether there's a better way to determine if the branch is up to date, or even automate the rebasing process.