### PR TITLE
refactor(rust): use Oxc's SymbolFlags::ConstVariable instead of custom IsConst flag

### DIFF
--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -523,16 +523,11 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
   fn add_local_export(&mut self, export_name: &str, local: SymbolId, span: Span) {
     let symbol_ref: SymbolRef = (self.immutable_ctx.idx, local).into();
 
-    let is_const = self.result.symbol_ref_db.scoping().symbol_flags(local).is_const_variable();
-
     // If there is any write reference to the local variable, it is reassigned.
     let is_reassigned =
       self.result.symbol_ref_db.get_resolved_references(local).any(Reference::is_write);
 
     let ref_flags = symbol_ref.flags_mut(&mut self.result.symbol_ref_db);
-    if is_const {
-      ref_flags.insert(SymbolRefFlags::IsConst);
-    }
     if !is_reassigned {
       ref_flags.insert(SymbolRefFlags::IsNotReassigned);
     }

--- a/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
+++ b/crates/rolldown/src/utils/chunk/render_chunk_exports.rs
@@ -368,8 +368,7 @@ fn must_keep_live_binding(
 ) -> bool {
   let canonical_ref = symbol_db.canonical_ref_for(export_ref);
 
-  if canonical_ref.is_declared_by_const(symbol_db).unwrap_or(false) {
-    // For unknown case, we consider it as not declared by `const`.
+  if canonical_ref.is_declared_by_const(symbol_db) {
     return false;
   }
 

--- a/crates/rolldown_common/src/types/symbol_ref.rs
+++ b/crates/rolldown_common/src/types/symbol_ref.rs
@@ -37,11 +37,8 @@ impl SymbolRef {
     db.local_db_mut(self.owner).flags.entry(self.symbol).or_default()
   }
 
-  // `None` means we don't know if it's declared by `const`.
-  pub fn is_declared_by_const(&self, db: &SymbolRefDb) -> Option<bool> {
-    let flags = self.flags(db)?;
-    // Not having this flag means we don't know if it's declared by `const` instead of it's not declared by `const`.
-    flags.contains(SymbolRefFlags::IsConst).then_some(true)
+  pub fn is_declared_by_const(&self, db: &SymbolRefDb) -> bool {
+    db.local_db(self.owner).ast_scopes.scoping().symbol_flags(self.symbol).is_const_variable()
   }
 
   /// `None` means we don't know if it gets reassigned.

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -26,8 +26,6 @@ bitflags::bitflags! {
   #[derive(Debug, Default, Clone, Copy)]
   pub struct SymbolRefFlags: u8 {
     const IsNotReassigned = 1;
-    /// If this symbol is declared by `const`. Eg. `const a = 1;`
-    const IsConst = 1 << 1;
     const MustStartWithCapitalLetterForJSX = 1 << 2;
     /// If the SymbolRef points to a side-effects-free function
     const SideEffectsFreeFunction = 1 << 3;


### PR DESCRIPTION
Oxc has a `SymbolFlags::ConstVariable` for `const` variables, so no need to add a custom `IsConst` flag 