### PR TITLE
ci: migrate runners to namespace

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   autofix:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     name: Rust Validation
     needs: changes
     if: ${{ needs.changes.outputs.rust-changes == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 
@@ -143,7 +143,7 @@ jobs:
     name: Type Check
     needs: [changes, build-rolldown-ubuntu]
     if: needs.changes.outputs.node-changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     timeout-minutes: 10
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
@@ -248,7 +248,7 @@ jobs:
     name: Node Validation
     needs: changes
     if: ${{ needs.changes.outputs.node-changes == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 
@@ -293,7 +293,7 @@ jobs:
 
   repo-validation:
     name: Repo Validation
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 

--- a/.github/workflows/metric.yml
+++ b/.github/workflows/metric.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   compile-time-and-binary-size:
     name: Compile Time and Binary Size
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     outputs:
       time: ${{ steps.run.outputs.COMPILE_TIME }}
       binary_size: ${{ steps.run.outputs.BINARY_SIZE }}
@@ -46,7 +46,7 @@ jobs:
   metric:
     name: Metric
     needs: [compile-time-and-binary-size]
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - name: Checkout rolldown metric repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -16,7 +16,7 @@ jobs:
   run:
     if: ${{ inputs.changed }}
     name: Cargo Test
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ inputs.os == 'ubuntu-latest' && 'namespace-profile-linux-x64-default' || inputs.os == 'macos-latest' && 'namespace-profile-mac-default' || inputs.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/reusable-native-build.yml
+++ b/.github/workflows/reusable-native-build.yml
@@ -16,7 +16,7 @@ jobs:
   run:
     name: Build Rolldown Native
     if: ${{ inputs.changed }}
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ inputs.os == 'ubuntu-latest' && 'namespace-profile-linux-x64-default' || inputs.os == 'macos-latest' && 'namespace-profile-mac-default' || inputs.os }}
     timeout-minutes: 15
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1

--- a/.github/workflows/reusable-node-dev-server-test.yml
+++ b/.github/workflows/reusable-node-dev-server-test.yml
@@ -19,7 +19,7 @@ jobs:
   run:
     name: Node Dev Server Test
     if: ${{ inputs.changed }}
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ inputs.os == 'ubuntu-latest' && 'namespace-profile-linux-x64-default' || inputs.os == 'macos-latest' && 'namespace-profile-mac-default' || inputs.os }}
     timeout-minutes: 15
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -19,7 +19,7 @@ jobs:
   run:
     name: Node Test
     if: ${{ inputs.changed }}
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ inputs.os == 'ubuntu-latest' && 'namespace-profile-linux-x64-default' || inputs.os == 'macos-latest' && 'namespace-profile-mac-default' || inputs.os }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-release-build.yml
+++ b/.github/workflows/reusable-release-build.yml
@@ -75,7 +75,7 @@ jobs:
               pnpm --filter rolldown build-binding:wasi:release
 
     name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'namespace-profile-linux-x64-default' || matrix.os == 'macos-latest' && 'namespace-profile-mac-default' || matrix.os }}
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 
@@ -129,7 +129,7 @@ jobs:
 
   build-freebsd:
     name: Build FreeBSD
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
       - name: Build
@@ -176,7 +176,7 @@ jobs:
     strategy:
       fail-fast: false
     name: Build `@rolldown/pluginutils` Package
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 
@@ -198,7 +198,7 @@ jobs:
     strategy:
       fail-fast: false
     name: Build Node Package
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     env:
       RELEASING: 'true'
     steps:
@@ -247,7 +247,7 @@ jobs:
     strategy:
       fail-fast: false
     name: Build `@rolldown/browser` Package
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 
@@ -295,7 +295,7 @@ jobs:
     strategy:
       fail-fast: false
     name: Build `@rolldown/debug` Package
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 

--- a/.github/workflows/update-test-dependencies.yml
+++ b/.github/workflows/update-test-dependencies.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   update-rollup:
     name: Update Rollup Submodule
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     permissions:
       contents: write # for create-pull-request
       pull-requests: write # for create-pull-request
@@ -145,7 +145,7 @@ jobs:
 
   update-test262:
     name: Update Test262 Submodule
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     permissions:
       contents: write # for create-pull-request
       pull-requests: write # for create-pull-request
@@ -253,7 +253,7 @@ jobs:
 
   update-esbuild:
     name: Update esbuild Version
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     permissions:
       contents: write # for create-pull-request
       pull-requests: write # for create-pull-request

--- a/.github/workflows/vite-tests.yml
+++ b/.github/workflows/vite-tests.yml
@@ -35,7 +35,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'test: vite-tests')
     strategy:
       matrix:
-        target: [ubuntu-latest, windows-latest]
+        target: [namespace-profile-linux-x64-default, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.target }}
     timeout-minutes: 30

--- a/README.md
+++ b/README.md
@@ -100,3 +100,7 @@ Licenses of these projects are listed in [THIRD-PARTY-LICENSE](/THIRD-PARTY-LICE
 
 [badge-binary-size-windows]: [https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-win32-x64-msvc/latest]
 [badge-binary-size-macos]: [https://img.shields.io/npm/unpacked-size/%40rolldown%2Fbinding-darwin-arm64/latest]
+
+## Sponsors
+
+Thanks to [namespace.so](https://namespace.so) for powering our CI/CD pipelines with fast, free macOS and Linux runners.


### PR DESCRIPTION
## Summary

- Migrate heavy CI runners from `ubuntu-latest`/`macos-latest` to Namespace runners (`namespace-profile-linux-x64-default`/`namespace-profile-mac-default`)
- Workflows migrated: `ci.yml`, `reusable-release-build.yml`, `autofix.yml`, `metric.yml`, `update-test-dependencies.yml`, `vite-tests.yml`
- Lightweight jobs (GitHub API automation, lint PR title, link check, etc.) and benchmarks remain on `ubuntu-latest`

## Sponsors

Thanks to [namespace.so](https://namespace.so) for powering our CI/CD pipelines with fast, free macOS and Linux runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)