### PR TITLE
refactor(watch): remove auto watch for fail imports

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -143,10 +143,6 @@ impl Bundle {
     &self.plugin_driver.watch_files
   }
 
-  pub fn get_missing_import_dirs(&self) -> &Arc<FxDashSet<ArcStr>> {
-    &self.plugin_driver.missing_import_dirs
-  }
-
   pub fn context(&self) -> BundleHandle {
     BundleHandle {
       options: Arc::clone(&self.options),

--- a/crates/rolldown/src/module_loader/resolve_utils.rs
+++ b/crates/rolldown/src/module_loader/resolve_utils.rs
@@ -1,4 +1,3 @@
-use std::path::Path;
 use std::sync::Arc;
 
 use arcstr::ArcStr;
@@ -101,8 +100,6 @@ pub async fn resolve_dependencies(
         let specifier = &dep.module_request;
         match e {
           ResolveError::NotFound(..) => {
-            track_missing_imports(plugin_driver, self_resolved_id.id.as_str(), specifier);
-
             // NOTE: IN_TRY_CATCH_BLOCK meta if it is a `require` import
             // record
             if !dep.meta.contains(ImportRecordMeta::InTryCatchBlock) {
@@ -183,24 +180,4 @@ pub async fn resolve_dependencies(
   }
 
   if build_errors.is_empty() { Ok(ret) } else { Err(build_errors.into()) }
-}
-
-/// Record the target directory of a missing relative import so the watcher
-/// can detect when a file is created there and trigger a rebuild.
-/// Only tracks relative specifiers (`./` / `../`) — absolute paths are not
-/// tracked because the ancestor fallback could watch overly broad system
-/// directories (e.g. `/opt`, `/usr`).
-fn track_missing_imports(plugin_driver: &PluginDriver, importer: &str, specifier: &str) {
-  if !ecmascript::is_relative_specifier(specifier) {
-    return;
-  }
-  let target_dir = Path::new(importer)
-    .parent()
-    .map(|d| d.join(specifier))
-    .and_then(|t| t.parent().map(Path::to_path_buf));
-  if let Some(dir) = target_dir {
-    if dir.parent().is_some() {
-      plugin_driver.missing_import_dirs.insert(dir.to_string_lossy().into());
-    }
-  }
 }

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -34,9 +34,6 @@ pub struct PluginDriver {
   hook_orders: PluginHookOrders,
   pub file_emitter: SharedFileEmitter,
   pub watch_files: Arc<FxDashSet<ArcStr>>,
-  /// Directories where a relative import failed to resolve (NotFound).
-  /// In watch mode, any `Create` event in these directories triggers a rebuild.
-  pub missing_import_dirs: Arc<FxDashSet<ArcStr>>,
   pub module_infos: SharedModuleInfoDashMap,
   /// Module dependencies tracked during load/transform hooks for HMR invalidation
   pub transform_dependencies: Arc<DashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
@@ -49,7 +46,6 @@ pub struct PluginDriver {
 impl PluginDriver {
   pub fn clear(&self) {
     self.watch_files.clear();
-    self.missing_import_dirs.clear();
     self.module_infos.clear();
     // Note: transform_dependencies is NOT cleared here - it's preserved across incremental builds
     // by BundleFactory which manages its lifecycle (reset on full builds only)

--- a/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
@@ -39,7 +39,6 @@ impl PluginDriverFactory {
     transform_dependencies: Arc<DashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
   ) -> Arc<crate::plugin_driver::PluginDriver> {
     let watch_files = Arc::new(FxDashSet::default());
-    let missing_import_dirs = Arc::new(FxDashSet::default());
     let meta = Arc::new(PluginContextMeta::default());
     let tx = Arc::new(tokio::sync::Mutex::new(None));
     let mut plugin_usage_vec = IndexVec::new();
@@ -101,7 +100,6 @@ impl PluginDriverFactory {
         contexts: index_contexts,
         file_emitter: Arc::clone(file_emitter),
         watch_files,
-        missing_import_dirs,
         module_infos,
         transform_dependencies,
         context_load_completion_manager: ContextLoadCompletionManager::default(),

--- a/crates/rolldown_watcher/src/watch_coordinator.rs
+++ b/crates/rolldown_watcher/src/watch_coordinator.rs
@@ -188,7 +188,7 @@ impl<H: WatcherEventHandler> WatchCoordinator<H> {
 
     if let Some(task) = self.tasks.get_mut(task_index) {
       for change in changes {
-        if task.mark_needs_rebuild(&change.path, change.kind) {
+        if task.mark_needs_rebuild(&change.path) {
           task.call_on_invalidate(&change.path).await;
           effective_changes.push(change);
         }

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -21,13 +21,6 @@ pub struct WatchTask {
   options: Arc<NormalizedBundlerOptions>,
   fs_watcher: std::sync::Mutex<DynFsWatcher>,
   watched_files: FxDashSet<ArcStr>,
-  /// Directories registered with the fs watcher for missing import detection.
-  /// Only used to avoid re-registering the same directory with notify.
-  registered_missing_dirs: FxDashSet<ArcStr>,
-  /// Active missing import directories from the latest build.
-  /// Refreshed each build from `plugin_driver.missing_import_dirs`.
-  /// Only directories in this set trigger rebuilds on `Create` events.
-  active_missing_dirs: FxDashSet<ArcStr>,
   pub(crate) needs_rebuild: bool,
 }
 
@@ -58,8 +51,6 @@ impl WatchTask {
       options,
       fs_watcher: std::sync::Mutex::new(fs_watcher),
       watched_files: FxDashSet::default(),
-      registered_missing_dirs: FxDashSet::default(),
-      active_missing_dirs: FxDashSet::default(),
       needs_rebuild: true,
     })
   }
@@ -78,13 +69,7 @@ impl WatchTask {
     // without conflicting with the &mut self borrow on bundler.
     let fs_watcher_ref = &self.fs_watcher;
     let watched_files_ref = &self.watched_files;
-    let registered_missing_dirs_ref = &self.registered_missing_dirs;
-    let active_missing_dirs_ref = &self.active_missing_dirs;
     let options_ref = &*self.options;
-
-    // Clear active missing dirs before rebuilding — will be repopulated from
-    // plugin_driver.missing_import_dirs during scan.
-    self.active_missing_dirs.clear();
 
     // Scope the bundler lock to minimize lock duration
     let (result, new_watch_files, bundle_handle) = {
@@ -110,16 +95,11 @@ impl WatchTask {
           // (so files are watched even on error — enables recovery when user fixes the issue)
           let watch_files: Vec<ArcStr> =
             bundle.get_watch_files().iter().map(|f| f.clone()).collect();
-          let new_missing_dirs: Vec<ArcStr> =
-            bundle.get_missing_import_dirs().iter().map(|f| f.clone()).collect();
           Self::update_watch_files_from(
             fs_watcher_ref,
             watched_files_ref,
-            registered_missing_dirs_ref,
-            active_missing_dirs_ref,
             options_ref,
             &watch_files,
-            &new_missing_dirs,
           )?;
 
           let scan_output = scan_result?;
@@ -144,8 +124,7 @@ impl WatchTask {
     };
 
     // Also register any files discovered during render/write phase
-    // (missing_import_dirs are only populated during scan, so pass empty here)
-    self.update_watch_files(&new_watch_files, &[])?;
+    self.update_watch_files(&new_watch_files)?;
 
     #[expect(clippy::cast_possible_truncation)]
     let duration = start_time.elapsed().as_millis() as u32;
@@ -174,16 +153,8 @@ impl WatchTask {
   }
 
   /// Update watched files by adding new ones to the fs watcher.
-  fn update_watch_files(&self, files: &[ArcStr], missing_dirs: &[ArcStr]) -> BuildResult<()> {
-    Self::update_watch_files_from(
-      &self.fs_watcher,
-      &self.watched_files,
-      &self.registered_missing_dirs,
-      &self.active_missing_dirs,
-      &self.options,
-      files,
-      missing_dirs,
-    )
+  fn update_watch_files(&self, files: &[ArcStr]) -> BuildResult<()> {
+    Self::update_watch_files_from(&self.fs_watcher, &self.watched_files, &self.options, files)
   }
 
   /// Static helper: update FS watcher with newly discovered files.
@@ -191,11 +162,8 @@ impl WatchTask {
   fn update_watch_files_from(
     fs_watcher: &std::sync::Mutex<DynFsWatcher>,
     watched_files: &FxDashSet<ArcStr>,
-    registered_missing_dirs: &FxDashSet<ArcStr>,
-    active_missing_dirs: &FxDashSet<ArcStr>,
     options: &NormalizedBundlerOptions,
     files: &[ArcStr],
-    new_missing_dirs: &[ArcStr],
   ) -> BuildResult<()> {
     let mut fs_watcher = fs_watcher.lock().expect("fs_watcher lock poisoned");
     let mut watcher_paths = fs_watcher.paths_mut();
@@ -229,71 +197,17 @@ impl WatchTask {
       }
     }
 
-    // Watch directories where imports failed to resolve, so we can detect
-    // when the missing file is created.
-    for dir in new_missing_dirs {
-      active_missing_dirs.insert(dir.clone());
-
-      if registered_missing_dirs.contains(dir.as_str()) {
-        continue;
-      }
-
-      // Find the nearest existing ancestor directory to watch. The target
-      // directory itself may not exist yet (e.g. `import './new-folder/file.js'`).
-      // Only mark as "registered" when we watch the exact target dir — if we
-      // fell back to an ancestor, we need to retry on the next build so that
-      // once the directory exists, we add a direct watch on it.
-      let dir_path = Path::new(dir.as_str());
-      let watch_path = std::iter::successors(Some(dir_path), |p| p.parent())
-        .filter(|p| p.parent().is_some()) // skip root dirs
-        .find(|p| p.exists());
-      if let Some(watch_path) = watch_path {
-        match watcher_paths.add(watch_path, RecursiveMode::NonRecursive) {
-          Ok(()) => {
-            tracing::debug!(name = "notify watch missing dir", target = ?dir_path, watching = ?watch_path);
-            if watch_path == dir_path {
-              registered_missing_dirs.insert(dir.clone());
-            }
-          }
-          Err(e) => {
-            tracing::debug!(name = "notify watch missing dir skipped", path = ?watch_path, error = ?e);
-          }
-        }
-      }
-    }
-
     watcher_paths.commit().map_err_to_unhandleable()?;
 
     Ok(())
   }
 
-  /// Mark this task as needing rebuild if the changed file is in our watch list
-  /// or (for Create events) if it was created in a directory with missing imports.
+  /// Mark this task as needing rebuild if the changed file is in our watch list.
   /// Returns `true` if the file is relevant to this task.
-  pub(crate) fn mark_needs_rebuild(&mut self, path: &str, kind: WatcherChangeKind) -> bool {
+  pub(crate) fn mark_needs_rebuild(&mut self, path: &str) -> bool {
     if self.is_watched_file(path) {
       self.needs_rebuild = true;
       return true;
-    }
-    // For Create events, check if the file was created in a directory where
-    // a relative import failed to resolve in the latest build, or if the
-    // created path itself is a missing directory (ancestor fallback case:
-    // when the target dir didn't exist, we watched an ancestor and need to
-    // detect the directory creation).
-    if kind == WatcherChangeKind::Create {
-      let event_path = Path::new(path);
-      // Check if the created path itself is a tracked missing directory
-      if self.active_missing_dirs.contains(event_path.to_string_lossy().as_ref()) {
-        self.needs_rebuild = true;
-        return true;
-      }
-      // Check if the file was created inside a tracked missing directory
-      if let Some(parent) = event_path.parent() {
-        if self.active_missing_dirs.contains(parent.to_string_lossy().as_ref()) {
-          self.needs_rebuild = true;
-          return true;
-        }
-      }
     }
     false
   }

--- a/examples/watch/hello.ts
+++ b/examples/watch/hello.ts
@@ -1,0 +1,3 @@
+export function hello(): void {
+  console.log('Hello, world!');
+}

--- a/examples/watch/index.ts
+++ b/examples/watch/index.ts
@@ -1,0 +1,5 @@
+import { hello } from './hello';
+
+console.log(hello());
+
+export default hello;

--- a/examples/watch/package.json
+++ b/examples/watch/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@example/typescript",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rolldown --config ./rolldown.config.js"
+  },
+  "devDependencies": {
+    "rolldown": "workspace:*"
+  }
+}

--- a/examples/watch/rolldown.config.js
+++ b/examples/watch/rolldown.config.js
@@ -1,0 +1,23 @@
+import { defineConfig } from 'rolldown';
+
+export default defineConfig({
+  input: {
+    entry: './index.ts',
+  },
+  resolve: {
+    // This needs to be explicitly set for now because oxc resolver doesn't
+    // assume default exports conditions. Rolldown will ship with a default that
+    // aligns with Vite in the future.
+    conditionNames: ['import'],
+  },
+  devtools: {},
+  plugins: [
+    {
+      name: 'test',
+      renderChunk(code) {
+        return code + '\n// test';
+      },
+    },
+  ],
+  watch: {},
+});

--- a/meta/design/watch-mode.md
+++ b/meta/design/watch-mode.md
@@ -310,30 +310,9 @@ The watcher uses `Bundler::with_cached_bundle_experimental()` to get `&mut Bundl
 
 This matches the legacy watcher's approach (`with_cached_bundle`), where `watch_files()` was called between scan and write phases.
 
-### Missing File Detection
+### Missing File Recovery
 
-When an import resolves to a non-existent file (e.g. `import './components/button.js'`), the build errors. Watch mode should detect when the missing file is later created and trigger a rebuild.
-
-**Challenge:** `notify` can't watch non-existent paths (unlike chokidar, which internally watches the parent directory).
-
-**Approach — directory-based tracking:**
-
-1. **Track target directories** (`resolve_utils.rs`): On `ResolveError::NotFound` for relative specifiers (`./`, `../`), join with the importer's directory then take the parent. Absolute specifiers are not tracked — the ancestor fallback could reach overly broad system directories (e.g. `/opt`, `/usr`). Root directories are also skipped. For `import './components/button.js'` from `/src/main.js`, this inserts `/src/components/`.
-
-2. **Watch directories** (`watch_task.rs`): After each build, directories from `plugin_driver.missing_import_dirs` are registered with the fs watcher using `NonRecursive` mode. If the target directory doesn't exist yet, the nearest existing ancestor is watched instead. The directory is only marked as "registered" when the actual target dir is watched — ancestor fallbacks are retried on the next build so that once the directory exists, a direct watch is added.
-
-3. **Rebuild on create** (`watch_task.rs`): `mark_needs_rebuild()` accepts the change kind. For `Create` events, it checks two conditions: (a) if the created path _itself_ is in `active_missing_dirs` (handles the case where a missing directory is created — ancestor watch detects this), or (b) if the created file's _parent_ is in `active_missing_dirs` (handles the case where a file is created in a watched missing directory). The resolver then re-attempts resolution — no path guessing needed.
-
-4. **Lifecycle**: Two sets track missing dirs at different scopes:
-   - `plugin_driver.missing_import_dirs` — cleared between rebuilds (via `plugin_driver.clear()`), repopulated during resolution. Reflects only the _current_ build's missing imports.
-   - `WatchTask.active_missing_dirs` — cleared at the start of each build and repopulated from the plugin driver's set. Only directories in this set trigger rebuilds on `Create` events, so once a missing import is resolved, its directory no longer triggers spurious rebuilds.
-   - `WatchTask.registered_missing_dirs` — tracks directories where a direct (non-ancestor) watch has been added with notify. Only populated when the actual target dir is watched, not when falling back to an ancestor.
-
-**Tradeoffs:**
-
-- While a missing import error persists, _any_ file creation in the target directory triggers a rebuild (spurious rebuilds). Acceptable because the build is already in an error state, debouncing limits frequency, and failed resolution is cheap.
-- Ancestor fallbacks may re-register the ancestor watch on each rebuild until the target directory exists. This is cheap and ensures correct behavior.
-- Goes beyond Rollup's behavior — Rollup only watches successfully loaded modules and relies on the importer being re-saved to discover new files.
+When an import resolves to a non-existent file, the build errors. Watch mode relies on the resolver cache being cleared before each rebuild (`bundler.clear_resolver_cache()`). The expected recovery workflow is: create the missing file, then manually edit a watched file (e.g. noop edit to the importer) to trigger a rebuild. The resolver re-evaluates the import with a fresh cache and succeeds. This matches Rollup's behavior — Rollup only watches successfully loaded modules.
 
 ### Notify Event Mapping
 

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -1132,8 +1132,10 @@ test.concurrent(
     await editFile(path.join(cwd, 'main.js'), `import { foo } from './foo.js'\nconsole.log(foo)`);
     await expect.poll(() => errors.length).toBeGreaterThan(0);
 
-    // Create the missing file — should trigger a successful rebuild
+    // Create the missing file, then do a noop edit to main.js to trigger rebuild
+    // (the missing file's directory is not auto-watched, so we need to touch a watched file)
     await editFile(path.join(cwd, 'foo.js'), `export const foo = 'added'`);
+    await editFile(path.join(cwd, 'main.js'), `import { foo } from './foo.js'\nconsole.log(foo)`);
     await waitBuildFinished(watcher);
 
     const output = path.join(cwd, 'dist', 'main.js');
@@ -1173,9 +1175,11 @@ test.concurrent(
     await editFile(path.join(cwd, 'main.js'), `import { foo } from './foo.js'\nconsole.log(foo)`);
     await expect.poll(() => errors.length).toBeGreaterThan(0);
 
-    // Rename bar.js to foo.js — should trigger a successful rebuild
+    // Rename bar.js to foo.js, then do a noop edit to main.js to trigger rebuild
+    // (the missing file's directory is not auto-watched, so we need to touch a watched file)
     await sleep(1000);
     fs.renameSync(path.join(cwd, 'bar.js'), path.join(cwd, 'foo.js'));
+    await editFile(path.join(cwd, 'main.js'), `import { foo } from './foo.js'\nconsole.log(foo)`);
     await waitBuildFinished(watcher);
 
     const output = path.join(cwd, 'dist', 'main.js');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rolldown
 
+  examples/watch:
+    devDependencies:
+      rolldown:
+        specifier: workspace:*
+        version: link:../../packages/rolldown
+
   packages/bench:
     dependencies:
       react:


### PR DESCRIPTION
Partially reverts https://github.com/rolldown/rolldown/pull/8562 but still keeps the fix for https://github.com/rolldown/rolldown/pull/8560