### PR TITLE
docs(lazy-barrel): clarify default export behavior

### DIFF
--- a/docs/in-depth/lazy-barrel-optimization.md
+++ b/docs/in-depth/lazy-barrel-optimization.md
@@ -147,7 +147,7 @@ export const increment = () => {
 
 :::
 
-For this reason, `export default ...` is considered as a own export and may prevent the optimization (see [Own exports](#own-exports-non-pure-re-export-barrels)).
+For this reason, `export default ...` is considered an own export and may prevent the optimization (see [Own exports](#own-exports-non-pure-re-export-barrels)).
 :::
 
 ## Advanced scenarios

--- a/docs/in-depth/lazy-barrel-optimization.md
+++ b/docs/in-depth/lazy-barrel-optimization.md
@@ -63,6 +63,7 @@ export * from './components';
 export { Component } from './Component';
 export { helper as utils } from './helper';
 export { default as Button } from './Button';
+export { Button as default } from './Button';
 ```
 
 ### Namespace re-exports
@@ -77,6 +78,10 @@ export * as ns from './module';
 // Equivalent to `export { a } from './a'`
 import { a } from './a';
 export { a };
+
+// Equivalent to `export { a as default } from './a'`
+import { a } from './a';
+export { a as default };
 
 // Equivalent to `export * as ns from './module'`
 import * as ns from './module';
@@ -99,6 +104,14 @@ export * from './more';
 When an import can be found in named exports, star exports are not searched, avoiding unnecessary module loading.
 
 However, if the import is not found in named exports, all star re-exports will be loaded to resolve it. If those star re-exported modules are also barrel modules, only the specific import specifier will be loaded from them.
+
+::: warning Re-export vs Own export for default
+`export { Button as default } from './Button'` and `import { Button } from './Button'; export default Button` are **not equivalent** for lazy barrel optimization.
+
+The first is a re-export — only `./Button` is loaded when `default` is imported.
+
+The second is an own export — `export default Button` references a local binding, making `default` an own export of the barrel. When `default` is imported, all of the barrel's import records must be loaded (see [Own exports](#own-exports-non-pure-re-export-barrels)).
+:::
 
 ## Advanced scenarios
 
@@ -180,9 +193,11 @@ export { d } from './d';
 console.log(b);
 
 export const index = 'index'; // own export
+export default b; // `default` is an own export
 
 // main.js
 import { index, c } from './barrel';
+// or import b, { c } from './barrel';
 ```
 
 In this case, when `index` is imported: `a.js`, `b.js`, `c.js`, and `d.js` are all loaded:

--- a/docs/in-depth/lazy-barrel-optimization.md
+++ b/docs/in-depth/lazy-barrel-optimization.md
@@ -117,30 +117,32 @@ This example shows the difference:
 ::: code-group
 
 ```js [main.js]
-import { Button, increment } from './Button.js'
-import ExportDefaultButton, { ReExportedButton } from './re-exporter.js'
+import { Button, increment } from './Button.js';
+import ExportDefaultButton, { ReExportedButton } from './re-exporter.js';
 
-console.log(Button) // 1
-console.log(ReExportedButton) // 1
-console.log(ExportDefaultButton) // 1
+console.log(Button); // 1
+console.log(ReExportedButton); // 1
+console.log(ExportDefaultButton); // 1
 
-increment()
+increment();
 
-console.log(Button) // 2
-console.log(ReExportedButton) // 2
-console.log(ExportDefaultButton) // 1
+console.log(Button); // 2
+console.log(ReExportedButton); // 2
+console.log(ExportDefaultButton); // 1
 ```
+
 ```js [re-exporter.js]
-import { Button } from './Button.js'
-export default Button
+import { Button } from './Button.js';
+export default Button;
 
-export { Button as ReExportedButton } from './Button.js'
+export { Button as ReExportedButton } from './Button.js';
 ```
+
 ```js [Button.js]
-export let Button = 1
+export let Button = 1;
 export const increment = () => {
-  Button++
-}
+  Button++;
+};
 ```
 
 :::

--- a/docs/in-depth/lazy-barrel-optimization.md
+++ b/docs/in-depth/lazy-barrel-optimization.md
@@ -105,7 +105,7 @@ When an import can be found in named exports, star exports are not searched, avo
 
 However, if the import is not found in named exports, all star re-exports will be loaded to resolve it. If those star re-exported modules are also barrel modules, only the specific import specifier will be loaded from them.
 
-::: warning Re-export vs Own export for default
+:::: warning Re-export vs Own export for default
 `export { Button as default } from './Button.js'` and `import { Button } from './Button.js'; export default Button` are **not equivalent**.
 
 In the former case, the value exported is synced with the value in `Button.js`. This is because it points to the same variable.
@@ -148,7 +148,7 @@ export const increment = () => {
 :::
 
 For this reason, `export default ...` is considered an own export and may prevent the optimization (see [Own exports](#own-exports-non-pure-re-export-barrels)).
-:::
+::::
 
 ## Advanced scenarios
 


### PR DESCRIPTION
We should clarify the default export behavior:

`export { Button as default } from './Button'` and `import { Button } from './Button'; export default Button` are **not equivalent**.