### PR TITLE
docs(guide): fix grammer in getting-started

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -267,5 +267,5 @@ const watcher = watch({
 
 watcher.on('event', () => {});
 
-await watcher.close(); // Here is different with rollup, the rolldown returned the promise at here.
+await watcher.close(); // This is different than rollup: rolldown returns a promise here.
 ```


### PR DESCRIPTION
Fix documentation grammar.