### PR TITLE
docs: avoid pipe character in codeSplitting example to fix broken rendering

### DIFF
--- a/packages/rolldown/src/options/docs/output-code-splitting.md
+++ b/packages/rolldown/src/options/docs/output-code-splitting.md
@@ -12,7 +12,7 @@ export default defineConfig({
         },
         {
           name: 'ui-vendor',
-          test: /node_modules[\\/](antd|@mui)/,
+          test: /node_modules[\\/]antd/,
           priority: 15,
         },
         {


### PR DESCRIPTION
Closed #8380

The root cause: when typedoc processes `{@include}` content, it re-parses it as a JSDoc comment. The `|` character inside the included markdown gets URL-encoded to `%7C` during this process (typedoc's inline tag handling interprets `|` specially). Since the pipe was inside a code block in the markdown, it shouldn't have been modified, but typedoc's JSDoc parser mangles it before the markdown code block structure is recognized. Avoiding `|` in `@include`-d files sidesteps this typedoc limitation.
