### PR TITLE
wip(dev/lazy): `this` in static class field is replaced with `void 0`

### DIFF
--- a/examples/lazy/src/async-entry-a.js
+++ b/examples/lazy/src/async-entry-a.js
@@ -3,3 +3,9 @@ import './async-lib-shared.js';
 
 console.log('async-entry-a.js', asyncLibA);
 document.getElementById('root').innerHTML += '[async-entry-a.js] loaded\n';
+
+class Foo {
+  // eslint-disable-next-line no-unused-private-class-members
+  static #_ = (this.foo = 0);
+}
+console.log(new Foo().foo);


### PR DESCRIPTION
This should log `0`, but the following error happens in browser:
```
Uncaught (in promise) TypeError: Cannot set properties of undefined (setting 'foo')
```
