### PR TITLE
fix: inline dynamic entry to user defined entry with esm wrap kind

### DIFF
--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/_config.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "entry.js"
+      }
+    ],
+    "experimental": {
+      "strictExecutionOrder": true
+    }
+  },
+  "configVariants": [
+    {
+      "format": "cjs"
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
@@ -1,0 +1,77 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+import assert from "node:assert";
+
+// HIDDEN [rolldown:runtime]
+//#region lib.js
+var lib_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+var a;
+var init_lib = __esmMin((() => {
+	a = 123;
+}));
+
+//#endregion
+//#region entry.js
+var init_entry = __esmMin((() => {
+	init_lib();
+	Promise.resolve().then(() => (init_lib(), lib_exports)).then((mod) => {
+		assert.strictEqual(mod.a, 123);
+		assert.strictEqual(a, 123);
+	});
+}));
+
+//#endregion
+init_entry();
+export { init_lib as n, a as t };
+```
+
+# Variant: [format: Cjs]
+
+## Assets
+
+### entry.js
+
+```js
+// HIDDEN [rolldown:runtime]
+let node_assert = require("node:assert");
+node_assert = __toESM(node_assert);
+
+//#region lib.js
+var lib_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+var a;
+var init_lib = __esmMin((() => {
+	a = 123;
+}));
+
+//#endregion
+//#region entry.js
+var init_entry = __esmMin((() => {
+	init_lib();
+	Promise.resolve().then(() => (init_lib(), lib_exports)).then((mod) => {
+		node_assert.default.strictEqual(mod.a, 123);
+		node_assert.default.strictEqual(a, 123);
+	});
+}));
+
+//#endregion
+init_entry();
+exports.a = a;
+Object.defineProperty(exports, 'init_lib', {
+  enumerable: true,
+  get: function () {
+    return init_lib;
+  }
+});
+Object.defineProperty(exports, 'lib_exports', {
+  enumerable: true,
+  get: function () {
+    return lib_exports;
+  }
+});
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/entry.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/entry.js
@@ -1,0 +1,7 @@
+import { a as c } from './lib.js';
+import assert from 'node:assert';
+
+import('./lib.js').then((mod) => {
+  assert.strictEqual(mod.a, 123);
+  assert.strictEqual(c, 123);
+});

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/lib.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/lib.js
@@ -1,0 +1,1 @@
+export const a = 123;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5345,6 +5345,10 @@ expression: output
 - imp-!~{005}~.js => imp-DbKOs7Vv.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-HJ3UrVuY.js
 
+# tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry
+
+- entry-!~{000}~.js => entry-DcfLMtJN.js
+
 # tests/rolldown/optimization/chunk_merging/dynamic_import_cjs_same_chunk
 
 - main-!~{000}~.js => main-BLg_1yBI.js
@@ -5527,11 +5531,11 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/12
 
-- entry-!~{000}~.js => entry-DQMlFeQJ.js
+- entry-!~{000}~.js => entry-BJEMNO8S.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/13
 
-- entry-!~{000}~.js => entry-w8w8VxwE.js
+- entry-!~{000}~.js => entry-12WaWIyG.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/14
 


### PR DESCRIPTION
1. Add a test for inlining a dynamic entry into a user-defined entry with `strictExecutionOrder: true`. Now all three kinds of `importee` wrap are considered. 