### PR TITLE
feat: add indentExclusionRanges property to MagicString

### DIFF
--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -9,6 +9,64 @@ use rolldown_utils::base64::to_standard_base64;
 use serde::Serialize;
 use string_wizard::{MagicString, MagicStringOptions, SourceMapOptions};
 
+/// Internal representation preserving the original JS format (flat `[start, end]` vs nested
+/// `[[start, end], ...]`) so the getter returns the same shape the user passed in.
+#[derive(Clone)]
+enum IndentExclusionRanges {
+  Flat(Vec<i64>),
+  Nested(Vec<Vec<i64>>),
+}
+
+impl IndentExclusionRanges {
+  fn from_either(either: Either<Vec<Vec<i64>>, Vec<i64>>) -> Self {
+    match either {
+      Either::A(nested) => Self::Nested(nested),
+      Either::B(flat) => Self::Flat(flat),
+    }
+  }
+
+  fn to_either(&self) -> Either<Vec<Vec<i64>>, Vec<i64>> {
+    match self {
+      Self::Flat(v) => Either::B(v.clone()),
+      Self::Nested(v) => Either::A(v.clone()),
+    }
+  }
+}
+
+/// Normalizes an `Either<Vec<Vec<i64>>, Vec<i64>>` (nested or flat exclusion ranges from JS)
+/// into `Vec<(u32, u32)>` byte-offset pairs suitable for the Rust indent implementation.
+/// The `offset` is applied to each index before UTF-16→byte conversion, matching the
+/// behavior of every other position-based API in this binding.
+fn normalize_exclude_ranges(
+  ranges: &Either<Vec<Vec<i64>>, Vec<i64>>,
+  mapper: &Utf16ToByteMapper,
+  offset: i64,
+) -> Vec<(u32, u32)> {
+  let pairs: Vec<(i64, i64)> = match ranges {
+    Either::B(flat) => {
+      if flat.len() >= 2 {
+        vec![(flat[0], flat[1])]
+      } else {
+        vec![]
+      }
+    }
+    Either::A(nested) => {
+      nested.iter().filter_map(|r| if r.len() >= 2 { Some((r[0], r[1])) } else { None }).collect()
+    }
+  };
+
+  pairs
+    .into_iter()
+    .filter_map(|(s, e)| {
+      let s_with_offset = u32::try_from(s + offset).ok()?;
+      let e_with_offset = u32::try_from(e + offset).ok()?;
+      let start = mapper.utf16_to_byte(s_with_offset)?;
+      let end = mapper.utf16_to_byte(e_with_offset)?;
+      Some((start, end))
+    })
+    .collect()
+}
+
 /// Serializable source map matching the SourceMap V3 specification.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -119,6 +177,13 @@ impl Utf16ToByteMapper {
 pub struct BindingMagicStringOptions {
   pub filename: Option<String>,
   pub offset: Option<i64>,
+  pub indent_exclusion_ranges: Option<Either<Vec<Vec<i64>>, Vec<i64>>>,
+}
+
+#[napi(object)]
+#[derive(Default)]
+pub struct BindingIndentOptions {
+  pub exclude: Option<Either<Vec<Vec<i64>>, Vec<i64>>>,
 }
 
 #[napi(object)]
@@ -280,6 +345,7 @@ pub struct BindingMagicString<'a> {
   pub(crate) inner: MagicString<'a>,
   utf16_to_byte_mapper: Utf16ToByteMapper,
   pub(crate) offset: i64,
+  indent_exclusion_ranges: Option<IndentExclusionRanges>,
 }
 
 #[napi]
@@ -289,11 +355,14 @@ impl BindingMagicString<'_> {
     let utf16_to_byte_mapper = Utf16ToByteMapper::new(&source);
     let opts = options.unwrap_or_default();
     let offset = opts.offset.unwrap_or(0);
+    let indent_exclusion_ranges =
+      opts.indent_exclusion_ranges.map(IndentExclusionRanges::from_either);
     let magic_string_options = MagicStringOptions { filename: opts.filename };
     Self {
       inner: MagicString::with_options(source, magic_string_options),
       utf16_to_byte_mapper,
       offset,
+      indent_exclusion_ranges,
     }
   }
 
@@ -305,6 +374,11 @@ impl BindingMagicString<'_> {
   #[napi(getter)]
   pub fn filename(&self) -> Option<&str> {
     self.inner.filename()
+  }
+
+  #[napi(getter)]
+  pub fn indent_exclusion_ranges(&self) -> Option<Either<Vec<Vec<i64>>, Vec<i64>>> {
+    self.indent_exclusion_ranges.as_ref().map(IndentExclusionRanges::to_either)
   }
 
   #[napi(getter)]
@@ -558,14 +632,26 @@ impl BindingMagicString<'_> {
   }
 
   #[napi]
-  pub fn indent<'s>(&'s mut self, this: This<'s>, indentor: Option<String>) -> This<'s> {
-    if let Some(indentor) = indentor {
-      self
-        .inner
-        .indent_with(string_wizard::IndentOptions { indentor: Some(&indentor), exclude: &[] });
+  pub fn indent<'s>(
+    &'s mut self,
+    this: This<'s>,
+    indentor: Option<String>,
+    options: Option<BindingIndentOptions>,
+  ) -> This<'s> {
+    // Per-call exclude takes priority; fall back to constructor's indentExclusionRanges.
+    let explicit_exclude = options.and_then(|opts| opts.exclude);
+    let exclude_ranges = if let Some(ref e) = explicit_exclude {
+      normalize_exclude_ranges(e, &self.utf16_to_byte_mapper, self.offset)
+    } else if let Some(ref stored) = self.indent_exclusion_ranges {
+      normalize_exclude_ranges(&stored.to_either(), &self.utf16_to_byte_mapper, self.offset)
     } else {
-      self.inner.indent();
-    }
+      vec![]
+    };
+
+    self.inner.indent_with(string_wizard::IndentOptions {
+      indentor: indentor.as_deref(),
+      exclude: &exclude_ranges,
+    });
     this
   }
 
@@ -614,6 +700,7 @@ impl BindingMagicString<'_> {
       inner: self.inner.clone(),
       utf16_to_byte_mapper: self.utf16_to_byte_mapper.clone(),
       offset: self.offset,
+      indent_exclusion_ranges: self.indent_exclusion_ranges.clone(),
     }
   }
 
@@ -644,6 +731,7 @@ impl BindingMagicString<'_> {
       inner: self.inner.snip(start_byte, end_byte).map_err(napi::Error::from_reason)?,
       utf16_to_byte_mapper: self.utf16_to_byte_mapper.clone(),
       offset: self.offset,
+      indent_exclusion_ranges: self.indent_exclusion_ranges.clone(),
     })
   }
 

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1480,6 +1480,7 @@ export declare class BindingMagicString {
   constructor(source: string, options?: BindingMagicStringOptions | undefined | null)
   get original(): string
   get filename(): string | null
+  get indentExclusionRanges(): Array<Array<number>> | Array<number> | null
   get offset(): number
   set offset(offset: number)
   replace(from: string, to: string): this
@@ -1504,7 +1505,7 @@ export declare class BindingMagicString {
    * Returns `this` for method chaining.
    */
   move(start: number, end: number, index: number): this
-  indent(indentor?: string | undefined | null): this
+  indent(indentor?: string | undefined | null, options?: BindingIndentOptions | undefined | null): this
   /** Trims whitespace or specified characters from the start and end. */
   trim(charType?: string | undefined | null): this
   /** Trims whitespace or specified characters from the start. */
@@ -2187,6 +2188,10 @@ export interface BindingHookTransformOutput {
   moduleType?: string
 }
 
+export interface BindingIndentOptions {
+  exclude?: Array<Array<number>> | Array<number>
+}
+
 export interface BindingInjectImportNamed {
   tagNamed: true
   imported: string
@@ -2292,6 +2297,7 @@ export interface BindingLogLocation {
 export interface BindingMagicStringOptions {
   filename?: string
   offset?: number
+  indentExclusionRanges?: Array<Array<number>> | Array<number>
 }
 
 export type BindingMakeAbsoluteExternalsRelative =

--- a/packages/rolldown/tests/magic-string/MagicString.test.ts
+++ b/packages/rolldown/tests/magic-string/MagicString.test.ts
@@ -153,7 +153,7 @@ describe('MagicString', () => {
       assert.equal(c.filename, 'foo.js');
     });
 
-    it.skip('should clone indentExclusionRanges', () => {
+    it('should clone indentExclusionRanges', () => {
       const array = [3, 6];
       const source = new MagicString('abcdefghijkl', {
         filename: 'foo.js',
@@ -166,7 +166,7 @@ describe('MagicString', () => {
       assert.deepEqual(source.indentExclusionRanges, clone.indentExclusionRanges);
     });
 
-    it.skip('should clone complex indentExclusionRanges', () => {
+    it('should clone complex indentExclusionRanges', () => {
       const array = [
         [3, 6],
         [7, 9],
@@ -679,7 +679,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), 'abc\ndef\nghi\njkl');
     });
 
-    it.skip('should prevent excluded characters from being indented', () => {
+    it('should prevent excluded characters from being indented', () => {
       const s = new MagicString('abc\ndef\nghi\njkl');
 
       s.indent('  ', { exclude: [7, 15] });

--- a/packages/rolldown/tests/magic-string/download-tests.mjs
+++ b/packages/rolldown/tests/magic-string/download-tests.mjs
@@ -11,7 +11,7 @@
  * 3. Skips tests that use unsupported features
  *
  * BindingMagicString API (supported methods):
- *   - constructor(source: string, options?: { filename?, offset? })
+ *   - constructor(source: string, options?: { filename?, offset?, indentExclusionRanges? })
  *   - offset: number (getter/setter — shifts all position-based operations)
  *   - replace(from: string, to: string): this
  *   - replaceAll(from: string, to: string): this
@@ -30,7 +30,7 @@
  *   - update(start: number, end: number, content: string): this
  *   - relocate(start: number, end: number, to: number): this
  *   - move(start: number, end: number, index: number): this (alias for relocate)
- *   - indent(indentor?: string | undefined | null): this
+ *   - indent(indentor?: string | undefined | null, options?: { exclude? }): this
  *   - slice(start?: number, end?: number): string
  *   - insert(index: number, content: string): throws Error (deprecated)
  *   - clone(): BindingMagicString
@@ -42,12 +42,10 @@
  *   - generateDecodedMap(options?): BindingDecodedMap (returns object with decoded mappings array)
  *
  * NOT supported (will be skipped):
- *   - constructor options (ignoreList, indentExclusionRanges) — filename and offset ARE supported
- *   - reset tests (most require splitting inside edited chunks)
+ *   - constructor options: ignoreList — filename, offset, and indentExclusionRanges ARE supported
  *   - addSourcemapLocation (not in string_wizard)
- *   - storeName option in overwrite (not in string_wizard)
- *   - x_google_ignoreList / ignoreList (not in string_wizard)
- *   - original property (getter — not yet implemented)
+ *   - storeName option in overwrite/update (not exposed in binding)
+ *   - x_google_ignoreList / ignoreList in generateMap output (not in string_wizard)
  *   - replace/replaceAll with regex or function replacer
  */
 
@@ -87,7 +85,7 @@ const SKIP_TESTS = [
   'should throw', // error handling differs
   // options-specific skips
   'stores ignore-list hint', // ignoreList option not supported
-  'indentExclusionRanges', // not supported
+  // Note: 'indentExclusionRanges' is now supported (constructor option + getter + clone)
   'sourcemapLocations', // not supported
   'should return cloned content', // clone-related
   'should noop', // edge cases that may differ
@@ -108,7 +106,7 @@ const SKIP_TESTS = [
 
   'should replace then remove', // causes split chunk panic
   'preserves intended order', // complex append/prepend ordering with slice
-  'excluded characters', // indent exclude option not supported
+  // Note: 'excluded characters' (indent exclude option) is now supported
   // remove-specific skips
   'should remove everything', // edge case
   'should adjust other removals', // complex removal interaction
@@ -132,8 +130,7 @@ const SKIP_TESTS = [
   'supports characters moved', // complex move + slice interaction
   // clone-specific skips (tests that use unsupported constructor options)
   // Note: 'should clone filename info' now works since filename is supported
-  'should clone indentExclusionRanges', // uses indentExclusionRanges constructor option
-  'should clone complex indentExclusionRanges', // uses indentExclusionRanges constructor option
+  // Note: 'should clone indentExclusionRanges' now works since indentExclusionRanges is supported
   'should clone sourcemapLocations', // uses sourcemapLocations
   // hasChanged tests that use clone
   'should not report change if content is identical', // uses clone
@@ -180,12 +177,12 @@ function transformTestFile(content, filename) {
   // Replace imports
   transformed = transformed.replace(
     /import MagicString from ['"]\.\/utils\/IntegrityCheckingMagicString['"];?/g,
-    "import { BindingMagicString as MagicString } from 'rolldown';",
+    "import { RolldownMagicString as MagicString } from 'rolldown';",
   );
 
   transformed = transformed.replace(
     /import MagicString from ['"]\.\.\/src\/MagicString['"];?/g,
-    "import { BindingMagicString as MagicString } from 'rolldown';",
+    "import { RolldownMagicString as MagicString } from 'rolldown';",
   );
 
   // Handle Bundle import - Bundle is not supported, so we import MagicString and skip all Bundle tests


### PR DESCRIPTION
**Description:** 

Adds `indentExclusionRanges` constructor option and getter to `BindingMagicString`, supporting both flat (`[start, end]`) and nested (`[[start, end], ...]`) formats. Also adds `exclude` option to the `indent` method for per-call range exclusion. Unskips 3 previously skipped tests.
