### PR TITLE
fix: use correct index when inserting keepNames statements during export default transformation

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1287,7 +1287,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                 };
 
                 if let Some(binding) = binding {
-                  let insert_position = self.cur_stmt_index + 1;
+                  // current statement will be pushed to program.body, so the insert position is program.body.len() + 1
+                  let insert_position = program.body.len() + 1;
                   self.keep_name_statement_to_insert.push((
                     insert_position,
                     binding,

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7852/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7852/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "keepNames": true
+  },
+  "_comment": "Tests that __name is called after the variable is defined, not before"
+}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7852/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7852/_test.mjs
@@ -1,0 +1,5 @@
+import fn from './dist/main.js'
+import assert from 'node:assert'
+
+assert.strictEqual(fn.name, 'default');
+assert.strictEqual(fn('32px'), 2);

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7852/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7852/artifacts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [rolldown:runtime]
+//#region main.js
+const baseFontSize = 16;
+var main_default = (px) => parseFloat(px) / baseFontSize;
+__name(main_default, "default");
+
+//#endregion
+export { main_default as default };
+```

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7852/main.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7852/main.js
@@ -1,0 +1,3 @@
+const baseFontSize = 16;
+
+export default px => parseFloat(px) / baseFontSize;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5974,6 +5974,10 @@ expression: output
 
 - index-!~{000}~.js => index-pA0WPiFF.js
 
+# tests/rolldown/topics/keep_names/issue_7852
+
+- main-!~{000}~.js => main-CkTekG0F.js
+
 # tests/rolldown/topics/keep_names/parenthesized_default_export
 
 - main-!~{000}~.js => main-DgH0nPHk.js


### PR DESCRIPTION
closed #7852