### PR TITLE
refactor: move ConfigExport and RolldownOptionsFunction types to define-config

### DIFF
--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -79,13 +79,11 @@ import type {
   PluginContext,
 } from './plugin/plugin-context';
 import type { TransformPluginContext } from './plugin/transform-plugin-context';
-import type { ConfigExport } from './types/config-export';
 import type { SourcemapIgnoreListOption } from './types/misc';
 import type { ModuleInfo } from './types/module-info';
 import type { TreeshakingOptions } from './types/module-side-effects';
 import type { OutputBundle } from './types/output-bundle';
 import type { RolldownOptions } from './types/rolldown-options';
-import type { RolldownOptionsFunction } from './types/rolldown-options-function';
 import type {
   OutputAsset,
   OutputChunk,
@@ -96,7 +94,11 @@ import type {
 } from './types/rolldown-output';
 import type { ExistingRawSourceMap, SourceMapInput } from './types/sourcemap';
 import type { PartialNull } from './types/utils';
-import { defineConfig } from './utils/define-config';
+import {
+  defineConfig,
+  type ConfigExport,
+  type RolldownOptionsFunction,
+} from './utils/define-config';
 import { VERSION } from './version';
 
 export { build, defineConfig, rolldown, VERSION, watch };

--- a/packages/rolldown/src/types/config-export.ts
+++ b/packages/rolldown/src/types/config-export.ts
@@ -1,7 +1,0 @@
-import type { RolldownOptions } from './rolldown-options';
-import type { RolldownOptionsFunction } from './rolldown-options-function';
-
-/**
- * Type for `default export` of `rolldown.config.js` file.
- */
-export type ConfigExport = RolldownOptions | RolldownOptions[] | RolldownOptionsFunction;

--- a/packages/rolldown/src/types/rolldown-options-function.ts
+++ b/packages/rolldown/src/types/rolldown-options-function.ts
@@ -1,6 +1,0 @@
-import type { RolldownOptions } from './rolldown-options';
-import type { MaybePromise } from './utils';
-
-export type RolldownOptionsFunction = (
-  commandLineArguments: Record<string, any>,
-) => MaybePromise<RolldownOptions | RolldownOptions[]>;

--- a/packages/rolldown/src/utils/define-config.ts
+++ b/packages/rolldown/src/utils/define-config.ts
@@ -1,6 +1,13 @@
-import type { ConfigExport } from '../types/config-export';
 import type { RolldownOptions } from '../types/rolldown-options';
-import type { RolldownOptionsFunction } from '../types/rolldown-options-function';
+import type { MaybePromise } from '../types/utils';
+
+/**
+ * Type for `default export` of `rolldown.config.js` file.
+ */
+export type ConfigExport = RolldownOptions | RolldownOptions[] | RolldownOptionsFunction;
+export type RolldownOptionsFunction = (
+  commandLineArguments: Record<string, any>,
+) => MaybePromise<RolldownOptions | RolldownOptions[]>;
 
 export function defineConfig(config: RolldownOptions): RolldownOptions;
 export function defineConfig(config: RolldownOptions[]): RolldownOptions[];

--- a/packages/rolldown/src/utils/load-config.ts
+++ b/packages/rolldown/src/utils/load-config.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { cwd } from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { rolldown } from '../api/rolldown';
-import type { ConfigExport } from '../types/config-export';
+import type { ConfigExport } from './define-config';
 import type { OutputChunk } from '../types/rolldown-output';
 
 async function bundleTsConfig(configFile: string, isEsm: boolean): Promise<string> {


### PR DESCRIPTION
Because `ConfigExport` and `RolldownOptionsFunction` are closely associated with `defineConfig`, they are placed together.