### PR TITLE
fix: pre-resolve paths option to avoid `invoke_sync` deadlock

### DIFF
--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -129,7 +129,7 @@ fn render_cjs_chunk_imports(ctx: &GenerateContext<'_>) -> String {
 
       let require_path_str = concat_string!(
         "require(\"",
-        &importee.get_import_path(ctx.chunk, ctx.options.paths.as_ref()),
+        &importee.get_import_path(ctx.chunk, ctx.resolved_paths),
         "\")"
       );
 

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -60,7 +60,7 @@ pub fn render_esm<'code>(
       for importee_idx in ctx.chunk.entry_level_external_module_idx.iter().copied() {
         let importee = &ctx.link_output.module_table[importee_idx];
         if let Some(m) = importee.as_external() {
-          let ext_name = m.get_import_path(ctx.chunk, ctx.options.paths.as_ref());
+          let ext_name = m.get_import_path(ctx.chunk, ctx.resolved_paths);
           source_joiner.append_source(concat_string!("export * from \"", ext_name, "\"\n"));
         }
       }
@@ -362,7 +362,7 @@ where
           s.push_str("import * as ");
           s.push_str(alias);
           s.push_str(" from ");
-          s.push_str(&escape(&importee.get_import_path(ctx.chunk, ctx.options.paths.as_ref())));
+          s.push_str(&escape(&importee.get_import_path(ctx.chunk, ctx.resolved_paths)));
           s.push_str(";\n");
           None
         }
@@ -395,7 +395,7 @@ where
       &ctx.link_output.module_table,
       specifiers,
       &default_alias,
-      &importee.get_import_path(ctx.chunk, ctx.options.paths.as_ref()),
+      &importee.get_import_path(ctx.chunk, ctx.resolved_paths),
       with_clause,
     ));
   }

--- a/crates/rolldown/src/ecmascript/format/umd.rs
+++ b/crates/rolldown/src/ecmascript/format/umd.rs
@@ -150,7 +150,7 @@ fn render_amd_dependencies(
   externals.iter().for_each(|external| {
     dependencies.push(concat_string!(
       "'",
-      external.get_import_path(ctx.chunk, ctx.options.paths.as_ref()),
+      external.get_import_path(ctx.chunk, ctx.resolved_paths),
       "'"
     ));
   });
@@ -170,7 +170,7 @@ fn render_cjs_dependencies(
   externals.iter().for_each(|external| {
     dependencies.push(concat_string!(
       "require('",
-      external.get_import_path(ctx.chunk, ctx.options.paths.as_ref()),
+      external.get_import_path(ctx.chunk, ctx.resolved_paths),
       "')"
     ));
   });

--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -1,7 +1,7 @@
 use rolldown_common::{
   AstScopes, Chunk, ChunkIdx, ConstExportMeta, ImportRecordIdx, IndexModules, ModuleIdx,
-  ModuleType, NormalModule, PathsOutputOption, RenderedConcatenatedModuleParts,
-  RuntimeModuleBrief, SharedFileEmitter, SymbolRef, SymbolRefDb,
+  ModuleType, NormalModule, PathsOutputOption, RenderedConcatenatedModuleParts, RuntimeModuleBrief,
+  SharedFileEmitter, SymbolRef, SymbolRefDb,
 };
 
 pub type FinalizerMutableFields = (

--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -1,7 +1,7 @@
 use rolldown_common::{
   AstScopes, Chunk, ChunkIdx, ConstExportMeta, ImportRecordIdx, IndexModules, ModuleIdx,
-  ModuleType, NormalModule, RenderedConcatenatedModuleParts, RuntimeModuleBrief, SharedFileEmitter,
-  SymbolRef, SymbolRefDb,
+  ModuleType, NormalModule, PathsOutputOption, RenderedConcatenatedModuleParts,
+  RuntimeModuleBrief, SharedFileEmitter, SymbolRef, SymbolRefDb,
 };
 
 pub type FinalizerMutableFields = (
@@ -40,6 +40,8 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub side_effect_free_function_symbols: &'me FxHashSet<SymbolRef>,
   pub safely_merge_cjs_ns_map: &'me FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
   pub used_symbol_refs: &'me FxHashSet<SymbolRef>,
+  /// Pre-resolved paths for external modules (always a `FxHashMap` variant).
+  pub resolved_paths: Option<&'me PathsOutputOption>,
 }
 
 impl<'me> ScopeHoistingFinalizerContext<'me> {

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -605,8 +605,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             else {
               return vec![];
             };
-            let importee_name =
-              &module.get_import_path(self.ctx.chunk, self.ctx.resolved_paths);
+            let importee_name = &module.get_import_path(self.ctx.chunk, self.ctx.resolved_paths);
             let call_expr = self.snippet.re_export_call_expr(
               re_export_fn_ref.clone_in(self.alloc),
               self.snippet.id_ref_expr(binding_name_for_namespace_object_ref, SPAN),

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -606,7 +606,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               return vec![];
             };
             let importee_name =
-              &module.get_import_path(self.ctx.chunk, self.ctx.options.paths.as_ref());
+              &module.get_import_path(self.ctx.chunk, self.ctx.resolved_paths);
             let call_expr = self.snippet.re_export_call_expr(
               re_export_fn_ref.clone_in(self.alloc),
               self.snippet.id_ref_expr(binding_name_for_namespace_object_ref, SPAN),
@@ -1152,7 +1152,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
               call_expr.arguments.get_mut(0).expect("require should have an argument");
             // Rewrite `require('xxx')` to `require('fs')`, if there is an alias that maps 'xxx' to 'fs'
             *request_path = ast::Argument::StringLiteral(self.snippet.alloc_string_literal(
-              &importee.get_import_path(self.ctx.chunk, self.ctx.options.paths.as_ref()),
+              &importee.get_import_path(self.ctx.chunk, self.ctx.resolved_paths),
               request_path.span(),
             ));
             None
@@ -1986,7 +1986,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         needs_to_esm_helper = importee.exports_kind.is_commonjs();
       }
       Module::External(importee) => {
-        let import_path = importee.get_import_path(self.ctx.chunk, self.ctx.options.paths.as_ref());
+        let import_path = importee.get_import_path(self.ctx.chunk, self.ctx.resolved_paths);
         if str != import_path {
           expr.source = Expression::StringLiteral(
             self.snippet.alloc_string_literal(&import_path, expr.source.span()),

--- a/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
@@ -72,6 +72,7 @@ impl GenerateStage<'_> {
             side_effect_free_function_symbols: &side_effect_free_function_symbols,
             safely_merge_cjs_ns_map: &self.link_output.safely_merge_cjs_ns_map,
             used_symbol_refs: &self.link_output.used_symbol_refs,
+            resolved_paths: self.resolved_paths.as_ref(),
           };
 
           let concatenated_wrapped_module_kind = ctx.linking_info.concatenated_wrapped_module_kind;

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -5,8 +5,8 @@ use futures::future::try_join_all;
 use oxc_index::IndexVec;
 use render_chunk_to_assets::set_emitted_chunk_preliminary_filenames;
 use rolldown_common::{
-  ChunkIdx, ChunkKind, ImportMetaRolldownAssetReplacer, Module, OutputExports, PreliminaryFilename,
-  RollupPreRenderedAsset,
+  ChunkIdx, ChunkKind, ImportMetaRolldownAssetReplacer, Module, OutputExports,
+  PathsOutputOption, PreliminaryFilename, RollupPreRenderedAsset,
 };
 use rolldown_devtools::{action, trace_action, trace_action_enabled};
 use rolldown_error::{BuildDiagnostic, BuildResult};
@@ -68,6 +68,10 @@ pub struct GenerateStage<'a> {
   link_output: &'a mut LinkStageOutput,
   options: &'a SharedOptions,
   plugin_driver: &'a SharedPluginDriver,
+  /// Pre-resolved paths for external modules. When the user provides a JS function for the
+  /// `paths` option, it is resolved asynchronously here before entering sync rendering code,
+  /// avoiding the need for `invoke_sync` which can cause deadlocks.
+  resolved_paths: Option<PathsOutputOption>,
 }
 
 impl<'a> GenerateStage<'a> {
@@ -76,7 +80,7 @@ impl<'a> GenerateStage<'a> {
     options: &'a SharedOptions,
     plugin_driver: &'a SharedPluginDriver,
   ) -> Self {
-    Self { link_output, options, plugin_driver }
+    Self { link_output, options, plugin_driver, resolved_paths: None }
   }
 
   #[tracing::instrument(level = "debug", skip_all)]
@@ -121,6 +125,18 @@ impl<'a> GenerateStage<'a> {
         );
       });
     });
+
+    // Pre-resolve paths for external modules to avoid sync JS callbacks during rendering.
+    // This eliminates the need for `invoke_sync` which can cause deadlocks (see #7280).
+    if let Some(paths) = &self.options.paths {
+      let ids = self
+        .link_output
+        .module_table
+        .modules
+        .iter()
+        .filter_map(|m| m.as_external().map(|e| e.id.as_str()));
+      self.resolved_paths = Some(paths.resolve_all(ids).await);
+    }
 
     self.finalize_modules(&mut chunk_graph);
     self.detect_ineffective_dynamic_imports(&chunk_graph);
@@ -396,6 +412,7 @@ impl<'a> GenerateStage<'a> {
           module_id_to_codegen_ret: Vec::new(),
           render_export_items_index_vec: &IndexVec::default(),
           chunk_idx,
+          resolved_paths: self.resolved_paths.as_ref(),
         },
         entry_module,
         &export_names,

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -5,8 +5,8 @@ use futures::future::try_join_all;
 use oxc_index::IndexVec;
 use render_chunk_to_assets::set_emitted_chunk_preliminary_filenames;
 use rolldown_common::{
-  ChunkIdx, ChunkKind, ImportMetaRolldownAssetReplacer, Module, OutputExports,
-  PathsOutputOption, PreliminaryFilename, RollupPreRenderedAsset,
+  ChunkIdx, ChunkKind, ImportMetaRolldownAssetReplacer, Module, OutputExports, PathsOutputOption,
+  PreliminaryFilename, RollupPreRenderedAsset,
 };
 use rolldown_devtools::{action, trace_action, trace_action_enabled};
 use rolldown_error::{BuildDiagnostic, BuildResult};

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -65,6 +65,7 @@ impl GenerateStage<'_> {
       &index_chunk_to_instances,
       self.options.hash_characters,
       self.options,
+      self.resolved_paths.as_ref(),
     )
     .await?;
 
@@ -178,6 +179,7 @@ impl GenerateStage<'_> {
           Some((chunk_idx, chunk, module_id_to_codegen_ret))
         })
         .flat_map(|(chunk_idx, chunk, module_id_to_codegen_ret)| {
+          let resolved_paths = self.resolved_paths.as_ref();
           let ecma_chunks_future: ChunkGeneratorFuture = Box::pin(async move {
             let mut ecma_ctx = GenerateContext {
               chunk_idx,
@@ -188,6 +190,7 @@ impl GenerateStage<'_> {
               plugin_driver: self.plugin_driver,
               module_id_to_codegen_ret,
               render_export_items_index_vec,
+              resolved_paths,
             };
             let ecma_chunks_future = EcmaGenerator::instantiate_chunk(&mut ecma_ctx);
             let ecma_chunks = ecma_chunks_future.await?;
@@ -203,6 +206,7 @@ impl GenerateStage<'_> {
               plugin_driver: self.plugin_driver,
               module_id_to_codegen_ret: vec![],
               render_export_items_index_vec: &index_vec![],
+              resolved_paths,
             };
             let asset_chunks_future = AssetGenerator::instantiate_chunk(&mut asset_ctx);
             let asset_chunks = asset_chunks_future.await?;

--- a/crates/rolldown/src/types/generator.rs
+++ b/crates/rolldown/src/types/generator.rs
@@ -2,7 +2,7 @@ use oxc::span::CompactStr;
 use oxc_index::IndexVec;
 use rolldown_common::{
   Chunk, ChunkIdx, InstantiatedChunk, ModuleRenderOutput, NormalizedBundlerOptions, OutputExports,
-  SymbolRef,
+  PathsOutputOption, SymbolRef,
 };
 use rolldown_error::{BuildDiagnostic, BuildResult};
 use rolldown_plugin::SharedPluginDriver;
@@ -27,6 +27,9 @@ pub struct GenerateContext<'a> {
   /// export {a as b}; // symbol_ref points to `a`, and alias is `b`
   /// ```
   pub render_export_items_index_vec: &'a IndexVec<ChunkIdx, FxIndexMap<SymbolRef, Vec<CompactStr>>>,
+  /// Pre-resolved paths for external modules (always a `FxHashMap` variant).
+  /// Used instead of `options.paths` in sync rendering code to avoid deadlocks.
+  pub resolved_paths: Option<&'a PathsOutputOption>,
 }
 
 impl GenerateContext<'_> {

--- a/crates/rolldown/src/utils/chunk/finalize_chunks.rs
+++ b/crates/rolldown/src/utils/chunk/finalize_chunks.rs
@@ -5,8 +5,8 @@ use futures::future::try_join_all;
 use itertools::Itertools;
 use oxc_index::IndexVec;
 use rolldown_common::{
-  Asset, HashCharacters, InsChunkIdx, InstantiationKind, NormalizedBundlerOptions, SourceMapType,
-  StrOrBytes,
+  Asset, HashCharacters, InsChunkIdx, InstantiationKind, NormalizedBundlerOptions,
+  PathsOutputOption, SourceMapType, StrOrBytes,
 };
 use rolldown_error::BuildResult;
 #[cfg(not(target_family = "wasm"))]
@@ -40,6 +40,7 @@ pub async fn finalize_assets(
   index_chunk_to_instances: &IndexChunkToInstances,
   hash_characters: HashCharacters,
   options: &NormalizedBundlerOptions,
+  resolved_paths: Option<&PathsOutputOption>,
 ) -> BuildResult<AssetVec> {
   let ins_chunk_idx_by_placeholder = index_instantiated_chunks
     .iter_enumerated()
@@ -168,7 +169,7 @@ pub async fn finalize_assets(
           link_output.module_table[*idx]
             .as_external()
             .expect("direct_imports_from_external_modules should only contain external modules")
-            .get_file_name(options.paths.as_ref())
+            .get_file_name(resolved_paths)
         }))
         .collect();
 

--- a/crates/rolldown/src/utils/chunk/mod.rs
+++ b/crates/rolldown/src/utils/chunk/mod.rs
@@ -46,7 +46,7 @@ pub fn generate_rendered_chunk(
   chunk: &GenerateContext<'_>,
   render_modules: FxHashMap<ModuleId, RenderedModule>,
 ) -> RollupRenderedChunk {
-  let GenerateContext { chunk_graph, chunk, link_output, options, .. } = chunk;
+  let GenerateContext { chunk_graph, chunk, link_output, resolved_paths, .. } = chunk;
   let pre_rendered_chunk =
     chunk.pre_rendered_chunk.as_ref().expect("Should have pre-rendered chunk");
   RollupRenderedChunk {
@@ -76,7 +76,7 @@ pub fn generate_rendered_chunk(
         link_output.module_table[*idx]
           .as_external()
           .expect("direct_imports_from_external_modules should only contain external modules")
-          .get_file_name(options.paths.as_ref())
+          .get_file_name(*resolved_paths)
       }))
       .collect(),
     dynamic_imports: chunk

--- a/crates/rolldown_binding/src/types/js_callback.rs
+++ b/crates/rolldown_binding/src/types/js_callback.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::Arc;
 
 use futures::Future;
 use napi::{
@@ -75,7 +75,6 @@ pub type MaybeAsyncJsCallback<Args = (), Ret = ()> = JsCallback<Args, Either<Pro
 
 pub trait JsCallbackExt<Args, Ret> {
   fn invoke_async(&self, args: Args) -> impl Future<Output = Result<Ret, napi::Error>> + Send;
-  fn invoke_sync(&self, args: Args) -> Result<Ret, napi::Error>;
 }
 
 impl<Args, Ret> JsCallbackExt<Args, Ret> for JsCallback<Args, Ret>
@@ -86,37 +85,6 @@ where
 {
   async fn invoke_async(&self, args: Args) -> Result<Ret, napi::Error> {
     match self.call_async(args).await? {
-      Either::A(ret) => Ok(ret),
-      Either::B(_unknown) => create_unknown_return_error::<Ret, Self>(),
-    }
-  }
-
-  fn invoke_sync(&self, args: Args) -> Result<Ret, napi::Error> {
-    let init_value = Ok(Either::B(UnknownReturnValue));
-    let pair = Arc::new((Mutex::new(init_value), Condvar::new()));
-    let pair_clone = Arc::clone(&pair);
-
-    self.call_with_return_value(
-      args,
-      napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking,
-      move |ret, _env| {
-        let (lock, cvar) = &*pair;
-        *lock.lock().unwrap() = ret;
-        cvar.notify_one();
-        Ok(())
-      },
-    );
-
-    let (lock, cvar) = &*pair_clone;
-    let notified = lock.lock().unwrap();
-    let mut res = cvar.wait(notified).map_err(|err| {
-      napi::Error::new(napi::Status::GenericFailure, format!("PoisonError: {err:?}",))
-    })?;
-    let res = res
-      .as_mut()
-      .map_err(|err| napi::Error::new(napi::Status::GenericFailure, format!("{err:?}",)))?;
-
-    match std::mem::replace(res, Either::B(UnknownReturnValue)) {
       Either::A(ret) => Ok(ret),
       Either::B(_unknown) => create_unknown_return_error::<Ret, Self>(),
     }

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -142,7 +142,7 @@ fn normalize_paths_option(
     Either::B(func) => rolldown_common::PathsOutputOption::Fn(Arc::new(move |id| {
       let func = Arc::clone(&func);
       let id = id.to_string();
-      func.invoke_sync((id,).into()).map_err(anyhow::Error::from)
+      Box::pin(async move { func.invoke_async((id,).into()).await.map_err(anyhow::Error::from) })
     })),
   })
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_option/paths.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_option/paths.rs
@@ -1,9 +1,11 @@
 use derive_more::Debug;
-use std::sync::Arc;
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use rustc_hash::FxHashMap;
 
-pub type PathsFunction = dyn Fn(&str) -> anyhow::Result<String> + 'static + Send + Sync;
+pub type PathsFunction = dyn Fn(&str) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send + 'static>>
+  + Send
+  + Sync;
 
 #[derive(Clone, Debug)]
 pub enum PathsOutputOption {
@@ -14,10 +16,35 @@ pub enum PathsOutputOption {
 }
 
 impl PathsOutputOption {
+  /// Sync call — only works for the `FxHashMap` variant.
+  /// The `Fn` variant should be pre-resolved via `resolve_all()` before sync access.
   pub fn call(&self, id: &str) -> Option<String> {
     match self {
       Self::FxHashMap(value) => value.get(id).cloned(),
-      Self::Fn(value) => value(id).ok(),
+      Self::Fn(_) => {
+        // The Fn variant should be pre-resolved via `resolve_all()` before sync access.
+        // If reached, the path was not pre-resolved — return None as a safe fallback.
+        None
+      }
+    }
+  }
+
+  /// Pre-resolve all paths for the given IDs asynchronously, returning a `FxHashMap` variant.
+  pub async fn resolve_all<'a>(
+    &self,
+    ids: impl Iterator<Item = &'a str>,
+  ) -> PathsOutputOption {
+    match self {
+      Self::FxHashMap(map) => Self::FxHashMap(map.clone()),
+      Self::Fn(f) => {
+        let mut resolved = FxHashMap::default();
+        for id in ids {
+          if let Ok(path) = f(id).await {
+            resolved.insert(id.to_string(), path);
+          }
+        }
+        Self::FxHashMap(resolved)
+      }
     }
   }
 }

--- a/crates/rolldown_common/src/inner_bundler_options/types/output_option/paths.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/output_option/paths.rs
@@ -22,18 +22,21 @@ impl PathsOutputOption {
     match self {
       Self::FxHashMap(value) => value.get(id).cloned(),
       Self::Fn(_) => {
-        // The Fn variant should be pre-resolved via `resolve_all()` before sync access.
-        // If reached, the path was not pre-resolved — return None as a safe fallback.
+        // Hitting this branch means a caller attempted to use the sync API on an async
+        // function-based configuration (e.g. `options.paths` instead of `resolved_paths`).
+        // Make this misuse visible in debug builds while preserving release behavior.
+        debug_assert!(
+          false,
+          "PathsOutputOption::call was used on the `Fn` variant. \
+           Use `resolve_all()` (or `resolved_paths`) to pre-resolve async paths before sync access."
+        );
         None
       }
     }
   }
 
   /// Pre-resolve all paths for the given IDs asynchronously, returning a `FxHashMap` variant.
-  pub async fn resolve_all<'a>(
-    &self,
-    ids: impl Iterator<Item = &'a str>,
-  ) -> PathsOutputOption {
+  pub async fn resolve_all<'a>(&self, ids: impl Iterator<Item = &'a str>) -> PathsOutputOption {
     match self {
       Self::FxHashMap(map) => Self::FxHashMap(map.clone()),
       Self::Fn(f) => {


### PR DESCRIPTION
closed #7280



**Description:** Pre-resolves the `paths` output option asynchronously before entering sync rendering code, eliminating the deadlock-prone `invoke_sync` pattern that blocks threads waiting for JS callbacks via `Mutex + Condvar`. Changes `PathsFunction` to async (matching other options like `globals`), adds a `resolve_all()` method, and removes `invoke_sync` entirely. 