### PR TITLE
feat: show error contexts for unhandleable errors

### DIFF
--- a/crates/rolldown_error/src/build_diagnostic/events/unhandleable_error.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/unhandleable_error.rs
@@ -20,7 +20,7 @@ impl BuildEvent for UnhandleableError {
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {
     format!(
-      "Something went wrong inside rolldown, please report this problem at https://github.com/rolldown/rolldown/issues.\n{}",
+      "Something went wrong inside rolldown, please report this problem at https://github.com/rolldown/rolldown/issues.\n{:?}",
       self.0
     )
   }


### PR DESCRIPTION
Added `:?` so that the contexts are output.