### PR TITLE
refactor(rust): remove `ModuleId#resource_id` and use `as_arc_str` directly

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -153,7 +153,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     let is_top_level_await = it.r#await && self.is_valid_tla_scope();
     if is_top_level_await && !self.immutable_ctx.flat_options.keep_esm_import_export_syntax() {
       self.result.errors.push(BuildDiagnostic::unsupported_feature(
-        self.immutable_ctx.id.resource_id().clone(),
+        self.immutable_ctx.id.as_arc_str().clone(),
         self.immutable_ctx.source.clone(),
         it.span(),
         format!(
@@ -173,7 +173,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     let is_top_level_await = self.is_valid_tla_scope();
     if !self.immutable_ctx.flat_options.keep_esm_import_export_syntax() && is_top_level_await {
       self.result.errors.push(BuildDiagnostic::unsupported_feature(
-        self.immutable_ctx.id.resource_id().clone(),
+        self.immutable_ctx.id.as_arc_str().clone(),
         self.immutable_ctx.source.clone(),
         it.span(),
         format!(
@@ -315,7 +315,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
             self
               .immutable_ctx
               .id
-              .resource_id()
+              .as_arc_str()
               .clone()
               .parse()
               .expect("should be a valid resource id"),

--- a/crates/rolldown/src/ast_scanner/import_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/import_analyzer.rs
@@ -37,7 +37,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
             let name = self.result.symbol_ref_db.symbol_name(symbol_id);
             self.result.warnings.push(
               BuildDiagnostic::cannot_call_namespace(
-                self.immutable_ctx.id.resource_id().clone(),
+                self.immutable_ctx.id.as_arc_str().clone(),
                 self.immutable_ctx.source.clone(),
                 span,
                 name.into(),
@@ -49,7 +49,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
 
         if let Some((span, name)) = self.get_span_if_namespace_specifier_updated() {
           self.result.errors.push(BuildDiagnostic::assign_to_import(
-            self.immutable_ctx.id.resource_id().clone(),
+            self.immutable_ctx.id.as_arc_str().clone(),
             self.immutable_ctx.source.clone(),
             span,
             name.into(),
@@ -61,7 +61,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         self.result.symbol_ref_db.scoping().get_reference(ident.reference_id()).flags();
       if reference_flag.is_write() {
         self.result.errors.push(BuildDiagnostic::assign_to_import(
-          self.immutable_ctx.id.resource_id().clone(),
+          self.immutable_ctx.id.as_arc_str().clone(),
           self.immutable_ctx.source.clone(),
           ident.span,
           ident.name.as_str().into(),

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -443,7 +443,7 @@ impl LinkStage<'_> {
                     {
                       warnings.push(
                         BuildDiagnostic::import_is_undefined(
-                          module.id.resource_id().clone(),
+                          module.id.as_arc_str().clone(),
                           module.source.clone(),
                           member_expr_ref.span,
                           ArcStr::from(name.as_str()),

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -87,7 +87,7 @@ impl ScanStageCache {
       if let rolldown_common::Module::Normal(normal_module) = &new_module {
         self
           .module_idx_by_abs_path
-          .insert(normal_module.id.resource_id().to_slash().unwrap().into(), normal_module.idx);
+          .insert(normal_module.id.as_arc_str().to_slash().unwrap().into(), normal_module.idx);
       }
       // Update `module_idx_by_stable_id`
       self.module_idx_by_stable_id.insert(new_module.stable_id().to_string(), new_module.idx());
@@ -142,7 +142,7 @@ impl ScanStageCache {
 
     for module in &build_snapshot.module_table.modules {
       if let rolldown_common::Module::Normal(normal_module) = module {
-        let filename = normal_module.id.resource_id().to_slash().unwrap().into();
+        let filename = normal_module.id.as_arc_str().to_slash().unwrap().into();
         let module_idx = normal_module.idx;
         self.module_idx_by_abs_path.insert(filename, module_idx);
       }

--- a/crates/rolldown_common/src/types/module_id.rs
+++ b/crates/rolldown_common/src/types/module_id.rs
@@ -9,42 +9,37 @@ use sugar_path::SugarPath;
 /// - Users could stored the `ModuleId` to track the module in different stages/hooks.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
 pub struct ModuleId {
-  // Id that rolldown uses to call `read_to_string` or `read` to get the content of the module.
-  resource_id: ArcStr,
+  inner: ArcStr,
 }
 
 impl ModuleId {
   #[inline]
   pub fn new(value: impl Into<ArcStr>) -> Self {
     let value = value.into();
-    Self { resource_id: value }
+    Self { inner: value }
   }
 
   #[inline]
-  pub const fn new_arc_str(resource_id: ArcStr) -> Self {
-    Self { resource_id }
-  }
-
-  pub fn resource_id(&self) -> &ArcStr {
-    &self.resource_id
+  pub const fn new_arc_str(inner: ArcStr) -> Self {
+    Self { inner }
   }
 
   pub fn as_str(&self) -> &str {
-    &self.resource_id
+    &self.inner
   }
 
   pub fn as_arc_str(&self) -> &ArcStr {
-    &self.resource_id
+    &self.inner
   }
 
   pub fn stabilize(&self, cwd: &Path) -> String {
-    stabilize_id(&self.resource_id, cwd)
+    stabilize_id(&self.inner, cwd)
   }
 }
 
 impl AsRef<str> for ModuleId {
   fn as_ref(&self) -> &str {
-    &self.resource_id
+    &self.inner
   }
 }
 
@@ -52,7 +47,7 @@ impl std::ops::Deref for ModuleId {
   type Target = str;
 
   fn deref(&self) -> &Self::Target {
-    &self.resource_id
+    &self.inner
   }
 }
 
@@ -76,13 +71,13 @@ impl From<ArcStr> for ModuleId {
 
 impl std::fmt::Display for ModuleId {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    std::fmt::Display::fmt(&self.resource_id, f)
+    std::fmt::Display::fmt(&self.inner, f)
   }
 }
 
 impl ModuleId {
   pub fn relative_path(&self, root: impl AsRef<Path>) -> PathBuf {
-    let path = self.resource_id.as_path();
+    let path = self.inner.as_path();
     path.relative(root)
   }
 }

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -57,7 +57,7 @@ impl PluginDriver {
   }
 
   pub fn set_module_info(&self, module_id: &ModuleId, module_info: Arc<ModuleInfo>) {
-    self.module_infos.insert(module_id.resource_id().into(), module_info);
+    self.module_infos.insert(module_id.as_arc_str().into(), module_info);
   }
 
   pub async fn set_context_load_modules_tx(

--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -50,7 +50,7 @@ impl Plugin for ChunkImportMapPlugin {
         let hasher = match &chunk.facade_module_id {
           Some(module_id) => {
             let mut hasher = Xxh3::with_seed(0);
-            module_id.resource_id().as_str().hash(&mut hasher);
+            module_id.as_str().hash(&mut hasher);
             hasher
           }
           None => {
@@ -59,7 +59,7 @@ impl Plugin for ChunkImportMapPlugin {
             if used_names.contains(&chunk.name) {
               // Reduce the impact factor
               let Some(module_id) = chunk.module_ids.iter().min() else { continue };
-              module_id.resource_id().as_str().hash(&mut hasher);
+              module_id.as_str().hash(&mut hasher);
             } else {
               used_names.insert(chunk.name.clone());
               chunk.name.hash(&mut hasher);

--- a/crates/rolldown_plugin_vite_css_post/src/lib.rs
+++ b/crates/rolldown_plugin_vite_css_post/src/lib.rs
@@ -185,7 +185,7 @@ impl Plugin for ViteCSSPostPlugin {
     let mut is_pure_css_chunk = args.chunk.exports.is_empty();
     let mut css_chunk: Option<String> = None;
     for module_id in &args.chunk.module_ids {
-      let id = module_id.resource_id().as_str();
+      let id = module_id.as_str();
       if let Some(css) = styles.inner.get(id) {
         // `?transform-only` is used for ?url and shouldn't be included in normal CSS chunks
         if find_special_query(id, b"transform-only").is_some() {
@@ -210,7 +210,7 @@ impl Plugin for ViteCSSPostPlugin {
               .keys
               .iter()
               .zip(chunk.modules.values.iter())
-              .find(|(key, _)| key.resource_id().as_str() == importer_id)
+              .find(|(key, _)| key.as_str() == importer_id)
               .is_some_and(|(_, importer)| {
                 exp
                   .as_ref()

--- a/crates/rolldown_plugin_vite_css_post/src/utils.rs
+++ b/crates/rolldown_plugin_vite_css_post/src/utils.rs
@@ -194,12 +194,7 @@ impl ViteCSSPostPlugin {
         // that means a JS entry file imports a CSS file.
         // in this case, only use the filename for the CSS chunk name like JS chunks.
         let css_asset_name = if ctx.args.chunk.is_entry
-          && ctx
-            .args
-            .chunk
-            .facade_module_id
-            .as_ref()
-            .is_none_or(|id| !is_css_request(id.resource_id().as_str()))
+          && ctx.args.chunk.facade_module_id.as_ref().is_none_or(|id| !is_css_request(id.as_str()))
         {
           css_asset_path.file_name().map(|v| v.to_string_lossy().into_owned()).unwrap()
         } else {

--- a/crates/rolldown_plugin_vite_html/src/lib.rs
+++ b/crates/rolldown_plugin_vite_html/src/lib.rs
@@ -519,7 +519,7 @@ impl Plugin for ViteHtmlPlugin {
           && chunk
             .facade_module_id
             .as_ref()
-            .is_some_and(|facade_module_id| facade_module_id.resource_id() == id))
+            .is_some_and(|facade_module_id| facade_module_id.as_arc_str() == id))
         .then_some(chunk),
         rolldown_common::Output::Asset(_) => None,
       });


### PR DESCRIPTION
- It's meaningless now
- `resource_id` concept is related to import attributes
- let's only reconsider this abstraction when we're working on import attributes