### PR TITLE
fix: correct inlining based on module's def format and esModule flag

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -531,30 +531,49 @@ impl LinkStage<'_> {
                     };
                   // corresponding to cases in:
                   // https://github.com/rolldown/rolldown/blob/30a5a2fc8fa6785821153922e21dc0273cc00c7a/crates/rolldown/tests/rolldown/tree_shaking/commonjs/main.js?plain=1#L3-L10
-                  if continue_resolve
-                    && let Some(m) = self.metas[maybe_namespace.owner]
-                      .named_import_to_cjs_module
-                      .get(&maybe_namespace)
-                      .or_else(|| {
-                        self.metas[maybe_namespace.owner]
-                          .import_record_ns_to_cjs_module
-                          .get(&maybe_namespace)
-                      })
-                      .or_else(|| {
-                        (self.metas[maybe_namespace.owner].has_dynamic_exports)
-                          .then_some(&maybe_namespace.owner)
-                      })
-                      .and_then(|idx| {
-                        self.metas[*idx]
-                          .resolved_exports
-                          .get(&member_expr_ref.prop_and_span_list[cursor].name)
-                          .and_then(|resolved_export| {
-                            resolved_export.came_from_commonjs.then_some(resolved_export)
-                          })
+                  let cjs_module_idx = continue_resolve
+                    .then(|| {
+                      self.metas[maybe_namespace.owner]
+                        .named_import_to_cjs_module
+                        .get(&maybe_namespace)
+                        .or_else(|| {
+                          self.metas[maybe_namespace.owner]
+                            .import_record_ns_to_cjs_module
+                            .get(&maybe_namespace)
+                        })
+                        .or_else(|| {
+                          (self.metas[maybe_namespace.owner].has_dynamic_exports)
+                            .then_some(&maybe_namespace.owner)
+                        })
+                        .copied()
+                    })
+                    .flatten();
+                  if let Some(cjs_idx) = cjs_module_idx
+                    && let Some(m) = self.metas[cjs_idx]
+                      .resolved_exports
+                      .get(&member_expr_ref.prop_and_span_list[cursor].name)
+                      .and_then(|resolved_export| {
+                        resolved_export.came_from_commonjs.then_some(resolved_export)
                       })
                   {
                     let is_default = member_expr_ref.prop_and_span_list[cursor].name == "default";
-                    target_commonjs_exported_symbol = Some((m.symbol_ref, is_default));
+                    // When the accessed property is `default`, check if `.default` represents
+                    // the whole `module.exports` (rather than `exports.default`). This is true when:
+                    // - Node ESM mode: __toESM always ignores __esModule flag
+                    // - Non-node mode without __esModule: __toESM sets .default = module.exports
+                    // In these cases, skip resolving `.default` to a specific CJS export.
+                    let default_is_module_exports = is_default && {
+                      let is_node_esm = module.should_consider_node_esm_spec_for_static_import();
+                      let importee_has_es_module_flag =
+                        self.module_table[cjs_idx].as_normal().is_some_and(|importee| {
+                          importee.ecma_view.ast_usage.contains(EcmaModuleAstUsage::EsModuleFlag)
+                        });
+                      is_node_esm || !importee_has_es_module_flag
+                    };
+
+                    if !default_is_module_exports {
+                      target_commonjs_exported_symbol = Some((m.symbol_ref, is_default));
+                    }
                     depended_refs.push(m.symbol_ref);
                     // If this member expression is a write (e.g. `cjs.c = 'abcd'`), the
                     // CJS exported symbol should not be inlined as a constant since its

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/_config.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "optimization": {
+      "inlineConst": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/artifacts.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.js
+var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
+	Object.defineProperty(exports, "__esModule", { value: true });
+	exports.default = "default";
+})))(), 1);
+assert.deepStrictEqual(import_cjs.default, { default: "default" });
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs.cjs
@@ -1,0 +1,2 @@
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.default = 'default';

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/main.js
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+import * as cjs from './cjs.cjs';
+
+// In node ESM mode ("type": "module"), __toESM ignores __esModule flag
+// and .default represents the whole module.exports, not exports.default.
+assert.deepStrictEqual(cjs.default, { default: 'default' });

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/package.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Summary

`inlineConst` incorrectly inlined `.default` on CJS modules when `.default` actually represents `module.exports` (not `exports.default`). This happens when the importer uses Node ESM semantics (`"type": "module"`) or the importee has no `__esModule` flag — in both cases `__toESM` sets `.default = module.exports`.

## Test plan
- Added `esm_import_cjs_with_esmodule_flag` fixture
- All existing `cjs_compat` and `inline_const` tests pass