### PR TITLE
fix: mark Node.js builtin modules as side-effect-free when resolved via `external` config

### DIFF
--- a/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/format_cjs_with_esm_require_esm/artifacts.snap
@@ -32,7 +32,6 @@ Object.defineProperty(exports, '__toESM', {
 
 ```js
 const require_chunk = require('./chunk.js');
-require("node:assert");
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/8299/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8299/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "platform": "node",
+    "external": ["node:module"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8299/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8299/artifacts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+console.log("Hello!");
+
+//#endregion
+export {  };
+```

--- a/crates/rolldown/tests/rolldown/issues/8299/main.js
+++ b/crates/rolldown/tests/rolldown/issues/8299/main.js
@@ -1,0 +1,1 @@
+console.log("Hello!");

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3848,7 +3848,7 @@ expression: output
 
 # tests/rolldown/code_splitting/format_cjs_with_esm_require_esm
 
-- main1-!~{000}~.js => main1-Cat2taJQ.js
+- main1-!~{000}~.js => main1-BPEdzKb_.js
 - main2-!~{001}~.js => main2-C8FUhn_n.js
 - chunk-!~{002}~.js => chunk-BFU93yk6.js
 
@@ -5184,6 +5184,10 @@ expression: output
 # tests/rolldown/issues/8120
 
 - main-!~{000}~.js => main-8iRAOpBT.js
+
+# tests/rolldown/issues/8299
+
+- main-!~{000}~.js => main-eeGHUsim.js
 
 # tests/rolldown/issues/duplicate_default_export
 

--- a/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
@@ -3,6 +3,7 @@ use crate::{
   types::{custom_field::CustomField, hook_resolve_id_skipped::HookResolveIdSkipped},
 };
 use arcstr::ArcStr;
+use nodejs_built_in_modules::is_nodejs_builtin_module;
 use rolldown_common::{
   ImportKind, MakeAbsoluteExternalsRelative, ModuleId, NormalizedBundlerOptions, ResolvedExternal,
   ResolvedId,
@@ -116,7 +117,13 @@ async fn resolve_external(
       ResolvedExternal::Absolute
     };
 
-  Ok(Some(ResolvedId { id: ModuleId::new(id), external, ..Default::default() }))
+  Ok(Some(ResolvedId {
+    is_external_without_side_effects: matches!(options.platform, rolldown_common::Platform::Node)
+      && is_nodejs_builtin_module(&id),
+    id: ModuleId::new(id),
+    external,
+    ..Default::default()
+  }))
 }
 
 fn is_not_absolute_external(


### PR DESCRIPTION
closed #8299