### PR TITLE
feat(dev): replace `DevEngine::hasLatestBuildOutput` with `DevEngine::getBundleState`

### DIFF
--- a/crates/rolldown_dev/src/bundle_coordinator.rs
+++ b/crates/rolldown_dev/src/bundle_coordinator.rs
@@ -385,6 +385,7 @@ impl BundleCoordinator {
   fn create_state_snapshot(&self) -> CoordinatorStateSnapshot {
     CoordinatorStateSnapshot {
       running_future: self.current_bundling_future.clone(),
+      last_full_build_failed: self.state == CoordinatorState::FullBuildFailed,
       has_stale_output: self.has_stale_bundle_output,
     }
   }

--- a/crates/rolldown_dev/src/lib.rs
+++ b/crates/rolldown_dev/src/lib.rs
@@ -10,7 +10,10 @@ use std::sync::Arc;
 
 use rolldown_utils::dashmap::FxDashMap;
 pub use {
-  crate::{dev_context::BundlingFuture, dev_engine::DevEngine},
+  crate::{
+    dev_context::BundlingFuture,
+    dev_engine::{BundleState, DevEngine},
+  },
   rolldown_dev_common::types::{
     BundleOutput, DevOptions, DevWatchOptions, NormalizedDevOptions, OnHmrUpdatesCallback,
     OnOutputCallback, RebuildStrategy, SharedNormalizedDevOptions, normalize_dev_options,

--- a/crates/rolldown_dev/src/types/coordinator_state_snapshot.rs
+++ b/crates/rolldown_dev/src/types/coordinator_state_snapshot.rs
@@ -5,5 +5,6 @@ use crate::dev_context::BundlingFuture;
 pub struct CoordinatorStateSnapshot {
   // `None` if no build is running
   pub running_future: Option<BundlingFuture>,
+  pub last_full_build_failed: bool,
   pub has_stale_output: bool,
 }

--- a/packages/rolldown/src/api/dev/dev-engine.ts
+++ b/packages/rolldown/src/api/dev/dev-engine.ts
@@ -1,4 +1,5 @@
 import {
+  type BindingBundleState,
   type BindingClientHmrUpdate,
   BindingDevEngine,
   type BindingDevOptions,
@@ -109,8 +110,8 @@ export class DevEngine {
     return promise;
   }
 
-  async hasLatestBuildOutput(): Promise<boolean> {
-    return this.#inner.hasLatestBuildOutput();
+  async getBundleState(): Promise<BindingBundleState> {
+    return this.#inner.getBundleState();
   }
 
   async ensureLatestBuildOutput(): Promise<void> {

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1380,7 +1380,7 @@ export declare class BindingDevEngine {
   constructor(options: BindingBundlerOptions, devOptions?: BindingDevOptions | undefined | null)
   run(): Promise<void>
   ensureCurrentBuildFinish(): Promise<void>
-  hasLatestBuildOutput(): Promise<boolean>
+  getBundleState(): Promise<BindingBundleState>
   ensureLatestBuildOutput(): Promise<void>
   invalidate(caller: string, firstInvalidatedBy?: string | undefined | null): Promise<Array<BindingClientHmrUpdate>>
   registerModules(clientId: string, modules: Array<string>): void
@@ -1632,6 +1632,11 @@ export interface BindingBundlerOptions {
   inputOptions: BindingInputOptions
   outputOptions: BindingOutputOptions
   parallelPluginsRegistry?: ParallelJsPluginRegistry
+}
+
+export interface BindingBundleState {
+  lastFullBuildFailed: boolean
+  hasStaleOutput: boolean
 }
 
 export interface BindingChecksOptions {

--- a/packages/test-dev-server/src/dev-server.ts
+++ b/packages/test-dev-server/src/dev-server.ts
@@ -85,8 +85,8 @@ class DevServer {
     this.#devEngine = devEngine;
     process.stdin.on('data', async data => {
       if (data.toString() === 'r') {
-        const hasLatestOutput = await devEngine.hasLatestBuildOutput();
-        if (!hasLatestOutput) {
+        const { hasStaleOutput } = await devEngine.getBundleState();
+        if (hasStaleOutput) {
           await devEngine.ensureLatestBuildOutput();
         }
       }


### PR DESCRIPTION
Replace `DevEngine::hasLatestBuildOutput` with `DevEngine::getBundleState` that returns more information.

This new API will be used here to avoid triggering a rebuild if the previous build errored.
https://github.com/vitejs/rolldown-vite/blob/593b1e4a0d1c1ab46d1f4f9620ace99eee7efccd/packages/vite/src/node/server/environments/fullBundleEnvironment.ts#L256-L265
https://github.com/vitejs/rolldown-vite/blob/593b1e4a0d1c1ab46d1f4f9620ace99eee7efccd/packages/vite/src/node/server/middlewares/indexHtml.ts#L479-L483
