### PR TITLE
feat(rolldown_plugin_vite_reporter): add newline after build summary for better log separation

### DIFF
--- a/crates/rolldown_plugin_vite_reporter/src/lib.rs
+++ b/crates/rolldown_plugin_vite_reporter/src/lib.rs
@@ -384,6 +384,10 @@ impl Plugin for ViteReporterPlugin {
       ).if_supports_color(Stream::Stdout, |text| { text.bold().yellow().to_string() }).to_string();
       ctx.warn(rolldown_common::LogWithoutPlugin { message, ..Default::default() });
     }
+    // Print a newline to separate from next log
+    if self.should_log_info && self.is_tty {
+      utils::log_info("");
+    }
     Ok(())
   }
 

--- a/crates/rolldown_plugin_vite_reporter/src/lib.rs
+++ b/crates/rolldown_plugin_vite_reporter/src/lib.rs
@@ -385,7 +385,7 @@ impl Plugin for ViteReporterPlugin {
       ctx.warn(rolldown_common::LogWithoutPlugin { message, ..Default::default() });
     }
     // Print a newline to separate from next log
-    if self.should_log_info && self.is_tty {
+    if self.should_log_info {
       utils::log_info("");
     }
     Ok(())


### PR DESCRIPTION
Evan mentioned that we should display it under the build info on a separate line from warnings such as the `[PLUGIN_TIMINGS] warning`.

![image.png](https://app.graphite.com/user-attachments/assets/46ef838d-978e-4347-b486-8852b541ea54.png)
![JI4}$_(LEEJ@3OU0H4HK8FX.png](https://app.graphite.com/user-attachments/assets/c31c3d34-f2c9-4677-a896-ef1be089fcb9.png)

