### PR TITLE
fix: export runtime helpers for cross-chunk access

### DIFF
--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -154,7 +154,13 @@ pub fn render_chunk_exports(
         ChunkKind::EntryPoint { module, .. } => {
           let module =
             &link_output.module_table[module].as_normal().expect("should be normal module");
-          if matches!(module.exports_kind, ExportsKind::Esm) {
+          if !matches!(module.exports_kind, ExportsKind::Esm) {
+            export_items.retain(|(_, export_ref)| {
+              let canonical_ref = link_output.symbol_db.canonical_ref_for(*export_ref);
+              canonical_ref.owner != module.idx
+            });
+          }
+          if !export_items.is_empty() {
             let rendered_items = export_items
               .into_iter()
               .map(|(exported_name, export_ref)| {

--- a/crates/rolldown/tests/rolldown/issues/7655/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/7655/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/7655/a.js
+++ b/crates/rolldown/tests/rolldown/issues/7655/a.js
@@ -1,0 +1,4 @@
+module.exports = {
+  value: 42,
+  hello: 'world',
+}

--- a/crates/rolldown/tests/rolldown/issues/7655/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7655/artifacts.snap
@@ -1,0 +1,38 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+const require_main = require('./main.js');
+
+//#region a.js
+var require_a = /* @__PURE__ */ require_main.__commonJSMin(((exports, module) => {
+	module.exports = {
+		value: 42,
+		hello: "world"
+	};
+}));
+
+//#endregion
+Object.defineProperty(exports, 'default', {
+  enumerable: true,
+  get: function () {
+    return require_a();
+  }
+});
+```
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+
+//#region main.js
+Promise.resolve().then(() => __toDynamicImportESM()(require("./a.js"))).then((m) => console.log(m.default));
+
+//#endregion
+exports.__commonJSMin = __commonJSMin;
+```

--- a/crates/rolldown/tests/rolldown/issues/7655/main.js
+++ b/crates/rolldown/tests/rolldown/issues/7655/main.js
@@ -1,0 +1,1 @@
+import("./a.js").then((m) => console.log(m.default));

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5075,6 +5075,11 @@ expression: output
 
 - main-!~{000}~.js => main-Ce2nz_GJ.js
 
+# tests/rolldown/issues/7655
+
+- main-!~{000}~.js => main-QsKk41YI.js
+- a-!~{001}~.js => a-BKgXR6kK.js
+
 # tests/rolldown/issues/duplicate_default_export
 
 - main-!~{000}~.js => main-D5owKpO2.js


### PR DESCRIPTION
closes #7655, #7656