### PR TITLE
chore: deprecate output.legalComments

### DIFF
--- a/packages/rolldown/src/options/normalized-output-options.ts
+++ b/packages/rolldown/src/options/normalized-output-options.ts
@@ -84,7 +84,10 @@ export interface NormalizedOutputOptions {
   sourcemapPathTransform: SourcemapPathTransformOption | undefined;
   /** @see {@linkcode OutputOptions.minify | minify} */
   minify: false | MinifyOptions | 'dce-only';
-  /** @see {@linkcode OutputOptions.legalComments | legalComments} */
+  /**
+   * @deprecated Use `comments.legal` instead.
+   * @see {@linkcode OutputOptions.legalComments | legalComments}
+   */
   legalComments: 'none' | 'inline';
   /** @see {@linkcode OutputOptions.comments | comments} */
   comments: Required<CommentsOptions>;

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -588,10 +588,12 @@ export interface OutputOptions {
     groups?: CodeSplittingGroup[];
   };
   /**
-   * Control comments in the output.
+   * Controls how legal comments are preserved in the output.
    *
-   * - `none`: no comments
-   * - `inline`: preserve comments that contain `@license`, `@preserve` or starts with `//!` `/*!`
+   * - `none`: no legal comments
+   * - `inline`: preserve legal comments that contain `@license`, `@preserve` or starts with `//!` `/*!`
+   *
+   * @deprecated Use `comments.legal` instead. When both `legalComments` and `comments.legal` are set, `comments.legal` takes priority.
    */
   legalComments?: 'none' | 'inline';
   /**

--- a/packages/rolldown/src/utils/bindingify-output-options.ts
+++ b/packages/rolldown/src/utils/bindingify-output-options.ts
@@ -44,6 +44,10 @@ export function bindingifyOutputOptions(outputOptions: OutputOptions): BindingOu
     strictExecutionOrder,
   } = outputOptions;
 
+  if (legalComments != null) {
+    logger.warn('`legalComments` option is deprecated, please use `comments.legal` instead.');
+  }
+
   // Handle codeSplitting and inlineDynamicImports
   const { inlineDynamicImports, advancedChunks } = bindingifyCodeSplitting(
     outputOptions.codeSplitting,


### PR DESCRIPTION
Applies https://github.com/rolldown/rolldown/pull/8254, which was accidentally dropped during a merge