### PR TITLE
fix: `[name]` in `assetFileNames` does not include the directory part

### DIFF
--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -1,11 +1,12 @@
 use crate::{
   AddEntryModuleMsg, FilenameTemplate, ModuleId, ModuleLoaderMsg, Modules,
   NormalizedBundlerOptions, Output, OutputAsset, OutputChunk, PreserveEntrySignatures, StrOrBytes,
+  is_path_fragment,
 };
 use anyhow::Context;
 use arcstr::ArcStr;
 use dashmap::{DashMap, DashSet, Entry};
-use rolldown_error::BuildDiagnostic;
+use rolldown_error::{BuildDiagnostic, InvalidOptionType};
 use rolldown_utils::dashmap::{FxDashMap, FxDashSet};
 use rolldown_utils::make_unique_name::make_unique_name;
 use rolldown_utils::xxhash::{xxhash_base64_url, xxhash_with_base};
@@ -13,6 +14,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use sugar_path::SugarPath;
 use tokio::sync::Mutex;
 
 #[derive(Debug, Default)]
@@ -26,6 +28,18 @@ pub struct EmittedAsset {
 impl EmittedAsset {
   pub fn name_for_sanitize(&self) -> &str {
     self.name.as_deref().unwrap_or("asset")
+  }
+
+  /// Returns true if the emitted asset has a valid name (not an absolute or relative path).
+  /// Similar to Rollup's `hasValidName` function.
+  pub fn has_valid_name(&self) -> bool {
+    let validated_name = self.file_name.as_deref().or(self.name.as_deref());
+    validated_name.is_none_or(|name| !is_path_fragment(name))
+  }
+
+  /// Returns the validated name (fileName or name) if present.
+  pub fn validated_name(&self) -> Option<&str> {
+    self.file_name.as_deref().or(self.name.as_deref())
   }
 }
 
@@ -125,6 +139,15 @@ impl FileEmitter {
     asset_filename_template: Option<FilenameTemplate>,
     sanitized_file_name: Option<ArcStr>,
   ) -> anyhow::Result<ArcStr> {
+    if !file.has_valid_name() {
+      return Err(
+        BuildDiagnostic::invalid_option(InvalidOptionType::InvalidEmittedFileName(
+          file.validated_name().unwrap_or_default().to_string(),
+        ))
+        .into(),
+      );
+    }
+
     let hash: ArcStr =
       xxhash_with_base(file.source.as_bytes(), self.options.hash_characters.base()).into();
 
@@ -216,14 +239,25 @@ impl FileEmitter {
     if file.file_name.is_none() {
       let sanitized_file_name = sanitized_file_name.expect("should has sanitized file name");
       let path = Path::new(sanitized_file_name.as_str());
-      let name = path.file_stem().and_then(OsStr::to_str);
+      // Extract extension from the filename only
       let extension = path.extension().and_then(OsStr::to_str);
+      // Extract name including directory path, but without extension
+      // e.g., "foo/bar.txt" -> "foo/bar", "bar.txt" -> "bar"
+      // Security: normalize path and filter out dangerous components
+      let name = path.file_stem().and_then(OsStr::to_str).map(|stem| {
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+          // Normalize to resolve ".." and "." where possible, then convert to forward slashes
+          parent.join(stem).normalize().to_slash_lossy().into_owned()
+        } else {
+          stem.to_string()
+        }
+      });
       let filename_template =
         filename_template.expect("should has filename template without filename");
 
       let mut filename = filename_template
         .render(
-          name,
+          name.as_deref(),
           None,
           Some(extension.unwrap_or_default()),
           Some(|len: Option<usize>| Ok(&hash[..len.map_or(8, |len| len.clamp(1, 21))])),

--- a/crates/rolldown_common/src/inner_bundler_options/types/filename_template.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/filename_template.rs
@@ -10,7 +10,7 @@ use rolldown_utils::replace_all_placeholder::{ReplaceAllPlaceholder, Replacer};
 /// - Starts with "/" (Unix absolute path)
 /// - Starts with "./" or "../" (relative paths)
 /// - Is an absolute path (e.g., "C:/" on Windows)
-fn is_path_fragment(name: &str) -> bool {
+pub fn is_path_fragment(name: &str) -> bool {
   if name.is_empty() {
     return false;
   }

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -37,7 +37,7 @@ pub mod bundler_options {
       devtools_options::DevtoolsOptions,
       es_module_flag::EsModuleFlag,
       experimental_options::ExperimentalOptions,
-      filename_template::FilenameTemplate,
+      filename_template::{FilenameTemplate, is_path_fragment},
       generated_code_options::GeneratedCodeOptions,
       hash_characters::HashCharacters,
       inject_import::InjectImport,

--- a/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
@@ -19,6 +19,7 @@ pub enum InvalidOptionType {
   CodeSplittingDisabledWithManualCodeSplitting,
   HashLengthTooLong { pattern_name: String, received: usize, max: usize },
   HashLengthTooShort { pattern_name: String, received: usize, min: usize, chunk_count: u32 },
+  InvalidEmittedFileName(String),
 }
 
 #[derive(Debug)]
@@ -99,6 +100,9 @@ impl BuildEvent for InvalidOption {
         }
         InvalidOptionType::HashLengthTooShort { pattern_name, received, min, chunk_count } => {
           format!("To generate hashes for this number of chunks (currently {chunk_count}), you need a minimum hash size of {min}, received {received}. Check the `{pattern_name}` option.")
+        }
+        InvalidOptionType::InvalidEmittedFileName(name) => {
+          format!("The \"fileName\" or \"name\" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received \"{name}\".")
         }
     }
   }

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file-invalid-name/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file-invalid-name/_config.ts
@@ -1,0 +1,68 @@
+import { defineTest } from "rolldown-tests";
+import { expect } from "vitest";
+
+// Test that emitFile rejects invalid asset names (absolute/relative paths)
+// This matches Rollup's behavior
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: "test-plugin",
+        buildStart() {
+          // Test relative path starting with "./"
+          expect(() => {
+            this.emitFile({
+              type: "asset",
+              name: "./relative.txt",
+              source: "content",
+            });
+          }).toThrow(
+            'The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths',
+          );
+
+          // Test relative path starting with "../"
+          expect(() => {
+            this.emitFile({
+              type: "asset",
+              name: "../parent.txt",
+              source: "content",
+            });
+          }).toThrow(
+            'The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths',
+          );
+
+          // Test absolute Unix path
+          expect(() => {
+            this.emitFile({
+              type: "asset",
+              name: "/absolute.txt",
+              source: "content",
+            });
+          }).toThrow(
+            'The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths',
+          );
+
+          // Test Windows absolute path (only on Windows)
+          if (process.platform === "win32") {
+            expect(() => {
+              this.emitFile({
+                type: "asset",
+                name: "C:/windows.txt",
+                source: "content",
+              });
+            }).toThrow(
+              'The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths',
+            );
+          }
+
+          // Emit a valid asset so the build succeeds
+          this.emitFile({
+            type: "asset",
+            name: "valid.txt",
+            source: "valid content",
+          });
+        },
+      },
+    ],
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file-invalid-name/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file-invalid-name/main.js
@@ -1,0 +1,1 @@
+export default 'main';

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file-with-directory-name/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file-with-directory-name/_config.ts
@@ -1,0 +1,58 @@
+import { defineTest } from 'rolldown-tests';
+import { getOutputAsset } from 'rolldown-tests/utils';
+import { expect } from 'vitest';
+
+// Test that [name] in assetFileNames includes directory part
+// https://github.com/rolldown/rolldown/issues/7315
+export default defineTest({
+  config: {
+    output: {
+      assetFileNames: '[name].[ext]',
+    },
+    plugins: [
+      {
+        name: 'test-plugin',
+        buildStart() {
+          // Emit asset with directory in name (valid - not a path fragment)
+          this.emitFile({
+            type: 'asset',
+            name: 'foo/bar.txt',
+            source: 'hello world',
+          });
+          // Emit asset with nested directory in name (valid)
+          this.emitFile({
+            type: 'asset',
+            name: 'a/b/c.txt',
+            source: 'nested',
+          });
+          // Path traversal in middle is allowed (will be normalized)
+          // "foo/../bar/baz.txt" -> "bar/baz.txt" after normalize
+          this.emitFile({
+            type: 'asset',
+            name: 'foo/../bar/baz.txt',
+            source: 'path traversal in middle',
+          });
+        },
+      },
+    ],
+  },
+  afterTest: (output) => {
+    const assets = getOutputAsset(output);
+    expect(assets.length).toBe(3);
+
+    const fooBarAsset = assets.find((a) => a.name === 'foo/bar.txt');
+    expect(fooBarAsset).toBeDefined();
+    // The [name] placeholder should include the directory part
+    expect(fooBarAsset!.fileName).toBe('foo/bar.txt');
+
+    const nestedAsset = assets.find((a) => a.name === 'a/b/c.txt');
+    expect(nestedAsset).toBeDefined();
+    expect(nestedAsset!.fileName).toBe('a/b/c.txt');
+
+    // Path traversal in middle should be resolved by normalize()
+    const bazAsset = assets.find((a) => a.name === 'foo/../bar/baz.txt');
+    expect(bazAsset).toBeDefined();
+    // "foo/.." resolves to "", leaving "bar/baz.txt"
+    expect(bazAsset!.fileName).toBe('bar/baz.txt');
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-file-with-directory-name/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-file-with-directory-name/main.js
@@ -1,0 +1,1 @@
+export default 'main';


### PR DESCRIPTION
closed #7315 