### PR TITLE
fix(dev): watch files even if the build failed

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_initial_build_syntax_error/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_initial_build_syntax_error/_config.json
@@ -4,8 +4,5 @@
       "hmr": {}
     }
   },
-  "dev": {
-    "ensureLatestBuildOutputForEachStep": true
-  },
   "expectError": true
 }

--- a/crates/rolldown_dev/src/type_aliases.rs
+++ b/crates/rolldown_dev/src/type_aliases.rs
@@ -1,3 +1,4 @@
+use rustc_hash::FxHashSet;
 use tokio::sync::{
   mpsc::{UnboundedReceiver, UnboundedSender},
   oneshot,
@@ -20,3 +21,5 @@ pub type CoordinatorSender = UnboundedSender<CoordinatorMsg>;
 pub type CoordinatorReceiver = UnboundedReceiver<CoordinatorMsg>;
 
 pub type EnsureLatestBundleOutputSender = oneshot::Sender<Option<EnsureLatestBundleOutputReturn>>;
+
+pub type GetWatchedFilesSender = oneshot::Sender<FxHashSet<String>>;

--- a/crates/rolldown_dev/src/types/coordinator_msg.rs
+++ b/crates/rolldown_dev/src/types/coordinator_msg.rs
@@ -1,7 +1,7 @@
 use rolldown_fs_watcher::FsEventResult;
 
 use crate::type_aliases::{
-  EnsureLatestBundleOutputSender, GetStateSender, ScheduleBuildIfStaleSender,
+  EnsureLatestBundleOutputSender, GetStateSender, GetWatchedFilesSender, ScheduleBuildIfStaleSender,
 };
 
 /// Messages sent to the BundleCoordinator
@@ -12,5 +12,6 @@ pub enum CoordinatorMsg {
   ScheduleBuildIfStale { reply: ScheduleBuildIfStaleSender },
   GetState { reply: GetStateSender },
   EnsureLatestBundleOutput { reply: EnsureLatestBundleOutputSender },
+  GetWatchedFiles { reply: GetWatchedFilesSender },
   Close,
 }

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -209,6 +209,11 @@ impl IntegrationTest {
           &hmr_temp_dir_path,
           hmr_edit_files,
         );
+        let watched_files = dev_engine.get_watched_files().await.unwrap();
+        assert!(
+          changed_files.iter().all(|file| watched_files.contains(file)),
+          "All changed files must be in watched files: {changed_files:#?} not in {watched_files:#?}"
+        );
         dev_engine
           .ensure_task_with_changed_files(changed_files.into_iter().map(Into::into).collect())
           .await;


### PR DESCRIPTION
Add watch files added by builds that fails so that the next build is triggered when changing the file that was watched / errored.

refs #6648
