### PR TITLE
fix: use sanitized filename for chunk name with preserveModulesRoot

### DIFF
--- a/.ls-lint.json
+++ b/.ls-lint.json
@@ -16,6 +16,7 @@
     "crates/rolldown/tests/**",
     "prepare/**",
     "packages/rolldown/tests/fixtures/builtin-plugin/load-fallback/path-has-hashtag/**",
+    "packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-preserve-modules-root-custom-sanitizer/**",
     "packages/debug/src/generated/**",
     "**/*.config.{js,mjs,cjs,ts,cts,mts}",
     "**/*.test.{js,mjs,cjs,ts,cts,mts}",

--- a/.ls-lint.json
+++ b/.ls-lint.json
@@ -17,6 +17,7 @@
     "prepare/**",
     "packages/rolldown/tests/fixtures/builtin-plugin/load-fallback/path-has-hashtag/**",
     "packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-preserve-modules-root-custom-sanitizer/**",
+    "packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-with-preserve-modules-root/**",
     "packages/debug/src/generated/**",
     "**/*.config.{js,mjs,cjs,ts,cts,mts}",
     "**/*.test.{js,mjs,cjs,ts,cts,mts}",

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -178,8 +178,8 @@ impl<'a> GenerateStage<'a> {
                 let p = PathBuf::from(sanitized_absolute_filename.as_str());
                 let relative_path = if p.is_absolute() {
                   if let Some(ref preserve_modules_root) = preserve_modules_root {
-                    if absolute_chunk_file_name.starts_with(preserve_modules_root.as_str()) {
-                      absolute_chunk_file_name[preserve_modules_root.len()..]
+                    if sanitized_absolute_filename.starts_with(preserve_modules_root.as_str()) {
+                      sanitized_absolute_filename[preserve_modules_root.len()..]
                         .trim_start_matches(['/', '\\'])
                         .to_string()
                     } else {

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -148,8 +148,8 @@ impl<'a> GenerateStage<'a> {
 
     let mut index_chunk_id_to_representative_name = FxHashMap::default();
 
-    // Sanitize preserveModulesRoot so that a custom sanitizeFileName (e.g. '+' → '__')
-    // doesn't break the starts_with prefix comparison against sanitized absolute filenames.
+    // Keep the sanitized preserveModulesRoot for preliminary filename generation,
+    // which still operates on sanitized chunk filenames later in this stage.
     let sanitized_preserve_modules_root =
       if let Some(ref preserve_modules_root) = self.options.preserve_modules_root {
         Some(self.options.sanitize_filename.call(preserve_modules_root).await?)
@@ -159,7 +159,7 @@ impl<'a> GenerateStage<'a> {
 
     let index_pre_generated_names_futures = chunk_graph.chunk_table.iter().map(|chunk| {
       let sanitize_filename = self.options.sanitize_filename.clone();
-      let preserve_modules_root = sanitized_preserve_modules_root.clone();
+      let preserve_modules_root = self.options.preserve_modules_root.clone();
       let input_base = chunk.input_base.clone();
       let virtual_dirname = self.options.virtual_dirname.clone();
       async move {
@@ -184,11 +184,13 @@ impl<'a> GenerateStage<'a> {
 
               // Apply the same logic as get_preserve_modules_chunk_name to include directory structure
               let chunk_name = {
-                let p = PathBuf::from(sanitized_absolute_filename.as_str());
+                let p = PathBuf::from(absolute_chunk_file_name.as_str());
                 let relative_path = if p.is_absolute() {
                   if let Some(ref preserve_modules_root) = preserve_modules_root {
-                    if sanitized_absolute_filename.starts_with(preserve_modules_root.as_str()) {
-                      sanitized_absolute_filename[preserve_modules_root.len()..]
+                    // Compare the original paths before sanitization so distinct directories
+                    // like `foo+bar` and `foo#bar` don't collide on the same sanitized prefix.
+                    if absolute_chunk_file_name.starts_with(preserve_modules_root.as_str()) {
+                      absolute_chunk_file_name[preserve_modules_root.len()..]
                         .trim_start_matches(['/', '\\'])
                         .to_string()
                     } else {
@@ -203,18 +205,19 @@ impl<'a> GenerateStage<'a> {
                 // `p` may be an absolute or relative path without extension, depending on the module path.
                 // Now we need to add the extension back when generating the relative chunk name.
                 // skip some common extension https://github.com/rollup/rollup/pull/4565/files
-                match ext.as_deref() {
+                let name_with_ext = match ext.as_deref() {
                   Some(e) if COMMON_JS_EXTENSIONS.contains(&e) => relative_path,
                   Some(e) if !e.is_empty() => format!("{relative_path}.{e}"),
                   _ => relative_path,
-                }
+                };
+                sanitize_filename.call(&name_with_ext).await?
               };
 
               let sanitized_representative_chunk_name =
                 sanitize_filename.call(&representative_chunk_name).await?;
               PreGeneratedChunkName {
                 representative_chunk_name: sanitized_representative_chunk_name,
-                chunk_name: chunk_name.into(),
+                chunk_name,
                 chunk_filename: sanitized_absolute_filename,
               }
             } else if meta.contains(rolldown_common::ChunkMeta::UserDefinedEntry) {

--- a/crates/rolldown/src/stages/generate_stage/mod.rs
+++ b/crates/rolldown/src/stages/generate_stage/mod.rs
@@ -148,9 +148,18 @@ impl<'a> GenerateStage<'a> {
 
     let mut index_chunk_id_to_representative_name = FxHashMap::default();
 
+    // Sanitize preserveModulesRoot so that a custom sanitizeFileName (e.g. '+' → '__')
+    // doesn't break the starts_with prefix comparison against sanitized absolute filenames.
+    let sanitized_preserve_modules_root =
+      if let Some(ref preserve_modules_root) = self.options.preserve_modules_root {
+        Some(self.options.sanitize_filename.call(preserve_modules_root).await?)
+      } else {
+        None
+      };
+
     let index_pre_generated_names_futures = chunk_graph.chunk_table.iter().map(|chunk| {
       let sanitize_filename = self.options.sanitize_filename.clone();
-      let preserve_modules_root = self.options.preserve_modules_root.clone();
+      let preserve_modules_root = sanitized_preserve_modules_root.clone();
       let input_base = chunk.input_base.clone();
       let virtual_dirname = self.options.virtual_dirname.clone();
       async move {
@@ -296,6 +305,7 @@ impl<'a> GenerateStage<'a> {
           &pre_generated_chunk_name.chunk_filename,
           &mut hash_placeholder_generator,
           &used_name_counts,
+          sanitized_preserve_modules_root.as_ref(),
         )
         .await?;
 

--- a/crates/rolldown/tests/rolldown/issues/7146/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7146/artifacts.snap
@@ -11,7 +11,7 @@ exports.__commonJSMin = __commonJSMin;
 
 ```
 
-## config.js
+## config.json.js
 
 ```js
 //#region config.json
@@ -31,7 +31,7 @@ Object.defineProperty(exports, "default", {
 ## main.js
 
 ```js
-const require_config$1 = require("./config.js");
+const require_config$1 = require("./config.json.js");
 //#region main.js
 const assert = require("assert");
 const config = require_config$1.default;
@@ -53,7 +53,7 @@ export { __commonJSMin, __require };
 
 ```
 
-### config.js
+### config.json.js
 
 ```js
 import { __commonJSMin } from "./_virtual/_rolldown/runtime.js";
@@ -71,7 +71,7 @@ export { require_config };
 
 ```js
 import { __require } from "./_virtual/_rolldown/runtime.js";
-import { require_config } from "./config.js";
+import { require_config } from "./config.json.js";
 //#region main.js
 const assert = __require("assert");
 const config = require_config();

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -217,14 +217,19 @@ impl Chunk {
         Ok(hash)
       }
     });
-    let chunk_name = self.get_preserve_modules_chunk_name(
-      options,
-      chunk_name.as_str(),
-      sanitized_preserve_modules_root,
-    );
+    let chunk_name_storage;
+    let chunk_name = if options.preserve_modules {
+      // Preserve-modules chunk names are already computed in generate_stage.
+      // Reusing the pre-rendered name avoids re-deriving it from a sanitized path here.
+      rollup_pre_rendered_chunk.name.as_str()
+    } else {
+      chunk_name_storage =
+        self.get_preserve_modules_chunk_name(options, chunk_name.as_str(), sanitized_preserve_modules_root);
+      chunk_name_storage.as_ref()
+    };
 
     let filename = filename_template
-      .render(Some(&chunk_name), Some(options.format.as_str()), None, hash_replacer)?
+      .render(Some(chunk_name), Some(options.format.as_str()), None, hash_replacer)?
       .into();
 
     let name = make_unique_name(&filename, used_name_counts);

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -223,8 +223,11 @@ impl Chunk {
       // Reusing the pre-rendered name avoids re-deriving it from a sanitized path here.
       rollup_pre_rendered_chunk.name.as_str()
     } else {
-      chunk_name_storage =
-        self.get_preserve_modules_chunk_name(options, chunk_name.as_str(), sanitized_preserve_modules_root);
+      chunk_name_storage = self.get_preserve_modules_chunk_name(
+        options,
+        chunk_name.as_str(),
+        sanitized_preserve_modules_root,
+      );
       chunk_name_storage.as_ref()
     };
 

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -189,6 +189,7 @@ impl Chunk {
     chunk_name: &ArcStr,
     hash_placeholder_generator: &mut HashPlaceholderGenerator,
     used_name_counts: &FxDashMap<ArcStr, u32>,
+    sanitized_preserve_modules_root: Option<&ArcStr>,
   ) -> anyhow::Result<PreliminaryFilename> {
     if let Some(file) = &options.file {
       let basename = PathBuf::from(file)
@@ -216,7 +217,11 @@ impl Chunk {
         Ok(hash)
       }
     });
-    let chunk_name = self.get_preserve_modules_chunk_name(options, chunk_name.as_str());
+    let chunk_name = self.get_preserve_modules_chunk_name(
+      options,
+      chunk_name.as_str(),
+      sanitized_preserve_modules_root,
+    );
 
     let filename = filename_template
       .render(Some(&chunk_name), Some(options.format.as_str()), None, hash_replacer)?
@@ -231,6 +236,7 @@ impl Chunk {
     &'b self,
     options: &NormalizedBundlerOptions,
     chunk_name: &'a str,
+    sanitized_preserve_modules_root: Option<&ArcStr>,
   ) -> Cow<'a, str> {
     if !options.preserve_modules {
       return Cow::Borrowed(chunk_name);
@@ -244,8 +250,8 @@ impl Chunk {
 
     let p = PathBuf::from(chunk_name);
     let p = if p.is_absolute() {
-      if let Some(ref preserve_modules_root) = options.preserve_modules_root {
-        if chunk_name.starts_with(preserve_modules_root) {
+      if let Some(preserve_modules_root) = sanitized_preserve_modules_root {
+        if chunk_name.starts_with(preserve_modules_root.as_str()) {
           return Cow::Borrowed(
             chunk_name[preserve_modules_root.len()..].trim_start_matches(['/', '\\']),
           );

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-preserve-modules-root-custom-sanitizer/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-preserve-modules-root-custom-sanitizer/_config.ts
@@ -1,0 +1,32 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+import { getOutputChunkNames } from '../../../../src/utils';
+
+// A custom sanitizeFileName that expands '+' to '__' makes the sanitized root longer
+// than the original, exposing byte-offset mismatches in preserveModulesRoot stripping.
+export default defineTest({
+  config: {
+    input: {
+      index: './src/+libs/index.js',
+    },
+    output: {
+      preserveModules: true,
+      preserveModulesRoot: 'src/+libs',
+      sanitizeFileName: (name) => name.replaceAll('+', '__'),
+    },
+  },
+  afterTest: (output) => {
+    // preserveModulesRoot stripping relies on absolute path prefixes,
+    // which differ on Windows — skip until cross-platform support is added.
+    if (process.platform !== 'win32') {
+      const chunkFileNames = getOutputChunkNames(output);
+      expect(chunkFileNames).toContain('index.js');
+      expect(chunkFileNames).toContain('helper.js');
+      // Verify no unsanitized '+' leaked into output filenames
+      for (const name of chunkFileNames) {
+        expect(name).not.toContain('+');
+        expect(name).not.toMatch(/libs\//);
+      }
+    }
+  },
+});

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-preserve-modules-root-custom-sanitizer/src/+libs/helper.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-preserve-modules-root-custom-sanitizer/src/+libs/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 42;
+}

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-preserve-modules-root-custom-sanitizer/src/+libs/index.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-preserve-modules-root-custom-sanitizer/src/+libs/index.js
@@ -1,0 +1,2 @@
+import { helper } from './helper';
+console.log(helper());

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-query-string/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-query-string/_config.ts
@@ -1,0 +1,47 @@
+import type { OutputChunk } from 'rolldown';
+import path from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  sequential: true,
+  config: {
+    input: {
+      entry: './entry.js',
+    },
+    output: {
+      dir: 'dist',
+      preserveModules: true,
+      preserveModulesRoot: '.',
+      entryFileNames(chunkInfo) {
+        return chunkInfo.name + '.js';
+      },
+    },
+    plugins: [
+      {
+        name: 'virtual-query-string',
+        resolveId(id, importer) {
+          if (id === 'virtual') {
+            // Simulate a Vue SFC virtual module with query parameters
+            return path.dirname(importer!) + '/Comp.vue?vue&type=script&setup=true&lang.ts';
+          }
+        },
+        load(id) {
+          if (id.includes('Comp.vue?vue')) {
+            return 'export const foo = 1; console.log(foo)';
+          }
+        },
+      },
+    ],
+  },
+  afterTest: (output) => {
+    const chunks = output.output.filter((item): item is OutputChunk => item.type === 'chunk');
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    for (const chunk of chunks) {
+      expect(chunk.fileName).not.toContain('?');
+      expect(chunk.fileName).not.toContain('&');
+      expect(chunk.name).not.toContain('?');
+      expect(chunk.name).not.toContain('&');
+    }
+  },
+});

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-query-string/entry.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-query-string/entry.js
@@ -1,2 +1,2 @@
-import { foo } from 'virtual'
-console.log(foo)
+import { foo } from 'virtual';
+console.log(foo);

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-query-string/entry.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-query-string/entry.js
@@ -1,0 +1,2 @@
+import { foo } from 'virtual'
+console.log(foo)

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-root-collision-default/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-root-collision-default/_config.ts
@@ -1,0 +1,57 @@
+import type { OutputChunk } from 'rolldown';
+import path from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  sequential: true,
+  config: {
+    input: {
+      entry: './entry.js',
+    },
+    output: {
+      dir: 'dist',
+      preserveModules: true,
+      preserveModulesRoot: 'foo+bar',
+    },
+    plugins: [
+      {
+        name: 'virtual-sanitize-root-collision-default',
+        resolveId(id, importer) {
+          if (!importer) return null;
+
+          const importerDir = path.dirname(importer);
+          if (id === 'inside') {
+            return path.join(importerDir, 'foo+bar', 'inside.js');
+          }
+          if (id === 'outside') {
+            return path.join(importerDir, 'foo#bar', 'outside.js');
+          }
+          return null;
+        },
+        load(id) {
+          if (id.includes(`${path.sep}foo+bar${path.sep}inside.js`)) {
+            return 'export const inside = "inside"';
+          }
+          if (id.includes(`${path.sep}foo#bar${path.sep}outside.js`)) {
+            return 'export const outside = "outside"';
+          }
+          return null;
+        },
+      },
+    ],
+  },
+  afterTest: (output) => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const chunks = output.output.filter((item): item is OutputChunk => item.type === 'chunk');
+    expect(chunks.map((chunk) => chunk.fileName)).toContain('inside.js');
+    expect(chunks.map((chunk) => chunk.fileName)).toContain('foo_bar/outside.js');
+    expect(chunks.map((chunk) => chunk.fileName)).not.toContain('outside.js');
+
+    const outsideChunk = chunks.find((chunk) => chunk.fileName === 'foo_bar/outside.js');
+    expect(outsideChunk?.name).toBe('foo_bar/outside');
+  },
+});

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-root-collision-default/entry.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-root-collision-default/entry.js
@@ -1,0 +1,4 @@
+import { inside } from 'inside';
+import { outside } from 'outside';
+
+console.log(inside, outside);

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-root-collision/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-root-collision/_config.ts
@@ -1,0 +1,60 @@
+import type { OutputChunk } from 'rolldown';
+import path from 'node:path';
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+export default defineTest({
+  sequential: true,
+  config: {
+    input: {
+      entry: './entry.js',
+    },
+    output: {
+      dir: 'dist',
+      preserveModules: true,
+      preserveModulesRoot: 'foo+bar',
+      entryFileNames(chunkInfo) {
+        return chunkInfo.name + '.js';
+      },
+    },
+    plugins: [
+      {
+        name: 'virtual-sanitize-root-collision',
+        resolveId(id, importer) {
+          if (!importer) return null;
+
+          const importerDir = path.dirname(importer);
+          if (id === 'inside') {
+            return path.join(importerDir, 'foo+bar', 'inside.js');
+          }
+          if (id === 'outside') {
+            return path.join(importerDir, 'foo#bar', 'outside.js');
+          }
+          return null;
+        },
+        load(id) {
+          if (id.includes(`${path.sep}foo+bar${path.sep}inside.js`)) {
+            return 'export const inside = "inside"';
+          }
+          if (id.includes(`${path.sep}foo#bar${path.sep}outside.js`)) {
+            return 'export const outside = "outside"';
+          }
+          return null;
+        },
+      },
+    ],
+  },
+  afterTest: (output) => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const chunks = output.output.filter((item): item is OutputChunk => item.type === 'chunk');
+    expect(chunks.map((chunk) => chunk.fileName)).toContain('inside.js');
+    expect(chunks.map((chunk) => chunk.fileName)).toContain('foo_bar/outside.js');
+    expect(chunks.map((chunk) => chunk.fileName)).not.toContain('outside.js');
+
+    const outsideChunk = chunks.find((chunk) => chunk.fileName === 'foo_bar/outside.js');
+    expect(outsideChunk?.name).toBe('foo_bar/outside');
+  },
+});

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-root-collision/entry.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-root-collision/entry.js
@@ -1,0 +1,4 @@
+import { inside } from 'inside';
+import { outside } from 'outside';
+
+console.log(inside, outside);

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-with-preserve-modules-root/_config.ts
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-with-preserve-modules-root/_config.ts
@@ -1,0 +1,28 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+import { getOutputChunkNames } from '../../../../src/utils';
+
+// Test that sanitizeFileName is applied to chunk filenames when preserveModulesRoot is set.
+// When a module's absolute path starts with the preserveModulesRoot, the relative portion
+// (used as chunk name) must also be sanitized. This was a bug where the unsanitized path
+// was used instead of the sanitized one.
+// See: https://github.com/rolldown/rolldown/issues/7554
+export default defineTest({
+  config: {
+    input: {
+      index: './src/index.js',
+    },
+    output: {
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+    },
+  },
+  afterTest: (output) => {
+    if (process.platform !== 'win32') {
+      const chunkFileNames = getOutputChunkNames(output);
+      // The '+module.js' file should be sanitized to '_module.js'
+      expect(chunkFileNames).toContain('_module.js');
+      expect(chunkFileNames).not.toContain('+module.js');
+    }
+  },
+});

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-with-preserve-modules-root/src/+module.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-with-preserve-modules-root/src/+module.js
@@ -1,0 +1,3 @@
+export function value() {
+  return 42;
+}

--- a/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-with-preserve-modules-root/src/index.js
+++ b/packages/rolldown/tests/fixtures/topics/preserve-modules/sanitize-filename-with-preserve-modules-root/src/index.js
@@ -1,0 +1,2 @@
+import { value } from './+module';
+console.log(value());


### PR DESCRIPTION
## Summary

- When `preserveModulesRoot` is set, the chunk name was derived from the unsanitized absolute filename, causing query string characters (`?`, `&`) to leak into `chunk.name` and subsequently into `fileName` when `entryFileNames` is a function
- This affected Vue SFC virtual modules (e.g. `Comp.vue?vue&type=script&setup=true&lang.ts`) in Vite lib mode, producing invalid filenames like `Comp.vue?vue&type=script&setup=true&lang.js`
- Fix: use the already-sanitized filename (`sanitized_absolute_filename`) instead of the raw one (`absolute_chunk_file_name`) when stripping the `preserveModulesRoot` prefix

Closes #8761

## Test plan

- [x] Added test fixture `sanitize-filename-query-string` that reproduces the bug with `preserveModulesRoot` + function-form `entryFileNames` + query string module IDs
- [x] Verified existing `sanitize-filename` test still passes
- [x] Verified with the [reproduction repo](https://github.com/ef81sp/rolldown-sanitize-filename-repro)