### PR TITLE
feat(treeshake): add `invalidImportSideEffects` option

### DIFF
--- a/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_treeshake.rs
@@ -45,6 +45,7 @@ pub struct BindingTreeshake {
   #[napi(ts_type = "ReadonlyArray<string>")]
   pub manual_pure_functions: Option<FxHashSet<String>>,
   pub unknown_global_side_effects: Option<bool>,
+  pub invalid_import_side_effects: Option<bool>,
   pub commonjs: Option<bool>,
   pub property_read_side_effects: Option<BindingPropertyReadSideEffects>,
   pub property_write_side_effects: Option<BindingPropertyWriteSideEffects>,
@@ -106,6 +107,7 @@ impl TryFrom<BindingTreeshake> for rolldown::TreeshakeOptions {
       annotations: value.annotations,
       manual_pure_functions: value.manual_pure_functions,
       unknown_global_side_effects: value.unknown_global_side_effects,
+      invalid_import_side_effects: value.invalid_import_side_effects,
       commonjs: value.commonjs,
       property_read_side_effects,
       property_write_side_effects,

--- a/crates/rolldown_common/src/inner_bundler_options/mod.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/mod.rs
@@ -351,6 +351,7 @@ where
         commonjs: Some(true),
         property_read_side_effects: None,
         property_write_side_effects: None,
+        invalid_import_side_effects: None,
       }))
     }
     Some(Value::Object(obj)) => {
@@ -375,12 +376,21 @@ where
           _ => Err(serde::de::Error::custom("commonjs should be a `true` or `false`")),
         },
       )?;
-      let unknown_global_side_effects = obj.get("unknown_global_side_effects").map_or_else(
+      let unknown_global_side_effects = obj.get("unknownGlobalSideEffects").map_or_else(
+        || Ok(Some(true)),
+        |v| match v {
+          Value::Bool(b) => Ok(Some(*b)),
+          _ => {
+            Err(serde::de::Error::custom("unknownGlobalSideEffects should be a `true` or `false`"))
+          }
+        },
+      )?;
+      let invalid_import_side_effects = obj.get("invalidImportSideEffects").map_or_else(
         || Ok(Some(true)),
         |v| match v {
           Value::Bool(b) => Ok(Some(*b)),
           _ => Err(serde::de::Error::custom(
-            "unknown_global_side_effects should be a `true` or `false`",
+            "invalid_import_side_effects should be a `true` or `false`",
           )),
         },
       )?;
@@ -434,6 +444,7 @@ where
         commonjs,
         property_read_side_effects,
         property_write_side_effects,
+        invalid_import_side_effects,
       }))
     }
     _ => Err(serde::de::Error::custom("treeshake should be a boolean or an object")),

--- a/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/treeshake.rs
@@ -69,6 +69,10 @@ impl NormalizedTreeshakeOptions {
     self.as_ref().and_then(|item| item.unknown_global_side_effects).unwrap_or(true)
   }
 
+  pub fn invalid_import_side_effects(&self) -> bool {
+    self.as_ref().and_then(|item| item.invalid_import_side_effects).unwrap_or(true)
+  }
+
   pub fn commonjs(&self) -> bool {
     self.as_ref().and_then(|item| item.commonjs).unwrap_or(true)
   }
@@ -206,6 +210,7 @@ pub struct InnerOptions {
   pub commonjs: Option<bool>,
   pub property_read_side_effects: Option<PropertyReadSideEffects>,
   pub property_write_side_effects: Option<PropertyWriteSideEffects>,
+  pub invalid_import_side_effects: Option<bool>,
 }
 
 impl Default for InnerOptions {
@@ -218,6 +223,7 @@ impl Default for InnerOptions {
       commonjs: None,
       property_read_side_effects: None,
       property_write_side_effects: None,
+      invalid_import_side_effects: None,
     }
   }
 }
@@ -252,7 +258,7 @@ impl From<&NormalizedTreeshakeOptions> for oxc::minifier::TreeShakeOptions {
       //   PropertyWriteSideEffects::False => oxc::minifier::PropertyWriteSideEffects::None,
       // },
       unknown_global_side_effects: value.unknown_global_side_effects(),
-      invalid_import_side_effects: true,
+      invalid_import_side_effects: value.invalid_import_side_effects(),
     }
   }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -924,6 +924,12 @@
               "type": "null"
             }
           ]
+        },
+        "invalidImportSideEffects": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2351,6 +2351,7 @@ export interface BindingTreeshake {
   annotations?: boolean
   manualPureFunctions?: ReadonlyArray<string>
   unknownGlobalSideEffects?: boolean
+  invalidImportSideEffects?: boolean
   commonjs?: boolean
   propertyReadSideEffects?: BindingPropertyReadSideEffects
   propertyWriteSideEffects?: BindingPropertyWriteSideEffects

--- a/packages/rolldown/src/types/module-side-effects.ts
+++ b/packages/rolldown/src/types/module-side-effects.ts
@@ -114,6 +114,14 @@ export type TreeshakingOptions = {
    */
   unknownGlobalSideEffects?: boolean;
   /**
+   * Whether to assume that invalid import statements might have side effects.
+   *
+   * See [related Oxc documentation](https://oxc.rs/docs/guide/usage/minifier/dead-code-elimination#ignoring-invalid-import-statement-side-effects) for more details.
+   *
+   * @default true
+   */
+  invalidImportSideEffects?: boolean;
+  /**
    * Whether to enable tree-shaking for CommonJS modules. When `true`, unused exports from CommonJS modules can be eliminated from the bundle, similar to ES modules. When disabled, CommonJS modules will always be included in their entirety.
    *
    * This option allows rolldown to analyze `exports.property` assignments in CommonJS modules and remove unused exports while preserving the module's side effects.

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -319,6 +319,7 @@ function bindingifyTreeshakeOptions(
     annotations: config.annotations,
     manualPureFunctions: config.manualPureFunctions,
     unknownGlobalSideEffects: config.unknownGlobalSideEffects,
+    invalidImportSideEffects: config.invalidImportSideEffects,
     commonjs: config.commonjs,
   };
   switch (config.propertyReadSideEffects) {

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -362,6 +362,7 @@ const TreeshakingOptionsSchema = v.union([
     annotations: v.optional(v.boolean()),
     manualPureFunctions: v.optional(v.array(v.string())),
     unknownGlobalSideEffects: v.optional(v.boolean()),
+    invalidImportSideEffects: v.optional(v.boolean()),
     commonjs: v.optional(v.boolean()),
     propertyReadSideEffects: v.optional(v.union([v.literal(false), v.literal('always')])),
     propertyWriteSideEffects: v.optional(v.union([v.literal(false), v.literal('always')])),


### PR DESCRIPTION
This is useful for lazy barrel optimization. Rspack automatically simplifies unused import statements to `import '..'`, which helps avoid unnecessary module loading. We could implement this as well, but doing it via the minifier would be simpler.