### PR TITLE
refactor: simplify PostChunkOptimizationOperation from bitflags to enum

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -915,14 +915,14 @@ impl GenerateStage<'_> {
         continue;
       };
 
-      chunk_graph.post_chunk_optimization_operations.insert(*from_chunk_idx, {
-        let mut meta = PostChunkOptimizationOperation::Removed;
-        meta.set(
-          PostChunkOptimizationOperation::PreserveExports,
-          chunk_meta.contains(ChunkMeta::EmittedChunk),
-        );
-        meta
-      });
+      chunk_graph.post_chunk_optimization_operations.insert(
+        *from_chunk_idx,
+        if chunk_meta.contains(ChunkMeta::EmittedChunk) {
+          PostChunkOptimizationOperation::RemovedWithPreservedExports
+        } else {
+          PostChunkOptimizationOperation::Removed
+        },
+      );
 
       // Track emitted chunks so their export names are preserved (not minified)
       if chunk_meta.contains(ChunkMeta::EmittedChunk) {

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -5,8 +5,8 @@ use oxc::span::CompactStr;
 use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
   Asset, ChunkIdx, ConcatenateWrappedModuleKind, EmittedChunkInfo, InstantiationKind,
-  ModuleRenderArgs, ModuleRenderOutput, Output, OutputAsset, OutputChunk,
-  PostChunkOptimizationOperation, SharedFileEmitter, SymbolRef,
+  ModuleRenderArgs, ModuleRenderOutput, Output, OutputAsset, OutputChunk, SharedFileEmitter,
+  SymbolRef,
 };
 use rolldown_devtools::{action, trace_action, trace_action_enabled};
 use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, BuildResult};
@@ -181,12 +181,7 @@ impl GenerateStage<'_> {
         .filter_map(|(idx, module_id_to_codegen_ret)| {
           let chunk_idx =
             ChunkIdx::from_raw(u32::try_from(idx).expect("chunk index should fit in u32"));
-          if chunk_graph
-            .post_chunk_optimization_operations
-            .get(&chunk_idx)
-            .map(|flag| flag.contains(PostChunkOptimizationOperation::Removed))
-            .unwrap_or(false)
-          {
+          if chunk_graph.post_chunk_optimization_operations.contains_key(&chunk_idx) {
             return None;
           }
           let chunk = chunk_graph.chunk_table.get(chunk_idx)?;

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -43,19 +43,18 @@ bitflags::bitflags! {
     }
 }
 
-bitflags::bitflags! {
-  /// Tracks post-optimization operations applied to chunks during code splitting.
-  #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-    pub struct PostChunkOptimizationOperation: u8 {
-        /// The chunk has been removed and merged into another chunk.
-        /// e.g., a dynamic chunk merged into a common chunk or user-defined entry chunk.
-        const Removed = 1;
-        /// The chunk's exports should be preserved in the target chunk.
-        /// e.g., an emitted chunk with `preserveEntrySignatures: 'allow-extension'` merged into
-        /// a manual chunks group - all exports should be preserved even though the original
-        /// emitted chunk is removed.
-        const PreserveExports = 1 << 1;
-    }
+/// Tracks post-optimization operations applied to chunks during code splitting.
+/// A chunk present in the map has been removed and merged into another chunk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PostChunkOptimizationOperation {
+  /// The chunk has been removed and merged into another chunk.
+  /// e.g., a dynamic chunk merged into a common chunk or user-defined entry chunk.
+  Removed,
+  /// The chunk has been removed, but its exports should be preserved in the target chunk.
+  /// e.g., an emitted chunk with `preserveEntrySignatures: 'allow-extension'` merged into
+  /// a manual chunks group - all exports should be preserved even though the original
+  /// emitted chunk is removed.
+  RemovedWithPreservedExports,
 }
 
 impl ChunkMeta {


### PR DESCRIPTION
The `remove` is always set, so use `Enum` instead of bitflags