### PR TITLE
fix: generate init calls for excluded re-exports in strict execution order

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -124,6 +124,53 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     expr
   }
 
+  /// For excluded re-export statements in strict execution order, generate init
+  /// calls by traversing through non-included barrel modules to find included
+  /// importees whose wrappers are available in this chunk.
+  fn generate_transitive_esm_init(
+    &mut self,
+    module_idx: ModuleIdx,
+    body: &mut allocator::Vec<'ast, Statement<'ast>>,
+  ) {
+    let Module::Normal(importee) = &self.ctx.modules[module_idx] else { return };
+    let importee_linking_info = &self.ctx.linking_infos[importee.idx];
+    if !matches!(importee_linking_info.wrap_kind(), WrapKind::Esm) {
+      return;
+    }
+
+    // Only generate init calls for modules in the same chunk whose wrapper is
+    // declared (i.e. the module is included in the output).
+    if importee_linking_info.is_included
+      && self.ctx.chunk_graph.module_to_chunk[importee.idx] == Some(self.ctx.chunk_idx)
+    {
+      if self.generated_init_esm_importee_ids.contains(&importee.idx) {
+        return;
+      }
+      self.generated_init_esm_importee_ids.insert(importee.idx);
+      let (wrapper_ref_expr, _) = self.finalized_expr_for_symbol_ref(
+        importee_linking_info.wrapper_ref.unwrap(),
+        false,
+        false,
+      );
+      let init_call = self.snippet.builder.expression_call(
+        SPAN,
+        wrapper_ref_expr,
+        NONE,
+        self.snippet.builder.vec(),
+        false,
+      );
+      body.push(self.snippet.builder.statement_expression(SPAN, init_call));
+    } else {
+      // Importee is not included (barrel module) — traverse its import records
+      // to find included importees transitively.
+      for rec in &importee.import_records {
+        if let Some(sub_importee_idx) = rec.resolved_module {
+          self.generate_transitive_esm_init(sub_importee_idx, body);
+        }
+      }
+    }
+  }
+
   /// If return true the import stmt should be removed,
   /// or transform the import stmt to target form.
   fn transform_or_remove_import_export_stmt(
@@ -1268,11 +1315,29 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       .enumerate()
       .zip(self.ctx.module.stmt_infos.iter_enumerated().skip(1))
       .for_each(|((_top_stmt_idx, mut top_stmt), (stmt_info_idx, _stmt_info))| {
-        if !self.ctx.linking_info.stmt_info_included.has_bit(stmt_info_idx) {
+        let is_stmt_included = self.ctx.linking_info.stmt_info_included.has_bit(stmt_info_idx);
+
+        if !is_stmt_included {
+          // For ESM-wrapped modules, excluded re-export statements still need
+          // init calls for correct initialization order.
+          if matches!(self.ctx.linking_info.wrap_kind(), WrapKind::Esm) {
+            let rec_idx = if let Some(export_all) = top_stmt.as_export_all_declaration() {
+              Some(self.ctx.module.imports[&export_all.span])
+            } else if let Some(named_decl) = top_stmt.as_export_named_declaration() {
+              named_decl.source.as_ref().map(|_| self.ctx.module.imports[&named_decl.span])
+            } else {
+              None
+            };
+            if let Some(importee_idx) =
+              rec_idx.and_then(|idx| self.ctx.module.import_records[idx].resolved_module)
+            {
+              self.generate_transitive_esm_init(importee_idx, &mut program.body);
+            }
+          }
           return;
         }
 
-        let is_module_decl = top_stmt.is_module_declaration_with_source();
+        let is_module_decl = is_stmt_included && top_stmt.is_module_declaration_with_source();
 
         if let Some(import_decl) = top_stmt.as_import_declaration() {
           let span = import_decl.span;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "strictExecutionOrder": true,
+    "minify": false
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/_test.mjs
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { star } from './dist/main.js';
+
+assert.strictEqual(star.foo, 1);

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/artifacts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region dep.js
+var init_dep = __esmMin((() => {}));
+
+//#endregion
+//#region leaf.js
+var foo;
+var init_leaf = __esmMin((() => {
+	init_dep();
+	;
+	foo = 1;
+}));
+
+//#endregion
+//#region inner.js
+var inner_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+var init_inner = __esmMin((() => {
+	init_leaf();
+}));
+
+//#endregion
+//#region outer.js
+var init_outer = __esmMin((() => {
+	init_inner();
+}));
+
+//#endregion
+//#region main.js
+var init_main = __esmMin((() => {
+	init_outer();
+}));
+
+//#endregion
+init_main();
+export { inner_exports as star };
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/dep.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/dep.js
@@ -1,0 +1,5 @@
+let one;
+
+one = 1;
+
+export { one };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/inner.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/inner.js
@@ -1,0 +1,1 @@
+export { foo } from './leaf.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/leaf.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/leaf.js
@@ -1,0 +1,7 @@
+import { one } from './dep.js';
+
+let foo;
+
+foo = one;
+
+export { foo };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/main.js
@@ -1,0 +1,3 @@
+import { unused } from './unused.js';
+
+export { star } from './outer.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/ns.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/ns.js
@@ -1,0 +1,3 @@
+import * as star from './inner.js';
+
+export { star };

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/outer.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/outer.js
@@ -1,0 +1,1 @@
+export { star } from './ns.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/package.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/unused.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/exports_chain_shared_barrel_fixpoint/unused.js
@@ -1,0 +1,1 @@
+export { foo as unused } from './inner.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "strictExecutionOrder": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/_test.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+import { Foo, fooClasses, getFooUtilityClass } from './dist/main.js';
+
+assert.deepStrictEqual(Foo, { name: 'Foo', root: 'MuiFoo-root' });
+assert.deepStrictEqual(fooClasses, { root: 'MuiFoo-root' });
+assert.strictEqual(getFooUtilityClass('root'), 'MuiFoo-root');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/artifacts.snap
@@ -1,0 +1,42 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region components/Foo/fooClasses.js
+function getFooUtilityClass(slot) {
+	return "MuiFoo-" + slot;
+}
+var fooClasses;
+var init_fooClasses = __esmMin((() => {
+	fooClasses = { root: "MuiFoo-root" };
+}));
+//#endregion
+//#region components/Foo/Foo.js
+var Foo;
+var init_Foo$1 = __esmMin((() => {
+	init_fooClasses();
+	Foo = {
+		name: "Foo",
+		root: fooClasses.root
+	};
+}));
+//#endregion
+//#region components/Foo/index.js
+var init_Foo = __esmMin((() => {
+	init_Foo$1();
+	init_fooClasses();
+	init_fooClasses();
+}));
+//#endregion
+__esmMin((() => {
+	init_Foo();
+	init_Foo();
+}))();
+export { Foo, fooClasses, getFooUtilityClass };
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/components/Foo/Foo.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/components/Foo/Foo.js
@@ -1,0 +1,3 @@
+import { fooClasses } from './fooClasses.js';
+const Foo = { name: 'Foo', root: fooClasses.root };
+export default Foo;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/components/Foo/fooClasses.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/components/Foo/fooClasses.js
@@ -1,0 +1,5 @@
+export function getFooUtilityClass(slot) {
+  return 'MuiFoo-' + slot;
+}
+export const fooClasses = { root: 'MuiFoo-root' };
+export default fooClasses;

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/components/Foo/index.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/components/Foo/index.js
@@ -1,0 +1,3 @@
+export { default } from './Foo.js';
+export { default as fooClasses } from './fooClasses.js';
+export * from './fooClasses.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/main.js
@@ -1,0 +1,4 @@
+// Main barrel — this is the ENTRY POINT
+// Re-exports from sub-module barrels (like @mui/material/index.js)
+export { default as Foo } from './components/Foo/index.js';
+export * from './components/Foo/index.js';

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/package.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_8777/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}


### PR DESCRIPTION
Closes #8777

## Summary
- In strict execution order mode, tree-shaken re-export statements (`export { x } from` / `export * from`) in ESM-wrapped modules were missing `init_*()` calls, causing runtime failures with barrel-file patterns (e.g. MUI-style re-exports)
- Fixes this in the module finalizer by generating init calls for excluded re-export statements, traversing transitively through non-included barrel modules to find the included importees
- Adds two regression tests: `issue_8777` (MUI-style barrel re-exports) and `exports_chain_shared_barrel_fixpoint` (multi-level barrel chain)