### PR TITLE
fix(ci): use step-level env override to unset VITE_PLUS_CLI_BIN in vite tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,11 +238,7 @@ jobs:
 
       - name: Run Vite Tests
         if: ${{ needs.changes.outputs.node-changes == 'true' }}
-        env:
-          VITE_PLUS_CLI_BIN: ''
-        run: |
-          unset VITE_PLUS_CLI_BIN
-          vp run --filter vite-tests test
+        run: vp run --filter vite-tests test
 
   vite-test-windows:
     name: Vite Test Windows
@@ -280,12 +276,7 @@ jobs:
 
       - name: Run Vite Tests
         if: ${{ needs.changes.outputs.node-changes == 'true' }}
-        env:
-          VITE_PLUS_CLI_BIN: ''
-        shell: bash
-        run: |
-          unset VITE_PLUS_CLI_BIN
-          vp run --filter vite-tests test
+        run: vp run --filter vite-tests test
 
   build-rolldown-windows:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
       changed: ${{ needs.changes.outputs.node-changes == 'true' }}
 
   vite-test-ubuntu:
-    name: Vite Test
+    name: Vite Test Ubuntu
     needs: [changes, build-rolldown-ubuntu]
     if: |
       always() &&
@@ -238,13 +238,14 @@ jobs:
 
       - name: Run Vite Tests
         if: ${{ needs.changes.outputs.node-changes == 'true' }}
+        env:
+          VITE_PLUS_CLI_BIN: ''
         run: |
-          # Unset all VITE_PLUS_* env vars to prevent leaking into loadEnv() test snapshots
-          for var in $(env | grep '^VITE_PLUS_' | cut -d= -f1); do unset "$var"; done
+          unset VITE_PLUS_CLI_BIN
           vp run --filter vite-tests test
 
   vite-test-windows:
-    name: Vite Test
+    name: Vite Test Windows
     needs: [changes, build-rolldown-windows]
     if: |
       github.ref_name == 'main' &&
@@ -279,7 +280,12 @@ jobs:
 
       - name: Run Vite Tests
         if: ${{ needs.changes.outputs.node-changes == 'true' }}
-        run: vp run --filter vite-tests test
+        env:
+          VITE_PLUS_CLI_BIN: ''
+        shell: bash
+        run: |
+          unset VITE_PLUS_CLI_BIN
+          vp run --filter vite-tests test
 
   build-rolldown-windows:
     needs: changes

--- a/packages/vite-tests/run.ts
+++ b/packages/vite-tests/run.ts
@@ -76,6 +76,13 @@ await runCmdAndPipeOrExit(
   ['pnpm', ['run', 'build'], { nodeOptions: { cwd: REPO_PATH } }],
 );
 
+// Remove VITE_PLUS_* env vars to prevent leaking into loadEnv() test snapshots
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith('VITE_PLUS_')) {
+    delete process.env[key];
+  }
+}
+
 const failed = []
 
 const failedTestUnit = await runCmdAndPipe(


### PR DESCRIPTION
## Summary

- The `setup-vp` action writes `VITE_PLUS_CLI_BIN` to `$GITHUB_ENV`, which leaks into Vite's `loadEnv()` and breaks 4 `env.spec.ts` snapshot tests
- The previous `for` loop `unset` approach was insufficient — use step-level `env:` to override the variable to empty, then `unset` it in the script
- Applied the fix to both Linux and Windows vite test jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)