### PR TITLE
docs: remove `https://rolldown.rs` from links in reference docs

### DIFF
--- a/docs/.vitepress/scripts/generate-reference.ts
+++ b/docs/.vitepress/scripts/generate-reference.ts
@@ -1,4 +1,4 @@
-import { copyFile, readFile, rm } from 'node:fs/promises';
+import { copyFile, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { Application, type TypeDocOptions } from 'typedoc';
 import type { PluginOptions } from 'typedoc-plugin-markdown';
@@ -13,6 +13,8 @@ const allEntryPoints = exportPaths.map((p) => p.replaceAll('\\', '/'));
 // Generate API documentation
 await runTypedoc(allEntryPoints);
 console.log('✅ Reference generated successfully!');
+
+await relativizeInternalLinks('reference');
 
 await rm('reference/index.md', { force: true });
 await copyFile('.vitepress/theme/components/api.index.md', 'reference/index.md');
@@ -29,6 +31,23 @@ async function discoverExports(): Promise<string[]> {
     if (excludedExports.has(key) || !entry.dev) return [];
     return path.join(root, 'packages/rolldown', entry.dev);
   });
+}
+
+/**
+ * Convert absolute rolldown.rs URLs in markdown links to relative paths,
+ * so VitePress treats them as internal navigation instead of opening
+ * external links with target="_blank".
+ */
+async function relativizeInternalLinks(dir: string): Promise<void> {
+  for (const file of await readdir(dir)) {
+    if (!file.endsWith('.md')) continue;
+    const filePath = path.join(dir, file);
+    const content = await readFile(filePath, 'utf-8');
+    const updated = content.replace(/\]\(https:\/\/rolldown\.rs\//g, '](/');
+    if (updated !== content) {
+      await writeFile(filePath, updated);
+    }
+  }
 }
 
 type TypedocVitepressThemeOptions = {


### PR DESCRIPTION
Remove `https://rolldown.rs` part from links in reference docs so that those links can be opened in the same tab.
Example: https://rolldown.rs/reference/OutputOptions.codeSplitting#:~:text=For%20deeper%20understanding%2C%20please%20refer%20to%20the%20in%2Ddepth%20documentation.

The source code has to include that part to keep the type definition files have an absolute path.
