### PR TITLE
test: execute `_test.mjs` even if `executeOutput` is false

### DIFF
--- a/crates/rolldown/tests/rolldown/function/dir/should_generate_correct_relative_import_path/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/dir/should_generate_correct_relative_import_path/_test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { value, asyncValue } from './dist/lib/entries/a.js';
-import { value as value2, asyncValue as asyncValue2 } from './dist/lib/entries/b.js';
+import { value, asyncValue } from './dist/lib/entries/a.mjs';
+import { value as value2, asyncValue as asyncValue2 } from './dist/lib/entries/b.mjs';
 
 assert.strictEqual(value, value2);
 assert.strictEqual(await asyncValue, await asyncValue2);

--- a/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_correct_relative_import_path/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/entry_filenames/should_generate_correct_relative_import_path/_test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { value, asyncValue } from './dist/entries/a.js';
-import { value as value2, asyncValue as asyncValue2 } from './dist/entries/b.js';
+import { value, asyncValue } from './dist/entries/a.mjs';
+import { value as value2, asyncValue as asyncValue2 } from './dist/entries/b.mjs';
 
 assert.strictEqual(value, value2);
 assert.strictEqual(await asyncValue, await asyncValue2);

--- a/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4944/_test.mjs
+++ b/crates/rolldown/tests/rolldown/misc/preserve_modules/issue_4944/_test.mjs
@@ -1,4 +1,4 @@
-import { assert } from 'node:test';
+import assert from 'node:assert';
 import { b } from './dist/a/index.js';
 
 assert.strictEqual(b, 2, 'b should be 2');

--- a/crates/rolldown/tests/rolldown/sourcemap/debug_ids/_test.mjs
+++ b/crates/rolldown/tests/rolldown/sourcemap/debug_ids/_test.mjs
@@ -1,15 +1,14 @@
-const require = (await import('node:module')).createRequire(import.meta.url);
-const fs = require('node:fs');
-const assert = require('node:assert');
-const path = require('node:path');
+import fs from 'node:fs';
+import assert from 'node:assert';
+import path from 'node:path';
 
-const source = fs.readFileSync(path.resolve(__dirname, 'dist/assets/main.js'), 'utf8');
+const source = fs.readFileSync(path.resolve(import.meta.dirname, 'dist/assets/main.js'), 'utf8');
 const match = source.match(/\/\/# debugId=([a-fA-F0-9-]+)/);
 
 assert.ok(match, 'Could not find debugId in source');
 const sourceDebugId = match[1];
 
 const sourceMap = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, 'dist/assets/main.js.map'), 'utf8'),
+  fs.readFileSync(path.resolve(import.meta.dirname, 'dist/assets/main.js.map'), 'utf8'),
 );
 assert.equal(sourceMap.debugId, sourceDebugId, 'debugId mismatch');


### PR DESCRIPTION
The behavior was not aligned with this comment:
https://github.com/rolldown/rolldown/blob/f94dbcc68e79244542bac01d6cb13aa46e004738/crates/rolldown_testing_config/src/test_meta.rs#L11