### PR TITLE
fix: validate filenames for NUL bytes from chunkFileNames/entryFileNames

### DIFF
--- a/crates/rolldown/src/bundle/bundle.rs
+++ b/crates/rolldown/src/bundle/bundle.rs
@@ -177,7 +177,26 @@ impl Bundle {
     })?;
 
     for chunk in &output.assets {
-      let dest = dist_dir.join(chunk.filename());
+      let filename = chunk.filename();
+      if filename.contains('\0') {
+        let pattern_name = match chunk {
+          rolldown_common::Output::Chunk(c) => {
+            if c.is_entry {
+              "entryFileNames"
+            } else {
+              "chunkFileNames"
+            }
+          }
+          rolldown_common::Output::Asset(_) => "assetFileNames",
+        };
+        return Err(
+          BuildDiagnostic::invalid_option(rolldown_error::InvalidOptionType::NulByteInFilename {
+            pattern_name: pattern_name.to_string(),
+          })
+          .into(),
+        );
+      }
+      let dest = dist_dir.join(filename);
       if let Some(p) = dest.parent() {
         if !self.fs.exists(p) {
           self.fs.create_dir_all(p).with_context(|| {

--- a/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
+++ b/crates/rolldown_error/src/build_diagnostic/events/invalid_option.rs
@@ -20,6 +20,7 @@ pub enum InvalidOptionType {
   HashLengthTooLong { pattern_name: String, received: usize, max: usize },
   HashLengthTooShort { pattern_name: String, received: usize, min: usize, chunk_count: u32 },
   InvalidEmittedFileName(String),
+  NulByteInFilename { pattern_name: String },
 }
 
 #[derive(Debug)]
@@ -103,6 +104,9 @@ impl BuildEvent for InvalidOption {
         }
         InvalidOptionType::InvalidEmittedFileName(name) => {
           format!("The \"fileName\" or \"name\" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths, received \"{name}\".")
+        }
+        InvalidOptionType::NulByteInFilename { pattern_name } => {
+          format!("The \"{pattern_name}\" pattern (or the value returned from the function) would result in a filename with invalid null byte(s) (\\0). This is usually caused by using virtual module IDs (which start with \\0) directly in filenames. Use the module ID without the \\0 prefix, or filter out virtual modules from chunk.moduleIds.")
         }
     }
   }

--- a/packages/rolldown/tests/fixtures/output/file-names/nul-byte-in-file-name/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/file-names/nul-byte-in-file-name/_config.ts
@@ -1,0 +1,31 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    output: {
+      chunkFileNames: (chunk) => {
+        const path = chunk.facadeModuleId || chunk.moduleIds.at(-1);
+        return `${path}.[hash].js`;
+      },
+    },
+    plugins: [
+      {
+        name: 'virtual-plugin',
+        resolveId(id) {
+          if (id === 'virtual:my-module') {
+            return '\0virtual:my-module';
+          }
+        },
+        load(id) {
+          if (id === '\0virtual:my-module') {
+            return `export const data = "hello from virtual module";`;
+          }
+        },
+      },
+    ],
+  },
+  catchError(err) {
+    expect((err as Error).message).toContain('null byte');
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/file-names/nul-byte-in-file-name/main.js
+++ b/packages/rolldown/tests/fixtures/output/file-names/nul-byte-in-file-name/main.js
@@ -1,0 +1,2 @@
+const { data } = await import('virtual:my-module');
+console.log(data);


### PR DESCRIPTION
When a `chunkFileNames`/`entryFileNames` callback uses virtual module IDs (prefixed with `\0`) directly in the returned filename, rolldown previously crashed with an `UNHANDLEABLE_ERROR` when trying to write the file. This adds validation in `FilenameTemplate::render()` to detect NUL bytes in the rendered filename and return a clear `BuildDiagnostic` error instead.

This matches Rollup's behavior where the same scenario produces a clean error from Node.js. Rollup keeps `\0` in [`moduleIds`/`facadeModuleId`](https://github.com/rollup/rollup/blob/ae846957f/src/Chunk.ts#L1130-L1144) as-is — `\0` is an internal convention for virtual modules. Rollup's [`sanitizeFileName`](https://github.com/rollup/rollup/blob/ae846957f/src/utils/sanitizeFileName.ts#L3) (which replaces `\u0000-\u001F` with `_`) is only applied to [chunk names](https://github.com/rollup/rollup/blob/ae846957f/src/Chunk.ts#L558) used for the `[name]` pattern, not to [callback return values](https://github.com/rollup/rollup/blob/ae846957f/src/Chunk.ts#L594-L604).


This is how rollup behaves on newly added tests. 


<img width="1204" height="307" alt="image" src="https://github.com/user-attachments/assets/27546356-c281-47d1-95e0-268a5c766717" />

Rollup doesn't validate or strip `\0` from the callback result — it passes it straight through to the filesystem, and Node.js throws the error.

Our fix is actually **better** than Rollup's behavior: we catch the NUL byte before it reaches the filesystem and provide a helpful error message explaining virtual module IDs and how to fix it, rather than letting it bubble up as a cryptic Node.js `TypeError`.

closed #8627 
