### PR TITLE
fix(ci): disable napi-rs DTS cache on CI

### DIFF
--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: oxc-project/setup-rust@4f86b5d871ae7d24bc420e578be68964ab09e5cc # v1.0.15
         with:
           tools: just
-          cache-key: native-build-1
+          cache-key: native-build-2
           save-cache: ${{ github.ref_name == 'main' }}
           target-dir: ${{ runner.os == 'Windows' && format('{0}/target', env.DEV_DRIVE) || '' }}
 

--- a/packages/rolldown/build-binding.ts
+++ b/packages/rolldown/build-binding.ts
@@ -23,7 +23,6 @@ const napiArgs = {
   jsBinding: 'binding.cjs',
   dts: 'binding.d.cts',
   constEnum: false,
-  dtsCache: !process.env.CI,
 };
 
 console.info('args:', napiArgs);

--- a/packages/rolldown/build-binding.ts
+++ b/packages/rolldown/build-binding.ts
@@ -23,6 +23,7 @@ const napiArgs = {
   jsBinding: 'binding.cjs',
   dts: 'binding.d.cts',
   constEnum: false,
+  dtsCache: !process.env.CI,
 };
 
 console.info('args:', napiArgs);


### PR DESCRIPTION
## Summary
- Disable napi-rs DTS cache on CI by setting `dtsCache: false` when `process.env.CI` is set, to avoid stale type definition artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)