### PR TITLE
fix(browser): bundle binding types in dts output

### DIFF
--- a/packages/rolldown/build.ts
+++ b/packages/rolldown/build.ts
@@ -155,7 +155,7 @@ function withShared({
 }
 
 // alias binding file to rolldown-binding.wasi.js and mark it as external
-// alias its dts file to rolldown-binding.d.ts without external
+// skip redirection for .d.ts importers so the dts plugin can bundle types
 function resolveWasiBinding(isBrowserBuild?: boolean): Plugin {
   return {
     name: 'resolve-wasi-binding',
@@ -165,6 +165,8 @@ function resolveWasiBinding(isBrowserBuild?: boolean): Plugin {
         const resolution = await this.resolve(id, importer, options);
 
         if (resolution?.id === bindingFile) {
+          // Let .d.ts importers resolve normally so binding types get bundled inline
+          if (importer && /\.d\.[cm]?ts$/.test(importer)) return resolution;
           const id = isBrowserBuild ? bindingFileWasiBrowser : bindingFileWasi;
           return { id, external: 'relative' };
         }


### PR DESCRIPTION
Fixes #8929

The browser package's `.d.mts` files reference `binding.cjs` as external, but no type declaration file exists in the published package. This is because `resolveWasiBinding()` marks `binding.cjs` as `external: 'relative'` for all importers, including `.d.ts` files from `rolldown-plugin-dts`. The dts resolver sees the external flag and passes it through without bundling the types.

Fix: skip the external redirect when the importer is a `.d.ts` file, so the dts plugin can resolve and bundle binding types inline.