### PR TITLE
chore: mark feature that will not be supported as ignored in rollup test status

### DIFF
--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -2,11 +2,6 @@
 
 ## Plugin related
 
-### The `rollup.rollup` api is not compatible with rollup, the build is start at `bundle.generate` or `bundle.write`, so the input plugin hooks is not called
- - rollup@hooks@supports buildStart and buildEnd hooks
- - rollup@hooks@supports warnings in buildStart and buildEnd hooks
- - rollup@hooks@passes errors to the buildEnd hook
-
 ### The `NormalziedOptions` at hooks is not compatible with rollup
  - rollup@function@options-hook: allows to read and modify options in the options hook
  - rollup@function@output-options-hook: allows to read and modify options in the options hook
@@ -50,9 +45,6 @@
  - rollup@hooks@opts-out transform hook cache for custom cache
 
 ### The `PluginContext.load` is not fully supported
- - rollup@form@supports-core-js: supports core-js (`@rollup/plugin-commonjs` is not supported)
- - rollup@form@supports-es5-shim: supports es5-shim (`@rollup/plugin-commonjs` is not supported)
- - rollup@form@supports-es6-shim: supports es6-shim (`@rollup/plugin-commonjs` is not supported)
  - rollup@function@preload-cyclic-module: handles pre-loading a cyclic module in the resolveId hook (load entry module at resolveId hook)
  - rollup@function@preload-module: allows pre-loading modules via this.load (load entry module at resolveId hook)
  - rollup@function@module-side-effects@writable: ModuleInfo.moduleSideEffects should be writable during build time(load entry module at resolveId hook)
@@ -259,9 +251,6 @@
  - rollup@form@addon-functions: provides module information when adding addons@generates es
  - rollup@hooks@supports generateBundle hook including reporting rendered exports and source length(`modules.dep.renderedExports/removedExports`)
 
-### The rolldown `output.dir` default to be `dist`, the rollup not specific `dir` or `file` by default
- - rollup@hooks@Throws when not specifying "file" or "dir"
-
 ## Features
 
 ### The `import.meta.ROLLUP_FILE_URL_<referenceId>` is not supported
@@ -295,13 +284,6 @@
  - rollup@form@merge-namespaces-non-live: merges namespaces without live-bindings
  - rollup@form@merge-namespaces: merges namespaces with live-bindings
  - rollup@form@namespace-optimization-in-operator-synthetic: disables optimization for synthetic named exports when using the in operator
-
-### The `import.meta.url` is not compatible
- - rollup@function@import-meta-url-b: Access document.currentScript at the top level
- - rollup@form@import-meta-url: supports import.meta.url@generates es
- - rollup@form@resolve-import-meta-url-export: correctly exports resolved import.meta.url@generates es
- - rollup@form@resolve-import-meta-url: allows to configure import.meta.url@generates es
- - rollup@function@import-meta-url-with-compact: Get the right URL with compact output
 
 ### Does not avoid module-related identifiers
  - rollup@form@system-module-reserved: does not output reserved system format identifiers@generates es

--- a/packages/rollup-tests/src/ignored-tests.js
+++ b/packages/rollup-tests/src/ignored-tests.js
@@ -1,4 +1,5 @@
 const ignoreTests = [
+  // # Tests ported to other locations
   // ## These tests are moved to package/rolldown/tests
   // https://github.com/rolldown/rolldown/pull/5715
   "rollup@hooks@passes errors from closeBundle hook",
@@ -41,10 +42,26 @@ const ignoreTests = [
   "rollup@form@jsx@transpiles-react-jsx: transpiles JSX for react",
   "rollup@function@jsx@missing-jsx-export: throws when the JSX factory is not exported",
 
+  // --------------------------------------------------------------------------------------
+  // # Test infraructure related ignores
   // ## Ignore skipIfWindows test avoid test status error
   'rollup@function@preserve-symlink: follows symlinks',
   'rollup@function@symlink: follows symlinks',
   "rollup@form@sourcemaps-inline: correct sourcemaps are written (inline)@generates es",
+
+  // --------------------------------------------------------------------------------------
+  // # Expected behavior differences
+  // ## build starts when `bundle.generate` / `bundle.write` is called instead of `rollup.rollup`
+  "rollup@hooks@supports buildStart and buildEnd hooks",
+  "rollup@hooks@supports warnings in buildStart and buildEnd hooks",
+  "rollup@hooks@passes errors to the buildEnd hook",
+
+  // ## import.meta.url polyfill behaves differently
+  "rollup@function@import-meta-url-b: Access document.currentScript at the top level",
+  "rollup@form@import-meta-url: supports import.meta.url@generates es",
+  "rollup@form@resolve-import-meta-url-export: correctly exports resolved import.meta.url@generates es",
+  "rollup@form@resolve-import-meta-url: allows to configure import.meta.url@generates es",
+  "rollup@function@import-meta-url-with-compact: Get the right URL with compact output",
 
   // ## warning / error differences
   "rollup@function@plugin-hook-filters: plugin hook filter is supported", // Rolldown has additional `EMPTY_IMPORT_META` warning
@@ -54,6 +71,9 @@ const ignoreTests = [
   // ## tests relying on plugins
   "rollup@function@no-treeshake-react: passes when bundling React without tree-shaking", // relies on @rollup/plugin-node-resolve
   "rollup@function@strip-bom-1: Works correctly with BOM files and the @rollup/plugin-commonjs plugin.", // relies on @rollup/plugin-commonjs
+  "rollup@form@supports-core-js: supports core-js", // relies on @rollup/plugin-commonjs
+  "rollup@form@supports-es5-shim: supports es5-shim", // relies on @rollup/plugin-commonjs
+  "rollup@form@supports-es6-shim: supports es6-shim", // relies on @rollup/plugin-commonjs
 
   // ## Order not guaranteed due to parallelism
   "rollup@hooks@assigns chunk IDs before creating outputBundle chunks", // The `renderChunk` is called at parallel, collect chunk info to array is unstable.  https://github.com/rolldown/rolldown/issues/2364
@@ -65,6 +85,7 @@ const ignoreTests = [
   "rollup@function@external-namespace-and-default-reexport-compat: reexports both a namespace and the default export when using compat interop",
 
   // ## Others
+  'rollup@hooks@Throws when not specifying "file" or "dir"', // Rolldown defaults `output.dir` to `dist`
   'rollup@function@bundle-facade-order: respects the order of entry points when there are additional facades for chunks', // https://github.com/rolldown/rolldown/issues/1842#issuecomment-2296345255
   "rollup@function@argument-deoptimization@global-calls: tracks argument mutations of calls to globals", // need as esm if module is unknown-format and add `use strcit` to the output, https://github.com/rolldown/rolldown/issues/2394
   "rollup@function@es5-class-called-without-new: does not swallow type errors when running constructor functions without \"new\"", // rolldown align directive rendering with esbuild

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,8 +1,8 @@
 {
   "failed": 0,
   "skipFailed": 7,
-  "ignored": 55,
-  "ignored(unsupported features)": 458,
+  "ignored": 67,
+  "ignored(unsupported features)": 446,
   "ignored(treeshaking)": 320,
   "ignored(behavior passed, snapshot different)": 152,
   "passed": 802

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -2,8 +2,8 @@
 |----| ---- |
 | failed | 0 |
 | skipFailed | 7 |
-| ignored | 55 |
-| ignored(unsupported features) | 458 |
+| ignored | 67 |
+| ignored(unsupported features) | 446 |
 | ignored(treeshaking) | 320 |
 | ignored(behavior passed, snapshot different) | 152 |
 | passed | 802 |


### PR DESCRIPTION
Moved some test cases that will not be supported to ignored-tests.js from ignored-by-unsupported-features.md.