### PR TITLE
fix(watch): clear emitted_filenames between rebuilds

### DIFF
--- a/crates/rolldown_common/src/file_emitter.rs
+++ b/crates/rolldown_common/src/file_emitter.rs
@@ -377,6 +377,7 @@ impl FileEmitter {
     self.base_reference_id.store(0, Ordering::Relaxed);
     self.emitted_files.clear();
     self.emitted_chunks.clear();
+    self.emitted_filenames.clear();
     self.module_to_file_ref.clear();
   }
 }

--- a/packages/rolldown/tests/watch/watch.test.ts
+++ b/packages/rolldown/tests/watch/watch.test.ts
@@ -1271,6 +1271,57 @@ test.concurrent(
   },
 );
 
+// https://github.com/rolldown/rolldown/issues/8912
+test.concurrent(
+  'watch should not emit false FILE_NAME_CONFLICT on rebuild',
+  { retry: TEST_RETRY, timeout: TEST_TIMEOUT },
+  async ({ task, expect, onTestFinished }) => {
+    const retryCount = task.result?.retryCount ?? 0;
+    const { dir } = createTestWithMultiFiles('watch-filename-conflict', retryCount, {
+      'main.js': `console.log('hello')`,
+    });
+    onTestFinished(() => {
+      if (!process.env.CI) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    const filenameConflictFn = vi.fn();
+    const watcher = watch({
+      input: path.join(dir, 'main.js'),
+      output: { dir: path.join(dir, 'dist') },
+      onwarn(warning) {
+        if (warning.code === 'FILE_NAME_CONFLICT') {
+          filenameConflictFn();
+        }
+      },
+      plugins: [
+        {
+          name: 'emit-asset',
+          buildStart() {
+            this.emitFile({
+              type: 'asset',
+              source: 'hello',
+              fileName: 'extra.txt',
+            });
+          },
+        },
+      ],
+    });
+    onTestFinished(async () => await watcher.close());
+
+    // Initial build should NOT emit FILE_NAME_CONFLICT
+    await waitBuildFinished(watcher);
+    expect(filenameConflictFn).not.toBeCalled();
+
+    // Rebuild should also NOT emit FILE_NAME_CONFLICT
+    filenameConflictFn.mockClear();
+    await editFile(path.join(dir, 'main.js'), `console.log('updated')`);
+    await waitBuildFinished(watcher);
+    expect(filenameConflictFn).not.toBeCalled();
+  },
+);
+
 function createTestInputAndOutput(testLabel: string, retryCount: number, content?: string) {
   const uniqueId = crypto.randomUUID().slice(0, 8);
   const dirname = `${testLabel}-${uniqueId}-retry${retryCount}`;


### PR DESCRIPTION
## Summary

`FileEmitter::clear()` was missing `emitted_filenames.clear()`, causing false `FILE_NAME_CONFLICT` warnings on every watch rebuild. Files emitted by plugins would conflict with themselves from the previous build.

Fixes #8912

## Changes

- Add `self.emitted_filenames.clear()` to `FileEmitter::clear()` — this field was added in #3503 but never included in the watch-mode reset
- Add JS watch test that verifies no false `FILE_NAME_CONFLICT` on rebuild

## Test plan

- [x] Rust unit test confirms false warning without fix, no warning with fix
- [x] JS watch test (`watch should not emit false FILE_NAME_CONFLICT on rebuild`) fails without fix, passes with fix
- [x] Existing `onwarn/filename-conflict` fixture still passes (intra-build conflicts unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)