### PR TITLE
refactor: simplify ESM init deduplication with idiomatic insert check

### DIFF
--- a/crates/rolldown/src/module_finalizers/mod.rs
+++ b/crates/rolldown/src/module_finalizers/mod.rs
@@ -142,10 +142,9 @@ impl<'me, 'ast> ScopeHoistingFinalizer<'me, 'ast> {
     // `generated_init_esm_importee_ids` serves double duty: it tracks both
     // modules for which we already emitted an init call AND modules we have
     // already visited during transitive traversal.
-    if self.generated_init_esm_importee_ids.contains(&importee.idx) {
+    if !self.generated_init_esm_importee_ids.insert(importee.idx) {
       return;
     }
-    self.generated_init_esm_importee_ids.insert(importee.idx);
 
     // Only generate init calls for modules in the same chunk whose wrapper is
     // declared (i.e. the module is included in the output).


### PR DESCRIPTION
## Summary
- Replace separate `contains` + `insert` calls on `generated_init_esm_importee_ids` with a single `insert` call that returns whether the value was newly added
- Idiomatic Rust simplification with no behavior change

## Test plan
- Existing tests pass — no logic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)