### PR TITLE
refactor(generator): replace npx oxfmt with vp fmt for ecma formatting

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -6,7 +6,6 @@
     ".": {
       "project": [],
       "ignoreDependencies": [
-        "oxfmt",
         "@oxc-project/runtime",
         "cjs-module-lexer",
         "playwright-chromium",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@types/node": "catalog:",
     "cjs-module-lexer": "^2.1.0",
     "knip": "^6.0.0",
-    "oxfmt": "^0.43.0",
     "playwright-chromium": "^1.56.1",
     "publint": "^0.3.16",
     "remove-unused-vars": "^0.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,9 +278,6 @@ importers:
       knip:
         specifier: ^6.0.0
         version: 6.1.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
-      oxfmt:
-        specifier: ^0.43.0
-        version: 0.43.0
       playwright-chromium:
         specifier: ^1.56.1
         version: 1.58.2

--- a/tasks/generator/src/output/rust.rs
+++ b/tasks/generator/src/output/rust.rs
@@ -41,20 +41,25 @@ pub fn rust_fmt(source_text: &str) -> String {
 }
 
 pub fn ecma_fmt(source_text: &str, path: &str) -> String {
-  let npx = if cfg!(target_os = "windows") { "npx.cmd" } else { "npx" };
-  let mut npx = Command::new(npx)
-    .args(["oxfmt", "--stdin-filepath", path])
+  let vp = if cfg!(target_os = "windows") { "vp.cmd" } else { "vp" };
+  let mut vp = Command::new(vp)
+    .args(["fmt", "--stdin-filepath", path])
     .stdin(Stdio::piped())
     .stdout(Stdio::piped())
     .spawn()
     .expect("Failed to run `oxfmt` (is it installed?)");
 
-  let stdin = npx.stdin.as_mut().unwrap();
+  let stdin = vp.stdin.as_mut().unwrap();
   stdin.write_all(source_text.as_bytes()).unwrap();
   stdin.flush().unwrap();
 
-  let output = npx.wait_with_output().unwrap();
-  String::from_utf8(output.stdout).unwrap()
+  let output = vp.wait_with_output().unwrap();
+  let stdout = String::from_utf8(output.stdout).unwrap();
+  // Strip the "VITE+ - The Unified Toolchain for the Web\n\n" banner from vp stdout
+  stdout
+    .strip_prefix("VITE+ - The Unified Toolchain for the Web\n\n")
+    .unwrap_or(&stdout)
+    .to_string()
 }
 
 pub fn replace_range_string(original: &str, span: Span, replacement: &str) -> String {


### PR DESCRIPTION
Related to https://github.com/rolldown/rolldown/pull/9019

At present, we need to standardize on using vite-plus.