### PR TITLE
refactor(devtools): emit data to `<CWD>/node_modules/.rolldown`

### DIFF
--- a/crates/rolldown_devtools/src/devtools_formatter.rs
+++ b/crates/rolldown_devtools/src/devtools_formatter.rs
@@ -82,7 +82,7 @@ where
     let session_id =
       found_context_fields.get("session_id").map(String::as_str).unwrap_or(DEFAULT_SESSION_ID);
 
-    std::fs::create_dir_all(format!(".rolldown/{session_id}")).ok();
+    std::fs::create_dir_all(format!("node_modules/.rolldown/{session_id}")).ok();
 
     let is_session_meta = action_value
       .as_object()
@@ -91,9 +91,9 @@ where
       .is_some_and(|v| v == "SessionMeta");
 
     let log_filename: Arc<str> = if is_session_meta {
-      format!(".rolldown/{session_id}/meta.json").into()
+      format!("node_modules/.rolldown/{session_id}/meta.json").into()
     } else {
-      format!(".rolldown/{session_id}/logs.json").into()
+      format!("node_modules/.rolldown/{session_id}/logs.json").into()
     };
 
     if !OPENED_FILE_HANDLES.contains_key(&log_filename) {

--- a/packages/rolldown/tests/behaviors/emit-debug-data/devtools.test.js
+++ b/packages/rolldown/tests/behaviors/emit-debug-data/devtools.test.js
@@ -6,7 +6,7 @@ import { expect, test } from 'vitest';
 
 // `.rolldown` dir is generated based on real cwd instead of `InputOptions.cwd`. We might be able to solve this in the future.
 // For now, we just live with it.
-const dotRolldownFileName = join(process.cwd(), '.rolldown');
+const dotRolldownFileName = join(process.cwd(), 'node_modules/.rolldown');
 
 test(`emit data for devtool`, async () => {
   // Clean up previous test data if exists


### PR DESCRIPTION
Had confirmed with devtools team