### PR TITLE
fix(dev): avoid mutex deadlock caused by inconsistent lock order

### DIFF
--- a/crates/rolldown_dev/src/dev_engine.rs
+++ b/crates/rolldown_dev/src/dev_engine.rs
@@ -263,11 +263,11 @@ impl DevEngine {
     first_invalidated_by: Option<String>,
   ) -> BuildResult<Vec<ClientHmrUpdate>> {
     self.create_error_if_closed()?;
+    let mut bundler = self.bundler.lock().await;
 
     // Use bundler directly for invalidation (avoid message roundtrip)
     let mut updates = Vec::new();
     for client in self.clients.iter() {
-      let mut bundler = self.bundler.lock().await;
       let update = bundler
         .compute_update_for_calling_invalidate(
           caller.clone(),
@@ -306,6 +306,7 @@ impl DevEngine {
     client_id: String,
   ) -> BuildResult<String> {
     self.create_error_if_closed()?;
+    let mut bundler = self.bundler.lock().await;
 
     // Get executed modules for this client
     let executed_modules =
@@ -314,7 +315,6 @@ impl DevEngine {
     // Mark the proxy module as fetched BEFORE compilation.
     // This changes the content returned by the lazy compilation plugin's load hook
     // from a stub (fetches via /lazy endpoint) to actual code that imports the real module.
-    let mut bundler = self.bundler.lock().await;
     if let Some(lazy_ctx) = &bundler.lazy_compilation_context {
       lazy_ctx.mark_as_fetched(&proxy_module_id);
     }


### PR DESCRIPTION
The lock order of `bundler` and `clients` were inconsistent. This potentially causes deadlocks (e.g. when one thread locks `bundler` and another thread locks `clients`).

- `bundler` -> `clients`
  - https://github.com/rolldown/rolldown/blob/11424ab221410a0661f473795695a1ed3084528f/crates/rolldown_dev/src/bundling_task.rs#L128-L138
- `clients` -> `bundler`
  - https://github.com/rolldown/rolldown/blob/11424ab221410a0661f473795695a1ed3084528f/crates/rolldown_dev/src/dev_engine.rs#L269-L270
  - https://github.com/rolldown/rolldown/blob/11424ab221410a0661f473795695a1ed3084528f/crates/rolldown_dev/src/dev_engine.rs#L310-L317

This PR changes all to `bundler` -> `clients`.

