### PR TITLE
revert: Revert "ci: Gate CI type-check job on node changes"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,6 @@ jobs:
     name: Type Check
     needs: [changes, build-rolldown-ubuntu]
     if: |
-      needs.changes.outputs.node-changes == 'true' &&
       always() &&
       (needs.build-rolldown-ubuntu.result == 'success' || needs.build-rolldown-ubuntu.result == 'skipped')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts rolldown/rolldown#8669

It doesn't solve the problem, https://github.com/rolldown/rolldown/pull/8663 still hang.