### PR TITLE
test: mark `output.dynamicImportInCjs` tests as passed

### DIFF
--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -18,11 +18,8 @@
  - rollup@function@plugin-error-should-transform: errors in shouldTransformCachedModule abort the build
 
 ### The `resolveDynamicImport` hook `specifier: AstNode` not supported
-- rollup@function@plugin-error-should-transform: errors in shouldTransformCachedModule abort the build
-
-### The `resolveDynamicImport` hook `specifier: AstNode` not supported
-- rollup@form@dynamic-import-unresolvable: Returns the raw AST nodes for unresolvable dynamic imports@generates es
-- rollup@function@dynamic-import-expression: Dynamic import expression replacement
+ - rollup@form@dynamic-import-unresolvable: Returns the raw AST nodes for unresolvable dynamic imports@generates es
+ - rollup@function@dynamic-import-expression: Dynamic import expression replacement
 
 ### The plugin `sequential` is not supported
  - rollup@function@enforce-sequential-plugin-order: allows to enforce sequential plugin hook order for parallel plugin hooks

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -14,7 +14,6 @@
  - rollup@function@validate-resolved-by-logic: validate resolvedBy logic
 
 ### The `shouldTransformCachedModule` hook is not supported
- - rollup@function@dynamic-import-expression: Dynamic import expression replacement
  - rollup@function@plugin-error-should-transform: errors in shouldTransformCachedModule abort the build
 
 ### The `resolveDynamicImport` hook `specifier: AstNode` not supported

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -14,6 +14,7 @@
  - rollup@function@validate-resolved-by-logic: validate resolvedBy logic
 
 ### The `shouldTransformCachedModule` hook is not supported
+ - rollup@function@dynamic-import-expression: Dynamic import expression replacement
  - rollup@function@plugin-error-should-transform: errors in shouldTransformCachedModule abort the build
 
 ### The `resolveDynamicImport` hook `specifier: AstNode` not supported
@@ -115,11 +116,6 @@
 ### The `input.perf` and `bundle.getTimings()` is not supported
  - rollup@function@adds-timings-to-bundle-when-codesplitting: Adds timing information to bundle when bundling with perf=true
  - rollup@function@adds-timings-to-bundle: Adds timing information to bundle when bundling with perf=true
-
-### `output.dynamicImportInCjs` is not compatible yet
- - rollup@function@dynamic-import-this-function: uses correct "this" in dynamic imports when not using arrow functions
- - rollup@function@dynamic-import-this-arrow: uses correct "this" in dynamic imports when using arrow functions
- - rollup@function@dynamic-import-expression: Dynamic import expression replacement
 
 ### The `input.moduleContext` is not supported
  - rollup@form@custom-module-context-function: allows custom module-specific context with a function option

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -18,7 +18,11 @@
  - rollup@function@plugin-error-should-transform: errors in shouldTransformCachedModule abort the build
 
 ### The `resolveDynamicImport` hook `specifier: AstNode` not supported
- - rollup@form@dynamic-import-unresolvable: Returns the raw AST nodes for unresolvable dynamic imports@generates es
+- rollup@function@plugin-error-should-transform: errors in shouldTransformCachedModule abort the build
+
+### The `resolveDynamicImport` hook `specifier: AstNode` not supported
+- rollup@form@dynamic-import-unresolvable: Returns the raw AST nodes for unresolvable dynamic imports@generates es
+- rollup@function@dynamic-import-expression: Dynamic import expression replacement
 
 ### The plugin `sequential` is not supported
  - rollup@function@enforce-sequential-plugin-order: allows to enforce sequential plugin hook order for parallel plugin hooks

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -2,8 +2,8 @@
   "failed": 0,
   "skipFailed": 7,
   "ignored": 95,
-  "ignored(unsupported features)": 311,
+  "ignored(unsupported features)": 309,
   "ignored(treeshaking)": 324,
   "ignored(behavior passed, snapshot different)": 157,
-  "passed": 912
+  "passed": 914
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -3,7 +3,7 @@
 | failed | 0 |
 | skipFailed | 7 |
 | ignored | 95 |
-| ignored(unsupported features) | 311 |
+| ignored(unsupported features) | 309 |
 | ignored(treeshaking) | 324 |
 | ignored(behavior passed, snapshot different) | 157 |
-| passed | 912 |
+| passed | 914 |


### PR DESCRIPTION
closes #7784

`rollup@function@dynamic-import-this-function` and `rollup@function@dynamic-import-this-arrow` are passing. `rollup@function@dynamic-import-expression` fails because we do not support `resolveDynamicImport(specifier)` when the `specifier` is an AST node.

Below test case config is `rollup@function@dynamic-import-expression`:
```js
const assert = require('node:assert');

module.exports = defineTest({
	description: 'Dynamic import expression replacement',
	options: {
		plugins: [
			{
				resolveDynamicImport(specifier) {
					if (
						typeof specifier !== 'string' && // string literal concatenation
						specifier.type === 'BinaryExpression' &&
						specifier.operator === '+' &&
						specifier.left.type === 'Literal' &&
						specifier.right.type === 'Literal' &&
						typeof specifier.left.value === 'string' &&
						typeof specifier.right.value === 'string'
					) {
						return '"' + specifier.left.value + specifier.right.value + '"';
					}
				}
			}
		],
		output: { dynamicImportInCjs: false }
	},
	exports(exports) {
		const expectedError = "Cannot find module 'x/y'";
		return exports.catch(error =>
			assert.strictEqual(error.message.slice(0, expectedError.length), expectedError)
		);
	}
});
```