### PR TITLE
chore: ban `expect.assertions` in fixture tests

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["import", "jsdoc", "unicorn", "typescript", "oxc"],
+  "jsPlugins": ["./scripts/lint/index.ts"],
   "ignorePatterns": [
     "crates/**",
     "packages/rollup-tests/**",
@@ -67,6 +68,12 @@
             "allow": ["warn", "error", "debug", "info"]
           }
         ]
+      }
+    },
+    {
+      "files": ["**/packages/rolldown/tests/fixtures/context/default-value/_config.ts"],
+      "rules": {
+        "rolldown-custom/ban-expect-assertions": "error"
       }
     }
   ]

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -88,7 +88,7 @@
       "entry": ["**/*.{test,spec}.{js,ts}"],
     },
     "scripts": {
-      "entry": ["misc/**"],
+      "entry": ["misc/**", "lint/index.ts"],
     },
     "packages/test-dev-server/tests/fixtures/*": {
       "entry": ["dev.config.mjs", "src/*.js"], // no @rolldown/test-dev-server plugin

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -857,6 +857,9 @@ importers:
       '@oxc-node/cli':
         specifier: 'catalog:'
         version: 0.0.35
+      '@oxlint/plugins':
+        specifier: ^1.48.0
+        version: 1.48.0
       acorn:
         specifier: 'catalog:'
         version: 8.15.0
@@ -3296,6 +3299,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@oxlint/plugins@1.48.0':
+    resolution: {integrity: sha512-kbvtiYwCR0kKUks/UYAsFV/o2jkEnJFTnhcOiU/E23x8TgRSSm6XnA24fmBU1uibxXjw8DU9yT3hS/Gq32/LNw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@peggyjs/from-mem@3.1.1':
     resolution: {integrity: sha512-m5OEjgJaePWpyNtQCvRZkpLoV+z44eh6QIO9yEwQuOThdUdkECO3wcKLT3tFA3H8WM5bxU/K/dpmo7r/X16UEw==}
@@ -8696,6 +8703,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.48.0':
     optional: true
+
+  '@oxlint/plugins@1.48.0': {}
 
   '@peggyjs/from-mem@3.1.1':
     dependencies:

--- a/scripts/lint/index.ts
+++ b/scripts/lint/index.ts
@@ -1,0 +1,32 @@
+import { eslintCompatPlugin, type CreateOnceRule, type VisitorWithHooks } from '@oxlint/plugins';
+
+const banExpectAssertionsRule: CreateOnceRule = {
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' &&
+          node.callee.object.name === 'expect' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'assertions'
+        ) {
+          context.report({
+            message:
+              'Fixture tests run concurrently and `expect.assertions` does not work with global expect. Use `vi.fn()` instead.',
+            node,
+          });
+        }
+      },
+    } as VisitorWithHooks;
+  },
+};
+
+export default eslintCompatPlugin({
+  meta: {
+    name: 'rolldown-custom',
+  },
+  rules: {
+    'ban-expect-assertions': banExpectAssertionsRule,
+  },
+});

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@oxc-node/cli": "catalog:",
+    "@oxlint/plugins": "^1.48.0",
     "acorn": "catalog:",
     "astring": "catalog:",
     "diff": "catalog:",


### PR DESCRIPTION
To catch https://github.com/rolldown/rolldown/pull/8383