### PR TITLE
docs: add viteplus alpha announcement banner

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -283,6 +283,12 @@ const config = defineConfig({
       },
     },
 
+    banner: {
+      id: 'viteplus-alpha',
+      text: 'Announcing Vite+ Alpha: Open source. Unified. Next-gen.',
+      url: 'https://voidzero.dev/posts/announcing-vite-plus-alpha?utm_source=rolldown&utm_content=top_banner',
+    },
+
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       {


### PR DESCRIPTION
From #8616 

Merge after Vite+ Alpha post is published: https://voidzero.dev/posts/announcing-vite-plus-alpha