### PR TITLE
fix(rust): circular inter-chunk imports when external dynamic imports exist

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -32,6 +32,10 @@ pub struct ChunkGraph {
   ///
   /// We use the second approach to avoid the overhead of re-indexing at the cost of some extra memory.
   pub post_chunk_optimization_operations: FxHashMap<ChunkIdx, PostChunkOptimizationOperation>,
+  /// Maps entry bit positions to their corresponding ChunkIdx.
+  /// Needed because external module entries are skipped during chunk creation,
+  /// causing bit positions (from enumerate) to not match chunk indices.
+  pub bit_to_chunk_idx: Vec<Option<ChunkIdx>>,
 }
 
 impl ChunkGraph {
@@ -46,6 +50,7 @@ impl ChunkGraph {
       common_chunk_exported_facade_chunk_namespace: FxHashMap::default(),
       common_chunk_preserve_export_names_modules: FxHashMap::default(),
       post_chunk_optimization_operations: FxHashMap::default(),
+      bit_to_chunk_idx: Vec::new(),
     }
   }
 

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -354,9 +354,15 @@ impl GenerateStage<'_> {
         }
         let chunk_idxs: Vec<_> = bits
           .index_of_one()
-          .map(ChunkIdx::from_raw)
-          // Some of the bits maybe not created yet, so filter it out.
-          // refer https://github.com/rolldown/rolldown/blob/d373794f5ce5b793ac751bbfaf101cc9cdd261d9/crates/rolldown/src/stages/generate_stage/code_splitting.rs?plain=1#L311-L313
+          // Use bit_to_chunk_idx to correctly map bit positions to chunk indices.
+          // Bit positions may not match chunk indices when external module entries
+          // are skipped during chunk creation.
+          .filter_map(|bit| {
+            chunk_graph
+              .bit_to_chunk_idx
+              .get(bit as usize)
+              .and_then(|idx| *idx)
+          })
           .filter(|idx| entry_chunk_idx.contains(idx))
           .collect();
 

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -315,8 +315,6 @@ impl GenerateStage<'_> {
     let static_entry_chunk_reference: FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>> =
       self.construct_static_entry_to_reached_dynamic_entries_map(chunk_graph);
 
-    let entry_chunk_idx =
-      chunk_graph.chunk_table.iter_enumerated().map(|(idx, _)| idx).collect::<FxHashSet<_>>();
     // Calculate on demand to avoid add a new field on each NormalModule.
     let dynamic_entry_to_dynamic_importers: FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>> = {
       // Get dynamic entry modules from chunk_table, then find matched entry points
@@ -358,7 +356,6 @@ impl GenerateStage<'_> {
           // Bit positions may not match chunk indices when external module entries
           // are skipped during chunk creation.
           .filter_map(|bit| chunk_graph.bit_to_chunk_idx.get(bit as usize).and_then(|idx| *idx))
-          .filter(|idx| entry_chunk_idx.contains(idx))
           .collect();
 
         let merge_target = Self::try_insert_into_existing_chunk(

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -357,12 +357,7 @@ impl GenerateStage<'_> {
           // Use bit_to_chunk_idx to correctly map bit positions to chunk indices.
           // Bit positions may not match chunk indices when external module entries
           // are skipped during chunk creation.
-          .filter_map(|bit| {
-            chunk_graph
-              .bit_to_chunk_idx
-              .get(bit as usize)
-              .and_then(|idx| *idx)
-          })
+          .filter_map(|bit| chunk_graph.bit_to_chunk_idx.get(bit as usize).and_then(|idx| *idx))
           .filter(|idx| entry_chunk_idx.contains(idx))
           .collect();
 

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -698,6 +698,9 @@ impl GenerateStage<'_> {
     entries_len: u32,
     input_base: &ArcStr,
   ) {
+    // Pre-allocate bit_to_chunk_idx mapping for all entry positions
+    chunk_graph.bit_to_chunk_idx = vec![None; entries_len as usize];
+
     // Create chunk for each static and dynamic entry
     for (entry_index, (&module_idx, entry_point)) in self
       .link_output
@@ -771,6 +774,10 @@ impl GenerateStage<'_> {
         self.options,
       );
       let chunk_idx = chunk_graph.add_chunk(chunk);
+      // Record the mapping from bit position to chunk index.
+      // External entries are skipped (no chunk created), so bit positions may not match chunk indices.
+      chunk_graph.bit_to_chunk_idx[entry_index] = Some(chunk_idx);
+
       if let Some(reference_ids) = self.link_output.entry_point_to_reference_ids.get(entry_point) {
         chunk_graph.chunk_idx_to_reference_ids.insert(chunk_idx, reference_ids.clone());
       }

--- a/crates/rolldown/tests/rolldown/issues/8595/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8595/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "input": [
+      { "name": "index1", "import": "index1.js" },
+      { "name": "index2", "import": "index2.js" }
+    ],
+    "external": [
+      "@prettier/plugin-oxc",
+      "@prettier/plugin-hermes",
+      "prettier-plugin-astro",
+      "prettier-plugin-marko"
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8595/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8595/_test.mjs
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+// Before the fix, external dynamic imports (@prettier/plugin-oxc, etc.)
+// caused bit-position/chunk-index mismatches, producing a circular static
+// import: babel.js <-> tt.js
+//
+// Expected: tt.js imports babel.js (not the reverse).
+// babel.js should import from chunk.js (the runtime chunk), not tt.js.
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const babel = fs.readFileSync(path.join(distDir, 'babel.js'), 'utf8');
+
+assert(
+  !babel.includes('from "./tt.js"'),
+  'babel.js should not import from tt.js (would create a cycle)',
+);

--- a/crates/rolldown/tests/rolldown/issues/8595/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8595/artifacts.snap
@@ -1,0 +1,140 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## acorn.js
+
+```js
+//#region plugins/acorn.mjs
+var acorn_default = {};
+//#endregion
+export { acorn_default as default };
+
+```
+
+## babel.js
+
+```js
+import { t as __exportAll } from "./chunk.js";
+//#region plugins/babel.mjs
+var babel_exports = /* @__PURE__ */ __exportAll({
+	default: () => Ks,
+	parsers: () => ra
+});
+var Ks = {};
+var ra = {};
+Ks.parsers = ra;
+//#endregion
+export { babel_exports as t };
+
+```
+
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as t };
+
+```
+
+## flow.js
+
+```js
+//#region plugins/flow.mjs
+var flow_default = {};
+//#endregion
+export { flow_default as default };
+
+```
+
+## glimmer.js
+
+```js
+//#region plugins/glimmer.mjs
+var glimmer_default = {};
+//#endregion
+export { glimmer_default as default };
+
+```
+
+## html.js
+
+```js
+//#region plugins/html.mjs
+var html_default = {};
+//#endregion
+export { html_default as default };
+
+```
+
+## index1.js
+
+```js
+//#region index1.js
+function a() {
+	import("./tt.js");
+}
+//#endregion
+export { a };
+
+```
+
+## index2.js
+
+```js
+import { a } from "./index1.js";
+export { a };
+
+```
+
+## meriyah.js
+
+```js
+//#region plugins/meriyah.mjs
+var meriyah_default = {};
+//#endregion
+export { meriyah_default as default };
+
+```
+
+## postcss.js
+
+```js
+import { t as __exportAll } from "./chunk.js";
+//#region plugins/postcss.mjs
+var postcss_exports = /* @__PURE__ */ __exportAll({ default: () => _l });
+var _l = {};
+_l.parsers = {};
+//#endregion
+export { postcss_exports as t };
+
+```
+
+## tt.js
+
+```js
+import { t as babel_exports } from "./babel.js";
+import { t as postcss_exports } from "./postcss.js";
+//#region tt.mjs
+import("./babel.js");
+import("./flow.js");
+import("./glimmer.js");
+import("./html.js");
+import("./postcss.js");
+const a = [
+	import("./html.js"),
+	import("./glimmer.js"),
+	import("./meriyah.js"),
+	import("./acorn.js"),
+	import("./flow.js")
+];
+import("@prettier/plugin-oxc");
+import("@prettier/plugin-hermes");
+import("prettier-plugin-astro");
+import("prettier-plugin-marko");
+const options = [postcss_exports, babel_exports];
+//#endregion
+export { a, options };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/8595/index1.js
+++ b/crates/rolldown/tests/rolldown/issues/8595/index1.js
@@ -1,0 +1,3 @@
+export function a() {
+  import('./tt.mjs');
+}

--- a/crates/rolldown/tests/rolldown/issues/8595/index2.js
+++ b/crates/rolldown/tests/rolldown/issues/8595/index2.js
@@ -1,0 +1,1 @@
+export { a } from './index1.js';

--- a/crates/rolldown/tests/rolldown/issues/8595/plugins/acorn.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8595/plugins/acorn.mjs
@@ -1,0 +1,1 @@
+export default {};

--- a/crates/rolldown/tests/rolldown/issues/8595/plugins/angular.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8595/plugins/angular.mjs
@@ -1,0 +1,1 @@
+export default {};

--- a/crates/rolldown/tests/rolldown/issues/8595/plugins/babel.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8595/plugins/babel.mjs
@@ -1,0 +1,4 @@
+var Ks = {};
+var ra = {};
+Ks.parsers = ra;
+export { Ks as default, ra as parsers };

--- a/crates/rolldown/tests/rolldown/issues/8595/plugins/flow.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8595/plugins/flow.mjs
@@ -1,0 +1,1 @@
+export default {};

--- a/crates/rolldown/tests/rolldown/issues/8595/plugins/glimmer.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8595/plugins/glimmer.mjs
@@ -1,0 +1,1 @@
+export default {};

--- a/crates/rolldown/tests/rolldown/issues/8595/plugins/html.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8595/plugins/html.mjs
@@ -1,0 +1,1 @@
+export default {};

--- a/crates/rolldown/tests/rolldown/issues/8595/plugins/meriyah.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8595/plugins/meriyah.mjs
@@ -1,0 +1,1 @@
+export default {};

--- a/crates/rolldown/tests/rolldown/issues/8595/plugins/postcss.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8595/plugins/postcss.mjs
@@ -1,0 +1,3 @@
+var _l = {};
+_l.parsers = {};
+export { _l as default };

--- a/crates/rolldown/tests/rolldown/issues/8595/tt.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8595/tt.mjs
@@ -1,0 +1,20 @@
+import * as prettierParserBabel from './plugins/babel.mjs';
+import * as prettierParserCss from './plugins/postcss.mjs';
+import('./plugins/babel.mjs');
+import('./plugins/flow.mjs');
+import('./plugins/glimmer.mjs');
+import('./plugins/html.mjs');
+import('./plugins/postcss.mjs');
+export const a = [
+  import('./plugins/html.mjs'),
+  import('./plugins/glimmer.mjs'),
+  import('./plugins/meriyah.mjs'),
+  import('./plugins/acorn.mjs'),
+  import('./plugins/flow.mjs'),
+];
+import('@prettier/plugin-oxc');
+import('@prettier/plugin-hermes');
+import('prettier-plugin-astro');
+import('prettier-plugin-marko');
+
+export const options = [prettierParserCss, prettierParserBabel];

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/_config.json
@@ -1,0 +1,9 @@
+{
+  "config": {
+    "input": [
+      { "name": "entry-a", "import": "entry-a.js" },
+      { "name": "entry-b", "import": "entry-b.js" }
+    ],
+    "external": ["@optional/ext"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/_test.mjs
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+// Before the fix, external dynamic imports (`@optional/ext`) caused
+// bit-position/chunk-index mismatches in the chunk optimizer, producing
+// a circular static import: parser-a.js <-> plugin.js
+//
+// Expected: plugin.js imports parser-a.js (not the reverse)
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const parserA = fs.readFileSync(path.join(distDir, 'parser-a.js'), 'utf8');
+
+assert(
+  !parserA.includes('from "./plugin.js"'),
+  'parser-a.js should not import from plugin.js (would create a cycle)',
+);

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/apis.js
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/apis.js
@@ -1,0 +1,5 @@
+export async function format(code) {
+  let pl = await import('./plugin.js');
+  let core = await import('./core.js');
+  return core.run(pl.transform(code));
+}

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/artifacts.snap
@@ -1,0 +1,124 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## apis.js
+
+```js
+//#region apis.js
+async function format(code) {
+	let pl = await import("./plugin.js");
+	return (await import("./core.js")).run(pl.transform(code));
+}
+//#endregion
+export { format as t };
+
+```
+
+## core.js
+
+```js
+//#region core.js
+async function run(code) {
+	let pa = await import("./parser-a.js");
+	let pb = await import("./parser-b.js");
+	let pc = await import("./parser-c.js");
+	return pa.parse(code) + pb.parse(code) + pc.parse(code);
+}
+//#endregion
+export { run };
+
+```
+
+## entry-a.js
+
+```js
+import { t as format } from "./apis.js";
+//#region entry-a.js
+const a = () => format("a");
+//#endregion
+export { a };
+
+```
+
+## entry-b.js
+
+```js
+import { t as format } from "./apis.js";
+//#region entry-b.js
+const b = () => format("b");
+//#endregion
+export { b };
+
+```
+
+## parser-a.js
+
+```js
+import { t as helper } from "./shared.js";
+//#region parser-a.js
+function parse(x) {
+	return helper("a" + x);
+}
+//#endregion
+export { parse };
+
+```
+
+## parser-b.js
+
+```js
+import { t as helper } from "./shared.js";
+//#region parser-b.js
+function parse(x) {
+	return helper("b" + x);
+}
+//#endregion
+export { parse };
+
+```
+
+## parser-c.js
+
+```js
+import { t as helper } from "./shared.js";
+//#region parser-c.js
+function parse(x) {
+	return helper("c" + x);
+}
+//#endregion
+export { parse };
+
+```
+
+## plugin.js
+
+```js
+import { parse } from "./parser-a.js";
+import { parse as parse$1 } from "./parser-b.js";
+import { parse as parse$2 } from "./parser-c.js";
+//#region plugin.js
+async function opt() {
+	await import("@optional/ext");
+}
+function transform(code) {
+	opt();
+	return parse(code) + parse$1(code) + parse$2(code);
+}
+//#endregion
+export { transform };
+
+```
+
+## shared.js
+
+```js
+//#region shared.js
+function helper(x) {
+	return x.toUpperCase();
+}
+//#endregion
+export { helper as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/core.js
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/core.js
@@ -1,0 +1,6 @@
+export async function run(code) {
+  let pa = await import('./parser-a.js');
+  let pb = await import('./parser-b.js');
+  let pc = await import('./parser-c.js');
+  return pa.parse(code) + pb.parse(code) + pc.parse(code);
+}

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/entry-a.js
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/entry-a.js
@@ -1,0 +1,2 @@
+import { format } from './apis.js';
+export const a = () => format('a');

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/entry-b.js
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/entry-b.js
@@ -1,0 +1,2 @@
+import { format } from './apis.js';
+export const b = () => format('b');

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/parser-a.js
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/parser-a.js
@@ -1,0 +1,4 @@
+import { helper } from './shared.js';
+export function parse(x) {
+  return helper('a' + x);
+}

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/parser-b.js
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/parser-b.js
@@ -1,0 +1,4 @@
+import { helper } from './shared.js';
+export function parse(x) {
+  return helper('b' + x);
+}

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/parser-c.js
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/parser-c.js
@@ -1,0 +1,4 @@
+import { helper } from './shared.js';
+export function parse(x) {
+  return helper('c' + x);
+}

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/plugin.js
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/plugin.js
@@ -1,0 +1,10 @@
+import { parse as pa } from './parser-a.js';
+import { parse as pb } from './parser-b.js';
+import { parse as pc } from './parser-c.js';
+async function opt() {
+  await import('@optional/ext');
+}
+export function transform(code) {
+  opt();
+  return pa(code) + pb(code) + pc(code);
+}

--- a/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/shared.js
+++ b/crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/shared.js
@@ -1,0 +1,3 @@
+export function helper(x) {
+  return x.toUpperCase();
+}

--- a/crates/rolldown_utils/src/bitset.rs
+++ b/crates/rolldown_utils/src/bitset.rs
@@ -11,7 +11,11 @@ impl BitSet {
   }
 
   pub fn has_bit(&self, bit: u32) -> bool {
-    (self.entries[bit as usize / 8] & (1 << (bit & 7))) != 0
+    let idx = bit as usize / 8;
+    if idx >= self.entries.len() {
+      return false;
+    }
+    (self.entries[idx] & (1 << (bit & 7))) != 0
   }
 
   pub fn set_bit(&mut self, bit: u32) {

--- a/crates/rolldown_utils/src/bitset.rs
+++ b/crates/rolldown_utils/src/bitset.rs
@@ -227,4 +227,13 @@ mod tests {
     let empty: BitSet = std::iter::empty().collect();
     assert!(empty.is_empty());
   }
+
+  #[test]
+  fn has_bit_out_of_bounds() {
+    let bs = BitSet::new(0);
+    assert!(!bs.has_bit(0));
+
+    let bs = BitSet::new(1);
+    assert!(!bs.has_bit(100));
+  }
 }

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -6,23 +6,25 @@ Code splitting determines which modules go into which output chunks. It uses a B
 
 ## Pipeline
 
+The entry point is `generate_chunks()` in `code_splitting.rs`, called from `GenerateStage::generate()`.
+
 ```
-LinkStageOutput.entries
+generate_chunks()
     │
-    ▼
-init_entry_point()          Assign bit positions, create entry chunks
+    ├─ init_entry_point()             Assign bit positions, create entry chunks
     │
-    ▼
-determine_reachable_modules_for_entry()   BFS per entry, set bits on reachable modules
-    │
-    ▼
-split_chunks()              Group modules by identical BitSet → chunks
-    │
-    ▼
-ChunkOptimizer              Merge common chunks into entry chunks, remove empty facades
-    │
-    ▼
-ChunkGraph                  Final module-to-chunk assignment
+    └─ split_chunks()
+         │
+         ├─ determine_reachable_modules_for_entry()   BFS per entry, set bits on reachable modules
+         │
+         ├─ apply_manual_code_splitting()             User-defined chunk groups (manualChunks)
+         │
+         ├─ Module assignment         Group modules by identical BitSet → chunks
+         │
+         └─ ChunkOptimizer           Merge common chunks into entry chunks, remove empty facades
+              │
+              ▼
+         ChunkGraph                   Final module-to-chunk assignment
 ```
 
 **Key files:**
@@ -63,10 +65,10 @@ entry-a.js:   bits = 0001  (only reachable from entry 0)
 
 ## Chunk Creation
 
-`split_chunks()` groups modules by identical `bits` patterns:
+After reachability propagation, `split_chunks()` assigns modules to chunks by their `bits` pattern:
 
 1. Entry chunks already exist from `init_entry_point()` with their single-bit patterns
-2. For each non-entry module, look up `bits_to_chunk[module.bits]`
+2. For each non-entry module (iterated in `sorted_modules` order), look up `bits_to_chunk[module.bits]`
 3. If a chunk exists for that pattern, add the module to it
 4. Otherwise, create a new `Common` chunk
 

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -1,0 +1,117 @@
+# Code Splitting
+
+## Summary
+
+Code splitting determines which modules go into which output chunks. It uses a BitSet-based reachability model: each entry point gets a bit position, modules are marked with the set of entries that can reach them, and modules with identical reachability patterns are grouped into the same chunk. An optimization pass then merges small common chunks into entry chunks when safe.
+
+## Pipeline
+
+```
+LinkStageOutput.entries
+    │
+    ▼
+init_entry_point()          Assign bit positions, create entry chunks
+    │
+    ▼
+determine_reachable_modules_for_entry()   BFS per entry, set bits on reachable modules
+    │
+    ▼
+split_chunks()              Group modules by identical BitSet → chunks
+    │
+    ▼
+ChunkOptimizer              Merge common chunks into entry chunks, remove empty facades
+    │
+    ▼
+ChunkGraph                  Final module-to-chunk assignment
+```
+
+**Key files:**
+
+- `crates/rolldown/src/stages/generate_stage/code_splitting.rs` — pipeline orchestration
+- `crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs` — merge/optimization
+- `crates/rolldown/src/chunk_graph.rs` — output data structure
+- `crates/rolldown_utils/src/bitset.rs` — compact reachability representation
+
+## Bit Positions and Entry Points
+
+`init_entry_point()` iterates `link_output.entries` (an `FxIndexMap<ModuleIdx, Vec<EntryPoint>>`), assigning each entry a sequential bit position via `.enumerate()`:
+
+```
+entry_index 0  →  entry-a.js      →  bit 0  →  ChunkIdx(0)
+entry_index 1  →  entry-b.js      →  bit 1  →  ChunkIdx(1)
+entry_index 2  →  @optional/ext   →  bit 2  →  (external, no chunk)
+entry_index 3  →  plugin.js       →  bit 3  →  ChunkIdx(2)
+```
+
+External modules get bit positions but no chunks. This means **bit positions do not equal chunk indices**. The mapping is stored in `chunk_graph.bit_to_chunk_idx: Vec<Option<ChunkIdx>>` — `None` for external entries, `Some(idx)` for real chunks.
+
+### Invariant
+
+Any code converting a bit position to a `ChunkIdx` **must** use `bit_to_chunk_idx`, not `ChunkIdx::from_raw(bit_position)`. Violating this produces wrong chunk assignments when external entries exist.
+
+## Reachability Propagation
+
+`determine_reachable_modules_for_entry()` runs BFS from each entry module, setting `splitting_info[module].bits.set_bit(entry_index)` on every reachable module.
+
+After all entries are processed, each module's `bits` encodes which entries can reach it:
+
+```
+shared.js:    bits = 1111  (reachable from all 4 entries)
+parser-a.js:  bits = 1010  (reachable from entries 1 and 3)
+entry-a.js:   bits = 0001  (only reachable from entry 0)
+```
+
+## Chunk Creation
+
+`split_chunks()` groups modules by identical `bits` patterns:
+
+1. Entry chunks already exist from `init_entry_point()` with their single-bit patterns
+2. For each non-entry module, look up `bits_to_chunk[module.bits]`
+3. If a chunk exists for that pattern, add the module to it
+4. Otherwise, create a new `Common` chunk
+
+Modules with the same reachability pattern always land in the same chunk. This is the core invariant that makes code splitting correct.
+
+## Chunk Optimizer
+
+When enabled, the optimizer reduces chunk count by merging common chunks into entry chunks. It operates on a temporary `ChunkOptimizationGraph`.
+
+### Common Module Merging (`try_insert_common_module_to_exist_chunk`)
+
+For each common chunk, translates its `bits` to chunk indices via `bit_to_chunk_idx`, then tries to merge it into one of those entry chunks. Merging is skipped if it would:
+
+- Create a circular dependency between chunks
+- Change an entry's export signature (when `preserveEntrySignatures: 'strict'`)
+
+### Facade Elimination (`optimize_facade_entry_chunks`)
+
+Dynamic/emitted entries can become empty facades when all their modules are pulled into other chunks. The optimizer identifies these and either:
+
+- Merges the facade into its target chunk
+- Marks it as `Removed` in `post_chunk_optimization_operations`
+
+Circular dependency checks (`would_create_circular_dependency`) run before every merge to preserve acyclicity.
+
+## ChunkGraph
+
+```rust
+pub struct ChunkGraph {
+    pub chunk_table: ChunkTable,                    // IndexVec<ChunkIdx, Chunk>
+    pub module_to_chunk: IndexVec<ModuleIdx, Option<ChunkIdx>>,
+    pub bit_to_chunk_idx: Vec<Option<ChunkIdx>>,    // bit position → chunk index
+    pub entry_module_to_entry_chunk: FxHashMap<ModuleIdx, ChunkIdx>,
+    pub post_chunk_optimization_operations: FxHashMap<ChunkIdx, PostChunkOptimizationOperation>,
+    // ...
+}
+```
+
+- `chunk_table` — All chunks, indexed by `ChunkIdx`. May contain removed chunks (marked in `post_chunk_optimization_operations`).
+- `module_to_chunk` — Which chunk each module belongs to. O(1) lookup.
+- `bit_to_chunk_idx` — Translates entry bit positions to chunk indices. `None` for external entries.
+
+## Related
+
+- [rust-bundler](./rust-bundler.md) — Build lifecycle
+- `crates/rolldown/src/stages/generate_stage/mod.rs` — Generate stage entry point
+- `crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs` — User-defined chunk groups
+- #8595 — Bug caused by bit position / chunk index mismatch

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -2,7 +2,37 @@
 
 ## Summary
 
-Code splitting determines which modules go into which output chunks. It uses a BitSet-based reachability model: each entry point gets a bit position, modules are marked with the set of entries that can reach them, and modules with identical reachability patterns are grouped into the same chunk. An optimization pass then merges small common chunks into entry chunks when safe.
+Code splitting determines which modules go into which output chunks. Rolldown uses a BitSet-based reachability model — the same fundamental approach as esbuild and Rollup. Each entry point gets a bit position, modules are marked with the set of entries that can reach them, and modules with identical reachability patterns are grouped into the same chunk.
+
+## Why BitSet-Based Reachability?
+
+All three approaches to code splitting in the ecosystem solve the same problem: given N entry points and M modules, assign each module to exactly one chunk such that no module is duplicated and every entry loads exactly the modules it needs.
+
+**Webpack's approach (constraint-based heuristics):** Uses `SplitChunksPlugin` with configurable rules — `minSize`, `minChunks`, `maxAsyncRequests`, cache group priorities. This gives users maximum control but accepts code duplication as a trade-off for fewer HTTP requests. The rules-based system can't guarantee zero duplication.
+
+**Rollup's approach (entry set coloring):** Builds a `Set<entryIndex>` per module, groups modules with identical sets. Uses `BigInt` bitmasks for efficient set operations. Guarantees zero duplication. Supports `experimentalMinChunkSize` for merging small chunks.
+
+**esbuild's approach (BitSet reachability):** Assigns each entry a bit position, propagates through the graph, groups by identical `BitSet`. Conceptually identical to Rollup's coloring but implemented with compact bitwise operations at file level. Guarantees zero duplication. Minimal user configuration.
+
+Rolldown follows the esbuild/Rollup model because:
+
+1. **Zero duplication guarantee** — Every module appears in exactly one chunk. No user configuration needed to avoid duplication pitfalls.
+2. **Deterministic output** — Same input always produces same chunks. No heuristic thresholds to tune.
+3. **Performance** — BitSet operations (union, intersection, equality) are O(entries/64) per operation, making the algorithm O(modules × entries) overall. This is critical for large codebases.
+4. **Rollup compatibility** — As a Rollup successor, matching Rollup's splitting semantics minimizes migration friction.
+
+The trade-off is that this approach can produce many small chunks when there are many entry points with different reachability patterns. The chunk optimizer (see below) mitigates this by merging small common chunks back into entry chunks when safe.
+
+## How Other Bundlers Handle Key Problems
+
+| Problem                    | Rollup                                                  | esbuild                                                 | Rolldown                                                                         |
+| -------------------------- | ------------------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Shared module detection    | `Set<entryIndex>` per module                            | `BitSet` per file                                       | `BitSet` per module                                                              |
+| Separate chunk vs. inline? | Always separate; `experimentalMinChunkSize` for merging | Always separate; no merging                             | Separate by default; optimizer merges into entry chunks                          |
+| Circular chunk deps        | Warns; allows cyclic reexports                          | Enforces acyclic static chunk graph                     | Enforces acyclic via `would_create_circular_dependency` check before every merge |
+| Dynamic imports            | New entry points; computes "already loaded" atoms       | New entry points; rewrites to chunk unique keys         | New entry points; facade elimination for empty dynamic entries                   |
+| External modules           | Excluded from chunk graph                               | Excluded from bundling                                  | Get bit positions but no chunks (see Invariant below)                            |
+| Granularity                | Module level                                            | File level (was statement-level, backed off due to TLA) | Module level                                                                     |
 
 ## Pipeline
 
@@ -45,15 +75,19 @@ entry_index 2  →  @optional/ext   →  bit 2  →  (external, no chunk)
 entry_index 3  →  plugin.js       →  bit 3  →  ChunkIdx(2)
 ```
 
-External modules get bit positions but no chunks. This means **bit positions do not equal chunk indices**. The mapping is stored in `chunk_graph.bit_to_chunk_idx: Vec<Option<ChunkIdx>>` — `None` for external entries, `Some(idx)` for real chunks.
+Dynamic imports are treated as entry points — they get bit positions and entry chunks just like static entries. This matches Rollup and esbuild behavior: a dynamic `import()` creates a new loading boundary, so the imported module needs its own chunk (or must be merged into an existing one).
+
+External modules get bit positions (because they appear in the entries list from the link stage) but no chunks are created for them (the `Module::Normal` check skips them). This means **bit positions do not equal chunk indices**. The mapping is stored in `chunk_graph.bit_to_chunk_idx: Vec<Option<ChunkIdx>>` — `None` for external entries, `Some(idx)` for real chunks.
 
 ### Invariant
 
-Any code converting a bit position to a `ChunkIdx` **must** use `bit_to_chunk_idx`, not `ChunkIdx::from_raw(bit_position)`. Violating this produces wrong chunk assignments when external entries exist.
+Any code converting a bit position to a `ChunkIdx` **must** use `bit_to_chunk_idx`, not `ChunkIdx::from_raw(bit_position)`. Violating this produces wrong chunk assignments when external entries exist. See #8595 for the bug this caused.
+
+esbuild avoids this problem because external modules never enter its entry list. Rollup uses `Set` objects rather than index-based lookup, so the mismatch can't occur. Rolldown's design — where external entries occupy bit positions without chunks — is unique and requires this explicit mapping.
 
 ## Reachability Propagation
 
-`determine_reachable_modules_for_entry()` runs BFS from each entry module, setting `splitting_info[module].bits.set_bit(entry_index)` on every reachable module.
+`determine_reachable_modules_for_entry()` runs BFS from each entry module, setting `splitting_info[module].bits.set_bit(entry_index)` on every reachable module. External modules are skipped during traversal (they're not `Module::Normal`).
 
 After all entries are processed, each module's `bits` encodes which entries can reach it:
 
@@ -62,6 +96,8 @@ shared.js:    bits = 1111  (reachable from all 4 entries)
 parser-a.js:  bits = 1010  (reachable from entries 1 and 3)
 entry-a.js:   bits = 0001  (only reachable from entry 0)
 ```
+
+This is equivalent to Rollup's "dependent entry set" and esbuild's `EntryBits`. The key insight is that modules with identical `bits` have identical loading requirements — they're always needed together, never separately — so they belong in the same chunk.
 
 ## Chunk Creation
 
@@ -72,27 +108,29 @@ After reachability propagation, `split_chunks()` assigns modules to chunks by th
 3. If a chunk exists for that pattern, add the module to it
 4. Otherwise, create a new `Common` chunk
 
-Modules with the same reachability pattern always land in the same chunk. This is the core invariant that makes code splitting correct.
+Modules with the same reachability pattern always land in the same chunk. This is the core invariant that guarantees zero code duplication — a module is emitted exactly once, in the chunk matching its reachability fingerprint.
 
 ## Chunk Optimizer
 
-When enabled, the optimizer reduces chunk count by merging common chunks into entry chunks. It operates on a temporary `ChunkOptimizationGraph`.
+Without optimization, the BitSet approach can produce many small common chunks (one per unique reachability pattern). For example, 10 entry points with varied sharing patterns could produce dozens of tiny chunks. This is the main drawback of the pure BitSet approach that webpack's heuristic system avoids.
+
+The chunk optimizer reduces chunk count by merging common chunks back into entry chunks when safe. It operates on a temporary `ChunkOptimizationGraph` to test merges without modifying the real chunk graph.
 
 ### Common Module Merging (`try_insert_common_module_to_exist_chunk`)
 
 For each common chunk, translates its `bits` to chunk indices via `bit_to_chunk_idx`, then tries to merge it into one of those entry chunks. Merging is skipped if it would:
 
-- Create a circular dependency between chunks
-- Change an entry's export signature (when `preserveEntrySignatures: 'strict'`)
+- **Create a circular dependency between chunks** — checked via BFS in `would_create_circular_dependency()`. This is stricter than Rollup (which warns but allows cycles) and matches esbuild's enforcement of acyclic static chunk graphs.
+- **Change an entry's export signature** — when `preserveEntrySignatures: 'strict'`, adding modules to an entry chunk would expose symbols that the original entry didn't export.
+
+The trade-off of merging: entry chunks may include modules that not all consumers of that entry need. This adds a small amount of unnecessary code loading but significantly reduces chunk count and HTTP requests.
 
 ### Facade Elimination (`optimize_facade_entry_chunks`)
 
-Dynamic/emitted entries can become empty facades when all their modules are pulled into other chunks. The optimizer identifies these and either:
+Dynamic/emitted entries can become empty facades when all their modules are pulled into other chunks by the optimizer. The optimizer identifies these and either:
 
 - Merges the facade into its target chunk
 - Marks it as `Removed` in `post_chunk_optimization_operations`
-
-Circular dependency checks (`would_create_circular_dependency`) run before every merge to preserve acyclicity.
 
 ## ChunkGraph
 
@@ -107,13 +145,13 @@ pub struct ChunkGraph {
 }
 ```
 
-- `chunk_table` — All chunks, indexed by `ChunkIdx`. May contain removed chunks (marked in `post_chunk_optimization_operations`).
+- `chunk_table` — All chunks, indexed by `ChunkIdx`. May contain removed chunks (marked in `post_chunk_optimization_operations`) since re-indexing would be expensive.
 - `module_to_chunk` — Which chunk each module belongs to. O(1) lookup.
-- `bit_to_chunk_idx` — Translates entry bit positions to chunk indices. `None` for external entries.
+- `bit_to_chunk_idx` — Translates entry bit positions to chunk indices. `None` for external entries that have bit positions but no chunks.
 
 ## Related
 
 - [rust-bundler](./rust-bundler.md) — Build lifecycle
 - `crates/rolldown/src/stages/generate_stage/mod.rs` — Generate stage entry point
 - `crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs` — User-defined chunk groups
-- #8595 — Bug caused by bit position / chunk index mismatch
+- #8595 — Bug caused by bit position / chunk index mismatch when external entries exist


### PR DESCRIPTION
## Summary

Fixes #8595. Found while investigating https://github.com/oxc-project/oxc/issues/20033. Also fixes https://github.com/rolldown/rolldown/issues/8522

- External dynamic imports create entry bit positions without corresponding chunks. The chunk optimizer uses `ChunkIdx::from_raw(bit_position)` which maps to wrong chunks when externals create gaps, causing shared modules to be placed in wrong chunks and producing circular inter-chunk imports from acyclic source modules.
- Adds `bit_to_chunk_idx: Vec<Option<ChunkIdx>>` mapping to `ChunkGraph`, populated during `init_entry_point`, used in chunk optimizer instead of `ChunkIdx::from_raw()`
- Adds bounds check to `BitSet::has_bit` for safety

## Test plan

- [x] Added snapshot test in `crates/rolldown/tests/rolldown/issues/circular_chunk_from_external_entries/` (minimal repro)
- [x] Added snapshot test in `crates/rolldown/tests/rolldown/issues/8595/` (real-world repro from [prettier-plugin-tailwindcss](https://github.com/rolldown/rolldown/issues/8522#issuecomment-3991956653))
- [x] Verified test fails without fix (`parser-a.js <-> plugin.js` circular dependency)
- [x] Verified test passes with fix (each chunk contains only its own module, no circular imports)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)