### PR TITLE
feat: rename `id` property to `exporter` in CIRCULAR_REEXPORT error

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -826,7 +826,7 @@ impl BindImportsAndExportsContext<'_> {
           && prev_tracker.imported_as == tracker.imported_as
         {
           let importer_module = &index_modules[tracker.importer];
-          let importer_id = importer_module.stable_id().to_string();
+          let importer_id = importer_module.id().to_string();
           let imported_specifier = tracker.imported.to_string();
           self.errors.push(BuildDiagnostic::circular_reexport(importer_id, imported_specifier));
           return MatchImportKind::Cycle;

--- a/crates/rolldown/tests/integration_test262.rs
+++ b/crates/rolldown/tests/integration_test262.rs
@@ -8,7 +8,7 @@ use anyhow::anyhow;
 use cow_utils::CowUtils;
 use regex::Regex;
 use rolldown::BundlerOptions;
-use rolldown_error::{BuildDiagnostic, EventKind};
+use rolldown_error::{BuildDiagnostic, DiagnosticOptions, EventKind};
 use rolldown_testing::integration_test::IntegrationTest;
 use rolldown_testing::test_config::TestMeta;
 use rustc_hash::FxHashSet;
@@ -495,8 +495,14 @@ fn generate_snapshot(results: &[TestResult]) -> String {
       TestOutcome::BundleError(diagnostics) => {
         _ = writeln!(snapshot, "Actual:");
         // Sort diagnostics for deterministic output
-        let mut normalized_diagnostics: Vec<_> =
-          diagnostics.iter().map(|d| normalize_diagnostic_output(&d.to_string())).collect();
+        let mut normalized_diagnostics: Vec<_> = diagnostics
+          .iter()
+          .map(|d| {
+            normalize_diagnostic_output(&d.to_message_with(&DiagnosticOptions {
+              cwd: result.path.parent().unwrap_or(&result.path).to_path_buf(),
+            }))
+          })
+          .collect();
         normalized_diagnostics.sort();
         for normalized in normalized_diagnostics {
           _ = writeln!(snapshot, "{normalized}");

--- a/crates/rolldown_error/src/build_diagnostic/events/circular_reexport.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/circular_reexport.rs
@@ -12,14 +12,15 @@ impl BuildEvent for CircularReexport {
     EventKind::CircularReexportError
   }
 
-  fn message(&self, _opts: &DiagnosticOptions) -> String {
+  fn message(&self, opts: &DiagnosticOptions) -> String {
     format!(
       "'{}' cannot be exported from '{}' as it is a reexport that references itself.",
-      self.imported_specifier, self.importer_id
+      self.imported_specifier,
+      opts.stabilize_path(&self.importer_id)
     )
   }
 
-  fn id(&self) -> Option<String> {
+  fn exporter(&self) -> Option<String> {
     Some(self.importer_id.clone())
   }
 }

--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -76,6 +76,10 @@ impl BuildDiagnostic {
     diagnostic
   }
 
+  pub fn to_message_with(&self, opts: &DiagnosticOptions) -> String {
+    self.inner.message(opts)
+  }
+
   #[cfg(feature = "napi")]
   pub fn downcast_napi_error(&self) -> Result<&napi::Error, &Self> {
     self.inner.as_napi_error().ok_or(self)

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -362,7 +362,6 @@
  - rollup@function@conflicting-reexports@named-import-external: warns when a conflicting binding is imported via a named import from external namespaces (`AMBIGUOUS_EXTERNAL_NAMESPACES`, `UNUSED_EXTERNAL_IMPORT` warning)
  - rollup@function@cycles-pathological-2: resolves even more pathological cyclical dependencies gracefully
  - rollup@function@circular-missed-reexports: handles circular reexports (`MISSING_EXPORT` should be warning instead of error)
- - rollup@function@circular-missed-reexports-2: handles circular reexports (`exporter` property is missing for `CIRCULAR_REEXPORT` error)
  - rollup@function@iife-code-splitting: throws when generating multiple chunks for an IIFE build (`INVALID_OPTION` error)
  - rollup@function@inline-imports-with-multiple-array: Having multiple inputs in an array is not supported when inlining dynamic imports (expected `INVALID_OPTION`, but got `GenericFailure`)
  - rollup@function@inline-imports-with-multiple-object: Having multiple inputs in an object is not supported when inlining dynamic imports (expected `INVALID_OPTION`, but got `GenericFailure`)
@@ -403,7 +402,6 @@
  - rollup@function@emit-file@emit-from-output-options: throws when trying to emit files from the outputOptions hook (`CANNOT_EMIT_FROM_OPTIONS_HOOK` error)
  - rollup@function@cannot-call-external-namespace: warns if code calls an external namespace (`CANNOT_CALL_NAMESPACE` warning)
  - rollup@function@cannot-call-internal-namespace: warns if code calls an internal namespace (`CANNOT_CALL_NAMESPACE` warning)
- - rollup@function@circular-reexport: throws proper error for circular reexports (`exporter` property is missing for `CIRCULAR_REEXPORT` error)
  - rollup@function@conflicting-reexports@namespace-import: warns when a conflicting binding is imported via a namespace import (`MISSING_EXPORT` warning)
  - rollup@function@cannot-resolve-sourcemap-warning: handles when a sourcemap cannot be resolved in a warning (`SOURCEMAP_ERROR` warning)
  - rollup@function@adds-json-hint-for-missing-export-if-is-json-file: should provide json hint when importing a no export json file (`pluginCode":"VALIDATION_ERROR"` expected, but got `pluginCode:"InvalidArg"`)

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -2,8 +2,8 @@
   "failed": 0,
   "skipFailed": 7,
   "ignored": 90,
-  "ignored(unsupported features)": 314,
+  "ignored(unsupported features)": 312,
   "ignored(treeshaking)": 320,
   "ignored(behavior passed, snapshot different)": 157,
-  "passed": 891
+  "passed": 893
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -3,7 +3,7 @@
 | failed | 0 |
 | skipFailed | 7 |
 | ignored | 90 |
-| ignored(unsupported features) | 314 |
+| ignored(unsupported features) | 312 |
 | ignored(treeshaking) | 320 |
 | ignored(behavior passed, snapshot different) | 157 |
-| passed | 891 |
+| passed | 893 |


### PR DESCRIPTION
Rename `id` property to `exporter` in CIRCULAR_REEXPORT error to align with Rollup.