### PR TITLE
refactor: move ESM format check into `determine_export_mode`

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -105,7 +105,7 @@ impl<'a> GenerateStage<'a> {
 
     let mut warnings = vec![];
     self.compute_chunk_output_exports(&mut chunk_graph, &mut warnings)?;
-    if !self.options.format.is_esm() {
+    if !warnings.is_empty() {
       self.link_output.warnings.extend(warnings);
     }
 

--- a/crates/rolldown/src/utils/chunk/determine_export_mode.rs
+++ b/crates/rolldown/src/utils/chunk/determine_export_mode.rs
@@ -46,14 +46,18 @@ pub fn determine_export_mode(
       } else if export_names.len() == 1 && export_names[0].as_str() == "default" {
         Ok(OutputExports::Default)
       } else {
-        let has_default_export = export_names.iter().any(|name| name.as_str() == "default");
-        if has_default_export {
-          let name =
-            ctx.options.name.as_deref().map(ArcStr::from).unwrap_or_else(|| ArcStr::from("chunk"));
+        if !ctx.options.format.is_esm()
+          && export_names.iter().any(|name| name.as_str() == "default")
+        {
           warnings.push(
             BuildDiagnostic::mixed_export(
               module.id.to_string(),
-              name,
+              ctx
+                .options
+                .name
+                .as_deref()
+                .map(ArcStr::from)
+                .unwrap_or_else(|| ArcStr::from("chunk")),
               module.stable_id.to_string(),
               export_names.iter().map(|name| name.as_str().into()).collect(),
             )


### PR DESCRIPTION
 The `!format.is_esm()` guard was at the warning collection site, silently discarding warnings generated for ESM. Move the check into `determine_export_mode` so the mixed export warning is only created for non-ESM formats in the first place.