### PR TITLE
docs: add `format` option to directives example config

### DIFF
--- a/docs/in-depth/directives.md
+++ b/docs/in-depth/directives.md
@@ -21,6 +21,7 @@ import { defineConfig } from 'rolldown';
 
 export default defineConfig({
   output: {
+    format: 'cjs',
     strict: true,
   },
 });


### PR DESCRIPTION
> The config example sets `output.strict: true` but doesn’t set `output.format`. Since `output.format` defaults to `'es'`, this example won’t actually emit a `"use strict"` directive (ESM is always strict and Rolldown doesn’t output the directive). Consider setting a non-ES format (e.g. `'cjs'`) in the example, or explicitly stating that the example assumes a non-ES output format.
> ```suggestion
>   output: {
>     format: 'cjs',
> ``` 

 _Originally posted by @Copilot in [#8535](https://github.com/rolldown/rolldown/pull/8535/changes#r2880787295)_