### PR TITLE
chore(ci): remove redundant `--no-run` build step from cargo-test

### DIFF
--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -43,9 +43,6 @@ jobs:
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
 
-      - name: Build
-        run: cargo test --workspace --exclude rolldown_binding --lib --tests --no-run
-
       - name: Run Test
         run: just test-rust
         env:


### PR DESCRIPTION
## Summary
- Remove the separate `cargo test --no-run` build step from the cargo-test workflow since `just test-rust` already compiles tests before running them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)