### PR TITLE
fix(node): `output.generateCode.preset: 'es2015'` should set `output.generateCode.symbols: true` by default

### DIFF
--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -52,7 +52,7 @@ fn normalize_generated_code_option(
     }
     None => GeneratedCodeOptions::default(),
   };
-  Ok(GeneratedCodeOptions { symbols: value.symbols.unwrap_or(false), ..v })
+  Ok(GeneratedCodeOptions { symbols: value.symbols.unwrap_or(v.symbols), ..v })
 }
 
 fn normalize_addon_option(

--- a/packages/rolldown/tests/fixtures/output/generated-code/preset-es2015/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/generated-code/preset-es2015/_config.ts
@@ -1,0 +1,17 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    output: {
+      format: 'cjs',
+      generatedCode: {
+        preset: 'es2015',
+      },
+    },
+  },
+  afterTest: (output) => {
+    // preset: 'es2015' should set symbols: true, which includes Symbol.toStringTag
+    expect(output.output[0].code).toContain('Symbol.toStringTag');
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/generated-code/preset-es2015/main.js
+++ b/packages/rolldown/tests/fixtures/output/generated-code/preset-es2015/main.js
@@ -1,0 +1,1 @@
+export const a = 1;


### PR DESCRIPTION
fixes https://github.com/vitejs/rolldown-vite/issues/525