### PR TITLE
feat: consolidate same tsconfig errors

### DIFF
--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -19,7 +19,9 @@ use rolldown_common::{
   SymbolRefDbForModule,
 };
 use rolldown_ecmascript::EcmaAst;
-use rolldown_error::{BuildDiagnostic, BuildResult, DiagnosableResolveError};
+use rolldown_error::{
+  BuildDiagnostic, BuildResult, DiagnosableResolveError, consolidate_diagnostics,
+};
 use rolldown_fs::OsFileSystem;
 use rolldown_plugin::SharedPluginDriver;
 use rolldown_utils::indexmap::FxIndexSet;
@@ -644,6 +646,7 @@ impl<'a> ModuleLoader<'a> {
         }
       }
 
+      let errors = consolidate_diagnostics(errors);
       return Err(errors.into());
     }
     if let Some(tx) = self.magic_string_tx.as_ref() {

--- a/crates/rolldown/tests/rolldown/errors/tsconfig_error/consolidate_same_errors/_config.json
+++ b/crates/rolldown/tests/rolldown/errors/tsconfig_error/consolidate_same_errors/_config.json
@@ -1,0 +1,9 @@
+{
+  "config": {
+    "input": [
+      { "name": "main1", "import": "./main1.ts" },
+      { "name": "main2", "import": "./main2.ts" }
+    ]
+  },
+  "expectError": true
+}

--- a/crates/rolldown/tests/rolldown/errors/tsconfig_error/consolidate_same_errors/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/errors/tsconfig_error/consolidate_same_errors/artifacts.snap
@@ -1,0 +1,11 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Errors
+
+## TSCONFIG_ERROR
+
+```text
+[TSCONFIG_ERROR] Error: Failed to load tsconfig for 'main1.ts', 'main2.ts': Tsconfig not found
+
+```

--- a/crates/rolldown/tests/rolldown/errors/tsconfig_error/consolidate_same_errors/main1.ts
+++ b/crates/rolldown/tests/rolldown/errors/tsconfig_error/consolidate_same_errors/main1.ts
@@ -1,0 +1,1 @@
+export const foo = 1;

--- a/crates/rolldown/tests/rolldown/errors/tsconfig_error/consolidate_same_errors/main2.ts
+++ b/crates/rolldown/tests/rolldown/errors/tsconfig_error/consolidate_same_errors/main2.ts
@@ -1,0 +1,1 @@
+export const bar = 2;

--- a/crates/rolldown/tests/rolldown/errors/tsconfig_error/consolidate_same_errors/tsconfig.json
+++ b/crates/rolldown/tests/rolldown/errors/tsconfig_error/consolidate_same_errors/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./foo.json"
+}

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -376,6 +376,6 @@ impl BuildDiagnostic {
   }
 
   pub fn tsconfig_error(file_path: String, reason: ResolveError) -> Self {
-    Self::new_inner(TsConfigError { file_path, reason })
+    Self::new_inner(TsConfigError { file_paths: vec![file_path], reason })
   }
 }

--- a/crates/rolldown_error/src/build_diagnostic/events/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/mod.rs
@@ -49,7 +49,7 @@ pub mod unloadable_dependency;
 pub mod unresolved_entry;
 pub mod unsupported_feature;
 
-pub trait BuildEvent: Debug + Sync + Send + AsAnyMut {
+pub trait BuildEvent: Debug + Sync + Send + AsAny + AsAnyMut {
   fn kind(&self) -> EventKind;
 
   fn message(&self, opts: &DiagnosticOptions) -> String;
@@ -82,6 +82,16 @@ where
 {
   fn from(e: T) -> Self {
     Box::new(e)
+  }
+}
+
+pub trait AsAny {
+  fn as_any(&self) -> &dyn Any;
+}
+
+impl<T: 'static + BuildEvent> AsAny for T {
+  fn as_any(&self) -> &dyn Any {
+    self
   }
 }
 

--- a/crates/rolldown_error/src/lib.rs
+++ b/crates/rolldown_error/src/lib.rs
@@ -7,6 +7,7 @@ pub type BuildResult<T> = Result<T, BatchedBuildDiagnostic>;
 pub type SingleBuildResult<T> = std::result::Result<T, BuildDiagnostic>;
 
 pub use crate::{
+  build_diagnostic::consolidate_diagnostics,
   build_diagnostic::events::DiagnosableArcstr,
   build_diagnostic::events::ambiguous_external_namespace::AmbiguousExternalNamespaceModule,
   build_diagnostic::events::bundler_initialize_error::BundlerInitializeError,


### PR DESCRIPTION
Consolidate same tsconfig errors into one error so that the output is cleaner.
I'm not sure if there's a better way to achieve this.
