### PR TITLE
docs: add dynamic OG image generation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -423,7 +423,7 @@ const config = defineConfig({
       pageData.frontmatter.editLink = false;
     }
 
-    // Automatically handle OG images for all markdown files
+    // Automatically handle OG images for all markdown files.
     if (!pageData.frontmatter.image && pageData.relativePath !== 'index.md') {
       await addOgImage(pageData, ctx, {
         domain: 'https://rolldown.rs',


### PR DESCRIPTION
Retry of #8191, as it wasn't merged with the merge queue.

---

Merging by graphite seems to ignore the authors in each commits. This PR is to test whether the co-author comment in the PR message works and add the co-authors in https://github.com/rolldown/rolldown/pull/8179 properly.

Co-authored-by: barbapapazes <e.soubiran25@gmail.com>