### PR TITLE
perf: bump to `sugar_path@2` for SIMD-based search and on-demand memory allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4011,10 +4011,11 @@ dependencies = [
 
 [[package]]
 name = "sugar_path"
-version = "1.2.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48abcb2199ce37819c20dc7a72dc09e3263a00e598ff5089fe5fda92e0f63c37"
+checksum = "36fe837e881ad5c3b60fadeb8e9b0bc5c907c4b7d84b4415a7f0bbc3f9073631"
 dependencies = [
+ "memchr",
  "smallvec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ serde_yaml = "0.9.34"
 simdutf8 = "0.1.5"
 smallvec = "1.15.0"
 string_cache = "0.9.0"
-sugar_path = { version = "1.2.1", features = ["cached_current_dir"] }
+sugar_path = { version = "2.0.1", features = ["cached_current_dir"] }
 terminal_size = "0.4.2"
 testing_macros = "1.0.0"
 tokio = { version = "1.45.0", default-features = false }

--- a/crates/rolldown/examples/basic.rs
+++ b/crates/rolldown/examples/basic.rs
@@ -12,7 +12,7 @@ async fn main() {
       InputItem { import: "./other-entry.js".to_string(), ..Default::default() },
       InputItem { name: Some("third-entry".to_string()), import: "./third-entry.js".to_string() },
     ]),
-    cwd: Some(workspace::crate_dir("rolldown").join("./examples/basic").normalize()),
+    cwd: Some(workspace::crate_dir("rolldown").join("./examples/basic").normalize().into_owned()),
     sourcemap: Some(SourceMapType::File),
     ..Default::default()
   })

--- a/crates/rolldown/examples/dev.rs
+++ b/crates/rolldown/examples/dev.rs
@@ -12,7 +12,9 @@ async fn main() {
   let bundler_config = BundlerConfig::new(
     BundlerOptions {
       input: Some(vec!["./entry.js".to_string().into()]),
-      cwd: Some(rolldown_workspace::crate_dir("rolldown").join("./examples/basic").normalize()),
+      cwd: Some(
+        rolldown_workspace::crate_dir("rolldown").join("./examples/basic").normalize().into_owned(),
+      ),
 
       experimental: Some(ExperimentalOptions {
         incremental_build: Some(true),

--- a/crates/rolldown/examples/lazy.rs
+++ b/crates/rolldown/examples/lazy.rs
@@ -8,7 +8,7 @@ use sugar_path::SugarPath;
 async fn main() {
   let mut bundler = Bundler::new(BundlerOptions {
     input: Some(vec!["./entry-a.js".to_string().into(), "./entry-b.js".to_string().into()]),
-    cwd: Some(workspace::crate_dir("rolldown").join("./examples/lazy").normalize()),
+    cwd: Some(workspace::crate_dir("rolldown").join("./examples/lazy").normalize().into_owned()),
     sourcemap: None,
     experimental: Some(ExperimentalOptions {
       dev_mode: Some(DevModeOptions { lazy: Some(true), ..Default::default() }),

--- a/crates/rolldown/examples/watch.rs
+++ b/crates/rolldown/examples/watch.rs
@@ -8,7 +8,9 @@ async fn main() {
   let config = BundlerConfig::new(
     BundlerOptions {
       input: Some(vec!["./entry.js".to_string().into()]),
-      cwd: Some(rolldown_workspace::crate_dir("rolldown").join("./examples/basic").normalize()),
+      cwd: Some(
+        rolldown_workspace::crate_dir("rolldown").join("./examples/basic").normalize().into_owned(),
+      ),
 
       experimental: Some(ExperimentalOptions {
         incremental_build: Some(true),

--- a/crates/rolldown/examples/watch_new.rs
+++ b/crates/rolldown/examples/watch_new.rs
@@ -32,7 +32,9 @@ async fn main() {
   let config = BundlerConfig::new(
     BundlerOptions {
       input: Some(vec!["./entry.js".to_string().into()]),
-      cwd: Some(rolldown_workspace::crate_dir("rolldown").join("./examples/basic").normalize()),
+      cwd: Some(
+        rolldown_workspace::crate_dir("rolldown").join("./examples/basic").normalize().into_owned(),
+      ),
       experimental: Some(ExperimentalOptions {
         incremental_build: Some(true),
         ..Default::default()

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -333,6 +333,7 @@ impl<'a> GenerateStage<'a> {
             module.idx,
             preliminary
               .absolutize_with(self.options.cwd.join(&self.options.out_dir))
+              .into_owned()
               .expect_into_string(),
           );
           chunk.asset_preliminary_filenames.insert(module.idx, preliminary);
@@ -344,6 +345,7 @@ impl<'a> GenerateStage<'a> {
       chunk.absolute_preliminary_filename = Some(
         preliminary_filename
           .absolutize_with(self.options.cwd.join(&self.options.out_dir))
+          .into_owned()
           .expect_into_string(),
       );
       chunk.preliminary_filename = Some(preliminary_filename);

--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_reporter_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_reporter_plugin_config.rs
@@ -27,7 +27,7 @@ pub struct BindingViteReporterPluginConfig {
 impl From<BindingViteReporterPluginConfig> for ViteReporterPlugin {
   fn from(config: BindingViteReporterPluginConfig) -> Self {
     Self {
-      root: PathBuf::from(config.root).normalize(),
+      root: PathBuf::from(config.root).normalize().into_owned(),
       is_lib: config.is_lib,
       is_tty: config.is_tty,
       assets_dir: config.assets_dir,

--- a/crates/rolldown_binding/src/options/plugin/config/binding_vite_transform_plugin_config.rs
+++ b/crates/rolldown_binding/src/options/plugin/config/binding_vite_transform_plugin_config.rs
@@ -30,7 +30,7 @@ pub struct BindingViteTransformPluginConfig {
 impl From<BindingViteTransformPluginConfig> for ViteTransformPlugin {
   fn from(value: BindingViteTransformPluginConfig) -> Self {
     Self {
-      root: PathBuf::from(value.root).normalize(),
+      root: PathBuf::from(value.root).normalize().into_owned(),
       include: value.include.map(bindingify_string_or_regex_array).unwrap_or_default(),
       exclude: value.exclude.map(bindingify_string_or_regex_array).unwrap_or_default(),
       jsx_refresh_include: value

--- a/crates/rolldown_common/src/inner_bundler_options/types/tsconfig.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/tsconfig.rs
@@ -25,7 +25,7 @@ impl TsConfig {
   pub fn with_base(self, base: &Path) -> Self {
     match self {
       Self::Auto(_) => self,
-      Self::Manual(path) => Self::Manual(base.join(path).normalize()),
+      Self::Manual(path) => Self::Manual(base.join(path).normalize().into_owned()),
     }
   }
 }

--- a/crates/rolldown_plugin_utils/src/check_public_file.rs
+++ b/crates/rolldown_plugin_utils/src/check_public_file.rs
@@ -9,6 +9,6 @@ pub fn check_public_file(path: &str, public_dir: &str) -> Option<PathBuf> {
     return None;
   }
   let path = &clean_url(path)[1..];
-  let file = Path::new(public_dir).join(path).normalize();
+  let file = Path::new(public_dir).join(path).normalize().into_owned();
   (file.starts_with(public_dir) && file.exists()).then_some(file)
 }

--- a/crates/rolldown_plugin_vite_asset_import_meta_url/src/lib.rs
+++ b/crates/rolldown_plugin_vite_asset_import_meta_url/src/lib.rs
@@ -94,7 +94,8 @@ impl Plugin for ViteAssetImportMetaUrlPlugin {
         continue;
       }
       let file = if url.starts_with('.') {
-        let path = PathBuf::from(args.id).parent().unwrap().join(&url).normalize();
+        let joined = PathBuf::from(args.id).parent().unwrap().join(&url);
+        let path = joined.normalize();
         let file = path.to_slash_lossy().into_owned();
         (self.try_fs_resolve)(&file).await?.unwrap_or(file)
       } else {
@@ -102,8 +103,8 @@ impl Plugin for ViteAssetImportMetaUrlPlugin {
           if let Some(stripped) = url.strip_prefix('/') {
             PathBuf::from(&self.public_dir).join(stripped).to_slash_lossy().into_owned()
           } else {
-            let path = PathBuf::from(args.id).parent().unwrap().join(&url).normalize();
-            path.to_slash_lossy().into_owned()
+            let joined = PathBuf::from(args.id).parent().unwrap().join(&url);
+            joined.normalize().to_slash_lossy().into_owned()
           }
         })
       };

--- a/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
+++ b/crates/rolldown_plugin_vite_build_import_analysis/src/ast_visit.rs
@@ -137,7 +137,8 @@ impl VisitMut<'_> for DynamicImportVisitor<'_, '_> {
       _ => None,
     };
     if let Some(url) = value {
-      let normalized = self.chunk_filename_dir.join(url.as_str()).normalize();
+      let joined = self.chunk_filename_dir.join(url.as_str());
+      let normalized = joined.normalize();
       if self.removed_pure_css_files.inner.contains_key(normalized.to_slash_lossy().as_ref()) {
         let s = self.s.get_or_insert_with(|| string_wizard::MagicString::new(self.code));
         s.update(

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -268,7 +268,8 @@ impl Plugin for ViteResolvePlugin {
         .get(&rolldown_plugin_utils::constants::ViteImportGlob)
         .is_some_and(|v| v.is_sub_imports_pattern())
       {
-        let path = Path::new(&self.resolve_options.root).join(id.as_ref()).normalize();
+        let joined = Path::new(&self.resolve_options.root).join(id.as_ref());
+        let path = joined.normalize();
         let package_json_path = (!self.legacy_inconsistent_cjs_interop)
           .then(|| {
             self

--- a/crates/rolldown_resolver/src/resolver.rs
+++ b/crates/rolldown_resolver/src/resolver.rs
@@ -209,7 +209,8 @@ impl<Fs: FileSystem> Resolver<Fs> {
       .unwrap_or(self.cwd.as_path());
 
     // Try resolving relative to cwd as a fallback
-    let specifier_path = self.cwd.join(specifier).normalize();
+    let joined = self.cwd.join(specifier);
+    let specifier_path = joined.normalize();
     let fallback = resolver.resolve(importer_dir, &specifier_path.to_string_lossy());
     if fallback.is_ok() { fallback } else { original_resolution }
   }


### PR DESCRIPTION
## Summary

Bump `sugar_path` from 1.2.1 to 2^

### What changed in sugar_path 2.0

The 2.0 release is focused on reducing allocations in hot paths. The key optimizations:

- **`normalize()` returns `Cow<'_, Path>` instead of `PathBuf`** — a `needs_normalization()` fast-path check (using `memchr`) detects already-clean paths and returns `Cow::Borrowed` with zero allocation ([#32](https://github.com/hyf0/sugar_path/pull/32))
- **`absolutize()` / `absolutize_with()` return `Cow<'_, Path>`** — same idea: already-absolute clean paths are returned borrowed ([#34](https://github.com/hyf0/sugar_path/pull/34))
- **`memchr`-accelerated fast path for `relative()`** — replaces the component-iterator approach with SIMD-accelerated `/` scanning, avoids the `absolutize()` → `current_dir()` syscall when both paths are already absolute, and uses `SmallVec<[&str; 8]>` to stay on the stack ([#27](https://github.com/hyf0/sugar_path/pull/27))
- **Reduced allocations across the board** — reuse buffers, `SmallVec` for component lists, avoid `collect()` into `Vec` ([#26](https://github.com/hyf0/sugar_path/pull/26))

### Breaking change

`normalize()`, `absolutize()`, and `absolutize_with()` now return `Cow<'_, Path>` instead of `PathBuf`. Call sites that need an owned `PathBuf` require `.into_owned()`, and chained operations like `.join().normalize().to_slash_lossy()` need to be split so the intermediate `Cow` lives long enough.

## Test plan

- [x] CI passes (same API surface, just `Cow` unwrapping at call sites)