### PR TITLE
fix(docs): correct dead link in CodeSplittingGroup.tags JSDoc

### DIFF
--- a/packages/rolldown/src/options/output-options.ts
+++ b/packages/rolldown/src/options/output-options.ts
@@ -913,7 +913,7 @@ export type CodeSplittingGroup = {
    *
    * Built-in tags: `'$initial'` (module is statically imported by a user-defined entry or part of its dependency chain).
    *
-   * @see {@link https://rolldown.rs/guide/manual-code-splitting | Manual Code Splitting}
+   * @see {@link https://rolldown.rs/in-depth/manual-code-splitting | Manual Code Splitting}
    *
    * @example
    * ```js


### PR DESCRIPTION
## Summary

- Fix dead link `/guide/manual-code-splitting` → `/in-depth/manual-code-splitting` in JSDoc for `CodeSplittingGroup.tags` (`packages/rolldown/src/options/output-options.ts:916`)
- This link is picked up by TypeDoc and generated into `docs/reference/TypeAlias.CodeSplittingGroup.md`, causing VitePress to fail the Netlify build with a dead link error

## Context

The Netlify deploy preview for #9050 failed because VitePress detected a dead link in the auto-generated reference docs. The doc page lives at `/in-depth/manual-code-splitting`, not `/guide/manual-code-splitting`. Another `@see` link on line 567 of the same file already uses the correct path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)