### PR TITLE
chore: pin pnpm to version 10.23.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,10 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": ["pnpm"],
+      "allowedVersions": "10.23.0"
+    },
+    {
       "groupName": "rolldown-plugin-dts",
       "matchManagers": ["npm"],
       "matchPackageNames": ["rolldown-plugin-dts"],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Rollup in Rust",
   "type": "module",
   "private": true,
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@10.23.0",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },


### PR DESCRIPTION
pin `pnpm` version to avoid renovate auto bump `pnpm` until the upstream issue is fixed.