### PR TITLE
fix(rolldown_plugin_vite_reporter): apply padding before ANSI coloring for proper size column alignment

### DIFF
--- a/crates/rolldown_plugin_vite_reporter/src/lib.rs
+++ b/crates/rolldown_plugin_vite_reporter/src/lib.rs
@@ -323,19 +323,19 @@ impl Plugin for ViteReporterPlugin {
             }
           };
 
-          let size = utils::display_size(log_entry.size);
+          let size = format!("{:>size_pad$}", utils::display_size(log_entry.size));
           if group == utils::AssetGroup::JS && log_entry.size.div_ceil(1000) > self.chunk_limit {
             has_large_chunks = true;
             let _ = write!(
               &mut info,
-              "{:>size_pad$}",
-              size.if_supports_color(Stream::Stdout, |text| { text.bold().yellow().to_string() })
+              "{}",
+              size.if_supports_color(Stream::Stdout, |text| text.bold().yellow().to_string())
             );
           } else {
             let _ = write!(
               &mut info,
-              "{:>size_pad$}",
-              size.if_supports_color(Stream::Stdout, |text| { text.bold().dimmed().to_string() })
+              "{}",
+              size.if_supports_color(Stream::Stdout, |text| text.bold().dimmed().to_string())
             );
           }
 


### PR DESCRIPTION
close vitejs/rolldown-vite#549