### PR TITLE
fix: `is_top_level` incorrectly treats strict-mode scopes as top-level

### DIFF
--- a/crates/rolldown/tests/rolldown/issues/8793/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8793/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "index",
+        "import": "index.js"
+      },
+      {
+        "name": "chunk",
+        "import": "chunk.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8793/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8793/artifacts.snap
@@ -1,0 +1,38 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## chunk.js
+
+```js
+//#region chunk.js
+function Ub() {}
+//#endregion
+export { Ub as Pb };
+
+```
+
+## index.js
+
+```js
+import { Pb as Ub$1 } from "./chunk.js";
+//#region index.js
+console.log(() => {
+	"use strict";
+	return 0;
+});
+var Ub = [
+	"open",
+	"opening",
+	"toggle"
+];
+console.log(class {
+	constructor() {
+		console.log(Ub);
+	}
+	static p = Ub$1({});
+});
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/8793/chunk.js
+++ b/crates/rolldown/tests/rolldown/issues/8793/chunk.js
@@ -1,0 +1,3 @@
+function Ub() {}
+
+export { Ub as Pb };

--- a/crates/rolldown/tests/rolldown/issues/8793/index.js
+++ b/crates/rolldown/tests/rolldown/issues/8793/index.js
@@ -1,0 +1,16 @@
+import { Pb as He } from './chunk.js';
+
+console.log(() => {
+  'use strict';
+  return 0;
+});
+
+var Ub = ['open', 'opening', 'toggle'];
+console.log(
+  class {
+    constructor() {
+      console.log(Ub);
+    }
+    static p = He({});
+  },
+);

--- a/crates/rolldown_ecmascript_utils/src/scope.rs
+++ b/crates/rolldown_ecmascript_utils/src/scope.rs
@@ -18,8 +18,8 @@ use oxc::semantic::ScopeFlags;
 /// }
 /// ```
 pub fn is_top_level(scope_stack: &[ScopeFlags]) -> bool {
-  scope_stack.iter().rev().all(|flag| {
-    flag.intersects(ScopeFlags::Top | ScopeFlags::StrictMode | ScopeFlags::ClassStaticBlock)
-      || flag.is_empty()
-  })
+  scope_stack
+    .iter()
+    .rev()
+    .all(|flag| flag.is_top() || flag.contains(ScopeFlags::ClassStaticBlock) || flag.is_block())
 }


### PR DESCRIPTION
Closes #8793

## Summary

Fix `is_top_level()` in `crates/rolldown_ecmascript_utils/src/scope.rs` which incorrectly treated scopes with `ScopeFlags::StrictMode` as "top-level" (eagerly evaluated during module evaluation).

## Root Cause

`is_top_level()` determines whether the current AST position executes eagerly during module evaluation (as opposed to being deferred inside a function). It checks that all scopes in the stack are "transparent" — i.e., `Top`, `ClassStaticBlock`, or empty block scopes.

The bug was that `ScopeFlags::StrictMode` was included in the transparency check via `intersects`:

```rust
flag.intersects(ScopeFlags::Top | ScopeFlags::StrictMode | ScopeFlags::ClassStaticBlock)
```

`StrictMode` is a **modifier flag** inherited by child scopes, not a scope boundary indicator. An arrow function with `"use strict"` gets scope flags like `Arrow | Function | StrictMode` — the `intersects(StrictMode)` check made this appear "transparent", so code inside the arrow function was incorrectly considered top-level.

## How This Causes Colliding Variable Names

Given this input:

```js
// index.js (entry)
import { Pb as He } from "./chunk.js";
console.log(() => { "use strict"; return 0 })
var Ub = ["open", "opening", "toggle"];
console.log(class {
  constructor() { console.log(Ub); }
  static p = He({});
})
```

The chain of failure:

1. **`is_top_level()` returns `true` inside the arrow function** — because its `StrictMode` flag matches the `intersects` check
2. **Scanner detects `return 0` as a top-level return** — top-level `return` is only valid in CommonJS, so the module gets `ExportsKind::CommonJs`
3. **Module gets CJS-wrapped** — its code is placed inside a `__commonJSMin(() => { ... })` closure
4. **Deconfliction skips local variables in CJS-wrapped modules** — because their code runs in a nested closure, not at chunk root scope. So the local `var Ub` (array) is NOT registered in the root scope renamer
5. **Cross-chunk import gets name `Ub`** — since the local `var Ub` wasn't registered, no conflict is detected, and the imported function keeps the name `Ub`
6. **Collision at runtime** — `static p = Ub({})` resolves to the local array `["open", "opening", "toggle"]` instead of the imported function, causing `TypeError: Ub is not a function`

## Fix

```rust
flag.is_top() || flag.contains(ScopeFlags::ClassStaticBlock) || flag.is_block()
```

This correctly handles all cases:
- **Top scope + StrictMode** (ESM modules): `Top` after stripping → transparent ✓
- **Block scope + StrictMode**: empty after stripping → transparent ✓
- **Arrow/function + StrictMode**: `Arrow|Function` after stripping → NOT transparent ✓

## Test plan

- [x] Added reproduction test case in `crates/rolldown/tests/rolldown/issues/8793/`
- [x] All 1645 integration tests pass
- [x] `rolldown_ecmascript_utils` unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)