### PR TITLE
refactor(node): add type checks that ensures validator schema is up to date with types

### DIFF
--- a/packages/rolldown/src/log/logging.ts
+++ b/packages/rolldown/src/log/logging.ts
@@ -3,7 +3,7 @@ export type LogLevel = 'info' | 'debug' | 'warn';
 /** @inline */
 export type LogLevelOption = LogLevel | 'silent';
 /** @inline */
-type LogLevelWithError = LogLevel | 'error';
+export type LogLevelWithError = LogLevel | 'error';
 
 export interface RolldownLog {
   binding?: string;


### PR DESCRIPTION
Added `isTypeTrue` function calls that ensures the validator schema is up to date with types.