### PR TITLE
refactor: inline __toDynamicImportESM 

### DIFF
--- a/crates/rolldown/src/runtime/runtime-base.js
+++ b/crates/rolldown/src/runtime/runtime-base.js
@@ -1,22 +1,19 @@
 export var __create = Object.create;
 export var __defProp = Object.defineProperty;
-export var __name = (target, value) =>
-  __defProp(target, 'name', { value, configurable: true });
+export var __name = (target, value) => __defProp(target, 'name', { value, configurable: true });
 export var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 export var __getOwnPropNames = Object.getOwnPropertyNames;
 export var __getProtoOf = Object.getPrototypeOf;
 export var __hasOwnProp = Object.prototype.hasOwnProperty;
 export var __esm = (fn, res) =>
-  function() {
-    return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+  function () {
+    return (fn && (res = (0, fn[__getOwnPropNames(fn)[0]])((fn = 0))), res);
   };
-export var __esmMin = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
+export var __esmMin = (fn, res) => () => (fn && (res = fn((fn = 0))), res);
 export var __commonJS = (cb, mod) =>
-  function() {
+  function () {
     return (
-      mod ||
-      (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod),
-        mod.exports
+      mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports
     );
   };
 export var __commonJSMin = (cb, mod) => () => (
@@ -34,11 +31,7 @@ export var __exportAll = (all, symbols) => {
 };
 export var __copyProps = (to, from, except, desc) => {
   if ((from && typeof from === 'object') || typeof from === 'function') {
-    for (
-      var keys = __getOwnPropNames(from), i = 0, n = keys.length, key;
-      i < n;
-      i++
-    ) {
+    for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
       key = keys[i];
       if (!__hasOwnProp.call(to, key) && key !== except) {
         __defProp(to, key, {
@@ -51,24 +44,22 @@ export var __copyProps = (to, from, except, desc) => {
   return to;
 };
 export var __reExport = (target, mod, secondTarget) => (
-  __copyProps(target, mod, 'default'),
-    secondTarget && __copyProps(secondTarget, mod, 'default')
+  __copyProps(target, mod, 'default'), secondTarget && __copyProps(secondTarget, mod, 'default')
 );
 export var __toESM = (mod, isNodeMode, target) => (
   (target = mod != null ? __create(__getProtoOf(mod)) : {}),
-    __copyProps(
-      isNodeMode || !mod || !mod.__esModule
-        ? __defProp(target, 'default', { value: mod, enumerable: true })
-        : target,
-      mod,
-    )
+  __copyProps(
+    isNodeMode || !mod || !mod.__esModule
+      ? __defProp(target, 'default', { value: mod, enumerable: true })
+      : target,
+    mod,
+  )
 );
 export var __toCommonJS = (mod) =>
   __hasOwnProp.call(mod, 'module.exports')
     ? mod['module.exports']
     : __copyProps(__defProp({}, '__esModule', { value: true }), mod);
-export var __toBinaryNode = (base64) =>
-  new Uint8Array(Buffer.from(base64, 'base64'));
+export var __toBinaryNode = (base64) => new Uint8Array(Buffer.from(base64, 'base64'));
 export var __toBinary = /* @__PURE__ */ (() => {
   var table = new Uint8Array(128);
   for (var i = 0; i < 64; i++) {
@@ -76,10 +67,8 @@ export var __toBinary = /* @__PURE__ */ (() => {
   }
   return (base64) => {
     var n = base64.length,
-      bytes = new Uint8Array(
-        (((n - (base64[n - 1] == '=') - (base64[n - 2] == '=')) * 3) / 4) | 0,
-      );
-    for (var i = 0, j = 0; i < n;) {
+      bytes = new Uint8Array((((n - (base64[n - 1] == '=') - (base64[n - 2] == '=')) * 3) / 4) | 0);
+    for (var i = 0, j = 0; i < n; ) {
       var c0 = table[base64.charCodeAt(i++)],
         c1 = table[base64.charCodeAt(i++)];
       var c2 = table[base64.charCodeAt(i++)],
@@ -91,7 +80,3 @@ export var __toBinary = /* @__PURE__ */ (() => {
     return bytes;
   };
 })();
-
-// Rolldown uses this to convert the return value of `import('./some-cjs-module.js')` to a more sensible ESM module namespace.
-export var __toDynamicImportESM = (isNodeMode) => (mod) =>
-  __toESM(mod.default, isNodeMode);

--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -265,10 +265,9 @@ impl LinkStage<'_> {
                       match &importee.exports_kind {
                         ExportsKind::CommonJs => {
                           // `import('./some-cjs-module.js')` would be converted to
-                          // `import('./some-cjs-module.js').then(__toDynamicImportESM(isNodeMode))`
-                          depended_runtime_helper_map
-                            [RuntimeHelper::ToDynamicImportEsm.bit_index()]
-                          .push(stmt_info_idx);
+                          // `import('./some-cjs-module.js').then((m) => __toESM(m.default, isNodeMode))`
+                          depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()]
+                            .push(stmt_info_idx);
                         }
                         ExportsKind::Esm | ExportsKind::None => {}
                       }

--- a/crates/rolldown/tests/esbuild/default/conditional_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/conditional_import/artifacts.snap
@@ -6,10 +6,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import { n as __toDynamicImportESM } from "./chunk.js";
+import { n as __toESM } from "./chunk.js";
 
 //#region a.js
-x ? import("a") : y ? import("./import.js").then(__toDynamicImportESM()) : import("c");
+x ? import("a") : y ? import("./import.js").then((m) => /* @__PURE__ */ __toESM(m.default)) : import("c");
 
 //#endregion
 ```
@@ -17,10 +17,10 @@ x ? import("a") : y ? import("./import.js").then(__toDynamicImportESM()) : impor
 ## b.js
 
 ```js
-import { n as __toDynamicImportESM } from "./chunk.js";
+import { n as __toESM } from "./chunk.js";
 
 //#region b.js
-x ? y ? import("a") : import("./import.js").then(__toDynamicImportESM()) : import(c);
+x ? y ? import("a") : import("./import.js").then((m) => /* @__PURE__ */ __toESM(m.default)) : import(c);
 
 //#endregion
 ```
@@ -29,7 +29,7 @@ x ? y ? import("a") : import("./import.js").then(__toDynamicImportESM()) : impor
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __toDynamicImportESM as n, __commonJSMin as t };
+export { __toESM as n, __commonJSMin as t };
 ```
 
 ## import.js

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/artifacts.snap
@@ -17,7 +17,7 @@ var require_foo = /* @__PURE__ */ __commonJSMin(((exports) => {
 //#endregion
 //#region entry.js
 var import_foo = require_foo();
-import("./foo.js").then(__toDynamicImportESM()).then(({ default: { bar: b } }) => {
+import("./foo.js").then((m) => /* @__PURE__ */ __toESM(m.default)).then(({ default: { bar: b } }) => {
 	assert.strictEqual(b, 123);
 	assert.strictEqual(import_foo.bar, 123);
 });

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_common_js_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_common_js_into_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region entry.js
-import("./foo.js").then(__toDynamicImportESM()).then(({ default: { bar } }) => console.log(bar));
+import("./foo.js").then((m) => /* @__PURE__ */ __toESM(m.default)).then(({ default: { bar } }) => console.log(bar));
 
 //#endregion
 export { __commonJSMin as t };

--- a/crates/rolldown/tests/rolldown/cjs_compat/dynamic_cjs_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/dynamic_cjs_entry/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __toDynamicImportESM as n, __commonJSMin as t };
+export { __toESM as n, __commonJSMin as t };
 ```
 
 ## cjs.js
@@ -28,10 +28,10 @@ export default require_cjs();
 ## main.js
 
 ```js
-import { n as __toDynamicImportESM } from "./chunk.js";
+import { n as __toESM } from "./chunk.js";
 
 //#region main.js
-var main_default = import("./cjs.js").then(__toDynamicImportESM());
+var main_default = import("./cjs.js").then((m) => /* @__PURE__ */ __toESM(m.default));
 
 //#endregion
 export { main_default as default };

--- a/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs/artifacts.snap
@@ -46,7 +46,7 @@ exports.value = value;
 //#region main.js
 Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("external"))).then(console.log);
 Promise.resolve().then(() => require("./internal.js")).then(console.log);
-Promise.resolve().then(() => __toDynamicImportESM()(require("./internal-cjs.js"))).then(console.log);
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./internal-cjs.js").default)).then(console.log);
 
 //#endregion
 exports.__commonJSMin = __commonJSMin;

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -27,7 +27,7 @@ import nodeAssert from "node:assert";
 // HIDDEN [rolldown:runtime]
 //#region non-node-mode.js
 async function main$1() {
-	const exports = await import("./lib.js").then(__toDynamicImportESM());
+	const exports = await import("./lib.js").then((m) => /* @__PURE__ */ __toESM(m.default));
 	nodeAssert.deepEqual(Object.keys(exports).sort(), ["parse"]);
 	nodeAssert.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
 	nodeAssert.strictEqual(exports.default, void 0, "Target has __esModule, so no auto-generated default export");
@@ -37,7 +37,7 @@ main$1();
 //#endregion
 //#region node-mode-by-mjs-extension.mjs
 async function main() {
-	const exports = await import("./lib.js").then(__toDynamicImportESM(1));
+	const exports = await import("./lib.js").then((m) => /* @__PURE__ */ __toESM(m.default, 1));
 	nodeAssert.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
 	nodeAssert.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
 	nodeAssert.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
@@ -48,7 +48,7 @@ main();
 //#region node-mode-by-cjs-extension.cjs
 var require_node_mode_by_cjs_extension = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	async function main() {
-		const exports = await import("./lib.js").then(__toDynamicImportESM(1));
+		const exports = await import("./lib.js").then((m) => /* @__PURE__ */ __toESM(m.default, 1));
 		nodeAssert.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
 		nodeAssert.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
 		nodeAssert.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
@@ -98,7 +98,7 @@ node_assert = __toESM(node_assert);
 
 //#region non-node-mode.js
 async function main$1() {
-	const exports$1 = await Promise.resolve().then(() => __toDynamicImportESM()(require("./lib.js")));
+	const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default));
 	node_assert.default.deepEqual(Object.keys(exports$1).sort(), ["parse"]);
 	node_assert.default.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 	node_assert.default.strictEqual(exports$1.default, void 0, "Target has __esModule, so no auto-generated default export");
@@ -108,7 +108,7 @@ main$1();
 //#endregion
 //#region node-mode-by-mjs-extension.mjs
 async function main() {
-	const exports$1 = await Promise.resolve().then(() => __toDynamicImportESM(1)(require("./lib.js")));
+	const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default, 1));
 	node_assert.default.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
 	node_assert.default.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 	node_assert.default.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
@@ -119,7 +119,7 @@ main();
 //#region node-mode-by-cjs-extension.cjs
 var require_node_mode_by_cjs_extension = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	async function main() {
-		const exports$1 = await Promise.resolve().then(() => __toDynamicImportESM(1)(require("./lib.js")));
+		const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default, 1));
 		node_assert.default.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
 		node_assert.default.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 		node_assert.default.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");

--- a/crates/rolldown/tests/rolldown/issues/6593/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6593/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __toDynamicImportESM as n, __commonJSMin as t };
+export { __toESM as n, __commonJSMin as t };
 ```
 
 ## lib.js
@@ -40,11 +40,11 @@ export default require_lib();
 ## main.js
 
 ```js
-import { n as __toDynamicImportESM } from "./chunk.js";
+import { n as __toESM } from "./chunk.js";
 import assert from "node:assert";
 
 //#region entry.js
-const mod = await import("./lib.js").then(__toDynamicImportESM());
+const mod = await import("./lib.js").then((m) => /* @__PURE__ */ __toESM(m.default));
 assert.strictEqual(mod.default().name, "plugin");
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
@@ -52,7 +52,7 @@ init_e();
 //#region b.js
 var require_b = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.defaultProvider = async function test() {
-		const { fromIni } = await import("./c.js").then(__toDynamicImportESM());
+		const { fromIni } = await import("./c.js").then((m) => /* @__PURE__ */ __toESM(m.default));
 		console.log(fromIni);
 	};
 }));

--- a/crates/rolldown/tests/rolldown/issues/7655/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7655/artifacts.snap
@@ -31,7 +31,7 @@ Object.defineProperty(exports, 'default', {
 // HIDDEN [rolldown:runtime]
 
 //#region main.js
-Promise.resolve().then(() => __toDynamicImportESM()(require("./a.js"))).then((m) => console.log(m.default));
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./a.js").default)).then((m) => console.log(m.default));
 
 //#endregion
 exports.__commonJSMin = __commonJSMin;

--- a/crates/rolldown/tests/rolldown/issues/duplicate_default_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/duplicate_default_export/artifacts.snap
@@ -13,7 +13,7 @@ var require_file = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 }));
 
 //#endregion
-export { __toDynamicImportESM as n, require_file as t };
+export { __toESM as n, require_file as t };
 ```
 
 ## file2.js
@@ -28,12 +28,12 @@ export default require_file();
 ## main.js
 
 ```js
-import { n as __toDynamicImportESM, t as require_file } from "./file.js";
+import { n as __toESM, t as require_file } from "./file.js";
 import assert from "node:assert";
 
 //#region main.js
 const required = require_file();
-const dynamicRes = await import("./file2.js").then(__toDynamicImportESM());
+const dynamicRes = await import("./file2.js").then((m) => /* @__PURE__ */ __toESM(m.default));
 assert.strictEqual(required.foo, "bar");
 assert.strictEqual(dynamicRes.default.foo, "bar");
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -45,7 +45,7 @@ var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 async function foo() {
-	await import("./exist-dep-cjs.js").then(__toDynamicImportESM()).then(console.log);
+	await import("./exist-dep-cjs.js").then((m) => /* @__PURE__ */ __toESM(m.default)).then(console.log);
 	await import("./exist-dep-esm.js").then(console.log);
 }
 hmr_hot.accept((mod) => {

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -643,10 +643,10 @@ expression: output
 
 # tests/esbuild/default/conditional_import
 
-- a-!~{000}~.js => a-CJXdFR_5.js
-- b-!~{001}~.js => b-DCSpFXkg.js
-- chunk-!~{002}~.js => chunk-DxxrS-O2.js
-- import-!~{004}~.js => import-CiFmGmRh.js
+- a-!~{000}~.js => a-C0NeE1La.js
+- b-!~{001}~.js => b-hT0K-d7J.js
+- chunk-!~{002}~.js => chunk-DktsPxOj.js
+- import-!~{004}~.js => import-BM-qrhnR.js
 
 # tests/esbuild/default/conditional_require
 
@@ -3227,8 +3227,8 @@ expression: output
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6
 
-- entry-!~{000}~.js => entry-BIuzO3gc.js
-- foo-!~{001}~.js => foo-D6ZpYFx4.js
+- entry-!~{000}~.js => entry-GF1_PXWz.js
+- foo-!~{001}~.js => foo-D2Fmh016.js
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6
 
@@ -3237,8 +3237,8 @@ expression: output
 
 # tests/esbuild/splitting/splitting_dynamic_common_js_into_es6
 
-- entry-!~{000}~.js => entry-C2lk-nBa.js
-- foo-!~{001}~.js => foo-CUJxbrVH.js
+- entry-!~{000}~.js => entry-5vBU_b7U.js
+- foo-!~{001}~.js => foo-CjQIDeaY.js
 
 # tests/esbuild/splitting/splitting_dynamic_es6_into_es6
 
@@ -3638,15 +3638,15 @@ expression: output
 
 # tests/rolldown/cjs_compat/dynamic_cjs_entry
 
-- main-!~{000}~.js => main-D_duaTHV.js
-- chunk-!~{001}~.js => chunk-DhkxgLhx.js
-- cjs-!~{003}~.js => cjs-BGgro4pb.js
+- main-!~{000}~.js => main-CALrOrPV.js
+- chunk-!~{001}~.js => chunk-mdRliFvb.js
+- cjs-!~{003}~.js => cjs-BzRvro5U.js
 
 # tests/rolldown/cjs_compat/dynamic_import_in_cjs
 
-- main-!~{000}~.js => main-D50uPii5.js
+- main-!~{000}~.js => main-vfeK-zo9.js
 - internal-!~{003}~.js => internal-DiqBI5kB.js
-- internal-cjs-!~{001}~.js => internal-cjs-CAIg6paw.js
+- internal-cjs-!~{001}~.js => internal-cjs-Dclx_OsA.js
 
 # tests/rolldown/cjs_compat/esm_require_cjs
 
@@ -4105,7 +4105,7 @@ expression: output
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4636
 
-- main-!~{000}~.js => main-BFvPO6M3.js
+- main-!~{000}~.js => main-BPFiS8pV.js
 
 # tests/rolldown/function/experimental/strict_execution_order/issue_4684
 
@@ -4810,7 +4810,7 @@ expression: output
 
 # tests/rolldown/issues/4129
 
-- main-!~{000}~.js => main-DnsOb4pD.js
+- main-!~{000}~.js => main-MngBan1P.js
 
 # tests/rolldown/issues/4196
 
@@ -4822,8 +4822,8 @@ expression: output
 
 # tests/rolldown/issues/4289
 
-- main-!~{000}~.js => main-DVgsJl3r.js
-- lib-!~{001}~.js => lib-BIqPty4I.js
+- main-!~{000}~.js => main-DNKP2R5u.js
+- lib-!~{001}~.js => lib-BWGrTXJs.js
 
 # tests/rolldown/issues/4324
 
@@ -4987,9 +4987,9 @@ expression: output
 
 # tests/rolldown/issues/6593
 
-- main-!~{000}~.js => main-1z9vQqLC.js
-- chunk-!~{001}~.js => chunk-DhkxgLhx.js
-- lib-!~{003}~.js => lib-ChhmvYi1.js
+- main-!~{000}~.js => main-Bk_aomjc.js
+- chunk-!~{001}~.js => chunk-mdRliFvb.js
+- lib-!~{003}~.js => lib-D4rMP-Xw.js
 
 # tests/rolldown/issues/6651
 
@@ -4997,9 +4997,9 @@ expression: output
 
 # tests/rolldown/issues/6660
 
-- index-!~{000}~.js => index-4k-Mt37U.js
-- c-!~{001}~.js => c-DbgVIkD1.js
-- e-!~{003}~.js => e-BN9Gbtnv.js
+- index-!~{000}~.js => index-CGJNCiyY.js
+- c-!~{001}~.js => c-DAgEJIWk.js
+- e-!~{003}~.js => e-DbVrWDEC.js
 
 # tests/rolldown/issues/6756
 
@@ -5087,14 +5087,14 @@ expression: output
 
 # tests/rolldown/issues/7655
 
-- main-!~{000}~.js => main-QsKk41YI.js
-- a-!~{001}~.js => a-BKgXR6kK.js
+- main-!~{000}~.js => main-UOGqPpjl.js
+- a-!~{001}~.js => a-DFXBzqLO.js
 
 # tests/rolldown/issues/duplicate_default_export
 
-- main-!~{000}~.js => main-D5owKpO2.js
-- file-!~{001}~.js => file-DkuDnLxQ.js
-- file-!~{003}~.js => file-hC2GaOdU.js
+- main-!~{000}~.js => main-BatCM-9U.js
+- file-!~{001}~.js => file-CEzEU-9B.js
+- file-!~{003}~.js => file-CnAdNPrT.js
 
 # tests/rolldown/issues/nullish_coalescing_es6
 
@@ -5897,102 +5897,102 @@ expression: output
 
 # tests/rolldown/topics/hmr/accept-outside-circular
 
-- main-!~{000}~.js => main-CLZR5ada.js
+- main-!~{000}~.js => main-DbJ4bJ0r.js
 
 # tests/rolldown/topics/hmr/change_accept
 
-- main-!~{000}~.js => main-DbRDwnvC.js
+- main-!~{000}~.js => main-jUT4ympq.js
 
 # tests/rolldown/topics/hmr/cjs_no_export
 
-- main-!~{000}~.js => main-BJYG_vCU.js
+- main-!~{000}~.js => main-DdPMzRHG.js
 
 # tests/rolldown/topics/hmr/delete_file_not_used_anymore
 
-- main-!~{000}~.js => main-Y20Q6Ujd.js
+- main-!~{000}~.js => main-UUOOQ12l.js
 
 # tests/rolldown/topics/hmr/delete_file_used
 
-- main-!~{000}~.js => main-RQMXlOJG.js
+- main-!~{000}~.js => main-Na798yjt.js
 
 # tests/rolldown/topics/hmr/dynamic_import
 
-- main-!~{000}~.js => main-Cm286Gqg.js
-- exist-dep-cjs-!~{001}~.js => exist-dep-cjs-CmGQaNMg.js
-- exist-dep-esm-!~{003}~.js => exist-dep-esm-BVcWepyC.js
+- main-!~{000}~.js => main-ZCaHdAYc.js
+- exist-dep-cjs-!~{001}~.js => exist-dep-cjs-CRwV2KEm.js
+- exist-dep-esm-!~{003}~.js => exist-dep-esm-C-jWFhVK.js
 
 # tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error
 
-- main-!~{000}~.js => main-BMNGsedU.js
+- main-!~{000}~.js => main-DKZzQHBW.js
 
 # tests/rolldown/topics/hmr/esm_no_export
 
-- main-!~{000}~.js => main-BSKantpI.js
+- main-!~{000}~.js => main-BFulbNLs.js
 
 # tests/rolldown/topics/hmr/export_star
 
-- main-!~{000}~.js => main-DHIj4NZQ.js
+- main-!~{000}~.js => main-BpgDqWBt.js
 
 # tests/rolldown/topics/hmr/generate_patch_error
 
-- main-!~{000}~.js => main-DS2Jetji.js
+- main-!~{000}~.js => main-D0-XK9ME.js
 
 # tests/rolldown/topics/hmr/import_meta_hot_accept
 
-- main-!~{000}~.js => main-BgGYx0gh.js
+- main-!~{000}~.js => main-ebwO97qT.js
 
 # tests/rolldown/topics/hmr/issue_4818
 
-- main-!~{000}~.js => main-CQmX7cpy.js
+- main-!~{000}~.js => main-Bf3gGxKZ.js
 
 # tests/rolldown/topics/hmr/issue_5149
 
-- main-!~{000}~.js => main-D0T9y176.js
+- main-!~{000}~.js => main-DO4h2jut.js
 
 # tests/rolldown/topics/hmr/issue_5150
 
-- main-!~{000}~.js => main-RtaPUL5_.js
+- main-!~{000}~.js => main-BCUN5Dh3.js
 
 # tests/rolldown/topics/hmr/issue_5159
 
-- main-!~{000}~.js => main-bxsTec3s.js
-- bar-!~{003}~.js => bar-DifdmgtM.js
-- foo-!~{005}~.js => foo-Bu7QarXC.js
-- string-!~{001}~.js => string-5tFSLDm2.js
+- main-!~{000}~.js => main-26vh8Srn.js
+- bar-!~{003}~.js => bar-B6JdptIm.js
+- foo-!~{005}~.js => foo-BppJ6KR6.js
+- string-!~{001}~.js => string-j7tVA1R_.js
 
 # tests/rolldown/topics/hmr/mutiply_entires
 
-- entry-!~{000}~.js => entry-DECLc6mQ.js
-- index-!~{001}~.js => index-BtgIhZIO.js
-- rolldown_hmr-!~{002}~.js => rolldown_hmr-DbzQbNCw.js
+- entry-!~{000}~.js => entry-B5V_TOBO.js
+- index-!~{001}~.js => index-FohbA_dd.js
+- rolldown_hmr-!~{002}~.js => rolldown_hmr-z_PYPb-N.js
 
 # tests/rolldown/topics/hmr/no-accept-outside-circular
 
-- main-!~{000}~.js => main-QoAxDP9g.js
+- main-!~{000}~.js => main-D07dmfbX.js
 
 # tests/rolldown/topics/hmr/no_boundary_reload
 
-- main-!~{000}~.js => main-n6vqrY8X.js
+- main-!~{000}~.js => main-BzZp3fxL.js
 
 # tests/rolldown/topics/hmr/non_used_export
 
-- main-!~{000}~.js => main-DJQp7YTF.js
+- main-!~{000}~.js => main-DASPKxem.js
 
 # tests/rolldown/topics/hmr/register_exports
 
-- main-!~{000}~.js => main-DwrAIUsJ.js
+- main-!~{000}~.js => main-CIlZNH3c.js
 
 # tests/rolldown/topics/hmr/runtime_correctness
 
-- main-!~{000}~.js => main-FXvwXhpE.js
+- main-!~{000}~.js => main-x2NXrmAs.js
 
 # tests/rolldown/topics/hmr/self-accept-within-circular
 
-- main-!~{000}~.js => main-DBp1UEa_.js
+- main-!~{000}~.js => main-gg6A0Br_.js
 
 # tests/rolldown/topics/hmr/static_import
 
-- main-!~{000}~.js => main-CEfixAjf.js
+- main-!~{000}~.js => main-Dq0HaX-G.js
 
 # tests/rolldown/topics/import_meta_url_dirname_filename_polyfill/node_cjs
 

--- a/crates/rolldown_common/src/generated/runtime_helper.rs
+++ b/crates/rolldown_common/src/generated/runtime_helper.rs
@@ -23,8 +23,7 @@ bitflags! {
     const ToCommonJs = 1 << 15;
     const ToBinaryNode = 1 << 16;
     const ToBinary = 1 << 17;
-    const ToDynamicImportEsm = 1 << 18;
-    const Require = 1 << 19;
+    const Require = 1 << 18;
   }
 }
 
@@ -56,7 +55,7 @@ impl DependedRuntimeHelperMapExt for DependedRuntimeHelperMap {
   }
 }
 
-pub const RUNTIME_HELPER_NAMES: [&str; 20] = [
+pub const RUNTIME_HELPER_NAMES: [&str; 19] = [
   "__create",
   "__defProp",
   "__name",
@@ -75,6 +74,5 @@ pub const RUNTIME_HELPER_NAMES: [&str; 20] = [
   "__toCommonJS",
   "__toBinaryNode",
   "__toBinary",
-  "__toDynamicImportESM",
   "__require",
 ];

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
@@ -3,7 +3,6 @@ import {
   __exportAll,
   __reExport,
   __toCommonJS,
-  __toDynamicImportESM,
   __toESM,
   // @ts-expect-error
 } from 'rolldown:runtime';
@@ -88,24 +87,28 @@ export class DevRuntime {
    * @type {<T>(fn: any, res: T) => () => T}
    * @internal
    */
-  createEsmInitializer = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
+  createEsmInitializer = (fn, res) => () => (fn && (res = fn((fn = 0))), res);
   /**
    * __commonJSMin
    *
    * @type {<T extends { exports: any }>(cb: any, mod: { exports: any }) => () => T}
    * @internal
    */
-  createCjsInitializer =
-    (cb, mod) =>
-    () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+  createCjsInitializer = (cb, mod) => () => (
+    mod || cb((mod = { exports: {} }).exports, mod), mod.exports
+  );
   /** @internal */
   __toESM = __toESM;
   /** @internal */
   __toCommonJS = __toCommonJS;
   /** @internal */
   __exportAll = __exportAll;
-  /** @internal */
-  __toDynamicImportESM = __toDynamicImportESM;
+  /**
+   * @param {boolean} [isNodeMode]
+   * @returns {(mod: any) => any}
+   * @internal
+   */
+  __toDynamicImportESM = (isNodeMode) => (mod) => __toESM(mod.default, isNodeMode);
   /** @internal */
   __reExport = __reExport;
 


### PR DESCRIPTION
I found an issue while trying to solve #4905. Here is an example https://github.com/rolldown/rolldown/pull/7742/changes#diff-627d2ba1517f46e8cfe17e7ce9efe06e8b51f83a3c3ff87586c415981e3e5bc3. When a module dynamically imports a CommonJS module, we always generate code like: 

```js
import("./foo.js").then(__toDynamicImportESM()).then(({ default: { bar: b } }) => {})
```

But after implementing the #4905 optimization, when the importer and the importee are in the same chunk, we generate code like: 

```js
Promise.resolve().then(() => __toESM(require_foo())).then(mod) => {
	console.log(mod);
});
```

Since the chunk optimization happens after linking state, we should reference both `__toDynamicImportESM` and `__toESM` runtime helpers. If the runtime module is included in a different chunk, 
one of `__toESM` and `__toDynamicImportESM` may not be used but is still included with the `import` statement, which can't be eliminated by the minifier.

Inlining `__toDynamicImportESM` could solve this issue.

### Pros
1. Resolves the issue mentioned above.
2. Improves run-time performance a little.
3. Reduces the overall size of the runtime modules.

### Cons
1. Increases the generated output size a little. `m.default` can't be compressed by the minifier.


I am open to both solution.
