### PR TITLE
refactor: introduce `TsconfigResolver` trait to share resolver instance

### DIFF
--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -324,7 +324,7 @@ pub fn prepare_build_context(
     // - Auto: Create Raw mode (will resolve tsconfig per file)
     // - None/Manual: Create Normal mode (resolve tsconfig once now)
     match tsconfig {
-      Some(ref v @ TsConfig::Manual(ref path)) => {
+      Some(TsConfig::Manual(ref path)) => {
         // Manual mode: Resolve tsconfig now and create Normal mode
         let resolved_tsconfig = resolver.resolve_tsconfig(&path).map_err(|err| {
           anyhow::anyhow!("Failed to resolve `tsconfig` option: {}", path.display()).context(err)
@@ -341,17 +341,17 @@ pub fn prepare_build_context(
           )
         } else {
           TransformOptions::new_raw(
-            RawTransformOptions::new(raw_transform_options, v.clone()),
+            RawTransformOptions::new(raw_transform_options, Arc::clone(&resolver)),
             target,
             jsx_preset,
           )
         })
       }
-      Some(v @ TsConfig::Auto) => {
+      Some(TsConfig::Auto) => {
         // Auto mode: Create Raw mode TransformOptions
         // Each file will find its nearest tsconfig during compilation
         Box::new(TransformOptions::new_raw(
-          RawTransformOptions::new(raw_transform_options, v),
+          RawTransformOptions::new(raw_transform_options, Arc::clone(&resolver)),
           target,
           jsx_preset,
         ))

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -76,7 +76,7 @@ pub mod bundler_options {
         TransformOptions as BundlerTransformOptions, TypeScriptOptions,
       },
       transform_options::{
-        JsxPreset, RawTransformOptions, TransformOptions, TransformOptionsInner,
+        JsxPreset, RawTransformOptions, TransformOptions, TransformOptionsInner, TsconfigResolver,
         merge_transform_options_with_tsconfig,
       },
       treeshake::{

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -12,6 +12,7 @@ use oxc_resolver::{
 };
 use rolldown_common::{
   ImportKind, ModuleDefFormat, PackageJson, Platform, ResolveOptions, ResolvedId, TsConfig,
+  TsconfigResolver,
 };
 use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_utils::dashmap::FxDashMap;
@@ -235,4 +236,10 @@ fn infer_module_def_format(info: &Resolution) -> ModuleDefFormat {
     }
   }
   ModuleDefFormat::Unknown
+}
+
+impl<Fs: FileSystem + std::fmt::Debug + Send + Sync> TsconfigResolver for Resolver<Fs> {
+  fn find_tsconfig(&self, path: &Path) -> Result<Option<Arc<OxcTsConfig>>, ResolveError> {
+    self.default_resolver.find_tsconfig(path)
+  }
 }


### PR DESCRIPTION
Shares tsconfig cache between module resolution and transform, avoiding duplicate resolver creation.