### PR TITLE
refactor(rolldown_plugin_vite_reporter): simplify hook registration and remove redundant state

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_reporter_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_reporter_plugin_config.rs
@@ -1,9 +1,6 @@
 use std::{
   path::PathBuf,
-  sync::{
-    Arc, RwLock,
-    atomic::{AtomicBool, AtomicU32},
-  },
+  sync::{Arc, RwLock, atomic::AtomicU32},
   time::Instant,
 };
 
@@ -38,8 +35,6 @@ impl From<BindingViteReporterPluginConfig> for ViteReporterPlugin {
       warn_large_chunks: config.warn_large_chunks,
       report_compressed_size: config.report_compressed_size,
       chunk_count: AtomicU32::new(0),
-      has_rendered_chunk: AtomicBool::new(false),
-      has_transformed: AtomicBool::new(false),
       transformed_count: AtomicU32::new(0),
       latest_checkpoint: Arc::new(RwLock::new(Instant::now())),
       log_info: config.log_info.map(|log_info| -> Arc<LogInfoFn> {


### PR DESCRIPTION
- Remove `has_rendered_chunk` and `has_transformed` boolean flags by reusing existing `chunk_count` and `transformed_count` atomic counters to detect first invocation (`== 0`)
- Consolidate `chunk_count` reset from `render_start` into `build_start` and remove the now-unnecessary `render_start` hook      
- Fix off-by-one in progress display (start from `1` instead of `0`)
- Optimize `register_hook_usage` to avoid registering hooks when they have no work to do