### PR TITLE
fix: watch overwrite rename event on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2735,32 +2735,32 @@ dependencies = [
 
 [[package]]
 name = "rolldown-notify"
-version = "8.2.1"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858a3e78503d89287b47d66fb042b4f04e34b237774506fbb48d7c3e5eb445cf"
+checksum = "58d681610d5f1818f4bd2a3c5ccaf92d494abf5ba5cabab1f707a652d9f7c5d8"
 dependencies = [
  "bitflags 2.10.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
- "log",
  "mio",
  "rolldown-notify-types",
+ "tracing",
  "walkdir",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rolldown-notify-debouncer-full"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e06775bbad4fa50fb0c07a1dfbb5ec3356131b6f0e19679910cb698aa54068"
+checksum = "8b121fd204ec8103827384d823041c3a97804ae71cef019e58cdde4298b639dc"
 dependencies = [
- "log",
  "rolldown-file-id",
  "rolldown-notify",
  "rolldown-notify-types",
+ "tracing",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,8 +178,8 @@ phf = "0.13.0"
 rayon = "1.10.0"
 regex = "1.11.1"
 regress = "0.10.3"
-rolldown-notify = { version = "8.1.0", default-features = false, features = ["macos_kqueue"] }
-rolldown-notify-debouncer-full = { version = "0.6.0", default-features = false, features = ["macos_kqueue"] }
+rolldown-notify = { version = "9.1.0", default-features = false, features = ["macos_kqueue"] }
+rolldown-notify-debouncer-full = { version = "0.7.1", default-features = false, features = ["macos_kqueue"] }
 ropey = "1.6.1"
 rustc-hash = { version = "2.1.1" }
 schemars = "1.0.0"

--- a/crates/rolldown_fs_watcher/src/debounced_poll_fs_watcher.rs
+++ b/crates/rolldown_fs_watcher/src/debounced_poll_fs_watcher.rs
@@ -39,7 +39,10 @@ impl FsWatcher for DebouncedPollFsWatcher {
     path: &std::path::Path,
     recursive_mode: notify::RecursiveMode,
   ) -> BuildResult<()> {
-    self.0.watch(path, recursive_mode).map_err_to_unhandleable()?;
+    self
+      .0
+      .watch(path, notify::WatchMode { recursive_mode, target_mode: notify::TargetMode::TrackPath })
+      .map_err_to_unhandleable()?;
 
     Ok(())
   }

--- a/crates/rolldown_fs_watcher/src/debounced_recommended_fs_watcher.rs
+++ b/crates/rolldown_fs_watcher/src/debounced_recommended_fs_watcher.rs
@@ -39,7 +39,10 @@ impl FsWatcher for DebouncedRecommendedFsWatcher {
     path: &std::path::Path,
     recursive_mode: notify::RecursiveMode,
   ) -> BuildResult<()> {
-    self.0.watch(path, recursive_mode).map_err_to_unhandleable()?;
+    self
+      .0
+      .watch(path, notify::WatchMode { recursive_mode, target_mode: notify::TargetMode::TrackPath })
+      .map_err_to_unhandleable()?;
 
     Ok(())
   }

--- a/crates/rolldown_fs_watcher/src/poll_fs_watcher.rs
+++ b/crates/rolldown_fs_watcher/src/poll_fs_watcher.rs
@@ -34,7 +34,10 @@ impl FsWatcher for PollFsWatcher {
     path: &std::path::Path,
     recursive_mode: notify::RecursiveMode,
   ) -> BuildResult<()> {
-    self.0.watch(path, recursive_mode).map_err_to_unhandleable()?;
+    self
+      .0
+      .watch(path, notify::WatchMode { recursive_mode, target_mode: notify::TargetMode::TrackPath })
+      .map_err_to_unhandleable()?;
     Ok(())
   }
 

--- a/crates/rolldown_fs_watcher/src/recommended_fs_watcher.rs
+++ b/crates/rolldown_fs_watcher/src/recommended_fs_watcher.rs
@@ -34,7 +34,10 @@ impl FsWatcher for RecommendedFsWatcher {
     path: &std::path::Path,
     recursive_mode: notify::RecursiveMode,
   ) -> BuildResult<()> {
-    self.0.watch(path, recursive_mode).map_err_to_unhandleable()?;
+    self
+      .0
+      .watch(path, notify::WatchMode { recursive_mode, target_mode: notify::TargetMode::TrackPath })
+      .map_err_to_unhandleable()?;
     Ok(())
   }
 

--- a/crates/rolldown_fs_watcher/src/utils.rs
+++ b/crates/rolldown_fs_watcher/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::{FsEventHandler, fs_event::FsEvent};
-use notify::RecursiveMode;
+use notify::{RecursiveMode, TargetMode, WatchMode};
 use rolldown_error::{BuildResult, ResultExt};
 use std::{path::Path, time::Instant};
 
@@ -20,7 +20,11 @@ impl<'me> NotifyPathsMutAdapter<'me> {
 
 impl crate::PathsMut for NotifyPathsMutAdapter<'_> {
   fn add(&mut self, path: &Path, recursive_mode: RecursiveMode) -> BuildResult<()> {
-    self.0.add(path, recursive_mode).map_err_to_unhandleable().map_err(Into::into)
+    self
+      .0
+      .add(path, WatchMode { recursive_mode, target_mode: TargetMode::TrackPath })
+      .map_err_to_unhandleable()
+      .map_err(Into::into)
   }
 
   fn remove(&mut self, path: &Path) -> BuildResult<()> {


### PR DESCRIPTION
fixes #6846, fixes #2634

requires https://github.com/rolldown/notify/pull/21, https://github.com/rolldown/notify/pull/22
