### PR TITLE
fix: preserve init calls for named re-exports under strict execution order

### DIFF
--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -190,11 +190,10 @@ impl LinkStage<'_> {
                           self.options.is_strict_execution_order_enabled()
                             && rec.meta.contains(ImportRecordMeta::IsReExportOnly)
                             && !is_reexport_all;
-                        stmt_info.side_effect =
-                          (is_reexport_all
-                            || importee.side_effects.has_side_effects()
-                            || needs_init_for_named_reexport)
-                            .into();
+                        stmt_info.side_effect = (is_reexport_all
+                          || importee.side_effects.has_side_effects()
+                          || needs_init_for_named_reexport)
+                          .into();
                         // Reference to `init_foo`
                         stmt_info
                           .referenced_symbols

--- a/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
+++ b/crates/rolldown/src/stages/link_stage/reference_needed_symbols.rs
@@ -186,8 +186,15 @@ impl LinkStage<'_> {
                       }
                       WrapKind::Esm => {
                         // Turn `import ... from 'bar_esm'` into `init_bar_esm()`
+                        let needs_init_for_named_reexport =
+                          self.options.is_strict_execution_order_enabled()
+                            && rec.meta.contains(ImportRecordMeta::IsReExportOnly)
+                            && !is_reexport_all;
                         stmt_info.side_effect =
-                          (is_reexport_all || importee.side_effects.has_side_effects()).into();
+                          (is_reexport_all
+                            || importee.side_effects.has_side_effects()
+                            || needs_init_for_named_reexport)
+                            .into();
                         // Reference to `init_foo`
                         stmt_info
                           .referenced_symbols

--- a/crates/rolldown/tests/rolldown/issues/8777/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8777/_config.json
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "strictExecutionOrder": true
+  },
+  "expectExecuted": true
+}

--- a/crates/rolldown/tests/rolldown/issues/8777/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8777/artifacts.snap
@@ -1,0 +1,27 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region foo.js
+var value;
+var init_foo = __esmMin((() => {
+	value = "foo";
+}));
+//#endregion
+//#region proxy.js
+var init_proxy = __esmMin((() => {
+	init_foo();
+}));
+//#endregion
+__esmMin((() => {
+	init_proxy();
+	assert.strictEqual(value, "foo");
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/issues/8777/foo.js
+++ b/crates/rolldown/tests/rolldown/issues/8777/foo.js
@@ -1,0 +1,6 @@
+import './dep.js';
+
+let value;
+export { value as default };
+
+value = 'foo';

--- a/crates/rolldown/tests/rolldown/issues/8777/main.js
+++ b/crates/rolldown/tests/rolldown/issues/8777/main.js
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import value from './proxy.js';
+
+assert.strictEqual(value, 'foo');

--- a/crates/rolldown/tests/rolldown/issues/8777/package.json
+++ b/crates/rolldown/tests/rolldown/issues/8777/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/crates/rolldown/tests/rolldown/issues/8777/proxy.js
+++ b/crates/rolldown/tests/rolldown/issues/8777/proxy.js
@@ -1,0 +1,1 @@
+export { default } from './foo.js';


### PR DESCRIPTION
## Summary
- keep named re-export records side-effectful when strict execution order wraps an ESM importee, so their generated init calls are not tree-shaken away just because the package is marked sideEffects: false
- add an issue 8777 regression fixture that snapshots and executes an export-default re-export under `strictExecutionOrder: true`
- verify the fix with `cargo test -p rolldown`

## Root cause
`reference_needed_symbols.rs` only treated wrapped ESM import records as side-effectful for `export *` or for importees whose package metadata reported side effects. Under `strictExecutionOrder`, named re-exports still need their generated `init_*()` call to run so wrapped export bindings are assigned before use, even when the importee is otherwise side-effect-free.

## Testing
- `cargo test -p rolldown`

Fixes #8777.