### PR TITLE
chore(ci): make native rolldown build reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,14 +95,34 @@ jobs:
       os: ${{ matrix.target }}
       changed: ${{ needs.changes.outputs.rust-changes == 'true' }}
 
-  node-test:
-    needs: changes
-    strategy:
-      matrix:
-        target: [ubuntu-latest, macos-latest, windows-latest]
+  node-test-windows:
+    needs: [changes, build-rolldown-windows]
     uses: ./.github/workflows/reusable-node-test.yml
+    if: |
+      always() &&
+      (needs.build-rolldown-windows.result == 'success' || needs.build-rolldown-windows.result == 'skipped')
     with:
-      os: ${{ matrix.target }}
+      os: windows-latest
+      changed: ${{ needs.changes.outputs.node-changes == 'true' }}
+
+  node-test-macos:
+    needs: [changes, build-rolldown-macos]
+    uses: ./.github/workflows/reusable-node-test.yml
+    if: |
+      always() &&
+      (needs.build-rolldown-macos.result == 'success' || needs.build-rolldown-macos.result == 'skipped')
+    with:
+      os: macos-latest
+      changed: ${{ needs.changes.outputs.node-changes == 'true' }}
+
+  node-test-ubuntu:
+    needs: [changes, build-rolldown-ubuntu]
+    uses: ./.github/workflows/reusable-node-test.yml
+    if: |
+      always() &&
+      (needs.build-rolldown-ubuntu.result == 'success' || needs.build-rolldown-ubuntu.result == 'skipped')
+    with:
+      os: ubuntu-latest
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}
 
   build-rolldown-wasi:
@@ -110,6 +130,27 @@ jobs:
     uses: ./.github/workflows/reusable-wasi-build.yml
     with:
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}
+
+  build-rolldown-windows:
+    needs: changes
+    uses: ./.github/workflows/reusable-native-build.yml
+    with:
+      changed: ${{ needs.changes.outputs.node-changes == 'true' }}
+      os: windows-latest
+
+  build-rolldown-macos:
+    needs: changes
+    uses: ./.github/workflows/reusable-native-build.yml
+    with:
+      changed: ${{ needs.changes.outputs.node-changes == 'true' }}
+      os: macos-latest
+
+  build-rolldown-ubuntu:
+    needs: changes
+    uses: ./.github/workflows/reusable-native-build.yml
+    with:
+      changed: ${{ needs.changes.outputs.node-changes == 'true' }}
+      os: ubuntu-latest
 
   build-browser:
     name: Build `@rolldown/browser`

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -1,0 +1,48 @@
+name: Reusable Rolldown Native Build
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        required: true
+        type: boolean
+      os:
+        required: true
+        type: string
+
+jobs:
+  run:
+    name: Build Rolldown Native
+    if: ${{ inputs.changed }}
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: true # Pull submodules for additional files
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: oxc-project/setup-rust@ecabb7322a2ba5aeedb3612d2a40b86a85cee235 # v1.0.11
+        with:
+          tools: just
+          cache-key: debug-build
+
+      - uses: oxc-project/setup-node@141eb77546de6702f92d320926403fe3f9f6a6f2 # v1.0.5
+
+      - name: Build Native Rolldown
+        run: just build-rolldown
+
+      - name: Check no diff
+        run: git diff --exit-code
+
+      - name: Upload Rolldown Native
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: rolldown-native-${{ inputs.os }}
+          path: |
+            packages/rolldown/dist
+            packages/pluginutils/dist
+          if-no-files-found: error

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -30,15 +30,14 @@ jobs:
         uses: oxc-project/setup-rust@ecabb7322a2ba5aeedb3612d2a40b86a85cee235 # v1.0.11
         with:
           tools: just
-          cache-key: debug-build
 
       - uses: oxc-project/setup-node@141eb77546de6702f92d320926403fe3f9f6a6f2 # v1.0.5
 
-      - name: Build Native Rolldown
-        run: just build-rolldown
-
-      - name: Check no diff
-        run: git diff --exit-code
+      - name: Download Native Rolldown Build
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: rolldown-native-${{ inputs.os }}
+          path: ./packages
 
       - name: Build `@rolldown/test-dev-server`
         run: pnpm --filter '@rolldown/test-dev-server' build


### PR DESCRIPTION
I wanna split the normal test and hmr tests.  
  
Hmr tests are flaky and sometimes we need to rerun them. By making the build step reusable and separated from normal tests, we could reduce its rerun time a lot.