### PR TITLE
perf(string_wizard): reduce allocations and add ASCII fast paths

### DIFF
--- a/crates/string_wizard/src/magic_string/indent.rs
+++ b/crates/string_wizard/src/magic_string/indent.rs
@@ -80,7 +80,7 @@ impl MagicString<'_> {
     }
 
     fn indent_frag(frag: &mut CowStr, indent_replacer: &mut IndentReplacer) {
-      let mut indented = String::new();
+      let mut indented = String::with_capacity(frag.len() + indent_replacer.indentor.len());
       for char in frag.chars() {
         if char == '\n' {
           indent_replacer.should_indent_next_char = true;

--- a/crates/string_wizard/src/magic_string/mod.rs
+++ b/crates/string_wizard/src/magic_string/mod.rs
@@ -109,7 +109,7 @@ impl<'text> MagicString<'text> {
   pub fn last_char(&self) -> Option<char> {
     // Check outro first (last in output order)
     if let Some(last_outro) = self.outro.back()
-      && let Some(c) = last_outro.chars().last()
+      && let Some(c) = last_outro.chars().next_back()
     {
       return Some(c);
     }
@@ -121,7 +121,7 @@ impl<'text> MagicString<'text> {
 
       // Check chunk outro
       if let Some(last_outro) = chunk.outro.back()
-        && let Some(c) = last_outro.chars().last()
+        && let Some(c) = last_outro.chars().next_back()
       {
         return Some(c);
       }
@@ -132,13 +132,13 @@ impl<'text> MagicString<'text> {
         .as_ref()
         .map(|s| s.as_ref())
         .unwrap_or_else(|| chunk.span.text(&self.source));
-      if let Some(c) = content.chars().last() {
+      if let Some(c) = content.chars().next_back() {
         return Some(c);
       }
 
       // Check chunk intro
       if let Some(last_intro) = chunk.intro.back()
-        && let Some(c) = last_intro.chars().last()
+        && let Some(c) = last_intro.chars().next_back()
       {
         return Some(c);
       }
@@ -148,7 +148,7 @@ impl<'text> MagicString<'text> {
 
     // Check intro last (first in output order, but we're going backwards)
     if let Some(last_intro) = self.intro.back()
-      && let Some(c) = last_intro.chars().last()
+      && let Some(c) = last_intro.chars().next_back()
     {
       return Some(c);
     }

--- a/crates/string_wizard/src/magic_string/source_map.rs
+++ b/crates/string_wizard/src/magic_string/source_map.rs
@@ -66,14 +66,21 @@ fn precompute_utf16_index_map(
   source: &str,
   byte_indices: impl Iterator<Item = u32>,
 ) -> FxHashMap<u32, u32> {
+  // Chunk traversal order may not be sorted (e.g. after relocate()), so sort is required.
   let mut byte_indices: Vec<u32> = byte_indices.collect();
-  byte_indices.sort();
+  byte_indices.sort_unstable();
   let mut index: u32 = 0;
   let mut index_utf16: u32 = 0;
-  let mut map: FxHashMap<u32, u32> = Default::default();
+  let mut map: FxHashMap<u32, u32> =
+    FxHashMap::with_capacity_and_hasher(byte_indices.len(), Default::default());
   for &i in &byte_indices {
-    index_utf16 +=
-      source[index as usize..i as usize].chars().map(|c| c.len_utf16() as u32).sum::<u32>();
+    let slice = &source[index as usize..i as usize];
+    // Fast path: ASCII strings have 1:1 byte-to-UTF-16 mapping
+    index_utf16 += if slice.is_ascii() {
+      slice.len() as u32
+    } else {
+      slice.chars().map(|c| c.len_utf16() as u32).sum::<u32>()
+    };
     index = i;
     map.insert(i, index_utf16);
   }

--- a/crates/string_wizard/src/source_map/locator.rs
+++ b/crates/string_wizard/src/source_map/locator.rs
@@ -10,7 +10,13 @@ impl Locator {
     let mut line_start_pos: u32 = 0;
     for line in source.split('\n') {
       line_offsets.push(line_start_pos);
-      line_start_pos += 1 + line.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
+      // Fast path: ASCII lines have 1:1 byte-to-UTF-16 mapping
+      let utf16_len = if line.is_ascii() {
+        line.len() as u32
+      } else {
+        line.chars().map(|c| c.len_utf16() as u32).sum::<u32>()
+      };
+      line_start_pos += 1 + utf16_len;
     }
     Self { line_offsets: line_offsets.into_boxed_slice() }
   }

--- a/crates/string_wizard/src/source_map/sourcemap_builder.rs
+++ b/crates/string_wizard/src/source_map/sourcemap_builder.rs
@@ -135,7 +135,12 @@ impl SourcemapBuilder {
     for _ in lines {
       self.bump_line();
     }
-    self.generated_code_column += last_line.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
+    // Fast path: ASCII strings have 1:1 byte-to-UTF-16 mapping
+    self.generated_code_column += if last_line.is_ascii() {
+      last_line.len() as u32
+    } else {
+      last_line.chars().map(|c| c.len_utf16() as u32).sum::<u32>()
+    };
   }
 
   fn bump_line(&mut self) {


### PR DESCRIPTION
### 

### 1\. `last_char()` — `next_back()` vs `last()`

**Before:** `.chars().last()` consumes the iterator front-to-back to find the last element — O(n) where n is the string length.
**Why faster:** `.chars().next_back()` uses `DoubleEndedIterator` to read the last character directly from the end of the UTF-8 byte sequence — O(1). For a 10,000-character string, this avoids iterating 9,999 characters.

### 2\. `indent_frag()` — pre-allocated capacity

**Before:** `String::new()` starts with zero capacity. As characters are pushed, the string reallocates and copies its buffer multiple times (typically ~log₂(n) reallocations).
**Why faster:** `String::with_capacity(frag.len() + indentor.len())` allocates enough space upfront. The string grows without any reallocation, avoiding repeated memcpy of the growing buffer.

### 3\. `precompute_utf16_index_map()` — `sort_unstable()` + pre-allocated HashMap + ASCII fast path

- **`sort_unstable()`:** Unlike `sort()`, `sort_unstable()` does not allocate temporary storage for merge sort. For `u32` values (no meaningful stability), this is purely free savings.
- **Pre-allocated HashMap:** `FxHashMap::with_capacity_and_hasher(n, ...)` allocates the hash table at the right size upfront. Without this, the map starts small and rehashes (recomputes all hashes and copies all entries) as it grows.
- **ASCII fast path:** `slice.is_ascii()` is a single SIMD-accelerated scan. When true, `slice.len()` gives the UTF-16 length directly (1 byte = 1 UTF-16 unit for ASCII). This skips the per-character `.chars().map(|c| c.len_utf16())` iteration. Since source code is predominantly ASCII, this fast path hits almost always.

### 4\. `Locator::new()` and `SourcemapBuilder::advance()` — ASCII fast path

Same principle as above. Both methods compute UTF-16 lengths by iterating every character calling `len_utf16()`. For ASCII lines (the vast majority of source code), `line.is_ascii()` lets us use `line.len()` directly, replacing per-character iteration with a single length read.