### PR TITLE
fix: correct execution order of transferred CJS init calls

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/8863/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8863/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "treeshake": false
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8863/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8863/artifacts.snap
@@ -1,0 +1,57 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region sheets.cjs
+var require_sheets = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	var GC;
+	(function() {
+		GC ??= {};
+		GC.Spread = {};
+	})();
+	(function(t) {
+		module.exports = t;
+	})(GC || {});
+}));
+//#endregion
+//#region resource.cjs
+var require_resource = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	(function(factory) {
+		if (typeof module === "object" && typeof module.exports === "object") module.exports = factory(require_sheets());
+		else factory(GC);
+	})(function(GC) {
+		GC = GC || {};
+		GC.Spread = GC.Spread || {};
+		GC.Spread.Sheets = GC.Spread.Sheets || {};
+		GC.Spread.Sheets.Designer = GC.Spread.Sheets.Designer || {};
+		GC.Spread.Sheets.Designer.DR = GC.Spread.Sheets.Designer.DR || {};
+		return {};
+	});
+}));
+//#endregion
+//#region designer.cjs
+var require_designer = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	(function(factory) {
+		if (typeof module === "object" && typeof module.exports === "object") {
+			let SJS_NS = require_sheets();
+			factory(SJS_NS);
+			module.exports = SJS_NS;
+		} else factory(GC);
+	})(function(GC) {
+		console.log(GC.Spread.Sheets.Designer.DR.res);
+		GC = GC || {};
+		GC.Spread = GC.Spread || {};
+		GC.Spread.Sheets = GC.Spread.Sheets || {};
+		GC.Spread.Sheets.Designer = GC.Spread.Sheets.Designer || {};
+	});
+}));
+require_resource();
+require_designer();
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/8863/designer.cjs
+++ b/crates/rolldown/tests/rolldown/issues/8863/designer.cjs
@@ -1,0 +1,15 @@
+(function (factory) {
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    let SJS_NS = require('./sheets.cjs');
+    factory(SJS_NS);
+    module.exports = SJS_NS;
+  } else {
+    factory(GC);
+  }
+})(function (GC) {
+  console.log(GC.Spread.Sheets.Designer.DR.res);
+  GC = GC || {};
+  GC.Spread = GC.Spread || {};
+  GC.Spread.Sheets = GC.Spread.Sheets || {};
+  GC.Spread.Sheets.Designer = GC.Spread.Sheets.Designer || {};
+});

--- a/crates/rolldown/tests/rolldown/issues/8863/main.js
+++ b/crates/rolldown/tests/rolldown/issues/8863/main.js
@@ -1,0 +1,3 @@
+import './resource.cjs';
+import './designer.cjs';
+import './noop.js';

--- a/crates/rolldown/tests/rolldown/issues/8863/noop.js
+++ b/crates/rolldown/tests/rolldown/issues/8863/noop.js
@@ -1,0 +1,3 @@
+// Empty module that gets included when treeshake is disabled.
+// This triggers ensure_lazy_module_initialization_order to transfer
+// CJS init calls, which must maintain the correct order.

--- a/crates/rolldown/tests/rolldown/issues/8863/resource.cjs
+++ b/crates/rolldown/tests/rolldown/issues/8863/resource.cjs
@@ -1,0 +1,14 @@
+(function (factory) {
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = factory(require('./sheets.cjs'));
+  } else {
+    factory(GC);
+  }
+})(function (GC) {
+  GC = GC || {};
+  GC.Spread = GC.Spread || {};
+  GC.Spread.Sheets = GC.Spread.Sheets || {};
+  GC.Spread.Sheets.Designer = GC.Spread.Sheets.Designer || {};
+  GC.Spread.Sheets.Designer.DR = GC.Spread.Sheets.Designer.DR || {};
+  return {};
+});

--- a/crates/rolldown/tests/rolldown/issues/8863/sheets.cjs
+++ b/crates/rolldown/tests/rolldown/issues/8863/sheets.cjs
@@ -1,0 +1,8 @@
+var GC;
+!(function () {
+  GC ??= {};
+  GC.Spread = {};
+})();
+(function (t) {
+  module.exports = t;
+})(GC || {});

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs/artifacts.snap
@@ -22,8 +22,8 @@ var require_basic_ref_with_named_default = /* @__PURE__ */ __commonJSMin(((expor
 var require_cjs$2 = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "export-star-from-cjs-a";
 }));
-require_basic_ref_with_named_default();
 require_basic_ns();
+require_basic_ref_with_named_default();
 __reExport(/* @__PURE__ */ __exportAll({}), /* @__PURE__ */ __toESM(require_cjs$2()));
 __reExport(/* @__PURE__ */ __exportAll({}), /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "nested-export-star-from-cjs-a";

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_inline_const/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_inline_const/artifacts.snap
@@ -22,8 +22,8 @@ var require_basic_ref_with_named_default = /* @__PURE__ */ __commonJSMin(((expor
 var require_cjs$2 = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "export-star-from-cjs-a";
 }));
-require_basic_ref_with_named_default();
 require_basic_ns();
+require_basic_ref_with_named_default();
 __reExport(/* @__PURE__ */ __exportAll({}), /* @__PURE__ */ __toESM(require_cjs$2()));
 __reExport(/* @__PURE__ */ __exportAll({}), /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.a = "named-import-export-star-from-cjs-a";

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -135,6 +135,6 @@ pub struct PrependRenderedImport {
 
 impl SourceMutation for PrependRenderedImport {
   fn apply(&self, magic_string: &mut string_wizard::MagicString<'_>) {
-    magic_string.prepend(self.intro.clone());
+    magic_string.append_intro(self.intro.clone());
   }
 }


### PR DESCRIPTION
## Summary
- When `ensure_lazy_module_initialization_order` transfers CJS init calls to a non-wrapped module, the `PrependRenderedImport` mutations were applied using `prepend()` (`push_front`), which reversed the order of multiple init calls.
- Changed to `append_intro()` (`push_back`) to maintain correct insertion order.

Closes #8863

## Test plan
- Added regression test in `crates/rolldown/tests/rolldown/issues/8863/` reproducing the scenario: ESM entry importing two CJS modules + a no-op module with `treeshake: false`
- Snapshot verifies `require_resource()` executes before `require_designer()`
- All 1648 existing integration tests pass