### PR TITLE
fix: apply `topLevelVar` to exported `const`/`let` declarations

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1541,8 +1541,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               return;
             }
           }
-        } else if self.ctx.options.top_level_var {
-          // Here we should find if it's a "VariableDeclaration" and switch it to "Var."
+        }
+
+        if self.ctx.options.top_level_var {
           if let Statement::VariableDeclaration(var_decl) = &mut top_stmt {
             var_decl.kind = ast::VariableDeclarationKind::Var;
             for decl in &mut var_decl.declarations {

--- a/crates/rolldown/tests/rolldown/function/top_level_var/enabled/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/top_level_var/enabled/artifacts.snap
@@ -12,6 +12,10 @@ var firstLevelVar = "var";
 var firstLevelConst = "const";
 var FirstLevelClass = class {};
 console.log(firstLevelLet, firstLevelVar, firstLevelConst, new FirstLevelClass());
+var exportedConst = "exported_const";
+var exportedLet = "exported_let";
+var ExportedClass = class {};
+function exportedFunction() {}
 console.log("let");
 function second_level() {
 	let secondLevelLet = "let";
@@ -22,5 +26,6 @@ function second_level() {
 }
 second_level();
 //#endregion
+export { ExportedClass, exportedConst, exportedFunction, exportedLet };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/top_level_var/enabled/main.js
+++ b/crates/rolldown/tests/rolldown/function/top_level_var/enabled/main.js
@@ -4,6 +4,11 @@ const firstLevelConst = 'const';
 class FirstLevelClass {}
 console.log(firstLevelLet, firstLevelVar, firstLevelConst, new FirstLevelClass());
 
+export const exportedConst = 'exported_const';
+export let exportedLet = 'exported_let';
+export class ExportedClass {}
+export function exportedFunction() {}
+
 if (true) {
   let shouldNotBeSubstitutedLet = 'let';
   console.log(shouldNotBeSubstitutedLet);

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4498,7 +4498,7 @@ expression: output
 
 # tests/rolldown/function/top_level_var/enabled
 
-- main-!~{000}~.js => main-fX6SLPHl.js
+- main-!~{000}~.js => main--DMU1jVn.js
 
 # tests/rolldown/hash/content_include_placeholder
 


### PR DESCRIPTION
closed #8506