### PR TITLE
fix: disable syntax transform optimization for `minify: 'dce-only'`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/minify_chunks.rs
+++ b/crates/rolldown/src/stages/generate_stage/minify_chunks.rs
@@ -1,7 +1,4 @@
-use oxc::{
-  codegen::{self, CodegenOptions, CommentOptions},
-  minifier::{CompressOptions, MinifierOptions, TreeShakeOptions},
-};
+use oxc::codegen::{self, CodegenOptions, CommentOptions};
 use oxc_allocator::AllocatorPool;
 use rolldown_common::{LegalComments, MinifyOptions, NormalizedBundlerOptions};
 use rolldown_ecmascript::EcmaCompiler;
@@ -21,17 +18,7 @@ impl GenerateStage<'_> {
   ) -> BuildResult<()> {
     let (compress, minify_option, remove_whitespace) = match &options.minify {
       MinifyOptions::Disabled => return Ok(()),
-      MinifyOptions::DeadCodeEliminationOnly => (
-        false,
-        &MinifierOptions {
-          mangle: None,
-          compress: Some(CompressOptions {
-            treeshake: TreeShakeOptions::from(&options.treeshake),
-            ..CompressOptions::dce()
-          }),
-        },
-        false,
-      ),
+      MinifyOptions::DeadCodeEliminationOnly(options) => (false, options, false),
       MinifyOptions::Enabled((options, remove_whitespace)) => (true, options, *remove_whitespace),
     };
     let allocator_pool = AllocatorPool::new(rayon::current_num_threads());

--- a/crates/rolldown_binding/src/types/binding_normalized_options.rs
+++ b/crates/rolldown_binding/src/types/binding_normalized_options.rs
@@ -270,7 +270,7 @@ impl BindingNormalizedOptions {
   pub fn minify(&self) -> Either3<bool, &'static str, oxc_minify_napi::MinifyOptions> {
     match &self.inner.minify {
       MinifyOptions::Disabled => Either3::A(false),
-      MinifyOptions::DeadCodeEliminationOnly => Either3::B("dce-only"),
+      MinifyOptions::DeadCodeEliminationOnly(_) => Either3::B("dce-only"),
       MinifyOptions::Enabled((minify_options, remove_whitespace)) => {
         Either3::C(oxc_minify_napi::MinifyOptions {
           compress: minify_options

--- a/packages/rolldown/tests/fixtures/output/minify/respect-target/main.js
+++ b/packages/rolldown/tests/fixtures/output/minify/respect-target/main.js
@@ -1,3 +1,5 @@
 export function hello(opts) {
   console.log(opts?.name);
+
+  opts == null ? void 0 : opts.name;
 }

--- a/packages/rolldown/tests/fixtures/output/minify/respect-target/snap-0/main.js.snap
+++ b/packages/rolldown/tests/fixtures/output/minify/respect-target/snap-0/main.js.snap
@@ -1,1 +1,1 @@
-function e(e){console.log(e==null?void 0:e.name)}export{e as hello};
+function e(e){console.log(e==null?void 0:e.name),e==null||e.name}export{e as hello};

--- a/packages/rolldown/tests/fixtures/output/minify/respect-target/snap-1/main.js.snap
+++ b/packages/rolldown/tests/fixtures/output/minify/respect-target/snap-1/main.js.snap
@@ -1,4 +1,5 @@
 function hello(opts) {
 	console.log(opts === null || opts === void 0 ? void 0 : opts.name);
+	opts == null || opts.name;
 }
 export { hello };

--- a/packages/rolldown/tests/fixtures/output/minify/respect-target/snap-2/main.js.snap
+++ b/packages/rolldown/tests/fixtures/output/minify/respect-target/snap-2/main.js.snap
@@ -1,1 +1,1 @@
-function hello(e){console.log(e==null?void 0:e.name)}export{hello};
+function hello(e){console.log(e==null?void 0:e.name),e==null||e.name}export{hello};


### PR DESCRIPTION
fixes https://github.com/vitejs/rolldown-vite/issues/556