### PR TITLE
perf: update oxc-resolver to reduce tsconfig.json lookup [DO NOT MERGE, ONLY FOR BENCHMARK]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1275,7 +1275,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1633,7 +1633,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2176,8 +2176,7 @@ dependencies = [
 [[package]]
 name = "oxc_resolver"
 version = "11.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5632fcd47d4fdaf7ef5ee150c7001fa8ed814ce38d1a073536a366dbfc239aad"
+source = "git+https://github.com/oxc-project/oxc-resolver?rev=c888ec9bd2a6ca9993619bc73847431a9bf3ab1b#c888ec9bd2a6ca9993619bc73847431a9bf3ab1b"
 dependencies = [
  "cfg-if",
  "compact_str",
@@ -2187,6 +2186,7 @@ dependencies = [
  "nodejs-built-in-modules",
  "once_cell",
  "papaya",
+ "percent-encoding",
  "pnp",
  "rustc-hash",
  "rustix",
@@ -2197,7 +2197,6 @@ dependencies = [
  "simdutf8",
  "thiserror 2.0.17",
  "tracing",
- "url",
  "windows",
 ]
 
@@ -3721,7 +3720,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3783,7 +3782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4077,7 +4076,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4576,7 +4575,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,3 +299,6 @@ opt-level = "s"
 # it will strip these information for non-debug files
 debug = "full"
 strip = "none"
+
+[patch.crates-io]
+oxc_resolver = { git = "https://github.com/oxc-project/oxc-resolver", rev = "c888ec9bd2a6ca9993619bc73847431a9bf3ab1b" }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Switches `oxc_resolver` from a crates.io release to a specific git revision, which can change module/tsconfig resolution behavior across the build. Also updates transitive Windows dependencies (`windows-sys` 0.61.2), which may affect Windows builds.
> 
> **Overview**
> This PR pins `oxc_resolver` to a specific upstream git revision via `[patch.crates-io]`, overriding the crates.io `11.19.1` release.
> 
> `Cargo.lock` is updated accordingly: `oxc_resolver` now resolves from the git source (with minor dependency graph changes like swapping `url` for `percent-encoding`), and several transitive crates bump `windows-sys` from `0.60.2` to `0.61.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73b6779fae72cb83d04591e494dd5fea0ec0095c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->