### PR TITLE
fix: treat object spread of local bindings as side-effect-free

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -546,6 +546,20 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
   fn visit_call_expression(&mut self, it: &ast::CallExpression<'ast>) {
     self.try_extract_hmr_info_from_hot_accept_call(it);
+    // If a spread-safe symbol is passed as an argument to any function call,
+    // remove it from the set — the function could mutate the object (e.g. via
+    // Object.defineProperty) making later spreads potentially side-effectful.
+    if !self.spread_safe_symbol_ids.is_empty() {
+      for arg in &it.arguments {
+        if let ast::Argument::Identifier(ident) = arg {
+          if let Some(ref_id) = ident.reference_id.get() {
+            if let Some(sym) = self.result.symbol_ref_db.ast_scopes.symbol_id_for(ref_id) {
+              self.spread_safe_symbol_ids.remove(&sym);
+            }
+          }
+        }
+      }
+    }
     walk::walk_call_expression(self, it);
   }
 

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -547,11 +547,23 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
   fn visit_call_expression(&mut self, it: &ast::CallExpression<'ast>) {
     self.try_extract_hmr_info_from_hot_accept_call(it);
     // If a spread-safe symbol is passed as an argument to any function call,
-    // remove it from the set — the function could mutate the object (e.g. via
-    // Object.defineProperty) making later spreads potentially side-effectful.
+    // or is the receiver of a method call, remove it from the set — the
+    // function/method could mutate the object (e.g. via Object.defineProperty
+    // or __defineGetter__) making later spreads potentially side-effectful.
     if !self.spread_safe_symbol_ids.is_empty() {
       for arg in &it.arguments {
         if let ast::Argument::Identifier(ident) = arg {
+          if let Some(ref_id) = ident.reference_id.get() {
+            if let Some(sym) = self.result.symbol_ref_db.ast_scopes.symbol_id_for(ref_id) {
+              self.spread_safe_symbol_ids.remove(&sym);
+            }
+          }
+        }
+      }
+      // Also invalidate when the object is the receiver of a method call
+      // (e.g. o.__defineGetter__(...), o.method())
+      if let Some(member) = it.callee.as_member_expression() {
+        if let Expression::Identifier(ident) = member.object() {
           if let Some(ref_id) = ident.reference_id.get() {
             if let Some(sym) = self.result.symbol_ref_db.ast_scopes.symbol_id_for(ref_id) {
               self.spread_safe_symbol_ids.remove(&sym);

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -25,7 +25,8 @@ use rolldown_std_utils::OptionExt;
 use crate::ast_scanner::{TraverseState, cjs_export_analyzer::CommonJsAstType};
 
 use super::{
-  AstScanner, UntranspiledSyntax, cjs_export_analyzer::CjsGlobalAssignmentType,
+  AstScanner, UntranspiledSyntax,
+  cjs_export_analyzer::CjsGlobalAssignmentType,
   side_effect_detector::{SideEffectDetector, is_plain_object_literal},
 };
 

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -552,24 +552,19 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     // or __defineGetter__) making later spreads potentially side-effectful.
     if !self.spread_safe_symbol_ids.is_empty() {
       for arg in &it.arguments {
-        if let ast::Argument::Identifier(ident) = arg {
-          if let Some(ref_id) = ident.reference_id.get() {
-            if let Some(sym) = self.result.symbol_ref_db.ast_scopes.symbol_id_for(ref_id) {
-              self.spread_safe_symbol_ids.remove(&sym);
-            }
+        match arg {
+          ast::Argument::SpreadElement(spread) => {
+            self.invalidate_spread_safe_from_expr(&spread.argument);
+          }
+          _ => {
+            self.invalidate_spread_safe_from_expr(arg.to_expression());
           }
         }
       }
       // Also invalidate when the object is the receiver of a method call
-      // (e.g. o.__defineGetter__(...), o.method())
+      // (e.g. o.__defineGetter__(...), (o).method(), (void 0, o).method())
       if let Some(member) = it.callee.as_member_expression() {
-        if let Expression::Identifier(ident) = member.object() {
-          if let Some(ref_id) = ident.reference_id.get() {
-            if let Some(sym) = self.result.symbol_ref_db.ast_scopes.symbol_id_for(ref_id) {
-              self.spread_safe_symbol_ids.remove(&sym);
-            }
-          }
-        }
+        self.invalidate_spread_safe_from_expr(member.object());
       }
     }
     walk::walk_call_expression(self, it);
@@ -603,6 +598,34 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 }
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
+  /// Unwrap parenthesized/sequence expressions and invalidate any spread-safe
+  /// symbol found at the base. This handles patterns like `(o)`, `(void 0, o)`,
+  /// `(1, 2, 3, o)` etc.
+  fn invalidate_spread_safe_from_expr(&mut self, mut expr: &Expression<'ast>) {
+    loop {
+      match expr {
+        Expression::ParenthesizedExpression(paren) => {
+          expr = &paren.expression;
+        }
+        Expression::SequenceExpression(seq) => {
+          if let Some(last) = seq.expressions.last() {
+            expr = last;
+          } else {
+            return;
+          }
+        }
+        _ => break,
+      }
+    }
+    if let Expression::Identifier(ident) = expr {
+      if let Some(ref_id) = ident.reference_id.get() {
+        if let Some(sym) = self.result.symbol_ref_db.ast_scopes.symbol_id_for(ref_id) {
+          self.spread_safe_symbol_ids.remove(&sym);
+        }
+      }
+    }
+  }
+
   /// visit `Class` of declaration
   #[expect(clippy::unused_self)]
   pub fn get_class_id(&self, class: &ast::Class<'ast>) -> Option<SymbolId> {

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -26,7 +26,7 @@ use crate::ast_scanner::{TraverseState, cjs_export_analyzer::CommonJsAstType};
 
 use super::{
   AstScanner, UntranspiledSyntax, cjs_export_analyzer::CjsGlobalAssignmentType,
-  side_effect_detector::SideEffectDetector,
+  side_effect_detector::{SideEffectDetector, is_plain_object_literal},
 };
 
 impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
@@ -116,7 +116,8 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
         self.immutable_ctx.flat_options,
         self.immutable_ctx.options,
         None,
-      );
+      )
+      .with_spread_safe_symbols(&self.spread_safe_symbol_ids);
       self.current_stmt_info.side_effect = detector.detect_side_effect_of_stmt(stmt);
 
       #[cfg(debug_assertions)]
@@ -390,6 +391,16 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
   }
 
   fn visit_variable_declaration(&mut self, decl: &ast::VariableDeclaration<'ast>) {
+    // Track symbols initialized with plain object literals for spread safety
+    for var_decl in &decl.declarations {
+      if let BindingPattern::BindingIdentifier(binding) = &var_decl.id {
+        if let Some(init) = &var_decl.init {
+          if is_plain_object_literal(init) {
+            self.spread_safe_symbol_ids.insert(binding.symbol_id());
+          }
+        }
+      }
+    }
     match decl.declarations.as_slice() {
       [decl] => {
         if let (BindingPattern::BindingIdentifier(binding), Some(init)) = (&decl.id, &decl.init) {

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -392,12 +392,16 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
   }
 
   fn visit_variable_declaration(&mut self, decl: &ast::VariableDeclaration<'ast>) {
-    // Track symbols initialized with plain object literals for spread safety
-    for var_decl in &decl.declarations {
-      if let BindingPattern::BindingIdentifier(binding) = &var_decl.id {
-        if let Some(init) = &var_decl.init {
-          if is_plain_object_literal(init) {
-            self.spread_safe_symbol_ids.insert(binding.symbol_id());
+    // Track symbols initialized with plain object literals for spread safety.
+    // Only consider `const` declarations, since `let`/`var` can be reassigned
+    // to a Proxy or other non-plain object after initialization.
+    if matches!(decl.kind, ast::VariableDeclarationKind::Const) {
+      for var_decl in &decl.declarations {
+        if let BindingPattern::BindingIdentifier(binding) = &var_decl.id {
+          if let Some(init) = &var_decl.init {
+            if is_plain_object_literal(init) {
+              self.spread_safe_symbol_ids.insert(binding.symbol_id());
+            }
           }
         }
       }

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -166,6 +166,9 @@ pub struct AstScanner<'me, 'ast> {
   traverse_state: TraverseState,
   current_comment_idx: usize,
   untranspiled_syntax: UntranspiledSyntax,
+  /// Symbols initialized with plain object literals (no getters/setters).
+  /// Used to determine if spreading a local variable is side-effect-free.
+  spread_safe_symbol_ids: FxHashSet<SymbolId>,
 }
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
@@ -256,6 +259,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       traverse_state: TraverseState::empty(),
       current_comment_idx: 0,
       untranspiled_syntax: UntranspiledSyntax::empty(),
+      spread_safe_symbol_ids: FxHashSet::default(),
     }
   }
 

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -1013,14 +1013,13 @@ impl<'a> SideEffectDetector<'a> {
 }
 
 /// Returns `true` if the expression is an object literal whose properties are
-/// all simple `init` properties (no getters, setters, or methods with
-/// non-`init` kind). Such objects are safe to spread without triggering
-/// getters or Proxy traps.
+/// all simple `init` properties (no getters, setters, or spreads).
+/// Such objects are safe to spread without triggering getters or Proxy traps.
 pub fn is_plain_object_literal(expr: &Expression) -> bool {
   matches!(expr, Expression::ObjectExpression(obj)
-    if !obj.properties.iter().any(|p| matches!(p,
+    if obj.properties.iter().all(|p| matches!(p,
       ast::ObjectPropertyKind::ObjectProperty(prop)
-        if prop.kind != ast::PropertyKind::Init
+        if prop.kind == ast::PropertyKind::Init
     ))
   )
 }
@@ -1092,6 +1091,37 @@ mod test {
     }
   }
 
+  /// Unwrap parenthesized/sequence expressions and remove any found
+  /// spread-safe symbol from the set.
+  fn unwrap_and_invalidate(
+    mut expr: &Expression,
+    set: &mut FxHashSet<SymbolId>,
+    scopes: &AstScopes,
+  ) {
+    loop {
+      match expr {
+        Expression::ParenthesizedExpression(paren) => {
+          expr = &paren.expression;
+        }
+        Expression::SequenceExpression(seq) => {
+          if let Some(last) = seq.expressions.last() {
+            expr = last;
+          } else {
+            return;
+          }
+        }
+        _ => break,
+      }
+    }
+    if let Expression::Identifier(ident) = expr {
+      if let Some(ref_id) = ident.reference_id.get() {
+        if let Some(sym) = scopes.symbol_id_for(ref_id) {
+          set.remove(&sym);
+        }
+      }
+    }
+  }
+
   fn invalidate_call_args_in_expr(
     expr: &Expression,
     set: &mut FxHashSet<SymbolId>,
@@ -1100,23 +1130,18 @@ mod test {
     match expr {
       Expression::CallExpression(call) => {
         for arg in &call.arguments {
-          if let ast::Argument::Identifier(ident) = arg {
-            if let Some(ref_id) = ident.reference_id.get() {
-              if let Some(sym) = scopes.symbol_id_for(ref_id) {
-                set.remove(&sym);
-              }
+          match arg {
+            ast::Argument::SpreadElement(spread) => {
+              unwrap_and_invalidate(&spread.argument, set, scopes);
+            }
+            _ => {
+              unwrap_and_invalidate(arg.to_expression(), set, scopes);
             }
           }
         }
         // Also invalidate when the object is the receiver of a method call
         if let Some(member) = call.callee.as_member_expression() {
-          if let Expression::Identifier(ident) = member.object() {
-            if let Some(ref_id) = ident.reference_id.get() {
-              if let Some(sym) = scopes.symbol_id_for(ref_id) {
-                set.remove(&sym);
-              }
-            }
-          }
+          unwrap_and_invalidate(member.object(), set, scopes);
         }
         invalidate_call_args_in_expr(&call.callee, set, scopes);
       }
@@ -1239,26 +1264,62 @@ mod test {
     assert!(get_statements_side_effect("({ ...getObj() })"));
     // let reassigned from plain object to something else is not safe
     assert!(get_statements_side_effect("let obj = { a: 1 }; obj = makeProxy(); ({ ...obj })"));
-    // Object.defineProperty can add getters, invalidating spread safety
-    assert!(get_statements_side_effect(
-      "const o = { a: 1 }; Object.defineProperty(o, 'x', { get() { return 1; } }); ({ ...o })"
-    ));
+    // Object.defineProperty can add getters, invalidating spread safety.
+    // Verify the spread statement itself (last) is side-effectful.
+    assert!(
+      get_statements_side_effect_details(
+        "const o = { a: 1 }; Object.defineProperty(o, 'x', { get() { return 1; } }); ({ ...o })"
+      )
+      .last()
+      .unwrap()
+      .has_side_effect()
+    );
     // Any function call with the symbol as argument invalidates it
-    assert!(get_statements_side_effect("const o = { a: 1 }; mutate(o); ({ ...o })"));
-    // A method call on the object as receiver can mutate it (e.g. by adding a getter)
-    assert!(get_statements_side_effect(
-      "const o = { a: 1 }; o.__defineGetter__('x', function() { sideEffect(); }); ({ ...o })",
-    ));
+    assert!(
+      get_statements_side_effect_details("const o = { a: 1 }; mutate(o); ({ ...o })")
+        .last()
+        .unwrap()
+        .has_side_effect()
+    );
+    // A method call on the object as receiver can mutate it
+    assert!(
+      get_statements_side_effect_details(
+        "const o = { a: 1 }; o.__defineGetter__('x', function() { sideEffect(); }); ({ ...o })",
+      )
+      .last()
+      .unwrap()
+      .has_side_effect()
+    );
     // Parenthesized expressions must not defeat the analysis
-    assert!(get_statements_side_effect("const o = { a: 1 }; mutate((o)); ({ ...o })"));
-    assert!(get_statements_side_effect(
-      "const o = { a: 1 }; (o).__defineGetter__('x', function() {}); ({ ...o })",
-    ));
+    assert!(
+      get_statements_side_effect_details("const o = { a: 1 }; mutate((o)); ({ ...o })")
+        .last()
+        .unwrap()
+        .has_side_effect()
+    );
+    assert!(
+      get_statements_side_effect_details(
+        "const o = { a: 1 }; (o).__defineGetter__('x', function() {}); ({ ...o })",
+      )
+      .last()
+      .unwrap()
+      .has_side_effect()
+    );
     // Sequence expressions (e.g. indirect call pattern) must not defeat the analysis
-    assert!(get_statements_side_effect(
-      "const o = { a: 1 }; (void 0, o).__defineGetter__('x', function() {}); ({ ...o })",
-    ));
-    assert!(get_statements_side_effect("const o = { a: 1 }; mutate((void 0, o)); ({ ...o })"));
+    assert!(
+      get_statements_side_effect_details(
+        "const o = { a: 1 }; (void 0, o).__defineGetter__('x', function() {}); ({ ...o })",
+      )
+      .last()
+      .unwrap()
+      .has_side_effect()
+    );
+    assert!(
+      get_statements_side_effect_details("const o = { a: 1 }; mutate((void 0, o)); ({ ...o })")
+        .last()
+        .unwrap()
+        .has_side_effect()
+    );
   }
 
   #[test]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -1030,7 +1030,7 @@ mod test {
   use std::sync::Arc;
 
   use itertools::Itertools;
-  use oxc::ast::ast::{BindingPattern, Statement};
+  use oxc::ast::ast::{self, BindingPattern, Expression, Statement};
   use oxc::semantic::SymbolId;
   use oxc::{parser::Parser, span::SourceType};
   use rolldown_common::{AstScopes, NormalizedBundlerOptions, SideEffectDetail};
@@ -1041,21 +1041,81 @@ mod test {
   use rolldown_common::FlatOptions;
 
   /// Collect symbol IDs of const variables initialized with plain object literals
-  /// from a variable declaration statement.
-  fn collect_spread_safe_symbols(stmt: &Statement, set: &mut FxHashSet<SymbolId>) {
+  /// from a variable declaration statement. Also invalidate symbols that appear
+  /// as arguments to function calls (since the function could mutate the object).
+  fn update_spread_safe_symbols(
+    stmt: &Statement,
+    set: &mut FxHashSet<SymbolId>,
+    scopes: &AstScopes,
+  ) {
+    // Add const plain object literal symbols
     if let Statement::VariableDeclaration(decl) = stmt {
-      if !matches!(decl.kind, oxc::ast::ast::VariableDeclarationKind::Const) {
-        return;
-      }
-      for var_decl in &decl.declarations {
-        if let BindingPattern::BindingIdentifier(binding) = &var_decl.id {
-          if let Some(init) = &var_decl.init {
-            if is_plain_object_literal(init) {
-              set.insert(binding.symbol_id());
+      if matches!(decl.kind, oxc::ast::ast::VariableDeclarationKind::Const) {
+        for var_decl in &decl.declarations {
+          if let BindingPattern::BindingIdentifier(binding) = &var_decl.id {
+            if let Some(init) = &var_decl.init {
+              if is_plain_object_literal(init) {
+                set.insert(binding.symbol_id());
+              }
             }
           }
         }
       }
+    }
+    // Invalidate symbols passed as call arguments
+    invalidate_call_args_in_stmt(stmt, set, scopes);
+  }
+
+  /// Walk the statement looking for call expressions, and remove any spread-safe
+  /// symbols that appear as arguments.
+  fn invalidate_call_args_in_stmt(
+    stmt: &Statement,
+    set: &mut FxHashSet<SymbolId>,
+    scopes: &AstScopes,
+  ) {
+    if set.is_empty() {
+      return;
+    }
+    // Simple recursive walk to find call expressions in the statement
+    match stmt {
+      Statement::ExpressionStatement(expr) => {
+        invalidate_call_args_in_expr(&expr.expression, set, scopes);
+      }
+      Statement::VariableDeclaration(decl) => {
+        for d in &decl.declarations {
+          if let Some(init) = &d.init {
+            invalidate_call_args_in_expr(init, set, scopes);
+          }
+        }
+      }
+      _ => {}
+    }
+  }
+
+  fn invalidate_call_args_in_expr(
+    expr: &Expression,
+    set: &mut FxHashSet<SymbolId>,
+    scopes: &AstScopes,
+  ) {
+    match expr {
+      Expression::CallExpression(call) => {
+        for arg in &call.arguments {
+          if let ast::Argument::Identifier(ident) = arg {
+            if let Some(ref_id) = ident.reference_id.get() {
+              if let Some(sym) = scopes.symbol_id_for(ref_id) {
+                set.remove(&sym);
+              }
+            }
+          }
+        }
+        invalidate_call_args_in_expr(&call.callee, set, scopes);
+      }
+      Expression::SequenceExpression(seq) => {
+        for e in &seq.expressions {
+          invalidate_call_args_in_expr(e, set, scopes);
+        }
+      }
+      _ => {}
     }
   }
 
@@ -1074,7 +1134,7 @@ mod test {
         .with_spread_safe_symbols(&spread_safe)
         .detect_side_effect_of_stmt(stmt)
         .has_side_effect();
-      collect_spread_safe_symbols(stmt, &mut spread_safe);
+      update_spread_safe_symbols(stmt, &mut spread_safe, &ast_scopes);
       has_side_effect
     })
   }
@@ -1097,7 +1157,7 @@ mod test {
         let detail = SideEffectDetector::new(&ast_scopes, flags, &options, None)
           .with_spread_safe_symbols(&spread_safe)
           .detect_side_effect_of_stmt(stmt);
-        collect_spread_safe_symbols(stmt, &mut spread_safe);
+        update_spread_safe_symbols(stmt, &mut spread_safe, &ast_scopes);
         detail
       })
       .collect_vec()
@@ -1169,6 +1229,12 @@ mod test {
     assert!(get_statements_side_effect("({ ...getObj() })"));
     // let reassigned from plain object to something else is not safe
     assert!(get_statements_side_effect("let obj = { a: 1 }; obj = makeProxy(); ({ ...obj })"));
+    // Object.defineProperty can add getters, invalidating spread safety
+    assert!(get_statements_side_effect(
+      "const o = { a: 1 }; Object.defineProperty(o, 'x', { get() { return 1; } }); ({ ...o })"
+    ));
+    // Any function call with the symbol as argument invalidates it
+    assert!(get_statements_side_effect("const o = { a: 1 }; mutate(o); ({ ...o })"));
   }
 
   #[test]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -74,7 +74,7 @@ impl<'a> SideEffectDetector<'a> {
   /// initialized with a plain object literal.
   fn is_spread_safe_symbol(&self, ident: &IdentifierReference) -> bool {
     let Some(set) = self.spread_safe_symbol_ids else { return false };
-    let ref_id = ident.reference_id.get().unwrap();
+    let Some(ref_id) = ident.reference_id.get() else { return false };
     self.scope.symbol_id_for(ref_id).is_some_and(|sym| set.contains(&sym))
   }
 
@@ -1016,7 +1016,7 @@ impl<'a> SideEffectDetector<'a> {
 /// all simple `init` properties (no getters, setters, or methods with
 /// non-`init` kind). Such objects are safe to spread without triggering
 /// getters or Proxy traps.
-pub fn is_plain_object_literal(expr: &Expression) -> bool {
+pub(crate) fn is_plain_object_literal(expr: &Expression) -> bool {
   matches!(expr, Expression::ObjectExpression(obj)
     if !obj.properties.iter().any(|p| matches!(p,
       ast::ObjectPropertyKind::ObjectProperty(prop)
@@ -1040,10 +1040,13 @@ mod test {
   use super::{SideEffectDetector, is_plain_object_literal};
   use rolldown_common::FlatOptions;
 
-  /// Collect symbol IDs of variables initialized with plain object literals
+  /// Collect symbol IDs of const variables initialized with plain object literals
   /// from a variable declaration statement.
   fn collect_spread_safe_symbols(stmt: &Statement, set: &mut FxHashSet<SymbolId>) {
     if let Statement::VariableDeclaration(decl) = stmt {
+      if !matches!(decl.kind, oxc::ast::ast::VariableDeclarationKind::Const) {
+        return;
+      }
       for var_decl in &decl.declarations {
         if let BindingPattern::BindingIdentifier(binding) = &var_decl.id {
           if let Some(init) = &var_decl.init {
@@ -1140,9 +1143,10 @@ mod test {
 
   #[test]
   fn test_object_spread_side_effects() {
-    // Spreading a symbol initialized with a plain object literal is safe
+    // Spreading a const symbol initialized with a plain object literal is safe
     assert!(!get_statements_side_effect("const obj = { a: 1 }; ({ ...obj })"));
-    assert!(!get_statements_side_effect("let obj = { a: 1 }; ({ ...obj })"));
+    // let/var can be reassigned, so spreading them is not safe
+    assert!(get_statements_side_effect("let obj = { a: 1 }; ({ ...obj })"));
     // Spreading an inline object expression without getters is side-effect-free
     assert!(!get_statements_side_effect("({ ...{ a: 1, b: 2 } })"));
     // Object literal with spread of local var and extra properties
@@ -1163,6 +1167,10 @@ mod test {
     assert!(get_statements_side_effect("const obj = {}; ({ ...obj.inner })"));
     // Spreading a call expression has side effects (result could be Proxy)
     assert!(get_statements_side_effect("({ ...getObj() })"));
+    // let reassigned from plain object to something else is not safe
+    assert!(get_statements_side_effect(
+      "let obj = { a: 1 }; obj = makeProxy(); ({ ...obj })"
+    ));
   }
 
   #[test]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -56,7 +56,13 @@ impl<'a> SideEffectDetector<'a> {
     options: &'a SharedNormalizedBundlerOptions,
     side_effect_free_function_symbol_ref: Option<&'a FxHashSet<Address>>,
   ) -> Self {
-    Self { scope, options, flat_options, side_effect_free_function_symbol_ref, spread_safe_symbol_ids: None }
+    Self {
+      scope,
+      options,
+      flat_options,
+      side_effect_free_function_symbol_ref,
+      spread_safe_symbol_ids: None,
+    }
   }
 
   pub fn with_spread_safe_symbols(mut self, symbols: &'a FxHashSet<SymbolId>) -> Self {

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -8,6 +8,7 @@ use oxc::ast::ast::{
   VariableDeclarationKind,
 };
 use oxc::ast::{match_expression, match_member_expression};
+use oxc::semantic::SymbolId;
 use oxc::span::Ident;
 use oxc_allocator::{Address, UnstableAddress};
 use rolldown_common::{AstScopes, FlatOptions, SharedNormalizedBundlerOptions, SideEffectDetail};
@@ -42,6 +43,10 @@ pub struct SideEffectDetector<'a> {
   flat_options: FlatOptions,
   /// This field is only used for `LinkStage#cross_module_optimization`.
   side_effect_free_function_symbol_ref: Option<&'a FxHashSet<Address>>,
+  /// Symbols known to be initialized with plain object literals (no
+  /// getters/setters). When an object spread references one of these symbols,
+  /// we can treat the property reads as side-effect-free.
+  spread_safe_symbol_ids: Option<&'a FxHashSet<SymbolId>>,
 }
 
 impl<'a> SideEffectDetector<'a> {
@@ -51,7 +56,20 @@ impl<'a> SideEffectDetector<'a> {
     options: &'a SharedNormalizedBundlerOptions,
     side_effect_free_function_symbol_ref: Option<&'a FxHashSet<Address>>,
   ) -> Self {
-    Self { scope, options, flat_options, side_effect_free_function_symbol_ref }
+    Self { scope, options, flat_options, side_effect_free_function_symbol_ref, spread_safe_symbol_ids: None }
+  }
+
+  pub fn with_spread_safe_symbols(mut self, symbols: &'a FxHashSet<SymbolId>) -> Self {
+    self.spread_safe_symbol_ids = Some(symbols);
+    self
+  }
+
+  /// Check if the given identifier reference resolves to a symbol known to be
+  /// initialized with a plain object literal.
+  fn is_spread_safe_symbol(&self, ident: &IdentifierReference) -> bool {
+    let Some(set) = self.spread_safe_symbol_ids else { return false };
+    let ref_id = ident.reference_id.get().unwrap();
+    self.scope.symbol_id_for(ref_id).is_some_and(|sym| set.contains(&sym))
   }
 
   #[inline]
@@ -448,7 +466,29 @@ impl<'a> SideEffectDetector<'a> {
             // refer https://github.com/rollup/rollup/blob/f7633942/src/ast/nodes/SpreadElement.ts#L32
             ast::ObjectPropertyKind::SpreadProperty(res) => {
               if self.flat_options.property_read_side_effects() {
-                return true.into();
+                // Object spread reads all enumerable own properties from the
+                // argument, which can trigger getters or Proxy traps on
+                // arbitrary expressions. We treat a spread as safe only when we
+                // can verify the argument is a plain object:
+                //
+                // - If the argument is an identifier whose symbol was
+                //   initialized with a plain object literal (tracked via
+                //   `spread_safe_symbol_ids`), the property reads are safe.
+                // - If the argument is an inline object literal whose
+                //   properties are all simple `init` properties (no
+                //   getters/setters), the property reads are safe.
+                //
+                // This matches rollup's `propertyReadSideEffects: true`
+                // behavior, which uses value tracking to verify the argument
+                // is a plain object before treating the spread as side-effect
+                // free.
+                let is_safe = matches!(
+                  &res.argument,
+                  Expression::Identifier(ident) if self.is_spread_safe_symbol(ident)
+                ) || is_plain_object_literal(&res.argument);
+                if !is_safe {
+                  return true.into();
+                }
               }
               self.detect_side_effect_of_expr(&res.argument)
             }
@@ -966,17 +1006,49 @@ impl<'a> SideEffectDetector<'a> {
   }
 }
 
+/// Returns `true` if the expression is an object literal whose properties are
+/// all simple `init` properties (no getters, setters, or methods with
+/// non-`init` kind). Such objects are safe to spread without triggering
+/// getters or Proxy traps.
+pub fn is_plain_object_literal(expr: &Expression) -> bool {
+  matches!(expr, Expression::ObjectExpression(obj)
+    if !obj.properties.iter().any(|p| matches!(p,
+      ast::ObjectPropertyKind::ObjectProperty(prop)
+        if prop.kind != ast::PropertyKind::Init
+    ))
+  )
+}
+
 #[cfg(test)]
 mod test {
   use std::sync::Arc;
 
   use itertools::Itertools;
+  use oxc::ast::ast::{BindingPattern, Statement};
+  use oxc::semantic::SymbolId;
   use oxc::{parser::Parser, span::SourceType};
   use rolldown_common::{AstScopes, NormalizedBundlerOptions, SideEffectDetail};
   use rolldown_ecmascript::{EcmaAst, EcmaCompiler};
+  use rustc_hash::FxHashSet;
 
-  use super::SideEffectDetector;
+  use super::{SideEffectDetector, is_plain_object_literal};
   use rolldown_common::FlatOptions;
+
+  /// Collect symbol IDs of variables initialized with plain object literals
+  /// from a variable declaration statement.
+  fn collect_spread_safe_symbols(stmt: &Statement, set: &mut FxHashSet<SymbolId>) {
+    if let Statement::VariableDeclaration(decl) = stmt {
+      for var_decl in &decl.declarations {
+        if let BindingPattern::BindingIdentifier(binding) = &var_decl.id {
+          if let Some(init) = &var_decl.init {
+            if is_plain_object_literal(init) {
+              set.insert(binding.symbol_id());
+            }
+          }
+        }
+      }
+    }
+  }
 
   fn get_statements_side_effect(code: &str) -> bool {
     let source_type = SourceType::tsx();
@@ -987,10 +1059,14 @@ mod test {
 
     let options = Arc::new(NormalizedBundlerOptions::default());
     let flags = FlatOptions::from_shared_options(&options);
+    let mut spread_safe = FxHashSet::default();
     ast.program().body.iter().any(|stmt| {
-      SideEffectDetector::new(&ast_scopes, flags, &options, None)
+      let has_side_effect = SideEffectDetector::new(&ast_scopes, flags, &options, None)
+        .with_spread_safe_symbols(&spread_safe)
         .detect_side_effect_of_stmt(stmt)
-        .has_side_effect()
+        .has_side_effect();
+      collect_spread_safe_symbols(stmt, &mut spread_safe);
+      has_side_effect
     })
   }
 
@@ -1003,12 +1079,17 @@ mod test {
 
     let options = Arc::new(NormalizedBundlerOptions::default());
     let flags = FlatOptions::from_shared_options(&options);
+    let mut spread_safe = FxHashSet::default();
     ast
       .program()
       .body
       .iter()
       .map(|stmt| {
-        SideEffectDetector::new(&ast_scopes, flags, &options, None).detect_side_effect_of_stmt(stmt)
+        let detail = SideEffectDetector::new(&ast_scopes, flags, &options, None)
+          .with_spread_safe_symbols(&spread_safe)
+          .detect_side_effect_of_stmt(stmt);
+        collect_spread_safe_symbols(stmt, &mut spread_safe);
+        detail
       })
       .collect_vec()
   }
@@ -1049,6 +1130,33 @@ mod test {
         '-2':'BAIL'
       };",
     ));
+  }
+
+  #[test]
+  fn test_object_spread_side_effects() {
+    // Spreading a symbol initialized with a plain object literal is safe
+    assert!(!get_statements_side_effect("const obj = { a: 1 }; ({ ...obj })"));
+    assert!(!get_statements_side_effect("let obj = { a: 1 }; ({ ...obj })"));
+    // Spreading an inline object expression without getters is side-effect-free
+    assert!(!get_statements_side_effect("({ ...{ a: 1, b: 2 } })"));
+    // Object literal with spread of local var and extra properties
+    assert!(!get_statements_side_effect("const proto = { x: 1 }; ({ ...proto, tag: 'Utc' })"));
+    // Spreading an inline object with a getter HAS side effects
+    assert!(get_statements_side_effect("({ ...{ get prop() { sideEffect() } } })"));
+    // Spreading an inline object with a setter HAS side effects
+    assert!(get_statements_side_effect("({ ...{ set prop(v) { sideEffect() } } })"));
+    // Spreading a global/unresolved identifier has side effects
+    assert!(get_statements_side_effect("({ ...globalVar })"));
+    // Spreading a local Proxy has side effects (not a plain object literal init)
+    assert!(get_statements_side_effect(
+      "const p = new Proxy({}, { ownKeys() { return []; } }); ({ ...p })"
+    ));
+    // Spreading a local variable initialized by a function call has side effects
+    assert!(get_statements_side_effect("const obj = getObj(); ({ ...obj })"));
+    // Spreading a member expression has side effects (could trigger getters)
+    assert!(get_statements_side_effect("const obj = {}; ({ ...obj.inner })"));
+    // Spreading a call expression has side effects (result could be Proxy)
+    assert!(get_statements_side_effect("({ ...getObj() })"));
   }
 
   #[test]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -1168,9 +1168,7 @@ mod test {
     // Spreading a call expression has side effects (result could be Proxy)
     assert!(get_statements_side_effect("({ ...getObj() })"));
     // let reassigned from plain object to something else is not safe
-    assert!(get_statements_side_effect(
-      "let obj = { a: 1 }; obj = makeProxy(); ({ ...obj })"
-    ));
+    assert!(get_statements_side_effect("let obj = { a: 1 }; obj = makeProxy(); ({ ...obj })"));
   }
 
   #[test]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -1249,6 +1249,16 @@ mod test {
     assert!(get_statements_side_effect(
       "const o = { a: 1 }; o.__defineGetter__('x', function() { sideEffect(); }); ({ ...o })",
     ));
+    // Parenthesized expressions must not defeat the analysis
+    assert!(get_statements_side_effect("const o = { a: 1 }; mutate((o)); ({ ...o })"));
+    assert!(get_statements_side_effect(
+      "const o = { a: 1 }; (o).__defineGetter__('x', function() {}); ({ ...o })",
+    ));
+    // Sequence expressions (e.g. indirect call pattern) must not defeat the analysis
+    assert!(get_statements_side_effect(
+      "const o = { a: 1 }; (void 0, o).__defineGetter__('x', function() {}); ({ ...o })",
+    ));
+    assert!(get_statements_side_effect("const o = { a: 1 }; mutate((void 0, o)); ({ ...o })"));
   }
 
   #[test]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -1108,6 +1108,16 @@ mod test {
             }
           }
         }
+        // Also invalidate when the object is the receiver of a method call
+        if let Some(member) = call.callee.as_member_expression() {
+          if let Expression::Identifier(ident) = member.object() {
+            if let Some(ref_id) = ident.reference_id.get() {
+              if let Some(sym) = scopes.symbol_id_for(ref_id) {
+                set.remove(&sym);
+              }
+            }
+          }
+        }
         invalidate_call_args_in_expr(&call.callee, set, scopes);
       }
       Expression::SequenceExpression(seq) => {
@@ -1235,6 +1245,10 @@ mod test {
     ));
     // Any function call with the symbol as argument invalidates it
     assert!(get_statements_side_effect("const o = { a: 1 }; mutate(o); ({ ...o })"));
+    // A method call on the object as receiver can mutate it (e.g. by adding a getter)
+    assert!(get_statements_side_effect(
+      "const o = { a: 1 }; o.__defineGetter__('x', function() { sideEffect(); }); ({ ...o })",
+    ));
   }
 
   #[test]

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -1016,7 +1016,7 @@ impl<'a> SideEffectDetector<'a> {
 /// all simple `init` properties (no getters, setters, or methods with
 /// non-`init` kind). Such objects are safe to spread without triggering
 /// getters or Proxy traps.
-pub(crate) fn is_plain_object_literal(expr: &Expression) -> bool {
+pub fn is_plain_object_literal(expr: &Expression) -> bool {
   matches!(expr, Expression::ObjectExpression(obj)
     if !obj.properties.iter().any(|p| matches!(p,
       ast::ObjectPropertyKind::ObjectProperty(prop)

--- a/crates/rolldown/tests/rolldown/tree_shaking/object_spread_local_binding/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/object_spread_local_binding/_config.json
@@ -1,0 +1,4 @@
+{
+  "config": {},
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/object_spread_local_binding/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/object_spread_local_binding/artifacts.snap
@@ -1,0 +1,21 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+const used = {
+	typeId: "~test/Proto",
+	pipe() {
+		return this;
+	},
+	toJSON() {
+		return { _tag: this.typeId };
+	}
+}.typeId;
+//#endregion
+export { used };
+
+```

--- a/crates/rolldown/tests/rolldown/tree_shaking/object_spread_local_binding/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/object_spread_local_binding/main.js
@@ -1,0 +1,18 @@
+// Spreading a local binding should not be treated as having side effects.
+// This is the pattern used by libraries like Effect (effect-ts).
+const Proto = {
+  typeId: '~test/Proto',
+  pipe() {
+    return this;
+  },
+  toJSON() {
+    return { _tag: this.typeId };
+  },
+};
+
+// These should be tree-shaken: result unused and spread of local var is safe
+const ProtoUtc = { ...Proto, _tag: 'Utc' };
+const ProtoZoned = { ...Proto, _tag: 'Zoned' };
+
+// Only this should survive
+export const used = Proto.typeId;

--- a/crates/rolldown/tests/rolldown/tree_shaking/object_spread_local_binding/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/object_spread_local_binding/main.js
@@ -10,7 +10,7 @@ const Proto = {
   },
 };
 
-// These should be tree-shaken: result unused and spread of local var is safe
+// These bindings should be tree-shaken: ProtoUtc/ProtoZoned are unused and spread of a const plain object is safe
 const ProtoUtc = { ...Proto, _tag: 'Utc' };
 const ProtoZoned = { ...Proto, _tag: 'Zoned' };
 

--- a/crates/rolldown/tests/rolldown/tree_shaking/object_spread_with_getter/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/object_spread_with_getter/_config.json
@@ -1,0 +1,4 @@
+{
+  "config": {},
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/object_spread_with_getter/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/object_spread_with_getter/artifacts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+let result = "FAIL";
+({ ...{ get prop() {
+	result = "PASS";
+} } });
+//#endregion
+export { result };
+
+```

--- a/crates/rolldown/tests/rolldown/tree_shaking/object_spread_with_getter/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/object_spread_with_getter/main.js
@@ -1,0 +1,11 @@
+// Spreading an inline object with a getter SHOULD be preserved — it has side effects.
+let result = 'FAIL';
+const unused = {
+  ...{
+    get prop() {
+      result = 'PASS';
+    },
+  },
+};
+
+export { result };

--- a/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
+++ b/crates/rolldown/tests/snapshots/integration_rolldown__filename_with_hash.snap
@@ -6327,6 +6327,14 @@ expression: output
 - entry2-!~{001}~.js => entry2-C-aRH99N.js
 - classLike-!~{002}~.js => classLike-BfQGe2ZS.js
 
+# tests/rolldown/tree_shaking/object_spread_local_binding
+
+- main-!~{000}~.js => main-7ika18pw.js
+
+# tests/rolldown/tree_shaking/object_spread_with_getter
+
+- main-!~{000}~.js => main-BtbBORBR.js
+
 # tests/rolldown/tree_shaking/property_read_side_effects
 
 - main-!~{000}~.js => main-1kB9c516.js


### PR DESCRIPTION
Fixes #8582 (I think; I have some unrelated `oxc_minifier` panic that seems to not let me test in my real case...)

This gets rid of statements like `({ ...Foo })`.

I'm not a rust or rolldown expert, so bear with me.