### PR TITLE
test: use assertion instead of console.log for some testcase

### DIFF
--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/artifacts.snap
@@ -6,6 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+import assert from "node:assert";
+
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var require_foo = /* @__PURE__ */ __commonJSMin(((exports) => {
@@ -15,7 +17,10 @@ var require_foo = /* @__PURE__ */ __commonJSMin(((exports) => {
 //#endregion
 //#region entry.js
 var import_foo = require_foo();
-import("./foo.js").then(__toDynamicImportESM()).then(({ default: { bar: b } }) => console.log(import_foo.bar, b));
+import("./foo.js").then(__toDynamicImportESM()).then(({ default: { bar: b } }) => {
+	assert.strictEqual(b, 123);
+	assert.strictEqual(import_foo.bar, 123);
+});
 
 //#endregion
 export { require_foo as t };

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/entry.js
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/entry.js
@@ -1,2 +1,7 @@
-import {bar as a} from "./foo.js"
-import("./foo.js").then(({default: {bar: b}}) => console.log(a, b))
+import { bar as a } from './foo.js';
+import assert from 'node:assert';
+
+import('./foo.js').then(({ default: { bar: b } }) => {
+  assert.strictEqual(b, 123);
+  assert.strictEqual(a, 123);
+});

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6/artifacts.snap
@@ -6,12 +6,17 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+import assert from "node:assert";
+
 //#region foo.js
 let bar = 123;
 
 //#endregion
 //#region entry.js
-import("./foo.js").then(({ bar: b }) => console.log(bar, b));
+import("./foo.js").then(({ bar: b }) => {
+	assert.strictEqual(b, 123);
+	assert.strictEqual(bar, 123);
+});
 
 //#endregion
 export { bar as t };

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6/entry.js
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6/entry.js
@@ -1,2 +1,7 @@
-import {bar as a} from "./foo.js"
-import("./foo.js").then(({bar: b}) => console.log(a, b))
+import assert from 'node:assert';
+import { bar as a } from './foo.js';
+
+import('./foo.js').then(({ bar: b }) => {
+  assert.strictEqual(b, 123);
+  assert.strictEqual(a, 123);
+});

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
@@ -14,6 +14,8 @@ export { foo };
 ## main.js
 
 ```js
+import assert from "node:assert";
+
 // HIDDEN [rolldown:runtime]
 //#region foo.js
 var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
@@ -21,8 +23,10 @@ const foo = 1;
 
 //#endregion
 //#region main.js
-import("./foo.js").then(console.log);
-console.log(foo_exports);
+assert.deepEqual(foo_exports, { foo: 1 });
+import("./foo.js").then((mod) => {
+	assert.deepEqual(JSON.parse(JSON.stringify(mod)), foo_exports);
+});
 
 //#endregion
 export { foo as t };

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/main.js
@@ -1,3 +1,11 @@
 import * as fooNamespace from './foo.js';
-import('./foo.js').then(console.log);
-console.log(fooNamespace);
+import assert from 'node:assert';
+
+assert.deepEqual(fooNamespace, {
+  foo: 1,
+});
+
+import('./foo.js').then((mod) => {
+  // workaround for the String tag `Module`
+  assert.deepEqual(JSON.parse(JSON.stringify(mod)), fooNamespace);
+});

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
@@ -6,6 +6,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+import assert from "node:assert";
+
 //#region share.js
 var share_default$1 = "shared";
 
@@ -15,9 +17,17 @@ var share_default = {};
 
 //#endregion
 //#region main.js
+assert.strictEqual(share_default$1, "shared");
+assert.deepStrictEqual(share_default, {});
 console.log(share_default$1, share_default);
-import("./share.js").then(console.log);
-import("./share2.js").then(console.log);
+import("./share.js").then((mod) => {
+	assert.deepEqual(JSON.parse(JSON.stringify(mod)), { default: "shared" });
+	console.log(mod);
+});
+import("./share2.js").then((mod) => {
+	assert.deepEqual(JSON.parse(JSON.stringify(mod)), { default: {} });
+	console.log(mod);
+});
 
 //#endregion
 export { share_default$1 as n, share_default as t };

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_2786/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_2786/main.js
@@ -1,7 +1,18 @@
-import shared from "./share";
-import sharedJson from "./share.json";
+import shared from './share';
+import sharedJson from './share.json';
+import assert from 'node:assert';
 
+assert.strictEqual(shared, 'shared');
+assert.deepStrictEqual(sharedJson, {});
 console.log(shared, sharedJson);
 
-import('./share').then(console.log)
-import('./share.json').then(console.log)
+import('./share').then((mod) => {
+  // workaround for the String tag `Module`
+  assert.deepEqual(JSON.parse(JSON.stringify(mod)), { default: 'shared' });
+  console.log(mod);
+});
+import('./share.json').then((mod) => {
+  // workaround for the String tag `Module`
+  assert.deepEqual(JSON.parse(JSON.stringify(mod)), { default: {} });
+  console.log(mod);
+});

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/_config.json
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/_config.json
@@ -1,5 +1,5 @@
 {
-    "config": {
-        "external": ["node:fs"]
-    }
+  "config": {
+    "external": ["node:fs", "node:assert"]
+  }
 }

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/artifacts.snap
@@ -15,14 +15,18 @@ export { read };
 
 ```js
 import { read } from "node:fs";
+import assert from "node:assert";
 
 //#region read.js
 console.log(1);
 
 //#endregion
 //#region main.js
-console.log(read);
-import("./indirect.js").then(console.log);
+assert.strictEqual(typeof read, "function");
+import("./indirect.js").then((mod) => {
+	assert.strictEqual(typeof mod.read, "function");
+	console.log(mod);
+});
 
 //#endregion
 export { read as t };

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/main.js
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/main.js
@@ -1,6 +1,10 @@
-import { read } from './indirect'
-import "./read";
+import { read } from './indirect';
+import './read';
+import assert from 'node:assert';
 
-console.log(read)
+assert.strictEqual(typeof read, 'function');
 
-import('./indirect').then(console.log)
+import('./indirect').then((mod) => {
+  assert.strictEqual(typeof mod.read, 'function');
+  console.log(mod);
+});

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3227,13 +3227,13 @@ expression: output
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6
 
-- entry-!~{000}~.js => entry-DsDwlLzc.js
-- foo-!~{001}~.js => foo-Zcch9Zsu.js
+- entry-!~{000}~.js => entry-BIuzO3gc.js
+- foo-!~{001}~.js => foo-D6ZpYFx4.js
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6
 
-- entry-!~{000}~.js => entry-HL_DagOc.js
-- foo-!~{001}~.js => foo-CQXqzJUL.js
+- entry-!~{000}~.js => entry-9U8sSCdQ.js
+- foo-!~{001}~.js => foo-q6H4gk-R.js
 
 # tests/esbuild/splitting/splitting_dynamic_common_js_into_es6
 
@@ -3821,8 +3821,8 @@ expression: output
 
 # tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file
 
-- main-!~{000}~.js => main-NIEFUZip.js
-- foo-!~{001}~.js => foo-Uv9gr96M.js
+- main-!~{000}~.js => main-B8ZEutxn.js
+- foo-!~{001}~.js => foo-BbjvKwqj.js
 
 # tests/rolldown/code_splitting/ensure_safe_identifier
 
@@ -3861,9 +3861,9 @@ expression: output
 
 # tests/rolldown/code_splitting/issue_2786
 
-- main-!~{000}~.js => main-BbxOV0vg.js
-- share-!~{001}~.js => share-DjQjC9mY.js
-- share-!~{003}~.js => share-wzwYn-nJ.js
+- main-!~{000}~.js => main-un2AmPj4.js
+- share-!~{003}~.js => share-BkbnSPG1.js
+- share-!~{001}~.js => share-C3TASj2N.js
 
 # tests/rolldown/code_splitting/issue_5276
 
@@ -4286,8 +4286,8 @@ expression: output
 
 # tests/rolldown/function/external/splitting_indirect_external_symbol
 
-- main-!~{000}~.js => main-EFjNd84_.js
-- indirect-!~{001}~.js => indirect-mBi_xyt4.js
+- main-!~{000}~.js => main-FqQaVwEC.js
+- indirect-!~{001}~.js => indirect-zX0bmQNV.js
 
 # tests/rolldown/function/external/splitting_with_external_module
 


### PR DESCRIPTION
Replace `console.log` with `assertion` in the test case updated at https://github.com/rolldown/rolldown/pull/7742/changes#r2659674348. This change enhances the robustness of the test case.