### PR TITLE
feat(watch): use new watcher to support watch mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,6 +2898,7 @@ dependencies = [
  "rolldown_sourcemap",
  "rolldown_tracing",
  "rolldown_utils",
+ "rolldown_watcher",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ rolldown_testing = { version = "0.1.0", path = "crates/rolldown_testing" }
 rolldown_testing_config = { version = "0.1.0", path = "crates/rolldown_testing_config" }
 rolldown_tracing = { version = "0.1.0", path = "crates/rolldown_tracing" }
 rolldown_utils = { version = "0.1.0", path = "crates/rolldown_utils" }
+rolldown_watcher = { version = "0.1.0", path = "crates/rolldown_watcher" }
 rolldown_workspace = { version = "0.1.0", path = "crates/rolldown_workspace" }
 string_wizard = { version = "0.0.27", path = "crates/string_wizard", features = ["serde"] }
 

--- a/crates/rolldown/examples/watch.rs
+++ b/crates/rolldown/examples/watch.rs
@@ -20,6 +20,6 @@ async fn main() {
     },
     vec![],
   );
-  let watcher = Watcher::new(config, None).unwrap();
+  let watcher = Watcher::new(config).unwrap();
   watcher.start().await;
 }

--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -88,7 +88,7 @@ impl Bundle {
   }
 
   #[tracing::instrument(level = "debug", skip_all, parent = &*self.bundle_span)]
-  pub(crate) async fn scan_modules(
+  pub async fn scan_modules(
     &mut self,
     scan_mode: ScanMode<ArcStr>,
   ) -> BuildResult<NormalizedScanStageOutput> {
@@ -201,7 +201,7 @@ impl Bundle {
   }
 
   #[tracing::instrument(level = "debug", skip_all, parent = &*self.bundle_span)]
-  pub(crate) async fn bundle_generate(
+  pub async fn bundle_generate(
     &mut self,
     scan_stage_output: NormalizedScanStageOutput,
   ) -> BuildResult<BundleOutput> {

--- a/crates/rolldown/src/bundler/bundler.rs
+++ b/crates/rolldown/src/bundler/bundler.rs
@@ -59,13 +59,8 @@ impl Bundler {
 
   // Rollup always creates a new build in watch mode, which could be called multiple times.
   // Here only reset the closed flag to make it possible to call again.
-  pub(crate) fn reset_closed_for_watch_mode(&mut self) {
+  pub fn reset_closed_for_watch_mode(&mut self) {
     self.closed = false;
-  }
-
-  #[cfg(feature = "experimental")]
-  pub fn reset_closed_for_watch_mode_experimental(&mut self) {
-    self.reset_closed_for_watch_mode();
   }
 
   pub(super) async fn inner_close(&mut self) -> Result<()> {

--- a/crates/rolldown/src/watcher.rs
+++ b/crates/rolldown/src/watcher.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use rolldown_common::NotifyOption;
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use tokio::sync::Mutex;
 
@@ -13,14 +12,11 @@ use crate::{
 pub struct Watcher(Arc<WatcherImpl>);
 
 impl Watcher {
-  pub fn new(config: BundlerConfig, notify_option: Option<NotifyOption>) -> BuildResult<Self> {
-    Self::with_configs(vec![config], notify_option)
+  pub fn new(config: BundlerConfig) -> BuildResult<Self> {
+    Self::with_configs(vec![config])
   }
 
-  pub fn with_configs(
-    configs: Vec<BundlerConfig>,
-    notify_option: Option<NotifyOption>,
-  ) -> BuildResult<Self> {
+  pub fn with_configs(configs: Vec<BundlerConfig>) -> BuildResult<Self> {
     let mut bundlers = Vec::with_capacity(configs.len());
 
     for config in configs {
@@ -46,7 +42,7 @@ impl Watcher {
       bundlers.push(Arc::new(Mutex::new(bundler)));
     }
 
-    let watcher = Arc::new(WatcherImpl::new(bundlers, notify_option)?);
+    let watcher = Arc::new(WatcherImpl::new(bundlers)?);
     Ok(Self(watcher))
   }
 

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -63,6 +63,7 @@ rolldown_plugin_vite_web_worker_post = { workspace = true }
 rolldown_sourcemap = { workspace = true }
 rolldown_tracing = { workspace = true }
 rolldown_utils = { workspace = true }
+rolldown_watcher = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/rolldown_binding/src/options/binding_input_options/binding_watch_option.rs
+++ b/crates/rolldown_binding/src/options/binding_input_options/binding_watch_option.rs
@@ -14,6 +14,8 @@ pub struct BindingWatchOption {
   pub include: Option<Vec<BindingStringOrRegex>>,
   pub exclude: Option<Vec<BindingStringOrRegex>>,
   pub build_delay: Option<u32>,
+  pub use_polling: Option<bool>,
+  pub poll_interval: Option<u32>,
   #[napi(ts_type = "((id: string) => void) | undefined")]
   #[debug(skip)]
   pub on_invalidate: Option<JsCallback<FnArgs<(String,)>>>,
@@ -26,6 +28,8 @@ impl From<BindingWatchOption> for rolldown_common::WatchOption {
       include: value.include.map(bindingify_string_or_regex_array),
       exclude: value.exclude.map(bindingify_string_or_regex_array),
       build_delay: value.build_delay,
+      use_polling: value.use_polling.unwrap_or_default(),
+      poll_interval: value.poll_interval.map(u64::from),
       on_invalidate: value.on_invalidate.map(|js_callback| {
         OnInvalidate::new(Arc::new(move |path| {
           let f = Arc::clone(&js_callback);

--- a/crates/rolldown_binding/src/watcher.rs
+++ b/crates/rolldown_binding/src/watcher.rs
@@ -3,65 +3,94 @@ use std::time::Duration;
 
 use napi::bindgen_prelude::FnArgs;
 use napi_derive::napi;
+use rolldown_common::WatcherChangeKind;
+use rolldown_watcher::{WatchEvent, WatcherConfig, WatcherEventHandler};
 
 use crate::types::binding_bundler_options::BindingBundlerOptions;
 use crate::types::binding_watcher_event::BindingWatcherEvent;
-
-use crate::utils::create_bundler_config_from_binding_options::create_bundler_config_from_binding_options;
-use crate::utils::handle_result;
-
 use crate::types::js_callback::{MaybeAsyncJsCallback, MaybeAsyncJsCallbackExt};
+use crate::utils::create_bundler_config_from_binding_options::create_bundler_config_from_binding_options;
 
-#[napi_derive::napi(object, object_to_js = false)]
-#[derive(Debug, Default)]
-pub struct BindingNotifyOption {
-  pub poll_interval: Option<u32>,
-  pub compare_contents: Option<bool>,
+/// Bridges watcher events from Rust to JS via a `ThreadsafeFunction`.
+struct NapiWatcherEventHandler {
+  listener: Arc<MaybeAsyncJsCallback<FnArgs<(BindingWatcherEvent,)>>>,
 }
 
-impl From<BindingNotifyOption> for rolldown_common::NotifyOption {
-  #[expect(clippy::cast_lossless)]
-  fn from(value: BindingNotifyOption) -> Self {
-    Self {
-      poll_interval: value.poll_interval.map(|m| Duration::from_millis(m as u64)),
-      compare_contents: value.compare_contents.unwrap_or_default(),
+impl WatcherEventHandler for NapiWatcherEventHandler {
+  async fn on_event(&self, event: WatchEvent) {
+    let binding_event = BindingWatcherEvent::from_watch_event(event);
+    if let Err(e) = self.listener.await_call(FnArgs { data: (binding_event,) }).await {
+      eprintln!("watcher on_event listener error: {e:?}");
+    }
+  }
+
+  async fn on_change(&self, path: &str, kind: WatcherChangeKind) {
+    let binding_event = BindingWatcherEvent::from_change(path.to_string(), kind.to_string());
+    if let Err(e) = self.listener.await_call(FnArgs { data: (binding_event,) }).await {
+      eprintln!("watcher on_change listener error: {e:?}");
+    }
+  }
+
+  async fn on_restart(&self) {
+    let binding_event = BindingWatcherEvent::from_restart();
+    if let Err(e) = self.listener.await_call(FnArgs { data: (binding_event,) }).await {
+      eprintln!("watcher on_restart listener error: {e:?}");
+    }
+  }
+
+  async fn on_close(&self) {
+    let binding_event = BindingWatcherEvent::from_close();
+    if let Err(e) = self.listener.await_call(FnArgs { data: (binding_event,) }).await {
+      eprintln!("watcher on_close listener error: {e:?}");
     }
   }
 }
 
+enum BindingWatcherState {
+  Pending { configs: Vec<rolldown::BundlerConfig>, watcher_config: WatcherConfig },
+  Running(rolldown_watcher::Watcher),
+  Closed,
+}
+
 #[napi]
 pub struct BindingWatcher {
-  inner: rolldown::Watcher,
+  state: std::sync::Mutex<BindingWatcherState>,
+  /// Stored separately so `wait_for_close` can await without holding the state mutex.
+  closed_notify: std::sync::Mutex<Option<Arc<napi::tokio::sync::Notify>>>,
 }
 
 #[napi]
 impl BindingWatcher {
   #[napi(constructor)]
-  pub fn new(
-    options: Vec<BindingBundlerOptions>,
-    notify_option: Option<BindingNotifyOption>,
-  ) -> napi::Result<Self> {
-    // TODO(hyf0): support emit debug data for builtin watch
-    let bundler_configs = options
+  pub fn new(options: Vec<BindingBundlerOptions>) -> napi::Result<Self> {
+    let configs = options
       .into_iter()
       .map(create_bundler_config_from_binding_options)
       .collect::<Result<Vec<_>, _>>()?;
 
-    let inner = rolldown::Watcher::with_configs(bundler_configs, notify_option.map(Into::into))
-      .map_err(|errs| {
-        napi::Error::new(
-          napi::Status::GenericFailure,
-          errs.iter().map(|e| e.to_diagnostic().to_string()).collect::<Vec<_>>().join("\n"),
-        )
-      })?;
+    // Forward the largest build_delay from configs to the watcher's debounce.
+    // This matches the old watcher's behavior of using the largest delay.
+    let build_delay =
+      configs.iter().filter_map(|c| c.options.watch.as_ref().and_then(|w| w.build_delay)).max();
 
-    Ok(Self { inner })
-  }
+    // Extract use_polling / poll_interval from the first config that specifies them.
+    let use_polling = configs
+      .iter()
+      .find_map(|c| c.options.watch.as_ref().filter(|w| w.use_polling).map(|w| w.use_polling))
+      .unwrap_or(false);
+    let poll_interval =
+      configs.iter().find_map(|c| c.options.watch.as_ref().and_then(|w| w.poll_interval));
 
-  #[tracing::instrument(level = "debug", skip_all)]
-  #[napi]
-  pub async fn close(&self) -> napi::Result<()> {
-    handle_result(self.inner.close().await)
+    let watcher_config = WatcherConfig {
+      debounce: build_delay.map(|ms| Duration::from_millis(u64::from(ms))),
+      use_polling,
+      poll_interval,
+    };
+
+    Ok(Self {
+      state: std::sync::Mutex::new(BindingWatcherState::Pending { configs, watcher_config }),
+      closed_notify: std::sync::Mutex::new(None),
+    })
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
@@ -70,31 +99,95 @@ impl BindingWatcher {
     &self,
     listener: MaybeAsyncJsCallback<FnArgs<(BindingWatcherEvent,)>>,
   ) -> napi::Result<()> {
-    let rx = Arc::clone(&self.inner.emitter().rx);
-    let future = async move {
-      let mut run = true;
-      let rx = rx.lock().await;
-      while run {
-        match rx.recv() {
-          Ok(event) => {
-            if let rolldown::WatcherEvent::Close = &event {
-              run = false;
-            }
-            tracing::debug!(name= "send event to js side", event = ?event);
-            if let Err(e) =
-              listener.await_call(FnArgs { data: (BindingWatcherEvent::new(event),) }).await
-            {
-              eprintln!("watcher listener error: {e:?}");
-            }
-          }
-          Err(e) => {
-            eprintln!("watcher receiver error: {e:?}");
-          }
+    let mut state = self
+      .state
+      .lock()
+      .map_err(|e| napi::Error::new(napi::Status::GenericFailure, format!("Lock poisoned: {e}")))?;
+
+    let (configs, watcher_config) =
+      match std::mem::replace(&mut *state, BindingWatcherState::Closed) {
+        BindingWatcherState::Pending { configs, watcher_config } => (configs, watcher_config),
+        other => {
+          *state = other;
+          return Err(napi::Error::new(
+            napi::Status::GenericFailure,
+            "Watcher is not in Pending state (already started or closed)",
+          ));
+        }
+      };
+
+    let handler = NapiWatcherEventHandler { listener: Arc::new(listener) };
+    let watcher = match rolldown_watcher::Watcher::with_multiple_bundler_configs(
+      configs,
+      handler,
+      &watcher_config,
+    ) {
+      Ok(w) => w,
+      Err(errs) => {
+        // Restore Pending state so the watcher can be retried.
+        *state = BindingWatcherState::Pending { configs: Vec::new(), watcher_config };
+        return Err(napi::Error::new(
+          napi::Status::GenericFailure,
+          errs.iter().map(|e| e.to_diagnostic().to_string()).collect::<Vec<_>>().join("\n"),
+        ));
+      }
+    };
+
+    // Store the closed_notify handle for wait_for_close()
+    let mut notify = self
+      .closed_notify
+      .lock()
+      .map_err(|e| napi::Error::new(napi::Status::GenericFailure, format!("Lock poisoned: {e}")))?;
+    *notify = Some(watcher.closed_notify());
+
+    *state = BindingWatcherState::Running(watcher);
+    Ok(())
+  }
+
+  /// Returns a Promise that resolves when the watcher closes.
+  /// The pending Promise keeps Node.js event loop alive (replaces setInterval hack).
+  #[tracing::instrument(level = "debug", skip_all)]
+  #[napi]
+  pub async fn wait_for_close(&self) -> napi::Result<()> {
+    let notify = {
+      let guard = self.closed_notify.lock().map_err(|e| {
+        napi::Error::new(napi::Status::GenericFailure, format!("Lock poisoned: {e}"))
+      })?;
+      guard.clone()
+    };
+
+    match notify {
+      Some(n) => {
+        n.notified().await;
+        Ok(())
+      }
+      None => Err(napi::Error::new(napi::Status::GenericFailure, "Watcher is not running")),
+    }
+  }
+
+  #[tracing::instrument(level = "debug", skip_all)]
+  #[napi]
+  pub async fn close(&self) -> napi::Result<()> {
+    let watcher = {
+      let mut state = self.state.lock().map_err(|e| {
+        napi::Error::new(napi::Status::GenericFailure, format!("Lock poisoned: {e}"))
+      })?;
+      match std::mem::replace(&mut *state, BindingWatcherState::Closed) {
+        BindingWatcherState::Running(watcher) => Some(watcher),
+        other => {
+          *state = other;
+          None
         }
       }
     };
-    napi::tokio::spawn(future);
-    self.inner.start().await;
+
+    if let Some(watcher) = watcher {
+      watcher
+        .close()
+        .await
+        .map_err(|e| napi::Error::new(napi::Status::GenericFailure, e.to_string()))?;
+    }
+
     Ok(())
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/watch_option.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/watch_option.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use derive_more::Debug;
 
@@ -17,6 +17,8 @@ use serde::{Deserialize, Deserializer};
 pub struct WatchOption {
   pub skip_write: bool,
   pub build_delay: Option<u32>,
+  pub use_polling: bool,
+  pub poll_interval: Option<u64>,
   #[cfg_attr(
     feature = "deserialize_bundler_options",
     serde(default, deserialize_with = "deserialize_string_or_regex"),
@@ -43,17 +45,6 @@ where
 {
   let deserialized = Option::<Vec<String>>::deserialize(deserializer)?;
   Ok(deserialized.map(|v| v.into_iter().map(StringOrRegex::String).collect::<Vec<_>>()))
-}
-
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(
-  feature = "deserialize_bundler_options",
-  derive(Deserialize, JsonSchema),
-  serde(rename_all = "camelCase", deny_unknown_fields)
-)]
-pub struct NotifyOption {
-  pub poll_interval: Option<Duration>,
-  pub compare_contents: bool,
 }
 
 // TODO should it be just placed here?

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -90,7 +90,7 @@ pub mod bundler_options {
       },
       tsconfig::TsConfig,
       tsconfig_merge::merge_transform_options_with_tsconfig as merge_tsconfig,
-      watch_option::{NotifyOption, OnInvalidate, WatchOption},
+      watch_option::{OnInvalidate, WatchOption},
     },
   };
 

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1434,6 +1434,17 @@
           "format": "uint32",
           "minimum": 0
         },
+        "usePolling": {
+          "type": "boolean"
+        },
+        "pollInterval": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
         "include": {
           "type": [
             "array",
@@ -1455,7 +1466,8 @@
       },
       "additionalProperties": false,
       "required": [
-        "skipWrite"
+        "skipWrite",
+        "usePolling"
       ]
     },
     "LegalComments": {

--- a/crates/rolldown_watcher/src/event.rs
+++ b/crates/rolldown_watcher/src/event.rs
@@ -1,5 +1,6 @@
 use crate::watch_task::WatchTaskIdx;
 use rolldown::Bundler;
+use rolldown_error::BuildDiagnostic;
 use std::fmt::{Debug, Display};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -67,7 +68,9 @@ impl Debug for BundleEndEventData {
 #[derive(Clone)]
 pub struct WatchErrorEventData {
   pub task_index: WatchTaskIdx,
-  pub errors: Vec<String>,
+  /// Raw diagnostics preserved for rich error conversion at the binding layer.
+  /// Wrapped in `Arc` because `BuildDiagnostic` is not `Clone`.
+  pub diagnostics: Arc<[BuildDiagnostic]>,
   pub cwd: PathBuf,
   pub bundler: Arc<Mutex<Bundler>>,
 }
@@ -76,7 +79,7 @@ impl Debug for WatchErrorEventData {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("WatchErrorEventData")
       .field("task_index", &self.task_index)
-      .field("errors", &self.errors)
+      .field("diagnostics", &self.diagnostics)
       .field("cwd", &self.cwd)
       .finish_non_exhaustive()
   }

--- a/crates/rolldown_watcher/src/watch_coordinator.rs
+++ b/crates/rolldown_watcher/src/watch_coordinator.rs
@@ -108,7 +108,8 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
         }
         Ok(BuildOutcome::Skipped) => {}
         Err(errs) => {
-          let error_messages: Vec<String> = errs.iter().map(|e| format!("{e:?}")).collect();
+          let error_messages: Vec<String> =
+            errs.iter().map(|e| e.to_diagnostic().to_string()).collect();
           tracing::error!("Fatal build error: {error_messages:?}");
         }
       }
@@ -162,7 +163,8 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
         }
         Ok(BuildOutcome::Skipped) => {}
         Err(errs) => {
-          let error_messages: Vec<String> = errs.iter().map(|e| format!("{e:?}")).collect();
+          let error_messages: Vec<String> =
+            errs.iter().map(|e| e.to_diagnostic().to_string()).collect();
           tracing::error!("Fatal build error: {error_messages:?}");
         }
       }

--- a/crates/rolldown_watcher/src/watcher.rs
+++ b/crates/rolldown_watcher/src/watcher.rs
@@ -6,22 +6,27 @@ use crate::watcher_msg::WatcherMsg;
 use anyhow::Result;
 use oxc_index::IndexVec;
 use rolldown::BundlerConfig;
-use rolldown_common::NotifyOption;
 use rolldown_error::BuildResult;
-use rolldown_fs_watcher::{FsWatcher, FsWatcherConfig, RecommendedFsWatcher};
+use rolldown_fs_watcher::{FsWatcher, FsWatcherConfig};
+#[cfg(not(target_family = "wasm"))]
+use rolldown_fs_watcher::{PollFsWatcher, RecommendedFsWatcher};
+use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Notify, mpsc, oneshot};
 
-/// Default debounce duration in milliseconds
-const DEFAULT_DEBOUNCE_MS: u64 = 100;
+/// Default debounce duration in milliseconds.
+/// Matches Rollup's default buildDelay of 0ms.
+const DEFAULT_DEBOUNCE_MS: u64 = 0;
 
 /// Configuration for the watcher
 #[derive(Debug, Clone, Default)]
 pub struct WatcherConfig {
   /// Debounce duration for file changes
   pub debounce: Option<Duration>,
-  /// Notify (file system watcher) options
-  pub notify: Option<NotifyOption>,
+  /// Whether to use polling-based file watching instead of native OS events
+  pub use_polling: bool,
+  /// Poll interval in milliseconds (only used when `use_polling` is true)
+  pub poll_interval: Option<u64>,
 }
 
 impl WatcherConfig {
@@ -29,14 +34,10 @@ impl WatcherConfig {
     self.debounce.unwrap_or(Duration::from_millis(DEFAULT_DEBOUNCE_MS))
   }
 
-  #[expect(clippy::cast_possible_truncation)]
   fn to_fs_watcher_config(&self) -> FsWatcherConfig {
     let mut config = FsWatcherConfig::default();
-    if let Some(notify) = &self.notify {
-      if let Some(poll_interval) = notify.poll_interval {
-        config.poll_interval = poll_interval.as_millis() as u64;
-      }
-      config.compare_contents_for_polling = notify.compare_contents;
+    if let Some(poll_interval) = self.poll_interval {
+      config.poll_interval = poll_interval;
     }
     config
   }
@@ -46,6 +47,7 @@ impl WatcherConfig {
 pub struct Watcher {
   tx: mpsc::UnboundedSender<WatcherMsg>,
   task_handle: tokio::task::JoinHandle<()>,
+  closed_notify: Arc<Notify>,
 }
 
 impl Drop for Watcher {
@@ -79,18 +81,41 @@ impl Watcher {
     for (index, config) in configs.into_iter().enumerate() {
       let task_index = WatchTaskIdx::from_usize(index);
       let fs_handler = TaskFsEventHandler { task_index, tx: tx.clone() };
-      let fs_watcher: Box<dyn FsWatcher + Send + 'static> =
-        Box::new(RecommendedFsWatcher::with_config(fs_handler, fs_watcher_config.clone())?);
+      #[cfg(not(target_family = "wasm"))]
+      let fs_watcher: Box<dyn FsWatcher + Send + 'static> = if watcher_config.use_polling {
+        Box::new(PollFsWatcher::with_config(fs_handler, fs_watcher_config.clone())?)
+      } else {
+        Box::new(RecommendedFsWatcher::with_config(fs_handler, fs_watcher_config.clone())?)
+      };
+      #[cfg(target_family = "wasm")]
+      let fs_watcher: Box<dyn FsWatcher + Send + 'static> = Box::new(
+        rolldown_fs_watcher::NoopFsWatcher::with_config(fs_handler, fs_watcher_config.clone())?,
+      );
       let task = WatchTask::new(config, fs_watcher)?;
       tasks.push(task);
     }
 
     let coordinator = WatchCoordinator::new(rx, handler, tasks, watcher_config);
+    let closed_notify = Arc::new(Notify::new());
+    let notify_clone = Arc::clone(&closed_notify);
     let task_handle = tokio::spawn(async move {
       coordinator.run().await;
+      notify_clone.notify_waiters();
     });
 
-    Ok(Self { tx, task_handle })
+    Ok(Self { tx, task_handle, closed_notify })
+  }
+
+  /// Get the closed notification handle.
+  /// Useful for NAPI bindings where the lock can't be held across await points.
+  pub fn closed_notify(&self) -> Arc<Notify> {
+    Arc::clone(&self.closed_notify)
+  }
+
+  /// Wait until the watcher coordinator finishes (i.e., after close).
+  /// On NAPI side, the pending Promise keeps Node.js event loop alive.
+  pub async fn wait_for_close(&self) {
+    self.closed_notify.notified().await;
   }
 
   /// Close the watcher
@@ -117,40 +142,21 @@ mod tests {
 
   #[test]
   fn test_watcher_config_custom_debounce() {
-    let config = WatcherConfig { debounce: Some(Duration::from_millis(500)), notify: None };
+    let config = WatcherConfig { debounce: Some(Duration::from_millis(500)), ..Default::default() };
     assert_eq!(config.debounce_duration(), Duration::from_millis(500));
   }
 
   #[test]
-  fn test_fs_watcher_config_defaults_when_notify_is_none() {
-    let config = WatcherConfig { debounce: None, notify: None };
+  fn test_fs_watcher_config_defaults() {
+    let config = WatcherConfig::default();
     let fs_config = config.to_fs_watcher_config();
     assert_eq!(fs_config.poll_interval, 100);
-    assert!(!fs_config.compare_contents_for_polling);
   }
 
   #[test]
   fn test_fs_watcher_config_with_poll_interval() {
-    let config = WatcherConfig {
-      debounce: None,
-      notify: Some(NotifyOption {
-        poll_interval: Some(Duration::from_millis(250)),
-        compare_contents: false,
-      }),
-    };
+    let config = WatcherConfig { poll_interval: Some(250), ..Default::default() };
     let fs_config = config.to_fs_watcher_config();
     assert_eq!(fs_config.poll_interval, 250);
-    assert!(!fs_config.compare_contents_for_polling);
-  }
-
-  #[test]
-  fn test_fs_watcher_config_with_compare_contents() {
-    let config = WatcherConfig {
-      debounce: None,
-      notify: Some(NotifyOption { poll_interval: None, compare_contents: true }),
-    };
-    let fs_config = config.to_fs_watcher_config();
-    assert_eq!(fs_config.poll_interval, 100);
-    assert!(fs_config.compare_contents_for_polling);
   }
 }

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1689,9 +1689,14 @@ export declare class BindingTransformPluginContext {
 }
 
 export declare class BindingWatcher {
-  constructor(options: Array<BindingBundlerOptions>, notifyOption?: BindingNotifyOption | undefined | null)
-  close(): Promise<void>
+  constructor(options: Array<BindingBundlerOptions>)
   start(listener: (data: BindingWatcherEvent) => void): Promise<void>
+  /**
+   * Returns a Promise that resolves when the watcher closes.
+   * The pending Promise keeps Node.js event loop alive (replaces setInterval hack).
+   */
+  waitForClose(): Promise<void>
+  close(): Promise<void>
 }
 
 /**
@@ -1709,10 +1714,10 @@ export declare class BindingWatcherChangeData {
 
 export declare class BindingWatcherEvent {
   eventKind(): string
-  watchChangeData(): BindingWatcherChangeData
-  bundleEndData(): BindingBundleEndEventData
   bundleEventKind(): string
+  bundleEndData(): BindingBundleEndEventData
   bundleErrorData(): BindingBundleErrorEventData
+  watchChangeData(): BindingWatcherChangeData
 }
 
 export declare class ParallelJsPluginRegistry {
@@ -2333,11 +2338,6 @@ export interface BindingModuleSideEffectsRule {
   external?: boolean | undefined
 }
 
-export interface BindingNotifyOption {
-  pollInterval?: number
-  compareContents?: boolean
-}
-
 export interface BindingOptimization {
   inlineConst?: boolean | BindingInlineConstConfig
   pifeForModuleWrappers?: boolean
@@ -2772,6 +2772,8 @@ export interface BindingWatchOption {
   include?: Array<BindingStringOrRegex>
   exclude?: Array<BindingStringOrRegex>
   buildDelay?: number
+  usePolling?: boolean
+  pollInterval?: number
   onInvalidate?: ((id: string) => void) | undefined
 }
 

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -26,6 +26,7 @@ import type {
   InputOptions,
   ModuleTypes,
   OptimizationOptions,
+  WatcherFileWatcherOptions,
   WatcherOptions,
 } from './options/input-options';
 import type { TransformOptions } from './options/transform-options';
@@ -217,6 +218,7 @@ export type {
   TransformResult,
   TreeshakingOptions,
   WarningHandlerWithDefault,
+  WatcherFileWatcherOptions,
   WatcherOptions,
   WatchOptions,
 };

--- a/packages/rolldown/src/log/logs.ts
+++ b/packages/rolldown/src/log/logs.ts
@@ -6,7 +6,7 @@ const INVALID_LOG_POSITION = 'INVALID_LOG_POSITION',
   PLUGIN_ERROR = 'PLUGIN_ERROR',
   INPUT_HOOK_IN_OUTPUT_PLUGIN = 'INPUT_HOOK_IN_OUTPUT_PLUGIN',
   CYCLE_LOADING = 'CYCLE_LOADING',
-  MULTIPLY_NOTIFY_OPTION = 'MULTIPLY_NOTIFY_OPTION',
+  MULTIPLE_WATCHER_OPTION = 'MULTIPLE_WATCHER_OPTION',
   PARSE_ERROR = 'PARSE_ERROR',
   NO_FS_IN_BROWSER = 'NO_FS_IN_BROWSER';
 
@@ -40,10 +40,10 @@ export function logCycleLoading(pluginName: string, moduleId: string): RolldownL
   };
 }
 
-export function logMultiplyNotifyOption(): RolldownLog {
+export function logMultipleWatcherOption(): RolldownLog {
   return {
-    code: MULTIPLY_NOTIFY_OPTION,
-    message: `Found multiply notify option at watch options, using first one to start notify watcher.`,
+    code: MULTIPLE_WATCHER_OPTION,
+    message: `Found multiple watcher options at watch options, using first one to start watcher.`,
   };
 }
 

--- a/packages/rolldown/src/options/input-options.ts
+++ b/packages/rolldown/src/options/input-options.ts
@@ -54,6 +54,26 @@ export type ModuleTypes = Record<
   | 'copy'
 >;
 
+export interface WatcherFileWatcherOptions {
+  /**
+   * Whether to use polling-based file watching instead of native OS events.
+   *
+   * Polling is useful for environments where native FS events are unreliable,
+   * such as network mounts, Docker volumes, or WSL2.
+   *
+   * @default false
+   */
+  usePolling?: boolean;
+  /**
+   * Interval between each poll in milliseconds.
+   *
+   * This option is only used when {@linkcode usePolling} is `true`.
+   *
+   * @default 100
+   */
+  pollInterval?: number;
+}
+
 export interface WatcherOptions {
   /**
    * Whether to skip the {@linkcode RolldownBuild.write | bundle.write()} step when a rebuild is triggered.
@@ -79,32 +99,13 @@ export interface WatcherOptions {
    */
   buildDelay?: number;
   /**
-   * An optional object of options that will be passed to the [notify](https://github.com/rolldown/notify) file watcher.
+   * File watcher options for configuring how file changes are detected.
    */
-  notify?: {
-    /**
-     * Interval between each re-scan attempt in milliseconds.
-     *
-     * This option is only used when polling backend is used.
-     *
-     * @default 30_000
-     */
-    pollInterval?: number;
-    /**
-     * Whether to compare file contents when checking for changes.
-     *
-     * This is especially important for pseudo filesystems like those on Linux
-     * under `/sys` and `/proc` which are not obligated to respect any other
-     * filesystem norms such as modification timestamps, file sizes, etc. By
-     * enabling this feature, performance will be significantly impacted as
-     * all files will need to be read and hashed at each interval.
-     *
-     * This option is only used when polling backend is used.
-     *
-     * @default false
-     */
-    compareContents?: boolean;
-  };
+  watcher?: WatcherFileWatcherOptions;
+  /**
+   * @deprecated Use {@linkcode watcher} instead.
+   */
+  notify?: WatcherFileWatcherOptions;
   /**
    * Filter to limit the file-watching to certain files.
    *

--- a/packages/rolldown/src/utils/bindingify-input-options.ts
+++ b/packages/rolldown/src/utils/bindingify-input-options.ts
@@ -292,9 +292,16 @@ function bindingifyInput(input: InputOptions['input']): BindingInputOptions['inp
 
 function bindingifyWatch(watch: InputOptions['watch']): BindingInputOptions['watch'] {
   if (watch) {
+    if (watch.notify) {
+      console.warn('The "watch.notify" option is deprecated. Please use "watch.watcher" instead.');
+    }
+    // Merge deprecated `notify` into `watcher`, with `watcher` taking precedence
+    const watcher = { ...watch.notify, ...watch.watcher };
     return {
       buildDelay: watch.buildDelay,
       skipWrite: watch.skipWrite,
+      usePolling: watcher.usePolling,
+      pollInterval: watcher.pollInterval,
       include: normalizedStringOrRegex(watch.include),
       exclude: normalizedStringOrRegex(watch.exclude),
       onInvalidate: (...args) => watch.onInvalidate?.(...args),

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -259,21 +259,25 @@ const TransformOptionsSchema = v.object({
 });
 isTypeTrue<IsSchemaSubType<typeof TransformOptionsSchema, TransformOptions>>();
 
+const WatcherFileWatcherOptionsSchema = v.strictObject({
+  usePolling: v.pipe(
+    v.optional(v.boolean()),
+    v.description('Use polling-based file watching instead of native OS events'),
+  ),
+  pollInterval: v.pipe(
+    v.optional(v.number()),
+    v.description('Poll interval in milliseconds (only used when usePolling is true)'),
+  ),
+});
+
 const WatcherOptionsSchema = v.strictObject({
   chokidar: v.optional(
-    v.never(`The "watch.chokidar" option is deprecated, please use "watch.notify" instead of it`),
+    v.never(`The "watch.chokidar" option is deprecated, please use "watch.watcher" instead of it`),
   ),
   exclude: v.optional(v.union([StringOrRegExpSchema, v.array(StringOrRegExpSchema)])),
   include: v.optional(v.union([StringOrRegExpSchema, v.array(StringOrRegExpSchema)])),
-  notify: v.pipe(
-    v.optional(
-      v.strictObject({
-        compareContents: v.optional(v.boolean()),
-        pollInterval: v.optional(v.number()),
-      }),
-    ),
-    v.description('Notify options'),
-  ),
+  watcher: v.optional(WatcherFileWatcherOptionsSchema),
+  notify: v.optional(WatcherFileWatcherOptionsSchema),
   skipWrite: v.pipe(v.optional(v.boolean()), v.description('Skip the bundle.write() step')),
   buildDelay: v.pipe(v.optional(v.number()), v.description('Throttle watch rebuilds')),
   clearScreen: v.pipe(

--- a/packages/rolldown/tests/validate-option.test.ts
+++ b/packages/rolldown/tests/validate-option.test.ts
@@ -22,11 +22,7 @@ test('validate input option', async () => {
     },
   });
   expect(consoleSpy).toHaveBeenCalledWith(
-    `\x1b[33mWarning: Invalid input options (4 issues found)
-- For the "input". Invalid type: Expected (string | Array | Object) but received 1. 
-- For the "resolve.foo". Invalid key: Expected never but received "foo". 
-- For the "watch.chokidar". The "watch.chokidar" option is deprecated, please use "watch.notify" instead of it. 
-- For the "foo". Invalid key: Expected never but received "foo". \x1b[0m`,
+    `\x1b[33mWarning: Invalid input options (4 issues found)\n- For the "input". Invalid type: Expected (string | Array | Object) but received 1. \n- For the "resolve.foo". Invalid key: Expected never but received "foo". \n- For the "watch.chokidar". The "watch.chokidar" option is deprecated, please use "watch.watcher" instead of it. \n- For the "foo". Invalid key: Expected never but received "foo". \x1b[0m`,
   );
 });
 
@@ -42,8 +38,7 @@ test('validate output option', async () => {
     hoistTransitiveImports: false,
   });
   expect(consoleSpy).toHaveBeenCalledWith(
-    `\x1b[33mWarning: Invalid output options (1 issue found)
-- For the "foo". Invalid key: Expected never but received "foo". \x1b[0m`,
+    `\x1b[33mWarning: Invalid output options (1 issue found)\n- For the "foo". Invalid key: Expected never but received "foo". \x1b[0m`,
   );
 });
 
@@ -58,7 +53,6 @@ test('give a warning for hoistTransitiveImports: true', async () => {
     hoistTransitiveImports: true,
   });
   expect(consoleSpy).toHaveBeenCalledWith(
-    `\x1b[33mWarning: Invalid output options (1 issue found)
-- For the "hoistTransitiveImports". Invalid type: Expected false but received true. \x1b[0m`,
+    `\x1b[33mWarning: Invalid output options (1 issue found)\n- For the "hoistTransitiveImports". Invalid type: Expected false but received true. \x1b[0m`,
   );
 });


### PR DESCRIPTION
## Summary

Wire up `rolldown_watcher` to fully replace the legacy watcher (`crates/rolldown/src/watch/`).

- Deprecate `watch.notify` option and add `watch.watcher` with `usePolling` / `pollInterval` (flat options instead of nested notify struct)
- Replace `setInterval` keep-alive hack with pending `waitForClose()` Promise
- Move event dispatching from channel-based (`rx.recv()` loop) to trait-based (`WatcherEventHandler`)
- Use `with_cached_bundle_experimental` for split-phase builds — register FS watches between scan and write so render-hook file changes are detected (see `meta/design/watch-mode.md` "Split-Phase Build")
- Add kind consolidation during debounce (Create+Update→Create, Create+Delete→removed, Delete+Create→Update) — see `meta/design/watch-mode.md` "Kind Consolidation"
- Simplify `WatcherEmitter` to a thin `emit()` dispatcher, move event decoding to `Watcher.createEventCallback()`
- Add `BindingWatcherState` (Pending→Running→Closed) in NAPI binding layer

---

I will fix reviews in separate PRs, this PR is too cumbersome to make changes

## Test plan

- [x] `cargo test -p rolldown_watcher` — 17 unit tests pass
- [x] `pnpm --filter rolldown-tests test:watcher` — 25 integration tests pass
- [x] `just roll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)