### PR TITLE
fix(ci): cache esbuild snapshots to avoid 429 rate limiting

### DIFF
--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -52,7 +52,7 @@ jobs:
           INSTA_UPDATE: no
 
       - name: Cache esbuild snapshots
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: scripts/tmp/esbuild-tests/snapshots
           key: esbuild-snapshots-${{ hashFiles('scripts/src/esbuild-tests/urls.ts') }}

--- a/.github/workflows/reusable-cargo-test.yml
+++ b/.github/workflows/reusable-cargo-test.yml
@@ -51,6 +51,12 @@ jobs:
           # Reject updated snapshots https://insta.rs/docs/advanced/#controlling-snapshot-updating
           INSTA_UPDATE: no
 
+      - name: Cache esbuild snapshots
+        uses: actions/cache@v4
+        with:
+          path: scripts/tmp/esbuild-tests/snapshots
+          key: esbuild-snapshots-${{ hashFiles('scripts/src/esbuild-tests/urls.ts') }}
+
       - name: Check if esbuild tests diff has changed
         run: |
           just ued

--- a/scripts/src/esbuild-tests/snap-diff/download-snapshots.ts
+++ b/scripts/src/esbuild-tests/snap-diff/download-snapshots.ts
@@ -22,6 +22,13 @@ export const SNAPSHOT_FILES = [
 export type SnapshotFileName = (typeof SNAPSHOT_FILES)[number];
 
 const SNAPSHOTS_DIR = path.resolve(import.meta.dirname, '../../../tmp/esbuild-tests/snapshots');
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function isCacheFresh(filePath: string): boolean {
+  if (!fs.existsSync(filePath)) return false;
+  const mtime = fs.statSync(filePath).mtimeMs;
+  return Date.now() - mtime < CACHE_TTL_MS;
+}
 
 async function downloadSnapshot(filename: SnapshotFileName): Promise<string> {
   const url = `${ESBUILD_SNAPSHOTS_URL}/${filename}`;
@@ -29,6 +36,14 @@ async function downloadSnapshot(filename: SnapshotFileName): Promise<string> {
 
   const response = await fetch(url);
   if (!response.ok) {
+    // If download fails and we have a stale cache, use it
+    const filePath = path.join(SNAPSHOTS_DIR, filename);
+    if (fs.existsSync(filePath)) {
+      console.warn(
+        `Download failed (${response.status} ${response.statusText}), using stale cache for ${filename}`,
+      );
+      return fs.readFileSync(filePath, 'utf-8');
+    }
     throw new Error(`Failed to download ${filename}: ${response.status} ${response.statusText}`);
   }
 
@@ -42,7 +57,8 @@ export async function ensureSnapshot(
 ): Promise<string> {
   const filePath = path.join(SNAPSHOTS_DIR, filename);
 
-  if (!options.force && fs.existsSync(filePath)) {
+  // Skip download if cache is fresh (less than 24h old) and not forced
+  if (!options.force && isCacheFresh(filePath)) {
     return fs.readFileSync(filePath, 'utf-8');
   }
 


### PR DESCRIPTION
## Summary

The `esbuild-snap-diff` step in `reusable-cargo-test.yml` downloads 14 snapshot files from `raw.githubusercontent.com` on every CI run, which triggers HTTP 429 (Too Many Requests) errors.

- Add `actions/cache` step to persist esbuild snapshots across CI runs, keyed by esbuild version hash (`urls.ts`)
- Add 24h TTL in `download-snapshots.ts` to skip downloads when cached files are fresh
- Fall back to stale cached files when download fails (e.g. 429) instead of crashing

Closes #8918

## Test plan

- [x] CI `cargo-test` job passes without downloading snapshots on cache hit
- [x] Cache invalidates when esbuild version in `urls.ts` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)