### PR TITLE
chore(deps): update rollup submodule for tests to v4.60.0

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -76,6 +76,7 @@
       "ignoreDependencies": [
         "acorn",
         "acorn-import-assertions",
+        "acorn-import-phases",
         "locate-character",
         "requirejs",
         "terser",

--- a/packages/rollup-tests/package.json
+++ b/packages/rollup-tests/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "acorn-import-assertions": "catalog:",
+    "acorn-import-phases": "^1.0.4",
     "fixturify": "catalog:",
     "fs-extra": "catalog:",
     "mocha": "catalog:",

--- a/packages/rollup-tests/src/ignored-by-unsupported-features.md
+++ b/packages/rollup-tests/src/ignored-by-unsupported-features.md
@@ -297,6 +297,13 @@
  - rollup@function@deprecated@transform-attributes: does not allow returning attributes from the "transform" hook
  - rollup@function@extend-more-hooks-to-include-import-attributes: extend load, transform and renderDynamicImport to include import attributes
 
+### Source phase import is not supported
+ - rollup@form@source-phase-imports-external: preserves source phase import externals
+ - rollup@function@source-phase-dynamic-import-error-resolved: throws for non-external dynamic source phase imports with dynamic attributes
+ - rollup@function@source-phase-dynamic-import-error: throws for non-external dynamic source phase imports
+ - rollup@function@source-phase-format-unsupported: throws for source phase imports in non-ES output formats
+ - rollup@function@source-phase-import-error: throws for non-external source phase imports
+
 ### watch behavior is not compatible yet
  - rollup@hooks@allows to enforce plugin hook order in watch mode
 

--- a/packages/rollup-tests/src/status.json
+++ b/packages/rollup-tests/src/status.json
@@ -2,8 +2,8 @@
   "failed": 0,
   "skipFailed": 11,
   "ignored": 103,
-  "ignored(unsupported features)": 313,
+  "ignored(unsupported features)": 317,
   "ignored(treeshaking)": 324,
-  "ignored(behavior passed, snapshot different)": 157,
+  "ignored(behavior passed, snapshot different)": 158,
   "passed": 915
 }

--- a/packages/rollup-tests/src/status.md
+++ b/packages/rollup-tests/src/status.md
@@ -1,9 +1,9 @@
 |  | number |
 |----| ---- |
 | failed | 0 |
-| skipFailed | 7 |
+| skipFailed | 11 |
 | ignored | 103 |
-| ignored(unsupported features) | 313 |
+| ignored(unsupported features) | 317 |
 | ignored(treeshaking) | 324 |
-| ignored(behavior passed, snapshot different) | 157 |
-| passed | 919 |
+| ignored(behavior passed, snapshot different) | 158 |
+| passed | 915 |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,6 +661,9 @@ importers:
       acorn-import-assertions:
         specifier: 'catalog:'
         version: 1.9.0(acorn@8.16.0)
+      acorn-import-phases:
+        specifier: ^1.0.4
+        version: 1.0.4(acorn@8.16.0)
       fixturify:
         specifier: 'catalog:'
         version: 3.0.0
@@ -4390,6 +4393,12 @@ packages:
     deprecated: package has been renamed to acorn-import-attributes
     peerDependencies:
       acorn: ^8
+
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -9818,6 +9827,10 @@ snapshots:
       acorn: 6.4.2
 
   acorn-import-assertions@1.9.0(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 


### PR DESCRIPTION
Updates the rollup submodule to the latest tag on master branch.

[Rollup v4.60.0 Release](https://github.com/rollup/rollup/releases/tag/v4.60.0)

The action failed so creating this PR manually: https://github.com/rolldown/rolldown/actions/runs/23467331833/job/68282263505#step:11:32
