### PR TITLE
docs(reference): add `Exported from` for values / types exported from subpath exports

### DIFF
--- a/docs/.vitepress/scripts/generate-reference.ts
+++ b/docs/.vitepress/scripts/generate-reference.ts
@@ -45,9 +45,9 @@ async function runTypedoc(entryPoints: string[]): Promise<void> {
     plugin: [
       'typedoc-plugin-markdown',
       'typedoc-vitepress-theme',
+      path.join(import.meta.dirname, 'custom-theme-plugin.ts'),
       'typedoc-plugin-merge-modules',
       path.join(import.meta.dirname, 'extract-options-plugin.ts'),
-      path.join(import.meta.dirname, 'custom-theme-plugin.ts'),
     ],
     theme: 'customTheme',
     out: './reference',


### PR DESCRIPTION
<img width="736" height="330" alt="image" src="https://github.com/user-attachments/assets/816a08ac-63b8-4bf0-b7fb-4583bf231199" />
