### PR TITLE
fix:Symbol.toStringTag not present for self imported namespaces

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -458,7 +458,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // if there is no export, we should generate `var ns = {}` instead of `var ns = __export({}, {})`
     // else construct `__export(ns_name, { prop_name: () => returned, ... })`
     let module_namespace_rhs = if arg_obj_expr.properties.is_empty() {
-      Expression::ObjectExpression(self.builder().alloc(arg_obj_expr))
+      if self.ctx.options.generated_code.symbols
+        && self.ctx.module.importers_idx.contains(&self.ctx.module.namespace_object_ref.owner)
+      {
+        self.snippet.object_freeze_symbol_tostringtag()
+      } else {
+        Expression::ObjectExpression(self.builder().alloc(arg_obj_expr))
+      }
     } else {
       let obj_expr = ast::Argument::ObjectExpression(arg_obj_expr.into_in(self.alloc));
       let args = if self.ctx.options.generated_code.symbols {

--- a/crates/rolldown/tests/rolldown/topics/generated_code/symbol_self_import/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/symbol_self_import/_config.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+     "generatedCode": {
+      "symbols": true
+    }
+  },
+  "configVariants": [
+    {
+      "format": "cjs"
+    },
+    {
+      "format": "iife"
+    }
+  ]
+ 
+}

--- a/crates/rolldown/tests/rolldown/topics/generated_code/symbol_self_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/symbol_self_import/artifacts.snap
@@ -1,0 +1,47 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+var main_exports = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null }, Symbol.toStringTag, { value: "Module" }));
+console.log(main_exports);
+
+//#endregion
+```
+
+# Variant: [format: Cjs]
+
+## Assets
+
+### main.js
+
+```js
+
+//#region main.js
+var main_exports = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null }, Symbol.toStringTag, { value: "Module" }));
+console.log(main_exports);
+
+//#endregion
+```
+
+# Variant: [format: Iife]
+
+## Assets
+
+### main.js
+
+```js
+(function() {
+
+
+//#region main.js
+	var main_exports = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null }, Symbol.toStringTag, { value: "Module" }));
+	console.log(main_exports);
+
+//#endregion
+})();
+```

--- a/crates/rolldown/tests/rolldown/topics/generated_code/symbol_self_import/main.js
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/symbol_self_import/main.js
@@ -1,0 +1,2 @@
+import * as ns from './main.js'
+console.log(ns)

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5689,6 +5689,10 @@ expression: output
 
 - main-!~{000}~.js => main-CDci1JBl.js
 
+# tests/rolldown/topics/generated_code/symbol_self_import
+
+- main-!~{000}~.js => main-CAwmmxDx.js
+
 # tests/rolldown/topics/generated_code/symbols
 
 - main-!~{000}~.js => main-D9Bb16oY.js


### PR DESCRIPTION
close #7152