### PR TITLE
test: add retry to tree-shake/module-side-effects-proxy4 as it is flaky

### DIFF
--- a/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy4/_config.ts
+++ b/packages/rolldown/tests/fixtures/tree-shake/module-side-effects-proxy4/_config.ts
@@ -4,6 +4,7 @@ import { defineTest } from 'rolldown-tests';
 import { expect } from 'vitest';
 
 export default defineTest({
+  retry: 3, // FIXME: retry added to mitigate flakiness, see https://github.com/rolldown/rolldown/pull/8397
   config: {
     plugins: [
       {


### PR DESCRIPTION
Not sure why but it seems this test is flaky.
https://github.com/rolldown/rolldown/actions/runs/22212800156/job/64250643931#step:18:817
