### PR TITLE
refactor(rust): rename `Module#id` to `Module#id_as_str`

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -302,7 +302,9 @@ impl Bundle {
                 .import_records
                 .iter()
                 .map(|r| action::ModuleImport {
-                  module_id: scan_stage_output.module_table[r.resolved_module].id().to_string(),
+                  module_id: scan_stage_output.module_table[r.resolved_module]
+                    .id_as_str()
+                    .to_string(),
                   kind: r.kind.to_string(),
                   module_request: r.module_request.to_string(),
                 })

--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -84,7 +84,7 @@ impl ChunkGraph {
       let mut runtime_related = vec![];
       for &module_idx in &chunk.modules {
         let module = &link_output.module_table[module_idx];
-        if module.id().starts_with("rolldown:") {
+        if module.id_as_str().starts_with("rolldown:") {
           runtime_related.push(module_idx);
           continue;
         }
@@ -97,7 +97,7 @@ impl ChunkGraph {
           rest.push(module_idx);
         }
       }
-      side_effects_free_leaf_modules.sort_by_key(|idx| link_output.module_table[*idx].id());
+      side_effects_free_leaf_modules.sort_by_key(|idx| link_output.module_table[*idx].id_as_str());
       rest.sort_unstable_by_key(|idx| link_output.module_table[*idx].exec_order());
       runtime_related.sort_unstable_by_key(|idx| link_output.module_table[*idx].exec_order());
 

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -403,7 +403,7 @@ impl<'a> HmrStage<'a> {
     // Sorting `modules_to_be_updated` is not strictly necessary, but it:
     // - Makes the snapshot more stable when we change logic that affects the order of modules.
     modules_to_be_updated
-      .sort_by_cached_key(|module_idx| self.module_table().modules[*module_idx].id());
+      .sort_by_cached_key(|module_idx| self.module_table().modules[*module_idx].id_as_str());
 
     let module_idx_to_init_fn_name = modules_to_be_updated
       .iter()
@@ -412,7 +412,7 @@ impl<'a> HmrStage<'a> {
         let Module::Normal(module) = &self.module_table().modules[*module_idx] else {
           unreachable!(
             "External modules should be removed before. But got {:?}",
-            self.module_table().modules[*module_idx].id()
+            self.module_table().modules[*module_idx].id_as_str()
           );
         };
         let prefix = if module.exports_kind.is_commonjs() { "require" } else { "init" };
@@ -585,7 +585,7 @@ impl<'a> HmrStage<'a> {
     // Sorting `modules_to_be_updated` is not strictly necessary, but it:
     // - Makes the snapshot more stable when we change logic that affects the order of modules.
     modules_to_be_updated
-      .sort_by_cached_key(|module_idx| self.module_table().modules[*module_idx].id());
+      .sort_by_cached_key(|module_idx| self.module_table().modules[*module_idx].id_as_str());
 
     let module_idx_to_init_fn_name = modules_to_be_updated
       .iter()
@@ -594,7 +594,7 @@ impl<'a> HmrStage<'a> {
         let Module::Normal(module) = &self.module_table().modules[*module_idx] else {
           unreachable!(
             "External modules should be removed before. But got {:?}",
-            self.module_table().modules[*module_idx].id()
+            self.module_table().modules[*module_idx].id_as_str()
           );
         };
         let prefix = if module.exports_kind.is_commonjs() { "require" } else { "init" };

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -574,7 +574,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               importer_namespace_ref_expr,
               self.snippet.call_expr_with_arg_expr_expr(
                 "require",
-                self.snippet.string_literal_expr(importee.id(), SPAN),
+                self.snippet.string_literal_expr(importee.id_as_str(), SPAN),
               ),
             );
 

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -423,7 +423,7 @@ impl<'a> ModuleLoader<'a> {
             // Dynamic imported module will be considered as an entry
             self.intermediate_normal_modules.importers[idx].push(ImporterRecord {
               kind: raw_rec.kind,
-              importer_path: ModuleId::new(module.id()),
+              importer_path: ModuleId::new(module.id_as_str()),
               importer_idx: module.idx(),
             });
             // defer usage merging, since we only have one consumer, we should keep action during fetching as simple

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -80,7 +80,7 @@ impl GenerateStage<'_> {
           let mut module_ids = chunk_graph.chunk_table[*chunk_id]
             .modules
             .iter()
-            .map(|id| self.link_output.module_table[*id].id())
+            .map(|id| self.link_output.module_table[*id].id_as_str())
             .collect::<Vec<_>>();
           module_ids.sort_unstable();
           module_ids
@@ -316,7 +316,7 @@ impl GenerateStage<'_> {
             "Symbol: {:?}, {:?} in {:?} should only belong to one chunk. Existed {:?}, new {chunk_id:?}",
             declared.name(symbols),
             declared,
-            self.link_output.module_table[declared.owner].id(),
+            self.link_output.module_table[declared.owner].id_as_str(),
             symbol_data.chunk_id,
           );
         }
@@ -425,7 +425,11 @@ impl GenerateStage<'_> {
         let importee_chunk_id = import_symbol.chunk_id.unwrap_or_else(|| {
           let symbol_owner = &self.link_output.module_table[import_ref.owner];
           let symbol_name = import_ref.name(&self.link_output.symbol_db);
-          panic!("Symbol {:?} in {:?} should belong to a chunk", symbol_name, symbol_owner.id())
+          panic!(
+            "Symbol {:?} in {:?} should belong to a chunk",
+            symbol_name,
+            symbol_owner.id_as_str()
+          )
         });
         // Check if the import is from another chunk
         if chunk_id != importee_chunk_id {

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -723,7 +723,7 @@ impl BindImportsAndExportsContext<'_> {
           let mut diagnostic = BuildDiagnostic::missing_export(
             module.id.to_string(),
             module.stable_id.clone(),
-            importee.id().to_string(),
+            importee.id_as_str().to_string(),
             importee.stable_id().to_string(),
             module.source.clone(),
             named_import.imported.to_string(),
@@ -826,7 +826,7 @@ impl BindImportsAndExportsContext<'_> {
           && prev_tracker.imported_as == tracker.imported_as
         {
           let importer_module = &index_modules[tracker.importer];
-          let importer_id = importer_module.id().to_string();
+          let importer_id = importer_module.id_as_str().to_string();
           let imported_specifier = tracker.imported.to_string();
           self.errors.push(BuildDiagnostic::circular_reexport(importer_id, imported_specifier));
           return MatchImportKind::Cycle;

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -129,7 +129,7 @@ impl<'a> LinkStage<'a> {
       .collect_vec();
 
     rest.sort_by_cached_key(|item| {
-      (item.kind, scan_stage_output.module_table.modules[item.idx].id())
+      (item.kind, scan_stage_output.module_table.modules[item.idx].id_as_str())
     });
 
     scan_stage_output.entry_points.extend(rest);

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -618,7 +618,11 @@ pub fn include_module(ctx: &mut IncludeContext, module: &NormalModule) {
   tracing::trace!(
     "{}:\n module_meta dependencies: {:#?}",
     module.stable_id,
-    module_meta.dependencies.iter().map(|idx| { ctx.modules[*idx].id().to_string() }).collect_vec()
+    module_meta
+      .dependencies
+      .iter()
+      .map(|idx| { ctx.modules[*idx].id_as_str().to_string() })
+      .collect_vec()
   );
   if module.meta.has_eval() && matches!(module.module_type, ModuleType::Js | ModuleType::Jsx) {
     module.named_imports.keys().for_each(|symbol| {

--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -108,7 +108,11 @@ impl GenerateContext<'_> {
       panic!(
         "canonical name not found for {symbol:?}, original_name: {:?} in module {:?}",
         symbol.name(symbol_db),
-        self.link_output.module_table.get(symbol.owner).map_or("unknown", |module| module.id())
+        self
+          .link_output
+          .module_table
+          .get(symbol.owner)
+          .map_or("unknown", |module| module.id_as_str())
       );
     })
   }

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -82,7 +82,7 @@ impl ScanStageCache {
     // merge module_table, index_ast_scope, index_ecma_ast
     for (new_idx, new_module) in modules {
       // FIXME: hyf0 should get `ModuleId` directly from `Module` instead of calling `ModuleId::new`
-      let idx = self.module_id_to_idx[&ModuleId::new(new_module.id())].idx();
+      let idx = self.module_id_to_idx[&ModuleId::new(new_module.id_as_str())].idx();
 
       // Update `module_idx_by_abs_path`
       if let rolldown_common::Module::Normal(normal_module) = &new_module {

--- a/crates/rolldown/src/utils/chunk/mod.rs
+++ b/crates/rolldown/src/utils/chunk/mod.rs
@@ -25,10 +25,10 @@ pub fn generate_pre_rendered_chunk(
     is_entry: matches!(&chunk.kind, ChunkKind::EntryPoint { meta, .. } if meta.contains(ChunkMeta::UserDefinedEntry)),
     is_dynamic_entry: matches!(&chunk.kind, ChunkKind::EntryPoint { meta, .. } if !meta.contains(ChunkMeta::UserDefinedEntry)),
     facade_module_id: match &chunk.kind {
-      ChunkKind::EntryPoint { module, .. } => Some(graph.module_table[*module].id().into()),
+      ChunkKind::EntryPoint { module, .. } => Some(graph.module_table[*module].id_as_str().into()),
       ChunkKind::Common => None,
     },
-    module_ids: chunk.modules.iter().map(|id| graph.module_table[*id].id().into()).collect(),
+    module_ids: chunk.modules.iter().map(|id| graph.module_table[*id].id_as_str().into()).collect(),
     exports: get_chunk_export_names(chunk, graph),
   }
 }

--- a/crates/rolldown_common/src/module/mod.rs
+++ b/crates/rolldown_common/src/module/mod.rs
@@ -29,7 +29,7 @@ impl Module {
     }
   }
 
-  pub fn id(&self) -> &str {
+  pub fn id_as_str(&self) -> &str {
     match self {
       Module::Normal(v) => &v.id,
       Module::External(v) => &v.id,


### PR DESCRIPTION
`id()` should return `ModuleId`