### PR TITLE
feat: suggest entriesAware in bundle analyzer optimization tips


### DIFF
--- a/crates/rolldown_plugin_bundle_analyzer/src/render_markdown.rs
+++ b/crates/rolldown_plugin_bundle_analyzer/src/render_markdown.rs
@@ -348,6 +348,13 @@ fn render_optimization_suggestions(out: &mut String, data: &AnalyzeData) {
     }
     out.push('\n');
   }
+
+  out.push_str("### Tip: Enable `entriesAware` for smarter code splitting\n\n");
+  out.push_str(
+    "Consider enabling `entriesAware: true` in your `codeSplitting.groups` configuration \
+     to let rolldown automatically split chunks based on entry point reachability. \
+     See https://rolldown.rs/reference/TypeAlias.CodeSplittingGroup#entriesaware\n\n",
+  );
 }
 
 fn render_full_module_graph(

--- a/examples/bundle-analyzer-demo/rolldown.config.js
+++ b/examples/bundle-analyzer-demo/rolldown.config.js
@@ -18,5 +18,9 @@ export default defineConfig({
       }
     },
   },
-  plugins: [bundleAnalyzerPlugin()],
+  plugins: [
+    bundleAnalyzerPlugin({
+      format: 'md',
+    }),
+  ],
 });

--- a/examples/bundle-analyzer-demo/src/main.js
+++ b/examples/bundle-analyzer-demo/src/main.js
@@ -3,7 +3,6 @@ import { logger } from './utils/logger.js';
 import { formatDate } from './utils/date-format.js';
 import { validate } from './utils/validator.js';
 import { getLocale } from './utils/locale.js';
-import './styles.css';
 
 const loadAdmin = () => import('./features/admin.js');
 const loadDashboard = () => import('./features/dashboard.js');

--- a/examples/bundle-analyzer-demo/src/styles.css
+++ b/examples/bundle-analyzer-demo/src/styles.css
@@ -1,3 +1,0 @@
-body {
-  margin: 0;
-}


### PR DESCRIPTION
Suggest `entriesAware` when common chunks contain modules that are not reachable from all entries that import the chunk.