### PR TITLE
fix: correct circular dependency check in facade elimination

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -798,10 +798,7 @@ impl GenerateStage<'_> {
         if temp_runtime_chunk_idx
           .and_then(|temp_runtime_idx| {
             let temp_target_idx = temp_chunk_opt_graph.to_temp_idx(target_chunk_idx)?;
-            Some(
-              temp_chunk_opt_graph
-                .would_create_circular_dependency(temp_runtime_idx, temp_target_idx),
-            )
+            Some(temp_chunk_opt_graph.is_reachable(temp_runtime_idx, temp_target_idx))
           })
           // If runtime is not included before, it will not create circular dependency, because
           // the runtime module will be either included in the target chunk or in a separate chunk loaded before.

--- a/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/_config.json
+++ b/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/_config.json
@@ -1,0 +1,17 @@
+{
+  "snapshotOutputStats": true,
+  "config": {
+    "manualCodeSplitting": {
+      "groups": [
+        {
+          "name": "i18n-ar",
+          "test": "ar_EG"
+        },
+        {
+          "name": "i18n-en-US",
+          "test": "en_US"
+        }
+      ]
+    }
+  }
+}

--- a/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/artifacts.snap
@@ -1,0 +1,95 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## i18n-ar.js
+
+```js
+import { n as __exportAll, t as __commonJSMin } from "./rolldown-runtime.js";
+//#region vendor/rc-picker/locale/common.js
+var require_common = /* @__PURE__ */ __commonJSMin(((exports) => {
+	exports.commonLocale = {
+		yearFormat: "YYYY",
+		dayFormat: "D",
+		monthBeforeYear: true
+	};
+}));
+//#endregion
+//#region vendor/rc-picker/locale/ar_EG.js
+var import_common = require_common();
+var locale$1 = Object.assign({}, import_common.commonLocale, {
+	locale: "ar",
+	today: "اليوم"
+});
+//#endregion
+//#region vendor/antd/locale/ar_EG.js
+var ar_EG_exports = /* @__PURE__ */ __exportAll({
+	DatePicker: () => locale$1,
+	locale: () => "ar"
+});
+//#endregion
+export { require_common as n, ar_EG_exports as t };
+
+```
+
+## i18n-en-US.js
+
+```js
+import { n as __exportAll } from "./rolldown-runtime.js";
+import { n as require_common } from "./i18n-ar.js";
+//#region vendor/rc-picker/locale/en_US.js
+var import_common = require_common();
+var locale$1 = Object.assign({}, import_common.commonLocale, {
+	locale: "en_US",
+	today: "Today"
+});
+//#endregion
+//#region vendor/antd/locale/en_US.js
+var en_US_exports = /* @__PURE__ */ __exportAll({
+	DatePicker: () => locale$1,
+	locale: () => "en"
+});
+//#endregion
+export { en_US_exports as t };
+
+```
+
+## main.js
+
+```js
+import assert from "node:assert";
+//#region main.js
+const loaders = {
+	ar: () => import("./i18n-ar.js").then((n) => n.t),
+	"en-US": () => import("./i18n-en-US.js").then((n) => n.t)
+};
+async function main() {
+	const ar = await loaders.ar();
+	const enUS = await loaders["en-US"]();
+	assert.strictEqual(ar.locale, "ar");
+	assert.strictEqual(ar.DatePicker.locale, "ar");
+	assert.strictEqual(ar.DatePicker.yearFormat, "YYYY");
+	assert.strictEqual(enUS.locale, "en");
+	assert.strictEqual(enUS.DatePicker.locale, "en_US");
+	assert.strictEqual(enUS.DatePicker.yearFormat, "YYYY");
+}
+main();
+//#endregion
+
+```
+
+## rolldown-runtime.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+export { __exportAll as n, __commonJSMin as t };
+
+```
+
+# Output Stats
+
+- i18n-ar.js, is_entry false, is_dynamic_entry false, exports ["n", "t"]
+- i18n-en-US.js, is_entry false, is_dynamic_entry false, exports ["t"]
+- main.js, is_entry true, is_dynamic_entry false, exports []
+- rolldown-runtime.js, is_entry false, is_dynamic_entry false, exports ["n", "t"]

--- a/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/main.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/main.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert';
+
+// This mimics the way import.meta.glob works in Vite.
+const loaders = {
+  ar: () => import('./vendor/antd/locale/ar_EG.js'),
+  'en-US': () => import('./vendor/antd/locale/en_US.js'),
+};
+
+async function main() {
+  const ar = await loaders.ar();
+  const enUS = await loaders['en-US']();
+
+  assert.strictEqual(ar.locale, 'ar');
+  assert.strictEqual(ar.DatePicker.locale, 'ar');
+  assert.strictEqual(ar.DatePicker.yearFormat, 'YYYY');
+
+  assert.strictEqual(enUS.locale, 'en');
+  assert.strictEqual(enUS.DatePicker.locale, 'en_US');
+  assert.strictEqual(enUS.DatePicker.yearFormat, 'YYYY');
+}
+
+main();

--- a/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/vendor/antd/locale/ar_EG.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/vendor/antd/locale/ar_EG.js
@@ -1,0 +1,3 @@
+import DatePicker from '../../rc-picker/locale/ar_EG.js';
+export const locale = 'ar';
+export { DatePicker };

--- a/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/vendor/antd/locale/en_US.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/vendor/antd/locale/en_US.js
@@ -1,0 +1,3 @@
+import DatePicker from '../../rc-picker/locale/en_US.js';
+export const locale = 'en';
+export { DatePicker };

--- a/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/vendor/rc-picker/locale/ar_EG.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/vendor/rc-picker/locale/ar_EG.js
@@ -1,0 +1,3 @@
+import { commonLocale } from './common.js';
+var locale = Object.assign({}, commonLocale, { locale: 'ar', today: 'اليوم' });
+export default locale;

--- a/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/vendor/rc-picker/locale/common.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/vendor/rc-picker/locale/common.js
@@ -1,0 +1,2 @@
+var commonLocale = { yearFormat: 'YYYY', dayFormat: 'D', monthBeforeYear: true };
+exports.commonLocale = commonLocale;

--- a/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/vendor/rc-picker/locale/en_US.js
+++ b/crates/rolldown/tests/rolldown/code_splitting/facade_elimination_with_shared_cjs_dep/vendor/rc-picker/locale/en_US.js
@@ -1,0 +1,3 @@
+import { commonLocale } from './common.js';
+var locale = Object.assign({}, commonLocale, { locale: 'en_US', today: 'Today' });
+export default locale;

--- a/crates/rolldown/tests/rolldown/issues/8361_2/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8361_2/artifacts.snap
@@ -15,17 +15,14 @@ source: crates/rolldown_testing/src/integration_test.rs
 ## a.js
 
 ```js
-import "./a2.js";
-
-```
-
-## a2.js
-
-```js
+import { n as __exportAll } from "./chunk.js";
 import { t as require_cjs } from "./cjs.js";
 import "./b.js";
+//#region a.js
+var a_exports = /* @__PURE__ */ __exportAll({});
 require_cjs();
 //#endregion
+export { a_exports as t };
 
 ```
 
@@ -36,7 +33,7 @@ import { n as __exportAll, r as __toESM } from "./chunk.js";
 //#region b.js
 var b_exports = /* @__PURE__ */ __exportAll({ foo2: () => foo2 });
 function foo2() {
-	import("./a.js");
+	import("./a.js").then((n) => n.t);
 	Promise.resolve().then(() => b_exports);
 }
 import("./cjs.js").then((n) => /* @__PURE__ */ __toESM(n.t()));
@@ -69,6 +66,6 @@ export { require_cjs as t };
 ## main.js
 
 ```js
-import "./a2.js";
+import "./a.js";
 
 ```

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/restore-query-extension/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/restore-query-extension/index.ts.snap
@@ -1,13 +1,13 @@
 import { t as a_exports } from "./a.js";
 import { t as b_exports } from "./b.js";
-import { n as modules_exports, r as name$2 } from "./modules2.js";
+import { n as name$2, t as modules_exports } from "./modules.js";
 import { t as a_default } from "./a2.js";
 import { t as b_default } from "./b2.js";
 //#region ../fixtures/a/index.ts
 const basic = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t),
-	"./modules/index.ts": () => import("./modules.js")
+	"./modules/index.ts": () => import("./modules.js").then((n) => n.t)
 });
 const basicWithObjectKeys = Object.keys({
 	"./modules/a.ts": 0,
@@ -17,7 +17,7 @@ const basicWithObjectKeys = Object.keys({
 const basicWithObjectValues = Object.values([
 	() => import("./a.js").then((n) => n.t),
 	() => import("./b.js").then((n) => n.t),
-	() => import("./modules.js")
+	() => import("./modules.js").then((n) => n.t)
 ]);
 const basicEager = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": a_exports,
@@ -61,7 +61,7 @@ const namedEagerWithObjectValues = Object.values([
 const namedDefault = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t).then((m) => m["default"]),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t).then((m) => m["default"]),
-	"./modules/index.ts": () => import("./modules.js").then((m) => m["default"])
+	"./modules/index.ts": () => import("./modules.js").then((n) => n.t).then((m) => m["default"])
 });
 const namedDefaultWithObjectKeys = Object.keys({
 	"./modules/a.ts": 0,
@@ -71,7 +71,7 @@ const namedDefaultWithObjectKeys = Object.keys({
 const namedDefaultWithObjectValues = Object.values([
 	() => import("./a.js").then((n) => n.t).then((m) => m["default"]),
 	() => import("./b.js").then((n) => n.t).then((m) => m["default"]),
-	() => import("./modules.js").then((m) => m["default"])
+	() => import("./modules.js").then((n) => n.t).then((m) => m["default"])
 ]);
 const eagerAs = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": a_default,
@@ -100,7 +100,7 @@ const cleverCwd2 = /* @__PURE__ */ Object.assign({
 const customBase = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t),
-	"./modules/index.ts": () => import("./modules.js"),
+	"./modules/index.ts": () => import("./modules.js").then((n) => n.t),
 	"./sibling.ts": () => import("./sibling.js")
 });
 const customRootBase = /* @__PURE__ */ Object.assign({

--- a/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
+++ b/packages/rolldown/tests/fixtures/builtin-plugin/import-glob/vite/transform/index.ts.snap
@@ -1,13 +1,13 @@
 import { t as a_exports } from "./a.js";
 import { t as b_exports } from "./b.js";
-import { n as modules_exports, r as name$2 } from "./modules2.js";
+import { n as name$2, t as modules_exports } from "./modules.js";
 import { t as a_default } from "./a2.js";
 import { t as b_default } from "./b2.js";
 //#region ../fixtures/a/index.ts
 const basic = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t),
-	"./modules/index.ts": () => import("./modules.js")
+	"./modules/index.ts": () => import("./modules.js").then((n) => n.t)
 });
 const basicWithObjectKeys = Object.keys({
 	"./modules/a.ts": 0,
@@ -17,7 +17,7 @@ const basicWithObjectKeys = Object.keys({
 const basicWithObjectValues = Object.values([
 	() => import("./a.js").then((n) => n.t),
 	() => import("./b.js").then((n) => n.t),
-	() => import("./modules.js")
+	() => import("./modules.js").then((n) => n.t)
 ]);
 const basicEager = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": a_exports,
@@ -61,7 +61,7 @@ const namedEagerWithObjectValues = Object.values([
 const namedDefault = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t).then((m) => m["default"]),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t).then((m) => m["default"]),
-	"./modules/index.ts": () => import("./modules.js").then((m) => m["default"])
+	"./modules/index.ts": () => import("./modules.js").then((n) => n.t).then((m) => m["default"])
 });
 const namedDefaultWithObjectKeys = Object.keys({
 	"./modules/a.ts": 0,
@@ -71,7 +71,7 @@ const namedDefaultWithObjectKeys = Object.keys({
 const namedDefaultWithObjectValues = Object.values([
 	() => import("./a.js").then((n) => n.t).then((m) => m["default"]),
 	() => import("./b.js").then((n) => n.t).then((m) => m["default"]),
-	() => import("./modules.js").then((m) => m["default"])
+	() => import("./modules.js").then((n) => n.t).then((m) => m["default"])
 ]);
 const eagerAs = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": a_default,
@@ -100,7 +100,7 @@ const cleverCwd2 = /* @__PURE__ */ Object.assign({
 const customBase = /* @__PURE__ */ Object.assign({
 	"./modules/a.ts": () => import("./a.js").then((n) => n.t),
 	"./modules/b.ts": () => import("./b.js").then((n) => n.t),
-	"./modules/index.ts": () => import("./modules.js"),
+	"./modules/index.ts": () => import("./modules.js").then((n) => n.t),
 	"./sibling.ts": () => import("./sibling.js")
 });
 const customRootBase = /* @__PURE__ */ Object.assign({


### PR DESCRIPTION
## Summary

This PR fixes an case of false-positive circular dependency check in facade chunk elimination that caused unnecessary facade chunks. The following is from a minimal reproduction case that is derived from https://github.com/vitejs/vite/issues/21884. You may refer to the test case in this PR for details.

`common.js` is a shared CJS dependency of both `ar_EG.js` and `en_US.js`. Due to
`includeDependenciesRecursively`, `common.js` gets pulled into whichever group is processed first
(`i18n-ar`). This makes `i18n-en-US` cross-chunk-depend on `i18n-ar` to access `require_common`:

i18n-en-US → i18n-ar → runtime

Since `i18n-ar` depends on the runtime, the old check — simulating merging runtime into `i18n-en-US` —
falsely constructs a cycle:

i18n-en-US → i18n-ar → (runtime = i18n-en-US)  ← cycle here

## Fix

Replaced `would_create_circular_dependency` with `is_reachable`. The old check is to simulate merging runtime into the target (i18n-en-US) instead of just checking if runtime has any reference to the target chunk. This causes a false positive on the case where there're multiple chunks that transitively or directly imports runtime. In this case, it's i18n-en-US that imports i18n-ar that imports runtime, which will be considered as cyclic deps. 

Changing to `is_reachable` fixes this as it only checks if runtime chunk has any imports to the target chunk. This makes more sense because we are not going to merge runtime into any of those chunks.

## Test plan

- [x] New fixture `facade_elimination_with_shared_cjs_dep` — 4 chunks, no facades
- [x] Existing snapshot updates from improved facade elimination

## Related issues

Reduces facade chunks in Lobehub's case. Check out the report made by claude here: https://github.com/vitejs/vite/issues/21884#issuecomment-4212470028