### PR TITLE
refactor(dev): `devEngine.compileEntry` does not return null

### DIFF
--- a/packages/test-dev-server/src/dev-server.ts
+++ b/packages/test-dev-server/src/dev-server.ts
@@ -202,11 +202,9 @@ class DevServer {
 
           if (moduleId && clientId) {
             const moduleCode = await devEngine.compileEntry(moduleId, clientId);
-            if (moduleCode != null) {
-              res!.setHeader('Content-Type', 'application/javascript');
-              res!.end(moduleCode);
-              return;
-            }
+            res!.setHeader('Content-Type', 'application/javascript');
+            res!.end(moduleCode);
+            return;
           }
         } catch (err) {
           // Return server error response


### PR DESCRIPTION
`devEngine.compileEntry` doesn't seem to return `null` or `undefined`. I guess we can simplify this code.