### PR TITLE
fix(rolldown_plugin_esm_external_require): apply conversion to UMD and IIFE outputs

### DIFF
--- a/crates/rolldown_plugin_esm_external_require/src/lib.rs
+++ b/crates/rolldown_plugin_esm_external_require/src/lib.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use nodejs_built_in_modules::is_nodejs_builtin_module;
-use rolldown_common::{ImportKind, ResolvedExternal};
+use rolldown_common::{ImportKind, OutputFormat, ResolvedExternal};
 use rolldown_plugin::{HookLoadOutput, HookResolveIdOutput, HookUsage, Plugin};
 use rolldown_utils::{concat_string, pattern_filter::StringOrRegex, rustc_hash::FxHashSetExt as _};
 use rustc_hash::FxHashSet;
@@ -109,7 +109,7 @@ impl Plugin for EsmExternalRequirePlugin {
     });
 
     if is_external {
-      if !ctx.options().format.is_esm() || args.kind != ImportKind::Require {
+      if matches!(ctx.options().format, OutputFormat::Cjs) || args.kind != ImportKind::Require {
         return Ok(Some(HookResolveIdOutput {
           id: args.specifier.into(),
           external: Some(ResolvedExternal::Bool(true)),

--- a/packages/rolldown/tests/fixtures/builtin-plugin/esm-external-require-plugin/iife-output/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/esm-external-require-plugin/iife-output/_config.ts
@@ -1,0 +1,17 @@
+import { defineTest } from 'rolldown-tests';
+import { esmExternalRequirePlugin } from 'rolldown/plugins';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    output: {
+      format: 'iife',
+    },
+    plugins: [esmExternalRequirePlugin({ external: ['ext'] })],
+  },
+  async afterTest(output) {
+    const code = output.output[0].code;
+    expect(code).toContain('function(ext)');
+    expect(code).toContain('module.exports = { ...ext }');
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/esm-external-require-plugin/iife-output/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/esm-external-require-plugin/iife-output/main.js
@@ -1,0 +1,2 @@
+const ext = require('ext');
+console.log(ext);

--- a/packages/rolldown/tests/fixtures/builtin-plugin/esm-external-require-plugin/umd-output/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/esm-external-require-plugin/umd-output/_config.ts
@@ -1,0 +1,17 @@
+import { defineTest } from 'rolldown-tests';
+import { esmExternalRequirePlugin } from 'rolldown/plugins';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    output: {
+      format: 'umd',
+    },
+    plugins: [esmExternalRequirePlugin({ external: ['ext'] })],
+  },
+  async afterTest(output) {
+    const code = output.output[0].code;
+    expect(code).toContain("define(['ext']");
+    expect(code).toContain('module.exports = { ...ext }');
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/esm-external-require-plugin/umd-output/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/esm-external-require-plugin/umd-output/main.js
@@ -1,0 +1,2 @@
+const ext = require('ext');
+console.log(ext);


### PR DESCRIPTION
`require` is left as-is for https://rolldown.rs/in-depth/bundling-cjs#require-external-modules for UMD output  and IIFE output ([REPL UMD](https://repl.rolldown.rs/#eNptkMFuwyAMhl/F4kIqRfQeaac9xrIDSUzLREwHZssU8e5z6NZdJiHAn3//lr0rp4ZdeVpwM2/5+JMa/uJezRLOkTJDQjszPMn7XnzCTjegT2Ma6VDEgCbES9dwo1KOauBUsPYqxRCW+ElGtM5fDD+6/ZO59/XrLSaGHRZ0nvC5paGCS3EF/VumRxoJtyYVoS2hvY+Cbh8JwNOt8AB3S7MiW9NQD+cz8BXB+YAZMgacGReYvhqdCnMkkCNTXYHtdJjFws2tOQO4mFYroS7rovuD1XbjxpjIhgFefpb1KryeZDNVNvIhIwbLmFnVb1kKh3g=), [REPL IIFE](https://repl.rolldown.rs/#eNptUEFuxCAM/IrFhawUsfdIPfUZpQeSmF0qYrbEtKki/l7ibbeXSgjb4/FYnl15Newq0IybeVuPnNTwV/dqauWUaGXI6CaGpxbfS8jYaQH0yWZLByNFNDFdOoEFbeOoBs4Fa69yinFOn2Qa14eL4ce2fzr3vWG5pcyww4w+ED5LGyr4nBbQv2PakiXchNqIrkSJj4FutwQQ6FZ4gLukWZCdEaiH8xn4iuBDxBVWjDgxzjB+CToW5kTQXrvqCuzGQywVFjVRBvApL66VOgSPuj/AKj9ujJlcHODlx61XS/XUnKnNkY92YnSMK6v6DV2Ph6M=)). That said, there's no way to achieve the on-demand execution semantics of `require` in AMD and IIFE, and thus it's not possible to achieve that in UMD as well.

This means we cannot add support internally like we do with CJS output and the user has to handle these cases. However, the `esmExternalRequirePlugin` only did the require -> import conversion for ESM outputs ([REPL UMD](https://repl.rolldown.rs/#eNp1UbFOxDAM/RUrS+6kqrcXMSF2xEoZcq17F5Q6JXGgqOq/k7qlDHBSFMfP7/k5yaQ6VU3KUotj+RaXM6nqNy9Uk9PGU2QIaBqG+xzfkw140ALoYx1qWhjeYen85SCwoFmOquKQcC5U8M61/pPKzO3speTd7Z/K6mv7wQeGCVrsLOGDlGGGLvge9I9M17QTMfaPI2Mg457XMZ9culj6IzoNgkd9V1NNOIo+25jkJO52h6kmAEtD4gpWn7JHNqVABZxOwFeEzjqMENFhw9jC+UvQc2L2BHnlN7kCm/PSzCeWbtIZoPOhNznVqW91sWCz7NuEFbysvFt3WycUxlbOku1zXtfSfFxiTpaDmvNvfOTndYYxspq/Ae6Ts1U=), [REPL IIFE](https://repl.rolldown.rs/#eNp1UcFOwzAM/RUrl2xS1d2LOCHuiCvlkLXOFpQ6I3FgqOq/k7qlHGBSFMfP7/k5yaisakblqMdr/ZbmM6nmN69UV9IuUGKIaDqG+xLfs4u40wLofRtbmhnBY+3DaSewoEWOquGYcapUDN734ZPqwrXuVPPm9k9l8XXDJUSGEXq0jvBByjCBjWEA/SPTLW1ETMPjlTGS8c/LmE8+nxz9ER0ugid911JLeBV9sTHZS9zsdmNLAI4umRtYfOoB2dQCVXA4AJ8RrPOYIKHHjrGH45egx8wcCMoqb3IGNse5Wcgs3aQzgA1xMCXVzlnU1QxOsq8jNvCyEG9dbhlRGGu5SNbfeV1K036OJZkPairf8VHe1xvGxGr6BqPos6w=)).

This PR changes the `esmExternalRequirePlugin` to also handle UMD output and IIFE output.

fixes https://github.com/rolldown/rolldown/issues/8349
