### PR TITLE
feat: add `inputMap` option to `minify` / `minifySync` functions

### DIFF
--- a/crates/rolldown_binding/src/types/binding_sourcemap.rs
+++ b/crates/rolldown_binding/src/types/binding_sourcemap.rs
@@ -64,19 +64,23 @@ impl TryFrom<BindingJsonSourcemap> for rolldown_sourcemap::SourceMap {
   }
 }
 
-impl From<rolldown_sourcemap::JSONSourceMap> for BindingSourcemap {
+impl From<rolldown_sourcemap::JSONSourceMap> for BindingJsonSourcemap {
   fn from(value: rolldown_sourcemap::JSONSourceMap) -> Self {
     Self {
-      inner: Either::B(BindingJsonSourcemap {
-        file: value.file,
-        mappings: Some(value.mappings),
-        source_root: value.source_root,
-        sources: Some(value.sources.into_iter().map(Some).collect()),
-        sources_content: value.sources_content,
-        names: Some(value.names),
-        debug_id: value.debug_id,
-        x_google_ignore_list: value.x_google_ignore_list,
-      }),
+      file: value.file,
+      mappings: Some(value.mappings),
+      source_root: value.source_root,
+      sources: Some(value.sources.into_iter().map(Some).collect()),
+      sources_content: value.sources_content,
+      names: Some(value.names),
+      debug_id: value.debug_id,
+      x_google_ignore_list: value.x_google_ignore_list,
     }
+  }
+}
+
+impl From<rolldown_sourcemap::JSONSourceMap> for BindingSourcemap {
+  fn from(value: rolldown_sourcemap::JSONSourceMap) -> Self {
+    Self { inner: Either::B(value.into()) }
   }
 }

--- a/crates/rolldown_binding/src/utils/collapse_sourcemaps.rs
+++ b/crates/rolldown_binding/src/utils/collapse_sourcemaps.rs
@@ -1,0 +1,12 @@
+use crate::types::binding_sourcemap::{BindingJsonSourcemap, BindingSourcemap};
+
+#[napi_derive::napi]
+pub fn collapse_sourcemaps(
+  sourcemap_chain: Vec<BindingSourcemap>,
+) -> napi::Result<BindingJsonSourcemap> {
+  let sourcemap_chain =
+    sourcemap_chain.into_iter().map(TryInto::try_into).collect::<Result<Vec<_>, _>>()?;
+  let collapsed =
+    rolldown_sourcemap::collapse_sourcemaps(&sourcemap_chain.iter().collect::<Vec<_>>());
+  Ok(collapsed.to_json().into())
+}

--- a/crates/rolldown_binding/src/utils/mod.rs
+++ b/crates/rolldown_binding/src/utils/mod.rs
@@ -1,5 +1,6 @@
 mod normalize_binding_transform_options;
 
+pub mod collapse_sourcemaps;
 pub mod create_bundler_config_from_binding_options;
 pub mod minify_options_conversion;
 pub mod napi_error;

--- a/packages/rolldown/src/binding.cjs
+++ b/packages/rolldown/src/binding.cjs
@@ -631,6 +631,7 @@ module.exports.BindingPluginOrder = nativeBinding.BindingPluginOrder
 module.exports.BindingPropertyReadSideEffects = nativeBinding.BindingPropertyReadSideEffects
 module.exports.BindingPropertyWriteSideEffects = nativeBinding.BindingPropertyWriteSideEffects
 module.exports.BindingRebuildStrategy = nativeBinding.BindingRebuildStrategy
+module.exports.collapseSourcemaps = nativeBinding.collapseSourcemaps
 module.exports.createTokioRuntime = nativeBinding.createTokioRuntime
 module.exports.FilterTokenKind = nativeBinding.FilterTokenKind
 module.exports.initTraceSubscriber = nativeBinding.initTraceSubscriber

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2513,6 +2513,8 @@ export interface BindingWatchOption {
   onInvalidate?: ((id: string) => void) | undefined
 }
 
+export declare function collapseSourcemaps(sourcemapChain: Array<BindingSourcemap>): BindingJsonSourcemap
+
 export declare function createTokioRuntime(blockingThreads?: number | undefined | null): void
 
 export interface ExtensionAliasItem {

--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -10,10 +10,6 @@ export {
   type IsolatedDeclarationsOptions,
   type IsolatedDeclarationsResult,
   isolatedDeclarationSync,
-  minify,
-  type MinifyOptions,
-  type MinifyResult,
-  minifySync,
   moduleRunnerTransform,
   type NapiResolveOptions as ResolveOptions,
   type ParseResult,
@@ -28,6 +24,7 @@ export {
 
 export { defineParallelPlugin } from './plugin/parallel-plugin';
 export { parse, parseSync } from './utils/parse';
+export { minify, type MinifyOptions, type MinifyResult, minifySync } from './utils/minify';
 // Builtin plugin factory
 export {
   isolatedDeclarationPlugin,

--- a/packages/rolldown/src/rolldown-binding.wasi-browser.js
+++ b/packages/rolldown/src/rolldown-binding.wasi-browser.js
@@ -118,6 +118,7 @@ export const BindingPluginOrder = __napiModule.exports.BindingPluginOrder
 export const BindingPropertyReadSideEffects = __napiModule.exports.BindingPropertyReadSideEffects
 export const BindingPropertyWriteSideEffects = __napiModule.exports.BindingPropertyWriteSideEffects
 export const BindingRebuildStrategy = __napiModule.exports.BindingRebuildStrategy
+export const collapseSourcemaps = __napiModule.exports.collapseSourcemaps
 export const createTokioRuntime = __napiModule.exports.createTokioRuntime
 export const FilterTokenKind = __napiModule.exports.FilterTokenKind
 export const initTraceSubscriber = __napiModule.exports.initTraceSubscriber

--- a/packages/rolldown/src/rolldown-binding.wasi.cjs
+++ b/packages/rolldown/src/rolldown-binding.wasi.cjs
@@ -163,6 +163,7 @@ module.exports.BindingPluginOrder = __napiModule.exports.BindingPluginOrder
 module.exports.BindingPropertyReadSideEffects = __napiModule.exports.BindingPropertyReadSideEffects
 module.exports.BindingPropertyWriteSideEffects = __napiModule.exports.BindingPropertyWriteSideEffects
 module.exports.BindingRebuildStrategy = __napiModule.exports.BindingRebuildStrategy
+module.exports.collapseSourcemaps = __napiModule.exports.collapseSourcemaps
 module.exports.createTokioRuntime = __napiModule.exports.createTokioRuntime
 module.exports.FilterTokenKind = __napiModule.exports.FilterTokenKind
 module.exports.initTraceSubscriber = __napiModule.exports.initTraceSubscriber

--- a/packages/rolldown/src/utils/minify.ts
+++ b/packages/rolldown/src/utils/minify.ts
@@ -1,0 +1,54 @@
+import {
+  minify as originalMinify,
+  minifySync as originalMinifySync,
+  collapseSourcemaps,
+  type MinifyOptions as OriginalMinifyOptions,
+  type MinifyResult,
+  type SourceMap,
+} from '../binding.cjs';
+import { bindingifySourcemap } from '../types/sourcemap';
+
+type MinifyOptions = OriginalMinifyOptions & {
+  inputMap?: SourceMap;
+};
+
+/**
+ * Minify asynchronously.
+ *
+ * Note: This function can be slower than `minifySync` due to the overhead of spawning a thread.
+ */
+async function minify(
+  filename: string,
+  sourceText: string,
+  options?: MinifyOptions | null,
+): Promise<MinifyResult> {
+  const inputMap = bindingifySourcemap(options?.inputMap);
+  const result = await originalMinify(filename, sourceText, options);
+  if (result.map && inputMap) {
+    result.map = {
+      version: 3,
+      ...collapseSourcemaps([inputMap, bindingifySourcemap(result.map)!]),
+    } as SourceMap;
+  }
+  return result;
+}
+
+/** Minify synchronously. */
+function minifySync(
+  filename: string,
+  sourceText: string,
+  options?: MinifyOptions | null,
+): MinifyResult {
+  const inputMap = bindingifySourcemap(options?.inputMap);
+  const result = originalMinifySync(filename, sourceText, options);
+  if (result.map && inputMap) {
+    result.map = {
+      version: 3,
+      ...collapseSourcemaps([inputMap, bindingifySourcemap(result.map)!]),
+    } as SourceMap;
+  }
+  return result;
+}
+
+export { minify, minifySync };
+export type { MinifyOptions, MinifyResult };

--- a/packages/rolldown/tests/utils/minify.test.ts
+++ b/packages/rolldown/tests/utils/minify.test.ts
@@ -1,0 +1,62 @@
+import { minify, minifySync } from 'rolldown/experimental';
+import { expect, test } from 'vitest';
+
+// Generated from `transformSync('original.ts', 'const a: number = 1;', { sourcemap: true })`
+const transformedCode = 'const a = 1;\n';
+const transformedMap = {
+  version: 3 as const,
+  sources: ['original.ts'],
+  sourcesContent: ['const a: number = 1;'],
+  names: [],
+  mappings: 'AAAA,MAAM,IAAY',
+};
+
+test('minify', async () => {
+  const result = await minify('foo.js', 'const a = 1;');
+  expect(result.code).toBe('const a=1;');
+  expect(result.map).toBeUndefined();
+});
+
+test('minify with sourcemap', async () => {
+  const result = await minify('foo.js', 'const a = 1;', { sourcemap: true });
+  expect(result.code).toBe('const a=1;');
+  expect(result.map).toBeDefined();
+  expect(result.map?.sources).toEqual(['foo.js']);
+});
+
+test('minify with inputMap', async () => {
+  const result = await minify('original.js', transformedCode, {
+    sourcemap: true,
+    inputMap: transformedMap,
+  });
+
+  expect(result.code).toBe('const a=1;');
+  expect(result.map).toBeDefined();
+  expect(result.map?.sources).toEqual(['original.ts']);
+  expect(result.map?.sourcesContent).toEqual(['const a: number = 1;']);
+});
+
+test('minifySync', () => {
+  const result = minifySync('foo.js', 'const a = 1;');
+  expect(result.code).toBe('const a=1;');
+  expect(result.map).toBeUndefined();
+});
+
+test('minifySync with sourcemap', () => {
+  const result = minifySync('foo.js', 'const a = 1;', { sourcemap: true });
+  expect(result.code).toBe('const a=1;');
+  expect(result.map).toBeDefined();
+  expect(result.map?.sources).toEqual(['foo.js']);
+});
+
+test('minifySync with inputMap', () => {
+  const result = minifySync('original.js', transformedCode, {
+    sourcemap: true,
+    inputMap: transformedMap,
+  });
+
+  expect(result.code).toBe('const a=1;');
+  expect(result.map).toBeDefined();
+  expect(result.map?.sources).toEqual(['original.ts']);
+  expect(result.map?.sourcesContent).toEqual(['const a: number = 1;']);
+});


### PR DESCRIPTION
Add `inputMap` option to `minify` / `minifySync` functions so that it is easier to migrate from [`transformWithEsbuild` function](https://github.com/vitejs/vite/blob/c47015eba4f0de255218c35769628d87152216ca/packages/vite/src/node/plugins/esbuild.ts#L99).