### PR TITLE
docs: use `vitepress-plugin-graphviz`

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,7 +5,8 @@ import { type DefaultTheme, defineConfig } from 'vitepress';
 import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons';
 import llmstxt from 'vitepress-plugin-llms';
 import { addOgImage } from 'vitepress-plugin-og';
-import { hooksGraphPlugin } from './markdown-hooks-graph.ts';
+import { graphvizMarkdownPlugin } from 'vitepress-plugin-graphviz';
+import { createHooksGraphProcessor } from './markdown-hooks-graph.ts';
 
 const sidebarForUserGuide: DefaultTheme.SidebarItem[] = [
   {
@@ -418,7 +419,9 @@ const config = defineConfig({
   markdown: {
     async config(md) {
       md.use(groupIconMdPlugin);
-      await hooksGraphPlugin(md);
+      await graphvizMarkdownPlugin(md, {
+        processors: { 'hooks-graph': createHooksGraphProcessor() },
+      });
     },
   },
   async transformPageData(pageData, ctx) {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,5 +1,6 @@
 import RolldownTheme from '@voidzero-dev/vitepress-theme/src/rolldown';
 import 'virtual:group-icons.css';
+import 'vitepress-plugin-graphviz/style.css';
 import type { Theme } from 'vitepress';
 import DefinedIn from './components/DefinedIn.vue';
 import './styles.css';

--- a/docs/.vitepress/theme/styles.css
+++ b/docs/.vitepress/theme/styles.css
@@ -17,14 +17,6 @@
 }
 
 /* For markdown-hooks-graph diagrams */
-:root.dark .light-only {
-  display: none !important;
-}
-
-:root:not(.dark) .dark-only {
-  display: none !important;
-}
-
 a text {
   text-decoration: underline;
 }

--- a/docs/apis/plugin-api.md
+++ b/docs/apis/plugin-api.md
@@ -101,7 +101,7 @@ Build hooks are run during the build phase. They are mainly concerned with locat
 
 The first hook of the build phase is [`options`](/reference/Interface.Plugin#options), the last one is always [`buildEnd`](/reference/Interface.Plugin#buildend). If there is a build error, [`closeBundle`](/reference/Interface.Plugin#closebundle) will be called after that.
 
-```hooks-graph
+```dot+hooks-graph
 # styles
 sequential: fillcolor="#ffe8cc", dark$fillcolor="#9d4f1a"
 parallel: fillcolor="#ffcccc", dark$fillcolor="#8a2a2a"
@@ -161,7 +161,7 @@ The first hook of the output generation phase is [`renderStart`](/reference/Inte
 
 Additionally, [`closeBundle`](/reference/Interface.Plugin#closebundle) can be called as the very last hook, but it is the responsibility of the User to manually call [`bundle.close()`](/reference/Interface.RolldownBuild#close) to trigger this. The CLI will always make sure this is the case.
 
-```hooks-graph
+```dot+hooks-graph
 # config
 margin=150,0
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,8 +12,6 @@
     "vue": "catalog:"
   },
   "devDependencies": {
-    "@hpcc-js/wasm-graphviz": "^1.8.0",
-    "@types/markdown-it": "^14.1.2",
     "@voidzero-dev/vitepress-theme": "^4.2.1",
     "oxc-minify": "catalog:",
     "typedoc": "^0.28.14",
@@ -21,6 +19,7 @@
     "typedoc-plugin-merge-modules": "^7.0.0",
     "typedoc-vitepress-theme": "^1.1.2",
     "vitepress": "catalog:",
+    "vitepress-plugin-graphviz": "catalog:",
     "vitepress-plugin-group-icons": "catalog:",
     "vitepress-plugin-llms": "catalog:",
     "vitepress-plugin-og": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ catalogs:
     vitepress:
       specifier: ^2.0.0-alpha.15
       version: 2.0.0-alpha.16
+    vitepress-plugin-graphviz:
+      specifier: ^0.0.1
+      version: 0.0.1
     vitepress-plugin-group-icons:
       specifier: ^1.7.1
       version: 1.7.1
@@ -315,12 +318,6 @@ importers:
         specifier: 'catalog:'
         version: 3.5.28(typescript@5.9.3)
     devDependencies:
-      '@hpcc-js/wasm-graphviz':
-        specifier: ^1.8.0
-        version: 1.21.0
-      '@types/markdown-it':
-        specifier: ^14.1.2
-        version: 14.1.2
       '@voidzero-dev/vitepress-theme':
         specifier: ^4.2.1
         version: 4.5.0(change-case@5.4.4)(focus-trap@7.8.0)(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitepress@2.0.0-alpha.16(@types/node@24.10.3)(change-case@5.4.4)(esbuild@0.27.3)(jiti@2.6.1)(oxc-minify@0.115.0)(postcss@8.5.6)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(vue@3.5.28(typescript@5.9.3))
@@ -342,6 +339,9 @@ importers:
       vitepress:
         specifier: 'catalog:'
         version: 2.0.0-alpha.16(@types/node@24.10.3)(change-case@5.4.4)(esbuild@0.27.3)(jiti@2.6.1)(oxc-minify@0.115.0)(postcss@8.5.6)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      vitepress-plugin-graphviz:
+        specifier: 'catalog:'
+        version: 0.0.1(vitepress@2.0.0-alpha.16(@types/node@24.10.3)(change-case@5.4.4)(esbuild@0.27.3)(jiti@2.6.1)(oxc-minify@0.115.0)(postcss@8.5.6)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       vitepress-plugin-group-icons:
         specifier: 'catalog:'
         version: 1.7.1(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -6545,6 +6545,11 @@ packages:
       yaml:
         optional: true
 
+  vitepress-plugin-graphviz@0.0.1:
+    resolution: {integrity: sha512-WEbW1674RKHmoeKG2q9dTqemZEAhGnt2pKtuhCNsJx9mJrqoyiZCpmYt7imR0+gnEcS0APsCkwzlzkfDosqubg==}
+    peerDependencies:
+      vitepress: ^1.0.0
+
   vitepress-plugin-group-icons@1.7.1:
     resolution: {integrity: sha512-3ZPcIqwHNBg1btrOOSecOqv8yJxHdu3W2ugxE5LusclDF005LAm60URMEmBQrkgl4JvM32AqJirqghK6lGIk8g==}
     peerDependencies:
@@ -12076,6 +12081,11 @@ snapshots:
       terser: 5.46.0
       tsx: 4.21.0
       yaml: 2.8.2
+
+  vitepress-plugin-graphviz@0.0.1(vitepress@2.0.0-alpha.16(@types/node@24.10.3)(change-case@5.4.4)(esbuild@0.27.3)(jiti@2.6.1)(oxc-minify@0.115.0)(postcss@8.5.6)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)):
+    dependencies:
+      '@hpcc-js/wasm-graphviz': 1.21.0
+      vitepress: 2.0.0-alpha.16(@types/node@24.10.3)(change-case@5.4.4)(esbuild@0.27.3)(jiti@2.6.1)(oxc-minify@0.115.0)(postcss@8.5.6)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
 
   vitepress-plugin-group-icons@1.7.1(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,6 +88,7 @@ catalog:
   vitepress-plugin-group-icons: ^1.7.1
   vitepress-plugin-llms: ^1.1.0
   vitepress-plugin-og: ^0.0.5
+  vitepress-plugin-graphviz: ^0.0.1
   vitest: ^4.0.15
   vue: ^3.5.13
   web-tree-sitter: ^0.26.0


### PR DESCRIPTION
Extracted graphviz rendering part to [a separate package](https://npmx.dev/package/vitepress-plugin-graphviz). I refined the cache mechanism, but there should be no observable changes .