### PR TITLE
feat: allow more options for `this.emitFile` with `type: 'prebuilt-chunk'`

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/types/binding_emitted_prebuilt_chunk.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_emitted_prebuilt_chunk.rs
@@ -6,10 +6,14 @@ use crate::types::binding_sourcemap::BindingSourcemap;
 #[derive(Debug)]
 pub struct BindingEmittedPrebuiltChunk {
   pub file_name: String,
+  pub name: Option<String>,
   pub code: String,
   pub exports: Option<Vec<String>>,
   pub map: Option<BindingSourcemap>,
   pub sourcemap_file_name: Option<String>,
+  pub facade_module_id: Option<String>,
+  pub is_entry: Option<bool>,
+  pub is_dynamic_entry: Option<bool>,
 }
 
 impl TryFrom<BindingEmittedPrebuiltChunk> for rolldown_common::EmittedPrebuiltChunk {
@@ -18,10 +22,14 @@ impl TryFrom<BindingEmittedPrebuiltChunk> for rolldown_common::EmittedPrebuiltCh
   fn try_from(value: BindingEmittedPrebuiltChunk) -> Result<Self, Self::Error> {
     Ok(Self {
       file_name: ArcStr::from(value.file_name),
+      name: value.name.map(ArcStr::from),
       code: value.code,
       exports: value.exports.unwrap_or_default(),
       map: value.map.map(TryInto::try_into).transpose()?,
       sourcemap_filename: value.sourcemap_file_name,
+      facade_module_id: value.facade_module_id.map(ArcStr::from),
+      is_entry: value.is_entry.unwrap_or(false),
+      is_dynamic_entry: value.is_dynamic_entry.unwrap_or(false),
     })
   }
 }

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1823,10 +1823,14 @@ export interface BindingEmittedChunk {
 
 export interface BindingEmittedPrebuiltChunk {
   fileName: string
+  name?: string
   code: string
   exports?: Array<string>
   map?: BindingSourcemap
   sourcemapFileName?: string
+  facadeModuleId?: string
+  isEntry?: boolean
+  isDynamicEntry?: boolean
 }
 
 export type BindingError =

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -106,6 +106,10 @@ export interface EmittedPrebuiltChunk {
   type: 'prebuilt-chunk';
   fileName: string;
   /**
+   * A semantic name for the chunk. If not provided, `fileName` will be used.
+   */
+  name?: string;
+  /**
    * The code of this chunk.
    */
   code: string;
@@ -120,6 +124,18 @@ export interface EmittedPrebuiltChunk {
    */
   map?: SourceMap;
   sourcemapFileName?: string;
+  /**
+   * The module id of the facade module for this chunk, if any.
+   */
+  facadeModuleId?: string;
+  /**
+   * Whether this chunk corresponds to an entry point.
+   */
+  isEntry?: boolean;
+  /**
+   * Whether this chunk corresponds to a dynamic entry point.
+   */
+  isDynamicEntry?: boolean;
 }
 
 /** @inline @category Plugin APIs */
@@ -356,10 +372,14 @@ export class PluginContextImpl extends MinimalPluginContextImpl {
     if (file.type === 'prebuilt-chunk') {
       return this.context.emitPrebuiltChunk({
         fileName: file.fileName,
+        name: file.name,
         code: file.code,
         exports: file.exports,
         map: bindingifySourcemap(file.map),
         sourcemapFileName: file.sourcemapFileName,
+        facadeModuleId: file.facadeModuleId,
+        isEntry: file.isEntry,
+        isDynamicEntry: file.isDynamicEntry,
       });
     }
     if (file.type === 'chunk') {

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-prebuilt-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-prebuilt-chunk/_config.ts
@@ -8,11 +8,23 @@ export default defineTest({
       {
         name: 'test-emit-prebuilt-chunk',
         buildStart() {
+          // Prebuilt chunk without custom options (defaults)
           this.emitFile({
             type: 'prebuilt-chunk',
             fileName: 'prebuilt.js',
             code: 'console.log("prebuilt chunk");',
             exports: ['default'],
+          });
+          // Prebuilt chunk with options
+          this.emitFile({
+            type: 'prebuilt-chunk',
+            fileName: 'vendor-abc123.js',
+            name: 'vendor',
+            code: 'console.log("vendor chunk");',
+            exports: ['foo'],
+            isEntry: true,
+            isDynamicEntry: true,
+            facadeModuleId: '/path/to/entry.js',
           });
         },
       },
@@ -20,9 +32,25 @@ export default defineTest({
   },
   afterTest: (output) => {
     const chunks = getOutputChunk(output);
+
+    // Test prebuilt chunk without custom options (defaults)
     const prebuiltChunk = chunks.find((c) => c.fileName === 'prebuilt.js');
     expect(prebuiltChunk).toBeDefined();
     expect(prebuiltChunk!.code).toBe('console.log("prebuilt chunk");');
     expect(prebuiltChunk!.exports).toStrictEqual(['default']);
+    expect(prebuiltChunk!.name).toBe('prebuilt.js'); // name defaults to fileName
+    expect(prebuiltChunk!.isEntry).toBe(false);
+    expect(prebuiltChunk!.isDynamicEntry).toBe(false);
+    expect(prebuiltChunk!.facadeModuleId).toBeNull();
+
+    // Test prebuilt chunk with options
+    const vendorChunk = chunks.find((c) => c.fileName === 'vendor-abc123.js');
+    expect(vendorChunk).toBeDefined();
+    expect(vendorChunk!.code).toBe('console.log("vendor chunk");');
+    expect(vendorChunk!.exports).toStrictEqual(['foo']);
+    expect(vendorChunk!.name).toBe('vendor');
+    expect(vendorChunk!.isEntry).toBe(true);
+    expect(vendorChunk!.isDynamicEntry).toBe(true);
+    expect(vendorChunk!.facadeModuleId).toBe('/path/to/entry.js');
   },
 });


### PR DESCRIPTION
Allow more options for `this.emitFile` with `type: 'prebuilt-chunk'`.

This is needed for https://github.com/vitejs/vite/pull/21498
