### PR TITLE
fix(dev): add `@vite-ignore` to lazy compilation proxy module import

### DIFF
--- a/crates/rolldown_plugin_lazy_compilation/src/proxy-module-template.js
+++ b/crates/rolldown_plugin_lazy_compilation/src/proxy-module-template.js
@@ -2,7 +2,7 @@ const lazyExports = (async () => {
   // Dev server will intercept this import and serve the actual module code.
   // We send the proxy module ID (with ?rolldown-lazy=1) so the server can mark it as fetched.
   await import(
-    `/lazy?id=${encodeURIComponent($PROXY_MODULE_ID)}&clientId=${__rolldown_runtime__.clientId}`
+    /* @vite-ignore */ `/lazy?id=${encodeURIComponent($PROXY_MODULE_ID)}&clientId=${__rolldown_runtime__.clientId}`
   );
   // After the module code is loaded, we can get its exports from the runtime.
   // The actual module registers with $STABLE_MODULE_ID (the stable/relative path).


### PR DESCRIPTION
Added `@vite-ignore` to the lazy compilation proxy module dynamic import to avoid warnings.

```
[plugin builtin:vite-dynamic-import-vars] Invalid import `/lazy?id=${encodeURIComponent("path.js?rolldown-lazy=1")}&clientId=${__rolldown_runtime__.clientId}`. Variable bare imports are not supported, imports must start with ./ in the static part of the import. For example: import(`./foo/${bar}.js`).
```
