### PR TITLE
refactor:  use `ModuleId` as the type of `ResolvedId#id`

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -308,7 +308,7 @@ impl Bundle {
                 })
                 .collect(),
             ),
-            importers: Some(module.importers.iter().map(|i| i.to_string()).collect()),
+            importers: Some(module.importers.iter().map(ToString::to_string).collect()),
           },
           Module::External(module) => action::Module {
             id: module.id.to_string(),

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -1,6 +1,6 @@
 use oxc_index::IndexVec;
 use rolldown_common::{
-  EcmaModuleAstUsage, EcmaRelated, EcmaView, EcmaViewMeta, ImportRecordIdx, ModuleId, ModuleType,
+  EcmaModuleAstUsage, EcmaRelated, EcmaView, EcmaViewMeta, ImportRecordIdx, ModuleType,
   RawImportRecord, ResolvedId, SharedNormalizedBundlerOptions, SideEffectDetail,
   side_effects::{DeterminedSideEffects, HookSideEffects},
 };
@@ -31,7 +31,7 @@ pub async fn create_ecma_view(
 
   ctx.warnings.extend(warnings);
 
-  let module_id = ModuleId::new(&ctx.resolved_id.id);
+  let module_id = ctx.resolved_id.id.clone();
 
   let repr_name = module_id.as_path().representative_file_name();
   let repr_name = legitimize_identifier_name(&repr_name);

--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -2,8 +2,7 @@ use std::{path::Path, sync::Arc};
 
 use arcstr::ArcStr;
 use rolldown_common::{
-  ExternalModuleTaskResult, ModuleId, ModuleIdx, ModuleInfo, ModuleLoaderMsg, ResolvedExternal,
-  ResolvedId,
+  ExternalModuleTaskResult, ModuleIdx, ModuleInfo, ModuleLoaderMsg, ResolvedExternal, ResolvedId,
 };
 use rolldown_error::BuildResult;
 use rolldown_utils::{ecmascript::legitimize_identifier_name, indexmap::FxIndexSet};
@@ -50,7 +49,7 @@ impl ExternalModuleTask {
     let external_module_side_effects =
       normalize_side_effects(&self.ctx.options, resolved_id, None, None, resolved_id.side_effects)
         .await?;
-    let id = ModuleId::new(&resolved_id.id);
+    let id = resolved_id.id.clone();
     self.ctx.plugin_driver.set_module_info(
       &id.clone(),
       Arc::new(ModuleInfo {
@@ -68,7 +67,7 @@ impl ExternalModuleTask {
     let need_renormalize_render_path = !matches!(resolved_id.external, ResolvedExternal::Absolute)
       && Path::new(resolved_id.id.as_str()).is_absolute();
 
-    let file_name = if need_renormalize_render_path {
+    let file_name: ArcStr = if need_renormalize_render_path {
       let entries_common_dir = commondir::CommonDir::try_new(
         self.user_defined_entries.iter().map(|(_, resolved_id)| resolved_id.id.as_str()),
       )
@@ -77,22 +76,22 @@ impl ExternalModuleTask {
         Path::new(resolved_id.id.as_str()).relative(entries_common_dir.common_root());
       relative_path.to_slash_lossy().into()
     } else {
-      resolved_id.id.clone()
+      resolved_id.id.as_arc_str().clone()
     };
 
-    let identifier_name = if need_renormalize_render_path {
+    let identifier_name: ArcStr = if need_renormalize_render_path {
       Path::new(resolved_id.id.as_str())
         .relative(&self.ctx.options.cwd)
         .normalize()
         .to_slash_lossy()
         .into()
     } else {
-      resolved_id.id.clone()
+      resolved_id.id.as_arc_str().clone()
     };
     let legitimized_identifier_name = legitimize_identifier_name(&identifier_name);
     let msg = ModuleLoaderMsg::ExternalModuleDone(Box::new(ExternalModuleTaskResult {
       idx: self.module_idx,
-      id: resolved_id.id.clone(),
+      id: resolved_id.id.as_arc_str().clone(),
       name: file_name,
       identifier_name: legitimized_identifier_name.into(),
       side_effects: external_module_side_effects,

--- a/crates/rolldown/src/module_loader/resolve_utils.rs
+++ b/crates/rolldown/src/module_loader/resolve_utils.rs
@@ -4,7 +4,7 @@ use arcstr::ArcStr;
 use futures::future::join_all;
 use oxc_index::IndexVec;
 use rolldown_common::{
-  ImportKind, ImportRecordIdx, ImportRecordMeta, ModuleDefFormat, ModuleType,
+  ImportKind, ImportRecordIdx, ImportRecordMeta, ModuleDefFormat, ModuleId, ModuleType,
   NormalizedBundlerOptions, RUNTIME_MODULE_KEY, RawImportRecord, ResolvedId,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult, DiagnosableArcstr, EventKind};
@@ -26,7 +26,7 @@ pub async fn resolve_id(
   // Check runtime module
   if specifier == RUNTIME_MODULE_KEY {
     return Ok(Ok(ResolvedId {
-      id: specifier.into(),
+      id: ModuleId::new(specifier),
       module_def_format: ModuleDefFormat::EsmMjs,
       ..Default::default()
     }));
@@ -91,7 +91,7 @@ pub async fn resolve_dependencies(
                 // Unlike rollup, we also emit errors for absolute path
                 build_errors.push(BuildDiagnostic::resolve_error(
                   source.clone(),
-                  self_resolved_id.id.clone(),
+                  self_resolved_id.id.as_arc_str().clone(),
                   if dep.is_unspanned() || is_css_module {
                     DiagnosableArcstr::String(specifier.as_str().into())
                   } else {
@@ -108,7 +108,7 @@ pub async fn resolve_dependencies(
                 warnings.push(
                   BuildDiagnostic::resolve_error(
                     source.clone(),
-                    self_resolved_id.id.clone(),
+                    self_resolved_id.id.as_arc_str().clone(),
                     if dep.is_unspanned() || is_css_module {
                       DiagnosableArcstr::String(specifier.as_str().into())
                     } else {
@@ -123,7 +123,7 @@ pub async fn resolve_dependencies(
               }
             }
             ret.push(ResolvedId {
-              id: specifier.as_str().into(),
+              id: ModuleId::new(specifier.as_str()),
               external: true.into(),
               ..Default::default()
             });
@@ -131,7 +131,7 @@ pub async fn resolve_dependencies(
           ResolveError::MatchedAliasNotFound(..) => {
             build_errors.push(BuildDiagnostic::resolve_error(
                 source.clone(),
-                self_resolved_id.id.clone(),
+                self_resolved_id.id.as_arc_str().clone(),
                 if dep.is_unspanned() || is_css_module {
                   DiagnosableArcstr::String(specifier.as_str().into())
                 } else {
@@ -145,7 +145,7 @@ pub async fn resolve_dependencies(
           e => {
             build_errors.push(BuildDiagnostic::resolve_error(
               source.clone(),
-              self_resolved_id.id.clone(),
+              self_resolved_id.id.as_arc_str().clone(),
               if dep.is_unspanned() || is_css_module {
                 DiagnosableArcstr::String(specifier.as_str().into())
               } else {

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -91,7 +91,7 @@ impl RuntimeModuleTask {
     } = scan_result;
 
     let mut resolved_id = ResolvedId::make_dummy();
-    resolved_id.id = RUNTIME_MODULE_ID.resource_id().clone();
+    resolved_id.id = RUNTIME_MODULE_ID;
     let module_type = ModuleType::Js;
 
     let resolved_deps = resolve_dependencies(

--- a/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/mod.rs
+++ b/crates/rolldown/tests/rolldown/plugin/plugin_context/custom_arg_in_resolve/mod.rs
@@ -39,7 +39,7 @@ impl Plugin for TestPluginCaller {
         )
         .await??;
 
-      if custom_resolve_ret.id == "hello, world" {
+      if custom_resolve_ret.id.as_str() == "hello, world" {
         Ok(Some(HookResolveIdOutput {
           id: arcstr::literal!("hello, world"),
           external: Some(true.into()),

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_pre_rendered_chunk.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_pre_rendered_chunk.rs
@@ -16,7 +16,7 @@ impl From<rolldown_common::RollupPreRenderedChunk> for PreRenderedChunk {
       is_entry: value.is_entry,
       is_dynamic_entry: value.is_dynamic_entry,
       facade_module_id: value.facade_module_id.map(|x| x.to_string()),
-      module_ids: value.module_ids.iter().map(|x| x.to_string()).collect(),
+      module_ids: value.module_ids.iter().map(ToString::to_string).collect(),
       exports: value.exports.iter().map(ToString::to_string).collect(),
     }
   }

--- a/crates/rolldown_binding/src/types/binding_module_info.rs
+++ b/crates/rolldown_binding/src/types/binding_module_info.rs
@@ -19,13 +19,13 @@ impl BindingModuleInfo {
   pub fn new(inner: Arc<rolldown_common::ModuleInfo>) -> Self {
     Self {
       id: inner.id.to_string(),
-      importers: inner.importers.iter().map(|id| id.to_string()).collect(),
-      dynamic_importers: inner.dynamic_importers.iter().map(|id| id.to_string()).collect(),
-      imported_ids: inner.imported_ids.iter().map(|id| id.to_string()).collect(),
+      importers: inner.importers.iter().map(ToString::to_string).collect(),
+      dynamic_importers: inner.dynamic_importers.iter().map(ToString::to_string).collect(),
+      imported_ids: inner.imported_ids.iter().map(ToString::to_string).collect(),
       dynamically_imported_ids: inner
         .dynamically_imported_ids
         .iter()
-        .map(|id| id.to_string())
+        .map(ToString::to_string)
         .collect(),
       is_entry: inner.is_entry,
       exports: inner.exports.iter().map(ToString::to_string).collect(),

--- a/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
+++ b/crates/rolldown_binding/src/types/binding_rendered_chunk.rs
@@ -77,7 +77,7 @@ pub struct BindingModules {
 impl From<&rolldown_common::Modules> for BindingModules {
   fn from(modules: &rolldown_common::Modules) -> Self {
     let values = modules.values.iter().map(|x| BindingRenderedModule::new(Arc::clone(x))).collect();
-    let keys = modules.keys.iter().map(|x| x.to_string()).collect();
+    let keys = modules.keys.iter().map(ToString::to_string).collect();
     Self { values, keys }
   }
 }

--- a/crates/rolldown_common/src/types/module_id.rs
+++ b/crates/rolldown_common/src/types/module_id.rs
@@ -16,7 +16,8 @@ pub struct ModuleId {
 impl ModuleId {
   #[inline]
   pub fn new(value: impl Into<ArcStr>) -> Self {
-    Self::new_arc_str(value.into())
+    let value = value.into();
+    Self { resource_id: value }
   }
 
   #[inline]
@@ -25,6 +26,14 @@ impl ModuleId {
   }
 
   pub fn resource_id(&self) -> &ArcStr {
+    &self.resource_id
+  }
+
+  pub fn as_str(&self) -> &str {
+    &self.resource_id
+  }
+
+  pub fn as_arc_str(&self) -> &ArcStr {
     &self.resource_id
   }
 
@@ -62,6 +71,12 @@ impl From<String> for ModuleId {
 impl From<ArcStr> for ModuleId {
   fn from(value: ArcStr) -> Self {
     Self::new(value)
+  }
+}
+
+impl std::fmt::Display for ModuleId {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    std::fmt::Display::fmt(&self.resource_id, f)
   }
 }
 

--- a/crates/rolldown_common/src/types/resolved_id.rs
+++ b/crates/rolldown_common/src/types/resolved_id.rs
@@ -3,6 +3,7 @@ use std::{path::Path, sync::Arc};
 use arcstr::ArcStr;
 use rolldown_utils::stabilize_id::stabilize_id;
 
+use super::module_id::ModuleId;
 use crate::{ModuleDefFormat, PackageJson, side_effects::HookSideEffects};
 
 #[derive(Debug, Clone, Copy)]
@@ -35,7 +36,7 @@ impl From<bool> for ResolvedExternal {
 
 #[derive(Debug, Default, Clone)]
 pub struct ResolvedId {
-  pub id: ArcStr,
+  pub id: ModuleId,
   // https://github.com/defunctzombie/package-browser-field-spec/blob/8c4869f6a5cb0de26d208de804ad0a62473f5a03/README.md?plain=1#L62-L77
   pub ignored: bool,
   pub module_def_format: ModuleDefFormat,
@@ -52,7 +53,7 @@ impl ResolvedId {
   /// note: A dummy `ResolvedId` usually used with `DUMMY_MODULE_IDX`
   pub fn make_dummy() -> Self {
     Self {
-      id: arcstr::literal!(""),
+      id: ModuleId::default(),
       ignored: false,
       module_def_format: ModuleDefFormat::Unknown,
       external: false.into(),
@@ -68,7 +69,7 @@ impl ResolvedId {
   /// 2. relative to the cwd, so it could show stable path across different machines
   pub fn debug_id(&self, cwd: impl AsRef<Path>) -> String {
     if self.id.trim_start().starts_with("data:") {
-      return format!("<{}>", self.id);
+      return format!("<{}>", self.id.as_str());
     }
 
     let stable = stabilize_id(&self.id, cwd.as_ref());
@@ -77,7 +78,7 @@ impl ResolvedId {
 
   pub fn new_external_without_side_effects(id: ArcStr) -> Self {
     Self {
-      id,
+      id: ModuleId::new(id),
       ignored: false,
       module_def_format: ModuleDefFormat::Unknown,
       external: true.into(),

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -8,8 +8,8 @@ use anyhow::Context;
 use arcstr::ArcStr;
 use derive_more::Debug;
 use rolldown_common::{
-  FilenameTemplate, LogLevel, LogWithoutPlugin, ModuleDefFormat, ModuleLoaderMsg, PackageJson,
-  PluginIdx, ResolvedId, SharedFileEmitter, SharedModuleInfoDashMap,
+  FilenameTemplate, LogLevel, LogWithoutPlugin, ModuleDefFormat, ModuleId, ModuleLoaderMsg,
+  PackageJson, PluginIdx, ResolvedId, SharedFileEmitter, SharedModuleInfoDashMap,
   SharedNormalizedBundlerOptions, side_effects::HookSideEffects,
 };
 use rolldown_resolver::{ResolveError, Resolver};
@@ -64,7 +64,7 @@ impl NativePluginContextImpl {
     };
     sender
       .send(ModuleLoaderMsg::FetchModule(Box::new(ResolvedId {
-        id: specifier.into(),
+        id: ModuleId::new(specifier),
         side_effects,
         module_def_format,
         ..Default::default()

--- a/crates/rolldown_plugin/src/types/hook_resolve_id_output.rs
+++ b/crates/rolldown_plugin/src/types/hook_resolve_id_output.rs
@@ -17,7 +17,7 @@ impl HookResolveIdOutput {
 
   pub fn from_resolved_id(resolved_id: ResolvedId) -> Self {
     Self {
-      id: resolved_id.id,
+      id: resolved_id.id.as_arc_str().clone(),
       external: Some(resolved_id.external),
       side_effects: resolved_id.side_effects,
       normalize_external_id: None,

--- a/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 use arcstr::ArcStr;
 use rolldown_common::{
-  ImportKind, MakeAbsoluteExternalsRelative, NormalizedBundlerOptions, ResolvedExternal, ResolvedId,
+  ImportKind, MakeAbsoluteExternalsRelative, ModuleId, NormalizedBundlerOptions, ResolvedExternal,
+  ResolvedId,
 };
 use rolldown_resolver::{ResolveError, Resolver};
 use std::{path::Path, sync::Arc};
@@ -116,7 +117,7 @@ async fn resolve_external(
       ResolvedExternal::Absolute
     };
 
-  Ok(Some(ResolvedId { id, external, ..Default::default() }))
+  Ok(Some(ResolvedId { id: ModuleId::new(id), external, ..Default::default() }))
 }
 
 fn is_not_absolute_external(

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -3,7 +3,7 @@ use crate::{
   types::{custom_field::CustomField, hook_resolve_id_skipped::HookResolveIdSkipped},
 };
 use nodejs_built_in_modules::is_nodejs_builtin_module;
-use rolldown_common::{ImportKind, ModuleDefFormat, PackageJson, ResolvedId};
+use rolldown_common::{ImportKind, ModuleDefFormat, ModuleId, PackageJson, ResolvedId};
 use rolldown_resolver::{ResolveError, Resolver};
 use std::{path::Path, sync::Arc};
 use sugar_path::SugarPath;
@@ -82,7 +82,7 @@ pub async fn resolve_id_with_plugins(
         .transpose()?;
       return Ok(Ok(ResolvedId {
         module_def_format: infer_module_def_format(r.id.as_str(), package_json.as_ref()),
-        id: r.id,
+        id: ModuleId::new(r.id),
         external: r.external.unwrap_or_default(),
         normalize_external_id: r.normalize_external_id,
         side_effects: r.side_effects,
@@ -112,7 +112,7 @@ pub async fn resolve_id_with_plugins(
       .transpose()?;
     return Ok(Ok(ResolvedId {
       module_def_format: infer_module_def_format(r.id.as_str(), package_json.as_ref()),
-      id: r.id,
+      id: ModuleId::new(r.id),
       external: r.external.unwrap_or_default(),
       normalize_external_id: r.normalize_external_id,
       side_effects: r.side_effects,
@@ -124,7 +124,7 @@ pub async fn resolve_id_with_plugins(
   // Auto external http url or data url
   if is_http_url(specifier) || is_data_url(specifier) {
     return Ok(Ok(ResolvedId {
-      id: specifier.into(),
+      id: ModuleId::new(specifier),
       external: true.into(),
       ..Default::default()
     }));
@@ -150,17 +150,17 @@ fn resolve_id(
         // `resolved` is always prefixed with "node:" in compliance with the ESM specification.
         // we needs to use `is_runtime_module` to get the original specifier
         is_external_without_side_effects: is_nodejs_builtin_module(&resolved),
-        id: if resolved.starts_with("node:") && !is_runtime_module {
-          resolved[5..].into()
+        id: ModuleId::new(if resolved.starts_with("node:") && !is_runtime_module {
+          &resolved[5..]
         } else {
-          resolved.into()
-        },
+          &resolved
+        }),
         external: true.into(),
         ..Default::default()
       }),
       ResolveError::Ignored(p) => Ok(ResolvedId {
         //(hyf0) TODO: This `p` doesn't seem to contains `query` or `fragment` of the input. We need to make sure this is ok
-        id: p.to_str().expect("Should be valid utf8").into(),
+        id: ModuleId::new(p.to_str().expect("Should be valid utf8")),
         ignored: true,
         ..Default::default()
       }),

--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -384,8 +384,8 @@ impl GlobImportVisit<'_, '_> {
         }),
       );
       if let Ok(result) = rolldown_utils::futures::block_on(future) {
-        let id = match result {
-          Ok(resolved_id) => resolved_id.id.into(),
+        let id: Cow<'_, str> = match result {
+          Ok(resolved_id) => Cow::Owned(resolved_id.id.to_string()),
           Err(_) => Cow::Borrowed(glob),
         };
         let path = Path::new(id.as_ref());

--- a/crates/rolldown_plugin_vite_import_glob/src/utils_2.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils_2.rs
@@ -297,8 +297,8 @@ impl GlobImportVisit<'_> {
         }),
       );
       if let Ok(result) = rolldown_utils::futures::block_on(future) {
-        let id = match result {
-          Ok(resolved_id) => resolved_id.id.into(),
+        let id: Cow<'_, str> = match result {
+          Ok(resolved_id) => Cow::Owned(resolved_id.id.to_string()),
           Err(_) => Cow::Borrowed(glob),
         };
         let path = Path::new(id.as_ref());

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -11,7 +11,8 @@ use oxc_resolver::{
   TsConfig as OxcTsConfig,
 };
 use rolldown_common::{
-  ImportKind, ModuleDefFormat, PackageJson, Platform, ResolveOptions, ResolvedId, TsConfig,
+  ImportKind, ModuleDefFormat, ModuleId, PackageJson, Platform, ResolveOptions, ResolvedId,
+  TsConfig,
 };
 use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_utils::dashmap::FxDashMap;
@@ -77,7 +78,7 @@ pub struct ResolveReturn {
 impl From<ResolveReturn> for ResolvedId {
   fn from(resolved_return: ResolveReturn) -> Self {
     ResolvedId {
-      id: resolved_return.path,
+      id: ModuleId::new(resolved_return.path),
       module_def_format: resolved_return.module_def_format,
       package_json: resolved_return.package_json,
       ..Default::default()


### PR DESCRIPTION
`Resolved#id` is the id we're gonna used for module id, now we make it `ModuleId` directly to make the data flow more clear