### PR TITLE
test: add test for why PureAnnotation is needed in execution order check

### DIFF
--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/_config.json
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "strictExecutionOrder": true,
+    "experimental": {
+      "onDemandWrapping": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/artifacts.snap
@@ -1,0 +1,27 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+function getGlobalValue() {
+	return globalValue;
+}
+var dep_default;
+__esmMin((() => {
+	//#region setup.js
+	globalThis.globalValue = "foo";
+	//#endregion
+	//#region dep.js
+	dep_default = /* @__PURE__ */ getGlobalValue();
+	//#endregion
+	//#region main.js
+	assert.strictEqual(dep_default, "foo");
+	//#endregion
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/dep.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/dep.js
@@ -1,0 +1,15 @@
+// `getGlobalValue` is a local function whose body accesses a global variable.
+// The `/*#__PURE__*/` annotation means the call itself is not treated as
+// having side effects (`Unknown`), and because the callee is a local
+// identifier (not a global like `Reflect.something`), there is no
+// `GlobalVarAccess` flag on this statement either.
+//
+// Without the `PureAnnotation` flag in the `ExecutionOrderSensitive` check,
+// this module would NOT be wrapped, and `getGlobalValue()` would execute
+// before `setup.js` has a chance to set `globalThis.globalValue`, producing
+// `undefined` instead of `'foo'`.
+function getGlobalValue() {
+  return globalValue;
+}
+
+export default /*#__PURE__*/ getGlobalValue();

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/main.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/main.js
@@ -1,0 +1,5 @@
+import assert from 'node:assert';
+import './setup.js';
+import value from './dep.js';
+
+assert.strictEqual(value, 'foo');

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/setup.js
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/pure_annotation_local_fn_reads_global/setup.js
@@ -1,0 +1,1 @@
+globalThis.globalValue = 'foo';


### PR DESCRIPTION
## Summary
- Adds an integration test combining scenarios from #4920 and #5303 to demonstrate that `PureAnnotation` must be included in the `ExecutionOrderSensitive` check.
- A `/*#__PURE__*/` call to a local function that reads a global variable set by another module must still trigger wrapping, otherwise execution order is broken.

Ref: https://github.com/rolldown/rolldown/pull/8909#discussion_r2992465103

## Test plan
- [x] New test `pure_annotation_local_fn_reads_global` passes with `just dt`
- [x] Snapshot confirms `dep.js` is wrapped with `__esmMin` in both default and `onDemandWrapping` variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)