### PR TITLE
docs: add external link icon to GitHub button in Hero section

### DIFF
--- a/docs/.vitepress/theme/Hero.vue
+++ b/docs/.vitepress/theme/Hero.vue
@@ -20,9 +20,23 @@
             href="https://github.com/rolldown/rolldown"
             target="_blank"
             rel="noopener noreferrer"
-            class="button inline-block w-fit"
+            class="button inline-flex items-center gap-2 w-fit"
           >
-            View on GitHub
+            <span>View on GitHub</span>
+            <svg class="size-3" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M3.18228 2.81797L9.54624 2.81797L9.54624 9.18193"
+                stroke="currentColor"
+                stroke-width="1.35"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M9.5459 2.81799L3.18194 9.18195"
+                stroke="currentColor"
+                stroke-width="1.35"
+                stroke-linejoin="round"
+              />
+            </svg>
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Description

This PR adds an external link icon to the **"View on GitHub"** button in the Hero section of the documentation. This provides a better visual cue to users that the link will open in a new tab, maintaining consistency with other external links like the REPL.

## Changes

- **Update [Hero.vue](cci:7://file:///home/13769K/Git/forks/rolldown/docs/.vitepress/theme/Hero.vue:0:0-0:0)**: Added an SVG external link icon to the GitHub action button.
- **Improved Layout**: Updated button classes from `inline-block` to `inline-flex items-center gap-2` to ensure the label and icon are perfectly aligned.
- **Dynamic Styling**: Used `currentColor` for the SVG stroke to ensure it remains visible and styled correctly across light and dark modes.

## Preview

*![Screencast from 16-03-26 01-40-46 PM IST](https://github.com/user-attachments/assets/da8eb588-863d-40b0-bfa1-772971c7846c)*

## Type of Change
- [ ] Bug fix
- [x] Documentation / UI improvement
- [ ] New feature
