### PR TITLE
fix: call `defer_sync_scan_data` in non-incremental build mode

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -2,7 +2,6 @@ use crate::bundle::bundle_handle::BundleHandle;
 
 use super::super::{
   SharedOptions, SharedResolver,
-  bundler::CacheGuard,
   module_loader::deferred_scan_data::defer_sync_scan_data,
   stages::{
     generate_stage::GenerateStage,
@@ -87,19 +86,13 @@ impl Bundle {
     trace_action!(action::BuildStart { action: "BuildStart" });
     let is_full_scan_mode = scan_mode.is_full();
 
-    // Make sure the cache is reset if incremental build is not enabled.
-    let mut scan_stage_cache_guard = CacheGuard {
-      is_incremental_build_enabled: self.options.experimental.is_incremental_build_enabled(),
-      cache: &mut self.cache,
-    };
-
     let scan_stage_output = match ScanStage::new(
       Arc::clone(&self.options),
       Arc::clone(&self.plugin_driver),
       self.fs.clone(),
       Arc::clone(&self.resolver),
     )
-    .scan(scan_mode, scan_stage_cache_guard.inner())
+    .scan(scan_mode, &mut self.cache)
     .await
     {
       Ok(v) => v,
@@ -114,12 +107,14 @@ impl Bundle {
       }
     };
 
-    // Manually drop it to avoid holding the mut reference.
-    drop(scan_stage_cache_guard);
-
     let scan_stage_output = self
       .normalize_scan_stage_output_and_update_cache(scan_stage_output, is_full_scan_mode)
       .await?;
+
+    // Make sure the cache is reset if incremental build is not enabled.
+    if !self.options.experimental.is_incremental_build_enabled() {
+      std::mem::take(&mut self.cache);
+    }
 
     Self::trace_action_module_graph_ready(&scan_stage_output);
     self.plugin_driver.build_end(None).await?;
@@ -209,10 +204,16 @@ impl Bundle {
   ) -> BuildResult<NormalizedScanStageOutput> {
     let is_incremental = self.options.experimental.is_incremental_build_enabled();
 
-    if is_full_scan_mode || !is_incremental {
-      let mut output =
+    if is_full_scan_mode {
+      let mut output: NormalizedScanStageOutput =
         output.try_into().expect("Should be able to convert to NormalizedScanStageOutput");
-      defer_sync_scan_data(&self.options, &self.resolver, &mut output).await?;
+      defer_sync_scan_data(
+        &self.options,
+        &self.resolver,
+        &self.cache.module_id_to_idx,
+        &mut output,
+      )
+      .await?;
       if is_incremental {
         self.cache.set_snapshot(output.make_copy());
       }

--- a/crates/rolldown/src/bundler/bundler.rs
+++ b/crates/rolldown/src/bundler/bundler.rs
@@ -82,24 +82,6 @@ impl Bundler {
   }
 }
 
-pub struct CacheGuard<'a> {
-  pub is_incremental_build_enabled: bool,
-  pub cache: &'a mut ScanStageCache,
-}
-impl CacheGuard<'_> {
-  pub fn inner(&mut self) -> &mut ScanStageCache {
-    self.cache
-  }
-}
-
-impl Drop for CacheGuard<'_> {
-  fn drop(&mut self) {
-    if !self.is_incremental_build_enabled {
-      std::mem::take(self.cache);
-    }
-  }
-}
-
 fn _test_bundler() {
   fn assert_send(_foo: impl Send) {}
   let mut bundler = Bundler::new(BundlerOptions::default()).expect("Failed to create bundler");

--- a/crates/rolldown/src/bundler/mod.rs
+++ b/crates/rolldown/src/bundler/mod.rs
@@ -4,4 +4,4 @@ mod impl_bundler_getter;
 mod impl_bundler_hmr;
 mod impl_bundler_incremental_build;
 
-pub use self::bundler::{Bundler, CacheGuard};
+pub use self::bundler::Bundler;

--- a/crates/rolldown/src/module_loader/deferred_scan_data.rs
+++ b/crates/rolldown/src/module_loader/deferred_scan_data.rs
@@ -1,48 +1,38 @@
+use arcstr::ArcStr;
 use rolldown_common::ImportKind;
 use rolldown_common::side_effects::{DeterminedSideEffects, HookSideEffects};
 use rolldown_error::BuildResult;
 use rustc_hash::FxHashMap;
 
 use crate::ecmascript::ecma_module_view_factory::normalize_side_effects;
+use crate::module_loader::module_loader::VisitState;
 use crate::{SharedOptions, SharedResolver, stages::scan_stage::NormalizedScanStageOutput};
 
 pub async fn defer_sync_scan_data(
   options: &SharedOptions,
   resolver: &SharedResolver,
+  module_id_to_idx: &FxHashMap<ArcStr, VisitState>,
   scan_stage_output: &mut NormalizedScanStageOutput,
 ) -> BuildResult<()> {
   let Some(ref func) = options.defer_sync_scan_data else {
     return Ok(());
   };
 
-  let result = func.exec().await?;
-  if result.is_empty() {
-    return Ok(());
-  }
-
-  // TODO: In incremental build mode, we can directly use `module_id_to_idx` map from `ScanStageCache`
-  let module_id_to_idx = scan_stage_output
-    .module_table
-    .modules
-    .iter()
-    .filter_map(|m| m.as_normal().map(|n| (n.id.resource_id().clone(), m.idx())))
-    .collect::<FxHashMap<_, _>>();
-
-  for data in result {
-    let Some(&module_idx) = module_id_to_idx.get(data.id.as_str()) else {
+  for data in func.exec().await? {
+    let source_id = arcstr::ArcStr::from(data.id);
+    let Some(state) = module_id_to_idx.get(&source_id) else {
       continue;
     };
-    let Some(normal_module) = scan_stage_output
-      .module_table
-      .modules
-      .get_mut(module_idx)
-      .and_then(|module| module.as_normal_mut())
-    else {
+    let module_idx = state.idx();
+    let Some(module) = scan_stage_output.module_table.modules.get_mut(module_idx) else {
+      continue;
+    };
+    let Some(normal) = module.as_normal_mut() else {
       continue;
     };
     // TODO: Document this and recommend user to return `moduleSideEffects` in hook return
     // value rather than mutate the `ModuleInfo`
-    normal_module.ecma_view.side_effects = match data.side_effects {
+    normal.ecma_view.side_effects = match data.side_effects {
       Some(HookSideEffects::False) => DeterminedSideEffects::UserDefined(false),
       Some(HookSideEffects::NoTreeshake) => DeterminedSideEffects::NoTreeshake,
       _ => {
@@ -51,14 +41,14 @@ pub async fn defer_sync_scan_data(
         let resolved_id = resolver
           // other params except `source_id` is not important, since we need `package_json`
           // from `resolved_id` to re analyze the side effects
-          .resolve(None, &data.id, ImportKind::Import, normal_module.is_user_defined_entry)
+          .resolve(None, source_id.as_str(), ImportKind::Import, normal.is_user_defined_entry)
           .expect("Should have resolved id")
           .into();
         normalize_side_effects(
           options,
           &resolved_id,
-          Some(&normal_module.stmt_infos),
-          Some(&normal_module.module_type),
+          Some(&normal.stmt_infos),
+          Some(&normal.module_type),
           data.side_effects,
         )
         .await?

--- a/crates/rolldown/src/module_loader/deferred_scan_data.rs
+++ b/crates/rolldown/src/module_loader/deferred_scan_data.rs
@@ -1,15 +1,13 @@
-use crate::ecmascript::ecma_module_view_factory::normalize_side_effects;
-use crate::module_loader::module_loader::VisitState;
-use crate::{SharedOptions, SharedResolver, stages::scan_stage::NormalizedScanStageOutput};
-use arcstr::ArcStr;
 use rolldown_common::ImportKind;
 use rolldown_common::side_effects::{DeterminedSideEffects, HookSideEffects};
 use rolldown_error::BuildResult;
 use rustc_hash::FxHashMap;
 
+use crate::ecmascript::ecma_module_view_factory::normalize_side_effects;
+use crate::{SharedOptions, SharedResolver, stages::scan_stage::NormalizedScanStageOutput};
+
 pub async fn defer_sync_scan_data(
   options: &SharedOptions,
-  module_id_to_idx: &FxHashMap<ArcStr, VisitState>,
   resolver: &SharedResolver,
   scan_stage_output: &mut NormalizedScanStageOutput,
 ) -> BuildResult<()> {
@@ -17,21 +15,34 @@ pub async fn defer_sync_scan_data(
     return Ok(());
   };
 
-  for data in func.exec().await? {
-    let source_id = arcstr::ArcStr::from(data.id);
-    let Some(state) = module_id_to_idx.get(&source_id) else {
+  let result = func.exec().await?;
+  if result.is_empty() {
+    return Ok(());
+  }
+
+  // TODO: In incremental build mode, we can directly use `module_id_to_idx` map from `ScanStageCache`
+  let module_id_to_idx = scan_stage_output
+    .module_table
+    .modules
+    .iter()
+    .filter_map(|m| m.as_normal().map(|n| (n.id.resource_id().clone(), m.idx())))
+    .collect::<FxHashMap<_, _>>();
+
+  for data in result {
+    let Some(&module_idx) = module_id_to_idx.get(data.id.as_str()) else {
       continue;
     };
-    let module_idx = state.idx();
-    let Some(module) = scan_stage_output.module_table.modules.get_mut(module_idx) else {
-      continue;
-    };
-    let Some(normal) = module.as_normal_mut() else {
+    let Some(normal_module) = scan_stage_output
+      .module_table
+      .modules
+      .get_mut(module_idx)
+      .and_then(|module| module.as_normal_mut())
+    else {
       continue;
     };
     // TODO: Document this and recommend user to return `moduleSideEffects` in hook return
     // value rather than mutate the `ModuleInfo`
-    normal.ecma_view.side_effects = match data.side_effects {
+    normal_module.ecma_view.side_effects = match data.side_effects {
       Some(HookSideEffects::False) => DeterminedSideEffects::UserDefined(false),
       Some(HookSideEffects::NoTreeshake) => DeterminedSideEffects::NoTreeshake,
       _ => {
@@ -40,14 +51,14 @@ pub async fn defer_sync_scan_data(
         let resolved_id = resolver
           // other params except `source_id` is not important, since we need `package_json`
           // from `resolved_id` to re analyze the side effects
-          .resolve(None, source_id.as_str(), ImportKind::Import, normal.is_user_defined_entry)
+          .resolve(None, &data.id, ImportKind::Import, normal_module.is_user_defined_entry)
           .expect("Should have resolved id")
           .into();
         normalize_side_effects(
           options,
           &resolved_id,
-          Some(&normal.stmt_infos),
-          Some(&normal.module_type),
+          Some(&normal_module.stmt_infos),
+          Some(&normal_module.module_type),
           data.side_effects,
         )
         .await?

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -50,7 +50,7 @@ impl ScanStageCache {
   ) -> BuildResult<()> {
     let snapshot = self.take_snapshot();
     if let Some(mut snapshot) = snapshot {
-      defer_sync_scan_data(options, resolver, &mut snapshot).await?;
+      defer_sync_scan_data(options, resolver, &self.module_id_to_idx, &mut snapshot).await?;
       self.set_snapshot(snapshot);
     }
     Ok(())

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -50,7 +50,7 @@ impl ScanStageCache {
   ) -> BuildResult<()> {
     let snapshot = self.take_snapshot();
     if let Some(mut snapshot) = snapshot {
-      defer_sync_scan_data(options, &self.module_id_to_idx, resolver, &mut snapshot).await?;
+      defer_sync_scan_data(options, resolver, &mut snapshot).await?;
       self.set_snapshot(snapshot);
     }
     Ok(())

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy2/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy2/_config.ts
@@ -11,7 +11,7 @@ export default defineTest({
           if (id.includes('bar.js')) {
             const resolved = await this.resolve('./foo.js', id);
             const moduleInfo = this.getModuleInfo(resolved!.id);
-            moduleInfo!.moduleSideEffects = true;
+            moduleInfo!.moduleSideEffects = false;
 
             // mutate sideEffects of bar.js to `false`
             const moduleInfo1 = this.getModuleInfo(id);
@@ -29,7 +29,7 @@ export default defineTest({
       .filter(({ type }) => type === 'chunk')
       .forEach((chunk) => {
         let code = (chunk as RolldownOutputChunk).code;
-        expect(code.includes(`sideeffects`)).toBe(true);
+        expect(code.includes(`sideeffects`)).toBe(false);
         expect(code.includes(`bar`)).toBe(false);
       });
   },

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy3/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy3/_config.ts
@@ -11,11 +11,7 @@ export default defineTest({
           if (id.includes('bar.js')) {
             const resolved = await this.resolve('./foo.js', id);
             const moduleInfo = this.getModuleInfo(resolved!.id);
-            moduleInfo!.moduleSideEffects = true;
-
-            // mutate sideEffects of bar.js to `false`
-            const moduleInfo1 = this.getModuleInfo(id);
-            moduleInfo1!.moduleSideEffects = false;
+            moduleInfo!.moduleSideEffects = false;
           }
           return {
             code,
@@ -29,8 +25,7 @@ export default defineTest({
       .filter(({ type }) => type === 'chunk')
       .forEach((chunk) => {
         let code = (chunk as RolldownOutputChunk).code;
-        expect(code.includes(`sideeffects`)).toBe(true);
-        expect(code.includes(`bar`)).toBe(false);
+        expect(code.includes(`sideeffects`)).toBe(false);
       });
   },
 });

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy3/bar.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy3/bar.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy3/foo.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy3/foo.js
@@ -1,0 +1,1 @@
+console.log('no sideeffects');

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy3/main.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy3/main.js
@@ -1,0 +1,2 @@
+import './foo.js';
+import './bar.js';


### PR DESCRIPTION
Related to #6568

Previously, `defer_sync_scan_data` was only called when incremental build was enabled, causing `moduleSideEffects` mutations via `getModuleInfo()` to be ignored in regular builds.