### PR TITLE
feat: expose `oxcRuntimePlugin`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2869,6 +2869,7 @@ dependencies = [
  "rolldown_plugin_bundle_analyzer",
  "rolldown_plugin_esm_external_require",
  "rolldown_plugin_isolated_declaration",
+ "rolldown_plugin_oxc_runtime",
  "rolldown_plugin_replace",
  "rolldown_plugin_utils",
  "rolldown_plugin_vite_alias",

--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -44,6 +44,7 @@ rolldown_plugin = { workspace = true }
 rolldown_plugin_bundle_analyzer = { workspace = true }
 rolldown_plugin_esm_external_require = { workspace = true }
 rolldown_plugin_isolated_declaration = { workspace = true }
+rolldown_plugin_oxc_runtime = { workspace = true }
 rolldown_plugin_replace = { workspace = true }
 rolldown_plugin_utils = { workspace = true }
 rolldown_plugin_vite_alias = { workspace = true }

--- a/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_builtin_plugin.rs
@@ -5,6 +5,7 @@ use rolldown_plugin::__inner::Pluginable;
 use rolldown_plugin_bundle_analyzer::BundleAnalyzerPlugin;
 use rolldown_plugin_esm_external_require::EsmExternalRequirePlugin;
 use rolldown_plugin_isolated_declaration::IsolatedDeclarationPlugin;
+use rolldown_plugin_oxc_runtime::OxcRuntimePlugin;
 use rolldown_plugin_replace::ReplacePlugin;
 use rolldown_plugin_vite_alias::ViteAliasPlugin;
 use rolldown_plugin_vite_build_import_analysis::ViteBuildImportAnalysisPlugin;
@@ -197,6 +198,7 @@ impl TryFrom<BindingBuiltinPlugin<'_>> for Arc<dyn Pluginable> {
       }
       BindingBuiltinPluginName::ViteWasmFallback => Arc::new(ViteWasmFallbackPlugin),
       BindingBuiltinPluginName::ViteWebWorkerPost => Arc::new(ViteWebWorkerPostPlugin),
+      BindingBuiltinPluginName::OxcRuntime => Arc::new(OxcRuntimePlugin),
     })
   }
 }

--- a/crates/rolldown_binding/src/options/plugin/types/binding_builtin_plugin_name.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_builtin_plugin_name.rs
@@ -39,4 +39,6 @@ pub enum BindingBuiltinPluginName {
   ViteWasmFallback,
   #[napi(value = "builtin:vite-web-worker-post")]
   ViteWebWorkerPost,
+  #[napi(value = "builtin:oxc-runtime")]
+  OxcRuntime,
 }

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1798,7 +1798,8 @@ export type BindingBuiltinPluginName =  'builtin:bundle-analyzer'|
 'builtin:vite-resolve'|
 'builtin:vite-transform'|
 'builtin:vite-wasm-fallback'|
-'builtin:vite-web-worker-post';
+'builtin:vite-web-worker-post'|
+'builtin:oxc-runtime';
 
 export interface BindingBundleAnalyzerPluginConfig {
   /** Output filename for the bundle analysis data (default: "analyze-data.json") */

--- a/packages/rolldown/src/builtin-plugin/constructors.ts
+++ b/packages/rolldown/src/builtin-plugin/constructors.ts
@@ -108,6 +108,14 @@ type ViteReactRefreshWrapperPluginConfig = Omit<
   exclude?: StringOrRegExp | StringOrRegExp[];
 };
 
+/**
+ * This plugin should not be used for Rolldown.
+ */
+export function oxcRuntimePlugin(): BuiltinPlugin {
+  const builtinPlugin = new BuiltinPlugin('builtin:oxc-runtime');
+  return makeBuiltinPluginCallable(builtinPlugin);
+}
+
 export function viteReactRefreshWrapperPlugin(
   config: ViteReactRefreshWrapperPluginConfig,
 ): BuiltinPlugin {

--- a/packages/rolldown/src/experimental-index.ts
+++ b/packages/rolldown/src/experimental-index.ts
@@ -21,6 +21,7 @@ export { defineParallelPlugin } from './plugin/parallel-plugin';
 // Builtin plugin factory
 export {
   isolatedDeclarationPlugin,
+  oxcRuntimePlugin,
   viteBuildImportAnalysisPlugin,
   viteDynamicImportVarsPlugin,
   viteImportGlobPlugin,

--- a/packages/rolldown/tests/builtin-plugin/oxc-runtime.test.ts
+++ b/packages/rolldown/tests/builtin-plugin/oxc-runtime.test.ts
@@ -1,0 +1,23 @@
+import { oxcRuntimePlugin } from 'rolldown/experimental';
+import { expect, test } from 'vitest';
+
+const plugin = oxcRuntimePlugin() as unknown as { resolveId: Function; load: Function };
+
+test('resolveId resolves oxc runtime helper to virtual module', async () => {
+  const result = await plugin.resolveId('@oxc-project/runtime/helpers/objectSpread2.js');
+  // oxlint-disable-next-line no-control-regex
+  expect(result.id).toMatch(/^\0@oxc-project\+runtime@[\d.]+\/helpers\/objectSpread2\.js$/);
+});
+
+test('resolveId returns null for non-matching specifier', async () => {
+  const result = await plugin.resolveId('some-random-module');
+  expect(result).toBeNull();
+});
+
+test('load returns code for resolved virtual module', async () => {
+  const resolved = await plugin.resolveId('@oxc-project/runtime/helpers/objectSpread2.js');
+  const result = await plugin.load(resolved.id);
+  expect(result).toBeTruthy();
+  expect(result.code).toBeTruthy();
+  expect(typeof result.code).toBe('string');
+});


### PR DESCRIPTION
Expose `oxcRuntimePlugin` as a callable plugin from `rolldown/experimental` to use it in Vite unbundled dev.

The aim is to reduce the inconsistency between dev and build as Rolldown resolves `@oxc-project/runtime` in a special way. The inconsistency caused a bug. See https://github.com/vitejs/vite/pull/21822 for more details.
