### PR TITLE
refactor(dev): move `clientId` property to `DevRuntime` base class

### DIFF
--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
@@ -36,10 +36,18 @@ class Module {
 
 export class DevRuntime {
   /**
-   * @param {Messenger} messenger
+   * Client ID generated at runtime initialization, used for lazy compilation requests.
+   * @type {string}
    */
-  constructor(messenger) {
+  clientId;
+
+  /**
+   * @param {Messenger} messenger
+   * @param {string} clientId
+   */
+  constructor(messenger, clientId) {
     this.messenger = messenger;
+    this.clientId = clientId;
   }
 
   /**

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
@@ -54,12 +54,6 @@ class ModuleHotContext {
 
 class DefaultDevRuntime extends BaseDevRuntime {
   /**
-   * Client ID generated at runtime initialization, used for lazy compilation requests.
-   * @type {string}
-   */
-  clientId;
-
-  /**
    * @param {WebSocket} socket
    * @param {string} clientId
    */
@@ -85,8 +79,7 @@ class DefaultDevRuntime extends BaseDevRuntime {
       socket.onopen = null;
     };
 
-    super(messenger);
-    this.clientId = clientId;
+    super(messenger, clientId);
   }
 
   /**


### PR DESCRIPTION
Moved `clientId` property to `DevRuntime` class as I think any dev runtime should have that property.