### PR TITLE
fix: apply `__name` to deconflicted class/fn expressions in all contexts


### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -368,6 +368,52 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
   }
 
   fn visit_expression(&mut self, expr: &mut ast::Expression<'ast>) {
+    // Handle keep_names for named class/function expressions in any expression context
+    // (return statements, function args, array elements, etc.)
+    if self.ctx.options.keep_names && self.ctx.runtime.id() != self.ctx.idx {
+      match expr {
+        ast::Expression::ClassExpression(class_expression) => {
+          if let Some(id) = class_expression.id.as_ref() {
+            if let Some(element) = self.keep_name_helper_for_class(
+              id.symbol_id.get().map(KeepNameId::SymbolId),
+              &class_expression.body,
+            ) {
+              class_expression.body.body.insert(0, element);
+            }
+          }
+        }
+        ast::Expression::FunctionExpression(fn_expression) => {
+          if let Some(id) = fn_expression.id.as_mut() {
+            if let Some(symbol_id) = id.symbol_id.get() {
+              let keep_name_id = KeepNameId::SymbolId(symbol_id);
+              if let Some((_insert_position, original_name, _)) =
+                self.process_fn(Some(keep_name_id), Some(keep_name_id))
+              {
+                // Manually rename the binding identifier before clearing symbol_id
+                let symbol_ref: SymbolRef = (self.ctx.idx, symbol_id).into();
+                let canonical_name = self.canonical_name_for(symbol_ref);
+                if id.name != canonical_name {
+                  id.name = self.snippet.atom(canonical_name).into();
+                }
+                // Clear symbol_id to prevent double processing:
+                // - visit_expression won't re-wrap when walker visits inner fn
+                // - visit_binding_identifier won't re-rename
+                id.symbol_id.get_mut().take();
+
+                let fn_expr = expr.take_in(self.alloc);
+                let name_ref = self.canonical_ref_for_runtime("__name");
+                let (finalized_callee, _) =
+                  self.finalized_expr_for_symbol_ref(name_ref, false, false);
+                *expr =
+                  self.snippet.keep_name_call_expr(&original_name, fn_expr, finalized_callee, true);
+              }
+            }
+          }
+        }
+        _ => {}
+      }
+    }
+
     match expr {
       ast::Expression::CallExpression(call_expr) => {
         self.rewrite_hot_accept_call_deps(call_expr);
@@ -673,10 +719,20 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
         ) {
           decl.body.body.insert(0, element);
         }
-        if let Some(decl) = self.get_transformed_class_decl(decl) {
-          *it = decl;
+        if let Some(new_decl) = self.get_transformed_class_decl(decl) {
+          *it = new_decl;
+          // Clear symbol_id on class expression's id to prevent visit_expression
+          // from inserting a duplicate __name static block during walk
+          if let ast::Declaration::VariableDeclaration(var_decl) = it {
+            if let Some(declarator) = var_decl.declarations.first_mut() {
+              if let Some(ast::Expression::ClassExpression(class_expr)) = &mut declarator.init {
+                if let Some(id) = &mut class_expr.id {
+                  id.symbol_id.get_mut().take();
+                }
+              }
+            }
+          }
         }
-        // deconflict class name
       }
       ast::Declaration::TSTypeAliasDeclaration(_)
       | ast::Declaration::TSInterfaceDeclaration(_)

--- a/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "keepNames": true,
+    "external": ["node:assert"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/_test.mjs
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/_test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const code = fs.readFileSync(path.join(__dirname, 'dist/main.js'), 'utf8');
+const matches = code.match(/__name\(this, "Foo"\);/g) ?? [];
+
+assert.strictEqual(matches.length, 1);

--- a/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/a.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/a.js
@@ -1,0 +1,3 @@
+export class Foo {
+  static self = Foo;
+}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/artifacts.snap
@@ -1,0 +1,27 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region a.js
+var Foo$1 = class Foo$1 {
+	static {
+		__name(this, "Foo");
+	}
+	static self = Foo$1;
+};
+//#endregion
+//#region main.js
+var Foo = class Foo {
+	static self = Foo;
+};
+assert.strictEqual(Foo$1.name, "Foo");
+assert.strictEqual(Foo.self, Foo);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/main.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict/main.js
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+import { Foo as ImportedFoo } from './a.js';
+
+class Foo {
+  static self = Foo;
+}
+
+assert.strictEqual(ImportedFoo.name, 'Foo');
+assert.strictEqual(Foo.self, Foo);

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_8513/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_8513/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "external": ["node:url"],
+    "keepNames": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_8513/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_8513/artifacts.snap
@@ -1,0 +1,49 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region url.js
+var URL = class {};
+//#endregion
+//#region main.js
+function createURL() {
+	return class URL$1 extends URL {
+		static {
+			__name(this, "URL");
+		}
+	};
+}
+function createFn() {
+	return function fn() {
+		return 1;
+	};
+}
+function wrapper1() {
+	function helper() {
+		return 42;
+	}
+	return helper;
+}
+function wrapper2() {
+	class MyClass {}
+	return MyClass;
+}
+function wrapper3() {
+	var myFn = function() {};
+	var myArrow = () => {};
+	var myClass = class {};
+	return {
+		myFn,
+		myArrow,
+		myClass
+	};
+}
+//#endregion
+export { createFn, createURL, wrapper1, wrapper2, wrapper3 };
+
+```

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_8513/main.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_8513/main.js
@@ -1,0 +1,33 @@
+import { URL as NodeURL, fn as otherFn } from './url.js';
+
+// Case 1: Class expression in return statement (deconflicted)
+export function createURL() {
+  return class URL extends NodeURL {};
+}
+
+// Case 2: Function expression in return statement (deconflicted)
+export function createFn() {
+  return function fn() {
+    return 1;
+  };
+}
+
+// Case 3-5: Non-deconflicted inner scope — should NOT get __name
+export function wrapper1() {
+  function helper() {
+    return 42;
+  }
+  return helper;
+}
+
+export function wrapper2() {
+  class MyClass {}
+  return MyClass;
+}
+
+export function wrapper3() {
+  var myFn = function () {};
+  var myArrow = () => {};
+  var myClass = class {};
+  return { myFn, myArrow, myClass };
+}

--- a/crates/rolldown/tests/rolldown/topics/keep_names/issue_8513/url.js
+++ b/crates/rolldown/tests/rolldown/topics/keep_names/issue_8513/url.js
@@ -1,0 +1,2 @@
+export class URL {}
+export function fn() {}

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -5934,6 +5934,10 @@ expression: output
 
 - main-!~{000}~.js => main-lM0Z7bta.js
 
+# tests/rolldown/topics/keep_names/class_decl_self_ref_deconflict
+
+- main-!~{000}~.js => main-btz8NE2L.js
+
 # tests/rolldown/topics/keep_names/declaration
 
 - main-!~{000}~.js => main-DCSt6GdC.js
@@ -5975,6 +5979,10 @@ expression: output
 # tests/rolldown/topics/keep_names/issue_7852
 
 - main-!~{000}~.js => main-B0IuB-dW.js
+
+# tests/rolldown/topics/keep_names/issue_8513
+
+- main-!~{000}~.js => main-DS3J4qXC.js
 
 # tests/rolldown/topics/keep_names/parenthesized_default_export
 


### PR DESCRIPTION
closed #8513