### PR TITLE
docs: mention execution order issue in `output.codeSplitting` docs

### DIFF
--- a/packages/rolldown/src/options/docs/output-code-splitting-example.md
+++ b/packages/rolldown/src/options/docs/output-code-splitting-example.md
@@ -1,0 +1,53 @@
+**Multiple chunk groups with priorities**
+
+```js
+export default defineConfig({
+  output: {
+    codeSplitting: {
+      groups: [
+        {
+          name: 'react-vendor',
+          test: /node_modules[\\/]react/,
+          priority: 20,
+        },
+        {
+          name: 'ui-vendor',
+          test: /node_modules[\\/]antd/,
+          priority: 15,
+        },
+        {
+          name: 'vendor',
+          test: /node_modules/,
+          priority: 10,
+        },
+        {
+          name: 'common',
+          minShareCount: 2,
+          minSize: 10000,
+          priority: 5,
+        },
+      ],
+    },
+  },
+});
+```
+
+**Size-based splitting**
+
+```js
+export default defineConfig({
+  output: {
+    codeSplitting: {
+      groups: [
+        {
+          name: 'large-libs',
+          test: /node_modules/,
+          minSize: 100000, // 100KB
+          maxSize: 250000, // 250KB
+          priority: 10,
+        },
+      ],
+    },
+  },
+});
+```

--- a/packages/rolldown/src/options/docs/output-code-splitting.md
+++ b/packages/rolldown/src/options/docs/output-code-splitting.md
@@ -1,53 +1,5 @@
-**Multiple chunk groups with priorities**
+:::warning
 
-```js
-export default defineConfig({
-  output: {
-    codeSplitting: {
-      groups: [
-        {
-          name: 'react-vendor',
-          test: /node_modules[\\/]react/,
-          priority: 20,
-        },
-        {
-          name: 'ui-vendor',
-          test: /node_modules[\\/]antd/,
-          priority: 15,
-        },
-        {
-          name: 'vendor',
-          test: /node_modules/,
-          priority: 10,
-        },
-        {
-          name: 'common',
-          minShareCount: 2,
-          minSize: 10000,
-          priority: 5,
-        },
-      ],
-    },
-  },
-});
-```
+Be aware that manual code splitting can change the behavior of the application if side effects are triggered before the corresponding modules are actually used. You can change the chunking configuration to group some modules so that the modules are reordered, or you can use the [`output.strictExecutionOrder`](https://rolldown.rs/reference/OutputOptions.strictExecutionOrder) option to ensure that modules are executed in the order they are imported with the cost of a slight increase in bundle size.
 
-**Size-based splitting**
-
-```js
-export default defineConfig({
-  output: {
-    codeSplitting: {
-      groups: [
-        {
-          name: 'large-libs',
-          test: /node_modules/,
-          minSize: 100000, // 100KB
-          maxSize: 250000, // 250KB
-          priority: 10,
-        },
-      ],
-    },
-  },
-});
-```
+:::

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -556,6 +556,8 @@ export interface OutputOptions {
    *
    * For deeper understanding, please refer to the in-depth [documentation](https://rolldown.rs/in-depth/manual-code-splitting).
    *
+   * {@include ./docs/output-code-splitting.md}
+   *
    * @example
    * **Basic vendor chunk**
    * ```js
@@ -573,7 +575,7 @@ export interface OutputOptions {
    *   },
    * });
    * ```
-   * {@include ./docs/output-code-splitting.md}
+   * {@include ./docs/output-code-splitting-example.md}
    *
    * @default true
    */


### PR DESCRIPTION
refs https://github.com/rolldown/rolldown/issues/7449