### PR TITLE
fix(dev): remove `imports` when an import is removed

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -386,6 +386,17 @@ impl<'a> ModuleLoader<'a> {
           } = *task_result;
           all_warnings.extend(warnings);
 
+          // remove importers from previous scan
+          if !self.is_full_scan
+            && let Some(previous_module) =
+              self.cache.get_snapshot().module_table.modules.get(module.idx())
+          {
+            for rec in previous_module.import_records() {
+              self.intermediate_normal_modules.importers[rec.resolved_module]
+                .retain(|v| v.importer_idx != module.idx());
+            }
+          }
+
           let mut import_records = IndexVec::with_capacity(raw_import_records.len());
           for ((rec_idx, mut raw_rec), resolved_id) in
             raw_import_records.into_iter_enumerated().zip(resolved_deps)

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
@@ -79,40 +79,9 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 
 # HMR Step 1
 
-## Code
-
-```js
-//#region parent.js
-var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
-	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({
-			childValue: () => childValue,
-			parentValue: () => parentValue
-		});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
-		const childValue = "not-child";
-		const parentValue = "parent";
-		hot_parent.accept((newMod) => {
-			const { childValue, parentValue } = newMod;
-			assert.strictEqual(parentValue, "parent");
-			assert.strictEqual(childValue, "not-child");
-		});
-	} finally {}
-}));
-
-//#endregion
-init_parent_0()
-__rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
-```
-
 ## Meta
 
-- update type: patch
-
-### Hmr Boundaries
-
-- boundary: parent.js, accepted_via: parent.js
+- update type: noop
 
 # HMR Step 2
 


### PR DESCRIPTION
I'm not sure if this is the supposed way to implement this fix. It feels we should do a refactor.
I also think should have a test that ensures the states are updated properly (a test that ensures the incremental build & full build generates the same states).