### PR TITLE
refactor: remove `warnings` field from `GenerateContext`

### DIFF
--- a/crates/rolldown/src/asset/asset_generator.rs
+++ b/crates/rolldown/src/asset/asset_generator.rs
@@ -37,9 +37,6 @@ impl Generator for AssetGenerator {
       });
     }
 
-    Ok(Ok(GenerateOutput {
-      chunks: instantiated_chunks,
-      warnings: std::mem::take(&mut ctx.warnings),
-    }))
+    Ok(Ok(GenerateOutput { chunks: instantiated_chunks, warnings: vec![] }))
   }
 }

--- a/crates/rolldown/src/css/css_generator.rs
+++ b/crates/rolldown/src/css/css_generator.rs
@@ -19,10 +19,7 @@ impl Generator for CssGenerator {
       .collect::<Vec<_>>();
 
     if ordered_css_modules.is_empty() {
-      return Ok(Ok(GenerateOutput {
-        chunks: vec![],
-        warnings: std::mem::take(&mut ctx.warnings),
-      }));
+      return Ok(Ok(GenerateOutput::default()));
     }
 
     ordered_css_modules.sort_by_key(|m| m.exec_order);
@@ -99,7 +96,7 @@ impl Generator for CssGenerator {
         post_banner: None,
         post_footer: None,
       }],
-      warnings: std::mem::take(&mut ctx.warnings),
+      warnings: vec![],
     }))
   }
 }

--- a/crates/rolldown/src/ecmascript/ecma_generator.rs
+++ b/crates/rolldown/src/ecmascript/ecma_generator.rs
@@ -200,8 +200,6 @@ impl Generator for EcmaGenerator {
       }
     };
 
-    ctx.warnings.extend(warnings);
-
     if ctx.options.experimental.is_attach_debug_info_full() && !ctx.chunk.debug_info.is_empty() {
       let debug_info_str =
         ctx.chunk.debug_info.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n//! ");
@@ -250,7 +248,7 @@ impl Generator for EcmaGenerator {
         post_banner,
         post_footer,
       }],
-      warnings: std::mem::take(&mut ctx.warnings),
+      warnings,
     }))
   }
 }

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -560,7 +560,6 @@ impl<'a> GenerateStage<'a> {
           link_output: self.link_output,
           chunk_graph,
           plugin_driver: self.plugin_driver,
-          warnings: Vec::new(),
           module_id_to_codegen_ret: Vec::new(),
           render_export_items_index_vec: &IndexVec::default(),
           chunk_idx,

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -196,7 +196,6 @@ impl GenerateStage<'_> {
               link_output: self.link_output,
               chunk_graph,
               plugin_driver: self.plugin_driver,
-              warnings: vec![],
               module_id_to_codegen_ret,
               render_export_items_index_vec,
             };
@@ -212,7 +211,6 @@ impl GenerateStage<'_> {
               link_output: self.link_output,
               chunk_graph,
               plugin_driver: self.plugin_driver,
-              warnings: vec![],
               module_id_to_codegen_ret: vec![],
               render_export_items_index_vec: &index_vec![],
             };
@@ -228,7 +226,6 @@ impl GenerateStage<'_> {
               link_output: self.link_output,
               chunk_graph,
               plugin_driver: self.plugin_driver,
-              warnings: vec![],
               module_id_to_codegen_ret: vec![],
               render_export_items_index_vec: &index_vec![],
             };

--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -18,7 +18,6 @@ pub struct GenerateContext<'a> {
   pub link_output: &'a LinkStageOutput,
   pub chunk_graph: &'a ChunkGraph,
   pub plugin_driver: &'a SharedPluginDriver,
-  pub warnings: Vec<BuildDiagnostic>,
   pub module_id_to_codegen_ret: Vec<Option<ModuleRenderOutput>>,
   /// The key of the map is exported item symbol,
   /// the value of the map is optional alias. e.g.
@@ -109,6 +108,7 @@ impl GenerateContext<'_> {
   }
 }
 
+#[derive(Default)]
 pub struct GenerateOutput {
   pub chunks: Vec<InstantiatedChunk>,
   pub warnings: Vec<BuildDiagnostic>,


### PR DESCRIPTION
 The `warnings` field was always initialized as an empty `Vec` at every call site and served no purpose other than acting as a temporary intermediary. Remove it and have each generator return warnings directly in `GenerateOutput` instead.