### PR TITLE
docs: fix error type for `RolldownBuild.generate` and others

### DIFF
--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -10,7 +10,7 @@ import { validateOption } from '../../utils/validator';
 // oxlint-disable-next-line no-unused-vars -- this is used in JSDoc links
 import type { rolldown } from './index';
 // oxlint-disable-next-line no-unused-vars -- this is used in JSDoc links
-import type { RolldownError } from '../../log/logging';
+import type { BundleError } from '../../utils/error';
 
 // @ts-expect-error TS2540: the polyfill of `asyncDispose`.
 Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose');
@@ -50,7 +50,7 @@ export class RolldownBuild {
    *
    * @param outputOptions The output options.
    * @returns The generated bundle.
-   * @throws {@linkcode RolldownError} When an error occurs during the build.
+   * @throws {@linkcode BundleError} When an error occurs during the build.
    */
   async generate(outputOptions: OutputOptions = {}): Promise<RolldownOutput> {
     return this.#build(false, outputOptions);
@@ -63,7 +63,7 @@ export class RolldownBuild {
    *
    * @param outputOptions The output options.
    * @returns The generated bundle.
-   * @throws {@linkcode RolldownError} When an error occurs during the build.
+   * @throws {@linkcode BundleError} When an error occurs during the build.
    */
   async write(outputOptions: OutputOptions = {}): Promise<RolldownOutput> {
     return this.#build(true, outputOptions);

--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -113,12 +113,14 @@ import {
   type ConfigExport,
   type RolldownOptionsFunction,
 } from './utils/define-config';
+import type { BundleError } from './utils/error';
 
 export { RUNTIME_MODULE_ID, VERSION } from './constants';
 export { build, defineConfig, rolldown, watch };
 export { BindingMagicString } from './binding.cjs';
 export type {
   AddonFunction,
+  BundleError,
   CodeSplittingGroup,
   CodeSplittingOptions,
   AsyncPluginHooks,

--- a/packages/rolldown/src/plugin/index.ts
+++ b/packages/rolldown/src/plugin/index.ts
@@ -30,6 +30,8 @@ import type { TreeshakingOptions } from '../types/module-side-effects';
 import type { WatcherOptions } from '../options/input-options';
 // oxlint-disable-next-line no-unused-vars -- this is used in JSDoc links
 import type { RolldownBuild } from '../api/rolldown/rolldown-build';
+// oxlint-disable-next-line no-unused-vars -- this is used in JSDoc links
+import type { BundleError } from '../utils/error';
 
 type ModuleSideEffects = boolean | 'no-treeshake' | null;
 export { withFilter } from './with-filter';
@@ -375,7 +377,7 @@ export interface FunctionPluginHooks {
    */
   [DEFINED_HOOK_NAMES.buildEnd]: (
     this: PluginContext,
-    /** The error occurred during the build if applicable. */
+    /** The error occurred during the build if applicable. Normally {@linkcode BundleError} */
     err?: Error,
   ) => void;
 
@@ -454,7 +456,11 @@ export interface FunctionPluginHooks {
    *
    * @group Output Generation Hooks
    */
-  [DEFINED_HOOK_NAMES.renderError]: (this: PluginContext, error: Error) => void;
+  [DEFINED_HOOK_NAMES.renderError]: (
+    this: PluginContext,
+    /** The error that occurred during the build. Normally {@linkcode BundleError} */
+    error: Error,
+  ) => void;
 
   /**
    * Called at the end of {@linkcode RolldownBuild.generate | bundle.generate()} or

--- a/packages/rolldown/src/utils/error.ts
+++ b/packages/rolldown/src/utils/error.ts
@@ -41,7 +41,19 @@ export function normalizeBindingError(e: BindingError): Error {
       });
 }
 
-export function aggregateBindingErrorsIntoJsError(rawErrors: BindingError[]): Error {
+/**
+ * The error type that is thrown by Rolldown for the whole build.
+ */
+export type BundleError = Error & {
+  /**
+   * The individual errors that happened during the build.
+   *
+   * This property is a getter to avoid unnecessary expansion of error details when the error is logged.
+   */
+  errors?: RolldownError[];
+};
+
+export function aggregateBindingErrorsIntoJsError(rawErrors: BindingError[]): BundleError {
   const errors = rawErrors.map(normalizeBindingError);
 
   // based on https://github.com/evanw/esbuild/blob/9eca46464ed5615cb36a3beb3f7a7b9a8ffbe7cf/lib/shared/common.ts#L1673


### PR DESCRIPTION
```
@throws {@linkcode RolldownError} When an error occurs during the build.
```
should be
```
@throws {@linkcode BundleError} When an error occurs during the build.
```
. `BundleError` here is
```ts
export type BundleError = Error & {
  errors?: RolldownError[];
};
```
