### PR TITLE
docs(maintenance): align release and canary workflow guide

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -3,15 +3,20 @@
 ## Publish Latest
 
 1. Visit https://github.com/rolldown/rolldown/actions/workflows/prepare-release.yml
-2. "Run workflow" with `1.0.0-beta.x` (without leading `v`).
-3. Wait for https://github.com/rolldown/rolldown/actions/workflows/publish-to-npm.yml to finish.
+2. Trigger "Run workflow" manually, or wait for the weekly cron run.
+3. `prepare-release.yml` auto-bumps `packages/rolldown/package.json` from `x.y.z-rc.n` to `x.y.z-rc.(n+1)` and opens a release PR.
+4. Merge the release PR, then wait for https://github.com/rolldown/rolldown/actions/workflows/publish-to-npm.yml to finish.
 
 ## Canary
 
-1. Visit https://github.com/rolldown/rolldown/actions/workflows/publish-to-npm-for-nightly-canary.yml
-2. "Run workflow"
+Current Canary/preview distribution is handled by `publish-to-pkg.pr.new.yml` (not by an npm canary workflow).
 
-Latest Canary versions are https://npmx.dev/package/rolldown/v/canary
+1. Visit https://github.com/rolldown/rolldown/actions/workflows/publish-to-pkg.pr.new.yml
+2. Trigger "Run workflow" manually, or:
+   - push to `main` with changes under `crates/**`, `packages/**`, lockfiles, or the workflow file itself, or
+   - add the `trigger: preview` label to a PR.
+3. Wait for the `Pkg Preview` job to finish and check the published preview at:
+   - https://pkg.pr.new/~/rolldown/rolldown
 
 ## pkg.pr.new
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -17,6 +17,8 @@ Current Canary/preview distribution is handled by `publish-to-pkg.pr.new.yml` (n
    - add the `trigger: preview` label to a PR.
 3. Wait for the `Pkg Preview` job to finish and check the published preview at:
    - https://pkg.pr.new/~/rolldown/rolldown
+4. For npm canary tag status (view only), check:
+   - https://npmx.dev/package/rolldown/v/canary
 
 ## pkg.pr.new
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -4,7 +4,7 @@
 
 1. Visit https://github.com/rolldown/rolldown/actions/workflows/prepare-release.yml
 2. Trigger "Run workflow" manually, or wait for the weekly cron run.
-3. `prepare-release.yml` auto-bumps `packages/rolldown/package.json` from `x.y.z-rc.n` to `x.y.z-rc.(n+1)` and opens a release PR.
+3. `prepare-release.yml` auto-bumps `packages/rolldown/package.json` from `x.y.z-rc.n` to `x.y.z-rc.(n+1)` and opens a release PR. This workflow assumes the current version already has an `-rc.n` suffix and fails if it does not match that pattern.
 4. Merge the release PR, then wait for https://github.com/rolldown/rolldown/actions/workflows/publish-to-npm.yml to finish.
 
 ## Canary
@@ -13,7 +13,7 @@ Current Canary/preview distribution is handled by `publish-to-pkg.pr.new.yml` (n
 
 1. Visit https://github.com/rolldown/rolldown/actions/workflows/publish-to-pkg.pr.new.yml
 2. Trigger "Run workflow" manually, or:
-   - push to `main` with changes under `crates/**`, `packages/**`, lockfiles, or the workflow file itself, or
+   - push to `main` with changes under `crates/**`, `packages/**`, lockfiles, `rust-toolchain.toml`, or the workflow file itself, or
    - add the `trigger: preview` label to a PR.
 3. Wait for the `Pkg Preview` job to finish and check the published preview at:
    - https://pkg.pr.new/~/rolldown/rolldown


### PR DESCRIPTION
## Summary
- update `MAINTENANCE.md` release instructions to reflect current `prepare-release.yml` behavior (weekly cron + optional manual trigger + automatic rc bump PR)
- replace outdated nightly canary npm workflow guidance with the current preview flow via `publish-to-pkg.pr.new.yml`
- add practical trigger paths for preview publishing (`workflow_dispatch`, matching `main` pushes, `trigger: preview` label on PR)

## Test plan
- [x] Doc-only change; no build/test execution required
- [x] Verified workflow names and triggers against `.github/workflows/prepare-release.yml`, `.github/workflows/publish-to-npm.yml`, and `.github/workflows/publish-to-pkg.pr.new.yml`