### PR TITLE
fix(types): remove `pluginName` from `MinimalPluginContext`

### DIFF
--- a/packages/rolldown/src/plugin/minimal-plugin-context.ts
+++ b/packages/rolldown/src/plugin/minimal-plugin-context.ts
@@ -44,8 +44,6 @@ export interface PluginContextMeta {
 
 /** @category Plugin APIs */
 export interface MinimalPluginContext {
-  /** @hidden */
-  readonly pluginName: string;
   /**
    * Similar to {@linkcode warn | this.warn}, except that it will also abort
    * the bundling process with an error.


### PR DESCRIPTION
This was added as an implementation detail was not meant to be exposed.
https://github.com/rolldown/rolldown/commit/265fbf5f57cce8b78502ad8cf73a4e52580381d4#diff-e4c17069b0d70ac2b066e8bc15e8540df4d9c4a64c6142630aa3098213949324
