### PR TITLE
feat(node): add `output.codeSplitting` option and deprecate `output.advancedChunks`

### DIFF
--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -31,10 +31,11 @@ import type {
   NormalizedOutputOptions,
 } from './options/normalized-output-options';
 import type {
-  AdvancedChunksGroup,
+  CodeSplittingGroup,
   AddonFunction,
   ChunkFileNamesFunction,
   ChunkingContext,
+  AdvancedChunksGroup,
   GeneratedCodeOptions,
   GeneratedCodePreset,
   GlobalsFunction,
@@ -108,8 +109,9 @@ export { build, defineConfig, rolldown, VERSION, watch };
 export { BindingMagicString } from './binding.cjs';
 export type {
   AddonFunction,
-  AdvancedChunksGroup,
+  CodeSplittingGroup,
   AsyncPluginHooks,
+  AdvancedChunksGroup,
   BufferEncoding,
   BuildOptions,
   ChecksOptions,

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -314,7 +314,7 @@ export interface OutputOptions {
    * Patterns support the following placeholders:
    * - `[format]`: The rendering format defined in the output options, e.g. `es` or `cjs`.
    * - `[hash]`: A hash based only on the content of the final generated chunk, including transformations in `renderChunk` and any referenced file hashes. You can also set a specific hash length via e.g. `[hash:10]`. By default, it will create a base-64 hash. If you need a reduced character set, see {@linkcode hashCharacters | output.hashCharacters}.
-   * - `[name]`: The name of the chunk. This can be explicitly set via the {@linkcode advancedChunks | output.advancedChunks} option or when the chunk is created by a plugin via `this.emitFile`. Otherwise, it will be derived from the chunk contents.
+   * - `[name]`: The name of the chunk. This can be explicitly set via the {@linkcode codeSplitting | output.codeSplitting} option or when the chunk is created by a plugin via `this.emitFile`. Otherwise, it will be derived from the chunk contents.
    *
    * Forward slashes (`/`) can be used to place files in sub-directories.
    *
@@ -490,7 +490,7 @@ export interface OutputOptions {
    *
    * ```js
    * {
-   *   advancedChunks: {
+   *   codeSplitting: {
    *     groups: [
    *       {
    *         name(moduleId) {
@@ -509,10 +509,10 @@ export interface OutputOptions {
    * Note that unlike Rollup, object form is not supported.
    *
    * @deprecated
-   * Please use {@linkcode advancedChunks | output.advancedChunks} instead.
+   * Please use {@linkcode codeSplitting | output.codeSplitting} instead.
    *
    * :::warning
-   * If `manualChunks` and `advancedChunks` are both specified, `manualChunks` option will be ignored.
+   * If `manualChunks` and `codeSplitting` are both specified, `manualChunks` option will be ignored.
    * :::
    */
   manualChunks?: ManualChunksFunction;
@@ -524,7 +524,7 @@ export interface OutputOptions {
    * ```js
    * export default defineConfig({
    *   output: {
-   *     advancedChunks: {
+   *     codeSplitting: {
    *       minSize: 20000,
    *       groups: [
    *         {
@@ -538,7 +538,7 @@ export interface OutputOptions {
    * ```
    * {@include ./docs/output-advanced-chunks.md}
    */
-  advancedChunks?: {
+  codeSplitting?: {
     /**
      * By default, each group will also include captured modules' dependencies. This reduces the chance of generating circular chunks.
      *
@@ -552,29 +552,47 @@ export interface OutputOptions {
      */
     includeDependenciesRecursively?: boolean;
     /**
-     * Global fallback of {@linkcode AdvancedChunksGroup.minSize | group.minSize}, if it's not specified in the group.
+     * Global fallback of {@linkcode CodeSplittingGroup.minSize | group.minSize}, if it's not specified in the group.
      */
     minSize?: number;
     /**
-     * Global fallback of {@linkcode AdvancedChunksGroup.maxSize | group.maxSize}, if it's not specified in the group.
+     * Global fallback of {@linkcode CodeSplittingGroup.maxSize | group.maxSize}, if it's not specified in the group.
      */
     maxSize?: number;
     /**
-     * Global fallback of {@linkcode AdvancedChunksGroup.maxModuleSize | group.maxModuleSize}, if it's not specified in the group.
+     * Global fallback of {@linkcode CodeSplittingGroup.maxModuleSize | group.maxModuleSize}, if it's not specified in the group.
      */
     maxModuleSize?: number;
     /**
-     * Global fallback of {@linkcode AdvancedChunksGroup.minModuleSize | group.minModuleSize}, if it's not specified in the group.
+     * Global fallback of {@linkcode CodeSplittingGroup.minModuleSize | group.minModuleSize}, if it's not specified in the group.
      */
     minModuleSize?: number;
     /**
-     * Global fallback of {@linkcode AdvancedChunksGroup.minShareCount | group.minShareCount}, if it's not specified in the group.
+     * Global fallback of {@linkcode CodeSplittingGroup.minShareCount | group.minShareCount}, if it's not specified in the group.
      */
     minShareCount?: number;
     /**
-     * Groups to be used for advanced chunking.
+     * Groups to be used for code splitting.
      */
-    groups?: AdvancedChunksGroup[];
+    groups?: CodeSplittingGroup[];
+  };
+  /**
+   * @deprecated Please use {@linkcode codeSplitting | output.codeSplitting} instead.
+   *
+   * Allows you to do manual chunking.
+   *
+   * :::warning
+   * If `advancedChunks` and `codeSplitting` are both specified, `advancedChunks` option will be ignored.
+   * :::
+   */
+  advancedChunks?: {
+    includeDependenciesRecursively?: boolean;
+    minSize?: number;
+    maxSize?: number;
+    maxModuleSize?: number;
+    minModuleSize?: number;
+    minShareCount?: number;
+    groups?: CodeSplittingGroup[];
   };
   /**
    * Control comments in the output.
@@ -659,7 +677,7 @@ export interface OutputOptions {
   keepNames?: boolean;
 }
 
-export type AdvancedChunksGroup = {
+export type CodeSplittingGroup = {
   /**
    * Name of the group. It will be also used as the name of the chunk and replace the `[name]` placeholder in the {@linkcode OutputOptions.chunkFileNames | output.chunkFileNames} option.
    *
@@ -787,6 +805,11 @@ export type AdvancedChunksGroup = {
   minModuleSize?: number;
 };
 
+/**
+ * Alias for {@linkcode CodeSplittingGroup}. Use this type for the `codeSplitting.groups` option.
+ */
+export type AdvancedChunksGroup = CodeSplittingGroup;
+
 interface OverwriteOutputOptionsForCli {
   banner?: string;
   footer?: string;
@@ -796,6 +819,10 @@ interface OverwriteOutputOptionsForCli {
   outro?: string;
   esModule?: boolean;
   globals?: Record<string, string>;
+  codeSplitting?: {
+    minSize?: number;
+    minShareCount?: number;
+  };
   advancedChunks?: {
     minSize?: number;
     minShareCount?: number;

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -52,7 +52,11 @@ export function bindingifyOutputOptions(outputOptions: OutputOptions): BindingOu
     }
   }
 
-  const advancedChunks = bindingifyAdvancedChunks(outputOptions.advancedChunks, manualChunks);
+  const advancedChunks = bindingifyAdvancedChunks(
+    outputOptions.codeSplitting,
+    outputOptions.advancedChunks,
+    manualChunks,
+  );
 
   return {
     dir,
@@ -174,13 +178,25 @@ function bindingifyAssetFilenames(
 }
 
 function bindingifyAdvancedChunks(
+  codeSplitting: OutputOptions['codeSplitting'],
   advancedChunks: OutputOptions['advancedChunks'],
   manualChunks: OutputOptions['manualChunks'],
 ): BindingOutputOptions['advancedChunks'] {
-  if (manualChunks != null && advancedChunks != null) {
-    console.warn('`manualChunks` option is ignored due to `advancedChunks` option is specified.');
+  // Determine the effective option with priority: codeSplitting > advancedChunks > manualChunks
+  let effectiveOption = codeSplitting;
+
+  if (codeSplitting != null && advancedChunks != null) {
+    console.warn('`advancedChunks` option is ignored due to `codeSplitting` option is specified.');
+  } else if (codeSplitting == null && advancedChunks != null) {
+    console.warn('`advancedChunks` option is deprecated, please use `codeSplitting` instead.');
+    effectiveOption = advancedChunks;
+  }
+
+  // Handle manualChunks migration
+  if (manualChunks != null && effectiveOption != null) {
+    console.warn('`manualChunks` option is ignored due to `codeSplitting` option is specified.');
   } else if (manualChunks != null) {
-    advancedChunks = {
+    effectiveOption = {
       groups: [
         {
           name(moduleId, ctx) {
@@ -193,14 +209,14 @@ function bindingifyAdvancedChunks(
     };
   }
 
-  if (advancedChunks == null) {
+  if (effectiveOption == null) {
     return undefined;
   }
 
-  const { groups, ...restAdvancedChunks } = advancedChunks;
+  const { groups, ...restOptions } = effectiveOption;
 
   return {
-    ...restAdvancedChunks,
+    ...restOptions,
     groups: groups?.map((group) => {
       const { name, ...restGroup } = group;
 

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -738,6 +738,7 @@ const OutputOptionsSchema = v.strictObject({
     v.description('Dynamic import in CJS output'),
   ),
   manualChunks: v.optional(ManualChunksFunctionSchema),
+  codeSplitting: v.optional(AdvancedChunksSchema),
   advancedChunks: v.optional(AdvancedChunksSchema),
   legalComments: v.pipe(
     v.optional(v.union([v.literal('none'), v.literal('inline')])),
@@ -824,6 +825,18 @@ const OutputCliOverrideSchema = v.strictObject({
     v.optional(v.record(v.string(), v.string())),
     v.description('Global variable of UMD / IIFE dependencies (syntax: `key=value`)'),
   ),
+  codeSplitting: v.pipe(
+    v.optional(
+      v.strictObject({
+        minSize: v.pipe(v.optional(v.number()), v.description('Minimum size of the chunk')),
+        minShareCount: v.pipe(
+          v.optional(v.number()),
+          v.description('Minimum share count of the chunk'),
+        ),
+      }),
+    ),
+    v.description('Code splitting options'),
+  ),
   advancedChunks: v.pipe(
     v.optional(
       v.strictObject({
@@ -834,7 +847,7 @@ const OutputCliOverrideSchema = v.strictObject({
         ),
       }),
     ),
-    v.description('Global variable of UMD / IIFE dependencies (syntax: `key=value`)'),
+    v.description('Deprecated: use codeSplitting instead'),
   ),
   minify: v.pipe(v.optional(v.boolean()), v.description('Minify the bundled file')),
 });

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -42,6 +42,8 @@ OPTIONS
   --checks.unresolved-import  Whether to emit warnings when an import cannot be resolved.
   --chunk-file-names <name>   Name pattern for emitted secondary chunks.
   --clean-dir                 Clean output directory before emitting output.
+  --code-splitting.min-share-count <code-splitting.min-share-count>Minimum share count of the chunk.
+  --code-splitting.min-size <code-splitting.min-size>Minimum size of the chunk.
   --context <context>         The entity top-level \`this\` represents.
   --css-chunk-file-names <css-chunk-file-names>Name pattern for emitted css secondary chunks.
   --css-entry-file-names <css-entry-file-names>Name pattern for emitted css entry chunks.

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/group-name-fn/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/group-name-fn/_config.ts
@@ -4,7 +4,7 @@ import { expect } from 'vitest';
 export default defineTest({
   config: {
     output: {
-      advancedChunks: {
+      codeSplitting: {
         groups: [
           {
             name(id, ctx) {

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/relative-path-name/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/relative-path-name/_config.ts
@@ -8,7 +8,7 @@ export default defineTest({
   config: {
     input: './entry.js',
     output: {
-      advancedChunks: {
+      codeSplitting: {
         groups: [
           {
             name: (file) => {

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/split-node-modules/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/split-node-modules/_config.ts
@@ -3,7 +3,7 @@ import { defineTest } from 'rolldown-tests';
 export default defineTest({
   config: {
     output: {
-      advancedChunks: {
+      codeSplitting: {
         groups: [
           {
             test: /[\\/]node_modules/,

--- a/packages/rolldown/tests/fixtures/function/advanced-chunks/test-fn/_config.ts
+++ b/packages/rolldown/tests/fixtures/function/advanced-chunks/test-fn/_config.ts
@@ -4,7 +4,7 @@ import { expect } from 'vitest';
 export default defineTest({
   config: {
     output: {
-      advancedChunks: {
+      codeSplitting: {
         groups: [
           {
             name: 'ab',

--- a/packages/rolldown/tests/fixtures/output/file-names/invalid-advanced-chunk-name/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/file-names/invalid-advanced-chunk-name/_config.ts
@@ -4,7 +4,7 @@ import { expect } from 'vitest';
 export default defineTest({
   config: {
     output: {
-      advancedChunks: {
+      codeSplitting: {
         groups: [
           {
             name: (file) => {


### PR DESCRIPTION
Part of https://github.com/rolldown/rolldown/issues/7330