### PR TITLE
test(vite-tests): remove JS plugin tests

### DIFF
--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -78,48 +78,23 @@ await runCmdAndPipeOrExit(
 
 const failed = []
 
-const failedNormalTestUnit = await runCmdAndPipe(
+const failedTestUnit = await runCmdAndPipe(
   '# Running `pnpm test-unit`...',
   ['pnpm', ['run', 'test-unit'], { nodeOptions: { cwd: REPO_PATH } }],
 );
-if (failedNormalTestUnit) failed.push('test-unit');
+if (failedTestUnit) failed.push('test-unit');
 
-const failedNormalTestServe = await runCmdAndPipe(
+const failedTestServe = await runCmdAndPipe(
   '# Running `pnpm test-serve`...',
   ['pnpm', ['run', 'test-serve'], { nodeOptions: { cwd: REPO_PATH } }],
 );
-if (failedNormalTestServe) failed.push('test-serve');
+if (failedTestServe) failed.push('test-serve');
 
-const failedNormalTestBuild = await runCmdAndPipe(
+const failedTestBuild = await runCmdAndPipe(
   '# Running `pnpm test-build`...',
   ['pnpm', ['run', 'test-build'], { nodeOptions: { cwd: REPO_PATH } }],
 );
-if (failedNormalTestBuild) failed.push('test-build');
-
-const failedJsTestUnit = await runCmdAndPipe(
-  '# Running `_VITE_TEST_JS_PLUGIN=1 pnpm test-unit`...',
-  ['pnpm', ['run', 'test-unit'], { nodeOptions: {
-    cwd: REPO_PATH,
-    env: { _VITE_TEST_JS_PLUGIN: '1' },
-  } }],
-);
-if (failedJsTestUnit) failed.push('[JS] test-unit');
-const failedJsTestServe = await runCmdAndPipe(
-  '# Running `_VITE_TEST_JS_PLUGIN=1 pnpm test-serve`...',
-  ['pnpm', ['run', 'test-serve'], { nodeOptions: {
-    cwd: REPO_PATH,
-    env: { _VITE_TEST_JS_PLUGIN: '1' },
-  } }],
-);
-if (failedJsTestServe) failed.push('[JS] test-serve');
-const failedJsTestBuild = await runCmdAndPipe(
-  '# Running `_VITE_TEST_JS_PLUGIN=1 pnpm test-build`...',
-  ['pnpm', ['run', 'test-build'], { nodeOptions: {
-    cwd: REPO_PATH,
-    env: { _VITE_TEST_JS_PLUGIN: '1' },
-  } }],
-);
-if (failedJsTestBuild) failed.push('[JS] test-build');
+if (failedTestBuild) failed.push('test-build');
 
 if (failed.length > 0) {
   console.error(styleText(['red', 'bold'], 'The following test suites failed:'));


### PR DESCRIPTION
These tests are removed in Vite repo.

refs https://github.com/vitejs/vite/pull/21744
