### PR TITLE
feat(chunk-optimizer): skip circular dependency check when strict execution order is enabled

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -61,6 +61,9 @@ pub struct ChunkOptimizationGraph {
   /// Initial chunks share identical indices; newly-created common chunks
   /// in chunk_graph are registered here so callers can translate.
   chunk_idx_to_temp_chunk_idx: FxHashMap<ChunkIdx, ChunkIdx>,
+  /// When true, `would_create_circular_dependency` always returns false because
+  /// init_() wrappers guarantee correct execution order regardless of chunk load order.
+  strict_execution_order: bool,
 }
 
 impl ChunkOptimizationGraph {
@@ -68,6 +71,7 @@ impl ChunkOptimizationGraph {
     chunk_optimization: bool,
     chunk_graph: &ChunkGraph,
     bits_to_chunk_idx: &FxHashMap<BitSet, ChunkIdx>,
+    strict_execution_order: bool,
   ) -> Self {
     if !chunk_optimization {
       return Self::default();
@@ -98,7 +102,13 @@ impl ChunkOptimizationGraph {
       bits_to_chunk_idx.iter().map(|(k, v)| (k.clone(), *v)).collect();
     bits_to_chunk_idx.sort_unstable_keys();
 
-    Self { chunks, bits_to_chunk_idx, module_to_chunk, chunk_idx_to_temp_chunk_idx }
+    Self {
+      chunks,
+      bits_to_chunk_idx,
+      module_to_chunk,
+      chunk_idx_to_temp_chunk_idx,
+      strict_execution_order,
+    }
   }
 
   /// Assigns a module to a temporary chunk based on its reachability bits.
@@ -186,6 +196,11 @@ impl ChunkOptimizationGraph {
     source_chunk_idx: ChunkIdx,
     target_chunk_idx: ChunkIdx,
   ) -> bool {
+    // When strictExecutionOrder is enabled, init_() wrappers handle execution order,
+    // so circular chunk dependencies are safe and we can skip this check.
+    if self.strict_execution_order {
+      return false;
+    }
     // Start BFS from the combined deps of source and target.
     let mut queue: VecDeque<ChunkIdx> = self.chunks[source_chunk_idx]
       .dependencies

--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -821,8 +821,12 @@ impl GenerateStage<'_> {
     // TODO: maybe we could bailout peer chunk?
     let allow_chunk_optimization = self.options.experimental.is_chunk_optimization_enabled()
       && !self.link_output.metas.iter().any(|meta| meta.is_tla_or_contains_tla_dependency);
-    let mut temp_chunk_graph =
-      ChunkOptimizationGraph::new(allow_chunk_optimization, chunk_graph, bits_to_chunk);
+    let mut temp_chunk_graph = ChunkOptimizationGraph::new(
+      allow_chunk_optimization,
+      chunk_graph,
+      bits_to_chunk,
+      self.options.is_strict_execution_order_enabled(),
+    );
 
     // 1. Assign modules to corresponding chunks
     // 2. Create shared chunks to store modules that belong to multiple chunks.

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/_config.json
@@ -1,0 +1,9 @@
+{
+  "config": {},
+  "configVariants": [
+    {
+      "strictExecutionOrder": true,
+      "_configName": "strict_execution_order"
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/_test.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/_test.mjs
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const isStrictExecutionOrder = globalThis.__configName === 'strict_execution_order';
+
+if (isStrictExecutionOrder) {
+  // With strictExecutionOrder, the circular dependency check is skipped,
+  // so the facade chunk is eliminated and a.js contains the actual content.
+  assert(
+    !fs.existsSync(path.join(distDir, 'a2.js')),
+    'a2.js should not exist (facade was eliminated)',
+  );
+  const aContent = fs.readFileSync(path.join(distDir, 'a.js'), 'utf8');
+  assert(!aContent.includes('import "./a2.js"'), 'a.js should not be a facade');
+} else {
+  // Without strictExecutionOrder, the circular dependency check prevents
+  // the facade from being eliminated. a.js is a facade that only imports a2.js for side effects.
+  assert(
+    fs.existsSync(path.join(distDir, 'a2.js')),
+    'a2.js common chunk should exist (facade was not eliminated)',
+  );
+  const aContent = fs.readFileSync(path.join(distDir, 'a.js'), 'utf8');
+  assert(aContent.includes('import "./a2.js"'), 'a.js should be a facade importing a2.js');
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/a.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/a.js
@@ -1,0 +1,2 @@
+import './cjs.js';
+import './b.js';

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/artifacts.snap
@@ -1,0 +1,147 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# warnings
+
+## INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: b.js is dynamically imported by b.js but also statically imported by a.js, dynamic import will not move module into another chunk.
+
+```
+
+# Assets
+
+## a.js
+
+```js
+import "./a2.js";
+
+```
+
+## a2.js
+
+```js
+import { t as require_cjs } from "./cjs.js";
+import "./b.js";
+require_cjs();
+//#endregion
+
+```
+
+## b.js
+
+```js
+import { n as __exportAll, r as __toESM } from "./chunk.js";
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+function foo() {
+	import("./a.js");
+	Promise.resolve().then(() => b_exports);
+}
+import("./cjs.js").then((n) => /* @__PURE__ */ __toESM(n.t()));
+//#endregion
+export { b_exports as t };
+
+```
+
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __toESM as r, __commonJSMin as t };
+
+```
+
+## cjs.js
+
+```js
+import { t as __commonJSMin } from "./chunk.js";
+//#region cjs.js
+var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = 42;
+}));
+//#endregion
+export { require_cjs as t };
+
+```
+
+## main.js
+
+```js
+import "./a2.js";
+
+```
+
+# Variant: strict_execution_order: [strict_execution_order: true]
+
+## warnings
+
+### INEFFECTIVE_DYNAMIC_IMPORT
+
+```text
+[INEFFECTIVE_DYNAMIC_IMPORT] Warning: b.js is dynamically imported by b.js but also statically imported by a.js, dynamic import will not move module into another chunk.
+
+```
+
+## Assets
+
+### a.js
+
+```js
+import { t as require_cjs } from "./cjs.js";
+import { n as init_b } from "./b.js";
+import { n as __esmMin, r as __exportAll } from "./main.js";
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({});
+var init_a = __esmMin((() => {
+	require_cjs();
+	init_b();
+}));
+//#endregion
+export { init_a as n, a_exports as t };
+
+```
+
+### b.js
+
+```js
+import { i as __toESM, n as __esmMin, r as __exportAll } from "./main.js";
+//#region b.js
+var b_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
+function foo() {
+	import("./a.js").then((n) => (n.n(), n.t));
+	Promise.resolve().then(() => (init_b(), b_exports));
+}
+var init_b = __esmMin((() => {
+	import("./cjs.js").then((n) => /* @__PURE__ */ __toESM(n.t()));
+}));
+//#endregion
+export { init_b as n, b_exports as t };
+
+```
+
+### cjs.js
+
+```js
+import { t as __commonJSMin } from "./main.js";
+//#region cjs.js
+var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = 42;
+}));
+//#endregion
+export { require_cjs as t };
+
+```
+
+### main.js
+
+```js
+import { n as init_a } from "./a.js";
+// HIDDEN [\0rolldown/runtime.js]
+__esmMin((() => {
+	init_a();
+}))();
+export { __toESM as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/b.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/b.js
@@ -1,0 +1,6 @@
+export function foo() {
+  import('./a.js');
+  import('./b.js');
+}
+
+import('./cjs.js');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/cjs.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/cjs.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/skip_circular_dep_check_with_strict_execution_order/main.js
@@ -1,0 +1,1 @@
+import './a.js';


### PR DESCRIPTION
## Summary

When `strictExecutionOrder` is enabled, rolldown wraps modules in `init_()` functions that guard execution order at runtime. This means circular chunk dependencies are safe — the wrappers ensure correct initialization regardless of load order.

Currently, the chunk optimizer conservatively skips merging chunks that would create circular dependencies. This PR skips that circular dependency check when `strictExecutionOrder` is enabled, allowing more aggressive chunk merging and producing fewer output chunks.

## Changes

- Wrap the circular dependency check in `chunk_optimizer.rs` with `!self.options.is_strict_execution_order_enabled()`, so it is bypassed when strict execution order is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)