### PR TITLE
feat(mcs): support `entriesAware`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_ext.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_ext.rs
@@ -12,10 +12,25 @@ pub trait ChunkDebugExt {
   );
 }
 pub enum ChunkCreationReason<'a> {
-  ManualCodeSplittingGroup(&'a str, u32),
-  PreserveModules { is_user_defined_entry: bool, module_stable_id: &'a str },
-  Entry { is_user_defined_entry: bool, entry_module_id: &'a str, name: Option<&'a ArcStr> },
-  CommonChunk { bits: &'a BitSet, link_output: &'a LinkStageOutput },
+  ManualCodeSplittingGroup {
+    name: &'a str,
+    group_index: u32,
+    bits: Option<&'a BitSet>,
+    link_output: &'a LinkStageOutput,
+  },
+  PreserveModules {
+    is_user_defined_entry: bool,
+    module_stable_id: &'a str,
+  },
+  Entry {
+    is_user_defined_entry: bool,
+    entry_module_id: &'a str,
+    name: Option<&'a ArcStr>,
+  },
+  CommonChunk {
+    bits: &'a BitSet,
+    link_output: &'a LinkStageOutput,
+  },
 }
 
 impl ChunkDebugExt for Chunk {
@@ -25,7 +40,7 @@ impl ChunkDebugExt for Chunk {
     options: &NormalizedBundlerOptions,
   ) {
     match reason {
-      ChunkCreationReason::ManualCodeSplittingGroup(_name, group_index) => {
+      ChunkCreationReason::ManualCodeSplittingGroup { group_index, .. } => {
         *self.chunk_reason_type = ChunkReasonType::ManualCodeSplitting { group_index };
       }
       ChunkCreationReason::PreserveModules { .. } => {
@@ -44,8 +59,14 @@ impl ChunkDebugExt for Chunk {
     }
 
     let reason = match reason {
-      ChunkCreationReason::ManualCodeSplittingGroup(name, _group_index) => {
-        format!("ManualCodeSplitting: [Group-Name: {name}]")
+      ChunkCreationReason::ManualCodeSplittingGroup { name, bits, link_output, .. } => {
+        let entries_info = bits
+          .map(|bits| {
+            let entries = resolve_bits_to_entry_names(bits, link_output);
+            format!(" [Entries: {entries}]")
+          })
+          .unwrap_or_default();
+        format!("ManualCodeSplitting: [Group-Name: {name}]{entries_info}")
       }
       ChunkCreationReason::PreserveModules { is_user_defined_entry, module_stable_id } => {
         format!(
@@ -64,24 +85,28 @@ impl ChunkDebugExt for Chunk {
         }
       }
       ChunkCreationReason::CommonChunk { bits, link_output } => {
-        let entries = link_output
-          .entries
-          .iter()
-          .flat_map(|(idx, entries)| entries.iter().map(move |_| idx))
-          .enumerate()
-          .filter_map(|(index, &module_idx)| {
-            if bits.has_bit(index.try_into().unwrap()) {
-              let entry_module = &link_output.module_table[module_idx];
-              Some(entry_module.stable_id().to_string())
-            } else {
-              None
-            }
-          })
-          .join(", ");
+        let entries = resolve_bits_to_entry_names(bits, link_output);
         format!("Common Chunk: [Shared-By: {entries}]")
       }
     };
 
     self.debug_info.push(ChunkDebugInfo::CreateReason(reason));
   }
+}
+
+fn resolve_bits_to_entry_names(bits: &BitSet, link_output: &LinkStageOutput) -> String {
+  link_output
+    .entries
+    .iter()
+    .flat_map(|(idx, entries)| entries.iter().map(move |_| idx))
+    .enumerate()
+    .filter_map(|(index, &module_idx)| {
+      if bits.has_bit(index.try_into().unwrap()) {
+        let entry_module = &link_output.module_table[module_idx];
+        Some(entry_module.stable_id().to_string())
+      } else {
+        None
+      }
+    })
+    .join(", ")
 }

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/_config.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "Without entriesAware (default false), all matching modules merge into one chunk. Expected: 1 vendor chunk containing shared-by-abc + shared-by-ab + shared-by-a, loaded by all 3 entries even though entry-c only needs shared-by-abc.",
+  "config": {
+    "input": [
+      {
+        "name": "entry-a",
+        "import": "./entry-a.js"
+      },
+      {
+        "name": "entry-b",
+        "import": "./entry-b.js"
+      },
+      {
+        "name": "entry-c",
+        "import": "./entry-c.js"
+      }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "vendor",
+          "test": "shared-by"
+        }
+      ]
+    },
+    "experimental": {
+      "attachDebugInfo": "full"
+    }
+  },
+  "hiddenRuntimeModule": true
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/artifacts.snap
@@ -1,0 +1,46 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-a.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: Some("entry-a")]
+import "./vendor.js";
+
+```
+
+## entry-b.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: Some("entry-b")]
+import "./vendor.js";
+
+```
+
+## entry-c.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: Some("entry-c")]
+import "./vendor.js";
+
+```
+
+## vendor.js
+
+```js
+//! ManualCodeSplitting: [Group-Name: vendor]
+//#region shared-by-abc.js
+console.log("shared-by-abc");
+
+//#endregion
+//#region shared-by-ab.js
+console.log("shared-by-ab");
+
+//#endregion
+//#region shared-by-a.js
+console.log("shared-by-a");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/entry-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/entry-a.js
@@ -1,0 +1,3 @@
+import './shared-by-abc'
+import './shared-by-ab'
+import './shared-by-a'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/entry-b.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/entry-b.js
@@ -1,0 +1,2 @@
+import './shared-by-abc'
+import './shared-by-ab'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/entry-c.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/entry-c.js
@@ -1,0 +1,1 @@
+import './shared-by-abc'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/shared-by-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/shared-by-a.js
@@ -1,0 +1,1 @@
+console.log('shared-by-a')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/shared-by-ab.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/shared-by-ab.js
@@ -1,0 +1,1 @@
+console.log('shared-by-ab')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/shared-by-abc.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_false/shared-by-abc.js
@@ -1,0 +1,1 @@
+console.log('shared-by-abc')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/_config.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "With entriesAware: true + minShareCount: 2, modules are split by entry reachability and filtered by share count. Expected: formatDate (bits={A,B}, shared by 2) -> utils chunk for A+B, deepClone (bits={B,C}, shared by 2) -> separate utils chunk for B+C, debounce (bits={A}, shared by 1) -> does NOT meet minShareCount, stays inlined in entry-a.",
+  "config": {
+    "input": [
+      {
+        "name": "entry-a",
+        "import": "./entry-a.js"
+      },
+      {
+        "name": "entry-b",
+        "import": "./entry-b.js"
+      },
+      {
+        "name": "entry-c",
+        "import": "./entry-c.js"
+      }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "utils",
+          "test": "utils",
+          "minShareCount": 2,
+          "entriesAware": true
+        }
+      ]
+    },
+    "experimental": {
+      "attachDebugInfo": "full"
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/artifacts.snap
@@ -1,0 +1,53 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-a.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: Some("entry-a")]
+import "./utils.js";
+
+//#region utils/debounce.js
+console.log("debounce");
+
+//#endregion
+```
+
+## entry-b.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: Some("entry-b")]
+import "./utils.js";
+import "./utils2.js";
+
+```
+
+## entry-c.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: Some("entry-c")]
+import "./utils2.js";
+
+```
+
+## utils.js
+
+```js
+//! ManualCodeSplitting: [Group-Name: utils] [Entries: entry-a.js, entry-b.js]
+//#region utils/formatDate.js
+console.log("formatDate");
+
+//#endregion
+```
+
+## utils2.js
+
+```js
+//! ManualCodeSplitting: [Group-Name: utils] [Entries: entry-b.js, entry-c.js]
+//#region utils/deepClone.js
+console.log("deepClone");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/entry-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/entry-a.js
@@ -1,0 +1,2 @@
+import './utils/formatDate'
+import './utils/debounce'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/entry-b.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/entry-b.js
@@ -1,0 +1,2 @@
+import './utils/formatDate'
+import './utils/deepClone'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/entry-c.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/entry-c.js
@@ -1,0 +1,1 @@
+import './utils/deepClone'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/utils/debounce.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/utils/debounce.js
@@ -1,0 +1,1 @@
+console.log('debounce')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/utils/deepClone.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/utils/deepClone.js
@@ -1,0 +1,1 @@
+console.log('deepClone')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/utils/formatDate.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_min_share_count/utils/formatDate.js
@@ -1,0 +1,1 @@
+console.log('formatDate')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/_config.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "With entriesAware: true, modules are split by entry-point reachability. Expected: 3 vendor chunks — shared-by-abc (bits={A,B,C}) loaded by all, shared-by-ab (bits={A,B}) loaded by A+B only, shared-by-a (bits={A}) loaded by A only.",
+  "config": {
+    "input": [
+      {
+        "name": "entry-a",
+        "import": "./entry-a.js"
+      },
+      {
+        "name": "entry-b",
+        "import": "./entry-b.js"
+      },
+      {
+        "name": "entry-c",
+        "import": "./entry-c.js"
+      }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "vendor",
+          "test": "shared-by",
+          "entriesAware": true
+        }
+      ]
+    },
+    "experimental": {
+      "attachDebugInfo": "full"
+    }
+  },
+  "hiddenRuntimeModule": true
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/artifacts.snap
@@ -1,0 +1,61 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-a.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: Some("entry-a")]
+import "./vendor.js";
+import "./vendor2.js";
+import "./vendor3.js";
+
+```
+
+## entry-b.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: Some("entry-b")]
+import "./vendor.js";
+import "./vendor2.js";
+
+```
+
+## entry-c.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: Some("entry-c")]
+import "./vendor.js";
+
+```
+
+## vendor.js
+
+```js
+//! ManualCodeSplitting: [Group-Name: vendor] [Entries: entry-a.js, entry-b.js, entry-c.js]
+//#region shared-by-abc.js
+console.log("shared-by-abc");
+
+//#endregion
+```
+
+## vendor2.js
+
+```js
+//! ManualCodeSplitting: [Group-Name: vendor] [Entries: entry-a.js, entry-b.js]
+//#region shared-by-ab.js
+console.log("shared-by-ab");
+
+//#endregion
+```
+
+## vendor3.js
+
+```js
+//! ManualCodeSplitting: [Group-Name: vendor] [Entries: entry-a.js]
+//#region shared-by-a.js
+console.log("shared-by-a");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/entry-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/entry-a.js
@@ -1,0 +1,3 @@
+import './shared-by-abc'
+import './shared-by-ab'
+import './shared-by-a'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/entry-b.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/entry-b.js
@@ -1,0 +1,2 @@
+import './shared-by-abc'
+import './shared-by-ab'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/entry-c.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/entry-c.js
@@ -1,0 +1,1 @@
+import './shared-by-abc'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/shared-by-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/shared-by-a.js
@@ -1,0 +1,1 @@
+console.log('shared-by-a')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/shared-by-ab.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/shared-by-ab.js
@@ -1,0 +1,1 @@
+console.log('shared-by-ab')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/shared-by-abc.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_true/shared-by-abc.js
@@ -1,0 +1,1 @@
+console.log('shared-by-abc')

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3920,6 +3920,30 @@ expression: output
 - other-!~{001}~.js => other-B3P9919W.js
 - shared-!~{002}~.js => shared-CFIfvxkD.js
 
+# tests/rolldown/function/advanced_chunks/entries_aware_false
+
+- entry-a-!~{000}~.js => entry-a-DAoBvWkD.js
+- entry-b-!~{001}~.js => entry-b-msWKko7E.js
+- entry-c-!~{002}~.js => entry-c-Bg5GIhoe.js
+- vendor-!~{003}~.js => vendor-stCDKbV-.js
+
+# tests/rolldown/function/advanced_chunks/entries_aware_min_share_count
+
+- entry-a-!~{000}~.js => entry-a-BuB0R6K1.js
+- entry-b-!~{001}~.js => entry-b-K_U200iY.js
+- entry-c-!~{002}~.js => entry-c-aGNiz1tQ.js
+- utils-!~{003}~.js => utils-BHkG74Os.js
+- utils-!~{005}~.js => utils-BhoauC96.js
+
+# tests/rolldown/function/advanced_chunks/entries_aware_true
+
+- entry-a-!~{000}~.js => entry-a-DnZjnQcX.js
+- entry-b-!~{001}~.js => entry-b-D57VDdfN.js
+- entry-c-!~{002}~.js => entry-c-ifTLlP1t.js
+- vendor-!~{007}~.js => vendor-C-UBb0Ro.js
+- vendor-!~{005}~.js => vendor-CvTFbgzK.js
+- vendor-!~{003}~.js => vendor-r_yNgesz.js
+
 # tests/rolldown/function/advanced_chunks/include_dependencies_recursively
 
 - main-!~{000}~.js => main-Cu3PnZ1_.js

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
@@ -38,6 +38,7 @@ pub struct BindingMatchGroup {
   pub min_module_size: Option<f64>,
   pub max_module_size: Option<f64>,
   pub max_size: Option<f64>,
+  pub entries_aware: Option<bool>,
 }
 
 #[napi_derive::napi]

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -460,6 +460,7 @@ pub fn normalize_binding_options(
             max_module_size: item.max_module_size,
             min_module_size: item.min_module_size,
             max_size: item.max_size,
+            entries_aware: item.entries_aware,
           })
           .collect::<Vec<_>>()
       }),

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -51,6 +51,7 @@ pub struct MatchGroup {
   pub min_share_count: Option<u32>,
   pub min_module_size: Option<f64>,
   pub max_module_size: Option<f64>,
+  pub entries_aware: Option<bool>,
 }
 
 type MatchGroupTestFn = dyn Fn(&str) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<bool>>> + Send + 'static>>

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1284,6 +1284,12 @@
             "null"
           ],
           "format": "double"
+        },
+        "entriesAware": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false,

--- a/crates/rolldown_utils/src/bitset.rs
+++ b/crates/rolldown_utils/src/bitset.rs
@@ -27,6 +27,7 @@ impl BitSet {
       self.entries[i] |= e;
     }
   }
+
   // It is safe to convert `usize` to `u32` here because we ensure that the bitset is created with a maximum bit count that fits within `u32`.
   #[expect(clippy::cast_possible_truncation)]
   pub fn index_of_one(&self) -> Vec<u32> {

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2285,6 +2285,7 @@ export interface BindingMatchGroup {
   minModuleSize?: number
   maxModuleSize?: number
   maxSize?: number
+  entriesAware?: boolean
 }
 
 export interface BindingModulePreloadOptions {

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -847,6 +847,26 @@ export type CodeSplittingGroup = {
    * @default 0
    */
   minModuleSize?: number;
+  /**
+   * When `false` (default), all matching modules are merged into a single chunk.
+   * Every entry that uses any of these modules must load the entire chunk — even
+   * modules it doesn't need.
+   *
+   * When `true`, matching modules are grouped by which entries actually import them.
+   * Modules shared by the same set of entries go into the same chunk, while modules
+   * shared by a different set go into a separate chunk. This way, each entry only
+   * loads the code it actually uses.
+   *
+   * Example: entries A, B, C all match a `"vendor"` group.
+   * - `moduleX` is used by A, B, C
+   * - `moduleY` is used by A, B only
+   *
+   * With `entriesAware: false` → one `vendor.js` chunk with both modules; C loads `moduleY` unnecessarily.
+   * With `entriesAware: true`  → `vendor.js` (moduleX, loaded by all) + `vendor2.js` (moduleY, loaded by A and B only).
+   *
+   * @default false
+   */
+  entriesAware?: boolean;
 };
 
 /**

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -764,6 +764,7 @@ const AdvancedChunksSchema = v.strictObject({
         maxSize: v.optional(v.number()),
         minModuleSize: v.optional(v.number()),
         maxModuleSize: v.optional(v.number()),
+        entriesAware: v.optional(v.boolean()),
       }),
     ),
   ),


### PR DESCRIPTION
- Fixes #7117 in a rolldown-style, which means considering the fact that rolldown enforcing esm and singleton.
- MCS -> Manual Code Splitting

---

## What `entriesAware` does

**Without `entriesAware` (default `false`):**
All modules matching a group are merged into one chunk. Every entry that imports any of these modules must load the entire chunk — even modules it doesn't need.

**With `entriesAware: true`:**
Modules are sub-grouped by their entry-point reachability (which entries can reach them). Modules shared by the **same set** of entries go into the same chunk; modules shared by a **different set** go into a separate chunk.

## Concrete example

Three entries: `entry-a`, `entry-b`, `entry-c`. One group: `{ name: "vendor", test: "shared-by", entriesAware: true }`.

Modules:
- `shared-by-abc` — imported by A, B, C
- `shared-by-ab` — imported by A, B only
- `shared-by-a` — imported by A only

**`entriesAware: false`** → 1 chunk:
- `vendor.js` contains all three modules. All three entries import `vendor.js`, so entry-c loads `shared-by-ab` and `shared-by-a` unnecessarily.

**`entriesAware: true`** → 3 chunks:
- `vendor.js` (`shared-by-abc`, reachable by A+B+C) — loaded by all entries
- `vendor2.js` (`shared-by-ab`, reachable by A+B) — loaded by entry-a and entry-b only
- `vendor3.js` (`shared-by-a`, reachable by A) — loaded by entry-a only

Each entry only loads exactly the code it needs.

## Interaction with `maxSize`

`maxSize` splitting happens **after** `entriesAware` grouping. The pipeline is:

1. **Group** modules by match pattern + (if `entriesAware`) entry-reachability bits
2. **Filter** groups by `minSize` / `minShareCount`
3. **Split** any group exceeding `maxSize` into smaller sub-chunks using a two-pointer greedy algorithm (sorted by module size, split so both halves satisfy `minSize`)
4. **Create** final chunks

So with `entriesAware: true`, `maxSize` applies to each reachability-based sub-group independently. A group that was already split by entry reachability may be further split if it still exceeds `maxSize`.

## Interaction with `minShareCount`

When combined with `entriesAware: true`, `minShareCount` filters based on how many entries reach each individual module. Example from tests:
- Group `{ name: "utils", test: "utils", minShareCount: 2, entriesAware: true }`
- `formatDate` (shared by A, B → count=2) → goes into `utils.js`
- `deepClone` (shared by B, C → count=2) → goes into `utils2.js` (different reachability set)
- `debounce` (only used by A → count=1) → **not captured** by the group, stays inlined in entry-a