### PR TITLE
feat(rolldown_plugin_vite_build_import_analysis): add support for `await import().then((m) => m.prop)`

### DIFF
--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
@@ -55,7 +55,7 @@ impl<'a> VisitMut<'a> for BuildImportAnalysisVisitor<'a> {
   fn visit_expression(&mut self, expr: &mut Expression<'a>) {
     if self.insert_preload {
       let is_rewritten = match expr {
-        Expression::CallExpression(expr) => self.rewrite_call_expr(expr),
+        Expression::CallExpression(_) => self.rewrite_call_expr(expr),
         Expression::StaticMemberExpression(expr) => self.rewrite_member_expr(expr),
         _ => self.rewrite_import_expr(expr),
       };

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-nested-import/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-nested-import/_config.ts
@@ -1,0 +1,52 @@
+import { defineTest } from 'rolldown-tests';
+import { viteBuildImportAnalysisPlugin } from 'rolldown/experimental';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    plugins: [
+      {
+        // insert some dummy runtime flag to assert the runtime behavior
+        name: 'insert_dummy_flag',
+        transform(code) {
+          let runtimeCode = `const __VITE_PRELOAD__ = [];`;
+          return {
+            code: runtimeCode + code,
+          };
+        },
+      },
+      viteBuildImportAnalysisPlugin({
+        preloadCode: `export const __vitePreload = (v) => { return v() };`,
+        insertPreload: true,
+        optimizeModulePreloadRelativePaths: false,
+        renderBuiltUrl: false,
+        isRelativeBase: false,
+      }),
+    ],
+  },
+  async afterTest(output) {
+    await import('./assert.mjs');
+    output.output.forEach((item) => {
+      if (item.type === 'chunk' && item.name === 'main') {
+        // Should transform both the outer and inner import() calls
+        expect(item.code).to.include('__vitePreload');
+        // Count occurrences of __vitePreload - should have at least 2 (one for each import)
+        const preloadCount = (item.code.match(/__vitePreload\(/g) || []).length;
+        expect(preloadCount).to.be.greaterThanOrEqual(2);
+      }
+      if (item.type === 'chunk' && item.name === 'lib1') {
+        // foo should be present since it's accessed in the then callback
+        expect(item.code).to.include('foo');
+        // Verify tree-shaking: unused1 should not be in the lib1 chunk
+        expect(item.code).to.not.include('unused1');
+      }
+      if (item.type === 'chunk' && item.name === 'lib2') {
+        // bar should be present since it's accessed in the second then callback
+        expect(item.code).to.include('bar');
+        // Verify tree-shaking: unused2 should not be in the lib2 chunk
+        expect(item.code).to.not.include('unused2');
+      }
+    });
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-nested-import/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-nested-import/assert.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert';
+import { a } from './dist/main';
+
+// a should be the bar value from lib2
+assert.strictEqual(a, 200);

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-nested-import/lib1.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-nested-import/lib1.js
@@ -1,0 +1,2 @@
+export const foo = 100;
+export const unused1 = 300;

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-nested-import/lib2.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-nested-import/lib2.js
@@ -1,0 +1,2 @@
+export const bar = 200;
+export const unused2 = 400;

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-nested-import/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-nested-import/main.js
@@ -1,0 +1,3 @@
+const a = await import('./lib1.js').then((m) => (console.log(m.foo), import('./lib2.js').then((m) => m.bar)));
+
+export { a };

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-property-access/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-property-access/_config.ts
@@ -1,0 +1,44 @@
+import { defineTest } from 'rolldown-tests';
+import { viteBuildImportAnalysisPlugin } from 'rolldown/experimental';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    plugins: [
+      {
+        // insert some dummy runtime flag to assert the runtime behavior
+        name: 'insert_dummy_flag',
+        transform(code) {
+          let runtimeCode = `const __VITE_PRELOAD__ = [];`;
+          return {
+            code: runtimeCode + code,
+          };
+        },
+      },
+      viteBuildImportAnalysisPlugin({
+        preloadCode: `export const __vitePreload = (v) => { return v() };`,
+        insertPreload: true,
+        optimizeModulePreloadRelativePaths: false,
+        renderBuiltUrl: false,
+        isRelativeBase: false,
+      }),
+    ],
+  },
+  async afterTest(output) {
+    await import('./assert.mjs');
+    output.output.forEach((item) => {
+      if (item.type === 'chunk' && item.name === 'main') {
+        // Should transform await import().then() pattern
+        expect(item.code).to.include('__vitePreload');
+      }
+      if (item.type === 'chunk' && item.name === 'lib') {
+        // Verify tree-shaking: unused export should not be in the lib chunk
+        expect(item.code).to.not.include('unused');
+        // The used exports should still be present
+        expect(item.code).to.include('foo');
+        expect(item.code).to.include('bar');
+      }
+    });
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-property-access/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-property-access/assert.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert';
+import { a, b } from './dist/main';
+
+assert.strictEqual(a, 100);
+assert.strictEqual(b, 200);

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-property-access/lib.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-property-access/lib.js
@@ -1,0 +1,3 @@
+export const foo = 100;
+export const bar = 200;
+export const unused = 300;

--- a/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-property-access/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/build-import-analysis/then-with-property-access/main.js
@@ -1,0 +1,4 @@
+const a = await import('./lib').then((m) => m.foo);
+const b = await import('./lib').then((m) => m.bar);
+
+export { a, b };


### PR DESCRIPTION
Add support for the `import().then((m) => m.prop)` pattern in rolldown_plugin_vite_build_import_analysis.

refs https://github.com/vitejs/vite/issues/21121
