### PR TITLE
fix: only uppercase facade symbols in JSX preserve mode

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -2,7 +2,10 @@ use oxc::allocator::{GetAddress, UnstableAddress};
 use oxc::{
   ast::{
     AstKind,
-    ast::{self, BindingPattern, Declaration, Expression, IdentifierReference},
+    ast::{
+      self, BindingPattern, Declaration, Expression, IdentifierReference, JSXClosingElement,
+      JSXElementName, JSXMemberExpressionObject, JSXOpeningElement,
+    },
   },
   ast_visit::{Visit, walk},
   semantic::{ScopeFlags, SymbolId},
@@ -530,6 +533,16 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     walk::walk_call_expression(self, it);
   }
 
+  fn visit_jsx_opening_element(&mut self, it: &JSXOpeningElement<'ast>) {
+    self.visit_jsx_opening_element_for_jsx_preserve(it);
+    walk::walk_jsx_opening_element(self, it);
+  }
+
+  fn visit_jsx_closing_element(&mut self, it: &JSXClosingElement<'ast>) {
+    self.visit_jsx_closing_element_for_jsx_preserve(it);
+    walk::walk_jsx_closing_element(self, it);
+  }
+
   fn visit_export_default_declaration(&mut self, it: &ast::ExportDefaultDeclaration<'ast>) {
     // Mark export default declarations with anonymous function/class expressions
     // so that __name helper will be included in the runtime
@@ -700,6 +713,9 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
           _ => {}
         }
 
+        // For JSX preserve mode, mark symbols used as JSX element names.
+        // This flag ensures that after bundling, JSX element names whose canonical
+        // name starts with lowercase get uppercased to remain valid component references.
         if self.immutable_ctx.flat_options.jsx_preserve()
           && self.visit_path.last().is_some_and(|ast_kind| {
             matches!(ast_kind, AstKind::JSXOpeningElement(_) | AstKind::JSXClosingElement(_))
@@ -789,5 +805,55 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     let id = self.add_import_record(value.as_ref(), ImportKind::Require, span, init_meta, None);
     self.result.imports.insert(expr.span, id);
     true
+  }
+
+  /// For JSX preserve mode, mark the root identifier of JSXElementName::MemberExpression.
+  /// Uses `UsedAsJSXMemberExprRoot` (not `MustStartWithCapitalLetterForJSX`) because
+  /// member expressions like `<obj.Foo>` are valid JSX regardless of root casing.
+  /// Only facade (generated) symbols need uppercasing (e.g. `import_react` → `Import_react`).
+  fn mark_jsx_member_expression_root(&mut self, element_name: &JSXElementName<'ast>) {
+    if !self.immutable_ctx.flat_options.jsx_preserve() {
+      return;
+    }
+
+    // Only handle MemberExpression case. IdentifierReference case is handled
+    // in visit_identifier_reference where the parent is JSXOpeningElement/JSXClosingElement.
+    let JSXElementName::MemberExpression(member_expr) = element_name else {
+      return;
+    };
+
+    // Get the root identifier of the member expression chain (e.g., `ns` in `<ns.Foo.Bar>`)
+    let mut current = &member_expr.object;
+    loop {
+      match current {
+        JSXMemberExpressionObject::IdentifierReference(ident_ref) => {
+          if let Some(symbol_id) = self.resolve_symbol_from_reference(ident_ref) {
+            if self.is_root_symbol(symbol_id) {
+              let symbol_ref: rolldown_common::SymbolRef =
+                (self.immutable_ctx.idx, symbol_id).into();
+              let symbol_ref_flags = symbol_ref.flags_mut(&mut self.result.symbol_ref_db);
+              *symbol_ref_flags |= SymbolRefFlags::UsedAsJSXMemberExprRoot;
+            }
+          }
+          break;
+        }
+        JSXMemberExpressionObject::MemberExpression(nested_member) => {
+          current = &nested_member.object;
+        }
+        JSXMemberExpressionObject::ThisExpression(_) => {
+          break;
+        }
+      }
+    }
+  }
+}
+
+impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
+  fn visit_jsx_opening_element_for_jsx_preserve(&mut self, elem: &JSXOpeningElement<'ast>) {
+    self.mark_jsx_member_expression_root(&elem.name);
+  }
+
+  fn visit_jsx_closing_element_for_jsx_preserve(&mut self, elem: &JSXClosingElement<'ast>) {
+    self.mark_jsx_member_expression_root(&elem.name);
   }
 }

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -758,6 +758,22 @@ impl BindImportsAndExportsContext<'_> {
         MatchImportKind::NormalAndNamespace { namespace_ref, alias } => {
           self.symbol_db.get_mut(*imported_as_ref).namespace_alias =
             Some(NamespaceAlias { property_name: alias, namespace_ref });
+
+          // Propagate JSX flags from the imported symbol to its namespace_ref.
+          // When we have: `import React from './cjs-module'; <React.Fragment/>`
+          // `React` has UsedAsJSXMemberExprRoot, but the rendered binding is
+          // the namespace_ref (`import_react`). Since namespace_ref is a facade
+          // (generated) symbol, we promote it to MustStartWithCapitalLetterForJSX
+          // so the renamer uppercases it (e.g. `Import_react`).
+          if imported_as_ref.flags(self.symbol_db).is_some_and(|flags| {
+            flags.intersects(
+              SymbolRefFlags::MustStartWithCapitalLetterForJSX
+                | SymbolRefFlags::UsedAsJSXMemberExprRoot,
+            )
+          }) {
+            let ns_flags = namespace_ref.flags_mut(self.symbol_db);
+            *ns_flags |= SymbolRefFlags::MustStartWithCapitalLetterForJSX;
+          }
         }
         MatchImportKind::NoMatch => {
           let importee = &self.index_modules[resolved_module_idx];

--- a/crates/rolldown/tests/rolldown/issues/6036/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6036/artifacts.snap
@@ -8,13 +8,13 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region component/hello.tsx
-var import_react = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
+var Import_react = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = {};
 })))());
 function Hello() {
-	return <import_react.default.Fragment>
+	return <Import_react.default.Fragment>
       <h1>Hello</h1>
-    </import_react.default.Fragment>;
+    </Import_react.default.Fragment>;
 }
 //#endregion
 export { Hello };

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -4806,7 +4806,7 @@ expression: output
 
 # tests/rolldown/issues/6036
 
-- main-!~{000}~.js => main-Ds11wQzB.js
+- main-!~{000}~.js => main-BaZrzl0P.js
 
 # tests/rolldown/issues/6097
 

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -289,8 +289,8 @@ impl SymbolRefDb {
     }
     self.get_mut(base_root).link = Some(target_root);
     if self.has_module_preserve_jsx {
-      let jsx_mask = SymbolRefFlags::MustStartWithCapitalLetterForJSX
-        | SymbolRefFlags::UsedAsJSXMemberExprRoot;
+      let jsx_mask =
+        SymbolRefFlags::MustStartWithCapitalLetterForJSX | SymbolRefFlags::UsedAsJSXMemberExprRoot;
       if let Some(jsx_flags) =
         base_root.flags(self).map(|f| *f & jsx_mask).filter(|f| !f.is_empty())
       {

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -51,6 +51,11 @@ bitflags::bitflags! {
     ///   when no explicit name exists (e.g. `export default 42` has no declared
     ///   identifier, so the bundler creates one)
     const IsFacade = 1 << 5;
+    /// Root identifier of a JSX member expression (e.g. `obj` in `<obj.Foo>`).
+    /// Unlike `MustStartWithCapitalLetterForJSX`, this only triggers uppercasing
+    /// for facade (generated) symbols — user-defined names are left unchanged
+    /// because `<obj.Foo>` is already a valid component reference in JSX.
+    const UsedAsJSXMemberExprRoot = 1 << 6;
   }
 }
 
@@ -283,12 +288,14 @@ impl SymbolRefDb {
       return;
     }
     self.get_mut(base_root).link = Some(target_root);
-    if self.has_module_preserve_jsx
-      && base_root
-        .flags(self)
-        .is_some_and(|flags| flags.contains(SymbolRefFlags::MustStartWithCapitalLetterForJSX))
-    {
-      *target_root.flags_mut(self) |= SymbolRefFlags::MustStartWithCapitalLetterForJSX;
+    if self.has_module_preserve_jsx {
+      let jsx_mask = SymbolRefFlags::MustStartWithCapitalLetterForJSX
+        | SymbolRefFlags::UsedAsJSXMemberExprRoot;
+      if let Some(jsx_flags) =
+        base_root.flags(self).map(|f| *f & jsx_mask).filter(|f| !f.is_empty())
+      {
+        *target_root.flags_mut(self) |= jsx_flags;
+      }
     }
   }
 


### PR DESCRIPTION
closed #6036 

**Description**: Fixes JSX preserve mode to only uppercase generated/facade symbols (like CJS interop bindings `import_xxx`) when used as JSX element names, not user-defined variables. Also adds `MustStartWithCapitalLetterForJSX` flag propagation from imported symbols to namespace refs, and marks JSX member expression root identifiers for proper handling during scope hoisting.