### PR TITLE
fix(dev): avoid duplicate build after failed initial dev run

### DIFF
--- a/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/error_recovery/from_rebuild_syntax_error/artifacts.snap
@@ -41,26 +41,36 @@ console.log("dep");
 
 ```
 
-## Build Output
+# HMR Step 1
 
-### Errors
+## Code
 
-#### PARSE_ERROR
+```js
+//#region dep.js
+var init_dep_0 = __rolldown_runtime__.createEsmInitializer((function() {
+	try {
+		var __rolldown_exports__ = __rolldown_runtime__.__exportAll({ value: () => value });
+		__rolldown_runtime__.registerModule("dep.js", { exports: __rolldown_exports__ });
+		const hot_dep = __rolldown_runtime__.createModuleHotContext("dep.js");
+		const value = "dep";
+		if (hot_dep) {
+			hot_dep.accept();
+		}
+	} finally {}
+}));
 
-```text
-[PARSE_ERROR] Error: Expected a semicolon or an implicit semicolon after a statement, but found none
-   ╭─[ dep.js:1:8 ]
-   │
- 1 │ invalid syntax
-   │        │ 
-   │        ╰─ 
-   │ 
-   │ Help: Try inserting a semicolon here
-───╯
-
+//#endregion
+init_dep_0()
+__rolldown_runtime__.applyUpdates([['dep.js', 'dep.js']]);
 ```
 
-# HMR Step 1
+## Meta
+
+- update type: patch
+
+### Hmr Boundaries
+
+- boundary: dep.js, accepted_via: dep.js
 
 ## Build Output
 

--- a/crates/rolldown_dev/src/bundle_coordinator.rs
+++ b/crates/rolldown_dev/src/bundle_coordinator.rs
@@ -408,14 +408,10 @@ impl BundleCoordinator {
         })
       }
       CoordinatorState::FullBuildFailed | CoordinatorState::Failed => {
-        // Clear all queued tasks and schedule a new full build
-        self.queued_tasks.clear();
-        self.queued_tasks.push_back(TaskInput::FullBuild);
-        let schedule_result = self.schedule_build_if_stale().await;
-        schedule_result.map(|ret| EnsureLatestBundleOutputReturn {
-          future: ret.future,
-          is_ensure_latest_bundle_output_future: true,
-        })
+        tracing::trace!(
+          "[BundleCoordinator] latest output cannot be ensured after a failed build without a new invalidation"
+        );
+        None
       }
     }
   }
@@ -450,5 +446,59 @@ impl BundleCoordinator {
     }
     paths_mut.commit()?;
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::Arc;
+
+  use rolldown::BundlerOptions;
+  use rolldown_fs_watcher::{FsWatcherExt, NoopFsWatcher};
+  use tokio::sync::{Mutex, mpsc::unbounded_channel};
+
+  use crate::{DevOptions, SharedClients, dev_context::DevContext, normalize_dev_options};
+
+  use super::*;
+
+  fn create_coordinator(state: CoordinatorState) -> BundleCoordinator {
+    let bundler =
+      Arc::new(Mutex::new(Bundler::new(BundlerOptions::default()).expect("bundler should build")));
+    let (coordinator_tx, coordinator_rx) = unbounded_channel();
+    let ctx = Arc::new(DevContext {
+      options: normalize_dev_options(DevOptions::default()),
+      coordinator_tx,
+      clients: SharedClients::default(),
+    });
+
+    let mut coordinator =
+      BundleCoordinator::new(bundler, ctx, coordinator_rx, NoopFsWatcher.into_dyn_fs_watcher());
+    coordinator.state = state;
+    coordinator.has_stale_bundle_output = true;
+    coordinator
+  }
+
+  #[tokio::test]
+  async fn ensure_latest_output_does_not_reschedule_after_full_build_failure() {
+    let mut coordinator = create_coordinator(CoordinatorState::FullBuildFailed);
+
+    let result = coordinator.ensure_latest_bundle_output().await;
+
+    assert!(result.is_none());
+    assert!(coordinator.queued_tasks.is_empty());
+    assert_eq!(coordinator.state, CoordinatorState::FullBuildFailed);
+    assert!(coordinator.has_stale_bundle_output);
+  }
+
+  #[tokio::test]
+  async fn ensure_latest_output_does_not_reschedule_after_incremental_failure() {
+    let mut coordinator = create_coordinator(CoordinatorState::Failed);
+
+    let result = coordinator.ensure_latest_bundle_output().await;
+
+    assert!(result.is_none());
+    assert!(coordinator.queued_tasks.is_empty());
+    assert_eq!(coordinator.state, CoordinatorState::Failed);
+    assert!(coordinator.has_stale_bundle_output);
   }
 }

--- a/packages/rolldown/tests/dev-mode-validation.test.ts
+++ b/packages/rolldown/tests/dev-mode-validation.test.ts
@@ -1,6 +1,6 @@
 import { build, rolldown } from 'rolldown';
-import { scan } from 'rolldown/experimental';
-import { describe, expect, test } from 'vitest';
+import { dev, scan } from 'rolldown/experimental';
+import { describe, expect, test, vi } from 'vitest';
 
 describe('Dev mode validation', () => {
   test('should throw error when using dev mode with build API', async () => {
@@ -150,5 +150,46 @@ describe('Dev mode validation', () => {
     );
 
     await bundle.close();
+  });
+
+  test('should not trigger a second full build after initial dev build failure', async () => {
+    const onOutput = vi.fn();
+    const devEngine = await dev(
+      {
+        input: 'virtual',
+        plugins: [
+          {
+            name: 'test-fail-initial-build',
+            resolveId(id) {
+              if (id === 'virtual') return '\0' + id;
+            },
+            load(id) {
+              if (id === '\0virtual') {
+                throw new Error('initial build failed');
+              }
+            },
+          },
+        ],
+      },
+      {},
+      {
+        onOutput,
+        watch: {
+          skipWrite: true,
+        },
+      },
+    );
+
+    try {
+      await expect(devEngine.run()).resolves.toBeUndefined();
+      expect(onOutput).toHaveBeenCalledTimes(1);
+      expect(onOutput).toHaveBeenCalledWith(expect.any(Error));
+      await expect(devEngine.getBundleState()).resolves.toMatchObject({
+        lastFullBuildFailed: true,
+        hasStaleOutput: true,
+      });
+    } finally {
+      await devEngine.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- stop `ensure_latest_bundle_output()` from scheduling a new full build when the coordinator is already in `FullBuildFailed` or `Failed`
- add regressions for the coordinator state machine and the public dev API path that triggered issue #7835

## Testing
- cargo test -p rolldown_dev --lib bundle_coordinator::tests
- pnpm --filter rolldown-tests exec vitest run dev-mode-validation.test.ts
- pnpm --filter @rolldown/test-dev-server-tests run test

Fixes #7835.
