### PR TITLE
fix(mcs): `maxSize` should split chunks correctly based on sizes

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -270,15 +270,15 @@ impl GenerateStage<'_> {
           } else {
             // TODO: Though, [0..next_left_index] is a valid group, we want to find a best split index that makes files in left group are in the same disk location.
             let mut split_size = left_size;
-            loop {
-              if next_left_index <= next_right_index && split_size < allow_max_size {
-                split_size += self.link_output.module_table.modules
-                  [modules[next_left_index as usize]]
-                  .size() as f64;
-                next_left_index += 1;
-              } else {
+            while next_left_index <= next_right_index {
+              let next_size = self.link_output.module_table.modules
+                [modules[next_left_index as usize]]
+                .size() as f64;
+              if split_size > 0.0 && split_size + next_size > allow_max_size {
                 break;
               }
+              split_size += next_size;
+              next_left_index += 1;
             }
             while next_left_index <= next_right_index && next_right_index >= 0 {
               right_size += self.link_output.module_table.modules

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size/_config.json
@@ -6,7 +6,7 @@
           // `size-15.js`, `size-20` and `size-41.js` will be captured
           "test": "size-.*\\.js",
           "name": "40max-size",
-          // `size-15.js` and `size-20.js` will be split into a chunk. And `size-41.js` will be split into another chunk because it's bigger than 40.
+          // `size-15.js` and `size-20.js` will be grouped into one chunk (35 <= 40), and `size-41.js` into another, because adding `size-41.js` would exceed `maxSize`.
           "maxSize": 40
         }
       ]

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size/_test.mjs
@@ -1,0 +1,19 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import assert from 'node:assert'
+
+const dist = path.join(import.meta.dirname, 'dist')
+const files = fs.readdirSync(dist).filter(f => f !== 'package.json').sort()
+
+// maxSize=40 should split into two chunks: [size-15 + size-20] and [size-41]
+assert.deepStrictEqual(files, ['40max-size.js', '40max-size2.js', 'main.js'])
+
+const chunk1 = fs.readFileSync(path.join(dist, '40max-size.js'), 'utf-8')
+assert.ok(chunk1.includes('size-15.js'), 'chunk1 should contain size-15')
+assert.ok(chunk1.includes('size-20.js'), 'chunk1 should contain size-20')
+assert.ok(!chunk1.includes('size-41.js'), 'chunk1 should not contain size-41')
+
+const chunk2 = fs.readFileSync(path.join(dist, '40max-size2.js'), 'utf-8')
+assert.ok(chunk2.includes('size-41.js'), 'chunk2 should contain size-41')
+assert.ok(!chunk2.includes('size-15.js'), 'chunk2 should not contain size-15')
+assert.ok(!chunk2.includes('size-20.js'), 'chunk2 should not contain size-20')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size/artifacts.snap
@@ -14,6 +14,11 @@ console.log(10);
 console.log(1e6);
 
 //#endregion
+```
+
+## 40max-size2.js
+
+```js
 //#region size-41.js
 console.log(1e6);
 console.log(1e6);
@@ -25,5 +30,6 @@ console.log(1e6);
 
 ```js
 import "./40max-size.js";
+import "./40max-size2.js";
 
 ```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size2/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size2/_test.mjs
@@ -1,0 +1,18 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import assert from 'node:assert'
+
+const dist = path.join(import.meta.dirname, 'dist')
+const files = fs.readdirSync(dist).filter(f => f !== 'package.json').sort()
+
+// maxSize=14 is smaller than every module, so each file becomes its own chunk
+assert.deepStrictEqual(files, ['14max-size.js', '14max-size2.js', '14max-size3.js', 'main.js'])
+
+const chunk1 = fs.readFileSync(path.join(dist, '14max-size.js'), 'utf-8')
+assert.ok(chunk1.includes('size-15.js'), 'chunk1 should contain size-15')
+
+const chunk2 = fs.readFileSync(path.join(dist, '14max-size2.js'), 'utf-8')
+assert.ok(chunk2.includes('size-20.js'), 'chunk2 should contain size-20')
+
+const chunk3 = fs.readFileSync(path.join(dist, '14max-size3.js'), 'utf-8')
+assert.ok(chunk3.includes('size-41.js'), 'chunk3 should contain size-41')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size3/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size3/_test.mjs
@@ -1,0 +1,19 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import assert from 'node:assert'
+
+const dist = path.join(import.meta.dirname, 'dist')
+const files = fs.readdirSync(dist).filter(f => f !== 'package.json').sort()
+
+// maxSize=42 should split into two chunks: [size-15 + size-20] and [size-41]
+assert.deepStrictEqual(files, ['42max-size.js', '42max-size2.js', 'main.js'])
+
+const chunk1 = fs.readFileSync(path.join(dist, '42max-size.js'), 'utf-8')
+assert.ok(chunk1.includes('size-15.js'), 'chunk1 should contain size-15')
+assert.ok(chunk1.includes('size-20.js'), 'chunk1 should contain size-20')
+assert.ok(!chunk1.includes('size-41.js'), 'chunk1 should not contain size-41')
+
+const chunk2 = fs.readFileSync(path.join(dist, '42max-size2.js'), 'utf-8')
+assert.ok(chunk2.includes('size-41.js'), 'chunk2 should contain size-41')
+assert.ok(!chunk2.includes('size-15.js'), 'chunk2 should not contain size-15')
+assert.ok(!chunk2.includes('size-20.js'), 'chunk2 should not contain size-20')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size3/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/max_size3/artifacts.snap
@@ -14,6 +14,11 @@ console.log(10);
 console.log(1e6);
 
 //#endregion
+```
+
+## 42max-size2.js
+
+```js
 //#region size-41.js
 console.log(1e6);
 console.log(1e6);
@@ -25,5 +30,6 @@ console.log(1e6);
 
 ```js
 import "./42max-size.js";
+import "./42max-size2.js";
 
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3967,8 +3967,9 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/max_size
 
-- main-!~{000}~.js => main-CtCvKpFG.js
-- 40max-size-!~{001}~.js => 40max-size-DW0VEBit.js
+- main-!~{000}~.js => main-DcX7aCDC.js
+- 40max-size-!~{001}~.js => 40max-size-CU-Uxq5V.js
+- 40max-size-!~{003}~.js => 40max-size-DM3xDrIe.js
 
 # tests/rolldown/function/advanced_chunks/max_size2
 
@@ -3979,8 +3980,9 @@ expression: output
 
 # tests/rolldown/function/advanced_chunks/max_size3
 
-- main-!~{000}~.js => main-Bl-mjDB_.js
-- 42max-size-!~{001}~.js => 42max-size-CyNLMSnx.js
+- main-!~{000}~.js => main-CNQ1zr8K.js
+- 42max-size-!~{003}~.js => 42max-size-BTwrW0Un.js
+- 42max-size-!~{001}~.js => 42max-size-Bal5MwKW.js
 
 # tests/rolldown/function/advanced_chunks/min_module_size
 


### PR DESCRIPTION
A prior fix for issues found in https://github.com/rolldown/rolldown/pull/8277#discussion_r2796470251.