### PR TITLE
fix(renamer): handle existing bindings in nested scopes when finding unique names

### DIFF
--- a/crates/rolldown/src/utils/renamer.rs
+++ b/crates/rolldown/src/utils/renamer.rs
@@ -257,16 +257,27 @@ impl<'name> Renamer<'name> {
     }
 
     // Find unique name: skip candidates that conflict with top-level symbols
+    // or with existing bindings in nested scopes of the same module.
     for count in 1u32.. {
       let name: CompactStr =
         concat_string!(original_name, "$", itoa::Buffer::new().format(count)).into();
 
-      if let Entry::Vacant(entry) = self.used_canonical_names.entry(name) {
-        let candidate_name = entry.key().clone();
-        entry.insert(0);
-        self.canonical_names.insert(symbol_ref, candidate_name);
-        return;
+      if self.used_canonical_names.contains_key(&name) {
+        continue;
       }
+
+      // Also skip if the candidate name conflicts with an existing binding in
+      // a nested scope of the same module. Without this check, renaming `child`
+      // to `child$1` could collide with an existing `child$1` binding in the
+      // same scope (e.g. from Gleam's variable shadowing convention).
+      if self.has_nested_scope_binding(symbol_ref.owner, &name) {
+        self.used_canonical_names.insert(name, 0);
+        continue;
+      }
+
+      self.used_canonical_names.insert(name.clone(), 0);
+      self.canonical_names.insert(symbol_ref, name);
+      return;
     }
   }
 

--- a/crates/rolldown/tests/rolldown/issues/8739/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8739/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "minify": false
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8739/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8739/artifacts.snap
@@ -1,0 +1,27 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+
+//#region dep.js
+function clashingIdentifier() {
+	return "middle";
+}
+
+//#endregion
+//#region main.js
+function test(head, tail) {
+	let clashingIdentifier$2 = head;
+	let middle = clashingIdentifier();
+	let clashingIdentifier$1 = tail;
+	return clashingIdentifier$2 + middle + clashingIdentifier$1;
+}
+assert.strictEqual(test("head", "tail"), "headmiddletail");
+
+//#endregion
+```

--- a/crates/rolldown/tests/rolldown/issues/8739/dep.js
+++ b/crates/rolldown/tests/rolldown/issues/8739/dep.js
@@ -1,0 +1,3 @@
+export function clashingIdentifier() {
+  return 'middle';
+}

--- a/crates/rolldown/tests/rolldown/issues/8739/main.js
+++ b/crates/rolldown/tests/rolldown/issues/8739/main.js
@@ -1,0 +1,11 @@
+import * as dep from './dep.js';
+import assert from 'node:assert';
+
+function test(head, tail) {
+  let clashingIdentifier = head;
+  let middle = dep.clashingIdentifier();
+  let clashingIdentifier$1 = tail;
+  return clashingIdentifier + middle + clashingIdentifier$1;
+}
+
+assert.strictEqual(test('head', 'tail'), 'headmiddletail');


### PR DESCRIPTION
Fixes #8739