### PR TITLE
refactor: use `LinkingMetadata::is_included` to check if a module is included

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -188,7 +188,7 @@ impl GenerateStage<'_> {
               {
                 // the the resolved module is not included in module graph, skip
                 // TODO: Is that possible that the module of the record is a external module?
-                if !importee_module.meta.is_included() {
+                if !self.link_output.metas[importee_module.idx].is_included {
                   return;
                 }
                 if matches!(rec.kind, ImportKind::DynamicImport) {

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -176,7 +176,9 @@ impl<'a> GenerateStage<'a> {
       let ast_table_iter = self.link_output.ast_table.par_iter_mut_enumerated();
       ast_table_iter
         .filter(|(idx, _ast)| {
-          self.link_output.module_table[*idx].as_normal().is_some_and(|m| m.meta.is_included())
+          self.link_output.module_table[*idx]
+            .as_normal()
+            .is_some_and(|m| self.link_output.metas[m.idx].is_included)
         })
         .filter_map(|(idx, ast)| {
           let Some(ast) = ast else {

--- a/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
+++ b/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
@@ -60,10 +60,10 @@ impl LinkStage<'_> {
           });
         });
         let needs_inherit_to_esm_runtime = meta.dependencies.iter().any(|dep_module_idx| {
-          let Some(dep_module) = self.module_table[*dep_module_idx].as_normal() else {
+          let Some(_) = self.module_table[*dep_module_idx].as_normal() else {
             return false;
           };
-          if dep_module.is_included() {
+          if self.metas[*dep_module_idx].is_included {
             return false;
           }
 

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -19,15 +19,14 @@ bitflags! {
     #[derive(Debug, Default, Clone, Copy)]
     pub struct EcmaViewMeta: u8 {
         const Eval = 1;
-        const Included = 1 << 1;
-        const HasLazyExport = 1 << 2;
-        const HasStarExport = 1 << 3;
-        const SafelyTreeshakeCommonjs = 1 << 4;
+        const HasLazyExport = 1 << 1;
+        const HasStarExport = 1 << 2;
+        const SafelyTreeshakeCommonjs = 1 << 3;
         /// If a module has side effects or has top-level global variable access
-        const ExecutionOrderSensitive = 1 << 5;
+        const ExecutionOrderSensitive = 1 << 4;
         /// If the module has top-level empty function, if any module has top level empty function, we need
         /// to apply cross module optimization.
-        const TopExportedSideEffectsFreeFunction = 1 << 6;
+        const TopExportedSideEffectsFreeFunction = 1 << 5;
     }
 }
 
@@ -51,10 +50,6 @@ impl EcmaViewMeta {
   #[inline]
   pub fn has_eval(&self) -> bool {
     self.contains(Self::Eval)
-  }
-  #[inline]
-  pub fn is_included(&self) -> bool {
-    self.contains(Self::Included)
   }
   #[inline]
   pub fn has_lazy_export(&self) -> bool {

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -56,10 +56,13 @@ impl NormalModule {
     self.ecma_view.meta.has_star_export()
   }
 
-  pub fn to_debug_normal_module_for_tree_shaking(&self) -> DebugNormalModuleForTreeShaking {
+  pub fn to_debug_normal_module_for_tree_shaking(
+    &self,
+    is_included: bool,
+  ) -> DebugNormalModuleForTreeShaking {
     DebugNormalModuleForTreeShaking {
       id: self.repr_name.clone(),
-      is_included: self.ecma_view.meta.is_included(),
+      is_included,
       stmt_infos: self
         .ecma_view
         .stmt_infos
@@ -228,10 +231,6 @@ impl NormalModule {
         Some(ModuleRenderOutput { code: render_output.code, map: render_output.map })
       }
     }
-  }
-
-  pub fn is_included(&self) -> bool {
-    self.ecma_view.meta.is_included()
   }
 
   #[expect(clippy::cast_precision_loss)]


### PR DESCRIPTION
Use `LinkingMetadata::is_included` as the single source of truth to determine whether a module is included in the final bundle.