### PR TITLE
feat(rust): introduce `rolldown_watcher`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,6 +2764,7 @@ dependencies = [
  "rolldown_testing",
  "rolldown_tracing",
  "rolldown_utils",
+ "rolldown_watcher",
  "rolldown_workspace",
  "rustc-hash",
  "serde",
@@ -3630,6 +3631,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rolldown_watcher"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arcstr",
+ "oxc_index",
+ "rolldown",
+ "rolldown-notify",
+ "rolldown_common",
+ "rolldown_error",
+ "rolldown_fs_watcher",
+ "rolldown_utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "rolldown_workspace"
 version = "0.1.0"
 
@@ -3844,6 +3862,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -4149,8 +4177,12 @@ version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -78,8 +78,10 @@ dunce = { workspace = true }
 glob = { workspace = true }
 insta = { workspace = true }
 regex = { workspace = true }
+rolldown_common = { workspace = true }
 rolldown_dev = { path = "../rolldown_dev" }
 rolldown_testing = { path = "../rolldown_testing" }
+rolldown_watcher = { path = "../rolldown_watcher" }
 rolldown_workspace = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/rolldown/examples/watch_new.rs
+++ b/crates/rolldown/examples/watch_new.rs
@@ -1,0 +1,58 @@
+#![expect(clippy::print_stdout, reason = "Example uses stdout for demonstration")]
+
+use rolldown::{BundlerConfig, BundlerOptions, ExperimentalOptions};
+use rolldown_common::WatcherChangeKind;
+use rolldown_watcher::{WatchEvent, Watcher, WatcherConfig, WatcherEventHandler};
+use sugar_path::SugarPath;
+
+// cargo run -p rolldown --example watch_new
+
+struct PrintHandler;
+
+impl WatcherEventHandler for PrintHandler {
+  async fn on_event(&self, event: WatchEvent) {
+    println!("[Event] {event}");
+  }
+
+  async fn on_change(&self, path: &str, kind: WatcherChangeKind) {
+    println!("[Change] {kind:?}: {path}");
+  }
+
+  async fn on_restart(&self) {
+    println!("[Restart]");
+  }
+
+  async fn on_close(&self) {
+    println!("[Close] Watcher closed");
+  }
+}
+
+#[tokio::main]
+async fn main() {
+  let config = BundlerConfig::new(
+    BundlerOptions {
+      input: Some(vec!["./entry.js".to_string().into()]),
+      cwd: Some(rolldown_workspace::crate_dir("rolldown").join("./examples/basic").normalize()),
+      experimental: Some(ExperimentalOptions {
+        incremental_build: Some(true),
+        ..Default::default()
+      }),
+      ..Default::default()
+    },
+    vec![],
+  );
+
+  let watcher = Watcher::new(config, PrintHandler, &WatcherConfig::default())
+    .expect("Failed to create watcher");
+
+  println!("Watching for changes... Press Ctrl+C to stop.");
+
+  // Keep the watcher alive; in real usage you'd use tokio::signal::ctrl_c()
+  // but that requires the "signal" tokio feature which isn't enabled for tests.
+  tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
+  println!("\nClosing watcher...");
+  watcher.close().await.expect("Failed to close watcher");
+
+  println!("Done.");
+}

--- a/crates/rolldown/src/bundler/bundler.rs
+++ b/crates/rolldown/src/bundler/bundler.rs
@@ -63,6 +63,11 @@ impl Bundler {
     self.closed = false;
   }
 
+  #[cfg(feature = "experimental")]
+  pub fn reset_closed_for_watch_mode_experimental(&mut self) {
+    self.reset_closed_for_watch_mode();
+  }
+
   pub(super) async fn inner_close(&mut self) -> Result<()> {
     if self.closed {
       return Ok(());

--- a/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
+++ b/crates/rolldown/src/bundler/impl_bundler_incremental_build.rs
@@ -19,6 +19,15 @@ impl Bundler {
   }
 
   #[cfg(feature = "experimental")]
+  pub async fn with_cached_bundle_experimental<T>(
+    &mut self,
+    bundle_mode: BundleMode,
+    with_fn: impl AsyncFnOnce(&mut Bundle) -> BuildResult<T>,
+  ) -> BuildResult<T> {
+    self.with_cached_bundle(bundle_mode, with_fn).await
+  }
+
+  #[cfg(feature = "experimental")]
   pub async fn incremental_write(
     &mut self,
     scan_mode: ScanMode<ArcStr>,

--- a/crates/rolldown_watcher/Cargo.toml
+++ b/crates/rolldown_watcher/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "rolldown_watcher"
+version = "0.1.0"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Watcher for rolldown with state machine-based implementation"
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+arcstr = { workspace = true }
+oxc_index = { workspace = true }
+rolldown = { path = "../rolldown", features = ["experimental"] }
+rolldown_common = { workspace = true }
+rolldown_error = { workspace = true }
+rolldown_fs_watcher = { workspace = true }
+rolldown-notify = { workspace = true }
+rolldown_utils = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros", "sync", "rt-multi-thread", "signal"] }

--- a/crates/rolldown_watcher/src/handler.rs
+++ b/crates/rolldown_watcher/src/handler.rs
@@ -1,0 +1,20 @@
+use crate::event::WatchEvent;
+use rolldown_common::WatcherChangeKind;
+
+/// Handler for watcher events. All methods are async and awaited by the coordinator,
+/// providing blocking semantics matching Rollup's behavior.
+///
+/// NAPI bindings will implement this trait in a follow-up PR.
+pub trait WatcherEventHandler: Send + Sync {
+  fn on_event(&self, event: WatchEvent) -> impl std::future::Future<Output = ()> + Send;
+
+  fn on_change(
+    &self,
+    path: &str,
+    kind: WatcherChangeKind,
+  ) -> impl std::future::Future<Output = ()> + Send;
+
+  fn on_restart(&self) -> impl std::future::Future<Output = ()> + Send;
+
+  fn on_close(&self) -> impl std::future::Future<Output = ()> + Send;
+}

--- a/crates/rolldown_watcher/src/lib.rs
+++ b/crates/rolldown_watcher/src/lib.rs
@@ -1,0 +1,13 @@
+mod event;
+mod handler;
+mod msg;
+mod state;
+mod watch_coordinator;
+mod watch_task;
+mod watcher;
+
+pub use event::{WatchEndEventData, WatchErrorEventData, WatchEvent, WatchStartEventData};
+pub use handler::WatcherEventHandler;
+pub use state::ChangeEntry;
+pub use watch_task::WatchTaskIdx;
+pub use watcher::{Watcher, WatcherConfig};

--- a/crates/rolldown_watcher/src/msg.rs
+++ b/crates/rolldown_watcher/src/msg.rs
@@ -1,0 +1,8 @@
+use crate::watch_task::WatchTaskIdx;
+use rolldown_fs_watcher::FsEventResult;
+use tokio::sync::oneshot;
+
+pub enum WatcherMsg {
+  FsEvent { task_index: WatchTaskIdx, event: FsEventResult },
+  Close(oneshot::Sender<()>),
+}

--- a/crates/rolldown_watcher/src/state.rs
+++ b/crates/rolldown_watcher/src/state.rs
@@ -1,0 +1,214 @@
+use arcstr::ArcStr;
+use rolldown_common::WatcherChangeKind;
+use std::time::{Duration, Instant};
+
+/// A change entry representing a file change event
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ChangeEntry {
+  pub path: ArcStr,
+  pub kind: WatcherChangeKind,
+}
+
+impl ChangeEntry {
+  pub fn new(path: ArcStr, kind: WatcherChangeKind) -> Self {
+    Self { path, kind }
+  }
+}
+
+/// The state machine for the watcher
+///
+/// State transitions:
+/// - Idle + file_change → Debouncing
+/// - Idle + close → Closing
+/// - Debouncing + file_change → Debouncing (extend deadline, add to changes)
+/// - Debouncing + timeout → Idle (returns changes for build)
+/// - Debouncing + close → Closing
+/// - Closing → Closed
+#[derive(Debug, Default)]
+pub enum WatcherState {
+  /// Waiting for file changes
+  #[default]
+  Idle,
+  /// Collecting changes before triggering a build
+  Debouncing { changes: Vec<ChangeEntry>, deadline: Instant },
+  /// Watcher is closing
+  Closing,
+  /// Watcher has closed
+  Closed,
+}
+
+impl WatcherState {
+  /// Handle a file change event
+  ///
+  /// Returns the new state after processing the file change
+  #[must_use]
+  pub fn on_file_change(self, entry: ChangeEntry, debounce_duration: Duration) -> Self {
+    match self {
+      WatcherState::Idle => {
+        let deadline = Instant::now() + debounce_duration;
+        WatcherState::Debouncing { changes: vec![entry], deadline }
+      }
+      WatcherState::Debouncing { mut changes, .. } => {
+        // Check if we already have a change for this path
+        if let Some(existing) = changes.iter_mut().find(|c| c.path == entry.path) {
+          existing.kind = entry.kind;
+        } else {
+          changes.push(entry);
+        }
+        // Reset the deadline
+        let deadline = Instant::now() + debounce_duration;
+        WatcherState::Debouncing { changes, deadline }
+      }
+      // Ignore changes when closing or closed
+      WatcherState::Closing | WatcherState::Closed => self,
+    }
+  }
+
+  /// Handle debounce timeout - transition from Debouncing to Idle
+  ///
+  /// Returns (new_state, changes_to_build) if transitioning to Idle,
+  /// otherwise returns (self, None)
+  pub fn on_debounce_timeout(self) -> (Self, Option<Vec<ChangeEntry>>) {
+    match self {
+      WatcherState::Debouncing { changes, .. } => (WatcherState::Idle, Some(changes)),
+      other => (other, None),
+    }
+  }
+
+  /// Handle close request
+  ///
+  /// Returns true if we should proceed with closing
+  pub fn on_close(self) -> (Self, bool) {
+    match self {
+      WatcherState::Closed => (WatcherState::Closed, false),
+      _ => (WatcherState::Closing, true),
+    }
+  }
+
+  /// Transition to closed state
+  #[must_use]
+  pub fn to_closed(self) -> Self {
+    WatcherState::Closed
+  }
+
+  /// Check if the watcher is idle
+  #[cfg(test)]
+  pub fn is_idle(&self) -> bool {
+    matches!(self, WatcherState::Idle)
+  }
+
+  /// Check if the watcher is debouncing
+  #[cfg(test)]
+  pub fn is_debouncing(&self) -> bool {
+    matches!(self, WatcherState::Debouncing { .. })
+  }
+
+  /// Check if the watcher is closing or closed
+  #[cfg(test)]
+  #[expect(dead_code)]
+  pub fn is_closing_or_closed(&self) -> bool {
+    matches!(self, WatcherState::Closing | WatcherState::Closed)
+  }
+
+  /// Get the debounce deadline if in debouncing state
+  #[cfg(test)]
+  #[expect(dead_code)]
+  pub fn debounce_deadline(&self) -> Option<Instant> {
+    match self {
+      WatcherState::Debouncing { deadline, .. } => Some(*deadline),
+      _ => None,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn default_duration() -> Duration {
+    Duration::from_millis(100)
+  }
+
+  #[test]
+  fn test_idle_to_debouncing_on_file_change() {
+    let state = WatcherState::Idle;
+    let entry = ChangeEntry::new("test.js".into(), WatcherChangeKind::Update);
+    let new_state = state.on_file_change(entry, default_duration());
+
+    assert!(new_state.is_debouncing());
+  }
+
+  #[test]
+  fn test_debouncing_accumulates_changes() {
+    let state = WatcherState::Idle;
+    let entry1 = ChangeEntry::new("test1.js".into(), WatcherChangeKind::Update);
+    let entry2 = ChangeEntry::new("test2.js".into(), WatcherChangeKind::Create);
+
+    let state = state.on_file_change(entry1, default_duration());
+    let state = state.on_file_change(entry2, default_duration());
+
+    if let WatcherState::Debouncing { changes, .. } = state {
+      assert_eq!(changes.len(), 2);
+    } else {
+      panic!("Expected Debouncing state");
+    }
+  }
+
+  #[test]
+  fn test_debounce_timeout_to_idle() {
+    let state = WatcherState::Debouncing {
+      changes: vec![ChangeEntry::new("test.js".into(), WatcherChangeKind::Update)],
+      deadline: Instant::now(),
+    };
+
+    let (new_state, changes) = state.on_debounce_timeout();
+
+    assert!(new_state.is_idle());
+    assert!(changes.is_some());
+    assert_eq!(changes.unwrap().len(), 1);
+  }
+
+  #[test]
+  fn test_debouncing_deduplicates_same_path() {
+    let state = WatcherState::Idle;
+    let entry1 = ChangeEntry::new("test.js".into(), WatcherChangeKind::Create);
+    let entry2 = ChangeEntry::new("test.js".into(), WatcherChangeKind::Update);
+
+    let state = state.on_file_change(entry1, default_duration());
+    let state = state.on_file_change(entry2, default_duration());
+
+    if let WatcherState::Debouncing { changes, .. } = state {
+      assert_eq!(changes.len(), 1);
+      assert_eq!(changes[0].kind, WatcherChangeKind::Update);
+    } else {
+      panic!("Expected Debouncing state");
+    }
+  }
+
+  #[test]
+  fn test_close_from_idle() {
+    let state = WatcherState::Idle;
+    let (new_state, should_close) = state.on_close();
+
+    assert!(matches!(new_state, WatcherState::Closing));
+    assert!(should_close);
+  }
+
+  #[test]
+  fn test_close_from_closed_is_noop() {
+    let state = WatcherState::Closed;
+    let (new_state, should_close) = state.on_close();
+
+    assert!(matches!(new_state, WatcherState::Closed));
+    assert!(!should_close);
+  }
+
+  #[test]
+  fn test_closing_ignores_file_changes() {
+    let state = WatcherState::Closing;
+    let entry = ChangeEntry::new("test.js".into(), WatcherChangeKind::Update);
+    let new_state = state.on_file_change(entry, default_duration());
+
+    assert!(matches!(new_state, WatcherState::Closing));
+  }
+}

--- a/crates/rolldown_watcher/src/watch_coordinator.rs
+++ b/crates/rolldown_watcher/src/watch_coordinator.rs
@@ -1,0 +1,267 @@
+use crate::event::WatchEvent;
+use crate::handler::WatcherEventHandler;
+use crate::msg::WatcherMsg;
+use crate::state::{ChangeEntry, WatcherState};
+use crate::watch_task::{BuildOutcome, WatchTask, WatchTaskIdx};
+use crate::watcher::WatcherConfig;
+use oxc_index::IndexVec;
+use rolldown_common::WatcherChangeKind;
+use rolldown_fs_watcher::FsEventResult;
+use std::mem;
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+
+/// The coordinator actor that owns all state and runs the event loop.
+pub struct WatchCoordinator<H: WatcherEventHandler> {
+  rx: mpsc::UnboundedReceiver<WatcherMsg>,
+  handler: H,
+  state: WatcherState,
+  debounce_duration: Duration,
+  tasks: IndexVec<WatchTaskIdx, WatchTask>,
+}
+
+impl<H: WatcherEventHandler> WatchCoordinator<H> {
+  pub(crate) fn new(
+    rx: mpsc::UnboundedReceiver<WatcherMsg>,
+    handler: H,
+    tasks: IndexVec<WatchTaskIdx, WatchTask>,
+    config: &WatcherConfig,
+  ) -> Self {
+    Self {
+      rx,
+      handler,
+      state: WatcherState::Idle,
+      debounce_duration: config.debounce_duration(),
+      tasks,
+    }
+  }
+
+  /// Main event loop: initial build → loop on state
+  pub(crate) async fn run(mut self) {
+    // Perform initial build
+    self.run_initial_build().await;
+
+    loop {
+      match &self.state {
+        WatcherState::Idle => {
+          let msg = self.rx.recv().await;
+          match msg {
+            Some(WatcherMsg::FsEvent { task_index, event }) => {
+              self.process_fs_event(task_index, event).await;
+            }
+            Some(WatcherMsg::Close(reply)) => {
+              self.handle_close(reply).await;
+              break;
+            }
+            None => break,
+          }
+        }
+        WatcherState::Debouncing { deadline, .. } => {
+          let timeout = tokio::time::sleep_until((*deadline).into());
+
+          tokio::select! {
+            () = timeout => {
+              let (new_state, changes) = mem::take(&mut self.state).on_debounce_timeout();
+              self.state = new_state;
+
+              if let Some(changes) = changes {
+                self.run_build_sequence(changes).await;
+              }
+            }
+            msg = self.rx.recv() => {
+              match msg {
+                Some(WatcherMsg::FsEvent { task_index, event }) => {
+                  self.process_fs_event(task_index, event).await;
+                }
+                Some(WatcherMsg::Close(reply)) => {
+                  self.handle_close(reply).await;
+                  break;
+                }
+                None => break,
+              }
+            }
+          }
+        }
+        WatcherState::Closing | WatcherState::Closed => {
+          break;
+        }
+      }
+    }
+  }
+
+  /// Run the initial build for all tasks
+  async fn run_initial_build(&mut self) {
+    self.handler.on_event(WatchEvent::Start).await;
+
+    for task_index in self.tasks.indices() {
+      let task = &self.tasks[task_index];
+      self.handler.on_event(WatchEvent::TaskStart(task.start_event_data(task_index))).await;
+
+      let task = &mut self.tasks[task_index];
+      match task.build(task_index).await {
+        Ok(BuildOutcome::Success(data)) => {
+          self.handler.on_event(WatchEvent::TaskEnd(data)).await;
+        }
+        Ok(BuildOutcome::Error(data)) => {
+          self.handler.on_event(WatchEvent::Error(data)).await;
+        }
+        Ok(BuildOutcome::Skipped) => {}
+        Err(errs) => {
+          let error_messages: Vec<String> = errs.iter().map(|e| format!("{e:?}")).collect();
+          tracing::error!("Fatal build error: {error_messages:?}");
+        }
+      }
+    }
+
+    self.handler.on_event(WatchEvent::End).await;
+  }
+
+  /// The rebuild sequence matching Rollup's semantics (spec §2.8):
+  /// 1. handler.on_change for each changed file
+  /// 2. For each task and each changed file: task.call_watch_change
+  /// 3. handler.on_restart
+  /// 4. handler.on_event(Start)
+  /// 5. For each task needing rebuild: TaskStart → build → TaskEnd/Error
+  /// 6. handler.on_event(End)
+  /// 7. drain_buffered_events
+  async fn run_build_sequence(&mut self, changes: Vec<ChangeEntry>) {
+    // Step 1 & 2: Notify handler and plugin hooks for each change
+    for change in &changes {
+      self.handler.on_change(change.path.as_str(), change.kind).await;
+    }
+
+    for task in &self.tasks {
+      for change in &changes {
+        task.call_watch_change(change.path.as_str(), change.kind).await;
+      }
+    }
+
+    // Step 3: Restart notification
+    self.handler.on_restart().await;
+
+    // Step 4: Start event
+    self.handler.on_event(WatchEvent::Start).await;
+
+    // Step 5: Build each task that needs it
+    for task_index in self.tasks.indices() {
+      if !self.tasks[task_index].needs_rebuild {
+        continue;
+      }
+
+      let task = &self.tasks[task_index];
+      self.handler.on_event(WatchEvent::TaskStart(task.start_event_data(task_index))).await;
+
+      let task = &mut self.tasks[task_index];
+      match task.build(task_index).await {
+        Ok(BuildOutcome::Success(data)) => {
+          self.handler.on_event(WatchEvent::TaskEnd(data)).await;
+        }
+        Ok(BuildOutcome::Error(data)) => {
+          self.handler.on_event(WatchEvent::Error(data)).await;
+        }
+        Ok(BuildOutcome::Skipped) => {}
+        Err(errs) => {
+          let error_messages: Vec<String> = errs.iter().map(|e| format!("{e:?}")).collect();
+          tracing::error!("Fatal build error: {error_messages:?}");
+        }
+      }
+    }
+
+    // Step 6: End event
+    self.handler.on_event(WatchEvent::End).await;
+
+    // Step 7: Drain buffered events that arrived during the build
+    self.drain_buffered_events().await;
+  }
+
+  /// Process a file system event: map notify events to ChangeEntry,
+  /// call on_invalidate, and update state.
+  async fn process_fs_event(&mut self, task_index: WatchTaskIdx, event: FsEventResult) {
+    match event {
+      Ok(fs_events) => {
+        for fs_event in fs_events {
+          tracing::debug!(name = "notify event", event = ?fs_event.detail);
+
+          for path in &fs_event.detail.paths {
+            let id = path.to_string_lossy();
+            let kind = match fs_event.detail.kind {
+              notify::EventKind::Create(_) => Some(WatcherChangeKind::Create),
+              notify::EventKind::Modify(
+                notify::event::ModifyKind::Data(_) | notify::event::ModifyKind::Any,
+              ) => {
+                tracing::debug!(name = "notify updated content", path = ?id.as_ref());
+                Some(WatcherChangeKind::Update)
+              }
+              notify::EventKind::Modify(notify::event::ModifyKind::Name(
+                notify::event::RenameMode::To,
+              )) => {
+                tracing::debug!(name = "notify renamed file", path = ?id.as_ref());
+                Some(WatcherChangeKind::Update)
+              }
+              notify::EventKind::Remove(_) => Some(WatcherChangeKind::Delete),
+              _ => None,
+            };
+
+            if let Some(kind) = kind {
+              // Call on_invalidate for the affected task
+              if let Some(task) = self.tasks.get_mut(task_index) {
+                task.invalidate(&id);
+                task.call_on_invalidate(&id).await;
+              }
+
+              let entry = ChangeEntry::new(id.into(), kind);
+              self.state = mem::take(&mut self.state).on_file_change(entry, self.debounce_duration);
+            }
+          }
+        }
+      }
+      Err(errors) => {
+        for e in errors {
+          tracing::error!("notify error: {e:?}");
+        }
+      }
+    }
+  }
+
+  /// Drain buffered fs events that arrived during a build.
+  /// Uses try_recv to process all pending messages without blocking.
+  async fn drain_buffered_events(&mut self) {
+    loop {
+      match self.rx.try_recv() {
+        Ok(WatcherMsg::FsEvent { task_index, event }) => {
+          self.process_fs_event(task_index, event).await;
+        }
+        Ok(WatcherMsg::Close(reply)) => {
+          self.handle_close(reply).await;
+          return;
+        }
+        Err(_) => break,
+      }
+    }
+  }
+
+  /// Handle close: call close_watcher hooks, close bundlers, emit close, reply
+  async fn handle_close(&mut self, reply: oneshot::Sender<()>) {
+    let (new_state, should_close) = mem::take(&mut self.state).on_close();
+    self.state = new_state;
+
+    if should_close {
+      // Close watcher hooks on all tasks
+      for task in &self.tasks {
+        task.call_hook_close_watcher().await;
+      }
+
+      // Close all bundlers
+      for task in &self.tasks {
+        if let Err(e) = task.close().await {
+          tracing::error!("Error closing bundler: {e:?}");
+        }
+      }
+
+      self.handler.on_close().await;
+    }
+
+    self.state = mem::take(&mut self.state).to_closed();
+    let _ = reply.send(());
+  }
+}

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -1,0 +1,215 @@
+use arcstr::ArcStr;
+use rolldown::{Bundler, BundlerBuilder, BundlerConfig};
+use rolldown_common::{NormalizedBundlerOptions, WatcherChangeKind};
+use rolldown_error::{BuildDiagnostic, BuildResult, ResultExt};
+use rolldown_fs_watcher::{DynFsWatcher, RecursiveMode};
+use rolldown_utils::{dashmap::FxDashSet, pattern_filter};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::Mutex as TokioMutex;
+
+use crate::event::{WatchEndEventData, WatchErrorEventData, WatchStartEventData};
+
+oxc_index::define_index_type! {
+  pub struct WatchTaskIdx = u32;
+}
+
+/// Per-task data container that owns a bundler and its file-system watcher.
+pub struct WatchTask {
+  bundler: Arc<TokioMutex<Bundler>>,
+  options: Arc<NormalizedBundlerOptions>,
+  fs_watcher: std::sync::Mutex<DynFsWatcher>,
+  watched_files: FxDashSet<ArcStr>,
+  pub(crate) needs_rebuild: bool,
+}
+
+impl WatchTask {
+  pub(crate) fn new(config: BundlerConfig, fs_watcher: DynFsWatcher) -> BuildResult<Self> {
+    // Validation: dev_mode not allowed with watch
+    if config.options.experimental.as_ref().and_then(|e| e.dev_mode.as_ref()).is_some() {
+      return Err(
+        BuildDiagnostic::bundler_initialize_error(
+          "The \"experimental.devMode\" option is only supported with the \"dev\" API. \
+           It cannot be used with \"watch\". Please use the \"dev\" API for dev mode functionality."
+            .to_string(),
+          None,
+        )
+        .into(),
+      );
+    }
+
+    let bundler = BundlerBuilder::default()
+      .with_options(config.options)
+      .with_plugins(config.plugins)
+      .build()?;
+
+    let options = Arc::clone(bundler.options());
+
+    Ok(Self {
+      bundler: Arc::new(TokioMutex::new(bundler)),
+      options,
+      fs_watcher: std::sync::Mutex::new(fs_watcher),
+      watched_files: FxDashSet::default(),
+      needs_rebuild: true,
+    })
+  }
+
+  /// Run a build and return the outcome for the caller to emit events.
+  #[tracing::instrument(level = "debug", skip_all)]
+  pub(crate) async fn build(&mut self, task_index: WatchTaskIdx) -> BuildResult<BuildOutcome> {
+    if !self.needs_rebuild {
+      return Ok(BuildOutcome::Skipped);
+    }
+
+    let start_time = Instant::now();
+
+    // Scope the bundler lock to minimize lock duration
+    let (result, new_watch_files) = {
+      let mut bundler = self.bundler.lock().await;
+
+      // TODO: `write()` does a full rebuild each time. We should integrate
+      // incremental builds here in the future.
+      let result = bundler.write().await;
+
+      // Collect watch files while we have the lock
+      let new_watch_files: Vec<ArcStr> = bundler.watch_files().iter().map(|f| f.clone()).collect();
+
+      (result, new_watch_files)
+    };
+
+    // Update watch files without holding the bundler lock
+    self.update_watch_files(&new_watch_files)?;
+
+    #[expect(clippy::cast_possible_truncation)]
+    let duration = start_time.elapsed().as_millis() as u32;
+
+    self.needs_rebuild = false;
+
+    match result {
+      Ok(_output) => Ok(BuildOutcome::Success(WatchEndEventData {
+        task_index,
+        output: self.options.cwd.join(&self.options.out_dir).to_string_lossy().into_owned(),
+        duration,
+        bundler: Arc::clone(&self.bundler),
+      })),
+      Err(errs) => {
+        let error_messages: Vec<String> = errs.iter().map(|e| format!("{e:?}")).collect();
+        Ok(BuildOutcome::Error(WatchErrorEventData {
+          task_index,
+          errors: error_messages,
+          cwd: self.options.cwd.clone(),
+          bundler: Arc::clone(&self.bundler),
+        }))
+      }
+    }
+  }
+
+  /// Start event data for this task
+  pub(crate) fn start_event_data(&self, task_index: WatchTaskIdx) -> WatchStartEventData {
+    WatchStartEventData { task_index }
+  }
+
+  /// Update watched files by adding new ones to the fs watcher.
+  fn update_watch_files(&self, files: &[ArcStr]) -> BuildResult<()> {
+    let mut fs_watcher = self.fs_watcher.lock().expect("fs_watcher lock poisoned");
+    let mut watcher_paths = fs_watcher.paths_mut();
+
+    for file in files {
+      let file_str = file.as_str();
+      if self.watched_files.contains(file_str) {
+        continue;
+      }
+      let path = Path::new(file_str);
+      if path.exists()
+        && pattern_filter::filter(
+          self.options.watch.exclude.as_deref(),
+          self.options.watch.include.as_deref(),
+          file_str,
+          self.options.cwd.to_string_lossy().as_ref(),
+        )
+        .inner()
+      {
+        tracing::debug!(name = "notify watch", path = ?path);
+        watcher_paths.add(path, RecursiveMode::NonRecursive).map_err_to_unhandleable()?;
+        self.watched_files.insert(file.clone());
+      }
+    }
+    watcher_paths.commit().map_err_to_unhandleable()?;
+
+    Ok(())
+  }
+
+  /// Mark this task as needing rebuild if the changed file is in our watch list.
+  pub(crate) fn invalidate(&mut self, path: &str) {
+    if self.is_watched_file(path) {
+      self.needs_rebuild = true;
+    }
+  }
+
+  /// Call on_invalidate callback if the path is in watch list
+  pub(crate) async fn call_on_invalidate(&self, path: &str) {
+    if self.is_watched_file(path) {
+      let bundler = self.bundler.lock().await;
+      if let Some(on_invalidate) = &bundler.options().watch.on_invalidate {
+        on_invalidate.call(path);
+      }
+    }
+  }
+
+  /// Call watch_change plugin hook
+  #[tracing::instrument(level = "debug", skip(self))]
+  pub(crate) async fn call_watch_change(&self, path: &str, kind: WatcherChangeKind) {
+    let bundler = self.bundler.lock().await;
+    if let Some(plugin_driver) =
+      bundler.last_bundle_handle.as_ref().map(rolldown::BundleHandle::plugin_driver)
+    {
+      let _ = plugin_driver.watch_change(path, kind).await.map_err(|e| {
+        tracing::error!("watch_change plugin hook error: {e:?}");
+      });
+    }
+  }
+
+  /// Call close_watcher plugin hooks
+  #[tracing::instrument(level = "debug", skip_all)]
+  pub(crate) async fn call_hook_close_watcher(&self) {
+    let bundler = self.bundler.lock().await;
+    if let Some(last_bundle_handle) = &bundler.last_bundle_handle {
+      let _ = last_bundle_handle.plugin_driver().close_watcher().await.map_err(|e| {
+        tracing::error!("close_watcher plugin hook error: {e:?}");
+      });
+    }
+  }
+
+  /// Close the bundler
+  #[tracing::instrument(level = "debug", skip_all)]
+  pub(crate) async fn close(&self) -> anyhow::Result<()> {
+    let mut bundler = self.bundler.lock().await;
+    bundler.close().await?;
+    Ok(())
+  }
+
+  fn is_watched_file(&self, path: &str) -> bool {
+    if self.watched_files.contains(path) {
+      return true;
+    }
+
+    // Windows path normalization
+    #[cfg(windows)]
+    if self.watched_files.contains(path.replace('\\', "/").as_str()) {
+      return true;
+    }
+
+    false
+  }
+}
+
+/// Outcome of a build attempt
+pub enum BuildOutcome {
+  /// Build was skipped (no rebuild needed)
+  Skipped,
+  /// Build succeeded
+  Success(WatchEndEventData),
+  /// Build had errors (but didn't fail fatally)
+  Error(WatchErrorEventData),
+}

--- a/crates/rolldown_watcher/src/watcher.rs
+++ b/crates/rolldown_watcher/src/watcher.rs
@@ -1,0 +1,169 @@
+use crate::handler::WatcherEventHandler;
+use crate::msg::WatcherMsg;
+use crate::watch_coordinator::WatchCoordinator;
+use crate::watch_task::{WatchTask, WatchTaskIdx};
+use anyhow::Result;
+use oxc_index::IndexVec;
+use rolldown::BundlerConfig;
+use rolldown_common::NotifyOption;
+use rolldown_error::BuildResult;
+use rolldown_fs_watcher::{
+  FsEventHandler, FsEventResult, FsWatcher, FsWatcherConfig, RecommendedFsWatcher,
+};
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+
+/// Default debounce duration in milliseconds
+const DEFAULT_DEBOUNCE_MS: u64 = 100;
+
+/// Configuration for the watcher
+#[derive(Debug, Clone, Default)]
+pub struct WatcherConfig {
+  /// Debounce duration for file changes
+  pub debounce: Option<Duration>,
+  /// Notify (file system watcher) options
+  pub notify: Option<NotifyOption>,
+}
+
+impl WatcherConfig {
+  pub fn debounce_duration(&self) -> Duration {
+    self.debounce.unwrap_or(Duration::from_millis(DEFAULT_DEBOUNCE_MS))
+  }
+
+  #[expect(clippy::cast_possible_truncation)]
+  fn to_fs_watcher_config(&self) -> FsWatcherConfig {
+    let mut config = FsWatcherConfig::default();
+    if let Some(notify) = &self.notify {
+      if let Some(poll_interval) = notify.poll_interval {
+        config.poll_interval = poll_interval.as_millis() as u64;
+      }
+      config.compare_contents_for_polling = notify.compare_contents;
+    }
+    config
+  }
+}
+
+/// Bridge that forwards fs events from a per-task watcher to the shared mpsc channel.
+struct TaskFsEventHandler {
+  task_index: WatchTaskIdx,
+  tx: mpsc::UnboundedSender<WatcherMsg>,
+}
+
+impl FsEventHandler for TaskFsEventHandler {
+  fn handle_event(&mut self, event: FsEventResult) {
+    let _ = self.tx.send(WatcherMsg::FsEvent { task_index: self.task_index, event });
+  }
+}
+
+/// The main watcher that manages multiple bundlers
+pub struct Watcher {
+  tx: mpsc::UnboundedSender<WatcherMsg>,
+  task_handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for Watcher {
+  fn drop(&mut self) {
+    self.task_handle.abort();
+  }
+}
+
+impl Watcher {
+  /// Create a new watcher with a single bundler config
+  pub fn new<H: WatcherEventHandler + 'static>(
+    config: BundlerConfig,
+    handler: H,
+    watcher_config: &WatcherConfig,
+  ) -> BuildResult<Self> {
+    Self::with_multiple_bundler_configs(vec![config], handler, watcher_config)
+  }
+
+  /// Create a new watcher with multiple bundler configs
+  pub fn with_multiple_bundler_configs<H: WatcherEventHandler + 'static>(
+    configs: Vec<BundlerConfig>,
+    handler: H,
+    watcher_config: &WatcherConfig,
+  ) -> BuildResult<Self> {
+    let (tx, rx) = mpsc::unbounded_channel::<WatcherMsg>();
+
+    let fs_watcher_config = watcher_config.to_fs_watcher_config();
+
+    // Create per-task watch tasks with their own fs watchers
+    let mut tasks = IndexVec::with_capacity(configs.len());
+    for (index, config) in configs.into_iter().enumerate() {
+      let task_index = WatchTaskIdx::from_usize(index);
+      let fs_handler = TaskFsEventHandler { task_index, tx: tx.clone() };
+      let fs_watcher: Box<dyn FsWatcher + Send + 'static> =
+        Box::new(RecommendedFsWatcher::with_config(fs_handler, fs_watcher_config.clone())?);
+      let task = WatchTask::new(config, fs_watcher)?;
+      tasks.push(task);
+    }
+
+    let coordinator = WatchCoordinator::new(rx, handler, tasks, watcher_config);
+    let task_handle = tokio::spawn(async move {
+      coordinator.run().await;
+    });
+
+    Ok(Self { tx, task_handle })
+  }
+
+  /// Close the watcher
+  pub async fn close(&self) -> Result<()> {
+    let (response_tx, response_rx) = oneshot::channel();
+    self
+      .tx
+      .send(WatcherMsg::Close(response_tx))
+      .map_err(|_| anyhow::anyhow!("Watcher event loop already closed"))?;
+    response_rx.await.map_err(|_| anyhow::anyhow!("Watcher event loop terminated unexpectedly"))?;
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_watcher_config_default_debounce() {
+    let config = WatcherConfig::default();
+    assert_eq!(config.debounce_duration(), Duration::from_millis(DEFAULT_DEBOUNCE_MS));
+  }
+
+  #[test]
+  fn test_watcher_config_custom_debounce() {
+    let config = WatcherConfig { debounce: Some(Duration::from_millis(500)), notify: None };
+    assert_eq!(config.debounce_duration(), Duration::from_millis(500));
+  }
+
+  #[test]
+  fn test_fs_watcher_config_defaults_when_notify_is_none() {
+    let config = WatcherConfig { debounce: None, notify: None };
+    let fs_config = config.to_fs_watcher_config();
+    assert_eq!(fs_config.poll_interval, 100);
+    assert!(!fs_config.compare_contents_for_polling);
+  }
+
+  #[test]
+  fn test_fs_watcher_config_with_poll_interval() {
+    let config = WatcherConfig {
+      debounce: None,
+      notify: Some(NotifyOption {
+        poll_interval: Some(Duration::from_millis(250)),
+        compare_contents: false,
+      }),
+    };
+    let fs_config = config.to_fs_watcher_config();
+    assert_eq!(fs_config.poll_interval, 250);
+    assert!(!fs_config.compare_contents_for_polling);
+  }
+
+  #[test]
+  fn test_fs_watcher_config_with_compare_contents() {
+    let config = WatcherConfig {
+      debounce: None,
+      notify: Some(NotifyOption { poll_interval: None, compare_contents: true }),
+    };
+    let fs_config = config.to_fs_watcher_config();
+    assert_eq!(fs_config.poll_interval, 100);
+    assert!(fs_config.compare_contents_for_polling);
+  }
+}


### PR DESCRIPTION
- For each event, rollup will wait for its all listeners's finish. This PR uses trait-based design for dispatching events to stimulate similar behaviors.
- Most of design is inspired from dev engine. I keep them separated instead of merging them together, because `DevEngine` is too complicated to be used for watch scenario.
- Might have some bad smells. Will improve it in later PRs.