### PR TITLE
perf: use dense IndexVec for SymbolRefFlags instead of FxHashMap

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -391,12 +391,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
 
     self.result.constant_export_map.retain(|symbol_id, constant_meta| {
       (constant_meta.commonjs_export && !bailout_inlined_cjs_exports_symbol_ids.contains(symbol_id))
-        || self
-          .result
-          .symbol_ref_db
-          .flags
-          .get(symbol_id)
-          .is_some_and(|flag| flag.contains(SymbolRefFlags::IsNotReassigned))
+        || self.result.symbol_ref_db.flags[*symbol_id].contains(SymbolRefFlags::IsNotReassigned)
     });
 
     if cfg!(debug_assertions) {
@@ -756,12 +751,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
                     .result
                     .ecma_view_meta
                     .insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-                  self
-                    .result
-                    .symbol_ref_db
-                    .flags
-                    .entry(symbol_id)
-                    .or_default()
+                  self.result.symbol_ref_db.flags[symbol_id]
                     .insert(SymbolRefFlags::SideEffectsFreeFunction);
                 }
               }
@@ -773,12 +763,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
             self.add_local_export(binding_id.name.as_str(), symbol_id, binding_id.span);
             if fn_decl.is_side_effect_free() || fn_decl.pure {
               self.result.ecma_view_meta.insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-              self
-                .result
-                .symbol_ref_db
-                .flags
-                .entry(symbol_id)
-                .or_default()
+              self.result.symbol_ref_db.flags[symbol_id]
                 .insert(SymbolRefFlags::SideEffectsFreeFunction);
             }
           }
@@ -834,12 +819,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       ast::ExportDefaultDeclarationKind::FunctionDeclaration(fn_decl) => {
         if fn_decl.is_side_effect_free() || fn_decl.pure {
           self.result.ecma_view_meta.insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-          self
-            .result
-            .symbol_ref_db
-            .flags
-            .entry(self.result.default_export_ref.symbol)
-            .or_default()
+          self.result.symbol_ref_db.flags[self.result.default_export_ref.symbol]
             .insert(SymbolRefFlags::SideEffectsFreeFunction);
         }
         fn_decl.id.as_ref().map(|id| {

--- a/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
@@ -27,10 +27,10 @@ impl GenerateStage<'_> {
           .contains(EcmaViewMeta::TopExportedSideEffectsFreeFunction)
           .then(move || {
             let symbol_for_module = symbol_for_module.as_ref()?;
-            Some(symbol_for_module.flags.iter().filter_map(move |(symbol_id, flag)| {
+            Some(symbol_for_module.flags.iter_enumerated().filter_map(move |(symbol_id, flag)| {
               flag
                 .contains(SymbolRefFlags::SideEffectsFreeFunction)
-                .then_some(SymbolRef::from((idx, *symbol_id)))
+                .then_some(SymbolRef::from((idx, symbol_id)))
             }))
           })
           .flatten()

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -382,7 +382,6 @@ impl LinkStage<'_> {
   /// export const c = 1;
   /// ```
   /// The final pointed `SymbolRef` of `foo_ns.bar_ns.c` is the `c` in `bar.js`.
-  #[expect(clippy::too_many_lines)]
   fn resolve_member_expr_refs(
     &mut self,
     side_effects_modules: &FxHashSet<ModuleIdx>,

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -602,10 +602,7 @@ impl LinkStage<'_> {
       for (import_symbol, cjs_module_idx) in
         meta.named_import_to_cjs_module.iter().chain(meta.import_record_ns_to_cjs_module.iter())
       {
-        if import_symbol
-          .flags(&self.symbols)
-          .is_some_and(|f| f.contains(SymbolRefFlags::HasComputedMemberWrite))
-        {
+        if import_symbol.flags(&self.symbols).contains(SymbolRefFlags::HasComputedMemberWrite) {
           written_cjs_export_symbols.extend(
             self.metas[*cjs_module_idx]
               .resolved_exports

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -72,10 +72,10 @@ impl LinkStage<'_> {
           .contains(EcmaViewMeta::TopExportedSideEffectsFreeFunction)
           .then(move || {
             let symbol_for_module = symbol_for_module.as_ref()?;
-            Some(symbol_for_module.flags.iter().filter_map(move |(symbol_id, flag)| {
+            Some(symbol_for_module.flags.iter_enumerated().filter_map(move |(symbol_id, flag)| {
               flag
                 .contains(SymbolRefFlags::SideEffectsFreeFunction)
-                .then_some(SymbolRef::from((idx, *symbol_id)))
+                .then_some(SymbolRef::from((idx, symbol_id)))
             }))
           })
           .flatten()
@@ -443,13 +443,10 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
       var_decl.declarations.iter().for_each(|declarator| {
         if let BindingPattern::BindingIdentifier(ref binding) = declarator.id {
           let symbol_ref: SymbolRef = (self.immutable_ctx.module_idx, binding.symbol_id()).into();
-          let is_not_assigned = self
-            .immutable_ctx
-            .symbols
-            .local_db(self.immutable_ctx.module_idx)
-            .flags
-            .get(&symbol_ref.symbol)
-            .is_some_and(|flag| flag.contains(SymbolRefFlags::IsNotReassigned));
+          let is_not_assigned =
+            self.immutable_ctx.symbols.local_db(self.immutable_ctx.module_idx).flags
+              [symbol_ref.symbol]
+              .contains(SymbolRefFlags::IsNotReassigned);
 
           if is_not_assigned
             && let Some(value) = declarator

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -171,7 +171,7 @@ impl<'name> Renamer<'name> {
     let original_name = if self.symbol_db.has_module_preserve_jsx()
       && canonical_ref
         .flags(self.symbol_db)
-        .is_some_and(|flags| flags.contains(SymbolRefFlags::MustStartWithCapitalLetterForJSX))
+        .contains(SymbolRefFlags::MustStartWithCapitalLetterForJSX)
       && canonical_name.as_bytes()[0].is_ascii_lowercase()
     {
       let mut s = String::with_capacity(canonical_name.len());

--- a/crates/rolldown_common/src/types/symbol_ref.rs
+++ b/crates/rolldown_common/src/types/symbol_ref.rs
@@ -27,26 +27,24 @@ impl SymbolRef {
     db[self.owner].unpack_ref_mut().ast_scopes.set_symbol_name(self.symbol, name);
   }
 
-  /// Not all symbols have flags info, we only care about part of them.
-  /// If you want to ensure the flags info exists, use `flags_mut` instead.
-  pub fn flags<'db, T: GetLocalDb>(&self, db: &'db T) -> Option<&'db SymbolRefFlags> {
-    db.local_db(self.owner).flags.get(&self.symbol)
+  pub fn flags<'db, T: GetLocalDb>(&self, db: &'db T) -> &'db SymbolRefFlags {
+    &db.local_db(self.owner).flags[self.symbol]
   }
 
   pub fn flags_mut<'db, T: GetLocalDbMut>(&self, db: &'db mut T) -> &'db mut SymbolRefFlags {
-    db.local_db_mut(self.owner).flags.entry(self.symbol).or_default()
+    &mut db.local_db_mut(self.owner).flags[self.symbol]
   }
 
   // `None` means we don't know if it's declared by `const`.
   pub fn is_declared_by_const(&self, db: &SymbolRefDb) -> Option<bool> {
-    let flags = self.flags(db)?;
+    let flags = self.flags(db);
     // Not having this flag means we don't know if it's declared by `const` instead of it's not declared by `const`.
     flags.contains(SymbolRefFlags::IsConst).then_some(true)
   }
 
   /// `None` means we don't know if it gets reassigned.
   pub fn is_not_reassigned(&self, db: &SymbolRefDb) -> Option<bool> {
-    let flags = self.flags(db)?;
+    let flags = self.flags(db);
     // Not having this flag means we don't know
     flags.contains(SymbolRefFlags::IsNotReassigned).then_some(true)
   }

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -59,8 +59,7 @@ pub struct SymbolRefDbForModule {
   owner_idx: ModuleIdx,
   root_scope_id: ScopeId,
   pub ast_scopes: AstScopes,
-  // Only some symbols would be cared about, so we use a hashmap to store the flags.
-  pub flags: FxHashMap<SymbolId, SymbolRefFlags>,
+  pub flags: IndexVec<SymbolId, SymbolRefFlags>,
   pub classic_data: IndexVec<SymbolId, SymbolRefDataClassic>,
   #[cfg(debug_assertions)]
   create_reason: FxHashMap<SymbolRef, String>,
@@ -72,7 +71,7 @@ impl Default for SymbolRefDbForModule {
       owner_idx: ModuleIdx::new(0),
       root_scope_id: ScopeId::new(0),
       ast_scopes: AstScopes::new(Scoping::default()),
-      flags: FxHashMap::default(),
+      flags: IndexVec::default(),
       classic_data: IndexVec::default(),
       #[cfg(debug_assertions)]
       create_reason: FxHashMap::default(),
@@ -89,8 +88,8 @@ impl SymbolRefDbForModule {
         SymbolRefDataClassic::default();
         scoping.symbols_len()
       ]),
+      flags: IndexVec::from_vec(vec![SymbolRefFlags::default(); scoping.symbols_len()]),
       ast_scopes: AstScopes::new(scoping),
-      flags: FxHashMap::default(),
       #[cfg(debug_assertions)]
       create_reason: FxHashMap::default(),
     }
@@ -101,7 +100,7 @@ impl SymbolRefDbForModule {
   pub fn create_facade_root_symbol_ref(&mut self, name: &str) -> SymbolRef {
     let symbol_id = self.ast_scopes.create_facade_root_symbol_ref(name);
     self.classic_data.push(SymbolRefDataClassic::default());
-    self.flags.entry(symbol_id).or_default().insert(SymbolRefFlags::IsFacade);
+    self.flags.push(SymbolRefFlags::IsFacade);
 
     let ret = SymbolRef::from((self.owner_idx, symbol_id));
     #[cfg(debug_assertions)]
@@ -121,25 +120,22 @@ impl SymbolRefDbForModule {
   /// Check if a symbol is a facade symbol (synthetic, not present in the original AST).
   #[inline]
   pub fn is_facade_symbol(&self, symbol_id: SymbolId) -> bool {
-    self.flags.get(&symbol_id).is_some_and(|f| f.contains(SymbolRefFlags::IsFacade))
+    self.flags[symbol_id].contains(SymbolRefFlags::IsFacade)
   }
 
   /// Merge immutable fields (Scoping) from a build's DB into this cache DB.
   /// Also extends `classic_data` and preserves `IsFacade` flags for facade symbols
   /// that were created during the linking phase.
   pub fn merge_from_build(&mut self, build_db: SymbolRefDbForModule) {
-    // Extend classic_data for any symbols added during linking (e.g., facade symbols)
     let new_len = build_db.ast_scopes.total_symbol_count();
-    let current_len = self.classic_data.len();
-    for _ in current_len..new_len {
+    // Extend classic_data and flags for any symbols added during linking (e.g., facade symbols)
+    while self.classic_data.len() < new_len {
       self.classic_data.push(SymbolRefDataClassic::default());
     }
-
-    // Preserve IsFacade flags for facade symbols added during linking
-    for (symbol_id, flags) in &build_db.flags {
-      if flags.contains(SymbolRefFlags::IsFacade) {
-        self.flags.entry(*symbol_id).or_default().insert(SymbolRefFlags::IsFacade);
-      }
+    while self.flags.len() < new_len {
+      let idx = SymbolId::from_usize(self.flags.len());
+      // Only preserve IsFacade flag from build for new symbols
+      self.flags.push(build_db.flags[idx] & SymbolRefFlags::IsFacade);
     }
 
     let scoping = build_db.ast_scopes.into_scoping();
@@ -284,9 +280,7 @@ impl SymbolRefDb {
     }
     self.get_mut(base_root).link = Some(target_root);
     if self.has_module_preserve_jsx
-      && base_root
-        .flags(self)
-        .is_some_and(|flags| flags.contains(SymbolRefFlags::MustStartWithCapitalLetterForJSX))
+      && base_root.flags(self).contains(SymbolRefFlags::MustStartWithCapitalLetterForJSX)
     {
       *target_root.flags_mut(self) |= SymbolRefFlags::MustStartWithCapitalLetterForJSX;
     }


### PR DESCRIPTION
## Summary
- Replace `FxHashMap<SymbolId, SymbolRefFlags>` with `IndexVec<SymbolId, SymbolRefFlags>` for symbol flags storage
- Since all symbols (including facade) now have contiguous IDs after #8540, we can use a dense array instead of a hash map
- Eliminates hash computation for `is_facade_symbol()` and all flag checks — direct O(1) array indexing with better cache locality
- `SymbolRefFlags` is just 1 byte (`u8`) per symbol, so memory overhead is minimal

## Test plan
- [x] `cargo clippy -p rolldown -p rolldown_common` passes
- [x] `cargo test -p rolldown --test integration_rolldown` passes (only pre-existing `util_deprecate` failure)
- [x] `cargo test -p rolldown --test integration_esbuild` passes
- [x] `cargo test -p rolldown --test integration_rollup` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)