### PR TITLE
refactor!: rename exported BindingMagicString to RolldownMagicString

### DIFF
--- a/packages/rolldown/src/index.ts
+++ b/packages/rolldown/src/index.ts
@@ -119,7 +119,7 @@ import type { BundleError } from './utils/error';
 
 export { RUNTIME_MODULE_ID, VERSION } from './constants';
 export { build, defineConfig, rolldown, watch };
-export { BindingMagicString };
+export { BindingMagicString as RolldownMagicString };
 export type {
   AddonFunction,
   BundleError,

--- a/packages/rolldown/tests/magic-string/MagicString.test.ts
+++ b/packages/rolldown/tests/magic-string/MagicString.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import assert from 'node:assert';
 import { SourceMapConsumer } from 'source-map-js';
-import { BindingMagicString as MagicString } from 'rolldown';
+import { RolldownMagicString as MagicString } from 'rolldown';
 import { describe, it } from 'vitest';
 
 describe('MagicString', () => {

--- a/packages/rolldown/tests/magic-string/binding-magic-string-offset.test.ts
+++ b/packages/rolldown/tests/magic-string/binding-magic-string-offset.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { BindingMagicString as MagicString } from 'rolldown';
+import { RolldownMagicString as MagicString } from 'rolldown';
 import { describe, it } from 'vitest';
 
 /**

--- a/packages/rolldown/tests/magic-string/magic-string-original.test.ts
+++ b/packages/rolldown/tests/magic-string/magic-string-original.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { BindingMagicString as MagicString } from 'rolldown';
+import { RolldownMagicString as MagicString } from 'rolldown';
 import { describe, it } from 'vitest';
 
 describe('MagicString#original', () => {

--- a/packages/rolldown/tests/magic-string/magic-string-to-string-tag.test.ts
+++ b/packages/rolldown/tests/magic-string/magic-string-to-string-tag.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { BindingMagicString as MagicString } from 'rolldown';
+import { RolldownMagicString as MagicString } from 'rolldown';
 import { describe, it } from 'vitest';
 
 describe('MagicString isRolldownMagicString', () => {


### PR DESCRIPTION
from https://github.com/rolldown/rolldown/pull/8614#discussion_r2911804160
## Summary
 
 Rename the exported `BindingMagicString` class to `RolldownMagicString` in the public API.
 
 Only the exported name is changed — internal TypeScript code continues to use `BindingMagicString` to keep naming consistent with the binding layer. The public rename aligns the class name with its detection flag `isRolldownMagicString` (introduced in #8614).
 
 ## Changes
 - Update the re-export in `packages/rolldown/src/index.ts`
 - Update test imports to use the new name