### PR TITLE
fix: `comments.annotation: false` breaking tree-shaking

### DIFF
--- a/crates/rolldown/tests/rolldown/function/comments/annotation_false_with_treeshaking/_config.json
+++ b/crates/rolldown/tests/rolldown/function/comments/annotation_false_with_treeshaking/_config.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "comments": {
+      "annotation": false
+    }
+  },
+  "configVariants": [
+    {
+      "comments": {
+        "annotation": true
+      }
+    }
+  ],
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/function/comments/annotation_false_with_treeshaking/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/comments/annotation_false_with_treeshaking/artifacts.snap
@@ -1,0 +1,36 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+//#region icons.js
+const AIcon = window.bar(function() {
+	return 1;
+});
+//#endregion
+//#region main.js
+console.log(AIcon);
+//#endregion
+
+```
+
+# Variant: [comments: true]
+
+## Assets
+
+### main.js
+
+```js
+//#region icons.js
+const AIcon = /* @__PURE__ */ window.bar(function() {
+	return 1;
+});
+//#endregion
+//#region main.js
+console.log(AIcon);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/function/comments/annotation_false_with_treeshaking/icons.js
+++ b/crates/rolldown/tests/rolldown/function/comments/annotation_false_with_treeshaking/icons.js
@@ -1,0 +1,8 @@
+const AIcon = /* #__PURE__ */ window.bar(function () {
+    return 1;
+  }),
+  BIcon = /* #__PURE__ */ window.bar(function () {
+    return 2;
+  });
+
+export { AIcon, BIcon };

--- a/crates/rolldown/tests/rolldown/function/comments/annotation_false_with_treeshaking/main.js
+++ b/crates/rolldown/tests/rolldown/function/comments/annotation_false_with_treeshaking/main.js
@@ -1,0 +1,3 @@
+import { AIcon } from './icons.js';
+
+console.log(AIcon);

--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -207,7 +207,18 @@ impl NormalModule {
           PrintOptions {
             sourcemap: enable_sourcemap,
             filename: self.id.to_string(),
-            comments: options.comments.into(),
+            comments: {
+              let mut c: rolldown_ecmascript::PrintCommentsOptions = options.comments.into();
+              // Annotation comments must survive into the rendered text because
+              // `minify_chunks` re-parses it; without them the parser won't set
+              // `expr.pure` and DCE can't eliminate unused pure calls.
+              // `minify_chunks` codegen will honour the user's `comments.annotation`
+              // setting when it emits the final output.
+              // Only `annotation` needs this override — `legal` and `jsdoc` comments
+              // have no effect on DCE behaviour.
+              c.annotation = true;
+              c
+            },
             initial_indent,
           },
         );

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1864,6 +1864,16 @@
             "null"
           ]
         },
+        "comments": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CommentsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "chunkOptimization": {
           "type": [
             "boolean",

--- a/crates/rolldown_testing_config/src/config_variant.rs
+++ b/crates/rolldown_testing_config/src/config_variant.rs
@@ -1,7 +1,7 @@
 use rolldown_common::{
-  AddonOutputOption, BundlerOptions, CodeSplittingMode, ExperimentalOptions, InlineConstOption,
-  OptimizationOption, OutputExports, OutputFormat, PreserveEntrySignatures, StrictMode,
-  TreeshakeOptions, deserialize_inline_const,
+  AddonOutputOption, BundlerOptions, CodeSplittingMode, CommentsOptions, ExperimentalOptions,
+  InlineConstOption, OptimizationOption, OutputExports, OutputFormat, PreserveEntrySignatures,
+  StrictMode, TreeshakeOptions, deserialize_inline_const,
 };
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -35,6 +35,7 @@ pub struct ConfigVariant {
   pub footer: Option<String>,
   pub intro: Option<String>,
   pub outro: Option<String>,
+  pub comments: Option<CommentsOptions>,
   pub chunk_optimization: Option<bool>,
   // --- non-bundler options are start with `_`
   /// Whether to include the output in the snapshot for this config variant.
@@ -127,6 +128,9 @@ impl ConfigVariant {
     if let Some(outro) = &self.outro {
       config.outro = Some(AddonOutputOption::String(Some(outro.clone())));
     }
+    if let Some(comments) = &self.comments {
+      config.comments = Some(*comments);
+    }
     if let Some(chunk_optimization) = &self.chunk_optimization {
       config.experimental = Some(ExperimentalOptions {
         chunk_optimization: Some(*chunk_optimization),
@@ -191,6 +195,9 @@ impl ConfigVariant {
     }
     if let Some(minify) = &self.minify {
       fields.push(format!("minify: {minify:?}"));
+    }
+    if let Some(comments) = &self.comments {
+      fields.push(format!("comments: {comments}"));
     }
     if let Some(chunk_optimization) = &self.chunk_optimization {
       fields.push(format!("chunk_optimization: {chunk_optimization:?}"));


### PR DESCRIPTION
Setting `output.comments.annotation: false` stripped `@__PURE__` annotations before the DCE pass could use them, preventing elimination of unused pure calls in multi-declarator statements. The fix always preserves annotation comments during module rendering so DCE can identify pure calls; the final `minify_chunks` codegen strips them based on user settings. Also adds `comments` to `ConfigVariant` for integration test variants.  
  
closed #8655