### PR TITLE
docs: remove `<script>` escape behavior difference note from `platform` option

### DIFF
--- a/docs/guide/notable-features.md
+++ b/docs/guide/notable-features.md
@@ -13,7 +13,6 @@ Similar to [esbuild's `platform` option](https://esbuild.github.io/api/#platform
 **Notable differences from esbuild:**
 
 - The default output format is always `esm` regardless of platform.
-- No `</script>` escape behavior when platform is `browser`.
 
 :::tip
 Rolldown does not polyfill Node built-ins when targeting the browser. You can opt-in to it with [rolldown-plugin-node-polyfills](https://github.com/rolldown/rolldown-plugin-node-polyfills).

--- a/packages/rolldown/src/options/docs/platform.md
+++ b/packages/rolldown/src/options/docs/platform.md
@@ -73,7 +73,6 @@ Platform-agnostic configuration:
 Notable differences from esbuild's `platform` option:
 
 - The default output format is always `'esm'` regardless of platform (in esbuild, Node.js defaults to `'cjs'`)
-- No automatic `</script>` escape behavior when platform is `'browser'`
 
 ##### Choosing a Platform
 


### PR DESCRIPTION
We always escape `<script>`. Users shouldn't need to be aware of this behavior difference.

refs https://github.com/rolldown/rolldown/issues/7098#issuecomment-3645494352