### PR TITLE
feat: implement module tagging system for code splitting

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/code_splitting.rs
@@ -11,8 +11,9 @@ use itertools::Itertools;
 use oxc_index::{IndexVec, index_vec};
 use rolldown_common::{
   Chunk, ChunkIdx, ChunkKind, ChunkMeta, EntryPointKind, ExportsKind, ImportKind, ImportRecordIdx,
-  ImportRecordMeta, IndexModules, Module, ModuleIdx, ModuleNamespaceIncludedReason,
-  PostChunkOptimizationOperation, PreserveEntrySignatures, SymbolRef, WrapKind,
+  ImportRecordMeta, IndexModules, Module, ModuleIdx, ModuleNamespaceIncludedReason, ModuleTag,
+  ModuleTagBitSet, ModuleTagRegistry, PostChunkOptimizationOperation, PreserveEntrySignatures,
+  SymbolRef, WrapKind,
 };
 use rolldown_error::BuildResult;
 use rolldown_utils::{
@@ -30,6 +31,8 @@ use super::{GenerateStage, chunk_ext::ChunkCreationReason};
 pub struct SplittingInfo {
   pub bits: BitSet,
   pub share_count: u32,
+  /// Module tags bitset. See meta/design/module-tags.md
+  pub tags_bit_set: ModuleTagBitSet,
 }
 
 pub type IndexSplittingInfo = IndexVec<ModuleIdx, SplittingInfo>;
@@ -54,7 +57,8 @@ impl GenerateStage<'_> {
 
     let mut index_splitting_info: IndexSplittingInfo = oxc_index::index_vec![SplittingInfo {
         bits: BitSet::new(entries_len),
-        share_count: 0
+        share_count: 0,
+        tags_bit_set: ModuleTagBitSet::default(),
       }; self.link_output.module_table.modules.len()];
     let mut bits_to_chunk = FxHashMap::with_capacity(entries_len as usize);
 
@@ -812,17 +816,23 @@ impl GenerateStage<'_> {
     input_base: &ArcStr,
   ) -> BuildResult<()> {
     // Determine which modules belong to which chunk. A module could belong to multiple chunks.
-    for (entry_index, (&module_idx, _)) in self
+    let tag_registry = ModuleTagRegistry::new();
+    for (entry_index, (&module_idx, entry_point)) in self
       .link_output
       .entries
       .iter()
       .flat_map(|(idx, entries)| entries.iter().map(move |e| (idx, e)))
       .enumerate()
     {
+      let is_user_defined_entry = matches!(
+        entry_point.kind,
+        EntryPointKind::UserDefined | EntryPointKind::EmittedUserDefined
+      );
       self.determine_reachable_modules_for_entry(
         module_idx,
         entry_index.try_into().expect("Too many entries, u32 overflowed."),
         index_splitting_info,
+        is_user_defined_entry,
       );
     }
 
@@ -835,6 +845,7 @@ impl GenerateStage<'_> {
         &mut module_is_assigned,
         chunk_graph,
         input_base,
+        &tag_registry,
       )
       .await?;
 
@@ -934,6 +945,7 @@ impl GenerateStage<'_> {
     entry_module_idx: ModuleIdx,
     entry_index: u32,
     index_splitting_info: &mut IndexSplittingInfo,
+    is_user_defined_entry: bool,
   ) {
     debug_assert!(
       self.link_output.module_table[entry_module_idx].is_normal(),
@@ -957,6 +969,11 @@ impl GenerateStage<'_> {
 
       index_splitting_info[module_idx].bits.set_bit(entry_index);
       index_splitting_info[module_idx].share_count += 1;
+      // Tag as initial if reachable from a user-defined entry via static imports.
+      // See meta/design/module-tags.md
+      if is_user_defined_entry {
+        index_splitting_info[module_idx].tags_bit_set.set_bit(ModuleTag::INITIAL_BIT);
+      }
       meta.dependencies.iter().copied().for_each(|dep_idx| {
         q.push_back(dep_idx);
       });

--- a/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
+++ b/crates/rolldown/src/stages/generate_stage/manual_code_splitting.rs
@@ -9,7 +9,7 @@ use arcstr::ArcStr;
 use oxc_index::IndexVec;
 use rolldown_common::{
   Chunk, ChunkKind, ChunkingContext, EntryPoint, ManualCodeSplittingOptions, MatchGroup,
-  MatchGroupTest, Module, ModuleIdx, ModuleTable,
+  MatchGroupTest, Module, ModuleIdx, ModuleTable, ModuleTagBitSet, ModuleTagRegistry,
 };
 use rolldown_error::BuildResult;
 use rolldown_plugin::SharedPluginDriver;
@@ -80,6 +80,9 @@ struct ManualSplitter<'a> {
   options: &'a SharedOptions,
   chunking_options: &'a ManualCodeSplittingOptions,
   match_groups: Vec<&'a MatchGroup>,
+  /// Precomputed tag bitsets per match group (parallel to `match_groups`).
+  /// `None` if the group has no `tags` filter.
+  match_group_required_tags: Vec<Option<ModuleTagBitSet>>,
   plugin_driver: &'a SharedPluginDriver,
   input_base: &'a ArcStr,
   chunk_graph: &'a mut ChunkGraph,
@@ -142,6 +145,13 @@ impl ManualSplitter<'_> {
 
         if !is_matched {
           continue;
+        }
+
+        // Filter by module tags. See meta/design/module-tags.md
+        if let Some(required_tags) = &self.match_group_required_tags[match_group_index] {
+          if !splitting_info.tags_bit_set.contains_all(required_tags) {
+            continue;
+          }
         }
 
         let allow_min_module_size =
@@ -508,6 +518,7 @@ impl GenerateStage<'_> {
     module_to_assigned: &mut IndexBitSet<ModuleIdx>,
     chunk_graph: &mut ChunkGraph,
     input_base: &ArcStr,
+    tag_registry: &ModuleTagRegistry,
   ) -> BuildResult<()> {
     let Some(chunking_options) = &self.options.manual_code_splitting else {
       return Ok(());
@@ -525,12 +536,17 @@ impl GenerateStage<'_> {
 
     let flattened_entries: Vec<&EntryPoint> =
       self.link_output.entries.iter().flat_map(|(_idx, entries)| entries.iter()).collect();
+    let match_group_required_tags: Vec<Option<ModuleTagBitSet>> = match_groups
+      .iter()
+      .map(|group| group.tags.as_ref().map(|tags| tag_registry.compile_tags_to_bit_set(tags)))
+      .collect();
     let mut splitter = ManualSplitter {
       link_output: self.link_output,
       index_splitting_info,
       options: self.options,
       chunking_options,
       match_groups,
+      match_group_required_tags,
       plugin_driver: self.plugin_driver,
       input_base,
       chunk_graph,

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/_config.json
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/_config.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "input": [
+      {
+        "name": "main",
+        "import": "./main.js"
+      }
+    ],
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "initial-deps",
+          "tags": ["$initial"]
+        }
+      ]
+    }
+  },
+  "extendedTests": {
+    "preserveEntrySignaturesAllowExtension": false,
+    "preserveEntrySignaturesStrict": false,
+    "oppositeMinifyInternalExports": false
+  }
+}

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/_test.mjs
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/_test.mjs
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+const dist = path.join(import.meta.dirname, 'dist');
+const files = fs
+  .readdirSync(dist)
+  .filter((f) => f !== 'package.json')
+  .sort();
+
+// tags: ['$initial'] should capture modules in the static import chain of the entry
+// but NOT modules only reachable via dynamic import
+assert.deepStrictEqual(files, ['initial-deps.js', 'lazy.js', 'main.js']);
+
+const initialDeps = fs.readFileSync(path.join(dist, 'initial-deps.js'), 'utf-8');
+assert.ok(
+  initialDeps.includes('shared.js'),
+  'initial-deps should contain shared.js (statically imported)',
+);
+assert.ok(
+  !initialDeps.includes('lazy-dep.js'),
+  'initial-deps should NOT contain lazy-dep.js (dynamic-only)',
+);
+
+const lazyChunk = fs.readFileSync(path.join(dist, 'lazy.js'), 'utf-8');
+assert.ok(lazyChunk.includes('lazy-dep.js'), 'lazy chunk should contain lazy-dep.js');
+assert.ok(!lazyChunk.includes('shared.js'), 'lazy chunk should NOT contain shared.js');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/artifacts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## initial-deps.js
+
+```js
+//#region shared.js
+const shared = "shared-initial";
+//#endregion
+//#region main.js
+const lazy = import("./lazy.js");
+//#endregion
+export { shared as n, lazy as t };
+
+```
+
+## lazy.js
+
+```js
+//#region lazy-dep.js
+const lazyDep = "lazy-dep";
+//#endregion
+export { lazyDep };
+
+```
+
+## main.js
+
+```js
+import { n as shared, t as lazy } from "./initial-deps.js";
+export { lazy, shared };
+
+```

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/lazy-dep.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/lazy-dep.js
@@ -1,0 +1,1 @@
+export const lazyDep = 'lazy-dep';

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/lazy.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/lazy.js
@@ -1,0 +1,2 @@
+import { lazyDep } from './lazy-dep.js';
+export { lazyDep };

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/main.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/main.js
@@ -1,0 +1,3 @@
+import { shared } from './shared.js';
+export { shared };
+export const lazy = import('./lazy.js');

--- a/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/shared.js
+++ b/crates/rolldown/tests/rolldown/function/advanced_chunks/tags_initial/shared.js
@@ -1,0 +1,1 @@
+export const shared = 'shared-initial';

--- a/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
+++ b/crates/rolldown_binding/src/options/binding_output_options/binding_manual_code_splitting_options.rs
@@ -40,6 +40,7 @@ pub struct BindingMatchGroup {
   pub max_size: Option<f64>,
   pub entries_aware: Option<bool>,
   pub entries_aware_merge_threshold: Option<f64>,
+  pub tags: Option<Vec<String>>,
 }
 
 #[napi_derive::napi]

--- a/crates/rolldown_binding/src/utils/normalize_binding_options.rs
+++ b/crates/rolldown_binding/src/utils/normalize_binding_options.rs
@@ -23,6 +23,7 @@ use rolldown::{
 };
 use rolldown_common::DeferSyncScanData;
 use rolldown_common::GeneratedCodeOptions;
+use rolldown_common::ModuleTag;
 use rolldown_plugin::__inner::SharedPluginable;
 use rolldown_utils::indexmap::FxIndexMap;
 use rolldown_utils::rustc_hash::FxHashMapExt;
@@ -517,6 +518,7 @@ pub fn normalize_binding_options(
             max_size: item.max_size,
             entries_aware: item.entries_aware,
             entries_aware_merge_threshold: item.entries_aware_merge_threshold,
+            tags: item.tags.map(|tags| tags.into_iter().map(ModuleTag::from).collect()),
           })
           .collect::<Vec<_>>()
       }),

--- a/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
+++ b/crates/rolldown_common/src/inner_bundler_options/types/manual_code_splitting_options.rs
@@ -7,7 +7,20 @@ use schemars::JsonSchema;
 #[cfg(feature = "deserialize_bundler_options")]
 use serde::{Deserialize, Deserializer};
 
-use crate::{ModuleInfo, SharedModuleInfoDashMap};
+use crate::{ModuleInfo, ModuleTag, SharedModuleInfoDashMap};
+
+/// Schema-only enum for built-in module tags. Used by `schemars` to generate
+/// a restricted JSON Schema for the `tags` field. Not used at runtime.
+#[cfg(feature = "deserialize_bundler_options")]
+#[derive(JsonSchema)]
+#[expect(dead_code)]
+enum BuiltinModuleTag {
+  #[schemars(rename = "$initial")]
+  Initial,
+  // Phase 2:
+  // #[schemars(rename = "$lazy")]
+  // Lazy,
+}
 
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(
@@ -54,6 +67,13 @@ pub struct MatchGroup {
   pub entries_aware: Option<bool>,
   /// Only effective when `entriesAware` is set to `true`.
   pub entries_aware_merge_threshold: Option<f64>,
+  /// Filter modules by tags. Only modules with all specified tags are captured.
+  /// See meta/design/module-tags.md
+  #[cfg_attr(
+    feature = "deserialize_bundler_options",
+    schemars(with = "Option<Vec<BuiltinModuleTag>>")
+  )]
+  pub tags: Option<Vec<ModuleTag>>,
 }
 
 type MatchGroupTestFn = dyn Fn(&str) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<bool>>> + Send + 'static>>

--- a/crates/rolldown_common/src/lib.rs
+++ b/crates/rolldown_common/src/lib.rs
@@ -188,6 +188,7 @@ pub use crate::{
   types::module_namespace_included_reason::ModuleNamespaceIncludedReason,
   types::module_render_output::ModuleRenderOutput,
   types::module_table::{IndexModules, ModuleTable},
+  types::module_tag::{ModuleTag, ModuleTagBitSet, ModuleTagRegistry},
   types::named_export::LocalExport,
   types::named_import::{NamedImport, Specifier},
   types::namespace_alias::NamespaceAlias,

--- a/crates/rolldown_common/src/types/mod.rs
+++ b/crates/rolldown_common/src/types/mod.rs
@@ -34,6 +34,7 @@ pub mod module_info;
 pub mod module_namespace_included_reason;
 pub mod module_render_output;
 pub mod module_table;
+pub mod module_tag;
 pub mod named_export;
 pub mod named_import;
 pub mod namespace_alias;

--- a/crates/rolldown_common/src/types/module_tag.rs
+++ b/crates/rolldown_common/src/types/module_tag.rs
@@ -1,0 +1,89 @@
+#[cfg(feature = "deserialize_bundler_options")]
+use serde::{Deserialize, Deserializer};
+
+// See meta/design/module-tags.md
+
+/// A `u64`-based bitset for module tags.
+///
+/// Unlike the general `BitSet` (heap-allocated `Vec<u8>`), this is `Copy` and
+/// `contains_all` is a single AND + CMP instruction. Supports up to 64 tags.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+pub struct ModuleTagBitSet(u64);
+
+impl ModuleTagBitSet {
+  pub fn set_bit(&mut self, bit: u32) {
+    self.0 |= 1u64 << bit;
+  }
+
+  pub fn has_bit(&self, bit: u32) -> bool {
+    (self.0 & (1u64 << bit)) != 0
+  }
+
+  /// True if all bits in `required` are also set in `self`.
+  pub fn contains_all(&self, required: &Self) -> bool {
+    (self.0 & required.0) == required.0
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.0 == 0
+  }
+}
+
+/// Module tag enum. Built-in tags have fixed bit indices for zero-cost matching.
+/// `Custom(String)` is reserved for future user-defined tags.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ModuleTag {
+  Initial,
+  // Phase 2: Async,
+  Custom(String),
+}
+
+impl ModuleTag {
+  pub const INITIAL_BIT: u32 = 0;
+  // Phase 2: pub const ASYNC_BIT: u32 = 1;
+}
+
+impl From<String> for ModuleTag {
+  fn from(s: String) -> Self {
+    match s.as_str() {
+      "$initial" => ModuleTag::Initial,
+      // Phase 2: "$async" => ModuleTag::Async,
+      _ => ModuleTag::Custom(s),
+    }
+  }
+}
+
+#[cfg(feature = "deserialize_bundler_options")]
+impl<'de> Deserialize<'de> for ModuleTag {
+  fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+    let s = String::deserialize(deserializer)?;
+    Ok(ModuleTag::from(s))
+  }
+}
+
+/// Registry for tag bit allocation. Built-in tags use fixed consts on `ModuleTag`.
+/// Custom tag support will be added in a future phase.
+pub struct ModuleTagRegistry {
+  // Future: custom_tag_bits: FxHashMap<String, u32>,
+}
+
+impl ModuleTagRegistry {
+  pub fn new() -> Self {
+    Self {}
+  }
+
+  /// Compile tags into a `ModuleTagBitSet`. Unknown custom tags are silently ignored.
+  pub fn compile_tags_to_bit_set(&self, tags: &[ModuleTag]) -> ModuleTagBitSet {
+    let mut bits = ModuleTagBitSet::default();
+    for tag in tags {
+      match tag {
+        ModuleTag::Initial => bits.set_bit(ModuleTag::INITIAL_BIT),
+        // Phase 2: ModuleTag::Async => bits.set_bit(ModuleTag::ASYNC_BIT),
+        ModuleTag::Custom(_name) => {
+          // Custom tags not yet supported — silently ignored.
+        }
+      }
+    }
+    bits
+  }
+}

--- a/crates/rolldown_testing/_config.schema.json
+++ b/crates/rolldown_testing/_config.schema.json
@@ -1311,11 +1311,28 @@
             "null"
           ],
           "format": "double"
+        },
+        "tags": {
+          "description": "Filter modules by tags. Only modules with all specified tags are captured.\nSee meta/design/module-tags.md",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/BuiltinModuleTag"
+          }
         }
       },
       "additionalProperties": false,
       "required": [
         "name"
+      ]
+    },
+    "BuiltinModuleTag": {
+      "description": "Schema-only enum for built-in module tags. Used by `schemars` to generate\na restricted JSON Schema for the `tags` field. Not used at runtime.",
+      "type": "string",
+      "enum": [
+        "$initial"
       ]
     },
     "ChecksOptions": {

--- a/meta/design/module-tags.md
+++ b/meta/design/module-tags.md
@@ -46,6 +46,14 @@ output: {
 
 `tags` uses AND semantics: only modules that have **all** specified tags are captured by the group. It combines with other filters (`test`, `minShareCount`, etc.) — a module must match all criteria.
 
+### Internal representation
+
+Tag names are mapped to bit indices at build time via a registry (`$initial` → bit 0, `$lazy` → bit 1, etc.). Each module stores its tags as a `u64` bitset rather than a set of strings. Matching a module against a group's `tags` filter is a single bitwise AND + comparison — no string allocation or comparison at match time.
+
+### Incremental build
+
+Built-in tags like `$initial` are computed from the module graph structure (which modules are statically reachable from which entries). When a file changes during incremental/watch rebuilds, the module graph may change — an `import` statement added or removed can shift a module between `$initial` and `$lazy`. Tags must be recomputed from scratch on each rebuild during the code splitting stage. This is acceptable because tag computation piggybacks on the existing entry reachability BFS (no separate pass), and the bitset operations are negligible compared to the rest of code splitting.
+
 ### Implementation priority
 
 **Phase 1:**

--- a/packages/rolldown/src/binding.d.cts
+++ b/packages/rolldown/src/binding.d.cts
@@ -2341,6 +2341,7 @@ export interface BindingMatchGroup {
   maxSize?: number
   entriesAware?: boolean
   entriesAwareMergeThreshold?: number
+  tags?: Array<string>
 }
 
 export interface BindingModulePreloadOptions {

--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -736,6 +736,13 @@ export interface OutputOptions {
   strict?: boolean | 'auto';
 }
 
+/**
+ * Built-in module tag names computed by rolldown.
+ *
+ * - `'$initial'` — the module is statically imported by at least one user-defined entry point, or is part of its static dependency chain.
+ */
+export type BuiltinModuleTag = '$initial';
+
 export type CodeSplittingGroup = {
   /**
    * Name of the group. It will be also used as the name of the chunk and replace the `[name]` placeholder in the {@linkcode OutputOptions.chunkFileNames | output.chunkFileNames} option.
@@ -899,6 +906,21 @@ export type CodeSplittingGroup = {
    * @default 0
    */
   entriesAwareMergeThreshold?: number;
+  /**
+   * Filter modules by tags. Only modules that have **all** specified tags
+   * are captured by this group. Combines with `test` and other filters —
+   * a module must match all criteria.
+   *
+   * Built-in tags: `'$initial'` (module is statically imported by a user-defined entry or part of its dependency chain).
+   *
+   * @see {@link https://rolldown.rs/guide/manual-code-splitting | Manual Code Splitting}
+   *
+   * @example
+   * ```js
+   * { name: 'initial-deps', tags: ['$initial'], maxSize: 1048576 }
+   * ```
+   */
+  tags?: BuiltinModuleTag[];
 };
 
 /**

--- a/packages/rolldown/src/utils/validator.ts
+++ b/packages/rolldown/src/utils/validator.ts
@@ -795,6 +795,7 @@ const AdvancedChunksSchema = v.strictObject({
         maxModuleSize: v.optional(v.number()),
         entriesAware: v.optional(v.boolean()),
         entriesAwareMergeThreshold: v.optional(v.number()),
+        tags: v.optional(v.array(v.string())),
       }),
     ),
   ),


### PR DESCRIPTION
## Summary

Implements Phase 1 of the module tags design ([#9017](https://github.com/rolldown/rolldown/pull/9017)):

- **`$initial` tag** — automatically computed during the entry BFS. Modules statically imported by user-defined entries (or in their dependency chain) are tagged `$initial`.
- **`tags` filter** — manual code splitting groups can filter by tags with AND semantics. Only modules with all specified tags are captured.

## Implementation

- `ModuleTagBitSet` — `u64`-based bitset (`Copy`, single AND+CMP for `contains_all`). Supports up to 64 tags.
- `ModuleTagRegistry` — sealed registry mapping tag names (`$initial`, future `$lazy`) to bit indices. All registration happens in `new()`.
- `$initial` tag is computed inside `determine_reachable_modules_for_entry` BFS — no separate pass needed.
- Built-in tags use `$` prefix to distinguish from user-defined tags.

## Test plan

- [x] Integration test `tags_initial` — entry with static + dynamic imports, verifies `tags: ['$initial']` captures only statically reachable modules
- [x] `cargo check` compiles
- [x] `just lint-rust` passes
- [x] `just build-rolldown` regenerates bindings
- [x] TypeScript types check

🤖 Generated with [Claude Code](https://claude.com/claude-code)