### PR TITLE
feat(rust): support `PluginOrder::PinPost`

### DIFF
--- a/crates/rolldown_plugin/src/plugin_driver/hook_orders.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/hook_orders.rs
@@ -118,6 +118,7 @@ impl PluginHookOrders {
   ) -> Vec<PluginIdx> {
     let mut pre_plugins = Vec::new();
     let mut post_plugins = Vec::new();
+    let mut pin_post_plugins = Vec::new();
     let mut normal_plugins = Vec::with_capacity(index_plugins.len());
     for (idx, plugin) in index_plugins.iter_enumerated() {
       let Some(meta) = get_hook_meta(idx, plugin) else { continue };
@@ -126,10 +127,13 @@ impl PluginHookOrders {
         Some(meta) => match meta.order {
           Some(PluginOrder::Pre) => pre_plugins.push(idx),
           Some(PluginOrder::Post) => post_plugins.push(idx),
+          Some(PluginOrder::PinPost) => pin_post_plugins.push(idx),
           None => normal_plugins.push(idx),
         },
       }
     }
-    [pre_plugins, normal_plugins, post_plugins].concat()
+    // Reverse so first-seen plugin runs last (pinned to the very end)
+    pin_post_plugins.reverse();
+    [pre_plugins, normal_plugins, post_plugins, pin_post_plugins].concat()
   }
 }

--- a/crates/rolldown_plugin/src/types/plugin_hook_meta.rs
+++ b/crates/rolldown_plugin/src/types/plugin_hook_meta.rs
@@ -2,6 +2,9 @@
 pub enum PluginOrder {
   Pre,
   Post,
+  /// Runs after all `Post` hooks. Unlike `Post`, earlier plugins run later —
+  /// so a plugin registered first is guaranteed to run last.
+  PinPost,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Add `PluginOrder::PinPost` — a fourth ordering bucket that runs after all `Post` hooks with reversed array order (first declared runs last).

This lets a prepended builtin plugin's hook reliably run after all user `Post` hooks, which is impossible with `Pre`/`Post` alone since array position is the tiebreaker within each bucket.

---

I didn't expose this in ts api, we could do that if users need it.

Closes #8416