### PR TITLE
fix: remove redundant symbol param in __reExport runtime helper

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -495,7 +495,6 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     if !export_all_externals_rec_ids.is_empty() {
       // construct `__reExport(importer_exports, importee_exports)`
       let re_export_fn_ref = self.finalized_expr_for_runtime_symbol("__reExport");
-      let enable_generated_code_symbols = self.ctx.options.generated_code.symbols;
       match self.ctx.options.format {
         OutputFormat::Esm => {
           let stmts = export_all_externals_rec_ids.iter().copied().flat_map(|idx| {
@@ -521,7 +520,6 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               re_export_fn_ref.clone_in(self.alloc),
               self.snippet.id_ref_expr(binding_name_for_namespace_object_ref, SPAN),
               self.snippet.id_ref_expr(importee_namespace_name, SPAN),
-              enable_generated_code_symbols,
             );
             vec![
               // Insert `import * as ns from 'ext'`external module in esm format
@@ -539,7 +537,6 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           let stmts = export_all_externals_rec_ids.iter().copied().map(|idx| {
             // Insert `__reExport(importer_exports, require('ext'))`
             let re_export_fn_ref = self.finalized_expr_for_runtime_symbol("__reExport");
-            let enable_generated_code_symbols = self.ctx.options.generated_code.symbols;
             // importer_exports
             let (importer_namespace_ref_expr, _) = self.finalized_expr_for_symbol_ref(
               self.ctx.module.namespace_object_ref,
@@ -556,7 +553,6 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 "require",
                 self.snippet.string_literal_expr(importee.id(), SPAN),
               ),
-              enable_generated_code_symbols,
             );
 
             self.snippet.builder.statement_expression(
@@ -1200,12 +1196,10 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                         false,
                       );
 
-                      let enable_generated_code_symbols = self.ctx.options.generated_code.symbols;
                       let call_expr = self.snippet.re_export_call_expr(
                         re_export_fn_ref,
                         importer_namespace_ref,
                         importee_namespace_ref,
-                        enable_generated_code_symbols,
                       );
                       // __reExport(exports, otherExports)
                       let stmt = ast::Statement::ExpressionStatement(
@@ -1244,7 +1238,6 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                       false,
                     );
 
-                    let enable_generated_code_symbols = self.ctx.options.generated_code.symbols;
                     let call_expr = self.snippet.re_export_call_expr(
                       re_export_fn_name,
                       importer_namespace_ref,
@@ -1261,7 +1254,6 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                         ),
                         self.ctx.module.should_consider_node_esm_spec_for_static_import(),
                       ),
-                      enable_generated_code_symbols,
                     );
 
                     // __reExport(importer_exports, __toESM(require_foo()))

--- a/crates/rolldown/src/runtime/runtime-base.js
+++ b/crates/rolldown/src/runtime/runtime-base.js
@@ -50,15 +50,10 @@ export var __copyProps = (to, from, except, desc) => {
   }
   return to;
 };
-export var __reExport = (target, mod, secondTarget, symbols) => {
-  if (symbols) {
-    __defProp(target, Symbol.toStringTag, { value: 'Module' });
-    secondTarget &&
-      __defProp(secondTarget, Symbol.toStringTag, { value: 'Module' });
-  }
+export var __reExport = (target, mod, secondTarget) => (
   __copyProps(target, mod, 'default'),
-    secondTarget && __copyProps(secondTarget, mod, 'default');
-};
+    secondTarget && __copyProps(secondTarget, mod, 'default')
+);
 export var __toESM = (mod, isNodeMode, target) => (
   (target = mod != null ? __create(__getProtoOf(mod)) : {}),
     __copyProps(

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_esm_dynamic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_esm_dynamic/artifacts.snap
@@ -12,12 +12,12 @@ import assert from "node:assert";
 //#region lib.mjs
 var lib_exports = /* @__PURE__ */ __export({}, 1);
 import * as import_foo from "foo";
-__reExport(lib_exports, import_foo, void 0, 1);
+__reExport(lib_exports, import_foo);
 
 //#endregion
 //#region reexports.mjs
 var reexports_exports = /* @__PURE__ */ __export({}, 1);
-__reExport(reexports_exports, lib_exports, void 0, 1);
+__reExport(reexports_exports, lib_exports);
 
 //#endregion
 //#region main.mjs
@@ -39,12 +39,12 @@ node_assert = __toESM(node_assert);
 
 //#region lib.mjs
 var lib_exports = /* @__PURE__ */ __export({}, 1);
-__reExport(lib_exports, require("foo"), void 0, 1);
+__reExport(lib_exports, require("foo"));
 
 //#endregion
 //#region reexports.mjs
 var reexports_exports = /* @__PURE__ */ __export({}, 1);
-__reExport(reexports_exports, lib_exports, void 0, 1);
+__reExport(reexports_exports, lib_exports);
 
 //#endregion
 //#region main.mjs

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external/artifacts.snap
@@ -12,7 +12,7 @@ node_assert = __toESM(node_assert);
 
 //#region reexports.mjs
 var reexports_exports = /* @__PURE__ */ __export({}, 1);
-__reExport(reexports_exports, require("foo"), void 0, 1);
+__reExport(reexports_exports, require("foo"));
 
 //#endregion
 //#region main.mjs
@@ -34,7 +34,7 @@ import assert from "node:assert";
 //#region reexports.mjs
 var reexports_exports = /* @__PURE__ */ __export({}, 1);
 import * as import_foo from "foo";
-__reExport(reexports_exports, import_foo, void 0, 1);
+__reExport(reexports_exports, import_foo);
 
 //#endregion
 //#region main.mjs

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external_commonjs/artifacts.snap
@@ -18,7 +18,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#endregion
 //#region reexports.mjs
 var reexports_exports = /* @__PURE__ */ __export({}, 1);
-__reExport(reexports_exports, /* @__PURE__ */ __toESM(require_cjs(), 1), void 0, 1);
+__reExport(reexports_exports, /* @__PURE__ */ __toESM(require_cjs(), 1));
 
 //#endregion
 //#region main.mjs
@@ -45,7 +45,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#endregion
 //#region reexports.mjs
 var reexports_exports = /* @__PURE__ */ __export({}, 1);
-__reExport(reexports_exports, /* @__PURE__ */ __toESM(require_cjs(), 1), void 0, 1);
+__reExport(reexports_exports, /* @__PURE__ */ __toESM(require_cjs(), 1));
 
 //#endregion
 //#region main.mjs

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -770,7 +770,7 @@ expression: output
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
-- entry-!~{000}~.js => entry-DSwd2qsx.js
+- entry-!~{000}~.js => entry-D7kYvPB5.js
 
 # tests/esbuild/default/external_module_exclusion_package
 
@@ -2029,7 +2029,7 @@ expression: output
 
 # tests/esbuild/importstar/re_export_star_entry_point_and_inner_file
 
-- entry-!~{000}~.js => entry-D2IUR6R2.js
+- entry-!~{000}~.js => entry-DPdVkvfs.js
 
 # tests/esbuild/importstar/re_export_star_es6_no_bundle
 
@@ -3533,7 +3533,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/exoprt_star_of_cjs
 
-- main-!~{000}~.js => main-m0vZD86K.js
+- main-!~{000}~.js => main-Cjg31eb4.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
 
@@ -3545,11 +3545,11 @@ expression: output
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
 
-- main-!~{000}~.js => main-DBt0vfVx.js
+- main-!~{000}~.js => main-DysDFWaX.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
 
-- main-!~{000}~.js => main-Ch1EA4Jk.js
+- main-!~{000}~.js => main-CyQr6ErN.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
 
@@ -3607,9 +3607,9 @@ expression: output
 
 # tests/rolldown/cjs_compat/node_module_commonjs
 
-- entry-!~{001}~.js => entry-CpSfNlIt.js
-- main-!~{000}~.js => main-CvJtlPTJ.js
-- commonjs-!~{002}~.js => commonjs-BGcCNXjd.js
+- entry-!~{001}~.js => entry-f_XeA3ad.js
+- main-!~{000}~.js => main-DI4Uv0re.js
+- commonjs-!~{002}~.js => commonjs-CboXWVLr.js
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout
 
@@ -3647,11 +3647,11 @@ expression: output
 
 # tests/rolldown/cjs_compat/reexport_commonjs
 
-- main-!~{000}~.js => main-D9nMpF8W.js
+- main-!~{000}~.js => main-B0Sd9sRr.js
 
 # tests/rolldown/cjs_compat/reexports_from_cjs
 
-- main-!~{000}~.js => main-DkbAod6X.js
+- main-!~{000}~.js => main-Cs_qA9CC.js
 
 # tests/rolldown/cjs_compat/require/create_require
 
@@ -3963,7 +3963,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-DKHTMYw7.js
+- main-!~{000}~.js => main-B4wvMC0V.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4120,11 +4120,11 @@ expression: output
 
 # tests/rolldown/function/external/commonjs_reexport_external
 
-- main-!~{000}~.js => main-CgB4vIOB.js
+- main-!~{000}~.js => main-cfiHexIG.js
 
 # tests/rolldown/function/external/double-namespace-reexport
 
-- main-!~{000}~.js => main-DrgZNRRM.js
+- main-!~{000}~.js => main-C1bJcvAJ.js
 
 # tests/rolldown/function/external/export_external
 
@@ -4649,7 +4649,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-sh7Mwo6G.js
+- main-!~{000}~.js => main-DiFwMJ7N.js
 
 # tests/rolldown/issues/4196
 
@@ -4686,7 +4686,7 @@ expression: output
 
 # tests/rolldown/issues/4472
 
-- main-!~{000}~.js => main-BsSOqROK.js
+- main-!~{000}~.js => main-O8lzF4lH.js
 
 # tests/rolldown/issues/4491
 
@@ -4740,10 +4740,10 @@ expression: output
 
 # tests/rolldown/issues/5387
 
-- main-!~{000}~.js => main-CSKl_IaL.js
-- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-DBjdwNxw.js
-- liblib/index-!~{005}~.js => liblib/index-C81eDwz1.js
-- liblib/lib-!~{003}~.js => liblib/lib-Y95MCJK2.js
+- main-!~{000}~.js => main-5AaimRzg.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-MbrqZrn5.js
+- liblib/index-!~{005}~.js => liblib/index-Br-kCGDK.js
+- liblib/lib-!~{003}~.js => liblib/lib-DoTOmXMq.js
 
 # tests/rolldown/issues/5482
 
@@ -4869,9 +4869,9 @@ expression: output
 
 # tests/rolldown/issues/6992
 
-- main-!~{000}~.js => main-D2QP9LbS.js
-- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-CRC6Pc46.js
-- server/index-!~{003}~.js => server/index-ChpZggGM.js
+- main-!~{000}~.js => main-coHrd27Y.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-i-iV_RSa.js
+- server/index-!~{003}~.js => server/index-2Zhk9aFS.js
 
 # tests/rolldown/issues/7021
 
@@ -4879,9 +4879,9 @@ expression: output
 
 # tests/rolldown/issues/7115
 
-- main-!~{000}~.js => main-C1x_kacg.js
-- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-D2VJOnTr.js
-- server-!~{003}~.js => server-QE6T68Bn.js
+- main-!~{000}~.js => main-WzLySSrW.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-khDlEcQL.js
+- server-!~{003}~.js => server-DOA4JQtF.js
 
 # tests/rolldown/issues/7146
 
@@ -4897,15 +4897,15 @@ expression: output
 
 # tests/rolldown/issues/7233
 
-- index-!~{000}~.js => index-1kB3Vgqb.js
-- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-CyrW_3gl.js
-- server-!~{003}~.js => server-zSw44YMI.js
+- index-!~{000}~.js => index-Bn3ZdonO.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-CwPsCxRt.js
+- server-!~{003}~.js => server-DzcxjD6x.js
 
 # tests/rolldown/issues/7233_chain
 
-- index-!~{000}~.js => index-yu2ot_m9.js
-- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-CyrW_3gl.js
-- middle-!~{005}~.js => middle-y2s8K8wc.js
+- index-!~{000}~.js => index-CWnsvjXX.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-CwPsCxRt.js
+- middle-!~{005}~.js => middle-gpaOAHhJ.js
 - server-!~{003}~.js => server-DFjxxrlr.js
 
 # tests/rolldown/issues/7286
@@ -5275,11 +5275,11 @@ expression: output
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry
 
-- entry-!~{000}~.js => entry-YXntGVES.js
+- entry-!~{000}~.js => entry-DIED1Ojv.js
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs
 
-- entry-!~{000}~.js => entry-DfM7nh0c.js
+- entry-!~{000}~.js => entry-D4anQDcN.js
 
 # tests/rolldown/sourcemap/css_sourcemap_reference
 
@@ -5679,15 +5679,15 @@ expression: output
 
 # tests/rolldown/topics/generated_code/reexports_esm_dynamic
 
-- main-!~{000}~.js => main-BfbMazEi.js
+- main-!~{000}~.js => main-kX5ihded.js
 
 # tests/rolldown/topics/generated_code/reexports_from_external
 
-- main-!~{000}~.js => main-C8Ztp7ml.js
+- main-!~{000}~.js => main-fzoZnBvS.js
 
 # tests/rolldown/topics/generated_code/reexports_from_external_commonjs
 
-- main-!~{000}~.js => main-BrYidzUG.js
+- main-!~{000}~.js => main-fUy_BIwP.js
 
 # tests/rolldown/topics/generated_code/symbols
 
@@ -5709,86 +5709,86 @@ expression: output
 
 # tests/rolldown/topics/hmr/accept-outside-circular
 
-- main-!~{000}~.js => main-B-6ZWZWf.js
+- main-!~{000}~.js => main-yqbJQRPS.js
 
 # tests/rolldown/topics/hmr/change_accept
 
-- main-!~{000}~.js => main-C1BdCT_R.js
+- main-!~{000}~.js => main-Cy0J5LeM.js
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-BO9UU8iZ.js
-- exist-dep-cjs-!~{001}~.js => exist-dep-cjs-DCCbl9xi.js
-- exist-dep-esm-!~{003}~.js => exist-dep-esm-Dsn1lQ8Z.js
+- main-!~{000}~.js => main-BVsagf63.js
+- exist-dep-cjs-!~{001}~.js => exist-dep-cjs-B-WqdnuU.js
+- exist-dep-esm-!~{003}~.js => exist-dep-esm-CvUiozan.js
 
 # tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error
 
-- main-!~{000}~.js => main-DfnFnpnQ.js
+- main-!~{000}~.js => main-B-6OWCri.js
 
 # tests/rolldown/topics/hmr/export_star
 
-- main-!~{000}~.js => main-7MCp_xUn.js
+- main-!~{000}~.js => main-DF4GKlq1.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main--lDtiDvo.js
+- main-!~{000}~.js => main-Cr2fJ8Ju.js
 
 # tests/rolldown/topics/hmr/import_meta_hot_accept
 
-- main-!~{000}~.js => main-Ct8F5aEJ.js
+- main-!~{000}~.js => main-DF_RCa33.js
 
 # tests/rolldown/topics/hmr/issue_4818
 
-- main-!~{000}~.js => main-CpnnrpTq.js
+- main-!~{000}~.js => main-DmdMO7_6.js
 
 # tests/rolldown/topics/hmr/issue_5149
 
-- main-!~{000}~.js => main-KtFBp7Ai.js
+- main-!~{000}~.js => main-DHGuZD1G.js
 
 # tests/rolldown/topics/hmr/issue_5150
 
-- main-!~{000}~.js => main-0Zh9_dKy.js
+- main-!~{000}~.js => main-Ciule4Jx.js
 
 # tests/rolldown/topics/hmr/issue_5159
 
-- main-!~{000}~.js => main-C1BOQqVg.js
-- bar-!~{003}~.js => bar-DRQ4WPHL.js
-- foo-!~{005}~.js => foo-D2vVr8ss.js
-- string-!~{001}~.js => string-Bpn7aEJD.js
+- main-!~{000}~.js => main-jTOvOHYB.js
+- bar-!~{003}~.js => bar-Bbo2fFE3.js
+- foo-!~{005}~.js => foo-CMy0ab5J.js
+- string-!~{001}~.js => string-B2q0E_z8.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-CO0J7ujR.js
-- index-!~{001}~.js => index-CDgmqZbJ.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-hLAAOio2.js
+- entry-!~{000}~.js => entry-5FRCF2-x.js
+- index-!~{001}~.js => index-DJGvCZ5l.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-BoZPSyOb.js
 
 # tests/rolldown/topics/hmr/no-accept-outside-circular
 
-- main-!~{000}~.js => main-D2ZPjmnc.js
+- main-!~{000}~.js => main-u-sRZrzL.js
 
 # tests/rolldown/topics/hmr/no_boundary_reload
 
-- main-!~{000}~.js => main-Bqso8ovr.js
+- main-!~{000}~.js => main-ClMA5P6T.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-WkgWt2RM.js
+- main-!~{000}~.js => main-DA-Mkmnm.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-Mm3xiEkB.js
+- main-!~{000}~.js => main-CT8uhQom.js
 
 # tests/rolldown/topics/hmr/runtime_correctness
 
-- main-!~{000}~.js => main-Ce604_xU.js
+- main-!~{000}~.js => main-CAU0z0Wz.js
 
 # tests/rolldown/topics/hmr/self-accept-within-circular
 
-- main-!~{000}~.js => main-B__nXvaB.js
+- main-!~{000}~.js => main-BP0ubZue.js
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-C-vMWT3_.js
+- main-!~{000}~.js => main-CcRsFuqB.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 
@@ -5998,7 +5998,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/commonjs
 
-- main-!~{000}~.js => main-C6j22QVK.js
+- main-!~{000}~.js => main-D1MpZPcJ.js
 
 # tests/rolldown/tree_shaking/commonjs_5546
 
@@ -6006,11 +6006,11 @@ expression: output
 
 # tests/rolldown/tree_shaking/commonjs_inline_const
 
-- main-!~{000}~.js => main-oJx94BDW.js
+- main-!~{000}~.js => main-BOetPQ3-.js
 
 # tests/rolldown/tree_shaking/commonjs_mixed
 
-- main-!~{000}~.js => main-GE7G7sM0.js
+- main-!~{000}~.js => main-BX-PfYi7.js
 
 # tests/rolldown/tree_shaking/commonjs_redefine_export
 

--- a/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
@@ -63,15 +63,8 @@ impl<'ast> AstSnippet<'ast> {
     re_export_fn_ref: Expression<'ast>,
     first_arg: Expression<'ast>,
     second_arg: Expression<'ast>,
-    enable_generated_code_symbols: bool,
   ) -> ast::CallExpression<'ast> {
-    let mut args = self.builder.vec_from_iter([first_arg.into(), second_arg.into()]);
-    if enable_generated_code_symbols {
-      args.extend([
-        self.void_zero().into(),
-        self.builder.expression_numeric_literal(SPAN, 1.0, None, NumberBase::Decimal).into(),
-      ]);
-    }
+    let args = self.builder.vec_from_iter([first_arg.into(), second_arg.into()]);
     self.builder.call_expression(SPAN, re_export_fn_ref, NONE, args, false)
   }
 


### PR DESCRIPTION
since #7345 already wrap the exports object with `__export(.., 1` whatever, overrode `String.toStringTag` is pretty redundant.