### PR TITLE
ci: correct if condition of `type-check` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,9 +131,7 @@ jobs:
   type-check:
     name: Type Check
     needs: [changes, build-rolldown-ubuntu]
-    if: |
-      always() &&
-      (needs.build-rolldown-ubuntu.result == 'success' || needs.build-rolldown-ubuntu.result == 'skipped')
+    if: needs.changes.outputs.node-changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
The `if: always()` pattern is used to ensure that `reusable` workflow are always triggered, so they could satisfy the require status check. We will skip unnecessary job inside the reusable workflow to avoid waste.

For inline workflow, no need to use this  `if: always()` pattern.

---

Context: this is the correct fix for https://github.com/rolldown/rolldown/pull/8669