### PR TITLE
chore(ci): extract shared infra-changes anchor in path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,19 @@ jobs:
         id: filter
         with:
           filters: |
-            rust-changes: &rust-changes
+            infra-changes: &infra-changes
               - '.github/workflows/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+            rust-changes: &rust-changes
+              - *infra-changes
               - 'crates/**'
               - 'tasks/**'
               - 'scripts/src/esbuild-tests/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
               - '.gitattributes'
               - 'justfile'
               - 'test262'
@@ -55,24 +58,17 @@ jobs:
               - 'packages/**'
               - 'examples/**'
               - 'scripts/**'
-              - 'package.json'
-              - 'justfile'
               - 'rollup'
             pluginutils-changes:
+              - *infra-changes
               - 'packages/pluginutils/**'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
             docs-changes:
-              - '.github/workflows/**'
+              - *infra-changes
               - 'docs/**'
               - 'packages/rolldown/src/**'
               - 'packages/rolldown/package.json'
               - 'packages/rolldown/tsconfig*.json'
               - 'packages/pluginutils/**'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
       - name: Show outputs
         run: |
           echo "Rust changes: ${{ (steps.filter.outputs.rust-changes == 'true') || (github.ref_name == 'main') }}"


### PR DESCRIPTION
## Summary

- Extract a shared `infra-changes` YAML anchor in the `dorny/paths-filter` config to deduplicate common infrastructure paths (`.github/workflows/**`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`) across all four path filters
- Fixes `package.json` missing from `rust-changes` — it was inconsistent since `pnpm-lock.yaml` and `pnpm-workspace.yaml` were already there, and some Rust tests depend on pnpm install behavior
- Removes redundant `justfile` and `package.json` entries from `node-changes` (already inherited via `*rust-changes`)
- `pluginutils-changes` gains `.github/workflows/**` via the shared anchor (acceptable broadening for consistency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)