### PR TITLE
perf: use u32 for string indices in string_wizard and rolldown to reduce memory usage

### DIFF
--- a/crates/rolldown/src/css/mod.rs
+++ b/crates/rolldown/src/css/mod.rs
@@ -34,16 +34,16 @@ pub fn create_css_view(
           None,
         ));
         record_idx_to_span.push(Span::new(range.start, range.end));
-        let mut range_end = range.end as usize;
-        if source.is_char_boundary(range_end) {
-          if source[range_end..].starts_with("\r\n") {
+        let mut range_end = range.end;
+        if source.is_char_boundary(range_end as usize) {
+          if source[range_end as usize..].starts_with("\r\n") {
             range_end += 2;
           }
-          if source[range_end..].starts_with('\n') {
+          if source[range_end as usize..].starts_with('\n') {
             range_end += 1;
           }
         }
-        css_renderer.at_import_ranges.push((range.start as usize, range_end));
+        css_renderer.at_import_ranges.push((range.start, range_end));
       }
       css_module_lexer::Dependency::Url { request, range, kind } => {
         // css_module_lexer return span of `request` if kind is `string`, return whole span of `url(dep)`, if the kind is function

--- a/crates/rolldown_common/src/css/css_view.rs
+++ b/crates/rolldown_common/src/css/css_view.rs
@@ -16,7 +16,7 @@ pub struct CssView {
 
 #[derive(Debug, Default)]
 pub struct CssRenderer {
-  pub at_import_ranges: Vec<(usize, usize)>,
+  pub at_import_ranges: Vec<(u32, u32)>,
 }
 
 #[derive(Debug)]
@@ -37,8 +37,8 @@ impl SourceMutation for CssAssetNameReplacer {
   fn apply(&self, magic_string: &mut string_wizard::MagicString<'_>) {
     magic_string
       .update_with(
-        self.span.start as usize,
-        self.span.end as usize,
+        self.span.start,
+        self.span.end,
         self.asset_name.clone(),
         string_wizard::UpdateOptions { keep_original: true, overwrite: true },
       )

--- a/crates/rolldown_plugin_replace/src/plugin.rs
+++ b/crates/rolldown_plugin_replace/src/plugin.rs
@@ -120,8 +120,9 @@ impl ReplacePlugin {
         break;
       };
       changed = true;
+      #[expect(clippy::cast_possible_truncation)]
       magic_string
-        .update(matched.start(), matched.end(), replacement)
+        .update(matched.start() as u32, matched.end() as u32, replacement)
         .expect("update should not fail in replace plugin");
     }
 
@@ -169,8 +170,9 @@ impl ReplacePlugin {
         break;
       };
       changed = true;
+      #[expect(clippy::cast_possible_truncation)]
       magic_string
-        .update(matched.start, matched.end, replacement)
+        .update(matched.start as u32, matched.end as u32, replacement)
         .expect("update should not fail in replace plugin");
     }
     changed

--- a/crates/rolldown_plugin_vite_asset_import_meta_url/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_asset_import_meta_url/src/ast_visit.rs
@@ -10,7 +10,7 @@ use rolldown_plugin::{LogWithoutPlugin, PluginContext};
 use rolldown_plugin_utils::inject_query;
 
 pub struct NewUrlVisitor<'a, 'b, 'ast> {
-  pub urls: &'a mut Vec<(String, Range<usize>, &'b str)>,
+  pub urls: &'a mut Vec<(String, Range<u32>, &'b str)>,
   pub s: &'a mut Option<string_wizard::MagicString<'b>>,
   pub code: &'b str,
   pub ctx: &'a PluginContext,
@@ -96,8 +96,8 @@ impl<'ast> VisitMut<'ast> for NewUrlVisitor<'_, '_, 'ast> {
             );
 
             s.update(
-              template.span.start as usize,
-              template.span.end as usize,
+              template.span.start,
+              template.span.end,
               rolldown_utils::concat_string!(
                 "(import.meta.glob('",
                 glob,
@@ -116,7 +116,7 @@ impl<'ast> VisitMut<'ast> for NewUrlVisitor<'_, '_, 'ast> {
       };
 
       let span = span.shrink(1);
-      self.urls.push((url, span.start as usize..span.end as usize, it.span.source_text(self.code)));
+      self.urls.push((url, span.start..span.end, it.span.source_text(self.code)));
     }
     walk_new_expression(self, it);
   }

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
@@ -141,8 +141,8 @@ impl VisitMut<'_> for DynamicImportVisitor<'_, '_> {
       if self.removed_pure_css_files.inner.contains_key(normalized.to_slash_lossy().as_ref()) {
         let s = self.s.get_or_insert_with(|| string_wizard::MagicString::new(self.code));
         s.update(
-          it.span.start as usize,
-          it.span.end as usize,
+          it.span.start,
+          it.span.end,
           format!(
             "Promise.resolve({{{:width$}}})",
             "",

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/lib.rs
@@ -361,9 +361,10 @@ impl Plugin for ViteBuildImportAnalysisPlugin {
               }
             }
 
+            #[expect(clippy::cast_possible_truncation)]
             s.update(
-              marker_start,
-              marker_start + 16, // __VITE_PRELOAD__
+              marker_start as u32,
+              (marker_start + 16) as u32, // __VITE_PRELOAD__
               if render_deps.is_empty() {
                 "[]".to_string()
               } else {
@@ -390,8 +391,9 @@ impl Plugin for ViteBuildImportAnalysisPlugin {
           );
           // inject extra code at the top or next line of hashbang
           if chunk.code.starts_with("#!") {
+            #[expect(clippy::cast_possible_truncation)]
             s.prepend_left(
-              chunk.code.find('\n').map(|pos| pos + 1).unwrap_or_default(),
+              chunk.code.find('\n').map(|pos| pos + 1).unwrap_or_default() as u32,
               map_deps_code,
             );
           } else {
@@ -403,7 +405,8 @@ impl Plugin for ViteBuildImportAnalysisPlugin {
         // all the markers regardless
         for (start, _) in chunk.code.match_indices("__VITE_PRELOAD__") {
           if !rewrote_marker_start_pos.contains(&start) {
-            s.update(start, start + 16, "void 0")
+            #[expect(clippy::cast_possible_truncation)]
+            s.update(start as u32, (start + 16) as u32, "void 0")
               .expect("update should not fail in build import analysis plugin");
           }
         }

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/utils.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/utils.rs
@@ -59,9 +59,10 @@ impl AddDeps<'_, '_> {
           }
         }
       }
+      #[expect(clippy::cast_possible_truncation)]
       self
         .s
-        .update(self.expr_range.start, self.expr_range.end, "Promise.resolve({})")
+        .update(self.expr_range.start as u32, self.expr_range.end as u32, "Promise.resolve({})")
         .expect("update should not fail in build import analysis plugin");
     }
   }

--- a/crates/rolldown_plugin_vite_css_post/src/utils.rs
+++ b/crates/rolldown_plugin_vite_css_post/src/utils.rs
@@ -111,8 +111,9 @@ impl ViteCSSPostPlugin {
         };
 
         if let Some(url) = url_cache.inner.get(&id) {
+          #[expect(clippy::cast_possible_truncation)]
           magic_string
-            .update(index, start + pos + 2, url.clone())
+            .update(index as u32, (start + pos + 2) as u32, url.clone())
             .expect("update should not fail in css post plugin");
           continue;
         }
@@ -163,8 +164,9 @@ impl ViteCSSPostPlugin {
           .to_asset_url_in_js()?;
 
         url_cache.inner.insert(id, url.clone());
+        #[expect(clippy::cast_possible_truncation)]
         magic_string
-          .update(index, start + pos + 2, url)
+          .update(index as u32, (start + pos + 2) as u32, url)
           .expect("update should not fail in css post plugin");
       }
     }
@@ -285,9 +287,10 @@ impl ViteCSSPostPlugin {
           ";document.head.appendChild(__vite_style__);"
         );
 
+        #[expect(clippy::cast_possible_truncation)]
         magic_string
           .get_or_insert_with(|| string_wizard::MagicString::new(&ctx.args.code))
-          .append_right(injection_point, inject_code);
+          .append_right(injection_point as u32, inject_code);
       }
     } else {
       ctx.meta().get::<CSSChunkCache>().expect("CSSChunkCache missing").inner.insert(
@@ -372,7 +375,10 @@ impl ViteCSSPostPlugin {
             .0
             .get(hash)
             .ok_or_else(|| {
-              anyhow::anyhow!("Can't find the cache of {}", &css_chunk[range.clone()])
+              anyhow::anyhow!(
+                "Can't find the cache of {}",
+                &css_chunk[(range.start as usize)..(range.end as usize)]
+              )
             })?
             .to_string();
 
@@ -444,13 +450,17 @@ impl ViteCSSPostPlugin {
 
     let mut s = string_wizard::MagicString::new(css);
     for matched in AT_IMPORT_RE.find_iter(&css_without_comments) {
-      s.remove(matched.start(), matched.end()).expect("remove should not fail in css post plugin");
+      #[expect(clippy::cast_possible_truncation)]
+      s.remove(matched.start() as u32, matched.end() as u32)
+        .expect("remove should not fail in css post plugin");
       s.append_left(0, matched.as_str());
     }
 
     let mut found_charset = false;
     for matched in AT_CHARSET_RE.find_iter(&css_without_comments) {
-      s.remove(matched.start(), matched.end()).expect("remove should not fail in css post plugin");
+      #[expect(clippy::cast_possible_truncation)]
+      s.remove(matched.start() as u32, matched.end() as u32)
+        .expect("remove should not fail in css post plugin");
       if !found_charset {
         s.prepend(matched.as_str());
         found_charset = true;

--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit_2.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/ast_visit_2.rs
@@ -158,7 +158,7 @@ impl<'ast> DynamicImportVarsVisit<'ast, '_> {
       self
         .magic_string
         .get_or_insert_with(|| MagicString::new(self.source_text))
-        .update(import_expr.span.start as usize, import_expr.span.end as usize, replacement)
+        .update(import_expr.span.start, import_expr.span.end, replacement)
         .expect("update should not fail in dynamic import vars plugin");
 
       self.need_helper = true;

--- a/crates/rolldown_plugin_vite_html/src/lib.rs
+++ b/crates/rolldown_plugin_vite_html/src/lib.rs
@@ -70,7 +70,8 @@ impl Plugin for ViteHtmlPlugin {
     Ok(())
   }
 
-  #[expect(clippy::too_many_lines)]
+  // html5gum::Span uses usize for start/end, but we know HTML files are < 4GB
+  #[expect(clippy::too_many_lines, clippy::cast_possible_truncation)]
   async fn transform(
     &self,
     ctx: rolldown_plugin::SharedTransformPluginContext,
@@ -148,7 +149,7 @@ impl Plugin for ViteHtmlPlugin {
                 }
                 "vite-ignore" => {
                   is_ignored = true;
-                  s.remove(attr.span.start, attr.span.end)
+                  s.remove(attr.span.start as u32, attr.span.end as u32)
                     .expect("remove should not fail in html plugin");
                 }
                 _ => {}
@@ -261,7 +262,7 @@ impl Plugin for ViteHtmlPlugin {
           ) {
             let attrs_borrowed = attrs.borrow();
             if let Some(attr) = attrs_borrowed.iter().find(|a| &*a.name == "vite-ignore") {
-              s.remove(attr.span.start, attr.span.end)
+              s.remove(attr.span.start as u32, attr.span.end as u32)
                 .expect("remove should not fail in html plugin");
             } else {
               // Collect all attributes into a map for filtering
@@ -359,7 +360,7 @@ impl Plugin for ViteHtmlPlugin {
           }
 
           if should_remove {
-            s.remove(elem_span.start, elem_span.end)
+            s.remove(elem_span.start as u32, elem_span.end as u32)
               .expect("remove should not fail in html plugin");
           }
         }
@@ -419,7 +420,7 @@ impl Plugin for ViteHtmlPlugin {
       } else {
         continue;
       };
-      s.update(range.start, range.end, partial_encode_url_path(&url).into_owned())
+      s.update(range.start as u32, range.end as u32, partial_encode_url_path(&url).into_owned())
         .expect("update should not fail in html plugin");
     }
 
@@ -434,7 +435,8 @@ impl Plugin for ViteHtmlPlugin {
     for (url, span, resolved) in resolved_style_urls {
       match resolved?.ok() {
         Some(_) => {
-          s.remove(span.start, span.end).expect("remove should not fail in html plugin");
+          s.remove(span.start as u32, span.end as u32)
+            .expect("remove should not fail in html plugin");
         }
         None => {
           ctx.warn(LogWithoutPlugin {

--- a/crates/rolldown_plugin_vite_html/src/utils/helpers.rs
+++ b/crates/rolldown_plugin_vite_html/src/utils/helpers.rs
@@ -26,7 +26,8 @@ pub fn overwrite_check_public_file(
   };
   let pos = src[start - span.start];
   let wrap_offset = usize::from(pos == b'"' || pos == b'\'');
-  s.update(start + wrap_offset, span.end - wrap_offset, value)
+  #[expect(clippy::cast_possible_truncation)]
+  s.update((start + wrap_offset) as u32, (span.end - wrap_offset) as u32, value)
     .expect("update should not fail in html plugin");
   Ok(())
 }

--- a/crates/rolldown_plugin_vite_import_glob/src/utils_2.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils_2.rs
@@ -256,7 +256,7 @@ impl<'ast> GlobImportVisit<'_> {
     self
       .magic_string
       .get_or_insert_with(|| string_wizard::MagicString::new(self.code))
-      .update(span.start as usize, span.end as usize, replacement)
+      .update(span.start, span.end, replacement)
       .expect("update should not fail in import glob plugin");
   }
 }

--- a/crates/string_wizard/src/chunk.rs
+++ b/crates/string_wizard/src/chunk.rs
@@ -37,15 +37,15 @@ impl Chunk<'_> {
 }
 
 impl<'str> Chunk<'str> {
-  pub fn start(&self) -> usize {
+  pub fn start(&self) -> u32 {
     self.span.start()
   }
 
-  pub fn end(&self) -> usize {
+  pub fn end(&self) -> u32 {
     self.span.end()
   }
 
-  pub fn contains(&self, text_index: usize) -> bool {
+  pub fn contains(&self, text_index: u32) -> bool {
     self.start() < text_index && text_index < self.end()
   }
 
@@ -65,7 +65,7 @@ impl<'str> Chunk<'str> {
     self.intro.push_front(content)
   }
 
-  pub fn split<'a>(&'a mut self, text_index: usize) -> Result<Chunk<'str>, String> {
+  pub fn split<'a>(&'a mut self, text_index: u32) -> Result<Chunk<'str>, String> {
     if let Some(ref content) = self.edited_content
       && !content.is_empty()
     {

--- a/crates/string_wizard/src/magic_string/append.rs
+++ b/crates/string_wizard/src/magic_string/append.rs
@@ -16,7 +16,7 @@ impl<'text> MagicString<'text> {
   /// s.append_left(2, "b");
   /// assert_eq!(s.to_string(), "01ab234")
   ///```
-  pub fn append_left(&mut self, text_index: usize, content: impl Into<CowStr<'text>>) -> &mut Self {
+  pub fn append_left(&mut self, text_index: u32, content: impl Into<CowStr<'text>>) -> &mut Self {
     // Note: by_end_mut only errors when splitting an already-edited chunk,
     // but append operations don't require splitting edited chunks in practice.
     // We use expect here as this is an internal invariant.
@@ -39,11 +39,7 @@ impl<'text> MagicString<'text> {
   /// s.append_left(2, "b");
   /// assert_eq!(s.to_string(), "01abAB234")
   ///```
-  pub fn append_right(
-    &mut self,
-    text_index: usize,
-    content: impl Into<CowStr<'text>>,
-  ) -> &mut Self {
+  pub fn append_right(&mut self, text_index: u32, content: impl Into<CowStr<'text>>) -> &mut Self {
     // Note: by_start_mut only errors when splitting an already-edited chunk,
     // but append operations don't require splitting edited chunks in practice.
     // We use expect here as this is an internal invariant.

--- a/crates/string_wizard/src/magic_string/indent.rs
+++ b/crates/string_wizard/src/magic_string/indent.rs
@@ -3,15 +3,15 @@ use std::borrow::Cow;
 use crate::{CowStr, MagicString};
 
 struct ExcludeSet<'a> {
-  exclude: &'a [(usize, usize)],
+  exclude: &'a [(u32, u32)],
 }
 
 impl<'a> ExcludeSet<'a> {
-  fn new(exclude: &'a [(usize, usize)]) -> Self {
+  fn new(exclude: &'a [(u32, u32)]) -> Self {
     Self { exclude }
   }
 
-  fn contains(&self, index: usize) -> bool {
+  fn contains(&self, index: u32) -> bool {
     self.exclude.iter().any(|s| s.0 <= index && index < s.1)
   }
 }
@@ -56,7 +56,7 @@ pub struct IndentOptions<'a, 'b> {
   /// The reason I use `[u32; 2]` instead of `(u32, u32)` to represent a range of text is that
   /// I want to emphasize that the `[u32; 2]` is the closed interval, which means both the start
   /// and the end are included in the range.
-  pub exclude: &'b [(usize, usize)],
+  pub exclude: &'b [(u32, u32)],
 }
 
 impl MagicString<'_> {
@@ -105,7 +105,7 @@ impl MagicString<'_> {
     let exclude_set = ExcludeSet::new(opts.exclude);
 
     let mut next_chunk_id = Some(self.first_chunk_idx);
-    let mut char_index = 0;
+    let mut char_index: u32 = 0;
     while let Some(chunk_idx) = next_chunk_id {
       // Make sure the `next_chunk_id` is updated before we split the chunk. Otherwise, we
       // might process the same chunk twice.
@@ -120,7 +120,7 @@ impl MagicString<'_> {
         char_index = chunk.start();
         let chunk_end = chunk.end();
         for char in chunk.span.text(&self.source).chars() {
-          debug_assert!(self.source.is_char_boundary(char_index));
+          debug_assert!(self.source.is_char_boundary(char_index as usize));
           if !exclude_set.contains(char_index) {
             if char == '\n' {
               indent_replacer.should_indent_next_char = true;
@@ -130,7 +130,7 @@ impl MagicString<'_> {
               line_starts.push(char_index);
             }
           }
-          char_index += char.len_utf8();
+          char_index += char.len_utf8() as u32;
         }
         for line_start in line_starts {
           self.prepend_right(line_start, indent_replacer.indentor.clone());

--- a/crates/string_wizard/src/magic_string/movement.rs
+++ b/crates/string_wizard/src/magic_string/movement.rs
@@ -3,7 +3,7 @@ use crate::MagicString;
 use super::update::UpdateOptions;
 
 impl MagicString<'_> {
-  pub fn remove(&mut self, start: usize, end: usize) -> Result<&mut Self, String> {
+  pub fn remove(&mut self, start: u32, end: u32) -> Result<&mut Self, String> {
     self.inner_update_with(
       start,
       end,
@@ -15,7 +15,7 @@ impl MagicString<'_> {
 
   /// Moves the characters from start and end to index. Returns this.
   // `move` is reserved keyword in Rust, so we use `relocate` instead.
-  pub fn relocate(&mut self, start: usize, end: usize, to: usize) -> Result<&mut Self, String> {
+  pub fn relocate(&mut self, start: u32, end: u32, to: u32) -> Result<&mut Self, String> {
     if to >= start && to <= end {
       return Err("Cannot move a selection inside itself".to_string());
     }
@@ -84,12 +84,12 @@ impl MagicString<'_> {
 
   /// Returns a clone with content outside the specified range removed.
   /// This is equivalent to `clone().remove(0, start).remove(end, original.len())`.
-  pub fn snip(&self, start: usize, end: usize) -> Result<Self, String> {
+  pub fn snip(&self, start: u32, end: u32) -> Result<Self, String> {
     let mut clone = self.clone();
     if start > 0 {
       clone.remove(0, start)?;
     }
-    let original_len = self.source.len();
+    let original_len = self.source.len() as u32;
     if end < original_len {
       clone.remove(end, original_len)?;
     }

--- a/crates/string_wizard/src/magic_string/prepend.rs
+++ b/crates/string_wizard/src/magic_string/prepend.rs
@@ -8,11 +8,7 @@ impl<'text> MagicString<'text> {
     self
   }
 
-  pub fn prepend_left(
-    &mut self,
-    text_index: usize,
-    content: impl Into<CowStr<'text>>,
-  ) -> &mut Self {
+  pub fn prepend_left(&mut self, text_index: u32, content: impl Into<CowStr<'text>>) -> &mut Self {
     // Note: by_end_mut only errors when splitting an already-edited chunk,
     // but prepend operations don't require splitting edited chunks in practice.
     // We use expect here as this is an internal invariant.
@@ -23,11 +19,7 @@ impl<'text> MagicString<'text> {
     self
   }
 
-  pub fn prepend_right(
-    &mut self,
-    text_index: usize,
-    content: impl Into<CowStr<'text>>,
-  ) -> &mut Self {
+  pub fn prepend_right(&mut self, text_index: u32, content: impl Into<CowStr<'text>>) -> &mut Self {
     // Note: by_start_mut only errors when splitting an already-edited chunk,
     // but prepend operations don't require splitting edited chunks in practice.
     // We use expect here as this is an internal invariant.

--- a/crates/string_wizard/src/magic_string/replace.rs
+++ b/crates/string_wizard/src/magic_string/replace.rs
@@ -40,7 +40,7 @@ impl<'text> MagicString<'text> {
     let to: CowStr<'text> = to.into();
     let matches = memchr::memmem::find_iter(self.source.as_bytes(), from.as_bytes())
       .take(options.count)
-      .map(|start| (start, start + from.len()))
+      .map(|start| (start as u32, (start + from.len()) as u32))
       .collect::<Vec<_>>();
     for (match_start, end) in matches {
       self.update_with(

--- a/crates/string_wizard/src/magic_string/reset.rs
+++ b/crates/string_wizard/src/magic_string/reset.rs
@@ -7,7 +7,7 @@ impl<'text> MagicString<'text> {
   /// # Errors
   /// - If `start` is greater than to `end`
   /// - If the range is out of bounds
-  pub fn reset(&mut self, start: usize, end: usize) -> Result<&mut Self, String> {
+  pub fn reset(&mut self, start: u32, end: u32) -> Result<&mut Self, String> {
     if start == end {
       return Ok(self);
     }
@@ -16,7 +16,7 @@ impl<'text> MagicString<'text> {
       return Err("end must be greater than start".to_string());
     }
 
-    if end > self.source.len() {
+    if (end as usize) > self.source.len() {
       return Err("Character is out of bounds".to_string());
     }
 

--- a/crates/string_wizard/src/magic_string/slice.rs
+++ b/crates/string_wizard/src/magic_string/slice.rs
@@ -5,8 +5,8 @@ impl<'text> MagicString<'text> {
   /// positions from `start` to `end`.
   ///
   /// If `end` is `None`, it defaults to the original string length.
-  pub fn slice(&self, start: usize, end: Option<usize>) -> Result<String, String> {
-    let original_len = self.source.len();
+  pub fn slice(&self, start: u32, end: Option<u32>) -> Result<String, String> {
+    let original_len = self.source.len() as u32;
 
     // Default end to original length
     let end = end.unwrap_or(original_len);
@@ -58,7 +58,7 @@ impl<'text> MagicString<'text> {
         return Err(format!("Cannot use replaced character {} as slice end anchor.", end));
       }
 
-      let slice_start = if idx == start_chunk_idx { start - chunk.start() } else { 0 };
+      let slice_start = if idx == start_chunk_idx { (start - chunk.start()) as usize } else { 0 };
 
       let content = if let Some(ref edited) = chunk.edited_content {
         edited.as_ref()
@@ -66,7 +66,12 @@ impl<'text> MagicString<'text> {
         chunk.span.text(&self.source)
       };
 
-      let slice_end = if contains_end { content.len() + end - chunk.end() } else { content.len() };
+      let slice_end = if contains_end {
+        // end <= chunk.end() when contains_end is true, so we subtract
+        content.len() - (chunk.end() - end) as usize
+      } else {
+        content.len()
+      };
 
       result.push_str(&content[slice_start..slice_end]);
 

--- a/crates/string_wizard/src/magic_string/source_map.rs
+++ b/crates/string_wizard/src/magic_string/source_map.rs
@@ -64,15 +64,16 @@ impl MagicString<'_> {
 
 fn precompute_utf16_index_map(
   source: &str,
-  byte_indices: impl Iterator<Item = usize>,
-) -> FxHashMap<usize, usize> {
-  let mut byte_indices: Vec<usize> = byte_indices.collect();
+  byte_indices: impl Iterator<Item = u32>,
+) -> FxHashMap<u32, u32> {
+  let mut byte_indices: Vec<u32> = byte_indices.collect();
   byte_indices.sort();
-  let mut index = 0;
-  let mut index_utf16 = 0;
-  let mut map: FxHashMap<usize, usize> = Default::default();
+  let mut index: u32 = 0;
+  let mut index_utf16: u32 = 0;
+  let mut map: FxHashMap<u32, u32> = Default::default();
   for &i in &byte_indices {
-    index_utf16 += source[index..i].chars().map(|c| c.len_utf16()).sum::<usize>();
+    index_utf16 +=
+      source[index as usize..i as usize].chars().map(|c| c.len_utf16() as u32).sum::<u32>();
     index = i;
     map.insert(i, index_utf16);
   }

--- a/crates/string_wizard/src/magic_string/update.rs
+++ b/crates/string_wizard/src/magic_string/update.rs
@@ -13,8 +13,8 @@ impl<'text> MagicString<'text> {
   /// A shorthand for `update_with(start, end, content, Default::default())`;
   pub fn update(
     &mut self,
-    start: usize,
-    end: usize,
+    start: u32,
+    end: u32,
     content: impl Into<CowStr<'text>>,
   ) -> Result<&mut Self, String> {
     self.update_with(start, end, content, Default::default())
@@ -22,8 +22,8 @@ impl<'text> MagicString<'text> {
 
   pub fn update_with(
     &mut self,
-    start: usize,
-    end: usize,
+    start: u32,
+    end: u32,
     content: impl Into<CowStr<'text>>,
     opts: UpdateOptions,
   ) -> Result<&mut Self, String> {
@@ -34,8 +34,8 @@ impl<'text> MagicString<'text> {
 
   pub(super) fn inner_update_with(
     &mut self,
-    start: usize,
-    end: usize,
+    start: u32,
+    end: u32,
     content: CowStr<'text>,
     opts: UpdateOptions,
     error_if_start_equal_end: bool,

--- a/crates/string_wizard/src/source_map/locator.rs
+++ b/crates/string_wizard/src/source_map/locator.rs
@@ -1,22 +1,22 @@
 #[derive(Debug)]
 pub struct Locator {
   /// offsets are calculated based on utf-16
-  line_offsets: Box<[usize]>,
+  line_offsets: Box<[u32]>,
 }
 
 impl Locator {
   pub fn new(source: &str) -> Self {
     let mut line_offsets = vec![];
-    let mut line_start_pos = 0;
+    let mut line_start_pos: u32 = 0;
     for line in source.split('\n') {
       line_offsets.push(line_start_pos);
-      line_start_pos += 1 + line.chars().map(|c| c.len_utf16()).sum::<usize>();
+      line_start_pos += 1 + line.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
     }
     Self { line_offsets: line_offsets.into_boxed_slice() }
   }
 
   /// Pass the index based on utf-16 and return the [Location] based on utf-16
-  pub fn locate(&self, index: usize) -> Location {
+  pub fn locate(&self, index: u32) -> Location {
     let mut left_cursor = 0;
     let mut right_cursor = self.line_offsets.len();
     while left_cursor < right_cursor {
@@ -27,17 +27,17 @@ impl Locator {
         left_cursor = mid + 1;
       }
     }
-    let line = left_cursor - 1;
-    let column = index - self.line_offsets[line];
+    let line = (left_cursor - 1) as u32;
+    let column = index - self.line_offsets[left_cursor - 1];
     Location { line, column }
   }
 }
 
 #[derive(Debug, PartialEq)]
 pub struct Location {
-  pub line: usize,
+  pub line: u32,
   // columns are calculated based on utf-16
-  pub column: usize,
+  pub column: u32,
 }
 
 impl Location {

--- a/crates/string_wizard/src/source_map/sourcemap_builder.rs
+++ b/crates/string_wizard/src/source_map/sourcemap_builder.rs
@@ -12,9 +12,9 @@ pub enum Hires {
 
 pub struct SourcemapBuilder {
   hires: Hires,
-  generated_code_line: usize,
+  generated_code_line: u32,
   /// `generated_code_column` is calculated based on utf-16.
-  generated_code_column: usize,
+  generated_code_column: u32,
   source_id: u32,
   source_map_builder: oxc_sourcemap::SourceMapBuilder,
 }
@@ -41,7 +41,7 @@ impl SourcemapBuilder {
   pub fn add_chunk(
     &mut self,
     chunk: &Chunk,
-    chunk_start_utf16: usize,
+    chunk_start_utf16: u32,
     locator: &Locator,
     source: &str,
     name: Option<&str>,
@@ -55,10 +55,10 @@ impl SourcemapBuilder {
     if let Some(edited_content) = &chunk.edited_content {
       if !edited_content.is_empty() {
         self.source_map_builder.add_token(
-          self.generated_code_line as u32,
-          self.generated_code_column as u32,
-          loc.line as u32,
-          loc.column as u32,
+          self.generated_code_line,
+          self.generated_code_column,
+          loc.line,
+          loc.column,
           Some(self.source_id),
           name_id,
         );
@@ -81,10 +81,10 @@ impl SourcemapBuilder {
                 if char.is_alphanumeric() || char == '_' {
                   if !char_in_hires_boundary {
                     self.source_map_builder.add_token(
-                      self.generated_code_line as u32,
-                      self.generated_code_column as u32,
-                      loc.line as u32,
-                      loc.column as u32,
+                      self.generated_code_line,
+                      self.generated_code_column,
+                      loc.line,
+                      loc.column,
                       Some(self.source_id),
                       name_id,
                     );
@@ -92,10 +92,10 @@ impl SourcemapBuilder {
                   }
                 } else {
                   self.source_map_builder.add_token(
-                    self.generated_code_line as u32,
-                    self.generated_code_column as u32,
-                    loc.line as u32,
-                    loc.column as u32,
+                    self.generated_code_line,
+                    self.generated_code_column,
+                    loc.line,
+                    loc.column,
                     Some(self.source_id),
                     name_id,
                   );
@@ -103,16 +103,16 @@ impl SourcemapBuilder {
                 }
               } else {
                 self.source_map_builder.add_token(
-                  self.generated_code_line as u32,
-                  self.generated_code_column as u32,
-                  loc.line as u32,
-                  loc.column as u32,
+                  self.generated_code_line,
+                  self.generated_code_column,
+                  loc.line,
+                  loc.column,
                   Some(self.source_id),
                   name_id,
                 );
               }
             }
-            let char_utf16_len = char.len_utf16();
+            let char_utf16_len = char.len_utf16() as u32;
             loc.column += char_utf16_len;
             self.generated_code_column += char_utf16_len;
             new_line = false;
@@ -135,7 +135,7 @@ impl SourcemapBuilder {
     for _ in lines {
       self.bump_line();
     }
-    self.generated_code_column += last_line.chars().map(|c| c.len_utf16()).sum::<usize>();
+    self.generated_code_column += last_line.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
   }
 
   fn bump_line(&mut self) {

--- a/crates/string_wizard/src/span.rs
+++ b/crates/string_wizard/src/span.rs
@@ -1,18 +1,16 @@
 #[derive(Debug, Default, Clone, Copy)]
-pub struct Span(pub usize, pub usize);
+pub struct Span(pub u32, pub u32);
 
 impl Span {
-  pub fn start(&self) -> usize {
+  pub fn start(&self) -> u32 {
     self.0
   }
 
-  pub fn end(&self) -> usize {
+  pub fn end(&self) -> u32 {
     self.1
   }
 
   pub fn text<'s>(&self, source: &'s str) -> &'s str {
-    // This crate doesn't support usize which is u16 on 16-bit platforms.
-    // So, we can safely cast usize/u32 to usize.
-    &source[self.start()..self.end()]
+    &source[self.start() as usize..self.end() as usize]
   }
 }

--- a/crates/string_wizard/tests/magic_string.rs
+++ b/crates/string_wizard/tests/magic_string.rs
@@ -6,23 +6,13 @@ use string_wizard::MagicStringOptions;
 use string_wizard::UpdateOptions;
 
 trait MagicStringExt<'text> {
-  fn overwrite(
-    &mut self,
-    start: usize,
-    end: usize,
-    content: impl Into<Cow<'text, str>>,
-  ) -> &mut Self;
+  fn overwrite(&mut self, start: u32, end: u32, content: impl Into<Cow<'text, str>>) -> &mut Self;
 
   fn indent_str(&mut self, indent_str: &str) -> &mut Self;
 }
 
 impl<'text> MagicStringExt<'text> for MagicString<'text> {
-  fn overwrite(
-    &mut self,
-    start: usize,
-    end: usize,
-    content: impl Into<Cow<'text, str>>,
-  ) -> &mut Self {
+  fn overwrite(&mut self, start: u32, end: u32, content: impl Into<Cow<'text, str>>) -> &mut Self {
     self
       .update_with(start, end, content, UpdateOptions { overwrite: true, ..Default::default() })
       .unwrap()

--- a/crates/string_wizard/tests/magic_string_source_map.rs
+++ b/crates/string_wizard/tests/magic_string_source_map.rs
@@ -10,7 +10,7 @@ fn basic() {
     .unwrap()
     .update_with(3, 4, "d", update_options.clone())
     .unwrap()
-    .update_with(input.len() - 4, input.len() - 1, "h1", update_options)
+    .update_with((input.len() - 4) as u32, (input.len() - 1) as u32, "h1", update_options)
     .unwrap();
 
   let sm = s.source_map(SourceMapOptions { include_content: true, ..Default::default() });


### PR DESCRIPTION

## Rationale
- oxc only supports parsing files up to 4GB, which fits within `u32`'s range
- `string_wizard` is an internal crate used exclusively by rolldown, so we don't need to consider broader scalability concerns