### PR TITLE
feat: expose `RUNTIME_MODULE_ID` constant for plugin authors

### DIFF
--- a/packages/rolldown/src/constants/index.ts
+++ b/packages/rolldown/src/constants/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Runtime helper module ID
+ */
+export const RUNTIME_MODULE_ID = '\0rolldown/runtime.js';

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -114,6 +114,7 @@ import {
 } from './utils/define-config';
 import { VERSION } from './version';
 
+export { RUNTIME_MODULE_ID } from './constants';
 export { build, defineConfig, rolldown, VERSION, watch };
 export { BindingMagicString } from './binding.cjs';
 export type {


### PR DESCRIPTION
Expose `RUNTIME_MODULE_ID` so users can use it to filter runtime ID transforms. Also, while fixing the Vite test failures, I found that some test cases need to filter it as well.