### PR TITLE
refactor: use `LinkingMetadata::stmt_info_included` to check if a stmt_info is included

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -111,7 +111,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       .ctx
       .linking_info
       .wrapper_stmt_info
-      .is_some_and(|idx| self.ctx.module.stmt_infos[idx].is_included)
+      .is_some_and(|idx| self.ctx.linking_info.stmt_info_included[idx])
       .then_some(self.ctx.linking_info.wrap_kind());
 
     self.needs_hosted_top_level_binding = matches!(included_wrap_kind, Some(WrapKind::Esm));
@@ -135,7 +135,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         .stmt_infos
         .declared_stmts_by_symbol(symbol_ref)
         .iter()
-        .any(|id| self.ctx.module.stmt_infos[*id].is_included);
+        .any(|id| self.ctx.linking_info.stmt_info_included[*id]);
       if is_included {
         let canonical_name = self.canonical_name_for(*symbol_ref);
         program.body.push(self.snippet.var_decl_stmt(canonical_name, self.snippet.void_zero()));

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1160,9 +1160,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     let old_body = program.body.take_in(self.alloc);
     // the first statement info is the namespace variable declaration
     // skip first statement info to make sure `program.body` has same index as `stmt_infos`
-    old_body.into_iter().enumerate().zip(self.ctx.module.stmt_infos.iter().skip(1)).for_each(
-      |((_top_stmt_idx, mut top_stmt), stmt_info)| {
-        if !stmt_info.is_included {
+    old_body
+      .into_iter()
+      .enumerate()
+      .zip(self.ctx.module.stmt_infos.iter_enumerated().skip(1))
+      .for_each(|((_top_stmt_idx, mut top_stmt), (stmt_info_idx, _stmt_info))| {
+        if !self.ctx.linking_info.stmt_info_included[stmt_info_idx] {
           return;
         }
 
@@ -1450,8 +1453,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         if is_module_decl {
           last_import_stmt_idx = Some(program.body.len());
         }
-      },
-    );
+      });
     last_import_stmt_idx.unwrap_or(0)
   }
 

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -218,8 +218,9 @@ impl GenerateStage<'_> {
                 .push((module.idx, import.clone()));
             }
           });
-          module.stmt_infos.iter().for_each(|stmt_info| {
-            if !stmt_info.is_included {
+          let linking_info = &self.link_output.metas[module.idx];
+          module.stmt_infos.iter_enumerated().for_each(|(stmt_info_idx, stmt_info)| {
+            if !linking_info.stmt_info_included[stmt_info_idx] {
               return;
             }
             stmt_info.declared_symbols.iter().for_each(|declared| {

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -73,7 +73,6 @@ impl LinkStage<'_> {
             declared_symbols: vec![TaggedSymbolRef::Normal(*symbol_ref)],
             referenced_symbols: vec![],
             side_effect: false.into(),
-            is_included: false,
             import_records: Vec::new(),
             #[cfg(debug_assertions)]
             debug_label: None,
@@ -123,7 +122,6 @@ impl LinkStage<'_> {
             declared_symbols,
             referenced_symbols,
             side_effect: false.into(),
-            is_included: false,
             import_records: Vec::new(),
             #[cfg(debug_assertions)]
             debug_label: None,

--- a/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
+++ b/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
@@ -27,38 +27,42 @@ impl LinkStage<'_> {
           return (module_idx, extended_dependencies, RuntimeHelper::default());
         };
 
-        module.stmt_infos.iter().filter(|stmt_info| stmt_info.is_included).for_each(|stmt_info| {
-          // We need this step to include the runtime module, if there are symbols of it.
-          // TODO: Maybe we should push runtime module to `LinkingMetadata::dependencies` while pushing the runtime symbols.
-          stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
-            match reference_ref {
-              rolldown_common::SymbolOrMemberExprRef::Symbol(sym_ref) => {
-                let canonical_ref = self.symbols.canonical_ref_for(*sym_ref);
-                extended_dependencies.insert(canonical_ref.owner);
-                let symbol = self.symbols.get(canonical_ref);
-                if let Some(ns) = &symbol.namespace_alias {
-                  extended_dependencies.insert(ns.namespace_ref.owner);
+        module
+          .stmt_infos
+          .iter_enumerated()
+          .filter(|(idx, _)| meta.stmt_info_included[*idx])
+          .for_each(|(_, stmt_info)| {
+            // We need this step to include the runtime module, if there are symbols of it.
+            // TODO: Maybe we should push runtime module to `LinkingMetadata::dependencies` while pushing the runtime symbols.
+            stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
+              match reference_ref {
+                rolldown_common::SymbolOrMemberExprRef::Symbol(sym_ref) => {
+                  let canonical_ref = self.symbols.canonical_ref_for(*sym_ref);
+                  extended_dependencies.insert(canonical_ref.owner);
+                  let symbol = self.symbols.get(canonical_ref);
+                  if let Some(ns) = &symbol.namespace_alias {
+                    extended_dependencies.insert(ns.namespace_ref.owner);
+                  }
                 }
-              }
-              rolldown_common::SymbolOrMemberExprRef::MemberExpr(member_expr) => {
-                match member_expr.represent_symbol_ref(&meta.resolved_member_expr_refs) {
-                  Some(sym_ref) => {
-                    let canonical_ref = self.symbols.canonical_ref_for(sym_ref);
-                    extended_dependencies.insert(canonical_ref.owner);
-                    let symbol = self.symbols.get(canonical_ref);
-                    if let Some(ns) = &symbol.namespace_alias {
-                      extended_dependencies.insert(ns.namespace_ref.owner);
+                rolldown_common::SymbolOrMemberExprRef::MemberExpr(member_expr) => {
+                  match member_expr.represent_symbol_ref(&meta.resolved_member_expr_refs) {
+                    Some(sym_ref) => {
+                      let canonical_ref = self.symbols.canonical_ref_for(sym_ref);
+                      extended_dependencies.insert(canonical_ref.owner);
+                      let symbol = self.symbols.get(canonical_ref);
+                      if let Some(ns) = &symbol.namespace_alias {
+                        extended_dependencies.insert(ns.namespace_ref.owner);
+                      }
+                    }
+                    _ => {
+                      // `None` means the member expression resolve to a ambiguous export, which means it actually resolve to nothing.
+                      // It would be rewrite to `undefined` in the final code, so we don't need to include anything to make `undefined` work.
                     }
                   }
-                  _ => {
-                    // `None` means the member expression resolve to a ambiguous export, which means it actually resolve to nothing.
-                    // It would be rewrite to `undefined` in the final code, so we don't need to include anything to make `undefined` work.
-                  }
                 }
               }
-            }
+            });
           });
-        });
         let needs_inherit_to_esm_runtime = meta.dependencies.iter().any(|dep_module_idx| {
           let Some(_) = self.module_table[*dep_module_idx].as_normal() else {
             return false;

--- a/crates/rolldown/src/stages/link_stage/wrapping.rs
+++ b/crates/rolldown/src/stages/link_stage/wrapping.rs
@@ -227,7 +227,6 @@ pub fn create_wrapper(
           runtime.resolve_symbol("__commonJSMin").into()
         }],
         side_effect: false.into(),
-        is_included: false,
         import_records: Vec::new(),
         #[cfg(debug_assertions)]
         debug_label: None,
@@ -259,7 +258,6 @@ pub fn create_wrapper(
           runtime.resolve_symbol("__esmMin").into()
         }],
         side_effect: true.into(),
-        is_included: false,
         import_records: Vec::new(),
         #[cfg(debug_assertions)]
         debug_label: None,

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -5,7 +5,7 @@ use crate::types::module_render_output::ModuleRenderOutput;
 use crate::{
   AssetView, DebugStmtInfoForTreeShaking, EcmaModuleAstUsage, ExportsKind, ImportRecordIdx,
   ImportRecordMeta, LegalComments, ModuleId, ModuleIdx, ModuleInfo, NormalizedBundlerOptions,
-  RawImportRecord, ResolvedId, StmtInfo,
+  RawImportRecord, ResolvedId, StmtInfoIdx,
 };
 use crate::{EcmaView, IndexModules, Interop, Module, ModuleType};
 use std::ops::{Deref, DerefMut};
@@ -59,6 +59,7 @@ impl NormalModule {
   pub fn to_debug_normal_module_for_tree_shaking(
     &self,
     is_included: bool,
+    stmt_info_included: &IndexVec<StmtInfoIdx, bool>,
   ) -> DebugNormalModuleForTreeShaking {
     DebugNormalModuleForTreeShaking {
       id: self.repr_name.clone(),
@@ -66,8 +67,8 @@ impl NormalModule {
       stmt_infos: self
         .ecma_view
         .stmt_infos
-        .iter()
-        .map(StmtInfo::to_debug_stmt_info_for_tree_shaking)
+        .iter_enumerated()
+        .map(|(idx, stmt)| stmt.to_debug_stmt_info_for_tree_shaking(stmt_info_included[idx]))
         .collect(),
     }
   }

--- a/crates/rolldown_common/src/types/stmt_info.rs
+++ b/crates/rolldown_common/src/types/stmt_info.rs
@@ -134,7 +134,6 @@ pub struct StmtInfo {
   /// Top level symbols referenced by this statement.
   pub referenced_symbols: Vec<SymbolOrMemberExprRef>,
   pub side_effect: SideEffectDetail,
-  pub is_included: bool,
   pub import_records: Vec<ImportRecordIdx>,
   #[cfg(debug_assertions)]
   pub debug_label: Option<String>,
@@ -150,9 +149,12 @@ const _: () = {
 };
 
 impl StmtInfo {
-  pub fn to_debug_stmt_info_for_tree_shaking(&self) -> DebugStmtInfoForTreeShaking {
+  pub fn to_debug_stmt_info_for_tree_shaking(
+    &self,
+    is_included: bool,
+  ) -> DebugStmtInfoForTreeShaking {
     DebugStmtInfoForTreeShaking {
-      is_included: self.is_included,
+      is_included,
       side_effect: self.side_effect,
       #[cfg(debug_assertions)]
       source: self.debug_label.clone().unwrap_or_else(|| "<Noop>".into()),


### PR DESCRIPTION
use `LinkingMetadata::stmt_info_included` as single source of truth to inspect if a stmt is included in the final bundle.