### PR TITLE
refactor: use `FxIndexMap` to store EntryPoint

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_ext.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_ext.rs
@@ -67,10 +67,11 @@ impl ChunkDebugExt for Chunk {
         let entries = link_output
           .entries
           .iter()
+          .flat_map(|(idx, entries)| entries.iter().map(move |_| idx))
           .enumerate()
-          .filter_map(|(index, entry_point)| {
+          .filter_map(|(index, &module_idx)| {
             if bits.has_bit(index.try_into().unwrap()) {
-              let entry_module = &link_output.module_table[entry_point.idx];
+              let entry_module = &link_output.module_table[module_idx];
               Some(entry_module.stable_id().to_string())
             } else {
               None

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -50,11 +50,16 @@ impl GenerateStage<'_> {
         ChunkKind::Common => None,
       })
       .collect::<FxHashMap<ModuleIdx, ChunkIdx>>();
-    for entry in self.link_output.entries.iter().filter(|item| item.kind.is_user_defined()) {
-      let Some(entry_chunk_idx) = chunk_graph.module_to_chunk[entry.idx] else {
+    for (&module_idx, _entry_points) in self
+      .link_output
+      .entries
+      .iter()
+      .filter(|(_, entries)| entries.iter().any(|e| e.kind.is_user_defined()))
+    {
+      let Some(entry_chunk_idx) = chunk_graph.module_to_chunk[module_idx] else {
         continue;
       };
-      let mut q = VecDeque::from_iter([entry.idx]);
+      let mut q = VecDeque::from_iter([module_idx]);
       let mut visited = FxHashSet::default();
       while let Some(cur) = q.pop_front() {
         if visited.contains(&cur) {

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -55,7 +55,8 @@ impl LinkStage<'_> {
       |ecma_module| {
         let linking_info = &mut self.metas[ecma_module.idx];
 
-        if let Some(entry) = self.entries.iter().find(|entry| entry.idx == ecma_module.idx) {
+        if let Some(entry) = self.entries.get(&ecma_module.idx).and_then(|entries| entries.first())
+        {
           init_entry_point_stmt_info(
             linking_info,
             entry,

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -121,7 +121,7 @@ impl LinkStage<'_> {
     // collect all modules that has dynamic import record
     // two dimension map module_idx -> stmt_idx -> dynamic_import_expression_address
     let mut module_idx_and_stmt_idx_to_dynamic_import_expr_addr_map = FxHashMap::default();
-    self.entries.iter().for_each(|entry| {
+    self.entries.values().flatten().for_each(|entry| {
       entry.related_stmt_infos.iter().for_each(
         |(module_idx, stmt_idx, address, _import_record_idx)| {
           module_idx_and_stmt_idx_to_dynamic_import_expr_addr_map

--- a/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
+++ b/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
@@ -1,7 +1,6 @@
 use std::ptr::addr_of;
 
 use rolldown_common::{ExportsKind, ImportKind, ImportRecordMeta, Module, OutputFormat, WrapKind};
-use rustc_hash::FxHashSet;
 
 use crate::utils::external_import_interop::import_record_needs_interop;
 
@@ -10,7 +9,6 @@ use super::LinkStage;
 impl LinkStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
   pub(super) fn determine_module_exports_kind(&mut self) {
-    let entry_ids_set = self.entries.iter().map(|e| e.idx).collect::<FxHashSet<_>>();
     self.module_table.modules.iter().filter_map(Module::as_normal).for_each(|importer| {
       // TODO(hyf0): should check if importer is a js module
       importer
@@ -84,7 +82,7 @@ impl LinkStage<'_> {
           }
         });
 
-      let is_entry = entry_ids_set.contains(&importer.idx);
+      let is_entry = self.entries.contains_key(&importer.idx);
       if matches!(importer.exports_kind, ExportsKind::CommonJs)
         && (!is_entry || matches!(self.options.format, OutputFormat::Esm))
       {

--- a/crates/rolldown/src/stages/link_stage/sort_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/sort_modules.rs
@@ -34,9 +34,9 @@ impl LinkStage<'_> {
     // The runtime module should always be the first module to be executed
     let mut execution_stack = self
       .entries
-      .iter()
+      .keys()
       .rev()
-      .map(|entry| Status::ToBeExecuted(entry.idx))
+      .map(|&module_idx| Status::ToBeExecuted(module_idx))
       .chain(iter::once(Status::ToBeExecuted(self.runtime.id())))
       .collect::<Vec<_>>();
 


### PR DESCRIPTION
This modification make get the dynamic importer of dynamic entry module more easy(Used in chunk optimizer).  
Also use `FxIndexMap` to store `EntryPoint` could speed up lookup performance in some place