### PR TITLE
refactor(rust): fix redundant_clone clippy lint

### DIFF
--- a/crates/bench/benches/bundle.rs
+++ b/crates/bench/benches/bundle.rs
@@ -21,7 +21,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
   items()
     .into_iter()
-    .flat_map(|(name, options)| derive_benchmark_items(&derive_options, name, options.clone()))
+    .flat_map(|(name, options)| derive_benchmark_items(&derive_options, name, options))
     .for_each(|item| {
       group.bench_function(format!("bundle@{}", item.name), move |b| {
         b.to_async(

--- a/crates/bench/benches/scan.rs
+++ b/crates/bench/benches/scan.rs
@@ -18,7 +18,7 @@ fn criterion_benchmark(c: &mut Criterion) {
   let derive_options = DeriveOptions { sourcemap: false, minify: false };
   items()
     .into_iter()
-    .flat_map(|(name, options)| derive_benchmark_items(&derive_options, name, options.clone()))
+    .flat_map(|(name, options)| derive_benchmark_items(&derive_options, name, options))
     .for_each(|item| {
       group.bench_function(format!("scan@{}", item.name), move |b| {
         b.to_async(

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -50,7 +50,7 @@ pub fn derive_benchmark_items(
     ret.push(BenchItem {
       name: format!("{name}-minify-sourcemap"),
       options: {
-        let mut options = options.clone();
+        let mut options = options;
         options.sourcemap = Some(rolldown::SourceMapType::File);
         options.minify = Some(true.into());
         options

--- a/crates/string_wizard/tests/magic_string_source_map.rs
+++ b/crates/string_wizard/tests/magic_string_source_map.rs
@@ -10,7 +10,7 @@ fn basic() {
     .unwrap()
     .update_with(3, 4, "d", update_options.clone())
     .unwrap()
-    .update_with(input.len() - 4, input.len() - 1, "h1", update_options.clone())
+    .update_with(input.len() - 4, input.len() - 1, "h1", update_options)
     .unwrap();
 
   let sm = s.source_map(SourceMapOptions { include_content: true, ..Default::default() });


### PR DESCRIPTION
Remove unnecessary `.clone()` calls that were flagged by the `redundant_clone` clippy lint.