### PR TITLE
fix(hmr): avoid class fields in HMR runtime to prevent OXC helper ordering issue

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/hmr/oxc_helper_with_low_target/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/oxc_helper_with_low_target/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    },
+    "transform": {
+      "target": "es2020"
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/oxc_helper_with_low_target/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/oxc_helper_with_low_target/artifacts.snap
@@ -1,0 +1,104 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+// HIDDEN [rolldown:hmr]
+// HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
+// HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
+// HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
+// HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
+// HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
+// HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
+// HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
+// HIDDEN [\0@oxc-project+runtime@0.0.0/file.js]
+//#region module_with_class_fields.js
+var module_with_class_fields_exports = /* @__PURE__ */ __exportAll({ getValue: () => getValue });
+const module_with_class_fields_hot = __rolldown_runtime__.createModuleHotContext("module_with_class_fields.js");
+__rolldown_runtime__.registerModule("module_with_class_fields.js", { exports: module_with_class_fields_exports });
+var _privateField = /* @__PURE__ */ new WeakMap();
+var MyService = class {
+	constructor() {
+		_defineProperty(this, "name", "service");
+		_classPrivateFieldInitSpec(this, _privateField, 42);
+	}
+	getValue() {
+		return _classPrivateFieldGet2(_privateField, this);
+	}
+};
+function getValue() {
+	return new MyService().getValue();
+}
+
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+console.log(getValue());
+main_hot.accept(() => {});
+
+//#endregion
+```
+
+# HMR Step 0
+
+## Code
+
+```js
+//#region main.js
+var init_main_0 = __rolldown_runtime__.createEsmInitializer((function() {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({});
+		__rolldown_runtime__.registerModule("main.js", { exports: __rolldown_exports__ });
+		init_module_with_class_fields_1();
+		const hot_main = __rolldown_runtime__.createModuleHotContext("main.js");
+		var import_rolldown_hmr_00 = __rolldown_runtime__.loadExports("rolldown:hmr");
+		var import_module_with_class_fields_01 = __rolldown_runtime__.loadExports("module_with_class_fields.js");
+		console.log(import_module_with_class_fields_01.getValue());
+		hot_main.accept(() => {});
+	} finally {}
+}));
+
+//#endregion
+//#region module_with_class_fields.js
+var init_module_with_class_fields_1 = __rolldown_runtime__.createEsmInitializer((function() {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ getValue: () => getValue });
+		__rolldown_runtime__.registerModule("module_with_class_fields.js", { exports: __rolldown_exports__ });
+		const hot_module_with_class_fields = __rolldown_runtime__.createModuleHotContext("module_with_class_fields.js");
+		var import_defineProperty_10 = __rolldown_runtime__.loadExports("\\0@oxc-project+runtime@0.112.0/helpers/defineProperty.js");
+		var import_classPrivateFieldInitSpec_11 = __rolldown_runtime__.loadExports("\\0@oxc-project+runtime@0.112.0/helpers/classPrivateFieldInitSpec.js");
+		var import_classPrivateFieldGet2_12 = __rolldown_runtime__.loadExports("\\0@oxc-project+runtime@0.112.0/helpers/classPrivateFieldGet2.js");
+		var _privateField = /* @__PURE__ */ new WeakMap();
+		class MyService {
+			constructor() {
+				import_defineProperty_10.default(this, "name", "service-updated");
+				import_classPrivateFieldInitSpec_11.default(this, _privateField, 99);
+			}
+			getValue() {
+				return import_classPrivateFieldGet2_12.default(_privateField, this);
+			}
+		}
+		function getValue() {
+			return new MyService().getValue();
+		}
+	} finally {}
+}));
+
+//#endregion
+init_main_0()
+__rolldown_runtime__.applyUpdates([['main.js', 'main.js']]);
+```
+
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: main.js, accepted_via: main.js

--- a/crates/rolldown/tests/rolldown/topics/hmr/oxc_helper_with_low_target/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/oxc_helper_with_low_target/main.js
@@ -1,0 +1,3 @@
+import { getValue } from './module_with_class_fields.js'
+console.log(getValue())
+import.meta.hot.accept(() => {})

--- a/crates/rolldown/tests/rolldown/topics/hmr/oxc_helper_with_low_target/module_with_class_fields.hmr-0.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/oxc_helper_with_low_target/module_with_class_fields.hmr-0.js
@@ -1,0 +1,10 @@
+class MyService {
+  name = 'service-updated';
+  #privateField = 99;
+  getValue() {
+    return this.#privateField;
+  }
+}
+export function getValue() {
+  return new MyService().getValue()
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/oxc_helper_with_low_target/module_with_class_fields.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/oxc_helper_with_low_target/module_with_class_fields.js
@@ -1,0 +1,10 @@
+class MyService {
+  name = 'service';
+  #privateField = 42;
+  getValue() {
+    return this.#privateField;
+  }
+}
+export function getValue() {
+  return new MyService().getValue()
+}

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
@@ -9,18 +9,12 @@ import {
 
 class Module {
   /**
-   * @type {{ exports: any }}
-   */
-  exportsHolder = { exports: null };
-  /**
-   * @type {string}
-   */
-  id;
-
-  /**
    * @param {string} id
    */
   constructor(id) {
+    /** @type {{ exports: any }} */
+    this.exportsHolder = { exports: null };
+    /** @type {string} */
     this.id = id;
   }
 
@@ -36,24 +30,84 @@ class Module {
 
 export class DevRuntime {
   /**
-   * Client ID generated at runtime initialization, used for lazy compilation requests.
-   * @type {string}
-   */
-  clientId;
-
-  /**
    * @param {Messenger} messenger
    * @param {string} clientId
    */
   constructor(messenger, clientId) {
     this.messenger = messenger;
+    /** @type {string} */
     this.clientId = clientId;
+    /** @type {Record<string, Module>} */
+    this.modules = {};
+
+    /**
+     * __esmMin
+     * @type {<T>(fn: any, res: T) => () => T}
+     * @internal
+     */
+    this.createEsmInitializer = (fn, res) => () => (fn && (res = fn((fn = 0))), res);
+    /**
+     * __commonJSMin
+     * @type {<T extends { exports: any }>(cb: any, mod: { exports: any }) => () => T}
+     * @internal
+     */
+    this.createCjsInitializer = (cb, mod) => () => (
+      mod || cb((mod = { exports: {} }).exports, mod), mod.exports
+    );
+    /** @internal */
+    this.__toESM = __toESM;
+    /** @internal */
+    this.__toCommonJS = __toCommonJS;
+    /** @internal */
+    this.__exportAll = __exportAll;
+    /**
+     * @param {boolean} [isNodeMode]
+     * @returns {(mod: any) => any}
+     * @internal
+     */
+    this.__toDynamicImportESM = (isNodeMode) => (mod) => __toESM(mod.default, isNodeMode);
+    /** @internal */
+    this.__reExport = __reExport;
+
+    this.sendModuleRegisteredMessage = (() => {
+      const cache = /** @type {string[]} */ ([]);
+      let timeout = /** @type {NodeJS.Timeout | null} */ (null);
+      let timeoutSetLength = 0;
+      const self = this;
+
+      /**
+       * @param {string} module
+       */
+      return function sendModuleRegisteredMessage(module) {
+        if (!self.messenger) {
+          return;
+        }
+        cache.push(module);
+        if (!timeout) {
+          timeout = setTimeout(
+            /** @returns void */
+            function flushCache() {
+              if (cache.length > timeoutSetLength) {
+                timeout = setTimeout(flushCache);
+                timeoutSetLength = cache.length;
+                return;
+              }
+
+              self.messenger.send({
+                type: 'hmr:module-registered',
+                modules: cache,
+              });
+              cache.length = 0;
+              timeout = null;
+              timeoutSetLength = 0;
+            },
+          );
+          timeoutSetLength = cache.length;
+        }
+      };
+    })();
   }
 
-  /**
-   * @type {Record<string, Module>}
-   */
-  modules = {};
   /**
    * @param {string} _moduleId
    */
@@ -88,73 +142,4 @@ export class DevRuntime {
       return {};
     }
   }
-
-  /**
-   * __esmMin
-   *
-   * @type {<T>(fn: any, res: T) => () => T}
-   * @internal
-   */
-  createEsmInitializer = (fn, res) => () => (fn && (res = fn((fn = 0))), res);
-  /**
-   * __commonJSMin
-   *
-   * @type {<T extends { exports: any }>(cb: any, mod: { exports: any }) => () => T}
-   * @internal
-   */
-  createCjsInitializer = (cb, mod) => () => (
-    mod || cb((mod = { exports: {} }).exports, mod), mod.exports
-  );
-  /** @internal */
-  __toESM = __toESM;
-  /** @internal */
-  __toCommonJS = __toCommonJS;
-  /** @internal */
-  __exportAll = __exportAll;
-  /**
-   * @param {boolean} [isNodeMode]
-   * @returns {(mod: any) => any}
-   * @internal
-   */
-  __toDynamicImportESM = (isNodeMode) => (mod) => __toESM(mod.default, isNodeMode);
-  /** @internal */
-  __reExport = __reExport;
-
-  sendModuleRegisteredMessage = (() => {
-    const cache = /** @type {string[]} */ ([]);
-    let timeout = /** @type {NodeJS.Timeout | null} */ (null);
-    let timeoutSetLength = 0;
-    const self = this;
-
-    /**
-     * @param {string} module
-     */
-    return function sendModuleRegisteredMessage(module) {
-      if (!self.messenger) {
-        return;
-      }
-      cache.push(module);
-      if (!timeout) {
-        timeout = setTimeout(
-          /** @returns void */
-          function flushCache() {
-            if (cache.length > timeoutSetLength) {
-              timeout = setTimeout(flushCache);
-              timeoutSetLength = cache.length;
-              return;
-            }
-
-            self.messenger.send({
-              type: 'hmr:module-registered',
-              modules: cache,
-            });
-            cache.length = 0;
-            timeout = null;
-            timeoutSetLength = 0;
-          },
-        );
-        timeoutSetLength = cache.length;
-      }
-    };
-  })();
 }

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
@@ -12,7 +12,7 @@ class ModuleHotContext {
    * @param {InstanceType<BaseDevRuntime>} devRuntime
    */
   constructor(moduleId, devRuntime) {
-    /** @type {{ deps: [string], fn: (moduleExports: Record<string, any>[]) => void }[]} */
+    /** @type {{ deps: string[], fn: (moduleExports: Record<string, any>) => void }[]} */
     this.acceptCallbacks = [];
     this.moduleId = moduleId;
     this.devRuntime = devRuntime;

--- a/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
+++ b/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-default.js
@@ -8,14 +8,12 @@ var BaseDevRuntime = DevRuntime;
 
 class ModuleHotContext {
   /**
-   * @type {{ deps: [string], fn: (moduleExports: Record<string, any>[]) => void }[]}
-   */
-  acceptCallbacks = [];
-  /**
    * @param {string} moduleId
    * @param {InstanceType<BaseDevRuntime>} devRuntime
    */
   constructor(moduleId, devRuntime) {
+    /** @type {{ deps: [string], fn: (moduleExports: Record<string, any>[]) => void }[]} */
+    this.acceptCallbacks = [];
     this.moduleId = moduleId;
     this.devRuntime = devRuntime;
   }
@@ -79,16 +77,12 @@ class DefaultDevRuntime extends BaseDevRuntime {
     };
 
     super(messenger, clientId);
-  }
 
-  /**
-   * @type {Map<string, ModuleHotContext>}
-   */
-  moduleHotContexts = new Map();
-  /**
-   * @type {Map<string, ModuleHotContext>}
-   */
-  moduleHotContextsToBeUpdated = new Map();
+    /** @type {Map<string, ModuleHotContext>} */
+    this.moduleHotContexts = new Map();
+    /** @type {Map<string, ModuleHotContext>} */
+    this.moduleHotContextsToBeUpdated = new Map();
+  }
   /**
    * @override
    * @param {string} moduleId

--- a/crates/rolldown_testing/src/hmr-runtime.js
+++ b/crates/rolldown_testing/src/hmr-runtime.js
@@ -7,15 +7,14 @@
 var BaseDevRuntime = DevRuntime;
 
 class TestHotContext {
-  moduleId;
-  /** @type {{ deps: string, cb: Function }[]} */
-  callbacks = [];
-
   /**
    * @param {string} moduleId
    */
   constructor(moduleId) {
+    /** @type {string} */
     this.moduleId = moduleId;
+    /** @type {{ deps: string, cb: Function }[]} */
+    this.callbacks = [];
   }
 
   /**
@@ -33,7 +32,14 @@ class TestHotContext {
 }
 
 class TestDevRuntime extends BaseDevRuntime {
-  contexts = new Map();
+  /**
+   * @param {...any} _args
+   */
+  constructor(..._args) {
+    super(..._args);
+    /** @type {Map<string, TestHotContext>} */
+    this.contexts = new Map();
+  }
 
   /**
    * @override

--- a/crates/rolldown_testing/src/hmr-runtime.js
+++ b/crates/rolldown_testing/src/hmr-runtime.js
@@ -13,7 +13,7 @@ class TestHotContext {
   constructor(moduleId) {
     /** @type {string} */
     this.moduleId = moduleId;
-    /** @type {{ deps: string, cb: Function }[]} */
+    /** @type {{ deps: string | string[], cb: (mod: any | any[]) => void }[]} */
     this.callbacks = [];
   }
 
@@ -33,10 +33,11 @@ class TestHotContext {
 
 class TestDevRuntime extends BaseDevRuntime {
   /**
-   * @param {...any} _args
+   * @param {any} messenger
+   * @param {string} clientId
    */
-  constructor(..._args) {
-    super(..._args);
+  constructor(messenger, clientId) {
+    super(messenger, clientId);
     /** @type {Map<string, TestHotContext>} */
     this.contexts = new Map();
   }


### PR DESCRIPTION
## Summary

Fixes https://github.com/rolldown/rolldown/issues/7863

When `transform.target` is set to es2020 or lower, class fields in the HMR runtime trigger OXC helper injection. These helpers become dependencies of `rolldown:hmr` and are placed before it in the bundle, causing `__rolldown_runtime__ is not defined` at runtime.

- Replace class fields with constructor-based initialization in `runtime-extra-dev-common.js`, `runtime-extra-dev-default.js`, and `hmr-runtime.js`
- Add `oxc_helper_with_low_target` integration test that reproduces the issue

## Test plan

- [x] `cargo test -p rolldown --test integration_rolldown -- topics__hmr` — all 25 HMR tests pass
- [x] Verified `ReferenceError: __rolldown_runtime__ is not defined` occurs without the fix
- [x] Verified the error is resolved with the fix