### PR TITLE
chore: add expectWarning option to test config

### DIFF
--- a/crates/rolldown/tests/rolldown/warnings/eval/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/eval/_config.json
@@ -1,1 +1,3 @@
-{}
+{
+  "expectWarning": true
+}

--- a/crates/rolldown/tests/rolldown/warnings/indirect_eval_optional_call/_config.json
+++ b/crates/rolldown/tests/rolldown/warnings/indirect_eval_optional_call/_config.json
@@ -1,1 +1,3 @@
-{}
+{
+  "expectWarning": false
+}

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -22,6 +22,14 @@
       "type": "boolean",
       "default": false
     },
+    "expectWarning": {
+      "description": "If `true`, the fixture are expected to produce warnings. If `false`, the fixture are expected\nto produce no warnings. If not set, no assertion is made on warnings.",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "default": null
+    },
     "_comment": {
       "description": "A workaround for writing comments in JSON.",
       "type": "string",

--- a/crates/rolldown_testing/src/integration_test.rs
+++ b/crates/rolldown_testing/src/integration_test.rs
@@ -133,6 +133,7 @@ impl IntegrationTest {
   }
 
   /// Run multiple bundler configurations in HMR mode
+  #[expect(clippy::too_many_lines)]
   async fn run_multiple_for_dev(
     &self,
     multiple_options: Vec<NamedBundlerOptions>,
@@ -298,6 +299,20 @@ impl IntegrationTest {
             !self.test_meta.expect_error,
             "Expected the bundling to be failed with diagnosable errors, but got success"
           );
+          if let Some(expect_warning) = self.test_meta.expect_warning {
+            if expect_warning {
+              assert!(
+                !output.warnings.is_empty(),
+                "Expected the bundling to produce warnings, but got none"
+              );
+            } else {
+              assert!(
+                output.warnings.is_empty(),
+                "Expected the bundling to produce no warnings, but got: {:#?}",
+                output.warnings
+              );
+            }
+          }
 
           // Process HMR updates and patches for execution
           let mut patch_chunks: Vec<String> = vec![];
@@ -434,6 +449,20 @@ impl IntegrationTest {
             !self.test_meta.expect_error,
             "Expected the bundling to be failed with diagnosable errors, but got success"
           );
+          if let Some(expect_warning) = self.test_meta.expect_warning {
+            if expect_warning {
+              assert!(
+                !output.warnings.is_empty(),
+                "Expected the bundling to produce warnings, but got none"
+              );
+            } else {
+              assert!(
+                output.warnings.is_empty(),
+                "Expected the bundling to produce no warnings, but got: {:#?}",
+                output.warnings
+              );
+            }
+          }
           let config_name = named_options
             .config_name
             .as_deref()

--- a/crates/rolldown_testing_config/src/test_meta.rs
+++ b/crates/rolldown_testing_config/src/test_meta.rs
@@ -13,6 +13,10 @@ pub struct TestMeta {
   #[serde(default)]
   /// If `true`, the fixture are expected to fail to compile/build.
   pub expect_error: bool,
+  #[serde(default)]
+  /// If `true`, the fixture are expected to produce warnings. If `false`, the fixture are expected
+  /// to produce no warnings. If not set, no assertion is made on warnings.
+  pub expect_warning: Option<bool>,
   #[serde(default, rename = "_comment")]
   /// A workaround for writing comments in JSON.
   pub _comment: String,


### PR DESCRIPTION
## Summary

- Add `expectWarning` option to `_config.json` for integration test fixtures
- Tri-state (`true` / `false` / `null`): `true` asserts warnings are produced, `false` asserts no warnings, `null` (default) skips the assertion
- Update existing `warnings/eval` and `warnings/indirect_eval_optional_call` fixtures to use the new option
- Add assertion logic in both single and multi-config test paths in `integration_test.rs`

## Test plan

- [x] `warnings/eval` fixture uses `"expectWarning": true`
- [x] `warnings/indirect_eval_optional_call` fixture uses `"expectWarning": false`
- [x] Run `just dt crates/rolldown/tests/rolldown/warnings/eval/_config.json` to verify warning assertion passes
- [x] Run `just dt crates/rolldown/tests/rolldown/warnings/indirect_eval_optional_call/_config.json` to verify no-warning assertion passes