### PR TITLE
test: make dev server tests deterministic by replacing fixed sleeps with event-driven polling

### DIFF
--- a/packages/test-dev-server/src/dev-server.ts
+++ b/packages/test-dev-server/src/dev-server.ts
@@ -90,10 +90,17 @@ class DevServer {
       onHmrUpdates: (errOrUpdates) => {
         if (errOrUpdates instanceof Error) {
           console.error('HMR update error:', errOrUpdates);
+          this.#buildSeq++;
         } else {
           this.handleHmrUpdates(errOrUpdates.updates);
+          // Only increment if no FullReload — a FullReload triggers a rebuild
+          // which will call onOutput, so we let onOutput do the increment to
+          // avoid double-counting a single build cycle.
+          const hasFullReload = errOrUpdates.updates.some((u) => u.update.type === 'FullReload');
+          if (!hasFullReload) {
+            this.#buildSeq++;
+          }
         }
-        this.#buildSeq++;
       },
       onOutput: (errOrOutputs) => {
         if (errOrOutputs instanceof Error) {

--- a/packages/test-dev-server/src/dev-server.ts
+++ b/packages/test-dev-server/src/dev-server.ts
@@ -46,6 +46,8 @@ class DevServer {
   #devOptions?: NormalizedDevOptions;
   #devEngine?: DevEngine;
   #port = 3000;
+  #buildSeq = 0;
+  #moduleRegistrationSeq = 0;
 
   constructor() {}
 
@@ -91,11 +93,13 @@ class DevServer {
         } else {
           this.handleHmrUpdates(errOrUpdates.updates);
         }
+        this.#buildSeq++;
       },
       onOutput: (errOrOutputs) => {
         if (errOrOutputs instanceof Error) {
           console.error('Build error:', errOrOutputs);
         }
+        this.#buildSeq++;
       },
       watch: getDevWatchOptionsForCi(),
     });
@@ -169,6 +173,7 @@ class DevServer {
           case 'hmr:module-registered': {
             console.log('Registering modules:', clientMessage.modules);
             this.#devEngine?.registerModules(clientSession.id, clientMessage.modules);
+            this.#moduleRegistrationSeq++;
             break;
           }
           default: {
@@ -213,6 +218,23 @@ class DevServer {
           console.error('Error handling lazy compile request:', err);
           return;
         }
+      }
+      next();
+    });
+    this.connectServer.use(async (req, res, next) => {
+      if (req.url === '/_dev/status') {
+        const bundleState = await devEngine.getBundleState();
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            hasStaleOutput: bundleState.hasStaleOutput,
+            lastFullBuildFailed: bundleState.lastFullBuildFailed,
+            buildSeq: this.#buildSeq,
+            connectedClients: this.#clients.size,
+            moduleRegistrationSeq: this.#moduleRegistrationSeq,
+          }),
+        );
+        return;
       }
       next();
     });

--- a/packages/test-dev-server/tests/fixtures.test.ts
+++ b/packages/test-dev-server/tests/fixtures.test.ts
@@ -5,8 +5,14 @@ import killPort from 'kill-port';
 import nodeFs from 'node:fs';
 import nodePath from 'node:path';
 import { afterAll, describe, test } from 'vitest';
-import { CONFIG } from './src/config';
-import { isDirectoryExists, removeDirSync, sensibleTimeoutInMs } from './src/utils';
+import { isDirectoryExists, removeDirSync } from './src/utils';
+import {
+  getBuildSeq,
+  getModuleRegistrationSeq,
+  waitForBuildStable,
+  waitForModuleRegistration,
+  waitForNextBuild,
+} from './test-utils';
 
 function main() {
   const fixturesPath = nodePath.resolve(__dirname, 'fixtures');
@@ -82,9 +88,12 @@ function main() {
 
         await waitForPathExists(nodeScriptPath);
 
-        let runningArtifactProcess = await runArtifactProcess(nodeScriptPath, tmpProjectPath);
+        let runningArtifactProcess = await runArtifactProcess(nodeScriptPath, tmpProjectPath, port);
 
         const hmrEditFiles = await collectHmrEditFiles(tmpProjectPath);
+
+        // Wait for the initial build to stabilize
+        await waitForBuildStable(port);
 
         for (const [index, [step, hmrEdits]] of hmrEditFiles.entries()) {
           console.log(
@@ -94,17 +103,6 @@ function main() {
               2,
             )}`,
           );
-
-          // Refer to `packages/test-dev-server/src/utils/get-dev-watch-options-for-ci.ts`
-          // We used a poll-based and debounced watcher in CI, so we need to wait for certain amount of time to
-          // - Make sure different steps are not debounced together
-          // - Make sure changes are detected individually for different steps
-          // - Make sure changes in the same step are detected together
-          if (index !== 0) {
-            await sensibleTimeoutInMs(
-              CONFIG.watch.debounceDuration + CONFIG.watch.debounceTickRate + 100,
-            );
-          }
 
           const hmrEditsWithContent = hmrEdits.map((e) => ({
             ...e,
@@ -119,6 +117,9 @@ function main() {
             currentArtifactContent = nodeFs.readFileSync(nodeScriptPath);
           }
 
+          // Snapshot buildSeq before writing so we can detect the resulting build
+          const preWriteBuildSeq = await getBuildSeq(port);
+
           for (const hmrEdit of hmrEditsWithContent) {
             console.log(`🔄 Writing content to: ${hmrEdit.targetPath}`);
             nodeFs.writeFileSync(hmrEdit.targetPath, hmrEdit.content);
@@ -127,16 +128,20 @@ function main() {
           console.log(`⏳ Waiting for HMR to be triggered for step ${step}`);
 
           if (needRestart || needReload) {
-            // Waiting Reload hmr update to be triggered. If we close the process too fast, dev engine will think there're no clients.
-            // No hmr update will be triggered.
-            await sensibleTimeoutInMs(2000);
             if (needReload) {
+              // For reload steps, send the 'r' signal to request a rebuild, which
+              // calls ensureLatestBuildOutput only when the output is stale.
+              // We don't rely on the watcher since the edited file may be new
+              // and not yet in the build graph.
               console.log(`🏃‍➡️ Sent rebuild message to the dev server`);
               devServeProcess.stdin.write('r');
+            } else {
+              // For restart steps (no reload), wait for the watcher-triggered build.
+              await waitForNextBuild(port, preWriteBuildSeq);
             }
             await runningArtifactProcess.close();
             await waitForFileToBeModified(nodeScriptPath, currentArtifactContent);
-            runningArtifactProcess = await runArtifactProcess(nodeScriptPath, tmpProjectPath);
+            runningArtifactProcess = await runArtifactProcess(nodeScriptPath, tmpProjectPath, port);
           }
           await waitForPathExists(nodePath.join(tmpProjectPath, `ok-${index}`), 10 * 1000);
           console.log(`✅ HMR triggered for step ${step}`);
@@ -161,7 +166,7 @@ function main() {
 
 let id = 0;
 
-async function runArtifactProcess(artifactPath: string, tmpProjectPath: string) {
+async function runArtifactProcess(artifactPath: string, tmpProjectPath: string, port: number) {
   const thisId = id;
   id++;
 
@@ -173,6 +178,9 @@ async function runArtifactProcess(artifactPath: string, tmpProjectPath: string) 
   `.trim(),
   );
 
+  // Snapshot registered clients before starting the process
+  const currentRegistered = await getModuleRegistrationSeq(port);
+
   console.log(`🔄 Starting Node.js process: ${artifactPath}`);
   const artifactProcess = execa(
     'node',
@@ -183,7 +191,8 @@ async function runArtifactProcess(artifactPath: string, tmpProjectPath: string) 
   // Wait for the Node.js process to start
   await waitForPathExists(initOkFilePath);
 
-  await sensibleTimeoutInMs(2000); // Make sure module are registered
+  // Wait for modules to be registered with the dev server
+  await waitForModuleRegistration(port, currentRegistered);
 
   return {
     process: artifactProcess,

--- a/packages/test-dev-server/tests/fixtures.test.ts
+++ b/packages/test-dev-server/tests/fixtures.test.ts
@@ -96,6 +96,12 @@ function main() {
         await waitForBuildStable(port);
 
         for (const [index, [step, hmrEdits]] of hmrEditFiles.entries()) {
+          // Wait for the previous build's debounce window to close so the
+          // watcher treats the next file write as a new change.
+          if (index !== 0) {
+            await waitForBuildStable(port);
+          }
+
           console.log(
             `🔄 Processing HMR edit files for step ${step} with edits: ${JSON.stringify(
               hmrEdits,

--- a/packages/test-dev-server/tests/hmr-full-bundle-mode.spec.ts
+++ b/packages/test-dev-server/tests/hmr-full-bundle-mode.spec.ts
@@ -1,6 +1,6 @@
 import { setTimeout } from 'node:timers/promises';
 import { describe, expect, test } from 'vitest';
-import { editFile, getPage } from './test-utils';
+import { editFile, getPage, waitForBuildStable } from './test-utils';
 
 describe('hmr-full-bundle-mode', () => {
   test.sequential('should render initial content', async () => {
@@ -23,12 +23,16 @@ describe('hmr-full-bundle-mode', () => {
 
     await expect.poll(() => page.textContent('.hmr')).toBe('hello1');
 
+    // Wait for the build to stabilize before the next edit so the watcher's
+    // debounce window has closed and will detect the new change.
+    await waitForBuildStable(3000);
     await editFile('hmr.js', (code) =>
       code.replace("const foo = 'hello1'", "const foo = 'hello2'"),
     );
 
     await expect.poll(() => page.textContent('.hmr')).toBe('hello2');
 
+    await waitForBuildStable(3000);
     await editFile('hmr.js', (code) => code.replace("const foo = 'hello2'", "const foo = 'hello'"));
     await expect.poll(() => page.textContent('.hmr')).toBe('hello');
   });

--- a/packages/test-dev-server/tests/src/config.ts
+++ b/packages/test-dev-server/tests/src/config.ts
@@ -2,8 +2,6 @@ import nodeAssert from 'node:assert';
 import nodeFs from 'node:fs';
 import nodePath from 'node:path';
 
-import { getDevWatchOptionsForCi } from '@rolldown/test-dev-server';
-
 // `/packages/test-dev-server/tests`
 const testsDir = nodePath.resolve(import.meta.dirname, '..').normalize();
 nodeAssert.ok(nodeFs.existsSync(nodePath.join(testsDir, 'playground')));
@@ -16,5 +14,4 @@ export const CONFIG = {
     hmrFullBundleModeDir: nodePath.join(testsDir, 'playground/hmr-full-bundle-mode'),
     tmpFullBundleModeDir: nodePath.join(testsDir, 'tmp-playground/hmr-full-bundle-mode'),
   },
-  watch: getDevWatchOptionsForCi(),
 };

--- a/packages/test-dev-server/tests/src/utils.ts
+++ b/packages/test-dev-server/tests/src/utils.ts
@@ -16,14 +16,6 @@ export function removeDirSync(path: string) {
   }
 }
 
-export function sensibleTimeoutInMs(ms: number) {
-  const actualMs = process.env.CI ? ms * 3 : ms;
-
-  return new Promise<void>((resolve) => {
-    setTimeout(resolve, actualMs);
-  });
-}
-
 export async function isDirectoryExists(path: string): Promise<boolean> {
   try {
     return await nodeFs.promises.access(path).then(() => true);

--- a/packages/test-dev-server/tests/test-utils.ts
+++ b/packages/test-dev-server/tests/test-utils.ts
@@ -1,8 +1,22 @@
 import nodeFs from 'node:fs';
 import { resolve } from 'node:path';
+import { vi } from 'vitest';
+import { getDevWatchOptionsForCi } from '@rolldown/test-dev-server';
 import { CONFIG } from './src/config.js';
 
 const testDir = CONFIG.paths.tmpFullBundleModeDir;
+
+/** Timeout (ms) for individual fetch requests to /_dev/status. */
+const FETCH_TIMEOUT_MS = 5_000;
+
+/**
+ * Minimum time (ms) buildSeq must remain unchanged to consider the build stable.
+ * Derived from the actual watcher debounce config with margin.
+ */
+const BUILD_STABLE_MS = (() => {
+  const opts = getDevWatchOptionsForCi();
+  return opts.debounceDuration + opts.debounceTickRate + 200;
+})();
 
 /**
  * Edit a file using Node.js fs module
@@ -20,10 +34,6 @@ export async function editFile(
     return;
   }
   nodeFs.writeFileSync(filePath, newContent, 'utf-8');
-
-  // Small delay to ensure file system events are picked up
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-
   console.log(`[editFile] Updated ${filename}`);
 }
 
@@ -36,4 +46,102 @@ export function getPage() {
     throw new Error('Playwright page not initialized. Check vitest-setup-playwright.ts');
   }
   return page;
+}
+
+interface DevStatus {
+  hasStaleOutput: boolean;
+  lastFullBuildFailed: boolean;
+  buildSeq: number;
+  connectedClients: number;
+  moduleRegistrationSeq: number;
+}
+
+async function fetchDevStatus(port: number): Promise<DevStatus> {
+  const res = await fetch(`http://localhost:${port}/_dev/status`, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`/_dev/status responded with ${res.status}`);
+  }
+  return await res.json();
+}
+
+/** Poll until buildSeq increments past the given value (i.e., a new build completed). */
+export async function waitForNextBuild(
+  port: number,
+  currentBuildSeq: number,
+  timeoutMs = 30_000,
+): Promise<DevStatus> {
+  return vi.waitFor(
+    async () => {
+      const status = await fetchDevStatus(port);
+      if (status.buildSeq > currentBuildSeq) return status;
+      throw new Error(`buildSeq still at ${status.buildSeq}, waiting for > ${currentBuildSeq}`);
+    },
+    { timeout: timeoutMs, interval: 50 },
+  );
+}
+
+/**
+ * Wait for buildSeq to stabilize (no changes for `stableMs`). This ensures the debounce window has closed.
+ *
+ * Uses BUILD_STABLE_MS derived from the actual watcher debounce config.
+ */
+export async function waitForBuildStable(
+  port: number,
+  stableMs = BUILD_STABLE_MS,
+  timeoutMs = 30_000,
+): Promise<DevStatus> {
+  const start = Date.now();
+  let lastSeq = -1;
+  let lastChangeTime = start;
+  let lastError: unknown;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const status = await fetchDevStatus(port);
+      if (status.buildSeq !== lastSeq) {
+        lastSeq = status.buildSeq;
+        lastChangeTime = Date.now();
+      } else if (Date.now() - lastChangeTime >= stableMs) {
+        return status;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(
+    `Build not stable within ${timeoutMs}ms` +
+      (lastError ? `. Last fetch error: ${lastError}` : ''),
+  );
+}
+
+/** Poll until moduleRegistrationSeq exceeds the given value (i.e., a new module registration happened). */
+export async function waitForModuleRegistration(
+  port: number,
+  currentSeq: number,
+  timeoutMs = 30_000,
+): Promise<DevStatus> {
+  return vi.waitFor(
+    async () => {
+      const status = await fetchDevStatus(port);
+      if (status.moduleRegistrationSeq > currentSeq) return status;
+      throw new Error(
+        `moduleRegistrationSeq still at ${status.moduleRegistrationSeq}, waiting for > ${currentSeq}`,
+      );
+    },
+    { timeout: timeoutMs, interval: 50 },
+  );
+}
+
+/** Get current module registration sequence number. */
+export async function getModuleRegistrationSeq(port: number): Promise<number> {
+  const status = await fetchDevStatus(port);
+  return status.moduleRegistrationSeq;
+}
+
+/** Get current build sequence number. */
+export async function getBuildSeq(port: number): Promise<number> {
+  const status = await fetchDevStatus(port);
+  return status.buildSeq;
 }

--- a/packages/test-dev-server/tests/vitest-setup-playwright.ts
+++ b/packages/test-dev-server/tests/vitest-setup-playwright.ts
@@ -141,13 +141,16 @@ beforeAll(async () => {
 beforeEach(async (ctx) => {
   const retryCount = ctx.task.result?.retryCount ?? 0;
   if (retryCount > 0) {
+    // On retry, restart the dev server with fresh files to avoid stale state
+    if (devServerProcess) {
+      devServerProcess.kill('SIGTERM');
+      devServerProcess = null;
+    }
+    await killPort(3000);
     await resetTestFiles();
-    // Wait for file system watcher to detect and process the changes
-    await new Promise((resolve) => setTimeout(resolve, 1000 * 3));
-    // Reload the page to ensure it reflects the reset file state
-    // This is necessary because after a failed test, the page may show stale content
+    ({ devServerProcess } = await startDevServer());
     if (page) {
-      await page.reload({ waitUntil: 'networkidle' });
+      await page.goto('http://localhost:3000', { waitUntil: 'networkidle' });
     }
   }
 });


### PR DESCRIPTION
## Summary

- Add a `/_dev/status` endpoint to the dev server exposing `buildSeq`, `moduleRegistrationSeq`, and bundle state counters
- Replace all fixed `setTimeout` sleeps in test synchronization with event-driven polling utilities (`waitForNextBuild`, `waitForBuildStable`, `waitForModuleRegistration`)
- Remove `sensibleTimeoutInMs` helper and unused `CONFIG.watch` references
- On retry, fully restart the dev server with fresh files instead of relying on sleep + page reload
- Fix `buildSeq` double-increment on full-reload HMR builds (skip increment in `onHmrUpdates` when FullReload is present, since `onOutput` will handle it)

Eliminates all hardcoded sleeps (710ms-6000ms, x3 on CI) that caused flakiness and wasted CI minutes.

### Local test results (macOS, 3 runs each)

| | main (sleeps) | this PR (polling) | Improvement |
|---|---|---|---|
| **Fixtures** | 17.24s avg | 7.54s avg | **56% faster** |
| **Browser** | 10.76s avg | 9.43s avg | **12% faster** |
| **Total** | 28.00s avg | 16.97s avg | **39% faster** |
| **Reliability** | 3/3 passed | 3/3 passed | OK |

### CI job time comparison (avg of 3 runs each)

| Platform | main | this PR | saved |
|----------|------|---------|-------|
| Ubuntu | 5m28s | 3m36s | 1m52s (34% faster) |
| macOS | 5m05s | 2m55s | 2m10s (43% faster) |
| Windows | 7m30s | 5m36s | 1m54s (25% faster) |

Closes #8556
