### PR TITLE
feat(rust/mcs): support `entriesAwareMergeThreshold`

### DIFF
--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/_config.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "With entriesAware: true + entriesAwareMergeThreshold, only one small entries-aware subgroup should be merged into a larger neighboring subgroup. Expected: 2 vendor chunks where `vendor~entry-a~entry-b` contains both shared-by-a and shared-by-ab.",
+  "config": {
+    "input": [
+      {
+        "name": "entry-a",
+        "import": "./entry-a.js"
+      },
+      {
+        "name": "entry-b",
+        "import": "./entry-b.js"
+      },
+      {
+        "name": "entry-c",
+        "import": "./entry-c.js"
+      }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "vendor",
+          "test": "shared-by",
+          "entriesAware": true,
+          "entriesAwareMergeThreshold": 28
+        }
+      ]
+    },
+    "experimental": {
+      "attachDebugInfo": "full"
+    }
+  },
+  "hiddenRuntimeModule": true
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/artifacts.snap
@@ -1,0 +1,54 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-a.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-a.js] [Name: Some("entry-a")]
+import "./vendor~entry-a~entry-b~entry-c.js";
+import "./vendor~entry-a~entry-b.js";
+
+```
+
+## entry-b.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-b.js] [Name: Some("entry-b")]
+import "./vendor~entry-a~entry-b~entry-c.js";
+import "./vendor~entry-a~entry-b.js";
+
+```
+
+## entry-c.js
+
+```js
+//! User-defined Entry: [Entry-Module-Id: entry-c.js] [Name: Some("entry-c")]
+import "./vendor~entry-a~entry-b~entry-c.js";
+
+```
+
+## vendor~entry-a~entry-b.js
+
+```js
+//! ManualCodeSplitting: [Group-Name: vendor] [Entries: entry-a.js, entry-b.js]
+//#region shared-by-ab.js
+console.log("shared-by-ab");
+
+//#endregion
+//#region shared-by-a.js
+console.log("shared-by-a");
+
+//#endregion
+```
+
+## vendor~entry-a~entry-b~entry-c.js
+
+```js
+//! ManualCodeSplitting: [Group-Name: vendor] [Entries: entry-a.js, entry-b.js, entry-c.js]
+//#region shared-by-abc.js
+console.log("shared-by-abc");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/entry-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/entry-a.js
@@ -1,0 +1,3 @@
+import './shared-by-abc'
+import './shared-by-ab'
+import './shared-by-a'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/entry-b.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/entry-b.js
@@ -1,0 +1,2 @@
+import './shared-by-abc'
+import './shared-by-ab'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/entry-c.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/entry-c.js
@@ -1,0 +1,1 @@
+import './shared-by-abc'

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/shared-by-a.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/shared-by-a.js
@@ -1,0 +1,1 @@
+console.log('shared-by-a')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/shared-by-ab.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/shared-by-ab.js
@@ -1,0 +1,1 @@
+console.log('shared-by-ab')

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/shared-by-abc.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic/shared-by-abc.js
@@ -1,0 +1,1 @@
+console.log('shared-by-abc')

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -3927,6 +3927,14 @@ expression: output
 - entry-c-!~{002}~.js => entry-c-Bg5GIhoe.js
 - vendor-!~{003}~.js => vendor-stCDKbV-.js
 
+# tests/rolldown/function/advanced_chunks/entries_aware_merge_threshold_basic
+
+- entry-a-!~{000}~.js => entry-a-BCSuIoVp.js
+- entry-b-!~{001}~.js => entry-b-DcpHyi0E.js
+- entry-c-!~{002}~.js => entry-c-Bl_CCreA.js
+- vendor~entry-a~entry-b-!~{005}~.js => vendor~entry-a~entry-b-CXLCP0zo.js
+- vendor~entry-a~entry-b~entry-c-!~{003}~.js => vendor~entry-a~entry-b~entry-c-BqP-AGpR.js
+
 # tests/rolldown/function/advanced_chunks/entries_aware_min_share_count
 
 - entry-a-!~{000}~.js => entry-a-DMEV0smO.js

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
@@ -39,6 +39,7 @@ pub struct BindingMatchGroup {
   pub max_module_size: Option<f64>,
   pub max_size: Option<f64>,
   pub entries_aware: Option<bool>,
+  pub entries_aware_merge_threshold: Option<f64>,
 }
 
 #[napi_derive::napi]

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -461,6 +461,7 @@ pub fn normalize_binding_options(
             min_module_size: item.min_module_size,
             max_size: item.max_size,
             entries_aware: item.entries_aware,
+            entries_aware_merge_threshold: item.entries_aware_merge_threshold,
           })
           .collect::<Vec<_>>()
       }),

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -52,6 +52,8 @@ pub struct MatchGroup {
   pub min_module_size: Option<f64>,
   pub max_module_size: Option<f64>,
   pub entries_aware: Option<bool>,
+  /// Only effective when `entriesAware` is set to `true`.
+  pub entries_aware_merge_threshold: Option<f64>,
 }
 
 type MatchGroupTestFn = dyn Fn(&str) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<bool>>> + Send + 'static>>

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1290,6 +1290,14 @@
             "boolean",
             "null"
           ]
+        },
+        "entriesAwareMergeThreshold": {
+          "description": "Only effective when `entriesAware` is set to `true`.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
         }
       },
       "additionalProperties": false,

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2287,6 +2287,7 @@ export interface BindingMatchGroup {
   maxModuleSize?: number
   maxSize?: number
   entriesAware?: boolean
+  entriesAwareMergeThreshold?: number
 }
 
 export interface BindingModulePreloadOptions {

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -867,6 +867,16 @@ export type CodeSplittingGroup = {
    * @default false
    */
   entriesAware?: boolean;
+  /**
+   * Size threshold in bytes for merging small `entriesAware` subgroups into the
+   * closest neighboring subgroup.
+   *
+   * This option only works when {@linkcode CodeSplittingGroup.entriesAware | entriesAware}
+   * is `true`. Set to `0` to disable subgroup merging.
+   *
+   * @default 0
+   */
+  entriesAwareMergeThreshold?: number;
 };
 
 /**

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -771,6 +771,7 @@ const AdvancedChunksSchema = v.strictObject({
         minModuleSize: v.optional(v.number()),
         maxModuleSize: v.optional(v.number()),
         entriesAware: v.optional(v.boolean()),
+        entriesAwareMergeThreshold: v.optional(v.number()),
       }),
     ),
   ),


### PR DESCRIPTION
## Summary

This PR adds `entriesAwareMergeThreshold` for advanced chunk groups (`manualCodeSplitting.groups[]`).

It is designed specifically for `entriesAware` mode, where we want to keep the correctness and fetch-precision benefits of entry-aware splitting, but avoid exploding into too many tiny chunks.

---

## What `entriesAware` does

When `entriesAware: true` is enabled on a group, matched modules are split by **entry reachability** (entry-bitset).

That means:
- modules reached by exactly the same entry set go to the same subgroup/chunk
- modules with different reachability bits go to different subgroups/chunks

Example:
- `{A,B,C}`-reachable modules -> one subgroup
- `{A,B}`-reachable modules -> another subgroup
- `{A}`-reachable modules -> another subgroup

### Benefits

- **Most precise loading behavior**: each entry loads only the shared pieces it actually needs.
- **Less over-fetching** compared with coarse “one shared vendor chunk” strategies.
- Works naturally with rolldown’s singleton module model.

### Downsides

- Can generate many small subgroups/chunks, especially in multi-entry apps.
- Too many tiny chunks increase request overhead and scheduling overhead.
- Chunk graph may become noisy/harder to reason about for users.

---

## What `entriesAwareMergeThreshold` does

New per-group option:

```js
manualCodeSplitting: {
  groups: [
    {
      name: 'vendor',
      test: /.../,
      entriesAware: true,
      entriesAwareMergeThreshold: 28000
    }
  ]
}
```

Behavior:
- only applies to `entriesAware` subgroups
- if subgroup `size < entriesAwareMergeThreshold`, it is considered **unqualified**
- unqualified subgroups are **merged** into a better sibling subgroup (same origin group), instead of being left as standalone tiny chunks

---

## How merge chooses a target

For each unqualified subgroup candidate, choose target by:
1. **lowest extra-entry count** (`|candidate-target| + |target-candidate|` on entry bits)
2. if tie: **smaller target size**
3. if tie: stable deterministic key order

This is intentional: the merge heuristic is not only about reducing chunk count, but also about keeping **unnecessary extra download** as low as possible after merging.

By preferring targets with fewer extra entries, we try to merge into the closest reachability neighbor so fewer entries pay for modules they do not strictly need.

---

## Recommended splitting pattern with `maxSize`

`entriesAwareMergeThreshold` and `maxSize` are intended to work together:

1. Use `entriesAwareMergeThreshold` to merge tiny entries-aware subgroups and reduce micro-chunk fragmentation.
2. Keep/use `maxSize` to split any merged result that becomes too large.

So even if merging creates a big group, `maxSize` can re-split it into smaller chunks in the existing splitting phase.

This is the recommended chunk-splitting pattern in practice:
- **merge tiny chunks first** (reduce request overhead)
- **then cap large chunks** (control payload size)
- while still minimizing additional over-fetch / unnecessary download introduced by merge

---

## Relationship with existing size options

- `minSize` and `maxSize` semantics remain unchanged.
- `entriesAwareMergeThreshold` runs as an entries-aware pre-merge step.
- `maxSize` is not a hard constraint in merge target selection.

So this is additive behavior targeted at entries-aware subgroup consolidation.

---

## Why this helps

`entriesAware` gives the best fetch precision but can be too fragmented.

`entriesAwareMergeThreshold` provides a practical middle ground:
- keep entry-aware structure
- reduce tiny subgroup count
- improve chunk graph practicality for real-world apps

In short: **preserve most of entries-aware correctness/precision while reducing micro-chunk overhead**.
