### PR TITLE
ci: dedupe type-check from dev server workflow

### DIFF
--- a/.github/workflows/reusable-node-dev-server-test.yml
+++ b/.github/workflows/reusable-node-dev-server-test.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Build `@rolldown/test-dev-server`
         run: pnpm --filter '@rolldown/test-dev-server' build
 
-      - name: Type Check
-        run: pnpm type-check
-
       - name: Install Playwright
         run: pnpm playwright install chromium
 


### PR DESCRIPTION
This PR removes a redundant `pnpm type-check` step from `reusable-node-dev-server-test.yml`.

Type checking is already covered in required `node-test-*` jobs across all three OS via `reusable-node-test.yml` (`Type Check` + `Node Type Test`), so coverage is unchanged.

Because `node-dev-server-test-*` is the slowest required CI lane, removing duplicate work helps reduce merge latency with minimal risk.
