### PR TITLE
chore(deps): downgrade pnpm to 10.23.0 to fix Netlify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Rollup in Rust",
   "type": "module",
   "private": true,
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@10.23.0",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },


### PR DESCRIPTION
```
1:32:56 PM: Failed during stage 'Install dependencies': dependency_installation script returned non-zero exit code: 1
1:32:56 PM: Installing npm packages using pnpm version 10.24.0
1:32:56 PM:  ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "catalogs" configuration doesn't match the value found in the lockfile
1:32:56 PM: Update your lockfile using "pnpm install --no-frozen-lockfile"
1:32:56 PM: Error during pnpm install
1:32:56 PM: Failing build: Failed to install dependencies
```