### PR TITLE
fix(binding): export BindingResult in generated dts header

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -144,7 +144,7 @@
   },
   "napi": {
     "binaryName": "rolldown-binding",
-    "dtsHeader": "type MaybePromise<T> = T | Promise<T>\ntype Nullable<T> = T | null | undefined\ntype VoidNullable<T = void> = T | null | undefined | void\nexport type BindingStringOrRegex = string | RegExp\ntype BindingResult<T> = { errors: BindingError[], isBindingErrors: boolean } | T\n\n",
+    "dtsHeader": "type MaybePromise<T> = T | Promise<T>\ntype Nullable<T> = T | null | undefined\ntype VoidNullable<T = void> = T | null | undefined | void\nexport type BindingStringOrRegex = string | RegExp\nexport type BindingResult<T> = { errors: BindingError[], isBindingErrors: boolean } | T\n\n",
     "packageName": "@rolldown/binding",
     "targets": [
       "x86_64-apple-darwin",

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2,7 +2,7 @@ type MaybePromise<T> = T | Promise<T>
 type Nullable<T> = T | null | undefined
 type VoidNullable<T = void> = T | null | undefined | void
 export type BindingStringOrRegex = string | RegExp
-type BindingResult<T> = { errors: BindingError[], isBindingErrors: boolean } | T
+export type BindingResult<T> = { errors: BindingError[], isBindingErrors: boolean } | T
 
 export interface CodegenOptions {
   /**


### PR DESCRIPTION
## Summary
- export `BindingResult` in `packages/rolldown/package.json` `napi.dtsHeader`
- regenerate `packages/rolldown/src/binding.d.cts` so the generated type is also exported
- remove `[MISSING_EXPORT] \"BindingResult\" is not exported by \"src/binding.d.cts\"` warning during `just test-node`

## Test plan
- [x] `just build-rolldown-binding`
- [x] `SKIP_PASS_DIFF=1 just test-node`
- [x] `pnpm --filter rolldown run build-js-glue`