### PR TITLE
fix(bench): access latency.mean instead of mean in tinybench result

### DIFF
--- a/packages/bench/benches/ci.js
+++ b/packages/bench/benches/ci.js
@@ -27,13 +27,13 @@ for (const suite of expandSuitesWithDerived(suitesForCI)) {
 await bench.run();
 
 const dataForGitHubBenchmarkAction = bench.tasks.map((task) => {
-  if (!task.result) {
+  if (!task.result || !('latency' in task.result)) {
     throw new Error('Task result is empty for ' + task.name);
   }
 
   return {
     name: task.name,
-    value: task.result.mean.toFixed(2),
+    value: task.result.latency.mean.toFixed(2),
     unit: 'ms / ops',
   };
 });


### PR DESCRIPTION
Fixed https://github.com/rolldown/rolldown/actions/runs/20087259968/job/57627444028

Related to #7371