### PR TITLE
chore: enable all test for `reset` category in MagicString.test.ts

### DIFF
--- a/packages/rolldown/tests/magic-string/MagicString.test.ts
+++ b/packages/rolldown/tests/magic-string/MagicString.test.ts
@@ -1317,7 +1317,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), 'a[]c;');
     });
 
-    it.skip('should provide a useful error when illegal removals are attempted', () => {
+    it('should provide a useful error when illegal removals are attempted', () => {
       const s = new MagicString('abcdefghijkl');
 
       s.overwrite(5, 7, 'XX');
@@ -1419,7 +1419,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), 'bc');
     });
 
-    it.skip('should reset modified ranges', () => {
+    it('should reset modified ranges', () => {
       const s = new MagicString('abcdefghi');
 
       s.overwrite(3, 6, 'DEF');
@@ -1451,7 +1451,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), '(a.c);');
     });
 
-    it.skip('should provide a useful error when illegal removals are attempted', () => {
+    it('should provide a useful error when illegal removals are attempted', () => {
       const s = new MagicString('abcdefghijkl');
 
       s.remove(4, 8);

--- a/packages/rolldown/tests/magic-string/download-tests.mjs
+++ b/packages/rolldown/tests/magic-string/download-tests.mjs
@@ -124,7 +124,7 @@ const SKIP_TESTS = [
   // The reset version passes, so we handle this with a special transformation below
   'should not remove content inserted', // complex interaction
   'should remove interior inserts', // causes panic
-  'should provide a useful error', // expects throw but gets panic
+  // Note: 'should provide a useful error' now works — errors are properly thrown, not panicked
   // slice-specific skips
   'should return the generated content between the specified original characters', // nested overwrites + slice
   'supports characters moved', // complex move + slice interaction
@@ -261,12 +261,7 @@ function transformTestFile(content, filename) {
     "$1\n$2it.skip('removes across moved content'",
   );
 
-  // Special case: skip "should reset modified ranges" but not "should reset modified ranges, redux"
-  // The "redux" version passes, but the first one uses overwrite+remove+reset which fails
-  transformed = transformed.replace(
-    /it\('should reset modified ranges', /g,
-    "it.skip('should reset modified ranges', ",
-  );
+  // Note: "should reset modified ranges" now passes (overwrite+remove+reset works correctly)
 
   return transformed;
 }


### PR DESCRIPTION
**Description:**   
  
Removes skip rules for "should reset modified ranges" and "should provide a useful error" from the test generation script. The Rust implementation now properly handles these cases — errors are thrown (not panicked) and reset-after-overwrite+remove works correctly.

