### PR TITLE
fix(resolver): disable node_path option to align ESM resolver behavior

### DIFF
--- a/crates/rolldown_plugin_vite_resolve/src/resolver.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/resolver.rs
@@ -185,6 +185,7 @@ fn get_resolve_options(
     } else {
       vec!["index".to_string()]
     },
+    node_path: false,
     prefer_relative: additional_options.prefer_relative,
     roots: if base_options.as_src { vec![base_options.root.clone()] } else { vec![] },
     symlinks: !base_options.preserve_symlinks,

--- a/crates/rolldown_resolver/src/resolver_config.rs
+++ b/crates/rolldown_resolver/src/resolver_config.rs
@@ -123,7 +123,7 @@ impl ResolverConfig {
       main_fields,
       main_files: resolve_options.main_files.unwrap_or_else(|| vec!["index".to_string()]),
       modules: resolve_options.modules.unwrap_or_else(|| vec!["node_modules".into()]),
-      node_path: true,
+      node_path: false,
       resolve_to_context: false,
       prefer_relative: false,
       prefer_absolute: false,


### PR DESCRIPTION
I think we should align with ESM resolver behavior so that it's less confusing.