### PR TITLE
chore: add syntax validation for test output chunks that are not executed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,6 +3481,7 @@ dependencies = [
  "insta",
  "json-strip-comments",
  "jsonschema",
+ "oxc",
  "regex",
  "rolldown",
  "rolldown_common",

--- a/crates/rolldown/tests/esbuild/default/hashbang_banner_use_strict_order/_config.json
+++ b/crates/rolldown/tests/esbuild/default/hashbang_banner_use_strict_order/_config.json
@@ -9,5 +9,7 @@
     "format": "iife",
     "banner": "#! from banner"
   },
-  "expectExecuted": false
+  "expectExecuted": false,
+  "skipSyntaxValidation": true,
+  "_comment": "Output has two hashbangs which is invalid syntax"
 }

--- a/crates/rolldown/tests/esbuild/default/top_level_await_allowed_import_without_splitting/_config.json
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_allowed_import_without_splitting/_config.json
@@ -8,5 +8,7 @@
     ],
     "inlineDynamicImports": true
   },
-  "expectExecuted": false
+  "expectExecuted": false,
+  "skipSyntaxValidation": true,
+  "_comment": "TODO: Output contains await in non-async function which is invalid syntax"
 }

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/_config.json
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/_config.json
@@ -7,5 +7,7 @@
       }
     ]
   },
-  "expectExecuted": false
+  "expectExecuted": false,
+  "skipSyntaxValidation": true,
+  "_comment": "TODO: Output contains await in non-async function which is invalid syntax"
 }

--- a/crates/rolldown/tests/esbuild/default/top_level_return_forbidden_tla/_config.json
+++ b/crates/rolldown/tests/esbuild/default/top_level_return_forbidden_tla/_config.json
@@ -7,5 +7,7 @@
       }
     ]
   },
-  "expectExecuted": false
+  "expectExecuted": false,
+  "skipSyntaxValidation": true,
+  "_comment": "TODO: Output contains await in non-async function which is invalid syntax"
 }

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/invalid_context_entity/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/invalid_context_entity/_config.json
@@ -3,5 +3,7 @@
     "context": "1",
     "format": "cjs"
   },
-  "expectExecuted": false
+  "expectExecuted": false,
+  "skipSyntaxValidation": true,
+  "_comment": "Using invalid member expression object as context"
 }

--- a/crates/rolldown_testing/Cargo.toml
+++ b/crates/rolldown_testing/Cargo.toml
@@ -23,6 +23,7 @@ glob = { workspace = true }
 insta = { workspace = true }
 json-strip-comments = { workspace = true }
 jsonschema = { workspace = true }
+oxc = { workspace = true }
 regex = { workspace = true }
 rolldown = { workspace = true, features = ["testing"] }
 rolldown_common = { workspace = true }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -52,6 +52,11 @@
       "type": "boolean",
       "default": false
     },
+    "skipSyntaxValidation": {
+      "description": "If `true`, skip syntax validation of output chunks. Useful for tests that\nintentionally produce invalid output (e.g., testing invalid configuration warnings).",
+      "type": "boolean",
+      "default": false
+    },
     "writeToDisk": {
       "description": "If `true`, the bundle will be called with `write()` instead of `generate()`.",
       "type": "boolean",

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -8,11 +8,14 @@ use std::{
 };
 
 use anyhow::Context;
+use oxc::parser::{ParseOptions, Parser};
+use oxc::span::SourceType;
 use rolldown::NormalizedBundlerOptions;
 use rolldown::{
   BundleOutput, Bundler, BundlerOptions, IsExternal, OutputFormat, Platform, SourceMapType,
   plugin::__inner::SharedPluginable,
 };
+use rolldown_common::Output;
 use rolldown_dev::{DevEngine, DevOptions, DevWatchOptions};
 use rolldown_error::BuildResult;
 use rolldown_testing_config::TestMeta;
@@ -87,6 +90,47 @@ impl IntegrationTest {
   /// Determine if output should be executed based on test meta
   fn should_execute_output(&self) -> bool {
     self.test_meta.expect_executed && !self.test_meta.expect_error && self.test_meta.write_to_disk
+  }
+
+  /// Validate that all output JS chunks have no syntax errors using oxc parser.
+  /// This is especially useful for tests with `expectExecuted: false` where we can't
+  /// run the output but still want to ensure it's syntactically valid.
+  ///
+  /// Skips validation when:
+  /// - JSX is preserved (output contains JSX syntax, not valid JS)
+  fn validate_output_chunks_syntax(
+    bundle_output: &BundleOutput,
+    options: &NormalizedBundlerOptions,
+  ) {
+    // Skip validation if JSX is preserved (output contains JSX syntax)
+    if options.transform_options.is_jsx_preserve() {
+      return;
+    }
+
+    let source_type = match options.format {
+      OutputFormat::Cjs => SourceType::cjs(),
+      OutputFormat::Esm | OutputFormat::Iife | OutputFormat::Umd => SourceType::mjs(),
+    };
+
+    for output in &bundle_output.assets {
+      if let Output::Chunk(chunk) = output {
+        let allocator = oxc::allocator::Allocator::default();
+        let ret = Parser::new(&allocator, &chunk.code, source_type)
+          .with_options(ParseOptions { allow_return_outside_function: true, ..Default::default() })
+          .parse();
+
+        if ret.panicked || !ret.errors.is_empty() {
+          let errors_str = ret
+            .errors
+            .iter()
+            .map(|e| e.clone().with_source_code(chunk.code.clone()).to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+          panic!("Syntax error in output chunk '{}':\n{errors_str}", chunk.filename);
+        }
+      }
+    }
   }
 
   /// Run multiple bundler configurations in HMR mode
@@ -255,7 +299,7 @@ impl IntegrationTest {
 
       // Verify result and process HMR if successful
       match &initial_build_output {
-        Ok(_) => {
+        Ok(output) => {
           assert!(
             !self.test_meta.expect_error,
             "Expected the bundling to be failed with diagnosable errors, but got success"
@@ -296,6 +340,9 @@ impl IntegrationTest {
                 .map(Some)
                 .unwrap_or(self.test_meta.config_name.as_deref()),
             );
+          } else if !self.test_meta.skip_syntax_validation {
+            // When not executing output, validate that all JS chunks are syntactically valid
+            Self::validate_output_chunks_syntax(output, bundler.lock().await.options());
           }
         }
         Err(errs) => {
@@ -366,7 +413,7 @@ impl IntegrationTest {
 
       // Verify result and execute output if needed
       match &bundle_output {
-        Ok(_) => {
+        Ok(output) => {
           assert!(
             !self.test_meta.expect_error,
             "Expected the bundling to be failed with diagnosable errors, but got success"
@@ -382,6 +429,9 @@ impl IntegrationTest {
                 .map(Some)
                 .unwrap_or(self.test_meta.config_name.as_deref()),
             );
+          } else if !self.test_meta.skip_syntax_validation {
+            // When not executing output, validate that all JS chunks are syntactically valid
+            Self::validate_output_chunks_syntax(output, bundler.options());
           }
         }
         Err(errs) => {

--- a/crates/rolldown_testing_config/src/test_meta.rs
+++ b/crates/rolldown_testing_config/src/test_meta.rs
@@ -31,6 +31,10 @@ pub struct TestMeta {
   /// If `true`, the `[hash]` pattern will be inserted in the `xxxxFilenames`.
   #[serde(default)]
   pub hash_in_filename: bool,
+  /// If `true`, skip syntax validation of output chunks. Useful for tests that
+  /// intentionally produce invalid output (e.g., testing invalid configuration warnings).
+  #[serde(default)]
+  pub skip_syntax_validation: bool,
   /// If `true`, the bundle will be called with `write()` instead of `generate()`.
   #[serde(default = "true_by_default")]
   pub write_to_disk: bool,


### PR DESCRIPTION
Catch some bug early like https://github.com/rolldown/rolldown/pull/7447