### PR TITLE
perf(rust/tla): skip compute_tla if there is no module use TLA

### DIFF
--- a/crates/rolldown/src/stages/link_stage/compute_tla.rs
+++ b/crates/rolldown/src/stages/link_stage/compute_tla.rs
@@ -14,7 +14,10 @@ enum TlaVisitState {
 impl LinkStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
   pub(super) fn compute_tla(&mut self) {
-    // TODO: skip this phase if there is no module use TLA
+    if self.tla_module_count == 0 {
+      return;
+    }
+
     fn is_tla(
       module_idx: ModuleIdx,
       module_table: &ModuleTable,

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -101,6 +101,7 @@ pub struct LinkStage<'a> {
   pub flat_options: FlatOptions,
   pub side_effects_free_function_symbol_ref: FxHashSet<SymbolRef>,
   pub user_defined_entry_modules: FxHashSet<ModuleIdx>,
+  pub tla_module_count: usize,
 }
 
 impl<'a> LinkStage<'a> {
@@ -188,6 +189,7 @@ impl<'a> LinkStage<'a> {
       flat_options: scan_stage_output.flat_options,
       side_effects_free_function_symbol_ref: FxHashSet::default(),
       user_defined_entry_modules: scan_stage_output.user_defined_entry_modules,
+      tla_module_count: scan_stage_output.tla_module_count,
     }
   }
 

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -51,6 +51,7 @@ pub struct NormalizedScanStageOutput {
   pub entry_point_to_reference_ids: FxHashMap<EntryPoint, Vec<ArcStr>>,
   pub flat_options: FlatOptions,
   pub user_defined_entry_modules: FxHashSet<ModuleIdx>,
+  pub tla_module_count: usize,
 }
 
 impl NormalizedScanStageOutput {
@@ -79,6 +80,7 @@ impl NormalizedScanStageOutput {
       entry_point_to_reference_ids: self.entry_point_to_reference_ids.clone(),
       flat_options: self.flat_options,
       user_defined_entry_modules: self.user_defined_entry_modules.clone(),
+      tla_module_count: self.tla_module_count,
     }
   }
 }
@@ -109,6 +111,7 @@ impl TryFrom<ScanStageOutput> for NormalizedScanStageOutput {
       entry_point_to_reference_ids: value.entry_point_to_reference_ids,
       flat_options: value.flat_options,
       user_defined_entry_modules: value.user_defined_entry_modules,
+      tla_module_count: value.tla_module_count,
     })
   }
 }
@@ -126,6 +129,7 @@ pub struct ScanStageOutput {
   pub entry_point_to_reference_ids: FxHashMap<EntryPoint, Vec<ArcStr>>,
   pub flat_options: FlatOptions,
   pub user_defined_entry_modules: FxHashSet<ModuleIdx>,
+  pub tla_module_count: usize,
 }
 
 impl ScanStage {
@@ -326,6 +330,7 @@ impl From<ModuleLoaderOutput> for ScanStageOutput {
       entry_point_to_reference_ids,
       flat_options,
       user_defined_entry_modules,
+      tla_module_count,
     } = module_loader_output;
     ScanStageOutput {
       module_table,
@@ -339,6 +344,7 @@ impl From<ModuleLoaderOutput> for ScanStageOutput {
       entry_point_to_reference_ids,
       flat_options,
       user_defined_entry_modules,
+      tla_module_count,
     }
   }
 }

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -115,7 +115,11 @@ impl ScanStageCache {
       let old_has_tla = module_has_tla(&cache.module_table[idx]);
       let new_has_tla = module_has_tla(&new_module);
       if old_has_tla && !new_has_tla {
-        cache.tla_module_count = cache.tla_module_count.saturating_sub(1);
+        debug_assert!(
+          cache.tla_module_count > 0,
+          "tla_module_count underflow: decrement called when count is already 0"
+        );
+        cache.tla_module_count -= 1;
       } else if !old_has_tla && new_has_tla {
         cache.tla_module_count += 1;
       }

--- a/crates/rolldown/src/types/scan_stage_cache.rs
+++ b/crates/rolldown/src/types/scan_stage_cache.rs
@@ -63,6 +63,12 @@ impl ScanStageCache {
   }
 
   pub fn merge(&mut self, mut scan_stage_output: ScanStageOutput) -> BuildResult<()> {
+    fn module_has_tla(module: &Module) -> bool {
+      module.as_normal().is_some_and(|normal_module| {
+        normal_module.ast_usage.contains(EcmaModuleAstUsage::TopLevelAwait)
+      })
+    }
+
     let Some(ref mut cache) = self.snapshot else {
       self.snapshot = Some(
         scan_stage_output.try_into().map_err(|e: &'static str| vec![anyhow::anyhow!(e).into()])?,
@@ -80,11 +86,6 @@ impl ScanStageCache {
       }
     };
     // merge module_table, index_ast_scope, index_ecma_ast
-    let module_has_tla = |module: &Module| {
-      module.as_normal().is_some_and(|normal_module| {
-        normal_module.ast_usage.contains(EcmaModuleAstUsage::TopLevelAwait)
-      })
-    };
     for (new_idx, new_module) in modules {
       let idx = self.module_id_to_idx[new_module.id()].idx();
 


### PR DESCRIPTION
A todo in `compute_tla`  indicates that this process could be skipped when there is no module that uses TLA — which is also the common case for many real-world projects.

This PR tracks the count of TLA-using modules during the scan stage and stores it in `tla_module_count`. Link stage will check this counter and return early if the count is zero.
