### PR TITLE
fix: `canonical name not found for "__toESM"` error when only named imports are used from a CJS module

### DIFF
--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -184,7 +184,9 @@ impl LinkStage<'_> {
                             .referenced_symbols
                             .push(importee_linking_info.wrapper_ref.unwrap().into());
                           // Only reference __toESM if this import needs interop (namespace or default import)
-                          if import_record_needs_interop(importer, *rec_id) {
+                          if rec.meta.contains(ImportRecordMeta::SafelyMergeCjsNs)
+                            || import_record_needs_interop(importer, *rec_id)
+                          {
                             depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()]
                               .push(stmt_info_idx);
                           }

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/_config.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "./entry.js"
+      }
+    ]
+  },
+  "snapshot": true
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/artifacts.snap
@@ -1,0 +1,29 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+import assert from "node:assert";
+
+// HIDDEN [rolldown:runtime]
+//#region node_modules/this-is-only-used-for-testing/index.js
+var require_this_is_only_used_for_testing = /* @__PURE__ */ __commonJS({ "node_modules/this-is-only-used-for-testing/index.js": ((exports, module) => {
+	function React() {}
+	React.useState = function() {
+		return "useState";
+	};
+	module.exports = React;
+	module.exports.default = React;
+	module.exports.useState = React.useState;
+}) });
+
+//#endregion
+//#region entry.js
+var import_this_is_only_used_for_testing = /* @__PURE__ */ __toESM(require_this_is_only_used_for_testing());
+assert.deepStrictEqual(typeof import_this_is_only_used_for_testing.useState, "function");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/entry.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/entry.js
@@ -1,0 +1,5 @@
+// Test case for SafelyMergeCjsNs optimization with only named and default imports
+import assert from 'node:assert';
+import { useState } from 'this-is-only-used-for-testing';
+
+assert.deepStrictEqual(typeof useState, 'function');

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/node_modules/this-is-only-used-for-testing/index.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/node_modules/this-is-only-used-for-testing/index.js
@@ -1,0 +1,8 @@
+// Simulate a CJS module like React
+function React() {}
+React.useState = function() { return 'useState'; };
+
+// CJS default export pattern
+module.exports = React;
+module.exports.default = React;
+module.exports.useState = React.useState;

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/node_modules/this-is-only-used-for-testing/package.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named/node_modules/this-is-only-used-for-testing/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "this-is-only-used-for-testing",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3585,6 +3585,10 @@ expression: output
 
 - main-!~{000}~.js => main-D1C-gG3C.js
 
+# tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named
+
+- entry-!~{000}~.js => entry-PmYJA9nw.js
+
 # tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_with_default_import
 
 - entry-!~{000}~.js => entry-B0qRPq32.js


### PR DESCRIPTION
`canonical name not found for "__toESM"` error when only named imports are used from a CJS module and SafelyMergeCjsNs optimization is applied.

refs #7006, #6850
