### PR TITLE
fix(rolldown_plugin_replace): avoid crashing with invalid delimiters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,6 +3132,7 @@ dependencies = [
 name = "rolldown_plugin_replace"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "oxc",
  "regex",
  "regress",

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -92,7 +92,7 @@ impl TryFrom<BindingBuiltinPlugin<'_>> for Arc<dyn Pluginable> {
         } else {
           BindingReplacePluginConfig::default()
         };
-        Arc::new(ReplacePlugin::with_options(config.into()))
+        Arc::new(ReplacePlugin::with_options(config.into())?)
       }
       BindingBuiltinPluginName::ViteAlias => {
         let plugin = if let Some(options) = plugin.options {

--- a/crates/rolldown_plugin_replace/Cargo.toml
+++ b/crates/rolldown_plugin_replace/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 doctest = false
 
 [dependencies]
+anyhow = { workspace = true }
 oxc = { workspace = true }
 regex = { workspace = true }
 regress = { workspace = true }

--- a/crates/rolldown_plugin_replace/tests/form/assignment/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/assignment/mod.rs
@@ -12,17 +12,20 @@ async fn assignment() {
     .build(TestMeta { expect_executed: false, visualize_sourcemap: true, ..Default::default() })
     .run_with_plugins(
       BundlerOptions { input: Some(vec!["./input.js".to_string().into()]), ..Default::default() },
-      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-        values: [
-          ("process.env.DEBUG".to_string(), "replaced".to_string()),
-          ("hello".to_string(), "world".to_string()),
-        ]
-        .into_iter()
-        .collect(),
-        prevent_assignment: true,
-        sourcemap: true,
-        ..Default::default()
-      }))],
+      vec![Arc::new(
+        ReplacePlugin::with_options(ReplaceOptions {
+          values: [
+            ("process.env.DEBUG".to_string(), "replaced".to_string()),
+            ("hello".to_string(), "world".to_string()),
+          ]
+          .into_iter()
+          .collect(),
+          prevent_assignment: true,
+          sourcemap: true,
+          ..Default::default()
+        })
+        .unwrap(),
+      )],
     )
     .await;
 }

--- a/crates/rolldown_plugin_replace/tests/form/delimiters/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/delimiters/mod.rs
@@ -11,12 +11,15 @@ async fn replace_strings() {
     .build(TestMeta { expect_executed: false, visualize_sourcemap: true, ..Default::default() })
     .run_with_plugins(
       BundlerOptions { input: Some(vec!["./input.js".to_string().into()]), ..Default::default() },
-      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-        values: std::iter::once(("original".to_string(), "replaced".to_string())).collect(),
-        delimiters: Some(("<%".to_string(), "%>".to_string())),
-        sourcemap: true,
-        ..Default::default()
-      }))],
+      vec![Arc::new(
+        ReplacePlugin::with_options(ReplaceOptions {
+          values: std::iter::once(("original".to_string(), "replaced".to_string())).collect(),
+          delimiters: Some(("<%".to_string(), "%>".to_string())),
+          sourcemap: true,
+          ..Default::default()
+        })
+        .unwrap(),
+      )],
     )
     .await;
 }

--- a/crates/rolldown_plugin_replace/tests/form/match_variables/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/match_variables/mod.rs
@@ -12,16 +12,19 @@ async fn match_variables() {
     .build(TestMeta { expect_executed: false, visualize_sourcemap: true, ..Default::default() })
     .run_with_plugins(
       BundlerOptions { input: Some(vec!["./input.js".to_string().into()]), ..Default::default() },
-      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-        values: [
-          ("BUILD".to_string(), "beta".to_string()),
-          ("BUILD_VERSION".to_string(), "1.0.0".to_string()),
-        ]
-        .into_iter()
-        .collect(),
-        sourcemap: true,
-        ..Default::default()
-      }))],
+      vec![Arc::new(
+        ReplacePlugin::with_options(ReplaceOptions {
+          values: [
+            ("BUILD".to_string(), "beta".to_string()),
+            ("BUILD_VERSION".to_string(), "1.0.0".to_string()),
+          ]
+          .into_iter()
+          .collect(),
+          sourcemap: true,
+          ..Default::default()
+        })
+        .unwrap(),
+      )],
     )
     .await;
 }

--- a/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/process_check/mod.rs
@@ -16,14 +16,20 @@ async fn process_check() {
         treeshake: TreeshakeOptions::Boolean(false),
         ..Default::default()
       },
-      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-        values: std::iter::once(("process.env.NODE_ENV".to_string(), "\"production\"".to_string()))
+      vec![Arc::new(
+        ReplacePlugin::with_options(ReplaceOptions {
+          values: std::iter::once((
+            "process.env.NODE_ENV".to_string(),
+            "\"production\"".to_string(),
+          ))
           .collect(),
-        prevent_assignment: true,
-        sourcemap: true,
-        object_guards: true,
-        ..Default::default()
-      }))],
+          prevent_assignment: true,
+          sourcemap: true,
+          object_guards: true,
+          ..Default::default()
+        })
+        .unwrap(),
+      )],
     )
     .await;
 }

--- a/crates/rolldown_plugin_replace/tests/form/replace_nothing/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/replace_nothing/mod.rs
@@ -11,9 +11,12 @@ async fn replace_strings() {
     .build(TestMeta { expect_executed: false, ..Default::default() })
     .run_with_plugins(
       BundlerOptions { input: Some(vec!["./input.js".to_string().into()]), ..Default::default() },
-      vec![Arc::new(ReplacePlugin::new(
-        std::iter::once(("typeof window".to_string(), "\"object\"".to_string())).collect(),
-      ))],
+      vec![Arc::new(
+        ReplacePlugin::new(
+          std::iter::once(("typeof window".to_string(), "\"object\"".to_string())).collect(),
+        )
+        .unwrap(),
+      )],
     )
     .await;
 }

--- a/crates/rolldown_plugin_replace/tests/form/replace_strings/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/replace_strings/mod.rs
@@ -11,14 +11,17 @@ async fn replace_strings() {
     .build(TestMeta { expect_executed: false, ..Default::default() })
     .run_with_plugins(
       BundlerOptions { input: Some(vec!["./input.js".to_string().into()]), ..Default::default() },
-      vec![Arc::new(ReplacePlugin::new(
-        [
-          ("ANSWER".to_string(), "42".to_string()),
-          ("typeof window".to_string(), "\"object\"".to_string()),
-        ]
-        .into_iter()
-        .collect(),
-      ))],
+      vec![Arc::new(
+        ReplacePlugin::new(
+          [
+            ("ANSWER".to_string(), "42".to_string()),
+            ("typeof window".to_string(), "\"object\"".to_string()),
+          ]
+          .into_iter()
+          .collect(),
+        )
+        .unwrap(),
+      )],
     )
     .await;
 }

--- a/crates/rolldown_plugin_replace/tests/form/simple_object_guards/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/simple_object_guards/mod.rs
@@ -12,11 +12,14 @@ async fn simple_object_guards() {
     .build(TestMeta { expect_executed: false, ..Default::default() })
     .run_with_plugins(
       BundlerOptions { input: Some(vec!["./input.js".to_string().into()]), ..Default::default() },
-      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-        values: std::iter::once(("foo".to_string(), "bar".to_string())).collect(),
-        object_guards: true,
-        ..Default::default()
-      }))],
+      vec![Arc::new(
+        ReplacePlugin::with_options(ReplaceOptions {
+          values: std::iter::once(("foo".to_string(), "bar".to_string())).collect(),
+          object_guards: true,
+          ..Default::default()
+        })
+        .unwrap(),
+      )],
     )
     .await;
 }

--- a/crates/rolldown_plugin_replace/tests/form/special_characters/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/special_characters/mod.rs
@@ -12,12 +12,15 @@ async fn special_characters() {
     .build(TestMeta { expect_executed: false, visualize_sourcemap: true, ..Default::default() })
     .run_with_plugins(
       BundlerOptions { input: Some(vec!["./input.js".to_string().into()]), ..Default::default() },
-      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-        values: std::iter::once(("require('one')".to_string(), "1".to_string())).collect(),
-        delimiters: Some((String::new(), String::new())),
-        sourcemap: true,
-        ..Default::default()
-      }))],
+      vec![Arc::new(
+        ReplacePlugin::with_options(ReplaceOptions {
+          values: std::iter::once(("require('one')".to_string(), "1".to_string())).collect(),
+          delimiters: Some((String::new(), String::new())),
+          sourcemap: true,
+          ..Default::default()
+        })
+        .unwrap(),
+      )],
     )
     .await;
 }

--- a/crates/rolldown_plugin_replace/tests/form/special_delimiters/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/special_delimiters/mod.rs
@@ -12,12 +12,15 @@ async fn special_delimiters() {
     .build(TestMeta { expect_executed: false, visualize_sourcemap: true, ..Default::default() })
     .run_with_plugins(
       BundlerOptions { input: Some(vec!["./input.js".to_string().into()]), ..Default::default() },
-      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-        values: std::iter::once(("special".to_string(), "replaced".to_string())).collect(),
-        delimiters: Some(("\\b".to_string(), "\\b".to_string())),
-        sourcemap: true,
-        ..Default::default()
-      }))],
+      vec![Arc::new(
+        ReplacePlugin::with_options(ReplaceOptions {
+          values: std::iter::once(("special".to_string(), "replaced".to_string())).collect(),
+          delimiters: Some(("\\b".to_string(), "\\b".to_string())),
+          sourcemap: true,
+          ..Default::default()
+        })
+        .unwrap(),
+      )],
     )
     .await;
 }

--- a/crates/rolldown_plugin_replace/tests/form/ternary_operator/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/ternary_operator/mod.rs
@@ -12,18 +12,21 @@ async fn ternary_operator() {
     .build(TestMeta { expect_executed: false, visualize_sourcemap: true, ..Default::default() })
     .run_with_plugins(
       BundlerOptions { input: Some(vec!["./input.js".to_string().into()]), ..Default::default() },
-      vec![Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-        values: [
-          ("condition".to_string(), "first".to_string()),
-          ("exprIfTrue".to_string(), "second".to_string()),
-          ("exprIfFalse".to_string(), "third".to_string()),
-        ]
-        .into_iter()
-        .collect(),
-        prevent_assignment: true,
-        sourcemap: true,
-        ..Default::default()
-      }))],
+      vec![Arc::new(
+        ReplacePlugin::with_options(ReplaceOptions {
+          values: [
+            ("condition".to_string(), "first".to_string()),
+            ("exprIfTrue".to_string(), "second".to_string()),
+            ("exprIfFalse".to_string(), "third".to_string()),
+          ]
+          .into_iter()
+          .collect(),
+          prevent_assignment: true,
+          sourcemap: true,
+          ..Default::default()
+        })
+        .unwrap(),
+      )],
     )
     .await;
 }

--- a/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
+++ b/crates/rolldown_plugin_replace/tests/form/typescript_declare/mod.rs
@@ -42,12 +42,15 @@ async fn typescript_declare() {
     .run_with_plugins(
       BundlerOptions { input: Some(vec!["./input.ts".to_string().into()]), ..Default::default() },
       vec![
-        Arc::new(ReplacePlugin::with_options(ReplaceOptions {
-          values: std::iter::once(("NAME".to_string(), "replaced".to_string())).collect(),
-          prevent_assignment: true,
-          sourcemap: true,
-          ..Default::default()
-        })),
+        Arc::new(
+          ReplacePlugin::with_options(ReplaceOptions {
+            values: std::iter::once(("NAME".to_string(), "replaced".to_string())).collect(),
+            prevent_assignment: true,
+            sourcemap: true,
+            ..Default::default()
+          })
+          .unwrap(),
+        ),
         Arc::new(TestPlugin(Arc::clone(&code))),
       ],
     )

--- a/packages/rolldown/tests/builtin-plugin/replace.test.ts
+++ b/packages/rolldown/tests/builtin-plugin/replace.test.ts
@@ -1,0 +1,15 @@
+import { replacePlugin } from 'rolldown/plugins';
+import { expect, test } from 'vitest';
+
+test('error on invalid delimiters', () => {
+  expect(() => {
+    replacePlugin(
+      {
+        'process.env.NODE_ENV': JSON.stringify('production'),
+      },
+      {
+        delimiters: ['(', ''],
+      },
+    );
+  }).toThrowError('Unbalanced parenthesis');
+});


### PR DESCRIPTION
We shouldn't crash even if an error happened here.