### PR TITLE
chore: normalize error object to make some Rollup tests pass

### DIFF
--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -198,7 +198,6 @@
  - rollup@function@circular-preserve-modules: correctly handles circular dependencies when preserving modules
  - rollup@function@missing-export-preserve-modules: supports shimming missing exports when preserving modules
  - rollup@function@preserve-modules-circular-order: preserves execution order for circular dependencies when preserving modules
- - rollup@function@preserve-modules@inline-dynamic-imports: Inlining dynamic imports is not supported when preserving modules
  - rollup@function@preserve-modules@invalid-default-export-mode: throws when using default export mode with named exports
  - rollup@function@preserve-modules@invalid-no-preserve-entry-signatures: throws when setting preserveEntrySignatures to false
  - rollup@function@preserve-modules@invalid-none-export-mode: throws when using none export mode with named exports
@@ -215,7 +214,6 @@
  - rollup@function@circular-namespace-reexport-manual-chunks: correctly handles namespace reexports with circular dependencies when using manual chunks
  - rollup@function@emit-chunk-manual-asset-source: supports setting asset sources as side effect of the manual chunks option
  - rollup@function@emit-chunk-manual: supports emitting chunks as side effect of the manual chunks option
- - rollup@function@inline-imports-with-manual: Manual chunks are not supported when inlining dynamic imports
 
 ### The `format: amd` not supported
  - rollup@function@amd-auto-id-id: throws when using both the amd.autoId and the amd.id option
@@ -350,107 +348,43 @@
 - rollup@sourcemaps@combined-sourcemap-3: get correct combined sourcemap of bundled code@generates es
 
 ### The error/warning information is not compatible with rollup
- - rollup@function@warn-on-eval: warns about use of eval
- - rollup@function@warn-missing-iife-name: warns if no name is provided for an IIFE bundle
- - rollup@function@plugin-error-with-numeric-code: rollup do not break if get a plugin error that contains numeric code
- - rollup@function@warn-on-auto-named-default-exports: warns if default and named exports are used in auto mode
- - rollup@function@namespace-reassign-import-fails: warns for reassignments to namespace exports
- - rollup@function@namespace-update-import-fails: disallows updates to namespace exports
- - rollup@function@load-module-error@load: throws when a module cannot be loaded
- - rollup@function@external-entry-point: throws for entry points that are resolved as false by plugins
- - rollup@function@external-entry-point-object: throws for entry points that are resolved as an external object by plugins
- - rollup@function@export-type-mismatch-c: cannot have named exports if explicit export type is default
- - rollup@function@export-type-mismatch: cannot have named exports if explicit export type is default
- - rollup@function@error-missing-umd-name: throws an error if no name is provided for a UMD bundle
- - rollup@function@dynamic-import-not-found: warns if a dynamic import is not found
- - rollup@function@does-not-hang-on-missing-module: does not hang on missing module (#53)
- - rollup@function@default-not-reexported: default export is not re-exported with export *
- - rollup@function@banner-and-footer: adds a banner/footer
- - rollup@function@check-resolve-for-entry: checks that entry is resolved
- - rollup@function@custom-path-resolver-plural-b: resolver error is not caught
- - rollup@function@conflicting-reexports@named-import: throws when a conflicting binding is imported via a named import
- - rollup@function@file-and-dir: throws when using both the file and the dir option
- - rollup@function@reexport-missing-error: reexporting a missing identifier should print an error
- - rollup@function@load-module-error@transform: plugin transform hooks can use `this.error({...}, char)` (#1140)
- - rollup@function@plugin-error@transform: plugin transform hooks can use `this.error({...}, char)` (#1140)
-  - rollup@function@plugin-error@buildEnd: buildStart hooks can use this.error
- - rollup@function@plugin-error@buildStart: buildStart hooks can use this.error
- - rollup@function@plugin-error@generateBundle: buildStart hooks can use this.error
- - rollup@function@plugin-error@load: buildStart hooks can use this.error
- - rollup@function@plugin-error@renderChunk: buildStart hooks can use this.error
- - rollup@function@plugin-error@renderStart: buildStart hooks can use this.error
- - rollup@function@plugin-error@resolveId: buildStart hooks can use this.error
- - rollup@function@load-module-error@buildEnd: buildStart hooks can use this.error
- - rollup@function@load-module-error@buildStart: buildStart hooks can use this.error
- - rollup@function@load-module-error@generateBundle: buildStart hooks can use this.error
- - rollup@function@load-module-error@renderChunk: buildStart hooks can use this.error
- - rollup@function@load-module-error@renderStart: buildStart hooks can use this.error
- - rollup@function@load-module-error@resolveId: buildStart hooks can use this.error
- - rollup@function@logging@this-error-onlog: can turn logs into errors via this.error in the onLog hook
- - rollup@function@plugin-error-only-first-render-chunk: throws error only with first plugin renderChunk
- - rollup@function@plugin-error-only-first-transform: throws error only with first plugin transform
- - rollup@function@plugin-error-module-parsed: errors in moduleParsed abort the build
- - rollup@function@module-side-effects@external-false: supports setting module side effects to false for external modules
+ - rollup@function@warn-on-auto-named-default-exports: warns if default and named exports are used in auto mode (should be `MIXED_EXPORTS` but is `MIXED_EXPORT`)
+ - rollup@function@error-missing-umd-name: throws an error if no name is provided for a UMD bundle (should be `MISSING_NAME_OPTION_FOR_IIFE_EXPORT` but is `MISSING_NAME_OPTION_FOR_UMD_EXPORT`)
+ - rollup@function@default-not-reexported: default export is not re-exported with export * (`exporter` propery is missing in `MISSING_EXPORT` error)
+ - rollup@function@banner-and-footer: adds a banner/footer (expects `ADDON_ERROR` but got `PLUGIN_ERROR`)
+ - rollup@function@conflicting-reexports@named-import: throws when a conflicting binding is imported via a named import (expects `AMBIGUOUS_EXTERNAL_NAMESPACES` but got `MISSING_EXPORT`)
+ - rollup@function@reexport-missing-error: reexporting a missing identifier should print an error (`exporter` propery is missing in `MISSING_EXPORT` error)
  - rollup@function@logging@handle-logs-in-plugins: allows plugins to read and filter logs
- - rollup@function@logging@promote-log-to-error: allows turning logs into errors
- - rollup@hooks@Throws when using the "file"" option for multiple chunks
  - rollup@hooks@supports renderError hook
- - rollup@function@ast-validations@double-named-export: throws on duplicate named exports
- - rollup@function@ast-validations@double-named-export: throws on duplicate named exports
- - rollup@function@ast-validations@double-named-reexport: throws on duplicate named exports
- - rollup@function@ast-validations@double-default-export: throws on double default exports
- - rollup@function@ast-validations@duplicate-function-export: throws on duplicate namespace exports
- - rollup@function@ast-validations@duplicate-import-fails: disallows duplicate imports
- - rollup@function@ast-validations@duplicate-import-specifier-fails: disallows duplicate import specifiers
- - rollup@function@ast-validations@duplicate-namespace-export: throws on duplicate namespace exports
- - rollup@function@ast-validations@duplicate-parameter-name: throws on duplicate parameter names as it would when running in strict mode
- - rollup@function@ast-validations@duplicate-var-export: throws on duplicate exports declared with "var"
- - rollup@function@ast-validations@reassign-import-fails: disallows assignments to imported bindings
- - rollup@function@ast-validations@reassign-import-not-at-top-level-fails: disallows assignments to imported bindings not at the top level
- - rollup@function@ast-validations@redeclare-block-function-function: throws when redeclaring a function binding as a function in a block scope
- - rollup@function@ast-validations@redeclare-catch-scope-local-variable-function: throws when redeclaring the parameter of a catch scope as a function
- - rollup@function@ast-validations@redeclare-catch-scope-parameter-function: throws when redeclaring local variable in a catch scope as a function
- - rollup@function@ast-validations@redeclare-catch-scope-parameter-var-outside-conflict: throws when redeclaring a parameter of a catch scope as a var that conflicts with an outside binding
- - rollup@function@ast-validations@redeclare-catch-scope-pattern-parameter-var: throws when redeclaring a pattern parameter of a catch scope as a var
- - rollup@function@ast-validations@redeclare-class-function: throws when redeclaring a class binding as a function
- - rollup@function@ast-validations@redeclare-const-function: throws when redeclaring a const binding as a function
- - rollup@function@ast-validations@redeclare-default-import-function: throws when redeclaring a default import with a function
- - rollup@function@ast-validations@redeclare-import-var: throws when redeclaring an import with a var
- - rollup@function@ast-validations@redeclare-let-function: throws when redeclaring a let binding as a function
- - rollup@function@ast-validations@redeclare-let-nested-var: throws when redeclaring a let binding with a nested var
- - rollup@function@ast-validations@redeclare-nested-var-let: throws when redeclaring a nested var binding with let
- - rollup@function@ast-validations@redeclare-parameter-let: throws when redeclaring the parameter of a function as a let
- - rollup@function@ast-validations@redeclare-top-level-function-function: throws when redeclaring a top-level function binding as a function
- - rollup@function@ast-validations@redeclare-top-level-var-function: throws when redeclaring a top-level var binding as a function
- - rollup@function@ast-validations@redeclare-var-class: throws when redeclaring a var binding as a class
- - rollup@function@ast-validations@update-expression-of-import-fails: disallows updates to imported bindings
- - rollup@function@catch-rust-panic-parse: Catch Rust panics and then throw them in Node when using this.parse
- - rollup@function@catch-rust-panic: Catch Rust panics and then throw them in Node
- - rollup@function@exports-are-not-defined: Throw descriptive error message for used export is not defined
- - rollup@function@load-module-error@buildEnd: buildEnd hooks can use this.error
- - rollup@function@load-module-error@generateBundle: generateBundle hooks can use this.error
- - rollup@function@load-module-error@renderChunk: renderChunk hooks can use this.error
- - rollup@function@load-module-error@renderStart: renderStart hooks can use this.error
- - rollup@function@load-module-error@resolveId: resolveId hooks can use this.error
- - rollup@function@logging@log-from-options: can log from the options hook
- - rollup@function@logging@log-from-plugin-onlog-onwarn: passes logs from plugins to onLog and onwarn
- - rollup@function@logging@log-from-plugin-onlog: passes logs from plugins to onLog
- - rollup@function@logging@log-from-plugin-onwarn: passes warn logs from plugins to onwarn
- - rollup@function@logging@log-from-plugin-options-onlog-onwarn: passes logs from plugins to onLog and onwarn
- - rollup@function@logging@log-from-plugin-options-onlog: passes logs from plugins to onLog
- - rollup@function@logging@log-from-plugin-options-onwarn: passes warn logs from plugins to onwarn
- - rollup@function@logging@log-from-plugin-simple: prints logs from plugins via input options if there are no handlers
- - rollup@function@logging@loglevel-debug: shows all logs for logLevel:debug
- - rollup@function@logging@loglevel-info: does not show debug logs for logLevel:info
- - rollup@function@logging@loglevel-warn: only shows warning logs for logLevel:warn
- - rollup@function@logging@no-log-with-position: does not support passing a position to this.warn/info/debug outside the transform hook
- - rollup@function@logging@plugin-order: allows to order plugins when logging
- - rollup@function@logging@transform-log-with-position: allows passing a position to this.warn/info/debug in the transform hook
- - rollup@function@missing-entry-export: throws when exporting something that does not exist from an entry
- - rollup@function@plugin-warn-loc-instead-pos: `this.warn(...)` accepts { line, column } object as second parameter (#1265)
- - rollup@function@plugin-warn: plugin transform hooks can use `this.warn({...}, char)` (#1140)
- - rollup@function@plugin-error-transform-pos: `this.error(...)` accepts number as second parameter (#5044)
- - rollup@function@plugin-error-loc-instead-pos: `this.error(...)` accepts { line, column } object as second parameter (#1265)
+ - rollup@function@ast-validations@double-named-export: throws on duplicate named exports (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@double-named-reexport: throws on duplicate named exports (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@double-default-export: throws on double default exports (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@duplicate-function-export: throws on duplicate namespace exports (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@duplicate-import-fails: disallows duplicate imports (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@duplicate-import-specifier-fails: disallows duplicate import specifiers (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@duplicate-namespace-export: throws on duplicate namespace exports (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@duplicate-parameter-name: throws on duplicate parameter names as it would when running in strict mode (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@duplicate-var-export: throws on duplicate exports declared with "var" (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-block-function-function: throws when redeclaring a function binding as a function in a block scope (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-catch-scope-local-variable-function: throws when redeclaring the parameter of a catch scope as a function (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-catch-scope-parameter-function: throws when redeclaring local variable in a catch scope as a function (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-catch-scope-parameter-var-outside-conflict: throws when redeclaring a parameter of a catch scope as a var that conflicts with an outside binding (unknown)
+ - rollup@function@ast-validations@redeclare-catch-scope-pattern-parameter-var: throws when redeclaring a pattern parameter of a catch scope as a var (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-class-function: throws when redeclaring a class binding as a function (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-const-function: throws when redeclaring a const binding as a function (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-default-import-function: throws when redeclaring a default import with a function (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-import-var: throws when redeclaring an import with a var (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-let-function: throws when redeclaring a let binding as a function (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-let-nested-var: throws when redeclaring a let binding with a nested var (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-nested-var-let: throws when redeclaring a nested var binding with let (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-parameter-let: throws when redeclaring the parameter of a function as a let (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-top-level-function-function: throws when redeclaring a top-level function binding as a function (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-top-level-var-function: throws when redeclaring a top-level var binding as a function (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@ast-validations@redeclare-var-class: throws when redeclaring a var binding as a class (`id` property is missing in `PARSE_ERROR` error)
+ - rollup@function@error-after-transform-should-throw-correct-location: error after transform should throw with correct location of file (`exporter` property is missing in `MISSING_EXPORT` error)
+ - rollup@function@import-of-unexported-fails: marking an imported, but unexported, identifier should throw (`exporter` property is missing in `MISSING_EXPORT` error)
+ - rollup@function@import-not-at-top-level-fails: disallows non-top-level imports (`id` property is missing in `PARSE_ERROR` error, also `cause` property is missing)
+ - rollup@function@export-not-at-top-level-fails: disallows non-top-level exports (`id` property is missing in `PARSE_ERROR` error, also `cause` property is missing)
 
 ### The error/warning not implement
  - rollup@hooks@Throws when using the "sourcemapFile" option for multiple chunks
@@ -475,14 +409,13 @@
  - rollup@function@cycles-export-star: does not stack overflow on `export * from X` cycles
  - rollup@function@circular-missed-reexports: handles circular reexports
  - rollup@function@circular-missed-reexports-2: handles circular reexports
- - rollup@function@dynamic-import-relative-not-found: throws if a dynamic relative import is not found
- - rollup@function@error-after-transform-should-throw-correct-location: error after transform should throw with correct location of file
  - rollup@function@error-parse-unknown-extension: throws with an extended error message when failing to parse a file without .(m)js extension
  - rollup@function@error-parse-json: throws with an extended error message when failing to parse a file with ".json" extension
  - rollup@function@iife-code-splitting: throws when generating multiple chunks for an IIFE build
- - rollup@function@import-of-unexported-fails: marking an imported, but unexported, identifier should throw
  - rollup@function@inline-imports-with-multiple-array: Having multiple inputs in an array is not supported when inlining dynamic imports
  - rollup@function@inline-imports-with-multiple-object: Having multiple inputs in an object is not supported when inlining dynamic imports
+ - rollup@function@preserve-modules@inline-dynamic-imports: Inlining dynamic imports is not supported when preserving modules
+ - rollup@function@inline-imports-with-manual: Manual chunks are not supported when inlining dynamic imports
  - rollup@function@warning-low-resolution-location: handles when a low resolution sourcemap is used to report an error
  - rollup@function@warning-incorrect-sourcemap-location: does not fail if a warning has an incorrect location due to missing sourcemaps
  - rollup@function@paths-are-case-sensitive: insists on correct casing for imports
@@ -495,7 +428,6 @@
  - rollup@function@warn-on-unused-missing-imports: warns on missing (but unused) imports
  - rollup@function@warn-misplaced-annotations: warns for misplaced annotations
  - rollup@function@namespace-missing-export: replaces missing namespace members with undefined and warns about them
- - rollup@function@throws-not-found-module: throws error if module is not found
  - rollup@function@transform-without-code-warn-ast: warns when returning a map but no code from a transform hook
  - rollup@function@transform-without-code-warn-map: warns when returning a map but no code from a transform hook
  - rollup@function@unknown-treeshake-value: throws for unknown string values for the treeshake option
@@ -510,13 +442,8 @@
  - rollup@function@invalid-top-level-await: throws for invalid top-level-await format
  - rollup@function@load-returns-string-or-null: throws error if load returns something wacky    
  - rollup@function@vars-with-init-in-dead-branch: handles vars with init in dead branch (#1198)
- - rollup@function@update-expression-of-import-fails: disallows updates to imported bindings
- - rollup@function@reassign-import-not-at-top-level-fails: disallows assignments to imported bindings not at the top level
- - rollup@function@reassign-import-fails: disallows assignments to imported bindings
  - rollup@function@unused-import: warns on unused imports ([#595])
  - rollup@function@module-level-directive: module level directives should produce warnings    
- - rollup@function@import-not-at-top-level-fails: disallows non-top-level imports
- - rollup@function@export-not-at-top-level-fails: disallows non-top-level exports
  - rollup@function@hashing@maximum-hash-size: throws when the maximum hash size is exceeded
  - rollup@function@hashing@minimum-hash-size: throws when the maximum hash size is exceeded
  - rollup@function@hashing@length-at-non-hash: throws when configuring a length for placeholder other than "hash"
@@ -525,11 +452,6 @@
  - rollup@function@emit-file@invalid-asset-name: throws for invalid asset names
  - rollup@function@emit-file@emit-same-file: warns if multiple files with the same name are emitted
  - rollup@function@emit-file@emit-from-output-options: throws when trying to emit files from the outputOptions hook
- - rollup@function@duplicate-import-specifier-fails: disallows duplicate import specifiers
- - rollup@function@duplicate-import-fails: disallows duplicate imports
- - rollup@function@double-named-export: throws on duplicate named exports
- - rollup@function@double-named-reexport: throws on duplicate named exports
- - rollup@function@double-default-export: throws on double default exports
  - rollup@function@deprecations@externalImportAssertions: marks the "output.externalImportAssertions" option as deprecated
  - rollup@function@cannot-call-external-namespace: warns if code calls an external namespace
  - rollup@function@cannot-call-internal-namespace: warns if code calls an internal namespace
@@ -537,10 +459,6 @@
  - rollup@function@conflicting-reexports@namespace-import: warns when a conflicting binding is imported via a namespace import 
  - rollup@function@cannot-resolve-sourcemap-warning: handles when a sourcemap cannot be resolved in a warning
  - rollup@function@adds-json-hint-for-missing-export-if-is-json-file: should provide json hint when importing a no export json file
- - rollup@function@add-watch-file-generate: throws when adding watch files during generate
- - rollup@function@input-name-validation2: throws for relative paths as input names
- - rollup@function@input-name-validation3: throws for relative paths as input names
- - rollup@function@input-name-validation: throws for absolute paths as input names
  - rollup@function@emit-file@asset-source-invalid: throws when setting an empty asset source
  - rollup@function@emit-file@asset-source-missing3: throws when accessing the file name before the asset source is set
  - rollup@function@emit-file@asset-source-missing4: throws when accessing the file name before the asset source is set

--- a/packages/rollup-tests/src/ignored-tests.js
+++ b/packages/rollup-tests/src/ignored-tests.js
@@ -65,8 +65,29 @@ const ignoreTests = [
 
   // ## warning / error differences
   "rollup@function@plugin-hook-filters: plugin hook filter is supported", // Rolldown has additional `EMPTY_IMPORT_META` warning
-  "rollup@function@warning-const-reassign: Cannot reassign a variable declared with `const`", // assignment to a const variable is an error instead of a warning in Rolldown
   "rollup@function@generate-bundle-mutation: handles adding or deleting symbols in generateBundle", // rolldown outputs a warning when assigning to bundle[foo]
+  "rollup@function@missing-entry-export: throws when exporting something that does not exist from an entry", // rolldown uses `PARSE_ERROR` instead of `MISSING_EXPORT`
+  // ### error message difference
+  "rollup@hooks@Throws when using the \"file\"\" option for multiple chunks",
+  "rollup@function@logging@plugin-order: allows to order plugins when logging",
+  "rollup@function@logging@log-from-plugin-onlog-onwarn: passes logs from plugins to onLog and onwarn",
+  "rollup@function@logging@log-from-plugin-onlog: passes logs from plugins to onLog",
+  "rollup@function@logging@log-from-plugin-onwarn: passes warn logs from plugins to onwarn",
+  "rollup@function@logging@log-from-plugin-options-onlog-onwarn: passes logs from plugins to onLog and onwarn",
+  "rollup@function@logging@log-from-plugin-options-onlog: passes logs from plugins to onLog",
+  "rollup@function@logging@log-from-plugin-options-onwarn: passes warn logs from plugins to onwarn",
+  "rollup@function@logging@log-from-plugin-simple: prints logs from plugins via input options if there are no handlers",
+  "rollup@function@logging@loglevel-debug: shows all logs for logLevel:debug",
+  "rollup@function@logging@loglevel-info: does not show debug logs for logLevel:info",
+  "rollup@function@logging@loglevel-warn: only shows warning logs for logLevel:warn",
+  // ### rolldown uses `ASSIGN_TO_IMPORT` while rollup uses `ILLEGAL_REASSIGNMENT`
+  "rollup@function@ast-validations@reassign-import-fails: disallows assignments to imported bindings",
+  "rollup@function@ast-validations@reassign-import-not-at-top-level-fails: disallows assignments to imported bindings not at the top level",
+  "rollup@function@ast-validations@update-expression-of-import-fails: disallows updates to imported bindings",
+  // ### assignment to a const variable is an error instead of a warning in Rolldown
+  "rollup@function@warning-const-reassign: Cannot reassign a variable declared with `const`",
+  "rollup@function@namespace-reassign-import-fails: warns for reassignments to namespace exports",
+  "rollup@function@namespace-update-import-fails: disallows updates to namespace exports",
 
   // ## tests relying on plugins
   "rollup@function@no-treeshake-react: passes when bundling React without tree-shaking", // relies on @rollup/plugin-node-resolve
@@ -91,6 +112,8 @@ const ignoreTests = [
   "rollup@function@es5-class-called-without-new: does not swallow type errors when running constructor functions without \"new\"", // rolldown align directive rendering with esbuild
   "rollup@function@jsx@unknown-mode: throws when using an unknown jsx mode", // validation is done before test are run
   "rollup@function@jsx@unnecessary-import-source: throws when preserving JSX syntax with an unnecessary import source", // `jsx.importSource` cannot be set with `jsx: 'preserve'`
+  "rollup@function@catch-rust-panic: Catch Rust panics and then throw them in Node", // specific to Rollup's implementation
+  "rollup@function@exports-are-not-defined: Throw descriptive error message for used export is not defined", // the input code triggers a different error in rolldown
 ]
 
 module.exports = {

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -1,9 +1,9 @@
 {
   "failed": 0,
   "skipFailed": 7,
-  "ignored": 67,
-  "ignored(unsupported features)": 446,
+  "ignored": 87,
+  "ignored(unsupported features)": 364,
   "ignored(treeshaking)": 320,
   "ignored(behavior passed, snapshot different)": 152,
-  "passed": 802
+  "passed": 849
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -2,8 +2,8 @@
 |----| ---- |
 | failed | 0 |
 | skipFailed | 7 |
-| ignored | 67 |
-| ignored(unsupported features) | 446 |
+| ignored | 87 |
+| ignored(unsupported features) | 364 |
 | ignored(treeshaking) | 320 |
 | ignored(behavior passed, snapshot different) | 152 |
-| passed | 802 |
+| passed | 849 |

--- a/packages/rollup-tests/test/function/index.js
+++ b/packages/rollup-tests/test/function/index.js
@@ -106,6 +106,12 @@ runTestSuiteWithSamples(
 					config.options.output = config.options.output || {}
 					config.options.output.keepNames = true; // avoid other tests snapshot changed
 				}
+				if (
+					directory.includes('input-name-validation') &&
+					config.generateError?.code === 'VALIDATION_ERROR'
+				) {
+					config.generateError.code = 'INVALID_OPTION';
+				}
 
 				return rollup
 					.rollup({


### PR DESCRIPTION
Normalize error object before comparing with Rollup's error so that some rollup tests passes.