### PR TITLE
fix: skip symbols that are imported from other module when deconflicting module symbols

### DIFF
--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
@@ -11,19 +11,19 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region foo/test.js
-var test_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var test_exports$1 = /* @__PURE__ */ __export({ foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports$1 = /* @__PURE__ */ __export({ bar: () => bar });
+var test_exports = /* @__PURE__ */ __export({ bar: () => bar });
 let bar = 123;
 
 //#endregion
 //#region entry.js
 console.log(exports, module.exports);
-node_assert.default.deepEqual(test_exports, { foo: 123 });
-node_assert.default.deepEqual(test_exports$1, { bar: 123 });
+node_assert.default.deepEqual(test_exports$1, { foo: 123 });
+node_assert.default.deepEqual(test_exports, { bar: 123 });
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
@@ -9,17 +9,17 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region foo/test.js
-var test_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var test_exports$1 = /* @__PURE__ */ __export({ foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports$1 = /* @__PURE__ */ __export({ bar: () => bar });
+var test_exports = /* @__PURE__ */ __export({ bar: () => bar });
 let bar = 123;
 
 //#endregion
 //#region entry.js
-console.log(exports, module.exports, test_exports, test_exports$1);
+console.log(exports, module.exports, test_exports$1, test_exports);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_index_no_ext/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_index_no_ext/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 //#region src/demo-pkg/no-ext-browser/index.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region src/demo-pkg/no-ext/index.js
@@ -17,14 +17,14 @@ let node = "node";
 
 //#endregion
 //#region src/demo-pkg/ext-browser/index.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
 assert.equal(node, "node");
-assert.equal(browser$1, "browser");
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
+assert.equal(browser, "browser");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_no_ext/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_no_ext/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 //#region src/demo-pkg/no-ext-browser.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region src/demo-pkg/no-ext.js
@@ -17,14 +17,14 @@ let node = "node";
 
 //#endregion
 //#region src/demo-pkg/ext-browser.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
 assert.equal(node, "node");
-assert.equal(browser$1, "browser");
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
+assert.equal(browser, "browser");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_index_no_ext/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_index_no_ext/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 //#region node_modules/demo-pkg/no-ext-browser/index.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region node_modules/demo-pkg/no-ext/index.js
@@ -17,14 +17,14 @@ let node = "node";
 
 //#endregion
 //#region node_modules/demo-pkg/ext-browser/index.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
 assert.equal(node, "node");
-assert.equal(browser$1, "browser");
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
+assert.equal(browser, "browser");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_no_ext/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_browser_node_modules_no_ext/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 //#region node_modules/demo-pkg/no-ext-browser.js
-let browser = "browser";
+let browser$1 = "browser";
 
 //#endregion
 //#region node_modules/demo-pkg/no-ext.js
@@ -17,14 +17,14 @@ let node = "node";
 
 //#endregion
 //#region node_modules/demo-pkg/ext-browser.js
-let browser$1 = "browser";
+let browser = "browser";
 
 //#endregion
 //#region src/entry.js
-assert.equal(browser, "browser");
+assert.equal(browser$1, "browser");
 assert.equal(node, "node");
-assert.equal(browser$1, "browser");
-assert.equal(browser$1, "browser");
+assert.equal(browser, "browser");
+assert.equal(browser, "browser");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/artifacts.snap
@@ -39,11 +39,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region keep/declare-class.ts
-let bar = 123;
+let bar$12 = 123;
 
 //#endregion
 //#region keep/declare-let.ts
-let bar$1 = 123;
+let bar$11 = 123;
 
 //#endregion
 //#region keep/interface-merged.ts
@@ -51,17 +51,17 @@ var foo$3 = class foo$3 {
 	static x = new foo$3();
 };
 var interface_merged_default = foo$3;
-let bar$2 = 123;
+let bar$10 = 123;
 
 //#endregion
 //#region keep/interface-nested.ts
 var interface_nested_default = foo;
-let bar$3 = 123;
+let bar$9 = 123;
 
 //#endregion
 //#region keep/type-nested.ts
 var type_nested_default = foo;
-let bar$4 = 123;
+let bar$8 = 123;
 
 //#endregion
 //#region keep/value-namespace.ts
@@ -70,7 +70,7 @@ let foo$2;
 	_foo.num = 0;
 })(foo$2 || (foo$2 = {}));
 var value_namespace_default = foo$2;
-let bar$5 = 123;
+let bar$7 = 123;
 
 //#endregion
 //#region keep/value-namespace-merged.ts
@@ -83,51 +83,51 @@ let bar$6 = 123;
 
 //#endregion
 //#region remove/interface.ts
-let bar$7 = 123;
+let bar$5 = 123;
 
 //#endregion
 //#region remove/interface-exported.ts
-let bar$8 = 123;
+let bar$4 = 123;
 
 //#endregion
 //#region remove/type.ts
-let bar$9 = 123;
+let bar$3 = 123;
 
 //#endregion
 //#region remove/type-exported.ts
-let bar$10 = 123;
+let bar$2 = 123;
 
 //#endregion
 //#region remove/type-only-namespace.ts
-let bar$11 = 123;
+let bar$1 = 123;
 
 //#endregion
 //#region remove/type-only-namespace-exported.ts
-let bar$12 = 123;
+let bar = 123;
 
 //#endregion
 //#region entry.ts
 var entry_default = [
 	dc_def,
-	bar,
+	bar$12,
 	dl_def,
-	bar$1,
+	bar$11,
 	interface_merged_default,
-	bar$2,
+	bar$10,
 	interface_nested_default,
-	bar$3,
+	bar$9,
 	type_nested_default,
-	bar$4,
+	bar$8,
 	value_namespace_default,
-	bar$5,
+	bar$7,
 	value_namespace_merged_default,
 	bar$6,
-	bar$7,
-	bar$8,
-	bar$9,
-	bar$10,
-	bar$11,
-	bar$12
+	bar$5,
+	bar$4,
+	bar$3,
+	bar$2,
+	bar$1,
+	bar
 ];
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/diff.md
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_default_type_issue316/diff.md
@@ -94,11 +94,11 @@ export {
 ### rolldown
 ```js
 //#region keep/declare-class.ts
-let bar = 123;
+let bar$12 = 123;
 
 //#endregion
 //#region keep/declare-let.ts
-let bar$1 = 123;
+let bar$11 = 123;
 
 //#endregion
 //#region keep/interface-merged.ts
@@ -106,17 +106,17 @@ var foo$3 = class foo$3 {
 	static x = new foo$3();
 };
 var interface_merged_default = foo$3;
-let bar$2 = 123;
+let bar$10 = 123;
 
 //#endregion
 //#region keep/interface-nested.ts
 var interface_nested_default = foo;
-let bar$3 = 123;
+let bar$9 = 123;
 
 //#endregion
 //#region keep/type-nested.ts
 var type_nested_default = foo;
-let bar$4 = 123;
+let bar$8 = 123;
 
 //#endregion
 //#region keep/value-namespace.ts
@@ -125,7 +125,7 @@ let foo$2;
 	_foo.num = 0;
 })(foo$2 || (foo$2 = {}));
 var value_namespace_default = foo$2;
-let bar$5 = 123;
+let bar$7 = 123;
 
 //#endregion
 //#region keep/value-namespace-merged.ts
@@ -138,51 +138,51 @@ let bar$6 = 123;
 
 //#endregion
 //#region remove/interface.ts
-let bar$7 = 123;
+let bar$5 = 123;
 
 //#endregion
 //#region remove/interface-exported.ts
-let bar$8 = 123;
+let bar$4 = 123;
 
 //#endregion
 //#region remove/type.ts
-let bar$9 = 123;
+let bar$3 = 123;
 
 //#endregion
 //#region remove/type-exported.ts
-let bar$10 = 123;
+let bar$2 = 123;
 
 //#endregion
 //#region remove/type-only-namespace.ts
-let bar$11 = 123;
+let bar$1 = 123;
 
 //#endregion
 //#region remove/type-only-namespace-exported.ts
-let bar$12 = 123;
+let bar = 123;
 
 //#endregion
 //#region entry.ts
 var entry_default = [
 	dc_def,
-	bar,
+	bar$12,
 	dl_def,
-	bar$1,
+	bar$11,
 	interface_merged_default,
-	bar$2,
+	bar$10,
 	interface_nested_default,
-	bar$3,
+	bar$9,
 	type_nested_default,
-	bar$4,
+	bar$8,
 	value_namespace_default,
-	bar$5,
+	bar$7,
 	value_namespace_merged_default,
 	bar$6,
-	bar$7,
-	bar$8,
-	bar$9,
-	bar$10,
-	bar$11,
-	bar$12
+	bar$5,
+	bar$4,
+	bar$3,
+	bar$2,
+	bar$1,
+	bar
 ];
 
 //#endregion
@@ -195,14 +195,15 @@ export { entry_default as default };
 +++ rolldown	entry.js
 @@ -1,37 +1,31 @@
 -var declare_class_default = foo;
- var bar = 123;
+-var bar = 123;
 -var declare_let_default = foo;
 -var bar2 = 123;
 -var foo2 = class _foo {
 -    static {
 -        this.x = new _foo();
 -    }
-+var bar$1 = 123;
++var bar$12 = 123;
++var bar$11 = 123;
 +var foo$3 = class foo$3 {
 +    static x = new foo$3();
  };
@@ -210,11 +211,11 @@ export { entry_default as default };
 -var bar3 = 123;
 -if (true) {}
 +var interface_merged_default = foo$3;
-+var bar$2 = 123;
++var bar$10 = 123;
  var interface_nested_default = foo;
 -var bar4 = 123;
 -if (true) {}
-+var bar$3 = 123;
++var bar$9 = 123;
  var type_nested_default = foo;
 -var bar5 = 123;
 -var foo3;
@@ -236,26 +237,26 @@ export { entry_default as default };
 -var bar12 = 123;
 -var bar13 = 123;
 -var entry_default = [declare_class_default, bar, declare_let_default, bar2, interface_merged_default, bar3, interface_nested_default, bar4, type_nested_default, bar5, value_namespace_default, bar6, value_namespace_merged_default, bar7, bar8, bar9, bar10, bar11, bar12, bar13];
-+var bar$4 = 123;
++var bar$8 = 123;
 +var foo$2;
 +(function (_foo) {
 +    _foo.num = 0;
 +})(foo$2 || (foo$2 = {}));
 +var value_namespace_default = foo$2;
-+var bar$5 = 123;
++var bar$7 = 123;
 +var foo$1;
 +(function (_foo) {
 +    _foo.num = 0;
 +})(foo$1 || (foo$1 = {}));
 +var value_namespace_merged_default = foo$1;
 +var bar$6 = 123;
-+var bar$7 = 123;
-+var bar$8 = 123;
-+var bar$9 = 123;
-+var bar$10 = 123;
-+var bar$11 = 123;
-+var bar$12 = 123;
-+var entry_default = [dc_def, bar, dl_def, bar$1, interface_merged_default, bar$2, interface_nested_default, bar$3, type_nested_default, bar$4, value_namespace_default, bar$5, value_namespace_merged_default, bar$6, bar$7, bar$8, bar$9, bar$10, bar$11, bar$12];
++var bar$5 = 123;
++var bar$4 = 123;
++var bar$3 = 123;
++var bar$2 = 123;
++var bar$1 = 123;
++var bar = 123;
++var entry_default = [dc_def, bar$12, dl_def, bar$11, interface_merged_default, bar$10, interface_nested_default, bar$9, type_nested_default, bar$8, value_namespace_default, bar$7, value_namespace_merged_default, bar$6, bar$5, bar$4, bar$3, bar$2, bar$1, bar];
  export {entry_default as default};
 
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
@@ -9,12 +9,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region esm.js
 var esm_exports = /* @__PURE__ */ __export({
-	default: () => esm_default_fn,
+	default: () => esm_default_fn$1,
 	esm_named_class: () => esm_named_class,
 	esm_named_fn: () => esm_named_fn,
 	esm_named_var: () => esm_named_var
 });
-function esm_default_fn() {}
+function esm_default_fn$1() {}
 function esm_named_fn() {}
 function hoisted_fn() {
 	const bar = 1;
@@ -38,10 +38,10 @@ var require_commonjs$1 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#region main.js
 var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs$1());
 init_esm();
-console.log(import_commonjs.default, esm_default_fn, esm_named_var, esm_named_fn, esm_named_class);
+console.log(import_commonjs.default, esm_default_fn$1, esm_named_var, esm_named_fn, esm_named_class);
 const require_commonjs = () => {};
-function esm_default_fn$1() {}
-console.log(require_commonjs, esm_default_fn$1);
+function esm_default_fn() {}
+console.log(require_commonjs, esm_default_fn);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge/artifacts.snap
@@ -15,21 +15,21 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#endregion
 //#region a.js
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
-function test() {
+function test$1() {
 	return import_cjs.default;
 }
 
 //#endregion
 //#region b.js
-function test$1() {
+function test() {
 	console.log(import_cjs.default);
 	return import_cjs.default;
 }
 
 //#endregion
 //#region main.js
-const aa = test();
-const bb = test$1();
+const aa = test$1();
+const bb = test();
 
 //#endregion
 export { aa, bb };

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize/artifacts.snap
@@ -24,21 +24,21 @@ var require_util = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#region a.js
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 var import_util = /* @__PURE__ */ __toESM(require_util());
-function test() {
+function test$1() {
 	(0, import_util.default)();
 	return import_cjs.default;
 }
 
 //#endregion
 //#region b.js
-function test$1() {
+function test() {
 	return import_cjs.default;
 }
-var b_default = test$1;
+var b_default = test;
 
 //#endregion
 //#region main.js
-const aa = test();
+const aa = test$1();
 const bb = b_default();
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize_chunk_split/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize_chunk_split/artifacts.snap
@@ -38,18 +38,18 @@ export { entry };
 ## main.js
 
 ```js
-import { n as require_cjs, r as __toESM, t as test } from "./a.js";
+import { n as require_cjs, r as __toESM, t as test$1 } from "./a.js";
 
 //#region b.js
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
-function test$1() {
+function test() {
 	return import_cjs.default;
 }
-var b_default = test$1;
+var b_default = test;
 
 //#endregion
 //#region main.js
-const aa = test();
+const aa = test$1();
 const bb = b_default();
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
@@ -7,20 +7,20 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region share.js
-var share_default = "shared";
+var share_default$1 = "shared";
 
 //#endregion
 //#region share.json
-var share_default$1 = {};
+var share_default = {};
 
 //#endregion
 //#region main.js
-console.log(share_default, share_default$1);
+console.log(share_default$1, share_default);
 import("./share.js").then(console.log);
 import("./share2.js").then(console.log);
 
 //#endregion
-export { share_default as n, share_default$1 as t };
+export { share_default$1 as n, share_default as t };
 ```
 
 ## share.js

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns/artifacts.snap
@@ -9,15 +9,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 import nodeAssert from "node:assert";
 
 //#region dep.js
-const value = "";
+const value$1 = "";
 
 //#endregion
 //#region lib-foo.js
-const value$1 = "foo" + value;
+const value = "foo" + value$1;
 
 //#endregion
 //#region main.js
-nodeAssert.equal(value$1, "foo");
+nodeAssert.equal(value, "foo");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns/artifacts.snap
@@ -9,15 +9,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 import nodeAssert from "node:assert";
 
 //#region dep.js
-const value = "";
+const value$1 = "";
 
 //#endregion
 //#region lib-foo.js
-const value$1 = "foo" + value;
+const value = "foo" + value$1;
 
 //#endregion
 //#region main.js
-nodeAssert.equal(value$1, "foo");
+nodeAssert.equal(value, "foo");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -22,18 +22,18 @@ To fix:
 
 ```js
 import { n as __export, t as __esmMin } from "./rolldown-runtime.js";
-import { r as value, t as init_second } from "./second.js";
+import { r as value$1, t as init_second } from "./second.js";
 
 //#region first.js
-var first_exports = /* @__PURE__ */ __export({ value: () => value$1 });
-var value$1;
+var first_exports = /* @__PURE__ */ __export({ value: () => value });
+var value;
 var init_first = __esmMin((() => {
 	init_second();
-	value$1 = "first" + value;
+	value = "first" + value$1;
 }));
 
 //#endregion
-export { init_first as n, value$1 as r, first_exports as t };
+export { init_first as n, value as r, first_exports as t };
 ```
 
 ## main.js
@@ -65,16 +65,16 @@ export { __export as n, __esmMin as t };
 
 ```js
 import { n as __export, t as __esmMin } from "./rolldown-runtime.js";
-import { n as init_first, r as value } from "./first.js";
+import { n as init_first, r as value$1 } from "./first.js";
 
 //#region second.js
-var second_exports = /* @__PURE__ */ __export({ value: () => value$1 });
-var value$1;
+var second_exports = /* @__PURE__ */ __export({ value: () => value });
+var value;
 var init_second = __esmMin((() => {
 	init_first();
-	value$1 = "second" + value;
+	value = "second" + value$1;
 }));
 
 //#endregion
-export { second_exports as n, value$1 as r, init_second as t };
+export { second_exports as n, value as r, init_second as t };
 ```

--- a/crates/rolldown/tests/rolldown/topics/deconflict/basic_scoped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/basic_scoped/artifacts.snap
@@ -9,16 +9,16 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "assert";
 
 //#region a.js
-const a = "a.js";
+const a$1 = "a.js";
 
 //#endregion
 //#region main.js
-const a$1 = "main.js";
+const a = "main.js";
 function foo(a$1$1) {
 	return [
 		a$1$1,
-		a$1,
-		a
+		a,
+		a$1
 	];
 }
 assert.deepEqual(foo("foo"), [
@@ -36,12 +36,12 @@ assert.deepEqual(foo("foo"), [
 ```
 - ../a.js
 (0:0) "const " --> (3:0) "const "
-(0:6) "a = " --> (3:6) "a = "
-(0:10) "'a.js'\n" --> (3:10) "\"a.js\";\n"
+(0:6) "a = " --> (3:6) "a$1 = "
+(0:10) "'a.js'\n" --> (3:12) "\"a.js\";\n"
 - ../main.js
 (2:0) "const " --> (7:0) "const "
-(2:6) "a = " --> (7:6) "a$1 = "
-(2:10) "'main.js'\n" --> (7:12) "\"main.js\";\n"
+(2:6) "a = " --> (7:6) "a = "
+(2:10) "'main.js'\n" --> (7:10) "\"main.js\";\n"
 (5:0) "function " --> (8:0) "function "
 (5:9) "foo(" --> (8:9) "foo("
 (5:13) "a$1) " --> (8:13) "a$1$1) "
@@ -49,8 +49,8 @@ assert.deepEqual(foo("foo"), [
 (6:2) "return " --> (9:0) "\treturn "
 (6:9) "[" --> (9:8) "[\n"
 (6:10) "a$1, " --> (10:2) "a$1$1,\n"
-(6:15) "a, " --> (11:2) "a$1,\n"
-(6:18) "aJs]" --> (12:2) "a\n"
+(6:15) "a, " --> (11:2) "a,\n"
+(6:18) "aJs]" --> (12:2) "a$1\n"
 (6:22) "\n" --> (13:2) ";\n"
 (9:0) "assert." --> (15:0) "assert."
 (9:7) "deepEqual(" --> (15:7) "deepEqual("

--- a/crates/rolldown/tests/rolldown/topics/deconflict/issue_364/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/issue_364/artifacts.snap
@@ -9,15 +9,15 @@ source: crates/rolldown_testing/src/integration_test.rs
 import assert from "node:assert";
 
 //#region shared.js
-const a = "shared.js";
+const a$2 = "shared.js";
 
 //#endregion
 //#region main.js
-const a$1 = "a";
-const a$1$1 = "a$1";
-assert.equal(a, "shared.js");
-assert.equal(a$1, "a");
-assert.equal(a$1$1, "a$1");
+const a = "a";
+const a$1 = "a$1";
+assert.equal(a$2, "shared.js");
+assert.equal(a, "a");
+assert.equal(a$1, "a$1");
 
 //#endregion
 //# sourceMappingURL=main.js.map
@@ -28,28 +28,28 @@ assert.equal(a$1$1, "a$1");
 ```
 - ../shared.js
 (0:0) "const " --> (3:0) "const "
-(0:6) "a = " --> (3:6) "a = "
-(0:10) "'shared.js'\n" --> (3:10) "\"shared.js\";\n"
+(0:6) "a = " --> (3:6) "a$2 = "
+(0:10) "'shared.js'\n" --> (3:12) "\"shared.js\";\n"
 - ../main.js
 (2:0) "const " --> (7:0) "const "
-(2:6) "a = " --> (7:6) "a$1 = "
-(2:10) "'a'\n" --> (7:12) "\"a\";\n"
+(2:6) "a = " --> (7:6) "a = "
+(2:10) "'a'\n" --> (7:10) "\"a\";\n"
 (3:0) "const " --> (8:0) "const "
-(3:6) "a$1 = " --> (8:6) "a$1$1 = "
-(3:12) "'a$1'\n" --> (8:14) "\"a$1\";\n"
+(3:6) "a$1 = " --> (8:6) "a$1 = "
+(3:12) "'a$1'\n" --> (8:12) "\"a$1\";\n"
 (5:0) "assert." --> (9:0) "assert."
 (5:7) "equal(" --> (9:7) "equal("
-(5:13) "a2, " --> (9:13) "a, "
-(5:17) "'shared.js')" --> (9:16) "\"shared.js\")"
-(5:29) "\n" --> (9:28) ";\n"
+(5:13) "a2, " --> (9:13) "a$2, "
+(5:17) "'shared.js')" --> (9:18) "\"shared.js\")"
+(5:29) "\n" --> (9:30) ";\n"
 (6:0) "assert." --> (10:0) "assert."
 (6:7) "equal(" --> (10:7) "equal("
-(6:13) "a, " --> (10:13) "a$1, "
-(6:16) "'a')" --> (10:18) "\"a\")"
-(6:20) "\n" --> (10:22) ";\n"
+(6:13) "a, " --> (10:13) "a, "
+(6:16) "'a')" --> (10:16) "\"a\")"
+(6:20) "\n" --> (10:20) ";\n"
 (7:0) "assert." --> (11:0) "assert."
 (7:7) "equal(" --> (11:7) "equal("
-(7:13) "a$1, " --> (11:13) "a$1$1, "
-(7:18) "'a$1')" --> (11:20) "\"a$1\")"
-(7:24) "\n" --> (11:26) ";\n"
+(7:13) "a$1, " --> (11:13) "a$1, "
+(7:18) "'a$1')" --> (11:18) "\"a$1\")"
+(7:24) "\n" --> (11:24) ";\n"
 ```

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
@@ -21,10 +21,10 @@ self_accept_hot.accept((mod) => {
 
 //#endregion
 //#region single_accept/child.js
-var child_exports$1 = /* @__PURE__ */ __export({ count: () => count$2 });
+var child_exports$1 = /* @__PURE__ */ __export({ count: () => count$3 });
 const child_hot$1 = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
 __rolldown_runtime__.registerModule("single_accept/child.js", { exports: child_exports$1 });
-const count$2 = 0;
+const count$3 = 0;
 
 //#endregion
 //#region single_accept/parent.js
@@ -35,11 +35,11 @@ globalThis.singleAcceptAcceptCount ??= 0;
 globalThis.singleAcceptParentExecuteCount ??= 0;
 globalThis.singleAcceptParentExecuteCount++;
 assert.strictEqual(globalThis.singleAcceptParentExecuteCount, 1);
-let count$3 = count$2;
+let count$2 = count$3;
 parent_hot$1.accept("single_accept/child.js", (mod) => {
-	count$3 = mod.count;
+	count$2 = mod.count;
 	globalThis.singleAcceptAcceptCount++;
-	assert.strictEqual(globalThis.singleAcceptAcceptCount, count$3);
+	assert.strictEqual(globalThis.singleAcceptAcceptCount, count$2);
 });
 process.on("beforeExit", (code) => {
 	if (code !== 0) return;
@@ -48,10 +48,10 @@ process.on("beforeExit", (code) => {
 
 //#endregion
 //#region array_accept/child.js
-var child_exports = /* @__PURE__ */ __export({ count: () => count });
+var child_exports = /* @__PURE__ */ __export({ count: () => count$1 });
 const child_hot = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
 __rolldown_runtime__.registerModule("array_accept/child.js", { exports: child_exports });
-const count = 0;
+const count$1 = 0;
 
 //#endregion
 //#region array_accept/parent.js
@@ -62,11 +62,11 @@ globalThis.arrayAcceptAcceptCount ??= 0;
 globalThis.arrayAcceptParentExecuteCount ??= 0;
 globalThis.arrayAcceptParentExecuteCount++;
 assert.strictEqual(globalThis.arrayAcceptParentExecuteCount, 1);
-let count$1 = count;
+let count = count$1;
 parent_hot.accept(["array_accept/child.js"], ([mod]) => {
-	count$1 = mod.count;
+	count = mod.count;
 	globalThis.arrayAcceptAcceptCount++;
-	assert.strictEqual(globalThis.arrayAcceptAcceptCount, count$1);
+	assert.strictEqual(globalThis.arrayAcceptAcceptCount, count);
 });
 process.on("beforeExit", (code) => {
 	if (code !== 0) return;

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -131,18 +131,18 @@ assert.strictEqual(Globals, Object);
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo.mjs
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
+var foo_exports$1 = /* @__PURE__ */ __export({ foo: () => foo$1 });
 init_trigger_dep();
 const foo_hot$1 = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo.mjs");
-__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo.mjs", { exports: foo_exports });
+__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo.mjs", { exports: foo_exports$1 });
 const foo$1 = "foo";
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo/index.mjs
-var foo_exports$1 = /* @__PURE__ */ __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
 init_trigger_dep();
 const foo_hot = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo/index.mjs");
-__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo/index.mjs", { exports: foo_exports$1 });
+__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo/index.mjs", { exports: foo_exports });
 const foo = "foo-index";
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/keep_names/declaration/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/declaration/artifacts.snap
@@ -10,21 +10,22 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region a.js
-function test() {}
-var Foo = class {};
-
-//#endregion
-//#region main.js
-const test$1 = 10;
-var Foo$1 = class extends Foo {
+function test$1() {}
+__name(test$1, "test");
+var Foo$1 = class {
 	static {
 		__name(this, "Foo");
 	}
 };
-console.log(`test: `, test$1);
-assert.strictEqual(Foo$1.name, "Foo");
+
+//#endregion
+//#region main.js
+const test = 10;
+var Foo = class extends Foo$1 {};
+console.log(`test: `, test);
 assert.strictEqual(Foo.name, "Foo");
-assert.strictEqual(test.name, "test");
+assert.strictEqual(Foo$1.name, "Foo");
+assert.strictEqual(test$1.name, "test");
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7507/src/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7507/src/_config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "input": [
+      {
+        "import": "./index.cjs",
+        "name": "index"
+      }
+    ],
+    "keepNames": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7507/src/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7507/src/artifacts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## index.js
+
+```js
+import assert from "node:assert";
+
+// HIDDEN [rolldown:runtime]
+//#region bar.cjs
+var test$1;
+var init_bar = __esmMin((() => {
+	test$1 = /* @__PURE__ */ __name(() => {
+		return { test: "bar" };
+	}, "test");
+}));
+
+//#endregion
+//#region foo.cjs
+function test() {
+	return { test: "foo" };
+}
+var init_foo = __esmMin((() => {}));
+
+//#endregion
+//#region index.cjs
+var require_src = /* @__PURE__ */ __commonJSMin((() => {
+	init_bar();
+	init_foo();
+	assert.strictEqual(test$1.name, "test");
+	assert.strictEqual(test.name, "test");
+}));
+
+//#endregion
+export default require_src();
+
+```

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7507/src/bar.cjs
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7507/src/bar.cjs
@@ -1,0 +1,5 @@
+export const test = () => {
+  return {
+    test: "bar"
+  };
+};

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7507/src/foo.cjs
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7507/src/foo.cjs
@@ -1,0 +1,5 @@
+export default function test() {
+  return {
+    test: "foo"
+  };
+}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7507/src/index.cjs
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7507/src/index.cjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert'
+import { test as barTest } from "./bar.cjs";
+import test from "./foo.cjs";
+
+assert.strictEqual(barTest.name, "test");
+assert.strictEqual(test.name, "test");

--- a/crates/rolldown/tests/rollup/jsx/preserves-jsx-attributes/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/preserves-jsx-attributes/artifacts.snap
@@ -13,19 +13,19 @@ console.log(Foo$2, value$2);
 
 //#endregion
 //#region dep2.js
-const Foo = () => {};
-const value = "value 2";
-console.log(Foo, value);
-
-//#endregion
-//#region dep3.js
 const Foo$1 = () => {};
-const value$1 = "value 3";
+const value$1 = "value 2";
 console.log(Foo$1, value$1);
 
 //#endregion
+//#region dep3.js
+const Foo = () => {};
+const value = "value 3";
+console.log(Foo, value);
+
+//#endregion
 //#region main.js
-const result = <Foo bar baz:foo="string" quux-nix={value} element=<Foo /> fragment=<></> />;
+const result = <Foo$1 bar baz:foo="string" quux-nix={value$1} element=<Foo$1 /> fragment=<></> />;
 
 //#endregion
 export { result };

--- a/crates/rolldown/tests/rollup/jsx/preserves-jsx-expression/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/preserves-jsx-expression/artifacts.snap
@@ -12,18 +12,18 @@ console.log(element$2);
 
 //#endregion
 //#region dep2.js
-const element = "element 2";
-console.log(element);
+const element$1 = "element 2";
+console.log(element$1);
 
 //#endregion
 //#region dep3.js
-const element$1 = "element 3";
-console.log(element$1);
+const element = "element 3";
+console.log(element);
 
 //#endregion
 //#region main.js
 const Foo = () => {};
-const result = <Foo>{"test" + element}</Foo>;
+const result = <Foo>{"test" + element$1}</Foo>;
 
 //#endregion
 export { result };

--- a/crates/rolldown/tests/rollup/jsx/preserves-jsx-spread-attribute/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/preserves-jsx-spread-attribute/artifacts.snap
@@ -12,20 +12,20 @@ console.log(obj$2);
 
 //#endregion
 //#region dep2.js
-const obj = { value2: true };
-console.log(obj);
+const obj$1 = { value2: true };
+console.log(obj$1);
 
 //#endregion
 //#region dep3.js
-const obj$1 = { value3: true };
-console.log(obj$1);
+const obj = { value3: true };
+console.log(obj);
 
 //#endregion
 //#region main.js
 const Foo = () => {};
-const result1 = <Foo {...obj} />;
-const result2 = <Foo {...obj} prop />;
-const result3 = <Foo prop1 prop2 {...obj} {...obj} />;
+const result1 = <Foo {...obj$1} />;
+const result2 = <Foo {...obj$1} prop />;
+const result3 = <Foo prop1 prop2 {...obj$1} {...obj$1} />;
 
 //#endregion
 export { result1, result2, result3 };

--- a/crates/rolldown/tests/rollup/jsx/preserves-jsx-spread-child/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/preserves-jsx-spread-child/artifacts.snap
@@ -12,19 +12,19 @@ console.log(spread$2);
 
 //#endregion
 //#region dep2.js
-const spread = ["spread 2"];
-console.log(spread);
+const spread$1 = ["spread 2"];
+console.log(spread$1);
 
 //#endregion
 //#region dep3.js
-const spread$1 = ["spread 3"];
-console.log(spread$1);
+const spread = ["spread 3"];
+console.log(spread);
 
 //#endregion
 //#region main.js
 const Foo = () => {};
-const element = <Foo>{...spread}</Foo>;
-const fragment = <>{...spread}</>;
+const element = <Foo>{...spread$1}</Foo>;
+const fragment = <>{...spread$1}</>;
 
 //#endregion
 export { element, fragment };

--- a/crates/rolldown/tests/rollup/jsx/transpiles-jsx-attributes/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/transpiles-jsx-attributes/artifacts.snap
@@ -13,23 +13,23 @@ console.log(Foo$2, value$2);
 
 //#endregion
 //#region dep2.js
-const Foo = () => {};
-const value = "value 2";
-console.log(Foo, value);
-
-//#endregion
-//#region dep3.js
 const Foo$1 = () => {};
-const value$1 = "value 3";
+const value$1 = "value 2";
 console.log(Foo$1, value$1);
 
 //#endregion
+//#region dep3.js
+const Foo = () => {};
+const value = "value 3";
+console.log(Foo, value);
+
+//#endregion
 //#region main.js
-const result = /* @__PURE__ */ React.createElement(Foo, {
+const result = /* @__PURE__ */ React.createElement(Foo$1, {
 	bar: true,
 	"baz:foo": "string",
-	"quux-nix": value,
-	element: /* @__PURE__ */ React.createElement(Foo, null),
+	"quux-nix": value$1,
+	element: /* @__PURE__ */ React.createElement(Foo$1, null),
 	fragment: /* @__PURE__ */ React.createElement(React.Fragment, null)
 });
 

--- a/crates/rolldown/tests/rollup/jsx/transpiles-jsx-expression/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/transpiles-jsx-expression/artifacts.snap
@@ -12,18 +12,18 @@ console.log(element$2);
 
 //#endregion
 //#region dep2.js
-const element = "element 2";
-console.log(element);
+const element$1 = "element 2";
+console.log(element$1);
 
 //#endregion
 //#region dep3.js
-const element$1 = "element 3";
-console.log(element$1);
+const element = "element 3";
+console.log(element);
 
 //#endregion
 //#region main.js
 const Foo = () => {};
-const result = /* @__PURE__ */ React.createElement(Foo, null, "test" + element);
+const result = /* @__PURE__ */ React.createElement(Foo, null, "test" + element$1);
 
 //#endregion
 export { result };

--- a/crates/rolldown/tests/rollup/jsx/transpiles-jsx-spread-attribute/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/transpiles-jsx-spread-attribute/artifacts.snap
@@ -12,27 +12,27 @@ console.log(obj$2);
 
 //#endregion
 //#region dep2.js
-const obj = { value2: true };
-console.log(obj);
+const obj$1 = { value2: true };
+console.log(obj$1);
 
 //#endregion
 //#region dep3.js
-const obj$1 = { value3: true };
-console.log(obj$1);
+const obj = { value3: true };
+console.log(obj);
 
 //#endregion
 //#region main.js
 const Foo = () => {};
-const result1 = /* @__PURE__ */ React.createElement(Foo, obj);
+const result1 = /* @__PURE__ */ React.createElement(Foo, obj$1);
 const result2 = /* @__PURE__ */ React.createElement(Foo, {
-	...obj,
+	...obj$1,
 	prop: true
 });
 const result3 = /* @__PURE__ */ React.createElement(Foo, {
 	prop1: true,
 	prop2: true,
-	...obj,
-	...obj
+	...obj$1,
+	...obj$1
 });
 
 //#endregion

--- a/crates/rolldown/tests/rollup/jsx/transpiles-jsx-spread-child/artifacts.snap
+++ b/crates/rolldown/tests/rollup/jsx/transpiles-jsx-spread-child/artifacts.snap
@@ -12,19 +12,19 @@ console.log(spread$2);
 
 //#endregion
 //#region dep2.js
-const spread = ["spread 2"];
-console.log(spread);
+const spread$1 = ["spread 2"];
+console.log(spread$1);
 
 //#endregion
 //#region dep3.js
-const spread$1 = ["spread 3"];
-console.log(spread$1);
+const spread = ["spread 3"];
+console.log(spread);
 
 //#endregion
 //#region main.js
 const Foo = () => {};
-const element = /* @__PURE__ */ React.createElement(Foo, null, ...spread);
-const fragment = /* @__PURE__ */ React.createElement(React.Fragment, null, ...spread);
+const element = /* @__PURE__ */ React.createElement(Foo, null, ...spread$1);
+const fragment = /* @__PURE__ */ React.createElement(React.Fragment, null, ...spread$1);
 
 //#endregion
 export { element, fragment };

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -798,7 +798,7 @@ expression: output
 
 # tests/esbuild/default/exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-DnqSLu3s.js
+- entry-!~{000}~.js => entry-2MvenvT0.js
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
@@ -1370,7 +1370,7 @@ expression: output
 
 # tests/esbuild/default/minified_exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-Ct04nQPW.js
+- entry-!~{000}~.js => entry-Dz5xGliI.js
 
 # tests/esbuild/default/minified_jsx_preserve_with_object_spread
 
@@ -2896,7 +2896,7 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_browser_index_no_ext
 
-- entry-!~{000}~.js => entry-Dv39UzBV.js
+- entry-!~{000}~.js => entry-DEzgRw24.js
 
 # tests/esbuild/packagejson/package_json_browser_issue2002_a
 
@@ -2944,15 +2944,15 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_browser_no_ext
 
-- entry-!~{000}~.js => entry-De-e1yQ-.js
+- entry-!~{000}~.js => entry-CDa22rfJ.js
 
 # tests/esbuild/packagejson/package_json_browser_node_modules_index_no_ext
 
-- entry-!~{000}~.js => entry-BL0xYy0_.js
+- entry-!~{000}~.js => entry-qYvU3w5L.js
 
 # tests/esbuild/packagejson/package_json_browser_node_modules_no_ext
 
-- entry-!~{000}~.js => entry-DofpIrhO.js
+- entry-!~{000}~.js => entry-BwGK4wwh.js
 
 # tests/esbuild/packagejson/package_json_browser_over_main_node
 
@@ -3462,7 +3462,7 @@ expression: output
 
 # tests/esbuild/ts/ts_export_default_type_issue316
 
-- entry-!~{000}~.js => entry-ezzTSP9M.js
+- entry-!~{000}~.js => entry-dPKBPQvB.js
 
 # tests/esbuild/ts/ts_export_equals
 
@@ -3626,7 +3626,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/basic_commonjs
 
-- main-!~{000}~.js => main-DcSKKmtL.js
+- main-!~{000}~.js => main-_CR9-_HU.js
 
 # tests/rolldown/cjs_compat/cjs_entry
 
@@ -3748,7 +3748,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge
 
-- main-!~{000}~.js => main-BCfSHTVS.js
+- main-!~{000}~.js => main-GJmcGM95.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_2
 
@@ -3756,12 +3756,12 @@ expression: output
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize
 
-- main-!~{000}~.js => main-BxnMq3TD.js
+- main-!~{000}~.js => main-C8xoHf6z.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize_chunk_split
 
 - entry-!~{000}~.js => entry-DGNBdQYB.js
-- main-!~{001}~.js => main-BG4QQTYh.js
+- main-!~{001}~.js => main-9tQkXCaJ.js
 - a-!~{002}~.js => a-DAOsjFT6.js
 
 # tests/rolldown/cjs_compat/react-like
@@ -3847,9 +3847,9 @@ expression: output
 
 # tests/rolldown/code_splitting/issue_2786
 
-- main-!~{000}~.js => main-B5YHu2JI.js
-- share-!~{001}~.js => share-C9WmgANT.js
-- share-!~{003}~.js => share-hE1clfub.js
+- main-!~{000}~.js => main-BbxOV0vg.js
+- share-!~{001}~.js => share-DjQjC9mY.js
+- share-!~{003}~.js => share-wzwYn-nJ.js
 
 # tests/rolldown/dce/conditional_exports
 
@@ -4078,11 +4078,11 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/exports_chain_indirect_ns
 
-- main-!~{000}~.js => main-CuDlvFzB.js
+- main-!~{000}~.js => main-DLGWTVDF.js
 
 # tests/rolldown/function/experimental/strict_execution_order/exports_chain_ns
 
-- main-!~{000}~.js => main-CuDlvFzB.js
+- main-!~{000}~.js => main-DLGWTVDF.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
@@ -4746,10 +4746,10 @@ expression: output
 
 # tests/rolldown/issues/3650
 
-- main-!~{000}~.js => main-DhNLi70T.js
-- first-!~{005}~.js => first-CqZUuY6b.js
+- main-!~{000}~.js => main-CQHe1UcT.js
+- first-!~{005}~.js => first-DhrrPFoL.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-BbrB2Vi1.js
-- second-!~{003}~.js => second-CxLJiUUU.js
+- second-!~{003}~.js => second-DaPxHoFn.js
 
 # tests/rolldown/issues/3746/a
 
@@ -5758,8 +5758,8 @@ expression: output
 
 # tests/rolldown/topics/deconflict/basic_scoped
 
-- main-!~{000}~.js => main-QTbkFQwx.js
-- main-QTbkFQwx.js.map
+- main-!~{000}~.js => main-DSjWo8hf.js
+- main-DSjWo8hf.js.map
 
 # tests/rolldown/topics/deconflict/cjs
 
@@ -5795,8 +5795,8 @@ expression: output
 
 # tests/rolldown/topics/deconflict/issue_364
 
-- main-!~{000}~.js => main-C3PfjjVO.js
-- main-C3PfjjVO.js.map
+- main-!~{000}~.js => main-Dhg00Vwi.js
+- main-Dhg00Vwi.js.map
 
 # tests/rolldown/topics/deconflict/issue_5737
 
@@ -5883,7 +5883,7 @@ expression: output
 
 # tests/rolldown/topics/hmr/import_meta_hot_accept
 
-- main-!~{000}~.js => main-DF_RCa33.js
+- main-!~{000}~.js => main-D0f-TceW.js
 
 # tests/rolldown/topics/hmr/issue_4818
 
@@ -5928,7 +5928,7 @@ expression: output
 
 # tests/rolldown/topics/hmr/runtime_correctness
 
-- main-!~{000}~.js => main-CAU0z0Wz.js
+- main-!~{000}~.js => main-vBItIea4.js
 
 # tests/rolldown/topics/hmr/self-accept-within-circular
 
@@ -5949,7 +5949,7 @@ expression: output
 
 # tests/rolldown/topics/keep_names/declaration
 
-- main-!~{000}~.js => main-ficVjDHh.js
+- main-!~{000}~.js => main-D3u2GAL2.js
 
 # tests/rolldown/topics/keep_names/declaration2
 
@@ -5969,7 +5969,7 @@ expression: output
 
 # tests/rolldown/topics/keep_names/issue_5525
 
-- entry-!~{000}~.js => entry-cBJVrGdT.js
+- entry-!~{000}~.js => entry--6zdr56O.js
 - entry2-!~{001}~.js => entry2-Eow-pZuM.js
 - foo-!~{002}~.js => foo-V6MEsHyi.js
 
@@ -5980,6 +5980,10 @@ expression: output
 # tests/rolldown/topics/keep_names/issue_7481_2
 
 - main-!~{000}~.js => main-B2TJpCLm.js
+
+# tests/rolldown/topics/keep_names/issue_7507/src
+
+- index-!~{000}~.js => index-pA0WPiFF.js
 
 # tests/rolldown/topics/keep_names/parenthesized_default_export
 
@@ -6407,7 +6411,7 @@ expression: output
 
 # tests/rollup/jsx/preserves-jsx-attributes
 
-- main-!~{000}~.js => main-BlPbWKJJ.js
+- main-!~{000}~.js => main-BUXhp3_g.js
 
 # tests/rollup/jsx/preserves-jsx-child
 
@@ -6423,7 +6427,7 @@ expression: output
 
 # tests/rollup/jsx/preserves-jsx-expression
 
-- main-!~{000}~.js => main-DKwBg2k7.js
+- main-!~{000}~.js => main-B4Hqedlf.js
 
 # tests/rollup/jsx/preserves-jsx-fragment
 
@@ -6439,11 +6443,11 @@ expression: output
 
 # tests/rollup/jsx/preserves-jsx-spread-attribute
 
-- main-!~{000}~.js => main-64oJFEcx.js
+- main-!~{000}~.js => main-BLz0t7-t.js
 
 # tests/rollup/jsx/preserves-jsx-spread-child
 
-- main-!~{000}~.js => main-Cc7oiETa.js
+- main-!~{000}~.js => main-350fJpPF.js
 
 # tests/rollup/jsx/preserves-jsx-text
 
@@ -6479,7 +6483,7 @@ expression: output
 
 # tests/rollup/jsx/transpiles-jsx-attributes
 
-- main-!~{000}~.js => main-D_cC-c0B.js
+- main-!~{000}~.js => main-CWcNaNIh.js
 
 # tests/rollup/jsx/transpiles-jsx-child
 
@@ -6495,7 +6499,7 @@ expression: output
 
 # tests/rollup/jsx/transpiles-jsx-expression
 
-- main-!~{000}~.js => main-D30YH_VA.js
+- main-!~{000}~.js => main-H0hWe3PS.js
 
 # tests/rollup/jsx/transpiles-jsx-fragment
 
@@ -6511,11 +6515,11 @@ expression: output
 
 # tests/rollup/jsx/transpiles-jsx-spread-attribute
 
-- main-!~{000}~.js => main-CvNxwQZ_.js
+- main-!~{000}~.js => main-5_a8wgEG.js
 
 # tests/rollup/jsx/transpiles-jsx-spread-child
 
-- main-!~{000}~.js => main-9NTv0iuK.js
+- main-!~{000}~.js => main-BU_Cc4ff.js
 
 # tests/rollup/jsx/transpiles-jsx-text
 


### PR DESCRIPTION
closed #7507
**Before:**

We were deconflicting symbols even when the final declaration was not in the current module. Some symbols declared via `ImportStmt` actually point to another module. This caused the deconfliction order to differ from our intended logic.

**Expected behavior:** When multiple modules use the same top-level name, modules with higher execution order (i.e., executed later) should be more likely to retain the original name.

- Previous logic: https://github.com/rolldown/rolldown/blob/64d18ac5a18050dedf22f8c9a9ee48a232af6ba1/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs#L127-L132

**After:**

The output now aligns with our deconfliction logic.

- Updated logic: https://github.com/rolldown/rolldown/blob/8ea0a88bf0ae95a71028c8c9c5b170f225a37dd1/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs#L110-L115


here is an example: 

https://github.com/rolldown/rolldown/pull/7510/changes#diff-18487ef445297a090c03a52fc7ac8ab76667ed7a3ea19e182c6ac9f9c1e45260

You could refer any other cases that snapshot has changed.