### PR TITLE
fix: don't mark calls to reassigned bindings as pure

### DIFF
--- a/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
+++ b/crates/rolldown/src/module_finalizers/impl_visit_mut.rs
@@ -427,6 +427,7 @@ impl<'ast> VisitMut<'ast> for ScopeHoistingFinalizer<'_, 'ast> {
             .map(|id| {
               let symbol_ref = self.ctx.symbol_db.canonical_ref_for((self.ctx.idx, id).into());
               self.ctx.side_effect_free_function_symbols.contains(&symbol_ref)
+                && symbol_ref.is_not_reassigned(self.ctx.symbol_db) == Some(true)
             })
             .unwrap_or(false);
           if is_empty_function {

--- a/crates/rolldown/tests/rolldown/tree_shaking/reassigned_let_binding_not_pure/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/reassigned_let_binding_not_pure/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "treeshake": true,
+    "external": ["node:assert"]
+  }
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/reassigned_let_binding_not_pure/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/reassigned_let_binding_not_pure/artifacts.snap
@@ -1,0 +1,29 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+//#region logger.js
+let send = () => {};
+const setup = () => {
+	send = (msg) => {
+		globalThis.result = msg;
+	};
+};
+//#endregion
+//#region consumer.js
+const doWork = () => {
+	send("hello from doWork");
+};
+//#endregion
+//#region main.js
+setup();
+doWork();
+assert.strictEqual(globalThis.result, "hello from doWork");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/tree_shaking/reassigned_let_binding_not_pure/consumer.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/reassigned_let_binding_not_pure/consumer.js
@@ -1,0 +1,5 @@
+import { send } from './logger.js';
+
+export const doWork = () => {
+  send('hello from doWork');
+};

--- a/crates/rolldown/tests/rolldown/tree_shaking/reassigned_let_binding_not_pure/logger.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/reassigned_let_binding_not_pure/logger.js
@@ -1,0 +1,7 @@
+export let send = () => {};
+
+export const setup = () => {
+  send = (msg) => {
+    globalThis.result = msg;
+  };
+};

--- a/crates/rolldown/tests/rolldown/tree_shaking/reassigned_let_binding_not_pure/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/reassigned_let_binding_not_pure/main.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+import { setup } from './logger.js';
+import { doWork } from './consumer.js';
+
+setup();
+doWork();
+
+assert.strictEqual(globalThis.result, 'hello from doWork');


### PR DESCRIPTION
fix #8916
## Summary

Rolldown incorrectly marked calls to `export let` bindings as `@__PURE__` based on their initial value, ignoring subsequent reassignments. This caused the call (and its side effects) to be tree-shaken away.

The fix checks the `IsNotReassigned` flag before marking a call expression as pure in the module finalizer.

## Test plan

- Added `tree_shaking/reassigned_let_binding_not_pure` test case that reproduces the bug
- All 1653 integration tests pass with no regressions