### PR TITLE
docs: bump theme & update activeMatch for reference

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -300,7 +300,7 @@ const config = defineConfig({
           },
         ],
       },
-      { text: 'Options & APIs', link: '/reference' },
+      { text: 'Options & APIs', activeMatch: '/reference', link: '/reference' },
       { text: 'REPL', link: 'https://repl.rolldown.rs/' },
       {
         text: 'Resources',

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@hpcc-js/wasm-graphviz": "^1.8.0",
     "@types/markdown-it": "^14.1.2",
-    "@voidzero-dev/vitepress-theme": "^4.0.4",
+    "@voidzero-dev/vitepress-theme": "^4.2.1",
     "oxc-minify": "catalog:",
     "typedoc": "^0.28.14",
     "typedoc-plugin-markdown": "^4.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,8 +316,8 @@ importers:
         specifier: ^14.1.2
         version: 14.1.2
       '@voidzero-dev/vitepress-theme':
-        specifier: ^4.0.4
-        version: 4.1.1(@algolia/client-search@5.46.3)(change-case@5.4.4)(focus-trap@7.6.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitepress@2.0.0-alpha.15(@algolia/client-search@5.46.3)(@types/node@24.10.3)(change-case@5.4.4)(esbuild@0.27.2)(jiti@2.6.1)(oxc-minify@0.108.0)(postcss@8.5.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3))
+        specifier: ^4.2.1
+        version: 4.2.1(@algolia/client-search@5.46.3)(change-case@5.4.4)(focus-trap@7.6.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitepress@2.0.0-alpha.15(@algolia/client-search@5.46.3)(@types/node@24.10.3)(change-case@5.4.4)(esbuild@0.27.2)(jiti@2.6.1)(oxc-minify@0.108.0)(postcss@8.5.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3))
       oxc-minify:
         specifier: 'catalog:'
         version: 0.108.0
@@ -3807,8 +3807,8 @@ packages:
   '@vitest/utils@4.0.17':
     resolution: {integrity: sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==}
 
-  '@voidzero-dev/vitepress-theme@4.1.1':
-    resolution: {integrity: sha512-RpR4upcIjpG/nWm0/uNQGeX8UOKMBZEcmIOMpNbxlvU586x8kUnZrBE+LrQO30zflo6S5pThxMA2rp5pl+a9PQ==}
+  '@voidzero-dev/vitepress-theme@4.2.1':
+    resolution: {integrity: sha512-aXRjG+Dc+t6oLb6gK+Cx9fixRpEEu+RsZGFK9Soe3GzVhFEh59thGgR42MckAcuRJ3Qrgg1Od+onf/c9BUr9Fw==}
     peerDependencies:
       vitepress: ^2.0.0-alpha.15
       vue: ^3.5.0
@@ -9101,7 +9101,7 @@ snapshots:
       '@vitest/pretty-format': 4.0.17
       tinyrainbow: 3.0.3
 
-  '@voidzero-dev/vitepress-theme@4.1.1(@algolia/client-search@5.46.3)(change-case@5.4.4)(focus-trap@7.6.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitepress@2.0.0-alpha.15(@algolia/client-search@5.46.3)(@types/node@24.10.3)(change-case@5.4.4)(esbuild@0.27.2)(jiti@2.6.1)(oxc-minify@0.108.0)(postcss@8.5.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3))':
+  '@voidzero-dev/vitepress-theme@4.2.1(@algolia/client-search@5.46.3)(change-case@5.4.4)(focus-trap@7.6.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitepress@2.0.0-alpha.15(@algolia/client-search@5.46.3)(@types/node@24.10.3)(change-case@5.4.4)(esbuild@0.27.2)(jiti@2.6.1)(oxc-minify@0.108.0)(postcss@8.5.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3))':
     dependencies:
       '@docsearch/css': 4.4.0
       '@docsearch/js': 4.4.0(@algolia/client-search@5.46.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)


### PR DESCRIPTION
Bumped theme solves:

Closes https://github.com/rolldown/rolldown/issues/7902

activeMatch:

<img width="975" height="367" alt="image" src="https://github.com/user-attachments/assets/34648f51-b5dc-4ab3-86da-12f258f62cb1" />
