### PR TITLE
refactor: use `NormalizedId` to ensure consistent behavior for id

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -31,7 +31,7 @@ pub async fn create_ecma_view(
 
   ctx.warnings.extend(warnings);
 
-  let module_id = ModuleId::new(&ctx.resolved_id.id);
+  let module_id = ModuleId::new(ctx.resolved_id.id.as_str());
 
   let repr_name = module_id.as_path().representative_file_name();
   let repr_name = legitimize_identifier_name(&repr_name);

--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -50,7 +50,7 @@ impl ExternalModuleTask {
     let external_module_side_effects =
       normalize_side_effects(&self.ctx.options, resolved_id, None, None, resolved_id.side_effects)
         .await?;
-    let id = ModuleId::new(&resolved_id.id);
+    let id = ModuleId::new(resolved_id.id.as_str());
     self.ctx.plugin_driver.set_module_info(
       &id.clone(),
       Arc::new(ModuleInfo {
@@ -68,7 +68,7 @@ impl ExternalModuleTask {
     let need_renormalize_render_path = !matches!(resolved_id.external, ResolvedExternal::Absolute)
       && Path::new(resolved_id.id.as_str()).is_absolute();
 
-    let file_name = if need_renormalize_render_path {
+    let file_name: ArcStr = if need_renormalize_render_path {
       let entries_common_dir = commondir::CommonDir::try_new(
         self.user_defined_entries.iter().map(|(_, resolved_id)| resolved_id.id.as_str()),
       )
@@ -77,22 +77,22 @@ impl ExternalModuleTask {
         Path::new(resolved_id.id.as_str()).relative(entries_common_dir.common_root());
       relative_path.to_slash_lossy().into()
     } else {
-      resolved_id.id.clone()
+      resolved_id.id.as_arc_str().clone()
     };
 
-    let identifier_name = if need_renormalize_render_path {
+    let identifier_name: ArcStr = if need_renormalize_render_path {
       Path::new(resolved_id.id.as_str())
         .relative(&self.ctx.options.cwd)
         .normalize()
         .to_slash_lossy()
         .into()
     } else {
-      resolved_id.id.clone()
+      resolved_id.id.as_arc_str().clone()
     };
     let legitimized_identifier_name = legitimize_identifier_name(&identifier_name);
     let msg = ModuleLoaderMsg::ExternalModuleDone(Box::new(ExternalModuleTaskResult {
       idx: self.module_idx,
-      id: resolved_id.id.clone(),
+      id: resolved_id.id.as_arc_str().clone(),
       name: file_name,
       identifier_name: legitimized_identifier_name.into(),
       side_effects: external_module_side_effects,

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -224,13 +224,16 @@ impl<'a> ModuleLoader<'a> {
     user_defined_entries: Arc<Vec<(Option<ArcStr>, ResolvedId)>>,
   ) -> ModuleIdx {
     let ctx = Arc::clone(&self.shared_context);
-    let idx = match self.cache.module_id_to_idx.get(&resolved_id.id) {
+    let idx = match self.cache.module_id_to_idx.get(resolved_id.id.as_str()) {
       Some(VisitState::Seen(idx)) => return *idx,
       Some(VisitState::Invalidate(idx)) => {
         // Full scan mode the idx will never be invalidated right?
         let idx = *idx;
         self.intermediate_normal_modules.alloc_ecma_module_idx_sparse(idx);
-        self.cache.module_id_to_idx.insert(resolved_id.id.clone(), VisitState::Seen(idx));
+        self
+          .cache
+          .module_id_to_idx
+          .insert(resolved_id.id.as_arc_str().clone(), VisitState::Seen(idx));
         idx
       }
       None if !self.is_full_scan => {
@@ -238,12 +241,18 @@ impl<'a> ModuleLoader<'a> {
         let len = self.cache.module_id_to_idx.len();
         let idx = self.intermediate_normal_modules.alloc_ecma_module_idx_sparse(len.into());
         self.new_added_modules_from_partial_scan.insert(idx);
-        self.cache.module_id_to_idx.insert(resolved_id.id.clone(), VisitState::Seen(idx));
+        self
+          .cache
+          .module_id_to_idx
+          .insert(resolved_id.id.as_arc_str().clone(), VisitState::Seen(idx));
         idx
       }
       None => {
         let idx = self.intermediate_normal_modules.alloc_ecma_module_idx();
-        self.cache.module_id_to_idx.insert(resolved_id.id.clone(), VisitState::Seen(idx));
+        self
+          .cache
+          .module_id_to_idx
+          .insert(resolved_id.id.as_arc_str().clone(), VisitState::Seen(idx));
         idx
       }
     };
@@ -323,10 +332,9 @@ impl<'a> ModuleLoader<'a> {
     }
 
     if self.is_full_scan && self.options.experimental.is_incremental_build_enabled() {
-      self
-        .cache
-        .user_defined_entry
-        .extend(user_defined_entries.iter().map(|(_, resolved_id)| resolved_id.id.clone()));
+      self.cache.user_defined_entry.extend(
+        user_defined_entries.iter().map(|(_, resolved_id)| resolved_id.id.as_arc_str().clone()),
+      );
     }
 
     // If it is in partial scan mode, we need to invalidate the changed modules
@@ -337,14 +345,16 @@ impl<'a> ModuleLoader<'a> {
       self
         .shared_context
         .plugin_driver
-        .invalidate_context_load_module(&resolved_id.id.clone().into());
-      if let Entry::Occupied(mut occ) = self.cache.module_id_to_idx.entry(resolved_id.id.clone()) {
+        .invalidate_context_load_module(&ModuleId::new(resolved_id.id.as_str()));
+      if let Entry::Occupied(mut occ) =
+        self.cache.module_id_to_idx.entry(resolved_id.id.as_arc_str().clone())
+      {
         let idx = occ.get().idx();
         occ.insert(VisitState::Invalidate(idx));
       }
       // User may update the entry module in incremental mode, so we need to make sure
       // if it is a user defined entry to avoid generate wrong asset file
-      let is_user_defined_entry = self.cache.user_defined_entry.contains(&resolved_id.id);
+      let is_user_defined_entry = self.cache.user_defined_entry.contains(resolved_id.id.as_str());
       // set `Owner` to `None` is safe, since it is used to emit `Unloadable` diagnostic, we know this is
       // exists in fs system, which is loadable.
       // TODO: copy assert_module_type
@@ -799,6 +809,6 @@ impl<'a> ModuleLoader<'a> {
     // module, but since all invalidate files is already processed in https://github.com/rolldown/rolldown/blob/88af0e2a29decd239b5555bff43e6499cae17ddc/crates/rolldown/src/module_loader/module_loader.rs?plain=1#L343
     // we could just skip to invalidate it again.
     // - if it does not need invalidate, we could just return the idx
-    self.cache.module_id_to_idx.get(&resolved_dep.id).map(|state| state.idx())
+    self.cache.module_id_to_idx.get(resolved_dep.id.as_str()).map(|state| state.idx())
   }
 }

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -77,7 +77,10 @@ impl ModuleTask {
   #[tracing::instrument(name="NormalModuleTask::run", level = "trace", skip_all, fields(module_id = ?self.resolved_id.id))]
   pub async fn run(mut self) {
     if let Err(errs) = self.run_inner().await {
-      self.ctx.plugin_driver.mark_context_load_modules_loaded(ModuleId::new(&self.resolved_id.id));
+      self
+        .ctx
+        .plugin_driver
+        .mark_context_load_modules_loaded(ModuleId::new(self.resolved_id.id.as_str()));
       self
         .ctx
         .tx
@@ -88,7 +91,7 @@ impl ModuleTask {
   }
 
   async fn run_inner(&mut self) -> BuildResult<()> {
-    let id = ModuleId::new(&self.resolved_id.id);
+    let id = ModuleId::new(self.resolved_id.id.as_str());
 
     self.ctx.plugin_driver.set_module_info(
       &id,
@@ -253,7 +256,7 @@ impl ModuleTask {
     if is_read_from_disk {
       // - Only add watch files for files read from disk.
       // - Add watch files as early as possible for we might be able to recover from build errors.
-      self.ctx.plugin_driver.watch_files.insert(self.resolved_id.id.clone());
+      self.ctx.plugin_driver.watch_files.insert(self.resolved_id.id.as_arc_str().clone());
     }
     let (source, mut module_type) = result.map_err(|err| {
       downcast_napi_error_diagnostics(err).unwrap_or_else(|e| {

--- a/crates/rolldown/src/module_loader/resolve_utils.rs
+++ b/crates/rolldown/src/module_loader/resolve_utils.rs
@@ -5,7 +5,7 @@ use futures::future::join_all;
 use oxc_index::IndexVec;
 use rolldown_common::{
   ImportKind, ImportRecordIdx, ImportRecordMeta, ModuleDefFormat, ModuleType,
-  NormalizedBundlerOptions, RUNTIME_MODULE_KEY, RawImportRecord, ResolvedId,
+  NormalizedBundlerOptions, NormalizedId, RUNTIME_MODULE_KEY, RawImportRecord, ResolvedId,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult, DiagnosableArcstr, EventKind};
 use rolldown_plugin::{__inner::resolve_id_check_external, PluginDriver, SharedPluginDriver};
@@ -26,7 +26,7 @@ pub async fn resolve_id(
   // Check runtime module
   if specifier == RUNTIME_MODULE_KEY {
     return Ok(Ok(ResolvedId {
-      id: specifier.into(),
+      id: NormalizedId::new(specifier),
       module_def_format: ModuleDefFormat::EsmMjs,
       ..Default::default()
     }));
@@ -91,7 +91,7 @@ pub async fn resolve_dependencies(
                 // Unlike rollup, we also emit errors for absolute path
                 build_errors.push(BuildDiagnostic::resolve_error(
                   source.clone(),
-                  self_resolved_id.id.clone(),
+                  self_resolved_id.id.as_arc_str().clone(),
                   if dep.is_unspanned() || is_css_module {
                     DiagnosableArcstr::String(specifier.as_str().into())
                   } else {
@@ -108,7 +108,7 @@ pub async fn resolve_dependencies(
                 warnings.push(
                   BuildDiagnostic::resolve_error(
                     source.clone(),
-                    self_resolved_id.id.clone(),
+                    self_resolved_id.id.as_arc_str().clone(),
                     if dep.is_unspanned() || is_css_module {
                       DiagnosableArcstr::String(specifier.as_str().into())
                     } else {
@@ -123,7 +123,7 @@ pub async fn resolve_dependencies(
               }
             }
             ret.push(ResolvedId {
-              id: specifier.as_str().into(),
+              id: NormalizedId::new(specifier.as_str()),
               external: true.into(),
               ..Default::default()
             });
@@ -131,7 +131,7 @@ pub async fn resolve_dependencies(
           ResolveError::MatchedAliasNotFound(..) => {
             build_errors.push(BuildDiagnostic::resolve_error(
                 source.clone(),
-                self_resolved_id.id.clone(),
+                self_resolved_id.id.as_arc_str().clone(),
                 if dep.is_unspanned() || is_css_module {
                   DiagnosableArcstr::String(specifier.as_str().into())
                 } else {
@@ -145,7 +145,7 @@ pub async fn resolve_dependencies(
           e => {
             build_errors.push(BuildDiagnostic::resolve_error(
               source.clone(),
-              self_resolved_id.id.clone(),
+              self_resolved_id.id.as_arc_str().clone(),
               if dep.is_unspanned() || is_css_module {
                 DiagnosableArcstr::String(specifier.as_str().into())
               } else {

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -9,8 +9,8 @@ use rolldown_common::{
   side_effects::DeterminedSideEffects,
 };
 use rolldown_common::{
-  ModuleLoaderMsg, RUNTIME_MODULE_ID, RUNTIME_MODULE_KEY, ResolvedId, RuntimeModuleBrief,
-  RuntimeModuleTaskResult,
+  ModuleLoaderMsg, NormalizedId, RUNTIME_MODULE_ID, RUNTIME_MODULE_KEY, ResolvedId,
+  RuntimeModuleBrief, RuntimeModuleTaskResult,
 };
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
 use rolldown_error::BuildResult;
@@ -91,7 +91,7 @@ impl RuntimeModuleTask {
     } = scan_result;
 
     let mut resolved_id = ResolvedId::make_dummy();
-    resolved_id.id = RUNTIME_MODULE_ID.resource_id().clone();
+    resolved_id.id = NormalizedId::new(RUNTIME_MODULE_ID.resource_id().clone());
     let module_type = ModuleType::Js;
 
     let resolved_deps = resolve_dependencies(

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/mod.rs
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/mod.rs
@@ -39,7 +39,7 @@ impl Plugin for TestPluginCaller {
         )
         .await??;
 
-      if custom_resolve_ret.id == "hello, world" {
+      if custom_resolve_ret.id.as_str() == "hello, world" {
         Ok(Some(HookResolveIdOutput {
           id: arcstr::literal!("hello, world"),
           external: Some(true.into()),

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -179,6 +179,7 @@ pub use crate::{
   types::named_export::LocalExport,
   types::named_import::{NamedImport, Specifier},
   types::namespace_alias::NamespaceAlias,
+  types::normalized_id::NormalizedId,
   types::output::{Output, OutputAsset},
   types::output_chunk::{Modules, OutputChunk},
   types::outputs_diagnostics::OutputsDiagnostics,

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -34,6 +34,7 @@ pub mod module_table;
 pub mod named_export;
 pub mod named_import;
 pub mod namespace_alias;
+pub mod normalized_id;
 pub mod output;
 pub mod output_chunk;
 pub mod outputs_diagnostics;

--- a/crates/rolldown_common/src/types/normalized_id.rs
+++ b/crates/rolldown_common/src/types/normalized_id.rs
@@ -1,0 +1,50 @@
+// This's a temporary abstraction to represent `normalized` resolved id, but if we call it `NormalizedResolvedId`, it may confuse with `ResolvedId`.
+// We might be able to replace this with `ModuleId` in the future. However, to push things forward, we create this new type for now.
+
+use arcstr::ArcStr;
+use sugar_path::SugarPath;
+
+/// Normalized module identifier that handles Windows path normalization.
+/// - If the id is an absolute path on Windows, backslashes are converted to forward slashes
+///   (e.g., `C:\path\to\file` → `C:/path/to/file`)
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct NormalizedId(ArcStr);
+
+impl NormalizedId {
+  pub fn new(value: impl Into<ArcStr>) -> Self {
+    let value = value.into();
+    if cfg!(windows) && value.as_path().is_absolute() {
+      Self(value.as_path().to_slash_lossy().into())
+    } else {
+      Self(value)
+    }
+  }
+
+  pub fn as_str(&self) -> &str {
+    &self.0
+  }
+
+  pub fn as_arc_str(&self) -> &ArcStr {
+    &self.0
+  }
+}
+
+impl std::ops::Deref for NormalizedId {
+  type Target = ArcStr;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl AsRef<str> for NormalizedId {
+  fn as_ref(&self) -> &str {
+    &self.0
+  }
+}
+
+impl std::fmt::Display for NormalizedId {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    std::fmt::Display::fmt(&self.0, f)
+  }
+}

--- a/crates/rolldown_common/src/types/resolved_id.rs
+++ b/crates/rolldown_common/src/types/resolved_id.rs
@@ -3,6 +3,7 @@ use std::{path::Path, sync::Arc};
 use arcstr::ArcStr;
 use rolldown_utils::stabilize_id::stabilize_id;
 
+use super::normalized_id::NormalizedId;
 use crate::{ModuleDefFormat, PackageJson, side_effects::HookSideEffects};
 
 #[derive(Debug, Clone, Copy)]
@@ -35,7 +36,7 @@ impl From<bool> for ResolvedExternal {
 
 #[derive(Debug, Default, Clone)]
 pub struct ResolvedId {
-  pub id: ArcStr,
+  pub id: NormalizedId,
   // https://github.com/defunctzombie/package-browser-field-spec/blob/8c4869f6a5cb0de26d208de804ad0a62473f5a03/README.md?plain=1#L62-L77
   pub ignored: bool,
   pub module_def_format: ModuleDefFormat,
@@ -52,7 +53,7 @@ impl ResolvedId {
   /// note: A dummy `ResolvedId` usually used with `DUMMY_MODULE_IDX`
   pub fn make_dummy() -> Self {
     Self {
-      id: arcstr::literal!(""),
+      id: NormalizedId::default(),
       ignored: false,
       module_def_format: ModuleDefFormat::Unknown,
       external: false.into(),
@@ -68,7 +69,7 @@ impl ResolvedId {
   /// 2. relative to the cwd, so it could show stable path across different machines
   pub fn debug_id(&self, cwd: impl AsRef<Path>) -> String {
     if self.id.trim_start().starts_with("data:") {
-      return format!("<{}>", self.id);
+      return format!("<{}>", self.id.as_str());
     }
 
     let stable = stabilize_id(&self.id, cwd.as_ref());
@@ -77,7 +78,7 @@ impl ResolvedId {
 
   pub fn new_external_without_side_effects(id: ArcStr) -> Self {
     Self {
-      id,
+      id: NormalizedId::new(id),
       ignored: false,
       module_def_format: ModuleDefFormat::Unknown,
       external: true.into(),

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -8,8 +8,8 @@ use anyhow::Context;
 use arcstr::ArcStr;
 use derive_more::Debug;
 use rolldown_common::{
-  FilenameTemplate, LogLevel, LogWithoutPlugin, ModuleDefFormat, ModuleLoaderMsg, PackageJson,
-  PluginIdx, ResolvedId, SharedFileEmitter, SharedModuleInfoDashMap,
+  FilenameTemplate, LogLevel, LogWithoutPlugin, ModuleDefFormat, ModuleLoaderMsg, NormalizedId,
+  PackageJson, PluginIdx, ResolvedId, SharedFileEmitter, SharedModuleInfoDashMap,
   SharedNormalizedBundlerOptions, side_effects::HookSideEffects,
 };
 use rolldown_resolver::{ResolveError, Resolver};
@@ -64,7 +64,7 @@ impl NativePluginContextImpl {
     };
     sender
       .send(ModuleLoaderMsg::FetchModule(Box::new(ResolvedId {
-        id: specifier.into(),
+        id: NormalizedId::new(specifier),
         side_effects,
         module_def_format,
         ..Default::default()
@@ -186,7 +186,7 @@ impl NativePluginContextImpl {
   }
 
   pub fn add_watch_file(&self, file: &str) {
-    self.watch_files.insert(file.into());
+    self.watch_files.insert(NormalizedId::new(file).as_arc_str().clone());
   }
 
   fn log(&self, level: LogLevel, log: LogWithoutPlugin) {

--- a/crates/rolldown_plugin/src/types/hook_resolve_id_output.rs
+++ b/crates/rolldown_plugin/src/types/hook_resolve_id_output.rs
@@ -17,7 +17,7 @@ impl HookResolveIdOutput {
 
   pub fn from_resolved_id(resolved_id: ResolvedId) -> Self {
     Self {
-      id: resolved_id.id,
+      id: resolved_id.id.as_arc_str().clone(),
       external: Some(resolved_id.external),
       side_effects: resolved_id.side_effects,
       normalize_external_id: None,

--- a/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 use arcstr::ArcStr;
 use rolldown_common::{
-  ImportKind, MakeAbsoluteExternalsRelative, NormalizedBundlerOptions, ResolvedExternal, ResolvedId,
+  ImportKind, MakeAbsoluteExternalsRelative, NormalizedBundlerOptions, NormalizedId,
+  ResolvedExternal, ResolvedId,
 };
 use rolldown_resolver::{ResolveError, Resolver};
 use std::{path::Path, sync::Arc};
@@ -116,7 +117,7 @@ async fn resolve_external(
       ResolvedExternal::Absolute
     };
 
-  Ok(Some(ResolvedId { id, external, ..Default::default() }))
+  Ok(Some(ResolvedId { id: NormalizedId::new(id), external, ..Default::default() }))
 }
 
 fn is_not_absolute_external(

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -3,7 +3,7 @@ use crate::{
   types::{custom_field::CustomField, hook_resolve_id_skipped::HookResolveIdSkipped},
 };
 use nodejs_built_in_modules::is_nodejs_builtin_module;
-use rolldown_common::{ImportKind, ModuleDefFormat, PackageJson, ResolvedId};
+use rolldown_common::{ImportKind, ModuleDefFormat, NormalizedId, PackageJson, ResolvedId};
 use rolldown_resolver::{ResolveError, Resolver};
 use std::{path::Path, sync::Arc};
 use sugar_path::SugarPath;
@@ -82,7 +82,7 @@ pub async fn resolve_id_with_plugins(
         .transpose()?;
       return Ok(Ok(ResolvedId {
         module_def_format: infer_module_def_format(r.id.as_str(), package_json.as_ref()),
-        id: r.id,
+        id: NormalizedId::new(r.id),
         external: r.external.unwrap_or_default(),
         normalize_external_id: r.normalize_external_id,
         side_effects: r.side_effects,
@@ -112,7 +112,7 @@ pub async fn resolve_id_with_plugins(
       .transpose()?;
     return Ok(Ok(ResolvedId {
       module_def_format: infer_module_def_format(r.id.as_str(), package_json.as_ref()),
-      id: r.id,
+      id: NormalizedId::new(r.id),
       external: r.external.unwrap_or_default(),
       normalize_external_id: r.normalize_external_id,
       side_effects: r.side_effects,
@@ -124,7 +124,7 @@ pub async fn resolve_id_with_plugins(
   // Auto external http url or data url
   if is_http_url(specifier) || is_data_url(specifier) {
     return Ok(Ok(ResolvedId {
-      id: specifier.into(),
+      id: NormalizedId::new(specifier),
       external: true.into(),
       ..Default::default()
     }));
@@ -150,17 +150,17 @@ fn resolve_id(
         // `resolved` is always prefixed with "node:" in compliance with the ESM specification.
         // we needs to use `is_runtime_module` to get the original specifier
         is_external_without_side_effects: is_nodejs_builtin_module(&resolved),
-        id: if resolved.starts_with("node:") && !is_runtime_module {
-          resolved[5..].into()
+        id: NormalizedId::new(if resolved.starts_with("node:") && !is_runtime_module {
+          &resolved[5..]
         } else {
-          resolved.into()
-        },
+          &resolved
+        }),
         external: true.into(),
         ..Default::default()
       }),
       ResolveError::Ignored(p) => Ok(ResolvedId {
         //(hyf0) TODO: This `p` doesn't seem to contains `query` or `fragment` of the input. We need to make sure this is ok
-        id: p.to_str().expect("Should be valid utf8").into(),
+        id: NormalizedId::new(p.to_str().expect("Should be valid utf8")),
         ignored: true,
         ..Default::default()
       }),

--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -385,8 +385,8 @@ impl GlobImportVisit<'_, '_> {
         }),
       );
       if let Ok(result) = rolldown_utils::futures::block_on(future) {
-        let id = match result {
-          Ok(resolved_id) => resolved_id.id.into(),
+        let id: Cow<'_, str> = match result {
+          Ok(resolved_id) => Cow::Owned(resolved_id.id.to_string()),
           Err(_) => Cow::Borrowed(glob),
         };
         let path = Path::new(id.as_ref());

--- a/crates/rolldown_plugin_vite_import_glob/src/utils_2.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils_2.rs
@@ -297,8 +297,8 @@ impl GlobImportVisit<'_> {
         }),
       );
       if let Ok(result) = rolldown_utils::futures::block_on(future) {
-        let id = match result {
-          Ok(resolved_id) => resolved_id.id.into(),
+        let id: Cow<'_, str> = match result {
+          Ok(resolved_id) => Cow::Owned(resolved_id.id.to_string()),
           Err(_) => Cow::Borrowed(glob),
         };
         let path = Path::new(id.as_ref());

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -11,7 +11,8 @@ use oxc_resolver::{
   TsConfig as OxcTsConfig,
 };
 use rolldown_common::{
-  ImportKind, ModuleDefFormat, PackageJson, Platform, ResolveOptions, ResolvedId, TsConfig,
+  ImportKind, ModuleDefFormat, NormalizedId, PackageJson, Platform, ResolveOptions, ResolvedId,
+  TsConfig,
 };
 use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_utils::dashmap::FxDashMap;
@@ -77,7 +78,7 @@ pub struct ResolveReturn {
 impl From<ResolveReturn> for ResolvedId {
   fn from(resolved_return: ResolveReturn) -> Self {
     ResolvedId {
-      id: resolved_return.path,
+      id: NormalizedId::new(resolved_return.path),
       module_def_format: resolved_return.module_def_format,
       package_json: resolved_return.package_json,
       ..Default::default()

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -250,7 +250,9 @@ impl IntegrationTest {
         );
         let watched_files = dev_engine.get_watched_files().await.unwrap();
         assert!(
-          changed_files.iter().all(|(file, _)| watched_files.contains(file)),
+          changed_files
+            .iter()
+            .all(|(file, _)| watched_files.contains(&*file.as_path().to_slash_lossy())),
           "All changed files must be in watched files: {changed_files:#?} not in {watched_files:#?}"
         );
         dev_engine


### PR DESCRIPTION
`NormalizedId` is a temporary abstraction to represent `normalized` resolved id, but if we call it `NormalizedResolvedId`, it may confuse with `ResolvedId`.