### PR TITLE
refactor: extract canonical_ref_resolving_namespace helper

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -234,23 +234,14 @@ impl GenerateStage<'_> {
             stmt_info.referenced_symbols.iter().for_each(|reference_ref| {
               match reference_ref {
                 rolldown_common::SymbolOrMemberExprRef::Symbol(referenced) => {
-                  let mut canonical_ref = symbols.canonical_ref_for(*referenced);
-                  if let Some(namespace_alias) = &symbols.get(canonical_ref).namespace_alias {
-                    canonical_ref = namespace_alias.namespace_ref;
-                  }
-                  depended_symbols.insert(canonical_ref);
+                  depended_symbols.insert(symbols.canonical_ref_resolving_namespace(*referenced));
                 }
                 rolldown_common::SymbolOrMemberExprRef::MemberExpr(member_expr) => {
                   match member_expr.represent_symbol_ref(
                     &self.link_output.metas[module.idx].resolved_member_expr_refs,
                   ) {
                     Some(sym_ref) => {
-                      let mut canonical_ref = self.link_output.symbol_db.canonical_ref_for(sym_ref);
-                      let symbol = symbols.get(canonical_ref);
-                      if let Some(ref ns_alias) = symbol.namespace_alias {
-                        canonical_ref = ns_alias.namespace_ref;
-                      }
-                      depended_symbols.insert(canonical_ref);
+                      depended_symbols.insert(symbols.canonical_ref_resolving_namespace(sym_ref));
                     }
                     _ => {
                       // `None` means the member expression resolve to a ambiguous export, which means it actually resolve to nothing.
@@ -275,12 +266,8 @@ impl GenerateStage<'_> {
               // out a exported symbol that came from a cjs module.
               .filter(|resolved_export| !resolved_export.came_from_cjs)
             {
-              let mut canonical_ref = symbols.canonical_ref_for(export_ref.symbol_ref);
-              let symbol = symbols.get(canonical_ref);
-              if let Some(ns_alias) = &symbol.namespace_alias {
-                canonical_ref = ns_alias.namespace_ref;
-              }
-              depended_symbols.insert(canonical_ref);
+              depended_symbols
+                .insert(symbols.canonical_ref_resolving_namespace(export_ref.symbol_ref));
             }
           }
 

--- a/crates/rolldown_common/src/types/symbol_ref_db.rs
+++ b/crates/rolldown_common/src/types/symbol_ref_db.rs
@@ -350,6 +350,16 @@ impl SymbolRefDb {
     canonical
   }
 
+  /// Resolves a symbol reference to its canonical form, following namespace aliases.
+  pub fn canonical_ref_resolving_namespace(&self, symbol_ref: SymbolRef) -> SymbolRef {
+    let canonical_ref = self.canonical_ref_for(symbol_ref);
+    if let Some(namespace_alias) = &self.get(canonical_ref).namespace_alias {
+      namespace_alias.namespace_ref
+    } else {
+      canonical_ref
+    }
+  }
+
   pub fn is_declared_in_root_scope(&self, refer: SymbolRef) -> bool {
     let local_db = self.inner[refer.owner].unpack_ref();
     local_db.ast_scopes.symbol_scope_id(refer.symbol) == local_db.root_scope_id


### PR DESCRIPTION
## Summary

- Add `SymbolRefDb::canonical_ref_resolving_namespace()` that combines `canonical_ref_for()` + namespace alias resolution into a single method call
- Replace 3 duplicated occurrences of this pattern in `collect_depended_symbols`

Closes #8633

🤖 Generated with [Claude Code](https://claude.com/claude-code)