### PR TITLE
refactor(binding): remove outdated TODO comment in MagicString to_string()

### DIFF
--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -421,7 +421,6 @@ impl BindingMagicString<'_> {
   }
 
   #[napi]
-  // TODO: should use `&str` instead. (claude code) Attempt failed due to generates new String from MagicString internal representation
   pub fn to_string(&self) -> String {
     self.inner.to_string()
   }


### PR DESCRIPTION
It is impossible to return `&str` since `MagicString` consist with fragment(string slice), `to_string` always need to return a concatenated string.