### PR TITLE
refactor(rolldown_plugin_vite_resolve): use `resolve_file` for tsconfig discovery

### DIFF
--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -142,7 +142,7 @@ impl ViteResolvePlugin {
       try_index: options.resolve_options.try_index,
       try_prefix: &options.resolve_options.try_prefix,
       as_src: options.resolve_options.as_src,
-      root: &options.resolve_options.root,
+      root: PathBuf::from(&options.resolve_options.root),
       preserve_symlinks: options.resolve_options.preserve_symlinks,
       tsconfig_paths: options.resolve_options.tsconfig_paths,
     };
@@ -440,16 +440,12 @@ impl Plugin for ViteResolvePlugin {
       }
     }
 
-    let base_dir = args
-      .importer
-      .map(|i| Path::new(i).parent().and_then(|p| p.to_str()).unwrap_or(i))
-      .unwrap_or(&self.resolve_options.root);
     let specifier = normalize_leading_slashes(&id);
     let resolved = resolver.normalize_oxc_resolver_result(
       args.importer,
       &self.dedupe,
       self.legacy_inconsistent_cjs_interop,
-      &resolver.resolve_raw(base_dir, specifier, false),
+      &resolver.resolve_raw(specifier, args.importer, false),
     )?;
     if let Some(mut resolved) = resolved {
       if !scan {


### PR DESCRIPTION
Ref https://github.com/rolldown/rolldown/actions/runs/19637773386/job/56232776780

I tested it locally and it passes the relevant Vite test cases.