### PR TITLE
feat: source map chain for native magic string plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4018,6 +4018,7 @@ dependencies = [
  "oxc_index",
  "oxc_sourcemap",
  "regex",
+ "rolldown_sourcemap",
  "rustc-hash",
  "serde",
 ]

--- a/crates/rolldown/src/stages/scan_stage.rs
+++ b/crates/rolldown/src/stages/scan_stage.rs
@@ -6,9 +6,9 @@ use oxc_index::IndexVec;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rolldown_common::SourceMapGenMsg;
 use rolldown_common::{
-  EntryPoint, FlatOptions, HybridIndexVec, Module, ModuleIdx, ModuleTable, PreserveEntrySignatures,
-  ResolvedId, RuntimeModuleBrief, ScanMode, SourcemapChainElement, SymbolRefDb,
-  dynamic_import_usage::DynamicImportExportsUsage,
+  EntryPoint, FlatOptions, HybridIndexVec, Module, ModuleIdx, ModuleTable, PluginIdx,
+  PreserveEntrySignatures, ResolvedId, RuntimeModuleBrief, ScanMode, SourcemapChainElement,
+  SymbolRefDb, dynamic_import_usage::DynamicImportExportsUsage,
 };
 use rolldown_ecmascript::EcmaAst;
 use rolldown_error::{BuildDiagnostic, BuildResult};
@@ -196,24 +196,60 @@ impl<Fs: FileSystem + Clone + 'static> ScanStage<Fs> {
     {
       let (tx, rx) = std::sync::mpsc::channel::<SourceMapGenMsg>();
       let handler = thread::spawn(move || {
-        let mut map: FxHashMap<ModuleIdx, Vec<_>> = FxHashMap::default();
+        let mut chains: FxHashMap<ModuleIdx, (string_wizard::MagicStringChain, PluginIdx)> =
+          FxHashMap::default();
+        let mut result: FxHashMap<ModuleIdx, Vec<SourcemapChainElement>> = FxHashMap::default();
+
+        let flush_chain =
+          |chain: string_wizard::MagicStringChain,
+           plugin_idx: PluginIdx,
+           module_idx: ModuleIdx,
+           result: &mut FxHashMap<ModuleIdx, Vec<SourcemapChainElement>>| {
+            let sourcemap = chain.source_map(string_wizard::SourceMapOptions::default());
+            result
+              .entry(module_idx)
+              .or_default()
+              .push(SourcemapChainElement::Transform((plugin_idx, sourcemap)));
+          };
+
         while let Ok(msg) = rx.recv() {
           match msg {
             SourceMapGenMsg::MagicString(v) => {
               let (module_idx, plugin_idx, magic_string) = *v;
-              let generated_sourcemap =
-                magic_string.source_map(string_wizard::SourceMapOptions::default());
-              map
-                .entry(module_idx)
-                .or_default()
-                .push(SourcemapChainElement::Transform((plugin_idx, generated_sourcemap)));
+
+              // Flush if source changed (non-MagicString plugin changed code).
+              if let std::collections::hash_map::Entry::Occupied(entry) = chains.entry(module_idx) {
+                if !entry.get().0.is_source_compatible(magic_string.source()) {
+                  let (chain, last_plugin_idx) = entry.remove();
+                  flush_chain(chain, last_plugin_idx, module_idx, &mut result);
+                }
+              }
+
+              let entry = chains.entry(module_idx).or_insert_with(|| {
+                (
+                  string_wizard::MagicStringChain::new(magic_string.source().to_string()),
+                  plugin_idx,
+                )
+              });
+              entry.0.end(magic_string);
+              entry.1 = plugin_idx;
+            }
+            SourceMapGenMsg::Barrier(module_idx) => {
+              if let Some((chain, last_plugin_idx)) = chains.remove(&module_idx) {
+                flush_chain(chain, last_plugin_idx, module_idx, &mut result);
+              }
             }
             SourceMapGenMsg::Terminate => {
               break;
             }
           }
         }
-        map
+
+        for (module_idx, (chain, last_plugin_idx)) in chains {
+          flush_chain(chain, last_plugin_idx, module_idx, &mut result);
+        }
+
+        result
       });
       (Some(Arc::new(tx)), Some(handler))
     } else {

--- a/crates/rolldown_common/src/source_map_gen_msg.rs
+++ b/crates/rolldown_common/src/source_map_gen_msg.rs
@@ -5,5 +5,9 @@ use crate::PluginIdx;
 #[derive(Debug)]
 pub enum SourceMapGenMsg {
   MagicString(Box<(crate::ModuleIdx, PluginIdx, MagicString<'static>)>),
+  /// Signal that a non-MagicString plugin intervened for this module.
+  /// The background thread must flush any in-progress chain for the module
+  /// before the next MagicString arrives, even if the code is unchanged.
+  Barrier(crate::ModuleIdx),
   Terminate,
 }

--- a/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
+++ b/crates/rolldown_plugin/src/plugin_driver/build_hooks.rs
@@ -273,6 +273,14 @@ impl PluginDriver {
         original_sourcemap_chain = plugin_sourcemap_chain.into_inner();
         if let Some(map) = self.normalize_transform_sourcemap(r.map, id, &code, r.code.as_ref()) {
           original_sourcemap_chain.push(SourcemapChainElement::Transform((plugin_idx, map)));
+          // Signal the background sourcemap thread that a non-MagicString
+          // sourcemap was produced, so any in-progress MagicStringChain for
+          // this module must be flushed before the next MagicString arrives.
+          if let Some(tx) = magic_string_tx.as_ref() {
+            tx.send(rolldown_common::SourceMapGenMsg::Barrier(module_idx)).expect(
+              "Failed to send Barrier to sourcemap worker — worker thread terminated unexpectedly",
+            );
+          }
         }
         plugin_sourcemap_chain = UniqueArc::new(original_sourcemap_chain);
         if let Some(v) = r.side_effects {

--- a/crates/string_wizard/Cargo.toml
+++ b/crates/string_wizard/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 insta = { workspace = true }
+rolldown_sourcemap = { workspace = true }
 
 [features]
 default = ["sourcemap", "serde"]

--- a/crates/string_wizard/src/lib.rs
+++ b/crates/string_wizard/src/lib.rs
@@ -1,6 +1,7 @@
 mod chunk;
 mod joiner;
 mod magic_string;
+mod magic_string_chain;
 #[cfg(feature = "sourcemap")]
 mod source_map;
 mod span;
@@ -16,6 +17,7 @@ pub use crate::{
     MagicString, MagicStringOptions, indent::IndentOptions, replace::ReplaceOptions,
     update::UpdateOptions,
   },
+  magic_string_chain::MagicStringChain,
 };
 
 #[cfg(feature = "sourcemap")]

--- a/crates/string_wizard/src/magic_string/mod.rs
+++ b/crates/string_wizard/src/magic_string/mod.rs
@@ -243,8 +243,16 @@ impl<'text> MagicString<'text> {
     self.intro.push_back(content.into());
   }
 
-  fn iter_chunks(&self) -> impl Iterator<Item = &Chunk<'_>> {
+  pub(crate) fn iter_chunks(&self) -> impl Iterator<Item = &Chunk<'_>> {
     IterChunks { next: Some(self.first_chunk_idx), chunks: &self.chunks }
+  }
+
+  pub(crate) fn global_intro(&self) -> &VecDeque<CowStr<'_>> {
+    &self.intro
+  }
+
+  pub(crate) fn global_outro(&self) -> &VecDeque<CowStr<'_>> {
+    &self.outro
   }
 
   pub(crate) fn fragments(&'text self) -> impl Iterator<Item = &'text str> {

--- a/crates/string_wizard/src/magic_string/source_map.rs
+++ b/crates/string_wizard/src/magic_string/source_map.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
-use rustc_hash::FxHashMap;
-
 use crate::{
   MagicString,
   source_map::{
     locator::Locator,
+    precompute_utf16_index_map,
     sourcemap_builder::{Hires, SourcemapBuilder},
   },
 };
@@ -69,27 +68,3 @@ impl MagicString<'_> {
   }
 }
 
-fn precompute_utf16_index_map(
-  source: &str,
-  byte_indices: impl Iterator<Item = u32>,
-) -> FxHashMap<u32, u32> {
-  // Chunk traversal order may not be sorted (e.g. after relocate()), so sort is required.
-  let mut byte_indices: Vec<u32> = byte_indices.collect();
-  byte_indices.sort_unstable();
-  let mut index: u32 = 0;
-  let mut index_utf16: u32 = 0;
-  let mut map: FxHashMap<u32, u32> =
-    FxHashMap::with_capacity_and_hasher(byte_indices.len(), Default::default());
-  for &i in &byte_indices {
-    let slice = &source[index as usize..i as usize];
-    // Fast path: ASCII strings have 1:1 byte-to-UTF-16 mapping
-    index_utf16 += if slice.is_ascii() {
-      slice.len() as u32
-    } else {
-      slice.chars().map(|c| c.len_utf16() as u32).sum::<u32>()
-    };
-    index = i;
-    map.insert(i, index_utf16);
-  }
-  map
-}

--- a/crates/string_wizard/src/magic_string/source_map.rs
+++ b/crates/string_wizard/src/magic_string/source_map.rs
@@ -67,4 +67,3 @@ impl MagicString<'_> {
     source_map
   }
 }
-

--- a/crates/string_wizard/src/magic_string_chain.rs
+++ b/crates/string_wizard/src/magic_string_chain.rs
@@ -155,9 +155,9 @@ impl MagicStringChain {
           ));
           chunk.edited_content = Some(content.into());
           chunk.keep_in_mappings = segment.keep_in_mappings;
-          let name = segment
-            .keep_in_mappings
-            .then(|| &self.original_source[segment.original_start as usize..segment.original_end as usize]);
+          let name = segment.keep_in_mappings.then(|| {
+            &self.original_source[segment.original_start as usize..segment.original_end as usize]
+          });
           builder.add_chunk(
             &chunk,
             utf16_map[&segment.original_start],

--- a/crates/string_wizard/src/magic_string_chain.rs
+++ b/crates/string_wizard/src/magic_string_chain.rs
@@ -1,0 +1,925 @@
+use crate::MagicString;
+
+#[derive(Debug, Clone, Copy)]
+struct Segment {
+  output_start: u32,
+  output_end: u32,
+  original_start: u32,
+  original_end: u32,
+  /// Content was modified (not a 1:1 byte mapping to original).
+  edited: bool,
+  keep_in_mappings: bool,
+}
+
+impl Segment {
+  fn is_inserted(&self) -> bool {
+    self.original_start == self.original_end
+  }
+
+  /// 1:1 byte mapping — positions within can be linearly mapped to original.
+  fn is_identity(&self) -> bool {
+    !self.is_inserted() && !self.edited
+  }
+}
+
+/// Chains multiple MagicString transformations while maintaining a position
+/// mapping from the current output back to the original source.
+///
+/// This allows generating a single sourcemap at the end without intermediate
+/// sourcemap generation and composition, which is more efficient.
+///
+/// # Example
+/// ```
+/// use string_wizard::MagicStringChain;
+///
+/// let mut sc = MagicStringChain::new("const a = 1;");
+/// let mut s = sc.start();
+/// s.update(10, 11, "100").unwrap();
+/// sc.end(s);
+/// assert_eq!(sc.current_output(), "const a = 100;");
+///
+/// let mut s = sc.start();
+/// s.update(13, 14, "").unwrap();
+/// sc.end(s);
+/// assert_eq!(sc.current_output(), "const a = 100");
+/// ```
+pub struct MagicStringChain {
+  /// The original source string.
+  original_source: String,
+  /// The current output string (after all steps so far).
+  current_output: String,
+  /// Position mapping: each segment maps an output range to an original range.
+  /// Segments are in output order.
+  segments: Vec<Segment>,
+  /// Whether any step MagicString had `ignore_list` set.
+  ignore_list: bool,
+}
+
+impl MagicStringChain {
+  /// Create a new chain with the given original source.
+  pub fn new(source: impl Into<String>) -> Self {
+    let source = source.into();
+    let len = source.len() as u32;
+    let segments = if len > 0 {
+      vec![Segment {
+        output_start: 0,
+        output_end: len,
+        original_start: 0,
+        original_end: len,
+        edited: false,
+        keep_in_mappings: false,
+      }]
+    } else {
+      vec![]
+    };
+    Self { current_output: source.clone(), original_source: source, segments, ignore_list: false }
+  }
+
+  /// Start a new transformation step.
+  /// Returns a fresh MagicString wrapping the current output.
+  pub fn start(&self) -> MagicString<'static> {
+    MagicString::new(self.current_output.clone())
+  }
+
+  /// End a transformation step.
+  /// Composes the MagicString's changes with the existing position mapping.
+  ///
+  /// # Panics
+  /// Panics if the MagicString's source doesn't match the chain's current output.
+  /// This indicates that a non-chained transformation happened in between.
+  pub fn end(&mut self, s: MagicString<'_>) {
+    debug_assert_eq!(
+      self.current_output,
+      s.source(),
+      "MagicString source must match chain's current output. \
+       A non-chained transformation may have happened between start() and end()."
+    );
+    if s.ignore_list() {
+      self.ignore_list = true;
+    }
+    let new_segments = self.compose_segments(&s);
+    self.current_output = s.to_string();
+    self.segments = merge_overlapping_segments(new_segments);
+  }
+
+  /// Returns true if the given source matches the chain's current output.
+  /// Use this to check whether a MagicString can be composed into this chain.
+  pub fn is_source_compatible(&self, source: &str) -> bool {
+    self.current_output == source
+  }
+
+  /// Returns a reference to the current output string.
+  pub fn current_output(&self) -> &str {
+    &self.current_output
+  }
+
+  /// Returns a reference to the original source string.
+  pub fn original_source(&self) -> &str {
+    &self.original_source
+  }
+
+  /// Generate a sourcemap from the original source to the current output.
+  ///
+  /// Builds the sourcemap directly from the composed segments, which correctly
+  /// handles relocations, `keep_in_mappings` names, and `ignore_list`.
+  #[cfg(feature = "sourcemap")]
+  pub fn source_map(&self, opts: crate::SourceMapOptions) -> oxc_sourcemap::SourceMap {
+    use crate::source_map::{locator::Locator, sourcemap_builder::SourcemapBuilder};
+
+    let mut builder = SourcemapBuilder::new(opts.hires);
+    builder.set_source_and_content(&opts.source, &self.original_source);
+
+    let locator = Locator::new(&self.original_source);
+    let utf16_map = crate::source_map::precompute_utf16_index_map(
+      &self.original_source,
+      self.segments.iter().filter(|s| !s.is_inserted()).map(|s| s.original_start),
+    );
+
+    for segment in &self.segments {
+      let content =
+        &self.current_output[segment.output_start as usize..segment.output_end as usize];
+
+      if segment.is_inserted() {
+        // Inserted content — advance output position, no source token.
+        builder.advance(content);
+      } else {
+        let original_content =
+          &self.original_source[segment.original_start as usize..segment.original_end as usize];
+        let is_edited = content != original_content;
+
+        if is_edited {
+          // Build a temporary edited chunk so we can reuse SourcemapBuilder::add_chunk.
+          let mut chunk = crate::chunk::Chunk::new(crate::span::Span(
+            segment.original_start,
+            segment.original_end,
+          ));
+          chunk.edited_content = Some(content.into());
+          chunk.keep_in_mappings = segment.keep_in_mappings;
+          let name = segment
+            .keep_in_mappings
+            .then(|| &self.original_source[segment.original_start as usize..segment.original_end as usize]);
+          builder.add_chunk(
+            &chunk,
+            utf16_map[&segment.original_start],
+            &locator,
+            &self.original_source,
+            name,
+          );
+        } else {
+          // Identity — unedited chunk: per-character tokens.
+          let chunk = crate::chunk::Chunk::new(crate::span::Span(
+            segment.original_start,
+            segment.original_end,
+          ));
+          builder.add_chunk(
+            &chunk,
+            utf16_map[&segment.original_start],
+            &locator,
+            &self.original_source,
+            None,
+          );
+        }
+      }
+    }
+
+    let mut source_map = builder.into_source_map();
+    if self.ignore_list {
+      source_map.set_x_google_ignore_list(vec![0]);
+    }
+    source_map
+  }
+
+  /// Compose the step MagicString's changes with the existing position mapping.
+  fn compose_segments(&self, s: &MagicString<'_>) -> Vec<Segment> {
+    let mut new_segments = Vec::new();
+    let mut new_output_pos = 0u32;
+
+    // Global intro (from prepend) — inserted content
+    for intro in s.global_intro() {
+      let len = intro.len() as u32;
+      if len > 0 {
+        new_segments.push(Segment {
+          output_start: new_output_pos,
+          output_end: new_output_pos + len,
+          original_start: 0,
+          original_end: 0,
+          edited: false,
+          keep_in_mappings: false,
+        });
+        new_output_pos += len;
+      }
+    }
+
+    for chunk in s.iter_chunks() {
+      // Chunk intro (from append_right / prepend_right)
+      for intro_frag in &chunk.intro {
+        let len = intro_frag.len() as u32;
+        if len > 0 {
+          let orig_pos = self.map_output_position(chunk.start());
+          new_segments.push(Segment {
+            output_start: new_output_pos,
+            output_end: new_output_pos + len,
+            original_start: orig_pos,
+            original_end: orig_pos,
+            edited: false,
+            keep_in_mappings: false,
+          });
+          new_output_pos += len;
+        }
+      }
+
+      let chunk_start = chunk.start();
+      let chunk_end = chunk.end();
+
+      if let Some(ref edited_content) = chunk.edited_content {
+        let (orig_start, orig_end) = self.map_output_range(chunk_start, chunk_end);
+        let content_len = edited_content.len() as u32;
+
+        if content_len > 0 || orig_start < orig_end {
+          new_segments.push(Segment {
+            output_start: new_output_pos,
+            output_end: new_output_pos + content_len,
+            original_start: orig_start,
+            original_end: orig_end,
+            edited: true,
+            keep_in_mappings: chunk.keep_in_mappings,
+          });
+        }
+        new_output_pos += content_len;
+      } else {
+        self.carry_forward_segments(chunk_start, chunk_end, &mut new_output_pos, &mut new_segments);
+      }
+
+      // Chunk outro (from append_left / prepend_left)
+      for outro_frag in &chunk.outro {
+        let len = outro_frag.len() as u32;
+        if len > 0 {
+          let orig_pos = self.map_output_position(chunk.end());
+          new_segments.push(Segment {
+            output_start: new_output_pos,
+            output_end: new_output_pos + len,
+            original_start: orig_pos,
+            original_end: orig_pos,
+            edited: false,
+            keep_in_mappings: false,
+          });
+          new_output_pos += len;
+        }
+      }
+    }
+
+    // Global outro (from append) — inserted content
+    for outro in s.global_outro() {
+      let len = outro.len() as u32;
+      if len > 0 {
+        let source_len = self.original_source.len() as u32;
+        new_segments.push(Segment {
+          output_start: new_output_pos,
+          output_end: new_output_pos + len,
+          original_start: source_len,
+          original_end: source_len,
+          edited: false,
+          keep_in_mappings: false,
+        });
+        new_output_pos += len;
+      }
+    }
+
+    new_segments
+  }
+
+  /// Map a single output position to the corresponding original position.
+  fn map_output_position(&self, pos: u32) -> u32 {
+    for seg in &self.segments {
+      if pos >= seg.output_start && pos < seg.output_end {
+        if seg.is_identity() {
+          return seg.original_start + (pos - seg.output_start);
+        }
+        return seg.original_start;
+      }
+    }
+    // pos is at or past the end of all segments
+    self.original_source.len() as u32
+  }
+
+  /// Map an output range [start, end) to the corresponding original range.
+  /// Returns the union of original ranges for all overlapping segments.
+  fn map_output_range(&self, start: u32, end: u32) -> (u32, u32) {
+    if start == end {
+      let pos = self.map_output_position(start);
+      return (pos, pos);
+    }
+
+    let mut orig_start = u32::MAX;
+    let mut orig_end = 0u32;
+
+    for seg in &self.segments {
+      // Skip non-overlapping segments
+      if seg.output_end <= start || seg.output_start >= end {
+        continue;
+      }
+
+      if seg.is_inserted() {
+        orig_start = orig_start.min(seg.original_start);
+        orig_end = orig_end.max(seg.original_end);
+        continue;
+      }
+
+      let overlap_start = start.max(seg.output_start);
+      let overlap_end = end.min(seg.output_end);
+
+      if seg.is_identity() {
+        // Identity: linear mapping for the overlapping part
+        let mapped_start = seg.original_start + (overlap_start - seg.output_start);
+        let mapped_end = seg.original_start + (overlap_end - seg.output_start);
+        orig_start = orig_start.min(mapped_start);
+        orig_end = orig_end.max(mapped_end);
+      } else {
+        // Edited: use the full original range
+        orig_start = orig_start.min(seg.original_start);
+        orig_end = orig_end.max(seg.original_end);
+      }
+    }
+
+    if orig_start == u32::MAX {
+      let source_len = self.original_source.len() as u32;
+      (source_len, source_len)
+    } else {
+      (orig_start, orig_end)
+    }
+  }
+
+  /// Carry forward existing segments for an unedited chunk in the step MagicString.
+  /// The chunk range [chunk_start, chunk_end) is in current_output positions.
+  fn carry_forward_segments(
+    &self,
+    chunk_start: u32,
+    chunk_end: u32,
+    new_output_pos: &mut u32,
+    new_segments: &mut Vec<Segment>,
+  ) {
+    for seg in &self.segments {
+      // Skip non-overlapping segments
+      if seg.output_end <= chunk_start || seg.output_start >= chunk_end {
+        continue;
+      }
+
+      let overlap_start = chunk_start.max(seg.output_start);
+      let overlap_end = chunk_end.min(seg.output_end);
+      let overlap_len = overlap_end - overlap_start;
+
+      if overlap_len == 0 && !seg.is_inserted() {
+        continue;
+      }
+
+      if seg.is_inserted() {
+        if overlap_len > 0 {
+          new_segments.push(Segment {
+            output_start: *new_output_pos,
+            output_end: *new_output_pos + overlap_len,
+            original_start: seg.original_start,
+            original_end: seg.original_end,
+            edited: seg.edited,
+            keep_in_mappings: seg.keep_in_mappings,
+          });
+          *new_output_pos += overlap_len;
+        }
+      } else if seg.is_identity() {
+        let orig_offset_start = overlap_start - seg.output_start;
+        let orig_offset_end = overlap_end - seg.output_start;
+        new_segments.push(Segment {
+          output_start: *new_output_pos,
+          output_end: *new_output_pos + overlap_len,
+          original_start: seg.original_start + orig_offset_start,
+          original_end: seg.original_start + orig_offset_end,
+          edited: false,
+          keep_in_mappings: seg.keep_in_mappings,
+        });
+        *new_output_pos += overlap_len;
+      } else {
+        // Edited segment: carry forward with full original range
+        new_segments.push(Segment {
+          output_start: *new_output_pos,
+          output_end: *new_output_pos + overlap_len,
+          original_start: seg.original_start,
+          original_end: seg.original_end,
+          edited: true,
+          keep_in_mappings: seg.keep_in_mappings,
+        });
+        *new_output_pos += overlap_len;
+      }
+    }
+  }
+}
+
+impl std::fmt::Display for MagicStringChain {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.write_str(&self.current_output)
+  }
+}
+
+/// Merge segments with overlapping original ranges.
+///
+/// After composition, a new edit can partially consume a previously-edited segment,
+/// leaving the remainder with an overlapping original range. This function merges
+/// such segments so that sourcemap generation produces correct, non-conflicting edits.
+///
+/// Only merges when the overlap is genuine (same direction), NOT when segments are
+/// simply out of order due to relocations.
+fn merge_overlapping_segments(segments: Vec<Segment>) -> Vec<Segment> {
+  if segments.len() <= 1 {
+    return segments;
+  }
+
+  let mut merged: Vec<Segment> = Vec::with_capacity(segments.len());
+
+  for seg in segments {
+    let should_merge = merged.last().is_some_and(|last: &Segment| {
+      // Merge if both are non-inserted, in the same monotonic direction,
+      // and their original ranges genuinely overlap (not merely reordered).
+      !last.is_inserted()
+        && !seg.is_inserted()
+        && seg.original_start >= last.original_start
+        && seg.original_start < last.original_end
+    });
+
+    if should_merge {
+      let last = merged.last_mut().unwrap();
+      last.output_end = seg.output_end;
+      last.original_end = last.original_end.max(seg.original_end);
+      // Preserve keep_in_mappings if either segment has it
+      last.keep_in_mappings = last.keep_in_mappings || seg.keep_in_mappings;
+    } else {
+      merged.push(seg);
+    }
+  }
+
+  merged
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn basic_single_step() {
+    let mut sc = MagicStringChain::new("const a = 1;");
+    let mut s = sc.start();
+    s.update(10, 11, "100").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "const a = 100;");
+  }
+
+  #[test]
+  fn issue_example_two_steps() {
+    // The exact example from the issue
+    let mut sc = MagicStringChain::new("const a = 1;");
+
+    let mut s = sc.start();
+    s.update(10, 11, "100").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "const a = 100;");
+
+    let mut s = sc.start();
+    // Position 13 in "const a = 100;" is the ";", position 14 is end
+    s.update(13, 14, "").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "const a = 100");
+  }
+
+  #[test]
+  fn two_steps_non_overlapping() {
+    let mut sc = MagicStringChain::new("abcdef");
+
+    let mut s = sc.start();
+    s.update(0, 2, "XY").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "XYcdef");
+
+    let mut s = sc.start();
+    s.update(4, 6, "ZZ").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "XYcdZZ");
+  }
+
+  #[test]
+  fn second_step_at_boundary_of_first_edit() {
+    let mut sc = MagicStringChain::new("abcdef");
+
+    // Step 1: replace "cd" with "XYZ"
+    let mut s = sc.start();
+    s.update(2, 4, "XYZ").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abXYZef");
+
+    // Step 2: edit right after the first edit (position 5 = "e")
+    let mut s = sc.start();
+    s.update(5, 6, "Q").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abXYZQf");
+  }
+
+  #[test]
+  fn second_step_overwrites_entire_previous_edit() {
+    let mut sc = MagicStringChain::new("abcdef");
+
+    let mut s = sc.start();
+    s.update(2, 4, "XYZ").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abXYZef");
+
+    // Step 2: overwrite the entire previous edit region [2, 5) = "XYZ"
+    let mut s = sc.start();
+    s.update(2, 5, "Q").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abQef");
+  }
+
+  #[test]
+  fn edit_spanning_previous_edit_and_unedited() {
+    let mut sc = MagicStringChain::new("abcdefg");
+
+    // Step 1: replace "de" with "xyz"
+    let mut s = sc.start();
+    s.update(3, 5, "xyz").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abcxyzfg");
+
+    // Step 2: overwrite across the edit boundary [2,5) = "cxy" → "Q"
+    let mut s = sc.start();
+    s.update(2, 5, "Q").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abQzfg");
+  }
+
+  #[test]
+  fn removal() {
+    let mut sc = MagicStringChain::new("abcdef");
+
+    let mut s = sc.start();
+    s.remove(2, 4).unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abef");
+
+    // Step 2: operate on the shorter string
+    let mut s = sc.start();
+    s.update(0, 2, "XY").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "XYef");
+  }
+
+  #[test]
+  fn append_left_insertion() {
+    let mut sc = MagicStringChain::new("abcdef");
+
+    let mut s = sc.start();
+    s.append_left(3, "XY");
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abcXYdef");
+
+    // Step 2: edit after the insertion
+    let mut s = sc.start();
+    s.update(5, 8, "QRS").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abcXYQRS");
+  }
+
+  #[test]
+  fn global_prepend_and_append() {
+    let mut sc = MagicStringChain::new("abc");
+
+    let mut s = sc.start();
+    s.prepend(">>>");
+    s.append("<<<");
+    sc.end(s);
+    assert_eq!(sc.current_output(), ">>>abc<<<");
+
+    // Step 2: edit the original content (positions shifted by prepend)
+    let mut s = sc.start();
+    s.update(3, 6, "XYZ").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), ">>>XYZ<<<");
+  }
+
+  #[test]
+  fn multiple_edits_in_one_step() {
+    let mut sc = MagicStringChain::new("abcdefgh");
+
+    let mut s = sc.start();
+    s.update(1, 2, "B").unwrap();
+    s.update(5, 6, "F").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "aBcdeFgh");
+
+    let mut s = sc.start();
+    s.update(0, 1, "A").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "ABcdeFgh");
+  }
+
+  #[test]
+  fn three_sequential_steps() {
+    let mut sc = MagicStringChain::new("hello world");
+
+    // Step 1
+    let mut s = sc.start();
+    s.update(0, 5, "HELLO").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "HELLO world");
+
+    // Step 2
+    let mut s = sc.start();
+    s.update(6, 11, "WORLD").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "HELLO WORLD");
+
+    // Step 3
+    let mut s = sc.start();
+    s.update(5, 6, "_").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "HELLO_WORLD");
+  }
+
+  #[test]
+  fn no_modification_step() {
+    let mut sc = MagicStringChain::new("abcdef");
+
+    let mut s = sc.start();
+    s.update(2, 4, "XY").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abXYef");
+
+    // Step 2: no modifications
+    let s = sc.start();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abXYef");
+  }
+
+  #[test]
+  fn edit_that_grows_then_shrinks() {
+    let mut sc = MagicStringChain::new("ab");
+
+    // Step 1: grow "a" into "xyz"
+    let mut s = sc.start();
+    s.update(0, 1, "xyz").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "xyzb");
+
+    // Step 2: shrink "xyzb" to "Qb" by replacing "xyz" (positions 0-3)
+    let mut s = sc.start();
+    s.update(0, 3, "Q").unwrap();
+    sc.end(s);
+    assert_eq!(sc.current_output(), "Qb");
+  }
+
+  #[test]
+  fn append_right_insertion() {
+    let mut sc = MagicStringChain::new("abcdef");
+
+    let mut s = sc.start();
+    s.append_right(3, "XY");
+    sc.end(s);
+    assert_eq!(sc.current_output(), "abcXYdef");
+  }
+
+  #[test]
+  fn chain_with_replace() {
+    let mut sc = MagicStringChain::new("hello world hello");
+
+    let mut s = sc.start();
+    let _ = s.replace("hello", "hi");
+    sc.end(s);
+    assert_eq!(sc.current_output(), "hi world hello");
+
+    let mut s = sc.start();
+    let _ = s.replace("hello", "hi");
+    sc.end(s);
+    assert_eq!(sc.current_output(), "hi world hi");
+  }
+
+  #[cfg(feature = "sourcemap")]
+  mod sourcemap_tests {
+    use super::*;
+    use crate::SourceMapOptions;
+    use crate::source_map::sourcemap_builder::Hires;
+    use crate::{MagicStringOptions, UpdateOptions};
+    use oxc_sourcemap::SourcemapVisualizer;
+
+    #[test]
+    fn sourcemap_basic() {
+      let mut sc = MagicStringChain::new("const a = 1;");
+
+      let mut s = sc.start();
+      s.update(10, 11, "100").unwrap();
+      sc.end(s);
+
+      let mut s = sc.start();
+      s.update(13, 14, "").unwrap();
+      sc.end(s);
+
+      assert_eq!(sc.current_output(), "const a = 100");
+
+      let sm = sc.source_map(SourceMapOptions {
+        source: "test.js".into(),
+        include_content: true,
+        hires: Hires::False,
+      });
+
+      // Verify the sourcemap was generated successfully
+      assert!(sm.get_source(0).is_some());
+    }
+
+    #[test]
+    fn sourcemap_with_insertion() {
+      let mut sc = MagicStringChain::new("abcdef");
+
+      let mut s = sc.start();
+      s.append_left(3, "XY");
+      sc.end(s);
+
+      assert_eq!(sc.current_output(), "abcXYdef");
+
+      let sm = sc.source_map(SourceMapOptions {
+        source: "test.js".into(),
+        include_content: false,
+        hires: Hires::False,
+      });
+
+      assert!(sm.get_source(0).is_some());
+    }
+
+    #[test]
+    fn sourcemap_matches_direct_magic_string() {
+      // Verify that the chain's sourcemap produces equivalent results
+      // to applying all edits directly on a single MagicString
+      let mut direct = MagicString::new("const a = 1;".to_string());
+      direct.update(10, 11, "100").unwrap();
+      direct.remove(11, 12).unwrap();
+
+      let direct_sm = direct.source_map(SourceMapOptions {
+        source: "test.js".into(),
+        include_content: true,
+        hires: Hires::False,
+      });
+
+      let mut sc = MagicStringChain::new("const a = 1;");
+      let mut s = sc.start();
+      s.update(10, 11, "100").unwrap();
+      sc.end(s);
+      let mut s = sc.start();
+      // In the chain output "const a = 100;", position 13 is ";", 14 is end
+      s.update(13, 14, "").unwrap();
+      sc.end(s);
+
+      let chain_sm = sc.source_map(SourceMapOptions {
+        source: "test.js".into(),
+        include_content: true,
+        hires: Hires::False,
+      });
+
+      // Both should produce the same output
+      assert_eq!(direct.to_string(), sc.current_output());
+
+      // Compare token counts (both should have same number of source tokens)
+      assert_eq!(direct_sm.get_tokens().count(), chain_sm.get_tokens().count());
+    }
+
+    #[test]
+    fn sourcemap_matches_direct_magic_string_for_relocate() {
+      let mut direct = MagicString::new("abcdef".to_string());
+      direct.relocate(0, 2, 6).unwrap();
+
+      let mut chain = MagicStringChain::new("abcdef");
+      let mut step = chain.start();
+      step.relocate(0, 2, 6).unwrap();
+      chain.end(step);
+
+      let output = direct.to_string();
+      assert_eq!(output, chain.current_output());
+
+      let opts =
+        || SourceMapOptions { source: "test.js".into(), include_content: true, hires: Hires::True };
+      let direct_sm = direct.source_map(opts());
+      let chain_sm = chain.source_map(opts());
+
+      assert_eq!(
+        SourcemapVisualizer::new(&output, &direct_sm).get_text(),
+        SourcemapVisualizer::new(&output, &chain_sm).get_text()
+      );
+    }
+
+    #[test]
+    fn sourcemap_preserves_original_names_from_step() {
+      let mut direct = MagicString::new("abc".to_string());
+      direct
+        .update_with(1, 2, "B", UpdateOptions { keep_original: true, ..Default::default() })
+        .unwrap();
+
+      let mut chain = MagicStringChain::new("abc");
+      let mut step = chain.start();
+      step
+        .update_with(1, 2, "B", UpdateOptions { keep_original: true, ..Default::default() })
+        .unwrap();
+      chain.end(step);
+
+      let direct_sm = direct.source_map(SourceMapOptions::default());
+      let chain_sm = chain.source_map(SourceMapOptions::default());
+      let direct_names = direct_sm.get_names().map(|name| name.as_ref()).collect::<Vec<_>>();
+      let chain_names = chain_sm.get_names().map(|name| name.as_ref()).collect::<Vec<_>>();
+
+      assert_eq!(direct_names, chain_names);
+    }
+
+    #[test]
+    fn sourcemap_preserves_ignore_list_from_step() {
+      let mut direct = MagicString::with_options(
+        "abc".to_string(),
+        MagicStringOptions { ignore_list: true, ..Default::default() },
+      );
+      direct.update(1, 2, "B").unwrap();
+
+      let mut chain = MagicStringChain::new("abc");
+      let mut step = MagicString::with_options(
+        "abc".to_string(),
+        MagicStringOptions { ignore_list: true, ..Default::default() },
+      );
+      step.update(1, 2, "B").unwrap();
+      chain.end(step);
+
+      let direct_sm = direct.source_map(SourceMapOptions::default());
+      let chain_sm = chain.source_map(SourceMapOptions::default());
+
+      assert_eq!(direct_sm.get_x_google_ignore_list(), chain_sm.get_x_google_ignore_list());
+    }
+
+    /// When a non-MagicString plugin returns an explicit sourcemap between two
+    /// native-MagicString plugins, the pipeline must flush the current chain,
+    /// eagerly collapse with the barrier, and start a fresh chain.
+    #[test]
+    fn sourcemap_chain_flush_and_collapse_at_barrier() {
+      use rolldown_sourcemap::collapse_sourcemaps;
+
+      let source = "abcdef";
+
+      let mut first_step = MagicString::new(source.to_string());
+      first_step.update(0, 1, "A").unwrap();
+      let after_first_step = first_step.to_string();
+      let first_step_map = first_step.source_map(SourceMapOptions {
+        source: "original.js".into(),
+        include_content: true,
+        hires: Hires::True,
+      });
+
+      // A plugin that returns the same code but a non-identity sourcemap.
+      let mut barrier = MagicString::new("uvwxyz".to_string());
+      barrier.update(0, 6, after_first_step.clone()).unwrap();
+      let barrier_map = barrier.source_map(SourceMapOptions {
+        source: "barrier.js".into(),
+        include_content: true,
+        hires: Hires::True,
+      });
+
+      let mut second_step = MagicString::new(after_first_step.clone());
+      second_step.update(1, 2, "B").unwrap();
+      let output = second_step.to_string();
+      let second_step_map = second_step.source_map(SourceMapOptions {
+        source: "after-first.js".into(),
+        include_content: true,
+        hires: Hires::True,
+      });
+
+      // Ground truth: collapsing all three individual sourcemaps.
+      let expected = collapse_sourcemaps(&[&first_step_map, &barrier_map, &second_step_map]);
+
+      // Simulate the background-thread pipeline:
+      // 1. Chain accumulates first_step, then a Barrier arrives.
+      let mut chain1 = MagicStringChain::new(source);
+      chain1.end(first_step);
+      let chain1_map = chain1.source_map(SourceMapOptions {
+        source: "original.js".into(),
+        include_content: true,
+        hires: Hires::True,
+      });
+
+      // 2. Eagerly collapse the chain's sourcemap with the barrier.
+      let base_map = collapse_sourcemaps(&[&chain1_map, &barrier_map]);
+
+      // 3. New chain for the second step.
+      let mut chain2 = MagicStringChain::new(after_first_step);
+      chain2.end(second_step);
+      let chain2_map = chain2.source_map(SourceMapOptions {
+        source: "after-first.js".into(),
+        include_content: true,
+        hires: Hires::True,
+      });
+
+      // 4. Collapse the accumulated base with the new chain.
+      let actual = collapse_sourcemaps(&[&base_map, &chain2_map]);
+
+      assert_eq!(
+        SourcemapVisualizer::new(&output, &expected).get_text(),
+        SourcemapVisualizer::new(&output, &actual).get_text()
+      );
+    }
+  }
+}

--- a/crates/string_wizard/src/source_map/mod.rs
+++ b/crates/string_wizard/src/source_map/mod.rs
@@ -1,2 +1,31 @@
 pub mod locator;
 pub mod sourcemap_builder;
+
+use rustc_hash::FxHashMap;
+
+/// Precompute a mapping from byte indices to UTF-16 column offsets.
+/// Used by both `MagicString::source_map` and `MagicStringChain::source_map`.
+pub(crate) fn precompute_utf16_index_map(
+  source: &str,
+  byte_indices: impl Iterator<Item = u32>,
+) -> FxHashMap<u32, u32> {
+  // Indices may be unsorted (e.g. after relocate()), so sort is required.
+  let mut byte_indices: Vec<u32> = byte_indices.collect();
+  byte_indices.sort_unstable();
+  byte_indices.dedup();
+  let mut index: u32 = 0;
+  let mut index_utf16: u32 = 0;
+  let mut map: FxHashMap<u32, u32> =
+    FxHashMap::with_capacity_and_hasher(byte_indices.len(), Default::default());
+  for &i in &byte_indices {
+    let slice = &source[index as usize..i as usize];
+    index_utf16 += if slice.is_ascii() {
+      slice.len() as u32
+    } else {
+      slice.chars().map(|c| c.len_utf16() as u32).sum::<u32>()
+    };
+    index = i;
+    map.insert(i, index_utf16);
+  }
+  map
+}

--- a/packages/rolldown/tests/fixtures/output/sourcemap/native-magic-string-with-custom-sourcemap/_config.ts
+++ b/packages/rolldown/tests/fixtures/output/sourcemap/native-magic-string-with-custom-sourcemap/_config.ts
@@ -1,0 +1,103 @@
+import MagicString from 'magic-string';
+import { defineTest } from 'rolldown-tests';
+import { getLocation, getOutputAsset, getOutputChunk } from 'rolldown-tests/utils';
+import { SourceMapConsumer } from 'source-map';
+import { expect } from 'vitest';
+
+// Simulates the barrier scenario: two native-MagicString plugins with a
+// non-MagicString plugin in between that returns a custom sourcemap.
+// The chain must flush at the barrier and produce correct mappings.
+export default defineTest({
+  sequential: true,
+  config: {
+    input: ['main.js'],
+    experimental: {
+      nativeMagicString: true,
+    },
+    output: {
+      sourcemap: true,
+    },
+    plugins: [
+      // Plugin 1: uses native MagicString to rename 'foo' → 'bar'
+      {
+        name: 'plugin-native-1',
+        transform(code, id, meta) {
+          if (id.startsWith('\0')) return null;
+          if (!meta?.magicString) return null;
+          meta.magicString.replace('foo', 'bar');
+          return { code: meta.magicString };
+        },
+      },
+      // Plugin 1b: second consecutive native MagicString — renames 'aaa' → 'bbb'.
+      // This tests that the chain composes multiple native MS steps before flushing.
+      {
+        name: 'plugin-native-1b',
+        transform(code, id, meta) {
+          if (id.startsWith('\0')) return null;
+          if (!meta?.magicString) return null;
+          meta.magicString.replace('aaa', 'bbb');
+          return { code: meta.magicString };
+        },
+      },
+      // Plugin 2: returns a custom sourcemap (the barrier).
+      // Uses JS MagicString to produce a precise per-token sourcemap.
+      {
+        name: 'plugin-custom-sourcemap',
+        transform(code, id) {
+          if (id.startsWith('\0')) return null;
+          const idx = code.indexOf('hello');
+          if (idx === -1) return null;
+          const s = new MagicString(code);
+          s.overwrite(idx, idx + 5, 'world');
+          return {
+            code: s.toString(),
+            map: s.generateMap({ source: id, includeContent: true, hires: true }),
+          };
+        },
+      },
+      // Plugin 3: uses native MagicString to rename 'bar' → 'baz'
+      {
+        name: 'plugin-native-2',
+        transform(code, id, meta) {
+          if (id.startsWith('\0')) return null;
+          if (!meta?.magicString) return null;
+          meta.magicString.replace('bar', 'baz');
+          return { code: meta.magicString };
+        },
+      },
+    ],
+  },
+  afterTest: async function (output) {
+    const chunk = getOutputChunk(output)[0];
+    // foo→bar→baz, hello→world, aaa→bbb
+    expect(chunk.code).toContain('baz');
+    expect(chunk.code).toContain('world');
+    expect(chunk.code).toContain('bbb');
+    expect(chunk.map).toBeDefined();
+
+    const map = getOutputAsset(output)[0].source as string;
+    const smc = await new SourceMapConsumer(JSON.parse(map));
+
+    // 'baz' was originally 'foo' on line 1.
+    // Traces through: chain2 (baz→bar) → barrier (identity) → chain1 (bar→foo).
+    const bazLoc = getLocation(chunk.code, chunk.code.indexOf('baz'));
+    const bazOriginal = smc.originalPositionFor(bazLoc);
+    expect(bazOriginal.source).toContain('main.js');
+    expect(bazOriginal.line).toBe(1);
+
+    // 'world' was originally 'hello' on line 1.
+    // Traces through: chain2 (identity) → barrier (world→hello) → chain1.
+    const worldLoc = getLocation(chunk.code, chunk.code.indexOf('world'));
+    const worldOriginal = smc.originalPositionFor(worldLoc);
+    expect(worldOriginal.source).toContain('main.js');
+    expect(worldOriginal.line).toBe(1);
+
+    // 'bbb' was originally 'aaa' on line 2.
+    // Verifies the chain composed two native MS steps (foo→bar, aaa→bbb)
+    // before flushing at the barrier.
+    const bbbLoc = getLocation(chunk.code, chunk.code.indexOf('bbb'));
+    const bbbOriginal = smc.originalPositionFor(bbbLoc);
+    expect(bbbOriginal.source).toContain('main.js');
+    expect(bbbOriginal.line).toBe(2);
+  },
+});

--- a/packages/rolldown/tests/fixtures/output/sourcemap/native-magic-string-with-custom-sourcemap/main.js
+++ b/packages/rolldown/tests/fixtures/output/sourcemap/native-magic-string-with-custom-sourcemap/main.js
@@ -1,0 +1,2 @@
+export const foo = 'hello';
+export const aaa = 'keep';

--- a/packages/rolldown/tests/package.json
+++ b/packages/rolldown/tests/package.json
@@ -30,6 +30,7 @@
     "@rolldown/test-side-effects-field": "link:./package-fixtures/test-side-effects-field",
     "@rolldown/test-side-effects-field-glob": "file:./package-fixtures/test-side-effects-field-glob",
     "@types/node": "catalog:",
+    "magic-string": "^0.30.17",
     "source-map-js": "^1.2.1",
     "tsx": "catalog:"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,6 +646,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.3
+      magic-string:
+        specifier: ^0.30.17
+        version: 0.30.21
       source-map-js:
         specifier: ^1.2.1
         version: 1.2.1


### PR DESCRIPTION

# Description

Implements a `MagicStringChain` in `string_wizard` that composes sourcemaps from consecutive native `meta.magicString` transform plugins on the Rust side, avoiding repeated JSON serialization of intermediate sourcemaps. When a JS sourcemap barrier is encountered, the chain flushes and remaps through the accumulated native steps. Includes integration tests for mixed native + custom sourcemap plugin chains.


ad-hoc benchmark https://gist.github.com/IWANABETHATGUY/67357ec53afeef84c58313670c2aa7b0
Based on https://github.com/rolldown/benchmarks


# Sourcemap Chain Benchmark Results

Comparing the optimized sourcemap chain (`04-08-feat_source_map_chain`) against `main`.

## Setup

- **App**: `apps/10000` (10,000 JSX modules)
- **Rolldown**: release builds on both branches
- **Runs**: 10 (with 3 warmup)

### Plugin configurations

| Scenario | Description |
|---|---|
| No plugin (baseline) | No plugins, just bundling with sourcemaps |
| Noop plugin | A transform plugin that matches `.jsx` but returns `null` (measures hook overhead) |
| Chain (5 plugins) | 5 consecutive native `meta.magicString` plugins, each doing a `replaceAll` |
| Barrier chain | Same 5 native plugins, but with a JS `MagicString` barrier plugin in the middle (forces flush + re-materialize of the sourcemap chain) |

## 1. Absolute Build Time

| Scenario | main | current (optimized) | Diff | Speedup |
|---|---|---|---|---|
| No plugin (baseline) | - | 1.282s ± 0.018s | - | - |
| Noop plugin | - | 1.323s ± 0.028s | - | - |
| Chain (5 native plugins) | 2.641s ± 0.052s | 2.607s ± 0.060s | -34ms | 1.01x |
| Barrier chain (native + JS + native) | 3.409s ± 0.054s | 3.302s ± 0.036s | -107ms | 1.03x |

## 2. Plugin Transform Time Only

Isolated by subtracting the noop plugin baseline (1.323s) from each scenario.

| Scenario | main | current (optimized) | Diff | Speedup |
|---|---|---|---|---|
| Chain (5 native plugins) | 1.318s | 1.284s | -34ms | 1.03x |
| Barrier chain (native + JS + native) | 2.086s | 1.979s | -107ms | 1.05x |

## Observations

- The **no-plugin baseline** (1.282s) vs **noop plugin** (1.323s) shows ~41ms of pure plugin hook overhead for 10,000 modules.
- The **pure native chain** sees a modest ~1.03x speedup in transform time. Consecutive native `meta.magicString` plugins already avoid JSON serialization on both branches; the improvement comes from the optimized chain composition.
- The **barrier chain** shows a larger improvement (~1.05x in transform time, 107ms saved). The JS MagicString barrier forces a flush of accumulated native sourcemaps, and the optimized branch handles this flush + re-materialize cycle more efficiently.
- Total build time is dominated by parsing, linking, codegen, and minification. The sourcemap chain accounts for a fraction of the total, so the end-to-end speedup is modest even when the chain itself is faster.


