### PR TITLE
fix(rolldown_plugin_esm_external_require): run resolveId hook before other plugins

### DIFF
--- a/crates/rolldown_plugin_esm_external_require/src/lib.rs
+++ b/crates/rolldown_plugin_esm_external_require/src/lib.rs
@@ -125,6 +125,10 @@ impl Plugin for EsmExternalRequirePlugin {
     Ok(None)
   }
 
+  fn resolve_id_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
+    Some(rolldown_plugin::PluginHookMeta { order: Some(rolldown_plugin::PluginOrder::Pre) })
+  }
+
   async fn load(
     &self,
     _ctx: &rolldown_plugin::PluginContext,

--- a/docs/builtin-plugins/esm-external-require.md
+++ b/docs/builtin-plugins/esm-external-require.md
@@ -2,6 +2,10 @@
 
 The `esmExternalRequirePlugin` is a built-in Rolldown plugin that converts CommonJS `require()` calls for external dependencies into ESM `import` statements, ensuring compatibility in environments that don't support the Node.js module API.
 
+:::tip NOTE
+This plugin sets `resolveId.meta.order` to `'pre'` to ensure external requires are resolved before other plugins. Additionally, it sets `enforce: 'pre'` by default for Vite compatibility.
+:::
+
 ## Why This Is Needed
 
 When bundling code with Rolldown, `require()` calls for external dependencies are not automatically converted to ESM imports to preserve the semantics of `require()`. While Rolldown injects `require` function when `platform: 'node'` is set, it does so by generating code like:

--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -103,7 +103,10 @@ export function viteWebWorkerPostPlugin(): BuiltinPlugin {
 export function esmExternalRequirePlugin(
   config?: BindingEsmExternalRequirePluginConfig,
 ): BuiltinPlugin {
-  return new BuiltinPlugin('builtin:esm-external-require', config);
+  const plugin = new BuiltinPlugin('builtin:esm-external-require', config);
+  // For Vite: ensure this plugin runs before other `resolveId.meta.order: 'pre'` plugins
+  plugin.enforce = 'pre';
+  return plugin;
 }
 
 type ViteReactRefreshWrapperPluginConfig =

--- a/packages/rolldown/src/builtin-plugin/utils.ts
+++ b/packages/rolldown/src/builtin-plugin/utils.ts
@@ -33,6 +33,9 @@ type BindingCallableBuiltinPluginLike = {
 
 // eslint-disable @typescript-eslint/no-unsafe-declaration-merging
 export class BuiltinPlugin {
+  /** Vite-specific option to control plugin ordering */
+  enforce?: 'pre' | 'post';
+
   constructor(
     public name: BindingBuiltinPluginName,
     // NOTE: has `_` to avoid conflict with `options` hook


### PR DESCRIPTION
closes vitejs/rolldown-vite#513