### PR TITLE
chore: remove unnecessary transform.decorator

### DIFF
--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -148,10 +148,6 @@ function withShared({
     },
     transform: {
       target: 'node22',
-      decorator: {
-        // Legacy decorators are required for the @lazyProp decorator
-        legacy: true,
-      },
       define: {
         'import.meta.browserBuild': String(isBrowserBuild),
       },


### PR DESCRIPTION
Fix the warning when building the binding.
<img width="1575" height="64" alt="image" src="https://github.com/user-attachments/assets/10bc7561-adf3-483e-b564-264ad416b1cb" />

It is already set to `true` at https://github.com/rolldown/rolldown/blob/0efd91d64afdda3abb46bbb69013c3ce625ec336/packages/rolldown/tsconfig.json#L21
