### PR TITLE
refactor(builtin-plugin): make config parameter required for vite plugins

### DIFF
--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -50,13 +50,13 @@ export function viteImportGlobPlugin(
 }
 
 export function viteReporterPlugin(
-  config?: BindingViteReporterPluginConfig,
+  config: BindingViteReporterPluginConfig,
 ): BuiltinPlugin {
   return new BuiltinPlugin('builtin:vite-reporter', config);
 }
 
 export function viteWasmHelperPlugin(
-  config?: BindingViteWasmHelperPluginConfig,
+  config: BindingViteWasmHelperPluginConfig,
 ): BuiltinPlugin {
   return new BuiltinPlugin('builtin:vite-wasm-helper', config);
 }
@@ -71,7 +71,7 @@ export function viteLoadFallbackPlugin(): BuiltinPlugin {
 }
 
 export function viteJsonPlugin(
-  config?: BindingViteJsonPluginConfig,
+  config: BindingViteJsonPluginConfig,
 ): BuiltinPlugin {
   const builtinPlugin = new BuiltinPlugin('builtin:vite-json', config);
   return makeBuiltinPluginCallable(builtinPlugin);

--- a/packages/rolldown/src/builtin-plugin/transform-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/transform-plugin.ts
@@ -23,19 +23,14 @@ type TransformPluginConfig =
   };
 
 export function viteTransformPlugin(
-  config?: TransformPluginConfig,
+  config: TransformPluginConfig,
 ): BuiltinPlugin {
-  if (config) {
-    config = {
-      ...config,
-      include: normalizedStringOrRegex(config.include),
-      exclude: normalizedStringOrRegex(config.exclude),
-      jsxRefreshInclude: normalizedStringOrRegex(config.jsxRefreshInclude),
-      jsxRefreshExclude: normalizedStringOrRegex(config.jsxRefreshExclude),
-    };
-  }
   return new BuiltinPlugin('builtin:vite-transform', {
     ...config,
+    include: normalizedStringOrRegex(config.include),
+    exclude: normalizedStringOrRegex(config.exclude),
+    jsxRefreshInclude: normalizedStringOrRegex(config.jsxRefreshInclude),
+    jsxRefreshExclude: normalizedStringOrRegex(config.jsxRefreshExclude),
     // process is undefined for browser build
     yarnPnp: typeof process === 'object' && !!process.versions?.pnp,
   });

--- a/packages/rolldown/src/builtin-plugin/vite-css-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/vite-css-plugin.ts
@@ -25,7 +25,7 @@ type ViteCssPluginConfig =
   };
 
 export function viteCSSPlugin(
-  config?: ViteCssPluginConfig,
+  config: ViteCssPluginConfig,
 ): BuiltinPlugin {
   return new BuiltinPlugin(
     'builtin:vite-css',

--- a/packages/rolldown/src/builtin-plugin/vite-css-post-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/vite-css-post-plugin.ts
@@ -14,7 +14,7 @@ export type ViteCssPostPluginConfig =
   };
 
 export function viteCSSPostPlugin(
-  config?: ViteCssPostPluginConfig,
+  config: ViteCssPostPluginConfig,
 ): BuiltinPlugin {
   return new BuiltinPlugin('builtin:vite-css-post', config);
 }

--- a/packages/rolldown/src/builtin-plugin/vite-html-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/vite-html-plugin.ts
@@ -62,7 +62,7 @@ export interface ViteHtmlPluginOptions extends
 }
 
 export function viteHtmlPlugin(
-  config?: ViteHtmlPluginOptions,
+  config: ViteHtmlPluginOptions,
 ): BuiltinPlugin {
   return new BuiltinPlugin('builtin:vite-html', config);
 }

--- a/packages/rolldown/src/builtin-plugin/vite-manifest-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/vite-manifest-plugin.ts
@@ -11,7 +11,7 @@ export type ViteManifestPluginConfig =
   };
 
 export function viteManifestPlugin(
-  config?: ViteManifestPluginConfig,
+  config: ViteManifestPluginConfig,
 ): BuiltinPlugin {
   return new BuiltinPlugin('builtin:vite-manifest', config);
 }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/basic/_config.ts
@@ -6,7 +6,7 @@ export default defineTest({
   config: {
     input: './main.ts',
     plugins: [
-      viteTransformPlugin(),
+      viteTransformPlugin({ root: __dirname }),
       {
         name: 'test',
         transform(code) {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/virtual/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/virtual/_config.ts
@@ -5,7 +5,7 @@ export default defineTest({
   config: {
     input: './main.js',
     plugins: [
-      viteTransformPlugin(),
+      viteTransformPlugin({ root: __dirname }),
       {
         name: 'virtual',
         resolveId(source) {

--- a/packages/rolldown/tests/fixtures/builtin-plugin/wasm-helper/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/wasm-helper/_config.ts
@@ -4,7 +4,7 @@ import { expect } from 'vitest';
 
 export default defineTest({
   config: {
-    plugins: [viteWasmHelperPlugin()],
+    plugins: [viteWasmHelperPlugin({ decodedBase: '' })],
   },
   async afterTest(output) {
     expect(output.output[1].fileName).toBe('assets/add-Bodj1WnG.wasm');


### PR DESCRIPTION
Related to #5791

I noticed that this can cause ts type and napi issues during testing if we’re not careful.