### PR TITLE
refactor(rolldown_plugin_vite_transform): use `oxc_resolver` for tsconfig discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3386,7 +3386,6 @@ dependencies = [
  "rolldown_common",
  "rolldown_error",
  "rolldown_plugin",
- "rolldown_plugin_utils",
  "rolldown_utils",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3382,6 +3382,7 @@ dependencies = [
  "itertools",
  "memchr",
  "oxc",
+ "oxc_resolver",
  "rolldown_common",
  "rolldown_error",
  "rolldown_plugin",

--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_transform_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_transform_plugin_config.rs
@@ -46,6 +46,7 @@ impl From<BindingViteTransformPluginConfig> for ViteTransformPlugin {
         .transform_options
         .map(normalize_binding_transform_options)
         .unwrap_or_default(),
+      resolver: ViteTransformPlugin::new_resolver(),
     }
   }
 }

--- a/crates/rolldown_plugin_vite_transform/Cargo.toml
+++ b/crates/rolldown_plugin_vite_transform/Cargo.toml
@@ -22,6 +22,7 @@ arcstr = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
 oxc = { workspace = true }
+oxc_resolver = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_error = { workspace = true }
 rolldown_plugin = { workspace = true }

--- a/crates/rolldown_plugin_vite_transform/Cargo.toml
+++ b/crates/rolldown_plugin_vite_transform/Cargo.toml
@@ -26,5 +26,4 @@ oxc_resolver = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_error = { workspace = true }
 rolldown_plugin = { workspace = true }
-rolldown_plugin_utils = { workspace = true }
 rolldown_utils = { workspace = true }

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -26,6 +26,16 @@ pub struct ViteTransformPlugin {
   pub is_server_consumer: bool,
   pub sourcemap: bool,
   pub transform_options: BundlerTransformOptions,
+  pub resolver: oxc_resolver::Resolver,
+}
+
+impl ViteTransformPlugin {
+  pub fn new_resolver() -> oxc_resolver::Resolver {
+    oxc_resolver::Resolver::new(oxc_resolver::ResolveOptions {
+      tsconfig: Some(oxc_resolver::TsconfigDiscovery::Auto),
+      ..Default::default()
+    })
+  }
 }
 
 /// only handle ecma like syntax, `jsx`,`tsx`,`ts`


### PR DESCRIPTION
closes #5867, vitejs/rolldown-vite#480