### PR TITLE
feat: support inlineConst for CJS exports accessed through module.exports

### DIFF
--- a/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+++ b/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
@@ -571,7 +571,50 @@ impl LinkStage<'_> {
                       is_node_esm || !importee_has_es_module_flag
                     };
 
-                    if !default_is_module_exports {
+                    // If the current property is `default` and it represents the whole `module.exports`,
+                    // try to resolve the next property as a CJS export.
+                    if default_is_module_exports
+                      && let Some(next_prop) = member_expr_ref.prop_and_span_list.get(cursor + 1)
+                    {
+                      if let Some(property) = self.metas[cjs_idx]
+                        .resolved_exports
+                        .get(&next_prop.name)
+                        .and_then(|resolved_export| {
+                          resolved_export.came_from_commonjs.then_some(resolved_export)
+                        })
+                      {
+                        let is_next_default = next_prop.name == "default";
+                        if is_next_default && maybe_namespace_symbol.namespace_alias.is_none() {
+                          // import * as ns; ns.default.default — can't optimize.
+                          //
+                          // __toESM sets import_ns.default = module.exports and __copyProps
+                          // skips "default" (already set), so exports.default is only
+                          // reachable via import_ns.default.default (two levels).
+                          // If we advance cursor, props becomes ["default"] and the finalizer
+                          // base is import_ns (#LOCAL_NAMESPACE has no namespace_alias to
+                          // append .default), so the result is import_ns.default which is
+                          // module.exports — not module.exports.default.
+                          //
+                          // Other non-"default" properties (e.g. ns.default.foo) work fine
+                          // because __copyProps copies them onto the __toESM target, so
+                          // import_ns.foo = module.exports.foo.
+                        } else {
+                          cursor += 1;
+                          target_commonjs_exported_symbol =
+                            Some((property.symbol_ref, is_next_default));
+                          depended_refs.push(property.symbol_ref);
+
+                          if member_expr_ref.is_write {
+                            written_cjs_exports.push(property.symbol_ref);
+                          }
+                        }
+                      }
+                    } else if default_is_module_exports {
+                      // `.default` represents the whole `module.exports` with no further
+                      // property access. Leave target_commonjs_exported_symbol as None so
+                      // that include_statements runs the CJS bailout check and keeps all
+                      // exports for this opaque usage.
+                    } else {
                       target_commonjs_exported_symbol = Some((m.symbol_ref, is_default));
                     }
                     depended_refs.push(m.symbol_ref);

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/artifacts.snap
@@ -8,12 +8,52 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 import assert from "node:assert";
 // HIDDEN [\0rolldown/runtime.js]
-//#region main.js
-var import_cjs = /* @__PURE__ */ __toESM((/* @__PURE__ */ __commonJSMin(((exports) => {
+//#region cjs.cjs
+var require_cjs = /* @__PURE__ */ __commonJSMin(((exports) => {
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = "default";
-})))(), 1);
-assert.deepStrictEqual(import_cjs.default, { default: "default" });
+	exports.foo = "foo";
+}));
+//#endregion
+//#region cjs2.cjs
+var require_cjs2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = "module.exports";
+}));
+//#endregion
+//#region cjs3.cjs
+var require_cjs3 = /* @__PURE__ */ __commonJSMin(((exports) => {
+	Object.defineProperty(exports, "__esModule", { value: true });
+	exports.default = "default";
+	exports.bar = "bar";
+}));
+//#endregion
+//#region main.js
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs(), 1);
+var import_cjs2 = /* @__PURE__ */ __toESM(require_cjs2(), 1);
+var import_cjs3 = /* @__PURE__ */ __toESM(require_cjs3(), 1);
+assert.deepStrictEqual(import_cjs.default, {
+	default: "default",
+	foo: "foo"
+});
+assert.deepStrictEqual(import_cjs.default, {
+	default: "default",
+	foo: "foo"
+});
+assert.deepStrictEqual(import_cjs.default, {
+	default: "default",
+	foo: "foo"
+});
+assert.deepStrictEqual(import_cjs.default.default, "default");
+assert.deepStrictEqual(import_cjs.default.default, "default");
+assert.deepStrictEqual("foo", "foo");
+assert.deepStrictEqual("foo", "foo");
+assert.deepStrictEqual("foo", "foo");
+assert.deepStrictEqual("foo", "foo");
+assert.deepStrictEqual(import_cjs2.default, "module.exports");
+assert.deepStrictEqual(import_cjs3.default, {
+	default: "default",
+	bar: "bar"
+});
 //#endregion
 
 ```

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs.cjs
@@ -1,2 +1,3 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.default = 'default';
+exports.foo = 'foo';

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs2.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs2.cjs
@@ -1,0 +1,1 @@
+module.exports = 'module.exports';

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs3.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/cjs3.cjs
@@ -1,0 +1,4 @@
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.default = 'default';
+// `bar` is not explicitly imported — only reachable via opaque ns.default
+exports.bar = 'bar';

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag/main.js
@@ -1,6 +1,27 @@
 import assert from 'node:assert';
 import * as cjs from './cjs.cjs';
+import cjs_default, { default as cjs_default_default, foo as cjs_foo } from './cjs.cjs';
+import * as cjs2 from './cjs2.cjs';
+import * as cjs3 from './cjs3.cjs';
 
 // In node ESM mode ("type": "module"), __toESM ignores __esModule flag
 // and .default represents the whole module.exports, not exports.default.
-assert.deepStrictEqual(cjs.default, { default: 'default' });
+assert.deepStrictEqual(cjs.default, { default: 'default', foo: 'foo' });
+assert.deepStrictEqual(cjs_default, { default: 'default', foo: 'foo' });
+assert.deepStrictEqual(cjs_default_default, { default: 'default', foo: 'foo' });
+
+// Cannot inline ns.default.default for `import * as ns`. See bind_imports_and_exports.
+assert.deepStrictEqual(cjs.default.default, 'default');
+assert.deepStrictEqual(cjs_default_default.default, 'default');
+
+// Inlined via module.exports resolution
+assert.deepStrictEqual(cjs.default.foo, 'foo');
+assert.deepStrictEqual(cjs.foo, 'foo');
+assert.deepStrictEqual(cjs_foo, 'foo');
+assert.deepStrictEqual(cjs_default_default.foo, 'foo');
+
+assert.deepStrictEqual(cjs2.default, 'module.exports');
+
+// CJS bailout: cjs3.default is an opaque use of module.exports.
+// `bar` is not explicitly imported but must survive tree-shaking.
+assert.deepStrictEqual(cjs3.default, { default: 'default', bar: 'bar' });

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/_config.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/_config.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "optimization": {
+      "inlineConst": true
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/artifacts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+import assert from "node:assert";
+// HIDDEN [\0rolldown/runtime.js]
+//#region cjs.cjs
+var require_cjs = /* @__PURE__ */ __commonJSMin(((exports) => {
+	Object.defineProperty(exports, "__esModule", { value: true });
+	exports.default = JSON.parse("\"default\"");
+}));
+//#endregion
+//#region cjs2.cjs
+var require_cjs2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = JSON.parse("\"default\"");
+}));
+//#endregion
+//#region main.js
+var import_cjs = /* @__PURE__ */ __toESM(require_cjs(), 1);
+var import_cjs2 = /* @__PURE__ */ __toESM(require_cjs2(), 1);
+assert.deepStrictEqual(import_cjs.default, { default: "default" });
+assert.deepStrictEqual(import_cjs.default.default, "default");
+assert.deepStrictEqual(import_cjs2.default, "default");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/cjs.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/cjs.cjs
@@ -1,0 +1,3 @@
+Object.defineProperty(exports, '__esModule', { value: true });
+// Non-constant default export — cannot be inlined
+exports.default = JSON.parse('"default"');

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/cjs2.cjs
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/cjs2.cjs
@@ -1,0 +1,1 @@
+module.exports = JSON.parse('"default"');

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/main.js
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/main.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+import * as cjs from './cjs.cjs';
+import * as cjs2 from './cjs2.cjs';
+
+// cjs.default = module.exports (node ESM mode, __esModule ignored)
+// cjs.default.default = module.exports.default = exports.default
+assert.deepStrictEqual(cjs.default, { default: 'default' });
+assert.deepStrictEqual(cjs.default.default, 'default');
+
+assert.deepStrictEqual(cjs2.default, 'default');

--- a/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/package.json
+++ b/crates/rolldown/tests/rolldown/cjs_compat/esm_import_cjs_with_esmodule_flag_non_const/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Summary

When `.default` represents `module.exports`, properties accessed through it (e.g. `ns.default.foo`) can now be resolved and inlined by looking up the next property in the CJS module's exports.

## Test plan
- Extended `esm_import_cjs_with_esmodule_flag` fixture with `ns.default.foo`, `ns.foo`, named imports, and default imports
- Added `esm_import_cjs_with_esmodule_flag_non_const` fixture for non-constant exports to verify the non-inlined path
- All existing `cjs_compat` and `inline_const` tests pass