### PR TITLE
fix(plugin/chunk-import-map): ensure `render_chunk_meta` run after users plugin

### DIFF
--- a/crates/rolldown/src/utils/apply_inner_plugins.rs
+++ b/crates/rolldown/src/utils/apply_inner_plugins.rs
@@ -26,6 +26,14 @@ pub fn apply_inner_plugins(
     Arc::new(rolldown_plugin_oxc_runtime::OxcRuntimePlugin),
   ];
 
+  if let Some(config) = &options.experimental.chunk_import_map {
+    before_user_plugins.push(Arc::new(rolldown_plugin_chunk_import_map::ChunkImportMapPlugin {
+      base_url: config.base_url.clone(),
+      file_name: config.file_name.clone(),
+      ..Default::default()
+    }));
+  }
+
   let mut lazy_compilation_context = None;
 
   if let Some(dev_mode) = &options.experimental.dev_mode {
@@ -35,14 +43,6 @@ pub fn apply_inner_plugins(
       lazy_compilation_context = Some(plugin.context());
       before_user_plugins.push(Arc::new(plugin));
     }
-  }
-
-  if let Some(config) = &options.experimental.chunk_import_map {
-    before_user_plugins.push(Arc::new(rolldown_plugin_chunk_import_map::ChunkImportMapPlugin {
-      base_url: config.base_url.clone(),
-      file_name: config.file_name.clone(),
-      ..Default::default()
-    }));
   }
 
   if !before_user_plugins.is_empty() {

--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -97,7 +97,7 @@ impl Plugin for ChunkImportMapPlugin {
   }
 
   fn render_chunk_meta(&self) -> Option<rolldown_plugin::PluginHookMeta> {
-    Some(rolldown_plugin::PluginHookMeta { order: Some(rolldown_plugin::PluginOrder::Post) })
+    Some(rolldown_plugin::PluginHookMeta { order: Some(rolldown_plugin::PluginOrder::PinPost) })
   }
 
   async fn generate_bundle(


### PR DESCRIPTION
Without `PinPost`, the chunk import map plugin's `render_chunk` uses `Post` ordering — but a user plugin that also specifies `Post` would land in the same bucket. Since the import map plugin is prepended (lowest index), it actually runs **first** among `Post` plugins, meaning user `Post` hooks run **after** hash placeholders have already been resolved. That sounds fine at first glance, but the real issue is the reverse scenario: if a user `Post` plugin modifies chunk code (e.g. appending a banner, injecting imports), those modifications could introduce new filename references that still contain unresolved hash placeholders — and the import map plugin has already run, so those placeholders are never replaced.

`PinPost` fixes this by running in a separate bucket **after** all `Post` hooks. The plugin being prepended (first-registered) makes it run last within `PinPost`, guaranteeing it sees the final chunk code after every user transform.