### PR TITLE
feat(rolldown_plugin_vite_import_glob): add transform-based v2 implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3275,13 +3275,16 @@ dependencies = [
 name = "rolldown_plugin_vite_import_glob"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "fast-glob",
  "itoa",
  "oxc",
+ "rolldown_common",
  "rolldown_ecmascript_utils",
  "rolldown_plugin",
  "rolldown_plugin_utils",
  "rolldown_utils",
+ "string_wizard",
  "sugar_path",
  "walkdir",
 ]

--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_import_glob_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_import_glob_plugin_config.rs
@@ -1,19 +1,27 @@
-use rolldown_plugin_vite_import_glob::{ViteImportGlobPlugin, ViteImportGlobPluginConfig};
+use rolldown_plugin_vite_import_glob::{ViteImportGlobPlugin, ViteImportGlobPluginV2Config};
+
+#[napi_derive::napi(object)]
+#[derive(Debug, Default)]
+pub struct BindingViteImportGlobPluginV2Config {
+  pub sourcemap: Option<bool>,
+}
 
 #[napi_derive::napi(object)]
 #[derive(Debug, Default)]
 pub struct BindingViteImportGlobPluginConfig {
   pub root: Option<String>,
   pub restore_query_extension: Option<bool>,
+  pub is_v2: Option<BindingViteImportGlobPluginV2Config>,
 }
 
 impl From<BindingViteImportGlobPluginConfig> for ViteImportGlobPlugin {
   fn from(value: BindingViteImportGlobPluginConfig) -> Self {
     Self {
-      config: ViteImportGlobPluginConfig {
-        root: value.root,
-        restore_query_extension: value.restore_query_extension.unwrap_or_default(),
-      },
+      root: value.root,
+      restore_query_extension: value.restore_query_extension.unwrap_or_default(),
+      is_v2: value
+        .is_v2
+        .map(|v2| ViteImportGlobPluginV2Config { sourcemap: v2.sourcemap.unwrap_or_default() }),
     }
   }
 }

--- a/crates/rolldown_plugin_vite_import_glob/Cargo.toml
+++ b/crates/rolldown_plugin_vite_import_glob/Cargo.toml
@@ -17,12 +17,15 @@ doctest = false
 workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 fast-glob = { workspace = true }
 itoa = { workspace = true }
 oxc = { workspace = true }
+rolldown_common = { workspace = true }
 rolldown_ecmascript_utils = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_plugin_utils = { workspace = true }
 rolldown_utils = { workspace = true }
+string_wizard = { workspace = true }
 sugar_path = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rolldown_plugin_vite_import_glob/src/lib.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/lib.rs
@@ -1,29 +1,97 @@
 mod utils;
+mod utils_2;
 
 use std::{borrow::Cow, path::PathBuf};
 
-use oxc::{ast::AstBuilder, ast_visit::VisitMut};
+use oxc::{
+  ast::AstBuilder,
+  ast_visit::{Visit, VisitMut},
+};
+use rolldown_common::ModuleType;
 use rolldown_plugin::{
-  HookTransformAstArgs, HookTransformAstReturn, HookUsage, Plugin, PluginContext,
+  HookTransformAstArgs, HookTransformAstReturn, HookTransformOutput, HookUsage, Plugin,
+  PluginContext,
 };
 use sugar_path::SugarPath;
 
 #[derive(Debug, Default)]
-pub struct ViteImportGlobPlugin {
-  pub config: ViteImportGlobPluginConfig,
+pub struct ViteImportGlobPluginV2Config {
+  pub sourcemap: bool,
 }
 
 #[derive(Debug, Default)]
-pub struct ViteImportGlobPluginConfig {
+pub struct ViteImportGlobPlugin {
   /// vite also support `source_map` config, but we can't support it now.
   /// Since the source map now follow the codegen option.
   pub root: Option<String>,
   pub restore_query_extension: bool,
+  pub is_v2: Option<ViteImportGlobPluginV2Config>,
 }
 
 impl Plugin for ViteImportGlobPlugin {
   fn name(&self) -> Cow<'static, str> {
     Cow::Borrowed("builtin:vite-import-glob")
+  }
+
+  async fn transform(
+    &self,
+    ctx: rolldown_plugin::SharedTransformPluginContext,
+    args: &rolldown_plugin::HookTransformArgs<'_>,
+  ) -> rolldown_plugin::HookTransformReturn {
+    if matches!(
+      args.module_type,
+      ModuleType::Js | ModuleType::Ts | ModuleType::Jsx | ModuleType::Tsx
+    ) && args.code.contains("import.meta.glob")
+    {
+      let allocator = oxc::allocator::Allocator::default();
+      let source_type = match args.module_type {
+        ModuleType::Js => oxc::span::SourceType::mjs(),
+        ModuleType::Jsx => oxc::span::SourceType::jsx(),
+        ModuleType::Ts => oxc::span::SourceType::ts(),
+        ModuleType::Tsx => oxc::span::SourceType::tsx(),
+        _ => unreachable!(),
+      };
+      let parser_ret = oxc::parser::Parser::new(&allocator, args.code, source_type).parse();
+      if parser_ret.panicked
+        && let Some(err) =
+          parser_ret.errors.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
+      {
+        return Err(anyhow::anyhow!(format!(
+          "Failed to parse code in '{}': {:?}",
+          args.id, err.message
+        )));
+      }
+      let id = args.id.to_slash_lossy();
+      let root = self.root.as_ref().map(PathBuf::from);
+      let root = root.as_ref().unwrap_or(ctx.cwd());
+      let mut visitor = utils_2::GlobImportVisit {
+        ctx: &ctx,
+        root,
+        id: &id,
+        current: 0,
+        code: args.code,
+        magic_string: None,
+        import_decls: Vec::new(),
+        restore_query_extension: self.restore_query_extension,
+      };
+      visitor.visit_program(&parser_ret.program);
+      if let Some(magic_string) = visitor.magic_string {
+        return Ok(Some(HookTransformOutput {
+          code: Some(magic_string.to_string()),
+          map: self.is_v2.as_ref().and_then(|config| {
+            config.sourcemap.then(|| {
+              magic_string.source_map(string_wizard::SourceMapOptions {
+                hires: string_wizard::Hires::Boundary,
+                source: args.id.into(),
+                ..Default::default()
+              })
+            })
+          }),
+          ..Default::default()
+        }));
+      }
+    }
+    Ok(None)
   }
 
   async fn transform_ast(
@@ -33,7 +101,7 @@ impl Plugin for ViteImportGlobPlugin {
   ) -> HookTransformAstReturn {
     args.ast.program.with_mut(|fields| {
       let id = args.id.to_slash_lossy();
-      let root = self.config.root.as_ref().map(PathBuf::from);
+      let root = self.root.as_ref().map(PathBuf::from);
       let root = root.as_ref().unwrap_or(args.cwd);
       let ast_builder = AstBuilder::new(fields.allocator);
       let mut visitor = utils::GlobImportVisit {
@@ -43,7 +111,7 @@ impl Plugin for ViteImportGlobPlugin {
         ast_builder,
         current: 0,
         import_decls: ast_builder.vec(),
-        restore_query_extension: self.config.restore_query_extension,
+        restore_query_extension: self.restore_query_extension,
       };
       visitor.visit_program(fields.program);
       if !visitor.import_decls.is_empty() {
@@ -54,6 +122,6 @@ impl Plugin for ViteImportGlobPlugin {
   }
 
   fn register_hook_usage(&self) -> HookUsage {
-    HookUsage::TransformAst
+    if self.is_v2.is_some() { HookUsage::Transform } else { HookUsage::TransformAst }
   }
 }

--- a/crates/rolldown_plugin_vite_import_glob/src/utils_2.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils_2.rs
@@ -1,0 +1,597 @@
+use std::borrow::Cow;
+use std::fmt::Write as _;
+use std::path::{MAIN_SEPARATOR, Path, PathBuf};
+use std::sync::Arc;
+
+use oxc::ast::ast::{
+  self, Argument, ArrayExpressionElement, Expression, ObjectPropertyKind, PropertyKey, PropertyKind,
+};
+use oxc::ast_visit::{Visit, walk};
+use rolldown_ecmascript_utils::ExpressionExt;
+use rolldown_plugin::{LogWithoutPlugin, PluginContext};
+use rolldown_plugin_utils::constants::{ViteImportGlob, ViteImportGlobValue};
+use string_wizard::MagicString;
+use sugar_path::SugarPath;
+
+pub struct GlobImportVisit<'a> {
+  pub ctx: &'a PluginContext,
+  pub id: &'a str,
+  pub root: &'a PathBuf,
+  pub restore_query_extension: bool,
+  pub current: usize,
+  pub code: &'a str,
+  pub magic_string: Option<MagicString<'a>>,
+  pub import_decls: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for GlobImportVisit<'_> {
+  fn visit_program(&mut self, it: &ast::Program<'ast>) {
+    walk::walk_program(self, it);
+    if !self.import_decls.is_empty() {
+      self
+        .magic_string
+        .get_or_insert_with(|| MagicString::new(self.code))
+        .prepend(self.import_decls.join("\n"));
+    }
+  }
+  fn visit_expression(&mut self, expr: &Expression<'ast>) {
+    if self.transform_glob_import(expr, ImportGlobOmitType::None) {
+      return;
+    }
+    walk::walk_expression(self, expr);
+  }
+}
+
+#[derive(Debug, Default)]
+pub struct ImportGlobOptions {
+  eager: bool,
+  exhaustive: bool,
+  base: Option<String>,
+  query: Option<String>,
+  import: Option<String>,
+}
+
+struct ImportGlobFileData {
+  file_path: Option<String>,
+  import_path: String,
+}
+
+#[derive(Debug)]
+struct PathWithGlob<'a> {
+  pub path: String,
+  pub glob: &'a str,
+}
+
+impl<'a> PathWithGlob<'a> {
+  fn new(mut path: String, glob: &'a str) -> Self {
+    let j = Self::split_path_and_glob_inner(&path, glob);
+    let i = Self::find_glob_syntax(&glob[glob.len() - j..]);
+    path.truncate(path.len() - i);
+    Self { path, glob: &glob[glob.len() - i..] }
+  }
+
+  fn find_glob_syntax(path: &str) -> usize {
+    let mut last_slash = 0;
+    for (i, b) in path.as_bytes().iter().enumerate() {
+      if *b == b'/' {
+        last_slash = i;
+      } else if [b'*', b'?', b'[', b']', b'{', b'}'].contains(b) {
+        return path.len() - last_slash;
+      }
+    }
+    path.len() - last_slash
+  }
+
+  fn split_path_and_glob_inner(path: &str, glob: &str) -> usize {
+    let path = path.as_bytes();
+    let glob = glob.as_bytes();
+
+    let mut num_equal = 0;
+    let max_equal = path.len().min(glob.len());
+    while num_equal < max_equal {
+      let r_ch = path[path.len() - 1 - num_equal];
+      let g_ch = glob[glob.len() - 1 - num_equal];
+
+      if r_ch == g_ch || (g_ch == b'/' && r_ch == MAIN_SEPARATOR as u8) {
+        num_equal += 1;
+      } else {
+        break;
+      }
+    }
+
+    num_equal
+  }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ImportGlobOmitType {
+  Keys,
+  Values,
+  None,
+}
+
+impl<'ast> GlobImportVisit<'_> {
+  fn transform_glob_import(
+    &mut self,
+    expr: &Expression<'ast>,
+    omit_type: ImportGlobOmitType,
+  ) -> bool {
+    let Some(call_expr) = expr.as_call_expression() else { return false };
+    let ast::Expression::StaticMemberExpression(ref mem_expr) = call_expr.callee else {
+      return false;
+    };
+
+    match &mem_expr.object {
+      Expression::Identifier(id)
+        if matches!(omit_type, ImportGlobOmitType::None) && id.name == "Object" =>
+      {
+        let omit_type = match mem_expr.property.name.as_str() {
+          "keys" => ImportGlobOmitType::Values,
+          "values" => ImportGlobOmitType::Keys,
+          _ => return false,
+        };
+        let [arg] = call_expr.arguments.as_slice() else { return false };
+        let Some(arg_expr) = arg.as_expression() else { return false };
+        self.transform_glob_import(arg_expr, omit_type)
+      }
+      Expression::MetaProperty(p)
+        if mem_expr.property.name == "glob"
+          && p.meta.name == "import"
+          && p.property.name == "meta" =>
+      {
+        let mut files: Vec<ImportGlobFileData> = vec![];
+        let mut options = ImportGlobOptions::default();
+
+        // import.meta.glob(['./dir/*.js'], { import: 'setup' })
+        if let Some(arg) = call_expr.arguments.get(1) {
+          Self::update_options(arg, &mut options);
+        }
+
+        // import.meta.glob('./dir/*.js')
+        let Some(arg) = call_expr.arguments.first() else { return true };
+
+        // {
+        //   './dir/ind.js': __glob__0_0_,
+        //   './dir/foo.js': () => import('./dir/foo.js'),
+        //   './dir/bar.js': () => import('./dir/bar.js?raw').then((m) => m.setup),
+        // }
+        if self.eval_glob_expr(arg, &mut files, &options).is_some() {
+          self.generate_glob_object_expression(&files, &options, omit_type, call_expr.span);
+        }
+
+        self.current += 1;
+        true
+      }
+      _ => false,
+    }
+  }
+
+  fn generate_glob_object_expression(
+    &mut self,
+    files: &[ImportGlobFileData],
+    options: &ImportGlobOptions,
+    omit_type: ImportGlobOmitType,
+    span: oxc::span::Span,
+  ) {
+    let properties = files.iter().enumerate().map(|(index, file_data)| {
+      let import_path = &file_data.import_path;
+      let formatted_file = if let Some(query) = &options.query {
+        let normalized_query = if query != "?raw" && self.restore_query_extension {
+          let path = Path::new(&import_path);
+          let extension = path.extension().and_then(|p| p.to_str()).unwrap_or_default();
+          &format!("{query}&lang.{extension}")
+        } else {
+          query
+        };
+        Cow::Owned(format!("{import_path}{normalized_query}"))
+      } else {
+        Cow::Borrowed(import_path)
+      };
+
+      let value: Cow<'_, str> = if matches!(omit_type, ImportGlobOmitType::Values) {
+        Cow::Borrowed("0")
+      } else if options.eager {
+        // import * as __import_glob__0_0_ from './dir/foo.js'
+        // const modules = {
+        //   './dir/foo.js': __import_glob__0_0_,
+        // }
+        let name = format!(
+          "__import_glob__{}_{}_",
+          itoa::Buffer::new().format(self.current),
+          itoa::Buffer::new().format(index)
+        );
+
+        let module_specifier = match options.import.as_deref() {
+          Some("*") | None => {
+            format!("* as {name}")
+          }
+          Some(import) => format!("{{ {import} as {name} }}"),
+        };
+
+        self.import_decls.push(format!("import {module_specifier} from \"{formatted_file}\";"));
+
+        Cow::Owned(name)
+      } else {
+        // () => import('./dir/bar.js') or () => import('./dir/foo.js').then((m) => m.setup)
+        Cow::Owned(match options.import.as_deref() {
+          Some(import) if import != "*" => {
+            format!("() => import(\"{formatted_file}\").then((m) => m[\"{import}\"])")
+          }
+          _ => format!("() => import(\"{formatted_file}\")"),
+        })
+      };
+
+      if let Some(file_path) = &file_data.file_path {
+        (file_path, value)
+      } else {
+        (import_path, value)
+      }
+    });
+
+    // Preserve line breaks from original code for sourcemap alignment
+    let line_breaks = "\n".repeat(span.source_text(self.code).matches('\n').count());
+    let replacement = match omit_type {
+      ImportGlobOmitType::Keys => {
+        format!(
+          "[{}{line_breaks}]",
+          properties.map(|(_, value)| value).collect::<Vec<_>>().join(",")
+        )
+      }
+      ImportGlobOmitType::Values => format!(
+        "{{{}{line_breaks}}}",
+        properties
+          .map(|(file, value)| format!("\"{file}\": {value}"))
+          .collect::<Vec<_>>()
+          .join(",")
+      ),
+      ImportGlobOmitType::None => format!(
+        "/* #__PURE__ */ Object.assign({{{}{line_breaks}}})",
+        properties
+          .map(|(file, value)| format!("\"{file}\": {value}"))
+          .collect::<Vec<_>>()
+          .join(",")
+      ),
+    };
+
+    self.magic_string.get_or_insert_with(|| string_wizard::MagicString::new(self.code)).update(
+      span.start as usize,
+      span.end as usize,
+      replacement,
+    );
+  }
+}
+
+impl GlobImportVisit<'_> {
+  fn is_virtual_module(&self) -> bool {
+    // https://vite.dev/guide/api-plugin.html#virtual-modules-convention
+    self.id.starts_with("virtual:") || self.id.starts_with('\0') || !self.id.contains('/')
+  }
+
+  fn to_absolute_glob<'a>(
+    &self,
+    glob: &'a str,
+    dir: &Path,
+    root: &Path,
+    base: Option<&str>,
+  ) -> Option<PathWithGlob<'a>> {
+    let dir = if let Some(base) = base {
+      if let Some(base) = base.strip_prefix('/') { root.join(base) } else { dir.join(base) }
+    } else {
+      dir.to_path_buf()
+    };
+    let absolute_glob = if let Some(glob) = glob.strip_prefix('/') {
+      root.join(glob)
+    } else if glob.starts_with("**") {
+      root.join(glob)
+    } else if glob.starts_with("./") || glob.starts_with("../") {
+      dir.join(glob)
+    } else {
+      let is_sub_imports_pattern = glob.starts_with('#') && glob.contains('*');
+      let future = self.ctx.resolve(
+        glob,
+        Some(self.id),
+        is_sub_imports_pattern.then(|| {
+          let custom = Arc::new(rolldown_plugin::CustomField::new());
+          custom.insert(ViteImportGlob, ViteImportGlobValue(true));
+          rolldown_plugin::PluginContextResolveOptions { custom, ..Default::default() }
+        }),
+      );
+      if let Ok(result) = rolldown_utils::futures::block_on(future) {
+        let id = match result {
+          Ok(resolved_id) => resolved_id.id.into(),
+          Err(_) => Cow::Borrowed(glob),
+        };
+        let path = Path::new(id.as_ref());
+        if path.is_absolute() && path.starts_with(root) {
+          return Some(PathWithGlob::new(id.to_string(), glob));
+        }
+      }
+
+      self.ctx.warn(LogWithoutPlugin {
+        message: format!(
+          "Invalid glob pattern: `{glob}` in file '{}'. Glob patterns must start with:\n  • '/' for absolute paths from project root\n  • './' or '../' for relative paths\n  • '**/' for recursive matching from project root\n  • '#' for subpath imports (with '*' wildcard)",
+          self.id.relative(self.root).display()
+        ),
+        ..Default::default()
+      });
+
+      return None;
+    };
+    Some(PathWithGlob::new(absolute_glob.normalize().to_string_lossy().into_owned(), glob))
+  }
+
+  fn relative_path(&self, path: &Path, to: Option<&Path>) -> String {
+    let path = path.relative(to.unwrap_or(self.root));
+    let path = path.to_slash_lossy();
+    if path.starts_with("./") || path.starts_with("../") {
+      path.to_string()
+    } else {
+      let prefix = if to.is_none() { "/" } else { "./" };
+      format!("{prefix}{path}")
+    }
+  }
+
+  fn get_common_base(&self, globs: &[PathWithGlob]) -> Cow<'_, str> {
+    if globs.is_empty() {
+      return self.root.to_string_lossy();
+    }
+
+    let first = globs[0].path.as_bytes();
+    let mut end = first.len();
+    for PathWithGlob { path, .. } in &globs[1..] {
+      let bytes = path.as_bytes();
+      let max_len = end.min(bytes.len());
+
+      let mut i = 0;
+      while i < max_len && first[i] == bytes[i] {
+        i += 1;
+      }
+
+      end = i;
+      if end == 0 {
+        break;
+      }
+    }
+
+    if end == 0 {
+      self.root.to_string_lossy()
+    } else {
+      Cow::Owned(globs[0].path[..end].to_string())
+    }
+  }
+
+  fn eval_glob_expr(
+    &self,
+    arg: &Argument,
+    files: &mut Vec<ImportGlobFileData>,
+    options: &ImportGlobOptions,
+  ) -> Option<()> {
+    let root = Path::new(&self.root);
+    let is_virtual_module = self.is_virtual_module();
+
+    let dir = if is_virtual_module {
+      root
+    } else {
+      let id = Path::new(self.id);
+      id.parent().unwrap_or(root)
+    };
+
+    let mut is_relative = true;
+    let mut negated_globs = vec![];
+    let mut positive_globs = vec![];
+
+    match arg {
+      Argument::StringLiteral(str) => {
+        if let Some(glob) = str.value.strip_prefix('!') {
+          negated_globs.push(self.to_absolute_glob(glob, dir, root, options.base.as_deref())?);
+        } else {
+          positive_globs.push(self.to_absolute_glob(
+            &str.value,
+            dir,
+            root,
+            options.base.as_deref(),
+          )?);
+          if !str.value.starts_with('.') {
+            is_relative = false;
+          }
+        }
+      }
+      Argument::ArrayExpression(array_expr) => {
+        for expr in &array_expr.elements {
+          if let ArrayExpressionElement::StringLiteral(str) = expr {
+            if let Some(glob) = str.value.strip_prefix('!') {
+              negated_globs.push(self.to_absolute_glob(
+                glob,
+                dir,
+                root,
+                options.base.as_deref(),
+              )?);
+            } else {
+              positive_globs.push(self.to_absolute_glob(
+                &str.value,
+                dir,
+                root,
+                options.base.as_deref(),
+              )?);
+              if !str.value.starts_with('.') {
+                is_relative = false;
+              }
+            }
+          }
+        }
+      }
+      _ => {}
+    }
+
+    if negated_globs.is_empty() && positive_globs.is_empty() {
+      return Some(());
+    }
+
+    assert!(
+      !(is_virtual_module && is_relative && options.base.as_ref().is_none()),
+      "In virtual modules, all globs must start with '/'"
+    );
+
+    let common = self.get_common_base(&positive_globs);
+    let entries = walkdir::WalkDir::new(common.as_ref())
+      .sort_by(|a, b| a.file_name().cmp(b.file_name()))
+      .into_iter()
+      .filter_entry(|entry| {
+        options.exhaustive || entry.depth() == 0 || {
+          let path = entry.file_name();
+          if path.as_encoded_bytes().first() == Some(&b'.') {
+            return false;
+          }
+          path.to_str().is_none_or(|s| s != "node_modules")
+        }
+      })
+      .filter_map(Result::ok)
+      .filter(|e| !e.file_type().is_dir());
+
+    let self_path = self.relative_path(Path::new(self.id), Some(dir));
+
+    for entry in entries {
+      let file = entry.path();
+      let path = file.to_string_lossy();
+
+      let matches_rule = |v: &PathWithGlob| -> bool {
+        path.strip_prefix(&v.path).map(|path| fast_glob::glob_match(v.glob, path)).unwrap_or(false)
+      };
+      if negated_globs.iter().any(matches_rule) || !positive_globs.iter().any(matches_rule) {
+        continue;
+      }
+
+      let file_path = self.relative_path(file, None);
+      if is_virtual_module {
+        let import_path =
+          if file_path.starts_with('/') { file_path } else { format!("/{file_path}") };
+        let file_path = options.base.as_ref().map(|base| {
+          self.relative_path(file, Some(&self.root.join(base.strip_prefix('/').unwrap_or(base))))
+        });
+        files.push(ImportGlobFileData { file_path, import_path });
+        continue;
+      }
+
+      let mut import_path = self.relative_path(file, Some(dir));
+      if self_path == import_path {
+        continue;
+      }
+
+      let file_path = if let Some(base) = &options.base {
+        if base.starts_with('/') {
+          import_path = self.relative_path(file, None);
+        }
+        let base_path = if let Some(base) = base.strip_prefix('/') {
+          self.root.join(base)
+        } else {
+          dir.join(base)
+        };
+        Some(self.relative_path(file, Some(&base_path)))
+      } else if is_relative {
+        None
+      } else {
+        Some(file_path)
+      };
+
+      files.push(ImportGlobFileData { file_path, import_path });
+    }
+    Some(())
+  }
+
+  fn update_options(arg: &Argument, options: &mut ImportGlobOptions) {
+    let Argument::ObjectExpression(obj) = arg else {
+      return;
+    };
+
+    for prop in &obj.properties {
+      let ObjectPropertyKind::ObjectProperty(p) = prop else {
+        continue;
+      };
+
+      let PropertyKind::Init = p.kind else {
+        continue;
+      };
+
+      let key = match &p.key {
+        PropertyKey::StringLiteral(str) => str.value.as_str(),
+        PropertyKey::StaticIdentifier(id) => id.name.as_str(),
+        _ => continue,
+      };
+
+      match key {
+        "base" => match &p.value {
+          Expression::StringLiteral(str) if !str.value.is_empty() => {
+            options.base = Some(str.value.as_str().to_string());
+          }
+          Expression::TemplateLiteral(str)
+            if str.is_no_substitution_template() && !str.quasis[0].value.raw.is_empty() =>
+          {
+            options.base = Some(str.quasis[0].value.raw.as_str().to_string());
+          }
+          _ => {}
+        },
+        "import" => {
+          if let Expression::StringLiteral(str) = &p.value {
+            options.import = Some(str.value.as_str().to_string());
+          }
+        }
+        "eager" => {
+          if let Expression::BooleanLiteral(bool) = &p.value {
+            options.eager = bool.value;
+          }
+        }
+        "exhaustive" => {
+          if let Expression::BooleanLiteral(bool) = &p.value {
+            options.exhaustive = bool.value;
+          }
+        }
+        "query" => match &p.value {
+          Expression::StringLiteral(str) => {
+            options.query = if str.value.starts_with('?') {
+              Some(str.value.to_string())
+            } else {
+              Some(format!("?{}", str.value))
+            }
+          }
+          Expression::ObjectExpression(expr) => {
+            let mut query_string = String::from("?");
+            for prop in &expr.properties {
+              let ObjectPropertyKind::ObjectProperty(p) = prop else { continue };
+
+              let key = match &p.key {
+                PropertyKey::StringLiteral(key) => key.value,
+                PropertyKey::StaticIdentifier(ident) => ident.name,
+                _ => continue,
+              };
+
+              let value = match &p.value {
+                Expression::StringLiteral(v) => v.value.as_str(),
+                Expression::BooleanLiteral(v) => {
+                  if v.value {
+                    "true"
+                  } else {
+                    "false"
+                  }
+                }
+                Expression::NumericLiteral(v) => &v.value.to_string(),
+                Expression::NullLiteral(_) => "null",
+                _ => continue,
+              };
+
+              if query_string.len() != 1 {
+                query_string.push('&');
+              }
+              write!(query_string, "{key}={value}").unwrap();
+            }
+
+            if query_string.len() != 1 {
+              options.query = Some(query_string);
+            }
+          }
+          _ => {}
+        },
+        _ => {}
+      }
+    }
+  }
+}

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2331,6 +2331,11 @@ export interface BindingViteHtmlPluginConfig {
 export interface BindingViteImportGlobPluginConfig {
   root?: string
   restoreQueryExtension?: boolean
+  isV2?: BindingViteImportGlobPluginV2Config
+}
+
+export interface BindingViteImportGlobPluginV2Config {
+  sourcemap?: boolean
 }
 
 export interface BindingViteJsonPluginConfig {


### PR DESCRIPTION
Resolve https://github.com/vitejs/rolldown-vite/issues/373

To make it easier to distinguish between v1 and v2, and to quickly remove the v1 logic once it becomes stable, I separated the two implementations.