### PR TITLE
fix(types): return `this` from on / off methods of `RolldownWatcher`

### DIFF
--- a/packages/rolldown/src/api/watch/watch-emitter.ts
+++ b/packages/rolldown/src/api/watch/watch-emitter.ts
@@ -63,18 +63,18 @@ export type RolldownWatcherWatcherEventMap = {
 /**
  * @category Programmatic APIs
  */
-export type RolldownWatcher = {
+export interface RolldownWatcher {
   on<E extends keyof RolldownWatcherWatcherEventMap>(
     event: E,
     listener: (...args: RolldownWatcherWatcherEventMap[E]) => MaybePromise<void>,
-  ): void;
+  ): this;
   off<E extends keyof RolldownWatcherWatcherEventMap>(
     event: E,
     listener: (...args: RolldownWatcherWatcherEventMap[E]) => MaybePromise<void>,
-  ): void;
+  ): this;
   clear<E extends keyof RolldownWatcherWatcherEventMap>(event: E): void;
   close(): Promise<void>;
-};
+}
 
 export class WatcherEmitter implements RolldownWatcher {
   listeners: Map<WatcherEvent, Array<(...parameters: any[]) => MaybePromise<void>>> = new Map();


### PR DESCRIPTION
To align with Rollup: https://github.com/rollup/rollup/blob/1cbac18d9fb153db123d8f266947c5a5acfa387f/src/rollup/types.d.ts#L1056