### PR TITLE
fix(ci): use `vpx` instead of `vp exec` for `pkg-pr-new`

### DIFF
--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -138,4 +138,4 @@ jobs:
           find ./packages/ -type d -maxdepth 1 -exec cp THIRD-PARTY-LICENSE {} \;
 
       - name: Release
-        run: vp exec pkg-pr-new publish --compact --pnpm './packages/rolldown/npm/*' './packages/rolldown' './packages/browser' './packages/debug' './packages/pluginutils'
+        run: vpx pkg-pr-new publish --compact --pnpm './packages/rolldown/npm/*' './packages/rolldown' './packages/browser' './packages/debug' './packages/pluginutils'


### PR DESCRIPTION
## Summary

- `vp exec` only runs binaries in local `node_modules/.bin`, but `pkg-pr-new` is not a project dependency — it was previously invoked via `pnpx`
- Changed to `vpx` which is the Vite+ equivalent of `pnpx`/`npx` and can fetch remote packages
- Fixes https://github.com/rolldown/rolldown/actions/runs/23371042712/job/67995986137

🤖 Generated with [Claude Code](https://claude.com/claude-code)