### PR TITLE
ci(prepare-release): skip workflow on forked repositories

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   prepare:
     name: Prepare Release
+    if: github.repository == 'rolldown/rolldown'
     runs-on: ubuntu-latest
     permissions:
       contents: write # for create-pull-request


### PR DESCRIPTION
Previously, forked repositories running the scheduled release workflow would create pull requests that requested reviews from maintainers. While the existing forks appear to have been cleaned up, this guard ensures it won't happen again.   