### PR TITLE
perf(rolldown_plugin_vite_reporter): skip gzip computation when `report_compressed_size` is disabled

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_reporter_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_reporter_plugin_config.rs
@@ -38,7 +38,6 @@ impl From<BindingViteReporterPluginConfig> for ViteReporterPlugin {
       warn_large_chunks: config.warn_large_chunks,
       report_compressed_size: config.report_compressed_size,
       chunk_count: AtomicU32::new(0),
-      compressed_count: AtomicU32::new(0),
       has_rendered_chunk: AtomicBool::new(false),
       has_transformed: AtomicBool::new(false),
       transformed_count: AtomicU32::new(0),


### PR DESCRIPTION
Related to #5734

1. Remove the unused `compressed_count` field and its reset in `render_start`
2. Skip Rayon parallel computation entirely when `report_compressed_size` is `false` (using `.then()`)
3. Simplify the "computing gzip size" log message (remove TTY-specific progress reporting)

Since #5734 removed the dynamic per-output progress reporting (`computing gzip size ({count})...`) in favor of printing the final sizes all at once, the remaining `computing gzip size (0)...` log is no longer meaningful. Additionally, with Rayon's `par_iter` and Rust's performance, gzip computation is fast enough that a progress log is unnecessary. Remove it.