### PR TITLE
build: remove warnings  for building rolldown with `not(feature = "experimental")`

### DIFF
--- a/crates/rolldown/src/bundler/impl_bundler_build.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_build.rs
@@ -10,23 +10,23 @@ impl Bundler {
   pub async fn write(&mut self) -> BuildResult<BundleOutput> {
     self.create_error_if_closed()?;
     // TODO: hyf0: Bad code smell: this overlaps with `incremental_write/xxx` APIs.
+    #[cfg(feature = "experimental")]
     if self.options.experimental.is_incremental_build_enabled() {
-      self.incremental_write(ScanMode::Full).await
-    } else {
-      let bundle = self.bundle_factory.create_bundle(BundleMode::FullBuild, None)?;
-      bundle.write().await
+      return self.incremental_write(ScanMode::Full).await;
     }
+    let bundle = self.bundle_factory.create_bundle(BundleMode::FullBuild, None)?;
+    bundle.write().await
   }
 
   #[tracing::instrument(level = "debug", skip_all, parent = &self.session.span)]
   pub async fn generate(&mut self) -> BuildResult<BundleOutput> {
     self.create_error_if_closed()?;
+    #[cfg(feature = "experimental")]
     if self.options.experimental.is_incremental_build_enabled() {
-      self.incremental_generate(ScanMode::Full).await
-    } else {
-      let bundle = self.bundle_factory.create_bundle(BundleMode::FullBuild, None)?;
-      bundle.generate().await
+      return self.incremental_generate(ScanMode::Full).await;
     }
+    let bundle = self.bundle_factory.create_bundle(BundleMode::FullBuild, None)?;
+    bundle.generate().await
   }
 
   #[tracing::instrument(target = "devtool", level = "debug", skip_all)]


### PR DESCRIPTION
The `rolldown` crate fails to build with its default featureset, since these two function calls aren't gated by `#[cfg(feature = "experimental")]`. Though it seems like it'd probably make more sense to get rid of that feature entirely, since there's a lot of experimental features that are available even without it.