### PR TITLE
chore: mark watch API as experimental

### DIFF
--- a/packages/rolldown/src/api/watch/index.ts
+++ b/packages/rolldown/src/api/watch/index.ts
@@ -29,6 +29,7 @@ import { createWatcher } from './watcher';
  * watcher.close();
  * ```
  *
+ * @experimental
  * @category Programmatic APIs
  */
 export const watch = (input: WatchOptions | WatchOptions[]): RolldownWatcher => {

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -648,6 +648,8 @@ export interface InputOptions {
    * Watch mode related options.
    *
    * These options only take effect when running with the `--watch` flag, or using `rolldown.watch()` API.
+   *
+   * @experimental
    */
   watch?: WatcherOptions | false;
   /**


### PR DESCRIPTION
Marking watch API as experimental as we may change this API after 1.0 RC release (and before 1.0).