### PR TITLE
chore: enable 7 previously-skipped MagicString tests

### DIFF
--- a/packages/rolldown/tests/magic-string/MagicString.test.ts
+++ b/packages/rolldown/tests/magic-string/MagicString.test.ts
@@ -44,7 +44,7 @@ describe('MagicString', () => {
   });
 
   describe('(ap|pre)pend(Left|Right)', () => {
-    it.skip('preserves intended order', () => {
+    it('preserves intended order', () => {
       const s = new MagicString('0123456789');
 
       s.appendLeft(5, 'A');
@@ -78,7 +78,7 @@ describe('MagicString', () => {
       assert.equal(s.slice(5), '])cba>}56789');
     });
 
-    it.skip('preserves intended order at beginning of string', () => {
+    it('preserves intended order at beginning of string', () => {
       const s = new MagicString('x');
 
       s.appendLeft(0, '1');
@@ -89,7 +89,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), '4213x');
     });
 
-    it.skip('preserves intended order at end of string', () => {
+    it('preserves intended order at end of string', () => {
       const s = new MagicString('x');
 
       s.appendRight(1, '1');
@@ -961,7 +961,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), 'abcdefyes');
     });
 
-    it.skip('should allow contiguous but non-overlapping replacements', () => {
+    it('should allow contiguous but non-overlapping replacements', () => {
       const s = new MagicString('abcdefghijkl');
 
       s.overwrite(3, 6, 'DEF');
@@ -1102,7 +1102,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), 'abcdefyes');
     });
 
-    it.skip('should allow contiguous but non-overlapping replacements', () => {
+    it('should allow contiguous but non-overlapping replacements', () => {
       const s = new MagicString('abcdefghijkl');
 
       s.update(3, 6, 'DEF');
@@ -1311,7 +1311,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), 'abhi');
     });
 
-    it.skip('should not remove content inserted after the end of removed range', () => {
+    it('should not remove content inserted after the end of removed range', () => {
       const s = new MagicString('ab.c;');
 
       s.prependRight(0, '(');
@@ -1801,7 +1801,7 @@ describe('MagicString', () => {
   });
 
   describe('hasChanged', () => {
-    it.skip('should works', () => {
+    it('should works', () => {
       const s = new MagicString(' abcde   fghijkl ');
 
       assert.ok(!s.hasChanged());

--- a/packages/rolldown/tests/magic-string/download-tests.mjs
+++ b/packages/rolldown/tests/magic-string/download-tests.mjs
@@ -99,13 +99,14 @@ const SKIP_TESTS = [
   'storeName', // storeName option not supported
   'contentOnly', // contentOnly option not supported
   'should remove overlapping ranges', // overlapping replacements cause panic
-  'overlapping replacements', // overlapping replacements cause panic
+  'error if overlapping replacements', // overlapping replacements cause panic
+  // Note: 'should allow contiguous but non-overlapping replacements' now works
   'already been edited', // Cannot split a chunk that has already been edited
   'non-zero-length inserts inside', // causes split chunk panic
   'should remove modified ranges', // causes split chunk panic
 
   'should replace then remove', // causes split chunk panic
-  'preserves intended order', // complex append/prepend ordering with slice
+  // Note: 'preserves intended order' now works (append/prepend ordering with slice)
   // Note: 'excluded characters' (indent exclude option) is now supported
   // remove-specific skips
   'should remove everything', // edge case
@@ -122,7 +123,7 @@ const SKIP_TESTS = [
   // remove-specific complex cases
   // Note: "removes across moved content" appears in both remove and reset sections
   // The reset version passes, so we handle this with a special transformation below
-  'should not remove content inserted', // complex interaction
+  // Note: 'should not remove content inserted after the end of removed range' now works
   'should remove interior inserts', // causes panic
   // Note: 'should provide a useful error' now works — errors are properly thrown, not panicked
   // slice-specific skips
@@ -132,9 +133,8 @@ const SKIP_TESTS = [
   // Note: 'should clone filename info' now works since filename is supported
   // Note: 'should clone indentExclusionRanges' now works since indentExclusionRanges is supported
   'should clone sourcemapLocations', // uses sourcemapLocations
-  // hasChanged tests that use clone
-  'should not report change if content is identical', // uses clone
-  'should works', // uses clone
+  // Note: 'should works' (hasChanged) now works — clone preserves hasChanged state
+  // Note: 'should not report change if content is identical' no longer in upstream tests
   // replace/replaceAll tests that use regex or function replacer
   'works with global regex replace', // regex not supported
   'works with global regex replace $$', // regex not supported


### PR DESCRIPTION
## Summary
- Enable 7 upstream MagicString tests that now pass with the slice fix from the parent PR
- **preserves intended order** (3 tests): append/prepend ordering with slice
- **should allow contiguous but non-overlapping replacements** (2 tests): overwrite & update
- **should not remove content inserted after the end of removed range** (1 test)
- **should works** (1 test): hasChanged with clone

## Changes
- Updated download-tests.mjs skip patterns: removed 4 entries, narrowed overlapping replacements to error if overlapping replacements so the contiguous test is no longer caught
- Regenerated MagicString.test.ts with the updated skip configuration
- Test count: 142 → 149 passing, 61 → 54 skipped

## Test plan
- [x] All 149 MagicString tests pass
- [x] Regenerated test file from download-tests.mjs produces identical results
