### PR TITLE
refactor(binding): return &str instead of String in filename() getter

### DIFF
--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -262,8 +262,8 @@ impl BindingMagicString<'_> {
   }
 
   #[napi(getter)]
-  pub fn filename(&self) -> Option<String> {
-    self.inner.filename().map(String::from)
+  pub fn filename(&self) -> Option<&str> {
+    self.inner.filename()
   }
 
   #[napi(getter)]


### PR DESCRIPTION
Avoids an unnecessary `String` allocation in the `filename()` getter on BindingMagicString by
  returning a borrowed `&str` directly from the inner type instead of cloning into a new String.