### PR TITLE
docs(options): inline types to option property pages

### DIFF
--- a/docs/.vitepress/scripts/custom-theme-plugin.ts
+++ b/docs/.vitepress/scripts/custom-theme-plugin.ts
@@ -1,6 +1,6 @@
 // Reference: https://github.com/typedoc2md/typedoc-plugin-markdown/blob/typedoc-plugin-markdown%404.9.0/packages/typedoc-plugin-markdown/internal-docs/custom-theme.md
 
-import type { Application, Reflection } from 'typedoc';
+import { ReflectionKind, type Application, type Reflection } from 'typedoc';
 import {
   type MarkdownPageEvent,
   MarkdownTheme,
@@ -25,7 +25,7 @@ class CustomThemeContext extends MarkdownThemeContext {
     this.partials = {
       ...superPartials,
       // Use DefinedIn component for "Defined in: [source](link)"
-      sources(model, _options) {
+      sources: (model, _options) => {
         if (!model.sources) return '';
         const sources = model.sources.map((source) => ({
           link: source.url,
@@ -33,10 +33,56 @@ class CustomThemeContext extends MarkdownThemeContext {
         }));
         return `<DefinedIn :sources="${escapeAttr(JSON.stringify(sources))}" />`;
       },
-      declarationTitle(model) {
-        // TODO: improve this to output a better formatted type info
+      comment: (model, options) => {
+        const result = superPartials.comment.call(this, model, options);
+        // Remove the `**`Experimental`**` text that comes from `@experimental` tag
+        return result.replace(/\*\*`Experimental`\*\*/g, '');
+      },
+      declarationTitle: (model) => {
         // https://github.com/typedoc2md/typedoc-plugin-markdown/blob/typedoc-plugin-markdown%404.9.0/packages/typedoc-plugin-markdown/src/theme/context/partials/member.declarationTitle.ts#L6
-        return superPartials.declarationTitle.call(this, model).replace('>', '- **Type**:');
+        const md: string[] = [];
+        const declarationType = this.helpers.getDeclarationType(model);
+
+        // Format type
+        let typeStr: string;
+        if (declarationType) {
+          typeStr = this.partials.someType(declarationType);
+        } else if (model.kind === ReflectionKind.TypeAlias) {
+          const expandObjects = this.options.getValue('expandObjects');
+          typeStr = expandObjects ? this.partials.declarationType(model) : '`object`';
+        } else {
+          typeStr = '`unknown`';
+        }
+
+        const type = declarationType || model.type;
+        const isObjectWithChildren =
+          type?.type === 'reflection' &&
+          type.declaration?.children &&
+          type.declaration.children.length > 0;
+
+        if (isObjectWithChildren) {
+          md.push('- **Type**: object with the properties below');
+        } else {
+          md.push(`- **Type**: ${typeStr}`);
+        }
+
+        if (model.flags?.isOptional) {
+          md.push('- **Optional**');
+        }
+
+        if (
+          model.defaultValue &&
+          model.defaultValue !== '...' &&
+          model.defaultValue !== model.name
+        ) {
+          md.push(`- **Default**: \`${model.defaultValue}\``);
+        }
+
+        if (model.comment?.modifierTags?.has('@experimental')) {
+          md.push('- **Experimental**');
+        }
+
+        return md.join('\n');
       },
     };
   }


### PR DESCRIPTION
Inline the content of types to `InputOptions.*` / `OutputOptions.*` pages