### PR TITLE
perf(rolldown): Ident optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,9 +226,9 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bpaf"
-version = "0.9.20"
+version = "0.9.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473976d7a8620bb1e06dcdd184407c2363fe4fec8e983ee03ed9197222634a31"
+checksum = "4ffe12d9bbc54238745f1749c5a18dc5759e03c235618dd05554a9be350390b1"
 
 [[package]]
 name = "bstr"
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.46"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -348,7 +348,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -381,11 +381,11 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -492,7 +492,7 @@ dependencies = [
  "cast",
  "ciborium",
  "codspeed",
- "colored 3.0.0",
+ "colored 3.1.1",
  "num-traits",
  "oorandom",
  "serde",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffc71fcdcdb40d6f087edddf7f8f1f8f79e6cf922f555a9ee8779752d4819bd"
+checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
@@ -725,7 +725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -777,21 +777,20 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "fixedbitset"
@@ -1131,9 +1130,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1145,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -1262,7 +1261,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1294,9 +1293,9 @@ checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1372,9 +1371,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libloading"
@@ -1399,13 +1398,13 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -1431,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "ls-lint"
@@ -1481,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
@@ -1613,7 +1612,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1657,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-format"
@@ -1771,8 +1770,7 @@ dependencies = [
 [[package]]
 name = "oxc"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fb7ab16506c9d7979a21cf0c8750bfb34b7ee3f787310ba06aaa8eea3602f"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1804,7 +1802,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -1818,7 +1816,7 @@ dependencies = [
  "owo-colors",
  "oxc-miette-derive",
  "textwrap",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1837,8 +1835,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2174c7c8f77137b1bd1c653d7a5a531ae41f3b8fec1dd0251c801689784e7a2e"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.16.1",
@@ -1851,8 +1848,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f1902f97a5cac8767b76a1d8a1b3124e9db80c176ebbc98f75143dcc124a15"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "bitflags 2.10.0",
  "oxc_allocator",
@@ -1868,8 +1864,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a31bd55516a98a35b2d99fa5813a3d3a5b798bad3262c819dfe7344bc6f390"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1880,8 +1875,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c520a488c04ba5267223edd0bb245fb7f10e2358e8955802a5d962bb95b50a"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1892,8 +1886,7 @@ dependencies = [
 [[package]]
 name = "oxc_cfg"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be287b1981226fb5c03be2a3d7bacec8e6bf3a6f8c8d7df034f69f9a378c77c"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "bitflags 2.10.0",
  "itertools",
@@ -1906,8 +1899,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfd3d146e6e0d340c183aa0e98f29ab1bba876c282350e5e06ab9d6f536eacd"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "bitflags 2.10.0",
  "cow-utils",
@@ -1927,8 +1919,7 @@ dependencies = [
 [[package]]
 name = "oxc_compat"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7319f12eb8d4a05737a7f71642d7a97aee210488dc4041a7a452352a31ac0fe6"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
@@ -1940,8 +1931,7 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42840ce8d83a08a92823dda6189e4d97359feca24a4fa732f3256c4614bb5a4"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "ropey",
 ]
@@ -1949,8 +1939,7 @@ dependencies = [
 [[package]]
 name = "oxc_diagnostics"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f7b09c1563a67ede53af131f717b31ba89a992959ebad188b5158c21d4dc0a"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1960,8 +1949,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4813b352bd5b0b05badf0c9e6c5ec7ea58a6a7ab49bec8d18ead262624c6ef8d"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1976,8 +1964,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54fb3effe995e6538d68070bf0a450b5ffd11dd41b62f11a4d01efa1f40e278"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
@@ -1998,8 +1985,7 @@ dependencies = [
 [[package]]
 name = "oxc_isolated_declarations"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb86ea9fb51eafba2d6dcecf190ba8f6d4936d1741e1ac7b46b6f52074237554"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "bitflags 2.10.0",
  "oxc_allocator",
@@ -2015,8 +2001,7 @@ dependencies = [
 [[package]]
 name = "oxc_mangler"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d18a10fd5172c1c73ad42fc2733a213408f332942ce44b90c131ead6de7465"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -2032,8 +2017,7 @@ dependencies = [
 [[package]]
 name = "oxc_minifier"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8382ff66d312b3ed4e7ad2dda1a2c1784f04ea09d6941f32a3ed954be73d4d51"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
@@ -2056,8 +2040,7 @@ dependencies = [
 [[package]]
 name = "oxc_minify_napi"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09718daa9d56ab8cf7b97285c20ecd0a631d746e59e7d716355800046b3df3e3"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "napi",
  "napi-build",
@@ -2076,8 +2059,7 @@ dependencies = [
 [[package]]
 name = "oxc_napi"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7d7902d9fadf224ad77fd8c4d5f9787d8cc5911ba6c94d8edea1117aa8660b"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "napi",
  "napi-build",
@@ -2092,8 +2074,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5592bf8b64743944eb46528f9eabdde2b2435c8293cd502f5c183f9dff644e16"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "bitflags 2.10.0",
  "cow-utils",
@@ -2115,8 +2096,7 @@ dependencies = [
 [[package]]
 name = "oxc_parser_napi"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b4099e6754053dd4cc13894bbd13bc248ce573ad0a1be62c52c1b688ce9019"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "napi",
  "napi-build",
@@ -2131,8 +2111,7 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09de7f7e0fb82f54750e3a95346a828fd354b9aeac00f131719008733e66a18d"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "bitflags 2.10.0",
  "oxc_allocator",
@@ -2166,7 +2145,7 @@ dependencies = [
  "serde_json",
  "simd-json",
  "simdutf8",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "windows",
@@ -2188,8 +2167,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2269186b4f1510a76daf02914cb70e82a78549de451b8276bba0a419c62ac3"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "itertools",
  "memchr",
@@ -2227,22 +2205,33 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a42c0759b745eca0fe776890af46ce12e79e61796995e51a8eb9dcdf5516ab0"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "compact_str",
  "oxc-miette",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_estree",
+ "oxc_str",
+ "serde",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.110.0"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
+dependencies = [
+ "compact_str",
+ "oxc_allocator",
+ "oxc_estree",
+ "rustc-hash",
  "serde",
 ]
 
 [[package]]
 name = "oxc_syntax"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63eac2e04a75a10c5714aeb753cdfa06b1abc66bbaa748b7994700f52c9b184"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "bitflags 2.10.0",
  "cow-utils",
@@ -2262,8 +2251,7 @@ dependencies = [
 [[package]]
 name = "oxc_transform_napi"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a388073a65004711d4dee5d9b02fc232e43c7032ea9221a0753f8b4d5c0d4914"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "napi",
  "napi-build",
@@ -2277,8 +2265,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e394bc5221c9e228fc06f54b7f7a3e2d63ed135a50b8678e8485b5b49222bb5"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "base64",
  "compact_str",
@@ -2306,8 +2293,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6eb4b0d9bc8b7ee9b8efe71747ec40e9b1348cf24c09dd76027df64259d1e"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -2328,8 +2314,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4473bf963b351d5b744b75aee9ff6aa41d62f8ca662012b03dc315cac9f1f2e5"
+source = "git+https://github.com/oxc-project/oxc?branch=perf-all#99ebd3cbf30dac9e551a6a69eadd036bcbbe9776"
 dependencies = [
  "itoa",
  "oxc_allocator",
@@ -2377,7 +2362,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2498,7 +2483,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2546,18 +2531,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -2603,6 +2588,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -3633,7 +3627,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3644,9 +3638,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -3695,7 +3689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3973,15 +3967,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4041,11 +4035,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4061,9 +4055,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4081,22 +4075,22 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -4216,7 +4210,7 @@ version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4994acea2522cd2b3b85c1d9529a55991e3ad5e25cdcd3de9d505972c4379424"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ts-rs-macros",
 ]
 
@@ -4397,18 +4391,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4419,9 +4413,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4429,9 +4423,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4442,9 +4436,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -4455,7 +4449,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4726,9 +4720,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
@@ -4773,18 +4767,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4853,6 +4847,6 @@ checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
-version = "1.0.1"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5858cd3a46fff31e77adea2935e357e3a2538d870741617bfb7c943e218fee6"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,3 +295,12 @@ opt-level = "s"
 # it will strip these information for non-debug files
 debug = "full"
 strip = "none"
+
+[patch.crates-io]
+oxc = { git = "https://github.com/oxc-project/oxc", branch = "perf-all" }
+oxc_allocator = { git = "https://github.com/oxc-project/oxc", branch = "perf-all" }
+oxc_ecmascript = { git = "https://github.com/oxc-project/oxc", branch = "perf-all" }
+oxc_minify_napi = { git = "https://github.com/oxc-project/oxc", branch = "perf-all" }
+oxc_parser_napi = { git = "https://github.com/oxc-project/oxc", branch = "perf-all" }
+oxc_transform_napi = { git = "https://github.com/oxc-project/oxc", branch = "perf-all" }
+oxc_traverse = { git = "https://github.com/oxc-project/oxc", branch = "perf-all" }

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -431,7 +431,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   }
 
   fn get_root_binding(&self, name: &str) -> Option<SymbolId> {
-    self.result.symbol_ref_db.scoping().get_root_binding(name)
+    self.result.symbol_ref_db.scoping().get_root_binding_by_name(name)
   }
 
   /// `is_dummy` means if it the import record is created during ast transformation.

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -190,7 +190,7 @@ impl<'a> SideEffectDetector<'a> {
 
     let mut side_effects_detail = SideEffectDetail::empty();
     let max_len = 3;
-    let mut chains = vec![expr.property.name];
+    let mut chains = vec![expr.property.name.as_atom()];
     let cur = &expr.object;
     self.common_member_chain_processing(
       property_access_side_effects,
@@ -236,7 +236,7 @@ impl<'a> SideEffectDetector<'a> {
       match cur {
         ast::Expression::StaticMemberExpression(expr) => {
           cur = &expr.object;
-          chains.push(expr.property.name);
+          chains.push(expr.property.name.as_atom());
         }
         ast::Expression::ComputedMemberExpression(computed_expr) => {
           if let ast::Expression::StringLiteral(ref str) = computed_expr.expression {
@@ -247,7 +247,7 @@ impl<'a> SideEffectDetector<'a> {
           cur = &computed_expr.object;
         }
         ast::Expression::Identifier(ident_ref) => {
-          chains.push(ident_ref.name);
+          chains.push(ident_ref.name.as_atom());
           chains.reverse();
           side_effects_detail
             .set(SideEffectDetail::GlobalVarAccess, self.is_unresolved_reference(ident_ref));

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/utils.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/utils.rs
@@ -221,7 +221,7 @@ pub fn extract_member_expr_chain<'a>(
       &computed_expr.object
     }
     MemberExpression::StaticMemberExpression(static_expr) => {
-      chain.push(static_expr.property.name);
+      chain.push(static_expr.property.name.as_atom());
       &static_expr.object
     }
     MemberExpression::PrivateFieldExpression(_) => return None,
@@ -232,7 +232,7 @@ pub fn extract_member_expr_chain<'a>(
     match cur {
       Expression::StaticMemberExpression(expr) => {
         cur = &expr.object;
-        chain.push(expr.property.name);
+        chain.push(expr.property.name.as_atom());
       }
       Expression::ComputedMemberExpression(expr) => {
         let Expression::StringLiteral(ref str) = expr.expression else {
@@ -242,7 +242,7 @@ pub fn extract_member_expr_chain<'a>(
         cur = &expr.object;
       }
       Expression::Identifier(ident) => {
-        chain.push(ident.name);
+        chain.push(ident.name.as_atom());
         let ref_id = ident.reference_id.get().expect("should have reference_id");
         chain.reverse();
         return Some((ref_id, chain));

--- a/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/hmr_ast_finalizer.rs
@@ -223,7 +223,9 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             } else {
               // export { foo, bar as bar2 }
               decl.specifiers.iter().for_each(|specifier| {
-                if let Some(symbol_id) = scoping.get_root_binding(&specifier.local.name()) {
+                if let Some(symbol_id) =
+                  scoping.get_root_binding_by_name(specifier.local.name().as_str())
+                {
                   self
                     .named_exports
                     .insert(specifier.exported.name(), NamedExport { local_binding: symbol_id });
@@ -619,16 +621,19 @@ impl<'ast> HmrAstFinalizer<'_, 'ast> {
             SPAN,
             ast::TemplateElementValue { raw: self.builder.atom("/@vite/lazy?id="), cooked: None },
             false,
+            false,
           ),
           self.builder.template_element(
             SPAN,
             ast::TemplateElementValue { raw: self.builder.atom("&clientId="), cooked: None },
+            false,
             false,
           ),
           self.builder.template_element(
             SPAN,
             ast::TemplateElementValue { raw: self.builder.atom(""), cooked: None },
             true,
+            false,
           ),
         ]);
         let expressions = self.builder.vec_from_iter([

--- a/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
+++ b/crates/rolldown/src/hmr/impl_traverse_for_hmr_ast_finalizer.rs
@@ -203,10 +203,10 @@ impl<'ast> Traverse<'ast, ()> for HmrAstFinalizer<'_, 'ast> {
           }
         } else if ident.name == CJS_EXPORTS_REF_ATOM {
           // Rewrite `exports` to `__rolldown_exports__`
-          ident.name = CJS_ROLLDOWN_EXPORTS_REF_ATOM;
+          ident.name = CJS_ROLLDOWN_EXPORTS_REF_ATOM.into();
         } else if ident.name == CJS_MODULE_REF_ATOM {
           // Rewrite `module` to `__rolldown_module__`
-          ident.name = CJS_ROLLDOWN_MODULE_REF_ATOM;
+          ident.name = CJS_ROLLDOWN_MODULE_REF_ATOM.into();
         }
       }
     }

--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -307,7 +307,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
       assert!(symbol.namespace_alias.is_none());
       let canonical_name = self.canonical_name_for(symbol_ref);
       if ident.name != canonical_name {
-        ident.name = self.snippet.atom(canonical_name);
+        ident.name = self.snippet.atom(canonical_name).into();
       }
       ident.symbol_id.get_mut().take();
     } else {

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -469,7 +469,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     }
     let mut ret = vec![];
     let exprs = decl.declarations.iter_mut().filter_map(|var_decl| {
-      ret.extend(var_decl.id.binding_identifiers().iter().map(|item| item.name));
+      ret.extend(var_decl.id.binding_identifiers().iter().map(|item| item.name.as_atom()));
       // Turn `var ... = ...` to `... = ...`
       if let Some(ref mut init_expr) = var_decl.init {
         let left = var_decl.id.take_in(self.alloc).into_assignment_target(self.alloc);
@@ -900,7 +900,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         // needs to rewrite to `var T = class T { static a = new T(); }`
         let mut id = id.clone();
         let new_name = self.canonical_name_for((self.ctx.idx, symbol_id).into());
-        id.name = self.snippet.atom(new_name);
+        id.name = self.snippet.atom(new_name).into();
         class.id = Some(id);
       }
     }

--- a/crates/rolldown/src/module_finalizers/rename.rs
+++ b/crates/rolldown/src/module_finalizers/rename.rs
@@ -118,7 +118,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
       } else {
         let canonical_name = self.canonical_name_for(canonical_ref);
         if target_id_ref.name != canonical_name {
-          target_id_ref.name = self.snippet.atom(canonical_name);
+          target_id_ref.name = self.snippet.atom(canonical_name).into();
         }
         target_id_ref.reference_id.take();
       }
@@ -135,7 +135,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
           if let Some(symbol_id) = ident.symbol_id.get() {
             let canonical_name = self.canonical_name_for((self.ctx.idx, symbol_id).into());
             if ident.name != canonical_name {
-              ident.name = self.snippet.atom(canonical_name);
+              ident.name = self.snippet.atom(canonical_name).into();
               prop.shorthand = false;
             }
             ident.symbol_id.get_mut().take();
@@ -150,7 +150,7 @@ impl<'ast> ScopeHoistingFinalizer<'_, 'ast> {
           if let Some(symbol_id) = ident.symbol_id.get() {
             let canonical_name = self.canonical_name_for((self.ctx.idx, symbol_id).into());
             if ident.name != canonical_name {
-              ident.name = self.snippet.atom(canonical_name);
+              ident.name = self.snippet.atom(canonical_name).into();
               prop.shorthand = false;
             }
             ident.symbol_id.get_mut().take();

--- a/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
+++ b/crates/rolldown/src/stages/link_stage/generate_lazy_export.rs
@@ -238,8 +238,10 @@ fn json_object_expr_to_esm(link_staged: &mut LinkStage, module_idx: ModuleIdx) -
   let mut all_declared_symbols =
     stmt_info.flat_map(|info| info.referenced_symbols).collect::<Vec<_>>();
   for (local, (exported, _)) in &declaration_binding_names {
-    let symbol_id =
-      symbol_ref_db.scoping().get_root_binding(local.as_str()).expect("should have binding");
+    let symbol_id = symbol_ref_db
+      .scoping()
+      .get_root_binding_by_name(local.as_str())
+      .expect("should have binding");
     let symbol_ref: SymbolRef = (module_idx, symbol_id).into();
     all_declared_symbols.push(SymbolOrMemberExprRef::from(symbol_ref));
     let stmt_info =

--- a/crates/rolldown/tests/snapshots/integration_test262__test262_module_code.snap
+++ b/crates/rolldown/tests/snapshots/integration_test262__test262_module_code.snap
@@ -82,7 +82,7 @@ Unexpected token
 Result: PASS
 Expected: error (type: SyntaxError, phase: parse)
 Actual:
-Unexpected token
+HTML comments are not allowed in modules
 ---
 
 # language/module-code/early-dup-export-as-star-as.js

--- a/crates/rolldown_binding/src/utils/normalize_binding_transform_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_transform_options.rs
@@ -25,8 +25,6 @@ pub fn normalize_binding_transform_options(options: TransformOptions) -> Bundler
         import_source: jsx.import_source,
         pragma: jsx.pragma,
         pragma_frag: jsx.pragma_frag,
-        use_built_ins: jsx.use_built_ins,
-        use_spread: jsx.use_spread,
         refresh,
       })
     }

--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -104,7 +104,7 @@ impl FileEmitter {
     )?
     .send(ModuleLoaderMsg::AddEntryModule(Box::new(AddEntryModuleMsg { chunk: Arc::clone(&chunk), reference_id: reference_id.clone() })))
     .await
-    .context("FileEmitter: failed to send AddEntryModule message - module loader shut down during file emission")?;
+    .map_err(|e| anyhow::anyhow!("FileEmitter: failed to send AddEntryModule message - module loader shut down during file emission: {e}"))?;
     self.chunks.insert(reference_id.clone(), chunk);
     Ok(reference_id)
   }

--- a/crates/rolldown_common/src/inner_bundler_options/types/transform_option/jsx_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/transform_option/jsx_options.rs
@@ -57,21 +57,6 @@ pub struct JsxOptions {
   /// @default 'React.Fragment'
   pub pragma_frag: Option<String>,
 
-  /// When spreading props, use `Object.assign` directly instead of an extend helper.
-  ///
-  /// Only used for `classic` {@link runtime}.
-  ///
-  /// @default false
-  pub use_built_ins: Option<bool>,
-
-  /// When spreading props, use inline object with spread elements directly
-  /// instead of an extend helper or Object.assign.
-  ///
-  /// Only used for `classic` {@link runtime}.
-  ///
-  /// @default false
-  pub use_spread: Option<bool>,
-
   /// Enable React Fast Refresh .
   ///
   /// Conforms to the implementation in {@link https://github.com/facebook/react/tree/v18.3.1/packages/react-refresh}
@@ -120,8 +105,6 @@ impl From<JsxOptions> for oxc::transformer::JsxOptions {
       import_source: options.import_source,
       pragma: options.pragma,
       pragma_frag: options.pragma_frag,
-      use_built_ins: options.use_built_ins,
-      use_spread: options.use_spread,
       refresh: options.refresh.and_then(|value| match value {
         Either::Left(b) => b.then(oxc::transformer::ReactRefreshOptions::default),
         Either::Right(options) => Some(oxc::transformer::ReactRefreshOptions::from(options)),

--- a/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/jsx.rs
+++ b/crates/rolldown_ecmascript_utils/src/extensions/ast_ext/jsx.rs
@@ -68,7 +68,7 @@ impl<'ast> JsxExt<'ast> for JSXMemberExpression<'ast> {
       object: JSXMemberExpressionObject::from_ast(member_expr.object, allocator)?,
       property: oxc::ast::ast::JSXIdentifier {
         span: member_expr.span,
-        name: member_expr.property.name,
+        name: member_expr.property.name.as_atom(),
       },
     })
   }

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -70,7 +70,7 @@ impl NativePluginContextImpl {
         ..Default::default()
       })))
       .await
-      .context("PluginContext: failed to send FetchModule message - module loader shut down during plugin execution")?;
+      .map_err(|e| anyhow::anyhow!("PluginContext: failed to send FetchModule message - module loader shut down during plugin execution: {e}"))?;
     let plugin_driver = self
       .plugin_driver
       .upgrade()

--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -647,7 +647,7 @@ impl GlobImportVisit<'_, '_> {
 
               let key = match &p.key {
                 PropertyKey::StringLiteral(key) => key.value,
-                PropertyKey::StaticIdentifier(ident) => ident.name,
+                PropertyKey::StaticIdentifier(ident) => ident.name.as_atom(),
                 _ => continue,
               };
 

--- a/crates/rolldown_plugin_vite_import_glob/src/utils_2.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils_2.rs
@@ -560,7 +560,7 @@ impl GlobImportVisit<'_> {
 
               let key = match &p.key {
                 PropertyKey::StringLiteral(key) => key.value,
-                PropertyKey::StaticIdentifier(ident) => ident.name,
+                PropertyKey::StaticIdentifier(ident) => ident.name.as_atom(),
                 _ => continue,
               };
 

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -972,23 +972,6 @@ export interface JsxOptions {
    */
   pragmaFrag?: string
   /**
-   * When spreading props, use `Object.assign` directly instead of an extend helper.
-   *
-   * Only used for `classic` {@link runtime}.
-   *
-   * @default false
-   */
-  useBuiltIns?: boolean
-  /**
-   * When spreading props, use inline object with spread elements directly
-   * instead of an extend helper or Object.assign.
-   *
-   * Only used for `classic` {@link runtime}.
-   *
-   * @default false
-   */
-  useSpread?: boolean
-  /**
    * Enable React Fast Refresh .
    *
    * Conforms to the implementation in {@link https://github.com/facebook/react/tree/v18.3.1/packages/react-refresh}

--- a/tasks/generator/src/utils/mod.rs
+++ b/tasks/generator/src/utils/mod.rs
@@ -91,8 +91,9 @@ struct ExtractTargetSpan<'a> {
 
 impl<'a> ExtractTargetSpan<'a> {
   fn new(toplevel_item_name: &str, semantic: &Semantic<'a>) -> Self {
-    let symbol_id =
-      semantic.scoping().find_binding(semantic.scoping().root_scope_id(), toplevel_item_name);
+    let symbol_id = semantic
+      .scoping()
+      .find_binding_by_name(semantic.scoping().root_scope_id(), toplevel_item_name);
     Self { ret_span: None, visit_path: vec![], symbol_id }
   }
 }


### PR DESCRIPTION
## Summary

- Upgrade oxc to the `perf-all` branch which introduces a new `Ident` type with precomputed hash for faster hash map operations
- Adapt rolldown code to work with the new `Ident`-based scoping APIs

## Blocked

This PR is blocked on oxc's `perf-all` branch adding `Sync`/`Send` implementations for `Ident`:

```rust
// SAFETY: Ident is just a view into an immutable string slice
unsafe impl Sync for Ident<'_> {}
unsafe impl Send for Ident<'_> {}
```

Without these implementations, rolldown's parallel code (rayon iterators, async tasks) cannot compile because `Ident` contains `NonNull<u8>` which is not `Sync`.

🤖 Generated with [Claude Code](https://claude.ai/code)