### PR TITLE
feat: warn unsupported combination of `preserveValueImports` and `importsNotUsedAsValues` in tsconfig.json

### DIFF
--- a/crates/rolldown_binding/src/generated/binding_checks_options.rs
+++ b/crates/rolldown_binding/src/generated/binding_checks_options.rs
@@ -22,6 +22,7 @@ pub struct BindingChecksOptions {
   pub could_not_clean_directory: Option<bool>,
   pub plugin_timings: Option<bool>,
   pub duplicate_shebang: Option<bool>,
+  pub unsupported_tsconfig_option: Option<bool>,
 }
 impl From<BindingChecksOptions> for rolldown_common::ChecksOptions {
   fn from(value: BindingChecksOptions) -> Self {
@@ -44,6 +45,7 @@ impl From<BindingChecksOptions> for rolldown_common::ChecksOptions {
       could_not_clean_directory: value.could_not_clean_directory,
       plugin_timings: value.plugin_timings,
       duplicate_shebang: value.duplicate_shebang,
+      unsupported_tsconfig_option: value.unsupported_tsconfig_option,
     }
   }
 }

--- a/crates/rolldown_common/src/generated/checks_options.rs
+++ b/crates/rolldown_common/src/generated/checks_options.rs
@@ -30,6 +30,7 @@ pub struct ChecksOptions {
   pub could_not_clean_directory: Option<bool>,
   pub plugin_timings: Option<bool>,
   pub duplicate_shebang: Option<bool>,
+  pub unsupported_tsconfig_option: Option<bool>,
 }
 impl From<ChecksOptions> for rolldown_error::EventKindSwitcher {
   fn from(value: ChecksOptions) -> Self {
@@ -97,6 +98,10 @@ impl From<ChecksOptions> for rolldown_error::EventKindSwitcher {
     flag.set(
       rolldown_error::EventKindSwitcher::DuplicateShebang,
       value.duplicate_shebang.unwrap_or(true),
+    );
+    flag.set(
+      rolldown_error::EventKindSwitcher::UnsupportedTsconfigOption,
+      value.unsupported_tsconfig_option.unwrap_or(true),
     );
     flag
   }

--- a/crates/rolldown_common/src/inner_bundler_options/types/tsconfig_merge.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/tsconfig_merge.rs
@@ -167,20 +167,23 @@ pub fn merge_transform_options_with_tsconfig(
       let preserve_value_imports = compiler_options.preserve_value_imports.unwrap_or(false);
       let imports_not_used_as_values =
         compiler_options.imports_not_used_as_values.as_deref().unwrap_or("remove");
-      typescript.only_remove_type_imports =
-        if !preserve_value_imports && imports_not_used_as_values == "remove" {
-          Some(true)
-        } else if preserve_value_imports
-          && (imports_not_used_as_values == "preserve" || imports_not_used_as_values == "error")
-        {
-          Some(false)
-        } else {
-          // warnings.push(
-          //   `preserveValueImports=${preserveValueImports} + importsNotUsedAsValues=${importsNotUsedAsValues} is not supported by oxc.` +
-          //     'Please migrate to the new verbatimModuleSyntax option.',
-          // )
-          Some(false)
-        };
+      typescript.only_remove_type_imports = if !preserve_value_imports
+        && imports_not_used_as_values == "remove"
+      {
+        Some(true)
+      } else if preserve_value_imports
+        && (imports_not_used_as_values == "preserve" || imports_not_used_as_values == "error")
+      {
+        Some(false)
+      } else {
+        warnings.push(
+            BuildDiagnostic::unsupported_tsconfig_option(format!(
+              "preserveValueImports={preserve_value_imports} + importsNotUsedAsValues={imports_not_used_as_values} in tsconfig.json is not supported. Please migrate to the verbatimModuleSyntax option."
+            ))
+            .with_severity_warning(),
+          );
+        Some(false)
+      };
     }
   } else if warn_on_conflict && compiler_options.verbatim_module_syntax.is_some() {
     warnings.push(

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -38,6 +38,7 @@ use super::events::tsconfig_error::TsConfigError;
 use super::events::unhandleable_error::UnhandleableError;
 use super::events::unloadable_dependency::{UnloadableDependency, UnloadableDependencyContext};
 use super::events::unsupported_feature::UnsupportedFeature;
+use super::events::unsupported_tsconfig_option::UnsupportedTsconfigOption;
 use super::events::{
   ambiguous_external_namespace::{AmbiguousExternalNamespace, AmbiguousExternalNamespaceModule},
   circular_dependency::CircularDependency,
@@ -377,5 +378,9 @@ impl BuildDiagnostic {
 
   pub fn tsconfig_error(file_path: String, reason: ResolveError) -> Self {
     Self::new_inner(TsConfigError { file_paths: vec![file_path], reason })
+  }
+
+  pub fn unsupported_tsconfig_option(message: String) -> Self {
+    Self::new_inner(UnsupportedTsconfigOption { message })
   }
 }

--- a/crates/rolldown_error/src/build_diagnostic/events/mod.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/mod.rs
@@ -48,6 +48,7 @@ pub mod unhandleable_error;
 pub mod unloadable_dependency;
 pub mod unresolved_entry;
 pub mod unsupported_feature;
+pub mod unsupported_tsconfig_option;
 
 pub trait BuildEvent: Debug + Sync + Send + AsAny + AsAnyMut {
   fn kind(&self) -> EventKind;

--- a/crates/rolldown_error/src/build_diagnostic/events/unsupported_tsconfig_option.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/unsupported_tsconfig_option.rs
@@ -1,0 +1,18 @@
+use crate::types::diagnostic_options::DiagnosticOptions;
+
+use super::BuildEvent;
+
+#[derive(Debug)]
+pub struct UnsupportedTsconfigOption {
+  pub message: String,
+}
+
+impl BuildEvent for UnsupportedTsconfigOption {
+  fn kind(&self) -> crate::types::event_kind::EventKind {
+    crate::types::event_kind::EventKind::UnsupportedTsconfigOption
+  }
+
+  fn message(&self, _opts: &DiagnosticOptions) -> String {
+    self.message.clone()
+  }
+}

--- a/crates/rolldown_error/src/generated/event_kind_switcher.rs
+++ b/crates/rolldown_error/src/generated/event_kind_switcher.rs
@@ -45,5 +45,6 @@ bitflags! {
     const PluginTimings = 1 << 38;
     const DuplicateShebang = 1 << 39;
     const TsConfigError = 1 << 40;
+    const UnsupportedTsconfigOption = 1 << 41;
   }
 }

--- a/crates/rolldown_error/src/types/event_kind.rs
+++ b/crates/rolldown_error/src/types/event_kind.rs
@@ -106,6 +106,8 @@ pub enum EventKind {
   /// Having multiple shebangs in a file is a syntax error.
   DuplicateShebang = 39,
   TsConfigError = 40,
+  /// Whether to emit warnings when a tsconfig option or combination of options is not supported.
+  UnsupportedTsconfigOption = 41,
 }
 
 impl Display for EventKind {
@@ -157,6 +159,7 @@ impl Display for EventKind {
       EventKind::PluginTimings => write!(f, "PLUGIN_TIMINGS"),
       EventKind::DuplicateShebang => write!(f, "DUPLICATE_SHEBANG"),
       EventKind::TsConfigError => write!(f, "TSCONFIG_ERROR"),
+      EventKind::UnsupportedTsconfigOption => write!(f, "UNSUPPORTED_TSCONFIG_OPTION"),
     }
   }
 }

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1391,6 +1391,12 @@
             "boolean",
             "null"
           ]
+        },
+        "unsupportedTsconfigOption": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1767,6 +1767,7 @@ export interface BindingChecksOptions {
   couldNotCleanDirectory?: boolean
   pluginTimings?: boolean
   duplicateShebang?: boolean
+  unsupportedTsconfigOption?: boolean
 }
 
 export interface BindingChunkImportMap {

--- a/packages/rolldown/src/options/generated/checks-options.ts
+++ b/packages/rolldown/src/options/generated/checks-options.ts
@@ -147,4 +147,10 @@ export interface ChecksOptions {
    * @default true
    * */
   duplicateShebang?: boolean;
+
+  /**
+   * Whether to emit warnings when a tsconfig option or combination of options is not supported.
+   * @default true
+   * */
+  unsupportedTsconfigOption?: boolean;
 }

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -373,6 +373,12 @@ const ChecksOptionsSchema = v.strictObject({
     v.optional(v.boolean()),
     v.description('Whether to emit warnings when both the code and postBanner contain shebang'),
   ),
+  unsupportedTsconfigOption: v.pipe(
+    v.optional(v.boolean()),
+    v.description(
+      'Whether to emit warnings when a tsconfig option or combination of options is not supported',
+    ),
+  ),
 });
 isTypeTrue<IsSchemaSubType<typeof ChecksOptionsSchema, ChecksOptions>>();
 

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -42,6 +42,7 @@ OPTIONS
   --checks.tolerated-transform Whether to emit warnings when detecting tolerated transform.
   --checks.unresolved-entry   Whether to emit warnings when an entrypoint cannot be resolved.
   --checks.unresolved-import  Whether to emit warnings when an import cannot be resolved.
+  --checks.unsupported-tsconfig-option Whether to emit warnings when a tsconfig option or combination of options is not supported.
   --chunk-file-names <name>   Name pattern for emitted secondary chunks.
   --clean-dir                 Clean output directory before emitting output.
   --code-splitting <code-splitting>Code splitting options (true, false, or object).


### PR DESCRIPTION
Add `"preserveValueImports={preserve_value_imports} + importsNotUsedAsValues={imports_not_used_as_values} in tsconfig.json is not supported. Please migrate to the verbatimModuleSyntax option."` warning.