### PR TITLE
feat(dev): change lazy module URL to `/@vite/lazy` from `/lazy`

### DIFF
--- a/crates/rolldown_plugin_lazy_compilation/src/proxy-module-template.js
+++ b/crates/rolldown_plugin_lazy_compilation/src/proxy-module-template.js
@@ -2,7 +2,7 @@ const lazyExports = (async () => {
   // Dev server will intercept this import and serve the actual module code.
   // We send the proxy module ID (with ?rolldown-lazy=1) so the server can mark it as fetched.
   await import(
-    /* @vite-ignore */ `/lazy?id=${encodeURIComponent($PROXY_MODULE_ID)}&clientId=${__rolldown_runtime__.clientId}`
+    /* @vite-ignore */ `/@vite/lazy?id=${encodeURIComponent($PROXY_MODULE_ID)}&clientId=${__rolldown_runtime__.clientId}`
   );
   // After the module code is loaded, we can get its exports from the runtime.
   // The actual module registers with $STABLE_MODULE_ID (the stable/relative path).

--- a/packages/test-dev-server/src/dev-server.ts
+++ b/packages/test-dev-server/src/dev-server.ts
@@ -193,7 +193,7 @@ class DevServer {
       }
     });
     this.connectServer.use(async (req, res, next) => {
-      if (req.url?.startsWith('/lazy?')) {
+      if (req.url?.startsWith('/@vite/lazy?')) {
         try {
           const url = new URL(req.url, `http://localhost:${this.#port}`);
           const moduleId = url.searchParams.get('id');


### PR DESCRIPTION
Change lazy module URL to `/@vite/lazy` from `/lazy` to reduce the URL conflict probability.