### PR TITLE
ci: build docs for production

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 # only build on netlify if there are any change in docs
-ignore = "git diff --quiet $CACHED_COMMIT_REF HEAD ./docs ./packages/rolldown"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown"
 
 [[redirects]]
 from = "/about/"


### PR DESCRIPTION
The production builds were skipped: https://app.netlify.com/projects/rolldown-rs/deploys/698372668f10530007e10e95