### PR TITLE
fix: relax test utils path assertion to support git worktrees

### DIFF
--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -58,11 +58,7 @@ export function testsDir(...joined: string[]) {
   return projectDir('tests', ...joined);
 }
 
-assert.deepEqual(testsDir().split(path.sep).slice(-3), [
-  'packages',
-  'rolldown',
-  'tests',
-]);
+assert.deepEqual(testsDir().split(path.sep).slice(-3), ['packages', 'rolldown', 'tests']);
 
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/rolldown/tests/src/utils.ts
+++ b/packages/rolldown/tests/src/utils.ts
@@ -58,8 +58,7 @@ export function testsDir(...joined: string[]) {
   return projectDir('tests', ...joined);
 }
 
-assert.deepEqual(testsDir().split(path.sep).slice(-4), [
-  'rolldown',
+assert.deepEqual(testsDir().split(path.sep).slice(-3), [
   'packages',
   'rolldown',
   'tests',


### PR DESCRIPTION
## Summary
- The `testsDir()` assertion in test utils checked the last 4 path segments, including the repo root directory name (`rolldown`). This fails when running in git worktrees or custom clone directories where the root name differs.
- Changed `slice(-4)` to `slice(-3)` so only `['packages', 'rolldown', 'tests']` is verified, which is sufficient to validate the path correctness regardless of the repo root name.

## Test plan
- Run existing tests in both the main repo and a git worktree to confirm the assertion passes in both cases.