### PR TITLE
refactor(dev): use direct module id instead of stable id

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -430,7 +430,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         let import_record = &self.module.import_records
           [self.module.hmr_info.module_request_to_import_record_idx[string_literal.value.as_str()]];
         string_literal.value =
-          self.snippet.builder.atom(self.modules[import_record.resolved_module].stable_id());
+          self.snippet.builder.atom(self.modules[import_record.resolved_module].id());
       }
       ast::Argument::ArrayExpression(array_expression) => {
         // `import.meta.hot.accept(['./dep1.js', './dep2.js'], ...)`
@@ -440,7 +440,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
               &self.module.import_records[self.module.hmr_info.module_request_to_import_record_idx
                 [string_literal.value.as_str()]];
             string_literal.value =
-              self.snippet.builder.atom(self.modules[import_record.resolved_module].stable_id());
+              self.snippet.builder.atom(self.modules[import_record.resolved_module].id());
           }
         });
       }
@@ -466,7 +466,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     }
     self.imports.insert(importee.idx());
 
-    let id = &importee.stable_id();
+    let id = importee.id();
     let interop = match importee {
       Module::Normal(importee) => self.module.interop(importee),
       Module::External(_) => None,
@@ -597,7 +597,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         self.snippet.builder.vec1(ast::Argument::StringLiteral(
           self.snippet.builder.alloc_string_literal(
             SPAN,
-            self.snippet.builder.atom(&importee.stable_id),
+            self.snippet.builder.atom(&importee.id),
             None,
           ),
         )),
@@ -712,7 +712,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         self.snippet.call_expr_expr(init_fn_name),
         self.snippet.call_expr_with_arg_expr(
           self.snippet.literal_prop_access_member_expr_expr("__rolldown_runtime__", "loadExports"),
-          self.snippet.string_literal_expr(&importee.stable_id, SPAN),
+          self.snippet.string_literal_expr(&importee.id, SPAN),
           false,
         ),
       );
@@ -722,7 +722,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
         self.snippet.call_expr_expr(init_fn_name),
         self.snippet.call_expr_with_arg_expr(
           self.snippet.literal_prop_access_member_expr_expr("__rolldown_runtime__", "loadExports"),
-          self.snippet.string_literal_expr(&importee.stable_id, SPAN),
+          self.snippet.string_literal_expr(&importee.id, SPAN),
           false,
         ),
       );

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -79,7 +79,7 @@ impl<'a> HmrStage<'a> {
   /// Compute hmr update caused by `import.meta.hot.invalidate()`.
   pub async fn compute_update_for_calling_invalidate(
     &mut self,
-    // The parameter is the stable id of the module that called `import.meta.hot.invalidate()`.
+    // The parameter is the absolute path (module ID) of the module that called `import.meta.hot.invalidate()`.
     invalidate_caller: String,
     first_invalidated_by: Option<String>,
     client_id: &str,
@@ -91,10 +91,12 @@ impl<'a> HmrStage<'a> {
       invalidate_caller,
       first_invalidated_by,
     );
+    // Convert to slashed path for lookup (matches how module_idx_by_abs_path is keyed)
+    let invalidate_caller_slashed: ArcStr = invalidate_caller.as_path().to_slash().unwrap().into();
     let module_idx = self
       .cache
-      .module_idx_by_stable_id
-      .get(invalidate_caller.as_str())
+      .module_idx_by_abs_path
+      .get(&invalidate_caller_slashed)
       .copied()
       .unwrap_or_else(|| panic!("Not found modules for file: {invalidate_caller}"));
 
@@ -102,7 +104,7 @@ impl<'a> HmrStage<'a> {
 
     // Use helper to check if module is executed (supports special testing client ID)
     let temp_client = ClientHmrInput { client_id, executed_modules };
-    if !temp_client.is_module_executed(&caller.stable_id) {
+    if !temp_client.is_module_executed(&caller.id) {
       // If this module is not registered, we simply ignore it.
       return Ok(HmrUpdate::Noop);
     }
@@ -526,7 +528,7 @@ impl<'a> HmrStage<'a> {
         .map(|boundary| {
           let boundary_mod = &self.module_table().modules[boundary.boundary];
           let accepted_via = &self.module_table().modules[boundary.accepted_via];
-          format!("['{}', '{}']", boundary_mod.stable_id(), accepted_via.stable_id())
+          format!("['{}', '{}']", boundary_mod.id(), accepted_via.id())
         })
         .collect::<Vec<_>>()
         .join(",")
@@ -563,9 +565,9 @@ impl<'a> HmrStage<'a> {
         .boundaries
         .into_iter()
         .map(|boundary| HmrBoundaryOutput {
-          boundary: self.module_table().modules[boundary.boundary].stable_id().as_arc_str().clone(),
+          boundary: self.module_table().modules[boundary.boundary].id().as_arc_str().clone(),
           accepted_via: self.module_table().modules[boundary.accepted_via]
-            .stable_id()
+            .id()
             .as_arc_str()
             .clone(),
         })
@@ -711,7 +713,7 @@ impl<'a> HmrStage<'a> {
         .map(|boundary| {
           let boundary_mod = &self.module_table().modules[boundary.boundary];
           let accepted_via = &self.module_table().modules[boundary.accepted_via];
-          format!("['{}', '{}']", boundary_mod.stable_id(), accepted_via.stable_id())
+          format!("['{}', '{}']", boundary_mod.id(), accepted_via.id())
         })
         .collect::<Vec<_>>()
         .join(",")
@@ -748,9 +750,9 @@ impl<'a> HmrStage<'a> {
         .boundaries
         .into_iter()
         .map(|boundary| HmrBoundaryOutput {
-          boundary: self.module_table().modules[boundary.boundary].stable_id().as_arc_str().clone(),
+          boundary: self.module_table().modules[boundary.boundary].id().as_arc_str().clone(),
           accepted_via: self.module_table().modules[boundary.accepted_via]
-            .stable_id()
+            .id()
             .as_arc_str()
             .clone(),
         })
@@ -817,11 +819,11 @@ impl<'a> HmrStage<'a> {
         continue;
       };
 
-      if !client.is_module_executed(&importer.stable_id) {
+      if !client.is_module_executed(&importer.id) {
         tracing::trace!(
           "[HmrStage] skip importer module since it's not executed\n - importer: {}, importee: {}, client: {}",
-          self.module_table().modules[importer_idx].stable_id(),
-          module.stable_id,
+          self.module_table().modules[importer_idx].id(),
+          module.id.as_ref(),
           client.client_id,
         );
         // If this module is not registered, we simply ignore it.
@@ -883,10 +885,10 @@ impl<'a> HmrStage<'a> {
       }
       let mut boundaries = FxIndexSet::default();
 
-      if !client.is_module_executed(self.module_table().modules[stale_module].stable_id()) {
+      if !client.is_module_executed(self.module_table().modules[stale_module].id()) {
         tracing::trace!(
           "[HmrStage] skip stale module {:?} for client {} since it's not executed",
-          self.module_table().modules[stale_module].stable_id(),
+          self.module_table().modules[stale_module].id(),
           client.client_id,
         );
         // If this module is not registered, we simply ignore it.

--- a/crates/rolldown/src/hmr/utils.rs
+++ b/crates/rolldown/src/hmr/utils.rs
@@ -4,6 +4,7 @@ use oxc::{
 };
 use rolldown_common::NormalModule;
 use rolldown_ecmascript::{CJS_MODULE_REF, CJS_ROLLDOWN_MODULE_REF};
+use sugar_path::SugarPath;
 
 use crate::{hmr::hmr_ast_finalizer::HmrAstFinalizer, module_finalizers::ScopeHoistingFinalizer};
 
@@ -66,7 +67,7 @@ pub trait HmrAstBuilder<'any, 'ast> {
     let arguments = self.builder().vec_from_array([
       ast::Argument::StringLiteral(self.builder().alloc_string_literal(
         SPAN,
-        self.builder().atom(&self.module().stable_id),
+        self.builder().atom(&self.module().id.as_arc_str().to_slash().unwrap()),
         None,
       )),
       module_exports,
@@ -90,9 +91,9 @@ pub trait HmrAstBuilder<'any, 'ast> {
     )
   }
 
-  /// `var $hot_name = __rolldown_runtime__.createModuleHotContext($stable_id);`
+  /// `var $hot_name = __rolldown_runtime__.createModuleHotContext($module_id);`
   fn create_module_hot_context_initializer_stmt(&self) -> ast::Statement<'ast> {
-    // var $hot_name = __rolldown_runtime__.createModuleHotContext($stable_id);
+    // var $hot_name = __rolldown_runtime__.createModuleHotContext($module_id);
     ast::Statement::VariableDeclaration(
       self.builder().alloc_variable_declaration(
         SPAN,
@@ -106,7 +107,7 @@ pub trait HmrAstBuilder<'any, 'ast> {
               .builder()
               .binding_pattern_binding_identifier(SPAN, self.alias_name_for_import_meta_hot()),
             NONE,
-            // __rolldown_runtime__.createModuleHotContext($stable_id)
+            // __rolldown_runtime__.createModuleHotContext($module_id)
             Some(ast::Expression::CallExpression(
               self.builder().alloc_call_expression(
                 SPAN,
@@ -120,7 +121,7 @@ pub trait HmrAstBuilder<'any, 'ast> {
                 self.builder().vec1(ast::Argument::StringLiteral(
                   self.builder().alloc_string_literal(
                     SPAN,
-                    self.builder().atom(&self.module().stable_id),
+                    self.builder().atom(&self.module().id.as_arc_str().to_slash().unwrap()),
                     None,
                   ),
                 )),

--- a/crates/rolldown/src/module_finalizers/hmr.rs
+++ b/crates/rolldown/src/module_finalizers/hmr.rs
@@ -58,7 +58,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
           .hmr_info
           .module_request_to_import_record_idx[string_literal.value.as_str()]];
         string_literal.value =
-          self.snippet.builder.atom(self.ctx.modules[import_record.resolved_module].stable_id());
+          self.snippet.builder.atom(self.ctx.modules[import_record.resolved_module].id());
       }
       ast::Argument::ArrayExpression(array_expression) => {
         // `import.meta.hot.accept(['./dep1.js', './dep2.js'], ...)`
@@ -69,10 +69,8 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
               .module
               .hmr_info
               .module_request_to_import_record_idx[string_literal.value.as_str()]];
-            string_literal.value = self
-              .snippet
-              .builder
-              .atom(self.ctx.modules[import_record.resolved_module].stable_id());
+            string_literal.value =
+              self.snippet.builder.atom(self.ctx.modules[import_record.resolved_module].id());
           }
         });
       }

--- a/crates/rolldown/tests/integration_rolldown.rs
+++ b/crates/rolldown/tests/integration_rolldown.rs
@@ -44,6 +44,11 @@ async fn filename_with_hash() {
       options.cwd = Some(fixture_path.to_path_buf());
     }
 
+    if options.experimental.as_ref().is_some_and(|inner| inner.dev_mode.is_some()) {
+      // Dev test will inject machine-related data, which produces non-deterministic hash.
+      continue;
+    }
+
     let integration_test = IntegrationTest::new(
       TestMeta { write_to_disk: false, hash_in_filename: true, ..meta },
       fixture_path.to_path_buf(),

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
@@ -12,8 +12,8 @@ import nodeAssert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region foo.cjs
 var require_foo = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.cjs");
-	__rolldown_runtime__.registerModule("foo.cjs", module);
+	const foo_hot = __rolldown_runtime__.createModuleHotContext("$CWD/foo.cjs");
+	__rolldown_runtime__.registerModule("$CWD/foo.cjs", module);
 	module.exports.value = "foo";
 }));
 
@@ -24,8 +24,8 @@ var import_foo, main_hot;
 var init_main = __esmMin((() => {
 	init_rolldown_hmr();
 	import_foo = require_foo();
-	main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-	__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+	main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+	__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 	nodeAssert.strictEqual(import_foo.value, "foo");
 }));
 

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -12,8 +12,8 @@ import assert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region lib.js
 var require_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const lib_hot = __rolldown_runtime__.createModuleHotContext("lib.js");
-	__rolldown_runtime__.registerModule("lib.js", module);
+	const lib_hot = __rolldown_runtime__.createModuleHotContext("$CWD/lib.js");
+	__rolldown_runtime__.registerModule("$CWD/lib.js", module);
 	exports.a = 1;
 }));
 
@@ -21,8 +21,8 @@ var require_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#region main.js
 var main_exports = {};
 var import_lib = require_lib();
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 assert.strictEqual(import_lib.a, 1);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept-outside-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept-outside-circular/artifacts.snap
@@ -12,29 +12,29 @@ import assert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region c.js
 var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
-const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
-__rolldown_runtime__.registerModule("c.js", { exports: c_exports });
+const c_hot = __rolldown_runtime__.createModuleHotContext("$CWD/c.js");
+__rolldown_runtime__.registerModule("$CWD/c.js", { exports: c_exports });
 const c = "c";
 
 //#endregion
 //#region b.js
 var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
-const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
-__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+const b_hot = __rolldown_runtime__.createModuleHotContext("$CWD/b.js");
+__rolldown_runtime__.registerModule("$CWD/b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
 var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
-const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
-__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+const a_hot = __rolldown_runtime__.createModuleHotContext("$CWD/a.js");
+__rolldown_runtime__.registerModule("$CWD/a.js", { exports: a_exports });
 const a = { b };
 
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 assert.strictEqual(a.b.c, "c");
 main_hot.accept((newMod) => {
 	assert.strictEqual(newMod.a.b.c, "cc");
@@ -63,29 +63,29 @@ import assert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region c.js
 var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
-const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
-__rolldown_runtime__.registerModule("c.js", { exports: c_exports });
+const c_hot = __rolldown_runtime__.createModuleHotContext("$CWD/c.js");
+__rolldown_runtime__.registerModule("$CWD/c.js", { exports: c_exports });
 const c = "cc";
 
 //#endregion
 //#region b.js
 var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
-const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
-__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+const b_hot = __rolldown_runtime__.createModuleHotContext("$CWD/b.js");
+__rolldown_runtime__.registerModule("$CWD/b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
 var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
-const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
-__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+const a_hot = __rolldown_runtime__.createModuleHotContext("$CWD/a.js");
+__rolldown_runtime__.registerModule("$CWD/a.js", { exports: a_exports });
 const a = { b };
 
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 assert.strictEqual(a.b.c, "c");
 main_hot.accept((newMod) => {
 	assert.strictEqual(newMod.a.b.c, "cc");

--- a/crates/rolldown/tests/rolldown/topics/hmr/add_watch_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/add_watch_file/artifacts.snap
@@ -10,8 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region entry.js
 var entry_exports = {};
-const entry_hot = __rolldown_runtime__.createModuleHotContext("entry.js");
-__rolldown_runtime__.registerModule("entry.js", { exports: entry_exports });
+const entry_hot = __rolldown_runtime__.createModuleHotContext("$CWD/entry.js");
+__rolldown_runtime__.registerModule("$CWD/entry.js", { exports: entry_exports });
 const content = "input\n";
 console.log(content);
 
@@ -36,8 +36,8 @@ console.log(content);
 // HIDDEN [rolldown:hmr]
 //#region entry.js
 var entry_exports = {};
-const entry_hot = __rolldown_runtime__.createModuleHotContext("entry.js");
-__rolldown_runtime__.registerModule("entry.js", { exports: entry_exports });
+const entry_hot = __rolldown_runtime__.createModuleHotContext("$CWD/entry.js");
+__rolldown_runtime__.registerModule("$CWD/entry.js", { exports: entry_exports });
 const content = "input2\n";
 console.log(content);
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
@@ -12,16 +12,16 @@ import assert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region child.js
 var child_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
-const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
-__rolldown_runtime__.registerModule("child.js", { exports: child_exports });
+const child_hot = __rolldown_runtime__.createModuleHotContext("$CWD/child.js");
+__rolldown_runtime__.registerModule("$CWD/child.js", { exports: child_exports });
 const foo = 0;
 
 //#endregion
 //#region parent.js
 var parent_exports = {};
-const parent_hot = __rolldown_runtime__.createModuleHotContext("parent.js");
-__rolldown_runtime__.registerModule("parent.js", { exports: parent_exports });
-parent_hot.accept("child.js", () => {
+const parent_hot = __rolldown_runtime__.createModuleHotContext("$CWD/parent.js");
+__rolldown_runtime__.registerModule("$CWD/parent.js", { exports: parent_exports });
+parent_hot.accept("$CWD/child.js", () => {
 	globalThis.oldAcceptWasCalled = true;
 });
 process.on("beforeExit", (code) => {
@@ -32,9 +32,9 @@ process.on("beforeExit", (code) => {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
-main_hot.accept("parent.js", () => {});
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
+main_hot.accept("$CWD/parent.js", () => {});
 
 //#endregion
 ```
@@ -49,10 +49,10 @@ import * as import_node_assert_00 from "node:assert";
 var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
-		var import_child_01 = __rolldown_runtime__.loadExports("child.js");
-		hot_parent.accept("child.js", () => {
+		__rolldown_runtime__.registerModule("$CWD/parent.js", { exports: __rolldown_exports__ });
+		const hot_parent = __rolldown_runtime__.createModuleHotContext("$CWD/parent.js");
+		var import_child_01 = __rolldown_runtime__.loadExports("$CWD/child.js");
+		hot_parent.accept("$CWD/child.js", () => {
 			globalThis.newAcceptWasCalled = true;
 		});
 		process.on("beforeExit", (code) => {
@@ -64,7 +64,7 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_parent_0()
-__rolldown_runtime__.applyUpdates([['main.js', 'parent.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/main.js', '$CWD/parent.js']]);
 ```
 
 ## Meta
@@ -73,7 +73,7 @@ __rolldown_runtime__.applyUpdates([['main.js', 'parent.js']]);
 
 ### Hmr Boundaries
 
-- boundary: main.js, accepted_via: parent.js
+- boundary: $CWD/main.js, accepted_via: $CWD/parent.js
 
 # HMR Step 1
 
@@ -84,15 +84,15 @@ __rolldown_runtime__.applyUpdates([['main.js', 'parent.js']]);
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("child.js");
+		__rolldown_runtime__.registerModule("$CWD/child.js", { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext("$CWD/child.js");
 		const foo = 1;
 	} finally {}
 }));
 
 //#endregion
 init_child_0()
-__rolldown_runtime__.applyUpdates([['parent.js', 'child.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/parent.js', '$CWD/child.js']]);
 ```
 
 ## Meta
@@ -101,4 +101,4 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'child.js']]);
 
 ### Hmr Boundaries
 
-- boundary: parent.js, accepted_via: child.js
+- boundary: $CWD/parent.js, accepted_via: $CWD/child.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/artifacts.snap
@@ -10,24 +10,24 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region a.js
 var require_a = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
-	__rolldown_runtime__.registerModule("a.js", module);
+	const a_hot = __rolldown_runtime__.createModuleHotContext("$CWD/a.js");
+	__rolldown_runtime__.registerModule("$CWD/a.js", module);
 	console.log("a");
 }));
 
 //#endregion
 //#region b.js
 var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
-	__rolldown_runtime__.registerModule("b.js", module);
+	const b_hot = __rolldown_runtime__.createModuleHotContext("$CWD/b.js");
+	__rolldown_runtime__.registerModule("$CWD/b.js", module);
 	console.log("b");
 }));
 
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 require_a();
 require_b();
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
@@ -10,8 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region child.js
 var child_exports = /* @__PURE__ */ __exportAll({ value: () => value });
-const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
-__rolldown_runtime__.registerModule("child.js", { exports: child_exports });
+const child_hot = __rolldown_runtime__.createModuleHotContext("$CWD/child.js");
+__rolldown_runtime__.registerModule("$CWD/child.js", { exports: child_exports });
 const value = "child";
 
 //#endregion
@@ -20,8 +20,8 @@ var parent_exports = /* @__PURE__ */ __exportAll({
 	childValue: () => value,
 	parentValue: () => parentValue
 });
-const parent_hot = __rolldown_runtime__.createModuleHotContext("parent.js");
-__rolldown_runtime__.registerModule("parent.js", { exports: parent_exports });
+const parent_hot = __rolldown_runtime__.createModuleHotContext("$CWD/parent.js");
+__rolldown_runtime__.registerModule("$CWD/parent.js", { exports: parent_exports });
 const parentValue = "parent";
 assert.strictEqual(parentValue, "parent");
 assert.strictEqual(value, "child");
@@ -34,8 +34,8 @@ parent_hot.accept((newMod) => {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 
 //#endregion
 ```
@@ -52,8 +52,8 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 			childValue: () => childValue,
 			parentValue: () => parentValue
 		});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
+		__rolldown_runtime__.registerModule("$CWD/parent.js", { exports: __rolldown_exports__ });
+		const hot_parent = __rolldown_runtime__.createModuleHotContext("$CWD/parent.js");
 		const childValue = "not-child";
 		const parentValue = "parent";
 		hot_parent.accept((newMod) => {
@@ -66,7 +66,7 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_parent_0()
-__rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/parent.js', '$CWD/parent.js']]);
 ```
 
 ## Meta
@@ -75,7 +75,7 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 
 ### Hmr Boundaries
 
-- boundary: parent.js, accepted_via: parent.js
+- boundary: $CWD/parent.js, accepted_via: $CWD/parent.js
 
 # HMR Step 1
 
@@ -92,8 +92,8 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
-		__rolldown_runtime__.registerModule("child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("child.js");
+		__rolldown_runtime__.registerModule("$CWD/child.js", { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext("$CWD/child.js");
 		const value = "child";
 	} finally {}
 }));
@@ -106,8 +106,8 @@ var init_parent_1 = __rolldown_runtime__.createEsmInitializer((function() {
 			childValue: () => childValue,
 			parentValue: () => parentValue
 		});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
+		__rolldown_runtime__.registerModule("$CWD/parent.js", { exports: __rolldown_exports__ });
+		const hot_parent = __rolldown_runtime__.createModuleHotContext("$CWD/parent.js");
 		const childValue = "not-child";
 		const parentValue = "parent";
 		hot_parent.accept((newMod) => {
@@ -120,7 +120,7 @@ var init_parent_1 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_parent_1()
-__rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/parent.js', '$CWD/parent.js']]);
 ```
 
 ## Meta
@@ -129,7 +129,7 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 
 ### Hmr Boundaries
 
-- boundary: parent.js, accepted_via: parent.js
+- boundary: $CWD/parent.js, accepted_via: $CWD/parent.js
 
 # HMR Step 3
 
@@ -143,9 +143,9 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 			parentValue: () => parentValue,
 			childValue: () => import_child_00.value
 		});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
-		var import_child_00 = __rolldown_runtime__.loadExports("child.js");
+		__rolldown_runtime__.registerModule("$CWD/parent.js", { exports: __rolldown_exports__ });
+		const hot_parent = __rolldown_runtime__.createModuleHotContext("$CWD/parent.js");
+		var import_child_00 = __rolldown_runtime__.loadExports("$CWD/child.js");
 		const parentValue = "parent";
 		assert.strictEqual(parentValue, "parent");
 		assert.strictEqual(import_child_00.value, "child");
@@ -154,7 +154,7 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_parent_0()
-__rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/parent.js', '$CWD/parent.js']]);
 ```
 
 ## Meta
@@ -163,4 +163,4 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 
 ### Hmr Boundaries
 
-- boundary: parent.js, accepted_via: parent.js
+- boundary: $CWD/parent.js, accepted_via: $CWD/parent.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_used/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_used/artifacts.snap
@@ -10,8 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region child.js
 var child_exports = /* @__PURE__ */ __exportAll({ value: () => value });
-const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
-__rolldown_runtime__.registerModule("child.js", { exports: child_exports });
+const child_hot = __rolldown_runtime__.createModuleHotContext("$CWD/child.js");
+__rolldown_runtime__.registerModule("$CWD/child.js", { exports: child_exports });
 const value = "child";
 
 //#endregion
@@ -20,8 +20,8 @@ var parent_exports = /* @__PURE__ */ __exportAll({
 	childValue: () => value,
 	parentValue: () => parentValue
 });
-const parent_hot = __rolldown_runtime__.createModuleHotContext("parent.js");
-__rolldown_runtime__.registerModule("parent.js", { exports: parent_exports });
+const parent_hot = __rolldown_runtime__.createModuleHotContext("$CWD/parent.js");
+__rolldown_runtime__.registerModule("$CWD/parent.js", { exports: parent_exports });
 const parentValue = "parent";
 parent_hot.accept((newMod) => {
 	const { childValue, parentValue: parentValue$1 } = newMod;
@@ -32,8 +32,8 @@ parent_hot.accept((newMod) => {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 
 //#endregion
 ```
@@ -50,9 +50,9 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 			parentValue: () => parentValue,
 			childValue: () => import_child_00.value
 		});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
-		var import_child_00 = __rolldown_runtime__.loadExports("child.js");
+		__rolldown_runtime__.registerModule("$CWD/parent.js", { exports: __rolldown_exports__ });
+		const hot_parent = __rolldown_runtime__.createModuleHotContext("$CWD/parent.js");
+		var import_child_00 = __rolldown_runtime__.loadExports("$CWD/child.js");
 		const parentValue = "parent";
 		hot_parent.accept((newMod) => {
 			const { childValue, parentValue } = newMod;
@@ -64,7 +64,7 @@ var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_parent_0()
-__rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/parent.js', '$CWD/parent.js']]);
 ```
 
 ## Meta
@@ -73,7 +73,7 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 
 ### Hmr Boundaries
 
-- boundary: parent.js, accepted_via: parent.js
+- boundary: $CWD/parent.js, accepted_via: $CWD/parent.js
 
 # HMR Step 1
 
@@ -84,8 +84,8 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
-		__rolldown_runtime__.registerModule("child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("child.js");
+		__rolldown_runtime__.registerModule("$CWD/child.js", { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext("$CWD/child.js");
 		const value = "child";
 	} finally {}
 }));
@@ -98,10 +98,10 @@ var init_parent_1 = __rolldown_runtime__.createEsmInitializer((function() {
 			parentValue: () => parentValue,
 			childValue: () => import_child_10.value
 		});
-		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/parent.js", { exports: __rolldown_exports__ });
 		init_child_0();
-		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
-		var import_child_10 = __rolldown_runtime__.loadExports("child.js");
+		const hot_parent = __rolldown_runtime__.createModuleHotContext("$CWD/parent.js");
+		var import_child_10 = __rolldown_runtime__.loadExports("$CWD/child.js");
 		const parentValue = "parent";
 		hot_parent.accept((newMod) => {
 			const { childValue, parentValue } = newMod;
@@ -113,7 +113,7 @@ var init_parent_1 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_parent_1()
-__rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/parent.js', '$CWD/parent.js']]);
 ```
 
 ## Meta
@@ -122,4 +122,4 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 
 ### Hmr Boundaries
 
-- boundary: parent.js, accepted_via: parent.js
+- boundary: $CWD/parent.js, accepted_via: $CWD/parent.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -10,8 +10,8 @@ import { t as __commonJSMin } from "./main.js";
 
 //#region exist-dep-cjs.js
 var require_exist_dep_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const exist_dep_cjs_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-cjs.js");
-	__rolldown_runtime__.registerModule("exist-dep-cjs.js", module);
+	const exist_dep_cjs_hot = __rolldown_runtime__.createModuleHotContext("$CWD/exist-dep-cjs.js");
+	__rolldown_runtime__.registerModule("$CWD/exist-dep-cjs.js", module);
 	exports.value = "exist-cjs";
 }));
 
@@ -27,8 +27,8 @@ import { n as __exportAll } from "./main.js";
 
 //#region exist-dep-esm.js
 var exist_dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
-const exist_dep_esm_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
-__rolldown_runtime__.registerModule("exist-dep-esm.js", { exports: exist_dep_esm_exports });
+const exist_dep_esm_hot = __rolldown_runtime__.createModuleHotContext("$CWD/exist-dep-esm.js");
+__rolldown_runtime__.registerModule("$CWD/exist-dep-esm.js", { exports: exist_dep_esm_exports });
 const value = "exist-esm";
 
 //#endregion
@@ -42,8 +42,8 @@ export { value };
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
 var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
-const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
-__rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+const hmr_hot = __rolldown_runtime__.createModuleHotContext("$CWD/hmr.js");
+__rolldown_runtime__.registerModule("$CWD/hmr.js", { exports: hmr_exports });
 async function foo() {
 	await import("./exist-dep-cjs.js").then(__toDynamicImportESM()).then(console.log);
 	await import("./exist-dep-esm.js").then(console.log);
@@ -57,8 +57,8 @@ hmr_hot.accept((mod) => {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 
 //#endregion
 export { __exportAll as n, __commonJSMin as t };
@@ -76,15 +76,15 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 			foo: () => foo,
 			bar: () => bar
 		});
-		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
-		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
+		__rolldown_runtime__.registerModule("$CWD/hmr.js", { exports: __rolldown_exports__ });
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext("$CWD/hmr.js");
 		async function foo() {
-			await Promise.resolve().then(() => __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports("exist-dep-cjs.js"))).then(console.log);
-			await Promise.resolve().then(() => __rolldown_runtime__.loadExports("exist-dep-esm.js")).then(console.log);
+			await Promise.resolve().then(() => __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports("$CWD/exist-dep-cjs.js"))).then(console.log);
+			await Promise.resolve().then(() => __rolldown_runtime__.loadExports("$CWD/exist-dep-esm.js")).then(console.log);
 		}
 		async function bar() {
-			await (require_new_dep_cjs_1(), Promise.resolve().then(() => __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports("new-dep-cjs.js")))).then(console.log);
-			await (init_new_dep_esm_2(), Promise.resolve().then(() => __rolldown_runtime__.loadExports("new-dep-esm.js"))).then(console.log);
+			await (require_new_dep_cjs_1(), Promise.resolve().then(() => __rolldown_runtime__.__toDynamicImportESM(__rolldown_runtime__.loadExports("$CWD/new-dep-cjs.js")))).then(console.log);
+			await (init_new_dep_esm_2(), Promise.resolve().then(() => __rolldown_runtime__.loadExports("$CWD/new-dep-esm.js"))).then(console.log);
 		}
 		hot_hmr.accept((mod) => {
 			if (mod) {
@@ -98,8 +98,8 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region new-dep-cjs.js
 var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
 	try {
-		__rolldown_runtime__.registerModule("new-dep-cjs.js", __rolldown_module__);
-		const hot_new_dep_cjs = __rolldown_runtime__.createModuleHotContext("new-dep-cjs.js");
+		__rolldown_runtime__.registerModule("$CWD/new-dep-cjs.js", __rolldown_module__);
+		const hot_new_dep_cjs = __rolldown_runtime__.createModuleHotContext("$CWD/new-dep-cjs.js");
 		__rolldown_exports__.value = "new-cjs";
 	} finally {}
 }));
@@ -109,15 +109,15 @@ var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer((function(
 var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
-		__rolldown_runtime__.registerModule("new-dep-esm.js", { exports: __rolldown_exports__ });
-		const hot_new_dep_esm = __rolldown_runtime__.createModuleHotContext("new-dep-esm.js");
+		__rolldown_runtime__.registerModule("$CWD/new-dep-esm.js", { exports: __rolldown_exports__ });
+		const hot_new_dep_esm = __rolldown_runtime__.createModuleHotContext("$CWD/new-dep-esm.js");
 		const value = "new-esm";
 	} finally {}
 }));
 
 //#endregion
 init_hmr_0()
-__rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/hmr.js', '$CWD/hmr.js']]);
 ```
 
 ## Meta
@@ -126,4 +126,4 @@ __rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 
 ### Hmr Boundaries
 
-- boundary: hmr.js, accepted_via: hmr.js
+- boundary: $CWD/hmr.js, accepted_via: $CWD/hmr.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_initial_build_syntax_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_initial_build_syntax_error/artifacts.snap
@@ -31,8 +31,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 console.log("main.js");
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
@@ -10,8 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region dep.js
 var dep_exports = /* @__PURE__ */ __exportAll({ value: () => value });
-const dep_hot = __rolldown_runtime__.createModuleHotContext("dep.js");
-__rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
+const dep_hot = __rolldown_runtime__.createModuleHotContext("$CWD/dep.js");
+__rolldown_runtime__.registerModule("$CWD/dep.js", { exports: dep_exports });
 const value = "dep";
 if (dep_hot) {
 	dep_hot.accept();
@@ -20,8 +20,8 @@ if (dep_hot) {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 console.log(value);
 
 //#endregion
@@ -78,8 +78,8 @@ console.log(value);
 // HIDDEN [rolldown:hmr]
 //#region dep.js
 var dep_exports = /* @__PURE__ */ __exportAll({ value: () => value });
-const dep_hot = __rolldown_runtime__.createModuleHotContext("dep.js");
-__rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
+const dep_hot = __rolldown_runtime__.createModuleHotContext("$CWD/dep.js");
+__rolldown_runtime__.registerModule("$CWD/dep.js", { exports: dep_exports });
 const value = "dep";
 if (dep_hot) {
 	dep_hot.accept();
@@ -88,8 +88,8 @@ if (dep_hot) {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 console.log(value);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/artifacts.snap
@@ -10,22 +10,22 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region a.js
 var a_exports = {};
-const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
-__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+const a_hot = __rolldown_runtime__.createModuleHotContext("$CWD/a.js");
+__rolldown_runtime__.registerModule("$CWD/a.js", { exports: a_exports });
 console.log("a");
 
 //#endregion
 //#region b.js
 var b_exports = {};
-const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
-__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+const b_hot = __rolldown_runtime__.createModuleHotContext("$CWD/b.js");
+__rolldown_runtime__.registerModule("$CWD/b.js", { exports: b_exports });
 console.log("b");
 
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
@@ -13,8 +13,8 @@ var foo_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	named: () => named$2
 });
-const foo_hot = __rolldown_runtime__.createModuleHotContext("sub/foo.js");
-__rolldown_runtime__.registerModule("sub/foo.js", { exports: foo_exports });
+const foo_hot = __rolldown_runtime__.createModuleHotContext("$CWD/sub/foo.js");
+__rolldown_runtime__.registerModule("$CWD/sub/foo.js", { exports: foo_exports });
 const foo = "foo";
 const named$2 = "foo";
 
@@ -24,16 +24,16 @@ var bar_exports = /* @__PURE__ */ __exportAll({
 	bar: () => bar,
 	named: () => named$1
 });
-const bar_hot = __rolldown_runtime__.createModuleHotContext("sub/bar.js");
-__rolldown_runtime__.registerModule("sub/bar.js", { exports: bar_exports });
+const bar_hot = __rolldown_runtime__.createModuleHotContext("$CWD/sub/bar.js");
+__rolldown_runtime__.registerModule("$CWD/sub/bar.js", { exports: bar_exports });
 const bar = "bar";
 const named$1 = "bar";
 
 //#endregion
 //#region sub/named.js
 var named_exports = /* @__PURE__ */ __exportAll({ named: () => named });
-const named_hot = __rolldown_runtime__.createModuleHotContext("sub/named.js");
-__rolldown_runtime__.registerModule("sub/named.js", { exports: named_exports });
+const named_hot = __rolldown_runtime__.createModuleHotContext("$CWD/sub/named.js");
+__rolldown_runtime__.registerModule("$CWD/sub/named.js", { exports: named_exports });
 const named = "named";
 
 //#endregion
@@ -43,22 +43,22 @@ var sub_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	named: () => named
 });
-const sub_hot = __rolldown_runtime__.createModuleHotContext("sub/index.js");
-__rolldown_runtime__.registerModule("sub/index.js", { exports: sub_exports });
+const sub_hot = __rolldown_runtime__.createModuleHotContext("$CWD/sub/index.js");
+__rolldown_runtime__.registerModule("$CWD/sub/index.js", { exports: sub_exports });
 
 //#endregion
 //#region hmr.js
 var hmr_exports = {};
-const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
-__rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+const hmr_hot = __rolldown_runtime__.createModuleHotContext("$CWD/hmr.js");
+__rolldown_runtime__.registerModule("$CWD/hmr.js", { exports: hmr_exports });
 console.log(foo, bar);
 hmr_hot.accept();
 
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 text(".app", "hello");
 function text(el, text$1) {
 	console.log(el, text$1);
@@ -77,9 +77,9 @@ import * as import_node_assert_00 from "node:assert";
 var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
-		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
-		var import_sub_01 = __rolldown_runtime__.loadExports("sub/index.js");
+		__rolldown_runtime__.registerModule("$CWD/hmr.js", { exports: __rolldown_exports__ });
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext("$CWD/hmr.js");
+		var import_sub_01 = __rolldown_runtime__.loadExports("$CWD/sub/index.js");
 		import_node_assert_00.default.strictEqual(import_sub_01.foo, "foo");
 		import_node_assert_00.default.strictEqual(import_sub_01.bar, "bar");
 		import_node_assert_00.default.strictEqual(import_sub_01.named, "named");
@@ -89,7 +89,7 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_hmr_0()
-__rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/hmr.js', '$CWD/hmr.js']]);
 ```
 
 ## Meta
@@ -98,4 +98,4 @@ __rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 
 ### Hmr Boundaries
 
-- boundary: hmr.js, accepted_via: hmr.js
+- boundary: $CWD/hmr.js, accepted_via: $CWD/hmr.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -10,8 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
 var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
-const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
-__rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+const hmr_hot = __rolldown_runtime__.createModuleHotContext("$CWD/hmr.js");
+__rolldown_runtime__.registerModule("$CWD/hmr.js", { exports: hmr_exports });
 const foo = "hello";
 text$1(".hmr", foo);
 function text$1(el, text$2) {
@@ -26,8 +26,8 @@ hmr_hot.accept((mod) => {
 //#endregion
 //#region sub.js
 var sub_exports = {};
-const sub_hot = __rolldown_runtime__.createModuleHotContext("sub.js");
-__rolldown_runtime__.registerModule("sub.js", { exports: sub_exports });
+const sub_hot = __rolldown_runtime__.createModuleHotContext("$CWD/sub.js");
+__rolldown_runtime__.registerModule("$CWD/sub.js", { exports: sub_exports });
 text(".app", "hello");
 function text(el, text$2) {
 	console.log(el, text$2);
@@ -36,8 +36,8 @@ function text(el, text$2) {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 
 //#endregion
 ```
@@ -68,8 +68,8 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
-		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
+		__rolldown_runtime__.registerModule("$CWD/hmr.js", { exports: __rolldown_exports__ });
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext("$CWD/hmr.js");
 		const foo = "hello";
 		text(".hmr", foo);
 		function text(el, text) {
@@ -85,7 +85,7 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_hmr_0()
-__rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/hmr.js', '$CWD/hmr.js']]);
 ```
 
 ## Meta
@@ -94,4 +94,4 @@ __rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 
 ### Hmr Boundaries
 
-- boundary: hmr.js, accepted_via: hmr.js
+- boundary: $CWD/hmr.js, accepted_via: $CWD/hmr.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
@@ -12,8 +12,8 @@ import assert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region self_accept.js
 var self_accept_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
-const self_accept_hot = __rolldown_runtime__.createModuleHotContext("self_accept.js");
-__rolldown_runtime__.registerModule("self_accept.js", { exports: self_accept_exports });
+const self_accept_hot = __rolldown_runtime__.createModuleHotContext("$CWD/self_accept.js");
+__rolldown_runtime__.registerModule("$CWD/self_accept.js", { exports: self_accept_exports });
 const foo$1 = "foo";
 self_accept_hot.accept((mod) => {
 	assert.strictEqual(mod.foo, "foo");
@@ -22,21 +22,21 @@ self_accept_hot.accept((mod) => {
 //#endregion
 //#region single_accept/child.js
 var child_exports$1 = /* @__PURE__ */ __exportAll({ count: () => count$3 });
-const child_hot$1 = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
-__rolldown_runtime__.registerModule("single_accept/child.js", { exports: child_exports$1 });
+const child_hot$1 = __rolldown_runtime__.createModuleHotContext("$CWD/single_accept/child.js");
+__rolldown_runtime__.registerModule("$CWD/single_accept/child.js", { exports: child_exports$1 });
 const count$3 = 0;
 
 //#endregion
 //#region single_accept/parent.js
 var parent_exports$1 = {};
-const parent_hot$1 = __rolldown_runtime__.createModuleHotContext("single_accept/parent.js");
-__rolldown_runtime__.registerModule("single_accept/parent.js", { exports: parent_exports$1 });
+const parent_hot$1 = __rolldown_runtime__.createModuleHotContext("$CWD/single_accept/parent.js");
+__rolldown_runtime__.registerModule("$CWD/single_accept/parent.js", { exports: parent_exports$1 });
 globalThis.singleAcceptAcceptCount ??= 0;
 globalThis.singleAcceptParentExecuteCount ??= 0;
 globalThis.singleAcceptParentExecuteCount++;
 assert.strictEqual(globalThis.singleAcceptParentExecuteCount, 1);
 let count$2 = count$3;
-parent_hot$1.accept("single_accept/child.js", (mod) => {
+parent_hot$1.accept("$CWD/single_accept/child.js", (mod) => {
 	count$2 = mod.count;
 	globalThis.singleAcceptAcceptCount++;
 	assert.strictEqual(globalThis.singleAcceptAcceptCount, count$2);
@@ -49,21 +49,21 @@ process.on("beforeExit", (code) => {
 //#endregion
 //#region array_accept/child.js
 var child_exports = /* @__PURE__ */ __exportAll({ count: () => count$1 });
-const child_hot = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
-__rolldown_runtime__.registerModule("array_accept/child.js", { exports: child_exports });
+const child_hot = __rolldown_runtime__.createModuleHotContext("$CWD/array_accept/child.js");
+__rolldown_runtime__.registerModule("$CWD/array_accept/child.js", { exports: child_exports });
 const count$1 = 0;
 
 //#endregion
 //#region array_accept/parent.js
 var parent_exports = {};
-const parent_hot = __rolldown_runtime__.createModuleHotContext("array_accept/parent.js");
-__rolldown_runtime__.registerModule("array_accept/parent.js", { exports: parent_exports });
+const parent_hot = __rolldown_runtime__.createModuleHotContext("$CWD/array_accept/parent.js");
+__rolldown_runtime__.registerModule("$CWD/array_accept/parent.js", { exports: parent_exports });
 globalThis.arrayAcceptAcceptCount ??= 0;
 globalThis.arrayAcceptParentExecuteCount ??= 0;
 globalThis.arrayAcceptParentExecuteCount++;
 assert.strictEqual(globalThis.arrayAcceptParentExecuteCount, 1);
 let count = count$1;
-parent_hot.accept(["array_accept/child.js"], ([mod]) => {
+parent_hot.accept(["$CWD/array_accept/child.js"], ([mod]) => {
 	count = mod.count;
 	globalThis.arrayAcceptAcceptCount++;
 	assert.strictEqual(globalThis.arrayAcceptAcceptCount, count);
@@ -76,8 +76,8 @@ process.on("beforeExit", (code) => {
 //#endregion
 //#region optional_chaining.js
 var optional_chaining_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
-const optional_chaining_hot = __rolldown_runtime__.createModuleHotContext("optional_chaining.js");
-__rolldown_runtime__.registerModule("optional_chaining.js", { exports: optional_chaining_exports });
+const optional_chaining_hot = __rolldown_runtime__.createModuleHotContext("$CWD/optional_chaining.js");
+__rolldown_runtime__.registerModule("$CWD/optional_chaining.js", { exports: optional_chaining_exports });
 const foo = "foo";
 optional_chaining_hot?.accept((mod) => {
 	assert.strictEqual(mod.foo, "foo");
@@ -86,8 +86,8 @@ optional_chaining_hot?.accept((mod) => {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 
 //#endregion
 ```
@@ -102,8 +102,8 @@ import * as import_node_assert_00 from "node:assert";
 var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("self_accept.js", { exports: __rolldown_exports__ });
-		const hot_self_accept = __rolldown_runtime__.createModuleHotContext("self_accept.js");
+		__rolldown_runtime__.registerModule("$CWD/self_accept.js", { exports: __rolldown_exports__ });
+		const hot_self_accept = __rolldown_runtime__.createModuleHotContext("$CWD/self_accept.js");
 		const foo = "foo2";
 		hot_self_accept.accept((mod) => {
 			import_node_assert_00.default.strictEqual(mod.foo, "foo2");
@@ -113,7 +113,7 @@ var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_self_accept_0()
-__rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/self_accept.js', '$CWD/self_accept.js']]);
 ```
 
 ## Meta
@@ -122,7 +122,7 @@ __rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
 
 ### Hmr Boundaries
 
-- boundary: self_accept.js, accepted_via: self_accept.js
+- boundary: $CWD/self_accept.js, accepted_via: $CWD/self_accept.js
 
 # HMR Step 1
 
@@ -134,8 +134,8 @@ import * as import_node_assert_00 from "node:assert";
 var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("self_accept.js", { exports: __rolldown_exports__ });
-		const hot_self_accept = __rolldown_runtime__.createModuleHotContext("self_accept.js");
+		__rolldown_runtime__.registerModule("$CWD/self_accept.js", { exports: __rolldown_exports__ });
+		const hot_self_accept = __rolldown_runtime__.createModuleHotContext("$CWD/self_accept.js");
 		const foo = "foo3";
 		hot_self_accept.accept((mod) => {
 			import_node_assert_00.default.strictEqual(mod.foo, "foo3");
@@ -145,7 +145,7 @@ var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_self_accept_0()
-__rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/self_accept.js', '$CWD/self_accept.js']]);
 ```
 
 ## Meta
@@ -154,7 +154,7 @@ __rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
 
 ### Hmr Boundaries
 
-- boundary: self_accept.js, accepted_via: self_accept.js
+- boundary: $CWD/self_accept.js, accepted_via: $CWD/self_accept.js
 
 # HMR Step 2
 
@@ -165,15 +165,15 @@ __rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
-		__rolldown_runtime__.registerModule("single_accept/child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
+		__rolldown_runtime__.registerModule("$CWD/single_accept/child.js", { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext("$CWD/single_accept/child.js");
 		const count = 1;
 	} finally {}
 }));
 
 //#endregion
 init_child_0()
-__rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/child.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/single_accept/parent.js', '$CWD/single_accept/child.js']]);
 ```
 
 ## Meta
@@ -182,7 +182,7 @@ __rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/ch
 
 ### Hmr Boundaries
 
-- boundary: single_accept/parent.js, accepted_via: single_accept/child.js
+- boundary: $CWD/single_accept/parent.js, accepted_via: $CWD/single_accept/child.js
 
 # HMR Step 3
 
@@ -193,15 +193,15 @@ __rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/ch
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
-		__rolldown_runtime__.registerModule("single_accept/child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
+		__rolldown_runtime__.registerModule("$CWD/single_accept/child.js", { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext("$CWD/single_accept/child.js");
 		const count = 2;
 	} finally {}
 }));
 
 //#endregion
 init_child_0()
-__rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/child.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/single_accept/parent.js', '$CWD/single_accept/child.js']]);
 ```
 
 ## Meta
@@ -210,7 +210,7 @@ __rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/ch
 
 ### Hmr Boundaries
 
-- boundary: single_accept/parent.js, accepted_via: single_accept/child.js
+- boundary: $CWD/single_accept/parent.js, accepted_via: $CWD/single_accept/child.js
 
 # HMR Step 4
 
@@ -221,15 +221,15 @@ __rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/ch
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
-		__rolldown_runtime__.registerModule("array_accept/child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
+		__rolldown_runtime__.registerModule("$CWD/array_accept/child.js", { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext("$CWD/array_accept/child.js");
 		const count = 1;
 	} finally {}
 }));
 
 //#endregion
 init_child_0()
-__rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/child.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/array_accept/parent.js', '$CWD/array_accept/child.js']]);
 ```
 
 ## Meta
@@ -238,7 +238,7 @@ __rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/chil
 
 ### Hmr Boundaries
 
-- boundary: array_accept/parent.js, accepted_via: array_accept/child.js
+- boundary: $CWD/array_accept/parent.js, accepted_via: $CWD/array_accept/child.js
 
 # HMR Step 5
 
@@ -249,15 +249,15 @@ __rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/chil
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
-		__rolldown_runtime__.registerModule("array_accept/child.js", { exports: __rolldown_exports__ });
-		const hot_child = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
+		__rolldown_runtime__.registerModule("$CWD/array_accept/child.js", { exports: __rolldown_exports__ });
+		const hot_child = __rolldown_runtime__.createModuleHotContext("$CWD/array_accept/child.js");
 		const count = 2;
 	} finally {}
 }));
 
 //#endregion
 init_child_0()
-__rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/child.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/array_accept/parent.js', '$CWD/array_accept/child.js']]);
 ```
 
 ## Meta
@@ -266,7 +266,7 @@ __rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/chil
 
 ### Hmr Boundaries
 
-- boundary: array_accept/parent.js, accepted_via: array_accept/child.js
+- boundary: $CWD/array_accept/parent.js, accepted_via: $CWD/array_accept/child.js
 
 # HMR Step 6
 
@@ -278,8 +278,8 @@ import * as import_node_assert_00 from "node:assert";
 var init_optional_chaining_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("optional_chaining.js", { exports: __rolldown_exports__ });
-		const hot_optional_chaining = __rolldown_runtime__.createModuleHotContext("optional_chaining.js");
+		__rolldown_runtime__.registerModule("$CWD/optional_chaining.js", { exports: __rolldown_exports__ });
+		const hot_optional_chaining = __rolldown_runtime__.createModuleHotContext("$CWD/optional_chaining.js");
 		const foo = "foo2";
 		hot_optional_chaining?.accept((mod) => {
 			import_node_assert_00.default.strictEqual(mod.foo, "foo2");
@@ -289,7 +289,7 @@ var init_optional_chaining_0 = __rolldown_runtime__.createEsmInitializer((functi
 
 //#endregion
 init_optional_chaining_0()
-__rolldown_runtime__.applyUpdates([['optional_chaining.js', 'optional_chaining.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/optional_chaining.js', '$CWD/optional_chaining.js']]);
 ```
 
 ## Meta
@@ -298,4 +298,4 @@ __rolldown_runtime__.applyUpdates([['optional_chaining.js', 'optional_chaining.j
 
 ### Hmr Boundaries
 
-- boundary: optional_chaining.js, accepted_via: optional_chaining.js
+- boundary: $CWD/optional_chaining.js, accepted_via: $CWD/optional_chaining.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_4818/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_4818/artifacts.snap
@@ -13,16 +13,16 @@ var foo_exports = /* @__PURE__ */ __exportAll({
 	default: () => foo_default,
 	foo: () => foo
 });
-const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.json");
-__rolldown_runtime__.registerModule("foo.json", { exports: foo_exports });
+const foo_hot = __rolldown_runtime__.createModuleHotContext("$CWD/foo.json");
+__rolldown_runtime__.registerModule("$CWD/foo.json", { exports: foo_exports });
 var foo = "__EXP__";
 var foo_default = { foo };
 
 //#endregion
 //#region main.js
 var main_exports = /* @__PURE__ */ __exportAll({ default: () => main_default });
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 var main_default = foo_default;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
@@ -10,22 +10,22 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region common.js
 var common_exports = /* @__PURE__ */ __exportAll({ prefix: () => prefix });
-const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
-__rolldown_runtime__.registerModule("common.js", { exports: common_exports });
+const common_hot = __rolldown_runtime__.createModuleHotContext("$CWD/common.js");
+__rolldown_runtime__.registerModule("$CWD/common.js", { exports: common_exports });
 const prefix = "prefix:";
 
 //#endregion
 //#region foo.js
 var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
-const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
-__rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
+const foo_hot = __rolldown_runtime__.createModuleHotContext("$CWD/foo.js");
+__rolldown_runtime__.registerModule("$CWD/foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
 
 //#endregion
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
-const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
-__rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
+const bar_hot = __rolldown_runtime__.createModuleHotContext("$CWD/bar.js");
+__rolldown_runtime__.registerModule("$CWD/bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
 
 //#endregion
@@ -34,8 +34,8 @@ var messenger_exports = /* @__PURE__ */ __exportAll({
 	msg: () => msg,
 	sayMessage: () => sayMessage
 });
-const messenger_hot = __rolldown_runtime__.createModuleHotContext("messenger.js");
-__rolldown_runtime__.registerModule("messenger.js", { exports: messenger_exports });
+const messenger_hot = __rolldown_runtime__.createModuleHotContext("$CWD/messenger.js");
+__rolldown_runtime__.registerModule("$CWD/messenger.js", { exports: messenger_exports });
 let msg = [
 	prefix,
 	foo,
@@ -56,8 +56,8 @@ if (messenger_hot) {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 sayMessage();
 
 //#endregion
@@ -72,9 +72,9 @@ sayMessage();
 var init_foo_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("foo.js", { exports: __rolldown_exports__ });
-		const hot_foo = __rolldown_runtime__.createModuleHotContext("foo.js");
-		var import_common_00 = __rolldown_runtime__.loadExports("common.js");
+		__rolldown_runtime__.registerModule("$CWD/foo.js", { exports: __rolldown_exports__ });
+		const hot_foo = __rolldown_runtime__.createModuleHotContext("$CWD/foo.js");
+		var import_common_00 = __rolldown_runtime__.loadExports("$CWD/common.js");
 		const foo = import_common_00.prefix + "foo-new";
 	} finally {}
 }));
@@ -87,12 +87,12 @@ var init_messenger_1 = __rolldown_runtime__.createEsmInitializer((function() {
 			msg: () => msg,
 			sayMessage: () => sayMessage
 		});
-		__rolldown_runtime__.registerModule("messenger.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/messenger.js", { exports: __rolldown_exports__ });
 		init_foo_0();
-		const hot_messenger = __rolldown_runtime__.createModuleHotContext("messenger.js");
-		var import_foo_10 = __rolldown_runtime__.loadExports("foo.js");
-		var import_bar_11 = __rolldown_runtime__.loadExports("bar.js");
-		var import_common_12 = __rolldown_runtime__.loadExports("common.js");
+		const hot_messenger = __rolldown_runtime__.createModuleHotContext("$CWD/messenger.js");
+		var import_foo_10 = __rolldown_runtime__.loadExports("$CWD/foo.js");
+		var import_bar_11 = __rolldown_runtime__.loadExports("$CWD/bar.js");
+		var import_common_12 = __rolldown_runtime__.loadExports("$CWD/common.js");
 		let msg = [
 			import_common_12.prefix,
 			import_foo_10.foo,
@@ -114,7 +114,7 @@ var init_messenger_1 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_messenger_1()
-__rolldown_runtime__.applyUpdates([['messenger.js', 'messenger.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/messenger.js', '$CWD/messenger.js']]);
 ```
 
 ## Meta
@@ -123,4 +123,4 @@ __rolldown_runtime__.applyUpdates([['messenger.js', 'messenger.js']]);
 
 ### Hmr Boundaries
 
-- boundary: messenger.js, accepted_via: messenger.js
+- boundary: $CWD/messenger.js, accepted_via: $CWD/messenger.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
@@ -10,22 +10,22 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region common.js
 var common_exports = /* @__PURE__ */ __exportAll({ prefix: () => prefix });
-const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
-__rolldown_runtime__.registerModule("common.js", { exports: common_exports });
+const common_hot = __rolldown_runtime__.createModuleHotContext("$CWD/common.js");
+__rolldown_runtime__.registerModule("$CWD/common.js", { exports: common_exports });
 const prefix = "prefix:";
 
 //#endregion
 //#region foo.js
 var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
-const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
-__rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
+const foo_hot = __rolldown_runtime__.createModuleHotContext("$CWD/foo.js");
+__rolldown_runtime__.registerModule("$CWD/foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
 
 //#endregion
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
-const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
-__rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
+const bar_hot = __rolldown_runtime__.createModuleHotContext("$CWD/bar.js");
+__rolldown_runtime__.registerModule("$CWD/bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
 
 //#endregion
@@ -34,8 +34,8 @@ var messenger_exports = /* @__PURE__ */ __exportAll({
 	msg: () => msg,
 	sayMessage: () => sayMessage
 });
-const messenger_hot = __rolldown_runtime__.createModuleHotContext("messenger.js");
-__rolldown_runtime__.registerModule("messenger.js", { exports: messenger_exports });
+const messenger_hot = __rolldown_runtime__.createModuleHotContext("$CWD/messenger.js");
+__rolldown_runtime__.registerModule("$CWD/messenger.js", { exports: messenger_exports });
 let msg = [
 	prefix,
 	foo,
@@ -56,8 +56,8 @@ if (messenger_hot) {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 setInterval(sayMessage, 1e3);
 
 //#endregion
@@ -72,10 +72,10 @@ setInterval(sayMessage, 1e3);
 var init_bar_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ bar: () => bar });
-		__rolldown_runtime__.registerModule("bar.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/bar.js", { exports: __rolldown_exports__ });
 		init_common_1();
-		const hot_bar = __rolldown_runtime__.createModuleHotContext("bar.js");
-		var import_common_00 = __rolldown_runtime__.loadExports("common.js");
+		const hot_bar = __rolldown_runtime__.createModuleHotContext("$CWD/bar.js");
+		var import_common_00 = __rolldown_runtime__.loadExports("$CWD/common.js");
 		const bar = import_common_00.prefix + "bar";
 	} finally {}
 }));
@@ -85,8 +85,8 @@ var init_bar_0 = __rolldown_runtime__.createEsmInitializer((function() {
 var init_common_1 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ prefix: () => prefix });
-		__rolldown_runtime__.registerModule("common.js", { exports: __rolldown_exports__ });
-		const hot_common = __rolldown_runtime__.createModuleHotContext("common.js");
+		__rolldown_runtime__.registerModule("$CWD/common.js", { exports: __rolldown_exports__ });
+		const hot_common = __rolldown_runtime__.createModuleHotContext("$CWD/common.js");
 		const prefix = "prefix-new:";
 	} finally {}
 }));
@@ -96,10 +96,10 @@ var init_common_1 = __rolldown_runtime__.createEsmInitializer((function() {
 var init_foo_2 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("foo.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/foo.js", { exports: __rolldown_exports__ });
 		init_common_1();
-		const hot_foo = __rolldown_runtime__.createModuleHotContext("foo.js");
-		var import_common_20 = __rolldown_runtime__.loadExports("common.js");
+		const hot_foo = __rolldown_runtime__.createModuleHotContext("$CWD/foo.js");
+		var import_common_20 = __rolldown_runtime__.loadExports("$CWD/common.js");
 		const foo = import_common_20.prefix + "foo";
 	} finally {}
 }));
@@ -112,14 +112,14 @@ var init_messenger_3 = __rolldown_runtime__.createEsmInitializer((function() {
 			msg: () => msg,
 			sayMessage: () => sayMessage
 		});
-		__rolldown_runtime__.registerModule("messenger.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/messenger.js", { exports: __rolldown_exports__ });
 		init_foo_2();
 		init_bar_0();
 		init_common_1();
-		const hot_messenger = __rolldown_runtime__.createModuleHotContext("messenger.js");
-		var import_foo_30 = __rolldown_runtime__.loadExports("foo.js");
-		var import_bar_31 = __rolldown_runtime__.loadExports("bar.js");
-		var import_common_32 = __rolldown_runtime__.loadExports("common.js");
+		const hot_messenger = __rolldown_runtime__.createModuleHotContext("$CWD/messenger.js");
+		var import_foo_30 = __rolldown_runtime__.loadExports("$CWD/foo.js");
+		var import_bar_31 = __rolldown_runtime__.loadExports("$CWD/bar.js");
+		var import_common_32 = __rolldown_runtime__.loadExports("$CWD/common.js");
 		let msg = [
 			import_common_32.prefix,
 			import_foo_30.foo,
@@ -141,7 +141,7 @@ var init_messenger_3 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_messenger_3()
-__rolldown_runtime__.applyUpdates([['messenger.js', 'messenger.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/messenger.js', '$CWD/messenger.js']]);
 ```
 
 ## Meta
@@ -150,4 +150,4 @@ __rolldown_runtime__.applyUpdates([['messenger.js', 'messenger.js']]);
 
 ### Hmr Boundaries
 
-- boundary: messenger.js, accepted_via: messenger.js
+- boundary: $CWD/messenger.js, accepted_via: $CWD/messenger.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -11,8 +11,8 @@ import { t as trim } from "./string.js";
 
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __exportAll({ default: () => bar_default });
-const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
-__rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
+const bar_hot = __rolldown_runtime__.createModuleHotContext("$CWD/bar.js");
+__rolldown_runtime__.registerModule("$CWD/bar.js", { exports: bar_exports });
 function bar_default() {
 	return trim("Route Bar");
 }
@@ -32,14 +32,14 @@ var utils_exports = /* @__PURE__ */ __exportAll({
 	trim: () => trim,
 	unused: () => unused
 });
-const utils_hot = __rolldown_runtime__.createModuleHotContext("utils/index.js");
-__rolldown_runtime__.registerModule("utils/index.js", { exports: utils_exports });
+const utils_hot = __rolldown_runtime__.createModuleHotContext("$CWD/utils/index.js");
+__rolldown_runtime__.registerModule("$CWD/utils/index.js", { exports: utils_exports });
 
 //#endregion
 //#region foo.js
 var foo_exports = /* @__PURE__ */ __exportAll({ default: () => foo_default });
-const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
-__rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
+const foo_hot = __rolldown_runtime__.createModuleHotContext("$CWD/foo.js");
+__rolldown_runtime__.registerModule("$CWD/foo.js", { exports: foo_exports });
 function foo_default() {
 	return trim("Route Foo");
 }
@@ -55,8 +55,8 @@ export { foo_default as default };
 // HIDDEN [rolldown:hmr]
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 const routes = {
 	foo: import("./foo.js"),
 	bar: import("./bar.js")
@@ -76,8 +76,8 @@ var string_exports = /* @__PURE__ */ __exportAll({
 	trim: () => trim,
 	unused: () => unused
 });
-const string_hot = __rolldown_runtime__.createModuleHotContext("utils/string.js");
-__rolldown_runtime__.registerModule("utils/string.js", { exports: string_exports });
+const string_hot = __rolldown_runtime__.createModuleHotContext("$CWD/utils/string.js");
+__rolldown_runtime__.registerModule("$CWD/utils/string.js", { exports: string_exports });
 function trim(s) {
 	return s.trim();
 }

--- a/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
@@ -10,8 +10,8 @@ import "./rolldown_hmr.js";
 
 //#region entry.js
 var entry_exports = {};
-const entry_hot = __rolldown_runtime__.createModuleHotContext("entry.js");
-__rolldown_runtime__.registerModule("entry.js", { exports: entry_exports });
+const entry_hot = __rolldown_runtime__.createModuleHotContext("$CWD/entry.js");
+__rolldown_runtime__.registerModule("$CWD/entry.js", { exports: entry_exports });
 console.log("entry");
 
 //#endregion
@@ -24,8 +24,8 @@ import "./rolldown_hmr.js";
 
 //#region index.js
 var mutiply_entires_exports = {};
-const mutiply_entires_hot = __rolldown_runtime__.createModuleHotContext("index.js");
-__rolldown_runtime__.registerModule("index.js", { exports: mutiply_entires_exports });
+const mutiply_entires_hot = __rolldown_runtime__.createModuleHotContext("$CWD/index.js");
+__rolldown_runtime__.registerModule("$CWD/index.js", { exports: mutiply_entires_exports });
 console.log("index");
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/no-accept-outside-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/no-accept-outside-circular/artifacts.snap
@@ -12,29 +12,29 @@ import assert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region c.js
 var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
-const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
-__rolldown_runtime__.registerModule("c.js", { exports: c_exports });
+const c_hot = __rolldown_runtime__.createModuleHotContext("$CWD/c.js");
+__rolldown_runtime__.registerModule("$CWD/c.js", { exports: c_exports });
 const c = "c";
 
 //#endregion
 //#region b.js
 var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
-const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
-__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+const b_hot = __rolldown_runtime__.createModuleHotContext("$CWD/b.js");
+__rolldown_runtime__.registerModule("$CWD/b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
 var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
-const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
-__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+const a_hot = __rolldown_runtime__.createModuleHotContext("$CWD/a.js");
+__rolldown_runtime__.registerModule("$CWD/a.js", { exports: a_exports });
 const a = { b };
 
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 assert.strictEqual(a.b.c, "c");
 
 //#endregion
@@ -60,29 +60,29 @@ import assert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region c.js
 var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
-const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
-__rolldown_runtime__.registerModule("c.js", { exports: c_exports });
+const c_hot = __rolldown_runtime__.createModuleHotContext("$CWD/c.js");
+__rolldown_runtime__.registerModule("$CWD/c.js", { exports: c_exports });
 const c = "cc";
 
 //#endregion
 //#region b.js
 var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
-const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
-__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+const b_hot = __rolldown_runtime__.createModuleHotContext("$CWD/b.js");
+__rolldown_runtime__.registerModule("$CWD/b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
 var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
-const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
-__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+const a_hot = __rolldown_runtime__.createModuleHotContext("$CWD/a.js");
+__rolldown_runtime__.registerModule("$CWD/a.js", { exports: a_exports });
 const a = { b };
 
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 assert.strictEqual(a.b.c, "c");
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/no_boundary_reload/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/no_boundary_reload/artifacts.snap
@@ -10,8 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 console.log(1);
 
 //#endregion
@@ -35,8 +35,8 @@ console.log(1);
 // HIDDEN [rolldown:hmr]
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 console.log(2);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
@@ -10,16 +10,16 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
 var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
-const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
-__rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+const hmr_hot = __rolldown_runtime__.createModuleHotContext("$CWD/hmr.js");
+__rolldown_runtime__.registerModule("$CWD/hmr.js", { exports: hmr_exports });
 const foo = "hello";
 hmr_hot.accept(() => {});
 
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 
 //#endregion
 ```

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/_test.mjs
@@ -3,4 +3,7 @@ import assert from "node:assert"
 
 const modules = __rolldown_runtime__.modules;
 
-assert.strictEqual(modules['cjs.js'].exports.value, 'cjs');
+// Module IDs are now absolute paths, so we need to find the module by suffix
+const cjsModule = Object.entries(modules).find(([key]) => key.endsWith('cjs.js'));
+assert(cjsModule, 'cjs.js module should be registered');
+assert.strictEqual(cjsModule[1].exports.value, 'cjs');

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -10,8 +10,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:hmr]
 //#region cjs.js
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const cjs_hot = __rolldown_runtime__.createModuleHotContext("cjs.js");
-	__rolldown_runtime__.registerModule("cjs.js", module);
+	const cjs_hot = __rolldown_runtime__.createModuleHotContext("$CWD/cjs.js");
+	__rolldown_runtime__.registerModule("$CWD/cjs.js", module);
 	module.exports.value = "cjs";
 }));
 
@@ -19,15 +19,15 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#region esm.js
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
 var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
-const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
-__rolldown_runtime__.registerModule("esm.js", { exports: esm_exports });
+const esm_hot = __rolldown_runtime__.createModuleHotContext("$CWD/esm.js");
+__rolldown_runtime__.registerModule("$CWD/esm.js", { exports: esm_exports });
 const value = "main";
 
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 console.log(import_cjs, esm_exports);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -14,8 +14,8 @@ import assert from "node:assert";
 var trigger_dep_exports = {};
 var trigger_dep_hot;
 var init_trigger_dep = __esmMin((() => {
-	trigger_dep_hot = __rolldown_runtime__.createModuleHotContext("trigger-dep.js");
-	__rolldown_runtime__.registerModule("trigger-dep.js", { exports: trigger_dep_exports });
+	trigger_dep_hot = __rolldown_runtime__.createModuleHotContext("$CWD/trigger-dep.js");
+	__rolldown_runtime__.registerModule("$CWD/trigger-dep.js", { exports: trigger_dep_exports });
 	console.log();
 }));
 
@@ -23,8 +23,8 @@ var init_trigger_dep = __esmMin((() => {
 //#region cases/require/cjs-lib-reassign-module-exports.js
 var require_cjs_lib_reassign_module_exports = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	init_trigger_dep();
-	const cjs_lib_reassign_module_exports_hot = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib-reassign-module-exports.js");
-	__rolldown_runtime__.registerModule("cases/require/cjs-lib-reassign-module-exports.js", module);
+	const cjs_lib_reassign_module_exports_hot = __rolldown_runtime__.createModuleHotContext("$CWD/cases/require/cjs-lib-reassign-module-exports.js");
+	__rolldown_runtime__.registerModule("$CWD/cases/require/cjs-lib-reassign-module-exports.js", module);
 	module.exports = function() {
 		return "exports";
 	};
@@ -35,8 +35,8 @@ var require_cjs_lib_reassign_module_exports = /* @__PURE__ */ __commonJSMin(((ex
 //#region cases/require/cjs-lib.js
 var require_cjs_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	init_trigger_dep();
-	const cjs_lib_hot = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib.js");
-	__rolldown_runtime__.registerModule("cases/require/cjs-lib.js", module);
+	const cjs_lib_hot = __rolldown_runtime__.createModuleHotContext("$CWD/cases/require/cjs-lib.js");
+	__rolldown_runtime__.registerModule("$CWD/cases/require/cjs-lib.js", module);
 	exports.foo = "foo";
 	exports.bar = "bar";
 	var Noop = class {
@@ -55,8 +55,8 @@ var require_cjs_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#region cases/require/umd-lib.js
 var require_umd_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	init_trigger_dep();
-	const umd_lib_hot = __rolldown_runtime__.createModuleHotContext("cases/require/umd-lib.js");
-	__rolldown_runtime__.registerModule("cases/require/umd-lib.js", module);
+	const umd_lib_hot = __rolldown_runtime__.createModuleHotContext("$CWD/cases/require/umd-lib.js");
+	__rolldown_runtime__.registerModule("$CWD/cases/require/umd-lib.js", module);
 	(function(root, umdLib) {
 		if (typeof __require === "function" && typeof exports === "object" && typeof module === "object") {
 			module.exports = umdLib();
@@ -80,8 +80,8 @@ var require_umd_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#region cases/require/index.js
 var require_exports = {};
 init_trigger_dep();
-const require_hot = __rolldown_runtime__.createModuleHotContext("cases/require/index.js");
-__rolldown_runtime__.registerModule("cases/require/index.js", { exports: require_exports });
+const require_hot = __rolldown_runtime__.createModuleHotContext("$CWD/cases/require/index.js");
+__rolldown_runtime__.registerModule("$CWD/cases/require/index.js", { exports: require_exports });
 const requiredCjsLibReassignModuleExports = require_cjs_lib_reassign_module_exports();
 assert.strictEqual(requiredCjsLibReassignModuleExports(), "exports");
 assert.strictEqual(requiredCjsLibReassignModuleExports.foo, "foo");
@@ -105,8 +105,8 @@ var lib_exports = /* @__PURE__ */ __exportAll({
 	value: () => value
 });
 init_trigger_dep();
-const lib_hot = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/lib.js");
-__rolldown_runtime__.registerModule("cases/manual_reexport/lib.js", { exports: lib_exports });
+const lib_hot = __rolldown_runtime__.createModuleHotContext("$CWD/cases/manual_reexport/lib.js");
+__rolldown_runtime__.registerModule("$CWD/cases/manual_reexport/lib.js", { exports: lib_exports });
 const Globals = Object;
 const value = "lib";
 
@@ -117,15 +117,15 @@ var barrel_exports = /* @__PURE__ */ __exportAll({
 	value: () => value
 });
 init_trigger_dep();
-const barrel_hot = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/barrel.js");
-__rolldown_runtime__.registerModule("cases/manual_reexport/barrel.js", { exports: barrel_exports });
+const barrel_hot = __rolldown_runtime__.createModuleHotContext("$CWD/cases/manual_reexport/barrel.js");
+__rolldown_runtime__.registerModule("$CWD/cases/manual_reexport/barrel.js", { exports: barrel_exports });
 
 //#endregion
 //#region cases/manual_reexport/index.js
 var manual_reexport_exports = {};
 init_trigger_dep();
-const manual_reexport_hot = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/index.js");
-__rolldown_runtime__.registerModule("cases/manual_reexport/index.js", { exports: manual_reexport_exports });
+const manual_reexport_hot = __rolldown_runtime__.createModuleHotContext("$CWD/cases/manual_reexport/index.js");
+__rolldown_runtime__.registerModule("$CWD/cases/manual_reexport/index.js", { exports: manual_reexport_exports });
 assert.strictEqual(value, "lib");
 assert.strictEqual(Globals, Object);
 
@@ -133,32 +133,32 @@ assert.strictEqual(Globals, Object);
 //#region cases/deconflict_import_bindings/foo.mjs
 var foo_exports$1 = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
 init_trigger_dep();
-const foo_hot$1 = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo.mjs");
-__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo.mjs", { exports: foo_exports$1 });
+const foo_hot$1 = __rolldown_runtime__.createModuleHotContext("$CWD/cases/deconflict_import_bindings/foo.mjs");
+__rolldown_runtime__.registerModule("$CWD/cases/deconflict_import_bindings/foo.mjs", { exports: foo_exports$1 });
 const foo$1 = "foo";
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo/index.mjs
 var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 init_trigger_dep();
-const foo_hot = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo/index.mjs");
-__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo/index.mjs", { exports: foo_exports });
+const foo_hot = __rolldown_runtime__.createModuleHotContext("$CWD/cases/deconflict_import_bindings/foo/index.mjs");
+__rolldown_runtime__.registerModule("$CWD/cases/deconflict_import_bindings/foo/index.mjs", { exports: foo_exports });
 const foo = "foo-index";
 
 //#endregion
 //#region cases/deconflict_import_bindings/index.js
 var deconflict_import_bindings_exports = {};
 init_trigger_dep();
-const deconflict_import_bindings_hot = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/index.js");
-__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/index.js", { exports: deconflict_import_bindings_exports });
+const deconflict_import_bindings_hot = __rolldown_runtime__.createModuleHotContext("$CWD/cases/deconflict_import_bindings/index.js");
+__rolldown_runtime__.registerModule("$CWD/cases/deconflict_import_bindings/index.js", { exports: deconflict_import_bindings_exports });
 assert.strictEqual(foo$1, "foo");
 assert.strictEqual(foo, "foo-index");
 
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 if (main_hot) {
 	main_hot.accept();
 }
@@ -175,10 +175,10 @@ if (main_hot) {
 var init_foo_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo.mjs", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/cases/deconflict_import_bindings/foo.mjs", { exports: __rolldown_exports__ });
 		init_trigger_dep_11();
-		const hot_foo = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo.mjs");
-		var import_trigger_dep_00 = __rolldown_runtime__.loadExports("trigger-dep.js");
+		const hot_foo = __rolldown_runtime__.createModuleHotContext("$CWD/cases/deconflict_import_bindings/foo.mjs");
+		var import_trigger_dep_00 = __rolldown_runtime__.loadExports("$CWD/trigger-dep.js");
 		const foo = "foo";
 	} finally {}
 }));
@@ -188,10 +188,10 @@ var init_foo_0 = __rolldown_runtime__.createEsmInitializer((function() {
 var init_foo_1 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
-		__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo/index.mjs", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/cases/deconflict_import_bindings/foo/index.mjs", { exports: __rolldown_exports__ });
 		init_trigger_dep_11();
-		const hot_foo = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo/index.mjs");
-		var import_trigger_dep_10 = __rolldown_runtime__.loadExports("trigger-dep.js");
+		const hot_foo = __rolldown_runtime__.createModuleHotContext("$CWD/cases/deconflict_import_bindings/foo/index.mjs");
+		var import_trigger_dep_10 = __rolldown_runtime__.loadExports("$CWD/trigger-dep.js");
 		const foo = "foo-index";
 	} finally {}
 }));
@@ -202,14 +202,14 @@ import * as import_node_assert_20 from "node:assert";
 var init_deconflict_import_bindings_2 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/index.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/cases/deconflict_import_bindings/index.js", { exports: __rolldown_exports__ });
 		init_foo_0();
 		init_foo_1();
 		init_trigger_dep_11();
-		const hot_deconflict_import_bindings = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/index.js");
-		var import_foo_21 = __rolldown_runtime__.loadExports("cases/deconflict_import_bindings/foo.mjs");
-		var import_foo_22 = __rolldown_runtime__.loadExports("cases/deconflict_import_bindings/foo/index.mjs");
-		var import_trigger_dep_23 = __rolldown_runtime__.loadExports("trigger-dep.js");
+		const hot_deconflict_import_bindings = __rolldown_runtime__.createModuleHotContext("$CWD/cases/deconflict_import_bindings/index.js");
+		var import_foo_21 = __rolldown_runtime__.loadExports("$CWD/cases/deconflict_import_bindings/foo.mjs");
+		var import_foo_22 = __rolldown_runtime__.loadExports("$CWD/cases/deconflict_import_bindings/foo/index.mjs");
+		var import_trigger_dep_23 = __rolldown_runtime__.loadExports("$CWD/trigger-dep.js");
 		import_node_assert_20.default.strictEqual(import_foo_21.foo, "foo");
 		import_node_assert_20.default.strictEqual(import_foo_22.foo, "foo-index");
 	} finally {}
@@ -223,12 +223,12 @@ var init_barrel_3 = __rolldown_runtime__.createEsmInitializer((function() {
 			Globals: () => import_lib_30.Globals,
 			value: () => import_lib_30.value
 		});
-		__rolldown_runtime__.registerModule("cases/manual_reexport/barrel.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/cases/manual_reexport/barrel.js", { exports: __rolldown_exports__ });
 		init_lib_5();
 		init_trigger_dep_11();
-		const hot_barrel = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/barrel.js");
-		var import_lib_30 = __rolldown_runtime__.loadExports("cases/manual_reexport/lib.js");
-		var import_trigger_dep_31 = __rolldown_runtime__.loadExports("trigger-dep.js");
+		const hot_barrel = __rolldown_runtime__.createModuleHotContext("$CWD/cases/manual_reexport/barrel.js");
+		var import_lib_30 = __rolldown_runtime__.loadExports("$CWD/cases/manual_reexport/lib.js");
+		var import_trigger_dep_31 = __rolldown_runtime__.loadExports("$CWD/trigger-dep.js");
 	} finally {}
 }));
 
@@ -238,12 +238,12 @@ import * as import_node_assert_40 from "node:assert";
 var init_manual_reexport_4 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("cases/manual_reexport/index.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/cases/manual_reexport/index.js", { exports: __rolldown_exports__ });
 		init_barrel_3();
 		init_trigger_dep_11();
-		const hot_manual_reexport = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/index.js");
-		var import_barrel_41 = __rolldown_runtime__.loadExports("cases/manual_reexport/barrel.js");
-		var import_trigger_dep_42 = __rolldown_runtime__.loadExports("trigger-dep.js");
+		const hot_manual_reexport = __rolldown_runtime__.createModuleHotContext("$CWD/cases/manual_reexport/index.js");
+		var import_barrel_41 = __rolldown_runtime__.loadExports("$CWD/cases/manual_reexport/barrel.js");
+		var import_trigger_dep_42 = __rolldown_runtime__.loadExports("$CWD/trigger-dep.js");
 		import_node_assert_40.default.strictEqual(import_barrel_41.value, "lib");
 		import_node_assert_40.default.strictEqual(import_barrel_41.Globals, Object);
 	} finally {}
@@ -257,10 +257,10 @@ var init_lib_5 = __rolldown_runtime__.createEsmInitializer((function() {
 			Globals: () => Globals,
 			value: () => value
 		});
-		__rolldown_runtime__.registerModule("cases/manual_reexport/lib.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/cases/manual_reexport/lib.js", { exports: __rolldown_exports__ });
 		init_trigger_dep_11();
-		const hot_lib = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/lib.js");
-		var import_trigger_dep_50 = __rolldown_runtime__.loadExports("trigger-dep.js");
+		const hot_lib = __rolldown_runtime__.createModuleHotContext("$CWD/cases/manual_reexport/lib.js");
+		var import_trigger_dep_50 = __rolldown_runtime__.loadExports("$CWD/trigger-dep.js");
 		const Globals = Object;
 		const value = "lib";
 	} finally {}
@@ -270,10 +270,10 @@ var init_lib_5 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region cases/require/cjs-lib-reassign-module-exports.js
 var require_cjs_lib_reassign_module_exports_6 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
 	try {
-		__rolldown_runtime__.registerModule("cases/require/cjs-lib-reassign-module-exports.js", __rolldown_module__);
+		__rolldown_runtime__.registerModule("$CWD/cases/require/cjs-lib-reassign-module-exports.js", __rolldown_module__);
 		init_trigger_dep_11();
-		const hot_cjs_lib_reassign_module_exports = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib-reassign-module-exports.js");
-		var import_trigger_dep_60 = __rolldown_runtime__.loadExports("trigger-dep.js");
+		const hot_cjs_lib_reassign_module_exports = __rolldown_runtime__.createModuleHotContext("$CWD/cases/require/cjs-lib-reassign-module-exports.js");
+		var import_trigger_dep_60 = __rolldown_runtime__.loadExports("$CWD/trigger-dep.js");
 		__rolldown_module__.exports = function() {
 			return "exports";
 		};
@@ -285,10 +285,10 @@ var require_cjs_lib_reassign_module_exports_6 = __rolldown_runtime__.createCjsIn
 //#region cases/require/cjs-lib.js
 var require_cjs_lib_7 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
 	try {
-		__rolldown_runtime__.registerModule("cases/require/cjs-lib.js", __rolldown_module__);
+		__rolldown_runtime__.registerModule("$CWD/cases/require/cjs-lib.js", __rolldown_module__);
 		init_trigger_dep_11();
-		const hot_cjs_lib = __rolldown_runtime__.createModuleHotContext("cases/require/cjs-lib.js");
-		var import_trigger_dep_70 = __rolldown_runtime__.loadExports("trigger-dep.js");
+		const hot_cjs_lib = __rolldown_runtime__.createModuleHotContext("$CWD/cases/require/cjs-lib.js");
+		var import_trigger_dep_70 = __rolldown_runtime__.loadExports("$CWD/trigger-dep.js");
 		__rolldown_exports__.foo = "foo";
 		__rolldown_exports__.bar = "bar";
 		class Noop {
@@ -310,19 +310,19 @@ import * as import_node_assert_80 from "node:assert";
 var init_require_8 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("cases/require/index.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/cases/require/index.js", { exports: __rolldown_exports__ });
 		init_trigger_dep_11();
-		const hot_require = __rolldown_runtime__.createModuleHotContext("cases/require/index.js");
-		var import_trigger_dep_81 = __rolldown_runtime__.loadExports("trigger-dep.js");
-		const requiredCjsLibReassignModuleExports = (require_cjs_lib_reassign_module_exports_6(), __rolldown_runtime__.loadExports("cases/require/cjs-lib-reassign-module-exports.js"));
+		const hot_require = __rolldown_runtime__.createModuleHotContext("$CWD/cases/require/index.js");
+		var import_trigger_dep_81 = __rolldown_runtime__.loadExports("$CWD/trigger-dep.js");
+		const requiredCjsLibReassignModuleExports = (require_cjs_lib_reassign_module_exports_6(), __rolldown_runtime__.loadExports("$CWD/cases/require/cjs-lib-reassign-module-exports.js"));
 		import_node_assert_80.default.strictEqual(requiredCjsLibReassignModuleExports(), "exports");
 		import_node_assert_80.default.strictEqual(requiredCjsLibReassignModuleExports.foo, "foo");
-		const requireCjsLib = (require_cjs_lib_7(), __rolldown_runtime__.loadExports("cases/require/cjs-lib.js"));
+		const requireCjsLib = (require_cjs_lib_7(), __rolldown_runtime__.loadExports("$CWD/cases/require/cjs-lib.js"));
 		import_node_assert_80.default.strictEqual(requireCjsLib.foo, "foo");
 		import_node_assert_80.default.strictEqual(requireCjsLib.bar, "bar");
 		import_node_assert_80.default.strictEqual(requireCjsLib.baz, undefined);
 		import_node_assert_80.default.strictEqual(requireCjsLib.qux, "qux");
-		const requiredUmdLib = (require_umd_lib_9(), __rolldown_runtime__.loadExports("cases/require/umd-lib.js"));
+		const requiredUmdLib = (require_umd_lib_9(), __rolldown_runtime__.loadExports("$CWD/cases/require/umd-lib.js"));
 		import_node_assert_80.default.strictEqual(requiredUmdLib(), "exports");
 		import_node_assert_80.default.strictEqual(requiredUmdLib.foo, "foo");
 		{
@@ -336,10 +336,10 @@ var init_require_8 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region cases/require/umd-lib.js
 var require_umd_lib_9 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
 	try {
-		__rolldown_runtime__.registerModule("cases/require/umd-lib.js", __rolldown_module__);
+		__rolldown_runtime__.registerModule("$CWD/cases/require/umd-lib.js", __rolldown_module__);
 		init_trigger_dep_11();
-		const hot_umd_lib = __rolldown_runtime__.createModuleHotContext("cases/require/umd-lib.js");
-		var import_trigger_dep_90 = __rolldown_runtime__.loadExports("trigger-dep.js");
+		const hot_umd_lib = __rolldown_runtime__.createModuleHotContext("$CWD/cases/require/umd-lib.js");
+		var import_trigger_dep_90 = __rolldown_runtime__.loadExports("$CWD/trigger-dep.js");
 		(function(root, umdLib) {
 			if (typeof __rolldown_runtime__.loadExports === "function" && typeof __rolldown_exports__ === "object" && typeof __rolldown_module__ === "object") {
 				__rolldown_module__.exports = umdLib();
@@ -365,15 +365,15 @@ var require_umd_lib_9 = __rolldown_runtime__.createCjsInitializer((function(__ro
 var init_main_10 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("main.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/main.js", { exports: __rolldown_exports__ });
 		init_require_8();
 		init_manual_reexport_4();
 		init_deconflict_import_bindings_2();
-		const hot_main = __rolldown_runtime__.createModuleHotContext("main.js");
+		const hot_main = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
 		var import_rolldown_hmr_100 = __rolldown_runtime__.loadExports("rolldown:hmr");
-		var import_require_101 = __rolldown_runtime__.loadExports("cases/require/index.js");
-		var import_manual_reexport_102 = __rolldown_runtime__.loadExports("cases/manual_reexport/index.js");
-		var import_deconflict_import_bindings_103 = __rolldown_runtime__.loadExports("cases/deconflict_import_bindings/index.js");
+		var import_require_101 = __rolldown_runtime__.loadExports("$CWD/cases/require/index.js");
+		var import_manual_reexport_102 = __rolldown_runtime__.loadExports("$CWD/cases/manual_reexport/index.js");
+		var import_deconflict_import_bindings_103 = __rolldown_runtime__.loadExports("$CWD/cases/deconflict_import_bindings/index.js");
 		if (hot_main) {
 			hot_main.accept();
 		}
@@ -384,15 +384,15 @@ var init_main_10 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region trigger-dep.js
 var init_trigger_dep_11 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		__rolldown_runtime__.registerModule("trigger-dep.js", {});
-		const hot_trigger_dep = __rolldown_runtime__.createModuleHotContext("trigger-dep.js");
+		__rolldown_runtime__.registerModule("$CWD/trigger-dep.js", {});
+		const hot_trigger_dep = __rolldown_runtime__.createModuleHotContext("$CWD/trigger-dep.js");
 		console.log();
 	} finally {}
 }));
 
 //#endregion
 init_main_10()
-__rolldown_runtime__.applyUpdates([['main.js', 'main.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/main.js', '$CWD/main.js']]);
 ```
 
 ## Meta
@@ -401,4 +401,4 @@ __rolldown_runtime__.applyUpdates([['main.js', 'main.js']]);
 
 ### Hmr Boundaries
 
-- boundary: main.js, accepted_via: main.js
+- boundary: $CWD/main.js, accepted_via: $CWD/main.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
@@ -12,8 +12,8 @@ import assert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region c.js
 var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
-const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
-__rolldown_runtime__.registerModule("c.js", { exports: c_exports });
+const c_hot = __rolldown_runtime__.createModuleHotContext("$CWD/c.js");
+__rolldown_runtime__.registerModule("$CWD/c.js", { exports: c_exports });
 const c = "c";
 assert.strictEqual(c, "c");
 c_hot.accept((nextExports) => {
@@ -23,22 +23,22 @@ c_hot.accept((nextExports) => {
 //#endregion
 //#region b.js
 var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
-const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
-__rolldown_runtime__.registerModule("b.js", { exports: b_exports });
+const b_hot = __rolldown_runtime__.createModuleHotContext("$CWD/b.js");
+__rolldown_runtime__.registerModule("$CWD/b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
 var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
-const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
-__rolldown_runtime__.registerModule("a.js", { exports: a_exports });
+const a_hot = __rolldown_runtime__.createModuleHotContext("$CWD/a.js");
+__rolldown_runtime__.registerModule("$CWD/a.js", { exports: a_exports });
 const a = { b };
 
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 assert.strictEqual(a.b.c, "c");
 
 //#endregion
@@ -54,9 +54,9 @@ import * as import_node_assert_00 from "node:assert";
 var init_c_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ c: () => c });
-		__rolldown_runtime__.registerModule("c.js", { exports: __rolldown_exports__ });
-		const hot_c = __rolldown_runtime__.createModuleHotContext("c.js");
-		var import_b_01 = __rolldown_runtime__.loadExports("b.js");
+		__rolldown_runtime__.registerModule("$CWD/c.js", { exports: __rolldown_exports__ });
+		const hot_c = __rolldown_runtime__.createModuleHotContext("$CWD/c.js");
+		var import_b_01 = __rolldown_runtime__.loadExports("$CWD/b.js");
 		const c = "cc";
 		import_node_assert_00.default.strictEqual(c, "cc");
 		hot_c.accept((nextExports) => {
@@ -67,7 +67,7 @@ var init_c_0 = __rolldown_runtime__.createEsmInitializer((function() {
 
 //#endregion
 init_c_0()
-__rolldown_runtime__.applyUpdates([['c.js', 'c.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/c.js', '$CWD/c.js']]);
 ```
 
 ## Meta
@@ -76,4 +76,4 @@ __rolldown_runtime__.applyUpdates([['c.js', 'c.js']]);
 
 ### Hmr Boundaries
 
-- boundary: c.js, accepted_via: c.js
+- boundary: $CWD/c.js, accepted_via: $CWD/c.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -12,8 +12,8 @@ import assert from "node:assert";
 // HIDDEN [rolldown:hmr]
 //#region modules/dep-cjs.js
 var require_dep_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const dep_cjs_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-cjs.js");
-	__rolldown_runtime__.registerModule("modules/dep-cjs.js", module);
+	const dep_cjs_hot = __rolldown_runtime__.createModuleHotContext("$CWD/modules/dep-cjs.js");
+	__rolldown_runtime__.registerModule("$CWD/modules/dep-cjs.js", module);
 	exports.value = "cjs";
 }));
 
@@ -21,15 +21,15 @@ var require_dep_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#region modules/dep-esm.js
 var import_dep_cjs = require_dep_cjs();
 var dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => value$1 });
-const dep_esm_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm.js");
-__rolldown_runtime__.registerModule("modules/dep-esm.js", { exports: dep_esm_exports });
+const dep_esm_hot = __rolldown_runtime__.createModuleHotContext("$CWD/modules/dep-esm.js");
+__rolldown_runtime__.registerModule("$CWD/modules/dep-esm.js", { exports: dep_esm_exports });
 const value$1 = "esm";
 
 //#endregion
 //#region modules/dep-cjs-default.js
 var require_dep_cjs_default = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const dep_cjs_default_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-cjs-default.js");
-	__rolldown_runtime__.registerModule("modules/dep-cjs-default.js", module);
+	const dep_cjs_default_hot = __rolldown_runtime__.createModuleHotContext("$CWD/modules/dep-cjs-default.js");
+	__rolldown_runtime__.registerModule("$CWD/modules/dep-cjs-default.js", module);
 	module.exports = "cjs-default";
 }));
 
@@ -37,15 +37,15 @@ var require_dep_cjs_default = /* @__PURE__ */ __commonJSMin(((exports, module) =
 //#region modules/dep-esm-default.js
 var import_dep_cjs_default = /* @__PURE__ */ __toESM(require_dep_cjs_default());
 var dep_esm_default_exports = /* @__PURE__ */ __exportAll({ default: () => dep_esm_default_default });
-const dep_esm_default_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-default.js");
-__rolldown_runtime__.registerModule("modules/dep-esm-default.js", { exports: dep_esm_default_exports });
+const dep_esm_default_hot = __rolldown_runtime__.createModuleHotContext("$CWD/modules/dep-esm-default.js");
+__rolldown_runtime__.registerModule("$CWD/modules/dep-esm-default.js", { exports: dep_esm_default_exports });
 var dep_esm_default_default = "esm-default";
 
 //#endregion
 //#region modules/dep-cjs-named.js
 var require_dep_cjs_named = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const dep_cjs_named_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-cjs-named.js");
-	__rolldown_runtime__.registerModule("modules/dep-cjs-named.js", module);
+	const dep_cjs_named_hot = __rolldown_runtime__.createModuleHotContext("$CWD/modules/dep-cjs-named.js");
+	__rolldown_runtime__.registerModule("$CWD/modules/dep-cjs-named.js", module);
 	exports.named = "cjs-named";
 }));
 
@@ -53,15 +53,15 @@ var require_dep_cjs_named = /* @__PURE__ */ __commonJSMin(((exports, module) => 
 //#region modules/dep-esm-named.js
 var import_dep_cjs_named = require_dep_cjs_named();
 var dep_esm_named_exports = /* @__PURE__ */ __exportAll({ named: () => named });
-const dep_esm_named_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-named.js");
-__rolldown_runtime__.registerModule("modules/dep-esm-named.js", { exports: dep_esm_named_exports });
+const dep_esm_named_hot = __rolldown_runtime__.createModuleHotContext("$CWD/modules/dep-esm-named.js");
+__rolldown_runtime__.registerModule("$CWD/modules/dep-esm-named.js", { exports: dep_esm_named_exports });
 const named = "esm-named";
 
 //#endregion
 //#region modules/dep-cjs-namespace.js
 var require_dep_cjs_namespace = /* @__PURE__ */ __commonJSMin(((exports, module) => {
-	const dep_cjs_namespace_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-cjs-namespace.js");
-	__rolldown_runtime__.registerModule("modules/dep-cjs-namespace.js", module);
+	const dep_cjs_namespace_hot = __rolldown_runtime__.createModuleHotContext("$CWD/modules/dep-cjs-namespace.js");
+	__rolldown_runtime__.registerModule("$CWD/modules/dep-cjs-namespace.js", module);
 	module.exports = { value: "cjs-namespace" };
 }));
 
@@ -69,15 +69,15 @@ var require_dep_cjs_namespace = /* @__PURE__ */ __commonJSMin(((exports, module)
 //#region modules/dep-esm-namespace.js
 var import_dep_cjs_namespace = /* @__PURE__ */ __toESM(require_dep_cjs_namespace());
 var dep_esm_namespace_exports = /* @__PURE__ */ __exportAll({ value: () => value });
-const dep_esm_namespace_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-namespace.js");
-__rolldown_runtime__.registerModule("modules/dep-esm-namespace.js", { exports: dep_esm_namespace_exports });
+const dep_esm_namespace_hot = __rolldown_runtime__.createModuleHotContext("$CWD/modules/dep-esm-namespace.js");
+__rolldown_runtime__.registerModule("$CWD/modules/dep-esm-namespace.js", { exports: dep_esm_namespace_exports });
 const value = "esm-namespace";
 
 //#endregion
 //#region hmr.js
 var hmr_exports = {};
-const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
-__rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
+const hmr_hot = __rolldown_runtime__.createModuleHotContext("$CWD/hmr.js");
+__rolldown_runtime__.registerModule("$CWD/hmr.js", { exports: hmr_exports });
 assert.strictEqual(import_dep_cjs_default.default, "cjs-default");
 assert.strictEqual(dep_esm_default_default, "esm-default");
 assert.strictEqual(import_dep_cjs_named.named, "cjs-named");
@@ -96,8 +96,8 @@ hmr_hot.accept((mod) => {
 //#endregion
 //#region main.js
 var main_exports = {};
-const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
-__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const main_hot = __rolldown_runtime__.createModuleHotContext("$CWD/main.js");
+__rolldown_runtime__.registerModule("$CWD/main.js", { exports: main_exports });
 
 //#endregion
 ```
@@ -112,20 +112,20 @@ import * as import_node_assert_00 from "node:assert";
 var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
-		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
+		__rolldown_runtime__.registerModule("$CWD/hmr.js", { exports: __rolldown_exports__ });
 		require_new_dep_cjs_1();
 		init_new_dep_esm_2();
-		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
-		var import_dep_cjs_01 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("modules/dep-cjs.js"));
-		var import_dep_esm_02 = __rolldown_runtime__.loadExports("modules/dep-esm.js");
-		var import_dep_cjs_default_03 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("modules/dep-cjs-default.js"));
-		var import_dep_esm_default_04 = __rolldown_runtime__.loadExports("modules/dep-esm-default.js");
-		var import_dep_cjs_named_05 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("modules/dep-cjs-named.js"));
-		var import_dep_esm_named_06 = __rolldown_runtime__.loadExports("modules/dep-esm-named.js");
-		var import_dep_cjs_namespace_07 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("modules/dep-cjs-namespace.js"));
-		var import_dep_esm_namespace_08 = __rolldown_runtime__.loadExports("modules/dep-esm-namespace.js");
-		var import_new_dep_cjs_09 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("modules/new-dep-cjs.js"));
-		var import_new_dep_esm_010 = __rolldown_runtime__.loadExports("modules/new-dep-esm.js");
+		const hot_hmr = __rolldown_runtime__.createModuleHotContext("$CWD/hmr.js");
+		var import_dep_cjs_01 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("$CWD/modules/dep-cjs.js"));
+		var import_dep_esm_02 = __rolldown_runtime__.loadExports("$CWD/modules/dep-esm.js");
+		var import_dep_cjs_default_03 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("$CWD/modules/dep-cjs-default.js"));
+		var import_dep_esm_default_04 = __rolldown_runtime__.loadExports("$CWD/modules/dep-esm-default.js");
+		var import_dep_cjs_named_05 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("$CWD/modules/dep-cjs-named.js"));
+		var import_dep_esm_named_06 = __rolldown_runtime__.loadExports("$CWD/modules/dep-esm-named.js");
+		var import_dep_cjs_namespace_07 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("$CWD/modules/dep-cjs-namespace.js"));
+		var import_dep_esm_namespace_08 = __rolldown_runtime__.loadExports("$CWD/modules/dep-esm-namespace.js");
+		var import_new_dep_cjs_09 = __rolldown_runtime__.__toESM(__rolldown_runtime__.loadExports("$CWD/modules/new-dep-cjs.js"));
+		var import_new_dep_esm_010 = __rolldown_runtime__.loadExports("$CWD/modules/new-dep-esm.js");
 		import_node_assert_00.default.strictEqual(import_dep_cjs_default_03.default, "cjs-default");
 		import_node_assert_00.default.strictEqual(import_dep_esm_default_04.default, "esm-default");
 		import_node_assert_00.default.strictEqual(import_dep_cjs_named_05.named, "cjs-named");
@@ -147,8 +147,8 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region modules/new-dep-cjs.js
 var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer((function(__rolldown_exports__, __rolldown_module__) {
 	try {
-		__rolldown_runtime__.registerModule("modules/new-dep-cjs.js", __rolldown_module__);
-		const hot_new_dep_cjs = __rolldown_runtime__.createModuleHotContext("modules/new-dep-cjs.js");
+		__rolldown_runtime__.registerModule("$CWD/modules/new-dep-cjs.js", __rolldown_module__);
+		const hot_new_dep_cjs = __rolldown_runtime__.createModuleHotContext("$CWD/modules/new-dep-cjs.js");
 		__rolldown_exports__.value = "new-cjs";
 	} finally {}
 }));
@@ -158,15 +158,15 @@ var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer((function(
 var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
 		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
-		__rolldown_runtime__.registerModule("modules/new-dep-esm.js", { exports: __rolldown_exports__ });
-		const hot_new_dep_esm = __rolldown_runtime__.createModuleHotContext("modules/new-dep-esm.js");
+		__rolldown_runtime__.registerModule("$CWD/modules/new-dep-esm.js", { exports: __rolldown_exports__ });
+		const hot_new_dep_esm = __rolldown_runtime__.createModuleHotContext("$CWD/modules/new-dep-esm.js");
 		const value = "new-esm";
 	} finally {}
 }));
 
 //#endregion
 init_hmr_0()
-__rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
+__rolldown_runtime__.applyUpdates([['$CWD/hmr.js', '$CWD/hmr.js']]);
 ```
 
 ## Meta
@@ -175,4 +175,4 @@ __rolldown_runtime__.applyUpdates([['hmr.js', 'hmr.js']]);
 
 ### Hmr Boundaries
 
-- boundary: hmr.js, accepted_via: hmr.js
+- boundary: $CWD/hmr.js, accepted_via: $CWD/hmr.js

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4103,10 +4103,6 @@ expression: output
 
 - main-!~{000}~.js => main-DLGWTVDF.js
 
-# tests/rolldown/function/experimental/strict_execution_order/issue_4636
-
-- main-!~{000}~.js => main-BFvPO6M3.js
-
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
 - main-!~{000}~.js => main-DsT4wfr7.js
@@ -4807,10 +4803,6 @@ expression: output
 # tests/rolldown/issues/4006
 
 - main-!~{000}~.js => main-C2pFBQES.js
-
-# tests/rolldown/issues/4129
-
-- main-!~{000}~.js => main-DnsOb4pD.js
 
 # tests/rolldown/issues/4196
 
@@ -5894,105 +5886,6 @@ expression: output
 # tests/rolldown/topics/generated_code/symbols_ns2
 
 - main-!~{000}~.js => main-C-XWdoTA.js
-
-# tests/rolldown/topics/hmr/accept-outside-circular
-
-- main-!~{000}~.js => main-CLZR5ada.js
-
-# tests/rolldown/topics/hmr/change_accept
-
-- main-!~{000}~.js => main-DbRDwnvC.js
-
-# tests/rolldown/topics/hmr/cjs_no_export
-
-- main-!~{000}~.js => main-BJYG_vCU.js
-
-# tests/rolldown/topics/hmr/delete_file_not_used_anymore
-
-- main-!~{000}~.js => main-Y20Q6Ujd.js
-
-# tests/rolldown/topics/hmr/delete_file_used
-
-- main-!~{000}~.js => main-RQMXlOJG.js
-
-# tests/rolldown/topics/hmr/dynamic_import
-
-- main-!~{000}~.js => main-Cm286Gqg.js
-- exist-dep-cjs-!~{001}~.js => exist-dep-cjs-CmGQaNMg.js
-- exist-dep-esm-!~{003}~.js => exist-dep-esm-BVcWepyC.js
-
-# tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error
-
-- main-!~{000}~.js => main-BMNGsedU.js
-
-# tests/rolldown/topics/hmr/esm_no_export
-
-- main-!~{000}~.js => main-BSKantpI.js
-
-# tests/rolldown/topics/hmr/export_star
-
-- main-!~{000}~.js => main-DHIj4NZQ.js
-
-# tests/rolldown/topics/hmr/generate_patch_error
-
-- main-!~{000}~.js => main-DS2Jetji.js
-
-# tests/rolldown/topics/hmr/import_meta_hot_accept
-
-- main-!~{000}~.js => main-BgGYx0gh.js
-
-# tests/rolldown/topics/hmr/issue_4818
-
-- main-!~{000}~.js => main-CQmX7cpy.js
-
-# tests/rolldown/topics/hmr/issue_5149
-
-- main-!~{000}~.js => main-D0T9y176.js
-
-# tests/rolldown/topics/hmr/issue_5150
-
-- main-!~{000}~.js => main-RtaPUL5_.js
-
-# tests/rolldown/topics/hmr/issue_5159
-
-- main-!~{000}~.js => main-bxsTec3s.js
-- bar-!~{003}~.js => bar-DifdmgtM.js
-- foo-!~{005}~.js => foo-Bu7QarXC.js
-- string-!~{001}~.js => string-5tFSLDm2.js
-
-# tests/rolldown/topics/hmr/mutiply_entires
-
-- entry-!~{000}~.js => entry-DECLc6mQ.js
-- index-!~{001}~.js => index-BtgIhZIO.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-DbzQbNCw.js
-
-# tests/rolldown/topics/hmr/no-accept-outside-circular
-
-- main-!~{000}~.js => main-QoAxDP9g.js
-
-# tests/rolldown/topics/hmr/no_boundary_reload
-
-- main-!~{000}~.js => main-n6vqrY8X.js
-
-# tests/rolldown/topics/hmr/non_used_export
-
-- main-!~{000}~.js => main-DJQp7YTF.js
-
-# tests/rolldown/topics/hmr/register_exports
-
-- main-!~{000}~.js => main-DwrAIUsJ.js
-
-# tests/rolldown/topics/hmr/runtime_correctness
-
-- main-!~{000}~.js => main-FXvwXhpE.js
-
-# tests/rolldown/topics/hmr/self-accept-within-circular
-
-- main-!~{000}~.js => main-DBp1UEa_.js
-
-# tests/rolldown/topics/hmr/static_import
-
-- main-!~{000}~.js => main-CEfixAjf.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 

--- a/crates/rolldown_testing/src/types/build_artifacts_snapshot.rs
+++ b/crates/rolldown_testing/src/types/build_artifacts_snapshot.rs
@@ -36,7 +36,7 @@ impl BuildArtifactsSnapshot {
             build_round_sections.extend(Self::create_warning_section(bundle_output.warnings, cwd));
 
             // Render `# Assets`
-            if let Some(assets_section) = Self::create_assets_section(test_meta, &assets) {
+            if let Some(assets_section) = Self::create_assets_section(test_meta, &assets, cwd) {
               build_round_sections.push(assets_section);
             }
 
@@ -95,7 +95,11 @@ impl BuildArtifactsSnapshot {
     Some(warnings_section)
   }
 
-  pub fn create_assets_section(test_meta: &TestMeta, assets: &[Output]) -> Option<SnapshotSection> {
+  pub fn create_assets_section(
+    test_meta: &TestMeta,
+    assets: &[Output],
+    cwd: &Path,
+  ) -> Option<SnapshotSection> {
     if assets.is_empty() {
       None
     } else {
@@ -108,7 +112,7 @@ impl BuildArtifactsSnapshot {
         match asset {
           Output::Chunk(output_chunk) => {
             let content = &output_chunk.code;
-            let content = tweak_snapshot(content, test_meta.hidden_runtime_module, true);
+            let content = tweak_snapshot(content, test_meta.hidden_runtime_module, true, cwd);
 
             let mut asset_child = SnapshotSection::with_title(asset.filename().to_string());
             asset_child.add_content(&format!("```{file_ext}\n"));
@@ -215,7 +219,7 @@ impl BuildArtifactsSnapshot {
     sections.extend(Self::create_warning_section(bundle_output.warnings, cwd));
 
     // Render `# Assets`
-    if let Some(assets_section) = Self::create_assets_section(test_meta, &assets) {
+    if let Some(assets_section) = Self::create_assets_section(test_meta, &assets, cwd) {
       sections.push(assets_section);
     }
 


### PR DESCRIPTION
It's very annoying to calculate between stable id and id. The intial purpose of using stable id is for portable cache, which is in a very far future. So change to use module id directly for convenience.