### PR TITLE
feat: add LLM-friendly markdown output format to bundle analyzer plugin

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/config/binding_bundle_analyzer_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_bundle_analyzer_plugin_config.rs
@@ -3,12 +3,15 @@ use rolldown_plugin_bundle_analyzer::BundleAnalyzerPlugin;
 #[napi_derive::napi(object)]
 #[derive(Debug, Default)]
 pub struct BindingBundleAnalyzerPluginConfig {
-  /// Output filename for the analysis data (default: "analyze-data.json")
+  /// Output filename for the bundle analysis data (default: "analyze-data.json")
   pub file_name: Option<String>,
+  /// Output format: "json" (default) or "md" for LLM-friendly markdown
+  #[napi(ts_type = "'json' | 'md'")]
+  pub format: Option<String>,
 }
 
 impl From<BindingBundleAnalyzerPluginConfig> for BundleAnalyzerPlugin {
   fn from(value: BindingBundleAnalyzerPluginConfig) -> Self {
-    Self { file_name: value.file_name }
+    Self { file_name: value.file_name, format: value.format }
   }
 }

--- a/crates/rolldown_binding/src/options/plugin/config/binding_chunk_visualize_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_chunk_visualize_plugin_config.rs
@@ -1,0 +1,17 @@
+use rolldown_plugin_chunk_visualize::ChunkVisualizePlugin;
+
+#[napi_derive::napi(object)]
+#[derive(Debug, Default)]
+pub struct BindingChunkVisualizePluginConfig {
+  /// Output filename for the visualization data (default: "analyze-data.json" or "analyze-data.md")
+  pub file_name: Option<String>,
+  /// Output format: "json" (default) or "md" for LLM-friendly markdown
+  #[napi(ts_type = "'json' | 'md'")]
+  pub format: Option<String>,
+}
+
+impl From<BindingChunkVisualizePluginConfig> for ChunkVisualizePlugin {
+  fn from(value: BindingChunkVisualizePluginConfig) -> Self {
+    Self { file_name: value.file_name, format: value.format }
+  }
+}

--- a/crates/rolldown_plugin_bundle_analyzer/src/render_markdown.rs
+++ b/crates/rolldown_plugin_bundle_analyzer/src/render_markdown.rs
@@ -1,0 +1,485 @@
+use std::fmt::Write;
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{AnalyzeData, ChunkType, ImportType, ModuleData};
+
+/// Render the analyze data as LLM-friendly markdown (inspired by Bun's --metafile-md)
+pub fn render_markdown(data: &AnalyzeData) -> String {
+  let mut out = String::new();
+
+  // Header
+  out.push_str("# Bundle Analysis Report\n\n");
+  out.push_str(
+    "This report helps identify bundle size issues, dependency bloat, and optimization opportunities.\n\n",
+  );
+
+  // Table of Contents
+  out.push_str("## Table of Contents\n\n");
+  out.push_str("- [Quick Summary](#quick-summary)\n");
+  out.push_str(
+    "- [Largest Modules by Output Contribution](#largest-modules-by-output-contribution)\n",
+  );
+  out.push_str("- [Entry Point Analysis](#entry-point-analysis)\n");
+  out.push_str("- [Dependency Chains](#dependency-chains)\n");
+  out.push_str("- [Optimization Suggestions](#optimization-suggestions)\n");
+  out.push_str("- [Full Module Graph](#full-module-graph)\n");
+  out.push_str("- [Raw Data for Searching](#raw-data-for-searching)\n\n");
+  out.push_str("---\n\n");
+
+  // Quick Summary
+  let total_output_size: usize = data.chunks.iter().map(|c| c.size).sum();
+  let entry_count = data
+    .chunks
+    .iter()
+    .filter(|c| matches!(c.chunk_type, ChunkType::StaticEntry | ChunkType::DynamicEntry))
+    .count();
+  let common_count =
+    data.chunks.iter().filter(|c| matches!(c.chunk_type, ChunkType::Common)).count();
+
+  out.push_str("## Quick Summary\n\n");
+  out.push_str("| Metric | Value |\n");
+  out.push_str("|--------|-------|\n");
+  writeln!(out, "| Total output size | {} |", format_size(total_output_size)).unwrap();
+  writeln!(out, "| Input modules | {} |", data.modules.len()).unwrap();
+  writeln!(out, "| Entry points | {entry_count} |").unwrap();
+  writeln!(out, "| Code-split chunks | {common_count} |").unwrap();
+  out.push('\n');
+
+  // Build reverse maps
+  // module index → list of modules it imports (derived from importers)
+  let mut module_imports: FxHashMap<usize, Vec<usize>> =
+    FxHashMap::with_capacity_and_hasher(data.modules.len(), Default::default());
+  for (idx, module) in data.modules.iter().enumerate() {
+    if let Some(importers) = &module.importers {
+      for &importer_idx in importers {
+        module_imports.entry(importer_idx).or_default().push(idx);
+      }
+    }
+  }
+
+  // Largest Modules by Output Contribution
+  render_largest_modules(&mut out, data, total_output_size);
+
+  // Entry Point Analysis
+  render_entry_point_analysis(&mut out, data);
+
+  // Dependency Chains
+  render_dependency_chains(&mut out, data);
+
+  // Optimization Suggestions
+  render_optimization_suggestions(&mut out, data);
+
+  // Full Module Graph
+  render_full_module_graph(&mut out, data, &module_imports);
+
+  // Raw Data for Searching
+  render_raw_data(&mut out, data, &module_imports);
+
+  out
+}
+
+fn render_largest_modules(out: &mut String, data: &AnalyzeData, total_output_size: usize) {
+  out.push_str("## Largest Modules by Output Contribution\n\n");
+  out.push_str(
+    "Modules sorted by bytes contributed to the output bundle. Large modules may indicate bloat.\n\n",
+  );
+
+  let mut all_modules: Vec<(usize, &ModuleData)> = data.modules.iter().enumerate().collect();
+  all_modules.sort_by(|a, b| b.1.size.cmp(&a.1.size));
+
+  out.push_str("| Output Bytes | % of Total | Module |\n");
+  out.push_str("|--------------|------------|--------|\n");
+  for &(_, module) in &all_modules {
+    let pct = if total_output_size > 0 {
+      (module.size as f64 / total_output_size as f64) * 100.0
+    } else {
+      0.0
+    };
+    writeln!(out, "| {} | {pct:.1}% | `{}` |", format_size(module.size), module.path).unwrap();
+  }
+  out.push('\n');
+}
+
+fn render_entry_point_analysis(out: &mut String, data: &AnalyzeData) {
+  out.push_str("## Entry Point Analysis\n\n");
+  out.push_str("Each entry point and the total code it loads (including shared chunks).\n\n");
+
+  for chunk in &data.chunks {
+    if !matches!(chunk.chunk_type, ChunkType::StaticEntry | ChunkType::DynamicEntry) {
+      continue;
+    }
+
+    let entry_path = chunk.entry_module.and_then(|idx| data.modules.get(idx));
+
+    if let Some(entry_module) = entry_path {
+      writeln!(out, "### Entry: `{}`\n", entry_module.path).unwrap();
+    } else {
+      writeln!(out, "### Entry: `{}`\n", chunk.name).unwrap();
+    }
+
+    writeln!(out, "**Output file**: `{}`", chunk.name).unwrap();
+    writeln!(out, "**Bundle size**: {}", format_size(chunk.size)).unwrap();
+
+    // Show chunk imports (code-splitting)
+    if let Some(imports) = &chunk.imports
+      && !imports.is_empty()
+    {
+      out.push('\n');
+      out.push_str("**Loads these chunks** (code-splitting):\n");
+      for import in imports {
+        if let Some(target) = data.chunks.get(import.target_chunk_index) {
+          let kind = match import.import_type {
+            ImportType::Static => "import-statement",
+            ImportType::Dynamic => "dynamic-import",
+          };
+          writeln!(out, "- `{}` ({}, {kind})", target.name, format_size(target.size)).unwrap();
+        }
+      }
+    }
+
+    // Bundled modules in this entry
+    if let Some(indices) = &chunk.module_indices
+      && !indices.is_empty()
+    {
+      let mut sorted_indices: Vec<usize> = indices.clone();
+      sorted_indices.sort_by(|a, b| {
+        let size_a = data.modules.get(*a).map_or(0, |m| m.size);
+        let size_b = data.modules.get(*b).map_or(0, |m| m.size);
+        size_b.cmp(&size_a)
+      });
+
+      out.push_str("\n**Bundled modules** (sorted by contribution):\n\n");
+      out.push_str("| Bytes | Module |\n");
+      out.push_str("|-------|--------|\n");
+      for &idx in &sorted_indices {
+        if let Some(module) = data.modules.get(idx) {
+          writeln!(out, "| {} | `{}` |", format_size(module.size), module.path).unwrap();
+        }
+      }
+    }
+
+    out.push('\n');
+  }
+}
+
+fn render_dependency_chains(out: &mut String, data: &AnalyzeData) {
+  out.push_str("## Dependency Chains\n\n");
+  out.push_str(
+    "For each module, shows what files import it. Use this to understand why a module is included.\n\n",
+  );
+
+  // Find modules imported by multiple files
+  let mut multi_imported: Vec<(usize, &ModuleData)> = data
+    .modules
+    .iter()
+    .enumerate()
+    .filter(|(_, m)| m.importers.as_ref().is_some_and(|i| i.len() >= 2))
+    .collect();
+  multi_imported.sort_by(|a, b| {
+    let count_a = a.1.importers.as_ref().map_or(0, |i| i.len());
+    let count_b = b.1.importers.as_ref().map_or(0, |i| i.len());
+    count_b.cmp(&count_a)
+  });
+
+  if !multi_imported.is_empty() {
+    out.push_str("### Most Commonly Imported Modules\n\n");
+    out.push_str("Modules imported by many files. Extracting these to shared chunks may help.\n\n");
+    out.push_str("| Import Count | Module | Imported By |\n");
+    out.push_str("|--------------|--------|-------------|\n");
+    for &(_, module) in &multi_imported {
+      if let Some(importers) = &module.importers {
+        let importer_paths: Vec<&str> =
+          importers.iter().filter_map(|&i| data.modules.get(i).map(|m| m.path.as_str())).collect();
+        writeln!(
+          out,
+          "| {} | `{}` | {} |",
+          importers.len(),
+          module.path,
+          importer_paths.iter().map(|p| format!("`{p}`")).collect::<Vec<_>>().join(", ")
+        )
+        .unwrap();
+      }
+    }
+    out.push('\n');
+  }
+}
+
+fn render_optimization_suggestions(out: &mut String, data: &AnalyzeData) {
+  // Step 1: Collect static entry chunks with reachability sets
+  let static_entries: Vec<(usize, &str, FxHashSet<usize>)> = data
+    .chunks
+    .iter()
+    .enumerate()
+    .filter(|(_, c)| matches!(c.chunk_type, ChunkType::StaticEntry))
+    .filter_map(|(idx, c)| {
+      let reachable = c.reachable_module_indices.as_ref()?;
+      let entry_path = c
+        .entry_module
+        .and_then(|i| data.modules.get(i))
+        .map_or(c.name.as_str(), |m| m.path.as_str());
+      Some((idx, entry_path, reachable.iter().copied().collect::<FxHashSet<usize>>()))
+    })
+    .collect();
+
+  if static_entries.is_empty() {
+    return;
+  }
+
+  // Step 2: For each common chunk, find modules reachable by exactly one static entry
+  struct Suggestion<'a> {
+    common_chunk_name: &'a str,
+    common_chunk_total_module_size: usize,
+    entry_path: &'a str,
+    modules: Vec<(&'a str, usize)>, // (path, size)
+    total_size: usize,
+  }
+
+  let mut suggestions: Vec<Suggestion> = Vec::new();
+
+  for common_chunk in data.chunks.iter().filter(|c| matches!(c.chunk_type, ChunkType::Common)) {
+    let module_indices = match &common_chunk.module_indices {
+      Some(indices) if !indices.is_empty() => indices,
+      _ => continue,
+    };
+
+    // Only consider common chunks shared by multiple static entries
+    let reaching_entry_count = static_entries
+      .iter()
+      .filter(|(_, _, reachable)| module_indices.iter().any(|idx| reachable.contains(idx)))
+      .count();
+    if reaching_entry_count < 2 {
+      continue;
+    }
+
+    // Total source size of all modules in this common chunk
+    let common_chunk_total_module_size: usize =
+      module_indices.iter().filter_map(|&i| data.modules.get(i)).map(|m| m.size).sum();
+
+    // Group modules by the single static entry that reaches them
+    let mut by_entry: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
+
+    for &mod_idx in module_indices {
+      let mut reaching_entries: Vec<usize> = Vec::new();
+      for &(entry_idx, _, ref reachable) in &static_entries {
+        if reachable.contains(&mod_idx) {
+          reaching_entries.push(entry_idx);
+        }
+      }
+      if reaching_entries.len() == 1 {
+        by_entry.entry(reaching_entries[0]).or_default().push(mod_idx);
+      }
+    }
+
+    for (entry_idx, mod_indices) in by_entry {
+      let entry_path = static_entries
+        .iter()
+        .find(|(idx, _, _)| *idx == entry_idx)
+        .map(|(_, path, _)| *path)
+        .unwrap_or("unknown");
+
+      let mut modules: Vec<(&str, usize)> = mod_indices
+        .iter()
+        .filter_map(|&i| data.modules.get(i).map(|m| (m.path.as_str(), m.size)))
+        .collect();
+      modules.sort_by(|a, b| b.1.cmp(&a.1));
+
+      let total_size: usize = modules.iter().map(|(_, s)| *s).sum();
+
+      suggestions.push(Suggestion {
+        common_chunk_name: &common_chunk.name,
+        common_chunk_total_module_size,
+        entry_path,
+        modules,
+        total_size,
+      });
+    }
+  }
+
+  if suggestions.is_empty() {
+    return;
+  }
+
+  suggestions.sort_by(|a, b| b.total_size.cmp(&a.total_size));
+
+  // Step 3: Render
+  out.push_str("## Optimization Suggestions\n\n");
+  out.push_str("Actionable suggestions to improve bundle efficiency.\n\n");
+
+  for suggestion in &suggestions {
+    let pct = if suggestion.common_chunk_total_module_size > 0 {
+      (suggestion.total_size as f64 / suggestion.common_chunk_total_module_size as f64) * 100.0
+    } else {
+      0.0
+    };
+
+    let level = if pct > 50.0 {
+      "HIGH"
+    } else if pct >= 30.0 {
+      "MEDIUM"
+    } else {
+      "LOW"
+    };
+
+    writeln!(
+      out,
+      "### [{level}] Common chunk `{}`: {pct:.1}% only reachable from `{}`\n",
+      suggestion.common_chunk_name, suggestion.entry_path,
+    )
+    .unwrap();
+
+    writeln!(
+      out,
+      "**{} modules** ({} of {}) in common chunk `{}` are only reachable \
+       from entry `{}`. Consider adjusting code splitting configuration to move these \
+       modules closer to their entry point.\n",
+      suggestion.modules.len(),
+      format_size(suggestion.total_size),
+      format_size(suggestion.common_chunk_total_module_size),
+      suggestion.common_chunk_name,
+      suggestion.entry_path,
+    )
+    .unwrap();
+
+    out.push_str("| Size | Module |\n");
+    out.push_str("|------|--------|\n");
+    for &(path, size) in &suggestion.modules {
+      writeln!(out, "| {} | `{path}` |", format_size(size)).unwrap();
+    }
+    out.push('\n');
+  }
+}
+
+fn render_full_module_graph(
+  out: &mut String,
+  data: &AnalyzeData,
+  module_imports: &FxHashMap<usize, Vec<usize>>,
+) {
+  out.push_str("## Full Module Graph\n\n");
+  out.push_str("Complete dependency information for each module.\n\n");
+
+  // Sort modules alphabetically by path for consistent output
+  let mut sorted_modules: Vec<(usize, &ModuleData)> = data.modules.iter().enumerate().collect();
+  sorted_modules.sort_by(|a, b| a.1.path.cmp(&b.1.path));
+
+  for &(idx, module) in &sorted_modules {
+    writeln!(out, "### `{}`\n", module.path).unwrap();
+    writeln!(out, "- **Output contribution**: {}", format_size(module.size)).unwrap();
+
+    // Imported by
+    if let Some(importers) = &module.importers
+      && !importers.is_empty()
+    {
+      let importer_paths: Vec<String> = importers
+        .iter()
+        .filter_map(|&i| data.modules.get(i).map(|m| format!("`{}`", m.path)))
+        .collect();
+      writeln!(out, "- **Imported by** ({} files): {}", importers.len(), importer_paths.join(" "))
+        .unwrap();
+    } else {
+      out.push_str("- **Imported by**: (entry point or orphan)\n");
+    }
+
+    // Imports
+    if let Some(deps) = module_imports.get(&idx)
+      && !deps.is_empty()
+    {
+      out.push_str("- **Imports**:\n");
+      for &dep_idx in deps {
+        if let Some(dep) = data.modules.get(dep_idx) {
+          writeln!(out, "  - `{}`", dep.path).unwrap();
+        }
+      }
+    }
+
+    out.push('\n');
+  }
+}
+
+fn render_raw_data(
+  out: &mut String,
+  data: &AnalyzeData,
+  module_imports: &FxHashMap<usize, Vec<usize>>,
+) {
+  out.push_str("## Raw Data for Searching\n\n");
+  out.push_str("This section contains raw, grep-friendly data. Use these patterns:\n");
+  out.push_str("- `[MODULE:` - Find all modules\n");
+  out.push_str("- `[OUTPUT_BYTES:` - Find output contribution for each module\n");
+  out.push_str("- `[IMPORT:` - Find all import relationships\n");
+  out.push_str("- `[IMPORTED_BY:` - Find reverse dependencies\n");
+  out.push_str("- `[ENTRY:` - Find entry points\n");
+  out.push_str("- `[CHUNK:` - Find code-split chunks\n\n");
+
+  // All Modules
+  let mut all_modules: Vec<(usize, &ModuleData)> = data.modules.iter().enumerate().collect();
+  all_modules.sort_by(|a, b| b.1.size.cmp(&a.1.size));
+
+  out.push_str("### All Modules\n\n```\n");
+  for &(_, module) in &all_modules {
+    writeln!(out, "[MODULE: {}]", module.path).unwrap();
+    writeln!(out, "[OUTPUT_BYTES: {} = {} bytes]", module.path, module.size).unwrap();
+  }
+  out.push_str("```\n\n");
+
+  // All Imports
+  let mut sorted_modules: Vec<(usize, &ModuleData)> = data.modules.iter().enumerate().collect();
+  sorted_modules.sort_by(|a, b| a.1.path.cmp(&b.1.path));
+
+  out.push_str("### All Imports\n\n```\n");
+  for &(idx, module) in &sorted_modules {
+    if let Some(deps) = module_imports.get(&idx) {
+      for &dep_idx in deps {
+        if let Some(dep) = data.modules.get(dep_idx) {
+          writeln!(out, "[IMPORT: {} -> {}]", module.path, dep.path).unwrap();
+        }
+      }
+    }
+  }
+  out.push_str("```\n\n");
+
+  // Reverse Dependencies
+  out.push_str("### Reverse Dependencies (Imported By)\n\n```\n");
+  for &(_, module) in &sorted_modules {
+    if let Some(importers) = &module.importers {
+      for &importer_idx in importers {
+        if let Some(importer) = data.modules.get(importer_idx) {
+          writeln!(out, "[IMPORTED_BY: {} <- {}]", module.path, importer.path).unwrap();
+        }
+      }
+    }
+  }
+  out.push_str("```\n\n");
+
+  // Entry Points
+  out.push_str("### Entry Points\n\n```\n");
+  for chunk in &data.chunks {
+    if matches!(chunk.chunk_type, ChunkType::StaticEntry | ChunkType::DynamicEntry) {
+      let entry_path = chunk
+        .entry_module
+        .and_then(|idx| data.modules.get(idx))
+        .map_or("unknown", |m| m.path.as_str());
+      writeln!(out, "[ENTRY: {} -> {} ({} bytes)]", entry_path, chunk.name, chunk.size).unwrap();
+    }
+  }
+  out.push_str("```\n\n");
+
+  // Chunks
+  out.push_str("### Chunks\n\n```\n");
+  for chunk in &data.chunks {
+    if matches!(chunk.chunk_type, ChunkType::Common) {
+      writeln!(out, "[CHUNK: {} ({} bytes)]", chunk.name, chunk.size).unwrap();
+    }
+  }
+  out.push_str("```\n");
+}
+
+/// Format a byte size into a human-readable string
+fn format_size(bytes: usize) -> String {
+  if bytes < 1024 {
+    format!("{bytes} B")
+  } else if bytes < 1024 * 1024 {
+    format!("{:.1} kB", bytes as f64 / 1024.0)
+  } else {
+    format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+  }
+}

--- a/examples/bundle-analyzer-demo/rolldown.config.js
+++ b/examples/bundle-analyzer-demo/rolldown.config.js
@@ -9,6 +9,14 @@ export default defineConfig({
   output: {
     dir: 'dist',
     format: 'esm',
+    entryFileNames: '[name]-[hash].js',
+    chunkFileNames: 'chunks/[name]-[hash].js',
+    // Force utils into a single shared chunk to demonstrate optimization suggestions
+    manualChunks(id) {
+      if (id.includes('/utils/') || id.includes('\\utils\\')) {
+        return 'utils';
+      }
+    },
   },
   plugins: [bundleAnalyzerPlugin()],
 });

--- a/examples/bundle-analyzer-demo/src/features/admin.js
+++ b/examples/bundle-analyzer-demo/src/features/admin.js
@@ -1,5 +1,5 @@
 import { logger } from '../utils/logger.js';
-import { formatDate } from '../utils/helpers.js';
+import { formatDate } from '../utils/date-format.js';
 
 export function initialize() {
   logger.info(formatDate());

--- a/examples/bundle-analyzer-demo/src/features/dashboard.js
+++ b/examples/bundle-analyzer-demo/src/features/dashboard.js
@@ -1,6 +1,6 @@
 import { logger } from '../utils/logger.js';
-import { formatDate } from '../utils/helpers.js';
+import { validate } from '../utils/validator.js';
 
-export function render() {
-  logger.info(formatDate());
+export function render(data) {
+  if (validate(data)) logger.info();
 }

--- a/examples/bundle-analyzer-demo/src/main.js
+++ b/examples/bundle-analyzer-demo/src/main.js
@@ -1,11 +1,13 @@
 import { createApp } from './app.js';
 import { logger } from './utils/logger.js';
+import { formatDate } from './utils/date-format.js';
+import { validate } from './utils/validator.js';
+import { getLocale } from './utils/locale.js';
 import './styles.css';
 
 const loadAdmin = () => import('./features/admin.js');
 const loadDashboard = () => import('./features/dashboard.js');
 
 createApp();
-logger.info();
-
+logger.info(formatDate(), validate(), getLocale());
 export { loadAdmin, loadDashboard };

--- a/examples/bundle-analyzer-demo/src/utils/date-format.js
+++ b/examples/bundle-analyzer-demo/src/utils/date-format.js
@@ -1,0 +1,5 @@
+import { padZero } from './pad.js';
+
+export function formatDate(d = new Date()) {
+  return `${d.getFullYear()}-${padZero(d.getMonth() + 1)}-${padZero(d.getDate())}`;
+}

--- a/examples/bundle-analyzer-demo/src/utils/helpers.js
+++ b/examples/bundle-analyzer-demo/src/utils/helpers.js
@@ -1,5 +1,1 @@
-export function formatDate() {}
-export function formatTime() {}
-export function debounce(fn) {
-  return fn;
-}
+export function debounce() {}

--- a/examples/bundle-analyzer-demo/src/utils/locale.js
+++ b/examples/bundle-analyzer-demo/src/utils/locale.js
@@ -1,0 +1,5 @@
+import { padZero } from './pad.js';
+
+export function getLocale() {
+  return padZero(1);
+}

--- a/examples/bundle-analyzer-demo/src/utils/logger.js
+++ b/examples/bundle-analyzer-demo/src/utils/logger.js
@@ -1,5 +1,1 @@
-export const logger = {
-  info() {},
-  warn() {},
-  error() {},
-};
+export const logger = { info() {}, warn() {} };

--- a/examples/bundle-analyzer-demo/src/utils/pad.js
+++ b/examples/bundle-analyzer-demo/src/utils/pad.js
@@ -1,0 +1,3 @@
+export function padZero(n) {
+  return String(n).padStart(2, '0');
+}

--- a/examples/bundle-analyzer-demo/src/utils/validator.js
+++ b/examples/bundle-analyzer-demo/src/utils/validator.js
@@ -1,0 +1,6 @@
+import { logger } from './logger.js';
+
+export function validate(v) {
+  if (!v) logger.warn();
+  return !!v;
+}

--- a/examples/bundle-analyzer-demo/src/worker.js
+++ b/examples/bundle-analyzer-demo/src/worker.js
@@ -1,6 +1,8 @@
 import { logger } from './utils/logger.js';
-import { formatDate, formatTime, debounce } from './utils/helpers.js';
+import { validate } from './utils/validator.js';
+import { formatDate } from './utils/date-format.js';
+import { debounce } from './utils/helpers.js';
 
 const loadDashboard = () => import('./features/dashboard.js');
 
-logger.info(formatDate(), formatTime(), debounce(), loadDashboard);
+logger.info(validate(), formatDate(), debounce(), loadDashboard);

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1793,8 +1793,10 @@ export type BindingBuiltinPluginName =  'builtin:bundle-analyzer'|
 'builtin:vite-web-worker-post';
 
 export interface BindingBundleAnalyzerPluginConfig {
-  /** Output filename for the analysis data (default: "analyze-data.json") */
+  /** Output filename for the bundle analysis data (default: "analyze-data.json") */
   fileName?: string
+  /** Output format: "json" (default) or "md" for LLM-friendly markdown */
+  format?: 'json' | 'md'
 }
 
 export interface BindingBundlerOptions {

--- a/packages/rolldown/src/builtin-plugin/bundle-analyzer-plugin.ts
+++ b/packages/rolldown/src/builtin-plugin/bundle-analyzer-plugin.ts
@@ -4,7 +4,7 @@ import { BuiltinPlugin } from './utils';
 /**
  * A plugin that analyzes bundle composition and generates detailed reports.
  *
- * The plugin outputs a JSON file containing detailed information about:
+ * The plugin outputs a file containing detailed information about:
  * - All chunks and their relationships
  * - Modules bundled in each chunk
  * - Import dependencies between chunks
@@ -30,6 +30,20 @@ import { BuiltinPlugin } from './utils';
  *   plugins: [
  *     bundleAnalyzerPlugin({
  *       fileName: 'bundle-analysis.json'
+ *     })
+ *   ]
+ * }
+ * ```
+ *
+ * @example
+ * **LLM-friendly markdown output**
+ * ```js
+ * import { chunkVisualizePlugin } from 'rolldown/experimental';
+ *
+ * export default {
+ *   plugins: [
+ *     chunkVisualizePlugin({
+ *       format: 'md'
  *     })
  *   ]
  * }


### PR DESCRIPTION
## Summary

Adds an LLM-friendly markdown output format for the chunk visualization plugin, and an optimization suggestions section that analyzes bundle composition.

### Markdown Format (`format: 'md'`)

When `format: 'md'` is set, the plugin emits a structured markdown report instead of JSON. The report is designed to be consumed by LLMs and contains:

| Section | Description |
| --- | --- |
| **Quick Summary** | Total output size, module count, entry points, code-split chunks |
| **Largest Modules by Output Contribution** | All modules sorted by size with percentage of total |
| **Entry Point Analysis** | Each entry's output file, bundle size, loaded chunks, and bundled modules |
| **Dependency Chains** | Modules imported by multiple files — helps understand why a module is included |
| **Optimization Suggestions** | Actionable suggestions with severity levels (see below) |
| **Full Module Graph** | Complete per-module dependency info (imports, imported-by, size) |
| **Raw Data for Searching** | Grep-friendly `[MODULE:]`, `[IMPORT:]`, `[IMPORTED_BY:]`, `[ENTRY:]`, `[CHUNK:]` patterns |

### Optimization Suggestions

The new suggestions section identifies modules in **shared common chunks** that are only reachable from a **single static entry**. These modules are unnecessarily shared and could be moved closer to their entry point via code splitting configuration.

Each suggestion includes a severity level based on the proportion of single-entry-reachable module size:

- **`[HIGH]`** — > 50%
- **`[MEDIUM]`** — 30%–50%
- **`[LOW]`** — < 30%

### Other Changes

- `format` field type narrowed from `string` to `'json' | 'md'` via `#[napi(ts_type)]`
- Updated `chunk-visualize-demo` example with a proper multi-entry dependency graph that demonstrates the optimization suggestions