### PR TITLE
ci: fix cache key mismatch and remove redundant cache saves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,8 +256,8 @@ jobs:
         uses: oxc-project/setup-rust@4f86b5d871ae7d24bc420e578be68964ab09e5cc # v1.0.15
         with:
           tools: just
-          cache-key: native-build-1
-          save-cache: ${{ github.ref_name == 'main' }}
+          cache-key: native-build
+          save-cache: false
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
 

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: oxc-project/setup-rust@4f86b5d871ae7d24bc420e578be68964ab09e5cc # v1.0.15
         with:
           tools: just
-          cache-key: native-build-1
+          cache-key: native-build
           save-cache: ${{ github.ref_name == 'main' }}
           target-dir: ${{ runner.os == 'Windows' && format('{0}/target', env.DEV_DRIVE) || '' }}
 

--- a/.github/workflows/vite-tests.yml
+++ b/.github/workflows/vite-tests.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           tools: just
           cache-key: native-build
-          save-cache: ${{ github.ref_name == 'main' }}
+          save-cache: false
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
 


### PR DESCRIPTION
## Summary

- Unify cache key from `native-build-1` back to `native-build` across all workflows to eliminate ~724 MB of duplicate cache entries
- Set `save-cache: false` in `ci.yml` (node-validation) and `vite-tests.yml` so only `reusable-native-build.yml` saves caches (one per OS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)