### PR TITLE
fix: deduplicate entry points when module is both emitted and dynamically imported

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/7833/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7833/artifacts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## imp.js
+
+```js
+//#region imp.js
+const imp = 1;
+const imp2 = 2;
+
+//#endregion
+export { imp, imp2 };
+```
+
+## main.js
+
+```js
+//#region main.js
+const load = async () => {
+	const result = await import("./imp.js");
+	console.log(result.imp);
+};
+load();
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/issues/7833/imp.js
+++ b/crates/rolldown/tests/rolldown/issues/7833/imp.js
@@ -1,0 +1,2 @@
+export const imp = 1;
+export const imp2 = 2;

--- a/crates/rolldown/tests/rolldown/issues/7833/main.js
+++ b/crates/rolldown/tests/rolldown/issues/7833/main.js
@@ -1,0 +1,5 @@
+const load = async () => {
+  const result = await import('./imp.js');
+  console.log(result.imp);
+};
+load();

--- a/crates/rolldown/tests/rolldown/issues/7833/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/7833/mod.rs
@@ -1,0 +1,58 @@
+use std::{borrow::Cow, sync::Arc};
+
+use rolldown::{BundlerOptions, InputItem, PreserveEntrySignatures};
+use rolldown_common::EmittedChunk;
+use rolldown_plugin::{HookUsage, Plugin};
+use rolldown_testing::{manual_integration_test, test_config::TestMeta};
+
+/// Test that when a module is both dynamically imported AND emitted via this.emitFile,
+/// only one entry chunk is created (emitted entry takes priority).
+/// See: https://github.com/rolldown/rolldown/issues/7833
+#[derive(Debug)]
+struct Test;
+
+impl Plugin for Test {
+  fn name(&self) -> Cow<'static, str> {
+    "test".into()
+  }
+
+  async fn transform(
+    &self,
+    ctx: rolldown_plugin::SharedTransformPluginContext,
+    args: &rolldown_plugin::HookTransformArgs<'_>,
+  ) -> rolldown_plugin::HookTransformReturn {
+    // Emit chunk for dynamically imported module
+    if args.id.ends_with("imp.js") {
+      ctx
+        .emit_chunk(EmittedChunk {
+          id: args.id.to_string(),
+          preserve_entry_signatures: Some(PreserveEntrySignatures::AllowExtension),
+          ..Default::default()
+        })
+        .await?;
+    }
+    Ok(None)
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::Transform
+  }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn deduplicate_emit_file_and_dynamic_import() {
+  // This test verifies that when imp.js is both:
+  // 1. Dynamically imported from main.js
+  // 2. Emitted via this.emitFile in transform hook
+  // Only ONE chunk for imp.js is created (not two duplicate chunks)
+  manual_integration_test!()
+    .build(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec![InputItem { name: Some("main".into()), import: "./main.js".into() }]),
+        ..Default::default()
+      },
+      vec![Arc::new(Test)],
+    )
+    .await;
+}

--- a/crates/rolldown/tests/rolldown/issues/mod.rs
+++ b/crates/rolldown/tests/rolldown/issues/mod.rs
@@ -4,3 +4,5 @@ mod _1733;
 mod _4895;
 #[path = "./5011/mod.rs"]
 mod _5011;
+#[path = "./7833/mod.rs"]
+mod _7833;


### PR DESCRIPTION
When a module is treated as a `this.emit`  entry and a dynamic import entry at the same time, rollup will try to merge it, but rolldown would create duplicate entry for the same module, this leads more chunk gereated compare to rollup here is an example:   
[https://stackblitz.com/edit/stackblitz-starters-anaqr2m2?description=Starter project for Node.js, a JavaScript runtime built on Chrome's V8 JavaScript engine&file=temp-stackblitz%2Fpackage.json,temp-stackblitz%2Fbuild-rollup.js&title=node.new Starter](https://stackblitz.com/edit/stackblitz-starters-anaqr2m2?description=Starter%20project%20for%20Node.js,%20a%20JavaScript%20runtime%20built%20on%20Chrome%27s%20V8%20JavaScript%20engine&file=temp-stackblitz%2Fpackage.json,temp-stackblitz%2Fbuild-rollup.js&title=node.new%20Starter)  
