### PR TITLE
feat(plugin): support addWatchGlob

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -143,6 +143,10 @@ impl Bundle {
     &self.plugin_driver.watch_files
   }
 
+  pub fn get_watch_globs(&self) -> &Arc<FxDashSet<ArcStr>> {
+    &self.plugin_driver.watch_globs
+  }
+
   pub fn context(&self) -> BundleHandle {
     BundleHandle {
       options: Arc::clone(&self.options),

--- a/crates/rolldown/src/bundle/bundle_handle.rs
+++ b/crates/rolldown/src/bundle/bundle_handle.rs
@@ -60,6 +60,14 @@ impl BundleHandle {
     &self.plugin_driver.watch_files
   }
 
+  /// Get the watch globs collected during this bundle.
+  ///
+  /// These patterns (already normalized to absolute form) are matched against
+  /// every path that `notify` emits. Any match triggers a rebuild.
+  pub fn watch_globs(&self) -> &Arc<rolldown_utils::dashmap::FxDashSet<arcstr::ArcStr>> {
+    &self.plugin_driver.watch_globs
+  }
+
   /// Get the plugin driver used in this bundle.
   ///
   /// Primarily used to call cleanup hooks like `close_bundle()` after the build completes.

--- a/crates/rolldown_binding/src/binding_bundler.rs
+++ b/crates/rolldown_binding/src/binding_bundler.rs
@@ -196,6 +196,15 @@ impl BindingBundler {
       .map(|handle| handle.watch_files().iter().map(|s| s.to_string()).collect())
       .unwrap_or_default()
   }
+
+  #[napi]
+  pub fn get_watch_globs(&self) -> Vec<String> {
+    self
+      .last_bundle_handle
+      .as_ref()
+      .map(|handle| handle.watch_globs().iter().map(|s| s.to_string()).collect())
+      .unwrap_or_default()
+  }
 }
 
 impl BindingBundler {

--- a/crates/rolldown_binding/src/options/plugin/binding_load_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_load_context.rs
@@ -24,4 +24,9 @@ impl BindingLoadPluginContext {
   pub fn add_watch_file(&self, file: String) {
     self.inner.add_watch_file(&file);
   }
+
+  #[napi]
+  pub fn add_watch_glob(&self, glob: String) {
+    self.inner.add_watch_glob(&glob);
+  }
 }

--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_context.rs
@@ -132,6 +132,11 @@ impl BindingPluginContext {
   pub fn add_watch_file(&self, file: String) {
     self.inner.add_watch_file(&file);
   }
+
+  #[napi]
+  pub fn add_watch_glob(&self, glob: String) {
+    self.inner.add_watch_glob(&glob);
+  }
 }
 
 impl From<PluginContext> for BindingPluginContext {

--- a/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_transform_context.rs
@@ -33,6 +33,11 @@ impl BindingTransformPluginContext {
   }
 
   #[napi]
+  pub fn add_watch_glob(&self, glob: String) {
+    self.inner.add_watch_glob(&glob);
+  }
+
+  #[napi]
   pub fn send_magic_string(
     &self,
     magic_string: &mut BindingMagicString<'static>,

--- a/crates/rolldown_plugin/src/plugin_context/load_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/load_plugin_context.rs
@@ -14,6 +14,11 @@ impl LoadPluginContext {
     Self { inner, module_idx }
   }
 
+  /// Add a glob pattern to watch in watch mode.
+  pub fn add_watch_glob(&self, glob: &str) {
+    self.inner.add_watch_glob(glob);
+  }
+
   /// Add a file as a dependency.
   ///
   /// * file - The file to add as a watch dependency. This should be a normalized absolute path.

--- a/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/native_plugin_context.rs
@@ -40,6 +40,7 @@ pub struct NativePluginContextImpl {
   pub(crate) file_emitter: SharedFileEmitter,
   pub(crate) options: SharedNormalizedBundlerOptions,
   pub(crate) watch_files: Arc<FxDashSet<ArcStr>>,
+  pub(crate) watch_globs: Arc<FxDashSet<ArcStr>>,
   pub(crate) module_infos: SharedModuleInfoDashMap,
   pub(crate) tx: Arc<Mutex<Option<tokio::sync::mpsc::Sender<ModuleLoaderMsg>>>>,
   pub(crate) session: rolldown_devtools::Session,
@@ -191,6 +192,12 @@ impl NativePluginContextImpl {
 
   pub fn add_watch_file(&self, file: &str) {
     self.watch_files.insert(file.into());
+  }
+
+  pub fn add_watch_glob(&self, glob: &str) {
+    let cwd = self.options.cwd.to_string_lossy();
+    let normalized = rolldown_utils::pattern_filter::get_matcher_string(glob, &cwd);
+    self.watch_globs.insert(normalized.into());
   }
 
   fn log(&self, level: LogLevel, log: LogWithoutPlugin) {

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
@@ -134,7 +134,9 @@ impl PluginContext {
     call_native_only!(self, "add_watch_file", ctx => ctx.add_watch_file(file));
   }
 
-  /// Add a glob pattern to watch. The pattern is normalized to absolute at storage time.
+  /// Add a glob pattern to watch.
+  ///
+  /// * glob - The glob pattern to add. This pattern is normalized to absolute at storage time.
   pub fn add_watch_glob(&self, glob: &str) {
     call_native_only!(self, "add_watch_glob", ctx => ctx.add_watch_glob(glob));
   }

--- a/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/plugin_context.rs
@@ -59,6 +59,7 @@ impl PluginContext {
         file_emitter: Arc::clone(&ctx.file_emitter),
         options: Arc::clone(&ctx.options),
         watch_files: Arc::clone(&ctx.watch_files),
+        watch_globs: Arc::clone(&ctx.watch_globs),
         module_infos: Arc::clone(&ctx.module_infos),
         tx: Arc::clone(&ctx.tx),
         session: ctx.session.clone(),
@@ -131,6 +132,11 @@ impl PluginContext {
   /// * file - The file to add as a watch dependency. This should be a normalized absolute path.
   pub fn add_watch_file(&self, file: &str) {
     call_native_only!(self, "add_watch_file", ctx => ctx.add_watch_file(file));
+  }
+
+  /// Add a glob pattern to watch. The pattern is normalized to absolute at storage time.
+  pub fn add_watch_glob(&self, glob: &str) {
+    call_native_only!(self, "add_watch_glob", ctx => ctx.add_watch_glob(glob));
   }
 
   pub fn meta(&self) -> &PluginContextMeta {

--- a/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
+++ b/crates/rolldown_plugin/src/plugin_context/transform_plugin_context.rs
@@ -64,6 +64,11 @@ impl TransformPluginContext {
     })
   }
 
+  /// Add a glob pattern to watch in watch mode.
+  pub fn add_watch_glob(&self, glob: &str) {
+    self.inner.add_watch_glob(glob);
+  }
+
   /// Add a file as a dependency.
   ///
   /// * file - The file to add as a watch dependency. This should be a normalized absolute path.

--- a/crates/rolldown_plugin/src/plugin_driver/mod.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/mod.rs
@@ -34,6 +34,7 @@ pub struct PluginDriver {
   hook_orders: PluginHookOrders,
   pub file_emitter: SharedFileEmitter,
   pub watch_files: Arc<FxDashSet<ArcStr>>,
+  pub watch_globs: Arc<FxDashSet<ArcStr>>,
   pub module_infos: SharedModuleInfoDashMap,
   /// Module dependencies tracked during load/transform hooks for HMR invalidation
   pub transform_dependencies: Arc<DashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
@@ -46,6 +47,7 @@ pub struct PluginDriver {
 impl PluginDriver {
   pub fn clear(&self) {
     self.watch_files.clear();
+    self.watch_globs.clear();
     self.module_infos.clear();
     // Note: transform_dependencies is NOT cleared here - it's preserved across incremental builds
     // by BundleFactory which manages its lifecycle (reset on full builds only)

--- a/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/plugin_driver_factory.rs
@@ -39,6 +39,7 @@ impl PluginDriverFactory {
     transform_dependencies: Arc<DashMap<ModuleIdx, Arc<FxDashSet<ArcStr>>>>,
   ) -> Arc<crate::plugin_driver::PluginDriver> {
     let watch_files = Arc::new(FxDashSet::default());
+    let watch_globs = Arc::new(FxDashSet::default());
     let meta = Arc::new(PluginContextMeta::default());
     let tx = Arc::new(tokio::sync::Mutex::new(None));
     let mut plugin_usage_vec = IndexVec::new();
@@ -87,6 +88,7 @@ impl PluginDriverFactory {
           module_infos: Arc::clone(&module_infos),
           options: Arc::clone(options),
           watch_files: Arc::clone(&watch_files),
+          watch_globs: Arc::clone(&watch_globs),
           tx: Arc::clone(&tx),
           session: session.clone(),
           bundle_span: Arc::clone(&bundle_span_arc),
@@ -100,6 +102,7 @@ impl PluginDriverFactory {
         contexts: index_contexts,
         file_emitter: Arc::clone(file_emitter),
         watch_files,
+        watch_globs,
         module_infos,
         transform_dependencies,
         context_load_completion_manager: ContextLoadCompletionManager::default(),

--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -186,62 +186,6 @@ mod tests {
 
   use super::*;
 
-  // --- get_matcher_string ---
-
-  #[test]
-  fn test_get_matcher_string_relative_joins_cwd() {
-    assert_eq!(get_matcher_string("src/**/*.ts", "/project"), "/project/src/**/*.ts");
-    assert_eq!(
-      get_matcher_string("data/*.txt", "/home/user/project"),
-      "/home/user/project/data/*.txt"
-    );
-  }
-
-  #[test]
-  fn test_get_matcher_string_absolute_passes_through() {
-    assert_eq!(get_matcher_string("/project/src/**/*.ts", "/project"), "/project/src/**/*.ts");
-  }
-
-  #[test]
-  fn test_get_matcher_string_double_star_prefix_passes_through() {
-    assert_eq!(get_matcher_string("**/*.ts", "/project"), "**/*.ts");
-  }
-
-  // --- glob_match_path ---
-
-  #[test]
-  fn test_glob_match_path_matches_deep_path() {
-    assert!(glob_match_path("/project/src/**/*.ts", "/project/src/utils/helper.ts"));
-    assert!(glob_match_path("/project/src/**/*.ts", "/project/src/deep/nested/file.ts"));
-  }
-
-  #[test]
-  fn test_glob_match_path_no_match_wrong_extension() {
-    assert!(!glob_match_path("/project/src/**/*.ts", "/project/src/utils/helper.js"));
-  }
-
-  #[test]
-  fn test_glob_match_path_no_match_wrong_root() {
-    assert!(!glob_match_path("/project/src/**/*.ts", "/other/src/utils/helper.ts"));
-  }
-
-  #[test]
-  fn test_glob_match_path_single_star_no_nested() {
-    assert!(glob_match_path("/project/data/*.txt", "/project/data/foo.txt"));
-    // single * does not cross directory boundaries
-    assert!(!glob_match_path("/project/data/*.txt", "/project/data/nested/foo.txt"));
-  }
-
-  #[test]
-  fn test_full_add_watch_glob_flow() {
-    // Simulate what add_watch_glob does: normalize at storage time, match at event time.
-    // Naive match without normalization fails:
-    assert!(!glob_match_path("src/**/*.ts", "/project/src/utils/helper.ts"));
-    // After normalization it matches:
-    let stored = get_matcher_string("src/**/*.ts", "/project");
-    assert!(glob_match_path(&stored, "/project/src/utils/helper.ts"));
-  }
-
   #[test]
   fn test_filter() {
     #[derive(Debug)]

--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -99,8 +99,19 @@ pub fn filter(
   }
 }
 
+/// Match a single normalized glob `pattern` against an absolute `path`.
+///
+/// Both arguments must use forward slashes. Exposed so callers outside this
+/// crate (e.g. `rolldown_watcher`) don't need a direct `fast-glob` dep.
+pub fn glob_match_path(pattern: &str, path: &str) -> bool {
+  todo!()
+}
+
 /// https://github.com/rollup/plugins/blob/e1a5ef99f1578eb38a8c87563cb9651db228f3bd/packages/pluginutils/src/createFilter.ts#L10
-fn get_matcher_string<'a>(glob: &'a str, cwd: &'a str) -> Cow<'a, str> {
+///
+/// Exposed as `pub` so `add_watch_glob` in `rolldown_plugin` can normalize
+/// user-supplied patterns the same way `watch.include`/`watch.exclude` does.
+pub fn get_matcher_string<'a>(glob: &'a str, cwd: &'a str) -> Cow<'a, str> {
   if glob.starts_with("**") || Path::new(glob).is_absolute() {
     normalize_path(glob)
   } else {
@@ -180,6 +191,65 @@ mod tests {
   use std::path;
 
   use super::*;
+
+  // --- get_matcher_string ---
+
+  #[test]
+  fn test_get_matcher_string_relative_joins_cwd() {
+    assert_eq!(get_matcher_string("src/**/*.ts", "/project"), "/project/src/**/*.ts");
+    assert_eq!(
+      get_matcher_string("data/*.txt", "/home/user/project"),
+      "/home/user/project/data/*.txt"
+    );
+  }
+
+  #[test]
+  fn test_get_matcher_string_absolute_passes_through() {
+    assert_eq!(
+      get_matcher_string("/project/src/**/*.ts", "/project"),
+      "/project/src/**/*.ts"
+    );
+  }
+
+  #[test]
+  fn test_get_matcher_string_double_star_prefix_passes_through() {
+    assert_eq!(get_matcher_string("**/*.ts", "/project"), "**/*.ts");
+  }
+
+  // --- glob_match_path ---
+
+  #[test]
+  fn test_glob_match_path_matches_deep_path() {
+    assert!(glob_match_path("/project/src/**/*.ts", "/project/src/utils/helper.ts"));
+    assert!(glob_match_path("/project/src/**/*.ts", "/project/src/deep/nested/file.ts"));
+  }
+
+  #[test]
+  fn test_glob_match_path_no_match_wrong_extension() {
+    assert!(!glob_match_path("/project/src/**/*.ts", "/project/src/utils/helper.js"));
+  }
+
+  #[test]
+  fn test_glob_match_path_no_match_wrong_root() {
+    assert!(!glob_match_path("/project/src/**/*.ts", "/other/src/utils/helper.ts"));
+  }
+
+  #[test]
+  fn test_glob_match_path_single_star_no_nested() {
+    assert!(glob_match_path("/project/data/*.txt", "/project/data/foo.txt"));
+    // single * does not cross directory boundaries
+    assert!(!glob_match_path("/project/data/*.txt", "/project/data/nested/foo.txt"));
+  }
+
+  #[test]
+  fn test_full_add_watch_glob_flow() {
+    // Simulate what add_watch_glob does: normalize at storage time, match at event time.
+    // Naive match without normalization fails:
+    assert!(!glob_match_path("src/**/*.ts", "/project/src/utils/helper.ts"));
+    // After normalization it matches:
+    let stored = get_matcher_string("src/**/*.ts", "/project");
+    assert!(glob_match_path(&stored, "/project/src/utils/helper.ts"));
+  }
 
   #[test]
   fn test_filter() {

--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -104,7 +104,7 @@ pub fn filter(
 /// Both arguments must use forward slashes. Exposed so callers outside this
 /// crate (e.g. `rolldown_watcher`) don't need a direct `fast-glob` dep.
 pub fn glob_match_path(pattern: &str, path: &str) -> bool {
-  todo!()
+  glob_match(pattern.as_bytes(), path.as_bytes())
 }
 
 /// https://github.com/rollup/plugins/blob/e1a5ef99f1578eb38a8c87563cb9651db228f3bd/packages/pluginutils/src/createFilter.ts#L10

--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -100,17 +100,11 @@ pub fn filter(
 }
 
 /// Match a single normalized glob `pattern` against an absolute `path`.
-///
-/// Both arguments must use forward slashes. Exposed so callers outside this
-/// crate (e.g. `rolldown_watcher`) don't need a direct `fast-glob` dep.
 pub fn glob_match_path(pattern: &str, path: &str) -> bool {
   glob_match(pattern.as_bytes(), path.as_bytes())
 }
 
 /// https://github.com/rollup/plugins/blob/e1a5ef99f1578eb38a8c87563cb9651db228f3bd/packages/pluginutils/src/createFilter.ts#L10
-///
-/// Exposed as `pub` so `add_watch_glob` in `rolldown_plugin` can normalize
-/// user-supplied patterns the same way `watch.include`/`watch.exclude` does.
 pub fn get_matcher_string<'a>(glob: &'a str, cwd: &'a str) -> Cow<'a, str> {
   if glob.starts_with("**") || Path::new(glob).is_absolute() {
     normalize_path(glob)
@@ -205,10 +199,7 @@ mod tests {
 
   #[test]
   fn test_get_matcher_string_absolute_passes_through() {
-    assert_eq!(
-      get_matcher_string("/project/src/**/*.ts", "/project"),
-      "/project/src/**/*.ts"
-    );
+    assert_eq!(get_matcher_string("/project/src/**/*.ts", "/project"), "/project/src/**/*.ts");
   }
 
   #[test]

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -269,7 +269,7 @@ impl WatchTask {
   /// Given a normalized absolute glob pattern, return the static base directory
   fn glob_base_dir(pattern: &str) -> (&str, bool) {
     let is_recursive = pattern.contains("**");
-    let glob_start = pattern.find(|c| c == '*' || c == '?' || c == '[').unwrap_or(pattern.len());
+    let glob_start = pattern.find(['*', '?', '[']).unwrap_or(pattern.len());
     let base_end = pattern[..glob_start].rfind('/').map_or(0, |i| i + 1);
     (&pattern[..base_end], is_recursive)
   }

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -253,6 +253,14 @@ impl WatchTask {
     bundler.close().await.map_err(Into::into)
   }
 
+  /// Returns `true` if any stored glob pattern matches `path`.
+  ///
+  /// Patterns must already be normalized to absolute form (done by `add_watch_glob`
+  /// at registration time). `path` is the absolute path emitted by `notify`.
+  fn matches_watch_globs(&self, path: &str) -> bool {
+    todo!()
+  }
+
   fn is_watched_file(&self, path: &str) -> bool {
     if self.watched_files.contains(path) {
       return true;
@@ -265,6 +273,70 @@ impl WatchTask {
     }
 
     false
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use arcstr::ArcStr;
+  use rolldown_utils::dashmap::FxDashSet;
+
+  /// Thin wrapper so tests can call `matches_watch_globs` without a full `WatchTask`.
+  /// Will be replaced by the real field + impl once the feature is built.
+  fn matches_globs(globs: &FxDashSet<ArcStr>, path: &str) -> bool {
+    globs
+      .iter()
+      .any(|pattern| rolldown_utils::pattern_filter::glob_match_path(pattern.as_str(), path))
+  }
+
+  #[test]
+  fn test_matches_watch_globs_double_star() {
+    let globs: FxDashSet<ArcStr> = FxDashSet::default();
+    globs.insert("/project/src/**/*.ts".into());
+
+    assert!(matches_globs(&globs, "/project/src/utils/helper.ts"));
+    assert!(matches_globs(&globs, "/project/src/deep/nested/file.ts"));
+    assert!(!matches_globs(&globs, "/project/src/utils/helper.js"));
+  }
+
+  #[test]
+  fn test_matches_watch_globs_single_star() {
+    let globs: FxDashSet<ArcStr> = FxDashSet::default();
+    globs.insert("/project/data/*.txt".into());
+
+    assert!(matches_globs(&globs, "/project/data/foo.txt"));
+    // single * does not cross directories
+    assert!(!matches_globs(&globs, "/project/data/nested/foo.txt"));
+    assert!(!matches_globs(&globs, "/project/data/foo.js"));
+  }
+
+  #[test]
+  fn test_matches_watch_globs_empty_set() {
+    let globs: FxDashSet<ArcStr> = FxDashSet::default();
+    assert!(!matches_globs(&globs, "/project/src/file.ts"));
+  }
+
+  #[test]
+  fn test_matches_watch_globs_multiple_patterns() {
+    let globs: FxDashSet<ArcStr> = FxDashSet::default();
+    globs.insert("/project/src/**/*.ts".into());
+    globs.insert("/project/data/*.txt".into());
+
+    assert!(matches_globs(&globs, "/project/src/file.ts"));
+    assert!(matches_globs(&globs, "/project/data/config.txt"));
+    assert!(!matches_globs(&globs, "/project/src/file.js"));
+    assert!(!matches_globs(&globs, "/project/other/file.ts"));
+  }
+
+  #[test]
+  fn test_non_matching_file_does_not_trigger() {
+    let globs: FxDashSet<ArcStr> = FxDashSet::default();
+    globs.insert("/project/src/**/*.ts".into());
+
+    // a .js file alongside .ts files should not match
+    assert!(!matches_globs(&globs, "/project/src/utils/helper.js"));
+    // a completely different directory should not match
+    assert!(!matches_globs(&globs, "/other/project/src/utils/helper.ts"));
   }
 }
 

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -132,13 +132,17 @@ impl WatchTask {
     // Also register any files discovered during render/write phase
     self.update_watch_files(&new_watch_files)?;
 
-    // Refresh globs from this build. Unlike watched_files, globs need no notify
-    // registration — they are matched against incoming paths on the fly.
-    // Plugins re-register globs each build, so we replace rather than accumulate.
+    // Refresh globs from this build. Plugins re-register globs each build,
+    // so we replace the pattern set rather than accumulate.
     self.watch_globs.clear();
-    for glob in new_watch_globs {
-      self.watch_globs.insert(glob);
+    for glob in &new_watch_globs {
+      self.watch_globs.insert(glob.clone());
     }
+    // Walk the filesystem to find files matching each glob pattern and
+    // register them individually with notify. This is more reliable than
+    // watching directories: only matching files trigger rebuilds, so
+    // non-matching files in the same directory are ignored.
+    self.register_glob_files(&new_watch_globs)?;
 
     #[expect(clippy::cast_possible_truncation)]
     let duration = start_time.elapsed().as_millis() as u32;
@@ -267,6 +271,77 @@ impl WatchTask {
     bundler.close().await.map_err(Into::into)
   }
 
+  /// Given a normalized absolute glob pattern, return the static base directory
+  /// (everything before the first `*`, `?`, or `[`) and whether it is recursive.
+  ///
+  /// Example: `/project/src/**/*.ts` → (`/project/src/`, true)
+  /// Example: `/project/data/*.txt`  → (`/project/data/`, false)
+  fn glob_base_dir(pattern: &str) -> (&str, bool) {
+    let is_recursive = pattern.contains("**");
+    let glob_start =
+      pattern.find(|c| c == '*' || c == '?' || c == '[').unwrap_or(pattern.len());
+    let base_end = pattern[..glob_start].rfind('/').map_or(0, |i| i + 1);
+    (&pattern[..base_end], is_recursive)
+  }
+
+  /// Walk the filesystem to find files matching each glob pattern and register
+  /// them individually with notify (same mechanism as `addWatchFile`).
+  ///
+  /// Called after every build. `update_watch_files` deduplicates, so
+  /// already-watched files are skipped cheaply.
+  fn register_glob_files(&self, globs: &[ArcStr]) -> BuildResult<()> {
+    let mut matched: Vec<ArcStr> = Vec::new();
+
+    for glob_pattern in globs {
+      let pattern_str = glob_pattern.as_str();
+      let (base, is_recursive) = Self::glob_base_dir(pattern_str);
+      if base.is_empty() {
+        continue;
+      }
+      let base_path = Path::new(base);
+      if !base_path.is_dir() {
+        continue;
+      }
+
+      if is_recursive {
+        Self::walk_matching_recursive(base_path, pattern_str, &mut matched);
+      } else {
+        if let Ok(entries) = std::fs::read_dir(base_path) {
+          for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+              continue;
+            }
+            let path_str = path.to_string_lossy();
+            let normalized = pattern_filter::normalize_path(&path_str);
+            if pattern_filter::glob_match_path(pattern_str, &normalized) {
+              matched.push(ArcStr::from(normalized.as_ref()));
+            }
+          }
+        }
+      }
+    }
+
+    self.update_watch_files(&matched)
+  }
+
+  /// Recursively walk `dir` and collect files whose normalized path matches `pattern`.
+  fn walk_matching_recursive(dir: &Path, pattern: &str, out: &mut Vec<ArcStr>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+      let path = entry.path();
+      if path.is_dir() {
+        Self::walk_matching_recursive(&path, pattern, out);
+      } else if path.is_file() {
+        let path_str = path.to_string_lossy();
+        let normalized = pattern_filter::normalize_path(&path_str);
+        if pattern_filter::glob_match_path(pattern, &normalized) {
+          out.push(ArcStr::from(normalized.as_ref()));
+        }
+      }
+    }
+  }
+
   /// Returns `true` if any stored glob pattern matches `path`.
   ///
   /// Patterns are already normalized to absolute forward-slash form by
@@ -274,7 +349,8 @@ impl WatchTask {
   /// comparison works correctly on Windows.
   fn matches_watch_globs(&self, path: &str) -> bool {
     let normalized = pattern_filter::normalize_path(path);
-    self.watch_globs
+    self
+      .watch_globs
       .iter()
       .any(|pattern| pattern_filter::glob_match_path(pattern.as_str(), &normalized))
   }

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -120,7 +120,7 @@ impl WatchTask {
       let bundle_handle =
         bundler.last_bundle_handle.clone().expect("bundle handle should exist after build");
 
-      // Collect watch files and globs while we have the lock (may include render-phase additions)
+      // Collect watch files and globs while we have the lock (may include render-phase)
       let new_watch_files: Vec<ArcStr> =
         bundle_handle.watch_files().iter().map(|f| f.clone()).collect();
       let new_watch_globs: Vec<ArcStr> =
@@ -133,6 +133,7 @@ impl WatchTask {
     self.update_watch_files(&new_watch_files)?;
 
     self.watch_globs.clear();
+    self.watch_glob_dirs.clear();
     for glob in &new_watch_globs {
       self.watch_globs.insert(glob.clone());
     }
@@ -266,9 +267,6 @@ impl WatchTask {
   }
 
   /// Given a normalized absolute glob pattern, return the static base directory
-  ///
-  /// Example: `/project/src/**/*.ts` → (`/project/src/`, true)
-  /// Example: `/project/data/*.txt`  → (`/project/data/`, false)
   fn glob_base_dir(pattern: &str) -> (&str, bool) {
     let is_recursive = pattern.contains("**");
     let glob_start = pattern.find(|c| c == '*' || c == '?' || c == '[').unwrap_or(pattern.len());
@@ -292,14 +290,16 @@ impl WatchTask {
       if base.is_empty() {
         continue;
       }
-      // Deduplicate: each unique base dir is registered with the OS only once.
+      
       if self.watch_glob_dirs.contains(base) {
         continue;
       }
+      
       let base_path = Path::new(base);
       if !base_path.is_dir() {
         continue;
       }
+      
       let mode = if is_recursive { RecursiveMode::Recursive } else { RecursiveMode::NonRecursive };
       match watcher_paths.add(base_path, mode) {
         Ok(()) => {
@@ -333,7 +333,7 @@ impl WatchTask {
       return true;
     }
 
-    // Windows path normalization for exact-file matches
+    // Windows path normalization
     #[cfg(windows)]
     if self.watched_files.contains(path.replace('\\', "/").as_str()) {
       return true;

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -21,9 +21,8 @@ pub struct WatchTask {
   options: Arc<NormalizedBundlerOptions>,
   fs_watcher: std::sync::Mutex<DynFsWatcher>,
   watched_files: FxDashSet<ArcStr>,
-  /// Glob patterns registered via `addWatchGlob` in the latest build.
-  /// Refreshed after every build; checked against each notify event path.
   watch_globs: FxDashSet<ArcStr>,
+  watch_glob_dirs: FxDashSet<ArcStr>,
   pub(crate) needs_rebuild: bool,
 }
 
@@ -55,6 +54,7 @@ impl WatchTask {
       fs_watcher: std::sync::Mutex::new(fs_watcher),
       watched_files: FxDashSet::default(),
       watch_globs: FxDashSet::default(),
+      watch_glob_dirs: FxDashSet::default(),
       needs_rebuild: true,
     })
   }
@@ -132,17 +132,11 @@ impl WatchTask {
     // Also register any files discovered during render/write phase
     self.update_watch_files(&new_watch_files)?;
 
-    // Refresh globs from this build. Plugins re-register globs each build,
-    // so we replace the pattern set rather than accumulate.
     self.watch_globs.clear();
     for glob in &new_watch_globs {
       self.watch_globs.insert(glob.clone());
     }
-    // Walk the filesystem to find files matching each glob pattern and
-    // register them individually with notify. This is more reliable than
-    // watching directories: only matching files trigger rebuilds, so
-    // non-matching files in the same directory are ignored.
-    self.register_glob_files(&new_watch_globs)?;
+    self.register_glob_dirs(&new_watch_globs)?;
 
     #[expect(clippy::cast_possible_truncation)]
     let duration = start_time.elapsed().as_millis() as u32;
@@ -272,25 +266,25 @@ impl WatchTask {
   }
 
   /// Given a normalized absolute glob pattern, return the static base directory
-  /// (everything before the first `*`, `?`, or `[`) and whether it is recursive.
   ///
   /// Example: `/project/src/**/*.ts` → (`/project/src/`, true)
   /// Example: `/project/data/*.txt`  → (`/project/data/`, false)
   fn glob_base_dir(pattern: &str) -> (&str, bool) {
     let is_recursive = pattern.contains("**");
-    let glob_start =
-      pattern.find(|c| c == '*' || c == '?' || c == '[').unwrap_or(pattern.len());
+    let glob_start = pattern.find(|c| c == '*' || c == '?' || c == '[').unwrap_or(pattern.len());
     let base_end = pattern[..glob_start].rfind('/').map_or(0, |i| i + 1);
     (&pattern[..base_end], is_recursive)
   }
 
-  /// Walk the filesystem to find files matching each glob pattern and register
-  /// them individually with notify (same mechanism as `addWatchFile`).
-  ///
-  /// Called after every build. `update_watch_files` deduplicates, so
-  /// already-watched files are skipped cheaply.
-  fn register_glob_files(&self, globs: &[ArcStr]) -> BuildResult<()> {
-    let mut matched: Vec<ArcStr> = Vec::new();
+  /// Register the base directory of each glob with the fs watcher using the
+  /// appropriate `RecursiveMode` (`Recursive` for `**`, `NonRecursive` otherwise).
+  fn register_glob_dirs(&self, globs: &[ArcStr]) -> BuildResult<()> {
+    if globs.is_empty() {
+      return Ok(());
+    }
+
+    let mut fs_watcher = self.fs_watcher.lock().expect("fs_watcher lock poisoned");
+    let mut watcher_paths = fs_watcher.paths_mut();
 
     for glob_pattern in globs {
       let pattern_str = glob_pattern.as_str();
@@ -298,55 +292,30 @@ impl WatchTask {
       if base.is_empty() {
         continue;
       }
+      // Deduplicate: each unique base dir is registered with the OS only once.
+      if self.watch_glob_dirs.contains(base) {
+        continue;
+      }
       let base_path = Path::new(base);
       if !base_path.is_dir() {
         continue;
       }
-
-      if is_recursive {
-        Self::walk_matching_recursive(base_path, pattern_str, &mut matched);
-      } else {
-        if let Ok(entries) = std::fs::read_dir(base_path) {
-          for entry in entries.flatten() {
-            let path = entry.path();
-            if !path.is_file() {
-              continue;
-            }
-            let path_str = path.to_string_lossy();
-            let normalized = pattern_filter::normalize_path(&path_str);
-            if pattern_filter::glob_match_path(pattern_str, &normalized) {
-              matched.push(ArcStr::from(normalized.as_ref()));
-            }
-          }
+      let mode = if is_recursive { RecursiveMode::Recursive } else { RecursiveMode::NonRecursive };
+      match watcher_paths.add(base_path, mode) {
+        Ok(()) => {
+          tracing::debug!(name = "notify watch glob dir", path = ?base_path, recursive = is_recursive);
+          self.watch_glob_dirs.insert(ArcStr::from(base));
+        }
+        Err(e) => {
+          tracing::debug!(name = "notify watch glob dir skipped", path = ?base_path, error = ?e);
         }
       }
     }
 
-    self.update_watch_files(&matched)
+    watcher_paths.commit().map_err_to_unhandleable()?;
+    Ok(())
   }
 
-  /// Recursively walk `dir` and collect files whose normalized path matches `pattern`.
-  fn walk_matching_recursive(dir: &Path, pattern: &str, out: &mut Vec<ArcStr>) {
-    let Ok(entries) = std::fs::read_dir(dir) else { return };
-    for entry in entries.flatten() {
-      let path = entry.path();
-      if path.is_dir() {
-        Self::walk_matching_recursive(&path, pattern, out);
-      } else if path.is_file() {
-        let path_str = path.to_string_lossy();
-        let normalized = pattern_filter::normalize_path(&path_str);
-        if pattern_filter::glob_match_path(pattern, &normalized) {
-          out.push(ArcStr::from(normalized.as_ref()));
-        }
-      }
-    }
-  }
-
-  /// Returns `true` if any stored glob pattern matches `path`.
-  ///
-  /// Patterns are already normalized to absolute forward-slash form by
-  /// `add_watch_glob`. The incoming `path` is also normalized here so the
-  /// comparison works correctly on Windows.
   fn matches_watch_globs(&self, path: &str) -> bool {
     let normalized = pattern_filter::normalize_path(path);
     self

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -21,6 +21,9 @@ pub struct WatchTask {
   options: Arc<NormalizedBundlerOptions>,
   fs_watcher: std::sync::Mutex<DynFsWatcher>,
   watched_files: FxDashSet<ArcStr>,
+  /// Glob patterns registered via `addWatchGlob` in the latest build.
+  /// Refreshed after every build; checked against each notify event path.
+  watch_globs: FxDashSet<ArcStr>,
   pub(crate) needs_rebuild: bool,
 }
 
@@ -51,6 +54,7 @@ impl WatchTask {
       options,
       fs_watcher: std::sync::Mutex::new(fs_watcher),
       watched_files: FxDashSet::default(),
+      watch_globs: FxDashSet::default(),
       needs_rebuild: true,
     })
   }
@@ -72,7 +76,7 @@ impl WatchTask {
     let options_ref = &*self.options;
 
     // Scope the bundler lock to minimize lock duration
-    let (result, new_watch_files, bundle_handle) = {
+    let (result, new_watch_files, new_watch_globs, bundle_handle) = {
       let mut bundler = self.bundler.lock().await;
 
       // Clear stale plugin driver state from previous build.
@@ -116,15 +120,25 @@ impl WatchTask {
       let bundle_handle =
         bundler.last_bundle_handle.clone().expect("bundle handle should exist after build");
 
-      // Collect watch files while we have the lock (may include render-phase files)
+      // Collect watch files and globs while we have the lock (may include render-phase additions)
       let new_watch_files: Vec<ArcStr> =
         bundle_handle.watch_files().iter().map(|f| f.clone()).collect();
+      let new_watch_globs: Vec<ArcStr> =
+        bundle_handle.watch_globs().iter().map(|g| g.clone()).collect();
 
-      (result, new_watch_files, bundle_handle)
+      (result, new_watch_files, new_watch_globs, bundle_handle)
     };
 
     // Also register any files discovered during render/write phase
     self.update_watch_files(&new_watch_files)?;
+
+    // Refresh globs from this build. Unlike watched_files, globs need no notify
+    // registration — they are matched against incoming paths on the fly.
+    // Plugins re-register globs each build, so we replace rather than accumulate.
+    self.watch_globs.clear();
+    for glob in new_watch_globs {
+      self.watch_globs.insert(glob);
+    }
 
     #[expect(clippy::cast_possible_truncation)]
     let duration = start_time.elapsed().as_millis() as u32;
@@ -255,10 +269,14 @@ impl WatchTask {
 
   /// Returns `true` if any stored glob pattern matches `path`.
   ///
-  /// Patterns must already be normalized to absolute form (done by `add_watch_glob`
-  /// at registration time). `path` is the absolute path emitted by `notify`.
+  /// Patterns are already normalized to absolute forward-slash form by
+  /// `add_watch_glob`. The incoming `path` is also normalized here so the
+  /// comparison works correctly on Windows.
   fn matches_watch_globs(&self, path: &str) -> bool {
-    todo!()
+    let normalized = pattern_filter::normalize_path(path);
+    self.watch_globs
+      .iter()
+      .any(|pattern| pattern_filter::glob_match_path(pattern.as_str(), &normalized))
   }
 
   fn is_watched_file(&self, path: &str) -> bool {
@@ -266,9 +284,13 @@ impl WatchTask {
       return true;
     }
 
-    // Windows path normalization
+    // Windows path normalization for exact-file matches
     #[cfg(windows)]
     if self.watched_files.contains(path.replace('\\', "/").as_str()) {
+      return true;
+    }
+
+    if self.matches_watch_globs(path) {
       return true;
     }
 
@@ -281,8 +303,8 @@ mod tests {
   use arcstr::ArcStr;
   use rolldown_utils::dashmap::FxDashSet;
 
-  /// Thin wrapper so tests can call `matches_watch_globs` without a full `WatchTask`.
-  /// Will be replaced by the real field + impl once the feature is built.
+  /// Standalone helper mirroring `WatchTask::matches_watch_globs` so tests
+  /// can exercise the logic without constructing a full `WatchTask`.
   fn matches_globs(globs: &FxDashSet<ArcStr>, path: &str) -> bool {
     globs
       .iter()

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -317,6 +317,10 @@ impl WatchTask {
   }
 
   fn matches_watch_globs(&self, path: &str) -> bool {
+    if self.watch_globs.is_empty() {
+      return false;
+    }
+
     let normalized = pattern_filter::normalize_path(path);
     self
       .watch_globs
@@ -340,70 +344,6 @@ impl WatchTask {
     }
 
     false
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use arcstr::ArcStr;
-  use rolldown_utils::dashmap::FxDashSet;
-
-  /// Standalone helper mirroring `WatchTask::matches_watch_globs` so tests
-  /// can exercise the logic without constructing a full `WatchTask`.
-  fn matches_globs(globs: &FxDashSet<ArcStr>, path: &str) -> bool {
-    globs
-      .iter()
-      .any(|pattern| rolldown_utils::pattern_filter::glob_match_path(pattern.as_str(), path))
-  }
-
-  #[test]
-  fn test_matches_watch_globs_double_star() {
-    let globs: FxDashSet<ArcStr> = FxDashSet::default();
-    globs.insert("/project/src/**/*.ts".into());
-
-    assert!(matches_globs(&globs, "/project/src/utils/helper.ts"));
-    assert!(matches_globs(&globs, "/project/src/deep/nested/file.ts"));
-    assert!(!matches_globs(&globs, "/project/src/utils/helper.js"));
-  }
-
-  #[test]
-  fn test_matches_watch_globs_single_star() {
-    let globs: FxDashSet<ArcStr> = FxDashSet::default();
-    globs.insert("/project/data/*.txt".into());
-
-    assert!(matches_globs(&globs, "/project/data/foo.txt"));
-    // single * does not cross directories
-    assert!(!matches_globs(&globs, "/project/data/nested/foo.txt"));
-    assert!(!matches_globs(&globs, "/project/data/foo.js"));
-  }
-
-  #[test]
-  fn test_matches_watch_globs_empty_set() {
-    let globs: FxDashSet<ArcStr> = FxDashSet::default();
-    assert!(!matches_globs(&globs, "/project/src/file.ts"));
-  }
-
-  #[test]
-  fn test_matches_watch_globs_multiple_patterns() {
-    let globs: FxDashSet<ArcStr> = FxDashSet::default();
-    globs.insert("/project/src/**/*.ts".into());
-    globs.insert("/project/data/*.txt".into());
-
-    assert!(matches_globs(&globs, "/project/src/file.ts"));
-    assert!(matches_globs(&globs, "/project/data/config.txt"));
-    assert!(!matches_globs(&globs, "/project/src/file.js"));
-    assert!(!matches_globs(&globs, "/project/other/file.ts"));
-  }
-
-  #[test]
-  fn test_non_matching_file_does_not_trigger() {
-    let globs: FxDashSet<ArcStr> = FxDashSet::default();
-    globs.insert("/project/src/**/*.ts".into());
-
-    // a .js file alongside .ts files should not match
-    assert!(!matches_globs(&globs, "/project/src/utils/helper.js"));
-    // a completely different directory should not match
-    assert!(!matches_globs(&globs, "/other/project/src/utils/helper.ts"));
   }
 }
 

--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -290,16 +290,16 @@ impl WatchTask {
       if base.is_empty() {
         continue;
       }
-      
+
       if self.watch_glob_dirs.contains(base) {
         continue;
       }
-      
+
       let base_path = Path::new(base);
       if !base_path.is_dir() {
         continue;
       }
-      
+
       let mode = if is_recursive { RecursiveMode::Recursive } else { RecursiveMode::NonRecursive };
       match watcher_paths.add(base_path, mode) {
         Ok(()) => {

--- a/packages/rolldown/src/api/rolldown/rolldown-build.ts
+++ b/packages/rolldown/src/api/rolldown/rolldown-build.ts
@@ -110,6 +110,14 @@ export class RolldownBuild {
     return Promise.resolve(this.#bundler.getWatchFiles());
   }
 
+  /**
+   * @experimental
+   * @hidden not ready for public usage yet
+   */
+  get watchGlobs(): Promise<string[]> {
+    return Promise.resolve(this.#bundler.getWatchGlobs());
+  }
+
   async #build(isWrite: boolean, outputOptions: OutputOptions): Promise<RolldownOutput> {
     validateOption('output', outputOptions);
     await this.#stopWorkers?.();

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1474,6 +1474,7 @@ export declare class BindingDevEngine {
 export declare class BindingLoadPluginContext {
   inner(): BindingPluginContext
   addWatchFile(file: string): void
+  addWatchGlob(glob: string): void
 }
 
 export declare class BindingMagicString {
@@ -1640,6 +1641,7 @@ export declare class BindingPluginContext {
   getModuleInfo(moduleId: string): BindingModuleInfo | null
   getModuleIds(): Array<string>
   addWatchFile(file: string): void
+  addWatchGlob(glob: string): void
 }
 
 export declare class BindingRenderedChunk {
@@ -1688,6 +1690,7 @@ export declare class BindingTransformPluginContext {
   getCombinedSourcemap(): string
   inner(): BindingPluginContext
   addWatchFile(file: string): void
+  addWatchGlob(glob: string): void
   sendMagicString(magicString: BindingMagicString): string | null
 }
 

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1418,6 +1418,7 @@ export declare class BindingBundler {
   close(): Promise<undefined>
   get closed(): boolean
   getWatchFiles(): Array<string>
+  getWatchGlobs(): Array<string>
 }
 
 export declare class BindingCallableBuiltinPlugin {

--- a/packages/rolldown/src/plugin/load-plugin-context.ts
+++ b/packages/rolldown/src/plugin/load-plugin-context.ts
@@ -25,4 +25,8 @@ export class LoadPluginContextImpl extends PluginContextImpl {
     // Use the inner context's addWatchFile which tracks dependencies for HMR
     this.inner.addWatchFile(id);
   }
+
+  public addWatchGlob(pattern: string): void {
+    this.inner.addWatchGlob(pattern);
+  }
 }

--- a/packages/rolldown/src/plugin/plugin-context.ts
+++ b/packages/rolldown/src/plugin/plugin-context.ts
@@ -234,6 +234,18 @@ export interface PluginContext extends MinimalPluginContext {
     id: string,
   ): void;
   /**
+   * Adds a glob pattern to be monitored in watch mode. Any file whose path matches the pattern
+   * will trigger a rebuild when changed.
+   */
+  addWatchGlob(
+    /**
+     * A glob pattern such as `"src/**\/*.ts"` or `"data/*.json"`.
+     *
+     * Relative patterns are resolved against the current working directory.
+     */
+    pattern: string,
+  ): void;
+  /**
    * Loads and parses the module corresponding to the given id, attaching additional
    * meta information to the module if provided. This will trigger the same
    * {@linkcode Plugin.load | load}, {@linkcode Plugin.transform | transform} and
@@ -427,6 +439,10 @@ export class PluginContextImpl extends MinimalPluginContextImpl {
 
   public addWatchFile(id: string): void {
     this.context.addWatchFile(id);
+  }
+
+  public addWatchGlob(pattern: string): void {
+    this.context.addWatchGlob(pattern);
   }
 
   public parse(input: string, options?: ParserOptions | null): Program {

--- a/packages/rolldown/src/plugin/transform-plugin-context.ts
+++ b/packages/rolldown/src/plugin/transform-plugin-context.ts
@@ -106,6 +106,10 @@ export class TransformPluginContextImpl extends PluginContextImpl {
     this.inner.addWatchFile(id);
   }
 
+  public addWatchGlob(pattern: string): void {
+    this.inner.addWatchGlob(pattern);
+  }
+
   public sendMagicString(s: BindingMagicString): void {
     this.inner.sendMagicString(s);
   }

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -1195,7 +1195,6 @@ test.concurrent(
     const { dir } = createTestWithMultiFiles('addWatchGlob-modify', retryCount, {
       'main.js': `console.log(1)`,
     });
-    // Create a src/ subdirectory with a file that matches the glob
     const srcDir = path.join(dir, 'src');
     fs.mkdirSync(srcDir, { recursive: true });
     const watchedFile = path.join(srcDir, 'data.txt');
@@ -1242,7 +1241,6 @@ test.concurrent(
     const { dir } = createTestWithMultiFiles('addWatchGlob-create', retryCount, {
       'main.js': `console.log(1)`,
     });
-    // src/ starts empty — no files exist yet that match the glob
     const srcDir = path.join(dir, 'src');
     fs.mkdirSync(srcDir, { recursive: true });
 
@@ -1266,16 +1264,12 @@ test.concurrent(
 
     await waitBuildFinished(watcher);
 
-    // Count rebuilds triggered after the initial build
     let rebuildCount = 0;
     watcher.on('event', (event) => {
       if (event.code === 'BUNDLE_START') rebuildCount++;
     });
 
-    // Create a brand-new file that matches the glob — this is the key scenario
-    // that addWatchGlob handles and addWatchFile cannot (file didn't exist at build time)
     await editFile(path.join(srcDir, 'new.txt'), 'hello');
-
     await expect.poll(() => rebuildCount, { timeout: TEST_TIMEOUT }).toBeGreaterThan(0);
   },
 );
@@ -1290,9 +1284,7 @@ test.concurrent(
     });
     const srcDir = path.join(dir, 'src');
     fs.mkdirSync(srcDir, { recursive: true });
-    // This file matches the glob and IS watched
     fs.writeFileSync(path.join(srcDir, 'watched.txt'), 'watched');
-    // This file does NOT match the glob (wrong extension) and should be ignored
     const ignoredFile = path.join(srcDir, 'ignored.js');
     fs.writeFileSync(ignoredFile, 'ignored');
 
@@ -1321,7 +1313,6 @@ test.concurrent(
       if (event.code === 'BUNDLE_START') rebuildCount++;
     });
 
-    // Modify the ignored .js file — must not trigger a rebuild
     await editFile(ignoredFile, 'still ignored');
     // Wait long enough that any spurious rebuild would have already fired
     await sleep(3000);
@@ -1367,7 +1358,6 @@ test.concurrent(
       if (event.code === 'BUNDLE_START') rebuildCount++;
     });
 
-    // Delete the watched file — should trigger a rebuild
     await deleteFile(watchedFile);
     await expect.poll(() => rebuildCount, { timeout: TEST_TIMEOUT }).toBeGreaterThan(0);
   },

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -1187,6 +1187,192 @@ test.concurrent(
   },
 );
 
+test.concurrent(
+  'PluginContext addWatchGlob - modify existing file triggers rebuild',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('addWatchGlob-modify', retryCount, {
+      'main.js': `console.log(1)`,
+    });
+    // Create a src/ subdirectory with a file that matches the glob
+    const srcDir = path.join(dir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    const watchedFile = path.join(srcDir, 'data.txt');
+    fs.writeFileSync(watchedFile, 'version=1');
+
+    const watcher = watch({
+      cwd: dir,
+      input: 'main.js',
+      output: { file: path.join(dir, 'dist', 'main.js') },
+      plugins: [
+        {
+          name: 'test-addWatchGlob-modify',
+          buildStart() {
+            this.addWatchGlob(path.join(srcDir, '*.txt'));
+          },
+        },
+      ],
+    });
+    onTestFinished(async () => {
+      await watcher.close();
+      if (!process.env.CI) fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    await waitBuildFinished(watcher);
+
+    const changeFn = vi.fn();
+    watcher.on('change', (id, event) => {
+      if (event.event === 'update') {
+        changeFn();
+        expect(id).toBe(watchedFile);
+      }
+    });
+
+    await editFile(watchedFile, 'version=2');
+    await expect.poll(() => changeFn).toBeCalled();
+  },
+);
+
+test.concurrent(
+  'PluginContext addWatchGlob - create new file matching glob triggers rebuild',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('addWatchGlob-create', retryCount, {
+      'main.js': `console.log(1)`,
+    });
+    // src/ starts empty — no files exist yet that match the glob
+    const srcDir = path.join(dir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+
+    const watcher = watch({
+      cwd: dir,
+      input: 'main.js',
+      output: { file: path.join(dir, 'dist', 'main.js') },
+      plugins: [
+        {
+          name: 'test-addWatchGlob-create',
+          buildStart() {
+            this.addWatchGlob(path.join(srcDir, '*.txt'));
+          },
+        },
+      ],
+    });
+    onTestFinished(async () => {
+      await watcher.close();
+      if (!process.env.CI) fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    await waitBuildFinished(watcher);
+
+    // Count rebuilds triggered after the initial build
+    let rebuildCount = 0;
+    watcher.on('event', (event) => {
+      if (event.code === 'BUNDLE_START') rebuildCount++;
+    });
+
+    // Create a brand-new file that matches the glob — this is the key scenario
+    // that addWatchGlob handles and addWatchFile cannot (file didn't exist at build time)
+    await editFile(path.join(srcDir, 'new.txt'), 'hello');
+
+    await expect.poll(() => rebuildCount, { timeout: TEST_TIMEOUT }).toBeGreaterThan(0);
+  },
+);
+
+test.concurrent(
+  'PluginContext addWatchGlob - modifying non-matching file should not trigger rebuild',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('addWatchGlob-no-rebuild', retryCount, {
+      'main.js': `console.log(1)`,
+    });
+    const srcDir = path.join(dir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    // This file matches the glob and IS watched
+    fs.writeFileSync(path.join(srcDir, 'watched.txt'), 'watched');
+    // This file does NOT match the glob (wrong extension) and should be ignored
+    const ignoredFile = path.join(srcDir, 'ignored.js');
+    fs.writeFileSync(ignoredFile, 'ignored');
+
+    const watcher = watch({
+      cwd: dir,
+      input: 'main.js',
+      output: { file: path.join(dir, 'dist', 'main.js') },
+      plugins: [
+        {
+          name: 'test-addWatchGlob-no-rebuild',
+          buildStart() {
+            this.addWatchGlob(path.join(srcDir, '*.txt'));
+          },
+        },
+      ],
+    });
+    onTestFinished(async () => {
+      await watcher.close();
+      if (!process.env.CI) fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    await waitBuildFinished(watcher);
+
+    let rebuildCount = 0;
+    watcher.on('event', (event) => {
+      if (event.code === 'BUNDLE_START') rebuildCount++;
+    });
+
+    // Modify the ignored .js file — must not trigger a rebuild
+    await editFile(ignoredFile, 'still ignored');
+    // Wait long enough that any spurious rebuild would have already fired
+    await sleep(3000);
+    expect(rebuildCount).toBe(0);
+  },
+);
+
+test.concurrent(
+  'PluginContext addWatchGlob - deleting a matching file triggers rebuild',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('addWatchGlob-delete', retryCount, {
+      'main.js': `console.log(1)`,
+    });
+    const srcDir = path.join(dir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    const watchedFile = path.join(srcDir, 'data.txt');
+    fs.writeFileSync(watchedFile, 'version=1');
+
+    const watcher = watch({
+      cwd: dir,
+      input: 'main.js',
+      output: { file: path.join(dir, 'dist', 'main.js') },
+      plugins: [
+        {
+          name: 'test-addWatchGlob-delete',
+          buildStart() {
+            this.addWatchGlob(path.join(srcDir, '*.txt'));
+          },
+        },
+      ],
+    });
+    onTestFinished(async () => {
+      await watcher.close();
+      if (!process.env.CI) fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    await waitBuildFinished(watcher);
+
+    let rebuildCount = 0;
+    watcher.on('event', (event) => {
+      if (event.code === 'BUNDLE_START') rebuildCount++;
+    });
+
+    // Delete the watched file — should trigger a rebuild
+    await deleteFile(watchedFile);
+    await expect.poll(() => rebuildCount, { timeout: TEST_TIMEOUT }).toBeGreaterThan(0);
+  },
+);
+
 function createTestInputAndOutput(testLabel: string, retryCount: number, content?: string) {
   const uniqueId = crypto.randomUUID().slice(0, 8);
   const dirname = `${testLabel}-${uniqueId}-retry${retryCount}`;


### PR DESCRIPTION
Resolve #8491 

## Context

Although Rolldown provides `addWatchFile` api, like the original issue and related issues mentioned, it would be useful to add a new API `addWatchGlob` allows glob watching.

## Implementation

Add a new API: `addWatchGlob(globPattern: string)`. Follow the existing pattern of `addWatchFile`, if multiple globs need to be watched, users need to add them one by one.

`watch_task.rs` holds core logic. For all passed globs, extract the static base directory and register those directories to `fs_watcher` after each build.

When Notify emits a file system event, `matches_watch_globs` check the event path against `watch_globs`. If matched, a rebuild will be triggered.

## Test

Follow the existing pattern, add some tests in `watch.test.ts` to cover:

- Modify existing file triggers rebuild
- Create new file matching glob triggers rebuild
- Modifying non-matching file should not trigger rebuild
- Deleting a matching file triggers rebuild

## Following work

Original issue and [API usage in tsdown](https://github.com/rolldown/tsdown/blob/2b1be7e0accdb1d6e903cd42642666431fc5e93d/src/features/watch.ts#L24-L26) show it maybe worth to support users provide multiple globs or files one time. But if we really want to support it, it would be better to do in a separated PR.

Documentation updating would be included in a separated PR once maintainer think this PR is good to merged, so that we have enough information about the API behavior to write the document.
