### PR TITLE
fix: prevent may_partial_namespace from leaking through include_module

### DIFF
--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -577,6 +577,13 @@ pub fn include_module(ctx: &mut IncludeContext, module: &NormalModule) {
     return;
   }
 
+  // Save and reset may_partial_namespace. When including a module's
+  // side-effectful statements, we should not inherit the partial namespace
+  // context from a specific member expression resolution — the module's
+  // own statements need independent bailout evaluation.
+  let prev_may_partial_namespace = ctx.may_partial_namespace;
+  ctx.may_partial_namespace = false;
+
   ctx.is_module_included_vec.set_bit(module.idx);
   ctx.module_inclusion_changed = true;
 
@@ -658,6 +665,8 @@ pub fn include_module(ctx: &mut IncludeContext, module: &NormalModule) {
     include_statement(ctx, module, StmtInfos::NAMESPACE_STMT_IDX);
     ctx.module_namespace_included_reason[module.idx].insert(ModuleNamespaceIncludedReason::Unknown);
   }
+
+  ctx.may_partial_namespace = prev_may_partial_namespace;
 }
 
 pub fn include_symbol(

--- a/crates/rolldown/tests/rolldown/issues/8675/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8675/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "minify": false
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/8675/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8675/artifacts.snap
@@ -1,0 +1,34 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region react.cjs
+var require_react = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.x = 1;
+}));
+
+//#endregion
+//#region createStyled.cjs
+var require_createStyled = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.default = createStyled;
+	function createStyled() {}
+}));
+
+//#endregion
+//#region bar.mjs
+var import_react = /* @__PURE__ */ __toESM(require_react(), 1);
+var import_createStyled = /* @__PURE__ */ __toESM(require_createStyled(), 1);
+const Root = (0, import_createStyled.default)();
+var bar_default = 1;
+
+//#endregion
+//#region main.js
+console.log(bar_default, Root);
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/issues/8675/bar.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8675/bar.mjs
@@ -1,0 +1,4 @@
+import * as React from './react.cjs';
+import createStyled from './createStyled.cjs';
+export const Root = createStyled();
+export default React.x;

--- a/crates/rolldown/tests/rolldown/issues/8675/createStyled.cjs
+++ b/crates/rolldown/tests/rolldown/issues/8675/createStyled.cjs
@@ -1,0 +1,2 @@
+exports.default = createStyled;
+function createStyled() {}

--- a/crates/rolldown/tests/rolldown/issues/8675/main.js
+++ b/crates/rolldown/tests/rolldown/issues/8675/main.js
@@ -1,0 +1,2 @@
+import Button, { Root } from './bar.mjs';
+console.log(Button, Root);

--- a/crates/rolldown/tests/rolldown/issues/8675/react.cjs
+++ b/crates/rolldown/tests/rolldown/issues/8675/react.cjs
@@ -1,0 +1,1 @@
+exports.x = 1;


### PR DESCRIPTION
 Fixes #8675 
where CJS module exports were incorrectly tree-shaken when an ESM module had both a namespace import (`import * as React from './react.cjs'`) and a default import (`import
createStyled from './createStyled.cjs'`). The may_partial_namespace flag leaked through recursive include_module calls, causing the second CJS module's bailout check to be skipped.
The fix saves and resets the flag at include_module boundaries.