### PR TITLE
feat(rolldown_plugin_chunk_import_map): output importmap without spaces

### DIFF
--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -126,10 +126,8 @@ impl Plugin for ChunkImportMapPlugin {
         file_name: Some(
           self.file_name.as_ref().map_or(arcstr::literal!("importmap.json"), ArcStr::from),
         ),
-        source: (serde_json::to_string_pretty(
-          &serde_json::json!({ "imports": chunk_import_map }),
-        )?)
-        .into(),
+        source: (serde_json::to_string(&serde_json::json!({ "imports": chunk_import_map }))?)
+          .into(),
         ..Default::default()
       })
       .await?;


### PR DESCRIPTION
In production, you won't need spaces in the importmap. I didn't add an option as I didn't find a case where you want to generate a formatted one (for debugging, I think formatting manually would suffice).