### PR TITLE
ci: add s390x and ppc64le linux gnu targets

### DIFF
--- a/.github/workflows/reusable-release-build.yml
+++ b/.github/workflows/reusable-release-build.yml
@@ -57,8 +57,18 @@ jobs:
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
+            build: pnpm ci:build-release-binding -x --target aarch64-unknown-linux-musl
+
+          - os: ubuntu-latest
+            target: s390x-unknown-linux-gnu
             build: |
-              pnpm ci:build-release-binding -x --target aarch64-unknown-linux-musl
+              export CFLAGS="-fuse-ld=lld"
+              pnpm ci:build-release-binding --target s390x-unknown-linux-gnu --use-napi-cross
+
+          - os: ubuntu-latest
+            target: powerpc64le-unknown-linux-gnu
+            build: pnpm ci:build-release-binding --target powerpc64le-unknown-linux-gnu --use-napi-cross
+
           - os: ubuntu-latest
             target: wasm32-wasip1-threads
             build: |
@@ -81,7 +91,7 @@ jobs:
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         if: ${{ contains(matrix.target, 'musl') }}
         with:
-          version: 0.14.1
+          version: 0.15.2
 
       - name: Setup OpenHarmony SDK
         if: ${{ contains(matrix.target, 'ohos') }}
@@ -129,7 +139,7 @@ jobs:
           RUSTUP_IO_THREADS: 1
         with:
           operating_system: freebsd
-          version: '14.2'
+          version: '15.0'
           memory: 8G
           cpu_count: 3
           environment_variables: 'DEBUG RUSTUP_IO_THREADS'

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -159,7 +159,9 @@
       "aarch64-unknown-linux-ohos",
       "aarch64-pc-windows-msvc",
       "aarch64-linux-android",
-      "wasm32-wasip1-threads"
+      "wasm32-wasip1-threads",
+      "s390x-unknown-linux-gnu",
+      "powerpc64le-unknown-linux-gnu"
     ],
     "wasm": {
       "initialMemory": 16384,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: CI/workflow and packaging metadata changes only; main risk is potential release-build failures for the new architectures.
> 
> **Overview**
> Expands the release build matrix to produce `@rolldown/binding` artifacts for **Linux `s390x-unknown-linux-gnu`** and **`powerpc64le-unknown-linux-gnu`** (using `--use-napi-cross`, with `s390x` forcing `CFLAGS=-fuse-ld=lld`).
> 
> Updates tooling versions used in CI by bumping Zig for musl builds to `0.15.2` and the FreeBSD VM version to `15.0`, and adds the two new targets to `packages/rolldown/package.json` `napi.targets` so they are included in published binaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73b60668b3775c9a5378744d38f6561f462f707a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->