### PR TITLE
fix: use try_init instead of init for tracing subscriber to avoid panic

### DIFF
--- a/crates/rolldown_devtools/src/init_tracing.rs
+++ b/crates/rolldown_devtools/src/init_tracing.rs
@@ -35,10 +35,10 @@ impl DebugTracer {
       }
     });
 
-    tracing_subscriber::registry()
+    let _ = tracing_subscriber::registry()
       .with(DevtoolsLayer.with_filter(devtools_event_filter))
       .with(fmt::layer().event_format(DevtoolsFormatter))
-      .init();
+      .try_init();
 
     tracer
   }

--- a/crates/rolldown_tracing/src/lib.rs
+++ b/crates/rolldown_tracing/src/lib.rs
@@ -48,10 +48,10 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
         if output_mode == "chrome-json" { TraceStyle::Async } else { TraceStyle::Threaded };
       let (chrome_layer, guard) =
         ChromeLayerBuilder::new().trace_style(trace_style).include_args(true).build();
-      tracing_subscriber::registry()
+      let _ = tracing_subscriber::registry()
         .with(Targets::from_str(&env_var).unwrap())
         .with(chrome_layer.with_filter(filter_for_removing_devtools_event))
-        .init();
+        .try_init();
       Some(Box::new(guard))
     }
     "json" => {
@@ -60,22 +60,22 @@ pub fn try_init_tracing() -> Option<Box<dyn Any + Send>> {
       unimplemented!()
     }
     "readable" => {
-      tracing_subscriber::registry()
+      let _ = tracing_subscriber::registry()
         .with(filter_for_removing_devtools_event)
         .with(Targets::from_str(&env_var).unwrap())
         .with(
           fmt::layer().pretty().with_span_events(FmtSpan::NONE).with_level(true).with_target(false),
         )
-        .init();
+        .try_init();
       tracing::debug!("Tracing initialized");
       None
     }
     _ => {
-      tracing_subscriber::registry()
+      let _ = tracing_subscriber::registry()
         .with(filter_for_removing_devtools_event)
         .with(Targets::from_str(&env_var).unwrap())
         .with(fmt::layer().pretty().with_span_events(FmtSpan::CLOSE | FmtSpan::ENTER))
-        .init();
+        .try_init();
       tracing::debug!("Tracing initialized");
       None
     }


### PR DESCRIPTION
## Summary

- Replace `.init()` with `.try_init()` for tracing subscriber initialization in `rolldown_tracing` and `rolldown_devtools`
- `.init()` calls `set_global_default()` which panics if a global subscriber is already set; `.try_init()` returns a `Result` instead
- Fixes concurrent build scenarios (e.g. multiple `build()` calls via `Promise.all`) where the second initialization would panic

Closes #8656

## Test plan

- [x] `cargo check -p rolldown_tracing -p rolldown_devtools` passes
- Concurrent builds via vite-plus no longer panic with `SetGlobalDefaultError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)