### PR TITLE
fix(ci): bump native-build cache key to invalidate stale napi-rs artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
         uses: oxc-project/setup-rust@4f86b5d871ae7d24bc420e578be68964ab09e5cc # v1.0.15
         with:
           tools: just
-          cache-key: native-build
+          cache-key: native-build-1
           save-cache: ${{ github.ref_name == 'main' }}
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: oxc-project/setup-rust@4f86b5d871ae7d24bc420e578be68964ab09e5cc # v1.0.15
         with:
           tools: just
-          cache-key: native-build
+          cache-key: native-build-1
           save-cache: ${{ github.ref_name == 'main' }}
           target-dir: ${{ runner.os == 'Windows' && format('{0}/target', env.DEV_DRIVE) || '' }}
 


### PR DESCRIPTION
## Summary

- Bump `cache-key` from `native-build` to `native-build-1` in both `reusable-native-build.yml` and `ci.yml` (node-validation job)
- Stale incremental compilation cache causes napi-rs to generate incomplete `binding.d.cts` missing `OxcError` and `Comment` types from `oxc_parser_napi`, failing CI with TypeScript errors across all PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)