### PR TITLE
fix: `deferred_scan_data.rs "Should have resolved id: NotFound"` error

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -218,13 +218,7 @@ impl Bundle {
     if is_full_scan_mode {
       let mut output: NormalizedScanStageOutput =
         output.try_into().expect("Should be able to convert to NormalizedScanStageOutput");
-      defer_sync_scan_data(
-        &self.options,
-        &self.resolver,
-        &self.cache.module_id_to_idx,
-        &mut output,
-      )
-      .await?;
+      defer_sync_scan_data(&self.options, &self.cache.module_id_to_idx, &mut output).await?;
       if is_incremental {
         self.cache.set_snapshot(output.make_copy());
       }
@@ -232,7 +226,7 @@ impl Bundle {
     }
 
     self.cache.merge(output)?;
-    self.cache.update_defer_sync_data(&self.options, &self.resolver).await?;
+    self.cache.update_defer_sync_data(&self.options).await?;
     Ok(self.cache.create_output())
   }
 

--- a/crates/rolldown/src/hmr/hmr_stage.rs
+++ b/crates/rolldown/src/hmr/hmr_stage.rs
@@ -286,8 +286,7 @@ impl<'a> HmrStage<'a> {
       self.cache.merge(module_loader_output.into())?;
 
       let options = Arc::clone(&self.options);
-      let resolver = Arc::clone(&self.resolver);
-      self.cache.update_defer_sync_data(&options, &resolver).await?;
+      self.cache.update_defer_sync_data(&options).await?;
       new_added_modules
     };
 
@@ -380,8 +379,7 @@ impl<'a> HmrStage<'a> {
     self.cache.merge(module_loader_output.into()).map_err(|e| vec![anyhow::anyhow!(e).into()])?;
 
     let options = Arc::clone(&self.options);
-    let resolver = Arc::clone(&self.resolver);
-    self.cache.update_defer_sync_data(&options, &resolver).await?;
+    self.cache.update_defer_sync_data(&options).await?;
 
     // Collect all sync dependencies, stopping at already-executed modules.
     // This ensures each client gets exactly the modules they need, regardless of what other clients have loaded (session-scoped cache vs client-scoped state).
@@ -619,8 +617,7 @@ impl<'a> HmrStage<'a> {
         .extend(module_loader_output.new_added_modules_from_partial_scan.clone());
       self.cache.merge(module_loader_output.into())?;
       let options = Arc::clone(&self.options);
-      let resolver = Arc::clone(&self.resolver);
-      self.cache.update_defer_sync_data(&options, &resolver).await?;
+      self.cache.update_defer_sync_data(&options).await?;
 
       // Note: New added modules might include external modules. There's no way to "update" them, so we need to remove them.
       modules_to_be_updated.retain(|idx| self.module_table().modules[*idx].is_normal());

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -10,7 +10,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use sugar_path::SugarPath;
 
 use crate::{
-  SharedOptions, SharedResolver,
+  SharedOptions,
   module_loader::{deferred_scan_data::defer_sync_scan_data, module_loader::VisitState},
   stages::scan_stage::{NormalizedScanStageOutput, ScanStageOutput},
 };
@@ -46,14 +46,10 @@ impl ScanStageCache {
     self.snapshot.take()
   }
 
-  pub async fn update_defer_sync_data(
-    &mut self,
-    options: &SharedOptions,
-    resolver: &SharedResolver,
-  ) -> BuildResult<()> {
+  pub async fn update_defer_sync_data(&mut self, options: &SharedOptions) -> BuildResult<()> {
     let snapshot = self.take_snapshot();
     if let Some(mut snapshot) = snapshot {
-      defer_sync_scan_data(options, resolver, &self.module_id_to_idx, &mut snapshot).await?;
+      defer_sync_scan_data(options, &self.module_id_to_idx, &mut snapshot).await?;
       self.set_snapshot(snapshot);
     }
     Ok(())

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy4/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy4/_config.ts
@@ -1,0 +1,43 @@
+import path from 'node:path';
+import type { OutputChunk as RolldownOutputChunk } from 'rolldown';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'loader',
+        resolveId(id, importer) {
+          if (importer?.includes('foo.js') && id === 'virtual') {
+            return { id: '\0virtual', moduleSideEffects: false };
+          }
+        },
+        load(id) {
+          if (id === '\0virtual') {
+            return 'console.log("sideeffects")';
+          }
+        },
+        async transform(code, id) {
+          if (id.includes('bar.js')) {
+            const fooPath = path.resolve(import.meta.dirname, 'foo.js');
+            const resolved = await this.resolve('virtual', fooPath, { skipSelf: false });
+            await this.load({ id: resolved!.id }); // ensure moduleInfo for `virtual` exists
+            const moduleInfo = this.getModuleInfo(resolved!.id);
+            moduleInfo!.moduleSideEffects = true;
+          }
+          return {
+            code,
+          };
+        },
+      },
+    ],
+  },
+  afterTest: (output) => {
+    output.output
+      .filter((chunk): chunk is RolldownOutputChunk => chunk.type === 'chunk')
+      .forEach((chunk) => {
+        expect(chunk.code).toContain('sideeffects');
+      });
+  },
+});

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy4/foo.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy4/foo.js
@@ -1,0 +1,1 @@
+import 'virtual';

--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy4/main.js
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy4/main.js
@@ -1,0 +1,2 @@
+import './foo.js';
+import './bar.js';


### PR DESCRIPTION
We shouldn't re-resolve here because there's no guarantee that the resovle id is resolved to the same id.

fixes #8236
close #8238
