### PR TITLE
refactor(cli): migrate CLI to CAC

### DIFF
--- a/meta/design/cli.md
+++ b/meta/design/cli.md
@@ -1,214 +1,275 @@
-# CLI Refactor: Replace `parseArgs` with `cac`
+# CLI Design
 
-## Summary
+The CLI uses [cac](https://github.com/cacjs/cac) (v6.7.14) for argument parsing. cac is the same library used by Vite and tsdown.
 
-The current CLI argument parsing (`packages/rolldown/src/cli/arguments/`) uses Node.js's built-in `parseArgs` with ~330 lines of custom workarounds. We replace it with [cac](https://github.com/cacjs/cac) (v6.7.14), the same CLI library used by Vite and tsdown. This fixes the camelCase option bug ([#8410](https://github.com/rolldown/rolldown/issues/8410)) and eliminates most of the custom parsing code.
+## Pipeline
 
-## CLI Features Currently in Use
-
-### Option Types
-
-| Type                               | Example                                                       | Current Implementation                                       |
-| ---------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------ |
-| boolean                            | `--minify`, `--watch`                                         | `parseArgs` native + manual `--no-*` handling                |
-| string                             | `--dir dist`, `--format cjs`                                  | `parseArgs` native                                           |
-| object (`key=val,key=val`)         | `--module-types .png=dataurl,.svg=text`, `--globals jQuery=$` | Manual split on `,` then `=` (`arguments/index.ts:109-129`)  |
-| array (repeated flags)             | `--external jquery --external lodash`                         | Manual push into array (`arguments/index.ts:130-139`)        |
-| union (string with limited values) | `--format esm`, `--platform node`, `--sourcemap inline`       | Falls through to default case (`arguments/index.ts:147-156`) |
-
-### Short Flags
-
-| Short | Long          | Type                    |
-| ----- | ------------- | ----------------------- |
-| `-c`  | `--config`    | string (optional value) |
-| `-h`  | `--help`      | boolean                 |
-| `-v`  | `--version`   | boolean                 |
-| `-w`  | `--watch`     | boolean                 |
-| `-d`  | `--dir`       | string (requireValue)   |
-| `-o`  | `--file`      | string (requireValue)   |
-| `-e`  | `--external`  | array                   |
-| `-f`  | `--format`    | union                   |
-| `-n`  | `--name`      | string                  |
-| `-g`  | `--globals`   | object                  |
-| `-s`  | `--sourcemap` | union (default: `true`) |
-| `-m`  | `--minify`    | boolean                 |
-| `-p`  | `--platform`  | union                   |
-
-### `--no-*` Boolean Negation
-
-Three options use `reverse: true` in `alias.ts`:
-
-| CLI Flag                         | Sets                              | Default    |
-| -------------------------------- | --------------------------------- | ---------- |
-| `--no-external-live-bindings`    | `externalLiveBindings = false`    | `true`     |
-| `--no-treeshake`                 | `treeshake = false`               | `true`     |
-| `--no-preserve-entry-signatures` | `preserveEntrySignatures = false` | `"strict"` |
-
-### Nested Dot-Notation Options
-
-Options with `.` in the key get unflattened into nested objects (`normalize.ts:28-37`):
-
-```bash
---transform.define __A__=A,__B__=B
---transform.target es2020
---transform.drop-labels debugOnly
---checks.circular-dependency
---optimization.inline-const
---devtools.session-id xxx
---code-splitting.min-size 1000
+```
+bin/cli.mjs
+  → src/cli/index.ts (entry)
+    → checkNodeVersion()
+    → parseCliArguments()
+      → arguments/index.ts
+        → getCliSchemaInfo()                 — flatten valibot schema into { key: { type, description } }
+        → build `options` export             — for help.ts consumption (kebab-case keys)
+        → build knownKeys / shortAliases     — for post-processing
+        → register options with cac          — loop schemaInfo + alias, build rawName strings
+        → cli.parse(process.argv, { run: true })
+        → post-processing:
+          → delete `--` key and short-alias duplicates
+          → prototype pollution guard
+          → unknown option detection + warning
+          → rawArgs snapshot
+          → remove unknown keys
+          → type coercion (duplicate filtering + array wrapping)
+          → object option parsing (key=val,key=val)
+      → arguments/normalize.ts
+        → validateCliOptions() via valibot
+        → split into input/output based on schema keys
+        → merge positionals into input.input
+    → process --environment (KEY:VALUE → process.env)
+    → if --help: showHelp()
+    → if --version: print version
+    → if --config: bundleWithConfig(configPath, cliOptions, rawArgs)
+    → if input specified: bundleWithCliOptions(cliOptions)
+    → else: showHelp()
 ```
 
-### Other Features
+## Key Files
 
-- **Positionals as input files**: `rolldown src/main.ts src/other.ts` — positionals become `input.input`, only when `--config` is not set.
-- **`--config` without value**: `rolldown -c` auto-detects config file. Enabled by `strict: false`.
-- **`rawArgs` passthrough**: All parsed args (including unrecognized) are collected into `rawArgs` and passed to config functions (`export default (cliArgs) => ({ ... })`).
-- **`--environment` processing**: `--environment KEY:VALUE,OTHER:VAL` — splits on `,` then `:`, sets `process.env`.
-- **`requireValue` validation**: `--dir` and `--file` must have a value. Without this, `-d` alone silently targets current directory.
-- **Unrecognized option warning**: Unknown options warn but do not error. They are included in `rawArgs`.
-- **Prototype pollution guard**: `__proto__`, `constructor`, `prototype` keys are silently dropped.
-- **Input/Output splitting**: Parsed options are split into `input` vs `output` based on schema keys.
-- **Help text generation**: Auto-generated from the `options` object with sorting, padding, and hints.
+| File                              | Role                                                                              |
+| --------------------------------- | --------------------------------------------------------------------------------- |
+| `cli/index.ts`                    | Entry point — orchestrates the pipeline                                           |
+| `cli/arguments/index.ts`          | Core parsing — cac setup, option registration, post-processing                    |
+| `cli/arguments/normalize.ts`      | Splits flat options into `input`/`output`, validates with valibot                 |
+| `cli/arguments/alias.ts`          | Short flags, `reverse`, `requireValue`, `hint` config                             |
+| `cli/arguments/utils.ts`          | `setNestedProperty`, `camelCaseToKebabCase`                                       |
+| `cli/commands/help.ts`            | Custom help text generation (reads `options` export)                              |
+| `cli/commands/bundle.ts`          | `bundleWithConfig`, `bundleWithCliOptions`, watch mode                            |
+| `cli/logger.ts`                   | consola logger, replaced with plain `console.log` when `ROLLDOWN_TEST=1`          |
+| `utils/validator.ts`              | valibot schemas for all CLI options, `getCliSchemaInfo()`, input/output key lists |
+| `utils/flatten-valibot-schema.ts` | Recursively flattens valibot object schemas into `{ key: { type, description } }` |
 
-## Hacks Built on Top of `parseArgs`
+## What `parseCliArguments()` Returns
 
-16 workarounds exist in the current implementation:
+```ts
+interface NormalizedCliOptions {
+  input: InputOptions;
+  output: OutputOptions;
+  help: boolean;
+  config: string;
+  version: boolean;
+  watch: boolean;
+  environment?: string | string[];
+}
 
-| #   | Hack                                                            | Goes Away with cac?                                           |
-| --- | --------------------------------------------------------------- | ------------------------------------------------------------- |
-| 1   | `strict: false` to allow unknown options and `-c` without value | Yes — cac has `allowUnknownOptions()` and `[optional]` syntax |
-| 2   | Manual kebab-case → camelCase after parsing                     | Yes — cac converts automatically                              |
-| 3   | Manual camelCase → kebab-case during registration               | Yes — cac accepts either                                      |
-| 4   | `--no-*` prefix stripping and boolean inversion                 | Yes — cac handles natively                                    |
-| 5   | Object parsing (`key=val,key=val` split)                        | **No** — cac has no record/map parsing                        |
-| 6   | Array accumulation via repeated flags                           | Yes — cac auto-accumulates                                    |
-| 7   | Union type handling with defaults                               | Yes — cac treats them as strings                              |
-| 8   | String-type missing value with default injection                | Yes — cac `[optional]` syntax                                 |
-| 9   | `requireValue` validation                                       | Yes — cac `<required>` syntax                                 |
-| 10  | `Object.defineProperty` everywhere                              | Yes — not needed with cac                                     |
-| 11  | Nested option unflattening                                      | Yes — cac has `setDotProp` built-in                           |
-| 12  | Prototype pollution guard                                       | **Needs custom code** — cac's `setDotProp` is not safe        |
-| 13  | Input/Output option splitting                                   | **No** — rolldown-specific logic                              |
-| 14  | Invalid option collection + warning                             | **Partially** — cac allows unknown options but doesn't warn   |
-| 15  | `rawArgs` assembly                                              | **Partially** — need to capture from cac's parsed result      |
-| 16  | Reverse option description rewriting for help                   | Yes — cac's `--no-*` handles help text                        |
+// Plus rawArgs: Record<string, any> — all parsed args including unknown ones
+```
 
-10 hacks go away entirely. 2 still need custom code. 4 are partially handled.
+## cac Setup
 
-## Behavioral Differences Between cac and Current CLI
+### Option Registration
 
-### Unrecognized options: warn vs error
+Loop over `schemaInfo` + `alias` and register each option with cac. Schema keys are camelCase (e.g. `moduleTypes`); cac's internal `camelcaseOptionName` handles kebab↔camel conversion, so we register with the camelCase key directly. cac will match both `--moduleTypes` and `--module-types` from argv.
 
-Current `parseArgs` **warns** on unknown flags and includes them in `rawArgs`. cac **throws `CACError`** by default.
+```ts
+for (const [key, info] of Object.entries(schemaInfo)) {
+  const config = alias[key as keyof typeof alias];
 
-Workaround: Use `.allowUnknownOptions()` to preserve the "warn but don't error" behavior, then manually compare parsed options against known schema keys to print a warning.
+  let rawName = '';
+  if (config?.abbreviation) rawName += `-${config.abbreviation}, `;
 
-### camelCase input
+  if (config?.reverse) {
+    rawName += `--no-${key}`;
+  } else {
+    rawName += `--${key}`;
+  }
 
-Current `parseArgs` **silently ignores** `--moduleTypes .png=dataurl` (treated as unknown boolean, value lost to positionals). cac **works correctly** — it converts kebab-case and camelCase interchangeably. This is the bug that prompted the migration.
+  // Bracket syntax determines how cac handles the option:
+  // - No brackets → boolean (registered in mri's boolean list)
+  // - <required>  → string, checkOptionValue throws CACError if missing
+  // - [optional]  → string, returns true if no value follows
+  if (info.type !== 'boolean' && !config?.reverse) {
+    if (config?.requireValue) {
+      rawName += ` <${config?.hint ?? key}>`;
+    } else {
+      rawName += ` [${config?.hint ?? key}]`;
+    }
+  }
 
-### Repeated flags for non-array options
+  cli.option(rawName, info.description ?? config?.description ?? '');
+}
+```
 
-Current behavior: last value wins for non-array types (e.g. `--format cjs --format esm` → `esm`). cac auto-accumulates into arrays (→ `["cjs", "esm"]`).
+### Default Command
 
-Workaround: Same as Vite's `filterDuplicateOptions()` — take last value for non-array option types.
+```ts
+const cmd = cli.command('[...input]', '');
+cmd.allowUnknownOptions();    // suppress cac's unknown option error — we warn instead
+cmd.ignoreOptionDefaultValue(); // prevent cac from injecting --no-* defaults
+cmd.action((input, opts) => { ... });
+cli.parse(process.argv, { run: true });
+```
 
-### Object parsing (`key=val,key=val`)
+### What cac Gives Us
 
-Current behavior: `--module-types .png=dataurl,.svg=text` is manually split into `{ ".png": "dataurl", ".svg": "text" }`. cac treats this as a plain string.
+- camelCase/kebab-case interchangeable matching (fixes [#8410])
+- `--no-*` boolean negation
+- `<required>` value validation via `checkOptionValue()` — throws `CACError`
+- `[optional]` value parsing — fixes `-s inline` position restriction ([#3248])
+- Dot-notation nesting via `setDotProp` (`--transform.define X=Y` → `{ transform: { define: 'X=Y' } }`)
+- Short flag aliases and stacking (`-ms` = `--minify --sourcemap`)
+- Array auto-accumulation for repeated flags
 
-Options:
+### What We Implement Ourselves
 
-1. Keep manual `key=val,key=val` parsing (~20 lines) to preserve current syntax (recommended)
-2. Change to dot-notation: `--module-types.png dataurl` (breaking change)
+- **Object parsing** — `--module-types .a=text,.b=json`: split on `,` then `=`. Supports both comma-separated single flag and repeated flags.
+- **Unknown option warning** — `allowUnknownOptions()` suppresses cac's error; we detect and warn with our own message format.
+- **Prototype pollution guard** — cac's `setDotProp` doesn't guard against `__proto__`, `constructor`, `prototype`.
+- **Input/output splitting** — rolldown-specific logic in `normalize.ts` that splits flat options into `InputOptions` and `OutputOptions`.
+- **Custom help text** — don't use `cli.help()`; keep our custom generator with sorting, padding, examples, notes.
+- **Duplicate option filtering** — take last value for non-array types; keep arrays for `external` and `input`.
+- **rawArgs assembly** — snapshot of all parsed args (including unknown) for config function passthrough.
+- **Short-alias key cleanup** — mri duplicates both short and long names (e.g. `{ s: true, sourcemap: true }`); we delete the short keys.
 
-### Nested dot-notation
+## Post-Processing Order
 
-Behavior is identical. cac's `setDotProp` does the same as rolldown's `setNestedProperty`. The `camelcaseOptionName` function in cac only camelCases the first segment before the dot, matching current behavior.
+1. Delete `parsedOptions['--']` (cac-specific artifact)
+2. Delete short-alias duplicate keys
+3. Prototype pollution guard
+4. Unknown option detection + warning
+5. Snapshot `rawArgs` (includes unknown keys)
+6. Remove unknown keys from `parsedOptions`
+7. Type coercion — duplicate filtering + array wrapping (single merged loop)
+8. Object option parsing (`key=val,key=val`)
+9. `normalizeCliOptions()` — valibot validation + input/output splitting
 
-### `--no-*` negation
+## Implementation Notes
 
-Registration syntax changes (cac uses `.option('--no-treeshake', '...')`) but runtime behavior is identical. cac auto-sets default to `true` when `--no-*` is defined.
+### `CACError` Is Not Exported
 
-### Help text generation
+cac only exports `cac`, `CAC`, and `Command`. `CACError` is in `utils.ts` but not re-exported. We catch by checking `err.name === 'CACError'`.
 
-Current help is fully custom (sorted by short flag, padded columns, hints, examples, notes). cac auto-generates a different format via `cli.help()`. cac supports a help callback for customization.
+### `ignoreOptionDefaultValue()`
 
-### Prototype pollution
+cac auto-injects `default: true` for `--no-*` options. Without `ignoreOptionDefaultValue()`, cac injects these into every parse result, even when the flag is not passed. This breaks valibot validation — e.g. `preserveEntrySignatures` only accepts `false`, so cac's injected `true` causes a validation error. We disable cac's defaults entirely and let the bundler handle its own defaults.
 
-cac's `setDotProp` does **not** guard against `--__proto__`. Must keep the prototype pollution check.
+### Short-Alias Key Duplication
 
-## Features Only in Rolldown CLI (Not in Vite)
+mri returns both short and long names as separate keys (e.g. `-s` → `{ s: true, sourcemap: true }`). We collect all short aliases at startup and delete them from parsed options.
 
-These are features rolldown uses through CLI that Vite only exposes through config files:
+### Nested Option Parent Keys
 
-| Feature                                  | Notes                                                                 |
-| ---------------------------------------- | --------------------------------------------------------------------- |
-| Object parsing (`key=val,key=val`)       | Vite only uses objects in config files                                |
-| `--no-*` boolean negation                | Vite has zero `--no-*` options                                        |
-| Nested dot-notation options              | Vite's nesting is config-file-only                                    |
-| Array accumulation                       | Vite deduplicates repeated flags (takes last value)                   |
-| `rawArgs` passthrough to config function | Vite's config function receives `{ mode, command }`, not raw CLI args |
-| `--environment` → `process.env`          | Vite uses `--mode` instead                                            |
+cac's `setDotProp` converts `--transform.define value` into `{ transform: { define: 'value' } }`. When checking for unknown options, the top-level key `transform` is not in flattened `schemaInfo` (only `transform.define`, `transform.target`, etc. are). We pre-compute parent keys from dot-separated schema keys and include them in the known set.
 
-### Vite's cac hacks (for reference)
+### Object Option Parsing Traversal
 
-1. **Duplicate option filtering** — takes last value when repeated (`filterDuplicateOptions`)
-2. **Global option cleaning** — strips global flags before passing to command config
-3. **Custom type converters** — `--host 0` and `--base 0` (numeric → string)
-4. **Sourcemap string→boolean coercion** — `"true"` → `true`
-5. **Watch flag→object conversion** — `true` → `{}`
-6. **Early debug processing** — before cac loads
+After cac's `setDotProp`, parsed options already have nested structure. The object parsing step traverses the dot-path to find and parse string values, rather than iterating top-level entries.
+
+### `--config` With Optional Value
+
+`-c` registered as `[optional]` returns `config: true` when no value follows. `normalize.ts` maps `config: true` → `config: ''` to preserve auto-detect behavior.
+
+### `--environment` Is Not an Object Option
+
+`--environment` uses `:` and `,` separators (Rollup-compatible), processed separately in `cli/index.ts` by writing to `process.env`. Schema type is `string | string[]`, not object. Unrelated to the object option parsing.
+
+### `--` Delimiter
+
+`parseArgs` treats args after `--` as positionals. cac collects them into `options['--']` as an array. We delete this key in post-processing since no downstream code uses it.
+
+## Edge Cases
+
+### `--sourcemap` Dual Behavior
+
+`-s` alone → `true`. `-s inline` → `"inline"`. `--sourcemap hidden` → `"hidden"`.
+
+Registered as `-s, --sourcemap [type]`. The `[optional]` bracket means mri does NOT treat `-s` as boolean — it consumes the next non-flag arg as the value, or returns `true` if none follows.
+
+### `--no-preserve-entry-signatures`
+
+When passed, cac sets `preserveEntrySignatures: false`. When not passed, it's `undefined` and the bundler applies its own default (`ExportsOnly`).
+
+### Object Options With Comma in Values
+
+`--transform.define __A__=A,__B__=B` — cac returns the single string `"__A__=A,__B__=B"`. Our post-processing splits it into `{ __A__: 'A', __B__: 'B' }`.
+
+### Prototype Pollution
+
+cac's `setDotProp` does not guard against `__proto__`, `constructor`, or `prototype`. We delete any such keys in post-processing before normalization.
 
 ## Test Cases
 
-Tests grouped by **CLI feature**. Each feature needs at least one test to verify its behavior before and after the cac migration.
+Tests are in `packages/rolldown/tests/cli/cli-e2e.test.ts`. Run with `cd packages/rolldown/tests && pnpm test:cli`.
 
-`[EXISTING]` = covered in `packages/rolldown/tests/cli/cli-e2e.test.ts`. `[MISSING]` = needs to be added.
-
-| #   | Feature                         | Status       | Example                                                              | Notes                                                                                       |
-| --- | ------------------------------- | ------------ | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| 1   | `--version` / `-v`              | `[EXISTING]` | `rolldown --version`                                                 |                                                                                             |
-| 2   | `--help` / `-h`                 | `[EXISTING]` | `rolldown --help`                                                    |                                                                                             |
-| 3   | Help for empty args             | `[EXISTING]` | `rolldown`                                                           |                                                                                             |
-| 4   | Help precedence over other opts | `[MISSING]`  | `rolldown lib -o dist/lib.js --help`                                 | [#8523](https://github.com/rolldown/rolldown/issues/8523)                                   |
-| 5   | Boolean options                 | `[EXISTING]` | `rolldown index.ts --minify -d dist`                                 | Also tests short flag `-m`                                                                  |
-| 6   | String options                  | `[EXISTING]` | `rolldown index.ts --format cjs -d dist`                             |                                                                                             |
-| 7   | Short flags                     | `[EXISTING]` | `rolldown index.ts -d dist -s`                                       | `-d`, `-s`, `-m`, `-c` etc. already covered across tests                                    |
-| 8   | Array (repeated flags)          | `[EXISTING]` | `rolldown index.ts --external node:path --external node:url -d dist` |                                                                                             |
-| 9   | Object (`key=val,key=val`)      | `[EXISTING]` | `rolldown index.ts --module-types .123=text -d dist`                 | `--globals` not separately tested but same code path                                        |
-| 10  | `--no-*` boolean negation       | `[EXISTING]` | `rolldown index.ts --no-external-live-bindings ...`                  | One of three `--no-*` options tested                                                        |
-| 11  | Nested dot-notation             | `[EXISTING]` | `rolldown index.js --transform.define __DEFINE__=defined`            | Tests single and comma-separated values                                                     |
-| 12  | Positionals as input            | `[EXISTING]` | `rolldown 1.ts --input ./2.js`                                       |                                                                                             |
-| 13  | Config loading (`-c`)           | `[EXISTING]` | `rolldown -c rolldown.config.ts`                                     | Tests `.js`, `.cjs`, `.ts`, `.cts`, `.mts`, auto-detect, multiple configs, multiple outputs |
-| 14  | Config function + rawArgs       | `[EXISTING]` | `rolldown -c rolldown.config.js --customArg=customValue`             | Unknown options passed to config function                                                   |
-| 15  | CLI overrides config            | `[EXISTING]` | `rolldown -c rolldown.config.js --format cjs`                        |                                                                                             |
-| 16  | `--environment`                 | `[EXISTING]` | `rolldown -c --environment PRODUCTION,FOO:bar`                       |                                                                                             |
-| 17  | `requireValue` validation       | `[EXISTING]` | `rolldown 1.ts -d` / `rolldown 1.ts -o`                              | `-d`, `--dir`, `-o`, `--file` without value → error                                         |
-| 18  | Invalid option value            | `[EXISTING]` | `rolldown index.ts --format INCORRECT`                               |                                                                                             |
-| 19  | Unknown option warns (no error) | `[EXISTING]` | `rolldown index.ts --someRandomFlag -d dist`                         |                                                                                             |
-| 20  | Watch mode                      | `[EXISTING]` | `rolldown index.ts -d dist -w -s`                                    | Tests `-w`, watch hooks, multiple configs, `ROLLDOWN_WATCH` env                             |
-| 21  | camelCase input ([#8410])       | `[MISSING]`  | `rolldown index.ts --moduleTypes .png=dataurl -d dist`               | The bug that prompted the migration — camelCase options are silently ignored                |
+| #   | Feature                   | Example                                                                         |
+| --- | ------------------------- | ------------------------------------------------------------------------------- |
+| 1   | `--version` / `-v`        | `rolldown --version`                                                            |
+| 2   | `--help` / `-h`           | `rolldown --help`                                                               |
+| 3   | Help for empty args       | `rolldown`                                                                      |
+| 4   | Help precedence ([#8523]) | `rolldown lib -o dist/lib.js --help`                                            |
+| 5   | Boolean options           | `rolldown index.ts --minify -d dist`                                            |
+| 6   | String options            | `rolldown index.ts --format cjs -d dist`                                        |
+| 7   | Short flags               | `rolldown index.ts -d dist -s`                                                  |
+| 8   | Array (repeated flags)    | `rolldown index.ts --external node:path --external node:url -d dist`            |
+| 9   | Object (repeated flags)   | `rolldown index.ts --module-types .123=text --module-types .b64=base64 -d dist` |
+| 9a  | Object (comma-separated)  | `rolldown index.ts --module-types .123=text,notjson=json,.b64=base64 -d dist`   |
+| 10  | `--no-*` boolean negation | `rolldown index.ts --no-external-live-bindings ...`                             |
+| 11  | Nested dot-notation       | `rolldown index.js --transform.define __DEFINE__=defined`                       |
+| 12  | Positionals as input      | `rolldown 1.ts --input ./2.js`                                                  |
+| 13  | Config loading (`-c`)     | `rolldown -c rolldown.config.ts`                                                |
+| 14  | Config function + rawArgs | `rolldown -c rolldown.config.js --customArg=customValue`                        |
+| 15  | CLI overrides config      | `rolldown -c rolldown.config.js --format cjs`                                   |
+| 16  | `--environment`           | `rolldown -c --environment PRODUCTION,FOO:bar`                                  |
+| 17  | `requireValue` validation | `rolldown 1.ts -d` (error: requires value)                                      |
+| 18  | Invalid option value      | `rolldown index.ts --format INCORRECT`                                          |
+| 19  | Unknown option warns      | `rolldown index.ts --someRandomFlag -d dist`                                    |
+| 20  | Watch mode                | `rolldown index.ts -d dist -w -s`                                               |
+| 21  | camelCase input ([#8410]) | `rolldown index.ts --moduleTypes .png=dataurl -d dist`                          |
 
 [#8410]: https://github.com/rolldown/rolldown/issues/8410
-
-### Summary
-
-- **Existing**: 20 features covered
-- **Missing**: 1 feature to add before migration
-  - camelCase input (#21) — the core bug
-
-CLI tests: `cd packages/rolldown/tests && pnpm test:cli`
-
-## Unresolved Questions
-
-- Should we keep `key=val,key=val` object syntax or migrate to cac's dot-notation (`--module-types.png dataurl`)? Keeping current syntax avoids breaking changes but requires ~20 lines of custom parsing.
-- Should unrecognized options remain as warnings, or should we switch to cac's default behavior (error)? Current behavior is warn + include in rawArgs for config function passthrough.
-- Should help text use cac's built-in format or preserve the current custom layout (sorted by short flag, with examples and notes sections)?
-- Is cac's `setDotProp` vulnerable to prototype pollution? If so, keep the existing guard.
+[#3248]: https://github.com/rolldown/rolldown/issues/3248
+[#8523]: https://github.com/rolldown/rolldown/issues/8523
 
 ## Related
 
 - [#8410 — CLI silently mishandles camelCase options](https://github.com/rolldown/rolldown/issues/8410)
-- [#8408 — Closed PR that attempted narrow camelCase fix](https://github.com/rolldown/rolldown/pull/8408)
+- [#3248 — `-s inline` position restriction](https://github.com/rolldown/rolldown/issues/3248)
+- [#8523 — `--help` precedence over other options](https://github.com/rolldown/rolldown/issues/8523)
 - [Vite CLI source](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/cli.ts) — reference for cac usage patterns
+
+---
+
+<details>
+<summary>Migration context (archived)</summary>
+
+## Migration: `parseArgs` → cac
+
+The previous implementation used Node.js's built-in `parseArgs` with 16 hand-rolled workarounds. The root cause of #8410 was that `parseArgs` treats `--moduleTypes` as an unknown boolean (since it only knows `--module-types`), silently dropping the value into positionals.
+
+### What Changed
+
+| File                         | Action       | Details                                         |
+| ---------------------------- | ------------ | ----------------------------------------------- |
+| `cli/arguments/index.ts`     | Rewrite      | Replace parseArgs with cac, add post-processing |
+| `cli/arguments/normalize.ts` | Simplify     | Remove unflattening loop + prototype guard      |
+| `cli/arguments/alias.ts`     | Simplify     | Remove `default` field (dead code)              |
+| `cli/arguments/utils.ts`     | Simplify     | Remove `kebabCaseToCamelCase`                   |
+| `cli/commands/help.ts`       | Minor update | Adjust to new `options` export shape            |
+| `cli/index.ts`               | No change    | Same interface                                  |
+| `cli/commands/bundle.ts`     | No change    | Same interface                                  |
+
+### Behavioral Differences
+
+| Change                      | Before                                             | After                                                |
+| --------------------------- | -------------------------------------------------- | ---------------------------------------------------- |
+| Numeric string coercion     | `--code-splitting.min-size 1000` → string `"1000"` | → number `1000` (mri coerces numeric-looking values) |
+| `--no-*` on unknown options | warns "foo is unrecognized"                        | same warning, value is `false` instead of absent     |
+| `--` delimiter              | args after `--` become positionals                 | collected into `options['--']`, deleted in post-proc |
+| Short flag stacking         | not supported                                      | `-ms` = `--minify --sourcemap`                       |
+
+### Why `default` Was Removed From `alias.ts`
+
+The three `reverse: true` options (`treeshake`, `externalLiveBindings`, `preserveEntrySignatures`) had `default` values that were dead code on main — the token loop only used `default` for `string`/`union` types passed without a value, and these are all `boolean`/`reverse` options. With `ignoreOptionDefaultValue()`, cac never applies defaults either.
+
+</details>

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -128,6 +128,7 @@
     "@oxc-node/cli": "catalog:",
     "@rollup/plugin-json": "catalog:",
     "buble": "catalog:",
+    "cac": "catalog:",
     "consola": "catalog:",
     "execa": "catalog:",
     "glob": "catalog:",

--- a/packages/rolldown/src/cli/arguments/alias.ts
+++ b/packages/rolldown/src/cli/arguments/alias.ts
@@ -9,10 +9,9 @@ export interface CliOptions extends InputCliOptions, OutputCliOptions {
   environment?: string | string[];
 }
 
-export interface OptionConfig {
+interface OptionConfig {
   abbreviation?: string;
   description?: string;
-  default?: string | boolean;
   hint?: string;
   reverse?: boolean;
   /**
@@ -58,7 +57,6 @@ export const alias: Partial<Record<keyof CliOptions, OptionConfig>> = {
   },
   sourcemap: {
     abbreviation: 's',
-    default: true,
   },
   minify: {
     abbreviation: 'm',
@@ -76,15 +74,12 @@ export const alias: Partial<Record<keyof CliOptions, OptionConfig>> = {
     hint: 'name',
   },
   externalLiveBindings: {
-    default: true,
     reverse: true,
   },
   treeshake: {
-    default: true,
     reverse: true,
   },
   preserveEntrySignatures: {
-    default: 'strict',
     reverse: true,
   },
   moduleTypes: {

--- a/packages/rolldown/src/cli/arguments/index.ts
+++ b/packages/rolldown/src/cli/arguments/index.ts
@@ -1,192 +1,222 @@
-import { parseArgs } from 'node:util';
+import cac from 'cac';
 import { getCliSchemaInfo } from '../../utils/validator';
 import { logger } from '../logger';
-import { alias, type OptionConfig } from './alias';
+import { alias, type CliOptions } from './alias';
 import { normalizeCliOptions, type NormalizedCliOptions } from './normalize';
-import { camelCaseToKebabCase, kebabCaseToCamelCase } from './utils';
+import { camelCaseToKebabCase } from './utils';
 
 const schemaInfo = getCliSchemaInfo();
 
+// Build the options export for help message
 export const options: {
   [k: string]: {
     type: 'boolean' | 'string';
-    multiple: boolean;
     short?: string;
-    default?: boolean | string | string[];
     hint?: string;
     description: string;
-    environment?: string | string[];
   };
 } = Object.fromEntries(
   Object.entries(schemaInfo)
     .filter(([_key, info]) => info.type !== 'never')
     .map(([key, info]) => {
-      const config = Object.getOwnPropertyDescriptor(alias, key)?.value as OptionConfig | undefined;
+      const config = alias[key as keyof typeof alias];
 
-      const type = info.type;
-
-      const result = {
-        type: type === 'boolean' ? 'boolean' : 'string',
-        // We only support comma separated mode right now.
-        // multiple: type === 'object' || type === 'array',
-        description: info?.description ?? config?.description ?? '',
-        hint: config?.hint,
-      } as {
-        type: 'boolean' | 'string';
-        multiple: boolean;
-        short?: string;
-        default?: boolean | string | string[];
-        hint?: string;
-        description: string;
-        environment?: string | string[];
-      };
-      if (config && config?.abbreviation) {
-        result.short = config?.abbreviation;
-      }
-      if (config && config.reverse) {
-        if (result.description.startsWith('enable')) {
-          result.description = result.description.replace('enable', 'disable');
-        } else if (!result.description.startsWith('Avoid')) {
-          result.description = `disable ${result.description}`;
+      let description = info?.description ?? config?.description ?? '';
+      if (config?.reverse) {
+        if (description.startsWith('enable')) {
+          description = description.replace('enable', 'disable');
+        } else if (!description.startsWith('Avoid')) {
+          description = `disable ${description}`;
         }
       }
-      key = camelCaseToKebabCase(key);
-      // add 'no-' prefix for need reverse options
-      return [config?.reverse ? `no-${key}` : key, result];
+
+      const result: {
+        type: 'boolean' | 'string';
+        short?: string;
+        hint?: string;
+        description: string;
+      } = {
+        type: info.type === 'boolean' ? 'boolean' : 'string',
+        description,
+      };
+      if (config?.abbreviation) {
+        result.short = config.abbreviation;
+      }
+      if (config?.hint) {
+        result.hint = config.hint;
+      }
+
+      const kebabKey = camelCaseToKebabCase(key);
+      const optionKey = config?.reverse ? `no-${kebabKey}` : kebabKey;
+      return [optionKey, result];
     }),
 );
+
+const knownKeys = new Set(Object.keys(schemaInfo));
+for (const key of Object.keys(schemaInfo)) {
+  const dotIdx = key.indexOf('.');
+  if (dotIdx > 0) {
+    knownKeys.add(key.substring(0, dotIdx));
+  }
+}
+
+const shortAliases = new Set<string>();
+for (const config of Object.values(alias)) {
+  if (config?.abbreviation) {
+    shortAliases.add(config.abbreviation);
+  }
+}
 
 export function parseCliArguments(): NormalizedCliOptions & {
   rawArgs: Record<string, any>;
 } {
-  const { values, tokens, positionals } = parseArgs({
-    options,
-    tokens: true,
-    allowPositionals: true,
-    // We can't use `strict` mode because we should handle the default config file name.
-    strict: false,
-  });
+  const cli = cac('rolldown');
 
-  let invalid_options = tokens
-    .filter((token) => token.kind === 'option')
-    .map((option) => {
-      let negative = false;
-      if (option.name.startsWith('no-')) {
-        // stripe `no-` prefix
-        const name = kebabCaseToCamelCase(option.name.substring(3));
-        if (name in schemaInfo) {
-          // Remove the `no-` in values
-          delete values[option.name];
-          option.name = name;
-          negative = true;
-        }
-      }
-      delete values[option.name]; // Strip the kebab-case options.
-      option.name = kebabCaseToCamelCase(option.name);
-      let originalInfo = schemaInfo[option.name];
-      if (!originalInfo) {
-        // Return the summary of invalid option.
-        return { name: option.name, value: option.value };
-      }
-      let type = originalInfo.type;
-      if (type === 'string' && typeof option.value !== 'string') {
-        let opt = option as { name: string };
-        // Check if this option requires a value
-        let config = Object.getOwnPropertyDescriptor(alias, opt.name)?.value as OptionConfig;
-        if (config?.requireValue) {
-          logger.error(
-            `Option \`--${camelCaseToKebabCase(opt.name)}\` requires a value but none was provided.`,
-          );
-          process.exit(1);
-        }
-        // We should use the default value.
-        Object.defineProperty(values, opt.name, {
-          value: config?.default ?? '',
-          enumerable: true,
-          configurable: true,
-          writable: true,
-        });
-      } else if (type === 'object' && typeof option.value === 'string') {
-        // `key1=value1,key2=value2`
-        const pairs = option.value.split(',').map((x) => x.split('='));
-        if (!values[option.name]) {
-          Object.defineProperty(values, option.name, {
-            value: {},
-            enumerable: true,
-            configurable: true,
-            writable: true,
-          });
-        }
-        for (const [key, value] of pairs) {
-          if (key && value) {
-            Object.defineProperty(values[option.name], key, {
-              value,
-              enumerable: true,
-              configurable: true,
-              writable: true,
-            });
-          }
-        }
-      } else if (type === 'array' && typeof option.value === 'string') {
-        if (!values[option.name]) {
-          Object.defineProperty(values, option.name, {
-            value: [],
-            enumerable: true,
-            configurable: true,
-            writable: true,
-          });
-        }
-        (values[option.name] as string[]).push(option.value);
-      } else if (type === 'boolean') {
-        Object.defineProperty(values, option.name, {
-          value: !negative,
-          enumerable: true,
-          configurable: true,
-          writable: true,
-        });
-      } else if (type === 'union') {
-        // We should use the default value.
-        let defaultValue = Object.getOwnPropertyDescriptor(alias, option.name)
-          ?.value as OptionConfig;
-        Object.defineProperty(values, option.name, {
-          value: option.value ?? defaultValue?.default ?? '',
-          enumerable: true,
-          configurable: true,
-          writable: true,
-        });
+  // Register all options with cac
+  for (const [key, info] of Object.entries(schemaInfo)) {
+    if (info.type === 'never') continue;
+    const config = alias[key as keyof typeof alias];
+
+    let rawName = '';
+    if (config?.abbreviation) rawName += `-${config.abbreviation}, `;
+
+    if (config?.reverse) {
+      rawName += `--no-${key}`;
+    } else {
+      rawName += `--${key}`;
+    }
+
+    if (info.type !== 'boolean' && !config?.reverse) {
+      if (config?.requireValue) {
+        rawName += ` <${config?.hint ?? key}>`;
       } else {
-        Object.defineProperty(values, option.name, {
-          value: option.value ?? '',
-          enumerable: true,
-          configurable: true,
-          writable: true,
-        });
+        rawName += ` [${config?.hint ?? key}]`;
       }
-    })
-    .filter((item) => {
-      return item !== undefined;
-    });
+    }
 
-  invalid_options.sort((a, b) => {
-    return a.name.localeCompare(b.name);
+    cli.option(rawName, info.description ?? config?.description ?? '');
+  }
+
+  let parsedInput: string[] = [];
+  let parsedOptions: Record<string, any> = {};
+
+  const cmd = cli.command('[...input]', '');
+  cmd.allowUnknownOptions();
+
+  // Disable applying default values.
+  //
+  // For options with prefix `--no-*`, cac sets `true` by default.
+  // For example, `--no-preserve-entry-signatures` will set `preserveEntrySignatures` to `true` by default. However, we want it to be `undefined` by default.
+  //
+  // Here we disable cac's default behavior and let the bundler's internal default value handling logic handle it.
+  cmd.ignoreOptionDefaultValue();
+
+  cmd.action((input: string[], opts: Record<string, any>) => {
+    parsedInput = input;
+    parsedOptions = opts;
   });
 
-  if (invalid_options.length !== 0) {
-    let single = invalid_options.length === 1;
+  try {
+    cli.parse(process.argv, { run: true });
+  } catch (err: any) {
+    if (err?.name === 'CACError') {
+      const match = err.message.match(/option `(.+?)` value is missing/);
+      if (match) {
+        const optName = match[1].replace(/ [<[].*/, '').replace(/^-\w, /, '');
+        logger.error(`Option \`${optName}\` requires a value but none was provided.`);
+      } else {
+        logger.error(err.message);
+      }
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  // Post-processing
+
+  // CAC collects arguments behind `--` in a separate `--` key.
+  // This is unknown to the bundler.
+  delete parsedOptions['--'];
+
+  // Remove short-alias keys (cac/mri duplicates them alongside the full name)
+  for (const short of shortAliases) {
+    delete parsedOptions[short];
+  }
+
+  // Prototype pollution guard
+  for (const key of Object.keys(parsedOptions)) {
+    if (
+      key === '__proto__' ||
+      key === 'constructor' ||
+      key === 'prototype' ||
+      key.startsWith('__proto__.') ||
+      key.startsWith('constructor.') ||
+      key.startsWith('prototype.')
+    ) {
+      delete parsedOptions[key];
+    }
+  }
+
+  // Unknown option detection + warning
+  const unknownKeys = Object.keys(parsedOptions).filter((k) => !knownKeys.has(k));
+
+  if (unknownKeys.length > 0) {
+    unknownKeys.sort();
+    const single = unknownKeys.length === 1;
     logger.warn(
-      `Option \`${invalid_options.map((item) => item.name).join(',')}\` ${
-        single ? 'is' : 'are'
-      } unrecognized. We will ignore ${single ? 'this' : 'those'} option${single ? '' : 's'}.`,
+      `Option \`${unknownKeys.join(',')}\` ${single ? 'is' : 'are'} unrecognized. ` +
+        `We will ignore ${single ? 'this' : 'those'} option${single ? '' : 's'}.`,
     );
   }
 
-  let rawArgs = {
-    ...values,
-    ...invalid_options.reduce((acc, cur) => {
-      acc[cur.name] = cur.value;
-      return acc;
-    }, Object.create(null)),
-  };
-  const normalizedOptions = normalizeCliOptions(values, positionals as string[]);
+  // rawArgs assembly — snapshot before removing unknown keys
+  const rawArgs: Record<string, any> = { ...parsedOptions };
+
+  // Remove unknown keys from parsedOptions before type coercion
+  for (const key of unknownKeys) {
+    delete parsedOptions[key];
+  }
+
+  // Type coercion — duplicate filtering + array wrapping
+  for (const [key, value] of Object.entries(parsedOptions)) {
+    const type = schemaInfo[key]?.type;
+    if (Array.isArray(value)) {
+      if (type !== 'array' && type !== 'object') {
+        parsedOptions[key] = value[value.length - 1];
+      }
+    } else if (type === 'array' && typeof value === 'string') {
+      parsedOptions[key] = [value];
+    }
+  }
+
+  // Object option parsing — parse "key=val,key=val" strings
+  for (const [schemaKey, info] of Object.entries(schemaInfo)) {
+    if (info.type !== 'object') continue;
+
+    const parts = schemaKey.split('.');
+    let parent: any = parsedOptions;
+    for (let i = 0; i < parts.length - 1; i++) {
+      parent = parent?.[parts[i]];
+    }
+    const leafKey = parts[parts.length - 1];
+    const value = parent?.[leafKey];
+    if (value === undefined) continue;
+
+    const values = Array.isArray(value) ? value : [value];
+    if (typeof values[0] !== 'string') continue;
+
+    const result: Record<string, string> = {};
+    for (const v of values) {
+      for (const pair of String(v).split(',')) {
+        const [k, ...rest] = pair.split('=');
+        if (k && rest.length > 0) {
+          result[k] = rest.join('=');
+        }
+      }
+    }
+    parent[leafKey] = result;
+  }
+
+  const normalizedOptions = normalizeCliOptions(parsedOptions as CliOptions, parsedInput);
   return { ...normalizedOptions, rawArgs };
 }

--- a/packages/rolldown/src/cli/arguments/normalize.ts
+++ b/packages/rolldown/src/cli/arguments/normalize.ts
@@ -9,6 +9,8 @@ import { logger } from '../logger';
 import type { CliOptions } from './alias';
 import { setNestedProperty } from './utils';
 
+const reservedKeys = new Set(['help', 'version', 'config', 'watch', 'environment']);
+
 export interface NormalizedCliOptions {
   input: InputOptions;
   output: OutputOptions;
@@ -23,21 +25,8 @@ export function normalizeCliOptions(
   cliOptions: CliOptions,
   positionals: string[],
 ): NormalizedCliOptions {
-  const prototypePollutionKeys = ['__proto__', 'constructor', 'prototype'];
-  const unflattenedCliOptions: Record<string, any> = {};
-  for (let [key, value] of Object.entries(cliOptions)) {
-    if (prototypePollutionKeys.includes(key)) {
-      // ignore prototype pollution keys
-    } else if (key.includes('.')) {
-      const [parentKey] = key.split('.');
-      unflattenedCliOptions[parentKey] ??= {};
-      setNestedProperty(unflattenedCliOptions, key, value);
-    } else {
-      unflattenedCliOptions[key] = value;
-    }
-  }
-
-  const [data, errors] = validateCliOptions<CliOptions>(unflattenedCliOptions);
+  // cliOptions is already unflattened (cac's setDotProp) and prototype-safe (post-processing in arguments/index.ts)
+  const [data, errors] = validateCliOptions<CliOptions>(cliOptions);
   if (errors?.length) {
     errors.forEach((error) => {
       logger.error(`${error}. You can use \`rolldown -h\` to see the help.`);
@@ -56,24 +45,25 @@ export function normalizeCliOptions(
 
   if (typeof options.config === 'string') {
     result.config = options.config;
+  } else if (options.config === true) {
+    result.config = '';
   }
 
   if (options.environment !== undefined) {
     result.environment = options.environment;
   }
 
-  const keysOfInput = getInputCliKeys();
-  const keysOfOutput = getOutputCliKeys();
-  const reservedKeys = ['help', 'version', 'config', 'watch', 'environment'];
+  const keysOfInput = new Set(getInputCliKeys());
+  const keysOfOutput = new Set(getOutputCliKeys());
 
   for (let [key, value] of Object.entries(options)) {
     const keys = key.split('.');
     const [primary] = keys;
-    if (keysOfInput.includes(primary)) {
+    if (keysOfInput.has(primary)) {
       setNestedProperty(result.input, key, value);
-    } else if (keysOfOutput.includes(primary)) {
+    } else if (keysOfOutput.has(primary)) {
       setNestedProperty(result.output, key, value);
-    } else if (!reservedKeys.includes(key)) {
+    } else if (!reservedKeys.has(key)) {
       logger.error(`Unknown option: ${key}`);
       process.exit(1);
     }

--- a/packages/rolldown/src/cli/arguments/utils.ts
+++ b/packages/rolldown/src/cli/arguments/utils.ts
@@ -21,7 +21,3 @@ export function setNestedProperty<T extends object, K>(obj: T, path: string, val
 export function camelCaseToKebabCase(str: string): string {
   return str.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
 }
-
-export function kebabCaseToCamelCase(str: string): string {
-  return str.replace(/-./g, (match) => match[1].toUpperCase());
-}

--- a/packages/rolldown/src/cli/commands/help.ts
+++ b/packages/rolldown/src/cli/commands/help.ts
@@ -28,8 +28,6 @@ const examples = [
 ];
 
 const notes = [
-  'Due to the API limitation, you need to pass `-s` for `.map` sourcemap file as the last argument.',
-  'If you are using the configuration, please pass the `-c` as the last argument if you ignore the default configuration file.',
   'CLI options will override the configuration file.',
   'For more information, please visit https://rolldown.rs/.',
 ];

--- a/packages/rolldown/src/cli/index.ts
+++ b/packages/rolldown/src/cli/index.ts
@@ -30,6 +30,16 @@ async function main() {
     }
   }
 
+  if (cliOptions.help) {
+    showHelp();
+    return;
+  }
+
+  if (cliOptions.version) {
+    logger.log(`rolldown v${version}`);
+    return;
+  }
+
   if (cliOptions.config || cliOptions.config === '') {
     await bundleWithConfig(cliOptions.config, cliOptions, rawArgs);
     return;
@@ -38,11 +48,6 @@ async function main() {
   if ('input' in cliOptions.input) {
     // If input is specified, we will bundle with the input options
     await bundleWithCliOptions(cliOptions);
-    return;
-  }
-
-  if (cliOptions.version) {
-    logger.log(`rolldown v${version}`);
     return;
   }
 

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -834,12 +834,7 @@ const OutputOptionsSchema = v.strictObject({
   ),
   sourcemap: v.pipe(
     v.optional(v.union([v.boolean(), v.literal('inline'), v.literal('hidden')])),
-    v.description(
-      `Generate sourcemap (\`-s inline\` for inline, or ${styleText(
-        'bold',
-        'pass the `-s` on the last argument if you want to generate `.map` file',
-      )})`,
-    ),
+    v.description(`Generate sourcemap (\`-s inline\` for inline, or \`-s\` for \`.map\` file)`),
   ),
   sourcemapBaseUrl: v.pipe(
     v.optional(v.string()),

--- a/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
+++ b/packages/rolldown/tests/cli/__snapshots__/cli-e2e.test.ts.snap
@@ -17,7 +17,7 @@ OPTIONS
   --name -n, <name>           Name for UMD / IIFE format outputs.
   --file -o, <file>           Single output file.
   --platform -p, <platform>   Platform for which the code should be generated (node, browser, neutral).
-  --sourcemap -s, <sourcemap> Generate sourcemap (\`-s inline\` for inline, or pass the \`-s\` on the last argument if you want to generate \`.map\` file).
+  --sourcemap -s, <sourcemap> Generate sourcemap (\`-s inline\` for inline, or \`-s\` for \`.map\` file).
   --version -v,               Show version number.
   --watch -w,                 Watch files in bundle and rebuild on changes.
   --advanced-chunks.min-share-count <advanced-chunks.min-share-count>Minimum share count of the chunk.
@@ -136,8 +136,6 @@ EXAMPLES
 
 NOTES
 
-  * Due to the API limitation, you need to pass \`-s\` for \`.map\` sourcemap file as the last argument.
-  * If you are using the configuration, please pass the \`-c\` as the last argument if you ignore the default configuration file.
   * CLI options will override the configuration file.
   * For more information, please visit https://rolldown.rs/."
 `;
@@ -159,7 +157,7 @@ OPTIONS
   --name -n, <name>           Name for UMD / IIFE format outputs.
   --file -o, <file>           Single output file.
   --platform -p, <platform>   Platform for which the code should be generated (node, browser, neutral).
-  --sourcemap -s, <sourcemap> Generate sourcemap (\`-s inline\` for inline, or pass the \`-s\` on the last argument if you want to generate \`.map\` file).
+  --sourcemap -s, <sourcemap> Generate sourcemap (\`-s inline\` for inline, or \`-s\` for \`.map\` file).
   --version -v,               Show version number.
   --watch -w,                 Watch files in bundle and rebuild on changes.
   --advanced-chunks.min-share-count <advanced-chunks.min-share-count>Minimum share count of the chunk.
@@ -278,8 +276,6 @@ EXAMPLES
 
 NOTES
 
-  * Due to the API limitation, you need to pass \`-s\` for \`.map\` sourcemap file as the last argument.
-  * If you are using the configuration, please pass the \`-c\` as the last argument if you ignore the default configuration file.
   * CLI options will override the configuration file.
   * For more information, please visit https://rolldown.rs/."
 `;
@@ -301,7 +297,7 @@ OPTIONS
   --name -n, <name>           Name for UMD / IIFE format outputs.
   --file -o, <file>           Single output file.
   --platform -p, <platform>   Platform for which the code should be generated (node, browser, neutral).
-  --sourcemap -s, <sourcemap> Generate sourcemap (\`-s inline\` for inline, or pass the \`-s\` on the last argument if you want to generate \`.map\` file).
+  --sourcemap -s, <sourcemap> Generate sourcemap (\`-s inline\` for inline, or \`-s\` for \`.map\` file).
   --version -v,               Show version number.
   --watch -w,                 Watch files in bundle and rebuild on changes.
   --advanced-chunks.min-share-count <advanced-chunks.min-share-count>Minimum share count of the chunk.
@@ -420,7 +416,286 @@ EXAMPLES
 
 NOTES
 
-  * Due to the API limitation, you need to pass \`-s\` for \`.map\` sourcemap file as the last argument.
+  * CLI options will override the configuration file.
+  * For more information, please visit https://rolldown.rs/."
+`;
+
+exports[`basic arguments > should show help when --help is used with other arguments (#8523) 1`] = `
+"Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API. (rolldown VERSION)
+
+USAGE rolldown -c <config> or rolldown <input> <options>
+
+OPTIONS
+
+  --config -c, <filename>     Path to the config file (default: \`rolldown.config.js\`).
+  --dir -d, <dir>             Output directory, defaults to \`dist\` if \`file\` is not set.
+  --external -e, <external>   Comma-separated list of module ids to exclude from the bundle \`<module-id>,...\`.
+  --format -f, <format>       Output format of the generated bundle (supports esm, cjs, and iife).
+  --globals -g, <globals>     Global variable of UMD / IIFE dependencies (syntax: \`key=value\`).
+  --help -h,                  Show help.
+  --minify -m,                Minify the bundled file.
+  --name -n, <name>           Name for UMD / IIFE format outputs.
+  --file -o, <file>           Single output file.
+  --platform -p, <platform>   Platform for which the code should be generated (node, browser, neutral).
+  --sourcemap -s, <sourcemap> Generate sourcemap (\`-s inline\` for inline, or \`-s\` for \`.map\` file).
+  --version -v,               Show version number.
+  --watch -w,                 Watch files in bundle and rebuild on changes.
+  --advanced-chunks.min-share-count <advanced-chunks.min-share-count>Minimum share count of the chunk.
+  --advanced-chunks.min-size <advanced-chunks.min-size>Minimum size of the chunk.
+  --asset-file-names <name>   Name pattern for asset files.
+  --banner <banner>           Code to insert the top of the bundled file (outside the wrapper function).
+  --checks.cannot-call-namespace Whether to emit warnings when a namespace is called as a function.
+  --checks.circular-dependency Whether to emit warnings when detecting circular dependency.
+  --checks.common-js-variable-in-esm Whether to emit warnings when a CommonJS variable is used in an ES module.
+  --checks.configuration-field-conflict Whether to emit warnings when a config value is overridden by another config value with a higher priority.
+  --checks.could-not-clean-directory Whether to emit warnings when Rolldown could not clean the output directory.
+  --checks.duplicate-shebang  Whether to emit warnings when both the code and postBanner contain shebang.
+  --checks.empty-import-meta  Whether to emit warnings when \`import.meta\` is not supported with the output format and is replaced with an empty object (\`{}\`).
+  --checks.eval               Whether to emit warnings when detecting uses of direct \`eval\`s.
+  --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
+  --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
+  --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
+  --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
+  --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
+  --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
+  --checks.plugin-timings     Whether to emit warnings when plugins take significant time during the build process.
+  --checks.prefer-builtin-feature Whether to emit warnings when a plugin that is covered by a built-in feature is used.
+  --checks.tolerated-transform Whether to emit warnings when detecting tolerated transform.
+  --checks.unresolved-entry   Whether to emit warnings when an entrypoint cannot be resolved.
+  --checks.unresolved-import  Whether to emit warnings when an import cannot be resolved.
+  --checks.unsupported-tsconfig-option Whether to emit warnings when a tsconfig option or combination of options is not supported.
+  --chunk-file-names <name>   Name pattern for emitted secondary chunks.
+  --clean-dir                 Clean output directory before emitting output.
+  --code-splitting <code-splitting>Code splitting options (true, false, or object).
+  --comments <comments>       Control comments in the output.
+  --context <context>         The entity top-level \`this\` represents.
+  --cwd <cwd>                 Current working directory.
+  --devtools.session-id <devtools.session-id>Used to name the build.
+  --dynamic-import-in-cjs     Dynamic import in CJS output.
+  --entry-file-names <name>   Name pattern for emitted entry chunks.
+  --environment <environment> Pass additional settings to the config file via process.ENV.
+  --es-module                 Always generate \`__esModule\` marks in non-ESM formats, defaults to \`if-default-prop\` (use \`--no-esModule\` to always disable).
+  --exports <exports>         Specify a export mode (auto, named, default, none).
+  --extend                    Extend global variable defined by name in IIFE / UMD formats.
+  --footer <footer>           Code to insert the bottom of the bundled file (outside the wrapper function).
+  --generated-code.preset <generated-code.preset>.
+  --generated-code.profiler-names Whether to add readable names to internal variables for profiling purposes.
+  --generated-code.symbols    Whether to use Symbol.toStringTag for namespace objects.
+  --hash-characters <hash-characters>Use the specified character set for file hashes.
+  --inline-dynamic-imports    Inline dynamic imports.
+  --input <input>             Entry file.
+  --intro <intro>             Code to insert the top of the bundled file (inside the wrapper function).
+  --keep-names                Keep function and class names after bundling.
+  --legal-comments <legal-comments>Control legal comments in the output.
+  --log-level <log-level>     Log level (silent, info, debug, warn).
+  --make-absolute-externals-relative Prevent normalization of external imports.
+  --minify-internal-exports   Minify internal exports.
+  --module-types <types>      Module types for customized extensions.
+  --no-external-live-bindings Disable external live bindings.
+  --no-preserve-entry-signatures Avoid facade chunks for entry points.
+  --no-treeshake              Disable treeshaking.
+  --optimization.inline-const <optimization.inline-const>Enable crossmodule constant inlining.
+  --optimization.pife-for-module-wrappers Use PIFE pattern for module wrappers.
+  --outro <outro>             Code to insert the bottom of the bundled file (inside the wrapper function).
+  --paths <paths>             Maps external module IDs to paths.
+  --polyfill-require          Disable require polyfill injection.
+  --post-banner <post-banner> A string to prepend to the top of each chunk. Applied after the \`renderChunk\` hook and minification.
+  --post-footer <post-footer> A string to append to the bottom of each chunk. Applied after the \`renderChunk\` hook and minification.
+  --preserve-modules          Preserve module structure.
+  --preserve-modules-root <preserve-modules-root>Put preserved modules under this path at root level.
+  --sanitize-file-name        Sanitize file name.
+  --shim-missing-exports      Create shim variables for missing exports.
+  --sourcemap-base-url <sourcemap-base-url>Base URL used to prefix sourcemap paths.
+  --sourcemap-debug-ids       Inject sourcemap debug IDs.
+  --strict <strict>           Whether to always output \`"use strict"\` directive in non-ES module outputs.
+  --strict-execution-order    Lets modules be executed in the order they are declared.
+  --top-level-var             Rewrite top-level declarations to use \`var\`.
+  --transform.assumptions.ignore-function-length .
+  --transform.assumptions.no-document-all .
+  --transform.assumptions.object-rest-no-symbols .
+  --transform.assumptions.pure-getters .
+  --transform.assumptions.set-public-class-fields .
+  --transform.decorator.emit-decorator-metadata .
+  --transform.decorator.legacy .
+  --transform.define <transform.define>Define global variables (syntax: key=value,key2=value2).
+  --transform.drop-labels <transform.drop-labels>Remove labeled statements with these label names.
+  --transform.helpers.mode <transform.helpers.mode>.
+  --transform.inject <transform.inject>Inject import statements on demand.
+  --transform.jsx <transform.jsx>.
+  --transform.plugins.styled-components <transform.plugins.styled-components>.
+  --transform.plugins.tagged-template-escape .
+  --transform.target <transform.target>The JavaScript target environment.
+  --transform.typescript.allow-declare-fields .
+  --transform.typescript.allow-namespaces .
+  --transform.typescript.declaration.sourcemap .
+  --transform.typescript.declaration.strip-internal .
+  --transform.typescript.jsx-pragma <transform.typescript.jsx-pragma>.
+  --transform.typescript.jsx-pragma-frag <transform.typescript.jsx-pragma-frag>.
+  --transform.typescript.only-remove-type-imports .
+  --transform.typescript.remove-class-fields-without-initializer .
+  --transform.typescript.rewrite-import-extensions <transform.typescript.rewrite-import-extensions>.
+  --tsconfig <tsconfig>       Path to the tsconfig.json file.
+  --virtual-dirname <virtual-dirname>.
+
+EXAMPLES
+
+  1. Bundle with a config file \`rolldown.config.mjs\`:
+    rolldown -c rolldown.config.mjs
+
+  2. Bundle the \`src/main.ts\` to \`dist\` with \`cjs\` format:
+    rolldown src/main.ts -d dist -f cjs
+
+  3. Bundle the \`src/main.ts\` and handle the \`.png\` assets to Data URL:
+    rolldown src/main.ts -d dist --moduleTypes .png=dataurl
+
+  4. Bundle the \`src/main.tsx\` and minify the output with sourcemap:
+    rolldown src/main.tsx -d dist -m -s
+
+  5. Create self-executing IIFE using external jQuery as \`$\` and \`_\`:
+    rolldown src/main.ts -d dist -n bundle -f iife -e jQuery,window._ -g jQuery=$
+
+NOTES
+
+  * CLI options will override the configuration file.
+  * For more information, please visit https://rolldown.rs/."
+`;
+
+exports[`basic arguments > should show help when --help is used with other arguments 1`] = `
+"Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API. (rolldown VERSION)
+
+USAGE rolldown -c <config> or rolldown <input> <options>
+
+OPTIONS
+
+  --config -c, <filename>     Path to the config file (default: \`rolldown.config.js\`).
+  --dir -d, <dir>             Output directory, defaults to \`dist\` if \`file\` is not set.
+  --external -e, <external>   Comma-separated list of module ids to exclude from the bundle \`<module-id>,...\`.
+  --format -f, <format>       Output format of the generated bundle (supports esm, cjs, and iife).
+  --globals -g, <globals>     Global variable of UMD / IIFE dependencies (syntax: \`key=value\`).
+  --help -h,                  Show help.
+  --minify -m,                Minify the bundled file.
+  --name -n, <name>           Name for UMD / IIFE format outputs.
+  --file -o, <file>           Single output file.
+  --platform -p, <platform>   Platform for which the code should be generated (node, browser, neutral).
+  --sourcemap -s, <sourcemap> Generate sourcemap (\`-s inline\` for inline, or \`-s\` for \`.map\` file).
+  --version -v,               Show version number.
+  --watch -w,                 Watch files in bundle and rebuild on changes.
+  --advanced-chunks.min-share-count <advanced-chunks.min-share-count>Minimum share count of the chunk.
+  --advanced-chunks.min-size <advanced-chunks.min-size>Minimum size of the chunk.
+  --asset-file-names <name>   Name pattern for asset files.
+  --banner <banner>           Code to insert the top of the bundled file (outside the wrapper function).
+  --checks.cannot-call-namespace Whether to emit warnings when a namespace is called as a function.
+  --checks.circular-dependency Whether to emit warnings when detecting circular dependency.
+  --checks.common-js-variable-in-esm Whether to emit warnings when a CommonJS variable is used in an ES module.
+  --checks.configuration-field-conflict Whether to emit warnings when a config value is overridden by another config value with a higher priority.
+  --checks.could-not-clean-directory Whether to emit warnings when Rolldown could not clean the output directory.
+  --checks.duplicate-shebang  Whether to emit warnings when both the code and postBanner contain shebang.
+  --checks.empty-import-meta  Whether to emit warnings when \`import.meta\` is not supported with the output format and is replaced with an empty object (\`{}\`).
+  --checks.eval               Whether to emit warnings when detecting uses of direct \`eval\`s.
+  --checks.filename-conflict  Whether to emit warnings when files generated have the same name with different contents.
+  --checks.import-is-undefined Whether to emit warnings when an imported variable is not exported.
+  --checks.ineffective-dynamic-import Whether to emit warnings when a module is dynamically imported but also statically imported, making the dynamic import ineffective for code splitting.
+  --checks.missing-global-name Whether to emit warnings when the \`output.globals\` option is missing when needed.
+  --checks.missing-name-option-for-iife-export Whether to emit warnings when the \`output.name\` option is missing when needed.
+  --checks.mixed-exports      Whether to emit warnings when the way to export values is ambiguous.
+  --checks.plugin-timings     Whether to emit warnings when plugins take significant time during the build process.
+  --checks.prefer-builtin-feature Whether to emit warnings when a plugin that is covered by a built-in feature is used.
+  --checks.tolerated-transform Whether to emit warnings when detecting tolerated transform.
+  --checks.unresolved-entry   Whether to emit warnings when an entrypoint cannot be resolved.
+  --checks.unresolved-import  Whether to emit warnings when an import cannot be resolved.
+  --checks.unsupported-tsconfig-option Whether to emit warnings when a tsconfig option or combination of options is not supported.
+  --chunk-file-names <name>   Name pattern for emitted secondary chunks.
+  --clean-dir                 Clean output directory before emitting output.
+  --code-splitting <code-splitting>Code splitting options (true, false, or object).
+  --comments <comments>       Control comments in the output.
+  --context <context>         The entity top-level \`this\` represents.
+  --cwd <cwd>                 Current working directory.
+  --devtools.session-id <devtools.session-id>Used to name the build.
+  --dynamic-import-in-cjs     Dynamic import in CJS output.
+  --entry-file-names <name>   Name pattern for emitted entry chunks.
+  --environment <environment> Pass additional settings to the config file via process.ENV.
+  --es-module                 Always generate \`__esModule\` marks in non-ESM formats, defaults to \`if-default-prop\` (use \`--no-esModule\` to always disable).
+  --exports <exports>         Specify a export mode (auto, named, default, none).
+  --extend                    Extend global variable defined by name in IIFE / UMD formats.
+  --footer <footer>           Code to insert the bottom of the bundled file (outside the wrapper function).
+  --generated-code.preset <generated-code.preset>.
+  --generated-code.profiler-names Whether to add readable names to internal variables for profiling purposes.
+  --generated-code.symbols    Whether to use Symbol.toStringTag for namespace objects.
+  --hash-characters <hash-characters>Use the specified character set for file hashes.
+  --inline-dynamic-imports    Inline dynamic imports.
+  --input <input>             Entry file.
+  --intro <intro>             Code to insert the top of the bundled file (inside the wrapper function).
+  --keep-names                Keep function and class names after bundling.
+  --legal-comments <legal-comments>Control legal comments in the output.
+  --log-level <log-level>     Log level (silent, info, debug, warn).
+  --make-absolute-externals-relative Prevent normalization of external imports.
+  --minify-internal-exports   Minify internal exports.
+  --module-types <types>      Module types for customized extensions.
+  --no-external-live-bindings Disable external live bindings.
+  --no-preserve-entry-signatures Avoid facade chunks for entry points.
+  --no-treeshake              Disable treeshaking.
+  --optimization.inline-const <optimization.inline-const>Enable crossmodule constant inlining.
+  --optimization.pife-for-module-wrappers Use PIFE pattern for module wrappers.
+  --outro <outro>             Code to insert the bottom of the bundled file (inside the wrapper function).
+  --paths <paths>             Maps external module IDs to paths.
+  --polyfill-require          Disable require polyfill injection.
+  --post-banner <post-banner> A string to prepend to the top of each chunk. Applied after the \`renderChunk\` hook and minification.
+  --post-footer <post-footer> A string to append to the bottom of each chunk. Applied after the \`renderChunk\` hook and minification.
+  --preserve-modules          Preserve module structure.
+  --preserve-modules-root <preserve-modules-root>Put preserved modules under this path at root level.
+  --sanitize-file-name        Sanitize file name.
+  --shim-missing-exports      Create shim variables for missing exports.
+  --sourcemap-base-url <sourcemap-base-url>Base URL used to prefix sourcemap paths.
+  --sourcemap-debug-ids       Inject sourcemap debug IDs.
+  --strict <strict>           Whether to always output \`"use strict"\` directive in non-ES module outputs.
+  --strict-execution-order    Lets modules be executed in the order they are declared.
+  --top-level-var             Rewrite top-level declarations to use \`var\`.
+  --transform.assumptions.ignore-function-length .
+  --transform.assumptions.no-document-all .
+  --transform.assumptions.object-rest-no-symbols .
+  --transform.assumptions.pure-getters .
+  --transform.assumptions.set-public-class-fields .
+  --transform.decorator.emit-decorator-metadata .
+  --transform.decorator.legacy .
+  --transform.define <transform.define>Define global variables (syntax: key=value,key2=value2).
+  --transform.drop-labels <transform.drop-labels>Remove labeled statements with these label names.
+  --transform.helpers.mode <transform.helpers.mode>.
+  --transform.inject <transform.inject>Inject import statements on demand.
+  --transform.jsx <transform.jsx>.
+  --transform.plugins.styled-components <transform.plugins.styled-components>.
+  --transform.plugins.tagged-template-escape .
+  --transform.target <transform.target>The JavaScript target environment.
+  --transform.typescript.allow-declare-fields .
+  --transform.typescript.allow-namespaces .
+  --transform.typescript.declaration.sourcemap .
+  --transform.typescript.declaration.strip-internal .
+  --transform.typescript.jsx-pragma <transform.typescript.jsx-pragma>.
+  --transform.typescript.jsx-pragma-frag <transform.typescript.jsx-pragma-frag>.
+  --transform.typescript.only-remove-type-imports .
+  --transform.typescript.remove-class-fields-without-initializer .
+  --transform.typescript.rewrite-import-extensions <transform.typescript.rewrite-import-extensions>.
+  --tsconfig <tsconfig>       Path to the tsconfig.json file.
+  --virtual-dirname <virtual-dirname>.
+
+EXAMPLES
+
+  1. Bundle with a config file \`rolldown.config.mjs\`:
+    rolldown -c rolldown.config.mjs
+
+  2. Bundle the \`src/main.ts\` to \`dist\` with \`cjs\` format:
+    rolldown src/main.ts -d dist -f cjs
+
+  3. Bundle the \`src/main.ts\` and handle the \`.png\` assets to Data URL:
+    rolldown src/main.ts -d dist --moduleTypes .png=dataurl
+
+  4. Bundle the \`src/main.tsx\` and minify the output with sourcemap:
+    rolldown src/main.tsx -d dist -m -s
+
+  5. Create self-executing IIFE using external jQuery as \`$\` and \`_\`:
+    rolldown src/main.ts -d dist -n bundle -f iife -e jQuery,window._ -g jQuery=$
+
+NOTES
+
   * If you are using the configuration, please pass the \`-c\` as the last argument if you ignore the default configuration file.
   * CLI options will override the configuration file.
   * For more information, please visit https://rolldown.rs/."
@@ -460,7 +735,31 @@ console.log("2");
 "
 `;
 
+exports[`cli options for bundling > should handle camelCase options (e.g. --moduleTypes) (#8410) 1`] = `
+"<DIR>/index.js  chunk │ size: 0.09 kB
+
+"
+`;
+
+exports[`cli options for bundling > should handle camelCase options (e.g. --moduleTypes) 1`] = `
+"<DIR>/index.js  chunk │ size: 0.09 kB
+
+"
+`;
+
+exports[`cli options for bundling > should handle camelCase options mixed with kebab-case (e.g. --moduleTypes) (#8410) 1`] = `
+"<DIR>/index.js  chunk │ size: 0.09 kB
+
+"
+`;
+
 exports[`cli options for bundling > should handle comma-separated object options 1`] = `
+"<DIR>/index.js  chunk │ size: 0.09 kB
+
+"
+`;
+
+exports[`cli options for bundling > should handle comma-separated object options mixed with single object 1`] = `
 "<DIR>/index.js  chunk │ size: 0.09 kB
 
 "

--- a/packages/rolldown/tests/cli/cli-e2e.test.ts
+++ b/packages/rolldown/tests/cli/cli-e2e.test.ts
@@ -70,7 +70,13 @@ describe('basic arguments', () => {
     expect(cleanStdout(ret.stdout)).toMatchSnapshot();
   });
 
-  // TODO: help message takes precedence over other arguments (#8523)
+  test('should show help when --help is used with other arguments (#8523)', async () => {
+    const cwd = cliFixturesDir('cli-option-string');
+    const ret = await execa({ cwd })`rolldown index.ts -o dist/lib.js --help`;
+
+    expect(ret.exitCode).toBe(0);
+    expect(cleanStdout(ret.stdout)).toMatchSnapshot();
+  });
 });
 
 describe('cli options for bundling', () => {
@@ -131,6 +137,15 @@ describe('cli options for bundling', () => {
     expect(cleanStdout(status.stdout)).toMatchSnapshot();
   });
 
+  it('should handle comma-separated object options mixed with single object', async () => {
+    const cwd = cliFixturesDir('cli-option-object');
+    const status = await $({
+      cwd,
+    })`rolldown index.ts --module-types .123=text,notjson=json --module-types .b64=base64 -d dist`;
+    expect(status.exitCode).toBe(0);
+    expect(cleanStdout(status.stdout)).toMatchSnapshot();
+  });
+
   it('should handle negative boolean options', async () => {
     const cwd = cliFixturesDir('cli-option-no-external-live-bindings');
     const status = await $({
@@ -140,11 +155,11 @@ describe('cli options for bundling', () => {
     expect(cleanStdout(status.stdout)).toMatchSnapshot();
   });
 
-  it('should handle pass `-s` options', async () => {
+  it('should handle pass `-s` options in any position', async () => {
     const cwd = cliFixturesDir('cli-option-sourcemap');
-    const status = await $({ cwd })`rolldown index.ts -d dist -s`;
+    const status = await $({ cwd })`rolldown index.ts -s -d dist`;
     expect(status.exitCode).toBe(0);
-    expect(cleanStdout(status.stdout)).toMatchSnapshot();
+    expect(fs.existsSync(path.join(cwd, 'dist/index.js.map'))).toBe(true);
   });
 
   it('should handle nested options', async () => {
@@ -244,6 +259,15 @@ describe('cli options for bundling', () => {
     const status = await $({ cwd })`rolldown index.ts --someRandomFlag -d dist`;
     expect(status.exitCode).toBe(0);
     expect(status.stdout).toContain('unrecognized');
+  });
+
+  it('should handle camelCase options (e.g. --moduleTypes) (#8410)', async () => {
+    const cwd = cliFixturesDir('cli-option-object');
+    const status = await $({
+      cwd,
+    })`rolldown index.ts --moduleTypes .123=text,notjson=json,.b64=base64 -d dist`;
+    expect(status.exitCode).toBe(0);
+    expect(cleanStdout(status.stdout)).toMatchSnapshot();
   });
 });
 
@@ -413,6 +437,20 @@ describe('config', () => {
     // Config has format: 'esm', CLI overrides with --format cjs
     expect(content).toContain('exports.foo');
     expect(content).not.toContain('export {');
+  });
+
+  it('should handle `-c -w` without `-w` being consumed as config filename (#3248)', async () => {
+    const cwd = cliFixturesDir('cli-config-with-watch');
+    const controller = new AbortController();
+    execa({
+      cwd,
+      reject: false,
+      cancelSignal: controller.signal,
+    })`rolldown -c -w`;
+    await vi.waitFor(() => {
+      expect(fs.existsSync(path.join(cwd, 'dist/index.js'))).toBe(true);
+    });
+    controller.abort();
   });
 });
 

--- a/packages/rolldown/tests/cli/fixtures/cli-config-with-watch/index.ts
+++ b/packages/rolldown/tests/cli/fixtures/cli-config-with-watch/index.ts
@@ -1,0 +1,3 @@
+export default function () {
+  console.log('Hello world!');
+}

--- a/packages/rolldown/tests/cli/fixtures/cli-config-with-watch/rolldown.config.mjs
+++ b/packages/rolldown/tests/cli/fixtures/cli-config-with-watch/rolldown.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  input: 'index.ts',
+  output: {
+    dir: 'dist',
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ catalogs:
     buble:
       specifier: ^0.20.0
       version: 0.20.0
+    cac:
+      specifier: ^6.7.14
+      version: 6.7.14
     chalk:
       specifier: ^5.3.0
       version: 5.6.2
@@ -573,6 +576,9 @@ importers:
       buble:
         specifier: 'catalog:'
         version: 0.20.0
+      cac:
+        specifier: 'catalog:'
+        version: 6.7.14
       consola:
         specifier: 'catalog:'
         version: 3.4.2
@@ -4316,6 +4322,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   camelcase-keys@6.2.2:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
@@ -9746,6 +9756,8 @@ snapshots:
       regexpu-core: 4.5.4
 
   buffer-from@1.1.2: {}
+
+  cac@6.7.14: {}
 
   camelcase-keys@6.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,6 +42,7 @@ catalog:
   acorn-import-assertions: ^1.9.0
   astring: ^1.9.0
   buble: ^0.20.0
+  cac: ^6.7.14
   chalk: ^5.3.0
   change-case: ^5.4.4
   connect: ^3.7.0


### PR DESCRIPTION
## Summary

Replace Node.js's built-in `parseArgs` with [cac](https://github.com/cacjs/cac) for CLI argument parsing.

**Fixes:** #8410 (camelCase options like `--moduleTypes` silently ignored), #3248 (`-s inline` position restriction), #8523 (`--help` precedence over other options)

## Changes

- Rewrite `cli/arguments/index.ts` — replace `parseArgs` + 16 hand-rolled workarounds with cac setup and a focused post-processing pipeline
- Simplify `cli/arguments/alias.ts` — remove dead `default` field
- Simplify `cli/arguments/utils.ts` — remove `kebabCaseToCamelCase` (cac handles this)
- Add CLI e2e tests for `--help` precedence (#8523), camelCase options (#8410), config override, `-c -w` interaction, and more
- Add `meta/design/cli.md` documenting the CLI architecture

## What cac gives us

- camelCase/kebab-case interchangeable matching (`--moduleTypes` and `--module-types` both work)
- `--no-*` negation, `<required>`/`[optional]` value validation, dot-notation nesting, short flag stacking
- ~130 lines removed, 10 of 16 workarounds eliminated

## Related issues

fixes #8410
fixes #3248
fixes #8523
fixes [#8524](https://github.com/rolldown/rolldown/issues/8524)