### PR TITLE
perf(rolldown): some minor perf optimization found by autoresearch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,8 +3568,6 @@ dependencies = [
  "memchr",
  "oxc",
  "oxc_sourcemap",
- "rolldown_utils",
- "rustc-hash",
 ]
 
 [[package]]

--- a/crates/rolldown_sourcemap/Cargo.toml
+++ b/crates/rolldown_sourcemap/Cargo.toml
@@ -22,8 +22,6 @@ doctest = false
 memchr = { workspace = true }
 oxc = { workspace = true }
 oxc_sourcemap = { workspace = true }
-rolldown_utils = { workspace = true }
-rustc-hash = { workspace = true }
 
 [dev-dependencies]
 criterion2 = { workspace = true, default-features = false }

--- a/crates/rolldown_sourcemap/src/lib.rs
+++ b/crates/rolldown_sourcemap/src/lib.rs
@@ -4,7 +4,6 @@ mod source_joiner;
 use std::sync::Arc;
 
 use oxc_sourcemap::Token;
-use rustc_hash::FxHashMap;
 
 pub use oxc_sourcemap::{JSONSourceMap, SourceMap, SourceMapBuilder, SourcemapVisualizer};
 pub use source_joiner::SourceJoiner;
@@ -45,10 +44,7 @@ pub fn adjust_sourcemap_dst_lines(sourcemap: SourceMap, lines: u32) -> SourceMap
   )
 }
 
-use rolldown_utils::rustc_hash::FxHashMapExt;
-
 // <https://github.com/rollup/rollup/blob/master/src/utils/collapseSourcemaps.ts>
-#[expect(clippy::cast_possible_truncation)]
 pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
   debug_assert!(sourcemap_chain.len() > 1);
   if sourcemap_chain.len() == 1 {
@@ -65,18 +61,8 @@ pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
     .map(|sourcemap| (sourcemap, sourcemap.generate_lookup_table()))
     .collect::<Vec<_>>();
 
-  let source_view_tokens = last_map.get_source_view_tokens();
-
-  let sources_map = first_map
-    .get_sources()
-    .enumerate()
-    .map(|(i, source)| (source, i as u32))
-    .collect::<FxHashMap<_, _>>();
-
-  // Avoid hashing the source text for every token.
-  let mut sources_cache = FxHashMap::with_capacity(sources_map.len());
-
-  let tokens = source_view_tokens
+  let tokens = last_map
+    .get_source_view_tokens()
     .filter_map(|token| {
       let original_token = sourcemap_and_lookup_table.iter().rev().try_fold(
         token,
@@ -94,14 +80,7 @@ pub fn collapse_sourcemaps(sourcemap_chain: &[&SourceMap]) -> SourceMap {
           token.get_dst_col(),
           original_token.get_src_line(),
           original_token.get_src_col(),
-          original_token.get_source_id().and_then(|source_id| {
-            sources_cache
-              .entry(source_id)
-              .or_insert_with(|| {
-                first_map.get_source(source_id).and_then(|source| sources_map.get(source))
-              })
-              .copied()
-          }),
+          original_token.get_source_id(),
           original_token.get_name_id(),
         )
       })

--- a/crates/rolldown_sourcemap/src/source.rs
+++ b/crates/rolldown_sourcemap/src/source.rs
@@ -82,7 +82,7 @@ impl Source for &Box<dyn Source + Send + Sync> {
 #[expect(clippy::cast_possible_truncation)]
 #[inline]
 fn lines_count(str: &str) -> u32 {
-  memchr::memmem::find_iter(str.as_bytes(), "\n").count() as u32
+  memchr::memchr_iter(b'\n', str.as_bytes()).count() as u32
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches `collapse_sourcemaps`, which is used in chunk rendering/minification; incorrect `source_id` propagation could subtly break sourcemap fidelity even though the change is small and performance-motivated.
> 
> **Overview**
> **Optimizes sourcemap processing** by removing `rustc-hash`/`rolldown_utils` dependencies and simplifying `collapse_sourcemaps` to pass through `source_id` directly instead of remapping via cached hash maps.
> 
> Also swaps newline counting in `SourceMapSource` to use `memchr::memchr_iter` for faster `\n` scanning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56cddc8f0ec2c440ded3a35829220eae95b0c923. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->