### PR TITLE
feat: enable `experimental.transform_hires_sourcemap: 'boundary'` by default

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_experimental_options.rs
@@ -51,7 +51,7 @@ impl TryFrom<BindingExperimentalOptions> for rolldown_common::ExperimentalOption
           }
         }
       } else {
-        None
+        Some(rolldown_common::SourcemapHires::Boundary)
       },
       native_magic_string: value.native_magic_string,
     })

--- a/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
@@ -64,7 +64,7 @@ impl TransformPluginContext {
       .options()
       .experimental
       .transform_hires_sourcemap
-      .unwrap_or(SourcemapHires::Boolean(true));
+      .unwrap_or(SourcemapHires::Boundary);
     magic_string.source_map(SourceMapOptions {
       hires: hires.into(),
       include_content: true,

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -323,11 +323,8 @@ impl PluginDriver {
       } else {
         // If sourcemap is empty and code has changed, need to create one remapping original code.
         let magic_string = MagicString::new(original_code);
-        let hires = self
-          .options
-          .experimental
-          .transform_hires_sourcemap
-          .unwrap_or(SourcemapHires::Boolean(true));
+        let hires =
+          self.options.experimental.transform_hires_sourcemap.unwrap_or(SourcemapHires::Boundary);
         Some(magic_string.source_map(SourceMapOptions {
           hires: hires.into(),
           include_content: true,


### PR DESCRIPTION
refs #7477, #5346
