### PR TITLE
ci: move Windows cargo target dir to Dev Drive

### DIFF
--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -33,7 +33,7 @@ jobs:
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
 
       - name: Setup Rust
-        uses: oxc-project/setup-rust@b21cce724d9e8c4131b316d350790f7a5b8c91c0 # v1.0.14
+        uses: oxc-project/setup-rust@4f86b5d871ae7d24bc420e578be68964ab09e5cc # v1.0.0
         with:
           tools: just
           cache-key: cargo-test

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -33,7 +33,7 @@ jobs:
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
 
       - name: Setup Rust
-        uses: oxc-project/setup-rust@b21cce724d9e8c4131b316d350790f7a5b8c91c0 # v1.0.14
+        uses: oxc-project/setup-rust@4f86b5d871ae7d24bc420e578be68964ab09e5cc # v1.0.0
         with:
           tools: just
           cache-key: native-build


### PR DESCRIPTION
## Summary

- Move the cargo `target` directory to the Dev Drive on Windows CI to improve build performance
- Bump `setup-rust` to `oxc-project/setup-rust@4f86b5d` which fixes rust-cache using `path.join` on absolute `target-dir` paths (producing incorrect cache paths like `D:\a\rolldown\rolldown\E:\target`)
- Use the new `target-dir` input to pass the Dev Drive target path directly, so the cache configuration correctly shows `E:\target`
- Increase Dev Drive size from 8GB to 12GB to accommodate the target directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)