### PR TITLE
chore(bench): use mimalloc as global allocator in bench crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ version = "0.1.0"
 dependencies = [
  "criterion2",
  "ignore",
+ "mimalloc-safe",
  "rolldown",
  "rolldown_fs",
  "rolldown_resolver",

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -32,3 +32,4 @@ codspeed = ["criterion2/codspeed"]
 
 [dev-dependencies]
 rustc-hash = { workspace = true }
+mimalloc-safe = { workspace = true }

--- a/crates/bench/benches/bench.rs
+++ b/crates/bench/benches/bench.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
+
 use bench::{BenchMode, DeriveOptions, bench_preset, rome_ts_preset, run_bench_group};
 use criterion::{Criterion, criterion_group, criterion_main};
 use rolldown::{BundlerOptions, ModuleType};


### PR DESCRIPTION
The bench crate was using the system allocator instead of mimalloc, making benchmark results unrepresentative of production performance. Adds `mimalloc-safe` as a dependency and sets `#[global_allocator]` so benchmarks match the actual NAPI bindings allocator configuration.