### PR TITLE
refactor(module-loader): remove intermediate ModuleTaskOwnerRef type

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -28,12 +28,13 @@ use rolldown_utils::rustc_hash::FxHashSetExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::Instrument;
 
+use crate::module_loader::module_task::ModuleTaskOwner;
 use crate::types::scan_stage_cache::ScanStageCache;
 use crate::utils::load_entry_module::load_entry_module;
 use crate::{SharedOptions, SharedResolver};
 
 use super::external_module_task::ExternalModuleTask;
-use super::module_task::{ModuleTask, ModuleTaskOwnerRef};
+use super::module_task::ModuleTask;
 use super::runtime_module_task::RuntimeModuleTask;
 use super::task_context::{TaskContext, TaskContextMeta};
 
@@ -207,7 +208,7 @@ impl<'a> ModuleLoader<'a> {
   fn try_spawn_new_task(
     &mut self,
     resolved_id: ResolvedId,
-    owner: Option<ModuleTaskOwnerRef>,
+    owner: Option<ModuleTaskOwner>,
     is_user_defined_entry: bool,
     assert_module_type: Option<&ModuleType>,
     user_defined_entries: &Arc<Vec<(Option<ArcStr>, ResolvedId)>>,
@@ -258,7 +259,7 @@ impl<'a> ModuleLoader<'a> {
         ctx,
         idx,
         resolved_id,
-        owner.map(Into::into),
+        owner,
         is_user_defined_entry,
         assert_module_type.cloned(),
         self.flat_options,
@@ -433,7 +434,7 @@ impl<'a> ModuleLoader<'a> {
 
             let idx = self.try_spawn_new_task(
               resolved_id,
-              Some(ModuleTaskOwnerRef::new(normal_module, raw_rec.span)),
+              Some(ModuleTaskOwner::new(normal_module, raw_rec.span)),
               false,
               raw_rec.asserted_module_type.as_ref(),
               &user_defined_entries,
@@ -921,7 +922,7 @@ impl<'a> ModuleLoader<'a> {
           None => {
             let new_idx = self.try_spawn_new_task(
               resolved_id.clone(),
-              Some(ModuleTaskOwnerRef::new(barrel_normal_module, import_record_state.span)),
+              Some(ModuleTaskOwner::new(barrel_normal_module, import_record_state.span)),
               false,
               import_record_state.asserted_module_type.as_ref(),
               user_defined_entries,

--- a/crates/rolldown/src/module_loader/module_task.rs
+++ b/crates/rolldown/src/module_loader/module_task.rs
@@ -26,31 +26,20 @@ use crate::{
 
 use super::{resolve_utils::resolve_dependencies, task_context::TaskContext};
 
-pub struct ModuleTaskOwnerRef<'a> {
-  module: &'a NormalModule,
-  importee_span: Span,
-}
-
-impl<'a> ModuleTaskOwnerRef<'a> {
-  pub fn new(module: &'a NormalModule, importee_span: Span) -> Self {
-    Self { module, importee_span }
-  }
-}
-
-impl From<ModuleTaskOwnerRef<'_>> for ModuleTaskOwner {
-  fn from(owner: ModuleTaskOwnerRef) -> Self {
-    ModuleTaskOwner {
-      source: owner.module.source.clone(),
-      importer_id: owner.module.stable_id.as_arc_str().clone(),
-      importee_span: owner.importee_span,
-    }
-  }
-}
-
 pub struct ModuleTaskOwner {
   source: ArcStr,
   importer_id: ArcStr,
   importee_span: Span,
+}
+
+impl ModuleTaskOwner {
+  pub fn new(normal_module: &NormalModule, importee_span: Span) -> Self {
+    Self {
+      source: normal_module.source.clone(),
+      importer_id: normal_module.stable_id.as_arc_str().clone(),
+      importee_span,
+    }
+  }
 }
 
 pub struct ModuleTask {

--- a/crates/rolldown_error/src/build_diagnostic/events/unloadable_dependency.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/unloadable_dependency.rs
@@ -1,6 +1,7 @@
-use crate::types::diagnostic_options::DiagnosticOptions;
 use arcstr::ArcStr;
 use oxc::span::Span;
+
+use crate::types::diagnostic_options::DiagnosticOptions;
 
 use super::BuildEvent;
 


### PR DESCRIPTION
Since we previously removed the conversion from `ArcStr` to `CompactStr`, cloning here (i.e. cloning the `ArcStr`) is cheap. This also resolves the mutable vs. immutable borrow conflict in the follow-up PR.