### PR TITLE
chore(deps): update `oxc_resolver_napi` to 11.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver_napi"
-version = "11.13.2"
+version = "11.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915f8f50b9ce98bec9755d51025d43ecdcad3b36a1c956032aba5b926ac96271"
+checksum = "6006e3dc9f0da1769c1dc9d06afd3b82d2b78651855c8d16f41f4e1e7cbfa7a8"
 dependencies = [
  "fancy-regex",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,7 +229,7 @@ oxc_traverse = { version = "0.98.0" }
 # Please update with `cargo update oxc_resolver oxc_resolver_napi oxc_sourcemap oxc_index oxc-browserslist`
 oxc_index = { version = "4", features = ["rayon", "serde"] } # https://github.com/oxc-project/oxc-index-vec
 oxc_resolver = { version = "11.14.0", features = ["yarn_pnp"] } # https://github.com/oxc-project/oxc-resolver
-oxc_resolver_napi = { version = "11.13.1", default-features = false, features = ["yarn_pnp"] }
+oxc_resolver_napi = { version = "11.14.0", default-features = false, features = ["yarn_pnp"] }
 oxc_sourcemap = { version = "6" } # https://github.com/oxc-project/oxc-sourcemap
 
 [profile.dev]


### PR DESCRIPTION
Related to #6909 

I forgot to update the `oxc_resolver_napi`