### PR TITLE
refactor: expose `parse` / `minify` / `transform` from `rolldown/utils`

### DIFF
--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -107,6 +107,7 @@ function withShared({
     input: {
       index: './src/index',
       'plugins-index': './src/plugins-index',
+      'utils-index': './src/utils-index',
       'experimental-index': './src/experimental-index',
       ...(!isBrowserBuild
         ? {

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -69,6 +69,10 @@
     "./plugins": {
       "dev": "./src/plugins-index.ts",
       "default": "./dist/plugins-index.mjs"
+    },
+    "./utils": {
+      "dev": "./src/utils-index.ts",
+      "default": "./dist/utils-index.mjs"
     }
   },
   "publishConfig": {
@@ -85,7 +89,8 @@
       "./parallelPlugin": "./dist/parallel-plugin.mjs",
       "./parseAst": "./dist/parse-ast-index.mjs",
       "./package.json": "./package.json",
-      "./plugins": "./dist/plugins-index.mjs"
+      "./plugins": "./dist/plugins-index.mjs",
+      "./utils": "./dist/utils-index.mjs"
     },
     "registry": "https://registry.npmjs.org/"
   },

--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -12,24 +12,12 @@ export {
   isolatedDeclarationSync,
   moduleRunnerTransform,
   type NapiResolveOptions as ResolveOptions,
-  type ParseResult,
-  type ParserOptions,
   type ResolveResult,
   ResolverFactory,
 } from './binding.cjs';
 
 export { defineParallelPlugin } from './plugin/parallel-plugin';
-export { parse, parseSync } from './utils/parse';
-export { minify, type MinifyOptions, type MinifyResult, minifySync } from './utils/minify';
-export {
-  transform,
-  type TransformOptions,
-  type TransformResult,
-  transformSync,
-  TsconfigCache,
-  type TsconfigRawOptions,
-  type TsconfigCompilerOptions,
-} from './utils/transform';
+
 // Builtin plugin factory
 export {
   isolatedDeclarationPlugin,
@@ -94,3 +82,60 @@ export const memfs: { fs: any; volume: any } | undefined = import.meta.browserBu
   ? // @ts-expect-error - __fs and __volume are only available in browser builds
     { fs: binding.__fs, volume: binding.__volume }
   : undefined;
+
+// #region util exports
+import {
+  parse as parse_,
+  parseSync as parseSync_,
+  type ParseResult as ParseResult_,
+  type ParserOptions as ParserOptions_,
+} from './utils/parse';
+/** @deprecated Use from `rolldown/utils` instead. */
+export const parse: typeof parse_ = parse_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export const parseSync: typeof parseSync_ = parseSync_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export type ParseResult = ParseResult_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export type ParserOptions = ParserOptions_;
+
+import {
+  minify as minify_,
+  minifySync as minifySync_,
+  type MinifyOptions as MinifyOptions_,
+  type MinifyResult as MinifyResult_,
+} from './utils/minify';
+/** @deprecated Use from `rolldown/utils` instead. */
+export const minify: typeof minify_ = minify_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export const minifySync: typeof minifySync_ = minifySync_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export type MinifyOptions = MinifyOptions_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export type MinifyResult = MinifyResult_;
+
+import {
+  transform as transform_,
+  transformSync as transformSync_,
+  TsconfigCache as TsconfigCache_,
+  type TransformOptions as TransformOptions_,
+  type TransformResult as TransformResult_,
+  type TsconfigCompilerOptions as TsconfigCompilerOptions_,
+  type TsconfigRawOptions as TsconfigRawOptions_,
+} from './utils/transform';
+/** @deprecated Use from `rolldown/utils` instead. */
+export const transform: typeof transform_ = transform_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export const transformSync: typeof transformSync_ = transformSync_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export type TransformOptions = TransformOptions_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export type TransformResult = TransformResult_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export const TsconfigCache: typeof TsconfigCache_ = TsconfigCache_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export type TsconfigRawOptions = TsconfigRawOptions_;
+/** @deprecated Use from `rolldown/utils` instead. */
+export type TsconfigCompilerOptions = TsconfigCompilerOptions_;
+
+// #endregion

--- a/packages/rolldown/src/utils-index.ts
+++ b/packages/rolldown/src/utils-index.ts
@@ -1,0 +1,11 @@
+export { parse, parseSync, type ParseResult, type ParserOptions } from './utils/parse';
+export { minify, type MinifyOptions, type MinifyResult, minifySync } from './utils/minify';
+export {
+  transform,
+  type TransformOptions,
+  type TransformResult,
+  transformSync,
+  TsconfigCache,
+  type TsconfigRawOptions,
+  type TsconfigCompilerOptions,
+} from './utils/transform';

--- a/packages/rolldown/src/utils/minify.ts
+++ b/packages/rolldown/src/utils/minify.ts
@@ -16,6 +16,8 @@ type MinifyOptions = OriginalMinifyOptions & {
  * Minify asynchronously.
  *
  * Note: This function can be slower than `minifySync` due to the overhead of spawning a thread.
+ *
+ * @experimental
  */
 async function minify(
   filename: string,
@@ -33,7 +35,11 @@ async function minify(
   return result;
 }
 
-/** Minify synchronously. */
+/**
+ * Minify synchronously.
+ *
+ * @experimental
+ */
 function minifySync(
   filename: string,
   sourceText: string,

--- a/packages/rolldown/src/utils/parse.ts
+++ b/packages/rolldown/src/utils/parse.ts
@@ -7,10 +7,22 @@ import {
 // @ts-ignore
 import * as oxcParserWrap from 'oxc-parser/src-js/wrap.js';
 
+export type { ParseResult, ParserOptions };
+
 /**
- * Parse asynchronously.
+ * Parse JS/TS source asynchronously on a separate thread.
  *
- * Note: This function can be slower than `parseSync` due to the overhead of spawning a thread.
+ * Note that not all of the workload can happen on a separate thread.
+ * Parsing on Rust side does happen in a separate thread, but deserialization of the AST to JS objects
+ * has to happen on current thread. This synchronous deserialization work typically outweighs
+ * the asynchronous parsing by a factor of between 3 and 20.
+ *
+ * i.e. the majority of the workload cannot be parallelized by using this method.
+ *
+ * Generally `parseSync` is preferable to use as it does not have the overhead of spawning a thread.
+ * If you need to parallelize parsing multiple files, it is recommended to use worker threads.
+ *
+ * @experimental
  */
 export async function parse(
   filename: string,
@@ -20,7 +32,18 @@ export async function parse(
   return oxcParserWrap.wrap(await originalParse(filename, sourceText, options));
 }
 
-/** Parse synchronously. */
+/**
+ * Parse JS/TS source synchronously on current thread.
+ *
+ * This is generally preferable over `parse` (async) as it does not have the overhead
+ * of spawning a thread, and the majority of the workload cannot be parallelized anyway
+ * (see `parse` documentation for details).
+ *
+ * If you need to parallelize parsing multiple files, it is recommended to use worker threads
+ * with `parseSync` rather than using `parse`.
+ *
+ * @experimental
+ */
 export function parseSync(
   filename: string,
   sourceText: string,

--- a/packages/rolldown/tests/utils/minify.test.ts
+++ b/packages/rolldown/tests/utils/minify.test.ts
@@ -1,4 +1,4 @@
-import { minify, minifySync } from 'rolldown/experimental';
+import { minify, minifySync } from 'rolldown/utils';
 import { expect, test } from 'vitest';
 
 // Generated from `transformSync('original.ts', 'const a: number = 1;', { sourcemap: true })`

--- a/packages/rolldown/tests/utils/parse.test.ts
+++ b/packages/rolldown/tests/utils/parse.test.ts
@@ -1,4 +1,4 @@
-import { parse, parseSync } from 'rolldown/experimental';
+import { parse, parseSync } from 'rolldown/utils';
 import { expect, test } from 'vitest';
 
 test('parse non json value', async () => {

--- a/packages/rolldown/tests/utils/transform.test.ts
+++ b/packages/rolldown/tests/utils/transform.test.ts
@@ -3,7 +3,7 @@ import {
   transform,
   transformSync,
   TsconfigCache,
-} from 'rolldown/experimental';
+} from 'rolldown/utils';
 import { expect, describe, it } from 'vitest';
 
 describe('enhanced transform', () => {


### PR DESCRIPTION
Expose `parse` / `minify` / `transform` from `rolldown/utils` instead of `rolldown/experimental`. It is still marked as experimental though.