### PR TITLE
ci: skip redundant native binding build for browser and remove standalone job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,31 +182,6 @@ jobs:
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}
       os: ubuntu-latest
 
-  build-browser:
-    name: Build `@rolldown/browser`
-    needs: [changes]
-    if: ${{ needs.changes.outputs.node-changes == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true # Pull submodules for additional files
-          persist-credentials: false
-
-      - name: Setup Rust
-        uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12
-        with:
-          tools: just
-          cache-key: debug-build-wasi
-
-      - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
-
-      - name: Add WASI target
-        run: rustup target add wasm32-wasip1-threads
-
-      - name: Build `@rolldown/browser`
-        run: just build-browser
-
   wasi-test:
     needs: [changes, build-rolldown-wasi]
     # run this even if build-rolldown-wasi is skipped

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -112,8 +112,8 @@
     "build-native:memory-profile": "pnpm run build-binding:profile --features default_global_allocator && pnpm run build-js-glue",
     "build-wasi:debug": "TARGET='rolldown-wasi' pnpm run --sequential '/^build-(binding|binding:wasi|node)$/'",
     "build-wasi:release": "TARGET='rolldown-wasi' pnpm run --sequential '/^build-(binding|binding:wasi:release|node)$/'",
-    "build-browser-pkg:debug": "TARGET='browser' pnpm run --sequential '/^build-(binding|binding:wasi|node)$/'",
-    "build-browser-pkg:release": "TARGET='browser' pnpm run --sequential '/^build-(binding|binding:wasi:release|node)$/'",
+    "build-browser-pkg:debug": "TARGET='browser' pnpm run --sequential '/^build-(binding:wasi|node)$/'",
+    "build-browser-pkg:release": "TARGET='browser' pnpm run --sequential '/^build-(binding:wasi:release|node)$/'",
     "# Scrips for docs #": "_",
     "prepublishOnly": "napi pre-publish -t npm --no-gh-release",
     "publint": "publint ."


### PR DESCRIPTION
Part of https://github.com/rolldown/rolldown/issues/8553

## Summary

- Remove `binding|` from `build-browser-pkg:debug` and `build-browser-pkg:release` scripts so browser builds only run WASI + node steps, skipping ~60-90s of unnecessary native Rust compilation (the `.node` file is marked as `external` in `copy-addon-plugin.ts` and never bundled)
- Remove standalone `build-browser` CI job since `node-validation` already builds and validates `@rolldown/browser` with publint/knip

https://github.com/rolldown/rolldown/blob/36b69d8676c5a5960551b7af3f06957144c80bd9/.github/workflows/ci.yml#L262-L263

**Note:** `build-browser` may need to be removed from GitHub branch protection required status checks after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)