### PR TITLE
fix(string_wizard): handle overlapping remove() ranges correctly


### DIFF
--- a/crates/string_wizard/src/magic_string/update.rs
+++ b/crates/string_wizard/src/magic_string/update.rs
@@ -64,9 +64,12 @@ impl<'text> MagicString<'text> {
       return Ok(self);
     };
 
-    while rest_chunk_idx != end_idx {
+    loop {
       let rest_chunk = &mut self.chunks[rest_chunk_idx];
       rest_chunk.edit("".into(), Default::default());
+      if rest_chunk_idx == end_idx {
+        break;
+      }
       rest_chunk_idx = rest_chunk.next.unwrap();
     }
     Ok(self)

--- a/crates/string_wizard/tests/magic_string.rs
+++ b/crates/string_wizard/tests/magic_string.rs
@@ -390,6 +390,24 @@ mod misc {
   }
 
   #[test]
+  fn remove_with_overlapping_ranges() {
+    // Regression test for https://github.com/rolldown/rolldown/issues/8090
+    // When two remove() calls have overlapping ranges, the second call should
+    // still correctly remove its portion of the content.
+    //
+    // "export { Foo, Bar }"
+    //  0       89  12 1417
+    // remove(9, 14) removes "Foo, " → "export { Bar }"
+    // remove(12, 17) removes ", Bar" (overlaps with previous at 12-14)
+    // Expected result: "export {  }" (space at 8 and space at 17)
+    let mut s = MagicString::new("export { Foo, Bar }");
+    s.remove(9, 14).unwrap();
+    assert_eq!(s.to_string(), "export { Bar }");
+    s.remove(12, 17).unwrap();
+    assert_eq!(s.to_string(), "export {  }");
+  }
+
+  #[test]
   fn allow_empty_input() {
     let mut s = MagicString::new("");
     s.append("xyz");


### PR DESCRIPTION
closed #8090

Changed the loop from a `while` condition to a `loop` with a `break` **after** processing the chunk:

- **Before**: `while rest_chunk_idx != end_idx` — stops before processing `end_idx`
- **After**: Process the chunk first, then check if we've reached `end_idx` and break

This ensures the ending chunk is also edited (cleared) when removing content, which is necessary when ranges overlap.