### PR TITLE
test: avoid `expect.assertions()` as it is not concurrent test friendly

### DIFF
--- a/packages/rolldown/tests/fixtures/plugin/transform/basic/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/basic/_config.ts
@@ -4,14 +4,14 @@ import { expect, vi } from 'vitest';
 const transformFn = vi.fn();
 
 export default defineTest({
-  sequential: true,
   config: {
     plugins: [
       {
         name: 'test-plugin',
         transform: function (code, id, meta) {
-          transformFn();
-          if (id.endsWith('foo.js')) {
+          const isFooJS = id.endsWith('foo.js');
+          transformFn(isFooJS);
+          if (isFooJS) {
             expect(code).toStrictEqual('');
             expect(meta.moduleType).toEqual('js');
             return {
@@ -22,9 +22,9 @@ export default defineTest({
       },
     ],
   },
-  afterTest: (output) => {
-    expect.assertions(4);
+  afterTest(output) {
     expect(transformFn).toHaveBeenCalledTimes(3);
+    expect(transformFn.mock.calls.filter((args) => args[0] === true).length).toBe(1);
     expect(output.output[0].code).contains('transformed');
   },
 });


### PR DESCRIPTION
`expect.assertions` doesn't work with concurrent tests unless local `expect` is used: https://vitest.dev/api/expect.html#expect-assertions:~:text=When%20using%20assertions%20with%20async%20concurrent%20tests%2C%20expect%20from%20the%20local%20Test%20Context%20must%20be%20used%20to%20ensure%20the%20right%20test%20is%20detected.