### PR TITLE
fix: ensure `\0rolldown/runtime.js` will go through transform hook and add test

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/mod.rs
@@ -1,1 +1,2 @@
 mod hmr;
+mod runtime;

--- a/crates/rolldown/tests/rolldown/topics/runtime/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/runtime/mod.rs
@@ -1,0 +1,1 @@
+mod transform;

--- a/crates/rolldown/tests/rolldown/topics/runtime/transform/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/runtime/transform/artifacts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dep.cjs
+var require_dep = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.value = "cjs-value";
+}));
+
+//#endregion
+//#region entry.js
+const dep = require_dep();
+const value = dep.value;
+
+//#endregion
+export { value };
+```

--- a/crates/rolldown/tests/rolldown/topics/runtime/transform/dep.cjs
+++ b/crates/rolldown/tests/rolldown/topics/runtime/transform/dep.cjs
@@ -1,0 +1,1 @@
+exports.value = 'cjs-value'

--- a/crates/rolldown/tests/rolldown/topics/runtime/transform/entry.js
+++ b/crates/rolldown/tests/rolldown/topics/runtime/transform/entry.js
@@ -1,0 +1,2 @@
+const dep = require('./dep.cjs')
+export const value = dep.value

--- a/crates/rolldown/tests/rolldown/topics/runtime/transform/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/runtime/transform/mod.rs
@@ -1,0 +1,81 @@
+use std::{
+  borrow::Cow,
+  sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+  },
+};
+
+use rolldown::{BundlerOptions, InputItem};
+use rolldown_common::RUNTIME_MODULE_KEY;
+use rolldown_plugin::{HookBuildStartArgs, HookNoopReturn, HookUsage, Plugin, PluginContext};
+use rolldown_testing::{manual_integration_test, test_config::TestMeta};
+
+/// Test that plugins can transform the runtime module via the transform hook.
+#[derive(Debug)]
+struct RuntimeTransformPlugin {
+  transform_called: Arc<AtomicBool>,
+}
+
+impl Plugin for RuntimeTransformPlugin {
+  fn name(&self) -> Cow<'static, str> {
+    "runtime-transform-plugin".into()
+  }
+
+  async fn build_start(
+    &self,
+    _ctx: &PluginContext,
+    _args: &HookBuildStartArgs<'_>,
+  ) -> HookNoopReturn {
+    // Reset at the start of each build
+    self.transform_called.store(false, Ordering::SeqCst);
+    Ok(())
+  }
+
+  async fn transform(
+    &self,
+    _ctx: rolldown_plugin::SharedTransformPluginContext,
+    args: &rolldown_plugin::HookTransformArgs<'_>,
+  ) -> rolldown_plugin::HookTransformReturn {
+    if args.id == RUNTIME_MODULE_KEY {
+      self.transform_called.store(true, Ordering::SeqCst);
+    }
+    Ok(None)
+  }
+
+  async fn build_end(
+    &self,
+    _ctx: &PluginContext,
+    _args: Option<&rolldown_plugin::HookBuildEndArgs<'_>>,
+  ) -> HookNoopReturn {
+    // Return error if transform was not called for the runtime module
+    if !self.transform_called.load(Ordering::SeqCst) {
+      return Err(anyhow::anyhow!("Transform hook was not called for the runtime module"));
+    }
+    Ok(())
+  }
+
+  fn register_hook_usage(&self) -> HookUsage {
+    HookUsage::BuildStart | HookUsage::Transform | HookUsage::BuildEnd
+  }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn transform_runtime_module() {
+  let transform_called = Arc::new(AtomicBool::new(false));
+  let plugin = Arc::new(RuntimeTransformPlugin { transform_called: Arc::clone(&transform_called) });
+
+  manual_integration_test!()
+    .build(TestMeta { expect_executed: false, ..Default::default() })
+    .run_with_plugins(
+      BundlerOptions {
+        input: Some(vec![InputItem {
+          name: Some("entry".to_string()),
+          import: "./entry.js".to_string(),
+        }]),
+        ..Default::default()
+      },
+      vec![plugin],
+    )
+    .await;
+}

--- a/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
@@ -68,10 +68,16 @@ impl TransformPluginContext {
   ///
   /// * file - The file to add as a watch dependency. This should be a normalized absolute path.
   pub fn add_watch_file(&self, file: &str) {
-    // Call the parent method to add to global watch files
+    // Skip all operations for virtual modules (starting with \0)
+    // Virtual modules can't be refetched from disk during HMR
+    if self.id.starts_with('\0') {
+      return;
+    }
+
+    // Add to global watch files
     self.inner.add_watch_file(file);
 
-    // Also add to this module's transform dependencies
+    // Add to this module's transform dependencies
     if let crate::PluginContext::Native(ctx) = &self.inner {
       if let Some(plugin_driver) = ctx.plugin_driver.upgrade() {
         plugin_driver.add_transform_dependency(self.module_idx, file);

--- a/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/include/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/ecma-transform/include/_config.ts
@@ -17,6 +17,10 @@ export default defineTest({
       {
         name: 'test',
         transform(_, id, meta) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return null;
+          }
           if (meta.moduleType === 'js') {
             transformed.push(id);
           }

--- a/packages/rolldown/tests/fixtures/lazy-barrel/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/basic/_config.ts
@@ -14,6 +14,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id);
         },
       },

--- a/packages/rolldown/tests/fixtures/lazy-barrel/circular-exports/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/circular-exports/_config.ts
@@ -13,6 +13,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id);
           return {
             moduleSideEffects: false

--- a/packages/rolldown/tests/fixtures/lazy-barrel/circular-star-exports/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/circular-star-exports/_config.ts
@@ -13,6 +13,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id);
           return {
             moduleSideEffects: false

--- a/packages/rolldown/tests/fixtures/lazy-barrel/dynamic-import-entry/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/dynamic-import-entry/_config.ts
@@ -13,6 +13,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id);
           return {
             moduleSideEffects: false

--- a/packages/rolldown/tests/fixtures/lazy-barrel/multiple-entries/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/multiple-entries/_config.ts
@@ -14,6 +14,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id);
           return {
             moduleSideEffects: false

--- a/packages/rolldown/tests/fixtures/lazy-barrel/self-re-export/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/self-re-export/_config.ts
@@ -13,6 +13,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id);
           return {
             moduleSideEffects: false

--- a/packages/rolldown/tests/fixtures/lazy-barrel/star-export-with-named/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/star-export-with-named/_config.ts
@@ -13,6 +13,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id);
           return {
             moduleSideEffects: false

--- a/packages/rolldown/tests/fixtures/lazy-barrel/star-export/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/star-export/_config.ts
@@ -13,6 +13,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id);
           return {
             moduleSideEffects: false

--- a/packages/rolldown/tests/fixtures/lazy-barrel/treeshake-behavior/case-import-export/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/treeshake-behavior/case-import-export/_config.ts
@@ -24,6 +24,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id)
           if (id.endsWith('d.js') || id.endsWith('g.js')) {
             return { moduleSideEffects: false }

--- a/packages/rolldown/tests/fixtures/lazy-barrel/treeshake-behavior/case-own-export-default/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/treeshake-behavior/case-own-export-default/_config.ts
@@ -24,6 +24,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id)
           if (id.endsWith('d.js') || id.endsWith('g.js')) {
             return { moduleSideEffects: false }

--- a/packages/rolldown/tests/fixtures/lazy-barrel/treeshake-behavior/case-own-export/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/treeshake-behavior/case-own-export/_config.ts
@@ -24,6 +24,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id)
           if (id.endsWith('d.js') || id.endsWith('g.js')) {
             return { moduleSideEffects: false }

--- a/packages/rolldown/tests/fixtures/lazy-barrel/treeshake-behavior/case-reexport-default/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/treeshake-behavior/case-reexport-default/_config.ts
@@ -24,6 +24,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id)
           if (id.endsWith('d.js') || id.endsWith('g.js')) {
             return { moduleSideEffects: false }

--- a/packages/rolldown/tests/fixtures/lazy-barrel/treeshake-behavior/case-reexport/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/treeshake-behavior/case-reexport/_config.ts
@@ -24,6 +24,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id)
           if (id.endsWith('d.js') || id.endsWith('g.js')) {
             return { moduleSideEffects: false }

--- a/packages/rolldown/tests/fixtures/lazy-barrel/unused-barrel-import/_config.ts
+++ b/packages/rolldown/tests/fixtures/lazy-barrel/unused-barrel-import/_config.ts
@@ -13,6 +13,10 @@ export default defineTest({
       {
         name: 'track-transforms',
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           transformedIds.push(id);
           if (!id.endsWith('main.js')) {
             return {

--- a/packages/rolldown/tests/fixtures/misc/error/transform/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/transform/_config.ts
@@ -7,7 +7,11 @@ export default defineTest({
     plugins: [
       {
         name: 'my-plugin',
-        async transform() {
+        async transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           await errorFn1();
         },
       },

--- a/packages/rolldown/tests/fixtures/plugin/build-start/wait-for-build-start/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/build-start/wait-for-build-start/_config.ts
@@ -15,7 +15,11 @@ export default defineTest({
           await sleepAsync(100);
           buildStartFn();
         },
-        transform() {
+        transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           expect(buildStartFn).toHaveBeenCalledTimes(1);
           expect(buildStartFn2).toHaveBeenCalledTimes(1);
         },

--- a/packages/rolldown/tests/fixtures/plugin/load/virtual-entry/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/load/virtual-entry/_config.ts
@@ -27,6 +27,10 @@ export default defineTest({
           }
         },
         transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return;
+          }
           idList.push(id);
         },
       },

--- a/packages/rolldown/tests/fixtures/plugin/native-magic-string-instance/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/native-magic-string-instance/_config.ts
@@ -14,6 +14,10 @@ export default defineTest({
       {
         name: 'test-magic-string-caching',
         transform(code, id, meta) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return null;
+          }
           if (!meta?.magicString) {
             return null;
           }

--- a/packages/rolldown/tests/fixtures/plugin/transform/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/basic/_config.ts
@@ -24,7 +24,7 @@ export default defineTest({
   },
   afterTest: (output) => {
     expect.assertions(4);
-    expect(transformFn).toHaveBeenCalledTimes(2);
+    expect(transformFn).toHaveBeenCalledTimes(3);
     expect(output.output[0].code).contains('transformed');
   },
 });

--- a/packages/rolldown/tests/fixtures/plugin/transform/filter/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/filter/_config.ts
@@ -57,7 +57,7 @@ export default defineTest({
   },
   afterTest: () => {
     expect(transformFn).toHaveBeenCalledTimes(1);
-    expect(transformFn2).toHaveBeenCalledTimes(2);
+    expect(transformFn2).toHaveBeenCalledTimes(3);
     expect(transformFn3).toHaveBeenCalledTimes(0);
   },
 });

--- a/packages/rolldown/tests/fixtures/plugin/transform/soucemap-with-multiple-sources/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/soucemap-with-multiple-sources/_config.ts
@@ -12,7 +12,11 @@ export default defineTest({
     plugins: [
       {
         name: 'test-plugin',
-        transform() {
+        transform(_, id) {
+          // Skip virtual modules (like \0rolldown/runtime.js)
+          if (id.startsWith('\0')) {
+            return null;
+          }
           return {
             code: `
 console.log('bar');

--- a/packages/rolldown/tests/fixtures/plugin/transform/with-filter-nested/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/with-filter-nested/_config.ts
@@ -11,7 +11,7 @@ const nestedPlugin: RolldownPluginOption = [
   {
     name: 'test-plugin-1',
     transform: {
-      handler(_, _id) {
+      handler() {
         transformFn();
       },
     },
@@ -48,7 +48,7 @@ export default defineTest({
     ],
   },
   afterTest: () => {
-    expect(transformFn).toHaveBeenCalledTimes(3);
+    expect(transformFn).toHaveBeenCalledTimes(4);
     expect(transformFn1).toHaveBeenCalledTimes(0);
     expect(transformFn2).toHaveBeenCalledTimes(0);
   },

--- a/packages/rolldown/tests/fixtures/plugin/transform/with-filter/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/with-filter/_config.ts
@@ -46,7 +46,7 @@ export default defineTest({
       withFilter(
         {
           name: 'test-plugin3',
-          // should have no effects
+          // should have no effects on resolveId but transform still called
           transform() {
             transformFn3();
           },
@@ -62,6 +62,6 @@ export default defineTest({
   afterTest: () => {
     expect(transformFn).toHaveBeenCalledTimes(0);
     expect(transformFn2).toHaveBeenCalledTimes(0);
-    expect(transformFn3).toHaveBeenCalledTimes(3);
+    expect(transformFn3).toHaveBeenCalledTimes(4);
   },
 });

--- a/packages/rolldown/tests/fixtures/tree-shake/filter-expression/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/filter-expression/_config.ts
@@ -19,6 +19,6 @@ export default defineTest({
     ],
   },
   afterTest: (_) => {
-    expect(transformHookFunction).toBeCalledTimes(2);
+    expect(transformHookFunction).toBeCalledTimes(3);
   },
 });

--- a/packages/rollup-tests/test/function/index.js
+++ b/packages/rollup-tests/test/function/index.js
@@ -9,6 +9,7 @@ const {
 	compareError,
 	compareLogs,
 	runTestSuiteWithSamples,
+	wrapPluginWithRuntimeFilter
 	// verifyAstPlugin
 } = require('../utils.js');
 
@@ -91,7 +92,8 @@ runTestSuiteWithSamples(
 				process.chdir(directory);
 				const logs = [];
 				const warnings = [];
-				const plugins = config.options?.plugins
+				// Wrap plugins to filter out rolldown runtime from transform hooks
+				const plugins = wrapPluginWithRuntimeFilter(config.options?.plugins);
 					// config.verifyAst === false
 						//? config.options?.plugins
 						// : config.options?.plugins === undefined

--- a/packages/rollup-tests/test/sourcemaps/index.js
+++ b/packages/rollup-tests/test/sourcemaps/index.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 // @ts-expect-error not included in types
 const rollup = require('../../dist/rollup');
 // @ts-expect-error not included in types
-const { compareLogs, runTestSuiteWithSamples } = require('../utils.js');
+const { compareLogs, runTestSuiteWithSamples, wrapPluginWithRuntimeFilter } = require('../utils.js');
 
 // TODO more formats
 // const FORMATS = ['amd', 'cjs', 'system', 'es', 'iife', 'umd'];
@@ -25,6 +25,8 @@ runTestSuiteWithSamples(
 					it('generates ' + format, async () => {
 						process.chdir(directory);
 						const warnings = [];
+						// Wrap plugins to filter out rolldown runtime from transform hooks
+						const plugins = wrapPluginWithRuntimeFilter(config.options?.plugins);
 						const inputOptions = {
 							input: directory + '/main.js',
               onLog: (level, log) => {
@@ -33,7 +35,8 @@ runTestSuiteWithSamples(
                 }
               },
 							strictDeprecations: true,
-							...config.options
+							...config.options,
+							plugins
 						};
 						let customOutputOptions = (config.options || {}).output || {};
 						const outputOptions = {


### PR DESCRIPTION
Follow up of https://github.com/rolldown/rolldown/pull/8068