### PR TITLE
fix: rename `__export` to `__exportAll` to be compatible with `cjs-module-lexer`

### DIFF
--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -554,7 +554,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
     // construct `__export(ns_name, { prop_name: () => returned, ... })`
     let export_call_expr = self.snippet.builder.expression_call(
       SPAN,
-      self.snippet.id_ref_expr("__rolldown_runtime__.__export", SPAN),
+      self.snippet.id_ref_expr("__rolldown_runtime__.__exportAll", SPAN),
       NONE,
       self
         .snippet
@@ -563,7 +563,7 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
       false,
     );
 
-    // construct `var [binding_name_for_namespace_object_ref] = __export({ prop_name: () => returned, ... })`
+    // construct `var [binding_name_for_namespace_object_ref] = __exportAll({ prop_name: () => returned, ... })`
     let decl_stmt =
       self.snippet.var_decl_stmt(binding_name_for_namespace_object_ref, export_call_expr);
     vec![decl_stmt]

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -478,8 +478,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       },
     ));
 
-    // if there is no export, we should generate `var ns = {}` instead of `var ns = __export({}, {})`
-    // else construct `__export(ns_name, { prop_name: () => returned, ... })`
+    // if there is no export, we should generate `var ns = {}` instead of `var ns = __exportAll({})`
+    // else construct `__exportAll({ prop_name: () => returned, ... })`
     let module_namespace_rhs =
       if arg_obj_expr.properties.is_empty() && !self.ctx.options.generated_code.symbols {
         Expression::ObjectExpression(self.builder().alloc(arg_obj_expr))
@@ -500,7 +500,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         };
         self.snippet.builder.expression_call_with_pure(
           SPAN,
-          self.finalized_expr_for_runtime_symbol("__export"),
+          self.finalized_expr_for_runtime_symbol("__exportAll"),
           NONE,
           args,
           false,
@@ -508,7 +508,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         )
       };
 
-    // construct `var [binding_name_for_namespace_object_ref] = __export(...)`
+    // construct `var [binding_name_for_namespace_object_ref] = __exportAll(...)`
     let decl_stmt =
       self.snippet.var_decl_stmt(binding_name_for_namespace_object_ref, module_namespace_rhs);
 

--- a/crates/rolldown/src/runtime/runtime-base.js
+++ b/crates/rolldown/src/runtime/runtime-base.js
@@ -22,7 +22,7 @@ export var __commonJS = (cb, mod) =>
 export var __commonJSMin = (cb, mod) => () => (
   mod || cb((mod = { exports: {} }).exports, mod), mod.exports
 );
-export var __export = (all, symbols) => {
+export var __exportAll = (all, symbols) => {
   let target = {};
   for (var name in all) {
     __defProp(target, name, { get: all[name], enumerable: true });

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -391,7 +391,7 @@ impl GenerateStage<'_> {
       module.stmt_infos[StmtInfos::NAMESPACE_STMT_IDX].referenced_symbols.retain(
         |item| match item {
           rolldown_common::SymbolOrMemberExprRef::Symbol(symbol_ref) => {
-            // module namespace symbol requires `__export` runtime helper
+            // module namespace symbol requires `__exportAll` runtime helper
             self.link_output.used_symbol_refs.contains(symbol_ref)
               || symbol_ref.owner == runtime_module_idx
           }
@@ -425,7 +425,7 @@ impl GenerateStage<'_> {
 
     let mut optimized_common_chunks = FxHashSet::default();
 
-    include_runtime_symbol(context, runtime, RuntimeHelper::Export);
+    include_runtime_symbol(context, runtime, RuntimeHelper::ExportAll);
 
     for (&entry_module, &(from_chunk_idx, target_chunk_idx)) in &rewrite_entry_to_chunk {
       // Point the entry module to related common chunk
@@ -451,7 +451,7 @@ impl GenerateStage<'_> {
       context.module_namespace_included_reason[entry_module]
         .insert(ModuleNamespaceIncludedReason::SimulateFacadeChunk);
       let target_chunk = &mut chunk_graph.chunk_table[target_chunk_idx];
-      target_chunk.depended_runtime_helper.insert(RuntimeHelper::Export);
+      target_chunk.depended_runtime_helper.insert(RuntimeHelper::ExportAll);
       optimized_common_chunks.insert(target_chunk_idx);
     }
 

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -93,7 +93,7 @@ impl LinkStage<'_> {
           let mut referenced_symbols = vec![];
           let mut declared_symbols = vec![];
           if !meta.is_canonical_exports_empty() || self.options.generated_code.symbols {
-            referenced_symbols.push(self.runtime.resolve_symbol("__export").into());
+            referenced_symbols.push(self.runtime.resolve_symbol("__exportAll").into());
             referenced_symbols
               .extend(meta.canonical_exports(false).map(|(_, export)| export.symbol_ref.into()));
           }

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index.js
-var demo_pkg_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var demo_pkg_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 var foo;
 var init_demo_pkg = __esmMin((() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index.js
-var demo_pkg_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var demo_pkg_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const foo = 123;
 console.log("hello");
 

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
@@ -18,7 +18,7 @@ var init_lib = __esmMin((() => {
 
 //#endregion
 //#region cjs.js
-var cjs_exports = /* @__PURE__ */ __export({ default: () => cjs_default });
+var cjs_exports = /* @__PURE__ */ __exportAll({ default: () => cjs_default });
 var cjs_default;
 var init_cjs = __esmMin((() => {
 	init_lib();

--- a/crates/rolldown/tests/esbuild/default/bundle_esm_with_nested_var_issue4348/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/bundle_esm_with_nested_var_issue4348/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({
+var foo_exports = /* @__PURE__ */ __exportAll({
 	a: () => a,
 	b: () => b,
 	c: () => c,

--- a/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
 function foo$1() {
 	return "foo";
 }
@@ -18,7 +18,7 @@ var init_foo = __esmMin((() => {}));
 
 //#endregion
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __export({ bar: () => bar$1 });
+var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar$1 });
 function bar$1() {
 	return "bar";
 }

--- a/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
@@ -15,7 +15,7 @@ var init_a = __esmMin((() => {
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __export({ xyz: () => xyz });
+var b_exports = /* @__PURE__ */ __exportAll({ xyz: () => xyz });
 var xyz;
 var init_b = __esmMin((() => {
 	xyz = null;
@@ -23,7 +23,7 @@ var init_b = __esmMin((() => {
 
 //#endregion
 //#region commonjs.js
-var commonjs_exports = /* @__PURE__ */ __export({
+var commonjs_exports = /* @__PURE__ */ __exportAll({
 	C: () => Class,
 	Class: () => Class,
 	Fn: () => Fn,
@@ -48,7 +48,7 @@ var init_commonjs = __esmMin((() => {
 
 //#endregion
 //#region c.js
-var c_exports = /* @__PURE__ */ __export({ default: () => c_default });
+var c_exports = /* @__PURE__ */ __exportAll({ default: () => c_default });
 var c_default;
 var init_c = __esmMin((() => {
 	c_default = class {};
@@ -56,7 +56,7 @@ var init_c = __esmMin((() => {
 
 //#endregion
 //#region d.js
-var d_exports = /* @__PURE__ */ __export({ default: () => Foo });
+var d_exports = /* @__PURE__ */ __exportAll({ default: () => Foo });
 var Foo;
 var init_d = __esmMin((() => {
 	Foo = class {};
@@ -65,13 +65,13 @@ var init_d = __esmMin((() => {
 
 //#endregion
 //#region e.js
-var e_exports = /* @__PURE__ */ __export({ default: () => e_default });
+var e_exports = /* @__PURE__ */ __exportAll({ default: () => e_default });
 function e_default() {}
 var init_e = __esmMin((() => {}));
 
 //#endregion
 //#region f.js
-var f_exports = /* @__PURE__ */ __export({ default: () => foo$1 });
+var f_exports = /* @__PURE__ */ __exportAll({ default: () => foo$1 });
 function foo$1() {}
 var init_f = __esmMin((() => {
 	foo$1.prop = 123;
@@ -79,13 +79,13 @@ var init_f = __esmMin((() => {
 
 //#endregion
 //#region g.js
-var g_exports = /* @__PURE__ */ __export({ default: () => g_default });
+var g_exports = /* @__PURE__ */ __exportAll({ default: () => g_default });
 async function g_default() {}
 var init_g = __esmMin((() => {}));
 
 //#endregion
 //#region h.js
-var h_exports = /* @__PURE__ */ __export({ default: () => foo });
+var h_exports = /* @__PURE__ */ __exportAll({ default: () => foo });
 async function foo() {}
 var init_h = __esmMin((() => {
 	foo.prop = 123;

--- a/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
@@ -12,7 +12,7 @@ const abc = void 0;
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __export({ xyz: () => xyz });
+var b_exports = /* @__PURE__ */ __exportAll({ xyz: () => xyz });
 const xyz = null;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
@@ -25,7 +25,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 //#endregion
 //#region b.js
-	var b_exports = /* @__PURE__ */ __export({ xyz: () => xyz });
+	var b_exports = /* @__PURE__ */ __exportAll({ xyz: () => xyz });
 	const xyz = null;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
@@ -35,7 +35,7 @@ export { b_default as default };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region b.js
-var b_exports = /* @__PURE__ */ __export({ default: () => b_default });
+var b_exports = /* @__PURE__ */ __exportAll({ default: () => b_default });
 function b_default() {}
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_special_name_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_special_name_bundle/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region lib.mjs
-var lib_exports = /* @__PURE__ */ __export({ ["__proto__"]: () => __proto__ });
+var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ });
 var __proto__;
 var init_lib = __esmMin((() => {
 	__proto__ = 123;

--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
@@ -11,12 +11,12 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region foo/test.js
-var test_exports$1 = /* @__PURE__ */ __export({ foo: () => foo });
+var test_exports$1 = /* @__PURE__ */ __exportAll({ foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports = /* @__PURE__ */ __export({ bar: () => bar });
+var test_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
 let bar = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
@@ -11,22 +11,22 @@ import { ns } from "x";
 
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ ns: () => ns$1 });
+var a_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
 var init_a = __esmMin((() => {}));
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __export({ ns: () => ns$1 });
+var b_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
 var init_b = __esmMin((() => {}));
 
 //#endregion
 //#region c.js
-var c_exports = /* @__PURE__ */ __export({ ns: () => ns$1 });
+var c_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
 var init_c = __esmMin((() => {}));
 
 //#endregion
 //#region d.js
-var d_exports = /* @__PURE__ */ __export({ ns: () => ns });
+var d_exports = /* @__PURE__ */ __exportAll({ ns: () => ns });
 var init_d = __esmMin((() => {}));
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/diff.md
@@ -68,22 +68,22 @@ import { ns } from "x";
 
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ ns: () => ns$1 });
+var a_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
 var init_a = __esmMin((() => {}));
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __export({ ns: () => ns$1 });
+var b_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
 var init_b = __esmMin((() => {}));
 
 //#endregion
 //#region c.js
-var c_exports = /* @__PURE__ */ __export({ ns: () => ns$1 });
+var c_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
 var init_c = __esmMin((() => {}));
 
 //#endregion
 //#region d.js
-var d_exports = /* @__PURE__ */ __export({ ns: () => ns });
+var d_exports = /* @__PURE__ */ __exportAll({ ns: () => ns });
 var init_d = __esmMin((() => {}));
 
 //#endregion
@@ -114,28 +114,28 @@ init_e();
 -    ns: () => ns
 +import * as ns$1 from "x";
 +import {ns} from "x";
-+var a_exports = __export({
++var a_exports = __exportAll({
 +    ns: () => ns$1
  });
 -import * as ns from "x";
 -var init_a = __esm({
 -    "a.js"() {}
 +var init_a = __esmMin(() => {});
-+var b_exports = __export({
++var b_exports = __exportAll({
 +    ns: () => ns$1
  });
 -var b_exports = {};
 -__export(b_exports, {
 -    ns: () => ns2
 +var init_b = __esmMin(() => {});
-+var c_exports = __export({
++var c_exports = __exportAll({
 +    ns: () => ns$1
  });
 -import * as ns2 from "x";
 -var init_b = __esm({
 -    "b.js"() {}
 +var init_c = __esmMin(() => {});
-+var d_exports = __export({
++var d_exports = __exportAll({
 +    ns: () => ns
  });
 -var c_exports = {};

--- a/crates/rolldown/tests/esbuild/default/forbid_string_export_names_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/forbid_string_export_names_bundle/artifacts.snap
@@ -16,7 +16,7 @@ let nested$1 = 2;
 
 //#endregion
 //#region nested.js
-var nested_exports = /* @__PURE__ */ __export({
+var nested_exports = /* @__PURE__ */ __exportAll({
 	"nested name": () => nested,
 	"very nested name": () => nested$1
 });

--- a/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __export({ esm_foo_: () => esm_foo_ });
+var esm_exports = /* @__PURE__ */ __exportAll({ esm_foo_: () => esm_foo_ });
 var esm_foo_;
 var init_esm = __esmMin((() => {
 	esm_foo_ = "foo";

--- a/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
@@ -9,12 +9,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region foo/test.js
-var test_exports$1 = /* @__PURE__ */ __export({ foo: () => foo });
+var test_exports$1 = /* @__PURE__ */ __exportAll({ foo: () => foo });
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports = /* @__PURE__ */ __export({ bar: () => bar });
+var test_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
 let bar = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/this_with_es6_syntax/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/this_with_es6_syntax/artifacts.snap
@@ -12,7 +12,7 @@ console.log(void 0);
 
 //#endregion
 //#region dummy.js
-var dummy_exports = /* @__PURE__ */ __export({ dummy: () => dummy });
+var dummy_exports = /* @__PURE__ */ __exportAll({ dummy: () => dummy });
 var dummy;
 var init_dummy = __esmMin((() => {
 	dummy = 123;

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
-var entry_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var entry_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const foo = 123;
 console.log(entry_exports);
 

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
-var entry_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var entry_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 var foo;
 var init_entry = __esmMin((() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
-var entry_exports = /* @__PURE__ */ __export({
+var entry_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region entry.js
-var entry_exports = /* @__PURE__ */ __export({
+var entry_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
@@ -251,7 +251,7 @@ console.log(internal_default, internal_exports);
 ```js
 // HIDDEN [rolldown:runtime]
 //#region internal.js
-var internal_exports = /* @__PURE__ */ __export({ default: () => internal_default });
+var internal_exports = /* @__PURE__ */ __exportAll({ default: () => internal_default });
 var internal_default = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region entry.js
-var entry_exports = /* @__PURE__ */ __export({
+var entry_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	ns: () => entry_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 var foo;
 var init_foo = __esmMin((() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
 const foo$1 = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
@@ -14,7 +14,7 @@ const foo$1 = 123;
 
 //#endregion
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
+var bar_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
@@ -18,7 +18,7 @@ const z = 4;
 
 //#endregion
 //#region common.js
-var common_exports = /* @__PURE__ */ __export({
+var common_exports = /* @__PURE__ */ __exportAll({
 	x: () => x,
 	z: () => z
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
@@ -10,12 +10,12 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __export({ bar: () => bar });
+var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
 const bar = 123;
 
 //#endregion
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ bar_ns: () => bar_exports });
+var foo_exports = /* @__PURE__ */ __exportAll({ bar_ns: () => bar_exports });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
@@ -12,7 +12,7 @@ const foo = () => "hi there";
 
 //#endregion
 //#region folders/index.js
-var folders_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var folders_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
@@ -25,7 +25,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ x: () => x });
+var foo_exports = /* @__PURE__ */ __exportAll({ x: () => x });
 const x = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
@@ -29,7 +29,7 @@ const x = 123;
 
 //#endregion
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ x: () => x });
+var foo_exports = /* @__PURE__ */ __exportAll({ x: () => x });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
@@ -25,7 +25,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __export({ x: () => x });
+var bar_exports = /* @__PURE__ */ __exportAll({ x: () => x });
 const x = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({
+var foo_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	ns: () => foo_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({
+var foo_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	ns: () => foo_exports
 });

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_and_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_and_common_js/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 var foo;
 var init_foo = __esmMin((() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
@@ -12,7 +12,7 @@ const foo = 123;
 
 //#endregion
 //#region bar.ts
-var bar_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var bar_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 
 //#endregion
 //#region entry.ts

--- a/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
@@ -12,7 +12,7 @@ var invalid_identifier$1 = true;
 
 //#endregion
 //#region test2.json
-var test2_exports = /* @__PURE__ */ __export({
+var test2_exports = /* @__PURE__ */ __exportAll({
 	default: () => test2_default,
 	"invalid-identifier": () => invalid_identifier
 });

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.browser.js
-var module_browser_exports = /* @__PURE__ */ __export({ default: () => module_browser_default });
+var module_browser_exports = /* @__PURE__ */ __exportAll({ default: () => module_browser_default });
 var module_browser_default;
 var init_module_browser = __esmMin((() => {
 	module_browser_default = "browser module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main/artifacts.snap
@@ -10,7 +10,7 @@ import assert, { deepEqual } from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_require_only/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_require_only/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __export({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/splitting/edge_case_issue2793_without_splitting/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/edge_case_issue2793_without_splitting/artifacts.snap
@@ -22,7 +22,7 @@ var init_b = __esmMin((() => {
 
 //#endregion
 //#region index.js
-var edge_case_issue2793_without_splitting_exports = /* @__PURE__ */ __export({
+var edge_case_issue2793_without_splitting_exports = /* @__PURE__ */ __exportAll({
 	A: () => A,
 	B: () => B
 });

--- a/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
@@ -17,7 +17,7 @@ export { foo };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var a_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 var foo;
 var init_a = __esmMin((() => {
 	;

--- a/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
@@ -8,12 +8,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.ts
-var a_exports = /* @__PURE__ */ __export({ foo: () => foo$3 });
+var a_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$3 });
 let foo$3 = 123;
 
 //#endregion
 //#region b.ts
-var b_exports = /* @__PURE__ */ __export({ foo: () => foo$2 });
+var b_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$2 });
 let foo$2 = 123;
 
 //#endregion
@@ -22,7 +22,7 @@ var Test = void 0;
 
 //#endregion
 //#region c.ts
-var c_exports = /* @__PURE__ */ __export({
+var c_exports = /* @__PURE__ */ __exportAll({
 	Test: () => Test,
 	foo: () => foo$1
 });
@@ -30,7 +30,7 @@ let foo$1 = 123;
 
 //#endregion
 //#region d.ts
-var d_exports = /* @__PURE__ */ __export({
+var d_exports = /* @__PURE__ */ __exportAll({
 	Test: () => Test,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
@@ -12,7 +12,7 @@ var nope = void 0;
 
 //#endregion
 //#region foo.ts
-var foo_exports = /* @__PURE__ */ __export({ nope: () => nope });
+var foo_exports = /* @__PURE__ */ __exportAll({ nope: () => nope });
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region import.ts
-var import_exports = /* @__PURE__ */ __export({ value: () => value });
+var import_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 let value = 123;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __export({
+var esm_exports = /* @__PURE__ */ __exportAll({
 	default: () => esm_default_fn$1,
 	esm_named_class: () => esm_named_class,
 	esm_named_fn: () => esm_named_fn,

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __export({ default: () => esm_default });
+var esm_exports = /* @__PURE__ */ __exportAll({ default: () => esm_default });
 var esm_default;
 var init_esm = __esmMin((() => {
 	esm_default = "esm";

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __export({ default: () => esm_default });
+var esm_exports = /* @__PURE__ */ __exportAll({ default: () => esm_default });
 var esm_default;
 var init_esm = __esmMin((() => {
 	esm_default = "esm";

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/basic/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __export({
+var esm_exports = /* @__PURE__ */ __exportAll({
 	__esModule: () => __esModule,
 	bar: () => bar,
 	default: () => esm_default,

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/fallback/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/fallback/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __export({
+var esm_exports = /* @__PURE__ */ __exportAll({
 	bar: () => bar,
 	default: () => esm_default,
 	foo: () => foo

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/priority/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/priority/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __export({
+var esm_exports = /* @__PURE__ */ __exportAll({
 	default: () => esm_default,
 	"module.exports": () => moduleExports,
 	namedExport: () => namedExport

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/with_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/with_default/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __export({
+var esm_exports = /* @__PURE__ */ __exportAll({
 	default: () => myFunction,
 	"module.exports": () => moduleExports
 });

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region json.js
-var json_exports = /* @__PURE__ */ __export({ default: () => json_default });
+var json_exports = /* @__PURE__ */ __exportAll({ default: () => json_default });
 var json_default;
 var init_json = __esmMin((() => {
 	json_default = JSON.parse("[1, 2, 3]");

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
@@ -14,7 +14,7 @@ var require_react = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __export({ default: () => toArray$1 });
+var lib_exports = /* @__PURE__ */ __exportAll({ default: () => toArray$1 });
 function toArray$1(children) {
 	import_react$1.default.Children.forEach(children, function(child) {});
 	return ret;

--- a/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
@@ -20,7 +20,7 @@ const value = 1;
 
 //#endregion
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({
+var foo_exports = /* @__PURE__ */ __exportAll({
 	bar: () => import_commonjs.bar,
 	value: () => value
 });

--- a/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __export({ a: () => a$1 });
+var esm_exports = /* @__PURE__ */ __exportAll({ a: () => a$1 });
 var a$1;
 var init_esm = __esmMin((() => {
 	a$1 = 100;

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
@@ -16,7 +16,7 @@ export { foo };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const foo = 1;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
@@ -14,10 +14,10 @@ Object.defineProperty(exports, '__esmMin', {
     return __esmMin;
   }
 });
-Object.defineProperty(exports, '__export', {
+Object.defineProperty(exports, '__exportAll', {
   enumerable: true,
   get: function () {
-    return __export;
+    return __exportAll;
   }
 });
 Object.defineProperty(exports, '__toESM', {
@@ -42,7 +42,7 @@ require("node:assert");
 const require_chunk = require('./chunk.js');
 
 //#region esm.js
-var esm_exports = /* @__PURE__ */ require_chunk.__export({ share: () => share });
+var esm_exports = /* @__PURE__ */ require_chunk.__exportAll({ share: () => share });
 function share() {
 	return 1;
 }

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
@@ -8,17 +8,17 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region imp1.js
-var imp1_exports = /* @__PURE__ */ __export({ imp1: () => imp1 });
+var imp1_exports = /* @__PURE__ */ __exportAll({ imp1: () => imp1 });
 const imp1 = 1;
 
 //#endregion
 //#region imp2.js
-var imp2_exports = /* @__PURE__ */ __export({ imp2: () => imp2 });
+var imp2_exports = /* @__PURE__ */ __exportAll({ imp2: () => imp2 });
 const imp2 = 2;
 
 //#endregion
 //#region imp3.js
-var imp3_exports = /* @__PURE__ */ __export({
+var imp3_exports = /* @__PURE__ */ __exportAll({
 	imp3: () => imp3,
 	imp33: () => imp33
 });

--- a/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region lib.prod.js
-var lib_prod_exports = /* @__PURE__ */ __export({ default: () => lib_prod_default });
+var lib_prod_exports = /* @__PURE__ */ __exportAll({ default: () => lib_prod_default });
 var lib_prod_default;
 var init_lib_prod = __esmMin((() => {
 	lib_prod_default = "prod";

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
@@ -15,15 +15,15 @@ export { lib_npm_a_exports as libA, lib_npm_b_exports as libB, lib_ui_exports as
 ## other-libs.js
 
 ```js
-import { t as __export } from "./rolldown-runtime.js";
+import { t as __exportAll } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-npm-a/index.js
-var lib_npm_a_exports = /* @__PURE__ */ __export({ default: () => lib_npm_a_default });
+var lib_npm_a_exports = /* @__PURE__ */ __exportAll({ default: () => lib_npm_a_default });
 var lib_npm_a_default = "npm-a";
 
 //#endregion
 //#region node_modules/lib-npm-b/index.js
-var lib_npm_b_exports = /* @__PURE__ */ __export({ default: () => lib_npm_b_default });
+var lib_npm_b_exports = /* @__PURE__ */ __exportAll({ default: () => lib_npm_b_default });
 var lib_npm_b_default = "npm-b";
 
 //#endregion
@@ -35,7 +35,7 @@ export { lib_npm_a_exports as n, lib_npm_b_exports as t };
 ```js
 //#region rolldown:runtime
 var __defProp = Object.defineProperty;
-var __export = (all, symbols) => {
+var __exportAll = (all, symbols) => {
 	let target = {};
 	for (var name in all) {
 		__defProp(target, name, {
@@ -50,16 +50,16 @@ var __export = (all, symbols) => {
 };
 
 //#endregion
-export { __export as t };
+export { __exportAll as t };
 ```
 
 ## ui.js
 
 ```js
-import { t as __export } from "./rolldown-runtime.js";
+import { t as __exportAll } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-ui/index.js
-var lib_ui_exports = /* @__PURE__ */ __export({ default: () => lib_ui_default });
+var lib_ui_exports = /* @__PURE__ */ __exportAll({ default: () => lib_ui_default });
 var lib_ui_default = "ui";
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/export_mode/cjs/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/cjs/default/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region mod.js
-var default_exports = /* @__PURE__ */ __export({ default: () => example });
+var default_exports = /* @__PURE__ */ __exportAll({ default: () => example });
 function example() {
 	return "default";
 }

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/default/artifacts.snap
@@ -11,7 +11,7 @@ var module = (function() {
 // HIDDEN [rolldown:runtime]
 
 //#region mod.js
-	var default_exports = /* @__PURE__ */ __export({
+	var default_exports = /* @__PURE__ */ __exportAll({
 		add: () => add,
 		subtract: () => subtract
 	});

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
@@ -12,7 +12,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 // HIDDEN [rolldown:runtime]
 
 //#region mod.js
-	var named_exports = /* @__PURE__ */ __export({
+	var named_exports = /* @__PURE__ */ __exportAll({
 		add: () => add,
 		subtract: () => subtract
 	});

--- a/crates/rolldown/tests/rolldown/function/format/export_proto_namespace/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/export_proto_namespace/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __export({ ["__proto__"]: () => __proto__ });
+var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ });
 const __proto__ = 123;
 
 //#endregion
@@ -25,7 +25,7 @@ export { lib_exports as lib };
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __export({ ["__proto__"]: () => __proto__ });
+var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ });
 const __proto__ = 123;
 
 //#endregion
@@ -49,7 +49,7 @@ var bundle = (function(exports) {
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js
-	var lib_exports = /* @__PURE__ */ __export({ ["__proto__"]: () => __proto__ });
+	var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ });
 	const __proto__ = 123;
 
 //#endregion
@@ -79,7 +79,7 @@ globalThis.bundle = bundle;
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js
-	var lib_exports = /* @__PURE__ */ __export({ ["__proto__"]: () => __proto__ });
+	var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ });
 	const __proto__ = 123;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/basic/artifacts.snap
@@ -18,7 +18,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __export({ value: () => value });
+var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 var value;
 var init_esm = __esmMin((() => {
 	value = 1;
@@ -53,7 +53,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __export({ value: () => value });
+var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 var value;
 var init_esm = __esmMin((() => {
 	value = 1;
@@ -90,7 +90,7 @@ Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }))
 
 //#endregion
 //#region esm.js
-	var esm_exports = /* @__PURE__ */ __export({ value: () => value });
+	var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 	var value;
 	var init_esm = __esmMin((() => {
 		value = 1;

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -21,11 +21,11 @@ To fix:
 ## first.js
 
 ```js
-import { n as __export, t as __esmMin } from "./rolldown-runtime.js";
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
 import { r as value$1, t as init_second } from "./second.js";
 
 //#region first.js
-var first_exports = /* @__PURE__ */ __export({ value: () => value });
+var first_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 var value;
 var init_first = __esmMin((() => {
 	init_second();
@@ -58,17 +58,17 @@ init_main();
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __export as n, __esmMin as t };
+export { __exportAll as n, __esmMin as t };
 ```
 
 ## second.js
 
 ```js
-import { n as __export, t as __esmMin } from "./rolldown-runtime.js";
+import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
 import { n as init_first, r as value$1 } from "./first.js";
 
 //#region second.js
-var second_exports = /* @__PURE__ */ __export({ value: () => value });
+var second_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 var value;
 var init_second = __esmMin((() => {
 	init_first();

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __export({ constant: () => constant });
+var lib_exports = /* @__PURE__ */ __exportAll({ constant: () => constant });
 var constant;
 var init_lib = __esmMin((() => {
 	constant = 1;
@@ -48,7 +48,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __export({ constant: () => constant });
+var lib_exports = /* @__PURE__ */ __exportAll({ constant: () => constant });
 var constant;
 var init_lib = __esmMin((() => {
 	constant = 1;

--- a/crates/rolldown/tests/rolldown/issues/6651/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6651/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.json
-var lib_exports = /* @__PURE__ */ __export({
+var lib_exports = /* @__PURE__ */ __exportAll({
 	a: () => a,
 	b: () => b,
 	c: () => c,

--- a/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
@@ -6,10 +6,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## c.js
 
 ```js
-import { i as __toCommonJS, n as __esmMin, r as __export, t as __commonJSMin } from "./index.js";
+import { i as __toCommonJS, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./index.js";
 
 //#region d.js
-var d_exports = /* @__PURE__ */ __export({ loadEventStreamCapability: () => loadEventStreamCapability });
+var d_exports = /* @__PURE__ */ __exportAll({ loadEventStreamCapability: () => loadEventStreamCapability });
 async function loadEventStreamCapability() {
 	const { EventStreamSerde } = await import("./e.js");
 	console.log(`EventStreamSerde: `, EventStreamSerde);
@@ -62,5 +62,5 @@ var require_b = /* @__PURE__ */ __commonJSMin(((exports) => {
 require_b();
 
 //#endregion
-export { __toCommonJS as i, __esmMin as n, __export as r, __commonJSMin as t };
+export { __toCommonJS as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
 ```

--- a/crates/rolldown/tests/rolldown/issues/6943/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6943/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __export({ tryPatchHandler: () => tryPatchHandler });
+var lib_exports = /* @__PURE__ */ __exportAll({ tryPatchHandler: () => tryPatchHandler });
 function tryPatchHandler(taskRoot, handlerPath) {
 	__require(taskRoot);
 }

--- a/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 
-exports.__export = __export;
+exports.__exportAll = __exportAll;
 exports.__reExport = __reExport;
 ```
 
@@ -20,7 +20,7 @@ require('./server.js');
 let zod = require("zod");
 
 //#region index.ts
-var _7233_exports = /* @__PURE__ */ require_rolldown_runtime.__export({
+var _7233_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({
 	object: () => zod.object,
 	string: () => zod.string
 });

--- a/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 
-exports.__export = __export;
+exports.__exportAll = __exportAll;
 exports.__reExport = __reExport;
 ```
 
@@ -20,7 +20,7 @@ require('./middle.js');
 let zod = require("zod");
 
 //#region index.ts
-var _7233_chain_exports = /* @__PURE__ */ require_rolldown_runtime.__export({
+var _7233_chain_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({
 	object: () => zod.object,
 	string: () => zod.string
 });

--- a/crates/rolldown/tests/rolldown/issues/7384/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7384/artifacts.snap
@@ -13,7 +13,7 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region mod.js
-var _7384_exports = /* @__PURE__ */ __export({ t: () => _babel_types });
+var _7384_exports = /* @__PURE__ */ __exportAll({ t: () => _babel_types });
 
 //#endregion
 //#region a.js
@@ -39,7 +39,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region mod.js
-var _7384_exports = /* @__PURE__ */ __export({ t: () => t$1 });
+var _7384_exports = /* @__PURE__ */ __exportAll({ t: () => t$1 });
 
 //#endregion
 //#region a.js

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
@@ -10,7 +10,7 @@ import nodeAssert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib-impl.js
-var lib_impl_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var lib_impl_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 function foo() {
 	return fn();
 }

--- a/crates/rolldown/tests/rolldown/misc/invalid_ident_repr/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/invalid_ident_repr/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region 1aaa.js
-var _1aaa_exports = /* @__PURE__ */ __export({ default: () => _1aaa_default });
+var _1aaa_exports = /* @__PURE__ */ __exportAll({ default: () => _1aaa_default });
 const a = "shared.js";
 var _1aaa_default = a;
 

--- a/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ abc: () => abc });
+var a_exports = /* @__PURE__ */ __exportAll({ abc: () => abc });
 const abc = void 0;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({
+var foo_exports = /* @__PURE__ */ __exportAll({
 	a: () => a,
 	a1: () => a1,
 	a2: () => a2,

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/artifacts.snap
@@ -10,7 +10,7 @@ export * from "node:fs"
 
 // HIDDEN [rolldown:runtime]
 //#region main.js
-var main_exports = /* @__PURE__ */ __export({ main: () => main });
+var main_exports = /* @__PURE__ */ __exportAll({ main: () => main });
 import * as import_node_fs from "node:fs";
 __reExport(main_exports, import_node_fs);
 var main;

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region main.js
-var main_exports = /* @__PURE__ */ __export({ main: () => main });
+var main_exports = /* @__PURE__ */ __exportAll({ main: () => main });
 __reExport(main_exports, require("node:fs"));
 var main;
 var init_main = __esmMin((() => {

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ default: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ default: () => foo$1 });
 function foo$1(a$1$1) {
 	assert.equal(a$1$1, a$1$1);
 	assert.equal(a$1, 1);

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
 function foo$1(a$1$1) {
 	console.log(a$1$1, a$1);
 }

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_esm_dynamic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_esm_dynamic/artifacts.snap
@@ -10,13 +10,13 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.mjs
-var lib_exports = /* @__PURE__ */ __export({}, 1);
+var lib_exports = /* @__PURE__ */ __exportAll({}, 1);
 import * as import_foo from "foo";
 __reExport(lib_exports, import_foo);
 
 //#endregion
 //#region reexports.mjs
-var reexports_exports = /* @__PURE__ */ __export({}, 1);
+var reexports_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(reexports_exports, lib_exports);
 
 //#endregion
@@ -38,12 +38,12 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region lib.mjs
-var lib_exports = /* @__PURE__ */ __export({}, 1);
+var lib_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(lib_exports, require("foo"));
 
 //#endregion
 //#region reexports.mjs
-var reexports_exports = /* @__PURE__ */ __export({}, 1);
+var reexports_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(reexports_exports, lib_exports);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external/artifacts.snap
@@ -11,7 +11,7 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region reexports.mjs
-var reexports_exports = /* @__PURE__ */ __export({}, 1);
+var reexports_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(reexports_exports, require("foo"));
 
 //#endregion
@@ -32,7 +32,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region reexports.mjs
-var reexports_exports = /* @__PURE__ */ __export({}, 1);
+var reexports_exports = /* @__PURE__ */ __exportAll({}, 1);
 import * as import_foo from "foo";
 __reExport(reexports_exports, import_foo);
 

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external_commonjs/artifacts.snap
@@ -17,7 +17,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region reexports.mjs
-var reexports_exports = /* @__PURE__ */ __export({}, 1);
+var reexports_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(reexports_exports, /* @__PURE__ */ __toESM(require_cjs(), 1));
 
 //#endregion
@@ -44,7 +44,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region reexports.mjs
-var reexports_exports = /* @__PURE__ */ __export({}, 1);
+var reexports_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(reexports_exports, /* @__PURE__ */ __toESM(require_cjs(), 1));
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/generated_code/symbols_ns/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/symbols_ns/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "assert";
 
 // HIDDEN [rolldown:runtime]
 //#region import.js
-var import_exports = /* @__PURE__ */ __export({ default: () => import_default }, 1);
+var import_exports = /* @__PURE__ */ __exportAll({ default: () => import_default }, 1);
 var import_default = "hi";
 
 //#endregion
@@ -33,7 +33,7 @@ let assert = require("assert");
 assert = __toESM(assert);
 
 //#region import.js
-var import_exports = /* @__PURE__ */ __export({ default: () => import_default }, 1);
+var import_exports = /* @__PURE__ */ __exportAll({ default: () => import_default }, 1);
 var import_default = "hi";
 
 //#endregion
@@ -66,7 +66,7 @@ assert.default.equal(String(import_exports), "[object Module]");
 assert = __toESM(assert);
 
 //#region import.js
-	var import_exports = /* @__PURE__ */ __export({ default: () => import_default }, 1);
+	var import_exports = /* @__PURE__ */ __exportAll({ default: () => import_default }, 1);
 	var import_default = "hi";
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/topics/generated_code/symbols_ns2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/symbols_ns2/artifacts.snap
@@ -25,12 +25,12 @@ import assert from "assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __export({ a: () => a }, 1);
+var lib_exports = /* @__PURE__ */ __exportAll({ a: () => a }, 1);
 const a = 1e3;
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ ns: () => lib_exports }, 1);
+var a_exports = /* @__PURE__ */ __exportAll({ ns: () => lib_exports }, 1);
 
 //#endregion
 //#region main.js
@@ -54,12 +54,12 @@ let assert = require("assert");
 assert = __toESM(assert);
 
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __export({ a: () => a }, 1);
+var lib_exports = /* @__PURE__ */ __exportAll({ a: () => a }, 1);
 const a = 1e3;
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ ns: () => lib_exports }, 1);
+var a_exports = /* @__PURE__ */ __exportAll({ ns: () => lib_exports }, 1);
 
 //#endregion
 //#region main.js
@@ -106,12 +106,12 @@ assert.default.equal(String(lib_exports), "[object Module]");
 assert = __toESM(assert);
 
 //#region lib.js
-	var lib_exports = /* @__PURE__ */ __export({ a: () => a }, 1);
+	var lib_exports = /* @__PURE__ */ __exportAll({ a: () => a }, 1);
 	const a = 1e3;
 
 //#endregion
 //#region a.js
-	var a_exports = /* @__PURE__ */ __export({ ns: () => lib_exports }, 1);
+	var a_exports = /* @__PURE__ */ __exportAll({ ns: () => lib_exports }, 1);
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept-outside-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept-outside-circular/artifacts.snap
@@ -11,21 +11,21 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = /* @__PURE__ */ __export({ c: () => c });
+var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __export({ b: () => b });
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ a: () => a });
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };
@@ -62,21 +62,21 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = /* @__PURE__ */ __export({ c: () => c });
+var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "cc";
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __export({ b: () => b });
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ a: () => a });
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region child.js
-var child_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var child_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
 __rolldown_runtime__.registerModule("child.js", { exports: child_exports });
 const foo = 0;
@@ -48,7 +48,7 @@ main_hot.accept("parent.js", () => {});
 import * as import_node_assert_00 from "node:assert";
 var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({});
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
 		__rolldown_runtime__.registerModule("parent.js", { exports: __rolldown_exports__ });
 		const hot_parent = __rolldown_runtime__.createModuleHotContext("parent.js");
 		var import_child_01 = __rolldown_runtime__.loadExports("child.js");
@@ -83,7 +83,7 @@ __rolldown_runtime__.applyUpdates([['main.js', 'parent.js']]);
 //#region child.js
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ foo: () => foo });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
 		__rolldown_runtime__.registerModule("child.js", { exports: __rolldown_exports__ });
 		const hot_child = __rolldown_runtime__.createModuleHotContext("child.js");
 		const foo = 1;

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
@@ -9,14 +9,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region child.js
-var child_exports = /* @__PURE__ */ __export({ value: () => value });
+var child_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
 __rolldown_runtime__.registerModule("child.js", { exports: child_exports });
 const value = "child";
 
 //#endregion
 //#region parent.js
-var parent_exports = /* @__PURE__ */ __export({
+var parent_exports = /* @__PURE__ */ __exportAll({
 	childValue: () => value,
 	parentValue: () => parentValue
 });
@@ -48,7 +48,7 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 //#region parent.js
 var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			childValue: () => childValue,
 			parentValue: () => parentValue
 		});
@@ -91,7 +91,7 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 //#region child.js
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ value: () => value });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
 		__rolldown_runtime__.registerModule("child.js", { exports: __rolldown_exports__ });
 		const hot_child = __rolldown_runtime__.createModuleHotContext("child.js");
 		const value = "child";
@@ -102,7 +102,7 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region parent.js
 var init_parent_1 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			childValue: () => childValue,
 			parentValue: () => parentValue
 		});
@@ -139,7 +139,7 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 //#region parent.js
 var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			parentValue: () => parentValue,
 			childValue: () => import_child_00.value
 		});

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_used/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_used/artifacts.snap
@@ -9,14 +9,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region child.js
-var child_exports = /* @__PURE__ */ __export({ value: () => value });
+var child_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
 __rolldown_runtime__.registerModule("child.js", { exports: child_exports });
 const value = "child";
 
 //#endregion
 //#region parent.js
-var parent_exports = /* @__PURE__ */ __export({
+var parent_exports = /* @__PURE__ */ __exportAll({
 	childValue: () => value,
 	parentValue: () => parentValue
 });
@@ -46,7 +46,7 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 //#region parent.js
 var init_parent_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			parentValue: () => parentValue,
 			childValue: () => import_child_00.value
 		});
@@ -83,7 +83,7 @@ __rolldown_runtime__.applyUpdates([['parent.js', 'parent.js']]);
 //#region child.js
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ value: () => value });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
 		__rolldown_runtime__.registerModule("child.js", { exports: __rolldown_exports__ });
 		const hot_child = __rolldown_runtime__.createModuleHotContext("child.js");
 		const value = "child";
@@ -94,7 +94,7 @@ var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region parent.js
 var init_parent_1 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			parentValue: () => parentValue,
 			childValue: () => import_child_10.value
 		});

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -23,10 +23,10 @@ export default require_exist_dep_cjs();
 ## exist-dep-esm.js
 
 ```js
-import { n as __export } from "./main.js";
+import { n as __exportAll } from "./main.js";
 
 //#region exist-dep-esm.js
-var exist_dep_esm_exports = /* @__PURE__ */ __export({ value: () => value });
+var exist_dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 const exist_dep_esm_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
 __rolldown_runtime__.registerModule("exist-dep-esm.js", { exports: exist_dep_esm_exports });
 const value = "exist-esm";
@@ -41,7 +41,7 @@ export { value };
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 async function foo() {
@@ -61,7 +61,7 @@ const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 
 //#endregion
-export { __export as n, __commonJSMin as t };
+export { __exportAll as n, __commonJSMin as t };
 ```
 
 # HMR Step 0
@@ -72,7 +72,7 @@ export { __export as n, __commonJSMin as t };
 //#region hmr.js
 var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			foo: () => foo,
 			bar: () => bar
 		});
@@ -108,7 +108,7 @@ var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer((function(
 //#region new-dep-esm.js
 var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ value: () => value });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
 		__rolldown_runtime__.registerModule("new-dep-esm.js", { exports: __rolldown_exports__ });
 		const hot_new_dep_esm = __rolldown_runtime__.createModuleHotContext("new-dep-esm.js");
 		const value = "new-esm";

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region dep.js
-var dep_exports = /* @__PURE__ */ __export({ value: () => value });
+var dep_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 const dep_hot = __rolldown_runtime__.createModuleHotContext("dep.js");
 __rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
 const value = "dep";
@@ -77,7 +77,7 @@ console.log(value);
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region dep.js
-var dep_exports = /* @__PURE__ */ __export({ value: () => value });
+var dep_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 const dep_hot = __rolldown_runtime__.createModuleHotContext("dep.js");
 __rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
 const value = "dep";

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region sub/foo.js
-var foo_exports = /* @__PURE__ */ __export({
+var foo_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	named: () => named$2
 });
@@ -20,7 +20,7 @@ const named$2 = "foo";
 
 //#endregion
 //#region sub/bar.js
-var bar_exports = /* @__PURE__ */ __export({
+var bar_exports = /* @__PURE__ */ __exportAll({
 	bar: () => bar,
 	named: () => named$1
 });
@@ -31,14 +31,14 @@ const named$1 = "bar";
 
 //#endregion
 //#region sub/named.js
-var named_exports = /* @__PURE__ */ __export({ named: () => named });
+var named_exports = /* @__PURE__ */ __exportAll({ named: () => named });
 const named_hot = __rolldown_runtime__.createModuleHotContext("sub/named.js");
 __rolldown_runtime__.registerModule("sub/named.js", { exports: named_exports });
 const named = "named";
 
 //#endregion
 //#region sub/index.js
-var sub_exports = /* @__PURE__ */ __export({
+var sub_exports = /* @__PURE__ */ __exportAll({
 	bar: () => bar,
 	foo: () => foo,
 	named: () => named
@@ -76,7 +76,7 @@ function text(el, text$1) {
 import * as import_node_assert_00 from "node:assert";
 var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({});
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
 		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
 		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
 		var import_sub_01 = __rolldown_runtime__.loadExports("sub/index.js");

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";
@@ -67,7 +67,7 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 //#region hmr.js
 var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ foo: () => foo });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
 		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
 		const hot_hmr = __rolldown_runtime__.createModuleHotContext("hmr.js");
 		const foo = "hello";

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region self_accept.js
-var self_accept_exports = /* @__PURE__ */ __export({ foo: () => foo$1 });
+var self_accept_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
 const self_accept_hot = __rolldown_runtime__.createModuleHotContext("self_accept.js");
 __rolldown_runtime__.registerModule("self_accept.js", { exports: self_accept_exports });
 const foo$1 = "foo";
@@ -21,7 +21,7 @@ self_accept_hot.accept((mod) => {
 
 //#endregion
 //#region single_accept/child.js
-var child_exports$1 = /* @__PURE__ */ __export({ count: () => count$3 });
+var child_exports$1 = /* @__PURE__ */ __exportAll({ count: () => count$3 });
 const child_hot$1 = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
 __rolldown_runtime__.registerModule("single_accept/child.js", { exports: child_exports$1 });
 const count$3 = 0;
@@ -48,7 +48,7 @@ process.on("beforeExit", (code) => {
 
 //#endregion
 //#region array_accept/child.js
-var child_exports = /* @__PURE__ */ __export({ count: () => count$1 });
+var child_exports = /* @__PURE__ */ __exportAll({ count: () => count$1 });
 const child_hot = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
 __rolldown_runtime__.registerModule("array_accept/child.js", { exports: child_exports });
 const count$1 = 0;
@@ -75,7 +75,7 @@ process.on("beforeExit", (code) => {
 
 //#endregion
 //#region optional_chaining.js
-var optional_chaining_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var optional_chaining_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const optional_chaining_hot = __rolldown_runtime__.createModuleHotContext("optional_chaining.js");
 __rolldown_runtime__.registerModule("optional_chaining.js", { exports: optional_chaining_exports });
 const foo = "foo";
@@ -101,7 +101,7 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 import * as import_node_assert_00 from "node:assert";
 var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ foo: () => foo });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
 		__rolldown_runtime__.registerModule("self_accept.js", { exports: __rolldown_exports__ });
 		const hot_self_accept = __rolldown_runtime__.createModuleHotContext("self_accept.js");
 		const foo = "foo2";
@@ -133,7 +133,7 @@ __rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
 import * as import_node_assert_00 from "node:assert";
 var init_self_accept_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ foo: () => foo });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
 		__rolldown_runtime__.registerModule("self_accept.js", { exports: __rolldown_exports__ });
 		const hot_self_accept = __rolldown_runtime__.createModuleHotContext("self_accept.js");
 		const foo = "foo3";
@@ -164,7 +164,7 @@ __rolldown_runtime__.applyUpdates([['self_accept.js', 'self_accept.js']]);
 //#region single_accept/child.js
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ count: () => count });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
 		__rolldown_runtime__.registerModule("single_accept/child.js", { exports: __rolldown_exports__ });
 		const hot_child = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
 		const count = 1;
@@ -192,7 +192,7 @@ __rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/ch
 //#region single_accept/child.js
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ count: () => count });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
 		__rolldown_runtime__.registerModule("single_accept/child.js", { exports: __rolldown_exports__ });
 		const hot_child = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
 		const count = 2;
@@ -220,7 +220,7 @@ __rolldown_runtime__.applyUpdates([['single_accept/parent.js', 'single_accept/ch
 //#region array_accept/child.js
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ count: () => count });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
 		__rolldown_runtime__.registerModule("array_accept/child.js", { exports: __rolldown_exports__ });
 		const hot_child = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
 		const count = 1;
@@ -248,7 +248,7 @@ __rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/chil
 //#region array_accept/child.js
 var init_child_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ count: () => count });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ count: () => count });
 		__rolldown_runtime__.registerModule("array_accept/child.js", { exports: __rolldown_exports__ });
 		const hot_child = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
 		const count = 2;
@@ -277,7 +277,7 @@ __rolldown_runtime__.applyUpdates([['array_accept/parent.js', 'array_accept/chil
 import * as import_node_assert_00 from "node:assert";
 var init_optional_chaining_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ foo: () => foo });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
 		__rolldown_runtime__.registerModule("optional_chaining.js", { exports: __rolldown_exports__ });
 		const hot_optional_chaining = __rolldown_runtime__.createModuleHotContext("optional_chaining.js");
 		const foo = "foo2";

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_4818/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_4818/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region foo.json
-var foo_exports = /* @__PURE__ */ __export({
+var foo_exports = /* @__PURE__ */ __exportAll({
 	default: () => foo_default,
 	foo: () => foo
 });
@@ -20,7 +20,7 @@ var foo_default = { foo };
 
 //#endregion
 //#region main.js
-var main_exports = /* @__PURE__ */ __export({ default: () => main_default });
+var main_exports = /* @__PURE__ */ __exportAll({ default: () => main_default });
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 var main_default = foo_default;

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
@@ -9,28 +9,28 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region common.js
-var common_exports = /* @__PURE__ */ __export({ prefix: () => prefix });
+var common_exports = /* @__PURE__ */ __exportAll({ prefix: () => prefix });
 const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
 __rolldown_runtime__.registerModule("common.js", { exports: common_exports });
 const prefix = "prefix:";
 
 //#endregion
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
 
 //#endregion
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __export({ bar: () => bar });
+var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
 
 //#endregion
 //#region messenger.js
-var messenger_exports = /* @__PURE__ */ __export({
+var messenger_exports = /* @__PURE__ */ __exportAll({
 	msg: () => msg,
 	sayMessage: () => sayMessage
 });
@@ -71,7 +71,7 @@ sayMessage();
 //#region foo.js
 var init_foo_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ foo: () => foo });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
 		__rolldown_runtime__.registerModule("foo.js", { exports: __rolldown_exports__ });
 		const hot_foo = __rolldown_runtime__.createModuleHotContext("foo.js");
 		var import_common_00 = __rolldown_runtime__.loadExports("common.js");
@@ -83,7 +83,7 @@ var init_foo_0 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region messenger.js
 var init_messenger_1 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			msg: () => msg,
 			sayMessage: () => sayMessage
 		});

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
@@ -9,28 +9,28 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region common.js
-var common_exports = /* @__PURE__ */ __export({ prefix: () => prefix });
+var common_exports = /* @__PURE__ */ __exportAll({ prefix: () => prefix });
 const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
 __rolldown_runtime__.registerModule("common.js", { exports: common_exports });
 const prefix = "prefix:";
 
 //#endregion
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
 
 //#endregion
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __export({ bar: () => bar });
+var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
 
 //#endregion
 //#region messenger.js
-var messenger_exports = /* @__PURE__ */ __export({
+var messenger_exports = /* @__PURE__ */ __exportAll({
 	msg: () => msg,
 	sayMessage: () => sayMessage
 });
@@ -71,7 +71,7 @@ setInterval(sayMessage, 1e3);
 //#region bar.js
 var init_bar_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ bar: () => bar });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ bar: () => bar });
 		__rolldown_runtime__.registerModule("bar.js", { exports: __rolldown_exports__ });
 		init_common_1();
 		const hot_bar = __rolldown_runtime__.createModuleHotContext("bar.js");
@@ -84,7 +84,7 @@ var init_bar_0 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region common.js
 var init_common_1 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ prefix: () => prefix });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ prefix: () => prefix });
 		__rolldown_runtime__.registerModule("common.js", { exports: __rolldown_exports__ });
 		const hot_common = __rolldown_runtime__.createModuleHotContext("common.js");
 		const prefix = "prefix-new:";
@@ -95,7 +95,7 @@ var init_common_1 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region foo.js
 var init_foo_2 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ foo: () => foo });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
 		__rolldown_runtime__.registerModule("foo.js", { exports: __rolldown_exports__ });
 		init_common_1();
 		const hot_foo = __rolldown_runtime__.createModuleHotContext("foo.js");
@@ -108,7 +108,7 @@ var init_foo_2 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region messenger.js
 var init_messenger_3 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			msg: () => msg,
 			sayMessage: () => sayMessage
 		});

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -6,11 +6,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## bar.js
 
 ```js
-import { t as __export } from "./main.js";
+import { t as __exportAll } from "./main.js";
 import { t as trim } from "./string.js";
 
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __export({ default: () => bar_default });
+var bar_exports = /* @__PURE__ */ __exportAll({ default: () => bar_default });
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 function bar_default() {
@@ -24,11 +24,11 @@ export { bar_default as default };
 ## foo.js
 
 ```js
-import { t as __export } from "./main.js";
+import { t as __exportAll } from "./main.js";
 import { n as unused, t as trim } from "./string.js";
 
 //#region utils/index.js
-var utils_exports = /* @__PURE__ */ __export({
+var utils_exports = /* @__PURE__ */ __exportAll({
 	trim: () => trim,
 	unused: () => unused
 });
@@ -37,7 +37,7 @@ __rolldown_runtime__.registerModule("utils/index.js", { exports: utils_exports }
 
 //#endregion
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ default: () => foo_default });
+var foo_exports = /* @__PURE__ */ __exportAll({ default: () => foo_default });
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 function foo_default() {
@@ -63,16 +63,16 @@ const routes = {
 };
 
 //#endregion
-export { __export as t };
+export { __exportAll as t };
 ```
 
 ## string.js
 
 ```js
-import { t as __export } from "./main.js";
+import { t as __exportAll } from "./main.js";
 
 //#region utils/string.js
-var string_exports = /* @__PURE__ */ __export({
+var string_exports = /* @__PURE__ */ __exportAll({
 	trim: () => trim,
 	unused: () => unused
 });

--- a/crates/rolldown/tests/rolldown/topics/hmr/no-accept-outside-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/no-accept-outside-circular/artifacts.snap
@@ -11,21 +11,21 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = /* @__PURE__ */ __export({ c: () => c });
+var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __export({ b: () => b });
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ a: () => a });
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };
@@ -59,21 +59,21 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = /* @__PURE__ */ __export({ c: () => c });
+var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "cc";
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __export({ b: () => b });
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ a: () => a });
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };

--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -18,7 +18,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#endregion
 //#region esm.js
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
-var esm_exports = /* @__PURE__ */ __export({ value: () => value });
+var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
 __rolldown_runtime__.registerModule("esm.js", { exports: esm_exports });
 const value = "main";

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -100,7 +100,7 @@ assert.strictEqual(requiredUmdLib.foo, "foo");
 
 //#endregion
 //#region cases/manual_reexport/lib.js
-var lib_exports = /* @__PURE__ */ __export({
+var lib_exports = /* @__PURE__ */ __exportAll({
 	Globals: () => Globals,
 	value: () => value
 });
@@ -112,7 +112,7 @@ const value = "lib";
 
 //#endregion
 //#region cases/manual_reexport/barrel.js
-var barrel_exports = /* @__PURE__ */ __export({
+var barrel_exports = /* @__PURE__ */ __exportAll({
 	Globals: () => Globals,
 	value: () => value
 });
@@ -131,7 +131,7 @@ assert.strictEqual(Globals, Object);
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo.mjs
-var foo_exports$1 = /* @__PURE__ */ __export({ foo: () => foo$1 });
+var foo_exports$1 = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
 init_trigger_dep();
 const foo_hot$1 = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo.mjs");
 __rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo.mjs", { exports: foo_exports$1 });
@@ -139,7 +139,7 @@ const foo$1 = "foo";
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo/index.mjs
-var foo_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 init_trigger_dep();
 const foo_hot = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo/index.mjs");
 __rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo/index.mjs", { exports: foo_exports });
@@ -174,7 +174,7 @@ if (main_hot) {
 //#region cases/deconflict_import_bindings/foo.mjs
 var init_foo_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ foo: () => foo });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
 		__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo.mjs", { exports: __rolldown_exports__ });
 		init_trigger_dep_11();
 		const hot_foo = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo.mjs");
@@ -187,7 +187,7 @@ var init_foo_0 = __rolldown_runtime__.createEsmInitializer((function() {
 //#region cases/deconflict_import_bindings/foo/index.mjs
 var init_foo_1 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ foo: () => foo });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ foo: () => foo });
 		__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo/index.mjs", { exports: __rolldown_exports__ });
 		init_trigger_dep_11();
 		const hot_foo = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo/index.mjs");
@@ -201,7 +201,7 @@ var init_foo_1 = __rolldown_runtime__.createEsmInitializer((function() {
 import * as import_node_assert_20 from "node:assert";
 var init_deconflict_import_bindings_2 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({});
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
 		__rolldown_runtime__.registerModule("cases/deconflict_import_bindings/index.js", { exports: __rolldown_exports__ });
 		init_foo_0();
 		init_foo_1();
@@ -219,7 +219,7 @@ var init_deconflict_import_bindings_2 = __rolldown_runtime__.createEsmInitialize
 //#region cases/manual_reexport/barrel.js
 var init_barrel_3 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			Globals: () => import_lib_30.Globals,
 			value: () => import_lib_30.value
 		});
@@ -237,7 +237,7 @@ var init_barrel_3 = __rolldown_runtime__.createEsmInitializer((function() {
 import * as import_node_assert_40 from "node:assert";
 var init_manual_reexport_4 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({});
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
 		__rolldown_runtime__.registerModule("cases/manual_reexport/index.js", { exports: __rolldown_exports__ });
 		init_barrel_3();
 		init_trigger_dep_11();
@@ -253,7 +253,7 @@ var init_manual_reexport_4 = __rolldown_runtime__.createEsmInitializer((function
 //#region cases/manual_reexport/lib.js
 var init_lib_5 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({
 			Globals: () => Globals,
 			value: () => value
 		});
@@ -309,7 +309,7 @@ var require_cjs_lib_7 = __rolldown_runtime__.createCjsInitializer((function(__ro
 import * as import_node_assert_80 from "node:assert";
 var init_require_8 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({});
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
 		__rolldown_runtime__.registerModule("cases/require/index.js", { exports: __rolldown_exports__ });
 		init_trigger_dep_11();
 		const hot_require = __rolldown_runtime__.createModuleHotContext("cases/require/index.js");
@@ -364,7 +364,7 @@ var require_umd_lib_9 = __rolldown_runtime__.createCjsInitializer((function(__ro
 //#region main.js
 var init_main_10 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({});
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
 		__rolldown_runtime__.registerModule("main.js", { exports: __rolldown_exports__ });
 		init_require_8();
 		init_manual_reexport_4();

--- a/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = /* @__PURE__ */ __export({ c: () => c });
+var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
@@ -22,14 +22,14 @@ c_hot.accept((nextExports) => {
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __export({ b: () => b });
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ a: () => a });
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };
@@ -53,7 +53,7 @@ assert.strictEqual(a.b.c, "c");
 import * as import_node_assert_00 from "node:assert";
 var init_c_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ c: () => c });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ c: () => c });
 		__rolldown_runtime__.registerModule("c.js", { exports: __rolldown_exports__ });
 		const hot_c = __rolldown_runtime__.createModuleHotContext("c.js");
 		var import_b_01 = __rolldown_runtime__.loadExports("b.js");

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -20,7 +20,7 @@ var require_dep_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#endregion
 //#region modules/dep-esm.js
 var import_dep_cjs = require_dep_cjs();
-var dep_esm_exports = /* @__PURE__ */ __export({ value: () => value$1 });
+var dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => value$1 });
 const dep_esm_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm.js");
 __rolldown_runtime__.registerModule("modules/dep-esm.js", { exports: dep_esm_exports });
 const value$1 = "esm";
@@ -36,7 +36,7 @@ var require_dep_cjs_default = /* @__PURE__ */ __commonJSMin(((exports, module) =
 //#endregion
 //#region modules/dep-esm-default.js
 var import_dep_cjs_default = /* @__PURE__ */ __toESM(require_dep_cjs_default());
-var dep_esm_default_exports = /* @__PURE__ */ __export({ default: () => dep_esm_default_default });
+var dep_esm_default_exports = /* @__PURE__ */ __exportAll({ default: () => dep_esm_default_default });
 const dep_esm_default_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-default.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-default.js", { exports: dep_esm_default_exports });
 var dep_esm_default_default = "esm-default";
@@ -52,7 +52,7 @@ var require_dep_cjs_named = /* @__PURE__ */ __commonJSMin(((exports, module) => 
 //#endregion
 //#region modules/dep-esm-named.js
 var import_dep_cjs_named = require_dep_cjs_named();
-var dep_esm_named_exports = /* @__PURE__ */ __export({ named: () => named });
+var dep_esm_named_exports = /* @__PURE__ */ __exportAll({ named: () => named });
 const dep_esm_named_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-named.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-named.js", { exports: dep_esm_named_exports });
 const named = "esm-named";
@@ -68,7 +68,7 @@ var require_dep_cjs_namespace = /* @__PURE__ */ __commonJSMin(((exports, module)
 //#endregion
 //#region modules/dep-esm-namespace.js
 var import_dep_cjs_namespace = /* @__PURE__ */ __toESM(require_dep_cjs_namespace());
-var dep_esm_namespace_exports = /* @__PURE__ */ __export({ value: () => value });
+var dep_esm_namespace_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 const dep_esm_namespace_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-namespace.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-namespace.js", { exports: dep_esm_namespace_exports });
 const value = "esm-namespace";
@@ -111,7 +111,7 @@ __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 import * as import_node_assert_00 from "node:assert";
 var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({});
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
 		__rolldown_runtime__.registerModule("hmr.js", { exports: __rolldown_exports__ });
 		require_new_dep_cjs_1();
 		init_new_dep_esm_2();
@@ -157,7 +157,7 @@ var require_new_dep_cjs_1 = __rolldown_runtime__.createCjsInitializer((function(
 //#region modules/new-dep-esm.js
 var init_new_dep_esm_2 = __rolldown_runtime__.createEsmInitializer((function() {
 	try {
-		var __rolldown_exports__ = __rolldown_runtime__.__export({ value: () => value });
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
 		__rolldown_runtime__.registerModule("modules/new-dep-esm.js", { exports: __rolldown_exports__ });
 		const hot_new_dep_esm = __rolldown_runtime__.createModuleHotContext("modules/new-dep-esm.js");
 		const value = "new-esm";

--- a/crates/rolldown/tests/rolldown/topics/keep_names/declaration2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/declaration2/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({
+var a_exports = /* @__PURE__ */ __exportAll({
 	delay: () => delay$1,
 	random64: () => random64$1
 });

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_snapshot_not_live/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_snapshot_not_live/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region file.js
-var file_exports = /* @__PURE__ */ __export({
+var file_exports = /* @__PURE__ */ __exportAll({
 	default: () => file_default,
 	inc: () => inc
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region main.js
-var main_exports = /* @__PURE__ */ __export({
+var main_exports = /* @__PURE__ */ __exportAll({
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
@@ -26,7 +26,7 @@ export { main_default as default, foo };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region main.js
-var main_exports = /* @__PURE__ */ __export({
+var main_exports = /* @__PURE__ */ __exportAll({
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
@@ -10,7 +10,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 // HIDDEN [rolldown:runtime]
 
 //#region main.js
-var main_exports = /* @__PURE__ */ __export({
+var main_exports = /* @__PURE__ */ __exportAll({
 	default: () => main_default,
 	foo: () => foo
 });

--- a/crates/rolldown/tests/rolldown/topics/tla/inline_dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/inline_dynamic_import/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region c.js
-var c_exports = /* @__PURE__ */ __export({ default: () => c_default });
+var c_exports = /* @__PURE__ */ __exportAll({ default: () => c_default });
 var _default, c_default;
 var init_c = __esmMin((() => {
 	_default = { aaa: { bbb: [
@@ -33,7 +33,7 @@ var init_b = __esmMin((async () => {
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __export({ buildDevConfig: () => buildDevConfig });
+var a_exports = /* @__PURE__ */ __exportAll({ buildDevConfig: () => buildDevConfig });
 var buildDevConfig;
 var init_a = __esmMin((async () => {
 	await init_b();

--- a/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
@@ -12,7 +12,7 @@ const foo = 1;
 
 //#endregion
 //#region export-star.js
-var export_star_exports = /* @__PURE__ */ __export({ foo: () => foo });
+var export_star_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/warnings/cannot_call_namespace/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/cannot_call_namespace/artifacts.snap
@@ -36,7 +36,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __export({ test: () => test });
+var foo_exports = /* @__PURE__ */ __exportAll({ test: () => test });
 const test = 1;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format/artifacts.snap
@@ -20,7 +20,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js
-	var lib_exports = /* @__PURE__ */ __export({ default: () => lib_default });
+	var lib_exports = /* @__PURE__ */ __exportAll({ default: () => lib_default });
 	var lib_default;
 	var init_lib = __esmMin((() => {
 		lib_default = 2;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -354,7 +354,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6
 
-- src_entry-!~{000}~.js => src_entry-umKmGigf.js
+- src_entry-!~{000}~.js => src_entry-BnAgoc4f.js
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js
 
@@ -370,7 +370,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6
 
-- src_entry-!~{000}~.js => src_entry-BRE7Gaou.js
+- src_entry-!~{000}~.js => src_entry-DCiVGrh4.js
 
 # tests/esbuild/dce/package_json_side_effects_false_no_warning_in_node_modules_issue999
 
@@ -496,7 +496,7 @@ expression: output
 
 # tests/esbuild/dce/tree_shaking_in_esm_wrapper
 
-- entry-!~{000}~.js => entry-U8BDzS5i.js
+- entry-!~{000}~.js => entry-BePXD7yz.js
 
 # tests/esbuild/dce/tree_shaking_js_with_associated_css
 
@@ -605,7 +605,7 @@ expression: output
 
 # tests/esbuild/default/bundle_esm_with_nested_var_issue4348
 
-- entry_js-!~{000}~.js => entry_js-DiD43zg5.js
+- entry_js-!~{000}~.js => entry_js-COs9l3dl.js
 
 # tests/esbuild/default/bundling_files_outside_of_outbase
 
@@ -639,7 +639,7 @@ expression: output
 
 # tests/esbuild/default/common_js_from_es6
 
-- entry-!~{000}~.js => entry-DPj_gKP_.js
+- entry-!~{000}~.js => entry-CK-Sm980.js
 
 # tests/esbuild/default/conditional_import
 
@@ -749,24 +749,24 @@ expression: output
 
 # tests/esbuild/default/export_forms_common_js
 
-- entry-!~{000}~.js => entry-e7oyEVIy.js
+- entry-!~{000}~.js => entry-DqHLcUhu.js
 
 # tests/esbuild/default/export_forms_es6
 
-- entry-!~{000}~.js => entry-CV_39RrB.js
+- entry-!~{000}~.js => entry-DkLerdwK.js
 
 # tests/esbuild/default/export_forms_iife
 
-- entry-!~{000}~.js => entry-BEU7eUUf.js
+- entry-!~{000}~.js => entry-BMGZPhxd.js
 
 # tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle
 
-- a-!~{000}~.js => a-CFbY0xjD.js
-- b-!~{001}~.js => b-BO8hiqPd.js
+- a-!~{000}~.js => a-BvjrJ9cP.js
+- b-!~{001}~.js => b-G9hXgjWn.js
 - c-!~{002}~.js => c-DbAYnqxj.js
 - d-!~{003}~.js => d-erhulghW.js
 - e-!~{004}~.js => e-BluWtRWc.js
-- b-!~{005}~.js => b-Bu6YeYjv.js
+- b-!~{005}~.js => b-C4Jajyl0.js
 
 # tests/esbuild/default/export_fs_browser
 
@@ -786,7 +786,7 @@ expression: output
 
 # tests/esbuild/default/export_special_name_bundle
 
-- entry-!~{000}~.js => entry-CxRjKLwV.js
+- entry-!~{000}~.js => entry-BjjJQ5Ef.js
 
 # tests/esbuild/default/export_wildcard_fs_node_common_js
 
@@ -798,11 +798,11 @@ expression: output
 
 # tests/esbuild/default/exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-2MvenvT0.js
+- entry-!~{000}~.js => entry-C09rIoOy.js
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
-- entry-!~{000}~.js => entry-D7kYvPB5.js
+- entry-!~{000}~.js => entry-DfZ2cDxp.js
 
 # tests/esbuild/default/external_module_exclusion_package
 
@@ -830,7 +830,7 @@ expression: output
 
 # tests/esbuild/default/forbid_string_export_names_bundle
 
-- entry-!~{000}~.js => entry--wFnnmma.js
+- entry-!~{000}~.js => entry-DxNiz98l.js
 
 # tests/esbuild/default/forbid_string_export_names_no_bundle
 
@@ -1205,9 +1205,9 @@ expression: output
 
 # tests/esbuild/default/mangle_props_import_export_bundled
 
-- entry-cjs-!~{001}~.js => entry-cjs-CLZOvq8N.js
-- entry-esm-!~{000}~.js => entry-esm-B_I49_P5.js
-- cjs-!~{002}~.js => cjs-CNypN8ou.js
+- entry-cjs-!~{001}~.js => entry-cjs-8ejPda3N.js
+- entry-esm-!~{000}~.js => entry-esm-C7jKUz9G.js
+- cjs-!~{002}~.js => cjs-DLh3OPP_.js
 
 # tests/esbuild/default/mangle_props_jsx_preserve
 
@@ -1370,7 +1370,7 @@ expression: output
 
 # tests/esbuild/default/minified_exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-Dz5xGliI.js
+- entry-!~{000}~.js => entry-D1McMU_m.js
 
 # tests/esbuild/default/minified_jsx_preserve_with_object_spread
 
@@ -1673,7 +1673,7 @@ expression: output
 
 # tests/esbuild/default/this_with_es6_syntax
 
-- entry-!~{000}~.js => entry-BRIDvGQu.js
+- entry-!~{000}~.js => entry-DFZD7V8M.js
 
 # tests/esbuild/default/to_esm_wrapper_omission
 
@@ -1851,19 +1851,19 @@ expression: output
 
 # tests/esbuild/importstar/export_self_and_import_self_common_js
 
-- entry-!~{000}~.js => entry-DiEcijmv.js
+- entry-!~{000}~.js => entry-ByOvwRH6.js
 
 # tests/esbuild/importstar/export_self_and_require_self_common_js
 
-- entry-!~{000}~.js => entry-bRw6-KmJ.js
+- entry-!~{000}~.js => entry-COL705w_.js
 
 # tests/esbuild/importstar/export_self_as_namespace_common_js
 
-- entry-!~{000}~.js => entry-BL0QIXR8.js
+- entry-!~{000}~.js => entry-DvfkJxvD.js
 
 # tests/esbuild/importstar/export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-D8anUUWc.js
+- entry-!~{000}~.js => entry-CpB6pM-Q.js
 
 # tests/esbuild/importstar/export_self_common_js
 
@@ -1897,13 +1897,13 @@ expression: output
 - external-ns-!~{001}~.js => external-ns-all2LFha.js
 - external-ns-def-!~{003}~.js => external-ns-def-CPrnmGVn.js
 - external-ns-default-!~{002}~.js => external-ns-default-Cbqf8eIs.js
-- internal-def-!~{00b}~.js => internal-def-B7MYUqTo.js
-- internal-default-!~{00a}~.js => internal-default-DUiSmlEx.js
-- internal-default2-!~{006}~.js => internal-default2-Cpugp8bs.js
-- internal-ns-!~{007}~.js => internal-ns-CNOkHIyl.js
-- internal-ns-def-!~{009}~.js => internal-ns-def-DZrgkTU3.js
-- internal-ns-default-!~{008}~.js => internal-ns-default-DQR6o0iN.js
-- internal-!~{00c}~.js => internal-D5zVAdWK.js
+- internal-def-!~{00b}~.js => internal-def-D_k0eYaQ.js
+- internal-default-!~{00a}~.js => internal-default-BqEYkRlK.js
+- internal-default2-!~{006}~.js => internal-default2-D1tDeBe1.js
+- internal-ns-def-!~{009}~.js => internal-ns-def-ClprM2kp.js
+- internal-ns-default-!~{008}~.js => internal-ns-default-BfmdVB_y.js
+- internal-ns-!~{007}~.js => internal-ns-oYOWLwV6.js
+- internal-!~{00c}~.js => internal-DNttTVWd.js
 
 # tests/esbuild/importstar/import_export_other_as_namespace_common_js
 
@@ -1911,7 +1911,7 @@ expression: output
 
 # tests/esbuild/importstar/import_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-D8anUUWc.js
+- entry-!~{000}~.js => entry-CpB6pM-Q.js
 
 # tests/esbuild/importstar/import_export_star_ambiguous_warning
 
@@ -1943,11 +1943,11 @@ expression: output
 
 # tests/esbuild/importstar/import_star_and_common_js
 
-- entry-!~{000}~.js => entry-D9yTZedt.js
+- entry-!~{000}~.js => entry-BMwA6T29.js
 
 # tests/esbuild/importstar/import_star_capture
 
-- entry-!~{000}~.js => entry-CA2297j7.js
+- entry-!~{000}~.js => entry-BMTZk2XA.js
 
 # tests/esbuild/importstar/import_star_common_js_capture
 
@@ -1963,7 +1963,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_import_star_capture
 
-- entry-!~{000}~.js => entry-CA2297j7.js
+- entry-!~{000}~.js => entry-BMTZk2XA.js
 
 # tests/esbuild/importstar/import_star_export_import_star_no_capture
 
@@ -1975,7 +1975,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_as_capture
 
-- entry-!~{000}~.js => entry-CA2297j7.js
+- entry-!~{000}~.js => entry-BMTZk2XA.js
 
 # tests/esbuild/importstar/import_star_export_star_as_no_capture
 
@@ -1987,7 +1987,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_capture
 
-- entry-!~{000}~.js => entry-Di5iSo_N.js
+- entry-!~{000}~.js => entry--xVxp6cF.js
 
 # tests/esbuild/importstar/import_star_export_star_no_capture
 
@@ -1995,7 +1995,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_omit_ambiguous
 
-- entry-!~{000}~.js => entry-B6aoMW1k.js
+- entry-!~{000}~.js => entry-DFePfCfT.js
 
 # tests/esbuild/importstar/import_star_export_star_unused
 
@@ -2031,7 +2031,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_of_export_star_as
 
-- entry-!~{000}~.js => entry-DLyWJBUb.js
+- entry-!~{000}~.js => entry-akSmFYWq.js
 
 # tests/esbuild/importstar/import_star_unused
 
@@ -2039,7 +2039,7 @@ expression: output
 
 # tests/esbuild/importstar/issue176
 
-- entry-!~{000}~.js => entry-BRUI-_l5.js
+- entry-!~{000}~.js => entry-C2v0EJZq.js
 
 # tests/esbuild/importstar/namespace_import_missing_common_js
 
@@ -2047,11 +2047,11 @@ expression: output
 
 # tests/esbuild/importstar/namespace_import_missing_es6
 
-- entry-!~{000}~.js => entry-D6_g7h9m.js
+- entry-!~{000}~.js => entry-BfwpFT-O.js
 
 # tests/esbuild/importstar/namespace_import_re_export_star_missing_es6
 
-- entry-!~{000}~.js => entry-Cu0yLav2.js
+- entry-!~{000}~.js => entry-BXlkpF-q.js
 
 # tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6
 
@@ -2075,7 +2075,7 @@ expression: output
 
 # tests/esbuild/importstar/re_export_namespace_import_missing_es6
 
-- entry-!~{000}~.js => entry-Cm8uC6QE.js
+- entry-!~{000}~.js => entry-CHes638X.js
 
 # tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6
 
@@ -2083,11 +2083,11 @@ expression: output
 
 # tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-CRxOLrnr.js
+- entry-!~{000}~.js => entry-CM26NCs6.js
 
 # tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-CRxOLrnr.js
+- entry-!~{000}~.js => entry-CM26NCs6.js
 
 # tests/esbuild/importstar/re_export_star_as_common_js_no_bundle
 
@@ -2159,11 +2159,11 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_and_common_js
 
-- entry-!~{000}~.js => entry-D6Z_TVc7.js
+- entry-!~{000}~.js => entry-_ddfNnkT.js
 
 # tests/esbuild/importstar_ts/ts_import_star_capture
 
-- entry-!~{000}~.js => entry-DXNKm6TU.js
+- entry-!~{000}~.js => entry-CCMpypc8.js
 
 # tests/esbuild/importstar_ts/ts_import_star_common_js_capture
 
@@ -2179,7 +2179,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture
 
-- entry-!~{000}~.js => entry-DXNKm6TU.js
+- entry-!~{000}~.js => entry-CCMpypc8.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_import_star_no_capture
 
@@ -2191,7 +2191,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture
 
-- entry-!~{000}~.js => entry-DXNKm6TU.js
+- entry-!~{000}~.js => entry-CCMpypc8.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_as_no_capture
 
@@ -2203,7 +2203,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_capture
 
-- entry-!~{000}~.js => entry-DmmQXMZm.js
+- entry-!~{000}~.js => entry-Cmt8YG1C.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_no_capture
 
@@ -2468,7 +2468,7 @@ expression: output
 
 # tests/esbuild/loader/loader_json_invalid_identifier_es6
 
-- entry-!~{000}~.js => entry-DVOOQG-i.js
+- entry-!~{000}~.js => entry-DDA7S-em.js
 
 # tests/esbuild/loader/loader_json_no_bundle
 
@@ -2984,27 +2984,27 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser
 
-- entry-!~{000}~.js => entry-nrt92tKj.js
+- entry-!~{000}~.js => entry-kpuZa0_b.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main
 
-- entry-!~{000}~.js => entry-rhiI4uwO.js
+- entry-!~{000}~.js => entry-oPMKq5Zu.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main
 
-- entry-!~{000}~.js => entry-BFTxDVsy.js
+- entry-!~{000}~.js => entry-pJ89N0zZ.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main
 
-- entry-!~{000}~.js => entry-BIcMrtIP.js
+- entry-!~{000}~.js => entry-CtGkUz4V.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file
 
-- entry-!~{000}~.js => entry-DvLw__g8.js
+- entry-!~{000}~.js => entry-dviZjHk0.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files
 
-- entry-!~{000}~.js => entry-Bnxzha-X.js
+- entry-!~{000}~.js => entry-CTuTImQr.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_only
 
@@ -3012,7 +3012,7 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_require_only
 
-- entry-!~{000}~.js => entry-CJak6S5W.js
+- entry-!~{000}~.js => entry-DelYX_kQ.js
 
 # tests/esbuild/packagejson/package_json_exports_alternatives
 
@@ -3184,7 +3184,7 @@ expression: output
 
 # tests/esbuild/splitting/edge_case_issue2793_without_splitting
 
-- index-!~{000}~.js => index-CirrTg-v.js
+- index-!~{000}~.js => index-DUCag6zs.js
 
 # tests/esbuild/splitting/splitting_assign_to_local
 
@@ -3258,9 +3258,9 @@ expression: output
 
 # tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617
 
-- a-!~{000}~.js => a-B8QxT3ip.js
-- b-!~{001}~.js => b-COQyeerB.js
-- a-!~{002}~.js => a-CqadyDvR.js
+- a-!~{000}~.js => a-PBwkuyOD.js
+- b-!~{001}~.js => b-BEYMaapY.js
+- a-!~{002}~.js => a-akC8J1zy.js
 
 # tests/esbuild/splitting/splitting_minify_identifiers_crash_issue437
 
@@ -3316,7 +3316,7 @@ expression: output
 
 # tests/esbuild/ts/export_type_issue379
 
-- entry-!~{000}~.js => entry-CnxsTExy.js
+- entry-!~{000}~.js => entry-BDtbHLUE.js
 
 # tests/esbuild/ts/this_inside_function_ts
 
@@ -3474,7 +3474,7 @@ expression: output
 
 # tests/esbuild/ts/ts_export_missing_es6
 
-- entry-!~{000}~.js => entry-BuxuDdkO.js
+- entry-!~{000}~.js => entry-DGxkyUjS.js
 
 # tests/esbuild/ts/ts_export_namespace
 
@@ -3510,7 +3510,7 @@ expression: output
 
 # tests/esbuild/ts/ts_import_equals_undefined_import
 
-- entry-!~{000}~.js => entry-KohaBHkm.js
+- entry-!~{000}~.js => entry-DBWK5sjd.js
 
 # tests/esbuild/ts/ts_import_missing_unused_es6
 
@@ -3630,7 +3630,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/basic_commonjs
 
-- main-!~{000}~.js => main-_CR9-_HU.js
+- main-!~{000}~.js => main-BHHaC6mR.js
 
 # tests/rolldown/cjs_compat/cjs_entry
 
@@ -3648,15 +3648,15 @@ expression: output
 
 # tests/rolldown/cjs_compat/esm_require_esm
 
-- main-!~{000}~.js => main-Bjg6T6uB.js
+- main-!~{000}~.js => main-CzWht2zu.js
 
 # tests/rolldown/cjs_compat/esm_require_esm_unused
 
-- main-!~{000}~.js => main-QyQhcPRe.js
+- main-!~{000}~.js => main-DH0m_kQa.js
 
 # tests/rolldown/cjs_compat/exoprt_star_of_cjs
 
-- main-!~{000}~.js => main-Cjg31eb4.js
+- main-!~{000}~.js => main-T7OOG3kA.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
 
@@ -3668,11 +3668,11 @@ expression: output
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
 
-- main-!~{000}~.js => main-DysDFWaX.js
+- main-!~{000}~.js => main-DLKx0URc.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
 
-- main-!~{000}~.js => main-CyQr6ErN.js
+- main-!~{000}~.js => main-CMmCqNLi.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
 
@@ -3697,15 +3697,15 @@ expression: output
 
 # tests/rolldown/cjs_compat/module.exports_export/basic
 
-- main-!~{000}~.js => main-aIMfrqcR.js
+- main-!~{000}~.js => main-ADhs7YGs.js
 
 # tests/rolldown/cjs_compat/module.exports_export/fallback
 
-- main-!~{000}~.js => main-BkkSOQiS.js
+- main-!~{000}~.js => main-CzBE7Hv-.js
 
 # tests/rolldown/cjs_compat/module.exports_export/priority
 
-- main-!~{000}~.js => main-DXIgz-eS.js
+- main-!~{000}~.js => main--ExzgxTS.js
 
 # tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named
 
@@ -3725,7 +3725,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/module.exports_export/with_default
 
-- main-!~{000}~.js => main-Be3AGnoN.js
+- main-!~{000}~.js => main-BITVMUs8.js
 
 # tests/rolldown/cjs_compat/multiple_circle_cjs_entries
 
@@ -3740,7 +3740,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout
 
-- main-!~{000}~.js => main-CFlqeH9F.js
+- main-!~{000}~.js => main-DaKUUiLf.js
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout2
 
@@ -3756,7 +3756,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_2
 
-- main-!~{000}~.js => main-Nmwzf9k-.js
+- main-!~{000}~.js => main-DATjVynl.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize
 
@@ -3774,7 +3774,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/reexport_commonjs
 
-- main-!~{000}~.js => main-fv2d4N30.js
+- main-!~{000}~.js => main-DJNuMCKL.js
 
 # tests/rolldown/cjs_compat/reexports_from_cjs
 
@@ -3796,7 +3796,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/require_call_expr_unused
 
-- main-!~{000}~.js => main-DnvoaSY9.js
+- main-!~{000}~.js => main-SQ43aH6p.js
 
 # tests/rolldown/cjs_compat/unnecessary_compat_default_property_access
 
@@ -3811,8 +3811,8 @@ expression: output
 
 # tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file
 
-- main-!~{000}~.js => main-Besvpz0U.js
-- foo-!~{001}~.js => foo-BiOvbkJW.js
+- main-!~{000}~.js => main-NIEFUZip.js
+- foo-!~{001}~.js => foo-Uv9gr96M.js
 
 # tests/rolldown/code_splitting/ensure_safe_identifier
 
@@ -3833,9 +3833,9 @@ expression: output
 
 # tests/rolldown/code_splitting/format_cjs_with_esm_require_esm
 
-- main1-!~{000}~.js => main1-Bo1hD4hr.js
-- main2-!~{001}~.js => main2-D5PNz2TR.js
-- chunk-!~{002}~.js => chunk-DdD6WhC_.js
+- main1-!~{000}~.js => main1-eDZ__DJN.js
+- main2-!~{001}~.js => main2-DawHdQL-.js
+- chunk-!~{002}~.js => chunk-Cvk4pxuF.js
 
 # tests/rolldown/code_splitting/format_cjs_with_module_cjs
 
@@ -3857,12 +3857,12 @@ expression: output
 
 # tests/rolldown/code_splitting/issue_5276
 
-- main-!~{000}~.js => main-D2wFultM.js
-- imp-!~{001}~.js => imp-SoLGn0du.js
+- main-!~{000}~.js => main-DducDCO3.js
+- imp-!~{001}~.js => imp-D2u5-7HD.js
 
 # tests/rolldown/dce/conditional_exports
 
-- main-!~{000}~.js => main-CneGfRWV.js
+- main-!~{000}~.js => main-CLgpo5DC.js
 
 # tests/rolldown/dce/defined_expr_in_paren_expr
 
@@ -3963,10 +3963,10 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/split_node_modules
 
-- main-!~{000}~.js => main-FN06bDZj.js
-- other-libs-!~{005}~.js => other-libs-CCaj3NK_.js
-- rolldown-runtime-!~{001}~.js => rolldown-runtime-2NVd3BEo.js
-- ui-!~{003}~.js => ui-cYo0VLjL.js
+- main-!~{000}~.js => main-CZ1IF8Uo.js
+- other-libs-!~{005}~.js => other-libs-BhogrQcJ.js
+- rolldown-runtime-!~{001}~.js => rolldown-runtime-COCv1wus.js
+- ui-!~{003}~.js => ui-C--J4tBt.js
 
 # tests/rolldown/function/context/defined
 
@@ -4095,7 +4095,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-B4wvMC0V.js
+- main-!~{000}~.js => main-BuOwM789.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4164,7 +4164,7 @@ expression: output
 
 # tests/rolldown/function/export_mode/cjs/default
 
-- main-!~{000}~.js => main-CTFpjasI.js
+- main-!~{000}~.js => main-W6ufBytz.js
 
 # tests/rolldown/function/export_mode/cjs/named
 
@@ -4176,11 +4176,11 @@ expression: output
 
 # tests/rolldown/function/export_mode/iife/default
 
-- main-!~{000}~.js => main-CfkHB5qM.js
+- main-!~{000}~.js => main-BBYS8Nu_.js
 
 # tests/rolldown/function/export_mode/iife/named
 
-- main-!~{000}~.js => main-CkuKlJBh.js
+- main-!~{000}~.js => main-BNjuvhTK.js
 
 # tests/rolldown/function/export_mode/umd/auto/none
 
@@ -4339,7 +4339,7 @@ expression: output
 
 # tests/rolldown/function/format/export_proto_namespace
 
-- main-!~{000}~.js => main-Bw-9b_dO.js
+- main-!~{000}~.js => main-DOVBuiuS.js
 
 # tests/rolldown/function/format/iife/conflict_exports_key
 
@@ -4407,7 +4407,7 @@ expression: output
 
 # tests/rolldown/function/inline_dynamic_imports/basic
 
-- main-!~{000}~.js => main-C1ceYg7r.js
+- main-!~{000}~.js => main-Bapc9Xl4.js
 
 # tests/rolldown/function/inline_dynamic_imports/issue-6935
 
@@ -4771,10 +4771,10 @@ expression: output
 
 # tests/rolldown/issues/3650
 
-- main-!~{000}~.js => main-CQHe1UcT.js
-- first-!~{005}~.js => first-DhrrPFoL.js
-- rolldown-runtime-!~{001}~.js => rolldown-runtime-BbrB2Vi1.js
-- second-!~{003}~.js => second-DaPxHoFn.js
+- main-!~{000}~.js => main-cl7qZVn_.js
+- first-!~{005}~.js => first-BYYHarZu.js
+- rolldown-runtime-!~{001}~.js => rolldown-runtime-vvRu2zEk.js
+- second-!~{003}~.js => second-B3DOFyUq.js
 
 # tests/rolldown/issues/3746/a
 
@@ -4796,7 +4796,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-DiFwMJ7N.js
+- main-!~{000}~.js => main-un8QjY40.js
 
 # tests/rolldown/issues/4196
 
@@ -4833,7 +4833,7 @@ expression: output
 
 # tests/rolldown/issues/4472
 
-- main-!~{000}~.js => main-O8lzF4lH.js
+- main-!~{000}~.js => main-96BM5Twy.js
 
 # tests/rolldown/issues/4491
 
@@ -4887,10 +4887,10 @@ expression: output
 
 # tests/rolldown/issues/5387
 
-- main-!~{000}~.js => main-5AaimRzg.js
-- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-MbrqZrn5.js
-- liblib/index-!~{005}~.js => liblib/index-Br-kCGDK.js
-- liblib/lib-!~{003}~.js => liblib/lib-DoTOmXMq.js
+- main-!~{000}~.js => main-DTSU2bID.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-D2H1NnSh.js
+- liblib/index-!~{005}~.js => liblib/index-7k5lzW3I.js
+- liblib/lib-!~{003}~.js => liblib/lib-DtktNslO.js
 
 # tests/rolldown/issues/5482
 
@@ -4916,7 +4916,7 @@ expression: output
 
 # tests/rolldown/issues/5870
 
-- main-!~{000}~.js => main-DjJKZnKQ.js
+- main-!~{000}~.js => main-CHzybDiW.js
 
 # tests/rolldown/issues/5871
 
@@ -4979,13 +4979,13 @@ expression: output
 
 # tests/rolldown/issues/6651
 
-- main-!~{000}~.js => main-DZ74b2O9.js
+- main-!~{000}~.js => main-CT6tqEQX.js
 
 # tests/rolldown/issues/6660
 
-- index-!~{000}~.js => index-BE8d2HS5.js
-- c-!~{001}~.js => c-BYqnuuyJ.js
-- e-!~{003}~.js => e-DWIylldC.js
+- index-!~{000}~.js => index-4k-Mt37U.js
+- c-!~{001}~.js => c-DbgVIkD1.js
+- e-!~{003}~.js => e-BN9Gbtnv.js
 
 # tests/rolldown/issues/6756
 
@@ -5044,15 +5044,15 @@ expression: output
 
 # tests/rolldown/issues/7233
 
-- index-!~{000}~.js => index-Bn3ZdonO.js
-- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-CwPsCxRt.js
-- server-!~{003}~.js => server-DzcxjD6x.js
+- index-!~{000}~.js => index-BTertlFf.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-l_zSX3-x.js
+- server-!~{003}~.js => server-BKb4kYU8.js
 
 # tests/rolldown/issues/7233_chain
 
-- index-!~{000}~.js => index-CWnsvjXX.js
-- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-CwPsCxRt.js
-- middle-!~{005}~.js => middle-gpaOAHhJ.js
+- index-!~{000}~.js => index-D_G-o2m_.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-l_zSX3-x.js
+- middle-!~{005}~.js => middle-BSmECWHb.js
 - server-!~{003}~.js => server-DFjxxrlr.js
 
 # tests/rolldown/issues/7286
@@ -5061,7 +5061,7 @@ expression: output
 
 # tests/rolldown/issues/7384
 
-- main-!~{000}~.js => main-DG2uveK9.js
+- main-!~{000}~.js => main-Bd-UmcB-.js
 
 # tests/rolldown/issues/7444
 
@@ -5083,7 +5083,7 @@ expression: output
 
 # tests/rolldown/issues/rolldown_vite_289
 
-- main-!~{000}~.js => main-CX_hZBSn.js
+- main-!~{000}~.js => main-VI1JWvhJ.js
 
 # tests/rolldown/issues/rolldown_vite_446
 
@@ -5156,7 +5156,7 @@ expression: output
 
 # tests/rolldown/misc/invalid_ident_repr
 
-- main-!~{000}~.js => main-Cxkixq2n.js
+- main-!~{000}~.js => main-HrmiIrKF.js
 
 # tests/rolldown/misc/merge_external_import
 
@@ -5274,9 +5274,9 @@ expression: output
 
 # tests/rolldown/misc/reexport_star
 
-- entry-!~{001}~.js => entry-CTZ8dXyc.js
-- main-!~{000}~.js => main-pGdZaZGo.js
-- a-!~{002}~.js => a-CPjz4mB7.js
+- entry-!~{001}~.js => entry-CAffeKTk.js
+- main-!~{000}~.js => main-jKEdOLVR.js
+- a-!~{002}~.js => a-5bffn5ds.js
 
 # tests/rolldown/misc/reexport_star_from_local_named_export
 
@@ -5316,8 +5316,8 @@ expression: output
 
 # tests/rolldown/misc/wrapped_esm
 
-- main-!~{000}~.js => main-Bwxjz2Xq.js
-- main-Bwxjz2Xq.js.map
+- main-!~{000}~.js => main-BraiWUCf.js
+- main-BraiWUCf.js.map
 
 # tests/rolldown/optimization/chunk_merging/cjs_format
 
@@ -5441,11 +5441,11 @@ expression: output
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry
 
-- entry-!~{000}~.js => entry-DIED1Ojv.js
+- entry-!~{000}~.js => entry-xjzaSOgk.js
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs
 
-- entry-!~{000}~.js => entry-D4anQDcN.js
+- entry-!~{000}~.js => entry-BoJBefRw.js
 
 # tests/rolldown/sourcemap/css_sourcemap_reference
 
@@ -5498,13 +5498,13 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/12
 
-- entry-!~{000}~.js => entry-CWDVDfqp.js
-- foo-!~{001}~.js => foo-B3AflSe9.js
+- entry-!~{000}~.js => entry-j1V3k2Xx.js
+- foo-!~{001}~.js => foo-DwnWFX0l.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/13
 
-- entry-!~{000}~.js => entry-DU3Rp14F.js
-- foo-!~{001}~.js => foo-jxfxhZwB.js
+- entry-!~{000}~.js => entry-B0ssMZSG.js
+- foo-!~{001}~.js => foo-aGY5MWt8.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/14
 
@@ -5524,11 +5524,11 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/18
 
-- entry-!~{000}~.js => entry-nIFmlMRa.js
+- entry-!~{000}~.js => entry-Dy53xtBV.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/19
 
-- entry-!~{000}~.js => entry-zfZlRfUq.js
+- entry-!~{000}~.js => entry-yMgn5zAq.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/2
 
@@ -5536,27 +5536,27 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/20
 
-- entry-!~{000}~.js => entry-DiO-MdT6.js
+- entry-!~{000}~.js => entry-Dhf8rkJZ.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/21
 
-- entry-!~{000}~.js => entry-BG9keO9N.js
+- entry-!~{000}~.js => entry-CvJCWYpr.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/22
 
-- entry-!~{000}~.js => entry-B2Xv-kZ7.js
+- entry-!~{000}~.js => entry-C5JtvjUT.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/23
 
-- entry-!~{000}~.js => entry-CTh5oA_T.js
+- entry-!~{000}~.js => entry-B1TBorC9.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/24
 
-- entry-!~{000}~.js => entry-DzTltVwM.js
+- entry-!~{000}~.js => entry-CtFiVmS1.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/25
 
-- entry-!~{000}~.js => entry-QBKfGQUs.js
+- entry-!~{000}~.js => entry-DdDxIQYT.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/26
 
@@ -5630,7 +5630,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/41
 
-- entry-!~{000}~.js => entry-XoLBPHeH.js
+- entry-!~{000}~.js => entry-BedQqpmy.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/42
 
@@ -5638,7 +5638,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/43
 
-- entry-!~{000}~.js => entry-CHqbe3tb.js
+- entry-!~{000}~.js => entry-DrVfrXgD.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/44
 
@@ -5646,15 +5646,15 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/45
 
-- entry-!~{000}~.js => entry-CGoBWbuF.js
+- entry-!~{000}~.js => entry-enM5gW4O.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/46
 
-- entry-!~{000}~.js => entry-CiMPkYut.js
+- entry-!~{000}~.js => entry-CPK6rwiQ.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/47
 
-- entry-!~{000}~.js => entry-BQYQynex.js
+- entry-!~{000}~.js => entry-Dz43LVnR.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/48
 
@@ -5734,7 +5734,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/7
 
-- entry-!~{000}~.js => entry-BSRfONys.js
+- entry-!~{000}~.js => entry-CCm3EQlJ.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/8
 
@@ -5742,7 +5742,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/9
 
-- entry-!~{000}~.js => entry-BXVLN4q0.js
+- entry-!~{000}~.js => entry-DokfWfHX.js
 
 # tests/rolldown/topics/chunk_modules_order/basic
 
@@ -5838,25 +5838,25 @@ expression: output
 
 # tests/rolldown/topics/deconflict/wrapped_esm_default_function
 
-- main-!~{000}~.js => main-CugJXCYT.js
-- main-CugJXCYT.js.map
+- main-!~{000}~.js => main-DFd_1436.js
+- main-DFd_1436.js.map
 
 # tests/rolldown/topics/deconflict/wrapped_esm_export_named_function
 
-- main-!~{000}~.js => main-BQ6B-COH.js
-- main-BQ6B-COH.js.map
+- main-!~{000}~.js => main-CeFjogtc.js
+- main-CeFjogtc.js.map
 
 # tests/rolldown/topics/generated_code/reexports_esm_dynamic
 
-- main-!~{000}~.js => main-kX5ihded.js
+- main-!~{000}~.js => main-x6vvwZtY.js
 
 # tests/rolldown/topics/generated_code/reexports_from_external
 
-- main-!~{000}~.js => main-fzoZnBvS.js
+- main-!~{000}~.js => main-YTroxBHR.js
 
 # tests/rolldown/topics/generated_code/reexports_from_external_commonjs
 
-- main-!~{000}~.js => main-fUy_BIwP.js
+- main-!~{000}~.js => main-DIehB1hM.js
 
 # tests/rolldown/topics/generated_code/symbols
 
@@ -5870,110 +5870,110 @@ expression: output
 
 # tests/rolldown/topics/generated_code/symbols_ns
 
-- main-!~{000}~.js => main-vaSjO_Xa.js
+- main-!~{000}~.js => main-CqnH_Z0b.js
 
 # tests/rolldown/topics/generated_code/symbols_ns2
 
-- main-!~{000}~.js => main-DNw9WvFh.js
+- main-!~{000}~.js => main-C-XWdoTA.js
 
 # tests/rolldown/topics/hmr/accept-outside-circular
 
-- main-!~{000}~.js => main-yqbJQRPS.js
+- main-!~{000}~.js => main-DSz5MJmJ.js
 
 # tests/rolldown/topics/hmr/change_accept
 
-- main-!~{000}~.js => main-Cy0J5LeM.js
+- main-!~{000}~.js => main-C35Mmeng.js
 
 # tests/rolldown/topics/hmr/cjs_no_export
 
-- main-!~{000}~.js => main-Ccc7i4mM.js
+- main-!~{000}~.js => main-X_g2bZ0J.js
 
 # tests/rolldown/topics/hmr/delete_file_not_used_anymore
 
-- main-!~{000}~.js => main-BFT5vJXs.js
+- main-!~{000}~.js => main-CsgZAC6v.js
 
 # tests/rolldown/topics/hmr/delete_file_used
 
-- main-!~{000}~.js => main-Cgcwqyj5.js
+- main-!~{000}~.js => main-D49Nsw7D.js
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-BVsagf63.js
-- exist-dep-cjs-!~{001}~.js => exist-dep-cjs-B-WqdnuU.js
-- exist-dep-esm-!~{003}~.js => exist-dep-esm-CvUiozan.js
+- main-!~{000}~.js => main-BwAe7MgM.js
+- exist-dep-cjs-!~{001}~.js => exist-dep-cjs-CANYwR0g.js
+- exist-dep-esm-!~{003}~.js => exist-dep-esm-DZIYUDvh.js
 
 # tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error
 
-- main-!~{000}~.js => main-B-6OWCri.js
+- main-!~{000}~.js => main-D5VGTVoj.js
 
 # tests/rolldown/topics/hmr/esm_no_export
 
-- main-!~{000}~.js => main-CFbz8g8Q.js
+- main-!~{000}~.js => main-BUfCkBy3.js
 
 # tests/rolldown/topics/hmr/export_star
 
-- main-!~{000}~.js => main-DF4GKlq1.js
+- main-!~{000}~.js => main-DZXa1h3d.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-Cr2fJ8Ju.js
+- main-!~{000}~.js => main-BxXzoZoo.js
 
 # tests/rolldown/topics/hmr/import_meta_hot_accept
 
-- main-!~{000}~.js => main-D0f-TceW.js
+- main-!~{000}~.js => main-Bph5QWD-.js
 
 # tests/rolldown/topics/hmr/issue_4818
 
-- main-!~{000}~.js => main-DmdMO7_6.js
+- main-!~{000}~.js => main-BZeYnog7.js
 
 # tests/rolldown/topics/hmr/issue_5149
 
-- main-!~{000}~.js => main-DHGuZD1G.js
+- main-!~{000}~.js => main-RQIydyBP.js
 
 # tests/rolldown/topics/hmr/issue_5150
 
-- main-!~{000}~.js => main-Ciule4Jx.js
+- main-!~{000}~.js => main-bUkcpoQJ.js
 
 # tests/rolldown/topics/hmr/issue_5159
 
-- main-!~{000}~.js => main-jTOvOHYB.js
-- bar-!~{003}~.js => bar-Bbo2fFE3.js
-- foo-!~{005}~.js => foo-CMy0ab5J.js
-- string-!~{001}~.js => string-B2q0E_z8.js
+- main-!~{000}~.js => main-ChMQCZJH.js
+- bar-!~{003}~.js => bar-D_PpnvEI.js
+- foo-!~{005}~.js => foo-CxO64BGU.js
+- string-!~{001}~.js => string-BiI3Sy7A.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-5FRCF2-x.js
-- index-!~{001}~.js => index-DJGvCZ5l.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-BoZPSyOb.js
+- entry-!~{000}~.js => entry-BwHh9JEp.js
+- index-!~{001}~.js => index-B6bzDVpC.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-BovuT1QU.js
 
 # tests/rolldown/topics/hmr/no-accept-outside-circular
 
-- main-!~{000}~.js => main-u-sRZrzL.js
+- main-!~{000}~.js => main-BXVbBM-d.js
 
 # tests/rolldown/topics/hmr/no_boundary_reload
 
-- main-!~{000}~.js => main-ClMA5P6T.js
+- main-!~{000}~.js => main-B85-HLTf.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-DA-Mkmnm.js
+- main-!~{000}~.js => main-Czl5UpAR.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-CT8uhQom.js
+- main-!~{000}~.js => main-DmJySX1j.js
 
 # tests/rolldown/topics/hmr/runtime_correctness
 
-- main-!~{000}~.js => main-vBItIea4.js
+- main-!~{000}~.js => main-o9NgRtR6.js
 
 # tests/rolldown/topics/hmr/self-accept-within-circular
 
-- main-!~{000}~.js => main-BP0ubZue.js
+- main-!~{000}~.js => main-DZ2t6NlC.js
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-CcRsFuqB.js
+- main-!~{000}~.js => main-CgEx5E29.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 
@@ -5994,7 +5994,7 @@ expression: output
 
 # tests/rolldown/topics/keep_names/declaration2
 
-- main-!~{000}~.js => main-8FCRJwRe.js
+- main-!~{000}~.js => main-CvDfXv9K.js
 
 # tests/rolldown/topics/keep_names/expression
 
@@ -6073,7 +6073,7 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/default_export_snapshot_not_live
 
-- main-!~{000}~.js => main-DC_77YGQ.js
+- main-!~{000}~.js => main-CVbT3w-K.js
 
 # tests/rolldown/topics/live_bindings/named_exports
 
@@ -6149,17 +6149,17 @@ expression: output
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped
 
-- main-!~{000}~.js => main-BYOMtY9x.js
+- main-!~{000}~.js => main-D2aaJgHN.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries
 
-- entry-!~{000}~.js => entry-xlCyna1A.js
-- entry2-!~{001}~.js => entry2-BXma5wqH.js
-- main-!~{002}~.js => main-B9MwVKOk.js
+- entry-!~{000}~.js => entry-QtGJ_nlM.js
+- entry2-!~{001}~.js => entry2-DLApVbrH.js
+- main-!~{002}~.js => main-D-XT4sEn.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs
 
-- main-!~{000}~.js => main-DU9VqvyW.js
+- main-!~{000}~.js => main-yYbp7LHV.js
 
 # tests/rolldown/topics/tla/basic
 
@@ -6167,7 +6167,7 @@ expression: output
 
 # tests/rolldown/topics/tla/inline_dynamic_import
 
-- main-!~{000}~.js => main-BTMg2o__.js
+- main-!~{000}~.js => main-BSOsT-XK.js
 
 # tests/rolldown/topics/tla/inside_try_block
 
@@ -6195,7 +6195,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/commonjs
 
-- main-!~{000}~.js => main-D1MpZPcJ.js
+- main-!~{000}~.js => main-DbroDfWT.js
 
 # tests/rolldown/tree_shaking/commonjs_5546
 
@@ -6203,7 +6203,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/commonjs_inline_const
 
-- main-!~{000}~.js => main-BOetPQ3-.js
+- main-!~{000}~.js => main-DaD2Ye4g.js
 
 # tests/rolldown/tree_shaking/commonjs_mixed
 
@@ -6273,7 +6273,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/export_star
 
-- main-!~{000}~.js => main-f6Q-w_rX.js
+- main-!~{000}~.js => main-Bl0LkFgN.js
 
 # tests/rolldown/tree_shaking/export_star2
 
@@ -6371,7 +6371,7 @@ expression: output
 
 # tests/rolldown/warnings/cannot_call_namespace
 
-- main-!~{000}~.js => main-Bga7cFqc.js
+- main-!~{000}~.js => main-lvdvs7gx.js
 
 # tests/rolldown/warnings/commonjs_variable_in_esm/1
 
@@ -6416,7 +6416,7 @@ expression: output
 
 # tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format
 
-- main-!~{000}~.js => main-DxtvSatn.js
+- main-!~{000}~.js => main-DYafMd5P.js
 
 # tests/rolldown/warnings/minified-with-eval
 

--- a/crates/rolldown_common/src/generated/runtime_helper.rs
+++ b/crates/rolldown_common/src/generated/runtime_helper.rs
@@ -16,7 +16,7 @@ bitflags! {
     const EsmMin = 1 << 8;
     const CommonJs = 1 << 9;
     const CommonJsMin = 1 << 10;
-    const Export = 1 << 11;
+    const ExportAll = 1 << 11;
     const CopyProps = 1 << 12;
     const ReExport = 1 << 13;
     const ToEsm = 1 << 14;
@@ -68,7 +68,7 @@ pub const RUNTIME_HELPER_NAMES: [&str; 20] = [
   "__esmMin",
   "__commonJS",
   "__commonJSMin",
-  "__export",
+  "__exportAll",
   "__copyProps",
   "__reExport",
   "__toESM",

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
@@ -1,6 +1,6 @@
 // @ts-check
 import {
-  __export,
+  __exportAll,
   __reExport,
   __toCommonJS,
   __toDynamicImportESM,
@@ -103,7 +103,7 @@ export class DevRuntime {
   /** @internal */
   __toCommonJS = __toCommonJS;
   /** @internal */
-  __export = __export;
+  __exportAll = __exportAll;
   /** @internal */
   __toDynamicImportESM = __toDynamicImportESM;
   /** @internal */


### PR DESCRIPTION
Closes https://github.com/rolldown/rolldown/issues/7634

Rename `__export` to `__exportAll` to ensure compatibility with `cjs-module-lexer` versions older than 2.1.1 (which covers most Node.js versions).

`cjs-module-lexer` has special handling for `__export` (a pattern used by TypeScript). Since it uses pattern matching to detect exports, it fails to parse `__export` when there is only one argument (e.g., `__export({ ... })`), expecting the form `__export(exports, { ... })` instead.

By using a different name, we avoid triggering this faulty heuristic entirely.


Background: 
why we change the `__export` runtime helper
1. https://github.com/rolldown/rolldown/pull/6114
2. https://github.com/rolldown/rolldown/pull/5926
