### PR TITLE
fix: pad `encode_hash_with_base` output to fixed length to prevent slice panics

### DIFF
--- a/crates/rolldown_utils/src/xxhash.rs
+++ b/crates/rolldown_utils/src/xxhash.rs
@@ -22,6 +22,10 @@ pub fn xxhash_with_base(input: &[u8], base: u8) -> String {
 }
 
 /// Encode pre-hashed 128-bit digest with the given base.
+///
+/// Generates a base-encoded xxhash string for use in output filenames.
+/// The result is guaranteed to be at least 21 characters (`MAX_HASH_SIZE`),
+/// left-padded with the zero character of the given base when necessary.
 pub fn encode_hash_with_base(hash: &[u8; 16], base: u8) -> String {
   let chars = match base {
     64 => CHARACTERS_BASE64,
@@ -31,7 +35,22 @@ pub fn encode_hash_with_base(hash: &[u8; 16], base: u8) -> String {
       unreachable!()
     }
   };
-  to_string(hash, base, chars).unwrap()
+
+  let result = to_string(hash, base, chars).unwrap();
+
+  // Left-pad with the zero character to ensure the output is at least 21 chars
+  // (MAX_HASH_SIZE). `base_encode::to_string` produces variable-length output
+  // depending on the numeric magnitude, which can cause panics when callers
+  // slice the result at a fixed offset (e.g. `hash[..placeholder.len()]`).
+  let pad_len = 21usize.saturating_sub(result.len());
+  if pad_len > 0 {
+    let mut padded = String::with_capacity(21);
+    padded.extend(std::iter::repeat_n(chars[0] as char, pad_len));
+    padded.push_str(&result);
+    padded
+  } else {
+    result
+  }
 }
 
 #[test]
@@ -39,4 +58,16 @@ fn test_xxhash_with_base() {
   assert_eq!(&xxhash_with_base(b"hello", 64), "YOFJeqs95x38-Gwetwem1");
   assert_eq!(&xxhash_with_base(b"hello", 36), "bpwli5k6mqm0gij09mxrh9npj");
   assert_eq!(&xxhash_with_base(b"hello", 16), "1838525eaacf79c77f3e1b07adc1e9b5");
+}
+
+#[test]
+fn test_encode_hash_with_base_padding() {
+  // 16-byte input with leading zeros: base_encode produces only 16 chars,
+  // verify it gets left-padded to 21.
+  let input = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1u8];
+  let raw = to_string(&input, 64, CHARACTERS_BASE64).unwrap();
+  assert_eq!(raw.len(), 16);
+
+  let hash = encode_hash_with_base(&input, 64);
+  assert_eq!(hash.len(), 21);
 }


### PR DESCRIPTION
closes #8270, related to rollup/rollup#5720

### Summary

`base_encode::to_string` performs a true mathematical base conversion (repeated division), which produces **variable-length output** depending on the numeric magnitude of the input. For a 128-bit xxhash encoded in base 64, the output is typically 21 or 22 characters (~75% chance of 22, ~25% chance of 21), and can be shorter (~0.4% chance) if the least-significant bytes of the hash happen to be zero.

This caused two issues:

1. **Potential panic**: Callers slice the hash at fixed offsets (e.g. `hash[..placeholder.len()]`), which panics if the hash string is shorter than expected.
2. **Incorrect `MAX_HASH_SIZE`**: It was set to 21, but the actual maximum for base 64 is `ceil(128/6) = 22`, preventing users from using `[hash:22]`.

### Additional

For the xxhash use case, the 128-bit hash output is approximately uniformly random. Having 13+ leading zero bytes would require a probability of   `1/256¹³ ≈ 10⁻³¹`, which is practically impossible. In practice, the output is almost always 21 characters (~75%) or 22 characters (~25%), with   an occasional 20 characters (~0.4%).