### PR TITLE
feat(lazy-barrel): skip plain imports in side-effect-free modules

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -695,6 +695,9 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         },
         None,
       );
+      if decl.specifiers.is_empty() {
+        self.result.import_records[record_idx].meta.insert(ImportRecordMeta::IsPlainImport);
+      }
       decl.specifiers.iter().for_each(|spec| {
         self.add_re_export(
           spec.exported.name().as_str(),
@@ -860,6 +863,9 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         .insert(rec_id, ImportAttribute::from_with_clause(with_clause));
     }
     self.result.imports.insert(decl.span, rec_id);
+    if decl.specifiers.as_ref().is_none_or(|s| s.is_empty()) {
+      self.result.import_records[rec_id].meta.insert(ImportRecordMeta::IsPlainImport);
+    }
 
     let Some(specifiers) = &decl.specifiers else { return };
     specifiers.iter().for_each(|spec| match spec {

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -408,8 +408,8 @@ impl<'a> ModuleLoader<'a> {
             }
 
             if self.flat_options.is_lazy_barrel_enabled() {
-              // Plain import records (e.g., `import '..'`) are not needed when `barrel_info` exists,
-              // since `barrel_info` implies the module is side-effect-free.
+              // Plain import records (e.g., `import '..'`) are skipped in side-effect-free modules
+              // during lazy barrel optimization.
               if matches!(normal_module.side_effects, DeterminedSideEffects::UserDefined(false))
                 && raw_rec.meta.contains(ImportRecordMeta::IsPlainImport)
               {

--- a/crates/rolldown_common/src/types/import_record.rs
+++ b/crates/rolldown_common/src/types/import_record.rs
@@ -72,8 +72,10 @@ bitflags::bitflags! {
     /// If a record is a re-export-all from an external module, and that re-export-all chain continues uninterrupted to the entry point,
     /// we can reuse the original re-export-all declaration instead of generating complex interoperability code.
     const EntryLevelExternal = 1 << 9;
-    /// `export { .. } from 'mod'` or `export * as ns from 'mod'`
+    /// `export { .. } from 'mod'` or `export * as ns from 'mod'` or `export * from 'mod'`
     const IsReExport = 1 << 10;
+    /// `import 'mod'` or `import { } from 'mod'` or `export { } from 'mod'`
+    const IsPlainImport = 1 << 11;
 
     const TopLevelPureDynamicImport = Self::IsTopLevel.bits() | Self::PureDynamicImport.bits();
   }

--- a/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/_config.ts
@@ -1,0 +1,34 @@
+import path from 'node:path'
+import { expect } from 'vitest'
+import { defineTest } from 'rolldown-tests'
+
+const transformedIds: string[] = []
+
+export default defineTest({
+  config: {
+    experimental: {
+      lazyBarrel: true,
+    },
+    plugins: [
+      {
+        name: 'track-transforms',
+        transform(_, id) {
+          transformedIds.push(id)
+          return {
+            moduleSideEffects: false,
+          }
+        },
+      },
+    ],
+  },
+  afterTest: () => {
+    const relativeIds = transformedIds.map((id) =>
+      path.relative(import.meta.dirname, id).replace(/\\/g, '/'),
+    )
+    // When barrel module is side-effect-free, plain imports are skipped
+    expect(relativeIds).toContain('main.js')
+    expect(relativeIds).toContain('barrel/index.js')
+    expect(relativeIds).toContain('barrel/d.js')
+    expect(transformedIds.length).toBe(3)
+  },
+})

--- a/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/barrel/a.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/barrel/a.js
@@ -1,0 +1,1 @@
+export const a = 'a';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/barrel/b.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/barrel/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/barrel/c.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/barrel/c.js
@@ -1,0 +1,1 @@
+export const c = 'c';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/barrel/d.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/barrel/d.js
@@ -1,0 +1,1 @@
+export const d = 'd';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/barrel/index.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/barrel/index.js
@@ -1,0 +1,4 @@
+import './a';
+import { } from './b';
+export { } from './c';
+export { d } from './d';

--- a/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/main.js
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/plain-import/main.js
@@ -1,0 +1,2 @@
+import { d } from './barrel';
+console.log(d);


### PR DESCRIPTION
Since we require the barrel file to be marked with `moduleSideEffects: false`, I guess we should remove these imports to be consistent.

_Originally posted by @sapphi-red in https://github.com/rolldown/rolldown/pull/7969#discussion_r2710810334_
            