### PR TITLE
fix(dev/hmr): ensure cjs modules with no exports reference correct `module` identifier

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -370,7 +370,9 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     // Following cases need to be registered:
     // - `ExportsKind::None` (no exports)
     // - `ExportsKind::CommonJs` (commonjs module)
-    if self.immutable_ctx.options.is_dev_mode_enabled() && !exports_kind.is_esm() {
+    if self.immutable_ctx.options.is_dev_mode_enabled()
+      && matches!(exports_kind, ExportsKind::None | ExportsKind::CommonJs)
+    {
       self.result.ast_usage.insert(EcmaModuleAstUsage::ModuleRef);
     }
 

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -361,9 +361,16 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       }
     }
 
-    if self.immutable_ctx.options.is_dev_mode_enabled() && exports_kind.is_commonjs() {
-      // https://github.com/rolldown/rolldown/issues/4129
-      // For cjs module with hmr enabled, bundler will generates code that references `module`.
+    // For cjs module with hmr enabled, bundler will generates code that references `module`.
+    // https://github.com/rolldown/rolldown/issues/4129
+    //
+    // Even if a cjs module doesn't export anything, the correct `module` reference in module scope
+    // still needs to be registered with the HMR runtime.
+    //
+    // Following cases need to be registered:
+    // - `ExportsKind::None` (no exports)
+    // - `ExportsKind::CommonJs` (commonjs module)
+    if self.immutable_ctx.options.is_dev_mode_enabled() && !exports_kind.is_esm() {
       self.result.ast_usage.insert(EcmaModuleAstUsage::ModuleRef);
     }
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/a.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/a.js
@@ -1,0 +1,1 @@
+console.log('a');

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/artifacts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+// HIDDEN [rolldown:hmr]
+//#region a.js
+var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
+	__rolldown_runtime__.registerModule("a.js", module);
+	console.log("a");
+}));
+
+//#endregion
+//#region b.js
+var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
+	__rolldown_runtime__.registerModule("b.js", module);
+	console.log("b");
+}));
+
+//#endregion
+//#region main.js
+var main_exports = {};
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+require_a();
+require_b();
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/b.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/b.js
@@ -1,0 +1,1 @@
+console.log('b');

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/main.js
@@ -1,0 +1,2 @@
+require('./a.js');
+require('./b.js');

--- a/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/a.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/a.js
@@ -1,0 +1,1 @@
+console.log('a');

--- a/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/artifacts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+// HIDDEN [rolldown:hmr]
+//#region a.js
+var a_exports = {};
+const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
+__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+console.log("a");
+
+//#endregion
+//#region b.js
+var b_exports = {};
+const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
+__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+console.log("b");
+
+//#endregion
+//#region main.js
+var main_exports = {};
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/b.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/b.js
@@ -1,0 +1,1 @@
+console.log('b');

--- a/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/main.js
@@ -1,0 +1,2 @@
+import './a.js';
+import './b.js';

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5867,6 +5867,10 @@ expression: output
 
 - main-!~{000}~.js => main-Cy0J5LeM.js
 
+# tests/rolldown/topics/hmr/cjs_no_export
+
+- main-!~{000}~.js => main-Ccc7i4mM.js
+
 # tests/rolldown/topics/hmr/delete_file_not_used_anymore
 
 - main-!~{000}~.js => main-BFT5vJXs.js
@@ -5884,6 +5888,10 @@ expression: output
 # tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error
 
 - main-!~{000}~.js => main-B-6OWCri.js
+
+# tests/rolldown/topics/hmr/esm_no_export
+
+- main-!~{000}~.js => main-CFbz8g8Q.js
 
 # tests/rolldown/topics/hmr/export_star
 


### PR DESCRIPTION
## Description

Fixes an issue where CommonJS modules with no exports reference an incorrect `module` identifier when registering with the HMR runtime.

**Problem**

[StackBlitz](https://stackblitz.com/edit/github-qel99geu)

When CommonJS modules without exports are registered with the HMR runtime, they reference the wrong `module` identifier:

```js
// other_1.js
console.log('other_1 loaded');

// main.js
require('./other_1.js');
```

```js
var require_other_1 = /* @__PURE__ */ __commonJSMin(() => {
  const other_1_hot = __rolldown_runtime__.createModuleHotContext("src/other_1.js");
  __rolldown_runtime__.registerModule("src/other_1.js", module); // Invalid `module` identifier
                                                          ^^
  console.log("other_1 loaded");
});
```

In Node.js, this references the global `module` object in CommonJS environment. In runtime environments like React Native, the `module` identifier doesn't exist, causing an error.

Even if a `module` identifier exists, CJS modules with no exports always share the same export reference, leading to incorrect behavior:

```js
const mod0 = __rolldown_runtime__.loadExports('src/other_1.js');
const mod1 = __rolldown_runtime__.loadExports('src/other_2.js');

// Different modules but identical `exports` reference
mod0 === mod1; // true
```

---

**After this changes**

References the `module` identifier from `__commonJSMin` scope

```js
var require_other_1 = /* @__PURE__ */ __commonJSMin((exports, module) => {
                                                                ^^
  const other_1_hot = __rolldown_runtime__.createModuleHotContext("src/other_1.js");
  __rolldown_runtime__.registerModule("src/other_1.js", module);
                                                          ^^
  console.log("other_1 loaded");
});
```

