### PR TITLE
feat: support `getIndentString` in MagicString

### DIFF
--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -741,6 +741,12 @@ impl BindingMagicString<'_> {
     self.inner.last_line()
   }
 
+  /// Returns the guessed indentation string, or `\t` if none is found.
+  #[napi]
+  pub fn get_indent_string(&self) -> &str {
+    self.inner.get_indent_string()
+  }
+
   /// Returns a clone with content outside the specified range removed.
   #[napi]
   pub fn snip(&self, start: u32, end: u32) -> napi::Result<Self> {

--- a/crates/string_wizard/src/magic_string/indent.rs
+++ b/crates/string_wizard/src/magic_string/indent.rs
@@ -56,7 +56,7 @@ pub struct IndentOptions<'a, 'b> {
 }
 
 impl MagicString<'_> {
-  fn guessed_indentor(&self) -> &str {
+  pub fn get_indent_string(&self) -> &str {
     self
       .guessed_indentor
       .get_or_init(|| guess_indentor(&self.source).unwrap_or_else(|| "\t".to_string()))
@@ -89,7 +89,7 @@ impl MagicString<'_> {
       *frag = Cow::Owned(indented);
     }
 
-    let indentor = opts.indentor.unwrap_or_else(|| self.guessed_indentor());
+    let indentor = opts.indentor.unwrap_or_else(|| self.get_indent_string());
 
     let mut indent_replacer =
       IndentReplacer { should_indent_next_char: true, indentor: indentor.to_string() };

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1528,6 +1528,8 @@ export declare class BindingMagicString {
   lastChar(): string
   /** Returns the content after the last newline in the generated string. */
   lastLine(): string
+  /** Returns the guessed indentation string, or `\t` if none is found. */
+  getIndentString(): string
   /** Returns a clone with content outside the specified range removed. */
   snip(start: number, end: number): BindingMagicString
   /**

--- a/packages/rolldown/tests/magic-string/MagicString.test.ts
+++ b/packages/rolldown/tests/magic-string/MagicString.test.ts
@@ -636,7 +636,7 @@ describe('MagicString', () => {
     });
   });
 
-  describe.skip('getIndentString', () => {
+  describe('getIndentString', () => {
     it('should guess the indent string', () => {
       const s = new MagicString('abc\n  def\nghi');
       assert.equal(s.getIndentString(), '  ');

--- a/packages/rolldown/tests/magic-string/download-tests.mjs
+++ b/packages/rolldown/tests/magic-string/download-tests.mjs
@@ -63,7 +63,7 @@ const BASE_URL = 'https://raw.githubusercontent.com/Rich-Harris/magic-string/mas
 // Describe blocks to skip entirely (unsupported features)
 const SKIP_DESCRIBE_BLOCKS = [
   'addSourcemapLocation', // not in string_wizard
-  'getIndentString', // not supported
+  // Note: 'getIndentString' is now supported
   'original', // not supported
   // Note: 'generateMap' is now supported (returns BindingSourceMap object)
   // Note: 'generateDecodedMap' is now supported (returns BindingDecodedMap object)


### PR DESCRIPTION
**Description:** Exposes the existing `guessed_indentor()` method as the public `getIndentString()` API on MagicString, matching the original magic-string behavior. Unskips 2 tests.