### PR TITLE
fix: `xxhash_with_base` skips hashing when input is exactly 16 bytes

### DIFF
--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -20,7 +20,7 @@ use rolldown_utils::{
   rayon::{
     IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
   },
-  xxhash::{xxhash_base64_url, xxhash_with_base},
+  xxhash::{encode_hash_with_base, xxhash_base64_url},
 };
 use rustc_hash::FxHashMap;
 use xxhash_rust::xxh3::Xxh3;
@@ -105,7 +105,7 @@ pub async fn finalize_assets(
       });
 
       let digested = hasher.digest128();
-      (xxhash_with_base(&digested.to_le_bytes(), hash_base), digested)
+      (encode_hash_with_base(&digested.to_le_bytes(), hash_base), digested)
     })
     .collect::<Vec<_>>()
     .into();

--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -11,7 +11,7 @@ use rolldown_utils::{
   dashmap::FxDashMap,
   hash_placeholder::{HASH_PLACEHOLDER_LEFT_FINDER, find_hash_placeholders},
   rustc_hash::FxHashMapExt as _,
-  xxhash::xxhash_with_base,
+  xxhash::encode_hash_with_base,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use xxhash_rust::xxh3::Xxh3;
@@ -67,7 +67,7 @@ impl Plugin for ChunkImportMapPlugin {
             hasher
           }
         };
-        let hash = xxhash_with_base(&hasher.digest128().to_le_bytes(), base);
+        let hash = encode_hash_with_base(&hasher.digest128().to_le_bytes(), base);
         let mut chunk_id = chunk.filename.to_string();
         for (start, end, placeholder) in hash_placeholders {
           let hash = hash[..end - start].to_string();

--- a/crates/rolldown_utils/src/xxhash.rs
+++ b/crates/rolldown_utils/src/xxhash.rs
@@ -15,9 +15,14 @@ const CHARACTERS_BASE64: &[u8] =
 
 const CHARACTERS_BASE16: &[u8] = b"0123456789abcdef";
 
+/// Hash input with xxh3_128, then encode with the given base.
+#[inline]
 pub fn xxhash_with_base(input: &[u8], base: u8) -> String {
-  let hash = if input.len() == 16 { input } else { &xxh3_128(input).to_le_bytes() };
+  encode_hash_with_base(&xxh3_128(input).to_le_bytes(), base)
+}
 
+/// Encode pre-hashed 128-bit digest with the given base.
+pub fn encode_hash_with_base(hash: &[u8; 16], base: u8) -> String {
   let chars = match base {
     64 => CHARACTERS_BASE64,
     36 => &CHARACTERS_BASE64[26..(26 + 36)],
@@ -26,7 +31,6 @@ pub fn xxhash_with_base(input: &[u8], base: u8) -> String {
       unreachable!()
     }
   };
-
   to_string(hash, base, chars).unwrap()
 }
 


### PR DESCRIPTION
### Summary
- Fix a bug in `xxhash_with_base` where inputs that happen to be exactly 16 bytes are incorrectly treated as pre-hashed digests and   skip `xxh3_128` hashing
- Extract `encode_hash_with_base` for callers that already have a 128-bit digest, avoiding the ambiguous length check