### PR TITLE
fix: correct return value of `parse` / `parseSync` functions

### DIFF
--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -15,10 +15,8 @@ export {
   minifySync,
   moduleRunnerTransform,
   type NapiResolveOptions as ResolveOptions,
-  parse,
   type ParseResult,
   type ParserOptions,
-  parseSync,
   type ResolveResult,
   ResolverFactory,
   transform,
@@ -27,6 +25,7 @@ export {
   transformSync,
 } from './binding.cjs';
 export { defineParallelPlugin } from './plugin/parallel-plugin';
+export { parse, parseSync } from './utils/parse';
 // Builtin plugin factory
 export {
   isolatedDeclarationPlugin,

--- a/packages/rolldown/src/parse-ast-index.ts
+++ b/packages/rolldown/src/parse-ast-index.ts
@@ -1,15 +1,11 @@
 import type { Program } from '@oxc-project/types';
-import { parse, parseSync } from './binding.cjs';
 import type { ParseResult, ParserOptions } from './binding.cjs';
 import { locate } from './log/locate-character';
 import { error, logParseError } from './log/logs';
 import { getCodeFrame } from './utils/code-frame';
-// @ts-ignore
-import * as oxcParserWrap from 'oxc-parser/src-js/wrap.js';
+import { parse, parseSync } from './utils/parse';
 
 function wrap(result: ParseResult, sourceText: string) {
-  // reuse oxc-parser wrap and eagerly throw an error if any
-  result = oxcParserWrap.wrap(result);
   if (result.errors.length > 0) {
     return normalizeParseError(sourceText, result.errors);
   }

--- a/packages/rolldown/src/utils/parse.ts
+++ b/packages/rolldown/src/utils/parse.ts
@@ -1,0 +1,30 @@
+import {
+  parse as originalParse,
+  type ParseResult,
+  type ParserOptions,
+  parseSync as originalParseSync,
+} from '../binding.cjs';
+// @ts-ignore
+import * as oxcParserWrap from 'oxc-parser/src-js/wrap.js';
+
+/**
+ * Parse asynchronously.
+ *
+ * Note: This function can be slower than `parseSync` due to the overhead of spawning a thread.
+ */
+export async function parse(
+  filename: string,
+  sourceText: string,
+  options?: ParserOptions | null,
+): Promise<ParseResult> {
+  return oxcParserWrap.wrap(await originalParse(filename, sourceText, options));
+}
+
+/** Parse synchronously. */
+export function parseSync(
+  filename: string,
+  sourceText: string,
+  options?: ParserOptions | null,
+): ParseResult {
+  return oxcParserWrap.wrap(originalParseSync(filename, sourceText, options));
+}

--- a/packages/rolldown/tests/utils/parse.test.ts
+++ b/packages/rolldown/tests/utils/parse.test.ts
@@ -1,0 +1,40 @@
+import { parse, parseSync } from 'rolldown/experimental';
+import { expect, test } from 'vitest';
+
+test('parse non json value', async () => {
+  const result = await parse('foo.js', '1n');
+  expect(result.program.body[0]).toMatchInlineSnapshot(`
+    {
+      "end": 2,
+      "expression": {
+        "bigint": "1",
+        "end": 2,
+        "raw": "1n",
+        "start": 0,
+        "type": "Literal",
+        "value": 1n,
+      },
+      "start": 0,
+      "type": "ExpressionStatement",
+    }
+  `);
+});
+
+test('parseSync non json value', () => {
+  const result = parseSync('foo.js', '1n');
+  expect(result.program.body[0]).toMatchInlineSnapshot(`
+    {
+      "end": 2,
+      "expression": {
+        "bigint": "1",
+        "end": 2,
+        "raw": "1n",
+        "start": 0,
+        "type": "Literal",
+        "value": 1n,
+      },
+      "start": 0,
+      "type": "ExpressionStatement",
+    }
+  `);
+});


### PR DESCRIPTION
fixes #7023
refs #3864
