### PR TITLE
fix(watch): filter out Access events to prevent infinite rebuild loop on Linux

### DIFF
--- a/crates/rolldown_watcher/src/task_fs_event_handler.rs
+++ b/crates/rolldown_watcher/src/task_fs_event_handler.rs
@@ -14,13 +14,17 @@ pub struct TaskFsEventHandler {
 
 impl TaskFsEventHandler {
   /// Map a notify `EventKind` to a `WatcherChangeKind`.
-  /// Falls back to `Update` for unrecognized events — a spurious rebuild
-  /// is better than a missed one.
-  fn map_event_kind(kind: &notify::EventKind) -> WatcherChangeKind {
+  ///
+  /// Returns `None` for event kinds that should not trigger a rebuild.
+  /// In particular, `Access` events (file open/read/close) are ignored because
+  /// the build process itself reads watched source files, which would otherwise
+  /// cause an infinite rebuild loop on Linux where inotify emits `IN_OPEN` events.
+  fn map_event_kind(kind: &notify::EventKind) -> Option<WatcherChangeKind> {
     match kind {
-      notify::EventKind::Create(_) => WatcherChangeKind::Create,
-      notify::EventKind::Remove(_) => WatcherChangeKind::Delete,
-      _ => WatcherChangeKind::Update,
+      notify::EventKind::Create(_) => Some(WatcherChangeKind::Create),
+      notify::EventKind::Remove(_) => Some(WatcherChangeKind::Delete),
+      notify::EventKind::Modify(_) => Some(WatcherChangeKind::Update),
+      _ => None,
     }
   }
 }
@@ -31,14 +35,17 @@ impl FsEventHandler for TaskFsEventHandler {
       Ok(fs_events) => {
         let changes: Vec<FileChangeEvent> = fs_events
           .into_iter()
-          .flat_map(|fs_event| {
-            let kind = Self::map_event_kind(&fs_event.detail.kind);
-            fs_event
-              .detail
-              .paths
-              .into_iter()
-              .map(move |path| FileChangeEvent::new(path.to_string_lossy().into_owned(), kind))
+          .filter_map(|fs_event| {
+            let kind = Self::map_event_kind(&fs_event.detail.kind)?;
+            Some(
+              fs_event
+                .detail
+                .paths
+                .into_iter()
+                .map(move |path| FileChangeEvent::new(path.to_string_lossy().into_owned(), kind)),
+            )
           })
+          .flatten()
           .collect();
 
         if !changes.is_empty() {

--- a/crates/rolldown_watcher/src/task_fs_event_handler.rs
+++ b/crates/rolldown_watcher/src/task_fs_event_handler.rs
@@ -19,10 +19,15 @@ impl TaskFsEventHandler {
   /// In particular, `Access` events (file open/read/close) are ignored because
   /// the build process itself reads watched source files, which would otherwise
   /// cause an infinite rebuild loop on Linux where inotify emits `IN_OPEN` events.
+  ///
+  /// Aligned with `BundleCoordinator::handle_watch_event` in `rolldown_dev`.
   fn map_event_kind(kind: &notify::EventKind) -> Option<WatcherChangeKind> {
     match kind {
       notify::EventKind::Create(_) => Some(WatcherChangeKind::Create),
-      notify::EventKind::Remove(_) => Some(WatcherChangeKind::Delete),
+      notify::EventKind::Modify(notify::event::ModifyKind::Name(
+        notify::event::RenameMode::From,
+      ))
+      | notify::EventKind::Remove(_) => Some(WatcherChangeKind::Delete),
       notify::EventKind::Modify(_) => Some(WatcherChangeKind::Update),
       _ => None,
     }


### PR DESCRIPTION
## Summary

Fix infinite rebuild loop in watch mode on Linux (regression in rc.7).

Closes #8555

## Root Cause

`rolldown-notify` with `TargetMode::TrackPath` registers inotify watches including `IN_OPEN` and `IN_ATTRIB` flags. When the build process reads watched source files during bundling, inotify emits `Access` events (`EventKind::Access(Open)`, `Access(Read)`, `Access(Close)`).

The previous catch-all `_ => WatcherChangeKind::Update` in `TaskFsEventHandler::map_event_kind` mapped these `Access` events to file-change notifications, causing:

```
build reads src/main.js → inotify fires IN_OPEN
→ notify emits Access(Open) → map_event_kind returns Update
→ watcher triggers rebuild → build reads src/main.js again → ∞
```

Evidence from `strace`:
```
inotify_add_watch(21, ".../src", IN_MODIFY|IN_ATTRIB|IN_CLOSE_WRITE|IN_OPEN|IN_MOVED_FROM|IN_MOVED_TO|IN_CREATE|IN_DELETE)
```

Evidence from `inotifywait` — the only events on source files during each rebuild cycle are reads:
```
OPEN src/main.js → ACCESS → CLOSE_NOWRITE
OPEN src/hello.js → ACCESS → CLOSE_NOWRITE
```

## Fix

Only map `Create`, `Remove`, and `Modify` events to rebuild triggers. All other event kinds (`Access`, `Other`, `Any`) return `None` and are filtered out before reaching the coordinator.

## Test Plan

Reproduced on Linux (Ubuntu, kernel 6.14.0) with a minimal project:
- **Before fix**: editing any source file triggers infinite rebuild loop (~2-3ms per cycle)
- **After fix**: single rebuild on file change, watcher stabilizes correctly
