### PR TITLE
chore: enable tracing feature for napi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,6 +1523,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,9 +212,9 @@ quote = "1"
 syn = { version = "2", default-features = false }
 
 # napi
-napi = { version = "3.0.0", features = ["async", "anyhow"] }
+napi = { version = "3.0.0", features = ["async", "anyhow", "tracing"] }
 napi-build = { version = "2.2.2" }
-napi-derive = { version = "3.0.0", default-features = false, features = ["type-def"] }
+napi-derive = { version = "3.0.0", default-features = false, features = ["type-def", "tracing"] }
 
 # oxc crates with the same version
 oxc = { version = "0.101.0", features = ["ast_visit", "transformer", "minifier", "mangler", "semantic", "codegen", "serialize", "isolated_declarations", "regular_expression", "cfg"] }


### PR DESCRIPTION
close #7287
refs https://github.com/rolldown/rolldown/pull/7317, https://github.com/napi-rs/napi-rs/pull/3041

With this change, I get the tracing output:

```
$env:RD_LOG="napi=trace"; pnpm build

> @example/typescript@ build D:\documents\GitHub\rolldown\examples\basic-typescript
> rolldown --config ./rolldown.config.js

  2025-12-03T03:05:29.770480Z DEBUG napi: BindingBundler::constructor
    at crates\rolldown_binding\src\binding_bundler.rs:26

  2025-12-03T03:05:29.772016Z DEBUG napi: BindingBundler::write
    at crates\rolldown_binding\src\binding_bundler.rs:26

  2025-12-03T03:05:29.786956Z DEBUG napi: BindingRenderedChunkMeta::chunks
    at crates\rolldown_binding\src\options\plugin\types\binding_render_chunk_meta_chunks.rs:15

  2025-12-03T03:05:29.788489Z DEBUG napi: BindingBundler::close
    at crates\rolldown_binding\src\binding_bundler.rs:26

  2025-12-03T03:05:29.788696Z DEBUG napi: shutdownAsyncRuntime
    at crates\rolldown_binding\src\lib.rs:79

  2025-12-03T03:05:29.788905Z DEBUG napi: BindingOutputChunk::getFileName
    at crates\rolldown_binding\src\types\binding_output_chunk.rs:17

  2025-12-03T03:05:29.789008Z DEBUG napi: BindingOutputChunk::getCode
    at crates\rolldown_binding\src\types\binding_output_chunk.rs:17

<DIR>/entry.js  chunk │ size: 0.23 kB

✔ rolldown v1.0.0-beta.52 Finished in 21.24 ms
```
(note: I had to comment out `debug` option, otherwise I got `failed to set global default subscriber: SetGlobalDefaultError("a global default trace dispatcher has already been set")` error)
