### PR TITLE
feat: MagicString ignoreList support

### DIFF
--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -79,6 +79,8 @@ struct SerializableSourceMap<'a> {
   sources_content: Option<&'a Vec<Option<String>>>,
   names: &'a Vec<String>,
   mappings: &'a String,
+  #[serde(rename = "x_google_ignoreList", skip_serializing_if = "Option::is_none")]
+  x_google_ignore_list: Option<&'a Vec<u32>>,
 }
 
 /// Per-UTF-16-index mapping entry: byte offset + surrogate code unit.
@@ -178,6 +180,7 @@ pub struct BindingMagicStringOptions {
   pub filename: Option<String>,
   pub offset: Option<i64>,
   pub indent_exclusion_ranges: Option<Either<Vec<Vec<i64>>, Vec<i64>>>,
+  pub ignore_list: Option<bool>,
 }
 
 #[napi(object)]
@@ -252,6 +255,12 @@ impl BindingSourceMap {
     self.json.mappings.clone()
   }
 
+  /// The list of source indices that should be excluded from debugging.
+  #[napi(getter, js_name = "x_google_ignoreList")]
+  pub fn x_google_ignore_list(&self) -> Option<Vec<u32>> {
+    self.json.x_google_ignore_list.clone()
+  }
+
   /// Returns the source map as a JSON string.
   #[napi]
   pub fn to_string(&self) -> String {
@@ -262,6 +271,7 @@ impl BindingSourceMap {
       sources_content: self.json.sources_content.as_ref(),
       names: &self.json.names,
       mappings: &self.json.mappings,
+      x_google_ignore_list: self.json.x_google_ignore_list.as_ref(),
     };
     serde_json::to_string(&serializable).expect("should be able to serialize source map")
   }
@@ -338,6 +348,12 @@ impl BindingDecodedMap {
 
     lines
   }
+
+  /// The list of source indices that should be excluded from debugging.
+  #[napi(getter, js_name = "x_google_ignoreList")]
+  pub fn x_google_ignore_list(&self) -> Option<Vec<u32>> {
+    self.json.x_google_ignore_list.clone()
+  }
 }
 
 #[napi]
@@ -346,6 +362,7 @@ pub struct BindingMagicString<'a> {
   utf16_to_byte_mapper: Utf16ToByteMapper,
   pub(crate) offset: i64,
   indent_exclusion_ranges: Option<IndentExclusionRanges>,
+  ignore_list: bool,
 }
 
 #[napi]
@@ -357,12 +374,14 @@ impl BindingMagicString<'_> {
     let offset = opts.offset.unwrap_or(0);
     let indent_exclusion_ranges =
       opts.indent_exclusion_ranges.map(IndentExclusionRanges::from_either);
-    let magic_string_options = MagicStringOptions { filename: opts.filename };
+    let ignore_list = opts.ignore_list.unwrap_or(false);
+    let magic_string_options = MagicStringOptions { filename: opts.filename, ignore_list };
     Self {
       inner: MagicString::with_options(source, magic_string_options),
       utf16_to_byte_mapper,
       offset,
       indent_exclusion_ranges,
+      ignore_list,
     }
   }
 
@@ -379,6 +398,11 @@ impl BindingMagicString<'_> {
   #[napi(getter)]
   pub fn indent_exclusion_ranges(&self) -> Option<Either<Vec<Vec<i64>>, Vec<i64>>> {
     self.indent_exclusion_ranges.as_ref().map(IndentExclusionRanges::to_either)
+  }
+
+  #[napi(getter)]
+  pub fn ignore_list(&self) -> bool {
+    self.ignore_list
   }
 
   #[napi(getter)]
@@ -701,6 +725,7 @@ impl BindingMagicString<'_> {
       utf16_to_byte_mapper: self.utf16_to_byte_mapper.clone(),
       offset: self.offset,
       indent_exclusion_ranges: self.indent_exclusion_ranges.clone(),
+      ignore_list: self.ignore_list,
     }
   }
 
@@ -732,6 +757,7 @@ impl BindingMagicString<'_> {
       utf16_to_byte_mapper: self.utf16_to_byte_mapper.clone(),
       offset: self.offset,
       indent_exclusion_ranges: self.indent_exclusion_ranges.clone(),
+      ignore_list: self.ignore_list,
     })
   }
 
@@ -877,7 +903,7 @@ impl BindingMagicString<'_> {
 
     // If file option is provided, reconstruct the source map with the file field
     let source_map = if let Some(file) = opts.file {
-      SourceMap::new(
+      let mut m = SourceMap::new(
         Some(Arc::from(file)),
         source_map.get_names().map(Arc::clone).collect(),
         None,
@@ -885,7 +911,11 @@ impl BindingMagicString<'_> {
         source_map.get_source_contents().map(|x| x.map(Arc::clone)).collect(),
         source_map.get_tokens().collect::<Vec<_>>().into_boxed_slice(),
         None,
-      )
+      );
+      if self.ignore_list {
+        m.set_x_google_ignore_list(vec![0]);
+      }
+      m
     } else {
       source_map
     };
@@ -914,7 +944,7 @@ impl BindingMagicString<'_> {
 
     // If file option is provided, reconstruct the source map with the file field
     let source_map = if let Some(file) = opts.file {
-      SourceMap::new(
+      let mut m = SourceMap::new(
         Some(Arc::from(file)),
         source_map.get_names().map(Arc::clone).collect(),
         None,
@@ -922,7 +952,11 @@ impl BindingMagicString<'_> {
         source_map.get_source_contents().map(|x| x.map(Arc::clone)).collect(),
         source_map.get_tokens().collect::<Vec<_>>().into_boxed_slice(),
         None,
-      )
+      );
+      if self.ignore_list {
+        m.set_x_google_ignore_list(vec![0]);
+      }
+      m
     } else {
       source_map
     };

--- a/crates/string_wizard/src/magic_string/mod.rs
+++ b/crates/string_wizard/src/magic_string/mod.rs
@@ -24,11 +24,13 @@ use crate::{
 #[derive(Debug, Default)]
 pub struct MagicStringOptions {
   pub filename: Option<String>,
+  pub ignore_list: bool,
 }
 
 #[derive(Debug, Clone)]
 pub struct MagicString<'s> {
   filename: Option<String>,
+  ignore_list: bool,
   intro: VecDeque<CowStr<'s>>,
   outro: VecDeque<CowStr<'s>>,
   source: Cow<'s, str>,
@@ -74,6 +76,7 @@ impl<'text> MagicString<'text> {
       chunk_by_start: Default::default(),
       chunk_by_end: Default::default(),
       filename: options.filename,
+      ignore_list: options.ignore_list,
       guessed_indentor: OnceLock::default(),
       last_searched_chunk_idx: initial_chunk_idx,
     };
@@ -90,6 +93,10 @@ impl<'text> MagicString<'text> {
 
   pub fn filename(&self) -> Option<&str> {
     self.filename.as_deref()
+  }
+
+  pub fn ignore_list(&self) -> bool {
+    self.ignore_list
   }
 
   pub fn len(&self) -> usize {

--- a/crates/string_wizard/src/magic_string/source_map.rs
+++ b/crates/string_wizard/src/magic_string/source_map.rs
@@ -58,7 +58,14 @@ impl MagicString<'_> {
       });
     });
 
-    source_builder.into_source_map()
+    let mut source_map = source_builder.into_source_map();
+
+    if self.ignore_list {
+      // The source is always at index 0 for a single MagicString instance.
+      source_map.set_x_google_ignore_list(vec![0]);
+    }
+
+    source_map
   }
 }
 

--- a/crates/string_wizard/tests/magic_string.rs
+++ b/crates/string_wizard/tests/magic_string.rs
@@ -27,8 +27,10 @@ mod options {
   use super::*;
   #[test]
   fn stores_source_file_information() {
-    let s =
-      MagicString::with_options("abc", MagicStringOptions { filename: Some("foo.js".to_string()) });
+    let s = MagicString::with_options(
+      "abc",
+      MagicStringOptions { filename: Some("foo.js".to_string()), ..Default::default() },
+    );
     assert_eq!(s.filename(), Some("foo.js"))
   }
 }

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1449,6 +1449,8 @@ export declare class BindingDecodedMap {
    * Each line is an array of segments, where each segment is [generatedColumn, sourceIndex, originalLine, originalColumn, nameIndex?].
    */
   get mappings(): Array<Array<Array<number>>>
+  /** The list of source indices that should be excluded from debugging. */
+  get x_google_ignoreList(): Array<number> | null
 }
 
 export declare class BindingDevEngine {
@@ -1481,6 +1483,7 @@ export declare class BindingMagicString {
   get original(): string
   get filename(): string | null
   get indentExclusionRanges(): Array<Array<number>> | Array<number> | null
+  get ignoreList(): boolean
   get offset(): number
   set offset(offset: number)
   replace(from: string, to: string): this
@@ -1683,6 +1686,8 @@ export declare class BindingSourceMap {
   get names(): Array<string>
   /** The VLQ-encoded mappings string. */
   get mappings(): string
+  /** The list of source indices that should be excluded from debugging. */
+  get x_google_ignoreList(): Array<number> | null
   /** Returns the source map as a JSON string. */
   toString(): string
   /** Returns the source map as a base64-encoded data URL. */
@@ -2298,6 +2303,7 @@ export interface BindingMagicStringOptions {
   filename?: string
   offset?: number
   indentExclusionRanges?: Array<Array<number>> | Array<number>
+  ignoreList?: boolean
 }
 
 export type BindingMakeAbsoluteExternalsRelative =

--- a/packages/rolldown/tests/magic-string/MagicString.test.ts
+++ b/packages/rolldown/tests/magic-string/MagicString.test.ts
@@ -14,7 +14,7 @@ describe('MagicString', () => {
       assert.equal(s.filename, 'foo.js');
     });
 
-    it.skip('stores ignore-list hint', () => {
+    it('stores ignore-list hint', () => {
       const s = new MagicString('abc', { ignoreList: true });
 
       assert.equal(s.ignoreList, true);
@@ -471,7 +471,7 @@ describe('MagicString', () => {
       assert.equal(map.mappings, 'IAAA');
     });
 
-    it.skip('generates x_google_ignoreList', () => {
+    it('generates x_google_ignoreList', () => {
       const s = new MagicString('function foo(){}', {
         ignoreList: true,
       });
@@ -479,6 +479,20 @@ describe('MagicString', () => {
       const map = s.generateMap({ source: 'foo.js' });
       assert.deepEqual(map.sources, ['foo.js']);
       assert.deepEqual(map.x_google_ignoreList, [0]);
+    });
+
+    it('preserves x_google_ignoreList when file is set', () => {
+      const s = new MagicString('function foo(){}', {
+        ignoreList: true,
+      });
+
+      const map = s.generateMap({ source: 'foo.js', file: 'out.js' });
+      assert.deepEqual(map.x_google_ignoreList, [0]);
+      assert.equal(map.file, 'out.js');
+
+      const decoded = s.generateDecodedMap({ source: 'foo.js', file: 'out.js' });
+      assert.deepEqual(decoded.x_google_ignoreList, [0]);
+      assert.equal(decoded.file, 'out.js');
     });
 
     it('generates segments per word boundary with hires "boundary"', () => {

--- a/packages/rolldown/tests/magic-string/download-tests.mjs
+++ b/packages/rolldown/tests/magic-string/download-tests.mjs
@@ -42,10 +42,10 @@
  *   - generateDecodedMap(options?): BindingDecodedMap (returns object with decoded mappings array)
  *
  * NOT supported (will be skipped):
- *   - constructor options: ignoreList — filename, offset, and indentExclusionRanges ARE supported
+ *   - constructor options: filename, offset, indentExclusionRanges, and ignoreList ARE supported
  *   - addSourcemapLocation (not in string_wizard)
  *   - storeName option in overwrite/update (not exposed in binding)
- *   - x_google_ignoreList / ignoreList in generateMap output (not in string_wizard)
+ *   - x_google_ignoreList / ignoreList in generateMap output is now supported
  *   - replace/replaceAll with regex or function replacer
  */
 
@@ -71,7 +71,7 @@ const SKIP_DESCRIBE_BLOCKS = [
   // Note: 'snip' is now supported
   // Note: 'lastChar' is now supported
   // Note: 'lastLine' is now supported
-  // Note: 'options' is now partially supported (filename works, ignoreList doesn't)
+  // Note: 'options' is now supported (filename, offset, indentExclusionRanges, ignoreList)
   // Note: 'insert' is now supported (throws deprecated error as expected)
   // Note: 'slice' is now supported
   // Note: 'clone' is now supported (some individual tests skipped)
@@ -84,7 +84,7 @@ const SKIP_TESTS = [
   'should throw when given non-string content', // error handling differs
   'should throw', // error handling differs
   // options-specific skips
-  'stores ignore-list hint', // ignoreList option not supported
+  // Note: 'stores ignore-list hint' is now supported (ignoreList option)
   // Note: 'indentExclusionRanges' is now supported (constructor option + getter + clone)
   'sourcemapLocations', // not supported
   'should return cloned content', // clone-related
@@ -152,7 +152,7 @@ const SKIP_TESTS = [
   'should generate a sourcemap using specified locations', // addSourcemapLocation not implemented
   'should recover original names', // storeName option not implemented
   'generates a map with trimmed content', // trim sourcemap behavior differs
-  'generates x_google_ignoreList', // ignoreList not implemented
+  // Note: 'generates x_google_ignoreList' is now supported
   'generates segments per word boundary with hires "boundary" in the next line', // multiline boundary mappings differ
   'generates a correct source map with update using a content containing a new line', // multiline update mappings differ
   'generates a correct source map with update using content ending with a new line', // multiline update mappings differ


### PR DESCRIPTION
## Summary

* Adds end-to-end `ignoreList` support to the native MagicString binding, matching the original magic-string API
* When `ignoreList: true` is passed in constructor options, `generateMap()` now populates `x_google_ignoreList` in the output source map
* Unskips the two related tests

## Changes

* **string\_wizard:** Added `ignore_list` field to `MagicStringOptions` and `MagicString`, set `x_google_ignoreList` on source map when enabled
* **rolldown\_binding:** Added `ignoreList` option, getter, and `x_google_ignoreList` getter on `BindingSourceMap` / `BindingDecodedMap`
* **Tests:** Unskipped `stores ignore-list hint` and `generates x_google_ignoreList` tests

Here's how `ignoreList` works in the original magic-string:

**1. Constructor** — stores the boolean from options:
[https://github.com/Rich-Harris/magic-string/blob/410fd4d080d8bf0b5be900c16c8ba11276fd8749/src/MagicString.js#L37](https://github.com/Rich-Harris/magic-string/blob/410fd4d080d8bf0b5be900c16c8ba11276fd8749/src/MagicString.js#L37)

**2. Source map generation** — populates `x_google_ignoreList` when true:
[https://github.com/Rich-Harris/magic-string/blob/410fd4d080d8bf0b5be900c16c8ba11276fd8749/src/MagicString.js#L183](https://github.com/Rich-Harris/magic-string/blob/410fd4d080d8bf0b5be900c16c8ba11276fd8749/src/MagicString.js#L183)