### PR TITLE
test(rolldown_plugin_vite_build_import_analysis): add test for dynamic import treeshaking

### DIFF
--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-destructuring/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-destructuring/_config.ts
@@ -1,0 +1,40 @@
+import { defineTest } from 'rolldown-tests';
+import { viteBuildImportAnalysisPlugin } from 'rolldown/experimental';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    plugins: [
+      {
+        name: 'insert_dummy_flag',
+        transform(code) {
+          let runtimeCode = `const __VITE_PRELOAD__ = [];`;
+          return {
+            code: runtimeCode + code,
+          };
+        },
+      },
+      viteBuildImportAnalysisPlugin({
+        preloadCode: `export const __vitePreload = (v) => { return v() };`,
+        insertPreload: true,
+        optimizeModulePreloadRelativePaths: false,
+        renderBuiltUrl: false,
+        isRelativeBase: false,
+      }),
+    ],
+  },
+  async afterTest(output) {
+    await import('./assert.mjs');
+    output.output.forEach((item) => {
+      if (item.type === 'chunk' && item.name === 'main') {
+        expect(item.code).to.include('__vitePreload');
+      }
+      if (item.type === 'chunk' && item.name === 'lib') {
+        expect(item.code).to.not.include('unused');
+        expect(item.code).to.include('foo');
+        expect(item.code).to.include('bar');
+      }
+    });
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-destructuring/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-destructuring/assert.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert';
+import { foo, bar } from './dist/main';
+
+assert.strictEqual(foo, 100);
+assert.strictEqual(bar, 200);

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-destructuring/lib.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-destructuring/lib.js
@@ -1,0 +1,3 @@
+export const foo = 100;
+export const bar = 200;
+export const unused = 300;

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-destructuring/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-destructuring/main.js
@@ -1,0 +1,4 @@
+const { foo } = await import('./lib');
+const { bar } = await import('./lib');
+
+export { foo, bar };

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-member-access/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-member-access/_config.ts
@@ -1,0 +1,40 @@
+import { defineTest } from 'rolldown-tests';
+import { viteBuildImportAnalysisPlugin } from 'rolldown/experimental';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    plugins: [
+      {
+        name: 'insert_dummy_flag',
+        transform(code) {
+          let runtimeCode = `const __VITE_PRELOAD__ = [];`;
+          return {
+            code: runtimeCode + code,
+          };
+        },
+      },
+      viteBuildImportAnalysisPlugin({
+        preloadCode: `export const __vitePreload = (v) => { return v() };`,
+        insertPreload: true,
+        optimizeModulePreloadRelativePaths: false,
+        renderBuiltUrl: false,
+        isRelativeBase: false,
+      }),
+    ],
+  },
+  async afterTest(output) {
+    await import('./assert.mjs');
+    output.output.forEach((item) => {
+      if (item.type === 'chunk' && item.name === 'main') {
+        expect(item.code).to.include('__vitePreload');
+      }
+      if (item.type === 'chunk' && item.name === 'lib') {
+        expect(item.code).to.not.include('unused');
+        expect(item.code).to.include('foo');
+        expect(item.code).to.include('bar');
+      }
+    });
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-member-access/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-member-access/assert.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert';
+import { a, b } from './dist/main';
+
+assert.strictEqual(a, 100);
+assert.strictEqual(b, 200);

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-member-access/lib.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-member-access/lib.js
@@ -1,0 +1,3 @@
+export const foo = 100;
+export const bar = 200;
+export const unused = 300;

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-member-access/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/await-import-member-access/main.js
@@ -1,0 +1,4 @@
+const a = (await import('./lib')).foo;
+const b = (await import('./lib')).bar;
+
+export { a, b };

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-destructuring/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-destructuring/_config.ts
@@ -1,0 +1,44 @@
+import { defineTest } from 'rolldown-tests';
+import { viteBuildImportAnalysisPlugin } from 'rolldown/experimental';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    plugins: [
+      {
+        // insert some dummy runtime flag to assert the runtime behavior
+        name: 'insert_dummy_flag',
+        transform(code) {
+          let runtimeCode = `const __VITE_PRELOAD__ = [];`;
+          return {
+            code: runtimeCode + code,
+          };
+        },
+      },
+      viteBuildImportAnalysisPlugin({
+        preloadCode: `export const __vitePreload = (v) => { return v() };`,
+        insertPreload: true,
+        optimizeModulePreloadRelativePaths: false,
+        renderBuiltUrl: false,
+        isRelativeBase: false,
+      }),
+    ],
+  },
+  async afterTest(output) {
+    await import('./assert.mjs');
+    output.output.forEach((item) => {
+      if (item.type === 'chunk' && item.name === 'main') {
+        // Should transform await import().then() pattern with destructuring
+        expect(item.code).to.include('__vitePreload');
+      }
+      if (item.type === 'chunk' && item.name === 'lib') {
+        // Verify tree-shaking: unused export should not be in the lib chunk
+        expect(item.code).to.not.include('unused');
+        // The used exports should still be present
+        expect(item.code).to.include('foo');
+        expect(item.code).to.include('bar');
+      }
+    });
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-destructuring/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-destructuring/assert.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert';
+import { a, b } from './dist/main';
+
+assert.strictEqual(a, 100);
+assert.strictEqual(b, 200);

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-destructuring/lib.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-destructuring/lib.js
@@ -1,0 +1,3 @@
+export const foo = 100;
+export const bar = 200;
+export const unused = 300;

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-destructuring/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-destructuring/main.js
@@ -1,0 +1,4 @@
+const a = await import('./lib').then(({ foo }) => foo);
+const b = await import('./lib').then(({ bar }) => bar);
+
+export { a, b };


### PR DESCRIPTION
Add tests to ensure the dynamic import treeshaking works even if `rolldown_plugin_vite_build_import_analysis` is used.