### PR TITLE
ci: skip benchmarks for PRs with 'graphite: merge-when-ready' label

### DIFF
--- a/.github/workflows/benchmark-node.yml
+++ b/.github/workflows/benchmark-node.yml
@@ -23,6 +23,10 @@ concurrency:
 jobs:
   benchmark-node:
     name: Benchmark Node
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft != true &&
+      !contains(github.event.pull_request.labels.*.name, 'graphite: merge-when-ready'))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/benchmark-rust.yml
+++ b/.github/workflows/benchmark-rust.yml
@@ -29,7 +29,10 @@ concurrency:
 jobs:
   codspeed-benchmark:
     name: Codspeed Benchmark
-    if: github.event.pull_request.draft != true
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft != true &&
+      !contains(github.event.pull_request.labels.*.name, 'graphite: merge-when-ready'))
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
@@ -64,7 +67,10 @@ jobs:
     permissions:
       pull-requests: write
     name: Benchmark Rust
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft != true
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft != true &&
+      !contains(github.event.pull_request.labels.*.name, 'graphite: merge-when-ready')
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1


### PR DESCRIPTION
## Summary

Skip running benchmark jobs when a PR has the `graphite: merge-when-ready` label to avoid redundant benchmark runs when Graphite rebases and retriggers CI.

### Changes

- Updated `codspeed-benchmark` job to skip when PR has `graphite: merge-when-ready` label
- Updated `benchmark-rust` job to skip when PR has `graphite: merge-when-ready` label
- Updated `benchmark-node` job to skip when PR has `graphite: merge-when-ready` label

When Graphite rebases PRs in a stack, it retriggers all CI jobs including benchmarks. Since the benchmarks were already run on the original commit, there's no need to run them again after a simple rebase.