### PR TITLE
refactor(rust): remove unnecessary Box wrapper around Vec in MemberExprRef

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ struct_field_names = "allow"
 unnecessary_wraps = "allow"
 unused_self = "allow"
 enum_variant_names = "allow"
-box_collection = "allow"
 upper_case_acronyms = "allow"
 wrong_self_convention = "allow"
 

--- a/crates/rolldown_common/src/types/member_expr_ref.rs
+++ b/crates/rolldown_common/src/types/member_expr_ref.rs
@@ -11,7 +11,7 @@ use crate::{MemberExprRefResolution, SymbolRef, type_aliases::MemberExprRefResol
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MemberExprRef {
   pub object_ref: SymbolRef,
-  pub prop_and_span_list: Box<Vec<(CompactStr, Span)>>,
+  pub prop_and_span_list: Vec<(CompactStr, Span)>,
   /// Span of the whole member expression
   /// FIXME: use `AstNodeId` to identify the MemberExpr instead of `Span`
   /// related discussion: https://github.com/rolldown/rolldown/pull/1818#discussion_r1699374441
@@ -38,13 +38,7 @@ impl MemberExprRef {
     obj_ref_type: MemberExprObjectReferencedType,
     reference_id: Option<ReferenceId>,
   ) -> Self {
-    Self {
-      object_ref,
-      prop_and_span_list: Box::new(prop_and_span_list),
-      span,
-      object_ref_type: obj_ref_type,
-      reference_id,
-    }
+    Self { object_ref, prop_and_span_list, span, object_ref_type: obj_ref_type, reference_id }
   }
 
   /// This method is tricky, use it with care.


### PR DESCRIPTION
- Changed `Box<Vec<(CompactStr, Span)>>` to `Vec<(CompactStr, Span)>` since Vec is already heap-allocated
- Removed `box_collection` allow rule from Cargo.toml

Size of `MemberExprRef` increased from 32 to 48, I doubt there will be any significant perf regression.