### PR TITLE
refactor(rust): fix inconsistent_struct_constructor clippy lint

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -171,7 +171,7 @@ impl<'a> ModuleLoader<'a> {
     // 1024 should be enough for most cases
     // over 1024 pending tasks are insane
     let (tx, rx) = tokio::sync::mpsc::channel(1024);
-    let shared_context = Arc::new(TaskContext { fs, options, resolver, plugin_driver, tx, meta });
+    let shared_context = Arc::new(TaskContext { options, tx, resolver, fs, plugin_driver, meta });
 
     let importers = std::mem::take(&mut cache.importers);
     let mut intermediate_normal_modules = IntermediateNormalModules::new(is_full_scan, importers);

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -323,13 +323,13 @@ impl From<ModuleLoaderOutput> for ScanStageOutput {
       flat_options,
     } = module_loader_output;
     ScanStageOutput {
+      module_table,
+      index_ecma_ast,
       entry_points,
       symbol_ref_db,
       runtime,
       warnings,
-      index_ecma_ast,
       dynamic_import_exports_usage_map,
-      module_table,
       overrode_preserve_entry_signature_map,
       entry_point_to_reference_ids,
       flat_options,

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -105,7 +105,7 @@ impl BuildDiagnostic {
     context: Option<UnloadableDependencyContext>,
     reason: ArcStr,
   ) -> Self {
-    Self::new_inner(UnloadableDependency { resolved, context, reason })
+    Self::new_inner(UnloadableDependency { reason, resolved, context })
   }
 
   pub fn circular_dependency(paths: Vec<String>) -> Self {
@@ -165,7 +165,7 @@ impl BuildDiagnostic {
     entry_module: ArcStr,
     export_keys: Vec<ArcStr>,
   ) -> Self {
-    Self::new_inner(InvalidExportOption { export_mode, export_keys, entry_module })
+    Self::new_inner(InvalidExportOption { export_mode, entry_module, export_keys })
   }
 
   pub fn filename_conflict(filename: ArcStr) -> Self {
@@ -203,7 +203,7 @@ impl BuildDiagnostic {
     span: Span,
     error_message: String,
   ) -> Self {
-    Self::new_inner(UnsupportedFeature { filename, source, span, error_message })
+    Self::new_inner(UnsupportedFeature { source, filename, span, error_message })
   }
 
   pub fn empty_import_meta(
@@ -284,7 +284,7 @@ impl BuildDiagnostic {
   }
 
   pub fn eval(filename: String, source: ArcStr, span: Span) -> Self {
-    Self::new_inner(Eval { filename, span, source })
+    Self::new_inner(Eval { span, source, filename })
   }
 
   pub fn configuration_field_conflict(

--- a/crates/rolldown_resolver/src/resolver_config.rs
+++ b/crates/rolldown_resolver/src/resolver_config.rs
@@ -144,6 +144,6 @@ impl ResolverConfig {
     let css_options = default_options.clone().with_prefer_relative(true);
     let new_url_options = default_options.clone().with_prefer_relative(true);
 
-    Self { default_options, import_options, require_options, css_options, new_url_options }
+    Self { default_options, import_options, require_options, new_url_options, css_options }
   }
 }


### PR DESCRIPTION
## Summary
- Reorder struct constructor field initialization to match struct definition field order
- Fixes 7 `inconsistent_struct_constructor` clippy lint violations across 4 files:
  - `crates/rolldown_error/src/build_diagnostic/constructors.rs` (4 fixes)
  - `crates/rolldown_resolver/src/resolver_config.rs` (1 fix)
  - `crates/rolldown/src/module_loader/module_loader.rs` (1 fix)
  - `crates/rolldown/src/stages/scan_stage.rs` (1 fix)

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -W clippy::inconsistent_struct_constructor` produces no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)