### PR TITLE
fix: inline __name calls for default exports 

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_7852/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_7852/artifacts.snap
@@ -9,8 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 //#region main.js
 const baseFontSize = 16;
-var main_default = (px) => parseFloat(px) / baseFontSize;
-__name(main_default, "default");
+var main_default = /* @__PURE__ */ __name((px) => parseFloat(px) / baseFontSize, "default");
 
 //#endregion
 export { main_default as default };

--- a/crates/rolldown/tests/rolldown/topics/keep_names/parenthesized_default_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/parenthesized_default_export/artifacts.snap
@@ -10,8 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region dep.js
-var dep_default = (function() {});
-__name(dep_default, "default");
+var dep_default = /* @__PURE__ */ __name((function() {}), "default");
 
 //#endregion
 //#region dep-class.js
@@ -23,8 +22,7 @@ var dep_class_default = class {
 
 //#endregion
 //#region dep-arrow.js
-var dep_arrow_default = (() => {});
-__name(dep_arrow_default, "default");
+var dep_arrow_default = /* @__PURE__ */ __name((() => {}), "default");
 
 //#endregion
 //#region dep-named-default.js

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -6038,11 +6038,11 @@ expression: output
 
 # tests/rolldown/topics/keep_names/issue_7852
 
-- main-!~{000}~.js => main-CkTekG0F.js
+- main-!~{000}~.js => main-BLYZq5mg.js
 
 # tests/rolldown/topics/keep_names/parenthesized_default_export
 
-- main-!~{000}~.js => main-DgH0nPHk.js
+- main-!~{000}~.js => main-Dn3lIuCt.js
 
 # tests/rolldown/topics/live_bindings/default_export_binding
 


### PR DESCRIPTION
closed https://github.com/rolldown/rolldown/issues/7854