### PR TITLE
fix: use `process.on('exit')` instead of `signal-exit` on webcontainers

### DIFF
--- a/packages/rolldown/src/cli/commands/bundle.ts
+++ b/packages/rolldown/src/cli/commands/bundle.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
-import { onExit } from 'signal-exit';
 import { version } from '../../../package.json';
 import type { RolldownOptions, RolldownOutput } from '../..';
 import { rolldown } from '../../api/rolldown';
@@ -8,6 +7,7 @@ import { watch as rolldownWatch } from '../../api/watch';
 import { getClearScreenFunction } from '../../utils/clear-screen';
 import { loadConfig } from '../../utils/load-config';
 import { arraify } from '../../utils/misc';
+import { onExit } from '../../utils/signal-exit';
 import { styleText } from '../../utils/style-text';
 import type { NormalizedCliOptions } from '../arguments/normalize';
 import { logger } from '../logger';

--- a/packages/rolldown/src/setup.ts
+++ b/packages/rolldown/src/setup.ts
@@ -1,6 +1,6 @@
 import { isMainThread } from 'node:worker_threads';
-import { onExit } from 'signal-exit';
 import { initTraceSubscriber } from './binding.cjs';
+import { onExit } from './utils/signal-exit';
 
 if (!import.meta.browserBuild && isMainThread) {
   const subscriberGuard = initTraceSubscriber();

--- a/packages/rolldown/src/utils/signal-exit.ts
+++ b/packages/rolldown/src/utils/signal-exit.ts
@@ -1,0 +1,15 @@
+import { onExit as originalOnExit } from 'signal-exit';
+
+export function onExit(...args: Parameters<typeof originalOnExit>): void {
+  // process is undefined for browser build
+  if (typeof process === 'object' && process.versions.webcontainer) {
+    // signal-exit does not work properly in webcontainers
+    // (https://github.com/rolldown/rolldown/issues/7381)
+    process.on('exit', (code) => {
+      args[0](code, null);
+    });
+    return;
+  }
+
+  originalOnExit(...args);
+}


### PR DESCRIPTION
fixes #7381