### PR TITLE
feat(plugin): add builtin fake-js plugin for TypeScript declaration bundling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,7 @@ dependencies = [
  "rolldown_error",
  "rolldown_plugin",
  "rolldown_plugin_esm_external_require",
+ "rolldown_plugin_fake_js",
  "rolldown_plugin_isolated_declaration",
  "rolldown_plugin_replace",
  "rolldown_plugin_utils",
@@ -3076,6 +3077,16 @@ dependencies = [
  "rolldown_plugin",
  "rolldown_utils",
  "rustc-hash",
+]
+
+[[package]]
+name = "rolldown_plugin_fake_js"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "oxc",
+ "regex",
+ "rolldown_plugin",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2623,6 +2623,7 @@ dependencies = [
  "rolldown_plugin",
  "rolldown_plugin_bundle_analyzer",
  "rolldown_plugin_esm_external_require",
+ "rolldown_plugin_fake_js",
  "rolldown_plugin_isolated_declaration",
  "rolldown_plugin_oxc_runtime",
  "rolldown_plugin_replace",
@@ -2902,6 +2903,20 @@ dependencies = [
  "rolldown_plugin",
  "rolldown_utils",
  "rustc-hash",
+]
+
+[[package]]
+name = "rolldown_plugin_fake_js"
+version = "1.2.3"
+dependencies = [
+ "anyhow",
+ "oxc",
+ "oxc_sourcemap",
+ "regex",
+ "rolldown_plugin",
+ "rolldown_sourcemap",
+ "rustc-hash",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,7 +2914,6 @@ dependencies = [
  "oxc_sourcemap",
  "regex",
  "rolldown_plugin",
- "rolldown_sourcemap",
  "rustc-hash",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ rolldown_plugin = { version = "0.1.0", path = "crates/rolldown_plugin" }
 rolldown_plugin_chunk_import_map = { version = "0.1.0", path = "crates/rolldown_plugin_chunk_import_map" }
 rolldown_plugin_data_uri = { version = "0.1.0", path = "crates/rolldown_plugin_data_uri" }
 rolldown_plugin_esm_external_require = { version = "0.1.0", path = "crates/rolldown_plugin_esm_external_require" }
+rolldown_plugin_fake_js = { version = "0.1.0", path = "crates/rolldown_plugin_fake_js" }
 rolldown_plugin_hmr = { version = "0.1.0", path = "crates/rolldown_plugin_hmr" }
 rolldown_plugin_isolated_declaration = { version = "0.1.0", path = "crates/rolldown_plugin_isolated_declaration" }
 rolldown_plugin_lazy_compilation = { version = "0.1.0", path = "crates/rolldown_plugin_lazy_compilation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ rolldown_plugin_copy_module = { version = "1.2.3", path = "crates/rolldown_plugi
 rolldown_plugin_bundle_analyzer = { version = "1.2.3", path = "crates/rolldown_plugin_bundle_analyzer" }
 rolldown_plugin_data_url = { version = "1.2.3", path = "crates/rolldown_plugin_data_url" }
 rolldown_plugin_esm_external_require = { version = "1.2.3", path = "crates/rolldown_plugin_esm_external_require" }
+rolldown_plugin_fake_js = { version = "1.2.3", path = "crates/rolldown_plugin_fake_js" }
 rolldown_plugin_hmr = { version = "1.2.3", path = "crates/rolldown_plugin_hmr" }
 rolldown_plugin_isolated_declaration = { version = "1.2.3", path = "crates/rolldown_plugin_isolated_declaration" }
 rolldown_plugin_lazy_compilation = { version = "1.2.3", path = "crates/rolldown_plugin_lazy_compilation" }

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -38,6 +38,7 @@ rolldown_devtools = { workspace = true }
 rolldown_error = { workspace = true, features = ["napi"] }
 rolldown_plugin = { workspace = true }
 rolldown_plugin_esm_external_require = { workspace = true }
+rolldown_plugin_fake_js = { workspace = true }
 rolldown_plugin_isolated_declaration = { workspace = true }
 rolldown_plugin_replace = { workspace = true }
 rolldown_plugin_utils = { workspace = true }

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -43,6 +43,7 @@ rolldown_error = { workspace = true, features = ["napi"] }
 rolldown_plugin = { workspace = true }
 rolldown_plugin_bundle_analyzer = { workspace = true }
 rolldown_plugin_esm_external_require = { workspace = true }
+rolldown_plugin_fake_js = { workspace = true }
 rolldown_plugin_isolated_declaration = { workspace = true }
 rolldown_plugin_oxc_runtime = { workspace = true }
 rolldown_plugin_replace = { workspace = true }

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use napi::{Unknown, bindgen_prelude::FromNapiValue};
 use rolldown_plugin::__inner::Pluginable;
 use rolldown_plugin_esm_external_require::EsmExternalRequirePlugin;
+use rolldown_plugin_fake_js::{FakeJsOptions, FakeJsRolldownPlugin};
 use rolldown_plugin_isolated_declaration::IsolatedDeclarationPlugin;
 use rolldown_plugin_replace::ReplacePlugin;
 use rolldown_plugin_vite_alias::ViteAliasPlugin;
@@ -22,8 +23,9 @@ use rolldown_plugin_vite_wasm_helper::ViteWasmHelperPlugin;
 use rolldown_plugin_vite_web_worker_post::ViteWebWorkerPostPlugin;
 
 use crate::options::plugin::config::{
-  BindingEsmExternalRequirePluginConfig, BindingViteModulePreloadPolyfillPluginConfig,
-  BindingViteReactRefreshWrapperPluginConfig, BindingViteWasmHelperPluginConfig,
+  BindingEsmExternalRequirePluginConfig, BindingFakeJsPluginConfig,
+  BindingViteModulePreloadPolyfillPluginConfig, BindingViteReactRefreshWrapperPluginConfig,
+  BindingViteWasmHelperPluginConfig,
 };
 
 use super::{
@@ -64,6 +66,14 @@ impl TryFrom<BindingBuiltinPlugin<'_>> for Arc<dyn Pluginable> {
           BindingEsmExternalRequirePluginConfig::from_unknown(options)?.into()
         } else {
           EsmExternalRequirePlugin::default()
+        };
+        Arc::new(plugin)
+      }
+      BindingBuiltinPluginName::FakeJs => {
+        let plugin = if let Some(options) = plugin.options {
+          FakeJsRolldownPlugin::new(BindingFakeJsPluginConfig::from_unknown(options)?.into())
+        } else {
+          FakeJsRolldownPlugin::new(FakeJsOptions::default())
         };
         Arc::new(plugin)
       }

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -4,6 +4,7 @@ use napi::{Unknown, bindgen_prelude::FromNapiValue};
 use rolldown_plugin::__inner::Pluginable;
 use rolldown_plugin_bundle_analyzer::BundleAnalyzerPlugin;
 use rolldown_plugin_esm_external_require::EsmExternalRequirePlugin;
+use rolldown_plugin_fake_js::{FakeJsOptions, FakeJsRolldownPlugin};
 use rolldown_plugin_isolated_declaration::IsolatedDeclarationPlugin;
 use rolldown_plugin_oxc_runtime::OxcRuntimePlugin;
 use rolldown_plugin_replace::ReplacePlugin;
@@ -23,7 +24,8 @@ use rolldown_plugin_vite_web_worker_post::ViteWebWorkerPostPlugin;
 
 use crate::options::plugin::config::{
   BindingBundleAnalyzerPluginConfig, BindingEsmExternalRequirePluginConfig,
-  BindingViteModulePreloadPolyfillPluginConfig, BindingViteReactRefreshWrapperPluginConfig,
+  BindingFakeJsPluginConfig, BindingViteModulePreloadPolyfillPluginConfig,
+  BindingViteReactRefreshWrapperPluginConfig,
 };
 
 use super::{
@@ -72,6 +74,14 @@ impl TryFrom<BindingBuiltinPlugin<'_>> for Arc<dyn Pluginable> {
           BindingEsmExternalRequirePluginConfig::from_unknown(options)?.into()
         } else {
           EsmExternalRequirePlugin::default()
+        };
+        Arc::new(plugin)
+      }
+      BindingBuiltinPluginName::FakeJs => {
+        let plugin = if let Some(options) = plugin.options {
+          FakeJsRolldownPlugin::new(BindingFakeJsPluginConfig::from_unknown(options)?.into())
+        } else {
+          FakeJsRolldownPlugin::new(FakeJsOptions::default())
         };
         Arc::new(plugin)
       }

--- a/crates/rolldown_binding/src/options/plugin/config/binding_fake_js_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_fake_js_plugin_config.rs
@@ -1,0 +1,19 @@
+use rolldown_plugin_fake_js::FakeJsOptions;
+
+#[napi_derive::napi(object, object_to_js = false)]
+#[derive(Debug, Default)]
+pub struct BindingFakeJsPluginConfig {
+  pub sourcemap: Option<bool>,
+  pub cjs_default: Option<bool>,
+  pub side_effects: Option<bool>,
+}
+
+impl From<BindingFakeJsPluginConfig> for FakeJsOptions {
+  fn from(config: BindingFakeJsPluginConfig) -> Self {
+    FakeJsOptions {
+      sourcemap: config.sourcemap.unwrap_or(false),
+      cjs_default: config.cjs_default.unwrap_or(false),
+      side_effects: config.side_effects.unwrap_or(false),
+    }
+  }
+}

--- a/crates/rolldown_binding/src/options/plugin/config/mod.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/mod.rs
@@ -1,4 +1,5 @@
 mod binding_esm_external_require_plugin_config;
+mod binding_fake_js_plugin_config;
 mod binding_isolated_declaration_plugin_config;
 mod binding_replace_plugin_config;
 mod binding_vite_alias_plugin_config;
@@ -15,6 +16,7 @@ mod binding_vite_transform_plugin_config;
 mod binding_vite_wasm_helper_plugin_config;
 
 pub use binding_esm_external_require_plugin_config::BindingEsmExternalRequirePluginConfig;
+pub use binding_fake_js_plugin_config::BindingFakeJsPluginConfig;
 pub use binding_isolated_declaration_plugin_config::BindingIsolatedDeclarationPluginConfig;
 pub use binding_replace_plugin_config::BindingReplacePluginConfig;
 pub use binding_vite_alias_plugin_config::BindingViteAliasPluginConfig;

--- a/crates/rolldown_binding/src/options/plugin/config/mod.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/mod.rs
@@ -1,5 +1,6 @@
 mod binding_bundle_analyzer_plugin_config;
 mod binding_esm_external_require_plugin_config;
+mod binding_fake_js_plugin_config;
 mod binding_isolated_declaration_plugin_config;
 mod binding_replace_plugin_config;
 mod binding_vite_alias_plugin_config;
@@ -16,6 +17,7 @@ mod binding_vite_transform_plugin_config;
 
 pub use binding_bundle_analyzer_plugin_config::BindingBundleAnalyzerPluginConfig;
 pub use binding_esm_external_require_plugin_config::BindingEsmExternalRequirePluginConfig;
+pub use binding_fake_js_plugin_config::BindingFakeJsPluginConfig;
 pub use binding_isolated_declaration_plugin_config::BindingIsolatedDeclarationPluginConfig;
 pub use binding_replace_plugin_config::BindingReplacePluginConfig;
 pub use binding_vite_alias_plugin_config::BindingViteAliasPluginConfig;

--- a/crates/rolldown_binding/src/options/plugin/types/binding_builtin_plugin_name.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_builtin_plugin_name.rs
@@ -5,6 +5,8 @@ use napi_derive::napi;
 pub enum BindingBuiltinPluginName {
   #[napi(value = "builtin:esm-external-require")]
   EsmExternalRequire,
+  #[napi(value = "builtin:fake-js")]
+  FakeJs,
   #[napi(value = "builtin:isolated-declaration")]
   IsolatedDeclaration,
   #[napi(value = "builtin:replace")]

--- a/crates/rolldown_binding/src/options/plugin/types/binding_builtin_plugin_name.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_builtin_plugin_name.rs
@@ -7,6 +7,8 @@ pub enum BindingBuiltinPluginName {
   BundleAnalyzer,
   #[napi(value = "builtin:esm-external-require")]
   EsmExternalRequire,
+  #[napi(value = "builtin:fake-js")]
+  FakeJs,
   #[napi(value = "builtin:isolated-declaration")]
   IsolatedDeclaration,
   #[napi(value = "builtin:replace")]

--- a/crates/rolldown_plugin_fake_js/Cargo.toml
+++ b/crates/rolldown_plugin_fake_js/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rolldown_plugin_fake_js"
+version = "0.1.0"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish = true
+repository.workspace = true
+description = "A Rolldown plugin for transforming TypeScript declaration files using OXC"
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false
+
+[dependencies]
+oxc = { workspace = true }
+regex = { workspace = true }
+anyhow = { workspace = true }
+rolldown_plugin = { workspace = true }

--- a/crates/rolldown_plugin_fake_js/Cargo.toml
+++ b/crates/rolldown_plugin_fake_js/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "rolldown_plugin_fake_js"
+version = "1.2.3"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish = true
+repository.workspace = true
+description = "A Rolldown plugin for transforming TypeScript declaration files using OXC"
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false
+
+[dependencies]
+anyhow = { workspace = true }
+oxc = { workspace = true }
+oxc_sourcemap = { workspace = true }
+regex = { workspace = true }
+rolldown_plugin = { workspace = true }
+rolldown_sourcemap = { workspace = true }
+rustc-hash = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/rolldown_plugin_fake_js/Cargo.toml
+++ b/crates/rolldown_plugin_fake_js/Cargo.toml
@@ -20,6 +20,5 @@ oxc = { workspace = true }
 oxc_sourcemap = { workspace = true }
 regex = { workspace = true }
 rolldown_plugin = { workspace = true }
-rolldown_sourcemap = { workspace = true }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rolldown_plugin_fake_js/src/ast_utils.rs
+++ b/crates/rolldown_plugin_fake_js/src/ast_utils.rs
@@ -1,0 +1,47 @@
+use oxc::ast::ast::{Comment, CommentKind, Program};
+use regex::Regex;
+use std::sync::LazyLock;
+
+static REFERENCE_RE: LazyLock<Regex> =
+  LazyLock::new(|| Regex::new(r"/\s*<reference\s+(?:path|types)=").unwrap());
+
+pub fn is_reference_directive(comment: &str) -> bool {
+  REFERENCE_RE.is_match(comment)
+}
+
+pub fn collect_reference_directives_from_program(program: &Program, source: &str) -> Vec<String> {
+  let mut directives = Vec::new();
+
+  for comment in &program.comments {
+    let comment_text = extract_comment_text(comment, source);
+
+    if comment.kind == CommentKind::Line && is_reference_directive(&comment_text) {
+      directives.push(comment_text);
+    }
+  }
+
+  directives
+}
+
+fn extract_comment_text(comment: &Comment, source: &str) -> String {
+  let start = comment.span.start as usize;
+  let end = comment.span.end as usize;
+
+  if start < source.len() && end <= source.len() && start < end {
+    source[start..end].to_string()
+  } else {
+    String::new()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_reference_directive() {
+    assert!(is_reference_directive("/// <reference path=\"foo\" />"));
+    assert!(is_reference_directive("/// <reference types=\"bar\" />"));
+    assert!(!is_reference_directive("// regular comment"));
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/ast_utils.rs
+++ b/crates/rolldown_plugin_fake_js/src/ast_utils.rs
@@ -1,0 +1,39 @@
+use std::sync::LazyLock;
+
+use oxc::ast::ast::{CommentKind, Program};
+use regex::Regex;
+
+use crate::codegen::extract_span_text;
+
+static REFERENCE_RE: LazyLock<Regex> =
+  LazyLock::new(|| Regex::new(r"/\s*<reference\s+(?:path|types)=").unwrap());
+
+pub fn is_reference_directive(comment: &str) -> bool {
+  REFERENCE_RE.is_match(comment)
+}
+
+pub fn collect_reference_directives_from_program(program: &Program, source: &str) -> Vec<String> {
+  let mut directives = Vec::new();
+
+  for comment in &program.comments {
+    let comment_text = extract_span_text(source, comment.span);
+
+    if comment.kind == CommentKind::Line && is_reference_directive(&comment_text) {
+      directives.push(comment_text);
+    }
+  }
+
+  directives
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_reference_directive() {
+    assert!(is_reference_directive("/// <reference path=\"foo\" />"));
+    assert!(is_reference_directive("/// <reference types=\"bar\" />"));
+    assert!(!is_reference_directive("// regular comment"));
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/codegen.rs
+++ b/crates/rolldown_plugin_fake_js/src/codegen.rs
@@ -1,0 +1,55 @@
+use oxc::allocator::Allocator;
+use oxc::ast::ast::Program;
+use oxc::codegen::Codegen;
+
+pub struct RuntimeBindingGenerator<'a> {
+  #[expect(dead_code)]
+  allocator: &'a Allocator,
+}
+
+impl<'a> RuntimeBindingGenerator<'a> {
+  #[expect(dead_code)]
+  pub fn new(allocator: &'a Allocator) -> Self {
+    Self { allocator }
+  }
+
+  pub fn generate_runtime_binding(
+    binding_name: &str,
+    decl_id: usize,
+    deps: &[String],
+    type_params: &[String],
+    has_side_effect: bool,
+  ) -> String {
+    let mut elements =
+      vec![format!("{decl_id}"), Self::format_deps_function(deps, type_params), "[]".to_string()];
+
+    if has_side_effect {
+      elements.push("sideEffect()".to_string());
+    }
+
+    format!("var {} = [{}]", binding_name, elements.join(", "))
+  }
+
+  fn format_deps_function(deps: &[String], type_params: &[String]) -> String {
+    let params = if type_params.is_empty() { String::new() } else { type_params.join(", ") };
+
+    let deps_str = if deps.is_empty() { String::new() } else { deps.join(", ") };
+
+    format!("({params}) => [{deps_str}]")
+  }
+
+  #[expect(dead_code)]
+  pub fn generate_code(program: &Program<'a>) -> String {
+    Codegen::new().build(program).code
+  }
+}
+
+pub fn extract_source_text(source: &str, start: u32, end: u32) -> String {
+  let start = start as usize;
+  let end = end as usize;
+  if start < source.len() && end <= source.len() && start < end {
+    source[start..end].to_string()
+  } else {
+    String::new()
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/codegen.rs
+++ b/crates/rolldown_plugin_fake_js/src/codegen.rs
@@ -1,0 +1,482 @@
+use oxc::allocator::Allocator;
+use oxc::ast::ast::Program;
+use oxc::codegen::{Codegen, CodegenOptions, IndentChar};
+use oxc::parser::Parser;
+use oxc::span::{SourceType, Span};
+use oxc_sourcemap::SourceMap;
+
+pub struct RuntimeBindingGenerator<'a> {
+  #[expect(dead_code)]
+  allocator: &'a Allocator,
+}
+
+impl<'a> RuntimeBindingGenerator<'a> {
+  #[expect(dead_code)]
+  pub fn new(allocator: &'a Allocator) -> Self {
+    Self { allocator }
+  }
+
+  pub fn generate_runtime_binding(
+    binding_names: &[String],
+    decl_id: usize,
+    deps: &[String],
+    type_params: &[String],
+    children: &[(u32, u32)],
+    has_side_effect: bool,
+  ) -> String {
+    let binding_name = binding_names.first().map(String::as_str).unwrap_or("_");
+    let children_str = if children.is_empty() {
+      "[]".to_string()
+    } else {
+      // Flat `[start,end,…]` wire format (not nested pairs). Quote restore uses
+      // transform-time `child_literals`, not these bundled elements.
+      let pairs: Vec<String> =
+        children.iter().flat_map(|(s, e)| [s.to_string(), e.to_string()]).collect();
+      format!("[{}]", pairs.join(", "))
+    };
+
+    let mut elements =
+      vec![format!("{decl_id}"), Self::format_deps_function(deps, type_params), children_str];
+
+    if has_side_effect {
+      // Pass the binding so Rolldown treats the call as a live reference and keeps the
+      // runtime binding (needed to restore `declare global` / `declare module`).
+      elements.push(format!("sideEffect({binding_name})"));
+    }
+
+    // Extra declarators without init so multi-binding `const a, b` can be renamed by Rolldown
+    // (`var a = [...], b`).
+    let mut decl_parts = vec![format!("{} = [{}]", binding_name, elements.join(", "))];
+    for extra in binding_names.iter().skip(1) {
+      decl_parts.push(extra.clone());
+    }
+    format!("var {}", decl_parts.join(", "))
+  }
+
+  fn format_deps_function(deps: &[String], type_params: &[String]) -> String {
+    let params = if type_params.is_empty() { String::new() } else { type_params.join(", ") };
+
+    let deps_str = if deps.is_empty() { String::new() } else { deps.join(", ") };
+
+    format!("({params}) => [{deps_str}]")
+  }
+
+  #[expect(dead_code)]
+  pub fn generate_code(program: &Program<'a>) -> String {
+    Codegen::new().build(program).code
+  }
+}
+
+pub fn generate_code_from_source(source: &str) -> String {
+  let allocator = Allocator::default();
+  let source_type = SourceType::d_ts();
+  let parser = Parser::new(&allocator, source, source_type);
+  let parse_result = parser.parse();
+
+  if parse_result.panicked {
+    return source.to_string();
+  }
+
+  let options =
+    CodegenOptions { indent_char: IndentChar::Space, indent_width: 2, ..Default::default() };
+
+  let codegen_result =
+    Codegen::new().with_options(options).with_source_text(source).build(&parse_result.program);
+
+  fix_enum_trailing_punctuation(&fix_enum_indentation(&codegen_result.code))
+}
+
+/// Remove trailing commas / post-brace semicolons that oxc adds for const enums.
+fn fix_enum_trailing_punctuation(code: &str) -> String {
+  let lines: Vec<&str> = code.lines().collect();
+  let mut out = Vec::with_capacity(lines.len());
+  let mut in_enum = false;
+  let mut depth = 0i32;
+
+  for line in lines {
+    let trimmed = line.trim();
+    if !in_enum
+      && (trimmed.contains(" enum ")
+        || trimmed.starts_with("enum ")
+        || trimmed.starts_with("declare enum ")
+        || trimmed.starts_with("declare const enum ")
+        || trimmed.starts_with("const enum "))
+      && trimmed.contains('{')
+    {
+      in_enum = true;
+      depth = 0;
+    }
+
+    if in_enum {
+      for ch in trimmed.chars() {
+        if ch == '{' {
+          depth += 1;
+        } else if ch == '}' {
+          depth -= 1;
+        }
+      }
+
+      if depth <= 0 && trimmed.starts_with('}') {
+        // oxc emits `};` after enum bodies; strip the semicolon.
+        let indent_len = line.len() - line.trim_start().len();
+        let indent = &line[..indent_len];
+        out.push(format!("{indent}}}"));
+        in_enum = false;
+        continue;
+      }
+    }
+
+    out.push(line.to_string());
+  }
+
+  let joined = out.join("\n");
+  let re = regex::Regex::new(r",(\s*\n\s*})").unwrap();
+  re.replace_all(&joined, "$1").to_string()
+}
+
+/// Fix oxc_codegen adding extra indentation before `enum` inside namespaces.
+/// e.g., `  export   enum F {}` → `  export enum F {}`
+/// and `    enum Shadowed2 {}` → `  enum Shadowed2 {}` (when inside a namespace)
+fn fix_enum_indentation(code: &str) -> String {
+  let re_export_enum = regex::Regex::new(r"(\bexport)\s{2,}(enum\b)").unwrap();
+  let mut result = Vec::new();
+  let mut in_namespace = false;
+  let mut brace_depth = 0;
+
+  for line in code.lines() {
+    let fixed = re_export_enum.replace_all(line, "$1 $2").to_string();
+
+    let trimmed = fixed.trim();
+    if trimmed.starts_with("declare namespace ") || trimmed.starts_with("namespace ") {
+      in_namespace = true;
+      brace_depth = 0;
+    }
+
+    if in_namespace {
+      for ch in trimmed.chars() {
+        if ch == '{' {
+          brace_depth += 1;
+        } else if ch == '}' {
+          brace_depth -= 1;
+          if brace_depth <= 0 {
+            in_namespace = false;
+          }
+        }
+      }
+
+      // oxc over-indents `enum` inside namespaces (4 spaces → 2).
+      if trimmed.starts_with("enum ") {
+        let indent_len = fixed.len() - fixed.trim_start().len();
+        if indent_len >= 4 {
+          let new_indent = &fixed[..indent_len - 2];
+          result.push(format!("{new_indent}{trimmed}"));
+          continue;
+        }
+      }
+    }
+
+    result.push(fixed);
+  }
+  result.join("\n")
+}
+
+pub fn extract_span_text(source: &str, span: Span) -> String {
+  if (span.end as usize) <= source.len() && span.start < span.end {
+    span.source_text(source).to_string()
+  } else {
+    String::new()
+  }
+}
+
+pub fn extract_source_text(source: &str, start: u32, end: u32) -> String {
+  extract_span_text(source, Span::new(start, end))
+}
+
+pub fn generate_code_with_source_map(
+  source: &str,
+  source_path: &str,
+) -> (String, Option<SourceMap<'static>>) {
+  let allocator = Allocator::default();
+  let source_type = SourceType::d_ts();
+  let parser = Parser::new(&allocator, source, source_type);
+  let parse_result = parser.parse();
+
+  if parse_result.panicked {
+    return (source.to_string(), None);
+  }
+
+  let options =
+    CodegenOptions { indent_char: IndentChar::Space, indent_width: 2, ..Default::default() };
+
+  let codegen_result = Codegen::new()
+    .with_options(CodegenOptions {
+      source_map_path: Some(source_path.into()),
+      indent_char: options.indent_char,
+      indent_width: options.indent_width,
+      ..options
+    })
+    .with_source_text(source)
+    .build(&parse_result.program);
+
+  (
+    fix_enum_trailing_punctuation(&fix_enum_indentation(&codegen_result.code)),
+    codegen_result.map.map(SourceMap::into_owned),
+  )
+}
+
+pub fn generate_declaration_from_source(source: &str) -> String {
+  let source = source.trim_end();
+
+  if source.is_empty() {
+    return String::new();
+  }
+
+  let leading_comments = extract_leading_comments(source);
+
+  let declaration_without_comments = prepare_declaration_body(source);
+
+  // Preserve multi-line var declarators (oxc_codegen collapses them to one line).
+  let result = if should_preserve_var_decl_formatting(&declaration_without_comments) {
+    let mut preserved = declaration_without_comments.trim_end().to_string();
+    if !preserved.ends_with(';') {
+      preserved.push(';');
+    }
+    preserved
+  } else {
+    let regenerated = generate_code_from_source(&declaration_without_comments);
+    let result = regenerated.trim_end().to_string();
+    let result = collapse_generic_params(&result);
+    let result = fix_jsdoc_star_indent(&result);
+    expand_multi_declarator_var(&result)
+  };
+
+  if leading_comments.is_empty() {
+    result
+  } else {
+    format!("{}\n{}", leading_comments.join("\n"), result)
+  }
+}
+
+pub fn generate_declaration_with_source_map(
+  source: &str,
+  source_path: &str,
+) -> (String, Option<SourceMap<'static>>) {
+  let source = source.trim_end();
+  if source.is_empty() {
+    return (String::new(), None);
+  }
+
+  let leading_comments = extract_leading_comments(source);
+  let declaration_without_comments = prepare_declaration_body(source);
+  let (regenerated, map) =
+    generate_code_with_source_map(&declaration_without_comments, source_path);
+  let mut result = regenerated.trim_end().to_string();
+  result = collapse_generic_params(&result);
+  result = fix_jsdoc_star_indent(&result);
+
+  let result = if leading_comments.is_empty() {
+    result
+  } else {
+    format!("{}\n{}", leading_comments.join("\n"), result)
+  };
+  (result, map)
+}
+
+/// Expand initializer multi-declarators to Babel-style multiline
+/// (`declare const a = 3, b = 3;` → broken across lines). Type-annotated forms stay one line.
+fn expand_multi_declarator_var(code: &str) -> String {
+  let re =
+    regex::Regex::new(r"(?m)^(declare\s+(?:const|let|var)\s+)([^;\n]+,[^;\n]+);?\s*$").unwrap();
+  re.replace_all(code, |caps: &regex::Captures| {
+    let prefix = &caps[1];
+    let body = caps[2].trim();
+    if !body.contains('=') {
+      return caps[0].to_string();
+    }
+    let parts: Vec<&str> = body.split(", ").collect();
+    if parts.len() < 2 {
+      return caps[0].to_string();
+    }
+    let mut out = String::new();
+    out.push_str(prefix);
+    for (i, part) in parts.iter().enumerate() {
+      if i > 0 {
+        out.push_str(",\n  ");
+      }
+      out.push_str(part.trim());
+    }
+    out.push(';');
+    out
+  })
+  .to_string()
+}
+
+/// True when we must keep original multi-line var formatting (oxc_codegen collapses it).
+fn should_preserve_var_decl_formatting(source: &str) -> bool {
+  let trimmed = source.trim_start();
+  // `declare const enum` also starts with `declare const `.
+  if trimmed.contains(" enum ") || trimmed.contains("\nenum ") {
+    return false;
+  }
+  let is_var = trimmed.starts_with("declare const ")
+    || trimmed.starts_with("declare let ")
+    || trimmed.starts_with("declare var ")
+    || trimmed.starts_with("const ")
+    || trimmed.starts_with("let ")
+    || trimmed.starts_with("var ");
+  is_var && (source.contains(",\n") || source.contains(",\r\n"))
+}
+
+fn prepare_declaration_body(source: &str) -> String {
+  let trimmed_start = source.trim_start();
+  if trimmed_start.starts_with("declare ") {
+    source.to_string()
+  } else if trimmed_start.starts_with("export declare ") {
+    let without_export = trimmed_start.strip_prefix("export ").unwrap();
+    without_export.to_string()
+  } else if trimmed_start.starts_with("export default ") {
+    let without_export_default = trimmed_start.strip_prefix("export default ").unwrap();
+    if without_export_default.starts_with("class ")
+      || without_export_default.starts_with("abstract ")
+      || without_export_default.starts_with("function ")
+      || without_export_default.starts_with("function<")
+      || without_export_default.starts_with("function(")
+    {
+      format!("declare {without_export_default}")
+    } else {
+      without_export_default.to_string()
+    }
+  } else if trimmed_start.starts_with("export ") {
+    let without_export = trimmed_start.strip_prefix("export ").unwrap();
+    if without_export.starts_with("type ") || without_export.starts_with("interface ") {
+      without_export.to_string()
+    } else {
+      format!("declare {without_export}")
+    }
+  } else if trimmed_start.starts_with("type ") || trimmed_start.starts_with("interface ") {
+    source.to_string()
+  } else {
+    format!("declare {trimmed_start}")
+  }
+}
+
+fn extract_leading_comments(source: &str) -> Vec<String> {
+  let mut comments = Vec::new();
+  let mut in_block_comment = false;
+  let mut block_comment_lines = Vec::new();
+
+  for line in source.lines() {
+    let trimmed = line.trim();
+
+    if in_block_comment {
+      block_comment_lines.push(line.to_string());
+      if trimmed.contains("*/") {
+        comments.append(&mut block_comment_lines);
+        in_block_comment = false;
+      }
+      continue;
+    }
+
+    if trimmed.starts_with("/**") || trimmed.starts_with("/*") {
+      in_block_comment = true;
+      block_comment_lines.push(line.to_string());
+      if trimmed.contains("*/") {
+        comments.append(&mut block_comment_lines);
+        in_block_comment = false;
+      }
+      continue;
+    }
+
+    if trimmed.starts_with("//") {
+      comments.push(line.to_string());
+      continue;
+    }
+
+    if trimmed.is_empty() {
+      if !comments.is_empty() {
+        comments.push(String::new());
+      }
+      continue;
+    }
+
+    break;
+  }
+
+  while comments.last().is_some_and(|l| l.trim().is_empty()) {
+    comments.pop();
+  }
+
+  comments
+}
+
+/// Fix oxc_codegen JSDoc formatting where continuation stars lose one space:
+/// `  /**` / `  * foo` → `  /**` / `   * foo`
+fn fix_jsdoc_star_indent(code: &str) -> String {
+  let lines: Vec<&str> = code.lines().collect();
+  let mut out: Vec<String> = Vec::with_capacity(lines.len());
+  let mut i = 0;
+  while i < lines.len() {
+    let line = lines[i];
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("/**") && !trimmed.contains("*/") {
+      let indent = line.len() - trimmed.len();
+      out.push(line.to_string());
+      i += 1;
+      let star_indent = " ".repeat(indent + 1);
+      while i < lines.len() {
+        let cont = lines[i];
+        let cont_trim = cont.trim_start();
+        if cont_trim.starts_with('*') {
+          out.push(format!("{star_indent}{cont_trim}"));
+          let done = cont_trim.contains("*/");
+          i += 1;
+          if done {
+            break;
+          }
+        } else {
+          break;
+        }
+      }
+      continue;
+    }
+    out.push(line.to_string());
+    i += 1;
+  }
+  let mut result = out.join("\n");
+  if code.ends_with('\n') {
+    result.push('\n');
+  }
+  result
+}
+
+fn collapse_generic_params(code: &str) -> String {
+  let re = regex::Regex::new(r"<\n(\s+\w[^>]*)\n\s*>").unwrap();
+  re.replace_all(code, |caps: &regex::Captures| {
+    let inner = caps[1].trim();
+    let collapsed = inner.split('\n').map(str::trim).collect::<Vec<_>>().join(" ");
+    format!("<{collapsed}>")
+  })
+  .to_string()
+}
+
+#[cfg(test)]
+mod declaration_codegen_tests {
+  use super::*;
+
+  #[test]
+  fn test_extract_span_text() {
+    let code = "hello world";
+    let span = Span::new(0, 5);
+    assert_eq!(extract_span_text(code, span), "hello");
+    assert_eq!(extract_source_text(code, 6, 11), "world");
+  }
+
+  #[test]
+  fn test_generate_declaration_with_source_map() {
+    let (code, map) =
+      generate_declaration_with_source_map("export interface Obj { x: number }", "foo.ts");
+    assert!(code.contains("interface Obj"));
+    assert!(map.is_some());
+    assert!(!map.unwrap().to_json_string().contains("\"mappings\":\"\""));
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/dependencies.rs
+++ b/crates/rolldown_plugin_fake_js/src/dependencies.rs
@@ -1,0 +1,330 @@
+use oxc::ast::ast::{
+  Class, ExportNamedDeclaration, Expression, ModuleExportName, PropertyKey, TSConditionalType,
+  TSImportType, TSImportTypeQualifiedName, TSImportTypeQualifier, TSInterfaceHeritage,
+  TSMethodSignature, TSPropertySignature, TSQualifiedName, TSType, TSTypeName, TSTypeParameter,
+  TSTypeQuery, TSTypeQueryExprName, TSTypeReference,
+};
+use oxc::ast_visit::Visit;
+use std::collections::HashSet;
+
+#[derive(Debug, Clone)]
+#[expect(dead_code)]
+pub struct ImportTypeInfo {
+  pub source: String,
+  pub qualifier: Option<String>,
+}
+
+pub struct DependencyCollector<'a> {
+  pub deps: HashSet<String>,
+  pub import_types: Vec<ImportTypeInfo>,
+  bindings: HashSet<String>,
+  inferred_stack: Vec<Vec<String>>,
+  current_inferred: HashSet<String>,
+  _phantom: std::marker::PhantomData<&'a ()>,
+}
+
+impl DependencyCollector<'_> {
+  pub fn new(bindings: Vec<String>) -> Self {
+    Self {
+      deps: HashSet::new(),
+      import_types: Vec::new(),
+      bindings: bindings.into_iter().collect(),
+      inferred_stack: Vec::new(),
+      current_inferred: HashSet::new(),
+      _phantom: std::marker::PhantomData,
+    }
+  }
+
+  fn is_inferred(&self, name: &str) -> bool {
+    self.current_inferred.contains(name)
+  }
+
+  fn is_binding(&self, name: &str) -> bool {
+    self.bindings.contains(name)
+  }
+
+  fn is_builtin(name: &str) -> bool {
+    matches!(
+      name,
+      "String"
+        | "Number"
+        | "Boolean"
+        | "Array"
+        | "Object"
+        | "Function"
+        | "Promise"
+        | "Record"
+        | "Partial"
+        | "Required"
+        | "Readonly"
+        | "Pick"
+        | "Omit"
+        | "Exclude"
+        | "Extract"
+        | "NonNullable"
+        | "ReturnType"
+        | "InstanceType"
+        | "ThisType"
+        | "Parameters"
+        | "ConstructorParameters"
+        | "Awaited"
+    )
+  }
+
+  fn add_dependency(&mut self, name: String) {
+    if name != "this"
+      && !self.is_inferred(&name)
+      && !self.is_binding(&name)
+      && !Self::is_builtin(&name)
+    {
+      self.deps.insert(name);
+    }
+  }
+
+  fn extract_type_name(type_name: &TSTypeName) -> Option<String> {
+    match type_name {
+      TSTypeName::IdentifierReference(id) => Some(id.name.to_string()),
+      TSTypeName::QualifiedName(qualified) => Self::extract_qualified_name_root(qualified),
+      TSTypeName::ThisExpression(_) => None,
+    }
+  }
+
+  fn extract_qualified_name_root(qualified: &TSQualifiedName) -> Option<String> {
+    let mut current = qualified;
+    loop {
+      match &current.left {
+        TSTypeName::IdentifierReference(id) => {
+          return Some(id.name.to_string());
+        }
+        TSTypeName::QualifiedName(q) => {
+          current = q;
+        }
+        TSTypeName::ThisExpression(_) => {
+          return None;
+        }
+      }
+    }
+  }
+
+  fn update_current_inferred(&mut self, include_last: bool) {
+    self.current_inferred.clear();
+    let stack_len = self.inferred_stack.len();
+    let limit = if include_last { stack_len } else { stack_len.saturating_sub(1) };
+
+    for i in 0..limit {
+      for name in &self.inferred_stack[i] {
+        self.current_inferred.insert(name.clone());
+      }
+    }
+  }
+
+  fn collect_inferred_names(&self, ts_type: &TSType) -> Vec<String> {
+    let mut inferred = Vec::new();
+    self.collect_inferred_recursive(ts_type, &mut inferred);
+    inferred
+  }
+
+  #[expect(clippy::self_only_used_in_recursion)]
+  fn collect_inferred_recursive(&self, ts_type: &TSType, inferred: &mut Vec<String>) {
+    match ts_type {
+      TSType::TSInferType(infer) => {
+        inferred.push(infer.type_parameter.name.name.to_string());
+      }
+      TSType::TSUnionType(union) => {
+        for t in &union.types {
+          self.collect_inferred_recursive(t, inferred);
+        }
+      }
+      TSType::TSIntersectionType(intersection) => {
+        for t in &intersection.types {
+          self.collect_inferred_recursive(t, inferred);
+        }
+      }
+      TSType::TSConditionalType(cond) => {
+        self.collect_inferred_recursive(&cond.extends_type, inferred);
+      }
+      _ => {}
+    }
+  }
+}
+
+impl<'a> Visit<'a> for DependencyCollector<'a> {
+  fn visit_ts_type_reference(&mut self, node: &TSTypeReference<'a>) {
+    if let Some(name) = Self::extract_type_name(&node.type_name) {
+      self.add_dependency(name);
+    }
+
+    if let Some(type_args) = &node.type_arguments {
+      for param in &type_args.params {
+        self.visit_ts_type(param);
+      }
+    }
+  }
+
+  fn visit_ts_type_query(&mut self, node: &TSTypeQuery<'a>) {
+    match &node.expr_name {
+      TSTypeQueryExprName::IdentifierReference(id) => {
+        self.add_dependency(id.name.to_string());
+      }
+      TSTypeQueryExprName::QualifiedName(qualified) => {
+        if let Some(name) = Self::extract_qualified_name_root(qualified) {
+          self.add_dependency(name);
+        }
+      }
+      TSTypeQueryExprName::TSImportType(_) | TSTypeQueryExprName::ThisExpression(_) => {}
+    }
+  }
+
+  fn visit_ts_conditional_type(&mut self, node: &TSConditionalType<'a>) {
+    let inferred = self.collect_inferred_names(&node.extends_type);
+    self.inferred_stack.push(inferred);
+    self.visit_ts_type(&node.check_type);
+    self.visit_ts_type(&node.extends_type);
+    self.update_current_inferred(true);
+    self.visit_ts_type(&node.true_type);
+    self.update_current_inferred(false);
+    self.visit_ts_type(&node.false_type);
+    self.inferred_stack.pop();
+    self.current_inferred.clear();
+  }
+
+  fn visit_ts_interface_heritage(&mut self, node: &TSInterfaceHeritage<'a>) {
+    match &node.expression {
+      Expression::Identifier(id) => {
+        self.add_dependency(id.name.to_string());
+      }
+      Expression::StaticMemberExpression(member) => {
+        if let Expression::Identifier(id) = &member.object {
+          self.add_dependency(id.name.to_string());
+        }
+      }
+      _ => {}
+    }
+
+    if let Some(type_args) = &node.type_arguments {
+      for param in &type_args.params {
+        self.visit_ts_type(param);
+      }
+    }
+  }
+
+  fn visit_class(&mut self, node: &Class<'a>) {
+    if let Some(Expression::Identifier(id)) = &node.super_class {
+      self.add_dependency(id.name.to_string());
+    }
+
+    for implement in &node.implements {
+      if let Some(name) = Self::extract_type_name(&implement.expression) {
+        self.add_dependency(name);
+      }
+
+      if let Some(type_args) = &implement.type_arguments {
+        for param in &type_args.params {
+          self.visit_ts_type(param);
+        }
+      }
+    }
+
+    if let Some(type_params) = &node.type_parameters {
+      for param in &type_params.params {
+        if let Some(constraint) = &param.constraint {
+          self.visit_ts_type(constraint);
+        }
+        if let Some(default) = &param.default {
+          self.visit_ts_type(default);
+        }
+      }
+    }
+
+    self.visit_class_body(&node.body);
+  }
+
+  fn visit_ts_import_type(&mut self, node: &TSImportType<'a>) {
+    let source_value = node.source.value.to_string();
+
+    let qualifier = node.qualifier.as_ref().and_then(|q| match q {
+      TSImportTypeQualifier::Identifier(id) => Some(id.name.to_string()),
+      TSImportTypeQualifier::QualifiedName(qn) => {
+        fn get_leftmost(q: &TSImportTypeQualifiedName) -> Option<String> {
+          match &q.left {
+            TSImportTypeQualifier::Identifier(id) => Some(id.name.to_string()),
+            TSImportTypeQualifier::QualifiedName(inner) => get_leftmost(inner),
+          }
+        }
+        get_leftmost(qn)
+      }
+    });
+
+    self.import_types.push(ImportTypeInfo { source: source_value, qualifier: qualifier.clone() });
+
+    if let Some(name) = qualifier {
+      self.add_dependency(name);
+    }
+
+    if let Some(type_args) = &node.type_arguments {
+      for param in &type_args.params {
+        self.visit_ts_type(param);
+      }
+    }
+  }
+
+  fn visit_ts_type_parameter(&mut self, node: &TSTypeParameter<'a>) {
+    if let Some(constraint) = &node.constraint {
+      self.visit_ts_type(constraint);
+    }
+    if let Some(default) = &node.default {
+      self.visit_ts_type(default);
+    }
+  }
+
+  fn visit_export_named_declaration(&mut self, node: &ExportNamedDeclaration<'a>) {
+    for specifier in &node.specifiers {
+      let name = match &specifier.local {
+        ModuleExportName::IdentifierName(id) => id.name.to_string(),
+        ModuleExportName::IdentifierReference(id) => id.name.to_string(),
+        ModuleExportName::StringLiteral(lit) => lit.value.to_string(),
+      };
+      self.add_dependency(name);
+    }
+
+    if let Some(decl) = &node.declaration {
+      self.visit_declaration(decl);
+    }
+  }
+
+  fn visit_ts_property_signature(&mut self, node: &TSPropertySignature<'a>) {
+    if node.computed {
+      if let PropertyKey::StaticIdentifier(id) = &node.key {
+        self.add_dependency(id.name.to_string());
+      }
+    }
+
+    if let Some(type_ann) = &node.type_annotation {
+      self.visit_ts_type(&type_ann.type_annotation);
+    }
+  }
+
+  fn visit_ts_method_signature(&mut self, node: &TSMethodSignature<'a>) {
+    if node.computed {
+      if let PropertyKey::StaticIdentifier(id) = &node.key {
+        self.add_dependency(id.name.to_string());
+      }
+    }
+
+    if let Some(return_type) = &node.return_type {
+      self.visit_ts_type(&return_type.type_annotation);
+    }
+
+    if let Some(param) = &node.this_param {
+      if let Some(type_ann) = &param.type_annotation {
+        self.visit_ts_type(&type_ann.type_annotation);
+      }
+    }
+
+    if let Some(type_params) = &node.type_parameters {
+      for param in &type_params.params {
+        self.visit_ts_type_parameter(param);
+      }
+    }
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/dependencies.rs
+++ b/crates/rolldown_plugin_fake_js/src/dependencies.rs
@@ -1,0 +1,564 @@
+use oxc::ast::ast::{
+  Class, ExportNamedDeclaration, Expression, IdentifierReference, MethodDefinition,
+  ModuleExportName, PropertyDefinition, PropertyKey, TSConditionalType, TSImportType,
+  TSImportTypeQualifiedName, TSImportTypeQualifier, TSInferType, TSInterfaceHeritage,
+  TSMethodSignature, TSPropertySignature, TSQualifiedName, TSType, TSTypeName, TSTypeParameter,
+  TSTypeQuery, TSTypeQueryExprName, TSTypeReference,
+};
+use oxc::ast_visit::Visit;
+use oxc::span::GetSpan;
+use rustc_hash::FxHashSet;
+
+#[derive(Debug, Clone)]
+#[expect(dead_code)]
+pub struct ImportTypeInfo {
+  pub source: String,
+  pub qualifier: Option<String>,
+}
+
+pub struct DependencyCollector<'a> {
+  pub deps: Vec<String>,
+  pub dep_refs: Vec<(String, u32, u32)>,
+  pub children: Vec<(u32, u32)>,
+  pub import_types: Vec<ImportTypeInfo>,
+  bindings: FxHashSet<String>,
+  dep_spans: FxHashSet<(u32, u32)>,
+  inferred_stack: Vec<Vec<String>>,
+  current_inferred: FxHashSet<String>,
+  _phantom: std::marker::PhantomData<&'a ()>,
+}
+
+impl DependencyCollector<'_> {
+  pub fn new(bindings: Vec<String>) -> Self {
+    Self {
+      deps: Vec::new(),
+      dep_refs: Vec::new(),
+      children: Vec::new(),
+      import_types: Vec::new(),
+      bindings: bindings.into_iter().collect(),
+      dep_spans: FxHashSet::default(),
+      inferred_stack: Vec::new(),
+      current_inferred: FxHashSet::default(),
+      _phantom: std::marker::PhantomData,
+    }
+  }
+
+  fn consider_child(&mut self, start: u32, end: u32) {
+    let key = (start, end);
+    if self.dep_spans.insert(key) {
+      self.children.push(key);
+    }
+  }
+
+  fn is_inferred(&self, name: &str) -> bool {
+    self.current_inferred.contains(name)
+  }
+
+  fn is_binding(&self, name: &str) -> bool {
+    self.bindings.contains(name)
+  }
+
+  fn is_builtin(name: &str) -> bool {
+    matches!(
+      name,
+      "String"
+        | "Number"
+        | "Boolean"
+        | "Array"
+        | "Object"
+        | "Function"
+        | "Promise"
+        | "Record"
+        | "Partial"
+        | "Required"
+        | "Readonly"
+        | "Pick"
+        | "Omit"
+        | "Exclude"
+        | "Extract"
+        | "NonNullable"
+        | "ReturnType"
+        | "InstanceType"
+        | "ThisType"
+        | "Parameters"
+        | "ConstructorParameters"
+        | "Awaited"
+        | "PropertyDescriptor"
+        | "PropertyKey"
+        | "ClassDecorator"
+        | "MethodDecorator"
+    )
+  }
+
+  fn add_dependency(&mut self, name: String) {
+    if name != "this"
+      && !self.is_inferred(&name)
+      && !self.is_binding(&name)
+      && !Self::is_builtin(&name)
+      && !self.deps.iter().any(|dep| dep == &name)
+    {
+      self.deps.push(name);
+    }
+  }
+
+  fn add_dependency_at(&mut self, name: String, start: u32, end: u32) {
+    if name != "this"
+      && !self.is_inferred(&name)
+      && !self.is_binding(&name)
+      && !Self::is_builtin(&name)
+    {
+      if !self.deps.iter().any(|dep| dep == &name) {
+        self.deps.push(name.clone());
+      }
+      self.dep_refs.push((name, start, end));
+      self.dep_spans.insert((start, end));
+    }
+  }
+
+  fn collect_computed_key_deps(&mut self, key: &PropertyKey<'_>) {
+    match key {
+      PropertyKey::StaticIdentifier(id) => {
+        self.add_dependency_at(id.name.to_string(), id.span.start, id.span.end);
+      }
+      PropertyKey::Identifier(id) => {
+        self.add_dependency_at(id.name.to_string(), id.span.start, id.span.end);
+      }
+      PropertyKey::StaticMemberExpression(member) => {
+        let mut object = &member.object;
+        loop {
+          match object {
+            Expression::Identifier(id) => {
+              self.add_dependency_at(id.name.to_string(), id.span.start, id.span.end);
+              break;
+            }
+            Expression::StaticMemberExpression(inner) => {
+              object = &inner.object;
+            }
+            _ => break,
+          }
+        }
+      }
+      PropertyKey::StringLiteral(lit) => {
+        self.consider_child(lit.span.start, lit.span.end);
+      }
+      _ => {}
+    }
+  }
+
+  fn extract_qualified_name_root(qualified: &TSQualifiedName) -> Option<(String, u32, u32)> {
+    let mut current = qualified;
+    loop {
+      match &current.left {
+        TSTypeName::IdentifierReference(id) => {
+          return Some((id.name.to_string(), id.span.start, id.span.end));
+        }
+        TSTypeName::QualifiedName(q) => {
+          current = q;
+        }
+        TSTypeName::ThisExpression(_) => {
+          return None;
+        }
+      }
+    }
+  }
+
+  fn update_current_inferred(&mut self, include_last: bool) {
+    self.current_inferred.clear();
+    let stack_len = self.inferred_stack.len();
+    let limit = if include_last { stack_len } else { stack_len.saturating_sub(1) };
+
+    for i in 0..limit {
+      for name in &self.inferred_stack[i] {
+        self.current_inferred.insert(name.clone());
+      }
+    }
+  }
+
+  fn collect_inferred_names(&self, ts_type: &TSType) -> Vec<String> {
+    let mut inferred = Vec::new();
+    self.collect_inferred_recursive(ts_type, &mut inferred);
+    inferred
+  }
+
+  #[expect(clippy::self_only_used_in_recursion)]
+  fn collect_inferred_recursive(&self, ts_type: &TSType, inferred: &mut Vec<String>) {
+    match ts_type {
+      TSType::TSInferType(infer) => {
+        inferred.push(infer.type_parameter.name.name.to_string());
+      }
+      TSType::TSUnionType(union) => {
+        for t in &union.types {
+          self.collect_inferred_recursive(t, inferred);
+        }
+      }
+      TSType::TSIntersectionType(intersection) => {
+        for t in &intersection.types {
+          self.collect_inferred_recursive(t, inferred);
+        }
+      }
+      TSType::TSConditionalType(cond) => {
+        self.collect_inferred_recursive(&cond.extends_type, inferred);
+      }
+      TSType::TSTypeReference(type_ref) => {
+        if let Some(type_args) = &type_ref.type_arguments {
+          for param in &type_args.params {
+            self.collect_inferred_recursive(param, inferred);
+          }
+        }
+      }
+      TSType::TSTypeOperatorType(op) => {
+        self.collect_inferred_recursive(&op.type_annotation, inferred);
+      }
+      TSType::TSArrayType(array) => {
+        self.collect_inferred_recursive(&array.element_type, inferred);
+      }
+      _ => {}
+    }
+  }
+}
+
+impl<'a> Visit<'a> for DependencyCollector<'a> {
+  // Don't treat `infer U` as a free type ref; scoping is handled via the conditional stack.
+  fn visit_ts_infer_type(&mut self, node: &TSInferType<'a>) {
+    if let Some(constraint) = &node.type_parameter.constraint {
+      self.visit_ts_type(constraint);
+    }
+    if let Some(default) = &node.type_parameter.default {
+      self.visit_ts_type(default);
+    }
+  }
+
+  // Free value ids are children (span bookkeeping), not deps. Deps come from type-name paths.
+  fn visit_identifier_reference(&mut self, node: &IdentifierReference<'a>) {
+    let name = node.name.as_str();
+    let span = node.span;
+    if !self.is_binding(name) && !self.is_inferred(name) && !self.deps.iter().any(|dep| dep == name)
+    {
+      self.consider_child(span.start, span.end);
+    }
+  }
+
+  fn visit_ts_type_reference(&mut self, node: &TSTypeReference<'a>) {
+    if let TSTypeName::IdentifierReference(id) = &node.type_name {
+      self.add_dependency_at(id.name.to_string(), id.span.start, id.span.end);
+    } else if let TSTypeName::QualifiedName(qualified) = &node.type_name {
+      if let Some((name, start, end)) = Self::extract_qualified_name_root(qualified) {
+        self.add_dependency_at(name, start, end);
+      }
+    }
+
+    if let Some(type_args) = &node.type_arguments {
+      for param in &type_args.params {
+        self.visit_ts_type(param);
+      }
+    }
+  }
+
+  fn visit_ts_type_query(&mut self, node: &TSTypeQuery<'a>) {
+    match &node.expr_name {
+      TSTypeQueryExprName::IdentifierReference(id) => {
+        self.add_dependency_at(id.name.to_string(), id.span.start, id.span.end);
+      }
+      TSTypeQueryExprName::QualifiedName(qualified) => {
+        if let Some((name, start, end)) = Self::extract_qualified_name_root(qualified) {
+          self.add_dependency_at(name, start, end);
+        }
+      }
+      TSTypeQueryExprName::TSImportType(_) | TSTypeQueryExprName::ThisExpression(_) => {}
+    }
+  }
+
+  fn visit_ts_conditional_type(&mut self, node: &TSConditionalType<'a>) {
+    let inferred = self.collect_inferred_names(&node.extends_type);
+    self.inferred_stack.push(inferred);
+    self.update_current_inferred(true);
+    self.visit_ts_type(&node.check_type);
+    self.visit_ts_type(&node.extends_type);
+    self.visit_ts_type(&node.true_type);
+    // Drop inferred names before the false branch so outer `U` can still be a dep.
+    self.update_current_inferred(false);
+    self.visit_ts_type(&node.false_type);
+    self.inferred_stack.pop();
+    if self.inferred_stack.is_empty() {
+      self.current_inferred.clear();
+    } else {
+      self.update_current_inferred(true);
+    }
+  }
+
+  fn visit_ts_interface_heritage(&mut self, node: &TSInterfaceHeritage<'a>) {
+    match &node.type_name {
+      TSTypeName::IdentifierReference(id) => {
+        self.add_dependency_at(id.name.to_string(), id.span.start, id.span.end);
+      }
+      TSTypeName::QualifiedName(qualified) => {
+        if let Some((name, start, end)) = Self::extract_qualified_name_root(qualified) {
+          self.add_dependency_at(name, start, end);
+        }
+      }
+      TSTypeName::ThisExpression(_) => {}
+    }
+
+    if let Some(type_args) = &node.type_arguments {
+      for param in &type_args.params {
+        self.visit_ts_type(param);
+      }
+    }
+  }
+
+  fn visit_class(&mut self, node: &Class<'a>) {
+    if let Some(super_class) = node.heritage_expression() {
+      match super_class {
+        Expression::Identifier(id) => {
+          self.add_dependency_at(id.name.to_string(), id.span.start, id.span.end);
+        }
+        Expression::StaticMemberExpression(member) => {
+          let mut object = &member.object;
+          loop {
+            match object {
+              Expression::Identifier(id) => {
+                self.add_dependency_at(id.name.to_string(), id.span.start, id.span.end);
+                break;
+              }
+              Expression::StaticMemberExpression(inner) => {
+                object = &inner.object;
+              }
+              _ => break,
+            }
+          }
+        }
+        _ => {}
+      }
+    }
+
+    for implement in &node.implements {
+      if let Some((name, start, end)) = match &implement.expression {
+        TSTypeName::IdentifierReference(id) => {
+          Some((id.name.to_string(), id.span.start, id.span.end))
+        }
+        TSTypeName::QualifiedName(qualified) => Self::extract_qualified_name_root(qualified),
+        TSTypeName::ThisExpression(_) => None,
+      } {
+        self.add_dependency_at(name, start, end);
+      }
+
+      if let Some(type_args) = &implement.type_arguments {
+        for param in &type_args.params {
+          self.visit_ts_type(param);
+        }
+      }
+    }
+
+    if let Some(type_params) = &node.type_parameters {
+      for param in &type_params.params {
+        if let Some(constraint) = &param.constraint {
+          self.visit_ts_type(constraint);
+        }
+        if let Some(default) = &param.default {
+          self.visit_ts_type(default);
+        }
+      }
+    }
+
+    self.visit_class_body(&node.body);
+  }
+
+  fn visit_ts_import_type(&mut self, node: &TSImportType<'a>) {
+    let source_value = node.source.value.to_string();
+
+    let qualifier = node.qualifier.as_ref().and_then(|q| match q {
+      TSImportTypeQualifier::Identifier(id) => Some(id.name.to_string()),
+      TSImportTypeQualifier::QualifiedName(qn) => {
+        fn get_leftmost(q: &TSImportTypeQualifiedName) -> Option<String> {
+          match &q.left {
+            TSImportTypeQualifier::Identifier(id) => Some(id.name.to_string()),
+            TSImportTypeQualifier::QualifiedName(inner) => get_leftmost(inner),
+          }
+        }
+        get_leftmost(qn)
+      }
+    });
+
+    self.import_types.push(ImportTypeInfo { source: source_value, qualifier: qualifier.clone() });
+
+    if let Some(name) = qualifier {
+      self.add_dependency(name);
+    }
+
+    if let Some(type_args) = &node.type_arguments {
+      for param in &type_args.params {
+        self.visit_ts_type(param);
+      }
+    }
+  }
+
+  fn visit_ts_type_parameter(&mut self, node: &TSTypeParameter<'a>) {
+    if let Some(constraint) = &node.constraint {
+      self.visit_ts_type(constraint);
+    }
+    if let Some(default) = &node.default {
+      self.visit_ts_type(default);
+    }
+  }
+
+  fn visit_export_named_declaration(&mut self, node: &ExportNamedDeclaration<'a>) {
+    for specifier in &node.specifiers {
+      match &specifier.local {
+        ModuleExportName::StringLiteral(lit) => {
+          self.add_dependency(lit.value.to_string());
+        }
+        other => {
+          let span = other.span();
+          self.add_dependency_at(other.name().to_string(), span.start, span.end);
+        }
+      }
+    }
+  }
+
+  fn visit_ts_property_signature(&mut self, node: &TSPropertySignature<'a>) {
+    if node.computed {
+      self.collect_computed_key_deps(&node.key);
+    } else if let PropertyKey::StringLiteral(lit) = &node.key {
+      self.consider_child(lit.span.start, lit.span.end);
+    }
+
+    if let Some(type_ann) = &node.type_annotation {
+      self.visit_ts_type(&type_ann.type_annotation);
+    }
+  }
+
+  fn visit_ts_method_signature(&mut self, node: &TSMethodSignature<'a>) {
+    if node.computed {
+      self.collect_computed_key_deps(&node.key);
+    } else if let PropertyKey::StringLiteral(lit) = &node.key {
+      self.consider_child(lit.span.start, lit.span.end);
+    }
+
+    if let Some(return_type) = &node.return_type {
+      self.visit_ts_type(&return_type.type_annotation);
+    }
+
+    if let Some(param) = &node.this_param {
+      if let Some(type_ann) = &param.type_annotation {
+        self.visit_ts_type(&type_ann.type_annotation);
+      }
+    }
+
+    for param in &node.params.items {
+      if let Some(type_ann) = &param.type_annotation {
+        self.visit_ts_type(&type_ann.type_annotation);
+      }
+    }
+
+    if let Some(type_params) = &node.type_parameters {
+      for param in &type_params.params {
+        self.visit_ts_type_parameter(param);
+      }
+    }
+  }
+
+  fn visit_property_definition(&mut self, node: &PropertyDefinition<'a>) {
+    if node.computed {
+      self.collect_computed_key_deps(&node.key);
+    }
+    if let Some(type_ann) = &node.type_annotation {
+      self.visit_ts_type(&type_ann.type_annotation);
+    }
+    if let Some(value) = &node.value {
+      match value {
+        Expression::Identifier(id) => {
+          self.add_dependency_at(id.name.to_string(), id.span.start, id.span.end);
+        }
+        Expression::StaticMemberExpression(member) => {
+          let mut object = &member.object;
+          loop {
+            match object {
+              Expression::Identifier(id) => {
+                self.add_dependency_at(id.name.to_string(), id.span.start, id.span.end);
+                break;
+              }
+              Expression::StaticMemberExpression(inner) => {
+                object = &inner.object;
+              }
+              _ => break,
+            }
+          }
+        }
+        _ => {}
+      }
+    }
+  }
+
+  fn visit_method_definition(&mut self, node: &MethodDefinition<'a>) {
+    if node.computed {
+      self.collect_computed_key_deps(&node.key);
+    }
+    if let Some(type_ann) = &node.value.return_type {
+      self.visit_ts_type(&type_ann.type_annotation);
+    }
+    for param in &node.value.params.items {
+      if let Some(type_ann) = &param.type_annotation {
+        self.visit_ts_type(&type_ann.type_annotation);
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  use oxc::allocator::Allocator;
+  use oxc::ast_visit::Visit;
+
+  use crate::parser::TypeScriptParser;
+
+  #[test]
+  fn test_typeof_qualified_dep_ref() {
+    let source = "export declare const bar: typeof mod.a;";
+    let allocator = Allocator::default();
+    let parser = TypeScriptParser::new(&allocator);
+    let parse = parser.parse(source, "f.d.ts").unwrap();
+    let mut collector = DependencyCollector::new(vec!["bar".into()]);
+    for stmt in &parse.program.body {
+      collector.visit_statement(stmt);
+    }
+    assert_eq!(collector.deps, vec!["mod"]);
+    assert_eq!(collector.dep_refs.len(), 1);
+    let (name, start, end) = &collector.dep_refs[0];
+    assert_eq!(name, "mod");
+    assert_eq!(&source[*start as usize..*end as usize], "mod");
+  }
+
+  #[test]
+  fn test_infer_false_branch_deps() {
+    let source =
+      "export type Test<T> = T extends Array<infer U> ? (T extends Array<infer U2> ? U2 : U) : U";
+    let allocator = Allocator::default();
+    let parser = TypeScriptParser::new(&allocator);
+    let parse = parser.parse(source, "f.d.ts").unwrap();
+    let mut collector = DependencyCollector::new(vec!["Test".into(), "T".into()]);
+    for stmt in &parse.program.body {
+      collector.visit_statement(stmt);
+    }
+    assert_eq!(collector.deps, vec!["U"]);
+    assert_eq!(collector.dep_refs.len(), 1);
+  }
+
+  #[test]
+  fn test_infer_false_branch_deps_multiline() {
+    let source = "export type Test<T> =\n  T extends Array<infer U> ? (T extends Array<infer U2> ? U2 : U) : U";
+    let allocator = Allocator::default();
+    let parser = TypeScriptParser::new(&allocator);
+    let parse = parser.parse(source, "f.d.ts").unwrap();
+    let mut collector = DependencyCollector::new(vec!["Test".into(), "T".into()]);
+    for stmt in &parse.program.body {
+      collector.visit_statement(stmt);
+    }
+    assert_eq!(collector.deps, vec!["U"]);
+    assert_eq!(collector.dep_refs.len(), 1);
+    let (name, start, end) = &collector.dep_refs[0];
+    assert_eq!(name, "U");
+    assert_eq!(&source[*start as usize..*end as usize], "U");
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/filename.rs
+++ b/crates/rolldown_plugin_fake_js/src/filename.rs
@@ -1,0 +1,22 @@
+use regex::Regex;
+use std::sync::LazyLock;
+
+static RE_DTS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\.d\.(ts|mts|cts)$").unwrap());
+
+pub fn is_dts(filename: &str) -> bool {
+  RE_DTS.is_match(filename)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_is_dts() {
+    assert!(is_dts("foo.d.ts"));
+    assert!(is_dts("foo.d.mts"));
+    assert!(is_dts("foo.d.cts"));
+    assert!(!is_dts("foo.ts"));
+    assert!(!is_dts("foo.js"));
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/filename.rs
+++ b/crates/rolldown_plugin_fake_js/src/filename.rs
@@ -1,0 +1,35 @@
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+static RE_DTS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\.d\.(ts|mts|cts)$").unwrap());
+
+pub fn is_dts(filename: &str) -> bool {
+  RE_DTS.is_match(filename)
+}
+
+pub fn patch_dts_extension(source: &str) -> String {
+  if let Some(base) = source.strip_suffix(".d.ts") {
+    format!("{base}.js")
+  } else if let Some(base) = source.strip_suffix(".d.mts") {
+    format!("{base}.mjs")
+  } else if let Some(base) = source.strip_suffix(".d.cts") {
+    format!("{base}.cjs")
+  } else {
+    source.to_string()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_is_dts() {
+    assert!(is_dts("foo.d.ts"));
+    assert!(is_dts("foo.d.mts"));
+    assert!(is_dts("foo.d.cts"));
+    assert!(!is_dts("foo.ts"));
+    assert!(!is_dts("foo.js"));
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/helpers.rs
+++ b/crates/rolldown_plugin_fake_js/src/helpers.rs
@@ -1,0 +1,255 @@
+use oxc::ast::ast::{
+  CallExpression, ExportNamedDeclaration, Expression, ImportDeclaration, Statement,
+  VariableDeclaration,
+};
+use oxc::span::GetSpan;
+use std::collections::HashMap;
+
+pub struct HelperTransformer;
+
+impl HelperTransformer {
+  pub fn transform_statements(stmts: &[Statement], source: &str) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut export_mappings = HashMap::new();
+
+    for stmt in stmts {
+      Self::collect_export_mappings(stmt, &mut export_mappings);
+    }
+
+    for stmt in stmts {
+      if let Some(transformed) = Self::transform_statement(stmt, source, &export_mappings) {
+        result.push(transformed);
+      }
+    }
+
+    result
+  }
+
+  fn collect_export_mappings(stmt: &Statement, mappings: &mut HashMap<String, String>) {
+    match stmt {
+      Statement::ImportDeclaration(import) => {
+        if let Some(specifiers) = &import.specifiers {
+          if specifiers.len() == 1 {
+            if let Some(oxc::ast::ast::ImportDeclarationSpecifier::ImportSpecifier(spec)) =
+              specifiers.first()
+            {
+              let local_name = spec.local.name.to_string();
+              if local_name.ends_with("_exports") {
+                mappings.insert(local_name.clone(), local_name);
+              }
+            }
+          }
+        }
+      }
+      Statement::ExpressionStatement(expr_stmt) => {
+        if let Expression::CallExpression(call) = &expr_stmt.expression {
+          if Self::is_re_export_call(call) {
+            if let (Some(first_arg), Some(second_arg)) =
+              (call.arguments.first(), call.arguments.get(1))
+            {
+              if let (
+                oxc::ast::ast::Argument::Identifier(first_id),
+                oxc::ast::ast::Argument::Identifier(second_id),
+              ) = (first_arg, second_arg)
+              {
+                mappings.insert(first_id.name.to_string(), second_id.name.to_string());
+              }
+            }
+          }
+        }
+      }
+      _ => {}
+    }
+  }
+
+  fn transform_statement(
+    stmt: &Statement,
+    source: &str,
+    export_mappings: &HashMap<String, String>,
+  ) -> Option<String> {
+    match stmt {
+      Statement::VariableDeclaration(var_decl) if Self::is_member_access(var_decl) => {
+        Self::transform_member_access(var_decl, export_mappings)
+      }
+      Statement::VariableDeclaration(var_decl) => Self::transform_export_all(var_decl, source),
+      Statement::ExportNamedDeclaration(export) => {
+        Self::transform_export_with_mapping(export, source, export_mappings)
+      }
+      Statement::ImportDeclaration(import) if Self::is_helper_import(import) => None,
+      Statement::ExpressionStatement(expr_stmt) => {
+        if let Expression::CallExpression(call) = &expr_stmt.expression {
+          if Self::is_re_export_call(call) {
+            return None;
+          }
+        }
+        Some(Self::extract_text(source, stmt.span()))
+      }
+      _ => Some(Self::extract_text(source, stmt.span())),
+    }
+  }
+
+  fn transform_export_all(var_decl: &VariableDeclaration, source: &str) -> Option<String> {
+    if var_decl.declarations.len() != 1 {
+      return Some(Self::extract_text(source, var_decl.span()));
+    }
+
+    let declarator = &var_decl.declarations[0];
+
+    let init = declarator.init.as_ref()?;
+    if let Expression::CallExpression(call) = init {
+      if !Self::is_export_all_call(call) {
+        return Some(Self::extract_text(source, var_decl.span()));
+      }
+
+      let ns_name = match &declarator.id {
+        oxc::ast::ast::BindingPattern::BindingIdentifier(id) => id.name.to_string(),
+        _ => return Some(Self::extract_text(source, var_decl.span())),
+      };
+
+      if let Some(oxc::ast::ast::Argument::ObjectExpression(obj)) = call.arguments.first() {
+        let mut exports = Vec::new();
+
+        for prop in &obj.properties {
+          if let oxc::ast::ast::ObjectPropertyKind::ObjectProperty(prop) = prop {
+            let exported = match &prop.key {
+              oxc::ast::ast::PropertyKey::Identifier(id) => id.name.to_string(),
+              oxc::ast::ast::PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+              _ => continue,
+            };
+
+            if let Expression::ArrowFunctionExpression(arrow) = &prop.value {
+              if arrow.expression && arrow.body.statements.len() == 1 {
+                if let Some(oxc::ast::ast::Statement::ExpressionStatement(expr_stmt)) =
+                  arrow.body.statements.first()
+                {
+                  if let Expression::Identifier(id) = &expr_stmt.expression {
+                    let local = id.name.to_string();
+                    exports.push(format!("{local} as {exported}"));
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        if exports.is_empty() {
+          return Some(format!("declare namespace {ns_name} {{}}"));
+        }
+
+        return Some(format!(
+          "declare namespace {ns_name} {{ export {{ {} }} }}",
+          exports.join(", ")
+        ));
+      }
+    }
+
+    Some(Self::extract_text(source, var_decl.span()))
+  }
+
+  fn transform_member_access(
+    var_decl: &VariableDeclaration,
+    export_mappings: &HashMap<String, String>,
+  ) -> Option<String> {
+    if var_decl.declarations.len() != 1 {
+      return None;
+    }
+
+    let declarator = &var_decl.declarations[0];
+    let init = declarator.init.as_ref()?;
+
+    if let Some(member) = init.as_member_expression() {
+      if let Expression::Identifier(obj_id) = member.object() {
+        let obj_name = obj_id.name.to_string();
+
+        if let Some(mapped_name) = export_mappings.get(&obj_name) {
+          let binding_name = match &declarator.id {
+            oxc::ast::ast::BindingPattern::BindingIdentifier(id) => id.name.to_string(),
+            _ => return None,
+          };
+
+          if let Some(prop_name) = member.static_property_name() {
+            return Some(format!("type {binding_name} = {mapped_name}.{prop_name}"));
+          }
+        }
+      }
+    }
+
+    None
+  }
+
+  fn transform_export_with_mapping(
+    export: &ExportNamedDeclaration,
+    source: &str,
+    export_mappings: &HashMap<String, String>,
+  ) -> Option<String> {
+    if export.declaration.is_some() {
+      return None;
+    }
+
+    if export.specifiers.len() != 1 {
+      return Some(Self::extract_text(source, export.span()));
+    }
+
+    if let Some(spec) = export.specifiers.first() {
+      let local_name = spec.local.name().to_string();
+
+      if let Some(mapped_name) = export_mappings.get(&local_name) {
+        let exported_name = match &spec.exported {
+          oxc::ast::ast::ModuleExportName::IdentifierName(id) => id.name.to_string(),
+          oxc::ast::ast::ModuleExportName::IdentifierReference(id) => id.name.to_string(),
+          oxc::ast::ast::ModuleExportName::StringLiteral(lit) => lit.value.to_string(),
+        };
+
+        return Some(format!("export {{ {mapped_name} as {exported_name} }}"));
+      }
+    }
+
+    Some(Self::extract_text(source, export.span()))
+  }
+
+  fn is_export_all_call(call: &CallExpression) -> bool {
+    if let Expression::Identifier(id) = &call.callee { id.name == "__exportAll" } else { false }
+  }
+
+  fn is_re_export_call(call: &CallExpression) -> bool {
+    if let Expression::Identifier(id) = &call.callee { id.name == "__reExport" } else { false }
+  }
+
+  fn is_helper_import(import: &ImportDeclaration) -> bool {
+    if let Some(specifiers) = &import.specifiers {
+      if specifiers.len() != 1 {
+        return false;
+      }
+
+      if let Some(oxc::ast::ast::ImportDeclarationSpecifier::ImportSpecifier(spec)) =
+        specifiers.first()
+      {
+        let name = spec.local.name.as_str();
+        return name == "__exportAll" || name == "__reExport";
+      }
+    }
+    false
+  }
+
+  fn is_member_access(var_decl: &VariableDeclaration) -> bool {
+    if var_decl.declarations.len() != 1 {
+      return false;
+    }
+
+    if let Some(init) = &var_decl.declarations[0].init {
+      init.as_member_expression().is_some()
+    } else {
+      false
+    }
+  }
+
+  fn extract_text(source: &str, span: oxc::span::Span) -> String {
+    let start = span.start as usize;
+    let end = span.end as usize;
+    if start < source.len() && end <= source.len() && start < end {
+      source[start..end].to_string()
+    } else {
+      String::new()
+    }
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/helpers.rs
+++ b/crates/rolldown_plugin_fake_js/src/helpers.rs
@@ -1,0 +1,197 @@
+use oxc::ast::ast::{
+  Argument, BindingPattern, CallExpression, Expression, ImportDeclaration,
+  ImportDeclarationSpecifier, ObjectPropertyKind, PropertyKey, Statement, VariableDeclaration,
+};
+use oxc::span::GetSpan;
+use rustc_hash::FxHashMap;
+
+use crate::codegen;
+
+pub struct HelperTransformer;
+
+impl HelperTransformer {
+  pub fn collect_export_mappings_public(
+    stmt: &Statement,
+    mappings: &mut FxHashMap<String, String>,
+  ) {
+    Self::collect_export_mappings(stmt, mappings);
+  }
+
+  pub fn is_helper_import_public(import: &ImportDeclaration) -> bool {
+    Self::is_helper_import(import)
+  }
+
+  pub fn transform_export_all_public(
+    var_decl: &VariableDeclaration,
+    source: &str,
+  ) -> Option<String> {
+    let result = Self::transform_export_all(var_decl, source)?;
+    let original = codegen::extract_span_text(source, var_decl.span());
+    if result == original { None } else { Some(result) }
+  }
+
+  pub fn transform_member_access_public(
+    var_decl: &VariableDeclaration,
+    export_mappings: &FxHashMap<String, String>,
+  ) -> Option<String> {
+    if !Self::is_member_access(var_decl) {
+      return None;
+    }
+    Self::transform_member_access(var_decl, export_mappings)
+  }
+
+  fn collect_export_mappings(stmt: &Statement, mappings: &mut FxHashMap<String, String>) {
+    match stmt {
+      Statement::ImportDeclaration(import) => {
+        if let Some(specifiers) = &import.specifiers {
+          if specifiers.len() == 1 {
+            if let Some(ImportDeclarationSpecifier::ImportSpecifier(spec)) = specifiers.first() {
+              let local_name = spec.local.name.to_string();
+              if local_name.ends_with("_exports") {
+                mappings.insert(local_name.clone(), local_name);
+              }
+            }
+          }
+        }
+      }
+      Statement::ExpressionStatement(expr_stmt) => {
+        if let Expression::CallExpression(call) = &expr_stmt.expression {
+          if Self::is_re_export_call(call) {
+            if let (Some(first_arg), Some(second_arg)) =
+              (call.arguments.first(), call.arguments.get(1))
+            {
+              if let (Argument::Identifier(first_id), Argument::Identifier(second_id)) =
+                (first_arg, second_arg)
+              {
+                mappings.insert(first_id.name.to_string(), second_id.name.to_string());
+              }
+            }
+          }
+        }
+      }
+      _ => {}
+    }
+  }
+
+  fn transform_export_all(var_decl: &VariableDeclaration, source: &str) -> Option<String> {
+    if var_decl.declarations.len() != 1 {
+      return Some(codegen::extract_span_text(source, var_decl.span()));
+    }
+
+    let declarator = &var_decl.declarations[0];
+
+    let init = declarator.init.as_ref()?;
+    if let Expression::CallExpression(call) = init {
+      if !Self::is_export_all_call(call) {
+        return Some(codegen::extract_span_text(source, var_decl.span()));
+      }
+
+      let ns_name = match &declarator.id {
+        BindingPattern::BindingIdentifier(id) => id.name.to_string(),
+        _ => return Some(codegen::extract_span_text(source, var_decl.span())),
+      };
+
+      if let Some(Argument::ObjectExpression(obj)) = call.arguments.first() {
+        let mut exports = Vec::new();
+
+        for prop in &obj.properties {
+          if let ObjectPropertyKind::ObjectProperty(prop) = prop {
+            let exported = match &prop.key {
+              PropertyKey::Identifier(id) => id.name.to_string(),
+              PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+              PropertyKey::StringLiteral(lit) => serde_json::to_string(lit.value.as_str())
+                .unwrap_or_else(|_| format!("\"{}\"", lit.value.escape_default())),
+              _ => continue,
+            };
+            let exported_is_string = matches!(&prop.key, PropertyKey::StringLiteral(_));
+
+            if let Expression::ArrowFunctionExpression(arrow) = &prop.value
+              && let Some(Expression::Identifier(id)) = arrow.get_expression()
+            {
+              let local = id.name.to_string();
+              if !exported_is_string && local == exported {
+                exports.push(local);
+              } else {
+                exports.push(format!("{local} as {exported}"));
+              }
+            }
+          }
+        }
+
+        if exports.is_empty() {
+          return Some(format!("declare namespace {ns_name} {{}}"));
+        }
+
+        let exports_str = exports.join(", ");
+        return Some(format!("declare namespace {ns_name} {{\n  export {{ {exports_str} }};\n}}"));
+      }
+    }
+
+    Some(codegen::extract_span_text(source, var_decl.span()))
+  }
+
+  fn transform_member_access(
+    var_decl: &VariableDeclaration,
+    export_mappings: &FxHashMap<String, String>,
+  ) -> Option<String> {
+    if var_decl.declarations.len() != 1 {
+      return None;
+    }
+
+    let declarator = &var_decl.declarations[0];
+    let init = declarator.init.as_ref()?;
+
+    if let Some(member) = init.as_member_expression() {
+      if let Expression::Identifier(obj_id) = member.object() {
+        let obj_name = obj_id.name.to_string();
+
+        if let Some(mapped_name) = export_mappings.get(&obj_name) {
+          let binding_name = match &declarator.id {
+            BindingPattern::BindingIdentifier(id) => id.name.to_string(),
+            _ => return None,
+          };
+
+          if let Some(prop_name) = member.static_property_name() {
+            return Some(format!("type {binding_name} = {mapped_name}.{prop_name};"));
+          }
+        }
+      }
+    }
+
+    None
+  }
+
+  fn is_export_all_call(call: &CallExpression) -> bool {
+    if let Expression::Identifier(id) = &call.callee { id.name == "__exportAll" } else { false }
+  }
+
+  fn is_re_export_call(call: &CallExpression) -> bool {
+    if let Expression::Identifier(id) = &call.callee { id.name == "__reExport" } else { false }
+  }
+
+  fn is_helper_import(import: &ImportDeclaration) -> bool {
+    if let Some(specifiers) = &import.specifiers {
+      if specifiers.len() != 1 {
+        return false;
+      }
+
+      if let Some(ImportDeclarationSpecifier::ImportSpecifier(spec)) = specifiers.first() {
+        let name = spec.local.name.as_str();
+        return name == "__exportAll" || name == "__reExport";
+      }
+    }
+    false
+  }
+
+  fn is_member_access(var_decl: &VariableDeclaration) -> bool {
+    if var_decl.declarations.len() != 1 {
+      return false;
+    }
+
+    if let Some(init) = &var_decl.declarations[0].init {
+      init.as_member_expression().is_some()
+    } else {
+      false
+    }
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/import_export.rs
+++ b/crates/rolldown_plugin_fake_js/src/import_export.rs
@@ -1,0 +1,178 @@
+use oxc::ast::ast::{
+  ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, Expression,
+  ImportDeclaration, Statement, TSExportAssignment, TSImportEqualsDeclaration,
+};
+use oxc::span::GetSpan;
+
+pub struct ImportExportRewriter;
+
+impl ImportExportRewriter {
+  pub fn rewrite_statement(
+    stmt: &Statement,
+    source: &str,
+    type_only_ids: &mut Vec<String>,
+  ) -> Option<String> {
+    match stmt {
+      Statement::ImportDeclaration(import) => {
+        Self::rewrite_import_declaration(import, source, type_only_ids)
+      }
+      Statement::ExportNamedDeclaration(export) => {
+        Self::rewrite_export_named_declaration(export, source, type_only_ids)
+      }
+      Statement::ExportAllDeclaration(export) => {
+        Self::rewrite_export_all_declaration(export, source)
+      }
+      Statement::ExportDefaultDeclaration(export) => {
+        Self::rewrite_export_default_declaration(export, source)
+      }
+      Statement::TSImportEqualsDeclaration(import_eq) => {
+        Self::rewrite_ts_import_equals(import_eq, source)
+      }
+      Statement::TSExportAssignment(export_assign) => {
+        Self::rewrite_ts_export_assignment(export_assign, source)
+      }
+      _ => None,
+    }
+  }
+
+  #[expect(clippy::unnecessary_wraps)]
+  fn rewrite_import_declaration(
+    import: &ImportDeclaration,
+    source: &str,
+    type_only_ids: &mut Vec<String>,
+  ) -> Option<String> {
+    let import_text = Self::extract_text(source, import.span());
+
+    if import.import_kind == oxc::ast::ast::ImportOrExportKind::Type {
+      if let Some(specifiers) = &import.specifiers {
+        for specifier in specifiers {
+          match specifier {
+            oxc::ast::ast::ImportDeclarationSpecifier::ImportSpecifier(spec) => {
+              type_only_ids.push(spec.local.name.to_string());
+            }
+            oxc::ast::ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
+              type_only_ids.push(spec.local.name.to_string());
+            }
+            oxc::ast::ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
+              type_only_ids.push(spec.local.name.to_string());
+            }
+          }
+        }
+      }
+    }
+
+    if let Some(specifiers) = &import.specifiers {
+      for specifier in specifiers {
+        if let oxc::ast::ast::ImportDeclarationSpecifier::ImportSpecifier(spec) = specifier {
+          if spec.import_kind == oxc::ast::ast::ImportOrExportKind::Type {
+            type_only_ids.push(spec.local.name.to_string());
+          }
+        }
+      }
+    }
+
+    Some(import_text)
+  }
+
+  fn rewrite_export_named_declaration(
+    export: &ExportNamedDeclaration,
+    source: &str,
+    type_only_ids: &mut Vec<String>,
+  ) -> Option<String> {
+    if export.declaration.is_some() {
+      return None;
+    }
+
+    let export_text = Self::extract_text(source, export.span());
+
+    if export.export_kind == oxc::ast::ast::ImportOrExportKind::Type {
+      for specifier in &export.specifiers {
+        let exported_name = match &specifier.exported {
+          oxc::ast::ast::ModuleExportName::IdentifierName(id) => id.name.to_string(),
+          oxc::ast::ast::ModuleExportName::IdentifierReference(id) => id.name.to_string(),
+          oxc::ast::ast::ModuleExportName::StringLiteral(lit) => lit.value.to_string(),
+        };
+        type_only_ids.push(exported_name);
+      }
+    }
+
+    for specifier in &export.specifiers {
+      if specifier.export_kind == oxc::ast::ast::ImportOrExportKind::Type {
+        let exported_name = match &specifier.exported {
+          oxc::ast::ast::ModuleExportName::IdentifierName(id) => id.name.to_string(),
+          oxc::ast::ast::ModuleExportName::IdentifierReference(id) => id.name.to_string(),
+          oxc::ast::ast::ModuleExportName::StringLiteral(lit) => lit.value.to_string(),
+        };
+        type_only_ids.push(exported_name);
+      }
+    }
+
+    Some(export_text)
+  }
+
+  #[expect(clippy::unnecessary_wraps)]
+  fn rewrite_export_all_declaration(export: &ExportAllDeclaration, source: &str) -> Option<String> {
+    Some(Self::extract_text(source, export.span()))
+  }
+
+  fn rewrite_export_default_declaration(
+    export: &ExportDefaultDeclaration,
+    _source: &str,
+  ) -> Option<String> {
+    if let oxc::ast::ast::ExportDefaultDeclarationKind::Identifier(id) = &export.declaration {
+      return Some(format!("export {{ {} as default }}", id.name));
+    }
+
+    None
+  }
+
+  #[expect(clippy::unnecessary_wraps)]
+  fn rewrite_ts_import_equals(
+    import_eq: &TSImportEqualsDeclaration,
+    source: &str,
+  ) -> Option<String> {
+    if let oxc::ast::ast::TSModuleReference::ExternalModuleReference(module_ref) =
+      &import_eq.module_reference
+    {
+      let binding_name = import_eq.id.name.as_str();
+      let source_value = &module_ref.expression.value;
+      return Some(format!("import {binding_name} from \"{source_value}\""));
+    }
+
+    Some(Self::extract_text(source, import_eq.span()))
+  }
+
+  fn rewrite_ts_export_assignment(
+    export_assign: &TSExportAssignment,
+    _source: &str,
+  ) -> Option<String> {
+    if let Expression::Identifier(id) = &export_assign.expression {
+      return Some(format!("export {{ {} as default }}", id.name));
+    }
+
+    None
+  }
+
+  fn extract_text(source: &str, span: oxc::span::Span) -> String {
+    let start = span.start as usize;
+    let end = span.end as usize;
+    if start < source.len() && end <= source.len() && start < end {
+      source[start..end].to_string()
+    } else {
+      String::new()
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_extract_text() {
+    let code = "hello world";
+    let span = oxc::span::Span::new(0, 5);
+    let result = ImportExportRewriter::extract_text(code, span);
+    assert_eq!(result, "hello");
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/import_export.rs
+++ b/crates/rolldown_plugin_fake_js/src/import_export.rs
@@ -1,0 +1,195 @@
+use oxc::ast::ast::{
+  ExportAllDeclaration, ExportDefaultDeclaration, ExportDefaultDeclarationKind,
+  ExportFromDeclaration, ExportNamedDeclaration, Expression, ImportDeclaration,
+  ImportDeclarationSpecifier, ImportOrExportKind, Statement, TSExportAssignment,
+  TSImportEqualsDeclaration, TSModuleReference,
+};
+use oxc::span::GetSpan;
+
+use crate::codegen;
+
+pub struct ImportExportRewriter;
+
+impl ImportExportRewriter {
+  pub fn rewrite_statement(
+    stmt: &Statement,
+    source: &str,
+    type_only_ids: &mut Vec<String>,
+  ) -> Option<String> {
+    match stmt {
+      Statement::ImportDeclaration(import) => {
+        Self::rewrite_import_declaration(import, source, type_only_ids)
+      }
+      Statement::ExportNamedDeclaration(export) => {
+        Self::rewrite_export_named_declaration(export, source, type_only_ids)
+      }
+      Statement::ExportFromDeclaration(export) => {
+        Self::rewrite_export_from_declaration(export, source, type_only_ids)
+      }
+      Statement::ExportAllDeclaration(export) => {
+        Self::rewrite_export_all_declaration(export, source, type_only_ids)
+      }
+      Statement::ExportDefaultDeclaration(export) => {
+        Self::rewrite_export_default_declaration(export, source)
+      }
+      Statement::TSImportEqualsDeclaration(import_eq) => {
+        Self::rewrite_ts_import_equals(import_eq, source)
+      }
+      Statement::TSExportAssignment(export_assign) => {
+        Self::rewrite_ts_export_assignment(export_assign, source)
+      }
+      _ => None,
+    }
+  }
+
+  #[expect(clippy::unnecessary_wraps)]
+  fn rewrite_import_declaration(
+    import: &ImportDeclaration,
+    source: &str,
+    _type_only_ids: &mut Vec<String>,
+  ) -> Option<String> {
+    let mut import_text = codegen::extract_span_text(source, import.span());
+
+    // Strip `type` so Rolldown keeps the import. Unlike exports, type-only imports are not tracked.
+    if import.import_kind == ImportOrExportKind::Type {
+      import_text = import_text.replace("import type ", "import ");
+    }
+
+    if let Some(specifiers) = &import.specifiers {
+      for specifier in specifiers {
+        if let ImportDeclarationSpecifier::ImportSpecifier(spec) = specifier {
+          if spec.import_kind == ImportOrExportKind::Type {
+            import_text = import_text.replace("{ type ", "{ ");
+            import_text = import_text.replace(", type ", ", ");
+          }
+        }
+      }
+    }
+
+    Some(import_text)
+  }
+
+  #[expect(clippy::unnecessary_wraps)]
+  fn rewrite_export_named_declaration(
+    export: &ExportNamedDeclaration,
+    source: &str,
+    type_only_ids: &mut Vec<String>,
+  ) -> Option<String> {
+    let mut export_text = codegen::extract_span_text(source, export.span());
+
+    // Track by exported name (`as` alias, else local) so render_chunk can restore `type`.
+    if export.export_kind == ImportOrExportKind::Type {
+      for specifier in &export.specifiers {
+        let exported_name = specifier.exported.name().to_string();
+        type_only_ids.push(exported_name);
+      }
+      export_text = export_text.replace("export type {", "export {");
+      export_text = export_text.replace("export type*", "export *");
+    }
+
+    let mut has_type_specifiers = false;
+    for specifier in &export.specifiers {
+      if specifier.export_kind == ImportOrExportKind::Type {
+        has_type_specifiers = true;
+        let exported_name = specifier.exported.name().to_string();
+        type_only_ids.push(exported_name);
+      }
+    }
+
+    if has_type_specifiers {
+      export_text = export_text.replace("{ type ", "{ ");
+      export_text = export_text.replace(", type ", ", ");
+    }
+
+    Some(export_text)
+  }
+
+  #[expect(clippy::unnecessary_wraps)]
+  fn rewrite_export_from_declaration(
+    export: &ExportFromDeclaration,
+    source: &str,
+    type_only_ids: &mut Vec<String>,
+  ) -> Option<String> {
+    let mut export_text = codegen::extract_span_text(source, export.span());
+
+    if export.export_kind == ImportOrExportKind::Type {
+      for specifier in &export.specifiers {
+        let exported_name = specifier.exported.name().to_string();
+        type_only_ids.push(exported_name);
+      }
+      export_text = export_text.replace("export type {", "export {");
+      export_text = export_text.replace("export type*", "export *");
+    }
+
+    let mut has_type_specifiers = false;
+    for specifier in &export.specifiers {
+      if specifier.export_kind == ImportOrExportKind::Type {
+        has_type_specifiers = true;
+        let exported_name = specifier.exported.name().to_string();
+        type_only_ids.push(exported_name);
+      }
+    }
+
+    if has_type_specifiers {
+      export_text = export_text.replace("{ type ", "{ ");
+      export_text = export_text.replace(", type ", ", ");
+    }
+
+    Some(export_text)
+  }
+
+  #[expect(clippy::unnecessary_wraps)]
+  fn rewrite_export_all_declaration(
+    export: &ExportAllDeclaration,
+    source: &str,
+    type_only_ids: &mut Vec<String>,
+  ) -> Option<String> {
+    let mut export_text = codegen::extract_span_text(source, export.span());
+
+    if export.export_kind == ImportOrExportKind::Type {
+      if let Some(exported) = &export.exported {
+        let exported_name = exported.name().to_string();
+        type_only_ids.push(exported_name);
+      }
+      export_text = export_text.replace("export type *", "export *");
+    }
+
+    Some(export_text)
+  }
+
+  fn rewrite_export_default_declaration(
+    export: &ExportDefaultDeclaration,
+    _source: &str,
+  ) -> Option<String> {
+    if let ExportDefaultDeclarationKind::Identifier(id) = &export.declaration {
+      return Some(format!("export {{ {} as default }}", id.name));
+    }
+
+    None
+  }
+
+  #[expect(clippy::unnecessary_wraps)]
+  fn rewrite_ts_import_equals(
+    import_eq: &TSImportEqualsDeclaration,
+    source: &str,
+  ) -> Option<String> {
+    if let TSModuleReference::ExternalModuleReference(module_ref) = &import_eq.module_reference {
+      let binding_name = import_eq.id.name.as_str();
+      let source_value = &module_ref.expression.value;
+      return Some(format!("import {binding_name} from \"{source_value}\""));
+    }
+
+    Some(codegen::extract_span_text(source, import_eq.span()))
+  }
+
+  fn rewrite_ts_export_assignment(
+    export_assign: &TSExportAssignment,
+    _source: &str,
+  ) -> Option<String> {
+    if let Expression::Identifier(id) = &export_assign.expression {
+      return Some(format!("export {{ {} as default }}", id.name));
+    }
+
+    None
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/inline_import.rs
+++ b/crates/rolldown_plugin_fake_js/src/inline_import.rs
@@ -1,0 +1,239 @@
+use oxc::allocator::Allocator;
+use oxc::ast::ast::{
+  TSImportType, TSImportTypeQualifiedName, TSImportTypeQualifier, TSTypeQuery, TSTypeQueryExprName,
+};
+use oxc::ast_visit::Visit;
+use oxc::ast_visit::walk::walk_ts_type_query;
+use oxc::parser::Parser;
+use oxc::span::{GetSpan, SourceType, Span};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+#[derive(Debug, Clone)]
+pub struct InlineImportInfo {
+  pub span: Span,
+  pub source: String,
+  pub qualifier: Option<String>,
+  pub is_typeof: bool,
+  pub is_local: bool,
+}
+
+pub struct InlineImportCollector {
+  pub imports: Vec<InlineImportInfo>,
+}
+
+impl InlineImportCollector {
+  pub fn new() -> Self {
+    Self { imports: Vec::new() }
+  }
+
+  pub fn collect(source: &str) -> Vec<InlineImportInfo> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::d_ts();
+    let parser = Parser::new(&allocator, source, source_type);
+    let parse_result = parser.parse();
+
+    let mut collector = Self::new();
+    collector.visit_program(&parse_result.program);
+    collector.imports
+  }
+
+  pub fn rewrite_source(source: &str) -> (String, Vec<String>) {
+    let imports = Self::collect(source);
+    if imports.is_empty() {
+      return (source.to_string(), Vec::new());
+    }
+
+    let mut generated_imports: Vec<String> = Vec::new();
+    let mut ns_counter: usize = 0;
+    let mut ns_map: FxHashMap<String, String> = FxHashMap::default();
+
+    let mut sorted_imports = imports;
+    sorted_imports.sort_by_key(|info| std::cmp::Reverse(info.span.start));
+
+    let mut result = source.to_string();
+
+    for info in &sorted_imports {
+      let start = info.span.start as usize;
+      let end = info.span.end as usize;
+
+      if start >= result.len() || end > result.len() {
+        continue;
+      }
+
+      if !info.is_local {
+        continue;
+      }
+
+      if let Some(qualifier) = &info.qualifier {
+        let replacement =
+          if info.is_typeof { format!("typeof {qualifier}") } else { qualifier.clone() };
+        result = format!("{}{}{}", &result[..start], replacement, &result[end..]);
+        generated_imports.push(format!("import {{ {} }} from \"{}\"", qualifier, info.source));
+      } else {
+        let ns_name = ns_map.entry(info.source.clone()).or_insert_with(|| {
+          let name = format!("{}_{}", sanitize_module_name(&info.source), ns_counter);
+          ns_counter += 1;
+          name
+        });
+        let replacement =
+          if info.is_typeof { format!("typeof {ns_name}") } else { ns_name.clone() };
+        result = format!("{}{}{}", &result[..start], replacement, &result[end..]);
+        generated_imports.push(format!("import * as {} from \"{}\"", ns_name, info.source));
+      }
+    }
+
+    generated_imports.sort();
+    generated_imports.dedup();
+
+    (result, generated_imports)
+  }
+
+  pub fn rewrite_external_imports(
+    source: &str,
+    allowed_sources: &FxHashSet<String>,
+  ) -> (String, Vec<String>) {
+    if allowed_sources.is_empty() {
+      return (source.to_string(), Vec::new());
+    }
+
+    let imports = Self::collect(source);
+    if imports.is_empty() {
+      return (source.to_string(), Vec::new());
+    }
+
+    let mut generated_imports: Vec<String> = Vec::new();
+    let mut ns_counters: FxHashMap<String, usize> = FxHashMap::default();
+    let mut ns_map: FxHashMap<String, String> = FxHashMap::default();
+
+    let mut sorted_imports = imports;
+    sorted_imports.sort_by_key(|info| std::cmp::Reverse(info.span.start));
+
+    let mut result = source.to_string();
+    let mut source_order: Vec<String> = Vec::new();
+
+    for info in &sorted_imports {
+      let start = info.span.start as usize;
+      let end = info.span.end as usize;
+
+      if start >= result.len() || end > result.len() {
+        continue;
+      }
+
+      if info.is_local {
+        continue;
+      }
+
+      if !allowed_sources.contains(&info.source) {
+        continue;
+      }
+
+      let ns_name = ns_map.entry(info.source.clone()).or_insert_with(|| {
+        let prefix = sanitize_module_name(&info.source);
+        let idx = ns_counters.entry(prefix.clone()).or_insert(0);
+        let name = format!("{}{}", prefix, *idx);
+        *idx += 1;
+        source_order.push(info.source.clone());
+        name
+      });
+
+      if let Some(qualifier) = &info.qualifier {
+        let replacement = if info.is_typeof {
+          format!("typeof {ns_name}.{qualifier}")
+        } else {
+          format!("{ns_name}.{qualifier}")
+        };
+        result = format!("{}{}{}", &result[..start], replacement, &result[end..]);
+      } else {
+        let replacement =
+          if info.is_typeof { format!("typeof {ns_name}") } else { ns_name.clone() };
+        result = format!("{}{}{}", &result[..start], replacement, &result[end..]);
+      }
+    }
+
+    source_order.reverse();
+    for source_path in &source_order {
+      if let Some(ns_name) = ns_map.get(source_path) {
+        generated_imports.push(format!("import * as {ns_name} from \"{source_path}\";"));
+      }
+    }
+
+    (result, generated_imports)
+  }
+}
+
+impl<'a> Visit<'a> for InlineImportCollector {
+  fn visit_ts_type_query(&mut self, node: &TSTypeQuery<'a>) {
+    if let TSTypeQueryExprName::TSImportType(import_type) = &node.expr_name {
+      // Handle `typeof import()` here and return early to avoid double-collect via visit_ts_import_type.
+      let source_value = import_type.source.value.to_string();
+      let is_local = source_value.starts_with("./") || source_value.starts_with("../");
+      let qualifier = extract_qualifier(import_type.qualifier.as_ref());
+
+      self.imports.push(InlineImportInfo {
+        span: node.span(),
+        source: source_value,
+        qualifier,
+        is_typeof: true,
+        is_local,
+      });
+
+      if let Some(type_args) = &import_type.type_arguments {
+        for param in &type_args.params {
+          self.visit_ts_type(param);
+        }
+      }
+      return;
+    }
+
+    walk_ts_type_query(self, node);
+  }
+
+  fn visit_ts_import_type(&mut self, node: &TSImportType<'a>) {
+    let source_value = node.source.value.to_string();
+    let is_local = source_value.starts_with("./") || source_value.starts_with("../");
+    let qualifier = extract_qualifier(node.qualifier.as_ref());
+
+    let span = if let (Some(_), Some(type_args)) = (&qualifier, node.type_arguments.as_ref()) {
+      // End before type args so `import("./m").Bar<number>` → `Bar` keeps `<number>`.
+      Span::new(node.span().start, type_args.span.start)
+    } else {
+      node.span()
+    };
+
+    self.imports.push(InlineImportInfo {
+      span,
+      source: source_value,
+      qualifier,
+      is_typeof: false,
+      is_local,
+    });
+
+    if let Some(type_args) = &node.type_arguments {
+      for param in &type_args.params {
+        self.visit_ts_type(param);
+      }
+    }
+  }
+}
+
+fn extract_qualifier(qualifier: Option<&TSImportTypeQualifier>) -> Option<String> {
+  qualifier.and_then(|q| match q {
+    TSImportTypeQualifier::Identifier(id) => Some(id.name.to_string()),
+    TSImportTypeQualifier::QualifiedName(qn) => {
+      fn get_leftmost(q: &TSImportTypeQualifiedName) -> Option<String> {
+        match &q.left {
+          TSImportTypeQualifier::Identifier(id) => Some(id.name.to_string()),
+          TSImportTypeQualifier::QualifiedName(inner) => get_leftmost(inner),
+        }
+      }
+      get_leftmost(qn)
+    }
+  })
+}
+
+fn sanitize_module_name(source: &str) -> String {
+  let name = source.trim_start_matches("./").trim_start_matches("../");
+  let sanitized: String =
+    name.chars().map(|c| if c.is_ascii_alphanumeric() { c } else { '_' }).collect();
+  sanitized
+}

--- a/crates/rolldown_plugin_fake_js/src/lib.rs
+++ b/crates/rolldown_plugin_fake_js/src/lib.rs
@@ -1,0 +1,16 @@
+mod ast_utils;
+mod codegen;
+mod dependencies;
+mod filename;
+mod helpers;
+mod import_export;
+mod parser;
+mod plugin_impl;
+mod transform;
+mod type_params;
+mod types;
+mod visitor;
+
+pub use plugin_impl::FakeJsRolldownPlugin;
+pub use transform::FakeJsPlugin;
+pub use types::{ChunkInfo, FakeJsOptions, Result, TransformResult};

--- a/crates/rolldown_plugin_fake_js/src/lib.rs
+++ b/crates/rolldown_plugin_fake_js/src/lib.rs
@@ -1,0 +1,17 @@
+mod ast_utils;
+mod codegen;
+mod dependencies;
+mod filename;
+mod helpers;
+mod import_export;
+mod inline_import;
+mod parser;
+mod plugin_impl;
+mod transform;
+mod type_params;
+mod types;
+mod visitor;
+
+pub use plugin_impl::FakeJsRolldownPlugin;
+pub use transform::FakeJsPlugin;
+pub use types::{ChunkInfo, FakeJsOptions, Result, TransformResult};

--- a/crates/rolldown_plugin_fake_js/src/parser.rs
+++ b/crates/rolldown_plugin_fake_js/src/parser.rs
@@ -1,0 +1,31 @@
+use crate::types::Result;
+use anyhow::Context;
+use oxc::allocator::Allocator;
+use oxc::parser::{Parser, ParserReturn};
+use oxc::span::SourceType;
+
+pub struct TypeScriptParser<'a> {
+  allocator: &'a Allocator,
+}
+
+impl<'a> TypeScriptParser<'a> {
+  pub fn new(allocator: &'a Allocator) -> Self {
+    Self { allocator }
+  }
+
+  pub fn parse(&self, source: &'a str, filename: &str) -> Result<ParserReturn<'a>> {
+    let source_type = SourceType::from_path(filename)
+      .with_context(|| format!("Invalid source type for file: {filename}"))?
+      .with_typescript(true)
+      .with_typescript_definition(true);
+
+    let parser_return = Parser::new(self.allocator, source, source_type).parse();
+
+    if !parser_return.errors.is_empty() {
+      let errors: Vec<String> = parser_return.errors.iter().map(|e| format!("{e:?}")).collect();
+      anyhow::bail!("Parse errors: {}", errors.join(", "));
+    }
+
+    Ok(parser_return)
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/parser.rs
+++ b/crates/rolldown_plugin_fake_js/src/parser.rs
@@ -1,0 +1,33 @@
+use anyhow::Context;
+use oxc::allocator::Allocator;
+use oxc::parser::{Parser, ParserReturn};
+use oxc::span::SourceType;
+
+use crate::types::Result;
+
+pub struct TypeScriptParser<'a> {
+  allocator: &'a Allocator,
+}
+
+impl<'a> TypeScriptParser<'a> {
+  pub fn new(allocator: &'a Allocator) -> Self {
+    Self { allocator }
+  }
+
+  pub fn parse(&self, source: &'a str, filename: &str) -> Result<ParserReturn<'a>> {
+    let source_type = SourceType::from_path(filename)
+      .with_context(|| format!("Invalid source type for file: {filename}"))?
+      .with_typescript(true)
+      .with_typescript_definition(true);
+
+    let parser_return = Parser::new(self.allocator, source, source_type).parse();
+
+    if parser_return.panicked {
+      let errors: Vec<String> =
+        parser_return.diagnostics.iter().map(|e| format!("{e:?}")).collect();
+      anyhow::bail!("Parse errors: {}", errors.join(", "));
+    }
+
+    Ok(parser_return)
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/plugin_impl.rs
+++ b/crates/rolldown_plugin_fake_js/src/plugin_impl.rs
@@ -1,0 +1,70 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use rolldown_plugin::{
+  HookRenderChunkArgs, HookRenderChunkOutput, HookTransformArgs, HookTransformOutput, HookUsage,
+  Plugin, PluginContext, SharedTransformPluginContext,
+};
+
+use crate::{transform::FakeJsPlugin, types::FakeJsOptions};
+
+#[derive(Debug)]
+pub struct FakeJsRolldownPlugin {
+  inner: Arc<FakeJsPlugin>,
+}
+
+impl FakeJsRolldownPlugin {
+  pub fn new(options: FakeJsOptions) -> Self {
+    Self { inner: Arc::new(FakeJsPlugin::new(options)) }
+  }
+}
+
+impl Plugin for FakeJsRolldownPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    Cow::Borrowed("builtin:fake-js")
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::Transform | HookUsage::RenderChunk
+  }
+
+  async fn transform(
+    &self,
+    _ctx: SharedTransformPluginContext,
+    args: &HookTransformArgs<'_>,
+  ) -> rolldown_plugin::HookTransformReturn {
+    if !args.id.ends_with(".d.ts") && !args.id.ends_with(".d.mts") && !args.id.ends_with(".d.cts") {
+      return Ok(None);
+    }
+
+    match self.inner.transform(args.code, args.id) {
+      Ok(result) => {
+        Ok(Some(HookTransformOutput { code: Some(result.code), map: None, ..Default::default() }))
+      }
+      Err(e) => Err(anyhow::anyhow!("FakeJs transform error: {e}")),
+    }
+  }
+
+  async fn render_chunk(
+    &self,
+    _ctx: &PluginContext,
+    args: &HookRenderChunkArgs<'_>,
+  ) -> rolldown_plugin::HookRenderChunkReturn {
+    if !args.chunk.filename.ends_with(".d.ts")
+      && !args.chunk.filename.ends_with(".d.mts")
+      && !args.chunk.filename.ends_with(".d.cts")
+    {
+      return Ok(None);
+    }
+
+    let chunk_info = crate::types::ChunkInfo {
+      filename: args.chunk.filename.to_string(),
+      module_ids: args.chunk.module_ids.iter().map(std::string::ToString::to_string).collect(),
+    };
+
+    match self.inner.render_chunk(&args.code, &chunk_info) {
+      Ok(code) => Ok(Some(HookRenderChunkOutput { code, map: None })),
+      Err(e) => Err(anyhow::anyhow!("FakeJs render_chunk error: {e}")),
+    }
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/plugin_impl.rs
+++ b/crates/rolldown_plugin_fake_js/src/plugin_impl.rs
@@ -1,0 +1,83 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use oxc_sourcemap::SourceMap;
+use rolldown_plugin::{
+  HookRenderChunkArgs, HookRenderChunkOutput, HookTransformArgs, HookTransformOutput,
+  HookTransformOutputMap, HookUsage, Plugin, PluginContext, SharedTransformPluginContext,
+};
+
+use crate::transform::FakeJsPlugin;
+use crate::types::{ChunkInfo, FakeJsOptions};
+
+#[derive(Debug)]
+pub struct FakeJsRolldownPlugin {
+  inner: Arc<FakeJsPlugin>,
+}
+
+impl FakeJsRolldownPlugin {
+  pub fn new(options: FakeJsOptions) -> Self {
+    Self { inner: Arc::new(FakeJsPlugin::new(options)) }
+  }
+}
+
+fn parse_map(json: Option<&str>) -> HookTransformOutputMap {
+  match json.and_then(|s| SourceMap::from_json_string(s).ok()) {
+    Some(map) => HookTransformOutputMap::Sourcemap(Box::new(map.into_owned())),
+    Option::None => HookTransformOutputMap::Null,
+  }
+}
+
+impl Plugin for FakeJsRolldownPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    Cow::Borrowed("builtin:fake-js")
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::Transform | HookUsage::RenderChunk
+  }
+
+  async fn transform(
+    &self,
+    _ctx: SharedTransformPluginContext,
+    args: &HookTransformArgs<'_>,
+  ) -> rolldown_plugin::HookTransformReturn {
+    if !args.id.ends_with(".d.ts") && !args.id.ends_with(".d.mts") && !args.id.ends_with(".d.cts") {
+      return Ok(None);
+    }
+
+    match self.inner.transform(args.code, args.id) {
+      Ok(result) => {
+        let map = parse_map(result.map.as_deref());
+        Ok(Some(HookTransformOutput { code: Some(result.code), map, ..Default::default() }))
+      }
+      Err(e) => Err(anyhow::anyhow!("FakeJs transform error: {e}")),
+    }
+  }
+
+  async fn render_chunk(
+    &self,
+    _ctx: &PluginContext,
+    args: &HookRenderChunkArgs<'_>,
+  ) -> rolldown_plugin::HookRenderChunkReturn {
+    if !args.chunk.filename.ends_with(".d.ts")
+      && !args.chunk.filename.ends_with(".d.mts")
+      && !args.chunk.filename.ends_with(".d.cts")
+    {
+      return Ok(None);
+    }
+
+    let chunk_info = ChunkInfo {
+      filename: args.chunk.filename.to_string(),
+      module_ids: args.chunk.module_ids.iter().map(std::string::ToString::to_string).collect(),
+    };
+
+    match self.inner.render_chunk(&args.code, &chunk_info) {
+      Ok(result) => {
+        let map = parse_map(result.map.as_deref());
+        Ok(Some(HookRenderChunkOutput { code: result.code, map }))
+      }
+      Err(e) => Err(anyhow::anyhow!("FakeJs render_chunk error: {e}")),
+    }
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/transform.rs
+++ b/crates/rolldown_plugin_fake_js/src/transform.rs
@@ -1,0 +1,341 @@
+use oxc::allocator::Allocator;
+use oxc::ast_visit::Visit;
+use oxc::span::GetSpan;
+use std::sync::{Arc, Mutex};
+
+use crate::{
+  codegen,
+  dependencies::DependencyCollector,
+  filename,
+  helpers::HelperTransformer,
+  import_export::ImportExportRewriter,
+  parser::TypeScriptParser,
+  type_params::TypeParamCollector,
+  types::{ChunkInfo, DeclarationInfo, FakeJsOptions, PluginState, Result, TransformResult},
+  visitor::DeclarationCollector,
+};
+
+#[derive(Debug)]
+pub struct FakeJsPlugin {
+  options: FakeJsOptions,
+  state: Arc<Mutex<PluginState>>,
+}
+
+impl FakeJsPlugin {
+  pub fn new(options: FakeJsOptions) -> Self {
+    Self { options, state: Arc::new(Mutex::new(PluginState::new())) }
+  }
+
+  pub fn transform(&self, code: &str, id: &str) -> Result<TransformResult> {
+    if !filename::is_dts(id) {
+      return Ok(TransformResult { code: code.to_string(), map: None });
+    }
+
+    let mut state = self.state.lock().unwrap();
+    let transformed = self.transform_declarations(code, id, &mut state)?;
+
+    Ok(TransformResult {
+      code: transformed,
+      map: if self.options.sourcemap { Some(Self::generate_sourcemap(id)) } else { None },
+    })
+  }
+
+  fn transform_declarations(
+    &self,
+    code: &str,
+    id: &str,
+    state: &mut PluginState,
+  ) -> Result<String> {
+    let allocator = Allocator::default();
+    let parser = TypeScriptParser::new(&allocator);
+
+    let parse_result = parser.parse(code, id)?;
+
+    let directives =
+      crate::ast_utils::collect_reference_directives_from_program(&parse_result.program, code);
+    if !directives.is_empty() {
+      state.comments_map.insert(id.to_string(), directives);
+    }
+
+    let mut collector = DeclarationCollector::new();
+    collector.visit_program(&parse_result.program);
+
+    let mut output = Vec::new();
+    let mut type_only_ids = Vec::new();
+
+    for stmt in &parse_result.program.body {
+      if let Some(rewritten) =
+        ImportExportRewriter::rewrite_statement(stmt, code, &mut type_only_ids)
+      {
+        if !matches!(
+          stmt,
+          oxc::ast::ast::Statement::TSInterfaceDeclaration(_)
+            | oxc::ast::ast::Statement::TSTypeAliasDeclaration(_)
+            | oxc::ast::ast::Statement::TSEnumDeclaration(_)
+            | oxc::ast::ast::Statement::FunctionDeclaration(_)
+            | oxc::ast::ast::Statement::ClassDeclaration(_)
+            | oxc::ast::ast::Statement::VariableDeclaration(_)
+            | oxc::ast::ast::Statement::TSModuleDeclaration(_)
+        ) {
+          output.push(rewritten);
+        }
+      }
+    }
+
+    for decl_node in collector.declarations {
+      let transformed =
+        Self::transform_declaration_node(&decl_node, code, &parse_result.program, state);
+      output.push(transformed);
+    }
+
+    if self.options.side_effects {
+      output.push("sideEffect();".to_string());
+    }
+
+    state.type_only_map.insert(id.to_string(), type_only_ids);
+
+    Ok(output.join("\n"))
+  }
+
+  fn transform_declaration_node(
+    decl_node: &crate::visitor::DeclarationNode,
+    source: &str,
+    program: &oxc::ast::ast::Program,
+    state: &mut PluginState,
+  ) -> String {
+    let bindings = &decl_node.bindings;
+
+    if bindings.is_empty() {
+      return String::new();
+    }
+
+    let decl_source =
+      codegen::extract_source_text(source, decl_node.span.start, decl_node.span.end);
+
+    let mut type_param_collector = TypeParamCollector::new();
+    let mut dep_collector = DependencyCollector::new(bindings.clone());
+
+    type_param_collector.visit_program(program);
+    dep_collector.visit_program(program);
+
+    let type_params = type_param_collector.into_params();
+    let deps: Vec<String> = dep_collector.deps.into_iter().collect();
+
+    let decl_info = DeclarationInfo {
+      id: 0,
+      bindings: bindings.clone(),
+      type_params,
+      deps: deps.clone(),
+      children: vec![],
+      source: decl_source,
+      is_side_effect: decl_node.is_side_effect,
+    };
+
+    let decl_id = state.register_declaration(decl_info);
+
+    let type_param_names: Vec<String> =
+      state.get_declaration(decl_id).unwrap().type_params.iter().map(|p| p.name.clone()).collect();
+
+    let runtime_binding = codegen::RuntimeBindingGenerator::generate_runtime_binding(
+      &bindings[0],
+      decl_id,
+      &deps,
+      &type_param_names,
+      decl_node.is_side_effect,
+    );
+
+    if decl_node.is_export {
+      if decl_node.is_default {
+        let export_line = format!("export {{ {} as default }}", bindings[0]);
+        format!("{runtime_binding}\n{export_line}")
+      } else {
+        format!("export {runtime_binding}")
+      }
+    } else {
+      runtime_binding
+    }
+  }
+
+  pub fn render_chunk(&self, code: &str, chunk: &ChunkInfo) -> Result<String> {
+    if !filename::is_dts(&chunk.filename) {
+      return Ok(code.to_string());
+    }
+
+    let state = self.state.lock().unwrap();
+
+    let allocator = Allocator::default();
+    let parser = TypeScriptParser::new(&allocator);
+    let parse_result = parser.parse(code, &chunk.filename)?;
+
+    let transformed_stmts =
+      HelperTransformer::transform_statements(&parse_result.program.body, code);
+
+    let mut output = Vec::new();
+
+    for stmt in &parse_result.program.body {
+      if let Some(transformed) = Self::process_statement(stmt, code, &state) {
+        output.push(transformed);
+      }
+    }
+
+    let mut final_output = Vec::new();
+
+    for transformed in transformed_stmts {
+      if !transformed.trim().is_empty() {
+        final_output.push(transformed);
+      }
+    }
+
+    for stmt_output in output {
+      if !stmt_output.trim().is_empty() {
+        final_output.push(stmt_output);
+      }
+    }
+
+    let mut comments = Vec::new();
+    for module_id in &chunk.module_ids {
+      if let Some(module_comments) = state.comments_map.get(module_id) {
+        comments.extend(module_comments.clone());
+      }
+    }
+
+    let mut result = String::new();
+    if !comments.is_empty() {
+      for comment in comments {
+        result.push_str(&comment);
+        result.push('\n');
+      }
+    }
+
+    result.push_str(&final_output.join("\n"));
+
+    if result.trim().is_empty() {
+      return Ok("export { };".to_string());
+    }
+
+    Ok(result)
+  }
+
+  fn process_statement(
+    stmt: &oxc::ast::ast::Statement,
+    source: &str,
+    state: &PluginState,
+  ) -> Option<String> {
+    use oxc::ast::ast::Statement;
+
+    match stmt {
+      Statement::VariableDeclaration(var_decl) => {
+        if let Some(decl_id) = Self::extract_declaration_id(var_decl) {
+          if let Some(decl_info) = state.get_declaration(decl_id) {
+            return Some(format!("declare {}", decl_info.source));
+          }
+        }
+        None
+      }
+      Statement::ExportNamedDeclaration(export) => {
+        if let Some(oxc::ast::ast::Declaration::VariableDeclaration(var_decl)) = &export.declaration
+        {
+          if let Some(decl_id) = Self::extract_declaration_id(var_decl) {
+            if let Some(decl_info) = state.get_declaration(decl_id) {
+              return Some(format!("export declare {}", decl_info.source));
+            }
+          }
+        }
+        Some(codegen::extract_source_text(source, stmt.span().start, stmt.span().end))
+      }
+      Statement::ExpressionStatement(_) => None,
+      Statement::ImportDeclaration(_) => {
+        let import_text = codegen::extract_source_text(source, stmt.span().start, stmt.span().end);
+        Some(Self::patch_import_source(&import_text))
+      }
+      _ => Some(codegen::extract_source_text(source, stmt.span().start, stmt.span().end)),
+    }
+  }
+
+  fn extract_declaration_id(var_decl: &oxc::ast::ast::VariableDeclaration) -> Option<usize> {
+    if var_decl.declarations.len() != 1 {
+      return None;
+    }
+
+    let declarator = &var_decl.declarations[0];
+    let init = declarator.init.as_ref()?;
+
+    if let oxc::ast::ast::Expression::ArrayExpression(arr) = init {
+      if arr.elements.is_empty() {
+        return None;
+      }
+
+      if let Some(oxc::ast::ast::ArrayExpressionElement::NumericLiteral(num)) = arr.elements.first()
+      {
+        #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        return Some(num.value as usize);
+      }
+    }
+
+    None
+  }
+
+  fn patch_import_source(import_text: &str) -> String {
+    let re_double = regex::Regex::new(r#""([^"]+)\.d\.(ts|mts|cts)""#).unwrap();
+    let re_single = regex::Regex::new(r"'([^']+)\.d\.(ts|mts|cts)'").unwrap();
+
+    let result = re_double.replace_all(import_text, |caps: &regex::Captures| {
+      let path = &caps[1];
+      let ext = &caps[2];
+      let js_ext = match ext {
+        "mts" => "mjs",
+        "cts" => "cjs",
+        _ => "js",
+      };
+      format!("\"{path}.{js_ext}\"")
+    });
+
+    let result = re_single.replace_all(&result, |caps: &regex::Captures| {
+      let path = &caps[1];
+      let ext = &caps[2];
+      let js_ext = match ext {
+        "mts" => "mjs",
+        "cts" => "cjs",
+        _ => "js",
+      };
+      format!("'{path}.{js_ext}'")
+    });
+
+    result.to_string()
+  }
+
+  fn generate_sourcemap(filename: &str) -> String {
+    format!(r#"{{"version":3,"file":"{filename}","sources":["{filename}"],"mappings":""}}"#)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_plugin_creation() {
+    let options = FakeJsOptions::default();
+    let plugin = FakeJsPlugin::new(options);
+    assert!(!plugin.options.sourcemap);
+  }
+
+  #[test]
+  fn test_transform_non_dts() {
+    let options = FakeJsOptions::default();
+    let plugin = FakeJsPlugin::new(options);
+    let code = "const x = 1;";
+    let result = plugin.transform(code, "test.ts").unwrap();
+    assert_eq!(result.code, code);
+  }
+
+  #[test]
+  fn test_transform_simple_interface() {
+    let options = FakeJsOptions::default();
+    let plugin = FakeJsPlugin::new(options);
+    let code = "export interface Foo { bar: string; }";
+    let result = plugin.transform(code, "test.d.ts").unwrap();
+    assert!(result.code.contains("var Foo"));
+    assert!(result.code.contains("export"));
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/transform.rs
+++ b/crates/rolldown_plugin_fake_js/src/transform.rs
@@ -1,0 +1,1953 @@
+use std::borrow::Cow;
+use std::sync::{Arc, Mutex};
+
+use oxc::allocator::Allocator;
+use oxc::ast::ast::{
+  ArrayExpressionElement, BindingPattern, Declaration, ExportNamedDeclaration, Expression,
+  ImportDeclaration, ImportDeclarationSpecifier, ModuleExportName, Statement,
+  TSNamespaceDeclarationBody, VariableDeclaration,
+};
+use oxc::ast_visit::Visit;
+use oxc::codegen::{Codegen, CodegenOptions};
+use oxc::parser::Parser;
+use oxc::span::{GetSpan, SourceType};
+use oxc_sourcemap::{ConcatSourceMapBuilder, SourceMap, Token};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{
+  ast_utils::collect_reference_directives_from_program,
+  codegen,
+  dependencies::DependencyCollector,
+  filename,
+  helpers::HelperTransformer,
+  import_export::ImportExportRewriter,
+  inline_import::InlineImportCollector,
+  parser::TypeScriptParser,
+  type_params::TypeParamCollector,
+  types::{ChunkInfo, DeclarationInfo, FakeJsOptions, PluginState, Result, TransformResult},
+  visitor::{DeclarationCollector, DeclarationNode},
+};
+
+#[expect(clippy::large_enum_variant)]
+enum RenderAction {
+  Keep { text: String, map: Option<SourceMap<'static>> },
+  Remove,
+}
+
+impl RenderAction {
+  fn keep(text: impl Into<String>) -> Self {
+    Self::Keep { text: text.into(), map: None }
+  }
+
+  fn keep_mapped(text: impl Into<String>, map: Option<SourceMap<'static>>) -> Self {
+    Self::Keep { text: text.into(), map }
+  }
+}
+
+/// Information extracted from a runtime binding variable declaration
+/// e.g., `var Foo$1 = [0, (T$1) => [Bar$1, Baz], ["child1"]], Bar`
+struct RuntimeBindingInfo {
+  declaration_id: usize,
+  /// Binding names from all var declarators (e.g., `Foo$1`, `Bar$1` after Rolldown renaming)
+  binding_names: Vec<String>,
+  renamed_params: Vec<String>,
+  renamed_deps: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct FakeJsPlugin {
+  options: FakeJsOptions,
+  state: Arc<Mutex<PluginState>>,
+}
+
+impl FakeJsPlugin {
+  pub fn new(options: FakeJsOptions) -> Self {
+    Self { options, state: Arc::new(Mutex::new(PluginState::new())) }
+  }
+
+  pub fn transform(&self, code: &str, id: &str) -> Result<TransformResult> {
+    if !filename::is_dts(id) {
+      return Ok(TransformResult { code: code.to_string(), map: None });
+    }
+
+    let mut state = self.state.lock().unwrap();
+    self.transform_declarations(code, id, &mut state)
+  }
+
+  fn transform_declarations(
+    &self,
+    code: &str,
+    id: &str,
+    state: &mut PluginState,
+  ) -> Result<TransformResult> {
+    let allocator = Allocator::default();
+    let parser = TypeScriptParser::new(&allocator);
+
+    let parse_result = parser.parse(code, id)?;
+
+    let directives = collect_reference_directives_from_program(&parse_result.program, code);
+    if !directives.is_empty() {
+      state.comments_map.insert(id.to_string(), directives);
+    }
+
+    let mut collector = DeclarationCollector::new();
+    collector.visit_program(&parse_result.program);
+
+    let mut output = Vec::new();
+    let mut type_only_ids = Vec::new();
+
+    for stmt in &parse_result.program.body {
+      if let Some(rewritten) =
+        ImportExportRewriter::rewrite_statement(stmt, code, &mut type_only_ids)
+      {
+        if !matches!(
+          stmt,
+          Statement::TSInterfaceDeclaration(_)
+            | Statement::TSTypeAliasDeclaration(_)
+            | Statement::TSEnumDeclaration(_)
+            | Statement::FunctionDeclaration(_)
+            | Statement::ClassDeclaration(_)
+            | Statement::VariableDeclaration(_)
+            | Statement::TSNamespaceDeclaration(_)
+            | Statement::TSExternalModuleDeclaration(_)
+            | Statement::TSGlobalDeclaration(_)
+        ) {
+          output.push(rewritten);
+        }
+      }
+    }
+
+    let mut seen_inline_imports = FxHashSet::default();
+
+    for decl_node in collector.declarations {
+      let transformed = Self::transform_declaration_node(&decl_node, code, id, state);
+      let mut deduped_lines = Vec::new();
+      for line in transformed.lines() {
+        if (line.starts_with("import {") || line.starts_with("import * as"))
+          && line.contains("from \"")
+        {
+          if seen_inline_imports.contains(line) {
+            continue;
+          }
+          seen_inline_imports.insert(line.to_string());
+        }
+        deduped_lines.push(line);
+      }
+      output.push(deduped_lines.join("\n"));
+    }
+
+    if self.options.side_effects {
+      output.push("sideEffect();".to_string());
+    }
+
+    state.type_only_map.insert(id.to_string(), type_only_ids);
+
+    let transformed_code = output.join("\n");
+
+    if self.options.sourcemap {
+      let codegen_allocator = Allocator::default();
+      let codegen_parser = TypeScriptParser::new(&codegen_allocator);
+      let codegen_source = transformed_code.clone();
+      let codegen_parse = codegen_parser.parse(&codegen_source, id)?;
+      let codegen_result = Codegen::new()
+        .with_options(CodegenOptions {
+          source_map_path: Some(id.into()),
+          ..CodegenOptions::default()
+        })
+        .with_source_text(&codegen_source)
+        .build(&codegen_parse.program);
+
+      return Ok(TransformResult {
+        code: transformed_code,
+        map: codegen_result.map.map(|m| m.into_owned().to_json_string()),
+      });
+    }
+
+    Ok(TransformResult { code: transformed_code, map: None })
+  }
+
+  fn transform_declaration_node(
+    decl_node: &DeclarationNode,
+    source: &str,
+    id: &str,
+    state: &mut PluginState,
+  ) -> String {
+    let bindings = if decl_node.is_side_effect {
+      let idx = state.get_identifier_index("");
+      vec![format!("_{idx}")]
+    } else {
+      decl_node.bindings.clone()
+    };
+
+    if bindings.is_empty() {
+      return String::new();
+    }
+
+    #[expect(clippy::cast_possible_truncation)]
+    let span_start = find_leading_comment_start(source, decl_node.span.start as usize) as u32;
+    let decl_source = codegen::extract_source_text(source, span_start, decl_node.span.end);
+
+    let (rewritten_source, inline_imports) = InlineImportCollector::rewrite_source(&decl_source);
+
+    {
+      let all_imports = InlineImportCollector::collect(&decl_source);
+      for info in &all_imports {
+        if !info.is_local {
+          state
+            .external_inline_imports
+            .entry(id.to_string())
+            .or_default()
+            .insert(info.source.clone());
+        }
+      }
+    }
+
+    let mut type_param_collector = TypeParamCollector::new();
+
+    let decl_allocator = Allocator::default();
+    let decl_parser = TypeScriptParser::new(&decl_allocator);
+    if let Ok(decl_parse) = decl_parser.parse(&rewritten_source, "fragment.d.ts") {
+      for stmt in &decl_parse.program.body {
+        type_param_collector.visit_statement(stmt);
+      }
+    }
+
+    let type_params = type_param_collector.into_params();
+
+    // Only type parameters are excluded from deps (scoped bindings). Declaration
+    // names stay eligible so same-name type references work (`const Stuff: Stuff`).
+    let mut dep_bindings = Vec::new();
+    for param in &type_params {
+      dep_bindings.push(param.name.clone());
+    }
+
+    let mut dep_collector = DependencyCollector::new(dep_bindings);
+    if let Ok(decl_parse) = decl_parser.parse(&rewritten_source, "fragment.d.ts") {
+      for stmt in &decl_parse.program.body {
+        dep_collector.visit_statement(stmt);
+      }
+    }
+
+    let deps = dep_collector.deps.clone();
+    let dep_refs = dep_collector.dep_refs;
+    let children = dep_collector.children;
+    let child_literals: Vec<String> = children
+      .iter()
+      .filter_map(|(start, end)| {
+        let start = *start as usize;
+        let end = *end as usize;
+        if end > rewritten_source.len() || start >= end {
+          return None;
+        }
+        let text = &rewritten_source[start..end];
+        if text.starts_with('\'') || text.starts_with('"') { Some(text.to_string()) } else { None }
+      })
+      .collect();
+
+    let decl_info = DeclarationInfo {
+      id: 0,
+      bindings: bindings.clone(), // synthetic `_N` for side-effect declarations
+      type_params,
+      deps: deps.clone(),
+      dep_refs,
+      children: children.clone(),
+      child_literals,
+      source: rewritten_source,
+      is_side_effect: decl_node.is_side_effect,
+      module_id: id.to_string(),
+    };
+
+    let decl_id = state.register_declaration(decl_info);
+
+    let type_param_names: Vec<String> =
+      state.get_declaration(decl_id).unwrap().type_params.iter().map(|p| p.name.clone()).collect();
+
+    let runtime_binding = codegen::RuntimeBindingGenerator::generate_runtime_binding(
+      &bindings,
+      decl_id,
+      &deps,
+      &type_param_names,
+      &children,
+      decl_node.is_side_effect,
+    );
+
+    if decl_node.is_export {
+      if decl_node.is_default {
+        let export_line = format!("export {{ {} as default }}", bindings[0]);
+        let mut parts = inline_imports;
+        parts.push(runtime_binding);
+        parts.push(export_line);
+        parts.join("\n")
+      } else {
+        let mut parts = inline_imports;
+        parts.push(format!("export {runtime_binding}"));
+        parts.join("\n")
+      }
+    } else {
+      let mut parts = inline_imports;
+      parts.push(runtime_binding);
+      parts.join("\n")
+    }
+  }
+
+  #[expect(clippy::too_many_lines)]
+  pub fn render_chunk(&self, code: &str, chunk: &ChunkInfo) -> Result<TransformResult> {
+    if !filename::is_dts(&chunk.filename) {
+      return Ok(TransformResult { code: code.to_string(), map: None });
+    }
+
+    let state = self.state.lock().unwrap();
+
+    let allocator = Allocator::default();
+    let parser = TypeScriptParser::new(&allocator);
+    let parse_result = parser.parse(code, &chunk.filename)?;
+
+    let mut all_type_only_ids = FxHashSet::default();
+    for module_id in &chunk.module_ids {
+      if let Some(type_ids) = state.type_only_map.get(module_id) {
+        for id in type_ids {
+          all_type_only_ids.insert(id.clone());
+        }
+      }
+    }
+
+    let mut export_mappings = FxHashMap::default();
+    for stmt in &parse_result.program.body {
+      HelperTransformer::collect_export_mappings_public(stmt, &mut export_mappings);
+    }
+
+    // When the bundle starts with a rolldown:runtime region, emit a closing //#endregion
+    // before the first user module region matching Babel's renderChunk behavior.
+    let mut needs_runtime_close = code.trim_start().starts_with("//#region rolldown:runtime");
+
+    let mut output_parts: Vec<String> = Vec::new();
+    let mut last_end: usize = 0;
+    let mut last_was_import = false;
+    let mut saw_kept_output = false;
+    let mut pending_endregions: Vec<String> = Vec::new();
+    // Track whether we're inside a rolldown:runtime region so we can skip its closing //#endregion
+    let mut in_runtime_region = false;
+    // Suppressed //#region for namespace decls; re-inserted if the namespace is later resolved.
+    let mut suppressed_ns_regions: FxHashMap<String, String> = FxHashMap::default();
+
+    let mut source_map_segments: Vec<(SourceMap<'static>, u32)> = Vec::new();
+
+    for stmt in &parse_result.program.body {
+      let stmt_start = stmt.span().start as usize;
+      let stmt_end = stmt.span().end as usize;
+
+      let result = self.process_render_chunk_statement(
+        stmt,
+        code,
+        &state,
+        &all_type_only_ids,
+        &export_mappings,
+        self.options.sourcemap,
+      );
+
+      let (is_kept, is_import) = match &result {
+        RenderAction::Keep { text, .. } => {
+          (!text.trim().is_empty(), matches!(stmt, Statement::ImportDeclaration(_)))
+        }
+        RenderAction::Remove => (false, false),
+      };
+
+      let (mut gap_regions, mut gap_endregions) = (Vec::new(), Vec::new());
+      if stmt_start > last_end {
+        let between = &code[last_end..stmt_start];
+        for line in between.lines() {
+          let lt = line.trim();
+          if lt.contains("rolldown:runtime") {
+            if lt.starts_with("//#region") {
+              in_runtime_region = true;
+            }
+            continue;
+          }
+          if in_runtime_region && lt.starts_with("//#endregion") {
+            in_runtime_region = false;
+            continue;
+          }
+          if lt.starts_with("//#region") {
+            gap_regions.push(line.to_string());
+          } else if lt.starts_with("//#endregion") {
+            gap_endregions.push(line.to_string());
+          }
+        }
+      }
+
+      // Namespace decls suppress their //#region (may re-insert if resolved later).
+      let is_export_all_namespace = matches!(&result, RenderAction::Keep { text, .. } if {
+        let trimmed = text.trim_start();
+        trimmed.starts_with("declare namespace ") && trimmed.contains("_exports")
+      });
+      let mut suppressed_region: Option<String> = None;
+      if is_export_all_namespace {
+        suppressed_region = gap_regions.first().cloned();
+        gap_regions.clear();
+        // Drop preceding //#endregion (kept namespaces merge into the previous module region).
+        gap_endregions.clear();
+      }
+
+      let has_gap_region_comments = !gap_regions.is_empty() || !gap_endregions.is_empty();
+
+      // Blank line after imports only when a region/declaration gap sits between them.
+      if is_kept && last_was_import && !is_import && has_gap_region_comments {
+        Self::push_output_part(&mut output_parts, String::new());
+      }
+
+      // Defer internal //#endregion until a module boundary or end of output.
+      if !gap_regions.is_empty() {
+        if needs_runtime_close && gap_endregions.is_empty() {
+          Self::push_output_part(&mut output_parts, "//#endregion".to_string());
+          needs_runtime_close = false;
+        }
+        if gap_endregions.is_empty() {
+          for comment in pending_endregions.drain(..) {
+            Self::push_output_part(&mut output_parts, comment);
+          }
+        } else {
+          // Real module boundary already has a closer (drop deferred ones).
+          pending_endregions.clear();
+        }
+        for comment in gap_endregions {
+          Self::push_output_part(&mut output_parts, comment);
+        }
+        for comment in gap_regions {
+          Self::push_output_part(&mut output_parts, comment);
+        }
+      } else if !gap_endregions.is_empty() {
+        if !saw_kept_output || !is_kept {
+          for comment in gap_endregions {
+            Self::push_output_part(&mut output_parts, comment);
+          }
+        } else {
+          pending_endregions.extend(gap_endregions);
+        }
+      }
+
+      // Flush deferred endregions before entry re-exports that live outside module regions.
+      let is_chunk_export = matches!(
+        stmt,
+        Statement::ExportNamedDeclaration(_)
+          | Statement::ExportFromDeclaration(_)
+          | Statement::ExportAllDeclaration(_)
+      );
+      let is_cjs_export_equals = matches!(
+        &result,
+        RenderAction::Keep { text, .. } if text.trim_start().starts_with("export =")
+      );
+      if is_kept && is_chunk_export && !pending_endregions.is_empty() && !is_cjs_export_equals {
+        for comment in pending_endregions.drain(..) {
+          Self::push_output_part(&mut output_parts, comment);
+        }
+      }
+
+      last_end = stmt_end;
+
+      match result {
+        RenderAction::Keep { text, map } => {
+          if !text.trim().is_empty() {
+            if let Some(map) = map {
+              source_map_segments.push((map, Self::output_parts_line_count(&output_parts)));
+            }
+            if let Some(region) = suppressed_region {
+              let trimmed_text = text.trim_start();
+              if let Some(after_prefix) = trimmed_text.strip_prefix("declare namespace ") {
+                if let Some(name_end) =
+                  after_prefix.find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+                {
+                  let ns_name = &after_prefix[..name_end];
+                  suppressed_ns_regions.insert(ns_name.to_string(), region);
+                }
+              }
+            }
+            Self::push_output_part(&mut output_parts, text);
+            saw_kept_output = true;
+            last_was_import = is_import;
+          }
+        }
+        RenderAction::Remove => {}
+      }
+    }
+
+    if last_end < code.len() {
+      let trailing = &code[last_end..];
+      let mut trailing_regions = Vec::new();
+      let mut trailing_endregions = Vec::new();
+      for line in trailing.lines() {
+        let lt = line.trim();
+        if lt.contains("rolldown:runtime") {
+          if lt.starts_with("//#region") {
+            in_runtime_region = true;
+          }
+          continue;
+        }
+        if in_runtime_region && lt.starts_with("//#endregion") {
+          in_runtime_region = false;
+          continue;
+        }
+        if lt.starts_with("//#region") {
+          trailing_regions.push(line.to_string());
+        } else if lt.starts_with("//#endregion") {
+          trailing_endregions.push(line.to_string());
+        }
+      }
+      if trailing_regions.is_empty() {
+        for comment in pending_endregions.drain(..) {
+          Self::push_output_part(&mut output_parts, comment);
+        }
+        for comment in trailing_endregions {
+          Self::push_output_part(&mut output_parts, comment);
+        }
+      } else {
+        for comment in pending_endregions.drain(..) {
+          Self::push_output_part(&mut output_parts, comment);
+        }
+        for comment in trailing_endregions {
+          Self::push_output_part(&mut output_parts, comment);
+        }
+        for comment in trailing_regions {
+          Self::push_output_part(&mut output_parts, comment);
+        }
+      }
+    } else {
+      for comment in pending_endregions.drain(..) {
+        Self::push_output_part(&mut output_parts, comment);
+      }
+    }
+
+    if output_parts.is_empty() {
+      return Ok(TransformResult { code: "export { };".to_string(), map: None });
+    }
+
+    let has_content = output_parts.iter().any(|p| {
+      let t = p.trim();
+      !t.is_empty() && !t.starts_with("//#region") && !t.starts_with("//#endregion")
+    });
+
+    if !has_content {
+      return Ok(TransformResult { code: "export { };".to_string(), map: None });
+    }
+
+    // Rolldown turns `import * as ns from "./mod"` into synthetic
+    // `declare namespace mod_d_exports { export { Foo }; }` + `mod_d_exports.Foo` uses.
+    // Flatten member access; keep the namespace only when used standalone.
+    let ns_decl_re = regex::Regex::new(
+      r"^declare namespace (\w+_exports)\s*\{\s*\n?\s*export \{([^}]*)\};\s*\n?\s*\}$",
+    )
+    .unwrap();
+
+    let mut ns_member_map: FxHashMap<String, Vec<(String, String)>> = FxHashMap::default();
+    for part in &output_parts {
+      let trimmed = part.trim();
+      if let Some(caps) = ns_decl_re.captures(trimmed) {
+        let ns_name = caps[1].to_string();
+        let members_str = &caps[2];
+        let members: Vec<(String, String)> = members_str
+          .split(',')
+          .filter_map(|m| {
+            let m = m.trim();
+            if m.is_empty() {
+              return None;
+            }
+            if let Some((local, exported)) = m.split_once(" as ") {
+              Some((exported.trim().to_string(), local.trim().to_string()))
+            } else {
+              Some((m.to_string(), m.to_string()))
+            }
+          })
+          .collect();
+        if !members.is_empty() {
+          ns_member_map.insert(ns_name, members);
+        }
+      }
+    }
+
+    // If a namespace name appears as a standalone identifier (e.g., in `export { foo_d_exports as fooNs }`),
+    // we must keep it. Only resolve namespaces used exclusively as `ns.member`.
+    if !ns_member_map.is_empty() {
+      let mut standalone_ns: FxHashSet<String> = FxHashSet::default();
+      for part in &output_parts {
+        let trimmed = part.trim();
+        if ns_decl_re.is_match(trimmed) {
+          continue;
+        }
+        for ns_name in ns_member_map.keys() {
+          if !part.contains(ns_name) {
+            continue;
+          }
+          // Manual scan instead of regex look-ahead (unsupported by regex crate)
+          let has_standalone = {
+            let bytes = part.as_bytes();
+            let name_len = ns_name.len();
+            let mut found = false;
+            let mut start = 0;
+            while let Some(pos) = part[start..].find(ns_name) {
+              let abs = start + pos;
+              let end = abs + name_len;
+              let before_ok = abs == 0 || {
+                let c = bytes[abs - 1];
+                !c.is_ascii_alphanumeric() && c != b'_'
+              };
+              let after_ok = end >= bytes.len() || {
+                let c = bytes[end];
+                !c.is_ascii_alphanumeric() && c != b'_'
+              };
+              let not_dot = end >= bytes.len() || bytes[end] != b'.';
+              if before_ok && after_ok && not_dot {
+                found = true;
+                break;
+              }
+              start = abs + 1;
+            }
+            found
+          };
+          if has_standalone {
+            standalone_ns.insert(ns_name.clone());
+          }
+        }
+      }
+
+      // Always flatten `ns.Member` → `Member`. Keep the namespace decl only if used standalone
+      // (e.g. `export { ns_exports as ns }`).
+      let removable: FxHashSet<String> =
+        ns_member_map.keys().filter(|ns_name| !standalone_ns.contains(*ns_name)).cloned().collect();
+
+      if !ns_member_map.is_empty() {
+        // Re-insert suppressed //#region for resolved namespaces (remaining same-module content).
+        let mut regions_to_insert: Vec<(usize, String)> = Vec::new();
+        for (i, part) in output_parts.iter().enumerate() {
+          let trimmed = part.trim();
+          if let Some(caps) = ns_decl_re.captures(trimmed) {
+            let ns_name = caps[1].to_string();
+            if removable.contains(&ns_name) {
+              if let Some(region) = suppressed_ns_regions.get(&ns_name) {
+                regions_to_insert.push((i, region.clone()));
+              }
+            }
+          }
+        }
+        // Reverse insert to preserve indices. Close the previous module first when needed
+        // (avoid a leading orphan //#endregion).
+        for (i, region) in regions_to_insert.into_iter().rev() {
+          let needs_preceding_endregion = output_parts[..i].iter().any(|part| {
+            let t = part.trim();
+            !t.is_empty()
+              && !t.starts_with("import ")
+              && !t.starts_with("//#region")
+              && !t.starts_with("//#endregion")
+          });
+          output_parts.insert(i, region);
+          if needs_preceding_endregion {
+            output_parts.insert(i, "//#endregion".to_string());
+          }
+        }
+
+        output_parts.retain(|part| {
+          let trimmed = part.trim();
+          if let Some(caps) = ns_decl_re.captures(trimmed) {
+            let ns_name = caps[1].to_string();
+            !removable.contains(&ns_name)
+          } else {
+            true
+          }
+        });
+
+        for part in &mut output_parts {
+          for (ns_name, members) in &ns_member_map {
+            for (exported, local) in members {
+              let qualified = format!("{ns_name}.{exported}");
+              if part.contains(&qualified) {
+                *part = part.replace(&qualified, local);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    let mut reference_comments: Vec<String> = Vec::new();
+    let mut seen_comments = FxHashSet::default();
+    for module_id in &chunk.module_ids {
+      if let Some(comments) = state.comments_map.get(module_id) {
+        for comment in comments {
+          if !seen_comments.contains(comment) {
+            seen_comments.insert(comment.clone());
+            reference_comments.push(comment.clone());
+          }
+        }
+      }
+    }
+
+    let mut allowed_external_imports = FxHashSet::default();
+    for module_id in &chunk.module_ids {
+      if let Some(sources) = state.external_inline_imports.get(module_id) {
+        allowed_external_imports.extend(sources.iter().cloned());
+      }
+    }
+
+    let mut joined = output_parts.join("\n");
+    let mut external_imports: Vec<String> = Vec::new();
+    if !allowed_external_imports.is_empty() {
+      let (rewritten, ext_imports) =
+        InlineImportCollector::rewrite_external_imports(&joined, &allowed_external_imports);
+      if !ext_imports.is_empty() {
+        joined = rewritten;
+        external_imports = ext_imports;
+        output_parts = joined.split('\n').map(std::string::ToString::to_string).collect();
+      }
+    }
+
+    let mut result = String::new();
+
+    for comment in &reference_comments {
+      result.push_str(comment);
+      result.push('\n');
+    }
+
+    if !external_imports.is_empty() {
+      for import in &external_imports {
+        result.push_str(import);
+        result.push('\n');
+      }
+      result.push('\n');
+    }
+
+    result.push_str(&output_parts.join("\n"));
+
+    result = Self::prune_unused_imports(&result);
+
+    result = Self::cleanup_region_markers(&result);
+    result = Self::restore_runtime_import_regions(&result);
+    result = Self::ensure_blank_line_after_imports(&result);
+    result = Self::normalize_whitespace(&result);
+
+    if self.options.sourcemap {
+      let prefix_lines = Self::count_prefix_lines(&reference_comments, &external_imports);
+      let map =
+        Self::compose_render_source_map(&source_map_segments, &chunk.filename, prefix_lines);
+      return Ok(TransformResult { code: result, map });
+    }
+
+    Ok(TransformResult { code: result, map: None })
+  }
+
+  fn prune_unused_imports(source: &str) -> String {
+    let allocator = Allocator::default();
+    let parser = TypeScriptParser::new(&allocator);
+    let Ok(parse_result) = parser.parse(source, "chunk.d.ts") else {
+      return source.to_string();
+    };
+
+    let mut non_import_parts = Vec::new();
+    for stmt in &parse_result.program.body {
+      if !matches!(stmt, Statement::ImportDeclaration(_)) {
+        non_import_parts.push(codegen::extract_source_text(
+          source,
+          stmt.span().start,
+          stmt.span().end,
+        ));
+      }
+    }
+    let usage_text = non_import_parts.join("\n");
+
+    let mut remove_ranges: Vec<(usize, usize)> = Vec::new();
+    for stmt in &parse_result.program.body {
+      if let Statement::ImportDeclaration(import) = stmt {
+        if !Self::is_import_used(import, &usage_text) {
+          let start = stmt.span().start as usize;
+          let mut end = stmt.span().end as usize;
+          if end < source.len() && source.as_bytes()[end] == b'\n' {
+            end += 1;
+          }
+          remove_ranges.push((start, end));
+        }
+      }
+    }
+
+    if remove_ranges.is_empty() {
+      return source.to_string();
+    }
+
+    remove_ranges.sort_by_key(|(start, _)| std::cmp::Reverse(*start));
+    let mut result = source.to_string();
+    for (start, end) in remove_ranges {
+      if start <= result.len() && end <= result.len() && start < end {
+        result.replace_range(start..end, "");
+      }
+    }
+
+    result
+  }
+
+  fn is_import_used(import: &ImportDeclaration, usage_text: &str) -> bool {
+    let Some(specifiers) = &import.specifiers else {
+      return true;
+    };
+
+    for spec in specifiers {
+      let local_name = match spec {
+        ImportDeclarationSpecifier::ImportSpecifier(s) => s.local.name.as_str(),
+        ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => s.local.name.as_str(),
+        ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => s.local.name.as_str(),
+      };
+
+      if Self::is_identifier_used(local_name, usage_text) {
+        return true;
+      }
+    }
+
+    false
+  }
+
+  fn is_identifier_used(name: &str, text: &str) -> bool {
+    let re = regex::Regex::new(&format!(r"\b{}\b", regex::escape(name))).unwrap();
+    re.is_match(text)
+  }
+
+  fn push_output_part(parts: &mut Vec<String>, part: String) {
+    parts.push(part);
+  }
+
+  fn output_parts_line_count(parts: &[String]) -> u32 {
+    if parts.is_empty() {
+      return 0;
+    }
+    #[expect(clippy::cast_possible_truncation)]
+    {
+      parts.join("\n").matches('\n').count() as u32 + 1
+    }
+  }
+
+  fn count_prefix_lines(reference_comments: &[String], external_imports: &[String]) -> u32 {
+    #[expect(clippy::cast_possible_truncation)]
+    {
+      let mut lines = 0u32;
+      for comment in reference_comments {
+        lines += comment.matches('\n').count() as u32 + 1;
+      }
+      for import in external_imports {
+        lines += import.matches('\n').count() as u32 + 1;
+      }
+      if !external_imports.is_empty() {
+        lines += 1;
+      }
+      lines
+    }
+  }
+
+  fn process_render_chunk_statement(
+    &self,
+    stmt: &Statement,
+    code: &str,
+    state: &PluginState,
+    type_only_ids: &FxHashSet<String>,
+    export_mappings: &FxHashMap<String, String>,
+    sourcemap: bool,
+  ) -> RenderAction {
+    match stmt {
+      Statement::ImportDeclaration(import) => {
+        if HelperTransformer::is_helper_import_public(import) {
+          return RenderAction::Remove;
+        }
+        let import_text = codegen::extract_source_text(code, stmt.span().start, stmt.span().end);
+        RenderAction::keep(Self::patch_import_source(&import_text))
+      }
+
+      // Bundler-only keep-alives (`sideEffect();`, etc.) (not part of the restored dts).
+      Statement::ExpressionStatement(_) => RenderAction::Remove,
+
+      Statement::ExportDeclaration(export) => {
+        if let Declaration::VariableDeclaration(var_decl) = &export.declaration {
+          if let Some(runtime_info) = Self::extract_runtime_binding_info(var_decl, code) {
+            if let Some(decl_info) = state.get_declaration(runtime_info.declaration_id) {
+              let (decl, map) = Self::generate_declaration_with_renames(
+                decl_info,
+                &runtime_info.binding_names,
+                &runtime_info.renamed_params,
+                &runtime_info.renamed_deps,
+                sourcemap,
+              );
+              let replacement =
+                if decl.trim().starts_with("export ") { decl } else { format!("export {decl}") };
+              return RenderAction::keep_mapped(replacement, map);
+            }
+          }
+        }
+
+        let text = codegen::extract_source_text(code, stmt.span().start, stmt.span().end);
+        RenderAction::keep(text)
+      }
+
+      Statement::ExportNamedDeclaration(export) => {
+        if export.specifiers.is_empty() {
+          return RenderAction::Remove;
+        }
+
+        self.process_export_specifiers(export, code, type_only_ids, export_mappings)
+      }
+
+      Statement::ExportFromDeclaration(_export) => {
+        let text = codegen::extract_source_text(code, stmt.span().start, stmt.span().end);
+        RenderAction::keep(Self::patch_import_source(&text))
+      }
+
+      Statement::ExportAllDeclaration(export_all) => {
+        let source_value = &export_all.source.value;
+        let patched_source = filename::patch_dts_extension(source_value);
+        if let Some(exported) = export_all.exported.as_ref() {
+          let exported_name = exported.name().to_string();
+          RenderAction::keep(format!("export * as {exported_name} from \"{patched_source}\";"))
+        } else {
+          RenderAction::keep(format!("export * from \"{patched_source}\";"))
+        }
+      }
+
+      Statement::VariableDeclaration(var_decl) => {
+        if let Some(runtime_info) = Self::extract_runtime_binding_info(var_decl, code) {
+          if let Some(decl_info) = state.get_declaration(runtime_info.declaration_id) {
+            let (decl, map) = Self::generate_declaration_with_renames(
+              decl_info,
+              &runtime_info.binding_names,
+              &runtime_info.renamed_params,
+              &runtime_info.renamed_deps,
+              sourcemap,
+            );
+            return RenderAction::keep_mapped(decl, map);
+          }
+        }
+
+        if let Some(transformed) = HelperTransformer::transform_export_all_public(var_decl, code) {
+          return RenderAction::keep(transformed);
+        }
+
+        if let Some(transformed) =
+          HelperTransformer::transform_member_access_public(var_decl, export_mappings)
+        {
+          return RenderAction::keep(transformed);
+        }
+
+        // Drop non-runtime-binding vars, including secondary declarators Rolldown may split
+        // out of multi-binding runtime vars (`var a = [...], b` → `var a = [...]; var b`).
+        RenderAction::Remove
+      }
+
+      _ => {
+        let text = codegen::extract_source_text(code, stmt.span().start, stmt.span().end);
+        RenderAction::keep(text)
+      }
+    }
+  }
+
+  fn process_export_specifiers(
+    &self,
+    export: &ExportNamedDeclaration,
+    _code: &str,
+    type_only_ids: &FxHashSet<String>,
+    export_mappings: &FxHashMap<String, String>,
+  ) -> RenderAction {
+    if export.specifiers.len() == 1 {
+      if let Some(spec) = export.specifiers.first() {
+        let local_name = spec.local.name().to_string();
+        if let Some(mapped_name) = export_mappings.get(&local_name) {
+          let exported_name = spec.exported.name().to_string();
+
+          // CJS default: export { x as default } → export = x
+          if self.options.cjs_default && exported_name == "default" {
+            return RenderAction::keep(format!("export = {mapped_name};"));
+          }
+
+          return RenderAction::keep(format!("export {{ {mapped_name} as {exported_name} }};"));
+        }
+      }
+    }
+
+    let mut new_specifiers = Vec::new();
+    for spec in &export.specifiers {
+      let local_name = spec.local.name().to_string();
+      // String-literal exports need quotes in the restored specifier text.
+      let exported_name = match &spec.exported {
+        ModuleExportName::StringLiteral(lit) => serde_json::to_string(lit.value.as_str())
+          .unwrap_or_else(|_| format!("\"{}\"", lit.value.escape_default())),
+        other => other.name().to_string(),
+      };
+      let exported_is_string = matches!(&spec.exported, ModuleExportName::StringLiteral(_));
+
+      let is_type_only = type_only_ids.contains(spec.exported.name().as_str());
+
+      if is_type_only {
+        if !exported_is_string && local_name == exported_name {
+          new_specifiers.push(format!("type {local_name}"));
+        } else {
+          new_specifiers.push(format!("type {local_name} as {exported_name}"));
+        }
+      } else if !exported_is_string && local_name == exported_name {
+        new_specifiers.push(local_name);
+      } else {
+        new_specifiers.push(format!("{local_name} as {exported_name}"));
+      }
+    }
+
+    if self.options.cjs_default && export.specifiers.len() == 1 {
+      if let Some(spec) = export.specifiers.first() {
+        let exported_name = spec.exported.name().to_string();
+        if exported_name == "default" {
+          let local_name = spec.local.name().to_string();
+          return RenderAction::keep(format!("export = {local_name};"));
+        }
+      }
+    }
+
+    RenderAction::keep(format!("export {{ {} }};", new_specifiers.join(", ")))
+  }
+
+  /// Runtime binding format: `var X = [id, (params...) => [deps...], [children...]]`
+  /// where children are a flat `[start,end,…]` span list.
+  /// After bundling, Rolldown may have renamed params/deps (extract those for restore).
+  fn extract_runtime_binding_info(
+    var_decl: &VariableDeclaration,
+    code: &str,
+  ) -> Option<RuntimeBindingInfo> {
+    if var_decl.declarations.is_empty() {
+      return None;
+    }
+
+    let declarator = &var_decl.declarations[0];
+
+    let mut binding_names = Vec::new();
+    for decl in &var_decl.declarations {
+      match &decl.id {
+        BindingPattern::BindingIdentifier(id) => {
+          binding_names.push(id.name.to_string());
+        }
+        _ => return None,
+      }
+    }
+    if binding_names.is_empty() {
+      return None;
+    }
+
+    let init = declarator.init.as_ref()?;
+
+    let Expression::ArrayExpression(arr) = init else {
+      return None;
+    };
+
+    if arr.elements.len() < 3 {
+      return None;
+    }
+
+    let declaration_id = match arr.elements.first() {
+      Some(ArrayExpressionElement::NumericLiteral(num)) => {
+        #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        {
+          num.value as usize
+        }
+      }
+      _ => return None,
+    };
+
+    let mut renamed_params = Vec::new();
+    let mut renamed_deps = Vec::new();
+
+    if let Some(ArrayExpressionElement::ArrowFunctionExpression(arrow)) = arr.elements.get(1) {
+      for param in &arrow.params.items {
+        if let BindingPattern::BindingIdentifier(id) = &param.pattern {
+          renamed_params.push(id.name.to_string());
+        }
+      }
+
+      if let Some(Expression::ArrayExpression(deps_arr)) = arrow.get_expression() {
+        for elem in &deps_arr.elements {
+          let dep_text = match elem {
+            ArrayExpressionElement::Identifier(id) => id.name.to_string(),
+            other => {
+              let span = other.span();
+              codegen::extract_source_text(code, span.start, span.end)
+            }
+          };
+          renamed_deps.push(dep_text);
+        }
+      }
+    }
+
+    Some(RuntimeBindingInfo { declaration_id, binding_names, renamed_params, renamed_deps })
+  }
+
+  fn generate_declaration_with_renames(
+    decl_info: &DeclarationInfo,
+    binding_names: &[String],
+    renamed_params: &[String],
+    renamed_deps: &[String],
+    sourcemap: bool,
+  ) -> (String, Option<SourceMap<'static>>) {
+    // Keep comments out of rename passes so identifiers inside them are not rewritten.
+    let (leading_comments, decl_only) = Self::split_leading_comments(&decl_info.source);
+
+    let mut source = decl_only;
+
+    let mut renames: Vec<(String, String)> = Vec::new();
+
+    // Dep renames first at original spans, applied reverse-order so earlier edits don't shift later ones.
+    let mut dep_span_replacements: Vec<(u32, u32, String)> = Vec::new();
+    for (i, original_dep) in decl_info.deps.iter().enumerate() {
+      if let Some(renamed) = renamed_deps.get(i) {
+        // Rolldown may rewrite free `undefined` to `void 0` in the deps array; treat as no-op.
+        let renamed = if renamed == "void 0" { "undefined" } else { renamed.as_str() };
+        if original_dep != renamed {
+          renames.push((original_dep.clone(), renamed.to_string()));
+          for (name, start, end) in &decl_info.dep_refs {
+            if name == original_dep {
+              dep_span_replacements.push((*start, *end, renamed.to_string()));
+            }
+          }
+        }
+      }
+    }
+    dep_span_replacements.sort_by_key(|(start, _, _)| std::cmp::Reverse(*start));
+    for (start, end, renamed) in dep_span_replacements {
+      let start = start as usize;
+      let end = end as usize;
+      if start < end && end <= source.len() {
+        source.replace_range(start..end, &renamed);
+      }
+    }
+
+    // Binding renames after deps (spans stay valid). Skip dep_ref spans and synthetic `_N`
+    // side-effect bindings (`declare global` / `declare module`).
+    let primary_binding = binding_names.first().map(String::as_str).unwrap_or("");
+    if !decl_info.is_side_effect {
+      let skip: Vec<(u32, u32)> = decl_info.dep_refs.iter().map(|(_, s, e)| (*s, *e)).collect();
+      for (i, original_binding) in decl_info.bindings.iter().enumerate() {
+        if let Some(renamed_binding) = binding_names.get(i) {
+          if original_binding != renamed_binding {
+            renames.push((original_binding.clone(), renamed_binding.clone()));
+            source =
+              replace_identifier_except_spans(&source, original_binding, renamed_binding, &skip);
+          }
+        }
+      }
+    }
+
+    for (i, original_param) in decl_info.type_params.iter().enumerate() {
+      if let Some(renamed) = renamed_params.get(i) {
+        if original_param.name != *renamed {
+          renames.push((original_param.name.clone(), renamed.clone()));
+          source = replace_identifier(&source, &original_param.name, renamed);
+        }
+      }
+    }
+
+    if !renames.is_empty() {
+      source = fix_namespace_export_specifiers(&source, &renames);
+    }
+
+    let source = Self::insert_unnamed_function_name(&source, primary_binding);
+
+    let (generated, map) = if sourcemap {
+      let source_path = Self::module_id_to_ts_source(&decl_info.module_id);
+      codegen::generate_declaration_with_source_map(&source, &source_path)
+    } else {
+      (codegen::generate_declaration_from_source(&source), None)
+    };
+    let generated = generated.replace("void 0", "undefined");
+    let generated = Self::restore_child_literal_quotes(&decl_info.child_literals, &generated);
+
+    let result = if leading_comments.is_empty() {
+      generated
+    } else {
+      format!("{}\n{}", leading_comments.trim_end(), generated.trim_start())
+    };
+    (result, map)
+  }
+
+  // oxc_codegen may flip `'lit'` ↔ `"lit"`; restore using transform-time child_literals.
+  fn restore_child_literal_quotes(child_literals: &[String], generated: &str) -> String {
+    let mut result = generated.to_string();
+    for original in child_literals {
+      if original.len() < 2 {
+        continue;
+      }
+      let quote = original.chars().next().filter(|c| *c == '\'' || *c == '"');
+      let Some(quote) = quote else { continue };
+      if !original.ends_with(quote) {
+        continue;
+      }
+      let inner = &original[1..original.len() - 1];
+      let alternate = if quote == '\'' { format!("\"{inner}\"") } else { format!("'{inner}'") };
+      if result.contains(&alternate) {
+        result = result.replace(&alternate, original);
+      }
+    }
+    result
+  }
+
+  fn split_leading_comments(source: &str) -> (String, String) {
+    let mut comment_end = 0;
+    let mut in_block_comment = false;
+
+    for (i, line) in source.lines().enumerate() {
+      let trimmed = line.trim();
+
+      if in_block_comment {
+        comment_end += line.len() + 1; // +1 for newline
+        if trimmed.contains("*/") {
+          in_block_comment = false;
+        }
+        continue;
+      }
+
+      if trimmed.starts_with("/**") || trimmed.starts_with("/*") {
+        in_block_comment = true;
+        comment_end += line.len() + 1;
+        if trimmed.contains("*/") {
+          in_block_comment = false;
+        }
+        continue;
+      }
+
+      if trimmed.starts_with("//") {
+        comment_end += line.len() + 1;
+        continue;
+      }
+
+      if trimmed.is_empty() && i == 0 {
+        comment_end += line.len() + 1;
+        continue;
+      }
+
+      break;
+    }
+
+    if comment_end == 0 || comment_end > source.len() {
+      return (String::new(), source.to_string());
+    }
+
+    let comments = source[..comment_end].trim_end().to_string();
+    let rest = source[comment_end..].to_string();
+
+    if comments.is_empty() { (String::new(), rest) } else { (comments, rest) }
+  }
+
+  /// If the source is an unnamed function declaration (e.g., `function <T>(...)` or `function(...)`),
+  /// insert the binding name after the `function` keyword.
+  /// Also handles `export default function <T>(...)` forms.
+  fn insert_unnamed_function_name(source: &str, binding_name: &str) -> String {
+    let trimmed = source.trim_start();
+
+    if let Some(rest) = trimmed.strip_prefix("export default function") {
+      let rest_trimmed = rest.trim_start();
+      if rest_trimmed.starts_with('<') || rest_trimmed.starts_with('(') || rest.is_empty() {
+        let prefix_len = source.len() - trimmed.len();
+        let prefix = &source[..prefix_len];
+        return format!("{prefix}export default function {binding_name} {rest_trimmed}");
+      }
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("function") {
+      let rest_trimmed = rest.trim_start();
+      if rest_trimmed.starts_with('<') || rest_trimmed.starts_with('(') {
+        let prefix_len = source.len() - trimmed.len();
+        let prefix = &source[..prefix_len];
+        return format!("{prefix}function {binding_name} {rest_trimmed}");
+      }
+    }
+
+    source.to_string()
+  }
+
+  fn cleanup_region_markers(code: &str) -> String {
+    let lines: Vec<&str> = code.lines().collect();
+    let mut kept: Vec<&str> = Vec::new();
+    let mut region_depth: usize = 0;
+
+    let is_basename_module_region = |line: &str| {
+      let trimmed = line.trim();
+      if !trimmed.starts_with("//#region ") {
+        return false;
+      }
+      let name = trimmed.trim_start_matches("//#region ").trim();
+      name.ends_with(".d.ts") && !name.contains('/') && name != "rolldown:runtime"
+    };
+
+    let mut i = 0;
+    while i < lines.len() {
+      let line = lines[i];
+      let trimmed = line.trim();
+
+      // Drop dependency-module regions like `//#region a.d.ts` when they only
+      // contain flattened import/type bindings (preserve regions with real declarations).
+      if is_basename_module_region(line) {
+        let region_start = i + 1;
+        let mut region_end = region_start;
+        while region_end < lines.len() && lines[region_end].trim() != "//#endregion" {
+          region_end += 1;
+        }
+        let flatten = lines[region_start..region_end].iter().all(|inner| {
+          let t = inner.trim();
+          t.is_empty() || t.starts_with("import ") || t.starts_with("type ")
+        });
+        if flatten {
+          i = region_end + 1;
+          for inner in &lines[region_start..region_end] {
+            kept.push(inner);
+          }
+          continue;
+        }
+      }
+
+      if trimmed == "//#endregion" {
+        if region_depth > 0 {
+          region_depth -= 1;
+          kept.push(line);
+        } else {
+          // Keep endregions that close a removed/suppressed region before a path-based
+          // module region or the final chunk export list.
+          let next_meaningful = lines[i + 1..].iter().find(|next| !next.trim().is_empty());
+          let keep = next_meaningful.is_some_and(|next| {
+            let t = next.trim();
+            (t.starts_with("//#region ") && t.contains('/')) || t.starts_with("export ")
+          });
+          if keep {
+            kept.push(line);
+          }
+        }
+        i += 1;
+        continue;
+      }
+
+      if trimmed.starts_with("//#region") {
+        let mut j = i + 1;
+        while j < lines.len() && lines[j].trim().is_empty() {
+          j += 1;
+        }
+        if j < lines.len() && lines[j].trim() == "//#endregion" {
+          // Keep the opening region marker but drop the closing marker for empty regions
+          // (matches Babel fake-js: empty modules still emit `//#region path`).
+          region_depth += 1;
+          kept.push(line);
+          i = j + 1;
+          continue;
+        }
+        region_depth += 1;
+      }
+
+      kept.push(line);
+      i += 1;
+    }
+
+    // Strip trailing //#endregion only when it follows the final export / block close
+    // (cjs `export =`, declare module). Keep endregions that precede a final export list.
+    while kept.last().is_some_and(|line| line.trim() == "//#endregion") {
+      let prev = kept.iter().rev().nth(1).map(|line| line.trim()).unwrap_or("");
+      if prev.starts_with("export ") || prev == "}" {
+        kept.pop();
+      } else {
+        break;
+      }
+    }
+
+    // Drop leading orphan endregions only when they precede an import (flattened dependency).
+    while kept.first().is_some_and(|line| line.trim() == "//#endregion") {
+      let mut next_idx = 1;
+      while next_idx < kept.len() && kept[next_idx].trim().is_empty() {
+        next_idx += 1;
+      }
+      let followed_by_import =
+        kept.get(next_idx).is_some_and(|next| next.trim().starts_with("import "));
+      if followed_by_import {
+        kept.remove(0);
+      } else {
+        break;
+      }
+    }
+
+    kept.join("\n")
+  }
+
+  /// Re-wrap imports that back `export { ns as alias }` re-exports after dependency
+  /// module regions are flattened (matches Babel's `//#region rolldown:runtime` layout).
+  fn restore_runtime_import_regions(code: &str) -> String {
+    let lines: Vec<&str> = code.lines().collect();
+    let mut result: Vec<String> = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+      let line = lines[i];
+      let trimmed = line.trim();
+
+      if trimmed.starts_with("export * from ") {
+        result.push(line.to_string());
+        i += 1;
+
+        while i < lines.len() && lines[i].trim().is_empty() {
+          result.push(lines[i].to_string());
+          i += 1;
+        }
+
+        if i < lines.len() && lines[i].trim().starts_with("import * as ") {
+          let import_line = lines[i].trim();
+          let import_name = import_line
+            .strip_prefix("import * as ")
+            .and_then(|rest| rest.split_whitespace().next())
+            .unwrap_or("");
+
+          let mut j = i + 1;
+          while j < lines.len() && lines[j].trim().is_empty() {
+            j += 1;
+          }
+
+          if j < lines.len() {
+            let export_line = lines[j].trim();
+            if export_line.starts_with("export { ")
+              && !import_name.is_empty()
+              && export_line.contains(import_name)
+              && export_line.contains(" as ")
+            {
+              if result.last().is_some_and(|prev| !prev.trim().is_empty()) {
+                result.push(String::new());
+              }
+              result.push("//#region rolldown:runtime".to_string());
+              result.push(String::new());
+              result.push(lines[i].to_string());
+              result.push("//#endregion".to_string());
+              i = j;
+              continue;
+            }
+          }
+        }
+
+        continue;
+      }
+
+      result.push(line.to_string());
+      i += 1;
+    }
+
+    result.join("\n")
+  }
+
+  fn ensure_blank_line_after_imports(code: &str) -> String {
+    let lines: Vec<&str> = code.lines().collect();
+    let mut result: Vec<String> = Vec::new();
+
+    for (i, line) in lines.iter().enumerate() {
+      result.push((*line).to_string());
+
+      let trimmed = line.trim();
+      if trimmed.starts_with("import ") || trimmed.starts_with("export * from ") {
+        if lines.get(i + 1).is_some_and(|next| next.trim().starts_with("//#region")) {
+          result.push(String::new());
+        }
+      }
+    }
+
+    result.join("\n")
+  }
+
+  /// Keep the module id for per-declaration maps. Final `.ts` vs `.d.ts` source
+  /// paths come from Rolldown composition (generate-step maps) in generateBundle.
+  fn module_id_to_ts_source(module_id: &str) -> String {
+    module_id.to_string()
+  }
+
+  fn compose_render_source_map(
+    segments: &[(SourceMap<'static>, u32)],
+    chunk_filename: &str,
+    line_offset: u32,
+  ) -> Option<String> {
+    if segments.is_empty() {
+      return None;
+    }
+
+    compose_render_source_map_inner(segments, chunk_filename, line_offset)
+  }
+
+  fn normalize_whitespace(code: &str) -> String {
+    let lines: Vec<&str> = code.lines().collect();
+    let mut result_lines: Vec<&str> = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+      let line = lines[i];
+      if line.trim().starts_with("import ") {
+        result_lines.push(line);
+        i += 1;
+        while i < lines.len() && lines[i].trim().is_empty() {
+          let next_is_decl = lines.get(i + 1).is_some_and(|next| {
+            let t = next.trim();
+            t.starts_with("type ")
+              || t.starts_with("export ")
+              || t.starts_with("declare ")
+              || t.starts_with("interface ")
+          });
+          if next_is_decl {
+            i += 1;
+          } else {
+            result_lines.push(lines[i]);
+            i += 1;
+          }
+        }
+        continue;
+      }
+      result_lines.push(line);
+      i += 1;
+    }
+
+    let mut result = result_lines.join("\n");
+
+    let re = regex::Regex::new(r"\n\n\n+").unwrap();
+    result = re.replace_all(&result, "\n\n").to_string();
+
+    result.trim_start().trim_end().to_string()
+  }
+
+  fn patch_import_source(import_text: &str) -> String {
+    let re_double = regex::Regex::new(r#""([^"]+)\.d\.(ts|mts|cts)""#).unwrap();
+    let re_single = regex::Regex::new(r"'([^']+)\.d\.(ts|mts|cts)'").unwrap();
+
+    let result = re_double.replace_all(import_text, |caps: &regex::Captures| {
+      let path = &caps[1];
+      let ext = &caps[2];
+      let js_ext = match ext {
+        "mts" => "mjs",
+        "cts" => "cjs",
+        _ => "js",
+      };
+      format!("\"{path}.{js_ext}\"")
+    });
+
+    let result = re_single.replace_all(&result, |caps: &regex::Captures| {
+      let path = &caps[1];
+      let ext = &caps[2];
+      let js_ext = match ext {
+        "mts" => "mjs",
+        "cts" => "cjs",
+        _ => "js",
+      };
+      format!("'{path}.{js_ext}'")
+    });
+
+    result.to_string()
+  }
+}
+
+fn compose_render_source_map_inner(
+  segments: &[(SourceMap<'static>, u32)],
+  chunk_filename: &str,
+  line_offset: u32,
+) -> Option<String> {
+  let refs: Vec<(&SourceMap<'_>, u32)> = segments
+    .iter()
+    .map(|(map, offset)| (map as &SourceMap<'_>, offset.saturating_add(line_offset)))
+    .collect();
+  let builder = ConcatSourceMapBuilder::from_sourcemaps(&refs);
+  let map = builder.into_sourcemap();
+  map.get_tokens().next()?;
+  let mut map = map.into_owned();
+  map = dedupe_source_map_sources_standalone(map);
+  map.set_file(chunk_filename);
+  map.set_source_contents(vec![]);
+  Some(map.to_json_string())
+}
+
+fn dedupe_source_map_sources_standalone(map: SourceMap<'static>) -> SourceMap<'static> {
+  let old_sources: Vec<String> = map.get_sources().map(str::to_owned).collect();
+  let mut canonical_sources: Vec<String> = Vec::new();
+  let mut old_to_new: Vec<u32> = Vec::with_capacity(old_sources.len());
+
+  #[expect(clippy::cast_possible_truncation)]
+  for source in &old_sources {
+    if let Some(idx) = canonical_sources.iter().position(|s| s == source) {
+      old_to_new.push(idx as u32);
+    } else {
+      canonical_sources.push(source.clone());
+      old_to_new.push(canonical_sources.len() as u32 - 1);
+    }
+  }
+
+  #[expect(clippy::cast_possible_truncation)]
+  if old_to_new.iter().enumerate().all(|(i, &n)| n == i as u32) {
+    return map;
+  }
+
+  let tokens: Vec<Token> = map
+    .get_tokens()
+    .map(|token| {
+      let source_id = token.get_source_id().and_then(|id| old_to_new.get(id as usize).copied());
+      Token::new(
+        token.get_dst_line(),
+        token.get_dst_col(),
+        token.get_src_line(),
+        token.get_src_col(),
+        source_id,
+        token.get_name_id(),
+      )
+    })
+    .collect();
+
+  SourceMap::new(
+    map.get_file().map(|f| Cow::Owned(f.to_owned())),
+    map.get_names().map(|n| Cow::Owned(n.to_owned())).collect(),
+    map.get_source_root().map(|s| Cow::Owned(s.to_owned())),
+    canonical_sources.into_iter().map(Cow::Owned).collect(),
+    vec![],
+    tokens.into_boxed_slice(),
+    None,
+  )
+}
+
+/// Include leading JSDoc/block/line comments when computing a declaration's source span.
+fn find_leading_comment_start(source: &str, decl_start: usize) -> usize {
+  let bytes = source.as_bytes();
+  let mut pos = decl_start;
+
+  loop {
+    while pos > 0 && matches!(bytes[pos - 1], b' ' | b'\t' | b'\r') {
+      pos -= 1;
+    }
+
+    if pos == 0 {
+      break;
+    }
+
+    // Only skip newlines when they precede a comment (not a previous declaration).
+    let mut scan = pos;
+    while scan > 0 && bytes[scan - 1].is_ascii_whitespace() {
+      scan -= 1;
+    }
+
+    if scan == 0 {
+      break;
+    }
+
+    if scan >= 2 && bytes[scan - 2] == b'*' && bytes[scan - 1] == b'/' {
+      pos = scan;
+    } else if scan > 0 {
+      let mut line_start = scan;
+      while line_start > 0 && bytes[line_start - 1] != b'\n' {
+        line_start -= 1;
+      }
+      let line = &source[line_start..scan];
+      let trimmed = line.trim();
+      if trimmed.starts_with("//") && !trimmed.starts_with("/// <reference") {
+        pos = line_start;
+      } else {
+        break;
+      }
+    } else {
+      break;
+    }
+
+    if pos >= 2 && bytes[pos - 2] == b'*' && bytes[pos - 1] == b'/' {
+      let end_pos = pos;
+      pos -= 2;
+      let mut found = false;
+      while pos > 0 {
+        if bytes[pos - 1] == b'/' && bytes[pos] == b'*' {
+          pos -= 1; // include the `/`
+          found = true;
+          break;
+        }
+        pos -= 1;
+      }
+      if bytes.get(pos) == Some(&b'/') && bytes.get(pos + 1) == Some(&b'*') {
+        found = true;
+      }
+      if !found {
+        pos = end_pos;
+        break;
+      }
+      continue;
+    }
+
+    if pos > 0 {
+      let mut line_start = pos;
+      while line_start > 0 && bytes[line_start - 1] != b'\n' {
+        line_start -= 1;
+      }
+      let line = &source[line_start..pos];
+      let trimmed = line.trim();
+      if trimmed.starts_with("//") && !trimmed.starts_with("/// <reference") {
+        pos = line_start;
+        continue;
+      }
+    }
+
+    break;
+  }
+
+  pos
+}
+
+/// After rename, rewrite `export { Item$1 }` inside namespaces to `export { Item$1 as Item }`.
+fn fix_namespace_export_specifiers(source: &str, renames: &[(String, String)]) -> String {
+  let rename_map: FxHashMap<&str, &str> =
+    renames.iter().map(|(old, new)| (new.as_str(), old.as_str())).collect();
+
+  let allocator = Allocator::default();
+  let source_type = SourceType::d_ts();
+  let parser = Parser::new(&allocator, source, source_type);
+  let parse_result = parser.parse();
+
+  if parse_result.panicked {
+    return source.to_string();
+  }
+
+  let mut replacements: Vec<(usize, usize, String)> = Vec::new();
+
+  for stmt in &parse_result.program.body {
+    collect_ns_export_fixes(stmt, &rename_map, &mut replacements);
+  }
+
+  if replacements.is_empty() {
+    return source.to_string();
+  }
+
+  replacements.sort_by_key(|(start, _, _)| std::cmp::Reverse(*start));
+  let mut result = source.to_string();
+  for (start, end, replacement) in replacements {
+    if start < result.len() && end <= result.len() {
+      result = format!("{}{}{}", &result[..start], replacement, &result[end..]);
+    }
+  }
+
+  result
+}
+
+fn collect_ns_export_fixes(
+  stmt: &Statement,
+  rename_map: &FxHashMap<&str, &str>,
+  replacements: &mut Vec<(usize, usize, String)>,
+) {
+  if let Statement::TSNamespaceDeclaration(module) = stmt {
+    collect_ns_export_fixes_from_body(&module.body, rename_map, replacements);
+  }
+}
+
+fn collect_ns_export_fixes_from_body(
+  body: &TSNamespaceDeclarationBody,
+  rename_map: &FxHashMap<&str, &str>,
+  replacements: &mut Vec<(usize, usize, String)>,
+) {
+  match body {
+    TSNamespaceDeclarationBody::TSModuleBlock(block) => {
+      for inner_stmt in &block.body {
+        if let Statement::ExportNamedDeclaration(export) = inner_stmt
+          && !export.specifiers.is_empty()
+        {
+          let mut new_specifiers = Vec::new();
+          let mut any_changed = false;
+
+          for spec in &export.specifiers {
+            let local_name = spec.local.name().to_string();
+            let exported_name = spec.exported.name().to_string();
+
+            if let Some(&original_name) = rename_map.get(local_name.as_str()) {
+              if exported_name == local_name {
+                new_specifiers.push(format!("{local_name} as {original_name}"));
+                any_changed = true;
+              } else {
+                new_specifiers.push(format!("{local_name} as {exported_name}"));
+              }
+            } else if local_name == exported_name {
+              new_specifiers.push(local_name);
+            } else {
+              new_specifiers.push(format!("{local_name} as {exported_name}"));
+            }
+          }
+
+          if any_changed {
+            let export_span = export.span();
+            let replacement = format!("export {{ {} }};", new_specifiers.join(", "));
+            replacements.push((export_span.start as usize, export_span.end as usize, replacement));
+          }
+        }
+        collect_ns_export_fixes(inner_stmt, rename_map, replacements);
+      }
+    }
+    TSNamespaceDeclarationBody::TSNamespaceDeclaration(inner) => {
+      collect_ns_export_fixes_from_body(&inner.body, rename_map, replacements);
+    }
+  }
+}
+
+/// Replace an identifier in source text using word-boundary matching.
+/// This avoids partial matches (e.g., replacing "T" in "TypeInfo").
+fn replace_identifier(source: &str, old_name: &str, new_name: &str) -> String {
+  replace_identifier_except_spans(source, old_name, new_name, &[])
+}
+
+/// Like [`replace_identifier`], but skips matches that overlap any of `skip_spans`.
+fn replace_identifier_except_spans(
+  source: &str,
+  old_name: &str,
+  new_name: &str,
+  skip_spans: &[(u32, u32)],
+) -> String {
+  let pattern = format!(r"\b{}\b", regex::escape(old_name));
+  let re = regex::Regex::new(&pattern).unwrap();
+
+  // `\b` treats `$` as non-word, so `\bB\b` matches the `B` in `B$1` (skip those).
+  let mut result = String::with_capacity(source.len());
+  let mut last_end = 0;
+
+  for mat in re.find_iter(source) {
+    let match_start = mat.start();
+    let match_end = mat.end();
+    if source[match_end..].starts_with('$') {
+      result.push_str(&source[last_end..match_end]);
+      last_end = match_end;
+      continue;
+    }
+    let overlaps_skip = skip_spans.iter().any(|&(s, e)| {
+      let s = s as usize;
+      let e = e as usize;
+      match_start < e && match_end > s
+    });
+    if overlaps_skip {
+      result.push_str(&source[last_end..match_end]);
+      last_end = match_end;
+      continue;
+    }
+    // `typeof` / `infer` operands are dep refs, not bindings.
+    let before = &source[last_end..match_start];
+    if before.trim_end().ends_with("typeof") {
+      result.push_str(&source[last_end..match_end]);
+      last_end = match_end;
+      continue;
+    }
+    if before.trim_end().ends_with("infer") {
+      result.push_str(&source[last_end..match_end]);
+      last_end = match_end;
+      continue;
+    }
+    result.push_str(&source[last_end..match_start]);
+    result.push_str(new_name);
+    last_end = match_end;
+  }
+  result.push_str(&source[last_end..]);
+  result
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn replace_dependency_spans(
+    source: &mut String,
+    dep_refs: &[(String, u32, u32)],
+    old_name: &str,
+    new_name: &str,
+  ) {
+    let mut spans: Vec<(u32, u32)> = dep_refs
+      .iter()
+      .filter(|(name, _, _)| name == old_name)
+      .map(|(_, start, end)| (*start, *end))
+      .collect();
+    spans.sort_by_key(|(start, _)| std::cmp::Reverse(*start));
+    for (start, end) in spans {
+      let start = start as usize;
+      let end = end as usize;
+      if start < end && end <= source.len() {
+        source.replace_range(start..end, new_name);
+      }
+    }
+  }
+
+  #[test]
+  fn test_plugin_creation() {
+    let options = FakeJsOptions::default();
+    let plugin = FakeJsPlugin::new(options);
+    assert!(!plugin.options.sourcemap);
+  }
+
+  #[test]
+  fn test_transform_non_dts() {
+    let options = FakeJsOptions::default();
+    let plugin = FakeJsPlugin::new(options);
+    let code = "const x = 1;";
+    let result = plugin.transform(code, "test.ts").unwrap();
+    assert_eq!(result.code, code);
+  }
+
+  #[test]
+  fn test_transform_simple_interface() {
+    let options = FakeJsOptions::default();
+    let plugin = FakeJsPlugin::new(options);
+    let code = "export interface Foo { bar: string; }";
+    let result = plugin.transform(code, "test.d.ts").unwrap();
+    assert!(result.code.contains("var Foo"));
+    assert!(result.code.contains("export"));
+  }
+
+  #[test]
+  fn test_transform_declare_global_side_effect() {
+    let options = FakeJsOptions { side_effects: true, ..FakeJsOptions::default() };
+    let plugin = FakeJsPlugin::new(options);
+    let code = "declare global {\n  let sideEffectExecuted: boolean\n}\n\nexport {}";
+    let result = plugin.transform(code, "mod.d.ts").unwrap();
+    assert!(result.code.contains("var _0"), "expected runtime binding, got: {}", result.code);
+  }
+
+  #[test]
+  fn test_infer_false_branch_render_with_local_u() {
+    let options = FakeJsOptions::default();
+    let plugin = FakeJsPlugin::new(options);
+    let code = "type U = 'local'\nexport type Test<T> = T extends Array<infer U> ? (T extends Array<infer U2> ? U2 : U) : U";
+    plugin.transform(code, "index.d.ts").unwrap();
+    let chunk = "var U = [0, () => [], []]\nexport var Test = [1, (T) => [U$1], []]";
+    let result = plugin
+      .render_chunk(
+        chunk,
+        &ChunkInfo { filename: "index.d.ts".into(), module_ids: vec!["index.d.ts".into()] },
+      )
+      .unwrap();
+    assert!(
+      result.code.contains(": U$1"),
+      "expected false-branch dep rename, got: {}",
+      result.code
+    );
+  }
+
+  #[test]
+  fn test_infer_false_branch_render() {
+    let options = FakeJsOptions::default();
+    let plugin = FakeJsPlugin::new(options);
+    let code =
+      "export type Test<T> = T extends Array<infer U> ? (T extends Array<infer U2> ? U2 : U) : U";
+    plugin.transform(code, "index.d.ts").unwrap();
+    let chunk = "export var Test = [0, (T) => [U$1], []]";
+    let result = plugin
+      .render_chunk(
+        chunk,
+        &ChunkInfo { filename: "index.d.ts".into(), module_ids: vec!["index.d.ts".into()] },
+      )
+      .unwrap();
+    assert!(
+      result.code.contains(": U$1"),
+      "expected false-branch dep rename, got: {}",
+      result.code
+    );
+  }
+
+  #[test]
+  fn test_replace_identifier() {
+    assert_eq!(replace_identifier("T extends Foo<T>", "T", "T$1"), "T$1 extends Foo<T$1>");
+    // \bT\b should NOT match T in TypeInfo since T is followed by word char 'y'
+    assert_eq!(replace_identifier("type T = TypeInfo", "T", "T$1"), "type T$1 = TypeInfo");
+    assert_eq!(replace_identifier("Foo extends Bar", "Foo", "Baz"), "Baz extends Bar");
+    // Should NOT double-rename: B$1 should stay B$1, not become B$1$1
+    assert_eq!(
+      replace_identifier("B$1 extends SomeInterface", "B", "B$1"),
+      "B$1 extends SomeInterface"
+    );
+    // Should still rename B that is NOT followed by $
+    assert_eq!(replace_identifier("B extends B$1", "B", "B$2"), "B$2 extends B$1");
+    // Dependency renames use span-based replacement; replace_identifier is for bindings/params only.
+    let mut nested =
+      "T extends Array<infer U> ? (T extends Array<infer U2> ? U2 : U) : U".to_string();
+    let last_u = u32::try_from(nested.rfind('U').unwrap()).unwrap();
+    replace_dependency_spans(&mut nested, &[("U".to_string(), last_u, last_u + 1)], "U", "U$2");
+    assert_eq!(nested, "T extends Array<infer U> ? (T extends Array<infer U2> ? U2 : U) : U$2");
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/type_params.rs
+++ b/crates/rolldown_plugin_fake_js/src/type_params.rs
@@ -1,0 +1,39 @@
+use crate::types::TypeParam;
+use oxc::ast::ast::TSTypeParameter;
+use oxc::ast_visit::Visit;
+use std::collections::HashMap;
+
+pub struct TypeParamCollector<'a> {
+  params: HashMap<String, usize>,
+  _phantom: std::marker::PhantomData<&'a ()>,
+}
+
+impl TypeParamCollector<'_> {
+  pub fn new() -> Self {
+    Self { params: HashMap::new(), _phantom: std::marker::PhantomData }
+  }
+
+  pub fn into_params(self) -> Vec<TypeParam> {
+    self.params.into_iter().map(|(name, occurrences)| TypeParam { name, occurrences }).collect()
+  }
+}
+
+impl<'a> Visit<'a> for TypeParamCollector<'a> {
+  fn visit_ts_type_parameter(&mut self, node: &TSTypeParameter<'a>) {
+    let name = node.name.name.to_string();
+    *self.params.entry(name).or_insert(0) += 1;
+
+    if let Some(constraint) = &node.constraint {
+      self.visit_ts_type(constraint);
+    }
+    if let Some(default) = &node.default {
+      self.visit_ts_type(default);
+    }
+  }
+}
+
+impl Default for TypeParamCollector<'_> {
+  fn default() -> Self {
+    Self::new()
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/type_params.rs
+++ b/crates/rolldown_plugin_fake_js/src/type_params.rs
@@ -1,0 +1,61 @@
+use oxc::ast::ast::{TSInferType, TSMappedType, TSTypeParameter};
+use oxc::ast_visit::Visit;
+use rustc_hash::FxHashMap;
+
+use crate::types::TypeParam;
+
+pub struct TypeParamCollector<'a> {
+  params: FxHashMap<String, usize>,
+  _phantom: std::marker::PhantomData<&'a ()>,
+}
+
+impl TypeParamCollector<'_> {
+  pub fn new() -> Self {
+    Self { params: FxHashMap::default(), _phantom: std::marker::PhantomData }
+  }
+
+  pub fn into_params(self) -> Vec<TypeParam> {
+    self.params.into_iter().map(|(name, occurrences)| TypeParam { name, occurrences }).collect()
+  }
+}
+
+impl<'a> Visit<'a> for TypeParamCollector<'a> {
+  // Babel only collects declaration `typeParameters`. Skip registering `infer U` /
+  // mapped `K` as params (they'd otherwise enter the deps-fn and break rename).
+  fn visit_ts_infer_type(&mut self, node: &TSInferType<'a>) {
+    if let Some(constraint) = &node.type_parameter.constraint {
+      self.visit_ts_type(constraint);
+    }
+    if let Some(default) = &node.type_parameter.default {
+      self.visit_ts_type(default);
+    }
+  }
+
+  fn visit_ts_mapped_type(&mut self, node: &TSMappedType<'a>) {
+    self.visit_ts_type(&node.constraint);
+    if let Some(name_type) = &node.name_type {
+      self.visit_ts_type(name_type);
+    }
+    if let Some(type_ann) = &node.type_annotation {
+      self.visit_ts_type(type_ann);
+    }
+  }
+
+  fn visit_ts_type_parameter(&mut self, node: &TSTypeParameter<'a>) {
+    let name = node.name.name.to_string();
+    *self.params.entry(name).or_insert(0) += 1;
+
+    if let Some(constraint) = &node.constraint {
+      self.visit_ts_type(constraint);
+    }
+    if let Some(default) = &node.default {
+      self.visit_ts_type(default);
+    }
+  }
+}
+
+impl Default for TypeParamCollector<'_> {
+  fn default() -> Self {
+    Self::new()
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/types.rs
+++ b/crates/rolldown_plugin_fake_js/src/types.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+
+pub type Result<T> = anyhow::Result<T>;
+
+#[derive(Debug, Clone, Default)]
+pub struct FakeJsOptions {
+  pub sourcemap: bool,
+  pub cjs_default: bool,
+  pub side_effects: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeclarationInfo {
+  pub id: usize,
+  #[expect(dead_code)]
+  pub bindings: Vec<String>,
+  pub type_params: Vec<TypeParam>,
+  #[expect(dead_code)]
+  pub deps: Vec<String>,
+  #[expect(dead_code)]
+  pub children: Vec<(u32, u32)>,
+  pub source: String,
+  #[expect(dead_code)]
+  pub is_side_effect: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct TypeParam {
+  pub name: String,
+  #[expect(dead_code)]
+  pub occurrences: usize,
+}
+
+#[derive(Debug)]
+pub struct PluginState {
+  pub declaration_idx: usize,
+  pub identifier_map: HashMap<String, usize>,
+  pub declaration_map: HashMap<usize, DeclarationInfo>,
+  pub comments_map: HashMap<String, Vec<String>>,
+  pub type_only_map: HashMap<String, Vec<String>>,
+}
+
+impl Default for PluginState {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl PluginState {
+  pub fn new() -> Self {
+    Self {
+      declaration_idx: 0,
+      identifier_map: HashMap::new(),
+      declaration_map: HashMap::new(),
+      comments_map: HashMap::new(),
+      type_only_map: HashMap::new(),
+    }
+  }
+
+  #[expect(dead_code)]
+  pub fn get_identifier_index(&mut self, name: &str) -> usize {
+    let entry = self.identifier_map.entry(name.to_string()).or_insert(0);
+    let idx = *entry;
+    *entry += 1;
+    idx
+  }
+
+  pub fn register_declaration(&mut self, mut info: DeclarationInfo) -> usize {
+    let id = self.declaration_idx;
+    self.declaration_idx += 1;
+    info.id = id;
+    self.declaration_map.insert(id, info);
+    id
+  }
+
+  pub fn get_declaration(&self, id: usize) -> Option<&DeclarationInfo> {
+    self.declaration_map.get(&id)
+  }
+
+  #[expect(dead_code)]
+  pub fn get_declaration_mut(&mut self, id: usize) -> Option<&mut DeclarationInfo> {
+    self.declaration_map.get_mut(&id)
+  }
+}
+
+#[derive(Debug)]
+pub struct TransformResult {
+  pub code: String,
+  pub map: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct ChunkInfo {
+  pub filename: String,
+  pub module_ids: Vec<String>,
+}

--- a/crates/rolldown_plugin_fake_js/src/types.rs
+++ b/crates/rolldown_plugin_fake_js/src/types.rs
@@ -1,0 +1,97 @@
+use rustc_hash::{FxHashMap, FxHashSet};
+
+pub type Result<T> = anyhow::Result<T>;
+
+#[derive(Debug, Clone, Default)]
+pub struct FakeJsOptions {
+  pub sourcemap: bool,
+  pub cjs_default: bool,
+  pub side_effects: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeclarationInfo {
+  pub id: usize,
+  pub bindings: Vec<String>,
+  pub type_params: Vec<TypeParam>,
+  pub deps: Vec<String>,
+  pub dep_refs: Vec<(String, u32, u32)>,
+  #[expect(dead_code)]
+  pub children: Vec<(u32, u32)>,
+  pub child_literals: Vec<String>,
+  pub source: String,
+  pub is_side_effect: bool,
+  pub module_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TypeParam {
+  pub name: String,
+  #[expect(dead_code)]
+  pub occurrences: usize,
+}
+
+#[derive(Debug)]
+pub struct PluginState {
+  pub declaration_idx: usize,
+  pub identifier_map: FxHashMap<String, usize>,
+  pub declaration_map: FxHashMap<usize, DeclarationInfo>,
+  pub comments_map: FxHashMap<String, Vec<String>>,
+  pub type_only_map: FxHashMap<String, Vec<String>>,
+  pub external_inline_imports: FxHashMap<String, FxHashSet<String>>,
+}
+
+impl Default for PluginState {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl PluginState {
+  pub fn new() -> Self {
+    Self {
+      declaration_idx: 0,
+      identifier_map: FxHashMap::default(),
+      declaration_map: FxHashMap::default(),
+      comments_map: FxHashMap::default(),
+      type_only_map: FxHashMap::default(),
+      external_inline_imports: FxHashMap::default(),
+    }
+  }
+
+  pub fn get_identifier_index(&mut self, name: &str) -> usize {
+    let entry = self.identifier_map.entry(name.to_string()).or_insert(0);
+    let idx = *entry;
+    *entry += 1;
+    idx
+  }
+
+  pub fn register_declaration(&mut self, mut info: DeclarationInfo) -> usize {
+    let id = self.declaration_idx;
+    self.declaration_idx += 1;
+    info.id = id;
+    self.declaration_map.insert(id, info);
+    id
+  }
+
+  pub fn get_declaration(&self, id: usize) -> Option<&DeclarationInfo> {
+    self.declaration_map.get(&id)
+  }
+
+  #[expect(dead_code)]
+  pub fn get_declaration_mut(&mut self, id: usize) -> Option<&mut DeclarationInfo> {
+    self.declaration_map.get_mut(&id)
+  }
+}
+
+#[derive(Debug)]
+pub struct TransformResult {
+  pub code: String,
+  pub map: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct ChunkInfo {
+  pub filename: String,
+  pub module_ids: Vec<String>,
+}

--- a/crates/rolldown_plugin_fake_js/src/visitor.rs
+++ b/crates/rolldown_plugin_fake_js/src/visitor.rs
@@ -1,0 +1,317 @@
+use oxc::ast::ast::{
+  BindingPattern, Declaration, ExportDefaultDeclaration, ExportDefaultDeclarationKind,
+  ExportNamedDeclaration, Program, Statement, TSModuleDeclarationKind, TSModuleDeclarationName,
+};
+use oxc::ast_visit::Visit;
+use oxc::span::Span;
+
+#[derive(Debug, Clone)]
+pub struct DeclarationNode {
+  #[expect(dead_code)]
+  pub kind: DeclarationKind,
+  pub bindings: Vec<String>,
+  pub span: Span,
+  pub is_export: bool,
+  pub is_default: bool,
+  pub is_side_effect: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DeclarationKind {
+  Function,
+  Class,
+  Interface,
+  TypeAlias,
+  Enum,
+  Variable,
+  Namespace,
+}
+
+pub struct DeclarationCollector {
+  pub declarations: Vec<DeclarationNode>,
+}
+
+impl DeclarationCollector {
+  pub fn new() -> Self {
+    Self { declarations: Vec::new() }
+  }
+
+  fn extract_binding_names(pattern: &BindingPattern) -> Vec<String> {
+    match pattern {
+      BindingPattern::BindingIdentifier(id) => {
+        vec![id.name.to_string()]
+      }
+      BindingPattern::ObjectPattern(obj) => {
+        let mut names = Vec::new();
+        for prop in &obj.properties {
+          names.extend(Self::extract_binding_names(&prop.value));
+        }
+        names
+      }
+      BindingPattern::ArrayPattern(arr) => {
+        let mut names = Vec::new();
+        for elem in arr.elements.iter().flatten() {
+          names.extend(Self::extract_binding_names(elem));
+        }
+        names
+      }
+      BindingPattern::AssignmentPattern(assign) => Self::extract_binding_names(&assign.left),
+    }
+  }
+}
+
+impl<'a> Visit<'a> for DeclarationCollector {
+  fn visit_program(&mut self, program: &Program<'a>) {
+    for stmt in &program.body {
+      self.visit_statement(stmt);
+    }
+  }
+
+  fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
+    if let Some(declaration) = &decl.declaration {
+      let is_default = decl.export_kind == oxc::ast::ast::ImportOrExportKind::Value
+        && matches!(
+          declaration,
+          Declaration::TSInterfaceDeclaration(_) | Declaration::TSTypeAliasDeclaration(_)
+        );
+
+      self.collect_declaration(declaration, true, is_default);
+    }
+  }
+
+  fn visit_export_default_declaration(&mut self, decl: &ExportDefaultDeclaration<'a>) {
+    match &decl.declaration {
+      ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
+        let binding = func
+          .id
+          .as_ref()
+          .map(|id| id.name.to_string())
+          .unwrap_or_else(|| "export_default".to_string());
+
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Function,
+          bindings: vec![binding],
+          span: func.span,
+          is_export: true,
+          is_default: true,
+          is_side_effect: false,
+        });
+      }
+      ExportDefaultDeclarationKind::ClassDeclaration(class) => {
+        let binding = class
+          .id
+          .as_ref()
+          .map(|id| id.name.to_string())
+          .unwrap_or_else(|| "export_default".to_string());
+
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Class,
+          bindings: vec![binding],
+          span: class.span,
+          is_export: true,
+          is_default: true,
+          is_side_effect: false,
+        });
+      }
+      _ => {}
+    }
+  }
+
+  fn visit_statement(&mut self, stmt: &Statement<'a>) {
+    match stmt {
+      Statement::ExportNamedDeclaration(decl) => {
+        self.visit_export_named_declaration(decl);
+      }
+      Statement::ExportDefaultDeclaration(decl) => {
+        self.visit_export_default_declaration(decl);
+      }
+      Statement::TSInterfaceDeclaration(decl) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Interface,
+          bindings: vec![decl.id.name.to_string()],
+          span: decl.span,
+          is_export: false,
+          is_default: false,
+          is_side_effect: false,
+        });
+      }
+      Statement::TSTypeAliasDeclaration(decl) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::TypeAlias,
+          bindings: vec![decl.id.name.to_string()],
+          span: decl.span,
+          is_export: false,
+          is_default: false,
+          is_side_effect: false,
+        });
+      }
+      Statement::TSEnumDeclaration(decl) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Enum,
+          bindings: vec![decl.id.name.to_string()],
+          span: decl.span,
+          is_export: false,
+          is_default: false,
+          is_side_effect: false,
+        });
+      }
+      Statement::VariableDeclaration(decl) => {
+        let bindings: Vec<String> =
+          decl.declarations.iter().flat_map(|d| Self::extract_binding_names(&d.id)).collect();
+
+        if !bindings.is_empty() {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Variable,
+            bindings,
+            span: decl.span,
+            is_export: false,
+            is_default: false,
+            is_side_effect: false,
+          });
+        }
+      }
+      Statement::TSModuleDeclaration(decl) => {
+        let binding = match &decl.id {
+          TSModuleDeclarationName::Identifier(id) => id.name.to_string(),
+          TSModuleDeclarationName::StringLiteral(lit) => lit.value.to_string(),
+        };
+
+        let is_side_effect = decl.kind != TSModuleDeclarationKind::Namespace;
+
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Namespace,
+          bindings: vec![binding],
+          span: decl.span,
+          is_export: false,
+          is_default: false,
+          is_side_effect,
+        });
+      }
+      Statement::FunctionDeclaration(func) => {
+        if let Some(id) = &func.id {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Function,
+            bindings: vec![id.name.to_string()],
+            span: func.span,
+            is_export: false,
+            is_default: false,
+            is_side_effect: false,
+          });
+        }
+      }
+      Statement::ClassDeclaration(class) => {
+        if let Some(id) = &class.id {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Class,
+            bindings: vec![id.name.to_string()],
+            span: class.span,
+            is_export: false,
+            is_default: false,
+            is_side_effect: false,
+          });
+        }
+      }
+      _ => {}
+    }
+  }
+}
+
+impl DeclarationCollector {
+  fn collect_declaration(&mut self, declaration: &Declaration, is_export: bool, is_default: bool) {
+    match declaration {
+      Declaration::FunctionDeclaration(func) => {
+        if let Some(id) = &func.id {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Function,
+            bindings: vec![id.name.to_string()],
+            span: func.span,
+            is_export,
+            is_default,
+            is_side_effect: false,
+          });
+        }
+      }
+      Declaration::ClassDeclaration(class) => {
+        if let Some(id) = &class.id {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Class,
+            bindings: vec![id.name.to_string()],
+            span: class.span,
+            is_export,
+            is_default,
+            is_side_effect: false,
+          });
+        }
+      }
+      Declaration::VariableDeclaration(var_decl) => {
+        let bindings: Vec<String> =
+          var_decl.declarations.iter().flat_map(|d| Self::extract_binding_names(&d.id)).collect();
+
+        if !bindings.is_empty() {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Variable,
+            bindings,
+            span: var_decl.span,
+            is_export,
+            is_default,
+            is_side_effect: false,
+          });
+        }
+      }
+      Declaration::TSInterfaceDeclaration(interface) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Interface,
+          bindings: vec![interface.id.name.to_string()],
+          span: interface.span,
+          is_export,
+          is_default,
+          is_side_effect: false,
+        });
+      }
+      Declaration::TSTypeAliasDeclaration(type_alias) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::TypeAlias,
+          bindings: vec![type_alias.id.name.to_string()],
+          span: type_alias.span,
+          is_export,
+          is_default,
+          is_side_effect: false,
+        });
+      }
+      Declaration::TSEnumDeclaration(enum_decl) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Enum,
+          bindings: vec![enum_decl.id.name.to_string()],
+          span: enum_decl.span,
+          is_export,
+          is_default,
+          is_side_effect: false,
+        });
+      }
+      Declaration::TSModuleDeclaration(module) => {
+        let binding = match &module.id {
+          TSModuleDeclarationName::Identifier(id) => id.name.to_string(),
+          TSModuleDeclarationName::StringLiteral(lit) => lit.value.to_string(),
+        };
+
+        let is_side_effect = module.kind != TSModuleDeclarationKind::Namespace;
+
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Namespace,
+          bindings: vec![binding],
+          span: module.span,
+          is_export,
+          is_default,
+          is_side_effect,
+        });
+      }
+      _ => {}
+    }
+  }
+}
+
+impl Default for DeclarationCollector {
+  fn default() -> Self {
+    Self::new()
+  }
+}

--- a/crates/rolldown_plugin_fake_js/src/visitor.rs
+++ b/crates/rolldown_plugin_fake_js/src/visitor.rs
@@ -1,0 +1,354 @@
+use oxc::ast::ast::{
+  BindingPattern, Declaration, ExportDeclaration, ExportDefaultDeclaration,
+  ExportDefaultDeclarationKind, Program, Statement, TSNamespaceDeclarationKind,
+};
+use oxc::ast_visit::Visit;
+use oxc::span::Span;
+
+#[derive(Debug, Clone)]
+pub struct DeclarationNode {
+  #[expect(dead_code)]
+  pub kind: DeclarationKind,
+  pub bindings: Vec<String>,
+  pub span: Span,
+  pub is_export: bool,
+  pub is_default: bool,
+  pub is_side_effect: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DeclarationKind {
+  Function,
+  Class,
+  Interface,
+  TypeAlias,
+  Enum,
+  Variable,
+  Namespace,
+}
+
+pub struct DeclarationCollector {
+  pub declarations: Vec<DeclarationNode>,
+}
+
+impl DeclarationCollector {
+  pub fn new() -> Self {
+    Self { declarations: Vec::new() }
+  }
+
+  fn extract_binding_names(pattern: &BindingPattern) -> Vec<String> {
+    match pattern {
+      BindingPattern::BindingIdentifier(id) => {
+        vec![id.name.to_string()]
+      }
+      BindingPattern::ObjectPattern(obj) => {
+        let mut names = Vec::new();
+        for prop in &obj.properties {
+          names.extend(Self::extract_binding_names(&prop.value));
+        }
+        names
+      }
+      BindingPattern::ArrayPattern(arr) => {
+        let mut names = Vec::new();
+        for elem in arr.elements.iter().flatten() {
+          names.extend(Self::extract_binding_names(elem));
+        }
+        names
+      }
+      BindingPattern::AssignmentPattern(assign) => Self::extract_binding_names(&assign.left),
+    }
+  }
+}
+
+impl<'a> Visit<'a> for DeclarationCollector {
+  fn visit_program(&mut self, program: &Program<'a>) {
+    for stmt in &program.body {
+      self.visit_statement(stmt);
+    }
+  }
+
+  fn visit_export_declaration(&mut self, decl: &ExportDeclaration<'a>) {
+    // Named `export …` decls are never default; real defaults use ExportDefaultDeclaration.
+    self.collect_declaration_with_span(&decl.declaration, decl.span, true, false);
+  }
+
+  fn visit_export_default_declaration(&mut self, decl: &ExportDefaultDeclaration<'a>) {
+    match &decl.declaration {
+      ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
+        let binding = func
+          .id
+          .as_ref()
+          .map(|id| id.name.to_string())
+          .unwrap_or_else(|| "export_default".to_string());
+
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Function,
+          bindings: vec![binding],
+          span: decl.span,
+          is_export: true,
+          is_default: true,
+          is_side_effect: false,
+        });
+      }
+      ExportDefaultDeclarationKind::ClassDeclaration(class) => {
+        let binding = class
+          .id
+          .as_ref()
+          .map(|id| id.name.to_string())
+          .unwrap_or_else(|| "export_default".to_string());
+
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Class,
+          bindings: vec![binding],
+          span: decl.span,
+          is_export: true,
+          is_default: true,
+          is_side_effect: false,
+        });
+      }
+      ExportDefaultDeclarationKind::TSInterfaceDeclaration(iface) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Interface,
+          bindings: vec![iface.id.name.to_string()],
+          span: decl.span,
+          is_export: true,
+          is_default: true,
+          is_side_effect: false,
+        });
+      }
+      _ => {}
+    }
+  }
+
+  fn visit_statement(&mut self, stmt: &Statement<'a>) {
+    match stmt {
+      Statement::ExportDeclaration(decl) => {
+        self.visit_export_declaration(decl);
+      }
+      Statement::ExportDefaultDeclaration(decl) => {
+        self.visit_export_default_declaration(decl);
+      }
+      Statement::TSInterfaceDeclaration(decl) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Interface,
+          bindings: vec![decl.id.name.to_string()],
+          span: decl.span,
+          is_export: false,
+          is_default: false,
+          is_side_effect: false,
+        });
+      }
+      Statement::TSTypeAliasDeclaration(decl) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::TypeAlias,
+          bindings: vec![decl.id.name.to_string()],
+          span: decl.span,
+          is_export: false,
+          is_default: false,
+          is_side_effect: false,
+        });
+      }
+      Statement::TSEnumDeclaration(decl) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Enum,
+          bindings: vec![decl.id.name.to_string()],
+          span: decl.span,
+          is_export: false,
+          is_default: false,
+          is_side_effect: false,
+        });
+      }
+      Statement::VariableDeclaration(decl) => {
+        let bindings: Vec<String> =
+          decl.declarations.iter().flat_map(|d| Self::extract_binding_names(&d.id)).collect();
+
+        if !bindings.is_empty() {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Variable,
+            bindings,
+            span: decl.span,
+            is_export: false,
+            is_default: false,
+            is_side_effect: false,
+          });
+        }
+      }
+      Statement::TSNamespaceDeclaration(decl) => {
+        // One runtime binding for the whole namespace (do not recurse into the body).
+        let binding = decl.id.name.to_string();
+        let is_side_effect = decl.kind != TSNamespaceDeclarationKind::Namespace;
+
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Namespace,
+          bindings: vec![binding],
+          span: decl.span,
+          is_export: false,
+          is_default: false,
+          is_side_effect,
+        });
+      }
+      Statement::TSExternalModuleDeclaration(decl) => {
+        let binding = decl.id.value.to_string();
+
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Namespace,
+          bindings: vec![binding],
+          span: decl.span,
+          is_export: false,
+          is_default: false,
+          is_side_effect: true,
+        });
+      }
+      Statement::TSGlobalDeclaration(decl) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Namespace,
+          bindings: vec!["global".to_string()],
+          span: decl.span,
+          is_export: false,
+          is_default: false,
+          is_side_effect: true,
+        });
+      }
+      Statement::FunctionDeclaration(func) => {
+        if let Some(id) = &func.id {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Function,
+            bindings: vec![id.name.to_string()],
+            span: func.span,
+            is_export: false,
+            is_default: false,
+            is_side_effect: false,
+          });
+        }
+      }
+      Statement::ClassDeclaration(class) => {
+        if let Some(id) = &class.id {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Class,
+            bindings: vec![id.name.to_string()],
+            span: class.span,
+            is_export: false,
+            is_default: false,
+            is_side_effect: false,
+          });
+        }
+      }
+      _ => {}
+    }
+  }
+}
+
+impl DeclarationCollector {
+  fn collect_declaration_with_span(
+    &mut self,
+    declaration: &Declaration,
+    span: Span,
+    is_export: bool,
+    is_default: bool,
+  ) {
+    match declaration {
+      Declaration::FunctionDeclaration(func) => {
+        if let Some(id) = &func.id {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Function,
+            bindings: vec![id.name.to_string()],
+            span,
+            is_export,
+            is_default,
+            is_side_effect: false,
+          });
+        }
+      }
+      Declaration::ClassDeclaration(class) => {
+        if let Some(id) = &class.id {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Class,
+            bindings: vec![id.name.to_string()],
+            span,
+            is_export,
+            is_default,
+            is_side_effect: false,
+          });
+        }
+      }
+      Declaration::VariableDeclaration(var_decl) => {
+        let bindings: Vec<String> =
+          var_decl.declarations.iter().flat_map(|d| Self::extract_binding_names(&d.id)).collect();
+
+        if !bindings.is_empty() {
+          self.declarations.push(DeclarationNode {
+            kind: DeclarationKind::Variable,
+            bindings,
+            span,
+            is_export,
+            is_default,
+            is_side_effect: false,
+          });
+        }
+      }
+      Declaration::TSInterfaceDeclaration(interface) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Interface,
+          bindings: vec![interface.id.name.to_string()],
+          span,
+          is_export,
+          is_default,
+          is_side_effect: false,
+        });
+      }
+      Declaration::TSTypeAliasDeclaration(type_alias) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::TypeAlias,
+          bindings: vec![type_alias.id.name.to_string()],
+          span,
+          is_export,
+          is_default,
+          is_side_effect: false,
+        });
+      }
+      Declaration::TSEnumDeclaration(enum_decl) => {
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Enum,
+          bindings: vec![enum_decl.id.name.to_string()],
+          span,
+          is_export,
+          is_default,
+          is_side_effect: false,
+        });
+      }
+      Declaration::TSNamespaceDeclaration(module) => {
+        // One runtime binding for the whole namespace (do not recurse into the body).
+        let binding = module.id.name.to_string();
+        let is_side_effect = module.kind != TSNamespaceDeclarationKind::Namespace;
+
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Namespace,
+          bindings: vec![binding],
+          span,
+          is_export,
+          is_default,
+          is_side_effect,
+        });
+      }
+      Declaration::TSExternalModuleDeclaration(module) => {
+        let binding = module.id.value.to_string();
+
+        self.declarations.push(DeclarationNode {
+          kind: DeclarationKind::Namespace,
+          bindings: vec![binding],
+          span,
+          is_export,
+          is_default,
+          is_side_effect: true,
+        });
+      }
+      _ => {}
+    }
+  }
+}
+
+impl Default for DeclarationCollector {
+  fn default() -> Self {
+    Self::new()
+  }
+}

--- a/crates/rolldown_plugin_fake_js/tests/integration_test.rs
+++ b/crates/rolldown_plugin_fake_js/tests/integration_test.rs
@@ -1,0 +1,342 @@
+use rolldown_plugin_fake_js::{ChunkInfo, FakeJsOptions, FakeJsPlugin};
+
+#[test]
+fn test_simple_interface() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export interface Foo { bar: string; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Foo"));
+  assert!(result.code.contains("export"));
+}
+
+#[test]
+fn test_interface_with_extends() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export interface Bar extends Foo { baz: number; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Bar"));
+  assert!(result.code.contains("Foo"));
+}
+
+#[test]
+fn test_type_alias() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export type MyType = string | number;";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyType"));
+}
+
+#[test]
+fn test_function_declaration() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export declare function foo(x: number): string;";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var foo"));
+}
+
+#[test]
+fn test_class_declaration() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export declare class MyClass { prop: string; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyClass"));
+}
+
+#[test]
+fn test_enum_declaration() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export enum Color { Red, Green, Blue }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Color"));
+}
+
+#[test]
+fn test_default_export() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export default class Foo { bar: string; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("as default"));
+}
+
+#[test]
+fn test_generic_type() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export interface Box<T> { value: T; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Box"));
+  assert!(result.code.contains('('));
+}
+
+#[test]
+fn test_multiple_declarations() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export interface Foo { a: string; }
+export interface Bar { b: number; }
+export type Baz = Foo | Bar;
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Foo"));
+  assert!(result.code.contains("var Bar"));
+  assert!(result.code.contains("var Baz"));
+}
+
+#[test]
+fn test_non_dts_file() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "const x = 1;";
+  let result = plugin.transform(code, "test.ts").unwrap();
+
+  assert_eq!(result.code, code);
+}
+
+#[test]
+fn test_sourcemap_option() {
+  let options = FakeJsOptions { sourcemap: true, ..Default::default() };
+  let plugin = FakeJsPlugin::new(options);
+  let code = "export interface Foo { bar: string; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.map.is_some());
+}
+
+#[test]
+fn test_side_effects_option() {
+  let options = FakeJsOptions { side_effects: true, ..Default::default() };
+  let plugin = FakeJsPlugin::new(options);
+  let code = "export interface Foo { bar: string; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("sideEffect"));
+}
+
+#[test]
+fn test_render_chunk() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+
+  let code = "export interface Foo { bar: string; }";
+  let _ = plugin.transform(code, "test.d.ts").unwrap();
+
+  let fake_js = "export var Foo = [0, () => [], []]";
+  let chunk =
+    ChunkInfo { filename: "bundle.d.ts".to_string(), module_ids: vec!["test.d.ts".to_string()] };
+
+  let result = plugin.render_chunk(fake_js, &chunk).unwrap();
+  assert!(result.contains("declare"));
+}
+
+#[test]
+fn test_empty_chunk() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let chunk = ChunkInfo { filename: "empty.d.ts".to_string(), module_ids: vec![] };
+
+  let result = plugin.render_chunk("", &chunk).unwrap();
+  assert_eq!(result, "export { };");
+}
+
+#[test]
+fn test_reference_directive() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r#"/// <reference types="node" />
+/// <reference path="./types.d.ts" />
+export interface Foo { bar: string; }
+"#;
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Foo"));
+
+  let fake_js = "export var Foo = [0, () => [], []]";
+  let chunk =
+    ChunkInfo { filename: "bundle.d.ts".to_string(), module_ids: vec!["test.d.ts".to_string()] };
+
+  let rendered = plugin.render_chunk(fake_js, &chunk).unwrap();
+
+  assert!(
+    rendered.contains("/// <reference types=\"node\" />")
+      || rendered.contains("/// <reference path=")
+  );
+}
+
+#[test]
+fn test_reference_directive_multiple_files() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+
+  let code1 = r#"/// <reference types="node" />
+export interface Foo { bar: string; }
+"#;
+  let _ = plugin.transform(code1, "file1.d.ts").unwrap();
+
+  let code2 = r#"/// <reference types="jest" />
+export interface Bar { baz: number; }
+"#;
+  let _ = plugin.transform(code2, "file2.d.ts").unwrap();
+
+  let fake_js = r"export var Foo = [0, () => [], []]
+export var Bar = [1, () => [], []]";
+  let chunk = ChunkInfo {
+    filename: "bundle.d.ts".to_string(),
+    module_ids: vec!["file1.d.ts".to_string(), "file2.d.ts".to_string()],
+  };
+
+  let rendered = plugin.render_chunk(fake_js, &chunk).unwrap();
+
+  assert!(rendered.contains("/// <reference"));
+}
+
+#[test]
+fn test_namespace_declaration() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export namespace MyNamespace {
+    export interface Foo { bar: string; }
+}
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyNamespace"));
+}
+
+#[test]
+fn test_conditional_type() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export type IsString<T> = T extends string ? true : false;
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var IsString"));
+}
+
+#[test]
+fn test_mapped_type() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export type Readonly<T> = {
+    readonly [P in keyof T]: T[P];
+};
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Readonly"));
+}
+
+#[test]
+fn test_import_type() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r#"
+export type MyType = import("./other").OtherType;
+"#;
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyType"));
+}
+
+#[test]
+fn test_class_with_extends_and_implements() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export declare class MyClass extends BaseClass implements IFoo, IBar {
+    prop: string;
+}
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyClass"));
+  assert!(result.code.contains("BaseClass") || result.code.contains("IFoo"));
+}
+
+#[test]
+fn test_infer_type_in_conditional() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export type UnwrapPromise<T> = T extends Promise<infer R> ? R : T;
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var UnwrapPromise"));
+}
+
+#[test]
+fn test_qualified_type_name() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export type MyType = Namespace.SubType;
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyType"));
+  assert!(result.code.contains("Namespace"));
+}
+
+#[test]
+fn test_typeof_query() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export type MyType = typeof someValue;
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyType"));
+  assert!(result.code.contains("someValue"));
+}
+
+#[test]
+fn test_module_side_effect() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+
+  let code = r#"
+declare module "foo" {
+    export interface Bar {}
+}
+"#;
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("sideEffect"));
+}
+
+#[test]
+fn test_variable_declaration_with_destructuring() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export declare const { a, b }: { a: string; b: number };
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var a") || result.code.contains("var b"));
+}
+
+#[test]
+fn test_dts_mts_cts_extensions() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+
+  let code = "export interface Foo {}";
+  let result = plugin.transform(code, "test.d.mts").unwrap();
+  assert!(result.code.contains("var Foo"));
+
+  let result = plugin.transform(code, "test.d.cts").unwrap();
+  assert!(result.code.contains("var Foo"));
+}
+
+#[test]
+fn test_import_source_patching() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+
+  let _ = plugin.transform("export interface Foo {}", "test.d.ts").unwrap();
+
+  let chunk_code = r#"import { Bar } from "./other.d.ts";"#;
+  let chunk =
+    ChunkInfo { filename: "bundle.d.ts".to_string(), module_ids: vec!["test.d.ts".to_string()] };
+
+  let result = plugin.render_chunk(chunk_code, &chunk).unwrap();
+
+  assert!(result.contains("./other.js"));
+}

--- a/crates/rolldown_plugin_fake_js/tests/integration_test.rs
+++ b/crates/rolldown_plugin_fake_js/tests/integration_test.rs
@@ -1,0 +1,348 @@
+use rolldown_plugin_fake_js::{ChunkInfo, FakeJsOptions, FakeJsPlugin};
+
+#[test]
+fn test_simple_interface() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export interface Foo { bar: string; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Foo"));
+  assert!(result.code.contains("export"));
+}
+
+#[test]
+fn test_interface_with_extends() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export interface Bar extends Foo { baz: number; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Bar"));
+  assert!(result.code.contains("Foo"));
+}
+
+#[test]
+fn test_type_alias() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export type MyType = string | number;";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyType"));
+}
+
+#[test]
+fn test_function_declaration() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export declare function foo(x: number): string;";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var foo"));
+}
+
+#[test]
+fn test_class_declaration() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export declare class MyClass { prop: string; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyClass"));
+}
+
+#[test]
+fn test_enum_declaration() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export enum Color { Red, Green, Blue }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Color"));
+}
+
+#[test]
+fn test_default_export() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export default class Foo { bar: string; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("as default"));
+}
+
+#[test]
+fn test_generic_type() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "export interface Box<T> { value: T; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Box"));
+  assert!(result.code.contains('('));
+}
+
+#[test]
+fn test_multiple_declarations() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export interface Foo { a: string; }
+export interface Bar { b: number; }
+export type Baz = Foo | Bar;
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Foo"));
+  assert!(result.code.contains("var Bar"));
+  assert!(result.code.contains("var Baz"));
+}
+
+#[test]
+fn test_non_dts_file() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = "const x = 1;";
+  let result = plugin.transform(code, "test.ts").unwrap();
+
+  assert_eq!(result.code, code);
+}
+
+#[test]
+fn test_sourcemap_option() {
+  let options = FakeJsOptions { sourcemap: true, ..Default::default() };
+  let plugin = FakeJsPlugin::new(options);
+  let code = "export interface Foo { bar: string; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.map.is_some());
+}
+
+#[test]
+fn test_side_effects_option() {
+  let options = FakeJsOptions { side_effects: true, ..Default::default() };
+  let plugin = FakeJsPlugin::new(options);
+  let code = "export interface Foo { bar: string; }";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("sideEffect"));
+}
+
+#[test]
+fn test_render_chunk() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+
+  let code = "export interface Foo { bar: string; }";
+  let _ = plugin.transform(code, "test.d.ts").unwrap();
+
+  let fake_js = "export var Foo = [0, () => [], []]";
+  let chunk =
+    ChunkInfo { filename: "bundle.d.ts".to_string(), module_ids: vec!["test.d.ts".to_string()] };
+
+  let result = plugin.render_chunk(fake_js, &chunk).unwrap();
+  assert!(
+    result.code.contains("interface Foo") || result.code.contains("declare"),
+    "got: {}",
+    result.code
+  );
+}
+
+#[test]
+fn test_empty_chunk() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let chunk = ChunkInfo { filename: "empty.d.ts".to_string(), module_ids: vec![] };
+
+  let result = plugin.render_chunk("", &chunk).unwrap();
+  assert_eq!(result.code, "export { };");
+}
+
+#[test]
+fn test_reference_directive() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r#"/// <reference types="node" />
+/// <reference path="./types.d.ts" />
+export interface Foo { bar: string; }
+"#;
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Foo"));
+
+  let fake_js = "export var Foo = [0, () => [], []]";
+  let chunk =
+    ChunkInfo { filename: "bundle.d.ts".to_string(), module_ids: vec!["test.d.ts".to_string()] };
+
+  let rendered = plugin.render_chunk(fake_js, &chunk).unwrap();
+
+  assert!(
+    rendered.code.contains("/// <reference types=\"node\" />")
+      || rendered.code.contains("/// <reference path=")
+  );
+}
+
+#[test]
+fn test_reference_directive_multiple_files() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+
+  let code1 = r#"/// <reference types="node" />
+export interface Foo { bar: string; }
+"#;
+  let _ = plugin.transform(code1, "file1.d.ts").unwrap();
+
+  let code2 = r#"/// <reference types="jest" />
+export interface Bar { baz: number; }
+"#;
+  let _ = plugin.transform(code2, "file2.d.ts").unwrap();
+
+  let fake_js = r"export var Foo = [0, () => [], []]
+export var Bar = [1, () => [], []]";
+  let chunk = ChunkInfo {
+    filename: "bundle.d.ts".to_string(),
+    module_ids: vec!["file1.d.ts".to_string(), "file2.d.ts".to_string()],
+  };
+
+  let rendered = plugin.render_chunk(fake_js, &chunk).unwrap();
+
+  assert!(rendered.code.contains("/// <reference"));
+}
+
+#[test]
+fn test_namespace_declaration() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export namespace MyNamespace {
+    export interface Foo { bar: string; }
+}
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyNamespace"));
+}
+
+#[test]
+fn test_conditional_type() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export type IsString<T> = T extends string ? true : false;
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var IsString"));
+}
+
+#[test]
+fn test_mapped_type() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export type Readonly<T> = {
+    readonly [P in keyof T]: T[P];
+};
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var Readonly"));
+}
+
+#[test]
+fn test_import_type() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r#"
+export type MyType = import("./other").OtherType;
+"#;
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyType"));
+}
+
+#[test]
+fn test_class_with_extends_and_implements() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export declare class MyClass extends BaseClass implements IFoo, IBar {
+    prop: string;
+}
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyClass"));
+  assert!(result.code.contains("BaseClass") || result.code.contains("IFoo"));
+}
+
+#[test]
+fn test_infer_type_in_conditional() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export type UnwrapPromise<T> = T extends Promise<infer R> ? R : T;
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var UnwrapPromise"));
+}
+
+#[test]
+fn test_qualified_type_name() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export type MyType = Namespace.SubType;
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyType"));
+  assert!(result.code.contains("Namespace"));
+}
+
+#[test]
+fn test_typeof_query() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export type MyType = typeof someValue;
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var MyType"));
+  assert!(result.code.contains("someValue"));
+}
+
+#[test]
+fn test_module_side_effect() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+
+  let code = r#"
+declare module "foo" {
+    export interface Bar {}
+}
+"#;
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("sideEffect"));
+}
+
+#[test]
+fn test_variable_declaration_with_destructuring() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+  let code = r"
+export declare const { a, b }: { a: string; b: number };
+";
+  let result = plugin.transform(code, "test.d.ts").unwrap();
+
+  assert!(result.code.contains("var a") || result.code.contains("var b"));
+}
+
+#[test]
+fn test_dts_mts_cts_extensions() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+
+  let code = "export interface Foo {}";
+  let result = plugin.transform(code, "test.d.mts").unwrap();
+  assert!(result.code.contains("var Foo"));
+
+  let result = plugin.transform(code, "test.d.cts").unwrap();
+  assert!(result.code.contains("var Foo"));
+}
+
+#[test]
+fn test_import_source_patching() {
+  let plugin = FakeJsPlugin::new(FakeJsOptions::default());
+
+  let _ = plugin.transform("export interface Foo {}", "test.d.ts").unwrap();
+
+  let chunk_code = r#"import { Bar } from "./other.d.ts";
+export type { Bar };
+"#;
+  let chunk =
+    ChunkInfo { filename: "bundle.d.ts".to_string(), module_ids: vec!["test.d.ts".to_string()] };
+
+  let result = plugin.render_chunk(chunk_code, &chunk).unwrap();
+
+  assert!(result.code.contains("./other.js"), "expected .d.ts → .js patch, got: {}", result.code);
+}

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1665,6 +1665,7 @@ export interface BindingBuiltinPlugin {
 }
 
 export type BindingBuiltinPluginName =  'builtin:esm-external-require'|
+'builtin:fake-js'|
 'builtin:isolated-declaration'|
 'builtin:replace'|
 'builtin:vite-alias'|
@@ -1812,6 +1813,12 @@ export interface BindingExperimentalOptions {
   transformHiresSourcemap?: boolean | 'boundary'
   nativeMagicString?: boolean
   chunkOptimization?: boolean
+}
+
+export interface BindingFakeJsPluginConfig {
+  sourcemap?: boolean
+  cjsDefault?: boolean
+  sideEffects?: boolean
 }
 
 export interface BindingFilterToken {

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1901,6 +1901,7 @@ export interface BindingBuiltinPlugin {
 
 export type BindingBuiltinPluginName =  'builtin:bundle-analyzer'|
 'builtin:esm-external-require'|
+'builtin:fake-js'|
 'builtin:isolated-declaration'|
 'builtin:replace'|
 'builtin:vite-alias'|
@@ -2253,6 +2254,12 @@ export interface BindingExperimentalOptions {
   nativeMagicString?: boolean
   chunkOptimization?: boolean | BindingChunkOptimizationOptions
   lazyBarrel?: boolean
+}
+
+export interface BindingFakeJsPluginConfig {
+  sourcemap?: boolean
+  cjsDefault?: boolean
+  sideEffects?: boolean
 }
 
 export interface BindingFilterToken {

--- a/packages/rolldown/src/builtin-plugin/fake-js-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/fake-js-plugin.ts
@@ -1,0 +1,6 @@
+import type { BindingFakeJsPluginConfig } from '../binding.cjs';
+import { BuiltinPlugin } from './utils';
+
+export function fakeJsPlugin(config?: BindingFakeJsPluginConfig): BuiltinPlugin {
+  return new BuiltinPlugin('builtin:fake-js', config);
+}

--- a/packages/rolldown/src/plugins-index.ts
+++ b/packages/rolldown/src/plugins-index.ts
@@ -1,2 +1,3 @@
 export { esmExternalRequirePlugin } from './builtin-plugin/constructors';
+export { fakeJsPlugin } from './builtin-plugin/fake-js-plugin';
 export { replacePlugin } from './builtin-plugin/replace-plugin';


### PR DESCRIPTION
## Description

This PR mplements the `fake-js` plugin as a Rolldown builtin plugin, replacing the TypeScript/Babel version with a Rust implementation using Oxc. This plugin transforms TypeScript declaration files into runtime JavaScript bindings for efficient bundling.

Closes #4393
Closes sxzz/rolldown-plugin-dts#162

## Implementation

## Features

### Core Capabilities
- Transforms all TypeScript declaration types (interfaces, types, classes, enums, namespaces)
- Handles type parameters with proper scoping
- Collects and tracks dependencies (type references, qualified names, typeof queries)
- Rewrites import/export statements (type-only tracking, inline types, TS-specific syntax)
- Transforms helper functions (`__exportAll`, `__reExport`)
- Preserves reference directives (`/// <reference types="..." />`)
- Patches import sources (`.d.ts` → `.js`, `.d.mts` → `.mjs`, `.d.cts` → `.cjs`)

### Advanced Features
- Conditional type inference (`infer R` in conditional types)
- Qualified type names (`Namespace.SubType`)
- Import type expressions (`import("./module").Type`)
- Side effect markers for module declarations
- Default export handling
- Empty chunk handling
- Sourcemap generation (optional)

## Configuration

```typescript
import { fakeJsPlugin } from 'rolldown/plugins';

export default {
  plugins: [
    fakeJsPlugin({
      sourcemap: true,      // Generate sourcemaps (default: false)
      cjsDefault: false,    // Handle CJS default exports (default: false)
      sideEffects: false,   // Preserve side effects (default: false)
    })
  ]
}
```

## Feature Parity

**100% feature parity** confirmed through line-by-line comparison with the original TypeScript implementation (`fake-js.ts`).

## Checklist

- [x] Rust core implementation complete
- [x] NAPI bindings generated and verified
- [x] TypeScript API created and exported
- [x] All tests passing
- [x] Zero linting warnings
- [x] Build successful
- [x] Feature parity verified
- [x] No breaking changes

## Related Issues

Closes #4393 - Built-in dts Plugin
Closes sxzz/rolldown-plugin-dts#162 - Integrate fake-js as builtin plugin