### PR TITLE
refactor(dev): fix type errors for test HMR runtime

### DIFF
--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
@@ -1,11 +1,10 @@
 // @ts-check
 
-/** @type {typeof import('./runtime-extra-dev-common.js').DevRuntime} */
+/** @import { DevRuntime, Messenger, DevRuntimeMessage } from './runtime-extra-dev-common.js' */
+
+/** @type {typeof DevRuntime} */
 // @ts-expect-error -- there's no way to declare a variable by JSDoc
 var BaseDevRuntime = DevRuntime;
-
-/** @typedef {import('./runtime-extra-dev-common.js').Messenger} Messenger */
-/** @typedef {import('./runtime-extra-dev-common.js').DevRuntimeMessage} DevRuntimeMessage */
 
 class ModuleHotContext {
   /**

--- a/crates/rolldown_testing/src/hmr-runtime.js
+++ b/crates/rolldown_testing/src/hmr-runtime.js
@@ -1,15 +1,27 @@
-// @ts-nocheck FIXME(hyf0): Enable type check
+// @ts-check
 
-/// <reference path="../../../crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js" />
+/** @import { DevRuntime } from "../../rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js" */
+
+/** @type {typeof DevRuntime} */
+// @ts-expect-error -- there's no way to declare a variable by JSDoc
+var BaseDevRuntime = DevRuntime;
 
 class TestHotContext {
   moduleId;
+  /** @type {{ deps: string, cb: Function }[]} */
   callbacks = [];
 
+  /**
+   * @param {string} moduleId
+   */
   constructor(moduleId) {
     this.moduleId = moduleId;
   }
 
+  /**
+   * @param {...any} args
+   * @returns {void}
+   */
   accept(...args) {
     if (args.length === 0) return;
     if (args.length === 1) {
@@ -20,7 +32,7 @@ class TestHotContext {
   }
 }
 
-class TestDevRuntime extends DevRuntime {
+class TestDevRuntime extends BaseDevRuntime {
   contexts = new Map();
 
   /**
@@ -59,4 +71,8 @@ class TestDevRuntime extends DevRuntime {
   }
 }
 
-/** @type {any} */ (globalThis).__rolldown_runtime__ ??= new TestDevRuntime();
+/** @type {any} */
+const messenger = undefined;
+const clientId = crypto.randomUUID();
+
+/** @type {any} */ (globalThis).__rolldown_runtime__ ??= new TestDevRuntime(messenger, clientId);

--- a/crates/rolldown_testing/src/tsconfig.json
+++ b/crates/rolldown_testing/src/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*", "../../rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js"],
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "isolatedDeclarations": false,
+    "allowJs": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
   "references": [
     { "path": "./crates/rolldown/src/runtime" },
     { "path": "./crates/rolldown_plugin_hmr/src/runtime" },
+    { "path": "./crates/rolldown_testing/src" },
     { "path": "./packages/bench" },
     { "path": "./packages/rolldown" },
     { "path": "./packages/rolldown/tests" },


### PR DESCRIPTION
Made type-check pass with test dev runtime. Also refactored the code a bit using `@import`.