### PR TITLE
fix: replace panics with proper errors in filter expression normalization


### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_plugin_options.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use napi::bindgen_prelude::{Either, FnArgs};
 use rolldown_utils::filter_expression::{self, FilterExprKind};
 use std::fmt::Debug;
@@ -217,45 +216,43 @@ pub struct FilterExprCache {
   pub render_chunk: Option<Vec<FilterExprKind>>,
 }
 impl BindingPluginOptions {
-  pub fn pre_compile_filter_expr(&self) -> FilterExprCache {
+  pub fn pre_compile_filter_expr(&self) -> napi::Result<FilterExprCache> {
+    let plugin_name = &self.name;
+    let make_err = |err: anyhow::Error| {
+      napi::Error::new(
+        napi::Status::InvalidArg,
+        format!("Invalid filter expression in plugin '{plugin_name}': {err}"),
+      )
+    };
+    let compile = |tokenss: &[Vec<_>]| -> napi::Result<Vec<FilterExprKind>> {
+      tokenss
+        .iter()
+        .cloned()
+        .map(|tokens| {
+          let normalized = normalized_tokens(tokens).map_err(&make_err)?;
+          filter_expression::parse(normalized).map_err(&make_err)
+        })
+        .collect()
+    };
+
     let mut cache = FilterExprCache::default();
     if let Some(tokenss) = self.resolve_id_filter.as_ref().and_then(|item| item.value.as_ref()) {
-      let filter_kind = tokenss
-        .clone()
-        .into_iter()
-        .map(|tokens| filter_expression::parse(normalized_tokens(tokens)))
-        .collect_vec();
-      cache.resolve_id = Some(filter_kind);
+      cache.resolve_id = Some(compile(tokenss)?);
     }
 
     if let Some(filter) = self.load_filter.as_ref().and_then(|item| item.value.as_ref()) {
-      let filter_kind = filter
-        .clone()
-        .into_iter()
-        .map(|tokens| filter_expression::parse(normalized_tokens(tokens)))
-        .collect_vec();
-      cache.load = Some(filter_kind);
+      cache.load = Some(compile(filter)?);
     }
 
     if let Some(filter) = self.transform_filter.as_ref().and_then(|item| item.value.as_ref()) {
-      let filter_kind = filter
-        .clone()
-        .into_iter()
-        .map(|tokens| filter_expression::parse(normalized_tokens(tokens)))
-        .collect_vec();
-      cache.transform = Some(filter_kind);
+      cache.transform = Some(compile(filter)?);
     }
 
     if let Some(filter) = self.render_chunk_filter.as_ref().and_then(|item| item.value.as_ref()) {
-      let filter_kind = filter
-        .clone()
-        .into_iter()
-        .map(|tokens| filter_expression::parse(normalized_tokens(tokens)))
-        .collect_vec();
-      cache.render_chunk = Some(filter_kind);
+      cache.render_chunk = Some(compile(filter)?);
     }
 
-    cache
+    Ok(cache)
   }
 }
 

--- a/crates/rolldown_binding/src/options/plugin/js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/js_plugin.rs
@@ -47,14 +47,14 @@ impl Deref for JsPlugin {
 
 impl JsPlugin {
   #[cfg_attr(target_family = "wasm", allow(unused))]
-  pub(super) fn new(inner: BindingPluginOptions) -> Self {
-    let filter_expr_cache = inner.pre_compile_filter_expr();
-    Self { inner, filter_expr_cache }
+  pub(super) fn new(inner: BindingPluginOptions) -> napi::Result<Self> {
+    let filter_expr_cache = inner.pre_compile_filter_expr()?;
+    Ok(Self { inner, filter_expr_cache })
   }
 
-  pub(crate) fn new_shared(inner: BindingPluginOptions) -> SharedPluginable {
-    let filter_expr_cache = inner.pre_compile_filter_expr();
-    Arc::new(Self { inner, filter_expr_cache })
+  pub(crate) fn new_shared(inner: BindingPluginOptions) -> napi::Result<SharedPluginable> {
+    let filter_expr_cache = inner.pre_compile_filter_expr()?;
+    Ok(Arc::new(Self { inner, filter_expr_cache }))
   }
 }
 

--- a/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/parallel_js_plugin.rs
@@ -30,17 +30,19 @@ impl ParallelJsPlugin {
   pub fn new_boxed(
     plugins: Vec<BindingPluginOptions>,
     worker_manager: Arc<WorkerManager>,
-  ) -> Box<dyn Pluginable> {
-    let plugins = plugins.into_iter().map(JsPlugin::new).collect::<Vec<_>>().into_boxed_slice();
-    Box::new(Self { plugins, worker_manager })
+  ) -> napi::Result<Box<dyn Pluginable>> {
+    let plugins =
+      plugins.into_iter().map(JsPlugin::new).collect::<napi::Result<Vec<_>>>()?.into_boxed_slice();
+    Ok(Box::new(Self { plugins, worker_manager }))
   }
 
   pub fn new_shared(
     plugins: Vec<BindingPluginOptions>,
     worker_manager: Arc<WorkerManager>,
-  ) -> Arc<dyn Pluginable> {
-    let plugins = plugins.into_iter().map(JsPlugin::new).collect::<Vec<_>>().into_boxed_slice();
-    Arc::new(Self { plugins, worker_manager })
+  ) -> napi::Result<Arc<dyn Pluginable>> {
+    let plugins =
+      plugins.into_iter().map(JsPlugin::new).collect::<napi::Result<Vec<_>>>()?.into_boxed_slice();
+    Ok(Arc::new(Self { plugins, worker_manager }))
   }
 
   fn first_plugin(&self) -> &JsPlugin {

--- a/crates/rolldown_binding/src/options/plugin/types/binding_filter_expression.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_filter_expression.rs
@@ -17,38 +17,31 @@ pub enum BindingFilterTokenPayloadInner {
 }
 
 impl BindingFilterTokenPayloadInner {
-  pub fn expect_string(self) -> String {
+  pub fn try_into_string(self) -> anyhow::Result<String> {
     match self {
-      BindingFilterTokenPayloadInner::StringOrRegex(inner) => inner.expect_string(),
-      BindingFilterTokenPayloadInner::Number(_) | BindingFilterTokenPayloadInner::Boolean(_) => {
-        unreachable!()
-      }
+      BindingFilterTokenPayloadInner::StringOrRegex(inner) => inner.try_into_string(),
+      other => anyhow::bail!("expected a string payload, but got {other:?}"),
     }
   }
 
-  pub fn expect_string_or_regex(self) -> StringOrRegex {
+  pub fn try_into_string_or_regex(self) -> anyhow::Result<StringOrRegex> {
     match self {
-      BindingFilterTokenPayloadInner::StringOrRegex(inner) => inner,
-      BindingFilterTokenPayloadInner::Number(_) | BindingFilterTokenPayloadInner::Boolean(_) => {
-        unreachable!()
-      }
+      BindingFilterTokenPayloadInner::StringOrRegex(inner) => Ok(inner),
+      other => anyhow::bail!("expected a string or regex payload, but got {other:?}"),
     }
   }
 
-  pub fn expect_number(self) -> u32 {
+  pub fn try_into_number(self) -> anyhow::Result<u32> {
     match self {
-      BindingFilterTokenPayloadInner::Number(v) => v,
-      BindingFilterTokenPayloadInner::StringOrRegex(_)
-      | BindingFilterTokenPayloadInner::Boolean(_) => unreachable!(),
+      BindingFilterTokenPayloadInner::Number(v) => Ok(v),
+      other => anyhow::bail!("expected a number payload, but got {other:?}"),
     }
   }
 
-  pub fn expect_regex(self) -> HybridRegex {
+  pub fn try_into_regex(self) -> anyhow::Result<HybridRegex> {
     match self {
-      BindingFilterTokenPayloadInner::StringOrRegex(inner) => inner.expect_regex(),
-      BindingFilterTokenPayloadInner::Number(_) | BindingFilterTokenPayloadInner::Boolean(_) => {
-        unreachable!()
-      }
+      BindingFilterTokenPayloadInner::StringOrRegex(inner) => inner.try_into_regex(),
+      other => anyhow::bail!("expected a regex payload, but got {other:?}"),
     }
   }
 }
@@ -107,64 +100,42 @@ pub enum FilterTokenKind {
   QueryValue,
 }
 
-pub fn normalized_tokens(tokens: Vec<BindingFilterToken>) -> Vec<Token> {
+pub fn normalized_tokens(tokens: Vec<BindingFilterToken>) -> anyhow::Result<Vec<Token>> {
+  fn take_payload(
+    token: &mut BindingFilterToken,
+  ) -> anyhow::Result<BindingFilterTokenPayloadInner> {
+    token
+      .payload
+      .take()
+      .ok_or_else(|| anyhow::anyhow!("`{:?}` token should have a payload", token.kind))
+      .map(BindingFilterTokenPayload::into_inner)
+  }
+
   let mut ret: Vec<Token> = Vec::with_capacity(tokens.len());
   let mut iter = tokens.into_iter().peekable();
   while let Some(value) = iter.peek_mut() {
     match value.kind {
       FilterTokenKind::Id => {
-        ret.push(Token::from(
-          value
-            .payload
-            .take()
-            .expect("`Id` should have payload")
-            .into_inner()
-            .expect_string_or_regex(),
-        ));
+        ret.push(Token::from(take_payload(value)?.try_into_string_or_regex()?));
         ret.push(Token::Id);
       }
       FilterTokenKind::ImporterId => {
-        ret.push(Token::from(
-          value
-            .payload
-            .take()
-            .expect("`ImporterId` should have payload")
-            .into_inner()
-            .expect_string_or_regex(),
-        ));
+        ret.push(Token::from(take_payload(value)?.try_into_string_or_regex()?));
         ret.push(Token::ImporterId);
       }
       FilterTokenKind::Code => {
-        ret.push(Token::from(
-          value
-            .payload
-            .take()
-            .expect("`Code` should have payload")
-            .into_inner()
-            .expect_string_or_regex(),
-        ));
+        ret.push(Token::from(take_payload(value)?.try_into_string_or_regex()?));
         ret.push(Token::Code);
       }
       FilterTokenKind::ModuleType => {
-        ret.push(Token::String(
-          value
-            .payload
-            .take()
-            .expect("`ModuleType` should have payload")
-            .into_inner()
-            .expect_string(),
-        ));
+        ret.push(Token::String(take_payload(value)?.try_into_string()?));
         ret.push(Token::ModuleType);
       }
       FilterTokenKind::And => {
-        ret.push(Token::And(
-          value.payload.take().expect("And should have payload").into_inner().expect_number(),
-        ));
+        ret.push(Token::And(take_payload(value)?.try_into_number()?));
       }
       FilterTokenKind::Or => {
-        ret.push(Token::Or(
-          value.payload.take().expect("`Or` should have payload").into_inner().expect_number(),
-        ));
+        ret.push(Token::Or(take_payload(value)?.try_into_number()?));
       }
       FilterTokenKind::Not => {
         ret.push(Token::Not);
@@ -173,29 +144,27 @@ pub fn normalized_tokens(tokens: Vec<BindingFilterToken>) -> Vec<Token> {
       FilterTokenKind::Exclude => ret.push(Token::Exclude),
       FilterTokenKind::CleanUrl => ret.push(Token::CleanUrl),
       FilterTokenKind::QueryKey => {
-        let query_key = value
-          .payload
-          .take()
-          .expect("`QueryKey` should have payload")
-          .into_inner()
-          .expect_string();
+        let query_key = take_payload(value)?.try_into_string()?;
         iter.next();
-        let Some(next_token) = iter.peek_mut() else {
-          unreachable!("`QueryKey` should be followed by one Token");
-        };
+        let next_token = iter.peek_mut().ok_or_else(|| {
+          anyhow::anyhow!("`QueryKey` should be followed by a `QueryValue` token")
+        })?;
         if next_token.kind != FilterTokenKind::QueryValue {
-          unreachable!("`QueryKey` should be followed by `QueryValue`");
+          anyhow::bail!(
+            "`QueryKey` should be followed by `QueryValue`, but got `{:?}`",
+            next_token.kind
+          );
         }
-        let query_value =
-          match next_token.payload.take().expect("`QueryValue` should have payload").into_inner() {
-            BindingFilterTokenPayloadInner::StringOrRegex(string_or_regex) => match string_or_regex
-            {
-              StringOrRegex::String(str) => Token::String(str),
-              StringOrRegex::Regex(regexp) => Token::Regex(regexp),
-            },
-            BindingFilterTokenPayloadInner::Boolean(v) => Token::Boolean(v),
-            BindingFilterTokenPayloadInner::Number(_) => todo!(),
-          };
+        let query_value = match take_payload(next_token)? {
+          BindingFilterTokenPayloadInner::StringOrRegex(string_or_regex) => match string_or_regex {
+            StringOrRegex::String(str) => Token::String(str),
+            StringOrRegex::Regex(regexp) => Token::Regex(regexp),
+          },
+          BindingFilterTokenPayloadInner::Boolean(v) => Token::Boolean(v),
+          BindingFilterTokenPayloadInner::Number(_) => {
+            anyhow::bail!("number values are not supported for query filter values");
+          }
+        };
         ret.push(query_value);
         ret.push(Token::String(query_key));
         ret.push(Token::Query);
@@ -203,10 +172,10 @@ pub fn normalized_tokens(tokens: Vec<BindingFilterToken>) -> Vec<Token> {
         continue;
       }
       FilterTokenKind::QueryValue => {
-        unreachable!("`QueryValue` is not expected");
+        anyhow::bail!("`QueryValue` token should not appear without a preceding `QueryKey`");
       }
     }
     iter.next();
   }
-  ret
+  Ok(ret)
 }

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -602,10 +602,10 @@ pub fn normalize_binding_options(
             .and_then(|plugin| plugin.remove(&index))
             .unwrap_or_default();
           let worker_manager = worker_manager.as_ref().unwrap();
-          Ok(ParallelJsPlugin::new_shared(plugins, Arc::clone(worker_manager)))
+          ParallelJsPlugin::new_shared(plugins, Arc::clone(worker_manager))
         },
         |plugin| match plugin {
-          Either::A(plugin_options) => Ok(JsPlugin::new_shared(plugin_options)),
+          Either::A(plugin_options) => JsPlugin::new_shared(plugin_options),
           Either::B(builtin) => {
             // Needs to save the name, since `try_into` will consume the ownership
             let name = format!("{:?}", builtin.__name);
@@ -628,7 +628,7 @@ pub fn normalize_binding_options(
     .chain(output_options.plugins)
     .filter_map(|plugin| {
       plugin.map(|plugin| match plugin {
-        Either::A(plugin_options) => Ok(JsPlugin::new_shared(plugin_options)),
+        Either::A(plugin_options) => JsPlugin::new_shared(plugin_options),
         Either::B(builtin) => {
           // Needs to save the name, since `try_into` will consume the ownership
           let name = format!("{:?}", builtin.__name);

--- a/crates/rolldown_utils/src/filter_expression.rs
+++ b/crates/rolldown_utils/src/filter_expression.rs
@@ -174,113 +174,82 @@ impl From<StringOrRegex> for Token {
   }
 }
 
-// TODO: better error handling
-pub fn parse(mut tokens: Vec<Token>) -> FilterExprKind {
-  fn rec(tokens: &mut Vec<Token>) -> Option<FilterExpr> {
-    let token = tokens.pop()?;
+pub fn parse(mut tokens: Vec<Token>) -> anyhow::Result<FilterExprKind> {
+  fn pop(tokens: &mut Vec<Token>) -> anyhow::Result<Token> {
+    tokens.pop().ok_or_else(|| anyhow::anyhow!("unexpected end of filter expression tokens"))
+  }
+
+  fn pop_string_or_regex(tokens: &mut Vec<Token>, context: &str) -> anyhow::Result<StringOrRegex> {
+    match pop(tokens)? {
+      Token::String(str) => Ok(StringOrRegex::String(str)),
+      Token::Regex(regexp) => Ok(StringOrRegex::Regex(regexp)),
+      other => {
+        anyhow::bail!("{context} token should be followed by a string or regex, but got {other:?}")
+      }
+    }
+  }
+
+  fn rec(tokens: &mut Vec<Token>) -> anyhow::Result<FilterExpr> {
+    let token = pop(tokens)?;
     match token {
-      Token::Id => {
-        let string_or_regex = match tokens.pop()? {
-          Token::String(str) => StringOrRegex::String(str),
-          Token::Regex(regexp) => StringOrRegex::Regex(regexp),
-          _ => {
-            unreachable!("Id token should be followed by a string or regex")
-          }
-        };
-        Some(FilterExpr::Id(string_or_regex))
-      }
-      Token::ImporterId => {
-        let string_or_regex = match tokens.pop()? {
-          Token::String(str) => StringOrRegex::String(str),
-          Token::Regex(regexp) => StringOrRegex::Regex(regexp),
-          _ => {
-            unreachable!("ImporterId token should be followed by a string or regex")
-          }
-        };
-        Some(FilterExpr::ImporterId(string_or_regex))
-      }
+      Token::Id => Ok(FilterExpr::Id(pop_string_or_regex(tokens, "Id")?)),
+      Token::ImporterId => Ok(FilterExpr::ImporterId(pop_string_or_regex(tokens, "ImporterId")?)),
+      Token::Code => Ok(FilterExpr::Code(pop_string_or_regex(tokens, "Code")?)),
       Token::Query => {
-        let Token::String(key) = tokens.pop()? else {
-          unreachable!("Key of `Query` should be string")
+        let key = match pop(tokens)? {
+          Token::String(key) => key,
+          other => anyhow::bail!("key of `Query` should be a string, but got {other:?}"),
         };
-        let value = match tokens.pop()? {
+        let value = match pop(tokens)? {
           Token::String(v) => QueryValue::String(v),
           Token::Regex(v) => QueryValue::Regex(v),
           Token::Boolean(v) => QueryValue::Boolean(v),
-          _ => {
-            unreachable!("Value of `Query` should be either `string`, `regex` or `boolean`")
-          }
+          other => anyhow::bail!(
+            "value of `Query` should be a string, regex, or boolean, but got {other:?}"
+          ),
         };
-        Some(FilterExpr::Query(key, value))
-      }
-      Token::Code => {
-        let string_or_regex = match tokens.pop()? {
-          Token::String(str) => StringOrRegex::String(str),
-          Token::Regex(regexp) => StringOrRegex::Regex(regexp),
-          _ => {
-            unreachable!("Code token should be followed by a string or regex")
-          }
-        };
-        Some(FilterExpr::Code(string_or_regex))
+        Ok(FilterExpr::Query(key, value))
       }
       Token::ModuleType => {
-        let Token::String(string) = tokens.pop()? else {
-          unreachable!("ModuleType token should be followed by a string");
+        let string = match pop(tokens)? {
+          Token::String(s) => s,
+          other => {
+            anyhow::bail!("ModuleType token should be followed by a string, but got {other:?}")
+          }
         };
-        Some(FilterExpr::ModuleType(string))
+        Ok(FilterExpr::ModuleType(string))
       }
       Token::And(arg_count) => {
         let mut args = Vec::with_capacity(arg_count as usize);
         for _ in 0..arg_count {
-          let inner = rec(tokens)?;
-          args.push(inner);
+          args.push(rec(tokens)?);
         }
-        Some(FilterExpr::And(args))
+        Ok(FilterExpr::And(args))
       }
       Token::Or(arg_count) => {
         let mut args = Vec::with_capacity(arg_count as usize);
         for _ in 0..arg_count {
-          let inner = rec(tokens)?;
-          args.push(inner);
+          args.push(rec(tokens)?);
         }
-        Some(FilterExpr::Or(args))
+        Ok(FilterExpr::Or(args))
       }
-      Token::Not => {
-        let inner = rec(tokens)?;
-        Some(FilterExpr::Not(Box::new(inner)))
-      }
-      Token::Include => {
-        unreachable!("Include token should not be in the expression");
-      }
-      Token::Exclude => {
-        unreachable!("Exclude token should not be in the expression");
-      }
-      Token::CleanUrl => {
-        let arg = rec(tokens)?;
-        Some(FilterExpr::CleanUrl(Box::new(arg)))
-      }
-      Token::String(_) => {
-        unreachable!("String token should not appear standalone");
-      }
-      Token::Regex(_) => {
-        unreachable!("Regex token should not appear standalone");
-      }
-      Token::Boolean(_) => {
-        unreachable!("Boolean token should not appear standalone");
-      }
+      Token::Not => Ok(FilterExpr::Not(Box::new(rec(tokens)?))),
+      Token::CleanUrl => Ok(FilterExpr::CleanUrl(Box::new(rec(tokens)?))),
+      Token::Include => anyhow::bail!("Include token should not appear inside an expression"),
+      Token::Exclude => anyhow::bail!("Exclude token should not appear inside an expression"),
+      Token::String(_) => anyhow::bail!("String token should not appear standalone"),
+      Token::Regex(_) => anyhow::bail!("Regex token should not appear standalone"),
+      Token::Boolean(_) => anyhow::bail!("Boolean token should not appear standalone"),
     }
   }
-  match tokens.pop() {
-    Some(Token::Include) => {
-      let inner = rec(&mut tokens).expect("Failed to parse expression");
-      FilterExprKind::Include(inner)
-    }
-    Some(Token::Exclude) => {
-      let inner = rec(&mut tokens).expect("Failed to parse expression");
-      FilterExprKind::Exclude(inner)
-    }
 
-    _ => unreachable!("Expression should start with Include or Exclude"),
+  match tokens.pop() {
+    Some(Token::Include) => Ok(FilterExprKind::Include(rec(&mut tokens)?)),
+    Some(Token::Exclude) => Ok(FilterExprKind::Exclude(rec(&mut tokens)?)),
+    Some(other) => {
+      anyhow::bail!("filter expression should start with Include or Exclude, but got {other:?}")
+    }
+    None => anyhow::bail!("filter expression is empty"),
   }
 }
 
@@ -360,7 +329,7 @@ mod test {
     ];
     tokens.reverse();
 
-    let expr = parse(tokens);
+    let expr = parse(tokens).unwrap();
     // the expr return `true`, but since it is a `Exclude`, finally it should be `false`
     assert!(!filter_exprs_interpreter(
       &[expr],

--- a/crates/rolldown_utils/src/pattern_filter.rs
+++ b/crates/rolldown_utils/src/pattern_filter.rs
@@ -11,17 +11,17 @@ pub enum StringOrRegex {
 }
 
 impl StringOrRegex {
-  pub fn expect_string(self) -> String {
+  pub fn try_into_string(self) -> anyhow::Result<String> {
     match self {
-      StringOrRegex::String(s) => s,
-      StringOrRegex::Regex(_) => unreachable!("Expected a string, but got {:?}", self),
+      StringOrRegex::String(s) => Ok(s),
+      StringOrRegex::Regex(_) => anyhow::bail!("expected a string, but got a regex"),
     }
   }
 
-  pub fn expect_regex(self) -> HybridRegex {
+  pub fn try_into_regex(self) -> anyhow::Result<HybridRegex> {
     match self {
-      StringOrRegex::Regex(s) => s,
-      StringOrRegex::String(_) => unreachable!("Expected a regex, but got {:?}", self),
+      StringOrRegex::Regex(s) => Ok(s),
+      StringOrRegex::String(_) => anyhow::bail!("expected a regex, but got a string"),
     }
   }
 }

--- a/packages/rolldown/tests/fixtures/plugin/transform/filter-invalid-payload/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/transform/filter-invalid-payload/_config.ts
@@ -1,0 +1,30 @@
+// Test that passing invalid filter payload types produces a clean error
+// instead of panicking. This simulates a user bypassing TypeScript type
+// checking (e.g., plain JS, @ts-ignore) and passing a number where a
+// string or RegExp is expected for an `id` filter.
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'bad-filter-plugin',
+        transform: {
+          filter: {
+            id: {
+              // This should be a string or RegExp, but we intentionally pass a number to trigger the error handling
+              include: [123 as any],
+            },
+          },
+          handler() {},
+        },
+      },
+    ],
+  },
+  catchError(e: any) {
+    expect(e).toBeInstanceOf(Error);
+    expect(e.message).toContain('expected a string or regex payload, but got Number(123)');
+    expect(e.message).toContain('bad-filter-plugin');
+  },
+});

--- a/packages/rolldown/tests/fixtures/plugin/transform/filter-invalid-payload/main.js
+++ b/packages/rolldown/tests/fixtures/plugin/transform/filter-invalid-payload/main.js
@@ -1,0 +1,1 @@
+console.log('main');


### PR DESCRIPTION
**Description:**

Replace all `unreachable!()`/`panic!()` calls in the binding filter expression normalization pipeline with `anyhow::Result` in `rolldown_utils` and `napi::Error` at the binding boundary. When users bypass TypeScript type checking and pass invalid filter payloads, rolldown now returns a clean error like `"Invalid filter expression in plugin 'my-plugin': expected a string or regex payload, but got Number(42)"` instead of crashing. Adds a JS test fixture to verify the behavior.

closed https://github.com/rolldown/rolldown/issues/8661
