### PR TITLE
build: fix early exit in script build-node

### DIFF
--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -103,7 +103,7 @@
     "build-binding:wasi": "pnpm build-binding --target wasm32-wasip1-threads",
     "build-binding:wasi:release": "pnpm build-binding --profile release-wasi --target wasm32-wasip1-threads",
     "# Scrips for node #": "_",
-    "build-node": "oxnode -C dev ./build.ts",
+    "build-node": "node --enable-source-maps --import @oxc-node/core/register -C dev ./build.ts",
     "build-types-check": "tsc -p ./tsconfig.check.json",
     "build-js-glue": "pnpm run --sequential '/^build-(node|types-check)$/'",
     "build-native:debug": "pnpm run --sequential '/^build-(binding|js-glue)$/'",


### PR DESCRIPTION
When debugging rolldown, script `build-node`, which hasn't completed yet, sometimes exit earlier than `build-types-check`, causing an issue where dts checks are not able to pass. Claude helps me find an issue related to an early exit issue in oxnode. In this PR, I temprarily replaced the script with direct invocation of `@oxc-node/core` to fix the issue.  
I've created an issue at https://github.com/oxc-project/oxc-node/issues/493  
  
Note: I've just changed the script that affects my workflow and kept the others as-is.