### PR TITLE
fix: set `order` for callable plugins

### DIFF
--- a/crates/rolldown_binding/src/options/plugin/binding_callable_builtin_plugin.rs
+++ b/crates/rolldown_binding/src/options/plugin/binding_callable_builtin_plugin.rs
@@ -10,8 +10,8 @@ use rolldown::ModuleType;
 use rolldown_common::WatcherChangeKind;
 use rolldown_plugin::{
   CustomField, HookLoadArgs, HookLoadOutput, HookResolveIdArgs, HookResolveIdOutput,
-  HookTransformArgs, LoadPluginContext, PluginIdx, Pluginable, SharedTransformPluginContext,
-  TransformPluginContext,
+  HookTransformArgs, LoadPluginContext, PluginIdx, PluginOrder, Pluginable,
+  SharedTransformPluginContext, TransformPluginContext,
 };
 use rolldown_plugin_vite_resolve::ResolveIdOptionsScan;
 use rolldown_utils::unique_arc::UniqueArc;
@@ -51,6 +51,30 @@ impl BindingCallableBuiltinPlugin {
         PluginIdx::new(0),
         None,
       )),
+    })
+  }
+
+  #[napi]
+  pub fn get_order(&self, hook_name: String) -> Option<String> {
+    let meta = match hook_name.as_str() {
+      "resolveId" => self.inner.call_resolve_id_meta(),
+      "load" => self.inner.call_load_meta(),
+      "transform" => self.inner.call_transform_meta(),
+      "watchChange" => self.inner.call_watch_change_meta(),
+      _ => None,
+    };
+    meta.and_then(|meta| {
+      meta.order.map(|order| {
+        (match order {
+          PluginOrder::Pre => "pre",
+          PluginOrder::Post => "post",
+          PluginOrder::PinPost => {
+            debug_assert!(false, "PinPost order is not supported in BindingCallableBuiltinPlugin");
+            "pre"
+          }
+        })
+        .to_string()
+      })
     })
   }
 

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -1422,6 +1422,7 @@ export declare class BindingBundler {
 
 export declare class BindingCallableBuiltinPlugin {
   constructor(plugin: BindingBuiltinPlugin)
+  getOrder(hookName: string): string | null
   resolveId(id: string, importer?: string | undefined | null, options?: BindingHookJsResolveIdOptions | undefined | null): Promise<BindingHookJsResolveIdOutput | undefined | null>
   load(id: string): Promise<BindingHookJsLoadOutput | undefined | null>
   transform(code: string, id: string, options: BindingTransformHookExtraArgs): Promise<BindingHookTransformOutput | undefined | null>

--- a/packages/rolldown/src/builtin-plugin/utils.ts
+++ b/packages/rolldown/src/builtin-plugin/utils.ts
@@ -31,8 +31,7 @@ export function makeBuiltinPluginCallable(
 
   const wrappedPlugin: Partial<BindingCallableBuiltinPluginLike> & BuiltinPlugin = plugin;
   for (const key in callablePlugin) {
-    // @ts-expect-error
-    wrappedPlugin[key] = async function (...args) {
+    const wrappedHook = async function (...args: any[]) {
       try {
         // @ts-expect-error
         return await callablePlugin[key](...args);
@@ -52,6 +51,18 @@ export function makeBuiltinPluginCallable(
         );
       }
     };
+
+    const order = callablePlugin.getOrder(key);
+    if (order == undefined) {
+      // @ts-expect-error
+      wrappedPlugin[key] = wrappedHook;
+    } else {
+      // @ts-expect-error
+      wrappedPlugin[key] = {
+        handler: wrappedHook,
+        order,
+      };
+    }
   }
   return wrappedPlugin as BuiltinPlugin & BindingCallableBuiltinPluginLike;
 }

--- a/packages/rolldown/tests/builtin-plugin/oxc-runtime.test.ts
+++ b/packages/rolldown/tests/builtin-plugin/oxc-runtime.test.ts
@@ -1,23 +1,31 @@
 import { oxcRuntimePlugin } from 'rolldown/experimental';
 import { expect, test } from 'vitest';
 
-const plugin = oxcRuntimePlugin() as unknown as { resolveId: Function; load: Function };
+const plugin = oxcRuntimePlugin() as unknown as {
+  resolveId: { handler: Function; order: string };
+  load: { handler: Function; order: string };
+};
 
 test('resolveId resolves oxc runtime helper to virtual module', async () => {
-  const result = await plugin.resolveId('@oxc-project/runtime/helpers/objectSpread2.js');
+  const result = await plugin.resolveId.handler('@oxc-project/runtime/helpers/objectSpread2.js');
   // oxlint-disable-next-line no-control-regex
   expect(result.id).toMatch(/^\0@oxc-project\+runtime@[\d.]+\/helpers\/objectSpread2\.js$/);
 });
 
 test('resolveId returns null for non-matching specifier', async () => {
-  const result = await plugin.resolveId('some-random-module');
+  const result = await plugin.resolveId.handler('some-random-module');
   expect(result).toBeNull();
 });
 
 test('load returns code for resolved virtual module', async () => {
-  const resolved = await plugin.resolveId('@oxc-project/runtime/helpers/objectSpread2.js');
-  const result = await plugin.load(resolved.id);
+  const resolved = await plugin.resolveId.handler('@oxc-project/runtime/helpers/objectSpread2.js');
+  const result = await plugin.load.handler(resolved.id);
   expect(result).toBeTruthy();
   expect(result.code).toBeTruthy();
   expect(typeof result.code).toBe('string');
+});
+
+test('has order', async () => {
+  expect(plugin.resolveId.order).toBe('pre');
+  expect(plugin.load.order).toBe('pre');
 });


### PR DESCRIPTION
This PR fixes the following failure:
```
 FAIL  packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts > module runner initialization > oxc runtime helpers are loadable
ReferenceError: module is not defined
 ❯ eval ../../../node_modules/.pnpm/@oxc-project+runtime@0.121.0/node_modules/@oxc-project/runtime/src/helpers/taggedTemplateLiteral.js:10:1
 ❯ ESModulesEvaluator.runInlinedModule packages/vite/src/module-runner/esmEvaluator.ts:35:11
     33|     )
     34|
     35|     await initModule(
       |           ^
     36|       context[ssrModuleExportsKey],
     37|       context[ssrImportMetaKey],
 ❯ ModuleRunner.directRequest packages/vite/src/module-runner/runner.ts:430:26
 ❯ ModuleRunner.cachedRequest packages/vite/src/module-runner/runner.ts:222:33
```
https://github.com/rolldown/rolldown/actions/runs/23327388763/job/67851374703#step:7:473

This error was happening only in this repo because, in this repo, `@oxc-project/runtime` is a dependency and was resolvable from `vite-tests` directory. The internal resolver plugin is placed before the `oxcRuntimePlugin` in Vite, and because the `order` property was not set for callable plugins, the internal resolver plugin resolved `@oxc-project/runtime`.
This PR fixes that by adding `order` property for callable plugins.
