### PR TITLE
fix(node): allow `output.strictExecutionOrder` by the option validator

### DIFF
--- a/examples/hmr-raw/dev.config.mjs
+++ b/examples/hmr-raw/dev.config.mjs
@@ -3,12 +3,14 @@ import { defineDevConfig } from '@rolldown/test-dev-server';
 export default defineDevConfig({
   build: {
     input: 'src/main.js',
+    output: {
+      strictExecutionOrder: true,
+    },
     experimental: {
       devMode: {
         new: true,
       },
       incrementalBuild: true,
-      strictExecutionOrder: true,
     },
     treeshake: false,
   },

--- a/examples/lazy/dev.config.mjs
+++ b/examples/lazy/dev.config.mjs
@@ -3,12 +3,14 @@ import { defineDevConfig } from '@rolldown/test-dev-server';
 export default defineDevConfig({
   build: {
     input: './src/entry-a.js',
+    output: {
+      strictExecutionOrder: true,
+    },
     experimental: {
       devMode: {
         lazy: true,
       },
       incrementalBuild: true,
-      strictExecutionOrder: true,
     },
     treeshake: false,
   },

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -470,7 +470,6 @@ const InputOptionsSchema = v.strictObject({
       enableComposingJsPlugins: v.optional(v.boolean()),
       viteMode: v.optional(v.boolean()),
       resolveNewUrlToAsset: v.optional(v.boolean()),
-      strictExecutionOrder: v.optional(v.boolean()),
       onDemandWrapping: v.optional(v.boolean()),
       incrementalBuild: v.optional(v.boolean()),
       devMode: v.optional(DevModeSchema),
@@ -774,6 +773,10 @@ const OutputOptionsSchema = v.strictObject({
   keepNames: v.pipe(
     v.optional(v.boolean()),
     v.description('Keep function and class names after bundling'),
+  ),
+  strictExecutionOrder: v.pipe(
+    v.optional(v.boolean()),
+    v.description('Lets modules be executed in the order they are declared.'),
   ),
 }) satisfies v.GenericSchema<OutputOptions>;
 

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -85,6 +85,7 @@ OPTIONS
   --shim-missing-exports      Create shim variables for missing exports.
   --sourcemap-base-url <sourcemap-base-url>Base URL used to prefix sourcemap paths.
   --sourcemap-debug-ids       Inject sourcemap debug IDs.
+  --strict-execution-order    Lets modules be executed in the order they are declared.
   --top-level-var             Rewrite top-level declarations to use \`var\`.
   --transform.assumptions.ignore-function-length .
   --transform.assumptions.no-document-all .


### PR DESCRIPTION
fixes #8016
refs #7901
