### PR TITLE
refactor(rust): rename `advanced_chunks` to `manual_code_splitting`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_ext.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_ext.rs
@@ -12,7 +12,7 @@ pub trait ChunkDebugExt {
   );
 }
 pub enum ChunkCreationReason<'a> {
-  AdvancedChunkGroup(&'a str, u32),
+  ManualCodeSplittingGroup(&'a str, u32),
   PreserveModules { is_user_defined_entry: bool, module_stable_id: &'a str },
   Entry { is_user_defined_entry: bool, entry_module_id: &'a str, name: Option<&'a ArcStr> },
   CommonChunk { bits: &'a BitSet, link_output: &'a LinkStageOutput },
@@ -25,8 +25,8 @@ impl ChunkDebugExt for Chunk {
     options: &NormalizedBundlerOptions,
   ) {
     match reason {
-      ChunkCreationReason::AdvancedChunkGroup(_name, group_index) => {
-        *self.chunk_reason_type = ChunkReasonType::AdvancedChunks { group_index };
+      ChunkCreationReason::ManualCodeSplittingGroup(_name, group_index) => {
+        *self.chunk_reason_type = ChunkReasonType::ManualCodeSplitting { group_index };
       }
       ChunkCreationReason::PreserveModules { .. } => {
         *self.chunk_reason_type = ChunkReasonType::PreserveModules;
@@ -44,8 +44,8 @@ impl ChunkDebugExt for Chunk {
     }
 
     let reason = match reason {
-      ChunkCreationReason::AdvancedChunkGroup(name, _group_index) => {
-        format!("AdvancedChunks: [Group-Name: {name}]")
+      ChunkCreationReason::ManualCodeSplittingGroup(name, _group_index) => {
+        format!("ManualCodeSplitting: [Group-Name: {name}]")
       }
       ChunkCreationReason::PreserveModules { is_user_defined_entry, module_stable_id } => {
         format!(

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -367,11 +367,11 @@ impl GenerateStage<'_> {
         continue;
       };
       let target_chunk = &chunk_graph.chunk_table[target_chunk_idx];
-      // 1. dynamic entry chunk that also captured by a advanced chunk group
+      // 1. dynamic entry chunk that also captured by a manual code splitting group
       // 2. dynamic entry module are already merged into  user defined entry chunk in previous round optimization
       if !(matches!(
         target_chunk.chunk_reason_type.as_ref(),
-        ChunkReasonType::AdvancedChunks { .. }
+        ChunkReasonType::ManualCodeSplitting { .. }
       ) || matches!(target_chunk.kind, ChunkKind::EntryPoint { meta, bit: _, module: _ } if meta.is_pure_user_defined_entry()))
       {
         continue;

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -739,7 +739,12 @@ impl GenerateStage<'_> {
       oxc_index::index_vec![false; self.link_output.module_table.modules.len()];
 
     self
-      .apply_advanced_chunks(index_splitting_info, &mut module_to_assigned, chunk_graph, input_base)
+      .apply_manual_code_splitting(
+        index_splitting_info,
+        &mut module_to_assigned,
+        chunk_graph,
+        input_base,
+      )
       .await?;
 
     let mut pending_common_chunks: FxIndexMap<BitSet, Vec<ModuleIdx>> = FxIndexMap::default();

--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -54,14 +54,14 @@ impl GenerateStage<'_> {
     clippy::cast_sign_loss,
     clippy::cast_possible_wrap
   )] // TODO(hyf0): refactor
-  pub async fn apply_advanced_chunks(
+  pub async fn apply_manual_code_splitting(
     &self,
     index_splitting_info: &IndexSplittingInfo,
     module_to_assigned: &mut IndexVec<ModuleIdx, bool>,
     chunk_graph: &mut ChunkGraph,
     input_base: &ArcStr,
   ) -> BuildResult<()> {
-    let Some(chunking_options) = &self.options.advanced_chunks else {
+    let Some(chunking_options) = &self.options.manual_code_splitting else {
       return Ok(());
     };
 
@@ -318,7 +318,7 @@ impl GenerateStage<'_> {
         None,
       );
       chunk.add_creation_reason(
-        ChunkCreationReason::AdvancedChunkGroup(
+        ChunkCreationReason::ManualCodeSplittingGroup(
           &this_module_group.name,
           this_module_group.match_group_index.try_into().unwrap(),
         ),

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -57,11 +57,11 @@ use crate::{
   },
 };
 
-mod advanced_chunks;
 mod chunk_ext;
 mod chunk_optimizer;
 mod code_splitting;
 mod compute_cross_chunk_links;
+mod manual_code_splitting;
 mod minify_chunks;
 mod on_demand_wrapping;
 mod post_banner_footer;

--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -72,40 +72,40 @@ fn verify_raw_options(raw_options: &crate::BundlerOptions) -> BuildResult<Vec<Bu
         InvalidOptionType::InlineDynamicImportsWithPreserveModules,
       ));
     }
-    if raw_options.advanced_chunks.is_some() {
+    if raw_options.manual_code_splitting.is_some() {
       errors.push(BuildDiagnostic::invalid_option(
-        InvalidOptionType::InlineDynamicImportsWithAdvancedChunks,
+        InvalidOptionType::InlineDynamicImportsWithManualCodeSplitting,
       ));
     }
   }
 
-  if let Some(advanced_chunks) = &raw_options.advanced_chunks {
-    let has_groups = advanced_chunks.groups.as_ref().is_some_and(|groups| !groups.is_empty());
+  if let Some(manual_code_splitting) = &raw_options.manual_code_splitting {
+    let has_groups = manual_code_splitting.groups.as_ref().is_some_and(|groups| !groups.is_empty());
 
     if !has_groups {
       let mut specified_options = Vec::new();
-      if advanced_chunks.min_share_count.is_some() {
+      if manual_code_splitting.min_share_count.is_some() {
         specified_options.push("minShareCount".to_string());
       }
-      if advanced_chunks.min_size.is_some() {
+      if manual_code_splitting.min_size.is_some() {
         specified_options.push("minSize".to_string());
       }
-      if advanced_chunks.max_size.is_some() {
+      if manual_code_splitting.max_size.is_some() {
         specified_options.push("maxSize".to_string());
       }
-      if advanced_chunks.min_module_size.is_some() {
+      if manual_code_splitting.min_module_size.is_some() {
         specified_options.push("minModuleSize".to_string());
       }
-      if advanced_chunks.max_module_size.is_some() {
+      if manual_code_splitting.max_module_size.is_some() {
         specified_options.push("maxModuleSize".to_string());
       }
-      if advanced_chunks.include_dependencies_recursively.is_some() {
+      if manual_code_splitting.include_dependencies_recursively.is_some() {
         specified_options.push("includeDependenciesRecursively".to_string());
       }
 
       if !specified_options.is_empty() {
         warnings.push(
-          BuildDiagnostic::invalid_option(InvalidOptionType::AdvancedChunksWithoutGroups(
+          BuildDiagnostic::invalid_option(InvalidOptionType::ManualCodeSplittingWithoutGroups(
             specified_options,
           ))
           .with_severity_warning(),
@@ -113,8 +113,8 @@ fn verify_raw_options(raw_options: &crate::BundlerOptions) -> BuildResult<Vec<Bu
       }
     }
 
-    // Check if `advancedChunks.include_dependencies_recursively` conflict with `preserveEntrySignatures`
-    if matches!(advanced_chunks.include_dependencies_recursively, Some(false)) {
+    // Check if `codeSplitting.include_dependencies_recursively` conflict with `preserveEntrySignatures`
+    if matches!(manual_code_splitting.include_dependencies_recursively, Some(false)) {
       if let Some(preserve_signatures) = &raw_options.preserve_entry_signatures {
         if matches!(
           preserve_signatures,
@@ -141,8 +141,9 @@ pub fn prepare_build_context(
 
   let format = raw_options.format.unwrap_or(crate::OutputFormat::Esm);
 
-  let preserve_entry_signatures = if let Some(advanced_chunks) = &raw_options.advanced_chunks
-    && matches!(advanced_chunks.include_dependencies_recursively, Some(false))
+  let preserve_entry_signatures = if let Some(manual_code_splitting) =
+    &raw_options.manual_code_splitting
+    && matches!(manual_code_splitting.include_dependencies_recursively, Some(false))
     && raw_options.preserve_entry_signatures.is_none()
   {
     warnings.push(
@@ -421,7 +422,7 @@ pub fn prepare_build_context(
     external_live_bindings: raw_options.external_live_bindings.unwrap_or(true),
     inline_dynamic_imports,
     dynamic_import_in_cjs: raw_options.dynamic_import_in_cjs.unwrap_or(true),
-    advanced_chunks: raw_options.advanced_chunks,
+    manual_code_splitting: raw_options.manual_code_splitting,
     checks: raw_options.checks.unwrap_or_default().into(),
     watch: raw_options.watch.unwrap_or_default(),
     legal_comments: raw_options.legal_comments.unwrap_or(LegalComments::Inline),

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "name": "imp",

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276_2/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276_2/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "name": "imp",

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/_config.json
@@ -7,7 +7,7 @@
       }
     ],
     "preserveEntrySignatures": "strict",
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "includeDependenciesRecursively": false
     }
   },

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/include_dependencies_recursively_conflict_preserve_entry_signatures/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```text
 [INVALID_OPTION] Error: Invalid option combination detected:
 
-- advancedChunks.includeDependenciesRecursively = false
+- codeSplitting.includeDependenciesRecursively = false
 - preserveEntrySignatures = "strict"
 
 To fix:

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/inline_dynamic_imports_with_advanced_chunks/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/inline_dynamic_imports_with_advanced_chunks/_config.json
@@ -2,7 +2,7 @@
   "config": {
     "input": [{ "import": "main.js" }],
     "inlineDynamicImports": true,
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "minSize": 0,
       "groups": [
         {

--- a/crates/rolldown/tests/rolldown/errors/invalid_option/inline_dynamic_imports_with_advanced_chunks/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/invalid_option/inline_dynamic_imports_with_advanced_chunks/artifacts.snap
@@ -6,6 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## INVALID_OPTION
 
 ```text
-[INVALID_OPTION] Error: Invalid value "true" for option "output.inlineDynamicImports" - this option is not supported for "output.advancedChunks".
+[INVALID_OPTION] Error: Invalid value "true" for option "output.inlineDynamicImports" - this option is not supported for "output.codeSplitting".
 
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/basic/_config.json
@@ -10,7 +10,7 @@
         "import": "./b.js"
       }
     ],
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "test": "[ab]\\.js",

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/basic_cjs/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/basic_cjs/_config.json
@@ -10,7 +10,7 @@
         "import": "./b.cjs"
       }
     ],
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "test": "[ab]\\.cjs",

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/include_dependencies_recursively/_config.json
@@ -3,7 +3,7 @@
     "experimental": {
       "strictExecutionOrder": true
     },
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "test": "foo\\.js",

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/issue_2617/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/issue_2617/_config.json
@@ -1,7 +1,7 @@
 {
   // Should not process trreeshaked modules
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "test": "lib\\.js",

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_module_size/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_module_size/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           // `size-14.js` and `size-23.js` will be captured

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_module_size_fallback/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_module_size_fallback/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       // Only `size-14.js` will be included in the chunk
       "maxModuleSize": 20,
       "groups": [

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           // `size-15.js`, `size-20` and `size-41.js` will be captured

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size2/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size2/_config.json
@@ -1,7 +1,7 @@
 {
   // Unsplitable max size shouldn't make the group invalid/ignored
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           // `size-15.js`, `size-20` and `size-41.js` will be captured

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size3/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size3/_config.json
@@ -1,7 +1,7 @@
 {
   // Unsplitable max size shouldn't make the group invalid/ignored
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           // `size-15.js`, `size-20` and `size-41.js` will be captured

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/min_module_size/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/min_module_size/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           // `size-14.js` and `size-23.js` will be captured

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/min_module_size_fallback/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/min_module_size_fallback/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       // Only `size-23.js` will be included in the chunk
       "minModuleSize": 20,
       "groups": [

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/min_share_count/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/min_share_count/_config.json
@@ -14,7 +14,7 @@
         "import": "./c.js"
       }
     ],
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "minShareCount": 2,
       "groups": [
         {

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/min_share_count_fallback/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/min_share_count_fallback/_config.json
@@ -14,7 +14,7 @@
         "import": "./c.js"
       }
     ],
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "minShareCount": 2,

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/min_size/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/min_size/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           // Should split failed

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/min_size_fallback/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/min_size_fallback/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "minSize": 1024,
       "groups": [
         {

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "test": "[\\\\/]node_modules",

--- a/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/full/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/full/_config.json
@@ -10,7 +10,7 @@
         "import": "./entry-b.js"
       }
     ],
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "name": "Splitted",

--- a/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/full/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/full/artifacts.snap
@@ -33,7 +33,7 @@ console.log("entry-b");
 ## Splitted.js
 
 ```js
-//! AdvancedChunks: [Group-Name: Splitted]
+//! ManualCodeSplitting: [Group-Name: Splitted]
 //#region share-splitted.js
 console.log("share-splitted");
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_5303/_config.json
@@ -4,7 +4,7 @@
       "strictExecutionOrder": true,
       "onDemandWrapping": true
     },
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "name": "test",

--- a/crates/rolldown/tests/rolldown/issues/3437/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/3437/_config.json
@@ -2,7 +2,7 @@
   "config": {
     "format": "esm",
     "platform": "node",
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "name": "rolldown",

--- a/crates/rolldown/tests/rolldown/issues/3650/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/3650/_config.json
@@ -3,7 +3,7 @@
     "experimental": {
       "strictExecutionOrder": true
     },
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "includeDependenciesRecursively": false,
       "groups": [
         {

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```text
 [INVALID_OPTION] Warning: `preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown
 
-- `advancedChunks.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+- `codeSplitting.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
 
 To fix:
 

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "name": "imp",

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/_config.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "name": "imp",

--- a/crates/rolldown/tests/rolldown/optimization/pife_for_module_wrappers/basic/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/pife_for_module_wrappers/basic/_config.json
@@ -10,7 +10,7 @@
         "import": "./b.js"
       }
     ],
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "test": "[ab]\\.js",

--- a/crates/rolldown/tests/rolldown/optimization/pife_for_module_wrappers/disabled/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/pife_for_module_wrappers/disabled/_config.json
@@ -10,7 +10,7 @@
         "import": "./b.js"
       }
     ],
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "test": "[ab]\\.js",

--- a/crates/rolldown/tests/rolldown/topics/exports/common_cjs_named_default/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/exports/common_cjs_named_default/_config.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "format": "cjs",
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "name": "shared",

--- a/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/exports/common_esm_named_named/_config.json
@@ -4,7 +4,7 @@
     "experimental": {
       "strictExecutionOrder": true
     },
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "groups": [
         {
           "name": "shared",

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/advanced_chunks_without_groups/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/advanced_chunks_without_groups/_config.json
@@ -6,7 +6,7 @@
         "import": "main.js"
       }
     ],
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "minShareCount": 2,
       "minSize": 1000,
       "maxSize": 5000,

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/advanced_chunks_without_groups/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/advanced_chunks_without_groups/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## INVALID_OPTION
 
 ```text
-[INVALID_OPTION] Warning: Advanced chunks options (minShareCount, minSize, maxSize, includeDependenciesRecursively) specified without groups. These options have no effect without groups - you should either add groups to use advanced chunking or remove these options.
+[INVALID_OPTION] Warning: Manual code splitting options (minShareCount, minSize, maxSize, includeDependenciesRecursively) specified without groups. These options have no effect without groups - you should either add groups to use manual code splitting or remove these options.
 
 ```
 

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/_config.json
@@ -6,7 +6,7 @@
         "import": "main.js"
       }
     ],
-    "advancedChunks": {
+    "manualCodeSplitting": {
       "includeDependenciesRecursively": false,
       "groups": [
         {

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/include_dependencies_recursively_implicit_preserve_entry_signatures/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```text
 [INVALID_OPTION] Warning: `preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown
 
-- `advancedChunks.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
+- `codeSplitting.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'
 
 To fix:
 

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4046,9 +4046,9 @@ expression: output
 
 # tests/rolldown/function/experimental/attach_debug_info/full
 
-- A-!~{000}~.js => A-BgXOerCN.js
-- B-!~{001}~.js => B-Dn8nRiS7.js
-- Splitted-!~{004}~.js => Splitted-CYdnxWY9.js
+- A-!~{000}~.js => A-Dg0npFc7.js
+- B-!~{001}~.js => B-DF0UcPoG.js
+- Splitted-!~{004}~.js => Splitted-CTFInIpB.js
 - dyn-entry-!~{006}~.js => dyn-entry-DRif6-yu.js
 - shared-!~{002}~.js => shared-DDQk-Tql.js
 

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
@@ -9,7 +9,7 @@ use crate::types::{
 
 #[napi_derive::napi(object, object_to_js = false)]
 #[derive(Debug)]
-pub struct BindingAdvancedChunksOptions {
+pub struct BindingManualCodeSplittingOptions {
   pub include_dependencies_recursively: Option<bool>,
   pub min_size: Option<f64>,
   pub min_share_count: Option<u32>,

--- a/crates/rolldown_binding/src/options/binding_output_options/mod.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/mod.rs
@@ -1,5 +1,5 @@
-pub mod binding_advanced_chunks_options;
 mod binding_generated_code_options;
+pub mod binding_manual_code_splitting_options;
 mod binding_pre_rendered_asset;
 mod binding_pre_rendered_chunk;
 use binding_pre_rendered_asset::BindingPreRenderedAsset;
@@ -8,8 +8,8 @@ use napi::Either;
 use napi::bindgen_prelude::{Either3, FnArgs};
 use rustc_hash::FxHashMap;
 
-use binding_advanced_chunks_options::BindingAdvancedChunksOptions;
 pub use binding_generated_code_options::BindingGeneratedCodeOptions;
+use binding_manual_code_splitting_options::BindingManualCodeSplittingOptions;
 use binding_pre_rendered_chunk::PreRenderedChunk;
 
 use super::plugin::BindingPluginOrParallelJsPluginPlaceholder;
@@ -146,7 +146,7 @@ pub struct BindingOutputOptions<'env> {
   #[debug(skip)]
   #[napi(ts_type = "boolean | 'dce-only' | MinifyOptions")]
   pub minify: Option<Either3<bool, String, oxc_minify_napi::MinifyOptions>>,
-  pub advanced_chunks: Option<BindingAdvancedChunksOptions>,
+  pub manual_code_splitting: Option<BindingManualCodeSplittingOptions>,
   #[napi(ts_type = "'none' | 'inline'")]
   pub legal_comments: Option<String>,
   pub polyfill_require: Option<bool>,

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -1,6 +1,6 @@
 use super::normalize_binding_transform_options;
 use crate::options::BindingGeneratedCodeOptions;
-use crate::options::binding_advanced_chunks_options::BindingChunkingContext;
+use crate::options::binding_manual_code_splitting_options::BindingChunkingContext;
 use crate::options::{AssetFileNamesOutputOption, ChunkFileNamesOutputOption, SanitizeFileName};
 use crate::types::binding_string_or_regex::bindingify_string_or_regex_array;
 use crate::{
@@ -14,10 +14,11 @@ use crate::{
 };
 use napi::bindgen_prelude::{Either, Either3, FnArgs};
 use rolldown::{
-  AddonOutputOption, AdvancedChunksOptions, AssetFilenamesOutputOption, BundlerConfig,
-  BundlerOptions, ChunkFilenamesOutputOption, DeferSyncScanDataOption, HashCharacters, IsExternal,
-  MatchGroup, MatchGroupName, ModuleType, OptimizationOption, OutputExports, OutputFormat,
-  Platform, RawMinifyOptions, RawMinifyOptionsDetailed, SanitizeFilename, TsConfig,
+  AddonOutputOption, AssetFilenamesOutputOption, BundlerConfig, BundlerOptions,
+  ChunkFilenamesOutputOption, DeferSyncScanDataOption, HashCharacters, IsExternal,
+  ManualCodeSplittingOptions, MatchGroup, MatchGroupName, ModuleType, OptimizationOption,
+  OutputExports, OutputFormat, Platform, RawMinifyOptions, RawMinifyOptionsDetailed,
+  SanitizeFilename, TsConfig,
 };
 use rolldown_common::DeferSyncScanData;
 use rolldown_common::GeneratedCodeOptions;
@@ -410,7 +411,7 @@ pub fn normalize_binding_options(
     external_live_bindings: output_options.external_live_bindings,
     inline_dynamic_imports: output_options.inline_dynamic_imports,
     dynamic_import_in_cjs: output_options.dynamic_import_in_cjs,
-    advanced_chunks: output_options.advanced_chunks.map(|inner| AdvancedChunksOptions {
+    manual_code_splitting: output_options.manual_code_splitting.map(|inner| ManualCodeSplittingOptions {
       min_size: inner.min_size,
       min_share_count: inner.min_share_count,
       min_module_size: inner.min_module_size,

--- a/crates/rolldown_common/src/chunk/types/chunk_reason_type.rs
+++ b/crates/rolldown_common/src/chunk/types/chunk_reason_type.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Default)]
 pub enum ChunkReasonType {
-  AdvancedChunks {
+  ManualCodeSplitting {
     group_index: u32,
   },
   PreserveModules,
@@ -18,14 +18,14 @@ impl std::fmt::Display for ChunkReasonType {
 impl ChunkReasonType {
   pub fn group_index(&self) -> Option<u32> {
     match self {
-      ChunkReasonType::AdvancedChunks { group_index } => Some(*group_index),
+      ChunkReasonType::ManualCodeSplitting { group_index } => Some(*group_index),
       _ => None,
     }
   }
 
   pub fn as_static_str(&self) -> &'static str {
     match self {
-      ChunkReasonType::AdvancedChunks { .. } => "advanced-chunks",
+      ChunkReasonType::ManualCodeSplitting { .. } => "manual-code-splitting",
       ChunkReasonType::PreserveModules => "preserve-modules",
       ChunkReasonType::Entry => "entry",
       ChunkReasonType::Common => "common",

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -1,7 +1,6 @@
 use rolldown_utils::indexmap::FxIndexMap;
 use rustc_hash::FxHashMap;
 use std::{fmt::Debug, path::PathBuf};
-use types::advanced_chunks_options::AdvancedChunksOptions;
 use types::devtools_options::DevtoolsOptions;
 use types::generated_code_options::GeneratedCodeOptions;
 use types::inject_import::InjectImport;
@@ -9,6 +8,7 @@ use types::invalidate_js_side_cache::InvalidateJsSideCache;
 use types::legal_comments::LegalComments;
 use types::log_level::LogLevel;
 use types::make_absolute_externals_relative::MakeAbsoluteExternalsRelative;
+use types::manual_code_splitting_options::ManualCodeSplittingOptions;
 use types::minify_options::RawMinifyOptions;
 use types::on_log::OnLog;
 use types::optimization::OptimizationOption;
@@ -200,7 +200,7 @@ pub struct BundlerOptions {
   pub external_live_bindings: Option<bool>,
   pub inline_dynamic_imports: Option<bool>,
   pub dynamic_import_in_cjs: Option<bool>,
-  pub advanced_chunks: Option<AdvancedChunksOptions>,
+  pub manual_code_splitting: Option<ManualCodeSplittingOptions>,
   pub checks: Option<ChecksOptions>,
   #[cfg_attr(
     feature = "deserialize_bundler_options",

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -15,7 +15,7 @@ use crate::{ModuleInfo, SharedModuleInfoDashMap};
   derive(Deserialize, JsonSchema),
   serde(rename_all = "camelCase", deny_unknown_fields)
 )]
-pub struct AdvancedChunksOptions {
+pub struct ManualCodeSplittingOptions {
   pub min_share_count: Option<u32>,
   pub min_size: Option<f64>,
   pub max_size: Option<f64>,

--- a/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/mod.rs
@@ -1,4 +1,3 @@
-pub mod advanced_chunks_options;
 pub mod attach_debug_info;
 pub mod chunk_import_map;
 pub mod chunk_modules_order;
@@ -17,6 +16,7 @@ pub mod is_external;
 pub mod legal_comments;
 pub mod log_level;
 pub mod make_absolute_externals_relative;
+pub mod manual_code_splitting_options;
 pub mod minify_options;
 pub mod module_type;
 pub mod normalized_bundler_options;

--- a/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/normalized_bundler_options.rs
@@ -10,10 +10,10 @@ use oxc::transformer_plugins::InjectGlobalVariablesConfig;
 use rolldown_error::EventKindSwitcher;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use super::advanced_chunks_options::AdvancedChunksOptions;
 use super::experimental_options::ExperimentalOptions;
 use super::generated_code_options::GeneratedCodeOptions;
 use super::legal_comments::LegalComments;
+use super::manual_code_splitting_options::ManualCodeSplittingOptions;
 use super::minify_options::MinifyOptions;
 use super::output_option::{
   AssetFilenamesOutputOption, ChunkFilenamesOutputOption, PathsOutputOption,
@@ -88,7 +88,7 @@ pub struct NormalizedBundlerOptions {
   pub external_live_bindings: bool,
   pub inline_dynamic_imports: bool,
   pub dynamic_import_in_cjs: bool,
-  pub advanced_chunks: Option<AdvancedChunksOptions>,
+  pub manual_code_splitting: Option<ManualCodeSplittingOptions>,
   pub checks: EventKindSwitcher,
   pub profiler_names: bool,
   pub watch: WatchOption,
@@ -163,7 +163,7 @@ impl Default for NormalizedBundlerOptions {
       external_live_bindings: Default::default(),
       inline_dynamic_imports: Default::default(),
       dynamic_import_in_cjs: true,
-      advanced_chunks: Default::default(),
+      manual_code_splitting: Default::default(),
       checks: Default::default(),
       profiler_names: Default::default(),
       watch: Default::default(),

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -28,9 +28,6 @@ pub mod bundler_options {
   pub use crate::inner_bundler_options::{
     BundlerOptions,
     types::{
-      advanced_chunks_options::{
-        AdvancedChunksOptions, ChunkingContext, MatchGroup, MatchGroupName, MatchGroupTest,
-      },
       attach_debug_info::AttachDebugInfo,
       chunk_import_map::ChunkImportMap,
       chunk_modules_order::ChunkModulesOrderBy,
@@ -49,6 +46,9 @@ pub mod bundler_options {
       legal_comments::LegalComments,
       log_level::LogLevel,
       make_absolute_externals_relative::MakeAbsoluteExternalsRelative,
+      manual_code_splitting_options::{
+        ChunkingContext, ManualCodeSplittingOptions, MatchGroup, MatchGroupName, MatchGroupTest,
+      },
       minify_options::{MinifyOptions, RawMinifyOptions, RawMinifyOptionsDetailed},
       module_type::ModuleType,
       normalized_bundler_options::{NormalizedBundlerOptions, SharedNormalizedBundlerOptions},

--- a/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
@@ -8,7 +8,7 @@ pub enum InvalidOptionType {
   InvalidOutputFile,
   InvalidOutputDirOption,
   NoEntryPoint,
-  AdvancedChunksWithoutGroups(Vec<String>),
+  ManualCodeSplittingWithoutGroups(Vec<String>),
   InvalidContext(String),
   IncludeDependenciesRecursivelyWithConflictPreserveEntrySignatures(String),
   IncludeDependenciesRecursivelyWithImplicitPreserveEntrySignatures,
@@ -16,7 +16,7 @@ pub enum InvalidOptionType {
   InvalidFilenameSubstitution { name: String, pattern_name: String },
   InlineDynamicImportsWithMultipleInputs,
   InlineDynamicImportsWithPreserveModules,
-  InlineDynamicImportsWithAdvancedChunks,
+  InlineDynamicImportsWithManualCodeSplitting,
   HashLengthTooLong { pattern_name: String, received: usize, max: usize },
   HashLengthTooShort { pattern_name: String, received: usize, min: usize, chunk_count: u32 },
 }
@@ -42,9 +42,9 @@ impl BuildEvent for InvalidOption {
         InvalidOptionType::InvalidOutputFile => "Invalid value for option \"output.file\" - When building multiple chunks, the \"output.dir\" option must be used, not \"output.file\". You may set `output.inlineDynamicImports` to `true` when using dynamic imports.".to_string(),
         InvalidOptionType::InvalidOutputDirOption => "Invalid value for option \"output.dir\" - you must set either \"output.file\" for a single-file build or \"output.dir\" when generating multiple chunks.".to_string(),
         InvalidOptionType::NoEntryPoint =>"You must supply `options.input` to rolldown, you should at least provide one entrypoint via `options.input` or `this.emitFile({type: 'chunk', ...})` (https://rollupjs.org/plugin-development/#this-emitfile)".to_string(),
-        InvalidOptionType::AdvancedChunksWithoutGroups(options) => {
+        InvalidOptionType::ManualCodeSplittingWithoutGroups(options) => {
           let options_list = options.join(", ");
-          format!("Advanced chunks options ({options_list}) specified without groups. These options have no effect without groups - you should either add groups to use advanced chunking or remove these options.")
+          format!("Manual code splitting options ({options_list}) specified without groups. These options have no effect without groups - you should either add groups to use manual code splitting or remove these options.")
         }
         InvalidOptionType::InvalidContext(options) => {
             format!("\"{options}\" is an illegitimate identifier for option \"context\". You may use a legitimate context identifier instead.")
@@ -53,7 +53,7 @@ impl BuildEvent for InvalidOption {
           [
             "Invalid option combination detected:",
             "",
-            "- advancedChunks.includeDependenciesRecursively = false",
+            "- codeSplitting.includeDependenciesRecursively = false",
             &format!("- preserveEntrySignatures = \"{value}\""),
             "",
             "To fix:",
@@ -65,7 +65,7 @@ impl BuildEvent for InvalidOption {
           [
             "`preserveEntrySignatures: 'allow-extension'` is set implicitly by Rolldown",
             "",
-            "- `advancedChunks.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'",
+            "- `codeSplitting.includeDependenciesRecursively = false` requires `preserveEntrySignatures` to be either `false` or 'allow-extension'",
             "",
             "To fix:",
             "",
@@ -91,8 +91,8 @@ impl BuildEvent for InvalidOption {
         InvalidOptionType::InlineDynamicImportsWithPreserveModules => {
           "Invalid value \"true\" for option \"output.inlineDynamicImports\" - this option is not supported for \"output.preserveModules\".".to_string()
         }
-        InvalidOptionType::InlineDynamicImportsWithAdvancedChunks => {
-          "Invalid value \"true\" for option \"output.inlineDynamicImports\" - this option is not supported for \"output.advancedChunks\".".to_string()
+        InvalidOptionType::InlineDynamicImportsWithManualCodeSplitting => {
+          "Invalid value \"true\" for option \"output.inlineDynamicImports\" - this option is not supported for \"output.codeSplitting\".".to_string()
         }
         InvalidOptionType::HashLengthTooLong { pattern_name, received, max } => {
           format!("Hashes cannot be longer than {max} characters, received {received}. Check the `{pattern_name}` option.")

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -407,10 +407,10 @@
             "null"
           ]
         },
-        "advancedChunks": {
+        "manualCodeSplitting": {
           "anyOf": [
             {
-              "$ref": "#/$defs/AdvancedChunksOptions"
+              "$ref": "#/$defs/ManualCodeSplittingOptions"
             },
             {
               "type": "null"
@@ -1187,7 +1187,7 @@
         }
       ]
     },
-    "AdvancedChunksOptions": {
+    "ManualCodeSplittingOptions": {
       "type": "object",
       "properties": {
         "minShareCount": {

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1653,16 +1653,6 @@ export interface AliasItem {
   replacements: Array<string | undefined | null>
 }
 
-export interface BindingAdvancedChunksOptions {
-  includeDependenciesRecursively?: boolean
-  minSize?: number
-  minShareCount?: number
-  groups?: Array<BindingMatchGroup>
-  maxSize?: number
-  minModuleSize?: number
-  maxModuleSize?: number
-}
-
 export interface BindingAssetSource {
   inner: string | Uint8Array
 }
@@ -2046,6 +2036,16 @@ export type BindingMakeAbsoluteExternalsRelative =
   | { type: 'Bool', field0: boolean }
   | { type: 'IfRelativeSource' }
 
+export interface BindingManualCodeSplittingOptions {
+  includeDependenciesRecursively?: boolean
+  minSize?: number
+  minShareCount?: number
+  groups?: Array<BindingMatchGroup>
+  maxSize?: number
+  minModuleSize?: number
+  maxModuleSize?: number
+}
+
 export interface BindingMatchGroup {
   name: string | ((id: string, ctx: BindingChunkingContext) => VoidNullable<string>)
   test?: string | RegExp | ((id: string) => VoidNullable<boolean>)
@@ -2117,7 +2117,7 @@ export interface BindingOutputOptions {
   sourcemapDebugIds?: boolean
   sourcemapPathTransform?: (source: string, sourcemapPath: string) => string
   minify?: boolean | 'dce-only' | MinifyOptions
-  advancedChunks?: BindingAdvancedChunksOptions
+  manualCodeSplitting?: BindingManualCodeSplittingOptions
   legalComments?: 'none' | 'inline'
   polyfillRequire?: boolean
   preserveModules?: boolean

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -1,4 +1,4 @@
-import type { BindingOutputOptions } from '../binding.cjs';
+import type { BindingChunkingContext, BindingOutputOptions } from '../binding.cjs';
 import type { OutputOptions } from '../options/output-options';
 import { ChunkingContextImpl } from '../types/chunking-context';
 import { transformAssetSource } from './asset-source';
@@ -93,7 +93,7 @@ export function bindingifyOutputOptions(outputOptions: OutputOptions): BindingOu
     externalLiveBindings: outputOptions.externalLiveBindings,
     inlineDynamicImports: outputOptions.inlineDynamicImports,
     dynamicImportInCjs: outputOptions.dynamicImportInCjs,
-    advancedChunks,
+    manualCodeSplitting: advancedChunks,
     polyfillRequire: outputOptions.polyfillRequire,
     sanitizeFileName,
     preserveModules,
@@ -181,7 +181,7 @@ function bindingifyAdvancedChunks(
   codeSplitting: OutputOptions['codeSplitting'],
   advancedChunks: OutputOptions['advancedChunks'],
   manualChunks: OutputOptions['manualChunks'],
-): BindingOutputOptions['advancedChunks'] {
+): BindingOutputOptions['manualCodeSplitting'] {
   // Determine the effective option with priority: codeSplitting > advancedChunks > manualChunks
   let effectiveOption = codeSplitting;
 
@@ -223,7 +223,9 @@ function bindingifyAdvancedChunks(
       return {
         ...restGroup,
         name:
-          typeof name === 'function' ? (id, ctx) => name(id, new ChunkingContextImpl(ctx)) : name,
+          typeof name === 'function'
+            ? (id: string, ctx: BindingChunkingContext) => name(id, new ChunkingContextImpl(ctx))
+            : name,
       };
     }),
   };


### PR DESCRIPTION
Part of https://github.com/rolldown/rolldown/issues/7330