### PR TITLE
fix: use ImportKind::Import for common-chunk root computation

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -269,145 +269,167 @@ impl GenerateStage<'_> {
       // guaranteed.
       return;
     }
-    chunk_graph
-      .chunk_table
-      .iter_mut()
-      .filter(|chunk| matches!(chunk.kind, ChunkKind::EntryPoint { .. }))
-      .for_each(|chunk| {
-        let ChunkKind::EntryPoint { module: entry_module, .. } = &chunk.kind else {
-          return;
-        };
-        // After modules in chunk is sorted, it is always sorted by execution order whatever the
-        // `chunk_modules_order` is `exec_order` or `module_id`. Because for `module_id` we only sort
-        // by `module_id` for side effects free leaf modules, those should always execute first and
-        // has no wrapping.
-        let mut wrapped_modules = vec![];
-        // If a none wrapped module has higher execution order than a wrapped module
-        // we called the none wrapped module depended on the wrapped module(e.g. the none wrapped
-        // module may depended on a global variable initialization in the wrapped module, however
-        // the wrapped module are usually lazy evaluate). So we need to adjust the initialization
-        // order
-        // manually.
-        let imported_symbol_owner_from_other_chunk = chunk
-          .imports_from_other_chunks
-          .iter()
-          .flat_map(|(_, import_items)| {
-            import_items
-              .iter()
-              .map(|item| self.link_output.symbol_db.canonical_ref_for(item.import_ref).owner)
-          })
-          .filter_map(|idx| {
-            let module = self.link_output.module_table[idx].as_normal()?;
-            (!self.link_output.metas[module.idx].original_wrap_kind().is_none()).then_some(idx)
-          })
-          .collect::<FxHashSet<_>>();
-        let chunk_module_to_exec_order = chunk
-          .modules
-          .iter()
-          .chain(imported_symbol_owner_from_other_chunk.iter())
-          .map(|idx| (*idx, self.link_output.module_table[*idx].exec_order()))
-          .collect::<FxHashMap<_, _>>();
-
-        // the key is the module_idx of none wrapped module
-        // the value is the how many wrapped modules did the none wrapped module depends on.
-        // when getting all depended wrapped modules, just use wrapped_modules[0..none_wrapped_module_to_wrapped_dependency_length[none_wrap_module_idx]].
-        let mut none_wrapped_module_to_wrapped_dependency_length = FxHashMap::default();
-        let js_import_order = self.js_import_order(*entry_module, &chunk_module_to_exec_order);
-        for idx in js_import_order {
-          match self.link_output.metas[idx].original_wrap_kind() {
-            WrapKind::None => {
-              if !wrapped_modules.is_empty() {
-                none_wrapped_module_to_wrapped_dependency_length.insert(idx, wrapped_modules.len());
-              }
-            }
-            WrapKind::Cjs | WrapKind::Esm => {
-              wrapped_modules.push(idx);
-            }
-          }
-        }
-        // All modules that we need to ensure the initialization order.
-        let mut modules_need_to_check: FxHashSet<ModuleIdx> = FxHashSet::default();
-        let mut max_length = 0;
-        for (none_wrapped, dep_length) in &none_wrapped_module_to_wrapped_dependency_length {
-          modules_need_to_check.insert(*none_wrapped);
-          max_length = max_length.max(*dep_length);
-        }
-        modules_need_to_check.extend(&wrapped_modules[0..max_length]);
-
-        if modules_need_to_check.is_empty() {
-          // No wrapped modules or none wrapped modules that depends on wrapped modules, so we can
-          // skip the initialization order check.
-          return;
-        }
-
-        // Record each module in `modules_need_to_check` first init position.
-        let mut module_init_position = FxIndexMap::default();
-
-        for idx in &chunk.modules {
-          let Some(module) = self.link_output.module_table[*idx].as_normal() else {
-            continue;
-          };
-          module
-            .import_records
-            .iter_enumerated()
-            .filter_map(|(rec_idx, rec)| {
-              rec.resolved_module.map(|module_idx| (rec_idx, rec, module_idx))
+    chunk_graph.chunk_table.iter_mut().for_each(|chunk| {
+      // Determine DFS roots based on chunk kind.
+      // For entry chunks, the root is the entry module.
+      // For common chunks, roots are modules not imported by any other module in the chunk.
+      let roots: Vec<ModuleIdx> = match &chunk.kind {
+        ChunkKind::EntryPoint { module, .. } => vec![*module],
+        ChunkKind::Common => {
+          let chunk_modules_set: FxHashSet<ModuleIdx> = chunk.modules.iter().copied().collect();
+          let imported_in_chunk: FxHashSet<ModuleIdx> = chunk
+            .modules
+            .iter()
+            .filter_map(|&idx| self.link_output.module_table[idx].as_normal())
+            .flat_map(|normal| &normal.import_records)
+            .filter_map(|rec| {
+              let resolved_module = rec.resolved_module?;
+              (rec.kind == ImportKind::Import && chunk_modules_set.contains(&resolved_module))
+                .then_some(resolved_module)
             })
-            .for_each(|(rec_idx, rec, module_idx)| {
-              if rec.kind == ImportKind::Import && modules_need_to_check.contains(&module_idx) {
-                module_init_position.entry(module_idx).or_insert((*idx, rec_idx));
-              }
-            });
-          if module_init_position.len() == modules_need_to_check.len() {
-            break;
+            .collect();
+          let mut roots: Vec<ModuleIdx> =
+            chunk.modules.iter().filter(|idx| !imported_in_chunk.contains(idx)).copied().collect();
+          roots.sort_unstable_by_key(|idx| self.link_output.module_table[*idx].exec_order());
+          roots
+        }
+      };
+
+      if roots.is_empty() {
+        return;
+      }
+
+      // After modules in chunk is sorted, it is always sorted by execution order whatever the
+      // `chunk_modules_order` is `exec_order` or `module_id`. Because for `module_id` we only sort
+      // by `module_id` for side effects free leaf modules, those should always execute first and
+      // has no wrapping.
+      let mut wrapped_modules = vec![];
+      // If a none wrapped module has higher execution order than a wrapped module
+      // we called the none wrapped module depended on the wrapped module(e.g. the none wrapped
+      // module may depended on a global variable initialization in the wrapped module, however
+      // the wrapped module are usually lazy evaluate). So we need to adjust the initialization
+      // order
+      // manually.
+      let imported_symbol_owner_from_other_chunk = chunk
+        .imports_from_other_chunks
+        .iter()
+        .flat_map(|(_, import_items)| {
+          import_items
+            .iter()
+            .map(|item| self.link_output.symbol_db.canonical_ref_for(item.import_ref).owner)
+        })
+        .filter_map(|idx| {
+          let module = self.link_output.module_table[idx].as_normal()?;
+          (!self.link_output.metas[module.idx].original_wrap_kind().is_none()).then_some(idx)
+        })
+        .collect::<FxHashSet<_>>();
+      let chunk_module_to_exec_order = chunk
+        .modules
+        .iter()
+        .chain(imported_symbol_owner_from_other_chunk.iter())
+        .map(|idx| (*idx, self.link_output.module_table[*idx].exec_order()))
+        .collect::<FxHashMap<_, _>>();
+
+      // the key is the module_idx of none wrapped module
+      // the value is the how many wrapped modules did the none wrapped module depends on.
+      // when getting all depended wrapped modules, just use wrapped_modules[0..none_wrapped_module_to_wrapped_dependency_length[none_wrap_module_idx]].
+      let mut none_wrapped_module_to_wrapped_dependency_length = FxHashMap::default();
+      let js_import_order = self.js_import_order(&roots, &chunk_module_to_exec_order);
+      for idx in js_import_order {
+        match self.link_output.metas[idx].original_wrap_kind() {
+          WrapKind::None => {
+            if !wrapped_modules.is_empty() {
+              none_wrapped_module_to_wrapped_dependency_length.insert(idx, wrapped_modules.len());
+            }
+          }
+          WrapKind::Cjs | WrapKind::Esm => {
+            wrapped_modules.push(idx);
           }
         }
+      }
+      // All modules that we need to ensure the initialization order.
+      let mut modules_need_to_check: FxHashSet<ModuleIdx> = FxHashSet::default();
+      let mut max_length = 0;
+      for (none_wrapped, dep_length) in &none_wrapped_module_to_wrapped_dependency_length {
+        modules_need_to_check.insert(*none_wrapped);
+        max_length = max_length.max(*dep_length);
+      }
+      modules_need_to_check.extend(&wrapped_modules[0..max_length]);
 
-        let mut module_init_position = module_init_position.into_iter().collect_vec();
-        module_init_position.sort_by_cached_key(|(idx, _)| chunk_module_to_exec_order[idx]);
+      if modules_need_to_check.is_empty() {
+        // No wrapped modules or none wrapped modules that depends on wrapped modules, so we can
+        // skip the initialization order check.
+        return;
+      }
 
-        let mut pending_transfer = vec![];
-        let mut insert_map: FxHashMap<ModuleIdx, Vec<(ModuleIdx, ImportRecordIdx)>> =
-          FxHashMap::default();
-        let mut remove_map: FxHashMap<ModuleIdx, Vec<ImportRecordIdx>> = FxHashMap::default();
-        for (module_idx, (importer_idx, rec_idx)) in module_init_position {
-          match self.link_output.metas[module_idx].original_wrap_kind() {
-            WrapKind::None => {
-              if let Some(deps_length) =
-                none_wrapped_module_to_wrapped_dependency_length.get(&module_idx)
-              {
-                let transfer_item = pending_transfer
-                  .extract_if(0.., |(midx, _, _)| wrapped_modules[0..*deps_length].contains(midx));
-                for (_midx, iidx, ridx) in transfer_item {
-                  // Should always avoid transfer any initialization from a low execution order module to a high execution order module.
-                  if chunk_module_to_exec_order[&iidx] <= chunk_module_to_exec_order[&module_idx] {
-                    // If the module is the same, we can skip the transfer.
-                    continue;
-                  }
-                  insert_map.entry(module_idx).or_default().push((iidx, ridx));
-                  remove_map.entry(iidx).or_default().push(ridx);
+      // Record each module in `modules_need_to_check` first init position.
+      let mut module_init_position = FxIndexMap::default();
+
+      for idx in &chunk.modules {
+        let Some(module) = self.link_output.module_table[*idx].as_normal() else {
+          continue;
+        };
+        module
+          .import_records
+          .iter_enumerated()
+          .filter_map(|(rec_idx, rec)| {
+            rec.resolved_module.map(|module_idx| (rec_idx, rec, module_idx))
+          })
+          .for_each(|(rec_idx, rec, module_idx)| {
+            if rec.kind == ImportKind::Import && modules_need_to_check.contains(&module_idx) {
+              module_init_position.entry(module_idx).or_insert((*idx, rec_idx));
+            }
+          });
+        if module_init_position.len() == modules_need_to_check.len() {
+          break;
+        }
+      }
+
+      let mut module_init_position = module_init_position.into_iter().collect_vec();
+      module_init_position.sort_by_cached_key(|(idx, _)| chunk_module_to_exec_order[idx]);
+
+      let mut pending_transfer = vec![];
+      let mut insert_map: FxHashMap<ModuleIdx, Vec<(ModuleIdx, ImportRecordIdx)>> =
+        FxHashMap::default();
+      let mut remove_map: FxHashMap<ModuleIdx, Vec<ImportRecordIdx>> = FxHashMap::default();
+      for (module_idx, (importer_idx, rec_idx)) in module_init_position {
+        match self.link_output.metas[module_idx].original_wrap_kind() {
+          WrapKind::None => {
+            if let Some(deps_length) =
+              none_wrapped_module_to_wrapped_dependency_length.get(&module_idx)
+            {
+              let transfer_item = pending_transfer
+                .extract_if(0.., |(midx, _, _)| wrapped_modules[0..*deps_length].contains(midx));
+              for (_midx, iidx, ridx) in transfer_item {
+                // Should always avoid transfer any initialization from a low execution order module to a high execution order module.
+                if chunk_module_to_exec_order[&iidx] <= chunk_module_to_exec_order[&module_idx] {
+                  // If the module is the same, we can skip the transfer.
+                  continue;
                 }
+                insert_map.entry(module_idx).or_default().push((iidx, ridx));
+                remove_map.entry(iidx).or_default().push(ridx);
               }
             }
-            WrapKind::Cjs | WrapKind::Esm => {
-              pending_transfer.push((module_idx, importer_idx, rec_idx));
-            }
+          }
+          WrapKind::Cjs | WrapKind::Esm => {
+            pending_transfer.push((module_idx, importer_idx, rec_idx));
           }
         }
-        chunk.insert_map = insert_map;
-        chunk.remove_map = remove_map;
-      });
+      }
+      chunk.insert_map = insert_map;
+      chunk.remove_map = remove_map;
+    });
   }
 
   /// Only considering module eager initialization order, both `require()` and `import()` are lazy
   /// initialization.
   fn js_import_order(
     &self,
-    entry: ModuleIdx,
+    roots: &[ModuleIdx],
     chunk_modules_map: &FxHashMap<ModuleIdx, u32>,
   ) -> Vec<ModuleIdx> {
     // traverse module graph with depth-first search to determine the order of JS imports
-    let mut stack = vec![entry];
+    let mut stack: Vec<ModuleIdx> = roots.iter().copied().rev().collect();
     let mut visited = FxHashSet::default();
     let mut js_import_order = vec![];
     while let Some(module_idx) = stack.pop() {

--- a/crates/rolldown/tests/rolldown/issues/8812/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8812/_config.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "entry-a",
+        "import": "entry-a.js"
+      },
+      {
+        "name": "entry-b",
+        "import": "entry-b.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8812/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8812/artifacts.snap
@@ -1,0 +1,71 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry-a.js
+
+```js
+import { n as import_fake_core, t as useCore } from "./utils.js";
+//#region entry-a.js
+console.log("Entry A:", import_fake_core.default, useCore());
+//#endregion
+
+```
+
+## entry-b.js
+
+```js
+import { n as import_fake_core, t as useCore } from "./utils.js";
+//#region entry-b.js
+console.log("Entry B:", import_fake_core.default, useCore());
+//#endregion
+
+```
+
+## utils.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region fake-core.cjs
+var require_fake_core = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	(function() {
+		"use strict";
+		var fakeCore = {
+			registry: [],
+			register: function(name) {
+				this.registry.push(name);
+			}
+		};
+		globalThis.fakeCore = fakeCore;
+		if (typeof module === "object") try {
+			module.exports = fakeCore;
+		} catch (_e) {}
+	})();
+}));
+//#endregion
+//#region fake-plugin-model.cjs
+var require_fake_plugin_model = /* @__PURE__ */ __commonJSMin((() => {
+	(function() {
+		"use strict";
+		globalThis.fakeCore.register("dom-model");
+	})();
+}));
+//#endregion
+//#region fake-plugin.cjs
+var require_fake_plugin = /* @__PURE__ */ __commonJSMin((() => {
+	require_fake_plugin_model();
+}));
+//#endregion
+//#region wrapper.js
+var import_fake_core = /* @__PURE__ */ __toESM(require_fake_core());
+require_fake_plugin();
+//#endregion
+//#region utils.js
+function useCore() {
+	return import_fake_core.default.registry;
+}
+//#endregion
+export { import_fake_core as n, useCore as t };
+
+```

--- a/crates/rolldown/tests/rolldown/issues/8812/entry-a.js
+++ b/crates/rolldown/tests/rolldown/issues/8812/entry-a.js
@@ -1,0 +1,3 @@
+import { fakeCore } from './wrapper.js';
+import { useCore } from './utils.js';
+console.log('Entry A:', fakeCore, useCore());

--- a/crates/rolldown/tests/rolldown/issues/8812/entry-b.js
+++ b/crates/rolldown/tests/rolldown/issues/8812/entry-b.js
@@ -1,0 +1,3 @@
+import { fakeCore } from './wrapper.js';
+import { useCore } from './utils.js';
+console.log('Entry B:', fakeCore, useCore());

--- a/crates/rolldown/tests/rolldown/issues/8812/fake-core.cjs
+++ b/crates/rolldown/tests/rolldown/issues/8812/fake-core.cjs
@@ -1,0 +1,16 @@
+// CJS IIFE: sets globalThis.fakeCore, exports via module.exports.
+(function () {
+  'use strict';
+  var fakeCore = {
+    registry: [],
+    register: function (name) {
+      this.registry.push(name);
+    },
+  };
+  globalThis.fakeCore = fakeCore;
+  if (typeof module === 'object') {
+    try {
+      module.exports = fakeCore;
+    } catch (_e) {}
+  }
+})();

--- a/crates/rolldown/tests/rolldown/issues/8812/fake-plugin-model.cjs
+++ b/crates/rolldown/tests/rolldown/issues/8812/fake-plugin-model.cjs
@@ -1,0 +1,6 @@
+// IIFE accessing global set by fake-core. No exports.
+// BUG: Without fix, this runs before fake-core sets globalThis.fakeCore.
+(function () {
+  'use strict';
+  globalThis.fakeCore.register('dom-model');
+})();

--- a/crates/rolldown/tests/rolldown/issues/8812/fake-plugin.cjs
+++ b/crates/rolldown/tests/rolldown/issues/8812/fake-plugin.cjs
@@ -1,0 +1,2 @@
+// Side-effect only: requires model which accesses global.
+require('./fake-plugin-model.cjs');

--- a/crates/rolldown/tests/rolldown/issues/8812/utils.js
+++ b/crates/rolldown/tests/rolldown/issues/8812/utils.js
@@ -1,0 +1,4 @@
+import fakeCore from './fake-core.cjs';
+export function useCore() {
+  return fakeCore.registry;
+}

--- a/crates/rolldown/tests/rolldown/issues/8812/wrapper.js
+++ b/crates/rolldown/tests/rolldown/issues/8812/wrapper.js
@@ -1,0 +1,3 @@
+import fakeCore from './fake-core.cjs';
+import './fake-plugin.cjs';
+export { fakeCore };


### PR DESCRIPTION
## Summary
- Aligns common-chunk root computation with `js_import_order` DFS traversal by filtering on `ImportKind::Import` instead of `is_static()`
- Previously, modules reached only via `require()` in a common chunk were excluded from roots but never visited by DFS, causing wrapped CJS dependencies to miss the init-order fixup
- Generalizes `js_import_order` to accept multiple roots so common chunks are processed alongside entry chunks

## Test plan
- [x] Added integration test for issue #8812 (two entry points sharing CJS modules with require-only edges)
- [x] Snapshot verifies `require_fake_core()` executes before `require_fake_plugin_model()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)