### PR TITLE
fix(rolldown_plugin_vite_dynamic_import_vars): align dynamic import fast check with Vite

### DIFF
--- a/crates/rolldown_plugin_vite_dynamic_import_vars/src/utils.rs
+++ b/crates/rolldown_plugin_vite_dynamic_import_vars/src/utils.rs
@@ -42,17 +42,9 @@ pub fn has_dynamic_import(code: &str) -> bool {
         j += 1;
       }
 
-      // Check for '('
-      if j < bytes.len() && bytes[j] == b'(' {
-        // Skip whitespace after "("
-        j += 1;
-        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
-          j += 1;
-        }
-        // Check for template literal
-        if j < bytes.len() && bytes[j] == b'`' {
-          return true;
-        }
+      // Check for '(' or '/' (slash covers comments between import and '(')
+      if j < bytes.len() && (bytes[j] == b'(' || bytes[j] == b'/') {
+        return true;
       }
 
       i = j;

--- a/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/_config.ts
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/_config.ts
@@ -1,0 +1,11 @@
+import { defineTest } from 'rolldown-tests';
+import { viteDynamicImportVarsPlugin, viteImportGlobPlugin } from 'rolldown/experimental';
+
+export default defineTest({
+  config: {
+    plugins: [viteDynamicImportVarsPlugin({}), viteImportGlobPlugin()],
+  },
+  async afterTest() {
+    await import('./assert.mjs');
+  },
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/assert.mjs
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/assert.mjs
@@ -1,0 +1,11 @@
+// @ts-nocheck
+import assert from 'node:assert';
+import { withCommentBeforeParen, withCommentAfterParen } from './dist/main';
+
+withCommentBeforeParen('module-a').then((m) => {
+  assert.strictEqual(m.default, 'a');
+});
+
+withCommentAfterParen('module-a').then((m) => {
+  assert.strictEqual(m.default, 'a');
+});

--- a/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/dir/module-a.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/dir/module-a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/main.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/main.js
@@ -1,0 +1,2 @@
+export { withCommentBeforeParen } from './with-comment-before-paren.js';
+export { withCommentAfterParen } from './with-comment-after-paren.js';

--- a/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/with-comment-after-paren.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/with-comment-after-paren.js
@@ -1,0 +1,3 @@
+export function withCommentAfterParen(name) {
+  return import(/* comment */ `./dir/${name}.js`);
+}

--- a/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/with-comment-before-paren.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/with-comment-before-paren.js
@@ -1,3 +1,4 @@
 export function withCommentBeforeParen(name) {
-  return import(/* comment */ `./dir/${name}.js`);
+  // oxfmt-ignore
+  return import /* comment */ (`./dir/${name}.js`);
 }

--- a/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/with-comment-before-paren.js
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/dynamic-import-vars/import-with-comment/with-comment-before-paren.js
@@ -1,0 +1,3 @@
+export function withCommentBeforeParen(name) {
+  return import(/* comment */ `./dir/${name}.js`);
+}


### PR DESCRIPTION
closes https://github.com/vitejs/vite/issues/21855, related to https://github.com/vitejs/vite/blob/40bc7293/packages/vite/src/node/plugins/dynamicImportVars.ts#L30-L33