### PR TITLE
feat: treeshake `module.exports` property write

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -169,8 +169,12 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     // check if the module is a reexport cjs module e.g.
     // module.exports = require('a');
     // normalize ast usage flag
-    if self.result.ast_usage.contains(EcmaModuleAstUsage::ModuleRef)
-      || !self.result.ast_usage.contains(EcmaModuleAstUsage::ExportsRef)
+    //
+    // Access apart from module.exports.xxx or exports.xxx
+    // will be considered as non-static property access
+    if self.result.ast_usage.contains(EcmaModuleAstUsage::ModuleExportsNonPropWriteRef)
+      || (!self.result.ast_usage.contains(EcmaModuleAstUsage::ModuleExportsPropWriteRef)
+        && !self.result.ast_usage.contains(EcmaModuleAstUsage::ExportsRef))
     {
       self.result.ast_usage.remove(EcmaModuleAstUsage::AllStaticExportPropertyAccess);
     }
@@ -306,13 +310,30 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
           }
         }
         // `module.exports.test` is also considered as commonjs keyword
-        Expression::StaticMemberExpression(member_expr) => {
-          if let Expression::Identifier(ref id) = member_expr.object {
+        Expression::StaticMemberExpression(inner_member_expr) => {
+          if let Expression::Identifier(ref id) = inner_member_expr.object {
             if id.name == "module"
               && self.is_global_identifier_reference(id)
-              && member_expr.property.name == "exports"
+              && inner_member_expr.property.name == "exports"
             {
               self.cjs_module_ident.get_or_insert(Span::new(id.span.start, id.span.start + 6));
+
+              // `module.exports.test = ...` — create facade symbol like `exports.test = ...`
+              if let Some((span, export_name)) = member_expr.static_property_info() {
+                let exported_symbol =
+                  self.result.symbol_ref_db.create_facade_root_symbol_ref(export_name);
+
+                self.declare_link_only_symbol_ref(exported_symbol.symbol);
+
+                if let Some(value) = self.extract_constant_value_from_expr(Some(&node.right)) {
+                  self
+                    .add_constant_symbol(exported_symbol.symbol, ConstExportMeta::new(value, true));
+                }
+
+                self.result.commonjs_exports.entry(export_name.into()).or_default().push(
+                  LocalExport { referenced: exported_symbol, span, came_from_commonjs: true },
+                );
+              }
             }
           }
         }
@@ -578,6 +599,16 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
               ident_ref,
               CjsGlobalAssignmentType::ModuleExportsAssignment,
             );
+            match v {
+              Some(CommonJsAstType::ExportsPropWrite(ref prop)) if prop != "*" => {
+                self.cjs_named_exports_usage.entry(prop.clone()).or_default().write += 1;
+                self.result.ast_usage.insert(EcmaModuleAstUsage::ModuleExportsPropWriteRef);
+              }
+              Some(CommonJsAstType::EsModuleFlag) => {
+                self.result.ast_usage.insert(EcmaModuleAstUsage::ModuleExportsPropWriteRef);
+              }
+              _ => self.result.ast_usage.insert(EcmaModuleAstUsage::ModuleExportsNonPropWriteRef),
+            }
             self.update_ast_usage_for_commonjs_export(v.as_ref());
           }
           "exports" => {

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -448,19 +448,37 @@ impl<'a> SideEffectDetector<'a> {
   }
 }
 
-/// Bundler-specific: detect `exports.staticProp = ...` CJS export pattern.
+/// Bundler-specific: detect CJS export patterns as side-effect-free.
+/// - `exports.a = ...`  / `exports['a'] = ...`
+/// - `module.exports.a = ...` / `module.exports['a'] = ...`
+///
 /// Returns `Some(PureCjs)` if the target matches, `None` otherwise.
 fn check_pure_cjs_export(scope: &AstScopes, target: &AssignmentTarget) -> Option<SideEffectDetail> {
   match target {
     AssignmentTarget::ComputedMemberExpression(_) | AssignmentTarget::StaticMemberExpression(_) => {
       let member_expr = target.to_member_expression();
-      if let Expression::Identifier(ident) = member_expr.object() {
-        if ident.reference_id.get().is_some_and(|ref_id| scope.is_unresolved(ref_id))
-          && ident.name == "exports"
-          && member_expr.static_property_name().is_some()
+      match member_expr.object() {
+        Expression::Identifier(ident)
+          if ident.reference_id.get().is_some_and(|ref_id| scope.is_unresolved(ref_id)) =>
         {
-          return Some(SideEffectDetail::PureCjs);
+          // exports.a / exports['a']
+          if ident.name == "exports" && member_expr.static_property_name().is_some() {
+            return Some(SideEffectDetail::PureCjs);
+          }
         }
+        // module.exports.a / module.exports['a']
+        Expression::ComputedMemberExpression(_) | Expression::StaticMemberExpression(_) => {
+          let nested = member_expr.object().to_member_expression();
+          if member_expr.static_property_name().is_some()
+            && matches!(nested.static_property_name(), Some("exports"))
+            && matches!(nested.object(), Expression::Identifier(ident)
+              if ident.reference_id.get().is_some_and(|ref_id| scope.is_unresolved(ref_id))
+                && ident.name == "module")
+          {
+            return Some(SideEffectDetail::PureCjs);
+          }
+        }
+        _ => {}
       }
       None
     }
@@ -1131,6 +1149,17 @@ mod test {
     assert_eq!(
       get_statements_side_effect_details("exports[test()] = true"),
       vec![SideEffectDetail::Unknown]
+    );
+
+    // module.exports.xxx = expr
+    assert_eq!(
+      get_statements_side_effect_details("module.exports.foo = 'bar'"),
+      vec![SideEffectDetail::PureCjs]
+    );
+
+    assert_eq!(
+      get_statements_side_effect_details("module.exports.foo = global()"),
+      vec![SideEffectDetail::Unknown | SideEffectDetail::PureCjs]
     );
 
     assert_eq!(

--- a/crates/rolldown/tests/esbuild/default/warn_common_js_exports_in_esm_convert/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/warn_common_js_exports_in_esm_convert/artifacts.snap
@@ -86,7 +86,6 @@ exports.foo = foo;
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 //#region cjs-in-esm2.js
 let foo = 1;
-module.exports.bar = 3;
 //#endregion
 exports.foo = foo;
 

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/esmodule_flag_with_named_exports/_config.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/esmodule_flag_with_named_exports/_config.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry",
+        "import": "./entry.js"
+      }
+    ]
+  },
+  "snapshot": true
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/esmodule_flag_with_named_exports/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/esmodule_flag_with_named_exports/artifacts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region entry.js
+var import_cjs = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports.__esModule = true;
+	module.exports.foo = "foo";
+})))();
+assert.strictEqual(import_cjs.foo, "foo");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/esmodule_flag_with_named_exports/cjs.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/esmodule_flag_with_named_exports/cjs.js
@@ -1,0 +1,4 @@
+module.exports.__esModule = true;
+module.exports.default = 'default_value';
+module.exports.foo = 'foo';
+module.exports.bar = 'bar';

--- a/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/esmodule_flag_with_named_exports/entry.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/module.exports_export/esmodule_flag_with_named_exports/entry.js
@@ -1,0 +1,5 @@
+// Test that module.exports.__esModule = true does not prevent tree-shaking of named exports
+import assert from 'node:assert';
+import { foo } from './cjs.js';
+
+assert.strictEqual(foo, 'foo');

--- a/crates/rolldown/tests/rolldown/topics/exports/entry_cjs_named_default/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/exports/entry_cjs_named_default/artifacts.snap
@@ -6,6 +6,19 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lib.js
 
 ```js
+const require_lib$1 = require("./lib2.js");
+Object.defineProperty(exports, "default", {
+	enumerable: true,
+	get: function() {
+		return require_lib$1.require_lib();
+	}
+});
+
+```
+
+## lib2.js
+
+```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region lib.js
 var require_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
@@ -13,13 +26,18 @@ var require_lib = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports.named = "named_value";
 }));
 //#endregion
-Object.defineProperty(exports, "default", {
+Object.defineProperty(exports, "__toESM", {
 	enumerable: true,
 	get: function() {
-		return require_lib();
+		return __toESM;
 	}
 });
-exports.__toESM = __toESM;
+Object.defineProperty(exports, "require_lib", {
+	enumerable: true,
+	get: function() {
+		return require_lib;
+	}
+});
 
 ```
 
@@ -27,11 +45,11 @@ exports.__toESM = __toESM;
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const require_lib$1 = require("./lib.js");
+const require_lib$1 = require("./lib2.js");
 let node_assert = require("node:assert");
 node_assert = require_lib$1.__toESM(node_assert);
 //#region main.js
-var import_lib = /* @__PURE__ */ require_lib$1.__toESM(require_lib$1.default);
+var import_lib = /* @__PURE__ */ require_lib$1.__toESM(require_lib$1.require_lib());
 node_assert.default.strictEqual(import_lib.default.value, 42);
 //#endregion
 exports.lib = import_lib.default;

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -126,6 +126,8 @@ bitflags! {
         const UnknownExportsRead = 1 << 7;
         /// Top-level return statement (only valid in CommonJS)
         const TopLevelReturn = 1 << 8;
+        const ModuleExportsPropWriteRef = 1 << 9;
+        const ModuleExportsNonPropWriteRef = 1 << 10;
         const ModuleOrExports = Self::ModuleRef.bits() | Self::ExportsRef.bits();
     }
 }


### PR DESCRIPTION
Extended the side effect detector to identify  `module.exports.property = ...` patterns as `PureCjs` operations. 

This adds on top of the existing `exports.xxx` support.

```js
// side-effect free if xxx is a static property and yyy is side-effect free
module.exports.xxx = yyy
```

This PR previously detects the side-effect of `module.exports` as a whole. But there's some issue with tree-shaking. Will take a look at it once I have a thorough knowledge of this.