### PR TITLE
docs: improve external examples for cross-platform correctness

### DIFF
--- a/packages/rolldown/src/options/docs/external.md
+++ b/packages/rolldown/src/options/docs/external.md
@@ -41,9 +41,11 @@ export default {
 ##### Function
 
 ```js
+import path from 'node:path';
+
 export default {
   external: (id) => {
-    return !id.startsWith('.') && !id.startsWith('/') && !id.includes('\\');
+    return !id.startsWith('.') && !path.isAbsolute(id);
   },
 };
 ```
@@ -73,6 +75,6 @@ export default {
   external: [/^vue/, /^react/, /^@mui/],
 
   // All bare module IDs (not starting with `.` or `/` or `C:\`)
-  external: /^[^./](?!:\\)/,
+  external: /^[^./](?!:[/\\])/,
 };
 ```


### PR DESCRIPTION
Follow-up to #8780.

### Function example

Replace manual `startsWith` / `includes` checks with `path.isAbsolute()`:

```js
// before
return !id.startsWith('.') && !id.startsWith('/') && !id.includes('\\');

// after
return !id.startsWith('.') && !path.isAbsolute(id);
```

`path.isAbsolute()` is what Rollup uses internally (`isPathFragment` in `src/utils/relativeId.ts`). It correctly handles all platform-specific absolute path formats: drive letters (`C:\\`), forward slash variants (`C:/`), and UNC paths (`\\\\server\\share`).

### Regex example

Add `/` to the negative lookahead so `c:/Users/...` style paths are also excluded:

```js
// before (misses c:/ paths)
external: /^[^./](?!:\\)/

// after
external: /^[^./](?!:[/\\])/
```