### PR TITLE
fix: update the links to Rolldown docs in the error messages

### DIFF
--- a/crates/rolldown/src/module_loader/resolve_utils.rs
+++ b/crates/rolldown/src/module_loader/resolve_utils.rs
@@ -139,7 +139,7 @@ pub async fn resolve_dependencies(
                 },
                 format!("Matched alias not found for '{specifier}'"),
                     EventKind::ResolveError,
-                Some("May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details".to_string()),
+                Some("Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details".to_string()),
               ));
           }
           e => {

--- a/crates/rolldown/tests/esbuild/default/package_alias/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/package_alias/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ──────────┬─────────  
    │                  ╰─────────── Matched alias not found for '@abs-path/pkg7/foo'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```
@@ -28,7 +28,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ─────────┬────────  
    │                 ╰────────── Matched alias not found for '@scope-only/pkg8'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```

--- a/crates/rolldown/tests/esbuild/default/package_alias_match_longest/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/package_alias_match_longest/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ──────┬──────  
    │              ╰──────── Matched alias not found for 'pkg/bar/baz'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```
@@ -28,7 +28,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ────┬────  
    │            ╰────── Matched alias not found for 'pkg/baz'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```
@@ -43,7 +43,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ────────┬────────  
    │                ╰────────── Matched alias not found for 'pkg/foo/bar/baz'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```

--- a/crates/rolldown/tests/esbuild/default/warnings_inside_node_modules/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/warnings_inside_node_modules/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │                                                                                   ───────────┬───────────  
    │                                                                                              ╰───────────── Matched alias not found for '@plugin/bad-typeof.js'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```
@@ -28,7 +28,7 @@ source: crates/rolldown_testing/src/integration_test.rs
     │                                                                                   ────────────┬────────────  
     │                                                                                               ╰────────────── Matched alias not found for '@plugin/delete-super.js'
     │ 
-    │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+    │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ────╯
 
 ```
@@ -43,7 +43,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │                                                                                   ──────────┬──────────  
    │                                                                                             ╰──────────── Matched alias not found for '@plugin/dup-case.js'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```
@@ -58,7 +58,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │                                                                                   ───────────┬───────────  
    │                                                                                              ╰───────────── Matched alias not found for '@plugin/equals-nan.js'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```
@@ -73,7 +73,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │                                                                                   ──────────────┬─────────────  
    │                                                                                                 ╰─────────────── Matched alias not found for '@plugin/equals-neg-zero.js'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```
@@ -88,7 +88,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │                                                                                   ─────────────┬────────────  
    │                                                                                                ╰────────────── Matched alias not found for '@plugin/equals-object.js'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```
@@ -103,7 +103,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │                                                                                   ─────────┬─────────  
    │                                                                                            ╰─────────── Matched alias not found for '@plugin/not-in.js'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```
@@ -118,7 +118,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │                                                                                   ─────────────┬─────────────  
    │                                                                                                ╰─────────────── Matched alias not found for '@plugin/not-instanceof.js'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```
@@ -133,7 +133,7 @@ source: crates/rolldown_testing/src/integration_test.rs
     │                                                                                   ────────────┬───────────  
     │                                                                                               ╰───────────── Matched alias not found for '@plugin/read-setter.js'
     │ 
-    │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+    │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ────╯
 
 ```
@@ -148,7 +148,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │                                                                                   ───────────┬───────────  
    │                                                                                              ╰───────────── Matched alias not found for '@plugin/return-asi.js'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```
@@ -163,7 +163,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │                                                                                   ────────────┬────────────  
    │                                                                                               ╰────────────── Matched alias not found for '@plugin/write-getter.js'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/errors/resolve_alias/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/resolve_alias/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │        ────────┬────────  
    │                ╰────────── Matched alias not found for '@vue/test-utils'
    │ 
-   │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 ───╯
 
 ```

--- a/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain_and_help/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/unresolved_import_with_chain_and_help/artifacts.snap
@@ -13,7 +13,7 @@ source: crates/rolldown_testing/src/integration_test.rs
    │                   ──────────┬─────────  
    │                             ╰─────────── Matched alias not found for '@missing/something'
    │ 
-   │ Help 1: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+   │ Help 1: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
    │ 
    │ Help 2: 'lib.js' is imported by the following path:
    │           - lib.js

--- a/crates/rolldown/tests/rolldown/resolve/matched_alias_not_found/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/resolve/matched_alias_not_found/artifacts.snap
@@ -8,6 +8,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```text
 [RESOLVE_ERROR] Error: Could not resolve 'react/jsx-runtime' in main.jsx
   │ 
-  │ Help: May be you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/apis/config-options#resolve-alias for more details
+  │ Help: Maybe you expected `resolve.alias` to call other plugins resolveId hook? see the docs https://rolldown.rs/reference/InputOptions.resolve#alias for more details
 
 ```

--- a/crates/rolldown_error/src/build_diagnostic/events/prefer_builtin_feature.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/prefer_builtin_feature.rs
@@ -17,7 +17,7 @@ impl BuildEvent for PreferBuiltinFeature {
   fn message(&self, _opts: &DiagnosticOptions) -> String {
     if let Some(feature) = &self.builtin_feature {
       format!(
-        "Rolldown supports `{feature}` natively, please refer https://rolldown.rs/apis/config-options for more details, this is performant than passing `{}` to plugins option.{}",
+        "Rolldown supports `{feature}` natively. Please refer https://rolldown.rs/reference/ for more details. It is more performant than passing `{}` to plugins option.{}",
         self.plugin_name,
         self.additional_message.unwrap_or_default()
       )

--- a/packages/rolldown/tests/fixtures/plugin/prefer-builtin-feature/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/prefer-builtin-feature/_config.ts
@@ -20,16 +20,16 @@ export default defineTest({
   },
   afterTest() {
     expect(warnings).toMatchInlineSnapshot(`
-			[
-			  "[PREFER_BUILTIN_FEATURE] Warning: The functionality provided by \`@rollup/plugin-json\` is already covered natively, maybe you could remove the plugin from your configuration.
-			  │ 
-			  │ Help: This diagnostic may be false positive, you could turn it off via \`checks.preferBuiltinFeature\`
-			",
-			  "[PREFER_BUILTIN_FEATURE] Warning: Rolldown supports \`inject\` natively, please refer https://rolldown.rs/apis/config-options for more details, this is performant than passing \`@rollup/plugin-inject\` to plugins option.
-			  │ 
-			  │ Help: This diagnostic may be false positive, you could turn it off via \`checks.preferBuiltinFeature\`
-			",
-			]
-		`);
+      [
+        "[PREFER_BUILTIN_FEATURE] Warning: The functionality provided by \`@rollup/plugin-json\` is already covered natively, maybe you could remove the plugin from your configuration.
+        │ 
+        │ Help: This diagnostic may be false positive, you could turn it off via \`checks.preferBuiltinFeature\`
+      ",
+        "[PREFER_BUILTIN_FEATURE] Warning: Rolldown supports \`inject\` natively. Please refer https://rolldown.rs/reference/ for more details. It is more performant than passing \`@rollup/plugin-inject\` to plugins option.
+        │ 
+        │ Help: This diagnostic may be false positive, you could turn it off via \`checks.preferBuiltinFeature\`
+      ",
+      ]
+    `);
   },
 });


### PR DESCRIPTION
The links were stale.