### PR TITLE
refactor: remove duplicate `preserve_entry_signatures` from `AddEntryModuleMsg`

### DIFF
--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -102,7 +102,7 @@ impl FileEmitter {
     .context(
       "The `PluginContext.emitFile` with `type: 'chunk'` only work at `buildStart/resolveId/load/transform/moduleParsed` hooks.",
     )?
-    .send(ModuleLoaderMsg::AddEntryModule(Box::new(AddEntryModuleMsg { chunk: Arc::clone(&chunk), reference_id: reference_id.clone(), preserve_entry_signatures: chunk.preserve_entry_signatures })))
+    .send(ModuleLoaderMsg::AddEntryModule(Box::new(AddEntryModuleMsg { chunk: Arc::clone(&chunk), reference_id: reference_id.clone() })))
     .await
     .context("FileEmitter: failed to send AddEntryModule message - module loader shut down during file emission")?;
     self.chunks.insert(reference_id.clone(), chunk);

--- a/crates/rolldown_common/src/module_loader/mod.rs
+++ b/crates/rolldown_common/src/module_loader/mod.rs
@@ -5,7 +5,7 @@ use rolldown_error::BuildDiagnostic;
 use runtime_task_result::RuntimeModuleTaskResult;
 use task_result::{ExternalModuleTaskResult, NormalModuleTaskResult};
 
-use crate::{EmittedChunk, PreserveEntrySignatures, ResolvedId};
+use crate::{EmittedChunk, ResolvedId};
 
 pub mod runtime_module_brief;
 pub mod runtime_task_result;
@@ -23,5 +23,4 @@ pub enum ModuleLoaderMsg {
 pub struct AddEntryModuleMsg {
   pub chunk: Arc<EmittedChunk>,
   pub reference_id: ArcStr,
-  pub preserve_entry_signatures: Option<PreserveEntrySignatures>,
 }


### PR DESCRIPTION
This field is already accessible via `chunk.preserve_entry_signatures`, so storing it separately is redundant.