### PR TITLE
fix: dynamic entry captured by common chunk with CJS format

### DIFF
--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276/_config.json
@@ -13,6 +13,9 @@
     {
       "_configName": "disableChunkOptimization",
       "chunkOptimization": false
+    },
+    {
+      "format": "cjs"
     }
   ]
 }

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
@@ -125,3 +125,121 @@ load();
 
 //#endregion
 ```
+
+# Variant: [format: Cjs]
+
+## Assets
+
+### imp.js
+
+```js
+const require_rolldown_runtime = require('./rolldown-runtime.js');
+
+//#region imp1.js
+var imp1_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ imp1: () => imp1 });
+const imp1 = 1;
+
+//#endregion
+//#region imp2.js
+var imp2_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ imp2: () => imp2 });
+const imp2 = 2;
+
+//#endregion
+//#region imp3.js
+var imp3_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({
+	imp3: () => imp3,
+	imp33: () => imp33
+});
+const imp3 = 3;
+const imp33 = 33;
+
+//#endregion
+Object.defineProperty(exports, 'imp1', {
+  enumerable: true,
+  get: function () {
+    return imp1;
+  }
+});
+Object.defineProperty(exports, 'imp1_exports', {
+  enumerable: true,
+  get: function () {
+    return imp1_exports;
+  }
+});
+Object.defineProperty(exports, 'imp2', {
+  enumerable: true,
+  get: function () {
+    return imp2;
+  }
+});
+Object.defineProperty(exports, 'imp2_exports', {
+  enumerable: true,
+  get: function () {
+    return imp2_exports;
+  }
+});
+Object.defineProperty(exports, 'imp3', {
+  enumerable: true,
+  get: function () {
+    return imp3;
+  }
+});
+Object.defineProperty(exports, 'imp33', {
+  enumerable: true,
+  get: function () {
+    return imp33;
+  }
+});
+Object.defineProperty(exports, 'imp3_exports', {
+  enumerable: true,
+  get: function () {
+    return imp3_exports;
+  }
+});
+```
+
+### main.js
+
+```js
+const require_rolldown_runtime = require('./rolldown-runtime.js');
+let node_assert = require("node:assert");
+node_assert = require_rolldown_runtime.__toESM(node_assert);
+
+//#region main.js
+const load = async () => {
+	Promise.resolve().then(() => require("./imp.js")).then((n) => n.imp1_exports).then((m) => {
+		node_assert.default.strictEqual(m.imp1, 1);
+	});
+	Promise.resolve().then(() => require("./imp.js")).then((n) => n.imp2_exports).then((m) => {
+		node_assert.default.strictEqual(m.imp2, 2);
+	});
+	Promise.resolve().then(() => require("./imp.js")).then((n) => n.imp3_exports).then((m) => {
+		node_assert.default.deepEqual(JSON.parse(JSON.stringify(m)), {
+			imp3: 3,
+			imp33: 33
+		});
+	});
+};
+load();
+
+//#endregion
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [rolldown:runtime]
+
+Object.defineProperty(exports, '__exportAll', {
+  enumerable: true,
+  get: function () {
+    return __exportAll;
+  }
+});
+Object.defineProperty(exports, '__toESM', {
+  enumerable: true,
+  get: function () {
+    return __toESM;
+  }
+});
+```

--- a/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
@@ -868,14 +868,26 @@ impl<'ast> AstSnippet<'ast> {
   /// Creates a call expression that transforms a dynamic import to extract a specific property.
   /// Generates: `import_expr.then(n => n.property_name)`
   /// This is used to transform dynamic imports to extract a specific export from the module namespace.
+  #[inline]
   pub fn import_then_extract_property(
     &self,
     import_expr: allocator::Box<'ast, ast::ImportExpression<'ast>>,
     property_name: &str,
   ) -> allocator::Box<'ast, ast::CallExpression<'ast>> {
+    self.then_extract_property(Expression::ImportExpression(import_expr), property_name)
+  }
+
+  /// Creates a call expression that chains `.then(n => n.property_name)` to any expression.
+  /// Generates: `expr.then(n => n.property_name)`
+  /// This is used to extract a specific export from a promise that resolves to a module namespace.
+  pub fn then_extract_property(
+    &self,
+    expr: Expression<'ast>,
+    property_name: &str,
+  ) -> allocator::Box<'ast, ast::CallExpression<'ast>> {
     let callee = self.builder.alloc_static_member_expression(
       SPAN,
-      Expression::ImportExpression(import_expr),
+      expr,
       self.builder.identifier_name(SPAN, "then"),
       false,
     );


### PR DESCRIPTION
1. Move the dynamic import module in CJS format transformation logic to `try_rewrite_import_expression` because the logic is more closely aligned with the function name. Before it is in https://github.com/rolldown/rolldown/blob/bc3a9adb27966f8633b9482351c2a6fbc3c9992e/crates/rolldown/src/module_finalizers/mod.rs#L1015-L1019

2. Add logic for dynamic entry merge in the common chunk for cjs format.