### PR TITLE
feat: remove inlined constants in smart mode

### DIFF
--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -662,11 +662,12 @@ pub fn include_symbol(
 
   if let Some(v) = ctx.constant_symbol_map.get(&canonical_ref)
     && !include_reason.contains(SymbolIncludeReason::EntryExport)
-    && !ctx.inline_const_smart
+    && (!ctx.inline_const_smart || v.safe_to_inline)
     && !v.commonjs_export
   {
-    // If the symbol is a constant value and it is not a commonjs module export , we don't need to include it since it would be always inline
-    // We don't need to add anyflag since if `inlineConst` is disabled, the test expr will always
+    // If the symbol is a constant value and it is not a commonjs module export, we don't need to include it since it would be always inlined.
+    // In smart mode, we only skip if `safe_to_inline` is true (meaning it will be inlined regardless of context).
+    // We don't need to add any flag since if `inlineConst` is disabled, the test expr will always
     // return `false`
     return;
   }

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode/artifacts.snap
@@ -8,12 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 //#region constants.js
 const mode = "production";
-const one = 1;
-const bool = true;
-const primitiveUndefined = void 0;
-const primitiveNull = null;
 const longString = "1234";
-const shortString = "123";
 
 //#endregion
 //#region main.js

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/_config.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      },
+      {
+        "name": "main2",
+        "import": "./main2.js"
+      }
+    ],
+    "optimization": {
+      "inlineConst": {
+        "mode": "smart",
+        "pass": 1
+      }
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/artifacts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+if (false) console.log("foo");
+
+//#endregion
+```
+
+## main2.js
+
+```js
+//#region main2.js
+if (false) console.log("foo");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/lib.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/lib.js
@@ -1,0 +1,1 @@
+export const foo = false

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/main.js
@@ -1,0 +1,5 @@
+import { foo } from './lib.js'
+
+if (foo) {
+  console.log('foo')
+}

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/main2.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/smart_mode_import_removal/main2.js
@@ -1,0 +1,5 @@
+import { foo } from './lib.js'
+
+if (foo) {
+  console.log('foo')
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5455,7 +5455,12 @@ expression: output
 
 # tests/rolldown/optimization/inline_const/smart_mode
 
-- main-!~{000}~.js => main-mRt7JHUp.js
+- main-!~{000}~.js => main-Ba43qeSj.js
+
+# tests/rolldown/optimization/inline_const/smart_mode_import_removal
+
+- main-!~{000}~.js => main-HMoY18ts.js
+- main2-!~{001}~.js => main2-C3W9je7R.js
 
 # tests/rolldown/optimization/inline_empty_function_call/basic
 

--- a/crates/rolldown_common/src/types/constant_value.rs
+++ b/crates/rolldown_common/src/types/constant_value.rs
@@ -21,8 +21,7 @@ pub struct ConstExportMeta {
   pub value: ConstantValue,
   /// For now we only support esm and commonjs format, so `bool` is enough.
   pub commonjs_export: bool,
-  /// If `true`, it's safe to inline this constant value whether in **inlineConst mode** `'all'` or
-  /// `'smart'`
+  /// If `true`, it's safe to inline this constant value regardless of **inlineConst mode**
   pub safe_to_inline: bool,
 }
 


### PR DESCRIPTION
Remove unnecessary imports like `import { t as foo } from "./lib1-lvcth4Jd.js";` when smart mode is used ([REPL](https://repl.rolldown.rs/#eNq9UMtuwyAQ/JUVFxzJpXGPSD31N3KhNkRUwFpA2qoW/94FP1RFPefAY9jZGWYXZphcmFc2iI9Ur4HJA/ZsJGT9jDHDAgYRCpiIHrh4dvZ9IBK/xEuoyxroiHGCpSKAEUNCp4XDa8epwE/1vdSNhDWTOd506ZvZy515ww9x33R28x2u3vq7eVet3PxfwSiXdFOh5ojOTfgVBDGMvf7R+adyF2fSxgb91spHrr3tiLX9gMjq5tp5NHVbUpyz9fZHZYtB7vEBbHArNWV6BY+TlsCTVzHzHmaVkoQB2kBgPUobESsU7JN+OoizOD/FUQys/AJHYrf1)).