### PR TITLE
perf(plugin): reuse allocator via AllocatorPool in vite plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,6 +3118,7 @@ dependencies = [
  "derive_more",
  "itertools",
  "memchr",
+ "oxc",
  "percent-encoding",
  "regex",
  "rolldown_common",
@@ -3234,6 +3235,7 @@ dependencies = [
  "oxc",
  "rolldown_common",
  "rolldown_plugin",
+ "rolldown_plugin_utils",
  "rolldown_utils",
  "string_wizard",
  "sugar_path",
@@ -3405,6 +3407,7 @@ dependencies = [
  "rolldown_common",
  "rolldown_error",
  "rolldown_plugin",
+ "rolldown_plugin_utils",
  "rolldown_utils",
 ]
 

--- a/crates/rolldown_plugin_utils/Cargo.toml
+++ b/crates/rolldown_plugin_utils/Cargo.toml
@@ -24,6 +24,7 @@ dashmap = { workspace = true }
 derive_more = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
+oxc = { workspace = true }
 percent-encoding = { workspace = true }
 regex = { workspace = true }
 rolldown_common = { workspace = true }

--- a/crates/rolldown_plugin_utils/src/constants.rs
+++ b/crates/rolldown_plugin_utils/src/constants.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use arcstr::ArcStr;
 
+use oxc::allocator::AllocatorPool as OxcAllocatorPool;
 use rolldown_common::OutputChunk;
 use rolldown_plugin::typedmap::TypedMapKey;
 use rolldown_utils::dashmap::{FxDashMap, FxDashSet};
@@ -98,4 +99,14 @@ pub struct CSSUrlCache {
 
 pub struct CSSScopeToMap {
   pub inner: FxHashMap<String, (String, Option<String>)>,
+}
+
+pub struct AllocatorPool {
+  pub inner: OxcAllocatorPool,
+}
+
+impl Default for AllocatorPool {
+  fn default() -> Self {
+    Self { inner: OxcAllocatorPool::new(0) }
+  }
 }

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/Cargo.toml
@@ -25,6 +25,7 @@ memchr = { workspace = true }
 oxc = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_plugin_utils = { workspace = true }
 rolldown_utils = { workspace = true }
 string_wizard = { workspace = true }
 sugar_path = { workspace = true }

--- a/crates/rolldown_plugin_vite_html/src/lib.rs
+++ b/crates/rolldown_plugin_vite_html/src/lib.rs
@@ -15,7 +15,7 @@ use rolldown_common::side_effects::HookSideEffects;
 use rolldown_plugin::{HookTransformOutput, HookUsage, LogWithoutPlugin, Plugin};
 use rolldown_plugin_utils::{
   AssetUrlResult, ModulePreload, RenderBuiltUrl, ToOutputFilePathEnv, UsizeOrFunction,
-  constants::{CSSBundleName, HTMLProxyMapItem},
+  constants::{AllocatorPool, CSSBundleName, HTMLProxyMapItem},
   partial_encode_url_path,
 };
 use rolldown_utils::{dashmap::FxDashMap, pattern_filter::normalize_path};
@@ -215,9 +215,10 @@ impl Plugin for ViteHtmlPlugin {
                     panic!("Expected text node but received: {:#?}", node.data);
                   };
                   if utils::constant::INLINE_IMPORT.is_match(contents) {
-                    let allocator = oxc::allocator::Allocator::default();
+                    let allocator_pool = ctx.meta().get_or_insert_default::<AllocatorPool>();
+                    let allocator_guard = allocator_pool.inner.get();
                     let parser_ret = oxc::parser::Parser::new(
-                      &allocator,
+                      &allocator_guard,
                       contents,
                       oxc::span::SourceType::default(),
                     )

--- a/crates/rolldown_plugin_vite_transform/Cargo.toml
+++ b/crates/rolldown_plugin_vite_transform/Cargo.toml
@@ -26,4 +26,5 @@ oxc_resolver = { workspace = true }
 rolldown_common = { workspace = true }
 rolldown_error = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_plugin_utils = { workspace = true }
 rolldown_utils = { workspace = true }


### PR DESCRIPTION
I didn’t observe any noticeable performance improvement. In addition, I’m concerned that it may cause some memory leakage, since the memory it allocates won’t be released for the entire build process. I need to measure its memory usage to confirm.

Ref https://github.com/rolldown/rolldown/pull/7400#discussion_r2605361392