### PR TITLE
ci: move Windows cargo target dir to Dev Drive

### DIFF
--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -26,18 +26,19 @@ jobs:
       - uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
         if: runner.os == 'Windows'
         with:
-          drive-size: 8GB
+          drive-size: 12GB
           drive-format: ReFS
           env-mapping: |
             CARGO_HOME,{{ DEV_DRIVE }}/.cargo
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
 
       - name: Setup Rust
-        uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12
+        uses: oxc-project/setup-rust@b21cce724d9e8c4131b316d350790f7a5b8c91c0 # v1.0.14
         with:
           tools: just
           cache-key: cargo-test
           save-cache: ${{ github.ref_name == 'main' }}
+          target-dir: ${{ runner.os == 'Windows' && format('{0}/target', env.DEV_DRIVE) || '' }}
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
 

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -26,18 +26,19 @@ jobs:
       - uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
         if: runner.os == 'Windows'
         with:
-          drive-size: 8GB
+          drive-size: 12GB
           drive-format: ReFS
           env-mapping: |
             CARGO_HOME,{{ DEV_DRIVE }}/.cargo
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
 
       - name: Setup Rust
-        uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12
+        uses: oxc-project/setup-rust@b21cce724d9e8c4131b316d350790f7a5b8c91c0 # v1.0.14
         with:
           tools: just
           cache-key: native-build
           save-cache: ${{ github.ref_name == 'main' }}
+          target-dir: ${{ runner.os == 'Windows' && format('{0}/target', env.DEV_DRIVE) || '' }}
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
 


### PR DESCRIPTION
## Summary

- Move `target/` directory to the Dev Drive on Windows CI for faster compilation I/O
- Upgrade `oxc-project/setup-rust` to v1.0.14 which adds `target-dir` input support
- Increase Dev Drive size from 8GB to 12GB to accommodate target artifacts

Windows CI builds are ~1.7x slower than Linux partly due to slow C: drive I/O for compilation artifacts. The Dev Drive (ReFS) provides significantly faster I/O ([actions/runner-images#8755](https://github.com/actions/runner-images/issues/8755)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)