### PR TITLE
fix: tree shake unused dynamic entry when `inlineDynamicImports` is enabled

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -683,18 +683,16 @@ impl<'a> ModuleLoader<'a> {
     });
 
     // if `inline_dynamic_imports` is set to be true, here we should not put dynamic imports to entries
-    if !self.options.inline_dynamic_imports {
-      let dynamic_import_entry_ids = dynamic_import_entry_ids.into_iter().collect::<Vec<_>>();
-      entry_points.extend(dynamic_import_entry_ids.into_iter().map(|(idx, related_stmt_infos)| {
-        EntryPoint {
-          name: None,
-          idx,
-          kind: EntryPointKind::DynamicImport,
-          file_name: None,
-          related_stmt_infos,
-        }
-      }));
-    }
+    let dynamic_import_entry_ids = dynamic_import_entry_ids.into_iter().collect::<Vec<_>>();
+    entry_points.extend(dynamic_import_entry_ids.into_iter().map(|(idx, related_stmt_infos)| {
+      EntryPoint {
+        name: None,
+        idx,
+        kind: EntryPointKind::DynamicImport,
+        file_name: None,
+        related_stmt_infos,
+      }
+    }));
 
     entry_points.extend(extra_entry_points);
 

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -130,10 +130,9 @@ impl<'a> LinkStage<'a> {
             .import_records()
             .iter()
             .filter_map(|rec| match rec.kind {
-              ImportKind::DynamicImport => {
-                options.inline_dynamic_imports.then_some(rec.resolved_module)
-              }
-              ImportKind::Require => None,
+              // Dynamically imported modules are included automatically by `include_statements`
+              // when `inlineDynamicImports` is enabled.
+              ImportKind::DynamicImport | ImportKind::Require => None,
               _ => Some(rec.resolved_module),
             })
             .collect();

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -185,7 +185,14 @@ impl LinkStage<'_> {
     dynamic_entries.retain(|entry| included_dynamic_entry.contains(&entry.idx));
 
     // update entries with lived only.
-    self.entries = user_defined_entries.into_iter().chain(dynamic_entries).collect();
+    self.entries = user_defined_entries
+      .into_iter()
+      .chain(if self.options.inline_dynamic_imports {
+        itertools::Either::Left(std::iter::empty())
+      } else {
+        itertools::Either::Right(dynamic_entries.into_iter())
+      })
+      .collect();
 
     // Setting the json module none self reference included symbol map
     for (mi, set) in std::mem::take(&mut context.json_module_none_self_reference_included_symbol) {

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/cjs/artifacts.snap
@@ -27,9 +27,9 @@ var init_esm = __esm({ "esm.js": (() => {
 
 //#endregion
 //#region main.js
-Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_foo()));
+Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
 Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs()));
-Promise.resolve().then(() => (init_esm(), esm_exports));
+Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/esm/artifacts.snap
@@ -26,9 +26,9 @@ var init_esm = __esm({ "esm.js": (() => {
 
 //#endregion
 //#region main.js
-Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_foo()));
+Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
 Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs()));
-Promise.resolve().then(() => (init_esm(), esm_exports));
+Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/iife/artifacts.snap
@@ -29,9 +29,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 //#endregion
 //#region main.js
-	Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_foo()));
+	Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
 	Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs()));
-	Promise.resolve().then(() => (init_esm(), esm_exports));
+	Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
 
 //#endregion
 })();

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/issue-6935/_config.json
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/issue-6935/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "inlineDynamicImports": true
+  },
+  "configVariants": []
+}

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/issue-6935/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/issue-6935/artifacts.snap
@@ -1,0 +1,21 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+//#region mod.js
+function testFunc() {
+	return 1;
+}
+
+//#endregion
+//#region main.js
+assert.strictEqual(testFunc(), 1);
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/issue-6935/lib.js
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/issue-6935/lib.js
@@ -1,0 +1,4 @@
+//#region node_modules/.pnpm/undici@7.16.0/node_modules/undici/index.js
+module.exports.Agent = class Agent {};
+
+throw new Error("This is a test error");

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/issue-6935/main.js
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/issue-6935/main.js
@@ -1,0 +1,4 @@
+import assert from "node:assert";
+import { testFunc } from "./mod";
+
+assert.strictEqual(testFunc(), 1);

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/issue-6935/mod.js
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/issue-6935/mod.js
@@ -1,0 +1,8 @@
+export function testFunc() {
+  return 1;
+}
+
+export async function makeAgent() {
+  const { Agent } = await import("./lib");
+  return new Agent();
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4269,15 +4269,19 @@ expression: output
 
 # tests/rolldown/function/inline_dynamic_imports/cjs
 
-- main-!~{000}~.js => main-j4VH_7R-.js
+- main-!~{000}~.js => main-5xT0bCgM.js
 
 # tests/rolldown/function/inline_dynamic_imports/esm
 
-- main-!~{000}~.js => main-CTE7AN26.js
+- main-!~{000}~.js => main-DRpP5LDP.js
 
 # tests/rolldown/function/inline_dynamic_imports/iife
 
-- main-!~{000}~.js => main-RPAa584s.js
+- main-!~{000}~.js => main-D4KDQmxd.js
+
+# tests/rolldown/function/inline_dynamic_imports/issue-6935
+
+- main-!~{000}~.js => main-FRcDF-nx.js
 
 # tests/rolldown/function/intro/cjs
 


### PR DESCRIPTION
closed #6935