### PR TITLE
refactor: use `InvalidOption` for hash placeholder generation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3591,6 +3591,7 @@ dependencies = [
  "rayon",
  "regex",
  "regress",
+ "rolldown_error",
  "rolldown_std_utils",
  "rustc-hash",
  "serde_json",

--- a/crates/rolldown/tests/rolldown/function/hashing/maximum-hash-size/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/hashing/maximum-hash-size/artifacts.snap
@@ -3,10 +3,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Errors
 
-## UNHANDLEABLE_ERROR
+## INVALID_OPTION
 
 ```text
-[UNHANDLEABLE_ERROR] Error: Something went wrong inside rolldown, please report this problem at https://github.com/rolldown/rolldown/issues.
-Hashes cannot be longer than 21 characters, received 22. Check the `entryFileNames` option.
+[INVALID_OPTION] Error: Hashes cannot be longer than 21 characters, received 22. Check the `entryFileNames` option.
 
 ```

--- a/crates/rolldown/tests/rolldown/function/hashing/minimum-hash-size/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/hashing/minimum-hash-size/artifacts.snap
@@ -3,10 +3,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Errors
 
-## UNHANDLEABLE_ERROR
+## INVALID_OPTION
 
 ```text
-[UNHANDLEABLE_ERROR] Error: Something went wrong inside rolldown, please report this problem at https://github.com/rolldown/rolldown/issues.
-To generate hashes for this number of chunks (currently 1), you need a minimum hash size of 6, received 2. Check the `entryFileNames` option.
+[INVALID_OPTION] Error: To generate hashes for this number of chunks (currently 1), you need a minimum hash size of 6, received 2. Check the `entryFileNames` option.
 
 ```

--- a/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
@@ -17,6 +17,8 @@ pub enum InvalidOptionType {
   InlineDynamicImportsWithMultipleInputs,
   InlineDynamicImportsWithPreserveModules,
   InlineDynamicImportsWithAdvancedChunks,
+  HashLengthTooLong { pattern_name: String, received: usize, max: usize },
+  HashLengthTooShort { pattern_name: String, received: usize, min: usize, chunk_count: u32 },
 }
 
 #[derive(Debug)]
@@ -91,6 +93,12 @@ impl BuildEvent for InvalidOption {
         }
         InvalidOptionType::InlineDynamicImportsWithAdvancedChunks => {
           "Invalid value \"true\" for option \"output.inlineDynamicImports\" - this option is not supported for \"output.advancedChunks\".".to_string()
+        }
+        InvalidOptionType::HashLengthTooLong { pattern_name, received, max } => {
+          format!("Hashes cannot be longer than {max} characters, received {received}. Check the `{pattern_name}` option.")
+        }
+        InvalidOptionType::HashLengthTooShort { pattern_name, received, min, chunk_count } => {
+          format!("To generate hashes for this number of chunks (currently {chunk_count}), you need a minimum hash size of {min}, received {received}. Check the `{pattern_name}` option.")
         }
     }
   }

--- a/crates/rolldown_utils/Cargo.toml
+++ b/crates/rolldown_utils/Cargo.toml
@@ -43,6 +43,7 @@ oxc_index = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 regex = { workspace = true }
 regress = { workspace = true }
+rolldown_error = { workspace = true }
 rolldown_std_utils = { workspace = true }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rolldown_utils/src/hash_placeholder.rs
+++ b/crates/rolldown_utils/src/hash_placeholder.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::sync::LazyLock;
 
 use memchr::memmem::Finder;
+use rolldown_error::{BuildDiagnostic, InvalidOptionType, SingleBuildResult};
 use rustc_hash::FxHashMap;
 
 use crate::indexmap::FxIndexSet;
@@ -97,13 +98,15 @@ pub struct HashPlaceholderGenerator {
 
 impl HashPlaceholderGenerator {
   // Refer to https://github.com/rollup/rollup/blob/1f2d579ccd4b39f223fed14ac7d031a6c848cd80/src/utils/hashPlaceholders.ts#L16-L17
-  pub fn generate(&mut self, len: Option<usize>, pattern_name: &str) -> anyhow::Result<String> {
+  pub fn generate(&mut self, len: Option<usize>, pattern_name: &str) -> SingleBuildResult<String> {
     let len = len.unwrap_or(DEFAULT_HASH_SIZE);
 
     if len > MAX_HASH_SIZE {
-      return Err(anyhow::anyhow!(
-        "Hashes cannot be longer than {MAX_HASH_SIZE} characters, received {len}. Check the `{pattern_name}` option.",
-      ));
+      return Err(BuildDiagnostic::invalid_option(InvalidOptionType::HashLengthTooLong {
+        pattern_name: pattern_name.to_string(),
+        received: len,
+        max: MAX_HASH_SIZE,
+      }));
     }
 
     let index_in_base64 = to_base64(self.next_index);
@@ -115,11 +118,12 @@ impl HashPlaceholderGenerator {
     // The placeholder format is `!~{index}~`, requiring at least `HASH_PLACEHOLDER_OVERHEAD + index_in_base64.len()` characters.
     // For example, with index 0 the placeholder is `!~{0}~` (6 chars), with index 100_000_000 it's `!~{5Zu40}~` (10 chars).
     if placeholder_size > len {
-      return Err(anyhow::anyhow!(
-        "To generate hashes for this number of chunks (currently {}), you need a minimum hash size of {}, received {len}. Check the `{pattern_name}` option.",
-        self.next_index + 1,
-        placeholder_size,
-      ));
+      return Err(BuildDiagnostic::invalid_option(InvalidOptionType::HashLengthTooShort {
+        pattern_name: pattern_name.to_string(),
+        received: len,
+        min: placeholder_size,
+        chunk_count: self.next_index + 1,
+      }));
     }
 
     placeholder.push_str(HASH_PLACEHOLDER_LEFT);

--- a/crates/rolldown_utils/src/replace_all_placeholder.rs
+++ b/crates/rolldown_utils/src/replace_all_placeholder.rs
@@ -1,23 +1,25 @@
 use std::borrow::Cow;
 
+use rolldown_error::SingleBuildResult;
+
 pub trait Replacer {
-  fn get(&mut self, _: Option<usize>) -> anyhow::Result<Cow<'_, str>>;
+  fn get(&mut self, _: Option<usize>) -> SingleBuildResult<Cow<'_, str>>;
 }
 
 impl Replacer for &str {
   #[inline]
-  fn get(&mut self, _: Option<usize>) -> anyhow::Result<Cow<'_, str>> {
+  fn get(&mut self, _: Option<usize>) -> SingleBuildResult<Cow<'_, str>> {
     Ok(Cow::Borrowed(self))
   }
 }
 
 impl<F, S> Replacer for F
 where
-  F: FnMut(Option<usize>) -> anyhow::Result<S>,
+  F: FnMut(Option<usize>) -> SingleBuildResult<S>,
   S: AsRef<str>,
 {
   #[inline]
-  fn get(&mut self, hash_len: Option<usize>) -> anyhow::Result<Cow<'_, str>> {
+  fn get(&mut self, hash_len: Option<usize>) -> SingleBuildResult<Cow<'_, str>> {
     Ok(Cow::Owned((*self)(hash_len)?.as_ref().to_string()))
   }
 }
@@ -30,7 +32,7 @@ pub trait ReplaceAllPlaceholder {
     self,
     placeholder: &str,
     replacer: impl Replacer,
-  ) -> anyhow::Result<String>;
+  ) -> SingleBuildResult<String>;
 }
 
 impl ReplaceAllPlaceholder for String {
@@ -44,7 +46,7 @@ impl ReplaceAllPlaceholder for String {
     self,
     placeholder: &str,
     replacer: impl Replacer,
-  ) -> anyhow::Result<String> {
+  ) -> SingleBuildResult<String> {
     replace_all_placeholder_impl(self, true, placeholder, replacer)
   }
 }
@@ -54,7 +56,7 @@ fn replace_all_placeholder_impl(
   is_len_enabled: bool,
   mut placeholder: &str,
   mut replacer: impl Replacer,
-) -> anyhow::Result<String> {
+) -> SingleBuildResult<String> {
   let offset = placeholder.len() - 1;
 
   if is_len_enabled {


### PR DESCRIPTION
closes #4021