### PR TITLE
fix: prevent circular runtime helper imports during facade elimination (#8989)

### DIFF
--- a/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
+++ b/crates/rolldown/src/stages/generate_stage/chunk_optimizer.rs
@@ -1061,15 +1061,50 @@ impl GenerateStage<'_> {
       include_runtime_symbol(context, runtime, RuntimeHelper::ExportAll);
     }
 
-    // Ensure runtime module is properly assigned to chunk graph
-    if chunk_graph.module_to_chunk[runtime_module_idx].is_none()
-      && !runtime_dependent_chunks.is_empty()
-    {
-      // If only one common chunk was appended with dynamic entry module, we just put runtime module into that chunk.
-      // Else create a new common chunk to store runtime module.
-      let runtime_chunk_idx = match runtime_dependent_chunks.len() {
-        1 => runtime_dependent_chunks.into_iter().next().unwrap(),
-        _ => {
+    // Ensure runtime module is properly assigned to chunk graph.
+    //
+    // Facade elimination above can introduce new runtime-helper consumers
+    // (`runtime_dependent_chunks`). The runtime module may also already be
+    // co-located with other modules in some host chunk from the merge phase.
+    // When the host has other modules AND a facade-elim consumer that is not
+    // the host exists, we have ≥2 distinct consumers that both need helpers
+    // from the host. If the host also has a forward path back to the other
+    // consumer, the dependency graph closes a cycle. Peel the runtime out in
+    // that case and let the placement step below re-home it.
+    if !runtime_dependent_chunks.is_empty() {
+      if let Some(host_idx) = chunk_graph.module_to_chunk[runtime_module_idx] {
+        let host_chunk = &chunk_graph.chunk_table[host_idx];
+        let host_has_other_modules = host_chunk.modules.len() > 1;
+        let has_external_consumer = runtime_dependent_chunks.iter().any(|&c| c != host_idx);
+        if host_has_other_modules
+          && has_external_consumer
+          && let Some(pos) = host_chunk.modules.iter().position(|m| *m == runtime_module_idx)
+        {
+          let host_chunk = &mut chunk_graph.chunk_table[host_idx];
+          host_chunk.modules.swap_remove(pos);
+          chunk_graph.module_to_chunk[runtime_module_idx] = None;
+        }
+      }
+
+      if chunk_graph.module_to_chunk[runtime_module_idx].is_none() {
+        // Pick a placement based on the full set of consumer chunks: every
+        // non-removed chunk with a non-empty `depended_runtime_helper`,
+        // unioned with `runtime_dependent_chunks`. Single consumer → reuse it;
+        // multiple consumers → dedicated leaf `rolldown-runtime` chunk.
+        let removed_chunks = &chunk_graph.post_chunk_optimization_operations;
+        let mut consumer_chunks: FxHashSet<ChunkIdx> = chunk_graph
+          .chunk_table
+          .iter_enumerated()
+          .filter_map(|(idx, chunk)| {
+            (!removed_chunks.contains_key(&idx) && !chunk.depended_runtime_helper.is_empty())
+              .then_some(idx)
+          })
+          .collect();
+        consumer_chunks.extend(runtime_dependent_chunks.iter().copied());
+
+        let runtime_chunk_idx = if consumer_chunks.len() == 1 {
+          consumer_chunks.into_iter().next().unwrap()
+        } else {
           let runtime_chunk = Chunk::new(
             Some("rolldown-runtime".into()),
             None,
@@ -1080,14 +1115,14 @@ impl GenerateStage<'_> {
             None,
           );
           chunk_graph.add_chunk(runtime_chunk)
-        }
-      };
-      chunk_graph.add_module_to_chunk(
-        runtime_module_idx,
-        runtime_chunk_idx,
-        self.link_output.metas[runtime_module_idx].depended_runtime_helper,
-      );
-      module_is_assigned.set_bit(runtime_module_idx);
+        };
+        chunk_graph.add_module_to_chunk(
+          runtime_module_idx,
+          runtime_chunk_idx,
+          self.link_output.metas[runtime_module_idx].depended_runtime_helper,
+        );
+        module_is_assigned.set_bit(runtime_module_idx);
+      }
     }
 
     // Restore the included info back to metas

--- a/crates/rolldown/tests/rolldown/issues/8989/_config.json
+++ b/crates/rolldown/tests/rolldown/issues/8989/_config.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "input": [
+      {
+        "import": "./node0.js",
+        "name": "entry0"
+      },
+      {
+        "import": "./node1.js",
+        "name": "entry1"
+      },
+      {
+        "import": "./node2.js",
+        "name": "entry2"
+      },
+      {
+        "import": "./node3.js",
+        "name": "entry3"
+      }
+    ],
+    "minify": false,
+    "preserveEntrySignatures": "allow-extension"
+  }
+}

--- a/crates/rolldown/tests/rolldown/issues/8989/_test.mjs
+++ b/crates/rolldown/tests/rolldown/issues/8989/_test.mjs
@@ -1,0 +1,51 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert';
+
+// Regression for #8989: facade chunk elimination used to add a runtime-helper
+// edge from entry2 → the chunk hosting the runtime, while that host chunk
+// already had a forward path entry2 → entry3 → node4 → entry2, closing a cycle.
+//
+// After the fix, the runtime is peeled out of its co-located host and placed
+// into a leaf chunk (here, node4.js). Both helper consumers (entry2 + node4)
+// must reach helpers via forward-only edges; no chunk that imports helpers
+// from another chunk may have a static import edge in the opposite direction.
+
+const distDir = path.join(import.meta.dirname, 'dist');
+const read = (name) => fs.readFileSync(path.join(distDir, name), 'utf8');
+
+const entry1 = read('entry1.js');
+const entry2 = read('entry2.js');
+const entry3 = read('entry3.js');
+const node4 = read('node4.js');
+
+// node4 is the leaf runtime host: no static imports from any other chunk.
+assert(
+  !/^import .* from ".\/(entry|node)/m.test(node4),
+  'node4.js must be a leaf chunk (no static imports from sibling chunks)',
+);
+
+// node4 hosts the runtime helpers and exports __exportAll for consumers.
+assert(node4.includes('rolldown/runtime.js'), 'node4.js should host the runtime module');
+assert(
+  /export \{[^}]*__exportAll/.test(node4),
+  'node4.js should re-export __exportAll for the other consumer chunks',
+);
+
+// entry2 needs __exportAll for node2_exports namespace materialization and
+// must import it from node4 (the leaf), not the other way around.
+assert(
+  /import \{[^}]*__exportAll[^}]*\} from "\.\/node4\.js"/.test(entry2),
+  'entry2.js should import __exportAll from node4.js',
+);
+assert(!entry2.includes('from "./entry2.js"'), 'entry2.js should not self-import');
+
+// entry3 statically depends on node4 (re-export of node_4) — this is the
+// forward edge. It must NOT have any back-edge to entry2 that would let
+// node4 → entry2 close a cycle.
+assert(/from "\.\/node4\.js"/.test(entry3), 'entry3.js should statically import from node4.js');
+
+// entry1 transitively reaches entry2 and entry3, both of which are forward
+// edges away from node4 — so the static graph must remain acyclic.
+assert(/from "\.\/entry2\.js"/.test(entry1), 'entry1.js should import from entry2.js');
+assert(/from "\.\/entry3\.js"/.test(entry1), 'entry1.js should import from entry3.js');

--- a/crates/rolldown/tests/rolldown/issues/8989/artifacts.snap
+++ b/crates/rolldown/tests/rolldown/issues/8989/artifacts.snap
@@ -1,0 +1,81 @@
+---
+source: crates/rolldown_testing/src/integration_test.rs
+---
+# Assets
+
+## entry0.js
+
+```js
+//#region node0.js
+globalThis.__acyclic_output_fuzz_0 = 0;
+var node_0 = {};
+node_0.value = 0;
+
+//#endregion
+export { node_0 };
+```
+
+## entry1.js
+
+```js
+import { node_3 } from "./entry3.js";
+import { t as node2_exports } from "./entry2.js";
+
+//#region node1.js
+globalThis.__acyclic_output_fuzz_1 = 1;
+var use_1_2 = node2_exports;
+use_1_2.ref = 1;
+var node_1 = {};
+node_1.value = 1;
+
+//#endregion
+export { node_1, node_3 as reexport_1_3, use_1_2 };
+```
+
+## entry2.js
+
+```js
+import { r as __exportAll } from "./node4.js";
+import { node_3 } from "./entry3.js";
+
+//#region node2.js
+var node2_exports = /* @__PURE__ */ __exportAll({
+	node_2: () => node_2,
+	reexport_2_3: () => node_3
+});
+globalThis.__acyclic_output_fuzz_2 = 2;
+var node_2 = {};
+node_2.value = 2;
+
+//#endregion
+export { node_2, node_3 as reexport_2_3, node2_exports as t };
+```
+
+## entry3.js
+
+```js
+import { n as node_4 } from "./node4.js";
+
+//#region node3.js
+globalThis.__acyclic_output_fuzz_3 = 3;
+import("./node4.js").then((n) => n.t);
+var node_3 = {};
+node_3.value = 3;
+
+//#endregion
+export { node_3, node_4 as reexport_3_4 };
+```
+
+## node4.js
+
+```js
+// HIDDEN [\0rolldown/runtime.js]
+//#region node4.js
+var node4_exports = /* @__PURE__ */ __exportAll({ node_4: () => node_4 });
+globalThis.__acyclic_output_fuzz_4 = 4;
+var node_4 = {};
+node_4.value = 4;
+
+//#endregion
+export { node_4 as n, __exportAll as r, node4_exports as t };
+```

--- a/crates/rolldown/tests/rolldown/issues/8989/node0.js
+++ b/crates/rolldown/tests/rolldown/issues/8989/node0.js
@@ -1,0 +1,4 @@
+globalThis.__acyclic_output_fuzz_0 = 0;
+var node_0 = {};
+node_0.value = 0;
+export { node_0 };

--- a/crates/rolldown/tests/rolldown/issues/8989/node1.js
+++ b/crates/rolldown/tests/rolldown/issues/8989/node1.js
@@ -1,0 +1,9 @@
+globalThis.__acyclic_output_fuzz_1 = 1;
+import * as imported_1_2 from './node2.js';
+var use_1_2 = imported_1_2;
+use_1_2.ref = 1;
+export { use_1_2 };
+export { node_3 as reexport_1_3 } from './node3.js';
+var node_1 = {};
+node_1.value = 1;
+export { node_1 };

--- a/crates/rolldown/tests/rolldown/issues/8989/node2.js
+++ b/crates/rolldown/tests/rolldown/issues/8989/node2.js
@@ -1,0 +1,5 @@
+globalThis.__acyclic_output_fuzz_2 = 2;
+export { node_3 as reexport_2_3 } from './node3.js';
+var node_2 = {};
+node_2.value = 2;
+export { node_2 };

--- a/crates/rolldown/tests/rolldown/issues/8989/node3.js
+++ b/crates/rolldown/tests/rolldown/issues/8989/node3.js
@@ -1,0 +1,6 @@
+globalThis.__acyclic_output_fuzz_3 = 3;
+export { node_4 as reexport_3_4 } from './node4.js';
+void import('./node4.js');
+var node_3 = {};
+node_3.value = 3;
+export { node_3 };

--- a/crates/rolldown/tests/rolldown/issues/8989/node4.js
+++ b/crates/rolldown/tests/rolldown/issues/8989/node4.js
@@ -1,0 +1,4 @@
+globalThis.__acyclic_output_fuzz_4 = 4;
+var node_4 = {};
+node_4.value = 4;
+export { node_4 };


### PR DESCRIPTION
Fixes #8989, a circular import that arises when facade chunk elimination adds new runtime-helper consumers (`__exportAll`, `__toESM`, etc.) to a chunk that already has a transitive forward path back to the chunk currently hosting the runtime module.

### Root cause

`optimize_facade_entry_chunks` runs after the merge phase has already placed the runtime module into some chunk based on bitset assignment. When facade elimination later calls `include_symbol(namespace_object_ref)` for an eliminated facade, it sets `target_chunk.depended_runtime_helper.insert(ExportAll)` and adds the target to `runtime_dependent_chunks`. If the target chunk transitively reaches the chunk currently hosting the runtime, the new helper-import edge closes a cycle.

For example, in the regression test the merge phase puts runtime in `chunk(node2)` which has a forward path `node2 -> node3 -> node4`, and facade elimination then makes `chunk(node4)` need `__exportAll` from `chunk(node2)` — closing `entry2 -> entry3 -> node4 -> entry2`.

### Algorithm

The fix replaces the original "place runtime once and never move it" branch in `optimize_facade_entry_chunks` with a two-step decision that runs whenever `runtime_dependent_chunks` is non-empty (i.e., facade elimination has actually added new consumers).

**Step 1 — Peel decision (cycle prevention):**

The runtime is peeled out of its current host chunk only when both predicates hold:

- `host_has_other_modules` — the host chunk contains modules besides the runtime. If runtime is alone in its chunk, that chunk is already a leaf with no outgoing imports and cannot participate in a cycle. Skipping this case avoids leaving an empty chunk that would crash downstream code expecting `chunk.modules[0]` to exist.

- `has_external_consumer` — `runtime_dependent_chunks` contains a chunk that is *not* the host. If every facade-elim consumer IS the host itself, then helpers don't have to cross any chunk boundary and no new edges are introduced.

When both are true, the implementation removes `runtime_module_idx` from the host chunk's `modules` vec via `swap_remove` (ordering doesn't matter — `sort_chunk_modules` re-establishes it later) and clears `module_to_chunk[runtime_module_idx]`.

**Step 2 — Placement decision (consumer-set count):**

When the runtime is unplaced (either because Step 1 just peeled it, or because the merge phase never placed it), the implementation computes the full set of consumer chunks as:

```
consumer_chunks = (non-removed chunks with non-empty depended_runtime_helper) ∪ runtime_dependent_chunks
```

The first term picks up chunks that already required helpers from the linking stage; the second term picks up chunks that facade elimination just announced. Deduplication is automatic via `FxHashSet`. Then:

- `consumer_chunks.len() == 1` → runtime moves into that single consumer chunk. No extra chunk is created; the lone consumer hosts both its own modules and the runtime.
- `consumer_chunks.len() > 1` → runtime is placed in a fresh `rolldown-runtime.js` leaf chunk created with the runtime's bitset. Every consumer imports from it; the dedicated chunk has zero outgoing edges so cycles are structurally impossible.

### Why both steps are needed

The peel gate exists because relying on the consumer-count alone over-triggers — many tests have multiple consumers that don't actually form cycles (e.g., `import_missing_neither_es6_nor_common_js`, where runtime lives in `foo.js` and `require.js` imports `__toCommonJS` from it without any back-edge). The peel gate keeps these untouched.

The consumer-set count exists because relying on `runtime_dependent_chunks.len()` alone (the original code's optimization) undercounts: it ignores chunks that already required helpers from the linking stage. After peeling, the unioned set correctly identifies whether runtime can piggyback on a single consumer or needs its own home.

### Test results and snapshot impact

Net change against `main`: only `chunk_optimizer.rs` and a new regression fixture at `crates/rolldown/tests/rolldown/issues/8989/`. **Zero existing snapshots are modified.** All 1677 integration tests pass.

The 8989 fixture covers the cycle: 4 entries (`node0`–`node3`), `node4` dynamically imported from `node3`, `node1` namespace-importing `node2` (forcing `__exportAll` for `node2`'s namespace materialization). The output places runtime into `node4.js` (the leaf), which both `entry2` and `entry3` reach through forward-only edges. Acyclic ✓.
