### PR TITLE
chore: remove Rolldown MF plan

### DIFF
--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -44,7 +44,6 @@ Finally, Rolldown provides some features that esbuild and Rollup do not (and may
 
 - [Manual code splitting](./notable-features#manual-code-splitting)
 - HMR support (WIP)
-- Module Federation (planned)
 
 ## Credits
 


### PR DESCRIPTION
Hi, thank you all for your support and interest in Rolldown Module Federation. After some research and discussion, we found that [module-federation/vite](https://github.com/module-federation/vite) is already compatible with Vite 7 and Vite 8, and provides good, consistent support for both dev and build modes. Therefore, we recommend using [module-federation/vite](https://github.com/module-federation/vite), and Rolldown will no longer provide built-in Module Federation support. Further discussion and feedback are very welcome.