### PR TITLE
fix: track CJS re-export import records to fix inline const and tree-shaking

### DIFF
--- a/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
+++ b/crates/rolldown/src/ast_scanner/cjs_export_analyzer.rs
@@ -3,7 +3,7 @@ use oxc::ast::{
   AstKind, MemberExpressionKind,
   ast::{self, AssignmentExpression, Expression, IdentifierReference, PropertyKey},
 };
-use oxc::span::CompactStr;
+use oxc::span::{CompactStr, Span};
 use rolldown_common::{AstScopes, EcmaModuleAstUsage};
 use rolldown_ecmascript_utils::ExpressionExt;
 
@@ -41,7 +41,7 @@ pub enum CommonJsAstType {
   /// `console.log(exports)`
   ExportsRead,
   EsModuleFlag,
-  Reexport,
+  Reexport(Span),
 }
 
 impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
@@ -118,8 +118,9 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       Some(CommonJsAstType::ExportsPropWrite(prop)) if prop == "*" => {
         self.result.ast_usage.remove(EcmaModuleAstUsage::AllStaticExportPropertyAccess);
       }
-      Some(CommonJsAstType::Reexport) => {
+      Some(CommonJsAstType::Reexport(span)) => {
         self.result.ast_usage.insert(EcmaModuleAstUsage::IsCjsReexport);
+        self.result.cjs_reexport_require_spans.push(*span);
       }
       _ => {}
     }
@@ -179,7 +180,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       .as_expression()?
       .as_string_literal()
       .is_some()
-      .then_some(CommonJsAstType::Reexport)
+      .then_some(CommonJsAstType::Reexport(call_expr.span))
   }
 }
 

--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -285,7 +285,6 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
           }
           if id.name == "exports" && self.is_global_identifier_reference(id) {
             self.cjs_exports_ident.get_or_insert(Span::new(id.span.start, id.span.start + 7));
-
             if let Some((span, export_name)) = member_expr.static_property_info() {
               // `exports.test = ...`
               let exported_symbol =
@@ -593,7 +592,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
                 self.cjs_named_exports_usage.entry(prop).or_default().write += 1;
               }
               Some(CommonJsAstType::EsModuleFlag) => {}
-              Some(CommonJsAstType::Reexport) => {
+              Some(CommonJsAstType::Reexport(_)) => {
                 // This is only usd for `module.exports = require('mod')`
                 // should only reached when `ident_ref` is `module`
                 unreachable!()

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -116,6 +116,11 @@ pub struct ScanResult {
   pub directive_range: Vec<Span>,
   pub constant_export_map: FxHashMap<SymbolId, ConstExportMeta>,
   pub import_attribute_map: FxHashMap<ImportRecordIdx, ImportAttribute>,
+  /// Temporary storage for spans of `require()` calls in `module.exports = require(...)` patterns.
+  /// Resolved to `cjs_reexport_import_record_ids` after scanning completes.
+  pub cjs_reexport_require_spans: Vec<Span>,
+  /// Import record indices for `module.exports = require(...)` patterns.
+  pub cjs_reexport_import_record_ids: Vec<ImportRecordIdx>,
 }
 
 bitflags::bitflags! {
@@ -223,6 +228,8 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       constant_export_map: FxHashMap::default(),
       ecma_view_meta: EcmaViewMeta::default(),
       import_attribute_map: FxHashMap::default(),
+      cjs_reexport_require_spans: Vec::new(),
+      cjs_reexport_import_record_ids: Vec::new(),
     };
 
     Self {
@@ -353,6 +360,14 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
     }
 
     self.result.exports_kind = exports_kind;
+
+    // Resolve CJS re-export require spans to import record indices
+    self.result.cjs_reexport_import_record_ids = self
+      .result
+      .cjs_reexport_require_spans
+      .iter()
+      .filter_map(|span| self.result.imports.get(span).copied())
+      .collect();
 
     // If some commonjs module facade exports was used locally, we need to explicitly mark them as
     // has side effects, so that they should not be removed in linking stage.

--- a/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
+++ b/crates/rolldown/src/ecmascript/ecma_module_view_factory.rs
@@ -75,6 +75,8 @@ pub async fn create_ecma_view(
     dummy_record_set,
     constant_export_map,
     import_attribute_map,
+    cjs_reexport_require_spans: _,
+    cjs_reexport_import_record_ids,
   } = scanner.scan(ast.program())?;
   // If a export symbol in commonjs defined in multiple time, we just bailout treeshake it.
   for (k, v) in commonjs_exports {
@@ -136,6 +138,7 @@ pub async fn create_ecma_view(
     depended_runtime_helper: Box::default(),
     import_attribute_map,
     json_module_none_self_reference_included_symbol: None,
+    cjs_reexport_import_record_ids,
   };
 
   let ecma_related = EcmaRelated { ast, symbols, dynamic_import_rec_exports_usage, preserve_jsx };

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -446,6 +446,13 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
 
     let resolved_export =
       self.ctx.linking_infos[importee.idx].resolved_exports.get(&namespace_alias.property_name)?;
+
+    // Don't inline when there are conflicting CJS sources — the value could differ per branch
+    // TODO(hana): Optimize this with conditional inlining
+    if resolved_export.cjs_conflicting_symbol_refs.is_some() {
+      return None;
+    }
+
     let export_symbol = resolved_export.symbol_ref;
     let canonical_export_ref = self.ctx.symbol_db.canonical_ref_for(export_symbol);
 

--- a/crates/rolldown/src/module_loader/runtime_module_task.rs
+++ b/crates/rolldown/src/module_loader/runtime_module_task.rs
@@ -199,6 +199,7 @@ impl<Fs: FileSystem + Clone + 'static> RuntimeModuleTask<Fs> {
         depended_runtime_helper: Box::default(),
         import_attribute_map: FxHashMap::default(),
         json_module_none_self_reference_included_symbol: None,
+        cjs_reexport_import_record_ids: Vec::new(),
       },
       // TODO(hyf0/hmr): We might need to find a better way to handle this.
       originative_resolved_id: resolved_id,

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -62,6 +62,7 @@ impl PartialEq for MatchImportKindNormal {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[expect(clippy::box_collection)]
 pub enum MatchImportKind {
   /// The import is either external or not defined.
   _Ignore,
@@ -81,7 +82,7 @@ pub enum MatchImportKind {
   // The import resolved to multiple symbols via "export * from"
   Ambiguous {
     symbol_ref: SymbolRef,
-    potentially_ambiguous_symbol_refs: Vec<SymbolRef>,
+    potentially_ambiguous_symbol_refs: Box<Vec<SymbolRef>>,
   },
   NoMatch,
 }
@@ -145,12 +146,7 @@ impl LinkStage<'_> {
         .named_exports
         .iter()
         .map(|(name, local)| {
-          let resolved_export = ResolvedExport {
-            symbol_ref: local.referenced,
-            potentially_ambiguous_symbol_refs: None,
-            came_from_cjs: local.came_from_commonjs,
-          };
-          (name.clone(), resolved_export)
+          (name.clone(), ResolvedExport::new(local.referenced, local.came_from_commonjs))
         })
         .collect::<FxHashMap<_, _>>();
 
@@ -222,7 +218,7 @@ impl LinkStage<'_> {
         {
           let main_ref = self.symbols.canonical_ref_for(resolved_export.symbol_ref);
 
-          for ambiguous_ref in potentially_ambiguous_symbol_refs {
+          for ambiguous_ref in potentially_ambiguous_symbol_refs.iter() {
             let ambiguous_ref = self.symbols.canonical_ref_for(*ambiguous_ref);
             if main_ref != ambiguous_ref {
               continue 'next_export;
@@ -319,12 +315,19 @@ impl LinkStage<'_> {
       return;
     };
 
-    let is_cjsreexports = module.ast_usage.contains(EcmaModuleAstUsage::IsCjsReexport);
+    let cjs_reexport_modules: Vec<ModuleIdx> =
+      if module.ast_usage.contains(EcmaModuleAstUsage::IsCjsReexport) {
+        module
+          .ecma_view
+          .cjs_reexport_import_record_ids
+          .iter()
+          .filter_map(|&rec_idx| module.import_records[rec_idx].resolved_module)
+          .collect()
+      } else {
+        vec![]
+      };
 
-    let cjs_reexport_module =
-      is_cjsreexports.then(|| module.import_records.first().unwrap().into_resolved_module());
-
-    for dep_id in module.star_export_module_ids().chain(cjs_reexport_module) {
+    for dep_id in module.star_export_module_ids().chain(cjs_reexport_modules) {
       let Module::Normal(dep_module) = &normal_modules[dep_id] else {
         continue;
       };
@@ -348,20 +351,27 @@ impl LinkStage<'_> {
         // We have filled `resolve_exports` with `named_exports`. If the export is already exists, it means that the importer
         // has a named export with the same name. So the export from dep module is shadowed.
         if let Some(resolved_export) = resolve_exports.get_mut(exported_name) {
-          if named_export.referenced != resolved_export.symbol_ref && !resolved_export.came_from_cjs
-          {
-            resolved_export
-              .potentially_ambiguous_symbol_refs
-              .get_or_insert(Vec::default())
-              .push(named_export.referenced);
+          if named_export.referenced != resolved_export.symbol_ref {
+            if resolved_export.came_from_cjs || named_export.came_from_commonjs {
+              // CJS conflict: at least one side came from CJS (e.g., conditional re-exports
+              // mixing ESM and CJS targets). Track these separately — they're expected runtime
+              // branches, not static ambiguity errors.
+              resolved_export
+                .cjs_conflicting_symbol_refs
+                .get_or_insert(Box::default())
+                .push(named_export.referenced);
+            } else {
+              resolved_export
+                .potentially_ambiguous_symbol_refs
+                .get_or_insert(Box::default())
+                .push(named_export.referenced);
+            }
           }
         } else {
-          let resolved_export = ResolvedExport {
-            symbol_ref: named_export.referenced,
-            potentially_ambiguous_symbol_refs: None,
-            came_from_cjs: named_export.came_from_commonjs,
-          };
-          resolve_exports.insert(exported_name.clone(), resolved_export);
+          resolve_exports.insert(
+            exported_name.clone(),
+            ResolvedExport::new(named_export.referenced, named_export.came_from_commonjs),
+          );
         }
       }
 
@@ -853,7 +863,8 @@ impl BindImportsAndExportsContext<'_> {
                 symbol: export.symbol_ref,
                 potentially_ambiguous_export_star_refs: export
                   .potentially_ambiguous_symbol_refs
-                  .clone()
+                  .as_deref()
+                  .cloned()
                   .unwrap_or_default(),
               }
             }
@@ -1023,15 +1034,19 @@ impl BindImportsAndExportsContext<'_> {
         if let MatchImportKind::Normal(MatchImportKindNormal { symbol, .. }) = ret {
           return MatchImportKind::Ambiguous {
             symbol_ref: symbol,
-            potentially_ambiguous_symbol_refs: ambiguous_results
-              .iter()
-              .filter_map(|kind| match *kind {
-                MatchImportKind::Normal(MatchImportKindNormal { symbol, .. }) => Some(symbol),
-                MatchImportKind::Namespace { namespace_ref }
-                | MatchImportKind::NormalAndNamespace { namespace_ref, .. } => Some(namespace_ref),
-                _ => None,
-              })
-              .collect(),
+            potentially_ambiguous_symbol_refs: Box::new(
+              ambiguous_results
+                .iter()
+                .filter_map(|kind| match *kind {
+                  MatchImportKind::Normal(MatchImportKindNormal { symbol, .. }) => Some(symbol),
+                  MatchImportKind::Namespace { namespace_ref }
+                  | MatchImportKind::NormalAndNamespace { namespace_ref, .. } => {
+                    Some(namespace_ref)
+                  }
+                  _ => None,
+                })
+                .collect(),
+            ),
           };
         }
 

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -861,28 +861,9 @@ pub fn include_statement(
         return;
       }
       if module.ast_usage.contains(EcmaModuleAstUsage::IsCjsReexport) {
-        // When the importer is a CJS re-export (`module.exports = require('./mod')`),
-        // we normally skip bailout since resolved_exports tracks needed exports.
-        // However, for conditional re-export patterns like:
-        //   if (cond) module.exports = require('./a');
-        //   else module.exports = require('./b');
-        // resolved_exports only captures one branch, causing the other branch's
-        // `exports.xxx = value` statements to be incorrectly tree-shaken.
-        // Detect this by checking if the importer requires multiple CJS modules.
-        let has_more_than_one_cjs_requires = module
-          .import_records
-          .iter()
-          .filter(|rec| {
-            matches!(rec.kind, ImportKind::Require)
-              && rec.resolved_module.is_some_and(|idx| {
-                ctx.modules[idx]
-                  .as_normal()
-                  .is_some_and(|m| matches!(m.exports_kind, ExportsKind::CommonJs))
-              })
-          })
-          .nth(1)
-          .is_some();
-        if has_more_than_one_cjs_requires {
+        // When the importer has multiple CJS re-export targets (conditional re-exports),
+        // bail out to prevent tree-shaking from dropping any branch's exports.
+        if module.ecma_view.cjs_reexport_import_record_ids.len() > 1 {
           ctx.bailout_cjs_tree_shaking_modules.insert(module_idx);
         }
       } else {

--- a/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/_config.json
+++ b/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/_config.json
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "experimental": {
+      "devMode": {}
+    },
+    "optimization": {
+      "inlineConst": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/artifacts.snap
@@ -1,0 +1,43 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region jsx-dev-runtime.development.js
+var require_jsx_dev_runtime_development = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	__rolldown_runtime__.createModuleHotContext("jsx-dev-runtime.development.js");
+	__rolldown_runtime__.registerModule("jsx-dev-runtime.development.js", module);
+	exports.jsxDEV = function jsxDEV(type, props) {
+		return {
+			type,
+			props
+		};
+	};
+}));
+//#endregion
+//#region jsx-dev-runtime.js
+var require_jsx_dev_runtime = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	__rolldown_runtime__.createModuleHotContext("jsx-dev-runtime.js");
+	__rolldown_runtime__.registerModule("jsx-dev-runtime.js", module);
+	module.exports = require_jsx_dev_runtime_development();
+}));
+//#endregion
+//#region main.js
+var main_exports = /* @__PURE__ */ __exportAll({});
+var import_jsx_dev_runtime = require_jsx_dev_runtime();
+const main_hot = __rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", { exports: main_exports });
+const result = (0, import_jsx_dev_runtime.jsxDEV)("span", { children: "hello" });
+assert.deepStrictEqual(result, {
+	type: "span",
+	props: { children: "hello" }
+});
+main_hot.accept();
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/jsx-dev-runtime.development.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/jsx-dev-runtime.development.js
@@ -1,0 +1,4 @@
+'use strict';
+exports.jsxDEV = function jsxDEV(type, props) {
+  return { type: type, props: props };
+};

--- a/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/jsx-dev-runtime.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/jsx-dev-runtime.js
@@ -1,0 +1,5 @@
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./jsx-dev-runtime.production.js');
+} else {
+  module.exports = require('./jsx-dev-runtime.development.js');
+}

--- a/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/jsx-dev-runtime.production.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/jsx-dev-runtime.production.js
@@ -1,0 +1,2 @@
+'use strict';
+exports.jsxDEV = void 0;

--- a/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/main.js
+++ b/crates/rolldown/tests/rolldown/topics/hmr/inline_const_cjs_reexport/main.js
@@ -1,0 +1,12 @@
+// Reproduces a bug where inline const incorrectly inlines `void 0` for a CJS
+// named export when the CJS entry conditionally re-exports from two files,
+// and one of them (production) sets the export to `void 0`.
+// This mimics the react/jsx-dev-runtime pattern.
+import assert from 'node:assert';
+import { jsxDEV } from './jsx-dev-runtime.js';
+
+const show = true;
+const result = show && jsxDEV('span', { children: 'hello' });
+assert.deepStrictEqual(result, { type: 'span', props: { children: 'hello' } });
+
+import.meta.hot.accept();

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/_config.json
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "treeshake": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/artifacts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region esm-impl.mjs
+var esm_impl_exports = /* @__PURE__ */ __exportAll({ foo: () => foo$1 });
+var foo$1;
+var init_esm_impl = __esmMin((() => {
+	foo$1 = "from-esm";
+}));
+//#endregion
+//#region cjs-impl.js
+var require_cjs_impl = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.foo = "from-cjs";
+}));
+//#endregion
+//#region main.js
+var import_reexporter = (/* @__PURE__ */ __commonJSMin(((exports, module) => {
+	if (process.env.USE_ESM) module.exports = (init_esm_impl(), __toCommonJS(esm_impl_exports));
+	else module.exports = require_cjs_impl();
+})))();
+assert.strictEqual(import_reexporter.foo, "from-cjs");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/cjs-impl.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/cjs-impl.js
@@ -1,0 +1,1 @@
+exports.foo = 'from-cjs';

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/esm-impl.mjs
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/esm-impl.mjs
@@ -1,0 +1,1 @@
+export const foo = 'from-esm';

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/main.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/main.js
@@ -1,0 +1,3 @@
+import assert from 'node:assert';
+import { foo } from './reexporter.js';
+assert.strictEqual(foo, 'from-cjs');

--- a/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/reexporter.js
+++ b/crates/rolldown/tests/rolldown/tree_shaking/commonjs_reexport_conditional/reexporter.js
@@ -1,0 +1,5 @@
+if (process.env.USE_ESM) {
+  module.exports = require('./esm-impl.mjs');
+} else {
+  module.exports = require('./cjs-impl.js');
+}

--- a/crates/rolldown_common/src/ecmascript/ecma_view.rs
+++ b/crates/rolldown_common/src/ecmascript/ecma_view.rs
@@ -107,6 +107,8 @@ pub struct EcmaView {
   pub import_attribute_map: FxHashMap<ImportRecordIdx, ImportAttribute>,
   /// Use `Box` since it is rarely used also it could reduce the size of `EcmaView`, .
   pub json_module_none_self_reference_included_symbol: Option<Box<FxHashSet<SymbolRef>>>,
+  /// Import record indices for `module.exports = require(...)` patterns.
+  pub cjs_reexport_import_record_ids: Vec<ImportRecordIdx>,
 }
 
 bitflags! {

--- a/crates/rolldown_common/src/types/resolved_export.rs
+++ b/crates/rolldown_common/src/types/resolved_export.rs
@@ -1,6 +1,7 @@
 use crate::SymbolRef;
 
 #[derive(Debug, Clone)]
+#[expect(clippy::box_collection)]
 pub struct ResolvedExport {
   // Because create export star exports happens before linking imports, The symbols can't  determine if duplicate names from export star resolution are
   // ambiguous (point to different symbols) or not (point to the same symbol).
@@ -22,13 +23,23 @@ pub struct ResolvedExport {
   // In this case "entry.js" should have two exports "x" and "y", neither of
   // which are ambiguous. To handle this case, ambiguity resolution will be
   // deferred to linking imports.
-  pub potentially_ambiguous_symbol_refs: Option<Vec<SymbolRef>>,
+  pub potentially_ambiguous_symbol_refs: Option<Box<Vec<SymbolRef>>>,
   pub symbol_ref: SymbolRef,
   pub came_from_cjs: bool,
+  /// When multiple CJS sources (conditional re-exports) provide the same export name,
+  /// this tracks the alternative symbols. Unlike ESM ambiguity (which is an error),
+  /// CJS conflicts are expected — only one branch runs at runtime, but statically
+  /// we don't know which.
+  pub cjs_conflicting_symbol_refs: Option<Box<Vec<SymbolRef>>>,
 }
 
 impl ResolvedExport {
   pub fn new(symbol_ref: SymbolRef, came_from_cjs: bool) -> Self {
-    Self { symbol_ref, potentially_ambiguous_symbol_refs: None, came_from_cjs }
+    Self {
+      symbol_ref,
+      potentially_ambiguous_symbol_refs: None,
+      came_from_cjs,
+      cjs_conflicting_symbol_refs: None,
+    }
   }
 }


### PR DESCRIPTION
## Summary

When a CJS module conditionally re-exports from multiple sources (e.g., React's `jsx-dev-runtime.js`), the linker previously only followed the first import record. This could lead to incorrect inline const values and incomplete tree-shaking.

This PR:
- Records which import records correspond to `module.exports = require(...)` during scanning, rather than relying on `import_records.first()`
- Follows all CJS re-export targets when building `resolved_exports`
- Tracks conflicting CJS exports when multiple targets provide the same name
- Skips inline const for exports with CJS conflicts, since the runtime value depends on which branch executes
- Uses the recorded import record indices to simplify the tree-shaking bailout heuristic

## Background

```js
// jsx-dev-runtime.js
if (process.env.NODE_ENV === 'production') {
  module.exports = require('./production');   // exports.jsxDEV = void 0
} else {
  module.exports = require('./development');  // exports.jsxDEV = function() {...}
}
```

Previously, `add_exports_for_export_star` used `import_records.first()` to find the re-export target. This meant only the first `require()` target's exports entered `resolved_exports` — the rest were silently dropped. This caused `jsxDEV` to be incorrectly inlined as `void 0`.

## Related issues

- https://github.com/vitejs/vite/issues/21884 — the `void 0` inlining case fixed by this PR
- https://github.com/rolldown/rolldown/issues/8345#issuecomment-3908370251 — related discussion on the underlying issue
- https://github.com/vitejs/vite/issues/21843 — related Vite issue, worked around by https://github.com/vitejs/vite/pull/21865 (disabling `inlineConst` for affected packages). This PR fixes the root cause in rolldown so we can reenable `inlineConst` in Vite. cc @sapphi-red 

## Test plan

- [x] New `inline_const_cjs_reexport` - validates inline const works with multiple cjs re-exports
- [x] New `tree_shaking/cjs_reexport_conditional` — validates ESM+CJS mixed re-export (ESM first, CJS second)
- [x] `just test-rust` all green