### PR TITLE
ci: add docs build check to catch dead links in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       rust-changes: ${{ (steps.filter.outputs.rust-changes == 'true') || (github.ref_name == 'main') }}
       node-changes: ${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') }}
       pluginutils-changes: ${{ (steps.filter.outputs.pluginutils-changes == 'true') || (github.ref_name == 'main') }}
+      docs-changes: ${{ (steps.filter.outputs.docs-changes == 'true') || (github.ref_name == 'main') }}
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
@@ -62,11 +63,22 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+            docs-changes:
+              - '.github/workflows/**'
+              - 'docs/**'
+              - 'packages/rolldown/src/**'
+              - 'packages/rolldown/package.json'
+              - 'packages/rolldown/tsconfig*.json'
+              - 'packages/pluginutils/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
       - name: Show outputs
         run: |
           echo "Rust changes: ${{ (steps.filter.outputs.rust-changes == 'true') || (github.ref_name == 'main') }}"
           echo "Node changes: ${{ (steps.filter.outputs.node-changes == 'true') || (github.ref_name == 'main') }}"
           echo "PluginUtils changes: ${{ (steps.filter.outputs.pluginutils-changes == 'true') || (github.ref_name == 'main') }}"
+          echo "Docs changes: ${{ (steps.filter.outputs.docs-changes == 'true') || (github.ref_name == 'main') }}"
 
   rust-validation:
     name: Rust Validation
@@ -380,3 +392,21 @@ jobs:
       - uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d # v1.45.0
         with:
           files: .
+
+  docs-validation:
+    name: Docs Validation
+    needs: changes
+    if: ${{ needs.changes.outputs.docs-changes == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
+        with:
+          cache: true
+
+      - name: Build @rolldown/pluginutils
+        run: vp run --filter '@rolldown/pluginutils' build
+
+      - name: Build Docs
+        run: vp run docs:build


### PR DESCRIPTION
## Summary

- Add a `docs-build` job to CI that runs the full docs pipeline (TypeDoc reference generation + VitePress build) to catch dead links and build errors before merge
- Add `docs-changes` path filter that triggers on changes to `docs/`, `packages/rolldown/src/**` (JSDoc comments feed TypeDoc), `packages/pluginutils/**`, and `pnpm-lock.yaml`
- Only runs when relevant files change (or on `main`), matching the existing CI pattern

## Context

The Netlify deploy preview for #9050 caught a dead link (`/guide/manual-code-splitting` → `/in-depth/manual-code-splitting`) that was only discovered after push. VitePress already has built-in dead link detection that fails the build, but this only ran on Netlify — not in the required CI checks. This adds it as a proper CI gate.

Fixed in #9051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)