### PR TITLE
test: disable `mockReset` option

### DIFF
--- a/packages/rolldown/tests/vitest.config.mts
+++ b/packages/rolldown/tests/vitest.config.mts
@@ -5,7 +5,6 @@ export default defineConfig({
   test: {
     testTimeout: 20000,
     disableConsoleIntercept: true,
-    mockReset: true,
     pool: 'forks',
   },
   resolve: {


### PR DESCRIPTION
I guess `mockReset: true` will break things: https://github.com/vitest-dev/vitest/pull/9697