### PR TITLE
test: normalize paths on Windows even if `resolve.symlinks` is false

### DIFF
--- a/packages/rolldown/tests/fixtures/resolve/windows-normalize/_config.ts
+++ b/packages/rolldown/tests/fixtures/resolve/windows-normalize/_config.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: [path.join(__dirname, './main.js').replaceAll('\\', '/')],
+    resolve: {
+      symlinks: false,
+    },
+  },
+  afterTest(output) {
+    function countOccurrences(str: string, substr: string) {
+      let count = 0;
+      let index = str.indexOf(substr);
+      while (index !== -1) {
+        count++;
+        index = str.indexOf(substr, index + 1);
+      }
+      return count;
+    }
+
+    expect(countOccurrences(output.output[0].code, 'console.log')).toBe(1);
+  },
+});

--- a/packages/rolldown/tests/fixtures/resolve/windows-normalize/main.js
+++ b/packages/rolldown/tests/fixtures/resolve/windows-normalize/main.js
@@ -1,0 +1,3 @@
+import './main.js';
+
+console.log('main');


### PR DESCRIPTION
This test was passing with Rollup, but doesn't with Rolldown. Fixed by https://github.com/oxc-project/oxc-resolver/pull/1036.