### PR TITLE
fix: remove redundant bare side-effect imports in entry/facade chunks

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -490,8 +490,18 @@ impl GenerateStage<'_> {
           }
         }
 
-        // If this is an entry point, make sure we import all chunks belonging to this entry point, even if there are no imports. We need to make sure these chunks are evaluated for their side effects too.
-        if let ChunkKind::EntryPoint { bit: importer_chunk_bit, .. } = &chunk.kind {
+        if let ChunkKind::EntryPoint { module: entry_module_idx, .. } = &chunk.kind {
+          // If the entry module is in a different chunk (facade entry), ensure that chunk
+          // is imported. Without this, the facade would be empty and the entry module's
+          // code would never execute.
+          if let Some(entry_chunk_idx) = chunk_graph.module_to_chunk[*entry_module_idx] {
+            if entry_chunk_idx != chunk_id {
+              index_cross_chunk_imports[chunk_id].insert(entry_chunk_idx);
+              let imports_from_other_chunks = &mut index_imports_from_other_chunks[chunk_id];
+              imports_from_other_chunks.entry(entry_chunk_idx).or_default();
+            }
+          }
+
           if self.options.preserve_modules {
             let entry_module =
               chunk.entry_module(&self.link_output.module_table).expect("Should have entry module");
@@ -511,63 +521,56 @@ impl GenerateStage<'_> {
                 let imports_from_other_chunks = &mut index_imports_from_other_chunks[chunk_id];
                 imports_from_other_chunks.entry(importee_chunk_idx).or_default();
               });
-          } else if !self.options.is_strict_execution_order_enabled() {
-            // With strict_execution_order/wrapping, modules aren't executed in loading but on-demand.
-            // So we don't need to do plain imports to address the side effects. It would be ensured
-            // by those `init_xxx()` calls.
-            chunk_graph
-              .chunk_table
-              .iter_enumerated()
-              .filter(|(id, _)| *id != chunk_id)
-              .filter(|(_, importee_chunk)| {
-                importee_chunk.bits.has_bit(*importer_chunk_bit)
-                  && importee_chunk.has_side_effect(&self.link_output.module_table)
-              })
-              .for_each(|(importee_chunk_id, _)| {
-                index_cross_chunk_imports[chunk_id].insert(importee_chunk_id);
-                let imports_from_other_chunks = &mut index_imports_from_other_chunks[chunk_id];
-                imports_from_other_chunks.entry(importee_chunk_id).or_default();
-              });
+          }
+        }
 
-            // Also check direct imports from all modules in this chunk to modules in other chunks.
-            // This handles cases where the bit-based check above misses cross-chunk dependencies:
-            // 1. Entry A imports entry B - entry B's chunk bits don't contain entry A's bit
-            // 2. Dynamic chunk imports a module that was inlined into another chunk
-            //
-            // We need to check ALL modules in the chunk because non-entry modules may be
-            // inlined into the entry chunk and their imports need to be preserved.
-            for &module_idx in &chunk.modules {
-              let Some(module) = self.link_output.module_table[module_idx].as_normal() else {
+        // Add bare imports for side-effectful dependencies in other chunks.
+        //
+        // With strict_execution_order/wrapping, modules aren't executed in loading but on-demand.
+        // So we don't need to do plain imports to address the side effects. It would be ensured
+        // by those `init_xxx()` calls.
+        if !self.options.is_strict_execution_order_enabled() {
+          for &module_idx in &chunk.modules {
+            let Some(module) = self.link_output.module_table[module_idx].as_normal() else {
+              continue;
+            };
+
+            // From import records.
+            // This adds side-effectful imports as bare imports if necessary.
+            for rec in &module.import_records {
+              if rec.kind != ImportKind::Import {
+                continue;
+              }
+              let Some(importee_module_idx) = rec.resolved_module else {
                 continue;
               };
-              for rec in &module.import_records {
-                if rec.kind == ImportKind::DynamicImport {
-                  continue;
+              if !self.link_output.module_table[importee_module_idx]
+                .side_effects()
+                .has_side_effects()
+              {
+                continue;
+              }
+              let Some(importee_chunk_idx) = chunk_graph.module_to_chunk[importee_module_idx]
+              else {
+                continue;
+              };
+              if importee_chunk_idx == chunk_id {
+                continue;
+              }
+              index_cross_chunk_imports[chunk_id].insert(importee_chunk_idx);
+              let imports_from_other_chunks = &mut index_imports_from_other_chunks[chunk_id];
+              imports_from_other_chunks.entry(importee_chunk_idx).or_default();
+            }
+
+            // Runtime module may have side effects (e.g. dev/HMR mode) without an import record.
+            if self.link_output.metas[module_idx].has_side_effectful_runtime_dep {
+              let runtime_idx = self.link_output.runtime.id();
+              if let Some(runtime_chunk_idx) = chunk_graph.module_to_chunk[runtime_idx] {
+                if runtime_chunk_idx != chunk_id {
+                  index_cross_chunk_imports[chunk_id].insert(runtime_chunk_idx);
+                  let imports_from_other_chunks = &mut index_imports_from_other_chunks[chunk_id];
+                  imports_from_other_chunks.entry(runtime_chunk_idx).or_default();
                 }
-                let Some(importee_module_idx) = rec.resolved_module else {
-                  continue;
-                };
-                if !self.link_output.module_table[importee_module_idx]
-                  .side_effects()
-                  .has_side_effects()
-                {
-                  continue;
-                }
-                let Some(importee_chunk_idx) = chunk_graph.module_to_chunk[importee_module_idx]
-                else {
-                  continue;
-                };
-                if importee_chunk_idx == chunk_id {
-                  continue;
-                }
-                // Skip if already covered by the bit-based check above
-                let importee_chunk = &chunk_graph.chunk_table[importee_chunk_idx];
-                if importee_chunk.bits.has_bit(*importer_chunk_bit) {
-                  continue;
-                }
-                index_cross_chunk_imports[chunk_id].insert(importee_chunk_idx);
-                let imports_from_other_chunks = &mut index_imports_from_other_chunks[chunk_id];
-                imports_from_other_chunks.entry(importee_chunk_idx).or_default();
               }
             }
           }

--- a/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
+++ b/crates/rolldown/src/stages/link_stage/patch_module_dependencies.rs
@@ -127,6 +127,7 @@ impl LinkStage<'_> {
         if runtime_module.side_effects.has_side_effects() {
           for &entry_module_idx in self.entries.keys() {
             self.metas[entry_module_idx].dependencies.insert(runtime_idx);
+            self.metas[entry_module_idx].has_side_effectful_runtime_dep = true;
           }
         }
       }

--- a/crates/rolldown/src/types/linking_metadata.rs
+++ b/crates/rolldown/src/types/linking_metadata.rs
@@ -82,6 +82,9 @@ pub struct LinkingMetadata {
   /// also need to link the exported facade symbol.
   pub included_commonjs_export_symbol: FxHashSet<SymbolRef>,
   pub depended_runtime_helper: RuntimeHelper,
+  /// Whether this module needs the runtime chunk loaded for its side effects.
+  /// Set when the runtime module has side effects (e.g. dev/HMR mode).
+  pub has_side_effectful_runtime_dep: bool,
   pub module_namespace_included_reason: ModuleNamespaceIncludedReason,
   /// Tracks which statements in this module are included after tree-shaking.
   /// Each entry corresponds to a statement in the module's `stmt_infos`.

--- a/crates/rolldown/tests/esbuild/default/top_level_await_allowed_import_with_splitting/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/default/top_level_await_allowed_import_with_splitting/artifacts.snap
@@ -6,7 +6,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import "./c2.js";
 import "./b2.js";
 
 ```
@@ -14,7 +13,6 @@ import "./b2.js";
 ## b.js
 
 ```js
-import "./c2.js";
 import "./b2.js";
 
 ```
@@ -22,6 +20,7 @@ import "./b2.js";
 ## b2.js
 
 ```js
+import "./c2.js";
 
 ```
 

--- a/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "input": [
+      { "name": "a", "import": "./a.js" },
+      { "name": "b", "import": "./b.js" }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/_test.mjs
+++ b/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/_test.mjs
@@ -1,0 +1,5 @@
+import './dist/a.js';
+import './dist/b.js';
+
+import assert from 'assert';
+assert(globalThis.sideEffectExecuted, 'side effect not executed');

--- a/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/a.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/a.js
@@ -1,0 +1,1 @@
+require('./shared');

--- a/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/artifacts.snap
@@ -1,0 +1,37 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## a.js
+
+```js
+import { t as require_shared } from "./shared.js";
+//#region a.js
+require_shared();
+//#endregion
+
+```
+
+## b.js
+
+```js
+import { t as require_shared } from "./shared.js";
+//#region b.js
+require_shared();
+//#endregion
+
+```
+
+## shared.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region shared.js
+var require_shared = /* @__PURE__ */ __commonJSMin((() => {
+	globalThis.sideEffectExecuted = true;
+}));
+//#endregion
+export { require_shared as t };
+
+```

--- a/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/b.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/b.js
@@ -1,0 +1,1 @@
+require('./shared');

--- a/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/shared.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/ensure_side_effect_executed_require/shared.js
@@ -1,0 +1,1 @@
+globalThis.sideEffectExecuted = true;

--- a/crates/rolldown/tests/rolldown/issues/8252/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8252/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "input": [
+      { "name": "index", "import": "./index.js" },
+      { "name": "sorter", "import": "./sorter.js" }
+    ],
+    "treeshake": true
+  },
+  "expectExecuted": false
+}

--- a/crates/rolldown/tests/rolldown/issues/8252/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8252/artifacts.snap
@@ -1,0 +1,76 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## index.js
+
+```js
+import { t as createSorter } from "./sorter2.js";
+//#region index.js
+async function main() {
+	const v3 = await import("./v3.js");
+	return {
+		sorter: createSorter(),
+		v3
+	};
+}
+//#endregion
+export { main };
+
+```
+
+## resolve.js
+
+```js
+//#region resolve.js
+const counter = new SomethingNew();
+function resolveJsFrom(base, id) {
+	return counter;
+}
+//#endregion
+export { resolveJsFrom as t };
+
+```
+
+## sorter.js
+
+```js
+import { t as createSorter } from "./sorter2.js";
+export { createSorter };
+
+```
+
+## sorter2.js
+
+```js
+import { t as resolveJsFrom } from "./resolve.js";
+//#region sorting.js
+function sort(input) {
+	return resolveJsFrom(input, "some-pkg");
+}
+//#endregion
+//#region sorter.js
+function createSorter() {
+	return {
+		sort,
+		resolveJsFrom
+	};
+}
+//#endregion
+export { createSorter as t };
+
+```
+
+## v3.js
+
+```js
+import { t as resolveJsFrom } from "./resolve.js";
+//#region v3.js
+function loadV3() {
+	return resolveJsFrom("v3-dir", "v3-config");
+}
+//#endregion
+export { loadV3 };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/8252/index.js
+++ b/crates/rolldown/tests/rolldown/issues/8252/index.js
@@ -1,0 +1,6 @@
+import { createSorter } from './sorter';
+
+export async function main() {
+  const v3 = await import('./v3');
+  return { sorter: createSorter(), v3 };
+}

--- a/crates/rolldown/tests/rolldown/issues/8252/resolve.js
+++ b/crates/rolldown/tests/rolldown/issues/8252/resolve.js
@@ -1,0 +1,5 @@
+const counter = new SomethingNew();
+
+export function resolveJsFrom(base, id) {
+  return counter;
+}

--- a/crates/rolldown/tests/rolldown/issues/8252/sorter.js
+++ b/crates/rolldown/tests/rolldown/issues/8252/sorter.js
@@ -1,0 +1,6 @@
+import { sort } from './sorting';
+import { resolveJsFrom } from './resolve';
+
+export function createSorter() {
+  return { sort, resolveJsFrom };
+}

--- a/crates/rolldown/tests/rolldown/issues/8252/sorting.js
+++ b/crates/rolldown/tests/rolldown/issues/8252/sorting.js
@@ -1,0 +1,5 @@
+import { resolveJsFrom } from './resolve';
+
+export function sort(input) {
+  return resolveJsFrom(input, 'some-pkg');
+}

--- a/crates/rolldown/tests/rolldown/issues/8252/v3.js
+++ b/crates/rolldown/tests/rolldown/issues/8252/v3.js
@@ -1,0 +1,5 @@
+import { resolveJsFrom } from './resolve';
+
+export function loadV3() {
+  return resolveJsFrom('v3-dir', 'v3-config');
+}

--- a/crates/rolldown/tests/rolldown/issues/8361_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8361_2/artifacts.snap
@@ -15,8 +15,6 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import "./cjs.js";
-import "./b.js";
 import "./a2.js";
 
 ```
@@ -25,6 +23,7 @@ import "./a2.js";
 
 ```js
 import { t as require_cjs } from "./cjs.js";
+import "./b.js";
 require_cjs();
 //#endregion
 
@@ -70,8 +69,6 @@ export { require_cjs as t };
 ## main.js
 
 ```js
-import "./cjs.js";
-import "./b.js";
 import "./a2.js";
 
 ```

--- a/packages/rolldown/tests/fixtures/plugin/context/emit-chunk/_config.ts
+++ b/packages/rolldown/tests/fixtures/plugin/context/emit-chunk/_config.ts
@@ -53,7 +53,7 @@ export default defineTest({
     `);
     expect(emittedChunkFilenames).toMatchInlineSnapshot(`
       [
-        "main-with-name-CKJu0JRS.js",
+        "main-with-name-C87_COi0.js",
         "main-with-fileName.js",
       ]
     `);


### PR DESCRIPTION
## Summary

Remove redundant bare side-effect imports from entry/facade chunks. Previously, a bit-based pass added
bare imports for ALL reachable side-effectful chunks to entry points, even when those chunks were already
transitively loaded through binding imports.

## Changes

- Replace the broad bit-based chunk lookup with import-record-based checks that add bare imports only where the
actual dependency exists (any chunk, not just entries)
- Ensure facade entries import their entry module's chunk so it executes. (This was implicitly handled in bit-based reachability check)
- Add `.has_side_effectful_runtime_dep` field if runtime has side-effect (e.g. runtime in dev/HMR mode)

## Related issues

closes https://github.com/rolldown/rolldown/issues/8252