### PR TITLE
ci: revert namespace runners for release build jobs

### DIFF
--- a/.github/workflows/reusable-release-build.yml
+++ b/.github/workflows/reusable-release-build.yml
@@ -75,7 +75,7 @@ jobs:
               pnpm --filter rolldown build-binding:wasi:release
 
     name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'namespace-profile-linux-x64-default' || matrix.os == 'macos-latest' && 'namespace-profile-mac-default' || matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 
@@ -129,7 +129,7 @@ jobs:
 
   build-freebsd:
     name: Build FreeBSD
-    runs-on: namespace-profile-linux-x64-default
+    runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
       - name: Build


### PR DESCRIPTION
## Summary

- Revert matrix `runs-on` mapping back to `${{ matrix.os }}` for release build jobs
- Revert FreeBSD job back to `ubuntu-latest`

Namespace runners lack support for:
- pip/setuptools on macOS (PEP 668) — broke `aarch64-apple-darwin` and `x86_64-apple-darwin`
- `fdisk` — broke FreeBSD cross-platform build
- `elf64_s390` linker emulation — broke `s390x-unknown-linux-gnu` cross-compilation

Other namespace runner jobs (pluginutils, node packages, browser, debug) are unaffected and remain on namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)