### PR TITLE
chore: remove unused `type-check` scripts

### DIFF
--- a/justfile
+++ b/justfile
@@ -164,7 +164,6 @@ clippy:
 
 lint-node:
   vp check
-  vp run type-check
   vp run lint-knip
   vp run lint-publint
 

--- a/packages/rolldown/tests/package.json
+++ b/packages/rolldown/tests/package.json
@@ -19,8 +19,7 @@
     "test:watcher": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run watch.test.ts --reporter verbose --hideSkippedTests",
     "test:cli": "RUST_BACKTRACE=1 ROLLDOWN_TEST=1 vitest run cli-e2e.test.ts --reporter verbose --hideSkippedTests",
     "test:stability": "node ./stability/issue-3453/src/build.mjs && node ./stability/issue-3453/verify.mjs",
-    "test:types": "vitest run --typecheck.only --reporter verbose --hideSkippedTests",
-    "type-check": "tsc --noEmit"
+    "test:types": "vitest run --typecheck.only --reporter verbose --hideSkippedTests"
   },
   "dependencies": {
     "rolldown": "workspace:*",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "type-check": "tsc -b",
     "setup-bench": "oxnode ./misc/setup-benchmark-input/index.js",
     "gen-esbuild-tests": "oxnode ./src/esbuild-tests/gen-tests.ts",
     "esbuild-snap-diff": "oxnode ./src/esbuild-tests/snap-diff/index.ts"


### PR DESCRIPTION
The type check is now handled by oxlint.

refs #8841