### PR TITLE
perf(sourcemap): parallelize collapse_sourcemaps with rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3569,7 +3569,6 @@ dependencies = [
  "oxc",
  "oxc_sourcemap",
  "rolldown_utils",
- "rustc-hash",
 ]
 
 [[package]]

--- a/crates/rolldown_sourcemap/Cargo.toml
+++ b/crates/rolldown_sourcemap/Cargo.toml
@@ -23,7 +23,6 @@ memchr = { workspace = true }
 oxc = { workspace = true }
 oxc_sourcemap = { workspace = true }
 rolldown_utils = { workspace = true }
-rustc-hash = { workspace = true }
 
 [dev-dependencies]
 criterion2 = { workspace = true, default-features = false }

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -4,7 +4,7 @@ mod source_joiner;
 use std::sync::Arc;
 
 use oxc_sourcemap::Token;
-use rustc_hash::FxHashMap;
+use rolldown_utils::rayon::{IntoParallelIterator, ParallelIterator};
 
 pub use oxc_sourcemap::{JSONSourceMap, SourceMap, SourceMapBuilder, SourcemapVisualizer};
 pub use source_joiner::SourceJoiner;
@@ -45,8 +45,6 @@ pub fn adjust_sourcemap_dst_lines(sourcemap: SourceMap, lines: u32) -> SourceMap
   )
 }
 
-use rolldown_utils::rustc_hash::FxHashMapExt;
-
 // <https://github.com/rollup/rollup/blob/master/src/utils/collapseSourcemaps.ts>
 #[expect(clippy::cast_possible_truncation)]
 pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
@@ -65,18 +63,10 @@ pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
     .map(|sourcemap| (sourcemap, sourcemap.generate_lookup_table()))
     .collect::<Vec<_>>();
 
-  let source_view_tokens = last_map.get_source_view_tokens();
-
-  let sources_map = first_map
-    .get_sources()
-    .enumerate()
-    .map(|(i, source)| (source, i as u32))
-    .collect::<FxHashMap<_, _>>();
-
-  // Avoid hashing the source text for every token.
-  let mut sources_cache = FxHashMap::with_capacity(sources_map.len());
+  let source_view_tokens = last_map.get_source_view_tokens().collect::<Vec<_>>();
 
   let tokens = source_view_tokens
+    .into_par_iter()
     .filter_map(|token| {
       let original_token = sourcemap_and_lookup_table.iter().rev().try_fold(
         token,
@@ -94,14 +84,7 @@ pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
           token.get_dst_col(),
           original_token.get_src_line(),
           original_token.get_src_col(),
-          original_token.get_source_id().and_then(|source_id| {
-            sources_cache
-              .entry(source_id)
-              .or_insert_with(|| {
-                first_map.get_source(source_id).and_then(|source| sources_map.get(source))
-              })
-              .copied()
-          }),
+          original_token.get_source_id(),
           original_token.get_name_id(),
         )
       })


### PR DESCRIPTION
Use rayon's `par_iter` to parallelize the token lookup loop in
`collapse_sourcemaps`. Each token's lookup through the sourcemap
chain is independent, making this embarrassingly parallel.

Also simplified the source_id remapping: since collapse_sourcemaps
only operates on a 2-map chain (concatenated map + minifier map)
where the first map's source indices are already identity-mapped,
the FxHashMap-based source_id cache was unnecessary overhead.
Replaced with direct pass-through of source_id.

On a 10K module benchmark with ~360K tokens, this reduces
collapse_sourcemaps from ~6.5ms to ~1ms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core sourcemap collapsing logic and changes token/source-id handling; while the work is embarrassingly parallel, any subtle ordering or mapping assumptions could impact sourcemap correctness.
> 
> **Overview**
> **Speeds up sourcemap collapsing** by parallelizing the per-token lookup in `collapse_sourcemaps` using rayon (`into_par_iter`) after materializing `get_source_view_tokens()` into a `Vec`.
> 
> **Simplifies token construction** by removing the `FxHashMap`-based source-id remapping/cache and directly passing through `original_token.get_source_id()`, and drops the `rustc-hash` dependency from `rolldown_sourcemap` (and lockfile).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cd958459217214f07153f6c8db23b165f5e7a86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->