### PR TITLE
refactor(rust): use `is_data_url` more consistently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,6 +3347,7 @@ version = "0.1.0"
 dependencies = [
  "memchr",
  "rolldown_plugin",
+ "rolldown_utils",
 ]
 
 [[package]]

--- a/crates/rolldown/src/ast_scanner/new_url.rs
+++ b/crates/rolldown/src/ast_scanner/new_url.rs
@@ -1,6 +1,7 @@
 use oxc::ast::{Comment, ast::NewExpression};
 use rolldown_common::{ImportKind, ImportRecordMeta, ModuleType, get_leading_comment};
 use rolldown_ecmascript_utils::ExpressionExt;
+use rolldown_utils::dataurl::is_data_url;
 
 use super::AstScanner;
 
@@ -43,7 +44,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     }
     let path = &first_arg_string_literal.value;
 
-    if path.starts_with("data:") {
+    if is_data_url(path) {
       return;
     }
 

--- a/crates/rolldown_common/src/types/resolved_id.rs
+++ b/crates/rolldown_common/src/types/resolved_id.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use arcstr::ArcStr;
-use rolldown_utils::stabilize_id::stabilize_id;
+use rolldown_utils::{dataurl::is_data_url, stabilize_id::stabilize_id};
 
 use super::module_id::ModuleId;
 use crate::{ModuleDefFormat, PackageJson, side_effects::HookSideEffects};
@@ -68,7 +68,7 @@ impl ResolvedId {
   /// 1. doesn't guarantee to be unique
   /// 2. relative to the cwd, so it could show stable path across different machines
   pub fn debug_id(&self, cwd: impl AsRef<Path>) -> String {
-    if self.id.trim_start().starts_with("data:") {
+    if is_data_url(&self.id) {
       return format!("<{}>", self.id.as_str());
     }
 

--- a/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
@@ -8,12 +8,11 @@ use rolldown_common::{
   ResolvedId,
 };
 use rolldown_resolver::{ResolveError, Resolver};
+use rolldown_utils::dataurl::is_data_url;
 use std::{path::Path, sync::Arc};
 use sugar_path::SugarPath;
 
 use crate::__inner::resolve_id_with_plugins;
-
-use super::resolve_id_with_plugins::is_data_url;
 
 #[expect(clippy::too_many_arguments)]
 pub async fn resolve_id_check_external(

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -5,15 +5,12 @@ use crate::{
 use nodejs_built_in_modules::is_nodejs_builtin_module;
 use rolldown_common::{ImportKind, ModuleDefFormat, ModuleId, PackageJson, ResolvedId};
 use rolldown_resolver::{ResolveError, Resolver};
+use rolldown_utils::dataurl::is_data_url;
 use std::{path::Path, sync::Arc};
 use sugar_path::SugarPath;
 
 fn is_http_url(s: &str) -> bool {
   s.starts_with("http://") || s.starts_with("https://") || s.starts_with("//")
-}
-
-pub fn is_data_url(s: &str) -> bool {
-  s.trim_start().starts_with("data:")
 }
 
 /// Infers ModuleDefFormat from file path and optional package.json.

--- a/crates/rolldown_plugin_utils/src/to_relative_runtime_path.rs
+++ b/crates/rolldown_plugin_utils/src/to_relative_runtime_path.rs
@@ -59,7 +59,7 @@ fn worker_iife(path: &str) -> String {
 }
 
 pub fn partial_encode_url_path(url: &str) -> Cow<'_, str> {
-  if url.starts_with("data:") {
+  if rolldown_utils::dataurl::is_data_url(url) {
     return Cow::Borrowed(url);
   }
   let file_path = rolldown_utils::url::clean_url(url);

--- a/crates/rolldown_plugin_utils/src/uri.rs
+++ b/crates/rolldown_plugin_utils/src/uri.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use percent_encoding::{AsciiSet, CONTROLS, percent_decode, utf8_percent_encode};
-use rolldown_utils::url::clean_url;
+use rolldown_utils::{dataurl::is_data_url, url::clean_url};
 
 const ENCODE_URI_SET: &AsciiSet = &CONTROLS
   .add(b'%')
@@ -28,7 +28,7 @@ const ENCODE_URI_SET: &AsciiSet = &CONTROLS
   .remove(b'~');
 
 pub fn encode_uri_path(uri: String) -> String {
-  if uri.starts_with("data:") {
+  if is_data_url(&uri) {
     uri
   } else {
     let path = clean_url(&uri);

--- a/crates/rolldown_plugin_vite_load_fallback/Cargo.toml
+++ b/crates/rolldown_plugin_vite_load_fallback/Cargo.toml
@@ -19,3 +19,4 @@ workspace = true
 [dependencies]
 memchr = { workspace = true }
 rolldown_plugin = { workspace = true }
+rolldown_utils = { workspace = true }

--- a/crates/rolldown_plugin_vite_load_fallback/src/lib.rs
+++ b/crates/rolldown_plugin_vite_load_fallback/src/lib.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookUsage, Plugin, PluginContext,
 };
+use rolldown_utils::dataurl::is_data_url;
 
 #[derive(Debug)]
 pub struct ViteLoadFallbackPlugin;
@@ -13,7 +14,7 @@ impl Plugin for ViteLoadFallbackPlugin {
   }
 
   async fn load(&self, ctx: &PluginContext, args: &HookLoadArgs<'_>) -> HookLoadReturn {
-    if args.id.trim_start().starts_with("data:") {
+    if is_data_url(args.id) {
       return Ok(None);
     }
 

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -18,7 +18,7 @@ use rolldown_plugin::{
   HookLoadArgs, HookLoadOutput, HookLoadReturn, HookResolveIdArgs, HookResolveIdOutput,
   HookResolveIdReturn, HookUsage, Plugin, PluginContext, typedmap::TypedMapKey,
 };
-use rolldown_utils::pattern_filter::StringOrRegex;
+use rolldown_utils::{dataurl::is_data_url, pattern_filter::StringOrRegex};
 use rustc_hash::FxHashSet;
 use std::{
   borrow::Cow,
@@ -321,7 +321,7 @@ impl Plugin for ViteResolvePlugin {
     }
 
     // data uri: pass through (this only happens during build and will be handled by rolldown)
-    if id.trim_start().starts_with("data:") {
+    if is_data_url(&id) {
       return Ok(None);
     }
 


### PR DESCRIPTION
I noticed this when fixing another issue.

While many places were using `s.trim_start().starts_with("data:")`, some others were *just* doing `s.starts_with("data:")` with no leading whitespace trim. I believe the correct behavior is to always trim leading whitespace, but this *may* change the behavior in some edge cases.

Note also that `resolve_id_with_plugins` had its own `is_data_url` helper, which is completely identical to the one that *already* existed in `rolldown_utils`! I've removed it.