### PR TITLE
feat(mcs): `maxSize` will split the oversized chunk with taking file relevance into account

### DIFF
--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size/_config.json
@@ -6,7 +6,7 @@
           // `size-15.js`, `size-20` and `size-41.js` will be captured
           "test": "size-.*\\.js",
           "name": "40max-size",
-          // `size-15.js` and `size-20.js` will be grouped into one chunk (35 <= 40), and `size-41.js` into another, because adding `size-41.js` would exceed `maxSize`.
+          // `size-15.js` and `size-20.js` will be grouped into one chunk, and `size-41.js` into another, because the similarity difference is insignificant so size-based tiebreaking picks the better distribution.
           "maxSize": 40
         }
       ]

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/_config.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          // Real-world style vendor splitting:
+          // react/* should stay together and date-fns/* should stay together.
+          "test": "node_modules[\\\\/].*\\.js",
+          "name": "vendor-similarity",
+          "maxSize": 80
+        }
+      ]
+    },
+    "experimental": {
+      "attachDebugInfo": "full"
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/artifacts.snap
@@ -1,0 +1,45 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: main.js] [Name: Some("main")]
+import "./vendor-similarity.js";
+import "./vendor-similarity2.js";
+
+//#region src/app-shell.js
+console.log("app shell");
+
+//#endregion
+```
+
+## vendor-similarity.js
+
+```js
+//! ManualCodeSplitting: [Group-Name: vendor-similarity]
+//#region node_modules/date-fns/format.js
+console.log("date-fns/format");
+
+//#endregion
+//#region node_modules/date-fns/parseISO.js
+console.log("date-fns/parseISO");
+
+//#endregion
+```
+
+## vendor-similarity2.js
+
+```js
+//! ManualCodeSplitting: [Group-Name: vendor-similarity]
+//#region node_modules/react/index.js
+console.log("react/index");
+
+//#endregion
+//#region node_modules/react/jsx-runtime.js
+console.log("react/jsx-runtime");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/main.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/main.js
@@ -1,0 +1,5 @@
+import "./src/app-shell";
+import "./node_modules/date-fns/format";
+import "./node_modules/date-fns/parseISO";
+import "./node_modules/react/index";
+import "./node_modules/react/jsx-runtime";

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/node_modules/date-fns/format.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/node_modules/date-fns/format.js
@@ -1,0 +1,1 @@
+console.log("date-fns/format");

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/node_modules/date-fns/parseISO.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/node_modules/date-fns/parseISO.js
@@ -1,0 +1,1 @@
+console.log("date-fns/parseISO");

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/node_modules/react/index.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/node_modules/react/index.js
@@ -1,0 +1,1 @@
+console.log("react/index");

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/node_modules/react/jsx-runtime.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/node_modules/react/jsx-runtime.js
@@ -1,0 +1,1 @@
+console.log("react/jsx-runtime");

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/src/app-shell.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/similarity_max_size/src/app-shell.js
@@ -1,0 +1,1 @@
+console.log("app shell");

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4018,6 +4018,12 @@ expression: output
 - main-!~{000}~.js => main-D94g3AZq.js
 - common_b-!~{001}~.js => common_b-C19ByyLz.js
 
+# tests/rolldown/function/advanced_chunks/similarity_max_size
+
+- main-!~{000}~.js => main-Iby7IDO-.js
+- vendor-similarity-!~{003}~.js => vendor-similarity-Dr0g2X-x.js
+- vendor-similarity-!~{001}~.js => vendor-similarity-cN77Fijl.js
+
 # tests/rolldown/function/advanced_chunks/split_node_modules
 
 - main-!~{000}~.js => main-Cds2SNwN.js


### PR DESCRIPTION
## Summary

When a manual chunk splitting (MCS) group exceeds `maxSize`, the old greedy loop split at the first position where the left half met `minSize`. This was **position-dependent and unaware of file relevance** — related files (e.g. all of `date-fns/format*`) could be torn apart simply because they happened to straddle the size boundary.

This PR replaces that logic with a **similarity-based split point selection** algorithm.

## How it works

### 1. Sort by `stable_id`, then pick the best split point

Modules in the oversized group are sorted lexicographically by `stable_id` (file path). The algorithm then scans every candidate split index that satisfies `minSize` on both sides, and scores the boundary between `modules[i-1]` and `modules[i]` using `stable_id_similarity`.

### 2. `stable_id_similarity` — character-level path similarity

```rust
fn stable_id_similarity(lhs: &str, rhs: &str) -> i32 {
  lhs.as_bytes().iter().zip(rhs.as_bytes()).fold(0, |acc, (lhs_char, rhs_char)| {
    acc + (10 - (i32::from(*lhs_char) - i32::from(*rhs_char)).abs()).max(0)
  })
}
```

Each aligned byte pair contributes 0–10 points (10 = identical). Paths sharing a long common prefix (same directory) accumulate a high score; paths diverging early score low. **Lower similarity = better split point** (the boundary between unrelated files).

### 3. Noise reduction: `SIMILARITY_SIGNIFICANCE_THRESHOLD` (= 10)

Digit-level ASCII differences (e.g. `util1.js` vs `util2.js`) produce tiny similarity fluctuations. The threshold of 10 (one character position's max score) absorbs this noise: two candidates whose similarity differs by ≤ 10 are treated as a **tie**, and the tie-breaker criteria decide instead.

### 4. 3-tier comparison for picking the best split

```
if |best_similarity − similarity| > THRESHOLD  →  prefer lower similarity
else if oversized_side_count differs            →  prefer fewer oversized halves
else                                            →  prefer smaller max_side_size
```

- **Tier 1 — Similarity**: Split between the least-related files (e.g. between `react/*` and `date-fns/*`).
- **Tier 2 — Oversized side count**: Among ties, prefer a split that keeps both halves under `maxSize`.
- **Tier 3 — Max side size**: Among remaining ties, prefer the most balanced split.

### 5. Recursive splitting

If either half is still oversized, it re-enters the same loop and splits again — so the algorithm naturally recurses until all chunks satisfy `maxSize` (or no valid split exists).

## Example

Given modules sorted by `stable_id`:
```
date-fns/addDays.js
date-fns/format.js
date-fns/parse.js       ← high similarity across these
react/Component.js
react/hooks.js           ← high similarity across these
lodash/merge.js
```

The algorithm picks the boundary with the **lowest** similarity (e.g. between `date-fns/parse.js` and `react/Component.js`, or between `react/hooks.js` and `lodash/merge.js`), keeping related library files together in the same chunk.