### PR TITLE
refactor: simplify try_rewrite_import_expression control flow

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -366,12 +366,12 @@ impl GenerateStage<'_> {
         continue;
       };
       let target_chunk = &chunk_graph.chunk_table[target_chunk_idx];
-      // 1. dynamic entry chunk that also capatured by a advanced chunk group
+      // 1. dynamic entry chunk that also captured by a advanced chunk group
       // 2. dynamic entry module are already merged into  user defined entry chunk in previous round optimization
       if !(matches!(
         target_chunk.chunk_reason_type.as_ref(),
         ChunkReasonType::AdvancedChunks { .. }
-      ) || matches!(target_chunk.kind, ChunkKind::EntryPoint { meta, bit, module } if meta.is_pure_user_defined_entry()))
+      ) || matches!(target_chunk.kind, ChunkKind::EntryPoint { meta, bit: _, module: _ } if meta.is_pure_user_defined_entry()))
       {
         continue;
       }


### PR DESCRIPTION
Use `let else` instead of `if let Some() = xxx` pattern to reduce the control flow which make the code more readable.