### PR TITLE
chore: fix esbuild compatibility metrics calculation

### DIFF
--- a/scripts/src/esbuild-tests/snap-diff/runner.ts
+++ b/scripts/src/esbuild-tests/snap-diff/runner.ts
@@ -206,8 +206,10 @@ function generateStatsMarkdown(
   const { stats, details } = aggregateStats;
   let markdown = '';
 
+  const unsupportedCaseCount = Object.keys(notSupportedReasons).length;
+
   // Exclude ignored tests from ratio calculation
-  const totalForRatio = stats.total - stats.ignored;
+  const totalForRatio = stats.total - (stats.ignored - unsupportedCaseCount);
   const passed = stats.pass;
 
   markdown += `# Compatibility metric\n`;
@@ -218,7 +220,6 @@ function generateStatsMarkdown(
     ((passed / totalForRatio) * 100).toFixed(2)
   }%\n`;
 
-  const unsupportedCaseCount = Object.keys(notSupportedReasons).length;
   let totalWithoutNotSupport = totalForRatio - unsupportedCaseCount;
   markdown += `# Compatibility metric without not supported case\n`;
   markdown += `- total: ${totalWithoutNotSupport}\n`;

--- a/scripts/src/esbuild-tests/snap-diff/stats/stats.md
+++ b/scripts/src/esbuild-tests/snap-diff/stats/stats.md
@@ -2,11 +2,11 @@
 - total: 808
 - ignored: 112
 - passed: 573
-- passed ratio: 82.33%
+- passed ratio: 75.20%
 # Compatibility metric without not supported case
-- total: 630
+- total: 696
 - passed: 573
-- passed ratio: 90.95%
+- passed ratio: 82.33%
 # Compatibility metric details
 ## dce
 - total: 120


### PR DESCRIPTION
It was possible to have passed ratio over 100% 😅