### PR TITLE
perf: run inline-const pass for modules that are affected by inlining

### DIFF
--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -133,23 +133,51 @@ impl LinkStage<'_> {
         },
       );
     });
+    // Track modules to process in subsequent passes. None means process all modules (first pass).
+    let mut modules_to_process: Option<FxHashSet<ModuleIdx>> = None;
     while ctx.config.pass > 0 && ctx.changed {
       ctx.config.pass -= 1;
       ctx.changed = false;
-      self.run(
+      let new_constant_refs = self.run(
         &mut ctx,
         &mut constant_symbol_map,
         &module_idx_and_stmt_idx_to_dynamic_import_expr_addr_map,
         &mut unreachable_addresses,
+        modules_to_process.as_ref(),
       );
       if !ctx.changed {
         break;
       }
+      modules_to_process = Some(self.find_modules_referencing_constants(&new_constant_refs));
     }
     self.global_constant_symbol_map = constant_symbol_map;
     // Return all unreachable import expression addresses instead of add it as a field of LinkStage,
     // Because this set is only used include statement stage.
     unreachable_addresses
+  }
+
+  /// Find all modules that have imports resolving to any of the given constant canonical refs.
+  fn find_modules_referencing_constants(
+    &self,
+    new_constant_refs: &FxHashSet<SymbolRef>,
+  ) -> FxHashSet<ModuleIdx> {
+    if new_constant_refs.is_empty() {
+      return FxHashSet::default();
+    }
+
+    self
+      .module_table
+      .iter()
+      .filter_map(|module| {
+        let normal_module = module.as_normal()?;
+        // Check if any of the module's named imports resolve to a newly discovered constant
+        let references_new_constant = normal_module.named_imports.keys().any(|local_symbol_ref| {
+          let canonical_ref = self.symbols.canonical_ref_for(*local_symbol_ref);
+          new_constant_refs.contains(&canonical_ref)
+        });
+        references_new_constant.then_some(normal_module.idx)
+      })
+      .collect()
   }
 
   fn run(
@@ -158,11 +186,15 @@ impl LinkStage<'_> {
     constant_symbol_map: &mut FxHashMap<SymbolRef, ConstExportMeta>,
     module_idx_and_stmt_idx_to_dynamic_import_expr_addr_map: &ModuleIdxAndStmtIdxToDynamicImportExprAddrMap,
     all_unreachable_addresses: &mut FxHashSet<Address>,
-  ) {
+    modules_to_process: Option<&FxHashSet<ModuleIdx>>,
+  ) -> FxHashSet<SymbolRef> {
     let mutation_result: Vec<MutationResult> = self
       .sorted_modules
       .par_iter()
       .filter_map(|item| {
+        if modules_to_process.is_some_and(|filter| !filter.contains(item)) {
+          return None;
+        }
         let module = self.module_table[*item].as_normal()?;
         let module_idx = module.idx;
         let ast =
@@ -236,6 +268,7 @@ impl LinkStage<'_> {
       })
       .collect();
 
+    let mut new_constant_refs = FxHashSet::default();
     for (side_effect_mutations, local_constants, unreachable_addresses) in mutation_result {
       if let Some((module_idx, mutations)) = side_effect_mutations {
         if let Some(module) = self.module_table[module_idx].as_normal_mut() {
@@ -247,12 +280,14 @@ impl LinkStage<'_> {
 
       if !local_constants.is_empty() {
         cross_module_inline_const_ctx.changed = true;
+        new_constant_refs.extend(local_constants.keys().copied());
         constant_symbol_map.extend(local_constants);
       }
 
       // Collect all unreachable import expression addresses
       all_unreachable_addresses.extend(unreachable_addresses);
     }
+    new_constant_refs
   }
 }
 

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "minify": "dceOnly",
+    "optimization": {
+      "inlineConst": {
+        "pass": 3
+      }
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/artifacts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+function unrelatedFn() {
+	return "hello";
+}
+console.log(unrelatedFn());
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/const_a.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/const_a.js
@@ -1,0 +1,2 @@
+// Base constant - discovered in scan phase
+export const CONST_A = 'a' === 'a'; // true

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/const_b.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/const_b.js
@@ -1,0 +1,3 @@
+// Depends on CONST_A - discovered in pass 1 of cross_module_optimization
+import { CONST_A } from './const_a.js';
+export const CONST_B = CONST_A ? 'foo' : 'bar';

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/const_c.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/const_c.js
@@ -1,0 +1,4 @@
+// Depends on CONST_B - discovered in pass 2 of cross_module_optimization
+// This is where the filtering optimization kicks in
+import { CONST_B } from './const_b.js';
+export const CONST_C = CONST_B === 'foo';

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/main.js
@@ -1,0 +1,11 @@
+// Entry point that uses the constant chain
+import { CONST_C } from './const_c.js';
+import { unrelatedFn } from './unrelated.js';
+
+// This should be eliminated when CONST_C is known to be true
+if (!CONST_C) {
+  console.log('this should be eliminated');
+}
+
+// This should remain
+console.log(unrelatedFn());

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/unrelated.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/multi_pass_filtering/unrelated.js
@@ -1,0 +1,6 @@
+// This module doesn't import any constants
+// With the optimization, it should be skipped in pass 2+
+export const UNRELATED = 'hello';
+export function unrelatedFn() {
+  return UNRELATED;
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5436,6 +5436,10 @@ expression: output
 - pageb-!~{001}~.js => pageb-BFCQ4ggL.js
 - foo-!~{002}~.js => foo-CUa9ehQs.js
 
+# tests/rolldown/optimization/inline_const/multi_pass_filtering
+
+- main-!~{000}~.js => main-jzXyUv2k.js
+
 # tests/rolldown/optimization/inline_const/ns_chain
 
 - main-!~{000}~.js => main-Brb9u1JP.js


### PR DESCRIPTION
Only run inline-const pass for modules that are affected by the inlining done by the previous pass.

I don't have a real-world case result. But a synthetic benchmark created by claude (#8078) had the improvement I was expecting.
