### PR TITLE
chore: skip running empty bin test targets

### DIFF
--- a/tasks/generator/Cargo.toml
+++ b/tasks/generator/Cargo.toml
@@ -28,5 +28,10 @@ syn = { workspace = true, features = [
   "printing",
   "proc-macro",
 ] }
+
+[[bin]]
+name = "generator"
+test = false
+
 [lints]
 workspace = true

--- a/tasks/ls_lint/Cargo.toml
+++ b/tasks/ls_lint/Cargo.toml
@@ -15,5 +15,9 @@ rolldown_workspace = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+[[bin]]
+name = "ls-lint"
+test = false
+
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- Set `test = false` on the `generator` and `ls-lint` binary targets so `cargo test` no longer compiles and runs them with 0 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)