### PR TITLE
feat: support inlineConst for CJS exports accessed through module.exports

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -531,30 +531,98 @@ impl LinkStage<'_> {
                     };
                   // corresponding to cases in:
                   // https://github.com/rolldown/rolldown/blob/30a5a2fc8fa6785821153922e21dc0273cc00c7a/crates/rolldown/tests/rolldown/tree_shaking/commonjs/main.js?plain=1#L3-L10
-                  if continue_resolve
-                    && let Some(m) = self.metas[maybe_namespace.owner]
-                      .named_import_to_cjs_module
-                      .get(&maybe_namespace)
-                      .or_else(|| {
-                        self.metas[maybe_namespace.owner]
-                          .import_record_ns_to_cjs_module
-                          .get(&maybe_namespace)
-                      })
-                      .or_else(|| {
-                        (self.metas[maybe_namespace.owner].has_dynamic_exports)
-                          .then_some(&maybe_namespace.owner)
-                      })
-                      .and_then(|idx| {
-                        self.metas[*idx]
-                          .resolved_exports
-                          .get(&member_expr_ref.prop_and_span_list[cursor].name)
-                          .and_then(|resolved_export| {
-                            resolved_export.came_from_commonjs.then_some(resolved_export)
-                          })
+                  let cjs_module_idx = continue_resolve
+                    .then(|| {
+                      self.metas[maybe_namespace.owner]
+                        .named_import_to_cjs_module
+                        .get(&maybe_namespace)
+                        .or_else(|| {
+                          self.metas[maybe_namespace.owner]
+                            .import_record_ns_to_cjs_module
+                            .get(&maybe_namespace)
+                        })
+                        .or_else(|| {
+                          (self.metas[maybe_namespace.owner].has_dynamic_exports)
+                            .then_some(&maybe_namespace.owner)
+                        })
+                        .copied()
+                    })
+                    .flatten();
+                  if let Some(cjs_idx) = cjs_module_idx
+                    && let Some(m) = self.metas[cjs_idx]
+                      .resolved_exports
+                      .get(&member_expr_ref.prop_and_span_list[cursor].name)
+                      .and_then(|resolved_export| {
+                        resolved_export.came_from_commonjs.then_some(resolved_export)
                       })
                   {
                     let is_default = member_expr_ref.prop_and_span_list[cursor].name == "default";
-                    target_commonjs_exported_symbol = Some((m.symbol_ref, is_default));
+                    // When the accessed property is `default`, check if `.default` represents
+                    // the whole `module.exports` (rather than `exports.default`). This is true when:
+                    // - Node ESM mode: __toESM always ignores __esModule flag
+                    // - Non-node mode without __esModule: __toESM sets .default = module.exports
+                    // In these cases, skip resolving `.default` to a specific CJS export.
+                    let default_is_module_exports = is_default && {
+                      let is_node_esm = module.should_consider_node_esm_spec_for_static_import();
+                      let importee_has_es_module_flag =
+                        self.module_table[cjs_idx].as_normal().is_some_and(|importee| {
+                          importee.ecma_view.ast_usage.contains(EcmaModuleAstUsage::EsModuleFlag)
+                        });
+                      is_node_esm || !importee_has_es_module_flag
+                    };
+
+                    // If the current property is `default` and it represents the whole `module.exports`,
+                    // try to resolve the next property as a CJS export.
+                    if default_is_module_exports
+                      && cursor + 1 < member_expr_ref.prop_and_span_list.len()
+                    {
+                      if let Some(property) = self.metas[cjs_idx]
+                        .resolved_exports
+                        .get(&member_expr_ref.prop_and_span_list[cursor + 1].name)
+                        .and_then(|resolved_export| {
+                          resolved_export.came_from_commonjs.then_some(resolved_export)
+                        })
+                      {
+                        let is_next_default =
+                          member_expr_ref.prop_and_span_list[cursor + 1].name == "default";
+                        if is_next_default && maybe_namespace_symbol.namespace_alias.is_none() {
+                          // import * as ns; ns.default.default — can't optimize.
+                          //
+                          // __toESM sets import_ns.default = module.exports and __copyProps
+                          // skips "default" (already set), so exports.default is only
+                          // reachable via import_ns.default.default (two levels).
+                          // If we advance cursor, props becomes ["default"] and the finalizer
+                          // base is import_ns (#LOCAL_NAMESPACE has no namespace_alias to
+                          // append .default), so the result is import_ns.default which is
+                          // module.exports — not module.exports.default.
+                          //
+                          // Other non-"default" properties (e.g. ns.default.foo) work fine
+                          // because __copyProps copies them onto the __toESM target, so
+                          // import_ns.foo = module.exports.foo.
+                        } else {
+                          cursor += 1;
+                          target_commonjs_exported_symbol =
+                            Some((property.symbol_ref, is_next_default));
+                          depended_refs.push(property.symbol_ref);
+
+                          if member_expr_ref.is_write {
+                            written_cjs_exports.push(property.symbol_ref);
+                          }
+                        }
+                      }
+                    } else if default_is_module_exports {
+                      // This represents the case like `import * as ns from 'cjs';
+                      // `ns.default` where `.default` is the whole `module.exports`.
+                      //
+                      // Currently, m.namespace_object_ref is not set to the constant value map.
+                      // So in this case, it's not going to be inlined as a constant.
+                      target_commonjs_exported_symbol = self.module_table[cjs_idx]
+                        .as_normal()
+                        .map(|m| (m.namespace_object_ref, true));
+                    } else {
+                      target_commonjs_exported_symbol = Some((m.symbol_ref, is_default));
+                    }
+
                     depended_refs.push(m.symbol_ref);
                     // If this member expression is a write (e.g. `cjs.c = 'abcd'`), the
                     // CJS exported symbol should not be inlined as a constant since its

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/_config.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "optimization": {
+      "inlineConst": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/artifacts.snap
@@ -1,0 +1,58 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region cjs.cjs
+var require_cjs = /* @__PURE__ */ __commonJSMin(((exports) => {
+	Object.defineProperties(exports, { __esModule: { value: true } });
+	exports.default = "default";
+	exports.foo = "foo";
+}));
+//#endregion
+//#region cjs2.cjs
+var require_cjs2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = "module.exports";
+}));
+//#endregion
+//#region cjs3.cjs
+var require_cjs3 = /* @__PURE__ */ __commonJSMin(((exports) => {
+	Object.defineProperties(exports, { __esModule: { value: true } });
+	exports.bar = () => "bar";
+	exports.baz = { qux: "qux" };
+}));
+//#endregion
+//#region main.js
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs(), 1);
+var import_cjs2 = /* @__PURE__ */ __toESM(require_cjs2(), 1);
+var import_cjs3 = /* @__PURE__ */ __toESM(require_cjs3(), 1);
+assert.deepStrictEqual(import_cjs.default, {
+	default: "default",
+	foo: "foo"
+});
+assert.deepStrictEqual(import_cjs.default, {
+	default: "default",
+	foo: "foo"
+});
+assert.deepStrictEqual(import_cjs.default, {
+	default: "default",
+	foo: "foo"
+});
+assert.deepStrictEqual(import_cjs.default.default, "default");
+assert.deepStrictEqual(import_cjs.default.default, "default");
+assert.deepStrictEqual("foo", "foo");
+assert.deepStrictEqual("foo", "foo");
+assert.deepStrictEqual("foo", "foo");
+assert.deepStrictEqual("foo", "foo");
+assert.deepStrictEqual(import_cjs2.default, "module.exports");
+assert.deepStrictEqual(import_cjs3.bar(), "bar");
+assert.deepStrictEqual((0, import_cjs3.bar)(), "bar");
+assert.deepStrictEqual(import_cjs3.baz.qux, "qux");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs.cjs
@@ -1,0 +1,5 @@
+Object.defineProperties(exports, {
+  __esModule: { value: true },
+});
+exports.default = 'default';
+exports.foo = 'foo';

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs2.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs2.cjs
@@ -1,0 +1,1 @@
+module.exports = 'module.exports';

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs3.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs3.cjs
@@ -1,0 +1,7 @@
+Object.defineProperties(exports, {
+  __esModule: { value: true },
+});
+exports.bar = () => 'bar';
+exports.baz = {
+  qux: 'qux',
+};

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/main.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert';
+
+import * as cjs from './cjs.cjs';
+import cjs_default, { default as cjs_default_default, foo as cjs_foo } from './cjs.cjs';
+import * as cjs2 from './cjs2.cjs';
+import * as cjs3 from './cjs3.cjs';
+import { bar } from './cjs3.cjs';
+
+// If this file is marked as `package.json#type: "module"` by rolldown,
+// then `cjs.default` should point to `module.exports` of `cjs.cjs`.
+assert.deepStrictEqual(cjs.default, { default: 'default', foo: 'foo' });
+assert.deepStrictEqual(cjs_default, { default: 'default', foo: 'foo' });
+assert.deepStrictEqual(cjs_default_default, { default: 'default', foo: 'foo' });
+
+// Cannot inline. Check out bind_imports_and_exports for more details.
+assert.deepStrictEqual(cjs.default.default, 'default');
+assert.deepStrictEqual(cjs_default_default.default, 'default');
+
+assert.deepStrictEqual(cjs.default.foo, 'foo');
+assert.deepStrictEqual(cjs.foo, 'foo');
+assert.deepStrictEqual(cjs_foo, 'foo');
+assert.deepStrictEqual(cjs_default_default.foo, 'foo');
+
+// Does't support inline `module.exports`. Not inlined
+assert.deepStrictEqual(cjs2.default, 'module.exports');
+
+assert.deepStrictEqual(cjs3.bar(), 'bar');
+assert.deepStrictEqual(bar(), 'bar');
+
+// Too deep. Not inlined
+assert.deepStrictEqual(cjs3.baz.qux, 'qux');

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/main.js
@@ -21,7 +21,7 @@ assert.deepStrictEqual(cjs.foo, 'foo');
 assert.deepStrictEqual(cjs_foo, 'foo');
 assert.deepStrictEqual(cjs_default_default.foo, 'foo');
 
-// Does't support inline `module.exports`. Not inlined
+// Doesn't support inline `module.exports`. Not inlined
 assert.deepStrictEqual(cjs2.default, 'module.exports');
 
 assert.deepStrictEqual(cjs3.bar(), 'bar');

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/package.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/_config.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "optimization": {
+      "inlineConst": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/artifacts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region cjs.cjs
+var require_cjs = /* @__PURE__ */ __commonJSMin(((exports) => {
+	Object.defineProperties(exports, { __esModule: { value: true } });
+	exports.default = JSON.parse("\"default\"");
+}));
+//#endregion
+//#region cjs2.cjs
+var require_cjs2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = JSON.parse("\"default\"");
+}));
+//#endregion
+//#region main.js
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs(), 1);
+var import_cjs2 = /* @__PURE__ */ __toESM(require_cjs2(), 1);
+assert.deepStrictEqual(import_cjs.default, { default: "default" });
+assert.deepStrictEqual(import_cjs.default.default, "default");
+assert.deepStrictEqual(import_cjs2.default, "default");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/cjs.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/cjs.cjs
@@ -1,0 +1,5 @@
+Object.defineProperties(exports, {
+  __esModule: { value: true },
+});
+// Non-constant default export — cannot be inlined
+exports.default = JSON.parse('"default"');

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/cjs2.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/cjs2.cjs
@@ -1,0 +1,1 @@
+module.exports = JSON.parse('"default"');

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/main.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+import * as cjs from './cjs.cjs';
+import * as cjs2 from './cjs2.cjs';
+
+// cjs.default = module.exports (node ESM mode, __esModule ignored)
+// cjs.default.default = module.exports.default = exports.default
+assert.deepStrictEqual(cjs.default, { default: 'default' });
+assert.deepStrictEqual(cjs.default.default, 'default');
+
+assert.deepStrictEqual(cjs2.default, 'default');

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/package.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Summary

**Fix**: `inlineConst` incorrectly inlined `.default` on CJS modules when `.default` actually
represents `module.exports` (not `exports.default`). This happens when the importer uses
Node ESM semantics (`"type": "module"`) or the importee has no `__esModule` flag — in
both cases `__toESM` sets `.default = module.exports`.

**Optimization**: When `.default` represents `module.exports`, properties accessed through it (e.g.
`ns.default.foo`) can now be resolved and inlined by looking up the next property in the
CJS module's exports.

## Test plan
- Added `esm_import_cjs_with_esmodule_flag` fixture covering `import *`, default import, named import, and mixed access patterns
- Added `esm_import_cjs_with_esmodule_flag_non_const` fixture for non-constant exports to verify the non-inlined path
- All existing `cjs_compat` and `inline_const` tests pass