### PR TITLE
refactor: use treeshake_context.is_stmt_info_included_vec to inspect if a stmt_info is included after linking

### DIFF
--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -44,7 +44,7 @@ pub type ModuleNamespaceReasonVec = IndexVec<ModuleIdx, ModuleNamespaceIncludedR
 
 #[derive(Debug, Default)]
 pub struct TreeshakeContext {
-  pub is_included_vec: StmtInclusionVec,
+  pub is_stmt_info_included_vec: StmtInclusionVec,
   pub is_module_included_vec: ModuleInclusionVec,
   pub module_namespace_included_reason: ModuleNamespaceReasonVec,
 }
@@ -78,6 +78,7 @@ pub struct LinkStageOutput {
   pub overrode_preserve_entry_signature_map: FxHashMap<ModuleIdx, PreserveEntrySignatures>,
   pub entry_point_to_reference_ids: FxHashMap<EntryPoint, Vec<ArcStr>>,
   pub global_constant_symbol_map: FxHashMap<SymbolRef, ConstExportMeta>,
+  pub treeshake_context: TreeshakeContext,
 }
 
 #[derive(Debug)]
@@ -222,6 +223,7 @@ impl<'a> LinkStage<'a> {
       overrode_preserve_entry_signature_map: self.overrode_preserve_entry_signature_map,
       entry_point_to_reference_ids: self.entry_point_to_reference_ids,
       global_constant_symbol_map: self.global_constant_symbol_map,
+      treeshake_context: self.treeshake_context,
     }
   }
 

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -279,7 +279,7 @@ impl LinkStage<'_> {
     self.used_symbol_refs = used_symbol_refs;
 
     self.treeshake_context.is_module_included_vec = is_module_included_vec;
-    self.treeshake_context.is_included_vec = is_included_vec;
+    self.treeshake_context.is_stmt_info_included_vec = is_included_vec;
     self.treeshake_context.module_namespace_included_reason = module_namespace_included_reason;
 
     tracing::trace!(

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -115,6 +115,8 @@ pub fn deconflict_chunk_symbols(
     .rev()
     .filter_map(|id| link_output.module_table[id].as_normal())
     .for_each(|module| {
+      let stmt_info_included_vec =
+        &link_output.treeshake_context.is_stmt_info_included_vec[module.idx];
       if let Some(hmr_hot_ref) = module.hmr_hot_ref {
         renamer.add_symbol_in_root_scope(hmr_hot_ref, true);
       }
@@ -123,38 +125,42 @@ pub fn deconflict_chunk_symbols(
       let meta = &link_output.metas[module.idx];
       let is_cjs_wrapped_module = matches!(meta.wrap_kind(), WrapKind::Cjs);
 
-      module.stmt_infos.iter().filter(|stmt_info| stmt_info.is_included).for_each(|stmt_info| {
-        for declared_symbol in stmt_info
-          .declared_symbols
-          .iter()
-          .filter(|item| matches!(item, TaggedSymbolRef::Normal(_)))
-        {
-          let symbol_ref = declared_symbol.inner();
-          let canonical_ref = link_output.symbol_db.canonical_ref_for(symbol_ref);
-          // Import statement declared some symbols that come from other module, those symbol should be skipped
-          if canonical_ref.owner != module.idx {
-            continue;
+      module
+        .stmt_infos
+        .iter_enumerated()
+        .filter_map(|(idx, stmt_info)| stmt_info_included_vec[idx].then_some(stmt_info))
+        .for_each(|stmt_info| {
+          for declared_symbol in stmt_info
+            .declared_symbols
+            .iter()
+            .filter(|item| matches!(item, TaggedSymbolRef::Normal(_)))
+          {
+            let symbol_ref = declared_symbol.inner();
+            let canonical_ref = link_output.symbol_db.canonical_ref_for(symbol_ref);
+            // Import statement declared some symbols that come from other module, those symbol should be skipped
+            if canonical_ref.owner != module.idx {
+              continue;
+            }
+            // For CJS wrapped modules, only facade symbols need deconflicting.
+            // Facade symbols are synthetic symbols created during linking (e.g., `require_foo` wrapper,
+            // namespace objects) that don't exist in the original AST. These are rendered at the chunk's
+            // root scope and must be deconflicted. Non-facade (real AST) symbols in CJS modules are
+            // wrapped inside the `__commonJS` closure and don't pollute the chunk's root scope.
+            let needs_deconflict = if is_cjs_wrapped_module {
+              // Note:
+              // 1. Some facade symbols may originate from external modules (e.g., namespace objects for external imports).
+              // 2. Since we merge external module symbols, external symbol declared in a cjs module also needs to be deconflicted
+              link_output.symbol_db.is_facade_symbol(canonical_ref)
+                || stmt_info.import_records.iter().any(|import_rec_idx| {
+                  link_output.module_table[module.import_records[*import_rec_idx].resolved_module]
+                    .is_external()
+                })
+            } else {
+              true
+            };
+            renamer.add_symbol_in_root_scope(symbol_ref, needs_deconflict);
           }
-          // For CJS wrapped modules, only facade symbols need deconflicting.
-          // Facade symbols are synthetic symbols created during linking (e.g., `require_foo` wrapper,
-          // namespace objects) that don't exist in the original AST. These are rendered at the chunk's
-          // root scope and must be deconflicted. Non-facade (real AST) symbols in CJS modules are
-          // wrapped inside the `__commonJS` closure and don't pollute the chunk's root scope.
-          let needs_deconflict = if is_cjs_wrapped_module {
-            // Note:
-            // 1. Some facade symbols may originate from external modules (e.g., namespace objects for external imports).
-            // 2. Since we merge external module symbols, external symbol declared in a cjs module also needs to be deconflicted
-            link_output.symbol_db.is_facade_symbol(canonical_ref)
-              || stmt_info.import_records.iter().any(|import_rec_idx| {
-                link_output.module_table[module.import_records[*import_rec_idx].resolved_module]
-                  .is_external()
-              })
-          } else {
-            true
-          };
-          renamer.add_symbol_in_root_scope(symbol_ref, needs_deconflict);
-        }
-      });
+        });
     });
 
   // Though, those symbols in `imports_from_other_chunks` doesn't belong to this chunk, but in the final output, they still behave


### PR DESCRIPTION
Make sure `treeeshake_context.is_stmt_info_included_vec` is the only single source of truth to inspect if a module stmt info is included after linking stage

related to #7486