### PR TITLE
refactor: remove `use_built_ins` and `use_spread` from internal JSX options

### DIFF
--- a/crates/rolldown_binding/src/utils/normalize_binding_transform_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_transform_options.rs
@@ -25,8 +25,6 @@ pub fn normalize_binding_transform_options(options: TransformOptions) -> Bundler
         import_source: jsx.import_source,
         pragma: jsx.pragma,
         pragma_frag: jsx.pragma_frag,
-        use_built_ins: None,
-        use_spread: None,
         refresh,
       })
     }

--- a/crates/rolldown_common/src/inner_bundler_options/types/transform_option/jsx_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/transform_option/jsx_options.rs
@@ -57,21 +57,6 @@ pub struct JsxOptions {
   /// @default 'React.Fragment'
   pub pragma_frag: Option<String>,
 
-  /// When spreading props, use `Object.assign` directly instead of an extend helper.
-  ///
-  /// Only used for `classic` {@link runtime}.
-  ///
-  /// @default false
-  pub use_built_ins: Option<bool>,
-
-  /// When spreading props, use inline object with spread elements directly
-  /// instead of an extend helper or Object.assign.
-  ///
-  /// Only used for `classic` {@link runtime}.
-  ///
-  /// @default false
-  pub use_spread: Option<bool>,
-
   /// Enable React Fast Refresh .
   ///
   /// Conforms to the implementation in {@link https://github.com/facebook/react/tree/v18.3.1/packages/react-refresh}
@@ -120,8 +105,6 @@ impl From<JsxOptions> for oxc::transformer::JsxOptions {
       import_source: options.import_source,
       pragma: options.pragma,
       pragma_frag: options.pragma_frag,
-      use_built_ins: options.use_built_ins,
-      use_spread: options.use_spread,
       refresh: options.refresh.and_then(|value| match value {
         Either::Left(b) => b.then(oxc::transformer::ReactRefreshOptions::default),
         Either::Right(options) => Some(oxc::transformer::ReactRefreshOptions::from(options)),

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -156,8 +156,6 @@ const JsxOptionsSchema = v.strictObject({
     v.optional(v.union([v.boolean(), v.any()])),
     v.description('Enable react fast refresh'),
   ),
-  useBuiltIns: v.pipe(v.optional(v.any()), v.description('Deprecated')),
-  useSpread: v.pipe(v.optional(v.any()), v.description('Deprecated')),
 });
 isTypeTrue<
   IsSchemaSubType<


### PR DESCRIPTION
Follow up to #8063. I missed this one