### PR TITLE
refactor: consolidate missing runtime symbol errors into a single diagnostic

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/runtime/transform_symbol_removed/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/runtime/transform_symbol_removed/artifacts.snap
@@ -6,6 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## RUNTIME_MODULE_SYMBOL_NOT_FOUND
 
 ```text
-[RUNTIME_MODULE_SYMBOL_NOT_FOUND] Error: Failed to resolve runtime symbol "__exportAll" after the runtime module was modified by plugin(s): runtime-breaking-plugin. Please review these plugins to ensure they do not accidentally remove or rename runtime utilities.
+[RUNTIME_MODULE_SYMBOL_NOT_FOUND] Error: Failed to resolve runtime symbol(s) "__exportAll", "__toCommonJS" after the runtime module was modified by plugin(s): runtime-breaking-plugin. Please review these plugins to ensure they do not accidentally remove or rename runtime utilities.
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/runtime/transform_symbol_removed/mod.rs
+++ b/crates/rolldown/tests/rolldown/topics/runtime/transform_symbol_removed/mod.rs
@@ -5,8 +5,8 @@ use rolldown_common::RUNTIME_MODULE_KEY;
 use rolldown_plugin::{HookTransformReturn, HookUsage, Plugin, SharedTransformPluginContext};
 use rolldown_testing::{manual_integration_test, test_config::TestMeta};
 
-/// A plugin that removes `__exportAll` from the runtime module,
-/// simulating a plugin that accidentally breaks a runtime utility.
+/// A plugin that removes `__exportAll` and `__toCommonJS` from the runtime module,
+/// simulating a plugin that accidentally breaks runtime utilities.
 #[derive(Debug)]
 struct RuntimeBreakingPlugin;
 
@@ -21,8 +21,11 @@ impl Plugin for RuntimeBreakingPlugin {
     args: &rolldown_plugin::HookTransformArgs<'_>,
   ) -> HookTransformReturn {
     if args.id == RUNTIME_MODULE_KEY {
-      // Remove __exportAll from the runtime module
-      let modified = args.code.replace("export var __exportAll", "var __removed_exportAll");
+      // Remove __exportAll and __toCommonJS from the runtime module
+      let modified = args
+        .code
+        .replace("export var __exportAll", "var __removed_exportAll")
+        .replace("export var __toCommonJS", "var __removed_toCommonJS");
       return Ok(Some(rolldown_plugin::HookTransformOutput {
         code: Some(modified),
         ..Default::default()

--- a/crates/rolldown_common/src/module_loader/runtime_module_brief.rs
+++ b/crates/rolldown_common/src/module_loader/runtime_module_brief.rs
@@ -41,16 +41,19 @@ impl RuntimeModuleBrief {
   /// Validate that all expected runtime helper symbols are present.
   /// Returns a list of errors for any missing symbols.
   pub fn validate_symbols(&self, expected_symbols: &[&str]) -> Vec<BuildDiagnostic> {
-    let mut errors = vec![];
-    for &name in expected_symbols {
-      if !self.name_to_symbol.contains_key(name) {
-        errors.push(BuildDiagnostic::runtime_module_symbol_not_found(
-          name.to_string(),
-          self.modified_by_plugins.clone(),
-        ));
-      }
+    let missing: Vec<String> = expected_symbols
+      .iter()
+      .filter(|name| !self.name_to_symbol.contains_key(**name))
+      .map(std::string::ToString::to_string)
+      .collect();
+    if missing.is_empty() {
+      vec![]
+    } else {
+      vec![BuildDiagnostic::runtime_module_symbol_not_found(
+        missing,
+        self.modified_by_plugins.clone(),
+      )]
     }
-    errors
   }
 
   pub fn resolve_symbol(&self, name: &str) -> SymbolRef {

--- a/crates/rolldown_error/src/build_diagnostic/constructors.rs
+++ b/crates/rolldown_error/src/build_diagnostic/constructors.rs
@@ -386,11 +386,11 @@ impl BuildDiagnostic {
   }
 
   pub fn runtime_module_symbol_not_found(
-    symbol_name: String,
+    symbol_names: Vec<String>,
     modified_by_plugins: Vec<String>,
   ) -> Self {
     Self::new_inner(super::events::runtime_module_symbol_not_found::RuntimeModuleSymbolNotFound {
-      symbol_name,
+      symbol_names,
       modified_by_plugins,
     })
   }

--- a/crates/rolldown_error/src/build_diagnostic/events/runtime_module_symbol_not_found.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/runtime_module_symbol_not_found.rs
@@ -3,7 +3,7 @@ use crate::{types::diagnostic_options::DiagnosticOptions, types::event_kind::Eve
 
 #[derive(Debug)]
 pub struct RuntimeModuleSymbolNotFound {
-  pub symbol_name: String,
+  pub symbol_names: Vec<String>,
   pub modified_by_plugins: Vec<String>,
 }
 
@@ -13,15 +13,15 @@ impl BuildEvent for RuntimeModuleSymbolNotFound {
   }
 
   fn message(&self, _opts: &DiagnosticOptions) -> String {
+    let symbols =
+      self.symbol_names.iter().map(|s| format!("\"{s}\"")).collect::<Vec<_>>().join(", ");
     if self.modified_by_plugins.is_empty() {
       format!(
-        "Failed to resolve runtime symbol \"{}\". This is a Rolldown internal error - please file an issue at https://github.com/rolldown/rolldown/issues.",
-        self.symbol_name
+        "Failed to resolve runtime symbol(s) {symbols}. This is a Rolldown internal error - please file an issue at https://github.com/rolldown/rolldown/issues.",
       )
     } else {
       format!(
-        "Failed to resolve runtime symbol \"{}\" after the runtime module was modified by plugin(s): {}. Please review these plugins to ensure they do not accidentally remove or rename runtime utilities.",
-        self.symbol_name,
+        "Failed to resolve runtime symbol(s) {symbols} after the runtime module was modified by plugin(s): {}. Please review these plugins to ensure they do not accidentally remove or rename runtime utilities.",
         self.modified_by_plugins.join(", ")
       )
     }


### PR DESCRIPTION
Before If all symbols in runtime module are eliminated accidently, we will emit 19 errors, but now we only emit one error.