### PR TITLE
fix: include inlined constants in namespace object

### DIFF
--- a/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "optimization": {
+      "inlineConst": { "mode": "all" }
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/artifacts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+// HIDDEN [\0rolldown/runtime.js]
+//#region bar.js
+var bar_exports = /* @__PURE__ */ __exportAll({ bar: () => "bar" });
+const bar = "bar";
+
+//#endregion
+//#region main.js
+assert.deepEqual(bar_exports, {
+	[Symbol.toStringTag]: "Module",
+	bar: "bar"
+});
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/bar.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/bar.js
@@ -1,0 +1,1 @@
+export const bar = "bar"

--- a/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/inline_const/namespace_object_export/main.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert';
+import * as ns from './bar';
+
+assert.deepEqual(ns, {
+  [Symbol.toStringTag]: 'Module',
+  bar: 'bar',
+});

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5445,6 +5445,10 @@ expression: output
 
 - main-!~{000}~.js => main-jzXyUv2k.js
 
+# tests/rolldown/optimization/inline_const/namespace_object_export
+
+- main-!~{000}~.js => main-_gmHMUS3.js
+
 # tests/rolldown/optimization/inline_const/ns_chain
 
 - main-!~{000}~.js => main-Brb9u1JP.js


### PR DESCRIPTION
This was not passing:
```js
// index.js
import assert from 'node:assert';
import * as ns from './bar';

assert.deepEqual(ns, {
  [Symbol.toStringTag]: 'Module',
  bar: 'bar',
});

// bar.js
export const bar = "bar"
```