### PR TITLE
perf: replace FxHashMap with IndexVec for sequential index keys

### DIFF
--- a/crates/rolldown/src/ast_scanner/const_eval.rs
+++ b/crates/rolldown/src/ast_scanner/const_eval.rs
@@ -8,13 +8,13 @@ use oxc_ecmascript::{
   constant_evaluation::{ConstantEvaluation, ConstantEvaluationCtx},
   side_effects::MayHaveSideEffectsContext,
 };
+use oxc_index::IndexVec;
 use rolldown_common::{ConstExportMeta, ConstantValue};
-use rustc_hash::FxHashMap;
 
 pub struct ConstEvalCtx<'me, 'ast: 'me> {
   pub ast: oxc::ast::AstBuilder<'ast>,
   pub scope: &'me Scoping,
-  pub constant_map: &'me FxHashMap<SymbolId, ConstExportMeta>,
+  pub constant_map: &'me IndexVec<SymbolId, Option<ConstExportMeta>>,
   pub overrode_get_constant_value_from_reference_id: Option<
     &'me dyn Fn(ReferenceId) -> Option<oxc_ecmascript::constant_evaluation::ConstantValue<'ast>>,
   >,
@@ -42,7 +42,7 @@ impl<'ast> GlobalContext<'ast> for ConstEvalCtx<'_, 'ast> {
     }
     let reference = self.scope.get_reference(reference_id);
     let symbol_id = reference.symbol_id()?;
-    let v = self.constant_map.get(&symbol_id)?;
+    let v = self.constant_map.get(symbol_id)?.as_ref()?;
     Some(oxc_ecmascript::constant_evaluation::ConstantValue::from(&v.value))
   }
 }

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -1,5 +1,4 @@
 use oxc::allocator::{GetAddress, UnstableAddress};
-use oxc_index::IndexVec;
 use oxc::{
   ast::{
     AstKind,
@@ -12,6 +11,7 @@ use oxc::{
   semantic::{ScopeFlags, SymbolId},
   span::{GetSpan, Span},
 };
+use oxc_index::IndexVec;
 use rolldown_common::{
   ConstExportMeta, EcmaModuleAstUsage, EcmaViewMeta, ImportKind, ImportRecordMeta, LocalExport,
   MemberExprObjectReferencedType, OutputFormat, RUNTIME_MODULE_KEY, SideEffectDetail, StmtInfoIdx,
@@ -152,7 +152,8 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     self.result.hashbang_range = program.hashbang.as_ref().map(GetSpan::span);
     self.result.directive_range = program.directives.iter().map(GetSpan::span).collect();
     {
-      let old_map = std::mem::take(&mut self.dynamic_import_usage_info.dynamic_import_exports_usage);
+      let old_map =
+        std::mem::take(&mut self.dynamic_import_usage_info.dynamic_import_exports_usage);
       let mut new_vec = IndexVec::with_capacity(self.result.import_records.len());
       new_vec.resize(self.result.import_records.len(), None);
       for (k, v) in old_map {

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -1,4 +1,5 @@
 use oxc::allocator::{GetAddress, UnstableAddress};
+use oxc_index::IndexVec;
 use oxc::{
   ast::{
     AstKind,
@@ -150,19 +151,28 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
     self.result.hashbang_range = program.hashbang.as_ref().map(GetSpan::span);
     self.result.directive_range = program.directives.iter().map(GetSpan::span).collect();
-    self.result.dynamic_import_rec_exports_usage =
-      std::mem::take(&mut self.dynamic_import_usage_info.dynamic_import_exports_usage);
+    {
+      let old_map = std::mem::take(&mut self.dynamic_import_usage_info.dynamic_import_exports_usage);
+      let mut new_vec = IndexVec::with_capacity(self.result.import_records.len());
+      new_vec.resize(self.result.import_records.len(), None);
+      for (k, v) in old_map {
+        new_vec[k] = Some(v);
+      }
+      self.result.dynamic_import_rec_exports_usage = new_vec;
+    }
     if self.result.ecma_view_meta.contains(EcmaViewMeta::Eval) {
       // if there exists `eval` in current module, assume all dynamic import are completely used;
-      for usage in self.result.dynamic_import_rec_exports_usage.values_mut() {
+      for usage in self.result.dynamic_import_rec_exports_usage.iter_mut().flatten() {
         *usage = DynamicImportExportsUsage::Complete;
       }
     }
 
     // Check if dynamic import record is a pure dynamic import
-    for (rec_idx, usage) in &self.result.dynamic_import_rec_exports_usage {
-      if matches!(usage, DynamicImportExportsUsage::Partial(set) if set.is_empty()) {
-        self.result.import_records[*rec_idx].meta.insert(ImportRecordMeta::PureDynamicImport);
+    for (rec_idx, usage) in self.result.dynamic_import_rec_exports_usage.iter_enumerated() {
+      if let Some(usage) = usage {
+        if matches!(usage, DynamicImportExportsUsage::Partial(set) if set.is_empty()) {
+          self.result.import_records[rec_idx].meta.insert(ImportRecordMeta::PureDynamicImport);
+        }
       }
     }
 

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -107,15 +107,15 @@ pub struct ScanResult {
   pub hashbang_range: Option<Span>,
   /// we don't know the ImportRecord related ModuleIdx yet, so use ImportRecordIdx as key
   /// temporarily
-  pub dynamic_import_rec_exports_usage: FxHashMap<ImportRecordIdx, DynamicImportExportsUsage>,
+  pub dynamic_import_rec_exports_usage: IndexVec<ImportRecordIdx, Option<DynamicImportExportsUsage>>,
   /// `new URL('...', import.meta.url)`
   pub new_url_references: FxHashMap<Span, ImportRecordIdx>,
   pub this_expr_replace_map: FxHashMap<Span, ThisExprReplaceKind>,
   pub hmr_info: HmrInfo,
   pub hmr_hot_ref: Option<SymbolRef>,
   pub directive_range: Vec<Span>,
-  pub constant_export_map: FxHashMap<SymbolId, ConstExportMeta>,
-  pub import_attribute_map: FxHashMap<ImportRecordIdx, ImportAttribute>,
+  pub constant_export_map: IndexVec<SymbolId, Option<ConstExportMeta>>,
+  pub import_attribute_map: IndexVec<ImportRecordIdx, Option<ImportAttribute>>,
 }
 
 bitflags::bitflags! {
@@ -212,7 +212,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       symbol_ref_db,
       self_referenced_class_decl_symbol_ids: FxHashSet::default(),
       hashbang_range: None,
-      dynamic_import_rec_exports_usage: FxHashMap::default(),
+      dynamic_import_rec_exports_usage: IndexVec::new(),
       new_url_references: FxHashMap::default(),
       this_expr_replace_map: FxHashMap::default(),
       hmr_info: HmrInfo::default(),
@@ -220,9 +220,9 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       directive_range: vec![],
       dummy_record_set: FxHashSet::default(),
       commonjs_exports: FxHashMap::default(),
-      constant_export_map: FxHashMap::default(),
+      constant_export_map: IndexVec::new(),
       ecma_view_meta: EcmaViewMeta::default(),
-      import_attribute_map: FxHashMap::default(),
+      import_attribute_map: IndexVec::new(),
     };
 
     Self {
@@ -389,15 +389,20 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       self.result.ast_usage.insert(EcmaModuleAstUsage::ModuleRef);
     }
 
-    self.result.constant_export_map.retain(|symbol_id, constant_meta| {
-      (constant_meta.commonjs_export && !bailout_inlined_cjs_exports_symbol_ids.contains(symbol_id))
-        || self
-          .result
-          .symbol_ref_db
-          .flags
-          .get(symbol_id)
-          .is_some_and(|flag| flag.contains(SymbolRefFlags::IsNotReassigned))
-    });
+    for (symbol_id, slot) in self.result.constant_export_map.iter_mut_enumerated() {
+      if let Some(constant_meta) = slot {
+        let keep = (constant_meta.commonjs_export
+          && !bailout_inlined_cjs_exports_symbol_ids.contains(&symbol_id))
+          || self
+            .result
+            .symbol_ref_db
+            .flags[symbol_id]
+            .contains(SymbolRefFlags::IsNotReassigned);
+        if !keep {
+          *slot = None;
+        }
+      }
+    }
 
     if cfg!(debug_assertions) {
       use rustc_hash::FxHashSet;
@@ -672,7 +677,8 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     }
     self.result.imports.insert(decl.span, id);
     if let Some(ref with_clause) = decl.with_clause {
-      self.result.import_attribute_map.insert(id, ImportAttribute::from_with_clause(with_clause));
+      self.result.import_attribute_map.resize(id.index() + 1, None);
+      self.result.import_attribute_map[id] = Some(ImportAttribute::from_with_clause(with_clause));
     }
   }
 
@@ -711,10 +717,9 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         );
       });
       if let Some(ref with_clause) = decl.with_clause {
-        self
-          .result
-          .import_attribute_map
-          .insert(record_idx, ImportAttribute::from_with_clause(with_clause));
+        self.result.import_attribute_map.resize(record_idx.index() + 1, None);
+        self.result.import_attribute_map[record_idx] =
+          Some(ImportAttribute::from_with_clause(with_clause));
       }
       self.result.imports.insert(decl.span, record_idx);
     } else {
@@ -754,9 +759,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
                   self
                     .result
                     .symbol_ref_db
-                    .flags
-                    .entry(symbol_id)
-                    .or_default()
+                    .flags[symbol_id]
                     .insert(SymbolRefFlags::SideEffectsFreeFunction);
                 }
               }
@@ -771,9 +774,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
               self
                 .result
                 .symbol_ref_db
-                .flags
-                .entry(symbol_id)
-                .or_default()
+                .flags[symbol_id]
                 .insert(SymbolRefFlags::SideEffectsFreeFunction);
             }
           }
@@ -832,9 +833,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
           self
             .result
             .symbol_ref_db
-            .flags
-            .entry(self.result.default_export_ref.symbol)
-            .or_default()
+            .flags[self.result.default_export_ref.symbol]
             .insert(SymbolRefFlags::SideEffectsFreeFunction);
         }
         fn_decl.id.as_ref().map(|id| {
@@ -881,10 +880,9 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     );
 
     if let Some(ref with_clause) = decl.with_clause {
-      self
-        .result
-        .import_attribute_map
-        .insert(rec_id, ImportAttribute::from_with_clause(with_clause));
+      self.result.import_attribute_map.resize(rec_id.index() + 1, None);
+      self.result.import_attribute_map[rec_id] =
+        Some(ImportAttribute::from_with_clause(with_clause));
     }
     self.result.imports.insert(decl.span, rec_id);
 
@@ -1081,7 +1079,8 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     if is_mutated {
       return;
     }
-    self.result.constant_export_map.insert(symbol_id, value);
+    self.result.constant_export_map.resize(symbol_id.index() + 1, None);
+    self.result.constant_export_map[symbol_id] = Some(value);
   }
 
   fn is_import_expr_ignored_by_comment(&mut self, expr: &ImportExpression<'ast>) -> bool {

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -107,7 +107,8 @@ pub struct ScanResult {
   pub hashbang_range: Option<Span>,
   /// we don't know the ImportRecord related ModuleIdx yet, so use ImportRecordIdx as key
   /// temporarily
-  pub dynamic_import_rec_exports_usage: IndexVec<ImportRecordIdx, Option<DynamicImportExportsUsage>>,
+  pub dynamic_import_rec_exports_usage:
+    IndexVec<ImportRecordIdx, Option<DynamicImportExportsUsage>>,
   /// `new URL('...', import.meta.url)`
   pub new_url_references: FxHashMap<Span, ImportRecordIdx>,
   pub this_expr_replace_map: FxHashMap<Span, ThisExprReplaceKind>,
@@ -393,11 +394,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       if let Some(constant_meta) = slot {
         let keep = (constant_meta.commonjs_export
           && !bailout_inlined_cjs_exports_symbol_ids.contains(&symbol_id))
-          || self
-            .result
-            .symbol_ref_db
-            .flags[symbol_id]
-            .contains(SymbolRefFlags::IsNotReassigned);
+          || self.result.symbol_ref_db.flags[symbol_id].contains(SymbolRefFlags::IsNotReassigned);
         if !keep {
           *slot = None;
         }
@@ -756,10 +753,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
                     .result
                     .ecma_view_meta
                     .insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-                  self
-                    .result
-                    .symbol_ref_db
-                    .flags[symbol_id]
+                  self.result.symbol_ref_db.flags[symbol_id]
                     .insert(SymbolRefFlags::SideEffectsFreeFunction);
                 }
               }
@@ -771,10 +765,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
             self.add_local_export(binding_id.name.as_str(), symbol_id, binding_id.span);
             if fn_decl.is_side_effect_free() || fn_decl.pure {
               self.result.ecma_view_meta.insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-              self
-                .result
-                .symbol_ref_db
-                .flags[symbol_id]
+              self.result.symbol_ref_db.flags[symbol_id]
                 .insert(SymbolRefFlags::SideEffectsFreeFunction);
             }
           }
@@ -830,10 +821,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       ast::ExportDefaultDeclarationKind::FunctionDeclaration(fn_decl) => {
         if fn_decl.is_side_effect_free() || fn_decl.pure {
           self.result.ecma_view_meta.insert(EcmaViewMeta::TopExportedSideEffectsFreeFunction);
-          self
-            .result
-            .symbol_ref_db
-            .flags[self.result.default_export_ref.symbol]
+          self.result.symbol_ref_db.flags[self.result.default_export_ref.symbol]
             .insert(SymbolRefFlags::SideEffectsFreeFunction);
         }
         fn_decl.id.as_ref().map(|id| {

--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -19,11 +19,11 @@ pub struct ChunkGraph {
   /// If the namespace is not merged, `Key` == `Value`.
   /// If the namespace is merged, `Key` is the original namespace symbol, and `Value` is the linked namespace symbol.
   pub finalized_cjs_ns_map_idx_vec: IndexVec<ChunkIdx, FxHashMap<SymbolRef, SymbolRef>>,
-  pub chunk_idx_to_reference_ids: FxHashMap<ChunkIdx, Vec<ArcStr>>,
-  pub common_chunk_exported_facade_chunk_namespace: FxHashMap<ChunkIdx, FxHashSet<ModuleIdx>>,
+  pub chunk_idx_to_reference_ids: IndexVec<ChunkIdx, Vec<ArcStr>>,
+  pub common_chunk_exported_facade_chunk_namespace: IndexVec<ChunkIdx, FxHashSet<ModuleIdx>>,
   /// Modules from emitted chunks with AllowExtension that were merged into common chunks.
   /// Their export names should be preserved (not minified).
-  pub common_chunk_preserve_export_names_modules: FxHashMap<ChunkIdx, FxHashSet<ModuleIdx>>,
+  pub common_chunk_preserve_export_names_modules: IndexVec<ChunkIdx, FxHashSet<ModuleIdx>>,
   /// Tracks chunks that have been removed during post-optimization of code splitting.
   ///
   /// Since chunks are stored in an `IndexVec`, we have two options when removing chunks:
@@ -31,7 +31,7 @@ pub struct ChunkGraph {
   /// 2. Keep them in place and mark them as dead
   ///
   /// We use the second approach to avoid the overhead of re-indexing at the cost of some extra memory.
-  pub post_chunk_optimization_operations: FxHashMap<ChunkIdx, PostChunkOptimizationOperation>,
+  pub post_chunk_optimization_operations: IndexVec<ChunkIdx, Option<PostChunkOptimizationOperation>>,
 }
 
 impl ChunkGraph {
@@ -42,10 +42,10 @@ impl ChunkGraph {
       sorted_chunk_idx_vec: Vec::new(),
       entry_module_to_entry_chunk: FxHashMap::default(),
       finalized_cjs_ns_map_idx_vec: index_vec![],
-      chunk_idx_to_reference_ids: FxHashMap::default(),
-      common_chunk_exported_facade_chunk_namespace: FxHashMap::default(),
-      common_chunk_preserve_export_names_modules: FxHashMap::default(),
-      post_chunk_optimization_operations: FxHashMap::default(),
+      chunk_idx_to_reference_ids: index_vec![],
+      common_chunk_exported_facade_chunk_namespace: index_vec![],
+      common_chunk_preserve_export_names_modules: index_vec![],
+      post_chunk_optimization_operations: index_vec![],
     }
   }
 
@@ -57,6 +57,10 @@ impl ChunkGraph {
   pub fn add_chunk(&mut self, chunk: Chunk) -> ChunkIdx {
     let idx = self.chunk_table.push(chunk);
     self.finalized_cjs_ns_map_idx_vec.push(FxHashMap::default());
+    self.chunk_idx_to_reference_ids.push(Vec::new());
+    self.common_chunk_exported_facade_chunk_namespace.push(FxHashSet::default());
+    self.common_chunk_preserve_export_names_modules.push(FxHashSet::default());
+    self.post_chunk_optimization_operations.push(None);
     idx
   }
 

--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -31,7 +31,8 @@ pub struct ChunkGraph {
   /// 2. Keep them in place and mark them as dead
   ///
   /// We use the second approach to avoid the overhead of re-indexing at the cost of some extra memory.
-  pub post_chunk_optimization_operations: IndexVec<ChunkIdx, Option<PostChunkOptimizationOperation>>,
+  pub post_chunk_optimization_operations:
+    IndexVec<ChunkIdx, Option<PostChunkOptimizationOperation>>,
 }
 
 impl ChunkGraph {

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -258,7 +258,8 @@ fn render_esm_chunk_imports(ctx: &GenerateContext<'_>) -> Option<String> {
     // TODO: Warning same import record has different import attributes. https://tinyurl.com/2ddnbbc8
     named_imports.iter().for_each(|(idx, named_import)| {
       let module = ctx.link_output.module_table[*idx].as_normal().unwrap();
-      if module.import_attribute_map.get(named_import.record_idx).and_then(|v| v.as_ref()).is_some() {
+      if module.import_attribute_map.get(named_import.record_idx).and_then(|v| v.as_ref()).is_some()
+      {
         if import_attribute.is_none() {
           import_attribute = Some((module.idx, named_import.record_idx));
         }

--- a/crates/rolldown/src/ecmascript/format/esm.rs
+++ b/crates/rolldown/src/ecmascript/format/esm.rs
@@ -258,7 +258,7 @@ fn render_esm_chunk_imports(ctx: &GenerateContext<'_>) -> Option<String> {
     // TODO: Warning same import record has different import attributes. https://tinyurl.com/2ddnbbc8
     named_imports.iter().for_each(|(idx, named_import)| {
       let module = ctx.link_output.module_table[*idx].as_normal().unwrap();
-      if module.import_attribute_map.contains_key(&named_import.record_idx) {
+      if module.import_attribute_map.get(named_import.record_idx).and_then(|v| v.as_ref()).is_some() {
         if import_attribute.is_none() {
           import_attribute = Some((module.idx, named_import.record_idx));
         }
@@ -286,7 +286,7 @@ fn create_import_declaration(
   let mut ret = String::new();
   let with_clause_string = with_clause.and_then(|(module_idx, record_idx)| {
     let module = module_table[module_idx].as_normal()?;
-    let import_attribute = module.import_attribute_map.get(&record_idx)?;
+    let import_attribute = module.import_attribute_map.get(record_idx)?.as_ref()?;
     Some(import_attribute.to_string())
   });
   let first_default_alias = match &default_alias {

--- a/crates/rolldown/src/module_finalizers/finalizer_context.rs
+++ b/crates/rolldown/src/module_finalizers/finalizer_context.rs
@@ -10,6 +10,7 @@ pub type FinalizerMutableFields = (
 );
 
 use oxc::ast_visit::VisitMut as _;
+use oxc_index::IndexVec;
 use rolldown_ecmascript::EcmaAst;
 use rolldown_ecmascript_utils::AstSnippet;
 use rolldown_utils::indexmap::{FxIndexMap, FxIndexSet};
@@ -38,7 +39,7 @@ pub struct ScopeHoistingFinalizerContext<'me> {
   pub file_emitter: &'me SharedFileEmitter,
   pub constant_value_map: &'me FxHashMap<SymbolRef, ConstExportMeta>,
   pub side_effect_free_function_symbols: &'me FxHashSet<SymbolRef>,
-  pub safely_merge_cjs_ns_map: &'me FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
+  pub safely_merge_cjs_ns_map: &'me IndexVec<ModuleIdx, Option<SafelyMergeCjsNsInfo>>,
   pub used_symbol_refs: &'me FxHashSet<SymbolRef>,
   /// Pre-resolved paths for external modules (always a `FxHashMap` variant).
   pub resolved_paths: Option<&'me PathsOutputOption>,

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -143,7 +143,7 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       }
       WrapKind::Cjs => {
         // Check if this CJS module's namespace can be merged with other imports
-        let merge_info = self.ctx.safely_merge_cjs_ns_map.get(&resolved_module_idx);
+        let merge_info = self.ctx.safely_merge_cjs_ns_map[resolved_module_idx].as_ref();
 
         // Consider user reference a module use relative path e.g.
         // ```js
@@ -1720,9 +1720,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     let needs_namespace_extraction = self
       .ctx
       .chunk_graph
-      .common_chunk_exported_facade_chunk_namespace
-      .get(&importee_chunk_idx)
-      .is_some_and(|set| set.contains(&importee_idx));
+      .common_chunk_exported_facade_chunk_namespace[importee_chunk_idx]
+      .contains(&importee_idx);
 
     if !needs_namespace_extraction {
       return None;

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1717,11 +1717,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
   ) -> Option<Expression<'ast>> {
     let importee_idx = importee.idx;
     // to make sure the semantic is correct after chunk merging optimization.
-    let needs_namespace_extraction = self
-      .ctx
-      .chunk_graph
-      .common_chunk_exported_facade_chunk_namespace[importee_chunk_idx]
-      .contains(&importee_idx);
+    let needs_namespace_extraction =
+      self.ctx.chunk_graph.common_chunk_exported_facade_chunk_namespace[importee_chunk_idx]
+        .contains(&importee_idx);
 
     if !needs_namespace_extraction {
       return None;

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -454,7 +454,9 @@ impl<'a> ModuleLoader<'a> {
             });
 
             // Defer usage merging - with only one consumer, keep fetch actions simple
-            if let Some(usage) = dynamic_import_rec_exports_usage.get_mut(rec_idx).and_then(Option::take) {
+            if let Some(usage) =
+              dynamic_import_rec_exports_usage.get_mut(rec_idx).and_then(Option::take)
+            {
               dynamic_import_exports_usage_pairs.push((idx, usage));
             }
             if matches!(raw_rec.kind, ImportKind::DynamicImport)

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -454,7 +454,7 @@ impl<'a> ModuleLoader<'a> {
             });
 
             // Defer usage merging - with only one consumer, keep fetch actions simple
-            if let Some(usage) = dynamic_import_rec_exports_usage.remove(&rec_idx) {
+            if let Some(usage) = dynamic_import_rec_exports_usage.get_mut(rec_idx).and_then(Option::take) {
               dynamic_import_exports_usage_pairs.push((idx, usage));
             }
             if matches!(raw_rec.kind, ImportKind::DynamicImport)

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -193,9 +193,9 @@ impl RuntimeModuleTask {
         hmr_hot_ref: None,
         directive_range: vec![],
         dummy_record_set,
-        constant_export_map: FxHashMap::default(),
+        constant_export_map: IndexVec::new(),
         depended_runtime_helper: Box::default(),
-        import_attribute_map: FxHashMap::default(),
+        import_attribute_map: IndexVec::new(),
         json_module_none_self_reference_included_symbol: None,
       },
       // TODO(hyf0/hmr): We might need to find a better way to handle this.

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -934,21 +934,16 @@ impl GenerateStage<'_> {
         continue;
       };
 
-      chunk_graph.post_chunk_optimization_operations.insert(
-        *from_chunk_idx,
-        if chunk_meta.contains(ChunkMeta::EmittedChunk) {
+      chunk_graph.post_chunk_optimization_operations[*from_chunk_idx] =
+        Some(if chunk_meta.contains(ChunkMeta::EmittedChunk) {
           PostChunkOptimizationOperation::RemovedWithPreservedExports
         } else {
           PostChunkOptimizationOperation::Removed
-        },
-      );
+        });
 
       // Track emitted chunks so their export names are preserved (not minified)
       if chunk_meta.contains(ChunkMeta::EmittedChunk) {
-        chunk_graph
-          .common_chunk_preserve_export_names_modules
-          .entry(*to_chunk_idx)
-          .or_default()
+        chunk_graph.common_chunk_preserve_export_names_modules[*to_chunk_idx]
           .insert(*entry_module_idx);
       }
 
@@ -956,10 +951,7 @@ impl GenerateStage<'_> {
       if !chunk_meta.contains(ChunkMeta::DynamicImported) {
         continue;
       }
-      chunk_graph
-        .common_chunk_exported_facade_chunk_namespace
-        .entry(*to_chunk_idx)
-        .or_default()
+      chunk_graph.common_chunk_exported_facade_chunk_namespace[*to_chunk_idx]
         .insert(*entry_module_idx);
 
       // Add debug info about eliminated facade chunk to target chunk
@@ -1068,9 +1060,8 @@ impl GenerateStage<'_> {
       to_chunk.modules.extend(from_chunk_modules);
       to_chunk.debug_info.extend(from_chunk_debug_info);
       to_chunk.depended_runtime_helper.insert(from_chunk_runtime_helper);
-      chunk_graph
-        .post_chunk_optimization_operations
-        .insert(merge.from_chunk_idx, PostChunkOptimizationOperation::Removed);
+      chunk_graph.post_chunk_optimization_operations[merge.from_chunk_idx] =
+        Some(PostChunkOptimizationOperation::Removed);
 
       // Retarget entry mappings that point at the removed chunk
       for entry_chunk_idx in chunk_graph.entry_module_to_entry_chunk.values_mut() {
@@ -1080,24 +1071,20 @@ impl GenerateStage<'_> {
       }
 
       // Retarget facade chunk namespace exports
-      if let Some(modules) =
-        chunk_graph.common_chunk_exported_facade_chunk_namespace.remove(&merge.from_chunk_idx)
       {
-        chunk_graph
-          .common_chunk_exported_facade_chunk_namespace
-          .entry(merge.to_chunk_idx)
-          .or_default()
+        let modules = std::mem::take(
+          &mut chunk_graph.common_chunk_exported_facade_chunk_namespace[merge.from_chunk_idx],
+        );
+        chunk_graph.common_chunk_exported_facade_chunk_namespace[merge.to_chunk_idx]
           .extend(modules);
       }
 
       // Retarget preserved export names
-      if let Some(modules) =
-        chunk_graph.common_chunk_preserve_export_names_modules.remove(&merge.from_chunk_idx)
       {
-        chunk_graph
-          .common_chunk_preserve_export_names_modules
-          .entry(merge.to_chunk_idx)
-          .or_default()
+        let modules = std::mem::take(
+          &mut chunk_graph.common_chunk_preserve_export_names_modules[merge.from_chunk_idx],
+        );
+        chunk_graph.common_chunk_preserve_export_names_modules[merge.to_chunk_idx]
           .extend(modules);
       }
 

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -1084,8 +1084,7 @@ impl GenerateStage<'_> {
         let modules = std::mem::take(
           &mut chunk_graph.common_chunk_preserve_export_names_modules[merge.from_chunk_idx],
         );
-        chunk_graph.common_chunk_preserve_export_names_modules[merge.to_chunk_idx]
-          .extend(modules);
+        chunk_graph.common_chunk_preserve_export_names_modules[merge.to_chunk_idx].extend(modules);
       }
 
       // Retarget runtime_dependent_chunks so runtime is placed in the correct chunk

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -128,8 +128,7 @@ impl GenerateStage<'_> {
         if let Some(entries) = self.link_output.entries.get(&module.idx) {
           for entry in entries {
             if let Some(reference_ids) = self.link_output.entry_point_to_reference_ids.get(entry) {
-              chunk_graph
-                .chunk_idx_to_reference_ids[chunk_idx]
+              chunk_graph.chunk_idx_to_reference_ids[chunk_idx]
                 .extend(reference_ids.iter().cloned());
             }
           }
@@ -433,7 +432,12 @@ impl GenerateStage<'_> {
   pub fn merge_cjs_namespace(&mut self, chunk_graph: &mut ChunkGraph) {
     let mut chunk_list: IndexVec<ChunkIdx, FxHashMap<(ModuleIdx, usize), Vec<SymbolRef>>> =
       index_vec![FxHashMap::default(); chunk_graph.chunk_table.len()];
-    for (k, info) in self.link_output.safely_merge_cjs_ns_map.iter_enumerated().filter_map(|(k, v)| v.as_ref().map(|info| (k, info))) {
+    for (k, info) in self
+      .link_output
+      .safely_merge_cjs_ns_map
+      .iter_enumerated()
+      .filter_map(|(k, v)| v.as_ref().map(|info| (k, info)))
+    {
       for symbol_ref in info
         .namespace_refs
         .iter()

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -129,9 +129,7 @@ impl GenerateStage<'_> {
           for entry in entries {
             if let Some(reference_ids) = self.link_output.entry_point_to_reference_ids.get(entry) {
               chunk_graph
-                .chunk_idx_to_reference_ids
-                .entry(chunk_idx)
-                .or_default()
+                .chunk_idx_to_reference_ids[chunk_idx]
                 .extend(reference_ids.iter().cloned());
             }
           }
@@ -187,7 +185,7 @@ impl GenerateStage<'_> {
       .chunk_table
       .iter_mut_enumerated()
       .filter(|(chunk_idx, _chunk)| {
-        chunk_graph.post_chunk_optimization_operations.get(chunk_idx).copied()
+        chunk_graph.post_chunk_optimization_operations[*chunk_idx]
           != Some(PostChunkOptimizationOperation::Removed)
       })
       .sorted_by(|(_ai, a), (_bi, b)| {
@@ -435,7 +433,7 @@ impl GenerateStage<'_> {
   pub fn merge_cjs_namespace(&mut self, chunk_graph: &mut ChunkGraph) {
     let mut chunk_list: IndexVec<ChunkIdx, FxHashMap<(ModuleIdx, usize), Vec<SymbolRef>>> =
       index_vec![FxHashMap::default(); chunk_graph.chunk_table.len()];
-    for (k, info) in &self.link_output.safely_merge_cjs_ns_map {
+    for (k, info) in self.link_output.safely_merge_cjs_ns_map.iter_enumerated().filter_map(|(k, v)| v.as_ref().map(|info| (k, info))) {
       for symbol_ref in info
         .namespace_refs
         .iter()
@@ -469,7 +467,7 @@ impl GenerateStage<'_> {
         let Some(group_idx) = group_idx else {
           continue;
         };
-        chunk_list[chunk_idx].entry((*k, group_idx)).or_default().push(*symbol_ref);
+        chunk_list[chunk_idx].entry((k, group_idx)).or_default().push(*symbol_ref);
       }
     }
 
@@ -772,7 +770,7 @@ impl GenerateStage<'_> {
       );
       let chunk_idx = chunk_graph.add_chunk(chunk);
       if let Some(reference_ids) = self.link_output.entry_point_to_reference_ids.get(entry_point) {
-        chunk_graph.chunk_idx_to_reference_ids.insert(chunk_idx, reference_ids.clone());
+        chunk_graph.chunk_idx_to_reference_ids[chunk_idx].clone_from(reference_ids);
       }
 
       bits_to_chunk.insert(bits, chunk_idx);

--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -348,11 +348,8 @@ impl GenerateStage<'_> {
       // Chunks with PreserveExports flag (e.g., emitted chunks merged into common chunks) are kept
       // because their exports still need to be computed.
       .filter(|(chunk_id, _)| {
-        !chunk_graph
-          .post_chunk_optimization_operations
-          .get(chunk_id)
-          .map(|flag| *flag == PostChunkOptimizationOperation::Removed)
-          .unwrap_or(false)
+        chunk_graph.post_chunk_optimization_operations[*chunk_id]
+          != Some(PostChunkOptimizationOperation::Removed)
       })
       .for_each(|(chunk_id, chunk)| {
         match chunk.kind {
@@ -400,38 +397,36 @@ impl GenerateStage<'_> {
             }
           }
           ChunkKind::Common => {
-            if let Some(set) =
-              chunk_graph.common_chunk_exported_facade_chunk_namespace.get(&chunk_id)
+            for dynamic_entry_module in
+              &chunk_graph.common_chunk_exported_facade_chunk_namespace[chunk_id]
             {
-              for dynamic_entry_module in set {
-                let meta = &self.link_output.metas[*dynamic_entry_module];
-                match meta.wrap_kind() {
-                  WrapKind::Cjs => {
-                    // For CJS modules, export only wrapper_ref (require_xxx)
-                    // Generated code: `import('./chunk.js').then((n) => __toESM(n.require_xxx()))`
-                    if let Some(wrapper_ref) = meta.wrapper_ref {
-                      index_chunk_exported_symbols[chunk_id].entry(wrapper_ref).or_default();
-                    }
+              let meta = &self.link_output.metas[*dynamic_entry_module];
+              match meta.wrap_kind() {
+                WrapKind::Cjs => {
+                  // For CJS modules, export only wrapper_ref (require_xxx)
+                  // Generated code: `import('./chunk.js').then((n) => __toESM(n.require_xxx()))`
+                  if let Some(wrapper_ref) = meta.wrapper_ref {
+                    index_chunk_exported_symbols[chunk_id].entry(wrapper_ref).or_default();
                   }
-                  WrapKind::Esm => {
-                    // For ESM modules, export both wrapper_ref (init_xxx) and namespace
-                    // Generated code: `import('./chunk.js').then((n) => (n.init_xxx(), n.namespace))`
-                    if let Some(wrapper_ref) = meta.wrapper_ref {
-                      index_chunk_exported_symbols[chunk_id].entry(wrapper_ref).or_default();
-                    }
-                    let ns_ref = self.link_output.module_table[*dynamic_entry_module]
-                      .namespace_object_ref()
-                      .expect("dynamic entry should be normal module");
-                    index_chunk_exported_symbols[chunk_id].entry(ns_ref).or_default();
+                }
+                WrapKind::Esm => {
+                  // For ESM modules, export both wrapper_ref (init_xxx) and namespace
+                  // Generated code: `import('./chunk.js').then((n) => (n.init_xxx(), n.namespace))`
+                  if let Some(wrapper_ref) = meta.wrapper_ref {
+                    index_chunk_exported_symbols[chunk_id].entry(wrapper_ref).or_default();
                   }
-                  WrapKind::None => {
-                    // For non-wrapped modules, export only namespace
-                    // Generated code: `import('./chunk.js').then((n) => n.namespace)`
-                    let ns_ref = self.link_output.module_table[*dynamic_entry_module]
-                      .namespace_object_ref()
-                      .expect("dynamic entry should be normal module");
-                    index_chunk_exported_symbols[chunk_id].entry(ns_ref).or_default();
-                  }
+                  let ns_ref = self.link_output.module_table[*dynamic_entry_module]
+                    .namespace_object_ref()
+                    .expect("dynamic entry should be normal module");
+                  index_chunk_exported_symbols[chunk_id].entry(ns_ref).or_default();
+                }
+                WrapKind::None => {
+                  // For non-wrapped modules, export only namespace
+                  // Generated code: `import('./chunk.js').then((n) => n.namespace)`
+                  let ns_ref = self.link_output.module_table[*dynamic_entry_module]
+                    .namespace_object_ref()
+                    .expect("dynamic entry should be normal module");
+                  index_chunk_exported_symbols[chunk_id].entry(ns_ref).or_default();
                 }
               }
             }
@@ -613,9 +608,9 @@ impl GenerateStage<'_> {
           });
         }
         // Also preserve exports from AllowExtension emitted chunks that were merged into this chunk
-        if let Some(modules) = preserve_export_names_modules.get(&chunk_id) {
+        {
           let exported_chunk_symbols = &index_chunk_exported_symbols[chunk_id];
-          for &module_idx in modules {
+          for &module_idx in &preserve_export_names_modules[chunk_id] {
             let module_meta = &self.link_output.metas[module_idx];
             module_meta.canonical_exports(false).for_each(|(name, export)| {
               let export_ref = self.link_output.symbol_db.canonical_ref_for(export.symbol_ref);

--- a/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
+++ b/crates/rolldown/src/stages/generate_stage/finalize_modules.rs
@@ -27,10 +27,10 @@ impl GenerateStage<'_> {
           .contains(EcmaViewMeta::TopExportedSideEffectsFreeFunction)
           .then(move || {
             let symbol_for_module = symbol_for_module.as_ref()?;
-            Some(symbol_for_module.flags.iter().filter_map(move |(symbol_id, flag)| {
+            Some(symbol_for_module.flags.iter_enumerated().filter_map(move |(symbol_id, flag)| {
               flag
                 .contains(SymbolRefFlags::SideEffectsFreeFunction)
-                .then_some(SymbolRef::from((idx, *symbol_id)))
+                .then_some(SymbolRef::from((idx, symbol_id)))
             }))
           })
           .flatten()

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -171,7 +171,7 @@ impl GenerateStage<'_> {
         .filter_map(|(idx, module_id_to_codegen_ret)| {
           let chunk_idx =
             ChunkIdx::from_raw(u32::try_from(idx).expect("chunk index should fit in u32"));
-          if chunk_graph.post_chunk_optimization_operations.contains_key(&chunk_idx) {
+          if chunk_graph.post_chunk_optimization_operations[chunk_idx].is_some() {
             return None;
           }
           let chunk = chunk_graph.chunk_table.get(chunk_idx)?;
@@ -312,8 +312,12 @@ pub fn set_emitted_chunk_preliminary_filenames(
     .chunks
     .iter_enumerated()
     .filter_map(|(idx, chunk)| {
-      chunk_graph.chunk_idx_to_reference_ids.get(&idx).map(|reference_ids| {
-        reference_ids.iter().map(|reference_id| EmittedChunkInfo {
+      {
+        let reference_ids = &chunk_graph.chunk_idx_to_reference_ids[idx];
+        if reference_ids.is_empty() {
+          return None;
+        }
+        Some(reference_ids.iter().map(|reference_id| EmittedChunkInfo {
           reference_id: reference_id.clone(),
           filename: chunk
             .preliminary_filename
@@ -321,8 +325,8 @@ pub fn set_emitted_chunk_preliminary_filenames(
             .expect("Emitted chunk should have filename")
             .deref()
             .clone(),
-        })
-      })
+        }))
+      }
     })
     .flatten();
   file_emitter.set_emitted_chunk_info(emitted_chunk_info);
@@ -337,12 +341,16 @@ fn set_emitted_chunk_filenames(
     .iter()
     .filter_map(|asset| {
       asset.originate_from.and_then(|originate_from| {
-        chunk_graph.chunk_idx_to_reference_ids.get(&originate_from).map(|reference_ids| {
-          reference_ids.iter().map(|reference_id| EmittedChunkInfo {
+        {
+          let reference_ids = &chunk_graph.chunk_idx_to_reference_ids[originate_from];
+          if reference_ids.is_empty() {
+            return None;
+          }
+          Some(reference_ids.iter().map(|reference_id| EmittedChunkInfo {
             reference_id: reference_id.clone(),
             filename: asset.filename.clone(),
-          })
-        })
+          }))
+        }
       })
     })
     .flatten();

--- a/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
+++ b/crates/rolldown/src/stages/generate_stage/render_chunk_to_assets.rs
@@ -312,12 +312,12 @@ pub fn set_emitted_chunk_preliminary_filenames(
     .chunks
     .iter_enumerated()
     .filter_map(|(idx, chunk)| {
-      {
-        let reference_ids = &chunk_graph.chunk_idx_to_reference_ids[idx];
-        if reference_ids.is_empty() {
-          return None;
-        }
-        Some(reference_ids.iter().map(|reference_id| EmittedChunkInfo {
+      let reference_ids = &chunk_graph.chunk_idx_to_reference_ids[idx];
+      if reference_ids.is_empty() {
+        return None;
+      }
+      Some(reference_ids.iter().map(|reference_id| {
+        EmittedChunkInfo {
           reference_id: reference_id.clone(),
           filename: chunk
             .preliminary_filename
@@ -325,8 +325,8 @@ pub fn set_emitted_chunk_preliminary_filenames(
             .expect("Emitted chunk should have filename")
             .deref()
             .clone(),
-        }))
-      }
+        }
+      }))
     })
     .flatten();
   file_emitter.set_emitted_chunk_info(emitted_chunk_info);
@@ -341,16 +341,14 @@ fn set_emitted_chunk_filenames(
     .iter()
     .filter_map(|asset| {
       asset.originate_from.and_then(|originate_from| {
-        {
-          let reference_ids = &chunk_graph.chunk_idx_to_reference_ids[originate_from];
-          if reference_ids.is_empty() {
-            return None;
-          }
-          Some(reference_ids.iter().map(|reference_id| EmittedChunkInfo {
-            reference_id: reference_id.clone(),
-            filename: asset.filename.clone(),
-          }))
+        let reference_ids = &chunk_graph.chunk_idx_to_reference_ids[originate_from];
+        if reference_ids.is_empty() {
+          return None;
         }
+        Some(reference_ids.iter().map(|reference_id| EmittedChunkInfo {
+          reference_id: reference_id.clone(),
+          filename: asset.filename.clone(),
+        }))
       })
     })
     .flatten();

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -604,7 +604,7 @@ impl LinkStage<'_> {
       {
         if import_symbol
           .flags(&self.symbols)
-          .is_some_and(|f| f.contains(SymbolRefFlags::HasComputedMemberWrite))
+          .contains(SymbolRefFlags::HasComputedMemberWrite)
         {
           written_cjs_export_symbols.extend(
             self.metas[*cjs_module_idx]
@@ -765,12 +765,10 @@ impl BindImportsAndExportsContext<'_> {
           // the namespace_ref (`import_react`). Since namespace_ref is a facade
           // (generated) symbol, we promote it to MustStartWithCapitalLetterForJSX
           // so the renamer uppercases it (e.g. `Import_react`).
-          if imported_as_ref.flags(self.symbol_db).is_some_and(|flags| {
-            flags.intersects(
-              SymbolRefFlags::MustStartWithCapitalLetterForJSX
-                | SymbolRefFlags::UsedAsJSXMemberExprRoot,
-            )
-          }) {
+          if imported_as_ref.flags(self.symbol_db).intersects(
+            SymbolRefFlags::MustStartWithCapitalLetterForJSX
+              | SymbolRefFlags::UsedAsJSXMemberExprRoot,
+          ) {
             let ns_flags = namespace_ref.flags_mut(self.symbol_db);
             *ns_flags |= SymbolRefFlags::MustStartWithCapitalLetterForJSX;
           }

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -602,10 +602,7 @@ impl LinkStage<'_> {
       for (import_symbol, cjs_module_idx) in
         meta.named_import_to_cjs_module.iter().chain(meta.import_record_ns_to_cjs_module.iter())
       {
-        if import_symbol
-          .flags(&self.symbols)
-          .contains(SymbolRefFlags::HasComputedMemberWrite)
-        {
+        if import_symbol.flags(&self.symbols).contains(SymbolRefFlags::HasComputedMemberWrite) {
           written_cjs_export_symbols.extend(
             self.metas[*cjs_module_idx]
               .resolved_exports

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -1,9 +1,9 @@
+use oxc_index::IndexVec;
 use rolldown_common::{
   EntryPoint, ExportsKind, ImportRecordMeta, ModuleIdx, OutputFormat, PreserveEntrySignatures,
   SharedNormalizedBundlerOptions, StmtInfo, StmtInfoMeta, TaggedSymbolRef, WrapKind,
   dynamic_import_usage::DynamicImportExportsUsage,
 };
-use rustc_hash::FxHashMap;
 
 use crate::{
   types::linking_metadata::LinkingMetadata, utils::chunk::normalize_preserve_entry_signature,
@@ -14,9 +14,9 @@ use super::LinkStage;
 fn init_entry_point_stmt_info(
   meta: &mut LinkingMetadata,
   entry: &EntryPoint,
-  dynamic_import_exports_usage_map: &FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
+  dynamic_import_exports_usage_map: &IndexVec<ModuleIdx, Option<DynamicImportExportsUsage>>,
   options: &SharedNormalizedBundlerOptions,
-  overrode_preserve_entry_signature_map: &FxHashMap<ModuleIdx, PreserveEntrySignatures>,
+  overrode_preserve_entry_signature_map: &IndexVec<ModuleIdx, Option<PreserveEntrySignatures>>,
   is_dynamic_imported: bool,
 ) {
   let mut referenced_symbols = vec![];

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -1,4 +1,3 @@
-use oxc_index::IndexVec;
 use oxc::{
   allocator::{Address, GetAddress, UnstableAddress},
   ast::{
@@ -11,6 +10,7 @@ use oxc::{
   ast_visit::{Visit, walk},
   semantic::ScopeFlags,
 };
+use oxc_index::IndexVec;
 use rolldown_common::{
   AstScopes, ConstExportMeta, EcmaViewMeta, FlatOptions, GetLocalDb, ModuleIdx,
   SharedNormalizedBundlerOptions, SideEffectDetail, StmtInfoIdx, SymbolRef, SymbolRefDb,
@@ -444,12 +444,10 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
       var_decl.declarations.iter().for_each(|declarator| {
         if let BindingPattern::BindingIdentifier(ref binding) = declarator.id {
           let symbol_ref: SymbolRef = (self.immutable_ctx.module_idx, binding.symbol_id()).into();
-          let is_not_assigned = self
-            .immutable_ctx
-            .symbols
-            .local_db(self.immutable_ctx.module_idx)
-            .flags[symbol_ref.symbol]
-            .contains(SymbolRefFlags::IsNotReassigned);
+          let is_not_assigned =
+            self.immutable_ctx.symbols.local_db(self.immutable_ctx.module_idx).flags
+              [symbol_ref.symbol]
+              .contains(SymbolRefFlags::IsNotReassigned);
 
           if is_not_assigned
             && let Some(value) = declarator

--- a/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
+++ b/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs
@@ -1,3 +1,4 @@
+use oxc_index::IndexVec;
 use oxc::{
   allocator::{Address, GetAddress, UnstableAddress},
   ast::{
@@ -72,10 +73,10 @@ impl LinkStage<'_> {
           .contains(EcmaViewMeta::TopExportedSideEffectsFreeFunction)
           .then(move || {
             let symbol_for_module = symbol_for_module.as_ref()?;
-            Some(symbol_for_module.flags.iter().filter_map(move |(symbol_id, flag)| {
+            Some(symbol_for_module.flags.iter_enumerated().filter_map(move |(symbol_id, flag)| {
               flag
                 .contains(SymbolRefFlags::SideEffectsFreeFunction)
-                .then_some(SymbolRef::from((idx, *symbol_id)))
+                .then_some(SymbolRef::from((idx, symbol_id)))
             }))
           })
           .flatten()
@@ -199,8 +200,8 @@ impl LinkStage<'_> {
         let module_idx = module.idx;
         let ast =
           self.ast_table[module_idx].as_ref().expect("ast should be set in a normal module");
-        // A dummy map to fits the api of `ConstEvalCtx`
-        let constant_map = FxHashMap::default();
+        // A dummy IndexVec to fit the api of `ConstEvalCtx`
+        let constant_map = IndexVec::new();
         ast.program.with_dependent(|owner, dep| {
           let module_symbol_table = self.symbols.local_db(module_idx);
           let eval_ctx = ConstEvalCtx {
@@ -447,9 +448,8 @@ impl<'a, 'ast: 'a> Visit<'ast> for CrossModuleOptimizationRunnerContext<'a, 'ast
             .immutable_ctx
             .symbols
             .local_db(self.immutable_ctx.module_idx)
-            .flags
-            .get(&symbol_ref.symbol)
-            .is_some_and(|flag| flag.contains(SymbolRefFlags::IsNotReassigned));
+            .flags[symbol_ref.symbol]
+            .contains(SymbolRefFlags::IsNotReassigned);
 
           if is_not_assigned
             && let Some(value) = declarator

--- a/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
+++ b/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
@@ -97,7 +97,9 @@ impl LinkStage<'_> {
   /// a single namespace binding, reducing code size.
   #[tracing::instrument(level = "debug", skip_all)]
   pub(super) fn determine_safely_merge_cjs_ns(&mut self) {
-    self.safely_merge_cjs_ns_map.clear();
+    for item in &mut self.safely_merge_cjs_ns_map {
+      *item = None;
+    }
 
     for importer in self.module_table.modules.iter().filter_map(Module::as_normal) {
       for (rec_idx, rec) in importer.import_records.iter_enumerated() {
@@ -111,7 +113,7 @@ impl LinkStage<'_> {
           rec.resolved_module.and_then(|importee_idx| self.module_table[importee_idx].as_normal())
           && matches!(importee.exports_kind, ExportsKind::CommonJs)
         {
-          let info = self.safely_merge_cjs_ns_map.entry(importee.idx).or_default();
+          let info = self.safely_merge_cjs_ns_map[importee.idx].get_or_insert_with(Default::default);
           info.namespace_refs.push(rec.namespace_ref);
           info.needs_interop |= import_record_needs_interop(importer, rec_idx);
         }

--- a/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
+++ b/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
@@ -113,7 +113,8 @@ impl LinkStage<'_> {
           rec.resolved_module.and_then(|importee_idx| self.module_table[importee_idx].as_normal())
           && matches!(importee.exports_kind, ExportsKind::CommonJs)
         {
-          let info = self.safely_merge_cjs_ns_map[importee.idx].get_or_insert_with(Default::default);
+          let info =
+            self.safely_merge_cjs_ns_map[importee.idx].get_or_insert_with(Default::default);
           info.namespace_refs.push(rec.namespace_ref);
           info.needs_interop |= import_record_needs_interop(importer, rec_idx);
         }

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -1,6 +1,6 @@
 use arcstr::ArcStr;
 use itertools::Itertools;
-use oxc_index::IndexVec;
+use oxc_index::{IndexVec, index_vec};
 #[cfg(debug_assertions)]
 use rolldown_common::common_debug_symbol_ref;
 use rolldown_common::{
@@ -66,12 +66,12 @@ pub struct LinkStageOutput {
   pub warnings: Vec<BuildDiagnostic>,
   pub errors: Vec<BuildDiagnostic>,
   pub used_symbol_refs: FxHashSet<SymbolRef>,
-  pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
-  pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
+  pub dynamic_import_exports_usage_map: IndexVec<ModuleIdx, Option<DynamicImportExportsUsage>>,
+  pub safely_merge_cjs_ns_map: IndexVec<ModuleIdx, Option<SafelyMergeCjsNsInfo>>,
   pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
   /// https://rollupjs.org/plugin-development/#this-emitfile
   /// Used to store `preserveSignature` specified with `this.emitFile` in plugins.
-  pub overrode_preserve_entry_signature_map: FxHashMap<ModuleIdx, PreserveEntrySignatures>,
+  pub overrode_preserve_entry_signature_map: IndexVec<ModuleIdx, Option<PreserveEntrySignatures>>,
   pub entry_point_to_reference_ids: FxHashMap<EntryPoint, Vec<ArcStr>>,
   pub global_constant_symbol_map: FxHashMap<SymbolRef, ConstExportMeta>,
   pub normal_symbol_exports_chain_map: FxHashMap<SymbolRef, Vec<SymbolRef>>,
@@ -91,11 +91,11 @@ pub struct LinkStage<'a> {
   pub ast_table: IndexEcmaAst,
   pub options: &'a SharedOptions,
   pub used_symbol_refs: FxHashSet<SymbolRef>,
-  pub safely_merge_cjs_ns_map: FxHashMap<ModuleIdx, SafelyMergeCjsNsInfo>,
-  pub dynamic_import_exports_usage_map: FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
+  pub safely_merge_cjs_ns_map: IndexVec<ModuleIdx, Option<SafelyMergeCjsNsInfo>>,
+  pub dynamic_import_exports_usage_map: IndexVec<ModuleIdx, Option<DynamicImportExportsUsage>>,
   pub normal_symbol_exports_chain_map: FxHashMap<SymbolRef, Vec<SymbolRef>>,
   pub external_import_namespace_merger: FxHashMap<ModuleIdx, FxIndexSet<SymbolRef>>,
-  pub overrode_preserve_entry_signature_map: FxHashMap<ModuleIdx, PreserveEntrySignatures>,
+  pub overrode_preserve_entry_signature_map: IndexVec<ModuleIdx, Option<PreserveEntrySignatures>>,
   pub entry_point_to_reference_ids: FxHashMap<EntryPoint, Vec<ArcStr>>,
   pub global_constant_symbol_map: FxHashMap<SymbolRef, ConstExportMeta>,
   pub flat_options: FlatOptions,
@@ -114,10 +114,15 @@ impl<'a> LinkStage<'a> {
         .par_iter_mut()
         .filter_map(|m| {
           let m = m.as_normal_mut()?;
-          Some(std::mem::take(&mut m.constant_export_map).into_iter().map(|(symbol_id, v)| {
-            let symbol_ref = SymbolRef { owner: m.idx, symbol: symbol_id };
-            (symbol_ref, v)
-          }))
+          Some(
+            std::mem::take(&mut m.constant_export_map)
+              .into_iter_enumerated()
+              .filter_map(move |(symbol_id, v)| {
+                let v = v?;
+                let symbol_ref = SymbolRef { owner: m.idx, symbol: symbol_id };
+                Some((symbol_ref, v))
+              }),
+          )
         })
         .flatten_iter()
         .collect::<FxHashMap<SymbolRef, ConstExportMeta>>()
@@ -136,6 +141,8 @@ impl<'a> LinkStage<'a> {
     });
 
     scan_stage_output.entry_points.extend(rest);
+
+    let module_count = scan_stage_output.module_table.modules.len();
 
     Self {
       sorted_modules: Vec::new(),
@@ -177,14 +184,25 @@ impl<'a> LinkStage<'a> {
       warnings: scan_stage_output.warnings,
       errors: vec![],
       ast_table: scan_stage_output.index_ecma_ast,
-      dynamic_import_exports_usage_map: scan_stage_output.dynamic_import_exports_usage_map,
+      dynamic_import_exports_usage_map: {
+        let mut vec = index_vec![None; module_count];
+        for (idx, usage) in scan_stage_output.dynamic_import_exports_usage_map {
+          vec[idx] = Some(usage);
+        }
+        vec
+      },
       options,
       used_symbol_refs: FxHashSet::default(),
-      safely_merge_cjs_ns_map: FxHashMap::default(),
+      safely_merge_cjs_ns_map: index_vec![None; module_count],
       normal_symbol_exports_chain_map: FxHashMap::default(),
       external_import_namespace_merger: FxHashMap::default(),
-      overrode_preserve_entry_signature_map: scan_stage_output
-        .overrode_preserve_entry_signature_map,
+      overrode_preserve_entry_signature_map: {
+        let mut vec = index_vec![None; module_count];
+        for (idx, sig) in scan_stage_output.overrode_preserve_entry_signature_map {
+          vec[idx] = Some(sig);
+        }
+        vec
+      },
       entry_point_to_reference_ids: scan_stage_output.entry_point_to_reference_ids,
       flat_options: scan_stage_output.flat_options,
       side_effects_free_function_symbol_ref: FxHashSet::default(),

--- a/crates/rolldown/src/stages/link_stage/mod.rs
+++ b/crates/rolldown/src/stages/link_stage/mod.rs
@@ -114,15 +114,13 @@ impl<'a> LinkStage<'a> {
         .par_iter_mut()
         .filter_map(|m| {
           let m = m.as_normal_mut()?;
-          Some(
-            std::mem::take(&mut m.constant_export_map)
-              .into_iter_enumerated()
-              .filter_map(move |(symbol_id, v)| {
-                let v = v?;
-                let symbol_ref = SymbolRef { owner: m.idx, symbol: symbol_id };
-                Some((symbol_ref, v))
-              }),
-          )
+          Some(std::mem::take(&mut m.constant_export_map).into_iter_enumerated().filter_map(
+            move |(symbol_id, v)| {
+              let v = v?;
+              let symbol_ref = SymbolRef { owner: m.idx, symbol: symbol_id };
+              Some((symbol_ref, v))
+            },
+          ))
         })
         .flatten_iter()
         .collect::<FxHashMap<SymbolRef, ConstExportMeta>>()

--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -168,7 +168,7 @@ impl LinkStage<'_> {
                             .push(importee_linking_info.wrapper_ref.unwrap().into());
                           // Only reference __toESM if this import needs interop (namespace or default import)
                           let needs_toesm =
-                            if let Some(info) = self.safely_merge_cjs_ns_map.get(&importee.idx) {
+                            if let Some(info) = self.safely_merge_cjs_ns_map[importee.idx].as_ref() {
                               info.needs_interop
                             } else {
                               import_record_needs_interop(importer, *rec_id)

--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -167,12 +167,13 @@ impl LinkStage<'_> {
                             .referenced_symbols
                             .push(importee_linking_info.wrapper_ref.unwrap().into());
                           // Only reference __toESM if this import needs interop (namespace or default import)
-                          let needs_toesm =
-                            if let Some(info) = self.safely_merge_cjs_ns_map[importee.idx].as_ref() {
-                              info.needs_interop
-                            } else {
-                              import_record_needs_interop(importer, *rec_id)
-                            };
+                          let needs_toesm = if let Some(info) =
+                            self.safely_merge_cjs_ns_map[importee.idx].as_ref()
+                          {
+                            info.needs_interop
+                          } else {
+                            import_record_needs_interop(importer, *rec_id)
+                          };
                           if needs_toesm {
                             depended_runtime_helper_map[RuntimeHelper::ToEsm.bit_index()]
                               .push(stmt_info_idx);

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -509,7 +509,7 @@ impl LinkStage<'_> {
       EntryPointKind::UserDefined | EntryPointKind::EmittedUserDefined => true,
       EntryPointKind::DynamicImport => {
         let is_dynamic_imported_module_exports_unused =
-          self.dynamic_import_exports_usage_map.get(&entry_point.idx).is_some_and(
+          self.dynamic_import_exports_usage_map[entry_point.idx].as_ref().is_some_and(
             |item| matches!(item, DynamicImportExportsUsage::Partial(set) if set.is_empty()),
           );
 

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -134,14 +134,14 @@ impl LinkingMetadata {
     &'b self,
     module_idx: ModuleIdx,
     entry_point_kind: EntryPointKind,
-    dynamic_import_exports_usage_map: &'a FxHashMap<ModuleIdx, DynamicImportExportsUsage>,
+    dynamic_import_exports_usage_map: &'a IndexVec<ModuleIdx, Option<DynamicImportExportsUsage>>,
     needs_commonjs_export: bool,
   ) -> impl Iterator<Item = (&'b CompactStr, &'b ResolvedExport)> + 'b {
     let partial_used_exports = match entry_point_kind {
       rolldown_common::EntryPointKind::UserDefined
       | rolldown_common::EntryPointKind::EmittedUserDefined => None,
       rolldown_common::EntryPointKind::DynamicImport => {
-        dynamic_import_exports_usage_map.get(&module_idx).and_then(|usage| match usage {
+        dynamic_import_exports_usage_map[module_idx].as_ref().and_then(|usage| match usage {
           DynamicImportExportsUsage::Complete => None,
           DynamicImportExportsUsage::Partial(set) => Some(set),
           DynamicImportExportsUsage::Single(_) => unreachable!(),

--- a/crates/rolldown/src/utils/chunk/mod.rs
+++ b/crates/rolldown/src/utils/chunk/mod.rs
@@ -1,5 +1,6 @@
 use self::render_chunk_exports::get_chunk_export_names;
 use arcstr::ArcStr;
+use oxc_index::IndexVec;
 use rolldown_common::{
   Chunk, ChunkKind, ChunkMeta, ModuleId, ModuleIdx, PreserveEntrySignatures, RenderedModule,
   RollupPreRenderedChunk, RollupRenderedChunk, SharedNormalizedBundlerOptions,
@@ -94,12 +95,10 @@ pub fn generate_rendered_chunk(
 }
 
 pub fn normalize_preserve_entry_signature(
-  overrode_preserve_entry_signature_map: &FxHashMap<ModuleIdx, PreserveEntrySignatures>,
+  overrode_preserve_entry_signature_map: &IndexVec<ModuleIdx, Option<PreserveEntrySignatures>>,
   options: &SharedNormalizedBundlerOptions,
   module_idx: ModuleIdx,
 ) -> PreserveEntrySignatures {
-  overrode_preserve_entry_signature_map
-    .get(&module_idx)
-    .copied()
+  overrode_preserve_entry_signature_map[module_idx]
     .unwrap_or(options.preserve_entry_signatures)
 }

--- a/crates/rolldown/src/utils/chunk/mod.rs
+++ b/crates/rolldown/src/utils/chunk/mod.rs
@@ -99,6 +99,5 @@ pub fn normalize_preserve_entry_signature(
   options: &SharedNormalizedBundlerOptions,
   module_idx: ModuleIdx,
 ) -> PreserveEntrySignatures {
-  overrode_preserve_entry_signature_map[module_idx]
-    .unwrap_or(options.preserve_entry_signatures)
+  overrode_preserve_entry_signature_map[module_idx].unwrap_or(options.preserve_entry_signatures)
 }

--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -171,7 +171,7 @@ impl<'name> Renamer<'name> {
     let original_name = if self.symbol_db.has_module_preserve_jsx()
       && canonical_ref
         .flags(self.symbol_db)
-        .is_some_and(|flags| flags.contains(SymbolRefFlags::MustStartWithCapitalLetterForJSX))
+        .contains(SymbolRefFlags::MustStartWithCapitalLetterForJSX)
       && canonical_name.as_bytes()[0].is_ascii_lowercase()
     {
       let mut s = String::with_capacity(canonical_name.len());

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -103,8 +103,8 @@ pub struct EcmaView {
 
   pub hmr_hot_ref: Option<SymbolRef>,
   pub hmr_info: HmrInfo,
-  pub constant_export_map: FxHashMap<SymbolId, ConstExportMeta>,
-  pub import_attribute_map: FxHashMap<ImportRecordIdx, ImportAttribute>,
+  pub constant_export_map: IndexVec<SymbolId, Option<ConstExportMeta>>,
+  pub import_attribute_map: IndexVec<ImportRecordIdx, Option<ImportAttribute>>,
   /// Use `Box` since it is rarely used also it could reduce the size of `EcmaView`, .
   pub json_module_none_self_reference_included_symbol: Option<Box<FxHashSet<SymbolRef>>>,
 }

--- a/crates/rolldown_common/src/module_loader/task_result.rs
+++ b/crates/rolldown_common/src/module_loader/task_result.rs
@@ -7,8 +7,6 @@ use arcstr::ArcStr;
 use oxc_index::IndexVec;
 use rolldown_ecmascript::EcmaAst;
 use rolldown_error::BuildDiagnostic;
-use rustc_hash::FxHashMap;
-
 pub struct NormalModuleTaskResult {
   pub module: Module,
   pub ecma_related: EcmaRelated,
@@ -30,7 +28,7 @@ pub struct ExternalModuleTaskResult {
 pub struct EcmaRelated {
   pub ast: EcmaAst,
   pub symbols: SymbolRefDbForModule,
-  pub dynamic_import_rec_exports_usage: FxHashMap<ImportRecordIdx, DynamicImportExportsUsage>,
+  pub dynamic_import_rec_exports_usage: IndexVec<ImportRecordIdx, Option<DynamicImportExportsUsage>>,
   /// Whether JSX syntax is preserved for this module, determined per-module
   /// during transformation based on the resolved tsconfig.
   pub preserve_jsx: bool,

--- a/crates/rolldown_common/src/module_loader/task_result.rs
+++ b/crates/rolldown_common/src/module_loader/task_result.rs
@@ -28,7 +28,8 @@ pub struct ExternalModuleTaskResult {
 pub struct EcmaRelated {
   pub ast: EcmaAst,
   pub symbols: SymbolRefDbForModule,
-  pub dynamic_import_rec_exports_usage: IndexVec<ImportRecordIdx, Option<DynamicImportExportsUsage>>,
+  pub dynamic_import_rec_exports_usage:
+    IndexVec<ImportRecordIdx, Option<DynamicImportExportsUsage>>,
   /// Whether JSX syntax is preserved for this module, determined per-module
   /// during transformation based on the resolved tsconfig.
   pub preserve_jsx: bool,

--- a/crates/rolldown_common/src/types/symbol_ref.rs
+++ b/crates/rolldown_common/src/types/symbol_ref.rs
@@ -27,14 +27,12 @@ impl SymbolRef {
     db[self.owner].unpack_ref_mut().ast_scopes.set_symbol_name(self.symbol, name);
   }
 
-  /// Not all symbols have flags info, we only care about part of them.
-  /// If you want to ensure the flags info exists, use `flags_mut` instead.
-  pub fn flags<'db, T: GetLocalDb>(&self, db: &'db T) -> Option<&'db SymbolRefFlags> {
-    db.local_db(self.owner).flags.get(&self.symbol)
+  pub fn flags<'db, T: GetLocalDb>(&self, db: &'db T) -> &'db SymbolRefFlags {
+    &db.local_db(self.owner).flags[self.symbol]
   }
 
   pub fn flags_mut<'db, T: GetLocalDbMut>(&self, db: &'db mut T) -> &'db mut SymbolRefFlags {
-    db.local_db_mut(self.owner).flags.entry(self.symbol).or_default()
+    &mut db.local_db_mut(self.owner).flags[self.symbol]
   }
 
   pub fn is_declared_by_const(&self, db: &SymbolRefDb) -> bool {
@@ -43,7 +41,7 @@ impl SymbolRef {
 
   /// `None` means we don't know if it gets reassigned.
   pub fn is_not_reassigned(&self, db: &SymbolRefDb) -> Option<bool> {
-    let flags = self.flags(db)?;
+    let flags = self.flags(db);
     // Not having this flag means we don't know
     flags.contains(SymbolRefFlags::IsNotReassigned).then_some(true)
   }

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -62,8 +62,7 @@ pub struct SymbolRefDbForModule {
   owner_idx: ModuleIdx,
   root_scope_id: ScopeId,
   pub ast_scopes: AstScopes,
-  // Only some symbols would be cared about, so we use a hashmap to store the flags.
-  pub flags: FxHashMap<SymbolId, SymbolRefFlags>,
+  pub flags: IndexVec<SymbolId, SymbolRefFlags>,
   pub classic_data: IndexVec<SymbolId, SymbolRefDataClassic>,
   #[cfg(debug_assertions)]
   create_reason: FxHashMap<SymbolRef, String>,
@@ -75,7 +74,7 @@ impl Default for SymbolRefDbForModule {
       owner_idx: ModuleIdx::new(0),
       root_scope_id: ScopeId::new(0),
       ast_scopes: AstScopes::new(Scoping::default()),
-      flags: FxHashMap::default(),
+      flags: IndexVec::default(),
       classic_data: IndexVec::default(),
       #[cfg(debug_assertions)]
       create_reason: FxHashMap::default(),
@@ -92,8 +91,8 @@ impl SymbolRefDbForModule {
         SymbolRefDataClassic::default();
         scoping.symbols_len()
       ]),
+      flags: IndexVec::from_vec(vec![SymbolRefFlags::default(); scoping.symbols_len()]),
       ast_scopes: AstScopes::new(scoping),
-      flags: FxHashMap::default(),
       #[cfg(debug_assertions)]
       create_reason: FxHashMap::default(),
     }
@@ -104,7 +103,7 @@ impl SymbolRefDbForModule {
   pub fn create_facade_root_symbol_ref(&mut self, name: &str) -> SymbolRef {
     let symbol_id = self.ast_scopes.create_facade_root_symbol_ref(name);
     self.classic_data.push(SymbolRefDataClassic::default());
-    self.flags.entry(symbol_id).or_default().insert(SymbolRefFlags::IsFacade);
+    self.flags.push(SymbolRefFlags::IsFacade);
 
     let ret = SymbolRef::from((self.owner_idx, symbol_id));
     #[cfg(debug_assertions)]
@@ -124,7 +123,7 @@ impl SymbolRefDbForModule {
   /// Check if a symbol is a facade symbol (synthetic, not present in the original AST).
   #[inline]
   pub fn is_facade_symbol(&self, symbol_id: SymbolId) -> bool {
-    self.flags.get(&symbol_id).is_some_and(|f| f.contains(SymbolRefFlags::IsFacade))
+    self.flags[symbol_id].contains(SymbolRefFlags::IsFacade)
   }
 
   /// Merge immutable fields (Scoping) from a build's DB into this cache DB.
@@ -138,10 +137,17 @@ impl SymbolRefDbForModule {
       self.classic_data.push(SymbolRefDataClassic::default());
     }
 
+    // Extend flags for any symbols added during linking (e.g., facade symbols)
+    let current_flags_len = self.flags.len();
+    if build_db.flags.len() > current_flags_len {
+      for i in current_flags_len..build_db.flags.len() {
+        self.flags.push(build_db.flags[SymbolId::from_usize(i)]);
+      }
+    }
     // Preserve IsFacade flags for facade symbols added during linking
-    for (symbol_id, flags) in &build_db.flags {
+    for (i, flags) in build_db.flags.iter_enumerated() {
       if flags.contains(SymbolRefFlags::IsFacade) {
-        self.flags.entry(*symbol_id).or_default().insert(SymbolRefFlags::IsFacade);
+        self.flags[i].insert(SymbolRefFlags::IsFacade);
       }
     }
 
@@ -289,9 +295,8 @@ impl SymbolRefDb {
     if self.has_module_preserve_jsx {
       let jsx_mask =
         SymbolRefFlags::MustStartWithCapitalLetterForJSX | SymbolRefFlags::UsedAsJSXMemberExprRoot;
-      if let Some(jsx_flags) =
-        base_root.flags(self).map(|f| *f & jsx_mask).filter(|f| !f.is_empty())
-      {
+      let jsx_flags = *base_root.flags(self) & jsx_mask;
+      if !jsx_flags.is_empty() {
         *target_root.flags_mut(self) |= jsx_flags;
       }
     }


### PR DESCRIPTION
## Summary

- Replace `FxHashMap` with `IndexVec` where keys are sequential index types (`ModuleIdx`, `ChunkIdx`, `SymbolId`, `ImportRecordIdx`) to eliminate hash overhead and improve cache locality
- **`SymbolRefDbForModule::flags`**: `FxHashMap<SymbolId, u8>` → `IndexVec<SymbolId, SymbolRefFlags>` — highest impact change, accessed in hot union-find paths. The `u8` bitflags cost 1 byte/symbol in IndexVec vs ~40+ bytes/entry in FxHashMap
- **`ChunkGraph`**: 4 `FxHashMap<ChunkIdx, ...>` fields → `IndexVec<ChunkIdx, ...>` — chunk count is small, trivial wins
- **`LinkStageOutput`**: 3 `FxHashMap<ModuleIdx, ...>` → `IndexVec<ModuleIdx, Option<...>>` — module count known at link stage
- **`ScanResult`**: 3 per-module `FxHashMap` fields → `IndexVec<_, Option<_>>` — sized from import record/symbol counts

## Test plan

- [x] `cargo check -p rolldown_common -p rolldown` passes
- [x] `cargo clippy -p rolldown_common -p rolldown` passes with no new warnings
- [ ] CI tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)