### PR TITLE
fix(ci): unset VITE_PLUS_CLI_BIN in vite-tests workflow

### DIFF
--- a/.github/workflows/vite-tests.yml
+++ b/.github/workflows/vite-tests.yml
@@ -64,3 +64,6 @@ jobs:
 
       - name: Run Vite Tests
         run: vp run --filter vite-tests test
+        env:
+          # Unset to prevent leaking into loadEnv() test snapshots
+          VITE_PLUS_CLI_BIN: ''


### PR DESCRIPTION
## Summary

- Unset `VITE_PLUS_CLI_BIN` env var before running Vite tests
- The `setup-vp` action sets this env var, and since it starts with `VITE_`, `loadEnv()` picks it up, causing 4 snapshot mismatches in `env.spec.ts`
- Affects both Linux and Windows Vite test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)