### PR TITLE
perf: limit concurrent filesystem I/O to reduce APFS kernel lock contention

### DIFF
--- a/crates/rolldown/src/module_loader/task_context.rs
+++ b/crates/rolldown/src/module_loader/task_context.rs
@@ -13,6 +13,10 @@ pub struct TaskContext {
   pub fs: OsFileSystem,
   pub plugin_driver: SharedPluginDriver,
   pub meta: TaskContextMeta,
+  /// Limits concurrent filesystem I/O to avoid APFS global kernel lock contention on macOS.
+  /// On macOS, too many threads calling open() concurrently causes severe lock contention
+  /// due to the APFS global kernel lock, degrading open() latency by 4x+.
+  pub fs_semaphore: tokio::sync::Semaphore,
 }
 
 pub struct TaskContextMeta {


### PR DESCRIPTION
On macOS, APFS has a global kernel lock that serializes concurrent open()
syscalls. Rolldown was spawning ~530 threads that all compete for this lock,
causing open() latency to degrade to 1,175μs avg (p99: 14.5ms), compared to
esbuild's 293μs avg with only 17 threads.

Add a tokio::sync::Semaphore to TaskContext that limits concurrent module
task I/O (file loading + dependency resolution) to 2/3 of logical cores.
The semaphore is acquired before load_source + resolve_dependencies and
released after both complete.

Benchmark results on 10,000 module project (Apple Silicon, macOS):
- Wall time: 957ms → 797ms (17% faster)
- System time: 5134ms → 2448ms (2.1x less kernel time)
- Variance: σ=216ms → σ=62ms (3.5x more consistent)
- vs esbuild: 1.12x slower → 1.16x faster

The concurrency limit is configurable via ROLLDOWN_FS_CONCURRENCY env var.

### Verify

<img width="1752" height="866" alt="CleanShot 2026-02-23 at 23 35 56@2x" src="https://github.com/user-attachments/assets/cfb58646-0a16-48c0-a815-485c28e2cb58" />


Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core module-loading hot path and introduces new async semaphore waits; misconfiguration or permit handling bugs could cause stalls or performance regressions, though behavior should remain functionally equivalent.
> 
> **Overview**
> Adds a `tokio::sync::Semaphore` to `TaskContext` and wires it up in `ModuleLoader` to cap concurrent filesystem operations.
> 
> `ModuleTask` now acquires a permit around the two I/O-heavy phases—`load_source_without_cache` and `resolve_dependencies`—while keeping CPU-bound parsing/transform work outside the permit. The concurrency defaults to a macOS-specific heuristic (overrideable via `ROLLDOWN_FS_CONCURRENCY`) and remains effectively unlimited on Linux/Windows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8af07fb4d560e087fcc256ffa5581e59a3d5be92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->