### PR TITLE
fix: emit separate __toESM bindings for mixed ESM/CJS external imports

### DIFF
--- a/crates/rolldown/src/ecmascript/format/cjs.rs
+++ b/crates/rolldown/src/ecmascript/format/cjs.rs
@@ -7,7 +7,7 @@ use crate::{
   utils::chunk::render_chunk_exports::render_chunk_exports,
   utils::external_import_interop::external_import_needs_interop,
 };
-use rolldown_common::{AddonRenderContext, OutputExports};
+use rolldown_common::{AddonRenderContext, NormalModule, OutputExports};
 use rolldown_error::BuildDiagnostic;
 use rolldown_sourcemap::SourceJoiner;
 use rolldown_utils::concat_string;
@@ -142,27 +142,60 @@ fn render_cjs_chunk_imports(ctx: &GenerateContext<'_>) -> String {
         let needs_interop =
           named_imports.is_some_and(|imports| external_import_needs_interop(imports));
         if needs_interop {
-          // generate code like:
-          // let external_module_symbol_name = require("external-module");
-          // external_module_symbol_name = __toESM(external_module_symbol_name);
-          let require_external = concat_string!(
-            "let ",
-            external_module_symbol_name,
-            " = ",
-            require_path_str,
-            ";\n",
-            external_module_symbol_name,
-            " = ",
-            ctx.finalized_string_pattern_for_symbol_ref(
-              ctx.link_output.runtime.resolve_symbol("__toESM"),
-              ctx.chunk_idx,
-              &ctx.chunk.canonical_names,
-            ),
-            "(",
-            external_module_symbol_name,
-            ");\n"
+          let to_esm_fn = ctx.finalized_string_pattern_for_symbol_ref(
+            ctx.link_output.runtime.resolve_symbol("__toESM"),
+            ctx.chunk_idx,
+            &ctx.chunk.canonical_names,
           );
-          s.push_str(&require_external);
+          let canonical_ref = ctx.link_output.symbol_db.canonical_ref_for(importee.namespace_ref);
+          if let Some(node_mode_name) = ctx.chunk.node_mode_external_ns_names.get(&canonical_ref) {
+            // Mixed-mode: emit two __toESM bindings (node-mode and non-node-mode)
+            let require_external = concat_string!(
+              "let ",
+              external_module_symbol_name,
+              " = ",
+              require_path_str,
+              ";\nlet ",
+              node_mode_name,
+              " = ",
+              to_esm_fn,
+              "(",
+              external_module_symbol_name,
+              ", 1);\n",
+              external_module_symbol_name,
+              " = ",
+              to_esm_fn,
+              "(",
+              external_module_symbol_name,
+              ");\n"
+            );
+            s.push_str(&require_external);
+          } else {
+            // Single-mode: check if any importer is ESM for node-mode flag
+            let is_node_esm = named_imports.is_some_and(|imports| {
+              imports.iter().any(|(importer_idx, _)| {
+                ctx.link_output.module_table[*importer_idx]
+                  .as_normal()
+                  .is_some_and(NormalModule::should_consider_node_esm_spec_for_static_import)
+              })
+            });
+            let node_mode_arg = if is_node_esm { ", 1" } else { "" };
+            let require_external = concat_string!(
+              "let ",
+              external_module_symbol_name,
+              " = ",
+              require_path_str,
+              ";\n",
+              external_module_symbol_name,
+              " = ",
+              to_esm_fn,
+              "(",
+              external_module_symbol_name,
+              node_mode_arg,
+              ");\n"
+            );
+            s.push_str(&require_external);
+          }
         } else {
           // generate code like:
           // let external_module_symbol_name = require("external-module");

--- a/crates/rolldown/src/ecmascript/format/utils/mod.rs
+++ b/crates/rolldown/src/ecmascript/format/utils/mod.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use rolldown_common::ExternalModule;
+use rolldown_common::{ExternalModule, NormalModule};
 use rolldown_sourcemap::SourceJoiner;
 
 use crate::{
@@ -74,13 +74,41 @@ pub fn render_chunk_external_imports<'a>(
             ctx.link_output.runtime.resolve_symbol("__toESM"),
             &ctx.chunk.canonical_names,
           );
+          let canonical_ref = ctx.link_output.symbol_db.canonical_ref_for(importee.namespace_ref);
 
-          import_code.push_str(external_module_symbol_name);
-          import_code.push_str(" = ");
-          import_code.push_str(to_esm_fn_name);
-          import_code.push('(');
-          import_code.push_str(external_module_symbol_name);
-          import_code.push_str(");\n");
+          if let Some(node_mode_name) = ctx.chunk.node_mode_external_ns_names.get(&canonical_ref) {
+            // Mixed-mode: emit two __toESM bindings
+            import_code.push_str("let ");
+            import_code.push_str(node_mode_name);
+            import_code.push_str(" = ");
+            import_code.push_str(to_esm_fn_name);
+            import_code.push('(');
+            import_code.push_str(external_module_symbol_name);
+            import_code.push_str(", 1);\n");
+
+            import_code.push_str(external_module_symbol_name);
+            import_code.push_str(" = ");
+            import_code.push_str(to_esm_fn_name);
+            import_code.push('(');
+            import_code.push_str(external_module_symbol_name);
+            import_code.push_str(");\n");
+          } else {
+            // Single-mode: check if any importer is ESM for node-mode flag
+            let is_node_esm = named_imports.iter().any(|(importer_idx, _)| {
+              ctx.link_output.module_table[*importer_idx]
+                .as_normal()
+                .is_some_and(NormalModule::should_consider_node_esm_spec_for_static_import)
+            });
+            import_code.push_str(external_module_symbol_name);
+            import_code.push_str(" = ");
+            import_code.push_str(to_esm_fn_name);
+            import_code.push('(');
+            import_code.push_str(external_module_symbol_name);
+            if is_node_esm {
+              import_code.push_str(", 1");
+            }
+            import_code.push_str(");\n");
+          }
         }
         Some(ExternalImportKind::Used(importee))
       } else if importee.side_effects.has_side_effects() {

--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -347,7 +347,17 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     }
     let mut hint = FinalizedExprProcessHint::empty();
     let mut expr = if self.ctx.modules[canonical_ref.owner].is_external() {
-      self.snippet.id_ref_expr(self.canonical_name_for(canonical_ref), SPAN)
+      // For mixed-mode externals, ESM importers use the node-mode binding name
+      if self.ctx.module.should_consider_node_esm_spec_for_static_import() {
+        if let Some(node_mode_name) = self.ctx.chunk.node_mode_external_ns_names.get(&canonical_ref)
+        {
+          self.snippet.id_ref_expr(node_mode_name.as_str(), SPAN)
+        } else {
+          self.snippet.id_ref_expr(self.canonical_name_for(canonical_ref), SPAN)
+        }
+      } else {
+        self.snippet.id_ref_expr(self.canonical_name_for(canonical_ref), SPAN)
+      }
     } else {
       match self.ctx.options.format {
         rolldown_common::OutputFormat::Cjs => {

--- a/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
+++ b/crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs
@@ -2,11 +2,14 @@ use oxc::span::CompactStr;
 
 use crate::{
   stages::link_stage::LinkStageOutput,
-  utils::renamer::{NestedScopeRenamer, Renamer},
+  utils::{
+    external_import_interop::{external_import_needs_interop, specifier_needs_interop},
+    renamer::{NestedScopeRenamer, Renamer},
+  },
 };
 use arcstr::ArcStr;
 use rolldown_common::{
-  Chunk, ChunkIdx, ChunkKind, GetLocalDb, OutputFormat, TaggedSymbolRef, WrapKind,
+  Chunk, ChunkIdx, ChunkKind, GetLocalDb, NormalModule, OutputFormat, TaggedSymbolRef, WrapKind,
 };
 use rolldown_utils::ecmascript::legitimize_identifier_name;
 use rustc_hash::FxHashMap;
@@ -164,6 +167,44 @@ pub fn deconflict_chunk_symbols(
       )
     })
     .collect();
+
+  // Detect mixed-mode external imports: both ESM (node-mode) and non-ESM importers
+  // needing interop on the same external. Create a separate binding name for node-mode.
+  if matches!(format, OutputFormat::Iife | OutputFormat::Umd | OutputFormat::Cjs) {
+    let mut node_mode_names = FxHashMap::default();
+    for (ext_idx, named_imports) in &chunk.direct_imports_from_external_modules {
+      if !external_import_needs_interop(named_imports) {
+        continue;
+      }
+      let mut has_node_mode = false;
+      let mut has_non_node_mode = false;
+      for (importer_idx, import) in named_imports {
+        if !specifier_needs_interop(&import.imported) {
+          continue;
+        }
+        if link_output.module_table[*importer_idx]
+          .as_normal()
+          .is_some_and(NormalModule::should_consider_node_esm_spec_for_static_import)
+        {
+          has_node_mode = true;
+        } else {
+          has_non_node_mode = true;
+        }
+        if has_node_mode && has_non_node_mode {
+          break;
+        }
+      }
+      if has_node_mode && has_non_node_mode {
+        let ext =
+          link_output.module_table[*ext_idx].as_external().expect("Should be external module here");
+        let canonical_ref = link_output.symbol_db.canonical_ref_for(ext.namespace_ref);
+        let original_name = canonical_ref.name(&link_output.symbol_db);
+        let node_name = renamer.create_conflictless_name(original_name);
+        node_mode_names.insert(canonical_ref, CompactStr::new(&node_name));
+      }
+    }
+    chunk.node_mode_external_ns_names = node_mode_names;
+  }
 
   rename_shadowing_symbols_in_nested_scopes(chunk, link_output, format, &mut renamer);
 

--- a/crates/rolldown/src/utils/external_import_interop.rs
+++ b/crates/rolldown/src/utils/external_import_interop.rs
@@ -3,7 +3,7 @@ use rolldown_common::{ImportRecordIdx, NamedImport, NormalModule, Specifier};
 /// Check if a specific import specifier needs the `__toESM` helper.
 /// Only namespace imports (`import * as foo`) and default imports (`import foo`)
 /// need the `__toESM` helper. Named imports (`import { foo }`) do not need it.
-fn specifier_needs_interop(specifier: &Specifier) -> bool {
+pub fn specifier_needs_interop(specifier: &Specifier) -> bool {
   matches!(specifier, Specifier::Star)
     || matches!(specifier, Specifier::Literal(name) if name.as_str() == "default")
 }

--- a/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/4289/artifacts.snap
@@ -111,6 +111,7 @@ Object.defineProperty(exports, "default", {
 ```js
 const require_chunk = require("./chunk.js");
 let node_assert = require("node:assert");
+let node_assert$1 = require_chunk.__toESM(node_assert, 1);
 node_assert = require_chunk.__toESM(node_assert);
 //#region non-node-mode.js
 async function main$1() {
@@ -124,9 +125,9 @@ main$1();
 //#region node-mode-by-mjs-extension.mjs
 async function main() {
 	const exports = await Promise.resolve().then(() => /* @__PURE__ */ require_chunk.__toESM(require("./lib.js").default, 1));
-	node_assert.default.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
-	node_assert.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
-	node_assert.default.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
+	node_assert$1.default.deepEqual(Object.keys(exports).sort(), ["default", "parse"]);
+	node_assert$1.default.strictEqual(exports.parse, "parse", "Expected export exists and is correct");
+	node_assert$1.default.strictEqual(exports.default.parse, "parse", "Target has __esModule, but this file triggered node compat mode");
 }
 main();
 (/* @__PURE__ */ require_chunk.__commonJSMin(((exports, module) => {

--- a/crates/rolldown/tests/rolldown/issues/8842/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8842/_config.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./index.ts" }],
+    "external": ["jsonc-parser"],
+    "format": "cjs"
+  },
+  "expectExecuted": true
+}

--- a/crates/rolldown/tests/rolldown/issues/8842/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8842/_test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const file = fs.readFileSync(path.resolve(import.meta.dirname, './dist/main.js'), 'utf-8');
+
+assert.ok(
+  file.includes('__toESM(jsonc_parser, 1)'),
+  'should use node-mode __toESM for ESM importer',
+);

--- a/crates/rolldown/tests/rolldown/issues/8842/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8842/artifacts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+let jsonc_parser = require("jsonc-parser");
+jsonc_parser = __toESM(jsonc_parser, 1);
+//#region index.ts
+jsonc_parser.default.parse("{}");
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/8842/index.ts
+++ b/crates/rolldown/tests/rolldown/issues/8842/index.ts
@@ -1,0 +1,2 @@
+import Parser from 'jsonc-parser';
+Parser.parse('{}');

--- a/crates/rolldown/tests/rolldown/issues/8842/package.json
+++ b/crates/rolldown/tests/rolldown/issues/8842/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/_config.json
@@ -1,0 +1,8 @@
+{
+  "expectExecuted": true,
+  "config": {
+    "input": [{ "name": "entry", "import": "./entry.js" }],
+    "external": ["foo"],
+    "format": "cjs"
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/_test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const file = fs.readFileSync(path.resolve(import.meta.dirname, './dist/entry.js'), 'utf-8');
+
+// Mixed-mode: should emit two separate __toESM bindings
+assert.ok(
+  file.includes('__toESM(foo, 1)'),
+  'should have node-mode __toESM for ESM importer (sub1.mjs)',
+);
+assert.ok(
+  /\bfoo = __toESM\(foo\);/.test(file),
+  'should have non-node-mode __toESM for non-ESM importer (sub2.js)',
+);

--- a/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/artifacts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+let foo = require("foo");
+let foo$3 = __toESM(foo, 1);
+foo = __toESM(foo);
+//#region sub1.mjs
+console.log(foo$3.default.bar);
+//#endregion
+//#region sub2.js
+console.log(foo.default.baz);
+//#endregion
+
+```

--- a/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/entry.js
+++ b/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/entry.js
@@ -1,0 +1,2 @@
+import './sub1.mjs';
+import './sub2.js';

--- a/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/sub1.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/sub1.mjs
@@ -1,0 +1,2 @@
+import foo from 'foo';
+console.log(foo.bar);

--- a/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/sub2.js
+++ b/crates/rolldown/tests/rolldown/issues/8842_mixed_chunk/sub2.js
@@ -1,0 +1,2 @@
+import foo from 'foo';
+console.log(foo.baz);

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_esm_dynamic/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_esm_dynamic/artifacts.snap
@@ -32,7 +32,7 @@ assert.equal(String(reexports_exports), "[object Module]");
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+node_assert = __toESM(node_assert, 1);
 //#region lib.mjs
 var lib_exports = /* @__PURE__ */ __exportAll({});
 __reExport(lib_exports, require("foo"));

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+node_assert = __toESM(node_assert, 1);
 //#region reexports.mjs
 var reexports_exports = /* @__PURE__ */ __exportAll({});
 __reExport(reexports_exports, require("foo"));

--- a/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external_commonjs/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/topics/generated_code/reexports_from_external_commonjs/artifacts.snap
@@ -8,7 +8,7 @@ source: crates/rolldown_testing/src/integration_test.rs
 ```js
 // HIDDEN [\0rolldown/runtime.js]
 let node_assert = require("node:assert");
-node_assert = __toESM(node_assert);
+node_assert = __toESM(node_assert, 1);
 //#region cjs.js
 var require_cjs = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 	module.exports = { a: 1 };

--- a/crates/rolldown_common/src/chunk/mod.rs
+++ b/crates/rolldown_common/src/chunk/mod.rs
@@ -77,6 +77,9 @@ pub struct Chunk {
   pub preliminary_filename: Option<PreliminaryFilename>,
   pub absolute_preliminary_filename: Option<String>,
   pub canonical_names: FxHashMap<SymbolRef, CompactStr>,
+  /// For mixed-mode externals: maps external `namespace_ref` to the node-mode binding name.
+  /// Only populated when an external has both ESM and non-ESM importers needing interop.
+  pub node_mode_external_ns_names: FxHashMap<SymbolRef, CompactStr>,
   // Sorted by Module#stable_id of modules in the chunk
   pub cross_chunk_imports: Vec<ChunkIdx>,
   pub cross_chunk_dynamic_imports: Vec<ChunkIdx>,


### PR DESCRIPTION
## Summary
- When a CJS/IIFE/UMD chunk has both ESM and non-ESM importers of the same external module, emits two __toESM bindings — one with node-mode (__toESM(x, 1)) for ESM importers and one without for non-ESM importers
- Previously, all importers shared a single binding, which broke interop when the external has __esModule: true
- Also fixes IIFE/UMD format which never passed the node-mode flag at all

Fixes #8842

## Test plan
- [x] Added 8842 test (single-mode: ESM importer of external in CJS output)
- [x] Added 8842_mixed_chunk test (mixed-mode: both .mjs and .js importers of same external)
- [x] All 1665 integration tests pass
