### PR TITLE
feat: skip unused external modules from IIFE parameter list

### DIFF
--- a/crates/rolldown/src/ecmascript/format/iife.rs
+++ b/crates/rolldown/src/ecmascript/format/iife.rs
@@ -84,6 +84,13 @@ pub async fn render_iife<'code>(
 
   // It is similar to CJS.
   let (import_code, externals) = render_chunk_external_imports(ctx);
+  // For IIFE, we only include externals with used exports in factory parameters/arguments
+  // because we don't have a way to trigger side effects.
+  let externals: Vec<_> = externals
+    .iter()
+    .filter(|e| e.is_used())
+    .map(super::utils::ExternalImportKind::module)
+    .collect();
 
   // Generate the identifier for the IIFE wrapper function.
   // You can refer to the function for more details.

--- a/crates/rolldown/src/ecmascript/format/umd.rs
+++ b/crates/rolldown/src/ecmascript/format/umd.rs
@@ -58,6 +58,7 @@ pub async fn render_umd<'code>(
 
   // It is similar to CJS.
   let (import_code, externals) = render_chunk_external_imports(ctx);
+  let externals: Vec<_> = externals.iter().map(super::utils::ExternalImportKind::module).collect();
 
   // The function argument and the external imports are passed as arguments to the wrapper function.
   let need_global = has_exports || named_exports || !externals.is_empty();

--- a/crates/rolldown/tests/rolldown/function/format/iife/external_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/external_modules/artifacts.snap
@@ -6,13 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## MISSING_GLOBAL_NAME
 
 ```text
-[MISSING_GLOBAL_NAME] Warning: No name was provided for external module "node:fs" in "output.globals" – guessing "node_fs".
-
-```
-
-## MISSING_GLOBAL_NAME
-
-```text
 [MISSING_GLOBAL_NAME] Warning: No name was provided for external module "node:path" in "output.globals" – guessing "node_path".
 
 ```
@@ -22,7 +15,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-(function(node_path, node_fs) {
+(function(node_path) {
 
 // HIDDEN [rolldown:runtime]
 node_path = __toESM(node_path);
@@ -31,5 +24,5 @@ node_path = __toESM(node_path);
 	console.log(node_path.default);
 
 //#endregion
-})(node_path, node_fs);
+})(node_path);
 ```

--- a/crates/rolldown/tests/rolldown/function/format/iife/side_effect_only_external/_config.json
+++ b/crates/rolldown/tests/rolldown/function/format/iife/side_effect_only_external/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "format": "iife",
+    "external": ["external"],
+    "name": "module"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/function/format/iife/side_effect_only_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/side_effect_only_external/artifacts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+(function() {
+
+
+//#region main.js
+	console.log("foo");
+
+//#endregion
+})();
+```

--- a/crates/rolldown/tests/rolldown/function/format/iife/side_effect_only_external/main.js
+++ b/crates/rolldown/tests/rolldown/function/format/iife/side_effect_only_external/main.js
@@ -1,0 +1,2 @@
+import 'external';
+console.log('foo');

--- a/crates/rolldown/tests/rolldown/function/format/umd/side_effect_only_external/_config.json
+++ b/crates/rolldown/tests/rolldown/function/format/umd/side_effect_only_external/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "format": "umd",
+    "external": ["external"],
+    "name": "module"
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/function/format/umd/side_effect_only_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/umd/side_effect_only_external/artifacts.snap
@@ -1,0 +1,29 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## MISSING_GLOBAL_NAME
+
+```text
+[MISSING_GLOBAL_NAME] Warning: No name was provided for external module "external" in "output.globals" – guessing "external".
+
+```
+
+# Assets
+
+## main.js
+
+```js
+(function(global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ?  factory(require('external')) :
+  typeof define === 'function' && define.amd ? define(['external'], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.external));
+})(this, function(external) {
+
+//#region main.js
+	console.log("foo");
+
+//#endregion
+});
+```

--- a/crates/rolldown/tests/rolldown/function/format/umd/side_effect_only_external/main.js
+++ b/crates/rolldown/tests/rolldown/function/format/umd/side_effect_only_external/main.js
@@ -1,0 +1,2 @@
+import 'external';
+console.log('foo');

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4365,7 +4365,7 @@ expression: output
 
 # tests/rolldown/function/format/iife/external_modules
 
-- main-!~{000}~.js => main-lEnI27u2.js
+- main-!~{000}~.js => main-CAyhMpiz.js
 
 # tests/rolldown/function/format/iife/external_modules_with_globals
 
@@ -4386,6 +4386,10 @@ expression: output
 # tests/rolldown/function/format/iife/namespaced_name_reserved
 
 - main-!~{000}~.js => main-Bd98rPpn.js
+
+# tests/rolldown/function/format/iife/side_effect_only_external
+
+- main-!~{000}~.js => main-Ba2JX_kz.js
 
 # tests/rolldown/function/format/umd/conflict_exports_key
 
@@ -4410,6 +4414,10 @@ expression: output
 # tests/rolldown/function/format/umd/namespaced_name_reserved
 
 - main-!~{000}~.js => main-CbRrEbie.js
+
+# tests/rolldown/function/format/umd/side_effect_only_external
+
+- main-!~{000}~.js => main-DlxOG_is.js
 
 # tests/rolldown/function/inject
 


### PR DESCRIPTION
close https://github.com/vitejs/rolldown-vite/issues/451

I don't think the previous behavior was wrong. This PR slightly improves the output.
