### PR TITLE
ci: skip Windows CI jobs on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,12 @@ jobs:
     needs: changes
     strategy:
       matrix:
-        target: [ubuntu-latest, macos-latest, windows-latest]
+        target:
+          - ubuntu-latest
+          - macos-latest
+          - ${{ github.ref_name == 'main' && 'windows-latest' || '' }}
+        exclude:
+          - target: ''
     uses: ./.github/workflows/reusable-cargo-test.yml
     with:
       os: ${{ matrix.target }}
@@ -100,6 +105,7 @@ jobs:
     needs: [changes, build-rolldown-windows]
     uses: ./.github/workflows/reusable-node-test.yml
     if: |
+      github.ref_name == 'main' &&
       always() &&
       (needs.build-rolldown-windows.result == 'success' || needs.build-rolldown-windows.result == 'skipped')
     with:
@@ -160,6 +166,7 @@ jobs:
     needs: [changes, build-rolldown-windows]
     uses: ./.github/workflows/reusable-node-dev-server-test.yml
     if: |
+      github.ref_name == 'main' &&
       always() &&
       (needs.build-rolldown-windows.result == 'success' || needs.build-rolldown-windows.result == 'skipped')
     with:
@@ -188,6 +195,7 @@ jobs:
 
   build-rolldown-windows:
     needs: changes
+    if: github.ref_name == 'main'
     uses: ./.github/workflows/reusable-native-build.yml
     with:
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}


### PR DESCRIPTION
## Summary

- Skip all Windows CI jobs (`cargo-test`, `build-rolldown-windows`, `node-test-windows`, `node-dev-server-test-windows`) on PRs to speed up feedback (~2x slower than Ubuntu)
- Windows jobs still run on `main` pushes to catch platform-specific issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)