### PR TITLE
fix: skip redundant side-effect imports for transitively reachable chunks

### DIFF
--- a/crates/rolldown/tests/rolldown/code_splitting/redundant_facade_side_effect_import/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/redundant_facade_side_effect_import/_config.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "sorter",
+        "import": "sorter.js"
+      },
+      {
+        "name": "main",
+        "import": "main.js"
+      }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "resolve-chunk",
+          "test": "resolve\\.js"
+        },
+        {
+          "name": "sorter-chunk",
+          "test": "sorter\\.js"
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/redundant_facade_side_effect_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/redundant_facade_side_effect_import/artifacts.snap
@@ -1,0 +1,54 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import { t as resolveThing } from "./resolve-chunk.js";
+
+//#region main.js
+function loadV4() {
+	return resolveThing();
+}
+
+//#endregion
+export { loadV4 };
+```
+
+## resolve-chunk.js
+
+```js
+//#region resolve.js
+let counter = 0;
+counter++;
+function resolveThing() {
+	return counter;
+}
+
+//#endregion
+export { resolveThing as t };
+```
+
+## sorter-chunk.js
+
+```js
+import { t as resolveThing } from "./resolve-chunk.js";
+
+//#region sorter.js
+function createSorter() {
+	return resolveThing();
+}
+
+//#endregion
+export { createSorter as t };
+```
+
+## sorter.js
+
+```js
+import { t as createSorter } from "./sorter-chunk.js";
+
+export { createSorter };
+```

--- a/crates/rolldown/tests/rolldown/code_splitting/redundant_facade_side_effect_import/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/redundant_facade_side_effect_import/main.js
@@ -1,0 +1,5 @@
+import { resolveThing } from './resolve.js';
+
+export function loadV4() {
+  return resolveThing();
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/redundant_facade_side_effect_import/resolve.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/redundant_facade_side_effect_import/resolve.js
@@ -1,0 +1,6 @@
+let counter = 0;
+counter++;
+
+export function resolveThing() {
+  return counter;
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/redundant_facade_side_effect_import/sorter.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/redundant_facade_side_effect_import/sorter.js
@@ -1,0 +1,5 @@
+import { resolveThing } from './resolve.js';
+
+export function createSorter() {
+  return resolveThing();
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3885,6 +3885,13 @@ expression: output
 - a-!~{004}~.js => a-Cth2Ajcb.js
 - dbp-2-!~{006}~.js => dbp-2-DLoK7iE_.js
 
+# tests/rolldown/code_splitting/redundant_facade_side_effect_import
+
+- main-!~{001}~.js => main-DSU_ad9X.js
+- sorter-!~{000}~.js => sorter-BTrahW75.js
+- resolve-chunk-!~{002}~.js => resolve-chunk-GG2UOsRv.js
+- sorter-chunk-!~{004}~.js => sorter-chunk-UVqCtK9h.js
+
 # tests/rolldown/dce/conditional_exports
 
 - main-!~{000}~.js => main-B-9hzRYa.js


### PR DESCRIPTION
I found this bug while working on https://github.com/tailwindlabs/prettier-plugin-tailwindcss/blob/125a8bc77639529a5a0c7e4e8a02174d7ed2d70b/tsdown.config.ts#L67.

## Summary

- When `manualChunks` moves an entry module into a separate chunk, the entry becomes a facade. The facade was incorrectly getting a direct side-effect import of transitive dependencies already loaded via the symbol import chain (e.g. `import "./resolve.js"` when `sorter-chunk` already imports it).
- Before adding side-effect imports, compute transitively reachable chunks from symbol-based imports by following module-level import records, and skip any chunk already in that transitive set.

**Before:**
```js
// dist/sorter.js (facade)
import "./resolve.js";  // <-- redundant
import { t as createSorter } from "./sorter-chunk.js";
export { createSorter };
```

**After:**
```js
// dist/sorter.js (facade)
import { t as createSorter } from "./sorter-chunk.js";
export { createSorter };
```

## Test plan

- [x] Added test case `code_splitting/redundant_facade_side_effect_import` reproducing the scenario
- [x] All existing Rust tests pass (`just test-rust`)
- [x] Clippy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)