### PR TITLE
fix(rolldown_plugin_vite_html): use patched `html5gum` with correct span tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,8 +1079,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 [[package]]
 name = "html5gum"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6fbe46e93059ce8ee19fbefdb0c7699cc7197fcaac048f2c3593f3e5da845f"
+source = "git+https://github.com/shulaoda/html5gum#e97132da1637df557fe706df727d6938571fed65"
 dependencies = [
  "jetscii",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ form_urlencoded = "1.2.1"
 futures = "0.3.31"
 glob = "0.3.2"
 heck = "0.5.0"
-html5gum = "0.8.0"
+html5gum = { git = "https://github.com/shulaoda/html5gum" }
 indexmap = "2.9.0"
 infer = "0.19.0"
 insta = "1.43.1"

--- a/crates/rolldown_plugin_vite_html/src/html/parser.rs
+++ b/crates/rolldown_plugin_vite_html/src/html/parser.rs
@@ -5,7 +5,11 @@ use super::sink::{Attribute, RcDom, RcDomEmitter};
 
 pub fn parse_html(html: &str) -> RcDom {
   let mut dom_builder = RcDomEmitter::new();
-  let tokenizer = Tokenizer::new_with_emitter(html, DefaultEmitter::<usize>::new_with_span());
+  let mut emitter = DefaultEmitter::<usize>::new_with_span();
+
+  emitter.naively_switch_states(true);
+
+  let tokenizer = Tokenizer::new_with_emitter(html, emitter);
 
   for token in tokenizer {
     match token {


### PR DESCRIPTION
Ref https://github.com/untitaker/html5gum/pull/124