### PR TITLE
refactor: unify tsconfig discovery to share resolver cache

### DIFF
--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -327,7 +327,7 @@ pub fn prepare_build_context(
     // - Auto: Create Raw mode (will resolve tsconfig per file)
     // - None/Manual: Create Normal mode (resolve tsconfig once now)
     match tsconfig {
-      ref v @ TsConfig::Manual(ref path) => {
+      TsConfig::Manual(ref path) => {
         // Manual mode: Resolve tsconfig now and create Normal mode
         let resolved_tsconfig = resolver.resolve_tsconfig(&path).map_err(|err| {
           anyhow::anyhow!("Failed to resolve `tsconfig` option: {}", path.display()).context(err)
@@ -344,18 +344,18 @@ pub fn prepare_build_context(
           )
         } else {
           TransformOptions::new_raw(
-            RawTransformOptions::new(raw_transform_options, v.clone()),
+            RawTransformOptions::new(raw_transform_options, Arc::clone(&resolver) as _),
             target,
             jsx_preset,
           )
         })
       }
-      v @ TsConfig::Auto(is_auto) => {
+      TsConfig::Auto(is_auto) => {
         Box::new(if is_auto {
           // Auto mode: Create Raw mode TransformOptions
           // Each file will find its nearest tsconfig during compilation
           TransformOptions::new_raw(
-            RawTransformOptions::new(raw_transform_options, v),
+            RawTransformOptions::new(raw_transform_options, Arc::clone(&resolver) as _),
             target,
             jsx_preset,
           )

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -81,7 +81,7 @@ pub mod bundler_options {
         TransformOptions as BundlerTransformOptions, TypeScriptOptions,
       },
       transform_options::{
-        JsxPreset, RawTransformOptions, TransformOptions, TransformOptionsInner,
+        JsxPreset, RawTransformOptions, TransformOptions, TransformOptionsInner, TsconfigFinder,
         merge_transform_options_with_tsconfig,
       },
       treeshake::{

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -12,7 +12,7 @@ use oxc_resolver::{
 };
 use rolldown_common::{
   ImportKind, ModuleDefFormat, ModuleId, PackageJson, Platform, ResolveOptions, ResolvedId,
-  TsConfig,
+  TsConfig, TsconfigFinder,
 };
 use rolldown_fs::{FileSystem, OsFileSystem};
 use rolldown_utils::dashmap::FxDashMap;
@@ -212,6 +212,12 @@ impl<Fs: FileSystem> Resolver<Fs> {
     let specifier_path = self.cwd.join(specifier).normalize();
     let fallback = resolver.resolve(importer_dir, &specifier_path.to_string_lossy());
     if fallback.is_ok() { fallback } else { original_resolution }
+  }
+}
+
+impl<Fs: FileSystem + Send + Sync> TsconfigFinder for Resolver<Fs> {
+  fn find_tsconfig(&self, path: &Path) -> Result<Option<Arc<OxcTsConfig>>, ResolveError> {
+    self.default_resolver.find_tsconfig(path)
   }
 }
 


### PR DESCRIPTION
Replace RawTransformOptions' private oxc_resolver::Resolver with a
TsconfigFinder trait object backed by the main bundler resolver.
This eliminates a redundant resolver instance and shares the
find_tsconfig cache between module resolution and transformation,
avoiding duplicate directory walks when auto-discovering tsconfig.json.

The performance benefit depends on the project having tsconfig.json
files with auto-discovery enabled (the default). Projects without
tsconfig.json or using explicit tsconfig paths see no measurable
difference.

Verified against in-repo criterion benchmarks (threejs, threejs10x)
and external rolldown-benchmark/apps/10000: no statistically
significant change detected (criterion p > 0.3, hyperfine within
noise). These benchmarks either lack tsconfig.json files or use
explicit manual tsconfig paths, so the shared cache is not exercised.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tsconfig discovery/caching and how per-file transform options are derived, which can subtly affect builds in projects with multiple/edge-case `tsconfig.json` layouts. The change is mostly a refactor with the same discovery API, but it alters cache ownership and object lifetimes.
> 
> **Overview**
> Refactors transform-phase tsconfig discovery to reuse the main bundler resolver’s cached `find_tsconfig` results instead of constructing a separate `oxc_resolver::Resolver` inside `RawTransformOptions`.
> 
> Introduces a `TsconfigFinder` trait (exported via `rolldown_common`) implemented by `rolldown_resolver::Resolver`, updates `RawTransformOptions` to hold an `Arc<dyn TsconfigFinder>`, and wires `prepare_build_context` to pass the shared resolver into `TransformOptions::new_raw` for `TsConfig::Auto` and referenced `TsConfig::Manual` cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 154a9247329f671f168d75fb12e7fa8c7e7599cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->