### PR TITLE
feat: rename error name to `RolldownError` from `RollupError`

### DIFF
--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -89,7 +89,7 @@ export function error(base: Error | RolldownLog): never {
   if (!(base instanceof Error)) {
     base = Object.assign(new Error(base.message), base);
     Object.defineProperty(base, 'name', {
-      value: 'RollupError',
+      value: 'RolldownError',
       writable: true,
     });
   }

--- a/packages/rolldown/tests/fixtures/misc/error/plugin-context/_config.ts
+++ b/packages/rolldown/tests/fixtures/misc/error/plugin-context/_config.ts
@@ -19,7 +19,7 @@ export default defineTest({
     const id = join(import.meta.dirname, 'main.js');
     expect(e.message).toContain(`\
 [plugin my-plugin] ${id}:1:4
-RollupError: my-error
+RolldownError: my-error
 1: xxx;
        ^
 2: yyy;

--- a/packages/rollup-tests/test/misc/misc.js
+++ b/packages/rollup-tests/test/misc/misc.js
@@ -271,7 +271,7 @@ console.log(x);
 			});
 		} catch (error) {
 			assert.notDeepStrictEqual(error.message, 'Maximum call stack size exceeded');
-			assert.strictEqual(error.name, 'RollupError');
+			assert.strictEqual(error.name, 'RolldownError');
 		}
 	});
 


### PR DESCRIPTION
To make it less confusing.