### PR TITLE
fix: emit build warnings during watch mode rebuilds

### DIFF
--- a/crates/rolldown_watcher/src/watch_task.rs
+++ b/crates/rolldown_watcher/src/watch_task.rs
@@ -1,7 +1,12 @@
 use arcstr::ArcStr;
 use rolldown::{Bundler, BundlerBuilder, BundlerConfig};
-use rolldown_common::{BundleMode, NormalizedBundlerOptions, ScanMode, WatcherChangeKind};
-use rolldown_error::{BuildDiagnostic, BuildResult, ResultExt};
+use rolldown_common::{
+  BundleMode, LogLevel, NormalizedBundlerOptions, ScanMode, WatcherChangeKind,
+};
+use rolldown_error::{
+  BatchedBuildDiagnostic, BuildDiagnostic, BuildResult, DiagnosticOptions, ResultExt,
+  filter_out_disabled_diagnostics,
+};
 use rolldown_fs_watcher::{DynFsWatcher, RecursiveMode};
 use rolldown_utils::{dashmap::FxDashSet, pattern_filter};
 use std::path::Path;
@@ -132,12 +137,24 @@ impl WatchTask {
     self.needs_rebuild = false;
 
     match result {
-      Ok(_output) => Ok(BuildOutcome::Success(BundleEndEventData {
-        task_index,
-        output: self.options.cwd.join(&self.options.out_dir).to_string_lossy().into_owned(),
-        duration,
-        bundle_handle,
-      })),
+      Ok(output) => {
+        // Emit build warnings (e.g. CIRCULAR_DEPENDENCY) via the on_log callback,
+        // matching the behavior of the non-watch build path.
+        if let Err(err) = Self::emit_warnings(&self.options, output.warnings).await {
+          return Ok(BuildOutcome::Error(WatchErrorEventData {
+            task_index,
+            diagnostics: Arc::from(BatchedBuildDiagnostic::from(err).into_vec()),
+            cwd: self.options.cwd.clone(),
+            bundle_handle,
+          }));
+        }
+        Ok(BuildOutcome::Success(BundleEndEventData {
+          task_index,
+          output: self.options.cwd.join(&self.options.out_dir).to_string_lossy().into_owned(),
+          duration,
+          bundle_handle,
+        }))
+      }
       Err(errs) => Ok(BuildOutcome::Error(WatchErrorEventData {
         task_index,
         diagnostics: Arc::from(errs.into_vec()),
@@ -145,6 +162,57 @@ impl WatchTask {
         bundle_handle,
       })),
     }
+  }
+
+  /// Emit build warnings via the `on_log` callback.
+  /// This mirrors the warning-handling logic in the non-watch build path so that
+  /// diagnostics such as CIRCULAR_DEPENDENCY are surfaced during watch rebuilds.
+  async fn emit_warnings(
+    options: &NormalizedBundlerOptions,
+    warnings: Vec<BuildDiagnostic>,
+  ) -> anyhow::Result<()> {
+    if warnings.is_empty() || options.log_level == Some(LogLevel::Silent) {
+      return Ok(());
+    }
+    if let Some(on_log) = options.on_log.as_ref() {
+      for warning in filter_out_disabled_diagnostics(warnings, &options.checks) {
+        let diag = warning.to_diagnostic_with(&DiagnosticOptions { cwd: options.cwd.clone() });
+        let code = warning.kind().to_string();
+        #[expect(
+          clippy::cast_possible_truncation,
+          reason = "line/column/position values are unlikely to exceed u32::MAX in practical use"
+        )]
+        let (loc, pos) = if let Some((_file, line, column, position)) = diag.get_primary_location()
+        {
+          (
+            Some(rolldown_common::LogLocation {
+              line: line as u32,
+              column: column as u32,
+              file: warning.id(),
+            }),
+            Some(position as u32),
+          )
+        } else {
+          (None, None)
+        };
+        on_log
+          .call(
+            LogLevel::Warn,
+            rolldown_common::Log {
+              id: warning.id(),
+              exporter: warning.exporter(),
+              code: Some(code),
+              message: diag.to_color_string(),
+              plugin: None,
+              loc,
+              pos,
+              ids: warning.ids(),
+            },
+          )
+          .await?;
+      }
+    }
+    Ok(())
   }
 
   /// Start event data for this task

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -1187,6 +1187,90 @@ test.concurrent(
   },
 );
 
+// https://github.com/rolldown/rolldown/issues/8892
+test.concurrent(
+  'watch should emit circular dependency warnings',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('watch-circular-warning', retryCount, {
+      'main.js': `import { a } from './a.js'\nconsole.log(a)`,
+      'a.js': `import { b } from './b.js'\nexport const a = b`,
+      'b.js': `import { a } from './a.js'\nexport const b = a`,
+    });
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    const onLogFn = vi.fn();
+    const watcher = watch({
+      input: path.join(dir, 'main.js'),
+      output: { dir: path.join(dir, 'dist') },
+      checks: { circularDependency: true },
+      plugins: [
+        {
+          name: 'test-circular-warning',
+          onLog(_level, log) {
+            if (log.code === 'CIRCULAR_DEPENDENCY') {
+              onLogFn();
+            }
+          },
+        },
+      ],
+    });
+    onTestFinished(async () => await watcher.close());
+
+    // Initial build should emit the circular dependency warning
+    await waitBuildFinished(watcher);
+    expect(onLogFn).toBeCalled();
+
+    // Rebuild should also emit the warning
+    onLogFn.mockClear();
+    await editFile(path.join(dir, 'a.js'), `import { b } from './b.js'\nexport const a = b + 1`);
+    await waitBuildFinished(watcher);
+    expect(onLogFn).toBeCalled();
+  },
+);
+
+test.concurrent(
+  'watch should fail when onLog rejects a warning',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('watch-circular-warning-error', retryCount, {
+      'main.js': `import { a } from './a.js'\nconsole.log(a)`,
+      'a.js': `import { b } from './b.js'\nexport const a = b`,
+      'b.js': `import { a } from './a.js'\nexport const b = a`,
+    });
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    const watcher = watch({
+      input: path.join(dir, 'main.js'),
+      output: { dir: path.join(dir, 'dist') },
+      checks: { circularDependency: true },
+      plugins: [
+        {
+          name: 'reject-circular-warning',
+          onLog(_level, log) {
+            if (log.code === 'CIRCULAR_DEPENDENCY') {
+              throw new Error('reject circular dependency');
+            }
+          },
+        },
+      ],
+    });
+    onTestFinished(async () => await watcher.close());
+
+    await expect(waitBuildFinished(watcher)).rejects.toThrow('reject circular dependency');
+  },
+);
+
 function createTestInputAndOutput(testLabel: string, retryCount: number, content?: string) {
   const uniqueId = crypto.randomUUID().slice(0, 8);
   const dirname = `${testLabel}-${uniqueId}-retry${retryCount}`;


### PR DESCRIPTION
## Summary
- Watch mode was silently discarding `BundleOutput.warnings` (including `CIRCULAR_DEPENDENCY`) after successful builds
- Forward warnings through the `on_log` callback in the watch task, matching the non-watch build path
- Add a test verifying circular dependency warnings are emitted on both initial build and rebuild

Closes #8892

## Test plan
- [x] New test `watch should emit circular dependency warnings` passes
- [x] All 29 existing watch tests pass with no regressions