### PR TITLE
refactor: use semantic reference flags for member write detection

### DIFF
--- a/crates/rolldown/src/ast_scanner/impl_visit.rs
+++ b/crates/rolldown/src/ast_scanner/impl_visit.rs
@@ -22,7 +22,7 @@ use rolldown_ecmascript_utils::{ExpressionExt, is_top_level};
 use rolldown_error::BuildDiagnostic;
 use rolldown_std_utils::OptionExt;
 
-use crate::ast_scanner::{TraverseState, cjs_export_analyzer::CommonJsAstType};
+use crate::ast_scanner::cjs_export_analyzer::CommonJsAstType;
 
 use super::{
   AstScanner, UntranspiledSyntax, cjs_export_analyzer::CjsGlobalAssignmentType,
@@ -36,12 +36,12 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
     _scope_id: &std::cell::Cell<Option<oxc::semantic::ScopeId>>,
   ) {
     self.scope_stack.push(flags);
-    self.traverse_state.set(TraverseState::TopLevel, is_top_level(&self.scope_stack));
+    self.is_top_level = is_top_level(&self.scope_stack);
   }
 
   fn leave_scope(&mut self) {
     self.scope_stack.pop();
-    self.traverse_state.set(TraverseState::TopLevel, is_top_level(&self.scope_stack));
+    self.is_top_level = is_top_level(&self.scope_stack);
   }
 
   fn enter_node(&mut self, kind: oxc::ast::AstKind<'ast>) {
@@ -50,43 +50,6 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
   fn leave_node(&mut self, _it: oxc::ast::AstKind<'ast>) {
     self.visit_path.pop();
-  }
-
-  fn visit_simple_assignment_target(&mut self, it: &ast::SimpleAssignmentTarget<'ast>) {
-    match it {
-      ast::SimpleAssignmentTarget::ComputedMemberExpression(_)
-      | ast::SimpleAssignmentTarget::StaticMemberExpression(_) => {
-        let pre = self.traverse_state;
-        self.traverse_state.insert(TraverseState::MemberExprIsWrite);
-        if !self.immutable_ctx.flat_options.property_write_side_effects()
-          && pre.contains(TraverseState::TopLevel)
-        {
-          self.traverse_state.insert(TraverseState::RootSymbolReferenceStmtInfoId);
-        }
-        walk::walk_simple_assignment_target(self, it);
-        self.traverse_state = pre;
-        return;
-      }
-      _ => {}
-    }
-    walk::walk_simple_assignment_target(self, it);
-  }
-
-  fn visit_computed_member_expression(&mut self, it: &ast::ComputedMemberExpression<'ast>) {
-    if self.traverse_state.contains(TraverseState::MemberExprIsWrite) {
-      let kind = AstKind::ComputedMemberExpression(self.alloc(it));
-      self.enter_node(kind);
-      // In assignment targets, only the member object is written.
-      // The computed key expression is evaluated as a read.
-      let pre = self.traverse_state;
-      self.visit_expression(&it.object);
-      self.traverse_state.remove(TraverseState::MemberExprIsWrite);
-      self.visit_expression(&it.expression);
-      self.traverse_state = pre;
-      self.leave_node(kind);
-      return;
-    }
-    walk::walk_computed_member_expression(self, it);
   }
 
   fn visit_program(&mut self, program: &ast::Program<'ast>) {
@@ -214,7 +177,7 @@ impl<'me, 'ast: 'me> Visit<'ast> for AstScanner<'me, 'ast> {
 
   fn visit_return_statement(&mut self, stmt: &ast::ReturnStatement<'ast>) {
     // Top-level return statements are only valid in CommonJS modules
-    if self.traverse_state.contains(TraverseState::TopLevel) {
+    if self.is_top_level {
       self.result.ast_usage.insert(EcmaModuleAstUsage::TopLevelReturn);
     }
     walk::walk_return_statement(self, stmt);
@@ -633,6 +596,8 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         self.process_global_identifier_ref_by_ancestor(ident_ref);
       }
       super::IdentifierReferenceKind::Root(root_symbol_id) => {
+        let is_member_write = self.is_member_write_target(ident_ref);
+
         // if the identifier_reference is a NamedImport MemberExpr access, we store it as a `MemberExpr`
         // use this flag to avoid insert it as `Symbol` at the same time.
         let mut is_inserted_before = false;
@@ -657,7 +622,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
               is_inserted_before = true;
 
               if matches!(ty, MemberExprObjectReferencedType::Namespace)
-                && self.traverse_state.contains(TraverseState::MemberExprIsWrite)
+                && is_member_write
                 && props[0].name == "default"
               {
                 // Write through namespace default (e.g. `ns.default.a = value`). Since
@@ -673,10 +638,10 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
                 span,
                 ty,
                 ident_ref.reference_id.get(),
-                self.traverse_state.contains(TraverseState::MemberExprIsWrite),
+                is_member_write,
               );
             }
-          } else if self.traverse_state.contains(TraverseState::MemberExprIsWrite)
+          } else if is_member_write
             && matches!(
               ty,
               MemberExprObjectReferencedType::Default | MemberExprObjectReferencedType::Namespace
@@ -692,7 +657,10 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
           self.add_referenced_symbol(root_symbol_id);
         }
 
-        if self.traverse_state.contains(TraverseState::RootSymbolReferenceStmtInfoId) {
+        if is_member_write
+          && !self.immutable_ctx.flat_options.property_write_side_effects()
+          && self.is_top_level
+        {
           // Since `0` is always namespace object stmt info
           self
             .result

--- a/crates/rolldown/src/ast_scanner/mod.rs
+++ b/crates/rolldown/src/ast_scanner/mod.rs
@@ -128,20 +128,6 @@ pub struct ScanResult {
   pub cjs_reexport_import_record_ids: Vec<ImportRecordIdx>,
 }
 
-bitflags::bitflags! {
-    #[derive(Debug, Clone, Copy)]
-    struct TraverseState: u8 {
-        /// If this flag is set, all top level symbol id during traverse should be inserted into
-        /// [`rolldown_common::types::stmt_info::StmtInfos::symbol_ref_to_referenced_stmt_idx`]
-        const RootSymbolReferenceStmtInfoId = 1;
-        /// If current position all parent scopes are block scope or top level scope.
-        /// A cache state of [AstScanner::is_valid_tla_scope]
-        const TopLevel = 1 << 1;
-        /// Set when traversing a member expression that is an assignment target (write context).
-        const MemberExprIsWrite = 1 << 2;
-    }
-}
-
 pub struct AstScannerImmutableCtx<'me, 'ast> {
   idx: ModuleIdx,
   source: &'me ArcStr,
@@ -176,7 +162,9 @@ pub struct AstScanner<'me, 'ast> {
   /// Set when `module.exports = <value>` is detected. All prior `exports.xxx`
   /// constants are stale since the entire exports object is replaced at runtime.
   has_module_exports_reassignment: bool,
-  traverse_state: TraverseState,
+  /// Whether the current position is at the top level (all parent scopes are block or top-level).
+  /// A cache of [AstScanner::is_valid_tla_scope].
+  is_top_level: bool,
   current_comment_idx: usize,
   untranspiled_syntax: UntranspiledSyntax,
   /// Symbol IDs of namespace imports (`import * as ns from '...'`).
@@ -273,7 +261,7 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
         CommonjsExportSymbolUsage { read: 0, write: 0, bailout: true },
       )]),
       has_module_exports_reassignment: false,
-      traverse_state: TraverseState::empty(),
+      is_top_level: false,
       current_comment_idx: 0,
       untranspiled_syntax: UntranspiledSyntax::empty(),
       namespace_object_symbol_ids: FxHashSet::default(),
@@ -1008,6 +996,14 @@ impl<'me, 'ast: 'me> AstScanner<'me, 'ast> {
       )
       .into(),
     );
+  }
+
+  /// Check if this identifier reference is the object of a member expression in a write context
+  /// (e.g., `A` in `A.foo = 1`, `A.foo += 1`, `A.foo++`, `delete A.foo`).
+  fn is_member_write_target(&self, ident_ref: &IdentifierReference) -> bool {
+    ident_ref.reference_id.get().is_some_and(|ref_id| {
+      self.result.symbol_ref_db.scoping().get_reference(ref_id).flags().is_member_write_target()
+    })
   }
 
   fn is_root_symbol(&self, symbol_id: SymbolId) -> bool {


### PR DESCRIPTION
## Summary

- Replace `TraverseState` bitflags with oxc's semantic `ReferenceFlags::is_member_write_target()` for detecting member expression writes
- Remove manual visitor overrides (`visit_simple_assignment_target`, `visit_computed_member_expression`) that tracked write context
- Simplify `TraverseState` enum down to a plain `is_top_level: bool` field

## Test plan

- [ ] CI passes (existing tests cover member write detection behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)