### PR TITLE
perf: use `IndexBitSet` instead of `FxHashSet<*Idx>`

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -5,7 +5,8 @@ use rolldown_common::{
   Chunk, ChunkIdx, ChunkModulesOrderBy, ChunkTable, EcmaViewMeta, ModuleIdx,
   PostChunkOptimizationOperation, RuntimeHelper, SymbolRef,
 };
-use rustc_hash::{FxHashMap, FxHashSet};
+use rolldown_utils::IndexBitSet;
+use rustc_hash::FxHashMap;
 
 use crate::{SharedOptions, stages::link_stage::LinkStageOutput};
 
@@ -20,10 +21,10 @@ pub struct ChunkGraph {
   /// If the namespace is merged, `Key` is the original namespace symbol, and `Value` is the linked namespace symbol.
   pub finalized_cjs_ns_map_idx_vec: IndexVec<ChunkIdx, FxHashMap<SymbolRef, SymbolRef>>,
   pub chunk_idx_to_reference_ids: FxHashMap<ChunkIdx, Vec<ArcStr>>,
-  pub common_chunk_exported_facade_chunk_namespace: FxHashMap<ChunkIdx, FxHashSet<ModuleIdx>>,
+  pub common_chunk_exported_facade_chunk_namespace: FxHashMap<ChunkIdx, IndexBitSet<ModuleIdx>>,
   /// Modules from emitted chunks with AllowExtension that were merged into common chunks.
   /// Their export names should be preserved (not minified).
-  pub common_chunk_preserve_export_names_modules: FxHashMap<ChunkIdx, FxHashSet<ModuleIdx>>,
+  pub common_chunk_preserve_export_names_modules: FxHashMap<ChunkIdx, IndexBitSet<ModuleIdx>>,
   /// Tracks chunks that have been removed during post-optimization of code splitting.
   ///
   /// Since chunks are stored in an `IndexVec`, we have two options when removing chunks:

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -21,7 +21,7 @@ use rolldown_sourcemap::{Source, SourceJoiner, SourceMapSource};
 #[cfg(not(target_family = "wasm"))]
 use rolldown_utils::rayon::IndexedParallelIterator;
 use rolldown_utils::{
-  concat_string,
+  IndexBitSet, concat_string,
   indexmap::{FxIndexMap, FxIndexSet},
   rayon::{IntoParallelIterator, ParallelIterator},
 };
@@ -470,7 +470,7 @@ impl<'a> HmrStage<'a> {
             affected_module_idx_to_init_fn_name: &module_idx_to_init_fn_name,
             use_pife_for_module_wrappers,
             dependencies: FxIndexSet::default(),
-            imports: FxHashSet::default(),
+            imports: IndexBitSet::new(modules.len()),
             generated_static_import_infos: FxHashMap::default(),
             re_export_all_dependencies: FxIndexSet::default(),
             generated_static_import_stmts_from_external: FxIndexMap::default(),
@@ -708,7 +708,7 @@ impl<'a> HmrStage<'a> {
             affected_module_idx_to_init_fn_name: &module_idx_to_init_fn_name,
             use_pife_for_module_wrappers,
             dependencies: FxIndexSet::default(),
-            imports: FxHashSet::default(),
+            imports: IndexBitSet::new(modules.len()),
             generated_static_import_infos: FxHashMap::default(),
             re_export_all_dependencies: FxIndexSet::default(),
             generated_static_import_stmts_from_external: FxIndexMap::default(),
@@ -899,7 +899,7 @@ impl<'a> HmrStage<'a> {
             affected_module_idx_to_init_fn_name: &module_idx_to_init_fn_name,
             use_pife_for_module_wrappers,
             dependencies: FxIndexSet::default(),
-            imports: FxHashSet::default(),
+            imports: IndexBitSet::new(modules.len()),
             generated_static_import_infos: FxHashMap::default(),
             re_export_all_dependencies: FxIndexSet::default(),
             generated_static_import_stmts_from_external: FxIndexMap::default(),

--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -12,6 +12,7 @@ pub type FinalizerMutableFields = (
 use oxc::ast_visit::VisitMut as _;
 use rolldown_ecmascript::EcmaAst;
 use rolldown_ecmascript_utils::AstSnippet;
+use rolldown_utils::IndexBitSet;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -67,12 +68,13 @@ impl<'me> ScopeHoistingFinalizerContext<'me> {
         .map(|idxs| idxs.into_iter().map(|idx| (idx, String::new())).collect::<FxIndexMap<_, _>>())
         .unwrap_or_default();
 
+      let modules_len = self.modules.len();
       let mut finalizer = ScopeHoistingFinalizer {
         alloc,
         ctx: self,
         scope: ast_scope,
         snippet: AstSnippet::new(alloc),
-        generated_init_esm_importee_ids: FxHashSet::default(),
+        generated_init_esm_importee_ids: IndexBitSet::new(modules_len),
         scope_stack: vec![],
         top_level_var_bindings: FxIndexSet::default(),
         state: TraverseState::empty(),

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -15,6 +15,7 @@ use oxc::span::CompactStr;
 use oxc_index::IndexVec;
 use rolldown_ecmascript::{EcmaAst, EcmaCompiler, PrintOptions};
 use rolldown_sourcemap::collapse_sourcemaps;
+use rolldown_utils::IndexBitSet;
 use rustc_hash::FxHashSet;
 use string_wizard::SourceMapOptions;
 
@@ -123,16 +124,16 @@ impl NormalModule {
   // https://tc39.es/ecma262/#sec-getexportednames
   pub fn get_exported_names<'modules>(
     &'modules self,
-    export_star_set: &mut FxHashSet<ModuleIdx>,
+    export_star_set: &mut IndexBitSet<ModuleIdx>,
     modules: &'modules IndexModules,
     include_default: bool,
     ret: &mut FxHashSet<&'modules CompactStr>,
   ) {
-    if export_star_set.contains(&self.idx) {
+    if export_star_set.has_bit(self.idx) {
       return;
     }
 
-    export_star_set.insert(self.idx);
+    export_star_set.set_bit(self.idx);
 
     self
       .star_export_module_ids()


### PR DESCRIPTION
Use `IndexBitSet` instead of `FxHashSet<*Idx>` for less memory usage and less hash calculation.