### PR TITLE
feat(rust): add `disable_panic_hook` feature to disable the panic hook

### DIFF
--- a/crates/rolldown_binding/Cargo.toml
+++ b/crates/rolldown_binding/Cargo.toml
@@ -93,3 +93,4 @@ napi-build = { workspace = true }
 
 [features]
 default_global_allocator = []
+disable_panic_hook = []

--- a/crates/rolldown_binding/src/lib.rs
+++ b/crates/rolldown_binding/src/lib.rs
@@ -106,12 +106,15 @@ fn init() {
     create_custom_tokio_runtime(rt);
   }
 
-  let default_hook = std::panic::take_hook();
-  std::panic::set_hook(Box::new(move |info| {
-    eprintln!("Rolldown panicked. This is a bug in Rolldown, not your code.");
-    default_hook(info);
-    eprintln!(
-      "\nPlease report this issue at: https://github.com/rolldown/rolldown/issues/new?template=panic_report.yml"
-    );
-  }));
+  #[cfg(not(feature = "disable_panic_hook"))]
+  {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+      eprintln!("Rolldown panicked. This is a bug in Rolldown, not your code.");
+      default_hook(info);
+      eprintln!(
+        "\nPlease report this issue at: https://github.com/rolldown/rolldown/issues/new?template=panic_report.yml"
+      );
+    }));
+  }
 }


### PR DESCRIPTION
Add `disable_panic_hook` feature to disable the panic hook for https://github.com/voidzero-dev/vite-plus/issues/1285#issuecomment-4183685852.

@fengmk2 Would you try if this works?