### PR TITLE
chore(ai): introduce progressive spec-driven development pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,14 @@ Rolldown is a JavaScript/TypeScript bundler written in Rust and TypeScript, desi
 
 </tips>
 
+# Spec-Driven Development
+
+Design docs live in `meta/design/`. They capture high-level vision and design intent, giving both humans and AI a shared understanding of what the system should be.
+
+When a design doc exists for a topic, treat it as the source of truth — read it before coding, update it before changing the design. When there isn't one, just code.
+
+- **Format:** See `meta/design/template.md` for the suggested format. Keep it freeform — one concept per file, link between docs, no rigid structure required.
+
 # Architecture
 
 ## Three-Layer Architecture
@@ -35,6 +43,7 @@ Rust Core (crates/rolldown)
 - `packages/rolldown-tests`: Test suite for the `rolldown` package using Vitest.
 - `packages/rollup-tests`: Compatibility test suite for Rollup plugins.
 - `docs/`: Documentation site built with VitePress.
+- `meta/design/`: Design documents. See the "Spec-Driven Development" section above.
 
 ## Auto-generated or Submodule Files
 

--- a/meta/design/template.md
+++ b/meta/design/template.md
@@ -1,0 +1,20 @@
+<!-- This template is a preference, not a hard requirement. -->
+<!-- Write in whatever structure best conveys the design. -->
+
+# [Concept Name]
+
+## Summary
+
+One paragraph. What this is and why it matters.
+
+<!-- Free form. Write whatever helps convey the design: -->
+<!-- behavior, structure, constraints, examples, DX details, etc. -->
+
+## Unresolved Questions
+
+- Things not yet decided or worth revisiting.
+- Skip this section if there are none.
+
+## Related
+
+- [other-concept](./other-concept.md)


### PR DESCRIPTION
## Why

AI coding agents are increasingly involved in implementing features and fixing bugs in rolldown. A recurring problem: without shared context about design intent, agents (and humans) make decisions in isolation — leading to inconsistent implementations, repeated mistakes, and wasted review cycles.

Lightweight design docs fix this. They give both humans and AI a shared understanding of *what the system should be* before anyone starts coding. This is especially valuable for cross-cutting concerns (watch mode, plugin hooks, dev mode) where multiple PRs touch the same subsystem over time.

## What

Adds a "Spec-Driven Development" section to `AGENTS.md` with a simple rule:

- Design docs live in `meta/design/`, one concept per file, freeform format
- When a doc exists, treat it as source of truth — read before coding, update before changing the design
- When there isn't one, just code — no bureaucracy for straightforward changes

Also adds `meta/design/template.md` as a lightweight starting point.

This is intentionally minimal — it's a convention, not a process.