### PR TITLE
chore(rolldown_binding): allow crate-type as lib

### DIFF
--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Rolldown binding crate configuration**
> 
> - Expands `crate-type` in `crates/rolldown_binding/Cargo.toml` from `["cdylib"]` to `["lib", "cdylib"]`, allowing the crate to compile as a Rust library in addition to a cdylib.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afe7a90e4d0ea5a35af0c075abbb6d81e592f41b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->