### PR TITLE
fix: handle negative indices, overlapping ranges, and moved content in MagicString remove

### DIFF
--- a/crates/rolldown_binding/src/types/binding_magic_string.rs
+++ b/crates/rolldown_binding/src/types/binding_magic_string.rs
@@ -744,15 +744,29 @@ impl BindingMagicString<'_> {
   }
 
   #[napi]
-  pub fn remove<'s>(&'s mut self, this: This<'s>, start: u32, end: u32) -> napi::Result<This<'s>> {
+  pub fn remove<'s>(&'s mut self, this: This<'s>, start: i64, end: i64) -> napi::Result<This<'s>> {
+    // Apply offset, then handle negative indices (matching reset/slice pattern)
+    let start = self.utf16_to_byte_mapper.normalize_index(self.apply_offset_i64(start));
+    let end = self.utf16_to_byte_mapper.normalize_index(self.apply_offset_i64(end));
+
+    if start == end {
+      return Ok(this);
+    }
+
+    // Convert character indices to byte indices
+    // indices are non-negative after normalize_index and files are < 4GB
+    #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     let start_byte = self
       .utf16_to_byte_mapper
-      .utf16_to_byte(self.apply_offset_u32(start)?)
-      .ok_or_else(|| napi::Error::from_reason("Invalid start character index"))?;
+      .utf16_to_byte(start as u32)
+      .ok_or_else(|| napi::Error::from_reason("Character is out of bounds"))?;
+
+    #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     let end_byte = self
       .utf16_to_byte_mapper
-      .utf16_to_byte(self.apply_offset_u32(end)?)
-      .ok_or_else(|| napi::Error::from_reason("Invalid end character index"))?;
+      .utf16_to_byte(end as u32)
+      .ok_or_else(|| napi::Error::from_reason("Character is out of bounds"))?;
+
     self.inner.remove(start_byte, end_byte).map_err(napi::Error::from_reason)?;
     Ok(this)
   }

--- a/crates/string_wizard/src/magic_string/movement.rs
+++ b/crates/string_wizard/src/magic_string/movement.rs
@@ -1,16 +1,32 @@
-use crate::MagicString;
-
-use super::update::UpdateOptions;
+use crate::{MagicString, chunk::EditOptions};
 
 impl MagicString<'_> {
+  /// Removes characters in the range `[start, end)` from the generated output.
+  ///
+  /// Unlike `update`/`overwrite`, this iterates by original position (via `chunk_by_start`)
+  /// rather than by linked-list order, so it works correctly across moved content.
   pub fn remove(&mut self, start: u32, end: u32) -> Result<&mut Self, String> {
-    self.inner_update_with(
-      start,
-      end,
-      "".into(),
-      UpdateOptions { keep_original: false, overwrite: true },
-      false,
-    )
+    if start == end {
+      return Ok(self);
+    }
+    if start > end {
+      return Err(format!("end must be greater than start, got start: {start}, end: {end}"));
+    }
+
+    self.split_at(start)?;
+    self.split_at(end)?;
+
+    let mut chunk_idx = self.chunk_by_start.get(&start).copied();
+
+    while let Some(idx) = chunk_idx {
+      let chunk = &mut self.chunks[idx];
+      let chunk_end = chunk.end();
+      chunk.edit("".into(), EditOptions { overwrite: true, store_name: false });
+
+      chunk_idx = if end > chunk_end { self.chunk_by_start.get(&chunk_end).copied() } else { None };
+    }
+
+    Ok(self)
   }
 
   /// Moves the characters from start and end to index. Returns this.

--- a/packages/rolldown/tests/magic-string/MagicString.test.ts
+++ b/packages/rolldown/tests/magic-string/MagicString.test.ts
@@ -1261,14 +1261,14 @@ describe('MagicString', () => {
       assert.equal(s.toString(), 'abcdef');
     });
 
-    it.skip('should treat zero-length removals as a no-op', () => {
+    it('should treat zero-length removals as a no-op', () => {
       const s = new MagicString('abcdefghijkl');
 
       s.remove(0, 0).remove(6, 6).remove(9, -3);
       assert.equal(s.toString(), 'abcdefghijkl');
     });
 
-    it.skip('should remove overlapping ranges', () => {
+    it('should remove overlapping ranges', () => {
       const s1 = new MagicString('abcdefghijkl');
 
       s1.remove(3, 7).remove(5, 9);
@@ -1280,7 +1280,7 @@ describe('MagicString', () => {
       assert.equal(s2.toString(), 'abchijkl');
     });
 
-    it.skip('should remove overlapping ranges, redux', () => {
+    it('should remove overlapping ranges, redux', () => {
       const s = new MagicString('abccde');
 
       s.remove(2, 3); // c
@@ -1288,7 +1288,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), 'acde');
     });
 
-    it.skip('should remove modified ranges', () => {
+    it('should remove modified ranges', () => {
       const s = new MagicString('abcdefghi');
 
       s.overwrite(3, 6, 'DEF');
@@ -1306,7 +1306,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), '(ab);');
     });
 
-    it.skip('should remove interior inserts', () => {
+    it('should remove interior inserts', () => {
       const s = new MagicString('abc;');
 
       s.appendLeft(1, '[');
@@ -1330,7 +1330,7 @@ describe('MagicString', () => {
       assert.strictEqual(s.remove(3, 4), s);
     });
 
-    it.skip('removes across moved content', () => {
+    it('removes across moved content', () => {
       const s = new MagicString('abcdefghijkl');
 
       s.move(6, 9, 3);
@@ -1339,7 +1339,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), 'abchidejkl');
     });
 
-    it.skip('should accept negative indices', () => {
+    it('should accept negative indices', () => {
       const s = new MagicString('abcde');
       // "abcde"
       //     ^
@@ -1347,7 +1347,7 @@ describe('MagicString', () => {
       assert.equal(s.toString(), 'abce');
     });
 
-    it.skip('should throw error when using negative indices with empty string', () => {
+    it('should throw error when using negative indices with empty string', () => {
       const s = new MagicString('');
       assert.throws(() => s.remove(-2, -1), /Error: Character is out of bounds/);
     });

--- a/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
+++ b/packages/rolldown/tests/magic-string/rolldown-magic-string.test.ts
@@ -11,7 +11,7 @@ describe('offset', () => {
   describe('underflow guard — negative (index + offset) must throw, not panic', () => {
     it('remove() throws when offset causes index underflow', () => {
       const s = new MagicString('hello world', { offset: -1 });
-      assert.throws(() => s.remove(0, 1), /out of bounds/);
+      assert.throws(() => s.remove(0, 1), /end must be greater than start/);
     });
 
     it('prependLeft() throws when offset causes index underflow', () => {


### PR DESCRIPTION
## Summary

- Rewrote MagicString::remove to iterate by original position (chunk_by_start) instead of linked-list order, fixing incorrect behavior with moved content
- Added support for negative indices in remove() by accepting i64 and using normalize_index (matching reset/slice pattern)
- Fixed overlapping range removal — previously errored, now correctly handles partially/fully overlapping removes
- Zero-length removals (e.g., remove(0, 0) or remove(9, -3) where indices resolve to the same position) are now treated as no-ops

## Test plan

- Unskipped 8 previously-skipped tests in MagicString.test.ts:
  - should treat zero-length removals as a no-op
  - should remove overlapping ranges
  - should remove overlapping ranges, redux
  - should remove modified ranges
  - should remove interior inserts
  - removes across moved content
  - should accept negative indices
  - should throw error when using negative indices with empty string
- Updated offset underflow test expectation to match new error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)