### PR TITLE
feat(rolldown_plugin_vite_dynamic_import_vars): add transform-based v2 implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,8 +3232,10 @@ dependencies = [
  "derive_more",
  "memchr",
  "oxc",
+ "rolldown_common",
  "rolldown_plugin",
  "rolldown_utils",
+ "string_wizard",
  "sugar_path",
 ]
 

--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_dynamic_import_vars_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_dynamic_import_vars_plugin_config.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use napi::bindgen_prelude::FnArgs;
-use rolldown_plugin_vite_dynamic_import_vars::{ResolverFn, ViteDynamicImportVarsPlugin};
+use rolldown_plugin_vite_dynamic_import_vars::{
+  ResolverFn, ViteDynamicImportVarsPlugin, ViteDynamicImportVarsPluginV2Config,
+};
 
 use crate::types::{
   binding_string_or_regex::{BindingStringOrRegex, bindingify_string_or_regex_array},
@@ -10,11 +12,18 @@ use crate::types::{
 
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Default)]
+pub struct BindingViteDynamicImportVarsPluginV2Config {
+  pub sourcemap: bool,
+}
+
+#[napi_derive::napi(object, object_to_js = false)]
+#[derive(Default)]
 pub struct BindingViteDynamicImportVarsPluginConfig {
   pub include: Option<Vec<BindingStringOrRegex>>,
   pub exclude: Option<Vec<BindingStringOrRegex>>,
   #[napi(ts_type = "(id: string, importer: string) => MaybePromise<string | undefined>")]
   pub resolver: Option<MaybeAsyncJsCallback<FnArgs<(String, String)>, Option<String>>>,
+  pub is_v2: Option<BindingViteDynamicImportVarsPluginV2Config>,
 }
 
 impl From<BindingViteDynamicImportVarsPluginConfig> for ViteDynamicImportVarsPlugin {
@@ -30,6 +39,9 @@ impl From<BindingViteDynamicImportVarsPluginConfig> for ViteDynamicImportVarsPlu
           })
         })
       }),
+      is_v2: value
+        .is_v2
+        .map(|v2_config| ViteDynamicImportVarsPluginV2Config { sourcemap: v2_config.sourcemap }),
     }
   }
 }

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
@@ -23,6 +23,8 @@ cow-utils = { workspace = true }
 derive_more = { workspace = true }
 memchr = { workspace = true }
 oxc = { workspace = true }
+rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
 rolldown_utils = { workspace = true }
+string_wizard = { workspace = true }
 sugar_path = { workspace = true }

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit_2.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit_2.rs
@@ -1,0 +1,169 @@
+use std::{borrow::Cow, path::Path};
+
+use cow_utils::CowUtils;
+use oxc::{
+  ast::{Comment, ast::Expression},
+  ast_visit::{Visit, walk},
+};
+use rolldown_plugin::{LogWithoutPlugin, PluginContext};
+use string_wizard::MagicString;
+use sugar_path::SugarPath as _;
+
+use super::dynamic_import_to_glob::{
+  has_special_query_param, should_ignore, template_literal_to_glob, to_valid_glob,
+};
+
+#[derive(Debug)]
+struct DynamicImportRequest<'a> {
+  pub query: &'a str,
+  pub import: bool,
+}
+
+pub struct DynamicImportVarsVisit<'ast, 'b> {
+  pub ctx: &'b PluginContext,
+  pub source_text: &'b str,
+  pub root: &'b Path,
+  pub importer: &'b Path,
+  pub need_helper: bool,
+  pub comments: &'b oxc::allocator::Vec<'ast, Comment>,
+  pub current_comment: usize,
+  pub async_imports: Vec<String>,
+  pub async_imports_addrs: Vec<*const Expression<'ast>>,
+  pub magic_string: Option<MagicString<'b>>,
+}
+
+impl<'ast> Visit<'ast> for DynamicImportVarsVisit<'ast, '_> {
+  fn visit_expression(&mut self, expr: &Expression<'ast>) {
+    if self.rewrite_variable_dynamic_import(expr, None) {
+      walk::walk_expression(self, expr);
+    }
+  }
+}
+
+impl<'ast> DynamicImportVarsVisit<'ast, '_> {
+  pub fn rewrite_variable_dynamic_import(
+    &mut self,
+    expr: &Expression<'ast>,
+    async_imports: Option<&str>,
+  ) -> bool {
+    if let Expression::ImportExpression(import_expr) = expr
+      && let Expression::TemplateLiteral(source) = &import_expr.source
+    {
+      // Respects @vite-ignore comment (e.g., import(/* @vite-ignore */ `..`))
+      if self.current_comment < self.comments.len() {
+        for comment in &self.comments[self.current_comment..] {
+          if comment.attached_to > source.span.start {
+            break;
+          }
+          self.current_comment += 1;
+          if comment.attached_to == source.span.start && comment.is_vite() {
+            return false;
+          }
+        }
+      }
+      let glob = match async_imports {
+        Some(glob) => Cow::Borrowed(glob),
+        None => {
+          if source.is_no_substitution_template() {
+            return false;
+          }
+
+          let glob = match template_literal_to_glob(source) {
+            Ok(glob) => glob,
+            Err(error) => {
+              self.ctx.warn(LogWithoutPlugin { message: error.to_string(), ..Default::default() });
+              return false;
+            }
+          };
+
+          if memchr::memchr(b'*', glob.as_bytes()).is_none() || should_ignore(&glob) {
+            return false;
+          }
+
+          if glob.as_bytes()[0] != b'.' && glob.as_bytes()[0] != b'/' {
+            self.async_imports.push(glob.into_owned());
+            self.async_imports_addrs.push(std::ptr::from_ref(expr));
+            return false;
+          }
+
+          glob
+        }
+      };
+
+      let Some(index) = memchr::memchr(b'*', glob.as_bytes()) else {
+        return false;
+      };
+
+      let raw = source.span.shrink(1).source_text(self.source_text);
+      let raw_pattern = if &glob[..index] == source.quasis[0].value.raw {
+        Cow::Borrowed(raw)
+      } else {
+        let mut s = String::with_capacity(index + source.quasis[0].value.raw.len());
+        s.push_str(&glob[..index]);
+        s.push_str(&raw[source.quasis[0].value.raw.len()..]);
+        Cow::Owned(s)
+      };
+
+      let base = self.importer.parent().unwrap_or(self.root);
+      let normalized = if raw_pattern.as_bytes()[0] == b'/' {
+        self.root.join(&raw_pattern[1..]).relative(base)
+      } else {
+        base.join(raw_pattern.as_ref()).relative(base)
+      };
+
+      let normalized = normalized.to_slash_lossy();
+      let new_raw_pattern = if normalized.starts_with("./") || normalized.starts_with("../") {
+        normalized.into_owned()
+      } else {
+        rolldown_utils::concat_string!("./", normalized)
+      };
+
+      let glob = glob.cow_replace("**", "*");
+      let source_text = source.span.source_text(self.source_text);
+
+      let (pattern, glob_params) = {
+        let index = glob.rfind('/').unwrap_or(0);
+        let index = glob[index..].find('?').map_or(glob.len(), |i| i + index);
+
+        let (glob, query) = glob.split_at(index);
+        let glob = match to_valid_glob(glob, source_text) {
+          Ok(glob) => glob,
+          Err(error) => {
+            self.ctx.warn(LogWithoutPlugin { message: error.to_string(), ..Default::default() });
+            return false;
+          }
+        };
+
+        let params = (!query.is_empty())
+          .then_some(DynamicImportRequest { query, import: has_special_query_param(query) });
+
+        (glob, params)
+      };
+
+      // __variableDynamicImportRuntimeHelper((import.meta.glob(pattern, params)), expr, segments)
+      let segments = pattern.split('/').count();
+      let replacement = format!(
+        "__variableDynamicImportRuntimeHelper(import.meta.glob(\"{pattern}\"{}), `{new_raw_pattern}`, {segments})",
+        glob_params
+          .map(|params| {
+            format!(
+              ", {{ query: \"{}\"{} }}",
+              params.query,
+              if params.import { ", import: \"*\"" } else { "" }
+            )
+          })
+          .unwrap_or_default()
+      );
+
+      self.magic_string.get_or_insert_with(|| MagicString::new(self.source_text)).update(
+        import_expr.span.start as usize,
+        import_expr.span.end as usize,
+        replacement,
+      );
+
+      self.need_helper = true;
+      return false;
+    }
+    true
+  }
+}

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/lib.rs
@@ -1,18 +1,24 @@
 mod ast_visit;
+mod ast_visit_2;
 mod dynamic_import_to_glob;
+mod utils;
 
-use std::{borrow::Cow, path::Path, pin::Pin, sync::Arc};
+use std::{borrow::Cow, pin::Pin, sync::Arc};
 
 use derive_more::Debug;
-use oxc::{ast::AstBuilder, ast_visit::VisitMut};
+use oxc::{
+  ast::AstBuilder,
+  ast_visit::{Visit, VisitMut},
+};
+use rolldown_common::ModuleType;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
-  HookResolveIdReturn, HookTransformAstArgs, HookTransformAstReturn, HookUsage, Plugin,
-  PluginContext,
+  HookResolveIdReturn, HookTransformAstArgs, HookTransformAstReturn, HookTransformOutput,
+  HookUsage, Plugin, PluginContext,
 };
 use rolldown_utils::{
   futures::{block_on, block_on_spawn_all},
-  pattern_filter::{StringOrRegex, filter as pattern_filter},
+  pattern_filter::StringOrRegex,
 };
 use sugar_path::SugarPath as _;
 
@@ -23,28 +29,28 @@ pub type ResolverFn = dyn Fn(String, String) -> Pin<Box<dyn Future<Output = anyh
   + Sync;
 
 #[derive(Debug, Default)]
+pub struct ViteDynamicImportVarsPluginV2Config {
+  pub sourcemap: bool,
+}
+
+#[derive(Debug, Default)]
 pub struct ViteDynamicImportVarsPlugin {
   pub include: Vec<StringOrRegex>,
   pub exclude: Vec<StringOrRegex>,
   #[debug(skip)]
   pub resolver: Option<Arc<ResolverFn>>,
-}
-
-impl ViteDynamicImportVarsPlugin {
-  fn filter(&self, id: &str, cwd: &Path) -> bool {
-    if self.include.is_empty() && self.exclude.is_empty() {
-      return true;
-    }
-
-    let exclude = (!self.exclude.is_empty()).then_some(self.exclude.as_slice());
-    let include = (!self.include.is_empty()).then_some(self.include.as_slice());
-    pattern_filter(exclude, include, id, &cwd.to_string_lossy()).inner()
-  }
+  pub is_v2: Option<ViteDynamicImportVarsPluginV2Config>,
 }
 
 impl Plugin for ViteDynamicImportVarsPlugin {
   fn name(&self) -> Cow<'static, str> {
     Cow::Borrowed("builtin:vite-dynamic-import-vars")
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::ResolveId
+      | HookUsage::Load
+      | if self.is_v2.is_some() { HookUsage::Transform } else { HookUsage::TransformAst }
   }
 
   async fn resolve_id(
@@ -63,6 +69,104 @@ impl Plugin for ViteDynamicImportVarsPlugin {
       code: arcstr::literal!(include_str!("dynamic-import-helper.js")),
       ..Default::default()
     }))
+  }
+
+  async fn transform(
+    &self,
+    ctx: rolldown_plugin::SharedTransformPluginContext,
+    args: &rolldown_plugin::HookTransformArgs<'_>,
+  ) -> rolldown_plugin::HookTransformReturn {
+    if !self.filter(args.id, ctx.cwd()) {
+      return Ok(None);
+    }
+    if matches!(
+      args.module_type,
+      ModuleType::Js | ModuleType::Ts | ModuleType::Jsx | ModuleType::Tsx
+    ) && utils::has_dynamic_import(args.code)
+    {
+      let allocator = oxc::allocator::Allocator::default();
+      let source_type = match args.module_type {
+        ModuleType::Js => oxc::span::SourceType::mjs(),
+        ModuleType::Jsx => oxc::span::SourceType::jsx(),
+        ModuleType::Ts => oxc::span::SourceType::ts(),
+        ModuleType::Tsx => oxc::span::SourceType::tsx(),
+        _ => unreachable!(),
+      };
+      let parser_ret = oxc::parser::Parser::new(&allocator, args.code, source_type).parse();
+      if parser_ret.panicked
+        && let Some(err) =
+          parser_ret.errors.iter().find(|e| e.severity == oxc::diagnostics::Severity::Error)
+      {
+        return Err(anyhow::anyhow!(format!(
+          "Failed to parse code in '{}': {:?}",
+          args.id, err.message
+        )));
+      }
+      let mut visitor = ast_visit_2::DynamicImportVarsVisit {
+        ctx: &ctx,
+        source_text: args.code,
+        root: ctx.cwd(),
+        importer: args.id.as_path(),
+        need_helper: false,
+        comments: &parser_ret.program.comments,
+        current_comment: 0,
+        async_imports: Vec::default(),
+        async_imports_addrs: Vec::default(),
+        magic_string: None,
+      };
+
+      visitor.visit_program(&parser_ret.program);
+
+      if !visitor.async_imports.is_empty()
+        && let Some(resolver) = &self.resolver
+      {
+        let async_imports = std::mem::take(&mut visitor.async_imports);
+        let task = async_imports
+          .into_iter()
+          .map(|glob| async { resolver(glob, args.id.to_string()).await.ok()? });
+
+        let importer = args.id.as_path().parent().unwrap();
+        let result = block_on(block_on_spawn_all(task));
+        for (i, item) in result.into_iter().enumerate() {
+          if let Some(id) = item {
+            let id = id.relative(importer);
+            let id = id.to_slash_lossy();
+            let id = if id.is_empty() {
+              continue;
+            } else if id.as_bytes()[0] == b'.' {
+              id.into_owned()
+            } else {
+              rolldown_utils::concat_string!("./", id)
+            };
+
+            let addr = visitor.async_imports_addrs[i];
+            visitor.rewrite_variable_dynamic_import(unsafe { &*addr }, Some(&id));
+          }
+        }
+      }
+
+      if let Some(mut magic_string) = visitor.magic_string {
+        if visitor.need_helper {
+          magic_string.prepend(format!(
+            "import __variableDynamicImportRuntimeHelper from \"{DYNAMIC_IMPORT_HELPER}\";"
+          ));
+        }
+        return Ok(Some(HookTransformOutput {
+          code: Some(magic_string.to_string()),
+          map: self.is_v2.as_ref().and_then(|config| {
+            config.sourcemap.then(|| {
+              magic_string.source_map(string_wizard::SourceMapOptions {
+                hires: string_wizard::Hires::Boundary,
+                source: args.id.into(),
+                ..Default::default()
+              })
+            })
+          }),
+          ..Default::default()
+        }));
+      }
+    }
+    Ok(None)
   }
 
   async fn transform_ast(
@@ -125,9 +229,5 @@ impl Plugin for ViteDynamicImportVarsPlugin {
     });
 
     Ok(args.ast)
-  }
-
-  fn register_hook_usage(&self) -> HookUsage {
-    HookUsage::ResolveId | HookUsage::Load | HookUsage::TransformAst
   }
 }

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/utils.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/utils.rs
@@ -1,0 +1,64 @@
+use std::path::Path;
+
+use rolldown_utils::pattern_filter::filter as pattern_filter;
+
+use super::ViteDynamicImportVarsPlugin;
+
+impl ViteDynamicImportVarsPlugin {
+  pub fn filter(&self, id: &str, cwd: &Path) -> bool {
+    if self.include.is_empty() && self.exclude.is_empty() {
+      return true;
+    }
+
+    let exclude = (!self.exclude.is_empty()).then_some(self.exclude.as_slice());
+    let include = (!self.include.is_empty()).then_some(self.include.as_slice());
+    pattern_filter(exclude, include, id, &cwd.to_string_lossy()).inner()
+  }
+}
+
+/// Check if code contains dynamic import pattern: /\bimport\s*[(/]/
+/// This is a fast check to avoid parsing files that don't contain dynamic imports.
+pub fn has_dynamic_import(code: &str) -> bool {
+  let bytes = code.as_bytes();
+
+  let mut i = 0;
+  while i + 6 < bytes.len() {
+    // Find "import"
+    if let Some(pos) = memchr::memmem::find(&bytes[i..], b"import") {
+      let abs_pos = i + pos;
+
+      // Check word boundary before "import"
+      if abs_pos > 0 {
+        let prev = bytes[abs_pos - 1];
+        if prev.is_ascii_alphanumeric() || prev == b'_' {
+          i = abs_pos + 6;
+          continue;
+        }
+      }
+
+      // Skip whitespace after "import"
+      let mut j = abs_pos + 6;
+      while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+        j += 1;
+      }
+
+      // Check for '('
+      if j < bytes.len() && bytes[j] == b'(' {
+        // Skip whitespace after "("
+        j += 1;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+          j += 1;
+        }
+        // Check for template literal
+        if j < bytes.len() && bytes[j] == b'`' {
+          return true;
+        }
+      }
+
+      i = j;
+    } else {
+      break;
+    }
+  }
+  false
+}

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2307,6 +2307,11 @@ export interface BindingViteDynamicImportVarsPluginConfig {
   include?: Array<BindingStringOrRegex>
   exclude?: Array<BindingStringOrRegex>
   resolver?: (id: string, importer: string) => MaybePromise<string | undefined>
+  isV2?: BindingViteDynamicImportVarsPluginV2Config
+}
+
+export interface BindingViteDynamicImportVarsPluginV2Config {
+  sourcemap: boolean
 }
 
 export interface BindingViteHtmlInlineProxyPluginConfig {


### PR DESCRIPTION
Resolve https://github.com/vitejs/rolldown-vite/issues/373

To make it easier to distinguish between v1 and v2, and to quickly remove the v1 logic once it becomes stable, I separated the two implementations.