### PR TITLE
refactor: simplify string repeat in guess_indentor

### DIFF
--- a/crates/string_wizard/src/magic_string/indent.rs
+++ b/crates/string_wizard/src/magic_string/indent.rs
@@ -41,11 +41,7 @@ pub fn guess_indentor(source: &str) -> Option<String> {
     .min()
     .unwrap_or(0);
 
-  let mut indent_str = String::with_capacity(min_space_count);
-  for _ in 0..min_space_count {
-    indent_str.push(' ');
-  }
-  Some(indent_str)
+  Some(" ".repeat(min_space_count))
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
**Description:**   
  
Replaces a manual `String::with_capacity` + loop with `" ".repeat()` in `guess_indentor` for cleaner, more idiomatic Rust.
