### PR TITLE
ci: use Dev Drive for Windows CI jobs

### DIFF
--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -33,11 +33,6 @@ jobs:
             CARGO_HOME,{{ DEV_DRIVE }}/.cargo
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
 
-      - name: Disable Windows Defender real-time monitoring
-        if: runner.os == 'Windows'
-        shell: powershell
-        run: Add-MpPreference -ExclusionPath ${{ github.workspace }}, $env:CARGO_HOME, $env:RUSTUP_HOME
-
       - name: Setup Rust
         uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12
         with:

--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -23,6 +23,11 @@ jobs:
           submodules: true # Pull submodules for additional files
           persist-credentials: false
 
+      - name: Disable Windows Defender real-time monitoring
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Add-MpPreference -ExclusionPath ${{ github.workspace }}, $env:CARGO_HOME, $env:RUSTUP_HOME
+
       - name: Setup Rust
         uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12
         with:

--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -26,9 +26,8 @@ jobs:
       - uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
         if: runner.os == 'Windows'
         with:
-          workspace-copy: true
           drive-size: 8GB
-          drive-format: NTFS
+          drive-format: ReFS
           env-mapping: |
             CARGO_HOME,{{ DEV_DRIVE }}/.cargo
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup

--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -26,7 +26,13 @@ jobs:
       - name: Disable Windows Defender real-time monitoring
         if: runner.os == 'Windows'
         shell: powershell
-        run: Add-MpPreference -ExclusionPath ${{ github.workspace }}, $env:CARGO_HOME, $env:RUSTUP_HOME
+        run: |
+          $paths = @("${{ github.workspace }}")
+          $cargo = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { "$env:USERPROFILE\.cargo" }
+          $rustup = if ($env:RUSTUP_HOME) { $env:RUSTUP_HOME } else { "$env:USERPROFILE\.rustup" }
+          $paths += $cargo
+          $paths += $rustup
+          Add-MpPreference -ExclusionPath $paths
 
       - name: Setup Rust
         uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12

--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -23,16 +23,20 @@ jobs:
           submodules: true # Pull submodules for additional files
           persist-credentials: false
 
+      - uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
+        if: runner.os == 'Windows'
+        with:
+          workspace-copy: true
+          drive-size: 8GB
+          drive-format: NTFS
+          env-mapping: |
+            CARGO_HOME,{{ DEV_DRIVE }}/.cargo
+            RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
+
       - name: Disable Windows Defender real-time monitoring
         if: runner.os == 'Windows'
         shell: powershell
-        run: |
-          $paths = @("${{ github.workspace }}")
-          $cargo = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { "$env:USERPROFILE\.cargo" }
-          $rustup = if ($env:RUSTUP_HOME) { $env:RUSTUP_HOME } else { "$env:USERPROFILE\.rustup" }
-          $paths += $cargo
-          $paths += $rustup
-          Add-MpPreference -ExclusionPath $paths
+        run: Add-MpPreference -ExclusionPath ${{ github.workspace }}, $env:CARGO_HOME, $env:RUSTUP_HOME
 
       - name: Setup Rust
         uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -24,6 +24,11 @@ jobs:
           submodules: true # Pull submodules for additional files
           persist-credentials: false
 
+      - name: Disable Windows Defender real-time monitoring
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Add-MpPreference -ExclusionPath ${{ github.workspace }}, $env:CARGO_HOME, $env:RUSTUP_HOME
+
       - name: Setup Rust
         uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12
         with:

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -24,16 +24,20 @@ jobs:
           submodules: true # Pull submodules for additional files
           persist-credentials: false
 
+      - uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
+        if: runner.os == 'Windows'
+        with:
+          workspace-copy: true
+          drive-size: 8GB
+          drive-format: NTFS
+          env-mapping: |
+            CARGO_HOME,{{ DEV_DRIVE }}/.cargo
+            RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
+
       - name: Disable Windows Defender real-time monitoring
         if: runner.os == 'Windows'
         shell: powershell
-        run: |
-          $paths = @("${{ github.workspace }}")
-          $cargo = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { "$env:USERPROFILE\.cargo" }
-          $rustup = if ($env:RUSTUP_HOME) { $env:RUSTUP_HOME } else { "$env:USERPROFILE\.rustup" }
-          $paths += $cargo
-          $paths += $rustup
-          Add-MpPreference -ExclusionPath $paths
+        run: Add-MpPreference -ExclusionPath ${{ github.workspace }}, $env:CARGO_HOME, $env:RUSTUP_HOME
 
       - name: Setup Rust
         uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -27,9 +27,8 @@ jobs:
       - uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
         if: runner.os == 'Windows'
         with:
-          workspace-copy: true
           drive-size: 8GB
-          drive-format: NTFS
+          drive-format: ReFS
           env-mapping: |
             CARGO_HOME,{{ DEV_DRIVE }}/.cargo
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -34,11 +34,6 @@ jobs:
             CARGO_HOME,{{ DEV_DRIVE }}/.cargo
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
 
-      - name: Disable Windows Defender real-time monitoring
-        if: runner.os == 'Windows'
-        shell: powershell
-        run: Add-MpPreference -ExclusionPath ${{ github.workspace }}, $env:CARGO_HOME, $env:RUSTUP_HOME
-
       - name: Setup Rust
         uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12
         with:

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -27,7 +27,13 @@ jobs:
       - name: Disable Windows Defender real-time monitoring
         if: runner.os == 'Windows'
         shell: powershell
-        run: Add-MpPreference -ExclusionPath ${{ github.workspace }}, $env:CARGO_HOME, $env:RUSTUP_HOME
+        run: |
+          $paths = @("${{ github.workspace }}")
+          $cargo = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { "$env:USERPROFILE\.cargo" }
+          $rustup = if ($env:RUSTUP_HOME) { $env:RUSTUP_HOME } else { "$env:USERPROFILE\.rustup" }
+          $paths += $cargo
+          $paths += $rustup
+          Add-MpPreference -ExclusionPath $paths
 
       - name: Setup Rust
         uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12


### PR DESCRIPTION
## Summary

- Add `setup-dev-drive` action to Windows CI jobs in `reusable-cargo-test.yml` and `reusable-native-build.yml`
- Creates an 8GB ReFS Dev Drive that automatically bypasses Windows Defender minifilter for faster I/O
- Places `CARGO_HOME` and `RUSTUP_HOME` on the Dev Drive where the heaviest compilation I/O occurs

Related #8553

🤖 Generated with [Claude Code](https://claude.com/claude-code)