### PR TITLE
fix: use string literal span for `new URL` error diagnostic

### DIFF
--- a/crates/rolldown/src/ast_scanner/new_url.rs
+++ b/crates/rolldown/src/ast_scanner/new_url.rs
@@ -48,8 +48,13 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       return;
     }
 
-    let idx =
-      self.add_import_record(path, ImportKind::NewUrl, expr.span, ImportRecordMeta::empty(), None);
+    let idx = self.add_import_record(
+      path,
+      ImportKind::NewUrl,
+      first_arg_string_literal.span,
+      ImportRecordMeta::empty(),
+      None,
+    );
     self.result.import_records[idx].asserted_module_type = Some(ModuleType::Asset);
     self.result.new_url_references.insert(expr.span, idx);
   }


### PR DESCRIPTION
Previously, the diagnostic span was taken from the *entire* `new URL(...)` expression. However, the `UNRESOLVED_IMPORT` diagnostic assumes all spans refer to string literals, and unconditionally strips the quotes. This results in the first and last characters of the `new URL(...)` expression being stripped:

<img width="670" height="37" alt="image" src="https://github.com/user-attachments/assets/80ac56b6-2362-4591-86b7-d2c0ec9956ed" />

I *think* dynamic imports' diagnostics already refer to just the string literal's span, so the `new URL` import should too.