### PR TITLE
fix: consistent order for `meta.chunks` in `renderChunk` hook

### DIFF
--- a/crates/rolldown/src/utils/render_chunks.rs
+++ b/crates/rolldown/src/utils/render_chunks.rs
@@ -8,7 +8,7 @@ use rolldown_common::{
 };
 use rolldown_plugin::{HookRenderChunkArgs, SharedPluginDriver};
 use rolldown_sourcemap::{SourceMap, collapse_sourcemaps};
-use rustc_hash::FxHashMap;
+use rolldown_utils::indexmap::FxIndexMap;
 
 use crate::type_alias::IndexInstantiatedChunks;
 
@@ -28,7 +28,7 @@ pub async fn render_chunks(
           None
         }
       })
-      .collect::<FxHashMap<ArcStr, Arc<RollupRenderedChunk>>>(),
+      .collect::<FxIndexMap<ArcStr, Arc<RollupRenderedChunk>>>(),
   );
 
   let result = try_join_all(assets.iter_mut().enumerate().map(|(index, asset)| {

--- a/crates/rolldown_binding/src/options/plugin/types/binding_render_chunk_meta_chunks.rs
+++ b/crates/rolldown_binding/src/options/plugin/types/binding_render_chunk_meta_chunks.rs
@@ -1,25 +1,27 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use arcstr::ArcStr;
+use indexmap::IndexMap;
 use rolldown_common::RollupRenderedChunk;
-use rustc_hash::FxHashMap;
+use rolldown_utils::indexmap::FxIndexMap;
+use rustc_hash::FxBuildHasher;
 
 use crate::types::binding_rendered_chunk::BindingRenderedChunk;
 
 #[napi_derive::napi]
 #[derive(Debug)]
 pub struct BindingRenderedChunkMeta {
-  inner: Arc<FxHashMap<ArcStr, Arc<RollupRenderedChunk>>>,
+  inner: Arc<FxIndexMap<ArcStr, Arc<RollupRenderedChunk>>>,
 }
 
 #[napi_derive::napi]
 impl BindingRenderedChunkMeta {
-  pub fn new(inner: Arc<FxHashMap<ArcStr, Arc<RollupRenderedChunk>>>) -> Self {
+  pub fn new(inner: Arc<FxIndexMap<ArcStr, Arc<RollupRenderedChunk>>>) -> Self {
     Self { inner }
   }
 
   #[napi(getter)]
-  pub fn chunks(&self) -> HashMap<String, BindingRenderedChunk> {
+  pub fn chunks(&self) -> IndexMap<String, BindingRenderedChunk, FxBuildHasher> {
     self
       .inner
       .iter()

--- a/crates/rolldown_plugin/src/types/hook_render_chunk_args.rs
+++ b/crates/rolldown_plugin/src/types/hook_render_chunk_args.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use arcstr::ArcStr;
 use rolldown_common::{RollupRenderedChunk, SharedNormalizedBundlerOptions};
-use rustc_hash::FxHashMap;
+use rolldown_utils::indexmap::FxIndexMap;
 
 #[derive(Debug)]
 pub struct HookRenderChunkArgs<'a> {
   pub options: &'a SharedNormalizedBundlerOptions,
   pub code: String,
   pub chunk: Arc<RollupRenderedChunk>,
-  pub chunks: Arc<FxHashMap<ArcStr, Arc<RollupRenderedChunk>>>,
+  pub chunks: Arc<FxIndexMap<ArcStr, Arc<RollupRenderedChunk>>>,
 }


### PR DESCRIPTION
plugin-legacy depends on the order of `meta.chunks` in `renderChunk` hook.

- https://github.com/vitejs/vite/blob/99897d27b44dd73307fa03e2f11f0baa1a1dc939/packages/plugin-legacy/src/index.ts#L487-L492
- https://github.com/vitejs/vite/blob/99897d27b44dd73307fa03e2f11f0baa1a1dc939/packages/plugin-legacy/src/index.ts#L307-L309
- https://github.com/vitejs/vite/blob/99897d27b44dd73307fa03e2f11f0baa1a1dc939/packages/plugin-legacy/src/index.ts#L339-L341
- https://github.com/vitejs/vite/blob/99897d27b44dd73307fa03e2f11f0baa1a1dc939/packages/plugin-legacy/src/index.ts#L949

This caused the output to be unstable (https://github.com/vitejs/vite/issues/21905#issuecomment-4147462251).

This PR fixes that issue by ensuring the order of `meta.chunks` in `renderChunk` hook is consistent.