### PR TITLE
fix(module_loader): mark emitted chunks as user-defined entry when already loaded

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/5011/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5011/artifacts.snap
@@ -13,6 +13,16 @@ console.log("after preload dynamic");
 //#endregion
 ```
 
+## before-preload-dynamic.js
+
+```js
+//#region src/before-preload-dynamic.js
+import("./dynamic-foo.js");
+console.log("before preload dynamic");
+
+//#endregion
+```
+
 ## dynamic-foo.js
 
 ```js
@@ -25,6 +35,7 @@ console.log("dynamic-foo");
 ## entry.js
 
 ```js
+import "./before-preload-dynamic.js";
 import "./after-preload-dynamic.js";
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/5011/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/5011/mod.rs
@@ -20,9 +20,17 @@ impl Plugin for Test {
   ) -> rolldown_plugin::HookTransformReturn {
     if args.id.ends_with("after-preload-dynamic.js") {
       ctx
-        .inner
         .emit_chunk(EmittedChunk {
           id: "./src/after-preload-dynamic.js".into(),
+          preserve_entry_signatures: None,
+          ..Default::default()
+        })
+        .await?;
+    }
+    if args.id.ends_with("dynamic-foo.js") {
+      ctx
+        .emit_chunk(EmittedChunk {
+          id: "./src/before-preload-dynamic.js".into(),
           preserve_entry_signatures: None,
           ..Default::default()
         })

--- a/crates/rolldown/tests/rolldown/issues/5011/src/before-preload-dynamic.js
+++ b/crates/rolldown/tests/rolldown/issues/5011/src/before-preload-dynamic.js
@@ -1,0 +1,3 @@
+import('./dynamic-foo');
+
+console.log('before preload dynamic');

--- a/crates/rolldown/tests/rolldown/issues/5011/src/entry.js
+++ b/crates/rolldown/tests/rolldown/issues/5011/src/entry.js
@@ -1,1 +1,2 @@
+import './before-preload-dynamic.js';
 import './after-preload-dynamic.js';


### PR DESCRIPTION
Related to #5012

When `emitFile` is called for a module that was already loaded as a dependency, the module's `is_user_defined_entry` flag was not being set correctly.
