### PR TITLE
fix: forward test filters through vp run

### DIFF
--- a/justfile
+++ b/justfile
@@ -100,7 +100,7 @@ test-node-hmr *args: build build-test-dev-server
   just test-node-hmr-only {{ args }}
 
 test-node-hmr-only *args:
-  vp run --filter @rolldown/test-dev-server-tests test {{ args }}
+  vp run --filter @rolldown/test-dev-server-tests test -- {{ args }}
 
 # Run Vite's test suite to check Rolldown's behaviors.
 test-vite: # We don't use `test-node-vite` because it's not expected to run in `just test-node`.
@@ -113,12 +113,12 @@ t-node: t-node-rolldown t-node-rollup
 
 # Run Rolldown's tests without building Rolldown.
 t-node-rolldown *args="":
-  vp run --filter rolldown-tests test:main {{ args }}
-  vp run --filter rolldown-tests test:watcher {{ args }}
+  vp run --filter rolldown-tests test:main -- {{ args }}
+  vp run --filter rolldown-tests test:watcher -- {{ args }}
 
 # Run Rollup's test suite without building Rolldown.
 t-node-rollup *args="":
-  vp run --filter rollup-tests test {{ args }}
+  vp run --filter rollup-tests test -- {{ args }}
 
 # Run specific rust test without enabling extended tests.
 [unix]


### PR DESCRIPTION
## Summary
- stop `vp run` from consuming forwarded test filters by inserting `--` before passthrough args in the affected `just` recipes
- add a `just --dry-run` regression test covering rolldown, rollup, and HMR test command forwarding

## Test Plan
- `vp run --filter rolldown-tests test:main -- justfile.test.ts`
- `just test-node-rolldown -t resolve/alias`
