### PR TITLE
feat(rust/data-url): use hash as id for data url modules to prevent long string overhead

### DIFF
--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_application_json/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_application_json/artifacts.snap
@@ -6,28 +6,28 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#region <data:application/json,"%31%32%33">
-var json___31_32_33__default = "123";
+//#region \0rolldown/data-url:2sIfhqSWlzaAHOZh4OtugA
+var data_url_2sIfhqSWlzaAHOZh4OtugA_default = "123";
 
 //#endregion
-//#region <data:application/json;base64,eyJ3b3JrcyI6dHJ1ZX0=>
-var json_base64_eyJ3b3JrcyI6dHJ1ZX0__default = { works: true };
+//#region \0rolldown/data-url:Zc9opCw73EFYe8tLmXMbQA
+var data_url_Zc9opCw73EFYe8tLmXMbQA_default = { works: true };
 
 //#endregion
-//#region <data:application/json;charset=UTF-8,%31%32%33>
-var json_charset_UTF_8__31_32_33_default = 123;
+//#region \0rolldown/data-url:2aX92f-tk6SUzQNEPgBe-w
+var data_url_2aX92f_tk6SUzQNEPgBe_w_default = 123;
 
 //#endregion
-//#region <data:application/json;charset=UTF-8;base64,eyJ3b3JrcyI6dHJ1ZX0=>
-var json_charset_UTF_8_base64_eyJ3b3JrcyI6dHJ1ZX0__default = { works: true };
+//#region \0rolldown/data-url:VArahB_JWxTNyEv16je5Vg
+var data_url_VArahB_JWxTNyEv16je5Vg_default = { works: true };
 
 //#endregion
 //#region entry.js
 console.log([
-	json___31_32_33__default,
-	json_base64_eyJ3b3JrcyI6dHJ1ZX0__default,
-	json_charset_UTF_8__31_32_33_default,
-	json_charset_UTF_8_base64_eyJ3b3JrcyI6dHJ1ZX0__default
+	data_url_2sIfhqSWlzaAHOZh4OtugA_default,
+	data_url_Zc9opCw73EFYe8tLmXMbQA_default,
+	data_url_2aX92f_tk6SUzQNEPgBe_w_default,
+	data_url_VArahB_JWxTNyEv16je5Vg_default
 ]);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_text_java_script/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_text_java_script/artifacts.snap
@@ -6,19 +6,19 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#region <data:text/javascript,console.log('%31%32%33')>
+//#region \0rolldown/data-url:ZkuZVdK78XLI6cN2c0BGHA
 console.log("123");
 
 //#endregion
-//#region <data:text/javascript;base64,Y29uc29sZS5sb2coMjM0KQ==>
+//#region \0rolldown/data-url:oDiUunfrO2vRNyOIvD8nnQ
 console.log(234);
 
 //#endregion
-//#region <data:text/javascript;charset=UTF-8,console.log(%31%32%33)>
+//#region \0rolldown/data-url:A662MVPSaNNmeB3z2giORg
 console.log(123);
 
 //#endregion
-//#region <data:text/javascript;charset=UTF-8;base64,Y29uc29sZS5sb2coMjM0KQ==>
+//#region \0rolldown/data-url:Qp-Cu7zrDBXspSQAeE5jdw
 console.log(234);
 
 //#endregion

--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_text_java_script_cannot_import/_config.json
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_text_java_script_cannot_import/_config.json
@@ -5,8 +5,7 @@
         "name": "entry",
         "import": "entry.js"
       }
-    ],
-    "external": ["./other.js"]
+    ]
   },
-  "expectExecuted": false
+  "expectError": true
 }

--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_text_java_script_cannot_import/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_text_java_script_cannot_import/artifacts.snap
@@ -1,12 +1,21 @@
 ---
 source: crates/rolldown_testing/src/integration_test.rs
-snapshot_kind: text
 ---
-# Assets
+# Errors
 
-## entry.js
+## UNRESOLVED_IMPORT
 
-```js
-import "./other.js";
+```text
+[UNRESOLVED_IMPORT] Error: Could not resolve './other.js' in \0rolldown/data-url:jAtxc31b5PqcjFC5TMaMtg
+   ╭─[ \0rolldown/data-url:jAtxc31b5PqcjFC5TMaMtg:1:8 ]
+   │
+ 1 │ import './other.js'
+   │        ──────┬─────  
+   │              ╰─────── Module not found.
+   │ 
+   │ Help: '\0rolldown/data-url:jAtxc31b5PqcjFC5TMaMtg' is imported by the following path:
+   │         - \0rolldown/data-url:jAtxc31b5PqcjFC5TMaMtg
+   │         - entry.js
+───╯
 
 ```

--- a/crates/rolldown/tests/esbuild/loader/loader_data_url_text_java_script_plus_character/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/loader/loader_data_url_text_java_script_plus_character/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## entry.js
 
 ```js
-//#region <data:text/javascript,console.log(1+2)>
+//#region \0rolldown/data-url:qNNXL4tBrgsN63AaYWHDHw
 console.log(3);
 
 //#endregion

--- a/crates/rolldown/tests/rolldown/issues/2300/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/2300/artifacts.snap
@@ -6,12 +6,12 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## main.js
 
 ```js
-//#region <data:text/javascript;base64, ZXhwb3J0IGRlZmF1bHQgJ2hpJw==>
-var javascript_base64__ZXhwb3J0IGRlZmF1bHQgJ2hpJw___default = "hi";
+//#region \0rolldown/data-url:mCqIXq0ZcOnBu61tWW9mRQ
+var data_url_mCqIXq0ZcOnBu61tWW9mRQ_default = "hi";
 
 //#endregion
 //#region main.js
-console.log(javascript_base64__ZXhwb3J0IGRlZmF1bHQgJ2hpJw___default);
+console.log(data_url_mCqIXq0ZcOnBu61tWW9mRQ_default);
 
 //#endregion
 ```

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -2151,7 +2151,7 @@ expression: output
 
 # tests/esbuild/loader/loader_data_url_application_json
 
-- entry-!~{000}~.js => entry-DxkwWC22.js
+- entry-!~{000}~.js => entry-AJwPng1x.js
 
 # tests/esbuild/loader/loader_data_url_base64_invalid_utf8
 
@@ -2175,15 +2175,11 @@ expression: output
 
 # tests/esbuild/loader/loader_data_url_text_java_script
 
-- entry-!~{000}~.js => entry-BlqvTVHi.js
-
-# tests/esbuild/loader/loader_data_url_text_java_script_cannot_import
-
-- entry-!~{000}~.js => entry-DLwL520U.js
+- entry-!~{000}~.js => entry-D_5EfHds.js
 
 # tests/esbuild/loader/loader_data_url_text_java_script_plus_character
 
-- entry-!~{000}~.js => entry-O0UN5aFb.js
+- entry-!~{000}~.js => entry-Cdiqy0po.js
 
 # tests/esbuild/loader/loader_data_url_unknown_mime
 
@@ -4558,7 +4554,7 @@ expression: output
 
 # tests/rolldown/issues/2300
 
-- main-!~{000}~.js => main-CFS0RCIR.js
+- main-!~{000}~.js => main-C6FU2ULk.js
 
 # tests/rolldown/issues/2669
 

--- a/crates/rolldown_error/src/types/diagnostic_options.rs
+++ b/crates/rolldown_error/src/types/diagnostic_options.rs
@@ -18,10 +18,12 @@ impl DiagnosticOptions {
   /// Example: `/Users/you/project/src/index.js` -> `src/index.js` (if cwd is `/Users/you/project`)
   pub fn stabilize_path(&self, path: impl AsRef<Path>) -> String {
     let path = path.as_ref();
-    if path.is_absolute() {
+    let result = if path.is_absolute() {
       path.relative(&self.cwd).to_slash_lossy().into_owned()
     } else {
       path.to_string_lossy().to_string()
-    }
+    };
+    // Escape virtual module prefix (\0 → \\0) so null bytes don't appear in diagnostics
+    if result.contains('\0') { result.replace('\0', "\\0") } else { result }
   }
 }

--- a/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_check_external.rs
@@ -139,7 +139,9 @@ fn is_not_absolute_external(
 }
 
 fn normalize_relative_external_id(cwd: &Path, specifier: &str, importer: Option<&str>) -> ArcStr {
-  if !is_relative(specifier) || importer.is_some_and(is_data_url) {
+  if !is_relative(specifier)
+    || importer.is_some_and(|id| is_data_url(id) || id.starts_with("\0rolldown/data-url:"))
+  {
     return specifier.into();
   }
   let path = if let Some(importer) = importer {

--- a/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
+++ b/crates/rolldown_plugin/src/utils/resolve_id_with_plugins.rs
@@ -137,6 +137,10 @@ fn resolve_id(
   import_kind: ImportKind,
   is_user_defined_entry: bool,
 ) -> Result<ResolvedId, ResolveError> {
+  // Data URL modules have no filesystem location, so imports from them cannot be resolved.
+  if importer.is_some_and(|id| id.starts_with("\0rolldown/data-url:")) {
+    return Err(ResolveError::NotFound(specifier.to_string()));
+  }
   let resolved =
     resolver.resolve(importer.map(Path::new), specifier, import_kind, is_user_defined_entry);
 


### PR DESCRIPTION
3 things:
- Use shorter hash as the module to reduce overhead of long data url modules
- data url plugin should only `load` modules that it handled, not general pattern
- `imports` inside of `data-url` shouldn't be resolveable