### PR TITLE
perf: use flag-based convergence detection in include_statements

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -906,6 +906,7 @@ impl GenerateStage<'_> {
       normal_symbol_exports_chain_map: &self.link_output.normal_symbol_exports_chain_map,
       bailout_cjs_tree_shaking_modules: FxHashSet::default(),
       may_partial_namespace: false,
+      module_inclusion_changed: false,
       module_namespace_included_reason: &mut module_namespace_reason_vec,
       inline_const_smart: self.options.optimization.is_inline_const_smart_mode(),
       json_module_none_self_reference_included_symbol: FxHashMap::default(),


### PR DESCRIPTION
Replace O(N) linear scan of is_module_included_vec per convergence
iteration with a boolean flag (module_inclusion_changed) that is set
when include_module() transitions a module to included. This avoids
scanning ~19K entries on every loop iteration to detect fixpoint.

Benchmark (10K module project, 15 runs):
- System time: 2.68s -> 2.52s (-5.9%)
- Wall clock: 4.42s -> 4.41s (-0.2%)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior should be unchanged (only alters fixpoint detection), but mistakes could cause premature termination and missed module inclusion in tree-shaking.
> 
> **Overview**
> Speeds up tree-shaking convergence in `include_statements` by replacing per-iteration O(N) scans of `is_module_included_vec` with a `module_inclusion_changed` flag that is reset each loop and set when `include_module` newly includes a module.
> 
> Extends `IncludeContext` (and its construction sites, including `chunk_optimizer`) to carry this flag so the dynamic-entry inclusion loop can stop at fixpoint without counting included modules each iteration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50910e26f3ea85c8ef915b606e199b0d49fb92ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->