### PR TITLE
perf: enable parallel AST cloning on macOS

### DIFF
--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -3,7 +3,6 @@ use std::{sync::Arc, thread};
 use arcstr::ArcStr;
 use futures::future::join_all;
 use oxc_index::IndexVec;
-#[cfg(not(target_os = "macos"))]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rolldown_common::SourceMapGenMsg;
 use rolldown_common::{
@@ -61,10 +60,7 @@ impl NormalizedScanStageOutput {
     Self {
       module_table: self.module_table.clone(),
       index_ecma_ast: {
-        #[cfg(not(target_os = "macos"))]
         let iter = self.index_ecma_ast.raw.par_iter();
-        #[cfg(target_os = "macos")]
-        let iter = self.index_ecma_ast.raw.iter();
 
         let index_ecma_ast = iter
           .map(|ast| ast.as_ref().map(rolldown_ecmascript::EcmaAst::clone_with_another_arena))


### PR DESCRIPTION
## Summary

- Remove the `#[cfg(target_os = "macos")]` guard that forced sequential iteration for `clone_with_another_arena` in incremental builds
- Benchmarking on macOS shows `par_iter` is ~2.3x faster than sequential `iter` (3.87ms vs 8.82ms for 500 ASTs)
- The original concern from #6167 is no longer reproducible

Closes #8630

## Benchmark (macOS, M3 Max)

| Suite | main | this PR | Change |
|-------|------|---------|--------|
| **threejs** | 27.76ms | 27.32ms | -1.6% |
| **react-stack** | 3.65ms | 3.56ms | -2.5% |
| **rome-ts** | 55.73ms | 52.61ms | -5.6% |

No regressions. Rome-ts shows a ~5.6% improvement.