### PR TITLE
fix: emit namespace declaration for empty modules in manual chunks

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -534,11 +534,17 @@ impl GenerateStage<'_> {
         let meta = &self.link_output.metas[module_idx];
 
         let module_namespace_included_reason = &meta.module_namespace_included_reason;
-        let is_namespace_referenced = matches!(m.exports_kind, ExportsKind::Esm)
-          && if module_namespace_included_reason.intersects(
-            ModuleNamespaceIncludedReason::Unknown
-              | ModuleNamespaceIncludedReason::SimulateFacadeChunk,
-          ) {
+        // SimulateFacadeChunk is set by the chunk optimizer when a dynamic entry is merged
+        // into a common chunk. This is an authoritative decision that the namespace must
+        // exist regardless of the module's exports_kind (e.g. empty modules have
+        // ExportsKind::None but still need their namespace declaration when exported
+        // cross-chunk).
+        let is_namespace_referenced = if module_namespace_included_reason
+          .contains(ModuleNamespaceIncludedReason::SimulateFacadeChunk)
+        {
+          true
+        } else if matches!(m.exports_kind, ExportsKind::Esm) {
+          if module_namespace_included_reason.contains(ModuleNamespaceIncludedReason::Unknown) {
             true
           } else if module_namespace_included_reason
             .contains(ModuleNamespaceIncludedReason::ReExportDynamicExports)
@@ -549,7 +555,10 @@ impl GenerateStage<'_> {
             meta.has_dynamic_exports
           } else {
             false
-          };
+          }
+        } else {
+          false
+        };
         Some((m.namespace_object_ref, is_namespace_referenced))
       })
       .collect_vec();

--- a/packages/rolldown/tests/fixtures/issues/empty-module-manual-chunks/_config.ts
+++ b/packages/rolldown/tests/fixtures/issues/empty-module-manual-chunks/_config.ts
@@ -1,0 +1,48 @@
+import { defineTest } from 'rolldown-tests';
+import { expect } from 'vitest';
+
+// Regression: empty module in named chunk via manualChunks produced
+// `export { empty_exports as t }` without ever defining `empty_exports`.
+// Note: virtual module IDs must NOT use \0 prefix — it prevents chunk creation.
+export default defineTest({
+  config: {
+    plugins: [
+      {
+        name: 'empty-module',
+        resolveId(source) {
+          if (source === 'fake-pkg/empty') return 'fake-pkg/empty';
+        },
+        load(id) {
+          if (id === 'fake-pkg/empty') return '';
+        },
+      },
+    ],
+    output: {
+      manualChunks: (id) => {
+        if (id.includes('fake-pkg')) {
+          return 'fake-pkg';
+        }
+      },
+    },
+  },
+  afterTest(output) {
+    for (const chunk of output.output) {
+      if (chunk.type !== 'chunk') continue;
+      // Every exported identifier must be defined in the chunk's code.
+      const exportMatch = chunk.code.match(/export\s*\{([^}]+)\}/);
+      if (!exportMatch) continue;
+      const exportedNames = exportMatch[1].split(',').map((s) =>
+        s
+          .trim()
+          .split(/\s+as\s+/)[0]
+          .trim(),
+      );
+      for (const name of exportedNames) {
+        expect(
+          chunk.code,
+          `exported "${name}" should be defined in chunk "${chunk.fileName}"`,
+        ).toContain(`var ${name}`);
+      }
+    }
+  },
+});

--- a/packages/rolldown/tests/fixtures/issues/empty-module-manual-chunks/main.js
+++ b/packages/rolldown/tests/fixtures/issues/empty-module-manual-chunks/main.js
@@ -1,0 +1,5 @@
+// Top-level await inlines the import (no separate chunk created),
+// so a function wrapper is needed to trigger the cross-chunk export path.
+(async () => {
+  await import('fake-pkg/empty');
+})();


### PR DESCRIPTION
## Summary

- Fix undefined export binding when an empty module is dynamically imported and routed to a named chunk via `manualChunks`
- Root cause: `finalized_module_namespace_ref_usage` gated on `ExportsKind::Esm` before checking `SimulateFacadeChunk`, so empty modules (`ExportsKind::None`) had their namespace removed despite the chunk optimizer marking it as needed

## Problem

When all three conditions are met:
1. **Empty module** (0 bytes, e.g. CSS extracted by Vite)
2. **`manualChunks`** routing the module to a named chunk
3. **Non-top-level dynamic import** (inside a function — top-level `await import()` gets inlined)

The output contained `export { empty_exports as t }` without ever defining `empty_exports`, causing a `SyntaxError` at runtime.

## Fix

Check `SimulateFacadeChunk` before the `ExportsKind` gate in `finalized_module_namespace_ref_usage`, since the chunk optimizer's decision is authoritative regardless of exports kind.

## Test plan

- [x] Added regression test `packages/rolldown/tests/fixtures/issues/empty-module-manual-chunks/`
- [x] 721 Node.js tests pass
- [x] 1662 Rust tests pass (1 pre-existing test262 submodule failure)