### PR TITLE
chore(vscode): use oxc formatter for markdown files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,10 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "oxc.oxc-vscode"
   },
+  "[markdown]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true
+  },
   "files.associations": {
     "*.snap": "markdown",
     "*.snap.new": "markdown",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,8 +20,8 @@
     "editor.defaultFormatter": "oxc.oxc-vscode"
   },
   "[markdown]": {
-    "editor.defaultFormatter": "oxc.oxc-vscode",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   },
   "files.associations": {
     "*.snap": "markdown",


### PR DESCRIPTION
## Summary
- Configure workspace Markdown formatting to use `oxc.oxc-vscode`.
- Enable format-on-save for Markdown in workspace settings.
- Ensure Markdown uses the workspace OXC formatter on save so user-level default formatter preferences (including Prettier) do not rewrite quote style in this repo.

## Test plan
- [x] Save a Markdown file in this workspace and confirm the active formatter is OXC.
- [x] Verify `.vscode/settings.json` includes `[markdown]` override with `editor.defaultFormatter` and `editor.formatOnSave`.
- [x] Confirm no other file changes are introduced by this update.