### PR TITLE
fix(rust): preserve dependencies added by `this.addWatchFile`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,6 +2711,7 @@ dependencies = [
  "commondir",
  "cow-utils",
  "css-module-lexer",
+ "dashmap",
  "dunce",
  "futures",
  "glob",

--- a/crates/rolldown/Cargo.toml
+++ b/crates/rolldown/Cargo.toml
@@ -26,6 +26,7 @@ experimental = []
 anyhow = { workspace = true }
 append-only-vec = { workspace = true }
 arcstr = { workspace = true }
+dashmap = { workspace = true }
 bitflags = { workspace = true }
 commondir = { workspace = true }
 css-module-lexer = { workspace = true }

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -47,7 +47,8 @@ impl PluginDriver {
   pub fn clear(&self) {
     self.watch_files.clear();
     self.module_infos.clear();
-    self.transform_dependencies.clear();
+    // Note: transform_dependencies is NOT cleared here - it's preserved across incremental builds
+    // by BundleFactory which manages its lifecycle (reset on full builds only)
     self.context_load_completion_manager.clear();
     self.file_emitter.clear();
     if let Some(collector) = &self.hook_timing_collector {

--- a/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
@@ -3,7 +3,9 @@ use std::sync::{Arc, Weak};
 use arcstr::ArcStr;
 use dashmap::DashMap;
 use oxc_index::IndexVec;
-use rolldown_common::{SharedFileEmitter, SharedModuleInfoDashMap, SharedNormalizedBundlerOptions};
+use rolldown_common::{
+  ModuleIdx, SharedFileEmitter, SharedModuleInfoDashMap, SharedNormalizedBundlerOptions,
+};
 use rolldown_resolver::Resolver;
 use rolldown_utils::dashmap::FxDashSet;
 
@@ -34,6 +36,7 @@ impl PluginDriverFactory {
     session: &rolldown_devtools::Session,
     initial_bundle_span: &Arc<tracing::Span>,
     module_infos: SharedModuleInfoDashMap,
+    transform_dependencies: Arc<DashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
   ) -> Arc<crate::plugin_driver::PluginDriver> {
     let watch_files = Arc::new(FxDashSet::default());
     let meta = Arc::new(PluginContextMeta::default());
@@ -98,7 +101,7 @@ impl PluginDriverFactory {
         file_emitter: Arc::clone(file_emitter),
         watch_files,
         module_infos,
-        transform_dependencies: Arc::new(DashMap::default()),
+        transform_dependencies,
         context_load_completion_manager: ContextLoadCompletionManager::default(),
         tx,
         hook_timing_collector: hook_timing_collector.clone(),


### PR DESCRIPTION
After the fix, I found other data might have the same problem. We need to have unified way/abstraction to manage them. This is a unsolved/left issue of previous refactor of `BundleFactory`. I will investigate it more in the process of rewriting watch mode.