### PR TITLE
perf(codegen): skip unnecessary annotation comment override

### DIFF
--- a/crates/rolldown_common/src/module/normal_module.rs
+++ b/crates/rolldown_common/src/module/normal_module.rs
@@ -207,18 +207,7 @@ impl NormalModule {
           PrintOptions {
             sourcemap: enable_sourcemap,
             filename: self.id.to_string(),
-            comments: {
-              let mut c: rolldown_ecmascript::PrintCommentsOptions = options.comments.into();
-              // Annotation comments must survive into the rendered text because
-              // `minify_chunks` re-parses it; without them the parser won't set
-              // `expr.pure` and DCE can't eliminate unused pure calls.
-              // `minify_chunks` codegen will honour the user's `comments.annotation`
-              // setting when it emits the final output.
-              // Only `annotation` needs this override — `legal` and `jsdoc` comments
-              // have no effect on DCE behaviour.
-              c.annotation = true;
-              c
-            },
+            comments: options.comments.into(),
             initial_indent,
           },
         );


### PR DESCRIPTION
The per-module codegen was forcing `annotation = true` to preserve
`/* @__PURE__ */` comments for chunk-level DCE. However, since
chunk-level compression is already skipped (mangle-only mode),
these annotation comments serve no purpose and only increase the
intermediate text size.

This reduces the concatenated chunk text by ~12%, speeding up the
subsequent minifier re-parse and sourcemap generation. On a 10K
module benchmark this is a ~5.5% wall-clock improvement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes comment preservation behavior during module codegen, which could affect `@__PURE__`/other annotation-driven DCE and downstream minification in some configurations. Functional impact should be limited when chunk-level compression is already disabled, but output size and tree-shaking could differ if annotation comments are no longer emitted.
> 
> **Overview**
> Removes the per-module codegen override that always forced `comments.annotation = true` during `EcmaCompiler::print_with` in `NormalModule::render`.
> 
> Module printing now respects the user-provided `options.comments` as-is, reducing intermediate generated text (and associated re-parse/sourcemap work) when annotation comments are not needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76f49917c903b0f8b00a69c777370803453f4950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->