### PR TITLE
fix: collect and re-export transitive internal exports with cjs

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -51,7 +51,8 @@ use crate::{
   types::generator::GenerateContext,
   utils::chunk::{
     deconflict_chunk_symbols::{deconflict_chunk_symbols, generate_star_reexport_binding_names},
-    determine_export_mode::determine_export_mode, generate_pre_rendered_chunk,
+    determine_export_mode::determine_export_mode,
+    generate_pre_rendered_chunk,
     render_chunk_exports::get_chunk_export_names,
     validate_options_for_multi_chunk_output::validate_options_for_multi_chunk_output,
   },

--- a/crates/rolldown/src/utils/chunk/collect_transitive_external_star_exports.rs
+++ b/crates/rolldown/src/utils/chunk/collect_transitive_external_star_exports.rs
@@ -3,8 +3,8 @@ use rustc_hash::FxHashSet;
 
 /// Collects all external module indices that are transitively star-exported through internal modules.
 ///
-/// This function performs a BFS traversal starting from the given entry module, following `export *`
-/// statements through internal (normal) modules and collecting all external modules encountered.
+/// This function performs a graph traversal (order does not affect correctness) starting from the given entry module,
+/// following `export *` statements through internal (normal) modules and collecting all external modules encountered.
 ///
 /// # Example
 /// Consider this module graph:

--- a/crates/rolldown/src/utils/chunk/collect_transitive_external_star_exports.rs
+++ b/crates/rolldown/src/utils/chunk/collect_transitive_external_star_exports.rs
@@ -1,0 +1,64 @@
+use rolldown_common::{IndexModules, ModuleIdx};
+use rustc_hash::FxHashSet;
+
+/// Collects all external module indices that are transitively star-exported through internal modules.
+///
+/// This function performs a BFS traversal starting from the given entry module, following `export *`
+/// statements through internal (normal) modules and collecting all external modules encountered.
+///
+/// # Example
+/// Consider this module graph:
+/// - `index.js`: `export * from './server.js'`
+/// - `server.js`: `export * from 'external-lib'`
+///
+/// When called with `index.js` as the entry module, this function will:
+/// 1. Start at `index.js`
+/// 2. See it star-exports `server.js` (internal module), so add it to the queue
+/// 3. Visit `server.js`
+/// 4. See it star-exports `external-lib` (external module), so collect it
+/// 5. Return `{external-lib}`
+///
+/// # Arguments
+/// * `entry_module_idx` - The starting module for the traversal
+/// * `module_table` - The module table to look up modules
+///
+/// # Returns
+/// A set of external module indices that are transitively star-exported from the entry module.
+///
+/// # Related
+/// This utility was extracted to avoid duplication across:
+/// - `render_chunk_exports.rs` (issue #7115)
+/// - `deconflict_chunk_symbols.rs` (issue #7115)
+pub fn collect_transitive_external_star_exports(
+  entry_module_idx: ModuleIdx,
+  module_table: &IndexModules,
+) -> FxHashSet<ModuleIdx> {
+  let mut visited = FxHashSet::default();
+  let mut queue = vec![entry_module_idx];
+  let mut transitive_external_star_exports = FxHashSet::default();
+
+  while let Some(module_idx) = queue.pop() {
+    if !visited.insert(module_idx) {
+      continue;
+    }
+
+    let rolldown_common::Module::Normal(module) = &module_table[module_idx] else {
+      continue;
+    };
+
+    for star_export_idx in module.star_export_module_ids() {
+      match &module_table[star_export_idx] {
+        rolldown_common::Module::Normal(_) => {
+          // Internal module - traverse it
+          queue.push(star_export_idx);
+        }
+        rolldown_common::Module::External(_) => {
+          // External module - collect it
+          transitive_external_star_exports.insert(star_export_idx);
+        }
+      }
+    }
+  }
+
+  transitive_external_star_exports
+}

--- a/crates/rolldown/src/utils/chunk/mod.rs
+++ b/crates/rolldown/src/utils/chunk/mod.rs
@@ -8,6 +8,7 @@ use rustc_hash::FxHashMap;
 
 use crate::{stages::link_stage::LinkStageOutput, types::generator::GenerateContext};
 
+pub mod collect_transitive_external_star_exports;
 pub mod deconflict_chunk_symbols;
 pub mod determine_export_mode;
 pub mod determine_use_strict;

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -301,7 +301,7 @@ pub fn render_chunk_exports(
 });\n".replace("$NAME", &binding_name);
 
               s.push('\n');
-              writeln!(s, "var {} = require(\"{}\");", binding_name, import_path).unwrap();
+              writeln!(s, "var {binding_name} = require(\"{import_path}\");").unwrap();
               s.push_str(&import_stmt);
             }
           }

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/transitive_export_star_cjs/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/transitive_export_star_cjs/_config.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "input": [
+      {
+        "import": "./index.js"
+      }
+    ],
+    "format": "cjs",
+    "preserveModules": true,
+    "external": ["external-lib"]
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/transitive_export_star_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/transitive_export_star_cjs/artifacts.snap
@@ -22,11 +22,11 @@ var transitive_export_star_cjs_exports = {};
 
 //#endregion
 
-var require_server = require("./server.js");
-Object.keys(require_server).forEach(function (k) {
+var require_server$1 = require("./server.js");
+Object.keys(require_server$1).forEach(function (k) {
   if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
     enumerable: true,
-    get: function () { return require_server[k]; }
+    get: function () { return require_server$1[k]; }
   });
 });
 

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/transitive_export_star_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/transitive_export_star_cjs/artifacts.snap
@@ -1,0 +1,49 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## _virtual/rolldown_runtime.js
+
+```js
+// HIDDEN [rolldown:runtime]
+
+exports.__reExport = __reExport;
+```
+
+## index.js
+
+```js
+const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
+require('./server.js');
+
+//#region index.js
+var transitive_export_star_cjs_exports = {};
+
+//#endregion
+
+var require_server = require("./server.js");
+Object.keys(require_server).forEach(function (k) {
+  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
+    enumerable: true,
+    get: function () { return require_server[k]; }
+  });
+});
+
+```
+
+## server.js
+
+```js
+const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
+
+
+var external_lib = require("external-lib");
+Object.keys(external_lib).forEach(function (k) {
+  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
+    enumerable: true,
+    get: function () { return external_lib[k]; }
+  });
+});
+
+```

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/transitive_export_star_cjs/index.js
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/transitive_export_star_cjs/index.js
@@ -1,0 +1,1 @@
+export * from './server.js';

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/transitive_export_star_cjs/server.js
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/transitive_export_star_cjs/server.js
@@ -1,0 +1,1 @@
+export * from 'external-lib';

--- a/crates/rolldown/tests/rolldown/misc/transitive_export_star_cjs_bundled/_config.json
+++ b/crates/rolldown/tests/rolldown/misc/transitive_export_star_cjs_bundled/_config.json
@@ -7,7 +7,6 @@
       }
     ],
     "format": "cjs",
-    "preserveModules": true,
     "external": ["external-lib"]
   },
   "expectExecuted": false

--- a/crates/rolldown/tests/rolldown/misc/transitive_export_star_cjs_bundled/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/transitive_export_star_cjs_bundled/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## index.js
+
+```js
+// HIDDEN [rolldown:runtime]
+
+//#region index.js
+var transitive_export_star_cjs_bundled_exports = {};
+
+//#endregion
+
+var external_lib = require("external-lib");
+Object.keys(external_lib).forEach(function (k) {
+  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
+    enumerable: true,
+    get: function () { return external_lib[k]; }
+  });
+});
+
+```

--- a/crates/rolldown/tests/rolldown/misc/transitive_export_star_cjs_bundled/index.js
+++ b/crates/rolldown/tests/rolldown/misc/transitive_export_star_cjs_bundled/index.js
@@ -1,0 +1,1 @@
+export * from './server.js';

--- a/crates/rolldown/tests/rolldown/misc/transitive_export_star_cjs_bundled/server.js
+++ b/crates/rolldown/tests/rolldown/misc/transitive_export_star_cjs_bundled/server.js
@@ -1,0 +1,1 @@
+export * from 'external-lib';

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5115,6 +5115,10 @@ expression: output
 
 - main-!~{000}~.js => main-DKngZ6kI.js
 
+# tests/rolldown/misc/transitive_export_star_cjs_bundled
+
+- index-!~{000}~.js => index-Df-bUDa9.js
+
 # tests/rolldown/misc/use_strict/emit_use_strict_with_strict_cjs_in_cjs_format
 
 - main-!~{000}~.js => main-Cp6Qz5JP.js

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5087,6 +5087,12 @@ expression: output
 - default-!~{003}~.js => default-csOjIx0W.js
 - function-!~{005}~.js => function-GN8nKCiR.js
 
+# tests/rolldown/misc/preserve_modules/transitive_export_star_cjs
+
+- index-!~{000}~.js => index-BYXdauAF.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-D2VJOnTr.js
+- server-!~{003}~.js => server-QE6T68Bn.js
+
 # tests/rolldown/misc/reexport_star
 
 - entry-!~{001}~.js => entry-CTZ8dXyc.js

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5089,7 +5089,7 @@ expression: output
 
 # tests/rolldown/misc/preserve_modules/transitive_export_star_cjs
 
-- index-!~{000}~.js => index-BYXdauAF.js
+- index-!~{000}~.js => index-Kcq8ec9L.js
 - _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-D2VJOnTr.js
 - server-!~{003}~.js => server-QE6T68Bn.js
 

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -64,6 +64,9 @@ pub struct Chunk {
   pub imports_from_other_chunks: Vec<(ChunkIdx, Vec<CrossChunkImportItem>)>,
   // Only meaningful for cjs format
   pub require_binding_names_for_other_chunks: FxHashMap<ChunkIdx, String>,
+  // Only meaningful for cjs format with preserveModules
+  // Maps chunk indices to binding names for star reexports (e.g., "require_server" for export * from './server.js')
+  pub require_binding_names_for_star_reexports: FxHashMap<ChunkIdx, String>,
   /// The first element of tuple is module idx of external module
   /// the second element is the related named import of external module.
   /// The second `ModuleIdx` is the importer of the named import which is used to look up related


### PR DESCRIPTION
This PR fixes a bug where transitive `export *` statements were not being re-exported in CJS format. The issue affected **both** `preserveModules: true` and `preserveModules: false` scenarios.

When using transitive `export *` chains like:

```js
// index.js
export * from './server.js';

// server.js  
export * from 'external-lib';
```

The generated CJS output would fail to re-export from `external-lib`, resulting in empty exports.

After some digging with AI help, it looks like the `star_exports_from_external_modules()` method only returns **direct** external star exports, missing transitive chains through internal modules.

I'm not versed in Rust, so feel free to suggest a better fix for this or close the PR, I know the issue wasn't triaged yet but thought to give it a go.

closes #7115 