### PR TITLE
perf: disable napi tracing feature to reduce binary size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,9 +229,9 @@ quote = "1"
 syn = { version = "2", default-features = false }
 
 # napi
-napi = { version = "3.0.0", features = ["async", "anyhow", "tracing", "object_indexmap"] }
+napi = { version = "3.0.0", features = ["async", "anyhow", "object_indexmap"] }
 napi-build = { version = "2.2.2" }
-napi-derive = { version = "3.0.0", default-features = false, features = ["type-def", "tracing"] }
+napi-derive = { version = "3.0.0", default-features = false, features = ["type-def"] }
 
 # oxc crates with the same version
 oxc = { version = "0.119.0", features = [


### PR DESCRIPTION
## Summary

- Remove the `"tracing"` feature from both `napi` and `napi-derive` workspace dependencies
- This eliminates ~491 generated `tracing::debug!()` call sites in napi wrapper functions, saving **~99 KiB** in the release binary
- Rolldown's own tracing infrastructure (`rolldown_tracing` / `RD_LOG`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)