### PR TITLE
docs: replace npmjs package links with npmx.dev

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -11,7 +11,7 @@
 1. Visit https://github.com/rolldown/rolldown/actions/workflows/publish-to-npm-for-nightly-canary.yml
 2. "Run workflow"
 
-Latest Canary versions are https://www.npmjs.com/package/rolldown/v/canary
+Latest Canary versions are https://npmx.dev/package/rolldown/v/canary
 
 ## pkg.pr.new
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@
 <div align="center">
 
 [![NPM Unpacked Size (with version)](https://img.shields.io/npm/unpacked-size/rolldown/latest?label=npm)][url-npm]
-[![NPM Unpacked Size darwin-arm64](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-darwin-arm64/latest?label=darwin-arm64)](https://www.npmjs.com/package/@rolldown/binding-darwin-arm64)
-[![NPM Unpacked Size darwin-x64](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-darwin-x64/latest?label=darwin-x64)](https://www.npmjs.com/package/@rolldown/binding-darwin-x64)
-[![NPM Unpacked Size linux-x64-gnu](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-linux-x64-gnu/latest?label=linux-x64-gnu)](https://www.npmjs.com/package/@rolldown/binding-linux-x64-gnu)
-[![NPM Unpacked Size win32-x64](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-win32-x64-msvc/latest?label=win32-x64)](https://www.npmjs.com/package/@rolldown/binding-win32-x64-msvc)
-[![NPM Unpacked Size wasm32-wasi](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-wasm32-wasi/latest?label=wasm32-wasi)](https://www.npmjs.com/package/@rolldown/binding-wasm32-wasi)
+[![NPM Unpacked Size darwin-arm64](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-darwin-arm64/latest?label=darwin-arm64)](https://npmx.dev/package/@rolldown/binding-darwin-arm64)
+[![NPM Unpacked Size darwin-x64](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-darwin-x64/latest?label=darwin-x64)](https://npmx.dev/package/@rolldown/binding-darwin-x64)
+[![NPM Unpacked Size linux-x64-gnu](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-linux-x64-gnu/latest?label=linux-x64-gnu)](https://npmx.dev/package/@rolldown/binding-linux-x64-gnu)
+[![NPM Unpacked Size win32-x64](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-win32-x64-msvc/latest?label=win32-x64)](https://npmx.dev/package/@rolldown/binding-win32-x64-msvc)
+[![NPM Unpacked Size wasm32-wasi](https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-wasm32-wasi/latest?label=wasm32-wasi)](https://npmx.dev/package/@rolldown/binding-wasm32-wasi)
 
 </div>
 
@@ -96,7 +96,7 @@ Licenses of these projects are listed in [THIRD-PARTY-LICENSE](/THIRD-PARTY-LICE
 [badge-license]: https://img.shields.io/badge/license-MIT-blue.svg
 [url-license]: https://github.com/rolldown/rolldown/blob/main/LICENSE
 [badge-npm-version]: https://img.shields.io/npm/v/rolldown/latest?color=brightgreen
-[url-npm]: https://www.npmjs.com/package/rolldown/v/latest
+[url-npm]: https://npmx.dev/package/rolldown/v/latest
 
 [badge-binary-size-windows]: [https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-win32-x64-msvc/latest]
 [badge-binary-size-macos]: [https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-darwin-arm64/latest]

--- a/docs/apis/plugin-api/hook-filters.md
+++ b/docs/apis/plugin-api/hook-filters.md
@@ -44,7 +44,7 @@ export default function myPlugin() {
 Rolldown evaluates the filter on the Rust side and only calls your handler when the filter matches.
 
 ::: tip
-[`@rolldown/pluginutils`](https://www.npmjs.com/package/@rolldown/pluginutils) exports some utilities for hook filters like `exactRegex` and `prefixRegex`.
+[`@rolldown/pluginutils`](https://npmx.dev/package/@rolldown/pluginutils) exports some utilities for hook filters like `exactRegex` and `prefixRegex`.
 :::
 
 ## Filter Properties

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -80,7 +80,7 @@ If you are using a platform that a prebuilt binary is not distributed, you have 
 
 ### Release Channels
 
-- [latest](https://www.npmjs.com/package/rolldown?activeTab=versions): currently `1.0.0-rc.*`.
+- [latest](https://npmx.dev/package/rolldown?activeTab=versions): currently `1.0.0-rc.*`.
 - [pkg.pr.new](https://pkg.pr.new/~/rolldown/rolldown): continuously released from the `main` branch. Install with `npm i https://pkg.pr.new/rolldown@sha` where `sha` is a successful build listed on [pkg.pr.new](https://pkg.pr.new/~/rolldown/rolldown).
 
 ## Using the CLI

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -80,7 +80,7 @@ If you are using a platform that a prebuilt binary is not distributed, you have 
 
 ### Release Channels
 
-- [latest](https://npmx.dev/package/rolldown?activeTab=versions): currently `1.0.0-rc.*`.
+- [latest](https://npmx.dev/package/rolldown#versions): currently `1.0.0-rc.*`.
 - [pkg.pr.new](https://pkg.pr.new/~/rolldown/rolldown): continuously released from the `main` branch. Install with `npm i https://pkg.pr.new/rolldown@sha` where `sha` is a successful build listed on [pkg.pr.new](https://pkg.pr.new/~/rolldown/rolldown).
 
 ## Using the CLI


### PR DESCRIPTION
## Summary
- replace https://www.npmjs.com/package/... links with https://npmx.dev/package/...
- update README, maintenance notes, and docs links
