### PR TITLE
fix: tree-shake dead dynamic imports to side-effect-free CJS modules

### DIFF
--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -860,6 +860,17 @@ pub fn include_statement(
       {
         return;
       }
+      // Skip CJS bailout for dynamic imports that will be determined dead:
+      // top-level pure (unused exports) importing a side-effect-free module.
+      // The dynamic entry mechanism handles CJS bailout for live entries via
+      // `process_and_retain_dynamic_entry`. Without this check, a dead dynamic
+      // import's CJS bailout would mark the module as included while the entry
+      // is later removed, causing an empty-bits assertion in code splitting.
+      if import_record.meta.contains(ImportRecordMeta::TopLevelPureDynamicImport)
+        && !m.side_effects.has_side_effects()
+      {
+        return;
+      }
       if module.ast_usage.contains(EcmaModuleAstUsage::IsCjsReexport) {
         // When the importer has multiple CJS re-export targets (conditional re-exports),
         // bail out to prevent tree-shaking from dropping any branch's exports.

--- a/crates/rolldown/tests/rolldown/issues/zarara_20260303_01/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/zarara_20260303_01/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.js" }],
+    "treeshake": {
+      "moduleSideEffects": false
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/zarara_20260303_01/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/zarara_20260303_01/artifacts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#endregion
+//#region main.js
+Promise.resolve().then(() => /* @__PURE__ */ Object.freeze({ __proto__: null }));
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/zarara_20260303_01/foo.cjs
+++ b/crates/rolldown/tests/rolldown/issues/zarara_20260303_01/foo.cjs
@@ -1,0 +1,1 @@
+exports.x = 1;

--- a/crates/rolldown/tests/rolldown/issues/zarara_20260303_01/main.js
+++ b/crates/rolldown/tests/rolldown/issues/zarara_20260303_01/main.js
@@ -1,0 +1,1 @@
+void import('./foo.cjs');


### PR DESCRIPTION
Dead dynamic imports to side-effect-free CJS modules were not being tree-shaken, producing an unnecessary chunk. The CJS bailout was marking the module as included even though the dynamic entry would later be removed. The fix skips CJS bailout for top-level pure dynamic imports targeting side-effect-free modules.

Found this case while trying to make a smaller repro for https://github.com/rolldown/rolldown/issues/8522 with https://github.com/sapphi-red/zarara.

[Playground link](https://repl.rolldown.rs/#eNptj8EKwjAQRH9l2UsVSsRri98geO6ltImkpNmSpLUS8u+mptGDXpYdduYx61Fg5VHqnq9ssNuusfrqErsoF5I9yHEi4w4FOwki1g22ONaNjg6OlTMzDyUaUqqnh2YdaSHvzH2Afy4JnajgnhMHD7fddp2cJG0hgDA0QpHjBTS60ZFhHSRS9ZO5gN9MYRt8fdN7LtpZ5QjGpvsLuV6WqVNKWbZG1rluTPwyxMwST6p13DoML71gatM=)