### PR TITLE
chore: support `tsconfig: true` in rust tests

### DIFF
--- a/crates/rolldown_common/src/inner_bundler_options/types/tsconfig.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/tsconfig.rs
@@ -3,13 +3,21 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "deserialize_bundler_options")]
 use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use sugar_path::SugarPath as _;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "deserialize_bundler_options", derive(Deserialize, JsonSchema))]
 #[cfg_attr(feature = "deserialize_bundler_options", serde(untagged))]
 pub enum TsConfig {
+  #[cfg_attr(
+    feature = "deserialize_bundler_options",
+    serde(deserialize_with = "deserialize_tsconfig_auto")
+  )]
+  #[cfg_attr(
+    feature = "deserialize_bundler_options",
+    schemars(schema_with = "schemars_for_tsconfig_auto")
+  )]
   Auto,
   Manual(PathBuf),
 }
@@ -22,4 +30,18 @@ impl TsConfig {
       Self::Manual(path) => Self::Manual(base.join(path).normalize()),
     }
   }
+}
+
+#[cfg(feature = "deserialize_bundler_options")]
+fn deserialize_tsconfig_auto<'de, D>(deserializer: D) -> Result<(), D::Error>
+where
+  D: Deserializer<'de>,
+{
+  let deserialized = bool::deserialize(deserializer)?;
+  if deserialized { Ok(()) } else { Err(serde::de::Error::custom("expected true or path")) }
+}
+
+#[cfg(feature = "deserialize_bundler_options")]
+fn schemars_for_tsconfig_auto(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+  schemars::json_schema!({ "type": "boolean", "const": true })
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1536,7 +1536,8 @@
     "TsConfig": {
       "anyOf": [
         {
-          "type": "null"
+          "type": "boolean",
+          "const": true
         },
         {
           "type": "string"


### PR DESCRIPTION
Support using `"tsconfig": true` in json configs for rust tests.