### PR TITLE
ci(docs): don't skip for build runs without cache

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 # only build on netlify if there are any change in docs
-# COMMIT_REF and CACHED_COMMIT_REF are the same for builds runs without cache
+# COMMIT_REF and CACHED_COMMIT_REF are the same for build runs without cache
 ignore = "if [ \"${COMMIT_REF}\" = \"${CACHED_COMMIT_REF}\" ] ; then false ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown ; fi"
 
 [[redirects]]

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 # only build on netlify if there are any change in docs
 # COMMIT_REF and CACHED_COMMIT_REF are the same for builds runs without cache
-ignore = "if [ \"${COMMIT_REF}\" == \"${CACHED_COMMIT_REF}\" ] ; then false ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown ; fi"
+ignore = "if [ \"${COMMIT_REF}\" = \"${CACHED_COMMIT_REF}\" ] ; then false ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown ; fi"
 
 [[redirects]]
 from = "/about/"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,6 +1,7 @@
 [build]
 # only build on netlify if there are any change in docs
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown"
+# COMMIT_REF and CACHED_COMMIT_REF are the same for builds runs without cache
+ignore = "if [ \"${COMMIT_REF}\" == \"${CACHED_COMMIT_REF}\" ] ; then false ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs ./packages/rolldown ; fi"
 
 [[redirects]]
 from = "/about/"


### PR DESCRIPTION
The production builds were skipped even if there's a change: https://app.netlify.com/projects/rolldown-rs/deploys/698c77ebc8dd2500085697f1

I tried to fix this in #8206 but that one didn't seem to fix it. Maybe this is caused by `CACHED_COMMIT_REF` and `COMMIT_REF` having the same value like https://answers.netlify.com/t/cached-commit-ref-eqals-commit-ref/81697. This PR changes the ignore command to trigger the build if those are the same value.


