### PR TITLE
fix: `output.generatedCode.preset: 'es2015'` was not set by default

### DIFF
--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index.js
-var demo_pkg_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var demo_pkg_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 var foo;
 var init_demo_pkg = __esmMin((() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/artifacts.snap
@@ -10,13 +10,16 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/index.js
-var demo_pkg_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var demo_pkg_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const foo = 123;
 console.log("hello");
 
 //#endregion
 //#region src/entry.js
-assert.deepEqual(demo_pkg_exports, { foo: 123 });
+assert.deepEqual(demo_pkg_exports, {
+	[Symbol.toStringTag]: "Module",
+	foo: 123
+});
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/src/entry.js
+++ b/crates/rolldown/tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6/src/entry.js
@@ -1,5 +1,6 @@
 import assert from "node:assert"
 import * as ns from "demo-pkg"
 assert.deepEqual(ns, {
+  [Symbol.toStringTag]: "Module",
   foo: 123
 })

--- a/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/dce/tree_shaking_in_esm_wrapper/artifacts.snap
@@ -18,7 +18,7 @@ var init_lib = __esmMin((() => {
 
 //#endregion
 //#region cjs.js
-var cjs_exports = /* @__PURE__ */ __exportAll({ default: () => cjs_default });
+var cjs_exports = /* @__PURE__ */ __exportAll({ default: () => cjs_default }, 1);
 var cjs_default;
 var init_cjs = __esmMin((() => {
 	init_lib();

--- a/crates/rolldown/tests/esbuild/default/bundle_esm_with_nested_var_issue4348/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/bundle_esm_with_nested_var_issue4348/artifacts.snap
@@ -19,7 +19,7 @@ var foo_exports = /* @__PURE__ */ __exportAll({
 	h: () => h,
 	i: () => i,
 	j: () => j
-});
+}, 1);
 var a, b, c, d, e, x, f, g, h, i, j;
 var init_foo = __esmMin((() => {
 	a = "a";

--- a/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/common_js_from_es6/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 }, 1);
 function foo$1() {
 	return "foo";
 }
@@ -18,7 +18,7 @@ var init_foo = __esmMin((() => {}));
 
 //#endregion
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar$1 });
+var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar$1 }, 1);
 function bar$1() {
 	return "bar";
 }

--- a/crates/rolldown/tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region types.mjs
-var types_exports = {};
+var types_exports = /* @__PURE__ */ __exportAll({}, 1);
 var init_types = __esmMin((() => {}));
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_common_js/artifacts.snap
@@ -15,7 +15,7 @@ var init_a = __esmMin((() => {
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({ xyz: () => xyz });
+var b_exports = /* @__PURE__ */ __exportAll({ xyz: () => xyz }, 1);
 var xyz;
 var init_b = __esmMin((() => {
 	xyz = null;
@@ -33,7 +33,7 @@ var commonjs_exports = /* @__PURE__ */ __exportAll({
 	default: () => commonjs_default,
 	l: () => l,
 	v: () => v
-});
+}, 1);
 function Fn() {}
 var commonjs_default, v, l, c, Class;
 var init_commonjs = __esmMin((() => {
@@ -48,7 +48,7 @@ var init_commonjs = __esmMin((() => {
 
 //#endregion
 //#region c.js
-var c_exports = /* @__PURE__ */ __exportAll({ default: () => c_default });
+var c_exports = /* @__PURE__ */ __exportAll({ default: () => c_default }, 1);
 var c_default;
 var init_c = __esmMin((() => {
 	c_default = class {};
@@ -56,7 +56,7 @@ var init_c = __esmMin((() => {
 
 //#endregion
 //#region d.js
-var d_exports = /* @__PURE__ */ __exportAll({ default: () => Foo });
+var d_exports = /* @__PURE__ */ __exportAll({ default: () => Foo }, 1);
 var Foo;
 var init_d = __esmMin((() => {
 	Foo = class {};
@@ -65,13 +65,13 @@ var init_d = __esmMin((() => {
 
 //#endregion
 //#region e.js
-var e_exports = /* @__PURE__ */ __exportAll({ default: () => e_default });
+var e_exports = /* @__PURE__ */ __exportAll({ default: () => e_default }, 1);
 function e_default() {}
 var init_e = __esmMin((() => {}));
 
 //#endregion
 //#region f.js
-var f_exports = /* @__PURE__ */ __exportAll({ default: () => foo$1 });
+var f_exports = /* @__PURE__ */ __exportAll({ default: () => foo$1 }, 1);
 function foo$1() {}
 var init_f = __esmMin((() => {
 	foo$1.prop = 123;
@@ -79,13 +79,13 @@ var init_f = __esmMin((() => {
 
 //#endregion
 //#region g.js
-var g_exports = /* @__PURE__ */ __exportAll({ default: () => g_default });
+var g_exports = /* @__PURE__ */ __exportAll({ default: () => g_default }, 1);
 async function g_default() {}
 var init_g = __esmMin((() => {}));
 
 //#endregion
 //#region h.js
-var h_exports = /* @__PURE__ */ __exportAll({ default: () => foo });
+var h_exports = /* @__PURE__ */ __exportAll({ default: () => foo }, 1);
 async function foo() {}
 var init_h = __esmMin((() => {
 	foo.prop = 123;

--- a/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_es6/artifacts.snap
@@ -12,7 +12,7 @@ const abc = void 0;
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({ xyz: () => xyz });
+var b_exports = /* @__PURE__ */ __exportAll({ xyz: () => xyz }, 1);
 const xyz = null;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_iife/artifacts.snap
@@ -17,7 +17,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var globalName = (function(exports) {
 
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 // HIDDEN [rolldown:runtime]
 
 //#region a.js
@@ -25,7 +25,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 //#endregion
 //#region b.js
-	var b_exports = /* @__PURE__ */ __exportAll({ xyz: () => xyz });
+	var b_exports = /* @__PURE__ */ __exportAll({ xyz: () => xyz }, 1);
 	const xyz = null;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle/artifacts.snap
@@ -35,7 +35,7 @@ export { b_default as default };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({ default: () => b_default });
+var b_exports = /* @__PURE__ */ __exportAll({ default: () => b_default }, 1);
 function b_default() {}
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/export_special_name/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_special_name/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region entry.mjs
 const __proto__ = 123;

--- a/crates/rolldown/tests/esbuild/default/export_special_name_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_special_name_bundle/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region lib.mjs
-var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ });
+var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ }, 1);
 var __proto__;
 var init_lib = __esmMin((() => {
 	__proto__ = 123;

--- a/crates/rolldown/tests/esbuild/default/export_wildcard_fs_node_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/export_wildcard_fs_node_common_js/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region internal.js
 let foo = 123;

--- a/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/exports_and_module_format_common_js/artifacts.snap
@@ -11,12 +11,12 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region foo/test.js
-var test_exports$1 = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var test_exports$1 = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
+var test_exports = /* @__PURE__ */ __exportAll({ bar: () => bar }, 1);
 let bar = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/artifacts.snap
@@ -11,27 +11,27 @@ import { ns } from "x";
 
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
+var a_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 }, 1);
 var init_a = __esmMin((() => {}));
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
+var b_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 }, 1);
 var init_b = __esmMin((() => {}));
 
 //#endregion
 //#region c.js
-var c_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
+var c_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 }, 1);
 var init_c = __esmMin((() => {}));
 
 //#endregion
 //#region d.js
-var d_exports = /* @__PURE__ */ __exportAll({ ns: () => ns });
+var d_exports = /* @__PURE__ */ __exportAll({ ns: () => ns }, 1);
 var init_d = __esmMin((() => {}));
 
 //#endregion
 //#region e.js
-var e_exports = {};
+var e_exports = /* @__PURE__ */ __exportAll({}, 1);
 import * as import_x from "x";
 __reExport(e_exports, import_x);
 var init_e = __esmMin((() => {}));

--- a/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/diff.md
+++ b/crates/rolldown/tests/esbuild/default/external_es6_converted_to_common_js/diff.md
@@ -68,27 +68,27 @@ import { ns } from "x";
 
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
+var a_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 }, 1);
 var init_a = __esmMin((() => {}));
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
+var b_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 }, 1);
 var init_b = __esmMin((() => {}));
 
 //#endregion
 //#region c.js
-var c_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 });
+var c_exports = /* @__PURE__ */ __exportAll({ ns: () => ns$1 }, 1);
 var init_c = __esmMin((() => {}));
 
 //#endregion
 //#region d.js
-var d_exports = /* @__PURE__ */ __exportAll({ ns: () => ns });
+var d_exports = /* @__PURE__ */ __exportAll({ ns: () => ns }, 1);
 var init_d = __esmMin((() => {}));
 
 //#endregion
 //#region e.js
-var e_exports = {};
+var e_exports = /* @__PURE__ */ __exportAll({}, 1);
 import * as import_x from "x";
 __reExport(e_exports, import_x);
 var init_e = __esmMin((() => {}));
@@ -111,33 +111,35 @@ init_e();
 @@ -1,43 +1,26 @@
 -var a_exports = {};
 -__export(a_exports, {
--    ns: () => ns
 +import * as ns$1 from "x";
 +import {ns} from "x";
 +var a_exports = __exportAll({
 +    ns: () => ns$1
- });
--import * as ns from "x";
--var init_a = __esm({
--    "a.js"() {}
++}, 1);
 +var init_a = __esmMin(() => {});
 +var b_exports = __exportAll({
 +    ns: () => ns$1
- });
--var b_exports = {};
--__export(b_exports, {
--    ns: () => ns2
++}, 1);
 +var init_b = __esmMin(() => {});
 +var c_exports = __exportAll({
 +    ns: () => ns$1
- });
++}, 1);
++var init_c = __esmMin(() => {});
++var d_exports = __exportAll({
+     ns: () => ns
+-});
+-import * as ns from "x";
+-var init_a = __esm({
+-    "a.js"() {}
+-});
+-var b_exports = {};
+-__export(b_exports, {
+-    ns: () => ns2
+-});
 -import * as ns2 from "x";
 -var init_b = __esm({
 -    "b.js"() {}
-+var init_c = __esmMin(() => {});
-+var d_exports = __exportAll({
-+    ns: () => ns
- });
+-});
 -var c_exports = {};
 -__export(c_exports, {
 -    ns: () => ns3
@@ -154,14 +156,16 @@ init_e();
 -var init_d = __esm({
 -    "d.js"() {}
 -});
-+var init_d = __esmMin(() => {});
- var e_exports = {};
+-var e_exports = {};
 -import * as x_star from "x";
 -var init_e = __esm({
 -    "e.js"() {
 -        __reExport(e_exports, x_star);
 -    }
 -});
++}, 1);
++var init_d = __esmMin(() => {});
++var e_exports = __exportAll({}, 1);
 +import * as import_x from "x";
 +__reExport(e_exports, import_x);
 +var init_e = __esmMin(() => {});

--- a/crates/rolldown/tests/esbuild/default/forbid_string_export_names_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/forbid_string_export_names_bundle/artifacts.snap
@@ -19,7 +19,7 @@ let nested$1 = 2;
 var nested_exports = /* @__PURE__ */ __exportAll({
 	"nested name": () => nested,
 	"very nested name": () => nested$1
-});
+}, 1);
 let nested = 1;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/import_missing_neither_es6_nor_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/import_missing_neither_es6_nor_common_js/artifacts.snap
@@ -60,7 +60,7 @@ init_foo();
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = {};
+var foo_exports = /* @__PURE__ */ __exportAll({}, 1);
 var default$1, x, y;
 var init_foo = __esmMin((() => {
 	console.log("no exports here");

--- a/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/mangle_props_import_export_bundled/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __exportAll({ esm_foo_: () => esm_foo_ });
+var esm_exports = /* @__PURE__ */ __exportAll({ esm_foo_: () => esm_foo_ }, 1);
 var esm_foo_;
 var init_esm = __esmMin((() => {
 	esm_foo_ = "foo";

--- a/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/minified_exports_and_module_format_common_js/artifacts.snap
@@ -9,12 +9,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region foo/test.js
-var test_exports$1 = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var test_exports$1 = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 let foo = 123;
 
 //#endregion
 //#region bar/test.js
-var test_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
+var test_exports = /* @__PURE__ */ __exportAll({ bar: () => bar }, 1);
 let bar = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/node_annotation_false_positive_issue3544/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/node_annotation_false_positive_issue3544/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region entry.mjs
 function confuseNode(exports) {

--- a/crates/rolldown/tests/esbuild/default/node_annotation_invalid_identifier_issue4100/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/node_annotation_invalid_identifier_issue4100/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry_mjs.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region entry.mjs
 let foo, bar, baz;

--- a/crates/rolldown/tests/esbuild/default/re_export_default_external_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/re_export_default_external_common_js/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 let foo = require("foo");
 foo = __toESM(foo);

--- a/crates/rolldown/tests/esbuild/default/re_export_default_no_bundle_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/re_export_default_no_bundle_common_js/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 let foo = require("./foo");
 foo = __toESM(foo);

--- a/crates/rolldown/tests/esbuild/default/string_export_names_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/string_export_names_common_js/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 let foo = require("./foo");
 foo = __toESM(foo);

--- a/crates/rolldown/tests/esbuild/default/string_export_names_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/string_export_names_iife/artifacts.snap
@@ -24,6 +24,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 (function(exports, foo) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 foo = __toESM(foo);
 

--- a/crates/rolldown/tests/esbuild/default/this_with_es6_syntax/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/this_with_es6_syntax/artifacts.snap
@@ -12,7 +12,7 @@ console.log(void 0);
 
 //#endregion
 //#region dummy.js
-var dummy_exports = /* @__PURE__ */ __exportAll({ dummy: () => dummy });
+var dummy_exports = /* @__PURE__ */ __exportAll({ dummy: () => dummy }, 1);
 var dummy;
 var init_dummy = __esmMin((() => {
 	dummy = 123;

--- a/crates/rolldown/tests/esbuild/default/top_level_await_allowed_import_without_splitting/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_allowed_import_without_splitting/artifacts.snap
@@ -14,7 +14,7 @@ var require_c = /* @__PURE__ */ __commonJSMin((async () => {
 
 //#endregion
 //#region b.js
-var b_exports = {};
+var b_exports = /* @__PURE__ */ __exportAll({}, 1);
 var import_c;
 var init_b = __esmMin((async () => {
 	import_c = require_c();
@@ -22,7 +22,7 @@ var init_b = __esmMin((async () => {
 
 //#endregion
 //#region a.js
-var a_exports = {};
+var a_exports = /* @__PURE__ */ __exportAll({}, 1);
 var init_a = __esmMin((async () => {
 	await init_b();
 }));

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require/artifacts.snap
@@ -14,7 +14,7 @@ var require_c = /* @__PURE__ */ __commonJSMin((async () => {
 
 //#endregion
 //#region b.js
-var b_exports = {};
+var b_exports = /* @__PURE__ */ __exportAll({}, 1);
 var import_c;
 var init_b = __esmMin((async () => {
 	import_c = require_c();
@@ -22,7 +22,7 @@ var init_b = __esmMin((async () => {
 
 //#endregion
 //#region a.js
-var a_exports = {};
+var a_exports = /* @__PURE__ */ __exportAll({}, 1);
 var init_a = __esmMin((async () => {
 	await init_b();
 }));

--- a/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_forbidden_require_dead_branch/artifacts.snap
@@ -24,12 +24,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 //#endregion
 //#region b.js
-	var b_exports = {};
+	var b_exports = /* @__PURE__ */ __exportAll({}, 1);
 	var init_b = __esmMin((() => {}));
 
 //#endregion
 //#region a.js
-	var a_exports = {};
+	var a_exports = /* @__PURE__ */ __exportAll({}, 1);
 	var init_a = __esmMin((() => {}));
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_cjs_issue2264/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_cjs_issue2264/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 'use strict';
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region entry.js
 let a = 1;

--- a/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_iife_issue2264/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/use_strict_directive_bundle_iife_issue2264/artifacts.snap
@@ -19,6 +19,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region entry.js
 	let a = 1;

--- a/crates/rolldown/tests/esbuild/default/warn_common_js_exports_in_esm_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/warn_common_js_exports_in_esm_bundle/artifacts.snap
@@ -41,6 +41,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## cjs-in-esm.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region cjs-in-esm.js
 let foo = 1;

--- a/crates/rolldown/tests/esbuild/default/warn_common_js_exports_in_esm_convert/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/warn_common_js_exports_in_esm_convert/artifacts.snap
@@ -70,6 +70,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## cjs-in-esm.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region cjs-in-esm.js
 let foo = 1;
@@ -83,6 +84,7 @@ exports.foo = foo;
 ## cjs-in-esm2.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region cjs-in-esm2.js
 let foo = 1;

--- a/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_as_namespace_common_js/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region foo.js

--- a/crates/rolldown/tests/esbuild/importstar/export_other_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_common_js/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region foo.js

--- a/crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_other_nested_common_js/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region foo.js

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_import_self_common_js/artifacts.snap
@@ -6,10 +6,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
-var entry_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var entry_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const foo = 123;
 console.log(entry_exports);
 

--- a/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_and_require_self_common_js/artifacts.snap
@@ -6,10 +6,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
-var entry_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var entry_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 var foo;
 var init_entry = __esmMin((() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_common_js/artifacts.snap
@@ -6,13 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region entry.js
 var entry_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	ns: () => entry_exports
-});
+}, 1);
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_as_namespace_es6/artifacts.snap
@@ -11,7 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 var entry_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	ns: () => entry_exports
-});
+}, 1);
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/export_self_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_common_js/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region entry.js
 const foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife/artifacts.snap
@@ -17,6 +17,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region entry.js
 	const foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_self_iife_with_name/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var someName = (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region entry.js
 	const foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/export_star_default_export_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/export_star_default_export_common_js/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region foo.js
 let foo = "foo";

--- a/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_default_namespace_combo_issue446/artifacts.snap
@@ -251,7 +251,7 @@ console.log(internal_default, internal_exports);
 ```js
 // HIDDEN [rolldown:runtime]
 //#region internal.js
-var internal_exports = /* @__PURE__ */ __exportAll({ default: () => internal_default });
+var internal_exports = /* @__PURE__ */ __exportAll({ default: () => internal_default }, 1);
 var internal_default = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_export_other_as_namespace_common_js/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region foo.js

--- a/crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_export_self_as_namespace_es6/artifacts.snap
@@ -11,7 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 var entry_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	ns: () => entry_exports
-});
+}, 1);
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_and_common_js/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 var foo;
 var init_foo = __esmMin((() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_capture/artifacts.snap
@@ -10,13 +10,16 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 }, 1);
 const foo$1 = 123;
 
 //#endregion
 //#region entry.js
 let foo = 234;
-assert.deepEqual(foo_exports, { foo: 123 });
+assert.deepEqual(foo_exports, {
+	[Symbol.toStringTag]: "Module",
+	foo: 123
+});
 assert.equal(foo$1, 123);
 assert.equal(foo, 234);
 

--- a/crates/rolldown/tests/esbuild/importstar/import_star_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_capture/entry.js
@@ -2,6 +2,7 @@ import assert from 'node:assert'
 import * as ns from './foo'
 let foo = 234
 assert.deepEqual(ns, {
+  [Symbol.toStringTag]: 'Module',
   foo: 123
 })
 assert.equal(ns.foo, 123)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/artifacts.snap
@@ -10,13 +10,16 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 }, 1);
 const foo$1 = 123;
 
 //#endregion
 //#region entry.js
 let foo = 234;
-assert.deepEqual(foo_exports, { foo: 123 });
+assert.deepEqual(foo_exports, {
+	[Symbol.toStringTag]: "Module",
+	foo: 123
+});
 assert.equal(foo$1, 123);
 assert.equal(foo, 234);
 

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_import_star_capture/entry.js
@@ -2,6 +2,7 @@ import assert from 'node:assert'
 import {ns} from './bar'
 let foo = 234
 assert.deepEqual(ns, {
+  [Symbol.toStringTag]: 'Module',
   foo: 123
 })
 assert.equal(ns.foo, 123)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/artifacts.snap
@@ -10,13 +10,16 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 }, 1);
 const foo$1 = 123;
 
 //#endregion
 //#region entry.js
 let foo = 234;
-assert.deepEqual(foo_exports, { foo: 123 });
+assert.deepEqual(foo_exports, {
+	[Symbol.toStringTag]: "Module",
+	foo: 123
+});
 assert.equal(foo$1, 123);
 assert.equal(foo, 234);
 

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_as_capture/entry.js
@@ -2,6 +2,7 @@ import assert from 'node:assert'
 import {ns} from './bar'
 let foo = 234
 assert.deepEqual(ns, {
+  [Symbol.toStringTag]: 'Module',
   foo: 123
 })
 assert.equal(ns.foo, 123)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/artifacts.snap
@@ -14,12 +14,15 @@ const foo$1 = 123;
 
 //#endregion
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
+var bar_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 }, 1);
 
 //#endregion
 //#region entry.js
 let foo = 234;
-assert.deepEqual(bar_exports, { foo: 123 });
+assert.deepEqual(bar_exports, {
+	[Symbol.toStringTag]: "Module",
+	foo: 123
+});
 assert.equal(foo$1, 123);
 assert.equal(foo, 234);
 

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_capture/entry.js
@@ -2,6 +2,7 @@ import assert from 'node:assert'
 import * as ns from './bar'
 let foo = 234
 assert.deepEqual(ns, {
+  [Symbol.toStringTag]: 'Module',
   foo: 123
 })
 assert.equal(ns.foo, 123)

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/artifacts.snap
@@ -21,11 +21,12 @@ const z = 4;
 var common_exports = /* @__PURE__ */ __exportAll({
 	x: () => x,
 	z: () => z
-});
+}, 1);
 
 //#endregion
 //#region entry.js
 assert.deepEqual(common_exports, {
+	[Symbol.toStringTag]: "Module",
 	x: 1,
 	z: 4
 });

--- a/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_export_star_omit_ambiguous/entry.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import * as ns from './common'
 assert.deepEqual(ns, {
+  [Symbol.toStringTag]: 'Module',
   x: 1,
   z: 4
 })

--- a/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/artifacts.snap
@@ -10,17 +10,23 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
+var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar }, 1);
 const bar = 123;
 
 //#endregion
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ bar_ns: () => bar_exports });
+var foo_exports = /* @__PURE__ */ __exportAll({ bar_ns: () => bar_exports }, 1);
 
 //#endregion
 //#region entry.js
 console.log(foo_exports);
-assert.deepEqual(foo_exports, { bar_ns: { bar: 123 } });
+assert.deepEqual(foo_exports, {
+	[Symbol.toStringTag]: "Module",
+	bar_ns: {
+		[Symbol.toStringTag]: "Module",
+		bar: 123
+	}
+});
 
 //#endregion
 ```

--- a/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/import_star_of_export_star_as/entry.js
@@ -2,7 +2,9 @@ import assert from 'node:assert'
 import * as foo_ns from './foo'
 console.log(foo_ns)
 assert.deepEqual(foo_ns, {
+  [Symbol.toStringTag]: 'Module',
   bar_ns: {
+    [Symbol.toStringTag]: 'Module',
     bar: 123
   }
 })

--- a/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/issue176/artifacts.snap
@@ -12,7 +12,7 @@ const foo = () => "hi there";
 
 //#endregion
 //#region folders/index.js
-var folders_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var folders_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/artifacts.snap
@@ -7,9 +7,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```text
 [IMPORT_IS_UNDEFINED] Warning: Import `foo` will always be undefined because there is no matching export in 'foo.js'
-   ╭─[ entry.js:6:14 ]
+   ╭─[ entry.js:7:14 ]
    │
- 6 │ assert.equal(ns.foo, undefined)
+ 7 │ assert.equal(ns.foo, undefined)
    │              ───┬──  
    │                 ╰──── 
 ───╯
@@ -25,12 +25,15 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ x: () => x });
+var foo_exports = /* @__PURE__ */ __exportAll({ x: () => x }, 1);
 const x = 123;
 
 //#endregion
 //#region entry.js
-assert.deepEqual(foo_exports, { x: 123 });
+assert.deepEqual(foo_exports, {
+	[Symbol.toStringTag]: "Module",
+	x: 123
+});
 assert.equal(void 0, void 0);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_missing_es6/entry.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import * as ns from './foo'
 assert.deepEqual(ns, {
+  [Symbol.toStringTag]: 'Module',
   x: 123
 })
 assert.equal(ns.foo, undefined)

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/artifacts.snap
@@ -7,9 +7,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```text
 [IMPORT_IS_UNDEFINED] Warning: Import `foo` will always be undefined because there is no matching export in 'foo.js'
-   ╭─[ entry.js:6:14 ]
+   ╭─[ entry.js:7:14 ]
    │
- 6 │ assert.equal(ns.foo, undefined)
+ 7 │ assert.equal(ns.foo, undefined)
    │              ───┬──  
    │                 ╰──── 
 ───╯
@@ -29,11 +29,14 @@ const x = 123;
 
 //#endregion
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ x: () => x });
+var foo_exports = /* @__PURE__ */ __exportAll({ x: () => x }, 1);
 
 //#endregion
 //#region entry.js
-assert.deepEqual(foo_exports, { x: 123 });
+assert.deepEqual(foo_exports, {
+	[Symbol.toStringTag]: "Module",
+	x: 123
+});
 assert.equal(void 0, void 0);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/namespace_import_re_export_star_missing_es6/entry.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import * as ns from './foo'
 assert.deepEqual(ns, {
+  [Symbol.toStringTag]: 'Module',
   x: 123
 })
 assert.equal(ns.foo, undefined)

--- a/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/artifacts.snap
@@ -7,9 +7,9 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```text
 [IMPORT_IS_UNDEFINED] Warning: Import `foo` will always be undefined because there is no matching export in 'bar.js'
-   ╭─[ entry.js:6:14 ]
+   ╭─[ entry.js:7:14 ]
    │
- 6 │ assert.equal(ns.foo, undefined)
+ 7 │ assert.equal(ns.foo, undefined)
    │              ───┬──  
    │                 ╰──── 
 ───╯
@@ -25,12 +25,15 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __exportAll({ x: () => x });
+var bar_exports = /* @__PURE__ */ __exportAll({ x: () => x }, 1);
 const x = 123;
 
 //#endregion
 //#region entry.js
-assert.deepEqual(bar_exports, { x: 123 });
+assert.deepEqual(bar_exports, {
+	[Symbol.toStringTag]: "Module",
+	x: 123
+});
 assert.equal(void 0, void 0);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/entry.js
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_namespace_import_missing_es6/entry.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import {ns} from './foo'
 assert.deepEqual(ns, {
+  [Symbol.toStringTag]: 'Module',
   x: 123
 })
 assert.equal(ns.foo, undefined)

--- a/crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6/artifacts.snap
@@ -11,7 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 var foo_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	ns: () => foo_exports
-});
+}, 1);
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6/artifacts.snap
@@ -11,7 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 var foo_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	ns: () => foo_exports
-});
+}, 1);
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_common_js_no_bundle/artifacts.snap
@@ -21,6 +21,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 let foo = require("foo");
 foo = __toESM(foo);

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_common_js/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 let foo = require("foo");
 foo = __toESM(foo);

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_external_iife/artifacts.snap
@@ -30,6 +30,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var mod = (function(exports, foo) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 foo = __toESM(foo);
 

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_as_iife_no_bundle/artifacts.snap
@@ -30,6 +30,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var mod = (function(exports, foo) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 foo = __toESM(foo);
 

--- a/crates/rolldown/tests/esbuild/importstar/re_export_star_entry_point_and_inner_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar/re_export_star_entry_point_and_inner_file/artifacts.snap
@@ -6,10 +6,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region inner.js
-var inner_exports = {};
+var inner_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(inner_exports, require("b"));
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_and_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_and_common_js/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 var foo;
 var init_foo = __esmMin((() => {
 	foo = 123;

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_capture/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.ts
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/importstar_ts/ts_import_star_export_star_capture/artifacts.snap
@@ -12,7 +12,7 @@ const foo = 123;
 
 //#endregion
 //#region bar.ts
-var bar_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var bar_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 
 //#endregion
 //#region entry.ts

--- a/crates/rolldown/tests/esbuild/loader/empty_loader_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/empty_loader_js/artifacts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
 # Assets
 
@@ -9,8 +8,9 @@ snapshot_kind: text
 ```js
 import assert from "node:assert";
 
+// HIDDEN [rolldown:runtime]
 //#region b.empty
-var b_exports = {};
+var b_exports = /* @__PURE__ */ __exportAll({}, 1);
 
 //#endregion
 //#region c.empty
@@ -22,7 +22,7 @@ var named = void 0;
 
 //#endregion
 //#region entry.js
-assert.deepEqual(b_exports, {});
+assert.deepEqual(b_exports, { [Symbol.toStringTag]: "Module" });
 assert.deepEqual(default$1, void 0);
 assert.equal(named, void 0);
 

--- a/crates/rolldown/tests/esbuild/loader/empty_loader_js/entry.js
+++ b/crates/rolldown/tests/esbuild/loader/empty_loader_js/entry.js
@@ -4,6 +4,6 @@ import * as ns from './b.empty'
 import def from './c.empty'
 import { named } from './d.empty'
 
-assert.deepEqual(ns, {})
+assert.deepEqual(ns, { [Symbol.toStringTag]: 'Module' })
 assert.deepEqual(def, undefined)
 assert.equal(named, undefined)

--- a/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_invalid_identifier_es6/artifacts.snap
@@ -15,7 +15,7 @@ var invalid_identifier$1 = true;
 var test2_exports = /* @__PURE__ */ __exportAll({
 	default: () => test2_default,
 	"invalid-identifier": () => invalid_identifier
-});
+}, 1);
 var invalid_identifier = true;
 var test2_default = { "invalid-identifier": invalid_identifier };
 

--- a/crates/rolldown/tests/esbuild/loader/loader_json_no_bundle_common_js/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_no_bundle_common_js/artifacts.snap
@@ -15,7 +15,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## test.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region test.json
 var test = 123;

--- a/crates/rolldown/tests/esbuild/loader/loader_json_no_bundle_iife/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_json_no_bundle_iife/artifacts.snap
@@ -24,7 +24,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 (function(exports) {
 
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region test.json
 	var test = 123;

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.browser.js
-var module_browser_exports = /* @__PURE__ */ __exportAll({ default: () => module_browser_default });
+var module_browser_exports = /* @__PURE__ */ __exportAll({ default: () => module_browser_default }, 1);
 var module_browser_default;
 var init_module_browser = __esmMin((() => {
 	module_browser_default = "browser module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default }, 1);
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main/artifacts.snap
@@ -10,7 +10,7 @@ import assert, { deepEqual } from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default }, 1);
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default }, 1);
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default }, 1);
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default }, 1);
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_require_only/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/packagejson/package_json_dual_package_hazard_require_only/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region node_modules/demo-pkg/module.js
-var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default });
+var module_exports = /* @__PURE__ */ __exportAll({ default: () => module_default }, 1);
 var module_default;
 var init_module = __esmMin((() => {
 	module_default = "module";

--- a/crates/rolldown/tests/esbuild/splitting/edge_case_issue2793_without_splitting/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/edge_case_issue2793_without_splitting/artifacts.snap
@@ -25,7 +25,7 @@ var init_b = __esmMin((() => {
 var edge_case_issue2793_without_splitting_exports = /* @__PURE__ */ __exportAll({
 	A: () => A,
 	B: () => B
-});
+}, 1);
 var init_edge_case_issue2793_without_splitting = __esmMin((() => {
 	init_a();
 	init_b();

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
+var foo_exports = /* @__PURE__ */ __exportAll({ bar: () => bar }, 1);
 let bar = 123;
 
 //#endregion
@@ -35,7 +35,7 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
+var foo_exports = /* @__PURE__ */ __exportAll({ bar: () => bar }, 1);
 let bar = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617/artifacts.snap
@@ -17,7 +17,7 @@ export { foo };
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var a_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 var foo;
 var init_a = __esmMin((() => {
 	;

--- a/crates/rolldown/tests/esbuild/splitting/splitting_missing_lazy_export/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_missing_lazy_export/artifacts.snap
@@ -56,8 +56,9 @@ console.log(bar());
 ## common.js
 
 ```js
+// HIDDEN [rolldown:runtime]
 //#region empty.js
-var empty_exports = {};
+var empty_exports = /* @__PURE__ */ __exportAll({}, 1);
 
 //#endregion
 //#region common.js

--- a/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/export_type_issue379/artifacts.snap
@@ -8,12 +8,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.ts
-var a_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$3 });
+var a_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$3 }, 1);
 let foo$3 = 123;
 
 //#endregion
 //#region b.ts
-var b_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$2 });
+var b_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$2 }, 1);
 let foo$2 = 123;
 
 //#endregion
@@ -25,7 +25,7 @@ var Test = void 0;
 var c_exports = /* @__PURE__ */ __exportAll({
 	Test: () => Test,
 	foo: () => foo$1
-});
+}, 1);
 let foo$1 = 123;
 
 //#endregion
@@ -33,7 +33,7 @@ let foo$1 = 123;
 var d_exports = /* @__PURE__ */ __exportAll({
 	Test: () => Test,
 	foo: () => foo
-});
+}, 1);
 let foo = 123;
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_export_missing_es6/artifacts.snap
@@ -12,7 +12,7 @@ var nope = void 0;
 
 //#endregion
 //#region foo.ts
-var foo_exports = /* @__PURE__ */ __exportAll({ nope: () => nope });
+var foo_exports = /* @__PURE__ */ __exportAll({ nope: () => nope }, 1);
 
 //#endregion
 //#region entry.js

--- a/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/ts/ts_import_equals_undefined_import/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region import.ts
-var import_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var import_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 let value = 123;
 
 //#endregion

--- a/crates/rolldown/tests/integration_test262.rs
+++ b/crates/rolldown/tests/integration_test262.rs
@@ -198,7 +198,7 @@ fn create_bundler_options(test_file: &Path, test_folder: &Path) -> BundlerOption
     format: Some(rolldown::OutputFormat::Esm),
     platform: Some(rolldown::Platform::Node),
     keep_names: Some(true),
-    generated_code: Some(rolldown::GeneratedCodeOptions { preset: None, symbols: true }),
+    generated_code: Some(rolldown::GeneratedCodeOptions { symbols: true }),
     ..Default::default()
   }
 }

--- a/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/basic_commonjs/artifacts.snap
@@ -13,7 +13,7 @@ var esm_exports = /* @__PURE__ */ __exportAll({
 	esm_named_class: () => esm_named_class,
 	esm_named_fn: () => esm_named_fn,
 	esm_named_var: () => esm_named_var
-});
+}, 1);
 function esm_default_fn$1() {}
 function esm_named_fn() {}
 function hoisted_fn() {

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __exportAll({ default: () => esm_default });
+var esm_exports = /* @__PURE__ */ __exportAll({ default: () => esm_default }, 1);
 var esm_default;
 var init_esm = __esmMin((() => {
 	esm_default = "esm";

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_require_esm_unused/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __exportAll({ default: () => esm_default });
+var esm_exports = /* @__PURE__ */ __exportAll({ default: () => esm_default }, 1);
 var esm_default;
 var init_esm = __esmMin((() => {
 	esm_default = "esm";

--- a/crates/rolldown/tests/rolldown/cjs_compat/exoprt_star_of_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/exoprt_star_of_cjs/artifacts.snap
@@ -14,17 +14,17 @@ var require_c = /* @__PURE__ */ __commonJSMin(((exports) => {
 
 //#endregion
 //#region b.js
-var b_exports = {};
+var b_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(b_exports, /* @__PURE__ */ __toESM(require_c()));
 
 //#endregion
 //#region a.js
-var a_exports = {};
+var a_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(a_exports, b_exports);
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(main_exports, a_exports);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import/artifacts.snap
@@ -16,7 +16,7 @@ var require_commonjs = /* @__PURE__ */ __commonJSMin(((exports) => {
 
 //#endregion
 //#region proxy.js
-var proxy_exports = {};
+var proxy_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(proxy_exports, /* @__PURE__ */ __toESM(require_commonjs()));
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import/artifacts.snap
@@ -20,7 +20,7 @@ var require_commonjs2 = /* @__PURE__ */ __commonJSMin(((exports) => {}));
 
 //#endregion
 //#region proxy.js
-var proxy_exports = {};
+var proxy_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(proxy_exports, /* @__PURE__ */ __toESM(require_commonjs()));
 __reExport(proxy_exports, /* @__PURE__ */ __toESM(require_commonjs2()));
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/issue_7634/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/issue_7634/artifacts.snap
@@ -6,10 +6,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region baz.js
-var baz_exports = /* @__PURE__ */ __exportAll({ baz: () => baz });
+var baz_exports = /* @__PURE__ */ __exportAll({ baz: () => baz }, 1);
 const baz = "baz";
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/basic/artifacts.snap
@@ -16,7 +16,7 @@ var esm_exports = /* @__PURE__ */ __exportAll({
 	default: () => esm_default,
 	foo: () => foo,
 	"module.exports": () => moduleExports
-});
+}, 1);
 var foo, bar, esm_default, __esModule, moduleExports;
 var init_esm = __esmMin((() => {
 	foo = "foo";

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/fallback/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/fallback/artifacts.snap
@@ -14,7 +14,7 @@ var esm_exports = /* @__PURE__ */ __exportAll({
 	bar: () => bar,
 	default: () => esm_default,
 	foo: () => foo
-});
+}, 1);
 var foo, bar, esm_default;
 var init_esm = __esmMin((() => {
 	foo = "foo";

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/priority/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/priority/artifacts.snap
@@ -14,7 +14,7 @@ var esm_exports = /* @__PURE__ */ __exportAll({
 	default: () => esm_default,
 	"module.exports": () => moduleExports,
 	namedExport: () => namedExport
-});
+}, 1);
 var namedExport, esm_default, moduleExports;
 var init_esm = __esmMin((() => {
 	namedExport = "named";

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/with_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/with_default/artifacts.snap
@@ -13,7 +13,7 @@ import assert from "node:assert";
 var esm_exports = /* @__PURE__ */ __exportAll({
 	default: () => myFunction,
 	"module.exports": () => moduleExports
-});
+}, 1);
 function myFunction() {
 	return "function value";
 }

--- a/crates/rolldown/tests/rolldown/cjs_compat/node_module_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/node_module_commonjs/artifacts.snap
@@ -13,13 +13,13 @@ var require_commonjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 }));
 
 //#endregion
-export { __reExport as n, __toESM as r, require_commonjs as t };
+export { __toESM as i, __exportAll as n, __reExport as r, require_commonjs as t };
 ```
 
 ## entry.js
 
 ```js
-import { r as __toESM, t as require_commonjs } from "./commonjs.js";
+import { i as __toESM, t as require_commonjs } from "./commonjs.js";
 
 //#region entry.js
 var import_commonjs = /* @__PURE__ */ __toESM(require_commonjs(), 1);
@@ -31,10 +31,10 @@ console.log(import_commonjs.default);
 ## main.js
 
 ```js
-import { n as __reExport, r as __toESM, t as require_commonjs } from "./commonjs.js";
+import { i as __toESM, n as __exportAll, r as __reExport, t as require_commonjs } from "./commonjs.js";
 
 //#region star-export.js
-var star_export_exports = {};
+var star_export_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(star_export_exports, /* @__PURE__ */ __toESM(require_commonjs(), 1));
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region json.js
-var json_exports = /* @__PURE__ */ __exportAll({ default: () => json_default });
+var json_exports = /* @__PURE__ */ __exportAll({ default: () => json_default }, 1);
 var json_default;
 var init_json = __esmMin((() => {
 	json_default = JSON.parse("[1, 2, 3]");

--- a/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/partial_cjs_ns_merge_2/artifacts.snap
@@ -14,7 +14,7 @@ var require_react = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __exportAll({ default: () => toArray$1 });
+var lib_exports = /* @__PURE__ */ __exportAll({ default: () => toArray$1 }, 1);
 function toArray$1(children) {
 	import_react$1.default.Children.forEach(children, function(child) {});
 	return ret;

--- a/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/reexport_commonjs/artifacts.snap
@@ -23,7 +23,7 @@ const value = 1;
 var foo_exports = /* @__PURE__ */ __exportAll({
 	bar: () => import_commonjs.bar,
 	value: () => value
-});
+}, 1);
 __reExport(foo_exports, /* @__PURE__ */ __toESM(require_commonjs()));
 var import_commonjs = require_commonjs();
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/reexports_from_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/reexports_from_cjs/artifacts.snap
@@ -16,7 +16,7 @@ var require_commonjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region reexports.mjs
-var reexports_exports = {};
+var reexports_exports = /* @__PURE__ */ __exportAll({}, 1);
 var import_commonjs = require_commonjs();
 __reExport(reexports_exports, /* @__PURE__ */ __toESM(require_commonjs(), 1));
 assert.equal(import_commonjs.bar, 1);

--- a/crates/rolldown/tests/rolldown/cjs_compat/require/require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require/require_esm/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = {};
+var esm_exports = /* @__PURE__ */ __exportAll({}, 1);
 var init_esm = __esmMin((() => {}));
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/require_call_expr_unused/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __exportAll({ a: () => a$1 });
+var esm_exports = /* @__PURE__ */ __exportAll({ a: () => a$1 }, 1);
 var a$1;
 var init_esm = __esmMin((() => {
 	a$1 = 100;

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/artifacts.snap
@@ -10,14 +10,17 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const foo = 1;
 
 //#endregion
 //#region main.js
-assert.deepEqual(foo_exports, { foo: 1 });
+assert.deepEqual(foo_exports, {
+	[Symbol.toStringTag]: "Module",
+	foo: 1
+});
 Promise.resolve().then(() => foo_exports).then((mod) => {
-	assert.deepEqual(JSON.parse(JSON.stringify(mod)), foo_exports);
+	assert.deepEqual(mod, foo_exports);
 });
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file/main.js
@@ -2,10 +2,10 @@ import * as fooNamespace from './foo.js';
 import assert from 'node:assert';
 
 assert.deepEqual(fooNamespace, {
+  [Symbol.toStringTag]: 'Module',
   foo: 1,
 });
 
 import('./foo.js').then((mod) => {
-  // workaround for the String tag `Module`
-  assert.deepEqual(JSON.parse(JSON.stringify(mod)), fooNamespace);
+  assert.deepEqual(mod, fooNamespace);
 });

--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
@@ -42,7 +42,7 @@ require("node:assert");
 const require_chunk = require('./chunk.js');
 
 //#region esm.js
-var esm_exports = /* @__PURE__ */ require_chunk.__exportAll({ share: () => share });
+var esm_exports = /* @__PURE__ */ require_chunk.__exportAll({ share: () => share }, 1);
 function share() {
 	return 1;
 }

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_2786/artifacts.snap
@@ -10,12 +10,12 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region share.js
-var share_exports$1 = /* @__PURE__ */ __exportAll({ default: () => share_default$1 });
+var share_exports$1 = /* @__PURE__ */ __exportAll({ default: () => share_default$1 }, 1);
 var share_default$1 = "shared";
 
 //#endregion
 //#region share.json
-var share_exports = /* @__PURE__ */ __exportAll({ default: () => share_default });
+var share_exports = /* @__PURE__ */ __exportAll({ default: () => share_default }, 1);
 var share_default = {};
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276/artifacts.snap
@@ -8,12 +8,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region imp1.js
-var imp1_exports = /* @__PURE__ */ __exportAll({ imp1: () => imp1 });
+var imp1_exports = /* @__PURE__ */ __exportAll({ imp1: () => imp1 }, 1);
 const imp1 = 1;
 
 //#endregion
 //#region imp2.js
-var imp2_exports = /* @__PURE__ */ __exportAll({ imp2: () => imp2 });
+var imp2_exports = /* @__PURE__ */ __exportAll({ imp2: () => imp2 }, 1);
 const imp2 = 2;
 
 //#endregion
@@ -21,7 +21,7 @@ const imp2 = 2;
 var imp3_exports = /* @__PURE__ */ __exportAll({
 	imp3: () => imp3,
 	imp33: () => imp33
-});
+}, 1);
 const imp3 = 3;
 const imp33 = 33;
 
@@ -136,12 +136,12 @@ load();
 const require_rolldown_runtime = require('./rolldown-runtime.js');
 
 //#region imp1.js
-var imp1_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ imp1: () => imp1 });
+var imp1_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ imp1: () => imp1 }, 1);
 const imp1 = 1;
 
 //#endregion
 //#region imp2.js
-var imp2_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ imp2: () => imp2 });
+var imp2_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ imp2: () => imp2 }, 1);
 const imp2 = 2;
 
 //#endregion
@@ -149,7 +149,7 @@ const imp2 = 2;
 var imp3_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({
 	imp3: () => imp3,
 	imp33: () => imp33
-});
+}, 1);
 const imp3 = 3;
 const imp33 = 33;
 

--- a/crates/rolldown/tests/rolldown/code_splitting/issue_5276_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/issue_5276_2/artifacts.snap
@@ -11,7 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 var imp_exports = /* @__PURE__ */ __exportAll({
 	imp2: () => imp2,
 	imp22: () => imp22
-});
+}, 1);
 const imp2 = 2;
 const imp22 = 22;
 
@@ -51,7 +51,7 @@ const require_rolldown_runtime = require('./rolldown-runtime.js');
 var imp_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({
 	imp2: () => imp2,
 	imp22: () => imp22
-});
+}, 1);
 const imp2 = 2;
 const imp22 = 22;
 

--- a/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/dce/conditional_exports/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region lib.prod.js
-var lib_prod_exports = /* @__PURE__ */ __exportAll({ default: () => lib_prod_default });
+var lib_prod_exports = /* @__PURE__ */ __exportAll({ default: () => lib_prod_default }, 1);
 var lib_prod_default;
 var init_lib_prod = __esmMin((() => {
 	lib_prod_default = "prod";

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/split_node_modules/artifacts.snap
@@ -18,12 +18,12 @@ export { lib_npm_a_exports as libA, lib_npm_b_exports as libB, lib_ui_exports as
 import { t as __exportAll } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-npm-a/index.js
-var lib_npm_a_exports = /* @__PURE__ */ __exportAll({ default: () => lib_npm_a_default });
+var lib_npm_a_exports = /* @__PURE__ */ __exportAll({ default: () => lib_npm_a_default }, 1);
 var lib_npm_a_default = "npm-a";
 
 //#endregion
 //#region node_modules/lib-npm-b/index.js
-var lib_npm_b_exports = /* @__PURE__ */ __exportAll({ default: () => lib_npm_b_default });
+var lib_npm_b_exports = /* @__PURE__ */ __exportAll({ default: () => lib_npm_b_default }, 1);
 var lib_npm_b_default = "npm-b";
 
 //#endregion
@@ -59,7 +59,7 @@ export { __exportAll as t };
 import { t as __exportAll } from "./rolldown-runtime.js";
 
 //#region node_modules/lib-ui/index.js
-var lib_ui_exports = /* @__PURE__ */ __exportAll({ default: () => lib_ui_default });
+var lib_ui_exports = /* @__PURE__ */ __exportAll({ default: () => lib_ui_default }, 1);
 var lib_ui_default = "ui";
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/es_module/always/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/always/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var module = (function(exports) {
 
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region main.js
 	const validator = "if_default_prop_false";

--- a/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_cjs_false/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_cjs_false/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 const validator = "if_default_prop_false";

--- a/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_cjs_true/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_cjs_true/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region main.js
 var main_default = "if_default_prop_true";

--- a/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_iife_false/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_iife_false/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var module = (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const validator = "if_default_prop_false";

--- a/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_iife_true/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/if_default_prop_iife_true/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var module = (function(exports) {
 
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region main.js
 	var main_default = "if_default_prop_true";

--- a/crates/rolldown/tests/rolldown/function/es_module/never/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/es_module/never/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var module = (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const validator = "if_default_prop_false";

--- a/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/eliminated_facade_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/attach_debug_info/eliminated_facade_chunk/artifacts.snap
@@ -11,12 +11,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 //! Eliminated Facade Chunk: [Chunk-Name: unnamed] [Entry-Module-Id: dynamic-a.js] [Reason: Dynamic entry chunk merged into user-defined entry chunk]
 // HIDDEN [rolldown:runtime]
 //#region dynamic-a.js
-var dynamic_a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+var dynamic_a_exports = /* @__PURE__ */ __exportAll({ a: () => a }, 1);
 const a = "dynamic-a";
 
 //#endregion
 //#region dynamic-b.js
-var dynamic_b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
+var dynamic_b_exports = /* @__PURE__ */ __exportAll({ b: () => b }, 1);
 const b = "dynamic-b";
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4636/artifacts.snap
@@ -19,7 +19,7 @@ var require_foo = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 var import_foo, main_hot;
 var init_main = __esmMin((() => {
 	init_rolldown_hmr();

--- a/crates/rolldown/tests/rolldown/function/export_mode/cjs/auto/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/cjs/auto/named/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 function a() {

--- a/crates/rolldown/tests/rolldown/function/export_mode/cjs/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/cjs/default/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region mod.js
-var default_exports = /* @__PURE__ */ __exportAll({ default: () => example });
+var default_exports = /* @__PURE__ */ __exportAll({ default: () => example }, 1);
 function example() {
 	return "default";
 }

--- a/crates/rolldown/tests/rolldown/function/export_mode/cjs/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/cjs/named/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region mod.js
 function example() {

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/default/artifacts.snap
@@ -14,7 +14,7 @@ var module = (function() {
 	var default_exports = /* @__PURE__ */ __exportAll({
 		add: () => add,
 		subtract: () => subtract
-	});
+	}, 1);
 	function add(a, b) {
 		return a + b;
 	}

--- a/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/iife/named/artifacts.snap
@@ -8,14 +8,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var module = (function(exports) {
 
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 // HIDDEN [rolldown:runtime]
 
 //#region mod.js
 	var named_exports = /* @__PURE__ */ __exportAll({
 		add: () => add,
 		subtract: () => subtract
-	});
+	}, 1);
 	function add(a, b) {
 		return a + b;
 	}

--- a/crates/rolldown/tests/rolldown/function/export_mode/umd/complex_name_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/umd/complex_name_named/artifacts.snap
@@ -11,6 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.test = global.test || {},global.test.module = {})));
 })(this, function(exports) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const a = 1;

--- a/crates/rolldown/tests/rolldown/function/export_mode/umd/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/umd/named/artifacts.snap
@@ -11,6 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.module = {})));
 })(this, function(exports) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const a = 1;

--- a/crates/rolldown/tests/rolldown/function/extend/iife/namespace_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/namespace_named/artifacts.snap
@@ -12,6 +12,7 @@ class A {
 this.test = this.test || {};
 (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const a = 1;

--- a/crates/rolldown/tests/rolldown/function/extend/iife/no_name_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/no_name_named/artifacts.snap
@@ -17,6 +17,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const a = 1;

--- a/crates/rolldown/tests/rolldown/function/extend/iife/non_namespace_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/iife/non_namespace_named/artifacts.snap
@@ -11,6 +11,7 @@ class A {
   constructor() {
 (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const a = 1;

--- a/crates/rolldown/tests/rolldown/function/extend/umd/complex_name_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/umd/complex_name_named/artifacts.snap
@@ -11,6 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.test = global.test || {},global.test.module = global.test.module || {})));
 })(this, function(exports) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const a = 1;

--- a/crates/rolldown/tests/rolldown/function/extend/umd/named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/extend/umd/named/artifacts.snap
@@ -11,6 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.module = global.module || {})));
 })(this, function(exports) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const a = 1;

--- a/crates/rolldown/tests/rolldown/function/external/commonjs_reexport_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/commonjs_reexport_external/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = {};
+var foo_exports = /* @__PURE__ */ __exportAll({}, 1);
 import * as import_external from "external";
 __reExport(foo_exports, import_external);
 var init_foo = __esmMin((() => {}));

--- a/crates/rolldown/tests/rolldown/function/external/double-namespace-reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/double-namespace-reexport/artifacts.snap
@@ -8,13 +8,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region second.js
-var second_exports = {};
+var second_exports = /* @__PURE__ */ __exportAll({}, 1);
 import * as import_external from "external";
 __reExport(second_exports, import_external);
 
 //#endregion
 //#region first.js
-var first_exports = {};
+var first_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(first_exports, second_exports);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external/splitting_indirect_external_symbol/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region indirect.js
-var indirect_exports = /* @__PURE__ */ __exportAll({ read: () => read });
+var indirect_exports = /* @__PURE__ */ __exportAll({ read: () => read }, 1);
 
 //#endregion
 //#region read.js

--- a/crates/rolldown/tests/rolldown/function/external_live_bindings/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/external_live_bindings/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 let node_fs = require("node:fs");
 
 //#region main.js

--- a/crates/rolldown/tests/rolldown/function/format/cjs/conflict_exports_key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/conflict_exports_key/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 const exports$1 = "exports";

--- a/crates/rolldown/tests/rolldown/function/format/cjs/import_export_unicode/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/import_export_unicode/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region foo.js
 const devil = "devil";

--- a/crates/rolldown/tests/rolldown/function/format/cjs/shared_entry_modules/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/cjs/shared_entry_modules/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry1.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 const value = "main";
@@ -17,6 +18,7 @@ exports.value = value;
 ## entry2.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_entry1 = require('./entry1.js');
 
 exports.value = require_entry1.value;

--- a/crates/rolldown/tests/rolldown/function/format/export_proto/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/export_proto/artifacts.snap
@@ -20,6 +20,7 @@ export { __proto__ };
 ### main.cjs
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 const __proto__ = 123;
@@ -40,6 +41,7 @@ Object.defineProperty(exports, '__proto__', {
 ```js
 var bundle = (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const __proto__ = 123;
@@ -66,6 +68,7 @@ globalThis.bundle = bundle;
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.bundle = {})));
 })(this, function(exports) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const __proto__ = 123;

--- a/crates/rolldown/tests/rolldown/function/format/export_proto_from/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/export_proto_from/artifacts.snap
@@ -18,6 +18,7 @@ export { __proto__ };
 ### main.cjs
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 let x = require("x");
 
 Object.defineProperty(exports, '__proto__', {
@@ -37,6 +38,7 @@ Object.defineProperty(exports, '__proto__', {
 ```js
 var bundle = (function(exports, x) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 Object.defineProperty(exports, '__proto__', {
   enumerable: true,
@@ -61,6 +63,7 @@ globalThis.bundle = bundle;
   typeof define === 'function' && define.amd ? define(['exports', 'x'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.bundle = {}), global.x));
 })(this, function(exports, x) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 Object.defineProperty(exports, '__proto__', {
   enumerable: true,

--- a/crates/rolldown/tests/rolldown/function/format/export_proto_namespace/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/export_proto_namespace/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ });
+var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ }, 1);
 const __proto__ = 123;
 
 //#endregion
@@ -22,10 +22,11 @@ export { lib_exports as lib };
 ### main.cjs
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ });
+var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ }, 1);
 const __proto__ = 123;
 
 //#endregion
@@ -46,10 +47,11 @@ Object.defineProperty(exports, 'lib', {
 ```js
 var bundle = (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js
-	var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ });
+	var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ }, 1);
 	const __proto__ = 123;
 
 //#endregion
@@ -76,10 +78,11 @@ globalThis.bundle = bundle;
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.bundle = {})));
 })(this, function(exports) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js
-	var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ });
+	var lib_exports = /* @__PURE__ */ __exportAll({ ["__proto__"]: () => __proto__ }, 1);
 	const __proto__ = 123;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/function/format/iife/conflict_exports_key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/conflict_exports_key/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var module = (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const exports$1 = "exports";

--- a/crates/rolldown/tests/rolldown/function/format/iife/conflict_exports_key_loop/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/conflict_exports_key_loop/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var module = (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const exports$1 = "exports";

--- a/crates/rolldown/tests/rolldown/function/format/iife/iife_with_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/iife_with_name/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var module = (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region foo.js
 	const value = 1;

--- a/crates/rolldown/tests/rolldown/function/format/iife/iife_with_name_with_minify/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/iife_with_name_with_minify/artifacts.snap
@@ -6,5 +6,5 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-var module=(function(e){return e.value=1,e})({});
+var module=(function(e){return Object.defineProperty(e,Symbol.toStringTag,{value:`Module`}),e.value=1,e})({});
 ```

--- a/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name/artifacts.snap
@@ -12,6 +12,7 @@ class A {
 this.namespace = this.namespace || {};
 this.namespace.module = (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region foo.js
 	const value = 1;

--- a/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name_reserved/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/iife/namespaced_name_reserved/artifacts.snap
@@ -12,6 +12,7 @@ class A {
 this["1"] = this["1"] || {};
 this["1"]["2"] = (function(exports) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region foo.js
 	const value = 1;

--- a/crates/rolldown/tests/rolldown/function/format/umd/conflict_exports_key/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/umd/conflict_exports_key/artifacts.snap
@@ -11,6 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.module = {})));
 })(this, function(exports) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const exports$1 = "exports";

--- a/crates/rolldown/tests/rolldown/function/format/umd/conflict_exports_key_loop/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/umd/conflict_exports_key_loop/artifacts.snap
@@ -11,6 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.module = {})));
 })(this, function(exports) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	const exports$1 = "exports";

--- a/crates/rolldown/tests/rolldown/function/format/umd/namespaced_name_reserved/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/format/umd/namespaced_name_reserved/artifacts.snap
@@ -11,6 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global["1"] = global["1"] || {},global["1"]["2"] = {})));
 })(this, function(exports) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region foo.js
 	const value = 1;

--- a/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/inline_dynamic_imports/basic/artifacts.snap
@@ -18,7 +18,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 var value;
 var init_esm = __esmMin((() => {
 	value = 1;
@@ -53,7 +53,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region esm.js
-var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 var value;
 var init_esm = __esmMin((() => {
 	value = 1;
@@ -90,7 +90,7 @@ Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }))
 
 //#endregion
 //#region esm.js
-	var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+	var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 	var value;
 	var init_esm = __esmMin((() => {
 		value = 1;

--- a/crates/rolldown/tests/rolldown/function/shim_missing_exports/basic_wrapped_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/shim_missing_exports/basic_wrapped_esm/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = {};
+var foo_exports = /* @__PURE__ */ __exportAll({}, 1);
 var missing;
 var init_foo = __esmMin((() => {
 	missing = void 0;

--- a/crates/rolldown/tests/rolldown/issues/2859/2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2859/2/artifacts.snap
@@ -39,7 +39,7 @@ export { bar, main_default as default, foo };
 ### main.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 // HIDDEN [rolldown:runtime]
 let assert = require("assert");
 assert = __toESM(assert);

--- a/crates/rolldown/tests/rolldown/issues/3456/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3456/artifacts.snap
@@ -18,6 +18,7 @@ export { test as "\n\"\\'" };
 ### main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 let external = require("external");
 
 exports["\n\"\\'"] = external["\n\"\\'"];

--- a/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/3650/artifacts.snap
@@ -25,7 +25,7 @@ import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
 import { r as value$1, t as init_second } from "./second.js";
 
 //#region first.js
-var first_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var first_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 var value;
 var init_first = __esmMin((() => {
 	init_second();
@@ -68,7 +68,7 @@ import { n as __exportAll, t as __esmMin } from "./rolldown-runtime.js";
 import { n as init_first, r as value$1 } from "./first.js";
 
 //#region second.js
-var second_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var second_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 var value;
 var init_second = __esmMin((() => {
 	init_first();

--- a/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4129/artifacts.snap
@@ -19,7 +19,7 @@ var require_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 var import_lib = require_lib();
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -92,6 +92,7 @@ Object.defineProperty(exports, 'default', {
 ### main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);

--- a/crates/rolldown/tests/rolldown/issues/4459/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4459/artifacts.snap
@@ -20,6 +20,7 @@ source: crates/rolldown_testing/src/integration_test.rs
   typeof define === 'function' && define.amd ? define(['exports', 'es-toolkit'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.Lib = {}), global.es_toolkit));
 })(this, function(exports, es_toolkit) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 	function test(str) {

--- a/crates/rolldown/tests/rolldown/issues/4585/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4585/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 let node_process = require("node:process");
 
 //#region lib.js

--- a/crates/rolldown/tests/rolldown/issues/5044/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5044/artifacts.snap
@@ -21,6 +21,7 @@ let preact = require("preact");
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 require('./lib.js');
 let preact = require("preact");
 

--- a/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/5870/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __exportAll({ constant: () => constant });
+var lib_exports = /* @__PURE__ */ __exportAll({ constant: () => constant }, 1);
 var constant;
 var init_lib = __esmMin((() => {
 	constant = 1;
@@ -48,7 +48,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __exportAll({ constant: () => constant });
+var lib_exports = /* @__PURE__ */ __exportAll({ constant: () => constant }, 1);
 var constant;
 var init_lib = __esmMin((() => {
 	constant = 1;

--- a/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
@@ -22,6 +22,7 @@ exports.ddd = ddd;
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);

--- a/crates/rolldown/tests/rolldown/issues/6651/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6651/artifacts.snap
@@ -15,7 +15,7 @@ var lib_exports = /* @__PURE__ */ __exportAll({
 	b: () => b,
 	c: () => c,
 	default: () => lib_default
-});
+}, 1);
 var a = 1;
 var b = 2;
 var c = "example";

--- a/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import { i as __toCommonJS, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./index.js";
 
 //#region d.js
-var d_exports = /* @__PURE__ */ __exportAll({ loadEventStreamCapability: () => loadEventStreamCapability });
+var d_exports = /* @__PURE__ */ __exportAll({ loadEventStreamCapability: () => loadEventStreamCapability }, 1);
 async function loadEventStreamCapability() {
 	const { EventStreamSerde } = await import("./e.js");
 	console.log(`EventStreamSerde: `, EventStreamSerde);

--- a/crates/rolldown/tests/rolldown/issues/6943/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6943/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __exportAll({ tryPatchHandler: () => tryPatchHandler });
+var lib_exports = /* @__PURE__ */ __exportAll({ tryPatchHandler: () => tryPatchHandler }, 1);
 function tryPatchHandler(taskRoot, handlerPath) {
 	__require(taskRoot);
 }

--- a/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6992/artifacts.snap
@@ -7,19 +7,19 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [rolldown:runtime]
-export { __reExport };
+export { __exportAll, __reExport };
 ```
 
 ## main.js
 
 ```js
-import { __reExport } from "./_virtual/rolldown_runtime.js";
+import { __exportAll, __reExport } from "./_virtual/rolldown_runtime.js";
 import "./server/index.js";
 
 export * from "@sentry/node"
 
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 
 //#endregion
 ```
@@ -27,7 +27,7 @@ var main_exports = {};
 ## server/index.js
 
 ```js
-import { __reExport } from "../_virtual/rolldown_runtime.js";
+import { __exportAll, __reExport } from "../_virtual/rolldown_runtime.js";
 
 export * from "@sentry/node"
 

--- a/crates/rolldown/tests/rolldown/issues/7115/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7115/artifacts.snap
@@ -8,6 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 
+exports.__exportAll = __exportAll;
 exports.__reExport = __reExport;
 ```
 
@@ -18,7 +19,7 @@ const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
 require('./server.js');
 
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({}, 1);
 
 //#endregion
 

--- a/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233/artifacts.snap
@@ -15,6 +15,7 @@ exports.__reExport = __reExport;
 ## index.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
 require('./server.js');
 let zod = require("zod");
@@ -23,7 +24,7 @@ let zod = require("zod");
 var _7233_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({
 	object: () => zod.object,
 	string: () => zod.string
-});
+}, 1);
 
 //#endregion
 Object.defineProperty(exports, 'object', {

--- a/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7233_chain/artifacts.snap
@@ -15,6 +15,7 @@ exports.__reExport = __reExport;
 ## index.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_rolldown_runtime = require('./_virtual/rolldown_runtime.js');
 require('./middle.js');
 let zod = require("zod");
@@ -23,7 +24,7 @@ let zod = require("zod");
 var _7233_chain_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({
 	object: () => zod.object,
 	string: () => zod.string
-});
+}, 1);
 
 //#endregion
 Object.defineProperty(exports, 'object', {

--- a/crates/rolldown/tests/rolldown/issues/7384/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7384/artifacts.snap
@@ -13,7 +13,7 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region mod.js
-var _7384_exports = /* @__PURE__ */ __exportAll({ t: () => _babel_types });
+var _7384_exports = /* @__PURE__ */ __exportAll({ t: () => _babel_types }, 1);
 
 //#endregion
 //#region a.js
@@ -39,7 +39,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region mod.js
-var _7384_exports = /* @__PURE__ */ __exportAll({ t: () => t$1 });
+var _7384_exports = /* @__PURE__ */ __exportAll({ t: () => t$1 }, 1);
 
 //#endregion
 //#region a.js

--- a/crates/rolldown/tests/rolldown/issues/7773/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7773/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js
@@ -39,6 +40,7 @@ Object.defineProperty(exports, 'dayjs2', {
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.test = {})));
 })(this, function(exports) {
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js

--- a/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/rolldown_vite_289/artifacts.snap
@@ -10,7 +10,7 @@ import nodeAssert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib-impl.js
-var lib_impl_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var lib_impl_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 function foo() {
 	return fn();
 }

--- a/crates/rolldown/tests/rolldown/misc/invalid_ident_repr/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/invalid_ident_repr/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region 1aaa.js
-var _1aaa_exports = /* @__PURE__ */ __exportAll({ default: () => _1aaa_default });
+var _1aaa_exports = /* @__PURE__ */ __exportAll({ default: () => _1aaa_default }, 1);
 const a = "shared.js";
 var _1aaa_default = a;
 

--- a/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/reexport_star/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region a.js
-var a_exports = /* @__PURE__ */ __exportAll({ abc: () => abc });
+var a_exports = /* @__PURE__ */ __exportAll({ abc: () => abc }, 1);
 const abc = void 0;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/misc/wrapped_esm/artifacts.snap
@@ -29,7 +29,7 @@ var foo_exports = /* @__PURE__ */ __exportAll({
 	x: () => x,
 	y: () => y,
 	z: () => z
-});
+}, 1);
 function foo$1() {}
 var a, b, c, d, e, g, x, y, z, k, bar, baz, a1, a2, index, a3, destructuring;
 var init_foo = __esmMin((() => {

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/allow_extension_exports/artifacts.snap
@@ -46,7 +46,7 @@ const value1 = "conflict-value";
 var lib3_exports = /* @__PURE__ */ __exportAll({
 	value3: () => value3,
 	value4: () => value4
-});
+}, 1);
 const value3 = "lib3-value";
 const value4 = "lib3-value4";
 

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/cjs_format/_test.cjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/cjs_format/_test.cjs
@@ -3,9 +3,9 @@ const dep = require("./dist/dep.js");
 const main = require("./dist/main.js");
 
 if (globalThis.__configName == "named") {
-  assert.deepEqual(main, { value: 42 });
-  assert.deepEqual(dep, { default: 42 });
+  assert.deepEqual(main, { [Symbol.toStringTag]: 'Module', value: 42 });
+  assert.deepEqual(dep, { [Symbol.toStringTag]: 'Module', default: 42 });
 } else {
-  assert.deepEqual(main, { value: 42 });
+  assert.deepEqual(main, { [Symbol.toStringTag]: 'Module', value: 42 });
   assert.deepEqual(dep, 42);
 }

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/cjs_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/cjs_format/artifacts.snap
@@ -17,6 +17,7 @@ module.exports = dep_default;
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_dep = require('./dep.js');
 
 exports.value = require_dep;
@@ -29,7 +30,7 @@ exports.value = require_dep;
 ### dep.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region dep.js
 var dep_default = 42;
@@ -41,6 +42,7 @@ exports.default = dep_default;
 ### main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_dep = require('./dep.js');
 
 exports.value = require_dep.default;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 import { n as __esmMin, r as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
 
 //#region imp2.js
-var imp2_exports = /* @__PURE__ */ __exportAll({ imp2: () => imp2 });
+var imp2_exports = /* @__PURE__ */ __exportAll({ imp2: () => imp2 }, 1);
 var imp2;
 var init_imp2 = __esmMin((() => {
 	imp2 = 2;
@@ -62,7 +62,7 @@ export { __toESM as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
 const require_rolldown_runtime = require('./rolldown-runtime.js');
 
 //#region imp2.js
-var imp2_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ imp2: () => imp2 });
+var imp2_exports = /* @__PURE__ */ require_rolldown_runtime.__exportAll({ imp2: () => imp2 }, 1);
 var imp2;
 var init_imp2 = require_rolldown_runtime.__esmMin((() => {
 	imp2 = 2;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+var lib_exports = /* @__PURE__ */ __exportAll({ a: () => a }, 1);
 var a;
 var init_lib = __esmMin((() => {
 	a = 123;
@@ -42,7 +42,7 @@ let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 
 //#region lib.js
-var lib_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+var lib_exports = /* @__PURE__ */ __exportAll({ a: () => a }, 1);
 var a;
 var init_lib = __esmMin((() => {
 	a = 123;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/issue_4905/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/issue_4905/artifacts.snap
@@ -10,7 +10,7 @@ import { strictEqual } from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const foo = "foo";
 
 //#endregion
@@ -34,7 +34,7 @@ Promise.resolve().then(() => foo_exports).then((mod) => {
 let node_assert = require("node:assert");
 
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const foo = "foo";
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry/artifacts.snap
@@ -10,7 +10,7 @@ export * from "node:fs"
 
 // HIDDEN [rolldown:runtime]
 //#region main.js
-var main_exports = /* @__PURE__ */ __exportAll({ main: () => main });
+var main_exports = /* @__PURE__ */ __exportAll({ main: () => main }, 1);
 import * as import_node_fs from "node:fs";
 __reExport(main_exports, import_node_fs);
 var main;

--- a/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs/artifacts.snap
@@ -6,10 +6,11 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 
 //#region main.js
-var main_exports = /* @__PURE__ */ __exportAll({ main: () => main });
+var main_exports = /* @__PURE__ */ __exportAll({ main: () => main }, 1);
 __reExport(main_exports, require("node:fs"));
 var main;
 var init_main = __esmMin((() => {

--- a/crates/rolldown/tests/rolldown/sourcemap/live_binding/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/sourcemap/live_binding/artifacts.snap
@@ -21,6 +21,7 @@ main();
 ## main2.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_shared = require('./shared.js');
 
 exports.shared = require_shared.shared;

--- a/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/exports/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/exports/_test.mjs
@@ -7,6 +7,6 @@ const { parse } = require('cjs-module-lexer');
 const parsed = parse(fs.readFileSync(path.resolve(import.meta.dirname, 'dist/main.js'), 'utf8'));
 parsed.exports.sort();
 assert.deepStrictEqual(parsed, {
-  exports: [ '__esModule', 'a', 'b', '😈', 'default'].sort(),
+  exports: ['a', 'b', '😈', 'default'].sort(),
   reexports: [],
 })

--- a/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/exports/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region main.js
 const a = "a";

--- a/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 let external = require("external");
 
 exports.readFileSync = external.readFileSync;

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_default_function/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "node:assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ default: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ default: () => foo$1 }, 1);
 function foo$1(a$1) {
 	assert.equal(a$1, a$1);
 	assert.equal(a$2, 1);

--- a/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/deconflict/wrapped_esm_export_named_function/artifacts.snap
@@ -10,7 +10,7 @@ import assert from "assert";
 
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 }, 1);
 function foo$1(a$1) {
 	console.log(a$1, a$2);
 }

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_cjs_named_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_cjs_named_default/artifacts.snap
@@ -27,6 +27,7 @@ exports.__toESM = __toESM;
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_lib$1 = require('./lib.js');
 let node_assert = require("node:assert");
 node_assert = require_lib$1.__toESM(node_assert);

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_cjs_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_cjs_named_named/artifacts.snap
@@ -45,6 +45,7 @@ Object.defineProperty(exports, 'require_lib', {
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_lib$1 = require('./lib2.js');
 let node_assert = require("node:assert");
 node_assert = require_lib$1.__toESM(node_assert);

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_default/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lib.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 const require_lib = require('./lib2.js');
 
 require_lib.init_lib();
@@ -62,6 +62,7 @@ Object.defineProperty(exports, 'named', {
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_lib = require('./lib2.js');
 let node_assert = require("node:assert");
 node_assert = require_lib.__toESM(node_assert);

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_esm_named_named/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lib.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_lib = require('./lib2.js');
 
 require_lib.init_lib();
@@ -61,6 +62,7 @@ Object.defineProperty(exports, 'init_lib', {
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_lib = require('./lib2.js');
 let node_assert = require("node:assert");
 node_assert = require_lib.__toESM(node_assert);

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_none_named_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_none_named_default/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lib.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region lib.js
 var lib_default = { value: 42 };
@@ -20,6 +20,7 @@ exports.named = named;
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 const require_lib = require('./lib.js');
 let node_assert = require("node:assert");

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_none_named_named/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_none_named_named/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lib.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region lib.js
 const foo = "foo_value";
@@ -19,6 +20,7 @@ exports.foo = foo;
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 // HIDDEN [rolldown:runtime]
 const require_lib = require('./lib.js');
 let node_assert = require("node:assert");

--- a/crates/rolldown/tests/rolldown/topics/hmr/accept-outside-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/accept-outside-circular/artifacts.snap
@@ -11,28 +11,28 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
+var c_exports = /* @__PURE__ */ __exportAll({ c: () => c }, 1);
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b }, 1);
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a }, 1);
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 assert.strictEqual(a.b.c, "c");
@@ -62,28 +62,28 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
+var c_exports = /* @__PURE__ */ __exportAll({ c: () => c }, 1);
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "cc";
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b }, 1);
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a }, 1);
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 assert.strictEqual(a.b.c, "c");

--- a/crates/rolldown/tests/rolldown/topics/hmr/add_watch_file/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/add_watch_file/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region entry.js
-var entry_exports = {};
+var entry_exports = /* @__PURE__ */ __exportAll({}, 1);
 const entry_hot = __rolldown_runtime__.createModuleHotContext("entry.js");
 __rolldown_runtime__.registerModule("entry.js", { exports: entry_exports });
 const content = "input\n";
@@ -35,7 +35,7 @@ console.log(content);
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region entry.js
-var entry_exports = {};
+var entry_exports = /* @__PURE__ */ __exportAll({}, 1);
 const entry_hot = __rolldown_runtime__.createModuleHotContext("entry.js");
 __rolldown_runtime__.registerModule("entry.js", { exports: entry_exports });
 const content = "input2\n";

--- a/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/change_accept/artifacts.snap
@@ -11,14 +11,14 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region child.js
-var child_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var child_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
 __rolldown_runtime__.registerModule("child.js", { exports: child_exports });
 const foo = 0;
 
 //#endregion
 //#region parent.js
-var parent_exports = {};
+var parent_exports = /* @__PURE__ */ __exportAll({}, 1);
 const parent_hot = __rolldown_runtime__.createModuleHotContext("parent.js");
 __rolldown_runtime__.registerModule("parent.js", { exports: parent_exports });
 parent_hot.accept("child.js", () => {
@@ -31,7 +31,7 @@ process.on("beforeExit", (code) => {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 main_hot.accept("parent.js", () => {});

--- a/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/cjs_no_export/artifacts.snap
@@ -25,7 +25,7 @@ var require_b = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 require_a();

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_not_used_anymore/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region child.js
-var child_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var child_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
 __rolldown_runtime__.registerModule("child.js", { exports: child_exports });
 const value = "child";
@@ -19,7 +19,7 @@ const value = "child";
 var parent_exports = /* @__PURE__ */ __exportAll({
 	childValue: () => value,
 	parentValue: () => parentValue
-});
+}, 1);
 const parent_hot = __rolldown_runtime__.createModuleHotContext("parent.js");
 __rolldown_runtime__.registerModule("parent.js", { exports: parent_exports });
 const parentValue = "parent";
@@ -33,7 +33,7 @@ parent_hot.accept((newMod) => {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/delete_file_used/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/delete_file_used/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region child.js
-var child_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var child_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 const child_hot = __rolldown_runtime__.createModuleHotContext("child.js");
 __rolldown_runtime__.registerModule("child.js", { exports: child_exports });
 const value = "child";
@@ -19,7 +19,7 @@ const value = "child";
 var parent_exports = /* @__PURE__ */ __exportAll({
 	childValue: () => value,
 	parentValue: () => parentValue
-});
+}, 1);
 const parent_hot = __rolldown_runtime__.createModuleHotContext("parent.js");
 __rolldown_runtime__.registerModule("parent.js", { exports: parent_exports });
 const parentValue = "parent";
@@ -31,7 +31,7 @@ parent_hot.accept((newMod) => {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -26,7 +26,7 @@ export default require_exist_dep_cjs();
 import { n as __exportAll } from "./main.js";
 
 //#region exist-dep-esm.js
-var exist_dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var exist_dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 const exist_dep_esm_hot = __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
 __rolldown_runtime__.registerModule("exist-dep-esm.js", { exports: exist_dep_esm_exports });
 const value = "exist-esm";
@@ -41,7 +41,7 @@ export { value };
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 async function foo() {
@@ -56,7 +56,7 @@ hmr_hot.accept((mod) => {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_initial_build_syntax_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_initial_build_syntax_error/artifacts.snap
@@ -30,7 +30,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 console.log("main.js");

--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region dep.js
-var dep_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var dep_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 const dep_hot = __rolldown_runtime__.createModuleHotContext("dep.js");
 __rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
 const value = "dep";
@@ -19,7 +19,7 @@ if (dep_hot) {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 console.log(value);
@@ -77,7 +77,7 @@ console.log(value);
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region dep.js
-var dep_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var dep_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 const dep_hot = __rolldown_runtime__.createModuleHotContext("dep.js");
 __rolldown_runtime__.registerModule("dep.js", { exports: dep_exports });
 const value = "dep";
@@ -87,7 +87,7 @@ if (dep_hot) {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 console.log(value);

--- a/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/esm_no_export/artifacts.snap
@@ -9,21 +9,21 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region a.js
-var a_exports = {};
+var a_exports = /* @__PURE__ */ __exportAll({}, 1);
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 console.log("a");
 
 //#endregion
 //#region b.js
-var b_exports = {};
+var b_exports = /* @__PURE__ */ __exportAll({}, 1);
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 console.log("b");
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/export_star/artifacts.snap
@@ -12,7 +12,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 var foo_exports = /* @__PURE__ */ __exportAll({
 	foo: () => foo,
 	named: () => named$2
-});
+}, 1);
 const foo_hot = __rolldown_runtime__.createModuleHotContext("sub/foo.js");
 __rolldown_runtime__.registerModule("sub/foo.js", { exports: foo_exports });
 const foo = "foo";
@@ -23,7 +23,7 @@ const named$2 = "foo";
 var bar_exports = /* @__PURE__ */ __exportAll({
 	bar: () => bar,
 	named: () => named$1
-});
+}, 1);
 const bar_hot = __rolldown_runtime__.createModuleHotContext("sub/bar.js");
 __rolldown_runtime__.registerModule("sub/bar.js", { exports: bar_exports });
 const bar = "bar";
@@ -31,7 +31,7 @@ const named$1 = "bar";
 
 //#endregion
 //#region sub/named.js
-var named_exports = /* @__PURE__ */ __exportAll({ named: () => named });
+var named_exports = /* @__PURE__ */ __exportAll({ named: () => named }, 1);
 const named_hot = __rolldown_runtime__.createModuleHotContext("sub/named.js");
 __rolldown_runtime__.registerModule("sub/named.js", { exports: named_exports });
 const named = "named";
@@ -42,13 +42,13 @@ var sub_exports = /* @__PURE__ */ __exportAll({
 	bar: () => bar,
 	foo: () => foo,
 	named: () => named
-});
+}, 1);
 const sub_hot = __rolldown_runtime__.createModuleHotContext("sub/index.js");
 __rolldown_runtime__.registerModule("sub/index.js", { exports: sub_exports });
 
 //#endregion
 //#region hmr.js
-var hmr_exports = {};
+var hmr_exports = /* @__PURE__ */ __exportAll({}, 1);
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 console.log(foo, bar);
@@ -56,7 +56,7 @@ hmr_hot.accept();
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 text(".app", "hello");

--- a/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/generate_patch_error/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";
@@ -25,7 +25,7 @@ hmr_hot.accept((mod) => {
 
 //#endregion
 //#region sub.js
-var sub_exports = {};
+var sub_exports = /* @__PURE__ */ __exportAll({}, 1);
 const sub_hot = __rolldown_runtime__.createModuleHotContext("sub.js");
 __rolldown_runtime__.registerModule("sub.js", { exports: sub_exports });
 text(".app", "hello");
@@ -35,7 +35,7 @@ function text(el, text) {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/import_meta_hot_accept/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region self_accept.js
-var self_accept_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
+var self_accept_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 }, 1);
 const self_accept_hot = __rolldown_runtime__.createModuleHotContext("self_accept.js");
 __rolldown_runtime__.registerModule("self_accept.js", { exports: self_accept_exports });
 const foo$1 = "foo";
@@ -21,14 +21,14 @@ self_accept_hot.accept((mod) => {
 
 //#endregion
 //#region single_accept/child.js
-var child_exports$1 = /* @__PURE__ */ __exportAll({ count: () => count$3 });
+var child_exports$1 = /* @__PURE__ */ __exportAll({ count: () => count$3 }, 1);
 const child_hot$1 = __rolldown_runtime__.createModuleHotContext("single_accept/child.js");
 __rolldown_runtime__.registerModule("single_accept/child.js", { exports: child_exports$1 });
 const count$3 = 0;
 
 //#endregion
 //#region single_accept/parent.js
-var parent_exports$1 = {};
+var parent_exports$1 = /* @__PURE__ */ __exportAll({}, 1);
 const parent_hot$1 = __rolldown_runtime__.createModuleHotContext("single_accept/parent.js");
 __rolldown_runtime__.registerModule("single_accept/parent.js", { exports: parent_exports$1 });
 globalThis.singleAcceptAcceptCount ??= 0;
@@ -48,14 +48,14 @@ process.on("beforeExit", (code) => {
 
 //#endregion
 //#region array_accept/child.js
-var child_exports = /* @__PURE__ */ __exportAll({ count: () => count$1 });
+var child_exports = /* @__PURE__ */ __exportAll({ count: () => count$1 }, 1);
 const child_hot = __rolldown_runtime__.createModuleHotContext("array_accept/child.js");
 __rolldown_runtime__.registerModule("array_accept/child.js", { exports: child_exports });
 const count$1 = 0;
 
 //#endregion
 //#region array_accept/parent.js
-var parent_exports = {};
+var parent_exports = /* @__PURE__ */ __exportAll({}, 1);
 const parent_hot = __rolldown_runtime__.createModuleHotContext("array_accept/parent.js");
 __rolldown_runtime__.registerModule("array_accept/parent.js", { exports: parent_exports });
 globalThis.arrayAcceptAcceptCount ??= 0;
@@ -75,7 +75,7 @@ process.on("beforeExit", (code) => {
 
 //#endregion
 //#region optional_chaining.js
-var optional_chaining_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var optional_chaining_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const optional_chaining_hot = __rolldown_runtime__.createModuleHotContext("optional_chaining.js");
 __rolldown_runtime__.registerModule("optional_chaining.js", { exports: optional_chaining_exports });
 const foo = "foo";
@@ -85,7 +85,7 @@ optional_chaining_hot?.accept((mod) => {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_4818/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_4818/artifacts.snap
@@ -12,7 +12,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 var foo_exports = /* @__PURE__ */ __exportAll({
 	default: () => foo_default,
 	foo: () => foo
-});
+}, 1);
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.json");
 __rolldown_runtime__.registerModule("foo.json", { exports: foo_exports });
 var foo = "__EXP__";
@@ -20,7 +20,7 @@ var foo_default = { foo };
 
 //#endregion
 //#region main.js
-var main_exports = /* @__PURE__ */ __exportAll({ default: () => main_default });
+var main_exports = /* @__PURE__ */ __exportAll({ default: () => main_default }, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 var main_default = foo_default;

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5149/artifacts.snap
@@ -9,21 +9,21 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region common.js
-var common_exports = /* @__PURE__ */ __exportAll({ prefix: () => prefix });
+var common_exports = /* @__PURE__ */ __exportAll({ prefix: () => prefix }, 1);
 const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
 __rolldown_runtime__.registerModule("common.js", { exports: common_exports });
 const prefix = "prefix:";
 
 //#endregion
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
 
 //#endregion
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
+var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar }, 1);
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
@@ -33,7 +33,7 @@ const bar = prefix + "bar";
 var messenger_exports = /* @__PURE__ */ __exportAll({
 	msg: () => msg,
 	sayMessage: () => sayMessage
-});
+}, 1);
 const messenger_hot = __rolldown_runtime__.createModuleHotContext("messenger.js");
 __rolldown_runtime__.registerModule("messenger.js", { exports: messenger_exports });
 let msg = [
@@ -55,7 +55,7 @@ if (messenger_hot) {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 sayMessage();

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5150/artifacts.snap
@@ -9,21 +9,21 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region common.js
-var common_exports = /* @__PURE__ */ __exportAll({ prefix: () => prefix });
+var common_exports = /* @__PURE__ */ __exportAll({ prefix: () => prefix }, 1);
 const common_hot = __rolldown_runtime__.createModuleHotContext("common.js");
 __rolldown_runtime__.registerModule("common.js", { exports: common_exports });
 const prefix = "prefix:";
 
 //#endregion
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 const foo = prefix + "foo";
 
 //#endregion
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar });
+var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => bar }, 1);
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 const bar = prefix + "bar";
@@ -33,7 +33,7 @@ const bar = prefix + "bar";
 var messenger_exports = /* @__PURE__ */ __exportAll({
 	msg: () => msg,
 	sayMessage: () => sayMessage
-});
+}, 1);
 const messenger_hot = __rolldown_runtime__.createModuleHotContext("messenger.js");
 __rolldown_runtime__.registerModule("messenger.js", { exports: messenger_exports });
 let msg = [
@@ -55,7 +55,7 @@ if (messenger_hot) {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 setInterval(sayMessage, 1e3);

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -10,7 +10,7 @@ import { t as __exportAll } from "./main.js";
 import { t as trim } from "./string.js";
 
 //#region bar.js
-var bar_exports = /* @__PURE__ */ __exportAll({ default: () => bar_default });
+var bar_exports = /* @__PURE__ */ __exportAll({ default: () => bar_default }, 1);
 const bar_hot = __rolldown_runtime__.createModuleHotContext("bar.js");
 __rolldown_runtime__.registerModule("bar.js", { exports: bar_exports });
 function bar_default() {
@@ -31,13 +31,13 @@ import { n as unused, t as trim } from "./string.js";
 var utils_exports = /* @__PURE__ */ __exportAll({
 	trim: () => trim,
 	unused: () => unused
-});
+}, 1);
 const utils_hot = __rolldown_runtime__.createModuleHotContext("utils/index.js");
 __rolldown_runtime__.registerModule("utils/index.js", { exports: utils_exports });
 
 //#endregion
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ default: () => foo_default });
+var foo_exports = /* @__PURE__ */ __exportAll({ default: () => foo_default }, 1);
 const foo_hot = __rolldown_runtime__.createModuleHotContext("foo.js");
 __rolldown_runtime__.registerModule("foo.js", { exports: foo_exports });
 function foo_default() {
@@ -54,7 +54,7 @@ export { foo_default as default };
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 const routes = {
@@ -75,7 +75,7 @@ import { t as __exportAll } from "./main.js";
 var string_exports = /* @__PURE__ */ __exportAll({
 	trim: () => trim,
 	unused: () => unused
-});
+}, 1);
 const string_hot = __rolldown_runtime__.createModuleHotContext("utils/string.js");
 __rolldown_runtime__.registerModule("utils/string.js", { exports: string_exports });
 function trim(s) {

--- a/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/mutiply_entires/artifacts.snap
@@ -6,10 +6,10 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-import "./rolldown_hmr.js";
+import { t as __exportAll } from "./rolldown_hmr.js";
 
 //#region entry.js
-var entry_exports = {};
+var entry_exports = /* @__PURE__ */ __exportAll({}, 1);
 const entry_hot = __rolldown_runtime__.createModuleHotContext("entry.js");
 __rolldown_runtime__.registerModule("entry.js", { exports: entry_exports });
 console.log("entry");
@@ -20,10 +20,10 @@ console.log("entry");
 ## index.js
 
 ```js
-import "./rolldown_hmr.js";
+import { t as __exportAll } from "./rolldown_hmr.js";
 
 //#region index.js
-var mutiply_entires_exports = {};
+var mutiply_entires_exports = /* @__PURE__ */ __exportAll({}, 1);
 const mutiply_entires_hot = __rolldown_runtime__.createModuleHotContext("index.js");
 __rolldown_runtime__.registerModule("index.js", { exports: mutiply_entires_exports });
 console.log("index");
@@ -36,4 +36,5 @@ console.log("index");
 ```js
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
+export { __exportAll as t };
 ```

--- a/crates/rolldown/tests/rolldown/topics/hmr/no-accept-outside-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/no-accept-outside-circular/artifacts.snap
@@ -11,28 +11,28 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
+var c_exports = /* @__PURE__ */ __exportAll({ c: () => c }, 1);
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b }, 1);
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a }, 1);
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 assert.strictEqual(a.b.c, "c");
@@ -59,28 +59,28 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
+var c_exports = /* @__PURE__ */ __exportAll({ c: () => c }, 1);
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "cc";
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b }, 1);
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a }, 1);
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 assert.strictEqual(a.b.c, "c");

--- a/crates/rolldown/tests/rolldown/topics/hmr/no_boundary_reload/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/no_boundary_reload/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 console.log(1);
@@ -34,7 +34,7 @@ console.log(1);
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 console.log(2);

--- a/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/non_used_export/artifacts.snap
@@ -9,7 +9,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region hmr.js
-var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 const foo = "hello";
@@ -17,7 +17,7 @@ hmr_hot.accept(() => {});
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/register_exports/artifacts.snap
@@ -18,14 +18,14 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#endregion
 //#region esm.js
 var import_cjs = /* @__PURE__ */ __toESM(require_cjs());
-var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var esm_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 const esm_hot = __rolldown_runtime__.createModuleHotContext("esm.js");
 __rolldown_runtime__.registerModule("esm.js", { exports: esm_exports });
 const value = "main";
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 console.log(import_cjs, esm_exports);

--- a/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/runtime_correctness/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region trigger-dep.js
-var trigger_dep_exports = {};
+var trigger_dep_exports = /* @__PURE__ */ __exportAll({}, 1);
 var trigger_dep_hot;
 var init_trigger_dep = __esmMin((() => {
 	trigger_dep_hot = __rolldown_runtime__.createModuleHotContext("trigger-dep.js");
@@ -78,7 +78,7 @@ var require_umd_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 
 //#endregion
 //#region cases/require/index.js
-var require_exports = {};
+var require_exports = /* @__PURE__ */ __exportAll({}, 1);
 init_trigger_dep();
 const require_hot = __rolldown_runtime__.createModuleHotContext("cases/require/index.js");
 __rolldown_runtime__.registerModule("cases/require/index.js", { exports: require_exports });
@@ -103,7 +103,7 @@ assert.strictEqual(requiredUmdLib.foo, "foo");
 var lib_exports = /* @__PURE__ */ __exportAll({
 	Globals: () => Globals,
 	value: () => value
-});
+}, 1);
 init_trigger_dep();
 const lib_hot = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/lib.js");
 __rolldown_runtime__.registerModule("cases/manual_reexport/lib.js", { exports: lib_exports });
@@ -115,14 +115,14 @@ const value = "lib";
 var barrel_exports = /* @__PURE__ */ __exportAll({
 	Globals: () => Globals,
 	value: () => value
-});
+}, 1);
 init_trigger_dep();
 const barrel_hot = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/barrel.js");
 __rolldown_runtime__.registerModule("cases/manual_reexport/barrel.js", { exports: barrel_exports });
 
 //#endregion
 //#region cases/manual_reexport/index.js
-var manual_reexport_exports = {};
+var manual_reexport_exports = /* @__PURE__ */ __exportAll({}, 1);
 init_trigger_dep();
 const manual_reexport_hot = __rolldown_runtime__.createModuleHotContext("cases/manual_reexport/index.js");
 __rolldown_runtime__.registerModule("cases/manual_reexport/index.js", { exports: manual_reexport_exports });
@@ -131,7 +131,7 @@ assert.strictEqual(Globals, Object);
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo.mjs
-var foo_exports$1 = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
+var foo_exports$1 = /* @__PURE__ */ __exportAll({ foo: () => foo$1 }, 1);
 init_trigger_dep();
 const foo_hot$1 = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo.mjs");
 __rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo.mjs", { exports: foo_exports$1 });
@@ -139,7 +139,7 @@ const foo$1 = "foo";
 
 //#endregion
 //#region cases/deconflict_import_bindings/foo/index.mjs
-var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var foo_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 init_trigger_dep();
 const foo_hot = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/foo/index.mjs");
 __rolldown_runtime__.registerModule("cases/deconflict_import_bindings/foo/index.mjs", { exports: foo_exports });
@@ -147,7 +147,7 @@ const foo = "foo-index";
 
 //#endregion
 //#region cases/deconflict_import_bindings/index.js
-var deconflict_import_bindings_exports = {};
+var deconflict_import_bindings_exports = /* @__PURE__ */ __exportAll({}, 1);
 init_trigger_dep();
 const deconflict_import_bindings_hot = __rolldown_runtime__.createModuleHotContext("cases/deconflict_import_bindings/index.js");
 __rolldown_runtime__.registerModule("cases/deconflict_import_bindings/index.js", { exports: deconflict_import_bindings_exports });
@@ -156,7 +156,7 @@ assert.strictEqual(foo, "foo-index");
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 if (main_hot) {

--- a/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/self-accept-within-circular/artifacts.snap
@@ -11,7 +11,7 @@ import assert from "node:assert";
 // HIDDEN [rolldown:runtime]
 // HIDDEN [rolldown:hmr]
 //#region c.js
-var c_exports = /* @__PURE__ */ __exportAll({ c: () => c });
+var c_exports = /* @__PURE__ */ __exportAll({ c: () => c }, 1);
 const c_hot = __rolldown_runtime__.createModuleHotContext("c.js");
 __rolldown_runtime__.registerModule("c.js", { exports: c_exports });
 const c = "c";
@@ -22,21 +22,21 @@ c_hot.accept((nextExports) => {
 
 //#endregion
 //#region b.js
-var b_exports = /* @__PURE__ */ __exportAll({ b: () => b });
+var b_exports = /* @__PURE__ */ __exportAll({ b: () => b }, 1);
 const b_hot = __rolldown_runtime__.createModuleHotContext("b.js");
 __rolldown_runtime__.registerModule("b.js", { exports: b_exports });
 const b = { c };
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __exportAll({ a: () => a });
+var a_exports = /* @__PURE__ */ __exportAll({ a: () => a }, 1);
 const a_hot = __rolldown_runtime__.createModuleHotContext("a.js");
 __rolldown_runtime__.registerModule("a.js", { exports: a_exports });
 const a = { b };
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 assert.strictEqual(a.b.c, "c");

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/artifacts.snap
@@ -20,7 +20,7 @@ var require_dep_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 //#endregion
 //#region modules/dep-esm.js
 var import_dep_cjs = require_dep_cjs();
-var dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => value$1 });
+var dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => value$1 }, 1);
 const dep_esm_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm.js");
 __rolldown_runtime__.registerModule("modules/dep-esm.js", { exports: dep_esm_exports });
 const value$1 = "esm";
@@ -36,7 +36,7 @@ var require_dep_cjs_default = /* @__PURE__ */ __commonJSMin(((exports, module) =
 //#endregion
 //#region modules/dep-esm-default.js
 var import_dep_cjs_default = /* @__PURE__ */ __toESM(require_dep_cjs_default());
-var dep_esm_default_exports = /* @__PURE__ */ __exportAll({ default: () => dep_esm_default_default });
+var dep_esm_default_exports = /* @__PURE__ */ __exportAll({ default: () => dep_esm_default_default }, 1);
 const dep_esm_default_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-default.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-default.js", { exports: dep_esm_default_exports });
 var dep_esm_default_default = "esm-default";
@@ -52,7 +52,7 @@ var require_dep_cjs_named = /* @__PURE__ */ __commonJSMin(((exports, module) => 
 //#endregion
 //#region modules/dep-esm-named.js
 var import_dep_cjs_named = require_dep_cjs_named();
-var dep_esm_named_exports = /* @__PURE__ */ __exportAll({ named: () => named });
+var dep_esm_named_exports = /* @__PURE__ */ __exportAll({ named: () => named }, 1);
 const dep_esm_named_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-named.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-named.js", { exports: dep_esm_named_exports });
 const named = "esm-named";
@@ -68,14 +68,14 @@ var require_dep_cjs_namespace = /* @__PURE__ */ __commonJSMin(((exports, module)
 //#endregion
 //#region modules/dep-esm-namespace.js
 var import_dep_cjs_namespace = /* @__PURE__ */ __toESM(require_dep_cjs_namespace());
-var dep_esm_namespace_exports = /* @__PURE__ */ __exportAll({ value: () => value });
+var dep_esm_namespace_exports = /* @__PURE__ */ __exportAll({ value: () => value }, 1);
 const dep_esm_namespace_hot = __rolldown_runtime__.createModuleHotContext("modules/dep-esm-namespace.js");
 __rolldown_runtime__.registerModule("modules/dep-esm-namespace.js", { exports: dep_esm_namespace_exports });
 const value = "esm-namespace";
 
 //#endregion
 //#region hmr.js
-var hmr_exports = {};
+var hmr_exports = /* @__PURE__ */ __exportAll({}, 1);
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
 __rolldown_runtime__.registerModule("hmr.js", { exports: hmr_exports });
 assert.strictEqual(import_dep_cjs_default.default, "cjs-default");
@@ -86,7 +86,10 @@ assert.deepStrictEqual(import_dep_cjs_namespace, {
 	value: "cjs-namespace",
 	default: { value: "cjs-namespace" }
 });
-assert.deepStrictEqual(dep_esm_namespace_exports, { value: "esm-namespace" });
+assert.deepEqual(dep_esm_namespace_exports, {
+	[Symbol.toStringTag]: "Module",
+	value: "esm-namespace"
+});
 hmr_hot.accept((mod) => {
 	if (mod) {
 		console.log(".hmr", mod.foo);
@@ -95,7 +98,7 @@ hmr_hot.accept((mod) => {
 
 //#endregion
 //#region main.js
-var main_exports = {};
+var main_exports = /* @__PURE__ */ __exportAll({}, 1);
 const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 
@@ -134,7 +137,10 @@ var init_hmr_0 = __rolldown_runtime__.createEsmInitializer((function() {
 			value: "cjs-namespace",
 			default: { value: "cjs-namespace" }
 		});
-		import_node_assert_00.default.deepStrictEqual(import_dep_esm_namespace_08, { value: "esm-namespace" });
+		import_node_assert_00.default.deepEqual(import_dep_esm_namespace_08, {
+			[Symbol.toStringTag]: "Module",
+			value: "esm-namespace"
+		});
 		hot_hmr.accept((mod) => {
 			if (mod) {
 				console.log(".hmr", mod.foo);

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/hmr.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/hmr.hmr-0.js
@@ -18,7 +18,10 @@ assert.deepStrictEqual(cjsNamespace, {
   value: 'cjs-namespace',
   default: { value: 'cjs-namespace' }
 })
-assert.deepStrictEqual(esmNamespace, { value: 'esm-namespace' })
+assert.deepEqual(esmNamespace, {
+  [Symbol.toStringTag]: 'Module',
+  value: 'esm-namespace'
+})
 
 import.meta.hot.accept((mod) => {
   if (mod) {

--- a/crates/rolldown/tests/rolldown/topics/hmr/static_import/hmr.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/static_import/hmr.js
@@ -16,7 +16,10 @@ assert.deepStrictEqual(cjsNamespace, {
   value: 'cjs-namespace',
   default: { value: 'cjs-namespace' }
 })
-assert.deepStrictEqual(esmNamespace, { value: 'esm-namespace' })
+assert.deepEqual(esmNamespace, {
+  [Symbol.toStringTag]: 'Module',
+  value: 'esm-namespace'
+})
 
 import.meta.hot.accept((mod) => {
   if (mod) {

--- a/crates/rolldown/tests/rolldown/topics/keep_names/declaration2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/declaration2/artifacts.snap
@@ -13,7 +13,7 @@ import assert from "node:assert";
 var a_exports = /* @__PURE__ */ __exportAll({
 	delay: () => delay$1,
 	random64: () => random64$1
-});
+}, 1);
 var delay$1 = /* @__PURE__ */ __name(function(time) {}, "delay");
 function random64$1() {
 	return BigInt(Math.random() * 4294967295 & 4294967295) << 32n & BigInt(Math.random() * 4294967295 & 4294967295);

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_binding_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_binding_cjs/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region main.js
 let count = 0;

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_decl/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_decl/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## foo.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region foo.js
 function foo() {}
@@ -18,7 +18,7 @@ exports.default = foo;
 ## main.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region main.js
 var Main = class {};

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_expr_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_expr_cjs/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region main.js
 let count = 0;

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_snapshot_not_live/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/default_export_snapshot_not_live/artifacts.snap
@@ -11,7 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 var file_exports = /* @__PURE__ */ __exportAll({
 	default: () => file_default,
 	inc: () => inc
-});
+}, 1);
 let x = 42;
 function inc() {
 	x += 1;

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_cjs/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 let count = 0;

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
@@ -28,6 +28,7 @@ node_assert.default.strictEqual(require_main.count, require_main.count);
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region shared.js
 let count = 0;

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 const short1 = "";

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_cjs/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region main.js
 const foo = "foo";

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs/artifacts.snap
@@ -6,6 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region main.js
 const foo = "foo";
@@ -19,6 +20,7 @@ exports.foo = foo;
 ## entry2.js
 
 ```js
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 const require_entry = require('./entry.js');
 
 exports.default = require_entry.default;

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped/artifacts.snap
@@ -11,7 +11,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 var main_exports = /* @__PURE__ */ __exportAll({
 	default: () => main_default,
 	foo: () => foo
-});
+}, 1);
 var foo, main_default;
 var init_main = __esmMin((() => {
 	foo = "foo";

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries/artifacts.snap
@@ -29,7 +29,7 @@ export { main_default as default, foo };
 var main_exports = /* @__PURE__ */ __exportAll({
 	default: () => main_default,
 	foo: () => foo
-});
+}, 1);
 var foo, main_default;
 var init_main = __esmMin((() => {
 	foo = "foo";

--- a/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs/artifacts.snap
@@ -6,14 +6,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 // HIDDEN [rolldown:runtime]
 
 //#region main.js
 var main_exports = /* @__PURE__ */ __exportAll({
 	default: () => main_default,
 	foo: () => foo
-});
+}, 1);
 var foo, main_default;
 var init_main = __esmMin((() => {
 	foo = "foo";

--- a/crates/rolldown/tests/rolldown/topics/tla/inline_dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/tla/inline_dynamic_import/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region c.js
-var c_exports = /* @__PURE__ */ __exportAll({ default: () => c_default });
+var c_exports = /* @__PURE__ */ __exportAll({ default: () => c_default }, 1);
 var _default, c_default;
 var init_c = __esmMin((() => {
 	_default = { aaa: { bbb: [
@@ -33,7 +33,7 @@ var init_b = __esmMin((async () => {
 
 //#endregion
 //#region a.js
-var a_exports = /* @__PURE__ */ __exportAll({ buildDevConfig: () => buildDevConfig });
+var a_exports = /* @__PURE__ */ __exportAll({ buildDevConfig: () => buildDevConfig }, 1);
 var buildDevConfig;
 var init_a = __esmMin((async () => {
 	await init_b();

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs/artifacts.snap
@@ -30,7 +30,7 @@ var require_cjs$2 = /* @__PURE__ */ __commonJSMin(((exports) => {
 //#region src/export_star_from_cjs/index.js
 var import_basic_ref_with_named_default = /* @__PURE__ */ __toESM(require_basic_ref_with_named_default());
 var import_basic_ns = /* @__PURE__ */ __toESM(require_basic_ns());
-var export_star_from_cjs_exports = {};
+var export_star_from_cjs_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(export_star_from_cjs_exports, /* @__PURE__ */ __toESM(require_cjs$2()));
 
 //#endregion
@@ -41,7 +41,7 @@ var require_cjs$1 = /* @__PURE__ */ __commonJSMin(((exports) => {
 
 //#endregion
 //#region src/nested_export_star_from_cjs/reexport.js
-var reexport_exports = {};
+var reexport_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(reexport_exports, /* @__PURE__ */ __toESM(require_cjs$1()));
 
 //#endregion
@@ -52,7 +52,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports) => {
 
 //#endregion
 //#region src/named_import_export_star_from_cjs/index.js
-var named_import_export_star_from_cjs_exports = {};
+var named_import_export_star_from_cjs_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(named_import_export_star_from_cjs_exports, /* @__PURE__ */ __toESM(require_cjs()));
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_inline_const/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_inline_const/artifacts.snap
@@ -30,7 +30,7 @@ var require_cjs$2 = /* @__PURE__ */ __commonJSMin(((exports) => {
 //#region src/export_star_from_cjs/index.js
 var import_basic_ref_with_named_default = /* @__PURE__ */ __toESM(require_basic_ref_with_named_default());
 var import_basic_ns = /* @__PURE__ */ __toESM(require_basic_ns());
-var export_star_from_cjs_exports = {};
+var export_star_from_cjs_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(export_star_from_cjs_exports, /* @__PURE__ */ __toESM(require_cjs$2()));
 
 //#endregion
@@ -41,7 +41,7 @@ var require_cjs$1 = /* @__PURE__ */ __commonJSMin(((exports) => {
 
 //#endregion
 //#region src/named_import_export_star_from_cjs/index.js
-var named_import_export_star_from_cjs_exports = {};
+var named_import_export_star_from_cjs_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(named_import_export_star_from_cjs_exports, /* @__PURE__ */ __toESM(require_cjs$1()));
 
 //#endregion
@@ -52,7 +52,7 @@ var require_cjs = /* @__PURE__ */ __commonJSMin(((exports) => {
 
 //#endregion
 //#region src/nested_export_star_from_cjs/reexport.js
-var reexport_exports = {};
+var reexport_exports = /* @__PURE__ */ __exportAll({}, 1);
 __reExport(reexport_exports, /* @__PURE__ */ __toESM(require_cjs()));
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/export_star/artifacts.snap
@@ -12,7 +12,7 @@ const foo = 1;
 
 //#endregion
 //#region export-star.js
-var export_star_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var export_star_exports = /* @__PURE__ */ __exportAll({ foo: () => foo }, 1);
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/tree_shaking/issue_4682/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/issue_4682/artifacts.snap
@@ -29,7 +29,7 @@ console.log("static no-treeshake");
 
 //#endregion
 //#region static.js
-var static_exports = {};
+var static_exports = /* @__PURE__ */ __exportAll({}, 1);
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/warnings/cannot_call_namespace/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/cannot_call_namespace/artifacts.snap
@@ -36,7 +36,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [rolldown:runtime]
 //#region foo.js
-var foo_exports = /* @__PURE__ */ __exportAll({ test: () => test });
+var foo_exports = /* @__PURE__ */ __exportAll({ test: () => test }, 1);
 const test = 1;
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format/artifacts.snap
@@ -20,7 +20,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 // HIDDEN [rolldown:runtime]
 
 //#region lib.js
-	var lib_exports = /* @__PURE__ */ __exportAll({ default: () => lib_default });
+	var lib_exports = /* @__PURE__ */ __exportAll({ default: () => lib_default }, 1);
 	var lib_default;
 	var init_lib = __esmMin((() => {
 		lib_default = 2;

--- a/crates/rolldown/tests/rolldown/warnings/mixed_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/warnings/mixed_export/artifacts.snap
@@ -17,7 +17,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 var bundle = (function(exports) {
 
-Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
 //#region main.js
 	var main_default = 1;

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -354,7 +354,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_bare_import_and_require_es6
 
-- src_entry-!~{000}~.js => src_entry-BnAgoc4f.js
+- src_entry-!~{000}~.js => src_entry-CJkq7xvK.js
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_named_import_common_js
 
@@ -370,7 +370,7 @@ expression: output
 
 # tests/esbuild/dce/package_json_side_effects_false_keep_star_import_es6
 
-- src_entry-!~{000}~.js => src_entry-DCiVGrh4.js
+- src_entry-!~{000}~.js => src_entry-MTbJFLaw.js
 
 # tests/esbuild/dce/package_json_side_effects_false_no_warning_in_node_modules_issue999
 
@@ -496,7 +496,7 @@ expression: output
 
 # tests/esbuild/dce/tree_shaking_in_esm_wrapper
 
-- entry-!~{000}~.js => entry-BePXD7yz.js
+- entry-!~{000}~.js => entry-BGs-njbC.js
 
 # tests/esbuild/dce/tree_shaking_js_with_associated_css
 
@@ -605,7 +605,7 @@ expression: output
 
 # tests/esbuild/default/bundle_esm_with_nested_var_issue4348
 
-- entry_js-!~{000}~.js => entry_js-COs9l3dl.js
+- entry_js-!~{000}~.js => entry_js-CS_sBxg4.js
 
 # tests/esbuild/default/bundling_files_outside_of_outbase
 
@@ -639,7 +639,7 @@ expression: output
 
 # tests/esbuild/default/common_js_from_es6
 
-- entry-!~{000}~.js => entry-CK-Sm980.js
+- entry-!~{000}~.js => entry-Bjdy2qtr.js
 
 # tests/esbuild/default/conditional_import
 
@@ -729,7 +729,7 @@ expression: output
 
 # tests/esbuild/default/empty_export_clause_bundle_as_common_js_issue910
 
-- entry-!~{000}~.js => entry-ZlryWzO-.js
+- entry-!~{000}~.js => entry-Ce0nlsOV.js
 
 # tests/esbuild/default/entry_names_chunk_names_ext_placeholder
 
@@ -749,24 +749,24 @@ expression: output
 
 # tests/esbuild/default/export_forms_common_js
 
-- entry-!~{000}~.js => entry-DqHLcUhu.js
+- entry-!~{000}~.js => entry-BrzV-U4k.js
 
 # tests/esbuild/default/export_forms_es6
 
-- entry-!~{000}~.js => entry-DkLerdwK.js
+- entry-!~{000}~.js => entry-CP0Yyj_s.js
 
 # tests/esbuild/default/export_forms_iife
 
-- entry-!~{000}~.js => entry-BMGZPhxd.js
+- entry-!~{000}~.js => entry-wXhA29QT.js
 
 # tests/esbuild/default/export_forms_with_minify_identifiers_and_no_bundle
 
-- a-!~{000}~.js => a-BvjrJ9cP.js
-- b-!~{001}~.js => b-G9hXgjWn.js
+- a-!~{000}~.js => a-BXyE3ODs.js
+- b-!~{001}~.js => b-DxGr0Pi8.js
 - c-!~{002}~.js => c-DbAYnqxj.js
 - d-!~{003}~.js => d-erhulghW.js
 - e-!~{004}~.js => e-BluWtRWc.js
-- b-!~{005}~.js => b-C4Jajyl0.js
+- b-!~{005}~.js => b-IocB4HQE.js
 
 # tests/esbuild/default/export_fs_browser
 
@@ -782,15 +782,15 @@ expression: output
 
 # tests/esbuild/default/export_special_name
 
-- entry-!~{000}~.js => entry-BlamnmIK.js
+- entry-!~{000}~.js => entry-i8k_HRja.js
 
 # tests/esbuild/default/export_special_name_bundle
 
-- entry-!~{000}~.js => entry-BjjJQ5Ef.js
+- entry-!~{000}~.js => entry-C7JhC86k.js
 
 # tests/esbuild/default/export_wildcard_fs_node_common_js
 
-- entry-!~{000}~.js => entry-_S2GQ9La.js
+- entry-!~{000}~.js => entry-CnfBS2_o.js
 
 # tests/esbuild/default/export_wildcard_fs_node_es6
 
@@ -798,11 +798,11 @@ expression: output
 
 # tests/esbuild/default/exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-C09rIoOy.js
+- entry-!~{000}~.js => entry-D633aKWf.js
 
 # tests/esbuild/default/external_es6_converted_to_common_js
 
-- entry-!~{000}~.js => entry-DfZ2cDxp.js
+- entry-!~{000}~.js => entry-sUTxpw8H.js
 
 # tests/esbuild/default/external_module_exclusion_package
 
@@ -830,7 +830,7 @@ expression: output
 
 # tests/esbuild/default/forbid_string_export_names_bundle
 
-- entry-!~{000}~.js => entry-DxNiz98l.js
+- entry-!~{000}~.js => entry-GuqfXbpC.js
 
 # tests/esbuild/default/forbid_string_export_names_no_bundle
 
@@ -906,14 +906,14 @@ expression: output
 
 # tests/esbuild/default/import_missing_neither_es6_nor_common_js
 
-- bare-!~{003}~.js => bare-DjqFHzVu.js
-- import-!~{005}~.js => import-CUeBBRmX.js
-- named-!~{000}~.js => named-BG_xjjWJ.js
-- require-!~{004}~.js => require-D2VIa6mL.js
-- star-!~{001}~.js => star-DrOxc72R.js
-- star-capture-!~{002}~.js => star-capture-0xUtQYbo.js
-- foo-!~{008}~.js => foo-Ce8FF60q.js
-- foo-!~{006}~.js => foo-DV95MSIF.js
+- bare-!~{003}~.js => bare-BTFA2y5q.js
+- import-!~{005}~.js => import-Dfm12AUY.js
+- named-!~{000}~.js => named-QgV8m12z.js
+- require-!~{004}~.js => require-DZGoVlD1.js
+- star-!~{001}~.js => star-DiJOEr0K.js
+- star-capture-!~{002}~.js => star-capture-Ddp9hQMn.js
+- foo-!~{008}~.js => foo-C74EV9cP.js
+- foo-!~{006}~.js => foo-xHDSjG-B.js
 
 # tests/esbuild/default/import_namespace_this_value
 
@@ -1205,9 +1205,9 @@ expression: output
 
 # tests/esbuild/default/mangle_props_import_export_bundled
 
-- entry-cjs-!~{001}~.js => entry-cjs-8ejPda3N.js
-- entry-esm-!~{000}~.js => entry-esm-C7jKUz9G.js
-- cjs-!~{002}~.js => cjs-DLh3OPP_.js
+- entry-cjs-!~{001}~.js => entry-cjs-6dG3KTIF.js
+- entry-esm-!~{000}~.js => entry-esm-WQ-W1nTQ.js
+- cjs-!~{002}~.js => cjs-2x38wojA.js
 
 # tests/esbuild/default/mangle_props_jsx_preserve
 
@@ -1370,7 +1370,7 @@ expression: output
 
 # tests/esbuild/default/minified_exports_and_module_format_common_js
 
-- entry-!~{000}~.js => entry-D1McMU_m.js
+- entry-!~{000}~.js => entry-DiVbuzjp.js
 
 # tests/esbuild/default/minified_jsx_preserve_with_object_spread
 
@@ -1436,11 +1436,11 @@ expression: output
 
 # tests/esbuild/default/node_annotation_false_positive_issue3544
 
-- entry-!~{000}~.js => entry-B0FcqYtb.js
+- entry-!~{000}~.js => entry-DNGb34bd.js
 
 # tests/esbuild/default/node_annotation_invalid_identifier_issue4100
 
-- entry_mjs-!~{000}~.js => entry_mjs-DXYbIR4S.js
+- entry_mjs-!~{000}~.js => entry_mjs-rhg6ftV1.js
 
 # tests/esbuild/default/node_modules
 
@@ -1491,7 +1491,7 @@ expression: output
 
 # tests/esbuild/default/re_export_default_external_common_js
 
-- entry-!~{000}~.js => entry-1r4OsFXL.js
+- entry-!~{000}~.js => entry-BA2BxmOL.js
 
 # tests/esbuild/default/re_export_default_external_es6
 
@@ -1507,7 +1507,7 @@ expression: output
 
 # tests/esbuild/default/re_export_default_no_bundle_common_js
 
-- entry-!~{000}~.js => entry-9TUo2tdJ.js
+- entry-!~{000}~.js => entry-BHdJSPTD.js
 
 # tests/esbuild/default/re_export_default_no_bundle_es6
 
@@ -1649,11 +1649,11 @@ expression: output
 
 # tests/esbuild/default/string_export_names_common_js
 
-- entry-!~{000}~.js => entry-auWl9XEI.js
+- entry-!~{000}~.js => entry-WFDDjl8P.js
 
 # tests/esbuild/default/string_export_names_iife
 
-- entry-!~{000}~.js => entry-BB73v6iX.js
+- entry-!~{000}~.js => entry-Bz1L1TxK.js
 
 # tests/esbuild/default/switch_scope_no_bundle
 
@@ -1673,7 +1673,7 @@ expression: output
 
 # tests/esbuild/default/this_with_es6_syntax
 
-- entry-!~{000}~.js => entry-DFZD7V8M.js
+- entry-!~{000}~.js => entry-Bo1lIH3r.js
 
 # tests/esbuild/default/to_esm_wrapper_omission
 
@@ -1690,7 +1690,7 @@ expression: output
 
 # tests/esbuild/default/top_level_await_allowed_import_without_splitting
 
-- entry-!~{000}~.js => entry-2MDmpQWu.js
+- entry-!~{000}~.js => entry-BAgvE9tN.js
 
 # tests/esbuild/default/top_level_await_cjs_dead_branch
 
@@ -1706,11 +1706,11 @@ expression: output
 
 # tests/esbuild/default/top_level_await_forbidden_require
 
-- entry-!~{000}~.js => entry--S-SU56k.js
+- entry-!~{000}~.js => entry-CEfXimo9.js
 
 # tests/esbuild/default/top_level_await_forbidden_require_dead_branch
 
-- entry-!~{000}~.js => entry-6krGZ10w.js
+- entry-!~{000}~.js => entry-DgeaC9Rj.js
 
 # tests/esbuild/default/top_level_await_iife_dead_branch
 
@@ -1762,7 +1762,7 @@ expression: output
 
 # tests/esbuild/default/use_strict_directive_bundle_cjs_issue2264
 
-- entry-!~{000}~.js => entry-Tn__zxkI.js
+- entry-!~{000}~.js => entry-C_VGWB8D.js
 
 # tests/esbuild/default/use_strict_directive_bundle_esm_issue2264
 
@@ -1770,7 +1770,7 @@ expression: output
 
 # tests/esbuild/default/use_strict_directive_bundle_iife_issue2264
 
-- entry-!~{000}~.js => entry-DyW_VbPa.js
+- entry-!~{000}~.js => entry-CYUl3ToA.js
 
 # tests/esbuild/default/use_strict_directive_bundle_issue1837
 
@@ -1790,14 +1790,14 @@ expression: output
 
 # tests/esbuild/default/warn_common_js_exports_in_esm_bundle
 
-- cjs-in-esm-!~{000}~.js => cjs-in-esm-plvIZEyb.js
+- cjs-in-esm-!~{000}~.js => cjs-in-esm-CtKdQvrY.js
 - import-in-cjs-!~{001}~.js => import-in-cjs-BBw1yeDo.js
 - no-warnings-here-!~{002}~.js => no-warnings-here-BnKOXmVw.js
 
 # tests/esbuild/default/warn_common_js_exports_in_esm_convert
 
-- cjs-in-esm-!~{000}~.js => cjs-in-esm-plvIZEyb.js
-- cjs-in-esm2-!~{001}~.js => cjs-in-esm2-DFD0Tg0r.js
+- cjs-in-esm-!~{000}~.js => cjs-in-esm-CtKdQvrY.js
+- cjs-in-esm2-!~{001}~.js => cjs-in-esm2-BuLEq44Q.js
 - import-in-cjs-!~{002}~.js => import-in-cjs-DF6X_Gpj.js
 - no-warnings-here-!~{003}~.js => no-warnings-here-83rFFOtF.js
 
@@ -1839,35 +1839,35 @@ expression: output
 
 # tests/esbuild/importstar/export_other_as_namespace_common_js
 
-- entry-!~{000}~.js => entry-c_lvxK8h.js
+- entry-!~{000}~.js => entry-CAB54Lga.js
 
 # tests/esbuild/importstar/export_other_common_js
 
-- entry-!~{000}~.js => entry-6wc0JFHX.js
+- entry-!~{000}~.js => entry-CW9IypRA.js
 
 # tests/esbuild/importstar/export_other_nested_common_js
 
-- entry-!~{000}~.js => entry-otdslZEx.js
+- entry-!~{000}~.js => entry-CAGDBsco.js
 
 # tests/esbuild/importstar/export_self_and_import_self_common_js
 
-- entry-!~{000}~.js => entry-ByOvwRH6.js
+- entry-!~{000}~.js => entry-CdniQdXM.js
 
 # tests/esbuild/importstar/export_self_and_require_self_common_js
 
-- entry-!~{000}~.js => entry-COL705w_.js
+- entry-!~{000}~.js => entry-BvnNZKnj.js
 
 # tests/esbuild/importstar/export_self_as_namespace_common_js
 
-- entry-!~{000}~.js => entry-DvfkJxvD.js
+- entry-!~{000}~.js => entry-tn8oUZw9.js
 
 # tests/esbuild/importstar/export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-CpB6pM-Q.js
+- entry-!~{000}~.js => entry-DQL_WMvZ.js
 
 # tests/esbuild/importstar/export_self_common_js
 
-- entry-!~{000}~.js => entry-CFmUWZlM.js
+- entry-!~{000}~.js => entry-Da5KQXgi.js
 
 # tests/esbuild/importstar/export_self_common_js_minified
 
@@ -1879,15 +1879,15 @@ expression: output
 
 # tests/esbuild/importstar/export_self_iife
 
-- entry-!~{000}~.js => entry-lbPVtccS.js
+- entry-!~{000}~.js => entry-UKrPu6bn.js
 
 # tests/esbuild/importstar/export_self_iife_with_name
 
-- entry-!~{000}~.js => entry-8JkQPpw9.js
+- entry-!~{000}~.js => entry-DxJ1bljb.js
 
 # tests/esbuild/importstar/export_star_default_export_common_js
 
-- entry-!~{000}~.js => entry-BrctAV5T.js
+- entry-!~{000}~.js => entry-BwDHOnsE.js
 
 # tests/esbuild/importstar/import_default_namespace_combo_issue446
 
@@ -1897,21 +1897,21 @@ expression: output
 - external-ns-!~{001}~.js => external-ns-all2LFha.js
 - external-ns-def-!~{003}~.js => external-ns-def-CPrnmGVn.js
 - external-ns-default-!~{002}~.js => external-ns-default-Cbqf8eIs.js
-- internal-def-!~{00b}~.js => internal-def-D_k0eYaQ.js
-- internal-default-!~{00a}~.js => internal-default-BqEYkRlK.js
-- internal-default2-!~{006}~.js => internal-default2-D1tDeBe1.js
-- internal-ns-def-!~{009}~.js => internal-ns-def-ClprM2kp.js
-- internal-ns-default-!~{008}~.js => internal-ns-default-BfmdVB_y.js
-- internal-ns-!~{007}~.js => internal-ns-oYOWLwV6.js
-- internal-!~{00c}~.js => internal-DNttTVWd.js
+- internal-def-!~{00b}~.js => internal-def-x34NtCvd.js
+- internal-default-!~{00a}~.js => internal-default-OuKSyQHX.js
+- internal-default2-!~{006}~.js => internal-default2-CT8Jpybg.js
+- internal-ns-!~{007}~.js => internal-ns-ULrkHzJQ.js
+- internal-ns-def-!~{009}~.js => internal-ns-def-BCuVkvvU.js
+- internal-ns-default-!~{008}~.js => internal-ns-default-tH8MwXvT.js
+- internal-!~{00c}~.js => internal-BD7cW7z3.js
 
 # tests/esbuild/importstar/import_export_other_as_namespace_common_js
 
-- entry-!~{000}~.js => entry-c_lvxK8h.js
+- entry-!~{000}~.js => entry-CAB54Lga.js
 
 # tests/esbuild/importstar/import_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-CpB6pM-Q.js
+- entry-!~{000}~.js => entry-DQL_WMvZ.js
 
 # tests/esbuild/importstar/import_export_star_ambiguous_warning
 
@@ -1943,11 +1943,11 @@ expression: output
 
 # tests/esbuild/importstar/import_star_and_common_js
 
-- entry-!~{000}~.js => entry-BMwA6T29.js
+- entry-!~{000}~.js => entry-jVRXxj2x.js
 
 # tests/esbuild/importstar/import_star_capture
 
-- entry-!~{000}~.js => entry-BMTZk2XA.js
+- entry-!~{000}~.js => entry-CwXB6YJG.js
 
 # tests/esbuild/importstar/import_star_common_js_capture
 
@@ -1963,7 +1963,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_import_star_capture
 
-- entry-!~{000}~.js => entry-BMTZk2XA.js
+- entry-!~{000}~.js => entry-CwXB6YJG.js
 
 # tests/esbuild/importstar/import_star_export_import_star_no_capture
 
@@ -1975,7 +1975,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_as_capture
 
-- entry-!~{000}~.js => entry-BMTZk2XA.js
+- entry-!~{000}~.js => entry-CwXB6YJG.js
 
 # tests/esbuild/importstar/import_star_export_star_as_no_capture
 
@@ -1987,7 +1987,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_capture
 
-- entry-!~{000}~.js => entry--xVxp6cF.js
+- entry-!~{000}~.js => entry-CfW5iLyp.js
 
 # tests/esbuild/importstar/import_star_export_star_no_capture
 
@@ -1995,7 +1995,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_export_star_omit_ambiguous
 
-- entry-!~{000}~.js => entry-DFePfCfT.js
+- entry-!~{000}~.js => entry-Dfs9RJPU.js
 
 # tests/esbuild/importstar/import_star_export_star_unused
 
@@ -2031,7 +2031,7 @@ expression: output
 
 # tests/esbuild/importstar/import_star_of_export_star_as
 
-- entry-!~{000}~.js => entry-akSmFYWq.js
+- entry-!~{000}~.js => entry-CE1cpYkR.js
 
 # tests/esbuild/importstar/import_star_unused
 
@@ -2039,7 +2039,7 @@ expression: output
 
 # tests/esbuild/importstar/issue176
 
-- entry-!~{000}~.js => entry-C2v0EJZq.js
+- entry-!~{000}~.js => entry-CYjsUASG.js
 
 # tests/esbuild/importstar/namespace_import_missing_common_js
 
@@ -2047,11 +2047,11 @@ expression: output
 
 # tests/esbuild/importstar/namespace_import_missing_es6
 
-- entry-!~{000}~.js => entry-BfwpFT-O.js
+- entry-!~{000}~.js => entry-DyVh38mS.js
 
 # tests/esbuild/importstar/namespace_import_re_export_star_missing_es6
 
-- entry-!~{000}~.js => entry-BXlkpF-q.js
+- entry-!~{000}~.js => entry-Dljf3iML.js
 
 # tests/esbuild/importstar/namespace_import_re_export_star_unused_missing_es6
 
@@ -2075,7 +2075,7 @@ expression: output
 
 # tests/esbuild/importstar/re_export_namespace_import_missing_es6
 
-- entry-!~{000}~.js => entry-CHes638X.js
+- entry-!~{000}~.js => entry-DBBPMX_J.js
 
 # tests/esbuild/importstar/re_export_namespace_import_unused_missing_es6
 
@@ -2083,15 +2083,15 @@ expression: output
 
 # tests/esbuild/importstar/re_export_other_file_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-CM26NCs6.js
+- entry-!~{000}~.js => entry-Py9TlGBH.js
 
 # tests/esbuild/importstar/re_export_other_file_import_export_self_as_namespace_es6
 
-- entry-!~{000}~.js => entry-CM26NCs6.js
+- entry-!~{000}~.js => entry-Py9TlGBH.js
 
 # tests/esbuild/importstar/re_export_star_as_common_js_no_bundle
 
-- entry-!~{000}~.js => entry-XA5PtodL.js
+- entry-!~{000}~.js => entry-CJCy2xGl.js
 
 # tests/esbuild/importstar/re_export_star_as_es6_no_bundle
 
@@ -2099,7 +2099,7 @@ expression: output
 
 # tests/esbuild/importstar/re_export_star_as_external_common_js
 
-- entry-!~{000}~.js => entry-XA5PtodL.js
+- entry-!~{000}~.js => entry-CJCy2xGl.js
 
 # tests/esbuild/importstar/re_export_star_as_external_es6
 
@@ -2107,11 +2107,11 @@ expression: output
 
 # tests/esbuild/importstar/re_export_star_as_external_iife
 
-- entry-!~{000}~.js => entry-GcaT2LSC.js
+- entry-!~{000}~.js => entry-DqDqZq6H.js
 
 # tests/esbuild/importstar/re_export_star_as_iife_no_bundle
 
-- entry-!~{000}~.js => entry-GcaT2LSC.js
+- entry-!~{000}~.js => entry-DqDqZq6H.js
 
 # tests/esbuild/importstar/re_export_star_common_js_no_bundle
 
@@ -2119,7 +2119,7 @@ expression: output
 
 # tests/esbuild/importstar/re_export_star_entry_point_and_inner_file
 
-- entry-!~{000}~.js => entry-DPdVkvfs.js
+- entry-!~{000}~.js => entry-Ixd3eIpn.js
 
 # tests/esbuild/importstar/re_export_star_es6_no_bundle
 
@@ -2159,11 +2159,11 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_and_common_js
 
-- entry-!~{000}~.js => entry-_ddfNnkT.js
+- entry-!~{000}~.js => entry-BGLYwKyo.js
 
 # tests/esbuild/importstar_ts/ts_import_star_capture
 
-- entry-!~{000}~.js => entry-CCMpypc8.js
+- entry-!~{000}~.js => entry-BWggiukW.js
 
 # tests/esbuild/importstar_ts/ts_import_star_common_js_capture
 
@@ -2179,7 +2179,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_import_star_capture
 
-- entry-!~{000}~.js => entry-CCMpypc8.js
+- entry-!~{000}~.js => entry-BWggiukW.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_import_star_no_capture
 
@@ -2191,7 +2191,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_as_capture
 
-- entry-!~{000}~.js => entry-CCMpypc8.js
+- entry-!~{000}~.js => entry-BWggiukW.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_as_no_capture
 
@@ -2203,7 +2203,7 @@ expression: output
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_capture
 
-- entry-!~{000}~.js => entry-Cmt8YG1C.js
+- entry-!~{000}~.js => entry-8epbKN25.js
 
 # tests/esbuild/importstar_ts/ts_import_star_export_star_no_capture
 
@@ -2265,8 +2265,8 @@ expression: output
 
 # tests/esbuild/loader/empty_loader_js
 
-- entry-!~{000}~.js => entry-CR2KEPxS.js
-- entry-CR2KEPxS.js.map
+- entry-!~{000}~.js => entry-CM5Sm0AA.js
+- entry-CM5Sm0AA.js.map
 
 # tests/esbuild/loader/extensionless_loader_js
 
@@ -2468,7 +2468,7 @@ expression: output
 
 # tests/esbuild/loader/loader_json_invalid_identifier_es6
 
-- entry-!~{000}~.js => entry-DDA7S-em.js
+- entry-!~{000}~.js => entry-ColGLmbg.js
 
 # tests/esbuild/loader/loader_json_no_bundle
 
@@ -2476,7 +2476,7 @@ expression: output
 
 # tests/esbuild/loader/loader_json_no_bundle_common_js
 
-- test-!~{000}~.js => test-AQT7NPlD.js
+- test-!~{000}~.js => test-DDvktIIg.js
 
 # tests/esbuild/loader/loader_json_no_bundle_es6
 
@@ -2488,7 +2488,7 @@ expression: output
 
 # tests/esbuild/loader/loader_json_no_bundle_iife
 
-- test-!~{000}~.js => test-9w8KKPXb.js
+- test-!~{000}~.js => test-CSsTizFx.js
 
 # tests/esbuild/loader/loader_json_prototype
 
@@ -2984,27 +2984,27 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_browser
 
-- entry-!~{000}~.js => entry-kpuZa0_b.js
+- entry-!~{000}~.js => entry-B75bSTIv.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_force_module_before_main
 
-- entry-!~{000}~.js => entry-oPMKq5Zu.js
+- entry-!~{000}~.js => entry-Ae2_kigM.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main
 
-- entry-!~{000}~.js => entry-pJ89N0zZ.js
+- entry-!~{000}~.js => entry-B8CZj-Zk.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_implicit_main_force_module_before_main
 
-- entry-!~{000}~.js => entry-CtGkUz4V.js
+- entry-!~{000}~.js => entry-7OQhfkES.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_same_file
 
-- entry-!~{000}~.js => entry-dviZjHk0.js
+- entry-!~{000}~.js => entry-Dr1SEAjm.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_and_require_separate_files
 
-- entry-!~{000}~.js => entry-CTuTImQr.js
+- entry-!~{000}~.js => entry-CwcEj9jW.js
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_import_only
 
@@ -3012,7 +3012,7 @@ expression: output
 
 # tests/esbuild/packagejson/package_json_dual_package_hazard_require_only
 
-- entry-!~{000}~.js => entry-DelYX_kQ.js
+- entry-!~{000}~.js => entry-DtZ2MyF_.js
 
 # tests/esbuild/packagejson/package_json_exports_alternatives
 
@@ -3184,7 +3184,7 @@ expression: output
 
 # tests/esbuild/splitting/edge_case_issue2793_without_splitting
 
-- index-!~{000}~.js => index-DUCag6zs.js
+- index-!~{000}~.js => index-EGoimXMH.js
 
 # tests/esbuild/splitting/splitting_assign_to_local
 
@@ -3231,7 +3231,7 @@ expression: output
 
 # tests/esbuild/splitting/splitting_dynamic_and_not_dynamic_es6_into_es6
 
-- entry-!~{000}~.js => entry-DFyR4Vrv.js
+- entry-!~{000}~.js => entry-CNj985zs.js
 
 # tests/esbuild/splitting/splitting_dynamic_common_js_into_es6
 
@@ -3256,9 +3256,9 @@ expression: output
 
 # tests/esbuild/splitting/splitting_hybrid_esm_and_cjs_issue617
 
-- a-!~{000}~.js => a-PBwkuyOD.js
-- b-!~{001}~.js => b-BEYMaapY.js
-- a-!~{002}~.js => a-akC8J1zy.js
+- a-!~{000}~.js => a-CnWFVnbI.js
+- b-!~{001}~.js => b-CRz1Vl4K.js
+- a-!~{002}~.js => a-BiwGJeWf.js
 
 # tests/esbuild/splitting/splitting_minify_identifiers_crash_issue437
 
@@ -3269,9 +3269,9 @@ expression: output
 
 # tests/esbuild/splitting/splitting_missing_lazy_export
 
-- a-!~{000}~.js => a-fzAtWTYJ.js
-- b-!~{001}~.js => b-HNqljLjd.js
-- common-!~{002}~.js => common-BmPOYD1U.js
+- a-!~{000}~.js => a-DP6lJ8v3.js
+- b-!~{001}~.js => b-DGOJcxBW.js
+- common-!~{002}~.js => common-Zs_fcluy.js
 
 # tests/esbuild/splitting/splitting_nested_directories
 
@@ -3314,7 +3314,7 @@ expression: output
 
 # tests/esbuild/ts/export_type_issue379
 
-- entry-!~{000}~.js => entry-BDtbHLUE.js
+- entry-!~{000}~.js => entry-BXwk3bfn.js
 
 # tests/esbuild/ts/this_inside_function_ts
 
@@ -3472,7 +3472,7 @@ expression: output
 
 # tests/esbuild/ts/ts_export_missing_es6
 
-- entry-!~{000}~.js => entry-DGxkyUjS.js
+- entry-!~{000}~.js => entry-BJKUruka.js
 
 # tests/esbuild/ts/ts_export_namespace
 
@@ -3508,7 +3508,7 @@ expression: output
 
 # tests/esbuild/ts/ts_import_equals_undefined_import
 
-- entry-!~{000}~.js => entry-DBWK5sjd.js
+- entry-!~{000}~.js => entry-BMKN42oQ.js
 
 # tests/esbuild/ts/ts_import_missing_unused_es6
 
@@ -3628,7 +3628,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/basic_commonjs
 
-- main-!~{000}~.js => main-BHHaC6mR.js
+- main-!~{000}~.js => main-CndYkW--.js
 
 # tests/rolldown/cjs_compat/cjs_entry
 
@@ -3656,15 +3656,15 @@ expression: output
 
 # tests/rolldown/cjs_compat/esm_require_esm
 
-- main-!~{000}~.js => main-CzWht2zu.js
+- main-!~{000}~.js => main-Dv9i6jTF.js
 
 # tests/rolldown/cjs_compat/esm_require_esm_unused
 
-- main-!~{000}~.js => main-DH0m_kQa.js
+- main-!~{000}~.js => main-ClY_STh6.js
 
 # tests/rolldown/cjs_compat/exoprt_star_of_cjs
 
-- main-!~{000}~.js => main-T7OOG3kA.js
+- main-!~{000}~.js => main--hOL-vho.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_cjs_import_star_as
 
@@ -3676,11 +3676,11 @@ expression: output
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_cjs_named_import
 
-- main-!~{000}~.js => main-DLKx0URc.js
+- main-!~{000}~.js => main-pV5ZJfHs.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_import_esm_which_export_all_from_multiple_cjs_named_import
 
-- main-!~{000}~.js => main-CMmCqNLi.js
+- main-!~{000}~.js => main-WA27VCDD.js
 
 # tests/rolldown/cjs_compat/import_reexport_between_esm_and_cjs/esm_reexport_cjs_default
 
@@ -3700,7 +3700,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/issue_7634
 
-- main-!~{000}~.js => main-lczLaht1.js
+- main-!~{000}~.js => main-LXqS_UUJ.js
 
 # tests/rolldown/cjs_compat/issue_7833
 
@@ -3714,15 +3714,15 @@ expression: output
 
 # tests/rolldown/cjs_compat/module.exports_export/basic
 
-- main-!~{000}~.js => main-ADhs7YGs.js
+- main-!~{000}~.js => main-Bc8g1y1l.js
 
 # tests/rolldown/cjs_compat/module.exports_export/fallback
 
-- main-!~{000}~.js => main-CzBE7Hv-.js
+- main-!~{000}~.js => main-D-XH58E8.js
 
 # tests/rolldown/cjs_compat/module.exports_export/priority
 
-- main-!~{000}~.js => main--ExzgxTS.js
+- main-!~{000}~.js => main-BSouPS1q.js
 
 # tests/rolldown/cjs_compat/module.exports_export/safely_merge_cjs_ns_only_named
 
@@ -3742,7 +3742,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/module.exports_export/with_default
 
-- main-!~{000}~.js => main-BITVMUs8.js
+- main-!~{000}~.js => main-DRnV9htM.js
 
 # tests/rolldown/cjs_compat/multiple_circle_cjs_entries
 
@@ -3751,13 +3751,13 @@ expression: output
 
 # tests/rolldown/cjs_compat/node_module_commonjs
 
-- entry-!~{001}~.js => entry-f_XeA3ad.js
-- main-!~{000}~.js => main-DI4Uv0re.js
-- commonjs-!~{002}~.js => commonjs-CboXWVLr.js
+- entry-!~{001}~.js => entry-D8xEpr6S.js
+- main-!~{000}~.js => main-BtfQUi6d.js
+- commonjs-!~{002}~.js => commonjs-Cd3e05tw.js
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout
 
-- main-!~{000}~.js => main-C3sXF3iC.js
+- main-!~{000}~.js => main-DdID-T2K.js
 
 # tests/rolldown/cjs_compat/optimize_interop_default_with_cjs_bailout2
 
@@ -3773,7 +3773,7 @@ expression: output
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_2
 
-- main-!~{000}~.js => main-DATjVynl.js
+- main-!~{000}~.js => main-BtjC3SeN.js
 
 # tests/rolldown/cjs_compat/partial_cjs_ns_merge_optimize
 
@@ -3791,11 +3791,11 @@ expression: output
 
 # tests/rolldown/cjs_compat/reexport_commonjs
 
-- main-!~{000}~.js => main-DJNuMCKL.js
+- main-!~{000}~.js => main-IjJkNc0H.js
 
 # tests/rolldown/cjs_compat/reexports_from_cjs
 
-- main-!~{000}~.js => main-Cs_qA9CC.js
+- main-!~{000}~.js => main-r2b976vS.js
 
 # tests/rolldown/cjs_compat/require/create_require
 
@@ -3808,12 +3808,12 @@ expression: output
 
 # tests/rolldown/cjs_compat/require/require_esm
 
-- main-!~{000}~.js => main-B6vdrOMP.js
-- main-B6vdrOMP.js.map
+- main-!~{000}~.js => main-DyYasbY0.js
+- main-DyYasbY0.js.map
 
 # tests/rolldown/cjs_compat/require_call_expr_unused
 
-- main-!~{000}~.js => main-SQ43aH6p.js
+- main-!~{000}~.js => main-BEqf5aNs.js
 
 # tests/rolldown/cjs_compat/unnecessary_compat_default_property_access
 
@@ -3828,7 +3828,7 @@ expression: output
 
 # tests/rolldown/code_splitting/dynamic_import_and_static_import_one_file
 
-- main-!~{000}~.js => main-BYdUJMok.js
+- main-!~{000}~.js => main-D_ILyqte.js
 
 # tests/rolldown/code_splitting/ensure_safe_identifier
 
@@ -3850,7 +3850,7 @@ expression: output
 # tests/rolldown/code_splitting/format_cjs_with_esm_require_esm
 
 - main1-!~{000}~.js => main1-eDZ__DJN.js
-- main2-!~{001}~.js => main2-DawHdQL-.js
+- main2-!~{001}~.js => main2-MCkmAMXo.js
 - chunk-!~{002}~.js => chunk-Cvk4pxuF.js
 
 # tests/rolldown/code_splitting/format_cjs_with_module_cjs
@@ -3867,21 +3867,21 @@ expression: output
 
 # tests/rolldown/code_splitting/issue_2786
 
-- main-!~{000}~.js => main-JjNfKQ3W.js
+- main-!~{000}~.js => main-BTyUR1F-.js
 
 # tests/rolldown/code_splitting/issue_5276
 
-- main-!~{000}~.js => main-B6YWjK7m.js
-- imp-!~{001}~.js => imp-BRmtGyuP.js
+- main-!~{000}~.js => main-Dlh5LkbZ.js
+- imp-!~{001}~.js => imp-DuNAuhNu.js
 
 # tests/rolldown/code_splitting/issue_5276_2
 
-- main-!~{000}~.js => main-C_JQXq7h.js
-- imp-!~{001}~.js => imp-CdA-oVqI.js
+- main-!~{000}~.js => main-C_bwRJp9.js
+- imp-!~{001}~.js => imp-c_hyelAG.js
 
 # tests/rolldown/dce/conditional_exports
 
-- main-!~{000}~.js => main-CLgpo5DC.js
+- main-!~{000}~.js => main-CkjcYrlj.js
 
 # tests/rolldown/dce/defined_expr_in_paren_expr
 
@@ -3982,10 +3982,10 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/split_node_modules
 
-- main-!~{000}~.js => main-CZ1IF8Uo.js
-- other-libs-!~{005}~.js => other-libs-BhogrQcJ.js
+- main-!~{000}~.js => main-BCnT30hq.js
+- other-libs-!~{005}~.js => other-libs-Bo3bYCYV.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-COCv1wus.js
-- ui-!~{003}~.js => ui-C--J4tBt.js
+- ui-!~{003}~.js => ui-DVJuNqSv.js
 
 # tests/rolldown/function/context/defined
 
@@ -4027,31 +4027,31 @@ expression: output
 
 # tests/rolldown/function/es_module/always
 
-- main-!~{000}~.js => main-Dt1QGEoW.js
+- main-!~{000}~.js => main-gZW-0Wjy.js
 
 # tests/rolldown/function/es_module/if_default_prop_cjs_false
 
-- main-!~{000}~.js => main-DxxMDNJY.js
+- main-!~{000}~.js => main-CLHVnQId.js
 
 # tests/rolldown/function/es_module/if_default_prop_cjs_true
 
-- main-!~{000}~.js => main-CECuwkXA.js
+- main-!~{000}~.js => main-7VjE_wYY.js
 
 # tests/rolldown/function/es_module/if_default_prop_iife_false
 
-- main-!~{000}~.js => main-BtfNOhnu.js
+- main-!~{000}~.js => main-BgkViPRe.js
 
 # tests/rolldown/function/es_module/if_default_prop_iife_true
 
-- main-!~{000}~.js => main-BReqUdTx.js
+- main-!~{000}~.js => main-Bzjz8xEA.js
 
 # tests/rolldown/function/es_module/never
 
-- main-!~{000}~.js => main-BtfNOhnu.js
+- main-!~{000}~.js => main-BgkViPRe.js
 
 # tests/rolldown/function/experimental/attach_debug_info/eliminated_facade_chunk
 
-- main-!~{000}~.js => main-DZW8KQfJ.js
+- main-!~{000}~.js => main-CqqKnRuq.js
 
 # tests/rolldown/function/experimental/attach_debug_info/full
 
@@ -4171,7 +4171,7 @@ expression: output
 
 # tests/rolldown/function/export_mode/cjs/auto/named
 
-- main-!~{000}~.js => main-j4LPpz5P.js
+- main-!~{000}~.js => main-Ds2F4BwT.js
 
 # tests/rolldown/function/export_mode/cjs/auto/none
 
@@ -4179,11 +4179,11 @@ expression: output
 
 # tests/rolldown/function/export_mode/cjs/default
 
-- main-!~{000}~.js => main-W6ufBytz.js
+- main-!~{000}~.js => main-8_FOLV8u.js
 
 # tests/rolldown/function/export_mode/cjs/named
 
-- main-!~{000}~.js => main-BVzUKAdH.js
+- main-!~{000}~.js => main-OkyxTT5V.js
 
 # tests/rolldown/function/export_mode/iife/auto/none
 
@@ -4191,11 +4191,11 @@ expression: output
 
 # tests/rolldown/function/export_mode/iife/default
 
-- main-!~{000}~.js => main-BBYS8Nu_.js
+- main-!~{000}~.js => main-CwGzes9f.js
 
 # tests/rolldown/function/export_mode/iife/named
 
-- main-!~{000}~.js => main-BNjuvhTK.js
+- main-!~{000}~.js => main-CcZoikNT.js
 
 # tests/rolldown/function/export_mode/umd/auto/none
 
@@ -4207,7 +4207,7 @@ expression: output
 
 # tests/rolldown/function/export_mode/umd/complex_name_named
 
-- main-!~{000}~.js => main-tn0Qu4_3.js
+- main-!~{000}~.js => main-woWLYLtp.js
 
 # tests/rolldown/function/export_mode/umd/default
 
@@ -4215,7 +4215,7 @@ expression: output
 
 # tests/rolldown/function/export_mode/umd/named
 
-- main-!~{000}~.js => main-CtuRWXMB.js
+- main-!~{000}~.js => main-Dt5UcERV.js
 
 # tests/rolldown/function/extend/entry-wrapped-cjs-default
 
@@ -4231,7 +4231,7 @@ expression: output
 
 # tests/rolldown/function/extend/iife/namespace_named
 
-- main-!~{000}~.js => main-K2e4wWw_.js
+- main-!~{000}~.js => main-Bmm0hMl0.js
 
 # tests/rolldown/function/extend/iife/no_name_default
 
@@ -4239,7 +4239,7 @@ expression: output
 
 # tests/rolldown/function/extend/iife/no_name_named
 
-- main-!~{000}~.js => main-D8TMSZ5a.js
+- main-!~{000}~.js => main-B9W4eh1Z.js
 
 # tests/rolldown/function/extend/iife/non_namespace_default
 
@@ -4247,7 +4247,7 @@ expression: output
 
 # tests/rolldown/function/extend/iife/non_namespace_named
 
-- main-!~{000}~.js => main-Vl2v0XGB.js
+- main-!~{000}~.js => main-2q0h3boc.js
 
 # tests/rolldown/function/extend/umd/complex_name_default
 
@@ -4255,7 +4255,7 @@ expression: output
 
 # tests/rolldown/function/extend/umd/complex_name_named
 
-- main-!~{000}~.js => main-BNLn-oCp.js
+- main-!~{000}~.js => main-CQQLayl1.js
 
 # tests/rolldown/function/extend/umd/default
 
@@ -4263,15 +4263,15 @@ expression: output
 
 # tests/rolldown/function/extend/umd/named
 
-- main-!~{000}~.js => main-Cp8Ma4bH.js
+- main-!~{000}~.js => main-D8FY9o6X.js
 
 # tests/rolldown/function/external/commonjs_reexport_external
 
-- main-!~{000}~.js => main-cfiHexIG.js
+- main-!~{000}~.js => main-jXDsGbNh.js
 
 # tests/rolldown/function/external/double-namespace-reexport
 
-- main-!~{000}~.js => main-C1bJcvAJ.js
+- main-!~{000}~.js => main-Dby57cR0.js
 
 # tests/rolldown/function/external/export_external
 
@@ -4291,7 +4291,7 @@ expression: output
 
 # tests/rolldown/function/external/splitting_indirect_external_symbol
 
-- main-!~{000}~.js => main-D46g0Eri.js
+- main-!~{000}~.js => main-CSqU2nZQ.js
 
 # tests/rolldown/function/external/splitting_with_external_module
 
@@ -4301,7 +4301,7 @@ expression: output
 
 # tests/rolldown/function/external_live_bindings
 
-- main-!~{000}~.js => main-B8aUep9f.js
+- main-!~{000}~.js => main-BFyeiS8B.js
 
 # tests/rolldown/function/file/css
 
@@ -4319,11 +4319,11 @@ expression: output
 
 # tests/rolldown/function/format/cjs/conflict_exports_key
 
-- main-!~{000}~.js => main-DXbGb_3B.js
+- main-!~{000}~.js => main-B-kvNpJT.js
 
 # tests/rolldown/function/format/cjs/import_export_unicode
 
-- main-!~{000}~.js => main-BsWcvfTH.js
+- main-!~{000}~.js => main-kPbz3_vg.js
 
 # tests/rolldown/function/format/cjs/plain_import_should_not_introduce_to_esm
 
@@ -4336,8 +4336,8 @@ expression: output
 
 # tests/rolldown/function/format/cjs/shared_entry_modules
 
-- entry1-!~{000}~.js => entry1-kxF07VlD.js
-- entry2-!~{001}~.js => entry2-XWD-058X.js
+- entry1-!~{000}~.js => entry1-BVN53gfZ.js
+- entry2-!~{001}~.js => entry2-pO5SITUl.js
 
 # tests/rolldown/function/format/esm/import_export_unicode
 
@@ -4353,15 +4353,15 @@ expression: output
 
 # tests/rolldown/function/format/export_proto_namespace
 
-- main-!~{000}~.js => main-DOVBuiuS.js
+- main-!~{000}~.js => main-HZ7ARoXf.js
 
 # tests/rolldown/function/format/iife/conflict_exports_key
 
-- main-!~{000}~.js => main-D8JHDTGU.js
+- main-!~{000}~.js => main-KDtwn0st.js
 
 # tests/rolldown/function/format/iife/conflict_exports_key_loop
 
-- main-!~{000}~.js => main-zFJen5PZ.js
+- main-!~{000}~.js => main-CA9CGoUl.js
 
 # tests/rolldown/function/format/iife/external_modules
 
@@ -4373,19 +4373,19 @@ expression: output
 
 # tests/rolldown/function/format/iife/iife_with_name
 
-- main-!~{000}~.js => main-Cs5fJW0V.js
+- main-!~{000}~.js => main-CWImEclR.js
 
 # tests/rolldown/function/format/iife/iife_with_name_with_minify
 
-- main-!~{000}~.js => main-BA6qDRj_.js
+- main-!~{000}~.js => main-flXbwRGB.js
 
 # tests/rolldown/function/format/iife/namespaced_name
 
-- main-!~{000}~.js => main-KV4fp_9m.js
+- main-!~{000}~.js => main-CrzQOnmF.js
 
 # tests/rolldown/function/format/iife/namespaced_name_reserved
 
-- main-!~{000}~.js => main-Bd98rPpn.js
+- main-!~{000}~.js => main-G0yDdX9u.js
 
 # tests/rolldown/function/format/iife/side_effect_only_external
 
@@ -4393,11 +4393,11 @@ expression: output
 
 # tests/rolldown/function/format/umd/conflict_exports_key
 
-- main-!~{000}~.js => main-D49IFcQQ.js
+- main-!~{000}~.js => main-DqP9h0PG.js
 
 # tests/rolldown/function/format/umd/conflict_exports_key_loop
 
-- main-!~{000}~.js => main-DbPZDLC3.js
+- main-!~{000}~.js => main-ChQFeiQk.js
 
 # tests/rolldown/function/format/umd/external_modules
 
@@ -4413,7 +4413,7 @@ expression: output
 
 # tests/rolldown/function/format/umd/namespaced_name_reserved
 
-- main-!~{000}~.js => main-CbRrEbie.js
+- main-!~{000}~.js => main-vd-hpavz.js
 
 # tests/rolldown/function/format/umd/side_effect_only_external
 
@@ -4429,7 +4429,7 @@ expression: output
 
 # tests/rolldown/function/inline_dynamic_imports/basic
 
-- main-!~{000}~.js => main-Bapc9Xl4.js
+- main-!~{000}~.js => main-CcTjYAxs.js
 
 # tests/rolldown/function/inline_dynamic_imports/issue-6935
 
@@ -4643,7 +4643,7 @@ expression: output
 
 # tests/rolldown/function/shim_missing_exports/basic_wrapped_esm
 
-- main-!~{000}~.js => main-hsEqE-uE.js
+- main-!~{000}~.js => main-DFUucV-l.js
 
 # tests/rolldown/function/shim_missing_exports/shake_unused_shimmed_exports
 
@@ -4797,10 +4797,10 @@ expression: output
 
 # tests/rolldown/issues/3650
 
-- main-!~{000}~.js => main-cl7qZVn_.js
-- first-!~{005}~.js => first-BYYHarZu.js
+- main-!~{000}~.js => main-CO4Uxhfl.js
+- first-!~{005}~.js => first-DO9M9-hf.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-vvRu2zEk.js
-- second-!~{003}~.js => second-B3DOFyUq.js
+- second-!~{003}~.js => second-BCdMOM6W.js
 
 # tests/rolldown/issues/3746/a
 
@@ -4851,7 +4851,7 @@ expression: output
 
 # tests/rolldown/issues/4459
 
-- main-!~{000}~.js => main-BhytnoTA.js
+- main-!~{000}~.js => main-CRVBueJY.js
 
 # tests/rolldown/issues/4472
 
@@ -4863,7 +4863,7 @@ expression: output
 
 # tests/rolldown/issues/4585
 
-- main-!~{000}~.js => main-qqQZYPJE.js
+- main-!~{000}~.js => main-B1GMfLtg.js
 
 # tests/rolldown/issues/4780
 
@@ -4891,7 +4891,7 @@ expression: output
 
 # tests/rolldown/issues/5044
 
-- main-!~{000}~.js => main-Bi1a19d7.js
+- main-!~{000}~.js => main-Dl96uXqy.js
 - cube-!~{001}~.js => cube-CPU7B1lQ.js
 - lib-!~{003}~.js => lib-3LCT-mx8.js
 
@@ -4909,9 +4909,9 @@ expression: output
 
 # tests/rolldown/issues/5387
 
-- main-!~{000}~.js => main-DTSU2bID.js
+- main-!~{000}~.js => main-nI3ZgA5n.js
 - _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-D2H1NnSh.js
-- liblib/index-!~{005}~.js => liblib/index-7k5lzW3I.js
+- liblib/index-!~{005}~.js => liblib/index-BdgjJjNn.js
 - liblib/lib-!~{003}~.js => liblib/lib-DtktNslO.js
 
 # tests/rolldown/issues/5482
@@ -4938,7 +4938,7 @@ expression: output
 
 # tests/rolldown/issues/5870
 
-- main-!~{000}~.js => main-CHzybDiW.js
+- main-!~{000}~.js => main-B45uLkW3.js
 
 # tests/rolldown/issues/5871
 
@@ -4985,8 +4985,8 @@ expression: output
 
 # tests/rolldown/issues/6513
 
-- main-!~{000}~.js => main-Cy8jHyag.js
-- dynamic-!~{001}~.js => dynamic-CjJBkbRj.js
+- main-!~{000}~.js => main-DuOeQMsN.js
+- dynamic-!~{001}~.js => dynamic-sKKxPRak.js
 
 # tests/rolldown/issues/6587
 
@@ -5001,13 +5001,13 @@ expression: output
 
 # tests/rolldown/issues/6651
 
-- main-!~{000}~.js => main-CT6tqEQX.js
+- main-!~{000}~.js => main-DUAgWtO5.js
 
 # tests/rolldown/issues/6660
 
-- index-!~{000}~.js => index-CGJNCiyY.js
-- c-!~{001}~.js => c-DAgEJIWk.js
-- e-!~{003}~.js => e-DbVrWDEC.js
+- index-!~{000}~.js => index-CSK_xCe5.js
+- c-!~{001}~.js => c-DlOIjhSX.js
+- e-!~{003}~.js => e-DI5XLdjw.js
 
 # tests/rolldown/issues/6756
 
@@ -5038,9 +5038,9 @@ expression: output
 
 # tests/rolldown/issues/6992
 
-- main-!~{000}~.js => main-coHrd27Y.js
-- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-i-iV_RSa.js
-- server/index-!~{003}~.js => server/index-2Zhk9aFS.js
+- main-!~{000}~.js => main-F7YsQNd4.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-rWNk89Nz.js
+- server/index-!~{003}~.js => server/index-D3FX5IWZ.js
 
 # tests/rolldown/issues/7021
 
@@ -5048,9 +5048,9 @@ expression: output
 
 # tests/rolldown/issues/7115
 
-- main-!~{000}~.js => main-WzLySSrW.js
-- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-khDlEcQL.js
-- server-!~{003}~.js => server-DOA4JQtF.js
+- main-!~{000}~.js => main-BzTXP3Ex.js
+- _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-l_zSX3-x.js
+- server-!~{003}~.js => server-D6QfZB4f.js
 
 # tests/rolldown/issues/7146
 
@@ -5066,13 +5066,13 @@ expression: output
 
 # tests/rolldown/issues/7233
 
-- index-!~{000}~.js => index-BTertlFf.js
+- index-!~{000}~.js => index-Z-MWepy9.js
 - _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-l_zSX3-x.js
 - server-!~{003}~.js => server-BKb4kYU8.js
 
 # tests/rolldown/issues/7233_chain
 
-- index-!~{000}~.js => index-D_G-o2m_.js
+- index-!~{000}~.js => index-Cu7G-7CV.js
 - _virtual/rolldown_runtime-!~{001}~.js => _virtual/rolldown_runtime-l_zSX3-x.js
 - middle-!~{005}~.js => middle-BSmECWHb.js
 - server-!~{003}~.js => server-DFjxxrlr.js
@@ -5083,7 +5083,7 @@ expression: output
 
 # tests/rolldown/issues/7384
 
-- main-!~{000}~.js => main-Bd-UmcB-.js
+- main-!~{000}~.js => main-2nvNgY3K.js
 
 # tests/rolldown/issues/7444
 
@@ -5100,7 +5100,7 @@ expression: output
 
 # tests/rolldown/issues/7773
 
-- main-!~{000}~.js => main-CjVLk02l.js
+- main-!~{000}~.js => main-CONGE20s.js
 
 # tests/rolldown/issues/7804
 
@@ -5125,7 +5125,7 @@ expression: output
 
 # tests/rolldown/issues/rolldown_vite_289
 
-- main-!~{000}~.js => main-C3t1M8qi.js
+- main-!~{000}~.js => main-ICaGt1Mh.js
 
 # tests/rolldown/issues/rolldown_vite_446
 
@@ -5198,7 +5198,7 @@ expression: output
 
 # tests/rolldown/misc/invalid_ident_repr
 
-- main-!~{000}~.js => main-HrmiIrKF.js
+- main-!~{000}~.js => main-CtW9Gjlj.js
 
 # tests/rolldown/misc/merge_external_import
 
@@ -5316,9 +5316,9 @@ expression: output
 
 # tests/rolldown/misc/reexport_star
 
-- entry-!~{001}~.js => entry-CAffeKTk.js
-- main-!~{000}~.js => main-jKEdOLVR.js
-- a-!~{002}~.js => a-5bffn5ds.js
+- entry-!~{001}~.js => entry-Dsc8t9kI.js
+- main-!~{000}~.js => main-qQDktygB.js
+- a-!~{002}~.js => a-bYnDQRaI.js
 
 # tests/rolldown/misc/reexport_star_from_local_named_export
 
@@ -5358,13 +5358,13 @@ expression: output
 
 # tests/rolldown/misc/wrapped_esm
 
-- main-!~{000}~.js => main-hIIRsBHo.js
-- main-hIIRsBHo.js.map
+- main-!~{000}~.js => main-RfFaWInz.js
+- main-RfFaWInz.js.map
 
 # tests/rolldown/optimization/chunk_merging/cjs_format
 
 - dep-!~{001}~.js => dep-DNFy2xKJ.js
-- main-!~{000}~.js => main-DoomfFj7.js
+- main-!~{000}~.js => main-BLsuWNS5.js
 
 # tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk
 
@@ -5374,13 +5374,13 @@ expression: output
 
 # tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_common_chunk2
 
-- main-!~{000}~.js => main-DwbFJsvM.js
-- imp-!~{005}~.js => imp-CoD1i-rZ.js
+- main-!~{000}~.js => main-DINIomB3.js
+- imp-!~{005}~.js => imp-BGIKs2ms.js
 - rolldown-runtime-!~{001}~.js => rolldown-runtime-HJ3UrVuY.js
 
 # tests/rolldown/optimization/chunk_merging/dynamic_entry_merged_in_user_defined_entry
 
-- entry-!~{000}~.js => entry-CEANyBgQ.js
+- entry-!~{000}~.js => entry-BvmvqiL-.js
 
 # tests/rolldown/optimization/chunk_merging/dynamic_import_cjs_same_chunk
 
@@ -5388,7 +5388,7 @@ expression: output
 
 # tests/rolldown/optimization/chunk_merging/issue_4905
 
-- main-!~{000}~.js => main-yZs-Mq7e.js
+- main-!~{000}~.js => main-NlUCWxy0.js
 
 # tests/rolldown/optimization/inline_const/5197
 
@@ -5507,11 +5507,11 @@ expression: output
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry
 
-- entry-!~{000}~.js => entry-xjzaSOgk.js
+- entry-!~{000}~.js => entry-BAzGfKmN.js
 
 # tests/rolldown/semantic/export_star_from_external_as_wrapped_entry_cjs
 
-- entry-!~{000}~.js => entry-BoJBefRw.js
+- entry-!~{000}~.js => entry-DSIB41Cw.js
 
 # tests/rolldown/sourcemap/css_sourcemap_reference
 
@@ -5537,7 +5537,7 @@ expression: output
 # tests/rolldown/sourcemap/live_binding
 
 - main1-!~{000}~.js => main1-DuhB17iW.js
-- main2-!~{001}~.js => main2-DJ4J9Dvy.js
+- main2-!~{001}~.js => main2-BFWt5NjJ.js
 - shared-!~{002}~.js => shared-Bisfm5lw.js
 - main1-DuhB17iW.js.map
 - shared-Bisfm5lw.js.map
@@ -5552,7 +5552,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/1
 
-- entry-!~{000}~.js => entry-BuF4UrxC.js
+- entry-!~{000}~.js => entry-C7vxd9dh.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/10
 
@@ -5564,11 +5564,11 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/12
 
-- entry-!~{000}~.js => entry-BMvQKGNA.js
+- entry-!~{000}~.js => entry-Cdys8K76.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/13
 
-- entry-!~{000}~.js => entry-CG_H5vLu.js
+- entry-!~{000}~.js => entry-Cteu25zI.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/14
 
@@ -5580,19 +5580,19 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/16
 
-- entry-!~{000}~.js => entry-BECIFGSk.js
+- entry-!~{000}~.js => entry-t0z-zM12.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/17
 
-- entry-!~{000}~.js => entry-C3skg_Ji.js
+- entry-!~{000}~.js => entry-DeVl7tGZ.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/18
 
-- entry-!~{000}~.js => entry-Dy53xtBV.js
+- entry-!~{000}~.js => entry-BJK7miFZ.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/19
 
-- entry-!~{000}~.js => entry-yMgn5zAq.js
+- entry-!~{000}~.js => entry-C68pESN8.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/2
 
@@ -5600,27 +5600,27 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/20
 
-- entry-!~{000}~.js => entry-Dhf8rkJZ.js
+- entry-!~{000}~.js => entry-Bgw5pSkO.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/21
 
-- entry-!~{000}~.js => entry-CvJCWYpr.js
+- entry-!~{000}~.js => entry-BHLNpY64.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/22
 
-- entry-!~{000}~.js => entry-C5JtvjUT.js
+- entry-!~{000}~.js => entry-4RMGKpBl.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/23
 
-- entry-!~{000}~.js => entry-B1TBorC9.js
+- entry-!~{000}~.js => entry-DyTTZONc.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/24
 
-- entry-!~{000}~.js => entry-CtFiVmS1.js
+- entry-!~{000}~.js => entry-CrJZuo6-.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/25
 
-- entry-!~{000}~.js => entry-DdDxIQYT.js
+- entry-!~{000}~.js => entry-DZy8r-58.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/26
 
@@ -5640,7 +5640,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/3
 
-- entry-!~{000}~.js => entry-BMbCISWD.js
+- entry-!~{000}~.js => entry-CLGPJms9.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/30
 
@@ -5694,7 +5694,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/41
 
-- entry-!~{000}~.js => entry-BedQqpmy.js
+- entry-!~{000}~.js => entry-VdS_Mwq3.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/42
 
@@ -5702,7 +5702,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/43
 
-- entry-!~{000}~.js => entry-DrVfrXgD.js
+- entry-!~{000}~.js => entry-D05yuG-X.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/44
 
@@ -5710,15 +5710,15 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/45
 
-- entry-!~{000}~.js => entry-enM5gW4O.js
+- entry-!~{000}~.js => entry-BP9QTjg7.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/46
 
-- entry-!~{000}~.js => entry-CPK6rwiQ.js
+- entry-!~{000}~.js => entry-Fj0laKpR.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/47
 
-- entry-!~{000}~.js => entry-Dz43LVnR.js
+- entry-!~{000}~.js => entry-B2_yw0Io.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/48
 
@@ -5798,7 +5798,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/7
 
-- entry-!~{000}~.js => entry-CCm3EQlJ.js
+- entry-!~{000}~.js => entry-DbTMCL_J.js
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/8
 
@@ -5806,7 +5806,7 @@ expression: output
 
 # tests/rolldown/topics/bundler_esm_cjs_tests/9
 
-- entry-!~{000}~.js => entry-DokfWfHX.js
+- entry-!~{000}~.js => entry-CHLO5rQx.js
 
 # tests/rolldown/topics/chunk_modules_order/basic
 
@@ -5818,11 +5818,11 @@ expression: output
 
 # tests/rolldown/topics/cjs_module_lexer_compat/exports
 
-- main-!~{000}~.js => main-B89Pmjkg.js
+- main-!~{000}~.js => main-DVwQ_ya4.js
 
 # tests/rolldown/topics/cjs_module_lexer_compat/import_and_reexport
 
-- main-!~{000}~.js => main-BBLTFHyN.js
+- main-!~{000}~.js => main-CebfAfqX.js
 
 # tests/rolldown/topics/css/align_vite
 
@@ -5930,13 +5930,13 @@ expression: output
 
 # tests/rolldown/topics/deconflict/wrapped_esm_default_function
 
-- main-!~{000}~.js => main-zvRHTHSF.js
-- main-zvRHTHSF.js.map
+- main-!~{000}~.js => main-BCT51Gbs.js
+- main-BCT51Gbs.js.map
 
 # tests/rolldown/topics/deconflict/wrapped_esm_export_named_function
 
-- main-!~{000}~.js => main-BBWadIJJ.js
-- main-BBWadIJJ.js.map
+- main-!~{000}~.js => main-UvJ2GaTW.js
+- main-UvJ2GaTW.js.map
 
 # tests/rolldown/topics/exports/common_cjs_named_default
 
@@ -5958,35 +5958,35 @@ expression: output
 # tests/rolldown/topics/exports/entry_cjs_named_default
 
 - lib-!~{001}~.js => lib-BBrptxjO.js
-- main-!~{000}~.js => main-WzK6-4yf.js
+- main-!~{000}~.js => main-C8nrbPDK.js
 
 # tests/rolldown/topics/exports/entry_cjs_named_named
 
 - lib-!~{001}~.js => lib-C0fXHNYz.js
-- main-!~{000}~.js => main-gHop2WPi.js
+- main-!~{000}~.js => main-DMrjlJUO.js
 - lib-!~{002}~.js => lib-B6ImgDSc.js
 
 # tests/rolldown/topics/exports/entry_esm_named_default
 
-- lib-!~{001}~.js => lib-CJPmTEFW.js
-- main-!~{000}~.js => main-DftzedCv.js
+- lib-!~{001}~.js => lib-D80SPeeG.js
+- main-!~{000}~.js => main-D148eubq.js
 - lib-!~{002}~.js => lib-DOoXVbVu.js
 
 # tests/rolldown/topics/exports/entry_esm_named_named
 
-- lib-!~{001}~.js => lib-DLl_zaLU.js
-- main-!~{000}~.js => main-Ls5CJH0_.js
+- lib-!~{001}~.js => lib-frxO7d8e.js
+- main-!~{000}~.js => main-pbShoIeg.js
 - lib-!~{002}~.js => lib-D-SnpJv5.js
 
 # tests/rolldown/topics/exports/entry_none_named_default
 
-- lib-!~{001}~.js => lib-DxVMVZnn.js
-- main-!~{000}~.js => main-CjIVNZec.js
+- lib-!~{001}~.js => lib-D1xiZjhs.js
+- main-!~{000}~.js => main-CaQiZv3J.js
 
 # tests/rolldown/topics/exports/entry_none_named_named
 
-- lib-!~{001}~.js => lib-BUNQ6UJ4.js
-- main-!~{000}~.js => main-DuafnD-Y.js
+- lib-!~{001}~.js => lib-Bg92p399.js
+- main-!~{000}~.js => main-C2AEQuys.js
 
 # tests/rolldown/topics/generated_code/reexports_esm_dynamic
 
@@ -6037,7 +6037,7 @@ expression: output
 
 # tests/rolldown/topics/keep_names/declaration2
 
-- main-!~{000}~.js => main-CvDfXv9K.js
+- main-!~{000}~.js => main-DQ8oZ_pl.js
 
 # tests/rolldown/topics/keep_names/expression
 
@@ -6053,8 +6053,8 @@ expression: output
 
 # tests/rolldown/topics/keep_names/issue_5525
 
-- entry-!~{000}~.js => entry--6zdr56O.js
-- entry2-!~{001}~.js => entry2-Eow-pZuM.js
+- entry-!~{000}~.js => entry-DnACirsZ.js
+- entry2-!~{001}~.js => entry2-CthO9IoE.js
 - foo-!~{002}~.js => foo-V6MEsHyi.js
 
 # tests/rolldown/topics/keep_names/issue_7481
@@ -6083,7 +6083,7 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/default_export_binding_cjs
 
-- main-!~{000}~.js => main-DKm0xrtI.js
+- main-!~{000}~.js => main-CWR5rOHl.js
 
 # tests/rolldown/topics/live_bindings/default_export_binding_in_common_chunks
 
@@ -6097,8 +6097,8 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/default_export_decl
 
-- foo-!~{001}~.js => foo-MB3bvGi-.js
-- main-!~{000}~.js => main-BXlmIqSf.js
+- foo-!~{001}~.js => foo-BG0shzn9.js
+- main-!~{000}~.js => main-CO9b5zLf.js
 
 # tests/rolldown/topics/live_bindings/default_export_expr
 
@@ -6106,7 +6106,7 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/default_export_expr_cjs
 
-- main-!~{000}~.js => main-BwdIKSnv.js
+- main-!~{000}~.js => main-DQaOeI0y.js
 
 # tests/rolldown/topics/live_bindings/default_export_expr_in_common_chunks
 
@@ -6120,7 +6120,7 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/default_export_snapshot_not_live
 
-- main-!~{000}~.js => main-CVbT3w-K.js
+- main-!~{000}~.js => main-DPM6R7Wv.js
 
 # tests/rolldown/topics/live_bindings/named_exports
 
@@ -6128,7 +6128,7 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/named_exports_cjs
 
-- main-!~{000}~.js => main-DCttS5sr.js
+- main-!~{000}~.js => main-D2PIadEV.js
 
 # tests/rolldown/topics/live_bindings/named_exports_in_common_chunks
 
@@ -6137,12 +6137,12 @@ expression: output
 
 # tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs
 
-- main-!~{000}~.js => main-BH7A1AV7.js
-- async-entry-!~{001}~.js => async-entry-CsMLzOr2.js
+- main-!~{000}~.js => main-CtruHxck.js
+- async-entry-!~{001}~.js => async-entry-DfG5m9H4.js
 
 # tests/rolldown/topics/live_bindings/on_demand_shorthand_pattern_cjs
 
-- main-!~{000}~.js => main-BEkYBMuZ.js
+- main-!~{000}~.js => main--plqeEzE.js
 
 # tests/rolldown/topics/new_url/dataurl
 
@@ -6182,7 +6182,7 @@ expression: output
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_cjs
 
-- main-!~{000}~.js => main-Brnm2XRt.js
+- main-!~{000}~.js => main-Bxknbpem.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries
 
@@ -6191,22 +6191,22 @@ expression: output
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_shared_entries_cjs
 
-- entry-!~{000}~.js => entry-D81lP1Oc.js
-- entry2-!~{001}~.js => entry2-BGA5rrZE.js
+- entry-!~{000}~.js => entry-D-khdwio.js
+- entry2-!~{001}~.js => entry2-CsbTCSs6.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped
 
-- main-!~{000}~.js => main-D2aaJgHN.js
+- main-!~{000}~.js => main-DpJX5ZFB.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_and_shared_entries
 
-- entry-!~{000}~.js => entry-QtGJ_nlM.js
-- entry2-!~{001}~.js => entry2-DLApVbrH.js
-- main-!~{002}~.js => main-D-XT4sEn.js
+- entry-!~{000}~.js => entry-DFKz1dKj.js
+- entry2-!~{001}~.js => entry2-CyaS7JWG.js
+- main-!~{002}~.js => main-CfiB-sgx.js
 
 # tests/rolldown/topics/preserve_semantic_of_entries_exports/named_export_in_wrapped_cjs
 
-- main-!~{000}~.js => main-yYbp7LHV.js
+- main-!~{000}~.js => main-fwWloUYM.js
 
 # tests/rolldown/topics/tla/basic
 
@@ -6214,7 +6214,7 @@ expression: output
 
 # tests/rolldown/topics/tla/inline_dynamic_import
 
-- main-!~{000}~.js => main-CwmTCtKS.js
+- main-!~{000}~.js => main-CxaMAGL1.js
 
 # tests/rolldown/topics/tla/inside_try_block
 
@@ -6246,7 +6246,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/commonjs
 
-- main-!~{000}~.js => main-DbroDfWT.js
+- main-!~{000}~.js => main-qK3fhr5m.js
 
 # tests/rolldown/tree_shaking/commonjs_5546
 
@@ -6254,7 +6254,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/commonjs_inline_const
 
-- main-!~{000}~.js => main-DaD2Ye4g.js
+- main-!~{000}~.js => main-BN2wiFCV.js
 
 # tests/rolldown/tree_shaking/commonjs_mixed
 
@@ -6328,7 +6328,7 @@ expression: output
 
 # tests/rolldown/tree_shaking/export_star
 
-- main-!~{000}~.js => main-Bl0LkFgN.js
+- main-!~{000}~.js => main-BsixLUy4.js
 
 # tests/rolldown/tree_shaking/export_star2
 
@@ -6357,8 +6357,8 @@ expression: output
 
 # tests/rolldown/tree_shaking/issue_4682
 
-- main-!~{000}~.js => main-DfW3c0hF.js
-- dynamic-!~{003}~.js => dynamic-B0UI9oTX.js
+- main-!~{000}~.js => main-B0Pg7IKo.js
+- dynamic-!~{003}~.js => dynamic-B0pR9m34.js
 
 # tests/rolldown/tree_shaking/json_default_import
 
@@ -6425,7 +6425,7 @@ expression: output
 
 # tests/rolldown/warnings/cannot_call_namespace
 
-- main-!~{000}~.js => main-lvdvs7gx.js
+- main-!~{000}~.js => main-DVJXO6A2.js
 
 # tests/rolldown/warnings/commonjs_variable_in_esm/1
 
@@ -6470,7 +6470,7 @@ expression: output
 
 # tests/rolldown/warnings/invalid_option/unsupported_inline_dynamic_format
 
-- main-!~{000}~.js => main-DYafMd5P.js
+- main-!~{000}~.js => main-C5wO3keC.js
 
 # tests/rolldown/warnings/minified-with-eval
 
@@ -6486,7 +6486,7 @@ expression: output
 
 # tests/rolldown/warnings/mixed_export
 
-- main-!~{000}~.js => main-C2--WjG8.js
+- main-!~{000}~.js => main-DV282-HF.js
 
 # tests/rolldown/warnings/none-ascii-content
 

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -47,7 +47,7 @@ fn normalize_generated_code_option(
     }
     None => GeneratedCodeOptions::default(),
   };
-  Ok(GeneratedCodeOptions { symbols: value.symbols.unwrap_or(v.symbols), ..v })
+  Ok(GeneratedCodeOptions { symbols: value.symbols.unwrap_or(v.symbols) })
 }
 
 fn normalize_addon_option(

--- a/crates/rolldown_common/src/inner_bundler_options/types/generated_code_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/generated_code_options.rs
@@ -2,11 +2,10 @@
 use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::Deserialize;
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "deserialize_bundler_options", derive(Deserialize, JsonSchema))]
 #[cfg_attr(feature = "deserialize_bundler_options", serde(rename_all = "camelCase"))]
 pub struct GeneratedCodeOptions {
-  pub preset: Option<GeneratedCodePreset>,
   // pub arrow_functions: bool,
   // pub const_bindings: bool,
   // pub object_shorthand: bool,
@@ -14,20 +13,18 @@ pub struct GeneratedCodeOptions {
   pub symbols: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "deserialize_bundler_options", derive(Deserialize, JsonSchema))]
-#[cfg_attr(feature = "deserialize_bundler_options", serde(rename_all = "camelCase"))]
-pub enum GeneratedCodePreset {
-  Es5,
-  Es2015,
+impl Default for GeneratedCodeOptions {
+  fn default() -> Self {
+    Self::es2015()
+  }
 }
 
 impl GeneratedCodeOptions {
   pub fn es5() -> Self {
-    Self { symbols: false, preset: None }
+    Self { symbols: false }
   }
 
   pub fn es2015() -> Self {
-    Self { symbols: true, preset: None }
+    Self { symbols: true }
   }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -629,29 +629,12 @@
     "GeneratedCodeOptions": {
       "type": "object",
       "properties": {
-        "preset": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/GeneratedCodePreset"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "symbols": {
           "type": "boolean"
         }
       },
       "required": [
         "symbols"
-      ]
-    },
-    "GeneratedCodePreset": {
-      "type": "string",
-      "enum": [
-        "es5",
-        "es2015"
       ]
     },
     "SourceMapType": {

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -182,6 +182,7 @@ exports[`cli options for bundling > should handle multiple define arguments with
 exports[`cli options for bundling > should handle negative boolean options 1`] = `
 "(function(exports, node_fs) {
 
+Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
 //#region index.ts
 	const nonExternal = "nonExternal";

--- a/packages/rolldown/tests/fixtures/output/es-module/common-chunks/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/common-chunks/_config.ts
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module';
 import type { OutputChunk as RolldownOutputChunk } from 'rolldown';
 import { defineTest } from 'rolldown-tests';
 import { expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 
 export default defineTest({
   config: {
@@ -11,13 +14,13 @@ export default defineTest({
     },
   },
   afterTest: (output) => {
+    fs.writeFileSync(path.join(import.meta.dirname, 'dist/package.json'), '{ "type": "commonjs" }');
+    const require = createRequire(import.meta.url);
     expect(
       output.output
-        .filter((output) => output.type === 'chunk' && output.isEntry)
+        .filter((output): output is RolldownOutputChunk => output.type === 'chunk' && output.isEntry)
         .every((chunk) =>
-          (chunk as RolldownOutputChunk).code.includes(
-            "Object.defineProperty(exports, '__esModule', { value: true });",
-          )
+          require(`./dist/${chunk.fileName}`).__esModule
         ),
     ).toBe(true);
   },

--- a/packages/rolldown/tests/fixtures/output/es-module/common-chunks/main.js
+++ b/packages/rolldown/tests/fixtures/output/es-module/common-chunks/main.js
@@ -1,3 +1,5 @@
+import assert from 'node:assert';
+
 import('./shared').then((imported) => {
   assert.strictEqual(imported.shared, 'shared');
 });

--- a/packages/rolldown/tests/fixtures/output/es-module/false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/false/_config.ts
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module';
 import type { OutputChunk as RolldownOutputChunk } from 'rolldown';
 import { defineTest } from 'rolldown-tests';
 import { expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 
 export default defineTest({
   config: {
@@ -11,14 +14,13 @@ export default defineTest({
     },
   },
   afterTest: (output) => {
+    fs.writeFileSync(path.join(import.meta.dirname, 'dist/package.json'), '{ "type": "commonjs" }');
+    const require = createRequire(import.meta.url);
     expect(
       output.output
-        .filter(({ type }) => type === 'chunk')
-        .every(
-          (chunk) =>
-            !(chunk as RolldownOutputChunk).code.includes(
-              "Object.defineProperty(exports, '__esModule', { value: true });",
-            ),
+        .filter((output): output is RolldownOutputChunk => output.type === 'chunk' && output.isEntry)
+        .every((chunk) =>
+          !require(`./dist/${chunk.fileName}`).__esModule
         ),
     ).toBe(true);
   },

--- a/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-false/_config.ts
@@ -1,35 +1,28 @@
+import { createRequire } from 'node:module';
 import type { OutputChunk as RolldownOutputChunk } from 'rolldown';
 import { defineTest } from 'rolldown-tests';
 import { expect, vi } from 'vitest';
-
-const onLogFn = vi.fn();
+import fs from 'node:fs';
+import path from 'node:path';
 
 export default defineTest({
   sequential: true,
   config: {
     output: {
+      name: 'bundle.nested',
       exports: 'named',
       format: 'iife',
       esModule: 'if-default-prop',
     },
-    onLog(level, log) {
-      expect(level).toBe('warn');
-      expect(log.code).toBe('MISSING_NAME_OPTION_FOR_IIFE_EXPORT');
-      expect(log.plugin).toBeUndefined();
-      onLogFn();
-    },
   },
   afterTest: (output) => {
-    expect(onLogFn).toHaveBeenCalledTimes(1);
-
+    fs.writeFileSync(path.join(import.meta.dirname, 'dist/package.json'), '{ "type": "commonjs" }');
+    const require = createRequire(import.meta.url);
     expect(
       output.output
-        .filter(({ type }) => type === 'chunk')
-        .every(
-          (chunk) =>
-            !(chunk as RolldownOutputChunk).code.includes(
-              "Object.defineProperty(exports, '__esModule', { value: true });",
-            ),
+        .filter((output): output is RolldownOutputChunk => output.type === 'chunk' && output.isEntry)
+        .every((chunk) =>
+          !require(`./dist/${chunk.fileName}`).bundle.nested.__esModule
         ),
     ).toBe(true);
   },

--- a/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/es-module/if-default-prop-true/_config.ts
@@ -1,34 +1,28 @@
+import { createRequire } from 'node:module';
 import type { OutputChunk as RolldownOutputChunk } from 'rolldown';
 import { defineTest } from 'rolldown-tests';
 import { expect, vi } from 'vitest';
-
-const onLogFn = vi.fn();
+import fs from 'node:fs';
+import path from 'node:path';
 
 export default defineTest({
   sequential: true,
   config: {
     output: {
+      name: 'bundle.nested',
       exports: 'named',
       format: 'iife',
       esModule: 'if-default-prop',
     },
-    onLog(level, log) {
-      expect(level).toBe('warn');
-      expect(log.code).toBe('MISSING_NAME_OPTION_FOR_IIFE_EXPORT');
-      expect(log.plugin).toBeUndefined();
-      onLogFn();
-    },
   },
   afterTest: (output) => {
-    expect(onLogFn).toHaveBeenCalledTimes(1);
-
+    fs.writeFileSync(path.join(import.meta.dirname, 'dist/package.json'), '{ "type": "commonjs" }');
+    const require = createRequire(import.meta.url);
     expect(
       output.output
-        .filter(({ type }) => type === 'chunk')
+        .filter((output): output is RolldownOutputChunk => output.type === 'chunk' && output.isEntry)
         .every((chunk) =>
-          (chunk as RolldownOutputChunk).code.includes(
-            "Object.defineProperty(exports, '__esModule', { value: true });",
-          ),
+          require(`./dist/${chunk.fileName}`).bundle.nested.__esModule
         ),
     ).toBe(true);
   },

--- a/packages/rolldown/tests/fixtures/output/extend/false/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/extend/false/_config.ts
@@ -15,6 +15,7 @@ export default defineTest({
     expect(output.output[0].code).toMatchInlineSnapshot(`
       "var module = (function(exports) {
 
+      Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
       //#region main.js
       	const main = "main";

--- a/packages/rolldown/tests/fixtures/output/extend/true/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/extend/true/_config.ts
@@ -15,6 +15,7 @@ export default defineTest({
     expect(output.output[0].code).toMatchInlineSnapshot(`
       "(function(exports) {
 
+      Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
       //#region main.js
       	const main = "main";

--- a/packages/rolldown/tests/fixtures/output/extend/undefined/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/extend/undefined/_config.ts
@@ -14,6 +14,7 @@ export default defineTest({
     expect(output.output[0].code).toMatchInlineSnapshot(`
       "var module = (function(exports) {
 
+      Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 
       //#region main.js
       	const main = "main";

--- a/packages/rolldown/tests/fixtures/output/format/iife/exports/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/format/iife/exports/_config.ts
@@ -29,7 +29,7 @@ export default defineTest({
     expect(output.output[0].code).toMatchInlineSnapshot(`
       "(function(exports, node_path) {
 
-      Object.defineProperty(exports, '__esModule', { value: true });
+      Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });
 
       //#region main.js
       	var main_default = node_path.join;

--- a/packages/rolldown/tests/fixtures/output/generated-code/default/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/generated-code/default/_config.ts
@@ -1,0 +1,14 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    output: {
+      format: 'cjs',
+    },
+  },
+  afterTest: (output) => {
+    // preset defaults to `'es2015'` which should set symbols: true, which includes Symbol.toStringTag
+    expect(output.output[0].code).toContain('Symbol.toStringTag');
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/generated-code/default/main.js
+++ b/packages/rolldown/tests/fixtures/output/generated-code/default/main.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/packages/rollup-tests/test/form/index.js
+++ b/packages/rollup-tests/test/form/index.js
@@ -68,7 +68,9 @@ runTestSuiteWithSamples(
 								format: defaultFormat,
 								validate: true,
 								keepNames: directory.includes('assignment-to-exports-class-declaration') ? true : false,
-								...(config.options || {}).output
+								...(config.options || {}).output,
+								// Rolldown uses `generatedCode.preset: 'es2015'` by default
+								generatedCode: { preset: 'es5', ...config.options?.output?.generatedCode },
 							},
 							bundleFile,
 							config

--- a/packages/rollup-tests/test/function/index.js
+++ b/packages/rollup-tests/test/function/index.js
@@ -140,7 +140,9 @@ runTestSuiteWithSamples(
 							.generate({
 								exports: 'auto',
 								format: 'cjs',
-								...(config.options || {}).output
+								...(config.options || {}).output,
+								// Rolldown uses `generatedCode.preset: 'es2015'` by default
+								generatedCode: { preset: 'es5', ...config.options?.output?.generatedCode },
 							})
 							.then(({ output }) => {
 								if (config.error || config.generateError) {


### PR DESCRIPTION
`output.generatedCode` should have `'es2015'` set by default, but it wasn't.

fixes #8017
