### PR TITLE
fix: prevent chunk merging from leaking entry side effects

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -217,6 +217,24 @@ impl ChunkOptimizationGraph {
     false
   }
 
+  /// Returns true if `from` can transitively reach `to` through the dependency graph.
+  pub fn is_reachable(&self, from: ChunkIdx, to: ChunkIdx) -> bool {
+    let mut queue: VecDeque<ChunkIdx> = self.chunks[from].dependencies.iter().copied().collect();
+    let mut visited = FxHashSet::default();
+    while let Some(chunk_idx) = queue.pop_front() {
+      if chunk_idx == to {
+        return true;
+      }
+      if !visited.insert(chunk_idx) {
+        continue;
+      }
+      queue.extend(
+        self.chunks[chunk_idx].dependencies.iter().copied().filter(|dep| !visited.contains(dep)),
+      );
+    }
+    false
+  }
+
   /// Merges the dependencies of source chunk into target chunk.
   ///
   /// When modules from one chunk are merged into another chunk, the dependencies
@@ -359,6 +377,8 @@ impl GenerateStage<'_> {
           &self.link_output.module_table,
           &dynamic_entry_to_dynamic_importers,
           temp_chunk,
+          temp_chunk_graph,
+          *temp_chunk_idx,
         );
 
         Some((bits.clone(), *temp_chunk_idx, chunk_idxs, merge_target))
@@ -511,6 +531,7 @@ impl GenerateStage<'_> {
   /// entry chunk when possible, rather than creating a separate common chunk.
   ///
   /// Returns `Some(ChunkIdx)` if a suitable merge target is found, `None` otherwise.
+  #[expect(clippy::too_many_arguments)]
   fn try_insert_into_existing_chunk(
     chunk_idxs: &[ChunkIdx],
     entry_chunk_reference: &FxHashMap<ChunkIdx, FxHashSet<ChunkIdx>>,
@@ -518,6 +539,8 @@ impl GenerateStage<'_> {
     module_table: &ModuleTable,
     dynamic_entry_to_dynamic_importers: &FxHashMap<ModuleIdx, FxHashSet<ModuleIdx>>,
     info: &ChunkCandidate,
+    temp_chunk_graph: &ChunkOptimizationGraph,
+    temp_chunk_idx: ChunkIdx,
   ) -> Option<ChunkIdx> {
     let mut user_defined_entry = vec![];
     let mut dynamic_entry = vec![];
@@ -554,6 +577,23 @@ impl GenerateStage<'_> {
         dynamic_entry.iter().all(|idx| reached_dynamic_chunk.is_some_and(|set| set.contains(idx)));
       if !all_dynamic_entries_reachable {
         return None;
+      }
+      // If any dynamic entry chunk depends on the pending common chunk,
+      // merging into the user-defined entry would make the dynamic entry
+      // import the entry chunk. This is only safe if the entry chunk
+      // has no side effects; otherwise loading the dynamic chunk would
+      // trigger the entry's side effects unexpectedly.
+      let would_make_dynamic_entry_depend_on_user_entry = dynamic_entry
+        .iter()
+        .any(|dynamic_chunk_idx| temp_chunk_graph.is_reachable(*dynamic_chunk_idx, temp_chunk_idx));
+      if would_make_dynamic_entry_depend_on_user_entry {
+        let entry_has_side_effects = chunk
+          .modules
+          .iter()
+          .any(|&module_idx| module_table[module_idx].side_effects().has_side_effects());
+        if entry_has_side_effects {
+          return None;
+        }
       }
       let modules_set = chunk
         .modules

--- a/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_common_js_into_es6/artifacts.snap
+++ b/crates/rolldown/tests/esbuild/splitting/splitting_dynamic_common_js_into_es6/artifacts.snap
@@ -3,21 +3,28 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
-## entry.js
+## chunk.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+export { __toESM as n, __commonJSMin as t };
+
+```
+
+## entry.js
+
+```js
+import { n as __toESM } from "./chunk.js";
 //#region entry.js
 import("./foo.js").then((m) => /* @__PURE__ */ __toESM(m.default)).then(({ default: { bar } }) => console.log(bar));
 //#endregion
-export { __commonJSMin as t };
 
 ```
 
 ## foo.js
 
 ```js
-import { t as __commonJSMin } from "./entry.js";
+import { t as __commonJSMin } from "./chunk.js";
 //#region foo.js
 var require_foo = /* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.bar = 123;

--- a/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/cjs_compat/dynamic_import_in_cjs/artifacts.snap
@@ -3,11 +3,30 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
+
+```
+
 ## internal-cjs.js
 
 ```js
 //#region internal-cjs.js
-var require_internal_cjs = /* @__PURE__ */ require("./main.js").__commonJSMin(((exports, module) => {
+var require_internal_cjs = /* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports, module) => {
 	module.exports = {
 		value: 42,
 		hello: "world"
@@ -38,12 +57,11 @@ exports.value = value;
 ## main.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+const require_chunk = require("./chunk.js");
 //#region main.js
-Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("external"))).then(console.log);
+Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("external"))).then(console.log);
 Promise.resolve().then(() => require("./internal.js")).then(console.log);
-Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./internal-cjs.js").default)).then(console.log);
+Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./internal-cjs.js").default)).then(console.log);
 //#endregion
-exports.__commonJSMin = __commonJSMin;
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/non_strict/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lazy-chunk.js
 
 ```js
-import { t as foo } from "./main.js";
+import { t as foo } from "./user-lib.js";
 //#region lazy-chunk.js
 foo();
 //#endregion
@@ -16,17 +16,24 @@ foo();
 ## main.js
 
 ```js
+import { t as foo } from "./user-lib.js";
 //#region polyfill.js
 Object.somePolyfilledFunction = () => {};
 //#endregion
+//#region main.js
+foo();
+//#endregion
+
+```
+
+## user-lib.js
+
+```js
 //#region user-lib.js
 Object.somePolyfilledFunction();
 async function foo() {
 	return import("./lazy-chunk.js");
 }
-//#endregion
-//#region main.js
-foo();
 //#endregion
 export { foo as t };
 

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/strict/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/esbuild_issue_2598/strict/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lazy-chunk.js
 
 ```js
-import { n as init_user_lib, r as __esmMin, t as foo } from "./main.js";
+import { n as init_user_lib, r as __esmMin, t as foo } from "./user-lib.js";
 //#endregion
 __esmMin((() => {
 	init_user_lib();
@@ -18,12 +18,24 @@ __esmMin((() => {
 ## main.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+import { n as init_user_lib, r as __esmMin, t as foo } from "./user-lib.js";
 //#region polyfill.js
 var init_polyfill = __esmMin((() => {
 	Object.somePolyfilledFunction = () => {};
 }));
 //#endregion
+__esmMin((() => {
+	init_polyfill();
+	init_user_lib();
+	foo();
+}))();
+
+```
+
+## user-lib.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
 //#region user-lib.js
 async function foo() {
 	return import("./lazy-chunk.js");
@@ -32,11 +44,6 @@ var init_user_lib = __esmMin((() => {
 	Object.somePolyfilledFunction();
 }));
 //#endregion
-__esmMin((() => {
-	init_polyfill();
-	init_user_lib();
-	foo();
-}))();
 export { init_user_lib as n, __esmMin as r, foo as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/experimental/strict_execution_order/issue_4684/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { n as read, r as __esmMin, t as init_read } from "./main.js";
+import { n as read, r as __esmMin, t as init_read } from "./read.js";
 //#endregion
 __esmMin((() => {
 	init_read();
@@ -18,8 +18,8 @@ __esmMin((() => {
 ## main.js
 
 ```js
+import { n as read, r as __esmMin, t as init_read } from "./read.js";
 import nodeAssert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
 //#region setup.js
 var setup;
 var init_setup = __esmMin((() => {
@@ -27,15 +27,6 @@ var init_setup = __esmMin((() => {
 		globalThis.foo = "foo";
 	};
 	setup();
-}));
-//#endregion
-//#region read.js
-var foo, read;
-var init_read = __esmMin((() => {
-	foo = globalThis.foo;
-	read = () => {
-		console.log("read", foo);
-	};
 }));
 //#endregion
 __esmMin((() => {
@@ -46,6 +37,22 @@ __esmMin((() => {
 	import("./dynamic.js");
 	nodeAssert.strictEqual(globalThis.foo, "foo");
 }))();
+
+```
+
+## read.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region read.js
+var foo, read;
+var init_read = __esmMin((() => {
+	foo = globalThis.foo;
+	read = () => {
+		console.log("read", foo);
+	};
+}));
+//#endregion
 export { read as n, __esmMin as r, init_read as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -3,10 +3,19 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
+## chunk.js
+
+```js
+import { createRequire } from "node:module";
+// HIDDEN [\0rolldown/runtime.js]
+export { __require as n, __toESM as r, __commonJSMin as t };
+
+```
+
 ## lib.js
 
 ```js
-import { t as __commonJSMin } from "./main.js";
+import { t as __commonJSMin } from "./chunk.js";
 //#region lib.js
 var require_lib = /* @__PURE__ */ __commonJSMin(((exports) => {
 	Object.defineProperty(exports, "__esModule", { value: true });
@@ -21,9 +30,8 @@ export {};
 ## main.js
 
 ```js
-import { createRequire } from "node:module";
+import { n as __require, r as __toESM, t as __commonJSMin } from "./chunk.js";
 import nodeAssert from "node:assert";
-// HIDDEN [\0rolldown/runtime.js]
 //#region non-node-mode.js
 async function main$1() {
 	const exports = await import("./lib.js").then((m) => /* @__PURE__ */ __toESM(m.default));
@@ -53,7 +61,7 @@ main();
 	module.exports = {};
 })))();
 //#endregion
-export { __commonJSMin as t };
+export {};
 
 ```
 
@@ -61,11 +69,30 @@ export { __commonJSMin as t };
 
 ## Assets
 
+### chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
+
+```
+
 ### lib.js
 
 ```js
 //#region lib.js
-var require_lib = /* @__PURE__ */ require("./main.js").__commonJSMin(((exports) => {
+var require_lib = /* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports) => {
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.parse = "parse";
 }));
@@ -82,13 +109,12 @@ Object.defineProperty(exports, "default", {
 ### main.js
 
 ```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-// HIDDEN [\0rolldown/runtime.js]
+const require_chunk = require("./chunk.js");
 let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+node_assert = require_chunk.__toESM(node_assert);
 //#region non-node-mode.js
 async function main$1() {
-	const exports = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default));
+	const exports = await Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./lib.js").default));
 	node_assert.default.deepEqual(Object.keys(exports).sort(), ["parse"]);
 	node_assert.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
 	node_assert.default.strictEqual(exports.default, void 0, "Target has __esModule, so no auto-generated default export");
@@ -97,16 +123,16 @@ main$1();
 //#endregion
 //#region node-mode-by-mjs-extension.mjs
 async function main() {
-	const exports = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default, 1));
+	const exports = await Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./lib.js").default, 1));
 	node_assert.default.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
 	node_assert.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
 	node_assert.default.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
 main();
-(/* @__PURE__ */ __commonJSMin(((exports, module) => {
+(/* @__PURE__ */ require_chunk.__commonJSMin(((exports, module) => {
 	const nodeAssert = require("node:assert");
 	async function main() {
-		const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./lib.js").default, 1));
+		const exports$1 = await Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./lib.js").default, 1));
 		nodeAssert.deepEqual(Object.keys(exports$1).sort(), ["default", "parse"]);
 		nodeAssert.strictEqual(exports$1.parse, "parse", "Expected export exists and is correct");
 		nodeAssert.strictEqual(exports$1.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
@@ -115,7 +141,6 @@ main();
 	module.exports = {};
 })))();
 //#endregion
-exports.__commonJSMin = __commonJSMin;
 
 ```
 

--- a/crates/rolldown/tests/rolldown/issues/4895/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4895/artifacts.snap
@@ -6,22 +6,20 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## allow-extension.js
 
 ```js
-//#region allow-extension/lib.js
-const shared = "shared";
-//#endregion
+import { t as shared } from "./lib.js";
 //#region allow-extension/main.js
 console.log(shared);
 import("./dynamic.js");
 const unused = 42;
 //#endregion
-export { shared as t, unused };
+export { unused };
 
 ```
 
 ## dynamic.js
 
 ```js
-import { t as shared } from "./allow-extension.js";
+import { t as shared } from "./lib.js";
 //#region allow-extension/dynamic.js
 console.log(shared);
 //#endregion
@@ -31,7 +29,7 @@ console.log(shared);
 ## dynamic2.js
 
 ```js
-import { t as shared } from "./false.js";
+import { t as shared } from "./lib2.js";
 //#region false/dynamic.js
 console.log(shared);
 //#endregion
@@ -41,7 +39,7 @@ console.log(shared);
 ## dynamic3.js
 
 ```js
-import { t as shared } from "./lib.js";
+import { t as shared } from "./lib3.js";
 //#region not-specified/dynamic.js
 console.log(shared);
 //#endregion
@@ -51,7 +49,7 @@ console.log(shared);
 ## dynamic4.js
 
 ```js
-import { t as shared } from "./lib2.js";
+import { t as shared } from "./lib4.js";
 //#region strict/dynamic.js
 console.log(shared);
 //#endregion
@@ -61,18 +59,35 @@ console.log(shared);
 ## false.js
 
 ```js
-//#region false/lib.js
-const shared = "shared";
-//#endregion
+import { t as shared } from "./lib2.js";
 //#region false/main.js
 console.log(shared);
 import("./dynamic2.js");
+//#endregion
+
+```
+
+## lib.js
+
+```js
+//#region allow-extension/lib.js
+const shared = "shared";
 //#endregion
 export { shared as t };
 
 ```
 
-## lib.js
+## lib2.js
+
+```js
+//#region false/lib.js
+const shared = "shared";
+//#endregion
+export { shared as t };
+
+```
+
+## lib3.js
 
 ```js
 //#region not-specified/lib.js
@@ -82,7 +97,7 @@ export { shared as t };
 
 ```
 
-## lib2.js
+## lib4.js
 
 ```js
 //#region strict/lib.js
@@ -101,7 +116,7 @@ export { shared as t };
 ## not-specified.js
 
 ```js
-import { t as shared } from "./lib.js";
+import { t as shared } from "./lib3.js";
 //#region not-specified/main.js
 console.log(shared);
 import("./dynamic3.js");
@@ -114,7 +129,7 @@ export { unused };
 ## strict.js
 
 ```js
-import { t as shared } from "./lib2.js";
+import { t as shared } from "./lib4.js";
 //#region strict/main.js
 console.log(shared);
 import("./dynamic4.js");

--- a/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6513/artifacts.snap
@@ -3,14 +3,39 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__esmMin", {
+	enumerable: true,
+	get: function() {
+		return __esmMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
+
+```
+
 ## dynamic.js
 
 ```js
-const require_main = require("./main.js");
+const require_chunk = require("./chunk.js");
 //#region dynamic.js
 var ddd;
 //#endregion
-require_main.__esmMin((() => {
+require_chunk.__esmMin((() => {
 	ddd = 100;
 }))();
 exports.ddd = ddd;
@@ -20,13 +45,12 @@ exports.ddd = ddd;
 ## main.js
 
 ```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-// HIDDEN [\0rolldown/runtime.js]
+const require_chunk = require("./chunk.js");
 let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+node_assert = require_chunk.__toESM(node_assert);
 //#endregion
 //#region entry.js
-var import_lib = (/* @__PURE__ */ __commonJSMin(((exports) => {
+var import_lib = (/* @__PURE__ */ require_chunk.__commonJSMin(((exports) => {
 	const remoteProvider = async function() {
 		return await Promise.resolve().then(() => require("./dynamic.js"));
 	};
@@ -36,6 +60,5 @@ var import_lib = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	(0, node_assert.default)((await (0, import_lib.defaultProvider)()).ddd === 100);
 })();
 //#endregion
-exports.__esmMin = __esmMin;
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6660/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## c.js
 
 ```js
-import { i as __toCommonJS, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./index.js";
+import { i as __toCommonJS, n as __esmMin, r as __exportAll, t as __commonJSMin } from "./chunk.js";
 //#region d.js
 var d_exports = /* @__PURE__ */ __exportAll({ loadEventStreamCapability: () => loadEventStreamCapability });
 async function loadEventStreamCapability() {
@@ -28,10 +28,18 @@ export default require_c();
 
 ```
 
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __toESM as a, __toCommonJS as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
+
+```
+
 ## e.js
 
 ```js
-import { n as __esmMin } from "./index.js";
+import { n as __esmMin } from "./chunk.js";
 //#endregion
 __esmMin((() => {
 	console.log("event");
@@ -42,7 +50,8 @@ __esmMin((() => {
 ## index.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+import { a as __toESM, t as __commonJSMin } from "./chunk.js";
+//#endregion
 //#region a.js
 (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.defaultProvider = async function test() {
@@ -51,6 +60,5 @@ __esmMin((() => {
 	};
 })))();
 //#endregion
-export { __toCommonJS as i, __esmMin as n, __exportAll as r, __commonJSMin as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/6756/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/6756/artifacts.snap
@@ -6,13 +6,24 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## dynamic.js
 
 ```js
-import { n as utilityClass, t as helper } from "./main.js";
+import { n as utilityClass, t as helper } from "./shared.js";
 new utilityClass(helper());
 //#endregion
 
 ```
 
 ## main.js
+
+```js
+import { t as helper } from "./shared.js";
+//#region main.js
+console.log(helper());
+import("./dynamic.js");
+//#endregion
+
+```
+
+## shared.js
 
 ```js
 //#region shared.js
@@ -24,10 +35,6 @@ var utilityClass = class {
 		this.value = value;
 	}
 };
-//#endregion
-//#region main.js
-console.log(helper());
-import("./dynamic.js");
 //#endregion
 export { utilityClass as n, helper as t };
 

--- a/crates/rolldown/tests/rolldown/issues/7655/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/7655/artifacts.snap
@@ -7,7 +7,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 //#region a.js
-var require_a = /* @__PURE__ */ require("./main.js").__commonJSMin(((exports, module) => {
+var require_a = /* @__PURE__ */ require("./chunk.js").__commonJSMin(((exports, module) => {
 	module.exports = {
 		value: 42,
 		hello: "world"
@@ -23,13 +23,31 @@ Object.defineProperty(exports, "default", {
 
 ```
 
-## main.js
+## chunk.js
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
+Object.defineProperty(exports, "__commonJSMin", {
+	enumerable: true,
+	get: function() {
+		return __commonJSMin;
+	}
+});
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
+
+```
+
+## main.js
+
+```js
+const require_chunk = require("./chunk.js");
 //#region main.js
-Promise.resolve().then(() => /* @__PURE__ */ __toESM(require("./a.js").default)).then((m) => console.log(m.default));
+Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./a.js").default)).then((m) => console.log(m.default));
 //#endregion
-exports.__commonJSMin = __commonJSMin;
 
 ```

--- a/crates/rolldown/tests/rolldown/issues/8053/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8053/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## lazy-a.js
 
 ```js
-import { t as import_lodash } from "./main.js";
+import { t as import_lodash } from "./utils.js";
 import assert from "node:assert";
 //#region lazy-a.js
 assert(typeof import_lodash.debounce === "function");
@@ -18,18 +18,25 @@ assert(typeof import_lodash.noop === "function");
 ## main.js
 
 ```js
+import { t as import_lodash } from "./utils.js";
 import assert from "node:assert";
+//#region main.js
+assert(typeof import_lodash.debounce === "function");
+assert(typeof import_lodash.noop === "function");
+import("./lazy-a.js");
+//#endregion
+
+```
+
+## utils.js
+
+```js
 // HIDDEN [\0rolldown/runtime.js]
 //#region utils.js
 var import_lodash = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.noop = function noop() {};
 	exports.debounce = function debounce() {};
 })))();
-//#endregion
-//#region main.js
-assert(typeof import_lodash.debounce === "function");
-assert(typeof import_lodash.noop === "function");
-import("./lazy-a.js");
 //#endregion
 export { import_lodash as n, import_lodash as t };
 
@@ -42,12 +49,12 @@ export { import_lodash as n, import_lodash as t };
 ### lazy-a.js
 
 ```js
-const require_main = require("./main.js");
+const require_utils = require("./utils.js");
 let node_assert = require("node:assert");
-node_assert = require_main.__toESM(node_assert);
+node_assert = require_utils.__toESM(node_assert);
 //#region lazy-a.js
-(0, node_assert.default)(typeof require_main.import_lodash.debounce === "function");
-(0, node_assert.default)(typeof require_main.import_lodash$1.noop === "function");
+(0, node_assert.default)(typeof require_utils.import_lodash.debounce === "function");
+(0, node_assert.default)(typeof require_utils.import_lodash$1.noop === "function");
 //#endregion
 
 ```
@@ -55,23 +62,33 @@ node_assert = require_main.__toESM(node_assert);
 ### main.js
 
 ```js
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-// HIDDEN [\0rolldown/runtime.js]
+const require_utils = require("./utils.js");
 let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+node_assert = require_utils.__toESM(node_assert);
+//#region main.js
+(0, node_assert.default)(typeof require_utils.import_lodash.debounce === "function");
+(0, node_assert.default)(typeof require_utils.import_lodash$1.noop === "function");
+Promise.resolve().then(() => require("./lazy-a.js"));
 //#endregion
+
+```
+
+### utils.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
 //#region utils.js
 var import_lodash = (/* @__PURE__ */ __commonJSMin(((exports) => {
 	exports.noop = function noop() {};
 	exports.debounce = function debounce() {};
 })))();
 //#endregion
-//#region main.js
-(0, node_assert.default)(typeof import_lodash.debounce === "function");
-(0, node_assert.default)(typeof import_lodash.noop === "function");
-Promise.resolve().then(() => require("./lazy-a.js"));
-//#endregion
-exports.__toESM = __toESM;
+Object.defineProperty(exports, "__toESM", {
+	enumerable: true,
+	get: function() {
+		return __toESM;
+	}
+});
 Object.defineProperty(exports, "import_lodash", {
 	enumerable: true,
 	get: function() {

--- a/crates/rolldown/tests/rolldown/issues/8849/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8849/_config.json
@@ -1,0 +1,15 @@
+{
+  "snapshotOutputStats": true,
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "main.js"
+      },
+      {
+        "name": "admin",
+        "import": "admin.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8849/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8849/_test.mjs
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+// Before the fix, the chunk optimizer merged value.js into the admin entry
+// chunk, causing common.js (a dynamic import) to import from admin.js.
+// This means loading main.js would also execute admin.js as a side effect.
+//
+// Expected: common.js should NOT import from admin.js.
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const common = fs.readFileSync(path.join(distDir, 'common.js'), 'utf8');
+
+assert(
+  !common.includes('from "./admin.js"'),
+  'common.js should not import from admin.js (would cause admin side effects when loading main)',
+);

--- a/crates/rolldown/tests/rolldown/issues/8849/admin.js
+++ b/crates/rolldown/tests/rolldown/issues/8849/admin.js
@@ -1,0 +1,6 @@
+import value from './value';
+
+const m = import('./common');
+
+console.log('rendering admin');
+console.log(m, value);

--- a/crates/rolldown/tests/rolldown/issues/8849/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8849/artifacts.snap
@@ -1,0 +1,54 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## admin.js
+
+```js
+import { t as value_default } from "./value.js";
+//#region admin.js
+const m = import("./common.js");
+console.log("rendering admin");
+console.log(m, value_default);
+//#endregion
+
+```
+
+## common.js
+
+```js
+import { t as value_default } from "./value.js";
+//#region common.js
+console.log(value_default);
+//#endregion
+
+```
+
+## main.js
+
+```js
+//#region main.js
+const m = import("./common.js");
+console.log("rendering main");
+console.log(m);
+//#endregion
+
+```
+
+## value.js
+
+```js
+//#region value.js
+var value_default = { value: 42 };
+//#endregion
+export { value_default as t };
+
+```
+
+# Output Stats
+
+- admin.js, is_entry true, is_dynamic_entry false, exports []
+- common.js, is_entry false, is_dynamic_entry true, exports []
+- main.js, is_entry true, is_dynamic_entry false, exports []
+- value.js, is_entry false, is_dynamic_entry false, exports ["t"]

--- a/crates/rolldown/tests/rolldown/issues/8849/common.js
+++ b/crates/rolldown/tests/rolldown/issues/8849/common.js
@@ -1,0 +1,3 @@
+import value from './value';
+
+console.log(value);

--- a/crates/rolldown/tests/rolldown/issues/8849/main.js
+++ b/crates/rolldown/tests/rolldown/issues/8849/main.js
@@ -1,0 +1,4 @@
+const m = import('./common');
+
+console.log('rendering main');
+console.log(m);

--- a/crates/rolldown/tests/rolldown/issues/8849/value.js
+++ b/crates/rolldown/tests/rolldown/issues/8849/value.js
@@ -1,0 +1,1 @@
+export default { value: 42 };

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/_config.json
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/_config.json
@@ -1,0 +1,15 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      },
+      {
+        "name": "entry-a",
+        "import": "./entry-a.js"
+      }
+    ]
+  }
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/_test.mjs
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/_test.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+const distMain = path.join(import.meta.dirname, 'dist', 'main.js');
+const stdout = execFileSync('node', [distMain], { encoding: 'utf-8' });
+
+assert.strictEqual(stdout.trim(), 'dynamic1:shared-b');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/artifacts.snap
@@ -1,0 +1,70 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## common-a.js
+
+```js
+import { t as sharedB } from "./common-b.js";
+//#region common-a.js
+function getSharedB() {
+	return sharedB;
+}
+//#endregion
+export { getSharedB as t };
+
+```
+
+## common-b.js
+
+```js
+//#region common-b.js
+const sharedB = "shared-b";
+//#endregion
+export { sharedB as t };
+
+```
+
+## dynamic1.js
+
+```js
+import { t as getSharedB } from "./common-a.js";
+//#region dynamic1.js
+const value = getSharedB();
+console.log(`dynamic1:${value}`);
+//#endregion
+export { value };
+
+```
+
+## dynamic2.js
+
+```js
+import { t as getSharedB } from "./common-a.js";
+//#region dynamic2.js
+const value = getSharedB();
+//#endregion
+export { value };
+
+```
+
+## entry-a.js
+
+```js
+//#region entry-a.js
+console.log("entry-a");
+globalThis.loadDynamic1FromEntryA = () => import("./dynamic1.js");
+globalThis.loadDynamic2FromEntryA = () => import("./dynamic2.js");
+//#endregion
+
+```
+
+## main.js
+
+```js
+//#region main.js
+import("./dynamic1.js");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/common-a.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/common-a.js
@@ -1,0 +1,5 @@
+import { sharedB } from './common-b.js';
+
+export function getSharedB() {
+  return sharedB;
+}

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/common-b.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/common-b.js
@@ -1,0 +1,1 @@
+export const sharedB = 'shared-b';

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/dynamic1.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/dynamic1.js
@@ -1,0 +1,6 @@
+import { getSharedB } from './common-a.js';
+
+const value = getSharedB();
+console.log(`dynamic1:${value}`);
+
+export { value };

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/dynamic2.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/dynamic2.js
@@ -1,0 +1,3 @@
+import { getSharedB } from './common-a.js';
+
+export const value = getSharedB();

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/entry-a.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/entry-a.js
@@ -1,0 +1,6 @@
+import { sharedB } from './common-b.js';
+
+console.log('entry-a');
+
+globalThis.loadDynamic1FromEntryA = () => import('./dynamic1.js');
+globalThis.loadDynamic2FromEntryA = () => import('./dynamic2.js');

--- a/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/main.js
+++ b/crates/rolldown/tests/rolldown/optimization/chunk_merging/transitive_dynamic_dep_should_not_merge_into_side_effectful_entry/main.js
@@ -1,0 +1,1 @@
+import('./dynamic1.js');

--- a/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/dynamic_import/artifacts.snap
@@ -3,10 +3,18 @@ source: crates/rolldown_testing/src/integration_test.rs
 ---
 # Assets
 
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __toESM as r, __commonJSMin as t };
+
+```
+
 ## exist-dep-cjs.js
 
 ```js
-import { t as __commonJSMin } from "./main.js";
+import { t as __commonJSMin } from "./chunk.js";
 //#region exist-dep-cjs.js
 var require_exist_dep_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	__rolldown_runtime__.createModuleHotContext("exist-dep-cjs.js");
@@ -21,7 +29,7 @@ export default require_exist_dep_cjs();
 ## exist-dep-esm.js
 
 ```js
-import { n as __exportAll } from "./main.js";
+import { n as __exportAll } from "./chunk.js";
 //#region exist-dep-esm.js
 var exist_dep_esm_exports = /* @__PURE__ */ __exportAll({ value: () => value });
 __rolldown_runtime__.createModuleHotContext("exist-dep-esm.js");
@@ -35,7 +43,7 @@ export { value };
 ## main.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
+import { n as __exportAll, r as __toESM } from "./chunk.js";
 //#region hmr.js
 var hmr_exports = /* @__PURE__ */ __exportAll({ foo: () => foo });
 const hmr_hot = __rolldown_runtime__.createModuleHotContext("hmr.js");
@@ -53,7 +61,6 @@ var main_exports = /* @__PURE__ */ __exportAll({});
 __rolldown_runtime__.createModuleHotContext("main.js");
 __rolldown_runtime__.registerModule("main.js", { exports: main_exports });
 //#endregion
-export { __exportAll as n, __commonJSMin as t };
 
 ```
 

--- a/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/hmr/issue_5159/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## bar.js
 
 ```js
-import { t as __exportAll } from "./main.js";
+import { t as __exportAll } from "./chunk.js";
 import { t as trim } from "./string.js";
 //#region bar.js
 var bar_exports = /* @__PURE__ */ __exportAll({ default: () => bar_default });
@@ -20,10 +20,18 @@ export { bar_default as default };
 
 ```
 
+## chunk.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as t };
+
+```
+
 ## foo.js
 
 ```js
-import { t as __exportAll } from "./main.js";
+import { t as __exportAll } from "./chunk.js";
 import { n as unused, t as trim } from "./string.js";
 //#region utils/index.js
 var utils_exports = /* @__PURE__ */ __exportAll({
@@ -48,15 +56,18 @@ export { foo_default as default };
 ## main.js
 
 ```js
-// HIDDEN [\0rolldown/runtime.js]
-export { __exportAll as t };
+import "./chunk.js";
+__rolldown_runtime__.createModuleHotContext("main.js");
+__rolldown_runtime__.registerModule("main.js", {});
+import("./foo.js"), import("./bar.js");
+//#endregion
 
 ```
 
 ## string.js
 
 ```js
-import { t as __exportAll } from "./main.js";
+import { t as __exportAll } from "./chunk.js";
 //#region utils/string.js
 var string_exports = /* @__PURE__ */ __exportAll({
 	trim: () => trim,

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks/artifacts.snap
@@ -6,7 +6,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## async-entry.js
 
 ```js
-import { count, inc, reset } from "./main.js";
+import { n as inc, r as reset, t as count } from "./shared.js";
 import assert from "node:assert";
 //#region async-entry.js
 reset();
@@ -25,6 +25,17 @@ assert.strictEqual(count, count);
 ## main.js
 
 ```js
+import { n as inc, r as reset, t as count } from "./shared.js";
+//#region main.js
+import("./async-entry.js");
+//#endregion
+export { count, inc, reset };
+
+```
+
+## shared.js
+
+```js
 //#region shared.js
 let count = 0;
 function reset() {
@@ -34,9 +45,6 @@ function inc() {
 	count += 1;
 }
 //#endregion
-//#region main.js
-import("./async-entry.js");
-//#endregion
-export { count, inc, reset };
+export { inc as n, reset as r, count as t };
 
 ```

--- a/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/live_bindings/named_exports_in_common_chunks_cjs/artifacts.snap
@@ -7,19 +7,19 @@ source: crates/rolldown_testing/src/integration_test.rs
 
 ```js
 // HIDDEN [\0rolldown/runtime.js]
-const require_main = require("./main.js");
+const require_shared = require("./shared.js");
 let node_assert = require("node:assert");
 node_assert = __toESM(node_assert);
 //#region async-entry.js
-require_main.reset();
-node_assert.default.strictEqual(require_main.count, 0);
-node_assert.default.strictEqual(require_main.count, require_main.count);
-require_main.inc();
-node_assert.default.strictEqual(require_main.count, 1);
-node_assert.default.strictEqual(require_main.count, require_main.count);
-require_main.inc();
-node_assert.default.strictEqual(require_main.count, 2);
-node_assert.default.strictEqual(require_main.count, require_main.count);
+require_shared.reset();
+node_assert.default.strictEqual(require_shared.count, 0);
+node_assert.default.strictEqual(require_shared.count, require_shared.count);
+require_shared.inc();
+node_assert.default.strictEqual(require_shared.count, 1);
+node_assert.default.strictEqual(require_shared.count, require_shared.count);
+require_shared.inc();
+node_assert.default.strictEqual(require_shared.count, 2);
+node_assert.default.strictEqual(require_shared.count, require_shared.count);
 //#endregion
 
 ```
@@ -28,6 +28,24 @@ node_assert.default.strictEqual(require_main.count, require_main.count);
 
 ```js
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const require_shared = require("./shared.js");
+//#region main.js
+Promise.resolve().then(() => require("./async-entry.js"));
+//#endregion
+Object.defineProperty(exports, "count", {
+	enumerable: true,
+	get: function() {
+		return require_shared.count;
+	}
+});
+exports.inc = require_shared.inc;
+exports.reset = require_shared.reset;
+
+```
+
+## shared.js
+
+```js
 //#region shared.js
 let count = 0;
 function reset() {
@@ -37,16 +55,23 @@ function inc() {
 	count += 1;
 }
 //#endregion
-//#region main.js
-Promise.resolve().then(() => require("./async-entry.js"));
-//#endregion
 Object.defineProperty(exports, "count", {
 	enumerable: true,
 	get: function() {
 		return count;
 	}
 });
-exports.inc = inc;
-exports.reset = reset;
+Object.defineProperty(exports, "inc", {
+	enumerable: true,
+	get: function() {
+		return inc;
+	}
+});
+Object.defineProperty(exports, "reset", {
+	enumerable: true,
+	get: function() {
+		return reset;
+	}
+});
 
 ```

--- a/packages/rolldown/tests/fixtures/output/sanitize-filename/function/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sanitize-filename/function/_config.ts
@@ -33,8 +33,9 @@ export default defineTest({
       [
         "assets/sanitized-+emitted-C6bBH0W1.txt",
         "assets/sanitized-asset-BIR0xpQL",
-        "sanitized-dynamic-DVinTJUZ.js",
+        "sanitized-dynamic-Bz1iwkVe.js",
         "sanitized-main.js",
+        "sanitized-share-CSwYeRHk.js",
       ]
     `);
   },


### PR DESCRIPTION
## Summary
- Use transitive reachability (BFS) instead of direct dependency checks when deciding whether to merge a common chunk into a side-effectful entry chunk
- Previously, shared modules were incorrectly merged into entry chunks when dynamic imports depended on them transitively, causing dynamic chunk loading to trigger unrelated entry side effects
- Fixes #8849

## Test plan
- Added `issues/8849` test with runtime assertion that loading `main.js` does not import from `admin.js`
- Added `transitive_dynamic_dep_should_not_merge_into_side_effectful_entry` test that spawns a separate node process to verify `dist/main.js` only outputs `dynamic1:shared-b` (no `entry-a` leak)
- Updated inline snapshot for `sanitize-filename/function` JS test
- All 18 snapshot updates verified: shared modules correctly extracted into separate chunks instead of being merged into side-effectful entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)