### PR TITLE
ci: skip building examples in cargo-test to reduce build time

### DIFF
--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
 
       - name: Build
-        run: cargo test --workspace --exclude rolldown_binding --no-run
+        run: cargo test --workspace --exclude rolldown_binding --lib --tests --no-run
 
       - name: Run Test
         run: just test-rust

--- a/justfile
+++ b/justfile
@@ -60,7 +60,7 @@ test-update-node:
 
 # Run Rust tests.
 test-rust: pnpm-install
-  cargo test --workspace --exclude rolldown_binding
+  cargo test --workspace --exclude rolldown_binding --lib --tests
 
 # Run Node.js tests for Rolldown.
 test-node-rolldown *args="": build-rolldown


### PR DESCRIPTION
## Summary

- Add `--lib --tests` flags to `cargo test` in CI build step and `just test-rust` recipe
- Skips compiling 6 examples (basic, dev, lazy, build_bench_rome_ts, build_bench_threejs10x, watch) that are never executed as tests
- Saves ~15s CPU time (~4-5s wall time on CI) per cargo-test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)