### PR TITLE
fix: preserve class names in assignment expressions with keepNames option

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -429,6 +429,13 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     walk::walk_call_expression(self, it);
   }
 
+  fn visit_class(&mut self, it: &ast::Class<'ast>) {
+    if self.is_root_scope() {
+      self.current_stmt_info.meta.insert(StmtInfoMeta::ClassExpr);
+    }
+    walk::walk_class(self, it);
+  }
+
   fn visit_export_default_declaration(&mut self, it: &ast::ExportDefaultDeclaration<'ast>) {
     // Mark export default declarations with anonymous function/class expressions
     // so that __name helper will be included in the runtime

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use oxc::allocator::FromIn;
 use oxc::ast::AstType;
-use oxc::ast::ast::JSXMemberExpression;
+use oxc::ast::ast::{AssignmentTarget, JSXMemberExpression};
 use oxc::span::{Atom, CompactStr};
 use oxc::{
   allocator::{self, IntoIn, TakeIn},
@@ -19,7 +19,7 @@ use rolldown_ecmascript::ToSourceString;
 use rolldown_ecmascript_utils::{ExpressionExt, JsxExt};
 
 use crate::hmr::utils::HmrAstBuilder;
-use crate::module_finalizers::TraverseState;
+use crate::module_finalizers::{KeepNameId, TraverseState};
 
 use super::ScopeHoistingFinalizer;
 
@@ -612,6 +612,16 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
     walk_mut::walk_simple_assignment_target(self, target);
   }
 
+  fn visit_assignment_expression(&mut self, it: &mut ast::AssignmentExpression<'ast>) {
+    if let AssignmentTarget::AssignmentTargetIdentifier(id) = &mut it.left {
+      self.process_keep_name_for_expression(
+        id.reference_id.get().map(KeepNameId::ReferenceId),
+        &mut it.right,
+      );
+    }
+    walk_mut::walk_assignment_expression(self, it);
+  }
+
   fn visit_for_statement_init(&mut self, it: &mut ast::ForStatementInit<'ast>) {
     walk_mut::walk_for_statement_init(self, it);
     if self.state.contains(TraverseState::TopLevel)
@@ -637,37 +647,14 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
           else {
             continue;
           };
-          match init {
-            ast::Expression::ClassExpression(class_expression) => {
-              if let Some(element) = self.keep_name_helper_for_class(
-                Some(class_expression.id.as_ref().unwrap_or_else(|| id)),
-                &class_expression.body,
-                false,
-              ) {
-                class_expression.body.body.insert(0, element);
-              }
-            }
-            ast::Expression::FunctionExpression(fn_expression) => {
-              // The `var fn = function foo() {}` should generate `__name(fn, 'foo')` to keep the name
-              if let Some((_insert_position, original_name, _)) =
-                self.process_fn(Some(id), Some(fn_expression.id.as_ref().unwrap_or_else(|| id)))
-              {
-                let fn_expr = init.take_in(self.alloc);
-
-                let name_ref = self.canonical_ref_for_runtime("__name");
-                let (finalized_callee, _) =
-                  self.finalized_expr_for_symbol_ref(name_ref, false, false);
-                *init =
-                  self.snippet.keep_name_call_expr(&original_name, fn_expr, finalized_callee, true);
-              }
-            }
-            _ => {}
-          }
+          self.process_keep_name_for_expression(id.symbol_id.get().map(KeepNameId::SymbolId), init);
         }
       }
       ast::Declaration::FunctionDeclaration(decl) => {
+        let keep_name_id =
+          decl.id.as_ref().and_then(|id| id.symbol_id.get().map(KeepNameId::SymbolId));
         if let Some((insert_position, original_name, new_name)) =
-          self.process_fn(decl.id.as_ref(), decl.id.as_ref())
+          self.process_fn(keep_name_id, keep_name_id)
         {
           self.keep_name_statement_to_insert.push((insert_position, original_name, new_name));
         }
@@ -675,8 +662,10 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       ast::Declaration::ClassDeclaration(decl) => {
         // need to insert `keep_names` helper, because `get_transformed_class_decl`
         // will remove id in `class.id`
-        if let Some(element) = self.keep_name_helper_for_class(decl.id.as_ref(), &decl.body, false)
-        {
+        if let Some(element) = self.keep_name_helper_for_class(
+          decl.id.as_ref().and_then(|id| id.symbol_id.get().map(KeepNameId::SymbolId)),
+          &decl.body,
+        ) {
           decl.body.body.insert(0, element);
         }
         if let Some(decl) = self.get_transformed_class_decl(decl) {

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "keepNames": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/artifacts.snap
@@ -1,0 +1,47 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+// HIDDEN [rolldown:runtime]
+//#region lib2.js
+var _Test$1;
+let Test = _Test$1 = class {
+	static {
+		__name(this, "_Test");
+	}
+};
+var _Fn$1;
+let Fn = _Fn$1 = /* @__PURE__ */ __name(function() {
+	return 1;
+}, "_Fn");
+var _ArrowFn$1;
+let ArrowFn = _ArrowFn$1 = /* @__PURE__ */ __name(() => {
+	return 2;
+}, "_ArrowFn");
+console.log(_Test$1, Test, _Fn$1, Fn, _ArrowFn$1, ArrowFn);
+assert.strictEqual(_Test$1.name, "_Test");
+assert.strictEqual(_Fn$1.name, "_Fn");
+assert.strictEqual(_ArrowFn$1.name, "_ArrowFn");
+assert.strictEqual(new _Test$1() instanceof Test, true);
+assert.strictEqual(Fn(), 1);
+assert.strictEqual(ArrowFn(), 2);
+assert.strictEqual(_Fn$1(), 1);
+assert.strictEqual(_ArrowFn$1(), 2);
+
+//#endregion
+//#region lib.js
+var _Test = class {};
+let _Fn = function() {};
+let _ArrowFn = () => {};
+assert.strictEqual(_Test.name, "_Test");
+assert.strictEqual(_Fn.name, "_Fn");
+assert.strictEqual(_ArrowFn.name, "_ArrowFn");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/lib.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/lib.js
@@ -1,0 +1,7 @@
+import assert from "node:assert";
+class _Test {}
+let _Fn = function () {};
+let _ArrowFn = () => {};
+assert.strictEqual(_Test.name, "_Test");
+assert.strictEqual(_Fn.name, "_Fn");
+assert.strictEqual(_ArrowFn.name, "_ArrowFn");

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/lib2.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/lib2.js
@@ -1,0 +1,24 @@
+import assert from "node:assert";
+var _Test;
+let Test = (_Test = class {});
+
+var _Fn;
+let Fn = (_Fn = function () {
+  return 1;
+});
+
+var _ArrowFn;
+let ArrowFn = (_ArrowFn = () => {
+  return 2;
+});
+
+console.log(_Test, Test, _Fn, Fn, _ArrowFn, ArrowFn);
+assert.strictEqual(_Test.name, "_Test");
+assert.strictEqual(_Fn.name, "_Fn");
+assert.strictEqual(_ArrowFn.name, "_ArrowFn");
+
+assert.strictEqual(new _Test() instanceof Test, true);
+assert.strictEqual(Fn(), 1);
+assert.strictEqual(ArrowFn(), 2);
+assert.strictEqual(_Fn(), 1);
+assert.strictEqual(_ArrowFn(), 2);

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/main.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481/main.js
@@ -1,0 +1,2 @@
+import './lib2.js'
+import './lib.js'

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481_2/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481_2/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "keepNames": true,
+    "tsconfig": "./tsconfig.json"
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481_2/artifacts.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+// HIDDEN [rolldown:runtime]
+// HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
+//#region main.ts
+var _MyClass;
+function MyDecorator() {
+	return (target) => {};
+}
+let MyClass = _MyClass = class MyClass$1 {
+	static {
+		__name(this, "MyClass");
+	}
+	constructor() {
+		this.myName = _MyClass.name;
+	}
+};
+MyClass = _MyClass = __decorate([MyDecorator()], MyClass);
+const myName = new MyClass().myName;
+assert.strictEqual(myName, "MyClass");
+
+//#endregion
+export { myName };
+```

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481_2/main.ts
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481_2/main.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert'
+function MyDecorator(): ClassDecorator {
+  return (target) => {}
+}
+
+@MyDecorator()
+class MyClass { 
+  myName = MyClass.name;
+}
+
+export const myName = new MyClass().myName;
+
+
+assert.strictEqual(myName, 'MyClass');

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481_2/tsconfig.json
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7481_2/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+		"experimentalDecorators": true,
+		"emitDecoratorMetadata": true,
+  }
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5973,6 +5973,14 @@ expression: output
 - entry2-!~{001}~.js => entry2-Eow-pZuM.js
 - foo-!~{002}~.js => foo-V6MEsHyi.js
 
+# tests/rolldown/topics/keep_names/issue_7481
+
+- main-!~{000}~.js => main-DQS9kmkX.js
+
+# tests/rolldown/topics/keep_names/issue_7481_2
+
+- main-!~{000}~.js => main-0tvpeDlq.js
+
 # tests/rolldown/topics/keep_names/parenthesized_default_export
 
 - main-!~{000}~.js => main-DgH0nPHk.js


### PR DESCRIPTION
closed #7481