### PR TITLE
refactor: remove `stable_id` field from `PARSE_ERROR` error

### DIFF
--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -977,7 +977,7 @@ mod test {
 
   fn get_statements_side_effect(code: &str) -> bool {
     let source_type = SourceType::tsx();
-    let ast = EcmaCompiler::parse("<Noop>", "<Noop>", code, source_type).unwrap();
+    let ast = EcmaCompiler::parse("<Noop>", code, source_type).unwrap();
     let semantic = EcmaAst::make_semantic(ast.program(), false);
     let scoping = semantic.into_scoping();
     let ast_scopes = AstScopes::new(scoping);
@@ -993,7 +993,7 @@ mod test {
 
   fn get_statements_side_effect_details(code: &str) -> Vec<SideEffectDetail> {
     let source_type = SourceType::tsx();
-    let ast = EcmaCompiler::parse("<Noop>", "<Noop>", code, source_type).unwrap();
+    let ast = EcmaCompiler::parse("<Noop>", code, source_type).unwrap();
     let semantic = EcmaAst::make_semantic(ast.program(), false);
     let scoping = semantic.into_scoping();
     let ast_scopes = AstScopes::new(scoping);

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -178,7 +178,7 @@ impl RuntimeModuleTask {
   fn make_ecma_ast(&self, filename: &str, source: &ArcStr) -> BuildResult<(EcmaAst, ScanResult)> {
     let source_type = SourceType::default();
 
-    let mut ast = EcmaCompiler::parse(filename, filename, source, source_type)?;
+    let mut ast = EcmaCompiler::parse(filename, source.clone(), source_type)?;
 
     ast.program.with_mut(|fields| {
       let mut pre_processor = PreProcessor::new(fields.allocator, false);

--- a/crates/rolldown/src/utils/parse_to_ecma_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ecma_ast.rs
@@ -83,14 +83,9 @@ pub async fn parse_to_ecma_ast(
       json_value_to_ecma_ast(&json_value)
     }
     ModuleType::Dataurl | ModuleType::Base64 | ModuleType::Text => {
-      EcmaCompiler::parse_expr_as_program(
-        resolved_id.id.as_str(),
-        stable_id,
-        source,
-        oxc_source_type,
-      )?
+      EcmaCompiler::parse_expr_as_program(resolved_id.id.as_str(), source, oxc_source_type)?
     }
-    _ => EcmaCompiler::parse(resolved_id.id.as_str(), stable_id, source, oxc_source_type)?,
+    _ => EcmaCompiler::parse(resolved_id.id.as_str(), source, oxc_source_type)?,
   };
 
   ecma_ast = plugin_driver

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -67,19 +67,12 @@ impl PreProcessEcmaAst {
       semantic_ret.errors.into_iter().partition(|w| w.severity == OxcSeverity::Error);
 
     let mut warnings = if errors.is_empty() {
-      BuildDiagnostic::from_oxc_diagnostics(
-        warnings,
-        &source,
-        resolved_id,
-        stable_id,
-        &Severity::Warning,
-      )
+      BuildDiagnostic::from_oxc_diagnostics(warnings, &source, resolved_id, &Severity::Warning)
     } else {
       return Err(BuildDiagnostic::from_oxc_diagnostics(
         errors,
         &source,
         resolved_id,
-        stable_id,
         &Severity::Error,
       ))?;
     };
@@ -124,7 +117,6 @@ impl PreProcessEcmaAst {
             errors,
             &source,
             resolved_id,
-            stable_id,
             &Severity::Error,
           )));
         }

--- a/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/mod.rs
@@ -84,7 +84,7 @@ impl Debug for EcmaAst {
 
 impl Default for EcmaAst {
   fn default() -> Self {
-    EcmaCompiler::parse("", "", "", SourceType::default()).unwrap()
+    EcmaCompiler::parse("", "", SourceType::default()).unwrap()
   }
 }
 

--- a/crates/rolldown_ecmascript/src/ecma_compiler.rs
+++ b/crates/rolldown_ecmascript/src/ecma_compiler.rs
@@ -19,12 +19,7 @@ use crate::ecma_ast::{
 pub struct EcmaCompiler;
 
 impl EcmaCompiler {
-  pub fn parse(
-    id: &str,
-    stable_id: &str,
-    source: impl Into<ArcStr>,
-    ty: SourceType,
-  ) -> BuildResult<EcmaAst> {
+  pub fn parse(id: &str, source: impl Into<ArcStr>, ty: SourceType) -> BuildResult<EcmaAst> {
     let source: ArcStr = source.into();
     let allocator = oxc::allocator::Allocator::default();
     let inner =
@@ -39,7 +34,6 @@ impl EcmaCompiler {
             ret.errors,
             &source.clone(),
             id,
-            stable_id,
             &Severity::Error,
           ))
         } else {
@@ -51,7 +45,6 @@ impl EcmaCompiler {
 
   pub fn parse_expr_as_program(
     id: &str,
-    stable_id: &str,
     source: impl Into<ArcStr>,
     ty: SourceType,
   ) -> BuildResult<EcmaAst> {
@@ -79,7 +72,6 @@ impl EcmaCompiler {
             errors,
             &source.clone(),
             id,
-            stable_id,
             &Severity::Error,
           )),
         }
@@ -139,7 +131,7 @@ impl EcmaCompiler {
 
 #[test]
 fn basic_test() {
-  let ast = EcmaCompiler::parse("", "", "const a = 1;".to_string(), SourceType::default()).unwrap();
+  let ast = EcmaCompiler::parse("", "const a = 1;".to_string(), SourceType::default()).unwrap();
   let code = EcmaCompiler::print_with(&ast, PrintOptions::default()).code;
   assert_eq!(code, "const a = 1;\n");
 }

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -224,19 +224,17 @@ impl BuildDiagnostic {
   pub fn oxc_parse_error(
     source: ArcStr,
     id: String,
-    stable_id: String,
     error_help: String,
     error_message: String,
     error_labels: Vec<LabeledSpan>,
   ) -> Self {
-    Self::new_inner(ParseError { source, id, stable_id, error_help, error_message, error_labels })
+    Self::new_inner(ParseError { source, id, error_help, error_message, error_labels })
   }
 
   pub fn from_oxc_diagnostics<T>(
     diagnostics: T,
     source: &ArcStr,
     id: &str,
-    stable_id: &str,
     severity: &Severity,
   ) -> Vec<Self>
   where
@@ -248,7 +246,6 @@ impl BuildDiagnostic {
         let diagnostic = BuildDiagnostic::oxc_parse_error(
           source.clone(),
           id.to_string(),
-          stable_id.to_string(),
           error.help.take().unwrap_or_default().into(),
           error.message.to_string(),
           error.labels.take().unwrap_or_default(),

--- a/crates/rolldown_error/src/build_diagnostic/events/parse_error.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/parse_error.rs
@@ -11,7 +11,6 @@ use super::BuildEvent;
 pub struct ParseError {
   pub(crate) source: ArcStr,
   pub(crate) id: String,
-  pub(crate) stable_id: String,
   pub(crate) error_help: String,
   pub(crate) error_message: String,
   pub(crate) error_labels: Vec<LabeledSpan>,
@@ -30,10 +29,10 @@ impl BuildEvent for ParseError {
     format!("Parse failed, got: {:?}", self.error_message)
   }
 
-  fn on_diagnostic(&self, diagnostic: &mut Diagnostic, _opts: &DiagnosticOptions) {
+  fn on_diagnostic(&self, diagnostic: &mut Diagnostic, opts: &DiagnosticOptions) {
     diagnostic.title.clone_from(&self.error_message);
 
-    let file_id = diagnostic.add_file(self.stable_id.clone(), self.source.clone());
+    let file_id = diagnostic.add_file(opts.stabilize_path(&self.id), self.source.clone());
 
     self.error_labels.iter().for_each(|label| {
       let offset = u32::try_from(label.offset()).unwrap();

--- a/crates/rolldown_filter_analyzer/src/lib.rs
+++ b/crates/rolldown_filter_analyzer/src/lib.rs
@@ -12,7 +12,7 @@ use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
 #[cfg(test)]
 mod test;
 pub fn filterable(source: &str) -> bool {
-  let ast = EcmaCompiler::parse("<Noop>", "<Noop>", source, SourceType::mjs()).unwrap();
+  let ast = EcmaCompiler::parse("<Noop>", source, SourceType::mjs()).unwrap();
   let semantic = EcmaAst::make_semantic(ast.program(), true);
   let mut analyzer = FilterableAnalyzer::new(&semantic);
   analyzer.visit_program(ast.program());

--- a/crates/rolldown_plugin_isolated_declaration/src/lib.rs
+++ b/crates/rolldown_plugin_isolated_declaration/src/lib.rs
@@ -57,7 +57,6 @@ impl Plugin for IsolatedDeclarationPlugin {
           ret.errors,
           &ArcStr::from(ret.program.source_text),
           args.id,
-          args.stable_id,
           &Severity::Error,
         )))?;
       }

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -11,9 +11,7 @@ use oxc::transformer::Transformer;
 use rolldown_common::{BundlerTransformOptions, ModuleType};
 use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, Severity};
 use rolldown_plugin::{HookUsage, Plugin, SharedTransformPluginContext};
-use rolldown_utils::{
-  concat_string, pattern_filter::StringOrRegex, stabilize_id::stabilize_id, url::clean_url,
-};
+use rolldown_utils::{concat_string, pattern_filter::StringOrRegex, url::clean_url};
 
 #[derive(Debug, Default)]
 pub struct ViteTransformPlugin {
@@ -63,13 +61,11 @@ impl Plugin for ViteTransformPlugin {
 
     let allocator = oxc::allocator::Allocator::default();
     let ret = Parser::new(&allocator, args.code, source_type).parse();
-    let stable_id = stabilize_id(args.id, &self.root);
     if ret.panicked || !ret.errors.is_empty() {
       return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
         ret.errors,
         &ArcStr::from(args.code.as_str()),
         args.id,
-        &stable_id,
         &Severity::Error,
       )))?;
     }
@@ -83,7 +79,6 @@ impl Plugin for ViteTransformPlugin {
         transformer_return.errors,
         &ArcStr::from(args.code.as_str()),
         args.id,
-        &stable_id,
         &Severity::Error,
       )))?;
     }


### PR DESCRIPTION
Refactored to use `DiagnosticOptions::stabilize_path`.

refs #7563
