### PR TITLE
refactor(rust): enable clippy nursery lint group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ module_inception = "allow"
 module_name_repetitions = "allow"
 similar_names = "allow"
 
-# These would require breaking API changes. See clippy.toml for why we don't care about breaking changes.
 trivially_copy_pass_by_ref = "allow"
 struct_field_names = "allow"
 unused_self = "allow"
@@ -56,31 +55,43 @@ missing_errors_doc = "allow"
 must_use_candidate = "allow"
 
 doc_markdown = "allow"
-missing_const_for_fn = "allow"
 needless_for_each = "allow"
 new_without_default = "allow"
 # TODO: should review this rule.
 missing_panics_doc = "allow"
 
-# Order doesn't really matter https://rust-lang.github.io/rust-clippy/master/index.html#/inconsistent_struct_constructor
-inconsistent_struct_constructor = "allow"
-
-# Single match is equally readable as if/else. https://rust-lang.github.io/rust-clippy/master/index.html#/single_match
-single_match = "allow"
-single_match_else = "allow"
-
-# Though the following are nursery rules, they're still useful.
-debug_assert_with_mut_call = "warn"
-iter_on_single_items = "warn"
-redundant_clone = "warn"
-redundant_pub_crate = "warn"
-significant_drop_in_scrutinee = "warn"
-unused_peekable = "warn"
-
-# Rewriting `unwrap_or` to `map_or` requires to annotate type explicitly which is cumbersome
-map_unwrap_or = "allow"
-
+# --- nursery https://doc.rust-lang.org/clippy/usage.html#clippynursery
+# We should only disable rules globally if they are either false positives, chaotic, or does not make sense.
+nursery = { level = "warn", priority = -1 }
+# `const` functions do not make sense for our project because this is not a `const` library.
+# This rule also confuses newcomers and forces them to add `const` blindlessly without any reason.
+missing_const_for_fn = "allow"
+option_if_let_else = "allow"
+or_fun_call = "allow"
+cognitive_complexity = "allow"
+non_send_fields_in_send_ty = "allow"
+use_self = "allow"
+significant_drop_tightening = "allow"
+branches_sharing_code = "allow"
+fallible_impl_from = "allow"
+useless_let_if_seq = "allow"
+impl_trait_in_params = "allow"
+# FIXME https://github.com/rust-lang/rust-clippy/issues/15429 - False positive with serde skip_serializing
+zero_sized_map_values = "allow"
+# False positive with derive_more debug attribute syntax
+literal_string_with_formatting_args = "allow"
+# Too many changes required across the codebase
 collapsible_if = "allow"
+too_long_first_doc_paragraph = "allow"
+single_match_else = "allow"
+single_option_map = "allow"
+map_unwrap_or = "allow"
+equatable_if_let = "allow"
+string_lit_as_bytes = "allow"
+needless_collect = "allow"
+iter_with_drain = "allow"
+unnecessary_struct_initialization = "allow"
+trivial_regex = "allow"
 
 [workspace.dependencies]
 # publish = true

--- a/crates/rolldown_binding/src/types/binding_log_level.rs
+++ b/crates/rolldown_binding/src/types/binding_log_level.rs
@@ -1,7 +1,7 @@
 use napi_derive::napi;
 use std::fmt::{self, Display, Formatter};
 
-#[derive(Debug, PartialEq, Clone, Copy, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 #[napi]
 pub enum BindingLogLevel {
   Silent,

--- a/crates/rolldown_common/src/inner_bundler_options/types/log_level.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/log_level.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Display, Formatter};
   derive(Deserialize, JsonSchema),
   serde(rename_all = "camelCase", deny_unknown_fields)
 )]
-#[derive(Debug, PartialEq, Clone, Copy, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum LogLevel {
   Silent,
   Warn,

--- a/crates/rolldown_common/src/inner_bundler_options/types/optimization.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/optimization.rs
@@ -169,7 +169,7 @@ impl NormalizedOptimizationConfig {
 
   #[inline]
   pub fn inline_const_pass(&self) -> u32 {
-    self.inline_const.map(|item| item.pass).unwrap_or(1)
+    self.inline_const.map_or(1, |item| item.pass)
   }
 
   #[inline]

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -254,10 +254,7 @@ impl SymbolRefDb {
     canonical_names: &'a FxHashMap<SymbolRef, CompactStr>,
   ) -> &'a str {
     let canonical_ref = self.canonical_ref_for(refer);
-    canonical_names
-      .get(&canonical_ref)
-      .map(CompactStr::as_str)
-      .unwrap_or_else(|| canonical_ref.name(self))
+    canonical_names.get(&canonical_ref).map_or_else(|| canonical_ref.name(self), CompactStr::as_str)
   }
 
   pub fn get(&self, refer: SymbolRef) -> &SymbolRefDataClassic {

--- a/crates/rolldown_devtools/src/devtools_formatter.rs
+++ b/crates/rolldown_devtools/src/devtools_formatter.rs
@@ -80,7 +80,7 @@ where
     inject_context_data(&mut action_value, &found_context_fields);
 
     let session_id =
-      found_context_fields.get("session_id").map(String::as_str).unwrap_or(DEFAULT_SESSION_ID);
+      found_context_fields.get("session_id").map_or(DEFAULT_SESSION_ID, String::as_str);
 
     std::fs::create_dir_all(format!("node_modules/.rolldown/{session_id}")).ok();
 

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -340,18 +340,18 @@ impl PluginDriver {
     for (_, plugin, ctx) in
       self.iter_plugin_with_context_by_order(&self.order_by_transform_ast_meta)
     {
+      // Reconstructing the struct is necessary because `args.ast` is moved and reassigned each iteration
+      #[expect(clippy::unnecessary_struct_initialization)]
+      let transform_args = HookTransformAstArgs {
+        cwd: args.cwd,
+        ast: args.ast,
+        id: args.id,
+        stable_id: args.stable_id,
+        is_user_defined_entry: args.is_user_defined_entry,
+        module_type: args.module_type,
+      };
       args.ast = plugin
-        .call_transform_ast(
-          ctx,
-          HookTransformAstArgs {
-            cwd: args.cwd,
-            ast: args.ast,
-            id: args.id,
-            stable_id: args.stable_id,
-            is_user_defined_entry: args.is_user_defined_entry,
-            module_type: args.module_type,
-          },
-        )
+        .call_transform_ast(ctx, transform_args)
         .instrument(debug_span!("transform_ast_hook", plugin_name = plugin.call_name().as_ref()))
         .await
         .with_context(|| CausedPlugin::new(plugin.call_name()))?;

--- a/crates/rolldown_utils/src/futures.rs
+++ b/crates/rolldown_utils/src/futures.rs
@@ -34,6 +34,7 @@ where
   }
 }
 
+#[expect(clippy::collection_is_never_read)]
 async fn _test_block_on_spawn_all_non_static_future() {
   let mut words = String::new();
   let non_static_future = async {

--- a/crates/rolldown_utils/src/light_guess.rs
+++ b/crates/rolldown_utils/src/light_guess.rs
@@ -2,7 +2,7 @@
 
 use crate::mime::MimeExt;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RawMimeExt {
   pub mime_str: &'static str,
   pub is_utf8_encoded: bool,

--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -121,7 +121,7 @@ pub fn normalize_path(path: &str) -> Cow<'_, str> {
   }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FilterResult {
   /// `Match(true)` means it is matched by `included`,
   /// `Match(false)` means it is matched by `excluded`


### PR DESCRIPTION
## Summary
- Enable the clippy nursery lint group, ported from the OXC project configuration
- Add appropriate allows for rules that are too noisy or don't make sense for the project
- Fix minor code issues (add `Eq` derives, use `map_or` instead of `map().unwrap_or()`)

## Test plan
- [x] `just lint-rust` passes

🤖 Generated with [Claude Code](https://claude.ai/code)