### PR TITLE
test(rollup-tests): make `--grep` work and document it

### DIFF
--- a/docs/development-guide/testing.md
+++ b/docs/development-guide/testing.md
@@ -196,6 +196,14 @@ In `/packages/rollup-tests`:
 - `just test-node-rollup` will run rollup tests.
 - `just test-node-rollup --update` will run and update the tests' status.
 
+To run a specific test, use the `--grep` option with `just test-node-rollup`:
+
+```shell
+just test-node-rollup --grep "function"
+```
+
+This will run only tests whose names match "function". For more filtering options, see [Mocha's grep documentation](https://mochajs.org/#grep).
+
 ## How to choose test technique
 
 Our Rust test infra is powerful enough to cover most of the case of JavaScript (plugin, passing function inside config).

--- a/justfile
+++ b/justfile
@@ -101,8 +101,8 @@ t-node-rolldown *args="":
   pnpm run --filter rolldown-tests test:watcher {{ args }}
 
 # Run Rollup's test suite without building Rolldown.
-t-node-rollup command="":
-  pnpm run --filter rollup-tests test{{ command }}
+t-node-rollup *args="":
+  pnpm run --filter rollup-tests test {{ args }}
 
 # Run specific rust test without enabling extended tests.
 [unix]

--- a/packages/rollup-tests/package.json
+++ b/packages/rollup-tests/package.json
@@ -2,8 +2,7 @@
   "name": "rollup-tests",
   "private": true,
   "scripts": {
-    "test": "ROLLUP_TEST=1 mocha --file ./src/intercept/check.js test/test.js",
-    "test--update": "ROLLUP_TEST=1 mocha --jobs 1 --file ./src/intercept/update-test-status.js test/test.js"
+    "test": "ROLLUP_TEST=1 mocha --file ./src/intercept/main.js test/test.js"
   },
   "keywords": [],
   "author": "",

--- a/packages/rollup-tests/src/intercept/check.js
+++ b/packages/rollup-tests/src/intercept/check.js
@@ -2,6 +2,8 @@ const { loadFailedTests, calcTestId, shouldIgnoredTest, status } = require('./ut
 const expectedStatus = require('../status.json');
 const alreadyFailedTests = new Set(loadFailedTests())
 
+const hasGrep = process.argv.some(arg => arg === '--grep' || arg === '-g')
+
 /**
  * @type {Set<{name: string, err: Error | undefined}>}
  */
@@ -61,7 +63,13 @@ after(function printStatus() {
     // enforce exit process to avoid Rust process is not exit.
     process.exit(1)
   } else {
-    if (expectedStatus.skipFailed !== status.skipFailed || expectedStatus.passed !== status.passed) {
+    if (hasGrep) {
+      console.log('Skip status verification as `--grep` is used.')
+      console.log('status', status)
+    } else if (
+      expectedStatus.skipFailed !== status.skipFailed ||
+        expectedStatus.passed !== status.passed
+    ) {
       console.log('expected', expectedStatus)
       console.log('actual', status)
       throw new Error('The rollup test status file is not updated. Please run `just test-node-rollup --update` to update it.')

--- a/packages/rollup-tests/src/intercept/main.js
+++ b/packages/rollup-tests/src/intercept/main.js
@@ -1,0 +1,12 @@
+const hasGrep = process.argv.some(arg => arg === '--grep' || arg === '-g')
+const hasUpdate = process.argv.includes('--update')
+
+if (hasUpdate && hasGrep) {
+  throw new Error('Cannot use --update with --grep')
+}
+
+if (hasUpdate) {
+  require('./update-test-status')
+} else {
+  require('./check')
+}

--- a/packages/rollup-tests/src/intercept/utils.js
+++ b/packages/rollup-tests/src/intercept/utils.js
@@ -45,7 +45,6 @@ function loadUnsupportedFeaturesIgnoredTests() {
 }
 
 const ignoredTests = new Set(require('../ignored-tests').ignoreTests)
-const onlyTests = new Set(require('../only-tests').onlyTests)
 const unsupportedFeaturesIgnoredTests = loadUnsupportedFeaturesIgnoredTests()
 const ignoredTreeshakingTests = new Set(require('../ignored-treeshaking-tests'))
 const ignoredSnapshotDifferentTests = new Set(require('../ignored-passed-snapshot-different-tests'))
@@ -72,8 +71,6 @@ function shouldIgnoredTest(id) {
 module.exports = {
   calcTestId,
   loadFailedTests,
-  loadIgnoredTests: () => ignoredTests,
-  loadOnlyTests: () => onlyTests,
   updateFailedTestsJson,
   shouldIgnoredTest,
   status

--- a/packages/rollup-tests/src/only-tests.js
+++ b/packages/rollup-tests/src/only-tests.js
@@ -1,8 +1,0 @@
-/**
- * @type {string[]}
- */
-const onlyTests = []
-
-module.exports = {
-  onlyTests,
-}


### PR DESCRIPTION
`packages/rollup-tests/src/only-tests.js` did not work so I removed it and added a way to run some tests.

