### PR TITLE
docs(tsconfig): document auto-discovery mode and improve structure

### DIFF
--- a/docs/options/tsconfig.md
+++ b/docs/options/tsconfig.md
@@ -1,13 +1,28 @@
 # tsconfig
 
-- **Type:** `string`
+- **Type:** `true | string`
 - **Optional:** Yes ✅
+- **Default:** `undefined` (no tsconfig resolution)
 
-Specifies the path to a TypeScript configuration file. You may provide a relative path (resolved relative to [`cwd`](./cwd.md)) or an absolute path.
+Configures TypeScript configuration file resolution and usage.
 
-## Examples
+## Options
 
-### Use default tsconfig.json
+### Auto-discovery mode (`true`)
+
+When set to `true`, Rolldown enables auto-discovery mode (similar to Vite). For each module, both the resolver and transformer will find the nearest `tsconfig.json`.
+
+If the tsconfig has `references`, the file extension is allowed, and the tsconfig's `include`/`exclude` patterns don't match the file, the referenced tsconfigs will be searched for a match. Falls back to the original tsconfig if no match is found.
+
+```js
+export default {
+  tsconfig: true,
+};
+```
+
+### Explicit path (`string`)
+
+Specifies the path to a specific TypeScript configuration file. You may provide a relative path (resolved relative to [`cwd`](./cwd.md)) or an absolute path.
 
 ```js
 export default {
@@ -15,15 +30,11 @@ export default {
 };
 ```
 
-### Use custom config
-
 ```js
 export default {
   tsconfig: './tsconfig.build.json',
 };
 ```
-
-### Use absolute path
 
 ```js
 export default {
@@ -31,27 +42,29 @@ export default {
 };
 ```
 
-## In-depth
+## What's used from tsconfig
 
-When a tsconfig path is specified, Rolldown will:
+When a tsconfig is resolved, Rolldown uses different parts for different purposes:
 
-### 1. Use compiler options for transpilation:
+### Resolver
 
-- `target`: ECMAScript version to compile to
-- `jsx`: JSX transformation mode
-- `experimentalDecorators`: Enable decorator support
-- `emitDecoratorMetadata`: Emit decorator metadata
-
-### 2. Use paths for module resolution:
+Uses the following for module path mapping:
 
 - `compilerOptions.paths`: Path mapping for module resolution
 - `compilerOptions.baseUrl`: Base directory for path resolution
 
-### 3. Merge with transform options:
+### Transformer
 
-The tsconfig options will be merged with the top-level `transform` options, with `transform` options taking precedence.
+Uses select compiler options including:
 
-### Example tsconfig.json:
+- `jsx`: JSX transformation mode
+- `experimentalDecorators`: Enable decorator support
+- `emitDecoratorMetadata`: Emit decorator metadata
+- `verbatimModuleSyntax`: Module syntax preservation
+- `useDefineForClassFields`: Class field semantics
+- And other TypeScript-specific options
+
+### Example
 
 ```json
 {
@@ -70,13 +83,12 @@ The tsconfig options will be merged with the top-level `transform` options, with
 
 With this configuration:
 
-- TypeScript will be transpiled to ES2020
 - JSX will use React's automatic runtime
 - Path aliases like `@/utils` will resolve to `src/utils`
 
-### Priority
+## Priority
 
-Options specified directly in Rolldown configuration take precedence over `tsconfig.json` settings:
+Top-level `transform` options always take precedence over tsconfig settings:
 
 ```js
 export default {
@@ -89,10 +101,6 @@ export default {
 };
 ```
 
-### Automatic Discovery
-
-Rolldown will NOT automatically look for `tsconfig.json` if this option is not specified. You must explicitly provide the path.
-
 :::tip
-For TypeScript projects, it's recommended to specify `tsconfig` to ensure consistent compilation behavior and enable path mapping.
+For TypeScript projects, it's recommended to use `tsconfig: true` for auto-discovery or specify an explicit path to ensure consistent compilation behavior and enable path mapping.
 :::

--- a/docs/options/tsconfig.md
+++ b/docs/options/tsconfig.md
@@ -12,7 +12,7 @@ Configures TypeScript configuration file resolution and usage.
 
 When set to `true`, Rolldown enables auto-discovery mode (similar to Vite). For each module, both the resolver and transformer will find the nearest `tsconfig.json`.
 
-If the tsconfig has `references`, the file extension is allowed, and the tsconfig's `include`/`exclude` patterns don't match the file, the referenced tsconfigs will be searched for a match. Falls back to the original tsconfig if no match is found.
+If the tsconfig has `references` and certain conditions are met (the file extension is allowed and the tsconfig's `include`/`exclude` patterns don't match the file), then the referenced tsconfigs will be searched for a match. If no match is found, it falls back to the original tsconfig.
 
 ```js
 export default {


### PR DESCRIPTION
Related to #6873

I noticed that we no longer generate the Markdown docs automatically, so I added the relevant documentation manually.