### PR TITLE
fix: dce-only minify should not set NODE_ENV to production

### DIFF
--- a/crates/rolldown/src/utils/prepare_build_context.rs
+++ b/crates/rolldown/src/utils/prepare_build_context.rs
@@ -163,7 +163,7 @@ pub fn prepare_build_context(
 
   let mut raw_define = raw_options.define.unwrap_or_default();
   if matches!(platform, Platform::Browser) && !raw_define.contains_key("process.env.NODE_ENV") {
-    if raw_minify.is_enabled() {
+    if raw_minify.is_production() {
       raw_define.insert("process.env.NODE_ENV".to_string(), "'production'".to_string());
     } else {
       raw_define.insert("process.env.NODE_ENV".to_string(), "'development'".to_string());

--- a/crates/rolldown/tests/rolldown/function/minify/dce_only_node_env/_config.json
+++ b/crates/rolldown/tests/rolldown/function/minify/dce_only_node_env/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "external": ["node:assert"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/minify/dce_only_node_env/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/minify/dce_only_node_env/artifacts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+//#region main.js
+assert.equal("development", "development");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/function/minify/dce_only_node_env/main.js
+++ b/crates/rolldown/tests/rolldown/function/minify/dce_only_node_env/main.js
@@ -1,0 +1,3 @@
+import assert from 'node:assert';
+// With dce-only (the default), NODE_ENV should be 'development', not 'production'
+assert.equal(process.env.NODE_ENV, 'development');

--- a/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/minify_options.rs
@@ -90,12 +90,12 @@ pub struct RawMinifyOptionsDetailed {
 }
 
 impl RawMinifyOptions {
-  /// Returns `true` if the minify options is [`Enabled`].
-  ///
-  /// [`Enabled`]: RawMinifyOptions::Object
+  /// Returns `true` only for full minification modes (`Bool(true)` or `Object`).
+  /// `DeadCodeEliminationOnly` is not considered production since it only performs DCE.
   #[must_use]
-  pub fn is_enabled(&self) -> bool {
-    !matches!(self, Self::Bool(false))
+  #[inline]
+  pub fn is_production(&self) -> bool {
+    matches!(self, Self::Bool(true) | Self::Object(_))
   }
 }
 


### PR DESCRIPTION
 `minify: 'dce-only'` (the default) was implicitly setting `process.env.NODE_ENV` to `'production'` for browser builds. This replaces `is_enabled()` with a new `is_production()` check that only returns true for full minification modes (`Bool(true)` or `Object`), so `dce-only` now correctly defaults to `'development'`. Fixes #8618.
