### PR TITLE
fix: `jsx.preserve` should also considering tsconfig json preserve

### DIFF
--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -1,7 +1,7 @@
 use oxc_index::IndexVec;
 use rolldown_common::{
-  EcmaModuleAstUsage, EcmaRelated, EcmaView, EcmaViewMeta, ImportRecordIdx, ModuleType,
-  RawImportRecord, ResolvedId, SharedNormalizedBundlerOptions, SideEffectDetail,
+  EcmaModuleAstUsage, EcmaRelated, EcmaView, EcmaViewMeta, FlatOptions, ImportRecordIdx,
+  ModuleType, RawImportRecord, ResolvedId, SharedNormalizedBundlerOptions, SideEffectDetail,
   side_effects::{DeterminedSideEffects, HookSideEffects},
 };
 use rolldown_error::BuildResult;
@@ -26,9 +26,9 @@ pub async fn create_ecma_view(
   args: CreateModuleViewArgs,
 ) -> BuildResult<CreateEcmaViewReturn> {
   let CreateModuleViewArgs { source, sourcemap_chain, hook_side_effects } = args;
-  let ParseToEcmaAstResult { ast, scoping, has_lazy_export, warnings } =
+  let ParseToEcmaAstResult { ast, scoping, has_lazy_export, warnings, preserve_jsx } =
     parse_to_ecma_ast(ctx, source).await?;
-
+  ctx.flat_options.set(FlatOptions::JsxPreserve, preserve_jsx);
   ctx.warnings.extend(warnings);
 
   let module_id = ctx.resolved_id.id.clone();
@@ -143,7 +143,7 @@ pub async fn create_ecma_view(
     json_module_none_self_reference_included_symbol: None,
   };
 
-  let ecma_related = EcmaRelated { ast, symbols, dynamic_import_rec_exports_usage };
+  let ecma_related = EcmaRelated { ast, symbols, dynamic_import_rec_exports_usage, preserve_jsx };
   Ok(CreateEcmaViewReturn { ecma_view, ecma_related, raw_import_records })
 }
 

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -152,7 +152,7 @@ impl<'a> ModuleLoader<'a> {
     }
 
     let flat_options = FlatOptions::from_shared_options(&options);
-    let symbol_ref_db = SymbolRefDb::new(options.transform_options.is_jsx_preserve());
+    let symbol_ref_db = SymbolRefDb::new();
     let meta = TaskContextMeta {
       replace_global_define_config: if options.define.is_empty() {
         None
@@ -358,7 +358,8 @@ impl<'a> ModuleLoader<'a> {
           let NormalModuleTaskResult {
             mut module,
             mut barrel_info,
-            ecma_related: EcmaRelated { ast, symbols, mut dynamic_import_rec_exports_usage },
+            ecma_related:
+              EcmaRelated { ast, symbols, mut dynamic_import_rec_exports_usage, preserve_jsx },
             resolved_deps,
             raw_import_records,
             warnings,
@@ -491,6 +492,9 @@ impl<'a> ModuleLoader<'a> {
           }
 
           self.symbol_ref_db.store_local_db(module_idx, symbols);
+          if preserve_jsx {
+            self.symbol_ref_db.set_has_module_preserve_jsx();
+          }
           self.remaining -= 1;
         }
         ModuleLoaderMsg::ExternalModuleDone(task_result) => {

--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -23,6 +23,7 @@ impl LinkStage<'_> {
   pub(super) fn reference_needed_symbols(&mut self) {
     // Since each module only access its own symbol ref db, we use zip rather than a Mutex to
     // access the symbol db in parallel.
+    let has_module_preserve_jsx = self.symbols.has_module_preserve_jsx();
     let old_symbol_db = std::mem::take(&mut self.symbols);
     let mut symbols_inner = old_symbol_db.into_inner();
     let keep_names = self.options.keep_names;
@@ -293,7 +294,10 @@ impl LinkStage<'_> {
       }
     }
 
-    self.symbols =
-      SymbolRefDb::new(self.options.transform_options.is_jsx_preserve()).with_inner(symbols_inner);
+    let mut symbols = SymbolRefDb::new().with_inner(symbols_inner);
+    if has_module_preserve_jsx {
+      symbols.set_has_module_preserve_jsx();
+    }
+    self.symbols = symbols;
   }
 }

--- a/crates/rolldown/src/utils/parse_to_ecma_ast.rs
+++ b/crates/rolldown/src/utils/parse_to_ecma_ast.rs
@@ -31,6 +31,9 @@ pub struct ParseToEcmaAstResult {
   pub scoping: Scoping,
   pub has_lazy_export: bool,
   pub warnings: Vec<BuildDiagnostic>,
+  /// Whether JSX syntax should be preserved in the output, determined per-module
+  /// during transformation based on the resolved tsconfig.
+  pub preserve_jsx: bool,
 }
 
 pub async fn parse_to_ecma_ast(

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -168,7 +168,7 @@ impl<'name> Renamer<'name> {
     let canonical_ref = symbol_ref.canonical_ref(self.symbol_db);
     let canonical_name = canonical_ref.name(self.symbol_db);
 
-    let original_name = if self.symbol_db.is_jsx_preserve
+    let original_name = if self.symbol_db.has_module_preserve_jsx()
       && canonical_ref
         .flags(self.symbol_db)
         .is_some_and(|flags| flags.contains(SymbolRefFlags::MustStartWithCapitalLetterForJSX))

--- a/crates/rolldown/tests/rolldown/issues/8216/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8216/_config.json
@@ -11,5 +11,5 @@
       "jsxPreset": "enable"
     }
   },
-  "expectError": true
+  "expectExecuted": false
 }

--- a/crates/rolldown/tests/rolldown/issues/8377/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8377/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.jsx" }]
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/8377/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8377/artifacts.snap
@@ -7,8 +7,8 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region main.jsx
-const main = <Component>Hello, World!</Component>;
+const foo = <div />;
 
 //#endregion
-export { main };
+export { foo };
 ```

--- a/crates/rolldown/tests/rolldown/issues/8377/main.jsx
+++ b/crates/rolldown/tests/rolldown/issues/8377/main.jsx
@@ -1,0 +1,1 @@
+export const foo = <div />;

--- a/crates/rolldown/tests/rolldown/issues/8377/tsconfig.json
+++ b/crates/rolldown/tests/rolldown/issues/8377/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve"
+  }
+}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5194,6 +5194,10 @@ expression: output
 
 - main-!~{000}~.js => main-8iRAOpBT.js
 
+# tests/rolldown/issues/8216
+
+- main-!~{000}~.js => main-BEIwxpN4.js
+
 # tests/rolldown/issues/8299
 
 - main-!~{000}~.js => main-eeGHUsim.js
@@ -5222,6 +5226,10 @@ expression: output
 - b-!~{005}~.js => b-Tw4qy3nc.js
 - chunk-!~{001}~.js => chunk-BuzPwJy5.js
 - cjs-!~{003}~.js => cjs-IJCXeZRo.js
+
+# tests/rolldown/issues/8377
+
+- main-!~{000}~.js => main-BBnK1pph.js
 
 # tests/rolldown/issues/duplicate_default_export
 

--- a/crates/rolldown_common/src/module_loader/task_result.rs
+++ b/crates/rolldown_common/src/module_loader/task_result.rs
@@ -31,4 +31,7 @@ pub struct EcmaRelated {
   pub ast: EcmaAst,
   pub symbols: SymbolRefDbForModule,
   pub dynamic_import_rec_exports_usage: FxHashMap<ImportRecordIdx, DynamicImportExportsUsage>,
+  /// Whether JSX syntax is preserved for this module, determined per-module
+  /// during transformation based on the resolved tsconfig.
+  pub preserve_jsx: bool,
 }

--- a/crates/rolldown_common/src/types/flat_options.rs
+++ b/crates/rolldown_common/src/types/flat_options.rs
@@ -7,6 +7,9 @@ bitflags! {
   /// which also make accessing frequently used options faster.
   pub struct FlatOptions: u16 {
     const IgnoreAnnotations = 1 << 0;
+    /// If set, JSX syntax is preserved in the output rather than being transformed.
+    /// Determined per-module during transformation based on the resolved tsconfig
+    /// (e.g. a module's `tsconfig.json` specifies `"jsx": "preserve"`).
     const JsxPreserve = 1 << 1;
     const IsManualPureFunctionsEmpty = 1 << 2;
     /// If the flag is set, it means the `treeshake.property_read_side_effects` is `Always`.
@@ -40,7 +43,6 @@ impl FlatOptions {
   pub fn from_shared_options(options: &SharedNormalizedBundlerOptions) -> Self {
     let mut flags = Self::empty();
     flags.set(Self::IgnoreAnnotations, !options.treeshake.annotations());
-    flags.set(Self::JsxPreserve, options.transform_options.is_jsx_preserve());
     flags
       .set(Self::IsManualPureFunctionsEmpty, options.treeshake.manual_pure_functions().is_none());
     flags.set(

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -114,7 +114,7 @@ impl IntegrationTest {
     for output in &bundle_output.assets {
       if let Output::Chunk(chunk) = output {
         let allocator = oxc::allocator::Allocator::default();
-        let ret = Parser::new(&allocator, &chunk.code, source_type)
+        let ret = Parser::new(&allocator, &chunk.code, source_type.with_jsx(true))
           .with_options(ParseOptions { allow_return_outside_function: true, ..Default::default() })
           .parse();
 


### PR DESCRIPTION
Previously, `FlatOptions::JsxPreserve` was determined once from the static bundler configuration (`transform_options.is_jsx_preserve()`). This didn't account for per-module tsconfig discovery — when a module's local `tsconfig.json` specifies `"jsx": "preserve"`, the static flag wouldn't reflect it.

This PR determines `preserve_jsx` per-module during transformation by checking the resolved `transform_options.jsx.jsx_plugin` after tsconfig discovery, then updates `FlatOptions::JsxPreserve` on the module's context accordingly.

closed https://github.com/rolldown/rolldown/issues/8377
