### PR TITLE
feat: add import path for unresolved import diagnostics

### DIFF
--- a/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain/_config.json
@@ -1,0 +1,3 @@
+{
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain/artifacts.snap
@@ -1,0 +1,21 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## UNRESOLVED_IMPORT
+
+```text
+[UNRESOLVED_IMPORT] Error: Could not resolve './nonexistent.js' in lib.js
+   ╭─[ lib.js:1:8 ]
+   │
+ 1 │ import './nonexistent.js';
+   │        ─────────┬────────  
+   │                 ╰────────── Module not found.
+   │ 
+   │ Help: 'lib.js' is imported by the following path:
+   │         - lib.js
+   │         - main.js
+───╯
+
+```

--- a/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain/lib.js
+++ b/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain/lib.js
@@ -1,0 +1,1 @@
+import './nonexistent.js';

--- a/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain/main.js
+++ b/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain/main.js
@@ -1,0 +1,1 @@
+import './lib.js';

--- a/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain_and_help/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain_and_help/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "resolve": {
+      "alias": [
+        ["@missing", [""]]
+      ]
+    }
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain_and_help/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain_and_help/artifacts.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## RESOLVE_ERROR
+
+```text
+[RESOLVE_ERROR] Error: Could not resolve '@missing/something' in lib.js
+   ╭─[ lib.js:1:19 ]
+   │
+ 1 │ import { a } from "@missing/something";
+   │                   ──────────┬─────────  
+   │                             ╰─────────── Matched alias not found for '@missing/something'
+   │ 
+   │ Help 1: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ 
+   │ Help 2: 'lib.js' is imported by the following path:
+   │           - lib.js
+   │           - main.js
+───╯
+
+```

--- a/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain_and_help/lib.js
+++ b/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain_and_help/lib.js
@@ -1,0 +1,2 @@
+import { a } from "@missing/something";
+console.log(a);

--- a/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain_and_help/main.js
+++ b/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain_and_help/main.js
@@ -1,0 +1,1 @@
+import './lib.js';

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -93,6 +93,7 @@ impl BuildDiagnostic {
       importee,
       reason,
       help,
+      import_chain: None,
       diagnostic_kind,
     })
   }

--- a/crates/rolldown_error/src/build_diagnostic/events/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{any::Any, fmt::Debug};
 
 use arcstr::ArcStr;
 use oxc::span::Span;
@@ -46,7 +46,7 @@ pub mod unloadable_dependency;
 pub mod unresolved_entry;
 pub mod unsupported_feature;
 
-pub trait BuildEvent: Debug + Sync + Send {
+pub trait BuildEvent: Debug + Sync + Send + AsAnyMut {
   fn kind(&self) -> EventKind;
 
   fn message(&self, opts: &DiagnosticOptions) -> String;
@@ -79,6 +79,16 @@ where
 {
   fn from(e: T) -> Self {
     Box::new(e)
+  }
+}
+
+pub trait AsAnyMut {
+  fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl<T: 'static + BuildEvent> AsAnyMut for T {
+  fn as_any_mut(&mut self) -> &mut dyn Any {
+    self
   }
 }
 

--- a/crates/rolldown_error/src/build_diagnostic/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/mod.rs
@@ -84,6 +84,11 @@ impl BuildDiagnostic {
   pub fn downcast_napi_error(&self) -> Result<&napi::Error, &Self> {
     self.inner.as_napi_error().ok_or(self)
   }
+
+  /// Attempt to downcast the inner event to a specific type.
+  pub fn downcast_mut<T: 'static + BuildEvent>(&mut self) -> Option<&mut T> {
+    self.inner.as_any_mut().downcast_mut()
+  }
 }
 
 impl From<anyhow::Error> for BuildDiagnostic {

--- a/crates/rolldown_error/src/lib.rs
+++ b/crates/rolldown_error/src/lib.rs
@@ -14,6 +14,7 @@ pub use crate::{
   build_diagnostic::events::invalid_option::InvalidOptionType,
   build_diagnostic::events::plugin_error::CausedPlugin,
   build_diagnostic::events::plugin_timings::PluginTimingInfo,
+  build_diagnostic::events::resolve_error::DiagnosableResolveError,
   build_diagnostic::events::unloadable_dependency::UnloadableDependencyContext,
   build_diagnostic::{BatchedBuildDiagnostic, BuildDiagnostic, Severity},
   generated::event_kind_switcher::EventKindSwitcher,


### PR DESCRIPTION
Added a help for UNRESOLVED_IMPORT error to output the import path.
```
[UNRESOLVED_IMPORT] Error: Could not resolve '../pkg' in node_modules/.pnpm/lightningcss@1.30.2/node_modules/lightningcss/node/index.js
    ╭─[ node_modules/.pnpm/lightningcss@1.30.2/node_modules/lightningcss/node/index.js:17:28 ]
    │
 17 │   module.exports = require(`../pkg`);
    │                            ────┬───  
    │                                ╰───── Module not found.
    │ 
    │ Help: 'node_modules/.pnpm/lightningcss@1.30.2/node_modules/lightningcss/node/index.js' is imported by the following path:
    │         - node_modules/.pnpm/lightningcss@1.30.2/node_modules/lightningcss/node/index.js
    │         - node_modules/.pnpm/lightningcss@1.30.2/node_modules/lightningcss/node/index.mjs
    │         - node_modules/.pnpm/vite@8.0.0-beta.4_@types+node@24.10.4/node_modules/vite/dist/node/chunks/node.js
    │         - node_modules/.pnpm/vite@8.0.0-beta.4_@types+node@24.10.4/node_modules/vite/dist/node/index.js
    │         - src/main.tsx
    │         - index.html
────╯
```
