### PR TITLE
fix: handle reversed slice ranges with moved content

### DIFF
--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -839,53 +839,67 @@ impl BindingMagicString<'_> {
 
     // When start == end, the result is always empty regardless of surrogate position.
     // Only check surrogates when the range is non-empty.
-    let (start_is_low, end_prev_entry) = if start_u32 < end_u32 {
+    let (start_is_low, end_is_low, end_prev_entry) = if start_u32 == end_u32 {
+      (false, false, None)
+    } else {
       let start_is_low = start_entry.is_some_and(Utf16Mapping::is_low_surrogate);
       let end_is_low = end_entry.is_some_and(Utf16Mapping::is_low_surrogate);
-      // When end is a low surrogate, look up the preceding high surrogate entry once
-      // (used for both the byte offset and the surrogate value to append).
-      let end_prev = if end_is_low {
+      // For forward ranges (start < end), when end is a low surrogate we adjust the
+      // byte offset to exclude the character entirely and later append the high surrogate.
+      // For reversed/moved ranges (start > end) this byte-offset trick does not work
+      // because the inner slice sees the end chunk before the start chunk, so we
+      // post-process instead (see below).
+      let end_prev = if end_is_low && start_u32 < end_u32 {
         debug_assert!(end_u32 > 0, "low surrogate cannot appear at index 0");
         self.utf16_to_byte_mapper.get(end_u32 - 1)
       } else {
         None
       };
-      (start_is_low, end_prev)
-    } else {
-      (false, None)
+      (start_is_low, end_is_low, end_prev)
     };
 
     let start_byte = start_entry.map_or(total_len, |e| e.byte_offset);
     let end_byte = if let Some(prev) = end_prev_entry {
-      // End falls on a low surrogate — use the high surrogate's byte_offset
+      // End falls on a low surrogate (forward range) — use the high surrogate's byte_offset
       // (before the character) so the UTF-8 slice excludes it.
       prev.byte_offset
     } else {
       end_entry.map_or(total_len, |e| e.byte_offset)
     };
-    // Clamp reversed ranges (e.g. slice(2, 1) on 'a🤷b') to empty.
-    let end_byte = end_byte.max(start_byte);
-
     let utf8_result =
       self.inner.slice(start_byte, Some(end_byte)).map_err(napi::Error::from_reason)?;
 
     // Fast path: no lone surrogates involved — return the UTF-8 string directly,
     // avoiding the UTF-16 transcoding and allocation.
-    if !start_is_low && end_prev_entry.is_none() {
+    if !start_is_low && !end_is_low {
       return env.create_string(&utf8_result);
     }
 
     // Slow path: build UTF-16 buffer with lone surrogates at the boundaries.
     let mut utf16_buf: Vec<u16> = Vec::new();
 
-    if let Some(entry) = start_entry.filter(|e| e.is_low_surrogate()) {
-      utf16_buf.push(entry.surrogate);
+    // Only prepend the start's low surrogate for forward ranges. For reversed ranges
+    // without moves the inner slice returns "" and we should return "" unchanged.
+    if start_u32 < end_u32 {
+      if let Some(entry) = start_entry.filter(|e| e.is_low_surrogate()) {
+        utf16_buf.push(entry.surrogate);
+      }
     }
 
     utf16_buf.extend(utf8_result.encode_utf16());
 
     if let Some(high_entry) = end_prev_entry {
+      // Forward range: emoji was excluded by byte-offset adjustment, append the high surrogate.
       utf16_buf.push(high_entry.surrogate);
+    } else if end_is_low && !utf8_result.is_empty() {
+      // Reversed/moved range: the inner slice included the full emoji character.
+      // Remove the trailing low surrogate to leave only the high surrogate,
+      // matching JS String.prototype.slice behavior at surrogate boundaries.
+      if let Some(&last) = utf16_buf.last() {
+        if (0xDC00..=0xDFFF).contains(&last) {
+          utf16_buf.pop();
+        }
+      }
     }
 
     env.create_string_utf16(&utf16_buf)

--- a/crates/string_wizard/src/magic_string/slice.rs
+++ b/crates/string_wizard/src/magic_string/slice.rs
@@ -73,7 +73,11 @@ impl<'text> MagicString<'text> {
         content.len()
       };
 
-      result.push_str(&content[slice_start..slice_end]);
+      // Guard against reversed range within a single chunk (matches JS .slice() behavior
+      // which returns "" for reversed ranges instead of panicking).
+      if slice_start < slice_end {
+        result.push_str(&content[slice_start..slice_end]);
+      }
 
       // Add outro if this chunk doesn't contain the end, or if chunk.end === end
       if !contains_end || chunk.end() == end {

--- a/packages/rolldown/tests/magic-string/MagicString.test.ts
+++ b/packages/rolldown/tests/magic-string/MagicString.test.ts
@@ -1493,7 +1493,7 @@ describe('MagicString', () => {
   });
 
   describe('slice', () => {
-    it.skip('should return the generated content between the specified original characters', () => {
+    it('should return the generated content between the specified original characters', () => {
       const s = new MagicString('abcdefghijkl');
 
       assert.equal(s.slice(3, 9), 'defghi');
@@ -1533,7 +1533,7 @@ describe('MagicString', () => {
       assert.equal(s.slice(3, 6), 'fghij');
     });
 
-    it.skip('supports characters moved outward', () => {
+    it('supports characters moved outward', () => {
       const s = new MagicString('abcdEFghIJklmn');
 
       s.move(4, 6, 2);
@@ -1548,7 +1548,7 @@ describe('MagicString', () => {
       assert.equal(s.slice(6, -6), 'gh');
     });
 
-    it.skip('supports characters moved inward', () => {
+    it('supports characters moved inward', () => {
       const s = new MagicString('abCDefghijKLmn');
 
       s.move(2, 4, 6);
@@ -1563,7 +1563,7 @@ describe('MagicString', () => {
       assert.equal(s.slice(6, -6), 'gh');
     });
 
-    it.skip('supports characters moved opposing', () => {
+    it('supports characters moved opposing', () => {
       const s = new MagicString('abCDefghIJkl');
 
       s.move(2, 4, 8);

--- a/packages/rolldown/tests/magic-string/download-tests.mjs
+++ b/packages/rolldown/tests/magic-string/download-tests.mjs
@@ -126,8 +126,8 @@ const SKIP_TESTS = [
   'should remove interior inserts', // causes panic
   // Note: 'should provide a useful error' now works — errors are properly thrown, not panicked
   // slice-specific skips
-  'should return the generated content between the specified original characters', // nested overwrites + slice
-  'supports characters moved', // complex move + slice interaction
+  // Note: 'should return the generated content between the specified original characters' now works
+  // Note: 'supports characters moved opposing' now works (reversed slice range fix)
   // clone-specific skips (tests that use unsupported constructor options)
   // Note: 'should clone filename info' now works since filename is supported
   // Note: 'should clone indentExclusionRanges' now works since indentExclusionRanges is supported

--- a/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
+++ b/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
@@ -197,4 +197,13 @@ describe('unicode handling', () => {
     const s = new MagicString('a🤷b');
     assert.strictEqual(s.slice(2, 1), '');
   });
+
+  it('should preserve lone-surrogate boundaries for reversed moved slices', () => {
+    const s = new MagicString('ab🤷efghIJkl');
+    s.move(2, 4, 8);
+    s.move(8, 10, 4);
+
+    assert.strictEqual(s.toString(), 'abIJefgh🤷kl');
+    assert.strictEqual(s.slice(-3, 3), 'Jefgh\uD83E');
+  });
 });


### PR DESCRIPTION

**Description:** 

Fixes `slice()` returning empty when start > end due to moved content (e.g. `slice(-3, 3)` with opposing moves). Removes the binding's reversed-range byte clamp and adds a guard in Rust's `slice.rs` to match JS `.slice()` behavior. Unskips all 4 previously skipped slice tests.

