### PR TITLE
fix: preserve comments when treeshaking global calls

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1280,16 +1280,18 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       .into_iter()
       .enumerate()
       .zip(self.ctx.module.stmt_infos.iter_enumerated().skip(1))
-      .for_each(|((_top_stmt_idx, mut top_stmt), (stmt_info_idx, _stmt_info))| {
-        let removed_stmt_comment_anchor = next_included_stmt_starts[_top_stmt_idx];
-        let removed_stmt_comment_region_end = next_source_stmt_starts[_top_stmt_idx];
+      .for_each(|((top_stmt_idx, mut top_stmt), (stmt_info_idx, _stmt_info))| {
+        let removed_stmt_comment_anchor = next_included_stmt_starts[top_stmt_idx];
+        let removed_stmt_comment_region_end = next_source_stmt_starts[top_stmt_idx];
         if !self.ctx.linking_info.stmt_info_included.has_bit(stmt_info_idx) {
-          self.preserve_removed_top_level_stmt_comments(
-            program,
-            top_stmt.span(),
-            removed_stmt_comment_anchor,
-            removed_stmt_comment_region_end,
-          );
+          if Self::should_preserve_removed_top_level_stmt_comments(&top_stmt) {
+            self.preserve_removed_top_level_stmt_comments(
+              program,
+              top_stmt.span(),
+              removed_stmt_comment_anchor,
+              removed_stmt_comment_region_end,
+            );
+          }
           return;
         }
 
@@ -1636,6 +1638,14 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         comment.attached_to = target_anchor;
       }
     }
+  }
+
+  fn should_preserve_removed_top_level_stmt_comments(stmt: &Statement<'ast>) -> bool {
+    !matches!(
+      stmt,
+      Statement::ExpressionStatement(expr_stmt)
+        if matches!(expr_stmt.expression.without_parentheses(), Expression::StringLiteral(_))
+    )
   }
 
   fn process_fn(

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -1,4 +1,5 @@
 use bitflags::bitflags;
+use oxc::ast::CommentPosition;
 use oxc::ast::ast::ObjectPropertyKind;
 use oxc::semantic::{ReferenceId, ScopeFlags, SymbolId};
 use oxc::{
@@ -1254,6 +1255,25 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     let mut last_import_stmt_idx = None;
 
     let old_body = program.body.take_in(self.alloc);
+    let next_included_stmt_starts = {
+      let mut next_anchor = program.span.end;
+      let mut anchors = vec![program.span.end; old_body.len()];
+      for ((top_stmt_idx, stmt), (stmt_info_idx, _stmt_info)) in
+        old_body.iter().enumerate().zip(self.ctx.module.stmt_infos.iter_enumerated().skip(1)).rev()
+      {
+        anchors[top_stmt_idx] = next_anchor;
+        if self.ctx.linking_info.stmt_info_included.has_bit(stmt_info_idx) {
+          next_anchor = stmt.span().start;
+        }
+      }
+      anchors
+    };
+    let next_source_stmt_starts = old_body
+      .iter()
+      .enumerate()
+      .map(|(idx, _)| old_body.get(idx + 1).map_or(program.span.end, |stmt| stmt.span().start))
+      .collect::<Vec<_>>();
+
     // the first statement info is the namespace variable declaration
     // skip first statement info to make sure `program.body` has same index as `stmt_infos`
     old_body
@@ -1261,7 +1281,15 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       .enumerate()
       .zip(self.ctx.module.stmt_infos.iter_enumerated().skip(1))
       .for_each(|((_top_stmt_idx, mut top_stmt), (stmt_info_idx, _stmt_info))| {
+        let removed_stmt_comment_anchor = next_included_stmt_starts[_top_stmt_idx];
+        let removed_stmt_comment_region_end = next_source_stmt_starts[_top_stmt_idx];
         if !self.ctx.linking_info.stmt_info_included.has_bit(stmt_info_idx) {
+          self.preserve_removed_top_level_stmt_comments(
+            program,
+            top_stmt.span(),
+            removed_stmt_comment_anchor,
+            removed_stmt_comment_region_end,
+          );
           return;
         }
 
@@ -1271,14 +1299,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           let span = import_decl.span;
           let rec_idx = self.ctx.module.imports[&import_decl.span];
           if self.transform_or_remove_import_export_stmt(&mut top_stmt, rec_idx) {
-            for comment in &mut program.comments {
-              if comment.attached_to == span.start {
-                comment.attached_to = 0;
-              }
-              if comment.attached_to > span.start {
-                break;
-              }
-            }
+            self.preserve_removed_top_level_stmt_comments(
+              program,
+              span,
+              removed_stmt_comment_anchor,
+              removed_stmt_comment_region_end,
+            );
             return;
           }
         } else if let Some(export_all_decl) = top_stmt.as_export_all_declaration() {
@@ -1403,6 +1429,12 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
                   | rolldown_common::OutputFormat::Umd
                   | rolldown_common::OutputFormat::Cjs => {
                     // Just remove the statement
+                    self.preserve_removed_top_level_stmt_comments(
+                      program,
+                      export_all_decl.span,
+                      removed_stmt_comment_anchor,
+                      removed_stmt_comment_region_end,
+                    );
                     return;
                   }
                 }
@@ -1523,8 +1555,8 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
           // comments
           *top_stmt.span_mut() = default_decl_span;
         } else if let Some(named_decl) = top_stmt.as_export_named_declaration_mut() {
+          let named_decl_span = named_decl.span;
           if named_decl.source.is_none() {
-            let named_decl_span = named_decl.span;
             if let Some(decl) = &mut named_decl.declaration {
               // `export var foo = 1` => `var foo = 1`
               // `export function foo() {}` => `function foo() {}`
@@ -1535,12 +1567,24 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
             } else {
               // `export { foo }`
               // Remove this statement by ignoring it
+              self.preserve_removed_top_level_stmt_comments(
+                program,
+                named_decl_span,
+                removed_stmt_comment_anchor,
+                removed_stmt_comment_region_end,
+              );
               return;
             }
           } else {
             // `export { foo } from 'path'`
             let rec_idx = self.ctx.module.imports[&named_decl.span];
             if self.transform_or_remove_import_export_stmt(&mut top_stmt, rec_idx) {
+              self.preserve_removed_top_level_stmt_comments(
+                program,
+                named_decl_span,
+                removed_stmt_comment_anchor,
+                removed_stmt_comment_region_end,
+              );
               return;
             }
           }
@@ -1565,6 +1609,33 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
         }
       });
     last_import_stmt_idx.unwrap_or(0)
+  }
+
+  fn preserve_removed_top_level_stmt_comments(
+    &self,
+    program: &mut ast::Program<'ast>,
+    removed_stmt_span: oxc::span::Span,
+    target_anchor: u32,
+    comment_region_end: u32,
+  ) {
+    for comment in &mut program.comments {
+      if comment.attached_to == removed_stmt_span.start {
+        if comment.position == CommentPosition::Trailing {
+          comment.position = CommentPosition::Leading;
+        }
+        comment.attached_to = target_anchor;
+        continue;
+      }
+
+      if comment.position == CommentPosition::Trailing
+        && comment.attached_to == 0
+        && comment.span.start >= removed_stmt_span.start
+        && comment.span.start < comment_region_end
+      {
+        comment.position = CommentPosition::Leading;
+        comment.attached_to = target_anchor;
+      }
+    }
   }
 
   fn process_fn(

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use oxc::ast::CommentPosition;
-use oxc::ast::ast::Program;
+use oxc::ast::ast::{Expression, Program, Statement};
 use oxc::ast_visit::VisitMut;
 use oxc::diagnostics::Severity as OxcSeverity;
 use oxc::minifier::{CompressOptions, Compressor, TreeShakeOptions};
@@ -161,8 +161,15 @@ impl PreProcessEcmaAst {
     // Step 5: Run DCE.
     // Avoid DCE for lazy export.
     if bundle_options.treeshake.is_some() && !has_lazy_export {
-      let original_top_level_stmt_spans =
-        ast.program().body.iter().map(GetSpan::span).collect::<Vec<_>>();
+      let original_top_level_stmts = ast
+        .program()
+        .body
+        .iter()
+        .map(|stmt| OriginalTopLevelStmt {
+          span: stmt.span(),
+          preserve_comments: should_preserve_removed_top_level_stmt_comments(stmt),
+        })
+        .collect::<Vec<_>>();
       ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
         let scoping = self.recreate_scoping(&mut scoping, program);
         let mut treeshake = TreeShakeOptions::from(&bundle_options.treeshake);
@@ -174,7 +181,7 @@ impl PreProcessEcmaAst {
           ..CompressOptions::dce()
         };
         Compressor::new(allocator).dead_code_elimination_with_scoping(program, scoping, options);
-        preserve_removed_top_level_stmt_comments(program, &original_top_level_stmt_spans);
+        preserve_removed_top_level_stmt_comments(program, &original_top_level_stmts);
       });
     }
 
@@ -202,36 +209,50 @@ impl PreProcessEcmaAst {
   }
 }
 
+#[derive(Clone, Copy)]
+struct OriginalTopLevelStmt {
+  span: oxc::span::Span,
+  preserve_comments: bool,
+}
+
+fn should_preserve_removed_top_level_stmt_comments(stmt: &Statement<'_>) -> bool {
+  !matches!(
+    stmt,
+    Statement::ExpressionStatement(expr_stmt)
+      if matches!(expr_stmt.expression.without_parentheses(), Expression::StringLiteral(_))
+  )
+}
+
 fn preserve_removed_top_level_stmt_comments(
   program: &mut Program<'_>,
-  original_stmt_spans: &[oxc::span::Span],
+  original_stmts: &[OriginalTopLevelStmt],
 ) {
-  if program.comments.is_empty() || original_stmt_spans.is_empty() {
+  if program.comments.is_empty() || original_stmts.is_empty() {
     return;
   }
 
   let remaining_stmt_starts =
     program.body.iter().map(|stmt| stmt.span().start).collect::<FxHashSet<_>>();
   let mut next_anchor = program.span.end;
-  let mut comment_anchors = vec![program.span.end; original_stmt_spans.len()];
+  let mut comment_anchors = vec![program.span.end; original_stmts.len()];
 
-  for (idx, span) in original_stmt_spans.iter().enumerate().rev() {
+  for (idx, stmt) in original_stmts.iter().enumerate().rev() {
     comment_anchors[idx] = next_anchor;
-    if remaining_stmt_starts.contains(&span.start) {
-      next_anchor = span.start;
+    if remaining_stmt_starts.contains(&stmt.span.start) {
+      next_anchor = stmt.span.start;
     }
   }
 
-  for (idx, span) in original_stmt_spans.iter().enumerate() {
-    if remaining_stmt_starts.contains(&span.start) {
+  for (idx, stmt) in original_stmts.iter().enumerate() {
+    if remaining_stmt_starts.contains(&stmt.span.start) || !stmt.preserve_comments {
       continue;
     }
 
     let comment_region_end =
-      original_stmt_spans.get(idx + 1).map_or(program.span.end, |next_span| next_span.start);
+      original_stmts.get(idx + 1).map_or(program.span.end, |next_stmt| next_stmt.span.start);
 
     for comment in &mut program.comments {
-      if comment.attached_to == span.start {
+      if comment.attached_to == stmt.span.start {
         if comment.position == CommentPosition::Trailing {
           comment.position = CommentPosition::Leading;
         }
@@ -241,7 +262,7 @@ fn preserve_removed_top_level_stmt_comments(
 
       if comment.position == CommentPosition::Trailing
         && comment.attached_to == 0
-        && comment.span.start >= span.start
+        && comment.span.start >= stmt.span.start
         && comment.span.start < comment_region_end
       {
         comment.position = CommentPosition::Leading;

--- a/crates/rolldown/src/utils/pre_process_ecma_ast.rs
+++ b/crates/rolldown/src/utils/pre_process_ecma_ast.rs
@@ -1,10 +1,12 @@
 use std::path::Path;
 
+use oxc::ast::CommentPosition;
 use oxc::ast::ast::Program;
 use oxc::ast_visit::VisitMut;
 use oxc::diagnostics::Severity as OxcSeverity;
 use oxc::minifier::{CompressOptions, Compressor, TreeShakeOptions};
 use oxc::semantic::{Scoping, SemanticBuilder, Stats};
+use oxc::span::GetSpan;
 use oxc::transformer::Transformer;
 use oxc::transformer_plugins::{
   InjectGlobalVariables, ReplaceGlobalDefines, ReplaceGlobalDefinesConfig,
@@ -14,6 +16,7 @@ use rolldown_common::NormalizedBundlerOptions;
 use rolldown_ecmascript::{EcmaAst, WithMutFields};
 use rolldown_ecmascript_utils::contains_script_closing_tag;
 use rolldown_error::{BatchedBuildDiagnostic, BuildDiagnostic, BuildResult, EventKind, Severity};
+use rustc_hash::FxHashSet;
 
 use crate::types::oxc_parse_type::OxcParseType;
 
@@ -158,6 +161,8 @@ impl PreProcessEcmaAst {
     // Step 5: Run DCE.
     // Avoid DCE for lazy export.
     if bundle_options.treeshake.is_some() && !has_lazy_export {
+      let original_top_level_stmt_spans =
+        ast.program().body.iter().map(GetSpan::span).collect::<Vec<_>>();
       ast.program.with_mut(|WithMutFields { program, allocator, .. }| {
         let scoping = self.recreate_scoping(&mut scoping, program);
         let mut treeshake = TreeShakeOptions::from(&bundle_options.treeshake);
@@ -169,6 +174,7 @@ impl PreProcessEcmaAst {
           ..CompressOptions::dce()
         };
         Compressor::new(allocator).dead_code_elimination_with_scoping(program, scoping, options);
+        preserve_removed_top_level_stmt_comments(program, &original_top_level_stmt_spans);
       });
     }
 
@@ -193,5 +199,54 @@ impl PreProcessEcmaAst {
       .semantic;
     self.stats = ret.stats();
     ret.into_scoping()
+  }
+}
+
+fn preserve_removed_top_level_stmt_comments(
+  program: &mut Program<'_>,
+  original_stmt_spans: &[oxc::span::Span],
+) {
+  if program.comments.is_empty() || original_stmt_spans.is_empty() {
+    return;
+  }
+
+  let remaining_stmt_starts =
+    program.body.iter().map(|stmt| stmt.span().start).collect::<FxHashSet<_>>();
+  let mut next_anchor = program.span.end;
+  let mut comment_anchors = vec![program.span.end; original_stmt_spans.len()];
+
+  for (idx, span) in original_stmt_spans.iter().enumerate().rev() {
+    comment_anchors[idx] = next_anchor;
+    if remaining_stmt_starts.contains(&span.start) {
+      next_anchor = span.start;
+    }
+  }
+
+  for (idx, span) in original_stmt_spans.iter().enumerate() {
+    if remaining_stmt_starts.contains(&span.start) {
+      continue;
+    }
+
+    let comment_region_end =
+      original_stmt_spans.get(idx + 1).map_or(program.span.end, |next_span| next_span.start);
+
+    for comment in &mut program.comments {
+      if comment.attached_to == span.start {
+        if comment.position == CommentPosition::Trailing {
+          comment.position = CommentPosition::Leading;
+        }
+        comment.attached_to = comment_anchors[idx];
+        continue;
+      }
+
+      if comment.position == CommentPosition::Trailing
+        && comment.attached_to == 0
+        && comment.span.start >= span.start
+        && comment.span.start < comment_region_end
+      {
+        comment.position = CommentPosition::Leading;
+        comment.attached_to = comment_anchors[idx];
+      }
+    }
   }
 }

--- a/crates/rolldown/tests/rolldown/issues/7917/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/7917/_config.json
@@ -1,0 +1,3 @@
+{
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/7917/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7917/artifacts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region main.js
+//!* This comment should still be there
+//!* This is there too!
+//!* This should still be there
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/7917/main.js
+++ b/crates/rolldown/tests/rolldown/issues/7917/main.js
@@ -1,5 +1,5 @@
-BigInt(1) //!* This comment should still be there
+BigInt(1); //!* This comment should still be there
 //!* This is there too!
 
 //!* This should still be there
-BigInt(1)
+BigInt(1);

--- a/crates/rolldown/tests/rolldown/issues/7917/main.js
+++ b/crates/rolldown/tests/rolldown/issues/7917/main.js
@@ -1,0 +1,5 @@
+BigInt(1) //!* This comment should still be there
+//!* This is there too!
+
+//!* This should still be there
+BigInt(1)


### PR DESCRIPTION
## Summary
- preserve comments when Oxc DCE removes a top-level statement
- preserve comments again during rolldown finalization when a top-level statement is removed later in the pipeline
- add a regression fixture for #7917 covering both inline and leading comments around `BigInt(1)`

Closes #7917.

## Testing
- `cargo run -p rolldown_testing --bin run-fixture crates/rolldown/tests/rolldown/issues/7917/_config.json`
- `cargo test --workspace --exclude rolldown_binding` in the original worktree reached all rolldown/esbuild/rollup integration tests but failed on `integration_test262` because the `test262` submodule is not present locally
- `pnpm run --filter rolldown-tests test:main`
- `pnpm run --filter rolldown-tests test:watcher`