### PR TITLE
refactor(rolldown_error): remove dependency on rolldown_utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,7 +2997,6 @@ dependencies = [
  "oxc",
  "oxc_resolver",
  "rolldown-ariadne",
- "rolldown_utils",
  "ropey",
  "rustc-hash",
  "sugar_path",

--- a/crates/rolldown_error/Cargo.toml
+++ b/crates/rolldown_error/Cargo.toml
@@ -27,7 +27,6 @@ heck = { workspace = true }
 napi = { workspace = true, optional = true }
 oxc = { workspace = true }
 oxc_resolver = { workspace = true }
-rolldown_utils = { workspace = true }
 ropey = { workspace = true }
 rustc-hash = { workspace = true }
 sugar_path = { workspace = true }

--- a/crates/rolldown_error/src/build_diagnostic/events/filename_conflict.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/filename_conflict.rs
@@ -1,6 +1,5 @@
 use crate::{types::diagnostic_options::DiagnosticOptions, types::event_kind::EventKind};
 use arcstr::ArcStr;
-use rolldown_utils::concat_string;
 
 use super::BuildEvent;
 
@@ -15,10 +14,9 @@ impl BuildEvent for FilenameConflict {
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {
-    concat_string!(
-      "The emitted file ",
-      self.filename,
-      " overwrites a previously emitted file of the same name."
+    format!(
+      "The emitted file {} overwrites a previously emitted file of the same name.",
+      self.filename
     )
   }
 }


### PR DESCRIPTION
As the foundational error-handling crate in Rolldown, `rolldown_error` should not have dependencies on other crates.