### PR TITLE
perf(minify): use correct jsx setting in minifier re-parse

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/minify_chunks.rs
+++ b/crates/rolldown/src/stages/generate_stage/minify_chunks.rs
@@ -48,7 +48,7 @@ impl GenerateStage<'_> {
           let (minified_content, new_map) = EcmaCompiler::dce_or_minify(
             &allocator_guard,
             chunk.content.try_as_inner_str()?,
-            options.format.source_type().with_jsx(true),
+            options.format.source_type().with_jsx(options.transform_options.is_jsx_preserve()),
             chunk.map.is_some(),
             chunk.preliminary_filename.as_str(),
             compress,


### PR DESCRIPTION
The minifier re-parse was unconditionally setting `with_jsx(true)`,
forcing the parser to handle JSX syntax even when the output format
doesn't preserve JSX. Use the actual `is_jsx_preserve()` setting
from transform options instead, allowing the parser to skip JSX
handling when not needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to minification parsing options that only affects whether JSX syntax is enabled during re-parse, with no changes to output logic beyond this flag.
> 
> **Overview**
> Fixes minification re-parse to **stop forcing JSX parsing** by replacing unconditional `with_jsx(true)` with `with_jsx(options.transform_options.is_jsx_preserve())`.
> 
> This aligns the minifier’s parser settings with the configured JSX preservation mode, avoiding unnecessary JSX handling when JSX is not expected in the output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0bc1d0af82e19ef73dab42ae7fd2d2ba7e1af7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->