### PR TITLE
feat(binding): add original getter to BindingMagicString

### DIFF
--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -257,6 +257,11 @@ impl BindingMagicString<'_> {
   }
 
   #[napi(getter)]
+  pub fn original(&self) -> &str {
+    self.inner.source()
+  }
+
+  #[napi(getter)]
   pub fn filename(&self) -> Option<String> {
     self.inner.filename().map(String::from)
   }

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1478,6 +1478,7 @@ export declare class BindingLoadPluginContext {
 
 export declare class BindingMagicString {
   constructor(source: string, options?: BindingMagicStringOptions | undefined | null)
+  get original(): string
   get filename(): string | null
   get offset(): number
   set offset(offset: number)

--- a/packages/rolldown/tests/magic-string/magic-string-original.test.ts
+++ b/packages/rolldown/tests/magic-string/magic-string-original.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert';
+import { BindingMagicString as MagicString } from 'rolldown';
+import { describe, it } from 'vitest';
+
+describe('MagicString#original', () => {
+  it('should return the original source string', () => {
+    const s = new MagicString('hello world');
+    assert.strictEqual(s.original, 'hello world');
+  });
+
+  it('should not change after modifications', () => {
+    const s = new MagicString('hello world');
+    s.overwrite(0, 5, 'goodbye');
+    assert.strictEqual(s.original, 'hello world');
+    assert.strictEqual(s.toString(), 'goodbye world');
+  });
+
+  it('should return full source string regardless of offset', () => {
+    const s = new MagicString('hello world', { offset: 6 });
+    assert.strictEqual(s.original, 'hello world');
+  });
+
+  it('should be preserved after clone', () => {
+    const s = new MagicString('hello world');
+    s.overwrite(0, 5, 'goodbye');
+    const clone = s.clone();
+    assert.strictEqual(clone.original, 'hello world');
+  });
+});


### PR DESCRIPTION
Summary\n\n- Ports the original property from the JavaScript magic-string library to BindingMagicString\n- Exposes the unmodified source string passed to the constructor as a read-only getter\n- Updates the generated TypeScript type definition (binding.d.cts)\n\nNote: The offset getter/setter and constructor option visible in this diff are from the parent PR #8531 (stacked beneath this one).\n\nPart of #7522.