### PR TITLE
feat: set log and pos properties for `parseAst` function errors

### DIFF
--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -13,11 +13,13 @@ const INVALID_LOG_POSITION = 'INVALID_LOG_POSITION',
 export function logParseError(
   message: string,
   id: string | undefined,
+  pos?: number,
 ): RollupLog {
   return {
     code: PARSE_ERROR,
     id,
     message,
+    pos,
   };
 }
 

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -355,7 +355,6 @@
  - rollup@function@ast-validations@redeclare-catch-scope-parameter-var-outside-conflict: throws when redeclaring a parameter of a catch scope as a var that conflicts with an outside binding (unknown)
  - rollup@function@import-not-at-top-level-fails: disallows non-top-level imports (`cause` property is missing)
  - rollup@function@export-not-at-top-level-fails: disallows non-top-level exports (`cause` property is missing)
- - rollup@function@catch-rust-panic-parse: Catch Rust panics and then throw them in Node when using this.parse (`loc` / `pos` properties are missing)
 
 ### The error/warning not implement
  - rollup@hooks@Throws when using the "sourcemapFile" option for multiple chunks

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -2,8 +2,8 @@
   "failed": 0,
   "skipFailed": 7,
   "ignored": 87,
-  "ignored(unsupported features)": 336,
+  "ignored(unsupported features)": 335,
   "ignored(treeshaking)": 320,
   "ignored(behavior passed, snapshot different)": 152,
-  "passed": 877
+  "passed": 878
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -3,7 +3,7 @@
 | failed | 0 |
 | skipFailed | 7 |
 | ignored | 87 |
-| ignored(unsupported features) | 336 |
+| ignored(unsupported features) | 335 |
 | ignored(treeshaking) | 320 |
 | ignored(behavior passed, snapshot different) | 152 |
-| passed | 877 |
+| passed | 878 |

--- a/packages/rollup-tests/test/utils.js
+++ b/packages/rollup-tests/test/utils.js
@@ -115,7 +115,9 @@ function normalizeExpectedError(error) {
 	}
 
 	// Normalize position values since SWC and Oxc may report different locations
-	if (clone.pos !== undefined) {
+	if (clone.pos === undefined) {
+		delete clone.pos;
+	} else {
 		clone.pos = '[pos]';
 	}
 	if (clone.loc?.line !== undefined) {


### PR DESCRIPTION
Added `log` and `pos` properties for `parseAst` function errors.