### PR TITLE
fix(rust): don't mark pure-annotated local calls as execution-order-sensitive

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -125,11 +125,11 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
       }
 
       self.visit_statement(stmt);
-      if self.current_stmt_info.side_effect.intersects(
-        SideEffectDetail::Unknown
-          | SideEffectDetail::GlobalVarAccess
-          | SideEffectDetail::PureAnnotation,
-      ) {
+      if self
+        .current_stmt_info
+        .side_effect
+        .intersects(SideEffectDetail::Unknown | SideEffectDetail::GlobalVarAccess)
+      {
         self.result.ecma_view_meta.insert(EcmaViewMeta::ExecutionOrderSensitive);
       }
       self.result.stmt_infos.add_stmt_info(std::mem::take(&mut self.current_stmt_info));

--- a/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
+++ b/crates/rolldown/src/ast_scanner/side_effect_detector/mod.rs
@@ -117,7 +117,6 @@ impl<'a> SideEffectDetector<'a> {
       && matches!(&expr.callee, Expression::Identifier(id) if self.is_unresolved_reference(id));
 
     let mut detail = SideEffectDetail::from(has_side_effect);
-    detail.set(SideEffectDetail::PureAnnotation, is_pure_annotated);
     detail.set(SideEffectDetail::GlobalVarAccess, is_global_call);
 
     if !has_side_effect {
@@ -202,12 +201,8 @@ impl<'a> SideEffectDetector<'a> {
         // METADATA: GlobalVarAccess — constructor is a known global
         let is_global_constructor = !has_side_effect
           && matches!(&expr.callee, Expression::Identifier(id) if self.is_unresolved_reference(id));
-        // METADATA: PureAnnotation — marked with /*@__PURE__*/
-        let is_pure_annotated = !self.flat_options.ignore_annotations() && expr.pure;
-
         let mut detail = SideEffectDetail::from(has_side_effect);
         detail.set(SideEffectDetail::GlobalVarAccess, is_global_constructor);
-        detail.set(SideEffectDetail::PureAnnotation, is_pure_annotated);
 
         if !has_side_effect {
           // Oxc already verified args are side-effect-free; only collect metadata flags.
@@ -1086,7 +1081,7 @@ mod test {
     // sideEffectful Global variable access with pure annotation
     assert_eq!(
       get_statements_side_effect_details("let a = /*@__PURE__ */ Reflect.something()"),
-      vec![SideEffectDetail::GlobalVarAccess | SideEffectDetail::PureAnnotation]
+      vec![SideEffectDetail::GlobalVarAccess]
     );
   }
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4920/artifacts.snap
@@ -38,13 +38,9 @@ import nodeAssert from "node:assert";
 function foo() {
 	globalThis.value = 1;
 }
-var dep_default;
-var init_dep = __esmMin((() => {
-	dep_default = /* @__PURE__ */ foo();
-}));
+var dep_default = /* @__PURE__ */ foo();
 //#endregion
 __esmMin((() => {
-	init_dep();
 	nodeAssert.strictEqual(globalThis.value, 1);
 }))();
 export { dep_default as dep };

--- a/crates/rolldown_common/src/types/side_effect_detail.rs
+++ b/crates/rolldown_common/src/types/side_effect_detail.rs
@@ -1,16 +1,14 @@
 use bitflags::bitflags;
 bitflags! {
     #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
-    /// Some statement is mark as side effects free via `Pure`, but we need to know
-    /// the original statement side effects when do some runtime wrapper optimization.
-    /// A global variable access with `pure` annotation, it could be eliminated when unused,
-    /// but If we can't remove it's wrapper safely,because runtime behavior of global variable access maybe execution
-    /// order aware
+    /// Metadata flags describing a statement's side effects.
+    /// Used to determine execution-order sensitivity for runtime wrapper optimization.
+    /// e.g. a global variable access may require preserving execution order even if the
+    /// statement is otherwise side-effect-free.
     pub struct SideEffectDetail: u8 {
         const GlobalVarAccess = 1;
         const PureCjs = 1 << 1;
         const Unknown = 1 << 2;
-        const PureAnnotation = 1 << 3;
     }
 }
 


### PR DESCRIPTION
Pure-annotated calls to local functions (e.g. `/*#__PURE__*/ foo()`) should not trigger `ExecutionOrderSensitive`, since the annotation is a developer contract that the call is side-effect-free. Only `Unknown` and `GlobalVarAccess` flags should trigger wrapping.

This also removes the now-unused `SideEffectDetail::PureAnnotation` flag.