### PR TITLE
refactor: rename came_from_cjs to came_from_commonjs for consistency

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
+++ b/crates/rolldown/src/stages/generate_stage/compute_cross_chunk_links.rs
@@ -266,7 +266,7 @@ impl GenerateStage<'_> {
               .map(|(_, export)| export)
               // A chunk should always consume a cjs export symbol by property access, so filter
               // out a exported symbol that came from a cjs module.
-              .filter(|resolved_export| !resolved_export.came_from_cjs)
+              .filter(|resolved_export| !resolved_export.came_from_commonjs)
             {
               depended_symbols
                 .insert(symbols.canonical_ref_resolving_namespace(export_ref.symbol_ref));

--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -226,7 +226,7 @@ impl LinkStage<'_> {
           }
         }
         sorted_and_non_ambiguous_resolved_exports
-          .push((exported_name.clone(), resolved_export.came_from_cjs));
+          .push((exported_name.clone(), resolved_export.came_from_commonjs));
       }
       sorted_and_non_ambiguous_resolved_exports.sort_unstable();
       meta.sorted_and_non_ambiguous_resolved_exports =
@@ -352,7 +352,7 @@ impl LinkStage<'_> {
         // has a named export with the same name. So the export from dep module is shadowed.
         if let Some(resolved_export) = resolve_exports.get_mut(exported_name) {
           if named_export.referenced != resolved_export.symbol_ref {
-            if resolved_export.came_from_cjs || named_export.came_from_commonjs {
+            if resolved_export.came_from_commonjs || named_export.came_from_commonjs {
               // CJS conflict: at least one side came from CJS (e.g., conditional re-exports
               // mixing ESM and CJS targets). Track these separately — they're expected runtime
               // branches, not static ambiguity errors.
@@ -432,7 +432,7 @@ impl LinkStage<'_> {
                   let name = &prop.name;
                   let meta = &self.metas[canonical_ref_owner.idx];
                   let export_symbol = meta.resolved_exports.get(name).and_then(|resolved_export| {
-                    (!resolved_export.came_from_cjs).then_some(resolved_export)
+                    (!resolved_export.came_from_commonjs).then_some(resolved_export)
                   });
                   let Some(export_symbol) = export_symbol else {
                     // when we try to resolve `a.b.c`, and found that `b` is not exported by module
@@ -549,7 +549,7 @@ impl LinkStage<'_> {
                           .resolved_exports
                           .get(&member_expr_ref.prop_and_span_list[cursor].name)
                           .and_then(|resolved_export| {
-                            resolved_export.came_from_cjs.then_some(resolved_export)
+                            resolved_export.came_from_commonjs.then_some(resolved_export)
                           })
                       })
                   {
@@ -621,7 +621,7 @@ impl LinkStage<'_> {
             self.metas[*cjs_module_idx]
               .resolved_exports
               .values()
-              .filter(|e| e.came_from_cjs)
+              .filter(|e| e.came_from_commonjs)
               .map(|e| e.symbol_ref),
           );
         }
@@ -852,7 +852,7 @@ impl BindImportsAndExportsContext<'_> {
       Specifier::Literal(literal_imported) => {
         match self.metas[importee_id].resolved_exports.get(literal_imported) {
           Some(export) => {
-            if export.came_from_cjs {
+            if export.came_from_commonjs {
               ImportStatus::DynamicFallbackWithCommonjsReference {
                 namespace_ref: importee.namespace_object_ref,
                 commonjs_symbol: export.symbol_ref,

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -40,7 +40,7 @@ fn init_entry_point_stmt_info(
           dynamic_import_exports_usage_map,
           true,
         )
-        .map(|(_, resolved_export)| (resolved_export.symbol_ref, resolved_export.came_from_cjs)),
+        .map(|(_, resolved_export)| (resolved_export.symbol_ref, resolved_export.came_from_commonjs)),
     );
   }
   // Entry chunk need to generate exports, so we need reference to all exports to make sure they are included in tree-shaking.

--- a/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
+++ b/crates/rolldown/src/stages/link_stage/create_exports_for_ecma_modules.rs
@@ -40,7 +40,9 @@ fn init_entry_point_stmt_info(
           dynamic_import_exports_usage_map,
           true,
         )
-        .map(|(_, resolved_export)| (resolved_export.symbol_ref, resolved_export.came_from_commonjs)),
+        .map(|(_, resolved_export)| {
+          (resolved_export.symbol_ref, resolved_export.came_from_commonjs)
+        }),
     );
   }
   // Entry chunk need to generate exports, so we need reference to all exports to make sure they are included in tree-shaking.

--- a/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
+++ b/crates/rolldown/src/stages/link_stage/tree_shaking/include_statements.rs
@@ -118,7 +118,7 @@ fn include_cjs_bailout_exports(
     metas[idx]
       .resolved_exports
       .iter()
-      .filter_map(|(_name, local)| local.came_from_cjs.then_some(local))
+      .filter_map(|(_name, local)| local.came_from_commonjs.then_some(local))
       .for_each(|local| {
         include_symbol_and_check_cjs_bailout(
           context,

--- a/crates/rolldown_common/src/types/resolved_export.rs
+++ b/crates/rolldown_common/src/types/resolved_export.rs
@@ -25,7 +25,7 @@ pub struct ResolvedExport {
   // deferred to linking imports.
   pub potentially_ambiguous_symbol_refs: Option<Box<Vec<SymbolRef>>>,
   pub symbol_ref: SymbolRef,
-  pub came_from_cjs: bool,
+  pub came_from_commonjs: bool,
   /// When multiple CJS sources (conditional re-exports) provide the same export name,
   /// this tracks the alternative symbols. Unlike ESM ambiguity (which is an error),
   /// CJS conflicts are expected — only one branch runs at runtime, but statically
@@ -38,7 +38,7 @@ impl ResolvedExport {
     Self {
       symbol_ref,
       potentially_ambiguous_symbol_refs: None,
-      came_from_cjs,
+      came_from_commonjs: came_from_cjs,
       cjs_conflicting_symbol_refs: None,
     }
   }


### PR DESCRIPTION
Renames the `ResolvedExport::came_from_cjs` field to `came_from_commonjs` to be consistent with the naming style used elsewhere (e.g., `NamedExport::came_from_commonjs`). Pure rename across 5 files, no behavioral change.