### PR TITLE
fix: wrap CJS entry modules for IIFE/UMD when using exports/module

### DIFF
--- a/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
+++ b/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
@@ -1,6 +1,8 @@
 use std::ptr::addr_of;
 
-use rolldown_common::{ExportsKind, ImportKind, ImportRecordMeta, Module, OutputFormat, WrapKind};
+use rolldown_common::{
+  EcmaModuleAstUsage, ExportsKind, ImportKind, ImportRecordMeta, Module, OutputFormat, WrapKind,
+};
 
 use crate::utils::external_import_interop::import_record_needs_interop;
 
@@ -84,7 +86,10 @@ impl LinkStage<'_> {
 
       let is_entry = self.entries.contains_key(&importer.idx);
       if matches!(importer.exports_kind, ExportsKind::CommonJs)
-        && (!is_entry || matches!(self.options.format, OutputFormat::Esm))
+        && (!is_entry
+          || matches!(self.options.format, OutputFormat::Esm)
+          || (matches!(self.options.format, OutputFormat::Iife | OutputFormat::Umd)
+            && importer.ast_usage.intersects(EcmaModuleAstUsage::ModuleOrExports)))
       {
         self.metas[importer.idx].sync_wrap_kind(WrapKind::Cjs);
       }

--- a/crates/rolldown/tests/rolldown/function/export_mode/entry-wrapped-cjs-none/_config.json
+++ b/crates/rolldown/tests/rolldown/function/export_mode/entry-wrapped-cjs-none/_config.json
@@ -1,0 +1,12 @@
+{
+  "expectExecuted": false,
+  "config": {
+    "format": "iife",
+    "input": [{ "import": "./main.cjs" }]
+  },
+  "configVariants": [
+    {
+      "format": "umd"
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/function/export_mode/entry-wrapped-cjs-none/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/export_mode/entry-wrapped-cjs-none/artifacts.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+(function() {
+	//#region main.cjs
+	console.log("side effect");
+	//#endregion
+})();
+
+```
+
+# Variant: [format: Umd]
+
+## Assets
+
+### main.js
+
+```js
+(function(factory) {
+	typeof define === "function" && define.amd ? define([], factory) : factory();
+})(function() {
+	//#region main.cjs
+	console.log("side effect");
+	//#endregion
+});
+
+```

--- a/crates/rolldown/tests/rolldown/function/export_mode/entry-wrapped-cjs-none/main.cjs
+++ b/crates/rolldown/tests/rolldown/function/export_mode/entry-wrapped-cjs-none/main.cjs
@@ -1,0 +1,1 @@
+console.log('side effect');

--- a/crates/rolldown/tests/rolldown/issues/8670/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8670/_config.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "input": [{ "name": "main", "import": "./main.cjs" }],
+    "name": "myLib",
+    "minify": false
+  },
+  "configVariants": [
+    {
+      "_configName": "iife",
+      "format": "iife",
+      "entryFilenames": "main.cjs",
+      "footer": "module.exports = myLib;"
+    },
+    {
+      "_configName": "umd",
+      "format": "umd",
+      "entryFilenames": "main.cjs"
+    }
+  ]
+}

--- a/crates/rolldown/tests/rolldown/issues/8670/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8670/_test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+
+const configName = globalThis.__configName;
+const require = createRequire(import.meta.url);
+
+if (configName === 'iife' || configName === 'umd') {
+  const mod = require('./dist/main.cjs');
+  assert.strictEqual(mod.foo, 'foo');
+} else {
+  const mod = await import('./dist/main.js');
+  assert.strictEqual(mod.default.foo, 'foo');
+}

--- a/crates/rolldown/tests/rolldown/issues/8670/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8670/artifacts.snap
@@ -1,0 +1,66 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region main.cjs
+var require_main = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.foo = "foo";
+}));
+
+//#endregion
+export default require_main();
+
+```
+
+# Variant: iife: [entry_filenames: "main.cjs"] [format: Iife]
+
+## Assets
+
+### main.cjs
+
+```js
+var myLib = (function() {
+
+// HIDDEN [\0rolldown/runtime.js]
+
+//#region main.cjs
+	var require_main = /* @__PURE__ */ __commonJSMin(((exports) => {
+		exports.foo = "foo";
+	}));
+
+//#endregion
+return require_main();
+
+})();
+module.exports = myLib;
+```
+
+# Variant: umd: [entry_filenames: "main.cjs"] [format: Umd]
+
+## Assets
+
+### main.cjs
+
+```js
+(function(global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports =  factory() :
+  typeof define === 'function' && define.amd ? define([], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, (global.myLib = factory()));
+})(this, function() {
+// HIDDEN [\0rolldown/runtime.js]
+
+//#region main.cjs
+	var require_main = /* @__PURE__ */ __commonJSMin(((exports) => {
+		exports.foo = "foo";
+	}));
+
+//#endregion
+return require_main();
+
+});
+```

--- a/crates/rolldown/tests/rolldown/issues/8670/main.cjs
+++ b/crates/rolldown/tests/rolldown/issues/8670/main.cjs
@@ -1,0 +1,1 @@
+exports.foo = 'foo';


### PR DESCRIPTION
## Summary
- CJS entry modules that reference `exports` or `module` were not wrapped with `__commonJSMin` for IIFE/UMD output formats, causing `exports is not defined` runtime errors
- Adds wrapping condition for IIFE/UMD in `determine_module_exports_kind` so CJS entries that use `exports`/`module` get properly wrapped
- Side-effect-only `.cjs` entries (no `exports`/`module` usage) continue to be directly inlined without wrapping

Closes #8670

## Test plan
- [x] Added test `issues/8670` with IIFE and UMD variants that bundle a CJS module using `exports.foo`
- [x] Added test `export_mode/entry-wrapped-cjs-none` for side-effect-only CJS entry (no wrapping needed)
- [x] Verified `extend/entry-wrapped-cjs-named` is not regressed
- [x] All 1671 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)