### PR TITLE
fix: prevent stack overflow in `generate_transitive_esm_init` on circular dependencies

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -138,15 +138,20 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
       return;
     }
 
+    // Guard against infinite recursion from circular dependencies.
+    // `generated_init_esm_importee_ids` serves double duty: it tracks both
+    // modules for which we already emitted an init call AND modules we have
+    // already visited during transitive traversal.
+    if self.generated_init_esm_importee_ids.contains(&importee.idx) {
+      return;
+    }
+    self.generated_init_esm_importee_ids.insert(importee.idx);
+
     // Only generate init calls for modules in the same chunk whose wrapper is
     // declared (i.e. the module is included in the output).
     if importee_linking_info.is_included
       && self.ctx.chunk_graph.module_to_chunk[importee.idx] == Some(self.ctx.chunk_idx)
     {
-      if self.generated_init_esm_importee_ids.contains(&importee.idx) {
-        return;
-      }
-      self.generated_init_esm_importee_ids.insert(importee.idx);
       let (wrapper_ref_expr, _) = self.finalized_expr_for_symbol_ref(
         importee_linking_info.wrapper_ref.unwrap(),
         false,

--- a/crates/rolldown/tests/rolldown/issues/9028/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/9028/_config.json
@@ -1,0 +1,5 @@
+{
+  "config": {
+    "strictExecutionOrder": true
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/9028/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/9028/artifacts.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## main.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region lib.js
+var init_lib = __esmMin((() => {}));
+//#endregion
+//#region barrel.js
+var init_barrel = __esmMin((() => {
+	init_lib();
+}));
+//#endregion
+__esmMin((() => {
+	init_barrel();
+	console.log(42);
+}))();
+
+```

--- a/crates/rolldown/tests/rolldown/issues/9028/barrel.js
+++ b/crates/rolldown/tests/rolldown/issues/9028/barrel.js
@@ -1,0 +1,5 @@
+// Barrel module: the re-export of `unused` will be excluded by tree-shaking,
+// but under strict execution order the excluded statement still triggers
+// `generate_transitive_esm_init` to walk through the import graph.
+export { value } from './lib.js';
+export { unused } from './cycle-a.js';

--- a/crates/rolldown/tests/rolldown/issues/9028/cycle-a.js
+++ b/crates/rolldown/tests/rolldown/issues/9028/cycle-a.js
@@ -1,0 +1,5 @@
+// cycle-a and cycle-b form a circular dependency.
+// Both are not included (unused), so generate_transitive_esm_init
+// will keep recursing through their import records without terminating
+// if there is no visited guard.
+export { unused } from './cycle-b.js';

--- a/crates/rolldown/tests/rolldown/issues/9028/cycle-b.js
+++ b/crates/rolldown/tests/rolldown/issues/9028/cycle-b.js
@@ -1,0 +1,2 @@
+import './cycle-a.js';
+export const unused = 'unused';

--- a/crates/rolldown/tests/rolldown/issues/9028/lib.js
+++ b/crates/rolldown/tests/rolldown/issues/9028/lib.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/crates/rolldown/tests/rolldown/issues/9028/main.js
+++ b/crates/rolldown/tests/rolldown/issues/9028/main.js
@@ -1,0 +1,2 @@
+import { value } from './barrel.js';
+console.log(value);


### PR DESCRIPTION
## Summary

`generate_transitive_esm_init` recursively traverses module import records to find included importees for ESM init call generation. It has two branches:

1. Importee is in the same chunk → emit init call, record in visited set
2. Importee is NOT in the same chunk → recurse into its import records

The visited-set guard (`generated_init_esm_importee_ids`) only existed in branch 1. When circular dependencies exist and the involved modules are in different chunks, branch 2 recurses infinitely (A → B → A → B → ...), causing a stack overflow on the rayon worker thread.

This was exposed by #8979, which prevents merging common chunks into side-effectful entry chunks — causing more modules to land in separate chunks, making branch 2 far more likely to be hit.

The fix moves the visited-set check before the branch, so it guards both paths.

Fixes #9028

## Test plan

- Added regression test `issues/9028` with circular dependencies in barrel modules under `strictExecutionOrder`
- Verified the crash no longer occurs on the reproduction project
- All existing tests pass