### PR TITLE
fix: transform non-static dynamic imports when `dynamicImportInCjs` is `false`

### DIFF
--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -62,6 +62,10 @@ impl LinkStage<'_> {
           if stmt_info.meta.contains(StmtInfoMeta::HasDummyRecord) {
             depended_runtime_helper_map[RuntimeHelper::Require.bit_index()].push(stmt_info_idx);
           }
+          // Handle non-static dynamic imports like `import(foo)` or `import('a' + 'b')`
+          if stmt_info.meta.intersects(StmtInfoMeta::NonStaticDynamicImport) {
+            depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()].push(stmt_info_idx);
+          }
           stmt_info.import_records.iter().for_each(|rec_id| {
             let rec = &importer.import_records[*rec_id];
             let rec_resolved_module = &self.module_table[rec.resolved_module];

--- a/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs_non_static/_config.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs_non_static/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "format": "cjs",
+    "dynamicImportInCjs": false
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs_non_static/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs_non_static/artifacts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+
+//#region main.js
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require(moduleName))).then(console.log);
+Promise.resolve().then(() => /* @__PURE__ */ __toESM(require(
+	/* @vite-ignore */
+	"./ignored.js"
+))).then(console.log);
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs_non_static/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs_non_static/main.js
@@ -1,0 +1,5 @@
+// Non-static dynamic import with variable
+import(moduleName).then(console.log);
+
+// Static import with @vite-ignore (no import record)
+import(/* @vite-ignore */ './ignored.js').then(console.log);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3646,6 +3646,10 @@ expression: output
 - internal-!~{003}~.js => internal-DiqBI5kB.js
 - internal-cjs-!~{001}~.js => internal-cjs-Dclx_OsA.js
 
+# tests/rolldown/cjs_compat/dynamic_import_in_cjs_non_static
+
+- main-!~{000}~.js => main-afWhV-a6.js
+
 # tests/rolldown/cjs_compat/esm_require_cjs
 
 - main-!~{000}~.js => main-CgFAgQJr.js

--- a/crates/rolldown_common/src/types/stmt_info.rs
+++ b/crates/rolldown_common/src/types/stmt_info.rs
@@ -122,6 +122,8 @@ bitflags! {
         const HasDummyRecord = 1 << 1;
         /// see `has_dynamic_exports` in https://github.com/rolldown/rolldown/blob/8bc7dca5a09047b6b494e3fa7b6b7564aa465372/crates/rolldown/src/types/linking_metadata.rs?plain=1#L49
         const ReExportDynamicExports = 1 << 2;
+        /// Statement contains non-static dynamic import like `import(foo)` or `import('a' + 'b')`
+        const NonStaticDynamicImport = 1 << 3;
     }
 }
 


### PR DESCRIPTION
Related to #7784

Previously, non-static dynamic imports like `import(foo)` or imports with `@vite-ignore` comment were not being transformed to require() calls in CJS output format when dynamicImportInCjs was false.

This change:
- Tracks statement indices for non-static/ignored dynamic imports
- Transforms them to `Promise.resolve().then(() => __toESM(require(...)))`
- Ensures __toESM runtime helper is properly included