### PR TITLE
test(vite-tests): run `playwright install` in case playwright binary is missing

### DIFF
--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -68,6 +68,10 @@ await runCmdAndPipeOrExit(
   ['pnpm', ['install', '--no-frozen-lockfile'], { nodeOptions: { cwd: REPO_PATH } }],
 );
 await runCmdAndPipeOrExit(
+  '# Running `pnpm exec playwright install chromium`...',
+  ['pnpm', ['exec', 'playwright', 'install', 'chromium'], { nodeOptions: { cwd: REPO_PATH } }],
+);
+await runCmdAndPipeOrExit(
   '# Running `pnpm run build`...',
   ['pnpm', ['run', 'build'], { nodeOptions: { cwd: REPO_PATH } }],
 );


### PR DESCRIPTION
Trying to fix failures like: https://github.com/rolldown/rolldown/actions/runs/19665411954/job/56321001064#step:6:387