### PR TITLE
chore: remove outdated TODO in determine_module_exports_kind

### DIFF
--- a/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
+++ b/crates/rolldown/src/stages/link_stage/determine_module_exports_kind.rs
@@ -12,7 +12,6 @@ impl LinkStage<'_> {
   #[tracing::instrument(level = "debug", skip_all)]
   pub(super) fn determine_module_exports_kind(&mut self) {
     self.module_table.modules.iter().filter_map(Module::as_normal).for_each(|importer| {
-      // TODO(hyf0): should check if importer is a js module
       importer
         .import_records
         .iter()


### PR DESCRIPTION
## Summary
- Resolves TODO comment by `hyf0`: "should check if importer is a js module"
