### PR TITLE
feat: add `exporter` property to `MISSING_EXPORT` error

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -723,6 +723,7 @@ impl BindImportsAndExportsContext<'_> {
           let mut diagnostic = BuildDiagnostic::missing_export(
             module.id.to_string(),
             module.stable_id.clone(),
+            importee.id().to_string(),
             importee.stable_id().to_string(),
             module.source.clone(),
             named_import.imported.to_string(),

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -114,9 +114,11 @@ impl BuildDiagnostic {
     Self::new_inner(CircularReexport { importer_id, imported_specifier })
   }
 
+  #[expect(clippy::too_many_arguments)]
   pub fn missing_export(
     importer: String,
     stable_importer: String,
+    importee: String,
     stable_importee: String,
     importer_source: ArcStr,
     imported_specifier: String,
@@ -126,6 +128,7 @@ impl BuildDiagnostic {
     Self::new_inner(MissingExport {
       importer,
       stable_importer,
+      importee,
       stable_importee,
       importer_source,
       imported_specifier,

--- a/crates/rolldown_error/src/build_diagnostic/events/missing_export.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/missing_export.rs
@@ -9,6 +9,7 @@ use super::BuildEvent;
 pub struct MissingExport {
   pub importer: String,
   pub stable_importer: String,
+  pub importee: String,
   pub stable_importee: String,
   pub importer_source: ArcStr,
   pub imported_specifier: String,
@@ -23,6 +24,10 @@ impl BuildEvent for MissingExport {
 
   fn id(&self) -> Option<String> {
     Some(self.importer.clone())
+  }
+
+  fn exporter(&self) -> Option<String> {
+    Some(self.importee.clone())
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -350,15 +350,11 @@
 ### The error/warning information is not compatible with rollup
  - rollup@function@warn-on-auto-named-default-exports: warns if default and named exports are used in auto mode (should be `MIXED_EXPORTS` but is `MIXED_EXPORT`)
  - rollup@function@error-missing-umd-name: throws an error if no name is provided for a UMD bundle (should be `MISSING_NAME_OPTION_FOR_IIFE_EXPORT` but is `MISSING_NAME_OPTION_FOR_UMD_EXPORT`)
- - rollup@function@default-not-reexported: default export is not re-exported with export * (`exporter` propery is missing in `MISSING_EXPORT` error)
  - rollup@function@banner-and-footer: adds a banner/footer (expects `ADDON_ERROR` but got `PLUGIN_ERROR`)
  - rollup@function@conflicting-reexports@named-import: throws when a conflicting binding is imported via a named import (expects `AMBIGUOUS_EXTERNAL_NAMESPACES` but got `MISSING_EXPORT`)
- - rollup@function@reexport-missing-error: reexporting a missing identifier should print an error (`exporter` propery is missing in `MISSING_EXPORT` error)
  - rollup@function@logging@handle-logs-in-plugins: allows plugins to read and filter logs
  - rollup@hooks@supports renderError hook
  - rollup@function@ast-validations@redeclare-catch-scope-parameter-var-outside-conflict: throws when redeclaring a parameter of a catch scope as a var that conflicts with an outside binding (unknown)
- - rollup@function@error-after-transform-should-throw-correct-location: error after transform should throw with correct location of file (`exporter` property is missing in `MISSING_EXPORT` error)
- - rollup@function@import-of-unexported-fails: marking an imported, but unexported, identifier should throw (`exporter` property is missing in `MISSING_EXPORT` error)
  - rollup@function@import-not-at-top-level-fails: disallows non-top-level imports (`cause` property is missing)
  - rollup@function@export-not-at-top-level-fails: disallows non-top-level exports (`cause` property is missing)
 

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -2,8 +2,8 @@
   "failed": 0,
   "skipFailed": 7,
   "ignored": 87,
-  "ignored(unsupported features)": 341,
+  "ignored(unsupported features)": 337,
   "ignored(treeshaking)": 320,
   "ignored(behavior passed, snapshot different)": 152,
-  "passed": 872
+  "passed": 876
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -3,7 +3,7 @@
 | failed | 0 |
 | skipFailed | 7 |
 | ignored | 87 |
-| ignored(unsupported features) | 341 |
+| ignored(unsupported features) | 337 |
 | ignored(treeshaking) | 320 |
 | ignored(behavior passed, snapshot different) | 152 |
-| passed | 872 |
+| passed | 876 |


### PR DESCRIPTION
Added `exporter` property to `MISSING_EXPORT` error to align with Rollup.