### PR TITLE
ci: add PNPM_HOME Dev Drive mapping to Windows CI workflows

### DIFF
--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -31,6 +31,7 @@ jobs:
           env-mapping: |
             CARGO_HOME,{{ DEV_DRIVE }}/.cargo
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
+            PNPM_HOME,{{ DEV_DRIVE }}/.pnpm
 
       - name: Setup Rust
         uses: oxc-project/setup-rust@4f86b5d871ae7d24bc420e578be68964ab09e5cc # v1.0.15

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -31,6 +31,7 @@ jobs:
           env-mapping: |
             CARGO_HOME,{{ DEV_DRIVE }}/.cargo
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
+            PNPM_HOME,{{ DEV_DRIVE }}/.pnpm
 
       - name: Setup Rust
         uses: oxc-project/setup-rust@4f86b5d871ae7d24bc420e578be68964ab09e5cc # v1.0.15

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -28,6 +28,14 @@ jobs:
           submodules: true # Pull submodules for additional files
           persist-credentials: false
 
+      - uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
+        if: runner.os == 'Windows'
+        with:
+          drive-size: 12GB
+          drive-format: ReFS
+          env-mapping: |
+            PNPM_HOME,{{ DEV_DRIVE }}/.pnpm
+
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
 
       - name: Download Native Rolldown Build


### PR DESCRIPTION
## Summary

- Add `PNPM_HOME` to the Dev Drive env-mapping in `reusable-native-build.yml` and `reusable-cargo-test.yml`
- Add `setup-dev-drive` with `PNPM_HOME` mapping to `reusable-node-test.yml` (which previously had no Dev Drive setup)
- Improves pnpm performance on Windows CI by placing the pnpm store on the Dev Drive (ReFS + Defender exclusion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)