### PR TITLE
chore: add `homepage` field to package.json

### DIFF
--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-beta.57",
   "license": "MIT",
   "type": "module",
+  "homepage": "https://rolldown.rs/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rolldown/rolldown.git",

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-beta.57",
   "license": "MIT",
   "type": "module",
+  "homepage": "https://rolldown.rs/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rolldown/rolldown.git",


### PR DESCRIPTION
Adds rolldown website as homepagen in debug and pluginutils

Right now, the [@rolldown/debug](https://www.npmjs.com/package/@rolldown/debug) shows GitHub repository as website.
After this PR is merged and published, it'll show [rolldown.rs](https://rolldown.rs/) just like it's shown for [rolldown](https://www.npmjs.com/package/rolldown)

Docs for package.json homepage: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#homepage
