### PR TITLE
refactor(rust): filter external modules from entries instead of mapping bit positions

### DIFF
--- a/crates/rolldown/src/chunk_graph.rs
+++ b/crates/rolldown/src/chunk_graph.rs
@@ -32,10 +32,6 @@ pub struct ChunkGraph {
   ///
   /// We use the second approach to avoid the overhead of re-indexing at the cost of some extra memory.
   pub post_chunk_optimization_operations: FxHashMap<ChunkIdx, PostChunkOptimizationOperation>,
-  /// Maps entry bit positions to their corresponding ChunkIdx.
-  /// Needed because external module entries are skipped during chunk creation,
-  /// causing bit positions (from enumerate) to not match chunk indices.
-  pub bit_to_chunk_idx: Vec<Option<ChunkIdx>>,
 }
 
 impl ChunkGraph {
@@ -50,7 +46,6 @@ impl ChunkGraph {
       common_chunk_exported_facade_chunk_namespace: FxHashMap::default(),
       common_chunk_preserve_export_names_modules: FxHashMap::default(),
       post_chunk_optimization_operations: FxHashMap::default(),
-      bit_to_chunk_idx: Vec::new(),
     }
   }
 

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -427,6 +427,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
               }
             }
 
+            let is_external = resolved_id.external.is_external();
             let idx = self.try_spawn_new_task(
               resolved_id,
               Some(ModuleTaskOwner::new(normal_module, raw_rec.span)),
@@ -458,6 +459,7 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
               dynamic_import_exports_usage_pairs.push((idx, usage));
             }
             if matches!(raw_rec.kind, ImportKind::DynamicImport)
+              && !is_external
               && !user_defined_entry_ids.contains(&idx)
             {
               match dynamic_import_entry_ids.entry(idx) {

--- a/crates/rolldown/src/module_loader/module_loader.rs
+++ b/crates/rolldown/src/module_loader/module_loader.rs
@@ -458,6 +458,10 @@ impl<'a, Fs: FileSystem + Clone + 'static> ModuleLoader<'a, Fs> {
             if let Some(usage) = dynamic_import_rec_exports_usage.remove(&rec_idx) {
               dynamic_import_exports_usage_pairs.push((idx, usage));
             }
+            // External modules are excluded here to preserve the bit-position-to-ChunkIdx
+            // invariant in code splitting. User-defined and emitted entries are already
+            // guaranteed non-external by `load_entry_module()` which rejects them with
+            // `entry_cannot_be_external`.
             if matches!(raw_rec.kind, ImportKind::DynamicImport)
               && !is_external
               && !user_defined_entry_ids.contains(&idx)

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -350,7 +350,7 @@ impl GenerateStage<'_> {
         if !temp_chunk.needs_creation {
           return None;
         }
-        let chunk_idxs: Vec<_> = bits.index_of_one().map(|bit| ChunkIdx::from_raw(bit)).collect();
+        let chunk_idxs: Vec<_> = bits.index_of_one().map(ChunkIdx::from_raw).collect();
 
         let merge_target = Self::try_insert_into_existing_chunk(
           &chunk_idxs,

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -352,10 +352,7 @@ impl GenerateStage<'_> {
         }
         let chunk_idxs: Vec<_> = bits
           .index_of_one()
-          // Use bit_to_chunk_idx to correctly map bit positions to chunk indices.
-          // Bit positions may not match chunk indices when external module entries
-          // are skipped during chunk creation.
-          .filter_map(|bit| chunk_graph.bit_to_chunk_idx.get(bit as usize).and_then(|idx| *idx))
+          .map(|bit| ChunkIdx::from_raw(bit))
           .collect();
 
         let merge_target = Self::try_insert_into_existing_chunk(

--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -350,10 +350,7 @@ impl GenerateStage<'_> {
         if !temp_chunk.needs_creation {
           return None;
         }
-        let chunk_idxs: Vec<_> = bits
-          .index_of_one()
-          .map(|bit| ChunkIdx::from_raw(bit))
-          .collect();
+        let chunk_idxs: Vec<_> = bits.index_of_one().map(|bit| ChunkIdx::from_raw(bit)).collect();
 
         let merge_target = Self::try_insert_into_existing_chunk(
           &chunk_idxs,

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -698,9 +698,6 @@ impl GenerateStage<'_> {
     entries_len: u32,
     input_base: &ArcStr,
   ) {
-    // Pre-allocate bit_to_chunk_idx mapping for all entry positions
-    chunk_graph.bit_to_chunk_idx = vec![None; entries_len as usize];
-
     // Create chunk for each static and dynamic entry
     for (entry_index, (&module_idx, entry_point)) in self
       .link_output
@@ -774,9 +771,6 @@ impl GenerateStage<'_> {
         self.options,
       );
       let chunk_idx = chunk_graph.add_chunk(chunk);
-      // Record the mapping from bit position to chunk index.
-      // External entries are skipped (no chunk created), so bit positions may not match chunk indices.
-      chunk_graph.bit_to_chunk_idx[entry_index] = Some(chunk_idx);
 
       if let Some(reference_ids) = self.link_output.entry_point_to_reference_ids.get(entry_point) {
         chunk_graph.chunk_idx_to_reference_ids.insert(chunk_idx, reference_ids.clone());
@@ -907,6 +901,10 @@ impl GenerateStage<'_> {
     entry_index: u32,
     index_splitting_info: &mut IndexSplittingInfo,
   ) {
+    debug_assert!(
+      self.link_output.module_table[entry_module_idx].is_normal(),
+      "Entry module {entry_module_idx:?} should be a normal module. External dynamic imports should be filtered out in module_loader.rs."
+    );
     let mut q = VecDeque::from([entry_module_idx]);
     while let Some(module_idx) = q.pop_front() {
       if !self.link_output.module_table[module_idx].is_normal() {

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -76,7 +76,7 @@ entry_index 2  →  plugin.js       →  bit 2  →  ChunkIdx(2)
 
 Dynamic imports are treated as entry points — they get bit positions and entry chunks just like static entries. This matches Rollup and esbuild behavior: a dynamic `import()` creates a new loading boundary, so the imported module needs its own chunk (or must be merged into an existing one).
 
-External modules are filtered out at the source — they never appear in `link_output.entries`. This is done in `module_loader.rs` where dynamic imports are collected as entry points: external modules are excluded from `dynamic_import_entry_ids`. This matches esbuild's approach where external modules never enter the entry list, and ensures that **bit positions directly equal chunk indices** — `ChunkIdx::from_raw(bit_position)` is always valid.
+External modules are filtered out at the source — they never appear in `link_output.entries`. This is done in `module_loader.rs` where dynamic imports are collected as entry points: external modules are excluded from `dynamic_import_entry_ids`. User-defined and emitted entries are also safe because `load_entry_module()` rejects external resolutions with `entry_cannot_be_external`. This matches esbuild's approach where external modules never enter the entry list, and ensures that **bit positions directly equal chunk indices** — `ChunkIdx::from_raw(bit_position)` is always valid.
 
 See #8595 for the bug that motivated this filtering.
 

--- a/meta/design/code-splitting.md
+++ b/meta/design/code-splitting.md
@@ -31,7 +31,7 @@ The trade-off is that this approach can produce many small chunks when there are
 | Separate chunk vs. inline? | Always separate; `experimentalMinChunkSize` for merging | Always separate; no merging                             | Separate by default; optimizer merges into entry chunks                          |
 | Circular chunk deps        | Warns; allows cyclic reexports                          | Enforces acyclic static chunk graph                     | Enforces acyclic via `would_create_circular_dependency` check before every merge |
 | Dynamic imports            | New entry points; computes "already loaded" atoms       | New entry points; rewrites to chunk unique keys         | New entry points; facade elimination for empty dynamic entries                   |
-| External modules           | Excluded from chunk graph                               | Excluded from bundling                                  | Get bit positions but no chunks (see Invariant below)                            |
+| External modules           | Excluded from chunk graph                               | Excluded from bundling                                  | Filtered from entry list at source (never get bit positions)                     |
 | Granularity                | Module level                                            | File level (was statement-level, backed off due to TLA) | Module level                                                                     |
 
 ## Pipeline
@@ -71,19 +71,14 @@ generate_chunks()
 ```
 entry_index 0  →  entry-a.js      →  bit 0  →  ChunkIdx(0)
 entry_index 1  →  entry-b.js      →  bit 1  →  ChunkIdx(1)
-entry_index 2  →  @optional/ext   →  bit 2  →  (external, no chunk)
-entry_index 3  →  plugin.js       →  bit 3  →  ChunkIdx(2)
+entry_index 2  →  plugin.js       →  bit 2  →  ChunkIdx(2)
 ```
 
 Dynamic imports are treated as entry points — they get bit positions and entry chunks just like static entries. This matches Rollup and esbuild behavior: a dynamic `import()` creates a new loading boundary, so the imported module needs its own chunk (or must be merged into an existing one).
 
-External modules get bit positions (because they appear in the entries list from the link stage) but no chunks are created for them (the `Module::Normal` check skips them). This means **bit positions do not equal chunk indices**. The mapping is stored in `chunk_graph.bit_to_chunk_idx: Vec<Option<ChunkIdx>>` — `None` for external entries, `Some(idx)` for real chunks.
+External modules are filtered out at the source — they never appear in `link_output.entries`. This is done in `module_loader.rs` where dynamic imports are collected as entry points: external modules are excluded from `dynamic_import_entry_ids`. This matches esbuild's approach where external modules never enter the entry list, and ensures that **bit positions directly equal chunk indices** — `ChunkIdx::from_raw(bit_position)` is always valid.
 
-### Invariant
-
-Any code converting a bit position to a `ChunkIdx` **must** use `bit_to_chunk_idx`, not `ChunkIdx::from_raw(bit_position)`. Violating this produces wrong chunk assignments when external entries exist. See #8595 for the bug this caused.
-
-esbuild avoids this problem because external modules never enter its entry list. Rollup uses `Set` objects rather than index-based lookup, so the mismatch can't occur. Rolldown's design — where external entries occupy bit positions without chunks — is unique and requires this explicit mapping.
+See #8595 for the bug that motivated this filtering.
 
 ## Reachability Propagation
 
@@ -118,7 +113,7 @@ The chunk optimizer reduces chunk count by merging common chunks back into entry
 
 ### Common Module Merging (`try_insert_common_module_to_exist_chunk`)
 
-For each common chunk, translates its `bits` to chunk indices via `bit_to_chunk_idx`, then tries to merge it into one of those entry chunks. Merging is skipped if it would:
+For each common chunk, translates its `bits` to chunk indices (bit positions directly map to `ChunkIdx`), then tries to merge it into one of those entry chunks. Merging is skipped if it would:
 
 - **Create a circular dependency between chunks** — checked via BFS in `would_create_circular_dependency()`. This is stricter than Rollup (which warns but allows cycles) and matches esbuild's enforcement of acyclic static chunk graphs.
 - **Change an entry's export signature** — when `preserveEntrySignatures: 'strict'`, adding modules to an entry chunk would expose symbols that the original entry didn't export.
@@ -138,7 +133,6 @@ Dynamic/emitted entries can become empty facades when all their modules are pull
 pub struct ChunkGraph {
     pub chunk_table: ChunkTable,                    // IndexVec<ChunkIdx, Chunk>
     pub module_to_chunk: IndexVec<ModuleIdx, Option<ChunkIdx>>,
-    pub bit_to_chunk_idx: Vec<Option<ChunkIdx>>,    // bit position → chunk index
     pub entry_module_to_entry_chunk: FxHashMap<ModuleIdx, ChunkIdx>,
     pub post_chunk_optimization_operations: FxHashMap<ChunkIdx, PostChunkOptimizationOperation>,
     // ...
@@ -147,7 +141,6 @@ pub struct ChunkGraph {
 
 - `chunk_table` — All chunks, indexed by `ChunkIdx`. May contain removed chunks (marked in `post_chunk_optimization_operations`) since re-indexing would be expensive.
 - `module_to_chunk` — Which chunk each module belongs to. O(1) lookup.
-- `bit_to_chunk_idx` — Translates entry bit positions to chunk indices. `None` for external entries that have bit positions but no chunks.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Follow-up to #8596. Instead of using `bit_to_chunk_idx` to map bit positions to chunk indices (a band-aid that every consumer must remember), this filters external modules at the source so they never get entry bit positions.

- **`module_loader.rs`**: Skip external modules when collecting `dynamic_import_entry_ids`
- **`chunk_graph.rs`**: Remove `bit_to_chunk_idx` field
- **`code_splitting.rs`**: Remove `bit_to_chunk_idx` pre-allocation/recording, add `debug_assert` for entry module normality
- **`chunk_optimizer.rs`**: Use direct `ChunkIdx::from_raw(bit)` instead of `bit_to_chunk_idx` lookup
- **`code-splitting.md`**: Update design doc to reflect new approach

This matches esbuild's approach where external modules never enter the entry list, ensuring bit positions directly equal chunk indices.

## Test plan

- [x] `cargo test -p rolldown --test integration -- "8595"` passes
- [x] `cargo test -p rolldown --test integration -- "circular_chunk_from_external"` passes
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)