### PR TITLE
refactor: pass addon option to rust as it is

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -163,16 +163,12 @@ impl Generator for EcmaGenerator {
     let post_banner = match ctx.options.post_banner.as_ref() {
       Some(hook) => hook.call(Arc::clone(&rendered_chunk)).await?,
       None => None,
-    }
-    // FIXME: this `is_empty` shouldn't be necessary
-    .filter(|s| !s.is_empty());
+    };
 
     let post_footer = match ctx.options.post_footer.as_ref() {
       Some(hook) => hook.call(Arc::clone(&rendered_chunk)).await?,
       None => None,
-    }
-    // FIXME: this `is_empty` shouldn't be necessary
-    .filter(|s| !s.is_empty());
+    };
 
     let mut warnings = vec![];
 

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -19,7 +19,8 @@ use crate::types::{
   js_callback::{JsCallback, MaybeAsyncJsCallback},
 };
 
-pub type AddonOutputOption = MaybeAsyncJsCallback<FnArgs<(BindingRenderedChunk,)>, Option<String>>;
+pub type AddonOutputOption =
+  Either<String, MaybeAsyncJsCallback<FnArgs<(BindingRenderedChunk,)>, Option<String>>>;
 pub type ChunkFileNamesOutputOption =
   Either<String, JsCallback<FnArgs<(PreRenderedChunk,)>, String>>;
 pub type AssetFileNamesOutputOption =
@@ -60,16 +61,24 @@ pub struct BindingOutputOptions<'env> {
   pub sanitize_file_name: Option<SanitizeFileName>,
   // amd: NormalizedAmdOptions;
   #[debug(skip)]
-  #[napi(ts_type = "(chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>")]
+  #[napi(
+    ts_type = "string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)"
+  )]
   pub banner: Option<AddonOutputOption>,
   #[debug(skip)]
-  #[napi(ts_type = "(chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>")]
+  #[napi(
+    ts_type = "string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)"
+  )]
   pub post_banner: Option<AddonOutputOption>,
   #[debug(skip)]
-  #[napi(ts_type = "(chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>")]
+  #[napi(
+    ts_type = "string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)"
+  )]
   pub footer: Option<AddonOutputOption>,
   #[debug(skip)]
-  #[napi(ts_type = "(chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>")]
+  #[napi(
+    ts_type = "string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)"
+  )]
   pub post_footer: Option<AddonOutputOption>,
   // compact: boolean;
   pub dir: Option<String>,
@@ -95,14 +104,18 @@ pub struct BindingOutputOptions<'env> {
   pub inline_dynamic_imports: Option<bool>,
   // interop: GetInterop;
   #[debug(skip)]
-  #[napi(ts_type = "(chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>")]
+  #[napi(
+    ts_type = "string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)"
+  )]
   pub intro: Option<AddonOutputOption>,
   // manualChunks: ManualChunksOption;
   // minifyInternalExports: boolean;
   // namespaceToStringTag: boolean;
   // noConflict: boolean;
   #[debug(skip)]
-  #[napi(ts_type = "(chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>")]
+  #[napi(
+    ts_type = "string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)"
+  )]
   pub outro: Option<AddonOutputOption>,
   #[debug(skip)]
   #[napi(ts_type = "Record<string, string> | ((id: string) => string)")]

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2010,10 +2010,10 @@ export interface BindingOutputOptions {
   cssEntryFileNames?: string | ((chunk: PreRenderedChunk) => string)
   cssChunkFileNames?: string | ((chunk: PreRenderedChunk) => string)
   sanitizeFileName?: boolean | ((name: string) => string)
-  banner?: (chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>
-  postBanner?: (chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>
-  footer?: (chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>
-  postFooter?: (chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>
+  banner?: string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)
+  postBanner?: string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)
+  footer?: string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)
+  postFooter?: string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)
   dir?: string
   file?: string
   esModule?: boolean | 'if-default-prop'
@@ -2025,8 +2025,8 @@ export interface BindingOutputOptions {
   globals?: Record<string, string> | ((name: string) => string)
   hashCharacters?: 'base64' | 'base36' | 'hex'
   inlineDynamicImports?: boolean
-  intro?: (chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>
-  outro?: (chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>
+  intro?: string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)
+  outro?: string | ((chunk: BindingRenderedChunk) => MaybePromise<VoidNullable<string>>)
   paths?: Record<string, string> | ((id: string) => string)
   plugins: (BindingBuiltinPlugin | BindingPluginOptions | undefined)[]
   sourcemap?: 'file' | 'inline' | 'hidden'

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -102,12 +102,13 @@ type AddonKeys = 'banner' | 'footer' | 'intro' | 'outro';
 function bindingifyAddon(
   configAddon: OutputOptions[AddonKeys],
 ): BindingOutputOptions[AddonKeys] {
-  return async (chunk) => {
-    if (typeof configAddon === 'function') {
-      return configAddon(transformRenderedChunk(chunk));
-    }
-    return configAddon || '';
-  };
+  if (configAddon == null || configAddon === '') {
+    return undefined;
+  }
+  if (typeof configAddon === 'function') {
+    return async (chunk) => configAddon(transformRenderedChunk(chunk));
+  }
+  return configAddon;
 }
 
 function bindingifyFormat(


### PR DESCRIPTION
- Closes https://github.com/rolldown/rolldown/issues/7514
- The previous code always create a function and pass it to rust
- The previous code use empty `''` as the default value