### PR TITLE
fix(rolldown_plugin_vite_web_worker_post): avoid replacing `new.target`

### DIFF
--- a/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
+++ b/crates/rolldown_plugin_vite_web_worker_post/src/ast_visitor.rs
@@ -70,7 +70,9 @@ impl<'ast> VisitMut<'ast> for WebWorkerPostVisitor<'ast> {
           *it = self.create_self_location_href_expr();
         }
       }
-      Expression::MetaProperty(_) => {
+      Expression::MetaProperty(meta)
+        if meta.meta.name == "import" && meta.property.name == "meta" =>
+      {
         self.should_inject_import_meta_object = true;
         *it = self.ast_snippet.id_ref_expr("_vite_importMeta", SPAN);
       }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/vite-web-worker-post/new-target/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/vite-web-worker-post/new-target/_config.ts
@@ -1,0 +1,23 @@
+import { defineTest } from 'rolldown-tests';
+import { viteWebWorkerPostPlugin } from 'rolldown/experimental';
+import type { OutputChunk } from 'rolldown';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    input: './main.js',
+    plugins: [viteWebWorkerPostPlugin()],
+  },
+  afterTest(output) {
+    const chunk = output.output.find(
+      (item): item is OutputChunk => item.type === 'chunk' && item.name === 'main',
+    );
+    expect(chunk).toBeDefined();
+    const code = chunk!.code;
+    // new.target must be preserved, not replaced with _vite_importMeta
+    expect(code).toContain('new.target');
+    expect(code).not.toContain('_vite_importMeta.prototype');
+    // import.meta should still be transformed
+    expect(code).not.toContain('import.meta');
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/vite-web-worker-post/new-target/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/vite-web-worker-post/new-target/main.js
@@ -1,0 +1,10 @@
+class CustomError extends Error {
+  constructor(message) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+console.log(import.meta.url);
+
+export { CustomError };


### PR DESCRIPTION
fixes https://github.com/vitejs/rolldown-vite/issues/601