### PR TITLE
refactor: use logger instead of console.log for warnings

### DIFF
--- a/packages/rolldown/src/cli/logger.ts
+++ b/packages/rolldown/src/cli/logger.ts
@@ -30,8 +30,9 @@ function createTestingLogger() {
   ];
   const ret: Record<string, any> = Object.create(null);
   for (const type of types) {
+    // Use a wrapper function to allow spying in tests
     // oxlint-disable-next-line no-console
-    ret[type] = console.log;
+    ret[type] = (...args: unknown[]) => console.log(...args);
   }
   return ret;
 }

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -4,6 +4,7 @@ import { ChunkingContextImpl } from '../types/chunking-context';
 import { transformAssetSource } from './asset-source';
 import { unimplemented } from './misc';
 import { transformRenderedChunk } from './transform-rendered-chunk';
+import { logger } from '../cli/logger';
 
 export function bindingifyOutputOptions(outputOptions: OutputOptions): BindingOutputOptions {
   const {
@@ -188,7 +189,7 @@ function bindingifyCodeSplitting(
   if (codeSplitting === false) {
     // Warn if inlineDynamicImports is also set
     if (inlineDynamicImportsOption != null) {
-      console.warn(
+      logger.warn(
         '`inlineDynamicImports` option is ignored because `codeSplitting: false` is set.',
       );
     }
@@ -200,7 +201,7 @@ function bindingifyCodeSplitting(
     }
     // When code splitting is disabled, ignore advancedChunks
     if (advancedChunks != null) {
-      console.warn('`advancedChunks` option is ignored because `codeSplitting` is set to `false`.');
+      logger.warn('`advancedChunks` option is ignored because `codeSplitting` is set to `false`.');
     }
     // Return early - no advanced chunks when code splitting is disabled
     return {
@@ -210,15 +211,13 @@ function bindingifyCodeSplitting(
   } else if (codeSplitting === true) {
     // Explicit code splitting enabled - ignore deprecated inlineDynamicImports
     if (inlineDynamicImportsOption != null) {
-      console.warn(
-        '`inlineDynamicImports` option is ignored because `codeSplitting: true` is set.',
-      );
+      logger.warn('`inlineDynamicImports` option is ignored because `codeSplitting: true` is set.');
     }
   } else if (codeSplitting == null) {
     // Default behavior: no inlining, automatic code splitting
     // Check if deprecated inlineDynamicImports is used
     if (inlineDynamicImportsOption != null) {
-      console.warn(
+      logger.warn(
         '`inlineDynamicImports` option is deprecated, please use `codeSplitting: false` instead.',
       );
       inlineDynamicImports = inlineDynamicImportsOption;
@@ -228,7 +227,7 @@ function bindingifyCodeSplitting(
     effectiveChunksOption = codeSplitting;
     // Ignore inlineDynamicImports if codeSplitting object is specified
     if (inlineDynamicImportsOption != null) {
-      console.warn(
+      logger.warn(
         '`inlineDynamicImports` option is ignored because the `codeSplitting` option is specified.',
       );
     }
@@ -244,18 +243,18 @@ function bindingifyCodeSplitting(
   // Handle advancedChunks deprecation (only if codeSplitting is not set to object)
   if (effectiveChunksOption == null) {
     if (advancedChunks != null) {
-      console.warn('`advancedChunks` option is deprecated, please use `codeSplitting` instead.');
+      logger.warn('`advancedChunks` option is deprecated, please use `codeSplitting` instead.');
       effectiveChunksOption = advancedChunks;
     }
   } else if (advancedChunks != null) {
-    console.warn(
+    logger.warn(
       '`advancedChunks` option is ignored because the `codeSplitting` option is specified.',
     );
   }
 
   // Handle manualChunks migration
   if (manualChunks != null && effectiveChunksOption != null) {
-    console.warn(
+    logger.warn(
       '`manualChunks` option is ignored because the `codeSplitting` option is specified.',
     );
   } else if (manualChunks != null) {

--- a/packages/rolldown/tests/utils/bindingify-code-splitting.test.ts
+++ b/packages/rolldown/tests/utils/bindingify-code-splitting.test.ts
@@ -4,7 +4,7 @@ import { expect, test, vi, beforeEach, afterEach } from 'vitest';
 let consoleSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
-  consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 });
 
 afterEach(() => {


### PR DESCRIPTION
**before**:
![image.png](https://app.graphite.com/user-attachments/assets/fe38c6b4-4a3e-4ef3-8008-3f20d63caefe.png)

**after**:   
![image.png](https://app.graphite.com/user-attachments/assets/03c64c00-f3d1-4eac-b2c4-c53324348b31.png)

