### PR TITLE
docs: correct composable filter support explanation

### DIFF
--- a/docs/apis/plugin-api/hook-filters.md
+++ b/docs/apis/plugin-api/hook-filters.md
@@ -85,7 +85,7 @@ See [`HookFilter`](/reference/Interface.HookFilter) as well.
 For more complex filtering logic, Rolldown provides composable filter expressions via the [`@rolldown/pluginutils`](https://github.com/rolldown/rolldown/tree/main/packages/pluginutils) package. These allow you to build filters using logical operators like `and`, `or`, and `not`.
 
 > [!WARNING]
-> Composable filters are not yet supported in legacy Vite or unplugin. They can be used in Rolldown/Rolldown-Vite/Vite Beta plugins only.
+> Composable filters are not yet supported in Vite or unplugin. They can be used in Rolldown plugins only.
 
 ### Example
 

--- a/packages/pluginutils/README.md
+++ b/packages/pluginutils/README.md
@@ -40,7 +40,7 @@ const myPlugin = {
 ### Composable Filters
 
 > [!WARNING]
-> Composable filters are not yet supported in legacy Vite or unplugin. They can be used in Rolldown/Rolldown-Vite/Vite Beta plugins only.
+> Composable filters are not yet supported in Vite or unplugin. They can be used in Rolldown plugins only.
 
 ```ts
 import { and, id, include, moduleType, query } from '@rolldown/pluginutils';


### PR DESCRIPTION
It doesn't work in Vite 7, Vite 8, rolldown-vite.