### PR TITLE
fix: align MagicString length/isEmpty with reference magic-string

### DIFF
--- a/crates/string_wizard/src/magic_string/mod.rs
+++ b/crates/string_wizard/src/magic_string/mod.rs
@@ -99,12 +99,17 @@ impl<'text> MagicString<'text> {
     self.ignore_list
   }
 
+  /// Returns the length of the content within chunks (intro + content + outro per chunk),
+  /// excluding the global intro/outro from `prepend`/`append`.
+  /// This aligns with the reference `magic-string` behavior.
   pub fn len(&self) -> usize {
-    self.fragments().map(|f| f.len()).sum()
+    self.iter_chunks().flat_map(|c| c.fragments(&self.source)).map(|f| f.len()).sum()
   }
 
+  /// Returns `true` if all chunk content (intro + content + outro) is whitespace or empty.
+  /// This aligns with the reference `magic-string` behavior where `isEmpty()` uses `.trim()`.
   pub fn is_empty(&self) -> bool {
-    self.len() == 0
+    self.iter_chunks().flat_map(|c| c.fragments(&self.source)).all(|f| f.trim().is_empty())
   }
 
   /// Indicates if the string has been changed.
@@ -334,7 +339,7 @@ impl<'text> MagicString<'text> {
 #[expect(clippy::to_string_trait_impl)] // `impl Display` causes extra allocation
 impl ToString for MagicString<'_> {
   fn to_string(&self) -> String {
-    let size_hint = self.len();
+    let size_hint = self.fragments().map(|f| f.len()).sum();
     let mut ret = String::with_capacity(size_hint);
     self.fragments().for_each(|f| ret.push_str(f));
     ret

--- a/packages/rolldown/tests/magic-string/MagicString.test.ts
+++ b/packages/rolldown/tests/magic-string/MagicString.test.ts
@@ -1740,7 +1740,7 @@ describe('MagicString', () => {
   });
 
   describe('isEmpty', () => {
-    it.skip('should support isEmpty', () => {
+    it('should support isEmpty', () => {
       const s = new MagicString(' abcde   fghijkl ');
 
       assert.equal(s.isEmpty(), false);
@@ -1759,7 +1759,7 @@ describe('MagicString', () => {
   });
 
   describe('length', () => {
-    it.skip('should support length', () => {
+    it('should support length', () => {
       const s = new MagicString(' abcde   fghijkl ');
 
       assert.equal(s.length(), 17);


### PR DESCRIPTION
## Summary
- Fix `len()` to only count chunk content (excluding global intro/outro from `prepend`/`append`), matching reference `magic-string` behavior
- Fix `isEmpty()` to check for whitespace-only content using `.trim()` instead of checking for zero length
- Fix `to_string()` size hint to still use full output length
- Unskip the `isEmpty` and `length` tests
