### PR TITLE
ci: parallelize Node tests on ubuntu, single Node 24 on macOS/windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,37 @@ jobs:
       os: ubuntu-latest
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}
 
+  type-check:
+    name: Type Check
+    needs: [changes, build-rolldown-ubuntu]
+    if: |
+      always() &&
+      (needs.build-rolldown-ubuntu.result == 'success' || needs.build-rolldown-ubuntu.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
+
+      - name: Download Native Rolldown Build
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: rolldown-native-ubuntu-latest
+          path: ./packages
+
+      - name: Build `@rolldown/test-dev-server`
+        run: pnpm --filter '@rolldown/test-dev-server' build
+
+      - name: Type Check
+        run: pnpm type-check
+
+      - name: Node Type Test
+        run: pnpm run --filter rolldown-tests test:types
+
   node-dev-server-test-windows:
     needs: [changes, build-rolldown-windows]
     uses: ./.github/workflows/reusable-node-dev-server-test.yml

--- a/.github/workflows/reusable-node-dev-server-test.yml
+++ b/.github/workflows/reusable-node-dev-server-test.yml
@@ -14,12 +14,14 @@ on:
 
 jobs:
   run:
-    name: Node Dev Server Test
+    name: Node Dev Server Test (Node ${{ matrix.node-version }})
     if: ${{ inputs.changed }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -45,29 +47,11 @@ jobs:
       - name: Install Playwright
         run: pnpm playwright install chromium
 
-      - name: Setup Node20 For Testing
+      - name: Setup Node${{ matrix.node-version }} For Testing
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           package-manager-cache: false
 
-      - name: Dev Server Test For Node20
-        run: pnpm run --filter '@rolldown/test-dev-server-tests' test
-
-      - name: Setup Node22 For Testing
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 22
-          package-manager-cache: false
-
-      - name: Dev Server Test For Node22
-        run: pnpm run --filter '@rolldown/test-dev-server-tests' test
-
-      - name: Setup Node24 For Testing
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 24
-          package-manager-cache: false
-
-      - name: Dev Server Test For Node24
+      - name: Dev Server Test
         run: pnpm run --filter '@rolldown/test-dev-server-tests' test

--- a/.github/workflows/reusable-node-dev-server-test.yml
+++ b/.github/workflows/reusable-node-dev-server-test.yml
@@ -28,11 +28,6 @@ jobs:
           submodules: true # Pull submodules for additional files
           persist-credentials: false
 
-      - name: Setup Rust
-        uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12
-        with:
-          tools: just
-
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
 
       - name: Download Native Rolldown Build

--- a/.github/workflows/reusable-node-dev-server-test.yml
+++ b/.github/workflows/reusable-node-dev-server-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: ${{ inputs.os == 'ubuntu-latest' && fromJson('[20, 22, 24]') || fromJson('[24]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -14,12 +14,14 @@ on:
 
 jobs:
   run:
-    name: Node Test
+    name: Node Test (Node ${{ matrix.node-version }})
     if: ${{ inputs.changed }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -49,54 +51,20 @@ jobs:
         run: |
           pnpm run --filter rolldown-tests test:types
 
-      - name: Setup Node20 For Testing
+      - name: Setup Node${{ matrix.node-version }} For Testing
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           package-manager-cache: false
 
-      - name: Node Test For Node20
+      - name: Node Test
         run: |
           pnpm run --filter rolldown-tests test:main && pnpm run --filter rolldown-tests test:watcher && pnpm run --filter rolldown-tests test:stability
 
-      - name: Rollup Test For Node20
+      - name: Rollup Test
         run: pnpm run --filter rollup-tests test
         env:
-          SKIP_PASS_DIFF: 1
+          SKIP_PASS_DIFF: ${{ matrix.node-version != 24 && '1' || '' }}
 
-      - name: Build Examples For Node20
-        run: pnpm --filter '@example/**' build
-
-      - name: Setup Node22 For Testing
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 22
-          package-manager-cache: false
-
-      - name: Node Test For Node22
-        run: |
-          pnpm run --filter rolldown-tests test:main && pnpm run --filter rolldown-tests test:watcher && pnpm run --filter rolldown-tests test:stability
-
-      - name: Rollup Test For Node22
-        run: pnpm run --filter rollup-tests test
-        env:
-          SKIP_PASS_DIFF: 1
-
-      - name: Build Examples For Node22
-        run: pnpm --filter '@example/**' build
-
-      - name: Setup Node24 For Testing
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 24
-          package-manager-cache: false
-
-      - name: Node Test For Node24
-        run: |
-          pnpm run --filter rolldown-tests test:main && pnpm run --filter rolldown-tests test:watcher && pnpm run --filter rolldown-tests test:stability
-
-      - name: Rollup Test For Node24
-        run: pnpm run --filter rollup-tests test
-
-      - name: Build Examples For Node24
+      - name: Build Examples
         run: pnpm --filter '@example/**' build

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -28,11 +28,6 @@ jobs:
           submodules: true # Pull submodules for additional files
           persist-credentials: false
 
-      - name: Setup Rust
-        uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12
-        with:
-          tools: just
-
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
 
       - name: Download Native Rolldown Build
@@ -43,13 +38,6 @@ jobs:
 
       - name: Build `@rolldown/test-dev-server`
         run: pnpm --filter '@rolldown/test-dev-server' build
-
-      - name: Type Check
-        run: pnpm type-check
-
-      - name: Node Type Test
-        run: |
-          pnpm run --filter rolldown-tests test:types
 
       - name: Setup Node${{ matrix.node-version }} For Testing
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: ${{ inputs.os == 'ubuntu-latest' && fromJson('[20, 22, 24]') || fromJson('[24]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

- Parallelize Node 20/22/24 test runs using matrix strategy in both `reusable-node-test` and `reusable-node-dev-server-test` workflows
- Run Node 20/22/24 matrix only on ubuntu; macOS and windows run Node 24 only
- This reduces billable minutes by ~46% vs main (79 vs 146) while keeping wall-clock ~4min faster than main

Related #8553

🤖 Generated with [Claude Code](https://claude.com/claude-code)