### PR TITLE
test(cli): add more cli-e2e test cases

### DIFF
--- a/meta/design/cli.md
+++ b/meta/design/cli.md
@@ -1,0 +1,214 @@
+# CLI Refactor: Replace `parseArgs` with `cac`
+
+## Summary
+
+The current CLI argument parsing (`packages/rolldown/src/cli/arguments/`) uses Node.js's built-in `parseArgs` with ~330 lines of custom workarounds. We replace it with [cac](https://github.com/cacjs/cac) (v6.7.14), the same CLI library used by Vite and tsdown. This fixes the camelCase option bug ([#8410](https://github.com/rolldown/rolldown/issues/8410)) and eliminates most of the custom parsing code.
+
+## CLI Features Currently in Use
+
+### Option Types
+
+| Type                               | Example                                                       | Current Implementation                                       |
+| ---------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------ |
+| boolean                            | `--minify`, `--watch`                                         | `parseArgs` native + manual `--no-*` handling                |
+| string                             | `--dir dist`, `--format cjs`                                  | `parseArgs` native                                           |
+| object (`key=val,key=val`)         | `--module-types .png=dataurl,.svg=text`, `--globals jQuery=$` | Manual split on `,` then `=` (`arguments/index.ts:109-129`)  |
+| array (repeated flags)             | `--external jquery --external lodash`                         | Manual push into array (`arguments/index.ts:130-139`)        |
+| union (string with limited values) | `--format esm`, `--platform node`, `--sourcemap inline`       | Falls through to default case (`arguments/index.ts:147-156`) |
+
+### Short Flags
+
+| Short | Long          | Type                    |
+| ----- | ------------- | ----------------------- |
+| `-c`  | `--config`    | string (optional value) |
+| `-h`  | `--help`      | boolean                 |
+| `-v`  | `--version`   | boolean                 |
+| `-w`  | `--watch`     | boolean                 |
+| `-d`  | `--dir`       | string (requireValue)   |
+| `-o`  | `--file`      | string (requireValue)   |
+| `-e`  | `--external`  | array                   |
+| `-f`  | `--format`    | union                   |
+| `-n`  | `--name`      | string                  |
+| `-g`  | `--globals`   | object                  |
+| `-s`  | `--sourcemap` | union (default: `true`) |
+| `-m`  | `--minify`    | boolean                 |
+| `-p`  | `--platform`  | union                   |
+
+### `--no-*` Boolean Negation
+
+Three options use `reverse: true` in `alias.ts`:
+
+| CLI Flag                         | Sets                              | Default    |
+| -------------------------------- | --------------------------------- | ---------- |
+| `--no-external-live-bindings`    | `externalLiveBindings = false`    | `true`     |
+| `--no-treeshake`                 | `treeshake = false`               | `true`     |
+| `--no-preserve-entry-signatures` | `preserveEntrySignatures = false` | `"strict"` |
+
+### Nested Dot-Notation Options
+
+Options with `.` in the key get unflattened into nested objects (`normalize.ts:28-37`):
+
+```bash
+--transform.define __A__=A,__B__=B
+--transform.target es2020
+--transform.drop-labels debugOnly
+--checks.circular-dependency
+--optimization.inline-const
+--devtools.session-id xxx
+--code-splitting.min-size 1000
+```
+
+### Other Features
+
+- **Positionals as input files**: `rolldown src/main.ts src/other.ts` — positionals become `input.input`, only when `--config` is not set.
+- **`--config` without value**: `rolldown -c` auto-detects config file. Enabled by `strict: false`.
+- **`rawArgs` passthrough**: All parsed args (including unrecognized) are collected into `rawArgs` and passed to config functions (`export default (cliArgs) => ({ ... })`).
+- **`--environment` processing**: `--environment KEY:VALUE,OTHER:VAL` — splits on `,` then `:`, sets `process.env`.
+- **`requireValue` validation**: `--dir` and `--file` must have a value. Without this, `-d` alone silently targets current directory.
+- **Unrecognized option warning**: Unknown options warn but do not error. They are included in `rawArgs`.
+- **Prototype pollution guard**: `__proto__`, `constructor`, `prototype` keys are silently dropped.
+- **Input/Output splitting**: Parsed options are split into `input` vs `output` based on schema keys.
+- **Help text generation**: Auto-generated from the `options` object with sorting, padding, and hints.
+
+## Hacks Built on Top of `parseArgs`
+
+16 workarounds exist in the current implementation:
+
+| #   | Hack                                                            | Goes Away with cac?                                           |
+| --- | --------------------------------------------------------------- | ------------------------------------------------------------- |
+| 1   | `strict: false` to allow unknown options and `-c` without value | Yes — cac has `allowUnknownOptions()` and `[optional]` syntax |
+| 2   | Manual kebab-case → camelCase after parsing                     | Yes — cac converts automatically                              |
+| 3   | Manual camelCase → kebab-case during registration               | Yes — cac accepts either                                      |
+| 4   | `--no-*` prefix stripping and boolean inversion                 | Yes — cac handles natively                                    |
+| 5   | Object parsing (`key=val,key=val` split)                        | **No** — cac has no record/map parsing                        |
+| 6   | Array accumulation via repeated flags                           | Yes — cac auto-accumulates                                    |
+| 7   | Union type handling with defaults                               | Yes — cac treats them as strings                              |
+| 8   | String-type missing value with default injection                | Yes — cac `[optional]` syntax                                 |
+| 9   | `requireValue` validation                                       | Yes — cac `<required>` syntax                                 |
+| 10  | `Object.defineProperty` everywhere                              | Yes — not needed with cac                                     |
+| 11  | Nested option unflattening                                      | Yes — cac has `setDotProp` built-in                           |
+| 12  | Prototype pollution guard                                       | **Needs custom code** — cac's `setDotProp` is not safe        |
+| 13  | Input/Output option splitting                                   | **No** — rolldown-specific logic                              |
+| 14  | Invalid option collection + warning                             | **Partially** — cac allows unknown options but doesn't warn   |
+| 15  | `rawArgs` assembly                                              | **Partially** — need to capture from cac's parsed result      |
+| 16  | Reverse option description rewriting for help                   | Yes — cac's `--no-*` handles help text                        |
+
+10 hacks go away entirely. 2 still need custom code. 4 are partially handled.
+
+## Behavioral Differences Between cac and Current CLI
+
+### Unrecognized options: warn vs error
+
+Current `parseArgs` **warns** on unknown flags and includes them in `rawArgs`. cac **throws `CACError`** by default.
+
+Workaround: Use `.allowUnknownOptions()` to preserve the "warn but don't error" behavior, then manually compare parsed options against known schema keys to print a warning.
+
+### camelCase input
+
+Current `parseArgs` **silently ignores** `--moduleTypes .png=dataurl` (treated as unknown boolean, value lost to positionals). cac **works correctly** — it converts kebab-case and camelCase interchangeably. This is the bug that prompted the migration.
+
+### Repeated flags for non-array options
+
+Current behavior: last value wins for non-array types (e.g. `--format cjs --format esm` → `esm`). cac auto-accumulates into arrays (→ `["cjs", "esm"]`).
+
+Workaround: Same as Vite's `filterDuplicateOptions()` — take last value for non-array option types.
+
+### Object parsing (`key=val,key=val`)
+
+Current behavior: `--module-types .png=dataurl,.svg=text` is manually split into `{ ".png": "dataurl", ".svg": "text" }`. cac treats this as a plain string.
+
+Options:
+
+1. Keep manual `key=val,key=val` parsing (~20 lines) to preserve current syntax (recommended)
+2. Change to dot-notation: `--module-types.png dataurl` (breaking change)
+
+### Nested dot-notation
+
+Behavior is identical. cac's `setDotProp` does the same as rolldown's `setNestedProperty`. The `camelcaseOptionName` function in cac only camelCases the first segment before the dot, matching current behavior.
+
+### `--no-*` negation
+
+Registration syntax changes (cac uses `.option('--no-treeshake', '...')`) but runtime behavior is identical. cac auto-sets default to `true` when `--no-*` is defined.
+
+### Help text generation
+
+Current help is fully custom (sorted by short flag, padded columns, hints, examples, notes). cac auto-generates a different format via `cli.help()`. cac supports a help callback for customization.
+
+### Prototype pollution
+
+cac's `setDotProp` does **not** guard against `--__proto__`. Must keep the prototype pollution check.
+
+## Features Only in Rolldown CLI (Not in Vite)
+
+These are features rolldown uses through CLI that Vite only exposes through config files:
+
+| Feature                                  | Notes                                                                 |
+| ---------------------------------------- | --------------------------------------------------------------------- |
+| Object parsing (`key=val,key=val`)       | Vite only uses objects in config files                                |
+| `--no-*` boolean negation                | Vite has zero `--no-*` options                                        |
+| Nested dot-notation options              | Vite's nesting is config-file-only                                    |
+| Array accumulation                       | Vite deduplicates repeated flags (takes last value)                   |
+| `rawArgs` passthrough to config function | Vite's config function receives `{ mode, command }`, not raw CLI args |
+| `--environment` → `process.env`          | Vite uses `--mode` instead                                            |
+
+### Vite's cac hacks (for reference)
+
+1. **Duplicate option filtering** — takes last value when repeated (`filterDuplicateOptions`)
+2. **Global option cleaning** — strips global flags before passing to command config
+3. **Custom type converters** — `--host 0` and `--base 0` (numeric → string)
+4. **Sourcemap string→boolean coercion** — `"true"` → `true`
+5. **Watch flag→object conversion** — `true` → `{}`
+6. **Early debug processing** — before cac loads
+
+## Test Cases
+
+Tests grouped by **CLI feature**. Each feature needs at least one test to verify its behavior before and after the cac migration.
+
+`[EXISTING]` = covered in `packages/rolldown/tests/cli/cli-e2e.test.ts`. `[MISSING]` = needs to be added.
+
+| #   | Feature                         | Status       | Example                                                              | Notes                                                                                       |
+| --- | ------------------------------- | ------------ | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| 1   | `--version` / `-v`              | `[EXISTING]` | `rolldown --version`                                                 |                                                                                             |
+| 2   | `--help` / `-h`                 | `[EXISTING]` | `rolldown --help`                                                    |                                                                                             |
+| 3   | Help for empty args             | `[EXISTING]` | `rolldown`                                                           |                                                                                             |
+| 4   | Help precedence over other opts | `[MISSING]`  | `rolldown lib -o dist/lib.js --help`                                 | [#8523](https://github.com/rolldown/rolldown/issues/8523)                                   |
+| 5   | Boolean options                 | `[EXISTING]` | `rolldown index.ts --minify -d dist`                                 | Also tests short flag `-m`                                                                  |
+| 6   | String options                  | `[EXISTING]` | `rolldown index.ts --format cjs -d dist`                             |                                                                                             |
+| 7   | Short flags                     | `[EXISTING]` | `rolldown index.ts -d dist -s`                                       | `-d`, `-s`, `-m`, `-c` etc. already covered across tests                                    |
+| 8   | Array (repeated flags)          | `[EXISTING]` | `rolldown index.ts --external node:path --external node:url -d dist` |                                                                                             |
+| 9   | Object (`key=val,key=val`)      | `[EXISTING]` | `rolldown index.ts --module-types .123=text -d dist`                 | `--globals` not separately tested but same code path                                        |
+| 10  | `--no-*` boolean negation       | `[EXISTING]` | `rolldown index.ts --no-external-live-bindings ...`                  | One of three `--no-*` options tested                                                        |
+| 11  | Nested dot-notation             | `[EXISTING]` | `rolldown index.js --transform.define __DEFINE__=defined`            | Tests single and comma-separated values                                                     |
+| 12  | Positionals as input            | `[EXISTING]` | `rolldown 1.ts --input ./2.js`                                       |                                                                                             |
+| 13  | Config loading (`-c`)           | `[EXISTING]` | `rolldown -c rolldown.config.ts`                                     | Tests `.js`, `.cjs`, `.ts`, `.cts`, `.mts`, auto-detect, multiple configs, multiple outputs |
+| 14  | Config function + rawArgs       | `[EXISTING]` | `rolldown -c rolldown.config.js --customArg=customValue`             | Unknown options passed to config function                                                   |
+| 15  | CLI overrides config            | `[EXISTING]` | `rolldown -c rolldown.config.js --format cjs`                        |                                                                                             |
+| 16  | `--environment`                 | `[EXISTING]` | `rolldown -c --environment PRODUCTION,FOO:bar`                       |                                                                                             |
+| 17  | `requireValue` validation       | `[EXISTING]` | `rolldown 1.ts -d` / `rolldown 1.ts -o`                              | `-d`, `--dir`, `-o`, `--file` without value → error                                         |
+| 18  | Invalid option value            | `[EXISTING]` | `rolldown index.ts --format INCORRECT`                               |                                                                                             |
+| 19  | Unknown option warns (no error) | `[EXISTING]` | `rolldown index.ts --someRandomFlag -d dist`                         |                                                                                             |
+| 20  | Watch mode                      | `[EXISTING]` | `rolldown index.ts -d dist -w -s`                                    | Tests `-w`, watch hooks, multiple configs, `ROLLDOWN_WATCH` env                             |
+| 21  | camelCase input ([#8410])       | `[MISSING]`  | `rolldown index.ts --moduleTypes .png=dataurl -d dist`               | The bug that prompted the migration — camelCase options are silently ignored                |
+
+[#8410]: https://github.com/rolldown/rolldown/issues/8410
+
+### Summary
+
+- **Existing**: 20 features covered
+- **Missing**: 1 feature to add before migration
+  - camelCase input (#21) — the core bug
+
+CLI tests: `cd packages/rolldown/tests && pnpm test:cli`
+
+## Unresolved Questions
+
+- Should we keep `key=val,key=val` object syntax or migrate to cac's dot-notation (`--module-types.png dataurl`)? Keeping current syntax avoids breaking changes but requires ~20 lines of custom parsing.
+- Should unrecognized options remain as warnings, or should we switch to cac's default behavior (error)? Current behavior is warn + include in rawArgs for config function passthrough.
+- Should help text use cac's built-in format or preserve the current custom layout (sorted by short flag, with examples and notes sections)?
+- Is cac's `setDotProp` vulnerable to prototype pollution? If so, keep the existing guard.
+
+## Related
+
+- [#8410 — CLI silently mishandles camelCase options](https://github.com/rolldown/rolldown/issues/8410)
+- [#8408 — Closed PR that attempted narrow camelCase fix](https://github.com/rolldown/rolldown/pull/8408)
+- [Vite CLI source](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/cli.ts) — reference for cac usage patterns

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -1,5 +1,289 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`basic arguments > should print help with --help 1`] = `
+"Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API. (rolldown VERSION)
+
+USAGE rolldown -c <config> or rolldown <input> <options>
+
+OPTIONS
+
+  --config -c, <filename>     Path to the config file (default: \`rolldown.config.js\`).
+  --dir -d, <dir>             Output directory, defaults to \`dist\` if \`file\` is not set.
+  --external -e, <external>   Comma-separated list of module ids to exclude from the bundle \`<module-id>,...\`.
+  --format -f, <format>       Output format of the generated bundle (supports esm, cjs, and iife).
+  --globals -g, <globals>     Global variable of UMD / IIFE dependencies (syntax: \`key=value\`).
+  --help -h,                  Show help.
+  --minify -m,                Minify the bundled file.
+  --name -n, <name>           Name for UMD / IIFE format outputs.
+  --file -o, <file>           Single output file.
+  --platform -p, <platform>   Platform for which the code should be generated (node, browser, neutral).
+  --sourcemap -s, <sourcemap> Generate sourcemap (\`-s inline\` for inline, or pass the \`-s\` on the last argument if you want to generate \`.map\` file).
+  --version -v,               Show version number.
+  --watch -w,                 Watch files in bundle and rebuild on changes.
+  --advanced-chunks.min-share-count <advanced-chunks.min-share-count>Minimum share count of the chunk.
+  --advanced-chunks.min-size <advanced-chunks.min-size>Minimum size of the chunk.
+  --asset-file-names <name>   Name pattern for asset files.
+  --banner <banner>           Code to insert the top of the bundled file (outside the wrapper function).
+  --checks.cannot-call-namespace Whether to emit warnings when a namespace is called as a function.
+  --checks.circular-dependency Whether to emit warnings when detecting circular dependency.
+  --checks.common-js-variable-in-esm Whether to emit warnings when a CommonJS variable is used in an ES module.
+  --checks.configuration-field-conflict Whether to emit warnings when a config value is overridden by another config value with a higher priority.
+  --checks.could-not-clean-directory Whether to emit warnings when Rolldown could not clean the output directory.
+  --checks.duplicate-shebang  Whether to emit warnings when both the code and postBanner contain shebang.
+  --checks.empty-import-meta  Whether to emit warnings when \`import.meta\` is not supported with the output format and is replaced with an empty object (\`{}\`).
+  --checks.eval               Whether to emit warnings when detecting uses of direct \`eval\`s.
+  --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
+  --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
+  --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
+  --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
+  --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
+  --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
+  --checks.plugin-timings     Whether to emit warnings when plugins take significant time during the build process.
+  --checks.prefer-builtin-feature Whether to emit warnings when a plugin that is covered by a built-in feature is used.
+  --checks.tolerated-transform Whether to emit warnings when detecting tolerated transform.
+  --checks.unresolved-entry   Whether to emit warnings when an entrypoint cannot be resolved.
+  --checks.unresolved-import  Whether to emit warnings when an import cannot be resolved.
+  --checks.unsupported-tsconfig-option Whether to emit warnings when a tsconfig option or combination of options is not supported.
+  --chunk-file-names <name>   Name pattern for emitted secondary chunks.
+  --clean-dir                 Clean output directory before emitting output.
+  --code-splitting <code-splitting>Code splitting options (true, false, or object).
+  --comments <comments>       Control comments in the output.
+  --context <context>         The entity top-level \`this\` represents.
+  --cwd <cwd>                 Current working directory.
+  --devtools.session-id <devtools.session-id>Used to name the build.
+  --dynamic-import-in-cjs     Dynamic import in CJS output.
+  --entry-file-names <name>   Name pattern for emitted entry chunks.
+  --environment <environment> Pass additional settings to the config file via process.ENV.
+  --es-module                 Always generate \`__esModule\` marks in non-ESM formats, defaults to \`if-default-prop\` (use \`--no-esModule\` to always disable).
+  --exports <exports>         Specify a export mode (auto, named, default, none).
+  --extend                    Extend global variable defined by name in IIFE / UMD formats.
+  --footer <footer>           Code to insert the bottom of the bundled file (outside the wrapper function).
+  --generated-code.preset <generated-code.preset>.
+  --generated-code.profiler-names Whether to add readable names to internal variables for profiling purposes.
+  --generated-code.symbols    Whether to use Symbol.toStringTag for namespace objects.
+  --hash-characters <hash-characters>Use the specified character set for file hashes.
+  --inline-dynamic-imports    Inline dynamic imports.
+  --input <input>             Entry file.
+  --intro <intro>             Code to insert the top of the bundled file (inside the wrapper function).
+  --keep-names                Keep function and class names after bundling.
+  --legal-comments <legal-comments>Control legal comments in the output.
+  --log-level <log-level>     Log level (silent, info, debug, warn).
+  --make-absolute-externals-relative Prevent normalization of external imports.
+  --minify-internal-exports   Minify internal exports.
+  --module-types <types>      Module types for customized extensions.
+  --no-external-live-bindings Disable external live bindings.
+  --no-preserve-entry-signatures Avoid facade chunks for entry points.
+  --no-treeshake              Disable treeshaking.
+  --optimization.inline-const <optimization.inline-const>Enable crossmodule constant inlining.
+  --optimization.pife-for-module-wrappers Use PIFE pattern for module wrappers.
+  --outro <outro>             Code to insert the bottom of the bundled file (inside the wrapper function).
+  --paths <paths>             Maps external module IDs to paths.
+  --polyfill-require          Disable require polyfill injection.
+  --post-banner <post-banner> A string to prepend to the top of each chunk. Applied after the \`renderChunk\` hook and minification.
+  --post-footer <post-footer> A string to append to the bottom of each chunk. Applied after the \`renderChunk\` hook and minification.
+  --preserve-modules          Preserve module structure.
+  --preserve-modules-root <preserve-modules-root>Put preserved modules under this path at root level.
+  --sanitize-file-name        Sanitize file name.
+  --shim-missing-exports      Create shim variables for missing exports.
+  --sourcemap-base-url <sourcemap-base-url>Base URL used to prefix sourcemap paths.
+  --sourcemap-debug-ids       Inject sourcemap debug IDs.
+  --strict <strict>           Whether to always output \`"use strict"\` directive in non-ES module outputs.
+  --strict-execution-order    Lets modules be executed in the order they are declared.
+  --top-level-var             Rewrite top-level declarations to use \`var\`.
+  --transform.assumptions.ignore-function-length .
+  --transform.assumptions.no-document-all .
+  --transform.assumptions.object-rest-no-symbols .
+  --transform.assumptions.pure-getters .
+  --transform.assumptions.set-public-class-fields .
+  --transform.decorator.emit-decorator-metadata .
+  --transform.decorator.legacy .
+  --transform.define <transform.define>Define global variables (syntax: key=value,key2=value2).
+  --transform.drop-labels <transform.drop-labels>Remove labeled statements with these label names.
+  --transform.helpers.mode <transform.helpers.mode>.
+  --transform.inject <transform.inject>Inject import statements on demand.
+  --transform.jsx <transform.jsx>.
+  --transform.plugins.styled-components <transform.plugins.styled-components>.
+  --transform.plugins.tagged-template-escape .
+  --transform.target <transform.target>The JavaScript target environment.
+  --transform.typescript.allow-declare-fields .
+  --transform.typescript.allow-namespaces .
+  --transform.typescript.declaration.sourcemap .
+  --transform.typescript.declaration.strip-internal .
+  --transform.typescript.jsx-pragma <transform.typescript.jsx-pragma>.
+  --transform.typescript.jsx-pragma-frag <transform.typescript.jsx-pragma-frag>.
+  --transform.typescript.only-remove-type-imports .
+  --transform.typescript.remove-class-fields-without-initializer .
+  --transform.typescript.rewrite-import-extensions <transform.typescript.rewrite-import-extensions>.
+  --tsconfig <tsconfig>       Path to the tsconfig.json file.
+  --virtual-dirname <virtual-dirname>.
+
+EXAMPLES
+
+  1. Bundle with a config file \`rolldown.config.mjs\`:
+    rolldown -c rolldown.config.mjs
+
+  2. Bundle the \`src/main.ts\` to \`dist\` with \`cjs\` format:
+    rolldown src/main.ts -d dist -f cjs
+
+  3. Bundle the \`src/main.ts\` and handle the \`.png\` assets to Data URL:
+    rolldown src/main.ts -d dist --moduleTypes .png=dataurl
+
+  4. Bundle the \`src/main.tsx\` and minify the output with sourcemap:
+    rolldown src/main.tsx -d dist -m -s
+
+  5. Create self-executing IIFE using external jQuery as \`$\` and \`_\`:
+    rolldown src/main.ts -d dist -n bundle -f iife -e jQuery,window._ -g jQuery=$
+
+NOTES
+
+  * Due to the API limitation, you need to pass \`-s\` for \`.map\` sourcemap file as the last argument.
+  * If you are using the configuration, please pass the \`-c\` as the last argument if you ignore the default configuration file.
+  * CLI options will override the configuration file.
+  * For more information, please visit https://rolldown.rs/."
+`;
+
+exports[`basic arguments > should print help with -h 1`] = `
+"Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API. (rolldown VERSION)
+
+USAGE rolldown -c <config> or rolldown <input> <options>
+
+OPTIONS
+
+  --config -c, <filename>     Path to the config file (default: \`rolldown.config.js\`).
+  --dir -d, <dir>             Output directory, defaults to \`dist\` if \`file\` is not set.
+  --external -e, <external>   Comma-separated list of module ids to exclude from the bundle \`<module-id>,...\`.
+  --format -f, <format>       Output format of the generated bundle (supports esm, cjs, and iife).
+  --globals -g, <globals>     Global variable of UMD / IIFE dependencies (syntax: \`key=value\`).
+  --help -h,                  Show help.
+  --minify -m,                Minify the bundled file.
+  --name -n, <name>           Name for UMD / IIFE format outputs.
+  --file -o, <file>           Single output file.
+  --platform -p, <platform>   Platform for which the code should be generated (node, browser, neutral).
+  --sourcemap -s, <sourcemap> Generate sourcemap (\`-s inline\` for inline, or pass the \`-s\` on the last argument if you want to generate \`.map\` file).
+  --version -v,               Show version number.
+  --watch -w,                 Watch files in bundle and rebuild on changes.
+  --advanced-chunks.min-share-count <advanced-chunks.min-share-count>Minimum share count of the chunk.
+  --advanced-chunks.min-size <advanced-chunks.min-size>Minimum size of the chunk.
+  --asset-file-names <name>   Name pattern for asset files.
+  --banner <banner>           Code to insert the top of the bundled file (outside the wrapper function).
+  --checks.cannot-call-namespace Whether to emit warnings when a namespace is called as a function.
+  --checks.circular-dependency Whether to emit warnings when detecting circular dependency.
+  --checks.common-js-variable-in-esm Whether to emit warnings when a CommonJS variable is used in an ES module.
+  --checks.configuration-field-conflict Whether to emit warnings when a config value is overridden by another config value with a higher priority.
+  --checks.could-not-clean-directory Whether to emit warnings when Rolldown could not clean the output directory.
+  --checks.duplicate-shebang  Whether to emit warnings when both the code and postBanner contain shebang.
+  --checks.empty-import-meta  Whether to emit warnings when \`import.meta\` is not supported with the output format and is replaced with an empty object (\`{}\`).
+  --checks.eval               Whether to emit warnings when detecting uses of direct \`eval\`s.
+  --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
+  --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
+  --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
+  --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
+  --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
+  --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
+  --checks.plugin-timings     Whether to emit warnings when plugins take significant time during the build process.
+  --checks.prefer-builtin-feature Whether to emit warnings when a plugin that is covered by a built-in feature is used.
+  --checks.tolerated-transform Whether to emit warnings when detecting tolerated transform.
+  --checks.unresolved-entry   Whether to emit warnings when an entrypoint cannot be resolved.
+  --checks.unresolved-import  Whether to emit warnings when an import cannot be resolved.
+  --checks.unsupported-tsconfig-option Whether to emit warnings when a tsconfig option or combination of options is not supported.
+  --chunk-file-names <name>   Name pattern for emitted secondary chunks.
+  --clean-dir                 Clean output directory before emitting output.
+  --code-splitting <code-splitting>Code splitting options (true, false, or object).
+  --comments <comments>       Control comments in the output.
+  --context <context>         The entity top-level \`this\` represents.
+  --cwd <cwd>                 Current working directory.
+  --devtools.session-id <devtools.session-id>Used to name the build.
+  --dynamic-import-in-cjs     Dynamic import in CJS output.
+  --entry-file-names <name>   Name pattern for emitted entry chunks.
+  --environment <environment> Pass additional settings to the config file via process.ENV.
+  --es-module                 Always generate \`__esModule\` marks in non-ESM formats, defaults to \`if-default-prop\` (use \`--no-esModule\` to always disable).
+  --exports <exports>         Specify a export mode (auto, named, default, none).
+  --extend                    Extend global variable defined by name in IIFE / UMD formats.
+  --footer <footer>           Code to insert the bottom of the bundled file (outside the wrapper function).
+  --generated-code.preset <generated-code.preset>.
+  --generated-code.profiler-names Whether to add readable names to internal variables for profiling purposes.
+  --generated-code.symbols    Whether to use Symbol.toStringTag for namespace objects.
+  --hash-characters <hash-characters>Use the specified character set for file hashes.
+  --inline-dynamic-imports    Inline dynamic imports.
+  --input <input>             Entry file.
+  --intro <intro>             Code to insert the top of the bundled file (inside the wrapper function).
+  --keep-names                Keep function and class names after bundling.
+  --legal-comments <legal-comments>Control legal comments in the output.
+  --log-level <log-level>     Log level (silent, info, debug, warn).
+  --make-absolute-externals-relative Prevent normalization of external imports.
+  --minify-internal-exports   Minify internal exports.
+  --module-types <types>      Module types for customized extensions.
+  --no-external-live-bindings Disable external live bindings.
+  --no-preserve-entry-signatures Avoid facade chunks for entry points.
+  --no-treeshake              Disable treeshaking.
+  --optimization.inline-const <optimization.inline-const>Enable crossmodule constant inlining.
+  --optimization.pife-for-module-wrappers Use PIFE pattern for module wrappers.
+  --outro <outro>             Code to insert the bottom of the bundled file (inside the wrapper function).
+  --paths <paths>             Maps external module IDs to paths.
+  --polyfill-require          Disable require polyfill injection.
+  --post-banner <post-banner> A string to prepend to the top of each chunk. Applied after the \`renderChunk\` hook and minification.
+  --post-footer <post-footer> A string to append to the bottom of each chunk. Applied after the \`renderChunk\` hook and minification.
+  --preserve-modules          Preserve module structure.
+  --preserve-modules-root <preserve-modules-root>Put preserved modules under this path at root level.
+  --sanitize-file-name        Sanitize file name.
+  --shim-missing-exports      Create shim variables for missing exports.
+  --sourcemap-base-url <sourcemap-base-url>Base URL used to prefix sourcemap paths.
+  --sourcemap-debug-ids       Inject sourcemap debug IDs.
+  --strict <strict>           Whether to always output \`"use strict"\` directive in non-ES module outputs.
+  --strict-execution-order    Lets modules be executed in the order they are declared.
+  --top-level-var             Rewrite top-level declarations to use \`var\`.
+  --transform.assumptions.ignore-function-length .
+  --transform.assumptions.no-document-all .
+  --transform.assumptions.object-rest-no-symbols .
+  --transform.assumptions.pure-getters .
+  --transform.assumptions.set-public-class-fields .
+  --transform.decorator.emit-decorator-metadata .
+  --transform.decorator.legacy .
+  --transform.define <transform.define>Define global variables (syntax: key=value,key2=value2).
+  --transform.drop-labels <transform.drop-labels>Remove labeled statements with these label names.
+  --transform.helpers.mode <transform.helpers.mode>.
+  --transform.inject <transform.inject>Inject import statements on demand.
+  --transform.jsx <transform.jsx>.
+  --transform.plugins.styled-components <transform.plugins.styled-components>.
+  --transform.plugins.tagged-template-escape .
+  --transform.target <transform.target>The JavaScript target environment.
+  --transform.typescript.allow-declare-fields .
+  --transform.typescript.allow-namespaces .
+  --transform.typescript.declaration.sourcemap .
+  --transform.typescript.declaration.strip-internal .
+  --transform.typescript.jsx-pragma <transform.typescript.jsx-pragma>.
+  --transform.typescript.jsx-pragma-frag <transform.typescript.jsx-pragma-frag>.
+  --transform.typescript.only-remove-type-imports .
+  --transform.typescript.remove-class-fields-without-initializer .
+  --transform.typescript.rewrite-import-extensions <transform.typescript.rewrite-import-extensions>.
+  --tsconfig <tsconfig>       Path to the tsconfig.json file.
+  --virtual-dirname <virtual-dirname>.
+
+EXAMPLES
+
+  1. Bundle with a config file \`rolldown.config.mjs\`:
+    rolldown -c rolldown.config.mjs
+
+  2. Bundle the \`src/main.ts\` to \`dist\` with \`cjs\` format:
+    rolldown src/main.ts -d dist -f cjs
+
+  3. Bundle the \`src/main.ts\` and handle the \`.png\` assets to Data URL:
+    rolldown src/main.ts -d dist --moduleTypes .png=dataurl
+
+  4. Bundle the \`src/main.tsx\` and minify the output with sourcemap:
+    rolldown src/main.tsx -d dist -m -s
+
+  5. Create self-executing IIFE using external jQuery as \`$\` and \`_\`:
+    rolldown src/main.ts -d dist -n bundle -f iife -e jQuery,window._ -g jQuery=$
+
+NOTES
+
+  * Due to the API limitation, you need to pass \`-s\` for \`.map\` sourcemap file as the last argument.
+  * If you are using the configuration, please pass the \`-c\` as the last argument if you ignore the default configuration file.
+  * CLI options will override the configuration file.
+  * For more information, please visit https://rolldown.rs/."
+`;
+
 exports[`basic arguments > should render help message for empty args 1`] = `
 "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API. (rolldown VERSION)
 
@@ -173,6 +457,12 @@ console.log("1");
 //#region 2.js
 console.log("2");
 //#endregion
+"
+`;
+
+exports[`cli options for bundling > should handle comma-separated object options 1`] = `
+"<DIR>/index.js  chunk │ size: 0.09 kB
+
 "
 `;
 

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -11,11 +11,11 @@ function cliFixturesDir(...joined: string[]) {
 
 // remove `Finished in x ms` since it is not deterministic
 // remove Ansi colors for snapshot testing
+// replace version number for snapshot testing
 function cleanStdout(stdout: string) {
-  return stripAnsi(stdout).replace(
-    /rolldown v(?<version>\S+) Finished in \d+(\.\d+)? (s|ms|us|ns)/g,
-    '',
-  );
+  return stripAnsi(stdout)
+    .replace(/rolldown v(?<version>\S+) Finished in \d+(\.\d+)? (s|ms|us|ns)/g, '')
+    .replace(/* Match `rolldown v*)` */ /rolldown\sv.*\)/, 'rolldown VERSION)');
 }
 
 describe('should not hang after running', () => {
@@ -30,12 +30,7 @@ describe('basic arguments', () => {
     const ret = await execa`rolldown`;
 
     expect(ret.exitCode).toBe(0);
-    expect(
-      cleanStdout(
-        // Prevent snapshot from breaking when version changes
-        ret.stdout.replace(/* Match `rolldown v*)` */ /rolldown\sv.*\)/, 'rolldown VERSION)'),
-      ),
-    ).toMatchSnapshot();
+    expect(cleanStdout(ret.stdout)).toMatchSnapshot();
   });
 
   test('should not show warning with supported Node.js version', async () => {
@@ -46,6 +41,36 @@ describe('basic arguments', () => {
     expect(ret.stdout).toContain('rolldown v');
     expect(ret.stdout).not.toContain('Please upgrade your Node.js version');
   });
+
+  test('should print version with --version', async () => {
+    const ret = await execa`rolldown --version`;
+
+    expect(ret.exitCode).toBe(0);
+    expect(ret.stdout).toMatch(/rolldown v\d+/);
+  });
+
+  test('should print version with -v', async () => {
+    const ret = await execa`rolldown -v`;
+
+    expect(ret.exitCode).toBe(0);
+    expect(ret.stdout).toMatch(/rolldown v\d+/);
+  });
+
+  test('should print help with --help', async () => {
+    const ret = await execa`rolldown --help`;
+
+    expect(ret.exitCode).toBe(0);
+    expect(cleanStdout(ret.stdout)).toMatchSnapshot();
+  });
+
+  test('should print help with -h', async () => {
+    const ret = await execa`rolldown -h`;
+
+    expect(ret.exitCode).toBe(0);
+    expect(cleanStdout(ret.stdout)).toMatchSnapshot();
+  });
+
+  // TODO: help message takes precedence over other arguments (#8523)
 });
 
 describe('cli options for bundling', () => {
@@ -93,6 +118,15 @@ describe('cli options for bundling', () => {
     const status = await $({
       cwd,
     })`rolldown index.ts --module-types .123=text --module-types notjson=json --module-types .b64=base64 -d dist`;
+    expect(status.exitCode).toBe(0);
+    expect(cleanStdout(status.stdout)).toMatchSnapshot();
+  });
+
+  it('should handle comma-separated object options', async () => {
+    const cwd = cliFixturesDir('cli-option-object');
+    const status = await $({
+      cwd,
+    })`rolldown index.ts --module-types .123=text,notjson=json,.b64=base64 -d dist`;
     expect(status.exitCode).toBe(0);
     expect(cleanStdout(status.stdout)).toMatchSnapshot();
   });
@@ -203,6 +237,13 @@ describe('cli options for bundling', () => {
     } catch (error: any) {
       expect(error.stdout).toContain('Option `--file` requires a value');
     }
+  });
+
+  it('should warn on unrecognized options but still bundle', async () => {
+    const cwd = cliFixturesDir('cli-option-string');
+    const status = await $({ cwd })`rolldown index.ts --someRandomFlag -d dist`;
+    expect(status.exitCode).toBe(0);
+    expect(status.stdout).toContain('unrecognized');
   });
 });
 
@@ -361,6 +402,17 @@ describe('config', () => {
     } catch (error: any) {
       expect(error.stdout).toContain('expected object or array, got 123');
     }
+  });
+
+  it('should allow CLI options to override config values', async () => {
+    const cwd = cliFixturesDir('cli-override-config');
+    const status = await $({ cwd })`rolldown -c rolldown.config.js --format cjs`;
+    expect(status.exitCode).toBe(0);
+    const file = path.resolve(cwd, 'dist/index.js');
+    const content = fs.readFileSync(file, 'utf-8');
+    // Config has format: 'esm', CLI overrides with --format cjs
+    expect(content).toContain('exports.foo');
+    expect(content).not.toContain('export {');
   });
 });
 

--- a/packages/rolldown/tests/cli/fixtures/cli-override-config/index.ts
+++ b/packages/rolldown/tests/cli/fixtures/cli-override-config/index.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/packages/rolldown/tests/cli/fixtures/cli-override-config/rolldown.config.js
+++ b/packages/rolldown/tests/cli/fixtures/cli-override-config/rolldown.config.js
@@ -1,0 +1,7 @@
+export default {
+  input: './index.ts',
+  output: {
+    dir: 'dist',
+    format: 'esm',
+  },
+};

--- a/packages/rolldown/tests/package.json
+++ b/packages/rolldown/tests/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "test:main": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run --exclude '**/watch.test.ts' --reporter verbose --hideSkippedTests",
     "test:watcher": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run watch.test.ts --reporter verbose --hideSkippedTests",
+    "test:cli": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run cli-e2e.test.ts --reporter verbose --hideSkippedTests",
     "test:stability": "node ./stability/issue-3453/src/build.mjs && node ./stability/issue-3453/verify.mjs",
     "test:types": "vitest run --typecheck.only --reporter verbose --hideSkippedTests",
     "type-check": "tsc --noEmit"


### PR DESCRIPTION
## New CLI e2e test cases

- `--version` and `-v`
- `--help` and `-h`
- Unrecognized options warn but do not error
- CLI options override config values (`--format cjs` overrides config `format: "esm"`)

## Other

- Add `test:cli` script to `packages/rolldown/tests/package.json`
- Add design doc `meta/design/cli.md` for CLI refactor (#8410)

## Design doc

Refer to the second PR for the finalized design doc https://github.com/rolldown/rolldown/pull/8551
Design doc in the PR is just used for migration.