### PR TITLE
ci: remove unnecessary submodule checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: true
           persist-credentials: false
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -21,7 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: true # Pull submodules for additional files
           persist-credentials: false
 
       - uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0

--- a/.github/workflows/reusable-node-dev-server-test.yml
+++ b/.github/workflows/reusable-node-dev-server-test.yml
@@ -25,7 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: true # Pull submodules for additional files
           persist-credentials: false
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6

--- a/.github/workflows/reusable-wasi-build.yml
+++ b/.github/workflows/reusable-wasi-build.yml
@@ -17,7 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: true
           persist-credentials: false
 
       - name: Setup Rust

--- a/.github/workflows/reusable-wasi-test.yml
+++ b/.github/workflows/reusable-wasi-test.yml
@@ -23,7 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: true # Pull submodules for additional files
           persist-credentials: false
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6

--- a/.github/workflows/vite-tests.yml
+++ b/.github/workflows/vite-tests.yml
@@ -43,7 +43,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: true # Pull submodules for additional files
           persist-credentials: false
 
       - name: Setup Rust


### PR DESCRIPTION
## Summary

- Remove `submodules: true` from workflows that don't need submodule content
- Affected workflows: `reusable-native-build.yml`, `reusable-node-dev-server-test.yml`, `type-check` job in `ci.yml`, `reusable-wasi-build.yml`, `reusable-wasi-test.yml`, `vite-tests.yml`
- Remaining legitimate usages: `reusable-node-test.yml` (needs `rollup/`), `reusable-cargo-test.yml` (needs `test262/`), `update-test-dependencies.yml` (operates on submodules directly)
- Saves CI time by avoiding unnecessary submodule checkouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)