### PR TITLE
chore: remove `{@include ./foo.md}` from d.ts files

### DIFF
--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -59,7 +59,7 @@ const bindingFileWasiBrowser = nodePath.resolve('src/rolldown-binding.wasi-brows
 
 const configs: BuildOptions[] = [
   withShared({
-    plugins: [patchBindingJs(), dts()],
+    plugins: [patchBindingJs(), dts(), removeIncludeTagsFromDts()],
     output: {
       dir: buildMeta.buildOutputDir,
       format: 'esm',
@@ -278,4 +278,33 @@ function getTsconfigCompilerOptionsForFile(file: string) {
     compilerOptions = parsedConfig.options;
   }
   return compilerOptions;
+}
+
+/**
+ * Removes {@include ...} tags from generated .d.ts files.
+ * These tags are only used for the docs site and should not appear in the published types.
+ */
+function removeIncludeTagsFromDts(): Plugin {
+  const includeTagRegex = /\s*\{@include\s+[^}]+\}/g;
+
+  return {
+    name: 'remove-include-tags-from-dts',
+    generateBundle(_options, bundle) {
+      for (const [fileName, output] of Object.entries(bundle)) {
+        if (!fileName.endsWith('.d.ts') && !fileName.endsWith('.d.mts')) {
+          continue;
+        }
+        if (output.type === 'asset') {
+          this.warn(
+            `Expected .d.ts files to be chunks, but found asset type for ${fileName} (type: ${output.type}).`,
+          );
+        } else if (output.type === 'chunk') {
+          const matches = output.code.match(includeTagRegex);
+          if (matches) {
+            output.code = output.code.replace(includeTagRegex, '');
+          }
+        }
+      }
+    },
+  };
 }


### PR DESCRIPTION
Removes `{@include ...}` tags from generated .d.ts files. These tags are only used for the docs site and should not appear in the published types as it will be confusing.