### PR TITLE
test(rolldown_plugin_vite_manifest): use relative path for outPath

### DIFF
--- a/packages/rolldown/tests/fixtures/builtin-plugin/manifest/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/manifest/_config.ts
@@ -13,7 +13,7 @@ export default defineTest({
     plugins: [
       viteManifestPlugin({
         root: path.resolve(import.meta.dirname),
-        outPath: path.resolve(import.meta.dirname, 'dist/manifest.json'),
+        outPath: 'manifest.json',
         cssEntries: () => Object.fromEntries(new Map().entries()),
       }),
       {


### PR DESCRIPTION
It seems that `this.emitFile` does not support absolute paths for asset filenames.