### PR TITLE
feat: export sync APIs to experimental

### DIFF
--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -12,6 +12,7 @@ export {
   minify,
   type MinifyOptions,
   type MinifyResult,
+  minifySync,
   moduleRunnerTransform,
   type NapiResolveOptions as ResolveOptions,
   parse,
@@ -23,6 +24,7 @@ export {
   transform,
   type TransformOptions,
   type TransformResult,
+  transformSync,
 } from './binding.cjs';
 export { defineParallelPlugin } from './plugin/parallel-plugin';
 // Builtin plugin factory


### PR DESCRIPTION
We need to expose `minifySync` so that it can be used by Vite. In addition, I’ve also exposed `transformSync` in case it may be needed later.