### PR TITLE
fix: `__toESM` should respect Node ESM spec for inlined dynamic CommonJS imports


### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1,5 +1,5 @@
 use bitflags::bitflags;
-use oxc::ast::ast::{Argument, ObjectPropertyKind};
+use oxc::ast::ast::ObjectPropertyKind;
 use oxc::semantic::{ReferenceId, ScopeFlags, SymbolId};
 use oxc::{
   allocator::{self, Allocator, Box as ArenaBox, CloneIn, Dummy, IntoIn, TakeIn},
@@ -1641,13 +1641,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           self.snippet.builder.vec(),
           false,
         );
-        // __toESM(require_xxx())
-        self.snippet.builder.expression_call(
-          SPAN,
+
+        // __toESM(require_xxx(), isNodeMode)
+        self.snippet.wrap_with_to_esm(
           finalized_to_esm,
-          NONE,
-          self.snippet.builder.vec1(Argument::from(wrapper_ref_call_expr)),
-          false,
+          wrapper_ref_call_expr,
+          self.ctx.module.should_consider_node_esm_spec_for_dynamic_import(),
         )
       } else {
         let (finalized_expr, _) =

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6/artifacts.snap
@@ -17,7 +17,7 @@ var require_foo = /* @__PURE__ */ __commonJSMin(((exports) => {
 //#endregion
 //#region entry.js
 var import_foo = require_foo();
-Promise.resolve().then(() => __toESM(require_foo())).then(({ default: { bar: b } }) => {
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_foo())).then(({ default: { bar: b } }) => {
 	assert.strictEqual(b, 123);
 	assert.strictEqual(import_foo.bar, 123);
 });

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_cjs_same_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_import_cjs_same_chunk/artifacts.snap
@@ -18,7 +18,7 @@ var require_cjs_module = /* @__PURE__ */ __commonJSMin(((exports) => {
 //#region main.js
 var import_cjs_module = /* @__PURE__ */ __toESM(require_cjs_module());
 assert.strictEqual(import_cjs_module.value, 42);
-Promise.resolve().then(() => __toESM(require_cjs_module())).then((mod) => {
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs_module())).then((mod) => {
 	assert.strictEqual(mod.value, 42);
 	assert.strictEqual(mod.default.value, 42);
 });
@@ -51,7 +51,7 @@ var require_cjs_module = /* @__PURE__ */ __commonJSMin(((exports) => {
 //#region main.js
 var import_cjs_module = /* @__PURE__ */ __toESM(require_cjs_module());
 node_assert.default.strictEqual(import_cjs_module.value, 42);
-Promise.resolve().then(() => __toESM(require_cjs_module())).then((mod) => {
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require_cjs_module())).then((mod) => {
 	node_assert.default.strictEqual(mod.value, 42);
 	node_assert.default.strictEqual(mod.default.value, 42);
 });

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3227,7 +3227,7 @@ expression: output
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6
 
-- entry-!~{000}~.js => entry-YfblYvsf.js
+- entry-!~{000}~.js => entry-CS1oueUX.js
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6
 
@@ -5331,7 +5331,7 @@ expression: output
 
 # tests/rolldown/optimization/chunk_merging/dynamic_import_cjs_same_chunk
 
-- main-!~{000}~.js => main-cLnL0EF5.js
+- main-!~{000}~.js => main-8BBJThoK.js
 
 # tests/rolldown/optimization/chunk_merging/issue_4905
 


### PR DESCRIPTION
fix CI issue https://github.com/rolldown/rolldown/actions/runs/20715725623/job/59466310236