### PR TITLE
fix: dynamic entry merged into common chunk with cjs and esm wrap kind

### DIFF
--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk/_config.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "advancedChunks": {
+      "groups": [
+        {
+          "name": "imp",
+          "test": "imp"
+        }
+      ]
+    }
+  },
+  "configVariants": [
+    {
+      "format": "cjs"
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk/artifacts.snap
@@ -1,0 +1,102 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## imp2.js
+
+```js
+import { t as __commonJSMin } from "./rolldown-runtime.js";
+
+//#region imp.js
+var require_imp = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.imp = 1;
+}));
+
+//#endregion
+export { require_imp as t };
+```
+
+## main.js
+
+```js
+import { n as __toESM } from "./rolldown-runtime.js";
+import assert from "node:assert";
+
+//#region main.js
+const load = async () => {
+	import("./imp2.js").then((n) => /* @__PURE__ */ __toESM(n.t())).then((m) => {
+		assert.strictEqual(m.imp, 1);
+	});
+};
+load();
+
+//#endregion
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [rolldown:runtime]
+export { __toESM as n, __commonJSMin as t };
+```
+
+# Variant: [format: Cjs]
+
+## Assets
+
+### imp2.js
+
+```js
+const require_rolldown_runtime = require('./rolldown-runtime.js');
+
+//#region imp.js
+var require_imp = /* @__PURE__ */ require_rolldown_runtime.__commonJSMin(((exports) => {
+	exports.imp = 1;
+}));
+
+//#endregion
+Object.defineProperty(exports, 'require_imp', {
+  enumerable: true,
+  get: function () {
+    return require_imp;
+  }
+});
+```
+
+### main.js
+
+```js
+const require_rolldown_runtime = require('./rolldown-runtime.js');
+let node_assert = require("node:assert");
+node_assert = require_rolldown_runtime.__toESM(node_assert);
+
+//#region main.js
+const load = async () => {
+	Promise.resolve().then(() => require("./imp2.js")).then((n) => /* @__PURE__ */ require_rolldown_runtime.__toESM(n.require_imp())).then((m) => {
+		node_assert.default.strictEqual(m.imp, 1);
+	});
+};
+load();
+
+//#endregion
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [rolldown:runtime]
+
+Object.defineProperty(exports, '__commonJSMin', {
+  enumerable: true,
+  get: function () {
+    return __commonJSMin;
+  }
+});
+Object.defineProperty(exports, '__toESM', {
+  enumerable: true,
+  get: function () {
+    return __toESM;
+  }
+});
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk/imp.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk/imp.js
@@ -1,0 +1,1 @@
+exports.imp = 1;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk/main.js
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+
+const load = async () => {
+  import('./imp').then((m) => {
+    assert.strictEqual(m.imp, 1);
+  });
+};
+
+load();

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/_config.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "advancedChunks": {
+      "groups": [
+        {
+          "name": "imp",
+          "test": "imp"
+        }
+      ]
+    }
+  },
+  "configVariants": [
+    {
+      "format": "cjs"
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/artifacts.snap
@@ -1,0 +1,154 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## imp.js
+
+```js
+import { n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
+
+//#region imp2.js
+var imp2_exports = /* @__PURE__ */ __exportAll({ imp2: () => imp2 });
+var imp2;
+var init_imp2 = __esmMin((() => {
+	imp2 = 2;
+}));
+
+//#endregion
+//#region imp.js
+var require_imp = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.imp = 1;
+}));
+
+//#endregion
+export { init_imp2 as i, imp2 as n, imp2_exports as r, require_imp as t };
+```
+
+## main.js
+
+```js
+import { i as __toESM } from "./rolldown-runtime.js";
+import assert from "node:assert";
+
+//#region main.js
+const load = async () => {
+	import("./imp.js").then((n) => /* @__PURE__ */ __toESM(n.t())).then((m) => {
+		assert.strictEqual(m.imp, 1);
+	});
+	import("./imp.js").then((n) => (n.i(), n.r)).then((m) => {
+		assert.strictEqual(m.imp2, 2);
+	});
+};
+load();
+
+//#endregion
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [rolldown:runtime]
+export { __toESM as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
+```
+
+# Variant: [format: Cjs]
+
+## Assets
+
+### imp.js
+
+```js
+const require_rolldown_runtime = require('./rolldown-runtime.js');
+
+//#region imp2.js
+var imp2_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ imp2: () => imp2 });
+var imp2;
+var init_imp2 = require_rolldown_runtime.__esmMin((() => {
+	imp2 = 2;
+}));
+
+//#endregion
+//#region imp.js
+var require_imp = /* @__PURE__ */ require_rolldown_runtime.__commonJSMin(((exports) => {
+	exports.imp = 1;
+}));
+
+//#endregion
+Object.defineProperty(exports, 'imp2', {
+  enumerable: true,
+  get: function () {
+    return imp2;
+  }
+});
+Object.defineProperty(exports, 'imp2_exports', {
+  enumerable: true,
+  get: function () {
+    return imp2_exports;
+  }
+});
+Object.defineProperty(exports, 'init_imp2', {
+  enumerable: true,
+  get: function () {
+    return init_imp2;
+  }
+});
+Object.defineProperty(exports, 'require_imp', {
+  enumerable: true,
+  get: function () {
+    return require_imp;
+  }
+});
+```
+
+### main.js
+
+```js
+const require_rolldown_runtime = require('./rolldown-runtime.js');
+let node_assert = require("node:assert");
+node_assert = require_rolldown_runtime.__toESM(node_assert);
+
+//#region main.js
+const load = async () => {
+	Promise.resolve().then(() => require("./imp.js")).then((n) => /* @__PURE__ */ require_rolldown_runtime.__toESM(n.require_imp())).then((m) => {
+		node_assert.default.strictEqual(m.imp, 1);
+	});
+	Promise.resolve().then(() => require("./imp.js")).then((n) => (n.init_imp2(), n.imp2_exports)).then((m) => {
+		node_assert.default.strictEqual(m.imp2, 2);
+	});
+};
+load();
+
+//#endregion
+```
+
+### rolldown-runtime.js
+
+```js
+// HIDDEN [rolldown:runtime]
+
+Object.defineProperty(exports, '__commonJSMin', {
+  enumerable: true,
+  get: function () {
+    return __commonJSMin;
+  }
+});
+Object.defineProperty(exports, '__esmMin', {
+  enumerable: true,
+  get: function () {
+    return __esmMin;
+  }
+});
+Object.defineProperty(exports, '__exportAll', {
+  enumerable: true,
+  get: function () {
+    return __exportAll;
+  }
+});
+Object.defineProperty(exports, '__toESM', {
+  enumerable: true,
+  get: function () {
+    return __toESM;
+  }
+});
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/imp.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/imp.js
@@ -1,0 +1,2 @@
+import './imp2.js';
+exports.imp = 1;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/imp2.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/imp2.js
@@ -1,0 +1,1 @@
+export const imp2 = 2;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/main.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert';
+
+const load = async () => {
+  import('./imp').then((m) => {
+    assert.strictEqual(m.imp, 1);
+  });
+  import('./imp2').then((m) => {
+    assert.strictEqual(m.imp2, 2);
+  });
+};
+
+load();

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3227,7 +3227,7 @@ expression: output
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_common_js_into_es6
 
-- entry-!~{000}~.js => entry-CS1oueUX.js
+- entry-!~{000}~.js => entry-B7YkKTSu.js
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6
 
@@ -5329,9 +5329,21 @@ expression: output
 - dep-!~{001}~.js => dep-DNFy2xKJ.js
 - main-!~{000}~.js => main-DoomfFj7.js
 
+# tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk
+
+- main-!~{000}~.js => main-Tfxzzbre.js
+- imp-!~{005}~.js => imp-CtvrU1WX.js
+- rolldown-runtime-!~{001}~.js => rolldown-runtime-B8KAVcZC.js
+
+# tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2
+
+- main-!~{000}~.js => main-C8zRIaBG.js
+- imp-!~{005}~.js => imp-DbKOs7Vv.js
+- rolldown-runtime-!~{001}~.js => rolldown-runtime-HJ3UrVuY.js
+
 # tests/rolldown/optimization/chunk_merging/dynamic_import_cjs_same_chunk
 
-- main-!~{000}~.js => main-8BBJThoK.js
+- main-!~{000}~.js => main-BLg_1yBI.js
 
 # tests/rolldown/optimization/chunk_merging/issue_4905
 

--- a/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
+++ b/crates/rolldown_ecmascript_utils/src/ast_snippet.rs
@@ -905,4 +905,124 @@ impl<'ast> AstSnippet<'ast> {
       false,
     )
   }
+
+  /// Creates a call expression that chains `.then(n => return_expr)` to any expression.
+  /// Generates: `expr.then(n => return_expr)`
+  /// The `build_return_expr` callback receives the parameter name "n" and should return the expression to use as the arrow function body.
+  fn then_with_arrow_callback(
+    &self,
+    expr: Expression<'ast>,
+    return_expr: Expression<'ast>,
+  ) -> allocator::Box<'ast, ast::CallExpression<'ast>> {
+    // Create arrow function: n => return_expr
+    let arrow_fn = self.builder.alloc_arrow_function_expression(
+      SPAN,
+      true,  // expression
+      false, // async
+      NONE,
+      self.builder.formal_parameters(
+        SPAN,
+        ast::FormalParameterKind::ArrowFormalParameters,
+        self.builder.vec1(self.builder.formal_parameter(
+          SPAN,
+          self.builder.vec(),
+          self.builder.binding_pattern_binding_identifier(SPAN, self.builder.atom("n")),
+          NONE,
+          NONE,
+          false,
+          None,
+          false,
+          false,
+        )),
+        NONE,
+      ),
+      NONE,
+      self.builder.function_body(
+        SPAN,
+        self.builder.vec(),
+        self.builder.vec1(ast::Statement::ExpressionStatement(
+          self.builder.alloc_expression_statement(SPAN, return_expr),
+        )),
+      ),
+    );
+
+    // expr.then(n => return_expr)
+    let callee = self.builder.alloc_static_member_expression(
+      SPAN,
+      expr,
+      self.builder.identifier_name(SPAN, "then"),
+      false,
+    );
+    self.builder.alloc_call_expression(
+      SPAN,
+      Expression::StaticMemberExpression(callee),
+      NONE,
+      self.builder.vec1(ast::Expression::ArrowFunctionExpression(arrow_fn).into()),
+      false,
+    )
+  }
+
+  /// Creates a call expression that chains `.then(n => __toESM(n.property_name()))` to any expression.
+  /// Generates: `expr.then(n => __toESM(n.property_name()))`
+  /// This is used for CJS modules merged into common chunks where we need to call the wrapper and wrap the result.
+  pub fn then_call_cjs_wrapper_with_to_esm(
+    &self,
+    expr: Expression<'ast>,
+    property_name: &str,
+    to_esm_fn_expr: Expression<'ast>,
+    node_mode: bool,
+  ) -> allocator::Box<'ast, ast::CallExpression<'ast>> {
+    // n.property_name
+    let member_expr =
+      Expression::StaticMemberExpression(self.builder.alloc_static_member_expression(
+        SPAN,
+        self.builder.expression_identifier(SPAN, "n"),
+        self.builder.identifier_name(SPAN, self.builder.atom(property_name)),
+        false,
+      ));
+    // n.property_name()
+    let wrapper_call =
+      self.builder.expression_call(SPAN, member_expr, NONE, self.builder.vec(), false);
+
+    // __toESM(n.property_name()) or __toESM(n.property_name(), 1)
+    let to_esm_call = self.wrap_with_to_esm(to_esm_fn_expr, wrapper_call, node_mode);
+
+    self.then_with_arrow_callback(expr, to_esm_call)
+  }
+
+  /// Creates a call expression that chains `.then(n => (n.wrapper_name(), n.namespace_name))` to any expression.
+  /// Generates: `expr.then(n => (n.init_xxx(), n.namespace))`
+  /// This is used for ESM modules merged into common chunks where we need to call the wrapper and return the namespace.
+  pub fn then_call_esm_wrapper_with_namespace(
+    &self,
+    expr: Expression<'ast>,
+    wrapper_name: &str,
+    namespace_name: &str,
+  ) -> allocator::Box<'ast, ast::CallExpression<'ast>> {
+    // n.wrapper_name
+    let wrapper_member =
+      Expression::StaticMemberExpression(self.builder.alloc_static_member_expression(
+        SPAN,
+        self.builder.expression_identifier(SPAN, "n"),
+        self.builder.identifier_name(SPAN, self.builder.atom(wrapper_name)),
+        false,
+      ));
+    // n.wrapper_name()
+    let wrapper_call =
+      self.builder.expression_call(SPAN, wrapper_member, NONE, self.builder.vec(), false);
+
+    // n.namespace_name
+    let namespace_member =
+      Expression::StaticMemberExpression(self.builder.alloc_static_member_expression(
+        SPAN,
+        self.builder.expression_identifier(SPAN, "n"),
+        self.builder.identifier_name(SPAN, self.builder.atom(namespace_name)),
+        false,
+      ));
+
+    // (n.wrapper_name(), n.namespace_name)
+    let seq_expr = self.seq2_in_paren_expr(wrapper_call, namespace_member);
+
+    self.then_with_arrow_callback(expr, seq_expr)
+  }
 }


### PR DESCRIPTION
Now test covered dynamic importee wrap kind `[None, Esm, Cjs]` * output format `[esm, cjs]`, feel free to point out if I am missing any related test case