### PR TITLE
fix(cjs): bailout treeshaking on cjs modules that have multiple re-exports

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/8345/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8345/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "platform": "node"
+  },
+  "expectExecuted": true
+}

--- a/crates/rolldown/tests/rolldown/issues/8345/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8345/artifacts.snap
@@ -1,0 +1,45 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib/prod.js
+var require_prod = /* @__PURE__ */ __commonJSMin(((exports) => {
+	var a = 1;
+	var b = 2;
+	exports.a = a, exports.b = b;
+}));
+
+//#endregion
+//#region lib/dev.js
+var require_dev = /* @__PURE__ */ __commonJSMin(((exports) => {
+	var a = 1;
+	var b = 2;
+	exports.a = a;
+	exports.b = b;
+}));
+
+//#endregion
+//#region lib/index.js
+var require_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	if (process.env.NODE_ENV === "production") module.exports = require_prod();
+	else module.exports = require_dev();
+}));
+
+//#endregion
+//#region main.js
+const lib = require_lib();
+assert.strictEqual(typeof lib.a, "number", "lib.a should be a number");
+assert.strictEqual(typeof lib.b, "number", "lib.b should be a number");
+assert.strictEqual(lib.a, 1);
+assert.strictEqual(lib.b, 2);
+
+//#endregion
+export {  };
+```

--- a/crates/rolldown/tests/rolldown/issues/8345/lib/dev.js
+++ b/crates/rolldown/tests/rolldown/issues/8345/lib/dev.js
@@ -1,0 +1,5 @@
+'use strict';
+var a = 1;
+var b = 2;
+exports.a = a;
+exports.b = b;

--- a/crates/rolldown/tests/rolldown/issues/8345/lib/index.js
+++ b/crates/rolldown/tests/rolldown/issues/8345/lib/index.js
@@ -1,0 +1,6 @@
+'use strict';
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./prod.js');
+} else {
+  module.exports = require('./dev.js');
+}

--- a/crates/rolldown/tests/rolldown/issues/8345/lib/prod.js
+++ b/crates/rolldown/tests/rolldown/issues/8345/lib/prod.js
@@ -1,0 +1,4 @@
+'use strict';
+var a = 1;
+var b = 2;
+exports.a = a, exports.b = b;

--- a/crates/rolldown/tests/rolldown/issues/8345/main.js
+++ b/crates/rolldown/tests/rolldown/issues/8345/main.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert'
+
+// This tests that conditional CJS re-exports preserve exports from all branches.
+// When platform: "node", process.env.NODE_ENV is not defined, so both branches
+// of the conditional require are included. The exports from both branches must
+// be preserved (not tree-shaken).
+const lib = require('./lib/index.js')
+assert.strictEqual(typeof lib.a, 'number', 'lib.a should be a number')
+assert.strictEqual(typeof lib.b, 'number', 'lib.b should be a number')
+assert.strictEqual(lib.a, 1)
+assert.strictEqual(lib.b, 2)

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5202,6 +5202,10 @@ expression: output
 - component-!~{001}~.js => component-CixrEwhh.js
 - main-!~{000}~.js => main-BuFdI7Y3.js
 
+# tests/rolldown/issues/8345
+
+- main-!~{000}~.js => main-DPjwW0Tl.js
+
 # tests/rolldown/issues/duplicate_default_export
 
 - main-!~{000}~.js => main-D8FPxBSA.js


### PR DESCRIPTION
Details is explained in https://github.com/rolldown/rolldown/issues/8345#issuecomment-3908370251.


Fixes https://github.com/rolldown/rolldown/issues/8345.