### PR TITLE
refactor(rolldown_error): introduce `BuildError` enum to unify error handling

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -15,7 +15,7 @@ use anyhow::Context;
 use arcstr::ArcStr;
 use rolldown_common::{GetLocalDbMut, Module, ScanMode, SharedFileEmitter, SymbolRefDb};
 use rolldown_devtools::{action, trace_action, trace_action_enabled};
-use rolldown_error::{BuildDiagnostic, BuildResult, Severity};
+use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_plugin::{HookBuildEndArgs, HookRenderErrorArgs, SharedPluginDriver};
 use rolldown_utils::dashmap::FxDashSet;
@@ -103,7 +103,7 @@ impl Bundle {
     {
       Ok(v) => v,
       Err(errs) => {
-        debug_assert!(errs.iter().all(|e| e.severity() == Severity::Error));
+        debug_assert!(errs.is_error_severity_only());
         self
           .plugin_driver
           .build_end(Some(&HookBuildEndArgs { errors: &errs, cwd: &self.options.cwd }))
@@ -246,7 +246,7 @@ impl Bundle {
         .await; // Notice we don't use `?` to break the control flow here.
 
     if let Err(errors) = &bundle_output {
-      debug_assert!(errors.iter().all(|e| e.severity() == Severity::Error));
+      debug_assert!(errors.is_error_severity_only());
       self
         .plugin_driver
         .render_error(&HookRenderErrorArgs { errors, cwd: &self.options.cwd })

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -282,7 +282,7 @@ impl<'a> HmrStage<'a> {
           .collect::<Vec<_>>(),
       );
 
-      self.cache.merge(module_loader_output.into()).map_err(|e| vec![anyhow::anyhow!(e).into()])?;
+      self.cache.merge(module_loader_output.into())?;
 
       let options = Arc::clone(&self.options);
       let resolver = Arc::clone(&self.resolver);
@@ -383,7 +383,7 @@ impl<'a> HmrStage<'a> {
       );
       modules_to_be_updated
         .extend(module_loader_output.new_added_modules_from_partial_scan.clone());
-      self.cache.merge(module_loader_output.into()).map_err(|e| vec![anyhow::anyhow!(e).into()])?;
+      self.cache.merge(module_loader_output.into())?;
       let options = Arc::clone(&self.options);
       let resolver = Arc::clone(&self.resolver);
       self.cache.update_defer_sync_data(&options, &resolver).await?;

--- a/crates/rolldown/src/module_loader/external_module_task.rs
+++ b/crates/rolldown/src/module_loader/external_module_task.rs
@@ -39,7 +39,7 @@ impl ExternalModuleTask {
       self
         .ctx
         .tx
-        .send(ModuleLoaderMsg::BuildErrors(errs.into_vec().into_boxed_slice()))
+        .send(ModuleLoaderMsg::BuildErrors(errs))
         .await
         .expect("ModuleLoader: failed to send external module build errors - main thread terminated while processing errors");
     }

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -609,7 +609,7 @@ impl<'a> ModuleLoader<'a> {
           extra_entry_points.push(entry);
         }
         ModuleLoaderMsg::BuildErrors(e) => {
-          errors.extend(e);
+          e.extend_into(&mut errors);
           self.remaining -= 1;
         }
       }

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -81,7 +81,7 @@ impl ModuleTask {
       self
         .ctx
         .tx
-        .send(ModuleLoaderMsg::BuildErrors(errs.into_vec().into_boxed_slice()))
+        .send(ModuleLoaderMsg::BuildErrors(errs))
         .await
         .expect("ModuleLoader: failed to send build errors - main thread terminated while processing module errors");
     }

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -57,11 +57,7 @@ impl RuntimeModuleTask {
   #[tracing::instrument(name = "RuntimeNormalModuleTaskResult::run", level = "debug", skip_all)]
   pub async fn run(self) {
     if let Err(errs) = self.run_inner().await {
-      self
-        .ctx
-        .tx
-        .try_send(ModuleLoaderMsg::BuildErrors(errs.into_vec().into_boxed_slice()))
-        .expect("Send should not fail");
+      self.ctx.tx.try_send(ModuleLoaderMsg::BuildErrors(errs)).expect("Send should not fail");
     }
   }
 

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -190,7 +190,7 @@ pub async fn finalize_assets(
   // apply sourcemap related logic
 
   let derived_assets = try_join_all(assets.iter_mut().map(async |asset| {
-    let mut derived_asset: Result<Option<Asset>, anyhow::Error> = Ok(None::<Asset>);
+    let mut derived_asset: BuildResult<Option<Asset>> = Ok(None::<Asset>);
     match &mut asset.meta {
       InstantiationKind::Ecma(ecma_meta) => {
         let asset_code = mem::take(&mut asset.content);

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -13,7 +13,7 @@ use oxc::transformer_plugins::{
 
 use rolldown_common::NormalizedBundlerOptions;
 use rolldown_ecmascript::{EcmaAst, WithMutFields};
-use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, BuildResult, Severity};
+use rolldown_error::{BuildDiagnostic, BuildError, BuildResult, Severity};
 
 use crate::types::oxc_parse_type::OxcParseType;
 
@@ -113,7 +113,7 @@ impl PreProcessEcmaAst {
             .into_iter()
             .filter(|item| matches!(item.severity, OxcSeverity::Error))
             .collect_vec();
-          return Err(BatchedBuildDiagnostic::from(BuildDiagnostic::from_oxc_diagnostics(
+          return Err(BuildError::Multi(BuildDiagnostic::from_oxc_diagnostics(
             errors,
             &source,
             resolved_id,

--- a/crates/rolldown/src/watch/watcher_task.rs
+++ b/crates/rolldown/src/watch/watcher_task.rs
@@ -110,10 +110,7 @@ impl WatcherTask {
       }
       Err(errs) => {
         self.emitter.emit(WatcherEvent::Event(BundleEvent::Error(BundleErrorEventData {
-          error: OutputsDiagnostics {
-            diagnostics: errs.into_vec(),
-            cwd: bundler.options.cwd.clone(),
-          },
+          error: OutputsDiagnostics { diagnostics: errs.into(), cwd: bundler.options.cwd.clone() },
           result: Arc::clone(&self.bundler),
         })))?;
       }

--- a/crates/rolldown/tests/rolldown/errors/plugin_error/mod.rs
+++ b/crates/rolldown/tests/rolldown/errors/plugin_error/mod.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, sync::Arc};
 
 use rolldown::{BundlerOptions, InputItem};
-use rolldown_error::BatchedBuildDiagnostic;
+use rolldown_error::BuildError;
 use rolldown_plugin::{HookUsage, Plugin, PluginContext};
 use rolldown_testing::{manual_integration_test, test_config::TestMeta};
 
@@ -22,10 +22,7 @@ impl Plugin for PluginErrorTest {
     _ctx: &PluginContext,
     _args: &rolldown_plugin::HookBuildStartArgs<'_>,
   ) -> rolldown_plugin::HookNoopReturn {
-    Err(BatchedBuildDiagnostic::new(vec![
-      anyhow::anyhow!("A").into(),
-      anyhow::anyhow!("B").into(),
-    ]))?
+    Err(BuildError::Multi(vec![anyhow::anyhow!("A").into(), anyhow::anyhow!("B").into()]))?
   }
 }
 

--- a/crates/rolldown_common/src/module_loader/mod.rs
+++ b/crates/rolldown_common/src/module_loader/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use arcstr::ArcStr;
-use rolldown_error::BuildDiagnostic;
+use rolldown_error::BuildError;
 use runtime_task_result::RuntimeModuleTaskResult;
 use task_result::{ExternalModuleTaskResult, NormalModuleTaskResult};
 
@@ -17,7 +17,7 @@ pub enum ModuleLoaderMsg {
   RuntimeNormalModuleDone(Box<RuntimeModuleTaskResult>),
   FetchModule(Box<ResolvedId>),
   AddEntryModule(Box<AddEntryModuleMsg>),
-  BuildErrors(Box<[BuildDiagnostic]>),
+  BuildErrors(BuildError),
 }
 
 pub struct AddEntryModuleMsg {

--- a/crates/rolldown_error/src/lib.rs
+++ b/crates/rolldown_error/src/lib.rs
@@ -3,7 +3,7 @@ mod generated;
 mod types;
 mod utils;
 
-pub type BuildResult<T> = Result<T, BatchedBuildDiagnostic>;
+pub type BuildResult<T> = Result<T, BuildError>;
 pub type SingleBuildResult<T> = std::result::Result<T, BuildDiagnostic>;
 
 pub use crate::{
@@ -16,7 +16,7 @@ pub use crate::{
   build_diagnostic::events::plugin_timings::PluginTimingInfo,
   build_diagnostic::events::resolve_error::DiagnosableResolveError,
   build_diagnostic::events::unloadable_dependency::UnloadableDependencyContext,
-  build_diagnostic::{BatchedBuildDiagnostic, BuildDiagnostic, Severity},
+  build_diagnostic::{BuildDiagnostic, BuildError, Severity},
   generated::event_kind_switcher::EventKindSwitcher,
   types::diagnostic_options::DiagnosticOptions,
   types::event_kind::EventKind,

--- a/crates/rolldown_plugin/src/types/hook_build_end_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_build_end_args.rs
@@ -1,7 +1,7 @@
-use rolldown_error::BuildDiagnostic;
+use rolldown_error::BuildError;
 
 #[derive(Debug)]
 pub struct HookBuildEndArgs<'a> {
-  pub errors: &'a Vec<BuildDiagnostic>,
+  pub errors: &'a BuildError,
   pub cwd: &'a std::path::PathBuf,
 }

--- a/crates/rolldown_plugin/src/types/hook_render_error.rs
+++ b/crates/rolldown_plugin/src/types/hook_render_error.rs
@@ -1,7 +1,7 @@
-use rolldown_error::BuildDiagnostic;
+use rolldown_error::BuildError;
 
 #[derive(Debug)]
 pub struct HookRenderErrorArgs<'a> {
-  pub errors: &'a Vec<BuildDiagnostic>,
+  pub errors: &'a BuildError,
   pub cwd: &'a std::path::PathBuf,
 }

--- a/crates/rolldown_plugin_isolated_declaration/src/lib.rs
+++ b/crates/rolldown_plugin_isolated_declaration/src/lib.rs
@@ -8,7 +8,7 @@ use oxc::{
   isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions},
 };
 use rolldown_common::{ModuleType, ResolvedExternal};
-use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, Severity};
+use rolldown_error::{BuildDiagnostic, BuildError, Severity};
 use rolldown_plugin::{HookUsage, Plugin, PluginHookMeta, PluginOrder};
 use sugar_path::SugarPath;
 use type_import_visitor::TypeImportVisitor;
@@ -53,7 +53,7 @@ impl Plugin for IsolatedDeclarationPlugin {
       });
 
       if !ret.errors.is_empty() {
-        return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
+        return Err(BuildError::Multi(BuildDiagnostic::from_oxc_diagnostics(
           ret.errors,
           &ArcStr::from(ret.program.source_text),
           args.id,

--- a/crates/rolldown_plugin_vite_transform/src/lib.rs
+++ b/crates/rolldown_plugin_vite_transform/src/lib.rs
@@ -9,7 +9,7 @@ use oxc::parser::Parser;
 use oxc::semantic::SemanticBuilder;
 use oxc::transformer::Transformer;
 use rolldown_common::{BundlerTransformOptions, ModuleType};
-use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, Severity};
+use rolldown_error::{BuildDiagnostic, BuildError, Severity};
 use rolldown_plugin::{HookUsage, Plugin, SharedTransformPluginContext};
 use rolldown_utils::{concat_string, pattern_filter::StringOrRegex, url::clean_url};
 
@@ -62,7 +62,7 @@ impl Plugin for ViteTransformPlugin {
     let allocator = oxc::allocator::Allocator::default();
     let ret = Parser::new(&allocator, args.code, source_type).parse();
     if ret.panicked || !ret.errors.is_empty() {
-      return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
+      return Err(BuildError::Multi(BuildDiagnostic::from_oxc_diagnostics(
         ret.errors,
         &ArcStr::from(args.code.as_str()),
         args.id,
@@ -75,7 +75,7 @@ impl Plugin for ViteTransformPlugin {
     let transformer = Transformer::new(&allocator, Path::new(args.id), &transform_options);
     let transformer_return = transformer.build_with_scoping(scoping, &mut program);
     if !transformer_return.errors.is_empty() {
-      return Err(BatchedBuildDiagnostic::new(BuildDiagnostic::from_oxc_diagnostics(
+      return Err(BuildError::Multi(BuildDiagnostic::from_oxc_diagnostics(
         transformer_return.errors,
         &ArcStr::from(args.code.as_str()),
         args.id,


### PR DESCRIPTION
Related to #6021