### PR TITLE
fix(ci): unset all VITE_PLUS_* env vars in vite-tests workflow

### DIFF
--- a/.github/workflows/vite-tests.yml
+++ b/.github/workflows/vite-tests.yml
@@ -63,7 +63,7 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Run Vite Tests
-        run: vp run --filter vite-tests test
-        env:
-          # Unset to prevent leaking into loadEnv() test snapshots
-          VITE_PLUS_CLI_BIN: ''
+        run: |
+          # Unset all VITE_PLUS_* env vars to prevent leaking into loadEnv() test snapshots
+          for var in $(env | grep '^VITE_PLUS_' | cut -d= -f1); do unset "$var"; done
+          vp run --filter vite-tests test


### PR DESCRIPTION
## Summary

- Replace specific `VITE_PLUS_CLI_BIN: ''` env override with a shell loop that unsets **all** `VITE_PLUS_*` env vars before running Vite tests
- Prevents any future env vars added by `setup-vp` from leaking into `loadEnv()` test snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)