### PR TITLE
fix: always use __export for empty namespace objects when symbols enabled

### DIFF
--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -93,7 +93,7 @@ impl LinkStage<'_> {
           let meta = &mut self.metas[ecma_module.idx];
           let mut referenced_symbols = vec![];
           let mut declared_symbols = vec![];
-          if !meta.is_canonical_exports_empty() {
+          if !meta.is_canonical_exports_empty() || self.options.generated_code.symbols {
             referenced_symbols.push(self.runtime.resolve_symbol("__export").into());
             referenced_symbols
               .extend(meta.canonical_exports(false).map(|(_, export)| export.symbol_ref.into()));

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_esm_dynamic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_esm_dynamic/artifacts.snap
@@ -10,13 +10,13 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.mjs
-var lib_exports = {};
+var lib_exports = /* @__PURE__ */ __export({}, 1);
 import * as import_foo from "foo";
 __reExport(lib_exports, import_foo, void 0, 1);
 
 //#endregion
 //#region reexports.mjs
-var reexports_exports = {};
+var reexports_exports = /* @__PURE__ */ __export({}, 1);
 __reExport(reexports_exports, lib_exports, void 0, 1);
 
 //#endregion
@@ -38,12 +38,12 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region lib.mjs
-var lib_exports = {};
+var lib_exports = /* @__PURE__ */ __export({}, 1);
 __reExport(lib_exports, require("foo"), void 0, 1);
 
 //#endregion
 //#region reexports.mjs
-var reexports_exports = {};
+var reexports_exports = /* @__PURE__ */ __export({}, 1);
 __reExport(reexports_exports, lib_exports, void 0, 1);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external/artifacts.snap
@@ -11,7 +11,7 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region reexports.mjs
-var reexports_exports = {};
+var reexports_exports = /* @__PURE__ */ __export({}, 1);
 __reExport(reexports_exports, require("foo"), void 0, 1);
 
 //#endregion
@@ -32,7 +32,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region reexports.mjs
-var reexports_exports = {};
+var reexports_exports = /* @__PURE__ */ __export({}, 1);
 import * as import_foo from "foo";
 __reExport(reexports_exports, import_foo, void 0, 1);
 

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external_commonjs/artifacts.snap
@@ -17,7 +17,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region reexports.mjs
-var reexports_exports = {};
+var reexports_exports = /* @__PURE__ */ __export({}, 1);
 __reExport(reexports_exports, /* @__PURE__ */ __toESM(require_cjs(), 1), void 0, 1);
 
 //#endregion
@@ -44,7 +44,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region reexports.mjs
-var reexports_exports = {};
+var reexports_exports = /* @__PURE__ */ __export({}, 1);
 __reExport(reexports_exports, /* @__PURE__ */ __toESM(require_cjs(), 1), void 0, 1);
 
 //#endregion

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5679,15 +5679,15 @@ expression: output
 
 # tests/rolldown/topics/generated_code/reexports_esm_dynamic
 
-- main-!~{000}~.js => main-D5CPHxcZ.js
+- main-!~{000}~.js => main-BfbMazEi.js
 
 # tests/rolldown/topics/generated_code/reexports_from_external
 
-- main-!~{000}~.js => main-k0XovFZf.js
+- main-!~{000}~.js => main-C8Ztp7ml.js
 
 # tests/rolldown/topics/generated_code/reexports_from_external_commonjs
 
-- main-!~{000}~.js => main-CDci1JBl.js
+- main-!~{000}~.js => main-BrYidzUG.js
 
 # tests/rolldown/topics/generated_code/symbols
 

--- a/crates/rolldown/tests/snapshots/integration_test262__test262_module_code.snap
+++ b/crates/rolldown/tests/snapshots/integration_test262__test262_module_code.snap
@@ -2,7 +2,7 @@
 source: crates/rolldown/tests/integration_test262.rs
 expression: snapshot
 ---
-Summary: 536 passed, 56 failed, 592 total
+Summary: 540 passed, 52 failed, 592 total
 
 ---
 
@@ -1323,14 +1323,9 @@ Actual: Runtime execution succeeded
 ---
 
 # language/module-code/namespace/Symbol.toStringTag.js
-Result: FAIL
-Reason: Symbol.toStringTag not properly set on module namespace objects for self-imports
-Issue: https://github.com/rolldown/rolldown/issues/7152
+Result: PASS
 Expected: success
-Actual:
-Runtime error: Failed to import test module: Test262Error {
-  message: 'Expected SameValue(«undefined», «"Module"») to be true'
-}
+Actual: Runtime execution succeeded
 ---
 
 # language/module-code/namespace/internals/define-own-property.js
@@ -1422,14 +1417,9 @@ Actual: Runtime execution succeeded
 ---
 
 # language/module-code/namespace/internals/get-own-property-sym.js
-Result: FAIL
-Reason: Symbol.toStringTag not properly set on module namespace objects for self-imports
-Issue: https://github.com/rolldown/rolldown/issues/7152
+Result: PASS
 Expected: success
-Actual:
-Runtime error: Failed to import test module: Test262Error {
-  message: 'Expected SameValue(«false», «true») to be true'
-}
+Actual: Runtime execution succeeded
 ---
 
 # language/module-code/namespace/internals/get-prototype-of.js
@@ -1477,14 +1467,9 @@ Actual: Runtime execution succeeded
 ---
 
 # language/module-code/namespace/internals/get-sym-found.js
-Result: FAIL
-Reason: Symbol.toStringTag not properly set on module namespace objects for self-imports
-Issue: https://github.com/rolldown/rolldown/issues/7152
+Result: PASS
 Expected: success
-Actual:
-Runtime error: Failed to import test module: Test262Error {
-  message: 'Expected SameValue(«"undefined"», «"string"») to be true'
-}
+Actual: Runtime execution succeeded
 ---
 
 # language/module-code/namespace/internals/get-sym-not-found.js
@@ -1516,12 +1501,9 @@ Runtime error: Failed to import test module: Test262Error {
 ---
 
 # language/module-code/namespace/internals/has-property-sym-found.js
-Result: FAIL
-Reason: Symbol.toStringTag not properly set on module namespace objects for self-imports
-Issue: https://github.com/rolldown/rolldown/issues/7152
+Result: PASS
 Expected: success
-Actual:
-Runtime error: Failed to import test module: Test262Error { message: 'in: Symbol.toStringTag' }
+Actual: Runtime execution succeeded
 ---
 
 # language/module-code/namespace/internals/has-property-sym-not-found.js

--- a/crates/rolldown/tests/test262_failures.json
+++ b/crates/rolldown/tests/test262_failures.json
@@ -85,10 +85,6 @@
   "language/module-code/instn-star-binding.js": {
     "reason": "Rolldown treats assignments to const as bundle errors instead of runtime errors"
   },
-  "language/module-code/namespace/Symbol.toStringTag.js": {
-    "reason": "Symbol.toStringTag not properly set on module namespace objects for self-imports",
-    "issue": "https://github.com/rolldown/rolldown/issues/7152"
-  },
   "language/module-code/namespace/internals/define-own-property.js": {
     "reason": "Rolldown allows defining properties on module namespace objects"
   },
@@ -110,26 +106,14 @@
   "language/module-code/namespace/internals/get-own-property-str-found-uninit.js": {
     "reason": "Rolldown does not preserve TDZ semantics"
   },
-  "language/module-code/namespace/internals/get-own-property-sym.js": {
-    "reason": "Symbol.toStringTag not properly set on module namespace objects for self-imports",
-    "issue": "https://github.com/rolldown/rolldown/issues/7152"
-  },
   "language/module-code/namespace/internals/get-prototype-of.js": {
     "reason": "Rolldown does not use null as the prototype of module namespace objects"
   },
   "language/module-code/namespace/internals/get-str-found-uninit.js": {
     "reason": "Rolldown does not preserve TDZ semantics"
   },
-  "language/module-code/namespace/internals/get-sym-found.js": {
-    "reason": "Symbol.toStringTag not properly set on module namespace objects for self-imports",
-    "issue": "https://github.com/rolldown/rolldown/issues/7152"
-  },
   "language/module-code/namespace/internals/has-property-str-not-found.js": {
     "reason": "Rolldown does not use null as the prototype of module namespace objects"
-  },
-  "language/module-code/namespace/internals/has-property-sym-found.js": {
-    "reason": "Symbol.toStringTag not properly set on module namespace objects for self-imports",
-    "issue": "https://github.com/rolldown/rolldown/issues/7152"
   },
   "language/module-code/namespace/internals/is-extensible.js": {
     "reason": "Rolldown does not freeze module namespace objects"


### PR DESCRIPTION
closed #7152