### PR TITLE
docs(in-depth): remove `invalidImportSideEffects` option mention from lazy barrel optimization doc

### DIFF
--- a/docs/in-depth/lazy-barrel-optimization.md
+++ b/docs/in-depth/lazy-barrel-optimization.md
@@ -205,17 +205,6 @@ export { b } from './b';
 import { a } from './barrel'; // a.js is loaded even if `a` is never used
 ```
 
-To automatically remove unused import specifiers and avoid loading their modules, set `treeshake.invalidImportSideEffects` to `false`:
-
-```js
-// rolldown.config.js
-export default {
-  treeshake: {
-    invalidImportSideEffects: false,
-  },
-};
-```
-
 ### Own exports (non-pure re-export barrels)
 
 When a barrel module has its own exports (not just re-exports), all its import records must be loaded when any own export is used:


### PR DESCRIPTION
This doesn't seem to change the behavior.
https://stackblitz.com/edit/5wkhznr9?file=rolldown.config.ts
```
/home/projects/cgfxyubn--run/index.js
rolldown/runtime.js
/home/projects/cgfxyubn--run/barrel/index.js
/home/projects/cgfxyubn--run/barrel/b.js
/home/projects/cgfxyubn--run/barrel/a.js
```
