### PR TITLE
feat: add isPathFragment validation for filename patterns (rollup compat)

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -484,8 +484,9 @@ impl<'a> GenerateStage<'a> {
             }
           });
 
-          let mut filename =
-            asset_filename_template.render(Some(&name), None, extension, hash_replacer).into();
+          let mut filename = asset_filename_template
+            .render("assetFileNames", Some(&name), None, extension, hash_replacer)?
+            .into();
           filename = make_unique_name(&filename, &used_name_counts);
           let preliminary = PreliminaryFilename::new(filename, hash_placeholder);
 

--- a/crates/rolldown/tests/rolldown/function/asset_filenames/mod.rs
+++ b/crates/rolldown/tests/rolldown/function/asset_filenames/mod.rs
@@ -28,7 +28,7 @@ impl Plugin for TestPlugin {
       },
       None,
       None,
-    );
+    )?;
 
     Ok(None)
   }

--- a/crates/rolldown/tests/rolldown/function/dir/should_generate_correct_relative_import_path/_config.json
+++ b/crates/rolldown/tests/rolldown/function/dir/should_generate_correct_relative_import_path/_config.json
@@ -10,10 +10,11 @@
         "import": "./b.js"
       }
     ],
-    "entryFilenames": "./entries/[name].mjs",
-    "chunkFilenames": "./chunks/[name].mjs",
+    "entryFilenames": "entries/[name].mjs",
+    "chunkFilenames": "chunks/[name].mjs",
     "dir": "./dist/lib"
   },
   "_comment": "See comments in `crates/rolldown/tests/common/fixture.rs`",
   "expectExecuted": false
 }
+

--- a/crates/rolldown/tests/rolldown/function/dir/should_generate_correct_relative_import_path/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/dir/should_generate_correct_relative_import_path/artifacts.snap
@@ -3,7 +3,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## ./chunks/async.mjs
+## chunks/async.mjs
 
 ```js
 //#region async.js
@@ -13,7 +13,7 @@ const value = "async";
 export { value };
 ```
 
-## ./chunks/shared.mjs
+## chunks/shared.mjs
 
 ```js
 //#region shared.js
@@ -23,7 +23,7 @@ const value = "shared";
 export { value as t };
 ```
 
-## ./entries/a.mjs
+## entries/a.mjs
 
 ```js
 import { t as value } from "../chunks/shared.mjs";
@@ -35,7 +35,7 @@ const asyncValue = import("../chunks/async.mjs");
 export { asyncValue, value };
 ```
 
-## ./entries/b.mjs
+## entries/b.mjs
 
 ```js
 import { t as value } from "../chunks/shared.mjs";

--- a/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_correct_relative_import_path/_config.json
+++ b/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_correct_relative_import_path/_config.json
@@ -10,9 +10,10 @@
         "import": "./b.js"
       }
     ],
-    "entryFilenames": "./entries/[name].mjs",
-    "chunkFilenames": "./chunks/[name].mjs"
+    "entryFilenames": "entries/[name].mjs",
+    "chunkFilenames": "chunks/[name].mjs"
   },
   "_comment": "See comments in `crates/rolldown/tests/common/fixture.rs`",
   "expectExecuted": false
 }
+

--- a/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_correct_relative_import_path/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_correct_relative_import_path/artifacts.snap
@@ -3,7 +3,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## ./chunks/async.mjs
+## chunks/async.mjs
 
 ```js
 //#region async.js
@@ -13,7 +13,7 @@ const value = "async";
 export { value };
 ```
 
-## ./chunks/shared.mjs
+## chunks/shared.mjs
 
 ```js
 //#region shared.js
@@ -23,7 +23,7 @@ const value = "shared";
 export { value as t };
 ```
 
-## ./entries/a.mjs
+## entries/a.mjs
 
 ```js
 import { t as value } from "../chunks/shared.mjs";
@@ -35,7 +35,7 @@ const asyncValue = import("../chunks/async.mjs");
 export { asyncValue, value };
 ```
 
-## ./entries/b.mjs
+## entries/b.mjs
 
 ```js
 import { t as value } from "../chunks/shared.mjs";

--- a/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_specified_hash_length/_config.json
+++ b/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_specified_hash_length/_config.json
@@ -6,8 +6,9 @@
         "import": "./entry.js"
       }
     ],
-    "entryFilenames": "./entries/[hash]-[hash:11]-[hash:2]-[hash:22].js",
-    "chunkFilenames": "./chunks/[hash]-[hash:11]-[hash:2]-[hash:22].js"
+    "entryFilenames": "entries/[hash]-[hash:11]-[hash:2]-[hash:22].js",
+    "chunkFilenames": "chunks/[hash]-[hash:11]-[hash:2]-[hash:22].js"
   },
   "expectExecuted": false
 }
+

--- a/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_specified_hash_length/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_specified_hash_length/artifacts.snap
@@ -3,7 +3,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## ./entries/DdSsPkRG-DdSsPkRG2Yj-DdSsPk-DdSsPkRG2Yjs97Y7JepQN.js
+## entries/C9xVeX1M-C9xVeX1M2a8-C9xVeX-C9xVeX1M2a84T2-Cu0BhH.js
 
 ```js
 //#region shared.js

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3857,21 +3857,21 @@ expression: output
 
 # tests/rolldown/function/dir/should_generate_correct_relative_import_path
 
-- ./entries/a.mjs => ./entries/a.mjs
-- ./entries/b.mjs => ./entries/b.mjs
-- ./chunks/async.mjs => ./chunks/async.mjs
-- ./chunks/shared.mjs => ./chunks/shared.mjs
+- entries/a.mjs => entries/a.mjs
+- entries/b.mjs => entries/b.mjs
+- chunks/async.mjs => chunks/async.mjs
+- chunks/shared.mjs => chunks/shared.mjs
 
 # tests/rolldown/function/entry_filenames/should_generate_correct_relative_import_path
 
-- ./entries/a.mjs => ./entries/a.mjs
-- ./entries/b.mjs => ./entries/b.mjs
-- ./chunks/async.mjs => ./chunks/async.mjs
-- ./chunks/shared.mjs => ./chunks/shared.mjs
+- entries/a.mjs => entries/a.mjs
+- entries/b.mjs => entries/b.mjs
+- chunks/async.mjs => chunks/async.mjs
+- chunks/shared.mjs => chunks/shared.mjs
 
 # tests/rolldown/function/entry_filenames/should_generate_specified_hash_length
 
-- ./entries/!~{000}~-!~{000001}~-!~{2}~-!~{0000000000000003}~.js => ./entries/DdSsPkRG-DdSsPkRG2Yj-DdSsPk-DdSsPkRG2Yjs97Y7JepQN.js
+- entries/!~{000}~-!~{000001}~-!~{2}~-!~{0000000000000003}~.js => entries/C9xVeX1M-C9xVeX1M2a8-C9xVeX-C9xVeX1M2a84T2-Cu0BhH.js
 
 # tests/rolldown/function/es-target
 

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
@@ -80,7 +80,11 @@ impl BindingPluginContext {
     asset_filename: Option<String>,
     fn_sanitized_file_name: Option<String>,
   ) -> napi::Result<napi::JsString<'env>> {
-    env.create_string(self.inner.emit_file(file.into(), asset_filename, fn_sanitized_file_name))
+    let reference_id = self
+      .inner
+      .emit_file(file.into(), asset_filename, fn_sanitized_file_name)
+      .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+    env.create_string(&reference_id)
   }
 
   #[napi]

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -213,8 +213,17 @@ impl Chunk {
     });
     let chunk_name = self.get_preserve_modules_chunk_name(options, chunk_name.as_str());
 
+    // Determine the pattern name for error messages
+    let pattern_name = if matches!(self.kind, ChunkKind::EntryPoint { meta, .. } if meta.contains(ChunkMeta::UserDefinedEntry) && !meta.contains(ChunkMeta::EmittedChunk))
+      || options.preserve_modules
+    {
+      "entryFileNames"
+    } else {
+      "chunkFileNames"
+    };
+
     let filename = filename_template
-      .render(Some(&chunk_name), Some(options.format.as_str()), None, hash_replacer)
+      .render(pattern_name, Some(&chunk_name), Some(options.format.as_str()), None, hash_replacer)?
       .into();
 
     let name = make_unique_name(&filename, used_name_counts);
@@ -285,8 +294,16 @@ impl Chunk {
     });
     let chunk_name = self.get_preserve_modules_chunk_name(options, chunk_name.as_str());
 
+    // Determine the pattern name for error messages
+    let pattern_name = if matches!(self.kind, ChunkKind::EntryPoint { meta, .. } if meta.contains(ChunkMeta::UserDefinedEntry) && !meta.contains(ChunkMeta::EmittedChunk))
+    {
+      "cssEntryFileNames"
+    } else {
+      "cssChunkFileNames"
+    };
+
     let filename = filename_template
-      .render(Some(&chunk_name), Some(options.format.as_str()), None, hash_replacer)
+      .render(pattern_name, Some(&chunk_name), Some(options.format.as_str()), None, hash_replacer)?
       .into();
 
     let name = make_unique_name(&filename, used_name_counts);

--- a/crates/rolldown_common/src/inner_bundler_options/types/filename_template.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/filename_template.rs
@@ -1,4 +1,32 @@
+use std::path::Path;
+
 use rolldown_utils::replace_all_placeholder::{ReplaceAllPlaceholder, Replacer};
+
+/// Check if a string is a path fragment (absolute or relative path).
+/// Patterns can be neither absolute nor relative paths.
+///
+/// Returns true if the name:
+/// - Starts with "/" (Unix absolute path)
+/// - Starts with "./" or "../" (relative paths)
+/// - Is an absolute path (e.g., "C:/" on Windows)
+fn is_path_fragment(name: &str) -> bool {
+  if name.is_empty() {
+    return false;
+  }
+
+  // Check for "/" prefix (Unix absolute)
+  if name.starts_with('/') {
+    return true;
+  }
+
+  // Check for "./" or "../" prefix (relative)
+  if name.starts_with("./") || name.starts_with("../") {
+    return true;
+  }
+
+  // Check if it's an absolute path (handles Windows paths like "C:/")
+  Path::new(name).is_absolute()
+}
 
 #[derive(Debug)]
 pub struct FilenameTemplate {
@@ -24,27 +52,65 @@ impl From<String> for FilenameTemplate {
 impl FilenameTemplate {
   pub fn render(
     self,
+    pattern_name: &str,
     name: Option<&str>,
     format: Option<&str>,
     extension: Option<&str>,
     hash_replacer: Option<impl Replacer>,
-  ) -> String {
+  ) -> anyhow::Result<String> {
+    // Validate the template pattern itself
+    if is_path_fragment(&self.template) {
+      anyhow::bail!(
+        "Invalid pattern \"{}\" for \"{}\", patterns can be neither absolute nor relative paths. \
+         If you want your files to be stored in a subdirectory, write its name without a leading \
+         slash like this: subdirectory/pattern.",
+        self.template,
+        pattern_name
+      );
+    }
+
     let mut tmp = self.template;
+
     if let Some(name) = name {
+      // Validate the name replacement
+      if is_path_fragment(name) {
+        anyhow::bail!(
+          "Invalid substitution \"{name}\" for placeholder \"[name]\" in \"{pattern_name}\" pattern, \
+           can be neither absolute nor relative path."
+        );
+      }
       tmp = tmp.replace_all("[name]", name);
     }
+
     if let Some(format) = format {
+      // Validate the format replacement
+      if is_path_fragment(format) {
+        anyhow::bail!(
+          "Invalid substitution \"{format}\" for placeholder \"[format]\" in \"{pattern_name}\" pattern, \
+           can be neither absolute nor relative path."
+        );
+      }
       tmp = tmp.replace_all("[format]", format);
     }
+
     if let Some(hash_replacer) = hash_replacer {
       tmp = tmp.replace_all_with_len("[hash]", hash_replacer);
     }
+
     if let Some(ext) = extension {
+      // Validate the extension replacement
+      if is_path_fragment(ext) {
+        anyhow::bail!(
+          "Invalid substitution \"{ext}\" for placeholder \"[ext]\" in \"{pattern_name}\" pattern, \
+           can be neither absolute nor relative path."
+        );
+      }
       let extname = if ext.is_empty() { "" } else { &format!(".{ext}") };
       tmp = tmp.replace_all("[ext]", ext);
       tmp = tmp.replace_all("[extname]", extname);
     }
-    tmp
+
+    Ok(tmp)
   }
 
   pub fn has_hash_pattern(&self) -> bool {
@@ -56,19 +122,92 @@ impl FilenameTemplate {
   }
 }
 
-#[test]
-fn basic() {
-  FilenameTemplate::new("[name]-[hash:8].js".to_string());
-}
+#[cfg(test)]
+mod tests {
+  use super::*;
 
-#[test]
-fn hash_with_len() {
-  let filename_template = FilenameTemplate::new("[name]-[hash:3]-[hash:3].js".to_string());
+  #[test]
+  fn basic() {
+    FilenameTemplate::new("[name]-[hash:8].js".to_string());
+  }
 
-  let mut hash_iter = ["abc", "def"].iter();
-  let hash_replacer = filename_template.has_hash_pattern().then_some(|_| hash_iter.next().unwrap());
+  #[test]
+  fn hash_with_len() {
+    let filename_template = FilenameTemplate::new("[name]-[hash:3]-[hash:3].js".to_string());
 
-  let filename = filename_template.render(Some("hello"), None, None, hash_replacer);
+    let mut hash_iter = ["abc", "def"].iter();
+    let hash_replacer =
+      filename_template.has_hash_pattern().then_some(|_| hash_iter.next().unwrap());
 
-  assert_eq!(filename, "hello-abc-def.js");
+    let filename = filename_template
+      .render("entryFileNames", Some("hello"), None, None, hash_replacer)
+      .expect("should render");
+
+    assert_eq!(filename, "hello-abc-def.js");
+  }
+
+  #[test]
+  fn test_is_path_fragment() {
+    // Absolute paths
+    assert!(is_path_fragment("/absolute/path"));
+    assert!(is_path_fragment("/"));
+
+    // Relative paths
+    assert!(is_path_fragment("./relative"));
+    assert!(is_path_fragment("../parent"));
+
+    // Valid subdirectory patterns (not path fragments)
+    assert!(!is_path_fragment("dist/[name].js"));
+    assert!(!is_path_fragment("[name]-[hash].js"));
+    assert!(!is_path_fragment("chunk"));
+
+    // Empty string
+    assert!(!is_path_fragment(""));
+  }
+
+  #[test]
+  fn test_invalid_pattern() {
+    let template = FilenameTemplate::new("/absolute/path/[name].js".to_string());
+    let result = template.render("entryFileNames", Some("test"), None, None, None::<&str>);
+    assert!(result.is_err());
+    assert!(
+      result.unwrap_err().to_string().contains("patterns can be neither absolute nor relative")
+    );
+  }
+
+  #[test]
+  fn test_invalid_name_substitution() {
+    let template = FilenameTemplate::new("[name].js".to_string());
+    let result =
+      template.render("entryFileNames", Some("/absolute/name"), None, None, None::<&str>);
+    assert!(result.is_err());
+    assert!(
+      result
+        .unwrap_err()
+        .to_string()
+        .contains("Invalid substitution \"/absolute/name\" for placeholder \"[name]\"")
+    );
+  }
+
+  #[test]
+  fn test_invalid_format_substitution() {
+    let template = FilenameTemplate::new("[name]-[format].js".to_string());
+    let result =
+      template.render("entryFileNames", Some("test"), Some("./relative"), None, None::<&str>);
+    assert!(result.is_err());
+    assert!(
+      result
+        .unwrap_err()
+        .to_string()
+        .contains("Invalid substitution \"./relative\" for placeholder \"[format]\"")
+    );
+  }
+
+  #[test]
+  fn test_valid_subdirectory() {
+    let template = FilenameTemplate::new("dist/[name].js".to_string());
+    let result = template.render("entryFileNames", Some("test"), None, None, None::<&str>);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "dist/test.js");
+  }
 }

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -144,7 +144,7 @@ impl NativePluginContextImpl {
     file: rolldown_common::EmittedAsset,
     fn_asset_filename: Option<String>,
     fn_sanitized_file_name: Option<String>,
-  ) -> ArcStr {
+  ) -> anyhow::Result<ArcStr> {
     let file_name_is_none = file.file_name.is_none();
     let asset_filename_template =
       file_name_is_none.then(|| self.options.asset_filenames.value(fn_asset_filename).into());
@@ -161,7 +161,7 @@ impl NativePluginContextImpl {
   ) -> anyhow::Result<ArcStr> {
     let asset_filename = self.options.asset_filename_with_file(&file).await?;
     let sanitized_file_name = self.options.sanitize_file_name_with_file(&file).await?;
-    Ok(self.file_emitter.emit_file(file, asset_filename.map(Into::into), sanitized_file_name))
+    self.file_emitter.emit_file(file, asset_filename.map(Into::into), sanitized_file_name)
   }
 
   pub fn get_file_name(&self, reference_id: &str) -> anyhow::Result<ArcStr> {

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
@@ -95,7 +95,7 @@ impl PluginContext {
     file: rolldown_common::EmittedAsset,
     fn_asset_filename: Option<String>,
     fn_sanitized_file_name: Option<String>,
-  ) -> ArcStr {
+  ) -> anyhow::Result<ArcStr> {
     call_native_only!(self, "emit_file", ctx => ctx.emit_file(file, fn_asset_filename, fn_sanitized_file_name))
   }
 

--- a/crates/rolldown_plugin_isolated_declaration/src/lib.rs
+++ b/crates/rolldown_plugin_isolated_declaration/src/lib.rs
@@ -76,7 +76,7 @@ impl Plugin for IsolatedDeclarationPlugin {
         },
         None,
         None,
-      );
+      )?;
     }
     Ok(args.ast)
   }

--- a/packages/rolldown/tests/fixtures/misc/rollup-file-url/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/rollup-file-url/_config.ts
@@ -8,8 +8,8 @@ export default defineTest({
   config: {
     output: {
       // tweak directory structure to test relative path reference
-      entryFileNames: './entries/[name].mjs',
-      assetFileNames: './assets/[name]-test.[ext]',
+      entryFileNames: 'entries/[name].mjs',
+      assetFileNames: 'assets/[name]-test.[ext]',
     },
     plugins: [
       // example plugin from

--- a/packages/rolldown/tests/fixtures/output/file-names/invalid-absolute-chunk-name/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/file-names/invalid-absolute-chunk-name/_config.ts
@@ -1,0 +1,23 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    output: {
+      manualChunks(id) {
+        if (id.includes('foo.js')) {
+          return '/absolute/path';
+        }
+        return null;
+      },
+    },
+  },
+  catchError(error: any) {
+    expect(error.message).toContain(
+      'Invalid substitution "/absolute/path" for placeholder "[name]"',
+    );
+    expect(error.message).toContain(
+      'can be neither absolute nor relative path',
+    );
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/file-names/invalid-absolute-chunk-name/foo.js
+++ b/packages/rolldown/tests/fixtures/output/file-names/invalid-absolute-chunk-name/foo.js
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/packages/rolldown/tests/fixtures/output/file-names/invalid-absolute-chunk-name/main.js
+++ b/packages/rolldown/tests/fixtures/output/file-names/invalid-absolute-chunk-name/main.js
@@ -1,0 +1,1 @@
+import('./foo.js');

--- a/packages/rolldown/tests/fixtures/output/file-names/invalid-advanced-chunk-name/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/file-names/invalid-advanced-chunk-name/_config.ts
@@ -1,0 +1,25 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    output: {
+      advancedChunks: {
+        groups: [
+          {
+            name: (file) => {
+              const relative = file.replace(/^\/src\//, '');
+              return relative.replace(/\..+$/, '');
+            },
+          },
+        ],
+      },
+    },
+  },
+  catchError(error: any) {
+    expect(error.message).toContain('Invalid substitution ');
+    expect(error.message).toContain(
+      'can be neither absolute nor relative path',
+    );
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/file-names/invalid-advanced-chunk-name/bar.js
+++ b/packages/rolldown/tests/fixtures/output/file-names/invalid-advanced-chunk-name/bar.js
@@ -1,0 +1,1 @@
+export default 'bar';

--- a/packages/rolldown/tests/fixtures/output/file-names/invalid-advanced-chunk-name/main.js
+++ b/packages/rolldown/tests/fixtures/output/file-names/invalid-advanced-chunk-name/main.js
@@ -1,0 +1,1 @@
+import('./bar.js');


### PR DESCRIPTION
Close #6424

---

- `"entryFilenames": "./entries/[name].mjs"` is not considered as valid anymore after aligning with rollup.
- The correct pattern should be `"entryFilenames": "entries/[name].mjs"`