### PR TITLE
fix(rolldown_plugin_vite_import_glob): keep common base on path segment boundary

### DIFF
--- a/crates/rolldown_plugin_vite_import_glob/src/utils.rs
+++ b/crates/rolldown_plugin_vite_import_glob/src/utils.rs
@@ -350,11 +350,25 @@ impl GlobImportVisit<'_> {
       let max_len = end.min(bytes.len());
 
       let mut i = 0;
+      let mut last_slash = 0;
       while i < max_len && first[i] == bytes[i] {
+        if first[i] == MAIN_SEPARATOR as u8 {
+          last_slash = i;
+        }
         i += 1;
       }
 
-      end = i;
+      // If the walk finished at `max_len` (not a byte mismatch), `i` itself
+      // may already be a deeper boundary than any separator we recorded —
+      // e.g. when one path fully matched the other up to a segment split.
+      if i == max_len
+        && (i == first.len() || first[i] == MAIN_SEPARATOR as u8)
+        && (i == bytes.len() || bytes[i] == MAIN_SEPARATOR as u8)
+      {
+        last_slash = i;
+      }
+
+      end = last_slash;
       if end == 0 {
         break;
       }


### PR DESCRIPTION
Related to https://github.com/vitejs/vite/issues/22170

`get_common_base` used a byte-wise longest common prefix, which could cut in the middle of a path segment — e.g. for `.../pattern3` and `.../pattern4` it returned `.../pattern`, a non-existent directory that made `walkdir` find nothing. Track the last shared separator while walking, and when the walk reaches `max_len` without a byte mismatch, promote `i` itself if both paths are at a segment boundary there. The base now always lands on a component boundary.

I will add a test case on Vite side.