### PR TITLE
perf(sourcemap): use memchr for single-byte newline search

### DIFF
--- a/crates/rolldown_sourcemap/src/source.rs
+++ b/crates/rolldown_sourcemap/src/source.rs
@@ -82,7 +82,7 @@ impl Source for &Box<dyn Source + Send + Sync> {
 #[expect(clippy::cast_possible_truncation)]
 #[inline]
 fn lines_count(str: &str) -> u32 {
-  memchr::memmem::find_iter(str.as_bytes(), "\n").count() as u32
+  memchr::memchr_iter(b'\n', str.as_bytes()).count() as u32
 }
 
 #[test]


### PR DESCRIPTION
Replace `memmem::find_iter` (substring search) with `memchr_iter`
(single-byte search) in `lines_count`. memchr's single-byte search
is more specialized and avoids the overhead of substring matching
when searching for a single byte.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance tweak: swaps the newline-counting implementation to a single-byte `memchr_iter` search, with existing tests unchanged to guard behavior.
> 
> **Overview**
> Improves `lines_count` performance in `rolldown_sourcemap` by replacing `memmem::find_iter` (substring search) with `memchr::memchr_iter` for counting `\n` bytes.
> 
> Behavior is intended to remain identical, with the existing unit test still validating counts for trailing and non-trailing newlines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 524479089f33b024eae7e88bdd6388549af5c9da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->