### PR TITLE
perf: use fsevents on macOS for file watching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,8 +180,8 @@ phf = "0.13.0"
 rayon = "1.10.0"
 regex = "1.11.1"
 regress = "0.10.3"
-rolldown-notify = { version = "10.0.0", default-features = false, features = ["macos_kqueue"] }
-rolldown-notify-debouncer-full = { version = "0.7.3", default-features = false, features = ["macos_kqueue"] }
+rolldown-notify = "10.0.0"
+rolldown-notify-debouncer-full = "0.7.3"
 ropey = "1.6.1"
 rustc-hash = { version = "2.1.1" }
 schemars = "1.0.0"

--- a/crates/rolldown/src/watch/watcher.rs
+++ b/crates/rolldown/src/watch/watcher.rs
@@ -1,6 +1,7 @@
 use crate::watch::event::{BundleEvent, WatcherChangeData, WatcherEvent};
 use anyhow::Context;
 use arcstr::ArcStr;
+use itertools::Itertools;
 #[cfg(not(target_family = "wasm"))]
 use notify::Watcher as _;
 use notify::{
@@ -204,7 +205,7 @@ impl WatcherImpl {
               self.watch_changes.remove(change);
             }
             let changed_files =
-              watch_changes.iter().map(|item| item.path.clone()).collect::<Vec<_>>();
+              watch_changes.iter().map(|item| item.path.clone()).unique().collect::<Vec<_>>();
             let _ = self.run(&changed_files).await;
           }
           ExecChannelMsg::Close => break,


### PR DESCRIPTION
Now that I implemented some improvements (https://github.com/rolldown/notify/pull/59, https://github.com/rolldown/notify/pull/60), it doesn't error on large projects. kqueue doesn't have a way to watch recursively, so it's faster to use fsevent which supports recursive watches.