### PR TITLE
ci: should do matrix outside of reusable workflows 2

### DIFF
--- a/.github/workflows/reusable-node-dev-server-test.yml
+++ b/.github/workflows/reusable-node-dev-server-test.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   run:
-    name: Node Dev Server Test (Node ${{ inputs.node-version }})
+    name: Node Dev Server Test
     if: ${{ inputs.changed }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: 15

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   run:
-    name: Node Test (Node ${{ inputs.node-version }})
+    name: Node Test
     if: ${{ inputs.changed }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

Follow up to #8690. Remove `(Node ${{ inputs.node-version }})` from the job name in reusable workflows.

## Problem

#8690 moved the node-version matrix to the caller level and added `inputs.node-version` to the reusable workflow's job name. However, GitHub matches required status checks by the **full job name**. When the job is skipped via `if: ${{ inputs.changed }}`, GitHub does not interpolate expressions in the `name` field — so the check name becomes a literal:

```
node-test-ubuntu (20) / Node Test (Node ${{ inputs.node-version }})
```

instead of:

```
node-test-ubuntu (20) / Node Test (Node 20)
```

This causes a name mismatch with the required status check, which still fails. See #8663 for an example.

## Fix

Use a static job name (`Node Test` / `Node Dev Server Test`) in the reusable workflows. The caller's matrix already provides the node-version disambiguation in the outer job name (e.g. `node-test-ubuntu (20) / Node Test`), so the version doesn't need to be repeated in the inner name.