### PR TITLE
perf: replace Vec allocation with lazy iterator in find_hash_placeholders

### DIFF
--- a/crates/rolldown_plugin_chunk_import_map/src/lib.rs
+++ b/crates/rolldown_plugin_chunk_import_map/src/lib.rs
@@ -42,9 +42,9 @@ impl Plugin for ChunkImportMapPlugin {
       let base = args.options.hash_characters.base();
       let mut used_names = FxHashSet::default();
       for chunk in args.chunks.values() {
-        let hash_placeholders =
-          find_hash_placeholders(&chunk.filename, &HASH_PLACEHOLDER_LEFT_FINDER);
-        if hash_placeholders.is_empty() {
+        let mut hash_placeholders =
+          find_hash_placeholders(&chunk.filename, &HASH_PLACEHOLDER_LEFT_FINDER).peekable();
+        if hash_placeholders.peek().is_none() {
           continue;
         }
         let hasher = match &chunk.facade_module_id {
@@ -78,8 +78,9 @@ impl Plugin for ChunkImportMapPlugin {
       }
     }
 
-    let mut placeholders = find_hash_placeholders(&args.code, &HASH_PLACEHOLDER_LEFT_FINDER);
-    placeholders.retain(|placeholder| self.chunk_import_map.contains_key(placeholder.2));
+    let placeholders: Vec<_> = find_hash_placeholders(&args.code, &HASH_PLACEHOLDER_LEFT_FINDER)
+      .filter(|placeholder| self.chunk_import_map.contains_key(placeholder.2))
+      .collect();
 
     if placeholders.is_empty() {
       return Ok(None);

--- a/crates/rolldown_utils/src/hash_placeholder.rs
+++ b/crates/rolldown_utils/src/hash_placeholder.rs
@@ -11,12 +11,8 @@ const HASH_PLACEHOLDER_LEFT: &str = "!~{";
 const HASH_PLACEHOLDER_RIGHT: &str = "}~";
 const HASH_PLACEHOLDER_OVERHEAD: usize = HASH_PLACEHOLDER_LEFT.len() + HASH_PLACEHOLDER_RIGHT.len();
 
-// This is the size of a 128-bit xxhash with `base_encode::to_string`
-const MIN_HASH_SIZE: usize = 6;
 const MAX_HASH_SIZE: usize = 21;
 const DEFAULT_HASH_SIZE: usize = 8;
-
-const MINIMUM_HASH_PLACEHOLDER_LENGTH: usize = HASH_PLACEHOLDER_OVERHEAD + MIN_HASH_SIZE;
 
 pub static HASH_PLACEHOLDER_LEFT_FINDER: LazyLock<Finder<'static>> =
   LazyLock::new(|| Finder::new(HASH_PLACEHOLDER_LEFT));
@@ -41,32 +37,43 @@ fn is_hash_placeholder(s: &str) -> bool {
   content.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'_' || c == b'$')
 }
 
-/// Finds all hash placeholders in a string and returns their positions and values
-pub fn find_hash_placeholders<'a>(
+/// A lazy iterator over hash placeholders in a string.
+pub struct HashPlaceholderIter<'a> {
   s: &'a str,
-  finder: &Finder<'static>,
-) -> Vec<(usize, usize, &'a str)> {
-  // pre-allocate, the max number of placeholders
-  let mut results = Vec::with_capacity(s.len() / MINIMUM_HASH_PLACEHOLDER_LENGTH);
-  let mut start = 0;
+  finder: &'a Finder<'static>,
+  start: usize,
+}
 
-  while let Some(left_pos) = finder.find(&s.as_bytes()[start..]) {
-    let left_pos = start + left_pos;
-    if let Some(right_pos) = s[left_pos..].find(HASH_PLACEHOLDER_RIGHT) {
-      let right_pos = left_pos + right_pos + HASH_PLACEHOLDER_RIGHT.len();
-      let placeholder = &s[left_pos..right_pos];
+impl<'a> Iterator for HashPlaceholderIter<'a> {
+  type Item = (usize, usize, &'a str);
 
-      if is_hash_placeholder(placeholder) {
-        results.push((left_pos, right_pos, placeholder));
+  fn next(&mut self) -> Option<Self::Item> {
+    loop {
+      let left_pos = self.finder.find(&self.s.as_bytes()[self.start..])?;
+      let left_pos = self.start + left_pos;
+      // Bound the search for `}~` to the maximum possible placeholder length
+      let search_end = (left_pos + MAX_HASH_SIZE + HASH_PLACEHOLDER_OVERHEAD).min(self.s.len());
+      if let Some(right_pos) = self.s[left_pos..search_end].find(HASH_PLACEHOLDER_RIGHT) {
+        let right_pos = left_pos + right_pos + HASH_PLACEHOLDER_RIGHT.len();
+        let placeholder = &self.s[left_pos..right_pos];
+        self.start = right_pos;
+        if is_hash_placeholder(placeholder) {
+          return Some((left_pos, right_pos, placeholder));
+        }
+      } else {
+        // No `}~` found within bound; skip past `!~{` and continue
+        self.start = left_pos + HASH_PLACEHOLDER_LEFT.len();
       }
-
-      start = right_pos;
-    } else {
-      break;
     }
   }
+}
 
-  results
+/// Finds all hash placeholders in a string and returns a lazy iterator over their positions and values.
+pub fn find_hash_placeholders<'a>(
+  s: &'a str,
+  finder: &'a Finder<'static>,
+) -> HashPlaceholderIter<'a> {
+  HashPlaceholderIter { s, finder, start: 0 }
 }
 
 const BASE: u32 = 64;
@@ -149,11 +156,11 @@ impl HashPlaceholderGenerator {
 pub fn replace_placeholder_with_hash<'a>(
   source: &'a str,
   final_hashes_by_placeholder: &FxHashMap<String, &'a str>,
-  finder: &Finder<'static>,
+  finder: &'a Finder<'static>,
 ) -> Cow<'a, str> {
   // Check for placeholders directly
-  let placeholders = find_hash_placeholders(source, finder);
-  if placeholders.is_empty() {
+  let mut placeholders = find_hash_placeholders(source, finder).peekable();
+  if placeholders.peek().is_none() {
     return Cow::Borrowed(source);
   }
 
@@ -182,12 +189,9 @@ pub fn replace_placeholder_with_hash<'a>(
 
 pub fn extract_hash_placeholders<'a>(
   source: &'a str,
-  finder: &Finder<'static>,
+  finder: &'a Finder<'static>,
 ) -> FxIndexSet<&'a str> {
-  find_hash_placeholders(source, finder)
-    .into_iter()
-    .map(|(_, _, placeholder)| placeholder)
-    .collect()
+  find_hash_placeholders(source, finder).map(|(_, _, placeholder)| placeholder).collect()
 }
 
 #[test]
@@ -226,17 +230,17 @@ fn test_is_hash_placeholder() {
 #[test]
 fn test_find_hash_placeholders() {
   let s = "prefix!~{000}~middle!~{abc}~suffix";
-  let placeholders = find_hash_placeholders(s, &HASH_PLACEHOLDER_LEFT_FINDER);
+  let placeholders: Vec<_> = find_hash_placeholders(s, &HASH_PLACEHOLDER_LEFT_FINDER).collect();
   assert_eq!(placeholders.len(), 2);
   assert_eq!(placeholders[0], (6, 14, "!~{000}~"));
   assert_eq!(placeholders[1], (20, 28, "!~{abc}~"));
 
   let s = "no placeholders here";
-  let placeholders = find_hash_placeholders(s, &HASH_PLACEHOLDER_LEFT_FINDER);
+  let placeholders: Vec<_> = find_hash_placeholders(s, &HASH_PLACEHOLDER_LEFT_FINDER).collect();
   assert_eq!(placeholders.len(), 0);
 
   let s = "!~{000}~!~{001}~";
-  let placeholders = find_hash_placeholders(s, &HASH_PLACEHOLDER_LEFT_FINDER);
+  let placeholders: Vec<_> = find_hash_placeholders(s, &HASH_PLACEHOLDER_LEFT_FINDER).collect();
   assert_eq!(placeholders.len(), 2);
   assert_eq!(placeholders[0], (0, 8, "!~{000}~"));
   assert_eq!(placeholders[1], (8, 16, "!~{001}~"));


### PR DESCRIPTION
## Summary

- Replace `Vec::with_capacity(s.len() / 11)` pre-allocation in `find_hash_placeholders` with a zero-allocation `HashPlaceholderIter` that yields matches lazily — eliminates ~29 MB heap allocation per 10 MB input
- Bound the `}~` search to `MAX_HASH_SIZE + HASH_PLACEHOLDER_OVERHEAD` bytes after each `!~{` match instead of scanning the entire remaining string
- Update callers in `rolldown_plugin_chunk_import_map` to use `.peekable()` and `.filter().collect()` instead of `.is_empty()` / `.retain()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)