### PR TITLE
feat(debug_info): add facade chunk elimination reason

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -4,9 +4,9 @@ use arcstr::ArcStr;
 use itertools::Itertools;
 use oxc_index::IndexVec;
 use rolldown_common::{
-  Chunk, ChunkDebugInfo, ChunkIdx, ChunkKind, ChunkMeta, ChunkReasonType, Module, ModuleIdx,
-  ModuleNamespaceIncludedReason, ModuleTable, PostChunkOptimizationOperation,
-  PreserveEntrySignatures, RuntimeHelper, StmtInfos, WrapKind,
+  Chunk, ChunkDebugInfo, ChunkIdx, ChunkKind, ChunkMeta, ChunkReasonType,
+  FacadeChunkEliminationReason, Module, ModuleIdx, ModuleNamespaceIncludedReason, ModuleTable,
+  PostChunkOptimizationOperation, PreserveEntrySignatures, RuntimeHelper, StmtInfos, WrapKind,
 };
 use rolldown_utils::{BitSet, indexmap::FxIndexMap};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -25,6 +25,10 @@ use super::{
   GenerateStage, chunk_ext::ChunkCreationReason, chunk_ext::ChunkDebugExt,
   code_splitting::IndexSplittingInfo,
 };
+
+/// Information about a facade chunk merge operation.
+/// Contains (source_chunk_idx, target_chunk_idx, elimination_reason).
+type FacadeChunkMergeInfo = (ChunkIdx, ChunkIdx, FacadeChunkEliminationReason);
 
 impl GenerateStage<'_> {
   /// Constructs a mapping from static entry chunks to the dynamic entry chunks they can reach.
@@ -340,10 +344,9 @@ impl GenerateStage<'_> {
 
   /// Finds empty dynamic entry chunks that should be merged with their target common chunks.
   /// Returns a tuple of (merge_entry_to_chunk, emitted_chunk_groups).
-  #[expect(clippy::type_complexity)]
   fn find_facade_chunk_merge_candidates(
     chunk_graph: &ChunkGraph,
-  ) -> (FxHashMap<ModuleIdx, (ChunkIdx, ChunkIdx)>, FxHashMap<ChunkIdx, Vec<ChunkIdx>>) {
+  ) -> (FxHashMap<ModuleIdx, FacadeChunkMergeInfo>, FxHashMap<ChunkIdx, Vec<ChunkIdx>>) {
     let mut merge_entry_to_chunk = FxHashMap::default();
     let mut emitted_chunk_groups: FxHashMap<ChunkIdx, Vec<ChunkIdx>> = FxHashMap::default();
     for (chunk_idx, chunk) in chunk_graph.chunk_table.iter_enumerated() {
@@ -386,10 +389,15 @@ impl GenerateStage<'_> {
       //    → Directly merge, the facade chunk can be removed
       if is_manual_to_chunk && is_emitted_from_chunk {
         emitted_chunk_groups.entry(target_chunk_idx).or_default().push(chunk_idx);
-      } else if !is_emitted_from_chunk
-        && (is_manual_to_chunk || is_pure_user_defined_to_entry_chunk)
-      {
-        merge_entry_to_chunk.insert(module, (chunk_idx, target_chunk_idx));
+      } else if !is_emitted_from_chunk {
+        let reason = if is_manual_to_chunk {
+          FacadeChunkEliminationReason::DynamicEntryMergedIntoManualGroup
+        } else if is_pure_user_defined_to_entry_chunk {
+          FacadeChunkEliminationReason::DynamicEntryMergedIntoUserDefinedEntry
+        } else {
+          continue;
+        };
+        merge_entry_to_chunk.insert(module, (chunk_idx, target_chunk_idx, reason));
       }
     }
     (merge_entry_to_chunk, emitted_chunk_groups)
@@ -401,7 +409,7 @@ impl GenerateStage<'_> {
     &self,
     chunk_graph: &ChunkGraph,
     emitted_chunk_groups: FxHashMap<ChunkIdx, Vec<ChunkIdx>>,
-    merge_entry_to_chunk: &mut FxHashMap<ModuleIdx, (ChunkIdx, ChunkIdx)>,
+    merge_entry_to_chunk: &mut FxHashMap<ModuleIdx, FacadeChunkMergeInfo>,
   ) {
     for (target_chunk_idx, chunk_indices) in emitted_chunk_groups {
       let Some(_target_chunk) = chunk_graph.chunk_table.get(target_chunk_idx) else {
@@ -438,7 +446,14 @@ impl GenerateStage<'_> {
             }
           });
         if !needs_facade {
-          merge_entry_to_chunk.insert(entry_module_idx, (chunk_idx, target_chunk_idx));
+          merge_entry_to_chunk.insert(
+            entry_module_idx,
+            (
+              chunk_idx,
+              target_chunk_idx,
+              FacadeChunkEliminationReason::EmittedChunkMergedIntoManualGroup,
+            ),
+          );
         }
       }
     }
@@ -518,7 +533,9 @@ impl GenerateStage<'_> {
     let mut optimized_common_chunks = FxHashSet::default();
 
     let mut needs_export_all_runtime = false;
-    for (&entry_module, &(from_chunk_idx, target_chunk_idx)) in &merge_entry_to_chunk {
+    for (&entry_module, &(from_chunk_idx, target_chunk_idx, elimination_reason)) in
+      &merge_entry_to_chunk
+    {
       // Point the entry module to related common chunk
       chunk_graph.entry_module_to_entry_chunk.remove(&entry_module);
 
@@ -574,6 +591,7 @@ impl GenerateStage<'_> {
           ChunkDebugInfo::EliminatedFacadeChunk {
             chunk_name: eliminated_chunk_name,
             entry_module_id: module_stable_id,
+            reason: elimination_reason,
           },
         );
       }

--- a/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/eliminated_facade_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/eliminated_facade_chunk/artifacts.snap
@@ -7,8 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
-//! Eliminated Facade Chunk: [Chunk-Name: unnamed] [Entry-Module-Id: dynamic-b.js]
-//! Eliminated Facade Chunk: [Chunk-Name: unnamed] [Entry-Module-Id: dynamic-a.js]
+//! Eliminated Facade Chunk: [Chunk-Name: unnamed] [Entry-Module-Id: dynamic-b.js] [Reason: Dynamic entry chunk merged into user-defined entry chunk]
+//! Eliminated Facade Chunk: [Chunk-Name: unnamed] [Entry-Module-Id: dynamic-a.js] [Reason: Dynamic entry chunk merged into user-defined entry chunk]
 // HIDDEN [rolldown:runtime]
 //#region dynamic-a.js
 var dynamic_a_exports = /* @__PURE__ */ __exportAll({ a: () => a });

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4051,7 +4051,7 @@ expression: output
 
 # tests/rolldown/function/experimental/attach_debug_info/eliminated_facade_chunk
 
-- main-!~{000}~.js => main-oZHjdmRw.js
+- main-!~{000}~.js => main-DZW8KQfJ.js
 
 # tests/rolldown/function/experimental/attach_debug_info/full
 

--- a/crates/rolldown_common/src/chunk/types/chunk_debug_info.rs
+++ b/crates/rolldown_common/src/chunk/types/chunk_debug_info.rs
@@ -1,5 +1,33 @@
 use std::fmt;
 
+/// The specific optimization scenario that led to a facade chunk being eliminated.
+#[derive(Debug, Clone, Copy)]
+pub enum FacadeChunkEliminationReason {
+  /// Emitted chunk (AllowExtension) merged into manual code splitting group.
+  /// Export name conflicts are checked before merging.
+  EmittedChunkMergedIntoManualGroup,
+  /// Dynamic entry chunk merged into manual code splitting group.
+  DynamicEntryMergedIntoManualGroup,
+  /// Dynamic entry chunk merged into user-defined entry chunk.
+  DynamicEntryMergedIntoUserDefinedEntry,
+}
+
+impl fmt::Display for FacadeChunkEliminationReason {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      FacadeChunkEliminationReason::EmittedChunkMergedIntoManualGroup => {
+        write!(f, "Emitted chunk (AllowExtension) merged into manual code splitting group")
+      }
+      FacadeChunkEliminationReason::DynamicEntryMergedIntoManualGroup => {
+        write!(f, "Dynamic entry chunk merged into manual code splitting group")
+      }
+      FacadeChunkEliminationReason::DynamicEntryMergedIntoUserDefinedEntry => {
+        write!(f, "Dynamic entry chunk merged into user-defined entry chunk")
+      }
+    }
+  }
+}
+
 /// Debug information attached to chunks when `experimental.attachDebugInfo: 'full'` is enabled.
 #[derive(Debug, Clone)]
 pub enum ChunkDebugInfo {
@@ -11,6 +39,8 @@ pub enum ChunkDebugInfo {
     chunk_name: String,
     /// Module ID of the entry module from the eliminated chunk
     entry_module_id: String,
+    /// The specific optimization scenario that led to this elimination
+    reason: FacadeChunkEliminationReason,
   },
 }
 
@@ -18,10 +48,10 @@ impl fmt::Display for ChunkDebugInfo {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       ChunkDebugInfo::CreateReason(reason) => write!(f, "{reason}"),
-      ChunkDebugInfo::EliminatedFacadeChunk { chunk_name, entry_module_id } => {
+      ChunkDebugInfo::EliminatedFacadeChunk { chunk_name, entry_module_id, reason } => {
         write!(
           f,
-          "Eliminated Facade Chunk: [Chunk-Name: {chunk_name}] [Entry-Module-Id: {entry_module_id}]"
+          "Eliminated Facade Chunk: [Chunk-Name: {chunk_name}] [Entry-Module-Id: {entry_module_id}] [Reason: {reason}]"
         )
       }
     }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -97,8 +97,11 @@ pub use crate::{
     Chunk, ChunkMeta, PostChunkOptimizationOperation,
     chunk_table::ChunkTable,
     types::{
-      AddonRenderContext, chunk_debug_info::ChunkDebugInfo, chunk_reason_type::ChunkReasonType,
-      cross_chunk_import_item::CrossChunkImportItem, module_group::ModuleGroup,
+      AddonRenderContext,
+      chunk_debug_info::{ChunkDebugInfo, FacadeChunkEliminationReason},
+      chunk_reason_type::ChunkReasonType,
+      cross_chunk_import_item::CrossChunkImportItem,
+      module_group::ModuleGroup,
       preliminary_filename::PreliminaryFilename,
     },
   },


### PR DESCRIPTION
# Elimination Reason for `EliminatedFacadeChunk` Debug Info

## Problem

When debugging chunk optimization issues, developers could see that a facade chunk was eliminated and merged into another chunk, but they couldn't tell **why** it was eliminated. This made it difficult to understand the optimization decisions Rolldown was making.

## Solution

Added a `reason` field to `EliminatedFacadeChunk` that captures which specific optimization scenario led to the elimination.

## Example
By default, a dynamic entry creates a standalone chunk. In this example, `main.js` both statically and dynamically imports `dynamic-a.js` and `dynamic-b.js`. Since these modules are already included in the entry chunk, creating separate dynamic chunks would be redundant. The optimizer merges them into the entry chunk, and the reason field shows why: "Dynamic entry chunk merged into user-defined entry chunk".

Given this input:

**main.js**
```js
import { a } from './dynamic-a.js'
import { b } from './dynamic-b.js'
import("./dynamic-a.js").then(console.log);
import("./dynamic-b.js").then(console.log);

console.log(a, b)
```

**dynamic-a.js**
```js
export const a = "dynamic-a";
```

**dynamic-b.js**
```js
export const b = "dynamic-b";
```

With `experimental.attachDebugInfo: 'full'`, the output now shows:

```js
//! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
//! Eliminated Facade Chunk: [Chunk-Name: unnamed] [Entry-Module-Id: dynamic-b.js] [Reason: Dynamic entry chunk merged into user-defined entry chunk]
//! Eliminated Facade Chunk: [Chunk-Name: unnamed] [Entry-Module-Id: dynamic-a.js] [Reason: Dynamic entry chunk merged into user-defined entry chunk]
```

This tells you exactly why the expected `dynamic-a.js` and `dynamic-b.js` chunks weren't created as separate files - they were merged into `main.js` because the entry point already statically imports them.


