### PR TITLE
test: use `vi.waitFor` and `expect.poll` instead of custom `waitUtil` function

### DIFF
--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -2,8 +2,8 @@ import { stripAnsi } from 'consola/utils';
 import { $, execa } from 'execa';
 import fs from 'node:fs';
 import path from 'node:path';
-import { testsDir, waitUtil } from 'rolldown-tests/utils';
-import { describe, expect, it, test } from 'vitest';
+import { testsDir } from 'rolldown-tests/utils';
+import { describe, expect, it, test, vi } from 'vitest';
 
 function cliFixturesDir(...joined: string[]) {
   return testsDir('cli/fixtures', ...joined);
@@ -328,7 +328,7 @@ describe('watch cli', () => {
       reject: false,
       cancelSignal: controller.signal,
     })`rolldown index.ts -d dist -w -s`;
-    await waitUtil(() => {
+    await vi.waitFor(() => {
       expect(fs.existsSync(path.join(cwd, 'dist'))).toBe(true);
       expect(fs.existsSync(path.join(cwd, 'dist/index.js.map'))).toBe(true);
     });
@@ -343,7 +343,7 @@ describe('watch cli', () => {
       reject: false,
       cancelSignal: controller.signal,
     })`rolldown -c rolldown.config.ts -d watch-dist-options -w`;
-    await waitUtil(() => {
+    await vi.waitFor(() => {
       expect(fs.existsSync(path.join(cwd, 'watch-dist-options/esm.js'))).toBe(true);
       expect(fs.existsSync(path.join(cwd, 'watch-dist-options/cjs.js'))).toBe(true);
     });
@@ -358,7 +358,7 @@ describe('watch cli', () => {
       reject: false,
       cancelSignal: controller.signal,
     })`rolldown -c rolldown.config.ts -d watch-dist-output -w`;
-    await waitUtil(() => {
+    await vi.waitFor(() => {
       expect(fs.existsSync(path.join(cwd, 'watch-dist-output/esm.js'))).toBe(true);
       expect(fs.existsSync(path.join(cwd, 'watch-dist-output/cjs.js'))).toBe(true);
     });

--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -91,14 +91,3 @@ export function getLocation(source: string, search: string | number) {
 
   throw new Error('Could not determine location of character');
 }
-
-export async function waitUtil(expectFn: () => void) {
-  for (let tries = 0; tries < 20; tries++) {
-    try {
-      expectFn();
-      return;
-    } catch {}
-    await sleep(50);
-  }
-  expectFn();
-}


### PR DESCRIPTION
Use `vi.waitFor` and `expect.poll` instead of custom `waitUtil` function so that the error message is more clear.