### PR TITLE
chore: disallow `HashMap::new` and `HashSet::new` by clippy

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -3,3 +3,8 @@ too-many-lines-threshold = 200
 # We don't have any downstream users, we don't care about external API changes,
 # and this makes the codebase cleaner
 avoid-breaking-exported-api = false
+
+disallowed-methods = [
+  { path = "std::collections::HashMap::new", reason = "prefer FxHashMap", replacement = "rustc_hash::FxHashMap::default" },
+  { path = "std::collections::HashSet::new", reason = "prefer FxHashSet", replacement = "rustc_hash::FxHashMap::default" },
+]


### PR DESCRIPTION
Disallow `HashMap::new` and `HashSet::new`. I didn't disallow `HashMap` and `HashSet` because there are many places that using the type itself makes sense.