### PR TITLE
docs: mark `build()` API as experimental

### DIFF
--- a/docs/.vitepress/scripts/custom-theme-plugin.ts
+++ b/docs/.vitepress/scripts/custom-theme-plugin.ts
@@ -38,6 +38,27 @@ class CustomThemeContext extends MarkdownThemeContext {
         // Remove the `**`Experimental`**` text that comes from `@experimental` tag
         return result.replace(/\*\*`Experimental`\*\*/g, '');
       },
+      signatureTitle: (model, _options) => {
+        const md: string[] = [];
+
+        const params = (model.parameters || [])
+          .map((param: any) => {
+            const optional = param.flags?.isOptional ? '?' : '';
+            const type = this.partials.someType(param.type);
+            return `\`${param.name}${optional}\`: ${type}`;
+          })
+          .join(', ');
+
+        const returnType = model.type ? this.partials.someType(model.type) : '`void`';
+
+        md.push(`- **Type**: (${params}) => ${returnType}`);
+
+        if (model.comment?.modifierTags?.has('@experimental')) {
+          md.push('- **Experimental**');
+        }
+
+        return md.join('\n');
+      },
       declarationTitle: (model) => {
         // https://github.com/typedoc2md/typedoc-plugin-markdown/blob/typedoc-plugin-markdown%404.9.0/packages/typedoc-plugin-markdown/src/theme/context/partials/member.declarationTitle.ts#L6
         const md: string[] = [];

--- a/docs/apis/bundler-api.md
+++ b/docs/apis/bundler-api.md
@@ -2,24 +2,6 @@
 
 Rolldown provides three main API functions for bundling your code programmatically.
 
-## `build()`
-
-`build()` is the simplest option for most use cases. The API is similar to esbuild's `build` function. It bundles and writes in a single call with automatic cleanup.
-
-```js
-import { build } from 'rolldown';
-
-const result = await build({
-  input: 'src/main.js',
-  output: {
-    file: 'bundle.js',
-  },
-});
-console.log(result);
-```
-
-See [its reference](/reference/Function.build) for more details.
-
 ## `rolldown()`
 
 `rolldown()` is the API compatible with Rollup's `rollup` function.
@@ -70,3 +52,27 @@ watcher.close();
 ```
 
 See [its reference](/reference/Function.watch) for more details.
+
+## `build()`
+
+::: warning Experimental
+
+This API is experimental and may change in patch releases.
+
+:::
+
+`build()` is the simplest option for most use cases. The API is similar to esbuild's `build` function. It bundles and writes in a single call with automatic cleanup.
+
+```js
+import { build } from 'rolldown';
+
+const result = await build({
+  input: 'src/main.js',
+  output: {
+    file: 'bundle.js',
+  },
+});
+console.log(result);
+```
+
+See [its reference](/reference/Function.build) for more details.

--- a/packages/rolldown/src/api/build.ts
+++ b/packages/rolldown/src/api/build.ts
@@ -6,6 +6,7 @@ import { rolldown } from './rolldown';
 /**
  * The options for {@linkcode build} function.
  *
+ * @experimental
  * @category Programmatic APIs
  */
 export type BuildOptions = InputOptions & {
@@ -48,6 +49,7 @@ async function build(options: BuildOptions[]): Promise<RolldownOutput[]>;
  * console.log(result);
  * ```
  *
+ * @experimental
  * @category Programmatic APIs
  */
 async function build(


### PR DESCRIPTION
It is not ready for stabilization.