### PR TITLE
fix(vite-resolve): normalize importer paths to native separators on Windows

### DIFF
--- a/crates/rolldown_plugin_vite_resolve/Cargo.toml
+++ b/crates/rolldown_plugin_vite_resolve/Cargo.toml
@@ -8,7 +8,6 @@ description = "Rolldown plugin for Vite module resolution"
 
 [lib]
 doctest = false
-test = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/rolldown_plugin_vite_resolve/src/resolver.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/resolver.rs
@@ -17,7 +17,7 @@ use crate::{
   package_json_cache::{PackageJsonCache, PackageJsonWithOptionalPeerDependencies},
   utils::{
     BROWSER_EXTERNAL_ID, OPTIONAL_PEER_DEP_ID, can_externalize_file, get_extension,
-    get_npm_package_name, is_bare_import, is_deep_import, normalize_path,
+    get_npm_package_name, is_bare_import, is_deep_import, normalize_path, normalize_path_to_native,
   },
 };
 
@@ -282,11 +282,14 @@ impl Resolver {
 
     let inner_resolver = if external { &self.inner_for_external } else { &self.inner };
     let result = if let Some(importer) = importer {
+      // Normalize importer to native separators to prevent mixed-separator
+      // paths on Windows that can break oxc_resolver's tsconfig resolution.
+      let native_importer = normalize_path_to_native(importer);
       // check if `is_absolute` to avoid extra `join` overhead
-      if Path::new(importer).is_absolute() {
-        inner_resolver.resolve_file(importer, specifier)
+      if Path::new(native_importer.as_ref()).is_absolute() {
+        inner_resolver.resolve_file(native_importer.as_ref(), specifier)
       } else {
-        inner_resolver.resolve_file(self.root.join(importer), specifier)
+        inner_resolver.resolve_file(self.root.join(native_importer.as_ref()), specifier)
       }
     } else {
       inner_resolver.resolve(&self.root, specifier)
@@ -327,11 +330,12 @@ impl Resolver {
     // this allows resolving `@pkg/pkg/foo.scss` to `@pkg/pkg/_foo.scss`, which is probably not allowed by sass's resolver
     // but that's an edge case so we ignore it here
     if let Some(importer) = importer {
+      let native_importer = normalize_path_to_native(importer);
       // check if `is_absolute` to avoid extra `join` overhead
-      if Path::new(importer).is_absolute() {
-        inner_resolver.resolve_file(importer, path_with_prefix)
+      if Path::new(native_importer.as_ref()).is_absolute() {
+        inner_resolver.resolve_file(native_importer.as_ref(), path_with_prefix)
       } else {
-        inner_resolver.resolve_file(self.root.join(importer), path_with_prefix)
+        inner_resolver.resolve_file(self.root.join(native_importer.as_ref()), path_with_prefix)
       }
     } else {
       inner_resolver.resolve(&self.root, path_with_prefix)

--- a/crates/rolldown_plugin_vite_resolve/src/resolver.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/resolver.rs
@@ -404,7 +404,7 @@ impl Resolver {
               })
             })
             .flatten();
-          if resolved_importer_dir.is_some_and(|dir| dir != self.root.to_str().unwrap())
+          if resolved_importer_dir.is_some_and(|dir| Path::new(dir) != self.root.as_path())
             && let Some(package_json) =
               self.get_nearest_package_json_optional_peer_deps(importer.unwrap())
             && package_json.optional_peer_dependencies.contains(pkg_name)

--- a/crates/rolldown_plugin_vite_resolve/src/utils.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/utils.rs
@@ -45,6 +45,24 @@ pub fn normalize_path(path: &str) -> Cow<'_, str> {
   path.cow_replace('\\', "/")
 }
 
+/// Normalize path separators to the OS-native format.
+///
+/// On Windows, converts forward slashes to backslashes so that all path
+/// operations (join, parent, etc.) produce paths with consistent separators.
+/// This prevents mixed-separator paths like `D:/a/analog\tsconfig.json` that
+/// can confuse oxc_resolver's path cache and tsconfig resolution.
+///
+/// On non-Windows platforms, this is a no-op.
+#[cfg(windows)]
+pub fn normalize_path_to_native(path: &str) -> Cow<'_, str> {
+  path.cow_replace('/', "\\")
+}
+
+#[cfg(not(windows))]
+pub fn normalize_path_to_native(path: &str) -> Cow<'_, str> {
+  Cow::Borrowed(path)
+}
+
 pub fn get_npm_package_name(id: &str) -> Option<&str> {
   if id.starts_with('@') {
     let mut indices = id.match_indices('/');

--- a/crates/rolldown_plugin_vite_resolve/src/utils.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/utils.rs
@@ -63,6 +63,41 @@ pub fn normalize_path_to_native(path: &str) -> Cow<'_, str> {
   Cow::Borrowed(path)
 }
 
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_normalize_path_converts_backslashes_to_forward_slashes() {
+    assert_eq!(normalize_path("foo/bar"), "foo/bar");
+    assert_eq!(normalize_path("foo\\bar"), "foo/bar");
+    assert_eq!(normalize_path("C:\\Users\\foo\\bar"), "C:/Users/foo/bar");
+    assert_eq!(normalize_path("/unix/path"), "/unix/path");
+  }
+
+  #[test]
+  fn test_normalize_path_borrows_when_no_change() {
+    assert!(matches!(normalize_path("foo/bar"), Cow::Borrowed(_)));
+  }
+
+  #[test]
+  #[cfg(not(windows))]
+  fn test_normalize_path_to_native_is_noop_on_non_windows() {
+    assert!(matches!(normalize_path_to_native("foo/bar"), Cow::Borrowed("foo/bar")));
+    assert!(matches!(normalize_path_to_native("D:/a/project/src"), Cow::Borrowed(_)));
+    assert!(matches!(normalize_path_to_native("foo\\bar"), Cow::Borrowed("foo\\bar")));
+  }
+
+  #[test]
+  #[cfg(windows)]
+  fn test_normalize_path_to_native_converts_to_backslashes_on_windows() {
+    assert_eq!(normalize_path_to_native("D:/a/project/src"), "D:\\a\\project\\src");
+    assert_eq!(normalize_path_to_native("D:/a/project\\src"), "D:\\a\\project\\src");
+    // Already native should be a no-op borrow
+    assert!(matches!(normalize_path_to_native("D:\\a\\project"), Cow::Borrowed(_)));
+  }
+}
+
 pub fn get_npm_package_name(id: &str) -> Option<&str> {
   if id.starts_with('@') {
     let mut indices = id.match_indices('/');

--- a/crates/rolldown_plugin_vite_resolve/src/utils.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/utils.rs
@@ -63,6 +63,29 @@ pub fn normalize_path_to_native(path: &str) -> Cow<'_, str> {
   Cow::Borrowed(path)
 }
 
+pub fn get_npm_package_name(id: &str) -> Option<&str> {
+  if id.starts_with('@') {
+    let mut indices = id.match_indices('/');
+    indices.next()?;
+    let second_pos = indices.next().map_or(id.len(), |(pos, _)| pos);
+    Some(&id[0..second_pos])
+  } else {
+    id.split('/').next()
+  }
+}
+
+pub fn can_externalize_file(file_path: &str) -> bool {
+  let ext = get_extension(file_path);
+  ext.is_empty() || ext == "js" || ext == "mjs" || ext == "cjs"
+}
+
+/// path.resolve normalizes the leading slashes to a single slash
+pub fn normalize_leading_slashes(specifier: &str) -> &str {
+  let trimmed = specifier.trim_start_matches('/');
+  let leading_slashes = specifier.len() - trimmed.len();
+  if leading_slashes <= 1 { specifier } else { &specifier[leading_slashes - 1..] }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -96,27 +119,4 @@ mod tests {
     // Already native should be a no-op borrow
     assert!(matches!(normalize_path_to_native("D:\\a\\project"), Cow::Borrowed(_)));
   }
-}
-
-pub fn get_npm_package_name(id: &str) -> Option<&str> {
-  if id.starts_with('@') {
-    let mut indices = id.match_indices('/');
-    indices.next()?;
-    let second_pos = indices.next().map_or(id.len(), |(pos, _)| pos);
-    Some(&id[0..second_pos])
-  } else {
-    id.split('/').next()
-  }
-}
-
-pub fn can_externalize_file(file_path: &str) -> bool {
-  let ext = get_extension(file_path);
-  ext.is_empty() || ext == "js" || ext == "mjs" || ext == "cjs"
-}
-
-/// path.resolve normalizes the leading slashes to a single slash
-pub fn normalize_leading_slashes(specifier: &str) -> &str {
-  let trimmed = specifier.trim_start_matches('/');
-  let leading_slashes = specifier.len() - trimmed.len();
-  if leading_slashes <= 1 { specifier } else { &specifier[leading_slashes - 1..] }
 }

--- a/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
+++ b/crates/rolldown_plugin_vite_resolve/src/vite_resolve_plugin.rs
@@ -30,7 +30,7 @@ use crate::{
   resolver::{self, AdditionalOptions, Resolvers},
   utils::{
     BROWSER_EXTERNAL_ID, OPTIONAL_PEER_DEP_ID, is_bare_import, is_windows_drive_path,
-    normalize_leading_slashes, normalize_path,
+    normalize_leading_slashes, normalize_path, normalize_path_to_native,
   },
 };
 
@@ -142,6 +142,10 @@ pub struct ViteResolvePlugin {
 
 impl ViteResolvePlugin {
   pub fn new(options: ViteResolveOptions) -> Self {
+    // Normalize root to native separators to prevent mixed-separator paths
+    // on Windows (e.g., `D:/a/project\tsconfig.json`) that can break
+    // oxc_resolver's tsconfig path resolution and cache lookups.
+    let root = PathBuf::from(normalize_path_to_native(&options.resolve_options.root).as_ref());
     let base_options = resolver::BaseOptions {
       main_fields: &options.resolve_options.main_fields,
       conditions: &options.resolve_options.conditions,
@@ -150,7 +154,7 @@ impl ViteResolvePlugin {
       try_index: options.resolve_options.try_index,
       try_prefix: &options.resolve_options.try_prefix,
       as_src: options.resolve_options.as_src,
-      root: PathBuf::from(&options.resolve_options.root),
+      root,
       preserve_symlinks: options.resolve_options.preserve_symlinks,
       tsconfig_paths: options.resolve_options.tsconfig_paths,
       yarn_pnp: options.yarn_pnp,


### PR DESCRIPTION
## Summary

- On Windows, Vite passes importer paths with forward slashes (`D:/a/project/src/main.ts`), but when these are joined with OS paths or used in oxc_resolver cache lookups, mixed separators (`D:/a/project\tsconfig.json`) cause tsconfig path resolution to fail.
- Added `normalize_path_to_native()` utility that converts path separators to the OS-native format (backslashes on Windows, no-op elsewhere).
- Normalize importer paths before passing to `oxc_resolver` and normalize the root path at plugin initialization to ensure consistent separators throughout resolution.
- Fixed optional peer dep detection to use `Path`-based comparison (`Path::eq` compares by components) instead of string comparison, preventing separator mismatches between the importer directory and root path on Windows.
- Enabled lib tests for the crate and added unit tests for `normalize_path` and `normalize_path_to_native` with platform-conditional assertions.

## Test plan

- [x] Unit tests for `normalize_path` and `normalize_path_to_native` (platform-conditional)
- [ ] Verify Windows CI passes with tsconfig paths resolution
- [ ] Verify no regression on Linux/macOS (the normalization is a no-op on non-Windows platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)