### PR TITLE
fix: `no entry found for key` error when merging CJS namespace exports

### DIFF
--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -120,7 +120,8 @@ pub fn render_chunk_exports(
             )
           });
           if let Some(ns_alias) = &symbol.namespace_alias {
-            let canonical_ns_name = &chunk.canonical_names[&ns_alias.namespace_ref];
+            let canonical_ns_ref = link_output.symbol_db.canonical_ref_for(ns_alias.namespace_ref);
+            let canonical_ns_name = &chunk.canonical_names[&canonical_ns_ref];
             let property_name = &ns_alias.property_name;
             s.push_str(&concat_string!(
               "var ",

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/_config.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "./entry.js"
+      }
+    ]
+  },
+  "snapshot": true
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/artifacts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+// HIDDEN [rolldown:runtime]
+//#region node_modules/this-is-only-used-for-testing/index.js
+var require_this_is_only_used_for_testing = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	function CJS() {}
+	CJS.foo = function() {
+		return "foo";
+	};
+	module.exports = CJS;
+	module.exports.default = CJS;
+	module.exports.foo = CJS.foo;
+}));
+
+//#endregion
+//#region helper.js
+var import_this_is_only_used_for_testing = /* @__PURE__ */ __toESM(require_this_is_only_used_for_testing());
+function useFoo() {
+	return (0, import_this_is_only_used_for_testing.foo)();
+}
+
+//#endregion
+var CJS = import_this_is_only_used_for_testing.default;
+export { CJS, useFoo };
+```

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/entry.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/entry.js
@@ -1,0 +1,6 @@
+// Test case: re-export from CJS module with namespace alias
+// This creates a namespace_alias for the "default" export
+// Combined with helper.js importing from the same CJS module,
+// the namespace refs get merged
+export { default as CJS } from 'this-is-only-used-for-testing';
+export { useFoo } from './helper.js';

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/helper.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/helper.js
@@ -1,0 +1,6 @@
+// This import creates a namespace ref that will be merged with entry.js's namespace ref
+import { foo } from 'this-is-only-used-for-testing';
+
+export function useFoo() {
+  return foo();
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/node_modules/this-is-only-used-for-testing/index.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/node_modules/this-is-only-used-for-testing/index.js
@@ -1,0 +1,7 @@
+// Simulate a CJS module
+function CJS() {}
+CJS.foo = function() { return 'foo'; };
+
+module.exports = CJS;
+module.exports.default = CJS;
+module.exports.foo = CJS.foo;

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/node_modules/this-is-only-used-for-testing/package.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport/node_modules/this-is-only-used-for-testing/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "this-is-only-used-for-testing",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3707,6 +3707,10 @@ expression: output
 
 - entry-!~{000}~.js => entry-CErn9CRR.js
 
+# tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_reexport
+
+- entry-!~{000}~.js => entry-V3jYNOBp.js
+
 # tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_with_default_import
 
 - entry-!~{000}~.js => entry-Bzob-Jc9.js


### PR DESCRIPTION
`no entry found for key` error was happening for this case (the case added in tests).