### PR TITLE
refactor(plugin_timings): filter out plugins with duration < 1s from timing warnings

### DIFF
--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -142,27 +142,31 @@ impl PluginDriver {
 
   /// Get plugin timings summary if timing collection is enabled and plugins are taking significant time.
   /// Returns a list of (plugin_name, percentage) pairs for plugins at or above average time.
+  /// Only plugins with total duration >= 1 second are included.
   #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
   pub fn get_plugin_timings_info(&self) -> Option<Vec<rolldown_error::PluginTimingInfo>> {
     const MAX_PLUGINS: usize = 5;
+    const ONE_SECOND_MICROS: u64 = 1_000_000;
     let collector = self.hook_timing_collector.as_ref()?;
     if !collector.plugins_are_slow() {
       return None;
     }
     let summary = collector.get_summary();
     let total_micros: u64 = summary.iter().map(|s| s.total_duration_micros).sum();
-    (total_micros != 0).then(|| {
-      let avg = total_micros / summary.len() as u64;
-      summary
-        .iter()
-        .filter(|s| s.total_duration_micros >= avg)
-        .take(MAX_PLUGINS)
-        .map(|s| rolldown_error::PluginTimingInfo {
-          name: s.plugin_name.to_string(),
-          percent: (s.total_duration_micros as f64 / total_micros as f64 * 100.0).round() as u8,
-        })
-        .collect::<Vec<_>>()
-    })
+    if total_micros == 0 {
+      return None;
+    }
+    let threshold = (total_micros / summary.len() as u64).max(ONE_SECOND_MICROS);
+    let result = summary
+      .iter()
+      .filter(|s| s.total_duration_micros >= threshold)
+      .take(MAX_PLUGINS)
+      .map(|s| rolldown_error::PluginTimingInfo {
+        name: s.plugin_name.to_string(),
+        percent: (s.total_duration_micros as f64 / total_micros as f64 * 100.0).round() as u8,
+      })
+      .collect::<Vec<_>>();
+    if result.is_empty() { None } else { Some(result) }
   }
 }
 

--- a/docs/options/checks.md
+++ b/docs/options/checks.md
@@ -97,7 +97,7 @@ When enabled, Rolldown measures time spent in each plugin hook. If plugins signi
 
 2. **Detection threshold**: A warning is triggered when plugin time (total build time minus link stage time) exceeds 100x the link stage time. This threshold was determined by studying plugin impact on real-world projects.
 
-3. **Identifying plugins**: When the threshold is exceeded, Rolldown reports up to 5 plugins that take longer than the average plugin time, sorted by duration. Each plugin shows its percentage of total plugin time.
+3. **Identifying plugins**: When the threshold is exceeded, Rolldown reports up to 5 plugins that take longer than the average plugin time, sorted by duration. Each plugin shows its percentage of total plugin time. Only plugins with total duration of at least 1 second are included in the report.
 
 > [!WARNING]
 > For hooks using `ctx.resolve()` or `ctx.load()`, the reported time includes waiting for other plugins, which may overestimate that plugin's actual cost.


### PR DESCRIPTION
Can we also add this one?

> - No warnings if the time spent in a specific plugin is <1s

_Originally posted by @sapphi-red in https://github.com/rolldown/rolldown/pull/7741#pullrequestreview-3633372466_
            