### PR TITLE
test: disable pluginTimings by default to avoid snapshot noise

### DIFF
--- a/packages/rolldown/tests/fixture.test.ts
+++ b/packages/rolldown/tests/fixture.test.ts
@@ -55,6 +55,9 @@ async function compileFixture(fixturePath: string, config: TestConfig) {
     cwd: fixturePath,
     ...config.config,
   };
+  // Ensure pluginTimings is false to avoid snapshot noise
+  inputOptions.checks ??= {};
+  inputOptions.checks.pluginTimings ??= false;
   const build = await rolldown(inputOptions);
   if (Array.isArray(config.config?.output)) {
     const outputs = [];

--- a/packages/rollup-tests/test/function/index.js
+++ b/packages/rollup-tests/test/function/index.js
@@ -112,7 +112,7 @@ runTestSuiteWithSamples(
 						input: path.join(directory, 'main.js'),
 						onLog: (level, log) => {
 							logs.push({ level, ...log });
-							if (level === 'warn') {
+							if (level === 'warn' && !config.expectedWarnings?.includes(log.code)) {
 								warnings.push(log);
 							}
 						},

--- a/packages/rollup-tests/test/sourcemaps/index.js
+++ b/packages/rollup-tests/test/sourcemaps/index.js
@@ -27,7 +27,11 @@ runTestSuiteWithSamples(
 						const warnings = [];
 						const inputOptions = {
 							input: directory + '/main.js',
-							onwarn: warning => warnings.push(warning),
+              onLog: (level, log) => {
+                if (level === 'warn' && !config.expectedWarnings?.includes(log.code)) {
+                  warnings.push(log);
+                }
+              },
 							strictDeprecations: true,
 							...config.options
 						};

--- a/packages/rollup-tests/test/utils.js
+++ b/packages/rollup-tests/test/utils.js
@@ -278,6 +278,10 @@ function loadConfigAndRunTest(directory, runTest) {
 		(!config.onlyWindows || platform === 'win32') &&
 		(!config.minNodeVersion || config.minNodeVersion <= Number(/^v(\d+)/.exec(version)[1]))
 	) {
+    if (!config.options?.checks?.pluginTimings) {
+      config.expectedWarnings ??= [];
+      config.expectedWarnings.push("PLUGIN_TIMINGS");
+    }
 		runTest(directory, config);
 	}
 }


### PR DESCRIPTION
See https://github.com/rolldown/rolldown/actions/runs/20154042854/job/57852611690?pr=7470