### PR TITLE
perf(rust): remove all usages of `with_scope_tree_child_ids(true)` for `SemanticBuilder`

### DIFF
--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -215,7 +215,7 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   // recreate semantic data
   #[expect(clippy::cast_possible_truncation)]
   let scoping = ecma_ast.make_symbol_table_and_scope_tree_with_semantic_builder(
-    SemanticBuilder::new().with_scope_tree_child_ids(true).with_stats(Stats {
+    SemanticBuilder::new().with_stats(Stats {
       nodes: declaration_binding_names.len().next_power_of_two() as u32,
       scopes: 1,
       symbols: declaration_binding_names.len() as u32,

--- a/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
+++ b/crates/rolldown_ecmascript/src/ecma_ast/helpers.rs
@@ -11,11 +11,7 @@ impl EcmaAst {
   }
 
   pub fn make_semantic<'ast>(program: &'ast Program<'ast>, with_cfg: bool) -> Semantic<'ast> {
-    SemanticBuilder::new()
-      .with_scope_tree_child_ids(true)
-      .with_cfg(with_cfg)
-      .build(program)
-      .semantic
+    SemanticBuilder::new().with_cfg(with_cfg).build(program).semantic
   }
 
   pub fn make_scoping(&self) -> Scoping {

--- a/tasks/generator/src/utils/mod.rs
+++ b/tasks/generator/src/utils/mod.rs
@@ -25,8 +25,7 @@ pub fn extract_toplevel_item_span(
     .with_options(ParseOptions { allow_return_outside_function: true, ..ParseOptions::default() });
   let ret = parser.parse();
 
-  let semantic =
-    SemanticBuilder::new().with_scope_tree_child_ids(true).build(&ret.program).semantic;
+  let semantic = SemanticBuilder::new().build(&ret.program).semantic;
   let mut visitor = ExtractTargetSpan::new(toplevel_item_name, &semantic);
   visitor.visit_program(&ret.program);
   visitor.ret_span


### PR DESCRIPTION
No usage after https://github.com/rolldown/rolldown/pull/7867